### PR TITLE
M3-3318 Support for Disks/Configs events (secondary entity!)

### DIFF
--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -58,21 +58,49 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
     notification: e => `Credit card information has been updated.`
   },
   disk_create: {
-    scheduled: e => `Disk is being added to Linode ${e.entity!.label}.`,
-    started: e => `Disk is being added to ${e.entity!.label}.`,
-    failed: e => `Disk could not be added to Linode ${e.entity!.label}.`,
-    finished: e => `Disk has been added to Linode ${e.entity!.label}.`
+    scheduled: e =>
+      `${safeSecondaryEntityLabel(e, 'Disk')} is being added to Linode ${
+        e.entity!.label
+      }.`,
+    started: e =>
+      `${safeSecondaryEntityLabel(e, 'Disk')} is being added to ${
+        e.entity!.label
+      }.`,
+    failed: e =>
+      `${safeSecondaryEntityLabel(e, 'Disk')} could not be added to Linode ${
+        e.entity!.label
+      }.`,
+    finished: e =>
+      `${safeSecondaryEntityLabel(e, 'Disk')} has been added to Linode ${
+        e.entity!.label
+      }.`
     // notification: e => ``,
   },
   disk_update: {
-    notification: e => `A disk has been updated on Linode ${e.entity!.label}.`
+    notification: e =>
+      `${safeSecondaryEntityLabel(
+        e,
+        'Disk',
+        'A disk'
+      )} has been updated on Linode ${e.entity!.label}.`
   },
   disk_delete: {
     scheduled: e =>
-      `A disk on Linode ${e.entity!.label} is scheduled for deletion.`,
-    started: e => `A disk on Linode ${e.entity!.label} is being deleted.`,
-    failed: e => `A disk on Linode ${e.entity!.label} could not be deleted.`,
-    finished: e => `A disk on Linode ${e.entity!.label} has been deleted`
+      `${safeSecondaryEntityLabel(e, 'Disk', 'A disk')} on Linode ${
+        e.entity!.label
+      } is scheduled for deletion.`,
+    started: e =>
+      `${safeSecondaryEntityLabel(e, 'Disk', 'A disk')} on Linode ${
+        e.entity!.label
+      } is being deleted.`,
+    failed: e =>
+      `${safeSecondaryEntityLabel(e, 'Disk', 'A disk')} on Linode ${
+        e.entity!.label
+      } could not be deleted.`,
+    finished: e =>
+      `${safeSecondaryEntityLabel(e, 'Disk', 'A disk')} on Linode ${
+        e.entity!.label
+      } has been deleted`
     // notification: e => ``,
   },
   disk_duplicate: {
@@ -325,13 +353,28 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
     finished: e => `A snapshot backup has been created for ${e.entity!.label}.`
   },
   linode_config_create: {
-    notification: e => `A config has been created on Linode ${e.entity!.label}.`
+    notification: e =>
+      `${safeSecondaryEntityLabel(
+        e,
+        'Config',
+        'A config'
+      )} has been created on Linode ${e.entity!.label}.`
   },
   linode_config_update: {
-    notification: e => `A config has been updated on Linode ${e.entity!.label}.`
+    notification: e =>
+      `${safeSecondaryEntityLabel(
+        e,
+        'Config',
+        'A config'
+      )} has been updated on Linode ${e.entity!.label}.`
   },
   linode_config_delete: {
-    notification: e => `A config has been deleted on Linode ${e.entity!.label}.`
+    notification: e =>
+      `${safeSecondaryEntityLabel(
+        e,
+        'Config',
+        'A config'
+      )} has been deleted on Linode ${e.entity!.label}.`
   },
   longviewclient_create: {
     notification: e => `Longview Client ${e.entity!.label} has been created.`

--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -59,21 +59,27 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
   },
   disk_create: {
     scheduled: e =>
-      `${safeSecondaryEntityLabel(e, 'Disk')} is being added to Linode ${
-        e.entity!.label
-      }.`,
+      `${safeSecondaryEntityLabel(
+        e,
+        'Disk',
+        'A disk'
+      )} is being added to Linode ${e.entity!.label}.`,
     started: e =>
-      `${safeSecondaryEntityLabel(e, 'Disk')} is being added to ${
+      `${safeSecondaryEntityLabel(e, 'Disk', 'A disk')} is being added to ${
         e.entity!.label
       }.`,
     failed: e =>
-      `${safeSecondaryEntityLabel(e, 'Disk')} could not be added to Linode ${
-        e.entity!.label
-      }.`,
+      `${safeSecondaryEntityLabel(
+        e,
+        'Disk',
+        'A disk'
+      )} could not be added to Linode ${e.entity!.label}.`,
     finished: e =>
-      `${safeSecondaryEntityLabel(e, 'Disk')} has been added to Linode ${
-        e.entity!.label
-      }.`
+      `${safeSecondaryEntityLabel(
+        e,
+        'Disk',
+        'A disk'
+      )} has been added to Linode ${e.entity!.label}.`
     // notification: e => ``,
   },
   disk_update: {

--- a/packages/manager/src/features/ToastNotifications/ToastNotifications.tsx
+++ b/packages/manager/src/features/ToastNotifications/ToastNotifications.tsx
@@ -102,6 +102,11 @@ class ToastNotifications extends React.PureComponent<WithSnackbarProps, {}> {
           );
         }
 
+        /**
+         * These create/delete failures are hypothetical.
+         * We don't know if it's possible for these to fail,
+         * but are including handling to be safe.
+         */
         if (
           event.action === 'linode_config_delete' &&
           ['failed'].includes(event.status)

--- a/packages/manager/src/features/ToastNotifications/ToastNotifications.tsx
+++ b/packages/manager/src/features/ToastNotifications/ToastNotifications.tsx
@@ -92,13 +92,38 @@ class ToastNotifications extends React.PureComponent<WithSnackbarProps, {}> {
         }
 
         if (event.action === 'disk_delete' && event.status === 'failed') {
-          const label = pathOr(false, ['entity', 'label'], event);
+          const label = pathOr('', ['secondary_entity', 'label'], event);
+          const linode = pathOr(false, ['entity', 'label'], event);
           return enqueueSnackbar(
-            `Unable to delete disk${
-              label ? ` on ${label}` : ''
+            `Unable to delete disk ${label} ${
+              linode ? ` on ${linode}` : ''
             }. Is it attached to a configuration profile that is in use?`,
             { variant: 'error' }
           );
+        }
+
+        if (
+          event.action === 'linode_config_delete' &&
+          ['failed'].includes(event.status)
+        ) {
+          const entity = event.secondary_entity
+            ? event.secondary_entity.label
+            : '';
+          return enqueueSnackbar(`Error deleting config ${entity}.`, {
+            variant: 'error'
+          });
+        }
+
+        if (
+          event.action === 'linode_config_create' &&
+          ['failed'].includes(event.status)
+        ) {
+          const entity = event.secondary_entity
+            ? event.secondary_entity.label
+            : '';
+          return enqueueSnackbar(`Error creating config ${entity}.`, {
+            variant: 'error'
+          });
         }
 
         return;

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeAdvancedConfigurationsPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeAdvancedConfigurationsPanel.tsx
@@ -67,7 +67,7 @@ class LinodeAdvancedConfigurationsPanel extends React.PureComponent<
       >
         <Grid item xs={12} md={7} lg={9}>
           <Typography variant="h2" className={classes.title}>
-            Advanced Configurations
+            Linode Disks and Configurations
           </Typography>
           <Paper className={classes.paper}>
             <LinodeConfigs />

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs.tsx
@@ -225,7 +225,6 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
 
   deleteConfig = () => {
     this.setConfirmDelete({ submitting: true });
-    const { deleteLinodeConfig } = this.props;
     const {
       confirmDelete: { id: configId }
     } = this.state;
@@ -233,11 +232,12 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
       return;
     }
 
-    deleteLinodeConfig(configId)
+    this.props
+      .deleteLinodeConfig(configId)
       .then(() => {
         this.setConfirmDelete(
           {
-            submitting: false
+            submitting: true
           },
           () => {
             this.setConfirmDelete({
@@ -248,7 +248,7 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
           }
         );
       })
-      .catch(error => {
+      .catch(_ => {
         this.setConfirmDelete({
           submitting: false,
           open: false,

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks.tsx
@@ -579,9 +579,6 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
     deleteLinodeDisk(diskId)
       .then(() => {
         this.setConfirmDelete({ open: false, errors: undefined });
-        this.props.enqueueSnackbar(`Disk queued for deletion.`, {
-          variant: 'info'
-        });
       })
       .catch(error => {
         // This error only fires if the request fails;

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -1,8 +1,3 @@
-/**
- * @todo The config information is now immediately available on the LinodeDetail context and we
- * should source it directly from there rather than making an additional request. OR We can source
- * it from there and make the (thunk) request to get the latest/greatest information.
- */
 import {
   Config,
   Disk,
@@ -286,7 +281,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
     ];
 
     return (
-      <form onSubmit={this.onSubmit}>
+      <React.Fragment>
         {generalError && (
           <Notice error errorGroup="linode-config-drawer" text={generalError} />
         )}
@@ -431,16 +426,16 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
           </FormControl>
 
           {/*
-            it's important to note here that if the memory limit
-            is set to 0, this config is going to use 100% of the
-            Linode's RAM. Otherwise, it only uses the limit
-            explicitly set by the user.
+              it's important to note here that if the memory limit
+              is set to 0, this config is going to use 100% of the
+              Linode's RAM. Otherwise, it only uses the limit
+              explicitly set by the user.
 
-            So to make this more clear to the user, we're going to
-            hide the option to change the RAM limit unless the
-            user explicity selects the option to change the
-            memory limit.
-          */}
+              So to make this more clear to the user, we're going to
+              hide the option to change the RAM limit unless the
+              user explicity selects the option to change the
+              memory limit.
+            */}
           <FormControl updateFor={[this.state.fields.setMemoryLimit, classes]}>
             <FormLabel
               htmlFor="memory_limit"
@@ -628,7 +623,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
             </Button>
           </ActionsPanel>
         </Grid>
-      </form>
+      </React.Fragment>
     );
   };
 
@@ -641,8 +636,6 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
       createLinodeConfig,
       updateLinodeConfig
     } = this.props;
-
-    this.setState({ submitting: true });
 
     /**
      * This is client-side validation to patch an API bug.
@@ -662,10 +655,11 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
               'You must select a valid Disk or Volume as your root device.',
             field: 'root_device'
           }
-        ],
-        submitting: false
+        ]
       });
     }
+
+    this.setState({ submitting: true });
 
     const configData = this.convertStateToData(this.state.fields);
 
@@ -673,15 +667,16 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
     if (linodeConfigId) {
       return updateLinodeConfig(linodeConfigId, configData)
         .then(_ => {
-          this.props.onClose();
           this.setState({ submitting: false });
+          this.props.onClose();
         })
         .catch(error => {
           this.setState({
             errors: getAPIErrorOrDefault(
               error,
               'Unable to update config. Please try again.'
-            )
+            ),
+            submitting: false
           });
         });
     }
@@ -689,6 +684,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
     /** Creating */
     return createLinodeConfig(configData)
       .then(_ => {
+        this.setState({ submitting: false });
         this.props.onClose();
       })
       .catch(error =>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -105,6 +105,7 @@ interface State {
   kernels: Kernel[];
   errors?: Error | APIError[];
   fields: EditableFields;
+  submitting: boolean;
 }
 
 type CombinedProps = LinodeContextProps &
@@ -121,7 +122,8 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
       config: false
     },
     kernels: [],
-    fields: LinodeConfigDrawer.defaultFieldsValues()
+    fields: LinodeConfigDrawer.defaultFieldsValues(),
+    submitting: false
   };
 
   static defaultFieldsValues: () => EditableFields = () => ({
@@ -256,7 +258,8 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
         virt_mode,
         helpers,
         root_device
-      }
+      },
+      submitting
     } = this.state;
 
     const errorFor = getAPIErrorsFor(
@@ -295,7 +298,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
     ];
 
     return (
-      <React.Fragment>
+      <form onSubmit={this.onSubmit}>
         {generalError && (
           <Notice error errorGroup="linode-config-drawer" text={generalError} />
         )}
@@ -628,6 +631,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
               onClick={this.onSubmit}
               buttonType="primary"
               disabled={readOnly}
+              loading={submitting}
             >
               Submit
             </Button>
@@ -636,7 +640,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
             </Button>
           </ActionsPanel>
         </Grid>
-      </React.Fragment>
+      </form>
     );
   };
 
@@ -649,6 +653,8 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
       createLinodeConfig,
       updateLinodeConfig
     } = this.props;
+
+    this.setState({ submitting: true });
 
     /**
      * This is client-side validation to patch an API bug.
@@ -668,7 +674,8 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
               'You must select a valid Disk or Volume as your root device.',
             field: 'root_device'
           }
-        ]
+        ],
+        submitting: false
       });
     }
 
@@ -679,6 +686,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
       return updateLinodeConfig(linodeConfigId, configData)
         .then(_ => {
           this.props.onClose();
+          this.setState({ submitting: false });
         })
         .catch(error => {
           this.setState({
@@ -700,7 +708,8 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
           errors: getAPIErrorOrDefault(
             error,
             'Unable to create config. Please try again.'
-          )
+          ),
+          submitting: false
         })
       );
   };

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation.tsx
@@ -111,7 +111,7 @@ const LinodesDetailNavigation: React.StatelessComponent<
     },
     {
       routeName: `${url}/advanced`,
-      title: 'Advanced'
+      title: 'Disks/Configs'
     }
   ];
 

--- a/packages/manager/src/store/linodes/disk/disk.events.ts
+++ b/packages/manager/src/store/linodes/disk/disk.events.ts
@@ -28,9 +28,9 @@ const handleDiskChange = (
   switch (status) {
     case 'finished':
     case 'notification':
+    case 'failed':
       return dispatch(getAllLinodeDisks({ linodeId }));
 
-    case 'failed':
     case 'scheduled':
     case 'started':
     default:

--- a/packages/manager/src/store/linodes/linodes.events.ts
+++ b/packages/manager/src/store/linodes/linodes.events.ts
@@ -49,6 +49,10 @@ const linodeEventsHandler: EventHandler = (event, dispatch, getState) => {
     case 'linode_create':
       return handleLinodeCreation(dispatch, status, id, getState());
 
+    case 'linode_config_create':
+    case 'linode_config_delete':
+      return handleConfigEvent(dispatch, status, id);
+
     case 'disk_delete':
       if (status === 'failed') {
         /**
@@ -191,6 +195,27 @@ const handleLinodeCreation = (
     case 'started':
       return dispatch(requestLinodeForStore(id, true));
 
+    default:
+      return;
+  }
+};
+
+const handleConfigEvent = (
+  dispatch: Dispatch<any>,
+  status: EventStatus,
+  id: number
+) => {
+  switch (status) {
+    case 'failed':
+      /**
+       * We optimistically add or remove configs as soon
+       * as the initial API request returns a 200.
+       *
+       * If we receive an event indicating that the creation/deletion
+       * failed on the backend, we need to re-request this Linode's configs
+       * (which will re-add or remove the target config).
+       */
+      return dispatch(getAllLinodeConfigs({ linodeId: id }));
     default:
       return;
   }

--- a/packages/manager/src/store/linodes/linodes.events.ts
+++ b/packages/manager/src/store/linodes/linodes.events.ts
@@ -49,6 +49,12 @@ const linodeEventsHandler: EventHandler = (event, dispatch, getState) => {
     case 'linode_create':
       return handleLinodeCreation(dispatch, status, id, getState());
 
+    /**
+     * Config actions
+     *
+     * It's not clear that these can actually fail, so this is here
+     * mostly as a failsafe.
+     */
     case 'linode_config_create':
     case 'linode_config_delete':
       return handleConfigEvent(dispatch, status, id);


### PR DESCRIPTION
## Description

The original plan here was to make use of the secondary_entity on these to make more targeted requests when CRUDding disks and configs. I actually left more intact than I planned: we're still optimistically adding/deleting disks and configs to the tables as soon as we get a 200.

Lots of changes, though:

- Update events messages for these events to include the disk/config name
- Request all disks or configs if we get a failed event for these
- Add loading state to submit button in config drawer
- Source config data from Redux in config drawer (we were requesting it separately)
- Add loading state to config deletion modal
- Move error message from toast to within the config deletion modal
- Change the name of the "Advanced" tab to "Disks/Configs" because we've been talking about it for ages and people keep complaining about it.

