### PR TITLE
M3-3161 Change: Add copy clarifying prorated transfer

### DIFF
--- a/packages/manager/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
@@ -21,7 +21,8 @@ export type ClassNames =
   | 'poolUsageProgress'
   | 'initialLoader'
   | 'title'
-  | 'overLimit';
+  | 'overLimit'
+  | 'proratedNotice';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -54,6 +55,9 @@ const styles = (theme: Theme) =>
     overLimit: {
       color: theme.palette.status.warningDark,
       fontFamily: theme.font.bold
+    },
+    proratedNotice: {
+      marginTop: theme.spacing(1)
     }
   });
 
@@ -139,6 +143,9 @@ class TransferDashboardCard extends React.Component<CombinedProps, State> {
                   </Typography>
                 </Grid>
               </Grid>
+              <Typography className={classes.proratedNotice}>
+                Your transfer is prorated and will reset next month
+              </Typography>
             </Grid>
           </Grid>
         </Paper>


### PR DESCRIPTION
##  Description

The total amount of transfer shown on the Dashboard is prorated for the month. For example, if you create a 1GB Linode halfway during the month, 500GB is added to your transfer instead of 1000GB.

https://www.linode.com/docs/platform/billing-and-support/network-transfer-quota/#why-is-my-linode-s-network-transfer-less-than-my-plan-s-transfer

This was causing some confusion, since the transfer on Linode Details in the total transfer that Linode type adds to your your pool.

To clarify, I included the note from Classic that explains that monthly transfer is prorated.

<img width="557" alt="Screen Shot 2019-12-19 at 3 55 44 PM" src="https://user-images.githubusercontent.com/16911484/71209543-cdf51680-2279-11ea-89d6-9d1c73aabb31.png">


## Type of Change
- Non breaking change ('update', 'change')

**Note:** There is currently an API bug where Object Storage is not included in your account transfer, so if you're comparing to Classic, there will be a 1000GB discrepancy.