### PR TITLE
M3-3755 Linode details Rebuild SSH keys A11y issues

### DIFF
--- a/packages/manager/src/components/AccessPanel/UserSSHKeyPanel.tsx
+++ b/packages/manager/src/components/AccessPanel/UserSSHKeyPanel.tsx
@@ -135,7 +135,13 @@ const UserSSHKeyPanel: React.FunctionComponent<CombinedProps> = props => {
                   data-testid="ssh-public-key"
                 >
                   <TableCell className={classes.cellCheckbox}>
-                    <CheckBox checked={selected} onChange={onSSHKeyChange} />
+                    <CheckBox
+                      checked={selected}
+                      onChange={onSSHKeyChange}
+                      inputProps={{
+                        'aria-label': `Enable SSH for ${username}`
+                      }}
+                    />
                   </TableCell>
                   <TableCell className={classes.cellUser}>
                     <div className={classes.userWrapper}>


### PR DESCRIPTION
## Description

Adding aria-label to checkbox on SSH Keys under Rebuild tab on Linode details so the checkbox is given context as to what it controls for assistive technologies.

## Type of Change
- Non breaking change ('update')
