### PR TITLE
Sentry improvements

### DIFF
--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -22,6 +22,7 @@ import TheApplicationIsOnFire from 'src/features/TheApplicationIsOnFire';
 
 import { ApplicationState } from 'src/store';
 import composeState from 'src/utilities/composeState';
+import { configureErrorReportingUser } from './exceptionReporting';
 import { MapState } from './store/types';
 import { isKubernetesEnabled as _isKubernetesEnabled } from './utilities/accountCapabilities';
 
@@ -81,6 +82,14 @@ export class App extends React.Component<CombinedProps, State> {
         (window as any).ga('send', 'pageview', pathname);
       }
     });
+
+    // Configure error reporting to include user information.
+    if (this.props.userId && this.props.username) {
+      configureErrorReportingUser(
+        String(this.props.userId),
+        this.props.username
+      );
+    }
 
     /*
      * We want to listen for migration events side-wide

--- a/packages/manager/src/exceptionReporting.ts
+++ b/packages/manager/src/exceptionReporting.ts
@@ -1,9 +1,6 @@
-import { captureException, configureScope } from '@sentry/browser';
+import { captureException, configureScope, withScope } from '@sentry/browser';
 import { pathOr } from 'ramda';
 import { SENTRY_URL } from 'src/constants';
-
-import store from 'src/store';
-
 import { initSentry } from 'src/initSentry';
 
 initSentry();
@@ -24,9 +21,9 @@ window.addEventListener('unhandledrejection', err => {
 
   const firstReason = pathOr('', [0, 'reason'], err.reason);
 
-  /* 
-    if our error is an error we want to ignore, don't report to Sentry 
-    
+  /*
+    if our error is an error we want to ignore, don't report to Sentry
+
     Ideally we shouldn't be doing this because the goal app-wide should be to
     catch every and all promise, but because of time and resources that just isn't a
     possibility. For now, just ignore OAuth and "Not Found" errors and don't report them
@@ -44,19 +41,20 @@ window.addEventListener('unhandledrejection', err => {
   reportException(err.reason);
 });
 
-window.addEventListener('error', err => {
-  reportException(err.message);
-});
-
+// Wrapper around Sentry's `captureException` function. A local scope is created
+// so that we can add `extra` and `tags` to this specific Sentry event.
 export const reportException = (
   error: string | Error,
   extra?: Record<string, any>,
   tags?: Record<string, string>
 ) => {
-  /**
-   * if we're in the development environment, log the error to the console
-   */
-  if (process.env.NODE_ENV !== 'production' && SENTRY_URL) {
+  // Don't report errors if the environment doesn't include a Sentry URL.
+  if (!SENTRY_URL) {
+    return;
+  }
+
+  // Log the error to the console in non-production environments.
+  if (process.env.NODE_ENV !== 'production') {
     /* tslint:disable */
     console.error('====================================');
     console.error(error);
@@ -64,44 +62,41 @@ export const reportException = (
     console.error('====================================');
   }
 
-  /** log the error to sentry as long as the URL exists in the .env */
-  if (SENTRY_URL) {
-    const userEmail = pathOr(
-      'Could not get user email',
-      ['__resources', 'profile', 'data', 'email'],
-      store.getState()
-    );
-    const userID = pathOr(
-      'Could not get user ID',
-      ['__resources', 'profile', 'data', 'uid'],
-      store.getState()
-    );
-    const username = pathOr(
-      'Could not get username',
-      ['__resources', 'profile', 'data', 'username'],
-      store.getState()
-    );
-
-    configureScope(scopes => {
-      if (extra) {
-        Object.keys(extra).forEach(extraKey => {
-          scopes.setExtra(extraKey, extra[extraKey]);
-        });
-      }
-
-      if (tags) {
-        Object.keys(tags).forEach(tagKey => {
-          scopes.setTag(tagKey, tags[tagKey]);
-        });
-      }
-
-      scopes.setUser({
-        user_id: userID,
-        email: userEmail,
-        username
+  // Create a local scope so we can add `extra` and `tags` to this specific
+  // Sentry event.
+  withScope(scope => {
+    if (extra) {
+      Object.keys(extra).forEach(extraKey => {
+        scope.setExtra(extraKey, extra[extraKey]);
       });
-    });
+    }
 
-    captureException(error);
-  }
+    if (tags) {
+      Object.keys(tags).forEach(tagKey => {
+        scope.setTag(tagKey, tags[tagKey]);
+      });
+    }
+
+    // `captureException` expects an Error object. If the `error` argument has
+    // been given as a string, convert it to an Error object before capturing.
+    if (typeof error === 'string') {
+      captureException(Error(error));
+    } else {
+      captureException(error);
+    }
+  });
+};
+
+// Configure global scope to include user information. This function should be
+// called once, as soon as user data is available.
+export const configureErrorReportingUser = (
+  userId: string,
+  username: string
+) => {
+  configureScope(scope => {
+    scope.setUser({
+      user_id: userId,
+      username
+    });
+  });
 };

--- a/packages/manager/src/initSentry.ts
+++ b/packages/manager/src/initSentry.ts
@@ -40,7 +40,7 @@ export const initSentry = () => {
         'ComboSearch is not defined',
         'http://loading.retry.widdit.com/',
         /** noisy error that appeared to be happening for logged out users? */
-        "mousedownt' of undefined",
+        "mousedown' of undefined",
         /**
          * see https://github.com/getsentry/sentry-javascript/issues/2074
          * for this noisy issue


### PR DESCRIPTION
This PR makes the following improvements to our Sentry integration:

1. Stop reporting JavaScript errors picked up by global `error` listener. The Sentry SDK already does this, so we were getting double-reporting.
2. Use `withScope()` instead of `configureScope()` for "extra" and "tag" data. This ensures the additional data is only sent on that specific Sentry event.
3. Configure scope for user data only once, in cDM of App.tsx. (Previously we were doing this in every `reportException()`  call.)
4. Ensure Sentry’s `captureException()` receives an Error object instead of a string. This should solve for the `"<unknown>: [object Object]"` errors we were getting.

**To test:**
Break the application in as many ways as you can. Call undefined functions, manually throw errors, use the `reportException` function in as many ways as you can think of. Check POST requests to Sentry as well as the Sentry Dashboard itself.