### PR TITLE
[Sentry] Ignore newrelic.js and Chrome extension errors 

### DIFF
--- a/packages/manager/src/initSentry.ts
+++ b/packages/manager/src/initSentry.ts
@@ -71,6 +71,13 @@ export const initSentry = () => {
         /** anything from either *.linode.com/* or localhost:3000 */
         /linode.com{1}/g,
         /localhost:3000{1}/g
+      ],
+      blacklistUrls: [
+        // Newrelic script
+        /newrelic\.js/i,
+        // Chrome extensions
+        /extensions\//i,
+        /^chrome:\/\//i
       ]
     });
   }


### PR DESCRIPTION
## Description

We received reports of errors in newrelic.js. This PR adds the `blacklistURLs` option so we can avoid reporting these errors to Sentry. 

I also copied the Chrome extension snippet from the[ Sentry docs](https://docs.sentry.io/platforms/javascript/#decluttering-sentry) so we can avoid reporting browser extension errors as well. 

To test (lack of) newrelic.js error reporting:

1) Make sure `REACT_APP_SENTRY_URL` is defined.
2) Make a bogus change in `newrelic.js`.
3) Observe (in the Network tab and Sentry Dashboard): the error appears in the console but is not reported to Sentry.
