### PR TITLE
M3-2431 Add URL param to reset password button

### DIFF
--- a/packages/manager/src/features/Profile/AuthenticationSettings/AuthenticationSettings.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/AuthenticationSettings.tsx
@@ -89,7 +89,7 @@ export class AuthenticationSettings extends React.Component<
         {success && <Notice success text={success} />}
         {!loading && (
           <React.Fragment>
-            <ResetPassword />
+            <ResetPassword username={username} />
             <TwoFactor
               twoFactor={twoFactor}
               username={username}
@@ -145,10 +145,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = dispatch => ({
   updateProfile: (v: Partial<Profile>) => dispatch(_updateProfile(v) as any)
 });
 
-const connected = connect(
-  mapStateToProps,
-  mapDispatchToProps
-);
+const connected = connect(mapStateToProps, mapDispatchToProps);
 
 const enhanced = compose<CombinedProps, {}>(
   styled,

--- a/packages/manager/src/features/Profile/AuthenticationSettings/ResetPassword.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/ResetPassword.tsx
@@ -12,7 +12,11 @@ import { LOGIN_ROOT } from 'src/constants';
 
 type ClassNames = 'root' | 'button';
 
-type CombinedProps = WithStyles<ClassNames>;
+interface Props {
+  username?: string;
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -26,7 +30,8 @@ const styles = (theme: Theme) =>
   });
 
 const ResetPassword: React.StatelessComponent<CombinedProps> = props => {
-  const { classes } = props;
+  const { classes, username } = props;
+
   return (
     <Paper className={classes.root}>
       <Typography variant="h2" data-qa-title>
@@ -34,7 +39,7 @@ const ResetPassword: React.StatelessComponent<CombinedProps> = props => {
       </Typography>
       <Button
         buttonType="primary"
-        href={`${LOGIN_ROOT}/forgot/password`}
+        href={`${LOGIN_ROOT}/forgot/password?username=${username}`}
         className={classes.button}
       >
         Reset Password


### PR DESCRIPTION
## M3-2431 Add URL param to reset password button

API has now implemented the ability to use a URL parameter to pre-fill the username when trying to reset password from cloud. This PR adds this URL param.

## Type of Change
- Non breaking change ('update', 'change')
