### PR TITLE
Fix Weblish error (safe access properties)

### DIFF
--- a/packages/manager/src/features/Lish/Weblish.tsx
+++ b/packages/manager/src/features/Lish/Weblish.tsx
@@ -154,9 +154,8 @@ export class Weblish extends React.Component<CombinedProps, State> {
       }
 
       if (
-        data.type &&
-        data.type === 'error' &&
-        data.reason.toLowerCase() === 'your session has expired.'
+        data?.type === 'error' &&
+        data?.reason.toLowerCase() === 'your session has expired.'
       ) {
         /*
          * We tried to reconnect 3 times

--- a/packages/manager/src/features/Lish/Weblish.tsx
+++ b/packages/manager/src/features/Lish/Weblish.tsx
@@ -155,7 +155,7 @@ export class Weblish extends React.Component<CombinedProps, State> {
 
       if (
         data?.type === 'error' &&
-        data?.reason.toLowerCase() === 'your session has expired.'
+        data?.reason?.toLowerCase() === 'your session has expired.'
       ) {
         /*
          * We tried to reconnect 3 times


### PR DESCRIPTION
## Description

We were getting error reports of `Cannot read property 'type' of null.` I was not able to reproduce this issue, but safe accessing the "type" (and "reason") attributes of `data` should at least stop the app from crashing if/when this happens.

To test, add `data = null;` to line 155 of Weblish.tsx.

