### PR TITLE
Add toast for failed snapshot

### DIFF
--- a/packages/manager/src/features/ToastNotifications/ToastNotifications.tsx
+++ b/packages/manager/src/features/ToastNotifications/ToastNotifications.tsx
@@ -102,6 +102,13 @@ class ToastNotifications extends React.PureComponent<WithSnackbarProps, {}> {
           );
         }
 
+        if (event.action === 'linode_snapshot' && event.status === 'failed') {
+          return enqueueSnackbar(
+            `There was an error creating a snapshot on Linode ${event.entity?.label}.`,
+            { variant: 'error' }
+          );
+        }
+
         /**
          * These create/delete failures are hypothetical.
          * We don't know if it's possible for these to fail,


### PR DESCRIPTION
## Description

I was digging around in backups for an unrelated reason, and realized we weren't toasting when a snapshot failed (we just have error handling for when the initial request fails).
