### PR TITLE
M3-3459 UserID for GTM

### DIFF
--- a/packages/linode-js-sdk/src/account/types.ts
+++ b/packages/linode-js-sdk/src/account/types.ts
@@ -25,6 +25,7 @@ export interface Account {
   company: string;
   active_promotions: ActivePromotion[];
   capabilities: AccountCapability[];
+  euuid: string;
 }
 
 export type AccountCapability =
@@ -251,8 +252,8 @@ export interface Event {
   action: EventAction;
   created: string;
   entity: Entity | null;
-  /* 
-    NOTE: events before the duration key was added will have a duration of 0 
+  /*
+    NOTE: events before the duration key was added will have a duration of 0
   */
   duration: number | null;
   percent_complete: number | null;

--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -31,6 +31,7 @@ import { handleLoadingDone } from 'src/store/initialLoad/initialLoad.actions';
 
 import IdentifyUser from './IdentifyUser';
 
+import { initGTMUser } from './analytics';
 import MainContent from './MainContent';
 
 interface Props {
@@ -89,6 +90,10 @@ export class App extends React.Component<CombinedProps, State> {
         String(this.props.userId),
         this.props.username
       );
+    }
+
+    if (this.props.euuid) {
+      initGTMUser(this.props.euuid);
     }
 
     /*
@@ -293,6 +298,7 @@ interface StateProps {
   typesError?: APIError[];
   regionsError?: APIError[];
   appIsLoading: boolean;
+  euuid?: string;
 }
 
 const mapStateToProps: MapState<StateProps, Props> = state => ({
@@ -339,7 +345,8 @@ const mapStateToProps: MapState<StateProps, Props> = state => ({
   nodeBalancersLoading: state.__resources.nodeBalancers.loading,
   accountError: path(['read'], state.__resources.account.error),
   nodeBalancersError: path(['read'], state.__resources.nodeBalancers.error),
-  appIsLoading: state.initialLoad.appIsLoading
+  appIsLoading: state.initialLoad.appIsLoading,
+  euuid: state.__resources.account.data?.euuid
 });
 
 export const connected = connect(mapStateToProps, mapDispatchToProps);

--- a/packages/manager/src/__data__/account.ts
+++ b/packages/manager/src/__data__/account.ts
@@ -38,7 +38,8 @@ export const account: Account = {
   phone: '2151231234',
   company: 'mmckenna',
   active_promotions: activePromotions,
-  capabilities: ['Linodes', 'NodeBalancers', 'Block Storage']
+  capabilities: ['Linodes', 'NodeBalancers', 'Block Storage'],
+  euuid: '827923A3-566B-4C83-9B84-6BF656628206'
 };
 
 export const accountSettings: AccountSettings = {

--- a/packages/manager/src/analytics.ts
+++ b/packages/manager/src/analytics.ts
@@ -1,3 +1,5 @@
+import { GTM_ID } from './constants';
+
 /* tslint:disable */
 const gaInit = (i: any, s: any, o: any, g: any, r: any, a: any, m: any) => {
   const currdate: any = new Date();
@@ -64,4 +66,16 @@ export const initTagManager = (gtmId?: string) => {
   }
 
   initGTM(window, document, 'script', 'dataLayer', gtmId);
+};
+
+export const initGTMUser = (userId: string) => {
+  if (!GTM_ID) {
+    return;
+  }
+  (window as any).dataLayer = (window as any).dataLayer || [];
+  (window as any).dataLayer.push({
+    event: 'userInfo',
+    gtmAccountID: GTM_ID,
+    gtmIndividualUserId: userId
+  });
 };

--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/SummaryPanel.test.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/SummaryPanel.test.tsx
@@ -33,7 +33,8 @@ describe('SummaryPanel', () => {
       balance_uninvoiced: 0,
       active_since: '2018-05-17T18:22:50',
       active_promotions: activePromotions,
-      capabilities: ['Linodes', 'NodeBalancers', 'Block Storage']
+      capabilities: ['Linodes', 'NodeBalancers', 'Block Storage'],
+      euuid: '827923A3-566B-4C83-9B84-6BF656628206'
     }
   };
 


### PR DESCRIPTION
## Description
Once we get `euuid` back from the API (on `/account`) add a `userInfo` event to the dataLayer. This takes place in cDM of `<App />`.

## Note to Reviewers

**To test,** make sure `REACT_APP_GTM_ID` is defined in your environment. Load the app. There are a few ways to verify the event is being added to the dataLayer:

1) Open up the console and type `dataLayer` (it's just an array on `window`).
2) Use an extension like [Dataslayer](https://chrome.google.com/webstore/detail/dataslayer/ikbablmmjldhamhcldjjigniffkkjgpo?hl=en-US)
3. Use Tag Manager preview mode

Also try logging out of Cloud and going through the whole flow with Login (the same `userInfo` event occurs there as well.)

