### PR TITLE
Longview: Add empty state for Disks tab in LongviewDetail

### DIFF
--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Disks/Disks.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Disks/Disks.tsx
@@ -8,6 +8,7 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 import Box from 'src/components/core/Box';
 import ErrorState from 'src/components/ErrorState';
 import LandingLoading from 'src/components/LandingLoading';
+import Placeholder from 'src/components/Placeholder';
 import TimeRangeSelect from '../../../shared/TimeRangeSelect';
 import DiskPaper from './DiskPaper';
 
@@ -70,25 +71,22 @@ const Disks: React.FC<CombinedProps> = props => {
         .then(r => {
           if (mounted) {
             setLoading(false);
-            const _disk = pathOr({}, ['Disk'], r);
+            const _disk = pathOr({}, ['DATA', 'Disk'], r);
 
-            const pathsToAlter = Object.keys(_disk).reduce(
-              (acc, eachKey) => {
-                acc.push(
-                  ...[
-                    [eachKey, 'reads'],
-                    [eachKey, 'writes'],
-                    [eachKey, 'fs', 'free'],
-                    [eachKey, 'fs', 'total'],
-                    [eachKey, 'fs', 'itotal'],
-                    [eachKey, 'fs', 'ifree']
-                  ]
-                );
+            const pathsToAlter = Object.keys(_disk).reduce((acc, eachKey) => {
+              acc.push(
+                ...[
+                  [eachKey, 'reads'],
+                  [eachKey, 'writes'],
+                  [eachKey, 'fs', 'free'],
+                  [eachKey, 'fs', 'total'],
+                  [eachKey, 'fs', 'itotal'],
+                  [eachKey, 'fs', 'ifree']
+                ]
+              );
 
-                return acc;
-              },
-              [] as (string | number)[][]
-            );
+              return acc;
+            }, [] as (string | number)[][]);
 
             const enhancedDisk = pathMaybeAddDataInThePast<Disk<'yAsNull'>>(
               _disk,
@@ -132,6 +130,16 @@ const Disks: React.FC<CombinedProps> = props => {
       alphabetically now
     */
     const sortedKeys = Object.keys(diskStats || {}).sort();
+
+    if (sortedKeys.length === 0) {
+      // Empty state
+      return (
+        <Placeholder
+          title="No disks detected"
+          copy="The Longview agent has not detected any disks that it can monitor."
+        />
+      );
+    }
 
     return sortedKeys.map(eachKey => (
       <DiskPaper

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/useGraphs.ts
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/useGraphs.ts
@@ -15,7 +15,12 @@ export const useGraphs = (
     if (!start || !end) {
       return;
     }
-    setLoading(true);
+    /**
+     * Only show loading state on first load
+     */
+    if (Object.keys(data).length === 0) {
+      setLoading(true);
+    }
     setData({});
     return getValues(clientAPIKey, {
       fields: requestFields,


### PR DESCRIPTION
Add a Placeholder component with empty state messaging when a user
has no disks that are reporting to Longview. This is different from
most empty states in LV, since most other tabs will have empty tables
or graphs. Disks, however, is an object of `sda: {data}` objects,
which will be empty if no data is available for the specified time frame.

We had discussed hiding the time select component from view in this empty
state, but on further testing discovered that it's easy to end up in a situation
where the empty state will disappear if the user changes to a longer time
frame, one in which data is present.

## Notes

This tab needs some follow-up work to match the behavior of other graphs (specifically, updating the X axis when the time box is changed), but that's turning out to be a big lift so I'm going to do a follow-on PR
