### PR TITLE
update outdated notistack

### DIFF
--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -44,7 +44,7 @@
     "memoizee": "^0.4.14",
     "moment": "^2.21.0",
     "moment-timezone": "^0.5.16",
-    "notistack": "^0.7.0",
+    "notistack": "^0.9.7",
     "novnc-node": "^0.5.3",
     "patch-package": "^6.1.0",
     "postinstall-postinstall": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14178,14 +14178,14 @@ normalizr@*:
   resolved "https://registry.yarnpkg.com/normalizr/-/normalizr-3.3.0.tgz#6f44b95e8bf2201845a9e551920c4e5861166d27"
   integrity sha512-u8Us8Ms5KpY0mmNwML4OBxNKvlmSKeXfPBIXU9XmcejrZUjhIvUOd8RYBq62UL4JHxrcO4wqo2sL4s8B74Hadw==
 
-notistack@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/notistack/-/notistack-0.7.0.tgz#fc46752ec2712ebe287691b2f3ed597a8667929d"
-  integrity sha512-Sb/ebrh4rpiF5cBM21taZlWdA2FMFKSB53PPsAxJXoimHPuLzYxwL+oH8xRrLW4ttkveGQ8hMAL/62eFAeoXDQ==
+notistack@^0.9.7:
+  version "0.9.7"
+  resolved "https://registry.yarnpkg.com/notistack/-/notistack-0.9.7.tgz#4475db65ec365c1d38244c66285e81f525ea0abb"
+  integrity sha512-OztbtaIiCMR7QdcDGXTcYu96Uuvu26k41d7cnMGdf4NaKkAX06fsLPAlodGPj4HrMjMBUl8nvUQ3LmQOS6kHWQ==
   dependencies:
     classnames "^2.2.6"
     hoist-non-react-statics "^3.3.0"
-    prop-types "^15.6.2"
+    prop-types "^15.7.2"
     react-is "^16.8.6"
 
 novnc-node@^0.5.3:


### PR DESCRIPTION
## Description

Update notistack which used outdated proptypes, react version

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests
There does not seem to be unit tests or storybook tests with this, so only e2e test can be run against this, and manual testing

## Note to Reviewers

Test manually that the snackbarprops works the same way