### PR TITLE
M3-3770 Convert invoice fields to Number() before using toFixed()

### DIFF
--- a/packages/manager/src/features/Billing/PdfGenerator/utils.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/utils.ts
@@ -30,7 +30,7 @@ export const createPaymentsTable = (doc: JSPDF, payment: Payment) => {
       [
         { content: 'Payment: Thank You' },
         { content: formatDate(payment.date, { format: 'YYYY-MM-DD' }) },
-        { content: `$${payment.usd.toFixed(2)}` }
+        { content: `$${Number(payment.usd).toFixed(2)}` }
       ]
     ]
   });
@@ -47,7 +47,9 @@ export const createPaymentsTotalsTable = (doc: JSPDF, payment: Payment) => {
     headStyles: {
       fillColor: '#444444'
     },
-    body: [['Payment Total (USD)        ', `$${payment.usd.toFixed(2)}`]]
+    body: [
+      ['Payment Total (USD)        ', `$${Number(payment.usd).toFixed(2)}`]
+    ]
   });
 };
 
@@ -99,17 +101,23 @@ export const createInvoiceItemsTable = (doc: JSPDF, items: InvoiceItem[]) => {
           styles: { halign: 'center', fontSize: 8, overflow: 'linebreak' },
           content: item.unit_price || ''
         },
+        /**
+         * We do number conversion here because some older invoice items
+         * (specifically Customer Packages) return these values as strings.
+         *
+         * The API team will fix this in ARB-1607.
+         */
         {
           styles: { halign: 'center', fontSize: 8, overflow: 'linebreak' },
-          content: `$${item.amount.toFixed(2)}`
+          content: `$${Number(item.amount).toFixed(2)}`
         },
         {
           styles: { halign: 'center', fontSize: 8, overflow: 'linebreak' },
-          content: `$${item.tax.toFixed(2)}`
+          content: `$${Number(item.tax).toFixed(2)}`
         },
         {
           styles: { halign: 'center', fontSize: 8, overflow: 'linebreak' },
-          content: `$${item.total.toFixed(2)}`
+          content: `$${Number(item.total).toFixed(2)}`
         }
       ];
     })
@@ -128,9 +136,9 @@ export const createInvoiceTotalsTable = (doc: JSPDF, invoice: Invoice) => {
       fillColor: '#444444'
     },
     body: [
-      ['Subtotal (USD)', `$${invoice.subtotal.toFixed(2)}`],
-      ['Tax (USD)', `$${invoice.tax.toFixed(2)}`],
-      [`Total (USD)`, `$${invoice.total.toFixed(2)}`]
+      ['Subtotal (USD)', `$${Number(invoice.subtotal).toFixed(2)}`],
+      ['Tax (USD)', `$${Number(invoice.tax).toFixed(2)}`],
+      [`Total (USD)`, `$${Number(invoice.total).toFixed(2)}`]
     ]
   });
 };


### PR DESCRIPTION
## Description

invoiceItem.amount (and .tax and .total) are guaranteed by the API
to be numbers, but some special cases (Customer Packages) and older
records returned these values as strings, which causes toFixed()
to throw an error.

The API will fix this bug in ARB-1607, but for safety sake we
should continue to manually convert values.

If anything other than a number or a valid numeric string comes in,
we'll end up showing "$NaN" to the user. I don't think this is possible
so I didn't do any complex conditional logic to account for it, but
we should keep this in mind in case something like this happens again.
