### PR TITLE
Chart native legend

### DIFF
--- a/packages/manager/src/components/LineGraph/LineGraph.stories.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.stories.tsx
@@ -7,18 +7,20 @@ const mockData = [
   {
     label: 'Linodes',
     borderColor: 'blue',
-    data: [[1537979728, 1000], [1637979728, 2000], [1737979728, 5000]] as [
-      number,
-      number
-    ][]
+    data: [
+      [1537979728, 1000],
+      [1637979728, 2000],
+      [1737979728, 5000]
+    ] as [number, number][]
   },
   {
     label: 'Volumes',
     borderColor: 'red',
-    data: [[1537979728, 100], [1637979728, 200], [1737979728, 500]] as [
-      number,
-      number
-    ][]
+    data: [
+      [1537979728, 100],
+      [1637979728, 200],
+      [1737979728, 500]
+    ] as [number, number][]
   }
 ];
 
@@ -42,6 +44,14 @@ storiesOf('Line Graph', module)
       showToday={false}
       data={mockData}
       suggestedMax={7000}
+      timezone={'America/Los_Angeles'}
+    />
+  ))
+  .add('Using the Chart.js native legend functionality', () => (
+    <LineGraph
+      nativeLegend
+      showToday={false}
+      data={mockData}
       timezone={'America/Los_Angeles'}
     />
   ));

--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -37,6 +37,7 @@ export interface Props {
   rowHeaders?: Array<string>;
   legendRows?: Array<ChartData<any>>;
   unit?: string; // Display unit on Y axis ticks
+  nativeLegend?: boolean; // Display chart.js native legend
 }
 
 type CombinedProps = Props;
@@ -134,6 +135,7 @@ const LineGraph: React.FC<CombinedProps> = props => {
     data,
     rowHeaders,
     legendRows,
+    nativeLegend,
     ...rest
   } = props;
   const finalRowHeaders = rowHeaders ? rowHeaders : ['Max', 'Avg', 'Last'];
@@ -159,7 +161,11 @@ const LineGraph: React.FC<CombinedProps> = props => {
     }
   ];
 
-  const getChartOptions = (_suggestedMax?: number, _unit?: string) => {
+  const getChartOptions = (
+    _suggestedMax?: number,
+    _unit?: string,
+    _nativeLegend?: boolean
+  ) => {
     const finalChartOptions = clone(chartOptions);
     const parser = parseInTimeZone(timezone || '');
     finalChartOptions.scales.xAxes[0].time.parser = parser;
@@ -190,6 +196,11 @@ const LineGraph: React.FC<CombinedProps> = props => {
       ) => `${humanizeLargeData(value)}${_unit}`;
     }
 
+    if (_nativeLegend) {
+      finalChartOptions.legend.display = true;
+      finalChartOptions.legend.position = 'bottom';
+    }
+
     return finalChartOptions;
   };
 
@@ -217,7 +228,7 @@ const LineGraph: React.FC<CombinedProps> = props => {
         <Line
           {...rest}
           height={chartHeight || 300}
-          options={getChartOptions(suggestedMax, unit)}
+          options={getChartOptions(suggestedMax, unit, nativeLegend)}
           plugins={plugins}
           ref={inputEl}
           data={{

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Disks/Graphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Disks/Graphs.tsx
@@ -251,7 +251,4 @@ export const generateHelperText = (
   return '';
 };
 
-export default compose<CombinedProps, Props>(
-  React.memo,
-  withTheme
-)(Graphs);
+export default compose<CombinedProps, Props>(React.memo, withTheme)(Graphs);

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/CPUGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/CPUGraph.tsx
@@ -49,6 +49,7 @@ export const CPUGraph: React.FC<CombinedProps> = props => {
     <LongviewLineGraph
       title="CPU"
       subtitle="%"
+      nativeLegend
       error={error}
       loading={loading}
       showToday={isToday}

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/DiskGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/DiskGraph.tsx
@@ -54,6 +54,7 @@ export const DiskGraph: React.FC<CombinedProps> = props => {
       subtitle={'ops/second'}
       showToday={isToday}
       timezone={timezone}
+      nativeLegend
       data={[
         {
           label: 'Swap',

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/MemoryGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/MemoryGraph.tsx
@@ -63,6 +63,7 @@ export const MemoryGraph: React.FC<CombinedProps> = props => {
       loading={loading}
       showToday={isToday}
       timezone={timezone}
+      nativeLegend
       data={[
         {
           label: 'Swap',

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/NetworkGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/NetworkGraph.tsx
@@ -73,6 +73,7 @@ export const NetworkGraph: React.FC<CombinedProps> = props => {
       loading={loading}
       showToday={isToday}
       timezone={timezone}
+      nativeLegend
       data={[
         {
           label: 'Inbound',
@@ -92,9 +93,6 @@ export const NetworkGraph: React.FC<CombinedProps> = props => {
   );
 };
 
-const enhanced = compose<CombinedProps, GraphProps>(
-  React.memo,
-  withTheme
-);
+const enhanced = compose<CombinedProps, GraphProps>(React.memo, withTheme);
 
 export default enhanced(NetworkGraph);


### PR DESCRIPTION
## Description

Chart.js has a built-in legend that Alban suggested we use for the LV graphs. This matches the designs, except for the positioning: it would actually be hugely difficult to move them outside of the graphs and into the header, so I'm going to hold off until we're sure that's something we really want to do.

## Note to Reviewers

I added the new prop to the Overview graphs (except Load, which has a single data series). Please click around.