### PR TITLE
React.lazy

### DIFF
--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -27,6 +27,7 @@ import LandingLoading from 'src/components/LandingLoading';
 import NotFound from 'src/components/NotFound';
 import PreferenceToggle, { ToggleProps } from 'src/components/PreferenceToggle';
 import SideMenu from 'src/components/SideMenu';
+import SuspenseLoader from 'src/components/SuspenseLoader';
 
 import withGlobalErrors, {
   Props as GlobalErrorProps
@@ -314,55 +315,60 @@ const MainContent: React.FC<CombinedProps> = props => {
                 <Grid container spacing={0} className={classes.grid}>
                   <Grid item className={classes.switchWrapper}>
                     <RegionStatusBanner />
-                    <Switch>
-                      <Route path="/linodes" component={LinodesRoutes} />
-                      <Route path="/volumes" component={Volumes} />
-                      <Redirect path="/volumes*" to="/volumes" />
-                      <Route path="/nodebalancers" component={NodeBalancers} />
-                      <Route path="/domains" component={Domains} />
-                      <Route path="/managed" component={Managed} />
-                      <Route path="/longview" component={Longview} />
-                      <Route exact strict path="/images" component={Images} />
-                      <Redirect path="/images*" to="/images" />
-                      <Route path="/stackscripts" component={StackScripts} />
-                      {getObjectStorageRoute(
-                        props.accountLoading,
-                        props.accountCapabilities,
-                        props.accountError
-                      )}
-                      {isKubernetesEnabled && (
-                        <Route path="/kubernetes" component={Kubernetes} />
-                      )}
-                      <Route path="/account" component={Account} />
-                      <Route
-                        exact
-                        strict
-                        path="/support/tickets"
-                        component={SupportTickets}
-                      />
-                      <Route
-                        path="/support/tickets/:ticketId"
-                        component={SupportTicketDetail}
-                        exact
-                        strict
-                      />
-                      <Route path="/profile" component={Profile} />
-                      <Route exact path="/support" component={Help} />
-                      <Route path="/dashboard" component={Dashboard} />
-                      <Route path="/search" component={SearchLanding} />
-                      <Route
-                        exact
-                        strict
-                        path="/support/search/"
-                        component={SupportSearchLanding}
-                      />
-                      <Route path="/events" component={EventsLanding} />
-                      {props.flags.firewalls && (
-                        <Route path="/firewalls" component={Firewalls} />
-                      )}
-                      <Redirect exact from="/" to="/dashboard" />
-                      <Route component={NotFound} />
-                    </Switch>
+                    <React.Suspense fallback={<SuspenseLoader delay={300} />}>
+                      <Switch>
+                        <Route path="/linodes" component={LinodesRoutes} />
+                        <Route path="/volumes" component={Volumes} />
+                        <Redirect path="/volumes*" to="/volumes" />
+                        <Route
+                          path="/nodebalancers"
+                          component={NodeBalancers}
+                        />
+                        <Route path="/domains" component={Domains} />
+                        <Route path="/managed" component={Managed} />
+                        <Route path="/longview" component={Longview} />
+                        <Route exact strict path="/images" component={Images} />
+                        <Redirect path="/images*" to="/images" />
+                        <Route path="/stackscripts" component={StackScripts} />
+                        {getObjectStorageRoute(
+                          props.accountLoading,
+                          props.accountCapabilities,
+                          props.accountError
+                        )}
+                        {isKubernetesEnabled && (
+                          <Route path="/kubernetes" component={Kubernetes} />
+                        )}
+                        <Route path="/account" component={Account} />
+                        <Route
+                          exact
+                          strict
+                          path="/support/tickets"
+                          component={SupportTickets}
+                        />
+                        <Route
+                          path="/support/tickets/:ticketId"
+                          component={SupportTicketDetail}
+                          exact
+                          strict
+                        />
+                        <Route path="/profile" component={Profile} />
+                        <Route exact path="/support" component={Help} />
+                        <Route path="/dashboard" component={Dashboard} />
+                        <Route path="/search" component={SearchLanding} />
+                        <Route
+                          exact
+                          strict
+                          path="/support/search/"
+                          component={SupportSearchLanding}
+                        />
+                        <Route path="/events" component={EventsLanding} />
+                        {props.flags.firewalls && (
+                          <Route path="/firewalls" component={Firewalls} />
+                        )}
+                        <Redirect exact from="/" to="/dashboard" />
+                        <Route component={NotFound} />
+                      </Switch>
+                    </React.Suspense>
                   </Grid>
                 </Grid>
               </main>

--- a/packages/manager/src/components/SuspenseLoader/SuspenseLoader.tsx
+++ b/packages/manager/src/components/SuspenseLoader/SuspenseLoader.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import CircleProgress from 'src/components/CircleProgress';
+
+interface Props {
+  delay?: number;
+}
+
+export type CombinedProps = Props;
+
+export const SuspenseLoader: React.FC<Props> = props => {
+  const { delay } = props;
+  const [show, setShow] = React.useState<boolean>(false);
+
+  React.useEffect(() => {
+    const timeout = setTimeout(() => setShow(true), delay ?? 500);
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, []);
+
+  return <>{show && <CircleProgress />}</>;
+};
+
+export default SuspenseLoader;

--- a/packages/manager/src/components/SuspenseLoader/SuspenseLoader.tsx
+++ b/packages/manager/src/components/SuspenseLoader/SuspenseLoader.tsx
@@ -16,7 +16,7 @@ export const SuspenseLoader: React.FC<Props> = props => {
     return () => {
       clearTimeout(timeout);
     };
-  }, []);
+  }, [delay]);
 
   return <>{show && <CircleProgress />}</>;
 };

--- a/packages/manager/src/components/SuspenseLoader/index.tsx
+++ b/packages/manager/src/components/SuspenseLoader/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './SuspenseLoader';

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -1,7 +1,7 @@
 import { getKubernetesClusterEndpoint } from 'linode-js-sdk/lib/kubernetes';
 import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
 
 import Breadcrumb from 'src/components/Breadcrumb';
@@ -94,9 +94,7 @@ type CombinedProps = WithTypesProps &
   DispatchProps &
   WithStyles<ClassNames>;
 
-export const KubernetesClusterDetail: React.FunctionComponent<
-  CombinedProps
-> = props => {
+export const KubernetesClusterDetail: React.FunctionComponent<CombinedProps> = props => {
   const {
     classes,
     cluster,
@@ -272,11 +270,10 @@ const withCluster = KubeContainer<
   }
 );
 
-const enhanced = compose<CombinedProps, {}>(
+const enhanced = compose<CombinedProps, RouteComponentProps>(
   styled,
   withTypes,
-  withCluster,
-  withRouter
+  withCluster
 );
 
 export default enhanced(KubernetesClusterDetail);

--- a/packages/manager/src/features/Kubernetes/index.tsx
+++ b/packages/manager/src/features/Kubernetes/index.tsx
@@ -16,14 +16,6 @@ const ClusterDetail = React.lazy(() => import('./KubernetesClusterDetail'));
 
 type Props = RouteComponentProps<{}>;
 
-const WrapWithSuspense = (_Component: React.ComponentType<any>) => {
-  return (
-    <React.Suspense fallback={<CircleProgress />}>
-      {<_Component />}
-    </React.Suspense>
-  );
-};
-
 class Kubernetes extends React.Component<Props> {
   render() {
     const {
@@ -32,25 +24,19 @@ class Kubernetes extends React.Component<Props> {
 
     return (
       <Switch>
-        <Route
-          render={() => WrapWithSuspense(ClusterCreate)}
-          exact
-          path={`${path}/create`}
-        />
-        <Route
-          component={(routeProps: RouteComponentProps<any>) => (
-            <React.Suspense fallback={<CircleProgress />}>
-              <ClusterDetail {...routeProps} />
-            </React.Suspense>
-          )}
-          path={`${path}/clusters/:clusterID`}
-        />
-        <Route
-          component={() => WrapWithSuspense(KubernetesLanding)}
-          exact
-          path={`${path}/clusters`}
-        />
-        <Redirect to={'/kubernetes/clusters'} />
+        <React.Suspense fallback={<CircleProgress />}>
+          <Route component={ClusterCreate} exact path={`${path}/create`} />
+          <Route
+            component={ClusterDetail}
+            path={`${path}/clusters/:clusterID`}
+          />
+          <Route
+            component={KubernetesLanding}
+            exact
+            path={`${path}/clusters`}
+          />
+          <Redirect to={'/kubernetes/clusters'} />
+        </React.Suspense>
       </Switch>
     );
   }

--- a/packages/manager/src/features/Kubernetes/index.tsx
+++ b/packages/manager/src/features/Kubernetes/index.tsx
@@ -6,22 +6,23 @@ import {
   Switch,
   withRouter
 } from 'react-router-dom';
+import CircleProgress from 'src/components/CircleProgress';
 
-import DefaultLoader from 'src/components/DefaultLoader';
+const KubernetesLanding = React.lazy(() => import('./KubernetesLanding'));
 
-const KubernetesLanding = DefaultLoader({
-  loader: () => import('./KubernetesLanding')
-});
+const ClusterCreate = React.lazy(() => import('./CreateCluster'));
 
-const ClusterCreate = DefaultLoader({
-  loader: () => import('./CreateCluster')
-});
-
-const ClusterDetail = DefaultLoader({
-  loader: () => import('./KubernetesClusterDetail')
-});
+const ClusterDetail = React.lazy(() => import('./KubernetesClusterDetail'));
 
 type Props = RouteComponentProps<{}>;
+
+const WrapWithSuspense = (_Component: React.ComponentType<any>) => {
+  return (
+    <React.Suspense fallback={<CircleProgress />}>
+      {<_Component />}
+    </React.Suspense>
+  );
+};
 
 class Kubernetes extends React.Component<Props> {
   render() {
@@ -31,9 +32,24 @@ class Kubernetes extends React.Component<Props> {
 
     return (
       <Switch>
-        <Route component={ClusterCreate} exact path={`${path}/create`} />
-        <Route component={ClusterDetail} path={`${path}/clusters/:clusterID`} />
-        <Route component={KubernetesLanding} exact path={`${path}/clusters`} />
+        <Route
+          render={() => WrapWithSuspense(ClusterCreate)}
+          exact
+          path={`${path}/create`}
+        />
+        <Route
+          component={(routeProps: RouteComponentProps<any>) => (
+            <React.Suspense fallback={<CircleProgress />}>
+              <ClusterDetail {...routeProps} />
+            </React.Suspense>
+          )}
+          path={`${path}/clusters/:clusterID`}
+        />
+        <Route
+          component={() => WrapWithSuspense(KubernetesLanding)}
+          exact
+          path={`${path}/clusters`}
+        />
         <Redirect to={'/kubernetes/clusters'} />
       </Switch>
     );

--- a/packages/manager/src/features/Kubernetes/index.tsx
+++ b/packages/manager/src/features/Kubernetes/index.tsx
@@ -6,7 +6,6 @@ import {
   Switch,
   withRouter
 } from 'react-router-dom';
-import CircleProgress from 'src/components/CircleProgress';
 
 const KubernetesLanding = React.lazy(() => import('./KubernetesLanding'));
 
@@ -24,19 +23,10 @@ class Kubernetes extends React.Component<Props> {
 
     return (
       <Switch>
-        <React.Suspense fallback={<CircleProgress />}>
-          <Route component={ClusterCreate} exact path={`${path}/create`} />
-          <Route
-            component={ClusterDetail}
-            path={`${path}/clusters/:clusterID`}
-          />
-          <Route
-            component={KubernetesLanding}
-            exact
-            path={`${path}/clusters`}
-          />
-          <Redirect to={'/kubernetes/clusters'} />
-        </React.Suspense>
+        <Route component={ClusterCreate} exact path={`${path}/create`} />
+        <Route component={ClusterDetail} path={`${path}/clusters/:clusterID`} />
+        <Route component={KubernetesLanding} exact path={`${path}/clusters`} />
+        <Redirect to={'/kubernetes/clusters'} />
       </Switch>
     );
   }

--- a/packages/manager/src/features/Volumes/Volumes.tsx
+++ b/packages/manager/src/features/Volumes/Volumes.tsx
@@ -6,7 +6,6 @@ import {
   Switch,
   withRouter
 } from 'react-router-dom';
-import CircleProgress from 'src/components/CircleProgress';
 
 const VolumesLanding = React.lazy(() => import('./VolumesLanding'));
 
@@ -22,16 +21,9 @@ class Volumes extends React.Component<Props> {
 
     return (
       <Switch>
-        <React.Suspense fallback={<CircleProgress />}>
-          <Route component={VolumesLanding} path={path} exact strict />
-          <Route
-            component={VolumeCreate}
-            path={`${path}/create`}
-            exact
-            strict
-          />
-          <Redirect to={path} />
-        </React.Suspense>
+        <Route component={VolumesLanding} path={path} exact strict />
+        <Route component={VolumeCreate} path={`${path}/create`} exact strict />
+        <Redirect to={path} />
       </Switch>
     );
   }

--- a/packages/manager/src/features/Volumes/Volumes.tsx
+++ b/packages/manager/src/features/Volumes/Volumes.tsx
@@ -6,16 +6,11 @@ import {
   Switch,
   withRouter
 } from 'react-router-dom';
+import CircleProgress from 'src/components/CircleProgress';
 
-import DefaultLoader from '../../../src/components/DefaultLoader';
+const VolumesLanding = React.lazy(() => import('./VolumesLanding'));
 
-const VolumesLanding = DefaultLoader({
-  loader: () => import('./VolumesLanding')
-});
-
-const VolumeCreate = DefaultLoader({
-  loader: () => import('./VolumeCreate/VolumeCreate')
-});
+const VolumeCreate = React.lazy(() => import('./VolumeCreate/VolumeCreate'));
 
 type Props = RouteComponentProps<{}>;
 
@@ -27,9 +22,16 @@ class Volumes extends React.Component<Props> {
 
     return (
       <Switch>
-        <Route component={VolumesLanding} path={path} exact strict />
-        <Route component={VolumeCreate} path={`${path}/create`} exact strict />
-        <Redirect to={path} />
+        <React.Suspense fallback={<CircleProgress />}>
+          <Route component={VolumesLanding} path={path} exact strict />
+          <Route
+            component={VolumeCreate}
+            path={`${path}/create`}
+            exact
+            strict
+          />
+          <Redirect to={path} />
+        </React.Suspense>
       </Switch>
     );
   }


### PR DESCRIPTION
## Description

Add React.lazy / React.suspense POC in the K8s and Volumes sections. The goal is to replace the react-loadable library (which we use in our DefaultLoader component), which is obsolete and hasn't been updated in more than a year.

If everything works out here, we can apply this pattern everywhere else we currently use DefaultLoader.