### PR TITLE
M3-3784 POC for units in memory graph

### DIFF
--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -102,7 +102,9 @@ const chartOptions: any = {
     borderColor: '#999',
     caretPadding: 10,
     position: 'nearest',
-    callbacks: {}
+    callbacks: {},
+    intersect: false,
+    mode: 'index'
   }
 };
 
@@ -374,7 +376,7 @@ export const metricsBySection = (data: Metrics): number[] => [
   data.last
 ];
 
-export const formatTooltip = curry((data: any, t: any, d: any) =>
+export const formatTooltip = curry((data: any, t: any, d: any) => {
   /**
    * This is a horror show, sorry.
    * We want to mimic the behavior of Classic Manager,
@@ -386,12 +388,10 @@ export const formatTooltip = curry((data: any, t: any, d: any) =>
    * we have to access the original data series passed into the
    * component.
    */
-  d.datasets.map((thisDataSet: any, idx: number) => {
-    // The y value for this entry in this series
-    const value = data[idx].data[t.index][1] || 0;
-    const roundedValue = Math.round(value * 100000000) / 100000000;
-    return `${thisDataSet.label}: ${readableBytes(roundedValue).formatted}`;
-  })
-);
+  const dataset = data[t.datasetIndex];
+  const label = dataset.label;
+  const value = readableBytes(dataset.data[t.index][1] || 0).formatted;
+  return `${label}: ${value}`;
+});
 
 export default LineGraph;

--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -13,6 +13,10 @@ import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
 import { setUpCharts } from 'src/utilities/charts';
 import { Metrics } from 'src/utilities/statMetrics';
+import {
+  convertBytesToTarget,
+  StorageSymbol
+} from 'src/utilities/unitConversions';
 import MetricDisplayStyles from './NewMetricDisplay.styles';
 setUpCharts();
 
@@ -37,6 +41,7 @@ export interface Props {
   rowHeaders?: Array<string>;
   legendRows?: Array<ChartData<any>>;
   unit?: string; // Display unit on Y axis ticks
+  maxUnit?: StorageSymbol; // Rounds data to all
   nativeLegend?: boolean; // Display chart.js native legend
 }
 
@@ -135,6 +140,7 @@ const LineGraph: React.FC<CombinedProps> = props => {
     data,
     rowHeaders,
     legendRows,
+    maxUnit,
     nativeLegend,
     ...rest
   } = props;
@@ -207,7 +213,10 @@ const LineGraph: React.FC<CombinedProps> = props => {
   const formatData = () => {
     return data.map(dataSet => {
       const timeData = dataSet.data.reduce((acc: any, point: any) => {
-        acc.push({ t: point[0], y: point[1] });
+        acc.push({
+          t: point[0],
+          y: maxUnit ? convertBytesToTarget(maxUnit, point[1]) : point[1]
+        });
         return acc;
       }, []);
 

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/MemoryGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/MemoryGraph.tsx
@@ -2,10 +2,7 @@ import { pathOr } from 'ramda';
 import * as React from 'react';
 import { withTheme, WithTheme } from 'src/components/core/styles';
 import LongviewLineGraph from 'src/components/LongviewLineGraph';
-import {
-  convertBytesToTarget,
-  readableBytes
-} from 'src/utilities/unitConversions';
+import { readableBytes, StorageSymbol } from 'src/utilities/unitConversions';
 import { Stat } from '../../../request.types';
 import { convertData, formatMemory } from '../../../shared/formatters';
 import { generateUsedMemory, statMax } from '../../../shared/utilities';
@@ -58,18 +55,11 @@ export const MemoryGraph: React.FC<CombinedProps> = props => {
   // LV returns stuff in KB so have to convert to bytes using base-2
   const unit = readableBytes(max * 1024).unit;
 
-  const formatMemory = (value: number | null) => {
-    if (value === null) {
-      return value;
-    }
-    // x1024 bc the API returns data in KB
-    return (convertBytesToTarget(unit as any, value * 1024) * 100) / 100;
-  };
-
   return (
     <LongviewLineGraph
       title="Memory"
       subtitle={unit}
+      maxUnit={unit as StorageSymbol}
       error={error}
       loading={loading}
       showToday={isToday}
@@ -105,6 +95,13 @@ export const MemoryGraph: React.FC<CombinedProps> = props => {
   );
 };
 
+const formatMemory = (value: number | null) => {
+  if (value === null) {
+    return null;
+  }
+  return value * 1024; // convert from KB to B
+};
+
 /**
  * This uses the generateUsedMemory utility,
  * but unlike in the graphs, here we're dealing
@@ -134,10 +131,3 @@ export const getUsedMemory = (used: Stat[], cache: Stat[], buffers: Stat[]) => {
 };
 
 export default withTheme(MemoryGraph);
-
-export const customRounding = (val: number) => {
-  if (val < 1) {
-    return (val * 100) / 100;
-  }
-  return Math.round(val);
-};

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/MemoryGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/MemoryGraph.tsx
@@ -4,7 +4,7 @@ import { withTheme, WithTheme } from 'src/components/core/styles';
 import LongviewLineGraph from 'src/components/LongviewLineGraph';
 import { readableBytes, StorageSymbol } from 'src/utilities/unitConversions';
 import { Stat } from '../../../request.types';
-import { convertData, formatMemory } from '../../../shared/formatters';
+import { convertData } from '../../../shared/formatters';
 import { generateUsedMemory, statMax } from '../../../shared/utilities';
 import { GraphProps } from './types';
 import { useGraphs } from './useGraphs';
@@ -93,6 +93,13 @@ export const MemoryGraph: React.FC<CombinedProps> = props => {
       ]}
     />
   );
+};
+
+export const formatMemory = (value: number | null) => {
+  if (value === null) {
+    return null;
+  }
+  return value * 1024; // Convert from KB to B
 };
 
 /**

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/MemoryGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/MemoryGraph.tsx
@@ -2,7 +2,10 @@ import { pathOr } from 'ramda';
 import * as React from 'react';
 import { withTheme, WithTheme } from 'src/components/core/styles';
 import LongviewLineGraph from 'src/components/LongviewLineGraph';
-import { readableBytes } from 'src/utilities/unitConversions';
+import {
+  convertBytesToTarget,
+  readableBytes
+} from 'src/utilities/unitConversions';
 import { Stat } from '../../../request.types';
 import { convertData, formatMemory } from '../../../shared/formatters';
 import { generateUsedMemory, statMax } from '../../../shared/utilities';
@@ -54,6 +57,14 @@ export const MemoryGraph: React.FC<CombinedProps> = props => {
   );
   // LV returns stuff in KB so have to convert to bytes using base-2
   const unit = readableBytes(max * 1024).unit;
+
+  const formatMemory = (value: number | null) => {
+    if (value === null) {
+      return value;
+    }
+    // x1024 bc the API returns data in KB
+    return (convertBytesToTarget(unit as any, value * 1024) * 100) / 100;
+  };
 
   return (
     <LongviewLineGraph
@@ -123,3 +134,10 @@ export const getUsedMemory = (used: Stat[], cache: Stat[], buffers: Stat[]) => {
 };
 
 export default withTheme(MemoryGraph);
+
+export const customRounding = (val: number) => {
+  if (val < 1) {
+    return (val * 100) / 100;
+  }
+  return Math.round(val);
+};

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/MemoryGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/MemoryGraph.tsx
@@ -95,13 +95,6 @@ export const MemoryGraph: React.FC<CombinedProps> = props => {
   );
 };
 
-const formatMemory = (value: number | null) => {
-  if (value === null) {
-    return null;
-  }
-  return value * 1024; // convert from KB to B
-};
-
 /**
  * This uses the generateUsedMemory utility,
  * but unlike in the graphs, here we're dealing

--- a/packages/manager/src/features/Longview/shared/formatters.ts
+++ b/packages/manager/src/features/Longview/shared/formatters.ts
@@ -107,7 +107,7 @@ export const convertData = (
   d: StatWithDummyPoint[],
   startTime: number,
   endTime: number,
-  formatter?: (pt: number | null) => number | null
+  formatter?: (pt: number | null, unit?: string) => number | null
 ) => {
   /**
    * For any empty data series, instead of an empty array

--- a/packages/manager/src/features/Longview/shared/formatters.ts
+++ b/packages/manager/src/features/Longview/shared/formatters.ts
@@ -107,7 +107,7 @@ export const convertData = (
   d: StatWithDummyPoint[],
   startTime: number,
   endTime: number,
-  formatter?: (pt: number | null, unit?: string) => number | null
+  formatter?: (pt: number | null) => number | null
 ) => {
   /**
    * For any empty data series, instead of an empty array

--- a/packages/manager/src/utilities/unitConversions.test.ts
+++ b/packages/manager/src/utilities/unitConversions.test.ts
@@ -1,152 +1,177 @@
-import { readableBytes, ReadableBytesOptions } from './unitConversions';
+import {
+  convertBytesToTarget,
+  readableBytes,
+  ReadableBytesOptions
+} from './unitConversions';
 
-describe('readableBytes', () => {
-  it('should return "0 bytes" if bytes === 0', () => {
-    expect(readableBytes(0).formatted).toBe('0 bytes');
+describe('conversion helper functinos', () => {
+  describe('readableBytes', () => {
+    it('should return "0 bytes" if bytes === 0', () => {
+      expect(readableBytes(0).formatted).toBe('0 bytes');
+    });
+
+    it("should handle negative values, unless it' disabled by the handleNegatives option", () => {
+      expect(readableBytes(-123).formatted).toBe('-123 bytes');
+      expect(readableBytes(-123).value).toBe(-123);
+      expect(readableBytes(-1048576).formatted).toBe('-1 MB');
+      expect(readableBytes(-1048576).value).toBe(-1);
+
+      expect(
+        readableBytes(-1048576, { handleNegatives: false }).formatted
+      ).toBe('0 bytes');
+      expect(readableBytes(-0.5, { handleNegatives: false }).formatted).toBe(
+        '0 bytes'
+      );
+    });
+
+    it('should return B if < 1024', () => {
+      expect(readableBytes(1023).formatted).toBe('1023 bytes');
+    });
+
+    it('handles KB, MB, GB', () => {
+      expect(readableBytes(1024).formatted).toBe('1 KB');
+      expect(readableBytes(1048576).formatted).toBe('1 MB');
+      expect(readableBytes(1073741824).formatted).toBe('1 GB');
+      expect(readableBytes(1073741824 * 40).formatted).toBe('40 GB');
+    });
+
+    it('returns results with two decimal places if x < 10', () => {
+      expect(readableBytes(1024 * 1.5).formatted).toBe('1.5 KB');
+      expect(readableBytes(1024 * 1.75).formatted).toBe('1.75 KB');
+    });
+
+    it('returns results with one decimal place if 10 >= x < 100', () => {
+      expect(readableBytes(1024 * 12.75).formatted).toBe('12.8 KB');
+    });
+
+    it('returns results rounded to whole number if x >= 100', () => {
+      expect(readableBytes(1024 * 100).formatted).toBe('100 KB');
+      expect(readableBytes(1024 * 100.25).formatted).toBe('100 KB');
+      expect(readableBytes(1024 * 100.5).formatted).toBe('101 KB');
+    });
+
+    it('respects rounding when specified with number', () => {
+      const round0 = { round: 0 };
+      const round1 = { round: 1 };
+      const round2 = { round: 2 };
+
+      expect(readableBytes(1024 * 9.72, round0).formatted).toBe('10 KB');
+      expect(readableBytes(1024 * 9.72, round1).formatted).toBe('9.7 KB');
+      expect(readableBytes(1024 * 9.72, round2).formatted).toBe('9.72 KB');
+
+      expect(readableBytes(1024 * 89.99, round0).formatted).toBe('90 KB');
+      expect(readableBytes(1024 * 89.99, round1).formatted).toBe('90 KB');
+      expect(readableBytes(1024 * 89.99, round2).formatted).toBe('89.99 KB');
+
+      expect(readableBytes(1024 * 100.25, round0).formatted).toBe('100 KB');
+      expect(readableBytes(1024 * 100.25, round1).formatted).toBe('100.3 KB');
+      expect(readableBytes(1024 * 100.25, round2).formatted).toBe('100.25 KB');
+    });
+
+    it('respects rounding when given specific units', () => {
+      expect(readableBytes(1024 * 9.723, { round: { KB: 3 } }).formatted).toBe(
+        '9.723 KB'
+      );
+      expect(readableBytes(1024 * 9.723, { round: { MB: 3 } }).formatted).toBe(
+        '9.72 KB'
+      );
+      expect(
+        readableBytes(1024 * 1024 * 143.22, { round: { MB: 2 } }).formatted
+      ).toBe('143.22 MB');
+    });
+
+    it("doesn't return units higher than the specific max unit", () => {
+      expect(
+        readableBytes(1024 * 1024 * 1024 * 50, { maxUnit: 'MB' }).formatted
+      ).toBe('51200 MB');
+      expect(
+        readableBytes(1024 * 1024 * 1024 * 50, { maxUnit: 'KB' }).formatted
+      ).toBe('52428800 KB');
+      expect(
+        readableBytes(1024 * 1024 * 1024 * 50, { maxUnit: 'bytes' }).formatted
+      ).toBe('53687091200 bytes');
+    });
+
+    it('returns the given unit if specified', () => {
+      expect(
+        readableBytes(1024 * 1024 * 1024 * 50, { unit: 'MB' }).formatted
+      ).toBe('51200 MB');
+      expect(
+        readableBytes(1024 * 1024 * 1024 * 50, { unit: 'GB' }).formatted
+      ).toBe('50 GB');
+      expect(
+        readableBytes(1024 * 1024 * 1024 * 50, { unit: 'TB' }).formatted
+      ).toBe('0.05 TB');
+    });
+
+    it('handles inputs that are <= 1', () => {
+      expect(readableBytes(1).formatted).toBe('1 byte');
+      expect(readableBytes(0.5).formatted).toBe('0.5 bytes');
+      expect(readableBytes(-0.5).formatted).toBe('-0.5 bytes');
+      expect(readableBytes(0.01, { maxUnit: 'bytes' }).formatted).toBe(
+        '0.01 bytes'
+      );
+      expect(readableBytes(0.5, { unit: 'MB' }).formatted).toBe('0 MB');
+      expect(readableBytes(0.3, { round: 0 }).formatted).toBe('0 bytes');
+      expect(readableBytes(0.5, { round: 0 }).formatted).toBe('1 byte');
+      expect(readableBytes(0.5, { round: 1 }).formatted).toBe('0.5 bytes');
+      expect(readableBytes(0.05, { round: 1 }).formatted).toBe('0.1 bytes');
+      expect(readableBytes(0.05, { round: 2 }).formatted).toBe('0.05 bytes');
+    });
+
+    it('allows custom unit labels', () => {
+      const unitLabels: ReadableBytesOptions['unitLabels'] = {
+        bytes: 'B',
+        KB: 'Kilobytes',
+        MB: 'Megabytes',
+        GB: 'Gigabytes',
+        TB: 'Terabytes'
+      };
+      expect(readableBytes(1, { unitLabels }).unit).toBe('B');
+      expect(readableBytes(1024, { unitLabels }).unit).toBe('Kilobytes');
+      expect(readableBytes(1048576, { unitLabels }).unit).toBe('Megabytes');
+      expect(readableBytes(1073741824, { unitLabels }).unit).toBe('Gigabytes');
+      expect(readableBytes(1073741824 * 10000, { unitLabels }).unit).toBe(
+        'Terabytes'
+      );
+    });
+
+    it('only affects values with custom labels that have been specified', () => {
+      const unitLabels: ReadableBytesOptions['unitLabels'] = {
+        bytes: 'B'
+      };
+      // Custom unit label:
+      expect(readableBytes(1, { unitLabels }).unit).toBe('B');
+      // Default unit label (not affected):
+      expect(readableBytes(1024, { unitLabels }).unit).toBe('KB');
+    });
+
+    it('correctly pluralizes "bytes"', () => {
+      expect(readableBytes(1).unit).toBe('byte');
+      expect(readableBytes(1).formatted).toBe('1 byte');
+      expect(readableBytes(-1).unit).toBe('byte');
+      expect(readableBytes(-1).formatted).toBe('-1 byte');
+      expect(readableBytes(2).unit).toBe('bytes');
+      expect(readableBytes(2).formatted).toBe('2 bytes');
+    });
   });
 
-  it("should handle negative values, unless it' disabled by the handleNegatives option", () => {
-    expect(readableBytes(-123).formatted).toBe('-123 bytes');
-    expect(readableBytes(-123).value).toBe(-123);
-    expect(readableBytes(-1048576).formatted).toBe('-1 MB');
-    expect(readableBytes(-1048576).value).toBe(-1);
+  describe('convertBytesToTarget', () => {
+    it('should convert bytes to kilobytes correctly', () => {
+      expect(convertBytesToTarget('KB', 1024)).toBe(1);
+      expect(convertBytesToTarget('KB', 5 * 1024)).toBe(5);
+    });
 
-    expect(readableBytes(-1048576, { handleNegatives: false }).formatted).toBe(
-      '0 bytes'
-    );
-    expect(readableBytes(-0.5, { handleNegatives: false }).formatted).toBe(
-      '0 bytes'
-    );
-  });
+    it('should convert bytes to megabytes', () => {
+      expect(convertBytesToTarget('MB', 5 * 1024 * 1024)).toBe(5);
+    });
 
-  it('should return B if < 1024', () => {
-    expect(readableBytes(1023).formatted).toBe('1023 bytes');
-  });
+    it("should return value unchanged if unit is 'bytes'", () => {
+      expect(convertBytesToTarget('bytes', 1919)).toBe(1919);
+    });
 
-  it('handles KB, MB, GB', () => {
-    expect(readableBytes(1024).formatted).toBe('1 KB');
-    expect(readableBytes(1048576).formatted).toBe('1 MB');
-    expect(readableBytes(1073741824).formatted).toBe('1 GB');
-    expect(readableBytes(1073741824 * 40).formatted).toBe('40 GB');
-  });
-
-  it('returns results with two decimal places if x < 10', () => {
-    expect(readableBytes(1024 * 1.5).formatted).toBe('1.5 KB');
-    expect(readableBytes(1024 * 1.75).formatted).toBe('1.75 KB');
-  });
-
-  it('returns results with one decimal place if 10 >= x < 100', () => {
-    expect(readableBytes(1024 * 12.75).formatted).toBe('12.8 KB');
-  });
-
-  it('returns results rounded to whole number if x >= 100', () => {
-    expect(readableBytes(1024 * 100).formatted).toBe('100 KB');
-    expect(readableBytes(1024 * 100.25).formatted).toBe('100 KB');
-    expect(readableBytes(1024 * 100.5).formatted).toBe('101 KB');
-  });
-
-  it('respects rounding when specified with number', () => {
-    const round0 = { round: 0 };
-    const round1 = { round: 1 };
-    const round2 = { round: 2 };
-
-    expect(readableBytes(1024 * 9.72, round0).formatted).toBe('10 KB');
-    expect(readableBytes(1024 * 9.72, round1).formatted).toBe('9.7 KB');
-    expect(readableBytes(1024 * 9.72, round2).formatted).toBe('9.72 KB');
-
-    expect(readableBytes(1024 * 89.99, round0).formatted).toBe('90 KB');
-    expect(readableBytes(1024 * 89.99, round1).formatted).toBe('90 KB');
-    expect(readableBytes(1024 * 89.99, round2).formatted).toBe('89.99 KB');
-
-    expect(readableBytes(1024 * 100.25, round0).formatted).toBe('100 KB');
-    expect(readableBytes(1024 * 100.25, round1).formatted).toBe('100.3 KB');
-    expect(readableBytes(1024 * 100.25, round2).formatted).toBe('100.25 KB');
-  });
-
-  it('respects rounding when given specific units', () => {
-    expect(readableBytes(1024 * 9.723, { round: { KB: 3 } }).formatted).toBe(
-      '9.723 KB'
-    );
-    expect(readableBytes(1024 * 9.723, { round: { MB: 3 } }).formatted).toBe(
-      '9.72 KB'
-    );
-    expect(
-      readableBytes(1024 * 1024 * 143.22, { round: { MB: 2 } }).formatted
-    ).toBe('143.22 MB');
-  });
-
-  it("doesn't return units higher than the specific max unit", () => {
-    expect(
-      readableBytes(1024 * 1024 * 1024 * 50, { maxUnit: 'MB' }).formatted
-    ).toBe('51200 MB');
-    expect(
-      readableBytes(1024 * 1024 * 1024 * 50, { maxUnit: 'KB' }).formatted
-    ).toBe('52428800 KB');
-    expect(
-      readableBytes(1024 * 1024 * 1024 * 50, { maxUnit: 'bytes' }).formatted
-    ).toBe('53687091200 bytes');
-  });
-
-  it('returns the given unit if specified', () => {
-    expect(
-      readableBytes(1024 * 1024 * 1024 * 50, { unit: 'MB' }).formatted
-    ).toBe('51200 MB');
-    expect(
-      readableBytes(1024 * 1024 * 1024 * 50, { unit: 'GB' }).formatted
-    ).toBe('50 GB');
-    expect(
-      readableBytes(1024 * 1024 * 1024 * 50, { unit: 'TB' }).formatted
-    ).toBe('0.05 TB');
-  });
-
-  it('handles inputs that are <= 1', () => {
-    expect(readableBytes(1).formatted).toBe('1 byte');
-    expect(readableBytes(0.5).formatted).toBe('0.5 bytes');
-    expect(readableBytes(-0.5).formatted).toBe('-0.5 bytes');
-    expect(readableBytes(0.01, { maxUnit: 'bytes' }).formatted).toBe(
-      '0.01 bytes'
-    );
-    expect(readableBytes(0.5, { unit: 'MB' }).formatted).toBe('0 MB');
-    expect(readableBytes(0.3, { round: 0 }).formatted).toBe('0 bytes');
-    expect(readableBytes(0.5, { round: 0 }).formatted).toBe('1 byte');
-    expect(readableBytes(0.5, { round: 1 }).formatted).toBe('0.5 bytes');
-    expect(readableBytes(0.05, { round: 1 }).formatted).toBe('0.1 bytes');
-    expect(readableBytes(0.05, { round: 2 }).formatted).toBe('0.05 bytes');
-  });
-
-  it('allows custom unit labels', () => {
-    const unitLabels: ReadableBytesOptions['unitLabels'] = {
-      bytes: 'B',
-      KB: 'Kilobytes',
-      MB: 'Megabytes',
-      GB: 'Gigabytes',
-      TB: 'Terabytes'
-    };
-    expect(readableBytes(1, { unitLabels }).unit).toBe('B');
-    expect(readableBytes(1024, { unitLabels }).unit).toBe('Kilobytes');
-    expect(readableBytes(1048576, { unitLabels }).unit).toBe('Megabytes');
-    expect(readableBytes(1073741824, { unitLabels }).unit).toBe('Gigabytes');
-    expect(readableBytes(1073741824 * 10000, { unitLabels }).unit).toBe(
-      'Terabytes'
-    );
-  });
-
-  it('only affects values with custom labels that have been specified', () => {
-    const unitLabels: ReadableBytesOptions['unitLabels'] = {
-      bytes: 'B'
-    };
-    // Custom unit label:
-    expect(readableBytes(1, { unitLabels }).unit).toBe('B');
-    // Default unit label (not affected):
-    expect(readableBytes(1024, { unitLabels }).unit).toBe('KB');
-  });
-
-  it('correctly pluralizes "bytes"', () => {
-    expect(readableBytes(1).unit).toBe('byte');
-    expect(readableBytes(1).formatted).toBe('1 byte');
-    expect(readableBytes(-1).unit).toBe('byte');
-    expect(readableBytes(-1).formatted).toBe('-1 byte');
-    expect(readableBytes(2).unit).toBe('bytes');
-    expect(readableBytes(2).formatted).toBe('2 bytes');
+    it('should convert to gigabytes correctly', () => {
+      expect(convertBytesToTarget('GB', 2 * 1024 * 1024 * 1024)).toBe(2);
+    });
   });
 });

--- a/packages/manager/src/utilities/unitConversions.ts
+++ b/packages/manager/src/utilities/unitConversions.ts
@@ -162,3 +162,17 @@ const determineDecimalPlaces = (
     return 0;
   }
 };
+
+export type Unit = 'B' | 'KB' | 'MB' | 'GB';
+export const convertBytesToTarget = (unit: Unit, value: number) => {
+  switch (unit) {
+    case 'B':
+      return value;
+    case 'KB':
+      return value / 1024;
+    case 'MB':
+      return value / 1024 / 1024;
+    case 'GB':
+      return value / 1024 / 1024 / 1024;
+  }
+};

--- a/packages/manager/src/utilities/unitConversions.ts
+++ b/packages/manager/src/utilities/unitConversions.ts
@@ -50,7 +50,7 @@ export interface ReadableBytesOptions {
   unitLabels?: Partial<Record<StorageSymbol, string>>;
 }
 
-type StorageSymbol = 'bytes' | 'KB' | 'MB' | 'GB' | 'TB';
+export type StorageSymbol = 'bytes' | 'KB' | 'MB' | 'GB' | 'TB';
 
 // This code inspired by: https://ourcodeworld.com/articles/read/713/converting-bytes-to-human-readable-values-kb-mb-gb-tb-pb-eb-zb-yb-with-javascript
 export const readableBytes = (
@@ -163,10 +163,9 @@ const determineDecimalPlaces = (
   }
 };
 
-export type Unit = 'B' | 'KB' | 'MB' | 'GB';
-export const convertBytesToTarget = (unit: Unit, value: number) => {
+export const convertBytesToTarget = (unit: StorageSymbol, value: number) => {
   switch (unit) {
-    case 'B':
+    case 'bytes':
       return value;
     case 'KB':
       return value / 1024;
@@ -174,5 +173,7 @@ export const convertBytesToTarget = (unit: Unit, value: number) => {
       return value / 1024 / 1024;
     case 'GB':
       return value / 1024 / 1024 / 1024;
+    case 'TB':
+      return value / 1024 / 1024 / 1024 / 1024;
   }
 };


### PR DESCRIPTION
- Adds a maxUnit prop to our LineGraph component. If this component is provided, the graph will assume that the values provided are in bytes, and convert them to the specified unit.
- Except in the tooltip, which will do what Classic does and convert to an appropriate unit for each individual value.
- Also stacked all values into each tooltip so the user doesn't have to scroll over the value they want to see it.
- Tried to get the color to work, but I'm not sure that's possible in chartjs without using a manual (HTML) tooltip.