### PR TITLE
M3-3785 Source Linodes from Redux in Networking and Backups

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/RestoreToLinodeDrawer.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/RestoreToLinodeDrawer.test.tsx
@@ -1,28 +1,27 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
-
-import { RestoreToLinodeDrawer } from './RestoreToLinodeDrawer';
+import { CombinedProps, RestoreToLinodeDrawer } from './RestoreToLinodeDrawer';
 
 describe('RestoreToLinodeDrawer', () => {
-  const props = {
+  const props: CombinedProps = {
     open: true,
     linodeID: 1234,
     linodeRegion: 'us-east',
     backupCreated: '12 hours ago',
     onClose: jest.fn(),
-    onSubmit: jest.fn()
+    onSubmit: jest.fn(),
+    linodesData: [],
+    linodesLastUpdated: 0,
+    linodesLoading: false,
+    getLinodes: jest.fn(),
+    linodesResults: []
   };
 
   const wrapper = shallow<RestoreToLinodeDrawer>(
     <RestoreToLinodeDrawer {...props} />
   );
 
-  it("doesn't wipe linodes when calling reset() method", () => {
-    const mockLinodes = [['123456', 'test-label']];
-
-    wrapper.setState({ linodes: mockLinodes });
-    const instance = wrapper.instance() as any;
-    instance.reset();
-    expect(wrapper.instance().state.linodes).toBe(mockLinodes);
+  it('renders without crashing', () => {
+    expect(wrapper).toHaveLength(1);
   });
 });

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/RestoreToLinodeDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/RestoreToLinodeDrawer.tsx
@@ -1,4 +1,4 @@
-import { getLinodes, restoreBackup } from 'linode-js-sdk/lib/linodes';
+import { restoreBackup } from 'linode-js-sdk/lib/linodes';
 import { Profile } from 'linode-js-sdk/lib/profile';
 import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
@@ -14,6 +14,9 @@ import Drawer from 'src/components/Drawer';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import Notice from 'src/components/Notice';
 import withProfile from 'src/containers/profile.container';
+import withLinodes, {
+  Props as LinodeProps
+} from 'src/containers/withLinodes.container';
 import { getPermissionsForLinode } from 'src/store/linodes/permissions/permissions.selector.ts';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
@@ -30,7 +33,6 @@ interface Props {
 }
 
 interface State {
-  linodes: string[][];
   overwrite: boolean;
   selectedLinode?: string;
   errors?: APIError[];
@@ -40,7 +42,7 @@ interface ProfileProps {
   profile?: Profile;
 }
 
-type CombinedProps = Props & ProfileProps;
+export type CombinedProps = Props & ProfileProps & LinodeProps;
 
 const canEditLinode = (profile: Profile | null, linodeId: number): boolean => {
   return getPermissionsForLinode(profile, linodeId) === 'read_only';
@@ -50,7 +52,6 @@ export class RestoreToLinodeDrawer extends React.Component<
   State
 > {
   defaultState = {
-    linodes: [],
     overwrite: false,
     selectedLinode: 'none',
     errors: []
@@ -64,21 +65,11 @@ export class RestoreToLinodeDrawer extends React.Component<
     if (!this.mounted) {
       return;
     }
-    this.setState({ ...this.defaultState, linodes: this.state.linodes });
+    this.setState({ ...this.defaultState });
   };
 
   componentDidMount() {
     this.mounted = true;
-    const { linodeRegion } = this.props;
-    getLinodes({ page: 1 }, { region: linodeRegion }).then(response => {
-      if (!this.mounted) {
-        return;
-      }
-      const linodeChoices = response.data.map(linode => {
-        return [`${linode.id}`, linode.label];
-      });
-      this.setState({ linodes: linodeChoices });
-    });
   }
 
   componentWillUnmount() {
@@ -140,7 +131,7 @@ export class RestoreToLinodeDrawer extends React.Component<
 
   render() {
     const { open, backupCreated, profile } = this.props;
-    const { linodes, selectedLinode, overwrite, errors } = this.state;
+    const { selectedLinode, overwrite, errors } = this.state;
 
     const hasErrorFor = getAPIErrorsFor(this.errorResources, errors);
     const linodeError = hasErrorFor('linode_id');
@@ -150,11 +141,10 @@ export class RestoreToLinodeDrawer extends React.Component<
     const readOnly = canEditLinode(profile || null, Number(selectedLinode));
     const selectError = Boolean(linodeError) || readOnly;
 
-    const linodeList =
-      linodes &&
-      linodes.map(l => {
-        const label = l[1];
-        return { label, value: l[0] };
+    const linodeOptions = this.props.linodesData
+      .filter(linode => linode.region === this.props.linodeRegion)
+      .map(({ label, id }) => {
+        return { label, value: id };
       });
 
     return (
@@ -179,7 +169,7 @@ export class RestoreToLinodeDrawer extends React.Component<
               }
             }}
             defaultValue={selectedLinode || ''}
-            options={linodeList}
+            options={linodeOptions}
             onChange={this.handleSelectLinode}
             errorText={linodeError}
             placeholder="Select a Linode"
@@ -237,7 +227,8 @@ const enhanced = compose<CombinedProps, Props>(
     return {
       profile
     };
-  })
+  }),
+  withLinodes()
 );
 
 export default enhanced(RestoreToLinodeDrawer);


### PR DESCRIPTION
## Description

The components in the "Restore to Linode" drawer (Linode Detail -> Backups) and the "Networking Actions" section (Linode Detail -> Networking) were making their own requests to `/linode/instances` in order to populate options in the Selects. 

They were only requesting the first page, which means that **if you had more than 25 Linodes in one region, you would not see all of them listed.**

In this PR, the data is sourced from Redux.

**Notes:**

- I thought about using the LinodeSelect component but wanted to keep the changes to an absolute minimum.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

Use production test account 1

- Navigate to the Backups Tab for `pagination-test-source`.
- Click "Restore to Existing Linode" in the Action Menu of one of the backups.
- **Observe:** `pagination-test-target` should be listed. In Production this is not the case.

For Networking Actions, test IP Transfer and IP Sharing for the following Linodes:

- `pagination-test-source`
- `pagination-test-target`
- `singular-linode-in-mumbai`

