### PR TITLE
Updating Longview graph colors

### DIFF
--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Disks/Graphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Disks/Graphs.tsx
@@ -100,6 +100,7 @@ const Graphs: React.FC<CombinedProps> = props => {
       <div className={classes.graphContainer}>
         {sysInfoType.toLowerCase() !== 'openvz' && (
           <div data-testid="diskio-graph">
+          {/* TODO update io colors */}
             <LongviewLineGraph
               loading={loading}
               data={[
@@ -136,8 +137,8 @@ const Graphs: React.FC<CombinedProps> = props => {
                   {
                     data: convertData(_free, startTime, endTime),
                     label: 'Space',
-                    borderColor: theme.graphs.salmonBorder,
-                    backgroundColor: theme.graphs.salmon
+                    borderColor: 'transparent',
+                    backgroundColor: theme.graphs.space
                   }
                 ]}
                 showToday={isToday}
@@ -154,8 +155,8 @@ const Graphs: React.FC<CombinedProps> = props => {
                   {
                     data: convertData(_inodes, startTime, endTime),
                     label: 'Inodes',
-                    borderColor: theme.graphs.pinkBorder,
-                    backgroundColor: theme.graphs.pink
+                    borderColor: 'transparent',
+                    backgroundColor: theme.graphs.inodes
                   }
                 ]}
                 showToday={isToday}

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Disks/Graphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Disks/Graphs.tsx
@@ -100,21 +100,20 @@ const Graphs: React.FC<CombinedProps> = props => {
       <div className={classes.graphContainer}>
         {sysInfoType.toLowerCase() !== 'openvz' && (
           <div data-testid="diskio-graph">
-          {/* TODO update io colors */}
             <LongviewLineGraph
               loading={loading}
               data={[
                 {
                   data: convertData(writes, startTime, endTime, formatDiskIO),
                   label: 'Write',
-                  borderColor: theme.graphs.orangeBorder,
-                  backgroundColor: theme.graphs.orange
+                  borderColor: 'transparent',
+                  backgroundColor: theme.graphs.diskIO.write
                 },
                 {
                   data: convertData(reads, startTime, endTime, formatDiskIO),
                   label: 'Read',
-                  borderColor: theme.graphs.yellowBorder,
-                  backgroundColor: theme.graphs.yellow
+                  borderColor: 'transparent',
+                  backgroundColor: theme.graphs.diskIO.read
                 }
               ]}
               title="Disk I/O"

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/NGINX/NGINXGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/NGINX/NGINXGraphs.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
 import Paper from 'src/components/core/Paper';
-import { makeStyles, Theme } from 'src/components/core/styles';
+import { compose } from 'recompose';
+import {
+  makeStyles,
+  Theme,
+  WithTheme,
+  withTheme
+} from 'src/components/core/styles';
 import Grid from 'src/components/Grid';
 import LongviewLineGraph from 'src/components/LongviewLineGraph';
 import { NginxResponse, NginxUserProcesses } from '../../../request.types';
@@ -33,7 +39,9 @@ interface Props {
   processesError?: string;
 }
 
-export const NGINXGraphs: React.FC<Props> = props => {
+type CombinedProps = Props & WithTheme;
+
+export const NGINXGraphs: React.FC<CombinedProps> = props => {
   const {
     data,
     error,
@@ -44,7 +52,8 @@ export const NGINXGraphs: React.FC<Props> = props => {
     end,
     processesData,
     processesLoading,
-    processesError
+    processesError,
+    theme
   } = props;
 
   const classes = useStyles();
@@ -65,8 +74,8 @@ export const NGINXGraphs: React.FC<Props> = props => {
             data={[
               {
                 label: 'Requests',
-                borderColor: '#22ceb6',
-                backgroundColor: '#22ceb6',
+                borderColor: 'transparent',
+                backgroundColor: theme.graphs.requests,
                 data: _convertData(data?.requests ?? [], start, end, formatData)
               }
             ]}
@@ -86,8 +95,8 @@ export const NGINXGraphs: React.FC<Props> = props => {
                 data={[
                   {
                     label: 'Accepted',
-                    borderColor: '#5b698b',
-                    backgroundColor: '#5b698b',
+                    borderColor: 'transparent',
+                    backgroundColor: theme.graphs.connections.accepted,
                     data: _convertData(
                       data?.accepted_cons ?? [],
                       start,
@@ -97,8 +106,8 @@ export const NGINXGraphs: React.FC<Props> = props => {
                   },
                   {
                     label: 'Handled',
-                    borderColor: '#323b4d',
-                    backgroundColor: '#323b4d',
+                    borderColor: 'transparent',
+                    backgroundColor: theme.graphs.connections.handled,
                     data: _convertData(
                       data?.handled_cons ?? [],
                       start,
@@ -120,8 +129,8 @@ export const NGINXGraphs: React.FC<Props> = props => {
                 data={[
                   {
                     label: 'Waiting',
-                    borderColor: '#63d997',
-                    backgroundColor: '#63d997',
+                    borderColor: 'transparent',
+                    backgroundColor: theme.graphs.workers.waiting,
                     data: _convertData(
                       data?.waiting ?? [],
                       start,
@@ -131,8 +140,8 @@ export const NGINXGraphs: React.FC<Props> = props => {
                   },
                   {
                     label: 'Reading',
-                    borderColor: '#2db969',
-                    backgroundColor: '#2db969',
+                    borderColor: 'transparent',
+                    backgroundColor: theme.graphs.workers.reading,
                     data: _convertData(
                       data?.reading ?? [],
                       start,
@@ -142,8 +151,8 @@ export const NGINXGraphs: React.FC<Props> = props => {
                   },
                   {
                     label: 'Writing',
-                    borderColor: '#20834b',
-                    backgroundColor: '#20834b',
+                    borderColor: 'transparent',
+                    backgroundColor: theme.graphs.workers.writing,
                     data: _convertData(
                       data?.writing ?? [],
                       start,
@@ -179,4 +188,8 @@ const formatData = (value: number | null) => {
   return Math.round(value * 100) / 100;
 };
 
-export default NGINXGraphs;
+const enhanced = compose<CombinedProps, Props>(
+  withTheme,
+  React.memo
+)(NGINXGraphs);
+export default enhanced;

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/NGINX/NGINXGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/NGINX/NGINXGraphs.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import Paper from 'src/components/core/Paper';
 import { compose } from 'recompose';
+import Paper from 'src/components/core/Paper';
 import {
   makeStyles,
   Theme,

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/NGINX/NGINXProcessGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/NGINX/NGINXProcessGraphs.tsx
@@ -78,8 +78,8 @@ export const NGINXProcessGraphs: React.FC<CombinedProps> = props => {
               data={[
                 {
                   label: 'CPU',
-                  borderColor: '#63d997',
-                  backgroundColor: '#63d997',
+                  borderColor: 'transparent',
+                  backgroundColor: theme.graphs.cpu,
                   data: _convertData(cpu, start, end, formatData)
                 }
               ]}
@@ -96,8 +96,8 @@ export const NGINXProcessGraphs: React.FC<CombinedProps> = props => {
               data={[
                 {
                   label: 'RAM',
-                  borderColor: '#e083e0',
-                  backgroundColor: '#e083e0',
+                  borderColor: 'transparent',
+                  backgroundColor: theme.graphs.ram,
                   data: _convertData(memory, start, end, formatMemory)
                 }
               ]}
@@ -108,6 +108,7 @@ export const NGINXProcessGraphs: React.FC<CombinedProps> = props => {
       <Grid item xs={12}>
         <Grid container direction="row">
           <Grid item xs={12} sm={6} className={classes.smallGraph}>
+            {/* TODO need updated colors */}
             <LongviewLineGraph
               title="Disk I/O"
               subtitle={`${diskUnit}/s`}
@@ -118,13 +119,13 @@ export const NGINXProcessGraphs: React.FC<CombinedProps> = props => {
               data={[
                 {
                   label: 'Read',
-                  borderColor: theme.graphs.lightYellow,
+                  borderColor: 'transparent',
                   backgroundColor: theme.graphs.lightYellow,
                   data: _convertData(diskRead, start, end, formatData)
                 },
                 {
                   label: 'Write',
-                  borderColor: theme.graphs.lightOrange,
+                  borderColor: 'transparent',
                   backgroundColor: theme.graphs.lightOrange,
                   data: _convertData(diskWrite, start, end, formatData)
                 }
@@ -141,8 +142,8 @@ export const NGINXProcessGraphs: React.FC<CombinedProps> = props => {
               data={[
                 {
                   label: 'Count',
-                  borderColor: '#7156f5',
-                  backgroundColor: '#7156f5',
+                  borderColor: 'transparent',
+                  backgroundColor: theme.graphs.processCount,
                   data: _convertData(processCount, start, end, formatData)
                 }
               ]}

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/NGINX/NGINXProcessGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/NGINX/NGINXProcessGraphs.tsx
@@ -108,7 +108,6 @@ export const NGINXProcessGraphs: React.FC<CombinedProps> = props => {
       <Grid item xs={12}>
         <Grid container direction="row">
           <Grid item xs={12} sm={6} className={classes.smallGraph}>
-            {/* TODO need updated colors */}
             <LongviewLineGraph
               title="Disk I/O"
               subtitle={`${diskUnit}/s`}
@@ -120,13 +119,13 @@ export const NGINXProcessGraphs: React.FC<CombinedProps> = props => {
                 {
                   label: 'Read',
                   borderColor: 'transparent',
-                  backgroundColor: theme.graphs.lightYellow,
+                  backgroundColor: theme.graphs.diskIO.read,
                   data: _convertData(diskRead, start, end, formatData)
                 },
                 {
                   label: 'Write',
                   borderColor: 'transparent',
-                  backgroundColor: theme.graphs.lightOrange,
+                  backgroundColor: theme.graphs.diskIO.write,
                   data: _convertData(diskWrite, start, end, formatData)
                 }
               ]}

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Network/NetworkGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Network/NetworkGraphs.tsx
@@ -89,14 +89,14 @@ export const NetworkGraphs: React.FC<CombinedProps> = props => {
                 data={[
                   {
                     label: 'Inbound',
-                    borderColor: theme.graphs.forestGreenBorder,
-                    backgroundColor: theme.graphs.networkGreenInbound,
+                    borderColor: 'transparent',
+                    backgroundColor: theme.graphs.network.inbound,
                     data: _convertData(rx_bytes, start, end, formatNetwork)
                   },
                   {
                     label: 'Outbound',
-                    borderColor: theme.graphs.forestGreenBorder,
-                    backgroundColor: theme.graphs.networkGreenOutbound,
+                    borderColor: 'transparent',
+                    backgroundColor: theme.graphs.network.outbound,
                     data: _convertData(tx_bytes, start, end, formatNetwork)
                   }
                 ]}

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/CPUGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/CPUGraph.tsx
@@ -57,20 +57,20 @@ export const CPUGraph: React.FC<CombinedProps> = props => {
       data={[
         {
           label: 'System',
-          borderColor: theme.graphs.deepBlueBorder,
-          backgroundColor: theme.graphs.deepBlue,
+          borderColor: 'transparent',
+          backgroundColor: theme.graphs.cpu.system,
           data: _convertData(cpuData.system, start, end, formatCPU)
         },
         {
           label: 'User',
-          borderColor: theme.graphs.skyBlueBorder,
-          backgroundColor: theme.graphs.skyBlue,
+          borderColor: 'transparent',
+          backgroundColor: theme.graphs.cpu.user,
           data: _convertData(cpuData.user, start, end, formatCPU)
         },
         {
           label: 'Wait',
-          borderColor: theme.graphs.lightBlueBorder,
-          backgroundColor: theme.graphs.lightBlue,
+          borderColor: 'transparent',
+          backgroundColor: theme.graphs.cpu.wait,
           data: _convertData(cpuData.wait, start, end, formatCPU)
         }
       ]}

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/DiskGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/DiskGraph.tsx
@@ -58,20 +58,20 @@ export const DiskGraph: React.FC<CombinedProps> = props => {
       data={[
         {
           label: 'Swap',
-          borderColor: theme.graphs.redBorder,
-          backgroundColor: theme.graphs.red,
+          borderColor: 'transparent',
+          backgroundColor: theme.graphs.diskIO.swap,
           data: _convertData(swap, start, end, formatDisk)
         },
         {
           label: 'Write',
-          borderColor: theme.graphs.lightOrangeBorder,
-          backgroundColor: theme.graphs.lightOrange,
+          borderColor: 'transparent',
+          backgroundColor: theme.graphs.diskIO.write,
           data: _convertData(write, start, end, formatDisk)
         },
         {
           label: 'Read',
-          borderColor: theme.graphs.lightYellowBorder,
-          backgroundColor: theme.graphs.lightYellow,
+          borderColor: 'transparent',
+          backgroundColor: theme.graphs.diskIO.read,
           data: _convertData(read, start, end, formatDisk)
         }
       ]}

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/LoadGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/LoadGraph.tsx
@@ -43,8 +43,8 @@ export const LoadGraph: React.FC<CombinedProps> = props => {
       data={[
         {
           label: 'Load',
-          borderColor: theme.graphs.lightGoldBorder,
-          backgroundColor: theme.graphs.lightGold,
+          borderColor: 'transparent',
+          backgroundColor: theme.graphs.load,
           data: _convertData(data.Load || [], start, end, formatLoad)
         }
       ]}

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/MemoryGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/MemoryGraph.tsx
@@ -67,26 +67,26 @@ export const MemoryGraph: React.FC<CombinedProps> = props => {
       data={[
         {
           label: 'Swap',
-          borderColor: theme.graphs.redBorder,
-          backgroundColor: theme.graphs.red,
+          borderColor: 'transparent',
+          backgroundColor: theme.graphs.memory.swap,
           data: _convertData(swap, start, end, formatMemory)
         },
         {
           label: 'Buffers',
-          borderColor: theme.graphs.darkPurpleBorder,
-          backgroundColor: theme.graphs.darkPurple,
+          borderColor: 'transparent',
+          backgroundColor: theme.graphs.memory.buffers,
           data: _convertData(buffers, start, end, formatMemory)
         },
         {
           label: 'Cache',
-          borderColor: theme.graphs.purpleBorder,
-          backgroundColor: theme.graphs.purple,
+          borderColor: 'transparent',
+          backgroundColor: theme.graphs.memory.cache,
           data: _convertData(cache, start, end, formatMemory)
         },
         {
           label: 'Used',
-          borderColor: theme.graphs.lightPurpleBorder,
-          backgroundColor: theme.graphs.lightPurple,
+          borderColor: 'transparent',
+          backgroundColor: theme.graphs.memory.used,
           data: _convertData(used, start, end, formatMemory)
         }
       ]}

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/NetworkGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/NetworkGraph.tsx
@@ -62,15 +62,14 @@ export const NetworkGraph: React.FC<CombinedProps> = props => {
       data={[
         {
           label: 'Inbound',
-          // @todo update colors based on Zeplin palette
-          borderColor: theme.graphs.emeraldGreenBorder,
-          backgroundColor: theme.graphs.emeraldGreen,
+          borderColor: 'transparent',
+          backgroundColor: theme.graphs.network.inbound,
           data: _convertData(rx_bytes, start, end, formatNetwork)
         },
         {
           label: 'Outbound',
-          borderColor: theme.graphs.forestGreenBorder,
-          backgroundColor: theme.graphs.forestGreen,
+          borderColor: 'transparent',
+          backgroundColor: theme.graphs.network.outbound,
           data: _convertData(tx_bytes, start, end, formatNetwork)
         }
       ]}

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -222,6 +222,32 @@ const themeDefaults: ThemeDefaults = ({ spacingOverride: spacingUnit }) => {
       primaryNavText: '#c9cacb'
     },
     graphs: {
+      load: 'rgba(255, 220, 77, 0.7)',
+      requests: 'rgba(34, 206, 182, 0.7)',
+      connections: {
+        accepted: 'rgba(91, 105, 139, 0.7)',
+        handled: 'rgba(50, 59, 77, 0.7)'
+      },
+      network: {
+        outbound: 'rgba(49, 206, 62, 0.7)',
+        inbound: 'rgba(16, 162, 29, 0.7)'
+      },
+      workers: {
+        waiting: 'rgba(99, 217, 151, 0.7)',
+        reading: 'rgba(45, 185, 105, 0.7)',
+        writing: 'rgba(32, 131, 75, 0.7)'
+      },
+      cpu: 'rgba(54, 131, 220, 0.7)',
+      ram: 'rgba(224, 131, 224, 0.7)',
+      space: 'rgba(255, 99, 61, 0.7)',
+      inodes: 'rgba(224, 138, 146, 0.7)',
+      // diskIO: {
+      //   read:,
+      //   write:,
+      //   swap:
+      // }
+      processCount: 'rgba(113, 86, 245, 0.7)',
+
       blue: '#64ADF6',
       blueBorder: '#3F99F0',
       green: '#5BD765',

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -237,56 +237,48 @@ const themeDefaults: ThemeDefaults = ({ spacingOverride: spacingUnit }) => {
         reading: 'rgba(45, 185, 105, 0.7)',
         writing: 'rgba(32, 131, 75, 0.7)'
       },
-      cpu: 'rgba(54, 131, 220, 0.7)',
+      cpu: {
+        system: 'rgba(2, 118, 253, 0.7)',
+        user: 'rgba(81, 166, 245, 0.7)',
+        wait: 'rgba(145, 199, 237, 0.7)'
+      },
+      memory: {
+        swap: 'rgba(238, 44, 44, 0.7)',
+        buffers: 'rgba(142, 56, 142, 0.7)',
+        cache: 'rgba(205, 150, 205, 0.7)',
+        used: 'rgba(236, 200, 236, 0.7)'
+      },
+      diskIO: {
+        read: 'rgba(255, 196, 105, 0.7)',
+        write: 'rgba(255, 179, 77, 0.7)',
+        swap: 'rgba(238, 44, 44, 0.7)'
+      },
       ram: 'rgba(224, 131, 224, 0.7)',
       space: 'rgba(255, 99, 61, 0.7)',
       inodes: 'rgba(224, 138, 146, 0.7)',
-      // diskIO: {
-      //   read:,
-      //   write:,
-      //   swap:
-      // }
+      queries: {
+        select: 'rgba(34, 192, 206, 0.7)',
+        insert: 'rgba(26, 151, 162, 0.7)',
+        update: 'rgba(19, 110, 118, 0.7)',
+        delete: 'rgba(2, 54, 59, 0.7)'
+      },
+      slowQueries: 'rgba(255, 61, 61, 0.7)',
+      aborted: {
+        connections: 'rgba(255, 10, 10, 0.7)',
+        clients: 'rgba(214, 0, 0, 0.7)'
+      },
       processCount: 'rgba(113, 86, 245, 0.7)',
-
       blue: '#64ADF6',
       blueBorder: '#3F99F0',
       green: '#5BD765',
       greenBorder: '#18B523',
       orange: 'rgba(255, 179, 77, 0.7)',
-      orangeBorder: '#ff9d1a',
       purple: '#d9b0d9',
       purpleBorder: '#d9b0d9',
-      lightPurple: '#f1d6f0',
-      lightPurpleBorder: '#f1d6f0',
-      darkPurple: '#ac6baa',
-      darkPurpleBorder: 'rgba(130, 38, 148, 0.8)',
       red: '#FF633C',
       redBorder: '#F13A0A',
       yellow: '#FFDC7D',
-      yellowBorder: '#DCB64E',
-      salmon: 'rgba(255, 99, 61, 0.7)',
-      salmonBorder: '#ff3a0a',
-      pinkBorder: '#d5626d',
-      pink: 'rgba(224, 138, 146, 0.7)',
-      deepBlue: '#9CC6F4',
-      deepBlueBorder: '#3595f3',
-      skyBlue: '#8CBDF3',
-      skyBlueBorder: '#72AEF',
-      lightBlue: '#B5D5EF',
-      lightBlueBorder: '#A2C2EA',
-      lightYellow: '#ffd391',
-      lightYellowBorder: '#ffd391',
-      lightOrange: '#FFBE67',
-      lightOrangeBorder: '#FFA823',
-      emeraldGreen: '#74D97E',
-      emeraldGreenBorder: '#31CC4D',
-      forestGreen: '#6FC37C',
-      forestGreenBorder: '#32AE4E',
-      lightGold: 'rgba(255, 220, 77, 0.7)',
-      lightGoldBorder: 'rgba(255,210,26,1)',
-      // @todo consolidate these with forest/emerald green
-      networkGreenOutbound: '#10a21d',
-      networkGreenInbound: '#31ce3e'
+      yellowBorder: '#DCB64E'
     },
     font: {
       normal: primaryFonts.normal,

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -119,6 +119,8 @@ const visuallyHidden = {
   clip: 'rect(1px, 1px, 1px, 1px)'
 };
 
+const graphTransparency = '0.7';
+
 export const COMPACT_SPACING_UNIT = 4;
 export const NORMAL_SPACING_UNIT = 8;
 
@@ -222,57 +224,57 @@ const themeDefaults: ThemeDefaults = ({ spacingOverride: spacingUnit }) => {
       primaryNavText: '#c9cacb'
     },
     graphs: {
-      load: 'rgba(255, 220, 77, 0.7)',
-      requests: 'rgba(34, 206, 182, 0.7)',
+      load: `rgba(255, 220, 77, ${graphTransparency})`,
+      requests: `rgba(34, 206, 182, ${graphTransparency})`,
       connections: {
-        accepted: 'rgba(91, 105, 139, 0.7)',
-        handled: 'rgba(50, 59, 77, 0.7)'
+        accepted: `rgba(91, 105, 139, ${graphTransparency})`,
+        handled: `rgba(50, 59, 77, ${graphTransparency})`
       },
       network: {
-        outbound: 'rgba(49, 206, 62, 0.7)',
-        inbound: 'rgba(16, 162, 29, 0.7)'
+        outbound: `rgba(49, 206, 62, ${graphTransparency})`,
+        inbound: `rgba(16, 162, 29, ${graphTransparency})`
       },
       workers: {
-        waiting: 'rgba(99, 217, 151, 0.7)',
-        reading: 'rgba(45, 185, 105, 0.7)',
-        writing: 'rgba(32, 131, 75, 0.7)'
+        waiting: `rgba(99, 217, 151, ${graphTransparency})`,
+        reading: `rgba(45, 185, 105, ${graphTransparency})`,
+        writing: `rgba(32, 131, 75, ${graphTransparency})`
       },
       cpu: {
-        system: 'rgba(2, 118, 253, 0.7)',
-        user: 'rgba(81, 166, 245, 0.7)',
-        wait: 'rgba(145, 199, 237, 0.7)'
+        system: `rgba(2, 118, 253, ${graphTransparency})`,
+        user: `rgba(81, 166, 245, ${graphTransparency})`,
+        wait: `rgba(145, 199, 237, ${graphTransparency})`
       },
       memory: {
-        swap: 'rgba(238, 44, 44, 0.7)',
-        buffers: 'rgba(142, 56, 142, 0.7)',
-        cache: 'rgba(205, 150, 205, 0.7)',
-        used: 'rgba(236, 200, 236, 0.7)'
+        swap: `rgba(238, 44, 44, ${graphTransparency})`,
+        buffers: `rgba(142, 56, 142, ${graphTransparency})`,
+        cache: `rgba(205, 150, 205, ${graphTransparency})`,
+        used: `rgba(236, 200, 236, ${graphTransparency})`
       },
       diskIO: {
-        read: 'rgba(255, 196, 105, 0.7)',
-        write: 'rgba(255, 179, 77, 0.7)',
-        swap: 'rgba(238, 44, 44, 0.7)'
+        read: `rgba(255, 196, 105, ${graphTransparency})`,
+        write: `rgba(255, 179, 77, ${graphTransparency})`,
+        swap: `rgba(238, 44, 44, ${graphTransparency})`
       },
-      ram: 'rgba(224, 131, 224, 0.7)',
-      space: 'rgba(255, 99, 61, 0.7)',
-      inodes: 'rgba(224, 138, 146, 0.7)',
+      ram: `rgba(224, 131, 224, ${graphTransparency})`,
+      space: `rgba(255, 99, 61, ${graphTransparency})`,
+      inodes: `rgba(224, 138, 146, ${graphTransparency})`,
       queries: {
-        select: 'rgba(34, 192, 206, 0.7)',
-        insert: 'rgba(26, 151, 162, 0.7)',
-        update: 'rgba(19, 110, 118, 0.7)',
-        delete: 'rgba(2, 54, 59, 0.7)'
+        select: `rgba(34, 192, 206, ${graphTransparency})`,
+        insert: `rgba(26, 151, 162, ${graphTransparency})`,
+        update: `rgba(19, 110, 118, ${graphTransparency})`,
+        delete: `rgba(2, 54, 59, ${graphTransparency})`
       },
-      slowQueries: 'rgba(255, 61, 61, 0.7)',
+      slowQueries: `rgba(255, 61, 61, ${graphTransparency})`,
       aborted: {
-        connections: 'rgba(255, 10, 10, 0.7)',
-        clients: 'rgba(214, 0, 0, 0.7)'
+        connections: `rgba(255, 10, 10, ${graphTransparency})`,
+        clients: `rgba(214, 0, 0, ${graphTransparency})`
       },
-      processCount: 'rgba(113, 86, 245, 0.7)',
+      processCount: `rgba(113, 86, 245, ${graphTransparency})`,
       blue: '#64ADF6',
       blueBorder: '#3F99F0',
       green: '#5BD765',
       greenBorder: '#18B523',
-      orange: 'rgba(255, 179, 77, 0.7)',
+      orange: `rgba(255, 179, 77, ${graphTransparency})`,
       purple: '#d9b0d9',
       purpleBorder: '#d9b0d9',
       red: '#FF633C',


### PR DESCRIPTION
## Description

Due to issues with opaque colors, we're re-introducing transparent colors for all longview graphs. Additionally, I removed the borders on the graphs to more closely align with the designs and removed 'deprecated' color values. 

## Type of Change
- Non breaking change ('update')

## Note to Reviewers

Something to consider is the naming scheme for these colors- I used the graph values so I could better keep track of them all and keep Longview graphs consistent, but maybe they should be actual color names so they're more general. Let me know if there's a preference and if these are actually helpful or more confusing. 
