### PR TITLE
[LV] Processes filter bug

### DIFF
--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Processes/ProcessesLanding.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Processes/ProcessesLanding.tsx
@@ -9,6 +9,7 @@ import get from 'src/features/Longview/request';
 import { LongviewProcesses } from 'src/features/Longview/request.types';
 import { statAverage, statMax } from 'src/features/Longview/shared/utilities';
 import { useAPIRequest } from 'src/hooks/useAPIRequest';
+import { escapeRegExp } from 'src/utilities/escapeRegExp';
 import ProcessesGraphs from './ProcessesGraphs';
 import ProcessesTable, { ExtendedProcess } from './ProcessesTable';
 
@@ -34,10 +35,13 @@ export const filterResults = (
   if (!inputText) {
     return results;
   }
+
+  const escapedInputText = escapeRegExp(inputText);
+
   return results.filter(
     thisResult =>
-      thisResult.user.match(RegExp(inputText, 'i')) ||
-      thisResult.name.match(RegExp(inputText, 'i'))
+      thisResult.user.match(RegExp(escapedInputText, 'i')) ||
+      thisResult.name.match(RegExp(escapedInputText, 'i'))
   );
 };
 

--- a/packages/manager/src/utilities/escapeRegExp.test.ts
+++ b/packages/manager/src/utilities/escapeRegExp.test.ts
@@ -1,0 +1,13 @@
+import { escapeRegExp } from './escapeRegExp';
+
+describe('escapeRegExp utility function', () => {
+  it('escapes special characters', () => {
+    expect(escapeRegExp('?')).toBe('\\?');
+    expect(escapeRegExp('\\')).toBe('\\\\');
+    expect(escapeRegExp('{')).toBe('\\{');
+  });
+  it('leaves strings without special characters untouched', () => {
+    expect(escapeRegExp('hello world')).toBe('hello world');
+    expect(escapeRegExp('')).toBe('');
+  });
+});

--- a/packages/manager/src/utilities/escapeRegExp.ts
+++ b/packages/manager/src/utilities/escapeRegExp.ts
@@ -1,0 +1,6 @@
+// Escape a string for use with the RegExp constructor.
+// This function comes from the MDN documentation.
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
+export const escapeRegExp = (s: string) => {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+};


### PR DESCRIPTION
## Description

A crash resulted when typing the forward-slash character in the Processes filter text input. The input string needed to be properly escaped before creating the regular expression. I added a utility function from the MDN documentation to do so.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers
**To verify bug:** 

Go to a LV Client’s “Processes” tab. Type `\` in the filter text input. The app crashes.

Feel free to play around with the new tests to further verify.
