### PR TITLE
M3-3779 ADD: Ability to edit axfr for slave Domains

### DIFF
--- a/packages/linode-js-sdk/src/domains/domains.schema.ts
+++ b/packages/linode-js-sdk/src/domains/domains.schema.ts
@@ -46,5 +46,6 @@ export const createDomainSchema = domainSchemaBase.shape({
 
 export const updateDomainSchema = domainSchemaBase.shape({
   domainId: number(),
-  soa_email: string().email('SOA Email is not valid.')
+  soa_email: string().email('SOA Email is not valid.'),
+  axfr_ips: array().of(string())
 });

--- a/packages/manager/src/features/Domains/DomainDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainDrawer.tsx
@@ -55,6 +55,7 @@ import LinodeSelect from 'src/features/linodes/LinodeSelect';
 import NodeBalancerSelect from 'src/features/NodeBalancers/NodeBalancerSelect';
 import { getErrorMap } from 'src/utilities/errorUtils';
 import { sendCreateDomainEvent } from 'src/utilities/ga';
+import DomainTransferInput from './DomainTransferInput';
 
 type ClassNames = 'root' | 'masterIPErrorNotice' | 'addIP';
 
@@ -80,6 +81,7 @@ interface State {
   errors?: APIError[];
   submitting: boolean;
   master_ips: string[];
+  axfr_ips: string[];
   masterIPsCount: number;
   defaultRecordsSetting: DefaultRecordsType;
   selectedDefaultLinode?: Linode;
@@ -158,10 +160,7 @@ const generateDefaultDomainRecords = (
 
 const masterIPsLens = lensPath(['master_ips']);
 const masterIPLens = (idx: number) =>
-  compose(
-    masterIPsLens,
-    lensPath([idx])
-  ) as Lens;
+  compose(masterIPsLens, lensPath([idx])) as Lens;
 const viewMasterIP = (idx: number, obj: any) =>
   view<any, string | undefined>(masterIPLens(idx), obj);
 const setMasterIP = (idx: number, value: string) =>
@@ -182,6 +181,7 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
     submitting: false,
     errors: [],
     master_ips: [],
+    axfr_ips: [],
     masterIPsCount: 1,
     defaultRecordsSetting: 'none',
     selectedDefaultLinode: undefined,
@@ -217,6 +217,7 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
 
       // then put it props into state to populate fields
       const {
+        axfr_ips,
         domain,
         tags,
         master_ips,
@@ -229,6 +230,7 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
         type,
         domain,
         master_ips,
+        axfr_ips,
         soaEmail: soa_email
       });
     }
@@ -248,6 +250,7 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
 
     const errorMap = getErrorMap(
       [
+        'axfr_ips',
         'master_ips',
         'domain',
         'type',
@@ -339,6 +342,14 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
         )}
         {(isCreatingSlaveDomain || isEditingSlaveDomain) && (
           <React.Fragment>
+            {isEditingSlaveDomain && (
+              // Only when editing
+              <DomainTransferInput
+                value={this.state.axfr_ips.join(',')}
+                onChange={this.handleTransferInput}
+                error={errorMap.axfr_ips}
+              />
+            )}
             {masterIPsError && (
               <Notice
                 className={classes.masterIPErrorNotice}
@@ -474,6 +485,12 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
     );
   }
 
+  handleTransferInput = (axfr_ips: string[]) => {
+    if (this.mounted) {
+      this.setState({ axfr_ips });
+    }
+  };
+
   resetInternalState = () => {
     if (this.mounted) {
       this.setState({ ...this.defaultState });
@@ -591,9 +608,7 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
               })
               .catch((e: APIError[]) => {
                 reportException(
-                  `Default DNS Records couldn't be created from Linode: ${
-                    e[0].reason
-                  }`,
+                  `Default DNS Records couldn't be created from Linode: ${e[0].reason}`,
                   {
                     selectedLinode: this.state.selectedDefaultLinode!.id,
                     domainID: domainData.id,
@@ -620,9 +635,7 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
               })
               .catch((e: APIError[]) => {
                 reportException(
-                  `Default DNS Records couldn't be created from NodeBalancer: ${
-                    e[0].reason
-                  }`,
+                  `Default DNS Records couldn't be created from NodeBalancer: ${e[0].reason}`,
                   {
                     selectedNodeBalancer: this.state
                       .selectedDefaultNodeBalancer!.id,
@@ -694,7 +707,7 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
   };
 
   update = () => {
-    const { domain, type, soaEmail, master_ips } = this.state;
+    const { axfr_ips, domain, type, soaEmail, master_ips } = this.state;
     const { domainActions, id } = this.props;
     const tags = this.state.tags.map(tag => tag.value);
 
@@ -723,12 +736,19 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
       type === 'master'
         ? // not sending type for master. There is a bug on server and it returns an error that `master_ips` is required
           { domain, tags, soa_email: soaEmail, domainId: id }
-        : { domain, type, tags, master_ips: finalMasterIPs, domainId: id };
+        : {
+            domain,
+            type,
+            tags,
+            master_ips: finalMasterIPs,
+            domainId: id,
+            axfr_ips
+          };
 
     this.setState({ submitting: true });
     domainActions
       .updateDomain(data)
-      .then((domainData: Domain) => {
+      .then(_ => {
         if (!this.mounted) {
           return;
         }
@@ -837,10 +857,7 @@ const mapStateToProps = (state: ApplicationState) => {
   };
 };
 
-const connected = connect(
-  mapStateToProps,
-  mapDispatchToProps
-);
+const connected = connect(mapStateToProps, mapDispatchToProps);
 
 export default compose<CombinedProps, {}>(
   withDomainActions,

--- a/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
@@ -34,6 +34,7 @@ import {
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
+import DomainTransferInput from './DomainTransferInput';
 import { isValidCNAME, isValidDomainRecord } from './domainUtils';
 
 const TextField: React.StatelessComponent<TextFieldProps> = props => (
@@ -162,15 +163,7 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
     expire_sec: 'expire rate'
   };
 
-  handleTransferUpdate = (e: React.ChangeEvent<HTMLInputElement>) => {
-    /**
-     * This is a textarea input type, and users
-     * are expected to input a comma-separated list of IPs.
-     * However, the API is expecting an array
-     * of strings. If the user clears the input, set axfr_ips to [].
-     * Otherwise, split the list into an array.
-     */
-    const transferIPs = e.target.value === '' ? [] : e.target.value.split(',');
+  handleTransferUpdate = (transferIPs: string[]) => {
     this.updateField('axfr_ips')(transferIPs);
   };
 
@@ -402,18 +395,11 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
   };
 
   DomainTransferField = () => (
-    <TextField
-      multiline
-      label="Domain Transfers"
-      placeholder="192.0.2.0,192.0.2.1"
-      errorText={getAPIErrorsFor(
+    <DomainTransferInput
+      error={getAPIErrorsFor(
         DomainRecordDrawer.errorFields,
         this.state.errors
       )('axfr_ips')}
-      // Include some warnings and info from the API docs.
-      helperText={`Comma-separated list of IPs that may perform a zone transfer for this Domain.
-        This is potentially dangerous, and should be left empty unless you intend to use it.`}
-      rows="3"
       value={defaultTo(
         DomainRecordDrawer.defaultFieldsState(this.props).axfr_ips,
         (this.state.fields as EditableDomainFields).axfr_ips

--- a/packages/manager/src/features/Domains/DomainTransferInput.tsx
+++ b/packages/manager/src/features/Domains/DomainTransferInput.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import TextField from 'src/components/TextField';
+
+interface Props {
+  error?: string;
+  value: string;
+  onChange: (ips: string[]) => void;
+}
+
+export const DomainTransferInput: React.FC<Props> = props => {
+  const { error, onChange, value } = props;
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    /**
+     * This is a textarea input type, and users
+     * are expected to input a comma-separated list of IPs.
+     * However, the API is expecting an array
+     * of strings. If the user clears the input, set axfr_ips to [].
+     * Otherwise, split the list into an array.
+     */
+    const transferIPs = e.target.value === '' ? [] : e.target.value.split(',');
+    onChange(transferIPs);
+  };
+
+  return (
+    <TextField
+      multiline
+      label="Domain Transfers"
+      placeholder="192.0.2.0,192.0.2.1"
+      errorText={error}
+      // Include some warnings and info from the API docs.
+      helperText={`Comma-separated list of up to 6 IPs that may perform a zone transfer for this Domain.
+        This is potentially dangerous, and should be left empty unless you intend to use it.`}
+      rows="3"
+      value={value}
+      onChange={handleChange}
+    />
+  );
+};
+
+export default DomainTransferInput;

--- a/packages/manager/src/features/Domains/DomainTransferInput.tsx
+++ b/packages/manager/src/features/Domains/DomainTransferInput.tsx
@@ -41,4 +41,4 @@ export const DomainTransferInput: React.FC<Props> = props => {
   );
 };
 
-export default DomainTransferInput;
+export default React.memo(DomainTransferInput);

--- a/packages/manager/src/features/Domains/DomainTransferInput.tsx
+++ b/packages/manager/src/features/Domains/DomainTransferInput.tsx
@@ -28,7 +28,7 @@ export const DomainTransferInput: React.FC<Props> = props => {
       placeholder="192.0.2.0,192.0.2.1"
       errorText={error}
       // Include some warnings and info from the API docs.
-      helperText={`Comma-separated list of up to 6 IPs that may perform a zone transfer for this Domain.
+      helperText={`Comma-separated list IPs that may perform a zone transfer for this Domain.
         This is potentially dangerous, and should be left empty unless you intend to use it.`}
       rows="3"
       value={value}

--- a/packages/manager/src/features/Domains/DomainTransferInput.tsx
+++ b/packages/manager/src/features/Domains/DomainTransferInput.tsx
@@ -16,6 +16,10 @@ export const DomainTransferInput: React.FC<Props> = props => {
      * However, the API is expecting an array
      * of strings. If the user clears the input, set axfr_ips to [].
      * Otherwise, split the list into an array.
+     *
+     * We're relying on the API to validate these, bc there's no easy
+     * way to validate both v4 and v6 without bringing in a library.
+     * Badly-formed input will error on their end.
      */
     const transferIPs = e.target.value === '' ? [] : e.target.value.split(',');
     onChange(transferIPs);


### PR DESCRIPTION
## Description

We had a field to allow users to update axfr IPs (addresses allowed
to transfer for this Domain) when editing the SOA record for a master
Domain, but nothing was available for slave domains, since there's
only a single drawer for all slave-related editing actions.

Abstracted the axfr textfield so that it could be used in both places.

## Notes

I kept this change simple to limit the scope, but that drawer is problematic. Really needs to be broken into separate drawers or components. There's some dubious cDU logic in there too, such that if you leave an editing drawer open and the app reloads you can end up in a weird limbo form. This likely only happens when hot-reloading in development, but it's icky and needs to be fixed on a tdt.
