### PR TITLE
M3 -1867 Fix: Hide Backups CTAs from restricted users

### DIFF
--- a/packages/manager/src/features/Backups/BackupsCTA.tsx
+++ b/packages/manager/src/features/Backups/BackupsCTA.tsx
@@ -13,6 +13,7 @@ import {
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
+import { isRestrictedUser } from 'src/features/Profile/permissionsHelpers';
 import { handleOpen } from 'src/store/backupDrawer';
 import { MapState } from 'src/store/types';
 
@@ -61,7 +62,13 @@ const BackupsCTA: React.StatelessComponent<CombinedProps> = props => {
     dismissed
   } = props;
 
-  if (managed || (linodesWithoutBackups && isEmpty(linodesWithoutBackups))) {
+  const restricted = isRestrictedUser();
+
+  if (
+    restricted ||
+    managed ||
+    (linodesWithoutBackups && isEmpty(linodesWithoutBackups))
+  ) {
     return null;
   }
 
@@ -145,14 +152,8 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
 
 const styled = withStyles(styles);
 
-const connected = connect(
-  mapStateToProps,
-  mapDispatchToProps
-);
+const connected = connect(mapStateToProps, mapDispatchToProps);
 
-const enhanced = compose<CombinedProps, Props>(
-  styled,
-  connected
-)(BackupsCTA);
+const enhanced = compose<CombinedProps, Props>(styled, connected)(BackupsCTA);
 
 export default enhanced;

--- a/packages/manager/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
@@ -11,6 +11,7 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
+import { isRestrictedUser } from 'src/features/Profile/permissionsHelpers';
 import DashboardCard from '../DashboardCard';
 
 type ClassNames =
@@ -70,9 +71,7 @@ interface Props {
 
 type CombinedProps = Props & RouteComponentProps<{}> & WithStyles<ClassNames>;
 
-export const BackupsDashboardCard: React.StatelessComponent<
-  CombinedProps
-> = props => {
+export const BackupsDashboardCard: React.FC<CombinedProps> = props => {
   const {
     accountBackups,
     classes,
@@ -80,7 +79,9 @@ export const BackupsDashboardCard: React.StatelessComponent<
     openBackupDrawer
   } = props;
 
-  if (accountBackups && !linodesWithoutBackups) {
+  const restricted = isRestrictedUser();
+
+  if (restricted || (accountBackups && !linodesWithoutBackups)) {
     return null;
   }
 

--- a/packages/manager/src/features/Profile/permissionsHelpers.ts
+++ b/packages/manager/src/features/Profile/permissionsHelpers.ts
@@ -1,14 +1,11 @@
-import { GlobalGrantTypes } from "linode-js-sdk/lib/account";
-import { pathOr } from 'ramda';
+import { GlobalGrantTypes } from 'linode-js-sdk/lib/account';
+import store, { ApplicationState } from 'src/store';
 
-export const isRestrictedUser = (state: any) => {
-  return pathOr(false, ['__resources', 'profile', 'data', 'restricted'], state);
+export const isRestrictedUser = (_state?: ApplicationState) => {
+  const state = _state ?? store.getState();
+  return state?.__resources?.profile?.data?.restricted ?? false;
 };
 
-export const hasGrant = (state: any, grant: GlobalGrantTypes) => {
-  return pathOr(
-    false,
-    ['__resources', 'profile', 'data', 'grants', 'global', grant],
-    state
-  );
+export const hasGrant = (state: ApplicationState, grant: GlobalGrantTypes) => {
+  return state?.__resources?.profile?.data?.grants?.global?.[grant] ?? false;
 };


### PR DESCRIPTION
## Description

This issue from @nwisnewski is still unfixed, so here we go. any restricted user, regardless of permissions, will no longer see the backups CTA on either the dashboard or Linode view. It's possible for a user with sufficient permissions to toggle this setting, so it might be worth it to check the specific grants involved.
