### PR TITLE
M3-3465 Allow rebooting from Rescue mode

### DIFF
--- a/packages/manager/src/factories/linodeConfigs.ts
+++ b/packages/manager/src/factories/linodeConfigs.ts
@@ -1,0 +1,44 @@
+import * as Factory from 'factory.ts';
+import { Config } from 'linode-js-sdk/lib/linodes/types';
+
+const generateRandomId = () => Math.floor(Math.random() * 10000);
+
+export const linodeConfigFactory = Factory.Sync.makeFactory<Config>({
+  created: '2018-06-26T16:04:28',
+  memory_limit: 0,
+  updated: '2018-06-26T16:04:28',
+  comments: '',
+  virt_mode: 'paravirt',
+  id: Factory.each(i => i),
+  run_level: 'default',
+  helpers: {
+    distro: true,
+    network: true,
+    modules_dep: true,
+    devtmpfs_automount: true,
+    updatedb_disabled: true
+  },
+  root_device: '/dev/sda',
+  label: 'My Arch Linux Disk Profile',
+  initrd: null,
+  devices: {
+    sdc: {
+      volume_id: 8702,
+      disk_id: null
+    },
+    sda: {
+      volume_id: null,
+      disk_id: generateRandomId()
+    },
+    sdd: null,
+    sdf: null,
+    sdb: {
+      volume_id: null,
+      disk_id: generateRandomId()
+    },
+    sdh: null,
+    sdg: null,
+    sde: null
+  },
+  kernel: 'linode/grub2'
+});

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.tsx
@@ -289,7 +289,7 @@ export class LinodeRescue extends React.Component<CombinedProps, State> {
                 data-qa-submit
                 disabled={disabled}
               >
-                Submit
+                Reboot into Rescue Mode
               </Button>
             </ActionsPanel>
           </Paper>

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeCard.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeCard.test.tsx
@@ -75,6 +75,8 @@ describe('LinodeRow', () => {
     openDeleteDialog: jest.fn(),
     openPowerActionDialog: jest.fn(),
     mutationAvailable: false,
+    enqueueSnackbar: jest.fn(),
+    closeSnackbar: jest.fn(),
 
     type: 'whatever',
     tags: [],

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeCard.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeCard.tsx
@@ -1,5 +1,11 @@
 import { Event, Notification } from 'linode-js-sdk/lib/account';
-import { Config, LinodeBackups, LinodeStatus } from 'linode-js-sdk/lib/linodes';
+import {
+  Config,
+  getLinodeConfigs,
+  LinodeBackups,
+  LinodeStatus
+} from 'linode-js-sdk/lib/linodes';
+import { withSnackbar, WithSnackbarProps } from 'notistack';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { compose } from 'recompose';
@@ -70,9 +76,18 @@ export type CombinedProps = Props &
   WithRecentEvent &
   WithNotifications &
   HasMutationAvailable &
+  WithSnackbarProps &
   StyleProps;
 
-export class LinodeCard extends React.PureComponent<CombinedProps> {
+interface State {
+  loadingConfigs: boolean;
+}
+
+export class LinodeCard extends React.PureComponent<CombinedProps, State> {
+  state: State = {
+    loadingConfigs: false
+  };
+
   handleConsoleButtonClick = () => {
     sendLinodeActionMenuItemEvent('Launch Console');
     const { id } = this.props;
@@ -80,9 +95,28 @@ export class LinodeCard extends React.PureComponent<CombinedProps> {
   };
 
   handleRebootButtonClick = () => {
+    const { id } = this.props;
+    this.setState({ loadingConfigs: true });
+    getLinodeConfigs(id)
+      .then(response => {
+        this.setState({ loadingConfigs: false });
+        this.handleReboot(response.data);
+      })
+      .catch(_ => {
+        this.setState({ loadingConfigs: false });
+        this.props.enqueueSnackbar(
+          'Unable to load configs for this Linode. Please try again.',
+          {
+            variant: 'error'
+          }
+        );
+      });
+  };
+
+  handleReboot = (configs: Config[]) => {
     sendLinodeActionMenuItemEvent('Reboot Linode');
     const { id, label, openPowerActionDialog } = this.props;
-    openPowerActionDialog('Reboot', id, label, []);
+    openPowerActionDialog('Reboot', id, label, configs);
   };
 
   render() {
@@ -110,6 +144,8 @@ export class LinodeCard extends React.PureComponent<CombinedProps> {
       imageLabel,
       maintenanceStartTime
     } = this.props;
+
+    const { loadingConfigs } = this.state;
 
     const loading = linodeInTransition(status, recentEvent);
     const dateTime = parseMaintenanceStartTime(maintenanceStartTime).split(' ');
@@ -240,6 +276,7 @@ export class LinodeCard extends React.PureComponent<CombinedProps> {
               className={`${classes.button}
               ${classes.rebootButton}`}
               onClick={this.handleRebootButtonClick}
+              loading={loadingConfigs}
               data-qa-reboot
             >
               Reboot
@@ -256,7 +293,8 @@ export default compose<CombinedProps, Props>(
   withDisplayType,
   withRecentEvent,
   withNotifications,
-  hasMutationAvailable
+  hasMutationAvailable,
+  withSnackbar
 )(LinodeCard) as React.ComponentType<Props>;
 
 const ProgressDisplay: React.StatelessComponent<{

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeCard.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeCard.tsx
@@ -95,6 +95,17 @@ export class LinodeCard extends React.PureComponent<CombinedProps, State> {
   };
 
   handleRebootButtonClick = () => {
+    /**
+     * We have to pass a configID to the
+     * API, and since we don't have that data in state
+     * we have to request it.
+     *
+     * The API can handle an empty linode/reboot
+     * request in most cases, but in some situations,
+     * such as a Linode in rescue mode, this will cause
+     * an error. If the API adjusts this behavior,
+     * this logic can be removed/simplified.
+     */
     const { id } = this.props;
     this.setState({ loadingConfigs: true });
     getLinodeConfigs(id)

--- a/packages/manager/src/features/linodes/PowerActionsDialogOrDrawer.test.tsx
+++ b/packages/manager/src/features/linodes/PowerActionsDialogOrDrawer.test.tsx
@@ -1,0 +1,18 @@
+import { linodeConfigFactory } from 'src/factories/linodeConfigs';
+import { selectDefaultConfig } from './PowerActionsDialogOrDrawer';
+
+describe('Default config selection logic', () => {
+  it('should return undefined when more than one config is available', () => {
+    expect(selectDefaultConfig()).toBeUndefined();
+  });
+
+  it('should return undefined when no configs are available', () => {
+    const configs = linodeConfigFactory.buildList(4);
+    expect(selectDefaultConfig(configs)).toBeUndefined();
+  });
+
+  it('should return the first (only) config ID when exactly one config is available', () => {
+    const configs = linodeConfigFactory.buildList(1);
+    expect(selectDefaultConfig(configs)).toEqual(configs[0].id);
+  });
+});

--- a/packages/manager/src/features/linodes/PowerActionsDialogOrDrawer.tsx
+++ b/packages/manager/src/features/linodes/PowerActionsDialogOrDrawer.tsx
@@ -38,11 +38,10 @@ type CombinedProps = Props;
  *
  * @param configs
  */
-const selectDefaultConfig = (configs?: Config[]) => {
+export const selectDefaultConfig = (configs?: Config[]) => {
   if (!configs || configs.length === 0) {
     return;
-  }
-  if (configs.length === 1) {
+  } else if (configs.length === 1) {
     return configs[0].id;
   } else {
     return;

--- a/packages/manager/src/features/linodes/PowerActionsDialogOrDrawer.tsx
+++ b/packages/manager/src/features/linodes/PowerActionsDialogOrDrawer.tsx
@@ -38,15 +38,8 @@ type CombinedProps = Props;
  *
  * @param configs
  */
-export const selectDefaultConfig = (configs?: Config[]) => {
-  if (!configs || configs.length === 0) {
-    return;
-  } else if (configs.length === 1) {
-    return configs[0].id;
-  } else {
-    return;
-  }
-};
+export const selectDefaultConfig = (configs?: Config[]) =>
+  configs?.length === 1 ? configs[0].id : undefined;
 
 const PowerActionsDialogOrDrawer: React.FC<CombinedProps> = props => {
   const { linodeConfigs } = props;

--- a/packages/manager/src/features/linodes/PowerActionsDialogOrDrawer.tsx
+++ b/packages/manager/src/features/linodes/PowerActionsDialogOrDrawer.tsx
@@ -30,11 +30,31 @@ interface Props {
 
 type CombinedProps = Props;
 
+/**
+ * In special cases, such as Rescue mode, the API's method
+ * for determining the last booted config doesn't work as
+ * expected. To avoid these cases, we should always pass
+ * the configId if there's only a single available config.
+ *
+ * @param configs
+ */
+const selectDefaultConfig = (configs?: Config[]) => {
+  if (!configs || configs.length === 0) {
+    return;
+  }
+  if (configs.length === 1) {
+    return configs[0].id;
+  } else {
+    return;
+  }
+};
+
 const PowerActionsDialogOrDrawer: React.FC<CombinedProps> = props => {
+  const { linodeConfigs } = props;
   const [isTakingAction, setTakingAction] = React.useState<boolean>(false);
   const [errors, setErrors] = React.useState<APIError[] | undefined>(undefined);
   const [selectedConfigID, selectConfigID] = React.useState<number | undefined>(
-    undefined
+    selectDefaultConfig(linodeConfigs)
   );
 
   const hasMoreThanOneConfigOnSelectedLinode =
@@ -47,7 +67,7 @@ const PowerActionsDialogOrDrawer: React.FC<CombinedProps> = props => {
        */
       setErrors(undefined);
       setTakingAction(false);
-      selectConfigID(undefined);
+      selectConfigID(selectDefaultConfig(linodeConfigs));
     }
   }, [props.isOpen]);
 
@@ -98,7 +118,7 @@ const PowerActionsDialogOrDrawer: React.FC<CombinedProps> = props => {
         onSelectConfig={selectConfigID}
         onSubmit={handleSubmit}
         onClose={props.close}
-        linodeConfigs={props.linodeConfigs!}
+        linodeConfigs={props.linodeConfigs ?? []}
         selectedConfigID={selectedConfigID}
       />
     );


### PR DESCRIPTION
The API logic that determines which config to reboot with
when no config ID is provided seems to glitch out when
in Rescue mode. If a user has a single config, we just call
reboot(), which returns an API error "No bootable config found"
API is aware of this now, but since it's not going to get fixed
in time for EOL, the simplest thing for us to do is pass the configId
manually whenever only one config is present.

- This affects the "Power action dropdown" in detail view and the action menu from list view. I don't think there's anywhere else but please double check.

- I also renamed "Submit" to "Reboot into Rescue Mode" on the rescue button
to match Classic.

## Notes

To test:

1. Have a Linode with only one config.
2. Boot into Rescue mode
3. Select "Reboot" from one of the above action menus.
4. Observe: In production, you get an API error, which should not be present on this branch.

