### PR TITLE
[LV] Fix bug in useClientLastUpdated.

### DIFF
--- a/packages/manager/src/features/Longview/shared/useClientLastUpdated.ts
+++ b/packages/manager/src/features/Longview/shared/useClientLastUpdated.ts
@@ -53,13 +53,15 @@ export const useClientLastUpdated = (
           only update _lastUpdated_ state if it hasn't already been set
           or the API response is in a time past what's already been set.
         */
+
+        const _lastUpdated = response.DATA.updated ?? 0;
+
         if (
           mounted &&
           (typeof newLastUpdated === 'undefined' ||
-            pathOr(0, ['updated'], response) > newLastUpdated)
+            _lastUpdated > newLastUpdated)
         ) {
-          const _lastUpdated = pathOr(0, ['DATA', 'updated'], response);
-          setLastUpdated(response.DATA.updated);
+          setLastUpdated(_lastUpdated);
           if (callback) {
             callback(_lastUpdated);
           }

--- a/packages/manager/src/features/Longview/shared/useClientLastUpdated.ts
+++ b/packages/manager/src/features/Longview/shared/useClientLastUpdated.ts
@@ -54,7 +54,7 @@ export const useClientLastUpdated = (
           or the API response is in a time past what's already been set.
         */
 
-        const _lastUpdated = response.DATA.updated ?? 0;
+        const _lastUpdated = response.DATA?.updated ?? 0;
 
         if (
           mounted &&


### PR DESCRIPTION
## Description

We had a faulty pathOr in useClientLastUpdated:
```typescript
pathOr(0, ['updated'], response)
```

It should have been: 
```typescript
pathOr(0, ['DATA', 'updated'], response)
```
 But I used optional chaining and nullish coalescing instead.

## Testing
To verify bug:

1. Open the Network tab.
2. Open Dev Tools, Network tab.
3. Filter on “fetch” to easily see requests.
4. Do something to generate traffic on your Linode.
5. Wait a while and check each polled `/fetch` request.
**6. Observe:** even though `lastUpdated` has changed, the graphs have not been updated.

To verify fix, follow steps 1-5, then:

**6. Observe:** graphs have been updated.