### PR TITLE
M3-3780 Request 200 entities at a time

### DIFF
--- a/packages/linode-js-sdk/src/nodebalancers/nodebalancers.ts
+++ b/packages/linode-js-sdk/src/nodebalancers/nodebalancers.ts
@@ -25,7 +25,7 @@ import { combineNodeBalancerConfigNodeAddressAndPort } from './utils';
  */
 export const getNodeBalancers = (params?: any, filters?: any) =>
   Request<Page<NodeBalancer>>(
-    setURL(`${API_ROOT}/nodebalancers/`),
+    setURL(`${API_ROOT}/nodebalancers`),
     setMethod('GET'),
     setParams(params),
     setXFilter(filters)

--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -316,3 +316,7 @@ export const OBJECT_STORAGE_ROOT = 'linodeobjects.com';
  * to simulate folder traversal of a bucket.
  */
 export const OBJECT_STORAGE_DELIMITER = '/';
+
+// Maximum page size allowed by the API. Used in the `getAll()` helper function
+// to request as many items at once as possible.
+export const MAX_PAGE_SIZE = 200;

--- a/packages/manager/src/store/image/image.requests.ts
+++ b/packages/manager/src/store/image/image.requests.ts
@@ -2,10 +2,8 @@ import {
   createImage as _create,
   getImage,
   getImages,
-  Image,
   updateImage as _update
 } from 'linode-js-sdk/lib/images';
-import { getAll } from 'src/utilities/getAll';
 import { createRequestThunk } from '../store.helpers';
 import {
   createImageActions,
@@ -14,10 +12,8 @@ import {
   updateImageActions
 } from './image.actions';
 
-const getAllImages = getAll<Image>(getImages);
-
 export const requestImages = createRequestThunk(requestImagesActions, () =>
-  getAllImages().then(response => response.data)
+  getImages().then(response => response.data)
 );
 
 export const createImage = createRequestThunk(

--- a/packages/manager/src/utilities/getAll.ts
+++ b/packages/manager/src/utilities/getAll.ts
@@ -8,6 +8,7 @@ import {
 import { getVolumes, Volume } from 'linode-js-sdk/lib/volumes';
 import { range } from 'ramda';
 
+import { MAX_PAGE_SIZE } from 'src/constants';
 import { sendFetchAllEvent } from 'src/utilities/ga';
 
 export interface APIResponsePage<T> {
@@ -40,8 +41,7 @@ export interface GetAllData<T> {
  * using the getter, then uses the response to determine the number of remaining pages.
  * Subsequent requests are then made and the results combined into a single array. This
  * procedure is necessary when retrieving all entities whenever the possible number of
- * entities is greater than 100 (the max number of results the API will return in a single
- * page).
+ * entities is greater than the max number of results the API will return in a single page).
  *
  * @param getter { Function } one of the Get functions from the API services library. Accepts
  * pagination or filter parameters.
@@ -56,7 +56,7 @@ export const getAll: <T>(
   params?: any,
   filter?: any
 ) => {
-  const pagination = { ...params, page_size: 100 };
+  const pagination = { ...params, page_size: MAX_PAGE_SIZE };
   return getter(pagination, filter).then(
     ({ data: firstPageData, page, pages, results }) => {
       // If we only have one page, return it.
@@ -99,7 +99,7 @@ export const getAllWithArguments: <T>(
   params?: any,
   filter?: any
 ) => Promise<GetAllData<T[]>> = getter => (args = [], params, filter) => {
-  const pagination = { ...params, page_size: 100 };
+  const pagination = { ...params, page_size: MAX_PAGE_SIZE };
 
   return getter(...args, pagination, filter).then(
     ({ data: firstPageData, page, pages, results }) => {


### PR DESCRIPTION
## Description

API has increased the maximum page size to 200. This PR moves this value to a constant and uses it in the getAll helper function.

API is returning an error when requesting 200 Images, but since there is a limit of 3 Images per account, I made a change to `images.requests` so that we _don't_ use `getAll` for images.

