### PR TITLE
Use v4 instead of v4beta for OBJ

### DIFF
--- a/packages/linode-js-sdk/src/object-storage/account.ts
+++ b/packages/linode-js-sdk/src/object-storage/account.ts
@@ -1,4 +1,4 @@
-import { BETA_API_ROOT } from 'src/constants';
+import { API_ROOT } from 'src/constants';
 import Request, { setMethod, setURL } from '../request';
 
 /**
@@ -9,5 +9,5 @@ import Request, { setMethod, setURL } from '../request';
 export const cancelObjectStorage = () =>
   Request<{}>(
     setMethod('POST'),
-    setURL(`${BETA_API_ROOT}/object-storage/cancel`)
+    setURL(`${API_ROOT}/object-storage/cancel`)
   ).then(response => response.data);

--- a/packages/linode-js-sdk/src/object-storage/buckets.ts
+++ b/packages/linode-js-sdk/src/object-storage/buckets.ts
@@ -1,4 +1,4 @@
-import { BETA_API_ROOT } from 'src/constants';
+import { API_ROOT } from 'src/constants';
 import Request, {
   setData,
   setMethod,
@@ -26,7 +26,7 @@ export const getBuckets = (params?: any, filters?: any) =>
     setMethod('GET'),
     setParams(params),
     setXFilter(filters),
-    setURL(`${BETA_API_ROOT}/object-storage/buckets`)
+    setURL(`${API_ROOT}/object-storage/buckets`)
   ).then(response => response.data);
 
 /**
@@ -39,7 +39,7 @@ export const getBuckets = (params?: any, filters?: any) =>
  */
 export const createBucket = (data: ObjectStorageBucketRequestPayload) =>
   Request<ObjectStorageBucket>(
-    setURL(`${BETA_API_ROOT}/object-storage/buckets`),
+    setURL(`${API_ROOT}/object-storage/buckets`),
     setMethod('POST'),
     setData(data, CreateBucketSchema)
   ).then(response => response.data);
@@ -56,7 +56,7 @@ export const deleteBucket = ({
   label
 }: ObjectStorageDeleteBucketRequestPayload) =>
   Request<ObjectStorageBucket>(
-    setURL(`${BETA_API_ROOT}/object-storage/buckets/${cluster}/${label}`),
+    setURL(`${API_ROOT}/object-storage/buckets/${cluster}/${label}`),
     setMethod('DELETE')
   );
 
@@ -72,6 +72,6 @@ export const getObjectList = (
     setMethod('GET'),
     setParams(params),
     setURL(
-      `${BETA_API_ROOT}/object-storage/buckets/${clusterId}/${bucketName}/object-list`
+      `${API_ROOT}/object-storage/buckets/${clusterId}/${bucketName}/object-list`
     )
   ).then(response => response.data);

--- a/packages/linode-js-sdk/src/object-storage/clusters.ts
+++ b/packages/linode-js-sdk/src/object-storage/clusters.ts
@@ -1,4 +1,4 @@
-import { BETA_API_ROOT } from 'src/constants';
+import { API_ROOT } from 'src/constants';
 import Request, { setMethod, setParams, setURL, setXFilter } from '../request';
 import { ResourcePage as Page } from '../types';
 import { ObjectStorageCluster } from './types';
@@ -13,5 +13,5 @@ export const getClusters = (params?: any, filters?: any) =>
     setMethod('GET'),
     setParams(params),
     setXFilter(filters),
-    setURL(`${BETA_API_ROOT}/object-storage/clusters`)
+    setURL(`${API_ROOT}/object-storage/clusters`)
   ).then(response => response.data);

--- a/packages/linode-js-sdk/src/object-storage/objectStorageKeys.ts
+++ b/packages/linode-js-sdk/src/object-storage/objectStorageKeys.ts
@@ -20,7 +20,7 @@ export const getObjectStorageKeys = (params?: any, filters?: any) =>
     setMethod('GET'),
     setParams(params),
     setXFilter(filters),
-    setURL(`${API_ROOT}beta/object-storage/keys`)
+    setURL(`${API_ROOT}/object-storage/keys`)
   ).then(response => response.data);
 
 /**
@@ -31,7 +31,7 @@ export const getObjectStorageKeys = (params?: any, filters?: any) =>
 export const createObjectStorageKeys = (data: ObjectStorageKeyRequest) =>
   Request<ObjectStorageKey>(
     setMethod('POST'),
-    setURL(`${API_ROOT}beta/object-storage/keys`),
+    setURL(`${API_ROOT}/object-storage/keys`),
     setData(data, createObjectStorageKeysSchema)
   ).then(response => response.data);
 
@@ -46,7 +46,7 @@ export const updateObjectStorageKey = (
 ) =>
   Request<ObjectStorageKey>(
     setMethod('PUT'),
-    setURL(`${API_ROOT}beta/object-storage/keys/${id}`),
+    setURL(`${API_ROOT}/object-storage/keys/${id}`),
     setData(data, createObjectStorageKeysSchema)
   ).then(response => response.data);
 
@@ -58,5 +58,5 @@ export const updateObjectStorageKey = (
 export const revokeObjectStorageKey = (id: number) =>
   Request<ObjectStorageKey>(
     setMethod('DELETE'),
-    setURL(`${API_ROOT}beta/object-storage/keys/${id}`)
+    setURL(`${API_ROOT}/object-storage/keys/${id}`)
   ).then(response => response.data);

--- a/packages/linode-js-sdk/src/object-storage/objects.ts
+++ b/packages/linode-js-sdk/src/object-storage/objects.ts
@@ -1,4 +1,4 @@
-import { BETA_API_ROOT } from 'src/constants';
+import { API_ROOT } from 'src/constants';
 import Request, { setData, setMethod, setURL } from '../request';
 import { ObjectStorageObjectURL, ObjectStorageObjectURLOptions } from './types';
 
@@ -15,7 +15,7 @@ export const getObjectURL = (
   Request<ObjectStorageObjectURL>(
     setMethod('POST'),
     setURL(
-      `${BETA_API_ROOT}/object-storage/buckets/${clusterId}/${bucketName}/object-url`
+      `${API_ROOT}/object-storage/buckets/${clusterId}/${bucketName}/object-url`
     ),
     setData({ name, method, ...options })
   ).then(response => response.data);


### PR DESCRIPTION
## Description

These endpoints can now be safely used with the v4 prefix.

## Note to Reviewers

Just make sure Object Storage still works.
