### PR TITLE
M3-2446 Region status message

### DIFF
--- a/packages/linode-js-sdk/src/regions/types.ts
+++ b/packages/linode-js-sdk/src/regions/types.ts
@@ -5,8 +5,11 @@ export type Capabilities =
   | 'Object Storage'
   | 'Kubernetes';
 
+export type RegionStatus = 'ok' | 'outage';
+
 export interface Region {
   id: string;
   country: string;
   capabilities: Capabilities[];
+  status: RegionStatus;
 }

--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -11,6 +11,7 @@ import {
   withTheme,
   WithTheme
 } from 'src/components/core/styles';
+import RegionStatusBanner from 'src/components/RegionStatusBanner';
 
 import BackupDrawer from 'src/features/Backups';
 import DomainDrawer from 'src/features/Domains/DomainDrawer';
@@ -312,6 +313,7 @@ const MainContent: React.FC<CombinedProps> = props => {
               <main className={classes.wrapper} id="main-content" role="main">
                 <Grid container spacing={0} className={classes.grid}>
                   <Grid item className={classes.switchWrapper}>
+                    <RegionStatusBanner />
                     <Switch>
                       <Route path="/linodes" component={LinodesRoutes} />
                       <Route path="/volumes" component={Volumes} />

--- a/packages/manager/src/__data__/regionsData.ts
+++ b/packages/manager/src/__data__/regionsData.ts
@@ -4,32 +4,38 @@ export const regions: Region[] = [
   {
     capabilities: ['Linodes', 'NodeBalancers', 'Block Storage'],
     country: 'in',
-    id: 'ap-west'
+    id: 'ap-west',
+    status: 'ok'
   },
   {
     capabilities: ['Linodes', 'NodeBalancers', 'Block Storage'],
     country: 'au',
-    id: 'ap-southeast'
+    id: 'ap-southeast',
+    status: 'ok'
   },
   {
     capabilities: ['Linodes', 'NodeBalancers', 'Block Storage'],
     country: 'ca',
-    id: 'ca-central'
+    id: 'ca-central',
+    status: 'ok'
   },
   {
     capabilities: ['Linodes', 'NodeBalancers', 'Block Storage'],
     country: 'us',
-    id: 'us-central'
+    id: 'us-central',
+    status: 'ok'
   },
   {
     capabilities: ['Linodes', 'NodeBalancers', 'Block Storage'],
     country: 'us',
-    id: 'us-west'
+    id: 'us-west',
+    status: 'ok'
   },
   {
     capabilities: ['Linodes', 'NodeBalancers'],
     country: 'us',
-    id: 'us-southeast'
+    id: 'us-southeast',
+    status: 'ok'
   },
   {
     capabilities: [
@@ -39,27 +45,32 @@ export const regions: Region[] = [
       'Object Storage'
     ],
     country: 'us',
-    id: 'us-east'
+    id: 'us-east',
+    status: 'ok'
   },
   {
     capabilities: ['Linodes', 'NodeBalancers', 'Block Storage'],
     country: 'uk',
-    id: 'eu-west'
+    id: 'eu-west',
+    status: 'ok'
   },
   {
     capabilities: ['Linodes', 'NodeBalancers', 'Block Storage'],
     country: 'sg',
-    id: 'ap-south'
+    id: 'ap-south',
+    status: 'ok'
   },
   {
     capabilities: ['Linodes', 'NodeBalancers', 'Block Storage'],
     country: 'de',
-    id: 'eu-central'
+    id: 'eu-central',
+    status: 'ok'
   },
   {
     capabilities: ['Linodes', 'NodeBalancers', 'Block Storage'],
     country: 'jp',
-    id: 'ap-northeast'
+    id: 'ap-northeast',
+    status: 'ok'
   }
 ];
 

--- a/packages/manager/src/components/RegionStatusBanner/RegionStatusBanner.test.tsx
+++ b/packages/manager/src/components/RegionStatusBanner/RegionStatusBanner.test.tsx
@@ -1,0 +1,50 @@
+import { cleanup } from '@testing-library/react';
+import * as React from 'react';
+import { regionFactory } from 'src/factories/regions';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+import { CombinedProps, RegionStatusBanner } from './RegionStatusBanner';
+
+afterEach(cleanup);
+
+const props = (regionsData: any): CombinedProps => ({
+  regionsData,
+  regionsLoading: false,
+  regionsLastUpdated: Date.now()
+});
+
+describe('Region status banner', () => {
+  it('should render null if there are no warnings', () => {
+    const regions = regionFactory.buildList(10);
+    expect(RegionStatusBanner(props(regions))).toBeNull();
+  });
+
+  it("should render a banner for each region with a status of 'outage'", () => {
+    const regions = regionFactory.buildList(5, { status: 'outage' });
+    const { queryAllByText } = renderWithTheme(
+      <RegionStatusBanner {...props(regions)} />
+    );
+    expect(queryAllByText(/we are aware/i)).toHaveLength(5);
+  });
+
+  it('should filter out regions with no issues', () => {
+    const regions = [
+      ...regionFactory.buildList(3, { status: 'outage' }),
+      ...regionFactory.buildList(2, { status: 'ok' })
+    ];
+    const { queryAllByText } = renderWithTheme(
+      <RegionStatusBanner {...props(regions)} />
+    );
+    expect(queryAllByText(/we are aware/i)).toHaveLength(3);
+  });
+
+  it('should include the name of a problem region', () => {
+    const regions = regionFactory.buildList(1, {
+      id: 'us-east',
+      status: 'outage'
+    });
+    const { getByText } = renderWithTheme(
+      <RegionStatusBanner {...props(regions)} />
+    );
+    getByText(/Newark, NJ/);
+  });
+});

--- a/packages/manager/src/components/RegionStatusBanner/RegionStatusBanner.test.tsx
+++ b/packages/manager/src/components/RegionStatusBanner/RegionStatusBanner.test.tsx
@@ -4,7 +4,10 @@ import { regionFactory } from 'src/factories/regions';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 import { CombinedProps, RegionStatusBanner } from './RegionStatusBanner';
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  regionFactory.resetSequenceNumber();
+});
 
 const props = (regionsData: any): CombinedProps => ({
   regionsData,
@@ -14,37 +17,39 @@ const props = (regionsData: any): CombinedProps => ({
 
 describe('Region status banner', () => {
   it('should render null if there are no warnings', () => {
-    const regions = regionFactory.buildList(10);
+    const regions = regionFactory.buildList(5);
     expect(RegionStatusBanner(props(regions))).toBeNull();
   });
 
-  it("should render a banner for each region with a status of 'outage'", () => {
-    const regions = regionFactory.buildList(5, { status: 'outage' });
-    const { queryAllByText } = renderWithTheme(
+  it("should render the region's name, and not a list, for a single affected region", () => {
+    const regions = regionFactory.build({
+      status: 'outage',
+      id: 'us-east'
+    });
+    const { queryAllByText, queryAllByTestId } = renderWithTheme(
+      <RegionStatusBanner {...props([regions])} />
+    );
+    expect(queryAllByText(/Newark, NJ/i)).toHaveLength(1);
+    expect(queryAllByTestId(/facility-outage/)).toHaveLength(0);
+  });
+
+  it("should render a list with each region with a status of 'outage' when there are more than one such region", () => {
+    const regions = regionFactory.buildList(5, {
+      status: 'outage'
+    });
+    const { queryAllByTestId } = renderWithTheme(
       <RegionStatusBanner {...props(regions)} />
     );
-    expect(queryAllByText(/we are aware/i)).toHaveLength(5);
+    expect(queryAllByTestId(/facility-outage/)).toHaveLength(5);
   });
 
   it('should filter out regions with no issues', () => {
-    const regions = [
-      ...regionFactory.buildList(3, { status: 'outage' }),
-      ...regionFactory.buildList(2, { status: 'ok' })
-    ];
-    const { queryAllByText } = renderWithTheme(
+    const badRegions = regionFactory.buildList(3, { status: 'outage' });
+    const goodRegions = regionFactory.buildList(2, { status: 'ok' });
+    const regions = [...badRegions, ...goodRegions];
+    const { queryAllByTestId } = renderWithTheme(
       <RegionStatusBanner {...props(regions)} />
     );
-    expect(queryAllByText(/we are aware/i)).toHaveLength(3);
-  });
-
-  it('should include the name of a problem region', () => {
-    const regions = regionFactory.buildList(1, {
-      id: 'us-east',
-      status: 'outage'
-    });
-    const { getByText } = renderWithTheme(
-      <RegionStatusBanner {...props(regions)} />
-    );
-    getByText(/Newark, NJ/);
+    expect(queryAllByTestId(/facility-outage/)).toHaveLength(3);
   });
 });

--- a/packages/manager/src/components/RegionStatusBanner/RegionStatusBanner.tsx
+++ b/packages/manager/src/components/RegionStatusBanner/RegionStatusBanner.tsx
@@ -10,23 +10,46 @@ import RegionsContainer, {
 
 export type CombinedProps = RegionsProps;
 
-const getFacilitiesText = (warnings: string[]) => {
-  return warnings.map(thisWarning => (
-    <li key={`facility-outage-${thisWarning}`}>{thisWarning}</li>
-  ));
-};
+const getFacilitiesList = (warnings: string[]) => (
+  <ul>
+    {warnings.map(thisWarning => (
+      <li
+        key={`facility-outage-${thisWarning}`}
+        data-testid={`facility-outage-${thisWarning}`}
+      >
+        {thisWarning}
+      </li>
+    ))}
+  </ul>
+);
 
-const renderBanner = (statusWarnings: string[]) => {
-  const facilitiesList = getFacilitiesText(statusWarnings);
+/**
+ * Takes an array of region display names and outputs the appropriate
+ * notice display.
+ *
+ * Includes conditional logic to show a list in the (rare) case that
+ * more than one region is affected. Since most outages only affect
+ * a single region, I thought the more compact display of a single
+ * region in that case was worth the cost in complexity.
+ *
+ * @param statusWarnings
+ */
+const renderBanner = (statusWarnings: string[]): JSX.Element => {
+  const moreThanOneRegionAffected = statusWarnings.length > 1;
   return (
     <>
       <Typography variant="h3" style={{ paddingBottom: '5px' }}>
-        We are aware of an issue affecting service in the following facilities:
+        We are aware of an issue affecting service in {` `}
+        {moreThanOneRegionAffected
+          ? 'the following facilities:'
+          : `our ${statusWarnings[0]} facility.`}
       </Typography>
-      <ul>{facilitiesList}</ul>
+      {moreThanOneRegionAffected && getFacilitiesList(statusWarnings)}
       <Typography>
-        If you are experiencing service issues in this facility, there is no
-        need to open a support ticket at this time. Please monitor our{` `}
+        If you are experiencing service issues in{' '}
+        {moreThanOneRegionAffected ? 'these facilities' : 'this facility'},
+        there is no need to open a support ticket at this time. Please monitor
+        our{` `}
         <ExternalLink
           link="https://status.linode.com"
           text="status blog"

--- a/packages/manager/src/components/RegionStatusBanner/RegionStatusBanner.tsx
+++ b/packages/manager/src/components/RegionStatusBanner/RegionStatusBanner.tsx
@@ -38,6 +38,10 @@ export const RegionStatusBanner: React.FC<CombinedProps> = props => {
     thisRegion => thisRegion.status === 'outage'
   );
 
+  if (statusWarnings.length === 0) {
+    return null;
+  }
+
   return (
     <>
       {statusWarnings.map(thisWarning => (

--- a/packages/manager/src/components/RegionStatusBanner/RegionStatusBanner.tsx
+++ b/packages/manager/src/components/RegionStatusBanner/RegionStatusBanner.tsx
@@ -10,13 +10,20 @@ import RegionsContainer, {
 
 export type CombinedProps = RegionsProps;
 
-const renderBanner = (regionID: string) => {
+const getFacilitiesText = (warnings: string[]) => {
+  return warnings.map(thisWarning => (
+    <li key={`facility-outage-${thisWarning}`}>{thisWarning}</li>
+  ));
+};
+
+const renderBanner = (statusWarnings: string[]) => {
+  const facilitiesList = getFacilitiesText(statusWarnings);
   return (
     <>
       <Typography variant="h3" style={{ paddingBottom: '5px' }}>
-        We are aware of an issue affecting service in our{' '}
-        {dcDisplayNames[regionID]} facility.
+        We are aware of an issue affecting service in the following facilities:
       </Typography>
+      <ul>{facilitiesList}</ul>
       <Typography>
         If you are experiencing service issues in this facility, there is no
         need to open a support ticket at this time. Please monitor our{` `}
@@ -34,26 +41,18 @@ const renderBanner = (regionID: string) => {
 export const RegionStatusBanner: React.FC<CombinedProps> = props => {
   const { regionsData } = props;
 
-  const statusWarnings = regionsData.filter(
-    thisRegion => thisRegion.status === 'outage'
-  );
+  const statusWarnings = regionsData
+    .filter(
+      thisRegion =>
+        thisRegion.status === 'outage' && !!dcDisplayNames[thisRegion.id]
+    )
+    .map(thisRegion => dcDisplayNames[thisRegion.id]);
 
   if (statusWarnings.length === 0) {
     return null;
   }
 
-  return (
-    <>
-      {statusWarnings.map(thisWarning => (
-        <Notice
-          key={`status-banner-${thisWarning.id}`}
-          warning
-          important
-          text={renderBanner(thisWarning.id)}
-        />
-      ))}
-    </>
-  );
+  return <Notice warning important text={renderBanner(statusWarnings)} />;
 };
 
 const withRegions = RegionsContainer(({ data, loading, error }) => ({

--- a/packages/manager/src/components/RegionStatusBanner/RegionStatusBanner.tsx
+++ b/packages/manager/src/components/RegionStatusBanner/RegionStatusBanner.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import { compose } from 'recompose';
+import Typography from 'src/components/core/Typography';
+import ExternalLink from 'src/components/ExternalLink';
+import Notice from 'src/components/Notice';
+import { dcDisplayNames } from 'src/constants';
+import RegionsContainer, {
+  DefaultProps as RegionsProps
+} from 'src/containers/regions.container';
+
+export type CombinedProps = RegionsProps;
+
+const renderBanner = (regionID: string) => {
+  return (
+    <>
+      <Typography variant="h3" style={{ paddingBottom: '5px' }}>
+        We are aware of an issue affecting service in our{' '}
+        {dcDisplayNames[regionID]} facility.
+      </Typography>
+      <Typography>
+        If you are experiencing service issues in this facility, there is no
+        need to open a support ticket at this time. Please monitor our{` `}
+        <ExternalLink
+          link="https://status.linode.com"
+          text="status blog"
+          hideIcon
+        />{' '}
+        for further information. Thank you for your patience and understanding.
+      </Typography>
+    </>
+  );
+};
+
+export const RegionStatusBanner: React.FC<CombinedProps> = props => {
+  const { regionsData } = props;
+
+  const statusWarnings = regionsData.filter(
+    thisRegion => thisRegion.status === 'outage'
+  );
+
+  return (
+    <>
+      {statusWarnings.map(thisWarning => (
+        <Notice
+          key={`status-banner-${thisWarning.id}`}
+          warning
+          important
+          text={renderBanner(thisWarning.id)}
+        />
+      ))}
+    </>
+  );
+};
+
+const withRegions = RegionsContainer(({ data, loading, error }) => ({
+  regionsData: data,
+  regionsLoading: loading,
+  regionsError: error
+}));
+
+const enhanced = compose<CombinedProps, {}>(withRegions);
+
+export default enhanced(RegionStatusBanner);

--- a/packages/manager/src/components/RegionStatusBanner/index.tsx
+++ b/packages/manager/src/components/RegionStatusBanner/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './RegionStatusBanner';

--- a/packages/manager/src/factories/regions.ts
+++ b/packages/manager/src/factories/regions.ts
@@ -1,0 +1,9 @@
+import * as Factory from 'factory.ts';
+import { Region } from 'linode-js-sdk/lib/regions/types';
+
+export const regionFactory = Factory.Sync.makeFactory<Region>({
+  id: Factory.each(id => `us-east-${id}`),
+  status: 'ok',
+  country: 'US',
+  capabilities: ['Block Storage']
+});

--- a/packages/manager/src/factories/regions.ts
+++ b/packages/manager/src/factories/regions.ts
@@ -1,8 +1,9 @@
 import * as Factory from 'factory.ts';
 import { Region } from 'linode-js-sdk/lib/regions/types';
+import { dcDisplayNames } from 'src/constants';
 
 export const regionFactory = Factory.Sync.makeFactory<Region>({
-  id: Factory.each(id => `us-east-${id}`),
+  id: Factory.each(id => Object.keys(dcDisplayNames)[id + 1] || `region-${id}`),
   status: 'ok',
   country: 'US',
   capabilities: ['Block Storage']

--- a/packages/manager/src/features/Dashboard/Dashboard.tsx
+++ b/packages/manager/src/features/Dashboard/Dashboard.tsx
@@ -18,6 +18,7 @@ import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
 import H1Header from 'src/components/H1Header';
 import MaintenanceBanner from 'src/components/MaintenanceBanner';
+import RegionStatusBanner from 'src/components/RegionStatusBanner';
 import TaxBanner from 'src/components/TaxBanner';
 import TagImportDrawer from 'src/features/TagImport';
 import useFlags from 'src/hooks/useFlags';
@@ -100,6 +101,7 @@ export const Dashboard: React.StatelessComponent<CombinedProps> = props => {
         />
       )}
       <Grid container spacing={3}>
+        <RegionStatusBanner />
         <AbuseTicketBanner />
         <TaxBanner location={location} marginBottom={8} />
         <DocumentTitleSegment segment="Dashboard" />
@@ -199,16 +201,10 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
   };
 };
 
-const connected = connect(
-  mapStateToProps,
-  mapDispatchToProps
-);
+const connected = connect(mapStateToProps, mapDispatchToProps);
 
 const styled = withStyles(styles, { withTheme: true });
 
-const enhanced = compose<CombinedProps, {}>(
-  styled,
-  connected
-)(Dashboard);
+const enhanced = compose<CombinedProps, {}>(styled, connected)(Dashboard);
 
 export default enhanced;

--- a/packages/manager/src/features/Dashboard/Dashboard.tsx
+++ b/packages/manager/src/features/Dashboard/Dashboard.tsx
@@ -18,7 +18,6 @@ import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
 import H1Header from 'src/components/H1Header';
 import MaintenanceBanner from 'src/components/MaintenanceBanner';
-import RegionStatusBanner from 'src/components/RegionStatusBanner';
 import TaxBanner from 'src/components/TaxBanner';
 import TagImportDrawer from 'src/features/TagImport';
 import useFlags from 'src/hooks/useFlags';
@@ -101,7 +100,6 @@ export const Dashboard: React.StatelessComponent<CombinedProps> = props => {
         />
       )}
       <Grid container spacing={3}>
-        <RegionStatusBanner />
         <AbuseTicketBanner />
         <TaxBanner location={location} marginBottom={8} />
         <DocumentTitleSegment segment="Dashboard" />

--- a/packages/manager/src/features/Kubernetes/ClusterList/ClusterList.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/ClusterList.tsx
@@ -21,6 +21,7 @@ import H1Header from 'src/components/H1Header';
 import OrderBy from 'src/components/OrderBy';
 import Paginate from 'src/components/Paginate';
 import PaginationFooter from 'src/components/PaginationFooter';
+import RegionStatusBanner from 'src/components/RegionStatusBanner';
 import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
 import TableSortCell from 'src/components/TableSortCell';
@@ -122,6 +123,7 @@ export const ClusterList: React.FunctionComponent<CombinedProps> = props => {
   return (
     <React.Fragment>
       <DocumentTitleSegment segment="Kubernetes Clusters" />
+      <RegionStatusBanner />
       <Grid
         container
         justify="space-between"
@@ -260,9 +262,6 @@ export const ClusterList: React.FunctionComponent<CombinedProps> = props => {
 
 const styled = withStyles(styles);
 
-const enhanced = compose<CombinedProps, Props>(
-  styled,
-  withTypes
-);
+const enhanced = compose<CombinedProps, Props>(styled, withTypes);
 
 export default enhanced(ClusterList);

--- a/packages/manager/src/features/Kubernetes/ClusterList/ClusterList.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/ClusterList.tsx
@@ -21,7 +21,6 @@ import H1Header from 'src/components/H1Header';
 import OrderBy from 'src/components/OrderBy';
 import Paginate from 'src/components/Paginate';
 import PaginationFooter from 'src/components/PaginationFooter';
-import RegionStatusBanner from 'src/components/RegionStatusBanner';
 import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
 import TableSortCell from 'src/components/TableSortCell';
@@ -123,7 +122,6 @@ export const ClusterList: React.FunctionComponent<CombinedProps> = props => {
   return (
     <React.Fragment>
       <DocumentTitleSegment segment="Kubernetes Clusters" />
-      <RegionStatusBanner />
       <Grid
         container
         justify="space-between"

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.tsx
@@ -27,6 +27,7 @@ import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
 import OrderBy from 'src/components/OrderBy';
+import RegionStatusBanner from 'src/components/RegionStatusBanner';
 import SectionErrorBoundary from 'src/components/SectionErrorBoundary';
 import Toggle from 'src/components/Toggle';
 import {
@@ -235,6 +236,7 @@ export class NodeBalancersLanding extends React.Component<
     return (
       <React.Fragment>
         <DocumentTitleSegment segment="NodeBalancers" />
+        <RegionStatusBanner />
         <PreferenceToggle<boolean>
           preferenceKey="nodebalancers_group_by_tag"
           preferenceOptions={[false, true]}

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.tsx
@@ -27,7 +27,6 @@ import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
 import OrderBy from 'src/components/OrderBy';
-import RegionStatusBanner from 'src/components/RegionStatusBanner';
 import SectionErrorBoundary from 'src/components/SectionErrorBoundary';
 import Toggle from 'src/components/Toggle';
 import {
@@ -236,7 +235,6 @@ export class NodeBalancersLanding extends React.Component<
     return (
       <React.Fragment>
         <DocumentTitleSegment segment="NodeBalancers" />
-        <RegionStatusBanner />
         <PreferenceToggle<boolean>
           preferenceKey="nodebalancers_group_by_tag"
           preferenceOptions={[false, true]}

--- a/packages/manager/src/features/ObjectStorage/ObjectStorageLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectStorageLanding.tsx
@@ -23,7 +23,6 @@ import Tabs from 'src/components/core/Tabs';
 import DefaultLoader from 'src/components/DefaultLoader';
 import DocumentationButton from 'src/components/DocumentationButton';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
-import RegionStatusBanner from 'src/components/RegionStatusBanner';
 import TabLink from 'src/components/TabLink';
 import { ApplicationState } from 'src/store';
 import { getAllBuckets } from 'src/store/bucket/bucket.requests';
@@ -104,7 +103,6 @@ export const ObjectStorageLanding: React.FunctionComponent<CombinedProps> = prop
   return (
     <React.Fragment>
       <DocumentTitleSegment segment="Object Storage" />
-      <RegionStatusBanner />
       <Box display="flex" flexDirection="row" justifyContent="space-between">
         <Breadcrumb
           pathname={props.location.pathname}

--- a/packages/manager/src/features/ObjectStorage/ObjectStorageLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectStorageLanding.tsx
@@ -23,6 +23,7 @@ import Tabs from 'src/components/core/Tabs';
 import DefaultLoader from 'src/components/DefaultLoader';
 import DocumentationButton from 'src/components/DocumentationButton';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import RegionStatusBanner from 'src/components/RegionStatusBanner';
 import TabLink from 'src/components/TabLink';
 import { ApplicationState } from 'src/store';
 import { getAllBuckets } from 'src/store/bucket/bucket.requests';
@@ -40,9 +41,7 @@ const AccessKeyLanding = DefaultLoader({
 
 type CombinedProps = StateProps & DispatchProps & RouteComponentProps<{}>;
 
-export const ObjectStorageLanding: React.FunctionComponent<
-  CombinedProps
-> = props => {
+export const ObjectStorageLanding: React.FunctionComponent<CombinedProps> = props => {
   const tabs = [
     /* NB: These must correspond to the routes inside the Switch */
     {
@@ -105,6 +104,7 @@ export const ObjectStorageLanding: React.FunctionComponent<
   return (
     <React.Fragment>
       <DocumentTitleSegment segment="Object Storage" />
+      <RegionStatusBanner />
       <Box display="flex" flexDirection="row" justifyContent="space-between">
         <Breadcrumb
           pathname={props.location.pathname}
@@ -192,10 +192,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
   };
 };
 
-export const connected = connect(
-  mapStateToProps,
-  mapDispatchToProps
-);
+export const connected = connect(mapStateToProps, mapDispatchToProps);
 
 const enhanced = compose<CombinedProps, {}>(connected);
 export default enhanced(ObjectStorageLanding);

--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
@@ -24,6 +24,7 @@ import Drawer from 'src/components/Drawer';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import ExpansionPanel from 'src/components/ExpansionPanel';
 import Notice from 'src/components/Notice';
+import RegionStatusBanner from 'src/components/RegionStatusBanner';
 import SectionErrorBoundary from 'src/components/SectionErrorBoundary';
 import TextField from 'src/components/TextField';
 import { getNodeBalancers } from 'src/services/nodebalancers';
@@ -475,6 +476,7 @@ export class SupportTicketDrawer extends React.Component<CombinedProps, State> {
         onClose={this.props.onClose}
         title="Open a Support Ticket"
       >
+        <RegionStatusBanner />
         {this.props.children || (
           <React.Fragment>
             {generalError && (
@@ -592,6 +594,7 @@ export class SupportTicketDrawer extends React.Component<CombinedProps, State> {
 
 const styled = withStyles(styles);
 
-export default recompose<CombinedProps, Props>(styled, SectionErrorBoundary)(
-  SupportTicketDrawer
-);
+export default recompose<CombinedProps, Props>(
+  styled,
+  SectionErrorBoundary
+)(SupportTicketDrawer);

--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
@@ -24,7 +24,6 @@ import Drawer from 'src/components/Drawer';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import ExpansionPanel from 'src/components/ExpansionPanel';
 import Notice from 'src/components/Notice';
-import RegionStatusBanner from 'src/components/RegionStatusBanner';
 import SectionErrorBoundary from 'src/components/SectionErrorBoundary';
 import TextField from 'src/components/TextField';
 import { getNodeBalancers } from 'src/services/nodebalancers';
@@ -476,7 +475,6 @@ export class SupportTicketDrawer extends React.Component<CombinedProps, State> {
         onClose={this.props.onClose}
         title="Open a Support Ticket"
       >
-        <RegionStatusBanner />
         {this.props.children || (
           <React.Fragment>
             {generalError && (

--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -24,7 +24,6 @@ import Grid from 'src/components/Grid';
 import OrderBy from 'src/components/OrderBy';
 import { PaginationProps } from 'src/components/Pagey';
 import Placeholder from 'src/components/Placeholder';
-import RegionStatusBanner from 'src/components/RegionStatusBanner';
 import Toggle from 'src/components/Toggle';
 import _withEvents, { EventsProps } from 'src/containers/events.container';
 import withVolumes, {
@@ -328,7 +327,6 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
     return (
       <React.Fragment>
         <DocumentTitleSegment segment="Volumes" />
-        <RegionStatusBanner />
         {readOnly && <LinodePermissionsError />}
         <PreferenceToggle<boolean>
           preferenceKey="volumes_group_by_tag"

--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -24,6 +24,7 @@ import Grid from 'src/components/Grid';
 import OrderBy from 'src/components/OrderBy';
 import { PaginationProps } from 'src/components/Pagey';
 import Placeholder from 'src/components/Placeholder';
+import RegionStatusBanner from 'src/components/RegionStatusBanner';
 import Toggle from 'src/components/Toggle';
 import _withEvents, { EventsProps } from 'src/containers/events.container';
 import withVolumes, {
@@ -327,6 +328,7 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
     return (
       <React.Fragment>
         <DocumentTitleSegment segment="Volumes" />
+        <RegionStatusBanner />
         {readOnly && <LinodePermissionsError />}
         <PreferenceToggle<boolean>
           preferenceKey="volumes_group_by_tag"
@@ -656,10 +658,7 @@ const mapDispatchToProps = (dispatch: Dispatch<any>) =>
     dispatch
   );
 
-const connected = connect(
-  undefined,
-  mapDispatchToProps
-);
+const connected = connect(undefined, mapDispatchToProps);
 
 const documented = setDocs(VolumesLanding.docs);
 

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -530,9 +530,6 @@ const mapDispatchToProps: MapDispatchToProps<
   setTab: value => dispatch(handleChangeCreateType(value))
 });
 
-const connected = connect(
-  undefined,
-  mapDispatchToProps
-);
+const connected = connect(undefined, mapDispatchToProps);
 
 export default connected(LinodeCreate);

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -30,7 +30,6 @@ import {
 import Breadcrumb from 'src/components/Breadcrumb';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
-import RegionStatusBanner from 'src/components/RegionStatusBanner';
 import { Tag } from 'src/components/TagsInput';
 
 import { dcDisplayNames } from 'src/constants';
@@ -564,7 +563,6 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
     return (
       <StickyContainer>
         <DocumentTitleSegment segment="Create a Linode" />
-        <RegionStatusBanner />
         <Grid container spacing={0}>
           <Grid item xs={12}>
             <Breadcrumb

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -30,6 +30,7 @@ import {
 import Breadcrumb from 'src/components/Breadcrumb';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
+import RegionStatusBanner from 'src/components/RegionStatusBanner';
 import { Tag } from 'src/components/TagsInput';
 
 import { dcDisplayNames } from 'src/constants';
@@ -563,6 +564,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
     return (
       <StickyContainer>
         <DocumentTitleSegment segment="Create a Linode" />
+        <RegionStatusBanner />
         <Grid container spacing={0}>
           <Grid item xs={12}>
             <Breadcrumb
@@ -628,10 +630,7 @@ interface DispatchProps {
   upsertLinode: (l: Linode) => void;
 }
 
-const connected = connect(
-  mapStateToProps,
-  { upsertLinode }
-);
+const connected = connect(mapStateToProps, { upsertLinode });
 
 const withRegions = regionsContainer(({ data, loading, error }) => ({
   regionsData: data.map(r => ({ ...r, display: dcDisplayNames[r.id] })),

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.test.tsx
@@ -43,7 +43,9 @@ describe('LinodeActionMenu', () => {
     it('includes `regionID` param if valid region', () => {
       wrapper.setProps({
         linodeRegion: 'us-east',
-        regionsData: [{ id: 'us-east', country: 'us', capabilities: [] }]
+        regionsData: [
+          { id: 'us-east', country: 'us', capabilities: [], status: 'ok' }
+        ]
       });
       expect(wrapper.instance().buildQueryStringForLinodeClone()).toMatch(
         'regionID=us-east'

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -20,7 +20,6 @@ import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
 import OrderBy from 'src/components/OrderBy';
-import RegionStatusBanner from 'src/components/RegionStatusBanner';
 import Toggle from 'src/components/Toggle';
 import withBackupCta, {
   BackupCTAProps
@@ -244,7 +243,6 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
           >
             <Grid container>
               <DocumentTitleSegment segment="Linodes" />
-              <RegionStatusBanner />
               <PreferenceToggle<boolean>
                 localStorageKey="GROUP_LINODES"
                 preferenceOptions={[false, true]}

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -20,6 +20,7 @@ import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
 import OrderBy from 'src/components/OrderBy';
+import RegionStatusBanner from 'src/components/RegionStatusBanner';
 import Toggle from 'src/components/Toggle';
 import withBackupCta, {
   BackupCTAProps
@@ -243,6 +244,7 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
           >
             <Grid container>
               <DocumentTitleSegment segment="Linodes" />
+              <RegionStatusBanner />
               <PreferenceToggle<boolean>
                 localStorageKey="GROUP_LINODES"
                 preferenceOptions={[false, true]}
@@ -515,10 +517,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
   deleteLinode: (linodeId: number) => dispatch(deleteLinode({ linodeId }))
 });
 
-const connected = connect(
-  mapStateToProps,
-  mapDispatchToProps
-);
+const connected = connect(mapStateToProps, mapDispatchToProps);
 
 const updateParams = <T extends any>(params: string, updater: (s: T) => T) => {
   const paramsAsObject: T = parse(params, { ignoreQueryPrefix: true });

--- a/packages/manager/src/store/regions/regions.reducer.ts
+++ b/packages/manager/src/store/regions/regions.reducer.ts
@@ -29,7 +29,6 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
 
     if (isType(action, regionsRequestActions.done)) {
       const { result } = action.payload;
-
       draft.loading = false;
       draft.lastUpdated = Date.now();
       draft.entities = result;

--- a/packages/manager/src/store/regions/regions.reducer.ts
+++ b/packages/manager/src/store/regions/regions.reducer.ts
@@ -38,6 +38,12 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
           status: 'outage',
           capabilities: [],
           country: 'US'
+        },
+        {
+          id: 'ap-south',
+          status: 'outage',
+          capabilities: [],
+          country: 'JP'
         }
       ];
       draft.results = result.map(r => r.id);

--- a/packages/manager/src/store/regions/regions.reducer.ts
+++ b/packages/manager/src/store/regions/regions.reducer.ts
@@ -31,7 +31,15 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
       const { result } = action.payload;
       draft.loading = false;
       draft.lastUpdated = Date.now();
-      draft.entities = result;
+      draft.entities = [
+        ...result,
+        {
+          id: 'us-east',
+          status: 'outage',
+          capabilities: [],
+          country: 'US'
+        }
+      ];
       draft.results = result.map(r => r.id);
     }
 

--- a/packages/manager/src/store/regions/regions.reducer.ts
+++ b/packages/manager/src/store/regions/regions.reducer.ts
@@ -31,21 +31,7 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
       const { result } = action.payload;
       draft.loading = false;
       draft.lastUpdated = Date.now();
-      draft.entities = [
-        ...result,
-        {
-          id: 'us-east',
-          status: 'outage',
-          capabilities: [],
-          country: 'US'
-        },
-        {
-          id: 'ap-south',
-          status: 'outage',
-          capabilities: [],
-          country: 'JP'
-        }
-      ];
+      draft.entities = result;
       draft.results = result.map(r => r.id);
     }
 


### PR DESCRIPTION
## Description

Add a banner to the top of all relevant pages (and to the support
ticket drawer) if any region returns a status of "outage". If multiple
regions have outages, the notices will stack.

This was our first use of the region.status field, so we had to update
typings and test data to respect the new API response.

## Notes

We could do this site-wide in App.tsx, but the AC made it clear that it should only be on relevant pages so I took my best guess at what counted (Domains don't, OBJ does). Feedback welcome.


To test, replace line 34 of `src/store/regions/regions.reducer.ts` with the following: 
```
draft.entities = [
        ...result,
        {
          id: 'us-east',
          status: 'outage',
          capabilities: [],
          country: 'US'
        }
      ];
```

To test multiple outages, use:
```
{
          id: 'us-east',
          status: 'outage',
          capabilities: [],
          country: 'US'
        }
        // {
        //   id: 'ap-south',
        //   status: 'outage',
        //   capabilities: [],
        //   country: 'JP'
        // }
```
