### PR TITLE
M3-3780 Add "Show All" option to Domain Records

### DIFF
--- a/packages/manager/src/features/Domains/DomainRecords.tsx
+++ b/packages/manager/src/features/Domains/DomainRecords.tsx
@@ -48,6 +48,7 @@ import {
   getErrorStringOrDefault
 } from 'src/utilities/errorUtils';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
+import { storage } from 'src/utilities/storage';
 import ActionMenu from './DomainRecordActionMenu';
 import Drawer from './DomainRecordDrawer';
 
@@ -282,31 +283,19 @@ class DomainRecords extends React.Component<CombinedProps, State> {
         },
         {
           title: 'Default TTL',
-          render: compose(
-            msToReadable,
-            pathOr(0, ['ttl_sec'])
-          )
+          render: compose(msToReadable, pathOr(0, ['ttl_sec']))
         },
         {
           title: 'Refresh Rate',
-          render: compose(
-            msToReadable,
-            pathOr(0, ['refresh_sec'])
-          )
+          render: compose(msToReadable, pathOr(0, ['refresh_sec']))
         },
         {
           title: 'Retry Rate',
-          render: compose(
-            msToReadable,
-            pathOr(0, ['retry_sec'])
-          )
+          render: compose(msToReadable, pathOr(0, ['retry_sec']))
         },
         {
           title: 'Expire Time',
-          render: compose(
-            msToReadable,
-            pathOr(0, ['expire_sec'])
-          )
+          render: compose(msToReadable, pathOr(0, ['expire_sec']))
         },
         {
           title: '',
@@ -708,7 +697,12 @@ class DomainRecords extends React.Component<CombinedProps, State> {
               >
                 {({ data: orderedData, handleOrderChange, order, orderBy }) => {
                   return (
-                    <Paginate data={orderedData} scrollToRef={ref}>
+                    <Paginate
+                      data={orderedData}
+                      scrollToRef={ref}
+                      pageSize={storage.infinitePageSize.get()}
+                      pageSizeSetter={storage.infinitePageSize.set}
+                    >
                       {({
                         count,
                         data: paginatedData,
@@ -779,6 +773,7 @@ class DomainRecords extends React.Component<CombinedProps, State> {
                               page={page}
                               pageSize={pageSize}
                               eventCategory={`${type.title.toLowerCase()} panel`}
+                              showAll
                             />
                           </>
                         );
@@ -835,10 +830,7 @@ const msToReadable = (v: number): null | string =>
     2419200: '4 weeks'
   });
 
-const getTTL = compose(
-  msToReadable,
-  pathOr(0, ['ttl_sec'])
-);
+const getTTL = compose(msToReadable, pathOr(0, ['ttl_sec']));
 
 const typeEq = propEq('type');
 
@@ -918,11 +910,7 @@ const getNSRecords = compose<
   DomainRecord[],
   DomainRecord[],
   DomainRecord[]
->(
-  prependLinodeNS,
-  filter(typeEq('NS')),
-  pathOr([], ['domainRecords'])
-);
+>(prependLinodeNS, filter(typeEq('NS')), pathOr([], ['domainRecords']));
 
 const styled = withStyles(styles);
 


### PR DESCRIPTION
## Description

This uses the same local storage key as Linodes, Domains, Volumes, and NodeBalancers, so if you select "Show All" on one of those pages, you'll see all of your Domain Records listed as well.

If we don't like this approach, we could make the Domain Records pagination independent or not saved in local storage at all. 

**Side note:** there are some serious performance problems when you have a ton of records on the page (at least running a dev server). E.g. try opening a drawer... all the record rows are re-rendered. Creating a ticket to address separately.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Use production test account #1, Domain "many-domain-records" for a Domain with 150 CNAME records.
