### PR TITLE
M3-3717 StackScript author links

### DIFF
--- a/packages/manager/src/components/DebouncedSearchTextField/DebouncedSearchTextField.tsx
+++ b/packages/manager/src/components/DebouncedSearchTextField/DebouncedSearchTextField.tsx
@@ -23,6 +23,7 @@ interface Props extends TextFieldProps {
   placeholder?: string;
   label: string;
   hideLabel?: boolean;
+  defaultValue?: string;
 }
 
 type CombinedProps = Props;
@@ -37,6 +38,7 @@ const DebouncedSearch: React.FC<CombinedProps> = props => {
     placeholder,
     label,
     hideLabel,
+    defaultValue,
     ...restOfTextFieldProps
   } = props;
   const [query, setQuery] = React.useState<string>('');
@@ -50,7 +52,7 @@ const DebouncedSearch: React.FC<CombinedProps> = props => {
       See: https://github.com/facebook/react/issues/14369#issuecomment-468267798
     */
     let didCancel = false;
-    /* 
+    /*
       don't run the search if the query hasn't changed.
       This is mostly to prevent this effect from running on first mount
     */
@@ -76,6 +78,7 @@ const DebouncedSearch: React.FC<CombinedProps> = props => {
       className={className}
       placeholder={placeholder || 'Filter by query'}
       onChange={_setQuery}
+      defaultValue={defaultValue}
       label={label}
       hideLabel={hideLabel}
       InputProps={{

--- a/packages/manager/src/components/StackScript/StackScript.tsx
+++ b/packages/manager/src/components/StackScript/StackScript.tsx
@@ -15,8 +15,8 @@ import DateTimeDisplay from 'src/components/DateTimeDisplay';
 import ExternalLink from 'src/components/ExternalLink';
 import H1Header from 'src/components/H1Header';
 import ScriptCode from 'src/components/ScriptCode';
+import { APP_ROOT } from 'src/constants';
 import withImages from 'src/containers/withImages.container';
-
 import { filterImagesByType } from 'src/store/image/image.helpers';
 
 type CSSClasses =
@@ -131,7 +131,7 @@ export class _StackScript extends React.Component<CombinedProps> {
           by&nbsp;
           <ExternalLink
             text={username}
-            link={`https://www.linode.com/stackscripts/profile/${username}`}
+            link={`${APP_ROOT}/stackscripts?type=community&query=username:${username}`}
             data-qa-community-stack-link
           />
         </Typography>

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -25,6 +25,7 @@ import { MapState } from 'src/store/types';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { sendStackscriptsSearchEvent } from 'src/utilities/ga';
 import { handleUnauthorizedErrors } from 'src/utilities/handleUnauthorizedErrors';
+import { getQueryParam } from 'src/utilities/queryParams';
 import StackScriptTableHead from '../Partials/StackScriptTableHead';
 import {
   AcceptedFilters,
@@ -119,6 +120,13 @@ const withStackScriptBase = (isSelecting: boolean) => (
 
     componentDidMount() {
       this.mounted = true;
+
+      // If the URL contains a QS param called "query" treat it as a filter.
+      const query = getQueryParam(this.props.location.search, 'query');
+      if (query) {
+        return this.handleSearch(query);
+      }
+
       return this.getDataAtPage(1);
     }
 
@@ -178,8 +186,8 @@ const withStackScriptBase = (isSelecting: boolean) => (
           // AND the filtered data set is 0 before we request the next page automatically
           if (
             isSorting &&
-            (newData.length !== 0 &&
-              newDataWithoutDeprecatedDistros.length === 0)
+            newData.length !== 0 &&
+            newDataWithoutDeprecatedDistros.length === 0
           ) {
             this.getNext();
             return;
@@ -358,7 +366,8 @@ const withStackScriptBase = (isSelecting: boolean) => (
           }
           this.setState({
             listOfStackScripts: response.data,
-            isSearching: false
+            isSearching: false,
+            loading: false
           });
           /*
            * If we're searching for search result, prevent the user
@@ -385,7 +394,8 @@ const withStackScriptBase = (isSelecting: boolean) => (
               e,
               'There was an error loading StackScripts'
             ),
-            isSearching: false
+            isSearching: false,
+            loading: false
           });
         });
     };
@@ -432,6 +442,8 @@ const withStackScriptBase = (isSelecting: boolean) => (
           </div>
         );
       }
+
+      const query = getQueryParam(this.props.location.search, 'query');
 
       return (
         <React.Fragment>
@@ -487,6 +499,7 @@ const withStackScriptBase = (isSelecting: boolean) => (
                   }
                   label="Search by Label, Username, or Description"
                   hideLabel
+                  defaultValue={query}
                 />
               </div>
               <Table
@@ -606,11 +619,7 @@ const withStackScriptBase = (isSelecting: boolean) => (
 
   const connected = connect(mapStateToProps);
 
-  return compose(
-    withRouter,
-    connected,
-    withStyles
-  )(EnhancedComponent);
+  return compose(withRouter, connected, withStyles)(EnhancedComponent);
 };
 
 export default withStackScriptBase;

--- a/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptPanel.test.ts
+++ b/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptPanel.test.ts
@@ -1,0 +1,26 @@
+import { getInitTab, StackScriptTab } from './StackScriptPanel';
+
+describe('getInitTab helper function', () => {
+  const tabs: StackScriptTab[] = [
+    {
+      title: 'Account StackScripts',
+      request: jest.fn(),
+      category: 'account'
+    },
+    {
+      title: 'Community StackScripts',
+      request: jest.fn(),
+      category: 'community'
+    }
+  ];
+  it('provides the index of the desired tab', () => {
+    expect(getInitTab('type=account', tabs)).toBe(0);
+    expect(getInitTab('type=community', tabs)).toBe(1);
+  });
+
+  it('provides the index of the default tab when the given type is not present', () => {
+    expect(getInitTab('type=unknown-type', tabs)).toBe(0);
+    expect(getInitTab('type=unknown-type', tabs, 10)).toBe(10);
+    expect(getInitTab('', tabs, 0)).toBe(0);
+  });
+});

--- a/packages/manager/src/features/StackScripts/StackScriptsLanding.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptsLanding.tsx
@@ -88,7 +88,10 @@ export class StackScriptsLanding extends React.Component<CombinedProps, {}> {
             <CircleProgress />
           ) : (
             <Grid item xs={12}>
-              <StackScriptPanel publicImages={imagesData} />
+              <StackScriptPanel
+                publicImages={imagesData}
+                queryString={this.props.location.search}
+              />
             </Grid>
           )}
         </Grid>


### PR DESCRIPTION
## Description

This PR addresses the fact that StackScript author (in StackScript Details) links recently stopped working.

The original AC was to remove the link entirely, but I realized we could use our own StackScript search if we made a few changes to honor some query params.

Now, `/stackscripts?type=community?query=<query>` does what you'd expect it to. I changed the author links to use this new feature.

## Note to Reviewers

Test that the StackScript Landing and Detail pages work as expect. Try to break it by putting junk in the query string. Also check the StackScript Detail drawer (in the Linode Create flow).