### PR TITLE
API page size from config variable

### DIFF
--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -31,6 +31,11 @@ export const ALGOLIA_SEARCH_KEY =
 export const LAUNCH_DARKLY_API_KEY =
   process.env.REACT_APP_LAUNCH_DARKLY_ID || '';
 
+// Maximum page size allowed by the API. Used in the `getAll()` helper function
+// to request as many items at once as possible.
+export const API_MAX_PAGE_SIZE =
+  Number(process.env.REACT_APP_API_MAX_PAGE_SIZE) || 100;
+
 // Sets Paypal Environment, valid values: 'sandbox|production'
 export const PAYPAL_CLIENT_ENV =
   process.env.REACT_APP_PAYPAL_ENV || 'production';
@@ -316,7 +321,3 @@ export const OBJECT_STORAGE_ROOT = 'linodeobjects.com';
  * to simulate folder traversal of a bucket.
  */
 export const OBJECT_STORAGE_DELIMITER = '/';
-
-// Maximum page size allowed by the API. Used in the `getAll()` helper function
-// to request as many items at once as possible.
-export const MAX_PAGE_SIZE = 200;

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
@@ -180,7 +180,8 @@ type CombinedProps = ContextProps & WithStyles<ClassNames> & DispatchProps;
 // Save some typing below
 export const uniqByIP = uniqBy((thisIP: IPAddress) => thisIP.address);
 
-const getAllIPs = getAll<IPAddress>(getIPs);
+// The API returns an error if more than 100 IPs are requested.
+const getAllIPs = getAll<IPAddress>(getIPs, 100);
 
 class LinodeNetworking extends React.Component<CombinedProps, State> {
   state: State = {
@@ -864,10 +865,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
   upsertLinode: linode => dispatch(_upsertLinode(linode))
 });
 
-const connected = connect(
-  undefined,
-  mapDispatchToProps
-);
+const connected = connect(undefined, mapDispatchToProps);
 
 const enhanced = recompose<CombinedProps, {}>(connected, linodeContext, styled);
 

--- a/packages/manager/src/store/bucket/bucket.requests.ts
+++ b/packages/manager/src/store/bucket/bucket.requests.ts
@@ -29,7 +29,9 @@ export const createBucket = createRequestThunk<
 /*
  * Get All Buckets
  */
-const _getAll = getAll<ObjectStorageBucket>(_getBuckets);
+
+// The API returns an error if more than 100 Buckets are requested.
+const _getAll = getAll<ObjectStorageBucket>(_getBuckets, 100);
 
 const getAllBucketsRequest = () => _getAll().then(({ data }) => data);
 

--- a/packages/manager/src/utilities/getAll.ts
+++ b/packages/manager/src/utilities/getAll.ts
@@ -8,7 +8,7 @@ import {
 import { getVolumes, Volume } from 'linode-js-sdk/lib/volumes';
 import { range } from 'ramda';
 
-import { MAX_PAGE_SIZE } from 'src/constants';
+import { API_MAX_PAGE_SIZE } from 'src/constants';
 import { sendFetchAllEvent } from 'src/utilities/ga';
 
 export interface APIResponsePage<T> {
@@ -51,12 +51,13 @@ export interface GetAllData<T> {
  *
  */
 export const getAll: <T>(
-  getter: GetFunction
-) => (params?: any, filter?: any) => Promise<GetAllData<T[]>> = getter => (
-  params?: any,
-  filter?: any
-) => {
-  const pagination = { ...params, page_size: MAX_PAGE_SIZE };
+  getter: GetFunction,
+  pageSize?: number
+) => (params?: any, filter?: any) => Promise<GetAllData<T[]>> = (
+  getter,
+  pageSize = API_MAX_PAGE_SIZE
+) => (params?: any, filter?: any) => {
+  const pagination = { ...params, page_size: pageSize };
   return getter(pagination, filter).then(
     ({ data: firstPageData, page, pages, results }) => {
       // If we only have one page, return it.
@@ -93,13 +94,13 @@ export const getAll: <T>(
 };
 
 export const getAllWithArguments: <T>(
-  getter: GetFunction
-) => (
-  args: any[],
-  params?: any,
-  filter?: any
-) => Promise<GetAllData<T[]>> = getter => (args = [], params, filter) => {
-  const pagination = { ...params, page_size: MAX_PAGE_SIZE };
+  getter: GetFunction,
+  pageSize?: number
+) => (args: any[], params?: any, filter?: any) => Promise<GetAllData<T[]>> = (
+  getter,
+  pageSize = API_MAX_PAGE_SIZE
+) => (args = [], params, filter) => {
+  const pagination = { ...params, page_size: pageSize };
 
   return getter(...args, pagination, filter).then(
     ({ data: firstPageData, page, pages, results }) => {


### PR DESCRIPTION
## Description

In this PR we specify the API page size from an environment variable rather than a feature flag. The new variable is `REACT_APP_API_MAX_PAGE_SIZE`, so add that to your `.env`.

I also fixed two places where the API returns an error if requesting more than 100 items:

- /networking/ips
- /object-storage/buckets

