### PR TITLE
M3-3356 Improve Form context help/info in Configuration Edit

### DIFF
--- a/packages/manager/src/components/Toggle/Toggle.tsx
+++ b/packages/manager/src/components/Toggle/Toggle.tsx
@@ -23,13 +23,14 @@ const styles = (theme: Theme) =>
   });
 
 interface Props {
-  tooltipText?: string;
+  tooltipText?: JSX.Element | string;
+  interactive?: boolean;
 }
 
 type CombinedProps = Props & SwitchProps & WithStyles<CSSClasses>;
 
 const LinodeSwitchControl: React.StatelessComponent<CombinedProps> = props => {
-  const { classes, tooltipText, ...rest } = props;
+  const { classes, tooltipText, interactive, ...rest } = props;
 
   return (
     <React.Fragment>
@@ -40,7 +41,7 @@ const LinodeSwitchControl: React.StatelessComponent<CombinedProps> = props => {
         color="primary"
         {...rest}
       />
-      {tooltipText && <HelpIcon text={tooltipText} />}
+      {tooltipText && <HelpIcon text={tooltipText} interactive={interactive} />}
     </React.Fragment>
   );
 };

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -287,18 +287,6 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
       { label: '/dev/sdh', value: '/dev/sdh' }
     ];
 
-    const TooltipText = () => {
-      return (
-        <>
-          Automatically configure static networking
-          <ExternalLink
-            text="(more info)"
-            link="https://www.linode.com/docs/platform/network-helper/"
-          />
-        </>
-      );
-    };
-
     return (
       <React.Fragment>
         {generalError && (
@@ -636,7 +624,15 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
                     checked={helpers.network}
                     onChange={this.handleAuthConfigureNetworkHelper}
                     disabled={readOnly}
-                    tooltipText={<TooltipText />}
+                    tooltipText={
+                      <>
+                        Automatically configure static networking
+                        <ExternalLink
+                          text="(more info)"
+                          link="https://www.linode.com/docs/platform/network-helper/"
+                        />
+                      </>
+                    }
                     interactive={true}
                   />
                 }

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -16,6 +16,7 @@ import CircleProgress from 'src/components/CircleProgress';
 import Divider from 'src/components/core/Divider';
 import FormControl from 'src/components/core/FormControl';
 import FormControlLabel from 'src/components/core/FormControlLabel';
+import FormHelperText from 'src/components/core/FormHelperText';
 import FormGroup from 'src/components/core/FormGroup';
 import FormLabel from 'src/components/core/FormLabel';
 import RadioGroup from 'src/components/core/RadioGroup';
@@ -51,8 +52,9 @@ import {
   UpdateLinodeConfig,
   withLinodeDetailContext
 } from '../linodeDetailContext';
+import ExternalLink from 'src/components/ExternalLink';
 
-type ClassNames = 'section' | 'divider';
+type ClassNames = 'section' | 'divider' | 'formControlToggle';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -62,6 +64,11 @@ const styles = (theme: Theme) =>
     divider: {
       margin: `${theme.spacing(2)}px ${theme.spacing(1)}px 0 `,
       width: `calc(100% - ${theme.spacing(2)}px)`
+    },
+    formControlToggle: {
+      '& button': {
+        order: 3
+      }
     }
   });
 
@@ -280,6 +287,15 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
       { label: '/dev/sdh', value: '/dev/sdh' }
     ];
 
+    const renderLink = () => {
+      return (
+        <ExternalLink
+          text="(more info)"
+          link="https://www.linode.com/docs/platform/network-helper/"
+        />
+      );
+    };
+
     return (
       <React.Fragment>
         {generalError && (
@@ -334,6 +350,8 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
               htmlFor="virt_mode"
               component="label"
               disabled={readOnly}
+              aria-describedby="virtModeCaption"
+              //TODO check this works for a11y
             >
               VM Mode
             </FormLabel>
@@ -355,6 +373,11 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
                 disabled={readOnly}
                 control={<Radio />}
               />
+              <FormHelperText id="virtModeCaption">
+                Controls if devices inside your virtual machine are
+                paravirtualized or fully virtualized. Paravirt is what you want,
+                unless you're doing weird things.
+              </FormHelperText>
             </RadioGroup>
           </FormControl>
         </Grid>
@@ -553,55 +576,65 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
             <FormGroup>
               <FormControlLabel
                 label="Distro Helper"
+                className={classes.formControlToggle}
                 control={
                   <Toggle
                     checked={helpers.distro}
                     onChange={this.handleToggleDistroHelper}
                     disabled={readOnly}
+                    tooltipText="Helps maintain correct inittab/upstart console device"
                   />
                 }
               />
 
               <FormControlLabel
                 label="Disable updatedb"
+                className={classes.formControlToggle}
                 control={
                   <Toggle
                     checked={helpers.updatedb_disabled}
                     onChange={this.handleToggleUpdateDBHelper}
                     disabled={readOnly}
+                    tooltipText="Disables updatedb cron job to avoid disk thrashing"
                   />
                 }
               />
 
               <FormControlLabel
                 label="modules.dep Helper"
+                className={classes.formControlToggle}
                 control={
                   <Toggle
                     checked={helpers.modules_dep}
                     onChange={this.handleToggleModulesDepHelper}
                     disabled={readOnly}
+                    tooltipText="Creates a modules dependency file for the kernel you run"
                   />
                 }
               />
 
               <FormControlLabel
                 label="automount devtpmfs"
+                className={classes.formControlToggle}
                 control={
                   <Toggle
                     checked={helpers.devtmpfs_automount}
                     onChange={this.handleToggleAutoMountHelper}
                     disabled={readOnly}
+                    tooltipText="Controls if pv_ops kernels automount devtmpfs at boot"
                   />
                 }
               />
 
               <FormControlLabel
                 label="auto-configure networking"
+                className={classes.formControlToggle}
                 control={
                   <Toggle
                     checked={helpers.network}
                     onChange={this.handleAuthConfigureNetworkHelper}
                     disabled={readOnly}
+                    tooltipText={`Automatically configure static networking ${renderLink()}`}
                   />
                 }
               />

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -354,7 +354,6 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
               component="label"
               disabled={readOnly}
               aria-describedby="virtModeCaption"
-              // TODO check this works for a11y
             >
               VM Mode
             </FormLabel>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -16,8 +16,8 @@ import CircleProgress from 'src/components/CircleProgress';
 import Divider from 'src/components/core/Divider';
 import FormControl from 'src/components/core/FormControl';
 import FormControlLabel from 'src/components/core/FormControlLabel';
-import FormHelperText from 'src/components/core/FormHelperText';
 import FormGroup from 'src/components/core/FormGroup';
+import FormHelperText from 'src/components/core/FormHelperText';
 import FormLabel from 'src/components/core/FormLabel';
 import RadioGroup from 'src/components/core/RadioGroup';
 import {
@@ -30,6 +30,7 @@ import Typography from 'src/components/core/Typography';
 import Drawer from 'src/components/Drawer';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import ErrorState from 'src/components/ErrorState';
+import ExternalLink from 'src/components/ExternalLink';
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
 import Radio from 'src/components/Radio';
@@ -52,7 +53,6 @@ import {
   UpdateLinodeConfig,
   withLinodeDetailContext
 } from '../linodeDetailContext';
-import ExternalLink from 'src/components/ExternalLink';
 
 type ClassNames = 'section' | 'divider' | 'formControlToggle';
 
@@ -287,12 +287,15 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
       { label: '/dev/sdh', value: '/dev/sdh' }
     ];
 
-    const renderLink = () => {
+    const TooltipText = () => {
       return (
-        <ExternalLink
-          text="(more info)"
-          link="https://www.linode.com/docs/platform/network-helper/"
-        />
+        <>
+          Automatically configure static networking
+          <ExternalLink
+            text="(more info)"
+            link="https://www.linode.com/docs/platform/network-helper/"
+          />
+        </>
       );
     };
 
@@ -351,7 +354,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
               component="label"
               disabled={readOnly}
               aria-describedby="virtModeCaption"
-              //TODO check this works for a11y
+              // TODO check this works for a11y
             >
               VM Mode
             </FormLabel>
@@ -634,7 +637,8 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
                     checked={helpers.network}
                     onChange={this.handleAuthConfigureNetworkHelper}
                     disabled={readOnly}
-                    tooltipText={`Automatically configure static networking ${renderLink()}`}
+                    tooltipText={<TooltipText />}
+                    interactive={true}
                   />
                 }
               />


### PR DESCRIPTION
## Description

Adding helper text/ tooltip text to the configuration section to match the captions currently in Classic.

## Type of Change
- Non breaking change ('update')