### PR TITLE
M3-3812: Fix visual regression on Clone Configs/Disks

### DIFF
--- a/packages/manager/src/features/linodes/CloneLanding/Details.tsx
+++ b/packages/manager/src/features/linodes/CloneLanding/Details.tsx
@@ -41,8 +41,15 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   closeIcon: {
     cursor: 'pointer',
-    position: 'relative',
-    top: -4
+    paddingTop: 0,
+    paddingBottom: 0,
+    display: 'flex',
+    alignItems: 'center',
+    backgroundColor: theme.color.white,
+    border: 'none',
+    '& path': {
+      fill: theme.color.blue
+    }
   },
   divider: {
     marginTop: theme.spacing(2),
@@ -55,6 +62,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   labelOuter: {
     display: 'flex',
     justifyContent: 'space-between',
+    alignItems: 'center',
     width: '100%'
   },
   errorText: {


### PR DESCRIPTION
## Description

Previously these `<a />` elements were changed to `<button />`s to make them more accessible. This resulted in a visual regression. This fixes that regression by adding a few CSS properties.

**Before:**
<img width="384" alt="Screen Shot 2020-01-17 at 3 12 43 PM" src="https://user-images.githubusercontent.com/16911484/72644399-e6bb1f80-393e-11ea-8c72-afde201363a4.png">
**After:**
<img width="358" alt="Screen Shot 2020-01-17 at 3 32 20 PM" src="https://user-images.githubusercontent.com/16911484/72644407-ecb10080-393e-11ea-88b3-badda8a34ca5.png">

## Type of Change
- Bug fix ('fix', 'repair', 'bug')