### PR TITLE
Fixes

### DIFF
--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -18,7 +18,7 @@ export const safeSecondaryEntityLabel = (
   text: string,
   fallback: string = ''
 ) => {
-  const label = path<string>(['secondary_entity', 'label'], e);
+  const label = e?.secondary_entity?.label;
   return label ? `${text} ${label}` : fallback;
 };
 
@@ -203,48 +203,53 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
         'booted'
       )}.`
   },
+  /**
+   * For these events, we expect an entity (the Linode being rebooted)
+   * but there have been cases where an event has come through with
+   * entity === null. Handle them safely.
+   */
   lassie_reboot: {
     scheduled: e =>
-      `Linode ${
-        e.entity!.label
-      } is scheduled to be rebooted by the Lassie watchdog service.`,
+      `Linode ${e.entity?.label ??
+        ''} is scheduled to be rebooted by the Lassie watchdog service.`,
     started: e =>
-      `Linode ${
-        e.entity!.label
-      } is being booted by the Lassie watchdog service.`,
+      `Linode ${e.entity?.label ??
+        ''} is being booted by the Lassie watchdog service.`,
     failed: e =>
-      `Linode ${
-        e.entity!.label
-      } could not be booted by the Lassie watchdog service.`,
+      `Linode ${e.entity?.label ??
+        ''} could not be booted by the Lassie watchdog service.`,
     finished: e =>
-      `Linode ${
-        e.entity!.label
-      } has been booted by the Lassie watchdog service.`
+      `Linode ${e.entity?.label ??
+        ''} has been booted by the Lassie watchdog service.`
   },
   host_reboot: {
     scheduled: e =>
-      `Linode ${
-        e.entity!.label
-      } is scheduled to reboot (Host initiated restart).`,
+      `Linode ${e.entity?.label ??
+        ''} is scheduled to reboot (Host initiated restart).`,
     started: e =>
-      `Linode ${e.entity!.label} is being booted (Host initiated restart).`,
+      `Linode ${e.entity?.label ??
+        ''} is being booted (Host initiated restart).`,
     failed: e =>
-      `Linode ${e.entity!.label} could not be booted (Host initiated restart).`,
+      `Linode ${e.entity?.label ??
+        ''} could not be booted (Host initiated restart).`,
     finished: e =>
-      `Linode ${e.entity!.label} has been booted (Host initiated restart).`
+      `Linode ${e.entity?.label ??
+        ''} has been booted (Host initiated restart).`
   },
   ipaddress_update: {
     notification: e => `An IP address has been updated on your account.`
   },
   lish_boot: {
     scheduled: e =>
-      `Linode ${e.entity!.label} is scheduled to boot (Lish initiated boot).`,
+      `Linode ${e.entity?.label ??
+        ''} is scheduled to boot (Lish initiated boot).`,
     started: e =>
-      `Linode ${e.entity!.label} is being booted (Lish initiated boot).`,
+      `Linode ${e.entity?.label ?? ''} is being booted (Lish initiated boot).`,
     failed: e =>
-      `Linode ${e.entity!.label} could not be booted (Lish initiated boot).`,
+      `Linode ${e.entity?.label ??
+        ''} could not be booted (Lish initiated boot).`,
     finished: e =>
-      `Linode ${e.entity!.label} has been booted (Lish initiated boot).`
+      `Linode ${e.entity?.label ?? ''} has been booted (Lish initiated boot).`
   },
   linode_clone: {
     scheduled: e => `Linode ${e.entity!.label} is scheduled to be cloned.`,

--- a/packages/manager/src/features/Events/EventsLanding.tsx
+++ b/packages/manager/src/features/Events/EventsLanding.tsx
@@ -310,17 +310,17 @@ export const EventsLanding: React.StatelessComponent<CombinedProps> = props => {
           </TableBody>
         </Table>
       </Paper>
-      {loadMoreEvents && (initialLoaded && !isLoading) ? (
+      {loadMoreEvents && initialLoaded && !isLoading ? (
         <Waypoint onEnter={getNext}>
           <div />
         </Waypoint>
       ) : (
         !isLoading &&
-        (!error && (
+        !error && (
           <Typography className={classes.noMoreEvents}>
             No more events to show
           </Typography>
-        ))
+        )
       )}
     </>
   );
@@ -397,10 +397,6 @@ const mapStateToProps = (state: ApplicationState) => ({
 
 const connected = connect(mapStateToProps);
 
-const enhanced = compose<CombinedProps, Props>(
-  styled,
-  connected,
-  withSnackbar
-);
+const enhanced = compose<CombinedProps, Props>(styled, connected, withSnackbar);
 
 export default enhanced(EventsLanding);

--- a/packages/manager/src/store/linodes/linodes.events.ts
+++ b/packages/manager/src/store/linodes/linodes.events.ts
@@ -31,7 +31,6 @@ const linodeEventsHandler: EventHandler = (event, dispatch, getState) => {
     case 'linode_snapshot':
     case 'linode_addip':
     case 'linode_boot':
-    case 'backups_restore':
     case 'backups_enable':
     case 'backups_cancel':
     case 'disk_imagize':
@@ -39,6 +38,7 @@ const linodeEventsHandler: EventHandler = (event, dispatch, getState) => {
       return handleLinodeUpdate(dispatch, status, id);
 
     case 'linode_rebuild':
+    case 'backups_restore':
       return handleLinodeRebuild(dispatch, status, id, percent_complete);
 
     /** Remove Linode */


### PR DESCRIPTION
## Description

Fixes 2 issues that were reported today:

1. Sometimes, for mysterious reasons, lassie_reboot events can come through with `entity: null`, which causes a console error. This is not a problem for users but will pollute sentry and the console. Now that we have nullish coalescing, we can handle this case more elegantly.

2. When a Linode is restored from a backup, the IDs of its
configs and disks change. When the process is complete,
we need to re-request both configs and disks to ensure
that our cache is up to date. If we fail to do this, a
user will try to boot the Linode with a previous config,
which will cause an error.

Fortunately, we already have an event that has this behavior
(for the same reasons), linode_rebuild. By moving backup_restore
to the same case in the switch in linode.events.ts, we can
achieve the desired effect.


## Type of Change
- Bug fix ('fix', 'repair', 'bug')


## Notes

To test #1, use Charles to pass a `lassie_reboot` event with an entity set to `null`. In the events menus, the event should be displayed without the label (since null.label isn't), and the console should be clear.

To test #2, select a backup then "restore to existing Linode". When the restore is complete, without reloading the page try to boot the target Linode.