### PR TITLE
M3-3813 Display updated CC info in Billing Summary

### DIFF
--- a/packages/manager/src/containers/account.container.ts
+++ b/packages/manager/src/containers/account.container.ts
@@ -1,6 +1,7 @@
 import { Account } from 'linode-js-sdk/lib/account';
 import { connect, InferableComponentEnhancerWithProps } from 'react-redux';
 import { ApplicationState } from 'src/store';
+import { updateCreditCard } from 'src/store/account/account.actions';
 import { State } from 'src/store/account/account.reducer';
 import {
   requestAccount,
@@ -18,6 +19,7 @@ export interface StateProps {
 export interface DispatchProps {
   requestAccount: () => void;
   updateAccount: (data: Partial<Account>) => Promise<any>;
+  updateCreditCard: (data: Account['credit_card']) => void;
 }
 
 type MapProps<ReduxStateProps, OwnProps> = (
@@ -63,7 +65,8 @@ const connected: Connected = <ReduxState extends {}, OwnProps extends {}>(
     },
     (dispatch: ThunkDispatch) => ({
       requestAccount: () => dispatch(requestAccount()),
-      updateAccount: data => dispatch(updateAccount(data))
+      updateAccount: data => dispatch(updateAccount(data)),
+      updateCreditCard: data => dispatch(updateCreditCard(data))
     })
   );
 

--- a/packages/manager/src/containers/account.container.ts
+++ b/packages/manager/src/containers/account.container.ts
@@ -1,7 +1,7 @@
 import { Account } from 'linode-js-sdk/lib/account';
 import { connect, InferableComponentEnhancerWithProps } from 'react-redux';
 import { ApplicationState } from 'src/store';
-import { updateCreditCard } from 'src/store/account/account.actions';
+import { saveCreditCard } from 'src/store/account/account.actions';
 import { State } from 'src/store/account/account.reducer';
 import {
   requestAccount,
@@ -19,7 +19,7 @@ export interface StateProps {
 export interface DispatchProps {
   requestAccount: () => void;
   updateAccount: (data: Partial<Account>) => Promise<any>;
-  updateCreditCard: (data: Account['credit_card']) => void;
+  saveCreditCard: (data: Account['credit_card']) => void;
 }
 
 type MapProps<ReduxStateProps, OwnProps> = (
@@ -66,7 +66,7 @@ const connected: Connected = <ReduxState extends {}, OwnProps extends {}>(
     (dispatch: ThunkDispatch) => ({
       requestAccount: () => dispatch(requestAccount()),
       updateAccount: data => dispatch(updateAccount(data)),
-      updateCreditCard: data => dispatch(updateCreditCard(data))
+      saveCreditCard: data => dispatch(saveCreditCard(data))
     })
   );
 

--- a/packages/manager/src/features/Billing/BillingPanels/UpdateCreditCardPanel/UpdateCreditCardPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/UpdateCreditCardPanel/UpdateCreditCardPanel.tsx
@@ -140,12 +140,12 @@ class UpdateCreditCardPanel extends React.Component<CombinedProps, State> {
           expiry: `${String(expiry_month).padStart(2, '0')}/${expiry_year}`,
           cvv
         };
-        // Update Redux state so subscribed components will display updated
+        // Update Redux store so subscribed components will display updated
         // information.
         this.props.updateCreditCard(credit_card);
 
-        // Update the context so components within this context tree will
-        // display updated information.
+        // Update context so components within this context tree will display
+        // updated information.
         this.props.updateContext(account => ({
           ...account,
           credit_card

--- a/packages/manager/src/features/Billing/BillingPanels/UpdateCreditCardPanel/UpdateCreditCardPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/UpdateCreditCardPanel/UpdateCreditCardPanel.tsx
@@ -142,7 +142,7 @@ class UpdateCreditCardPanel extends React.Component<CombinedProps, State> {
         };
         // Update Redux store so subscribed components will display updated
         // information.
-        this.props.updateCreditCard(credit_card);
+        this.props.saveCreditCard(credit_card);
 
         // Update context so components within this context tree will display
         // updated information.

--- a/packages/manager/src/store/account/account.actions.ts
+++ b/packages/manager/src/store/account/account.actions.ts
@@ -13,6 +13,13 @@ export const profileRequestSuccess = actionCreator<Account>('success');
 
 export const profileRequestFail = actionCreator<APIError[]>('fail');
 
+// Separate action to update credit card information, since updating this info
+// is accomplished with a separate endpoint that doesn't return the new credit
+// card info in the response.
+export const updateCreditCard = actionCreator<Account['credit_card']>(
+  'update-credit-card'
+);
+
 export type UpdateAccountParams = Partial<Account>;
 export const updateAccountActions = actionCreator.async<
   UpdateAccountParams,

--- a/packages/manager/src/store/account/account.actions.ts
+++ b/packages/manager/src/store/account/account.actions.ts
@@ -16,7 +16,7 @@ export const profileRequestFail = actionCreator<APIError[]>('fail');
 // Separate action to update credit card information, since updating this info
 // is accomplished with a separate endpoint that doesn't return the new credit
 // card info in the response.
-export const updateCreditCard = actionCreator<Account['credit_card']>(
+export const saveCreditCard = actionCreator<Account['credit_card']>(
   'update-credit-card'
 );
 

--- a/packages/manager/src/store/account/account.reducer.ts
+++ b/packages/manager/src/store/account/account.reducer.ts
@@ -7,8 +7,8 @@ import {
   profileRequest,
   profileRequestFail,
   profileRequestSuccess,
-  updateAccountActions,
-  updateCreditCard
+  saveCreditCard,
+  updateAccountActions
 } from './account.actions';
 
 /**
@@ -70,12 +70,17 @@ const reducer: Reducer<State> = (state: State = defaultState, action) => {
       draft.error.update = error;
     }
 
-    if (isType(action, updateCreditCard)) {
+    if (isType(action, saveCreditCard)) {
       const { payload } = action;
 
-      if (draft.data?.credit_card) {
-        draft.data.credit_card = payload;
+      // This action updates a nested slice of `data.` If `data` is undefined,
+      // don't do anything. This situation is impossible in practice but the
+      // logic is here to make the TypeScript compiler happy.
+      if (!draft.data) {
+        return;
       }
+
+      draft.data.credit_card = payload;
     }
   });
 };

--- a/packages/manager/src/store/account/account.reducer.ts
+++ b/packages/manager/src/store/account/account.reducer.ts
@@ -7,7 +7,8 @@ import {
   profileRequest,
   profileRequestFail,
   profileRequestSuccess,
-  updateAccountActions
+  updateAccountActions,
+  updateCreditCard
 } from './account.actions';
 
 /**
@@ -67,6 +68,14 @@ const reducer: Reducer<State> = (state: State = defaultState, action) => {
 
       draft.loading = false;
       draft.error.update = error;
+    }
+
+    if (isType(action, updateCreditCard)) {
+      const { payload } = action;
+
+      if (draft.data?.credit_card) {
+        draft.data.credit_card = payload;
+      }
     }
   });
 };


### PR DESCRIPTION
## Description

The Billing Summary component sources its info from Redux. Upon updating credit card information, only the account context was being updated, which meant that Billing Summary didn’t display the updated information.

To fix, I created a new Redux action to update the credit card information, which is dispatched after the CC info is successfully updated.

Note: this entire section should be refactored to use Redux instead of the Context API since it’s one of the only big components/features that uses it.