### PR TITLE
M3-3682 Fix Linode network graph units

### DIFF
--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -40,7 +40,7 @@ export interface Props {
   timezone: string;
   rowHeaders?: Array<string>;
   legendRows?: Array<ChartData<any>>;
-  tooltipUnit?: string; // @todo deprecate unit prop above and rename this to unit. graphs should be consistent
+  unit?: string; // @todo deprecate unit prop above and rename this to unit. graphs should be consistent
   maxUnit?: StorageSymbol; // Rounds data to this unit. IMPORTANT: if this prop is provided, data should be in bytes
   nativeLegend?: boolean; // Display chart.js native legend
 }
@@ -144,7 +144,7 @@ const LineGraph: React.FC<CombinedProps> = props => {
     legendRows,
     maxUnit,
     nativeLegend,
-    tooltipUnit,
+    unit,
     ...rest
   } = props;
   const finalRowHeaders = rowHeaders ? rowHeaders : ['Max', 'Avg', 'Last'];
@@ -269,7 +269,7 @@ const LineGraph: React.FC<CombinedProps> = props => {
             undefined, // @todo remove this
             nativeLegend,
             maxUnit,
-            tooltipUnit
+            unit
           )}
           plugins={plugins}
           ref={inputEl}
@@ -389,7 +389,7 @@ export const formatTooltip = curry(
   (
     data: any,
     maxUnit: StorageSymbol | undefined,
-    tooltipUnit: string | undefined,
+    unit: string | undefined,
     t?: any,
     d?: any
   ) => {
@@ -413,7 +413,7 @@ export const formatTooltip = curry(
     const value = maxUnit
       ? readableBytes(val).formatted
       : Math.round(val * 100) / 100;
-    return `${label}: ${value} ${tooltipUnit}`;
+    return `${label}: ${value} ${unit}`;
   }
 );
 

--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -172,7 +172,6 @@ const LineGraph: React.FC<CombinedProps> = props => {
 
   const getChartOptions = (
     _suggestedMax?: number,
-    _unit?: string,
     _nativeLegend?: boolean,
     _maxUnit?: StorageSymbol,
     _tooltipUnit?: string
@@ -198,13 +197,6 @@ const LineGraph: React.FC<CombinedProps> = props => {
 
     if (_suggestedMax) {
       finalChartOptions.scales.yAxes[0].ticks.suggestedMax = _suggestedMax;
-    }
-
-    if (_unit) {
-      finalChartOptions.scales.yAxes[0].ticks.callback = (
-        value: number,
-        index: number
-      ) => `${humanizeLargeData(value)}${_unit}`;
     }
 
     if (_nativeLegend) {
@@ -264,13 +256,7 @@ const LineGraph: React.FC<CombinedProps> = props => {
         <Line
           {...rest}
           height={chartHeight || 300}
-          options={getChartOptions(
-            suggestedMax,
-            undefined, // @todo remove this
-            nativeLegend,
-            maxUnit,
-            unit
-          )}
+          options={getChartOptions(suggestedMax, nativeLegend, maxUnit, unit)}
           plugins={plugins}
           ref={inputEl}
           data={{

--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -399,7 +399,7 @@ export const formatTooltip = curry(
     const value = maxUnit
       ? readableBytes(val).formatted
       : Math.round(val * 100) / 100;
-    return `${label}: ${value} ${unit}`;
+    return `${label}: ${value} ${unit ? unit : ''}`;
   }
 );
 

--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -40,7 +40,7 @@ export interface Props {
   timezone: string;
   rowHeaders?: Array<string>;
   legendRows?: Array<ChartData<any>>;
-  unit?: string; // @todo deprecate unit prop above and rename this to unit. graphs should be consistent
+  unit?: string;
   maxUnit?: StorageSymbol; // Rounds data to this unit. IMPORTANT: if this prop is provided, data should be in bytes
   nativeLegend?: boolean; // Display chart.js native legend
 }

--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -32,7 +32,6 @@ export interface DataSet {
   backgroundColor?: string;
   data: [number, number | null][];
 }
-
 export interface Props {
   chartHeight?: number;
   showToday: boolean;
@@ -41,7 +40,6 @@ export interface Props {
   timezone: string;
   rowHeaders?: Array<string>;
   legendRows?: Array<ChartData<any>>;
-  unit?: string; // Display unit on Y axis ticks
   tooltipUnit?: string; // @todo deprecate unit prop above and rename this to unit. graphs should be consistent
   maxUnit?: StorageSymbol; // Rounds data to this unit. IMPORTANT: if this prop is provided, data should be in bytes
   nativeLegend?: boolean; // Display chart.js native legend
@@ -138,7 +136,6 @@ const LineGraph: React.FC<CombinedProps> = props => {
   const classes = useStyles();
   const {
     chartHeight,
-    unit,
     suggestedMax,
     showToday,
     timezone,
@@ -269,7 +266,7 @@ const LineGraph: React.FC<CombinedProps> = props => {
           height={chartHeight || 300}
           options={getChartOptions(
             suggestedMax,
-            unit,
+            undefined, // @todo remove this
             nativeLegend,
             maxUnit,
             tooltipUnit
@@ -416,7 +413,7 @@ export const formatTooltip = curry(
     const value = maxUnit
       ? readableBytes(val).formatted
       : Math.round(val * 100) / 100;
-    return `${label}: ${value} ${tooltipUnit ? tooltipUnit : ''}`;
+    return `${label}: ${value} ${tooltipUnit}`;
   }
 );
 

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/NGINX/NGINXGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/NGINX/NGINXGraphs.tsx
@@ -75,7 +75,7 @@ export const NGINXGraphs: React.FC<CombinedProps> = props => {
           <LongviewLineGraph
             title="Requests"
             subtitle="requests/s"
-            tooltipUnit="requests/s"
+            unit="requests/s"
             data={[
               {
                 label: 'Requests',
@@ -93,7 +93,7 @@ export const NGINXGraphs: React.FC<CombinedProps> = props => {
               <LongviewLineGraph
                 title="Connections"
                 subtitle="connections/s"
-                tooltipUnit="connections/s"
+                unit="connections/s"
                 nativeLegend
                 data={[
                   {

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Network/NetworkGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Network/NetworkGraphs.tsx
@@ -83,7 +83,7 @@ export const NetworkGraphs: React.FC<CombinedProps> = props => {
                 title="Network Traffic"
                 nativeLegend
                 subtitle={maxUnit + '/s'}
-                tooltipUnit={maxUnit + '/s'}
+                unit={maxUnit + '/s'}
                 error={error}
                 loading={loading}
                 showToday={isToday}

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/CPUGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/CPUGraph.tsx
@@ -49,7 +49,7 @@ export const CPUGraph: React.FC<CombinedProps> = props => {
     <LongviewLineGraph
       title="CPU"
       subtitle="%"
-      tooltipUnit="%"
+      unit="%"
       nativeLegend
       error={error}
       loading={loading}

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/DiskGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/DiskGraph.tsx
@@ -52,7 +52,7 @@ export const DiskGraph: React.FC<CombinedProps> = props => {
       error={(!data.Disk && requestError) || error}
       loading={loading}
       subtitle={'ops/second'}
-      tooltipUnit={'ops/second'}
+      unit={'ops/second'}
       showToday={isToday}
       timezone={timezone}
       nativeLegend

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/NetworkGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/NetworkGraph.tsx
@@ -54,7 +54,7 @@ export const NetworkGraph: React.FC<CombinedProps> = props => {
     <LongviewLineGraph
       title="Network"
       subtitle={maxUnit + '/s'}
-      tooltipUnit={maxUnit + '/s'}
+      unit={maxUnit + '/s'}
       error={error}
       loading={loading}
       showToday={isToday}

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ProcessGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ProcessGraphs.tsx
@@ -81,7 +81,7 @@ export const ProcessGraphs: React.FC<CombinedProps> = props => {
             <LongviewLineGraph
               title="CPU"
               subtitle={'%'}
-              tooltipUnit="%"
+              unit="%"
               data={[
                 {
                   label: 'CPU',
@@ -117,7 +117,7 @@ export const ProcessGraphs: React.FC<CombinedProps> = props => {
             <LongviewLineGraph
               title="Disk I/O"
               subtitle={`${diskUnit}/s`}
-              tooltipUnit={`${diskUnit}/s`}
+              unit={`${diskUnit}/s`}
               data={[
                 {
                   label: 'Read',

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Processes/ProcessesGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Processes/ProcessesGraphs.tsx
@@ -106,7 +106,7 @@ const ProcessesGraphs: React.FC<CombinedProps> = props => {
         <LongviewLineGraph
           title="CPU"
           subtitle="%"
-          tooltipUnit="%"
+          unit="%"
           data={[
             {
               data: _convertData(cpu, start, end),
@@ -152,7 +152,7 @@ const ProcessesGraphs: React.FC<CombinedProps> = props => {
           <LongviewLineGraph
             title="Disk I/O"
             subtitle={ioUnit + '/s'}
-            tooltipUnit={ioUnit + '/s'}
+            unit={ioUnit + '/s'}
             nativeLegend
             data={[
               {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.test.tsx
@@ -23,7 +23,6 @@ describe('LinodeSummary', () => {
         graphControls: '',
         graphTitle: '',
         graphSelectTitle: '',
-        totalTraffic: '',
         chartSelect: '',
         subHeaderOuter: '',
         textWrap: '',

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -428,7 +428,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
           <LineGraph
             timezone={timezone}
             chartHeight={chartHeight}
-            tooltipUnit={`${unit}/s`}
+            unit={`${unit}/s`}
             showToday={rangeSelection === '24'}
             data={[
               {
@@ -539,7 +539,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
           <LineGraph
             timezone={timezone}
             chartHeight={chartHeight}
-            tooltipUnit={unit}
+            unit={unit}
             showToday={rangeSelection === '24'}
             data={[
               {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -50,6 +50,11 @@ import StatsPanel from './StatsPanel';
 import SummaryPanel from './SummaryPanel';
 import TotalTraffic, { TotalTrafficProps } from './TotalTraffic';
 
+import {
+  convertNetworkToUnit,
+  generateNetworkUnits
+} from 'src/features/Longview/shared/utilities';
+
 setUpCharts();
 
 type ClassNames =
@@ -386,6 +391,8 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
 
     const netv4InMetrics = getMetrics(v4Data.publicIn);
     const netv4OutMetrics = getMetrics(v4Data.publicOut);
+    const netv4PrivateInMetrics = getMetrics(v4Data.privateIn);
+    const netv4PrivateOutMetrics = getMetrics(v4Data.privateOut);
 
     const totalTraffic: TotalTrafficProps = map(
       formatBytes,
@@ -398,36 +405,54 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
       )
     );
 
+    const unit = generateNetworkUnits(
+      Math.max(
+        netv4InMetrics.max,
+        netv4OutMetrics.max,
+        netv4PrivateInMetrics.max,
+        netv4PrivateOutMetrics.max
+      )
+    );
+
+    const convertNetworkData = (point: any) => {
+      return [point[0], convertNetworkToUnit(point[1], unit)];
+    };
+    const convertedPublicIn = v4Data.publicIn.map(convertNetworkData);
+    const convertedPublicOut = v4Data.publicOut.map(convertNetworkData);
+    const convertedPrivateIn = v4Data.privateIn.map(convertNetworkData);
+    const convertedPrivateOut = v4Data.privateOut.map(convertNetworkData);
+
     return (
       <React.Fragment>
         <div className={classes.chart}>
           <LineGraph
             timezone={timezone}
             chartHeight={chartHeight}
+            tooltipUnit={`${unit}/s`}
             showToday={rangeSelection === '24'}
             data={[
               {
                 borderColor: theme.graphs.blueBorder,
                 backgroundColor: theme.graphs.blue,
-                data: v4Data.publicIn,
+                data: convertedPublicIn,
                 label: 'Public Inbound'
               },
               {
                 borderColor: theme.graphs.greenBorder,
                 backgroundColor: theme.graphs.green,
-                data: v4Data.publicOut,
+                data: convertedPublicOut,
                 label: 'Public Outbound'
               },
               {
                 borderColor: theme.graphs.purpleBorder,
                 backgroundColor: theme.graphs.purple,
-                data: v4Data.privateIn,
+                data: convertedPrivateIn,
                 label: 'Private Inbound'
               },
               {
                 borderColor: theme.graphs.yellowBorder,
                 backgroundColor: theme.graphs.yellow,
-                data: v4Data.privateOut,
+                data: convertedPrivateOut,
                 label: 'Private Outbound'
               }
             ]}
@@ -479,6 +504,8 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
 
     const publicInMetrics = getMetrics(data.publicIn);
     const publicOutMetrics = getMetrics(data.publicOut);
+    const privateInMetrics = getMetrics(data.privateIn);
+    const privateOutMetrics = getMetrics(data.privateOut);
 
     const totalTraffic: TotalTrafficProps = map(
       formatBytes,
@@ -489,39 +516,57 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
       )
     );
 
+    const unit = generateNetworkUnits(
+      Math.max(
+        publicInMetrics.max,
+        publicOutMetrics.max,
+        privateInMetrics.max,
+        privateOutMetrics.max
+      )
+    );
+
+    const convertNetworkData = (point: any) => {
+      return [point[0], convertNetworkToUnit(point[1], unit)];
+    };
+    const convertedPublicIn = data.publicIn.map(convertNetworkData);
+    const convertedPublicOut = data.publicOut.map(convertNetworkData);
+    const convertedPrivateIn = data.privateIn.map(convertNetworkData);
+    const convertedPrivateOut = data.privateOut.map(convertNetworkData);
+
     return (
       <React.Fragment>
         <div className={classes.chart}>
           <LineGraph
             timezone={timezone}
             chartHeight={chartHeight}
+            tooltipUnit={unit}
             showToday={rangeSelection === '24'}
             data={[
               {
                 borderColor: theme.graphs.blueBorder,
                 backgroundColor: theme.graphs.blue,
-                data: data.publicIn,
+                data: convertedPublicIn,
                 label: 'Public Inbound',
                 fill: 'origin'
               },
               {
                 borderColor: theme.graphs.greenBorder,
                 backgroundColor: theme.graphs.green,
-                data: data.publicOut,
+                data: convertedPublicOut,
                 label: 'Public Outbound',
                 fill: '-1'
               },
               {
                 borderColor: theme.graphs.purpleBorder,
                 backgroundColor: theme.graphs.purple,
-                data: data.privateIn,
+                data: convertedPrivateIn,
                 label: 'Private Inbound',
                 fill: '-2'
               },
               {
                 borderColor: theme.graphs.yellowBorder,
                 backgroundColor: theme.graphs.yellow,
-                data: data.privateOut,
+                data: convertedPrivateOut,
                 label: 'Private Outbound'
               }
             ]}
@@ -535,11 +580,11 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
                 format
               },
               {
-                data: getMetrics(data.privateIn),
+                data: privateInMetrics,
                 format
               },
               {
-                data: getMetrics(data.privateOut),
+                data: privateOutMetrics,
                 format
               }
             ]}
@@ -716,13 +761,13 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
             />
 
             <StatsPanel
-              title="IPv4 Traffic (bits/s)"
+              title={`IPv4 Traffic (${'Kb'}/s)`}
               renderBody={this.renderIPv4TrafficChart}
               {...chartProps}
             />
 
             <StatsPanel
-              title="IPv6 Traffic (bits/s)"
+              title={`IPv6 Traffic (${'Kb'}/s)`}
               renderBody={this.renderIPv6TrafficChart}
               {...chartProps}
             />

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph.tsx
@@ -1,0 +1,258 @@
+import { map, pathOr } from 'ramda';
+import * as React from 'react';
+import {
+  makeStyles,
+  Theme,
+  WithTheme,
+  withTheme
+} from 'src/components/core/styles';
+import Grid from 'src/components/Grid';
+import LineGraph from 'src/components/LineGraph';
+import {
+  convertNetworkToUnit,
+  generateNetworkUnits
+} from 'src/features/Longview/shared/utilities';
+import {
+  formatBitsPerSecond,
+  formatBytes,
+  getMetrics,
+  getTotalTraffic,
+  Metrics
+} from 'src/utilities/statMetrics';
+import StatsPanel from './StatsPanel';
+import TotalTraffic, { TotalTrafficProps } from './TotalTraffic';
+import { ChartProps } from './types';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  chart: {
+    position: 'relative',
+    paddingLeft: theme.spacing(1)
+  },
+  totalTraffic: {
+    margin: '12px'
+  }
+}));
+
+interface Props extends ChartProps {
+  timezone: string;
+  rangeSelection: string;
+  stats: any;
+}
+
+export type CombinedProps = Props & WithTheme;
+
+interface NetworkMetrics {
+  publicIn: Metrics;
+  publicOut: Metrics;
+  privateIn: Metrics;
+  privateOut: Metrics;
+}
+
+const _getMetrics = (data: any) => {
+  return {
+    publicIn: getMetrics(data.publicIn),
+    publicOut: getMetrics(data.publicOut),
+    privateIn: getMetrics(data.privateIn),
+    privateOut: data.privateOut && getMetrics(data.privateOut)
+  };
+};
+
+export const NetworkGraph: React.FC<CombinedProps> = props => {
+  const { rangeSelection, stats, timezone, theme, ...rest } = props;
+
+  const v4Data = {
+    publicIn: pathOr([], ['data', 'netv4', 'in'], stats),
+    publicOut: pathOr([], ['data', 'netv4', 'out'], stats),
+    privateIn: pathOr([], ['data', 'netv4', 'private_in'], stats),
+    privateOut: pathOr([], ['data', 'netv4', 'private_out'], stats)
+  };
+
+  const v6Data = {
+    publicIn: pathOr([], ['data', 'netv6', 'in'], stats),
+    publicOut: pathOr([], ['data', 'netv6', 'out'], stats),
+    privateIn: pathOr([], ['data', 'netv6', 'private_in'], stats),
+    privateOut: pathOr([], ['data', 'netv6', 'private_out'], stats)
+  };
+
+  const v4Metrics = _getMetrics(v4Data);
+  const v6Metrics = _getMetrics(v6Data);
+
+  const v4totalTraffic: TotalTrafficProps = map(
+    formatBytes,
+    getTotalTraffic(
+      v4Metrics.publicIn.total,
+      v4Metrics.publicOut.total,
+      v4Data.publicIn.length,
+      v6Metrics.publicIn.total,
+      v6Metrics.publicOut.total
+    )
+  );
+
+  const v6totalTraffic: TotalTrafficProps = map(
+    formatBytes,
+    getTotalTraffic(
+      v6Metrics.publicIn.total,
+      v6Metrics.publicOut.total,
+      v6Metrics.publicIn.length
+    )
+  );
+
+  const v4Unit = generateNetworkUnits(
+    Math.max(
+      v4Metrics.publicIn.max,
+      v4Metrics.publicOut.max,
+      v4Metrics.privateIn.max,
+      v4Metrics.privateOut.max
+    )
+  );
+
+  const v6Unit = generateNetworkUnits(
+    Math.max(
+      v6Metrics.publicIn.max,
+      v6Metrics.publicOut.max,
+      v6Metrics.privateIn.max,
+      v6Metrics.privateOut?.max ?? 0
+    )
+  );
+
+  const commonGraphProps = {
+    timezone,
+    theme,
+    chartHeight: props.height,
+    rangeSelection
+  };
+
+  return (
+    <>
+      <StatsPanel
+        title={`IPv4 Traffic (${v4Unit}/s)`}
+        renderBody={() => (
+          <Graph
+            data={v4Data}
+            unit={v4Unit}
+            totalTraffic={v4totalTraffic}
+            metrics={v4Metrics}
+            {...commonGraphProps}
+          />
+        )}
+        {...rest}
+      />
+      <StatsPanel
+        title={`IPv6 Traffic (${v6Unit}/s)`}
+        renderBody={() => (
+          <Graph
+            data={v6Data}
+            unit={v6Unit}
+            totalTraffic={v6totalTraffic}
+            metrics={v6Metrics}
+            {...commonGraphProps}
+          />
+        )}
+        {...rest}
+      />
+    </>
+  );
+};
+
+interface GraphProps {
+  timezone: string;
+  data: any;
+  unit: string;
+  theme: Theme;
+  rangeSelection: string;
+  chartHeight: number;
+  totalTraffic: TotalTrafficProps;
+  metrics: NetworkMetrics;
+}
+
+const Graph: React.FC<GraphProps> = props => {
+  const classes = useStyles();
+  const {
+    chartHeight,
+    data,
+    metrics,
+    rangeSelection,
+    theme,
+    timezone,
+    unit,
+    totalTraffic
+  } = props;
+
+  const format = formatBitsPerSecond;
+
+  const convertNetworkData = (point: any) => {
+    return [point[0], convertNetworkToUnit(point[1], unit as any)];
+  };
+  const convertedPublicIn = data.publicIn.map(convertNetworkData);
+  const convertedPublicOut = data.publicOut.map(convertNetworkData);
+  const convertedPrivateIn = data.privateIn.map(convertNetworkData);
+  const convertedPrivateOut = data.privateOut?.map(convertNetworkData) ?? [];
+
+  return (
+    <React.Fragment>
+      <div className={classes.chart}>
+        <LineGraph
+          timezone={timezone}
+          chartHeight={chartHeight}
+          unit={`${unit}/s`}
+          showToday={rangeSelection === '24'}
+          data={[
+            {
+              borderColor: theme.graphs.blueBorder,
+              backgroundColor: theme.graphs.blue,
+              data: convertedPublicIn,
+              label: 'Public Inbound'
+            },
+            {
+              borderColor: theme.graphs.greenBorder,
+              backgroundColor: theme.graphs.green,
+              data: convertedPublicOut,
+              label: 'Public Outbound'
+            },
+            {
+              borderColor: theme.graphs.purpleBorder,
+              backgroundColor: theme.graphs.purple,
+              data: convertedPrivateIn,
+              label: 'Private Inbound'
+            },
+            {
+              borderColor: theme.graphs.yellowBorder,
+              backgroundColor: theme.graphs.yellow,
+              data: convertedPrivateOut,
+              label: 'Private Outbound'
+            }
+          ]}
+          legendRows={[
+            {
+              data: metrics.publicIn,
+              format
+            },
+            {
+              data: metrics.publicOut,
+              format
+            },
+            {
+              data: metrics.privateIn,
+              format
+            },
+            {
+              data: metrics.privateOut,
+              format
+            }
+          ]}
+        />
+      </div>
+      {rangeSelection === '24' && (
+        <Grid item xs={12} lg={6} className={classes.totalTraffic}>
+          <TotalTraffic
+            inTraffic={totalTraffic.inTraffic}
+            outTraffic={totalTraffic.outTraffic}
+            combinedTraffic={totalTraffic.combinedTraffic}
+          />
+        </Grid>
+      )}
+    </React.Fragment>
+  );
+};
+
+export default withTheme(NetworkGraph);

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph.tsx
@@ -1,3 +1,4 @@
+import { Stats } from 'linode-js-sdk/lib/linodes';
 import { map, pathOr } from 'ramda';
 import * as React from 'react';
 import {
@@ -36,7 +37,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 interface Props extends ChartProps {
   timezone: string;
   rangeSelection: string;
-  stats: any;
+  stats?: Stats;
 }
 
 export type CombinedProps = Props & WithTheme;
@@ -48,26 +49,33 @@ interface NetworkMetrics {
   privateOut: Metrics;
 }
 
-const _getMetrics = (data: any) => {
+interface NetworkStats {
+  publicIn: [number, number][];
+  publicOut: [number, number][];
+  privateIn: [number, number][];
+  privateOut: [number, number][];
+}
+
+const _getMetrics = (data: NetworkStats) => {
   return {
     publicIn: getMetrics(data.publicIn),
     publicOut: getMetrics(data.publicOut),
     privateIn: getMetrics(data.privateIn),
-    privateOut: data.privateOut && getMetrics(data.privateOut)
+    privateOut: getMetrics(data.privateOut ?? [])
   };
 };
 
 export const NetworkGraph: React.FC<CombinedProps> = props => {
-  const { rangeSelection, stats, timezone, theme, ...rest } = props;
+  const { rangeSelection, stats, theme, ...rest } = props;
 
-  const v4Data = {
+  const v4Data: NetworkStats = {
     publicIn: pathOr([], ['data', 'netv4', 'in'], stats),
     publicOut: pathOr([], ['data', 'netv4', 'out'], stats),
     privateIn: pathOr([], ['data', 'netv4', 'private_in'], stats),
     privateOut: pathOr([], ['data', 'netv4', 'private_out'], stats)
   };
 
-  const v6Data = {
+  const v6Data: NetworkStats = {
     publicIn: pathOr([], ['data', 'netv6', 'in'], stats),
     publicOut: pathOr([], ['data', 'netv6', 'out'], stats),
     privateIn: pathOr([], ['data', 'netv6', 'private_in'], stats),
@@ -116,7 +124,7 @@ export const NetworkGraph: React.FC<CombinedProps> = props => {
   );
 
   const commonGraphProps = {
-    timezone,
+    timezone: props.timezone,
     theme,
     chartHeight: props.height,
     rangeSelection

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph.tsx
@@ -1,6 +1,7 @@
 import { Stats } from 'linode-js-sdk/lib/linodes';
 import { map, pathOr } from 'ramda';
 import * as React from 'react';
+import { compose } from 'recompose';
 import {
   makeStyles,
   Theme,
@@ -119,7 +120,7 @@ export const NetworkGraph: React.FC<CombinedProps> = props => {
       v6Metrics.publicIn.max,
       v6Metrics.publicOut.max,
       v6Metrics.privateIn.max,
-      v6Metrics.privateOut?.max ?? 0
+      v6Metrics.privateOut.max
     )
   );
 
@@ -164,7 +165,7 @@ export const NetworkGraph: React.FC<CombinedProps> = props => {
 
 interface GraphProps {
   timezone: string;
-  data: any;
+  data: NetworkStats;
   unit: string;
   theme: Theme;
   rangeSelection: string;
@@ -188,13 +189,23 @@ const Graph: React.FC<GraphProps> = props => {
 
   const format = formatBitsPerSecond;
 
-  const convertNetworkData = (point: any) => {
+  const convertNetworkData = (point: [number, number]) => {
     return [point[0], convertNetworkToUnit(point[1], unit as any)];
   };
-  const convertedPublicIn = data.publicIn.map(convertNetworkData);
-  const convertedPublicOut = data.publicOut.map(convertNetworkData);
-  const convertedPrivateIn = data.privateIn.map(convertNetworkData);
-  const convertedPrivateOut = data.privateOut?.map(convertNetworkData) ?? [];
+  const convertedPublicIn = data.publicIn.map(convertNetworkData) as [
+    number,
+    number
+  ][];
+  const convertedPublicOut = data.publicOut.map(convertNetworkData) as [
+    number,
+    number
+  ][];
+  const convertedPrivateIn = data.privateIn.map(convertNetworkData) as [
+    number,
+    number
+  ][];
+  const convertedPrivateOut =
+    (data.privateOut?.map(convertNetworkData) as [number, number][]) ?? [];
 
   return (
     <React.Fragment>
@@ -263,4 +274,5 @@ const Graph: React.FC<GraphProps> = props => {
   );
 };
 
-export default withTheme(NetworkGraph);
+const enhanced = compose<CombinedProps, Props>(withTheme, React.memo);
+export default enhanced(NetworkGraph);

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/types.ts
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/types.ts
@@ -1,0 +1,8 @@
+export interface ChartProps {
+  height: number;
+  loading: boolean;
+  error?: string;
+  isTooEarlyForGraphData: boolean;
+  timezone: string;
+  rangeSelection: string;
+}

--- a/packages/manager/src/utilities/statMetrics.test.ts
+++ b/packages/manager/src/utilities/statMetrics.test.ts
@@ -26,15 +26,36 @@ describe('Stat Metrics', () => {
     expect(metrics.max).toBe(2.98);
     const newData = [...data, [0, 100]];
     expect(getMetrics(newData).max).toBe(100.0);
-    expect(getMetrics([[0, 0], [0, 0]]).max).toBe(0);
+    expect(
+      getMetrics([
+        [0, 0],
+        [0, 0]
+      ]).max
+    ).toBe(0);
   });
 
   it('returns average', () => {
     expect(metrics.average).toBe(0.63);
     expect(getMetrics([[0, 0]]).average).toBe(0);
-    expect(getMetrics([[0, 0], [0, 0]]).average).toBe(0);
-    expect(getMetrics([[0, 0], [0, 1]]).average).toBe(0.5);
-    expect(getMetrics([[0, 0], [0, 3], [0, 12]]).average).toBe(5);
+    expect(
+      getMetrics([
+        [0, 0],
+        [0, 0]
+      ]).average
+    ).toBe(0);
+    expect(
+      getMetrics([
+        [0, 0],
+        [0, 1]
+      ]).average
+    ).toBe(0.5);
+    expect(
+      getMetrics([
+        [0, 0],
+        [0, 3],
+        [0, 12]
+      ]).average
+    ).toBe(5);
   });
 
   it('returns last', () => {
@@ -71,7 +92,12 @@ describe('Stat Metrics', () => {
       max: 3,
       total: 3
     });
-    expect(getMetrics([[3, 'hello'], ['hello', 3]] as any)).toEqual({
+    expect(
+      getMetrics([
+        [3, 'hello'],
+        ['hello', 3]
+      ] as any)
+    ).toEqual({
       average: 1.5,
       last: 3,
       length: 2,
@@ -101,16 +127,10 @@ describe('format magnitude', () => {
     expect(formatMagnitude(99.09, 'b/s')).toBe('99.09 b/s');
   });
 
-  it('milli', () => {
-    expect(formatMagnitude('0.021', 'b/s')).toBe('21.00 mb/s');
-    expect(formatMagnitude('0.001', 'b/s')).toBe('1.00 mb/s');
-    expect(formatMagnitude('0.999', 'b/s')).toBe('999.00 mb/s');
-  });
-
   it('kilo', () => {
-    expect(formatMagnitude('6211.21', 'b/s')).toBe('6.21 kb/s');
-    expect(formatMagnitude('1000', 'b/s')).toBe('1.00 kb/s');
-    expect(formatMagnitude('555555', 'b/s')).toBe('555.55 kb/s');
+    expect(formatMagnitude('6211.21', 'b/s')).toBe('6.21 Kb/s');
+    expect(formatMagnitude('1000', 'b/s')).toBe('1.00 Kb/s');
+    expect(formatMagnitude('555555', 'b/s')).toBe('555.55 Kb/s');
   });
 
   it('mega', () => {

--- a/packages/manager/src/utilities/statMetrics.test.ts
+++ b/packages/manager/src/utilities/statMetrics.test.ts
@@ -128,9 +128,9 @@ describe('format magnitude', () => {
   });
 
   it('kilo', () => {
-    expect(formatMagnitude('6211.21', 'b/s')).toBe('6.21 Kb/s');
-    expect(formatMagnitude('1000', 'b/s')).toBe('1.00 Kb/s');
-    expect(formatMagnitude('555555', 'b/s')).toBe('555.55 Kb/s');
+    expect(formatMagnitude('6211.21', 'b/s')).toBe('6.21 kb/s');
+    expect(formatMagnitude('1000', 'b/s')).toBe('1.00 kb/s');
+    expect(formatMagnitude('555555', 'b/s')).toBe('555.55 kb/s');
   });
 
   it('mega', () => {

--- a/packages/manager/src/utilities/statMetrics.tsx
+++ b/packages/manager/src/utilities/statMetrics.tsx
@@ -21,19 +21,17 @@ export const getMetrics = (data: number[][]): Metrics => {
   let sum = 0;
 
   // The data is large, so we get everything we need in one iteration
-  data.forEach(
-    ([_, value]: number[], idx): void => {
-      if (!value || isNaN(value)) {
-        return;
-      }
-
-      if (value > max) {
-        max = value;
-      }
-
-      sum += value;
+  data.forEach(([_, value]: number[], idx): void => {
+    if (!value || isNaN(value)) {
+      return;
     }
-  );
+
+    if (value > max) {
+      max = value;
+    }
+
+    sum += value;
+  });
 
   const length = data.length;
 
@@ -57,9 +55,8 @@ export const formatMagnitude = (value: number | string, unit: string) => {
   const ranges = [
     { divider: 1e9, suffix: 'G' },
     { divider: 1e6, suffix: 'M' },
-    { divider: 1e3, suffix: 'k' },
-    { divider: 1, suffix: '' },
-    { divider: 1e-3, suffix: 'm' }
+    { divider: 1e3, suffix: 'K' },
+    { divider: 1, suffix: '' }
   ];
 
   let finalNum;

--- a/packages/manager/src/utilities/statMetrics.tsx
+++ b/packages/manager/src/utilities/statMetrics.tsx
@@ -55,7 +55,7 @@ export const formatMagnitude = (value: number | string, unit: string) => {
   const ranges = [
     { divider: 1e9, suffix: 'G' },
     { divider: 1e6, suffix: 'M' },
-    { divider: 1e3, suffix: 'K' },
+    { divider: 1e3, suffix: 'k' },
     { divider: 1, suffix: '' }
   ];
 


### PR DESCRIPTION
## Description

- Calculate max units for Linode IPv4/IPv6 graphs and convert graphs to that unit.
- v4 and v6 graphs were redundant and tightly coupled, so I extracted them to a separate component. This also made it easier for the unit in the graph header to be dynamic.

LineGraph had 3 props related to units:
- unit
- maxUnit
- tooltipUnit

Unit was unused, so I removed it and renamed tooltipUnit to unit to be
more concise.