### PR TITLE
[M3-3689] Add: Ability to delete a Domain from Domain Detail

### DIFF
--- a/packages/manager/src/features/Domains/DeleteDomain.test.tsx
+++ b/packages/manager/src/features/Domains/DeleteDomain.test.tsx
@@ -1,4 +1,3 @@
-// import '@testing-library/jest-dom/extend-expect';
 import { cleanup, fireEvent, render, wait } from '@testing-library/react';
 import * as React from 'react';
 import { reactRouterProps } from 'src/__data__/reactRouterProps';

--- a/packages/manager/src/features/Domains/DeleteDomain.test.tsx
+++ b/packages/manager/src/features/Domains/DeleteDomain.test.tsx
@@ -1,0 +1,56 @@
+// import '@testing-library/jest-dom/extend-expect';
+import { cleanup, fireEvent, render, wait } from '@testing-library/react';
+import * as React from 'react';
+import { reactRouterProps } from 'src/__data__/reactRouterProps';
+import { wrapWithTheme } from 'src/utilities/testHelpers';
+import { CombinedProps, DeleteDomain } from './DeleteDomain';
+
+afterEach(cleanup);
+
+const mockDeleteDomain = jest.fn(() => Promise.resolve({}));
+const domainId = 1;
+const domainLabel = 'example.com';
+
+const props: CombinedProps = {
+  domainId,
+  domainLabel,
+  ...reactRouterProps,
+  enqueueSnackbar: jest.fn(),
+  closeSnackbar: jest.fn(),
+  domainActions: {
+    createDomain: jest.fn(),
+    deleteDomain: mockDeleteDomain,
+    updateDomain: jest.fn()
+  }
+};
+
+describe('DeleteDomain', () => {
+  it('includes a button to delete the domain', () => {
+    const { getByText } = render(wrapWithTheme(<DeleteDomain {...props} />));
+    getByText('Delete Domain');
+  });
+
+  it('displays the modal when the button is clicked', () => {
+    const { getByText } = render(wrapWithTheme(<DeleteDomain {...props} />));
+    fireEvent.click(getByText('Delete Domain'));
+    getByText(/Are you sure you want to delete/);
+  });
+
+  it('dispatches the deleteDomain action when the "Delete" button is clicked', async () => {
+    const { getByText } = render(wrapWithTheme(<DeleteDomain {...props} />));
+    fireEvent.click(getByText('Delete Domain'));
+    await wait(() => fireEvent.click(getByText('Delete')));
+    expect(mockDeleteDomain).toHaveBeenCalledWith({ domainId });
+  });
+
+  it('closes the modal when the "Cancel" button is clicked', async () => {
+    const { getByText, queryByText } = render(
+      wrapWithTheme(<DeleteDomain {...props} />)
+    );
+    fireEvent.click(getByText('Delete Domain'));
+    await wait(() => fireEvent.click(getByText('Cancel')));
+    await wait(() =>
+      expect(queryByText(/Are you sure you want to delete/)).toBeNull()
+    );
+  });
+});

--- a/packages/manager/src/features/Domains/DeleteDomain.tsx
+++ b/packages/manager/src/features/Domains/DeleteDomain.tsx
@@ -16,12 +16,12 @@ interface Props {
   domainLabel: string;
 }
 
-type CombinedProps = Props &
+export type CombinedProps = Props &
   WithSnackbarProps &
   RouteComponentProps &
   DomainActionsProps;
 
-const DeleteDomain: React.FC<CombinedProps> = props => {
+export const DeleteDomain: React.FC<CombinedProps> = props => {
   const {
     dialog,
     openDialog,

--- a/packages/manager/src/features/Domains/DeleteDomain.tsx
+++ b/packages/manager/src/features/Domains/DeleteDomain.tsx
@@ -1,0 +1,76 @@
+import { withSnackbar, WithSnackbarProps } from 'notistack';
+import * as React from 'react';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { compose } from 'recompose';
+import Button from 'src/components/Button';
+import DeletionDialog from 'src/components/DeletionDialog';
+import { useDialog } from 'src/hooks/useDialog';
+import {
+  DomainActionsProps,
+  withDomainActions
+} from 'src/store/domains/domains.container';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+
+interface Props {
+  domainId: number;
+  domainLabel: string;
+}
+
+type CombinedProps = Props &
+  WithSnackbarProps &
+  RouteComponentProps &
+  DomainActionsProps;
+
+const DeleteDomain: React.FC<CombinedProps> = props => {
+  const {
+    dialog,
+    openDialog,
+    closeDialog,
+    submitDialog,
+    handleError
+  } = useDialog<number>((domainId: number) =>
+    props.domainActions.deleteDomain({ domainId })
+  );
+
+  const handleDelete = () => {
+    submitDialog(dialog.entityID)
+      .then(() => {
+        props.enqueueSnackbar('Domain deleted successfully.', {
+          variant: 'success'
+        });
+        props.history.push('/domains');
+      })
+      .catch(e =>
+        handleError(getAPIErrorOrDefault(e, 'Error deleting domain.')[0].reason)
+      );
+  };
+
+  return (
+    <>
+      <Button
+        buttonType="secondary"
+        destructive
+        onClick={() => openDialog(props.domainId, props.domainLabel)}
+      >
+        Delete Domain
+      </Button>
+      <DeletionDialog
+        open={dialog.isOpen}
+        label={dialog.entityLabel || ''}
+        loading={dialog.isLoading}
+        error={dialog.error}
+        onClose={closeDialog}
+        onDelete={handleDelete}
+      />
+    </>
+  );
+};
+
+const enhanced = compose<CombinedProps, Props>(
+  withSnackbar,
+  withRouter,
+  withDomainActions,
+  React.memo
+);
+
+export default enhanced(DeleteDomain);

--- a/packages/manager/src/features/Domains/DomainRecordsWrapper.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordsWrapper.tsx
@@ -9,6 +9,7 @@ import TagsPanel from 'src/components/TagsPanel';
 import summaryPanelStyles, {
   StyleProps
 } from 'src/containers/SummaryPanels.styles';
+import DeleteDomain from './DeleteDomain';
 import DomainRecords from './DomainRecords';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -71,6 +72,9 @@ const DomainRecordsWrapper: React.FC<CombinedProps> = props => {
             <TagsPanel tags={domain.tags} updateTags={handleUpdateTags} />
           </div>
         </Paper>
+        <div className={hookClasses.tagPanel}>
+          <DeleteDomain domainId={domain.id} domainLabel={domain.domain} />
+        </div>
       </Grid>
     </Grid>
   );


### PR DESCRIPTION
## Description

This PR adds the ability to delete a domain from the Domain Details page.

![Screen Shot 2020-01-20 at 4 16 46 PM](https://user-images.githubusercontent.com/16911484/72758257-48c68f80-3ba0-11ea-8edb-2e74594afc63.png)


Still to do:
- [x] Write tests

## Type of Change
- Non breaking change ('update', 'change')
