### PR TITLE
M3-3819 Longview user preferences

### DIFF
--- a/packages/linode-js-sdk/src/profile/profile.ts
+++ b/packages/linode-js-sdk/src/profile/profile.ts
@@ -9,7 +9,7 @@ import Request, {
 } from '../request';
 import { ResourcePage } from '../types';
 import { updateProfileSchema } from './profile.schema';
-import { Profile, TrustedDevice } from './types';
+import { Profile, TrustedDevice, UserPreferences } from './types';
 
 /**
  * getProfile
@@ -110,8 +110,8 @@ export const getUserPreferences = () => {
  * Stores an arbitrary JSON blob for the purposes of implementing
  * conditional logic based on preferences the user chooses
  */
-export const updateUserPreferences = (payload: Record<string, any>) => {
-  return Request<Record<string, any>>(
+export const updateUserPreferences = (payload: UserPreferences) => {
+  return Request<UserPreferences>(
     setURL(`${API_ROOT}/profile/preferences`),
     setData(payload),
     setMethod('PUT')

--- a/packages/linode-js-sdk/src/profile/types.ts
+++ b/packages/linode-js-sdk/src/profile/types.ts
@@ -61,3 +61,5 @@ export interface Secret {
   secret: string;
   expiry: Date;
 }
+
+export type UserPreferences = Record<string, any>;

--- a/packages/manager/src/LinodeThemeWrapper.tsx
+++ b/packages/manager/src/LinodeThemeWrapper.tsx
@@ -15,8 +15,8 @@ import {
   sendThemeToggleEvent
 } from 'src/utilities/ga';
 
-type ThemeChoice = 'light' | 'dark';
-type SpacingChoice = 'compact' | 'normal';
+export type ThemeChoice = 'light' | 'dark';
+export type SpacingChoice = 'compact' | 'normal';
 
 type RenderChildren = (
   toggle: () => void,
@@ -96,7 +96,10 @@ const LinodeThemeWrapper: React.FC<CombinedProps> = props => {
             togglePreference: _toggleSpacing
           }: ToggleProps<SpacingChoice>) => (
             <ThemeProvider
-              theme={safelyGetTheme(themes, themeChoice)({
+              theme={safelyGetTheme(
+                themes,
+                themeChoice
+              )({
                 spacingOverride:
                   spacingChoice === 'compact'
                     ? COMPACT_SPACING_UNIT

--- a/packages/manager/src/components/PreferenceToggle/PreferenceToggle.tsx
+++ b/packages/manager/src/components/PreferenceToggle/PreferenceToggle.tsx
@@ -173,7 +173,7 @@ const PreferenceToggle: React.FC<CombinedProps> = props => {
             .then(response => {
               props
                 .updateUserPreferences({
-                  ...response.preferences,
+                  ...response,
                   [preferenceKey]: currentlySetPreference
                 })
                 .catch(() => /** swallow the error */ null);

--- a/packages/manager/src/containers/preferences.container.ts
+++ b/packages/manager/src/containers/preferences.container.ts
@@ -32,7 +32,7 @@ export default <TInner extends {}, TOuter extends {}>(
       if (mapAccountToProps) {
         return mapAccountToProps(ownProps, state.preferences);
       }
-      return { preferences: state.preferences.data };
+      return { preferences: state.preferences.data ?? {} };
     },
     (dispatch: ThunkDispatch) => ({
       getUserPreferences: () => dispatch(getUserPreferences()),

--- a/packages/manager/src/containers/preferences.container.ts
+++ b/packages/manager/src/containers/preferences.container.ts
@@ -1,4 +1,4 @@
-import { Profile } from 'linode-js-sdk/lib/profile';
+import { Profile, UserPreferences } from 'linode-js-sdk/lib/profile';
 
 import { connect } from 'react-redux';
 import { ApplicationState } from 'src/store';
@@ -11,12 +11,18 @@ import {
 
 import { ThunkDispatch } from 'src/store/types';
 
+export interface PreferencesStateProps {
+  preferences: UserPreferences;
+}
+
 export interface PreferencesActionsProps {
   getUserPreferences: () => Promise<Record<string, any>>;
   updateUserPreferences: (
     params: Record<string, any>
   ) => Promise<Record<string, any>>;
 }
+
+export type Props = PreferencesActionsProps & PreferencesStateProps;
 
 export default <TInner extends {}, TOuter extends {}>(
   mapAccountToProps?: (ownProps: TOuter, profile: State) => TInner
@@ -26,7 +32,7 @@ export default <TInner extends {}, TOuter extends {}>(
       if (mapAccountToProps) {
         return mapAccountToProps(ownProps, state.preferences);
       }
-      return {};
+      return { preferences: state.preferences.data };
     },
     (dispatch: ThunkDispatch) => ({
       getUserPreferences: () => dispatch(getUserPreferences()),

--- a/packages/manager/src/containers/preferences.container.ts
+++ b/packages/manager/src/containers/preferences.container.ts
@@ -1,8 +1,7 @@
-import { Profile, UserPreferences } from 'linode-js-sdk/lib/profile';
-
 import { connect } from 'react-redux';
 import { ApplicationState } from 'src/store';
 
+import { UserPreferences } from 'src/store/preferences/preferences.actions';
 import { State } from 'src/store/preferences/preferences.reducer';
 import {
   getUserPreferences,
@@ -16,10 +15,8 @@ export interface PreferencesStateProps {
 }
 
 export interface PreferencesActionsProps {
-  getUserPreferences: () => Promise<Record<string, any>>;
-  updateUserPreferences: (
-    params: Record<string, any>
-  ) => Promise<Record<string, any>>;
+  getUserPreferences: () => Promise<UserPreferences>;
+  updateUserPreferences: (params: UserPreferences) => Promise<UserPreferences>;
 }
 
 export type Props = PreferencesActionsProps & PreferencesStateProps;
@@ -36,7 +33,7 @@ export default <TInner extends {}, TOuter extends {}>(
     },
     (dispatch: ThunkDispatch) => ({
       getUserPreferences: () => dispatch(getUserPreferences()),
-      updateUserPreferences: (payload: Partial<Profile>) =>
+      updateUserPreferences: (payload: UserPreferences) =>
         dispatch(updateUserPreferences(payload))
     })
   );

--- a/packages/manager/src/features/Longview/shared/TimeRangeSelect.tsx
+++ b/packages/manager/src/features/Longview/shared/TimeRangeSelect.tsx
@@ -43,10 +43,19 @@ const TimeRangeSelect: React.FC<CombinedProps> = props => {
   /*
     the time range is the label instead of the value because it's a lot harder
     to keep Date.now() consistent with this state. We can get the actual
-    values when it comes time to make the request
+    values when it comes time to make the request.
+
+    Use the value from user preferences if available, then fall back to
+    the default that was passed to the component, and use Past 30 Minutes
+    if all else fails.
+
+    @todo Validation here to make sure that the value from user preferences
+    is a valid time window.
   */
   const [selectedTimeRange, setTimeRange] = React.useState<Labels>(
-    preferences?.longviewTimeRange || defaultValue || 'Past 30 Minutes'
+    (preferences?.longviewTimeRange as Labels) ||
+      defaultValue ||
+      'Past 30 Minutes'
   );
 
   /*

--- a/packages/manager/src/features/Longview/shared/TimeRangeSelect.tsx
+++ b/packages/manager/src/features/Longview/shared/TimeRangeSelect.tsx
@@ -59,7 +59,6 @@ const TimeRangeSelect: React.FC<CombinedProps> = props => {
   const nowInSeconds = Date.now() / 1000;
 
   React.useEffect(() => {
-    // Check if we have a
     // Do the math and send start/end values to the consumer
     // (in most cases the consumer has passed defaultValue={'last 30 minutes'}
     // but the calcs to turn that into start/end numbers live here)

--- a/packages/manager/src/store/preferences/preferences.actions.ts
+++ b/packages/manager/src/store/preferences/preferences.actions.ts
@@ -1,16 +1,31 @@
 import { APIError } from 'linode-js-sdk/lib/types';
 import { actionCreatorFactory } from 'typescript-fsa';
 
+import { SpacingChoice, ThemeChoice } from 'src/LinodeThemeWrapper';
+
 const actionCreator = actionCreatorFactory(`@@manager/preferences`);
+
+export interface UserPreferences {
+  longviewTimeRange?: string;
+  gst_banner_dismissed?: boolean;
+  linodes_group_by_tag?: boolean;
+  domains_group_by_tag?: boolean;
+  volumes_group_by_tag?: boolean;
+  nodebalancers_group_by_tag?: boolean;
+  linodes_view_style?: 'grid' | 'list';
+  theme?: ThemeChoice;
+  spacing?: SpacingChoice;
+  desktop_sidebar_open?: boolean;
+}
 
 export const handleGetPreferences = actionCreator.async<
   void,
-  Record<string, any>,
+  UserPreferences,
   APIError[]
 >(`get`);
 
 export const handleUpdatePreferences = actionCreator.async<
-  Record<string, any>,
-  Record<string, any>,
+  UserPreferences,
+  UserPreferences,
   APIError[]
 >(`update`);

--- a/packages/manager/src/store/preferences/preferences.reducer.ts
+++ b/packages/manager/src/store/preferences/preferences.reducer.ts
@@ -3,10 +3,11 @@ import { reducerWithInitialState } from 'typescript-fsa-reducers';
 import { EntityError, RequestableData } from '../types';
 import {
   handleGetPreferences,
-  handleUpdatePreferences
+  handleUpdatePreferences,
+  UserPreferences
 } from './preferences.actions';
 
-export type State = RequestableData<Record<string, any>, EntityError>;
+export type State = RequestableData<UserPreferences, EntityError>;
 
 export const defaultState: State = {
   lastUpdated: 0,

--- a/packages/manager/src/store/preferences/preferences.requests.ts
+++ b/packages/manager/src/store/preferences/preferences.requests.ts
@@ -5,11 +5,12 @@ import {
 import { ThunkActionCreator } from 'src/store/types';
 import {
   handleGetPreferences,
-  handleUpdatePreferences
+  handleUpdatePreferences,
+  UserPreferences
 } from './preferences.actions';
 
 export const getUserPreferences: ThunkActionCreator<Promise<
-  Record<string, any>
+  UserPreferences
 >> = () => dispatch => {
   const { started, done, failed } = handleGetPreferences;
 
@@ -35,8 +36,8 @@ export const getUserPreferences: ThunkActionCreator<Promise<
 };
 
 export const updateUserPreferences: ThunkActionCreator<
-  Promise<Record<string, any>>,
-  Record<string, any>
+  Promise<UserPreferences>,
+  UserPreferences
 > = payload => dispatch => {
   const { started, done, failed } = handleUpdatePreferences;
 

--- a/packages/manager/src/store/preferences/preferences.requests.ts
+++ b/packages/manager/src/store/preferences/preferences.requests.ts
@@ -8,9 +8,9 @@ import {
   handleUpdatePreferences
 } from './preferences.actions';
 
-export const getUserPreferences: ThunkActionCreator<
-  Promise<Record<string, any>>
-> = () => dispatch => {
+export const getUserPreferences: ThunkActionCreator<Promise<
+  Record<string, any>
+>> = () => dispatch => {
   const { started, done, failed } = handleGetPreferences;
 
   dispatch(started());
@@ -40,11 +40,7 @@ export const updateUserPreferences: ThunkActionCreator<
 > = payload => dispatch => {
   const { started, done, failed } = handleUpdatePreferences;
 
-  dispatch(
-    started({
-      params: payload
-    })
-  );
+  dispatch(started(payload));
 
   return _updateUserPreferences(payload)
     .then(response => {


### PR DESCRIPTION
## Description

Part I, only addressing the TimeRangeSelects used in Longview

- Return preferences data from the preferences container if no mStP is provided
- Add UserPreferences type to the SDK for easier reference
- Wrap TimeRangeSelect in the container, and default the select value to
the one stored in the longviewTimeRange preference
- Request + update preferences every time the time range is toggled
