### PR TITLE
M3-3826 Delete Domain from drawer

### DIFF
--- a/packages/manager/src/features/Domains/DeleteDomain.tsx
+++ b/packages/manager/src/features/Domains/DeleteDomain.tsx
@@ -1,6 +1,5 @@
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import * as React from 'react';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
 import Button from 'src/components/Button';
 import DeletionDialog from 'src/components/DeletionDialog';
@@ -14,12 +13,11 @@ import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 interface Props {
   domainId: number;
   domainLabel: string;
+  // Function that is invoked after Domain has been successfully deleted.
+  onSuccess?: () => void;
 }
 
-export type CombinedProps = Props &
-  WithSnackbarProps &
-  RouteComponentProps &
-  DomainActionsProps;
+export type CombinedProps = Props & WithSnackbarProps & DomainActionsProps;
 
 export const DeleteDomain: React.FC<CombinedProps> = props => {
   const {
@@ -38,7 +36,9 @@ export const DeleteDomain: React.FC<CombinedProps> = props => {
         props.enqueueSnackbar('Domain deleted successfully.', {
           variant: 'success'
         });
-        props.history.push('/domains');
+        if (props.onSuccess) {
+          props.onSuccess();
+        }
       })
       .catch(e =>
         handleError(getAPIErrorOrDefault(e, 'Error deleting domain.')[0].reason)
@@ -68,7 +68,6 @@ export const DeleteDomain: React.FC<CombinedProps> = props => {
 
 const enhanced = compose<CombinedProps, Props>(
   withSnackbar,
-  withRouter,
   withDomainActions,
   React.memo
 );

--- a/packages/manager/src/features/Domains/DomainDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainDrawer.tsx
@@ -16,6 +16,7 @@ import { bindActionCreators } from 'redux';
 import ActionsPanel from 'src/components/ActionsPanel';
 import AddNewLink from 'src/components/AddNewLink';
 import Button from 'src/components/Button';
+import Divider from 'src/components/core/Divider';
 import FormControlLabel from 'src/components/core/FormControlLabel';
 import FormHelperText from 'src/components/core/FormHelperText';
 import RadioGroup from 'src/components/core/RadioGroup';
@@ -26,10 +27,14 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 import Drawer from 'src/components/Drawer';
+import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import Notice from 'src/components/Notice';
 import Radio from 'src/components/Radio';
 import TagsInput, { Tag } from 'src/components/TagsInput';
 import TextField from 'src/components/TextField';
+import { reportException } from 'src/exceptionReporting';
+import LinodeSelect from 'src/features/linodes/LinodeSelect';
+import NodeBalancerSelect from 'src/features/NodeBalancers/NodeBalancerSelect';
 import {
   hasGrant,
   isRestrictedUser
@@ -46,18 +51,13 @@ import {
   DomainActionsProps,
   withDomainActions
 } from 'src/store/domains/domains.container';
-import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
-import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
-
-import Select, { Item } from 'src/components/EnhancedSelect/Select';
-import { reportException } from 'src/exceptionReporting';
-import LinodeSelect from 'src/features/linodes/LinodeSelect';
-import NodeBalancerSelect from 'src/features/NodeBalancers/NodeBalancerSelect';
-import { getErrorMap } from 'src/utilities/errorUtils';
+import { getAPIErrorOrDefault, getErrorMap } from 'src/utilities/errorUtils';
 import { sendCreateDomainEvent } from 'src/utilities/ga';
+import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
+import DeleteDomain from './DeleteDomain';
 import DomainTransferInput from './DomainTransferInput';
 
-type ClassNames = 'root' | 'masterIPErrorNotice' | 'addIP';
+type ClassNames = 'root' | 'masterIPErrorNotice' | 'addIP' | 'divider';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -67,6 +67,10 @@ const styles = (theme: Theme) =>
     },
     addIP: {
       left: -theme.spacing(2) + 3
+    },
+    divider: {
+      marginTop: theme.spacing(2),
+      marginBottom: theme.spacing(4)
     }
   });
 
@@ -481,6 +485,16 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
             Cancel
           </Button>
         </ActionsPanel>
+        {mode === EDITING && this.props.id && this.props.domain && (
+          <>
+            <Divider className={classes.divider} />
+            <DeleteDomain
+              domainId={this.props.id}
+              domainLabel={this.props.domain}
+              onSuccess={this.closeDrawer}
+            />
+          </>
+        )}
       </Drawer>
     );
   }

--- a/packages/manager/src/features/Domains/DomainRecordsWrapper.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordsWrapper.tsx
@@ -1,6 +1,6 @@
 import { Domain, DomainRecord } from 'linode-js-sdk/lib/domains';
 import * as React from 'react';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 import { compose } from 'recompose';
 import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme, withStyles } from 'src/components/core/styles';
@@ -44,11 +44,12 @@ interface Props {
   handleUpdateTags: (tagList: string[]) => Promise<Domain>;
 }
 
-type CombinedProps = Props & StyleProps & RouteComponentProps;
+type CombinedProps = Props & StyleProps;
 
 const DomainRecordsWrapper: React.FC<CombinedProps> = props => {
   const { domain, records, updateRecords, handleUpdateTags, classes } = props;
   const hookClasses = useStyles();
+  const history = useHistory();
 
   return (
     <Grid container className={hookClasses.root}>
@@ -77,7 +78,7 @@ const DomainRecordsWrapper: React.FC<CombinedProps> = props => {
           <DeleteDomain
             domainId={domain.id}
             domainLabel={domain.domain}
-            onSuccess={() => props.history.push('/domains')}
+            onSuccess={() => history.push('/domains')}
           />
         </div>
       </Grid>
@@ -89,6 +90,5 @@ const styled = withStyles(summaryPanelStyles);
 
 export default compose<CombinedProps, Props>(
   React.memo,
-  styled,
-  withRouter
+  styled
 )(DomainRecordsWrapper);

--- a/packages/manager/src/features/Domains/DomainRecordsWrapper.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordsWrapper.tsx
@@ -1,5 +1,6 @@
 import { Domain, DomainRecord } from 'linode-js-sdk/lib/domains';
 import * as React from 'react';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
 import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme, withStyles } from 'src/components/core/styles';
@@ -43,7 +44,7 @@ interface Props {
   handleUpdateTags: (tagList: string[]) => Promise<Domain>;
 }
 
-type CombinedProps = Props & StyleProps;
+type CombinedProps = Props & StyleProps & RouteComponentProps;
 
 const DomainRecordsWrapper: React.FC<CombinedProps> = props => {
   const { domain, records, updateRecords, handleUpdateTags, classes } = props;
@@ -73,7 +74,11 @@ const DomainRecordsWrapper: React.FC<CombinedProps> = props => {
           </div>
         </Paper>
         <div className={hookClasses.tagPanel}>
-          <DeleteDomain domainId={domain.id} domainLabel={domain.domain} />
+          <DeleteDomain
+            domainId={domain.id}
+            domainLabel={domain.domain}
+            onSuccess={() => props.history.push('/domains')}
+          />
         </div>
       </Grid>
     </Grid>
@@ -84,5 +89,6 @@ const styled = withStyles(summaryPanelStyles);
 
 export default compose<CombinedProps, Props>(
   React.memo,
-  styled
+  styled,
+  withRouter
 )(DomainRecordsWrapper);

--- a/packages/manager/src/features/Domains/DomainsLanding.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.tsx
@@ -4,7 +4,7 @@ import { withSnackbar, WithSnackbarProps } from 'notistack';
 import { pathOr } from 'ramda';
 import * as React from 'react';
 import { connect, MapStateToProps } from 'react-redux';
-import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
+import { Link, RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
 import DomainIcon from 'src/assets/addnewmenu/domain.svg';
 import ActionsPanel from 'src/components/ActionsPanel';
@@ -25,8 +25,10 @@ import setDocs from 'src/components/DocsSidebar/setDocs';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
+import Notice from 'src/components/Notice';
 import OrderBy from 'src/components/OrderBy';
 import Placeholder from 'src/components/Placeholder';
+import PreferenceToggle, { ToggleProps } from 'src/components/PreferenceToggle';
 import Toggle from 'src/components/Toggle';
 import domainsContainer, {
   Props as DomainProps,
@@ -35,6 +37,7 @@ import domainsContainer, {
 import { Domains } from 'src/documentation';
 import ListDomains from 'src/features/Domains/ListDomains';
 import ListGroupedDomains from 'src/features/Domains/ListGroupedDomains';
+import { ApplicationState } from 'src/store';
 import {
   openForCloning,
   openForCreating,
@@ -45,10 +48,6 @@ import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { sendGroupByTagEnabledEvent } from 'src/utilities/ga';
 import DisableDomainDialog from './DisableDomainDialog';
 import DomainZoneImportDrawer from './DomainZoneImportDrawer';
-
-import Notice from 'src/components/Notice';
-import PreferenceToggle, { ToggleProps } from 'src/components/PreferenceToggle';
-import { ApplicationState } from 'src/store';
 
 type ClassNames =
   | 'root'
@@ -530,10 +529,11 @@ const mapStateToProps: MapStateToProps<
   )
 });
 
-export const connected = connect(
-  mapStateToProps,
-  { openForCreating, openForCloning, openForEditing }
-);
+export const connected = connect(mapStateToProps, {
+  openForCreating,
+  openForCloning,
+  openForEditing
+});
 
 export default compose<CombinedProps, Props>(
   setDocs(DomainsLanding.docs),
@@ -544,7 +544,6 @@ export default compose<CombinedProps, Props>(
       domainsLoading
     })
   ),
-  withRouter,
   connected,
   withSnackbar,
   styled

--- a/packages/manager/src/hooks/useDialog.ts
+++ b/packages/manager/src/hooks/useDialog.ts
@@ -63,15 +63,24 @@ export const useDialog = <T>(
   const [entityID, setEntityID] = React.useState<number>(-1);
   const [entityLabel, setEntityLabel] = React.useState<string>('');
 
+  const mountedRef = React.useRef<boolean>(true);
+
   const submitDialog = (params: T) => {
     setErrors(undefined);
     setLoading(true);
     return request(params)
       .then(response => {
+        if (!mountedRef.current) {
+          return;
+        }
         handleSuccess();
         return response;
       })
       .catch((e: APIError[]) => {
+        if (!mountedRef.current) {
+          return;
+        }
+
         /**
          * This sets the error to whatever the API returns.
          * Consumers can use the exposed handleError method
@@ -104,6 +113,12 @@ export const useDialog = <T>(
   const closeDialog = () => {
     setOpen(false);
   };
+
+  React.useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   return {
     dialog: { isOpen, isLoading, error, entityLabel, entityID },


### PR DESCRIPTION
## Description

Add a "Delete Domain" button to the Domain Drawer (while in Edit mode). This (along with https://github.com/linode/manager/pull/6028) solves the problem of not being able to delete a domain after clicking on a Slave Domain on the Search Landing page (or Dashboard).

I reused the brand new `<DeleteDomain />` component for this. I made a slight modification so that the consumer can decide what to do after successfully deleting the domain. The `<DeleteDomain />` component _still initiates the Toast_ since I figured we wanted that in all cases, but I'm open to other opinions here.


<img width="465" alt="Screen Shot 2020-01-21 at 12 46 14 PM" src="https://user-images.githubusercontent.com/16911484/72829233-63eed900-3c4c-11ea-9c68-3ab293f53511.png">


## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

To test, open the drawer for a slave domain from the Domains Landing and Dashboard and delete the domain.
