### PR TITLE
LV Improvement- Process Arrow Rework

### DIFF
--- a/packages/manager/src/components/TableRow/TableRow.tsx
+++ b/packages/manager/src/components/TableRow/TableRow.tsx
@@ -13,11 +13,13 @@ import _TableRow, {
   TableRowProps as _TableRowProps
 } from 'src/components/core/TableRow';
 
-import { COMPACT_SPACING_UNIT } from 'src/themeFactory';
-
-import ActiveCaret from 'src/assets/icons/activeRowCaret.svg';
-
-type ClassNames = 'root' | 'selected' | 'withForcedIndex' | 'activeCaret';
+type ClassNames =
+  | 'root'
+  | 'selected'
+  | 'withForcedIndex'
+  | 'activeCaret'
+  | 'activeCaretOverlay'
+  | 'selectedOuter';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -80,16 +82,48 @@ const styles = (theme: Theme) =>
         }
       }
     },
+    selectedOuter: {
+      padding: 0
+    },
     activeCaret: {
-      [theme.breakpoints.down('md')]: {
-        display: 'none'
+      '&:before': {
+        content: '""',
+        width: 15,
+        height: '50%',
+        position: 'absolute',
+        left: '99%',
+        top: 0,
+        background: `linear-gradient(to right top, ${theme.palette.primary.light} 50%, transparent 50%)`
       },
-      color: theme.bg.lightBlue,
-      position: 'absolute',
-      top: 0,
-      right: theme.spacing() === COMPACT_SPACING_UNIT ? -12 : -14,
-      transform: 'translate(-.5px, -.5px)',
-      height: theme.spacing() === COMPACT_SPACING_UNIT ? 34 : 42
+      '&:after': {
+        content: '""',
+        width: 15,
+        height: '50%',
+        position: 'absolute',
+        left: '99%',
+        top: '50%',
+        background: `linear-gradient(to right bottom, ${theme.palette.primary.light} 50%, transparent 50%)`
+      }
+    },
+    activeCaretOverlay: {
+      '&:before': {
+        content: '""',
+        position: 'absolute',
+        left: '100%',
+        top: 0,
+        width: 15,
+        height: '50%',
+        background: `linear-gradient(to right top, ${theme.bg.lightBlue} 46%, transparent 46%)`
+      },
+      '&:after': {
+        content: '""',
+        position: 'absolute',
+        left: '100%',
+        bottom: 0,
+        width: 15,
+        height: '50%',
+        background: `linear-gradient(to right bottom, ${theme.bg.lightBlue} 46%, transparent 46%)`
+      }
     }
   });
 
@@ -188,8 +222,9 @@ class TableRow extends React.Component<CombinedProps> {
         {this.props.children}
         {selected && (
           <Hidden mdDown>
-            <td colSpan={0}>
-              <ActiveCaret className={classes.activeCaret} />
+            <td colSpan={0} className={classes.selectedOuter}>
+              <span className={classes.activeCaret}></span>
+              <span className={classes.activeCaretOverlay}></span>
             </td>
           </Hidden>
         )}

--- a/packages/manager/src/components/TableRow/TableRow.tsx
+++ b/packages/manager/src/components/TableRow/TableRow.tsx
@@ -91,7 +91,7 @@ const styles = (theme: Theme) =>
         width: 15,
         height: '50%',
         position: 'absolute',
-        left: '99%',
+        left: 0,
         top: 0,
         background: `linear-gradient(to right top, ${theme.palette.primary.light} 0%, ${theme.palette.primary.light} 49%, transparent 50.1%)`
       },
@@ -100,7 +100,7 @@ const styles = (theme: Theme) =>
         width: 15,
         height: '50%',
         position: 'absolute',
-        left: '99%',
+        left: 0,
         top: '50%',
         background: `linear-gradient(to right bottom, ${theme.palette.primary.light} 0%, ${theme.palette.primary.light} 49%, transparent 50.1%)`
       }
@@ -109,7 +109,7 @@ const styles = (theme: Theme) =>
       '&:before': {
         content: '""',
         position: 'absolute',
-        left: '100%',
+        left: 0,
         top: 0,
         width: 15,
         height: '50%',
@@ -118,7 +118,7 @@ const styles = (theme: Theme) =>
       '&:after': {
         content: '""',
         position: 'absolute',
-        left: '100%',
+        left: 0,
         bottom: 0,
         width: 15,
         height: '50%',

--- a/packages/manager/src/components/TableRow/TableRow.tsx
+++ b/packages/manager/src/components/TableRow/TableRow.tsx
@@ -93,7 +93,7 @@ const styles = (theme: Theme) =>
         position: 'absolute',
         left: '99%',
         top: 0,
-        background: `linear-gradient(to right top, ${theme.palette.primary.light} 50%, transparent 50%)`
+        background: `linear-gradient(to right top, ${theme.palette.primary.light} 0%, ${theme.palette.primary.light} 49%, transparent 50.1%)`
       },
       '&:after': {
         content: '""',
@@ -102,7 +102,7 @@ const styles = (theme: Theme) =>
         position: 'absolute',
         left: '99%',
         top: '50%',
-        background: `linear-gradient(to right bottom, ${theme.palette.primary.light} 50%, transparent 50%)`
+        background: `linear-gradient(to right bottom, ${theme.palette.primary.light} 0%, ${theme.palette.primary.light} 49%, transparent 50.1%)`
       }
     },
     activeCaretOverlay: {
@@ -113,7 +113,7 @@ const styles = (theme: Theme) =>
         top: 0,
         width: 15,
         height: '50%',
-        background: `linear-gradient(to right top, ${theme.bg.lightBlue} 46%, transparent 46%)`
+        background: `linear-gradient(to right top, ${theme.bg.lightBlue} 0%, ${theme.bg.lightBlue} 45%, transparent 46.1%)`
       },
       '&:after': {
         content: '""',
@@ -122,7 +122,7 @@ const styles = (theme: Theme) =>
         bottom: 0,
         width: 15,
         height: '50%',
-        background: `linear-gradient(to right bottom, ${theme.bg.lightBlue} 46%, transparent 46%)`
+        background: `linear-gradient(to right bottom, ${theme.bg.lightBlue} 0%, ${theme.bg.lightBlue} 45%, transparent 46.1%)`
       }
     }
   });

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Processes/ProcessesTable.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Processes/ProcessesTable.tsx
@@ -1,5 +1,6 @@
 import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
 import OrderBy from 'src/components/OrderBy';
@@ -14,6 +15,15 @@ import { formatCPU } from 'src/features/Longview/shared/formatters';
 import { useWindowDimensions } from 'src/hooks/useWindowDimensions';
 import { readableBytes } from 'src/utilities/unitConversions';
 import { Process } from './types';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  processName: {
+    display: 'flex',
+    flexFlow: 'row nowrap',
+    wordBreak: 'break-all',
+    alignItems: 'center'
+  }
+}));
 
 export interface Props {
   processesData: ExtendedProcess[];
@@ -171,6 +181,9 @@ export const ProcessesTableRow: React.FC<ProcessTableRowProps> = React.memo(
       setSelectedProcess,
       isSelected
     } = props;
+
+    const classes = useStyles();
+
     return (
       <TableRow
         onClick={() => setSelectedProcess({ name, user })}
@@ -182,7 +195,9 @@ export const ProcessesTableRow: React.FC<ProcessTableRowProps> = React.memo(
         forceIndex
         aria-label={`${name} for ${user}`}
       >
-        <TableCell data-testid={`name-${name}`}>{name}</TableCell>
+        <TableCell className={classes.processName} data-testid={`name-${name}`}>
+          {name}
+        </TableCell>
         <TableCell data-testid={`user-${user}`}>{user}</TableCell>
         <TableCell data-testid={`max-count-${Math.round(maxCount)}`}>
           {Math.round(maxCount)}

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Processes/ProcessesTable.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Processes/ProcessesTable.tsx
@@ -195,8 +195,8 @@ export const ProcessesTableRow: React.FC<ProcessTableRowProps> = React.memo(
         forceIndex
         aria-label={`${name} for ${user}`}
       >
-        <TableCell className={classes.processName} data-testid={`name-${name}`}>
-          {name}
+        <TableCell data-testid={`name-${name}`}>
+          <div className={classes.processName}>{name}</div>
         </TableCell>
         <TableCell data-testid={`user-${user}`}>{user}</TableCell>
         <TableCell data-testid={`max-count-${Math.round(maxCount)}`}>


### PR DESCRIPTION
## Description

This was a bit of an edge case- but if the process name was lengthy enough to wrap to next line, the selected caret arrow wouldn't expand with the table row, which was not ideal. The solution was to use pure CSS for the caret instead of an svg so it could dynamically expand/shrink as needed per row. 

## Type of Change
- Bug fix ('fix')

## Note to Reviewers

To test, make a process name long enough to wrap, and observe the new arrow style compared to production. I checked Safari, Firefox, and Chrome without any notable issues, as well as tested to make sure the spans would have no impact for screen readers. There should also be no difference on mobile. 
