### PR TITLE
Bump react-waypoint to 9.0.2

### DIFF
--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -66,7 +66,7 @@
     "react-router-dom": "^5.1.0",
     "react-select": "^2.0.0",
     "react-sticky": "^6.0.3",
-    "react-waypoint": "^8.0.3",
+    "react-waypoint": "~9.0.2",
     "recompose": "^0.30.0",
     "redux": "^4.0.4",
     "redux-thunk": "^2.3.0",

--- a/packages/manager/src/features/Events/EventsLanding.tsx
+++ b/packages/manager/src/features/Events/EventsLanding.tsx
@@ -4,7 +4,7 @@ import { withSnackbar, WithSnackbarProps } from 'notistack';
 import { compose as rCompose, concat, uniq } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
-import Waypoint from 'react-waypoint';
+import { Waypoint } from 'react-waypoint';
 import { compose } from 'recompose';
 import Paper from 'src/components/core/Paper';
 import {
@@ -310,17 +310,17 @@ export const EventsLanding: React.StatelessComponent<CombinedProps> = props => {
           </TableBody>
         </Table>
       </Paper>
-      {loadMoreEvents && (initialLoaded && !isLoading) ? (
+      {loadMoreEvents && initialLoaded && !isLoading ? (
         <Waypoint onEnter={getNext}>
           <div />
         </Waypoint>
       ) : (
         !isLoading &&
-        (!error && (
+        !error && (
           <Typography className={classes.noMoreEvents}>
             No more events to show
           </Typography>
-        ))
+        )
       )}
     </>
   );
@@ -397,10 +397,6 @@ const mapStateToProps = (state: ApplicationState) => ({
 
 const connected = connect(mapStateToProps);
 
-const enhanced = compose<CombinedProps, Props>(
-  styled,
-  connected,
-  withSnackbar
-);
+const enhanced = compose<CombinedProps, Props>(styled, connected, withSnackbar);
 
 export default enhanced(EventsLanding);

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -9,7 +9,7 @@ import { withSnackbar, WithSnackbarProps } from 'notistack';
 import { prop, sortBy } from 'ramda';
 import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
-import Waypoint from 'react-waypoint';
+import { Waypoint } from 'react-waypoint';
 import { compose } from 'recompose';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Breadcrumb from 'src/components/Breadcrumb';
@@ -542,9 +542,6 @@ export class BucketDetail extends React.Component<CombinedProps, {}> {
 
 const styled = withStyles(styles);
 
-const enhanced = compose<CombinedProps, {}>(
-  styled,
-  withSnackbar
-);
+const enhanced = compose<CombinedProps, {}>(styled, withSnackbar);
 
 export default enhanced(BucketDetail);

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -6,7 +6,7 @@ import { pathOr } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
-import Waypoint from 'react-waypoint';
+import { Waypoint } from 'react-waypoint';
 import { compose } from 'recompose';
 import StackScriptsIcon from 'src/assets/addnewmenu/stackscripts.svg';
 import Button from 'src/components/Button';
@@ -178,8 +178,8 @@ const withStackScriptBase = (isSelecting: boolean) => (
           // AND the filtered data set is 0 before we request the next page automatically
           if (
             isSorting &&
-            (newData.length !== 0 &&
-              newDataWithoutDeprecatedDistros.length === 0)
+            newData.length !== 0 &&
+            newDataWithoutDeprecatedDistros.length === 0
           ) {
             this.getNext();
             return;
@@ -606,11 +606,7 @@ const withStackScriptBase = (isSelecting: boolean) => (
 
   const connected = connect(mapStateToProps);
 
-  return compose(
-    withRouter,
-    connected,
-    withStyles
-  )(EnhancedComponent);
+  return compose(withRouter, connected, withStyles)(EnhancedComponent);
 };
 
 export default withStackScriptBase;

--- a/yarn.lock
+++ b/yarn.lock
@@ -16269,10 +16269,10 @@ react-transition-group@^4.0.0:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react-waypoint@^8.0.3:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/react-waypoint/-/react-waypoint-8.1.0.tgz#91d926a2fd1be4cbd0351cb8c3d494fac0ef1699"
-  integrity sha512-HoOItWTHObgz7bstmz9p3wuTVDRdsyNspnkAOFz9eE4z8LRj1bbNP9Nzye2k9zsFiujlz8lmp13UFmuXPWXPYw==
+react-waypoint@~9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/react-waypoint/-/react-waypoint-9.0.2.tgz#d65fb0fe6ff5c1b832a1d01b1462a661fb921e45"
+  integrity sha512-6tIr9NozeDH789Ox2tOkyDcmprYOx1+eII40dERLrZclFe6RhWAQ/bbd6B7cGild6onXNwPzg16y0/wHWQ/q+g==
   dependencies:
     consolidated-events "^1.1.0 || ^2.0.0"
     prop-types "^15.0.0"


### PR DESCRIPTION
There was some console noise from deprecated React lifecycle methods, upgrading should fix them.

Waypoint is used in 3 places: Object storage buckets, events landing page, and stackscripts. Please make sure behavior is unchanged in all 3.