### PR TITLE
M3-3735 Scopes can be space separated

### DIFF
--- a/packages/manager/src/features/Profile/APITokens/APITokenTable.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokenTable.tsx
@@ -331,23 +331,6 @@ export class APITokenTable extends React.Component<CombinedProps, State> {
       );
       return;
     }
-    if (!this.state.form.values.label) {
-      // if no label
-      this.setState(
-        {
-          form: {
-            ...this.state.form,
-            errors: [
-              { reason: 'You must give your token a label.', field: 'label' }
-            ]
-          }
-        },
-        () => {
-          scrollErrorIntoView();
-        }
-      );
-      return;
-    }
 
     const { form } = this.state;
     this.setState(

--- a/packages/manager/src/features/Profile/APITokens/utils.ts
+++ b/packages/manager/src/features/Profile/APITokens/utils.ts
@@ -47,7 +47,10 @@ const defaultScopeMap = (perms: string[]): Record<string, 0> =>
 
 /**
  * This function accepts scopes strings as given by the API, which have the following format:
+ * Either:
  * "linodes:delete,domains:modify,nodebalancers:modify,images:create,events:view,clients:view"
+ * Or:
+ * "linodes:delete domains:modify nodebalancers:modify images:create"
  *
  * It returns an array of 2-tuples in alphabetical order by scope name.
  *
@@ -67,7 +70,7 @@ const defaultScopeMap = (perms: string[]): Record<string, 0> =>
  *
  * Each permission level gives a user access to all lower permission levels.
  */
-
+const permRegex = new RegExp(/[, ]/);
 export const scopeStringToPermTuples = (
   scopes: string,
   perms: string[]
@@ -76,7 +79,7 @@ export const scopeStringToPermTuples = (
     return perms.map(perm => [perm, 2] as Permission);
   }
 
-  const scopeMap = scopes.split(',').reduce((map, scopeStr) => {
+  const scopeMap = scopes.split(permRegex).reduce((map, scopeStr) => {
     const [perm, level] = scopeStr.split(':');
     return {
       ...map,
@@ -160,5 +163,5 @@ export const permTuplesToScopeString = (
     }
     return [...acc];
   }, []);
-  return joinedTups.join(',');
+  return joinedTups.join(' ');
 };


### PR DESCRIPTION
## Description

The API now allows scopes to be a string of space-separated values, as in:
"linodes:read_write domains:read_only"

This means that:

- We _must_ be able to read these
- We _can_ use this format when creating, I did it this way bc
the Oauth spec has it this way, but it isn't necessary.


## Note to Reviewers

Test account 4 has a few tokens of both types. Try creating, reading, editing, etc. to see if everything works as before.