### PR TITLE
M3-3818 longview loading state

### DIFF
--- a/packages/manager/src/components/GaugePercent/GaugePercent.tsx
+++ b/packages/manager/src/components/GaugePercent/GaugePercent.tsx
@@ -23,7 +23,7 @@ const useStyles = (options: Options) =>
     },
     innerText: {
       position: 'absolute',
-      top: `calc((${options.height}px / 2))`,
+      top: `calc((${options.height + theme.spacing(3.75)}px / 2))`,
       width: options.width,
       textAlign: 'center',
       fontSize: '1rem',
@@ -33,7 +33,7 @@ const useStyles = (options: Options) =>
       position: 'absolute',
       width: options.width,
       textAlign: 'center',
-      top: `calc(${options.height}px)`,
+      top: `calc(${options.height + theme.spacing(1.25)}px)`,
       fontSize: options.fontSize || `${theme.spacing(2.5)}px `,
       color: theme.color.headline
     }
@@ -78,7 +78,8 @@ const GaugePercent: React.FC<CombinedProps> = props => {
       <div
         className={classes.gaugeWrapper}
         style={{
-          width
+          width,
+          height: height + props.theme.spacing(3.75)
         }}
       >
         <Doughnut

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
@@ -29,7 +29,8 @@ import withProfile from 'src/containers/profile.container';
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
     marginBottom: theme.spacing(4),
-    padding: theme.spacing(3)
+    padding: theme.spacing(3),
+    height: 220
   },
   gaugeContainer: {
     [theme.breakpoints.down('sm')]: {
@@ -69,9 +70,12 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
     userCanModifyClient
   } = props;
 
-  const { lastUpdated, lastUpdatedError, authed } = useClientLastUpdated(
-    clientAPIKey,
-    _lastUpdated => props.getClientStats(clientAPIKey, _lastUpdated)
+  const {
+    lastUpdated,
+    lastUpdatedError,
+    authed
+  } = useClientLastUpdated(clientAPIKey, _lastUpdated =>
+    props.getClientStats(clientAPIKey, _lastUpdated)
   );
 
   /**
@@ -116,7 +120,7 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
               />
             </Grid>
             <Grid item xs={12} md={9}>
-              <Grid container>
+              <Grid container direction="row" alignItems="center">
                 <Grid item xs={4} sm={2} className={classes.gaugeContainer}>
                   <CPUGauge
                     clientID={clientID}

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
@@ -25,12 +25,15 @@ import withClientStats, {
   Props as LVDataProps
 } from 'src/containers/longview.stats.container';
 import withProfile from 'src/containers/profile.container';
+import { COMPACT_SPACING_UNIT } from 'src/themeFactory';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
     marginBottom: theme.spacing(4),
     padding: theme.spacing(3),
-    height: 220
+    [theme.breakpoints.up('md')]: {
+      height: theme.spacing() === COMPACT_SPACING_UNIT ? 180 : 220
+    }
   },
   gaugeContainer: {
     [theme.breakpoints.down('sm')]: {

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
@@ -355,17 +355,17 @@ export const LongviewClients: React.FC<CombinedProps> = props => {
   );
 };
 
+interface StateProps {
+  lvClientData: StatsState;
+}
+
 /**
  * Calling connect directly here rather than use a
  * container because this is a unique case; we need
  * access to data from all clients.
  */
-interface StateProps {
-  lvClientData: Record<string, StatsState>;
-}
-
 const mapStateToProps: MapState<StateProps, Props> = (state, ownProps) => {
-  const lvClientData = pathOr({}, ['longviewStats'], state);
+  const lvClientData = state.longviewStats ?? {};
   return {
     lvClientData
   };
@@ -428,7 +428,7 @@ export const sortFunc = (
 export const sortClientsBy = (
   sortKey: SortKey,
   clients: LongviewClient[],
-  clientData: Record<string, StatsState>
+  clientData: StatsState
 ) => {
   switch (sortKey) {
     case 'name':
@@ -500,7 +500,7 @@ export const sortClientsBy = (
 export const filterLongviewClientsByQuery = (
   query: string,
   clientList: LongviewClient[],
-  clientData: Record<string, StatsState>
+  clientData: StatsState
 ) => {
   /** just return the original list if there's no query */
   if (!query.trim()) {


### PR DESCRIPTION
## Description

The original plan was for a single loading state on the landing page. This didn't work out well; we have to first request the clients and then request data for each of them, which would be a long load. In addition, the page is set up to rely on the gauges to make requests to the LV API; in order to do this, we'd have to add a `getAllClientData([...longviewClientAPIKeys])` method and call it. We'd also lose the individual loading states for clients and gauges.

So I'm trying another idea, where we set a height for the client cards so there's no jumping in the view as each client loads.

@WilkinsKa1 I didn't like how they looked when they were all the same height as the instructions component, but I noticed that clients don't switch from instructions to normal during loading, so it's ok. Still having trouble getting everything centered without jumping. Thanks!
 