### PR TITLE
StackScript Panel + query string improvements

### DIFF
--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -257,7 +257,7 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
       },
       {
         display: 'StackScripts',
-        href: '/stackscripts',
+        href: '/stackscripts?type=account',
         key: 'stackscripts',
         icon: <StackScript />
       },

--- a/packages/manager/src/components/StackScript/StackScript.tsx
+++ b/packages/manager/src/components/StackScript/StackScript.tsx
@@ -1,5 +1,6 @@
 import { Image } from 'linode-js-sdk/lib/images';
 import { StackScript } from 'linode-js-sdk/lib/stackscripts';
+import { stringify } from 'qs';
 import * as React from 'react';
 import { compose } from 'recompose';
 import Chip from 'src/components/core/Chip';
@@ -120,6 +121,11 @@ export class _StackScript extends React.Component<CombinedProps> {
         return acc;
       }, []) || 'No compatible images found';
 
+    const queryString = stringify({
+      type: 'community',
+      query: `username:${username}`
+    });
+
     return (
       <div className={classes.root}>
         <H1Header title={label} data-qa-stack-title={label} />
@@ -131,7 +137,7 @@ export class _StackScript extends React.Component<CombinedProps> {
           by&nbsp;
           <ExternalLink
             text={username}
-            link={`${APP_ROOT}/stackscripts?type=community&query=username:${username}`}
+            link={`${APP_ROOT}/stackscripts?${queryString}`}
             data-qa-community-stack-link
           />
         </Typography>

--- a/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
+++ b/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
@@ -57,6 +57,7 @@ interface Props {
   bodyClass?: string;
   noPadding?: boolean;
   handleTabChange?: (value?: number) => void;
+  value?: number;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -84,7 +85,11 @@ class TabbedPanel extends React.Component<CombinedProps> {
       noPadding,
       ...rest
     } = this.props;
-    const { value } = this.state;
+
+    // Allow the consumer to pass in a custom tab value. Otherwise, read it from
+    // component state.
+    const value = this.props.value ?? this.state.value;
+
     // if this bombs the app shouldn't crash
     const render = safeGetTabRender(tabs, value);
 

--- a/packages/manager/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanelContent.tsx
+++ b/packages/manager/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanelContent.tsx
@@ -76,6 +76,6 @@ class SelectStackScriptPanelContent extends React.Component<
   }
 }
 
-export default compose<CombinedProps, Props>(StackScriptBase(true))(
-  SelectStackScriptPanelContent
-);
+export default compose<CombinedProps, Props>(
+  StackScriptBase({ isSelecting: true })
+)(SelectStackScriptPanelContent);

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -653,7 +653,7 @@ const updateQueryString = (
   query: string,
   history: RouteComponentProps<{}>['history']
 ) => {
-  const queryString = '?' + stringify({ type, query });
+  const queryString = stringify({ type, query });
 
   // Use `replace` instead of `push` so that each keystroke is not a separate
   // browser history item.

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -2,6 +2,7 @@ import { Grant } from 'linode-js-sdk/lib/account';
 import { Image } from 'linode-js-sdk/lib/images';
 import { StackScript } from 'linode-js-sdk/lib/stackscripts';
 import { APIError, ResourcePage } from 'linode-js-sdk/lib/types';
+import { stringify } from 'qs';
 import { pathOr } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -24,6 +25,7 @@ import {
 import { MapState } from 'src/store/types';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { sendStackscriptsSearchEvent } from 'src/utilities/ga';
+import { getDisplayName } from 'src/utilities/getDisplayName';
 import { handleUnauthorizedErrors } from 'src/utilities/handleUnauthorizedErrors';
 import { getQueryParam } from 'src/utilities/queryParams';
 import StackScriptTableHead from '../Partials/StackScriptTableHead';
@@ -33,8 +35,6 @@ import {
   generateSpecificFilter
 } from '../stackScriptUtils';
 import withStyles, { StyleProps } from './StackScriptBase.styles';
-
-import { getDisplayName } from 'src/utilities/getDisplayName';
 
 type CurrentFilter = 'label' | 'deploys' | 'revision';
 
@@ -87,10 +87,19 @@ interface HelperFunctions {
 
 export type StateProps = HelperFunctions & State;
 
+interface WithStackScriptBaseOptions {
+  isSelecting: boolean;
+  // Whether or not `type=` and `query=` QS params should be respected and
+  // written to on user input.
+  useQueryString?: boolean;
+}
+
 /* tslint:disable-next-line */
-const withStackScriptBase = (isSelecting: boolean) => (
+const withStackScriptBase = (options: WithStackScriptBaseOptions) => (
   Component: React.ComponentType<StateProps>
 ) => {
+  const { isSelecting, useQueryString } = options;
+
   class EnhancedComponent extends React.Component<CombinedProps, State> {
     static displayName = `WithStackScriptBase(${getDisplayName(Component)})`;
 
@@ -305,10 +314,21 @@ const withStackScriptBase = (isSelecting: boolean) => (
 
     handleSearch = (value: string) => {
       const { currentFilter } = this.state;
-      const { category, currentUser, request, stackScriptGrants } = this.props;
+      const {
+        category,
+        currentUser,
+        request,
+        stackScriptGrants,
+        history
+      } = this.props;
       const filteredUser = category === 'linode' ? 'linode' : currentUser;
 
       const lowerCaseValue = value.toLowerCase().trim();
+
+      // Update the Query String as the user types.
+      if (useQueryString) {
+        updateQueryString(category, lowerCaseValue, history);
+      }
 
       let filter: any;
 
@@ -443,7 +463,10 @@ const withStackScriptBase = (isSelecting: boolean) => (
         );
       }
 
-      const query = getQueryParam(this.props.location.search, 'query');
+      // Use the query string if the argument has been specified.
+      const query = useQueryString
+        ? getQueryParam(this.props.location.search, 'query')
+        : undefined;
 
       return (
         <React.Fragment>
@@ -623,3 +646,18 @@ const withStackScriptBase = (isSelecting: boolean) => (
 };
 
 export default withStackScriptBase;
+
+// Update the query string with a `type=` and `query=`.
+const updateQueryString = (
+  type: string,
+  query: string,
+  history: RouteComponentProps<{}>['history']
+) => {
+  const queryString = '?' + stringify({ type, query });
+
+  // Use `replace` instead of `push` so that each keystroke is not a separate
+  // browser history item.
+  history.replace({
+    search: queryString
+  });
+};

--- a/packages/manager/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
@@ -166,7 +166,7 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
           return;
         }
         this.setState({ isSubmitting: false });
-        history.push('/stackscripts', {
+        history.push('/stackscripts?type=account', {
           successMessage: `${stackScript.label} successfully created`
         });
       })

--- a/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptPanel.test.ts
+++ b/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptPanel.test.ts
@@ -1,6 +1,6 @@
-import { getInitTab, StackScriptTab } from './StackScriptPanel';
+import { getTabValueFromQueryString, StackScriptTab } from './StackScriptPanel';
 
-describe('getInitTab helper function', () => {
+describe('getTabValueFromQueryString helper function', () => {
   const tabs: StackScriptTab[] = [
     {
       title: 'Account StackScripts',
@@ -14,13 +14,13 @@ describe('getInitTab helper function', () => {
     }
   ];
   it('provides the index of the desired tab', () => {
-    expect(getInitTab('type=account', tabs)).toBe(0);
-    expect(getInitTab('type=community', tabs)).toBe(1);
+    expect(getTabValueFromQueryString('type=account', tabs)).toBe(0);
+    expect(getTabValueFromQueryString('type=community', tabs)).toBe(1);
   });
 
   it('provides the index of the default tab when the given type is not present', () => {
-    expect(getInitTab('type=unknown-type', tabs)).toBe(0);
-    expect(getInitTab('type=unknown-type', tabs, 10)).toBe(10);
-    expect(getInitTab('', tabs, 0)).toBe(0);
+    expect(getTabValueFromQueryString('type=unknown-type', tabs)).toBe(0);
+    expect(getTabValueFromQueryString('type=unknown-type', tabs, 10)).toBe(10);
+    expect(getTabValueFromQueryString('', tabs, 0)).toBe(0);
   });
 });

--- a/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptPanel.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptPanel.tsx
@@ -95,7 +95,7 @@ class SelectStackScriptPanel extends React.Component<CombinedProps, {}> {
 
     const category = StackScriptTabs[value].category;
 
-    const queryString = '?' + stringify({ type: category });
+    const queryString = stringify({ type: category });
 
     // Push a new item of browser history here containing the StackScript type.
     // It's OK to clear out the "query" QS param from a UX perspective.

--- a/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptPanelContent.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptPanelContent.tsx
@@ -167,9 +167,7 @@ class StackScriptPanelContent extends React.Component<CombinedProps, State> {
           return;
         }
         this.setState({
-          successMessage: `${
-            dialog.stackScriptLabel
-          } successfully published to the public library`,
+          successMessage: `${dialog.stackScriptLabel} successfully published to the public library`,
           dialog: {
             delete: {
               open: false
@@ -298,6 +296,6 @@ class StackScriptPanelContent extends React.Component<CombinedProps, State> {
   }
 }
 
-export default compose<CombinedProps, Props>(StackScriptBase(false))(
-  StackScriptPanelContent
-);
+export default compose<CombinedProps, Props>(
+  StackScriptBase({ isSelecting: false, useQueryString: true })
+)(StackScriptPanelContent);

--- a/packages/manager/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.tsx
@@ -214,7 +214,7 @@ export class StackScriptUpdate extends React.Component<CombinedProps, State> {
           return;
         }
         this.setState({ isSubmitting: false });
-        history.push('/stackscripts', {
+        history.push('/stackscripts?type=account', {
           successMessage: `${updatedStackScript.label} successfully updated`
         });
       })

--- a/packages/manager/src/features/StackScripts/StackScriptsLanding.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptsLanding.tsx
@@ -92,6 +92,7 @@ export class StackScriptsLanding extends React.Component<CombinedProps, {}> {
                 publicImages={imagesData}
                 queryString={this.props.location.search}
                 history={this.props.history}
+                location={this.props.location}
               />
             </Grid>
           )}

--- a/packages/manager/src/features/StackScripts/StackScriptsLanding.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptsLanding.tsx
@@ -91,6 +91,7 @@ export class StackScriptsLanding extends React.Component<CombinedProps, {}> {
               <StackScriptPanel
                 publicImages={imagesData}
                 queryString={this.props.location.search}
+                history={this.props.history}
               />
             </Grid>
           )}


### PR DESCRIPTION
## Description

@Jskobos pointed out [here](https://github.com/linode/manager/pull/6010#pullrequestreview-346085330) that the query string was being re-read when the tab was changed. I set out to fix this, which led to a few other enhancements as well:

1. Clicking a tab ("Account" or "Community") will update the query string, which means that the tabs are now bookmark-able and are added to browser history. 
2. The query string is updated when the user types in the Search field, which means searches are bookmark-able. Note that in this case, **the history is replaced** meaning history events aren't added each time the user types.

A few behind-the-scenes things:

- Use the `qs` library to properly encode author links.
- Allow a specific value to be given to `<TabbedPanel />` (necessary for these changes)
- Add a `useQueryString` option to StackScriptBase. This is because we don't want the StackScript section of LinodeRebuild to be integrated with query strings. Since I added this option, I decided to make the args to StackScriptBase an object instead of multiple context-less boolean values.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

- Please check everywhere you can find StackScripts in the app, as there are many places that reuse (some of) the components.
- Checked TabbedComponent everywhere it is used.
- Check multiple combinations of interaction with the StackScript tabs and search field. Refreshing the page, bookmarking, clicking "Back", etc.
