### PR TITLE
[Fix] Refactor LineGraphs to allow mixed units for network graphs

### DIFF
--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -12,6 +12,7 @@ import Typography from 'src/components/core/Typography';
 import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
 import { setUpCharts } from 'src/utilities/charts';
+import roundTo from 'src/utilities/roundTo';
 import { Metrics } from 'src/utilities/statMetrics';
 import MetricDisplayStyles from './NewMetricDisplay.styles';
 setUpCharts();
@@ -382,7 +383,7 @@ export const _formatTooltip = curry(
     const dataset = data[t.datasetIndex];
     const label = dataset.label;
     const val = dataset.data[t.index][1] || 0;
-    const value = formatter ? formatter(val) : Math.round(val * 100) / 100;
+    const value = formatter ? formatter(val) : roundTo(val);
     return `${label}: ${value}${unit ? unit : ''}`;
   }
 );

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Apache/ApacheGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Apache/ApacheGraphs.tsx
@@ -83,7 +83,8 @@ export const ApacheGraphs: React.FC<CombinedProps> = props => {
   /**
    * NB: unlike some other places in Longview,
    * totalKBytes appears to actually be returned
-   * in kilobytes. Our network helper utilities
+   * in kilobytes (usually it's bytes, even if the variable name
+   * has kb in it). Our network helper utilities
    * aren't prepared for this, so we have to convert
    * to bytes by passing a formatter to convertData.
    *

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Apache/ApacheGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Apache/ApacheGraphs.tsx
@@ -10,7 +10,6 @@ import {
 import Grid from 'src/components/Grid';
 import LongviewLineGraph from 'src/components/LongviewLineGraph';
 import {
-  convertNetworkToBits,
   convertNetworkToUnit,
   formatNetworkTooltip,
   generateNetworkUnits,
@@ -81,9 +80,19 @@ export const ApacheGraphs: React.FC<CombinedProps> = props => {
   const totalKBytes = data?.['Total kBytes'] ?? [];
   const totalAccesses = data?.['Total Accesses'] ?? [];
 
-  const unit = React.useMemo(() => generateNetworkUnits(statMax(totalKBytes)), [
-    totalKBytes
-  ]);
+  /**
+   * NB: unlike some other places in Longview,
+   * totalKBytes appears to actually be returned
+   * in kilobytes. Our network helper utilities
+   * aren't prepared for this, so we have to convert
+   * to bytes by passing a formatter to convertData.
+   *
+   * Conversion from bytes to bits takes place inside the helpers.
+   */
+  const networkUnit = React.useMemo(
+    () => generateNetworkUnits(statMax(totalKBytes)),
+    [totalKBytes]
+  );
 
   const graphProps = {
     timezone,
@@ -105,7 +114,7 @@ export const ApacheGraphs: React.FC<CombinedProps> = props => {
                 label: 'Requests',
                 borderColor: 'transparent',
                 backgroundColor: theme.graphs.requests,
-                data: _convertData(totalAccesses, start, end, formatData)
+                data: _convertData(totalAccesses, start, end)
               }
             ]}
             {...graphProps}
@@ -116,10 +125,12 @@ export const ApacheGraphs: React.FC<CombinedProps> = props => {
             <Grid item xs={12} sm={6} className={classes.smallGraph}>
               <LongviewLineGraph
                 title="Throughput"
-                subtitle={`${unit}/s`}
+                subtitle={`${networkUnit}/s`}
                 unit={'/s'}
                 formatData={(value: number) =>
-                  convertNetworkToUnit(value, unit)
+                  Math.round(
+                    convertNetworkToUnit(value * 8, networkUnit) * 100
+                  ) / 100
                 }
                 formatTooltip={formatNetworkTooltip}
                 data={[
@@ -127,12 +138,7 @@ export const ApacheGraphs: React.FC<CombinedProps> = props => {
                     label: 'Throughput',
                     borderColor: 'transparent',
                     backgroundColor: theme.graphs.network.outbound,
-                    data: _convertData(
-                      totalKBytes,
-                      start,
-                      end,
-                      convertNetworkToBits
-                    )
+                    data: _convertData(totalKBytes, start, end, kilobytesToBits)
                   }
                 ]}
                 {...graphProps}
@@ -146,61 +152,61 @@ export const ApacheGraphs: React.FC<CombinedProps> = props => {
                     label: 'Waiting',
                     borderColor: 'transparent',
                     backgroundColor: theme.graphs.workers.waiting,
-                    data: _convertData(workersWaiting, start, end, formatData)
+                    data: _convertData(workersWaiting, start, end)
                   },
                   {
                     label: 'Starting',
                     borderColor: 'transparent',
                     backgroundColor: theme.graphs.workers.starting,
-                    data: _convertData(workersStarting, start, end, formatData)
+                    data: _convertData(workersStarting, start, end)
                   },
                   {
                     label: 'Reading',
                     borderColor: 'transparent',
                     backgroundColor: theme.graphs.workers.reading,
-                    data: _convertData(workersReading, start, end, formatData)
+                    data: _convertData(workersReading, start, end)
                   },
                   {
                     label: 'Sending',
                     borderColor: 'transparent',
                     backgroundColor: theme.graphs.workers.sending,
-                    data: _convertData(workersSending, start, end, formatData)
+                    data: _convertData(workersSending, start, end)
                   },
                   {
                     label: 'Keepalive',
                     borderColor: 'transparent',
                     backgroundColor: theme.graphs.workers.keepAlive,
-                    data: _convertData(workersKeepAlive, start, end, formatData)
+                    data: _convertData(workersKeepAlive, start, end)
                   },
                   {
                     label: 'DNS Lookup',
                     borderColor: 'transparent',
                     backgroundColor: theme.graphs.workers.DNSLookup,
-                    data: _convertData(workersDNSLookup, start, end, formatData)
+                    data: _convertData(workersDNSLookup, start, end)
                   },
                   {
                     label: 'Closing',
                     borderColor: 'transparent',
                     backgroundColor: theme.graphs.workers.closing,
-                    data: _convertData(workersClosing, start, end, formatData)
+                    data: _convertData(workersClosing, start, end)
                   },
                   {
                     label: 'Logging',
                     borderColor: 'transparent',
                     backgroundColor: theme.graphs.workers.logging,
-                    data: _convertData(workersLogging, start, end, formatData)
+                    data: _convertData(workersLogging, start, end)
                   },
                   {
                     label: 'Finishing',
                     borderColor: 'transparent',
                     backgroundColor: theme.graphs.workers.finishing,
-                    data: _convertData(workersFinishing, start, end, formatData)
+                    data: _convertData(workersFinishing, start, end)
                   },
                   {
                     label: 'Cleanup',
                     borderColor: 'transparent',
                     backgroundColor: theme.graphs.workers.cleanup,
-                    data: _convertData(workersCleanup, start, end, formatData)
+                    data: _convertData(workersCleanup, start, end)
                   }
                 ]}
                 {...graphProps}
@@ -222,13 +228,11 @@ export const ApacheGraphs: React.FC<CombinedProps> = props => {
   );
 };
 
-const formatData = (value: number | null) => {
+export const kilobytesToBits = (value: number | null) => {
   if (value === null) {
-    return value;
+    return null;
   }
-
-  // Round to 2 decimal places.
-  return Math.round(value * 100) / 100;
+  return value * 1024;
 };
 
 const enhanced = compose<CombinedProps, Props>(

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Apache/ApacheGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Apache/ApacheGraphs.tsx
@@ -138,7 +138,12 @@ export const ApacheGraphs: React.FC<CombinedProps> = props => {
                     label: 'Throughput',
                     borderColor: 'transparent',
                     backgroundColor: theme.graphs.network.outbound,
-                    data: _convertData(totalKBytes, start, end, kilobytesToBits)
+                    data: _convertData(
+                      totalKBytes,
+                      start,
+                      end,
+                      kilobytesToBytes
+                    )
                   }
                 ]}
                 {...graphProps}
@@ -228,7 +233,7 @@ export const ApacheGraphs: React.FC<CombinedProps> = props => {
   );
 };
 
-export const kilobytesToBits = (value: number | null) => {
+export const kilobytesToBytes = (value: number | null) => {
   if (value === null) {
     return null;
   }

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Apache/ApacheGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Apache/ApacheGraphs.tsx
@@ -15,6 +15,7 @@ import {
   generateNetworkUnits,
   statMax
 } from 'src/features/Longview/shared/utilities';
+import roundTo from 'src/utilities/roundTo';
 import { ApacheResponse, LongviewProcesses } from '../../../request.types';
 import { convertData } from '../../../shared/formatters';
 import ProcessGraphs from '../ProcessGraphs';
@@ -129,9 +130,7 @@ export const ApacheGraphs: React.FC<CombinedProps> = props => {
                 subtitle={`${networkUnit}/s`}
                 unit={'/s'}
                 formatData={(value: number) =>
-                  Math.round(
-                    convertNetworkToUnit(value * 8, networkUnit) * 100
-                  ) / 100
+                  roundTo(convertNetworkToUnit(value * 8, networkUnit))
                 }
                 formatTooltip={formatNetworkTooltip}
                 data={[

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/MySQL/MySQLGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/MySQL/MySQLGraphs.tsx
@@ -125,6 +125,7 @@ export const MySQLGraphs: React.FC<CombinedProps> = props => {
               <LongviewLineGraph
                 title="Throughput"
                 subtitle={`${maxUnit}/s`}
+                unit={'/s'}
                 formatData={formatNetwork}
                 formatTooltip={formatNetworkTooltip}
                 nativeLegend
@@ -152,6 +153,7 @@ export const MySQLGraphs: React.FC<CombinedProps> = props => {
               <LongviewLineGraph
                 title="Connections"
                 subtitle="connections/s"
+                unit={' connections/s'}
                 nativeLegend
                 error={error}
                 loading={loading}

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/MySQL/MySQLGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/MySQL/MySQLGraphs.tsx
@@ -9,7 +9,6 @@ import {
 import Grid from 'src/components/Grid';
 import LongviewLineGraph from 'src/components/LongviewLineGraph';
 import {
-  convertNetworkToBits,
   formatNetworkTooltip,
   getMaxUnitAndFormatNetwork
 } from 'src/features/Longview/shared/utilities';
@@ -75,7 +74,10 @@ export const MySQLGraphs: React.FC<CombinedProps> = props => {
   const inbound = data?.Bytes_received ?? [];
   const outbound = data?.Bytes_sent ?? [];
 
-  const { formatNetwork } = getMaxUnitAndFormatNetwork(inbound, outbound);
+  const { maxUnit, formatNetwork } = getMaxUnitAndFormatNetwork(
+    inbound,
+    outbound
+  );
 
   return (
     <Paper className={classes.root}>
@@ -122,7 +124,7 @@ export const MySQLGraphs: React.FC<CombinedProps> = props => {
             <Grid item xs={12} sm={6} className={classes.smallGraph}>
               <LongviewLineGraph
                 title="Throughput"
-                subtitle={`/s`}
+                subtitle={`${maxUnit}/s`}
                 formatData={formatNetwork}
                 formatTooltip={formatNetworkTooltip}
                 nativeLegend
@@ -135,23 +137,13 @@ export const MySQLGraphs: React.FC<CombinedProps> = props => {
                     label: 'Inbound',
                     borderColor: 'transparent',
                     backgroundColor: theme.graphs.network.inbound,
-                    data: _convertData(
-                      inbound,
-                      start,
-                      end,
-                      convertNetworkToBits
-                    )
+                    data: _convertData(inbound, start, end)
                   },
                   {
                     label: 'Outbound',
                     borderColor: 'transparent',
                     backgroundColor: theme.graphs.network.outbound,
-                    data: _convertData(
-                      outbound,
-                      start,
-                      end,
-                      convertNetworkToBits
-                    )
+                    data: _convertData(outbound, start, end)
                   }
                 ]}
               />

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/MySQL/MySQLGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/MySQL/MySQLGraphs.tsx
@@ -8,7 +8,11 @@ import {
 } from 'src/components/core/styles';
 import Grid from 'src/components/Grid';
 import LongviewLineGraph from 'src/components/LongviewLineGraph';
-import { getMaxUnitAndFormatNetwork } from 'src/features/Longview/shared/utilities';
+import {
+  convertNetworkToBits,
+  formatNetworkTooltip,
+  getMaxUnitAndFormatNetwork
+} from 'src/features/Longview/shared/utilities';
 import { LongviewProcesses, MySQLResponse } from '../../../request.types';
 import { convertData } from '../../../shared/formatters';
 import ProcessGraphs from '../ProcessGraphs';
@@ -71,10 +75,7 @@ export const MySQLGraphs: React.FC<CombinedProps> = props => {
   const inbound = data?.Bytes_received ?? [];
   const outbound = data?.Bytes_sent ?? [];
 
-  const { maxUnit: netMaxUnit, formatNetwork } = getMaxUnitAndFormatNetwork(
-    inbound,
-    outbound
-  );
+  const { formatNetwork } = getMaxUnitAndFormatNetwork(inbound, outbound);
 
   return (
     <Paper className={classes.root}>
@@ -121,7 +122,9 @@ export const MySQLGraphs: React.FC<CombinedProps> = props => {
             <Grid item xs={12} sm={6} className={classes.smallGraph}>
               <LongviewLineGraph
                 title="Throughput"
-                subtitle={`${netMaxUnit}/s`}
+                subtitle={`/s`}
+                formatData={formatNetwork}
+                formatTooltip={formatNetworkTooltip}
                 nativeLegend
                 error={error}
                 loading={loading}
@@ -132,13 +135,23 @@ export const MySQLGraphs: React.FC<CombinedProps> = props => {
                     label: 'Inbound',
                     borderColor: 'transparent',
                     backgroundColor: theme.graphs.network.inbound,
-                    data: _convertData(inbound, start, end, formatNetwork)
+                    data: _convertData(
+                      inbound,
+                      start,
+                      end,
+                      convertNetworkToBits
+                    )
                   },
                   {
                     label: 'Outbound',
                     borderColor: 'transparent',
                     backgroundColor: theme.graphs.network.outbound,
-                    data: _convertData(outbound, start, end, formatNetwork)
+                    data: _convertData(
+                      outbound,
+                      start,
+                      end,
+                      convertNetworkToBits
+                    )
                   }
                 ]}
               />

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/NGINX/NGINXGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/NGINX/NGINXGraphs.tsx
@@ -75,7 +75,7 @@ export const NGINXGraphs: React.FC<CombinedProps> = props => {
           <LongviewLineGraph
             title="Requests"
             subtitle="requests/s"
-            unit="requests/s"
+            unit=" requests/s"
             data={[
               {
                 label: 'Requests',
@@ -93,7 +93,7 @@ export const NGINXGraphs: React.FC<CombinedProps> = props => {
               <LongviewLineGraph
                 title="Connections"
                 subtitle="connections/s"
-                unit="connections/s"
+                unit=" connections/s"
                 nativeLegend
                 data={[
                   {

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Network/NetworkGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Network/NetworkGraphs.tsx
@@ -4,7 +4,12 @@ import { withTheme, WithTheme } from 'src/components/core/styles';
 import ErrorState from 'src/components/ErrorState';
 import LongviewLineGraph from 'src/components/LongviewLineGraph';
 import Placeholder from 'src/components/Placeholder';
-import { getMaxUnitAndFormatNetwork } from 'src/features/Longview/shared/utilities';
+import {
+  convertNetworkToUnit,
+  formatNetworkTooltip,
+  generateNetworkUnits,
+  statMax
+} from 'src/features/Longview/shared/utilities';
 import {
   InboundOutboundNetwork,
   LongviewNetworkInterface
@@ -71,9 +76,8 @@ export const NetworkGraphs: React.FC<CombinedProps> = props => {
         const [name, interfaceData] = thisInterface;
         const { rx_bytes, tx_bytes } = interfaceData;
 
-        const { maxUnit, formatNetwork } = getMaxUnitAndFormatNetwork(
-          rx_bytes,
-          tx_bytes
+        const maxUnit = generateNetworkUnits(
+          Math.max(statMax(rx_bytes), statMax(tx_bytes))
         );
 
         return (
@@ -83,7 +87,11 @@ export const NetworkGraphs: React.FC<CombinedProps> = props => {
                 title="Network Traffic"
                 nativeLegend
                 subtitle={maxUnit + '/s'}
-                unit={maxUnit + '/s'}
+                unit={'/s'}
+                formatData={(value: number) =>
+                  convertNetworkToUnit(value, maxUnit)
+                }
+                formatTooltip={formatNetworkTooltip}
                 error={error}
                 loading={loading}
                 showToday={isToday}
@@ -93,13 +101,13 @@ export const NetworkGraphs: React.FC<CombinedProps> = props => {
                     label: 'Inbound',
                     borderColor: 'transparent',
                     backgroundColor: theme.graphs.network.inbound,
-                    data: _convertData(rx_bytes, start, end, formatNetwork)
+                    data: _convertData(rx_bytes, start, end)
                   },
                   {
                     label: 'Outbound',
                     borderColor: 'transparent',
                     backgroundColor: theme.graphs.network.outbound,
-                    data: _convertData(tx_bytes, start, end, formatNetwork)
+                    data: _convertData(tx_bytes, start, end)
                   }
                 ]}
               />

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/DiskGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/DiskGraph.tsx
@@ -52,7 +52,7 @@ export const DiskGraph: React.FC<CombinedProps> = props => {
       error={(!data.Disk && requestError) || error}
       loading={loading}
       subtitle={'ops/second'}
-      unit={'ops/second'}
+      unit={' ops/second'}
       showToday={isToday}
       timezone={timezone}
       nativeLegend

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/MemoryGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/MemoryGraph.tsx
@@ -2,7 +2,10 @@ import { pathOr } from 'ramda';
 import * as React from 'react';
 import { withTheme, WithTheme } from 'src/components/core/styles';
 import LongviewLineGraph from 'src/components/LongviewLineGraph';
-import { StorageSymbol } from 'src/utilities/unitConversions';
+import {
+  convertBytesToTarget,
+  readableBytes
+} from 'src/utilities/unitConversions';
 import { Stat } from '../../../request.types';
 import { convertData, formatMemory } from '../../../shared/formatters';
 import { generateUsedMemory, getMaxUnit } from '../../../shared/utilities';
@@ -57,7 +60,8 @@ export const MemoryGraph: React.FC<CombinedProps> = props => {
     <LongviewLineGraph
       title="Memory"
       subtitle={unit}
-      maxUnit={unit as StorageSymbol}
+      formatData={(value: number) => convertBytesToTarget(unit, value)}
+      formatTooltip={(value: number) => readableBytes(value).formatted}
       error={error}
       loading={loading}
       showToday={isToday}

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/NetworkGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/NetworkGraph.tsx
@@ -4,7 +4,6 @@ import { compose } from 'recompose';
 import { withTheme, WithTheme } from 'src/components/core/styles';
 import LongviewLineGraph from 'src/components/LongviewLineGraph';
 import {
-  convertNetworkToBits,
   formatNetworkTooltip,
   getMaxUnitAndFormatNetwork,
   sumNetwork
@@ -69,13 +68,13 @@ export const NetworkGraph: React.FC<CombinedProps> = props => {
           label: 'Inbound',
           borderColor: 'transparent',
           backgroundColor: theme.graphs.network.inbound,
-          data: _convertData(rx_bytes, start, end, convertNetworkToBits)
+          data: _convertData(rx_bytes, start, end)
         },
         {
           label: 'Outbound',
           borderColor: 'transparent',
           backgroundColor: theme.graphs.network.outbound,
-          data: _convertData(tx_bytes, start, end, convertNetworkToBits)
+          data: _convertData(tx_bytes, start, end)
         }
       ]}
     />

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/NetworkGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/NetworkGraph.tsx
@@ -4,6 +4,8 @@ import { compose } from 'recompose';
 import { withTheme, WithTheme } from 'src/components/core/styles';
 import LongviewLineGraph from 'src/components/LongviewLineGraph';
 import {
+  convertNetworkToBits,
+  formatNetworkTooltip,
   getMaxUnitAndFormatNetwork,
   sumNetwork
 } from 'src/features/Longview/shared/utilities';
@@ -54,7 +56,9 @@ export const NetworkGraph: React.FC<CombinedProps> = props => {
     <LongviewLineGraph
       title="Network"
       subtitle={maxUnit + '/s'}
-      unit={maxUnit + '/s'}
+      unit={'/s'}
+      formatData={formatNetwork}
+      formatTooltip={formatNetworkTooltip}
       error={error}
       loading={loading}
       showToday={isToday}
@@ -65,13 +69,13 @@ export const NetworkGraph: React.FC<CombinedProps> = props => {
           label: 'Inbound',
           borderColor: 'transparent',
           backgroundColor: theme.graphs.network.inbound,
-          data: _convertData(rx_bytes, start, end, formatNetwork)
+          data: _convertData(rx_bytes, start, end, convertNetworkToBits)
         },
         {
           label: 'Outbound',
           borderColor: 'transparent',
           backgroundColor: theme.graphs.network.outbound,
-          data: _convertData(tx_bytes, start, end, formatNetwork)
+          data: _convertData(tx_bytes, start, end, convertNetworkToBits)
         }
       ]}
     />

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ProcessGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ProcessGraphs.tsx
@@ -123,7 +123,7 @@ export const ProcessGraphs: React.FC<CombinedProps> = props => {
             <LongviewLineGraph
               title="Disk I/O"
               subtitle={`${diskUnit}/s`}
-              unit={`${diskUnit}/s`}
+              unit={` ${diskUnit}/s`}
               data={[
                 {
                   label: 'Read',

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ProcessGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ProcessGraphs.tsx
@@ -8,7 +8,10 @@ import {
 } from 'src/components/core/styles';
 import Grid from 'src/components/Grid';
 import LongviewLineGraph from 'src/components/LongviewLineGraph';
-import { readableBytes } from 'src/utilities/unitConversions';
+import {
+  convertBytesToTarget,
+  readableBytes
+} from 'src/utilities/unitConversions';
 import { LongviewProcesses } from '../../request.types';
 import { convertData, formatMemory } from '../../shared/formatters';
 import {
@@ -97,7 +100,10 @@ export const ProcessGraphs: React.FC<CombinedProps> = props => {
             <LongviewLineGraph
               title="RAM"
               subtitle={memoryUnit}
-              maxUnit={memoryUnit}
+              formatData={(value: number) =>
+                convertBytesToTarget(memoryUnit, value)
+              }
+              formatTooltip={(value: number) => readableBytes(value).formatted}
               data={[
                 {
                   label: 'RAM',

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ProcessGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ProcessGraphs.tsx
@@ -124,6 +124,10 @@ export const ProcessGraphs: React.FC<CombinedProps> = props => {
               title="Disk I/O"
               subtitle={`${diskUnit}/s`}
               unit={` ${diskUnit}/s`}
+              formatData={(value: number) =>
+                convertBytesToTarget(diskUnit, value)
+              }
+              formatTooltip={(value: number) => readableBytes(value).formatted}
               data={[
                 {
                   label: 'Read',

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ProcessGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ProcessGraphs.tsx
@@ -123,7 +123,7 @@ export const ProcessGraphs: React.FC<CombinedProps> = props => {
             <LongviewLineGraph
               title="Disk I/O"
               subtitle={`${diskUnit}/s`}
-              unit={` ${diskUnit}/s`}
+              unit={`/s`}
               formatData={(value: number) =>
                 convertBytesToTarget(diskUnit, value)
               }

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Processes/ProcessesGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Processes/ProcessesGraphs.tsx
@@ -17,7 +17,10 @@ import {
   formatMemory
 } from 'src/features/Longview/shared/formatters';
 import { statMax } from 'src/features/Longview/shared/utilities';
-import { readableBytes } from 'src/utilities/unitConversions';
+import {
+  convertBytesToTarget,
+  readableBytes
+} from 'src/utilities/unitConversions';
 import { Process } from './types';
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -121,7 +124,8 @@ const ProcessesGraphs: React.FC<CombinedProps> = props => {
           <LongviewLineGraph
             title="RAM"
             subtitle={memUnit}
-            maxUnit={memUnit}
+            formatData={(value: number) => convertBytesToTarget(memUnit, value)}
+            formatTooltip={(value: number) => readableBytes(value).formatted}
             data={[
               {
                 data: _convertData(memory, start, end, formatMemory),

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Processes/ProcessesGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Processes/ProcessesGraphs.tsx
@@ -156,7 +156,9 @@ const ProcessesGraphs: React.FC<CombinedProps> = props => {
           <LongviewLineGraph
             title="Disk I/O"
             subtitle={ioUnit + '/s'}
-            unit={ioUnit + '/s'}
+            unit={'/s'}
+            formatData={(value: number) => convertBytesToTarget(ioUnit, value)}
+            formatTooltip={(value: number) => readableBytes(value).formatted}
             nativeLegend
             data={[
               {

--- a/packages/manager/src/features/Longview/shared/utilities.ts
+++ b/packages/manager/src/features/Longview/shared/utilities.ts
@@ -364,3 +364,16 @@ export const getMaxUnit = (stats: Stat[][]) => {
   const max = Math.max(...stats.map(statMax));
   return readableBytes(max * 1024).unit; // LV always returns in KB, need bytes here
 };
+
+export const formatNetworkTooltip = (value: number) => {
+  const _unit = generateNetworkUnits(value);
+  const converted = convertNetworkToUnit(value, _unit);
+  return `${Math.round(converted * 100) / 100} ${_unit}`;
+};
+
+export const convertNetworkToBits = (value: number | null) => {
+  if (value === null) {
+    return null;
+  }
+  return value * 8;
+};

--- a/packages/manager/src/features/Longview/shared/utilities.ts
+++ b/packages/manager/src/features/Longview/shared/utilities.ts
@@ -367,7 +367,7 @@ export const getMaxUnit = (stats: Stat[][]) => {
 
 export const formatNetworkTooltip = (value: number) => {
   const _unit = generateNetworkUnits(value);
-  const converted = convertNetworkToUnit(value, _unit);
+  const converted = convertNetworkToUnit(value * 8, _unit);
   return `${Math.round(converted * 100) / 100} ${_unit}`;
 };
 

--- a/packages/manager/src/features/Longview/shared/utilities.ts
+++ b/packages/manager/src/features/Longview/shared/utilities.ts
@@ -365,15 +365,8 @@ export const getMaxUnit = (stats: Stat[][]) => {
   return readableBytes(max * 1024).unit; // LV always returns in KB, need bytes here
 };
 
-export const formatNetworkTooltip = (value: number) => {
-  const _unit = generateNetworkUnits(value);
-  const converted = convertNetworkToUnit(value * 8, _unit);
+export const formatNetworkTooltip = (valueInBytes: number) => {
+  const _unit = generateNetworkUnits(valueInBytes);
+  const converted = convertNetworkToUnit(valueInBytes * 8, _unit);
   return `${Math.round(converted * 100) / 100} ${_unit}`;
-};
-
-export const convertNetworkToBits = (value: number | null) => {
-  if (value === null) {
-    return null;
-  }
-  return value * 8;
 };

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph.tsx
@@ -12,6 +12,7 @@ import Grid from 'src/components/Grid';
 import LineGraph from 'src/components/LineGraph';
 import {
   convertNetworkToUnit,
+  formatNetworkTooltip,
   generateNetworkUnits
 } from 'src/features/Longview/shared/utilities';
 import {
@@ -189,23 +190,14 @@ const Graph: React.FC<GraphProps> = props => {
 
   const format = formatBitsPerSecond;
 
-  const convertNetworkData = (point: [number, number]) => {
-    return [point[0], convertNetworkToUnit(point[1], unit as any)];
+  const convertNetworkData = (value: number) => {
+    return convertNetworkToUnit(value, unit as any);
   };
-  const convertedPublicIn = data.publicIn.map(convertNetworkData) as [
-    number,
-    number
-  ][];
-  const convertedPublicOut = data.publicOut.map(convertNetworkData) as [
-    number,
-    number
-  ][];
-  const convertedPrivateIn = data.privateIn.map(convertNetworkData) as [
-    number,
-    number
-  ][];
-  const convertedPrivateOut =
-    (data.privateOut?.map(convertNetworkData) as [number, number][]) ?? [];
+
+  const convertedPublicIn = data.publicIn;
+  const convertedPublicOut = data.publicOut;
+  const convertedPrivateIn = data.privateIn;
+  const convertedPrivateOut = data.privateOut;
 
   return (
     <React.Fragment>
@@ -213,7 +205,9 @@ const Graph: React.FC<GraphProps> = props => {
         <LineGraph
           timezone={timezone}
           chartHeight={chartHeight}
-          unit={`${unit}/s`}
+          unit={`/s`}
+          formatData={convertNetworkData}
+          formatTooltip={formatNetworkTooltip}
           showToday={rangeSelection === '24'}
           data={[
             {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph.tsx
@@ -194,6 +194,16 @@ const Graph: React.FC<GraphProps> = props => {
     return convertNetworkToUnit(value, unit as any);
   };
 
+  /**
+   * formatNetworkTooltip is a helper method from Longview, where
+   * data is expected in bytes. The method does the rounding, unit conversions, etc.
+   * that we want, but it first multiplies by 8 to convert to bits.
+   * APIv4 returns this data in bits to begin with,
+   * so we have to preemptively divide by 8 to counter the conversion inside the helper.
+   *
+   */
+  const _formatTooltip = (value: number) => formatNetworkTooltip(value / 8);
+
   const convertedPublicIn = data.publicIn;
   const convertedPublicOut = data.publicOut;
   const convertedPrivateIn = data.privateIn;
@@ -207,7 +217,7 @@ const Graph: React.FC<GraphProps> = props => {
           chartHeight={chartHeight}
           unit={`/s`}
           formatData={convertNetworkData}
-          formatTooltip={formatNetworkTooltip}
+          formatTooltip={_formatTooltip}
           showToday={rangeSelection === '24'}
           data={[
             {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph.tsx
@@ -202,7 +202,8 @@ const Graph: React.FC<GraphProps> = props => {
    * so we have to preemptively divide by 8 to counter the conversion inside the helper.
    *
    */
-  const _formatTooltip = (value: number) => formatNetworkTooltip(value / 8);
+  const _formatTooltip = (valueInBytes: number) =>
+    formatNetworkTooltip(valueInBytes / 8);
 
   const convertedPublicIn = data.publicIn;
   const convertedPublicOut = data.publicOut;

--- a/packages/manager/src/utilities/roundTo/index.ts
+++ b/packages/manager/src/utilities/roundTo/index.ts
@@ -1,0 +1,1 @@
+export { roundTo as default } from './roundTo';

--- a/packages/manager/src/utilities/roundTo/roundTo.test.ts
+++ b/packages/manager/src/utilities/roundTo/roundTo.test.ts
@@ -1,0 +1,24 @@
+import { roundTo } from './roundTo';
+
+describe('roundTo utility', () => {
+  it('should round to 2 digits by default', () => {
+    expect(roundTo(2.112)).toBe(2.11);
+  });
+
+  it('should not add decimals to integers', () => {
+    expect(roundTo(4)).toBe(4);
+  });
+
+  it('should handle small values', () => {
+    expect(roundTo(0.000000000000711)).toBe(0);
+  });
+
+  it('should round to different number of decimals based on the second argument', () => {
+    expect(roundTo(2.001, 3)).toBe(2.001);
+    expect(roundTo(2.001)).toBe(2);
+  });
+
+  it('should handle small values with a larger multiplier value', () => {
+    expect(roundTo(0.000234, 5)).toBe(0.00023);
+  });
+});

--- a/packages/manager/src/utilities/roundTo/roundTo.ts
+++ b/packages/manager/src/utilities/roundTo/roundTo.ts
@@ -1,0 +1,20 @@
+/**
+ * Round to a given number of decimals, by default 2.
+ * This is different from toFixed and similar methods,
+ * because we only want to append decimals if they are
+ * significant.
+ *
+ * Example:
+ *
+ * 2.toFixed(2) = '2.00'
+ * roundTo(2) = 2
+ * roundTo(0.01) = 0.01
+ * roundTo(0.000234, 5) = 0.00023
+ *
+ * @param value
+ * @param places (Optional) Number of decimal places to round to
+ */
+export const roundTo = (value: number, places: number = 2) => {
+  const multiplier = 10 ** places;
+  return Math.round(value * multiplier) / multiplier;
+};


### PR DESCRIPTION
## Description

Remove the concept of maxUnit inside our LineGraph abstraction, and replace it with two optional props:
- formatData(), called by the internal formatData method. Replaces the functionality of maxUnit, so consumers now have to pass readableBytes or whatever they'd like to use to shrink the data to a manageable unit.
- formatTooltip(), called by the tooltip callback inside LineGraph. We need two methods bc units in a tooltip can be mixed (to account for smaller values).

Rearranged things to work with the new pattern.

Possible future enhancements:
- Quarantine Longview utilities inside the LV directory, and make Manager-specific copies of any needed utilities to reduce the square peg/round hole problem. Alternatively, generalize our data pipeline so we can put different units through it.
- Create `variants` for Longview graphs using the LongviewLineGraph abstraction. Maybe `base`, `mixedBytes`, and `mixedBits` to handle the three main cases.
- Nix the `formatData` prop and convert data to maxUnit before sending it to the graph. Use new methods, something like `scaleInBits` and `scaleInBytes` to format the tooltip. Something like:

```
scaleInBits = (baseUnit: NetworkUnit, value: number) => {
    if (value < 0.05) {
       convertBaseUnitToSmallerUnit(value)
.....
```

## Notes

Please compare LV and Linode graphs with Classic and Cloud production. Use different clients to try to work with a range of data.