### PR TITLE
M3-3817: Show progress on cloned Linode targets

### DIFF
--- a/packages/manager/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
@@ -29,11 +29,7 @@ import {
   isEntityEvent,
   isInProgressEvent
 } from 'src/store/events/event.helpers';
-import {
-  isEventRelevantToLinodeAsSecondaryEntity,
-  isPrimaryEntity,
-  isSecondaryEntity
-} from 'src/store/events/event.selectors';
+import { isEventRelevantToLinode } from 'src/store/events/event.selectors';
 import { addNotificationsToLinodes } from 'src/store/linodes/linodes.helpers';
 import { LinodeWithMaintenanceAndDisplayStatus } from 'src/store/linodes/types';
 import { formatNotifications } from 'src/utilities/formatNotifications';
@@ -244,9 +240,7 @@ const mergeEvents = (events: Event[]) => (linodes: Linode[]) =>
   events.reduce((updatedLinodes, event) => {
     if (isWantedEvent(event)) {
       return updatedLinodes.map(linode =>
-        isPrimaryEntity(event, linode.id) ||
-        (isSecondaryEntity(event, linode.id) &&
-          isEventRelevantToLinodeAsSecondaryEntity(event))
+        isEventRelevantToLinode(event, linode.id)
           ? { ...linode, recentEvent: event }
           : linode
       );

--- a/packages/manager/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
@@ -29,6 +29,11 @@ import {
   isEntityEvent,
   isInProgressEvent
 } from 'src/store/events/event.helpers';
+import {
+  isEventRelevantToLinodeAsSecondaryEntity,
+  isPrimaryEntity,
+  isSecondaryEntity
+} from 'src/store/events/event.selectors';
 import { addNotificationsToLinodes } from 'src/store/linodes/linodes.helpers';
 import { LinodeWithMaintenanceAndDisplayStatus } from 'src/store/linodes/types';
 import { formatNotifications } from 'src/utilities/formatNotifications';
@@ -239,7 +244,9 @@ const mergeEvents = (events: Event[]) => (linodes: Linode[]) =>
   events.reduce((updatedLinodes, event) => {
     if (isWantedEvent(event)) {
       return updatedLinodes.map(linode =>
-        event.entity.id === linode.id
+        isPrimaryEntity(event, linode.id) ||
+        (isSecondaryEntity(event, linode.id) &&
+          isEventRelevantToLinodeAsSecondaryEntity(event))
           ? { ...linode, recentEvent: event }
           : linode
       );

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeBusyStatus.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeBusyStatus.tsx
@@ -22,7 +22,6 @@ const styles = (theme: Theme) =>
       marginTop: theme.spacing(2)
     },
     status: {
-      textTransform: 'capitalize',
       marginBottom: theme.spacing(1)
     }
   });
@@ -30,12 +29,13 @@ const styles = (theme: Theme) =>
 interface LinodeDetailContextProps {
   status: string;
   linodeEvents?: Event[];
+  linodeId: number;
 }
 
 type CombinedProps = LinodeDetailContextProps & WithStyles<ClassNames>;
 
 const LinodeBusyStatus: React.StatelessComponent<CombinedProps> = props => {
-  const { classes, status, linodeEvents } = props;
+  const { classes, status, linodeEvents, linodeId } = props;
 
   const firstEventWithProgress = (linodeEvents || []).find(
     eachEvent => typeof eachEvent.percent_complete === 'number'
@@ -49,7 +49,7 @@ const LinodeBusyStatus: React.StatelessComponent<CombinedProps> = props => {
     <Paper className={classes.root}>
       <div className={classes.status}>
         <Typography>
-          {transitionText(status, firstEventWithProgress)}: {value}%
+          {transitionText(status, linodeId, firstEventWithProgress)}: {value}%
         </Typography>
       </div>
       <LinearProgress value={value} />
@@ -63,7 +63,8 @@ const enhanced = compose<CombinedProps, {}>(
   styled,
   withLinodeDetailContext(({ linode }) => ({
     status: linode.status,
-    linodeEvents: linode._events
+    linodeEvents: linode._events,
+    linodeId: linode.id
   }))
 );
 

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeCard.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeCard.tsx
@@ -217,7 +217,7 @@ export class LinodeCard extends React.PureComponent<CombinedProps, State> {
           >
             {recentEvent && linodeInTransition(status, recentEvent) && (
               <ProgressDisplay
-                text={transitionText(status, recentEvent)}
+                text={transitionText(status, id, recentEvent)}
                 progress={recentEvent.percent_complete}
                 classes={{
                   statusProgress: classes.statusProgress,

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
@@ -189,7 +189,7 @@ const LinodeRowHeadCell: React.StatelessComponent<CombinedProps> = props => {
             {recentEvent && linodeInTransition(status, recentEvent) && (
               <ProgressDisplay
                 className={classes.loadingStatus}
-                text={transitionText(status, recentEvent)}
+                text={transitionText(status, id, recentEvent)}
                 progress={recentEvent.percent_complete}
               />
             )}

--- a/packages/manager/src/features/linodes/transitions.test.ts
+++ b/packages/manager/src/features/linodes/transitions.test.ts
@@ -3,7 +3,7 @@ import { transitionText } from './transitions';
 describe('transitionText helper', () => {
   it('should remove "linode" from the event and capitalize it', () => {
     expect(
-      transitionText('loading', {
+      transitionText('loading', 123, {
         id: 123,
         action: 'linode_snapshot',
         secondary_entity: null,
@@ -22,12 +22,12 @@ describe('transitionText helper', () => {
   });
 
   it('should use status if an event is missing and capitalize it', () => {
-    expect(transitionText('loading')).toEqual('Loading');
+    expect(transitionText('loading', 0)).toEqual('Loading');
   });
 
   it('should use status if an event is not a transition event and capitalize it', () => {
     expect(
-      transitionText('optimus', {
+      transitionText('optimus', 123, {
         id: 123,
         action: 'linode_addip',
         secondary_entity: null,

--- a/packages/manager/src/store/events/event.selectors.test.ts
+++ b/packages/manager/src/store/events/event.selectors.test.ts
@@ -1,0 +1,71 @@
+import { entityFactory, eventFactory } from 'src/factories/events';
+import {
+  isEventRelevantToLinode,
+  isEventRelevantToLinodeAsSecondaryEntity,
+  isPrimaryEntity,
+  isSecondaryEntity
+} from './event.selectors';
+
+describe('event selector helpers', () => {
+  describe('isEventRelevantToLinode', () => {
+    const event0 = eventFactory.build({
+      action: 'linode_create',
+      entity: entityFactory.build({ id: 0 })
+    });
+    const event1 = eventFactory.build({
+      action: 'linode_create',
+      entity: entityFactory.build({ id: 1 })
+    });
+    const event2 = eventFactory.build({
+      action: 'linode_create',
+      secondary_entity: entityFactory.build({ id: 1 })
+    });
+    const event3 = eventFactory.build({
+      action: 'linode_clone',
+      secondary_entity: entityFactory.build({ id: 1 })
+    });
+    it("returns `true` when the linodeId is the event's entity ID, or if it's the event's secondary_entity ID and the event is relevant", () => {
+      expect(isEventRelevantToLinode(event0, 0)).toBe(true);
+      expect(isEventRelevantToLinode(event1, 0)).toBe(false);
+      expect(isEventRelevantToLinode(event2, 1)).toBe(false);
+      expect(isEventRelevantToLinode(event3, 1)).toBe(true);
+    });
+  });
+
+  describe('isPrimaryEntity', () => {
+    const event = eventFactory.build({
+      entity: entityFactory.build({ id: 1 })
+    });
+    it("returns `true` when the linodeId matches the event's entity ID", () => {
+      expect(isPrimaryEntity(event, 0)).toBe(false);
+      expect(isPrimaryEntity(event, 1)).toBe(true);
+    });
+  });
+
+  describe('isSecondaryEntity', () => {
+    const event = eventFactory.build({
+      secondary_entity: entityFactory.build({ id: 1 })
+    });
+    it("returns `true` when the linodeId matches the event's secondary_entity ID", () => {
+      expect(isSecondaryEntity(event, 0)).toBe(false);
+      expect(isSecondaryEntity(event, 1)).toBe(true);
+    });
+  });
+
+  describe('isEventRelevantToLinodeAsSecondaryEntity', () => {
+    const linodeCreateEvent = eventFactory.build({
+      action: 'linode_create'
+    });
+    const linodeCloneEvent = eventFactory.build({
+      action: 'linode_clone'
+    });
+    it('returns `true` if the event type is relevant to Linodes as secondary entities', () => {
+      expect(isEventRelevantToLinodeAsSecondaryEntity(linodeCreateEvent)).toBe(
+        false
+      );
+      expect(isEventRelevantToLinodeAsSecondaryEntity(linodeCloneEvent)).toBe(
+        true
+      );
+    });
+  });
+});

--- a/packages/manager/src/store/events/event.selectors.ts
+++ b/packages/manager/src/store/events/event.selectors.ts
@@ -1,7 +1,33 @@
+import { Event, EventAction } from 'linode-js-sdk/lib/account';
 import { State } from './event.reducer';
 
 export const eventsForLinode = (state: State, linodeId: number) => {
-  return state.events.filter(
-    ({ entity }) => entity && entity.type === 'linode' && entity.id === linodeId
-  );
+  return state.events.filter(event => {
+    return (
+      isPrimaryEntity(event, linodeId) ||
+      (isSecondaryEntity(event, linodeId) &&
+        isEventRelevantToLinodeAsSecondaryEntity(event))
+    );
+  });
 };
+
+export const isPrimaryEntity = (event: Event, linodeId: number) =>
+  event?.entity?.type === 'linode' && event?.entity?.id === linodeId;
+
+export const isSecondaryEntity = (event: Event, linodeId: number) =>
+  event?.secondary_entity?.type === 'linode' &&
+  event?.secondary_entity?.id === linodeId;
+
+// Some event types include a Linode as a `secondary_entity`. A subset of these
+// events should be included in the `eventsForLinode` selector since they are
+// relevant to that Linode.
+//
+// An example: `clone_linode` events include the source Linode as the `entity`
+// and the target Linode as the `secondary_entity`. In this case, we want the
+// consumer of the `eventsForLinode` selector to have access to these events so
+// it can do things like display progress bars.
+export const eventActionsForLinodeAsSecondaryEntity: EventAction[] = [
+  'linode_clone'
+];
+export const isEventRelevantToLinodeAsSecondaryEntity = (event: Event) =>
+  eventActionsForLinodeAsSecondaryEntity.includes(event?.action);

--- a/packages/manager/src/store/events/event.selectors.ts
+++ b/packages/manager/src/store/events/event.selectors.ts
@@ -2,14 +2,13 @@ import { Event, EventAction } from 'linode-js-sdk/lib/account';
 import { State } from './event.reducer';
 
 export const eventsForLinode = (state: State, linodeId: number) => {
-  return state.events.filter(event => {
-    return (
-      isPrimaryEntity(event, linodeId) ||
-      (isSecondaryEntity(event, linodeId) &&
-        isEventRelevantToLinodeAsSecondaryEntity(event))
-    );
-  });
+  return state.events.filter(event => isEventRelevantToLinode(event, linodeId));
 };
+
+export const isEventRelevantToLinode = (event: Event, linodeId: number) =>
+  isPrimaryEntity(event, linodeId) ||
+  (isSecondaryEntity(event, linodeId) &&
+    isEventRelevantToLinodeAsSecondaryEntity(event));
 
 export const isPrimaryEntity = (event: Event, linodeId: number) =>
   event?.entity?.type === 'linode' && event?.entity?.id === linodeId;

--- a/packages/manager/src/store/selectors/recentEventForLinode.ts
+++ b/packages/manager/src/store/selectors/recentEventForLinode.ts
@@ -1,12 +1,7 @@
 import { Event } from 'linode-js-sdk/lib/account';
 import { createSelector } from 'reselect';
 import { ApplicationState } from 'src/store';
-import { isInProgressEvent } from 'src/store/events/event.helpers';
-import {
-  isEventRelevantToLinodeAsSecondaryEntity,
-  isPrimaryEntity,
-  isSecondaryEntity
-} from '../events/event.selectors';
+import { isEventRelevantToLinode } from '../events/event.selectors';
 
 export default (linodeId: number) =>
   createSelector<ApplicationState, Event[], undefined | Event>(
@@ -16,12 +11,7 @@ export default (linodeId: number) =>
       const len = events.length;
       for (; idx < len; idx += 1) {
         const event = events[idx];
-        if (
-          isInProgressEvent(event) &&
-          (isPrimaryEntity(event, linodeId) ||
-            (isSecondaryEntity(event, linodeId) &&
-              isEventRelevantToLinodeAsSecondaryEntity(event)))
-        ) {
+        if (isEventRelevantToLinode(event, linodeId)) {
           return event;
         }
       }

--- a/packages/manager/src/store/selectors/recentEventForLinode.ts
+++ b/packages/manager/src/store/selectors/recentEventForLinode.ts
@@ -1,7 +1,12 @@
-import { Event } from 'linode-js-sdk/lib/account'
+import { Event } from 'linode-js-sdk/lib/account';
 import { createSelector } from 'reselect';
 import { ApplicationState } from 'src/store';
 import { isInProgressEvent } from 'src/store/events/event.helpers';
+import {
+  isEventRelevantToLinodeAsSecondaryEntity,
+  isPrimaryEntity,
+  isSecondaryEntity
+} from '../events/event.selectors';
 
 export default (linodeId: number) =>
   createSelector<ApplicationState, Event[], undefined | Event>(
@@ -11,12 +16,11 @@ export default (linodeId: number) =>
       const len = events.length;
       for (; idx < len; idx += 1) {
         const event = events[idx];
-        const { entity } = event;
         if (
           isInProgressEvent(event) &&
-          entity &&
-          entity.type === 'linode' &&
-          entity.id === linodeId
+          (isPrimaryEntity(event, linodeId) ||
+            (isSecondaryEntity(event, linodeId) &&
+              isEventRelevantToLinodeAsSecondaryEntity(event)))
         ) {
           return event;
         }


### PR DESCRIPTION
## Description

Previously we only showed progress on the source Linode during clone events. Now that the target Linode is included as the event’s `secondary_entity`, we can show progress there as well.

This required adjust both event selectors. Please feel free to judge readability and variable names harshly; I struggled coming up with meaningful names.

Still to do: 

- [x] write tests

Notes: 
  - I added another argument to `transitionText()`: the Linode ID. I had to adjust the order of the arguments since the `event` arg is optional and `linodeId` is not.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Please test that Linode events work as expected across all views: Dashboard, Linode Landing, Linode Detail.
