### PR TITLE
M3-3837 Re-order Edit Domain drawer

### DIFF
--- a/packages/manager/src/features/Domains/DomainDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainDrawer.tsx
@@ -57,14 +57,11 @@ import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import DeleteDomain from './DeleteDomain';
 import DomainTransferInput from './DomainTransferInput';
 
-type ClassNames = 'root' | 'masterIPErrorNotice' | 'addIP' | 'divider';
+type ClassNames = 'root' | 'addIP' | 'divider';
 
 const styles = (theme: Theme) =>
   createStyles({
     root: {},
-    masterIPErrorNotice: {
-      marginTop: theme.spacing(2)
-    },
     addIP: {
       left: -theme.spacing(2) + 3
     },
@@ -346,19 +343,11 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
         )}
         {(isCreatingSlaveDomain || isEditingSlaveDomain) && (
           <React.Fragment>
-            {isEditingSlaveDomain && (
-              // Only when editing
-              <DomainTransferInput
-                value={this.state.axfr_ips.join(',')}
-                onChange={this.handleTransferInput}
-                error={errorMap.axfr_ips}
-              />
-            )}
             {masterIPsError && (
               <Notice
-                className={classes.masterIPErrorNotice}
                 error
                 text={`Master IP addresses must be valid IPv4 addresses.`}
+                spacingTop={16}
               />
             )}
             {Array.from(Array(this.state.masterIPsCount)).map((slave, idx) => (
@@ -379,6 +368,14 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
               data-qa-add-master-ip-field
               disabled={disabled}
             />
+            {isEditingSlaveDomain && (
+              // Only when editing
+              <DomainTransferInput
+                value={this.state.axfr_ips.join(',')}
+                onChange={this.handleTransferInput}
+                error={errorMap.axfr_ips}
+              />
+            )}
           </React.Fragment>
         )}
         {this.props.mode !== CLONING && (


### PR DESCRIPTION
## Description

Feedback from stakeholder review. The Master nameserver IP section is more important than the AXFR section and should be higher in the drawer.

**Notes:**
- I remove a class on the `<Notice />` that wasn't doing anything since the `spacingTop` prop takes precedence (so I used that instead).

<img width="468" alt="Screen Shot 2020-01-24 at 3 53 45 PM" src="https://user-images.githubusercontent.com/16911484/73103293-bc7adc00-3ec1-11ea-9f62-499929889466.png">

## Type of Change
- Non breaking change ('update', 'change'
