### PR TITLE
M3-3841 Fix: Images events messaging & assorted bugs

### DIFF
--- a/packages/manager/src/containers/withImages.container.ts
+++ b/packages/manager/src/containers/withImages.container.ts
@@ -1,6 +1,14 @@
-import { Image } from 'linode-js-sdk/lib/images';
-import { connect } from 'react-redux';
+import { CreateImagePayload, Image } from 'linode-js-sdk/lib/images';
+import { connect, MapDispatchToProps } from 'react-redux';
+import { AnyAction } from 'redux';
+import { ThunkDispatch } from 'redux-thunk';
 import { ApplicationState } from 'src/store';
+import { UpdateImagePayload } from 'src/store/image/image.actions';
+import {
+  createImage as _create,
+  requestImages as _request,
+  updateImage as _update
+} from 'src/store/image/image.requests';
 import { EntityError } from 'src/store/types';
 
 export interface WithImages {
@@ -8,6 +16,20 @@ export interface WithImages {
   imagesLoading: boolean;
   imagesError: EntityError;
 }
+
+export interface ImagesDispatch {
+  createImage: (payload: CreateImagePayload) => Promise<Image>;
+  requestImages: () => Promise<Image[]>;
+  updateImage: (payload: UpdateImagePayload) => Promise<Image>;
+}
+
+const mapDispatchToProps: MapDispatchToProps<ImagesDispatch, {}> = (
+  dispatch: ThunkDispatch<ApplicationState, undefined, AnyAction>
+) => ({
+  createImage: (payload: CreateImagePayload) => dispatch(_create(payload)),
+  requestImages: () => dispatch(_request()),
+  updateImage: (payload: UpdateImagePayload) => dispatch(_update(payload))
+});
 
 export default <TInner extends {}, TOuter extends {}>(
   mapImagesToProps?: (
@@ -34,4 +56,4 @@ export default <TInner extends {}, TOuter extends {}>(
     }
 
     return mapImagesToProps(ownProps, imagesData, loading, imagesError);
-  });
+  }, mapDispatchToProps);

--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -118,13 +118,14 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
     // notification: e => ``,
   },
   disk_imagize: {
-    // Currently, the event contains no information about the image,
-    // making it impossible to access the label for these messages.
-    scheduled: e => `Image scheduled for creation.`,
-    started: e => `Image being created.`,
-    failed: e => `Image creation failed.`,
-    finished: e => `Image has been created.`
-    // notification: e => ``,
+    scheduled: e =>
+      `Image ${e?.secondary_entity?.label + ' ' ?? ''}scheduled for creation.`,
+    started: e =>
+      `Image ${e?.secondary_entity?.label + ' ' ?? ''}being created.`,
+    failed: e =>
+      `Error creating Image ${e?.secondary_entity?.label + ' ' ?? ''}.`,
+    finished: e =>
+      `Image ${e?.secondary_entity?.label + ' ' ?? ''}has been created.`
   },
   disk_resize: {
     scheduled: e => `A disk on ${e.entity!.label} is scheduled for resizing.`,
@@ -165,14 +166,14 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
       `A domain record has been deleted from ${e.entity!.label}`
   },
   image_update: {
-    notification: e => `Image ${e.entity!.label} has been updated.`
+    notification: e => `Image ${e.entity?.label ?? ''} has been updated.`
   },
   image_delete: {
-    // scheduled: e => `Image ${e.entity!.label} scheduled for deletion.`,
-    // started: e => `Image ${e.entity!.label} is being deleted.`,
-    // failed: e => `There was a problem deleting ${e.entity!.label}.`,
-    // finished: e => `${e.entity!.label}`,
-    notification: e => `Image ${e.entity!.label} has been deleted.`
+    scheduled: e => `Image ${e.entity?.label ?? ''} scheduled for deletion.`,
+    started: e => `Image ${e.entity?.label ?? ''} is being deleted.`,
+    failed: e => `There was a problem deleting ${e.entity?.label ?? ''}.`,
+    finished: e => `Image ${e.entity?.label ?? ''} has been deleted.`,
+    notification: e => `Image ${e.entity?.label ?? ''} has been deleted.`
   },
   linode_addip: {
     notification: e => `An IP has been added to ${e.entity!.label}.`

--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -122,8 +122,7 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
       `Image ${e?.secondary_entity?.label + ' ' ?? ''}scheduled for creation.`,
     started: e =>
       `Image ${e?.secondary_entity?.label + ' ' ?? ''}being created.`,
-    failed: e =>
-      `Error creating Image ${e?.secondary_entity?.label + ' ' ?? ''}.`,
+    failed: e => `Error creating Image ${e?.secondary_entity?.label ?? ''}.`,
     finished: e =>
       `Image ${e?.secondary_entity?.label + ' ' ?? ''}has been created.`
   },

--- a/packages/manager/src/features/Images/ImagesDrawer.tsx
+++ b/packages/manager/src/features/Images/ImagesDrawer.tsx
@@ -1,4 +1,3 @@
-import { createImage, updateImage } from 'linode-js-sdk/lib/images';
 import { Disk, getLinodeDisks } from 'linode-js-sdk/lib/linodes';
 import { APIError } from 'linode-js-sdk/lib/types';
 import { equals } from 'ramda';
@@ -18,6 +17,9 @@ import Drawer from 'src/components/Drawer';
 import Notice from 'src/components/Notice';
 import SectionErrorBoundary from 'src/components/SectionErrorBoundary';
 import TextField from 'src/components/TextField';
+import withImages, {
+  ImagesDispatch
+} from 'src/containers/withImages.container';
 import { resetEventsPolling } from 'src/eventsPolling';
 import DiskSelect from 'src/features/linodes/DiskSelect';
 import LinodeSelect from 'src/features/linodes/LinodeSelect';
@@ -66,7 +68,10 @@ interface State {
   submitting: boolean;
 }
 
-type CombinedProps = Props & WithStyles<ClassNames> & RouteComponentProps<{}>;
+type CombinedProps = Props &
+  WithStyles<ClassNames> &
+  RouteComponentProps<{}> &
+  ImagesDispatch;
 
 export const modes = {
   CLOSED: 'closed',
@@ -178,7 +183,9 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
       description,
       history,
       selectedDisk,
-      selectedLinode
+      selectedLinode,
+      updateImage,
+      createImage
     } = this.props;
 
     this.setState({ errors: undefined, notice: undefined, submitting: true });
@@ -190,7 +197,7 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
           return;
         }
 
-        updateImage(imageID, label, safeDescription)
+        updateImage({ imageID, label, description: safeDescription })
           .then(() => {
             if (!this.mounted) {
               return;
@@ -216,7 +223,11 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
 
       case modes.CREATING:
       case modes.IMAGIZING:
-        createImage(Number(selectedDisk), label, safeDescription)
+        createImage({
+          diskID: Number(selectedDisk),
+          label,
+          description: safeDescription
+        })
           .then(_ => {
             if (!this.mounted) {
               return;
@@ -410,5 +421,6 @@ const styled = withStyles(styles);
 export default compose<CombinedProps, Props>(
   styled,
   withRouter,
+  withImages(),
   SectionErrorBoundary
 )(ImageDrawer);

--- a/packages/manager/src/features/Images/ImagesDrawer.tsx
+++ b/packages/manager/src/features/Images/ImagesDrawer.tsx
@@ -152,6 +152,12 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
     }
   }
 
+  handleLinodeChange = (linodeID: number) => {
+    // Clear any disk errors
+    this.setState({ errors: undefined });
+    this.props.changeLinode(linodeID);
+  };
+
   close = () => {
     this.props.onClose();
     if (this.mounted) {
@@ -202,7 +208,7 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
               submitting: false,
               errors: getAPIErrorOrDefault(
                 errorResponse,
-                'Unable to edit image'
+                'Unable to edit Image'
               )
             });
           });
@@ -284,7 +290,6 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
       selectedLinode,
       mode,
       changeDisk,
-      changeLinode,
       changeLabel,
       changeDescription,
       classes
@@ -323,7 +328,7 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
           <LinodeSelect
             selectedLinode={selectedLinode}
             linodeError={linodeError}
-            handleChange={linode => changeLinode(linode.id)}
+            handleChange={linode => this.handleLinodeChange(linode.id)}
             updateFor={[selectedLinode, linodeError, classes]}
           />
         )}

--- a/packages/manager/src/features/Images/ImagesDrawer.tsx
+++ b/packages/manager/src/features/Images/ImagesDrawer.tsx
@@ -55,7 +55,6 @@ export interface Props {
   onClose: () => void;
   changeDisk: (disk: string | null) => void;
   selectedLinode: number | null;
-  onSuccess: () => void;
   changeLinode: (linodeId: number) => void;
   changeLabel: (e: React.ChangeEvent<HTMLInputElement>) => void;
   changeDescription: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -158,9 +157,15 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
   }
 
   handleLinodeChange = (linodeID: number) => {
-    // Clear any disk errors
+    // Clear any errors
     this.setState({ errors: undefined });
     this.props.changeLinode(linodeID);
+  };
+
+  handleDiskChange = (diskID: string | null) => {
+    // Clear any errors
+    this.setState({ errors: undefined });
+    this.props.changeDisk(diskID);
   };
 
   close = () => {
@@ -178,7 +183,6 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
     const {
       mode,
       imageID,
-      onSuccess,
       label,
       description,
       history,
@@ -203,7 +207,6 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
               return;
             }
 
-            onSuccess();
             this.close();
           })
           .catch(errorResponse => {
@@ -300,7 +303,6 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
       selectedDisk,
       selectedLinode,
       mode,
-      changeDisk,
       changeLabel,
       changeDescription,
       classes
@@ -350,7 +352,7 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
               selectedDisk={selectedDisk}
               disks={disks}
               diskError={diskError}
-              handleChange={changeDisk}
+              handleChange={this.handleDiskChange}
               updateFor={[disks, selectedDisk, diskError, classes]}
               disabled={mode === modes.IMAGIZING}
               data-qa-disk-select

--- a/packages/manager/src/features/Images/ImagesLanding.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding.tsx
@@ -274,7 +274,7 @@ class ImagesLanding extends React.Component<CombinedProps, State> {
         label={imageDrawer.label}
         description={imageDrawer.description}
         selectedDisk={imageDrawer.selectedDisk}
-        selectedLinode={imageDrawer.selectedLinode}
+        selectedLinode={imageDrawer.selectedLinode || null}
         imageID={imageDrawer.imageID}
         changeDisk={this.changeSelectedDisk}
         changeLinode={this.changeSelectedLinode}

--- a/packages/manager/src/features/Images/ImagesLanding.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding.tsx
@@ -281,7 +281,6 @@ class ImagesLanding extends React.Component<CombinedProps, State> {
         changeLabel={this.setLabel}
         changeDescription={this.setDescription}
         onClose={this.closeImageDrawer}
-        onSuccess={() => null}
       />
     );
   };

--- a/packages/manager/src/features/ToastNotifications/ToastNotifications.tsx
+++ b/packages/manager/src/features/ToastNotifications/ToastNotifications.tsx
@@ -90,7 +90,7 @@ class ToastNotifications extends React.PureComponent<WithSnackbarProps, {}> {
           ['finished', 'notification'].includes(event.status)
         ) {
           return enqueueSnackbar(
-            `Image ${event.entity?.label ?? ''}deleted successfully.`,
+            `Image ${event.entity?.label + ' ' ?? ''}deleted successfully.`,
             {
               variant: 'success'
             }

--- a/packages/manager/src/features/ToastNotifications/ToastNotifications.tsx
+++ b/packages/manager/src/features/ToastNotifications/ToastNotifications.tsx
@@ -54,33 +54,47 @@ class ToastNotifications extends React.PureComponent<WithSnackbarProps, {}> {
         }
 
         if (event.action === 'disk_imagize' && event.status === 'failed') {
-          return enqueueSnackbar('There was an error creating an image.', {
-            variant: 'error'
-          });
+          return enqueueSnackbar(
+            `There was an error creating image ${event.secondary_entity
+              ?.label ?? ''}.`,
+            {
+              variant: 'error'
+            }
+          );
         }
 
         if (event.action === 'image_delete' && event.status === 'failed') {
-          return enqueueSnackbar('There was an error deleting an image.', {
-            variant: 'error'
-          });
+          return enqueueSnackbar(
+            `There was an error deleting image ${event.entity?.label ?? ''}.`,
+            {
+              variant: 'error'
+            }
+          );
         }
 
         if (
           event.action === 'disk_imagize' &&
           ['finished', 'notification'].includes(event.status)
         ) {
-          return enqueueSnackbar('Image created successfully.', {
-            variant: 'success'
-          });
+          return enqueueSnackbar(
+            `Image ${event.secondary_entity?.label ??
+              ''} created successfully.`,
+            {
+              variant: 'success'
+            }
+          );
         }
 
         if (
           event.action === 'image_delete' &&
           ['finished', 'notification'].includes(event.status)
         ) {
-          return enqueueSnackbar('Image deleted successfully.', {
-            variant: 'success'
-          });
+          return enqueueSnackbar(
+            `Image ${event.entity?.label ?? ''}deleted successfully.`,
+            {
+              variant: 'success'
+            }
+          );
         }
 
         if (event.action === 'volume_create' && event.status === 'failed') {

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -152,7 +152,8 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
     ...defaultState,
     // These can be passed in as query params
     selectedTypeID: this.params.typeID,
-    selectedRegionID: this.params.regionID
+    selectedRegionID: this.params.regionID,
+    selectedImageID: this.params.imageID
   };
 
   componentDidUpdate(prevProps: CombinedProps) {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks.tsx
@@ -360,10 +360,14 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
         description={description}
         label={label}
         disks={disk ? [disk] : []}
-        selectedDisk={disk && '' + disk.id}
+        selectedDisk={disk ? '' + disk.id : null}
         onClose={this.closeImagizeDrawer}
         changeDescription={this.changeImageDescription}
         changeLabel={this.changeImageLabel}
+        changeDisk={() => null}
+        onSuccess={() => null}
+        changeLinode={() => null}
+        selectedLinode={null}
       />
     );
   };

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks.tsx
@@ -365,7 +365,6 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
         changeDescription={this.changeImageDescription}
         changeLabel={this.changeImageLabel}
         changeDisk={() => null}
-        onSuccess={() => null}
         changeLinode={() => null}
         selectedLinode={null}
       />

--- a/packages/manager/src/features/linodes/LinodesLanding/CardView.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/CardView.tsx
@@ -1,6 +1,7 @@
 import { Image } from 'linode-js-sdk/lib/images';
 import { Config } from 'linode-js-sdk/lib/linodes';
 import * as React from 'react';
+import { compose } from 'recompose';
 import Grid from 'src/components/Grid';
 import { PaginationProps } from 'src/components/Paginate';
 import withImages from 'src/containers/withImages.container';
@@ -62,7 +63,11 @@ interface WithImagesProps {
   imagesData: Record<string, Image>;
 }
 
-export default withImages((ownProps, imagesData) => ({
-  ...ownProps,
-  imagesData
-}))(CardView);
+const enhanced = compose<CombinedProps, Props>(
+  withImages((ownProps, imagesData) => ({
+    ...ownProps,
+    imagesData
+  }))
+);
+
+export default enhanced(CardView);


### PR DESCRIPTION
## Description

Started out updating Images messaging to account for new secondary_entity capability, and found ~two~ four bugs while I was at it:

- Images list wasn't updating after editing label etc.
- CreateLinodeContainer wasn't looking at the imageID param, so "Deploy image to Linode" action was essentially broken
- ImagesDrawer didn't have a loading state
- Changing selected disk/Linode didn't reset the error state, so you could:
    1. Open the Images drawer
    2. Block requests
    3. Select a Linode
    4. Observe: you get a disks error
    5. Unblock requests and select a new Linode
    6. Observe: error is persistent, can't be gotten rid of until you submit the form.

Refactored a few things too, but there's still more tech debt in there, like many of our older components.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')
- Non breaking change ('update', 'change')

## Note to Reviewers

Make, fail, delete, edit, etc. a bunch of Images. Check the messaging in the events menu, activity summary, and toasts.