### PR TITLE
M3-3838 Use base-2 for graph metrics

### DIFF
--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/Network.test.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/Network.test.tsx
@@ -75,7 +75,7 @@ describe('Longview Network Gauge UI', () => {
       {}
     );
 
-    expect(innerText).toHaveTextContent('4 Mb/s');
+    expect(innerText).toHaveTextContent('4 Mibit/s');
     expect(subtext).toHaveTextContent('Network');
   });
 });

--- a/packages/manager/src/features/Longview/shared/utilities.test.ts
+++ b/packages/manager/src/features/Longview/shared/utilities.test.ts
@@ -6,6 +6,7 @@ import {
 } from '../request.types';
 import {
   appendStats,
+  formatBitsPerSecond,
   generateNetworkUnits,
   generateTotalMemory,
   generateUsedMemory,
@@ -360,6 +361,13 @@ describe('Utility Functions', () => {
       expect(result).toHaveProperty('pears');
       expect(result.apples[0].y).toEqual(2);
       expect(result.pears[0].y).toEqual(6);
+    });
+  });
+  describe('formatBitsPerSecond', () => {
+    it('adds unit', () => {
+      expect(formatBitsPerSecond(12)).toBe('12 b/s');
+      expect(formatBitsPerSecond(0)).toBe('0 b/s');
+      expect(formatBitsPerSecond(123456789)).toBe('117.74 Mibit/s');
     });
   });
 });

--- a/packages/manager/src/features/Longview/shared/utilities.test.ts
+++ b/packages/manager/src/features/Longview/shared/utilities.test.ts
@@ -75,8 +75,8 @@ describe('Utility Functions', () => {
     it('should generate the correct units and values', () => {
       const oneKilobit = 1000;
       const oneMegabit = 1000000;
-      expect(generateNetworkUnits(oneKilobit)).toEqual('Kb');
-      expect(generateNetworkUnits(oneMegabit)).toEqual('Mb');
+      expect(generateNetworkUnits(oneKilobit)).toEqual('Kibit');
+      expect(generateNetworkUnits(oneMegabit)).toEqual('Mibit');
       expect(generateNetworkUnits(100)).toEqual('b');
     });
   });

--- a/packages/manager/src/features/Longview/shared/utilities.ts
+++ b/packages/manager/src/features/Longview/shared/utilities.ts
@@ -370,3 +370,6 @@ export const formatNetworkTooltip = (valueInBytes: number) => {
   const converted = convertNetworkToUnit(valueInBytes * 8, _unit);
   return `${Math.round(converted * 100) / 100} ${_unit}`;
 };
+
+export const formatBitsPerSecond = (valueInBits: number) =>
+  formatNetworkTooltip(valueInBits / 8) + '/s';

--- a/packages/manager/src/features/Longview/shared/utilities.ts
+++ b/packages/manager/src/features/Longview/shared/utilities.ts
@@ -302,7 +302,7 @@ export const sumRelatedProcessesAcrossAllUsers = (
     return accum;
   }, {} as ProcessStats);
 
-export type NetworkUnit = 'b' | 'Kb' | 'Mb';
+export type NetworkUnit = 'b' | 'Kibit' | 'Mibit';
 /**
  * converts bytes to either Kb (Kilobits) or Mb (Megabits)
  * depending on if the Kilobit conversion exceeds 1000.
@@ -315,9 +315,9 @@ export const generateNetworkUnits = (networkUsed: number): NetworkUnit => {
   if (networkUsedToKilobits <= 1) {
     return 'b';
   } else if (networkUsedToKilobits <= 1000) {
-    return 'Kb';
+    return 'Kibit';
   } else {
-    return 'Mb';
+    return 'Mibit';
   }
 };
 
@@ -325,11 +325,11 @@ export const convertNetworkToUnit = (
   valueInBits: number,
   maxUnit: NetworkUnit
 ) => {
-  if (maxUnit === 'Mb') {
+  if (maxUnit === 'Mibit') {
     // If the unit we're using for the graph is Mb, return the output in Mb.
     const valueInMegabits = valueInBits / 1024 / 1024;
     return valueInMegabits;
-  } else if (maxUnit === 'Kb') {
+  } else if (maxUnit === 'Kibit') {
     // If the unit we're using for the graph is Kb, return the output in Kb.
     const valueInKilobits = valueInBits / 1024;
     return valueInKilobits;

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
@@ -21,14 +21,11 @@ import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
 import LineGraph from 'src/components/LineGraph';
 import MetricsDisplay from 'src/components/LineGraph/MetricsDisplay';
+import { formatBitsPerSecond } from 'src/features/Longview/shared/utilities';
 import { ExtendedNodeBalancer } from 'src/services/nodebalancers';
 import { ApplicationState } from 'src/store';
 import { initAll } from 'src/utilities/initAll';
-import {
-  formatBitsPerSecond,
-  formatNumber,
-  getMetrics
-} from 'src/utilities/statMetrics';
+import { formatNumber, getMetrics } from 'src/utilities/statMetrics';
 
 type ClassNames =
   | 'chart'
@@ -369,10 +366,6 @@ const withTimezone = connect((state: ApplicationState, ownProps) => ({
 
 const styled = withStyles(styles);
 
-const enhanced = compose<CombinedProps, Props>(
-  withTheme,
-  withTimezone,
-  styled
-);
+const enhanced = compose<CombinedProps, Props>(withTheme, withTimezone, styled);
 
 export default enhanced(TablesPanel);

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph.tsx
@@ -17,14 +17,16 @@ import {
 } from 'src/features/Longview/shared/utilities';
 import {
   formatBitsPerSecond,
-  formatBytes,
   getMetrics,
   getTotalTraffic,
   Metrics
 } from 'src/utilities/statMetrics';
+import { readableBytes } from 'src/utilities/unitConversions';
 import StatsPanel from './StatsPanel';
 import TotalTraffic, { TotalTrafficProps } from './TotalTraffic';
 import { ChartProps } from './types';
+
+const formatTotalTraffic = (value: number) => readableBytes(value).formatted;
 
 const useStyles = makeStyles((theme: Theme) => ({
   chart: {
@@ -88,7 +90,7 @@ export const NetworkGraph: React.FC<CombinedProps> = props => {
   const v6Metrics = _getMetrics(v6Data);
 
   const v4totalTraffic: TotalTrafficProps = map(
-    formatBytes,
+    formatTotalTraffic,
     getTotalTraffic(
       v4Metrics.publicIn.total,
       v4Metrics.publicOut.total,
@@ -99,7 +101,7 @@ export const NetworkGraph: React.FC<CombinedProps> = props => {
   );
 
   const v6totalTraffic: TotalTrafficProps = map(
-    formatBytes,
+    formatTotalTraffic,
     getTotalTraffic(
       v6Metrics.publicIn.total,
       v6Metrics.publicOut.total,

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph.tsx
@@ -12,11 +12,11 @@ import Grid from 'src/components/Grid';
 import LineGraph from 'src/components/LineGraph';
 import {
   convertNetworkToUnit,
+  formatBitsPerSecond,
   formatNetworkTooltip,
   generateNetworkUnits
 } from 'src/features/Longview/shared/utilities';
 import {
-  formatBitsPerSecond,
   getMetrics,
   getTotalTraffic,
   Metrics

--- a/packages/manager/src/utilities/statMetrics.test.ts
+++ b/packages/manager/src/utilities/statMetrics.test.ts
@@ -137,8 +137,8 @@ describe('formatting', () => {
     expect(formatPercentage(123456789)).toBe('123456789.00%');
   });
   it('formatBitsPerSecond adds unit', () => {
-    expect(formatBitsPerSecond(12)).toBe('12.00 b/s');
-    expect(formatBitsPerSecond(0)).toBe('0.00 b/s');
-    expect(formatBitsPerSecond(123456789)).toBe('123.46 Mb/s');
+    expect(formatBitsPerSecond(12)).toBe('12 b/s');
+    expect(formatBitsPerSecond(0)).toBe('0 b/s');
+    expect(formatBitsPerSecond(123456789)).toBe('117.74 Mibit/s');
   });
 });

--- a/packages/manager/src/utilities/statMetrics.test.ts
+++ b/packages/manager/src/utilities/statMetrics.test.ts
@@ -1,5 +1,4 @@
 import {
-  formatBitsPerSecond,
   formatNumber,
   formatPercentage,
   getMetrics,
@@ -135,10 +134,5 @@ describe('formatting', () => {
     expect(formatPercentage(12)).toBe('12.00%');
     expect(formatPercentage(0)).toBe('0.00%');
     expect(formatPercentage(123456789)).toBe('123456789.00%');
-  });
-  it('formatBitsPerSecond adds unit', () => {
-    expect(formatBitsPerSecond(12)).toBe('12 b/s');
-    expect(formatBitsPerSecond(0)).toBe('0 b/s');
-    expect(formatBitsPerSecond(123456789)).toBe('117.74 Mibit/s');
   });
 });

--- a/packages/manager/src/utilities/statMetrics.test.ts
+++ b/packages/manager/src/utilities/statMetrics.test.ts
@@ -1,7 +1,5 @@
 import {
   formatBitsPerSecond,
-  formatBytes,
-  formatMagnitude,
   formatNumber,
   formatPercentage,
   getMetrics,
@@ -119,31 +117,6 @@ describe('total traffic', () => {
   });
 });
 
-describe('format magnitude', () => {
-  it("doesn't add magnitude when 1 < X < 999", () => {
-    expect(formatMagnitude('612.12', 'b/s')).toBe('612.12 b/s');
-    expect(formatMagnitude(1, 'b/s')).toBe('1.00 b/s');
-    expect(formatMagnitude(99, 'b/s')).toBe('99.00 b/s');
-    expect(formatMagnitude(99.09, 'b/s')).toBe('99.09 b/s');
-  });
-
-  it('kilo', () => {
-    expect(formatMagnitude('6211.21', 'b/s')).toBe('6.21 kb/s');
-    expect(formatMagnitude('1000', 'b/s')).toBe('1.00 kb/s');
-    expect(formatMagnitude('555555', 'b/s')).toBe('555.55 kb/s');
-  });
-
-  it('mega', () => {
-    expect(formatMagnitude('62232111.21', 'b/s')).toBe('62.23 Mb/s');
-    expect(formatMagnitude('1000000', 'b/s')).toBe('1.00 Mb/s');
-  });
-
-  it('giga', () => {
-    expect(formatMagnitude('62331232111.21', 'b/s')).toBe('62.33 Gb/s');
-    expect(formatMagnitude('1000000000', 'b/s')).toBe('1.00 Gb/s');
-  });
-});
-
 describe('format number', () => {
   it('always returns two decimal places', () => {
     expect(formatNumber(24)).toBe('24.00');
@@ -167,10 +140,5 @@ describe('formatting', () => {
     expect(formatBitsPerSecond(12)).toBe('12.00 b/s');
     expect(formatBitsPerSecond(0)).toBe('0.00 b/s');
     expect(formatBitsPerSecond(123456789)).toBe('123.46 Mb/s');
-  });
-  it('formatBytes adds unit', () => {
-    expect(formatBytes(12)).toBe('12.00 B');
-    expect(formatBytes(0)).toBe('0.00 B');
-    expect(formatBytes(123456789)).toBe('123.46 MB');
   });
 });

--- a/packages/manager/src/utilities/statMetrics.tsx
+++ b/packages/manager/src/utilities/statMetrics.tsx
@@ -1,4 +1,5 @@
 import { StatsData } from 'linode-js-sdk/lib/linodes';
+import { formatNetworkTooltip } from 'src/features/Longview/shared/utilities';
 
 export interface Metrics {
   max: number;
@@ -45,42 +46,10 @@ export const getMetrics = (data: number[][]): Metrics => {
 
 export const formatNumber = (n: number): string => n.toFixed(2);
 
-// Applies SI Magnitude prefix.
-// 1400 --> "1.40 K"
-// 1400000 --> "1.40 M"
-// 1400000000 --> "1.40 G"
-export const formatMagnitude = (value: number | string, unit: string) => {
-  const num = Number(value);
-
-  const ranges = [
-    { divider: 1e9, suffix: 'G' },
-    { divider: 1e6, suffix: 'M' },
-    { divider: 1e3, suffix: 'k' },
-    { divider: 1, suffix: '' }
-  ];
-
-  let finalNum;
-  let magnitude;
-
-  // Use Array.prototype.some, because we might need to break this loop early.
-  ranges.some(range => {
-    if (num >= range.divider) {
-      finalNum = num / range.divider;
-      magnitude = range.suffix;
-      return true;
-    }
-    return false;
-  });
-
-  return finalNum
-    ? `${formatNumber(finalNum)} ${magnitude}${unit}`
-    : `${formatNumber(num)} ${unit}`;
-};
-
 export const formatPercentage = (value: number) => formatNumber(value) + '%';
+
 export const formatBitsPerSecond = (value: number) =>
-  formatMagnitude(value, 'b/s');
-export const formatBytes = (value: number) => formatMagnitude(value, 'B');
+  formatNetworkTooltip(value / 8) + '/s';
 
 export const getTraffic = (averageInBits: number): number => {
   const averageInBytes = averageInBits / 8;

--- a/packages/manager/src/utilities/statMetrics.tsx
+++ b/packages/manager/src/utilities/statMetrics.tsx
@@ -1,5 +1,4 @@
 import { StatsData } from 'linode-js-sdk/lib/linodes';
-import { formatNetworkTooltip } from 'src/features/Longview/shared/utilities';
 
 export interface Metrics {
   max: number;
@@ -47,9 +46,6 @@ export const getMetrics = (data: number[][]): Metrics => {
 export const formatNumber = (n: number): string => n.toFixed(2);
 
 export const formatPercentage = (value: number) => formatNumber(value) + '%';
-
-export const formatBitsPerSecond = (valueInBits: number) =>
-  formatNetworkTooltip(valueInBits / 8) + '/s';
 
 export const getTraffic = (averageInBits: number): number => {
   const averageInBytes = averageInBits / 8;

--- a/packages/manager/src/utilities/statMetrics.tsx
+++ b/packages/manager/src/utilities/statMetrics.tsx
@@ -48,8 +48,8 @@ export const formatNumber = (n: number): string => n.toFixed(2);
 
 export const formatPercentage = (value: number) => formatNumber(value) + '%';
 
-export const formatBitsPerSecond = (value: number) =>
-  formatNetworkTooltip(value / 8) + '/s';
+export const formatBitsPerSecond = (valueInBits: number) =>
+  formatNetworkTooltip(valueInBits / 8) + '/s';
 
 export const getTraffic = (averageInBits: number): number => {
   const averageInBytes = averageInBits / 8;


### PR DESCRIPTION
## Description

Use base-2 for graph metrics

Previously the metrics displayed under each Linode and NodeBalancer graph were in base-10. This makes it so that these metrics are calculated with base-2 since that’s the way the data is formatted in the actual graph.

I also changed the following units:

`Kb` -> `Kibit`
`Mb` -> `Mibit`

This affects the Linode graphs and the Longview graphs.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Please test against production and Classic. Compare values for Max, Avg, and Last. The values in this PR should be slightly lower (the difference between base-10 and base-2).

Please remember to test the NodeBalancer graphs (which haven’t actually been updated to use native legends yet).
