### PR TITLE
Fix capitalization of "StackScripts" 

### DIFF
--- a/packages/manager/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
@@ -277,6 +277,12 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
               pathname={location.pathname}
               labelTitle="Create New StackScript"
               className={classes.createTitle}
+              crumbOverrides={[
+                {
+                  position: 1,
+                  label: 'StackScripts'
+                }
+              ]}
               data-qa-create-stackscript-breadcrumb
             />
           </Grid>

--- a/packages/manager/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.tsx
@@ -326,6 +326,10 @@ export class StackScriptUpdate extends React.Component<CombinedProps, State> {
               labelTitle="Edit"
               data-qa-update-stackscript-breadcrumb
               crumbOverrides={[
+                {
+                  position: 1,
+                  label: 'StackScripts'
+                },
                 { position: 2, label: this.defaultStackScriptValues.labelText }
               ]}
             />

--- a/packages/manager/src/features/StackScripts/StackScriptsDetail.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptsDetail.tsx
@@ -125,6 +125,12 @@ export class StackScriptsDetail extends React.Component<CombinedProps, {}> {
               pathname={this.props.location.pathname}
               labelOptions={{ prefixComponent: userNameSlash, noCap: true }}
               labelTitle={stackScript.label}
+              crumbOverrides={[
+                {
+                  position: 1,
+                  label: 'StackScripts'
+                }
+              ]}
             />
           </Grid>
           <Grid item className={classes.cta}>


### PR DESCRIPTION
## Description

This was a result of the dynamic breadcrumb. I added crumb overrides for: 

- Create StackScript
- Edit StackScript
- StackScript Detail
