### PR TITLE
M3-3819  [LV] User preferences phase 2

### DIFF
--- a/packages/manager/src/components/OrderBy.test.ts
+++ b/packages/manager/src/components/OrderBy.test.ts
@@ -1,4 +1,4 @@
-import { sortData } from './OrderBy';
+import { getInitialValuesFromUserPreferences, sortData } from './OrderBy';
 
 const a = {
   name: 'april',
@@ -48,6 +48,44 @@ describe('OrderBy', () => {
     it('should sort by array length', () => {
       const order = sortData('hobbies', 'asc')(data);
       expect(order).toEqual([b, c, e, a, d]);
+    });
+  });
+
+  describe('getInitialValuesFromUserPreferences', () => {
+    const preferences = {
+      sortKeys: {
+        ['listening-services']: {
+          orderBy: 'test-order',
+          order: 'desc' as any
+        }
+      }
+    };
+    it('should return values from preferences if the preference key exists', () => {
+      expect(
+        getInitialValuesFromUserPreferences(
+          'listening-services',
+          preferences,
+          'default',
+          'desc'
+        )
+      ).toEqual({ orderBy: 'test-order', order: 'desc' });
+    });
+
+    it("should return the defaults if the key isn't found", () => {
+      expect(
+        getInitialValuesFromUserPreferences(
+          'listening-services',
+          {},
+          'default',
+          'asc'
+        )
+      ).toEqual({ order: 'asc', orderBy: 'default' });
+    });
+
+    it('should return the defaults if there is no preference key provided', () => {
+      expect(
+        getInitialValuesFromUserPreferences('', preferences, 'default', 'asc')
+      ).toEqual({ order: 'asc', orderBy: 'default' });
     });
   });
 });

--- a/packages/manager/src/components/OrderBy.ts
+++ b/packages/manager/src/components/OrderBy.ts
@@ -41,8 +41,22 @@ interface Props {
 
 type CombinedProps = Props & PreferencesProps;
 
+/**
+ * Given a set of UserPreferences (returned from the API),
+ * and a preferenceKey, returns the order and orderby for
+ * that preferenceKey if it exists. If the key isn't found,
+ * or isn't provided, it will instead return
+ * {
+ *   order: defaultOrder,
+ *   orderBy: defaultOrderBy
+ * }
+ * @param preferenceKey
+ * @param preferences
+ * @param defaultOrderBy
+ * @param defaultOrder
+ */
 export const getInitialValuesFromUserPreferences = (
-  preferenceKey: string,
+  preferenceKey: SortKey | '',
   preferences: UserPreferences,
   defaultOrderBy: string,
   defaultOrder: Order

--- a/packages/manager/src/components/OrderBy.ts
+++ b/packages/manager/src/components/OrderBy.ts
@@ -152,7 +152,7 @@ export class OrderBy extends React.Component<CombinedProps, State> {
             sortKeys: {
               ...preferences.sortKeys,
               [preferenceKey]: { order, orderBy }
-            } as UserPreferences['sortKeys']
+            }
           });
         })
         // It doesn't matter if this fails, the value simply won't be preserved.

--- a/packages/manager/src/components/OrderBy.ts
+++ b/packages/manager/src/components/OrderBy.ts
@@ -8,7 +8,10 @@ import { Order } from 'src/components/Pagey';
 import withPreferences, {
   Props as PreferencesProps
 } from 'src/containers/preferences.container';
-import { UserPreferences } from 'src/store/preferences/preferences.actions';
+import {
+  SortKey,
+  UserPreferences
+} from 'src/store/preferences/preferences.actions';
 import { isArray } from 'util';
 
 import {
@@ -33,7 +36,7 @@ interface Props {
   children: (p: OrderByProps) => React.ReactNode;
   order?: Order;
   orderBy?: string;
-  preferenceKey?: string; // If provided, will store/read values from user preferences
+  preferenceKey?: SortKey; // If provided, will store/read values from user preferences
 }
 
 type CombinedProps = Props & PreferencesProps;
@@ -135,7 +138,7 @@ export class OrderBy extends React.Component<CombinedProps, State> {
             sortKeys: {
               ...preferences.sortKeys,
               [preferenceKey]: { order, orderBy }
-            }
+            } as UserPreferences['sortKeys']
           });
         })
         // It doesn't matter if this fails, the value simply won't be preserved.
@@ -143,7 +146,7 @@ export class OrderBy extends React.Component<CombinedProps, State> {
     }
   };
 
-  updateUserPreferences = debounce(2000, false, this._updateUserPreferences);
+  updateUserPreferences = debounce(1500, false, this._updateUserPreferences);
 
   handleOrderChange = (orderBy: string, order: Order) => {
     this.setState({ orderBy, order });

--- a/packages/manager/src/components/OrderBy.ts
+++ b/packages/manager/src/components/OrderBy.ts
@@ -2,6 +2,8 @@ import * as moment from 'moment';
 import { pathOr, sort, splitAt } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
+import { debounce } from 'throttle-debounce';
+
 import { Order } from 'src/components/Pagey';
 import withPreferences, {
   Props as PreferencesProps
@@ -114,13 +116,8 @@ export class OrderBy extends React.Component<CombinedProps, State> {
     this.props.order ?? 'asc'
   );
 
-  handleOrderChange = (orderBy: string, order: Order) => {
+  _updateUserPreferences = (orderBy: string, order: Order) => {
     /**
-     * All that we really have to do here is save the updated
-     * values to state. However, if a consumer asks us, we
-     * can also store the selection in user preferences, so that
-     * it will be preserved for later visits.
-     *
      * If the preferenceKey is provided, we will store the passed
      * order props in user preferences. They will be read the next
      * time this component is loaded.
@@ -144,7 +141,13 @@ export class OrderBy extends React.Component<CombinedProps, State> {
         // It doesn't matter if this fails, the value simply won't be preserved.
         .catch(_ => null);
     }
+  };
+
+  updateUserPreferences = debounce(2000, false, this._updateUserPreferences);
+
+  handleOrderChange = (orderBy: string, order: Order) => {
     this.setState({ orderBy, order });
+    this.updateUserPreferences(orderBy, order);
   };
 
   render() {

--- a/packages/manager/src/components/OrderBy.ts
+++ b/packages/manager/src/components/OrderBy.ts
@@ -1,7 +1,12 @@
 import * as moment from 'moment';
 import { pathOr, sort, splitAt } from 'ramda';
 import * as React from 'react';
+import { compose } from 'recompose';
 import { Order } from 'src/components/Pagey';
+import withPreferences, {
+  Props as PreferencesProps
+} from 'src/containers/preferences.container';
+import { UserPreferences } from 'src/store/preferences/preferences.actions';
 import { isArray } from 'util';
 
 import {
@@ -26,7 +31,24 @@ interface Props {
   children: (p: OrderByProps) => React.ReactNode;
   order?: Order;
   orderBy?: string;
+  preferenceKey?: string; // If provided, will store/read values from user preferences
 }
+
+type CombinedProps = Props & PreferencesProps;
+
+export const getInitialValuesFromUserPreferences = (
+  preferenceKey: string,
+  preferences: UserPreferences,
+  defaultOrderBy: string,
+  defaultOrder: Order
+) => {
+  return (
+    preferences?.sortKeys?.[preferenceKey] ?? {
+      orderBy: defaultOrderBy,
+      order: defaultOrder
+    }
+  );
+};
 
 export const sortData = (orderBy: string, order: Order) =>
   sort((a, b) => {
@@ -55,7 +77,7 @@ export const sortData = (orderBy: string, order: Order) =>
     /**
      * @todo document this in a README
      *
-     * this allows us to pass a value such as 'maintenance:when' to the handleOrderChagne
+     * this allows us to pass a value such as 'maintenance:when' to the handleOrderChange
      * callback and it will turn it into a pathOr-friendly format
      *
      * so "maintenance:when" turns into ['maintenance', 'when']
@@ -84,19 +106,52 @@ export const sortData = (orderBy: string, order: Order) =>
     return sortByNumber(aValue, bValue, order);
   });
 
-export default class OrderBy extends React.Component<Props, State> {
-  state: State = {
-    order: this.props.order || 'asc',
-    orderBy: this.props.orderBy || 'label'
+export class OrderBy extends React.Component<CombinedProps, State> {
+  state: State = getInitialValuesFromUserPreferences(
+    this.props.preferenceKey ?? '',
+    this.props.preferences,
+    this.props.orderBy ?? 'label',
+    this.props.order ?? 'asc'
+  );
+
+  handleOrderChange = (orderBy: string, order: Order) => {
+    /**
+     * All that we really have to do here is save the updated
+     * values to state. However, if a consumer asks us, we
+     * can also store the selection in user preferences, so that
+     * it will be preserved for later visits.
+     *
+     * If the preferenceKey is provided, we will store the passed
+     * order props in user preferences. They will be read the next
+     * time this component is loaded.
+     */
+    const {
+      getUserPreferences,
+      preferenceKey,
+      updateUserPreferences
+    } = this.props;
+    if (preferenceKey) {
+      getUserPreferences()
+        .then(preferences => {
+          updateUserPreferences({
+            ...preferences,
+            sortKeys: {
+              ...preferences.sortKeys,
+              [preferenceKey]: { order, orderBy }
+            }
+          });
+        })
+        // It doesn't matter if this fails, the value simply won't be preserved.
+        .catch(_ => null);
+    }
+    this.setState({ orderBy, order });
   };
 
-  handleOrderChange = (orderBy: string, order: Order) =>
-    this.setState({ orderBy, order });
-
   render() {
-    const sortedData = sortData(this.state.orderBy, this.state.order)(
-      this.props.data
-    );
+    const sortedData = sortData(
+      this.state.orderBy,
+      this.state.order
+    )(this.props.data);
 
     const props = {
       ...this.props,
@@ -109,6 +164,10 @@ export default class OrderBy extends React.Component<Props, State> {
     return this.props.children(props);
   }
 }
+
+const enhanced = compose<CombinedProps, Props>(withPreferences());
+
+export default enhanced(OrderBy);
 
 const isValidDate = (date: any) => {
   return moment(date, moment.ISO_8601, true).isValid();

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ActiveConnections/ActiveConnections.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ActiveConnections/ActiveConnections.tsx
@@ -64,7 +64,12 @@ export const ConnectionsTable: React.FC<TableProps> = props => {
   const classes = useStyles();
 
   return (
-    <OrderBy data={connections} orderBy={'process'} order={'asc'}>
+    <OrderBy
+      data={connections}
+      orderBy={'process'}
+      order={'asc'}
+      preferenceKey={'active-connections'}
+    >
       {({ data: orderedData, handleOrderChange, order, orderBy }) => (
         <Paginate data={orderedData} pageSize={25}>
           {({

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ListeningServices/ListeningServices.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ListeningServices/ListeningServices.tsx
@@ -59,7 +59,12 @@ export const ServicesTable: React.FC<TableProps> = props => {
   const classes = useStyles();
 
   return (
-    <OrderBy data={services} orderBy={'process'} order={'asc'}>
+    <OrderBy
+      data={services}
+      orderBy={'process'}
+      order={'asc'}
+      preferenceKey={'listening-services'}
+    >
       {({ data: orderedData, handleOrderChange, order, orderBy }) => (
         <Paginate data={orderedData} pageSize={25}>
           {({

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.test.tsx
@@ -22,7 +22,7 @@ describe('ObjectStorageLanding', () => {
   });
 
   it('renders an "OrderBy" component, ordered by label', () => {
-    expect(wrapper.find('OrderBy').prop('orderBy')).toBe('label');
+    expect(wrapper.find('Connect(OrderBy)').prop('orderBy')).toBe('label');
   });
 
   it('renders a loading state when the data is loading', () => {

--- a/packages/manager/src/store/preferences/preferences.actions.ts
+++ b/packages/manager/src/store/preferences/preferences.actions.ts
@@ -10,6 +10,8 @@ export interface OrderSet {
   order: Order;
   orderBy: string;
 }
+
+export type SortKey = 'listening-services' | 'active-connections';
 export interface UserPreferences {
   longviewTimeRange?: string;
   gst_banner_dismissed?: boolean;
@@ -21,7 +23,7 @@ export interface UserPreferences {
   theme?: ThemeChoice;
   spacing?: SpacingChoice;
   desktop_sidebar_open?: boolean;
-  sortKeys?: Record<string, OrderSet>;
+  sortKeys?: Record<SortKey, OrderSet>;
 }
 
 export const handleGetPreferences = actionCreator.async<

--- a/packages/manager/src/store/preferences/preferences.actions.ts
+++ b/packages/manager/src/store/preferences/preferences.actions.ts
@@ -1,10 +1,15 @@
 import { APIError } from 'linode-js-sdk/lib/types';
 import { actionCreatorFactory } from 'typescript-fsa';
 
+import { Order } from 'src/components/Pagey';
 import { SpacingChoice, ThemeChoice } from 'src/LinodeThemeWrapper';
 
 const actionCreator = actionCreatorFactory(`@@manager/preferences`);
 
+export interface OrderSet {
+  order: Order;
+  orderBy: string;
+}
 export interface UserPreferences {
   longviewTimeRange?: string;
   gst_banner_dismissed?: boolean;
@@ -16,6 +21,7 @@ export interface UserPreferences {
   theme?: ThemeChoice;
   spacing?: SpacingChoice;
   desktop_sidebar_open?: boolean;
+  sortKeys?: Record<string, OrderSet>;
 }
 
 export const handleGetPreferences = actionCreator.async<

--- a/packages/manager/src/store/preferences/preferences.actions.ts
+++ b/packages/manager/src/store/preferences/preferences.actions.ts
@@ -23,7 +23,7 @@ export interface UserPreferences {
   theme?: ThemeChoice;
   spacing?: SpacingChoice;
   desktop_sidebar_open?: boolean;
-  sortKeys?: Record<SortKey, OrderSet>;
+  sortKeys?: Partial<Record<SortKey, OrderSet>>;
 }
 
 export const handleGetPreferences = actionCreator.async<


### PR DESCRIPTION
## Description

POC for how to save sortable table selections (order and orderby) in user preferences. Right now, only activated in the bottom Longview Overview tables (connections and services).

The idea is that you pass an optional `preferenceKey` prop to `OrderBy` if you'd like a table's options stored in preferences. OrderBy then does all the work of looking for and updating order and orderby for that table.

## Note to Reviewers

I debounced the actual API calls so that a user can toggle back and forth without it getting laggy. The experience still doesn't seem super-fast though, suggestions welcome.