### PR TITLE
M3-3846 Close any Lish sessions when logging out

### DIFF
--- a/packages/manager/src/features/Lish/Lish.tsx
+++ b/packages/manager/src/features/Lish/Lish.tsx
@@ -22,6 +22,7 @@ import Tab from 'src/components/core/Tab';
 import Tabs from 'src/components/core/Tabs';
 import NotFound from 'src/components/NotFound';
 import { convertForAria } from 'src/components/TabLink/TabLink';
+// import { authentication } from 'src/utilities/storage';
 import Glish from './Glish';
 import Weblish from './Weblish';
 
@@ -71,6 +72,7 @@ class Lish extends React.Component<CombinedProps, State> {
     loading: true
   };
 
+  interval: number;
   mounted: boolean;
 
   componentDidMount() {
@@ -109,10 +111,19 @@ class Lish extends React.Component<CombinedProps, State> {
       });
 
     this.refreshToken();
+    // If the user signs out in another window, close this session
+    this.interval = window.setInterval(() => {
+      const token = localStorage.getItem('authentication/token');
+
+      if (!token) {
+        window.close();
+      }
+    }, 5000);
   }
 
   componentWillUnmount() {
     this.mounted = false;
+    window.clearInterval(this.interval);
   }
 
   refreshToken = () => {


### PR DESCRIPTION
To test:

- Go to Linode Detail and select Launch Console
- From the original tab, log out

In prod, the Lish window would stay open. On this branch, it will close automatically.

Other fun things to try: 

- Mobile 
- Opening a link to Lish directly (something like http://localhost:3000/linodes/{id}/lish/weblish) and seeing how it responds to logging out in a separate window
- Triggering a token refresh (setting your token to expire in a minute or two) and making sure it doesn't disrupt the experience of the other open windows.