### PR TITLE
M3-3839 DNS manager displays '1 hours' instead of '1 hour'

### DIFF
--- a/packages/manager/src/features/Domains/DomainRecords.tsx
+++ b/packages/manager/src/features/Domains/DomainRecords.tsx
@@ -817,7 +817,7 @@ const msToReadable = (v: number): null | string =>
   pathOr(null, [v], {
     0: 'Default',
     300: '5 minutes',
-    3600: '1 hours',
+    3600: '1 hour',
     7200: '2 hours',
     14400: '4 hours',
     28800: '8 hours',


### PR DESCRIPTION
## Description

Another small adjustment based on customer feedback, there was a typo on the DNS Manager record time display.

## Type of Change
- Non breaking change ('update')