### PR TITLE
Fix regression with in-progress events

### DIFF
--- a/packages/manager/src/store/selectors/recentEventForLinode.test.ts
+++ b/packages/manager/src/store/selectors/recentEventForLinode.test.ts
@@ -1,0 +1,39 @@
+import { entityFactory, eventFactory } from 'src/factories/events';
+import recentEventForLinode from './recentEventForLinode';
+
+describe('recentEventForLinode selector', () => {
+  const selector = recentEventForLinode(1);
+  const entity = entityFactory.build({
+    id: 1
+  });
+
+  it('only returns in-progress events', () => {
+    const nonInProgressEvent = eventFactory.build({
+      entity,
+      percent_complete: null
+    });
+    const inProgressEvent = eventFactory.build({
+      entity,
+      percent_complete: 50
+    });
+    const mockState1: any = { events: { events: [nonInProgressEvent] } };
+    const mockState2: any = { events: { events: [inProgressEvent] } };
+    expect(selector(mockState1)).toBeUndefined();
+    expect(selector(mockState2)).toBeDefined();
+  });
+
+  it('only returns events relevant to the Linode', () => {
+    const irrelevantEvent = eventFactory.build({
+      entity: entityFactory.build({
+        id: 2
+      })
+    });
+    const relevantEvent = eventFactory.build({
+      entity
+    });
+    const mockState1: any = { events: { events: [irrelevantEvent] } };
+    const mockState2: any = { events: { events: [relevantEvent] } };
+    expect(selector(mockState1)).toBeUndefined();
+    expect(selector(mockState2)).toBeDefined();
+  });
+});

--- a/packages/manager/src/store/selectors/recentEventForLinode.ts
+++ b/packages/manager/src/store/selectors/recentEventForLinode.ts
@@ -1,6 +1,7 @@
 import { Event } from 'linode-js-sdk/lib/account';
 import { createSelector } from 'reselect';
 import { ApplicationState } from 'src/store';
+import { isInProgressEvent } from '../events/event.helpers';
 import { isEventRelevantToLinode } from '../events/event.selectors';
 
 export default (linodeId: number) =>
@@ -11,7 +12,10 @@ export default (linodeId: number) =>
       const len = events.length;
       for (; idx < len; idx += 1) {
         const event = events[idx];
-        if (isEventRelevantToLinode(event, linodeId)) {
+        if (
+          isInProgressEvent(event) &&
+          isEventRelevantToLinode(event, linodeId)
+        ) {
           return event;
         }
       }


### PR DESCRIPTION
## Description

Thanks to @Jskobos for catching this.

This PR fixes a regression with Linodes that have an in-progress action happening as well as a more recent non-progress action. An example:

1. Reboot a Linode.
2. Quickly, change the Linode's label.
3. Observe: You no longer see progress on the reboot action.

This was happening because the `linode_update` was being considered as an "recent" event for the Linode. This was a regression that happened here: 

https://github.com/linode/manager/pull/6039/commits/dbf7af8faa45e62984fba2dbab8c34a8211090aa#diff-c3ba94a71d4fe8736aae34e6f82d0813L20

I also added unit tests to validate this behavior and prevent future regressions.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')
