### PR TITLE
M3-3842 Change: Update event toasts

### DIFF
--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -286,10 +286,11 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
     notification: e => `An IP was deleted from Linode ${e.entity!.id}`
   },
   linode_migrate: {
-    scheduled: e => `Linode ${e.entity!.label} is scheduled for migration.`,
-    started: e => `Linode ${e.entity!.label} is being migrated.`,
-    failed: e => `Migration failed for Linode ${e.entity!.label}.`,
-    finished: e => `Linode ${e.entity!.label} has been migrated.`
+    scheduled: e =>
+      `Linode ${e.entity?.label ?? ''} is scheduled for migration.`,
+    started: e => `Linode ${e.entity?.label ?? ''} is being migrated.`,
+    failed: e => `Migration failed for Linode ${e.entity?.label ?? ''}.`,
+    finished: e => `Linode ${e.entity?.label ?? ''} has been migrated.`
   },
   // This event type isn't currently being displayed, but I added a message here just in case.
   linode_migrate_datacenter_create: {
@@ -298,10 +299,11 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
   },
   // These are the same as the messages for `linode_migrate`.
   linode_migrate_datacenter: {
-    scheduled: e => `Linode ${e.entity!.label} is scheduled for migration.`,
-    started: e => `Linode ${e.entity!.label} is being migrated.`,
-    failed: e => `Migration failed for Linode ${e.entity!.label}.`,
-    finished: e => `Linode ${e.entity!.label} has been migrated.`
+    scheduled: e =>
+      `Linode ${e.entity?.label ?? ''} is scheduled for migration.`,
+    started: e => `Linode ${e.entity?.label ?? ''} is being migrated.`,
+    failed: e => `Migration failed for Linode ${e.entity?.label ?? ''}.`,
+    finished: e => `Linode ${e.entity?.label ?? ''} has been migrated.`
   },
   // This event type isn't currently being displayed, but I added a message here just in case.
   linode_mutate_create: {
@@ -309,11 +311,12 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
       `Upgrade for Linode ${e.entity!.label} has been initiated.`
   },
   linode_mutate: {
-    scheduled: e => `Linode ${e.entity!.label} is scheduled for an upgrade.`,
-    started: e => `Linode ${e.entity!.label} is being upgraded.`,
-    failed: e => `Linode ${e.entity!.label} could not be upgraded.`,
-    finished: e => `Linode ${e.entity!.label} has been upgraded.`,
-    notification: e => `Linode ${e.entity!.label} is being upgraded.`
+    scheduled: e =>
+      `Linode ${e.entity?.label ?? ''} is scheduled for an upgrade.`,
+    started: e => `Linode ${e.entity?.label ?? ''} is being upgraded.`,
+    failed: e => `Linode ${e.entity?.label ?? ''} could not be upgraded.`,
+    finished: e => `Linode ${e.entity?.label ?? ''} has been upgraded.`,
+    notification: e => `Linode ${e.entity?.label ?? ''} is being upgraded.`
   },
   linode_reboot: {
     scheduled: e =>
@@ -353,10 +356,11 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
       `Resize for Linode ${e.entity!.label} has been initiated.`
   },
   linode_resize: {
-    scheduled: e => `Linode ${e.entity!.label} is scheduled for resizing.`,
-    started: e => `Linode ${e.entity!.label} is resizing.`,
-    failed: e => `Linode ${e.entity!.label} could not be resized`,
-    finished: e => `Linode ${e.entity!.label} has been resized.`
+    scheduled: e =>
+      `Linode ${e.entity?.label ?? ''} is scheduled for resizing.`,
+    started: e => `Linode ${e.entity?.label ?? ''} is resizing.`,
+    failed: e => `Linode ${e.entity?.label ?? ''} could not be resized`,
+    finished: e => `Linode ${e.entity?.label ?? ''} has been resized.`
   },
   linode_shutdown: {
     scheduled: e => `Linode ${e.entity!.label} is scheduled for shutdown.`,

--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -252,11 +252,20 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
       `Linode ${e.entity?.label ?? ''} has been booted (Lish initiated boot).`
   },
   linode_clone: {
-    scheduled: e => `Linode ${e.entity!.label} is scheduled to be cloned.`,
-    started: e => `Linode ${e.entity!.label} is being cloned.`,
-    failed: e => `Linode ${e.entity!.label} could not be cloned.`,
-    finished: e => `Linode ${e.entity!.label} has been cloned.`,
-    notification: e => `Linode ${e.entity!.label} is scheduled to be cloned.`
+    scheduled: e =>
+      `Linode ${e.entity?.label ?? ''} is scheduled to be cloned to ${e
+        .secondary_entity?.label ?? ''}.`,
+    started: e =>
+      `Linode ${e.entity?.label ?? ''} is being cloned to ${e.secondary_entity
+        ?.label ?? ''}.`,
+    failed: e =>
+      `Linode ${e.entity?.label ?? ''} could not be cloned to ${e
+        .secondary_entity?.label ?? ''}.`,
+    finished: e =>
+      `Linode ${e.entity?.label ?? ''} has been cloned to ${e.secondary_entity
+        ?.label ?? ''}.`,
+    notification: e =>
+      `Linode ${e.entity?.label ?? ''} is scheduled to be cloned.`
   },
   linode_create: {
     scheduled: e => `Linode ${e.entity!.label} is scheduled for creation.`,

--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -253,17 +253,21 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
   },
   linode_clone: {
     scheduled: e =>
-      `Linode ${e.entity?.label ?? ''} is scheduled to be cloned to ${e
-        .secondary_entity?.label ?? ''}.`,
+      `Linode ${e.entity?.label ??
+        ''} is scheduled to be cloned ${safeSecondaryEntityLabel(
+        e,
+        'to',
+        ''
+      )}.`,
     started: e =>
-      `Linode ${e.entity?.label ?? ''} is being cloned to ${e.secondary_entity
-        ?.label ?? ''}.`,
+      `Linode ${e.entity?.label ??
+        ''} is being cloned${safeSecondaryEntityLabel(e, ' to', '')}.`,
     failed: e =>
-      `Linode ${e.entity?.label ?? ''} could not be cloned to ${e
-        .secondary_entity?.label ?? ''}.`,
+      `Linode ${e.entity?.label ??
+        ''} could not be cloned${safeSecondaryEntityLabel(e, ' to', '')}.`,
     finished: e =>
-      `Linode ${e.entity?.label ?? ''} has been cloned to ${e.secondary_entity
-        ?.label ?? ''}.`,
+      `Linode ${e.entity?.label ??
+        ''} has been cloned${safeSecondaryEntityLabel(e, ' to', '')}.`,
     notification: e =>
       `Linode ${e.entity?.label ?? ''} is scheduled to be cloned.`
   },

--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -254,9 +254,9 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
   linode_clone: {
     scheduled: e =>
       `Linode ${e.entity?.label ??
-        ''} is scheduled to be cloned ${safeSecondaryEntityLabel(
+        ''} is scheduled to be cloned${safeSecondaryEntityLabel(
         e,
-        'to',
+        ' to',
         ''
       )}.`,
     started: e =>

--- a/packages/manager/src/features/ToastNotifications/ToastNotifications.tsx
+++ b/packages/manager/src/features/ToastNotifications/ToastNotifications.tsx
@@ -178,6 +178,60 @@ class ToastNotifications extends React.PureComponent<WithSnackbarProps, {}> {
           );
         }
 
+        if (
+          ['linode_migrate_datacenter', 'linode_migrate'].includes(
+            event.action
+          ) &&
+          ['failed'].includes(event.status)
+        ) {
+          return enqueueSnackbar(
+            `Error migrating Linode ${event.entity?.label ?? ''}.`,
+            {
+              variant: 'error'
+            }
+          );
+        }
+
+        if (
+          ['linode_migrate_datacenter', 'linode_migrate'].includes(
+            event.action
+          ) &&
+          ['finished', 'notification'].includes(event.status)
+        ) {
+          return enqueueSnackbar(
+            `Linode ${event.entity?.label ??
+              ''} has been migrated successfully.`,
+            {
+              variant: 'success'
+            }
+          );
+        }
+
+        if (
+          event.action === 'linode_resize' &&
+          ['failed'].includes(event.status)
+        ) {
+          return enqueueSnackbar(
+            `Error resizing Linode ${event.entity?.label ?? ''}.`,
+            {
+              variant: 'error'
+            }
+          );
+        }
+
+        if (
+          event.action === 'linode_resize' &&
+          ['finished', 'notification'].includes(event.status)
+        ) {
+          return enqueueSnackbar(
+            `Linode ${event.entity?.label ??
+              ''} has been resized successfully.`,
+            {
+              variant: 'success'
+            }
+          );
+        }
+
         return;
       })
       /**

--- a/packages/manager/src/features/ToastNotifications/ToastNotifications.tsx
+++ b/packages/manager/src/features/ToastNotifications/ToastNotifications.tsx
@@ -22,7 +22,7 @@ import { events$ } from 'src/events';
  */
 export const toastSuccessAndFailure = curry(
   (
-    enqueueSnackbar: any,
+    enqueueSnackbar: WithSnackbarProps['enqueueSnackbar'],
     eventStatus: EventStatus,
     successMessage: string | undefined,
     failureMessage: string | undefined
@@ -58,18 +58,18 @@ class ToastNotifications extends React.PureComponent<WithSnackbarProps, {}> {
         switch (event.action) {
           case 'volume_attach':
             return _toast(
-              'Volume successfully attached.',
-              'Volume successfully detached.'
+              `Volume ${label} successfully attached.`,
+              `Error attaching Volume ${label}.`
             );
           case 'volume_detach':
             return _toast(
-              'Volume successfully detached.',
-              'Error detaching Volume.'
+              `Volume ${label} successfully detached.`,
+              `Error detaching Volume ${label}.`
             );
           case 'volume_create':
             return _toast(
-              'Volume successfully created.',
-              'Error creating Volume.'
+              `Volume ${label} successfully created.`,
+              `Error creating Volume ${label}.`
             );
           case 'volume_delete':
             return _toast(

--- a/packages/manager/src/features/ToastNotifications/ToastNotifications.tsx
+++ b/packages/manager/src/features/ToastNotifications/ToastNotifications.tsx
@@ -152,6 +152,32 @@ class ToastNotifications extends React.PureComponent<WithSnackbarProps, {}> {
           });
         }
 
+        if (
+          event.action === 'linode_clone' &&
+          ['failed'].includes(event.status)
+        ) {
+          return enqueueSnackbar(
+            `Error cloning Linode ${event.entity?.label ?? ''}.`,
+            {
+              variant: 'error'
+            }
+          );
+        }
+
+        if (
+          event.action === 'linode_clone' &&
+          ['finished', 'notification'].includes(event.status)
+        ) {
+          return enqueueSnackbar(
+            `Linode ${event.entity?.label ??
+              ''} has been cloned successfully to ${event.secondary_entity
+              ?.label ?? ''}.`,
+            {
+              variant: 'success'
+            }
+          );
+        }
+
         return;
       })
       /**

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/ActivityRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/ActivityRow.tsx
@@ -59,7 +59,7 @@ export const ActivityRow: React.StatelessComponent<CombinedProps> = props => {
     >
       <Grid item>
         <Typography>
-          {displayedMessage} {duration === '' ? '' : `(${duration})`}
+          {displayedMessage} {duration && `(${duration})`}
         </Typography>
       </Grid>
       <Grid item>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/ActivityRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/ActivityRow.tsx
@@ -36,6 +36,7 @@ export const ActivityRow: React.StatelessComponent<CombinedProps> = props => {
   const { classes, event } = props;
 
   const message = eventMessageGenerator(event);
+  const duration = formatEventSeconds(event.duration);
 
   if (!message) {
     return null;
@@ -58,7 +59,7 @@ export const ActivityRow: React.StatelessComponent<CombinedProps> = props => {
     >
       <Grid item>
         <Typography>
-          {displayedMessage} ({formatEventSeconds(event.duration)})
+          {displayedMessage} {duration === '' ? '' : `(${duration})`}
         </Typography>
       </Grid>
       <Grid item>

--- a/packages/manager/src/utilities/minute-conversion/minute-conversion.test.ts
+++ b/packages/manager/src/utilities/minute-conversion/minute-conversion.test.ts
@@ -41,9 +41,9 @@ describe('Human-Readable Minute Conversion', () => {
 
 describe('Event seconds conversion', () => {
   it('should format event seconds correctly', () => {
-    expect(formatEventSeconds(null)).toBe('Unknown');
-    expect(formatEventSeconds(undefined as any)).toBe('Unknown');
-    expect(formatEventSeconds(0)).toBe('Unknown');
+    expect(formatEventSeconds(null)).toBe('');
+    expect(formatEventSeconds(undefined as any)).toBe('');
+    expect(formatEventSeconds(0)).toBe('');
 
     expect(formatEventSeconds(3600)).toBe('1 hour');
     expect(formatEventSeconds(3660)).toBe('1 hour, 1 minute');

--- a/packages/manager/src/utilities/minute-conversion/minute-conversion.ts
+++ b/packages/manager/src/utilities/minute-conversion/minute-conversion.ts
@@ -89,7 +89,7 @@ export const generateMigrationTimeString = (migrationTimeInMins: number) => {
 
 export const formatEventSeconds = (seconds: number | null) => {
   if (!seconds) {
-    return 'Unknown';
+    return ''; // Show nothing if we don't know a duration
   }
 
   if (seconds >= 3600) {


### PR DESCRIPTION
## Description

- Add toasts for successful/failed resize, clone, and migrate events
- Refactor the ToastNotification.tsx logic (long time coming, the copy/paste was getting unmanageable)
- Remove (Unknown) from the duration column if we don't have a duration (has Jay's ok)

## Note to Reviewers

Trigger a bunch of disk deletes, images, resizes, clones, etc. and make sure you get the same toasts as before, and that the new ones work correctly