### PR TITLE
Fix typo intra -> inter

### DIFF
--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -291,7 +291,7 @@ export const LINODE_ARN_TAX_ID = '3000 1606 0612';
 export const MBpsIntraDC = 75;
 
 /**
- * MBps rate for intra DC migrations (AKA Cross-Datacenter migrations )
+ * MBps rate for inter DC migrations (AKA Cross-Datacenter migrations )
  */
 export const MBpsInterDC = 1.5;
 


### PR DESCRIPTION
## Description

The comment on both intra- and inter- DC migrations said intra. This makes the inter- comment match the inter- constant.

## Type of Change
Typo (bug fix in comment only)

## Applicable E2E Tests

Should not have any impact whatsoever on the functionality of the code

