### PR TITLE
Accept 'patch' as a branch prefix

### DIFF
--- a/packages/manager/scripts/pre-push.sh
+++ b/packages/manager/scripts/pre-push.sh
@@ -2,7 +2,7 @@
 
 # Confirm Branch includes M3 Ticket
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
-BRANCH_INCLUDES_TICKET=$(git rev-parse --abbrev-ref HEAD | egrep -i '(M3-[0-9]*)|feature|staging|develop|testing|master|release-.*|OBJ.*|LKE.*|OCA.*')
+BRANCH_INCLUDES_TICKET=$(git rev-parse --abbrev-ref HEAD | egrep -i '(M3-[0-9]*)|feature|patch|staging|develop|testing|master|release-.*|OBJ.*|LKE.*|OCA.*')
 RED='\033[0;31m'
 
 if [ $BRANCH_INCLUDES_TICKET ]


### PR DESCRIPTION
## Description

Accept "patch" as a valid prefix for branch names.

To test, create a branch and run the `pre-push.sh` script: 

```
$ sh packages/manager/scripts/pre-push.sh
```