### PR TITLE
M3-3467 Fix updating Disks bug

### DIFF
--- a/packages/manager/src/factories/disk.ts
+++ b/packages/manager/src/factories/disk.ts
@@ -1,0 +1,12 @@
+import * as Factory from 'factory.ts';
+import { Disk } from 'linode-js-sdk/lib/linodes/types';
+
+export const diskFactory = Factory.Sync.makeFactory<Disk>({
+  id: Factory.each(id => id),
+  label: Factory.each(id => `disk-${id}`),
+  status: 'running',
+  created: '2018-01-01',
+  updated: '2019-01-01',
+  filesystem: 'raw',
+  size: 1000
+});

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.tsx
@@ -309,12 +309,11 @@ const linodeContext = withLinodeDetailContext(({ linode }) => ({
   permissions: linode._permissions
 }));
 
-const mapStateToProps: MapState<StateProps, CombinedProps> = state => ({
-  diskError: pathOr(
-    undefined,
-    ['__resources', 'linodeDisks', 'error', 'read'],
-    state
-  )
+const mapStateToProps: MapState<StateProps, CombinedProps> = (
+  state,
+  ownProps
+) => ({
+  diskError: state.__resources.linodeDisks[ownProps.linodeId]?.error?.read
 });
 
 const connected = connect(mapStateToProps);

--- a/packages/manager/src/features/linodes/LinodesDetail/maybeRenderError.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/maybeRenderError.tsx
@@ -11,6 +11,7 @@ import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 interface OuterProps {
   configsError?: APIError[];
   typesError?: APIError[];
+  linodeId: number;
 }
 
 interface InnerProps {
@@ -19,7 +20,7 @@ interface InnerProps {
 
 const collectErrors: MapState<InnerProps, OuterProps> = (
   state,
-  { configsError, typesError }
+  { configsError, typesError, linodeId }
 ) => {
   const {
     linodes,
@@ -37,16 +38,16 @@ const collectErrors: MapState<InnerProps, OuterProps> = (
       types.error ||
       notifications.error ||
       path(['error', 'read'], linodeConfigs) ||
-      path(['error', 'read'], linodeDisks)
+      linodeDisks[linodeId]?.error?.read
   };
 };
 
 /*
   Collect possible errors from Redux, configs request, and disks requests.
   If any are defined, render the ErrorComponent. (early return)
-  
+
   IMPORTANT NOTE: The errors we're collecting here should only be the errors that
-  dictate when the Linode detail page should bomb. You'll notice that we're not 
+  dictate when the Linode detail page should bomb. You'll notice that we're not
   collecting volumes errors here, and it's because we don't want to crash the entire
   page if there was an issue loading the volumes.
  */

--- a/packages/manager/src/features/linodes/LinodesDetail/maybeRenderLoading.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/maybeRenderLoading.tsx
@@ -10,6 +10,7 @@ const isLoading = (state: { loading: boolean; lastUpdated: number }) =>
 interface OuterProps {
   configsLoading: boolean;
   disksLoading: boolean;
+  linodeId: number;
 }
 
 interface InnerProps {
@@ -28,7 +29,7 @@ const collectLoadingState: MapState<InnerProps, OuterProps> = (
     linodeConfigs,
     linodeDisks
   } = state.__resources;
-  const { configsLoading, disksLoading } = ownProps;
+  const { configsLoading, disksLoading, linodeId } = ownProps;
 
   return {
     loading:
@@ -39,7 +40,7 @@ const collectLoadingState: MapState<InnerProps, OuterProps> = (
       isLoading(volumes) ||
       isLoading(notifications) ||
       isLoading(linodeConfigs) ||
-      isLoading(linodeDisks)
+      isLoading(linodeDisks[linodeId] ?? mockLoading)
   };
 };
 
@@ -50,5 +51,10 @@ const collectLoadingState: MapState<InnerProps, OuterProps> = (
  */
 export default compose(
   connect(collectLoadingState),
-  branch(({ loading }) => loading, renderComponent(() => <CircleProgress />))
+  branch(
+    ({ loading }) => loading,
+    renderComponent(() => <CircleProgress />)
+  )
 );
+
+const mockLoading = { lastUpdated: 0, loading: true };

--- a/packages/manager/src/features/linodes/LinodesDetail/maybeRenderLoading.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/maybeRenderLoading.tsx
@@ -40,7 +40,7 @@ const collectLoadingState: MapState<InnerProps, OuterProps> = (
       isLoading(volumes) ||
       isLoading(notifications) ||
       isLoading(linodeConfigs) ||
-      isLoading(linodeDisks[linodeId] ?? mockLoading)
+      (linodeDisks[linodeId] && isLoading(linodeDisks[linodeId]))
   };
 };
 
@@ -56,5 +56,3 @@ export default compose(
     renderComponent(() => <CircleProgress />)
   )
 );
-
-const mockLoading = { lastUpdated: 0, loading: true };

--- a/packages/manager/src/store/linodes/disk/disk.reducer.test.ts
+++ b/packages/manager/src/store/linodes/disk/disk.reducer.test.ts
@@ -1,4 +1,3 @@
-// import { diskFactory } from 'src/factories/disk';
 import { diskFactory } from 'src/factories/disk';
 import { deleteLinodeActions } from '../linodes.actions';
 import {
@@ -55,89 +54,6 @@ describe('Disk reducer', () => {
     });
   });
 
-  describe('createLinodeDiskActions', () => {
-    it('loads the disk when the request is complete', () => {
-      const newState = reducer(
-        defaultState,
-        createLinodeDiskActions.done({
-          params: {
-            linodeId: mockDisk1.linode_id,
-            label: mockDisk1.label,
-            size: mockDisk1.size
-          },
-          result: mockDisk1
-        })
-      );
-      verifyDisk(newState, mockDisk1);
-    });
-  });
-
-  describe('updateLinodeDiskActions', () => {
-    it('updates the disk when the request is complete', () => {
-      const newState = reducer(
-        defaultState,
-        updateLinodeDiskActions.done({
-          params: {
-            linodeId: mockDisk1.linode_id,
-            diskId: mockDisk1.id,
-            label: 'test-disk'
-          },
-          result: mockDisk1
-        })
-      );
-      verifyDisk(newState, mockDisk1);
-    });
-  });
-
-  describe('deleteLinodeDiskActions', () => {
-    // Create state with disks.
-    let state = reducer(
-      defaultState,
-      createLinodeDiskActions.done({
-        params: {
-          linodeId: mockDisk1.linode_id
-        } as any,
-        result: mockDisk1
-      })
-    );
-    state = reducer(
-      state,
-      createLinodeDiskActions.done({
-        params: {
-          linodeId: mockDisk2.linode_id
-        } as any,
-        result: mockDisk2
-      })
-    );
-
-    it('sets error.delete to `undefined` when the request is started', () => {
-      const newState = reducer(
-        state,
-        deleteLinodeDiskActions.started({
-          linodeId: mockDisk1.linode_id,
-          diskId: mockDisk1.id
-        })
-      );
-      expect(newState[mockDisk1.linode_id].error?.delete).toBeUndefined();
-    });
-    it('removes the disk when the request is complete', () => {
-      const newState = reducer(
-        state,
-        deleteLinodeDiskActions.done({
-          params: {
-            linodeId: mockDisk1.linode_id,
-            diskId: mockDisk1.id
-          },
-          result: {}
-        })
-      );
-      expect(
-        newState[mockDisk1.linode_id].itemsById[mockDisk1.id]
-      ).toBeUndefined();
-      expect(newState[mockDisk1.linode_id].items).toHaveLength(1);
-    });
-  });
-
   describe('getAllLinodeDisksActions', () => {
     it('should set loading to `true` and error to `undefined` when the request is started', () => {
       const newState = reducer(
@@ -178,6 +94,85 @@ describe('Disk reducer', () => {
       );
     });
   });
+
+  describe('createLinodeDiskActions', () => {
+    it('loads the disk when the request is complete', () => {
+      const newState = reducer(
+        defaultState,
+        createLinodeDiskActions.done({
+          params: {
+            linodeId: mockDisk1.linode_id,
+            label: mockDisk1.label,
+            size: mockDisk1.size
+          },
+          result: mockDisk1
+        })
+      );
+      verifyDisk(newState, mockDisk1);
+    });
+  });
+
+  describe('updateLinodeDiskActions', () => {
+    it('updates the disk when the request is complete', () => {
+      const newState = reducer(
+        defaultState,
+        updateLinodeDiskActions.done({
+          params: {
+            linodeId: mockDisk1.linode_id,
+            diskId: mockDisk1.id,
+            label: mockDisk1.label
+          },
+          result: mockDisk1
+        })
+      );
+      verifyDisk(newState, mockDisk1);
+    });
+  });
+
+  describe('deleteLinodeDiskActions', () => {
+    const state: State = {
+      [mockDisk1.linode_id]: {
+        items: [String(mockDisk1.id)],
+        itemsById: { [mockDisk1.id]: mockDisk1 },
+        lastUpdated: 1,
+        loading: false
+      },
+      [mockDisk2.linode_id]: {
+        items: [String(mockDisk2.id)],
+        itemsById: { [mockDisk2.id]: mockDisk2 },
+        lastUpdated: 1,
+        loading: false
+      }
+    };
+
+    it('sets error.delete to `undefined` when the request is started', () => {
+      const newState = reducer(
+        state,
+        deleteLinodeDiskActions.started({
+          linodeId: mockDisk1.linode_id,
+          diskId: mockDisk1.id
+        })
+      );
+      expect(newState[mockDisk1.linode_id].error?.delete).toBeUndefined();
+    });
+    it('removes the disk when the request is complete', () => {
+      const newState = reducer(
+        state,
+        deleteLinodeDiskActions.done({
+          params: {
+            linodeId: mockDisk1.linode_id,
+            diskId: mockDisk1.id
+          },
+          result: {}
+        })
+      );
+      expect(
+        newState[mockDisk1.linode_id].itemsById[mockDisk1.id]
+      ).toBeUndefined();
+      expect(newState[mockDisk1.linode_id].items).toHaveLength(1);
+    });
+  });
+
   describe('deleteLinodeActions', () => {
     const state = reducer(
       defaultState,
@@ -188,7 +183,6 @@ describe('Disk reducer', () => {
         result: mockDisk1
       })
     );
-
     it('removes the linodeId from the state when the request is complete', () => {
       const newState = reducer(
         state,

--- a/packages/manager/src/store/linodes/disk/disk.reducer.test.ts
+++ b/packages/manager/src/store/linodes/disk/disk.reducer.test.ts
@@ -1,0 +1,209 @@
+// import { diskFactory } from 'src/factories/disk';
+import { diskFactory } from 'src/factories/disk';
+import { deleteLinodeActions } from '../linodes.actions';
+import {
+  createLinodeDiskActions,
+  deleteLinodeDiskActions,
+  getAllLinodeDisksActions,
+  getLinodeDiskActions,
+  updateLinodeDiskActions
+} from './disk.actions';
+import reducer, { State } from './disk.reducer';
+import { Entity } from './disk.types';
+
+describe('Disk reducer', () => {
+  const defaultState: State = {};
+  const mockDisk1 = {
+    ...diskFactory.build({
+      id: 2,
+      label: 'test-disk1',
+      size: 1000
+    }),
+    linode_id: 1
+  };
+  const mockDisk2 = {
+    ...diskFactory.build({
+      id: 3,
+      label: 'test-disk2',
+      size: 2000
+    }),
+    linode_id: 1
+  };
+
+  describe('getLinodeDiskActions', () => {
+    it('should set loading to `true` and error to `undefined` when starting the request', () => {
+      const newState = reducer(
+        defaultState,
+        getLinodeDiskActions.started({
+          linodeId: mockDisk1.linode_id,
+          diskId: mockDisk1.id
+        })
+      );
+      expect(newState).toHaveProperty(String(mockDisk1.linode_id));
+      expect(newState[mockDisk1.linode_id]).toHaveProperty('loading', true);
+      expect(newState[mockDisk1.linode_id]).toHaveProperty('error', undefined);
+    });
+    it('should load data when the request has been completed', () => {
+      const newState = reducer(
+        defaultState,
+        getLinodeDiskActions.done({
+          params: { linodeId: mockDisk1.linode_id, diskId: mockDisk1.id },
+          result: mockDisk1
+        })
+      );
+      verifyDisk(newState, mockDisk1);
+    });
+  });
+
+  describe('createLinodeDiskActions', () => {
+    it('loads the disk when the request is complete', () => {
+      const newState = reducer(
+        defaultState,
+        createLinodeDiskActions.done({
+          params: {
+            linodeId: mockDisk1.linode_id,
+            label: mockDisk1.label,
+            size: mockDisk1.size
+          },
+          result: mockDisk1
+        })
+      );
+      verifyDisk(newState, mockDisk1);
+    });
+  });
+
+  describe('updateLinodeDiskActions', () => {
+    it('updates the disk when the request is complete', () => {
+      const newState = reducer(
+        defaultState,
+        updateLinodeDiskActions.done({
+          params: {
+            linodeId: mockDisk1.linode_id,
+            diskId: mockDisk1.id,
+            label: 'test-disk'
+          },
+          result: mockDisk1
+        })
+      );
+      verifyDisk(newState, mockDisk1);
+    });
+  });
+
+  describe('deleteLinodeDiskActions', () => {
+    // Create state with disks.
+    let state = reducer(
+      defaultState,
+      createLinodeDiskActions.done({
+        params: {
+          linodeId: mockDisk1.linode_id
+        } as any,
+        result: mockDisk1
+      })
+    );
+    state = reducer(
+      state,
+      createLinodeDiskActions.done({
+        params: {
+          linodeId: mockDisk2.linode_id
+        } as any,
+        result: mockDisk2
+      })
+    );
+
+    it('sets error.delete to `undefined` when the request is started', () => {
+      const newState = reducer(
+        state,
+        deleteLinodeDiskActions.started({
+          linodeId: mockDisk1.linode_id,
+          diskId: mockDisk1.id
+        })
+      );
+      expect(newState[mockDisk1.linode_id].error?.delete).toBeUndefined();
+    });
+    it('removes the disk when the request is complete', () => {
+      const newState = reducer(
+        state,
+        deleteLinodeDiskActions.done({
+          params: {
+            linodeId: mockDisk1.linode_id,
+            diskId: mockDisk1.id
+          },
+          result: {}
+        })
+      );
+      expect(
+        newState[mockDisk1.linode_id].itemsById[mockDisk1.id]
+      ).toBeUndefined();
+      expect(newState[mockDisk1.linode_id].items).toHaveLength(1);
+    });
+  });
+
+  describe('getAllLinodeDisksActions', () => {
+    it('should set loading to `true` and error to `undefined` when the request is started', () => {
+      const newState = reducer(
+        defaultState,
+        getAllLinodeDisksActions.started({
+          linodeId: mockDisk1.linode_id
+        })
+      );
+      expect(newState).toHaveProperty(String(mockDisk1.linode_id));
+      expect(newState[mockDisk1.linode_id]).toHaveProperty('loading', true);
+      expect(newState[mockDisk1.linode_id]).toHaveProperty('error', undefined);
+    });
+    it('should load data when the request has been completed', () => {
+      const newState = reducer(
+        defaultState,
+        getAllLinodeDisksActions.done({
+          params: { linodeId: mockDisk1.linode_id },
+          result: [mockDisk1, mockDisk2]
+        })
+      );
+      verifyDisk(newState, mockDisk1);
+      verifyDisk(newState, mockDisk2);
+      expect(newState[mockDisk1.linode_id].items.length).toBe(2);
+    });
+    it('sets error.read when the request fails', () => {
+      const errorMessage = 'An error occurred.';
+      const newState = reducer(
+        defaultState,
+        getAllLinodeDisksActions.failed({
+          params: { linodeId: mockDisk1.linode_id },
+          error: [{ reason: errorMessage }]
+        })
+      );
+      expect(newState[mockDisk1.linode_id].error).toHaveProperty('read');
+      expect(newState[mockDisk1.linode_id].loading).toBe(false);
+      expect(newState[mockDisk1.linode_id].error?.read?.[0].reason).toBe(
+        errorMessage
+      );
+    });
+  });
+  describe('deleteLinodeActions', () => {
+    const state = reducer(
+      defaultState,
+      createLinodeDiskActions.done({
+        params: {
+          linodeId: mockDisk1.linode_id
+        } as any,
+        result: mockDisk1
+      })
+    );
+
+    it('removes the linodeId from the state when the request is complete', () => {
+      const newState = reducer(
+        state,
+        deleteLinodeActions.done({
+          params: { linodeId: mockDisk1.linode_id },
+          result: {}
+        })
+      );
+      expect(newState[mockDisk1.linode_id]).toBeUndefined();
+    });
+  });
+});
+
+const verifyDisk = (state: State, disk: Entity) => {
+  expect(state[disk.linode_id].loading).toBe(false);
+  expect(state[disk.linode_id].items.includes(String(disk.id))).toBe(true);
+  expect(state[disk.linode_id].itemsById[disk.id]).toEqual(disk);
+};

--- a/packages/manager/src/store/linodes/disk/disk.reducer.ts
+++ b/packages/manager/src/store/linodes/disk/disk.reducer.ts
@@ -94,16 +94,7 @@ const reducer: Reducer<State> = (state = defaultState, action) =>
     if (isType(action, deleteLinodeDiskActions.started)) {
       const { linodeId } = action.payload;
       draft = ensureInitializedNestedState(draft, linodeId);
-
-      draft[linodeId] = onError<
-        MappedEntityState<Entity, EntityError>,
-        EntityError
-      >(
-        {
-          delete: undefined
-        },
-        draft[linodeId]
-      );
+      draft[linodeId].error = { ...draft[linodeId].error, delete: undefined };
     }
 
     if (isType(action, deleteLinodeDiskActions.done)) {

--- a/packages/manager/src/store/linodes/disk/disk.reducer.ts
+++ b/packages/manager/src/store/linodes/disk/disk.reducer.ts
@@ -7,8 +7,7 @@ import {
   onDeleteSuccess,
   onError,
   onGetAllSuccess,
-  onStart,
-  removeMany
+  onStart
 } from 'src/store/store.helpers';
 import { EntityError, MappedEntityState } from 'src/store/types';
 import { isType } from 'typescript-fsa';
@@ -27,90 +26,42 @@ export type State = Record<number, MappedEntityState<Entity, EntityError>>;
 
 export const defaultState: State = {};
 
-const reducer: Reducer<State> = (state = defaultState, action) => {
-  return produce(state, draft => {
-    if (isType(action, deleteLinodeActions.done)) {
-      const {
-        params: { linodeId }
-      } = action.payload;
+const reducer: Reducer<State> = (state = defaultState, action) =>
+  produce(state, draft => {
+    // getLinodeDiskActions
+    // getAllLinodeDiskActions
+    if (
+      isType(action, getLinodeDiskActions.started) ||
+      isType(action, getAllLinodeDisksActions.started)
+    ) {
+      const { linodeId } = action.payload;
+      draft = ensureInitializedNestedState(draft, linodeId);
 
-      delete draft[linodeId];
-    }
-
-    if (isType(action, deleteLinode)) {
-      const { payload } = action;
-      const linodeId = action.payload;
-
-      const configIdsToRemove = Object.values(state[linodeId]?.itemsById ?? {})
-        .filter(({ linode_id }) => linode_id === payload)
-        .map(({ id }) => String(id));
-
-      // @todo: Should this actually just remove the key from state?
-      draft[linodeId] = removeMany(configIdsToRemove, state[linodeId]);
+      draft[linodeId] = onStart(draft[linodeId]);
     }
 
     if (isType(action, getLinodeDisksActions.done)) {
       const { result } = action.payload;
       const { linodeId } = action.payload.params;
-      draft[linodeId].loading = false;
-      draft[linodeId] = addMany(result, draft[linodeId]);
-    }
-
-    if (
-      isType(action, createLinodeDiskActions.done) ||
-      isType(action, getLinodeDiskActions.done) ||
-      isType(action, updateLinodeDiskActions.done)
-    ) {
-      const { result } = action.payload;
-      const { linodeId } = action.payload.params;
-
       draft = ensureInitializedNestedState(draft, linodeId);
 
       draft[linodeId].loading = false;
-      draft[linodeId] = onCreateOrUpdate(result, draft[linodeId]);
-    }
-
-    if (isType(action, deleteLinodeDiskActions.started)) {
-      const { linodeId } = action.payload;
-      draft[linodeId] = onError<
-        MappedEntityState<Entity, EntityError>,
-        EntityError
-      >(
-        {
-          delete: undefined
-        },
-        state[linodeId]
-      );
-    }
-
-    if (isType(action, deleteLinodeDiskActions.done)) {
-      const {
-        params: { diskId: DiskId, linodeId }
-      } = action.payload;
-      draft[linodeId] = onDeleteSuccess(DiskId, state[linodeId]);
-    }
-
-    /**
-     * reset error state when our request to disks has started and
-     * or a request to get one disk has started
-     */
-    if (
-      isType(action, getAllLinodeDisksActions.started) ||
-      isType(action, getLinodeDiskActions.started)
-    ) {
-      const { linodeId } = action.payload;
-      draft[linodeId] = onStart(state[linodeId]);
+      draft[linodeId] = addMany(result, draft[linodeId]);
     }
 
     if (isType(action, getAllLinodeDisksActions.done)) {
       const { result } = action.payload;
       const { linodeId } = action.payload.params;
-      draft[linodeId] = onGetAllSuccess(result, state[linodeId]);
+      draft = ensureInitializedNestedState(draft, linodeId);
+
+      draft[linodeId] = onGetAllSuccess(result, draft[linodeId]);
     }
 
     if (isType(action, getAllLinodeDisksActions.failed)) {
       const { error } = action.payload;
       const { linodeId } = action.payload.params;
+
+      draft = ensureInitializedNestedState(draft, linodeId);
 
       draft[linodeId] = onError<
         MappedEntityState<Entity, EntityError>,
@@ -119,10 +70,67 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
         {
           read: error
         },
-        state[linodeId]
+        draft[linodeId]
       );
     }
+
+    // createLinodeDiskActions
+    // getLinodeDiskActions
+    // updateLinodeDiskActions
+    if (
+      isType(action, createLinodeDiskActions.done) ||
+      isType(action, getLinodeDiskActions.done) ||
+      isType(action, updateLinodeDiskActions.done)
+    ) {
+      const { result } = action.payload;
+      const { linodeId } = action.payload.params;
+      draft = ensureInitializedNestedState(draft, linodeId);
+
+      draft[linodeId].loading = false;
+      draft[linodeId] = onCreateOrUpdate(result, draft[linodeId]);
+    }
+
+    // deleteLinodeDiskActions
+    if (isType(action, deleteLinodeDiskActions.started)) {
+      const { linodeId } = action.payload;
+      draft = ensureInitializedNestedState(draft, linodeId);
+
+      draft[linodeId] = onError<
+        MappedEntityState<Entity, EntityError>,
+        EntityError
+      >(
+        {
+          delete: undefined
+        },
+        draft[linodeId]
+      );
+    }
+
+    if (isType(action, deleteLinodeDiskActions.done)) {
+      const {
+        params: { diskId: DiskId, linodeId }
+      } = action.payload;
+      draft = ensureInitializedNestedState(draft, linodeId);
+      draft[linodeId] = onDeleteSuccess(DiskId, draft[linodeId]);
+    }
+
+    // deleteLinode (sync – used to respond to events)
+    // deleteLinodeActions (async – used when a delete Linode request is made)
+    //
+    // The reducer result is the same, but these need to be two code blocks
+    // because the linodeId is located in different places between the actions.
+    if (isType(action, deleteLinode)) {
+      const linodeId = action.payload;
+      delete draft[linodeId];
+    }
+
+    if (isType(action, deleteLinodeActions.done)) {
+      const {
+        params: { linodeId }
+      } = action.payload;
+
+      delete draft[linodeId];
+    }
   });
-};
 
 export default reducer;

--- a/packages/manager/src/store/linodes/disk/disk.selectors.ts
+++ b/packages/manager/src/store/linodes/disk/disk.selectors.ts
@@ -1,6 +1,10 @@
 import { State } from './disk.reducer';
 
-export const getLinodeDisksForLinode = (state: State, linodeId: number) =>
-  Object.values(state.itemsById).filter(
-    ({ linode_id }) => linodeId === linodeId
-  );
+export const getLinodeDisksForLinode = (state: State, linodeId: number) => {
+  // Safe access of `itemsById` is necessary here, even though TypeScript will
+  // not complain about omitting the "?". The reason is that `state[linodeId]`
+  // could still be `undefined`.
+  const itemsById = state[linodeId]?.itemsById ?? {};
+
+  return Object.values(itemsById);
+};

--- a/packages/manager/src/store/store.helpers.ts
+++ b/packages/manager/src/store/store.helpers.ts
@@ -158,3 +158,13 @@ export const updateInPlace = <E extends Entity>(
     }
   };
 };
+
+export const ensureInitializedNestedState = (
+  draft: Record<number, any>,
+  id: number
+) => {
+  if (!draft[id]) {
+    draft[id] = createDefaultState();
+  }
+  return draft;
+};

--- a/packages/manager/src/store/store.helpers.ts
+++ b/packages/manager/src/store/store.helpers.ts
@@ -159,12 +159,15 @@ export const updateInPlace = <E extends Entity>(
   };
 };
 
+// Given a nested state and an ID, ensures that MappedEntityState exists at the
+// provided key. If the nested state already exists, return the state untouched.
+// If it doesn't exist, initialize the state with `createDefaultState()`.
 export const ensureInitializedNestedState = (
-  draft: Record<number, any>,
+  state: Record<number, any>,
   id: number
 ) => {
-  if (!draft[id]) {
-    draft[id] = createDefaultState();
+  if (!state[id]) {
+    state[id] = createDefaultState();
   }
-  return draft;
+  return state;
 };


### PR DESCRIPTION
## Description

This fixes a bug in which editing disks for _one_ Linode in _one_ tab modifies the **display of disks** for a _different_ Linode in a _different_ tab.

The mechanism behind this faulty behavior is that we have ONE key for Linode Disks in the store, called `__resources.linodeDisks`. This state is populated when a user navigates to a particular Linode’s Detail page. By design, only disks belonging to _that particular Linode_ are loaded in this state.

However, we dispatch the `getAllLinodeDisks` action when we receive a Disk event, so if we get a `disk_update` event for LinodeA, the `linodeDisks` state gets populated with LinodeA’s disks, even if we’re currently viewing LinodeB.

To fix, I have changed the shape of `linodeDisks`. Instead of being an instance of MappedEntityState, we map Linode IDs to their disks:
```
{
  [linodeA’s ID]: <Disks for LinodeA>,
  [linodeB’s ID]: <Disks for LinodeB>,
}
```
This required reworking the reducer, which Immer.js made clearer.

Still TODO:

- [x] Write unit tests.
- [x] More comments
- [ ] Once this shape is agreed upon, this same work needs to be done for Configs.

## Notes for reviewers
As this is a pretty big change, please check everything related to disks:
- Linode creation/deletion/cloning/resizing/rescue/migrating
- Disk creation/editing/deletion/cloning
- Since configs are related, check those too.
- etc...

This reducer is pretty big since it also listens for Linode actions that affect disks. Some of the code got repetitive (e.g. the repeated calls to ensure the nested state). I tried several things that reduced repetition but increased complexity. I'm happy for suggestions here. 