### PR TITLE
have an import zone drawer when no domain exist

### DIFF
--- a/packages/manager/src/features/Domains/DomainsLanding.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.tsx
@@ -127,6 +127,7 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
   state: State = {
     importDrawerOpen: false,
     importDrawerSubmitting: false,
+    importDrawerErrors: undefined,
     remote_nameserver: '',
     createDrawerMode: 'create',
     createDrawerOpen: false,
@@ -294,7 +295,19 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
     }
 
     if (!domainsData || domainsData.length === 0) {
-      return <RenderEmpty onClick={this.openCreateDomainDrawer} />;
+      return (
+        <React.Fragment>
+          <RenderEmpty
+            onCreateDomain={this.openCreateDomainDrawer}
+            onImportZone={this.openImportZoneDrawer}
+          />
+          <DomainZoneImportDrawer
+            open={this.state.importDrawerOpen}
+            onClose={this.closeImportZoneDrawer}
+            onSuccess={this.handleSuccess}
+          />
+        </React.Fragment>
+      );
     }
 
     /**
@@ -504,7 +517,8 @@ const EmptyCopy = () => (
 );
 
 const RenderEmpty: React.StatelessComponent<{
-  onClick: (e: React.MouseEvent<HTMLElement>) => void;
+  onCreateDomain: (e: React.MouseEvent<HTMLElement>) => void;
+  onImportZone: () => void;
 }> = props => {
   return (
     <React.Fragment>
@@ -515,8 +529,12 @@ const RenderEmpty: React.StatelessComponent<{
         icon={DomainIcon}
         buttonProps={[
           {
-            onClick: props.onClick,
+            onClick: props.onCreateDomain,
             children: 'Add a Domain'
+          },
+          {
+            onClick: props.onImportZone,
+            children: 'Import a Zone'
           }
         ]}
       />

--- a/packages/manager/src/features/Domains/DomainsLanding.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.tsx
@@ -269,10 +269,8 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
     });
   };
 
-  openCreateDomainDrawer = (e: React.MouseEvent<HTMLElement>) => {
+  openCreateDomainDrawer = () => {
     this.props.openForCreating('Created from Domain Landing');
-
-    e.preventDefault();
   };
 
   render() {
@@ -517,7 +515,7 @@ const EmptyCopy = () => (
 );
 
 const RenderEmpty: React.StatelessComponent<{
-  onCreateDomain: (e: React.MouseEvent<HTMLElement>) => void;
+  onCreateDomain: () => void;
   onImportZone: () => void;
 }> = props => {
   return (


### PR DESCRIPTION
## Description

Idea is to have an import zone button on the landing page of domains by default

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

Here i did not see an existing e2e to update.
But I will create a task to have e2e on all placeholder actions i guess.