### PR TITLE
Managed network graph units

### DIFF
--- a/packages/manager/src/features/Dashboard/ManagedDashboardCard/ManagedChartPanel.tsx
+++ b/packages/manager/src/features/Dashboard/ManagedDashboardCard/ManagedChartPanel.tsx
@@ -109,7 +109,10 @@ const createTabs = (
   const netInMax = Math.max(...formattedNetIn);
   const netOutMax = Math.max(...formattedNetOut);
 
-  const unit = generateNetworkUnits(Math.max(netInMax, netOutMax));
+  // Find the max and convert to bytes, which is what generateNetworkUnits
+  // expects.
+  const maxNetworkInBytes = Math.max(netInMax, netOutMax) / 8;
+  const unit = generateNetworkUnits(maxNetworkInBytes);
 
   const convertNetworkData = (value: number) => {
     return convertNetworkToUnit(value, unit as any);

--- a/packages/manager/src/features/Longview/shared/utilities.ts
+++ b/packages/manager/src/features/Longview/shared/utilities.ts
@@ -307,11 +307,13 @@ export type NetworkUnit = 'b' | 'Kibit' | 'Mibit';
  * converts bytes to either Kb (Kilobits) or Mb (Megabits)
  * depending on if the Kilobit conversion exceeds 1000.
  *
- * @param networkUsed inbound and outbound traffic in bytes
+ * @param networkUsedInBytes inbound and outbound traffic in bytes
  */
-export const generateNetworkUnits = (networkUsed: number): NetworkUnit => {
+export const generateNetworkUnits = (
+  networkUsedInBytes: number
+): NetworkUnit => {
   /** Thanks to http://www.matisse.net/bitcalc/ */
-  const networkUsedToKilobits = (networkUsed * 8) / 1024;
+  const networkUsedToKilobits = (networkUsedInBytes * 8) / 1024;
   if (networkUsedToKilobits <= 1) {
     return 'b';
   } else if (networkUsedToKilobits <= 1000) {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph.tsx
@@ -109,23 +109,25 @@ export const NetworkGraph: React.FC<CombinedProps> = props => {
     )
   );
 
-  const v4Unit = generateNetworkUnits(
+  // Convert to bytes, which is what generateNetworkUnits expects.
+  const maxV4InBytes =
     Math.max(
       v4Metrics.publicIn.max,
       v4Metrics.publicOut.max,
       v4Metrics.privateIn.max,
       v4Metrics.privateOut.max
-    )
-  );
+    ) / 8;
+  const v4Unit = generateNetworkUnits(maxV4InBytes);
 
-  const v6Unit = generateNetworkUnits(
+  // Convert to bytes, which is what generateNetworkUnits expects.
+  const maxV6InBytes =
     Math.max(
       v6Metrics.publicIn.max,
       v6Metrics.publicOut.max,
       v6Metrics.privateIn.max,
       v6Metrics.privateOut.max
-    )
-  );
+    ) / 8;
+  const v6Unit = generateNetworkUnits(maxV6InBytes);
 
   const commonGraphProps = {
     timezone: props.timezone,


### PR DESCRIPTION
## Description

This PR does three things:

1) Use the new formatData and formatTooltip patterns on the Managed Network Graph. So instead of always showing `bit/s`, we generate the units dynamically. We had previously done this work for Linode graphs but not Managed. Still to do: NodeBalancers.
2) Fix bug where dynamic units were being double converted, so sometimes the scale of Linode graphs was incorrect. 
3) Use the native legend on Managed Graph.

## Notes to Reviewers
To test, run up various amounts of traffic on Linodes and look at Linode graphs and Managed graphs.
