### PR TITLE
[for release] Update LKE types

### DIFF
--- a/packages/linode-js-sdk/src/kubernetes/types.ts
+++ b/packages/linode-js-sdk/src/kubernetes/types.ts
@@ -10,12 +10,13 @@ export interface KubernetesCluster {
 export interface KubeNodePoolResponse {
   count: number;
   id: number;
-  linodes: PoolNodeResponse[];
+  nodes: PoolNodeResponse[];
   type: string;
 }
 
 export interface PoolNodeResponse {
-  id: number;
+  id: string;
+  instance_id: number | null;
   status: string;
 }
 

--- a/packages/manager/src/__data__/nodePools.ts
+++ b/packages/manager/src/__data__/nodePools.ts
@@ -5,10 +5,11 @@ export const pool1: ExtendedNodePool = {
   id: 1,
   count: 1,
   type: 'g5-standard-1',
-  linodes: [
+  nodes: [
     {
       status: 'ready',
-      id: 1
+      id: 'id-1',
+      instance_id: 1
     }
   ],
   clusterID: 10
@@ -18,14 +19,16 @@ export const pool2: ExtendedNodePool = {
   id: 2,
   count: 5,
   type: 'g5-standard-2',
-  linodes: [
+  nodes: [
     {
       status: 'ready',
-      id: 1
+      id: 'id-1',
+      instance_id: 1
     },
     {
       status: 'ready',
-      id: 2
+      id: 'id-2',
+      instance_id: 2
     }
   ],
   clusterID: 10
@@ -35,10 +38,11 @@ export const pool3: ExtendedNodePool = {
   id: 3,
   count: 1,
   type: 'g5-standard-1',
-  linodes: [
+  nodes: [
     {
       status: 'ready',
-      id: 1
+      id: 'id-1',
+      instance_id: 1
     }
   ],
   clusterID: 10

--- a/packages/manager/src/factories/kubernetesCluster.ts
+++ b/packages/manager/src/factories/kubernetesCluster.ts
@@ -20,7 +20,8 @@ import {
  */
 
 export const kubeLinodeFactory = Factory.Sync.makeFactory<PoolNodeResponse>({
-  id: Factory.each(id => id),
+  id: Factory.each(id => `id-${id}`),
+  instance_id: Factory.each(id => id),
   status: 'ready'
 });
 
@@ -33,7 +34,7 @@ export const _nodePoolFactory = Factory.Sync.makeFactory<PoolNodeWithPrice>({
 
 export const nodePoolFactory = _nodePoolFactory.withDerivation1(
   ['count'],
-  'linodes',
+  'nodes',
   (count: number) => {
     const linodes = [];
     let i = 0;

--- a/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolRow.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolRow.tsx
@@ -112,17 +112,14 @@ const tooltipText = (
   </Typography>
 );
 
-export const getStatusString = (
-  count: number,
-  linodes?: PoolNodeResponse[]
-) => {
+export const getStatusString = (count: number, nodes?: PoolNodeResponse[]) => {
   if (!count) {
     return '';
   }
-  if (!linodes || linodes.length === 0) {
+  if (!nodes || nodes.length === 0) {
     return <Typography>{`${count} (0 up, ${count} down)`}</Typography>;
   }
-  const status = getNodeStatus(linodes);
+  const status = getNodeStatus(nodes);
 
   if (status.ready + status.not_ready !== count) {
     // The API hasn't registered/created all of the nodes
@@ -201,7 +198,7 @@ export const NodePoolRow: React.FunctionComponent<CombinedProps> = props => {
             }
           />
         ) : (
-          getStatusString(pool.count, pool.linodes)
+          getStatusString(pool.count, pool.nodes)
         )}
       </TableCell>
       <TableCell parentColumn="Pricing" className={classes.priceTableCell}>

--- a/packages/manager/src/features/Kubernetes/types.ts
+++ b/packages/manager/src/features/Kubernetes/types.ts
@@ -16,7 +16,7 @@ export interface ExtendedPoolNode {
   count: number;
   type: string;
   clusterID?: number;
-  linodes?: PoolNodeResponse[];
+  nodes?: PoolNodeResponse[];
 }
 export interface ExtendedCluster extends KubernetesCluster {
   node_pools: PoolNodeWithPrice[];


### PR DESCRIPTION
## Description

**Do not release until API changes are in production.**

- The NodePools key "linodes" has been renamed to "nodes".
- NodePools now has an `instance_id` which can be a number or null.
- The NodePools key "id" is now a string instead of a number.

The renaming of "linodes" to "nodes" was causing a bug where the node status display was incorrect.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')
- Non breaking change ('update', 'change')

## Note to Reviewers

Currently you must these changes in dev.
