### PR TITLE
Fix default image and change default to Debian 10

### DIFF
--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -117,7 +117,7 @@ const defaultState: State = {
   backupsEnabled: false,
   label: '',
   password: '',
-  selectedImageID: 'linode/debian9',
+  selectedImageID: undefined,
   selectedBackupID: undefined,
   selectedDiskSize: undefined,
   selectedLinodeID: undefined,

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -72,6 +72,8 @@ import { sendCreateLinodeEvent } from 'src/utilities/ga';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import { getRegionIDFromLinodeID } from './utilities';
 
+const DEFAULT_IMAGE = 'linode/debian10';
+
 interface State {
   selectedImageID?: string;
   selectedRegionID?: string;
@@ -153,7 +155,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
     // These can be passed in as query params
     selectedTypeID: this.params.typeID,
     selectedRegionID: this.params.regionID,
-    selectedImageID: this.params.imageID
+    selectedImageID: this.params.imageID ?? DEFAULT_IMAGE
   };
 
   componentDidUpdate(prevProps: CombinedProps) {


### PR DESCRIPTION
## Description

This PR does two things:

1) Fixes a regression introduced [here](https://github.com/linode/manager/pull/6046/files#diff-d9337d394dbeec6c368da20a7e38a161R156), which meant that the default image wasn’t working. To fix, I used nullish coalescing to give an optional value to selectedImageID.
2) Changes the default image from Debian 9 to Debian 10.
