### PR TITLE
M3-3930 Fix: Regression with Notistack

### DIFF
--- a/packages/manager/src/components/SnackBar/CloseSnackbar.tsx
+++ b/packages/manager/src/components/SnackBar/CloseSnackbar.tsx
@@ -1,5 +1,4 @@
 import Close from '@material-ui/icons/Close';
-import { useSnackbar } from 'notistack';
 import * as React from 'react';
 import {
   createStyles,
@@ -12,7 +11,7 @@ import IconButton from 'src/components/IconButton';
 type ClassNames = 'icon';
 
 interface Props {
-  key: string;
+  onClick: () => void;
   text: string;
 }
 
@@ -27,15 +26,10 @@ const styles = (theme: Theme) =>
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 const CloseSnackbar: React.FC<CombinedProps> = props => {
-  const { classes, text } = props;
-  const { closeSnackbar } = useSnackbar();
-
-  const handleClose = () => {
-    closeSnackbar(props.key);
-  };
+  const { classes, text, onClick } = props;
 
   return (
-    <IconButton onClick={handleClose} title={text} className={classes.icon}>
+    <IconButton onClick={onClick} title={text} className={classes.icon}>
       <Close />
     </IconButton>
   );

--- a/packages/manager/src/components/SnackBar/SnackBar.tsx
+++ b/packages/manager/src/components/SnackBar/SnackBar.tsx
@@ -6,7 +6,6 @@ import {
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
-import { v4 } from 'uuid';
 import CloseSnackbar from './CloseSnackbar';
 
 type ClassNames = 'root' | 'info' | 'success' | 'error' | 'warning';
@@ -34,27 +33,36 @@ const styles = (theme: Theme) =>
 
 type CombinedProps = SnackbarProviderProps & WithStyles<ClassNames>;
 
-class SnackBar extends React.Component<CombinedProps> {
-  render() {
-    const { children, classes, ...rest } = this.props;
+const SnackBar: React.FC<CombinedProps> = props => {
+  const notistackRef: React.Ref<any> = React.createRef();
+  const onClickDismiss = (key: string | number | undefined) => () => {
+    notistackRef.current.closeSnackbar(key);
+  };
 
-    return (
-      <SnackbarProvider
-        {...rest}
-        classes={{
-          root: classes.root,
-          variantSuccess: classes.success,
-          variantError: classes.error,
-          variantWarning: classes.warning,
-          variantInfo: classes.info
-        }}
-        action={<CloseSnackbar key={v4()} text="Dismiss Notification" />}
-      >
-        {children}
-      </SnackbarProvider>
-    );
-  }
-}
+  const { children, classes, ...rest } = props;
+
+  return (
+    <SnackbarProvider
+      ref={notistackRef}
+      {...rest}
+      classes={{
+        root: classes.root,
+        variantSuccess: classes.success,
+        variantError: classes.error,
+        variantWarning: classes.warning,
+        variantInfo: classes.info
+      }}
+      action={key => (
+        <CloseSnackbar
+          onClick={onClickDismiss(key)}
+          text="Dismiss Notification"
+        />
+      )}
+    >
+      {children}
+    </SnackbarProvider>
+  );
+};
 
 const styled = withStyles(styles);
 

--- a/packages/manager/src/components/SnackBar/SnackBar.tsx
+++ b/packages/manager/src/components/SnackBar/SnackBar.tsx
@@ -1,4 +1,8 @@
-import { SnackbarProvider, SnackbarProviderProps } from 'notistack';
+import {
+  SnackbarProvider,
+  SnackbarProviderProps,
+  WithSnackbarProps
+} from 'notistack';
 import * as React from 'react';
 import {
   createStyles,
@@ -34,9 +38,13 @@ const styles = (theme: Theme) =>
 type CombinedProps = SnackbarProviderProps & WithStyles<ClassNames>;
 
 const SnackBar: React.FC<CombinedProps> = props => {
-  const notistackRef: React.Ref<any> = React.createRef();
+  /**
+   * This pattern is taken from the Notistack docs:
+   * https://iamhosseindhv.com/notistack/demos#action-for-all-snackbars
+   */
+  const notistackRef: React.Ref<WithSnackbarProps> = React.createRef();
   const onClickDismiss = (key: string | number | undefined) => () => {
-    notistackRef.current.closeSnackbar(key);
+    notistackRef?.current?.closeSnackbar(key);
   };
 
   const { children, classes, ...rest } = props;


### PR DESCRIPTION
We recently upgraded to Notistack 0.9.7, and our logic update was incorrect.
This introduced a regression where clicking on the X on a toast message
dismissed all notices currently on the screen.

To fix this, I used patterns from the official docs
(https://iamhosseindhv.com/notistack/demos#action-for-all-snackbars).
This involved changing our Snackbar abstraction to a function component
and passing an onClick handler down to CloseSnackbar (rather than the key prop
that was previously used).

It may be possible to use the useSnackbar hook with this new version,
but I felt safer using officially recommended methods.
