### PR TITLE
[hotfix] OBJ support in Frankfurt

### DIFF
--- a/packages/linode-js-sdk/src/object-storage/types.ts
+++ b/packages/linode-js-sdk/src/object-storage/types.ts
@@ -49,7 +49,7 @@ export interface ObjectStorageObjectURLOptions {
 }
 
 // Enum containing IDs for each Cluster
-export type ObjectStorageClusterID = 'us-east-1' | 'us-east';
+export type ObjectStorageClusterID = 'us-east-1' | 'us-east' | 'eu-central-1';
 
 export interface ObjectStorageCluster {
   region: string;

--- a/packages/linode-js-sdk/src/object-storage/types.ts
+++ b/packages/linode-js-sdk/src/object-storage/types.ts
@@ -49,7 +49,7 @@ export interface ObjectStorageObjectURLOptions {
 }
 
 // Enum containing IDs for each Cluster
-export type ObjectStorageClusterID = 'us-east-1' | 'us-east' | 'eu-central-1';
+export type ObjectStorageClusterID = 'us-east-1' | 'eu-central-1';
 
 export interface ObjectStorageCluster {
   region: string;

--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -126,7 +126,8 @@ export const dcDisplayNames = {
   'ca-central': 'Toronto, ON',
   'ca-east': 'Toronto, ON', // @todo Fallback for old Toronto ID; remove once DB has been updated.
   'ap-west': 'Mumbai, IN',
-  'ap-southeast': 'Sydney, AU'
+  'ap-southeast': 'Sydney, AU',
+  philadelphia: 'Philadelphia, PA' // internal use only
 };
 
 // @todo no longer in use; remove if current design is approved.
@@ -176,13 +177,15 @@ export const dcDisplayCountry = {
   'ap-southeast': 'AU'
 };
 
+// Map OBJ Cluster IDs to their display country.
 export const objectStorageClusterDisplay: Record<
   ObjectStorageClusterID | 'philadelphia',
   string
 > = {
   'us-east-1': 'Newark, NJ',
   'us-east': 'Newark, NJ',
-  philadelphia: 'Philadelphia, PA'
+  philadelphia: 'Philadelphia, PA',
+  'eu-central-1': 'Frankfurt, DE'
 };
 
 export type ContinentKey = 'NA' | 'EU' | 'AS';

--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -126,8 +126,7 @@ export const dcDisplayNames = {
   'ca-central': 'Toronto, ON',
   'ca-east': 'Toronto, ON', // @todo Fallback for old Toronto ID; remove once DB has been updated.
   'ap-west': 'Mumbai, IN',
-  'ap-southeast': 'Sydney, AU',
-  philadelphia: 'Philadelphia, PA' // internal use only
+  'ap-southeast': 'Sydney, AU'
 };
 
 // @todo no longer in use; remove if current design is approved.
@@ -179,12 +178,11 @@ export const dcDisplayCountry = {
 
 // Map OBJ Cluster IDs to their display country.
 export const objectStorageClusterDisplay: Record<
-  ObjectStorageClusterID | 'philadelphia',
+  ObjectStorageClusterID,
   string
 > = {
   'us-east-1': 'Newark, NJ',
   'us-east': 'Newark, NJ',
-  philadelphia: 'Philadelphia, PA',
   'eu-central-1': 'Frankfurt, DE'
 };
 

--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -182,7 +182,6 @@ export const objectStorageClusterDisplay: Record<
   string
 > = {
   'us-east-1': 'Newark, NJ',
-  'us-east': 'Newark, NJ',
   'eu-central-1': 'Frankfurt, DE'
 };
 

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.test.tsx
@@ -16,7 +16,7 @@ describe('BucketTableRow', () => {
       label="test-bucket-001"
       created="2019-02-24 18:46:15.516813"
       hostname="test-bucket-001.alpha.linodeobjects.com"
-      cluster="us-east"
+      cluster="us-east-1"
       onRemove={mockOnRemove}
     />
   );

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.tsx
@@ -41,9 +41,7 @@ interface BucketTableRowProps extends ObjectStorageBucket {
 
 type CombinedProps = BucketTableRowProps & WithStyles<ClassNames>;
 
-export const BucketTableRow: React.StatelessComponent<
-  CombinedProps
-> = props => {
+export const BucketTableRow: React.StatelessComponent<CombinedProps> = props => {
   const { classes, label, cluster, hostname, created, onRemove } = props;
 
   return (
@@ -79,7 +77,7 @@ export const BucketTableRow: React.StatelessComponent<
       </TableCell>
       <TableCell parentColumn="Region">
         <Typography variant="body2" data-qa-region>
-          {formatObjectStorageCluster(cluster)}
+          {formatObjectStorageCluster(cluster) || cluster}
         </Typography>
       </TableCell>
       <TableCell parentColumn="Created">

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/ClusterSelect.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/ClusterSelect.tsx
@@ -4,7 +4,7 @@ import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import clustersContainer, {
   StateProps
 } from 'src/containers/clusters.container';
-import { formatObjectStorageCluster } from 'src/utilities/formatRegion';
+import { formatRegion } from 'src/utilities/formatRegion';
 
 interface Props {
   selectedCluster: string;
@@ -28,7 +28,7 @@ export const ClusterSelect: React.StatelessComponent<CombinedProps> = props => {
 
   const options: Item<string>[] = clustersData.map(eachCluster => ({
     value: eachCluster.id,
-    label: formatObjectStorageCluster(eachCluster.region)
+    label: formatRegion(eachCluster.region)
   }));
 
   React.useEffect(() => {

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/ClusterSelect.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/ClusterSelect.tsx
@@ -28,7 +28,7 @@ export const ClusterSelect: React.StatelessComponent<CombinedProps> = props => {
 
   const options: Item<string>[] = clustersData.map(eachCluster => ({
     value: eachCluster.id,
-    label: formatRegion(eachCluster.region)
+    label: formatRegion(eachCluster.region) || eachCluster.region
   }));
 
   React.useEffect(() => {


### PR DESCRIPTION
# Description

Add OBJ support for Frankfurt DC.

I also changed the Cluster Select to use `formatRegion()` instead of `formatObjectStorageCluster()`, since these display names are based on the region, not cluster (there was initially some back-and-forth with this).

I also removed the display name mapping for PHL and defaulted to the actual cluster ID and region slug for this case (this can be seen in Dev).

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers
Here is an `/object-storage/clusters` payload you can use to test (Charles, hardcoded, whatever you like):

```json
{ 
  "data":[ 
    { 
      "id":"us-east-1",
      "region":"us-east",
      "status":"available",
      "domain":"us-east-1.linodeobjects.com",
      "static_site_domain":"website-us-east-1.linodeobjects.com"
    },
    { 
      "id":"eu-central-1",
      "region":"eu-central",
      "status":"available",
      "domain":"eu-central-1.linodeobjects.com",
      "static_site_domain":"website-eu-central-1.linodeobjects.com"
    }
  ],
  "page":1,
  "pages":1,
  "results":2
}
```

(@Dorthu this payload look OK to you?)

- Also, please check the Bucket Table by modifying the response to `/object-storage/buckets` (change the `cluster` to `eu-central-1`). 
- You won't be able to create buckets in Frankfurt yet, but please attempt to and check the POST payload looks correct.



