### PR TITLE
M3-3810 LKE: Add messaging for lke_node_create error event

### DIFF
--- a/packages/linode-js-sdk/src/account/types.ts
+++ b/packages/linode-js-sdk/src/account/types.ts
@@ -211,6 +211,7 @@ export type EventAction =
   | 'linode_config_create'
   | 'linode_config_update'
   | 'linode_config_delete'
+  | 'lke_node_create'
   | 'longviewclient_create'
   | 'longviewclient_delete'
   | 'longviewclient_update'

--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -404,6 +404,14 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
         'A config'
       )} has been deleted on Linode ${e.entity!.label}.`
   },
+  lke_node_create: {
+    // This event is a special case; a notification means the node creation failed.
+    // The entity is the node pool, but entity.label contains the cluster's label.
+    notification: e =>
+      `Failed to create a node on Kubernetes Cluster${
+        e.entity?.label ? ` ${e.entity.label}` : ''
+      }.`
+  },
   longviewclient_create: {
     notification: e => `Longview Client ${e.entity!.label} has been created.`
   },

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -99,13 +99,20 @@ export class CreateCluster extends React.Component<CombinedProps, State> {
   componentDidMount() {
     getAllVersions()
       .then(response => {
+        /**
+         * 1. Convert versions to Items
+         * 2. Sort descending (so newest version is at top)
+         * 3. Pre-select the newest version
+         */
+        const versionOptions = response.data
+          .map(eachVersion => ({
+            value: eachVersion.id,
+            label: eachVersion.id
+          }))
+          .sort(sortByLabelDescending);
         this.setState({
-          versionOptions: response.data
-            .map(eachVersion => ({
-              value: eachVersion.id,
-              label: eachVersion.id
-            }))
-            .sort(sortByLabelDescending)
+          versionOptions,
+          version: versionOptions[0]
         });
       })
       .catch(error => {


### PR DESCRIPTION
## Description

To test:
- Use dev services
- Set your reputation to 0 in Admin
- Create a cluster
- Observe: you should see nicely formatted events for this event type, one for each node you specified.

@jnschaeffer mentioned a CTA to open a support ticket, I'm working on that as an add-on, but currently the necessary API filters aren't enabled.

- Added the event action type to EventAction
- Pre-filled the k8s version in the Create flow, I should have done this to start with and it's been bugging me.
