### PR TITLE
M3-3247 Add: Predefined firewall rules

### DIFF
--- a/packages/linode-js-sdk/src/firewalls/types.ts
+++ b/packages/linode-js-sdk/src/firewalls/types.ts
@@ -21,8 +21,7 @@ export interface FirewallRules {
 
 export interface FirewallRuleType {
   protocol: FirewallRuleProtocol;
-  start_port: number;
-  end_port?: null | number;
+  ports: string;
   addresses?: null | {
     ipv4?: null | string[];
     ipv6?: null | string[];

--- a/packages/manager/src/__data__/firewalls.ts
+++ b/packages/manager/src/__data__/firewalls.ts
@@ -12,13 +12,13 @@ export const firewall: Firewall = {
     inbound: [
       {
         protocol: 'ALL',
-        start_port: 443
+        ports: '443'
       }
     ],
     outbound: [
       {
         protocol: 'UDP',
-        start_port: 22,
+        ports: '22',
         addresses: {
           ipv4: ['12.12.12.12'],
           ipv6: ['192.168.12.12']
@@ -40,11 +40,11 @@ export const firewall2: Firewall = {
     outbound: [
       {
         protocol: 'ALL',
-        start_port: 443
+        ports: '443'
       },
       {
         protocol: 'ALL',
-        start_port: 80
+        ports: '80'
       }
     ]
   }

--- a/packages/manager/src/features/Firewalls/shared.ts
+++ b/packages/manager/src/features/Firewalls/shared.ts
@@ -5,96 +5,126 @@ export interface FirewallOption {
 
 export const predefinedFirewalls: FirewallOption[] = [
   {
-    label: 'SSH (TCP 22)',
+    label: 'SSH (TCP 22 - All IPv4, All IPv6)',
     value: {
       inbound: [
         {
           ports: '22',
           protocol: 'TCP',
-          addresses: {}
+          addresses: {
+            ipv4: '0.0.0.0/0',
+            ipv6: '::0/0'
+          }
         }
       ],
       outbound: [
         {
           ports: '22',
           protocol: 'TCP',
-          addresses: {}
+          addresses: {
+            ipv4: '0.0.0.0/0',
+            ipv6: '::0/0'
+          }
         }
       ]
     }
   },
   {
-    label: 'HTTP (TCP 80)',
+    label: 'HTTP (TCP 80 - All IPv4, All IPv6)',
     value: {
       inbound: [
         {
           ports: '80',
           protocol: 'TCP',
-          addresses: {}
+          addresses: {
+            ipv4: '0.0.0.0/0',
+            ipv6: '::0/0'
+          }
         }
       ],
       outbound: [
         {
           ports: '80',
           protocol: 'TCP',
-          addresses: {}
+          addresses: {
+            ipv4: '0.0.0.0/0',
+            ipv6: '::0/0'
+          }
         }
       ]
     }
   },
   {
-    label: 'HTTPS (TCP 443)',
+    label: 'HTTPS (TCP 443 - All IPv4, All IPv6)',
     value: {
       inbound: [
         {
           ports: '443',
           protocol: 'TCP',
-          addresses: {}
+          addresses: {
+            ipv4: '0.0.0.0/0',
+            ipv6: '::0/0'
+          }
         }
       ],
       outbound: [
         {
           ports: '443',
           protocol: 'TCP',
-          addresses: {}
+          addresses: {
+            ipv4: '0.0.0.0/0',
+            ipv6: '::0/0'
+          }
         }
       ]
     }
   },
   {
-    label: 'MySQL (TCP 3306)',
+    label: 'MySQL (TCP 3306 - All IPv4, All IPv6)',
     value: {
       inbound: [
         {
           ports: '3306',
           protocol: 'TCP',
-          addresses: {}
+          addresses: {
+            ipv4: '0.0.0.0/0',
+            ipv6: '::0/0'
+          }
         }
       ],
       outbound: [
         {
           ports: '3306',
           protocol: 'TCP',
-          addresses: {}
+          addresses: {
+            ipv4: '0.0.0.0/0',
+            ipv6: '::0/0'
+          }
         }
       ]
     }
   },
   {
-    label: 'DNS (TCP 53)',
+    label: 'DNS (TCP 53 - All IPv4, All IPv6)',
     value: {
       inbound: [
         {
           ports: '53',
           protocol: 'TCP',
-          addresses: {}
+          addresses: {
+            ipv4: '0.0.0.0/0',
+            ipv6: '::0/0'
+          }
         }
       ],
       outbound: [
         {
           ports: '53',
           protocol: 'TCP',
-          addresses: {}
+          addresses: {
+            ipv4: '0.0.0.0/0',
+            ipv6: '::0/0'
+          }
         }
       ]
     }

--- a/packages/manager/src/features/Firewalls/shared.ts
+++ b/packages/manager/src/features/Firewalls/shared.ts
@@ -1,0 +1,102 @@
+export interface FirewallOption {
+  label: string;
+  value: any;
+}
+
+export const predefinedFirewalls: FirewallOption[] = [
+  {
+    label: 'SSH (TCP 22)',
+    value: {
+      inbound: [
+        {
+          ports: '22',
+          protocol: 'TCP',
+          addresses: {}
+        }
+      ],
+      outbound: [
+        {
+          ports: '22',
+          protocol: 'TCP',
+          addresses: {}
+        }
+      ]
+    }
+  },
+  {
+    label: 'HTTP (TCP 80)',
+    value: {
+      inbound: [
+        {
+          ports: '80',
+          protocol: 'TCP',
+          addresses: {}
+        }
+      ],
+      outbound: [
+        {
+          ports: '80',
+          protocol: 'TCP',
+          addresses: {}
+        }
+      ]
+    }
+  },
+  {
+    label: 'HTTPS (TCP 443)',
+    value: {
+      inbound: [
+        {
+          ports: '443',
+          protocol: 'TCP',
+          addresses: {}
+        }
+      ],
+      outbound: [
+        {
+          ports: '443',
+          protocol: 'TCP',
+          addresses: {}
+        }
+      ]
+    }
+  },
+  {
+    label: 'MySQL (TCP 3306)',
+    value: {
+      inbound: [
+        {
+          ports: '3306',
+          protocol: 'TCP',
+          addresses: {}
+        }
+      ],
+      outbound: [
+        {
+          ports: '3306',
+          protocol: 'TCP',
+          addresses: {}
+        }
+      ]
+    }
+  },
+  {
+    label: 'DNS (TCP 53)',
+    value: {
+      inbound: [
+        {
+          ports: '53',
+          protocol: 'TCP',
+          addresses: {}
+        }
+      ],
+      outbound: [
+        {
+          ports: '53',
+          protocol: 'TCP',
+          addresses: {}
+        }
+      ]
+    }
+  }
+];

--- a/packages/manager/src/features/Firewalls/shared.ts
+++ b/packages/manager/src/features/Firewalls/shared.ts
@@ -1,6 +1,8 @@
+import { FirewallRules } from 'linode-js-sdk/lib/firewalls/types';
+
 export interface FirewallOption {
   label: string;
-  value: any;
+  value: FirewallRules;
 }
 
 export const predefinedFirewalls: FirewallOption[] = [
@@ -12,8 +14,8 @@ export const predefinedFirewalls: FirewallOption[] = [
           ports: '22',
           protocol: 'TCP',
           addresses: {
-            ipv4: '0.0.0.0/0',
-            ipv6: '::0/0'
+            ipv4: ['0.0.0.0/0'],
+            ipv6: ['::0/0']
           }
         }
       ],
@@ -22,8 +24,8 @@ export const predefinedFirewalls: FirewallOption[] = [
           ports: '22',
           protocol: 'TCP',
           addresses: {
-            ipv4: '0.0.0.0/0',
-            ipv6: '::0/0'
+            ipv4: ['0.0.0.0/0'],
+            ipv6: ['::0/0']
           }
         }
       ]
@@ -37,8 +39,8 @@ export const predefinedFirewalls: FirewallOption[] = [
           ports: '80',
           protocol: 'TCP',
           addresses: {
-            ipv4: '0.0.0.0/0',
-            ipv6: '::0/0'
+            ipv4: ['0.0.0.0/0'],
+            ipv6: ['::0/0']
           }
         }
       ],
@@ -47,8 +49,8 @@ export const predefinedFirewalls: FirewallOption[] = [
           ports: '80',
           protocol: 'TCP',
           addresses: {
-            ipv4: '0.0.0.0/0',
-            ipv6: '::0/0'
+            ipv4: ['0.0.0.0/0'],
+            ipv6: ['::0/0']
           }
         }
       ]
@@ -62,8 +64,8 @@ export const predefinedFirewalls: FirewallOption[] = [
           ports: '443',
           protocol: 'TCP',
           addresses: {
-            ipv4: '0.0.0.0/0',
-            ipv6: '::0/0'
+            ipv4: ['0.0.0.0/0'],
+            ipv6: ['::0/0']
           }
         }
       ],
@@ -72,8 +74,8 @@ export const predefinedFirewalls: FirewallOption[] = [
           ports: '443',
           protocol: 'TCP',
           addresses: {
-            ipv4: '0.0.0.0/0',
-            ipv6: '::0/0'
+            ipv4: ['0.0.0.0/0'],
+            ipv6: ['::0/0']
           }
         }
       ]
@@ -87,8 +89,8 @@ export const predefinedFirewalls: FirewallOption[] = [
           ports: '3306',
           protocol: 'TCP',
           addresses: {
-            ipv4: '0.0.0.0/0',
-            ipv6: '::0/0'
+            ipv4: ['0.0.0.0/0'],
+            ipv6: ['::0/0']
           }
         }
       ],
@@ -97,8 +99,8 @@ export const predefinedFirewalls: FirewallOption[] = [
           ports: '3306',
           protocol: 'TCP',
           addresses: {
-            ipv4: '0.0.0.0/0',
-            ipv6: '::0/0'
+            ipv4: ['0.0.0.0/0'],
+            ipv6: ['::0/0']
           }
         }
       ]
@@ -112,8 +114,8 @@ export const predefinedFirewalls: FirewallOption[] = [
           ports: '53',
           protocol: 'TCP',
           addresses: {
-            ipv4: '0.0.0.0/0',
-            ipv6: '::0/0'
+            ipv4: ['0.0.0.0/0'],
+            ipv6: ['::0/0']
           }
         }
       ],
@@ -122,8 +124,8 @@ export const predefinedFirewalls: FirewallOption[] = [
           ports: '53',
           protocol: 'TCP',
           addresses: {
-            ipv4: '0.0.0.0/0',
-            ipv6: '::0/0'
+            ipv4: ['0.0.0.0/0'],
+            ipv6: ['::0/0']
           }
         }
       ]

--- a/packages/manager/src/store/firewalls/firewalls.reducer.test.ts
+++ b/packages/manager/src/store/firewalls/firewalls.reducer.test.ts
@@ -12,11 +12,11 @@ const baseFirewall: Firewall[] = [
       outbound: [
         {
           protocol: 'ALL',
-          start_port: 443
+          ports: '443'
         },
         {
           protocol: 'ALL',
-          start_port: 80
+          ports: '80'
         }
       ]
     },
@@ -61,12 +61,12 @@ describe('Cloud Firewalls Reducer', () => {
           outbound: [
             {
               protocol: 'ALL',
-              start_port: 443,
+              ports: '443',
               sequence: 1
             },
             {
               protocol: 'ALL',
-              start_port: 80,
+              ports: '80',
               sequence: 2
             }
           ]


### PR DESCRIPTION
## Description

We want to provide some common, predefined firewall rules for users to choose from when creating a Firewall. They can add or edit these rules afterwards.


## Note to Reviewers

These won't be used until we update the create drawer. In the meantime, please test the `rules` payloads with `curl` or Insomnia.