### PR TITLE
Remove extra whitespace in Contact Information on account/billing

### DIFF
--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
@@ -85,7 +85,7 @@ const ContactInformation: React.FC<CombinedProps> = props => {
             {!(address1 || address2 || city || state || zip) && 'None'}
             <span>{address1}</span>
             <div>{address2}</div>
-            <div>{`${city} ${city && state && ', '} ${state} ${zip}`}</div>
+            <div>{`${city}${city && state && ','} ${state} ${zip}`}</div>
           </div>
         </div>
         <div className={classes.section} data-qa-contact-email>


### PR DESCRIPTION
## Description

I happened to find this extra space:

<img width="176" alt="Screen Shot 2020-02-14 at 4 57 44 PM" src="https://user-images.githubusercontent.com/16911484/74570934-23ccfe80-4f4b-11ea-974f-523d8c502450.png">
