### PR TITLE
M3-3857 firewall sdk redux

### DIFF
--- a/packages/manager/src/__data__/firewalls.ts
+++ b/packages/manager/src/__data__/firewalls.ts
@@ -1,5 +1,4 @@
 import { Firewall } from 'linode-js-sdk/lib/firewalls';
-import { FirewallWithSequence } from 'src/store/firewalls/firewalls.reducer';
 
 export const firewall: Firewall = {
   id: 1,
@@ -49,38 +48,5 @@ export const firewall2: Firewall = {
     ]
   }
 };
-
-const firewallWithSequence: FirewallWithSequence = {
-  ...firewall,
-  rules: {
-    inbound: (firewall.rules.inbound || []).map((eachRule, index) => ({
-      ...eachRule,
-      sequence: index + 1
-    })),
-    outbound: (firewall.rules.outbound || []).map((eachRule, index) => ({
-      ...eachRule,
-      sequence: index + 1
-    }))
-  }
-};
-
-const firewallWithSequence2: FirewallWithSequence = {
-  ...firewall2,
-  rules: {
-    inbound: (firewall2.rules.inbound || []).map((eachRule, index) => ({
-      ...eachRule,
-      sequence: index + 1
-    })),
-    outbound: (firewall2.rules.outbound || []).map((eachRule, index) => ({
-      ...eachRule,
-      sequence: index + 1
-    }))
-  }
-};
-
-export const firewallsWithSequence = [
-  firewallWithSequence,
-  firewallWithSequence2
-];
 
 export const firewalls = [firewall, firewall2];

--- a/packages/manager/src/containers/firewalls.container.ts
+++ b/packages/manager/src/containers/firewalls.container.ts
@@ -1,8 +1,11 @@
-import { Firewall } from 'linode-js-sdk/lib/firewalls';
+import { CreateFirewallPayload, Firewall } from 'linode-js-sdk/lib/firewalls';
 import { connect } from 'react-redux';
 import { ApplicationState } from 'src/store';
 import { State } from 'src/store/firewalls/firewalls.reducer';
-import { getAllFirewalls as _getFirewalls } from 'src/store/firewalls/firewalls.requests';
+import {
+  createFirewall as _create,
+  getAllFirewalls as _getFirewalls
+} from 'src/store/firewalls/firewalls.requests';
 import { ThunkDispatch } from 'src/store/types';
 import { GetAllData } from 'src/utilities/getAll';
 
@@ -11,6 +14,7 @@ interface DispatchProps {
     params?: any,
     filters?: any
   ) => Promise<GetAllData<Firewall[]>>;
+  createFirewall: (payload: CreateFirewallPayload) => Promise<Firewall>;
 }
 
 /* tslint:disable-next-line */
@@ -39,7 +43,8 @@ const connected = <ReduxStateProps extends {}, OwnProps extends {}>(
     },
     (dispatch: ThunkDispatch) => ({
       getFirewalls: (params, filter) =>
-        dispatch(_getFirewalls({ params, filter }))
+        dispatch(_getFirewalls({ params, filter })),
+      createFirewall: payload => dispatch(_create(payload))
     })
   );
 

--- a/packages/manager/src/containers/firewalls.container.ts
+++ b/packages/manager/src/containers/firewalls.container.ts
@@ -1,20 +1,29 @@
 import { CreateFirewallPayload, Firewall } from 'linode-js-sdk/lib/firewalls';
 import { connect } from 'react-redux';
 import { ApplicationState } from 'src/store';
+import { UpdateFirewallPayloadWithID } from 'src/store/firewalls/firewalls.actions';
 import { State } from 'src/store/firewalls/firewalls.reducer';
 import {
   createFirewall as _create,
-  getAllFirewalls as _getFirewalls
+  deleteFirewall as _delete,
+  disableFirewall as _disable,
+  enableFirewall as _enable,
+  getAllFirewalls as _getFirewalls,
+  updateFirewall as _update
 } from 'src/store/firewalls/firewalls.requests';
 import { ThunkDispatch } from 'src/store/types';
 import { GetAllData } from 'src/utilities/getAll';
 
-interface DispatchProps {
+export interface DispatchProps {
   getFirewalls: (
     params?: any,
     filters?: any
   ) => Promise<GetAllData<Firewall[]>>;
   createFirewall: (payload: CreateFirewallPayload) => Promise<Firewall>;
+  deleteFirewall: (firewallID: number) => Promise<{}>;
+  disableFirewall: (firewallID: number) => Promise<Firewall>;
+  enableFirewall: (firewallID: number) => Promise<Firewall>;
+  updateFirewall: (payload: UpdateFirewallPayloadWithID) => Promise<Firewall>;
 }
 
 /* tslint:disable-next-line */
@@ -44,7 +53,12 @@ const connected = <ReduxStateProps extends {}, OwnProps extends {}>(
     (dispatch: ThunkDispatch) => ({
       getFirewalls: (params, filter) =>
         dispatch(_getFirewalls({ params, filter })),
-      createFirewall: payload => dispatch(_create(payload))
+      createFirewall: payload => dispatch(_create(payload)),
+      deleteFirewall: (firewallID: number) => dispatch(_delete({ firewallID })),
+      disableFirewall: (firewallID: number) =>
+        dispatch(_disable({ firewallID })),
+      enableFirewall: (firewallID: number) => dispatch(_enable({ firewallID })),
+      updateFirewall: payload => dispatch(_update(payload))
     })
   );
 

--- a/packages/manager/src/factories/firewalls.ts
+++ b/packages/manager/src/factories/firewalls.ts
@@ -1,0 +1,27 @@
+import * as Factory from 'factory.ts';
+import {
+  Firewall,
+  FirewallRules,
+  FirewallRuleType
+} from 'linode-js-sdk/lib/firewalls/types';
+
+export const firewallRuleFactory = Factory.Sync.makeFactory<FirewallRuleType>({
+  ports: '22',
+  protocol: 'TCP',
+  addresses: {}
+});
+
+export const firewallRulesFactory = Factory.Sync.makeFactory<FirewallRules>({
+  inbound: firewallRuleFactory.buildList(1),
+  outbound: firewallRuleFactory.buildList(1)
+});
+
+export const firewallFactory = Factory.Sync.makeFactory<Firewall>({
+  id: Factory.each(id => id),
+  label: Factory.each(id => `mock-firewall-${id}`),
+  rules: firewallRulesFactory.build(),
+  created_dt: '2020-01-01 00:00:00',
+  updated_dt: '2020-01-01 00:00:00',
+  tags: [],
+  status: 'enabled'
+});

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallLanding.tsx
@@ -101,6 +101,7 @@ const FirewallLanding: React.FC<CombinedProps> = props => {
         triggerDisableFirewall={handleOpenDisableFirewallModal}
         triggerEditFirewall={(id, label) => null}
         triggerEnableFirewall={(id, label) => null}
+        createFirewall={props.createFirewall}
       />
       <AddFirewallDrawer
         open={addFirewallDrawerOpen}

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallLanding.tsx
@@ -57,19 +57,14 @@ const FirewallLanding: React.FC<CombinedProps> = props => {
     data: firewalls,
     loading: firewallsLoading,
     error: firewallsError,
-    lastUpdated: firewallsLastUpdated,
-    listOfIDsInOriginalOrder: firewallsKeys
+    lastUpdated: firewallsLastUpdated
   } = props;
 
   React.useEffect(() => {
-    if (
-      firewallsKeys.length === 0 &&
-      firewallsLastUpdated === 0 &&
-      !firewallsLoading
-    ) {
+    if (firewallsLastUpdated === 0 && !firewallsLoading) {
       props.getFirewalls();
     }
-  }, [firewallsLastUpdated, firewallsLoading, firewallsKeys]);
+  }, [firewallsLastUpdated, firewallsLoading]);
 
   return (
     <React.Fragment>
@@ -101,7 +96,6 @@ const FirewallLanding: React.FC<CombinedProps> = props => {
         loading={firewallsLoading}
         error={firewallsError}
         lastUpdated={firewallsLastUpdated}
-        listOfIDsInOriginalOrder={firewallsKeys}
         results={props.results}
         triggerDeleteFirewall={handleOpenDeleteFirewallModal}
         triggerDisableFirewall={handleOpenDisableFirewallModal}

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallLanding.tsx
@@ -60,12 +60,6 @@ const FirewallLanding: React.FC<CombinedProps> = props => {
     lastUpdated: firewallsLastUpdated
   } = props;
 
-  React.useEffect(() => {
-    if (firewallsLastUpdated === 0 && !firewallsLoading) {
-      props.getFirewalls();
-    }
-  }, [firewallsLastUpdated, firewallsLoading]);
-
   return (
     <React.Fragment>
       <Box display="flex" flexDirection="row" justifyContent="space-between">

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallTable.tsx
@@ -109,7 +109,7 @@ const FirewallTable: React.FC<CombinedProps> = props => {
                       <FirewallRows
                         data={paginatedAndOrderedData}
                         loading={firewallsLoading}
-                        error={firewallsError}
+                        error={firewallsError.read}
                         lastUpdated={firewallsLastUpdated}
                         {...actionMenuHandlers}
                       />

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallTable.tsx
@@ -44,7 +44,6 @@ const FirewallTable: React.FC<CombinedProps> = props => {
     loading: firewallsLoading,
     error: firewallsError,
     lastUpdated: firewallsLastUpdated,
-    listOfIDsInOriginalOrder: firewallsKeys,
     ...actionMenuHandlers
   } = props;
 
@@ -106,7 +105,6 @@ const FirewallTable: React.FC<CombinedProps> = props => {
                         data={paginatedAndOrderedData}
                         loading={firewallsLoading}
                         error={firewallsError}
-                        listOfIDsInOriginalOrder={firewallsKeys}
                         lastUpdated={firewallsLastUpdated}
                         {...actionMenuHandlers}
                       />

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallTable.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
 import { compose } from 'recompose';
 import { makeStyles, Theme } from 'src/components/core/styles';
-import { Props as FireProps } from 'src/containers/firewalls.container';
+import {
+  DispatchProps,
+  StateProps as FireProps
+} from 'src/containers/firewalls.container';
 
 import Paper from 'src/components/core/Paper';
 import TableBody from 'src/components/core/TableBody';
@@ -32,7 +35,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   }
 }));
 
-type FirewallProps = Omit<FireProps, 'getFirewalls'> & ActionHandlers;
+type FirewallProps = FireProps &
+  Pick<DispatchProps, 'createFirewall'> &
+  ActionHandlers;
 
 type CombinedProps = FirewallProps;
 

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallTableRows.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallTableRows.tsx
@@ -1,4 +1,5 @@
 import { Firewall } from 'linode-js-sdk/lib/firewalls/types';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import { compose } from 'recompose';
 
@@ -6,13 +7,15 @@ import TableRowEmpty from 'src/components/TableRowEmptyState';
 import TableRowError from 'src/components/TableRowError';
 import TableRowLoading from 'src/components/TableRowLoading';
 
-import { StateProps as FireProps } from 'src/containers/firewalls.container';
 import { ActionHandlers } from './FirewallActionMenu';
 
 import FirewallRow from './FirewallRow';
 
-interface Props extends Omit<FireProps, 'data' | 'results'> {
+interface Props {
   data: Firewall[];
+  loading: boolean;
+  lastUpdated: number;
+  error?: APIError[];
 }
 
 type CombinedProps = Props & ActionHandlers;
@@ -33,10 +36,8 @@ const FirewallTableRows: React.FC<CombinedProps> = props => {
   /**
    * only display error if we don't already have data
    */
-  if (firewallsError.read && firewallsLastUpdated === 0) {
-    return (
-      <TableRowError colSpan={6} message={firewallsError.read[0].reason} />
-    );
+  if (firewallsError && firewallsLastUpdated === 0) {
+    return <TableRowError colSpan={6} message={firewallsError[0].reason} />;
   }
 
   if (firewallsLastUpdated !== 0 && Object.keys(firewalls).length === 0) {

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallTableRows.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallTableRows.tsx
@@ -6,12 +6,12 @@ import TableRowEmpty from 'src/components/TableRowEmptyState';
 import TableRowError from 'src/components/TableRowError';
 import TableRowLoading from 'src/components/TableRowLoading';
 
-import { Props as FireProps } from 'src/containers/firewalls.container';
+import { StateProps as FireProps } from 'src/containers/firewalls.container';
 import { ActionHandlers } from './FirewallActionMenu';
 
 import FirewallRow from './FirewallRow';
 
-interface Props extends Omit<FireProps, 'data' | 'results' | 'getFirewalls'> {
+interface Props extends Omit<FireProps, 'data' | 'results'> {
   data: Firewall[];
 }
 

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallTableRows.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallTableRows.tsx
@@ -1,3 +1,4 @@
+import { Firewall } from 'linode-js-sdk/lib/firewalls/types';
 import * as React from 'react';
 import { compose } from 'recompose';
 
@@ -6,13 +7,12 @@ import TableRowError from 'src/components/TableRowError';
 import TableRowLoading from 'src/components/TableRowLoading';
 
 import { Props as FireProps } from 'src/containers/firewalls.container';
-import { FirewallWithSequence } from 'src/store/firewalls/firewalls.reducer';
 import { ActionHandlers } from './FirewallActionMenu';
 
 import FirewallRow from './FirewallRow';
 
 interface Props extends Omit<FireProps, 'data' | 'results' | 'getFirewalls'> {
-  data: FirewallWithSequence[];
+  data: Firewall[];
 }
 
 type CombinedProps = Props & ActionHandlers;
@@ -23,7 +23,6 @@ const FirewallTableRows: React.FC<CombinedProps> = props => {
     loading: firewallsLoading,
     error: firewallsError,
     lastUpdated: firewallsLastUpdated,
-    listOfIDsInOriginalOrder: firewallsKeys,
     ...actionMenuHandlers
   } = props;
 
@@ -40,7 +39,7 @@ const FirewallTableRows: React.FC<CombinedProps> = props => {
     );
   }
 
-  if (firewallsLastUpdated !== 0 && firewallsKeys.length === 0) {
+  if (firewallsLastUpdated !== 0 && Object.keys(firewalls).length === 0) {
     return (
       <TableRowEmpty colSpan={6} message="You do not have any Firewalls" />
     );

--- a/packages/manager/src/features/Firewalls/index.tsx
+++ b/packages/manager/src/features/Firewalls/index.tsx
@@ -2,6 +2,9 @@ import * as React from 'react';
 import { Route, RouteComponentProps, Switch } from 'react-router-dom';
 import DefaultLoader from 'src/components/DefaultLoader';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import withFirewalls, {
+  Props as FireProps
+} from 'src/containers/firewalls.container';
 
 const FirewallLanding = DefaultLoader({
   loader: () => import('./FirewallLanding')
@@ -13,7 +16,17 @@ const FirewallDetail = DefaultLoader({
 
 type Props = RouteComponentProps<{}>;
 
-class Firewall extends React.Component<Props> {
+type CombinedProps = Props & FireProps;
+
+class Firewall extends React.Component<CombinedProps> {
+  componentDidMount() {
+    // @todo refactor to use useReduxLoad when that is available in develop
+    const { getFirewalls, lastUpdated, loading } = this.props;
+    if (lastUpdated === 0 && !loading) {
+      getFirewalls();
+    }
+  }
+
   render() {
     const {
       match: { path }
@@ -32,4 +45,4 @@ class Firewall extends React.Component<Props> {
   }
 }
 
-export default Firewall;
+export default withFirewalls()(Firewall);

--- a/packages/manager/src/store/firewalls/firewalls.actions.ts
+++ b/packages/manager/src/store/firewalls/firewalls.actions.ts
@@ -1,4 +1,4 @@
-import { Firewall } from 'linode-js-sdk/lib/firewalls';
+import { CreateFirewallPayload, Firewall } from 'linode-js-sdk/lib/firewalls';
 import { APIError } from 'linode-js-sdk/lib/types';
 import { GetAllData } from 'src/utilities/getAll';
 
@@ -13,4 +13,10 @@ export const getFirewalls = actionCreator.async<
   },
   GetAllData<Firewall[]>,
   APIError[]
->(`success`);
+>(`get-all`);
+
+export const createFirewallActions = actionCreator.async<
+  CreateFirewallPayload,
+  Firewall,
+  APIError[]
+>(`create`);

--- a/packages/manager/src/store/firewalls/firewalls.actions.ts
+++ b/packages/manager/src/store/firewalls/firewalls.actions.ts
@@ -1,4 +1,8 @@
-import { CreateFirewallPayload, Firewall } from 'linode-js-sdk/lib/firewalls';
+import {
+  CreateFirewallPayload,
+  Firewall,
+  UpdateFirewallPayload
+} from 'linode-js-sdk/lib/firewalls';
 import { APIError } from 'linode-js-sdk/lib/types';
 import { GetAllData } from 'src/utilities/getAll';
 
@@ -20,3 +24,18 @@ export const createFirewallActions = actionCreator.async<
   Firewall,
   APIError[]
 >(`create`);
+
+export type UpdateFirewallPayloadWithID = UpdateFirewallPayload & {
+  firewallID: number;
+};
+export const updateFirewallActions = actionCreator.async<
+  UpdateFirewallPayloadWithID,
+  Firewall,
+  APIError[]
+>(`update`);
+
+export const deleteFirewallActions = actionCreator.async<
+  { firewallID: number },
+  {},
+  APIError[]
+>(`delete`);

--- a/packages/manager/src/store/firewalls/firewalls.reducer.test.ts
+++ b/packages/manager/src/store/firewalls/firewalls.reducer.test.ts
@@ -5,6 +5,7 @@ import reducer, { defaultState } from './firewalls.reducer';
 const mockError = [{ reason: 'no reason' }];
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 const baseFirewall: Firewall[] = [
   {
     id: 1,
@@ -28,9 +29,8 @@ const baseFirewall: Firewall[] = [
     tags: []
   }
 ];
-=======
-const baseFirewall = firewallFactory.buildList(1);
->>>>>>> Add partial factories and tests
+
+const baseFirewall = firewallFactory.buildList(3);
 
 describe('Cloud Firewalls Reducer', () => {
   it('should handle an initiated request for services', () => {
@@ -57,10 +57,24 @@ describe('Cloud Firewalls Reducer', () => {
         result: { data: baseFirewall, results: 2 }
       })
     );
-    expect(newState).toHaveProperty('data', baseFirewall);
+    expect(Object.values(newState.data)).toEqual(baseFirewall);
     expect(newState).toHaveProperty('loading', false);
     expect(newState.error!.read).toBeUndefined();
     expect(newState.results).toBe(2);
+  });
+
+  it('should handle a successful GET with an empty response', () => {
+    const newState = reducer(
+      { ...defaultState, loading: true },
+      getFirewalls.done({
+        params: {},
+        result: { data: [], results: 0 }
+      })
+    );
+    expect(newState.data).toEqual({});
+    expect(newState).toHaveProperty('loading', false);
+    expect(newState.error!.read).toBeUndefined();
+    expect(newState.results).toBe(0);
   });
 
   it('should handle a successful Create action', () => {
@@ -74,6 +88,17 @@ describe('Cloud Firewalls Reducer', () => {
     );
 
     expect(newState.error.create).toBeUndefined();
-    expect(newState.data).toHaveLength(1);
+    expect(newState.data).toHaveProperty(String(newFirewall.id), newFirewall);
+  });
+
+  it('should handle a failed Create action', () => {
+    const params = {
+      rules: firewallRulesFactory.build()
+    };
+    const newState = reducer(
+      defaultState,
+      createFirewallActions.failed({ params, error: mockError })
+    );
+    expect(newState.error).toHaveProperty('create', mockError);
   });
 });

--- a/packages/manager/src/store/firewalls/firewalls.reducer.test.ts
+++ b/packages/manager/src/store/firewalls/firewalls.reducer.test.ts
@@ -9,32 +9,6 @@ import reducer, { defaultState } from './firewalls.reducer';
 
 const mockError = [{ reason: 'no reason' }];
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-const baseFirewall: Firewall[] = [
-  {
-    id: 1,
-    rules: {
-      inbound: [],
-      outbound: [
-        {
-          protocol: 'ALL',
-          ports: '443'
-        },
-        {
-          protocol: 'ALL',
-          ports: '80'
-        }
-      ]
-    },
-    status: 'disabled',
-    label: 'zzz',
-    created_dt: '2019-12-11T19:44:38.526Z',
-    updated_dt: '2019-12-11T19:44:38.526Z',
-    tags: []
-  }
-];
-
 const baseFirewall = firewallFactory.buildList(3);
 
 const addEntities = () =>

--- a/packages/manager/src/store/firewalls/firewalls.reducer.test.ts
+++ b/packages/manager/src/store/firewalls/firewalls.reducer.test.ts
@@ -1,9 +1,10 @@
-import { Firewall } from 'linode-js-sdk/lib/firewalls';
-import { getFirewalls } from './firewalls.actions';
+import { firewallFactory, firewallRulesFactory } from 'src/factories/firewalls';
+import { createFirewallActions, getFirewalls } from './firewalls.actions';
 import reducer, { defaultState } from './firewalls.reducer';
 
 const mockError = [{ reason: 'no reason' }];
 
+<<<<<<< HEAD
 const baseFirewall: Firewall[] = [
   {
     id: 1,
@@ -27,6 +28,9 @@ const baseFirewall: Firewall[] = [
     tags: []
   }
 ];
+=======
+const baseFirewall = firewallFactory.buildList(1);
+>>>>>>> Add partial factories and tests
 
 describe('Cloud Firewalls Reducer', () => {
   it('should handle an initiated request for services', () => {
@@ -53,33 +57,23 @@ describe('Cloud Firewalls Reducer', () => {
         result: { data: baseFirewall, results: 2 }
       })
     );
-    expect(newState).toHaveProperty('data', {
-      1: {
-        id: 1,
-        rules: {
-          inbound: [],
-          outbound: [
-            {
-              protocol: 'ALL',
-              ports: '443',
-              sequence: 1
-            },
-            {
-              protocol: 'ALL',
-              ports: '80',
-              sequence: 2
-            }
-          ]
-        },
-        status: 'disabled',
-        label: 'zzz',
-        created_dt: '2019-12-11T19:44:38.526Z',
-        updated_dt: '2019-12-11T19:44:38.526Z',
-        tags: []
-      }
-    });
+    expect(newState).toHaveProperty('data', baseFirewall);
     expect(newState).toHaveProperty('loading', false);
     expect(newState.error!.read).toBeUndefined();
     expect(newState.results).toBe(2);
+  });
+
+  it('should handle a successful Create action', () => {
+    const params = {
+      rules: firewallRulesFactory.build()
+    };
+    const newFirewall = firewallFactory.build();
+    const newState = reducer(
+      defaultState,
+      createFirewallActions.done({ params, result: newFirewall })
+    );
+
+    expect(newState.error.create).toBeUndefined();
+    expect(newState.data).toHaveLength(1);
   });
 });

--- a/packages/manager/src/store/firewalls/firewalls.reducer.test.ts
+++ b/packages/manager/src/store/firewalls/firewalls.reducer.test.ts
@@ -16,7 +16,7 @@ const addEntities = () =>
     defaultState,
     getFirewalls.done({
       params: {},
-      result: { data: baseFirewall, results: 2 }
+      result: { data: baseFirewall, results: 3 }
     })
   );
 
@@ -42,7 +42,7 @@ describe('Cloud Firewalls Reducer', () => {
       { ...defaultState, loading: true },
       getFirewalls.done({
         params: {},
-        result: { data: baseFirewall, results: 2 }
+        result: { data: baseFirewall, results: 3 }
       })
     );
     expect(Object.values(newState.data)).toEqual(baseFirewall);

--- a/packages/manager/src/store/firewalls/firewalls.reducer.test.ts
+++ b/packages/manager/src/store/firewalls/firewalls.reducer.test.ts
@@ -48,7 +48,7 @@ describe('Cloud Firewalls Reducer', () => {
     expect(Object.values(newState.data)).toEqual(baseFirewall);
     expect(newState).toHaveProperty('loading', false);
     expect(newState.error!.read).toBeUndefined();
-    expect(newState.results).toBe(2);
+    expect(newState.results).toBe(3);
   });
 
   it('should handle a successful GET with an empty response', () => {

--- a/packages/manager/src/store/firewalls/firewalls.reducer.ts
+++ b/packages/manager/src/store/firewalls/firewalls.reducer.ts
@@ -4,7 +4,12 @@ import { Reducer } from 'redux';
 import { isType } from 'typescript-fsa';
 import { apiResponseToMappedState } from '../store.helpers';
 import { EntitiesAsObjectState } from '../types';
-import { createFirewallActions, getFirewalls } from './firewalls.actions';
+import {
+  createFirewallActions,
+  deleteFirewallActions,
+  getFirewalls,
+  updateFirewallActions
+} from './firewalls.actions';
 
 export type State = EntitiesAsObjectState<Firewall>;
 
@@ -56,6 +61,45 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
       const { error } = action.payload;
 
       draft.error.create = error;
+    }
+
+    if (isType(action, createFirewallActions.failed)) {
+      const { error } = action.payload;
+
+      draft.error.create = error;
+    }
+
+    if (isType(action, updateFirewallActions.started)) {
+      draft.error.update = undefined;
+    }
+
+    if (isType(action, updateFirewallActions.done)) {
+      const { result } = action.payload;
+      draft.data[result.id] = result;
+      draft.lastUpdated = Date.now();
+    }
+
+    if (isType(action, updateFirewallActions.failed)) {
+      const { error } = action.payload;
+
+      draft.error.update = error;
+    }
+
+    if (isType(action, deleteFirewallActions.started)) {
+      draft.error.delete = undefined;
+    }
+
+    if (isType(action, deleteFirewallActions.done)) {
+      const { firewallID } = action.payload.params;
+      delete draft.data[firewallID];
+      draft.results--;
+      draft.lastUpdated = Date.now();
+    }
+
+    if (isType(action, deleteFirewallActions.failed)) {
+      const { error } = action.payload;
+
+      draft.error.delete = error;
     }
   });
 };

--- a/packages/manager/src/store/firewalls/firewalls.reducer.ts
+++ b/packages/manager/src/store/firewalls/firewalls.reducer.ts
@@ -63,12 +63,6 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
       draft.error.create = error;
     }
 
-    if (isType(action, createFirewallActions.failed)) {
-      const { error } = action.payload;
-
-      draft.error.create = error;
-    }
-
     if (isType(action, updateFirewallActions.started)) {
       draft.error.update = undefined;
     }

--- a/packages/manager/src/store/firewalls/firewalls.requests.ts
+++ b/packages/manager/src/store/firewalls/firewalls.requests.ts
@@ -1,7 +1,14 @@
-import { Firewall, getFirewalls } from 'linode-js-sdk/lib/firewalls';
+import {
+  createFirewall as _create,
+  Firewall,
+  getFirewalls
+} from 'linode-js-sdk/lib/firewalls';
 import { getAll } from 'src/utilities/getAll';
 import { createRequestThunk } from '../store.helpers';
-import { getFirewalls as _getFirewallsAction } from './firewalls.actions';
+import {
+  createFirewallActions,
+  getFirewalls as _getFirewallsAction
+} from './firewalls.actions';
 
 const getAllFirewallsRequest = (payload: { params?: any; filter?: any }) =>
   getAll<Firewall>((passedParams, passedFilter) =>
@@ -11,4 +18,9 @@ const getAllFirewallsRequest = (payload: { params?: any; filter?: any }) =>
 export const getAllFirewalls = createRequestThunk(
   _getFirewallsAction,
   getAllFirewallsRequest
+);
+
+export const createFirewall = createRequestThunk(
+  createFirewallActions,
+  _create
 );

--- a/packages/manager/src/store/firewalls/firewalls.requests.ts
+++ b/packages/manager/src/store/firewalls/firewalls.requests.ts
@@ -1,13 +1,19 @@
 import {
   createFirewall as _create,
+  deleteFirewall as _delete,
+  disableFirewall as _disable,
+  enableFirewall as _enable,
   Firewall,
-  getFirewalls
+  getFirewalls,
+  updateFirewall as _update
 } from 'linode-js-sdk/lib/firewalls';
 import { getAll } from 'src/utilities/getAll';
 import { createRequestThunk } from '../store.helpers';
 import {
   createFirewallActions,
-  getFirewalls as _getFirewallsAction
+  deleteFirewallActions,
+  getFirewalls as _getFirewallsAction,
+  updateFirewallActions
 } from './firewalls.actions';
 
 const getAllFirewallsRequest = (payload: { params?: any; filter?: any }) =>
@@ -23,4 +29,24 @@ export const getAllFirewalls = createRequestThunk(
 export const createFirewall = createRequestThunk(
   createFirewallActions,
   _create
+);
+
+export const updateFirewall = createRequestThunk(
+  updateFirewallActions,
+  ({ firewallID, ...data }) => _update(firewallID, data)
+);
+
+export const enableFirewall = createRequestThunk(
+  updateFirewallActions,
+  ({ firewallID }) => _enable(firewallID)
+);
+
+export const disableFirewall = createRequestThunk(
+  updateFirewallActions,
+  ({ firewallID }) => _disable(firewallID)
+);
+
+export const deleteFirewall = createRequestThunk(
+  deleteFirewallActions,
+  ({ firewallID }) => _delete(firewallID)
 );

--- a/packages/manager/src/store/image/image.reducer.ts
+++ b/packages/manager/src/store/image/image.reducer.ts
@@ -21,8 +21,7 @@ export const defaultState: State = {
   lastUpdated: 0,
   results: 0,
   data: {},
-  error: {},
-  listOfIDsInOriginalOrder: []
+  error: {}
 };
 
 /**
@@ -39,7 +38,6 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
 
       draft.loading = false;
       draft.lastUpdated = Date.now();
-      draft.listOfIDsInOriginalOrder = result.map(eachImage => eachImage.id);
       draft.data = result.reduce((acc, eachImage) => {
         if (eachImage.label.match(/kube/i)) {
           // NOTE: Temporarily hide public Kubernetes images until ImageSelect redesign.
@@ -68,10 +66,6 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
       draft.loading = false;
       draft.data[result.id] = result;
       draft.results = Object.keys(draft.data).length;
-      draft.listOfIDsInOriginalOrder = [
-        ...state.listOfIDsInOriginalOrder,
-        result.id
-      ];
     }
 
     if (isType(action, requestImageForStoreActions.failed)) {
@@ -107,10 +101,6 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
       draft.lastUpdated = Date.now();
       draft.data[result.id] = result;
       draft.results = Object.keys(draft.data).length;
-      draft.listOfIDsInOriginalOrder = [
-        ...state.listOfIDsInOriginalOrder,
-        result.id
-      ];
     }
 
     if (isType(action, createImageActions.failed)) {
@@ -132,9 +122,7 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
       delete dataClone[id];
 
       draft.data = dataClone;
-      draft.listOfIDsInOriginalOrder = state.listOfIDsInOriginalOrder.filter(
-        eachID => eachID !== id
-      );
+
       draft.results = Object.keys(dataClone).length;
       if (draft.results !== state.results) {
         // something was actually updated
@@ -149,13 +137,6 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
       dataClone[image.id] = image;
 
       draft.data = dataClone;
-      /**
-       * in the case of updating and adding, we're just going to add the new ID to the
-       * end of the list. Set() will make sure to get rid of the dupes in the list
-       */
-      draft.listOfIDsInOriginalOrder = [
-        ...new Set([...state.listOfIDsInOriginalOrder, image.id])
-      ];
       draft.results = Object.keys(dataClone).length;
       draft.lastUpdated = Date.now();
     }

--- a/packages/manager/src/store/longview/longview.reducer.ts
+++ b/packages/manager/src/store/longview/longview.reducer.ts
@@ -16,8 +16,7 @@ export const defaultState: State = {
   lastUpdated: 0,
   results: 0,
   data: {},
-  error: {},
-  listOfIDsInOriginalOrder: []
+  error: {}
 };
 
 const reducer = reducerWithInitialState(defaultState)
@@ -40,9 +39,6 @@ const reducer = reducerWithInitialState(defaultState)
       }, {}),
       loading: false,
       results: result.results,
-      listOfIDsInOriginalOrder: result.data.map(
-        eachFirewall => eachFirewall.id
-      ),
       lastUpdated: Date.now()
     })
   )
@@ -70,7 +66,6 @@ const reducer = reducerWithInitialState(defaultState)
         [result.id]: result
       },
       results: state.results + 1,
-      listOfIDsInOriginalOrder: [...state.listOfIDsInOriginalOrder, result.id],
       lastUpdated: Date.now()
     })
   )
@@ -103,10 +98,7 @@ const reducer = reducerWithInitialState(defaultState)
         ...state,
         data: dataCopy,
         results: state.results - 1,
-        lastUpdated: Date.now(),
-        listOfIDsInOriginalOrder: state.listOfIDsInOriginalOrder.filter(
-          e => e !== params.id
-        )
+        lastUpdated: Date.now()
       };
     }
   )

--- a/packages/manager/src/store/store.helpers.ts
+++ b/packages/manager/src/store/store.helpers.ts
@@ -171,3 +171,9 @@ export const ensureInitializedNestedState = (
   }
   return state;
 };
+
+export const apiResponseToMappedState = <T extends Entity>(data: T[]) => {
+  return data.reduce((acc, thisEntity) => {
+    acc[thisEntity.id] = thisEntity;
+    return acc;
+  }, {});

--- a/packages/manager/src/store/store.helpers.ts
+++ b/packages/manager/src/store/store.helpers.ts
@@ -177,3 +177,4 @@ export const apiResponseToMappedState = <T extends Entity>(data: T[]) => {
     acc[thisEntity.id] = thisEntity;
     return acc;
   }, {});
+};

--- a/packages/manager/src/store/types.ts
+++ b/packages/manager/src/store/types.ts
@@ -97,7 +97,6 @@ export interface EntitiesAsObjectState<T> {
   results: number;
   lastUpdated: number;
   loading: boolean;
-  listOfIDsInOriginalOrder?: (string | number)[];
 }
 
 /**

--- a/packages/manager/src/store/types.ts
+++ b/packages/manager/src/store/types.ts
@@ -97,7 +97,7 @@ export interface EntitiesAsObjectState<T> {
   results: number;
   lastUpdated: number;
   loading: boolean;
-  listOfIDsInOriginalOrder: (string | number)[];
+  listOfIDsInOriginalOrder?: (string | number)[];
 }
 
 /**


### PR DESCRIPTION
## Description

Adds Redux methods for the basic Firewall CRUD actions, and wires them all into firewall.container.ts. I haven't done any of the rules/devices work yet, since I'm not sure all of that belongs in Redux.

Some typing changes were involved but the behavior of the app should be unchanged from develop.