### PR TITLE
M3-3931 Fix: kubeconfig format

### DIFF
--- a/packages/manager/src/components/DrawerContent/DrawerContent.tsx
+++ b/packages/manager/src/components/DrawerContent/DrawerContent.tsx
@@ -6,11 +6,12 @@ export interface Props {
   title: string;
   loading: boolean;
   error: boolean;
+  errorMessage?: string;
 }
 
 export class DrawerContent extends React.PureComponent<Props> {
   render() {
-    const { title, loading, error, children } = this.props;
+    const { title, loading, error, errorMessage, children } = this.props;
     if (loading) {
       return <CircleProgress />;
     }
@@ -18,7 +19,7 @@ export class DrawerContent extends React.PureComponent<Props> {
     if (error) {
       return (
         <Notice error spacingTop={8}>
-          Couldn't load {title}
+          {errorMessage ?? `Couldn't load ${title}`}
         </Notice>
       );
     }

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigDrawer.tsx
@@ -54,19 +54,6 @@ interface Props {
 
 export type CombinedProps = Props & WithStyles<ClassNames>;
 
-const splitCode = (code: string): string => {
-  const MAX_LENGTH = 75;
-  const lines = code.trim().split('\n');
-  const shortLines = lines.map(thisLine =>
-    thisLine.length > MAX_LENGTH
-      ? splitCode(
-          thisLine.slice(0, MAX_LENGTH) + '\n' + thisLine.slice(MAX_LENGTH)
-        )
-      : thisLine
-  );
-  return shortLines.join('\n');
-};
-
 export const KubeConfigDrawer: React.FC<CombinedProps> = props => {
   const {
     classes,
@@ -81,7 +68,7 @@ export const KubeConfigDrawer: React.FC<CombinedProps> = props => {
     extensions: ['highlightjs'],
     simplifiedAutoLink: true,
     openLinksInNewWindow: true
-  }).makeHtml(splitCode('```\n' + kubeConfig + '\n```'));
+  }).makeHtml('```\n' + kubeConfig + '\n```');
 
   return (
     <Drawer title={'View Kubeconfig'} open={open} onClose={closeDrawer} wide>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigDrawer.tsx
@@ -48,7 +48,7 @@ interface Props {
   clusterLabel: string;
   open: boolean;
   loading: boolean;
-  error: boolean;
+  error: string | null;
   closeDrawer: () => void;
 }
 
@@ -72,7 +72,12 @@ export const KubeConfigDrawer: React.FC<CombinedProps> = props => {
 
   return (
     <Drawer title={'View Kubeconfig'} open={open} onClose={closeDrawer} wide>
-      <DrawerContent title={clusterLabel} error={error} loading={loading}>
+      <DrawerContent
+        title={clusterLabel}
+        error={!!error}
+        errorMessage={error || undefined}
+        loading={loading}
+      >
         <Grid container spacing={2}>
           <Grid item>
             <Typography variant="h3">{clusterLabel}</Typography>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigDrawer.tsx
@@ -18,6 +18,8 @@ import 'showdown-highlightjs-extension';
 import { downloadFile } from 'src/utilities/downloadFile';
 import { sanitizeHTML } from 'src/utilities/sanitize-html';
 
+import 'src/formatted-text.css';
+
 type ClassNames = 'root' | 'icon' | 'tooltip' | 'iconLink';
 
 const styles = (theme: Theme) =>
@@ -101,7 +103,10 @@ export const KubeConfigDrawer: React.FC<CombinedProps> = props => {
           </Grid>
         </Grid>
         <div>
-          <div dangerouslySetInnerHTML={{ __html: sanitizeHTML(html) }} />
+          <div
+            className="formatted-text"
+            dangerouslySetInnerHTML={{ __html: sanitizeHTML(html) }}
+          />
         </div>
       </DrawerContent>
     </Drawer>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigPanel.tsx
@@ -1,5 +1,6 @@
 import * as classNames from 'classnames';
 import { getKubeConfig } from 'linode-js-sdk/lib/kubernetes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import * as React from 'react';
 import { compose } from 'recompose';
@@ -88,7 +89,7 @@ export type CombinedProps = Props &
 export const KubeConfigPanel: React.FC<CombinedProps> = props => {
   const { classes, clusterID, clusterLabel, enqueueSnackbar, theme } = props;
   const [drawerOpen, setDrawerOpen] = React.useState<boolean>(false);
-  const [drawerError, setDrawerError] = React.useState<boolean>(false);
+  const [drawerError, setDrawerError] = React.useState<string | null>(null);
   const [drawerLoading, setDrawerLoading] = React.useState<boolean>(false);
   const [kubeConfig, setKubeConfig] = React.useState<string>('');
   const spacingMode =
@@ -113,7 +114,7 @@ export const KubeConfigPanel: React.FC<CombinedProps> = props => {
   };
 
   const handleOpenDrawer = () => {
-    setDrawerError(false);
+    setDrawerError(null);
     setDrawerLoading(true);
     setDrawerOpen(true);
     fetchKubeConfig()
@@ -125,8 +126,8 @@ export const KubeConfigPanel: React.FC<CombinedProps> = props => {
           // There was a parsing error; the user will see an error toast.
         }
       })
-      .catch(_ => {
-        setDrawerError(true);
+      .catch((error: APIError[]) => {
+        setDrawerError(error[0].reason);
         setDrawerLoading(false);
       });
   };

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigPanel.tsx
@@ -127,7 +127,7 @@ export const KubeConfigPanel: React.FC<CombinedProps> = props => {
         }
       })
       .catch((error: APIError[]) => {
-        setDrawerError(error[0].reason);
+        setDrawerError(error[0]?.reason || null);
         setDrawerLoading(false);
       });
   };

--- a/packages/manager/src/features/Support/SupportTicketDetail/TabbedReply/PreviewReply.tsx
+++ b/packages/manager/src/features/Support/SupportTicketDetail/TabbedReply/PreviewReply.tsx
@@ -12,6 +12,8 @@ import {
 import Typography from 'src/components/core/Typography';
 import { sanitizeHTML } from 'src/utilities/sanitize-html';
 
+import 'src/formatted-text.css';
+
 type ClassNames = 'root';
 
 const styles = (theme: Theme) =>
@@ -43,6 +45,7 @@ const PreviewReply: React.FC<CombinedProps> = props => {
   return (
     <Paper className={classes.root} error={error}>
       <Typography
+        className="formatted-text"
         dangerouslySetInnerHTML={{
           __html: sanitizeHTML(markupToMarkdown)
         }}
@@ -53,7 +56,4 @@ const PreviewReply: React.FC<CombinedProps> = props => {
 
 const styled = withStyles(styles);
 
-export default compose<CombinedProps, Props>(
-  React.memo,
-  styled
-)(PreviewReply);
+export default compose<CombinedProps, Props>(React.memo, styled)(PreviewReply);

--- a/packages/manager/src/features/Support/TicketDetailText.tsx
+++ b/packages/manager/src/features/Support/TicketDetailText.tsx
@@ -14,7 +14,7 @@ import IconButton from 'src/components/IconButton';
 
 import truncateText from 'src/utilities/truncateText';
 
-import './formatted-text.css';
+import 'src/formatted-text.css';
 
 type ClassNames = 'root' | 'expButton' | 'toggle' | 'buttonText';
 

--- a/packages/manager/src/formatted-text.css
+++ b/packages/manager/src/formatted-text.css
@@ -36,7 +36,6 @@
 
 .formatted-text span.hljs-variable,
 .formatted-text span.hljs-template-variable,
-.formatted-text span.hljs-attribute,
 .formatted-text span.hljs-tag,
 .formatted-text span.hljs-name,
 .formatted-text span.hljs-regexp .formatted-text span.hljs-link,
@@ -45,7 +44,8 @@
   color: #be4678;
 }
 
-.formatted-text span.hljs-attr {
+.formatted-text span.hljs-attr,
+.formatted-text span.hljs-attribute {
   color: #2466b3;
 }
 


### PR DESCRIPTION
## Description

Syntax highlighting broke in the kubeconfig drawer, and we had a request to not split lines (we were doing this to show all of the config values within the drawer without scrolling).

- Fixed highlighting in the kubeconfig drawer
- Fixed highlighting in the support ticket preview drawer (logic was the same)
- Removed `splitLines` function
- Allowed passing a custom error message to `<DrawerContent />` (this was a separate ticket--M3-3969--but I was in the file anyway).

## Note to reviewers

To test, create a new k8s cluster and immediately click "View Config" (this will let you test the error message). After a minute or so, view config again to check the highlighting.