### PR TITLE
M3-3971 Update manifest.json display to standalone for IOS support

### DIFF
--- a/packages/manager/public/manifest.json
+++ b/packages/manager/public/manifest.json
@@ -1,12 +1,7 @@
 {
   "short_name": "Linode",
   "name": "Linode Cloud Manager",
-  "categories": [
-    "cloud hosting",
-    "cloud",
-    "linode",
-    "compute"
-  ],
+  "categories": ["cloud hosting", "cloud", "linode", "compute"],
   "description": "Linode Cloud Manager interface",
   "icons": [
     {
@@ -26,7 +21,7 @@
     }
   ],
   "start_url": "/",
-  "display": "minimal-ui",
+  "display": "standalone",
   "theme_color": "#f4f4f4",
   "background_color": "#f4f4f4",
   "orientation": "portrait-primary"


### PR DESCRIPTION
## Description
Customer would like to have a "standalone" experience, whereas we had previously opted for "minimal-ui". I'm not sure what the reason was for choosing minimal-ui, but this seems to do what's requested on both Android and Safari.

To test:
- Open local build in Chrome or Safari (I think only Safari will work on IOS).
- Choose "Save to home screen"
- Click the generated link.
- You should see a native-like experience with no web browser UI (navbar, bookmarks, etc.) visible.

![Screenshot_20200217-132841](https://user-images.githubusercontent.com/1624067/74679067-c2936e00-518a-11ea-9047-1511b97ec997.jpg)
