### PR TITLE
M3-3556 Always enable TCP Connection as a health check

### DIFF
--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -355,8 +355,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
       },
       {
         label: 'TCP Connection',
-        value: 'connection',
-        isDisabled: protocol === 'http' || protocol === 'https'
+        value: 'connection'
       },
       {
         label: 'HTTP Status',


### PR DESCRIPTION
## Description

While creating/editing a NB config, the "TCP Connection" health check option was intentionally disabled when "HTTP" or "HTTPS" was the selected protocol. It is unclear why this was the case, but we've received feedback that this is restrictive for some use cases, so this PR removes it.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers
Please check the NB config creation/update flow, cross reference with API documentation.

