### PR TITLE
M3-3278 Firewall Detail structure (tabs, routing)

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallDetail/FirewallLinodesLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/FirewallLinodesLanding.tsx
@@ -14,7 +14,7 @@ type CombinedProps = RouteComponentProps;
 const FirewallLinodesLanding: React.FC<CombinedProps> = props => {
   // const classes = useStyles();
 
-  return <div>hello world</div>;
+  return <h2>Firewall Linodes Landing</h2>;
 };
 
 export default compose<CombinedProps, {}>(React.memo)(FirewallLinodesLanding);

--- a/packages/manager/src/features/Firewalls/FirewallDetail/FirewallRulesLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/FirewallRulesLanding.tsx
@@ -14,7 +14,7 @@ type CombinedProps = RouteComponentProps;
 const FirewallRulesLanding: React.FC<CombinedProps> = props => {
   // const classes = useStyles();
 
-  return <div>hello world</div>;
+  return <h2>Firewall Rules Landing</h2>;
 };
 
 export default compose<CombinedProps, {}>(React.memo)(FirewallRulesLanding);

--- a/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
@@ -13,7 +13,6 @@ import AppBar from 'src/components/core/AppBar';
 import Box from 'src/components/core/Box';
 import Tab from 'src/components/core/Tab';
 import Tabs from 'src/components/core/Tabs';
-import DefaultLoader from 'src/components/DefaultLoader';
 import DocumentationButton from 'src/components/DocumentationButton';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import ErrorState from 'src/components/ErrorState';
@@ -23,13 +22,11 @@ import withFirewalls, {
   Props as WithFirewallsProps
 } from 'src/containers/firewalls.container';
 
-const FirewallRulesLanding = DefaultLoader({
-  loader: () => import('./FirewallRulesLanding')
-});
+const FirewallRulesLanding = React.lazy(() => import('./FirewallRulesLanding'));
 
-const FirewallLinodesLanding = DefaultLoader({
-  loader: () => import('./FirewallLinodesLanding')
-});
+const FirewallLinodesLanding = React.lazy(() =>
+  import('./FirewallLinodesLanding')
+);
 
 type CombinedProps = RouteComponentProps<{ id: string }> & WithFirewallsProps;
 

--- a/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
@@ -1,33 +1,145 @@
 import * as React from 'react';
-import { Route, RouteComponentProps, Switch } from 'react-router-dom';
+import {
+  matchPath,
+  Redirect,
+  Route,
+  RouteComponentProps,
+  Switch
+} from 'react-router-dom';
+import { compose } from 'recompose';
+import Breadcrumb from 'src/components/Breadcrumb';
+import CircleProgress from 'src/components/CircleProgress';
+import AppBar from 'src/components/core/AppBar';
+import Box from 'src/components/core/Box';
+import Tab from 'src/components/core/Tab';
+import Tabs from 'src/components/core/Tabs';
 import DefaultLoader from 'src/components/DefaultLoader';
+import DocumentationButton from 'src/components/DocumentationButton';
+import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import ErrorState from 'src/components/ErrorState';
+import NotFound from 'src/components/NotFound';
+import TabLink from 'src/components/TabLink';
+import withFirewalls, {
+  Props as WithFirewallsProps
+} from 'src/containers/firewalls.container';
 
-const FirewallRules = DefaultLoader({
+const FirewallRulesLanding = DefaultLoader({
   loader: () => import('./FirewallRulesLanding')
 });
 
-const FirewallLinodes = DefaultLoader({
+const FirewallLinodesLanding = DefaultLoader({
   loader: () => import('./FirewallLinodesLanding')
 });
 
-type Props = RouteComponentProps<{}>;
+type CombinedProps = RouteComponentProps<{ id: string }> & WithFirewallsProps;
 
-class FirewallDetail extends React.Component<Props> {
-  render() {
-    const {
-      match: { path }
-    } = this.props;
+export const FirewallDetail: React.FC<CombinedProps> = props => {
+  // Source the Firewall's ID from the /:id path param.
+  const thisFirewallId = props.match.params.id;
 
+  // Find the Firewall in the store.
+  const thisFirewall = props.data[thisFirewallId];
+
+  // If we're still fetching Firewalls, display a loading spinner. This will
+  // probably only happen when navigating to a Firewall's Detail page directly
+  // via URL bookmark (as opposed to clicking on the Firewall Landing table).
+  if (props.lastUpdated === 0 && props.loading === true && !thisFirewall) {
+    return <CircleProgress />;
+  }
+
+  if (props.error.read) {
     return (
-      <React.Fragment>
-        <Switch>
-          <Route exact path={`${path}/rules`} component={FirewallRules} />
-          <Route exact path={`${path}/linodes`} component={FirewallLinodes} />
-          <Route component={FirewallRules} />
-        </Switch>
-      </React.Fragment>
+      <ErrorState errorText="There was a problem retrieving your Firewall. Please try again." />
     );
   }
-}
 
-export default FirewallDetail;
+  // If we've already fetched Firewalls but don't have a Firewall that
+  // corresponds to the ID in the path param, show a 404.
+  if (!thisFirewall) {
+    return <NotFound />;
+  }
+
+  const URL = props.match.url;
+
+  const tabs = [
+    {
+      title: 'Rules',
+      routeName: `${URL}/rules`
+    },
+    {
+      title: 'Linodes',
+      routeName: `${URL}/linodes`
+    }
+  ];
+
+  const handleTabChange = (
+    _: React.ChangeEvent<HTMLDivElement>,
+    value: number
+  ) => {
+    const routeName = tabs[value].routeName;
+    props.history.push(`${routeName}`);
+  };
+
+  const matches = (p: string) => {
+    return Boolean(matchPath(p, { path: props.location.pathname }));
+  };
+
+  return (
+    <React.Fragment>
+      <DocumentTitleSegment segment="Firewalls" />
+      <Box display="flex" flexDirection="row" justifyContent="space-between">
+        <Breadcrumb
+          pathname={props.location.pathname}
+          labelTitle={thisFirewall.label}
+          removeCrumbX={2}
+        />
+        {/* @todo: Insert real link when the doc is written. */}
+        <DocumentationButton href="https://www.linode.com/docs/platform" />
+      </Box>
+      <AppBar position="static" color="default" role="tablist">
+        <Tabs
+          value={tabs.findIndex(tab => matches(tab.routeName))}
+          onChange={handleTabChange}
+          indicatorColor="primary"
+          textColor="primary"
+          variant="scrollable"
+          scrollButtons="on"
+        >
+          {tabs.map(tab => (
+            <Tab
+              key={tab.title}
+              data-qa-tab={tab.title}
+              component={React.forwardRef((forwardedProps, ref) => (
+                <TabLink
+                  to={tab.routeName}
+                  title={tab.title}
+                  {...forwardedProps}
+                  ref={ref}
+                />
+              ))}
+            />
+          ))}
+        </Tabs>
+      </AppBar>
+      <Switch>
+        <Route
+          exact
+          strict
+          path={`${URL}/rules`}
+          component={FirewallRulesLanding}
+        />
+        <Route
+          exact
+          strict
+          path={`${URL}/linodes`}
+          component={FirewallLinodesLanding}
+        />
+        <Redirect to={`${URL}/rules`} />
+      </Switch>
+    </React.Fragment>
+  );
+};
+
+const enhanced = compose(withFirewalls());
+
+export default enhanced(FirewallDetail);


### PR DESCRIPTION
## Description

This PR contains the basic tabbed routing structure for Firewall Details. A lot of this boilerplate code comes from similar tabbed interfaces (I copied this one from ObjectStorageLanding).

Until https://github.com/linode/manager/pull/6108/files is merged, apply this patch to request Firewalls at the Firewall index level: https://gist.github.com/johnwcallahan/857efc9dc1d9302f36fb74593b840416


## Note to Reviewers

Please check the usual suspects:

- Loading
- Error
- 404
- Browser "Back" and "Forward" buttons
