### PR TITLE
M3-3942 Fix: Mode persistence in Linode Disk drawer

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.tsx
@@ -100,6 +100,13 @@ export class LinodeDiskDrawer extends React.Component<CombinedProps, State> {
     selectedMode: modes.EMPTY
   };
 
+  componentDidUpdate(prevProps: CombinedProps) {
+    if (!prevProps.open && this.props.open) {
+      // Drawer is opening, make sure mode is set to modes.EMPTY
+      this.setState({ selectedMode: modes.EMPTY });
+    }
+  }
+
   static getDerivedStateFromProps(props: CombinedProps, state: State) {
     return {
       hasErrorFor: getAPIErrorsFor(
@@ -121,18 +128,6 @@ export class LinodeDiskDrawer extends React.Component<CombinedProps, State> {
         return 'Resize Disk';
     }
   }
-
-  handleCloseDrawer = () => {
-    const { onClose } = this.props;
-    onClose();
-    this.setState({ selectedMode: modes.EMPTY });
-  };
-
-  handleSubmit = () => {
-    const { onSubmit } = this.props;
-    onSubmit();
-    this.setState({ selectedMode: modes.EMPTY });
-  };
 
   onLabelChange = (e: React.ChangeEvent<HTMLInputElement>) =>
     this.props.onLabelChange(e.target.value);
@@ -237,7 +232,7 @@ export class LinodeDiskDrawer extends React.Component<CombinedProps, State> {
       <Drawer
         title={LinodeDiskDrawer.getTitle(mode)}
         open={open}
-        onClose={this.handleCloseDrawer}
+        onClose={this.props.onClose}
       >
         <Grid container direction="row">
           {mode === 'create' && (
@@ -278,7 +273,7 @@ export class LinodeDiskDrawer extends React.Component<CombinedProps, State> {
           <Grid item className={classes.section}>
             <ActionsPanel>
               <Button
-                onClick={this.handleSubmit}
+                onClick={this.props.onSubmit}
                 buttonType="primary"
                 loading={submitting}
                 data-qa-disk-submit
@@ -286,7 +281,7 @@ export class LinodeDiskDrawer extends React.Component<CombinedProps, State> {
                 {submitLabelMap[mode]}
               </Button>
               <Button
-                onClick={this.handleCloseDrawer}
+                onClick={this.props.onClose}
                 buttonType="secondary"
                 className="cancel"
                 data-qa-disk-cancel

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.tsx
@@ -122,6 +122,12 @@ export class LinodeDiskDrawer extends React.Component<CombinedProps, State> {
     }
   }
 
+  handleCloseDrawer = () => {
+    const { onClose } = this.props;
+    onClose();
+    this.setState({ selectedMode: modes.EMPTY });
+  };
+
   onLabelChange = (e: React.ChangeEvent<HTMLInputElement>) =>
     this.props.onLabelChange(e.target.value);
 
@@ -211,7 +217,6 @@ export class LinodeDiskDrawer extends React.Component<CombinedProps, State> {
       mode,
       onSubmit,
       submitting,
-      onClose,
       classes,
       password,
       userSSHKeys,
@@ -227,7 +232,7 @@ export class LinodeDiskDrawer extends React.Component<CombinedProps, State> {
       <Drawer
         title={LinodeDiskDrawer.getTitle(mode)}
         open={open}
-        onClose={onClose}
+        onClose={this.handleCloseDrawer}
       >
         <Grid container direction="row">
           {mode === 'create' && (
@@ -276,7 +281,7 @@ export class LinodeDiskDrawer extends React.Component<CombinedProps, State> {
                 {submitLabelMap[mode]}
               </Button>
               <Button
-                onClick={onClose}
+                onClick={this.handleCloseDrawer}
                 buttonType="secondary"
                 className="cancel"
                 data-qa-disk-cancel

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.tsx
@@ -128,6 +128,12 @@ export class LinodeDiskDrawer extends React.Component<CombinedProps, State> {
     this.setState({ selectedMode: modes.EMPTY });
   };
 
+  handleSubmit = () => {
+    const { onSubmit } = this.props;
+    onSubmit();
+    this.setState({ selectedMode: modes.EMPTY });
+  };
+
   onLabelChange = (e: React.ChangeEvent<HTMLInputElement>) =>
     this.props.onLabelChange(e.target.value);
 
@@ -215,7 +221,6 @@ export class LinodeDiskDrawer extends React.Component<CombinedProps, State> {
     const {
       open,
       mode,
-      onSubmit,
       submitting,
       classes,
       password,
@@ -273,7 +278,7 @@ export class LinodeDiskDrawer extends React.Component<CombinedProps, State> {
           <Grid item className={classes.section}>
             <ActionsPanel>
               <Button
-                onClick={onSubmit}
+                onClick={this.handleSubmit}
                 buttonType="primary"
                 loading={submitting}
                 data-qa-disk-submit

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks.tsx
@@ -297,7 +297,7 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
         actions={this.confirmDeleteActions}
       >
         {errors && <Notice error text={errors[0].reason} />}
-        <Typography>Are you sure you want to delete "{label}"</Typography>
+        <Typography>Are you sure you want to delete {label}?</Typography>
       </ConfirmationDialog>
     );
   };


### PR DESCRIPTION
We use the same Disk drawer for all cases, disabling/hiding unneeded fields
for actions such as renaming a disk, where only one field is editable.

However, we were not resetting the "mode" of the drawer on close. This lead
to a bug:

1. Open the "Add Disk" drawer and choose "from Image"
2. Close the drawer
3. Reopen the drawer in "rename" or "resize" mode.
4. The "from image" fields are all there and editable.

This PR resets the mode to "from empty" on close.

- Fixes a small typo

NOTE: I did this on close to avoid the `prevProps.open === false && props.open === true` logic in a cDU. If the change while the drawer is closing is too jarring, I can do on open instead.