### PR TITLE
Use copy icons instead of external links on Bucket Landing

### DIFF
--- a/packages/manager/src/components/CopyTooltip/CopyTooltip.tsx
+++ b/packages/manager/src/components/CopyTooltip/CopyTooltip.tsx
@@ -1,3 +1,4 @@
+import MUIFileCopy from '@material-ui/icons/FileCopy';
 import * as classNames from 'classnames';
 import * as copy from 'copy-to-clipboard';
 import * as React from 'react';
@@ -14,6 +15,7 @@ interface Props {
   className?: string;
   standAlone?: boolean;
   ariaLabel?: string;
+  muiIcon?: boolean;
 }
 
 interface State {
@@ -92,7 +94,7 @@ class CopyTooltip extends React.Component<CombinedProps, State> {
   };
 
   render() {
-    const { classes, text, className, standAlone } = this.props;
+    const { classes, text, className, standAlone, muiIcon } = this.props;
     const { copied } = this.state;
 
     return (
@@ -111,7 +113,7 @@ class CopyTooltip extends React.Component<CombinedProps, State> {
             copied
           </span>
         )}
-        <FileCopy />
+        {muiIcon ? <MUIFileCopy /> : <FileCopy />}
       </button>
     );
   }

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.test.tsx
@@ -11,7 +11,9 @@ describe('BucketTableRow', () => {
       classes={{
         bucketNameWrapper: '',
         bucketRow: '',
-        link: ''
+        link: '',
+        hostnameWrapper: '',
+        copyTooltip: ''
       }}
       label="test-bucket-001"
       created="2019-02-24 18:46:15.516813"

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.tsx
@@ -1,5 +1,6 @@
 import { ObjectStorageBucket } from 'linode-js-sdk/lib/object-storage';
 import * as React from 'react';
+import CopyTooltip from 'src/components/CopyTooltip';
 import {
   createStyles,
   Theme,
@@ -15,7 +16,12 @@ import TableRow from 'src/components/TableRow';
 import { formatObjectStorageCluster } from 'src/utilities/formatRegion';
 import BucketActionMenu from './BucketActionMenu';
 
-type ClassNames = 'bucketNameWrapper' | 'bucketRow' | 'link';
+type ClassNames =
+  | 'bucketNameWrapper'
+  | 'bucketRow'
+  | 'link'
+  | 'hostnameWrapper'
+  | 'copyTooltip';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -27,6 +33,14 @@ const styles = (theme: Theme) =>
       flexFlow: 'row nowrap',
       alignItems: 'center',
       wordBreak: 'break-all'
+    },
+    hostnameWrapper: {
+      display: 'flex',
+      alignItems: 'center',
+      flexDirection: 'row'
+    },
+    copyTooltip: {
+      padding: 0
     },
     link: {
       '&:hover': {
@@ -62,16 +76,14 @@ export const BucketTableRow: React.StatelessComponent<CombinedProps> = props => 
                 {label}
               </Typography>
             </div>
-            <a
-              className={classes.link}
-              href={`https://${hostname}`}
-              target="_blank"
-              aria-describedby="external-site"
-              rel="noopener noreferrer"
-              data-qa-hostname
-            >
-              {hostname}
-            </a>
+            <div className={classes.hostnameWrapper}>
+              <Typography>{hostname}</Typography>
+              <CopyTooltip
+                className={classes.copyTooltip}
+                standAlone
+                text={`https://${hostname}`}
+              />
+            </div>
           </Grid>
         </Grid>
       </TableCell>

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.tsx
@@ -77,7 +77,7 @@ export const BucketTableRow: React.StatelessComponent<CombinedProps> = props => 
               </Typography>
             </div>
             <div className={classes.hostnameWrapper}>
-              <Typography>{hostname}</Typography>
+              <Typography data-qa-hostname>{hostname}</Typography>
               <CopyTooltip
                 className={classes.copyTooltip}
                 standAlone

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.tsx
@@ -40,7 +40,11 @@ const styles = (theme: Theme) =>
       flexDirection: 'row'
     },
     copyTooltip: {
-      padding: 0
+      padding: 0,
+      marginTop: 2,
+      '& :hover': {
+        color: theme.color.grey6
+      }
     },
     link: {
       '&:hover': {
@@ -81,6 +85,7 @@ export const BucketTableRow: React.StatelessComponent<CombinedProps> = props => 
               <CopyTooltip
                 className={classes.copyTooltip}
                 standAlone
+                muiIcon
                 text={`https://${hostname}`}
               />
             </div>

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -203,6 +203,7 @@ const themeDefaults: ThemeDefaults = ({ spacingOverride: spacingUnit }) => {
       grey3: '#ccc',
       grey4: '#8C929D',
       grey5: '#f5f5f5',
+      grey6: '#717885',
       white: '#fff',
       black: '#222',
       blue: primaryColors.main,


### PR DESCRIPTION
## Description

Use copy icons instead of external links on the Bucket Table. The external links could be annoying.

