### PR TITLE
Add checking for showInfo URL param

### DIFF
--- a/packages/manager/src/features/linodes/LinodesCreate/SelectAppPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectAppPanel.tsx
@@ -88,11 +88,19 @@ class SelectAppPanel extends React.PureComponent<CombinedProps> {
         matchedApp.images,
         matchedApp.user_defined_fields
       );
+
+      // If the URL also included &showInfo, open the Info drawer as well
+      const showInfo = getParamFromUrl(location.search, 'showInfo');
+      if (showInfo) {
+        this.props.openDrawer(matchedApp.label);
+      }
     }
   };
+
   componentDidMount() {
     this.clickAppIfQueryParamExists();
   }
+
   componentDidUpdate(prevProps: CombinedProps) {
     if (
       typeof prevProps.appInstances === 'undefined' &&

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -109,16 +109,13 @@ class FromAppsContent extends React.PureComponent<CombinedProps, State> {
      * to our list of master images supported by Linode and filter out the ones
      * that aren't compatible with our selected StackScript
      */
-    const compatibleImages = Object.keys(imagesData).reduce(
-      (acc, eachKey) => {
-        if (stackScriptImages.some(eachSSImage => eachSSImage === eachKey)) {
-          acc.push(imagesData[eachKey]);
-        }
+    const compatibleImages = Object.keys(imagesData).reduce((acc, eachKey) => {
+      if (stackScriptImages.some(eachSSImage => eachSSImage === eachKey)) {
+        acc.push(imagesData[eachKey]);
+      }
 
-        return acc;
-      },
-      [] as Image[]
-    );
+      return acc;
+    }, [] as Image[]);
 
     /**
      * if a UDF field comes back from the API with a "default"


### PR DESCRIPTION
@acourdavault this took 5 minutes so I just went ahead and did it.

Try http://localhost:3000/linodes/create?type=One-Click&appID=401697&showInfo, WP should be selected and the info drawer should be open.