### PR TITLE
simple search bar event tracking in GA

### DIFF
--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -16,6 +16,7 @@ import withStoreSearch, {
 } from 'src/features/Search/withStoreSearch';
 import { ApplicationState } from 'src/store';
 import { sendSearchBarUsedEvent } from 'src/utilities/ga.ts';
+import { debounce } from 'throttle-debounce';
 import styled, { StyleProps } from './SearchBar.styles';
 import SearchSuggestion from './SearchSuggestion';
 
@@ -66,6 +67,9 @@ export const selectStyles = {
   menu: (base: any) => ({ ...base, maxWidth: '100% !important' })
 };
 
+// Timeout of 1sec in debounce to avoid sending too many events to GA
+const debouncedSearchAutoEvent = debounce(1000, false, sendSearchBarUsedEvent);
+
 class SearchBar extends React.Component<CombinedProps, State> {
   selectRef = React.createRef<HTMLInputElement>();
 
@@ -86,7 +90,11 @@ class SearchBar extends React.Component<CombinedProps, State> {
 
   handleSearchChange = (searchText: string): void => {
     this.setState({ searchText });
-    // sendSearchBarUsedEvent('Search auto');
+
+    // do not trigger debounce for empty text
+    if (searchText !== '') {
+      debouncedSearchAutoEvent('Search Auto', searchText);
+    }
     this.props.search(searchText);
   };
 
@@ -127,10 +135,10 @@ class SearchBar extends React.Component<CombinedProps, State> {
       });
       // we are selecting the View all option sending the user to the landing,
       // this is like key down enter
-      sendSearchBarUsedEvent('Search Landing');
+      sendSearchBarUsedEvent('Search Landing', searchText);
       return;
     }
-    sendSearchBarUsedEvent('Search Select');
+    sendSearchBarUsedEvent('Search Select', searchText);
     history.push(item.data.path);
   };
 
@@ -143,7 +151,7 @@ class SearchBar extends React.Component<CombinedProps, State> {
           pathname: `/search`,
           search: `?query=${encodeURIComponent(searchText)}`
         });
-        sendSearchBarUsedEvent('Search Landing');
+        sendSearchBarUsedEvent('Search Landing', searchText);
         this.onClose();
       }
     }

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -15,6 +15,7 @@ import withStoreSearch, {
   SearchProps
 } from 'src/features/Search/withStoreSearch';
 import { ApplicationState } from 'src/store';
+import { sendSearchBarUsedEvent } from 'src/utilities/ga.ts';
 import styled, { StyleProps } from './SearchBar.styles';
 import SearchSuggestion from './SearchSuggestion';
 
@@ -85,6 +86,7 @@ class SearchBar extends React.Component<CombinedProps, State> {
 
   handleSearchChange = (searchText: string): void => {
     this.setState({ searchText });
+    // sendSearchBarUsedEvent('Search auto');
     this.props.search(searchText);
   };
 
@@ -123,8 +125,12 @@ class SearchBar extends React.Component<CombinedProps, State> {
         pathname: `/search`,
         search: `?query=${encodeURIComponent(searchText)}`
       });
+      // we are selecting the View all option sending the user to the landing,
+      // this is like key down enter
+      sendSearchBarUsedEvent('Search Landing');
       return;
     }
+    sendSearchBarUsedEvent('Search Select');
     history.push(item.data.path);
   };
 
@@ -137,6 +143,7 @@ class SearchBar extends React.Component<CombinedProps, State> {
           pathname: `/search`,
           search: `?query=${encodeURIComponent(searchText)}`
         });
+        sendSearchBarUsedEvent('Search Landing');
         this.onClose();
       }
     }

--- a/packages/manager/src/utilities/ga.ts
+++ b/packages/manager/src/utilities/ga.ts
@@ -332,11 +332,15 @@ export const sendObjectsQueuedForUploadEvent = (numObjects: number) => {
 };
 
 export const sendSearchBarUsedEvent = (
-  action: 'Search Landing' | 'Search Select'
+  category: 'Search Landing' | 'Search Select' | 'Search Auto',
+  searchText: string
 ) => {
+  if (searchText === '') {
+    return;
+  }
   sendEvent({
-    category: 'Search Bar',
-    action,
+    category,
+    action: searchText,
     label: window.location.pathname
   });
 };

--- a/packages/manager/src/utilities/ga.ts
+++ b/packages/manager/src/utilities/ga.ts
@@ -330,3 +330,13 @@ export const sendObjectsQueuedForUploadEvent = (numObjects: number) => {
     label: `${numObjects} objects`
   });
 };
+
+export const sendSearchBarUsedEvent = (
+  action: 'Search Landing' | 'Search Select'
+) => {
+  sendEvent({
+    category: 'Search Bar',
+    action,
+    label: window.location.pathname
+  });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -17571,12 +17571,7 @@ throat@^4.0.0:
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
   integrity sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=
 
-throttle-debounce@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-2.0.1.tgz#7307ddd6cd9acadb349132fbf6c18d78c88a5e62"
-  integrity sha512-Sr6jZBlWShsAaSXKyNXyNicOrJW/KtkDqIEwHt4wYwWA2wa/q67Luhqoujg48V8hTk60wB56tYrJJn6jc2R7VA==
-
-throttle-debounce@^2.1.0:
+throttle-debounce@^2.0.0, throttle-debounce@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-2.1.0.tgz#257e648f0a56bd9e54fe0f132c4ab8611df4e1d5"
   integrity sha512-AOvyNahXQuU7NN+VVvOOX+uW6FPaWdAOdRP5HfwYxAfCzXTFKRMoIMk+n+po318+ktcChx+F1Dd91G3YHeMKyg==


### PR DESCRIPTION
## Description

Adding Event tracking on GA:
- search + select, or go to landing page of search event.
- pathname  (to know the context of the search)

Goal is to be able to track the usage of this feature.

I decided so far not to track the searched text, or time of search, Both could be useful informations though

## Type of Change
- Non breaking change ('update', 'change')