### PR TITLE
M3-3970: Implement new Redux shape for Configs

### DIFF
--- a/packages/manager/src/factories/config.ts
+++ b/packages/manager/src/factories/config.ts
@@ -1,0 +1,33 @@
+import * as Factory from 'factory.ts';
+import { Config } from 'linode-js-sdk/lib/linodes/types';
+
+export const configFactory = Factory.Sync.makeFactory<Config>({
+  id: Factory.each(id => id),
+  label: Factory.each(id => `disk-${id}`),
+  created: '2020-01-01',
+  updated: '2020-01-01',
+  comments: '',
+  devices: {
+    sda: null,
+    sdb: null,
+    sdc: null,
+    sdd: null,
+    sde: null,
+    sdf: null,
+    sdg: null,
+    sdh: null
+  },
+  helpers: {
+    distro: true,
+    network: true,
+    modules_dep: true,
+    devtmpfs_automount: true,
+    updatedb_disabled: true
+  },
+  initrd: null,
+  kernel: 'linode/grub2',
+  memory_limit: 0,
+  root_device: 'sda',
+  run_level: 'default',
+  virt_mode: 'paravirt'
+});

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -908,7 +908,7 @@ const enhanced = compose<CombinedProps, Props>(
     const { itemsById } = state.__resources.volumes;
 
     const config = linodeConfigId
-      ? state.__resources.linodeConfigs.itemsById[linodeConfigId]
+      ? state.__resources.linodeConfigs[linodeId].itemsById[linodeConfigId]
       : undefined;
 
     const volumes = Object.values(itemsById).reduce(

--- a/packages/manager/src/features/linodes/LinodesDetail/maybeRenderError.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/maybeRenderError.tsx
@@ -37,7 +37,7 @@ const collectErrors: MapState<InnerProps, OuterProps> = (
       path(['error', 'read'], linodes) ||
       types.error ||
       notifications.error ||
-      path(['error', 'read'], linodeConfigs) ||
+      linodeConfigs[linodeId]?.error?.read ||
       linodeDisks[linodeId]?.error?.read
   };
 };

--- a/packages/manager/src/features/linodes/LinodesDetail/maybeRenderLoading.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/maybeRenderLoading.tsx
@@ -39,7 +39,7 @@ const collectLoadingState: MapState<InnerProps, OuterProps> = (
       isLoading(types) ||
       isLoading(volumes) ||
       isLoading(notifications) ||
-      isLoading(linodeConfigs) ||
+      (linodeConfigs[linodeId] && isLoading(linodeConfigs[linodeId])) ||
       (linodeDisks[linodeId] && isLoading(linodeDisks[linodeId]))
   };
 };

--- a/packages/manager/src/store/linodes/config/config.reducer.test.ts
+++ b/packages/manager/src/store/linodes/config/config.reducer.test.ts
@@ -1,0 +1,209 @@
+import { configFactory } from 'src/factories/config';
+import { deleteLinodeActions } from '../linodes.actions';
+import {
+  createLinodeConfigActions,
+  deleteLinodeConfigActions,
+  getAllLinodeConfigsActions,
+  getLinodeConfigActions,
+  updateLinodeConfigActions
+} from './config.actions';
+import reducer, { State } from './config.reducer';
+import { Entity } from './config.types';
+
+describe('config reducer', () => {
+  const defaultState: State = {};
+  const mockConfig1 = {
+    ...configFactory.build({
+      id: 2,
+      label: 'test-config1'
+    }),
+    linode_id: 1
+  };
+  const mockConfig2 = {
+    ...configFactory.build({
+      id: 3,
+      label: 'test-config2'
+    }),
+    linode_id: 1
+  };
+
+  describe('getLinodeConfigActions', () => {
+    it('should set loading to `true` and error to `undefined` when starting the request', () => {
+      const newState = reducer(
+        defaultState,
+        getLinodeConfigActions.started({
+          linodeId: mockConfig1.linode_id,
+          configId: mockConfig1.id
+        })
+      );
+      expect(newState).toHaveProperty(String(mockConfig1.linode_id));
+      expect(newState[mockConfig1.linode_id]).toHaveProperty('loading', true);
+      expect(newState[mockConfig1.linode_id]).toHaveProperty(
+        'error',
+        undefined
+      );
+    });
+    it('should load data when the request has been completed', () => {
+      const newState = reducer(
+        defaultState,
+        getLinodeConfigActions.done({
+          params: { linodeId: mockConfig1.linode_id, configId: mockConfig1.id },
+          result: mockConfig1
+        })
+      );
+      verifyConfig(newState, mockConfig1);
+    });
+  });
+
+  describe('getAllLinodeConfigsActions', () => {
+    it('should set loading to `true` and error to `undefined` when the request is started', () => {
+      const newState = reducer(
+        defaultState,
+        getAllLinodeConfigsActions.started({
+          linodeId: mockConfig1.linode_id
+        })
+      );
+      expect(newState).toHaveProperty(String(mockConfig1.linode_id));
+      expect(newState[mockConfig1.linode_id]).toHaveProperty('loading', true);
+      expect(newState[mockConfig1.linode_id]).toHaveProperty(
+        'error',
+        undefined
+      );
+    });
+    it('should load data when the request has been completed', () => {
+      const newState = reducer(
+        defaultState,
+        getAllLinodeConfigsActions.done({
+          params: { linodeId: mockConfig1.linode_id },
+          result: [mockConfig1, mockConfig2]
+        })
+      );
+      verifyConfig(newState, mockConfig1);
+      verifyConfig(newState, mockConfig2);
+      expect(newState[mockConfig1.linode_id].items.length).toBe(2);
+    });
+    it('sets error.read when the request fails', () => {
+      const errorMessage = 'An error occurred.';
+      const newState = reducer(
+        defaultState,
+        getAllLinodeConfigsActions.failed({
+          params: { linodeId: mockConfig1.linode_id },
+          error: [{ reason: errorMessage }]
+        })
+      );
+      expect(newState[mockConfig1.linode_id].error).toHaveProperty('read');
+      expect(newState[mockConfig1.linode_id].loading).toBe(false);
+      expect(newState[mockConfig1.linode_id].error?.read?.[0].reason).toBe(
+        errorMessage
+      );
+    });
+  });
+
+  describe('createLinodeConfigActions', () => {
+    it('loads the config when the request is complete', () => {
+      const newState = reducer(
+        defaultState,
+        createLinodeConfigActions.done({
+          params: {
+            linodeId: 1,
+            label: mockConfig1.label,
+            devices: mockConfig1.devices,
+            root_device: mockConfig1.root_device,
+            helpers: mockConfig1.helpers
+          },
+          result: mockConfig1
+        })
+      );
+      verifyConfig(newState, mockConfig1);
+    });
+  });
+
+  describe('updateLinodeConfigActions', () => {
+    it('updates the config when the request is complete', () => {
+      const newState = reducer(
+        defaultState,
+        updateLinodeConfigActions.done({
+          params: {
+            linodeId: mockConfig1.linode_id,
+            configId: mockConfig1.id,
+            label: mockConfig1.label
+          },
+          result: mockConfig1
+        })
+      );
+      verifyConfig(newState, mockConfig1);
+    });
+  });
+
+  describe('deleteLinodeConfigActions', () => {
+    const state: State = {
+      [mockConfig1.linode_id]: {
+        items: [String(mockConfig1.id)],
+        itemsById: { [mockConfig1.id]: mockConfig1 },
+        lastUpdated: 1,
+        loading: false
+      },
+      [mockConfig2.linode_id]: {
+        items: [String(mockConfig2.id)],
+        itemsById: { [mockConfig2.id]: mockConfig2 },
+        lastUpdated: 1,
+        loading: false
+      }
+    };
+
+    it('sets error.delete to `undefined` when the request is started', () => {
+      const newState = reducer(
+        state,
+        deleteLinodeConfigActions.started({
+          linodeId: mockConfig1.linode_id,
+          configId: mockConfig1.id
+        })
+      );
+      expect(newState[mockConfig1.linode_id].error?.delete).toBeUndefined();
+    });
+    it('removes the config when the request is complete', () => {
+      const newState = reducer(
+        state,
+        deleteLinodeConfigActions.done({
+          params: {
+            linodeId: mockConfig1.linode_id,
+            configId: mockConfig1.id
+          },
+          result: {}
+        })
+      );
+      expect(
+        newState[mockConfig1.linode_id].itemsById[mockConfig1.id]
+      ).toBeUndefined();
+      expect(newState[mockConfig1.linode_id].items).toHaveLength(1);
+    });
+  });
+
+  describe('deleteLinodeActions', () => {
+    const state = reducer(
+      defaultState,
+      createLinodeConfigActions.done({
+        params: {
+          linodeId: mockConfig1.linode_id
+        } as any,
+        result: mockConfig1
+      })
+    );
+    it('removes the linodeId from the state when the request is complete', () => {
+      const newState = reducer(
+        state,
+        deleteLinodeActions.done({
+          params: { linodeId: mockConfig1.linode_id },
+          result: {}
+        })
+      );
+      expect(newState[mockConfig1.linode_id]).toBeUndefined();
+    });
+  });
+});
+
+const verifyConfig = (state: State, config: Entity) => {
+  expect(state[config.linode_id].loading).toBe(false);
+  expect(state[config.linode_id].items.includes(String(config.id))).toBe(true);
+  expect(state[config.linode_id].itemsById[config.id]).toEqual(config);
+};

--- a/packages/manager/src/store/linodes/config/config.selectors.ts
+++ b/packages/manager/src/store/linodes/config/config.selectors.ts
@@ -1,6 +1,10 @@
 import { State } from './config.reducer';
 
-export const getLinodeConfigsForLinode = (
-  { itemsById }: State,
-  linodeId: number
-) => Object.values(itemsById).filter(({ linode_id }) => linode_id === linodeId);
+export const getLinodeConfigsForLinode = (state: State, linodeId: number) => {
+  // Safe access of `itemsById` is necessary here, even though TypeScript will
+  // not complain about omitting the "?". The reason is that `state[linodeId]`
+  // could still be `undefined`.
+  const itemsById = state[linodeId]?.itemsById ?? {};
+
+  return Object.values(itemsById);
+};

--- a/packages/manager/src/store/store.helpers.ts
+++ b/packages/manager/src/store/store.helpers.ts
@@ -167,7 +167,7 @@ export const ensureInitializedNestedState = (
   id: number
 ) => {
   if (!state[id]) {
-    state[id] = createDefaultState();
+    state[id] = createDefaultState({ error: {} });
   }
   return state;
 };


### PR DESCRIPTION
## Description

This implements the new Redux shape for configs, following https://github.com/linode/manager/pull/6073.

There is _a lot_ of copy/paste from the disk reducer and tests. I don’t love this, but I thought it was better than trying to use one reducer for multiple entity types. I’m open to suggestions if you see something that I don’t.

## Note to Reviewers

To test, please thoroughly check everything to do with configs:

- Linode creation/deletion/cloning/resizing/rescue/migrating
- Config creation/editing/deletion/cloning
- Since disks are related, check those too.
- etc…

Please monitor Redux Dev Tools, operate multiple tabs, and just try to break it in general.
