### PR TITLE
Hide duration for host_reboot events

### DIFF
--- a/packages/linode-js-sdk/src/account/types.ts
+++ b/packages/linode-js-sdk/src/account/types.ts
@@ -194,6 +194,7 @@ export type EventAction =
   | 'firewall_disable'
   | 'firewall_enable'
   | 'firewall_update'
+  | 'host_reboot'
   | 'image_update'
   | 'image_delete'
   | 'lassie_reboot'

--- a/packages/manager/src/features/Events/EventRow.tsx
+++ b/packages/manager/src/features/Events/EventRow.tsx
@@ -140,9 +140,12 @@ export const Row: React.StatelessComponent<RowProps> = props => {
         </Typography>
       </TableCell>
       <TableCell parentColumn="Duration">
-        <Typography variant="body1">{`${formatEventSeconds(
-          duration
-        )}`}</Typography>
+        <Typography variant="body1">
+          {/* There is currently an API bug where host_reboot event durations are
+          not reported correctly. This patch simply hides the duration. @todo
+          remove this // check when the API bug is fixed. */}
+          {action === 'host_reboot' ? '' : formatEventSeconds(duration)}
+        </Typography>
       </TableCell>
       <TableCell parentColumn={'When'} data-qa-event-created-cell compact>
         <DateTimeDisplay value={created} />

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/ActivityRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/ActivityRow.tsx
@@ -36,7 +36,12 @@ export const ActivityRow: React.StatelessComponent<CombinedProps> = props => {
   const { classes, event } = props;
 
   const message = eventMessageGenerator(event);
-  const duration = formatEventSeconds(event.duration);
+
+  // There is currently an API bug where host_reboot event durations are not
+  // reported correctly. This patch simply hides the duration. @todo remove this
+  // check when the API bug is fixed.
+  const duration =
+    event.action === 'host_reboot' ? '' : formatEventSeconds(event.duration);
 
   if (!message) {
     return null;


### PR DESCRIPTION
## Description

There is currently an API bug where `host_reboot` event durations are not reported correctly. This patch hides the duration for these events until the API bug is fixed.

