### PR TITLE
M3-3685 Display invalid SS errors on Linode rebuild

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallRow.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallRow.tsx
@@ -7,7 +7,6 @@ import { APIError } from 'linode-js-sdk/lib/types';
 import { take } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
-import { devices as mockDevices } from 'src/__data__/firewallDevices';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import ActionMenu, { ActionHandlers } from './FirewallActionMenu';

--- a/packages/manager/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/packages/manager/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -77,10 +77,10 @@ const styles = (theme: Theme) =>
     },
     inner: {
       padding: theme.spacing(2),
-      paddingTop: 0,
+      paddingTop: theme.spacing(),
       [theme.breakpoints.up('sm')]: {
         padding: theme.spacing(3),
-        paddingTop: 0
+        paddingTop: theme.spacing()
       }
     },
     header: {}
@@ -211,7 +211,9 @@ class SelectStackScriptPanel extends React.Component<CombinedProps, State> {
     return (
       <Paper className={classes.panel}>
         <div className={classes.inner}>
-          {error && <Notice text={error} error />}
+          {error && (
+            <Notice text={error} error spacingTop={8} spacingBottom={0} />
+          )}
           {stackScriptError && (
             <Typography variant="body2">
               An error occurred while loading the selected StackScript.


### PR DESCRIPTION
We noticed that selecting an invalid stackscript when rebuilding didn't
result in an error that the user can see. It turns out what was wrong
was that the field returned in that case was script, whereas our
Formik field was listening for stackscript_id.

I also tweaked the styles of SelectStackscriptPanel so that the
resulting error wasn't stuck to the top of the Paper.

## Note to Reviewers
Steps to reproduce: 

1. Go to the /rebuild tab in LinodesDetail
2. Select a crummy stackscript to rebuild from (LinodeApps/Wordpress will do the job)
3. Submit the form (with devtools open)
4. Observe: the request returns a 404, but nothing is displayed to the user.