### PR TITLE
Respond to linode_config events

### DIFF
--- a/packages/manager/src/store/index.ts
+++ b/packages/manager/src/store/index.ts
@@ -69,6 +69,7 @@ import linodeCreateReducer, {
   defaultState as linodeCreateDefaultState,
   State as LinodeCreateState
 } from 'src/store/linodeCreate/linodeCreate.reducer';
+import linodeConfigEvents from 'src/store/linodes/config/config.events';
 import linodeConfigs, {
   defaultState as defaultLinodeConfigsState,
   State as LinodeConfigsState
@@ -304,7 +305,8 @@ const enhancers = compose(
       nodeBalancerEvents,
       nodeBalancerConfigEvents,
       volumeEvents,
-      diskEvents
+      diskEvents,
+      linodeConfigEvents
     )
   ),
   reduxDevTools ? reduxDevTools() : (f: any) => f

--- a/packages/manager/src/store/linodes/config/config.events.ts
+++ b/packages/manager/src/store/linodes/config/config.events.ts
@@ -1,0 +1,39 @@
+import { EventStatus } from 'linode-js-sdk/lib/account';
+import { Dispatch } from 'redux';
+import { EventHandler } from 'src/store/types';
+import { getAllLinodeConfigs } from './config.requests';
+
+const configEventHandler: EventHandler = (event, dispatch) => {
+  const { action, entity, status } = event;
+  const { id } = entity;
+
+  switch (action) {
+    case 'linode_config_create':
+    case 'linode_config_delete':
+    case 'linode_config_update':
+      return handleConfigChange(dispatch, status, id);
+
+    default:
+      return;
+  }
+};
+
+export default configEventHandler;
+
+const handleConfigChange = (
+  dispatch: Dispatch<any>,
+  status: EventStatus,
+  linodeId: number
+) => {
+  switch (status) {
+    case 'finished':
+    case 'notification':
+    case 'failed':
+      return dispatch(getAllLinodeConfigs({ linodeId }));
+
+    case 'scheduled':
+    case 'started':
+    default:
+      return;
+  }
+};


### PR DESCRIPTION
This adds handling for linode_config events, as suggested by @Jskobos in #6130. I reused the pattern we use for [disks](https://github.com/linode/manager/blob/develop/packages/manager/src/store/linodes/disk/disk.events.ts).

Now, when we receive `linode_config_create`, `linode_config_update`, or `linode_config_delete` events, we re-request that Linode’s configs to keep the store up-to-date.

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Note to Reviewers

**To test:** have two browser windows opened, both on the Disks/Configs tab on a Linode. Create/Edit/Delete configs in one window. Changes should be reflected in the other window (after the next polling interval).
