### PR TITLE
Hold our horses

### DIFF
--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -102,7 +102,7 @@ export class CreateCluster extends React.Component<CombinedProps, State> {
         /**
          * 1. Convert versions to Items
          * 2. Sort descending (so newest version is at top)
-         * 3. Pre-select the newest version
+         * // 3. Pre-select the newest version <--- do this someday, but not now
          */
         const versionOptions = response.data
           .map(eachVersion => ({
@@ -111,8 +111,8 @@ export class CreateCluster extends React.Component<CombinedProps, State> {
           }))
           .sort(sortByLabelDescending);
         this.setState({
-          versionOptions,
-          version: versionOptions[0]
+          versionOptions
+          // version: versionOptions[0]
         });
       })
       .catch(error => {


### PR DESCRIPTION
At UX review for LKE yesterday, Andrew expressed that we don't want to select a k8s version by default when creating a cluster. The UX isn't ideal (it's an additional 2 clicks) but there are technical reasons for it, so disabling this logic for the time being.