### PR TITLE
Rename isProduction constant

### DIFF
--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -4,7 +4,7 @@ import { ObjectStorageClusterID } from 'linode-js-sdk/lib/object-storage';
 const PRODUCTION = 'production';
 
 /** native to webpack build */
-export const isProduction = process.env.NODE_ENV === PRODUCTION;
+export const isProductionBuild = process.env.NODE_ENV === PRODUCTION;
 
 /** required for the app to function */
 export const APP_ROOT =
@@ -53,7 +53,8 @@ export const GTM_ID = process.env.REACT_APP_GTM_ID;
 export const ACCESS_TOKEN = process.env.REACT_APP_ACCESS_TOKEN;
 
 export const LOG_PERFORMANCE_METRICS =
-  !isProduction && process.env.REACT_APP_LOG_PERFORMANCE_METRICS === 'true';
+  !isProductionBuild &&
+  process.env.REACT_APP_LOG_PERFORMANCE_METRICS === 'true';
 
 // Features
 export const isObjectStorageEnabledForEnvironment =

--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -1,6 +1,6 @@
 import { Event } from 'linode-js-sdk/lib/account';
 import { path } from 'ramda';
-import { isProduction } from 'src/constants';
+import { isProductionBuild } from 'src/constants';
 import { reportException } from 'src/exceptionReporting';
 
 type EventMessageCreator = (e: Event) => string;
@@ -641,7 +641,7 @@ export default (e: Event): string => {
   /** we couldn't find the event in our list above */
   if (!fn) {
     /** log unknown events to the console */
-    if (!isProduction) {
+    if (!isProductionBuild) {
       /* tslint:disable */
       console.error('============================================');
       console.error('Unknown API Event Received');

--- a/packages/manager/src/index.tsx
+++ b/packages/manager/src/index.tsx
@@ -13,7 +13,7 @@ import AuthenticationWrapper from 'src/components/AuthenticationWrapper';
 import CookieWarning from 'src/components/CookieWarning';
 import DefaultLoader from 'src/components/DefaultLoader';
 import SnackBar from 'src/components/SnackBar';
-import { GA_ID, GTM_ID, isProduction } from 'src/constants';
+import { GA_ID, GTM_ID, isProductionBuild } from 'src/constants';
 import 'src/exceptionReporting';
 import LoginAsCustomerCallback from 'src/layouts/LoginAsCustomerCallback';
 import Logout from 'src/layouts/Logout';
@@ -43,7 +43,7 @@ const Cancel = DefaultLoader({
 /*
  * Initialize Analytic and Google Tag Manager
  */
-initAnalytics(isProduction, GA_ID);
+initAnalytics(isProductionBuild, GA_ID);
 
 initTagManager(GTM_ID);
 
@@ -121,6 +121,6 @@ ReactDOM.render(
   document.getElementById('root') as HTMLElement
 );
 
-if (module.hot && !isProduction) {
+if (module.hot && !isProductionBuild) {
   module.hot.accept();
 }


### PR DESCRIPTION
## Description

This changes the name of the `isProduction` variable in `constants.ts` to `isProductionBuild`.

This has tripped us up more than once, because the name leads you to believe that it will be `true` only in the production environment. In reality, this value is `true` across all builds that aren’t your local dev server.

BTW, the NODE_ENV is set [here](https://github.com/linode/manager/blob/develop/packages/manager/scripts/build.js#L5).

