### PR TITLE
M3-4018 Fix uptime calculation in Longview

### DIFF
--- a/packages/manager/src/utilities/formatUptime.test.ts
+++ b/packages/manager/src/utilities/formatUptime.test.ts
@@ -1,3 +1,4 @@
+import * as moment from 'moment';
 import { formatUptime } from './formatUptime';
 
 describe('Formatting uptime', () => {
@@ -27,5 +28,15 @@ describe('Formatting uptime', () => {
     expect(
       formatUptime(60 * 60 * 24 * 9 + 60 * 60 * 19 + 60 * 45 + 45)
     ).toMatch('9d 19h 45m');
+  });
+
+  it('should handle durations longer than a month', () => {
+    expect(
+      formatUptime(
+        moment
+          .duration({ years: 1, months: 2, days: 12, hours: 10, minutes: 15 })
+          .asSeconds()
+      )
+    ).toMatch('438d 10h 15m');
   });
 });

--- a/packages/manager/src/utilities/formatUptime.test.ts
+++ b/packages/manager/src/utilities/formatUptime.test.ts
@@ -39,4 +39,21 @@ describe('Formatting uptime', () => {
       )
     ).toMatch('438d 10h 15m');
   });
+
+  it('should ignore seconds for longer durations', () => {
+    expect(
+      formatUptime(
+        moment
+          .duration({
+            years: 1,
+            months: 2,
+            days: 12,
+            hours: 8,
+            minutes: 15,
+            seconds: 54
+          })
+          .asSeconds()
+      )
+    ).toMatch('438d 8h 15m');
+  });
 });

--- a/packages/manager/src/utilities/formatUptime.ts
+++ b/packages/manager/src/utilities/formatUptime.ts
@@ -6,8 +6,9 @@ export const formatUptime = (uptime: number) => {
    * seconds.
    */
   const duration = moment.duration(uptime, 'seconds');
-  if (duration.days() > 0) {
-    return `${duration.days()}d ${duration.hours()}h ${duration.minutes()}m`;
+  const days = Math.floor(duration.asDays());
+  if (days > 0) {
+    return `${days}d ${duration.hours()}h ${duration.minutes()}m`;
   } else if (duration.hours() > 0) {
     return `${duration.hours()}h ${duration.minutes()}m`;
   } else if (duration.minutes() > 0) {


### PR DESCRIPTION
## Description

Longview uptime is inaccurate for servers up longer than 30 days. To test the fix, please compare clients of various ages/uptimes against Classic. The displays should match.