### PR TITLE
M3-3928 Add: Firewall linode tab

### DIFF
--- a/packages/linode-js-sdk/src/firewalls/types.ts
+++ b/packages/linode-js-sdk/src/firewalls/types.ts
@@ -37,6 +37,8 @@ export interface FirewallDeviceEntity {
 
 export interface FirewallDevice {
   id: number;
+  created: string;
+  updated: string;
   entity: FirewallDeviceEntity;
 }
 

--- a/packages/manager/src/__data__/firewallDevices.ts
+++ b/packages/manager/src/__data__/firewallDevices.ts
@@ -2,6 +2,8 @@ import { FirewallDevice } from 'linode-js-sdk/lib/firewalls';
 
 export const device: FirewallDevice = {
   id: 1,
+  created: '2020-01-01',
+  updated: '2020-01-01',
   entity: {
     id: 16621754,
     url: 'v4/linode/instances/16621754',
@@ -12,6 +14,8 @@ export const device: FirewallDevice = {
 
 export const device2: FirewallDevice = {
   id: 2,
+  created: '2020-01-01',
+  updated: '2020-01-01',
   entity: {
     id: 15922741,
     url: 'v4/linode/instances/15922741',

--- a/packages/manager/src/components/TableContentWrapper.tsx/TableContentWrapper.test.tsx
+++ b/packages/manager/src/components/TableContentWrapper.tsx/TableContentWrapper.test.tsx
@@ -1,0 +1,94 @@
+import { cleanup, render } from '@testing-library/react';
+
+import * as React from 'react';
+import { wrapWithTableBody } from 'src/utilities/testHelpers';
+import TableContentWrapper from './TableContentWrapper';
+
+const children = [
+  <tr key={1}>
+    <td>A row!</td>
+  </tr>,
+  <tr key={2}>
+    <td>Another row!</td>
+  </tr>
+];
+afterEach(cleanup);
+
+describe('TableContentWrapper component', () => {
+  it('should render its children if everything is kosher', () => {
+    const kosherProps = {
+      lastUpdated: 100,
+      loading: false,
+      length: 1,
+      children
+    };
+    const { getByText } = render(
+      wrapWithTableBody(<TableContentWrapper {...kosherProps} />)
+    );
+    getByText('A row!');
+    getByText('Another row!');
+  });
+
+  it('should render a loading spinner if loading is true', () => {
+    const loadingProps = {
+      lastUpdated: 10,
+      loading: true,
+      length: 100,
+      children
+    };
+    const { getByTestId, queryByText } = render(
+      wrapWithTableBody(<TableContentWrapper {...loadingProps} />)
+    );
+
+    getByTestId('table-row-loading');
+    expect(queryByText('A row!')).not.toBeInTheDocument();
+  });
+
+  it('should render an error row if an error is provided', () => {
+    const mockError = [{ reason: 'API is down' }];
+    const errorProps = {
+      loading: false,
+      lastUpdated: 0,
+      length: 0,
+      error: mockError,
+      children
+    };
+
+    const { getByTestId, getByText, queryByText } = render(
+      wrapWithTableBody(<TableContentWrapper {...errorProps} />)
+    );
+    getByTestId('table-row-error');
+    getByText('API is down');
+    expect(queryByText('A row!')).not.toBeInTheDocument();
+  });
+
+  it("should render an empty state if there's no data", () => {
+    const emptyProps = {
+      loading: false,
+      lastUpdated: 10,
+      length: 0,
+      children
+    };
+
+    const { getByText, queryByText } = render(
+      wrapWithTableBody(<TableContentWrapper {...emptyProps} />)
+    );
+    getByText(/no data to display/i);
+    expect(queryByText('A row!')).not.toBeInTheDocument();
+  });
+
+  it('should use the emptyMessage if provided', () => {
+    const emptyProps = {
+      loading: false,
+      lastUpdated: 10,
+      length: 0,
+      emptyMessage: 'Nothing to see here',
+      children
+    };
+
+    const { getByText } = render(
+      wrapWithTableBody(<TableContentWrapper {...emptyProps} />)
+    );
+    getByText(emptyProps.emptyMessage);
+  });
+});

--- a/packages/manager/src/components/TableContentWrapper.tsx/TableContentWrapper.tsx
+++ b/packages/manager/src/components/TableContentWrapper.tsx/TableContentWrapper.tsx
@@ -1,0 +1,41 @@
+import { APIError } from 'linode-js-sdk/lib/types';
+import * as React from 'react';
+import { compose } from 'recompose';
+
+import TableRowEmpty from 'src/components/TableRowEmptyState';
+import TableRowError from 'src/components/TableRowError';
+import TableRowLoading from 'src/components/TableRowLoading';
+
+interface Props {
+  length: number;
+  loading: boolean;
+  lastUpdated: number;
+  error?: APIError[];
+}
+
+type CombinedProps = Props;
+
+const TableContentWrapper: React.FC<CombinedProps> = props => {
+  const { length, loading, error, lastUpdated } = props;
+
+  if (loading && lastUpdated === 0) {
+    return <TableRowLoading colSpan={6} firstColWidth={25} oneLine />;
+  }
+
+  /**
+   * only display error if we don't already have data
+   */
+  if (error && lastUpdated === 0) {
+    return <TableRowError colSpan={6} message={error[0].reason} />;
+  }
+
+  if (lastUpdated !== 0 && length === 0) {
+    return (
+      <TableRowEmpty colSpan={6} message="You do not have any Firewalls" />
+    );
+  }
+
+  return <React.Fragment>{props.children}</React.Fragment>;
+};
+
+export default compose<CombinedProps, Props>(React.memo)(TableContentWrapper);

--- a/packages/manager/src/components/TableContentWrapper.tsx/TableContentWrapper.tsx
+++ b/packages/manager/src/components/TableContentWrapper.tsx/TableContentWrapper.tsx
@@ -19,14 +19,11 @@ type CombinedProps = Props;
 const TableContentWrapper: React.FC<CombinedProps> = props => {
   const { length, loading, emptyMessage, error, lastUpdated } = props;
 
-  if (loading && lastUpdated === 0) {
+  if (loading) {
     return <TableRowLoading colSpan={6} firstColWidth={25} oneLine />;
   }
 
-  /**
-   * only display error if we don't already have data
-   */
-  if (error && lastUpdated === 0) {
+  if (error) {
     return <TableRowError colSpan={6} message={error[0].reason} />;
   }
 

--- a/packages/manager/src/components/TableContentWrapper.tsx/TableContentWrapper.tsx
+++ b/packages/manager/src/components/TableContentWrapper.tsx/TableContentWrapper.tsx
@@ -11,12 +11,13 @@ interface Props {
   loading: boolean;
   lastUpdated: number;
   error?: APIError[];
+  emptyMessage?: string;
 }
 
 type CombinedProps = Props;
 
 const TableContentWrapper: React.FC<CombinedProps> = props => {
-  const { length, loading, error, lastUpdated } = props;
+  const { length, loading, emptyMessage, error, lastUpdated } = props;
 
   if (loading && lastUpdated === 0) {
     return <TableRowLoading colSpan={6} firstColWidth={25} oneLine />;
@@ -31,7 +32,10 @@ const TableContentWrapper: React.FC<CombinedProps> = props => {
 
   if (lastUpdated !== 0 && length === 0) {
     return (
-      <TableRowEmpty colSpan={6} message="You do not have any Firewalls" />
+      <TableRowEmpty
+        colSpan={6}
+        message={emptyMessage ?? 'No data to display.'}
+      />
     );
   }
 

--- a/packages/manager/src/components/TableContentWrapper.tsx/index.tsx
+++ b/packages/manager/src/components/TableContentWrapper.tsx/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './TableContentWrapper';

--- a/packages/manager/src/factories/firewalls.ts
+++ b/packages/manager/src/factories/firewalls.ts
@@ -30,6 +30,8 @@ export const firewallFactory = Factory.Sync.makeFactory<Firewall>({
 
 export const firewallDeviceFactory = Factory.Sync.makeFactory<FirewallDevice>({
   id: Factory.each(i => i),
+  created: '2020-01-01',
+  updated: '2020-01-01',
   entity: {
     type: 'linode' as FirewallDeviceEntityType,
     label: Factory.each(i => `factory-device-${i}`) as any,

--- a/packages/manager/src/factories/firewalls.ts
+++ b/packages/manager/src/factories/firewalls.ts
@@ -1,6 +1,8 @@
 import * as Factory from 'factory.ts';
 import {
   Firewall,
+  FirewallDevice,
+  FirewallDeviceEntityType,
   FirewallRules,
   FirewallRuleType
 } from 'linode-js-sdk/lib/firewalls/types';
@@ -24,4 +26,14 @@ export const firewallFactory = Factory.Sync.makeFactory<Firewall>({
   updated_dt: '2020-01-01 00:00:00',
   tags: [],
   status: 'enabled'
+});
+
+export const firewallDeviceFactory = Factory.Sync.makeFactory<FirewallDevice>({
+  id: Factory.each(i => i),
+  entity: {
+    type: 'linode' as FirewallDeviceEntityType,
+    label: Factory.each(i => `factory-device-${i}`) as any,
+    id: Factory.each(i => i) as any,
+    url: '/linodes/1'
+  }
 });

--- a/packages/manager/src/features/Firewalls/FirewallDetail/FirewallDeviceActionMenu.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/FirewallDeviceActionMenu.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+
+import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
+
+export interface ActionHandlers {
+  triggerRemoveDevice: (deviceID: number, label: string) => void;
+}
+
+export interface Props extends ActionHandlers {
+  deviceID: number;
+  deviceLabel: string;
+}
+
+type CombinedProps = Props;
+
+const FirewallDeviceActionMenu: React.FC<CombinedProps> = props => {
+  const { deviceID, deviceLabel, triggerRemoveDevice } = props;
+
+  const createActions = () => {
+    return (closeMenu: Function): Action[] => [
+      {
+        title: 'Remove',
+        onClick: () => {
+          triggerRemoveDevice(deviceID, deviceLabel);
+          closeMenu();
+        }
+      }
+    ];
+  };
+
+  return (
+    <ActionMenu
+      createActions={createActions()}
+      ariaLabel={`Action menu for Firewall Device ${deviceLabel}`}
+    />
+  );
+};
+
+export default React.memo(FirewallDeviceActionMenu);

--- a/packages/manager/src/features/Firewalls/FirewallDetail/FirewallDeviceRow.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/FirewallDeviceRow.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { compose } from 'recompose';
+import TableCell from 'src/components/TableCell';
+import TableRow from 'src/components/TableRow';
+import ActionMenu, { Props as ActionProps } from './FirewallDeviceActionMenu';
+
+export type CombinedProps = ActionProps;
+
+export const FirewallDeviceRow: React.FC<CombinedProps> = props => {
+  const { deviceLabel, deviceID } = props;
+
+  return (
+    <TableRow
+      rowLink={`/linodes/${deviceID}`}
+      data-testid={`firewall-device-row-${deviceID}`}
+    >
+      <TableCell>{deviceLabel}</TableCell>
+      <TableCell>
+        <ActionMenu {...props} />
+      </TableCell>
+    </TableRow>
+  );
+};
+
+export default compose<CombinedProps, ActionProps>(React.memo)(
+  FirewallDeviceRow
+);

--- a/packages/manager/src/features/Firewalls/FirewallDetail/FirewallDevicesTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/FirewallDevicesTable.tsx
@@ -12,6 +12,7 @@ import PaginationFooter from 'src/components/PaginationFooter';
 import Table from 'src/components/Table';
 import TableContentWrapper from 'src/components/TableContentWrapper.tsx';
 import TableSortCell from 'src/components/TableSortCell';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import FirewallDeviceRow from './FirewallDeviceRow';
 
 interface Props {
@@ -26,6 +27,12 @@ type CombinedProps = Props;
 
 const FirewallTable: React.FC<CombinedProps> = props => {
   const { devices, error, lastUpdated, loading, triggerRemoveDevice } = props;
+
+  const _error =
+    error && lastUpdated === 0
+      ? // @todo change to Devices or make dynamic when NBs are possible as Devices
+        getAPIErrorOrDefault(error, 'Unable to retrieve Linodes')
+      : undefined;
 
   return (
     <React.Fragment>
@@ -60,7 +67,7 @@ const FirewallTable: React.FC<CombinedProps> = props => {
                       <TableContentWrapper
                         length={paginatedAndOrderedData.length}
                         loading={loading && lastUpdated === 0}
-                        error={error && lastUpdated === 0 ? error : undefined}
+                        error={_error}
                         lastUpdated={lastUpdated}
                       >
                         {paginatedAndOrderedData.map(thisDevice => (

--- a/packages/manager/src/features/Firewalls/FirewallDetail/FirewallDevicesTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/FirewallDevicesTable.tsx
@@ -3,7 +3,6 @@ import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import { compose } from 'recompose';
 import Paper from 'src/components/core/Paper';
-import { makeStyles, Theme } from 'src/components/core/styles';
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
 import TableRow from 'src/components/core/TableRow';
@@ -14,21 +13,6 @@ import Table from 'src/components/Table';
 import TableContentWrapper from 'src/components/TableContentWrapper.tsx';
 import TableSortCell from 'src/components/TableSortCell';
 import FirewallDeviceRow from './FirewallDeviceRow';
-
-const useStyles = makeStyles((theme: Theme) => ({
-  labelCell: {
-    width: '25%'
-  },
-  statusCell: {
-    width: '15%'
-  },
-  ruleCell: {
-    width: '25%'
-  },
-  linodeCell: {
-    width: '25%'
-  }
-}));
 
 interface Props {
   devices: FirewallDevice[];
@@ -42,7 +26,6 @@ type CombinedProps = Props;
 
 const FirewallTable: React.FC<CombinedProps> = props => {
   const { devices, error, lastUpdated, loading, triggerRemoveDevice } = props;
-  const classes = useStyles();
 
   return (
     <React.Fragment>
@@ -68,7 +51,6 @@ const FirewallTable: React.FC<CombinedProps> = props => {
                           direction={order}
                           handleClick={handleOrderChange}
                           data-qa-firewall-device-linode-header
-                          className={classes.labelCell}
                         >
                           Linode
                         </TableSortCell>

--- a/packages/manager/src/features/Firewalls/FirewallDetail/FirewallDevicesTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/FirewallDevicesTable.tsx
@@ -1,0 +1,113 @@
+import { FirewallDevice } from 'linode-js-sdk/lib/firewalls/types';
+import { APIError } from 'linode-js-sdk/lib/types';
+import * as React from 'react';
+import { compose } from 'recompose';
+import Paper from 'src/components/core/Paper';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import TableBody from 'src/components/core/TableBody';
+import TableHead from 'src/components/core/TableHead';
+import TableRow from 'src/components/core/TableRow';
+import OrderBy from 'src/components/OrderBy';
+import Paginate from 'src/components/Paginate';
+import PaginationFooter from 'src/components/PaginationFooter';
+import Table from 'src/components/Table';
+import TableContentWrapper from 'src/components/TableContentWrapper.tsx';
+import TableSortCell from 'src/components/TableSortCell';
+import FirewallDeviceRow from './FirewallDeviceRow';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  labelCell: {
+    width: '25%'
+  },
+  statusCell: {
+    width: '15%'
+  },
+  ruleCell: {
+    width: '25%'
+  },
+  linodeCell: {
+    width: '25%'
+  }
+}));
+
+interface Props {
+  devices: FirewallDevice[];
+  error?: APIError[];
+  loading: boolean;
+  lastUpdated: number;
+  triggerRemoveDevice: (deviceID: number, label: string) => void;
+}
+
+type CombinedProps = Props;
+
+const FirewallTable: React.FC<CombinedProps> = props => {
+  const { devices, error, lastUpdated, loading, triggerRemoveDevice } = props;
+  const classes = useStyles();
+
+  return (
+    <React.Fragment>
+      <OrderBy data={devices} orderBy={'entity:label'} order={'asc'}>
+        {({ data: orderedData, handleOrderChange, order, orderBy }) => (
+          <Paginate data={orderedData}>
+            {({
+              data: paginatedAndOrderedData,
+              count,
+              handlePageChange,
+              handlePageSizeChange,
+              page,
+              pageSize
+            }) => (
+              <>
+                <Paper>
+                  <Table aria-label="List of Linodes attached to this Firewall">
+                    <TableHead>
+                      <TableRow>
+                        <TableSortCell
+                          active={orderBy === 'entity:label'}
+                          label={'entity:label'}
+                          direction={order}
+                          handleClick={handleOrderChange}
+                          data-qa-firewall-device-linode-header
+                          className={classes.labelCell}
+                        >
+                          Linode
+                        </TableSortCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      <TableContentWrapper
+                        length={paginatedAndOrderedData.length}
+                        loading={loading}
+                        error={error}
+                        lastUpdated={lastUpdated}
+                      >
+                        {paginatedAndOrderedData.map(thisDevice => (
+                          <FirewallDeviceRow
+                            key={`device-row-${thisDevice.id}`}
+                            deviceLabel={thisDevice.entity.label}
+                            deviceID={thisDevice.entity.id}
+                            triggerRemoveDevice={triggerRemoveDevice}
+                          />
+                        ))}
+                      </TableContentWrapper>
+                    </TableBody>
+                  </Table>
+                </Paper>
+                <PaginationFooter
+                  count={count}
+                  handlePageChange={handlePageChange}
+                  handleSizeChange={handlePageSizeChange}
+                  page={page}
+                  pageSize={pageSize}
+                  eventCategory="Firewall Devices Table"
+                />
+              </>
+            )}
+          </Paginate>
+        )}
+      </OrderBy>
+    </React.Fragment>
+  );
+};
+
+export default compose<CombinedProps, Props>(React.memo)(FirewallTable);

--- a/packages/manager/src/features/Firewalls/FirewallDetail/FirewallDevicesTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/FirewallDevicesTable.tsx
@@ -59,8 +59,8 @@ const FirewallTable: React.FC<CombinedProps> = props => {
                     <TableBody>
                       <TableContentWrapper
                         length={paginatedAndOrderedData.length}
-                        loading={loading}
-                        error={error}
+                        loading={loading && lastUpdated === 0}
+                        error={error && lastUpdated === 0 ? error : undefined}
                         lastUpdated={lastUpdated}
                       >
                         {paginatedAndOrderedData.map(thisDevice => (

--- a/packages/manager/src/features/Firewalls/FirewallDetail/FirewallLinodesLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/FirewallLinodesLanding.tsx
@@ -6,6 +6,7 @@ import { compose } from 'recompose';
 // const useStyles = makeStyles((theme: Theme) => ({
 //   root: {}
 // }))
+import Typography from 'src/components/core/Typography';
 
 // interface Props { }
 
@@ -14,7 +15,13 @@ type CombinedProps = RouteComponentProps;
 const FirewallLinodesLanding: React.FC<CombinedProps> = props => {
   // const classes = useStyles();
 
-  return <h2>Firewall Linodes Landing</h2>;
+  return (
+    <>
+      <Typography>
+        The following Linodes have been assigned to this Firewall.
+      </Typography>
+    </>
+  );
 };
 
 export default compose<CombinedProps, {}>(React.memo)(FirewallLinodesLanding);

--- a/packages/manager/src/features/Firewalls/FirewallDetail/FirewallLinodesLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/FirewallLinodesLanding.tsx
@@ -3,6 +3,7 @@ import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
 
 import AddNewLink from 'src/components/AddNewLink';
+import Box from 'src/components/core/Box';
 // import { makeStyles, Theme } from 'src/components/core/styles'
 
 // const useStyles = makeStyles((theme: Theme) => ({
@@ -34,11 +35,18 @@ const FirewallLinodesLanding: React.FC<CombinedProps> = props => {
       <Typography>
         The following Linodes have been assigned to this Firewall.
       </Typography>
-      <AddNewLink
-        onClick={() => null}
-        disabled={true}
-        label="Add Linodes to Firewall"
-      />
+      <Box
+        display="flex"
+        flexDirection="row"
+        alignItems="flex-end"
+        justifyContent="flex-end"
+      >
+        <AddNewLink
+          onClick={() => null}
+          disabled={true}
+          label="Add Linodes to Firewall"
+        />
+      </Box>
       <FirewallDevicesTable
         devices={deviceList}
         error={devices.error.read}

--- a/packages/manager/src/features/Firewalls/FirewallDetail/FirewallLinodesLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/FirewallLinodesLanding.tsx
@@ -7,21 +7,35 @@ import { compose } from 'recompose';
 //   root: {}
 // }))
 import Typography from 'src/components/core/Typography';
+import useFirewallDevices from 'src/hooks/useFirewallDevices';
 
-// interface Props { }
+interface Props {
+  firewallID: number;
+}
 
-type CombinedProps = RouteComponentProps;
+type CombinedProps = RouteComponentProps & Props;
 
 const FirewallLinodesLanding: React.FC<CombinedProps> = props => {
+  const { firewallID } = props;
   // const classes = useStyles();
+  const { devices, requestDevices } = useFirewallDevices(firewallID);
 
+  const deviceList = devices.itemsById ? Object.values(devices.itemsById) : [];
+  React.useEffect(() => {
+    if (devices.lastUpdated === 0 && !devices.loading) {
+      requestDevices();
+    }
+  }, [firewallID]);
   return (
     <>
       <Typography>
         The following Linodes have been assigned to this Firewall.
       </Typography>
+      <div>{deviceList.map((thisDevice: any) => thisDevice.entity.label)}</div>
     </>
   );
 };
 
-export default compose<CombinedProps, {}>(React.memo)(FirewallLinodesLanding);
+export default compose<CombinedProps, Props>(React.memo)(
+  FirewallLinodesLanding
+);

--- a/packages/manager/src/features/Firewalls/FirewallDetail/FirewallLinodesLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/FirewallLinodesLanding.tsx
@@ -4,14 +4,16 @@ import { compose } from 'recompose';
 
 import AddNewLink from 'src/components/AddNewLink';
 import Box from 'src/components/core/Box';
-// import { makeStyles, Theme } from 'src/components/core/styles'
-
-// const useStyles = makeStyles((theme: Theme) => ({
-//   root: {}
-// }))
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import useFirewallDevices from 'src/hooks/useFirewallDevices';
 import FirewallDevicesTable from './FirewallDevicesTable';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  message: {
+    fontSize: '16px'
+  }
+}));
 
 interface Props {
   firewallID: number;
@@ -21,7 +23,7 @@ type CombinedProps = RouteComponentProps & Props;
 
 const FirewallLinodesLanding: React.FC<CombinedProps> = props => {
   const { firewallID } = props;
-  // const classes = useStyles();
+  const classes = useStyles();
   const { devices, requestDevices } = useFirewallDevices(firewallID);
 
   const deviceList = Object.values(devices.itemsById ?? {}); // Gives the devices as an array or [] if nothing is found
@@ -32,7 +34,7 @@ const FirewallLinodesLanding: React.FC<CombinedProps> = props => {
   }, [firewallID]);
   return (
     <>
-      <Typography>
+      <Typography className={classes.message}>
         The following Linodes have been assigned to this Firewall.
       </Typography>
       <Box

--- a/packages/manager/src/features/Firewalls/FirewallDetail/FirewallLinodesLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/FirewallLinodesLanding.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
+
+import AddNewLink from 'src/components/AddNewLink';
 // import { makeStyles, Theme } from 'src/components/core/styles'
 
 // const useStyles = makeStyles((theme: Theme) => ({
@@ -8,6 +10,7 @@ import { compose } from 'recompose';
 // }))
 import Typography from 'src/components/core/Typography';
 import useFirewallDevices from 'src/hooks/useFirewallDevices';
+import FirewallDevicesTable from './FirewallDevicesTable';
 
 interface Props {
   firewallID: number;
@@ -20,7 +23,7 @@ const FirewallLinodesLanding: React.FC<CombinedProps> = props => {
   // const classes = useStyles();
   const { devices, requestDevices } = useFirewallDevices(firewallID);
 
-  const deviceList = devices.itemsById ? Object.values(devices.itemsById) : [];
+  const deviceList = Object.values(devices.itemsById ?? {}); // Gives the devices as an array or [] if nothing is found
   React.useEffect(() => {
     if (devices.lastUpdated === 0 && !devices.loading) {
       requestDevices();
@@ -31,7 +34,18 @@ const FirewallLinodesLanding: React.FC<CombinedProps> = props => {
       <Typography>
         The following Linodes have been assigned to this Firewall.
       </Typography>
-      <div>{deviceList.map((thisDevice: any) => thisDevice.entity.label)}</div>
+      <AddNewLink
+        onClick={() => null}
+        disabled={true}
+        label="Add Linodes to Firewall"
+      />
+      <FirewallDevicesTable
+        devices={deviceList}
+        error={devices.error.read}
+        lastUpdated={devices.lastUpdated}
+        loading={devices.loading}
+        triggerRemoveDevice={(deviceID: number, label: string) => null}
+      />
     </>
   );
 };

--- a/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
@@ -1,3 +1,4 @@
+import { getFirewallDevices } from 'linode-js-sdk/lib/firewalls';
 import * as React from 'react';
 import {
   matchPath,

--- a/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
@@ -1,4 +1,3 @@
-import { getFirewallDevices } from 'linode-js-sdk/lib/firewalls';
 import * as React from 'react';
 import {
   matchPath,

--- a/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
@@ -129,7 +129,7 @@ export const FirewallDetail: React.FC<CombinedProps> = props => {
           exact
           strict
           path={`${URL}/linodes`}
-          component={FirewallLinodesLanding}
+          render={() => <FirewallLinodesLanding firewallID={+thisFirewallId} />}
         />
         <Redirect to={`${URL}/rules`} />
       </Switch>

--- a/packages/manager/src/hooks/useFirewallDevices.ts
+++ b/packages/manager/src/hooks/useFirewallDevices.ts
@@ -23,11 +23,12 @@ export interface UseDevicesProps {
   requestDevices: () => Promise<FirewallDevice[]>;
 }
 
-const defaultState = {
+const defaultState: MappedEntityState2<FirewallDevice, EntityError> = {
   loading: false,
   lastUpdated: 0,
-  itemsByID: {},
-  error: {}
+  itemsById: {},
+  error: {},
+  results: 0
 };
 
 /**

--- a/packages/manager/src/hooks/useFirewallDevices.ts
+++ b/packages/manager/src/hooks/useFirewallDevices.ts
@@ -39,7 +39,10 @@ export const useFirewallDevices = (firewallID: number): UseDevicesProps => {
     (state: ApplicationState) =>
       state.firewallDevices[firewallID] ?? { ...defaultState }
   );
-  const requestDevices = () => dispatch(getAllFirewallDevices({ firewallID }));
+  const requestDevices = () =>
+    dispatch(getAllFirewallDevices({ firewallID })).then(
+      response => response.data
+    );
   const addDevice = (newDevice: FirewallDevicePayload) =>
     dispatch(addFirewallDevice({ firewallID, ...newDevice }));
   const removeDevice = (deviceID: number) =>

--- a/packages/manager/src/hooks/useFirewallDevices.ts
+++ b/packages/manager/src/hooks/useFirewallDevices.ts
@@ -1,4 +1,7 @@
-import { FirewallDevicePayload } from 'linode-js-sdk/lib/firewalls/types';
+import {
+  FirewallDevice,
+  FirewallDevicePayload
+} from 'linode-js-sdk/lib/firewalls/types';
 
 import { useDispatch, useSelector } from 'react-redux';
 import { ApplicationState } from 'src/store';
@@ -7,14 +10,34 @@ import {
   getAllFirewallDevices,
   removeFirewallDevice
 } from 'src/store/firewalls/devices.requests';
+import {
+  EntityError,
+  MappedEntityState2,
+  ThunkDispatch
+} from 'src/store/types';
+
+export interface UseDevicesProps {
+  devices: MappedEntityState2<FirewallDevice, EntityError>;
+  addDevice: (newDevice: FirewallDevicePayload) => Promise<FirewallDevice>;
+  removeDevice: (deviceID: number) => Promise<{}>;
+  requestDevices: () => Promise<FirewallDevice[]>;
+}
+
+const defaultState = {
+  loading: false,
+  lastUpdated: 0,
+  itemsByID: {},
+  error: {}
+};
 
 /**
  * Hook for viewing and working with Firewall devices
  */
-export const useFirewallDevices = (firewallID: number) => {
-  const dispatch = useDispatch();
+export const useFirewallDevices = (firewallID: number): UseDevicesProps => {
+  const dispatch: ThunkDispatch = useDispatch();
   const devices = useSelector(
-    (state: ApplicationState) => state.firewallDevices[firewallID]
+    (state: ApplicationState) =>
+      state.firewallDevices[firewallID] ?? { ...defaultState }
   );
   const requestDevices = () => dispatch(getAllFirewallDevices({ firewallID }));
   const addDevice = (newDevice: FirewallDevicePayload) =>

--- a/packages/manager/src/hooks/useFirewallDevices.ts
+++ b/packages/manager/src/hooks/useFirewallDevices.ts
@@ -1,0 +1,28 @@
+import { FirewallDevicePayload } from 'linode-js-sdk/lib/firewalls/types';
+
+import { useDispatch, useSelector } from 'react-redux';
+import { ApplicationState } from 'src/store';
+import {
+  addFirewallDevice,
+  getAllFirewallDevices,
+  removeFirewallDevice
+} from 'src/store/firewalls/devices.requests';
+
+/**
+ * Hook for viewing and working with Firewall devices
+ */
+export const useFirewallDevices = (firewallID: number) => {
+  const dispatch = useDispatch();
+  const devices = useSelector(
+    (state: ApplicationState) => state.firewallDevices[firewallID]
+  );
+  const requestDevices = () => dispatch(getAllFirewallDevices({ firewallID }));
+  const addDevice = (newDevice: FirewallDevicePayload) =>
+    dispatch(addFirewallDevice({ firewallID, ...newDevice }));
+  const removeDevice = (deviceID: number) =>
+    dispatch(removeFirewallDevice({ firewallID, deviceID }));
+
+  return { devices, requestDevices, addDevice, removeDevice };
+};
+
+export default useFirewallDevices;

--- a/packages/manager/src/store/firewalls/devices.actions.ts
+++ b/packages/manager/src/store/firewalls/devices.actions.ts
@@ -2,7 +2,7 @@ import {
   FirewallDevice,
   FirewallDevicePayload
 } from 'linode-js-sdk/lib/firewalls';
-import { APIError } from 'linode-js-sdk/lib/types';
+import { APIError, ResourcePage } from 'linode-js-sdk/lib/types';
 
 import actionCreatorFactory from 'typescript-fsa';
 
@@ -17,7 +17,7 @@ export interface GetDevicesPayload {
 }
 export const getAllFirewallDevicesActions = actionCreator.async<
   GetDevicesPayload,
-  FirewallDevice[],
+  ResourcePage<FirewallDevice>,
   APIError[]
 >(`get-all`);
 

--- a/packages/manager/src/store/firewalls/devices.actions.ts
+++ b/packages/manager/src/store/firewalls/devices.actions.ts
@@ -6,7 +6,9 @@ import { APIError } from 'linode-js-sdk/lib/types';
 
 import actionCreatorFactory from 'typescript-fsa';
 
-export const actionCreator = actionCreatorFactory(`@@manager/firewalls`);
+export const actionCreator = actionCreatorFactory(
+  `@@manager/firewalls/devices`
+);
 
 export interface GetDevicesPayload {
   firewallID: number;

--- a/packages/manager/src/store/firewalls/devices.actions.ts
+++ b/packages/manager/src/store/firewalls/devices.actions.ts
@@ -1,0 +1,33 @@
+import {
+  FirewallDevice,
+  FirewallDevicePayload
+} from 'linode-js-sdk/lib/firewalls';
+import { APIError } from 'linode-js-sdk/lib/types';
+
+import actionCreatorFactory from 'typescript-fsa';
+
+export const actionCreator = actionCreatorFactory(`@@manager/firewalls`);
+
+export interface GetDevicesPayload {
+  firewallID: number;
+  params?: any;
+  filters?: any;
+}
+export const getAllFirewallDevicesActions = actionCreator.async<
+  GetDevicesPayload,
+  FirewallDevice[],
+  APIError[]
+>(`get-all`);
+
+export type AddDevicePayload = FirewallDevicePayload & { firewallID: number };
+export const addFirewallDeviceActions = actionCreator.async<
+  AddDevicePayload,
+  FirewallDevice,
+  APIError[]
+>(`add`);
+
+export const removeFirewallDeviceActions = actionCreator.async<
+  { firewallID: number; deviceID: number },
+  {},
+  APIError[]
+>(`delete`);

--- a/packages/manager/src/store/firewalls/devices.reducer.test.ts
+++ b/packages/manager/src/store/firewalls/devices.reducer.test.ts
@@ -1,0 +1,57 @@
+import { firewallDeviceFactory } from 'src/factories/firewalls';
+
+import {
+  // addFirewallDeviceActions,
+  getAllFirewallDevicesActions
+  // removeFirewallDeviceActions
+} from './devices.actions';
+import reducer, { defaultState } from './devices.reducer';
+
+const mockError = [{ reason: 'An error occurred.' }];
+
+describe('Firewall devices reducer', () => {
+  it('should handle a get.started action', () => {
+    const newState = reducer(
+      defaultState,
+      getAllFirewallDevicesActions.started({ firewallID: 1 })
+    );
+    expect(newState).toHaveProperty('1');
+    expect(newState['1']).toHaveProperty('lastUpdated', 0);
+    expect(newState['1']).toHaveProperty('error', {});
+    expect(newState['1']).toHaveProperty('loading', true);
+    expect(newState['1']).toHaveProperty('itemsById', {});
+    expect(newState['1']).toHaveProperty('results', 0);
+  });
+
+  it('should handle a get.done action', () => {
+    const mockDevices = firewallDeviceFactory.buildList(3);
+    const newState = reducer(
+      defaultState,
+      getAllFirewallDevicesActions.done({
+        params: { firewallID: 1 },
+        result: {
+          data: mockDevices,
+          results: mockDevices.length,
+          page: 1,
+          pages: 1
+        }
+      })
+    );
+    expect(newState).toHaveProperty('1');
+    expect(newState['1']).toHaveProperty('error', {});
+    expect(Object.values(newState['1'].itemsById)).toEqual(mockDevices);
+    expect(newState['1']).toHaveProperty('results', mockDevices.length);
+  });
+
+  it('should handle a get.failed action', () => {
+    const newState = reducer(
+      defaultState,
+      getAllFirewallDevicesActions.failed({
+        params: { firewallID: 1 },
+        error: mockError
+      })
+    );
+
+    expect(newState['1'].error).toHaveProperty('read', mockError);
+  });
+});

--- a/packages/manager/src/store/firewalls/devices.reducer.test.ts
+++ b/packages/manager/src/store/firewalls/devices.reducer.test.ts
@@ -165,7 +165,9 @@ describe('Firewall devices reducer', () => {
         result: {}
       })
     );
-
-    expect(newState).toEqual(oldState);
+    // Can't just compare states because of lastUpdated variance
+    expect(newState['1'].itemsById).toEqual(oldState['1'].itemsById);
+    expect(newState['1'].results).toEqual(oldState['1'].results);
+    expect(newState['1'].error).toEqual(oldState['1'].error);
   });
 });

--- a/packages/manager/src/store/firewalls/devices.reducer.test.ts
+++ b/packages/manager/src/store/firewalls/devices.reducer.test.ts
@@ -68,6 +68,7 @@ describe('Firewall devices reducer', () => {
     );
 
     expect(newState['1'].error).toHaveProperty('read', mockError);
+    expect(newState['1']).toHaveProperty('loading', false);
   });
 
   it('should handle an add.started action', () => {

--- a/packages/manager/src/store/firewalls/devices.reducer.test.ts
+++ b/packages/manager/src/store/firewalls/devices.reducer.test.ts
@@ -1,13 +1,29 @@
 import { firewallDeviceFactory } from 'src/factories/firewalls';
 
 import {
-  // addFirewallDeviceActions,
-  getAllFirewallDevicesActions
-  // removeFirewallDeviceActions
+  addFirewallDeviceActions,
+  getAllFirewallDevicesActions,
+  removeFirewallDeviceActions
 } from './devices.actions';
 import reducer, { defaultState } from './devices.reducer';
 
 const mockError = [{ reason: 'An error occurred.' }];
+
+const mockDevices = firewallDeviceFactory.buildList(3);
+
+const addDevice = () =>
+  reducer(
+    defaultState,
+    getAllFirewallDevicesActions.done({
+      params: { firewallID: 1 },
+      result: {
+        data: mockDevices,
+        results: mockDevices.length,
+        page: 1,
+        pages: 1
+      }
+    })
+  );
 
 describe('Firewall devices reducer', () => {
   it('should handle a get.started action', () => {
@@ -24,7 +40,6 @@ describe('Firewall devices reducer', () => {
   });
 
   it('should handle a get.done action', () => {
-    const mockDevices = firewallDeviceFactory.buildList(3);
     const newState = reducer(
       defaultState,
       getAllFirewallDevicesActions.done({
@@ -53,5 +68,104 @@ describe('Firewall devices reducer', () => {
     );
 
     expect(newState['1'].error).toHaveProperty('read', mockError);
+  });
+
+  it('should handle an add.started action', () => {
+    const oldState = addDevice();
+    const newState = reducer(
+      { ...oldState, '1': { ...oldState['1'], error: { create: mockError } } },
+      addFirewallDeviceActions.started({
+        firewallID: 1,
+        type: 'linode',
+        id: 10
+      })
+    );
+
+    expect(newState['1']).toHaveProperty('error', { create: undefined });
+  });
+
+  it('should handle an add.done action', () => {
+    const newDevicePayload = { firewallID: 1, type: 'linode' as any, id: 10 };
+    const newDeviceResponse = firewallDeviceFactory.build({
+      entity: { type: newDevicePayload.type, id: newDevicePayload.id }
+    });
+    const newState = reducer(
+      defaultState,
+      addFirewallDeviceActions.done({
+        params: newDevicePayload,
+        result: newDeviceResponse
+      })
+    );
+
+    expect(newState['1'].itemsById[newDeviceResponse.id]).toEqual(
+      newDeviceResponse
+    );
+    expect(newState['1']).toHaveProperty('results', 1);
+  });
+
+  it('should handle an add.failed action', () => {
+    const newDevicePayload = { firewallID: 1, type: 'linode' as any, id: 10 };
+    const newState = reducer(
+      defaultState,
+      addFirewallDeviceActions.failed({
+        params: newDevicePayload,
+        error: mockError
+      })
+    );
+
+    expect(newState['1'].error).toHaveProperty('create', mockError);
+  });
+
+  it('should handle a remove.start action', () => {
+    const oldState = addDevice();
+    const newState = reducer(
+      { ...oldState, '1': { ...oldState['1'], error: { delete: mockError } } },
+      removeFirewallDeviceActions.started({
+        firewallID: 1,
+        deviceID: mockDevices[0].id
+      })
+    );
+    expect(newState['1'].error).toHaveProperty('delete', undefined);
+  });
+
+  it('should handle a remove.done action', () => {
+    const oldState = addDevice();
+    const newState = reducer(
+      oldState,
+      removeFirewallDeviceActions.done({
+        params: { firewallID: 1, deviceID: mockDevices[0].id },
+        result: {}
+      })
+    );
+
+    expect(newState['1'].itemsById).not.toHaveProperty(
+      String(mockDevices[0].id)
+    );
+    expect(newState['1'].results).toBe(2);
+  });
+
+  it('should handle a remove.failed action', () => {
+    const newState = reducer(
+      defaultState,
+      removeFirewallDeviceActions.failed({
+        params: { firewallID: 1, deviceID: 2 },
+        error: mockError
+      })
+    );
+
+    expect(newState['1'].error).toHaveProperty('delete', mockError);
+  });
+
+  it("trying to delete something nonexistent doesn't break anything", () => {
+    const oldState = addDevice();
+    const newState = reducer(
+      oldState,
+      removeFirewallDeviceActions.done({
+        params: { firewallID: 1, deviceID: Infinity },
+        result: {}
+      })
+    );
+
+    expect(newState).toEqual(oldState);
   });
 });

--- a/packages/manager/src/store/firewalls/devices.reducer.ts
+++ b/packages/manager/src/store/firewalls/devices.reducer.ts
@@ -1,0 +1,61 @@
+// import produce from 'immer';
+// import { Firewall, FirewallDevice } from 'linode-js-sdk/lib/firewalls';
+// import { Reducer } from 'redux';
+// import { isType } from 'typescript-fsa';
+// import {
+//   ensureInitializedNestedState,
+//   onCreateOrUpdate,
+//   onDeleteSuccess,
+//   onError,
+//   onGetAllSuccess,
+//   onStart
+// } from 'src/store/store.helpers';
+// import { Entity, EntityError, RelationalDataSet } from '../types';
+// import {
+//   addFirewallDeviceActions,
+//   getAllFirewallDevicesActions,
+//   removeFirewallDeviceActions
+// } from './devices.actions';
+
+// export type State = RelationalDataSet<FirewallDevice[], EntityError>;
+
+// export const defaultState: State = {};
+
+// /**
+//  * Reducer
+//  */
+// const reducer: Reducer<State> = (state = defaultState, action) => {
+//   return produce(state, draft => {
+//     if (isType(action, getAllFirewallDevicesActions.started)) {
+//       const { firewallID } = action.payload;
+//       draft = ensureInitializedNestedState(draft, firewallID);
+
+//       draft[firewallID] = onStart(draft[firewallID]);
+//     }
+
+//     if (isType(action, getAllFirewallDevicesActions.done)) {
+//       const { result } = action.payload;
+//       const { firewallID } = action.payload.params;
+//       draft = ensureInitializedNestedState(draft, firewallID);
+
+//       draft[firewallID].loading = false;
+//       draft[firewallID].data = result;
+//       draft[firewallID].lastUpdated = Date.now();
+//     }
+
+//     if (isType(action, getAllFirewallDevicesActions.failed)) {
+//       const { error } = action.payload;
+//       const { firewallID } = action.payload.params;
+
+//       draft = ensureInitializedNestedState(draft, firewallID);
+
+//       draft[firewallID].error.read = error;
+//     }
+
+//     if (isType(action, addFirewallDeviceActions.done)) {
+//       const { result } = action.payload;
+//     }
+//   });
+// };
+
+// export default reducer;

--- a/packages/manager/src/store/firewalls/devices.reducer.ts
+++ b/packages/manager/src/store/firewalls/devices.reducer.ts
@@ -3,8 +3,7 @@ import { FirewallDevice } from 'linode-js-sdk/lib/firewalls';
 import { Reducer } from 'redux';
 import {
   apiResponseToMappedState,
-  ensureInitializedNestedState,
-  onStart
+  ensureInitializedNestedState
 } from 'src/store/store.helpers';
 import { isType } from 'typescript-fsa';
 import { EntityError, RelationalMappedEntityState } from '../types';
@@ -27,7 +26,7 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
       const { firewallID } = action.payload;
       draft = ensureInitializedNestedState(draft, firewallID);
 
-      draft[firewallID] = onStart(draft[firewallID]);
+      draft[firewallID].loading = true;
     }
 
     if (isType(action, getAllFirewallDevicesActions.done)) {

--- a/packages/manager/src/store/firewalls/devices.reducer.ts
+++ b/packages/manager/src/store/firewalls/devices.reducer.ts
@@ -47,6 +47,7 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
       draft = ensureInitializedNestedState(draft, firewallID, { results: 0 });
 
       draft[firewallID].error.read = error;
+      draft[firewallID].loading = false;
     }
 
     if (isType(action, addFirewallDeviceActions.started)) {

--- a/packages/manager/src/store/firewalls/devices.reducer.ts
+++ b/packages/manager/src/store/firewalls/devices.reducer.ts
@@ -24,7 +24,7 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
   return produce(state, draft => {
     if (isType(action, getAllFirewallDevicesActions.started)) {
       const { firewallID } = action.payload;
-      draft = ensureInitializedNestedState(draft, firewallID);
+      draft = ensureInitializedNestedState(draft, firewallID, { results: 0 });
 
       draft[firewallID].loading = true;
     }
@@ -32,18 +32,19 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
     if (isType(action, getAllFirewallDevicesActions.done)) {
       const { result } = action.payload;
       const { firewallID } = action.payload.params;
-      draft = ensureInitializedNestedState(draft, firewallID);
+      draft = ensureInitializedNestedState(draft, firewallID, { results: 0 });
 
       draft[firewallID].loading = false;
-      draft[firewallID].itemsById = apiResponseToMappedState(result);
+      draft[firewallID].itemsById = apiResponseToMappedState(result.data);
       draft[firewallID].lastUpdated = Date.now();
+      draft[firewallID].results = result.results;
     }
 
     if (isType(action, getAllFirewallDevicesActions.failed)) {
       const { error } = action.payload;
       const { firewallID } = action.payload.params;
 
-      draft = ensureInitializedNestedState(draft, firewallID);
+      draft = ensureInitializedNestedState(draft, firewallID, { results: 0 });
 
       draft[firewallID].error.read = error;
     }
@@ -51,7 +52,7 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
     if (isType(action, addFirewallDeviceActions.started)) {
       const { firewallID } = action.payload;
 
-      draft = ensureInitializedNestedState(draft, firewallID);
+      draft = ensureInitializedNestedState(draft, firewallID, { results: 0 });
       draft[firewallID].error.create = undefined;
     }
 
@@ -59,37 +60,44 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
       const { result } = action.payload;
       const { firewallID } = action.payload.params;
 
-      draft = ensureInitializedNestedState(draft, firewallID);
+      draft = ensureInitializedNestedState(draft, firewallID, { results: 0 });
       draft[firewallID].lastUpdated = Date.now();
       draft[firewallID].itemsById[result.id] = result;
+      draft[firewallID].results = Object.keys(
+        draft[firewallID].itemsById
+      ).length;
     }
 
     if (isType(action, addFirewallDeviceActions.failed)) {
       const { error } = action.payload;
       const { firewallID } = action.payload.params;
 
-      draft = ensureInitializedNestedState(draft, firewallID);
+      draft = ensureInitializedNestedState(draft, firewallID, { results: 0 });
       draft[firewallID].error.create = error;
     }
 
     if (isType(action, removeFirewallDeviceActions.started)) {
       const { firewallID } = action.payload;
 
-      draft = ensureInitializedNestedState(draft, firewallID);
+      draft = ensureInitializedNestedState(draft, firewallID, { results: 0 });
       draft[firewallID].error.delete = undefined;
     }
 
     if (isType(action, removeFirewallDeviceActions.done)) {
-      const { firewallID } = action.payload.params;
+      const { deviceID, firewallID } = action.payload.params;
 
-      delete draft[firewallID];
+      delete draft[firewallID].itemsById[deviceID];
+      draft[firewallID].lastUpdated = Date.now();
+      draft[firewallID].results = Object.keys(
+        draft[firewallID].itemsById
+      ).length;
     }
 
     if (isType(action, removeFirewallDeviceActions.failed)) {
       const { error } = action.payload;
       const { firewallID } = action.payload.params;
 
-      draft = ensureInitializedNestedState(draft, firewallID);
+      draft = ensureInitializedNestedState(draft, firewallID, { results: 0 });
       draft[firewallID].error.delete = error;
     }
   });

--- a/packages/manager/src/store/firewalls/devices.requests.ts
+++ b/packages/manager/src/store/firewalls/devices.requests.ts
@@ -1,0 +1,34 @@
+import {
+  addFirewallDevice as _add,
+  deleteFirewallDevice as _delete,
+  FirewallDevice,
+  getFirewallDevices as _get
+} from 'linode-js-sdk/lib/firewalls';
+import { getAll } from 'src/utilities/getAll';
+import { createRequestThunk } from '../store.helpers';
+import {
+  addFirewallDeviceActions,
+  getAllFirewallDevicesActions,
+  GetDevicesPayload,
+  removeFirewallDeviceActions
+} from './devices.actions';
+
+const requestAll = (payload: GetDevicesPayload) =>
+  getAll<FirewallDevice>(({ firewallID, passedParams, passedFilter }) =>
+    _get(firewallID, passedParams, passedFilter)
+  )(payload.params, payload.filters).then(response => response.data);
+
+export const getAllFirewalls = createRequestThunk(
+  getAllFirewallDevicesActions,
+  requestAll
+);
+
+export const addFirewallDevice = createRequestThunk(
+  addFirewallDeviceActions,
+  ({ firewallID, ...rest }) => _add(firewallID, { ...rest })
+);
+
+export const removeFirewallDevice = createRequestThunk(
+  removeFirewallDeviceActions,
+  ({ firewallID, deviceID }) => _delete(firewallID, deviceID)
+);

--- a/packages/manager/src/store/firewalls/devices.requests.ts
+++ b/packages/manager/src/store/firewalls/devices.requests.ts
@@ -18,7 +18,7 @@ const requestAll = (payload: GetDevicesPayload) =>
     _get(firewallID, passedParams, passedFilter)
   )(payload.params, payload.filters).then(response => response.data);
 
-export const getAllFirewalls = createRequestThunk(
+export const getAllFirewallDevices = createRequestThunk(
   getAllFirewallDevicesActions,
   requestAll
 );

--- a/packages/manager/src/store/firewalls/devices.requests.ts
+++ b/packages/manager/src/store/firewalls/devices.requests.ts
@@ -16,7 +16,7 @@ import {
 const requestAll = (payload: GetDevicesPayload) =>
   getAll<FirewallDevice>(({ passedParams, passedFilter }) =>
     _get(payload.firewallID, passedParams, passedFilter)
-  )(payload.params, payload.filters).then(response => response.data);
+  )(payload.params, payload.filters);
 
 export const getAllFirewallDevices = createRequestThunk(
   getAllFirewallDevicesActions,

--- a/packages/manager/src/store/firewalls/devices.requests.ts
+++ b/packages/manager/src/store/firewalls/devices.requests.ts
@@ -14,8 +14,8 @@ import {
 } from './devices.actions';
 
 const requestAll = (payload: GetDevicesPayload) =>
-  getAll<FirewallDevice>(({ firewallID, passedParams, passedFilter }) =>
-    _get(firewallID, passedParams, passedFilter)
+  getAll<FirewallDevice>(({ passedParams, passedFilter }) =>
+    _get(payload.firewallID, passedParams, passedFilter)
   )(payload.params, payload.filters).then(response => response.data);
 
 export const getAllFirewallDevices = createRequestThunk(

--- a/packages/manager/src/store/index.ts
+++ b/packages/manager/src/store/index.ts
@@ -49,6 +49,10 @@ import firewalls, {
   defaultState as defaultFirewallState,
   State as FirewallState
 } from 'src/store/firewalls/firewalls.reducer';
+import firewallDevices, {
+  defaultState as defaultFirewallDevicesState,
+  State as FirewallDevicesState
+} from 'src/store/firewalls/firewalls.reducer';
 import globalErrors, {
   defaultState as defaultGlobalErrorState,
   State as GlobalErrorState
@@ -222,6 +226,7 @@ export interface ApplicationState {
   preferences: PreferencesState;
   initialLoad: InitialLoadState;
   firewalls: FirewallState;
+  firewallDevices: FirewallDevicesState;
   globalErrors: GlobalErrorState;
   longviewClients: LongviewState;
   longviewStats: LongviewStatsState;
@@ -242,6 +247,7 @@ const defaultState: ApplicationState = {
   preferences: preferencesState,
   initialLoad: initialLoadState,
   firewalls: defaultFirewallState,
+  firewallDevices: defaultFirewallDevicesState,
   globalErrors: defaultGlobalErrorState,
   longviewClients: defaultLongviewState,
   longviewStats: defaultLongviewStatsState
@@ -288,6 +294,7 @@ const reducers = combineReducers<ApplicationState>({
   preferences,
   initialLoad,
   firewalls,
+  firewallDevices,
   globalErrors,
   longviewClients: longview,
   longviewStats

--- a/packages/manager/src/store/index.ts
+++ b/packages/manager/src/store/index.ts
@@ -45,13 +45,13 @@ import events, {
   defaultState as eventsDefaultState,
   State as EventsState
 } from 'src/store/events/event.reducer';
-import firewalls, {
-  defaultState as defaultFirewallState,
-  State as FirewallState
-} from 'src/store/firewalls/firewalls.reducer';
 import firewallDevices, {
   defaultState as defaultFirewallDevicesState,
   State as FirewallDevicesState
+} from 'src/store/firewalls/devices.reducer';
+import firewalls, {
+  defaultState as defaultFirewallState,
+  State as FirewallState
 } from 'src/store/firewalls/firewalls.reducer';
 import globalErrors, {
   defaultState as defaultGlobalErrorState,

--- a/packages/manager/src/store/store.helpers.ts
+++ b/packages/manager/src/store/store.helpers.ts
@@ -164,10 +164,11 @@ export const updateInPlace = <E extends Entity>(
 // If it doesn't exist, initialize the state with `createDefaultState()`.
 export const ensureInitializedNestedState = (
   state: Record<number, any>,
-  id: number
+  id: number,
+  override: any = {}
 ) => {
   if (!state[id]) {
-    state[id] = createDefaultState({ error: {} });
+    state[id] = createDefaultState({ ...override, error: {} });
   }
   return state;
 };

--- a/packages/manager/src/store/types.ts
+++ b/packages/manager/src/store/types.ts
@@ -111,10 +111,10 @@ export interface EntitiesAsObjectState<T> {
  */
 export type RelationalDataSet<T extends {}, E = EntityError> = Record<
   string,
-  Partial<{
+  {
     data: T;
     loading: boolean;
     error: E;
     lastUpdated: number;
-  }>
+  }
 >;

--- a/packages/manager/src/store/types.ts
+++ b/packages/manager/src/store/types.ts
@@ -62,7 +62,7 @@ export interface MappedEntityState2<T extends Entity, E = APIError[]> {
   error: E;
   lastUpdated: number;
   loading: boolean;
-  itemsById: EntityMap<T>;
+  itemsById: Record<string, T>;
   results: number;
 }
 

--- a/packages/manager/src/store/types.ts
+++ b/packages/manager/src/store/types.ts
@@ -57,6 +57,20 @@ export interface MappedEntityState<
   loading: boolean;
 }
 
+// NOTE: These 2 interfaces are as of 2/26/2020 what we intend to consolidate around
+export interface MappedEntityState2<T extends Entity, E = APIError[]> {
+  error: E;
+  lastUpdated: number;
+  loading: boolean;
+  itemsById: EntityMap<T>;
+  results: number;
+}
+
+export type RelationalMappedEntityState<T extends Entity, E> = Record<
+  string | number,
+  MappedEntityState2<T, E>
+>;
+
 export interface EntityState<T extends Entity, E = APIError[] | undefined> {
   results: TypeOfID<T>[];
   entities: T[];
@@ -92,7 +106,7 @@ export type EventHandler = (
 ) => void;
 
 export interface EntitiesAsObjectState<T> {
-  error: Partial<EntityError>;
+  error: EntityError;
   data: Record<string, T>;
   results: number;
   lastUpdated: number;
@@ -111,10 +125,10 @@ export interface EntitiesAsObjectState<T> {
  */
 export type RelationalDataSet<T extends {}, E = EntityError> = Record<
   string,
-  {
+  Partial<{
     data: T;
     loading: boolean;
     error: E;
     lastUpdated: number;
-  }
+  }>
 >;


### PR DESCRIPTION
## Description

Adds content to the firewalls/id/linodes view. Includes:

- Redux boilerplate for Firewall devices
- Hook with useSelector instead of a normal container for devices
- 2 new Redux types that we hope will serve as our universal store format
- TableContentWrapper, which abstracts our loading/empty/error logic for tables

Still to come in this PR: 

- [x] Styling cleanup
- [x] Reducer tests
- [x] Tests for the wrapper component

Still to come in the next PRs:

- Add the "Add a Linode to this Firewall" drawer
- Enable the action menu ("remove" is there but non-functional)
- Rewire the existing FirewallRows component to use the new hook