### PR TITLE
Utilize webpack performance budgets

### DIFF
--- a/packages/manager/config/webpack.config.prod.js
+++ b/packages/manager/config/webpack.config.prod.js
@@ -332,5 +332,19 @@ module.exports = {
     net: 'empty',
     tls: 'empty',
     child_process: 'empty'
+  },
+
+  // Utilize webpack performance budgets that will fail the build if the assets
+  // exceed the configured size.
+  // See https://webpack.js.org/configuration/performance/
+  performance: {
+    hints: 'error',
+    maxEntrypointSize: 1140000,
+    maxAssetSize: 1140000, // ~1.08 MiB
+    assetFilter: function(assetFilename) {
+      return !(
+        assetFilename.endsWith('.chunk.js') || assetFilename.endsWith('.map')
+      );
+    }
   }
 };


### PR DESCRIPTION
## Description

To make sure we're not excessively bloating the javascript bundle size, we can set a performance budget that will fail `yarn build` if the bundle exceeds 1.08MiB. The current size is 1.07MiB. We might want to loosen this threshold a bit so it doesn't fail every time.