### PR TITLE
Sort by OBJ cluster instead of region

### DIFF
--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTable.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTable.tsx
@@ -79,8 +79,8 @@ export const BucketTable: React.StatelessComponent<CombinedProps> = props => {
                     Name
                   </TableSortCell>
                   <TableSortCell
-                    active={orderBy === 'region'}
-                    label="region"
+                    active={orderBy === 'cluster'}
+                    label="cluster"
                     direction={order}
                     handleClick={handleOrderChange}
                     data-qa-region


### PR DESCRIPTION
## Description

The `label` and `active` props were looking at `region` instead of `cluster`, which meant sorting by clicking the Region header column doesn't work.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

To test: create buckets in multiple regions. Click the "Region" table header to sort.
