### PR TITLE
fix: Use label + region as React key for OBJ table

### DIFF
--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTable.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTable.tsx
@@ -132,7 +132,7 @@ const RenderData: React.StatelessComponent<RenderDataProps> = props => {
       {data.map(bucket => (
         <BucketTableRow
           {...bucket}
-          key={bucket.label}
+          key={`${bucket.label}-${bucket.cluster}`}
           onRemove={() => onRemove(bucket)}
         />
       ))}


### PR DESCRIPTION
## Description

Well here’s a fun one! Previously the Bucket Table Row used `label` as it’s key. That’d be fine if bucket labels had a unique constraint. Well… they actually do, but only per region. Now, with multiple regions, it’s possible to have two items in this table with the same label, and therefore the same key.

Which means, that when the table is re-ordered (e.g. adding a new bucket or sorting the table) React doesn’t throw away the old entry, and you end up with duplicate items in the table.

This changes this behavior so that the key is determined by the label AND the region. This should ensure uniqueness.

