### PR TITLE
Change: Use Redux/useFirewallDevices hook in FirewallRow

### DIFF
--- a/packages/manager/src/hooks/useFirewallDevices.ts
+++ b/packages/manager/src/hooks/useFirewallDevices.ts
@@ -20,7 +20,7 @@ export interface UseDevicesProps {
   devices: MappedEntityState2<FirewallDevice, EntityError>;
   addDevice: (newDevice: FirewallDevicePayload) => Promise<FirewallDevice>;
   removeDevice: (deviceID: number) => Promise<{}>;
-  requestDevices: () => Promise<FirewallDevice[]>;
+  requestDevices: () => Promise<FirewallDevice[] | null>;
 }
 
 const defaultState: MappedEntityState2<FirewallDevice, EntityError> = {
@@ -41,9 +41,9 @@ export const useFirewallDevices = (firewallID: number): UseDevicesProps => {
       state.firewallDevices[firewallID] ?? { ...defaultState }
   );
   const requestDevices = () =>
-    dispatch(getAllFirewallDevices({ firewallID })).then(
-      response => response.data
-    );
+    dispatch(getAllFirewallDevices({ firewallID }))
+      .then(response => response.data)
+      .catch(_ => null); // Handle errors through Redux
   const addDevice = (newDevice: FirewallDevicePayload) =>
     dispatch(addFirewallDevice({ firewallID, ...newDevice }));
   const removeDevice = (deviceID: number) =>

--- a/packages/manager/src/store/firewalls/devices.reducer.ts
+++ b/packages/manager/src/store/firewalls/devices.reducer.ts
@@ -27,6 +27,7 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
       draft = ensureInitializedNestedState(draft, firewallID, { results: 0 });
 
       draft[firewallID].loading = true;
+      draft[firewallID].error.read = undefined;
     }
 
     if (isType(action, getAllFirewallDevicesActions.done)) {


### PR DESCRIPTION
## Description

Each FirewallRow was making its own request to /devices to see
what Linodes were attached to it. This is hard to avoid, but every
time you e.g. switched tabs and came back, the requests happened again.

This way, the requests are only made once, whenever we first need to
access a Firewall's device list. Subsequent views will read from the
Redux store.

## Notes for Reviewers

Navigate around the app with the networking tab open (filter for /devices). Ensure that devices load normally in all views, and that requests are only made the first time a particular Firewall's devices are needed.