### PR TITLE
Add support for secondary promo button

### DIFF
--- a/packages/manager/src/components/PromotionalOfferCard/PromotionalOfferCard.test.tsx
+++ b/packages/manager/src/components/PromotionalOfferCard/PromotionalOfferCard.test.tsx
@@ -33,7 +33,9 @@ describe('PromotionalOfferCard', () => {
     const { queryByText } = renderWithTheme(
       <PromotionalOfferCard
         {...promo}
-        buttons={[{ text: 'Button Text', href: 'javascript:alert(1' }]}
+        buttons={[
+          { text: 'Button Text', href: 'javascript:alert(1)', type: 'primary' }
+        ]}
       />
     );
     const anchor = queryByText('Button Text')?.closest('a');

--- a/packages/manager/src/components/PromotionalOfferCard/PromotionalOfferCard.tsx
+++ b/packages/manager/src/components/PromotionalOfferCard/PromotionalOfferCard.tsx
@@ -145,9 +145,7 @@ export const PromotionalOfferCard: React.FC<CombinedProps> = props => {
                 key={button.text}
                 className={classnames({
                   [classes.button]: true,
-                  [classes.buttonSecondary]: Boolean(
-                    button.type === 'secondary'
-                  )
+                  [classes.buttonSecondary]: button.type === 'secondary'
                 })}
                 {...buttonProps(button.href)}
               >

--- a/packages/manager/src/components/PromotionalOfferCard/PromotionalOfferCard.tsx
+++ b/packages/manager/src/components/PromotionalOfferCard/PromotionalOfferCard.tsx
@@ -71,6 +71,18 @@ const useStyles = makeStyles((theme: Theme) => ({
       backgroundColor: '#3f8a4e',
       color: 'white'
     }
+  },
+  buttonSecondary: {
+    backgroundColor: 'inherit',
+    color: '#4FAD62',
+    border: '1px solid transparent',
+    transition: theme.transitions.create(['color', 'border-color']),
+    borderColor: '#4FAD62',
+    '&:hover, &:focus': {
+      backgroundColor: 'inherit',
+      color: '#72BD81',
+      borderColor: '#72BD81'
+    }
   }
 }));
 
@@ -131,7 +143,12 @@ export const PromotionalOfferCard: React.FC<CombinedProps> = props => {
             {offer.buttons.slice(0, 2).map(button => (
               <Button
                 key={button.text}
-                className={classes.button}
+                className={classnames({
+                  [classes.button]: true,
+                  [classes.buttonSecondary]: Boolean(
+                    button.type === 'secondary'
+                  )
+                })}
                 {...buttonProps(button.href)}
               >
                 {button.text}

--- a/packages/manager/src/factories/promotionalOffer.ts
+++ b/packages/manager/src/factories/promotionalOffer.ts
@@ -13,10 +13,11 @@ export const promotionalOfferFactory = Factory.Sync.makeFactory<
   alt: 'Promotional Offer',
   displayOnDashboard: true,
   buttons: [
-    { text: 'Try it Now', href: '/object-storage/buckets' },
+    { text: 'Try it Now', href: '/object-storage/buckets', type: 'primary' },
     {
       text: 'Cost Estimator',
-      href: 'https://www.linode.com/products/object-storage/'
+      href: 'https://www.linode.com/products/object-storage/',
+      type: 'secondary'
     }
   ]
 });

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -26,6 +26,7 @@ type PromotionalOfferFeature =
 interface PromotionalOfferButton {
   text: string;
   href: string;
+  type: 'primary' | 'secondary';
 }
 
 export interface PromotionalOffer {


### PR DESCRIPTION
## Description

<img width="487" alt="Screen Shot 2020-03-02 at 3 37 05 PM" src="https://user-images.githubusercontent.com/16911484/75715724-df0bcc00-5c9b-11ea-88f4-a8e2e4fcecf1.png">

This gives us the ability to specify a promo button’s type as “secondary”, which will use styling similar to the “secondary” variant of our Button component. The colors are different here, so I added the CSS manually.

@WilkinsKa1  let me know your thoughts on the colors.

## Note to Reviewers

**To test:** check out this PR and have a look at the Dashboard. The change has already been made to the feature flag, so you should see it.
