### PR TITLE
Use real data for Firewall rules

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallDetail/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/FirewallRuleTable.tsx
@@ -13,6 +13,7 @@ import TableRow from 'src/components/TableRow';
 import TableRowEmptyState from 'src/components/TableRowEmptyState';
 import TableSortCell from 'src/components/TableSortCell';
 import capitalize from 'src/utilities/capitalize';
+import { v4 } from 'uuid';
 import {
   generateAddressesLabel,
   generateRuleLabel,
@@ -34,6 +35,7 @@ interface RuleRow {
   protocol: string;
   ports: string;
   addresses: string;
+  id: string;
 }
 
 interface Props {
@@ -108,10 +110,10 @@ const FirewallRuleTable: React.FC<CombinedProps> = props => {
                 <TableRowEmptyState colSpan={5} />
               ) : (
                 orderedData.map((ruleRow: RuleRow, idx) => {
-                  const { type, protocol, ports, addresses } = ruleRow;
+                  const { id, type, protocol, ports, addresses } = ruleRow;
 
                   return (
-                    <TableRow key={idx}>
+                    <TableRow key={id}>
                       <TableCell>{type}</TableCell>
                       <TableCell>{protocol}</TableCell>
                       <TableCell>{ports}</TableCell>
@@ -152,7 +154,8 @@ export const firewallRuleToRowData = (
       type: generateRuleLabel(ruleType),
       protocol: thisRule.protocol,
       addresses: generateAddressesLabel(thisRule.addresses),
-      ports: thisRule.ports
+      ports: thisRule.ports,
+      id: v4()
     };
   });
 };

--- a/packages/manager/src/features/Firewalls/FirewallDetail/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/FirewallRuleTable.tsx
@@ -10,23 +10,14 @@ import OrderBy from 'src/components/OrderBy';
 import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
+import TableRowEmptyState from 'src/components/TableRowEmptyState';
 import TableSortCell from 'src/components/TableSortCell';
-import { firewallRuleFactory } from 'src/factories/firewalls';
 import capitalize from 'src/utilities/capitalize';
 import {
   generateAddressesLabel,
   generateRuleLabel,
   predefinedFirewallFromRule as ruleToPredefinedFirewall
 } from '../shared';
-
-// Use mock data for now.
-// @todo: use real data.
-const MOCK_RULES = firewallRuleFactory.buildList(4);
-MOCK_RULES[1].ports = '443';
-MOCK_RULES[2].protocol = 'UDP';
-MOCK_RULES[2].addresses = {
-  ipv4: ['1.1.1.1', '2.2.2.2', '3.3.3.3']
-};
 
 const useStyles = makeStyles((theme: Theme) => ({
   header: {
@@ -47,29 +38,29 @@ interface RuleRow {
 
 interface Props {
   category: Category;
+  rules: FirewallRuleType[];
 }
 
 type CombinedProps = Props;
 
 const FirewallRuleTable: React.FC<CombinedProps> = props => {
+  const { category, rules } = props;
+
   const classes = useStyles();
 
   const addressColumnLabel =
-    props.category === 'inbound' ? 'sources' : 'destinations';
+    category === 'inbound' ? 'sources' : 'destinations';
 
-  // @todo: Use real data.
-  const rowData = firewallRuleToRowData(MOCK_RULES);
+  const rowData = firewallRuleToRowData(rules);
 
   return (
     <>
       <div className={classes.header}>
-        <Typography variant="h2">{`${capitalize(
-          props.category
-        )} Rules`}</Typography>
+        <Typography variant="h2">{`${capitalize(category)} Rules`}</Typography>
         <AddNewLink
           // @todo: Use real handlers.
           onClick={() => alert("This doesn't do anything yet.")}
-          label={`Add an ${capitalize(props.category)} Rule`}
+          label={`Add an ${capitalize(category)} Rule`}
         />
       </div>
       <OrderBy data={rowData} orderBy={'type'} order={'asc'}>
@@ -113,25 +104,29 @@ const FirewallRuleTable: React.FC<CombinedProps> = props => {
               </TableRow>
             </TableHead>
             <TableBody>
-              {orderedData.map((ruleRow: RuleRow, idx) => {
-                const { type, protocol, ports, addresses } = ruleRow;
+              {orderedData.length === 0 ? (
+                <TableRowEmptyState colSpan={5} />
+              ) : (
+                orderedData.map((ruleRow: RuleRow, idx) => {
+                  const { type, protocol, ports, addresses } = ruleRow;
 
-                return (
-                  <TableRow key={idx}>
-                    <TableCell>{type}</TableCell>
-                    <TableCell>{protocol}</TableCell>
-                    <TableCell>{ports}</TableCell>
-                    <TableCell>{addresses}</TableCell>
-                    <TableCell>
-                      {/* Mocked for now. */}
-                      <ActionMenu
-                        createActions={() => []}
-                        ariaLabel="Action menu for Firewall rule"
-                      />
-                    </TableCell>
-                  </TableRow>
-                );
-              })}
+                  return (
+                    <TableRow key={idx}>
+                      <TableCell>{type}</TableCell>
+                      <TableCell>{protocol}</TableCell>
+                      <TableCell>{ports}</TableCell>
+                      <TableCell>{addresses}</TableCell>
+                      <TableCell>
+                        {/* Mocked for now. */}
+                        <ActionMenu
+                          createActions={() => []}
+                          ariaLabel="Action menu for Firewall rule"
+                        />
+                      </TableCell>
+                    </TableRow>
+                  );
+                })
+              )}
             </TableBody>
           </Table>
         )}

--- a/packages/manager/src/features/Firewalls/FirewallDetail/FirewallRulesLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/FirewallRulesLanding.tsx
@@ -1,3 +1,4 @@
+import { FirewallRules } from 'linode-js-sdk/lib/firewalls';
 import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
@@ -17,9 +18,15 @@ const useStyles = makeStyles((theme: Theme) => ({
   }
 }));
 
-type CombinedProps = RouteComponentProps;
+interface Props {
+  rules: FirewallRules;
+}
+
+type CombinedProps = Props & RouteComponentProps;
 
 const FirewallRulesLanding: React.FC<CombinedProps> = props => {
+  const { rules } = props;
+
   const classes = useStyles();
 
   return (
@@ -30,13 +37,13 @@ const FirewallRulesLanding: React.FC<CombinedProps> = props => {
         permitted by a rule is blocked.
       </Typography>
       <div className={classes.table}>
-        <FirewallRuleTable category="inbound" />
+        <FirewallRuleTable category="inbound" rules={rules.inbound ?? []} />
       </div>
       <div className={classes.table}>
-        <FirewallRuleTable category="outbound" />
+        <FirewallRuleTable category="outbound" rules={rules.outbound ?? []} />
       </div>
     </>
   );
 };
 
-export default compose<CombinedProps, {}>(React.memo)(FirewallRulesLanding);
+export default compose<CombinedProps, Props>(React.memo)(FirewallRulesLanding);

--- a/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
@@ -123,7 +123,7 @@ export const FirewallDetail: React.FC<CombinedProps> = props => {
           exact
           strict
           path={`${URL}/rules`}
-          component={FirewallRulesLanding}
+          render={() => <FirewallRulesLanding rules={thisFirewall.rules} />}
         />
         <Route
           exact


### PR DESCRIPTION
## Description

- Use real data for FW rules.
- Add an “Empty” table row state.
<img width="1291" alt="Screen Shot 2020-03-02 at 4 37 41 PM" src="https://user-images.githubusercontent.com/16911484/75720252-28601980-5ca4-11ea-8b75-019ce287e9f5.png">

## Note to Reviewers

The Add/Edit/Delete actions don't work yet, so you'll still need to add rules with the API to see them. Here's a sample payload:

```
PUT https://api.linode.com/v4beta/networking/firewalls/{ID}/rules 

{
  "inbound":[
    {
      "ports":"443",
      "protocol":"TCP",
      "addresses":{
        "ipv4":[
          "0.0.0.0/0"
        ],
        "ipv6":[
          "::0/0"
        ]
      }
    },
    {
      "ports":"80",
      "protocol":"TCP",
      "addresses":{
        "ipv4":[
          "0.0.0.0/0"
        ],
        "ipv6":[
          "::0/0"
        ]
      }
    },
    {
      "ports":"22",
      "protocol":"TCP",
      "addresses":{
        "ipv4":[
          "0.0.0.0/0"
        ],
        "ipv6":[
          "::0/0"
        ]
      }
    }
  ]
}
