### PR TITLE
M3-4020 Add: "Add Device" drawer to Firewall Linodes tab

### DIFF
--- a/packages/manager/src/components/EnhancedSelect/__mocks__/Select.tsx
+++ b/packages/manager/src/components/EnhancedSelect/__mocks__/Select.tsx
@@ -13,12 +13,13 @@ const groupsToItems = (groups: any[]) => {
   }, []);
 };
 
-export default ({ options, value, onChange, errorText }: any) => {
+export default ({ options, value, onChange, errorText, isMulti }: any) => {
   const handleChange = (event: any) => {
     const option = _options.find(
-      (thisOption: any) => thisOption.value === event.currentTarget.value
+      /* tslint:disable-next-line */
+      (thisOption: any) => thisOption.value == event.currentTarget.value
     );
-    onChange(option);
+    isMulti ? onChange([option]) : onChange(option);
   };
 
   const _options = groupsToItems(options);
@@ -26,14 +27,14 @@ export default ({ options, value, onChange, errorText }: any) => {
     <>
       <select
         data-testid="select"
-        value={value || ''}
+        value={value ?? ''}
         onBlur={handleChange}
-        onChange={() => null}
+        onChange={handleChange}
       >
         {_options.map((thisOption: any) => (
           <option
-            key={thisOption.value || ''}
-            value={thisOption.value || ''}
+            key={thisOption.value ?? ''}
+            value={thisOption.value ?? ''}
             aria-selected={thisOption.value === value}
           >
             {thisOption.label}

--- a/packages/manager/src/components/LinodeMultiSelect/LinodeMultiSelect.test.tsx
+++ b/packages/manager/src/components/LinodeMultiSelect/LinodeMultiSelect.test.tsx
@@ -1,0 +1,130 @@
+import { cleanup, fireEvent, wait } from '@testing-library/react';
+import * as React from 'react';
+
+import { linodeFactory } from 'src/factories/linodes';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import {
+  CombinedProps,
+  generateOptions,
+  LinodeMultiSelect,
+  userSelectedAllLinodes
+} from './LinodeMultiSelect';
+
+afterEach(cleanup);
+
+jest.mock('src/components/EnhancedSelect/Select');
+
+const linodes = linodeFactory.buildList(10);
+
+const props: CombinedProps = {
+  handleChange: jest.fn(),
+  linodesLoading: false,
+  linodesData: linodes,
+  linodesResults: linodes.map(i => i.id),
+  linodesLastUpdated: 1000,
+  showAllOption: true,
+  getLinodes: jest.fn()
+};
+
+const allLinodesOption = { label: 'All Linodes', value: 'ALL' };
+
+const optionsWithSelectAll = [
+  allLinodesOption,
+  { label: 'my-linode', value: 1234456 }
+];
+
+const optionsWithoutSelectAll = [
+  { label: 'my-linode', value: 1234456 },
+  { label: 'my-linode-2', value: 999999 }
+];
+
+describe('Linode Multi Select', () => {
+  describe('userSelectedAllLinodes selector', () => {
+    it('should return true ALL is among the selected options', () => {
+      expect(userSelectedAllLinodes(optionsWithSelectAll)).toBe(true);
+    });
+
+    it('should return false if ALL is not among the selected options', () => {
+      expect(userSelectedAllLinodes(optionsWithoutSelectAll)).toBe(false);
+    });
+
+    it('should return false if nothing is selected', () => {
+      expect(userSelectedAllLinodes([])).toBe(false);
+    });
+  });
+
+  describe('generateOptions', () => {
+    it('should return a list of items based on the provided Linodes data', () => {
+      const options = generateOptions(false, true, linodes, undefined);
+      expect(options).toHaveLength(linodes.length + 1);
+      expect(options[1]).toHaveProperty('value');
+      expect(options[1]).toHaveProperty('label');
+    });
+
+    it('should include an All Linodes option', () => {
+      const options = generateOptions(false, true, linodes, undefined);
+      expect(options).toContainEqual(allLinodesOption);
+    });
+
+    it('should return nothing if there is an error', () => {
+      const options = generateOptions(false, true, linodes, [
+        { reason: 'an error ' }
+      ]);
+      expect(options).toEqual([]);
+    });
+
+    it('should only return the ALL option if the allLinodesSelected argument is true', () => {
+      const options = generateOptions(true, true, linodes, undefined);
+      expect(options).toEqual([allLinodesOption]);
+    });
+
+    it('should not include the All Linodes option if the param is false', () => {
+      const options = generateOptions(true, false, linodes, undefined);
+      expect(options).not.toContainEqual(allLinodesOption);
+      expect(options.length).toBe(linodes.length);
+    });
+  });
+
+  describe('MultiSelect component', () => {
+    it('should render error text if provided', () => {
+      const errorText = 'This is an error message';
+      const { getByText } = renderWithTheme(
+        <LinodeMultiSelect {...props} errorText={errorText} />
+      );
+      getByText(errorText);
+    });
+
+    it('should filter out Linodes from a provided list', () => {
+      const filteredLinodes = [linodes[2].id, linodes[4].id];
+      const { queryByText } = renderWithTheme(
+        <LinodeMultiSelect {...props} filteredLinodes={filteredLinodes} />
+      );
+      expect(queryByText(linodes[2].label)).not.toBeInTheDocument();
+      expect(queryByText(linodes[4].label)).not.toBeInTheDocument();
+      expect(queryByText(linodes[5].label)).toBeInTheDocument();
+    });
+
+    it('should call its handleSelect method with a list of Linode IDs', async () => {
+      const { getByTestId } = renderWithTheme(<LinodeMultiSelect {...props} />);
+
+      await wait(() =>
+        fireEvent.change(getByTestId('select'), {
+          target: { value: linodes[1].id }
+        })
+      );
+      expect(props.handleChange).toHaveBeenCalledWith([linodes[1].id]);
+    });
+
+    it('should call its handleSelect method with all Linode IDs if ALL is selected', async () => {
+      const { getByTestId } = renderWithTheme(<LinodeMultiSelect {...props} />);
+
+      await wait(() =>
+        fireEvent.change(getByTestId('select'), {
+          target: { value: 'ALL' }
+        })
+      );
+      expect(props.handleChange).toHaveBeenCalledWith(linodes.map(i => i.id));
+    });
+  });
+});

--- a/packages/manager/src/components/LinodeMultiSelect/LinodeMultiSelect.tsx
+++ b/packages/manager/src/components/LinodeMultiSelect/LinodeMultiSelect.tsx
@@ -1,0 +1,144 @@
+import * as React from 'react';
+import { compose } from 'recompose';
+import Select, { BaseSelectProps, Item } from 'src/components/EnhancedSelect';
+import withLinodes, {
+  Props as LinodeProps
+} from 'src/containers/withLinodes.container';
+
+export interface Props extends Partial<BaseSelectProps> {
+  filteredLinodes?: number[];
+  helperText?: string;
+  showAllOption?: boolean;
+  handleChange: (selected: number[]) => void;
+}
+
+export type CombinedProps = Props & LinodeProps;
+
+export const LinodeMultiSelect: React.FC<CombinedProps> = props => {
+  const {
+    errorText,
+    filteredLinodes,
+    helperText,
+    linodesData,
+    linodesError,
+    linodesLoading,
+    handleChange,
+    showAllOption,
+    ...selectProps
+  } = props;
+
+  const _filteredLinodes = filteredLinodes ?? [];
+
+  const filteredLinodesData = React.useMemo(
+    () =>
+      linodesData.filter(
+        thisLinode => !_filteredLinodes.includes(thisLinode.id)
+      ),
+    [filteredLinodes, linodesData]
+  );
+
+  const linodeError = linodesError && linodesError[0]?.reason;
+
+  const [selectAll, toggleSelectAll] = React.useState<boolean>(false);
+
+  /**
+   * Update the current list of selected Linodes.
+   *
+   * This will call whatever state management function is passed as the
+   * handleChange prop.
+   *
+   * - If the user has clicked the "All Linodes" option, we will short circuit
+   * and call the handler with a list of all Linodes.
+   *
+   * - In some cases, such as Firewall devices, we don't want to submit with
+   * all Linodes even if the user has selected this option, since the API will
+   * return an error if you try to re-add an existing Device. We provide the
+   * filteredLinodes prop to allow this. When selectAll is true and filteredLinodes
+   * is provided, we will call the handler with a list of all Linodes *except* those
+   * in the filteredLinodes array.
+   *
+   */
+  const handleSelectLinodes = (selectedLinodes: Item<number>[]) => {
+    const hasSelectedAll =
+      !!showAllOption && userSelectedAllLinodes(selectedLinodes);
+    toggleSelectAll(hasSelectedAll);
+    const newSelectedLinodes = hasSelectedAll
+      ? filteredLinodesData.map(eachLinode => eachLinode.id)
+      : selectedLinodes.map(eachValue => eachValue.value);
+    handleChange(newSelectedLinodes);
+  };
+
+  return (
+    <Select
+      label="Linodes"
+      name="linodes"
+      isLoading={linodesLoading}
+      errorText={linodeError || errorText}
+      isMulti
+      options={generateOptions(
+        selectAll,
+        !!showAllOption,
+        filteredLinodesData,
+        linodesError
+      )}
+      noOptionsMessage={({ inputValue }) =>
+        linodesData.length === 0 || selectAll
+          ? 'No Linodes available.'
+          : 'No results.'
+      }
+      onChange={handleSelectLinodes}
+      placeholder="Select a Linode or type to search..."
+      aria-label="Select one or more Linodes"
+      textFieldProps={{
+        helperTextPosition: 'top',
+        helperText
+      }}
+      hideSelectedOptions={true}
+      {...selectProps}
+    />
+  );
+};
+
+export const generateOptions = (
+  allLinodesAreSelected: boolean,
+  showAllOption: boolean,
+  linodesData: LinodeProps['linodesData'],
+  linodeError: LinodeProps['linodesError']
+): Item<any>[] => {
+  /** if there's an error, don't show any options */
+  if (linodeError) {
+    return [];
+  }
+
+  const items = linodesData.map(eachLinode => ({
+    value: eachLinode.id,
+    label: eachLinode.label
+  }));
+
+  /** If there's no show all, just return the list of Items. */
+  if (!showAllOption) {
+    return items;
+  }
+
+  return allLinodesAreSelected
+    ? [
+        {
+          value: 'ALL',
+          label: 'All Linodes'
+        }
+      ]
+    : [
+        {
+          value: 'ALL',
+          label: 'All Linodes'
+        },
+        ...items
+      ];
+};
+
+export const userSelectedAllLinodes = (values: Item<string | number>[]) =>
+  values.some(eachValue => eachValue.value === 'ALL');
+
+const enhanced = compose<CombinedProps, Props>(React.memo, withLinodes());
+
+export default enhanced(LinodeMultiSelect);

--- a/packages/manager/src/components/LinodeMultiSelect/index.tsx
+++ b/packages/manager/src/components/LinodeMultiSelect/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './LinodeMultiSelect';

--- a/packages/manager/src/factories/linodes.ts
+++ b/packages/manager/src/factories/linodes.ts
@@ -1,0 +1,52 @@
+import * as Factory from 'factory.ts';
+import {
+  Linode,
+  LinodeAlerts,
+  LinodeBackups,
+  LinodeSpecs
+} from 'linode-js-sdk/lib/linodes/types';
+
+export const linodeAlertsFactory = Factory.Sync.makeFactory<LinodeAlerts>({
+  cpu: 10,
+  network_in: 0,
+  network_out: 0,
+  transfer_quota: 80,
+  io: 10000
+});
+
+export const linodeSpecsFactory = Factory.Sync.makeFactory<LinodeSpecs>({
+  disk: 51200,
+  memory: 2048,
+  vcpus: 1,
+  gpus: 0,
+  transfer: 2000
+});
+
+export const linodeBackupsFactory = Factory.Sync.makeFactory<LinodeBackups>({
+  enabled: true,
+  schedule: {
+    day: 'Scheduling',
+    window: 'Scheduling'
+  },
+  last_successful: '2020-01-01'
+});
+
+export const linodeFactory = Factory.Sync.makeFactory<Linode>({
+  id: Factory.each(i => i),
+  label: Factory.each(i => `linode-${i}`),
+  type: 'g6-standard-1',
+  region: 'us-east',
+  created: '2020-01-01',
+  updated: '2020-01-01',
+  hypervisor: 'kvm',
+  image: 'linode/debian10',
+  watchdog_enabled: true,
+  status: 'running',
+  ipv4: ['192.168.0.0'],
+  ipv6: '2600:3c00::f03c:92ff:fee2:6c40/64',
+  group: '',
+  alerts: linodeAlertsFactory.build(),
+  specs: linodeSpecsFactory.build(),
+  tags: [],
+  backups: linodeBackupsFactory.build()
+});

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddDeviceDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddDeviceDrawer.tsx
@@ -1,0 +1,73 @@
+import { APIError } from 'linode-js-sdk/lib/types';
+import * as React from 'react';
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
+import Drawer from 'src/components/Drawer';
+import LinodeMultiSelect from 'src/components/LinodeMultiSelect';
+import Notice from 'src/components/Notice';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+
+interface Props {
+  open: boolean;
+  error?: APIError[];
+  isSubmitting: boolean;
+  firewallLabel: string;
+  currentDevices: number[];
+  onClose: () => void;
+  addDevice: (selectedLinodes: number[]) => void;
+}
+
+export const AddDeviceDrawer: React.FC<Props> = props => {
+  const {
+    addDevice,
+    currentDevices,
+    error,
+    isSubmitting,
+    firewallLabel,
+    onClose,
+    open
+  } = props;
+
+  const [selectedLinodes, setSelectedLinodes] = React.useState<number[]>([]);
+
+  const handleSubmit = () => {
+    // @todo handling will have to be added here when we support Firewalls for NodeBalancers
+    addDevice(selectedLinodes);
+  };
+
+  const errorMessage = error
+    ? getAPIErrorOrDefault(error, 'Error adding Device')[0].reason
+    : undefined;
+
+  return (
+    <Drawer
+      title={`Add Device to Firewall: ${firewallLabel}`}
+      open={open}
+      onClose={onClose}
+    >
+      <form onSubmit={() => handleSubmit()}>
+        {errorMessage && <Notice error text={errorMessage} />}
+        <LinodeMultiSelect
+          handleChange={selected => setSelectedLinodes(selected)}
+          helperText="You can assign one or more Linodes to this Firewall."
+          filteredLinodes={currentDevices}
+        />
+        <ActionsPanel>
+          <Button
+            buttonType="primary"
+            onClick={() => handleSubmit()}
+            data-qa-submit
+            loading={isSubmitting}
+          >
+            Add
+          </Button>
+          <Button onClick={onClose} buttonType="cancel" data-qa-cancel>
+            Cancel
+          </Button>
+        </ActionsPanel>
+      </form>
+    </Drawer>
+  );
+};
+
+export default AddDeviceDrawer;

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallDevicesTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallDevicesTable.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { compose } from 'recompose';
 import Paper from 'src/components/core/Paper';
 import TableBody from 'src/components/core/TableBody';
+import TableCell from 'src/components/core/TableCell';
 import TableHead from 'src/components/core/TableHead';
 import TableRow from 'src/components/core/TableRow';
 import OrderBy from 'src/components/OrderBy';
@@ -61,6 +62,7 @@ const FirewallTable: React.FC<CombinedProps> = props => {
                         >
                           Linode
                         </TableSortCell>
+                        <TableCell />
                       </TableRow>
                     </TableHead>
                     <TableBody>

--- a/packages/manager/src/store/firewalls/devices.requests.ts
+++ b/packages/manager/src/store/firewalls/devices.requests.ts
@@ -4,19 +4,24 @@ import {
   FirewallDevice,
   getFirewallDevices as _get
 } from 'linode-js-sdk/lib/firewalls';
-import { getAll } from 'src/utilities/getAll';
+import { getAllWithArguments } from 'src/utilities/getAll';
 import { createRequestThunk } from '../store.helpers';
 import {
   addFirewallDeviceActions,
   getAllFirewallDevicesActions,
-  GetDevicesPayload,
   removeFirewallDeviceActions
 } from './devices.actions';
 
-const requestAll = (payload: GetDevicesPayload) =>
-  getAll<FirewallDevice>(({ passedParams, passedFilter }) =>
-    _get(payload.firewallID, passedParams, passedFilter)
-  )(payload.params, payload.filters);
+const requestAll = (payload: {
+  firewallID: number;
+  params?: any;
+  filter?: any;
+}) =>
+  getAllWithArguments<FirewallDevice>(_get)(
+    [payload.firewallID],
+    payload.params,
+    payload.filter
+  );
 
 export const getAllFirewallDevices = createRequestThunk(
   getAllFirewallDevicesActions,

--- a/packages/manager/src/utilities/getAll.ts
+++ b/packages/manager/src/utilities/getAll.ts
@@ -78,7 +78,7 @@ export const getAll: <T>(
             response => response.data
           )
         )
-          /** We're given NodeBalancer[][], so we flatten that, and append the first page response. */
+          /** We're given data[][], so we flatten that, and append the first page response. */
           .then(resultPages => {
             const combinedData = resultPages.reduce((result, nextPage) => {
               return [...result, ...nextPage];


### PR DESCRIPTION
## Description

- Adds an Add Device drawer
- Extracts the select multiple Linodes logic from AddFirewallDrawer to a new component (LinodeMultiSelect)

Still missing: 

- [x] Unit tests

## Note to Reviewers

To test: Use test account 4 or create your own Firewall. Navigate to /firewalls/id/linodes and click "Add Linodes to Firewall"  to try and add Linodes through the drawer. Please test all paths (success, failure, single addition, multiple additions, "All Linodes").