### PR TITLE
Feature/search logic

### DIFF
--- a/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
+++ b/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
@@ -29,7 +29,7 @@ import { requestAccount } from 'src/store/account/account.requests';
 import { requestAccountSettings } from 'src/store/accountSettings/accountSettings.requests';
 import { getAllBuckets } from 'src/store/bucket/bucket.requests';
 import { requestClusters } from 'src/store/clusters/clusters.actions';
-import { requestDomains } from 'src/store/domains/domains.actions';
+import { requestDomains } from 'src/store/domains/domains.requests';
 import { requestImages } from 'src/store/image/image.requests';
 import { requestLinodes } from 'src/store/linodes/linode.requests';
 import { requestTypes } from 'src/store/linodeType/linodeType.requests';

--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -80,6 +80,11 @@ export const MAX_VOLUME_SIZE = 10240;
 export const INTERVAL = 1000;
 
 /**
+ * Time after which data from the API is considered stale
+ */
+export const REFRESH_INTERVAL = 60000;
+
+/**
  * Used by e.g. LISH to determine the websocket connection address.
  * Whenever updating this, also update the corresponding name in resolvers.ts
  */

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -68,7 +68,7 @@ export const SearchBar: React.FC<CombinedProps> = props => {
   const [menuOpen, setMenuOpen] = React.useState<boolean>(false);
 
   const { _loading } = useReduxLoad(
-    ['linodes', 'nodeBalancers', 'images', 'domains', 'managed'],
+    ['linodes', 'nodeBalancers', 'images', 'domains'],
     60000,
     searchActive // Only request things if the search bar is open/active.
   );

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -79,15 +79,6 @@ class SearchBar extends React.Component<CombinedProps, State> {
     menuOpen: false
   };
 
-  dataAvailable() {
-    return (
-      this.state.linodes ||
-      this.state.volumes ||
-      this.state.nodebalancers ||
-      this.state.domains
-    );
-  }
-
   handleSearchChange = (searchText: string): void => {
     this.setState({ searchText });
 

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -8,6 +8,7 @@ import _Option from 'react-select/lib/components/Option';
 import { compose } from 'recompose';
 import IconButton from 'src/components/core/IconButton';
 import EnhancedSelect, { Item } from 'src/components/EnhancedSelect/Select';
+import { REFRESH_INTERVAL } from 'src/constants';
 import withTypes, { WithTypesProps } from 'src/containers/types.container';
 import withImages, { WithImages } from 'src/containers/withImages.container';
 import withStoreSearch, {
@@ -69,7 +70,7 @@ export const SearchBar: React.FC<CombinedProps> = props => {
 
   const { _loading } = useReduxLoad(
     ['linodes', 'nodeBalancers', 'images', 'domains'],
-    60000,
+    REFRESH_INTERVAL,
     searchActive // Only request things if the search bar is open/active.
   );
 

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -94,7 +94,7 @@ export const SearchBar: React.FC<CombinedProps> = props => {
     if (searchText !== '') {
       debouncedSearchAutoEvent('Search Auto', searchText);
     }
-    props.search(searchText);
+    props.search(_searchText);
   };
 
   const toggleSearch = () => {

--- a/packages/manager/src/hooks/useReduxLoad.ts
+++ b/packages/manager/src/hooks/useReduxLoad.ts
@@ -70,15 +70,18 @@ const requestMap: RequestMap = {
 
 export const useReduxLoad = <T>(
   deps: ReduxEntity[] = [],
-  refreshInterval: number = 60000
+  refreshInterval: number = 60000,
+  predicate: boolean = true
 ): UseReduxPreload => {
   const [_loading, setLoading] = useState<boolean>(false);
   const dispatch = useDispatch();
   const state = useStore<ApplicationState>().getState();
 
   useEffect(() => {
-    requestDeps(state, dispatch, deps, refreshInterval, setLoading);
-  }, []);
+    if (predicate) {
+      requestDeps(state, dispatch, deps, refreshInterval, setLoading);
+    }
+  }, [predicate]);
 
   return { _loading };
 };

--- a/packages/manager/src/hooks/useReduxLoad.ts
+++ b/packages/manager/src/hooks/useReduxLoad.ts
@@ -2,6 +2,7 @@ import * as Bluebird from 'bluebird';
 import { useEffect, useState } from 'react';
 import { useDispatch, useStore } from 'react-redux';
 import { Dispatch } from 'redux';
+import { REFRESH_INTERVAL } from 'src/constants';
 import { ApplicationState } from 'src/store';
 import { requestAccount } from 'src/store/account/account.requests';
 import { requestAccountSettings } from 'src/store/accountSettings/accountSettings.requests';
@@ -68,9 +69,9 @@ const requestMap: RequestMap = {
   firewalls: getAllFirewalls
 };
 
-export const useReduxLoad = <T>(
+export const useReduxLoad = (
   deps: ReduxEntity[] = [],
-  refreshInterval: number = 60000,
+  refreshInterval: number = REFRESH_INTERVAL,
   predicate: boolean = true
 ): UseReduxPreload => {
   const [_loading, setLoading] = useState<boolean>(false);

--- a/packages/manager/src/hooks/useReduxLoad.ts
+++ b/packages/manager/src/hooks/useReduxLoad.ts
@@ -5,6 +5,7 @@ import { ApplicationState } from 'src/store';
 import { requestAccount } from 'src/store/account/account.requests';
 import { requestAccountSettings } from 'src/store/accountSettings/accountSettings.requests';
 import { getAllBuckets } from 'src/store/bucket/bucket.requests';
+import { requestDomains } from 'src/store/domains/domains.requests';
 import { getEvents } from 'src/store/events/event.request';
 import { getAllFirewalls } from 'src/store/firewalls/firewalls.requests';
 import { requestImages } from 'src/store/image/image.requests';
@@ -29,6 +30,7 @@ export type ReduxEntity =
   | 'volumes'
   | 'account'
   | 'accountSettings'
+  | 'domains'
   | 'images'
   | 'kubernetes'
   | 'managed'
@@ -49,6 +51,7 @@ const requestMap: RequestMap = {
   volumes: getAllVolumes,
   account: requestAccount,
   accountSettings: requestAccountSettings,
+  domains: requestDomains,
   nodeBalancers: getAllNodeBalancers,
   images: requestImages,
   events: getEvents,

--- a/packages/manager/src/store/domains/domains.actions.ts
+++ b/packages/manager/src/store/domains/domains.actions.ts
@@ -1,16 +1,12 @@
 import {
   CreateDomainPayload,
   Domain,
-  getDomain,
-  getDomains,
   UpdateDomainPayload
 } from 'linode-js-sdk/lib/domains';
 import { APIError } from 'linode-js-sdk/lib/types';
-import { Dispatch } from 'redux';
-import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
-import { getAll } from 'src/utilities/getAll';
 import actionCreatorFactory from 'typescript-fsa';
-import { ThunkActionCreator } from '../types';
+
+import { GetAllData } from 'src/utilities/getAll';
 
 export interface DomainId {
   domainId: number;
@@ -18,19 +14,7 @@ export interface DomainId {
 
 export type UpdateDomainParams = DomainId & UpdateDomainPayload;
 
-/**
- * Actions
- */
 const actionCreator = actionCreatorFactory(`@@manager/domains`);
-
-export const getDomainsRequest = actionCreator('request');
-
-export const getDomainsSuccess = actionCreator<{
-  data: Domain[];
-  results: number;
-}>('success');
-
-export const getDomainsFailure = actionCreator<APIError[]>('fail');
 
 export const upsertDomain = actionCreator<Domain>('upsert');
 
@@ -52,44 +36,8 @@ export const deleteDomainActions = actionCreator.async<
   APIError[]
 >('delete');
 
-/**
- * Async
- */
-export const requestDomains: ThunkActionCreator<Promise<Domain[]>> = () => (
-  dispatch: Dispatch<any>
-) => {
-  dispatch(getDomainsRequest());
-
-  return getAll<Domain>(getDomains)()
-    .then(domains => {
-      dispatch(getDomainsSuccess(domains));
-      return domains;
-    })
-    .catch(err => {
-      const errors = getAPIErrorOrDefault(
-        err,
-        'There was an error retrieving your Domains.'
-      );
-      dispatch(getDomainsFailure(errors));
-      return err;
-    });
-};
-
-type RequestDomainForStoreThunk = ThunkActionCreator<void, number>;
-export const requestDomainForStore: RequestDomainForStoreThunk = id => (
-  dispatch,
-  getState
-) => {
-  const { data } = getState().__resources.domains;
-
-  const ids = data ? data.map(domain => domain.id) : [];
-
-  getDomain(id)
-    .then(response => response)
-    .then(domain => {
-      if (ids.includes(id)) {
-        return dispatch(upsertDomain(domain));
-      }
-      return dispatch(upsertDomain(domain));
-    });
-};
+export const getDomainsActions = actionCreator.async<
+  void,
+  GetAllData<Domain[]>,
+  APIError[]
+>('get-all');

--- a/packages/manager/src/store/domains/domains.reducer.ts
+++ b/packages/manager/src/store/domains/domains.reducer.ts
@@ -7,9 +7,7 @@ import {
   createDomainActions,
   deleteDomain,
   deleteDomainActions,
-  getDomainsFailure,
-  getDomainsRequest,
-  getDomainsSuccess,
+  getDomainsActions,
   updateDomainActions,
   upsertDomain
 } from './domains.actions';
@@ -32,32 +30,30 @@ export const defaultState: State = {
  * Reducer
  */
 const reducer: Reducer<State> = (state = defaultState, action) => {
-  if (isType(action, getDomainsRequest)) {
+  if (isType(action, getDomainsActions.started)) {
     return {
       ...state,
       loading: true
     };
   }
 
-  if (isType(action, getDomainsSuccess)) {
-    const {
-      payload: { data, results }
-    } = action;
+  if (isType(action, getDomainsActions.done)) {
+    const { result } = action.payload;
     return {
       ...state,
-      data: entitiesFromPayload(data),
-      results,
+      data: entitiesFromPayload(result.data),
+      results: result.results,
       lastUpdated: Date.now(),
       loading: false
     };
   }
 
-  if (isType(action, getDomainsFailure)) {
-    const { payload } = action;
+  if (isType(action, getDomainsActions.failed)) {
+    const { error } = action.payload;
     return {
       ...state,
       error: {
-        read: payload
+        read: error
       },
       loading: false
     };

--- a/packages/manager/src/store/domains/domains.requests.ts
+++ b/packages/manager/src/store/domains/domains.requests.ts
@@ -3,16 +3,24 @@ import {
   CreateDomainPayload,
   deleteDomain as _deleteDomain,
   Domain,
+  getDomain,
+  getDomains,
   updateDomain as _updateDomain
 } from 'linode-js-sdk/lib/domains';
 import { APIError } from 'linode-js-sdk/lib/types';
+import { Dispatch } from 'redux';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import { getAll } from 'src/utilities/getAll';
 import { createRequestThunk } from '../store.helpers';
+import { ThunkActionCreator } from '../types';
 import {
   createDomainActions,
   deleteDomainActions,
   DomainId,
+  getDomainsActions,
   updateDomainActions,
-  UpdateDomainParams
+  UpdateDomainParams,
+  upsertDomain
 } from './domains.actions';
 
 export const createDomain = createRequestThunk<
@@ -33,3 +41,42 @@ export const updateDomain = createRequestThunk<
 >(updateDomainActions, ({ domainId, ...payload }) =>
   _updateDomain(domainId, payload)
 );
+
+export const requestDomains: ThunkActionCreator<Promise<Domain[]>> = () => (
+  dispatch: Dispatch<any>
+) => {
+  dispatch(getDomainsActions.started());
+
+  return getAll<Domain>(getDomains)()
+    .then(domains => {
+      dispatch(getDomainsActions.done({ result: domains }));
+      return domains;
+    })
+    .catch(err => {
+      const errors = getAPIErrorOrDefault(
+        err,
+        'There was an error retrieving your Domains.'
+      );
+      dispatch(getDomainsActions.failed({ error: errors }));
+      return err;
+    });
+};
+
+type RequestDomainForStoreThunk = ThunkActionCreator<void, number>;
+export const requestDomainForStore: RequestDomainForStoreThunk = id => (
+  dispatch,
+  getState
+) => {
+  const { data } = getState().__resources.domains;
+
+  const ids = data ? data.map(domain => domain.id) : [];
+
+  getDomain(id)
+    .then(response => response)
+    .then(domain => {
+      if (ids.includes(id)) {
+        return dispatch(upsertDomain(domain));
+      }
+      return dispatch(upsertDomain(domain));
+    });
+};


### PR DESCRIPTION
## Description

In order to reduce request load, we have to change our search bar logic, since at present it expects that all entity data is always available.

I converted SearchBar to a function component so that we can use hooks there, but unfortunately we can't use the new useReduxLoad hook directly, since hooks can't be called conditionally and we only want to request data when the user opens the search menu (otherwise we haven't gained anything, since the search bar is always visible).

To fix this, I extracted the actual request-making logic from useReduxLoad and called it from within SearchBar (whenever searchActive becomes true). I don't feel great about this but it seems to work.

For testing purposes, I included "managed" in the list of deps. You can filter for managed or services in your dev tools and intercept those requests with Charles, then confirm that when you focus the search bar a) you can see the loading state and b) a request to managed is fired. You can play around with the initial requests array to experiment with this, but I didn't want to push anything that would break the app if you loaded the wrong page.