### PR TITLE
Adjustment for table cell dark theme styles

### DIFF
--- a/packages/manager/src/themes.ts
+++ b/packages/manager/src/themes.ts
@@ -480,7 +480,11 @@ export const dark = (options: ThemeOverrides) =>
       MuiTableCell: {
         root: {
           borderTop: `1px solid ${primaryColors.divider}`,
-          borderBottom: `1px solid ${primaryColors.divider}`
+          borderBottom: `1px solid ${primaryColors.divider}`,
+          '&:first-child': {
+            paddingLeft: 15,
+            borderLeft: '1px solid #2f3236'
+          }
         },
         head: {
           color: primaryColors.text,


### PR DESCRIPTION
## Description

In dark theme mode, the table cells were inheriting a white border. This fixes that!

## Type of Change
- Non breaking change ('update')
