### PR TITLE
Feature/device links

### DIFF
--- a/packages/manager/src/factories/firewalls.ts
+++ b/packages/manager/src/factories/firewalls.ts
@@ -37,8 +37,8 @@ export const firewallDeviceFactory = Factory.Sync.makeFactory<FirewallDevice>({
   updated: '2020-01-01',
   entity: {
     type: 'linode' as FirewallDeviceEntityType,
-    label: Factory.each(i => `factory-device-${i}`) as any,
-    id: Factory.each(i => i) as any,
+    label: 'entity',
+    id: 10,
     url: '/linodes/1'
   }
 });

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallRow.test.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallRow.test.tsx
@@ -2,12 +2,16 @@ import { cleanup, render } from '@testing-library/react';
 import {} from 'history';
 import * as React from 'react';
 import { firewalls } from 'src/__data__/firewalls';
-import { firewallFactory } from 'src/factories/firewalls';
-import { wrapWithTableBody } from 'src/utilities/testHelpers';
+import {
+  firewallDeviceFactory,
+  firewallFactory
+} from 'src/factories/firewalls';
+import { renderWithTheme, wrapWithTableBody } from 'src/utilities/testHelpers';
 import {
   CombinedProps,
   FirewallRow,
   getCountOfRules,
+  getDeviceLinks,
   getRuleString
 } from './FirewallRow';
 
@@ -54,6 +58,30 @@ describe('FirewallRow', () => {
       getByText(firewall.label);
       getByText(firewall.status);
       getByText(getRuleString(getCountOfRules(firewall.rules)));
+    });
+  });
+
+  describe('getDeviceLinks', () => {
+    it('should return a single Link if one Device is attached', () => {
+      const device = firewallDeviceFactory.build();
+      const links = getDeviceLinks([device]);
+      const { getByText } = renderWithTheme(links);
+      expect(getByText(device.entity.label));
+    });
+
+    it('should render up to three comma-separated links', () => {
+      const devices = firewallDeviceFactory.buildList(3);
+      const links = getDeviceLinks(devices);
+      const { queryAllByTestId } = renderWithTheme(links);
+      expect(queryAllByTestId('firewall-row-link')).toHaveLength(3);
+    });
+
+    it('should render "plus N more" text for any devices over three', () => {
+      const devices = firewallDeviceFactory.buildList(13);
+      const links = getDeviceLinks(devices);
+      const { getByText, queryAllByTestId } = renderWithTheme(links);
+      expect(queryAllByTestId('firewall-row-link')).toHaveLength(3);
+      expect(getByText(/10 more/));
     });
   });
 });

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallRow.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallRow.tsx
@@ -1,11 +1,12 @@
 import { Firewall, FirewallDevice } from 'linode-js-sdk/lib/firewalls';
 import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 import { compose } from 'recompose';
+import Typography from 'src/components/core/Typography';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import useFirewallDevices from 'src/hooks/useFirewallDevices';
-import { truncateAndJoinList } from 'src/utilities/stringUtils';
 import ActionMenu, { ActionHandlers } from './FirewallActionMenu';
 
 interface Props extends ActionHandlers {
@@ -97,7 +98,7 @@ const getLinodesCellString = (
   data: FirewallDevice[],
   loading: boolean,
   error?: APIError[]
-): string => {
+): string | JSX.Element => {
   if (loading) {
     return 'Loading...';
   }
@@ -110,8 +111,30 @@ const getLinodesCellString = (
     return 'None assigned';
   }
 
-  const deviceLabels = data.map(thisDevice => thisDevice.entity.label);
-  return truncateAndJoinList(deviceLabels, 3);
+  return getDeviceLinks(data);
+};
+
+export const getDeviceLinks = (data: FirewallDevice[]): JSX.Element => {
+  const firstThree = data.slice(0, 3);
+  return (
+    <>
+      {firstThree.map((thisDevice, idx) => (
+        <Link
+          className="link secondaryLink"
+          key={thisDevice.id}
+          to={`/linodes/${thisDevice.entity.id}`}
+        >
+          {idx > 0 && `, `}
+          {thisDevice.entity.label}
+        </Link>
+      ))}
+      {data.length > 3 && (
+        <Typography>
+          {` `}plus {data.length - 3} more.
+        </Typography>
+      )}
+    </>
+  );
 };
 
 export default compose<CombinedProps, Props>(React.memo)(FirewallRow);

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallRow.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallRow.tsx
@@ -123,6 +123,7 @@ export const getDeviceLinks = (data: FirewallDevice[]): JSX.Element => {
           className="link secondaryLink"
           key={thisDevice.id}
           to={`/linodes/${thisDevice.entity.id}`}
+          data-testid="firewall-row-link"
         >
           {idx > 0 && `, `}
           {thisDevice.entity.label}

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallRow.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallRow.tsx
@@ -3,7 +3,6 @@ import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { compose } from 'recompose';
-import Typography from 'src/components/core/Typography';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import useFirewallDevices from 'src/hooks/useFirewallDevices';
@@ -130,9 +129,9 @@ export const getDeviceLinks = (data: FirewallDevice[]): JSX.Element => {
         </Link>
       ))}
       {data.length > 3 && (
-        <Typography>
-          {` `}plus {data.length - 3} more.
-        </Typography>
+        <span>
+          {`, `}plus {data.length - 3} more.
+        </span>
       )}
     </>
   );


### PR DESCRIPTION
## Description

Make the device labels clickable in FirewallTableRow. We still need a solution for the hidden devices "plus 80 more", and I'm not sure I like the mixed styles. But if a firewall has one or two Linodes attached to it this will be very useful by itself.