### PR TITLE
Pin GitHub release link to linode-manager tag

### DIFF
--- a/packages/manager/src/features/Footer/Footer.tsx
+++ b/packages/manager/src/features/Footer/Footer.tsx
@@ -160,7 +160,7 @@ export class Footer extends React.PureComponent<CombinedProps> {
     return (
       <a
         className={className}
-        href={`https://github.com/linode/manager/releases/tag/v${VERSION}`}
+        href={`https://github.com/linode/manager/releases/tag/linode-manager@v${VERSION}`}
         target="_blank"
         aria-describedby="external-site"
         rel="noopener noreferrer"


### PR DESCRIPTION
## Description
This brings the footer up to date with our current tagging practice. This is backwards compatible (will work with the current release) and will allow us to stop creating the bogus 3rd tag for every release.

## To test:

Click the version link at the bottom of Cloud and make sure it takes you to a valid GitHub release.