### PR TITLE
M3-4020 Follow-up

### DIFF
--- a/packages/manager/src/components/LinodeMultiSelect/LinodeMultiSelect.tsx
+++ b/packages/manager/src/components/LinodeMultiSelect/LinodeMultiSelect.tsx
@@ -82,7 +82,7 @@ export const LinodeMultiSelect: React.FC<CombinedProps> = props => {
         linodesError
       )}
       noOptionsMessage={({ inputValue }) =>
-        linodesData.length === 0 || selectAll
+        filteredLinodesData.length === 0 || selectAll
           ? 'No Linodes available.'
           : 'No results.'
       }

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddDeviceDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddDeviceDrawer.tsx
@@ -35,10 +35,16 @@ export const AddDeviceDrawer: React.FC<Props> = props => {
   // the LinodeMultiSelect manages its state internally.
   const [key, setKey] = React.useState<string>(v4());
 
+  React.useEffect(() => {
+    // If we have a new error, clear out the select values
+    if (error && error.length > 0) {
+      setKey(v4());
+    }
+  }, [error]);
+
   const handleSubmit = () => {
     // @todo handling will have to be added here when we support Firewalls for NodeBalancers
     addDevice(selectedLinodes);
-    setKey(v4());
   };
 
   // @todo title and error messaging will update to "Device" once NodeBalancers are allowed

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddDeviceDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddDeviceDrawer.tsx
@@ -35,17 +35,23 @@ export const AddDeviceDrawer: React.FC<Props> = props => {
     addDevice(selectedLinodes);
   };
 
+  // @todo title and error messaging will update to "Device" once NodeBalancers are allowed
   const errorMessage = error
-    ? getAPIErrorOrDefault(error, 'Error adding Device')[0].reason
+    ? getAPIErrorOrDefault(error, 'Error adding Linode')[0].reason
     : undefined;
 
   return (
     <Drawer
-      title={`Add Device to Firewall: ${firewallLabel}`}
+      title={`Add Linode to Firewall: ${firewallLabel}`}
       open={open}
       onClose={onClose}
     >
-      <form onSubmit={() => handleSubmit()}>
+      <form
+        onSubmit={(e: React.ChangeEvent<HTMLFormElement>) => {
+          e.preventDefault();
+          handleSubmit();
+        }}
+      >
         {errorMessage && <Notice error text={errorMessage} />}
         <LinodeMultiSelect
           handleChange={selected => setSelectedLinodes(selected)}
@@ -55,7 +61,8 @@ export const AddDeviceDrawer: React.FC<Props> = props => {
         <ActionsPanel>
           <Button
             buttonType="primary"
-            onClick={() => handleSubmit()}
+            disabled={selectedLinodes.length === 0}
+            onClick={handleSubmit}
             data-qa-submit
             loading={isSubmitting}
           >

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddDeviceDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddDeviceDrawer.tsx
@@ -6,6 +6,7 @@ import Drawer from 'src/components/Drawer';
 import LinodeMultiSelect from 'src/components/LinodeMultiSelect';
 import Notice from 'src/components/Notice';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import v4 from 'uuid';
 
 interface Props {
   open: boolean;
@@ -30,9 +31,14 @@ export const AddDeviceDrawer: React.FC<Props> = props => {
 
   const [selectedLinodes, setSelectedLinodes] = React.useState<number[]>([]);
 
+  // Used to reset the selected form values on form submit, since
+  // the LinodeMultiSelect manages its state internally.
+  const [key, setKey] = React.useState<string>(v4());
+
   const handleSubmit = () => {
     // @todo handling will have to be added here when we support Firewalls for NodeBalancers
     addDevice(selectedLinodes);
+    setKey(v4());
   };
 
   // @todo title and error messaging will update to "Device" once NodeBalancers are allowed
@@ -54,6 +60,7 @@ export const AddDeviceDrawer: React.FC<Props> = props => {
       >
         {errorMessage && <Notice error text={errorMessage} />}
         <LinodeMultiSelect
+          key={key}
           handleChange={selected => setSelectedLinodes(selected)}
           helperText="You can assign one or more Linodes to this Firewall."
           filteredLinodes={currentDevices}


### PR DESCRIPTION
## Description

Assorted feedback items from the original PR and sprint review:

- disable addDevice form button if no Linodes have been selected
- Show slightly more helpful message if all Linodes are already attached
- use e.preventDefault() to prevent page from reloading when pressing Enter inside the <form>
- Use `key` prop to reset LinodeMultiSelect form state

When the Add Device form is submitted, and an error occurs,
the previously selected Linodes remained selected in the LinodeMultiSelect
field. They remained unchanged regardless of whether the Linode in question
was successfully added to the firewall.

This could cause problems, e.g.:

1. Select one invalid Linode and two valid Linodes
2. Submit the form
3. Observe: all 3 are still selected and an error is displayed for the "bad" Linode
4. Submit the form again
5. Observe: you can now get an error for the valid Linodes, since it's not
possible to re-add something that's already attached to the Firewall.

To fix this, I used React's key prop. By resetting the key on submit, the
LinodeMultiSelect is re-created, with new filteredLinodes props. The result
is that the select is cleared, and the user is unable to re-select any Linodes
that were successfully added.