### PR TITLE
Update Images messaging to reflect new 6144 MB default limit

### DIFF
--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -220,6 +220,9 @@ export const dcContinent: Record<string, ContinentKey> = {
 // Default error message for non-API errors
 export const DEFAULT_ERROR_MESSAGE = 'An unexpected error occurred.';
 
+// Default size limit for Images (some users have custom limits)
+export const IMAGE_DEFAULT_LIMIT = 6144;
+
 export const allowedHTMLTags = [
   'a',
   'abbr',

--- a/packages/manager/src/features/Images/ImagesDrawer.tsx
+++ b/packages/manager/src/features/Images/ImagesDrawer.tsx
@@ -17,6 +17,7 @@ import Drawer from 'src/components/Drawer';
 import Notice from 'src/components/Notice';
 import SectionErrorBoundary from 'src/components/SectionErrorBoundary';
 import TextField from 'src/components/TextField';
+import { IMAGE_DEFAULT_LIMIT } from 'src/constants';
 import withImages, {
   ImagesDispatch
 } from 'src/containers/withImages.container';
@@ -360,11 +361,12 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
               data-qa-disk-select
             />
             <Typography className={classes.helperText} variant="body1">
-              Linode Images are limited to 6144MB of data per disk by default.
-              Please ensure that your disk content does not exceed this size
-              limit, or open a Support ticket to request a higher limit.
-              Additionally, Linode Images cannot be created if you are using raw
-              disks or disks that have been formatted using custom filesystems.
+              Linode Images are limited to {IMAGE_DEFAULT_LIMIT}MB of data per
+              disk by default. Please ensure that your disk content does not
+              exceed this size limit, or open a Support ticket to request a
+              higher limit. Additionally, Linode Images cannot be created if you
+              are using raw disks or disks that have been formatted using custom
+              filesystems.
             </Typography>
           </>
         )}

--- a/packages/manager/src/features/Images/ImagesDrawer.tsx
+++ b/packages/manager/src/features/Images/ImagesDrawer.tsx
@@ -360,11 +360,11 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
               data-qa-disk-select
             />
             <Typography className={classes.helperText} variant="body1">
-              Linode Images are limited to 2048MB of data per disk. You will
-              need to ensure that your disk content does not exceed this size
-              limit. Additionally, Linode Images cannot be created if you are
-              using raw disks or disks that have been formatted using custom
-              filesystems.
+              Linode Images are limited to 6144MB of data per disk by default.
+              Please ensure that your disk content does not exceed this size
+              limit, or open a Support ticket to request a higher limit.
+              Additionally, Linode Images cannot be created if you are using raw
+              disks or disks that have been formatted using custom filesystems.
             </Typography>
           </>
         )}

--- a/packages/manager/src/features/TopMenu/UserEventsMenu/UserEventsList.tsx
+++ b/packages/manager/src/features/TopMenu/UserEventsMenu/UserEventsList.tsx
@@ -17,9 +17,7 @@ interface Props {
 
 type CombinedProps = Props & RouteComponentProps<void>;
 
-export const UserEventsList: React.StatelessComponent<
-  CombinedProps
-> = props => {
+export const UserEventsList: React.StatelessComponent<CombinedProps> = props => {
   const { events, closeMenu } = props;
 
   return (
@@ -39,7 +37,7 @@ export const UserEventsList: React.StatelessComponent<
             event.action === 'disk_imagize' && event.status === 'failed';
 
           const helperText = failedImage
-            ? 'This likely happened because your disk content was larger than the 2048 MB limit, or you attempted to imagize a raw or custom formatted disk.'
+            ? 'This likely happened because your disk content was larger than the 6144 MB limit, or you attempted to imagize a raw or custom formatted disk.'
             : '';
 
           const linkPath = createLinkHandlerForNotification(

--- a/packages/manager/src/features/TopMenu/UserEventsMenu/UserEventsList.tsx
+++ b/packages/manager/src/features/TopMenu/UserEventsMenu/UserEventsList.tsx
@@ -3,6 +3,7 @@ import * as moment from 'moment';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
+import { IMAGE_DEFAULT_LIMIT } from 'src/constants';
 import eventMessageGenerator from 'src/eventMessageGenerator';
 import { ExtendedEvent } from 'src/store/events/event.types';
 import createLinkHandlerForNotification from 'src/utilities/getEventsActionLinkStrings';
@@ -37,7 +38,7 @@ export const UserEventsList: React.StatelessComponent<CombinedProps> = props => 
             event.action === 'disk_imagize' && event.status === 'failed';
 
           const helperText = failedImage
-            ? 'This likely happened because your disk content was larger than the 6144 MB limit, or you attempted to imagize a raw or custom formatted disk.'
+            ? `This likely happened because your disk content was larger than the ${IMAGE_DEFAULT_LIMIT} MB limit, or you attempted to imagize a raw or custom formatted disk.`
             : '';
 
           const linkPath = createLinkHandlerForNotification(


### PR DESCRIPTION
## Description

DM for link to the post explaining why this is happening. The change should go live soon-ish, so we should update our messaging.