### PR TITLE
increase asset limit to 1.12 MB

### DIFF
--- a/packages/manager/config/webpack.config.prod.js
+++ b/packages/manager/config/webpack.config.prod.js
@@ -339,8 +339,8 @@ module.exports = {
   // See https://webpack.js.org/configuration/performance/
   performance: {
     hints: 'error',
-    maxEntrypointSize: 1140000,
-    maxAssetSize: 1140000, // ~1.08 MiB
+    maxEntrypointSize: 1180000, // ~1.12 MiB
+    maxAssetSize: 1180000, // ~1.12 MiB
     assetFilter: function(assetFilename) {
       return !(
         assetFilename.endsWith('.chunk.js') || assetFilename.endsWith('.map')


### PR DESCRIPTION
## Description

Looks, like build was broken by check of the assets max size.
With recent addition of firewall it seems to make some sense that we increased by about ~ 200kb
I upgraded the limit to 1.12 MB (Instead of 1.08) to trigger only in case of a big bump over our current new size (1.09).