### PR TITLE
Use factories in node pools test to resolve console error

### DIFF
--- a/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolDisplayTable.test.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolDisplayTable.test.tsx
@@ -2,14 +2,14 @@ import { cleanup, fireEvent, render } from '@testing-library/react';
 import * as React from 'react';
 
 import { extendedTypes } from 'src/__data__/ExtendedType';
-import { nodePoolRequests } from 'src/__data__/nodePools';
+import { nodePoolFactory } from 'src/factories/kubernetesCluster';
 import { wrapWithTheme } from 'src/utilities/testHelpers';
 
 import NodePoolDisplayTable from './NodePoolDisplayTable';
 
 const props = {
   types: extendedTypes,
-  pools: nodePoolRequests,
+  pools: nodePoolFactory.buildList(5),
   editable: true,
   loading: false,
   handleDelete: jest.fn(),


### PR DESCRIPTION
## Description

Console noise was bugging me.

## Note to Reviewers

On `develop`, `yarn test nodepooldisplay` will give a bunch of duplicate key errors.
On this branch, should be clean.