### PR TITLE
Adjust header padding in Linode Group By Tag

### DIFF
--- a/packages/manager/src/features/Domains/ListGroupedDomains.tsx
+++ b/packages/manager/src/features/Domains/ListGroupedDomains.tsx
@@ -47,7 +47,7 @@ const styles = (theme: Theme) =>
       }
     },
     groupContainer: {
-      '&:first-of-type': {
+      [theme.breakpoints.up('md')]: {
         '& $tagHeaderRow > td': {
           padding: `${theme.spacing(1) + 2}px 0`
         }

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/ListGroupedNodeBalancers.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/ListGroupedNodeBalancers.tsx
@@ -47,7 +47,7 @@ const styles = (theme: Theme) =>
     title: { marginBottom: theme.spacing(2) },
     transferred: { width: '10%', minWidth: 100 },
     groupContainer: {
-      '&:first-of-type': {
+      [theme.breakpoints.up('md')]: {
         '& $tagHeaderRow > td': {
           padding: '10px 0'
         }

--- a/packages/manager/src/features/Volumes/ListGroupedVolumes.tsx
+++ b/packages/manager/src/features/Volumes/ListGroupedVolumes.tsx
@@ -46,7 +46,7 @@ const styles = (theme: Theme) =>
       }
     },
     groupContainer: {
-      '&:first-of-type': {
+      [theme.breakpoints.up('md')]: {
         '& $tagHeaderRow > td': {
           padding: '10px 0'
         }

--- a/packages/manager/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
@@ -47,7 +47,7 @@ const styles = (theme: Theme) =>
       }
     },
     groupContainer: {
-      '&:first-of-type': {
+      [theme.breakpoints.up('md')]: {
         '& $tagHeaderRow > td': {
           padding: '10px 0'
         }


### PR DESCRIPTION
# Description

Addresses https://github.com/linode/manager/issues/6191.

Previously right/left padding was set to 0 for all groups except the first. I think originally this was probably to make the "No tags" group stand out, since the "No tags" group used to be first in the table. This has since changed, and now "No tags" is the last group in the list.

I tried applying the 0 padding to the *last* group (where the "No tags" group currently lives) but this looked a bit off to me.

Instead I applied the 0 padding everywhere, except for smaller viewports where the cards are used (this looked better to me).

@WilkinsKa1 and @tiffwong let me know if this looks OK to you.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Please check `/linodes` with all display options (group by tag, list, grid, etc.).