### PR TITLE
[Performance] NodeBalancers part II

### DIFF
--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -153,10 +153,7 @@ export class App extends React.Component<CombinedProps, State> {
       accountSettingsError,
       accountSettingsLoading,
       userId,
-      username,
-      volumesLoading,
-      bucketsLoading,
-      nodeBalancersLoading
+      username
     } = this.props;
 
     if (hasError) {
@@ -214,17 +211,8 @@ export class App extends React.Component<CombinedProps, State> {
           linodesLoadedOrErrorExists={
             linodesLoading === false || !!linodesError
           }
-          volumesLoadedOrErrorExists={
-            volumesLoading === false || !!volumesError
-          }
           domainsLoadedOrErrorExists={
             domainsLoading === false || !!domainsError
-          }
-          bucketsLoadedOrErrorExists={
-            bucketsLoading === false || !!bucketsError
-          }
-          nodeBalancersLoadedOrErrorExists={
-            nodeBalancersLoading === false || !!nodeBalancersError
           }
           profileLoadedOrErrorExists={!!this.props.userId || !!profileError}
           accountLoadedOrErrorExists={

--- a/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.test.tsx
+++ b/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.test.tsx
@@ -23,13 +23,6 @@ const component = shallow<AuthenticationWrapper>(
     requestProfile={jest.fn()}
     requestRegions={jest.fn()}
     requestSettings={jest.fn()}
-    nodeBalancerActions={{
-      createNodeBalancer: jest.fn(),
-      deleteNodeBalancer: jest.fn(),
-      getAllNodeBalancers: jest.fn(),
-      getAllNodeBalancersWithConfigs: jest.fn(),
-      updateNodeBalancer: jest.fn()
-    }}
   >
     <div />
   </AuthenticationWrapper>

--- a/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
+++ b/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
@@ -11,7 +11,6 @@ import { Profile } from 'linode-js-sdk/lib/profile';
 import { Region } from 'linode-js-sdk/lib/regions';
 import * as React from 'react';
 import { connect, MapDispatchToProps } from 'react-redux';
-import { compose } from 'recompose';
 import { Action } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 
@@ -28,16 +27,12 @@ import { requestDomains } from 'src/store/domains/domains.requests';
 import { requestImages } from 'src/store/image/image.requests';
 import { requestLinodes } from 'src/store/linodes/linode.requests';
 import { requestTypes } from 'src/store/linodeType/linodeType.requests';
-import {
-  withNodeBalancerActions,
-  WithNodeBalancerActions
-} from 'src/store/nodeBalancer/nodeBalancer.containers';
 import { requestNotifications } from 'src/store/notification/notification.requests';
 import { requestProfile } from 'src/store/profile/profile.requests';
 import { requestRegions } from 'src/store/regions/regions.actions';
 import { GetAllData } from 'src/utilities/getAll';
 
-type CombinedProps = DispatchProps & StateProps & WithNodeBalancerActions;
+type CombinedProps = DispatchProps & StateProps;
 
 export class AuthenticationWrapper extends React.Component<CombinedProps> {
   state = {
@@ -54,9 +49,6 @@ export class AuthenticationWrapper extends React.Component<CombinedProps> {
       return;
     }
 
-    const {
-      nodeBalancerActions: { getAllNodeBalancersWithConfigs }
-    } = this.props;
     // Initial Requests
     const dataFetchingPromises: Promise<any>[] = [
       this.props.requestAccount(),
@@ -67,8 +59,7 @@ export class AuthenticationWrapper extends React.Component<CombinedProps> {
       this.props.requestNotifications(),
       this.props.requestSettings(),
       this.props.requestTypes(),
-      this.props.requestRegions(),
-      getAllNodeBalancersWithConfigs()
+      this.props.requestRegions()
     ];
 
     try {
@@ -170,7 +161,4 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
 
 const connected = connect(mapStateToProps, mapDispatchToProps);
 
-export default compose<CombinedProps, {}>(
-  connected,
-  withNodeBalancerActions
-)(AuthenticationWrapper);
+export default connected(AuthenticationWrapper);

--- a/packages/manager/src/components/DataLoadedListener.tsx
+++ b/packages/manager/src/components/DataLoadedListener.tsx
@@ -11,9 +11,6 @@ interface Props {
   profileLoadedOrErrorExists: boolean;
   accountLoadedOrErrorExists: boolean;
   linodesLoadedOrErrorExists: boolean;
-  volumesLoadedOrErrorExists: boolean;
-  nodeBalancersLoadedOrErrorExists: boolean;
-  bucketsLoadedOrErrorExists: boolean;
   domainsLoadedOrErrorExists: boolean;
   accountSettingsLoadedOrErrorExists: boolean;
   markAppAsLoaded: () => void;

--- a/packages/manager/src/components/DataLoadedListener.tsx
+++ b/packages/manager/src/components/DataLoadedListener.tsx
@@ -28,9 +28,6 @@ const DataLoadedListener: React.FC<Props> = props => {
         props.profileLoadedOrErrorExists,
         props.accountLoadedOrErrorExists,
         props.linodesLoadedOrErrorExists,
-        props.volumesLoadedOrErrorExists,
-        props.nodeBalancersLoadedOrErrorExists,
-        props.bucketsLoadedOrErrorExists,
         props.domainsLoadedOrErrorExists,
         props.accountSettingsLoadedOrErrorExists,
         props.flagsHaveLoaded
@@ -50,9 +47,6 @@ const shouldMarkAppAsDone = (
   profileLoadedOrErrorExists: boolean,
   accountLoadedOrErrorExists: boolean,
   linodesLoadedOrErrorExists: boolean,
-  volumesLoadedOrErrorExists: boolean,
-  nodeBalancersLoadedOrErrorExists: boolean,
-  bucketsLoadedOrErrorExists: boolean,
   domainsLoadedOrErrorExists: boolean,
   accountSettingsLoadedOrErrorExists: boolean,
   flagsHaveLoaded: boolean
@@ -100,11 +94,11 @@ const shouldMarkAppAsDone = (
     return true;
   }
 
-  if (pathname.match(/volume/i) && !!volumesLoadedOrErrorExists) {
+  if (pathname.match(/volume/i)) {
     return true;
   }
 
-  if (pathname.match(/nodebalancer/i) && !!nodeBalancersLoadedOrErrorExists) {
+  if (pathname.match(/nodebalancer/i)) {
     return true;
   }
 

--- a/packages/manager/src/components/DataLoadedListener.tsx
+++ b/packages/manager/src/components/DataLoadedListener.tsx
@@ -88,7 +88,6 @@ const shouldMarkAppAsDone = (
   if (
     pathname.match(/dashboard/i) &&
     linodesLoadedOrErrorExists &&
-    nodeBalancersLoadedOrErrorExists &&
     accountLoadedOrErrorExists &&
     profileLoadedOrErrorExists &&
     domainsLoadedOrErrorExists

--- a/packages/manager/src/containers/withNodeBalancers.container.ts
+++ b/packages/manager/src/containers/withNodeBalancers.container.ts
@@ -27,14 +27,12 @@ export default <TInner extends {}, TOuter extends {}>(
      *
      * NodeBalancer[]
      */
-    const nodeBalancers = Object.keys(itemsById).map(
-      eachKey => itemsById[eachKey]
-    );
+    const nodeBalancers = Object.values(itemsById);
 
     return mapToProps(
       ownProps,
       nodeBalancers,
       loading,
-      error ? error.read : undefined
+      error?.read ?? undefined
     );
   });

--- a/packages/manager/src/containers/withNodeBalancers.container.ts
+++ b/packages/manager/src/containers/withNodeBalancers.container.ts
@@ -7,6 +7,8 @@ type MapProps<TOuter, TInner> = (
   ownProps: TOuter,
   nodeBalancers: NodeBalancer[],
   loading: boolean,
+  results: number,
+  lastUpdated: number,
   error?: APIError[]
 ) => TInner;
 
@@ -14,7 +16,13 @@ export default <TInner extends {}, TOuter extends {}>(
   mapToProps: MapProps<TOuter, TInner>
 ) =>
   connect((state: ApplicationState, ownProps: TOuter) => {
-    const { loading, error, itemsById } = state.__resources.nodeBalancers;
+    const {
+      lastUpdated,
+      loading,
+      error,
+      itemsById,
+      results
+    } = state.__resources.nodeBalancers;
 
     /** itemsById looks like this
      *
@@ -33,6 +41,8 @@ export default <TInner extends {}, TOuter extends {}>(
       ownProps,
       nodeBalancers,
       loading,
+      results,
+      lastUpdated,
       error?.read ?? undefined
     );
   });

--- a/packages/manager/src/features/Dashboard/NodeBalancersDashboardCard/NodeBalancersDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/NodeBalancersDashboardCard/NodeBalancersDashboardCard.tsx
@@ -101,21 +101,29 @@ const NodeBalancersDashboardCard: React.FunctionComponent<CombinedProps> = props
     nodeBalancersError,
     nodeBalancersLastUpdated,
     nodeBalancersLoading,
+    nodeBalancersResults,
     nodeBalancersData
   } = props;
 
   React.useEffect(() => {
-    getNodeBalancerPage({ page_size: 25, page: 1 });
+    if (
+      nodeBalancersLastUpdated === 0 &&
+      nodeBalancersResults === 0 &&
+      !nodeBalancersLoading
+    ) {
+      // We don't have any data available and we aren't currently requesting it, so ask the API for what we need
+      getNodeBalancerPage({ page_size: 25, page: 1 });
+    }
   }, []);
 
   const data = take(5, nodeBalancersData);
 
   const renderAction = () =>
-    nodeBalancersData.length > 5 ? (
+    nodeBalancersResults > 5 ? (
       <ViewAllLink
         text="View All"
         link={'/nodebalancers'}
-        count={nodeBalancersData.length}
+        count={nodeBalancersResults}
       />
     ) : null;
 
@@ -213,7 +221,8 @@ const withNodeBalancers = NodeBalancerContainer(
     nodeBalancersData,
     nodeBalancersLoading,
     nodeBalancersLastUpdated,
-    nodeBalancersError
+    nodeBalancersError,
+    nodeBalancersResults
   })
 );
 const enhanced = compose<CombinedProps, {}>(

--- a/packages/manager/src/features/Dashboard/NodeBalancersDashboardCard/NodeBalancersDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/NodeBalancersDashboardCard/NodeBalancersDashboardCard.tsx
@@ -85,6 +85,8 @@ const styles = (theme: Theme) =>
 interface NodeBalancerProps {
   nodeBalancersData: NodeBalancer[];
   nodeBalancersLoading: boolean;
+  nodeBalancersLastUpdated: number;
+  nodeBalancersResults: number;
   nodeBalancersError?: APIError[];
 }
 
@@ -97,6 +99,7 @@ const NodeBalancersDashboardCard: React.FunctionComponent<CombinedProps> = props
     classes,
     nodeBalancerActions: { getNodeBalancerPage },
     nodeBalancersError,
+    nodeBalancersLastUpdated,
     nodeBalancersLoading,
     nodeBalancersData
   } = props;
@@ -117,7 +120,7 @@ const NodeBalancersDashboardCard: React.FunctionComponent<CombinedProps> = props
     ) : null;
 
   const renderContent = () => {
-    if (nodeBalancersLoading && nodeBalancersData.length === 0) {
+    if (nodeBalancersLoading && nodeBalancersLastUpdated === 0) {
       return renderLoading();
     }
 
@@ -198,10 +201,18 @@ const NodeBalancersDashboardCard: React.FunctionComponent<CombinedProps> = props
 const styled = withStyles(styles);
 
 const withNodeBalancers = NodeBalancerContainer(
-  (ownProps, nodeBalancersData, nodeBalancersLoading, nodeBalancersError) => ({
+  (
+    ownProps,
+    nodeBalancersData,
+    nodeBalancersLoading,
+    nodeBalancersResults,
+    nodeBalancersLastUpdated,
+    nodeBalancersError
+  ) => ({
     ...ownProps,
     nodeBalancersData,
     nodeBalancersLoading,
+    nodeBalancersLastUpdated,
     nodeBalancersError
   })
 );

--- a/packages/manager/src/features/Dashboard/NodeBalancersDashboardCard/NodeBalancersDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/NodeBalancersDashboardCard/NodeBalancersDashboardCard.tsx
@@ -25,6 +25,11 @@ import TableRowLoading from 'src/components/TableRowLoading';
 import ViewAllLink from 'src/components/ViewAllLink';
 import NodeBalancerContainer from 'src/containers/withNodeBalancers.container';
 import RegionIndicator from 'src/features/linodes/LinodesLanding/RegionIndicator';
+import {
+  withNodeBalancerActions,
+  WithNodeBalancerActions
+} from 'src/store/nodeBalancer/nodeBalancer.containers';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import DashboardCard from '../DashboardCard';
 
 type ClassNames =
@@ -83,15 +88,22 @@ interface NodeBalancerProps {
   nodeBalancersError?: APIError[];
 }
 
-type CombinedProps = NodeBalancerProps & WithStyles<ClassNames>;
+type CombinedProps = NodeBalancerProps &
+  WithNodeBalancerActions &
+  WithStyles<ClassNames>;
 
 const NodeBalancersDashboardCard: React.FunctionComponent<CombinedProps> = props => {
   const {
     classes,
+    nodeBalancerActions: { getNodeBalancerPage },
     nodeBalancersError,
     nodeBalancersLoading,
     nodeBalancersData
   } = props;
+
+  React.useEffect(() => {
+    getNodeBalancerPage({ page_size: 25, page: 1 });
+  }, []);
 
   const data = take(5, nodeBalancersData);
 
@@ -125,7 +137,12 @@ const NodeBalancersDashboardCard: React.FunctionComponent<CombinedProps> = props
   };
 
   const renderErrors = (errors: APIError[]) => (
-    <TableRowError colSpan={2} message={`Unable to load NodeBalancers.`} />
+    <TableRowError
+      colSpan={2}
+      message={
+        getAPIErrorOrDefault(errors, 'Unable to load NodeBalancers.')[0].reason
+      }
+    />
   );
 
   const renderEmpty = () => <TableRowEmptyState colSpan={2} />;
@@ -188,6 +205,10 @@ const withNodeBalancers = NodeBalancerContainer(
     nodeBalancersError
   })
 );
-const enhanced = compose<CombinedProps, {}>(withNodeBalancers, styled);
+const enhanced = compose<CombinedProps, {}>(
+  withNodeBalancers,
+  withNodeBalancerActions,
+  styled
+);
 
 export default enhanced(NodeBalancersDashboardCard);

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.test.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.test.tsx
@@ -24,7 +24,8 @@ describe.skip('NodeBalancers', () => {
               createNodeBalancer: jest.fn(),
               deleteNodeBalancer: jest.fn(),
               getAllNodeBalancers: jest.fn(),
-              getAllNodeBalancersWithConfigs: jest.fn()
+              getAllNodeBalancersWithConfigs: jest.fn(),
+              getNodeBalancerPage: jest.fn()
             }}
             setDocs={jest.fn()}
             clearDocs={jest.fn()}

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.test.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.test.tsx
@@ -25,7 +25,8 @@ describe.skip('NodeBalancers', () => {
               deleteNodeBalancer: jest.fn(),
               getAllNodeBalancers: jest.fn(),
               getAllNodeBalancersWithConfigs: jest.fn(),
-              getNodeBalancerPage: jest.fn()
+              getNodeBalancerPage: jest.fn(),
+              getNodeBalancerWithConfigs: jest.fn()
             }}
             setDocs={jest.fn()}
             clearDocs={jest.fn()}

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.tsx
@@ -131,11 +131,17 @@ export class NodeBalancersLanding extends React.Component<
   pollInterval: number;
 
   componentDidMount() {
+    const { getAllNodeBalancersWithConfigs } = this.props.nodeBalancerActions;
+    /**
+     * Normally we check for lastUpdated === 0 before requesting data,
+     * but since this page is already polling every 30 seconds (@todo should it?),
+     * it seems counterintuitive to make the first request conditional.
+     */
+    getAllNodeBalancersWithConfigs();
     /**
      * To keep NB node status up to date, poll NodeBalancers and configs every 30 seconds while the
      * user is on this page.
      */
-    const { getAllNodeBalancersWithConfigs } = this.props.nodeBalancerActions;
     this.pollInterval = window.setInterval(
       () => getAllNodeBalancersWithConfigs(),
       30 * 1000

--- a/packages/manager/src/store/nodeBalancer/nodeBalancer.containers.ts
+++ b/packages/manager/src/store/nodeBalancer/nodeBalancer.containers.ts
@@ -10,7 +10,8 @@ import {
 import {
   getAllNodeBalancers,
   getAllNodeBalancersWithConfigs,
-  getNodeBalancersPage
+  getNodeBalancersPage,
+  getNodeBalancerWithConfigs
 } from 'src/store/nodeBalancer/nodeBalancer.requests';
 import { UpdateNodeBalancerParams } from './nodeBalancer.actions';
 import {
@@ -22,6 +23,7 @@ import {
 export interface WithNodeBalancerActions {
   nodeBalancerActions: {
     getAllNodeBalancersWithConfigs: () => Promise<void>;
+    getNodeBalancerWithConfigs: (nodeBalancerID: number) => Promise<void>;
     getNodeBalancerPage: (params?: any, filters?: any) => Promise<void>;
     getAllNodeBalancers: () => Promise<NodeBalancer[]>;
     createNodeBalancer: (
@@ -49,7 +51,9 @@ export const withNodeBalancerActions = connect(
         dispatch
       ),
       getNodeBalancerPage: (params: any = {}, filters: any = {}) =>
-        dispatch(getNodeBalancersPage({ params, filters }))
+        dispatch(getNodeBalancersPage({ params, filters })),
+      getNodeBalancerWithConfigs: (nodeBalancerId: number) =>
+        dispatch(getNodeBalancerWithConfigs({ nodeBalancerId }))
     }
   })
 );

--- a/packages/manager/src/store/nodeBalancer/nodeBalancer.containers.ts
+++ b/packages/manager/src/store/nodeBalancer/nodeBalancer.containers.ts
@@ -1,13 +1,16 @@
 import { NodeBalancer } from 'linode-js-sdk/lib/nodebalancers';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
+import { Action, bindActionCreators } from 'redux';
+import { ThunkDispatch } from 'redux-thunk';
+import { ApplicationState } from 'src/store';
 import {
   CreateNodeBalancerParams,
   DeleteNodeBalancerParams
 } from 'src/store/nodeBalancer/nodeBalancer.actions';
 import {
   getAllNodeBalancers,
-  getAllNodeBalancersWithConfigs
+  getAllNodeBalancersWithConfigs,
+  getNodeBalancersPage
 } from 'src/store/nodeBalancer/nodeBalancer.requests';
 import { UpdateNodeBalancerParams } from './nodeBalancer.actions';
 import {
@@ -19,6 +22,7 @@ import {
 export interface WithNodeBalancerActions {
   nodeBalancerActions: {
     getAllNodeBalancersWithConfigs: () => Promise<void>;
+    getNodeBalancerPage: (params?: any, filters?: any) => Promise<void>;
     getAllNodeBalancers: () => Promise<NodeBalancer[]>;
     createNodeBalancer: (
       params: CreateNodeBalancerParams
@@ -32,16 +36,20 @@ export interface WithNodeBalancerActions {
 
 export const withNodeBalancerActions = connect(
   undefined,
-  dispatch => ({
-    nodeBalancerActions: bindActionCreators(
-      {
-        getAllNodeBalancersWithConfigs,
-        getAllNodeBalancers,
-        createNodeBalancer,
-        deleteNodeBalancer,
-        updateNodeBalancer
-      },
-      dispatch
-    )
+  (dispatch: ThunkDispatch<ApplicationState, undefined, Action<any>>) => ({
+    nodeBalancerActions: {
+      ...bindActionCreators(
+        {
+          getAllNodeBalancersWithConfigs,
+          getAllNodeBalancers,
+          createNodeBalancer,
+          deleteNodeBalancer,
+          updateNodeBalancer
+        },
+        dispatch
+      ),
+      getNodeBalancerPage: (params: any = {}, filters: any = {}) =>
+        dispatch(getNodeBalancersPage({ params, filters }))
+    }
   })
 );

--- a/packages/manager/src/store/nodeBalancer/nodeBalancer.requests.ts
+++ b/packages/manager/src/store/nodeBalancer/nodeBalancer.requests.ts
@@ -129,8 +129,8 @@ export const getNodeBalancerWithConfigs: ThunkActionCreator<
 
   try {
     const nodeBalancer = await _getNodeBalancer(nodeBalancerId);
-    const { data: nodeBalancerConfigs } = await getAll<NodeBalancerConfig>(
-      getNodeBalancerConfigs
+    const { data: nodeBalancerConfigs } = await getAll<NodeBalancerConfig>(() =>
+      getNodeBalancerConfigs(nodeBalancerId)
     )();
     dispatch(addNodeBalancerConfigs(nodeBalancerConfigs));
     dispatch(done({ params, result: nodeBalancer }));


### PR DESCRIPTION
## Description

- [x] Add getPage to nodebalancers.container
- [x] Remove getAll requests from AuthenticationWrapper
- [x] Add getAll requests where they belong (NB landing and detail)
- [x] Use getPage on the Dashboard

There may be a part III, since it turns out NB detail doesn't use Redux at all, and just eternally polls the API to maintain its internal state. Fixing this is a lot of overhead and won't actually save many requests (polling is polling), but I still think it's worth it if I have time.