### PR TITLE
Update Redux store after importing Domain Zone

### DIFF
--- a/packages/manager/src/containers/domains.container.ts
+++ b/packages/manager/src/containers/domains.container.ts
@@ -12,6 +12,7 @@ import {
   updateDomain
 } from 'src/store/domains/domains.requests';
 import { EntityError, ThunkDispatch } from 'src/store/types';
+import { Action } from 'typescript-fsa';
 
 export interface StateProps {
   domainsData?: Domain[];
@@ -23,7 +24,7 @@ export interface DomainActionsProps {
   createDomain: (payload: CreateDomainPayload) => Promise<Domain>;
   updateDomain: (params: UpdateDomainParams & DomainId) => Promise<Domain>;
   deleteDomain: (domainId: DomainId) => Promise<{}>;
-  upsertDomain: (domain: Domain) => Promise<Domain>;
+  upsertDomain: (domain: Domain) => Action<Domain>;
 }
 
 export type Props = StateProps & DomainActionsProps;

--- a/packages/manager/src/containers/domains.container.ts
+++ b/packages/manager/src/containers/domains.container.ts
@@ -3,7 +3,8 @@ import { connect } from 'react-redux';
 import { ApplicationState } from 'src/store';
 import {
   DomainId,
-  UpdateDomainParams
+  UpdateDomainParams,
+  upsertDomain
 } from 'src/store/domains/domains.actions';
 import {
   createDomain,
@@ -22,6 +23,7 @@ export interface DomainActionsProps {
   createDomain: (payload: CreateDomainPayload) => Promise<Domain>;
   updateDomain: (params: UpdateDomainParams & DomainId) => Promise<Domain>;
   deleteDomain: (domainId: DomainId) => Promise<{}>;
+  upsertDomain: (domain: Domain) => Promise<Domain>;
 }
 
 export type Props = StateProps & DomainActionsProps;
@@ -56,6 +58,7 @@ export default <InnerStateProps extends {}, TOuter extends {}>(
         dispatch(createDomain(payload)),
       updateDomain: (params: UpdateDomainParams & DomainId) =>
         dispatch(updateDomain(params)),
-      deleteDomain: (domainId: DomainId) => dispatch(deleteDomain(domainId))
+      deleteDomain: (domainId: DomainId) => dispatch(deleteDomain(domainId)),
+      upsertDomain: (domain: Domain) => dispatch(upsertDomain(domain))
     })
   );

--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -164,6 +164,9 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
     notification: e =>
       `A domain record has been deleted from ${e.entity!.label}`
   },
+  domain_import: {
+    notification: e => `Domain ${e.entity?.label ?? ''} has been imported.`
+  },
   firewall_enable: {
     notification: e => `Firewall ${e.entity?.label ?? ''} has been enabled.`
   },

--- a/packages/manager/src/features/Domains/DomainsLanding.test.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.test.tsx
@@ -15,6 +15,7 @@ const props: CombinedProps = {
   createDomain: jest.fn(),
   updateDomain: jest.fn(),
   deleteDomain: jest.fn(),
+  upsertDomain: jest.fn(),
   linodesLoading: false,
   openForCloning: jest.fn(),
   openForCreating: jest.fn(),

--- a/packages/manager/src/features/Domains/DomainsLanding.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.tsx
@@ -174,6 +174,8 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
     });
 
   handleSuccess = (domain: Domain) => {
+    this.props.upsertDomain(domain);
+
     if (domain.id) {
       return this.props.history.push(`/domains/${domain.id}`);
     }


### PR DESCRIPTION
## Description

This fixes an issue described here: https://github.com/linode/manager/issues/6105

Previously after a successful zone import, we were redirecting to the Domain Detail page but not updating the Redux store with the domain. This resulted in a 404.

In this PR, we dispatch an `upsertDomain` action first to update the Redux store.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

**To test**, you need to you import a domain from another DNS provider that allows AXFR requests (you also need to whitelist Linode's servers as described [here](https://www.linode.com/docs/platform/manager/dns-manager/#import-domains-with-axfr)). I've got a test domain set up if you want to reach out to me for ease of testing.
