### PR TITLE
Multiple IP Input errors

### DIFF
--- a/packages/manager/src/components/MultipleIPInput/MultipleIPInput.test.tsx
+++ b/packages/manager/src/components/MultipleIPInput/MultipleIPInput.test.tsx
@@ -9,7 +9,7 @@ afterEach(cleanup);
 
 const baseProps: Props = {
   title: 'My Input',
-  ips: ['ip1', 'ip2', 'ip3'],
+  ips: [{ address: 'ip1' }, { address: 'ip2' }, { address: 'ip3' }],
   onChange: jest.fn()
 };
 
@@ -28,7 +28,12 @@ describe('MultipleIPInput', () => {
     const { getByText } = renderWithTheme(<MultipleIPInput {...baseProps} />);
     const addButton = getByText(/add/i);
     fireEvent.click(addButton);
-    expect(baseProps.onChange).toHaveBeenCalledWith(['ip1', 'ip2', 'ip3', '']);
+    expect(baseProps.onChange).toHaveBeenCalledWith([
+      { address: 'ip1' },
+      { address: 'ip2' },
+      { address: 'ip3' },
+      { address: '' }
+    ]);
   });
 
   it('all inputs after the first should have a close button (X)', () => {
@@ -44,6 +49,9 @@ describe('MultipleIPInput', () => {
     const { getByTestId } = renderWithTheme(<MultipleIPInput {...baseProps} />);
     const closeButton = getByTestId('delete-ip-1');
     fireEvent.click(closeButton);
-    expect(baseProps.onChange).toHaveBeenCalledWith(['ip1', 'ip3']);
+    expect(baseProps.onChange).toHaveBeenCalledWith([
+      { address: 'ip1' },
+      { address: 'ip3' }
+    ]);
   });
 });

--- a/packages/manager/src/components/MultipleIPInput/MultipleIPInput.tsx
+++ b/packages/manager/src/components/MultipleIPInput/MultipleIPInput.tsx
@@ -2,7 +2,6 @@
 import { InputBaseProps } from '@material-ui/core/InputBase';
 import Close from '@material-ui/icons/Close';
 import * as classnames from 'classnames';
-import { update } from 'ramda';
 import * as React from 'react';
 import AddNewLink from 'src/components/AddNewLink';
 import Button from 'src/components/Button';
@@ -12,6 +11,7 @@ import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
+import { ExtendedIP } from 'src/utilities/ipUtils';
 
 const useStyles = makeStyles((theme: Theme) => ({
   addIP: {
@@ -50,8 +50,8 @@ export interface Props {
   title: string;
   helperText?: string;
   error?: string;
-  ips: string[];
-  onChange: (ips: string[]) => void;
+  ips: ExtendedIP[];
+  onChange: (ips: ExtendedIP[]) => void;
   inputProps?: InputBaseProps;
   className?: string;
 }
@@ -64,12 +64,13 @@ export const MultipleIPInput: React.FC<Props> = props => {
     e: React.ChangeEvent<HTMLInputElement>,
     idx: number
   ) => {
-    const transferIPs = update(idx, e.target.value, ips);
-    onChange(transferIPs);
+    const newIPs = [...ips];
+    newIPs[idx].address = e.target.value;
+    onChange(newIPs);
   };
 
   const addNewInput = () => {
-    onChange([...ips, '']);
+    onChange([...ips, { address: '' }]);
   };
 
   const removeInput = (idx: number) => {
@@ -113,10 +114,12 @@ export const MultipleIPInput: React.FC<Props> = props => {
                 'aria-label': `${title} ip-address-${idx}`,
                 ...props.inputProps
               }}
-              value={thisIP}
+              value={thisIP.address}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                 handleChange(e, idx)
               }
+              error={Boolean(thisIP.error)}
+              errorText={thisIP.error}
               hideLabel
             />
           </Grid>

--- a/packages/manager/src/components/MultipleIPInput/MultipleIPInput.tsx
+++ b/packages/manager/src/components/MultipleIPInput/MultipleIPInput.tsx
@@ -118,7 +118,6 @@ export const MultipleIPInput: React.FC<Props> = props => {
               onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                 handleChange(e, idx)
               }
-              error={Boolean(thisIP.error)}
               errorText={thisIP.error}
               hideLabel
             />

--- a/packages/manager/src/features/Domains/DomainDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainDrawer.tsx
@@ -53,6 +53,11 @@ import {
 } from 'src/store/domains/domains.container';
 import { getAPIErrorOrDefault, getErrorMap } from 'src/utilities/errorUtils';
 import { sendCreateDomainEvent } from 'src/utilities/ga';
+import {
+  ExtendedIP,
+  extendedIPToString,
+  stringToExtendedIP
+} from 'src/utilities/ipUtils';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import DeleteDomain from './DeleteDomain';
 import { getInitialIPs, transferHelperText as helperText } from './domainUtils';
@@ -330,7 +335,7 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
           <React.Fragment>
             <MultipleIPInput
               title="Master Nameserver IP Address"
-              ips={this.state.master_ips}
+              ips={this.state.master_ips.map(stringToExtendedIP)}
               onChange={this.updateMasterIPAddress}
               error={masterIPsError}
             />
@@ -339,7 +344,7 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
               <MultipleIPInput
                 title="Domain Transfer IPs"
                 helperText={helperText}
-                ips={this.state.axfr_ips}
+                ips={this.state.axfr_ips.map(stringToExtendedIP)}
                 onChange={this.handleTransferInput}
                 error={errorMap.axfr_ips}
               />
@@ -464,8 +469,8 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
     );
   }
 
-  handleTransferInput = (newIPs: string[]) => {
-    const axfr_ips = newIPs.length > 0 ? newIPs : [''];
+  handleTransferInput = (newIPs: ExtendedIP[]) => {
+    const axfr_ips = newIPs.length > 0 ? newIPs.map(extendedIPToString) : [''];
     if (this.mounted) {
       this.setState({ axfr_ips });
     }
@@ -794,8 +799,9 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
     value: 'master' | 'slave'
   ) => this.setState({ type: value });
 
-  updateMasterIPAddress = (newIPs: string[]) => {
-    const master_ips = newIPs.length > 0 ? newIPs : [''];
+  updateMasterIPAddress = (newIPs: ExtendedIP[]) => {
+    const master_ips =
+      newIPs.length > 0 ? newIPs.map(extendedIPToString) : [''];
     if (this.mounted) {
       this.setState({ master_ips });
     }

--- a/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
@@ -34,6 +34,11 @@ import {
 } from 'src/store/domains/domains.container';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
+import {
+  ExtendedIP,
+  extendedIPToString,
+  stringToExtendedIP
+} from 'src/utilities/ipUtils';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import {
   getInitialIPs,
@@ -166,8 +171,9 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
     expire_sec: 'expire rate'
   };
 
-  handleTransferUpdate = (transferIPs: string[]) => {
-    const axfr_ips = transferIPs.length > 0 ? transferIPs : [''];
+  handleTransferUpdate = (transferIPs: ExtendedIP[]) => {
+    const axfr_ips =
+      transferIPs.length > 0 ? transferIPs.map(extendedIPToString) : [''];
     this.updateField('axfr_ips')(axfr_ips);
   };
 
@@ -398,18 +404,23 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
     );
   };
 
-  DomainTransferField = () => (
-    <MultipleIPInput
-      title="Domain Transfer IPs"
-      helperText={helperText}
-      error={getAPIErrorsFor(
-        DomainRecordDrawer.errorFields,
-        this.state.errors
-      )('axfr_ips')}
-      ips={(this.state.fields as EditableDomainFields).axfr_ips ?? ['']}
-      onChange={this.handleTransferUpdate}
-    />
-  );
+  DomainTransferField = () => {
+    const finalIPs = (
+      (this.state.fields as EditableDomainFields).axfr_ips ?? ['']
+    ).map(stringToExtendedIP);
+    return (
+      <MultipleIPInput
+        title="Domain Transfer IPs"
+        helperText={helperText}
+        error={getAPIErrorsFor(
+          DomainRecordDrawer.errorFields,
+          this.state.errors
+        )('axfr_ips')}
+        ips={finalIPs}
+        onChange={this.handleTransferUpdate}
+      />
+    );
+  };
 
   handleSubmissionErrors = (errorResponse: any) => {
     const errors = getAPIErrorOrDefault(errorResponse);

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
@@ -29,6 +29,11 @@ import {
   protocolOptions
 } from 'src/features/Firewalls/shared';
 import capitalize from 'src/utilities/capitalize';
+import {
+  ExtendedIP,
+  extendedIPToString,
+  stringToExtendedIP
+} from 'src/utilities/ipUtils';
 import { FirewallRuleWithStatus } from './firewallRuleEditor';
 
 export type Mode = 'create' | 'edit';
@@ -220,11 +225,11 @@ const FirewallRuleForm: React.FC<FirewallRuleFormProps> = React.memo(props => {
   );
 
   const handleIPChange = React.useCallback(
-    (_ips: string[]) => {
+    (_ips: ExtendedIP[]) => {
       if (!formTouched) {
         setFormTouched(true);
       }
-      setIPs(_ips);
+      setIPs(_ips.map(extendedIPToString));
     },
     [formTouched]
   );
@@ -300,7 +305,7 @@ const FirewallRuleForm: React.FC<FirewallRuleFormProps> = React.memo(props => {
           title="IP / Netmask"
           aria-label="IP / Netmask for firewall rule"
           className={classes.ipSelect}
-          ips={ips}
+          ips={ips.map(stringToExtendedIP)}
           onChange={handleIPChange}
           inputProps={{ autoFocus: true }}
         />

--- a/packages/manager/src/utilities/ipUtils.ts
+++ b/packages/manager/src/utilities/ipUtils.ts
@@ -9,3 +9,11 @@ export const removePrefixLength = (ip: string) => ip.replace(/\/\d+/, '');
  * Regex for determining if a string is a private IP Addresses
  */
 export const privateIPRegex = /^10\.|^172\.1[6-9]\.|^172\.2[0-9]\.|^172\.3[0-1]\.|^192\.168\.|^fd/;
+
+export interface ExtendedIP {
+  address: string;
+  error?: string;
+}
+
+export const stringToExtendedIP = (ip: string): ExtendedIP => ({ address: ip });
+export const extendedIPToString = (ip: ExtendedIP): string => ip.address;


### PR DESCRIPTION
## Description
For Firewall Rules we need a way to display errors for individual IPs in the Rule Drawer. The MultipleIPInput component dealt with an array of strings, which didn't lend itself well to also keeping track of errors.

I tried a few different things to address this, including a separate `ipErrors` array (and map) but managing state separately led to numerous headaches.

The best solution I found was to create a new `ExtendedIP` interface, which has an address and optional `error` string. This way an error is explicitly bound to the IP address it references.

## Note to Reviewers

To test, please check the places where MultipleIPInput is used, specifically when creating a slave domain and editing the SOA record of a master domain. **Nothing should be different.**

Don't pay much attention to the changes in FirewallRuleDrawer; more changes will come in another PR which deals with validation and error handling.
