### PR TITLE
M3-4055: Prompt user when navigating away from Firewall Rules

### DIFF
--- a/packages/manager/src/components/Prompt/Prompt.tsx
+++ b/packages/manager/src/components/Prompt/Prompt.tsx
@@ -44,14 +44,16 @@ const Prompt: React.FC<CombinedProps> = props => {
   const history = useHistory();
 
   React.useEffect(() => {
+    if (!props.when || !props.confirmWhenLeaving) {
+      return;
+    }
+
     // See: https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-      if (props.when && props.confirmWhenLeaving) {
-        // Prevent the unload event.
-        e.preventDefault();
-        // Chrome requires returnValue to be set to a string.
-        e.returnValue = '';
-      }
+      // Prevent the unload event.
+      e.preventDefault();
+      // Chrome requires returnValue to be set to a string.
+      e.returnValue = '';
     };
     window.addEventListener('beforeunload', handleBeforeUnload);
     return () => window.removeEventListener('beforeunload', handleBeforeUnload);

--- a/packages/manager/src/components/Prompt/Prompt.tsx
+++ b/packages/manager/src/components/Prompt/Prompt.tsx
@@ -1,12 +1,16 @@
+import { Location } from 'history';
 import * as React from 'react';
 import { Prompt as ReactRouterPrompt, useHistory } from 'react-router-dom';
-import ActionsPanel from 'src/components/ActionsPanel';
-import Button from 'src/components/Button';
-import ConfirmationDialog from 'src/components/ConfirmationDialog';
-import Typography from 'src/components/core/Typography';
+
+interface ChildrenProps {
+  isModalOpen: boolean;
+  handleCancel: () => void;
+  handleConfirm: () => void;
+}
 
 interface Props {
   when: boolean;
+  children: (props: ChildrenProps) => React.ReactNode;
 }
 
 type CombinedProps = Props;
@@ -14,74 +18,45 @@ type CombinedProps = Props;
 const Prompt: React.FC<CombinedProps> = props => {
   const history = useHistory();
 
-  const confirmNav = React.useRef<boolean>(false);
+  // Whether or not the user has confirmed navigation.
+  const confirmedNav = React.useRef<boolean>(false);
 
+  // The location the user is navigating to.
   const [nextLocation, setNextLocation] = React.useState<Location | null>(null);
-  const [isOpen, setIsOpen] = React.useState<boolean>(false);
+
+  const [isModalOpen, setIsModalOpen] = React.useState<boolean>(false);
+
+  const handleCancel = () => setIsModalOpen(false);
 
   const handleConfirm = () => {
-    setIsOpen(false);
-    confirmNav.current = true;
-    if (nextLocation) {
-      history.push(nextLocation.pathname);
+    setIsModalOpen(false);
+
+    if (!nextLocation) {
+      return;
     }
+
+    // Set confirmedNav to `true`, which will allow navigation in `handleNavigation()`.
+    confirmedNav.current = true;
+    history.push(nextLocation.pathname);
   };
 
-  const handleBlockedNavigation = (_nextLocation: Location) => {
-    if (!confirmNav.current) {
-      setIsOpen(true);
-      setNextLocation(_nextLocation);
+  const handleNavigation = (location: Location) => {
+    // If this user hasn't yet confirmed navigation, present a confirmation modal.
+    if (!confirmedNav.current) {
+      setIsModalOpen(true);
+      // We need to set the requested location as well.
+      setNextLocation(location);
       return false;
     }
-
+    // The user has confirmed navigation, so we allow it.
     return true;
   };
 
   return (
     <>
-      <ReactRouterPrompt {...props} message={handleBlockedNavigation as any} />;
-      <ConfirmationModal
-        isOpen={isOpen}
-        handleClose={() => setIsOpen(false)}
-        handleConfirm={handleConfirm}
-      />
+      <ReactRouterPrompt when={props.when} message={handleNavigation} />
+      {props.children({ isModalOpen, handleCancel, handleConfirm })}
     </>
   );
 };
-export default Prompt;
-
-interface ConfirmationModalProps {
-  isOpen: boolean;
-  handleClose: () => void;
-  handleConfirm: () => void;
-}
-
-export const ConfirmationModal: React.FC<ConfirmationModalProps> = props => {
-  const { isOpen, handleClose, handleConfirm } = props;
-
-  const actions = () => (
-    <ActionsPanel>
-      <Button buttonType="cancel" onClick={handleConfirm}>
-        Leave and discard changes
-      </Button>
-
-      <Button buttonType="primary" onClick={handleClose}>
-        Go back and review changes
-      </Button>
-    </ActionsPanel>
-  );
-
-  return (
-    <ConfirmationDialog
-      open={isOpen}
-      onClose={() => handleClose()}
-      title="Discard Firewall changes?"
-      actions={actions}
-    >
-      <Typography variant="subtitle1">
-        The changes you made to this Firewall haven't been applied. If you
-        navigate away from this page, your changes will be discarded.
-      </Typography>
-    </ConfirmationDialog>
-  );
-};
+export default React.memo(Prompt);

--- a/packages/manager/src/components/Prompt/Prompt.tsx
+++ b/packages/manager/src/components/Prompt/Prompt.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+import { Prompt as ReactRouterPrompt, useHistory } from 'react-router-dom';
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
+import ConfirmationDialog from 'src/components/ConfirmationDialog';
+import Typography from 'src/components/core/Typography';
+
+interface Props {
+  when: boolean;
+}
+
+type CombinedProps = Props;
+
+const Prompt: React.FC<CombinedProps> = props => {
+  const history = useHistory();
+
+  const confirmNav = React.useRef<boolean>(false);
+
+  const [nextLocation, setNextLocation] = React.useState<Location | null>(null);
+  const [isOpen, setIsOpen] = React.useState<boolean>(false);
+
+  const handleConfirm = () => {
+    setIsOpen(false);
+    confirmNav.current = true;
+    if (nextLocation) {
+      history.push(nextLocation.pathname);
+    }
+  };
+
+  const handleBlockedNavigation = (_nextLocation: Location) => {
+    if (!confirmNav.current) {
+      setIsOpen(true);
+      setNextLocation(_nextLocation);
+      return false;
+    }
+
+    return true;
+  };
+
+  return (
+    <>
+      <ReactRouterPrompt {...props} message={handleBlockedNavigation as any} />;
+      <ConfirmationModal
+        isOpen={isOpen}
+        handleClose={() => setIsOpen(false)}
+        handleConfirm={handleConfirm}
+      />
+    </>
+  );
+};
+export default Prompt;
+
+interface ConfirmationModalProps {
+  isOpen: boolean;
+  handleClose: () => void;
+  handleConfirm: () => void;
+}
+
+export const ConfirmationModal: React.FC<ConfirmationModalProps> = props => {
+  const { isOpen, handleClose, handleConfirm } = props;
+
+  const actions = () => (
+    <ActionsPanel>
+      <Button buttonType="cancel" onClick={handleConfirm}>
+        Leave and discard changes
+      </Button>
+
+      <Button buttonType="primary" onClick={handleClose}>
+        Go back and review changes
+      </Button>
+    </ActionsPanel>
+  );
+
+  return (
+    <ConfirmationDialog
+      open={isOpen}
+      onClose={() => handleClose()}
+      title="Discard Firewall changes?"
+      actions={actions}
+    >
+      <Typography variant="subtitle1">
+        The changes you made to this Firewall haven't been applied. If you
+        navigate away from this page, your changes will be discarded.
+      </Typography>
+    </ConfirmationDialog>
+  );
+};

--- a/packages/manager/src/components/Prompt/Prompt.tsx
+++ b/packages/manager/src/components/Prompt/Prompt.tsx
@@ -47,9 +47,9 @@ const Prompt: React.FC<CombinedProps> = props => {
     // See: https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
       if (props.when && props.confirmWhenLeaving) {
-        // Prevent the unload event
+        // Prevent the unload event.
         e.preventDefault();
-        // Chrome requires returnValue to be set to a string;
+        // Chrome requires returnValue to be set to a string.
         e.returnValue = '';
       }
     };

--- a/packages/manager/src/components/Prompt/Prompt.tsx
+++ b/packages/manager/src/components/Prompt/Prompt.tsx
@@ -1,3 +1,27 @@
+/**
+ * The <Prompt /> component is used to prevent transitions when a user has unsaved changes.
+ * Internal routes can be prevented using custom components (as render props). Prevention of
+ * external route changes (and closing of tabs/windows) is achieved by using an event listener on
+ * "beforeunload". The browser controls this prompt, and it is not possible to customize it. Pass
+ * in the `confirmWhenLeaving` prop if this behavior is desired.
+ *
+ * Example usage:
+ *
+ * ```typescript
+ * return (
+ *   <Prompt when={hasUnsavedChanges}>
+ *     (({ isModalOpen, handleCancel, handleConfirm }) => {
+ *       <YourConfirmationComponent
+ *         open={isModalOpen}
+ *         handleCancel={handleCancel}
+ *         handleConfirm={handleConfirm}
+ *       />
+ *     })
+ *   </Prompt>
+ * );
+ * ```
+ */
+
 import { Location } from 'history';
 import * as React from 'react';
 import { Prompt as ReactRouterPrompt, useHistory } from 'react-router-dom';
@@ -10,6 +34,7 @@ interface ChildrenProps {
 
 interface Props {
   when: boolean;
+  confirmWhenLeaving?: boolean;
   children: (props: ChildrenProps) => React.ReactNode;
 }
 
@@ -17,6 +42,20 @@ type CombinedProps = Props;
 
 const Prompt: React.FC<CombinedProps> = props => {
   const history = useHistory();
+
+  React.useEffect(() => {
+    // See: https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (props.when && props.confirmWhenLeaving) {
+        // Prevent the unload event
+        e.preventDefault();
+        // Chrome requires returnValue to be set to a string;
+        e.returnValue = '';
+      }
+    };
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [props.when, props.confirmWhenLeaving]);
 
   // Whether or not the user has confirmed navigation.
   const confirmedNav = React.useRef<boolean>(false);

--- a/packages/manager/src/components/Prompt/index.ts
+++ b/packages/manager/src/components/Prompt/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Prompt';

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRulesLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRulesLanding.tsx
@@ -182,7 +182,34 @@ const FirewallRulesLanding: React.FC<CombinedProps> = props => {
 
   return (
     <>
-      <Prompt when={hasUnsavedChanges} />
+      <Prompt when={hasUnsavedChanges}>
+        {({ isModalOpen, handleCancel, handleConfirm }) => {
+          return (
+            <ConfirmationDialog
+              open={isModalOpen}
+              onClose={handleCancel}
+              title="Discard Firewall changes?"
+              actions={() => (
+                <ActionsPanel>
+                  <Button buttonType="cancel" onClick={handleConfirm}>
+                    Leave and discard changes
+                  </Button>
+
+                  <Button buttonType="primary" onClick={handleCancel}>
+                    Go back and review changes
+                  </Button>
+                </ActionsPanel>
+              )}
+            >
+              <Typography variant="subtitle1">
+                The changes you made to this Firewall haven't been applied. If
+                you navigate away from this page, your changes will be
+                discarded.
+              </Typography>
+            </ConfirmationDialog>
+          );
+        }}
+      </Prompt>
 
       <Typography variant="body1" className={classes.copy}>
         Firewall rules act as a whitelist, allowing network traffic that meets

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRulesLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRulesLanding.tsx
@@ -182,7 +182,7 @@ const FirewallRulesLanding: React.FC<CombinedProps> = props => {
 
   return (
     <>
-      <Prompt when={hasUnsavedChanges}>
+      <Prompt when={hasUnsavedChanges} confirmWhenLeaving={true}>
         {({ isModalOpen, handleCancel, handleConfirm }) => {
           return (
             <ConfirmationDialog

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRulesLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRulesLanding.tsx
@@ -9,6 +9,7 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import FixedToolBar from 'src/components/FixedToolbar/FixedToolbar';
 import Notice from 'src/components/Notice';
+import Prompt from 'src/components/Prompt';
 import withFirewalls, {
   DispatchProps
 } from 'src/containers/firewalls.container';
@@ -158,8 +159,8 @@ const FirewallRulesLanding: React.FC<CombinedProps> = props => {
       });
   };
 
-  const shouldDisplayFixedToolbar = React.useMemo(
-    () => _hasModified(inboundState) || _hasModified(outboundState),
+  const hasUnsavedChanges = React.useMemo(
+    () => Boolean(_hasModified(inboundState) || _hasModified(outboundState)),
     [inboundState, outboundState]
   );
 
@@ -181,6 +182,8 @@ const FirewallRulesLanding: React.FC<CombinedProps> = props => {
 
   return (
     <>
+      <Prompt when={hasUnsavedChanges} />
+
       <Typography variant="body1" className={classes.copy}>
         Firewall rules act as a whitelist, allowing network traffic that meets
         the rules’ parameters to pass through. Any traffic not explicitly
@@ -221,7 +224,7 @@ const FirewallRulesLanding: React.FC<CombinedProps> = props => {
         onSubmit={ruleDrawer.mode === 'create' ? handleAddRule : handleEditRule}
         ruleToModify={ruleToModify}
       />
-      {shouldDisplayFixedToolbar && (
+      {hasUnsavedChanges && (
         <FixedToolBar>
           <ActionsPanel className={classes.actions}>
             <Button


### PR DESCRIPTION
## Description

This PR adds a confirmation modal when the user navigates away from a Firewall with unsaved rule changes.

React-router has a `<Prompt />` component which almost does the thing we want. The problem is that you can't provide a custom modal (since it uses the browser's `window.confirm()` function).

There are a few ways around this, but they are in general fairly anti-React (like this one, which involves manually creating DOM nodes at the root level: https://gist.github.com/robertgonzales/e54699212da497740845712f3648d98c)

Another alternative is the [react-router-navigation-prompt library](https://www.npmjs.com/package/react-router-navigation-prompt), which I took for a test drive. The problem there is that with the way the components are rendered, we lose MUI transitions on the modal, so it made for a choppy experience.

The solution I went with is an in-house component that takes advantage of the fact that the `message` prop of react-router's `<Prompt />` component also accepts a function. With some ref magic, we can conditionally block navigation and prompt with a custom modal. It was inspired by [this blog post ](https://medium.com/@michaelchan_13570/using-react-router-v4-prompt-with-custom-modal-component-ca839f5faf39) and the react-router-navigation-prompt library.

## Note to Reviewers

**To test:** edit Firewall rules and navigate away from the page by clicking other parts of the app. You should be prompted to confirm navigation.

Note: react-router's `<Prompt />` component doesn't prompt the user when navigating away from the page by changing the URL manually. I think this OK but let me know if you think it's not.
