### PR TITLE
Feature/search landing fc

### DIFF
--- a/packages/manager/src/__data__/searchResults.ts
+++ b/packages/manager/src/__data__/searchResults.ts
@@ -33,6 +33,7 @@ export const docs_result = {
 export const searchbarResult1 = {
   label: 'result1',
   value: '111111',
+  entityType: 'linode' as any,
   data: {
     icon: 'LinodeIcon',
     tags: [],

--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -80,9 +80,9 @@ export const MAX_VOLUME_SIZE = 10240;
 export const INTERVAL = 1000;
 
 /**
- * Time after which data from the API is considered stale
+ * Time after which data from the API is considered stale (half an hour)
  */
-export const REFRESH_INTERVAL = 60000;
+export const REFRESH_INTERVAL = 60 * 30 * 1000;
 
 /**
  * Used by e.g. LISH to determine the websocket connection address.

--- a/packages/manager/src/features/Search/SearchLanding.test.tsx
+++ b/packages/manager/src/features/Search/SearchLanding.test.tsx
@@ -15,15 +15,7 @@ import Typography from 'src/components/core/Typography';
 import { CombinedProps as Props, SearchLanding } from './SearchLanding';
 import { emptyResults } from './utils';
 
-const classes = {
-  emptyResultWrapper: '',
-  emptyResult: '',
-  errorIcon: '',
-  headline: ''
-};
-
 const props: Props = {
-  classes,
   entities: [],
   entitiesLoading: false,
   searchResultsByEntity: emptyResults,

--- a/packages/manager/src/features/Search/SearchLanding.test.tsx
+++ b/packages/manager/src/features/Search/SearchLanding.test.tsx
@@ -4,13 +4,13 @@
  * services/domains no longer require src/store, we should restore these tests.
  */
 
-import { shallow } from 'enzyme';
+import { cleanup, render } from '@testing-library/react';
 import { assocPath } from 'ramda';
 import * as React from 'react';
 
 import { reactRouterProps } from 'src/__data__/reactRouterProps';
 import { searchbarResult1 } from 'src/__data__/searchResults';
-import Typography from 'src/components/core/Typography';
+import { renderWithTheme, wrapWithTheme } from 'src/utilities/testHelpers';
 
 import { CombinedProps as Props, SearchLanding } from './SearchLanding';
 import { emptyResults } from './utils';
@@ -32,63 +32,77 @@ const props: Props = {
   ...reactRouterProps
 };
 
-const component = shallow(
-  <div />
-  // <SearchLanding {...props} />
-);
+const propsWithResults: Props = {
+  ...props,
+  combinedResults: [searchbarResult1],
+  searchResultsByEntity: { ...emptyResults, linodes: [searchbarResult1] }
+};
 
-describe.skip('Component', () => {
-  // describe('Component', () => {
+jest.mock('linode-js-sdk');
+jest.mock('src/hooks/useReduxLoad', () => ({
+  useReduxLoad: () => jest.fn().mockReturnValue({ _loading: false })
+}));
+
+afterEach(cleanup);
+
+describe('Component', () => {
   it('should render', () => {
-    expect(component).toBeDefined();
+    const { getByText } = renderWithTheme(<SearchLanding {...props} />);
+    expect(getByText(/search/));
   });
+
   it('should search on mount', () => {
-    const newProps = assocPath(['location', 'search'], '?query=search', props);
-    shallow(<SearchLanding {...newProps} />);
+    const newProps = assocPath(
+      ['location', 'search'],
+      '?query=search',
+      propsWithResults
+    );
+    const { getByText } = renderWithTheme(<SearchLanding {...newProps} />);
+    getByText(/search/i);
     expect(props.search).toHaveBeenCalledWith('search');
   });
-  it('should show a loading state', () => {
-    component.setProps({ entitiesLoading: true });
-    expect(component.find('[data-qa-search-loading]')).toHaveLength(1);
-    component.setProps({ entitiesLoading: false });
-  });
+
   it('should search when the entity list (from Redux) changes', () => {
     jest.resetAllMocks();
-    component.setProps({
-      entities: { ...emptyResults, linodes: [searchbarResult1] }
-    });
+    const { rerender } = render(wrapWithTheme(<SearchLanding {...props} />));
     expect(props.search).toHaveBeenCalledTimes(1);
+
+    const newEntities = [searchbarResult1];
+    rerender(
+      wrapWithTheme(<SearchLanding {...props} entities={newEntities} />)
+    );
+    expect(props.search).toHaveBeenCalledTimes(2);
   });
+
   it('should show an empty state', () => {
-    component.setState({ error: false, results: emptyResults, loading: false });
-    expect(component.find('[data-qa-error-state]')).toHaveLength(0);
-    expect(component.find('[data-qa-empty-state]')).toHaveLength(1);
+    const { getByText } = renderWithTheme(<SearchLanding {...props} />);
+    getByText(/no results/i);
   });
-  it('should read the query from params', () => {
-    expect(component.state()).toHaveProperty('query', 'search');
-  });
+
   it('should display the query term', () => {
-    expect(
-      component.containsMatchingElement(
-        <Typography>Search Results for "search"</Typography>
-      )
-    ).toBeTruthy();
+    const { getByText } = renderWithTheme(
+      <SearchLanding {...propsWithResults} />
+    );
+    getByText('Search Results for "search"');
   });
+
   it('should parse multi-word queries correctly', () => {
     const newProps = assocPath(
       ['location', 'search'],
       '?query=two%20words',
-      props
+      propsWithResults
     );
-    // const _component = shallow(<div {...newProps} />);
-    const _component = shallow(<SearchLanding {...newProps} />);
-    expect(_component.state()).toHaveProperty('query', 'two words');
+    const { getByText } = renderWithTheme(<SearchLanding {...newProps} />);
+    expect(getByText('Search Results for "two words"'));
   });
+
   it('should handle blank or unusual queries without crashing', () => {
-    const newProps = assocPath(['location', 'search'], '?query=', props);
-    // const _component = shallow(<div {...newProps} />);
-    const _component = shallow(<SearchLanding {...newProps} />);
-    expect(_component).toBeDefined();
-    expect(_component.state()).toHaveProperty('query', '');
+    const newProps = assocPath(
+      ['location', 'search'],
+      '?query=',
+      propsWithResults
+    );
+    const { getByText } = renderWithTheme(<SearchLanding {...newProps} />);
+    getByText(/search/i);
   });
 });

--- a/packages/manager/src/features/Search/SearchLanding.tsx
+++ b/packages/manager/src/features/Search/SearchLanding.tsx
@@ -67,10 +67,6 @@ const displayMap = {
   images: 'Images'
 };
 
-interface State {
-  query: string;
-}
-
 export type CombinedProps = SearchProps &
   RouteComponentProps<{}> &
   WithStyles<ClassNames>;
@@ -104,95 +100,74 @@ const splitWord = (word: any) => {
   return word;
 };
 
-export class SearchLanding extends React.Component<CombinedProps, State> {
-  mounted: boolean = false;
+export const SearchLanding: React.FC<CombinedProps> = props => {
+  const {
+    classes,
+    entities,
+    entitiesLoading,
+    errors,
+    searchResultsByEntity
+  } = props;
 
-  state: State = {
-    query: getQueryParam(this.props.location.search, 'query')
-  };
+  const query = getQueryParam(props.location.search, 'query');
 
-  componentDidMount() {
-    const { query } = this.state;
-    this.mounted = true;
-    this.props.search(query);
-  }
+  React.useEffect(() => {
+    props.search(query);
+  }, [query, entities]);
 
-  componentWillUnmount() {
-    this.mounted = false;
-  }
+  const resultsEmpty = equals(searchResultsByEntity, emptyResults);
 
-  componentDidUpdate(prevProps: CombinedProps) {
-    const { query } = this.state;
-    if (!equals(prevProps.entities, this.props.entities)) {
-      this.props.search(query);
-    }
-  }
-
-  render() {
-    const {
-      classes,
-      entitiesLoading,
-      errors,
-      searchResultsByEntity
-    } = this.props;
-    const { query } = this.state;
-
-    const resultsEmpty = equals(searchResultsByEntity, emptyResults);
-
-    return (
-      <Grid container direction="column">
-        <Grid item>
-          {!resultsEmpty && !entitiesLoading && (
-            <H1Header
-              title={`Search Results ${query && `for "${query}"`}`}
-              className={classes.headline}
-            />
-          )}
-        </Grid>
-        {errors.hasErrors && (
-          <Grid item>
-            <Notice error text={getErrorMessage(errors)} />
-          </Grid>
-        )}
-        {entitiesLoading && (
-          <Grid item data-qa-search-loading>
-            <CircleProgress />
-          </Grid>
-        )}
-        {resultsEmpty && !entitiesLoading && (
-          <Grid item data-qa-empty-state className={classes.emptyResultWrapper}>
-            <div className={classes.emptyResult}>
-              <Error className={classes.errorIcon} />
-              <Typography style={{ marginBottom: 16 }}>
-                You searched for ...
-              </Typography>
-              <Typography className="resultq">
-                {query && splitWord(query)}
-              </Typography>
-              <Typography style={{ marginTop: 56 }} className="nothing">
-                sorry, no results for this one
-              </Typography>
-            </div>
-          </Grid>
-        )}
-        {!entitiesLoading && (
-          <Grid item>
-            {Object.keys(searchResultsByEntity).map(
-              (entityType, idx: number) => (
-                <ResultGroup
-                  key={idx}
-                  entity={displayMap[entityType]}
-                  results={searchResultsByEntity[entityType]}
-                  groupSize={100}
-                />
-              )
-            )}
-          </Grid>
+  return (
+    <Grid container direction="column">
+      <Grid item>
+        {!resultsEmpty && !entitiesLoading && (
+          <H1Header
+            title={`Search Results ${query && `for "${query}"`}`}
+            className={classes.headline}
+          />
         )}
       </Grid>
-    );
-  }
-}
+      {errors.hasErrors && (
+        <Grid item>
+          <Notice error text={getErrorMessage(errors)} />
+        </Grid>
+      )}
+      {entitiesLoading && (
+        <Grid item data-qa-search-loading>
+          <CircleProgress />
+        </Grid>
+      )}
+      {resultsEmpty && !entitiesLoading && (
+        <Grid item data-qa-empty-state className={classes.emptyResultWrapper}>
+          <div className={classes.emptyResult}>
+            <Error className={classes.errorIcon} />
+            <Typography style={{ marginBottom: 16 }}>
+              You searched for ...
+            </Typography>
+            <Typography className="resultq">
+              {query && splitWord(query)}
+            </Typography>
+            <Typography style={{ marginTop: 56 }} className="nothing">
+              sorry, no results for this one
+            </Typography>
+          </div>
+        </Grid>
+      )}
+      {!entitiesLoading && (
+        <Grid item>
+          {Object.keys(searchResultsByEntity).map((entityType, idx: number) => (
+            <ResultGroup
+              key={idx}
+              entity={displayMap[entityType]}
+              results={searchResultsByEntity[entityType]}
+              groupSize={100}
+            />
+          ))}
+        </Grid>
+      )}
+    </Grid>
+  );
+};
 
 const styled = withStyles(styles);
 

--- a/packages/manager/src/features/Search/SearchLanding.tsx
+++ b/packages/manager/src/features/Search/SearchLanding.tsx
@@ -92,7 +92,13 @@ export const SearchLanding: React.FC<CombinedProps> = props => {
 
   const classes = useStyles();
 
-  const query = getQueryParam(props.location.search, 'query');
+  let query = '';
+  let queryError = false;
+  try {
+    query = getQueryParam(props.location.search, 'query');
+  } catch {
+    queryError = true;
+  }
 
   const { _loading } = useReduxLoad([
     'linodes',
@@ -123,8 +129,13 @@ export const SearchLanding: React.FC<CombinedProps> = props => {
           <Notice error text={getErrorMessage(errors)} />
         </Grid>
       )}
+      {queryError && (
+        <Grid item>
+          <Notice error text="Invalid query" />
+        </Grid>
+      )}
       {_loading && (
-        <Grid item data-qa-search-loading>
+        <Grid item data-qa-search-loading data-testid="loading">
           <CircleProgress />
         </Grid>
       )}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingIPTransferPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingIPTransferPanel.tsx
@@ -415,7 +415,7 @@ class LinodeNetworkingIPTransferPanel extends React.Component<
     assignAddresses(createRequestData(this.state.ips, this.props.linodeRegion))
       .then(() => {
         // Refresh Linodes in the region in which the changes were made.
-        this.props.getLinodes({ region: this.props.linodeRegion });
+        this.props.getLinodes({}, { region: this.props.linodeRegion });
 
         return this.props
           .refreshIPs()

--- a/packages/manager/src/hooks/useReduxLoad.ts
+++ b/packages/manager/src/hooks/useReduxLoad.ts
@@ -49,7 +49,7 @@ export type ReduxEntity =
 
 type RequestMap = Record<ReduxEntity, any>;
 const requestMap: RequestMap = {
-  linodes: requestLinodes,
+  linodes: () => requestLinodes({}),
   volumes: getAllVolumes,
   account: requestAccount,
   accountSettings: requestAccountSettings,

--- a/packages/manager/src/store/linodeCreate/linodeCreate.reducer.ts
+++ b/packages/manager/src/store/linodeCreate/linodeCreate.reducer.ts
@@ -8,7 +8,13 @@ export interface State {
 }
 
 export const getInitialType = (): CreateTypes => {
-  const queryParams = parse(location.search.replace('?', '').toLowerCase());
+  let queryParams;
+  try {
+    queryParams = parse(location.search.replace('?', '').toLowerCase());
+  } catch {
+    // Broken query params shouldn't break the app, just default to fromImage
+    return 'fromImage';
+  }
 
   if (queryParams.type) {
     if (queryParams.subtype) {


### PR DESCRIPTION
## Description

Due the recent refactor (#6148), the search landing page no longer has Volumes data available to it if you load directly (or navigate from anywhere else in the app that doesn't need to request Volumes).

To resolve this, I converted it to a function component and used the `useReduxLoad` hook to ensure all data is requested on page load.

Still to come:

- [x] Update tests (we've been skipping this component's tests for a long time, might as well fix them now)