### PR TITLE
Follow up: Dynamic theming for highlight.js

### DIFF
--- a/packages/manager/src/components/HighlightedMarkdown/HighlightedMarkdown.test.tsx
+++ b/packages/manager/src/components/HighlightedMarkdown/HighlightedMarkdown.test.tsx
@@ -1,6 +1,7 @@
-import { cleanup, render } from '@testing-library/react';
+import { cleanup } from '@testing-library/react';
 import * as React from 'react';
 
+import { renderWithTheme } from 'src/utilities/testHelpers';
 import HighlightedMarkdown from './HighlightedMarkdown';
 
 const sampleMarkdown =
@@ -10,7 +11,7 @@ afterEach(cleanup);
 
 describe('HighlightedMarkdown component', () => {
   it('should highlight text consistently', () => {
-    const { asFragment } = render(
+    const { asFragment } = renderWithTheme(
       <HighlightedMarkdown textOrMarkdown={sampleMarkdown} />
     );
     expect(asFragment()).toMatchSnapshot();

--- a/packages/manager/src/components/HighlightedMarkdown/HighlightedMarkdown.tsx
+++ b/packages/manager/src/components/HighlightedMarkdown/HighlightedMarkdown.tsx
@@ -1,3 +1,4 @@
+import * as classNames from 'classnames';
 import hljs from 'highlight.js/lib/highlight';
 // Import languages as we need them to keep bundle size down
 import apache from 'highlight.js/lib/languages/apache';
@@ -5,10 +6,10 @@ import bash from 'highlight.js/lib/languages/bash';
 import javascript from 'highlight.js/lib/languages/javascript';
 import nginx from 'highlight.js/lib/languages/nginx';
 import yaml from 'highlight.js/lib/languages/yaml';
-import 'highlight.js/styles/an-old-hope.css';
+import 'highlight.js/styles/lightfair.css';
 import * as React from 'react';
 import { Converter } from 'showdown';
-
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import 'src/formatted-text.css';
 import { sanitizeHTML } from 'src/utilities/sanitize-html';
@@ -19,6 +20,14 @@ hljs.registerLanguage('bash', bash);
 hljs.registerLanguage('javascript', javascript);
 hljs.registerLanguage('nginx', nginx);
 hljs.registerLanguage('yaml', yaml);
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    '& .hljs': {
+      color: theme.color.offBlack
+    }
+  }
+}));
 
 export type SupportedLanguage =
   | 'plaintext'
@@ -34,6 +43,7 @@ export interface HighlightedMarkdownProps {
 }
 
 export const HighlightedMarkdown: React.FC<HighlightedMarkdownProps> = props => {
+  const classes = useStyles();
   const { language, textOrMarkdown } = props;
   const rootRef = React.useRef<HTMLDivElement>(null);
 
@@ -67,7 +77,10 @@ export const HighlightedMarkdown: React.FC<HighlightedMarkdownProps> = props => 
 
   return (
     <Typography
-      className="formatted-text"
+      className={classNames({
+        [classes.root]: true,
+        'formatted-text': true
+      })}
       ref={rootRef}
       dangerouslySetInnerHTML={{
         __html: sanitizedHtml

--- a/packages/manager/src/components/HighlightedMarkdown/__snapshots__/HighlightedMarkdown.test.tsx.snap
+++ b/packages/manager/src/components/HighlightedMarkdown/__snapshots__/HighlightedMarkdown.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`HighlightedMarkdown component should highlight text consistently 1`] = `
 <DocumentFragment>
   <p
-    class="MuiTypography-root formatted-text MuiTypography-body1"
+    class="MuiTypography-root makeStyles-root-32 formatted-text MuiTypography-body1"
   />
   <h1>
     Some markdown


### PR DESCRIPTION
## Description

This PR acts as a followup to the conversation from the original PR: https://github.com/linode/manager/pull/6182#pullrequestreview-375294060 

I updated the theme from `highlight.js` to a more light-theme-friendly style, but that caused issues for dark theme. Originally I wanted this to be a bit more dynamic than it is, but at this point in time conditional imports aren't a thing (yet). Instead, I added a custom style to aid in the switch of the styling of MD for dark theme.

## Type of Change
- Non breaking change ('update')

## Note to Reviewers

Please view highlighted markdown usage in a variety of places (LKE, Support ticket preview, etc.) in both themes. 
