### PR TITLE
M3-3888: Prevent Linode Power Control menu from being empty upon click

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.test.tsx
@@ -68,4 +68,15 @@ describe('Linode Power Control Dialogs', () => {
       renderedComponent.find('[data-qa-set-power="reboot"]').exists()
     ).toBeFalsy();
   });
+
+  it('button should be disabled if status is not Running or Offline', () => {
+    const renderedComponent = shallow(component);
+
+    // Set status to a transition status such as "cloning."
+    renderedComponent.setProps({ status: 'cloning' });
+
+    expect(
+      renderedComponent.find('WithStyles(wrappedButton)').prop('disabled')
+    ).toEqual(true);
+  });
 });

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.tsx
@@ -182,7 +182,7 @@ export class LinodePowerButton extends React.Component<CombinedProps, State> {
     const isBusy = linodeInTransition(status, firstEventWithPercent);
     const isRunning = !isBusy && status === 'running';
     const isOffline = !isBusy && status === 'offline';
-    const isUnknown = isRunning || isOffline ? false : true;
+    const isUnknown = !isRunning && !isOffline;
 
     const buttonText = () => {
       if (isBusy) {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.tsx
@@ -182,6 +182,8 @@ export class LinodePowerButton extends React.Component<CombinedProps, State> {
     const isBusy = linodeInTransition(status, firstEventWithPercent);
     const isRunning = !isBusy && status === 'running';
     const isOffline = !isBusy && status === 'offline';
+    const isUnknown = isRunning || isOffline ? false : true;
+
     const buttonText = () => {
       if (isBusy) {
         return 'Busy';
@@ -199,7 +201,7 @@ export class LinodePowerButton extends React.Component<CombinedProps, State> {
     return (
       <React.Fragment>
         <Button
-          disabled={isBusy}
+          disabled={isBusy || isUnknown}
           onClick={this.openMenu}
           aria-owns={anchorEl ? 'power' : undefined}
           aria-haspopup="true"


### PR DESCRIPTION
## Description
Currently, situations can arise where if a Linode is not running and is not offline (i.e., in a transition state), a user can click the Linode Power Control menu and it will be empty.

To remedy this, I made it so that the menu is disabled while the Linode is in one of those transition states, such as cloning.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')
- Non breaking change ('update', 'change')

## Tests
1. `yarn test LinodePowerControl.test.tsx`

## Still to Come
- [x] Explore converting test from Enzyme to RTL (to be done in another PR)
