### PR TITLE
M3-3925: Make Firewall breadcrumb editable

### DIFF
--- a/packages/manager/src/components/EditableText/EditableText.tsx
+++ b/packages/manager/src/components/EditableText/EditableText.tsx
@@ -257,6 +257,7 @@ const EditableText: React.FC<FinalProps> = props => {
           className={classes.textField}
           type="text"
           label={`Edit ${text} Label`}
+          editable
           hideLabel
           onChange={onChange}
           onKeyDown={handleKeyPress}

--- a/packages/manager/src/components/TextField.tsx
+++ b/packages/manager/src/components/TextField.tsx
@@ -85,7 +85,10 @@ const styles = (theme: Theme) =>
       width: '3.6em'
     },
     errorText: {
-      color: theme.color.red
+      color: theme.color.red,
+      '&$editable': {
+        position: 'absolute'
+      }
     },
     editable: {
       wordBreak: 'keep-all',

--- a/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
@@ -34,6 +34,8 @@ export const FirewallDetail: React.FC<CombinedProps> = props => {
   // Source the Firewall's ID from the /:id path param.
   const thisFirewallId = props.match.params.id;
 
+  const [updateError, setUpdateError] = React.useState<string | undefined>();
+
   // Find the Firewall in the store.
   const thisFirewall = props.data[thisFirewallId];
 
@@ -81,12 +83,18 @@ export const FirewallDetail: React.FC<CombinedProps> = props => {
     return Boolean(matchPath(p, { path: props.location.pathname }));
   };
 
-  const handleLabelChange = async (newLabel: string) => {
-    props.updateFirewall({ firewallID: thisFirewall.id, label: newLabel });
-    return thisFirewall.label;
+  const handleLabelChange = (newLabel: string) => {
+    setUpdateError(undefined);
+
+    return props
+      .updateFirewall({ firewallID: thisFirewall.id, label: newLabel })
+      .catch(e => {
+        setUpdateError(e[0].reason);
+      });
   };
 
   const resetEditableLabel = () => {
+    setUpdateError(undefined);
     return thisFirewall.label;
   };
 
@@ -100,7 +108,8 @@ export const FirewallDetail: React.FC<CombinedProps> = props => {
           onEditHandlers={{
             editableTextTitle: thisFirewall.label,
             onEdit: handleLabelChange,
-            onCancel: resetEditableLabel
+            onCancel: resetEditableLabel,
+            errorText: updateError
           }}
         />
         {/* @todo: Insert real link when the doc is written. */}

--- a/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
@@ -90,6 +90,7 @@ export const FirewallDetail: React.FC<CombinedProps> = props => {
       .updateFirewall({ firewallID: thisFirewall.id, label: newLabel })
       .catch(e => {
         setUpdateError(e[0].reason);
+        return Promise.reject(e);
       });
   };
 

--- a/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
@@ -81,14 +81,27 @@ export const FirewallDetail: React.FC<CombinedProps> = props => {
     return Boolean(matchPath(p, { path: props.location.pathname }));
   };
 
+  const handleLabelChange = async (newLabel: string) => {
+    props.updateFirewall({ firewallID: thisFirewall.id, label: newLabel });
+    return thisFirewall.label;
+  };
+
+  const resetEditableLabel = () => {
+    return thisFirewall.label;
+  };
+
   return (
     <React.Fragment>
       <DocumentTitleSegment segment="Firewalls" />
       <Box display="flex" flexDirection="row" justifyContent="space-between">
         <Breadcrumb
           pathname={props.location.pathname}
-          labelTitle={thisFirewall.label}
           removeCrumbX={2}
+          onEditHandlers={{
+            editableTextTitle: thisFirewall.label,
+            onEdit: handleLabelChange,
+            onCancel: resetEditableLabel
+          }}
         />
         {/* @todo: Insert real link when the doc is written. */}
         <DocumentationButton href="https://www.linode.com/docs/platform" />


### PR DESCRIPTION
## Description

Edit a Firewall's label in the breadcrumb of the detail view. This will be the only way to edit a Firewall's label.

**Update:** 
Added error handling to the breadcrumb and prevented the error text from shifting the the textfield up.

<img width="826" alt="Screen Shot 2020-03-20 at 3 02 26 PM" src="https://user-images.githubusercontent.com/7692354/77197614-e31d5380-6abb-11ea-869a-a0665bee19a6.png">

## Type of Change
- Non breaking change ('update', 'change')
