### PR TITLE
M3-3558 Remove page break on invoices

### DIFF
--- a/packages/linode-js-sdk/src/account/types.ts
+++ b/packages/linode-js-sdk/src/account/types.ts
@@ -75,7 +75,7 @@ export interface InvoiceItem {
   label: string;
   quantity: null | number;
   type: 'hourly' | 'prepay' | 'misc';
-  unit_price: null | number;
+  unit_price: null | string;
   tax: number;
   total: number;
 }

--- a/packages/manager/src/factories/invoiceItem.ts
+++ b/packages/manager/src/factories/invoiceItem.ts
@@ -1,0 +1,14 @@
+import * as Factory from 'factory.ts';
+import { InvoiceItem } from 'linode-js-sdk/lib/account';
+
+export const invoiceItemFactory = Factory.Sync.makeFactory<InvoiceItem>({
+  label: Factory.each(i => `Nanode 1GB - my-linode-${i} (${i})`),
+  unit_price: '0.0075',
+  amount: 5,
+  quantity: 730,
+  tax: 0,
+  total: 5,
+  from: '2020-01-01T12:00:00',
+  to: '2020-01-31T12:00:00',
+  type: 'hourly'
+});

--- a/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
@@ -201,7 +201,6 @@ export const printInvoice = (
       }
     });
 
-    doc.addPage();
     createInvoiceTotalsTable(doc, invoice);
     createFooter(doc, baseFont);
 

--- a/packages/manager/src/features/Billing/PdfGenerator/utils.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/utils.ts
@@ -144,7 +144,7 @@ export const createInvoiceTotalsTable = (doc: JSPDF, invoice: Invoice) => {
       1: {
         cellWidth: 16,
         cellPadding: {
-          right: 2
+          right: 6
         }
       }
     },

--- a/packages/manager/src/features/Billing/PdfGenerator/utils.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/utils.ts
@@ -135,6 +135,19 @@ export const createInvoiceTotalsTable = (doc: JSPDF, invoice: Invoice) => {
     headStyles: {
       fillColor: '#444444'
     },
+    columnStyles: {
+      0: {
+        cellPadding: {
+          right: 12
+        }
+      },
+      1: {
+        cellWidth: 16,
+        cellPadding: {
+          right: 2
+        }
+      }
+    },
     body: [
       ['Subtotal (USD)', `$${Number(invoice.subtotal).toFixed(2)}`],
       ['Tax (USD)', `$${Number(invoice.tax).toFixed(2)}`],

--- a/packages/manager/src/features/Billing/PdfGenerator/utils.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/utils.ts
@@ -148,6 +148,7 @@ export const createInvoiceTotalsTable = (doc: JSPDF, invoice: Invoice) => {
         }
       }
     },
+    pageBreak: 'avoid',
     body: [
       ['Subtotal (USD)', `$${Number(invoice.subtotal).toFixed(2)}`],
       ['Tax (USD)', `$${Number(invoice.tax).toFixed(2)}`],

--- a/packages/manager/src/features/Profile/Referrals/Referrals.tsx
+++ b/packages/manager/src/features/Profile/Referrals/Referrals.tsx
@@ -65,7 +65,7 @@ class Referrals extends React.Component<CombinedProps, {}> {
               Referrals reward you when you refer people to Linode. If someone
               signs up using your referral code, you'll receive a credit of
               $20.00, so long as the person you referred remains an active
-              customer for 90 days.
+              customer for 90 days and spends a minimum of $15.
             </Typography>
           </Grid>
           {profileLoading ? (


### PR DESCRIPTION
## Description

This fixes https://github.com/linode/manager/issues/6089.

This PR removes an unnecessary page break that was inserted before the "Invoice Totals Table" at the bottom of PDF invoices.

It also:

- Adds an `invoiceItem` factory for testing.
- Fixes typing of `unit_price` on `invoiceItem`.
- Adjusts widths of the "Invoice Totals Table" to fix clipping.

<img width="747" alt="Screen Shot 2020-03-19 at 10 09 02 AM" src="https://user-images.githubusercontent.com/16911484/77076091-b6890f00-69c9-11ea-8afd-2fe7e0c1b6e2.png">


## Note to Reviewers

**To test,** please check real invoices on test accounts as well as your personal accounts. To test specific numbers of line items (to check line breaking) insert this at L11:

```typescript
import { invoiceItemFactory } from 'src/factories/invoiceItem';
```

and this at L138:

```typescript
items = invoiceItemFactory.buildList(20);
```

and adjust the number as desired.