### PR TITLE
Fix Volumes creation bug

### DIFF
--- a/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
+++ b/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
@@ -143,7 +143,7 @@ interface DispatchProps {
   requestAccount: () => Promise<Account>;
   requestDomains: () => Promise<Domain[]>;
   requestImages: () => Promise<Image[]>;
-  requestLinodes: () => Promise<GetAllData<Linode[]>>;
+  requestLinodes: () => Promise<GetAllData<Linode>>;
   requestNotifications: () => Promise<Notification[]>;
   requestSettings: () => Promise<AccountSettings>;
   requestTypes: () => Promise<LinodeType[]>;

--- a/packages/manager/src/containers/firewalls.container.ts
+++ b/packages/manager/src/containers/firewalls.container.ts
@@ -23,10 +23,7 @@ import { ThunkDispatch } from 'src/store/types';
 import { GetAllData } from 'src/utilities/getAll';
 
 export interface DispatchProps {
-  getFirewalls: (
-    params?: any,
-    filters?: any
-  ) => Promise<GetAllData<Firewall[]>>;
+  getFirewalls: (params?: any, filters?: any) => Promise<GetAllData<Firewall>>;
   createFirewall: (payload: CreateFirewallPayload) => Promise<Firewall>;
   deleteFirewall: (firewallID: number) => Promise<{}>;
   disableFirewall: (firewallID: number) => Promise<Firewall>;

--- a/packages/manager/src/containers/longview.container.ts
+++ b/packages/manager/src/containers/longview.container.ts
@@ -15,7 +15,7 @@ export interface DispatchProps {
   getLongviewClients: (
     params?: any,
     filters?: any
-  ) => Promise<GetAllData<LongviewClient[]>>;
+  ) => Promise<GetAllData<LongviewClient>>;
   createLongviewClient: (label?: string) => Promise<LongviewClient>;
   deleteLongviewClient: (id: number) => Promise<{}>;
   updateLongviewClient: (id: number, label: string) => Promise<LongviewClient>;

--- a/packages/manager/src/containers/withLinodes.container.ts
+++ b/packages/manager/src/containers/withLinodes.container.ts
@@ -10,7 +10,7 @@ import { ThunkDispatch } from 'src/store/types';
 import { GetAllData } from 'src/utilities/getAll';
 
 export interface DispatchProps {
-  getLinodes: (params?: any, filters?: any) => Promise<GetAllData<Linode[]>>;
+  getLinodes: (params?: any, filters?: any) => Promise<GetAllData<Linode>>;
 }
 
 export type LinodeWithMaintenance = L;

--- a/packages/manager/src/hooks/useEntities.ts
+++ b/packages/manager/src/hooks/useEntities.ts
@@ -82,13 +82,13 @@ export const useEntities = () => {
     },
     nodeBalancers: {
       data: nodeBalancers,
-      request: requestNodeBalancers,
+      request: () => requestNodeBalancers().then(response => response.data),
       lastUpdated: _nodeBalancers.lastUpdated,
       error: _nodeBalancers.error?.read
     },
     volumes: {
       data: volumes,
-      request: requestVolumes,
+      request: () => requestVolumes().then(response => response.data),
       lastUpdated: _volumes.lastUpdated,
       error: _volumes.error?.read
     }

--- a/packages/manager/src/store/domains/domains.actions.ts
+++ b/packages/manager/src/store/domains/domains.actions.ts
@@ -38,6 +38,6 @@ export const deleteDomainActions = actionCreator.async<
 
 export const getDomainsActions = actionCreator.async<
   void,
-  GetAllData<Domain[]>,
+  GetAllData<Domain>,
   APIError[]
 >('get-all');

--- a/packages/manager/src/store/firewalls/firewalls.actions.ts
+++ b/packages/manager/src/store/firewalls/firewalls.actions.ts
@@ -15,7 +15,7 @@ export const getFirewalls = actionCreator.async<
     params?: any;
     filter?: any;
   },
-  GetAllData<Firewall[]>,
+  GetAllData<Firewall>,
   APIError[]
 >(`get-all`);
 

--- a/packages/manager/src/store/linodes/linodes.actions.ts
+++ b/packages/manager/src/store/linodes/linodes.actions.ts
@@ -30,7 +30,7 @@ export const getLinodesActions = actionCreator.async<
     params?: any;
     filter?: any;
   },
-  GetAllData<Linode[]>,
+  GetAllData<Linode>,
   APIError[]
 >('get-all');
 

--- a/packages/manager/src/store/longview/longview.actions.ts
+++ b/packages/manager/src/store/longview/longview.actions.ts
@@ -11,7 +11,7 @@ export const getLongviewClients = actionCreator.async<
     params?: any;
     filter?: any;
   },
-  GetAllData<LongviewClient[]>,
+  GetAllData<LongviewClient>,
   APIError[]
 >(`get`);
 

--- a/packages/manager/src/store/nodeBalancer/nodeBalancer.actions.ts
+++ b/packages/manager/src/store/nodeBalancer/nodeBalancer.actions.ts
@@ -17,7 +17,7 @@ type Entity = NodeBalancer;
 
 export const getAllNodeBalancersActions = actionCreator.async<
   void,
-  GetAllData<NodeBalancer[]>,
+  GetAllData<NodeBalancer>,
   APIError[]
 >(`get-all`);
 

--- a/packages/manager/src/store/store.helpers.tmp.ts
+++ b/packages/manager/src/store/store.helpers.tmp.ts
@@ -115,7 +115,7 @@ export const getAddRemoved = <E extends Entity>(
 export const createRequestThunk = <Req extends any, Res extends any, Err>(
   actions: AsyncActionCreators<Req, Res, Err>,
   request: (params: Req) => Promise<any>
-): ThunkActionCreator<Promise<Res[]>, Req> => {
+): ThunkActionCreator<Promise<Res>, Req> => {
   return (params: Req) => async dispatch => {
     const { started, done, failed } = actions;
 
@@ -125,7 +125,7 @@ export const createRequestThunk = <Req extends any, Res extends any, Err>(
       const result = await request(params);
       const doneAction = done({ result, params });
       dispatch(doneAction);
-      return result.data;
+      return result;
     } catch (error) {
       const failAction = failed({ error, params });
       dispatch(failAction);

--- a/packages/manager/src/store/volume/volume.actions.ts
+++ b/packages/manager/src/store/volume/volume.actions.ts
@@ -72,7 +72,7 @@ export interface GetAllVolumesOptions {
 }
 export const getAllVolumesActions = actionCreator.async<
   GetAllVolumesOptions | void,
-  GetAllData<Volume[]>,
+  GetAllData<Volume>,
   APIError[]
 >('get-all');
 

--- a/packages/manager/src/utilities/getAll.ts
+++ b/packages/manager/src/utilities/getAll.ts
@@ -29,7 +29,7 @@ export type GetFromEntity = (
 ) => Promise<APIResponsePage<any>>;
 
 export interface GetAllData<T> {
-  data: T;
+  data: T[];
   results: number;
 }
 
@@ -53,7 +53,7 @@ export interface GetAllData<T> {
 export const getAll: <T>(
   getter: GetFunction,
   pageSize?: number
-) => (params?: any, filter?: any) => Promise<GetAllData<T[]>> = (
+) => (params?: any, filter?: any) => Promise<GetAllData<T>> = (
   getter,
   pageSize = API_MAX_PAGE_SIZE
 ) => (params?: any, filter?: any) => {
@@ -96,7 +96,7 @@ export const getAll: <T>(
 export const getAllWithArguments: <T>(
   getter: GetFunction,
   pageSize?: number
-) => (args: any[], params?: any, filter?: any) => Promise<GetAllData<T[]>> = (
+) => (args: any[], params?: any, filter?: any) => Promise<GetAllData<T>> = (
   getter,
   pageSize = API_MAX_PAGE_SIZE
 ) => (args = [], params, filter) => {


### PR DESCRIPTION
## Description

In an attempt to make the typing work out for the updated createRequestThunk,
I returned response.data from the Thunk's "done" logic. This broke single-entity
requests, such as createVolume, which returns a single Volume object and has
no data property.

I undid this, and tried a different way to resolve the typing. This involved
matching the GetAllData type with ResponsePage, which assumes an array
of its type argument (`ResponsePage<Linode>` returns `Linode[]` in its data field).

For now, manually did then(result => result.data) in the Volumes and NBs
handling in useEntities so that they return an array as intended.

## Notes for reviewers

Please make sure everything still works. Volume creation was broken after the change described above and the support ticket drawer was broken before it, but anything related to Volumes or NodeBalancers could be affected.