### PR TITLE
Removing extraneous empty table header cell on Search Landing

### DIFF
--- a/packages/manager/src/features/Search/ResultGroup.tsx
+++ b/packages/manager/src/features/Search/ResultGroup.tsx
@@ -88,7 +88,6 @@ export const ResultGroup: React.StatelessComponent<CombinedProps> = props => {
         <Table aria-label="Search Results">
           <TableHead>
             <TableRow>
-              <TableCell className={classes.emptyCell} />
               <Hidden smDown>
                 <TableCell className={classes.emptyCell} />
               </Hidden>
@@ -139,9 +138,6 @@ const handlers = withStateHandlers(
   }
 );
 
-const enhanced = compose<CombinedProps, Props>(
-  styled,
-  handlers
-)(ResultGroup);
+const enhanced = compose<CombinedProps, Props>(styled, handlers)(ResultGroup);
 
 export default enhanced;


### PR DESCRIPTION
## Description

An extra empty table header cell was causing a shift on the search results landing page. Removing this should fix that issue.

## Type of Change
- Bug fix ('fix')

## Note to Reviewers

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
