### PR TITLE
M3-4033 Invoice PDF tax ID collision

### DIFF
--- a/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
@@ -106,7 +106,7 @@ interface Title {
   text: string;
   leftMargin?: number;
 }
-// The `y` argument is the position in which the first text string should be added to the doc.
+// The `y` argument is the position (in pixels) in which the first text string should be added to the doc.
 const addTitle = (doc: jsPDF, y: number, ...textStrings: Title[]) => {
   doc.setFontSize(12);
   doc.setFontStyle('bold');

--- a/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
@@ -56,6 +56,8 @@ const addLeftHeader = (
   if (taxID) {
     addLine(`Linode Tax ID: ${taxID}`);
   }
+
+  return currentLine;
 };
 
 const addRightHeader = (doc: jsPDF, account: Account) => {
@@ -96,18 +98,20 @@ const addRightHeader = (doc: jsPDF, account: Account) => {
   }
   addLine(`${city}, ${state}, ${zip}`);
   addLine(`${country}`);
+
+  return currentLine;
 };
 
 interface Title {
   text: string;
   leftMargin?: number;
 }
-
-const addTitle = (doc: jsPDF, ...textStrings: Title[]) => {
+// The `y` argument is the position in which the first text string should be added to the doc.
+const addTitle = (doc: jsPDF, y: number, ...textStrings: Title[]) => {
   doc.setFontSize(12);
   doc.setFontStyle('bold');
   textStrings.forEach(eachString => {
-    doc.text(eachString.text, eachString.leftMargin || leftMargin, 130, {
+    doc.text(eachString.text, eachString.leftMargin || leftMargin, y, {
       charSpace: 0.75,
       maxWidth: 100
     });
@@ -171,8 +175,16 @@ export const printInvoice = (
     // Create a separate page for each set of invoice items
     itemsChunks.forEach((itemsChunk, index) => {
       doc.addImage(LinodeLogo, 'JPEG', 150, 5, 120, 50);
-      addLeftHeader(doc, index + 1, itemsChunks.length, date, 'Invoice', taxID);
-      addRightHeader(doc, account);
+
+      const leftHeaderYPosition = addLeftHeader(
+        doc,
+        index + 1,
+        itemsChunks.length,
+        date,
+        'Invoice',
+        taxID
+      );
+      const rightHeaderYPosition = addRightHeader(doc, account);
 
       /** only show tax ID if there is one provided */
       const strings =
@@ -192,7 +204,11 @@ export const printInvoice = (
             ]
           : [{ text: `Invoice: #${invoiceId}` }];
 
-      addTitle(doc, ...strings);
+      addTitle(
+        doc,
+        Math.max(leftHeaderYPosition, rightHeaderYPosition) + 4,
+        ...strings
+      );
 
       createInvoiceItemsTable(doc, itemsChunk);
       createFooter(doc, baseFont);
@@ -234,10 +250,18 @@ export const printPayment = (
     doc.setFontStyle('bold');
 
     doc.addImage(LinodeLogo, 'JPEG', 150, 5, 120, 50);
-    addLeftHeader(doc, 1, 1, date, 'Payment', taxID);
-
-    addRightHeader(doc, account);
-    addTitle(doc, { text: `Receipt for Payment #${payment.id}` });
+    const leftHeaderYPosition = addLeftHeader(
+      doc,
+      1,
+      1,
+      date,
+      'Payment',
+      taxID
+    );
+    const rightHeaderYPosition = addRightHeader(doc, account);
+    addTitle(doc, Math.max(leftHeaderYPosition, rightHeaderYPosition) + 4, {
+      text: `Receipt for Payment #${payment.id}`
+    });
 
     createPaymentsTable(doc, payment);
     createFooter(doc, baseFont);


### PR DESCRIPTION
## Description

Previously the `addTitles()` method (used to insert the Tax ID into the document) used a constant value for the Y coordinate. This meant that if a user had a long address, there would be a collision:

![Screen Shot 2020-03-20 at 2 49 04 PM](https://user-images.githubusercontent.com/16911484/77197672-fe885e80-6abb-11ea-838f-e65a3266e748.png)

To fix this, the `addLeftHeader()` and `addRightHeader()` methods now return the Y value of the last line they inserted. We then pass the max of these (either left OR right header Y coordinate) to the "addTitles" method, which uses this dynamic value instead of the constant.

Note: I don't like this code.

## Note to Reviewers

Make your address long, change your country a tax country and add a Tax ID. Check that invoices and payment receipts work OK.
