### PR TITLE
Test Cleanup

### DIFF
--- a/packages/manager/config/testSetup.js
+++ b/packages/manager/config/testSetup.js
@@ -1,4 +1,5 @@
 // Configure Enzyme Adapter
+const sdk = require('linode-js-sdk/lib/request');
 var Enzyme = require('enzyme');
 var Adapter = require('enzyme-adapter-react-16');
 var React = require('react');
@@ -26,6 +27,14 @@ const localStorageMock = (function() {
     }
   };
 })();
+
+// If we ever forget to mock a request in our unit tests,
+// and hit the API, log an error to the console (and stop
+// the request)
+sdk.baseRequest.interceptors.request.use(request => {
+  console.error('Making a real API request', request.url);
+  return null;
+});
 
 Object.defineProperty(window, 'localStorage', { value: localStorageMock });
 

--- a/packages/manager/config/testSetup.js
+++ b/packages/manager/config/testSetup.js
@@ -1,5 +1,6 @@
 // Configure Enzyme Adapter
 const sdk = require('linode-js-sdk/lib/request');
+const preferences = require.requireMock('linode-js-sdk/lib/profile');
 var Enzyme = require('enzyme');
 var Adapter = require('enzyme-adapter-react-16');
 var React = require('react');
@@ -35,6 +36,15 @@ sdk.baseRequest.interceptors.request.use(request => {
   console.error('Making a real API request', request.url);
   return null;
 });
+
+// Our renderWithTheme helper includes a call to /preferences, mock that out
+jest.mock('linode-js-sdk/lib/profile', () => ({
+  getUserPreferences: jest.fn(),
+  updateUserPreferences: jest.fn()
+}));
+
+preferences.getUserPreferences = jest.fn().mockResolvedValue({});
+preferences.updateUserPreferences = jest.fn().mockResolvedValue({});
 
 Object.defineProperty(window, 'localStorage', { value: localStorageMock });
 

--- a/packages/manager/src/components/EnhancedSelect/__mocks__/Select.tsx
+++ b/packages/manager/src/components/EnhancedSelect/__mocks__/Select.tsx
@@ -26,7 +26,6 @@ export default ({ options, value, onChange, errorText, isMulti }: any) => {
   return (
     <>
       <select
-        multiple={isMulti}
         data-testid="select"
         value={value ?? ''}
         onBlur={handleChange}

--- a/packages/manager/src/components/EnhancedSelect/__mocks__/Select.tsx
+++ b/packages/manager/src/components/EnhancedSelect/__mocks__/Select.tsx
@@ -26,6 +26,7 @@ export default ({ options, value, onChange, errorText, isMulti }: any) => {
   return (
     <>
       <select
+        multiple={isMulti}
         data-testid="select"
         value={value ?? ''}
         onBlur={handleChange}
@@ -36,6 +37,7 @@ export default ({ options, value, onChange, errorText, isMulti }: any) => {
             key={thisOption.value ?? ''}
             value={thisOption.value ?? ''}
             aria-selected={thisOption.value === value}
+            data-testid={`mock-option`}
           >
             {thisOption.label}
           </option>

--- a/packages/manager/src/components/LinodeMultiSelect/LinodeMultiSelect.test.tsx
+++ b/packages/manager/src/components/LinodeMultiSelect/LinodeMultiSelect.test.tsx
@@ -110,7 +110,7 @@ describe('Linode Multi Select', () => {
 
       await wait(() =>
         fireEvent.change(getByTestId('select'), {
-          target: { value: linodes[1].id }
+          target: { value: [linodes[1].id] }
         })
       );
       expect(props.handleChange).toHaveBeenCalledWith([linodes[1].id]);
@@ -121,7 +121,7 @@ describe('Linode Multi Select', () => {
 
       await wait(() =>
         fireEvent.change(getByTestId('select'), {
-          target: { value: 'ALL' }
+          target: { value: ['ALL'] }
         })
       );
       expect(props.handleChange).toHaveBeenCalledWith(linodes.map(i => i.id));

--- a/packages/manager/src/components/TagsInput/TagsInput.test.tsx
+++ b/packages/manager/src/components/TagsInput/TagsInput.test.tsx
@@ -22,10 +22,7 @@ describe('TagsInput', () => {
 
   const { getByTestId, queryAllByTestId } = renderWithTheme(
     <TagsInput
-      value={['someTag', 'someOtherTag'].map(tag => ({
-        value: tag,
-        label: tag
-      }))}
+      value={'mockvalue' as any} // We're mocking this component so ignore the Props typing
       onChange={onChange}
     />
   );

--- a/packages/manager/src/components/TagsInput/TagsInput.test.tsx
+++ b/packages/manager/src/components/TagsInput/TagsInput.test.tsx
@@ -1,23 +1,26 @@
-import { shallow } from 'enzyme';
-import { baseRequest } from 'linode-js-sdk/lib/request';
+import { fireEvent } from '@testing-library/react';
 import * as React from 'react';
 
+import { renderWithTheme } from 'src/utilities/testHelpers';
 import TagsInput from './TagsInput';
 
-import MockAdapter from 'axios-mock-adapter';
+const request = require.requireMock('linode-js-sdk/lib/tags');
 
-const mockApi = new MockAdapter(baseRequest);
+jest.mock('linode-js-sdk/lib/tags', () => ({
+  getTags: jest.fn()
+}));
+jest.mock('src/components/EnhancedSelect/Select');
 
 const mockTags = ['tag1', 'tag2', 'tag3', 'tag4', 'tag5'];
 
-mockApi.onGet('/tags').reply(200, {
-  data: mockTags.map(tag => ({ label: tag }))
-});
+request.getTags = jest
+  .fn()
+  .mockResolvedValue({ data: mockTags.map(tag => ({ label: tag })) });
 
 describe('TagsInput', () => {
   const onChange = jest.fn();
 
-  const component = shallow(
+  const { getByTestId, queryAllByTestId } = renderWithTheme(
     <TagsInput
       value={['someTag', 'someOtherTag'].map(tag => ({
         value: tag,
@@ -28,16 +31,15 @@ describe('TagsInput', () => {
   );
 
   it('sets account tags based on API request', () => {
-    expect(component.state('accountTags')).toHaveLength(mockTags.length);
+    fireEvent.click(getByTestId('select'));
+    expect(queryAllByTestId('mock-option')).toHaveLength(mockTags.length);
+    expect(request.getTags).toHaveBeenCalledTimes(1);
   });
 
   it('calls onChange handler when the value is updated', () => {
-    const newValue = ['someTag', 'anotherTag', 'onMoreTag'].map(tag => ({
-      value: tag,
-      label: tag
-    }));
-
-    component.simulate('change', newValue);
-    expect(onChange).toHaveBeenCalledWith(newValue);
+    fireEvent.change(getByTestId('select'), {
+      target: { value: 'tag2' }
+    });
+    expect(onChange).toHaveBeenCalledWith([{ label: 'tag2', value: 'tag2' }]);
   });
 });

--- a/packages/manager/src/components/TagsInput/TagsInput.tsx
+++ b/packages/manager/src/components/TagsInput/TagsInput.tsx
@@ -64,7 +64,7 @@ class TagsInput extends React.Component<Props, State> {
         });
         this.setState({ accountTags });
       })
-      .catch(_ => {
+      .catch(err => {
         const defaultError = [
           { reason: 'There was an error retrieving your tags.' }
         ];

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/TopProcesses.test.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/TopProcesses.test.tsx
@@ -15,7 +15,7 @@ const props: Props = {
 describe('Top Processes', () => {
   describe('TopProcesses Component', () => {
     beforeEach(() => {
-      jest.resetAllMocks();
+      jest.clearAllMocks();
     });
 
     it('renders the title', () => {

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.test.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.test.tsx
@@ -16,6 +16,7 @@ import {
 afterEach(cleanup);
 
 jest.mock('../request');
+jest.mock('./LongviewClientRow');
 
 const clients = longviewClientFactory.buildList(5);
 

--- a/packages/manager/src/features/Longview/LongviewLanding/__mocks__/LongviewClientRow.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/__mocks__/LongviewClientRow.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+interface Props {
+  clientLabel: string;
+}
+
+export const LongviewClientRowMock = ({ clientLabel }: Props) => {
+  return <div data-testid="longview-client-row">{clientLabel}</div>;
+};
+
+export default LongviewClientRowMock;

--- a/packages/manager/src/features/Longview/__mocks__/request.ts
+++ b/packages/manager/src/features/Longview/__mocks__/request.ts
@@ -1,5 +1,7 @@
-export const get = jest.fn().mockResolvedValue({});
+export const get = jest.fn().mockResolvedValue({ DATA: {} });
 export const getLastUpdated = jest.fn().mockResolvedValue(0);
 export const getValues = jest.fn().mockResolvedValue({});
 export const getLatestValue = jest.fn().mockResolvedValue({});
+export const getTopProcesses = jest.fn().mockResolvedValue({});
+export const handleLongviewResponse = jest.fn().mockResolvedValue({});
 export default get;

--- a/packages/manager/src/features/Longview/request.ts
+++ b/packages/manager/src/features/Longview/request.ts
@@ -151,25 +151,3 @@ export const getTopProcesses = curry((token: string, options?: Options) => {
 });
 
 export default get;
-
-/*
- * getTopProcesses
- * lastUpdated
- * batch
- *  - api
- * getValues and getLatestValue
- *  - keys:
- *    - SysInfo.(os.distSysInfo|client)
- *    - Processes.*.(cpu|ioreadkbytes|iowritekbytes)
- *    - Disk.*.(reads|writes|read_bytes|write_bytes)
- *    - CPU.*.(wait|system|user)
- *    - Network.Linode.v[46].(rx|tx|ip6_rx|ip6_tx)(_private)_bytes
- *    - Network.Interface.*.(tx_bytes|rx_bytes)
- *    - Applications.{application}.status
- *    - Applications.{application}.status_message
- *    - Applications.Apache.Total
- *    - Applications.Nginx.(accepted_cons|handled_cons|requests)
- *    - Applications.MySQL.(Com|Slow_queries|Bytes|Connections|Max_used|Aborted|
- *    -                     Qcache_hits|Qcache_inserts)
- *    - Packages (?)
- **/

--- a/packages/manager/src/features/Volumes/VolumeDrawer/LinodeSelect.test.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/LinodeSelect.test.tsx
@@ -4,6 +4,14 @@ import { regions } from 'src/__data__/regionsData';
 import { Item } from 'src/components/EnhancedSelect/Select';
 import { LinodeSelect } from './LinodeSelect';
 
+const requests = require.requireMock('linode-js-sdk/lib/linodes');
+
+jest.mock('linode-js-sdk/lib/linodes', () => ({
+  getLinodes: () => jest.fn()
+}));
+
+requests.getLinodes = jest.fn().mockResolvedValue([]);
+
 const linodes: Item[] = [
   {
     label: 'test-linode-001',

--- a/packages/manager/src/store/longviewStats/longviewStats.requests.ts
+++ b/packages/manager/src/store/longviewStats/longviewStats.requests.ts
@@ -18,7 +18,7 @@ export const getClientStats = createRequestThunk(
     let packages: LongviewPackage[];
     try {
       const result = await get(api_key, 'getValues', { fields: ['packages'] });
-      packages = result.DATA.Packages || [];
+      packages = result?.DATA?.Packages || [];
     } catch {
       packages = [];
     }
@@ -34,7 +34,6 @@ export const getClientStats = createRequestThunk(
     if (lastUpdated && Date.now() / 1000 - lastUpdated > 60 * 30) {
       return Promise.resolve({ Packages: [...packages] });
     }
-
     return get(api_key, 'getLatestValue', {
       fields: ['cpu', 'disk', 'load', 'memory', 'network', 'sysinfo', 'uptime']
     }).then(response => ({


### PR DESCRIPTION
## Description

- Mock client rows in the LinodeClients.test to prevent them from
rendering the gauges and making a ton of mock requests unrelated
to the test. (this fixes the not wrapped in act warnings)
- When trying to track that down, I added logic to log an error
if any of our tests attempted to hit the real Linode API. This led
down a bit of a rabbit hole:

  - removed axios-mock-adapter from the TagsInput test and rewrote
those tests in RTL
  - mocked preferences calls since it turns out that our wrapWithTheme
  helper was making a call on each use
  - fixed TopProcesses tests, which were calling resetAllMocks() instead
of clearAllMocks(), which was resetting the mocked preference calls
  - stopped a call to /linodes in the old LinodeSelect tests


## Note to Reviewers

No "real" files were affected by this PR, test stuff only. What was passing before is passing now, and there should be less console noise. You'll notice a few instances of "Making a real API request" console errors, which I'll clean up in a follow-on.