### PR TITLE
Fix deletealltestlinodes was deleting ALL linodes (not just test ones)

### DIFF
--- a/packages/manager/cypress/support/api/linodes.js
+++ b/packages/manager/cypress/support/api/linodes.js
@@ -9,7 +9,6 @@ import {
 } from './common';
 const testLinodeTag = testTag;
 export const makeLinodeLabel = makeTestLabel;
-const isTestLinode = isTestEntity;
 
 const makeLinodeCreateReq = linode => {
   const linodeData = linode
@@ -63,7 +62,7 @@ export const deleteLinodeByLabel = (label = undefined) => {
 export const deleteAllTestLinodes = () => {
   getLinodes().then(resp => {
     resp.body.data.forEach(linode => {
-      if (isTestLinode) deleteLinodeById(linode.id);
+      if (isTestEntity(linode)) deleteLinodeById(linode.id);
     });
   });
 };


### PR DESCRIPTION
## Description

Bed regression, the test code is supposed to clean up test linodes when launching cypress, but instead it was deleting  all linodes ignoring if they were test linodes ('cy-test' tag or 'cy-test-' prefix in name)

## Type of Change
- Bug fix ('fix', 'repair', 'bug')
