### PR TITLE
Use clearAllMocks instead of resetAllMocks in SearchLanding.test.tsx

### DIFF
--- a/packages/manager/src/features/Search/SearchLanding.test.tsx
+++ b/packages/manager/src/features/Search/SearchLanding.test.tsx
@@ -1,9 +1,3 @@
-/*
- * IMPORTANT NOTE:
- * These tests have been skipped for now to address a cyclic dependency issue. Once services/linodes and
- * services/domains no longer require src/store, we should restore these tests.
- */
-
 import { cleanup, render } from '@testing-library/react';
 import { assocPath } from 'ramda';
 import * as React from 'react';
@@ -38,7 +32,6 @@ const propsWithResults: Props = {
   searchResultsByEntity: { ...emptyResults, linodes: [searchbarResult1] }
 };
 
-jest.mock('linode-js-sdk');
 jest.mock('src/hooks/useReduxLoad', () => ({
   useReduxLoad: () => jest.fn().mockReturnValue({ _loading: false })
 }));
@@ -63,7 +56,7 @@ describe('Component', () => {
   });
 
   it('should search when the entity list (from Redux) changes', () => {
-    jest.resetAllMocks();
+    jest.clearAllMocks();
     const { rerender } = render(wrapWithTheme(<SearchLanding {...props} />));
     expect(props.search).toHaveBeenCalledTimes(1);
 


### PR DESCRIPTION
resetAllMocks undoes the mocking of the preferences endpoint,
which in turn breaks any tests wrapped in LinodeThemeWrapper.

## Description

Please start the pull request title with the jira ticket corresponding to the work if applicable. Please include a short summary of the feature added, the change, or issue fixed.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')
- Non breaking change ('update', 'change')
- Breaking change ('break', 'deprecate')

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Applicable E2E Tests

To run relevant E2E tests, run these commands in 3 separate terminals:

1. `yarn && yarn start`
2. `yarn selenium`
3. `yarn e2e --spec=COMMA_SEPARATED_LIST_OF_SPECS_HERE --browser=headlessChrome`

## Note to Reviewers

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
