### PR TITLE
M3-3963 [Performance] Images Redux load

### DIFF
--- a/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.test.tsx
+++ b/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.test.tsx
@@ -17,7 +17,6 @@ const component = shallow<AuthenticationWrapper>(
     requestTypes={jest.fn()}
     requestClusters={jest.fn()}
     requestDomains={jest.fn()}
-    requestImages={jest.fn()}
     requestLinodes={jest.fn()}
     requestNotifications={jest.fn()}
     requestProfile={jest.fn()}

--- a/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
+++ b/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
@@ -4,7 +4,6 @@ import {
   Notification
 } from 'linode-js-sdk/lib/account';
 import { Domain } from 'linode-js-sdk/lib/domains';
-import { Image } from 'linode-js-sdk/lib/images';
 import { Linode, LinodeType } from 'linode-js-sdk/lib/linodes';
 import { ObjectStorageCluster } from 'linode-js-sdk/lib/object-storage';
 import { Profile } from 'linode-js-sdk/lib/profile';
@@ -25,7 +24,6 @@ import { requestAccount } from 'src/store/account/account.requests';
 import { requestAccountSettings } from 'src/store/accountSettings/accountSettings.requests';
 import { requestClusters } from 'src/store/clusters/clusters.actions';
 import { requestDomains } from 'src/store/domains/domains.requests';
-import { requestImages } from 'src/store/image/image.requests';
 import { requestLinodes } from 'src/store/linodes/linode.requests';
 import { requestTypes } from 'src/store/linodeType/linodeType.requests';
 import {
@@ -61,7 +59,6 @@ export class AuthenticationWrapper extends React.Component<CombinedProps> {
     const dataFetchingPromises: Promise<any>[] = [
       this.props.requestAccount(),
       this.props.requestDomains(),
-      this.props.requestImages(),
       this.props.requestProfile(),
       this.props.requestLinodes(),
       this.props.requestNotifications(),
@@ -142,7 +139,6 @@ interface DispatchProps {
   initSession: () => void;
   requestAccount: () => Promise<Account>;
   requestDomains: () => Promise<Domain[]>;
-  requestImages: () => Promise<Image[]>;
   requestLinodes: () => Promise<GetAllData<Linode>>;
   requestNotifications: () => Promise<Notification[]>;
   requestSettings: () => Promise<AccountSettings>;
@@ -158,7 +154,6 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
   initSession: () => dispatch(handleInitTokens()),
   requestAccount: () => dispatch(requestAccount()),
   requestDomains: () => dispatch(requestDomains()),
-  requestImages: () => dispatch(requestImages()),
   requestLinodes: () => dispatch(requestLinodes({})),
   requestNotifications: () => dispatch(requestNotifications()),
   requestSettings: () => dispatch(requestAccountSettings()),

--- a/packages/manager/src/components/EnhancedSelect/__mocks__/Select.tsx
+++ b/packages/manager/src/components/EnhancedSelect/__mocks__/Select.tsx
@@ -13,7 +13,14 @@ const groupsToItems = (groups: any[]) => {
   }, []);
 };
 
-export default ({ options, value, onChange, errorText, isMulti }: any) => {
+export default ({
+  options,
+  value,
+  label,
+  onChange,
+  errorText,
+  isMulti
+}: any) => {
   const handleChange = (event: any) => {
     const option = _options.find(
       /* tslint:disable-next-line */
@@ -25,6 +32,7 @@ export default ({ options, value, onChange, errorText, isMulti }: any) => {
   const _options = groupsToItems(options);
   return (
     <>
+      <div>{label}</div>
       <select
         data-testid="select"
         value={value ?? ''}

--- a/packages/manager/src/components/ImageSelect/ImageSelect.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.tsx
@@ -9,6 +9,7 @@ import Select, { GroupType, Item } from 'src/components/EnhancedSelect';
 import SingleValue from 'src/components/EnhancedSelect/components/SingleValue';
 import { BaseSelectProps } from 'src/components/EnhancedSelect/Select';
 import Grid from 'src/components/Grid';
+import { useReduxLoad } from 'src/hooks/useReduxLoad';
 import { arePropsEqual } from 'src/utilities/arePropsEqual';
 import getSelectedOptionFromGroupedOptions from 'src/utilities/getSelectedOptionFromGroupedOptions';
 import { distroIcons } from './icons';
@@ -123,6 +124,8 @@ export const ImageSelect: React.FC<Props> = props => {
   } = props;
   const classes = useStyles();
 
+  const { _loading } = useReduxLoad(['images']);
+
   const filteredImages = images.filter(thisImage => {
     switch (variant) {
       case 'public':
@@ -158,6 +161,7 @@ export const ImageSelect: React.FC<Props> = props => {
                 <Select
                   disabled={disabled}
                   label="Images"
+                  isLoading={_loading}
                   placeholder="Choose an image"
                   options={options}
                   onChange={onChange}

--- a/packages/manager/src/components/ImageSelect/ImageSelect.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.tsx
@@ -9,8 +9,10 @@ import Select, { GroupType, Item } from 'src/components/EnhancedSelect';
 import SingleValue from 'src/components/EnhancedSelect/components/SingleValue';
 import { BaseSelectProps } from 'src/components/EnhancedSelect/Select';
 import Grid from 'src/components/Grid';
+import { useImages } from 'src/hooks/useImages';
 import { useReduxLoad } from 'src/hooks/useReduxLoad';
 import { arePropsEqual } from 'src/utilities/arePropsEqual';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getSelectedOptionFromGroupedOptions from 'src/utilities/getSelectedOptionFromGroupedOptions';
 import { distroIcons } from './icons';
 import ImageOption from './ImageOption';
@@ -126,6 +128,13 @@ export const ImageSelect: React.FC<Props> = props => {
 
   const { _loading } = useReduxLoad(['images']);
 
+  // Check for request errors in Redux
+  const { images: _images } = useImages();
+  const imageError = _images.error.read
+    ? getAPIErrorOrDefault(_images.error.read, 'Unable to load Images')[0]
+        .reason
+    : undefined;
+
   const filteredImages = images.filter(thisImage => {
     switch (variant) {
       case 'public':
@@ -170,7 +179,7 @@ export const ImageSelect: React.FC<Props> = props => {
                     selectedImageID || '',
                     options
                   )}
-                  errorText={error}
+                  errorText={error || imageError}
                   components={{ Option: ImageOption, SingleValue }}
                   {...reactSelectProps}
                   className={classNames}

--- a/packages/manager/src/components/ImageSelect/ImageSelect.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.tsx
@@ -130,7 +130,7 @@ export const ImageSelect: React.FC<Props> = props => {
 
   // Check for request errors in Redux
   const { images: _images } = useImages();
-  const imageError = _images.error.read
+  const imageError = _images?.error?.read
     ? getAPIErrorOrDefault(_images.error.read, 'Unable to load Images')[0]
         .reason
     : undefined;

--- a/packages/manager/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
@@ -24,6 +24,7 @@ import TableRowLoading from 'src/components/TableRowLoading';
 import ViewAllLink from 'src/components/ViewAllLink';
 import LinodeRowHeadCell from 'src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell';
 import RegionIndicator from 'src/features/linodes/LinodesLanding/RegionIndicator';
+import { useReduxLoad } from 'src/hooks/useReduxLoad';
 import { ApplicationState } from 'src/store';
 import {
   isEntityEvent,
@@ -79,57 +80,43 @@ type CombinedProps = ConnectedProps &
   WithTypesProps &
   WithStyles<ClassNames>;
 
-class LinodesDashboardCard extends React.Component<CombinedProps> {
-  render() {
-    const { classes } = this.props;
-    return (
-      <DashboardCard
-        title="Linodes"
-        headerAction={this.renderAction}
-        className={classes.root}
-        alignHeader="flex-start"
-      >
-        <Paper>
-          <Table>
-            <TableBody>{this.renderContent()}</TableBody>
-          </Table>
-        </Paper>
-      </DashboardCard>
-    );
-  }
+const LinodesDashboardCard: React.FC<CombinedProps> = props => {
+  const { classes } = props;
 
-  renderAction = () => {
-    return this.props.linodeCount > 5 ? (
+  const { _loading } = useReduxLoad(['linodes', 'images']);
+
+  const renderAction = () => {
+    return props.linodeCount > 5 ? (
       <ViewAllLink
         text="View All"
         link={'/linodes'}
-        count={this.props.linodeCount}
+        count={props.linodeCount}
       />
     ) : null;
   };
 
-  renderContent = () => {
-    const { loading, linodes, error } = this.props;
-    if (loading) {
-      return this.renderLoading();
+  const renderContent = () => {
+    const { loading, linodes, error } = props;
+    if (loading || _loading) {
+      return renderLoading();
     }
 
     if (error) {
-      return this.renderErrors(error);
+      return renderErrors(error);
     }
 
     if (linodes.length > 0) {
-      return this.renderData(linodes);
+      return renderData(linodes);
     }
 
-    return this.renderEmpty();
+    return renderEmpty();
   };
 
-  renderLoading = () => {
+  const renderLoading = () => {
     return <TableRowLoading colSpan={3} />;
   };
 
-  renderErrors = (errors: APIError[]) => {
+  const renderErrors = (errors: APIError[]) => {
     let errorText: string | JSX.Element = pathOr(
       'Unable to load Linodes.',
       [0, 'reason'],
@@ -152,10 +139,10 @@ class LinodesDashboardCard extends React.Component<CombinedProps> {
     return <TableRowError colSpan={3} message={errorText} />;
   };
 
-  renderEmpty = () => <TableRowEmptyState colSpan={3} />;
+  const renderEmpty = () => <TableRowEmptyState colSpan={3} />;
 
-  renderData = (data: ExtendedLinode[]) => {
-    const { classes } = this.props;
+  const renderData = (data: ExtendedLinode[]) => {
+    const { classes } = props;
 
     return data.map(linode => {
       const { id, label, region } = linode;
@@ -192,8 +179,22 @@ class LinodesDashboardCard extends React.Component<CombinedProps> {
       );
     });
   };
-}
 
+  return (
+    <DashboardCard
+      title="Linodes"
+      headerAction={renderAction}
+      className={classes.root}
+      alignHeader="flex-start"
+    >
+      <Paper>
+        <Table>
+          <TableBody>{renderContent()}</TableBody>
+        </Table>
+      </Paper>
+    </DashboardCard>
+  );
+};
 const styled = withStyles(styles);
 
 interface WithTypesProps {

--- a/packages/manager/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
@@ -142,8 +142,6 @@ const LinodesDashboardCard: React.FC<CombinedProps> = props => {
   const renderEmpty = () => <TableRowEmptyState colSpan={3} />;
 
   const renderData = (data: ExtendedLinode[]) => {
-    const { classes } = props;
-
     return data.map(linode => {
       const { id, label, region } = linode;
       return (

--- a/packages/manager/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx.rej
+++ b/packages/manager/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx.rej
@@ -1,7 +1,0 @@
-diff a/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx b/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx	(rejected hunks)
-@@ -22 +22,4 @@ import { ApplicationState } from 'src/store';
--import { isEntityEvent, isInProgressEvent } from 'src/store/events/event.helpers';
-+import {
-+  isEntityEvent,
-+  isInProgressEvent
-+} from 'src/store/events/event.helpers';

--- a/packages/manager/src/features/Images/ImageSelect.test.tsx
+++ b/packages/manager/src/features/Images/ImageSelect.test.tsx
@@ -1,8 +1,12 @@
-import { shallow } from 'enzyme';
 import * as React from 'react';
+import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { images } from 'src/__data__/images';
-import Select from 'src/components/EnhancedSelect/Select';
+
+jest.mock('src/hooks/useReduxLoad', () => ({
+  useReduxLoad: () => jest.fn().mockReturnValue({ _loading: false })
+}));
+jest.mock('src/components/EnhancedSelect/Select');
 
 import {
   getImagesOptions,
@@ -12,12 +16,9 @@ import {
 } from './ImageSelect';
 
 const props = {
-  classes: { root: '', icon: '', selectContainer: '' },
   images,
   onSelect: jest.fn()
 };
-
-const component = shallow(<ImageSelect {...props} />);
 
 const privateImage1 = {
   deprecated: false,
@@ -209,21 +210,19 @@ describe('ImageSelect', () => {
       expect(getImagesOptions([])).toEqual([]);
     });
   });
+
   describe('ImageSelect component', () => {
     it('should render', () => {
-      expect(component).toBeDefined();
+      const { getByText } = renderWithTheme(<ImageSelect {...props} />);
+      getByText(/image/i);
     });
     it('should display an error', () => {
-      component.setProps({ imageError: 'An error' });
-      expect(
-        component.containsMatchingElement(
-          <Select
-            onChange={props.onSelect}
-            errorText={'An error'}
-            label="Image"
-          />
-        )
-      ).toBeTruthy();
+      const imageError = 'An error';
+      const { getByText } = renderWithTheme(
+        <ImageSelect {...props} imageError={imageError} />
+      );
+
+      getByText(imageError);
     });
   });
 });

--- a/packages/manager/src/features/Images/ImageSelect.tsx
+++ b/packages/manager/src/features/Images/ImageSelect.tsx
@@ -1,36 +1,27 @@
 import { Image } from 'linode-js-sdk/lib/images';
-import * as React from 'react';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles
-} from 'src/components/core/styles';
-
 import { always, cond, groupBy, propOr } from 'ramda';
-
+import * as React from 'react';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Select, { GroupType, Item } from 'src/components/EnhancedSelect/Select';
 import Grid from 'src/components/Grid';
 import HelpIcon from 'src/components/HelpIcon';
+import { useReduxLoad } from 'src/hooks/useReduxLoad';
 
-type ClassNames = 'root' | 'selectContainer' | 'icon';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    width: '100%'
+  },
+  icon: {
+    marginTop: theme.spacing(2) + 14,
+    marginLeft: -theme.spacing(1)
+  },
+  selectContainer: {
+    width: 415 + theme.spacing(2),
+    [theme.breakpoints.down('xs')]: {
       width: '100%'
-    },
-    icon: {
-      marginTop: theme.spacing(2) + 14,
-      marginLeft: -theme.spacing(1)
-    },
-    selectContainer: {
-      width: 415 + theme.spacing(2),
-      [theme.breakpoints.down('xs')]: {
-        width: '100%'
-      }
     }
-  });
+  }
+}));
 
 interface Props {
   images: Image[];
@@ -45,89 +36,67 @@ interface Props {
   required?: boolean;
 }
 
-interface State {
-  renderedImages: GroupType<string>[];
-}
+type CombinedProps = Props;
 
-type CombinedProps = Props & WithStyles<ClassNames>;
+export const ImageSelect: React.FC<CombinedProps> = props => {
+  const {
+    helperText,
+    images,
+    imageError,
+    imageFieldError,
+    isMulti,
+    label,
+    onSelect,
+    value,
+    disabled,
+    required
+  } = props;
 
-export class ImageSelect extends React.Component<CombinedProps, State> {
-  mounted: boolean = false;
-  state: State = {
-    renderedImages: getImagesOptions(this.props.images) as GroupType<string>[]
-  };
+  const classes = useStyles();
 
-  componentDidMount() {
-    this.mounted = true;
-  }
+  const { _loading } = useReduxLoad(['images']);
 
-  componentWillUnmount() {
-    this.mounted = false;
-  }
+  const renderedImages = React.useMemo(() => getImagesOptions(images), [
+    images
+  ]);
 
-  componentDidUpdate(prevProps: CombinedProps) {
-    if (!this.mounted) {
-      return;
-    }
-    if (prevProps.images !== this.props.images) {
-      this.setState({
-        renderedImages: getImagesOptions(this.props.images) as GroupType<
-          string
-        >[]
-      });
-    }
-  }
-
-  render() {
-    const {
-      classes,
-      helperText,
-      imageError,
-      imageFieldError,
-      isMulti,
-      onSelect,
-      value,
-      disabled,
-      required
-    } = this.props;
-    const { renderedImages } = this.state;
-    return (
-      <React.Fragment>
-        <Grid
-          className={classes.root}
-          container
-          wrap="nowrap"
-          direction="row"
-          justify="flex-start"
-          alignItems="flex-start"
-        >
-          <Grid item className={classes.selectContainer}>
-            <Select
-              id={'image-select'}
-              value={value}
-              isMulti={Boolean(isMulti)}
-              errorText={imageError || imageFieldError}
-              disabled={disabled || Boolean(imageError)}
-              onChange={onSelect}
-              options={renderedImages as any}
-              placeholder="Select an Image"
-              textFieldProps={{
-                required
-              }}
-              label={this.props.label || 'Image'}
-            />
-          </Grid>
-          <Grid item xs={1}>
-            <HelpIcon
-              className={classes.icon}
-              text={helperText || 'Choosing a 64-bit distro is recommended.'}
-            />
-          </Grid>
+  return (
+    <React.Fragment>
+      <Grid
+        className={classes.root}
+        container
+        wrap="nowrap"
+        direction="row"
+        justify="flex-start"
+        alignItems="flex-start"
+      >
+        <Grid item className={classes.selectContainer}>
+          <Select
+            id={'image-select'}
+            isLoading={_loading}
+            value={value}
+            isMulti={Boolean(isMulti)}
+            errorText={imageError || imageFieldError}
+            disabled={disabled || Boolean(imageError)}
+            onChange={onSelect}
+            options={renderedImages as any}
+            placeholder="Select an Image"
+            textFieldProps={{
+              required
+            }}
+            label={label || 'Image'}
+          />
         </Grid>
-      </React.Fragment>
-    );
-  }
-}
+        <Grid item xs={1}>
+          <HelpIcon
+            className={classes.icon}
+            text={helperText || 'Choosing a 64-bit distro is recommended.'}
+          />
+        </Grid>
+      </Grid>
+    </React.Fragment>
+  );
+};
 
 export const getImagesOptions = (images: Image[]) => {
   const groupedImages = groupImages(images);
@@ -187,6 +156,4 @@ export const groupNameMap = {
 const getDisplayNameForGroup = (key: string) =>
   propOr('Other', key, groupNameMap);
 
-const styled = withStyles(styles);
-
-export default styled(ImageSelect);
+export default ImageSelect;

--- a/packages/manager/src/features/Images/ImageSelect.tsx
+++ b/packages/manager/src/features/Images/ImageSelect.tsx
@@ -5,7 +5,9 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 import Select, { GroupType, Item } from 'src/components/EnhancedSelect/Select';
 import Grid from 'src/components/Grid';
 import HelpIcon from 'src/components/HelpIcon';
+import { useImages } from 'src/hooks/useImages';
 import { useReduxLoad } from 'src/hooks/useReduxLoad';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -56,6 +58,14 @@ export const ImageSelect: React.FC<CombinedProps> = props => {
 
   const { _loading } = useReduxLoad(['images']);
 
+  // Check for request errors in Redux
+  const {
+    images: { error }
+  } = useImages();
+  const reduxError = error.read
+    ? getAPIErrorOrDefault(error.read, 'Unable to load Images')[0].reason
+    : undefined;
+
   const renderedImages = React.useMemo(() => getImagesOptions(images), [
     images
   ]);
@@ -76,7 +86,7 @@ export const ImageSelect: React.FC<CombinedProps> = props => {
             isLoading={_loading}
             value={value}
             isMulti={Boolean(isMulti)}
-            errorText={imageError || imageFieldError}
+            errorText={imageError || imageFieldError || reduxError}
             disabled={disabled || Boolean(imageError)}
             onChange={onSelect}
             options={renderedImages as any}

--- a/packages/manager/src/features/Images/ImageSelect.tsx
+++ b/packages/manager/src/features/Images/ImageSelect.tsx
@@ -62,7 +62,7 @@ export const ImageSelect: React.FC<CombinedProps> = props => {
   const {
     images: { error }
   } = useImages();
-  const reduxError = error.read
+  const reduxError = error?.read
     ? getAPIErrorOrDefault(error.read, 'Unable to load Images')[0].reason
     : undefined;
 

--- a/packages/manager/src/features/Images/ImagesLanding.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding.tsx
@@ -4,9 +4,11 @@ import { deleteImage, Image } from 'linode-js-sdk/lib/images';
 import { APIError } from 'linode-js-sdk/lib/types';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import * as React from 'react';
-import { connect } from 'react-redux';
+import { connect, MapDispatchToProps } from 'react-redux';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
+import { AnyAction } from 'redux';
+import { ThunkDispatch } from 'redux-thunk';
 import 'rxjs/add/operator/filter';
 import { Subscription } from 'rxjs/Subscription';
 import ActionsPanel from 'src/components/ActionsPanel';
@@ -38,6 +40,7 @@ import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
 import TableSortCell from 'src/components/TableSortCell';
 import { ApplicationState } from 'src/store';
+import { requestImages as _requestImages } from 'src/store/image/image.requests';
 import imageEvents from 'src/store/selectors/imageEvents';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import ImageRow from './ImageRow';
@@ -73,6 +76,7 @@ interface State {
 }
 
 type CombinedProps = WithPrivateImages &
+  ImageDispatch &
   WithStyles<ClassNames> &
   RouteComponentProps<{}> &
   WithSnackbarProps;
@@ -93,6 +97,16 @@ class ImagesLanding extends React.Component<CombinedProps, State> {
       submitting: false
     }
   };
+
+  componentDidMount() {
+    if (
+      this.props.imagesData.length === 0 &&
+      this.props.imagesLastUpdated === 0 &&
+      !this.props.imagesLoading
+    ) {
+      this.props.requestImages();
+    }
+  }
 
   openForCreate = () => {
     this.setState({
@@ -490,11 +504,22 @@ interface WithPrivateImages {
   imagesData: ImageWithEvent[];
   imagesLoading: boolean;
   imagesError?: APIError[];
+  imagesLastUpdated: number;
 }
+
+interface ImageDispatch {
+  requestImages: () => Promise<Image[]>;
+}
+
+const mapDispatchToProps: MapDispatchToProps<ImageDispatch, {}> = (
+  dispatch: ThunkDispatch<ApplicationState, undefined, AnyAction>
+) => ({
+  requestImages: () => dispatch(_requestImages())
+});
 
 const withPrivateImages = connect(
   (state: ApplicationState): WithPrivateImages => {
-    const { error, data, loading } = state.__resources.images;
+    const { error, data, lastUpdated, loading } = state.__resources.images;
     const events = imageEvents(state.events);
     const privateImagesWithEvents = Object.values(data).reduce(
       (accum, thisImage) =>
@@ -518,9 +543,11 @@ const withPrivateImages = connect(
     return {
       imagesData: privateImagesWithEvents,
       imagesLoading: loading,
-      imagesError: error ? error.read : undefined
+      imagesError: error ? error.read : undefined,
+      imagesLastUpdated: lastUpdated
     };
-  }
+  },
+  mapDispatchToProps
 );
 
 const styled = withStyles(styles);

--- a/packages/manager/src/features/Images/ImagesLanding.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding.tsx
@@ -539,7 +539,7 @@ const withPrivateImages = connect(
     return {
       imagesData: privateImagesWithEvents,
       imagesLoading: loading,
-      imagesError: error ? error.read : undefined,
+      imagesError: error?.read,
       imagesLastUpdated: lastUpdated
     };
   },

--- a/packages/manager/src/features/Images/ImagesLanding.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding.tsx
@@ -99,11 +99,7 @@ class ImagesLanding extends React.Component<CombinedProps, State> {
   };
 
   componentDidMount() {
-    if (
-      this.props.imagesData.length === 0 &&
-      this.props.imagesLastUpdated === 0 &&
-      !this.props.imagesLoading
-    ) {
+    if (this.props.imagesLastUpdated === 0 && !this.props.imagesLoading) {
       this.props.requestImages();
     }
   }

--- a/packages/manager/src/features/StackScripts/StackScriptsLanding.test.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptsLanding.test.tsx
@@ -11,7 +11,6 @@ describe('StackScripts Landing', () => {
       imagesData={normalizedImages}
       imagesLoading={false}
       imagesError={{}}
-      classes={{ root: '', title: '' }}
       {...reactRouterProps}
     />
   );

--- a/packages/manager/src/features/StackScripts/StackScriptsLanding.test.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptsLanding.test.tsx
@@ -1,36 +1,24 @@
-import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 import * as React from 'react';
 
 import { normalizedImages } from 'src/__data__/images';
 import { reactRouterProps } from 'src/__data__/reactRouterProps';
+import { wrapWithTheme } from 'src/utilities/testHelpers';
 import { StackScriptsLanding } from './StackScriptsLanding';
 
 describe('StackScripts Landing', () => {
-  const component = shallow(
-    <StackScriptsLanding
-      imagesData={normalizedImages}
-      imagesLoading={false}
-      imagesError={{}}
-      {...reactRouterProps}
-    />
+  const { getByText } = render(
+    wrapWithTheme(
+      <StackScriptsLanding
+        imagesData={normalizedImages}
+        imagesLoading={false}
+        imagesError={{}}
+        {...reactRouterProps}
+      />
+    )
   );
 
-  it('should have an Icon Text Link', () => {
-    expect(component.find('[data-qa-create-new-stackscript]')).toHaveLength(1);
-  });
-
   it('icon text link text should read "Create New StackScript"', () => {
-    const iconText = component
-      .find('[data-qa-create-new-stackscript]')
-      .prop('label');
-    expect(iconText).toBe('Create New StackScript');
-  });
-
-  it('should render SelectStackScriptPanel', () => {
-    expect(
-      component.find(
-        'Connect(WithTheme(WithRenderGuard(WithStyles(SelectStackScriptPanel))))'
-      )
-    ).toHaveLength(1);
+    getByText(/create new stackscript/i);
   });
 });

--- a/packages/manager/src/features/StackScripts/StackScriptsLanding.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptsLanding.tsx
@@ -1,108 +1,90 @@
 import * as React from 'react';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
 import AddNewLink from 'src/components/AddNewLink';
 import Breadcrumb from 'src/components/Breadcrumb';
 import CircleProgress from 'src/components/CircleProgress';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles
-} from 'src/components/core/styles';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
 import withImagesContainer, {
   WithImages
 } from 'src/containers/withImages.container';
+import { useReduxLoad } from 'src/hooks/useReduxLoad';
 import StackScriptPanel from './StackScriptPanel';
 
 import { filterImagesByType } from 'src/store/image/image.helpers';
 
-type ClassNames = 'root' | 'title';
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {},
+  title: {
+    marginTop: theme.spacing(2),
+    marginBottom: theme.spacing(1) + theme.spacing(1) / 2
+  }
+}));
 
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {},
-    title: {
-      marginTop: theme.spacing(2),
-      marginBottom: theme.spacing(1) + theme.spacing(1) / 2
-    }
-  });
+type CombinedProps = WithImages & RouteComponentProps<{}>;
 
-type CombinedProps = WithImages &
-  WithStyles<ClassNames> &
-  RouteComponentProps<{}>;
+export const StackScriptsLanding: React.FC<CombinedProps> = props => {
+  const { history, imagesData, location } = props;
+  const classes = useStyles();
 
-export class StackScriptsLanding extends React.Component<CombinedProps, {}> {
-  goToCreateStackScript = () => {
-    const { history } = this.props;
+  const goToCreateStackScript = () => {
     history.push('/stackscripts/create');
   };
 
-  render() {
-    const {
-      classes,
-      history,
-      imagesData,
-      imagesLoading,
-      location
-    } = this.props;
+  const { _loading } = useReduxLoad(['images']);
 
-    return (
-      <React.Fragment>
-        <DocumentTitleSegment segment="StackScripts" />
-        {!!history.location.state &&
-          !!history.location.state.successMessage && (
-            <Notice success text={history.location.state.successMessage} />
-          )}
-        <Grid
-          container
-          justify="space-between"
-          alignItems="flex-end"
-          style={{ paddingBottom: 0 }}
-        >
-          <Grid item className="py0">
-            <Breadcrumb
-              pathname={location.pathname}
-              labelTitle="StackScripts"
-              data-qa-title
-              className={classes.title}
-            />
-          </Grid>
-          <Grid item className="py0">
-            <Grid container alignItems="flex-end">
-              <Grid item className="pt0">
-                <AddNewLink
-                  onClick={this.goToCreateStackScript}
-                  label="Create New StackScript"
-                  data-qa-create-new-stackscript
-                />
-              </Grid>
-            </Grid>
-          </Grid>
+  return (
+    <React.Fragment>
+      <DocumentTitleSegment segment="StackScripts" />
+      {!!history.location.state && !!history.location.state.successMessage && (
+        <Notice success text={history.location.state.successMessage} />
+      )}
+      <Grid
+        container
+        justify="space-between"
+        alignItems="flex-end"
+        style={{ paddingBottom: 0 }}
+      >
+        <Grid item className="py0">
+          <Breadcrumb
+            pathname={location.pathname}
+            labelTitle="StackScripts"
+            data-qa-title
+            className={classes.title}
+          />
         </Grid>
-        <Grid container>
-          {imagesLoading ? (
-            <CircleProgress />
-          ) : (
-            <Grid item xs={12}>
-              <StackScriptPanel
-                publicImages={imagesData}
-                queryString={this.props.location.search}
-                history={this.props.history}
-                location={this.props.location}
+        <Grid item className="py0">
+          <Grid container alignItems="flex-end">
+            <Grid item className="pt0">
+              <AddNewLink
+                onClick={goToCreateStackScript}
+                label="Create New StackScript"
+                data-qa-create-new-stackscript
               />
             </Grid>
-          )}
+          </Grid>
         </Grid>
-      </React.Fragment>
-    );
-  }
-}
-
-const styled = withStyles(styles);
+      </Grid>
+      <Grid container>
+        {_loading ? (
+          <CircleProgress />
+        ) : (
+          <Grid item xs={12}>
+            <StackScriptPanel
+              publicImages={imagesData}
+              queryString={props.location.search}
+              history={props.history}
+              location={props.location}
+            />
+          </Grid>
+        )}
+      </Grid>
+    </React.Fragment>
+  );
+};
 
 export default compose<CombinedProps, {}>(
   withImagesContainer((ownProps, imagesData, imagesLoading, imagesError) => ({
@@ -110,7 +92,5 @@ export default compose<CombinedProps, {}>(
     imagesData: filterImagesByType(imagesData, 'public'),
     imagesLoading,
     imagesError
-  })),
-  withRouter,
-  styled
+  }))
 )(StackScriptsLanding);

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.test.tsx
@@ -12,8 +12,11 @@ import { CombinedProps, RebuildFromImage } from './RebuildFromImage';
 
 jest.mock('src/utilities/scrollErrorIntoView');
 jest.mock('src/components/EnhancedSelect/Select');
+jest.mock('src/hooks/useReduxLoad', () => ({
+  useReduxLoad: () => jest.fn().mockReturnValue({ _loading: false })
+}));
 jest.mock('src/hooks/useImages', () => ({
-  images: jest.fn()
+  useImages: jest.fn().mockResolvedValue({ error: {} })
 }));
 
 afterEach(cleanup);

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.test.tsx
@@ -12,7 +12,10 @@ import { CombinedProps, RebuildFromImage } from './RebuildFromImage';
 
 jest.mock('src/utilities/scrollErrorIntoView');
 jest.mock('src/components/EnhancedSelect/Select');
-jest.mock('src/hooks/useImages');
+jest.mock('src/hooks/useImages', () => ({
+  images: jest.fn()
+}));
+
 afterEach(cleanup);
 
 const props: CombinedProps = {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.test.tsx
@@ -12,6 +12,7 @@ import { CombinedProps, RebuildFromImage } from './RebuildFromImage';
 
 jest.mock('src/utilities/scrollErrorIntoView');
 jest.mock('src/components/EnhancedSelect/Select');
+jest.mock('src/hooks/useImages');
 afterEach(cleanup);
 
 const props: CombinedProps = {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetail.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetail.tsx
@@ -74,7 +74,7 @@ const LinodeDetail: React.StatelessComponent<CombinedProps> = props => {
    * Other portions of loading state handled by maybeRenderLoading
    * (Linode info, configs, disks, etc.)
    */
-  const { _loading } = useReduxLoad(['volumes']);
+  const { _loading } = useReduxLoad(['volumes', 'images']);
 
   if (props.loading || _loading) {
     return <CircleProgress />;

--- a/packages/manager/src/features/linodes/LinodesLanding/index.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/index.tsx
@@ -1,2 +1,11 @@
-import LinodesLanding from './LinodesLanding';
+import * as React from 'react';
+import CircleProgress from 'src/components/CircleProgress';
+import { useReduxLoad } from 'src/hooks/useReduxLoad';
+
+const LinodesLanding: React.FC<{}> = _ => {
+  const { _loading } = useReduxLoad(['linodes', 'images']);
+  return _loading ? <CircleProgress /> : <_LinodesLanding />;
+};
+
+import _LinodesLanding from './LinodesLanding';
 export default LinodesLanding;

--- a/packages/manager/src/hooks/useReduxLoad.ts
+++ b/packages/manager/src/hooks/useReduxLoad.ts
@@ -1,5 +1,5 @@
 import * as Bluebird from 'bluebird';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useDispatch, useStore } from 'react-redux';
 import { Dispatch } from 'redux';
 import { REFRESH_INTERVAL } from 'src/constants';
@@ -78,11 +78,19 @@ export const useReduxLoad = (
   const dispatch = useDispatch();
   const state = useStore<ApplicationState>().getState();
 
+  const mountedRef = useRef<boolean>(true);
+
   useEffect(() => {
-    if (predicate) {
+    if (predicate && mountedRef.current) {
       requestDeps(state, dispatch, deps, refreshInterval, setLoading);
     }
-  }, [predicate]);
+  }, [predicate, mountedRef.current]);
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   return { _loading };
 };

--- a/packages/manager/src/hooks/useReduxLoad.ts
+++ b/packages/manager/src/hooks/useReduxLoad.ts
@@ -80,9 +80,15 @@ export const useReduxLoad = (
 
   const mountedRef = useRef<boolean>(true);
 
+  const _setLoading = (val: boolean) => {
+    if (mountedRef.current) {
+      setLoading(val);
+    }
+  };
+
   useEffect(() => {
     if (predicate && mountedRef.current) {
-      requestDeps(state, dispatch, deps, refreshInterval, setLoading);
+      requestDeps(state, dispatch, deps, refreshInterval, _setLoading);
     }
   }, [predicate, mountedRef.current]);
 

--- a/packages/manager/src/store/image/image.reducer.ts
+++ b/packages/manager/src/store/image/image.reducer.ts
@@ -17,7 +17,7 @@ import { EntitiesAsObjectState } from '../types';
 export type State = EntitiesAsObjectState<Image>;
 
 export const defaultState: State = {
-  loading: true,
+  loading: false,
   lastUpdated: 0,
   results: 0,
   data: {},


### PR DESCRIPTION
## Description

Remove requestImages() from our initialRequests block and have different components request images data as needed.

Performance gains are likely to be small here, since Images are needed in most of the major workflows in the app.