### PR TITLE
Change StackScript "Active Deploys" column to "Total Deploys"

### DIFF
--- a/packages/manager/src/features/StackScripts/Partials/StackScriptTableHead.tsx
+++ b/packages/manager/src/features/StackScripts/Partials/StackScriptTableHead.tsx
@@ -138,7 +138,7 @@ class StackScriptTableHead extends React.Component<CombinedProps, {}> {
               data-qa-stackscript-active-deploy-header
               {...maybeAddSortingProps('deploys')}
             >
-              Active Deploys
+              Total Deploys
             </Cell>
           )}
           {!isSelecting && (

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -40,7 +40,7 @@ type CurrentFilter = 'label' | 'deploys' | 'revision';
 
 type SortOrder = 'asc' | 'desc';
 
-type APIFilters = 'label' | 'deployments_active' | 'updated';
+type APIFilters = 'label' | 'deployments_total' | 'updated';
 
 interface FilterInfo {
   apiFilter: APIFilters | null;
@@ -115,7 +115,7 @@ const withStackScriptBase = (options: WithStackScriptBaseOptions) => (
       sortOrder: 'asc',
       currentFilterType: null,
       currentFilter: {
-        ['+order_by']: 'deployments_active',
+        ['+order_by']: 'deployments_total',
         ['+order']: 'desc'
       },
       currentSearchFilter: {},
@@ -260,7 +260,7 @@ const withStackScriptBase = (options: WithStackScriptBaseOptions) => (
           };
         case 'deploys':
           return {
-            apiFilter: 'deployments_active',
+            apiFilter: 'deployments_total',
             currentFilter: 'deploys'
           };
         case 'revision':

--- a/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptRow.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptRow.tsx
@@ -18,7 +18,7 @@ export interface Props {
   label: string;
   description: string;
   images: string[];
-  deploymentsActive: number;
+  deploymentsTotal: number;
   updated: string;
   stackScriptID: number;
   stackScriptUsername: string;
@@ -43,7 +43,7 @@ export class StackScriptRow extends React.Component<CombinedProps, {}> {
       label,
       description,
       images,
-      deploymentsActive,
+      deploymentsTotal,
       updated,
       stackScriptID,
       stackScriptUsername,
@@ -62,9 +62,7 @@ export class StackScriptRow extends React.Component<CombinedProps, {}> {
             <Typography variant="h3" className={classes.libTitle}>
               {stackScriptUsername && (
                 <span
-                  className={`${classes.libRadioLabel} ${
-                    classes.stackScriptUsername
-                  }`}
+                  className={`${classes.libRadioLabel} ${classes.stackScriptUsername}`}
                 >
                   {stackScriptUsername} /&nbsp;
                 </span>
@@ -87,9 +85,9 @@ export class StackScriptRow extends React.Component<CombinedProps, {}> {
           <TableCell data-qa-stackscript-title parentColumn="StackScript">
             {renderLabel()}
           </TableCell>
-          <TableCell parentColumn="Active Deploys">
+          <TableCell parentColumn="Total Deploys">
             <Typography data-qa-stackscript-deploys>
-              {deploymentsActive}
+              {deploymentsTotal}
             </Typography>
           </TableCell>
           <TableCell parentColumn="Last Revision">

--- a/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptsSection.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptsSection.tsx
@@ -77,7 +77,7 @@ const StackScriptsSection: React.StatelessComponent<CombinedProps> = props => {
       description={truncateText(s.description, 100)}
       isPublic={s.is_public}
       images={stripImageName(s.images)}
-      deploymentsActive={s.deployments_active}
+      deploymentsTotal={s.deployments_total}
       updated={formatDate(s.updated, false)}
       stackScriptID={s.id}
       triggerDelete={triggerDelete}
@@ -128,9 +128,6 @@ const mapStateToProps: MapState<StateProps, {}> = state => ({
 
 const connected = connect(mapStateToProps);
 
-const enhanced = compose<CombinedProps, Props>(
-  connected,
-  styled
-);
+const enhanced = compose<CombinedProps, Props>(connected, styled);
 
 export default enhanced(StackScriptsSection);


### PR DESCRIPTION
## Description

Cloud was sorting StackScripts by `deployments_active`, was wasn't officially supported by the API. The API introduced a change that broke this behavior, so we need to sort by `deployments_total` instead of `deployments_active`.
