### PR TITLE
Fix regex for isProdApi constant

### DIFF
--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -32,7 +32,9 @@ export const LAUNCH_DARKLY_API_KEY =
   process.env.REACT_APP_LAUNCH_DARKLY_ID || '';
 
 /** If it's hitting the prod API */
-export const isProdAPI = RegExp('api.linode.com/v4').test(API_ROOT);
+export const isProdAPI = RegExp(
+  /api.linode.com\/v4|cloud.linode.com\/api\/v4/
+).test(API_ROOT);
 
 // Maximum page size allowed by the API. Used in the `getAll()` helper function
 // to request as many items at once as possible.


### PR DESCRIPTION
In production, we proxy the api through cloud.linode.com/api/v4. I forgot
about this when doing the caching logic, and as a result types requests
are cached when running locally against prod services, but not in
actual production. Updated the regex to account for this.

