### PR TITLE
M3-4054: Edit DNS Records containing "linode.com" substring in NS, Pt. 2

### DIFF
--- a/packages/manager/src/features/Domains/DomainRecords.tsx
+++ b/packages/manager/src/features/Domains/DomainRecords.tsx
@@ -130,8 +130,6 @@ const createLink = (title: string, handler: () => void) => (
   <AddNewLink onClick={handler} label={title} />
 );
 
-const nameServerRegex = /ns([1-5]).linode.com/;
-
 class DomainRecords extends React.Component<CombinedProps, State> {
   eventsSubscription$: Subscription;
 
@@ -346,7 +344,7 @@ class DomainRecords extends React.Component<CombinedProps, State> {
            * cannot make changes to Linode's nameservers.
            */
           render: ({ id, name, target, ttl_sec }: DomainRecord) =>
-            nameServerRegex.test(target) ? null : (
+            id === -1 ? null : (
               <ActionMenu
                 editPayload={{
                   id,
@@ -843,7 +841,7 @@ const prependLinodeNS = compose<any, any, DomainRecord[]>(
       priority: 0,
       type: 'NS',
       name: '',
-      id: 9999,
+      id: -1,
       protocol: null,
       weight: 0,
       tag: null,
@@ -856,7 +854,7 @@ const prependLinodeNS = compose<any, any, DomainRecord[]>(
       priority: 0,
       type: 'NS',
       name: '',
-      id: 9999,
+      id: -1,
       protocol: null,
       weight: 0,
       tag: null,
@@ -869,7 +867,7 @@ const prependLinodeNS = compose<any, any, DomainRecord[]>(
       priority: 0,
       type: 'NS',
       name: '',
-      id: 9999,
+      id: -1,
       protocol: null,
       weight: 0,
       tag: null,
@@ -882,7 +880,7 @@ const prependLinodeNS = compose<any, any, DomainRecord[]>(
       priority: 0,
       type: 'NS',
       name: '',
-      id: 9999,
+      id: -1,
       protocol: null,
       weight: 0,
       tag: null,
@@ -895,7 +893,7 @@ const prependLinodeNS = compose<any, any, DomainRecord[]>(
       priority: 0,
       type: 'NS',
       name: '',
-      id: 9999,
+      id: -1,
       protocol: null,
       weight: 0,
       tag: null,

--- a/packages/manager/src/features/Domains/DomainRecords.tsx
+++ b/packages/manager/src/features/Domains/DomainRecords.tsx
@@ -130,6 +130,8 @@ const createLink = (title: string, handler: () => void) => (
   <AddNewLink onClick={handler} label={title} />
 );
 
+const nameServerRegex = /ns([1-5]).linode.com/;
+
 class DomainRecords extends React.Component<CombinedProps, State> {
   eventsSubscription$: Subscription;
 
@@ -344,7 +346,7 @@ class DomainRecords extends React.Component<CombinedProps, State> {
            * cannot make changes to Linode's nameservers.
            */
           render: ({ id, name, target, ttl_sec }: DomainRecord) =>
-            /ns([1-5]).linode.com/.test(target) ? null : (
+            nameServerRegex.test(target) ? null : (
               <ActionMenu
                 editPayload={{
                   id,

--- a/packages/manager/src/features/Domains/domainUtils.test.ts
+++ b/packages/manager/src/features/Domains/domainUtils.test.ts
@@ -31,10 +31,10 @@ describe('Domain-related utilities', () => {
   });
 
   describe('Ability to edit and delete records', () => {
-    it('should allow user to edit NS Records with Name Servers containing "linode.com" substring, except for ns1 through ns5, with no restrictions for records without "linode.com" substring', () => {
-      expect(isEditableNameServer('ns3.linode.com')).toBe(false);
-      expect(isEditableNameServer('ns9.linode.com')).toBe(true);
-      expect(isEditableNameServer('randomtesturl.com')).toBe(true);
+    it('should allow user to edit NS Records except the 5 we prepend', () => {
+      expect(isEditableNameServer(-1)).toBe(false);
+      expect(isEditableNameServer(10)).toBe(true);
+      expect(isEditableNameServer(9999)).toBe(true);
     });
   });
 });

--- a/packages/manager/src/features/Domains/domainUtils.test.ts
+++ b/packages/manager/src/features/Domains/domainUtils.test.ts
@@ -1,5 +1,9 @@
 import { domainRecords as records } from 'src/__data__/domains';
-import { isValidCNAME, isValidDomainRecord } from './domainUtils';
+import {
+  isEditableNameServer,
+  isValidCNAME,
+  isValidDomainRecord
+} from './domainUtils';
 
 describe('Domain-related utilities', () => {
   describe('Validating CNAME records', () => {
@@ -23,6 +27,14 @@ describe('Domain-related utilities', () => {
 
     it('should allow valid records', () => {
       expect(isValidDomainRecord('api', records)).toBe(true);
+    });
+  });
+
+  describe('Ability to edit and delete records', () => {
+    it('should allow user to edit NS Records with Name Servers containing "linode.com" substring, except for ns1 through ns5, with no restrictions for records without "linode.com" substring', () => {
+      expect(isEditableNameServer('ns3.linode.com')).toBe(false);
+      expect(isEditableNameServer('ns9.linode.com')).toBe(true);
+      expect(isEditableNameServer('randomtesturl.com')).toBe(true);
     });
   });
 });

--- a/packages/manager/src/features/Domains/domainUtils.ts
+++ b/packages/manager/src/features/Domains/domainUtils.ts
@@ -30,3 +30,9 @@ export const getInitialIPs = (ipsFromProps?: string[]): string[] => {
   const ips = ipsFromProps ?? [''];
   return ips.length > 0 ? ips : [''];
 };
+
+export const isEditableNameServer = (nameServer: string) => {
+  const nameServerRegex = /ns([1-5]).linode.com/;
+
+  return nameServerRegex.test(nameServer) ? false : true;
+};

--- a/packages/manager/src/features/Domains/domainUtils.ts
+++ b/packages/manager/src/features/Domains/domainUtils.ts
@@ -31,8 +31,8 @@ export const getInitialIPs = (ipsFromProps?: string[]): string[] => {
   return ips.length > 0 ? ips : [''];
 };
 
-export const isEditableNameServer = (nameServer: string) => {
-  const nameServerRegex = /ns([1-5]).linode.com/;
+export const isEditableNameServer = (nameServerId: number) => {
+  const nameServerDummyId = -1;
 
-  return nameServerRegex.test(nameServer) ? false : true;
+  return nameServerDummyId !== nameServerId ? true : false;
 };


### PR DESCRIPTION
## Description
A follow-up to #6224. This PR stores the regex pattern in a const and adds unit testing.

## Type of Change
- Non breaking change ('update', 'change')

## Tests
`yarn test domainUtils.test.ts`

## Note to Reviewers
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
