### PR TITLE
M3-4077 TDT: Update Linode shape in Redux

### DIFF
--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -304,7 +304,7 @@ interface StateProps {
 const mapStateToProps: MapState<StateProps, Props> = state => ({
   /** Profile */
   profileError: path(['read'], state.__resources.profile.error),
-  linodes: state.__resources.linodes.entities,
+  linodes: Object.values(state.__resources.linodes.itemsById),
   linodesError: path(['read'], state.__resources.linodes.error),
   domainsError: state.__resources.domains.error.read,
   imagesError: path(['read'], state.__resources.images.error),

--- a/packages/manager/src/components/LinodeMultiSelect/LinodeMultiSelect.test.tsx
+++ b/packages/manager/src/components/LinodeMultiSelect/LinodeMultiSelect.test.tsx
@@ -21,7 +21,7 @@ const props: CombinedProps = {
   handleChange: jest.fn(),
   linodesLoading: false,
   linodesData: linodes,
-  linodesResults: linodes.map(i => i.id),
+  linodesResults: linodes.length,
   linodesLastUpdated: 1000,
   showAllOption: true,
   getLinodes: jest.fn()

--- a/packages/manager/src/containers/withBackupCTA.container.ts
+++ b/packages/manager/src/containers/withBackupCTA.container.ts
@@ -7,6 +7,7 @@ export interface BackupCTAProps {
 
 export default connect((state: ApplicationState, ownProps) => ({
   backupsCTA:
-    state.__resources.linodes.entities.filter(l => !l.backups.enabled).length >
-      0 && !(state?.__resources?.accountSettings?.data?.managed ?? false)
+    Object.values(state.__resources.linodes.itemsById).some(
+      l => !l.backups.enabled
+    ) && !(state?.__resources?.accountSettings?.data?.managed ?? false)
 }));

--- a/packages/manager/src/containers/withLinodes.container.ts
+++ b/packages/manager/src/containers/withLinodes.container.ts
@@ -4,8 +4,8 @@ import { path } from 'ramda';
 import { connect, InferableComponentEnhancerWithProps } from 'react-redux';
 import { ApplicationState } from 'src/store';
 import { requestLinodes } from 'src/store/linodes/linode.requests';
-import { LinodeWithMaintenance as L } from 'src/store/linodes/linodes.helpers';
 import { State } from 'src/store/linodes/linodes.reducer';
+import { LinodeWithMaintenanceAndDisplayStatus } from 'src/store/linodes/types';
 import { ThunkDispatch } from 'src/store/types';
 import { GetAllData } from 'src/utilities/getAll';
 
@@ -13,13 +13,11 @@ export interface DispatchProps {
   getLinodes: (params?: any, filters?: any) => Promise<GetAllData<Linode>>;
 }
 
-export type LinodeWithMaintenance = L;
-
 /* tslint:disable-next-line */
 export interface StateProps {
   linodesError?: APIError[];
   linodesLoading: State['loading'];
-  linodesData: State['entities'];
+  linodesData: LinodeWithMaintenanceAndDisplayStatus[];
   linodesLastUpdated: State['lastUpdated'];
   linodesResults: State['results'];
 }
@@ -59,14 +57,15 @@ const connected: Connected = <ReduxState extends {}, OwnProps extends {}>(
       const {
         loading,
         error,
-        entities,
+        itemsById,
         lastUpdated,
         results
       } = state.__resources.linodes;
+      const linodes = Object.values(itemsById);
       if (mapStateToProps) {
         return mapStateToProps(
           ownProps,
-          entities,
+          linodes,
           loading,
           path(['read'], error)
         );
@@ -75,7 +74,7 @@ const connected: Connected = <ReduxState extends {}, OwnProps extends {}>(
       return {
         linodesError: path(['read'], error),
         linodesLoading: loading,
-        linodesData: entities,
+        linodesData: linodes,
         linodesResults: results,
         linodesLastUpdated: lastUpdated
       };

--- a/packages/manager/src/features/Account/GlobalSettings.tsx
+++ b/packages/manager/src/features/Account/GlobalSettings.tsx
@@ -22,6 +22,7 @@ import { handleOpen } from 'src/store/backupDrawer';
 import getEntitiesWithGroupsToImport, {
   GroupedEntitiesForImport
 } from 'src/store/selectors/getEntitiesWithGroupsToImport';
+import { getLinodesWithoutBackups } from 'src/store/selectors/getLinodesWithBackups';
 import { openDrawer as openGroupDrawer } from 'src/store/tagImportDrawer';
 import { MapState } from 'src/store/types';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
@@ -170,9 +171,7 @@ const mapStateToProps: MapState<StateProps, {}> = state => ({
     ['__resources', 'accountSettings', 'error', 'update'],
     state
   ),
-  linodesWithoutBackups: state.__resources.linodes.entities.filter(
-    l => !l.backups.enabled
-  ),
+  linodesWithoutBackups: getLinodesWithoutBackups(state.__resources),
   networkHelperEnabled: pathOr(
     false,
     ['__resources', 'accountSettings', 'data', 'network_helper'],

--- a/packages/manager/src/features/Backups/BackupDrawer.test.tsx
+++ b/packages/manager/src/features/Backups/BackupDrawer.test.tsx
@@ -12,9 +12,9 @@ import {
   addTypeInfo,
   BackupDrawer,
   enhanceLinodes,
-  ExtendedLinode,
   getTotalPrice
 } from './BackupDrawer';
+import { ExtendedLinode } from './types';
 
 const linodes = [linode1, linode3];
 

--- a/packages/manager/src/features/Backups/BackupDrawer.tsx
+++ b/packages/manager/src/features/Backups/BackupDrawer.tsx
@@ -21,18 +21,12 @@ import {
   handleResetError,
   handleResetSuccess
 } from 'src/store/backupDrawer';
+import { getLinodesWithoutBackups } from 'src/store/selectors/getLinodesWithBackups';
 import { ThunkDispatch } from 'src/store/types';
 import { getTypeInfo } from 'src/utilities/typesHelpers';
 import AutoEnroll from './AutoEnroll';
 import BackupsTable from './BackupsTable';
-
-export interface ExtendedLinode extends LinodeWithTypeInfo {
-  linodeError?: BackupError;
-}
-
-export interface LinodeWithTypeInfo extends Linode {
-  typeInfo?: LinodeType;
-}
+import { ExtendedLinode, LinodeWithTypeInfo } from './types';
 
 interface DispatchProps {
   actions: {
@@ -262,9 +256,7 @@ const mapStateToProps: MapStateToProps<
   ApplicationState
 > = (state: ApplicationState, ownProps: CombinedProps) => {
   const enableErrors = pathOr([], ['backups', 'enableErrors'], state);
-  const linodes = state.__resources.linodes.entities.filter(
-    l => !l.backups.enabled
-  );
+  const linodes = getLinodesWithoutBackups(state.__resources);
   return {
     accountBackups: pathOr(
       false,
@@ -290,10 +282,7 @@ const mapStateToProps: MapStateToProps<
   };
 };
 
-const connected = connect(
-  mapStateToProps,
-  mapDispatchToProps
-);
+const connected = connect(mapStateToProps, mapDispatchToProps);
 
 interface WithTypesProps {
   typesData: LinodeType[];
@@ -303,10 +292,6 @@ const withTypes = connect((state: ApplicationState, ownProps) => ({
   typesData: state.__resources.types.entities
 }));
 
-const enhanced = compose<CombinedProps, {}>(
-  withTypes,
-  connected,
-  withSnackbar
-);
+const enhanced = compose<CombinedProps, {}>(withTypes, connected, withSnackbar);
 
 export default enhanced(BackupDrawer);

--- a/packages/manager/src/features/Backups/BackupLinodes.test.tsx
+++ b/packages/manager/src/features/Backups/BackupLinodes.test.tsx
@@ -5,7 +5,7 @@ import * as linodes from 'src/__data__/linodes';
 import * as types from 'src/__data__/types';
 import { displayPrice as _display } from 'src/components/DisplayPrice';
 
-import { ExtendedLinode } from './BackupDrawer';
+import { ExtendedLinode } from './types';
 
 const type = types.types[0];
 

--- a/packages/manager/src/features/Backups/BackupLinodes.tsx
+++ b/packages/manager/src/features/Backups/BackupLinodes.tsx
@@ -11,7 +11,7 @@ import Typography from 'src/components/core/Typography';
 import { displayPrice as _displayPrice } from 'src/components/DisplayPrice/DisplayPrice';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
-import { ExtendedLinode } from './BackupDrawer';
+import { ExtendedLinode } from './types';
 
 type ClassNames = 'root' | 'error';
 

--- a/packages/manager/src/features/Backups/BackupsCTA.tsx
+++ b/packages/manager/src/features/Backups/BackupsCTA.tsx
@@ -15,6 +15,7 @@ import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 import { isRestrictedUser } from 'src/features/Profile/permissionsHelpers';
 import { handleOpen } from 'src/store/backupDrawer';
+import { getLinodesWithoutBackups } from 'src/store/selectors/getLinodesWithBackups';
 import { MapState } from 'src/store/types';
 
 type ClassNames = 'root' | 'container' | 'buttonsContainer' | 'dismiss';
@@ -129,9 +130,7 @@ interface DispatchProps {
 }
 
 const mapStateToProps: MapState<StateProps, {}> = (state, ownProps) => ({
-  linodesWithoutBackups: state.__resources.linodes.entities.filter(
-    l => !l.backups.enabled
-  ),
+  linodesWithoutBackups: getLinodesWithoutBackups(state.__resources),
   managed: state?.__resources?.accountSettings?.data?.managed ?? false
 });
 

--- a/packages/manager/src/features/Backups/BackupsTable.test.tsx
+++ b/packages/manager/src/features/Backups/BackupsTable.test.tsx
@@ -5,8 +5,8 @@ import * as linodes from 'src/__data__/linodes';
 import * as types from 'src/__data__/types';
 import TableRowLoading from 'src/components/TableRowLoading';
 
-import { ExtendedLinode } from './BackupDrawer';
 import { BackupsTable } from './BackupsTable';
+import { ExtendedLinode } from './types';
 
 const type = types.types[0];
 

--- a/packages/manager/src/features/Backups/BackupsTable.tsx
+++ b/packages/manager/src/features/Backups/BackupsTable.tsx
@@ -12,8 +12,8 @@ import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import TableRowLoading from 'src/components/TableRowLoading';
-import { ExtendedLinode } from './BackupDrawer';
 import BackupLinodes from './BackupLinodes';
+import { ExtendedLinode } from './types';
 
 type ClassNames = 'root' | 'container';
 

--- a/packages/manager/src/features/Backups/types.ts
+++ b/packages/manager/src/features/Backups/types.ts
@@ -1,0 +1,10 @@
+import { Linode, LinodeType } from 'linode-js-sdk/lib/linodes';
+import { BackupError } from 'src/store/backupDrawer';
+
+export interface ExtendedLinode extends LinodeWithTypeInfo {
+  linodeError?: BackupError;
+}
+
+export interface LinodeWithTypeInfo extends Linode {
+  typeInfo?: LinodeType;
+}

--- a/packages/manager/src/features/Dashboard/Dashboard.tsx
+++ b/packages/manager/src/features/Dashboard/Dashboard.tsx
@@ -146,7 +146,7 @@ export const Dashboard: React.StatelessComponent<CombinedProps> = props => {
 };
 
 const mapStateToProps: MapState<StateProps, {}> = (state, ownProps) => {
-  const linodes = state.__resources.linodes.entities;
+  const linodes = Object.values(state.__resources.linodes.itemsById);
   const notifications = state.__resources.notifications.data || [];
 
   const linodesWithMaintenance = addNotificationsToLinodes(

--- a/packages/manager/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
@@ -216,7 +216,7 @@ interface WithUpdatingLinodesProps {
 }
 
 const withUpdatingLinodes = connect((state: ApplicationState, ownProps: {}) => {
-  const linodes = state.__resources.linodes.entities;
+  const linodes = Object.values(state.__resources.linodes.itemsById);
   const notifications = state.__resources.notifications.data || [];
 
   const linodesWithMaintenance = addNotificationsToLinodes(
@@ -230,7 +230,7 @@ const withUpdatingLinodes = connect((state: ApplicationState, ownProps: {}) => {
       take(5),
       sortBy(prop('label'))
     )(linodesWithMaintenance),
-    linodeCount: state.__resources.linodes.entities.length,
+    linodeCount: state.__resources.linodes.results,
     loading: state.__resources.linodes.loading,
     error: path(['read'], state.__resources.linodes.error)
   };

--- a/packages/manager/src/features/linodes/LinodesCreate/withLabelGenerator.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/withLabelGenerator.tsx
@@ -72,7 +72,9 @@ export const withLabelGenerator = (Component: React.ComponentType<any>) => {
 
 // Connect to Redux state, so that we have access to existing Linode Labels (we may need to dedupe).
 const connected = connect((state: ApplicationState) => ({
-  linodeLabels: state.__resources.linodes.entities.map(l => l.label)
+  linodeLabels: Object.values(state.__resources.linodes.itemsById).map(
+    l => l.label
+  )
 }));
 
 // Regex taken from API documentation.

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/RestoreToLinodeDrawer.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/RestoreToLinodeDrawer.test.tsx
@@ -14,7 +14,7 @@ describe('RestoreToLinodeDrawer', () => {
     linodesLastUpdated: 0,
     linodesLoading: false,
     getLinodes: jest.fn(),
-    linodesResults: []
+    linodesResults: 0
   };
 
   const wrapper = shallow<RestoreToLinodeDrawer>(

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeNetSummary.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeNetSummary.tsx
@@ -1,4 +1,4 @@
-import { getLinodeTransfer, Linode } from 'linode-js-sdk/lib/linodes';
+import { getLinodeTransfer } from 'linode-js-sdk/lib/linodes';
 import * as moment from 'moment';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -161,9 +161,7 @@ interface StoreProps {
 }
 
 const mapStateToProps: MapState<StoreProps, CombinedProps> = (state, props) => {
-  const linode = state.__resources.linodes.entities.find(
-    (l: Linode) => l.id === props.linodeId
-  );
+  const linode = state.__resources.linodes.itemsById[props.linodeId];
   return {
     total: linode ? linode.specs.transfer : 0,
     isTooEarlyForStats:

--- a/packages/manager/src/hooks/useEntities.ts
+++ b/packages/manager/src/hooks/useEntities.ts
@@ -46,7 +46,7 @@ export const useEntities = () => {
    * or Object.value(data.itemsById).
    */
 
-  const linodes = _linodes.entities ?? [];
+  const linodes = Object.values(_linodes.itemsById);
   const domains = _domains.data ?? [];
   const images = (Object.values(_images.data) ?? []).filter(
     thisImage => !thisImage.is_public

--- a/packages/manager/src/store/backupDrawer/index.ts
+++ b/packages/manager/src/store/backupDrawer/index.ts
@@ -5,6 +5,7 @@ import { isEmpty, pathOr } from 'ramda';
 import { Reducer } from 'redux';
 import { updateAccountSettings } from 'src/store/accountSettings/accountSettings.requests';
 import { updateMultipleLinodes } from 'src/store/linodes/linodes.actions';
+import { getLinodesWithoutBackups } from 'src/store/selectors/getLinodesWithBackups';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import { sendBackupsEnabledEvent } from 'src/utilities/ga';
 import { ThunkActionCreator } from '../types';
@@ -251,10 +252,8 @@ export const enableAllBackups: EnableAllBackupsThunk = () => (
   dispatch,
   getState
 ) => {
-  const { entities } = getState().__resources.linodes;
-
-  const linodesWithoutBackups = entities.filter(
-    linode => !linode.backups.enabled
+  const linodesWithoutBackups = getLinodesWithoutBackups(
+    getState().__resources
   );
 
   dispatch(handleEnable());

--- a/packages/manager/src/store/linodes/linode.requests.ts
+++ b/packages/manager/src/store/linodes/linode.requests.ts
@@ -60,7 +60,10 @@ export const requestLinodeForStore: RequestLinodeForStoreThunk = (
 ) => (dispatch, getState) => {
   const state = getState();
   /** Don't request a Linode if it's already been deleted. */
-  if (isCreatingOrUpdating || state.__resources.linodes.results.includes(id)) {
+  if (
+    isCreatingOrUpdating ||
+    Boolean(state.__resources.linodes.itemsById[id])
+  ) {
     return _getLinode(id)
       .then(response => response.data)
       .then(linode => {

--- a/packages/manager/src/store/linodes/linodes.events.ts
+++ b/packages/manager/src/store/linodes/linodes.events.ts
@@ -168,7 +168,7 @@ const handleLinodeDelete = (
   id: number,
   state: ApplicationState
 ) => {
-  const found = state.__resources.linodes.results.find(i => i === id);
+  const found = state.__resources.linodes.itemsById[id];
 
   if (!found) {
     return;

--- a/packages/manager/src/store/linodes/linodes.selector.ts
+++ b/packages/manager/src/store/linodes/linodes.selector.ts
@@ -1,4 +1,4 @@
 import { State } from './linodes.reducer';
 
 export const findLinodeById = (state: State, linodeId: number) =>
-  state.entities.find(({ id }) => linodeId === id);
+  state.itemsById[linodeId];

--- a/packages/manager/src/store/selectors/entitiesLoading.ts
+++ b/packages/manager/src/store/selectors/entitiesLoading.ts
@@ -5,7 +5,11 @@ import { APIError } from 'linode-js-sdk/lib/types';
 import { Volume } from 'linode-js-sdk/lib/volumes';
 import { createSelector } from 'reselect';
 import { ApplicationState } from 'src/store';
-import { EntityError, RequestableDataWithEntityError } from 'src/store/types';
+import {
+  EntityError,
+  MappedEntityState2 as MappedEntityState,
+  RequestableDataWithEntityError
+} from 'src/store/types';
 
 import { State as ImageState } from 'src/store/image/image.reducer';
 
@@ -39,7 +43,7 @@ const isInitialLoad = (
 
 export default createSelector<
   State,
-  Resource<Linode[], EntityError>,
+  MappedEntityState<Linode, EntityError>,
   Resource<Volume[]>,
   Resource<NodeBalancer[][]>,
   RequestableDataWithEntityError<Domain[]>,

--- a/packages/manager/src/store/selectors/getEntitiesWithGroupsToImport.test.tsx
+++ b/packages/manager/src/store/selectors/getEntitiesWithGroupsToImport.test.tsx
@@ -4,7 +4,9 @@ import { entitiesWithGroupsToImport } from './getEntitiesWithGroupsToImport';
 
 const state = {
   __resources: {
-    linodes: { entities: linodes },
+    linodes: {
+      itemsById: linodes.reduce((result, c) => ({ ...result, [c.id]: c }), {})
+    },
     domains: { data: domains }
   }
 };
@@ -73,7 +75,7 @@ describe('Entities that have groups to import', () => {
 
       const newState = {
         __resources: {
-          linodes: { entities: linodes },
+          linodes: { ...state.__resources.linodes },
           domains: { entities: [domain] }
         }
       };

--- a/packages/manager/src/store/selectors/getEntitiesWithGroupsToImport.tsx
+++ b/packages/manager/src/store/selectors/getEntitiesWithGroupsToImport.tsx
@@ -47,7 +47,7 @@ export const extractProps = (entity: GroupedEntity) => ({
 });
 
 const linodeSelector = (state: ApplicationState) =>
-  state.__resources.linodes.entities;
+  Object.values(state.__resources.linodes.itemsById);
 const domainSelector = (state: ApplicationState) =>
   state.__resources.domains.data || [];
 

--- a/packages/manager/src/store/selectors/getLinodesWithBackups.ts
+++ b/packages/manager/src/store/selectors/getLinodesWithBackups.ts
@@ -1,0 +1,16 @@
+import { ApplicationState } from 'src/store';
+import { LinodeWithMaintenanceAndDisplayStatus as Linode } from 'src/store/linodes/types';
+
+export const getLinodesWithBackups = (
+  state: ApplicationState['__resources']
+) => {
+  const linodes = Object.values(state.linodes.itemsById);
+  return linodes.filter((thisLinode: Linode) => thisLinode.backups.enabled);
+};
+
+export const getLinodesWithoutBackups = (
+  state: ApplicationState['__resources']
+) => {
+  const linodes = Object.values(state.linodes.itemsById);
+  return linodes.filter((thisLinode: Linode) => !thisLinode.backups.enabled);
+};

--- a/packages/manager/src/store/selectors/getSearchEntities.ts
+++ b/packages/manager/src/store/selectors/getSearchEntities.ts
@@ -120,7 +120,7 @@ const nodeBalToSearchableItem = (nodebal: NodeBalancer): SearchableItem => ({
   }
 });
 
-const linodeSelector = (state: State) => state.linodes.entities;
+const linodeSelector = (state: State) => Object.values(state.linodes.itemsById);
 const volumeSelector = ({ volumes }: State) => Object.values(volumes.itemsById);
 const nodebalSelector = ({ nodeBalancers }: State) =>
   Object.values(nodeBalancers.itemsById);

--- a/packages/manager/src/store/selectors/getSearchEntitites.test.ts
+++ b/packages/manager/src/store/selectors/getSearchEntitites.test.ts
@@ -38,13 +38,21 @@ describe('getSearchEntities selector', () => {
   });
   it('should recompute objects if the list of entities changes.', () => {
     getSearchEntities.resetRecomputations();
-    getSearchEntities({ ...mockState, linodes: { entities: [] } });
+    getSearchEntities({ ...mockState, linodes: { itemsById: {} } });
     expect(getSearchEntities.recomputations()).toEqual(1);
   });
   it('should recompute if an entry in entities is updated', () => {
     getSearchEntities.resetRecomputations();
     const updatedLinodes = assocPath([0, 'label'], 'newlabel', linodes);
-    getSearchEntities({ ...mockState, linodes: { entities: updatedLinodes } });
+    getSearchEntities({
+      ...mockState,
+      linodes: {
+        itemsById: updatedLinodes.reduce(
+          (result, c) => ({ ...result, [c.id]: c }),
+          {}
+        )
+      }
+    });
     expect(getSearchEntities.recomputations()).toEqual(1);
   });
 });

--- a/packages/manager/src/store/selectors/getSearchEntitites.test.ts
+++ b/packages/manager/src/store/selectors/getSearchEntitites.test.ts
@@ -11,7 +11,9 @@ import getSearchEntities from './getSearchEntities';
 
 describe('getSearchEntities selector', () => {
   const mockState: any = {
-    linodes: { entities: linodes },
+    linodes: {
+      itemsById: linodes.reduce((result, c) => ({ ...result, [c.id]: c }), {})
+    },
     domains: { entities: domains },
     images: { entities: images },
     types: { entities: types },

--- a/packages/manager/src/store/selectors/inProgressEventForLinode.ts
+++ b/packages/manager/src/store/selectors/inProgressEventForLinode.ts
@@ -20,7 +20,7 @@ const findInProgressEvent = (e: Event[]) => (id: number) => {
 };
 
 export default createSelector<ApplicationState, Linode[], Event[], Linode[]>(
-  state => state.__resources.linodes.entities,
+  state => Object.values(state.__resources.linodes.itemsById),
   inProgressEvents('linode'),
   (linodes, events) => {
     const eventFor = findInProgressEvent(events);

--- a/packages/manager/src/utilities/getEntityByIDFromStore.test.ts
+++ b/packages/manager/src/utilities/getEntityByIDFromStore.test.ts
@@ -6,8 +6,8 @@ const volume = mockVolumes[0];
 const mockState = {
   __resources: {
     linodes: {
-      results: [mockLinode.id],
-      entities: [mockLinode]
+      results: 1,
+      itemsById: { [mockLinode.id]: mockLinode }
     },
     volumes: {
       items: [volume.id],

--- a/packages/manager/src/utilities/getEntityByIDFromStore.ts
+++ b/packages/manager/src/utilities/getEntityByIDFromStore.ts
@@ -44,7 +44,7 @@ const _getEntityByIDFromStore = (
   } = _store.__resources;
   switch (entityType) {
     case 'linode':
-      return linodes.entities.find(linode => entityID === linode.id);
+      return linodes.itemsById[entityID];
     case 'image':
       return (images.data || {})[entityID];
     case 'nodebalancer':


### PR DESCRIPTION
## Description

Use the updated Redux state data model for Linodes. Any changes outside of /src/store are updating accessors to use the new shape.

## Note to reviewers

Make sure everything related to Linodes--CRUD, migration, events, etc.--works as before.