### PR TITLE
Fix bug in image select

### DIFF
--- a/packages/manager/src/components/ImageSelect/ImageSelect.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.tsx
@@ -161,7 +161,6 @@ export const ImageSelect: React.FC<Props> = props => {
                   placeholder="Choose an image"
                   options={options}
                   onChange={onChange}
-                  onFocus={onChange}
                   value={getSelectedOptionFromGroupedOptions(
                     selectedImageID || '',
                     options


### PR DESCRIPTION
We were using the onFocus handler in the ImageSelect component,
and passing it the same change handler as in the onChange prop.
Since onFocus is always called with undefined, clicking on the select
to view available options would clear the input. Removed the onFocus
handler to account for this.
