### PR TITLE
[LKE] Refactor Checkout bar

### DIFF
--- a/packages/manager/src/components/CheckoutBar/CheckoutBar.tsx
+++ b/packages/manager/src/components/CheckoutBar/CheckoutBar.tsx
@@ -12,11 +12,12 @@ interface Props {
   isMakingRequest?: boolean;
   priceHelperText?: string;
   submitText?: string;
+  children?: JSX.Element;
 }
 
 type CombinedProps = Props;
 
-const CheckoutBar: React.FC<CombinedProps> = props => {
+const CheckoutBar = React.forwardRef<any, CombinedProps>((props, ref) => {
   const classes = useStyles();
 
   const {
@@ -32,7 +33,7 @@ const CheckoutBar: React.FC<CombinedProps> = props => {
   const price = calculatedPrice ?? 0;
 
   return (
-    <div className={classes.root}>
+    <div className={classes.root} ref={ref}>
       <Typography
         variant="h2"
         className={classes.sidebarTitle}
@@ -67,6 +68,6 @@ const CheckoutBar: React.FC<CombinedProps> = props => {
       </div>
     </div>
   );
-};
+});
 
 export default CheckoutBar;

--- a/packages/manager/src/components/CheckoutBar/CheckoutBar.tsx
+++ b/packages/manager/src/components/CheckoutBar/CheckoutBar.tsx
@@ -1,76 +1,8 @@
-import * as classNames from 'classnames';
 import * as React from 'react';
 import Button from 'src/components/Button';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles
-} from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import DisplayPrice from 'src/components/DisplayPrice';
-
-type ClassNames =
-  | 'root'
-  | 'checkoutSection'
-  | 'noBorder'
-  | 'sidebarTitle'
-  | 'detail'
-  | 'createButton'
-  | 'price';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    '@keyframes fadeIn': {
-      from: {
-        opacity: 0
-      },
-      to: {
-        opacity: 1
-      }
-    },
-    root: {
-      minHeight: '24px',
-      minWidth: '24px',
-      [theme.breakpoints.down('sm')]: {
-        position: 'relative !important' as 'relative',
-        left: '0 !important' as '0',
-        bottom: '0 !important' as '0',
-        background: theme.color.white,
-        padding: theme.spacing(2)
-      }
-    },
-    checkoutSection: {
-      opacity: 0,
-      padding: `${theme.spacing(2)}px 0`,
-      borderTop: `1px solid ${theme.color.border2}`,
-      animation: '$fadeIn 225ms linear forwards'
-    },
-    noBorder: {
-      border: 0
-    },
-    sidebarTitle: {
-      fontSize: '1.5rem',
-      color: theme.color.green,
-      wordBreak: 'break-word'
-    },
-    detail: {
-      fontSize: '.8rem',
-      color: theme.color.headline,
-      lineHeight: '1.5em'
-    },
-    createButton: {
-      [theme.breakpoints.up('lg')]: {
-        width: '100%'
-      }
-    },
-    price: {
-      fontSize: '.8rem',
-      color: theme.color.headline,
-      lineHeight: '1.5em',
-      marginTop: theme.spacing(1)
-    }
-  });
+import useStyles from './styles';
 
 interface Props {
   onDeploy: () => void;
@@ -78,96 +10,63 @@ interface Props {
   calculatedPrice?: number;
   disabled?: boolean;
   isMakingRequest?: boolean;
-  displaySections?: { title: string; details?: string | number }[];
   priceHelperText?: string;
+  submitText?: string;
 }
 
-type CombinedProps = Props & WithStyles<ClassNames>;
+type CombinedProps = Props;
 
-class CheckoutBar extends React.Component<CombinedProps> {
-  static defaultProps: Partial<Props> = {
-    calculatedPrice: 0
-  };
+const CheckoutBar: React.FC<CombinedProps> = props => {
+  const classes = useStyles();
 
-  render() {
-    const {
-      classes,
-      onDeploy,
-      heading,
-      calculatedPrice,
-      disabled,
-      displaySections,
-      isMakingRequest,
-      priceHelperText
-    } = this.props;
+  const {
+    onDeploy,
+    heading,
+    calculatedPrice,
+    disabled,
+    isMakingRequest,
+    priceHelperText,
+    submitText
+  } = props;
 
-    const price = calculatedPrice ? calculatedPrice : 0;
+  const price = calculatedPrice ?? 0;
 
-    return (
-      <div className={classes.root}>
-        <Typography
-          variant="h2"
-          className={classes.sidebarTitle}
-          data-qa-order-summary
+  return (
+    <div className={classes.root}>
+      <Typography
+        variant="h2"
+        className={classes.sidebarTitle}
+        data-qa-order-summary
+      >
+        {heading}
+      </Typography>
+      {props.children}
+      {
+        <div
+          className={`${classes.checkoutSection} ${classes.noBorder}`}
+          data-qa-total-price
         >
-          {heading}
-        </Typography>
-        {displaySections &&
-          displaySections.map(({ title, details }, idx) => (
-            <div
-              key={idx}
-              className={classNames({
-                [classes.checkoutSection]: true,
-                [classes.noBorder]: idx === 0
-              })}
-            >
-              {title && (
-                <Typography variant="h3" data-qa-subheading={title}>
-                  {title}
-                </Typography>
-              )}
-              {details && (
-                <Typography
-                  component="span"
-                  data-qa-details={details}
-                  className={classes.detail}
-                >
-                  {details}
-                </Typography>
-              )}
-            </div>
-          ))}
-        {
-          <div
-            className={`${classes.checkoutSection} ${classes.noBorder}`}
-            data-qa-total-price
-          >
-            <DisplayPrice price={price} interval="mo" />
-            {priceHelperText && price > 0 && (
-              <Typography className={classes.price}>
-                {priceHelperText}
-              </Typography>
-            )}
-          </div>
-        }
-
-        <div className={`${classes.checkoutSection} ${classes.noBorder}`}>
-          <Button
-            buttonType="primary"
-            className={classes.createButton}
-            disabled={disabled}
-            onClick={onDeploy}
-            data-qa-deploy-linode
-            loading={isMakingRequest}
-          >
-            Create
-          </Button>
+          <DisplayPrice price={price} interval="mo" />
+          {priceHelperText && price > 0 && (
+            <Typography className={classes.price}>{priceHelperText}</Typography>
+          )}
         </div>
+      }
+
+      <div className={`${classes.checkoutSection} ${classes.noBorder}`}>
+        <Button
+          buttonType="primary"
+          className={classes.createButton}
+          disabled={disabled}
+          onClick={onDeploy}
+          data-qa-deploy-linode
+          loading={isMakingRequest}
+        >
+          {submitText ?? 'Create'}
+        </Button>
       </div>
-    );
-  }
-}
+    </div>
+  );
+};
 
-const styled = withStyles(styles);
-
-export default styled(CheckoutBar);
+export default CheckoutBar;

--- a/packages/manager/src/components/CheckoutBar/DisplaySection.tsx
+++ b/packages/manager/src/components/CheckoutBar/DisplaySection.tsx
@@ -1,0 +1,40 @@
+import * as classNames from 'classnames';
+import * as React from 'react';
+import Typography from 'src/components/core/Typography';
+import useStyles from './styles';
+
+export interface Props {
+  title: string;
+  details?: string | number;
+  hideBorder?: boolean;
+}
+
+export const DisplaySection: React.FC<Props> = props => {
+  const { title, details, hideBorder } = props;
+  const classes = useStyles();
+  return (
+    <div
+      className={classNames({
+        [classes.checkoutSection]: true,
+        [classes.noBorder]: hideBorder
+      })}
+    >
+      {title && (
+        <Typography variant="h3" data-qa-subheading={title}>
+          {title}
+        </Typography>
+      )}
+      {details && (
+        <Typography
+          component="span"
+          data-qa-details={details}
+          className={classes.detail}
+        >
+          {details}
+        </Typography>
+      )}
+    </div>
+  );
+};
+
+export default DisplaySection;

--- a/packages/manager/src/components/CheckoutBar/DisplaySection.tsx
+++ b/packages/manager/src/components/CheckoutBar/DisplaySection.tsx
@@ -37,4 +37,4 @@ export const DisplaySection: React.FC<Props> = props => {
   );
 };
 
-export default DisplaySection;
+export default React.memo(DisplaySection);

--- a/packages/manager/src/components/CheckoutBar/DisplaySectionList.tsx
+++ b/packages/manager/src/components/CheckoutBar/DisplaySectionList.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import DisplaySection from './DisplaySection';
+
+interface Props {
+  displaySections?: { title: string; details?: string | number }[];
+}
+
+export const DisplaySectionList: React.FC<Props> = ({ displaySections }) => {
+  if (!displaySections) {
+    return null;
+  }
+  return (
+    <>
+      {displaySections.map(({ title, details }, idx) => (
+        <DisplaySection
+          key={`${title}-${idx}`}
+          title={title}
+          details={details}
+          hideBorder={idx === 0}
+        />
+      ))}
+    </>
+  );
+};
+
+export default DisplaySectionList;

--- a/packages/manager/src/components/CheckoutBar/index.ts
+++ b/packages/manager/src/components/CheckoutBar/index.ts
@@ -1,2 +1,4 @@
 import CheckoutBar from './CheckoutBar';
+export { default as DisplaySection } from './DisplaySection';
+export { default as DisplaySectionList } from './DisplaySectionList';
 export default CheckoutBar;

--- a/packages/manager/src/components/CheckoutBar/styles.ts
+++ b/packages/manager/src/components/CheckoutBar/styles.ts
@@ -1,0 +1,55 @@
+import { makeStyles, Theme } from 'src/components/core/styles';
+
+export const useStyles = makeStyles((theme: Theme) => ({
+  '@keyframes fadeIn': {
+    from: {
+      opacity: 0
+    },
+    to: {
+      opacity: 1
+    }
+  },
+  root: {
+    minHeight: '24px',
+    minWidth: '24px',
+    [theme.breakpoints.down('sm')]: {
+      position: 'relative !important' as 'relative',
+      left: '0 !important' as '0',
+      bottom: '0 !important' as '0',
+      background: theme.color.white,
+      padding: theme.spacing(2)
+    }
+  },
+  checkoutSection: {
+    opacity: 0,
+    padding: `${theme.spacing(2)}px 0`,
+    borderTop: `1px solid ${theme.color.border2}`,
+    animation: '$fadeIn 225ms linear forwards'
+  },
+  noBorder: {
+    border: 0
+  },
+  sidebarTitle: {
+    fontSize: '1.5rem',
+    color: theme.color.green,
+    wordBreak: 'break-word'
+  },
+  detail: {
+    fontSize: '.8rem',
+    color: theme.color.headline,
+    lineHeight: '1.5em'
+  },
+  createButton: {
+    [theme.breakpoints.up('lg')]: {
+      width: '100%'
+    }
+  },
+  price: {
+    fontSize: '.8rem',
+    color: theme.color.headline,
+    lineHeight: '1.5em',
+    marginTop: theme.spacing(1)
+  }
+}));
+
+export default useStyles;

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Sticky, StickyProps } from 'react-sticky';
 
-import CheckoutBar from 'src/components/CheckoutBar';
+import CheckoutBar, { DisplaySectionList } from 'src/components/CheckoutBar';
 import renderGuard from 'src/components/RenderGuard';
 import { ExtendedType } from 'src/features/linodes/LinodesCreate/SelectPlanPanel';
 import { getTotalClusterMemoryAndCPU, getTotalClusterPrice } from './kubeUtils';
@@ -40,9 +40,11 @@ export const KubeCheckoutBar: React.FunctionComponent<Props> = props => {
               isMakingRequest={submitting}
               disabled={false}
               onDeploy={createCluster}
-              displaySections={displaySections}
               priceHelperText={priceHelperText}
-            />
+              submitText={'Create Cluster'}
+            >
+              <DisplaySectionList displaySections={displaySections} />
+            </CheckoutBar>
             {/* {this.props.documentation.length > 0 && (
               <DocsSidebar docs={this.props.documentation} />
             )} */}

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -19,7 +19,7 @@ import { compose as recompose } from 'recompose';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Breadcrumb from 'src/components/Breadcrumb';
 import Button from 'src/components/Button';
-import CheckoutBar from 'src/components/CheckoutBar';
+import CheckoutBar, { DisplaySectionList } from 'src/components/CheckoutBar';
 import CircleProgress from 'src/components/CircleProgress';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
 import Paper from 'src/components/core/Paper';
@@ -189,10 +189,7 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
 
   afterProtocolUpdate = (L: { [key: string]: Lens }) => () => {
     this.setState(
-      compose(
-        set(L.sslCertificateLens, ''),
-        set(L.privateKeyLens, '')
-      )
+      compose(set(L.sslCertificateLens, ''), set(L.privateKeyLens, ''))
     );
   };
 
@@ -394,7 +391,10 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
 
   tagsChange = (tags: Tag[]) => {
     this.setState(
-      set(lensPath(['nodeBalancerFields', 'tags']), tags.map(tag => tag.value))
+      set(
+        lensPath(['nodeBalancerFields', 'tags']),
+        tags.map(tag => tag.value)
+      )
     );
   };
 
@@ -658,12 +658,14 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
                     r => r.id === region
                   );
                   if (foundRegion) {
-                    displaySections = {
-                      title: dcDisplayCountry[foundRegion.id],
-                      details: foundRegion.display
-                    };
+                    displaySections = [
+                      {
+                        title: dcDisplayCountry[foundRegion.id],
+                        details: foundRegion.display
+                      }
+                    ];
                   } else {
-                    displaySections = { title: 'Unknown Region' };
+                    displaySections = [{ title: 'Unknown Region' }];
                   }
                 }
                 return (
@@ -672,10 +674,11 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
                       'NodeBalancer'} Summary`}
                     onDeploy={this.createNodeBalancer}
                     calculatedPrice={10}
-                    displaySections={displaySections && [displaySections]}
                     disabled={this.state.submitting || disabled}
                     {...props}
-                  />
+                  >
+                    <DisplaySectionList displaySections={displaySections} />
+                  </CheckoutBar>
                 );
               }}
             </Sticky>

--- a/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
-import CheckoutBar from 'src/components/CheckoutBar';
+import CheckoutBar, { DisplaySectionList } from 'src/components/CheckoutBar';
 import FormHelperText from 'src/components/core/FormHelperText';
 import Paper from 'src/components/core/Paper';
 import {
@@ -324,8 +324,9 @@ const CreateVolumeForm: React.FC<CombinedProps> = props => {
                   calculatedPrice={values.size / 10}
                   disabled={values.configId === -9999 || disabled}
                   isMakingRequest={isSubmitting}
-                  displaySections={displaySections && displaySections}
-                />
+                >
+                  <DisplaySectionList displaySections={displaySections} />
+                </CheckoutBar>
               </Grid>
             </Grid>
           </Form>

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -6,7 +6,7 @@ import { connect, MapStateToProps } from 'react-redux';
 import { Sticky, StickyProps } from 'react-sticky';
 import { compose } from 'recompose';
 import AccessPanel from 'src/components/AccessPanel';
-import CheckoutBar from 'src/components/CheckoutBar';
+import CheckoutBar, { DisplaySectionList } from 'src/components/CheckoutBar';
 import Paper from 'src/components/core/Paper';
 import {
   createStyles,
@@ -424,8 +424,9 @@ class FromAppsContent extends React.PureComponent<CombinedProps, State> {
                     isMakingRequest={formIsSubmitting}
                     disabled={formIsSubmitting || userCannotCreateLinode}
                     onDeploy={this.handleCreateLinode}
-                    displaySections={displaySections}
-                  />
+                  >
+                    <DisplaySectionList displaySections={displaySections} />
+                  </CheckoutBar>
                   {this.props.documentation.length > 0 && (
                     <DocsSidebar docs={this.props.documentation} />
                   )}

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
@@ -7,7 +7,7 @@ import { compose as ramdaCompose, pathOr } from 'ramda';
 import * as React from 'react';
 import { Sticky, StickyProps } from 'react-sticky';
 import VolumeIcon from 'src/assets/addnewmenu/volume.svg';
-import CheckoutBar from 'src/components/CheckoutBar';
+import CheckoutBar, { DisplaySectionList } from 'src/components/CheckoutBar';
 import Paper from 'src/components/core/Paper';
 import {
   createStyles,
@@ -378,9 +378,10 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
                     isMakingRequest={this.props.formIsSubmitting}
                     disabled={this.props.formIsSubmitting || disabled}
                     onDeploy={this.createLinode}
-                    displaySections={displaySections}
                     {...props}
-                  />
+                  >
+                    <DisplaySectionList displaySections={displaySections} />
+                  </CheckoutBar>
                 );
               }}
             </Sticky>

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { Sticky, StickyProps } from 'react-sticky';
 import AccessPanel from 'src/components/AccessPanel';
-import CheckoutBar from 'src/components/CheckoutBar';
+import CheckoutBar, { DisplaySectionList } from 'src/components/CheckoutBar';
 import Paper from 'src/components/core/Paper';
 import {
   createStyles,
@@ -322,9 +322,10 @@ export class FromImageContent extends React.PureComponent<CombinedProps> {
                     this.props.formIsSubmitting || userCannotCreateLinode
                   }
                   onDeploy={this.createLinode}
-                  displaySections={displaySections}
                   {...props}
-                />
+                >
+                  <DisplaySectionList displaySections={displaySections} />
+                </CheckoutBar>
               );
             }}
           </Sticky>

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
@@ -2,7 +2,7 @@ import { pathOr } from 'ramda';
 import * as React from 'react';
 import { Sticky, StickyProps } from 'react-sticky';
 import VolumeIcon from 'src/assets/addnewmenu/volume.svg';
-import CheckoutBar from 'src/components/CheckoutBar';
+import CheckoutBar, { DisplaySectionList } from 'src/components/CheckoutBar';
 import Paper from 'src/components/core/Paper';
 import {
   createStyles,
@@ -236,9 +236,10 @@ export class FromLinodeContent extends React.PureComponent<CombinedProps> {
                         this.props.formIsSubmitting || userCannotCreateLinode
                       }
                       onDeploy={this.cloneLinode}
-                      displaySections={displaySections}
                       {...props}
-                    />
+                    >
+                      <DisplaySectionList displaySections={displaySections} />
+                    </CheckoutBar>
                   );
                 }}
               </Sticky>

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -6,7 +6,7 @@ import { assocPath, pathOr } from 'ramda';
 import * as React from 'react';
 import { Sticky, StickyProps } from 'react-sticky';
 import AccessPanel from 'src/components/AccessPanel';
-import CheckoutBar from 'src/components/CheckoutBar';
+import CheckoutBar, { DisplaySectionList } from 'src/components/CheckoutBar';
 import Paper from 'src/components/core/Paper';
 import {
   createStyles,
@@ -416,9 +416,10 @@ export class FromStackScriptContent extends React.PureComponent<CombinedProps> {
                   isMakingRequest={this.props.formIsSubmitting}
                   disabled={this.props.formIsSubmitting || disabled}
                   onDeploy={this.handleCreateLinode}
-                  displaySections={displaySections}
                   {...props}
-                />
+                >
+                  <DisplaySectionList displaySections={displaySections} />
+                </CheckoutBar>
               );
             }}
           </Sticky>


### PR DESCRIPTION
## Description

The designs for updated LKE call for a more flexible checkout bar than we've used in the past, but since this is used elsewhere it's important to maintain consistency, styling, etc. I refactored the existing CheckoutBar component to render props.children instead of a list of display sections. I provided an additional DisplaySectionList component to make the original use case easier, since that's what everything has used up to this point.

Nothing LKE-specific has been changed; this PR just re-creates the existing functionality using a slightly different pattern. Checkout bars are found wherever users create something that will cost $; please check that Linode, NodeBalancer, K8s cluster, and Volume creation are unchanged.
