### PR TITLE
M3-4089: Allow custom empty messaging on EventsLanding

### DIFF
--- a/packages/manager/src/features/Events/EventsLanding.tsx
+++ b/packages/manager/src/features/Events/EventsLanding.tsx
@@ -59,6 +59,7 @@ interface Props {
   // isEventsLandingForEntity?: boolean;
   entityId?: number;
   errorMessage?: string; // Custom error message (for an entity's Activity page, for example)
+  emptyMessage?: string; // Custom message for the empty state (i.e. no events).
 }
 
 type CombinedProps = Props &
@@ -265,7 +266,13 @@ export const EventsLanding: React.StatelessComponent<CombinedProps> = props => {
     });
   }, [props.eventsFromRedux, props.inProgressEvents]);
 
-  const { classes, entitiesLoading, errorMessage, entityId } = props;
+  const {
+    classes,
+    entitiesLoading,
+    errorMessage,
+    entityId,
+    emptyMessage
+  } = props;
   const isLoading = loading || entitiesLoading;
 
   return (
@@ -305,7 +312,8 @@ export const EventsLanding: React.StatelessComponent<CombinedProps> = props => {
               errorMessage,
               entityId,
               error,
-              events.reactStateEvents
+              events.reactStateEvents,
+              emptyMessage
             )}
           </TableBody>
         </Table>
@@ -316,7 +324,8 @@ export const EventsLanding: React.StatelessComponent<CombinedProps> = props => {
         </Waypoint>
       ) : (
         !isLoading &&
-        !error && (
+        !error &&
+        events.reactStateEvents.length > 0 && (
           <Typography className={classes.noMoreEvents}>
             No more events to show
           </Typography>
@@ -332,7 +341,8 @@ export const renderTableBody = (
   errorMessage = 'There was an error retrieving the events on your account.',
   entityId?: number,
   error?: string,
-  events?: Event[]
+  events?: Event[],
+  emptyMessage = "You don't have any events on your account."
 ) => {
   const filteredEvents = removeBlacklistedEvents(events, ['profile_update']);
 
@@ -359,7 +369,7 @@ export const renderTableBody = (
     return (
       <TableRowEmptyState
         colSpan={12}
-        message={"You don't have any events on your account."}
+        message={emptyMessage}
         data-qa-events-table-empty
       />
     );

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeActivity/LinodeActivity.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeActivity/LinodeActivity.tsx
@@ -23,9 +23,7 @@ const styles = (theme: Theme) =>
 
 type CombinedProps = WithStyles<ClassNames> & StateProps;
 
-export const LinodeActivity: React.StatelessComponent<
-  CombinedProps
-> = props => {
+export const LinodeActivity: React.StatelessComponent<CombinedProps> = props => {
   const { classes, linodeID } = props;
 
   return (
@@ -43,6 +41,7 @@ export const LinodeActivity: React.StatelessComponent<
           getEventsForEntity(params, 'linode', props.linodeID)
         }
         errorMessage="There was an error retrieving activity for this Linode."
+        emptyMessage="No recent activity for this Linode."
         data-qa-events-landing-for-linode
       />
     </div>
@@ -58,9 +57,6 @@ const linodeContext = withLinodeDetailContext(({ linode }) => ({
 
 const styled = withStyles(styles);
 
-const enhanced = compose<CombinedProps, {}>(
-  linodeContext,
-  styled
-);
+const enhanced = compose<CombinedProps, {}>(linodeContext, styled);
 
 export default enhanced(LinodeActivity);

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeActivity/LinodeActivity.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeActivity/LinodeActivity.tsx
@@ -23,7 +23,7 @@ const styles = (theme: Theme) =>
 
 type CombinedProps = WithStyles<ClassNames> & StateProps;
 
-export const LinodeActivity: React.StatelessComponent<CombinedProps> = props => {
+export const LinodeActivity: React.FC<CombinedProps> = props => {
   const { classes, linodeID } = props;
 
   return (


### PR DESCRIPTION
## Description

This PR allows the consumer of `<EventsLanding />` to specify a message to display in the empty state. This means the Activity tab of Linode Details can say "No recent activity for this Linode." instead of "No events on your account".

Also, `<EventsLanding />` now takes into account the number of events when determining whether to display "No more events to show." 

### Before:
![Screen Shot 2020-03-25 at 11 38 57 AM](https://user-images.githubusercontent.com/16911484/77555199-5c86be80-6e8d-11ea-91cf-b5aa62d4e593.png)

## After:
![Screen Shot 2020-03-25 at 11 38 24 AM](https://user-images.githubusercontent.com/16911484/77555158-542e8380-6e8d-11ea-9ddd-750e7738bbe3.png)

## Note to Reviewers

DM for an example of a Linode with no recent events. Additionally, please check the Events Landing page (http://localhost:3000/events) in different states.
