### PR TITLE
M3-4088: Fix skeleton loader on EventsLanding

### DIFF
--- a/packages/manager/src/components/TableRowLoading/TableRowLoading.tsx
+++ b/packages/manager/src/components/TableRowLoading/TableRowLoading.tsx
@@ -25,9 +25,12 @@ const styles = (theme: Theme) =>
     }
   });
 
+type Columns = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+
 export interface Props {
-  colSpan: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+  colSpan: Columns;
   numberOfRows?: number;
+  numberOfColumns?: Columns;
   firstColWidth?: number;
   transparent?: any;
   oneLine?: boolean;
@@ -46,8 +49,22 @@ const tableRowLoading: React.FC<CombinedProps> = props => {
     oneLine,
     numberOfRows,
     hasEntityIcon,
-    compact
+    compact,
+    numberOfColumns
   } = props;
+
+  // Default number of columns for the <Skeleton />.
+  let numColumns: Columns = 8;
+
+  // If the consumer has explicitly specified the number of columns to use, go with that.
+  // This may be different than colSpan... for example, if one column contains an Icon,
+  // we'd like colSpan to be numberOfColumns + 1.
+  if (numberOfColumns) {
+    numColumns = numberOfColumns;
+    // Otherwise if they've specified a colSpan, use that, since it's a pretty good guess.
+  } else if (colSpan) {
+    numColumns = colSpan;
+  }
 
   const ifRows = numberOfRows ?? 1;
   const rowBuilder = () => {
@@ -72,7 +89,7 @@ const tableRowLoading: React.FC<CombinedProps> = props => {
           >
             <Skeleton
               table
-              numColumns={colSpan ? colSpan : 8}
+              numColumns={numColumns}
               firstColWidth={firstColWidth ? firstColWidth : undefined}
               oneLine={oneLine}
               compact={compact}

--- a/packages/manager/src/features/Events/EventsLanding.tsx
+++ b/packages/manager/src/features/Events/EventsLanding.tsx
@@ -339,11 +339,12 @@ export const renderTableBody = (
   if (loading) {
     return (
       <TableRowLoading
-        colSpan={3}
+        colSpan={4}
         numberOfRows={10}
+        numberOfColumns={3}
         oneLine
         data-qa-events-table-loading
-        firstColWidth={70}
+        firstColWidth={60}
         compact
       />
     );
@@ -373,7 +374,17 @@ export const renderTableBody = (
             event={thisEvent}
           />
         ))}
-        {isRequesting && <TableRowLoading colSpan={12} transparent />}
+        {isRequesting && (
+          <TableRowLoading
+            colSpan={4}
+            numberOfColumns={3}
+            numberOfRows={4}
+            oneLine
+            compact
+            firstColWidth={60}
+            transparent
+          />
+        )}
       </>
     );
   }


### PR DESCRIPTION
## Description

Previously the skeleton loaders on the EventsLanding page were questionable at best:

![Screen Shot 2020-03-25 at 3 13 26 PM](https://user-images.githubusercontent.com/16911484/77576777-1ab94080-6eac-11ea-9aa0-b9a1fbdad4d9.png)

![Screen Shot 2020-03-25 at 3 13 43 PM](https://user-images.githubusercontent.com/16911484/77576824-27d62f80-6eac-11ea-830b-e5ac20e20e98.png)

The EventsLanding table has 4 columns, but one of them is used for the entity icon, so to the user it appears like there's only 3 columns.

We still want the TableRowLoading component to span 4 columns, but we only want to show 3 skeleton loaders. Previously, `colSpan` was overloaded in the sense that it handled both of these things. Now, `colSpan` can be used as intended and `numberOfColumns` can be used to specify the number of skeleton loaders.

If `numberOfColumns` is NOT provided but `colSpan` IS provided, we use `colSpan` for both purposes, like it was previously.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')
