### PR TITLE
M3-4006 Fix: Backup restoration status doesn't clear on completion

### DIFF
--- a/packages/manager/src/store/linodes/linodes.events.ts
+++ b/packages/manager/src/store/linodes/linodes.events.ts
@@ -97,6 +97,11 @@ const handleLinodeRebuild = (
         // event doesn't come through.
         dispatch(getAllLinodeDisks({ linodeId: id }));
         dispatch(getAllLinodeConfigs({ linodeId: id }));
+        // There seems to be a race condition here where the final event
+        // doesn't come through and the Linode's status is not updated
+        // for >5 seconds, so we show an infinite spinner/busy Linode.
+        // This is not the most elegant solution but it works.
+        setTimeout(() => dispatch(requestLinodeForStore(id)), 10000);
       }
       return dispatch(requestLinodeForStore(id));
     case 'finished':
@@ -104,6 +109,8 @@ const handleLinodeRebuild = (
       // Get the new disks and update the store.
       dispatch(getAllLinodeDisks({ linodeId: id }));
       dispatch(getAllLinodeConfigs({ linodeId: id }));
+      // See above; this should never matter but it doesn't hurt to be thorough.
+      setTimeout(() => dispatch(requestLinodeForStore(id)), 10000);
       return dispatch(requestLinodeForStore(id));
     default:
       return;


### PR DESCRIPTION
## Description

When restoring from a backup, there seems to be a race condition:
we receive a `percent_complete: 100` event, make a final request,
but the Linode still reports its status as "restoring". This is true
for >5 seconds after the final event rolls in. I added a final request
delayed 10 seconds, which is not pretty but it resolves the issue.

It's still unclear why the final `status: finished` event isn't registering
with our system, even though we continue to poll.

## Note

I'm still working on a) figuring out why we don't register the completed event and b) how you all can reproduce this for testing. I used Steve Jacob's account but that doesn't scale well. 

1. From Linode Detail backups tab, right click on a backup and choose "Deploy new Linode".
2. Submit the form
3. Wait
4. When the restore completes, the status should be updated and the progress bar should disappear.