### PR TITLE
Feature/preserve ticket text

### DIFF
--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
@@ -7,6 +7,8 @@ import { APIError } from 'linode-js-sdk/lib/types';
 import { update } from 'ramda';
 import * as React from 'react';
 import { compose as recompose } from 'recompose';
+import { debounce } from 'throttle-debounce';
+
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import FormHelperText from 'src/components/core/FormHelperText';
@@ -131,7 +133,7 @@ export const getInitialValue = (
   fromProps?: string,
   fromStorage?: string
 ): string => {
-  return fromProps || fromStorage || '';
+  return fromProps ?? fromStorage ?? '';
 };
 
 export const SupportTicketDrawer: React.FC<CombinedProps> = props => {
@@ -168,9 +170,16 @@ export const SupportTicketDrawer: React.FC<CombinedProps> = props => {
     }
   }, [open]);
 
+  const saveText = (_title: string, _description: string) => {
+    storage.supportText.set({ title: _title, description: _description });
+  };
+
+  // Has to be a ref or else the timeout is redone with each render
+  const debouncedSave = React.useRef(debounce(500, false, saveText)).current;
+
   React.useEffect(() => {
     // Store in-progress work to localStorage
-    storage.supportText.set({ title: summary, description });
+    debouncedSave(summary, description);
   }, [summary, description]);
 
   const handleSetOrRequestEntities = (

--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
@@ -170,9 +170,7 @@ export const SupportTicketDrawer: React.FC<CombinedProps> = props => {
 
   React.useEffect(() => {
     // Store in-progress work to localStorage
-    if (summary || description) {
-      storage.supportText.set({ title: summary, description });
-    }
+    storage.supportText.set({ title: summary, description });
   }, [summary, description]);
 
   const handleSetOrRequestEntities = (
@@ -233,7 +231,6 @@ export const SupportTicketDrawer: React.FC<CombinedProps> = props => {
   };
 
   const resetTicket = () => {
-    const valuesFromStorage = storage.supportText.get();
     setSummary(getInitialValue(prefilledTitle, valuesFromStorage.title));
     setDescription(
       getInitialValue(prefilledDescription, valuesFromStorage.description)

--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
@@ -230,18 +230,26 @@ export const SupportTicketDrawer: React.FC<CombinedProps> = props => {
     }
   };
 
-  const resetTicket = () => {
-    setSummary(getInitialValue(prefilledTitle, valuesFromStorage.title));
-    setDescription(
-      getInitialValue(prefilledDescription, valuesFromStorage.description)
-    );
+  const resetTicket = (clearValues: boolean = false) => {
+    /**
+     * Clear the drawer completely if clearValues is passed (as in when closing the drawer)
+     * or reset to the default values (from props or localStorage) otherwise.
+     */
+    const _summary = clearValues
+      ? ''
+      : getInitialValue(prefilledTitle, valuesFromStorage.title);
+    const _description = clearValues
+      ? ''
+      : getInitialValue(prefilledDescription, valuesFromStorage.description);
+    setSummary(_summary);
+    setDescription(_description);
     setEntityID('');
     setEntityType('none');
   };
 
-  const resetDrawer = () => {
+  const resetDrawer = (clearValues: boolean = false) => {
     setData([]);
-    resetTicket();
+    resetTicket(clearValues);
     setFiles([]);
   };
 
@@ -284,9 +292,8 @@ export const SupportTicketDrawer: React.FC<CombinedProps> = props => {
   };
 
   const close = () => {
-    storage.supportText.set({ title: '', description: '' });
     props.onClose();
-    resetDrawer();
+    resetDrawer(true);
   };
 
   const updateFiles = (newFiles: FileAttachment[]) => {

--- a/packages/manager/src/store/authentication/authentication.helpers.ts
+++ b/packages/manager/src/store/authentication/authentication.helpers.ts
@@ -1,8 +1,15 @@
-import { authentication } from 'src/utilities/storage';
+import { authentication, supportText } from 'src/utilities/storage';
 
 export const clearLocalStorage = () => {
   authentication.token.set('');
   authentication.scopes.set('');
   authentication.expire.set('');
   authentication.nonce.set('');
+};
+
+export const clearUserInput = () => {
+  // Add more things here as needed, right now we only cache
+  // Support ticket title/description.
+
+  supportText.set({ title: '', description: '' });
 };

--- a/packages/manager/src/store/authentication/authentication.reducer.ts
+++ b/packages/manager/src/store/authentication/authentication.reducer.ts
@@ -8,7 +8,7 @@ import {
   handleRefreshTokens,
   handleStartSession
 } from './authentication.actions';
-import { clearLocalStorage } from './authentication.helpers';
+import { clearLocalStorage, clearUserInput } from './authentication.helpers';
 import { State } from './index';
 
 export const defaultState: State = {
@@ -85,7 +85,7 @@ const reducer = reducerWithInitialState(defaultState)
       loggedInAsCustomer: isLoggedInAsCustomer
     };
   })
-  .cases([handleExpireTokens, handleLogout], state => {
+  .case(handleExpireTokens, state => {
     /** clear local storage and redux state - plain and simple */
     clearLocalStorage();
     return {
@@ -96,11 +96,25 @@ const reducer = reducerWithInitialState(defaultState)
       loggedInAsCustomer: false
     };
   })
+  .case(handleLogout, state => {
+    /** clear local storage and redux state */
+    clearLocalStorage();
+    /** since the user is explicitly logging out, clear user input from local storage */
+    clearUserInput();
+    return {
+      ...state,
+      scopes: null,
+      token: null,
+      expiration: null,
+      loggedInAsCustomer: false
+    };
+  })
   .case(handleRefreshTokens, state => {
     /** get local storage values and append to redux state */
-    const [localToken, localScopes, localExpiry] = (tokenInLocalStorage.get(),
-    scopesInLocalStorage.get(),
-    expiryInLocalStorage.get());
+    const [localToken, localScopes, localExpiry] =
+      (tokenInLocalStorage.get(),
+      scopesInLocalStorage.get(),
+      expiryInLocalStorage.get());
     return {
       ...state,
       token: localToken,

--- a/packages/manager/src/utilities/storage.ts
+++ b/packages/manager/src/utilities/storage.ts
@@ -10,7 +10,7 @@ export const getStorage = (key: string, fallback?: any) => {
    * Basically, if localstorage doesn't exist,
    * return whatever we set as a fallback
    */
-  if (item === null && !!fallback) {
+  if ((item === null || item === undefined) && !!fallback) {
     return fallback;
   }
 
@@ -126,7 +126,7 @@ export const storage: Storage = {
     set: () => setStorage(BACKUPSCTA_DISMISSED, 'true')
   },
   supportText: {
-    get: () => getStorage(SUPPORT),
+    get: () => getStorage(SUPPORT, { title: '', description: '' }),
     set: v => setStorage(SUPPORT, JSON.stringify(v))
   }
 };

--- a/packages/manager/src/utilities/storage.ts
+++ b/packages/manager/src/utilities/storage.ts
@@ -44,12 +44,18 @@ const TOKEN = 'authentication/token';
 const NONCE = 'authentication/nonce';
 const SCOPES = 'authentication/scopes';
 const EXPIRE = 'authentication/expire';
+const SUPPORT = 'support';
 
 export type PageSize = number;
 
 interface AuthGetAndSet {
   get: () => any;
   set: (value: string) => void;
+}
+
+interface SupportText {
+  title: string;
+  description: string;
 }
 
 export interface Storage {
@@ -70,6 +76,10 @@ export interface Storage {
   BackupsCtaDismissed: {
     get: () => boolean;
     set: (v: 'true' | 'false') => void;
+  };
+  supportText: {
+    get: () => SupportText;
+    set: (v: SupportText) => void;
   };
 }
 
@@ -114,6 +124,10 @@ export const storage: Storage = {
   BackupsCtaDismissed: {
     get: () => getStorage(BACKUPSCTA_DISMISSED),
     set: () => setStorage(BACKUPSCTA_DISMISSED, 'true')
+  },
+  supportText: {
+    get: () => getStorage(SUPPORT),
+    set: v => setStorage(SUPPORT, JSON.stringify(v))
   }
 };
 

--- a/packages/manager/src/utilities/storage.ts
+++ b/packages/manager/src/utilities/storage.ts
@@ -131,4 +131,4 @@ export const storage: Storage = {
   }
 };
 
-export const { authentication, BackupsCtaDismissed } = storage;
+export const { authentication, BackupsCtaDismissed, supportText } = storage;


### PR DESCRIPTION
## Description

If a user's session expires while working on a support ticket,
or they accidentally close the tab, their work will be lost.

The first situation can and should be solved by some kind of token
refresh logic, but in the meantime and for the second situation,
I added logic to store the values in local storage.

- Added supportText field to utilities/storage.ts
- Added logic in SupportTicketDrawer to read and write values

Local storage will be cleared:
 - when the drawer is closed (including after a successful submit)
 - when the user explicitly logs out

Other adjustments: 

- Make the setting logic unconditional, to allow the user to clear
their input and have that be stored in localStorage.
- Add a reducer case to authentication.reducer to make sure any stored
input is cleared when the user explicitly logs out. Previously the same
reducer case was used for expireTokens and logOut actions, but I think
that would defeat the purpose (if the user's tokens expire we want to
preserve their text).

- Added a fallback to the getStorage() method for supportText
- Added === undefined check to the existing === null check in getStorage(),
so if the value is not in local storage it'll also get the default. I don't think
this affects actual usage, but our mock local storage implementation seems to break
on nested keys without this.
## Note to Reviewers

Point to dev services and try things with support tickets. Keep an eye on the value in the Application tab of devtools. It should update when you type, be preserved when you open a new tab or reload the page, etc. It should clear when you manually close the drawer or submit the form.