### PR TITLE
Fix query param parsing

### DIFF
--- a/packages/manager/src/utilities/queryParams.ts
+++ b/packages/manager/src/utilities/queryParams.ts
@@ -33,18 +33,3 @@ export const getParamFromUrl = (
   const parsedUrl = parseUrl(url) as any;
   return getQueryParam(parsedUrl.query, paramName, defaultValue);
 };
-
-/**
- * Splits a string into at most two parts using a separator character.
- *
- * @param str The string to split
- * @param sep The separator character to use
- * @returns An array of length 2, which are the two separated parts of str
- */
-export const splitIntoTwo = (str: string, sep: string): string[] => {
-  const idx = str.indexOf(sep);
-  if (idx === -1 || idx === str.length - 1) {
-    throw new Error(`"${str}" cannot be split into two parts by ${sep}`);
-  }
-  return [str.substr(0, idx), str.substr(idx + 1)];
-};


### PR DESCRIPTION
Query params from returnTo urls were being lost, so a user trying to
visit cloud.linode.com/linodes/create?type=One-Click&appID=401719&showInfo=true
without being logged in would end up at cloud.linode.com/linodes/create?type=One-Click after completing the login process.

This is due to how parsers such as qs interpret query strings containing
URLs that themselves contain query params. We were ending up with an object
like:

```
{
  access_token:
   '0d025eaa329b643032b7a4905f145d70410e186a713b121cd87646a674084e1b',
  token_type: 'bearer',
  expires_in: '7200',
  scope: '*',
  state: '83388bfa-207f-4ea9-a1c5-8653750b721b',
  return:
   'http://localhost:3000/oauth/callback?returnTo=/linodes/create?type=One-Click',
  appID: '401719',
  showInfo: 'true'
}
```

Other approaches like new UrlSearchParams() had the same behavior. It seemed
easiest to just grab the returnTo path directly, and that seems to work under
all conditions. The return=.../returnTo= param is guaranteed to be the last
param returned from the Login service (any later params would be ambiguous for
the reasons above), so this should be a safe approach.


## Note to Reviewers

To test, log out of your local Cloud and try to visit `http://localhost:3000/linodes/create?type=One-Click&appID=401719&showInfo=true`. After you go through login, you should be redirected to the OCA page, with the app pre-selected and the info drawer open.