### PR TITLE
M3-4063 Add: Resize Node Pool Drawer

### DIFF
--- a/packages/manager/src/__data__/types.ts
+++ b/packages/manager/src/__data__/types.ts
@@ -9,7 +9,7 @@ export const types: LinodeType[] = [
       hourly: 0.015
     },
     id: 'g5-standard-1',
-    label: 'Linode 2048',
+    label: 'Linode 2GB',
     class: 'standard',
     addons: {
       backups: {

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -26,6 +26,9 @@ import { ExtendedCluster } from '.././types';
 import KubeSummaryPanel from './KubeSummaryPanel';
 import NodePoolsDisplay from './NodePoolsDisplay';
 
+// @todo delete/move this before merge
+import ResizeNodePoolDrawer from './ResizeNodePoolDrawer';
+
 type ClassNames =
   | 'root'
   | 'title'
@@ -104,6 +107,9 @@ export const KubernetesClusterDetail: React.FunctionComponent<CombinedProps> = p
   const [endpointLoading, setEndpointLoading] = React.useState<boolean>(false);
 
   const [updateError, setUpdateError] = React.useState<string | undefined>();
+
+  // @todo delete before merge
+  const [open, setOpen] = React.useState<boolean>(true);
 
   React.useEffect(() => {
     const clusterID = +props.match.params.clusterID;
@@ -220,6 +226,15 @@ export const KubernetesClusterDetail: React.FunctionComponent<CombinedProps> = p
           />
         </Grid>
       </Grid>
+      {/** Delete before merge */}
+      <ResizeNodePoolDrawer
+        open={open}
+        onClose={() => setOpen(false)}
+        onSubmit={() => null}
+        isSubmitting={false}
+        nodePool={cluster.node_pools[0]}
+        error="An error"
+      />
     </React.Fragment>
   );
 };

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -26,9 +26,6 @@ import { ExtendedCluster } from '.././types';
 import KubeSummaryPanel from './KubeSummaryPanel';
 import NodePoolsDisplay from './NodePoolsDisplay';
 
-// @todo delete/move this before merge
-import ResizeNodePoolDrawer from './ResizeNodePoolDrawer';
-
 type ClassNames =
   | 'root'
   | 'title'
@@ -107,9 +104,6 @@ export const KubernetesClusterDetail: React.FunctionComponent<CombinedProps> = p
   const [endpointLoading, setEndpointLoading] = React.useState<boolean>(false);
 
   const [updateError, setUpdateError] = React.useState<string | undefined>();
-
-  // @todo delete before merge
-  const [open, setOpen] = React.useState<boolean>(true);
 
   React.useEffect(() => {
     const clusterID = +props.match.params.clusterID;
@@ -226,15 +220,6 @@ export const KubernetesClusterDetail: React.FunctionComponent<CombinedProps> = p
           />
         </Grid>
       </Grid>
-      {/** Delete before merge */}
-      <ResizeNodePoolDrawer
-        open={open}
-        onClose={() => setOpen(false)}
-        onSubmit={() => null}
-        isSubmitting={false}
-        nodePool={cluster.node_pools[0]}
-        error="An error"
-      />
     </React.Fragment>
   );
 };

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/ResizeNodePoolDrawer/ResizeNodePoolDrawer.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/ResizeNodePoolDrawer/ResizeNodePoolDrawer.test.tsx
@@ -1,0 +1,57 @@
+import { cleanup, fireEvent } from '@testing-library/react';
+import * as React from 'react';
+import { nodePoolFactory } from 'src/factories/kubernetesCluster';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import ResizeNodePoolDrawer, { Props } from './ResizeNodePoolDrawer';
+
+afterEach(cleanup);
+
+const pool = nodePoolFactory.build();
+const smallPool = nodePoolFactory.build({ count: 2 });
+
+const props: Props = {
+  open: true,
+  onClose: jest.fn(),
+  onSubmit: jest.fn(),
+  nodePool: pool,
+  isSubmitting: false
+};
+
+jest.mock('src/features/linodes/presentation', () => ({
+  displayClassAndSize: jest.fn().mockReturnValue('type and size')
+}));
+
+describe('ResizeNodePoolDrawer', () => {
+  it("should render the pool's type and size", () => {
+    const { getByText } = renderWithTheme(<ResizeNodePoolDrawer {...props} />);
+    getByText(/type and size/);
+  });
+
+  it('should call the submit handler when submit is clicked', () => {
+    const { getByTestId, getByText } = renderWithTheme(
+      <ResizeNodePoolDrawer {...props} />
+    );
+    const increment = getByTestId('increment-button');
+    fireEvent.click(increment);
+    const button = getByText(/save/i);
+    fireEvent.click(button);
+    expect(props.onSubmit).toHaveBeenCalledWith(pool.count + 1);
+  });
+
+  it('should display a warning if the user tries to resize a node pool to < 3 nodes', () => {
+    const { getByText } = renderWithTheme(
+      <ResizeNodePoolDrawer {...props} nodePool={smallPool} />
+    );
+    expect(getByText(/we recommend at least 3 nodes/i));
+  });
+
+  it('should display a warning if the user tries to resize to a smaller node count', () => {
+    const { getByTestId, getByText } = renderWithTheme(
+      <ResizeNodePoolDrawer {...props} />
+    );
+    const decrement = getByTestId('decrement-button');
+    fireEvent.click(decrement);
+    expect(getByText(/resizing to fewer nodes/i));
+  });
+});

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/ResizeNodePoolDrawer/ResizeNodePoolDrawer.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/ResizeNodePoolDrawer/ResizeNodePoolDrawer.test.tsx
@@ -1,5 +1,6 @@
 import { cleanup, fireEvent } from '@testing-library/react';
 import * as React from 'react';
+import { types as _types } from 'src/__data__/types';
 import { nodePoolFactory } from 'src/factories/kubernetesCluster';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
@@ -7,7 +8,7 @@ import ResizeNodePoolDrawer, { Props } from './ResizeNodePoolDrawer';
 
 afterEach(cleanup);
 
-const pool = nodePoolFactory.build();
+const pool = nodePoolFactory.build({ type: 'g5-standard-1' });
 const smallPool = nodePoolFactory.build({ count: 2 });
 
 const props: Props = {
@@ -18,14 +19,16 @@ const props: Props = {
   isSubmitting: false
 };
 
-jest.mock('src/features/linodes/presentation', () => ({
-  displayClassAndSize: jest.fn().mockReturnValue('type and size')
+const useTypes = jest.fn().mockReturnValue({ types: { entities: _types } });
+
+jest.mock('src/hooks/useTypes', () => ({
+  useTypes: () => useTypes()
 }));
 
 describe('ResizeNodePoolDrawer', () => {
   it("should render the pool's type and size", () => {
     const { getByText } = renderWithTheme(<ResizeNodePoolDrawer {...props} />);
-    getByText(/type and size/);
+    getByText(/linode 2GB/i);
   });
 
   it('should call the submit handler when submit is clicked', () => {

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/ResizeNodePoolDrawer/ResizeNodePoolDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/ResizeNodePoolDrawer/ResizeNodePoolDrawer.tsx
@@ -1,0 +1,130 @@
+import * as React from 'react';
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+import Drawer from 'src/components/Drawer';
+import EnhancedNumberInput from 'src/components/EnhancedNumberInput';
+import Notice from 'src/components/Notice';
+import { displayClassAndSize } from 'src/features/linodes/presentation';
+import { useTypes } from 'src/hooks/useTypes';
+import { nodeWarning } from '../../kubeUtils';
+import { PoolNodeWithPrice } from '../../types';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  summary: {
+    fontWeight: 'bold',
+    lineHeight: '20px',
+    fontSize: '16px'
+  },
+  helperText: {
+    paddingBottom: theme.spacing() / 2
+  },
+  section: {
+    paddingBottom: theme.spacing(3)
+  }
+}));
+
+export interface Props {
+  open: boolean;
+  error?: string;
+  isSubmitting: boolean;
+  onClose: () => void;
+  onSubmit: (updatedValue: number) => void;
+  nodePool: PoolNodeWithPrice;
+}
+
+const resizeWarning = `Resizing to fewer nodes will delete random nodes from
+the pool. If you want to keep specific nodes, delete unneeded nodes manually from
+the pool's node list.`;
+
+export const AddDeviceDrawer: React.FC<Props> = props => {
+  const { error, isSubmitting, nodePool, onClose, onSubmit, open } = props;
+  const { types } = useTypes();
+  const classes = useStyles();
+
+  const [updatedCount, setUpdatedCount] = React.useState<number>(
+    nodePool.count
+  );
+
+  const handleChange = (value: number) => {
+    setUpdatedCount(Math.min(100, Math.floor(value)));
+  };
+
+  const handleSubmit = () => {
+    alert(`Called onSubmit with ${updatedCount}`);
+    onSubmit(updatedCount);
+  };
+
+  const planType = types.entities.find(
+    thisType => thisType.id === nodePool.type
+  );
+
+  const pricePerNode = planType?.price.monthly ?? 0;
+
+  return (
+    <Drawer
+      title={`Resize Pool: ${displayClassAndSize(
+        planType?.class ?? '',
+        planType?.memory ?? 0
+      )}`}
+      open={open}
+      onClose={onClose}
+    >
+      <form
+        onSubmit={(e: React.ChangeEvent<HTMLFormElement>) => {
+          e.preventDefault();
+          handleSubmit();
+        }}
+      >
+        <div className={classes.section}>
+          <Typography className={classes.summary}>
+            Current pool: ${nodePool.totalMonthlyPrice}/month ({nodePool.count}{' '}
+            nodes at ${pricePerNode}/month)
+          </Typography>
+        </div>
+
+        {error && <Notice error text={error} />}
+
+        <div className={classes.section}>
+          <Typography className={classes.helperText}>
+            Enter the number of nodes you'd like in this pool:
+          </Typography>
+          <EnhancedNumberInput value={updatedCount} setValue={handleChange} />
+        </div>
+
+        <div className={classes.section}>
+          <Typography className={classes.summary}>
+            Resized pool: ${updatedCount * pricePerNode}/month ({updatedCount}{' '}
+            nodes at ${pricePerNode}/month)
+          </Typography>
+        </div>
+
+        {updatedCount < nodePool.count && (
+          <Notice important warning text={resizeWarning} />
+        )}
+
+        {updatedCount < 3 && <Notice important warning text={nodeWarning} />}
+
+        <ActionsPanel>
+          <Button
+            buttonType="primary"
+            disabled={updatedCount === nodePool.count}
+            onClick={handleSubmit}
+            data-qa-submit
+            loading={isSubmitting}
+          >
+            Save Changes
+          </Button>
+          {/* 
+            <Button onClick={onClose} buttonType="cancel" data-qa-cancel>
+                Cancel
+            </Button> 
+          */}
+        </ActionsPanel>
+      </form>
+    </Drawer>
+  );
+};
+
+export default AddDeviceDrawer;

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/ResizeNodePoolDrawer/ResizeNodePoolDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/ResizeNodePoolDrawer/ResizeNodePoolDrawer.tsx
@@ -51,7 +51,6 @@ export const AddDeviceDrawer: React.FC<Props> = props => {
   };
 
   const handleSubmit = () => {
-    alert(`Called onSubmit with ${updatedCount}`);
     onSubmit(updatedCount);
   };
 

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/ResizeNodePoolDrawer/ResizeNodePoolDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/ResizeNodePoolDrawer/ResizeNodePoolDrawer.tsx
@@ -37,7 +37,7 @@ const resizeWarning = `Resizing to fewer nodes will delete random nodes from
 the pool. If you want to keep specific nodes, delete unneeded nodes manually from
 the pool's node list.`;
 
-export const AddDeviceDrawer: React.FC<Props> = props => {
+export const ResizeNodePoolDrawer: React.FC<Props> = props => {
   const { error, isSubmitting, nodePool, onClose, onSubmit, open } = props;
   const { types } = useTypes();
   const classes = useStyles();
@@ -122,4 +122,4 @@ export const AddDeviceDrawer: React.FC<Props> = props => {
   );
 };
 
-export default AddDeviceDrawer;
+export default ResizeNodePoolDrawer;

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/ResizeNodePoolDrawer/ResizeNodePoolDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/ResizeNodePoolDrawer/ResizeNodePoolDrawer.tsx
@@ -6,7 +6,6 @@ import Typography from 'src/components/core/Typography';
 import Drawer from 'src/components/Drawer';
 import EnhancedNumberInput from 'src/components/EnhancedNumberInput';
 import Notice from 'src/components/Notice';
-import { displayClassAndSize } from 'src/features/linodes/presentation';
 import { useTypes } from 'src/hooks/useTypes';
 import { nodeWarning } from '../../kubeUtils';
 import { PoolNodeWithPrice } from '../../types';
@@ -64,10 +63,7 @@ export const AddDeviceDrawer: React.FC<Props> = props => {
 
   return (
     <Drawer
-      title={`Resize Pool: ${displayClassAndSize(
-        planType?.class ?? '',
-        planType?.memory ?? 0
-      )}`}
+      title={`Resize Pool: ${planType?.label ?? 'Unknown'} Plan`}
       open={open}
       onClose={onClose}
     >

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/ResizeNodePoolDrawer/ResizeNodePoolDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/ResizeNodePoolDrawer/ResizeNodePoolDrawer.tsx
@@ -18,7 +18,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     fontSize: '16px'
   },
   helperText: {
-    paddingBottom: theme.spacing() / 2
+    paddingBottom: theme.spacing(2) + 1
   },
   section: {
     paddingBottom: theme.spacing(3)

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/ResizeNodePoolDrawer/index.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/ResizeNodePoolDrawer/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './ResizeNodePoolDrawer';

--- a/packages/manager/src/features/Kubernetes/kubeUtils.ts
+++ b/packages/manager/src/features/Kubernetes/kubeUtils.ts
@@ -2,8 +2,7 @@ import { KubernetesCluster } from 'linode-js-sdk/lib/kubernetes';
 import { LinodeType } from 'linode-js-sdk/lib/linodes';
 import { ExtendedCluster, ExtendedPoolNode, PoolNodeWithPrice } from './types';
 
-export const nodeWarning = `A single Node cluster may suffer downtime during Kubernetes upgrades. 
-For high availability, we suggest clusters with three or more Nodes.`;
+export const nodeWarning = `We recommend at least 3 nodes in each pool. Fewer nodes may affect availability.`;
 
 export const getMonthlyPrice = (
   type: string,
@@ -86,3 +85,8 @@ export const getTotalClusterMemoryAndCPU = (
     { RAM: 0, CPU: 0 }
   );
 };
+
+export const getTotalNodesInCluster = (pools: PoolNodeWithPrice[]): number =>
+  pools.reduce((accum, thisPool) => {
+    return accum + thisPool.count;
+  }, 0);

--- a/packages/manager/src/features/linodes/presentation.ts
+++ b/packages/manager/src/features/linodes/presentation.ts
@@ -46,15 +46,27 @@ export const displayType = (
   return 'Unknown Plan';
 };
 
+export const displayClass = (category: string) => {
+  const formattedCategory = category === 'highmem' ? 'High Memory' : category;
+  return titlecase(formattedCategory);
+};
+
+export const displaySize = (memory: number) => {
+  const memG = memory / 1024;
+  return `${memG}GB`;
+};
+
+export const displayClassAndSize = (category: string, memory: number) => {
+  return `${displayClass(category)} ${displaySize(memory)}`;
+};
+
 export const displayTypeForKubePoolNode = (
   category: string,
   memory: number,
   vcpus: number
 ) => {
-  const formattedCategory = category === 'highmem' ? 'High Memory' : category;
-  const label = titlecase(formattedCategory);
-  const memG = memory / 1024;
-  const size = `${memG}GB`;
+  const label = displayClass(category);
+  const size = displaySize(memory);
   const cpus = `${vcpus} CPU${vcpus !== 1 ? 's' : ''}`;
   return `${label} ${size}, ${cpus}`;
 };

--- a/packages/manager/src/features/linodes/presentation.ts
+++ b/packages/manager/src/features/linodes/presentation.ts
@@ -56,10 +56,6 @@ export const displaySize = (memory: number) => {
   return `${memG}GB`;
 };
 
-export const displayClassAndSize = (category: string, memory: number) => {
-  return `${displayClass(category)} ${displaySize(memory)}`;
-};
-
 export const displayTypeForKubePoolNode = (
   category: string,
   memory: number,

--- a/packages/manager/src/hooks/useTypes.ts
+++ b/packages/manager/src/hooks/useTypes.ts
@@ -1,0 +1,9 @@
+import { useSelector } from 'react-redux';
+import { ApplicationState } from 'src/store';
+
+export const useTypes = () => {
+  const types = useSelector(
+    (state: ApplicationState) => state.__resources.types
+  );
+  return { types };
+};


### PR DESCRIPTION
## Description

Drawer for resizing node pools. To avoid conflicts, I've avoided doing any of the logic to add this component to the details view. Instead, I added a dummy drawer to ClusterDetails that I'll delete before merge. Then I can follow-up after #6251 is merged (since that's where the action to open this drawer will live). 
