### PR TITLE
Convert values on LV Network graphs

### DIFF
--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Network/NetworkGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Network/NetworkGraphs.tsx
@@ -89,7 +89,7 @@ export const NetworkGraphs: React.FC<CombinedProps> = props => {
                 subtitle={maxUnit + '/s'}
                 unit={'/s'}
                 formatData={(value: number) =>
-                  convertNetworkToUnit(value, maxUnit)
+                  convertNetworkToUnit(value * 8, maxUnit)
                 }
                 formatTooltip={formatNetworkTooltip}
                 error={error}


### PR DESCRIPTION
## Description

Data was being given to the graph in bytes, but not converted to bits before being passed to `convertNetworkToUnit`, (which accepts bits).

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Notes to reviewers

Test acct 4 has a LV client named "nginx-working". Compare the Network graphs to Classic, and make sure the tooltip values/units align with the graph.