### PR TITLE
M3-4048 Fix Longview NGINX bug

### DIFF
--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ProcessGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ProcessGraphs.tsx
@@ -45,7 +45,6 @@ export const ProcessGraphs: React.FC<CombinedProps> = props => {
   const { data, error, loading, isToday, timezone, start, end, theme } = props;
 
   const _convertData = React.useCallback(convertData, [data, start, end]);
-
   const _data = React.useMemo(() => sumRelatedProcessesAcrossAllUsers(data), [
     data
   ]);

--- a/packages/manager/src/features/Longview/shared/utilities.ts
+++ b/packages/manager/src/features/Longview/shared/utilities.ts
@@ -142,6 +142,9 @@ export const appendStats = (
   prevStats: StatWithDummyPoint[],
   newStats: StatWithDummyPoint[]
 ) => {
+  if (!newStats || !Array.isArray(newStats)) {
+    return prevStats;
+  }
   return newStats.reduce(
     (acc, { x, y }, idx) => {
       const existing = acc[idx];
@@ -247,13 +250,15 @@ export const sumStatsObject = <T>(
   return Object.values(data).reduce(
     (accum, thisObject) => {
       return produce(accum, draft => {
-        Object.keys(thisObject).forEach(thisKey => {
-          if (thisKey in accum) {
-            draft[thisKey] = appendStats(accum[thisKey], thisObject[thisKey]);
-          } else {
-            draft[thisKey] = thisObject[thisKey];
-          }
-        });
+        if (thisObject && typeof thisObject === 'object') {
+          Object.keys(thisObject).forEach(thisKey => {
+            if (thisKey in accum) {
+              draft[thisKey] = appendStats(accum[thisKey], thisObject[thisKey]);
+            } else {
+              draft[thisKey] = thisObject[thisKey];
+            }
+          });
+        }
       });
     },
     { ...emptyState }


### PR DESCRIPTION
## Description

A user reported that their NGINX tab in Longview was crashing.
This is due to a badly malformed response from the Longview API.
Classic Manager's Longview client handled for this case but did
not display data for the malformed request (probably a try/catch somewhere).

It turns out the crash was because we weren't manually type checking
the arguments to appendStats() in longview/shared/utilities. The bad
request was sending an array rather than an object to that method
and Object.keys().reduce() was crashing. Added an isArray() check
to prevent this.

We actually display data in this case, though it can't possibly be
entirely accurate since the "bad" data is being ignored. I'm not sure
whether the best thing to do is check the shape higher up and blank
out the graphs if the shape doesn't match (basically what Classic does)
or leave it as it is now, where graphs are displayed but some data
may be missing.

## Note to Reviewers

I have no idea how Longview is borking the request and I can't reproduce it, so you'll have to log in as this customer to check the fix. If you haven't done that before please reach out. There's more information and screenshots in the ticket.