### PR TITLE
Placeholder A11y Improvement: add component prop

### DIFF
--- a/packages/manager/src/components/H1Header/H1Header.tsx
+++ b/packages/manager/src/components/H1Header/H1Header.tsx
@@ -6,6 +6,7 @@ interface Props {
   title: string;
   className?: string;
   dataQaEl?: string;
+  renderAsSecondary?: boolean;
 }
 
 const useStyles = makeStyles({
@@ -22,7 +23,7 @@ const useStyles = makeStyles({
 // It should serve as the only source for all H1s
 const H1Header: React.FC<Props> = props => {
   const h1Header = React.useRef<HTMLDivElement>(null);
-  const { className, title, dataQaEl } = props;
+  const { className, title, dataQaEl, renderAsSecondary } = props;
   const classes = useStyles();
 
   React.useEffect(() => {
@@ -34,6 +35,7 @@ const H1Header: React.FC<Props> = props => {
   return (
     <Typography
       variant="h1"
+      component={renderAsSecondary ? 'h2' : 'h1'}
       className={`${classes.root} ${className}`}
       ref={h1Header}
       tabIndex={0}

--- a/packages/manager/src/components/Placeholder/Placeholder.tsx
+++ b/packages/manager/src/components/Placeholder/Placeholder.tsx
@@ -98,12 +98,21 @@ export interface Props {
   title: string;
   buttonProps?: ExtendedButtonProps[];
   className?: string;
+  renderAsSecondary?: boolean;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 const Placeholder: React.StatelessComponent<CombinedProps> = props => {
-  const { animate, classes, copy, title, icon: Icon, buttonProps } = props;
+  const {
+    animate,
+    classes,
+    copy,
+    title,
+    icon: Icon,
+    buttonProps,
+    renderAsSecondary
+  } = props;
   return (
     <Grid
       container
@@ -120,6 +129,7 @@ const Placeholder: React.StatelessComponent<CombinedProps> = props => {
         <H1Header
           title={title}
           className={classes.title}
+          renderAsSecondary={renderAsSecondary}
           data-qa-placeholder-title
         />
       </Grid>

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Disks/Disks.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Disks/Disks.tsx
@@ -91,6 +91,7 @@ const Disks: React.FC<CombinedProps> = props => {
         <Placeholder
           title="No disks detected"
           copy="The Longview agent has not detected any disks that it can monitor."
+          renderAsSecondary
         />
       );
     }

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Network/NetworkGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Network/NetworkGraphs.tsx
@@ -66,6 +66,7 @@ export const NetworkGraphs: React.FC<CombinedProps> = props => {
       <Placeholder
         title="No network interfaces detected"
         copy="The Longview agent has not detected any interfaces that it can monitor."
+        renderAsSecondary
       />
     );
   }

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
@@ -256,6 +256,7 @@ const RenderEmpty: React.StatelessComponent<{
         title="Object Storage"
         copy={<EmptyCopy />}
         icon={BucketIcon}
+        renderAsSecondary
         buttonProps={[
           {
             onClick: props.onClick,

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -486,6 +486,7 @@ const withStackScriptBase = (options: WithStackScriptBaseOptions) => (
               {userCannotCreateStackScripts ? (
                 <Placeholder
                   icon={StackScriptsIcon}
+                  renderAsSecondary
                   title="StackScripts"
                   copy="You don't have any StackScripts to select from."
                   className={classes.stackscriptPlaceholder}
@@ -493,6 +494,7 @@ const withStackScriptBase = (options: WithStackScriptBaseOptions) => (
               ) : (
                 <Placeholder
                   icon={StackScriptsIcon}
+                  renderAsSecondary
                   title="StackScripts"
                   copy={<EmptyCopy />}
                   buttonProps={[

--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -437,6 +437,8 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
       fromLinodes
     } = this.props;
 
+    const isVolumesLanding = this.props.match.params.linodeId === undefined;
+
     if (
       linodeRegion &&
       !doesRegionSupportBlockStorage(linodeRegion, regionsData)
@@ -448,6 +450,7 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
             title="Volumes are not available in this region"
             copy=""
             icon={VolumesIcon}
+            renderAsSecondary={!isVolumesLanding}
           />
         </React.Fragment>
       );
@@ -467,6 +470,7 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
                 children: 'View Linode Configurations'
               }
             ]}
+            renderAsSecondary={!isVolumesLanding}
           />
         </React.Fragment>
       );
@@ -480,6 +484,7 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
           title="Add Block Storage!"
           copy={<EmptyCopy />}
           icon={VolumesIcon}
+          renderAsSecondary={!isVolumesLanding}
           buttonProps={[
             {
               onClick: fromLinodes

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
@@ -245,6 +245,7 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
                 icon={VolumeIcon}
                 copy="You do not have backups enabled for your Linodes. Please visit the Backups panel in the Linode Details view."
                 title="Create from Backup"
+                renderAsSecondary
               />
             </Paper>
           ) : (

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -126,6 +126,7 @@ export class FromImageContent extends React.PureComponent<CombinedProps> {
           <Paper>
             <Placeholder
               title="My Images"
+              renderAsSecondary
               copy={
                 <Typography variant="subtitle1">
                   You don't have any private Images. Visit the{' '}

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
@@ -121,6 +121,7 @@ export class FromLinodeContent extends React.PureComponent<CombinedProps> {
             <Paper>
               <Placeholder
                 icon={VolumeIcon}
+                renderAsSecondary
                 copy="You do not have any existing Linodes to clone from.
                     Please first create a Linode from either an Image or StackScript."
                 title="Clone from Existing Linode"

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -563,6 +563,7 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
         <Placeholder
           icon={VolumeIcon}
           title="Backups"
+          renderAsSecondary
           copy={backupPlaceholderText}
           buttonProps={[
             {


### PR DESCRIPTION
## Description

Currently there are states within the app where a double h1 could occur (ex. landing pages that are empty). To fix, we added a new prop to render the Placeholder title as an h2 instead of an h1 as needed. There should be no visual impact, but the output will now be semantically correct.

## Type of Change
- Bug fix ('fix')
