### PR TITLE
M3-3776: Allow Users to See Domain's "Last Modified" Date

### DIFF
--- a/packages/manager/src/features/Domains/DomainTableRow.tsx
+++ b/packages/manager/src/features/Domains/DomainTableRow.tsx
@@ -1,4 +1,4 @@
-import { DomainStatus } from 'linode-js-sdk/lib/domains';
+import { DomainStatus, getDomainRecords } from 'linode-js-sdk/lib/domains';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import {
@@ -121,6 +121,9 @@ class DomainTableRow extends React.Component<CombinedProps> {
         <TableCell parentColumn="Status" data-qa-domain-status>
           {humanizeDomainStatus(status)}
         </TableCell>
+        <TableCell parentColumn="Last Modified" data-qa-domain-lastmodified>
+          {retrieveRecords(id)}
+        </TableCell>
         <TableCell>
           <ActionMenu
             domain={domain}
@@ -151,6 +154,33 @@ const humanizeDomainStatus = (status: DomainStatus) => {
     default:
       return 'Unknown';
   }
+};
+
+const retrieveRecords = (domainId: number) => {
+  return domainId; // comment this line out and uncomment the below lines when testing; I only added this here to return something and make TypeScript happy on the commit checks.
+
+  // getDomainRecords(domainId)
+  //   .then(result => {
+  //     const recordUpdateTimes: Array<Date> = [];
+
+  //     result.data.forEach(record => {
+  //       const individualRecordUpdateTime = new Date(record.updated + 'Z');
+  //       recordUpdateTimes.push(individualRecordUpdateTime);
+  //     });
+
+  //     const mostRecentChange = recordUpdateTimes.reduce((a, b) => {
+  //       return a > b ? a : b;
+  //     });
+
+  //     // console.log(recordUpdateTimes);
+  //     // console.log(mostRecentChange);
+
+  //     // return mostRecentChange;
+  //     return 'Success';
+  //   })
+  //   .catch(error => {
+  //     return 'Failed';
+  //   });
 };
 
 const styled = withStyles(styles);

--- a/packages/manager/src/features/Domains/ListDomains.tsx
+++ b/packages/manager/src/features/Domains/ListDomains.tsx
@@ -94,6 +94,15 @@ const ListDomains: React.StatelessComponent<CombinedProps> = props => {
                   >
                     Status
                   </TableSortCell>
+                  <TableSortCell
+                    data-qa-domain-type-header={order}
+                    active={orderBy === 'last_modified'}
+                    label="last_modified"
+                    direction={order}
+                    handleClick={handleOrderChange}
+                  >
+                    Last Modified
+                  </TableSortCell>
                   <TableCell />
                 </TableRow>
               </TableHead>
@@ -127,8 +136,36 @@ interface RenderDataProps extends Handlers {
   data: Domain[];
 }
 
-const RenderData: React.StatelessComponent<RenderDataProps> = props => {
+const RenderData: React.FunctionComponent<RenderDataProps> = props => {
   const { data, onClone, onEdit, onRemove, onDisableOrEnable } = props;
+
+  // const retrieveRecords = (domainId: number) => {
+  //   // return domainId;
+
+  //   getDomainRecords(domainId)
+  //     .then(result => {
+  //       // const recordUpdateTimes: Array<Date> = [];
+
+  //       // result.data.forEach(record => {
+  //       //   const individualRecordUpdateTime = new Date(record.updated + 'Z');
+  //       //   recordUpdateTimes.push(individualRecordUpdateTime);
+  //       // });
+
+  //       // const mostRecentChange = recordUpdateTimes.reduce((a, b) => {
+  //       //   return a > b ? a : b;
+  //       // });
+
+  //       return 'Success';
+
+  //       // console.log(recordUpdateTimes);
+  //       // console.log(mostRecentChange);
+
+  //       // return mostRecentChange;
+  //     })
+  //     .catch(error => {
+  //       return 'Failed';
+  //     })
+  // }
 
   return (
     <>
@@ -142,6 +179,7 @@ const RenderData: React.StatelessComponent<RenderDataProps> = props => {
           onRemove={onRemove}
           type={domain.type}
           status={domain.status}
+          // updated={retrieveRecords(domain.id)}
           onDisableOrEnable={onDisableOrEnable}
         />
       ))}


### PR DESCRIPTION
## Description
In the Classic Manager, users were able to see a "Last Modified" date for each domain on the DNS Manager page. This information is not currently shown in Cloud.

This PR attempts to bring that information into the Domains landing page with a new "Last Modified" column, with the last modified time determined by getting each domain's DNS records, comparing their "Updated" field, and selecting the most recent value.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
