### PR TITLE
Fix handling of local storage on logout

### DIFF
--- a/packages/manager/src/layouts/Logout.tsx
+++ b/packages/manager/src/layouts/Logout.tsx
@@ -5,10 +5,13 @@ import { AnyAction } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { CLIENT_ID } from 'src/constants';
 import { ApplicationState } from 'src/store';
+import { clearUserInput } from 'src/store/authentication/authentication.helpers';
 import { handleLogout } from 'src/store/authentication/authentication.requests';
 
 export class Logout extends Component<DispatchProps & StateProps> {
   componentDidMount() {
+    // Clear any user input (in the Support Drawer) since the user is manually logging out.
+    clearUserInput();
     // Split the token so we can get the token portion of the "<prefix> <token>" pair
     this.props.dispatchLogout(CLIENT_ID || '', this.props.token.split(' ')[1]);
   }
@@ -42,9 +45,6 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
   };
 };
 
-const connected = connect(
-  mapStateToProps,
-  mapDispatchToProps
-);
+const connected = connect(mapStateToProps, mapDispatchToProps);
 
 export default connected(Logout);

--- a/packages/manager/src/store/authentication/authentication.actions.ts
+++ b/packages/manager/src/store/authentication/authentication.actions.ts
@@ -24,4 +24,3 @@ export const handleRefreshTokens = actionCreator('REFRESH_TOKENS');
  * basically just clear local storage and redux state
  */
 export const handleLogout = actionCreator('LOGOUT');
-export const handleExpireTokens = actionCreator('EXPIRE_TOKENS');

--- a/packages/manager/src/store/authentication/authentication.reducer.ts
+++ b/packages/manager/src/store/authentication/authentication.reducer.ts
@@ -2,13 +2,12 @@ import { redirectToLogin } from 'src/session';
 import { authentication } from 'src/utilities/storage';
 import { reducerWithInitialState } from 'typescript-fsa-reducers';
 import {
-  handleExpireTokens,
   handleInitTokens,
   handleLogout,
   handleRefreshTokens,
   handleStartSession
 } from './authentication.actions';
-import { clearLocalStorage, clearUserInput } from './authentication.helpers';
+import { clearLocalStorage } from './authentication.helpers';
 import { State } from './index';
 
 export const defaultState: State = {
@@ -85,22 +84,10 @@ const reducer = reducerWithInitialState(defaultState)
       loggedInAsCustomer: isLoggedInAsCustomer
     };
   })
-  .case(handleExpireTokens, state => {
-    /** clear local storage and redux state - plain and simple */
-    clearLocalStorage();
-    return {
-      ...state,
-      scopes: null,
-      token: null,
-      expiration: null,
-      loggedInAsCustomer: false
-    };
-  })
   .case(handleLogout, state => {
     /** clear local storage and redux state */
     clearLocalStorage();
-    /** since the user is explicitly logging out, clear user input from local storage */
-    clearUserInput();
+
     return {
       ...state,
       scopes: null,


### PR DESCRIPTION
I originally thought that handleLogout was called on manual logout, and
handleExpireTokens was called when a user's tokens had expired. On closer
inspection, I realized that handleExpireTokens was never called at all.

This meant that the original case the localStorage cache of support
tickets was intended to solve wouldn't actually work, since when the
user is redirected to Login the values are cleared. To resolve this,
I deleted the unused refreshTokens action and instead cleared localStorage
from inside the Logout component, which is the actual logic triggered uniquely
when a user clicks the logout button.
