### PR TITLE
More Sentry improvements

### DIFF
--- a/packages/manager/src/exceptionReporting.ts
+++ b/packages/manager/src/exceptionReporting.ts
@@ -7,8 +7,13 @@ initSentry();
 const errorsToIgnore: string[] = [
   'Invalid OAuth Token',
   'Not Found',
-  // Ignore errors from Safari extensions.
-  'safari-extension'
+  'You are not authorized',
+  'safari-extension',
+  'chrome-extension',
+  // We know this is a problem. @todo: implement flow control in Lish.
+  'write data discarded, use flow control to avoid losing data',
+  // This is an error coming from the MUI Ripple effect.
+  'TouchRipple'
 ];
 
 window.addEventListener('unhandledrejection', event => {


### PR DESCRIPTION
## Description

This PR stops reporting a few errors to Sentry:

- Flow Control xterm errors (we know we need to address this, no reason to keep reporting them)
- Safari and Chrome extensions
- MUI touch Ripple error (see discussion here: https://github.com/mui-org/material-ui/issues/16841
