### PR TITLE
M3-4059 [LKE]: Logic clean-up for "Provisioning" view of Detail Summary

### DIFF
--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
@@ -97,6 +97,7 @@ interface Props {
   endpointError?: string;
   endpointLoading: boolean;
   kubeconfigAvailable: boolean;
+  kubeconfigError?: string;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames> & WithSnackbarProps;
@@ -104,15 +105,17 @@ type CombinedProps = Props & WithStyles<ClassNames> & WithSnackbarProps;
 const renderEndpoint = (
   endpoint: string | null,
   endpointLoading: boolean,
-  kubeconfigAvailable: boolean,
   endpointError?: string
 ) => {
-  if (endpointLoading || !kubeconfigAvailable) {
+  if (endpoint) {
+    return endpoint;
+  } else if (endpointLoading) {
     return 'Loading...';
   } else if (endpointError) {
     return endpointError;
+  } else {
+    return 'Your endpoint will be displayed here once it is available.';
   }
-  return endpoint || ''; // Just leave it blank if endpoint === null (which should never happen)
 };
 
 export const KubeSummaryPanel: React.FunctionComponent<CombinedProps> = props => {
@@ -123,7 +126,8 @@ export const KubeSummaryPanel: React.FunctionComponent<CombinedProps> = props =>
     endpointError,
     endpointLoading,
     enqueueSnackbar,
-    kubeconfigAvailable
+    kubeconfigAvailable,
+    kubeconfigError
   } = props;
   const [drawerOpen, setDrawerOpen] = React.useState<boolean>(false);
   const [drawerError, setDrawerError] = React.useState<string | null>(null);
@@ -197,37 +201,21 @@ export const KubeSummaryPanel: React.FunctionComponent<CombinedProps> = props =>
   }; */
 
   const setKubeconfigDisplay = () => {
-    if (!endpoint && kubeconfigAvailable === false) {
-      return (
-        <Grid item className={classes.linksGrid} xs={12} md={6}>
-          <Paper className={classes.item}>
-            <Typography>
-              This cluster is being provisioned. Upon completion, the Kubernetes
-              API Endpoint and Kubeconfig will appear here.
-            </Typography>
-          </Paper>
-        </Grid>
-      );
-    } else {
-      return (
-        <Grid item className={classes.linksGrid} xs={12} md={4}>
-          <Paper className={classes.item}>
-            <Typography className={classes.label}>
-              Kubernetes API Endpoint:
-            </Typography>
-            <Typography>
-              {renderEndpoint(
-                endpoint,
-                endpointLoading,
-                kubeconfigAvailable,
-                endpointError
-              )}
-            </Typography>
-          </Paper>
+    return (
+      <Grid item className={classes.linksGrid} xs={12} md={4}>
+        <Paper className={classes.item}>
+          <Typography className={classes.label}>
+            Kubernetes API Endpoint:
+          </Typography>
+          <Typography>
+            {renderEndpoint(endpoint, endpointLoading, endpointError)}
+          </Typography>
+        </Paper>
 
-          <Paper className={classes.item}>
-            <Typography className={classes.label}>Kubeconfig:</Typography>
+        <Paper className={classes.item}>
+          <Typography className={classes.label}>Kubeconfig:</Typography>
 
+          {kubeconfigAvailable ? (
             <div className={classes.kubeconfigElements}>
               <Typography
                 className={classes.kubeconfigFileText}
@@ -247,10 +235,15 @@ export const KubeSummaryPanel: React.FunctionComponent<CombinedProps> = props =>
                 />
               </div>
             </div>
-          </Paper>
-        </Grid>
-      );
-    }
+          ) : (
+            <Typography>
+              {kubeconfigError ??
+                'Your Kubeconfig will be viewable here once it is available.'}
+            </Typography>
+          )}
+        </Paper>
+      </Grid>
+    );
   };
 
   return (


### PR DESCRIPTION
## Description
This is a follow-up to https://github.com/linode/manager/pull/6272 that does some minor clean-up and addresses two bigger issues:  the brief delay in transition from the "Provisioning" view when a user clicks into an existing cluster, and the unavailability of the Kubeconfig for download although the download links are shown.

- The checks for the availability of the endpoint and kubeconfig were decoupled. This allows for the "Provisioning" view to show only when the endpoint is available, but the kubeconfig is not yet ready. 
- `kubeconfigAvailable` now defaults to true, and is set to false if the `getKubeConfig` request fails. This is to stop the "Provisioning" screen from displaying when a user clicks into an existing cluster.
- The default initial view is now "Loading..." -- when a user first clicks into a cluster or creates a new cluster, that is what they will see first, before the availability of the endpoint and kubeconfig are determined (this takes about a second or less). 
- `kubeconfigAvailabilityCheckWithInterval()` was created to cut down on some code repetition. 

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
