### PR TITLE
set a timeout in getGravatarUrlFromHash

### DIFF
--- a/packages/manager/src/utilities/gravatar.ts
+++ b/packages/manager/src/utilities/gravatar.ts
@@ -7,7 +7,7 @@ export const getEmailHash = (email: string) => {
 
 export const getGravatarUrlFromHash = (hash: string): Promise<string> => {
   const url = `https://gravatar.com/avatar/${hash}?d=404`;
-  const instance = Axios.create();
+  const instance = Axios.create({timeout: 1000});
   return instance
     .get(url)
     .then(response => {


### PR DESCRIPTION
I don't actually know the slow load times for a subset of users are from this request or from the actual loading of the Gravatar image(s), but it seems like this can't hurt