### PR TITLE
Make sure window.paypal is defined before using it (fixes crash)

### DIFF
--- a/packages/manager/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
@@ -189,7 +189,13 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
   };
 
   componentDidUpdate(prevProps: CombinedProps, prevState: State) {
-    if (!prevProps.isScriptLoadSucceed && this.props.isScriptLoadSucceed) {
+    const isPayPalInitialized = (window as any).paypal !== undefined;
+
+    if (
+      !prevProps.isScriptLoadSucceed &&
+      this.props.isScriptLoadSucceed &&
+      isPayPalInitialized
+    ) {
       /*
        * Because the paypal script is now loaded, so now we have access to this React component
        * in the window element. This will be used in the render method.
@@ -345,7 +351,7 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
    *
    * @param data - information that Paypal returns to then send to
    * /account/payment/paypal/execute
-   * @param actions - handers to do more things. Optional argument that we
+   * @param actions - handlers to do more things. Optional argument that we
    * don't really need
    *
    * See documentation:
@@ -362,7 +368,7 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
    * the order_id that we get from APIv4. It is imperative that this step happens before
    * we make the call to v4/execute.
    *
-   * It is also impertive that this function returns the checkout_id returned from APIv4.
+   * It is also imperative that this function returns the checkout_id returned from APIv4.
    * checkout_id is the same thing as order_id
    */
   createOrder = () => {

--- a/packages/manager/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
@@ -189,7 +189,7 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
   };
 
   componentDidUpdate(prevProps: CombinedProps, prevState: State) {
-    const isPayPalInitialized = (window as any).paypal !== undefined;
+    const isPayPalInitialized = window.hasOwnProperty('paypal');
 
     if (
       !prevProps.isScriptLoadSucceed &&


### PR DESCRIPTION
## Description

This in theory fixes a unreproducible bug in which loading the PayPal script fails, but `react-async-script-loader` thinks it was loaded successfully. If that happens, the app will crash because we try to use `window.paypal`, which is `undefined` unless the actual PayPal script is loaded correctly.

We've heard a report of this happening, and I believe it had to do with blocked pages in the user's network configuration. In this case, the PayPal script was routed through a filter, which returned a 200 but without the correct content.

With this fix, if something like the above happens, PayPal will simply not appear as a payment option (instead of the app crashing). This is already what happens is PayPal isn't loaded correctly, i.e. we have no true error for this (maybe should address later).

## Note to Reviewers

I tested this in latest Chrome, FireFox, Safari, and Edge. To simulate a successful script load without PayPal being initialized, change the script in L163 (something real, like [Bootstrap](https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css)).
