### PR TITLE
Adjust events polling filter to handle edge case

### DIFF
--- a/packages/manager/src/utilities/requestFilters.test.ts
+++ b/packages/manager/src/utilities/requestFilters.test.ts
@@ -1,19 +1,78 @@
-import { generateInFilter, generatePollingFilter } from './requestFilters';
+import {
+  generateInFilter,
+  generateNeqFilter,
+  generatePollingFilter
+} from './requestFilters';
 
 describe('requestFilters', () => {
   describe('generateInFilter', () => {
     it('generates a filter from an array of values', () => {
-      const res = generateInFilter('id', [12, 21, 32]);
-      expect(res).toEqual({
-        '+or': [{ id: 12 }, { id: 21 }, { id: 32 }]
-      });
+      const result = generateInFilter('id', [1, 2, 3]);
+      expect(result).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
+    });
+  });
+
+  describe('generateNeqFilter', () => {
+    it('generates +neq filter from key and array of values', () => {
+      const result = generateNeqFilter('id', [1, 2, 3]);
+      expect(result).toEqual([
+        { id: { '+neq': 1 } },
+        { id: { '+neq': 2 } },
+        { id: { '+neq': 3 } }
+      ]);
     });
   });
 
   describe('generatePollingFilter', () => {
+    const timestamp = '2020-01-01T00:00:00';
+
     it('generates a simple filter when pollIDs is empty', () => {
-      const res = generatePollingFilter('1970-01-01T00:00:00', []);
-      expect(res).toEqual({ created: { '+gte': '1970-01-01T00:00:00' } });
+      const result = generatePollingFilter(timestamp, []);
+      expect(result).toEqual({ created: { '+gte': timestamp } });
+    });
+
+    it('handles "in" IDs', () => {
+      const inIds = [1, 2, 3];
+      const result = generatePollingFilter(timestamp, inIds);
+      expect(result).toEqual({
+        '+or': [
+          { created: { '+gte': timestamp } },
+          { id: 1 },
+          { id: 2 },
+          { id: 3 }
+        ]
+      });
+    });
+
+    it('handles "+neq" IDs', () => {
+      const result = generatePollingFilter(timestamp, [], [1, 2, 3]);
+      expect(result).toEqual({
+        '+and': [
+          { created: { '+gte': timestamp } },
+          { id: { '+neq': 1 } },
+          { id: { '+neq': 2 } },
+          { id: { '+neq': 3 } }
+        ]
+      });
+    });
+
+    it('handles "in" and "+neq" IDs together', () => {
+      const result = generatePollingFilter(timestamp, [1, 2, 3], [4, 5, 6]);
+      expect(result).toEqual({
+        '+or': [
+          {
+            '+and': [
+              { created: { '+gte': timestamp } },
+              { id: { '+neq': 4 } },
+              { id: { '+neq': 5 } },
+              { id: { '+neq': 6 } }
+            ]
+          },
+          { id: 1 },
+          { id: 2 },
+          { id: 3 }
+        ]
+      });
     });
   });
 });

--- a/packages/manager/src/utilities/requestFilters.test.ts
+++ b/packages/manager/src/utilities/requestFilters.test.ts
@@ -13,7 +13,7 @@ describe('requestFilters', () => {
   describe('generatePollingFilter', () => {
     it('generates a simple filter when pollIDs is empty', () => {
       const res = generatePollingFilter('1970-01-01T00:00:00', []);
-      expect(res).toEqual({ created: { '+gt': '1970-01-01T00:00:00' } });
+      expect(res).toEqual({ created: { '+gte': '1970-01-01T00:00:00' } });
     });
   });
 });

--- a/packages/manager/src/utilities/requestFilters.ts
+++ b/packages/manager/src/utilities/requestFilters.ts
@@ -12,20 +12,21 @@ export const generateInFilter = (keyName: string, arr: any[]) => {
 };
 
 /**
- * Generates a filter for API reqeusts;
+ * Generates a filter for API requests;
  * If we have IDs:
- *  "If `created` is greater than the datestamp provided or the `id` is one of ids."
+ *  "If `created` is greater than the timestamp provided or the `id` is one of ids."
  * or:
- *   "If `created` is greater than the datestamp provided."
+ *   "If `created` is greater than the timestamp provided."
  *
  * This filter is invoked on every events request to only get the latest or in-progress events.
  */
-export const generatePollingFilter = (datestamp: string, ids: string[]) => {
+export const generatePollingFilter = (timestamp: string, ids: string[]) => {
+  // @todo: Add check to NOT request events already in store (by ID).
   return ids.length
     ? {
-        '+or': [{ created: { '+gt': datestamp } }, generateInFilter('id', ids)]
+        '+or': [{ created: { '+gte': timestamp } }, generateInFilter('id', ids)]
       }
     : {
-        created: { '+gt': datestamp }
+        created: { '+gte': timestamp }
       };
 };


### PR DESCRIPTION
## Description

### The problem:
In the new LKE Node Pool display, I noticed that after creating a new cluster the Node Rows weren’t always updated with the Linode’s status once provisioned. A few of the nodes might be displayed as "Powered off", even though the Linodes were running.

### The cause:
After studying the polled requests to `/events` during this sequence, I realized this was happening because _we weren't receiving all events from the API_. And if we don’t receive a completed `linode_boot` event, for example, we don’t update the Linode’s status. 

**So why aren’t we receiving all events from the API?** A little context on how we poll `/events`...

When we receive a batch of events, we find the most recent `created` time. We use that timestamp in a filter like this: 

```
{ "created": { "+gt": <mostRecentCreatedTime> } }
```
This means we won’t receive any events **created on or before the most recent created time**. If there are events still in progress, we add an "+or" clause, like this:

```
{
  "+or": [
    { "created": { "+gt": <mostRecentCreatedTime> } },
    { "+or": [{ "id":<inProgressEventId> }] }
  ]
}
``` 

This approach works fine for most cases. But as it turns out, **there is a potential dead zone.**

Consider the case where there are four events with the same `created` time (let’s say `2020-04-08T12:00:00`). It turns out, this is likely with something like LKE cluster provisioning.

If the request/query lands at _just the right time_, you may only see the first 3 of these events. Since subsequent `/events` requests have a filter on `created` being greater than `2020-04-08T12:00:00`, we’ll never see the 4th event! (unless the app is refreshed). **This means the UI might not update appropriately.**

### My solution:
To solve this, I’ve changed the "+gt" filter to "+gte". Any (non-in-progress) events created at the mostRecentCreated time will be excluded via "+neq" filter.

### Bottom line:
Instead of polling `/events` with a filter like this:

```
{ "created": { "+gt": <mostRecentCreatedTime> } }
```

We poll with a filter that looks like this:

```
{
  "+and": [
    { "created": { "+gte": <mostRecentEventTime> } },
    { "id": { "+neq": <mostRecentEventId> } }
  ]
}
```

Check the new test cases for variations for in-progress events.


## Note to Reviewers

Most of the app should function like before. 

To see the bug that started this thing, provision a new LKE cluster with at least 6 nodes. You may have to do it a few times before you see the bug.
