### PR TITLE
LKE Fix: Create cluster bug

### DIFF
--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -19,7 +19,7 @@ import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import RegionSelect from 'src/components/EnhancedSelect/variants/RegionSelect';
 import ErrorState from 'src/components/ErrorState';
-// import Notice from 'src/components/Notice';
+import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
 import { dcDisplayNames } from 'src/constants';
 import regionsContainer from 'src/containers/regions.container';
@@ -289,6 +289,7 @@ export const CreateCluster: React.FC<CombinedProps> = props => {
 
         <Grid item className={`mlMain py0`}>
           <div className={classes.main}>
+            {errorMap.none && <Notice error text={errorMap.none} />}
             <Paper data-qa-label-header>
               <div className={classes.inner}>
                 <Grid item>
@@ -374,11 +375,12 @@ export const CreateCluster: React.FC<CombinedProps> = props => {
             removePool={removePool}
             typesData={typesData || []}
             updateFor={[
-              label,
-              selectedRegion,
               nodePools,
               submitting,
               typesData,
+              updatePool,
+              removePool,
+              createCluster,
               classes
             ]}
           />


### PR DESCRIPTION
## Description

- Added a Notice to display errorMap.none (general error)
- Adjusted the updateFor dependencies in the checkout bar. This
fixes a bug introduced by the conversion to an FC. The functions
are no longer instance methods, so they change to reflect current
component state. Since the checkoutBar wasn't listening for changes
to these functions, when submitted older versions of the functions
were called with old state.

Example:

1. Fill in Region and Version but don't add node pools
2. Submit the form
3. Observe: field errors are displayed for both version and node pools,
even though version is correct.

I considered removing renderGuard from the components in this form,
but that actually slows down the form significantly. I think the ideal
thing is a bunch of React.memo and React.useCallback, but that can wait.

