### PR TITLE
Don't run unit tests pre-push

### DIFF
--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -94,7 +94,7 @@
     "lint": "tslint 'src/**/*.ts' 'src/**/*.tsx'",
     "build": "node scripts/build.js",
     "precommit": "lint-staged && tsc --noEmit",
-    "prepush": "./scripts/pre-push.sh && yarn test --color",
+    "prepush": "./scripts/pre-push.sh",
     "mock": "./scripts/mb.js",
     "test": "jest --color",
     "test:debug": "node --inspect-brk scripts/test.js --runInBand",


### PR DESCRIPTION
Tests are run on Travis builds (and/or in Baker), we can rely on that instead. Devs can also run the tests locally before pushing if they have doubts.