### PR TITLE
[LKE] Node Table action menu

### DIFF
--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeActionMenu.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeActionMenu.tsx
@@ -4,22 +4,22 @@ import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
 interface Props {
   instanceId?: number;
   instanceLabel?: string;
-  openDeleteNodeDialog: (linodeId: number, linodeLabel: string) => void;
+  openRecycleNodeDialog: (linodeId: number, linodeLabel: string) => void;
 }
 
 export const NodeActionMenu: React.FC<Props> = props => {
-  const { instanceId, instanceLabel, openDeleteNodeDialog } = props;
+  const { instanceId, instanceLabel, openRecycleNodeDialog } = props;
 
   const createActions = () => {
     return (closeMenu: Function): Action[] => {
       const actions = [
         {
-          title: 'Delete',
+          title: 'Recycle',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             if (!instanceId || !instanceLabel) {
               return;
             }
-            openDeleteNodeDialog(instanceId!, instanceLabel!);
+            openRecycleNodeDialog(instanceId!, instanceLabel!);
             closeMenu();
             e.preventDefault();
           },

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeActionMenu.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeActionMenu.tsx
@@ -16,8 +16,10 @@ export const NodeActionMenu: React.FC<Props> = props => {
         {
           title: 'Delete',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
-            // Defaults for TS, but this option will be disabled anyway in that case.
-            openDeleteNodeDialog(instanceId ?? 0, instanceLabel ?? '');
+            if (!instanceId || !instanceLabel) {
+              return;
+            }
+            openDeleteNodeDialog(instanceId!, instanceLabel!);
             closeMenu();
             e.preventDefault();
           },

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeActionMenu.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeActionMenu.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
+
+interface Props {
+  instanceId?: number;
+  instanceLabel?: string;
+  openDeleteNodeDialog: (linodeId: number, linodeLabel: string) => void;
+}
+
+export const NodeActionMenu: React.FC<Props> = props => {
+  const { instanceId, instanceLabel, openDeleteNodeDialog } = props;
+
+  const createActions = () => {
+    return (closeMenu: Function): Action[] => {
+      const actions = [
+        {
+          title: 'Delete',
+          onClick: (e: React.MouseEvent<HTMLElement>) => {
+            // Defaults for TS, but this option will be disabled anyway in that case.
+            openDeleteNodeDialog(instanceId ?? 0, instanceLabel ?? '');
+            closeMenu();
+            e.preventDefault();
+          },
+          disabled: !instanceId || !instanceLabel
+        }
+      ];
+
+      return actions;
+    };
+  };
+
+  return (
+    <ActionMenu
+      createActions={createActions()}
+      ariaLabel={`Action menu for Node ${instanceLabel}`}
+    />
+  );
+};
+
+export default React.memo(NodeActionMenu);

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeDialog.tsx
@@ -37,7 +37,7 @@ const renderActions = (
         data-qa-confirm
         data-testid={'dialog-confirm'}
       >
-        Delete
+        Recycle
       </Button>
     </ActionsPanel>
   );
@@ -49,16 +49,14 @@ const NodeDialog: React.FC<Props> = props => {
   return (
     <ConfirmationDialog
       open={open}
-      title={`Are you sure you want to delete ${
-        label ? label : 'this Linode'
-      }?`}
+      title={`Recycle ${label ? label : 'this Node'}?`}
       onClose={onClose}
       actions={() => renderActions(loading, onClose, onDelete)}
     >
       {error && <Notice error text={error} />}
       <Typography>
-        Are you sure you want to delete your Linode? This will result in
-        permanent data loss.
+        Are you sure you want to recycle this Node? The Linode will be deleted
+        and all data lost. A new Linode we be recreated to take its place.
       </Typography>
     </ConfirmationDialog>
   );

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeDialog.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
+import ConfirmationDialog from 'src/components/ConfirmationDialog';
+import Typography from 'src/components/core/Typography';
+import Notice from 'src/components/Notice';
+
+interface Props {
+  open: boolean;
+  loading: boolean;
+  error?: string;
+  onClose: () => void;
+  onDelete: () => void;
+  label?: string;
+}
+
+const renderActions = (
+  loading: boolean,
+  onClose: () => void,
+  onDelete: () => void
+) => {
+  return (
+    <ActionsPanel style={{ padding: 0 }}>
+      <Button
+        buttonType="cancel"
+        onClick={onClose}
+        data-qa-cancel
+        data-testid={'dialog-cancel'}
+      >
+        Cancel
+      </Button>
+      <Button
+        buttonType="secondary"
+        destructive
+        loading={loading}
+        onClick={onDelete}
+        data-qa-confirm
+        data-testid={'dialog-confirm'}
+      >
+        Delete
+      </Button>
+    </ActionsPanel>
+  );
+};
+
+const NodeDialog: React.FC<Props> = props => {
+  const { error, loading, open, onClose, onDelete, label } = props;
+
+  return (
+    <ConfirmationDialog
+      open={open}
+      title={`Are you sure you want to delete ${label}?`}
+      onClose={onClose}
+      actions={() => renderActions(loading, onClose, onDelete)}
+    >
+      {error && <Notice error text={error} />}
+      <Typography>
+        Are you sure you want to delete your Linode? This will result in
+        permanent data loss.
+      </Typography>
+    </ConfirmationDialog>
+  );
+};
+
+export default React.memo(NodeDialog);

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeDialog.tsx
@@ -49,7 +49,9 @@ const NodeDialog: React.FC<Props> = props => {
   return (
     <ConfirmationDialog
       open={open}
-      title={`Are you sure you want to delete ${label}?`}
+      title={`Are you sure you want to delete ${
+        label ? label : 'this Linode'
+      }?`}
       onClose={onClose}
       actions={() => renderActions(loading, onClose, onDelete)}
     >

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeDialog.tsx
@@ -56,7 +56,8 @@ const NodeDialog: React.FC<Props> = props => {
       {error && <Notice error text={error} />}
       <Typography>
         Are you sure you want to recycle this Node? The Linode will be deleted
-        and all data lost. A new Linode we be recreated to take its place.
+        and its data will be lost. A new Linode we be created to take its place.
+        It may take up to 30 minutes for the recycled Node to come back online.
       </Typography>
     </ConfirmationDialog>
   );

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
@@ -41,7 +41,7 @@ interface Props {
   typeLabel: string;
   nodes: PoolNodeResponse[];
   openDeletePoolDialog: (poolId: number) => void;
-  openDeleteNodeDialog: (linodeId: number, linodeLabel: string) => void;
+  openRecycleNodeDialog: (linodeId: number, linodeLabel: string) => void;
   handleClickResize: (poolId: number) => void;
   // Not yet supported by the API:
   // recycleNodes: (poolId: number) => void;
@@ -51,7 +51,7 @@ const NodePool: React.FC<Props> = props => {
   const {
     handleClickResize,
     openDeletePoolDialog,
-    openDeleteNodeDialog,
+    openRecycleNodeDialog,
     nodes,
     typeLabel,
     poolId
@@ -92,7 +92,7 @@ const NodePool: React.FC<Props> = props => {
           poolId={poolId}
           nodes={nodes}
           typeLabel={typeLabel}
-          openDeleteNodeDialog={openDeleteNodeDialog}
+          openRecycleNodeDialog={openRecycleNodeDialog}
         />
       </div>
     </>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
@@ -40,7 +40,7 @@ interface Props {
   poolId: number;
   typeLabel: string;
   nodes: PoolNodeResponse[];
-  openDeleteDialog: (poolId: number) => void;
+  openDeletePoolDialog: (poolId: number) => void;
   openDeleteNodeDialog: (linodeId: number, linodeLabel: string) => void;
   handleClickResize: (poolId: number) => void;
   // Not yet supported by the API:
@@ -50,7 +50,7 @@ interface Props {
 const NodePool: React.FC<Props> = props => {
   const {
     handleClickResize,
-    openDeleteDialog,
+    openDeletePoolDialog,
     openDeleteNodeDialog,
     nodes,
     typeLabel,
@@ -82,7 +82,7 @@ const NodePool: React.FC<Props> = props => {
             text="Delete Pool"
             SideIcon={Collapse}
             title="Delete Pool"
-            onClick={() => openDeleteDialog(poolId)}
+            onClick={() => openDeletePoolDialog(poolId)}
             className={classes.icon}
           />
         </div>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
@@ -41,6 +41,7 @@ interface Props {
   typeLabel: string;
   nodes: PoolNodeResponse[];
   openDeleteDialog: (poolId: number) => void;
+  openDeleteNodeDialog: (linodeId: number, linodeLabel: string) => void;
   handleClickResize: (poolId: number) => void;
   // Not yet supported by the API:
   // recycleNodes: (poolId: number) => void;
@@ -50,6 +51,7 @@ const NodePool: React.FC<Props> = props => {
   const {
     handleClickResize,
     openDeleteDialog,
+    openDeleteNodeDialog,
     nodes,
     typeLabel,
     poolId
@@ -86,7 +88,12 @@ const NodePool: React.FC<Props> = props => {
         </div>
       </div>
       <div className={classes.nodeTable}>
-        <NodeTable poolId={poolId} nodes={nodes} typeLabel={typeLabel} />
+        <NodeTable
+          poolId={poolId}
+          nodes={nodes}
+          typeLabel={typeLabel}
+          openDeleteNodeDialog={openDeleteNodeDialog}
+        />
       </div>
     </>
   );

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -61,7 +61,7 @@ export const NodePoolsDisplay: React.FC<Props> = props => {
   const { deleteLinode } = useLinodes();
 
   const deletePoolDialog = useDialog<number>(deletePool);
-  const deleteNodeDialog = useDialog<number>(deleteLinode);
+  const recycleNodeDialog = useDialog<number>(deleteLinode);
 
   const [drawerOpen, setDrawerOpen] = React.useState<boolean>(false);
   const [drawerSubmitting, setDrawerSubmitting] = React.useState<boolean>(
@@ -111,7 +111,7 @@ export const NodePoolsDisplay: React.FC<Props> = props => {
   };
 
   const handleDeleteNode = () => {
-    const { dialog, submitDialog, handleError } = deleteNodeDialog;
+    const { dialog, submitDialog, handleError } = recycleNodeDialog;
     if (!dialog.entityID) {
       return;
     }
@@ -169,7 +169,7 @@ export const NodePoolsDisplay: React.FC<Props> = props => {
                       nodes={nodes ?? []}
                       handleClickResize={handleOpenResizeDrawer}
                       openDeletePoolDialog={deletePoolDialog.openDialog}
-                      openDeleteNodeDialog={deleteNodeDialog.openDialog}
+                      openRecycleNodeDialog={recycleNodeDialog.openDialog}
                     />
                   </div>
                 );
@@ -197,11 +197,11 @@ export const NodePoolsDisplay: React.FC<Props> = props => {
             />
             <NodeDialog
               onDelete={handleDeleteNode}
-              onClose={deleteNodeDialog.closeDialog}
-              open={deleteNodeDialog.dialog.isOpen}
-              error={deleteNodeDialog.dialog.error}
-              loading={deleteNodeDialog.dialog.isLoading}
-              label={deleteNodeDialog.dialog.entityLabel}
+              onClose={recycleNodeDialog.closeDialog}
+              open={recycleNodeDialog.dialog.isOpen}
+              error={recycleNodeDialog.dialog.error}
+              loading={recycleNodeDialog.dialog.isLoading}
+              label={recycleNodeDialog.dialog.entityLabel}
             />
           </Grid>
         )}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -112,7 +112,7 @@ export const NodePoolsDisplay: React.FC<Props> = props => {
 
   const handleDeleteNode = () => {
     const { dialog, submitDialog, handleError } = deleteNodeDialog;
-    if (!deleteNodeDialog.dialog.entityID) {
+    if (!dialog.entityID) {
       return;
     }
     submitDialog(dialog.entityID).catch(err => {
@@ -168,7 +168,7 @@ export const NodePoolsDisplay: React.FC<Props> = props => {
                       typeLabel={typeLabel}
                       nodes={nodes ?? []}
                       handleClickResize={handleOpenResizeDrawer}
-                      openDeleteDialog={deletePoolDialog.openDialog}
+                      openDeletePoolDialog={deletePoolDialog.openDialog}
                       openDeleteNodeDialog={deleteNodeDialog.openDialog}
                     />
                   </div>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.test.tsx
@@ -23,7 +23,8 @@ request.getLinodes = jest.fn().mockResolvedValue({
 const props: Props = {
   nodes: mockKubeNodes,
   poolId: 1,
-  typeLabel: 'Linode 2G'
+  typeLabel: 'Linode 2G',
+  openDeleteNodeDialog: jest.fn()
 };
 
 describe('NodeTable', () => {

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.test.tsx
@@ -24,7 +24,7 @@ const props: Props = {
   nodes: mockKubeNodes,
   poolId: 1,
   typeLabel: 'Linode 2G',
-  openDeleteNodeDialog: jest.fn()
+  openRecycleNodeDialog: jest.fn()
 };
 
 describe('NodeTable', () => {

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
@@ -22,6 +22,7 @@ import useLinodes from 'src/hooks/useLinodes';
 import { useReduxLoad } from 'src/hooks/useReduxLoad';
 import { LinodeWithMaintenanceAndDisplayStatus } from 'src/store/linodes/types';
 import { useRecentEventForLinode } from 'src/store/selectors/recentEventForLinode';
+import NodeActionMenu from './NodeActionMenu';
 
 const useStyles = makeStyles((theme: Theme) => ({
   labelCell: {
@@ -45,10 +46,11 @@ export interface Props {
   poolId: number;
   nodes: PoolNodeResponse[];
   typeLabel: string;
+  openDeleteNodeDialog: (linodeId: number, linodeLabel: string) => void;
 }
 
 export const NodeTable: React.FC<Props> = props => {
-  const { nodes, poolId, typeLabel } = props;
+  const { nodes, poolId, typeLabel, openDeleteNodeDialog } = props;
 
   const classes = useStyles();
 
@@ -127,6 +129,7 @@ export const NodeTable: React.FC<Props> = props => {
                               nodeStatus={eachRow.nodeStatus}
                               typeLabel={typeLabel}
                               linodeError={linodes.error?.read}
+                              openDeleteNodeDialog={openDeleteNodeDialog}
                             />
                           );
                         })}
@@ -175,6 +178,7 @@ interface NodeRow {
 type NodeRowProps = Omit<NodeRow, 'nodeId'> & {
   typeLabel: string;
   linodeError?: APIError[];
+  openDeleteNodeDialog: (linodeId: number, linodeLabel: string) => void;
 };
 
 export const NodeRow: React.FC<NodeRowProps> = React.memo(props => {
@@ -185,7 +189,8 @@ export const NodeRow: React.FC<NodeRowProps> = React.memo(props => {
     ip,
     typeLabel,
     nodeStatus,
-    linodeError
+    linodeError,
+    openDeleteNodeDialog
   } = props;
 
   const classes = useStyles();
@@ -232,6 +237,11 @@ export const NodeRow: React.FC<NodeRowProps> = React.memo(props => {
         )}
       </TableCell>
       <TableCell>
+        <NodeActionMenu
+          instanceId={instanceId}
+          instanceLabel={label}
+          openDeleteNodeDialog={openDeleteNodeDialog}
+        />
         {/* @todo: action menu */}
         {/* <ActionMenu/> */}
       </TableCell>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
@@ -46,11 +46,11 @@ export interface Props {
   poolId: number;
   nodes: PoolNodeResponse[];
   typeLabel: string;
-  openDeleteNodeDialog: (linodeId: number, linodeLabel: string) => void;
+  openRecycleNodeDialog: (linodeId: number, linodeLabel: string) => void;
 }
 
 export const NodeTable: React.FC<Props> = props => {
-  const { nodes, poolId, typeLabel, openDeleteNodeDialog } = props;
+  const { nodes, poolId, typeLabel, openRecycleNodeDialog } = props;
 
   const classes = useStyles();
 
@@ -129,7 +129,7 @@ export const NodeTable: React.FC<Props> = props => {
                               nodeStatus={eachRow.nodeStatus}
                               typeLabel={typeLabel}
                               linodeError={linodes.error?.read}
-                              openDeleteNodeDialog={openDeleteNodeDialog}
+                              openRecycleNodeDialog={openRecycleNodeDialog}
                             />
                           );
                         })}
@@ -178,7 +178,7 @@ interface NodeRow {
 type NodeRowProps = Omit<NodeRow, 'nodeId'> & {
   typeLabel: string;
   linodeError?: APIError[];
-  openDeleteNodeDialog: (linodeId: number, linodeLabel: string) => void;
+  openRecycleNodeDialog: (linodeId: number, linodeLabel: string) => void;
 };
 
 export const NodeRow: React.FC<NodeRowProps> = React.memo(props => {
@@ -190,7 +190,7 @@ export const NodeRow: React.FC<NodeRowProps> = React.memo(props => {
     typeLabel,
     nodeStatus,
     linodeError,
-    openDeleteNodeDialog
+    openRecycleNodeDialog
   } = props;
 
   const classes = useStyles();
@@ -240,7 +240,7 @@ export const NodeRow: React.FC<NodeRowProps> = React.memo(props => {
         <NodeActionMenu
           instanceId={instanceId}
           instanceLabel={label}
-          openDeleteNodeDialog={openDeleteNodeDialog}
+          openRecycleNodeDialog={openRecycleNodeDialog}
         />
         {/* @todo: action menu */}
         {/* <ActionMenu/> */}

--- a/packages/manager/src/hooks/useLinodes.ts
+++ b/packages/manager/src/hooks/useLinodes.ts
@@ -1,24 +1,33 @@
 import { Linode } from 'linode-js-sdk/lib/linodes/types';
 import { useDispatch, useSelector } from 'react-redux';
 import { ApplicationState } from 'src/store';
-import { requestLinodes as _requestLinodes } from 'src/store/linodes/linode.requests';
+import {
+  deleteLinode as _deleteLinode,
+  requestLinodes as _requestLinodes
+} from 'src/store/linodes/linode.requests';
 import { State } from 'src/store/linodes/linodes.reducer';
 import { Dispatch } from './types';
 
 export interface LinodesProps {
   linodes: State;
   requestLinodes: () => Promise<Linode[]>;
+  deleteLinode: (linodeId: number) => Promise<{}>;
 }
 
 export const useLinodes = (): LinodesProps => {
   const dispatch: Dispatch = useDispatch();
+
   const linodes = useSelector(
     (state: ApplicationState) => state.__resources.linodes
   );
+
   const requestLinodes = () =>
     dispatch(_requestLinodes({})).then(response => response.data);
 
-  return { linodes, requestLinodes };
+  const deleteLinode = (linodeId: number) =>
+    dispatch(_deleteLinode({ linodeId }));
+
+  return { linodes, requestLinodes, deleteLinode };
 };
 
 export default useLinodes;


### PR DESCRIPTION
## Description

This PR adds the Action Menu for the Node table, with a "Delete" action.

- Add "deleteLinode" to the `useLinodes` hook. 
- Rename the existing pool deletion dialog to `deletePoolDialog`.
- Add new dialog for node deletion called `deleteNodeDialog`.

I thought about using the existing `<DeleteDialog />` component (used for Linodes), but I wanted to keep the pattern consistent with the other deletion dialog (for Node Pools). Plus, it's possible we'll want to change the messaging of this dialog (but for now I reused the text from `<DeleteDialog />`

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Try deleting some nodes on an LKE cluster. Success/Failure/Loading states should all work correctly.
