### PR TITLE
Hotfix: Change version to k8s_version

### DIFF
--- a/packages/linode-js-sdk/src/kubernetes/kubernetes.schema.ts
+++ b/packages/linode-js-sdk/src/kubernetes/kubernetes.schema.ts
@@ -21,7 +21,7 @@ export const clusterLabelSchema = string()
 export const createKubeClusterSchema = object().shape({
   label: clusterLabelSchema,
   region: string().required('Region is required.'),
-  version: string().required('Kubernetes version is required.'),
+  k8s_version: string().required('Kubernetes version is required.'),
   node_pools: array()
     .of(nodePoolSchema)
     .min(1, 'Please add at least one node pool.')

--- a/packages/linode-js-sdk/src/kubernetes/types.ts
+++ b/packages/linode-js-sdk/src/kubernetes/types.ts
@@ -3,7 +3,7 @@ export interface KubernetesCluster {
   region: string;
   status: string; // @todo enum this
   label: string;
-  version: string;
+  k8s_version: string;
   id: number;
 }
 
@@ -41,5 +41,5 @@ export interface CreateKubeClusterPayload {
   label?: string; // Label will be assigned by the API if not provided
   region?: string; // Will be caught by Yup if undefined
   node_pools: PoolNodeRequest[];
-  version?: string; // Will be caught by Yup if undefined
+  k8s_version?: string; // Will be caught by Yup if undefined
 }

--- a/packages/manager/src/__data__/kubernetes.ts
+++ b/packages/manager/src/__data__/kubernetes.ts
@@ -8,7 +8,7 @@ export const clusters: KubernetesCluster[] = [
     created: '2019-04-29 18:02:17',
     id: 35,
     status: 'running',
-    version: '1.13.5'
+    k8s_version: '1.13.5'
   },
   {
     region: 'us-central',
@@ -16,7 +16,7 @@ export const clusters: KubernetesCluster[] = [
     created: '2019-04-29 18:02:17',
     id: 34,
     status: 'running',
-    version: '1.13.5'
+    k8s_version: '1.13.5'
   }
 ];
 

--- a/packages/manager/src/factories/kubernetesCluster.ts
+++ b/packages/manager/src/factories/kubernetesCluster.ts
@@ -53,7 +53,7 @@ export const kubernetesClusterFactory = Factory.Sync.makeFactory<
   region: 'us-central',
   status: 'ready',
   label: Factory.each(i => `test-cluster-${i}`),
-  version: '1.17',
+  k8s_version: '1.17',
   node_pools: nodePoolFactory.buildList(2),
   totalMemory: 1000,
   totalCPU: 4

--- a/packages/manager/src/features/Kubernetes/ClusterList/ClusterList.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/ClusterList.tsx
@@ -178,8 +178,8 @@ export const ClusterList: React.FunctionComponent<CombinedProps> = props => {
                           Cluster Label
                         </TableSortCell>
                         <TableSortCell
-                          active={orderBy === 'version'}
-                          label={'version'}
+                          active={orderBy === 'k8s_version'}
+                          label={'k8s_version'}
                           direction={order}
                           handleClick={handleOrderChange}
                           data-qa-kubernetes-clusters-version-header

--- a/packages/manager/src/features/Kubernetes/ClusterList/ClusterRow.test.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/ClusterRow.test.tsx
@@ -32,7 +32,7 @@ describe('ClusterRow component', () => {
 
   it('should render the cluster version', () => {
     const version = component.find('[data-qa-cluster-version]');
-    expect(version.contains(extendedClusters[0].version)).toBeTruthy();
+    expect(version.contains(extendedClusters[0].k8s_version)).toBeTruthy();
   });
 
   it('should render the cluster label', () => {

--- a/packages/manager/src/features/Kubernetes/ClusterList/ClusterRow.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/ClusterRow.tsx
@@ -72,7 +72,7 @@ export const ClusterRow: React.FunctionComponent<CombinedProps> = props => {
         </Grid>
       </TableCell>
       <TableCell parentColumn="Version" data-qa-cluster-version>
-        {cluster.version}
+        {cluster.k8s_version}
       </TableCell>
       <TableCell parentColumn="Created" data-qa-cluster-date>
         <DateTimeDisplay value={cluster.created} humanizeCutoff="month" />

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -137,7 +137,7 @@ export class CreateCluster extends React.Component<CombinedProps, State> {
       submitting: true
     });
 
-    const _version = version ? version.value : undefined;
+    const k8s_version = version ? version.value : undefined;
 
     /**
      * We need to remove the monthly price, which is used for client-side
@@ -150,7 +150,7 @@ export class CreateCluster extends React.Component<CombinedProps, State> {
       region: selectedRegion,
       node_pools,
       label,
-      version: _version
+      k8s_version
     };
 
     createKubernetesCluster(payload)

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -227,7 +227,7 @@ export class CreateCluster extends React.Component<CombinedProps, State> {
     } = this.state;
 
     const errorMap = getErrorMap(
-      ['region', 'node_pools', 'label', 'version', 'versionLoad'],
+      ['region', 'node_pools', 'label', 'k8s_version', 'versionLoad'],
       errors
     );
 
@@ -329,7 +329,7 @@ export class CreateCluster extends React.Component<CombinedProps, State> {
                 <Select
                   label="Version"
                   value={version || null}
-                  errorText={errorMap.version}
+                  errorText={errorMap.k8s_version}
                   options={versionOptions}
                   placeholder={'Select a Kubernetes version'}
                   onChange={(selected: Item<string>) =>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
@@ -54,9 +54,7 @@ const renderEndpoint = (
   return endpoint || ''; // Just leave it blank if endpoint === null (which should never happen)
 };
 
-export const KubeSummaryPanel: React.FunctionComponent<
-  CombinedProps
-> = props => {
+export const KubeSummaryPanel: React.FunctionComponent<CombinedProps> = props => {
   const { classes, cluster, endpoint, endpointError, endpointLoading } = props;
   const region = dcDisplayNames[cluster.region] || 'Unknown region';
   return (
@@ -66,7 +64,7 @@ export const KubeSummaryPanel: React.FunctionComponent<
       </Paper>
       <Paper className={classes.item}>
         <Typography className={classes.label}>Version</Typography>
-        <Typography>{cluster.version}</Typography>
+        <Typography>{cluster.k8s_version}</Typography>
       </Paper>
       <Paper className={classes.item}>
         <Typography className={classes.label}>Total RAM</Typography>
@@ -100,9 +98,6 @@ export const KubeSummaryPanel: React.FunctionComponent<
 
 const styled = withStyles(styles);
 
-const enhanced = compose<CombinedProps, Props>(
-  React.memo,
-  styled
-);
+const enhanced = compose<CombinedProps, Props>(React.memo, styled);
 
 export default enhanced(KubeSummaryPanel);


### PR DESCRIPTION
The API is changing the Kubernetes cluster schema such that version is now
k8s_version. This will break our creation flow and display unless we make
a matching change.
