### PR TITLE
LKE Details & Add New Menu z-index issue

### DIFF
--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -226,18 +226,20 @@ export const KubernetesClusterDetail: React.FunctionComponent<CombinedProps> = p
             data-qa-breadcrumb
           />
         </Grid>
-        <AppBar position="static" color="default" role="tablist">
-          <Tabs
-            value={0}
-            indicatorColor="primary"
-            textColor="primary"
-            variant="scrollable"
-            scrollButtons="on"
-            className={classes.tabBar}
-          >
-            <Tab key="Summary" label="Summary" data-qa-tab="Summary" />}
-          </Tabs>
-        </AppBar>
+        <Grid item xs={12}>
+          <AppBar position="static" color="default" role="tablist">
+            <Tabs
+              value={0}
+              indicatorColor="primary"
+              textColor="primary"
+              variant="scrollable"
+              scrollButtons="on"
+              className={classes.tabBar}
+            >
+              <Tab key="Summary" label="Summary" data-qa-tab="Summary" />}
+            </Tabs>
+          </AppBar>
+        </Grid>
         <Grid item xs={12} className={classes.section}>
           <KubeSummaryPanel
             cluster={cluster}


### PR DESCRIPTION
## Description

The AppBar on the K8 Details page was competing with the Add New Menu's zindex. Wrapping AppBar in a grid element resolves this issue.

## Type of Change
- Bug fix ('fix'')