### PR TITLE
LKE: API updates

### DIFF
--- a/packages/linode-js-sdk/src/kubernetes/kubernetes.schema.ts
+++ b/packages/linode-js-sdk/src/kubernetes/kubernetes.schema.ts
@@ -6,7 +6,7 @@ export const nodePoolSchema = object().shape({
 });
 
 export const clusterLabelSchema = string()
-  .notRequired()
+  .required('Label is required.')
   /**
    * This regex is adapted from the API docs. Kubernetes does
    * not allow underscores.

--- a/packages/linode-js-sdk/src/kubernetes/kubernetes.schema.ts
+++ b/packages/linode-js-sdk/src/kubernetes/kubernetes.schema.ts
@@ -21,7 +21,7 @@ export const clusterLabelSchema = string()
 export const createKubeClusterSchema = object().shape({
   label: clusterLabelSchema,
   region: string().required('Region is required.'),
-  version: string().required('Kubernetes version is required.'),
+  k8s_version: string().required('Kubernetes version is required.'),
   node_pools: array()
     .of(nodePoolSchema)
     .min(1, 'Please add at least one node pool.')

--- a/packages/linode-js-sdk/src/kubernetes/kubernetes.ts
+++ b/packages/linode-js-sdk/src/kubernetes/kubernetes.ts
@@ -121,8 +121,8 @@ export const getKubernetesVersion = (versionID: string) =>
  *
  */
 
-export const getKubernetesClusterEndpoint = (clusterID: number) =>
-  Request<KubernetesEndpointResponse>(
+export const getKubernetesClusterEndpoints = (clusterID: number) =>
+  Request<Page<KubernetesEndpointResponse>>(
     setMethod('GET'),
-    setURL(`${BETA_API_ROOT}/lke/clusters/${clusterID}/api-endpoint`)
+    setURL(`${BETA_API_ROOT}/lke/clusters/${clusterID}/api-endpoints`)
   ).then(response => response.data);

--- a/packages/linode-js-sdk/src/kubernetes/types.ts
+++ b/packages/linode-js-sdk/src/kubernetes/types.ts
@@ -3,7 +3,7 @@ export interface KubernetesCluster {
   region: string;
   status: string; // @todo enum this
   label: string;
-  version: string;
+  k8s_version: string;
   id: number;
 }
 
@@ -34,12 +34,12 @@ export interface KubernetesVersion {
 }
 
 export interface KubernetesEndpointResponse {
-  endpoints: string[];
+  endpoint: string;
 }
 
 export interface CreateKubeClusterPayload {
   label?: string; // Label will be assigned by the API if not provided
   region?: string; // Will be caught by Yup if undefined
   node_pools: PoolNodeRequest[];
-  version?: string; // Will be caught by Yup if undefined
+  k8s_version?: string; // Will be caught by Yup if undefined
 }

--- a/packages/manager/src/__data__/kubernetes.ts
+++ b/packages/manager/src/__data__/kubernetes.ts
@@ -8,7 +8,7 @@ export const clusters: KubernetesCluster[] = [
     created: '2019-04-29 18:02:17',
     id: 35,
     status: 'running',
-    version: '1.13.5'
+    k8s_version: '1.13.5'
   },
   {
     region: 'us-central',
@@ -16,7 +16,7 @@ export const clusters: KubernetesCluster[] = [
     created: '2019-04-29 18:02:17',
     id: 34,
     status: 'running',
-    version: '1.13.5'
+    k8s_version: '1.13.5'
   }
 ];
 

--- a/packages/manager/src/factories/kubernetesCluster.ts
+++ b/packages/manager/src/factories/kubernetesCluster.ts
@@ -53,7 +53,7 @@ export const kubernetesClusterFactory = Factory.Sync.makeFactory<
   region: 'us-central',
   status: 'ready',
   label: Factory.each(i => `test-cluster-${i}`),
-  version: '1.17',
+  k8s_version: '1.17',
   node_pools: nodePoolFactory.buildList(2),
   totalMemory: 1000,
   totalCPU: 4,

--- a/packages/manager/src/features/Kubernetes/ClusterList/ClusterList.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/ClusterList.tsx
@@ -178,8 +178,8 @@ export const ClusterList: React.FunctionComponent<CombinedProps> = props => {
                           Cluster Label
                         </TableSortCell>
                         <TableSortCell
-                          active={orderBy === 'version'}
-                          label={'version'}
+                          active={orderBy === 'k8s_version'}
+                          label={'k8s_version'}
                           direction={order}
                           handleClick={handleOrderChange}
                           data-qa-kubernetes-clusters-version-header

--- a/packages/manager/src/features/Kubernetes/ClusterList/ClusterRow.test.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/ClusterRow.test.tsx
@@ -32,7 +32,7 @@ describe('ClusterRow component', () => {
 
   it('should render the cluster version', () => {
     const version = component.find('[data-qa-cluster-version]');
-    expect(version.contains(extendedClusters[0].version)).toBeTruthy();
+    expect(version.contains(extendedClusters[0].k8s_version)).toBeTruthy();
   });
 
   it('should render the cluster label', () => {

--- a/packages/manager/src/features/Kubernetes/ClusterList/ClusterRow.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/ClusterRow.tsx
@@ -72,7 +72,7 @@ export const ClusterRow: React.FunctionComponent<CombinedProps> = props => {
         </Grid>
       </TableCell>
       <TableCell parentColumn="Version" data-qa-cluster-version>
-        {cluster.version}
+        {cluster.k8s_version}
       </TableCell>
       <TableCell parentColumn="Created" data-qa-cluster-date>
         <DateTimeDisplay value={cluster.created} humanizeCutoff="month" />

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -256,7 +256,7 @@ export const CreateCluster: React.FC<CombinedProps> = props => {
   } = props;
 
   const errorMap = getErrorMap(
-    ['region', 'node_pools', 'label', 'version', 'versionLoad'],
+    ['region', 'node_pools', 'label', 'k8s_version', 'versionLoad'],
     errors
   );
 
@@ -354,7 +354,7 @@ export const CreateCluster: React.FC<CombinedProps> = props => {
                     className={classes.inputWidth}
                     label="Kubernetes Version"
                     value={version || null}
-                    errorText={errorMap.version}
+                    errorText={errorMap.k8s_version}
                     options={versionOptions}
                     placeholder={' '}
                     onChange={(selected: Item<string>) => setVersion(selected)}

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -185,7 +185,7 @@ export const CreateCluster: React.FC<CombinedProps> = props => {
     setErrors(undefined);
     setSubmitting(true);
 
-    const _version = version ? version.value : undefined;
+    const k8s_version = version ? version.value : undefined;
 
     /**
      * We need to remove the monthly price, which is used for client-side
@@ -198,7 +198,7 @@ export const CreateCluster: React.FC<CombinedProps> = props => {
       region: selectedRegion,
       node_pools,
       label,
-      version: _version
+      k8s_version
     };
 
     createKubernetesCluster(payload)

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
@@ -270,7 +270,7 @@ export const KubeSummaryPanel: React.FunctionComponent<CombinedProps> = props =>
               </Grid>
 
               <Grid item>
-                <Typography>Version {cluster.version}</Typography>
+                <Typography>Version {cluster.k8s_version}</Typography>
               </Grid>
             </Grid>
 

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -1,4 +1,7 @@
-import { getKubernetesClusterEndpoints } from 'linode-js-sdk/lib/kubernetes';
+import {
+  getKubernetesClusterEndpoints,
+  KubernetesEndpointResponse
+} from 'linode-js-sdk/lib/kubernetes';
 import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
@@ -88,7 +91,9 @@ type CombinedProps = WithTypesProps &
   DispatchProps &
   WithStyles<ClassNames>;
 
-const getAllEndpoints = getAll<string>(getKubernetesClusterEndpoints);
+const getAllEndpoints = getAll<KubernetesEndpointResponse>(
+  getKubernetesClusterEndpoints
+);
 
 export const KubernetesClusterDetail: React.FunctionComponent<CombinedProps> = props => {
   const {
@@ -135,7 +140,9 @@ export const KubernetesClusterDetail: React.FunctionComponent<CombinedProps> = p
       const kubeconfigAvailabilityCheck = () => {
         getAllEndpoints(clusterID)
           .then(response => {
-            successfulClusterEndpointResponse(response.data);
+            successfulClusterEndpointResponse(
+              response.data.map(thisEndpoint => thisEndpoint.endpoint)
+            );
           })
           .catch(error => {
             // Do nothing since kubeconfigAvailable is false by default
@@ -148,7 +155,9 @@ export const KubernetesClusterDetail: React.FunctionComponent<CombinedProps> = p
       setEndpointLoading(true);
       getAllEndpoints(clusterID)
         .then(response => {
-          successfulClusterEndpointResponse(response.data);
+          successfulClusterEndpointResponse(
+            response.data.map(thisEndpoint => thisEndpoint.endpoint)
+          );
         })
         .catch(error => {
           setEndpointLoading(false);

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -25,7 +25,7 @@ import KubeContainer, {
 } from 'src/containers/kubernetes.container';
 import withTypes, { WithTypesProps } from 'src/containers/types.container';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
-import { getAll } from 'src/utilities/getAll';
+import { getAllWithArguments } from 'src/utilities/getAll';
 import { ExtendedCluster, PoolNodeWithPrice } from '.././types';
 import KubeSummaryPanel from './KubeSummaryPanel';
 import NodePoolsDisplay from './NodePoolsDisplay';
@@ -91,7 +91,7 @@ type CombinedProps = WithTypesProps &
   DispatchProps &
   WithStyles<ClassNames>;
 
-const getAllEndpoints = getAll<KubernetesEndpointResponse>(
+const getAllEndpoints = getAllWithArguments<KubernetesEndpointResponse>(
   getKubernetesClusterEndpoints
 );
 
@@ -138,7 +138,7 @@ export const KubernetesClusterDetail: React.FunctionComponent<CombinedProps> = p
     const clusterID = +props.match.params.clusterID;
     if (clusterID) {
       const kubeconfigAvailabilityCheck = () => {
-        getAllEndpoints(clusterID)
+        getAllEndpoints([clusterID])
           .then(response => {
             successfulClusterEndpointResponse(
               response.data.map(thisEndpoint => thisEndpoint.endpoint)
@@ -153,7 +153,7 @@ export const KubernetesClusterDetail: React.FunctionComponent<CombinedProps> = p
       // The cluster endpoint has its own API...uh, endpoint, so we need
       // to request it separately.
       setEndpointLoading(true);
-      getAllEndpoints(clusterID)
+      getAllEndpoints([clusterID])
         .then(response => {
           successfulClusterEndpointResponse(
             response.data.map(thisEndpoint => thisEndpoint.endpoint)

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -203,7 +203,7 @@ export const KubernetesClusterDetail: React.FunctionComponent<CombinedProps> = p
           setEndpointLoading(false);
 
           // If the error is that the endpoint is not yet available, set endpointAvailabilityInterval equal to function that continues polling the endpoint every 5 seconds to grab it when it is.
-          if (error?.[0]?.reason.match(/endpoint not available/i)) {
+          if (error?.[0]?.reason.match(/endpoints are not yet available/i)) {
             endpointAvailabilityInterval.current = window.setInterval(() => {
               endpointAvailabilityCheck();
             }, 5000);

--- a/packages/manager/src/utilities/getAll.ts
+++ b/packages/manager/src/utilities/getAll.ts
@@ -137,43 +137,6 @@ export const getAllWithArguments: <T>(
   );
 };
 
-export const getAllFromEntity: (
-  getter: GetFromEntity
-) => (params?: any, filter?: any) => Promise<any> = getter => (
-  entityId: number,
-  params?: any,
-  filter?: any
-) => {
-  const pagination = { ...params, page_size: 100 };
-  return getter(entityId, pagination, filter).then(
-    ({ data: firstPageData, page, pages }) => {
-      // If we only have one page, return it.
-      if (page === pages) {
-        return firstPageData;
-      }
-
-      // Create an iterable list of the remaining pages.
-      const remainingPages = range(page + 1, pages + 1);
-
-      //
-      return (
-        Bluebird.map(remainingPages, nextPage =>
-          getter({ ...pagination, page: nextPage }, filter).then(
-            response => response.data
-          )
-        )
-          /** We're given NodeBalancer[][], so we flatten that, and append the first page response. */
-          .then(resultPages =>
-            resultPages.reduce(
-              (result, nextPage) => [...result, ...nextPage],
-              firstPageData
-            )
-          )
-      );
-    }
-  );
-};
-
 export type GetAllHandler = (
   linodes: Linode[],
   nodebalancers: NodeBalancer[],


### PR DESCRIPTION
## Description

We did it for the old UI, now we have to do it for the new UI. LKE should function as before, despite the following API changes:

- /api-endpoint is now /api-endpoints, and returns a standard paginated response.
- k8s clusters "version" field has been renamed k8s_version, for both request and response payloads.


Point your env at staging.