### PR TITLE
LKE Fix: Autoselect region

### DIFF
--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -137,6 +137,22 @@ const regionHelperText = (
 
 export const CreateCluster: React.FC<CombinedProps> = props => {
   const classes = useStyles();
+  const {
+    regionsData,
+    typesData,
+    typesLoading,
+    typesError,
+    regionsError
+  } = props;
+
+  // Only include regions that have LKE capability
+  const filteredRegions = React.useMemo(() => {
+    return regionsData
+      ? regionsData.filter(thisRegion =>
+          thisRegion.capabilities.includes('Kubernetes')
+        )
+      : [];
+  }, [regionsData]);
 
   const [selectedRegion, setSelectedRegion] = React.useState<string>('');
   const [nodePools, setNodePools] = React.useState<PoolNodeWithPrice[]>([]);
@@ -176,6 +192,12 @@ export const CreateCluster: React.FC<CombinedProps> = props => {
         );
       });
   }, []);
+
+  React.useEffect(() => {
+    if (filteredRegions.length === 1 && !selectedRegion) {
+      setSelectedRegion(filteredRegions[0].id);
+    }
+  }, [filteredRegions]);
 
   const createCluster = () => {
     const {
@@ -247,25 +269,10 @@ export const CreateCluster: React.FC<CombinedProps> = props => {
     setLabel(newLabel ? newLabel : undefined);
   };
 
-  const {
-    regionsData,
-    typesData,
-    typesLoading,
-    typesError,
-    regionsError
-  } = props;
-
   const errorMap = getErrorMap(
     ['region', 'node_pools', 'label', 'version', 'versionLoad'],
     errors
   );
-
-  // Only displaying regions that have LKE capability
-  const filteredRegions = regionsData
-    ? regionsData.filter(thisRegion =>
-        thisRegion.capabilities.includes('Kubernetes')
-      )
-    : [];
 
   const selectedID = selectedRegion || null;
 

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -338,12 +338,7 @@ export const CreateCluster: React.FC<CombinedProps> = props => {
                       setSelectedRegion(regionID)
                     }
                     regions={filteredRegions}
-                    selectedID={
-                      // Select the first region by default if there is only one to choose from.
-                      filteredRegions.length === 1
-                        ? filteredRegions[0].id
-                        : selectedID
-                    }
+                    selectedID={selectedID}
                     textFieldProps={
                       // Only show the "Find out which region is best for you" message if there are
                       // actually multiple regions to choose from.


### PR DESCRIPTION
## Description

We had logic to automatically select the region field if there
was only one available region. However, we were only pre-populating
the field and not setting the region to state. This fixes it and memoizes
the filteredRegions calculation to support it.