### PR TITLE
[LKE] Fix Summary Panel's "CPU Cores" pluralization based on number of cores

### DIFF
--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
@@ -28,6 +28,7 @@ import { reportException } from 'src/exceptionReporting';
 import { ExtendedCluster } from 'src/features/Kubernetes/types';
 import { downloadFile } from 'src/utilities/downloadFile';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import { pluralize } from 'src/utilities/pluralize';
 import { getTotalClusterPrice } from '../kubeUtils';
 
 import KubeConfigDrawer from './KubeConfigDrawer';
@@ -322,7 +323,9 @@ export const KubeSummaryPanel: React.FunctionComponent<CombinedProps> = props =>
               </Grid>
 
               <Grid item>
-                <Typography>{cluster.totalCPU} CPU Cores</Typography>
+                <Typography>
+                  {pluralize('CPU Core', 'CPU Cores', cluster.totalCPU)}
+                </Typography>
               </Grid>
             </Grid>
 


### PR DESCRIPTION
## Description
KubeSummaryPanel.tsx previously had the "CPU Cores" phrase explicitly written in instead of being singular or plural based on the total CPUs value of the cluster. I brought in the `pluralize` util to remedy this, so it should now say "1 CPU Core" when there is only one, and "[2, 3, etc.] CPU Cores" when there are multiple. 

## Type of Change
- Bug fix ('fix', 'repair', 'bug')
