### PR TITLE
M3-4041: Fix alignment on invoice labels

### DIFF
--- a/packages/manager/src/components/Table/Table.tsx
+++ b/packages/manager/src/components/Table/Table.tsx
@@ -40,7 +40,7 @@ const styles = (theme: Theme) =>
           '& > td:first-child': {
             backgroundColor: theme.bg.tableHeader,
             '& .data': {
-              textAlign: 'left'
+              textAlign: 'right'
             }
           }
         },

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -1244,9 +1244,6 @@ const themeDefaults: ThemeDefaults = ({ spacingOverride: spacingUnit }) => {
           padding: spacingUnit + 2,
           borderTop: `1px solid ${primaryColors.divider}`,
           borderBottom: `1px solid ${primaryColors.divider}`,
-          '&:first-child': {
-            paddingLeft: 15
-          },
           '&:last-child': {
             paddingRight: spacingUnit + 2
           },

--- a/packages/manager/src/themes.ts
+++ b/packages/manager/src/themes.ts
@@ -480,10 +480,7 @@ export const dark = (options: ThemeOverrides) =>
       MuiTableCell: {
         root: {
           borderTop: `1px solid ${primaryColors.divider}`,
-          borderBottom: `1px solid ${primaryColors.divider}`,
-          '&:first-child': {
-            paddingLeft: 15
-          }
+          borderBottom: `1px solid ${primaryColors.divider}`
         },
         head: {
           color: primaryColors.text,


### PR DESCRIPTION
## Description

When the Recent Invoices section wraps for smaller screens, the Date Created section on the right was misaligned so this should fix that

## Type of Change
- Non breaking change ('update', 'change')
