### PR TITLE
[LKE] Adjustments to create cluster component

### DIFF
--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -164,7 +164,6 @@ export const CreateCluster: React.FC<CombinedProps> = props => {
     []
   );
   const [selectedType, setSelectedType] = React.useState<string>('');
-  const [newCount, setNewCount] = React.useState<number>(0);
 
   React.useEffect(() => {
     getAllVersions()
@@ -251,10 +250,6 @@ export const CreateCluster: React.FC<CombinedProps> = props => {
   const removePool = (poolIdx: number) => {
     const updatedPools = remove(poolIdx, 1, nodePools);
     setNodePools(updatedPools);
-  };
-
-  const updateCount = (count: number) => {
-    setNewCount(count);
   };
 
   const selectType = (type: string) => {
@@ -382,12 +377,10 @@ export const CreateCluster: React.FC<CombinedProps> = props => {
                   addNodePool={(pool: PoolNodeWithPrice) => addPool(pool)}
                   deleteNodePool={(poolIdx: number) => removePool(poolIdx)}
                   handleTypeSelect={(newType: string) => selectType(newType)}
-                  updateNodeCount={(count: number) => updateCount(count)}
                   updatePool={updatePool}
                   updateFor={[
                     nodePools,
                     typesData,
-                    newCount,
                     errorMap,
                     typesLoading,
                     selectedType,

--- a/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
@@ -46,7 +46,6 @@ interface Props {
   hideTable?: boolean;
   addNodePool: (pool: PoolNodeWithPrice) => void;
   handleTypeSelect: (newType?: string) => void;
-  updateNodeCount: (newCount: number) => void;
   // Props only needed if hideTable is false
   pools?: PoolNodeWithPrice[];
   deleteNodePool?: (poolIdx: number) => void;
@@ -97,7 +96,6 @@ const Panel: React.FunctionComponent<CombinedProps> = props => {
     hideTable,
     pools,
     selectedType,
-    updateNodeCount,
     updatePool,
     types,
     isOnCreate
@@ -151,18 +149,13 @@ const Panel: React.FunctionComponent<CombinedProps> = props => {
       totalMonthlyPrice: getMonthlyPrice(selectedPlanType, nodeCount, types)
     });
     handleTypeSelect(undefined);
-    updateNodeCount(3);
+    updatePlanCount(selectedPlanType, 0);
   };
 
   const selectType = (newType: string) => {
     setTypeError(undefined);
     handleTypeSelect(newType);
   };
-
-  React.useEffect(() => {
-    const typesWithCount = addCountToTypes(types);
-    setNewType(typesWithCount);
-  }, [types]);
 
   const updatePlanCount = (planId: string, newCount: number) => {
     const newTypes = _types.map((thisType: any) => {

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
@@ -192,7 +192,7 @@ export class SelectPlanPanel extends React.Component<
                   <Button
                     buttonType="primary"
                     onClick={() => submitForm!(type.id, type.count)}
-                    disabled={type.id !== String(selectedID)}
+                    disabled={type.count < 1}
                     className={classes.enhancedInputButton}
                   >
                     Add


### PR DESCRIPTION
## Description

- The "Add" button is now disabled only if that row's count < 1.
- Adding a pool resets that row's count to 0.

Also:
- Removed unnecessary useEffect which sometimes caused an bug where the first click of the "Plus" button didn't do anything.
- Removed a state value and updater that AFAICT were not being used.

