### PR TITLE
Theme performance optimizations

### DIFF
--- a/packages/manager/src/LinodeThemeWrapper.tsx
+++ b/packages/manager/src/LinodeThemeWrapper.tsx
@@ -95,25 +95,52 @@ const LinodeThemeWrapper: React.FC<CombinedProps> = props => {
             preference: spacingChoice,
             togglePreference: _toggleSpacing
           }: ToggleProps<SpacingChoice>) => (
-            <ThemeProvider
-              theme={safelyGetTheme(
-                themes,
-                themeChoice
-              )({
-                spacingOverride:
-                  spacingChoice === 'compact'
-                    ? COMPACT_SPACING_UNIT
-                    : NORMAL_SPACING_UNIT
-              })}
-            >
-              {typeof children === 'function'
-                ? (children as RenderChildren)(_toggleTheme, _toggleSpacing)
-                : children}
-            </ThemeProvider>
+            <MemoizedThemeProvider
+              themeChoice={themeChoice}
+              spacingChoice={spacingChoice}
+              toggleTheme={_toggleTheme}
+              toggleSpacing={_toggleSpacing}
+              children={children}
+            />
           )}
         </PreferenceToggle>
       )}
     </PreferenceToggle>
+  );
+};
+
+interface MemoizedThemeProviderProps {
+  themeChoice: ThemeChoice;
+  spacingChoice: SpacingChoice;
+  toggleTheme: () => ThemeChoice;
+  toggleSpacing: () => SpacingChoice;
+  children: any;
+}
+
+const MemoizedThemeProvider: React.FC<MemoizedThemeProviderProps> = props => {
+  const {
+    themeChoice,
+    toggleTheme,
+    spacingChoice,
+    toggleSpacing,
+    children
+  } = props;
+
+  const theme = React.useMemo(() => {
+    const themeCreator = safelyGetTheme(themes, themeChoice);
+
+    const spacingUnit =
+      spacingChoice === 'compact' ? COMPACT_SPACING_UNIT : NORMAL_SPACING_UNIT;
+
+    return themeCreator(spacingUnit);
+  }, [themeChoice, spacingChoice]);
+
+  return (
+    <ThemeProvider theme={theme}>
+      {typeof children === 'function'
+        ? (children as RenderChildren)(toggleTheme, toggleSpacing)
+        : children}
+    </ThemeProvider>
   );
 };
 

--- a/packages/manager/src/components/HighlightedMarkdown/__snapshots__/HighlightedMarkdown.test.tsx.snap
+++ b/packages/manager/src/components/HighlightedMarkdown/__snapshots__/HighlightedMarkdown.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`HighlightedMarkdown component should highlight text consistently 1`] = `
 <DocumentFragment>
   <p
-    class="MuiTypography-root makeStyles-root-32 formatted-text MuiTypography-body1"
+    class="MuiTypography-root makeStyles-root-1 formatted-text MuiTypography-body1"
   />
   <h1>
     Some markdown

--- a/packages/manager/src/components/LineGraph/MetricsDisplay.test.tsx
+++ b/packages/manager/src/components/LineGraph/MetricsDisplay.test.tsx
@@ -33,9 +33,7 @@ describe('CPUMetrics', () => {
         simpleLegendRoot: '',
         simpleLegend: ''
       }}
-      theme={light({
-        spacingOverride: 4
-      })}
+      theme={light(4)}
       rows={[
         {
           legendTitle: 'Legend Title',

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.test.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.test.tsx
@@ -44,9 +44,7 @@ describe('PrimaryNav', () => {
       wrapper = shallow(
         <PrimaryNav
           classes={mockClasses}
-          theme={light({
-            spacingOverride: 4
-          })}
+          theme={light(4)}
           toggleSpacing={jest.fn()}
           closeMenu={jest.fn()}
           flags={{}}
@@ -113,9 +111,7 @@ describe('PrimaryNav', () => {
       wrapper = shallow(
         <PrimaryNav
           classes={mockClasses}
-          theme={light({
-            spacingOverride: 4
-          })}
+          theme={light(4)}
           toggleSpacing={jest.fn()}
           closeMenu={jest.fn()}
           flags={{}}
@@ -146,9 +142,7 @@ describe('PrimaryNav', () => {
       wrapper = shallow(
         <PrimaryNav
           classes={mockClasses}
-          theme={light({
-            spacingOverride: 4
-          })}
+          theme={light(4)}
           toggleSpacing={jest.fn()}
           closeMenu={jest.fn()}
           flags={{}}
@@ -179,9 +173,7 @@ describe('PrimaryNav', () => {
       wrapper = shallow(
         <PrimaryNav
           classes={mockClasses}
-          theme={light({
-            spacingOverride: 4
-          })}
+          theme={light(4)}
           toggleSpacing={jest.fn()}
           closeMenu={jest.fn()}
           flags={{}}

--- a/packages/manager/src/components/PrimaryNav/ThemeToggle.test.tsx
+++ b/packages/manager/src/components/PrimaryNav/ThemeToggle.test.tsx
@@ -15,7 +15,7 @@ describe('ThemeToggle', () => {
       <ThemeToggle
         toggleTheme={jest.fn()}
         classes={mockClasses}
-        theme={light({ spacingOverride: 4 })}
+        theme={light(4)}
       />
     );
   });

--- a/packages/manager/src/components/RenderGuard.tsx
+++ b/packages/manager/src/components/RenderGuard.tsx
@@ -34,7 +34,10 @@ const renderGuard = <P extends {}>(
     render() {
       // cast of this.props to any needed because of
       // https://github.com/Microsoft/TypeScript/issues/17281
-      const { updateFor, ...rest } = this.props as any;
+      //
+      // Destructure out "theme" so it's not passed to the component.
+      // This fixes the "<div theme=[object Object] />" issue.
+      const { updateFor, theme, ...rest } = this.props as any;
       return <Component {...rest} />;
     }
   }

--- a/packages/manager/src/features/Dashboard/Dashboard.test.tsx
+++ b/packages/manager/src/features/Dashboard/Dashboard.test.tsx
@@ -19,7 +19,7 @@ const props = {
   backupError: undefined,
   entitiesWithGroupsToImport: { linodes: [], domains: [] },
   classes: { root: '' },
-  theme: light({ spacingOverride: 8 })
+  theme: light(8)
 };
 
 jest.mock('src/store');

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewPlans.test.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewPlans.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, waitForDomChange, within } from '@testing-library/react';
+import { cleanup, within } from '@testing-library/react';
 import * as React from 'react';
 import { accountSettings } from 'src/__data__/account';
 import { withDocumentTitleProvider } from 'src/components/DocumentTitle';
@@ -37,7 +37,6 @@ describe('LongviewPlans', () => {
   it('sets the document title to "Plan Details"', async () => {
     const WrappedComponent = withDocumentTitleProvider(LongviewPlans);
     renderWithTheme(<WrappedComponent {...props} />);
-    await waitForDomChange();
     expect(document.title).toMatch(/^Plan Details/);
   });
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.test.tsx
@@ -32,9 +32,7 @@ describe('LinodeSummary', () => {
         textWrap: '',
         headerOuter: ''
       }}
-      theme={light({
-        spacingOverride: 4
-      })}
+      theme={light(4)}
       linodeVolumes={[]}
       typesData={[]}
       imagesData={{}}

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeCard.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeCard.test.tsx
@@ -69,7 +69,7 @@ describe('LinodeRow', () => {
 
   const mockProps: CombinedProps = {
     classes: mockClasses,
-    theme: light({ spacingOverride: 4 }),
+    theme: light(4),
     maintenanceStartTime: '',
     recentEvent: undefined,
     openDeleteDialog: jest.fn(),

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.test.tsx
@@ -23,7 +23,7 @@ describe('LinodeRow', () => {
 
   const mockProps: CombinedProps = {
     classes: mockClasses,
-    theme: light({ spacingOverride: 4 }),
+    theme: light(4),
     maintenanceStartTime: '',
     recentEvent: undefined,
     openDeleteDialog: jest.fn(),

--- a/packages/manager/src/themes.ts
+++ b/packages/manager/src/themes.ts
@@ -1,13 +1,17 @@
 import createBreakpoints from 'src/components/core/styles/createBreakpoints';
-import createTheme, { ThemeOverrides } from './themeFactory';
+import createTheme from './themeFactory';
 
 const breakpoints = createBreakpoints({});
 
-export const light = (options: ThemeOverrides) =>
-  createTheme({
-    name: 'lightTheme',
-    ...options
-  });
+export const light = (spacingOverride?: number) => {
+  const options: any = { name: 'lightTheme' };
+
+  if (spacingOverride) {
+    options.spacingOverride = spacingOverride;
+  }
+
+  return createTheme(options);
+};
 
 const primaryColors = {
   main: '#3683dc',
@@ -37,513 +41,519 @@ const iconCircleAnimation = {
   }
 };
 
-export const dark = (options: ThemeOverrides) =>
-  createTheme({
-    name: 'darkTheme',
-    breakpoints,
-    '@keyframes rotate': {
-      from: {
-        transform: 'rotate(0deg)'
+export const dark = (spacingOverride?: number) => {
+  const options: any = { ...darkThemeOptions };
+  if (spacingOverride) {
+    options.spacingOverride = spacingOverride;
+  }
+  return createTheme(options);
+};
+
+const darkThemeOptions = {
+  name: 'darkTheme',
+  breakpoints,
+  '@keyframes rotate': {
+    from: {
+      transform: 'rotate(0deg)'
+    },
+    to: {
+      transform: 'rotate(360deg)'
+    }
+  },
+  '@keyframes dash': {
+    to: {
+      'stroke-dashoffset': 0
+    }
+  },
+  bg: {
+    main: '#2f3236',
+    offWhite: '#111111',
+    offWhiteDT: '#444', // better handing for dark theme
+    navy: '#32363c',
+    lightBlue: '#222',
+    white: '#32363c',
+    pureWhite: '#000',
+    tableHeader: '#2B2E32',
+    primaryNavActive: '#303235',
+    primaryNavActiveBG: '#464c53',
+    primaryNavBorder: '#303235',
+    primaryNavPaper: '#3a3f45',
+    topMenu: '#33383d'
+  },
+  color: {
+    headline: primaryColors.headline,
+    red: '#ca0813',
+    green: '#00b159',
+    yellow: '#fecf2f',
+    border1: '#000',
+    border2: '#111',
+    border3: '#222',
+    borderPagination: '#222222',
+    grey1: '#abadaf',
+    grey2: 'rgba(0, 0, 0, 0.2)',
+    grey3: '#999',
+    grey5: 'rgba(0, 0, 0, 0.2)',
+    white: '#32363c',
+    blue: primaryColors.main,
+    black: '#fff',
+    offBlack: primaryColors.offBlack,
+    boxShadow: '#222',
+    boxShadowDark: '#000',
+    focusBorder: '#999',
+    absWhite: '#000',
+    blueDTwhite: '#fff',
+    selectDropDowns: primaryColors.main,
+    borderRow: 'rgba(0, 0, 0, 0.15)',
+    tableHeaderText: '#fff',
+    toggleActive: '#444',
+    diskSpaceBorder: '#222222',
+    drawerBackdrop: 'rgba(0, 0, 0, 0.5)',
+    label: '#c9cacb',
+    disabledText: '#c9cacb',
+    kubeLabel: '#fff',
+    primaryNavText: '#fff'
+  },
+  animateCircleIcon: {
+    ...iconCircleAnimation
+  },
+  notificationList: {
+    borderBottom: '1px solid #f4f4f4',
+    '&:hover': {
+      backgroundColor: '#111111'
+    }
+  },
+  palette: {
+    divider: primaryColors.divider,
+    primary: primaryColors,
+    text: {
+      primary: primaryColors.text
+    }
+  },
+  typography: {
+    h1: {
+      color: primaryColors.headline
+    },
+    h2: {
+      color: primaryColors.headline
+    },
+    h3: {
+      color: primaryColors.headline
+    },
+    caption: {
+      color: primaryColors.text
+    },
+    h4: {
+      color: primaryColors.text
+    },
+    body1: {
+      color: primaryColors.text
+    },
+    body2: {
+      color: primaryColors.text
+    },
+    subtitle1: {
+      color: primaryColors.text
+    }
+  },
+  overrides: {
+    MuiAppBar: {
+      colorDefault: {
+        backgroundColor: 'transparent'
+      }
+    },
+    MuiBackdrop: {
+      root: {
+        backgroundColor: 'rgba(0, 0, 0, 0.5)'
+      }
+    },
+    MuiButton: {
+      label: {
+        position: 'relative'
       },
-      to: {
-        transform: 'rotate(360deg)'
-      }
-    },
-    '@keyframes dash': {
-      to: {
-        'stroke-dashoffset': 0
-      }
-    },
-    bg: {
-      main: '#2f3236',
-      offWhite: '#111111',
-      offWhiteDT: '#444', // better handing for dark theme
-      navy: '#32363c',
-      lightBlue: '#222',
-      white: '#32363c',
-      pureWhite: '#000',
-      tableHeader: '#2B2E32',
-      primaryNavActive: '#303235',
-      primaryNavActiveBG: '#464c53',
-      primaryNavBorder: '#303235',
-      primaryNavPaper: '#3a3f45',
-      topMenu: '#33383d'
-    },
-    color: {
-      headline: primaryColors.headline,
-      red: '#ca0813',
-      green: '#00b159',
-      yellow: '#fecf2f',
-      border1: '#000',
-      border2: '#111',
-      border3: '#222',
-      borderPagination: '#222222',
-      grey1: '#abadaf',
-      grey2: 'rgba(0, 0, 0, 0.2)',
-      grey3: '#999',
-      grey5: 'rgba(0, 0, 0, 0.2)',
-      white: '#32363c',
-      blue: primaryColors.main,
-      black: '#fff',
-      offBlack: primaryColors.offBlack,
-      boxShadow: '#222',
-      boxShadowDark: '#000',
-      focusBorder: '#999',
-      absWhite: '#000',
-      blueDTwhite: '#fff',
-      selectDropDowns: primaryColors.main,
-      borderRow: 'rgba(0, 0, 0, 0.15)',
-      tableHeaderText: '#fff',
-      toggleActive: '#444',
-      diskSpaceBorder: '#222222',
-      drawerBackdrop: 'rgba(0, 0, 0, 0.5)',
-      label: '#c9cacb',
-      disabledText: '#c9cacb',
-      kubeLabel: '#fff',
-      primaryNavText: '#fff'
-    },
-    animateCircleIcon: {
-      ...iconCircleAnimation
-    },
-    notificationList: {
-      borderBottom: '1px solid #f4f4f4',
-      '&:hover': {
-        backgroundColor: '#111111'
-      }
-    },
-    palette: {
-      divider: primaryColors.divider,
-      primary: primaryColors,
+      root: {
+        color: primaryColors.main,
+        '&:hover': {
+          backgroundColor: '#000'
+        },
+        '&[aria-expanded="true"]': {
+          backgroundColor: primaryColors.dark
+        },
+        '&$disabled': {
+          color: '#888',
+          opacity: 0.5
+        },
+        '&.loading': {
+          color: primaryColors.text
+        }
+      },
       text: {
-        primary: primaryColors.text
-      }
-    },
-    typography: {
-      h1: {
-        color: primaryColors.headline
-      },
-      h2: {
-        color: primaryColors.headline
-      },
-      h3: {
-        color: primaryColors.headline
-      },
-      caption: {
-        color: primaryColors.text
-      },
-      h4: {
-        color: primaryColors.text
-      },
-      body1: {
-        color: primaryColors.text
-      },
-      body2: {
-        color: primaryColors.text
-      },
-      subtitle1: {
-        color: primaryColors.text
-      }
-    },
-    overrides: {
-      MuiAppBar: {
-        colorDefault: {
+        '&:hover': {
           backgroundColor: 'transparent'
         }
       },
-      MuiBackdrop: {
-        root: {
-          backgroundColor: 'rgba(0, 0, 0, 0.5)'
+      containedPrimary: {
+        '&:hover, &:focus': {
+          backgroundColor: primaryColors.light
+        },
+        '&:active': {
+          backgroundColor: primaryColors.dark
+        },
+        '&$disabled': {
+          color: '#888'
+        },
+        '&.loading': {
+          backgroundColor: primaryColors.text
+        },
+        '&.cancel': {
+          '&:hover, &:focus': {
+            borderColor: '#fff'
+          }
         }
       },
-      MuiButton: {
-        label: {
-          position: 'relative'
+      containedSecondary: {
+        color: primaryColors.main,
+        border: `1px solid ${primaryColors.main}`,
+        '&:hover, &:focus': {
+          color: primaryColors.light,
+          borderColor: primaryColors.light
         },
-        root: {
-          color: primaryColors.main,
-          '&:hover': {
-            backgroundColor: '#000'
-          },
-          '&[aria-expanded="true"]': {
-            backgroundColor: primaryColors.dark
-          },
-          '&$disabled': {
-            color: '#888',
-            opacity: 0.5
-          },
-          '&.loading': {
-            color: primaryColors.text
-          }
+        '&:active': {
+          color: primaryColors.dark,
+          borderColor: primaryColors.dark
         },
-        text: {
-          '&:hover': {
-            backgroundColor: 'transparent'
-          }
+        '&$disabled': {
+          borderColor: '#c9cacb',
+          color: '#c9cacb'
         },
-        containedPrimary: {
+        '&.cancel': {
+          borderColor: 'transparent',
           '&:hover, &:focus': {
-            backgroundColor: primaryColors.light
-          },
-          '&:active': {
-            backgroundColor: primaryColors.dark
-          },
-          '&$disabled': {
-            color: '#888'
-          },
-          '&.loading': {
-            backgroundColor: primaryColors.text
-          },
-          '&.cancel': {
-            '&:hover, &:focus': {
-              borderColor: '#fff'
-            }
-          }
-        },
-        containedSecondary: {
-          color: primaryColors.main,
-          border: `1px solid ${primaryColors.main}`,
-          '&:hover, &:focus': {
-            color: primaryColors.light,
             borderColor: primaryColors.light
+          }
+        },
+        '&.destructive': {
+          borderColor: '#c44742',
+          color: '#c44742',
+          '&:hover, &:focus': {
+            color: '#df6560',
+            borderColor: '#df6560',
+            backgroundColor: 'transparent'
           },
           '&:active': {
-            color: primaryColors.dark,
-            borderColor: primaryColors.dark
-          },
-          '&$disabled': {
-            borderColor: '#c9cacb',
-            color: '#c9cacb'
-          },
-          '&.cancel': {
-            borderColor: 'transparent',
-            '&:hover, &:focus': {
-              borderColor: primaryColors.light
-            }
-          },
-          '&.destructive': {
-            borderColor: '#c44742',
-            color: '#c44742',
-            '&:hover, &:focus': {
-              color: '#df6560',
-              borderColor: '#df6560',
-              backgroundColor: 'transparent'
-            },
-            '&:active': {
-              color: '#963530',
-              borderColor: '#963530'
-            }
-          },
-          '&.loading': {
-            borderColor: primaryColors.text,
-            color: primaryColors.text,
-            minWidth: 100,
-            '& svg': {
-              width: 22,
-              height: 22
-            }
-          }
-        }
-      },
-      MuiButtonBase: {
-        root: {
-          fontSize: '1rem'
-        }
-      },
-      MuiCardHeader: {
-        root: {
-          backgroundColor: 'rgba(0, 0, 0, 0.2)'
-        }
-      },
-      MuiChip: {
-        root: {
-          color: primaryColors.text,
-          backgroundColor: primaryColors.main
-        }
-      },
-      MuiCardActions: {
-        root: {
-          backgroundColor: 'rgba(0, 0, 0, 0.2) !important'
-        }
-      },
-      MuiDialog: {
-        paper: {
-          boxShadow: '0 0 5px #222',
-          background: '#000'
-        }
-      },
-      MuiDialogTitle: {
-        root: {
-          borderBottom: '1px solid #222',
-          '& h2': {
-            color: primaryColors.headline
-          }
-        }
-      },
-      MuiDrawer: {
-        paper: {
-          boxShadow: '0 0 5px #222'
-        }
-      },
-      MuiExpansionPanel: {
-        root: {
-          '& table': {
-            border: `1px solid ${primaryColors.divider}`
-          }
-        }
-      },
-      MuiExpansionPanelDetails: {
-        root: {
-          backgroundColor: '#32363c'
-        }
-      },
-      MuiExpansionPanelSummary: {
-        root: {
-          '&$focused': {
-            backgroundColor: '#111111'
-          },
-          backgroundColor: '#32363c',
-          '&:hover': {
-            '& h3': {
-              color: primaryColors.light
-            },
-            '& $expandIcon': {
-              '& svg': {
-                fill: primaryColors.light
-              }
-            }
+            color: '#963530',
+            borderColor: '#963530'
           }
         },
-        expandIcon: {
-          color: primaryColors.main,
+        '&.loading': {
+          borderColor: primaryColors.text,
+          color: primaryColors.text,
+          minWidth: 100,
           '& svg': {
-            fill: 'transparent'
-          },
-          '& .border': {
-            stroke: `${primaryColors.light} !important`
-          }
-        },
-        focused: {}
-      },
-      MuiFormControl: {
-        root: {
-          '&.copy > div': {
-            backgroundColor: '#2f3236'
-          }
-        }
-      },
-      MuiFormControlLabel: {
-        root: {
-          '& $disabled': {
-            color: '#aaa !important'
-          }
-        },
-        label: {
-          color: primaryColors.text
-        },
-        disabled: {}
-      },
-      MuiFormLabel: {
-        root: {
-          color: '#c9cacb',
-          '&$focused': {
-            color: '#c9cacb'
-          },
-          '&$error': {
-            color: '#c9cacb'
-          },
-          '&$disabled': {
-            color: '#c9cacb'
-          }
-        }
-      },
-      MuiFormHelperText: {
-        root: {
-          color: '#c9cacb',
-          '&$error': {
-            color: '#ca0813'
-          }
-        }
-      },
-      MuiIconButton: {
-        root: {
-          color: primaryColors.main,
-          '&:hover': {
-            color: primaryColors.light
-          }
-        }
-      },
-      MuiInput: {
-        root: {
-          '&$disabled': {
-            borderColor: '#606469',
-            color: '#ccc !important'
-          },
-          '&$focused': {
-            borderColor: primaryColors.main,
-            boxShadow: '0 0 2px 1px #222'
-          },
-          border: '1px solid #222',
-          color: primaryColors.text,
-          backgroundColor: '#444',
-          '& svg': {
-            color: primaryColors.main
-          }
-        },
-        focused: {},
-        disabled: {}
-      },
-      MuiInputAdornment: {
-        root: {
-          color: '#eee',
-          '& p': {
-            color: '#eee'
-          }
-        }
-      },
-      MuiListItem: {
-        root: {
-          color: primaryColors.text,
-          '&.selectHeader': {
-            color: primaryColors.text
-          }
-        }
-      },
-      MuiMenuItem: {
-        root: {
-          color: primaryColors.text,
-          '&$selected, &$selected:hover': {
-            backgroundColor: 'transparent',
-            color: primaryColors.main,
-            opacity: 1
-          }
-        },
-        selected: {}
-      },
-      MuiPaper: {
-        root: {
-          backgroundColor: '#32363c'
-        }
-      },
-      MuiPopover: {
-        paper: {
-          boxShadow: '0 0 5px #222'
-        }
-      },
-      MuiSelect: {
-        selectMenu: {
-          color: primaryColors.text,
-          backgroundColor: '#444',
-          '&:focus': {
-            backgroundColor: '#444'
-          }
-        }
-      },
-      MuiSnackbarContent: {
-        root: {
-          backgroundColor: '#32363c',
-          color: primaryColors.text,
-          boxShadow: '0 0 5px #222'
-        }
-      },
-      MuiSwitch: {
-        root: {
-          '& $checked': {
-            color: `#abadaf !important`,
-            '& .square': {
-              fill: 'white !important'
-            }
-          }
-        },
-        checked: {},
-        switchBase: {
-          color: '#abadaf !important'
-        },
-        track: {
-          border: '1px solid #222'
-        }
-      },
-      MuiTab: {
-        root: {
-          color: '#fff',
-          '&$selected, &$selected:hover': {
-            color: '#fff'
-          }
-        },
-        textColorPrimary: {
-          color: '#fff',
-          '&$selected, &$selected:hover': {
-            color: '#fff'
-          }
-        },
-        selected: {}
-      },
-      MuiTableCell: {
-        root: {
-          borderTop: `1px solid ${primaryColors.divider}`,
-          borderBottom: `1px solid ${primaryColors.divider}`
-        },
-        head: {
-          color: primaryColors.text,
-          backgroundColor: 'rgba(0, 0, 0, 0.15)'
-        }
-      },
-      MuiTabs: {
-        root: {
-          boxShadow: 'inset 0 -1px 0 #222'
-        },
-        flexContainer: {
-          '& $scrollButtons:first-child': {
-            color: '#222'
-          }
-        },
-        scrollButtons: {
-          color: '#fff'
-        }
-      },
-      MuiTableRow: {
-        root: {
-          backgroundColor: '#32363c',
-          '&:before': {
-            borderLeftColor: '#32363c'
-          },
-          '&:hover, &:focus': {
-            '&$hover': {
-              backgroundColor: 'rgba(0, 0, 0, 0.1)'
-            }
-          }
-        },
-        head: {
-          backgroundColor: '#32363c',
-          '&:before': {
-            backgroundColor: 'rgba(0, 0, 0, 0.15) !important'
-          }
-        },
-        hover: {
-          '& a': {
-            color: primaryColors.text
-          }
-        }
-      },
-      MuiTooltip: {
-        tooltip: {
-          backgroundColor: '#444',
-          boxShadow: '0 0 5px #222',
-          color: '#fff'
-        }
-      },
-      MuiTypography: {
-        root: {
-          '& a.black': {
-            color: primaryColors.text
-          },
-          '& a.black:visited': {
-            color: primaryColors.text
-          },
-          '& a.black:hover': {
-            color: primaryColors.text
+            width: 22,
+            height: 22
           }
         }
       }
     },
-    ...options
-  });
+    MuiButtonBase: {
+      root: {
+        fontSize: '1rem'
+      }
+    },
+    MuiCardHeader: {
+      root: {
+        backgroundColor: 'rgba(0, 0, 0, 0.2)'
+      }
+    },
+    MuiChip: {
+      root: {
+        color: primaryColors.text,
+        backgroundColor: primaryColors.main
+      }
+    },
+    MuiCardActions: {
+      root: {
+        backgroundColor: 'rgba(0, 0, 0, 0.2) !important'
+      }
+    },
+    MuiDialog: {
+      paper: {
+        boxShadow: '0 0 5px #222',
+        background: '#000'
+      }
+    },
+    MuiDialogTitle: {
+      root: {
+        borderBottom: '1px solid #222',
+        '& h2': {
+          color: primaryColors.headline
+        }
+      }
+    },
+    MuiDrawer: {
+      paper: {
+        boxShadow: '0 0 5px #222'
+      }
+    },
+    MuiExpansionPanel: {
+      root: {
+        '& table': {
+          border: `1px solid ${primaryColors.divider}`
+        }
+      }
+    },
+    MuiExpansionPanelDetails: {
+      root: {
+        backgroundColor: '#32363c'
+      }
+    },
+    MuiExpansionPanelSummary: {
+      root: {
+        '&$focused': {
+          backgroundColor: '#111111'
+        },
+        backgroundColor: '#32363c',
+        '&:hover': {
+          '& h3': {
+            color: primaryColors.light
+          },
+          '& $expandIcon': {
+            '& svg': {
+              fill: primaryColors.light
+            }
+          }
+        }
+      },
+      expandIcon: {
+        color: primaryColors.main,
+        '& svg': {
+          fill: 'transparent'
+        },
+        '& .border': {
+          stroke: `${primaryColors.light} !important`
+        }
+      },
+      focused: {}
+    },
+    MuiFormControl: {
+      root: {
+        '&.copy > div': {
+          backgroundColor: '#2f3236'
+        }
+      }
+    },
+    MuiFormControlLabel: {
+      root: {
+        '& $disabled': {
+          color: '#aaa !important'
+        }
+      },
+      label: {
+        color: primaryColors.text
+      },
+      disabled: {}
+    },
+    MuiFormLabel: {
+      root: {
+        color: '#c9cacb',
+        '&$focused': {
+          color: '#c9cacb'
+        },
+        '&$error': {
+          color: '#c9cacb'
+        },
+        '&$disabled': {
+          color: '#c9cacb'
+        }
+      }
+    },
+    MuiFormHelperText: {
+      root: {
+        color: '#c9cacb',
+        '&$error': {
+          color: '#ca0813'
+        }
+      }
+    },
+    MuiIconButton: {
+      root: {
+        color: primaryColors.main,
+        '&:hover': {
+          color: primaryColors.light
+        }
+      }
+    },
+    MuiInput: {
+      root: {
+        '&$disabled': {
+          borderColor: '#606469',
+          color: '#ccc !important'
+        },
+        '&$focused': {
+          borderColor: primaryColors.main,
+          boxShadow: '0 0 2px 1px #222'
+        },
+        border: '1px solid #222',
+        color: primaryColors.text,
+        backgroundColor: '#444',
+        '& svg': {
+          color: primaryColors.main
+        }
+      },
+      focused: {},
+      disabled: {}
+    },
+    MuiInputAdornment: {
+      root: {
+        color: '#eee',
+        '& p': {
+          color: '#eee'
+        }
+      }
+    },
+    MuiListItem: {
+      root: {
+        color: primaryColors.text,
+        '&.selectHeader': {
+          color: primaryColors.text
+        }
+      }
+    },
+    MuiMenuItem: {
+      root: {
+        color: primaryColors.text,
+        '&$selected, &$selected:hover': {
+          backgroundColor: 'transparent',
+          color: primaryColors.main,
+          opacity: 1
+        }
+      },
+      selected: {}
+    },
+    MuiPaper: {
+      root: {
+        backgroundColor: '#32363c'
+      }
+    },
+    MuiPopover: {
+      paper: {
+        boxShadow: '0 0 5px #222'
+      }
+    },
+    MuiSelect: {
+      selectMenu: {
+        color: primaryColors.text,
+        backgroundColor: '#444',
+        '&:focus': {
+          backgroundColor: '#444'
+        }
+      }
+    },
+    MuiSnackbarContent: {
+      root: {
+        backgroundColor: '#32363c',
+        color: primaryColors.text,
+        boxShadow: '0 0 5px #222'
+      }
+    },
+    MuiSwitch: {
+      root: {
+        '& $checked': {
+          color: `#abadaf !important`,
+          '& .square': {
+            fill: 'white !important'
+          }
+        }
+      },
+      checked: {},
+      switchBase: {
+        color: '#abadaf !important'
+      },
+      track: {
+        border: '1px solid #222'
+      }
+    },
+    MuiTab: {
+      root: {
+        color: '#fff',
+        '&$selected, &$selected:hover': {
+          color: '#fff'
+        }
+      },
+      textColorPrimary: {
+        color: '#fff',
+        '&$selected, &$selected:hover': {
+          color: '#fff'
+        }
+      },
+      selected: {}
+    },
+    MuiTableCell: {
+      root: {
+        borderTop: `1px solid ${primaryColors.divider}`,
+        borderBottom: `1px solid ${primaryColors.divider}`
+      },
+      head: {
+        color: primaryColors.text,
+        backgroundColor: 'rgba(0, 0, 0, 0.15)'
+      }
+    },
+    MuiTabs: {
+      root: {
+        boxShadow: 'inset 0 -1px 0 #222'
+      },
+      flexContainer: {
+        '& $scrollButtons:first-child': {
+          color: '#222'
+        }
+      },
+      scrollButtons: {
+        color: '#fff'
+      }
+    },
+    MuiTableRow: {
+      root: {
+        backgroundColor: '#32363c',
+        '&:before': {
+          borderLeftColor: '#32363c'
+        },
+        '&:hover, &:focus': {
+          '&$hover': {
+            backgroundColor: 'rgba(0, 0, 0, 0.1)'
+          }
+        }
+      },
+      head: {
+        backgroundColor: '#32363c',
+        '&:before': {
+          backgroundColor: 'rgba(0, 0, 0, 0.15) !important'
+        }
+      },
+      hover: {
+        '& a': {
+          color: primaryColors.text
+        }
+      }
+    },
+    MuiTooltip: {
+      tooltip: {
+        backgroundColor: '#444',
+        boxShadow: '0 0 5px #222',
+        color: '#fff'
+      }
+    },
+    MuiTypography: {
+      root: {
+        '& a.black': {
+          color: primaryColors.text
+        },
+        '& a.black:visited': {
+          color: primaryColors.text
+        },
+        '& a.black:hover': {
+          color: primaryColors.text
+        }
+      }
+    }
+  }
+};

--- a/packages/manager/src/utilities/storybookDecorators.tsx
+++ b/packages/manager/src/utilities/storybookDecorators.tsx
@@ -15,7 +15,7 @@ const ThemeDecorator = (story: Function) => {
   const content = story();
 
   return (
-    <ThemeProvider theme={options[key]({ spacingOverride: 8 })}>
+    <ThemeProvider theme={options[key](8)}>
       <CssBaseline />
       {content}
     </ThemeProvider>


### PR DESCRIPTION
## Description

This PR does two things: 

- Memoizes safelyGetTheme in PreferenceToggle so that createTheme isn't called repeatedly.
- Improves markup by not passing the theme object to every component wrapped in RenderGuard (that's why we were getting `<div theme="[object Object]" />` throughout the markup).

I've tried to run some benchmarks but haven't produced anything that proves performance is actually better. It _feels_ snappier to me, but the placebo effect is powerful, so I'm taking that with a grain of salt. I'm curious to know you're experience.

**Note:** many of the line changes are the result of moving the dark theme options to a variable.

In any case, the markup is cleaner this way, and we demonstrably save some JavaScript cycles by not calling the createTheme methods with almost every render.


## Note to Reviewers

Please check various places throughout the app. Theme selection selection should work, and components should update appropriately. Check the markup.