### PR TITLE
Add LKE as searchable entity

### DIFF
--- a/packages/linode-js-sdk/src/kubernetes/types.ts
+++ b/packages/linode-js-sdk/src/kubernetes/types.ts
@@ -1,10 +1,12 @@
 export interface KubernetesCluster {
   created: string;
+  updated: string;
   region: string;
   status: string; // @todo enum this
   label: string;
   k8s_version: string;
   id: number;
+  tags: string[];
 }
 
 export interface KubeNodePoolResponse {

--- a/packages/manager/src/__data__/kubernetes.ts
+++ b/packages/manager/src/__data__/kubernetes.ts
@@ -6,17 +6,21 @@ export const clusters: KubernetesCluster[] = [
     region: 'us-central',
     label: 'cluster-1',
     created: '2019-04-29 18:02:17',
+    updated: '2019-04-29 18:02:17',
     id: 35,
     status: 'running',
-    k8s_version: '1.13.5'
+    k8s_version: '1.13.5',
+    tags: []
   },
   {
     region: 'us-central',
     label: 'cluster-2',
     created: '2019-04-29 18:02:17',
+    updated: '2019-04-29 18:02:17',
     id: 34,
     status: 'running',
-    k8s_version: '1.13.5'
+    k8s_version: '1.13.5',
+    tags: []
   }
 ];
 

--- a/packages/manager/src/factories/kubernetesCluster.ts
+++ b/packages/manager/src/factories/kubernetesCluster.ts
@@ -50,6 +50,7 @@ export const kubernetesClusterFactory = Factory.Sync.makeFactory<
 >({
   id: Factory.each(id => id),
   created: '2020-01-01 8:00',
+  updated: '2020-01-01 8:00',
   region: 'us-central',
   status: 'ready',
   label: Factory.each(i => `test-cluster-${i}`),
@@ -57,5 +58,6 @@ export const kubernetesClusterFactory = Factory.Sync.makeFactory<
   node_pools: nodePoolFactory.buildList(2),
   totalMemory: 1000,
   totalCPU: 4,
-  totalStorage: 1000
+  totalStorage: 1000,
+  tags: []
 });

--- a/packages/manager/src/features/Search/SearchLanding.test.tsx
+++ b/packages/manager/src/features/Search/SearchLanding.test.tsx
@@ -21,7 +21,8 @@ const props: Props = {
     domains: false,
     nodebalancers: false,
     images: false,
-    volumes: false
+    volumes: false,
+    kubernetes: false
   },
   ...reactRouterProps
 };

--- a/packages/manager/src/features/Search/SearchLanding.tsx
+++ b/packages/manager/src/features/Search/SearchLanding.tsx
@@ -53,7 +53,8 @@ const displayMap = {
   domains: 'Domains',
   volumes: 'Volumes',
   nodebalancers: 'NodeBalancers',
-  images: 'Images'
+  images: 'Images',
+  kubernetesClusters: 'Kubernetes'
 };
 
 export type CombinedProps = SearchProps & RouteComponentProps<{}>;
@@ -74,6 +75,9 @@ const getErrorMessage = (errors: ErrorObject): string => {
   }
   if (errors.images) {
     errorString.push('Images');
+  }
+  if (errors.kubernetes) {
+    errorString.push('Kubernetes');
   }
   const joined = errorString.join(', ');
   return `Could not retrieve search results for: ${joined}`;
@@ -105,7 +109,8 @@ export const SearchLanding: React.FC<CombinedProps> = props => {
     'volumes',
     'nodeBalancers',
     'images',
-    'domains'
+    'domains',
+    'kubernetes'
   ]);
 
   React.useEffect(() => {

--- a/packages/manager/src/features/Search/search.interfaces.ts
+++ b/packages/manager/src/features/Search/search.interfaces.ts
@@ -15,7 +15,8 @@ export type SearchableEntityType =
   | 'volume'
   | 'domain'
   | 'image'
-  | 'nodebalancer';
+  | 'nodebalancer'
+  | 'kubernetesCluster';
 
 // These are the properties on our entities we'd like to search
 export type SearchField = 'tags' | 'label' | 'ips' | 'type';
@@ -26,4 +27,5 @@ export interface SearchResultsByEntity {
   nodebalancers: SearchableItem[];
   domains: SearchableItem[];
   images: SearchableItem[];
+  kubernetesClusters: SearchableItem[];
 }

--- a/packages/manager/src/features/Search/utils.test.ts
+++ b/packages/manager/src/features/Search/utils.test.ts
@@ -12,6 +12,7 @@ describe('separate results by entity', () => {
     expect(results).toHaveProperty('domains');
     expect(results).toHaveProperty('images');
     expect(results).toHaveProperty('nodebalancers');
+    expect(results).toHaveProperty('kubernetesClusters');
   });
 
   it('the value of each entity type is an array', () => {
@@ -20,6 +21,7 @@ describe('separate results by entity', () => {
     expect(results.domains).toBeInstanceOf(Array);
     expect(results.images).toBeInstanceOf(Array);
     expect(results.nodebalancers).toBeInstanceOf(Array);
+    expect(results.kubernetesClusters).toBeInstanceOf(Array);
   });
 
   it('returns empty results if there is no data', () => {
@@ -29,7 +31,8 @@ describe('separate results by entity', () => {
       volumes: [],
       domains: [],
       images: [],
-      nodebalancers: []
+      nodebalancers: [],
+      kubernetesClusters: []
     });
   });
 });

--- a/packages/manager/src/features/Search/utils.ts
+++ b/packages/manager/src/features/Search/utils.ts
@@ -1,23 +1,12 @@
-import DomainIcon from 'src/assets/addnewmenu/domain.svg';
-import LinodeIcon from 'src/assets/addnewmenu/linode.svg';
-import NodebalIcon from 'src/assets/addnewmenu/nodebalancer.svg';
-import VolumeIcon from 'src/assets/addnewmenu/volume.svg';
 import { SearchableItem, SearchResultsByEntity } from './search.interfaces';
-
-export const iconMap = {
-  LinodeIcon,
-  NodebalIcon,
-  VolumeIcon,
-  DomainIcon,
-  default: LinodeIcon
-};
 
 export const emptyResults: SearchResultsByEntity = {
   linodes: [],
   volumes: [],
   domains: [],
   images: [],
-  nodebalancers: []
+  nodebalancers: [],
+  kubernetesClusters: []
 };
 
 export const separateResultsByEntity = (
@@ -28,7 +17,8 @@ export const separateResultsByEntity = (
     volumes: [],
     domains: [],
     images: [],
-    nodebalancers: []
+    nodebalancers: [],
+    kubernetesClusters: []
   };
 
   searchResults.forEach(result => {

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -69,7 +69,7 @@ export const SearchBar: React.FC<CombinedProps> = props => {
   const [menuOpen, setMenuOpen] = React.useState<boolean>(false);
 
   const { _loading } = useReduxLoad(
-    ['linodes', 'nodeBalancers', 'images', 'domains', 'volumes'],
+    ['linodes', 'nodeBalancers', 'images', 'domains', 'volumes', 'kubernetes'],
     REFRESH_INTERVAL,
     searchActive // Only request things if the search bar is open/active.
   );

--- a/packages/manager/src/store/selectors/entitiesErrors.ts
+++ b/packages/manager/src/store/selectors/entitiesErrors.ts
@@ -11,6 +11,7 @@ export interface ErrorObject {
   domains: boolean;
   images: boolean;
   nodebalancers: boolean;
+  kubernetes: boolean;
 }
 
 export const linodesErrorSelector = (state: State) => {
@@ -25,9 +26,12 @@ export const imagesErrorSelector = (state: State) =>
   Object.values(state.images.error ?? {}).some(Boolean);
 export const typesErrorSelector = (state: State) =>
   Boolean(state.types.error && state.types.error.length > 0);
+export const kubernetesErrorSelector = (state: State) =>
+  Object.values(state.kubernetes.error ?? {}).some(Boolean);
 
 export default createSelector<
   State,
+  boolean,
   boolean,
   boolean,
   boolean,
@@ -40,12 +44,15 @@ export default createSelector<
   nodeBalsErrorSelector,
   domainsErrorSelector,
   imagesErrorSelector,
-  (linodes, volumes, nodebalancers, domains, images) => ({
+  kubernetesErrorSelector,
+  (linodes, volumes, nodebalancers, domains, images, kubernetes) => ({
     linodes,
     volumes,
     nodebalancers,
     domains,
     images,
-    hasErrors: linodes || volumes || nodebalancers || domains || images
+    kubernetes,
+    hasErrors:
+      linodes || volumes || nodebalancers || domains || images || kubernetes
   })
 );

--- a/packages/manager/src/store/selectors/getSearchEntities.ts
+++ b/packages/manager/src/store/selectors/getSearchEntities.ts
@@ -1,5 +1,6 @@
 import { Domain } from 'linode-js-sdk/lib/domains';
 import { Image } from 'linode-js-sdk/lib/images';
+import { KubernetesCluster } from 'linode-js-sdk/lib/kubernetes';
 import { Linode, LinodeType } from 'linode-js-sdk/lib/linodes';
 import { NodeBalancer } from 'linode-js-sdk/lib/nodebalancers';
 import { Volume } from 'linode-js-sdk/lib/volumes';
@@ -120,6 +121,25 @@ const nodeBalToSearchableItem = (nodebal: NodeBalancer): SearchableItem => ({
   }
 });
 
+const kubernetesClusterToSearchableItem = (
+  kubernetesCluster: KubernetesCluster
+): SearchableItem => ({
+  label: kubernetesCluster.label,
+  value: kubernetesCluster.id,
+  entityType: 'kubernetesCluster',
+  data: {
+    icon: 'kube',
+    path: `/kubernetes/clusters/${kubernetesCluster.id}/summary`,
+    status: kubernetesCluster.status,
+    created: kubernetesCluster.created,
+    updated: kubernetesCluster.updated,
+    label: kubernetesCluster.label,
+    region: kubernetesCluster.region,
+    k8s_version: kubernetesCluster.k8s_version,
+    tags: kubernetesCluster.tags
+  }
+});
+
 const linodeSelector = (state: State) => Object.values(state.linodes.itemsById);
 const volumeSelector = ({ volumes }: State) => Object.values(volumes.itemsById);
 const nodebalSelector = ({ nodeBalancers }: State) =>
@@ -128,6 +148,7 @@ const imageSelector = (state: State) => state.images.data || {};
 const domainSelector = (state: State) =>
   Object.values(state.domains.itemsById) || [];
 const typesSelector = (state: State) => state.types.entities;
+const kubernetesClusterSelector = (state: State) => state.kubernetes.entities;
 
 export default createSelector<
   State,
@@ -137,6 +158,7 @@ export default createSelector<
   Domain[],
   NodeBalancer[],
   LinodeType[],
+  KubernetesCluster[],
   SearchableItem[]
 >(
   linodeSelector,
@@ -145,7 +167,16 @@ export default createSelector<
   domainSelector,
   nodebalSelector,
   typesSelector,
-  (linodes, volumes, images, domains, nodebalancers, types) => {
+  kubernetesClusterSelector,
+  (
+    linodes,
+    volumes,
+    images,
+    domains,
+    nodebalancers,
+    types,
+    kubernetesClusters
+  ) => {
     const arrOfImages = Object.values(images);
     const searchableLinodes = linodes.map(linode =>
       formatLinode(linode, types, images)
@@ -154,13 +185,17 @@ export default createSelector<
     const searchableImages = arrOfImages.reduce(imageReducer, []);
     const searchableDomains = domains.map(domainToSearchableItem);
     const searchableNodebalancers = nodebalancers.map(nodeBalToSearchableItem);
+    const searchableKubernetesClusters = kubernetesClusters.map(
+      kubernetesClusterToSearchableItem
+    );
 
     return [
       ...searchableLinodes,
       ...searchableVolumes,
       ...searchableImages,
       ...searchableDomains,
-      ...searchableNodebalancers
+      ...searchableNodebalancers,
+      ...searchableKubernetesClusters
     ];
   }
 );

--- a/packages/manager/src/store/selectors/getSearchEntitites.test.ts
+++ b/packages/manager/src/store/selectors/getSearchEntitites.test.ts
@@ -7,6 +7,7 @@ import {
   types,
   volumes
 } from 'src/__data__';
+import { kubernetesClusterFactory } from 'src/factories/kubernetesCluster';
 import { apiResponseToMappedState } from 'src/store/store.helpers.tmp';
 import getSearchEntities from './getSearchEntities';
 
@@ -26,6 +27,9 @@ describe('getSearchEntities selector', () => {
         (result, c) => ({ ...result, [c.id]: c }),
         {}
       )
+    },
+    kubernetes: {
+      entities: kubernetesClusterFactory.buildList(2)
     }
   };
   it('should return an array of SearchableItems', () => {


### PR DESCRIPTION
## Description

Previously Kubernetes Clusters were not searchable in our search bar. Now that we're going to support tags, we need clusters to be searchable (clicking on a tag takes you to the search results landing page).

Also updated the KubernetesCluster type to include `tags[]` and `updated`.

To test: make sure everything with search still function. Search bar, search landing, failure scenarios, etc.

