### PR TITLE
Fix SelectPlanPanel visual regression

### DIFF
--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -144,7 +144,7 @@ export class SelectPlanPanel extends React.Component<
               [classes.disabledRow]: isSamePlan || planTooSmall
             })}
           >
-            <TableCell>
+            <TableCell className={classes.radioCell}>
               {!isSamePlan && (
                 <FormControlLabel
                   label={type.heading}


### PR DESCRIPTION
## Description

Looks like this class was lost here: https://github.com/linode/manager/pull/6295/files#diff-86d0256904fe6812859a8e7f376682f9R147

This made this column too wide.

<img width="782" alt="Screen Shot 2020-04-13 at 2 58 51 PM" src="https://user-images.githubusercontent.com/16911484/79150774-50f52c00-7d97-11ea-9898-c631e4ad1a73.png">
