### PR TITLE
[for release] Add min/max on EnhancedNumberInput

### DIFF
--- a/packages/manager/src/components/EnhancedNumberInput/EnhancedNumberInput.stories.tsx
+++ b/packages/manager/src/components/EnhancedNumberInput/EnhancedNumberInput.stories.tsx
@@ -1,6 +1,6 @@
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
-
+import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 import EnhancedNumberInput from './EnhancedNumberInput';
 
@@ -29,6 +29,31 @@ storiesOf('Enhanced Number Input', module)
     return (
       <Grid container style={{ padding: '2em' }}>
         <EnhancedNumberInput value={value} setValue={setValue} disabled />
+      </Grid>
+    );
+  })
+  .add('Max/Min', () => {
+    const [value, setValue] = React.useState<number>(0);
+
+    return (
+      <Grid container style={{ padding: '2em' }}>
+        <Grid item xs={12} style={{ marginBottom: 24 }}>
+          <Typography variant="h2" style={{ marginBottom: 12 }}>
+            Defaults (0, 100)
+          </Typography>
+          <EnhancedNumberInput value={value} setValue={setValue} />
+        </Grid>
+        <Grid item xs={12}>
+          <Typography variant="h2" style={{ marginBottom: 12 }}>
+            Custom (1, 5)
+          </Typography>
+          <EnhancedNumberInput
+            value={value}
+            setValue={setValue}
+            min={1}
+            max={5}
+          />
+        </Grid>
       </Grid>
     );
   });

--- a/packages/manager/src/components/EnhancedNumberInput/EnhancedNumberInput.test.tsx
+++ b/packages/manager/src/components/EnhancedNumberInput/EnhancedNumberInput.test.tsx
@@ -64,6 +64,26 @@ describe('EnhancedNumberInput', () => {
     expect(setValue).toHaveBeenCalledWith(0);
   });
 
+  it('should respect min values', () => {
+    const { getByTestId } = render(
+      wrapWithTheme(<EnhancedNumberInput {...props} value={0} min={1} />)
+    );
+
+    const input = getByTestId('textfield-input') as HTMLInputElement;
+    expect(input.value).toBe('1');
+    expect(getByTestId('decrement-button')).toHaveAttribute('disabled');
+  });
+
+  it('should respect max values', () => {
+    const { getByTestId } = render(
+      wrapWithTheme(<EnhancedNumberInput {...props} value={6} max={5} />)
+    );
+
+    const input = getByTestId('textfield-input') as HTMLInputElement;
+    expect(input.value).toBe('5');
+    expect(getByTestId('increment-button')).toHaveAttribute('disabled');
+  });
+
   it('should display buttons and input as disabled when given the corresponding prop', () => {
     const { getByTestId } = render(
       wrapWithTheme(<EnhancedNumberInput {...disabledProps} />)

--- a/packages/manager/src/components/EnhancedNumberInput/EnhancedNumberInput.tsx
+++ b/packages/manager/src/components/EnhancedNumberInput/EnhancedNumberInput.tsx
@@ -164,4 +164,4 @@ export const EnhancedNumberInput: React.FC<FinalProps> = props => {
   );
 };
 
-export default EnhancedNumberInput;
+export default React.memo(EnhancedNumberInput);

--- a/packages/manager/src/components/EnhancedNumberInput/EnhancedNumberInput.tsx
+++ b/packages/manager/src/components/EnhancedNumberInput/EnhancedNumberInput.tsx
@@ -90,7 +90,10 @@ export const EnhancedNumberInput: React.FC<FinalProps> = props => {
   }
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setValue(+e.target.value);
+    const parsedValue = +e.target.value;
+    if (parsedValue >= min && parsedValue <= max) {
+      setValue(+e.target.value);
+    }
   };
 
   const incrementValue = () => {

--- a/packages/manager/src/components/EnhancedNumberInput/EnhancedNumberInput.tsx
+++ b/packages/manager/src/components/EnhancedNumberInput/EnhancedNumberInput.tsx
@@ -70,21 +70,37 @@ interface Props {
   value: number;
   setValue: (value: number) => void;
   disabled?: boolean;
+  max?: number;
+  min?: number;
 }
 
 type FinalProps = Props;
 
 export const EnhancedNumberInput: React.FC<FinalProps> = props => {
-  const { inputLabel, small, value, setValue, disabled } = props;
+  const { inputLabel, small, setValue, disabled } = props;
+
+  const max = props.max ?? 100;
+  const min = props.min ?? 0;
+
+  let value = props.value;
+  if (value > max) {
+    value = max;
+  } else if (value < min) {
+    value = min;
+  }
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setValue(+e.target.value);
   };
 
-  const incrementValue = () => setValue(value + 1);
+  const incrementValue = () => {
+    if (value < max) {
+      setValue(value + 1);
+    }
+  };
 
   const decrementValue = () => {
-    if (value > 0) {
+    if (value > min) {
       setValue(value - 1);
     }
   };
@@ -106,7 +122,7 @@ export const EnhancedNumberInput: React.FC<FinalProps> = props => {
           aria-label="Subtract 1"
           name="Subtract 1"
           onClick={decrementValue}
-          disabled={disabled || value === 0 ? true : false}
+          disabled={disabled || value === min}
           data-testid={'decrement-button'}
         >
           <Minus className={classes.minusIcon} />
@@ -125,8 +141,8 @@ export const EnhancedNumberInput: React.FC<FinalProps> = props => {
             className: classnames({
               [classes.input]: true
             }),
-            min: 0,
-            max: 100
+            min,
+            max
           }}
           disabled={disabled}
           data-testid={'quantity-input'}
@@ -138,7 +154,7 @@ export const EnhancedNumberInput: React.FC<FinalProps> = props => {
           aria-label="Add 1"
           name="Add 1"
           onClick={incrementValue}
-          disabled={disabled}
+          disabled={disabled || value === max}
           data-testid={'increment-button'}
         >
           <Plus className={classes.plusIcon} />

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/NodePoolSummary.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/NodePoolSummary.tsx
@@ -80,6 +80,7 @@ export const NodePoolSummary: React.FC<Props> = props => {
           value={nodeCount}
           setValue={updateNodeCount}
           small
+          min={1}
         />
       </Grid>
       <Grid item>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/ResizeNodePoolDrawer/ResizeNodePoolDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/ResizeNodePoolDrawer/ResizeNodePoolDrawer.tsx
@@ -7,6 +7,7 @@ import Drawer from 'src/components/Drawer';
 import EnhancedNumberInput from 'src/components/EnhancedNumberInput';
 import Notice from 'src/components/Notice';
 import { useTypes } from 'src/hooks/useTypes';
+import { pluralize } from 'src/utilities/pluralize';
 import { nodeWarning } from '../../kubeUtils';
 import { PoolNodeWithPrice } from '../../types';
 
@@ -89,8 +90,8 @@ export const ResizeNodePoolDrawer: React.FC<Props> = props => {
       >
         <div className={classes.section}>
           <Typography className={classes.summary}>
-            Current pool: ${nodePool.totalMonthlyPrice}/month ({nodePool.count}{' '}
-            nodes at ${pricePerNode}/month)
+            Current pool: ${nodePool.totalMonthlyPrice}/month (
+            {pluralize('node', 'nodes', updatedCount)} at ${pricePerNode}/month)
           </Typography>
         </div>
 
@@ -104,13 +105,14 @@ export const ResizeNodePoolDrawer: React.FC<Props> = props => {
             value={updatedCount}
             setValue={handleChange}
             small
+            min={1}
           />
         </div>
 
         <div className={classes.section}>
           <Typography className={classes.summary}>
-            Resized pool: ${updatedCount * pricePerNode}/month ({updatedCount}{' '}
-            nodes at ${pricePerNode}/month)
+            Resized pool: ${updatedCount * pricePerNode}/month (
+            {pluralize('node', 'nodes', updatedCount)} at ${pricePerNode}/month)
           </Typography>
         </div>
 


### PR DESCRIPTION
## Description

The min in the Resize drawer needed to be `1`, otherwise you could do this:

![Screen Shot 2020-04-14 at 9 41 15 AM](https://user-images.githubusercontent.com/16911484/79235559-c4e81080-7e39-11ea-9c43-ca2211bb5dfa.png)

I added max and min props to EnhancedNumberInput and added `min={1}` in the Resize drawer. I also updated pluralization for the copy (to fix "1 nodes").

TODO: 
- [x] add test

## Note to Reviewers

Please check the create flow works as expected as well. Now, the increment button will be disabled if the value is `100` (@Jskobos mentioned this was the upper limit).
