### PR TITLE
[LKE] Disable "Create Cluster" button unless at least 1 Node Pool has been added

### DIFF
--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
@@ -40,7 +40,7 @@ export const KubeCheckoutBar: React.FC<Props> = props => {
               heading="Cluster Summary"
               calculatedPrice={getTotalClusterPrice(pools)}
               isMakingRequest={submitting}
-              disabled={false}
+              disabled={pools.length > 0 ? false : true}
               onDeploy={createCluster}
               submitText={'Create Cluster'}
             >

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
@@ -40,7 +40,7 @@ export const KubeCheckoutBar: React.FC<Props> = props => {
               heading="Cluster Summary"
               calculatedPrice={getTotalClusterPrice(pools)}
               isMakingRequest={submitting}
-              disabled={pools.length > 0 ? false : true}
+              disabled={pools.length < 1}
               onDeploy={createCluster}
               submitText={'Create Cluster'}
             >


### PR DESCRIPTION
## Description
Disable the LKE "Create Cluster" button when there are no Node Pools added.

## Type of Change
- Non breaking change ('update', 'change')
