### PR TITLE
Clear permissions errors on form submit

### DIFF
--- a/packages/manager/src/features/Users/UserPermissions.tsx
+++ b/packages/manager/src/features/Users/UserPermissions.tsx
@@ -207,12 +207,10 @@ class UserPermissions extends React.Component<CombinedProps, State> {
         })
         .catch(errResponse => {
           this.setState({
-            errors: [
-              {
-                reason:
-                  'Unknown error occured while fetching user permissions. Try again later.'
-              }
-            ]
+            errors: getAPIErrorOrDefault(
+              errResponse,
+              'Unknown error occurred while fetching user permissions. Try again later.'
+            )
           });
           scrollErrorIntoView();
         });
@@ -230,6 +228,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
   }
 
   savePermsType = (type: string) => () => {
+    this.setState({ errors: undefined });
     const { username, clearNewUser } = this.props;
     const { grants } = this.state;
     if (!username || !(grants && grants[type])) {
@@ -285,6 +284,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
   };
 
   saveSpecificGrants = () => {
+    this.setState({ errors: undefined });
     const { username } = this.props;
     const { grants } = this.state;
     if (!username || !grants) {


### PR DESCRIPTION
## Description
I wasn't able to reproduce the issue described in this ticket. I pinged Adrien and we can probably close it out or refer it to ARB. I did find that we're not clearing errors on the UserPermissions form on submit, so I did that here.