### PR TITLE
[LKE] Unit test for "Create Cluster" button being disabled when 0 Node Pools added

### DIFF
--- a/packages/manager/src/components/CheckoutBar/CheckoutBar.tsx
+++ b/packages/manager/src/components/CheckoutBar/CheckoutBar.tsx
@@ -62,6 +62,7 @@ const CheckoutBar = React.forwardRef<any, CombinedProps>((props, ref) => {
           onClick={onDeploy}
           data-qa-deploy-linode
           loading={isMakingRequest}
+          data-testid="checkout-btn"
         >
           {submitText ?? 'Create'}
         </Button>

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.test.tsx
@@ -8,7 +8,6 @@ import { renderWithTheme } from 'src/utilities/testHelpers';
 import KubeCheckoutBar, { Props } from './KubeCheckoutBar';
 
 const pools = nodePoolFactory.buildList(5, { count: 3 });
-const emptyPools = nodePoolFactory.buildList(0, { count: 0 });
 
 const props: Props = {
   pools,
@@ -56,7 +55,7 @@ describe('KubeCheckoutBar', () => {
   it('should have a disabled "Create Cluster" button if no Node Pools have been added', () => {
     const { queryByTestId } = renderComponent({
       ...props,
-      pools: emptyPools
+      pools: []
     });
 
     expect(queryByTestId(/checkout-btn/i)).toBeDisabled();

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.test.tsx
@@ -8,6 +8,7 @@ import { renderWithTheme } from 'src/utilities/testHelpers';
 import KubeCheckoutBar, { Props } from './KubeCheckoutBar';
 
 const pools = nodePoolFactory.buildList(5, { count: 3 });
+const emptyPools = nodePoolFactory.buildList(0, { count: 0 });
 
 const props: Props = {
   pools,
@@ -50,5 +51,14 @@ describe('KubeCheckoutBar', () => {
   it('should display the total price of the cluster', () => {
     const { getByText } = renderComponent(props);
     getByText(/\$5,000\.00/);
+  });
+
+  it('should have a disabled "Create Cluster" button if no Node Pools have been added', () => {
+    const { queryByTestId } = renderComponent({
+      ...props,
+      pools: emptyPools
+    });
+
+    expect(queryByTestId(/checkout-btn/i)).toBeDisabled();
   });
 });

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
@@ -40,7 +40,7 @@ export const KubeCheckoutBar: React.FC<Props> = props => {
               heading="Cluster Summary"
               calculatedPrice={getTotalClusterPrice(pools)}
               isMakingRequest={submitting}
-              disabled={false}
+              disabled={pools.length > 0 ? false : true}
               onDeploy={createCluster}
               submitText={'Create Cluster'}
             >

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
@@ -40,7 +40,7 @@ export const KubeCheckoutBar: React.FC<Props> = props => {
               heading="Cluster Summary"
               calculatedPrice={getTotalClusterPrice(pools)}
               isMakingRequest={submitting}
-              disabled={pools.length > 0 ? false : true}
+              disabled={pools.length < 1}
               onDeploy={createCluster}
               submitText={'Create Cluster'}
             >


### PR DESCRIPTION
## Description
Follow-up to https://github.com/linode/manager/pull/6322.

Added a data-testid attribute to the Button in `CheckoutBar` component and a unit test to make sure the button is disabled when zero Node Pools have been added by user.

## Type of Change
- Non breaking change ('update', 'change')

## Testing
`yarn test KubeCheckoutBar.tsx`

## Note to Reviewers
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.