### PR TITLE
[LKE] Unit test for "Create Cluster" button being disabled when 0 Node Pools added

### DIFF
--- a/packages/manager/src/components/CheckoutBar/CheckoutBar.tsx
+++ b/packages/manager/src/components/CheckoutBar/CheckoutBar.tsx
@@ -62,6 +62,7 @@ const CheckoutBar = React.forwardRef<any, CombinedProps>((props, ref) => {
           onClick={onDeploy}
           data-qa-deploy-linode
           loading={isMakingRequest}
+          data-testid="checkout-btn"
         >
           {submitText ?? 'Create'}
         </Button>

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.test.tsx
@@ -51,4 +51,13 @@ describe('KubeCheckoutBar', () => {
     const { getByText } = renderComponent(props);
     getByText(/\$5,000\.00/);
   });
+
+  it('should have a disabled "Create Cluster" button if no Node Pools have been added', () => {
+    const { queryByTestId } = renderComponent({
+      ...props,
+      pools: []
+    });
+
+    expect(queryByTestId(/checkout-btn/i)).toBeDisabled();
+  });
 });


### PR DESCRIPTION
## Description
Follow-up to https://github.com/linode/manager/pull/6322.

Added a data-testid attribute to the Button in `CheckoutBar` component and a unit test to make sure the button is disabled when zero Node Pools have been added by user.

## Type of Change
- Non breaking change ('update', 'change')

## Testing
`yarn test KubeCheckoutBar.tsx`

## Note to Reviewers
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.