### PR TITLE
Update LKE endpoint and capabilities

### DIFF
--- a/packages/linode-js-sdk/src/kubernetes/kubernetes.ts
+++ b/packages/linode-js-sdk/src/kubernetes/kubernetes.ts
@@ -1,4 +1,4 @@
-import { BETA_API_ROOT } from 'src/constants';
+import { API_ROOT } from 'src/constants';
 import Request, {
   setData,
   setMethod,
@@ -26,7 +26,7 @@ export const getKubernetesClusters = (params?: any, filters?: any) =>
     setMethod('GET'),
     setParams(params),
     setXFilter(filters),
-    setURL(`${BETA_API_ROOT}/lke/clusters`)
+    setURL(`${API_ROOT}/lke/clusters`)
   ).then(response => response.data);
 
 /**
@@ -37,7 +37,7 @@ export const getKubernetesClusters = (params?: any, filters?: any) =>
 export const getKubernetesCluster = (clusterID: number) =>
   Request<KubernetesCluster>(
     setMethod('GET'),
-    setURL(`${BETA_API_ROOT}/lke/clusters/${clusterID}`)
+    setURL(`${API_ROOT}/lke/clusters/${clusterID}`)
   ).then(response => response.data);
 
 /**
@@ -48,7 +48,7 @@ export const getKubernetesCluster = (clusterID: number) =>
 export const createKubernetesCluster = (data: CreateKubeClusterPayload) =>
   Request<KubernetesCluster>(
     setMethod('POST'),
-    setURL(`${BETA_API_ROOT}/lke/clusters`),
+    setURL(`${API_ROOT}/lke/clusters`),
     setData(data, createKubeClusterSchema)
   ).then(response => response.data);
 
@@ -63,7 +63,7 @@ export const updateKubernetesCluster = (
 ) =>
   Request<KubernetesCluster>(
     setMethod('PUT'),
-    setURL(`${BETA_API_ROOT}/lke/clusters/${clusterID}`),
+    setURL(`${API_ROOT}/lke/clusters/${clusterID}`),
     setData(data)
   ).then(response => response.data);
 
@@ -75,7 +75,7 @@ export const updateKubernetesCluster = (
 export const deleteKubernetesCluster = (clusterID: number) =>
   Request<{}>(
     setMethod('DELETE'),
-    setURL(`${BETA_API_ROOT}/lke/clusters/${clusterID}`)
+    setURL(`${API_ROOT}/lke/clusters/${clusterID}`)
   ).then(response => response.data);
 
 /** getKubeConfig
@@ -88,7 +88,7 @@ export const deleteKubernetesCluster = (clusterID: number) =>
 export const getKubeConfig = (clusterId: number) =>
   Request<KubeConfigResponse>(
     setMethod('GET'),
-    setURL(`${BETA_API_ROOT}/lke/clusters/${clusterId}/kubeconfig`)
+    setURL(`${API_ROOT}/lke/clusters/${clusterId}/kubeconfig`)
   ).then(response => response.data);
 
 /** getKubernetesVersions
@@ -100,7 +100,7 @@ export const getKubeConfig = (clusterId: number) =>
 export const getKubernetesVersions = () =>
   Request<Page<KubernetesVersion>>(
     setMethod('GET'),
-    setURL(`${BETA_API_ROOT}/lke/versions`)
+    setURL(`${API_ROOT}/lke/versions`)
   ).then(response => response.data);
 
 /** getKubernetesVersion
@@ -112,7 +112,7 @@ export const getKubernetesVersions = () =>
 export const getKubernetesVersion = (versionID: string) =>
   Request<KubernetesVersion>(
     setMethod('GET'),
-    setURL(`${BETA_API_ROOT}/lke/versions/${versionID}`)
+    setURL(`${API_ROOT}/lke/versions/${versionID}`)
   ).then(response => response.data);
 
 /** getKubernetesClusterEndpoint
@@ -124,5 +124,5 @@ export const getKubernetesVersion = (versionID: string) =>
 export const getKubernetesClusterEndpoints = (clusterID: number) =>
   Request<Page<KubernetesEndpointResponse>>(
     setMethod('GET'),
-    setURL(`${BETA_API_ROOT}/lke/clusters/${clusterID}/api-endpoints`)
+    setURL(`${API_ROOT}/lke/clusters/${clusterID}/api-endpoints`)
   ).then(response => response.data);

--- a/packages/linode-js-sdk/src/kubernetes/nodePools.ts
+++ b/packages/linode-js-sdk/src/kubernetes/nodePools.ts
@@ -1,4 +1,4 @@
-import { BETA_API_ROOT } from 'src/constants';
+import { API_ROOT } from 'src/constants';
 import Request, {
   setData,
   setMethod,
@@ -20,7 +20,7 @@ export const getNodePools = (clusterID: number, params?: any, filters?: any) =>
     setMethod('GET'),
     setParams(params),
     setXFilter(filters),
-    setURL(`${BETA_API_ROOT}/lke/clusters/${clusterID}/pools`)
+    setURL(`${API_ROOT}/lke/clusters/${clusterID}/pools`)
   ).then(response => response.data);
 
 /**
@@ -31,7 +31,7 @@ export const getNodePools = (clusterID: number, params?: any, filters?: any) =>
 export const getNodePool = (clusterID: number, nodePoolID: number) =>
   Request<KubeNodePoolResponse>(
     setMethod('GET'),
-    setURL(`${BETA_API_ROOT}/lke/clusters/${clusterID}/pools/${nodePoolID}`)
+    setURL(`${API_ROOT}/lke/clusters/${clusterID}/pools/${nodePoolID}`)
   ).then(response => response.data);
 
 /**
@@ -42,7 +42,7 @@ export const getNodePool = (clusterID: number, nodePoolID: number) =>
 export const createNodePool = (clusterID: number, data: PoolNodeRequest) =>
   Request<KubeNodePoolResponse>(
     setMethod('POST'),
-    setURL(`${BETA_API_ROOT}/lke/clusters/${clusterID}/pools`),
+    setURL(`${API_ROOT}/lke/clusters/${clusterID}/pools`),
     setData(data, nodePoolSchema)
   ).then(response => response.data);
 
@@ -58,7 +58,7 @@ export const updateNodePool = (
 ) =>
   Request<KubeNodePoolResponse>(
     setMethod('PUT'),
-    setURL(`${BETA_API_ROOT}/lke/clusters/${clusterID}/pools/${nodePoolID}`),
+    setURL(`${API_ROOT}/lke/clusters/${clusterID}/pools/${nodePoolID}`),
     setData(data, nodePoolSchema)
   ).then(response => response.data);
 
@@ -70,5 +70,5 @@ export const updateNodePool = (
 export const deleteNodePool = (clusterID: number, nodePoolID: number) =>
   Request<{}>(
     setMethod('DELETE'),
-    setURL(`${BETA_API_ROOT}/lke/clusters/${clusterID}/pools/${nodePoolID}`)
+    setURL(`${API_ROOT}/lke/clusters/${clusterID}/pools/${nodePoolID}`)
   ).then(response => response.data);

--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -22,7 +22,6 @@ import TheApplicationIsOnFire from 'src/features/TheApplicationIsOnFire';
 import composeState from 'src/utilities/composeState';
 import { configureErrorReportingUser } from './exceptionReporting';
 import { MapState } from './store/types';
-import { isKubernetesEnabled as _isKubernetesEnabled } from './utilities/accountCapabilities';
 
 import IdentifyUser from './IdentifyUser';
 

--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -36,8 +36,6 @@ import withFeatureFlags, {
 
 import Logo from 'src/assets/logo/logo-text.svg';
 
-import { isKubernetesEnabled as _isKubernetesEnabled } from './utilities/accountCapabilities';
-
 const useStyles = makeStyles((theme: Theme) => ({
   appFrame: {
     position: 'relative',
@@ -213,8 +211,6 @@ const MainContent: React.FC<CombinedProps> = props => {
 
   const [menuIsOpen, toggleMenu] = React.useState<boolean>(false);
 
-  const isKubernetesEnabled = _isKubernetesEnabled(props.accountCapabilities);
-
   /**
    * this is the case where the user has successfully completed signup
    * but needs a manual review from Customer Support. In this case,
@@ -329,9 +325,7 @@ const MainContent: React.FC<CombinedProps> = props => {
                           path="/object-storage"
                           component={ObjectStorage}
                         />
-                        {isKubernetesEnabled && (
-                          <Route path="/kubernetes" component={Kubernetes} />
-                        )}
+                        <Route path="/kubernetes" component={Kubernetes} />
                         <Route path="/account" component={Account} />
                         <Route
                           exact

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -18,7 +18,6 @@ import withFeatureFlagConsumer, {
   FeatureFlagConsumerProps
 } from 'src/containers/withFeatureFlagConsumer.container';
 import { MapState } from 'src/store/types';
-import { isKubernetesEnabled } from 'src/utilities/accountCapabilities';
 import { sendOneClickNavigationEvent } from 'src/utilities/ga';
 import AdditionalMenuItems from './AdditionalMenuItems';
 import styled, { StyleProps } from './PrimaryNav.styles';
@@ -133,32 +132,17 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
   }
 
   primaryNavManipulator = (): MenuItemReducer[] => {
-    const {
-      hasAccountAccess,
-      isManagedAccount,
-      accountCapabilities,
-      flags
-    } = this.props;
+    const { hasAccountAccess, isManagedAccount, flags } = this.props;
 
     return [
       {
         conditionToAdd: () => isManagedAccount,
-        insertAfter: 'Longview',
+        insertAfter: 'Kubernetes',
         link: {
           display: 'Managed',
           href: '/managed',
           key: 'managed',
           icon: <Managed />
-        }
-      },
-      {
-        conditionToAdd: () => isKubernetesEnabled(accountCapabilities),
-        insertAfter: 'Longview',
-        link: {
-          display: 'Kubernetes',
-          href: '/kubernetes/clusters',
-          key: 'kubernetes',
-          icon: <Kubernetes />
         }
       },
       {
@@ -244,6 +228,12 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
         href: '/longview',
         key: 'longview',
         icon: <Longview className="small" />
+      },
+      {
+        display: 'Kubernetes',
+        href: '/kubernetes/clusters',
+        key: 'kubernetes',
+        icon: <Kubernetes />
       },
       {
         display: 'StackScripts',

--- a/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -30,7 +30,6 @@ import {
 } from 'src/components/core/styles';
 import { openForCreating as openDomainDrawerForCreating } from 'src/store/domainDrawer';
 import { MapState } from 'src/store/types';
-import { isKubernetesEnabled } from 'src/utilities/accountCapabilities';
 import AddNewMenuItem from './AddNewMenuItem';
 
 import { sendOneClickNavigationEvent } from 'src/utilities/ga';
@@ -219,19 +218,17 @@ class AddNewMenu extends React.Component<CombinedProps> {
                   attr={{ 'data-qa-one-click-add-new': true }}
                 />
               </MenuLink>
-              {isKubernetesEnabled(this.props.accountCapabilities) && (
-                <MenuLink
-                  as={Link}
-                  to="/kubernetes/create"
-                  className={classes.menuItemLink}
-                >
-                  <AddNewMenuItem
-                    title="Kubernetes"
-                    body="Create and manage Kubernetes Clusters for highly available container workloads"
-                    ItemIcon={KubernetesIcon}
-                  />
-                </MenuLink>
-              )}
+              <MenuLink
+                as={Link}
+                to="/kubernetes/create"
+                className={classes.menuItemLink}
+              >
+                <AddNewMenuItem
+                  title="Kubernetes"
+                  body="Create and manage Kubernetes Clusters for highly available container workloads"
+                  ItemIcon={KubernetesIcon}
+                />
+              </MenuLink>
             </MenuItems>
           </MenuPopover>
         </Menu>

--- a/packages/manager/src/utilities/accountCapabilities.test.ts
+++ b/packages/manager/src/utilities/accountCapabilities.test.ts
@@ -1,5 +1,6 @@
-const mockTrue = { isObjectStorageEnabledForEnvironment: true };
-const mockFalse = { isObjectStorageEnabledForEnvironment: false };
+import { isFeatureEnabled } from './accountCapabilities';
+
+const isObjectStorageEnabled = isFeatureEnabled('Object Storage');
 
 describe('isObjectStorageEnabled', () => {
   beforeEach(() => {
@@ -7,39 +8,40 @@ describe('isObjectStorageEnabled', () => {
   });
   describe('when "Object Storage EAP" is NOT in beta_programs...', () => {
     it("returns `false` when OBJ isn't enabled for the environment", () => {
-      // Since `isObjectStorageEnabledForEnvironment` is a global constant that
-      // the isObjectStorageEnabled() helper consumes, it needs to be mocked from
-      // constants.ts, and the helper function needs to be imported for each test.
-      jest.mock('src/constants', () => mockFalse);
-      const { isObjectStorageEnabled } = require('./accountCapabilities');
-      expect(isObjectStorageEnabled([])).toBe(false);
-      expect(isObjectStorageEnabled(['Hello', 'World'])).toBe(false);
+      expect(isObjectStorageEnabled(false, [])).toBe(false);
+      expect(isObjectStorageEnabled(false, ['Hello', 'World'] as any)).toBe(
+        false
+      );
     });
 
     it('returns `true` when OBJ is enabled for the environment', () => {
-      jest.mock('src/constants', () => mockTrue);
-      const { isObjectStorageEnabled } = require('./accountCapabilities');
-      expect(isObjectStorageEnabled([])).toBe(true);
-      expect(isObjectStorageEnabled(['Hello', 'World'])).toBe(true);
+      expect(isObjectStorageEnabled(true, [])).toBe(true);
+      expect(isObjectStorageEnabled(true, ['Hello', 'World'] as any)).toBe(
+        true
+      );
     });
   });
 
   describe('when "Object Storage EAP" IS in beta_programs', () => {
     it('returns `true` if OBJ is disabled for environment', () => {
-      jest.mock('src/constants', () => mockFalse);
-      const { isObjectStorageEnabled } = require('./accountCapabilities');
-      expect(isObjectStorageEnabled(['Object Storage'])).toBe(true);
-      expect(isObjectStorageEnabled(['Hello', 'World', 'Object Storage'])).toBe(
-        true
-      );
+      expect(isObjectStorageEnabled(false, ['Object Storage'])).toBe(true);
+      expect(
+        isObjectStorageEnabled(false, [
+          'Hello',
+          'World',
+          'Object Storage'
+        ] as any)
+      ).toBe(true);
     });
     it('returns `true` if OBJ is enabled for environment', () => {
-      jest.mock('src/constants', () => mockFalse);
-      const { isObjectStorageEnabled } = require('./accountCapabilities');
-      expect(isObjectStorageEnabled(['Object Storage'])).toBe(true);
-      expect(isObjectStorageEnabled(['Hello', 'World', 'Object Storage'])).toBe(
-        true
-      );
+      expect(isObjectStorageEnabled(false, ['Object Storage'])).toBe(true);
+      expect(
+        isObjectStorageEnabled(false, [
+          'Hello',
+          'World',
+          'Object Storage'
+        ] as any)
+      ).toBe(true);
     });
   });
 });

--- a/packages/manager/src/utilities/accountCapabilities.ts
+++ b/packages/manager/src/utilities/accountCapabilities.ts
@@ -1,11 +1,6 @@
-import { AccountCapability } from 'linode-js-sdk/lib/account'
+import { AccountCapability } from 'linode-js-sdk/lib/account';
 
 import { curry } from 'ramda';
-
-import {
-  isKubernetesEnabledForEnvironment,
-  isObjectStorageEnabledForEnvironment
-} from 'src/constants';
 
 /**
  * Determines if a feature should be enabled. If the feature is returned from account.capabilities or if it is explicitly enabled
@@ -23,7 +18,7 @@ import {
  * isMyFeatureEnabled(['Feature one', 'Feature two']) // true
  */
 
-const isFeatureEnabled = curry(
+export const isFeatureEnabled = curry(
   (
     featureName: AccountCapability,
     environmentVar: boolean,
@@ -31,14 +26,4 @@ const isFeatureEnabled = curry(
   ) => {
     return environmentVar || capabilities.indexOf(featureName) > -1;
   }
-);
-
-export const isObjectStorageEnabled = isFeatureEnabled(
-  'Object Storage',
-  isObjectStorageEnabledForEnvironment
-);
-
-export const isKubernetesEnabled = isFeatureEnabled(
-  'Kubernetes',
-  isKubernetesEnabledForEnvironment
 );


### PR DESCRIPTION
- Use the normal api root instead of beta for LKE methods in the SDK
- Remove conditional rendering of LKE routes and views
- Remove isObj & isKube enabled methods from accountCapabilities
- Refactor accountCapabilities.test to test the exported generic function
rather than the (deleted) OBJ-specific method.


To test: make sure LKE is working as before.