### PR TITLE
Move identify user functions to fix race condition

### DIFF
--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -20,13 +20,10 @@ import { events$ } from 'src/events';
 import TheApplicationIsOnFire from 'src/features/TheApplicationIsOnFire';
 
 import composeState from 'src/utilities/composeState';
-import { configureErrorReportingUser } from './exceptionReporting';
 import { MapState } from './store/types';
 import { isKubernetesEnabled as _isKubernetesEnabled } from './utilities/accountCapabilities';
 
 import IdentifyUser from './IdentifyUser';
-
-import { initGTMUser } from './analytics';
 import MainContent from './MainContent';
 
 interface Props {
@@ -77,18 +74,6 @@ export class App extends React.Component<CombinedProps, State> {
         (window as any).ga('send', 'pageview', pathname);
       }
     });
-
-    // Configure error reporting to include user information.
-    if (this.props.userId && this.props.username) {
-      configureErrorReportingUser(
-        String(this.props.userId),
-        this.props.username
-      );
-    }
-
-    if (this.props.euuid) {
-      initGTMUser(this.props.euuid);
-    }
 
     /*
      * We want to listen for migration events side-wide
@@ -194,6 +179,7 @@ export class App extends React.Component<CombinedProps, State> {
           accountError={accountError}
           accountCountry={accountData ? accountData.country : undefined}
           taxID={accountData ? accountData.tax_id : undefined}
+          euuid={this.props.euuid}
         />
         <DocumentTitleSegment segment="Linode Manager" />
         <MainContent

--- a/packages/manager/src/IdentifyUser.tsx
+++ b/packages/manager/src/IdentifyUser.tsx
@@ -3,6 +3,8 @@ import * as md5 from 'md5';
 import * as React from 'react';
 import { LAUNCH_DARKLY_API_KEY } from 'src/constants';
 import { useLDClient } from 'src/containers/withFeatureFlagProvider.container';
+import { initGTMUser } from './analytics';
+import { configureErrorReportingUser } from './exceptionReporting';
 
 interface Props {
   accountCountry?: string;
@@ -11,6 +13,7 @@ interface Props {
   username?: string;
   taxID?: string;
   setFlagsLoaded: () => void;
+  euuid?: string;
 }
 
 /**
@@ -27,9 +30,24 @@ export const IdentifyUser: React.FC<Props> = props => {
     accountCountry,
     accountError,
     username,
-    taxID
+    taxID,
+    euuid
   } = props;
   const client = useLDClient();
+
+  // Configure user for error reporting once we have the info we need.
+  React.useEffect(() => {
+    if (userID && username) {
+      configureErrorReportingUser(String(userID), username);
+    }
+  }, [userID, username]);
+
+  // Configure user for GTM once we have the info we need.
+  React.useEffect(() => {
+    if (euuid) {
+      initGTMUser(euuid);
+    }
+  }, [euuid]);
 
   React.useEffect(() => {
     if (!LAUNCH_DARKLY_API_KEY) {


### PR DESCRIPTION
## Description

Previously there was a bug where the `initGTMUser()` function would not fire if the `/account` endpoint was slower than the component was rendered.

To fix this, I moved the `initGTMUser()` invocation to the `<IdentifyUser />` component. 

I also moved the `configureErrorReportingUser()` invocation, which could theoretically be suffering the same bug.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

To reproduce the bug, throw in some console.log statements around this functions and add a breakpoint on on `/account`. You'll see that `initGTMUser()` isn't called because the euuid isn't available in cDM.
