### PR TITLE
M3-4136 Update: Minimum payment placeholder text

### DIFF
--- a/packages/manager/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.test.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.test.tsx
@@ -1,5 +1,6 @@
 import {
   getDefaultPayment,
+  getMinimumPayment,
   isAllowedUSDAmount,
   shouldEnablePaypalButton
 } from './MakeAPaymentPanel';
@@ -38,6 +39,28 @@ describe('Make a Payment Panel', () => {
 
     it('should return a formatted string if the balance is above $5', () => {
       expect(getDefaultPayment(6.1)).toEqual('6.10');
+    });
+  });
+
+  describe('getMinimumPayment helper method', () => {
+    it('should return 5 if the balance due is 0', () => {
+      expect(getMinimumPayment(0, 'CREDIT_CARD')).toBe(5);
+    });
+
+    it('should return the balance if the balance due is less than $5', () => {
+      expect(getMinimumPayment(1.5, 'CREDIT_CARD')).toBe(1.5);
+    });
+
+    it('should return 5 if the user is making a PayPal payment', () => {
+      expect(getMinimumPayment(2, 'PAYPAL')).toBe(5);
+    });
+
+    it('should return 5 if the balance due is less than 0', () => {
+      expect(getMinimumPayment(-10.6, 'CREDIT_CARD')).toBe(5);
+    });
+
+    it('should return 5 if the balance due is greater than 5', () => {
+      expect(getMinimumPayment(100000, 'CREDIT_CARD')).toBe(5);
     });
   });
 });


### PR DESCRIPTION
We show "5.00 minimum" in the number input for choosing a payment amount.
We do this under all conditions, even though the API will accept a smaller
payment if the balance is greater than 0 but less than 5. Our placeholder
has confused a few customers with small balances, who didn't think
it was possible to only pay their balance.

Paypal (I think) always requires a minimum of $5. For all other payments
we follow the API's validation logic.

To test:

You'll have to use admin (dev admin is probably best, reach out if you need help) to invoice yourself for various amounts. dev test account #4 currently has a $1.50 balance, so you can use that to get started. The API's validation logic is explained in the ticket (and in the code comments here).