### PR TITLE
Refactor LKE Redux to use MappedEntityState2

### DIFF
--- a/packages/manager/src/containers/kubernetes.container.ts
+++ b/packages/manager/src/containers/kubernetes.container.ts
@@ -57,7 +57,8 @@ export interface DispatchProps {
 const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
   dispatch: ThunkDispatch<ApplicationState, undefined, AnyAction>
 ) => ({
-  requestKubernetesClusters: () => dispatch(_requestKubernetesClusters()),
+  requestKubernetesClusters: () =>
+    dispatch(_requestKubernetesClusters()).then(response => response.data),
   requestClusterForStore: (clusterID: number) =>
     dispatch(_requestClusterForStore(clusterID)),
   updateCluster: (params: UpdateClusterParams) =>
@@ -105,7 +106,7 @@ const connected: Connected = <ReduxState extends {}, OwnProps extends {}>(
   mapKubernetesToProps?: MapProps<ReduxState, OwnProps>
 ) =>
   connect((state: ApplicationState, ownProps: OwnProps) => {
-    const _clusters = state.__resources.kubernetes.entities;
+    const _clusters = Object.values(state.__resources.kubernetes.itemsById);
     // Add node pool and pricing data to clusters
     const nodePools = state.__resources.nodePools.entities;
     const types = state.__resources.types.entities;

--- a/packages/manager/src/hooks/useEntities.ts
+++ b/packages/manager/src/hooks/useEntities.ts
@@ -52,7 +52,7 @@ export const useEntities = () => {
     thisImage => !thisImage.is_public
   );
   const volumes = Object.values(_volumes.itemsById);
-  const kubernetesClusters = _kubernetesClusters.entities;
+  const kubernetesClusters = Object.values(_kubernetesClusters.itemsById);
   const nodeBalancers = Object.values(_nodeBalancers.itemsById);
 
   return {
@@ -70,7 +70,8 @@ export const useEntities = () => {
     },
     kubernetesClusters: {
       data: kubernetesClusters,
-      request: requestKubernetesClusters,
+      request: () =>
+        requestKubernetesClusters().then(response => response.data),
       lastUpdated: _kubernetesClusters.lastUpdated,
       error: _kubernetesClusters.error?.read
     },

--- a/packages/manager/src/store/domains/domains.reducer.ts
+++ b/packages/manager/src/store/domains/domains.reducer.ts
@@ -74,7 +74,7 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
   }
 
   if (isType(action, createDomainActions.started)) {
-    return setError('create', undefined, state);
+    return setError({ create: undefined }, state);
   }
 
   if (isType(action, createDomainActions.done)) {
@@ -93,7 +93,7 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
   }
 
   if (isType(action, updateDomainActions.started)) {
-    return setError('update', undefined, state);
+    return setError({ update: undefined }, state);
   }
 
   if (isType(action, updateDomainActions.done)) {
@@ -112,7 +112,7 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
   }
 
   if (isType(action, deleteDomainActions.started)) {
-    return setError('delete', undefined, state);
+    return setError({ delete: undefined }, state);
   }
 
   if (isType(action, deleteDomainActions.done)) {
@@ -130,7 +130,7 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
   }
 
   if (isType(action, getDomainsPageActions.started)) {
-    return setError('read', undefined, state);
+    return setError({ read: undefined }, state);
   }
 
   if (isType(action, getDomainsPageActions.done)) {

--- a/packages/manager/src/store/kubernetes/kubernetes.actions.ts
+++ b/packages/manager/src/store/kubernetes/kubernetes.actions.ts
@@ -3,12 +3,13 @@ import { APIError } from 'linode-js-sdk/lib/types';
 import actionCreatorFactory from 'typescript-fsa';
 
 import { EntityError } from 'src/store/types';
+import { GetAllData } from 'src/utilities/getAll';
 
 export const actionCreator = actionCreatorFactory(`@@manager/kubernetes`);
 
 export const requestClustersActions = actionCreator.async<
   void,
-  KubernetesCluster[],
+  GetAllData<KubernetesCluster>,
   APIError[]
 >('request');
 

--- a/packages/manager/src/store/kubernetes/kubernetes.reducer.ts
+++ b/packages/manager/src/store/kubernetes/kubernetes.reducer.ts
@@ -1,8 +1,18 @@
-import produce from 'immer';
 import { KubernetesCluster } from 'linode-js-sdk/lib/kubernetes';
 import { Reducer } from 'redux';
-import { EntityError, EntityState } from 'src/store/types';
-import updateOrAdd from 'src/utilities/updateOrAdd';
+import {
+  createDefaultState,
+  onCreateOrUpdate,
+  onDeleteSuccess,
+  onError,
+  onGetAllSuccess,
+  onStart,
+  setError
+} from 'src/store/store.helpers.tmp';
+import {
+  EntityError,
+  MappedEntityState2 as MappedEntityState
+} from 'src/store/types';
 import { isType } from 'typescript-fsa';
 import {
   deleteClusterActions,
@@ -17,110 +27,82 @@ import {
  * State
  */
 
-export type State = EntityState<KubernetesCluster, EntityError>;
+export type State = MappedEntityState<KubernetesCluster, EntityError>;
 
-export const defaultState: State = {
-  results: [],
-  entities: [],
-  loading: false,
-  lastUpdated: 0,
-  error: {}
-};
+export const defaultState: State = createDefaultState();
 
 /**
  * Reducer
  */
 const reducer: Reducer<State> = (state = defaultState, action) => {
-  return produce(state, draft => {
-    if (isType(action, requestClustersActions.started)) {
-      draft.loading = true;
-      draft.error!.read = undefined;
-    }
+  if (isType(action, requestClustersActions.started)) {
+    return onStart(state);
+  }
 
-    if (isType(action, requestClustersActions.done)) {
-      const { result } = action.payload;
-      draft.entities = result;
-      draft.results = result.map(cluster => cluster.id);
-      draft.lastUpdated = Date.now();
-      draft.loading = false;
-    }
+  if (isType(action, requestClustersActions.done)) {
+    const { result } = action.payload;
+    return onGetAllSuccess(result.data, state, result.results);
+  }
 
-    if (isType(action, requestClustersActions.failed)) {
-      const { error } = action.payload;
-      draft.error!.read = error;
-      draft.loading = false;
-    }
+  if (isType(action, requestClustersActions.failed)) {
+    const { error } = action.payload;
+    return onError({ read: error }, state);
+  }
 
-    if (isType(action, upsertCluster)) {
-      const { payload } = action;
-      const entities = updateOrAdd(payload, state.entities);
+  if (isType(action, upsertCluster)) {
+    const { payload } = action;
+    return onCreateOrUpdate(payload, state);
+  }
 
-      draft.entities = entities;
-      draft.results = entities.map(cluster => cluster.id);
-    }
+  if (isType(action, updateClusterActions.started)) {
+    return setError({ update: undefined }, state);
+  }
 
-    if (isType(action, updateClusterActions.started)) {
-      draft.error!.update = undefined;
-    }
+  if (isType(action, updateClusterActions.done)) {
+    const { result } = action.payload;
+    return onCreateOrUpdate(result, state);
+  }
 
-    if (isType(action, updateClusterActions.done)) {
-      const { result } = action.payload;
-      const update = updateOrAdd(result, state.entities);
+  if (isType(action, updateClusterActions.failed)) {
+    const { error } = action.payload;
+    return onError({ update: error }, state);
+  }
 
-      draft.entities = update;
-      draft.results = update.map(cluster => cluster.id);
-    }
+  if (isType(action, setErrors)) {
+    const newErrors = action.payload;
+    return setError(newErrors, state);
+  }
 
-    if (isType(action, updateClusterActions.failed)) {
-      const { error } = action.payload;
-      draft.error!.update = error;
-    }
+  if (isType(action, deleteClusterActions.started)) {
+    return setError({ delete: undefined }, state);
+  }
 
-    if (isType(action, setErrors)) {
-      const newErrors = action.payload;
-      draft.error = newErrors;
-    }
+  if (isType(action, deleteClusterActions.done)) {
+    const {
+      params: { clusterID }
+    } = action.payload;
+    return onDeleteSuccess(clusterID, state);
+  }
 
-    if (isType(action, deleteClusterActions.started)) {
-      draft.error!.delete = undefined;
-    }
+  if (isType(action, deleteClusterActions.failed)) {
+    const { error } = action.payload;
+    return onError({ delete: error }, state);
+  }
 
-    if (isType(action, deleteClusterActions.done)) {
-      const {
-        params: { clusterID }
-      } = action.payload;
-      const entities = state.entities.filter(({ id }) => id !== clusterID);
+  if (isType(action, requestClusterActions.started)) {
+    return setError({ read: undefined }, state);
+  }
 
-      draft.entities = entities;
-      draft.results = entities.map(c => c.id);
-    }
+  if (isType(action, requestClusterActions.done)) {
+    const { result } = action.payload;
+    return onCreateOrUpdate(result, state);
+  }
 
-    if (isType(action, deleteClusterActions.failed)) {
-      const { error } = action.payload;
-      draft.error!.delete = error;
-    }
-
-    if (isType(action, requestClusterActions.started)) {
-      draft.error!.read = undefined;
-      draft.loading = true;
-    }
-
-    if (isType(action, requestClusterActions.done)) {
-      const { result } = action.payload;
-      const entities = updateOrAdd(result, state.entities);
-
-      draft.loading = false;
-      draft.entities = entities;
-      draft.results = entities.map(cluster => cluster.id);
-      draft.lastUpdated = Date.now();
-    }
-
-    if (isType(action, requestClusterActions.failed)) {
-      const { error } = action.payload;
-      draft.error!.read = error;
-      draft.loading = false;
-    }
-  });
+  if (isType(action, requestClusterActions.failed)) {
+    const { error } = action.payload;
+    return onError({ read: error }, state);
+  }
+  return state;
 };
 
 export default reducer;

--- a/packages/manager/src/store/kubernetes/kubernetes.requests.ts
+++ b/packages/manager/src/store/kubernetes/kubernetes.requests.ts
@@ -8,7 +8,7 @@ import {
   updateKubernetesCluster as _updateCluster,
   updateNodePool as _updateNodePool
 } from 'linode-js-sdk/lib/kubernetes';
-import { getAll } from 'src/utilities/getAll';
+import { getAll, GetAllData } from 'src/utilities/getAll';
 import { createRequestThunk } from '../store.helpers';
 import { ThunkActionCreator } from '../types';
 import {
@@ -22,22 +22,24 @@ import { requestNodePoolsForCluster } from './nodePools.requests';
 const getAllClusters = getAll<KubernetesCluster>(getKubernetesClusters);
 
 export const requestKubernetesClusters: ThunkActionCreator<Promise<
-  KubernetesCluster[]
+  GetAllData<KubernetesCluster>
 >> = () => dispatch => {
   dispatch(requestClustersActions.started());
 
   return getAllClusters()
-    .then(({ data }) => {
+    .then(response => {
       let i = 0;
-      for (; i < data.length; i++) {
-        dispatch(requestNodePoolsForCluster({ clusterID: data[i].id }));
+      for (; i < response.data.length; i++) {
+        dispatch(
+          requestNodePoolsForCluster({ clusterID: response.data[i].id })
+        );
       }
       dispatch(
         requestClustersActions.done({
-          result: data
+          result: response
         })
       );
-      return data;
+      return response.data;
     })
     .catch(error => {
       dispatch(requestClustersActions.failed({ error }));

--- a/packages/manager/src/store/selectors/getSearchEntities.ts
+++ b/packages/manager/src/store/selectors/getSearchEntities.ts
@@ -148,7 +148,8 @@ const imageSelector = (state: State) => state.images.data || {};
 const domainSelector = (state: State) =>
   Object.values(state.domains.itemsById) || [];
 const typesSelector = (state: State) => state.types.entities;
-const kubernetesClusterSelector = (state: State) => state.kubernetes.entities;
+const kubernetesClusterSelector = (state: State) =>
+  Object.values(state.kubernetes.itemsById);
 
 export default createSelector<
   State,

--- a/packages/manager/src/store/selectors/getSearchEntitites.test.ts
+++ b/packages/manager/src/store/selectors/getSearchEntitites.test.ts
@@ -23,13 +23,10 @@ describe('getSearchEntities selector', () => {
       itemsById: volumes.reduce((result, c) => ({ ...result, [c.id]: c }), {})
     },
     nodeBalancers: {
-      itemsById: nodeBalancers.reduce(
-        (result, c) => ({ ...result, [c.id]: c }),
-        {}
-      )
+      itemsById: apiResponseToMappedState(nodeBalancers)
     },
     kubernetes: {
-      entities: kubernetesClusterFactory.buildList(2)
+      itemsById: apiResponseToMappedState(kubernetesClusterFactory.buildList(2))
     }
   };
   it('should return an array of SearchableItems', () => {
@@ -52,10 +49,7 @@ describe('getSearchEntities selector', () => {
     getSearchEntities({
       ...mockState,
       linodes: {
-        itemsById: updatedLinodes.reduce(
-          (result, c) => ({ ...result, [c.id]: c }),
-          {}
-        )
+        itemsById: apiResponseToMappedState(updatedLinodes)
       }
     });
     expect(getSearchEntities.recomputations()).toEqual(1);

--- a/packages/manager/src/store/store.helpers.tmp.ts
+++ b/packages/manager/src/store/store.helpers.tmp.ts
@@ -1,6 +1,6 @@
 // @todo rename this file to store.helpers when all reducers are using MappedEntityState2
 import { APIError } from 'linode-js-sdk/lib/types';
-import { assoc, omit } from 'ramda';
+import { assoc, omit } from 'ramda'; // @todo replace with mergeRight when updating Ramda
 import {
   Entity,
   EntityError,
@@ -35,11 +35,10 @@ export const onGetAllSuccess = <E extends Entity, S>(
   });
 
 export const setError = <E extends Entity>(
-  type: string,
-  error: APIError[] | undefined,
+  error: EntityError,
   state: MappedEntityState<E, EntityError>
 ) => {
-  return Object.assign({}, state, { error: { ...state.error, [type]: error } });
+  return Object.assign({}, state, { error: { ...state.error, ...error } });
 };
 
 export const onError = <S = {}, E = APIError[] | undefined>(
@@ -48,8 +47,8 @@ export const onError = <S = {}, E = APIError[] | undefined>(
 ) => Object.assign({}, state, { error, loading: false });
 
 export const createDefaultState = <E extends Entity, O extends EntityError>(
-  override: Partial<MappedEntityState<E, O>>,
-  defaultError?: O
+  override: Partial<MappedEntityState<E, O>> = {},
+  defaultError: O = {} as O
 ): MappedEntityState<E, O> => ({
   itemsById: {},
   loading: false,

--- a/packages/manager/src/store/store.helpers.tmp.ts
+++ b/packages/manager/src/store/store.helpers.tmp.ts
@@ -1,6 +1,6 @@
 // @todo rename this file to store.helpers when all reducers are using MappedEntityState2
 import { APIError } from 'linode-js-sdk/lib/types';
-import { assoc, omit } from 'ramda'; // @todo replace with mergeRight when updating Ramda
+import { assoc, omit } from 'ramda';
 import {
   Entity,
   EntityError,

--- a/packages/manager/src/utilities/getEntityByIDFromStore.ts
+++ b/packages/manager/src/utilities/getEntityByIDFromStore.ts
@@ -57,7 +57,7 @@ const _getEntityByIDFromStore = (
     case 'volume':
       return volumes.itemsById[entityID];
     case 'kubeCluster':
-      return kubernetes.entities.find(cluster => cluster.id === entityID);
+      return kubernetes.itemsById[entityID];
     default:
       return;
   }


### PR DESCRIPTION
We're in the process of updating our reducers so that they use the
same set of helper methods/actions/data shape (where possible). This
brings LKE up to date with our patterns. The behavior of the app should
be unchanged.
