### PR TITLE
Use nodePool.count instead of updated count for displaying current pool

### DIFF
--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/ResizeNodePoolDrawer/ResizeNodePoolDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/ResizeNodePoolDrawer/ResizeNodePoolDrawer.tsx
@@ -90,7 +90,8 @@ export const ResizeNodePoolDrawer: React.FC<Props> = props => {
         <div className={classes.section}>
           <Typography className={classes.summary}>
             Current pool: ${nodePool.totalMonthlyPrice}/month (
-            {pluralize('node', 'nodes', updatedCount)} at ${pricePerNode}/month)
+            {pluralize('node', 'nodes', nodePool.count)} at ${pricePerNode}
+            /month)
           </Typography>
         </div>
 


### PR DESCRIPTION
## Description

Little bit of overzealous copy-pasting caused a problem here. Only the Resized Pool: display should update when toggling the number input.