### PR TITLE
Basic e2e smoke create nodebal

### DIFF
--- a/packages/manager/cypress/integration/nodebalancers/smoke-create-nodebal.spec.js
+++ b/packages/manager/cypress/integration/nodebalancers/smoke-create-nodebal.spec.js
@@ -1,0 +1,47 @@
+
+import {
+  deleteNodeBalancerByLabel,
+  makeNodeBalLabel,
+  testNodeBalTag
+} from '../../support/api/nodebalancers';
+import {
+    makeLinodeLabel,
+    createLinode,
+    deleteLinodeById
+} from '../../support/api/linodes';
+// import { assertToast } from '../../support/ui/events';
+
+describe('create NodeBalancer', () => {
+
+  it('creates a nodebal', () => {
+    createLinode().then(linode=>{
+        cy.server();
+        cy.route({
+          method: 'POST',
+          url: '*/nodebalancers'
+        }).as('createNodeBalancer');
+        const privateIp = linode.ipv4[1];
+        const nodeBalLabel = makeNodeBalLabel();
+        cy.visitWithLogin('/nodebalancers/create');
+        cy.findByText('NodeBalancer Settings');
+        cy.findByLabelText('NodeBalancer Label').click().type(nodeBalLabel);
+        cy.contains('create a tag').click().type(testNodeBalTag);
+        cy.contains('Regions')
+        .click()
+        .type('new {enter}');
+        // node backend config
+        cy.findByLabelText('Label').click().type(makeLinodeLabel());
+        cy.contains('Enter IP Address').click().type(`${privateIp}{enter}`);
+        
+        // This is not an error, the tag is deploy-linode
+        cy.get('[data-qa-deploy-linode]').click();
+        cy.wait('@createNodeBalancer')
+            .its('status')
+            .should('be', 200);
+        // cy.visit('/nodebalancers');
+
+        deleteNodeBalancerByLabel(nodeBalLabel);
+        deleteLinodeById(linode.id);
+    });
+  });
+});

--- a/packages/manager/cypress/integration/nodebalancers/smoke-create-nodebal.spec.js
+++ b/packages/manager/cypress/integration/nodebalancers/smoke-create-nodebal.spec.js
@@ -14,6 +14,8 @@ import {
 describe('create NodeBalancer', () => {
 
   it('creates a nodebal', () => {
+
+    // create a linode in NW where the NB will be created
     createLinode().then(linode=>{
         cy.server();
         cy.route({
@@ -26,9 +28,11 @@ describe('create NodeBalancer', () => {
         cy.findByText('NodeBalancer Settings');
         cy.findByLabelText('NodeBalancer Label').click().type(nodeBalLabel);
         cy.contains('create a tag').click().type(testNodeBalTag);
+        // this will create the NB in newark, where the default Linode was created
         cy.contains('Regions')
         .click()
         .type('new {enter}');
+
         // node backend config
         cy.findByLabelText('Label').click().type(makeLinodeLabel());
         cy.contains('Enter IP Address').click().type(`${privateIp}{enter}`);

--- a/packages/manager/cypress/integration/nodebalancers/smoke-create-nodebal.spec.js
+++ b/packages/manager/cypress/integration/nodebalancers/smoke-create-nodebal.spec.js
@@ -82,7 +82,7 @@ describe('create NodeBalancer', () => {
             ]
     });
     cy.findByText(errMessage).should('be.visible');
-
+    deleteLinodeById(linode.id);
 
   });
 });

--- a/packages/manager/cypress/support/api/linodes.js
+++ b/packages/manager/cypress/support/api/linodes.js
@@ -22,7 +22,7 @@ const makeLinodeCreateReq = linode => {
         tags: [testLinodeTag],
         backups_enabled: false,
         booted: true,
-        private_ip: false,
+        private_ip: true,
         authorized_users: []
       };
 
@@ -54,7 +54,7 @@ export const deleteLinodeById = linodeId =>
 
 export const deleteLinodeByLabel = (label = undefined) => {
   getLinodes().then(resp => {
-    const linodeToDelete = resp.body.data.find(l => l.label == label);
+    const linodeToDelete = resp.body.data.find(l => l.label === label);
     deleteLinodeById(linodeToDelete.id);
   });
 };

--- a/packages/manager/cypress/support/api/nodebalancers.js
+++ b/packages/manager/cypress/support/api/nodebalancers.js
@@ -1,0 +1,65 @@
+import {
+  apiCheckErrors,
+  testTag,
+  getAll,
+  deleteById,
+  isTestEntity,
+  makeTestLabel
+} from './common';
+export const testNodeBalTag = testTag;
+export const makeNodeBalLabel = makeTestLabel;
+
+const makeNodeBalCreateReq = nodeBal => {
+  const nodeBalData = nodeBal
+    ? nodeBal
+    : {
+    client_conn_throttle: 0,
+    label: makeNodeBalLabel(),
+    tags: [testNodeBalTag],
+    region: "us-east",
+    configs:[]
+  };
+
+  return cy.request({
+    method: 'POST',
+    url: Cypress.env('apiroot') + '/v4/nodebalancers',
+    body: nodeBalData,
+    auth: {
+      bearer: Cypress.env('oauthtoken')
+    }
+  });
+};
+
+/// Use this method if you do not need to get the request detail
+// if linode is undefined, will create default test debian linode in us-east
+/// @param linode {label:'', tags:[],type:'',region:'',image:'',root_pass:''}
+export const createLinode = (linode = undefined) => {
+  return makeNodeBalCreateReq(linode).then(resp => {
+    apiCheckErrors(resp);
+    console.log(`Created Linode ${resp.body.label} successfully`, resp);
+    return resp.body;
+  });
+};
+
+export const getNodeBalancers = () => getAll('nodebalancers');
+
+export const deleteNodeBalancerById = nodeBalId =>
+  deleteById('nodebalancers', nodeBalId);
+
+
+export const deleteNodeBalancerByLabel = (label = undefined) => {
+  getNodeBalancers().then(resp => {
+    cy.log('get all nb',resp.body.data);
+    const nodeBalToDelete = resp.body.data.find(nb => nb.label === label);
+    cy.log('to delete',nodeBalToDelete)
+    deleteNodeBalancerById(nodeBalToDelete.id);
+  });
+};
+
+export const deleteAllTestNodeBalancers = () => {
+  getNodeBalancers().then(resp => {
+    resp.body.data.forEach(nodeBal => {
+      if (isTestEntity(nodeBal)) deleteNodeBalancerById(nodeBal.id);
+    });
+  });
+};

--- a/packages/manager/cypress/support/api/nodebalancers.js
+++ b/packages/manager/cypress/support/api/nodebalancers.js
@@ -1,5 +1,4 @@
 import {
-  apiCheckErrors,
   testTag,
   getAll,
   deleteById,
@@ -9,7 +8,7 @@ import {
 export const testNodeBalTag = testTag;
 export const makeNodeBalLabel = makeTestLabel;
 
-const makeNodeBalCreateReq = nodeBal => {
+export const makeNodeBalCreateReq = nodeBal => {
   const nodeBalData = nodeBal
     ? nodeBal
     : {
@@ -27,17 +26,6 @@ const makeNodeBalCreateReq = nodeBal => {
     auth: {
       bearer: Cypress.env('oauthtoken')
     }
-  });
-};
-
-/// Use this method if you do not need to get the request detail
-// if linode is undefined, will create default test debian linode in us-east
-/// @param linode {label:'', tags:[],type:'',region:'',image:'',root_pass:''}
-export const createLinode = (linode = undefined) => {
-  return makeNodeBalCreateReq(linode).then(resp => {
-    apiCheckErrors(resp);
-    console.log(`Created Linode ${resp.body.label} successfully`, resp);
-    return resp.body;
   });
 };
 

--- a/packages/manager/cypress/support/index.js
+++ b/packages/manager/cypress/support/index.js
@@ -22,8 +22,10 @@ chai.use(chaiString);
 
 import './commands';
 import { deleteAllTestLinodes } from './api/linodes';
+import { deleteAllTestNodeBalancers } from './api/nodebalancers';
 import { deleteAllTestVolumes } from './api/volumes';
 it('Delete All Test Entities before anything happens', () => {
   deleteAllTestLinodes();
+  deleteAllTestNodeBalancers();
   deleteAllTestVolumes();
 });


### PR DESCRIPTION
## Description

I would like to add some e2e test to cover NodeBalancers,
This PR aims at throwing some base code for testing creation, clean up nodebal test resources etc.

It checks:
- no error (should succeed)
- bad label error displayed (on validation of the form)
- bad stickiness for tcp is displayed (on API response)

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

when running the e2e tests, normally i wait for the linode to be created and the nodebal to be created before deletion so hopefully no race issue here

About the re-rendering/detached element, we should have no rerendering issue here hopefully, 

The list of Private IPs available is populated based on the region, so IF the data for this was missing, would we have an error?
=> probably not as i type the IP directly.

