### PR TITLE
Cypress uses .env, no independant json file anymore

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -162,7 +162,7 @@ Example with localhost:
     "password": "somepass",
     "clientId": "someId",
     "oauthtoken": "someauthtoken",
-    "apiroot": "https://api.linode.com/v4",
+    "apiroot": "https://api.linode.com",
     "loginUrl": "https://login.linode.com/login"
   }
 }
@@ -178,7 +178,7 @@ Example using staging:
     "password": "somepass",
     "clientId": "someId",
     "oauthtoken": "someauthtoken",
-    "apiroot": "https://api.staging.linode.com/v4",
+    "apiroot": "https://api.staging.linode.com",
     "loginUrl": "https://login.staging.linode.com/login"
   }
 }

--- a/TESTING.md
+++ b/TESTING.md
@@ -150,39 +150,8 @@ See cypress documentation on how to check this in the UI: https://docs.cypress.i
 
 #### set up your environment
 
-You will need to create a `development.json` file and `staging.json` file in `~/packages/manager/config` to run these locally.
-An example of this can be found in `~packages/manager/config/development.example.json`
-
-Example with localhost:
-
-```
-{
-  "env": {
-    "username": "someuser",
-    "password": "somepass",
-    "clientId": "someId",
-    "oauthtoken": "someauthtoken",
-    "apiroot": "https://api.linode.com",
-    "loginUrl": "https://login.linode.com/login"
-  }
-}
-```
-
-Example using staging:
-
-```
-{
-  "baseUrl": "https://cloud.staging.linode.com",
-  "env": {
-    "username": "someuser",
-    "password": "somepass",
-    "clientId": "someId",
-    "oauthtoken": "someauthtoken",
-    "apiroot": "https://api.staging.linode.com",
-    "loginUrl": "https://login.staging.linode.com/login"
-  }
-}
-```
+Cypress will read your env variables from `.env` in `/packages/manager`.
+It uses `MANAGER_OAUTH`, `REACT_APP_LOGIN_ROOT` and `REACT_APP_API_ROOT`.
 
 #### Dependencies
 

--- a/package.json
+++ b/package.json
@@ -40,8 +40,6 @@
     "e2e": "yarn workspace linode-manager e2e --color",
     "e2e:all": "yarn workspace linode-manager e2e:all --color",
     "e2e:modified": "yarn workspace linode-manager e2e:modified --color",
-    "cy:stage2e": "yarn workspace linode-manager cy:stage2e",
-    "cy:stagedebug": "yarn workspace linode-manager cy:stagedebug",
     "cy:e2e": "yarn workspace linode-manager cy:e2e",
     "cy:debug": "yarn workspace linode-manager cy:debug",
     "cy:rec-snap": "yarn workspace linode-manager cy:rec-snap",

--- a/packages/manager/config/development.example.json
+++ b/packages/manager/config/development.example.json
@@ -1,8 +1,0 @@
-{
-    "env": {
-        "oauthtoken": "xxxxxx",
-        "apiroot": "https://api.linode.com",
-        "loginUrl": "https://login.linode.com/login",
-        "loginRoot": "https://login.linode.com"
-    }
-}

--- a/packages/manager/cypress/integration/smoke-axe.spec.js
+++ b/packages/manager/cypress/integration/smoke-axe.spec.js
@@ -19,7 +19,6 @@ describe.skip('smoke - axe', () => {
         ]
       });
       cy.checkA11y();
-
     });
   });
 });

--- a/packages/manager/cypress/integration/smoke-deep-link.spec.js
+++ b/packages/manager/cypress/integration/smoke-deep-link.spec.js
@@ -8,7 +8,7 @@ describe('smoke - deep link', () => {
       return;
     }
     describe.skip(`Got to ${page.name}`, () => {
-      // Here we use login to /null here 
+      // Here we use login to /null here
       // so this is independant from what is coded in constants and which path are skipped
       beforeEach(() => {
         cy.visitWithLogin('/null');

--- a/packages/manager/cypress/plugins/index.js
+++ b/packages/manager/cypress/plugins/index.js
@@ -15,16 +15,14 @@ const path = require('path');
 
 // loading config object to append to cypress
 function getConfiguration() {
-
-  const dotenvPath = path.resolve(__dirname,'../../.env');
-  console.log(dotenvPath)
+  const dotenvPath = path.resolve(__dirname, '../../.env');
   const conf = require('dotenv').config({
-    path: dotenvPath,
+    path: dotenvPath
   });
-  if (conf.error){
+  if (conf.error) {
     throw `Could not load .env from Cypress plugin/index.js: ${conf.error}`;
   }
-  return {env:conf.parsed};
+  return { env: conf.parsed };
 }
 
 const registerVisualRegTasks = require('./visualRegPlugin');

--- a/packages/manager/cypress/plugins/index.js
+++ b/packages/manager/cypress/plugins/index.js
@@ -10,13 +10,21 @@
 
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
-const fs = require('fs-extra');
+
 const path = require('path');
 
-function getConfigurationByFile(file) {
-  const pathToConfigFile = path.resolve('../manager', 'config', `${file}.json`);
+// loading config object to append to cypress
+function getConfiguration() {
 
-  return fs.readJson(pathToConfigFile);
+  const dotenvPath = path.resolve(__dirname,'../../.env');
+  console.log(dotenvPath)
+  const conf = require('dotenv').config({
+    path: dotenvPath,
+  });
+  if (conf.error){
+    throw `Could not load .env from Cypress plugin/index.js: ${conf.error}`;
+  }
+  return {env:conf.parsed};
 }
 
 const registerVisualRegTasks = require('./visualRegPlugin');
@@ -27,15 +35,9 @@ function checkNodeVersionRequiredByLinode() {
   }
 }
 
-
 module.exports = (on, config) => {
   registerVisualRegTasks(on);
   checkNodeVersionRequiredByLinode();
-
-
-  // `on` is used to hook into various events Cypress emits
-  // `config` is the resolved Cypress config
-  // accept a configFile value or use development by default
 
   on('task', {
     datenow() {
@@ -43,7 +45,5 @@ module.exports = (on, config) => {
     }
   });
 
-  const file = config.env.configFile || 'development';
-
-  return getConfigurationByFile(file);
+  return getConfiguration();
 };

--- a/packages/manager/cypress/support/api/common.js
+++ b/packages/manager/cypress/support/api/common.js
@@ -1,5 +1,6 @@
 import strings from '../cypresshelpers';
-
+const apiroot = Cypress.env('REACT_APP_API_ROOT') + '/';
+const oauthtoken = Cypress.env('MANAGER_OAUTH');
 export const apiCheckErrors = (resp, failOnError = true) => {
   let errs = undefined;
   if (resp.body && resp.body.ERRORARRAY && resp.body.ERRORARRAY.length > 0) {
@@ -18,18 +19,18 @@ export const apiCheckErrors = (resp, failOnError = true) => {
 export const getAll = path => {
   return cy.request({
     method: 'GET',
-    url: Cypress.env('apiroot') + '/v4/' + path,
+    url: `${apiroot}${path}`,
     auth: {
-      bearer: Cypress.env('oauthtoken')
+      bearer: oauthtoken
     }
   });
 };
 export const deleteById = (path, id) => {
   return cy.request({
     method: 'DELETE',
-    url: `${Cypress.env('apiroot')}/v4/${path}/${id}`,
+    url: `${apiroot}${path}/${id}`,
     auth: {
-      bearer: Cypress.env('oauthtoken')
+      bearer: oauthtoken
     }
   });
 };

--- a/packages/manager/cypress/support/api/linodes.js
+++ b/packages/manager/cypress/support/api/linodes.js
@@ -1,4 +1,3 @@
-
 import strings from '../cypresshelpers';
 import {
   apiCheckErrors,

--- a/packages/manager/cypress/support/api/linodes.js
+++ b/packages/manager/cypress/support/api/linodes.js
@@ -1,3 +1,4 @@
+
 import strings from '../cypresshelpers';
 import {
   apiCheckErrors,
@@ -7,6 +8,8 @@ import {
   isTestEntity,
   makeTestLabel
 } from './common';
+
+const oauthtoken = Cypress.env('MANAGER_OAUTH');
 const testLinodeTag = testTag;
 export const makeLinodeLabel = makeTestLabel;
 
@@ -28,10 +31,10 @@ const makeLinodeCreateReq = linode => {
 
   return cy.request({
     method: 'POST',
-    url: Cypress.env('apiroot') + '/v4/linode/instances',
+    url: Cypress.env('REACT_APP_API_ROOT') + '/linode/instances',
     body: linodeData,
     auth: {
-      bearer: Cypress.env('oauthtoken')
+      bearer: oauthtoken
     }
   });
 };

--- a/packages/manager/cypress/support/commands.js
+++ b/packages/manager/cypress/support/commands.js
@@ -27,4 +27,3 @@ import '@testing-library/cypress/add-commands';
 import 'cypress-axe';
 import './login';
 import './visualRegCommands';
-

--- a/packages/manager/cypress/support/login.js
+++ b/packages/manager/cypress/support/login.js
@@ -1,10 +1,7 @@
 const loginUrl = Cypress.env('REACT_APP_LOGIN_ROOT') + '/login';
 const oauthtoken = Cypress.env('MANAGER_OAUTH');
 const _loginWithToken = win => {
-  win.localStorage.setItem(
-    'authentication/oauth-token',
-    oauthtoken
-  );
+  win.localStorage.setItem('authentication/oauth-token', oauthtoken);
   win.localStorage.setItem('authentication/scopes', '*');
   // cy.log(window.localStorage.getItem('authentication/oauth-token'));
   const expireDate = Cypress.moment().add(30, 'days');
@@ -12,10 +9,7 @@ const _loginWithToken = win => {
   // cy.log(isoExpire);
   win.localStorage.setItem('authentication/expires', isoExpire);
   win.localStorage.setItem('authentication/expire-datetime', isoExpire);
-  win.localStorage.setItem(
-    'authentication/token',
-    'Bearer ' + oauthtoken
-  );
+  win.localStorage.setItem('authentication/token', 'Bearer ' + oauthtoken);
   win.localStorage.setItem('authentication/expire', isoExpire);
 };
 

--- a/packages/manager/cypress/support/login.js
+++ b/packages/manager/cypress/support/login.js
@@ -1,57 +1,9 @@
-Cypress.Commands.add('loginWithUsername', () => {
-  Cypress.on('uncaught:exception', (err, runnable) => {
-    // returning false here prevents Cypress from
-    // failing the test with newrelic errors
-    return false;
-  });
-
-  cy.clearCookies();
-  cy.clearLocalStorage();
-  try {
-    cy.request({ url: '/logout' });
-    cy.request({ url: Cypress.env('loginUrl') });
-    cy.log('logged out');
-  } catch (err) {
-    cy.log('Could not log out');
-  }
-  let options = {
-    url: Cypress.env('loginUrl'),
-    body: {
-      client_id: Cypress.env('clientId'),
-      response_type: `token`,
-      scope: '*',
-      redirect_uri: Cypress.env('baseUrl')
-    }
-  };
-  cy.request(options).then(resp => {
-    expect(resp.status).equals(200);
-    const xmlResp = Cypress.$.parseHTML(resp.body);
-    cy.log(resp.body);
-    const csrfToken = Cypress.$(xmlResp)
-      .find('#csrf_token')
-      .attr('value');
-    const options = {
-      method: 'POST',
-      url: Cypress.env('loginUrl'),
-      form: true,
-      body: {
-        username: Cypress.env('username'),
-        password: Cypress.env('password'),
-        csrf_token: csrfToken
-      }
-    };
-
-    cy.request(options).then(resp => {
-      cy.log(resp);
-      expect(resp.status).equals(200);
-    });
-  });
-});
-
+const loginUrl = Cypress.env('REACT_APP_LOGIN_ROOT') + '/login';
+const oauthtoken = Cypress.env('MANAGER_OAUTH');
 const _loginWithToken = win => {
   win.localStorage.setItem(
     'authentication/oauth-token',
-    Cypress.env('oauthtoken')
+    oauthtoken
   );
   win.localStorage.setItem('authentication/scopes', '*');
   // cy.log(window.localStorage.getItem('authentication/oauth-token'));
@@ -62,7 +14,7 @@ const _loginWithToken = win => {
   win.localStorage.setItem('authentication/expire-datetime', isoExpire);
   win.localStorage.setItem(
     'authentication/token',
-    'Bearer ' + Cypress.env('oauthtoken')
+    'Bearer ' + oauthtoken
   );
   win.localStorage.setItem('authentication/expire', isoExpire);
 };

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -105,8 +105,6 @@
     "storyshots:update": "export UPDATE=-u && docker-compose -f storyshots.yml up --build --exit-code-from manager-storyshots && unset UPDATE && docker-compose -f storyshots.yml down -v",
     "storyshots:test": "npx jest --config ./.storybook/storyshots.jest.config.js src/components/Storyshots.test.tsx --env=jsdom",
     "build-storybook": "build-storybook",
-    "cy:stage2e": "cypress run --env configFile=staging",
-    "cy:stagedebug": "cypress open --env configFile=staging",
     "cy:e2e": "cypress run",
     "cy:debug": "cypress open",
     "cy:rec-snap": "cypress open --env visualRegMode=record",

--- a/packages/manager/scripts/start.js
+++ b/packages/manager/scripts/start.js
@@ -23,7 +23,7 @@ const {
   prepareUrls
 } = require('react-dev-utils/WebpackDevServerUtils');
 const paths = require('../config/paths');
-
+require('dotenv').config({path:paths.dotenv});
 const cypressProxyApiUrl = process.env.REACT_APP_API_ROOT;
 
 const config = require('../config/webpack.config.dev');

--- a/packages/manager/scripts/start.js
+++ b/packages/manager/scripts/start.js
@@ -24,7 +24,7 @@ const {
 } = require('react-dev-utils/WebpackDevServerUtils');
 const paths = require('../config/paths');
 
-const cypressProxyApiUrl = require('../config/development.json').env.apiroot;
+const cypressProxyApiUrl = process.env.REACT_APP_API_ROOT;
 
 const config = require('../config/webpack.config.dev');
 const createDevServerConfig = require('../config/webpackDevServer.config');


### PR DESCRIPTION
## Description

Removes need for development.json file
Uses `.env` instead.

To use e2e with staging change `.env`, and restart `yarn up`

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers
delete or Rename your `development.json` file for cypress, restart `yarn up` the dev server should still work without it.
The e2e test with cypress should also work.

Also remove need for `cy:stage` type of command