### PR TITLE
M3-3950 Fix and clean Import Groups as Tags logic

### DIFF
--- a/packages/manager/src/features/Account/GlobalSettings.tsx
+++ b/packages/manager/src/features/Account/GlobalSettings.tsx
@@ -12,6 +12,7 @@ import { ThunkDispatch } from 'redux-thunk';
 import CircleProgress from 'src/components/CircleProgress';
 import ErrorState from 'src/components/ErrorState';
 import TagImportDrawer from 'src/features/TagImport';
+import { useReduxLoad } from 'src/hooks/useReduxLoad';
 import { ApplicationState } from 'src/store';
 import { updateSettingsInStore } from 'src/store/accountSettings/accountSettings.actions';
 import {
@@ -60,28 +61,34 @@ type CombinedProps = StateProps &
   WithSnackbarProps &
   RouteComponentProps<{}>;
 
-class GlobalSettings extends React.Component<CombinedProps, {}> {
-  toggleAutomaticBackups = () => {
-    const {
-      actions: { updateAccount },
-      backups_enabled
-    } = this.props;
+const GlobalSettings: React.FC<CombinedProps> = props => {
+  const {
+    actions: { openBackupsDrawer, openImportDrawer, updateAccount },
+    backups_enabled,
+    networkHelperEnabled,
+    error,
+    loading,
+    linodesWithoutBackups,
+    entitiesWithGroupsToImport,
+    isManaged,
+    object_storage
+  } = props;
+
+  const { _loading } = useReduxLoad(['accountSettings', 'domains']);
+
+  const toggleAutomaticBackups = () => {
     return updateAccount({ backups_enabled: !backups_enabled }).catch(
-      this.displayError
+      displayError
     );
   };
 
-  toggleNetworkHelper = () => {
-    const {
-      actions: { updateAccount },
-      networkHelperEnabled
-    } = this.props;
+  const toggleNetworkHelper = () => {
     return updateAccount({ network_helper: !networkHelperEnabled }).catch(
-      this.displayError
+      displayError
     );
   };
 
-  displayError = (errors: APIError[] | undefined) => {
+  const displayError = (errors: APIError[] | undefined) => {
     if (!errors) {
       return;
     }
@@ -90,74 +97,51 @@ class GlobalSettings extends React.Component<CombinedProps, {}> {
       'There was an error updating your account settings.'
     )[0].reason;
 
-    return this.props.enqueueSnackbar(errorText, {
+    return props.enqueueSnackbar(errorText, {
       variant: 'error'
     });
   };
 
-  // Make sure account settings are fresh on mount.
-  componentDidMount = () => {
-    this.props.actions.requestSettings();
-  };
-
-  render() {
-    const {
-      actions: { openBackupsDrawer, openImportDrawer },
-      backups_enabled,
-      networkHelperEnabled,
-      error,
-      loading,
-      linodesWithoutBackups,
-      entitiesWithGroupsToImport,
-      isManaged,
-      object_storage
-    } = this.props;
-
-    if (loading) {
-      return <CircleProgress />;
-    }
-    if (error) {
-      return (
-        <ErrorState
-          errorText={'There was an error retrieving your account data.'}
-        />
-      );
-    }
-
+  if (loading || _loading) {
+    return <CircleProgress />;
+  }
+  if (error) {
     return (
-      <div
-        id="tabpanel-settings"
-        role="tabpanel"
-        aria-labelledby="tab-settings"
-      >
-        <AutoBackups
-          isManagedCustomer={isManaged}
-          backups_enabled={backups_enabled}
-          onChange={this.toggleAutomaticBackups}
-          openBackupsDrawer={openBackupsDrawer}
-          hasLinodesWithoutBackups={!isEmpty(linodesWithoutBackups)}
-        />
-        <NetworkHelper
-          onChange={this.toggleNetworkHelper}
-          networkHelperEnabled={networkHelperEnabled}
-        />
-        <EnableObjectStorage
-          object_storage={object_storage}
-          update={this.props.actions.updateAccountSettingsInStore}
-        />
-        <EnableManaged
-          isManaged={isManaged}
-          update={this.props.actions.updateAccountSettingsInStore}
-          push={this.props.history.push}
-        />
-        {shouldDisplayGroupImport(entitiesWithGroupsToImport) && (
-          <ImportGroupsAsTags openDrawer={openImportDrawer} />
-        )}
-        <TagImportDrawer />
-      </div>
+      <ErrorState
+        errorText={'There was an error retrieving your account data.'}
+      />
     );
   }
-}
+
+  return (
+    <div id="tabpanel-settings" role="tabpanel" aria-labelledby="tab-settings">
+      <AutoBackups
+        isManagedCustomer={isManaged}
+        backups_enabled={backups_enabled}
+        onChange={toggleAutomaticBackups}
+        openBackupsDrawer={openBackupsDrawer}
+        hasLinodesWithoutBackups={!isEmpty(linodesWithoutBackups)}
+      />
+      <NetworkHelper
+        onChange={toggleNetworkHelper}
+        networkHelperEnabled={networkHelperEnabled}
+      />
+      <EnableObjectStorage
+        object_storage={object_storage}
+        update={props.actions.updateAccountSettingsInStore}
+      />
+      <EnableManaged
+        isManaged={isManaged}
+        update={props.actions.updateAccountSettingsInStore}
+        push={props.history.push}
+      />
+      {shouldDisplayGroupImport(entitiesWithGroupsToImport) && (
+        <ImportGroupsAsTags openDrawer={openImportDrawer} />
+      )}
+      <TagImportDrawer />
+    </div>
+  );
+};
 const mapStateToProps: MapState<StateProps, {}> = state => ({
   loading: pathOr(false, ['__resources', 'accountSettings', 'loading'], state),
 

--- a/packages/manager/src/features/Account/GlobalSettings.tsx
+++ b/packages/manager/src/features/Account/GlobalSettings.tsx
@@ -74,7 +74,7 @@ const GlobalSettings: React.FC<CombinedProps> = props => {
     object_storage
   } = props;
 
-  const { _loading } = useReduxLoad(['accountSettings', 'domains']);
+  const { _loading } = useReduxLoad(['accountSettings', 'domains', 'linodes']);
 
   const toggleAutomaticBackups = () => {
     return updateAccount({ backups_enabled: !backups_enabled }).catch(

--- a/packages/manager/src/features/Dashboard/Dashboard.tsx
+++ b/packages/manager/src/features/Dashboard/Dashboard.tsx
@@ -20,11 +20,9 @@ import H1Header from 'src/components/H1Header';
 import MaintenanceBanner from 'src/components/MaintenanceBanner';
 import PromotionalOfferCard from 'src/components/PromotionalOfferCard/PromotionalOfferCard';
 import TaxBanner from 'src/components/TaxBanner';
-import TagImportDrawer from 'src/features/TagImport';
 import useFlags from 'src/hooks/useFlags';
 import { handleOpen } from 'src/store/backupDrawer';
 import { addNotificationsToLinodes } from 'src/store/linodes/linodes.helpers';
-import { openDrawer as openGroupDrawer } from 'src/store/tagImportDrawer';
 import { MapState } from 'src/store/types';
 import { formatNotifications } from 'src/utilities/formatNotifications';
 import BackupsDashboardCard from './BackupsDashboardCard';
@@ -60,7 +58,6 @@ interface StateProps {
 interface DispatchProps {
   actions: {
     openBackupDrawer: () => void;
-    openImportDrawer: () => void;
   };
 }
 
@@ -140,7 +137,6 @@ export const Dashboard: React.StatelessComponent<CombinedProps> = props => {
           <BlogDashboardCard />
         </Grid>
       </Grid>
-      <TagImportDrawer />
     </React.Fragment>
   );
 };
@@ -185,8 +181,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
 ) => {
   return {
     actions: {
-      openBackupDrawer: () => dispatch(handleOpen()),
-      openImportDrawer: () => dispatch(openGroupDrawer())
+      openBackupDrawer: () => dispatch(handleOpen())
     }
   };
 };


### PR DESCRIPTION
- Remove some dead code (the tagimport drawer was still on the Dashboard
even though we no longer included logic to open it)
- Refactor GlobalSettings to a function component to use useReduxLoad.
There's a small bug post-performance refactor where if you have a group
on your Domains that should trigger showing the "Import Groups as Tags"
CTA on the Global Settings view, but you navigate directly to that page,
you don't see the CTA (Domains haven't been requested yet).

To test the bug:

1. Use the API or classic to add a "group" to one of your Domains
2. Go to /account/settings/. Depending on where you came from, you may see a CTA to import your group as a tag.
3. Reload the page. 
4. Observe: the CTA is not displayed (because Domains have not yet been requested).