### PR TITLE
[for release] Fix issue loading spinner when bucket data == 0

### DIFF
--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
@@ -30,6 +30,7 @@ import bucketRequestsContainer, {
   BucketsRequests
 } from 'src/containers/bucketRequests.container';
 import useOpenClose from 'src/hooks/useOpenClose';
+import { BucketError } from 'src/store/bucket/types';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import {
   sendDeleteBucketEvent,
@@ -191,7 +192,12 @@ export const BucketLanding: React.FC<CombinedProps> = props => {
   }
 
   if (bucketsData.length === 0) {
-    return <RenderEmpty onClick={openBucketDrawer} data-qa-empty-state />;
+    return (
+      <>
+        {bucketErrors && <BucketErrorDisplay bucketErrors={bucketErrors} />}
+        <RenderEmpty onClick={openBucketDrawer} data-qa-empty-state />;
+      </>
+    );
   }
 
   return (
@@ -203,13 +209,7 @@ export const BucketLanding: React.FC<CombinedProps> = props => {
             <AddNewLink onClick={openBucketDrawer} label="Add a Bucket" />
           </Grid>
         </Grid>
-        {bucketErrors && (
-          <Banner
-            regionsAffected={bucketErrors.map(
-              thisError => objectStorageClusterDisplay[thisError.clusterId]
-            )}
-          />
-        )}
+        {bucketErrors && <BucketErrorDisplay bucketErrors={bucketErrors} />}
         <Grid item xs={12}>
           <OrderBy data={bucketsData} order={'asc'} orderBy={'label'}>
             {({ data: orderedData, handleOrderChange, order, orderBy }) => {
@@ -309,6 +309,22 @@ const enhanced = compose<CombinedProps, Props>(
 );
 
 export default enhanced(BucketLanding);
+
+interface BucketErrorDisplayProps {
+  bucketErrors: BucketError[];
+}
+
+const BucketErrorDisplay: React.FC<BucketErrorDisplayProps> = React.memo(
+  ({ bucketErrors }) => {
+    return (
+      <Banner
+        regionsAffected={bucketErrors.map(
+          thisError => objectStorageClusterDisplay[thisError.clusterId]
+        )}
+      />
+    );
+  }
+);
 
 interface BannerProps {
   regionsAffected: string[];

--- a/packages/manager/src/store/bucket/bucket.requests.ts
+++ b/packages/manager/src/store/bucket/bucket.requests.ts
@@ -78,9 +78,7 @@ export const getAllBucketsFromAllClusters: ThunkActionCreator<Promise<
       dispatch(getAllBucketsForAllClustersActions.failed({ error: errors }));
     }
 
-    if (data.length > 0) {
-      dispatch(getAllBucketsForAllClustersActions.done({ result: data }));
-    }
+    dispatch(getAllBucketsForAllClustersActions.done({ result: data }));
 
     return data;
   });


### PR DESCRIPTION
## Description

The getAllBucketsForAllClusters `done` action was only dispatched if data.length > 0, which meant that if you didn't have any buckets, you'd see an eternal loading spinner on the BucketsLanding page.

I also realized another issue, which is that if you only have buckets in Newark, and the Newark request fails, you'll see the "Empty" state, without an error message. I abstracted the error display out to its own component and include it in the main content as well as the "Empty" state.

## Note to Reviewers

Try to test all combinations:

- No buckets
- No buckets with partial failure (block requests to one DC)
- No buckets with complete failure (block requests to all DCs)
- 1 bucket
- 1 bucket with partial failure 
... etc
