### PR TITLE
[For Release]: Removing width from empty table cell styles

### DIFF
--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -1258,7 +1258,6 @@ const themeDefaults: ThemeDefaults = ({ spacingOverride: spacingUnit }) => {
           fontSize: '.9rem',
           lineHeight: 1.1,
           '&.emptyCell': {
-            width: '100%',
             height: 48
           }
         },


### PR DESCRIPTION
## Description

Removing width from empty table cell styles. I checked to ensure this fixes the issue as well as still keeping the original fix (height not expanding to match other table header cells) and it seems to work well, but please check various tables with empty cells present.

## Type of Change
- Bug fix ('fix')
