### PR TITLE
M3-3798 Address Xterm flow control errors

### DIFF
--- a/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
+++ b/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
@@ -55,6 +55,9 @@ export class AuthenticationWrapper extends React.Component<CombinedProps> {
       this.props.requestRegions()
     ];
 
+    // Start events polling
+    startEventsInterval();
+
     try {
       await Promise.all(dataFetchingPromises);
       this.props.markAppAsDoneLoading();
@@ -70,7 +73,7 @@ export class AuthenticationWrapper extends React.Component<CombinedProps> {
      * set redux state to what's in local storage
      * or expire the tokens if the expiry time is in the past
      *
-     * if nothing exist in local storage, we get shot off to login
+     * if nothing exists in local storage, we get shot off to login
      */
     initSession();
 
@@ -82,7 +85,6 @@ export class AuthenticationWrapper extends React.Component<CombinedProps> {
       this.setState({ showChildren: true });
 
       this.makeInitialRequests();
-      startEventsInterval();
     }
   }
 
@@ -98,7 +100,6 @@ export class AuthenticationWrapper extends React.Component<CombinedProps> {
       !this.state.showChildren
     ) {
       this.makeInitialRequests();
-      startEventsInterval();
 
       return this.setState({ showChildren: true });
     }

--- a/packages/manager/src/features/Lish/Weblish.tsx
+++ b/packages/manager/src/features/Lish/Weblish.tsx
@@ -146,7 +146,7 @@ export class Weblish extends React.Component<CombinedProps, State> {
       /*
        * data is either going to be command line strings
        * or it's going to look like {type: 'error', reason: 'thing failed'}
-       * the latter be JSON parsed and the other cannot
+       * the latter can be JSON parsed and the other cannot
        */
       try {
         data = JSON.parse(evt.data);
@@ -180,7 +180,19 @@ export class Weblish extends React.Component<CombinedProps, State> {
         retryingConnection: false,
         retryAttempts: 0
       });
-      this.terminal.write(evt.data);
+      try {
+        this.terminal.write(evt.data);
+      } catch {
+        /**
+         * We've most likely hit a data flow limit.
+         * This is fine and won't break anything. However,
+         * by reloading the page, we can bring the window back
+         * in sync with the screen session that Weblish is connecting
+         * to.
+         */
+
+        window.location.reload();
+      }
     });
 
     this.socket.addEventListener('close', () => {


### PR DESCRIPTION
We were receiving Sentry reports of xterm.js reaching its flow
control limit and discarding write data. After talking with Abe,
this is a normal thing and an appropriate way to handle it. Since
the underlying screen session has a log, no data is actually lost.

I've been unable to replicate this effect (Abe suggested cat /dev/urandom
but that doesn't trigger it). He suggested that we do what they've
previously done for Glish, which is reload the Lish window when one
of these errors occurs. This will bring the window back in sync with
the screen session.

I also moved the events polling initialization so that it doesn't happen when the user
is loading Lish. There's no reason to poll events from inside a Lish console.