### PR TITLE
Adjustments to precommit/tsc

### DIFF
--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -90,7 +90,7 @@
     "start": "node scripts/start.js",
     "lint": "yarn run eslint . --ext .js,.ts,.tsx --quiet",
     "build": "node scripts/build.js",
-    "precommit": "lint-staged",
+    "precommit": "lint-staged && yarn typecheck",
     "prepush": "./scripts/pre-push.sh",
     "mock": "./scripts/mb.js",
     "test": "jest --color",
@@ -119,11 +119,7 @@
   "lint-staged": {
     "*.{ts,tsx,js}": [
       "prettier --write",
-      "eslint --ext .js,.ts,.tsx --debug",
-      "git add"
-    ],
-    "*.{ts,tsx}": [
-      "tsc -p tsconfig.json --noEmit"
+      "eslint --ext .js,.ts,.tsx --debug"
     ]
   },
   "devDependencies": {

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -119,7 +119,7 @@
   "lint-staged": {
     "*.{ts,tsx,js}": [
       "prettier --write",
-      "eslint --ext .js,.ts,.tsx --debug"
+      "eslint --ext .js,.ts,.tsx --quiet"
     ]
   },
   "devDependencies": {

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -122,7 +122,7 @@
       "eslint --ext .js,.ts,.tsx --debug",
       "git add"
     ],
-    "*.{ts,.tsx}":[
+    "*.{ts,tsx}": [
       "tsc -p tsconfig.json --noEmit"
     ]
   },


### PR DESCRIPTION
## Description

- Removed `tsc` from `lint-staged` because you can't pass a `--project` as well as file name arguments. Add to `precommit` instead.
- Removed `git add` which was causing this warning: `Some of your tasks use `git add` command. Please remove it from the config since all modifications made by tasks will be automatically added to the git commit index.`

I've verified that does PR does the following on commit:

- Compiles `.ts` files
- Compiles `.tsx` files
- Writes prettier changes 

