### PR TITLE
fix eslint peer dependancy wrning from eslint-plugin-sonarjs in sdk

### DIFF
--- a/packages/linode-js-sdk/package.json
+++ b/packages/linode-js-sdk/package.json
@@ -56,6 +56,7 @@
     "@types/yup": "^0.26.22",
     "babel-plugin-module-resolver": "^3.2.0",
     "concurrently": "^4.1.1",
+    "eslint": "^6.8.0",
     "eslint-plugin-ramda": "^2.5.1",
     "eslint-plugin-sonarjs": "^0.5.0",
     "jest": "^24.8.0",


### PR DESCRIPTION
## Description

Simply add the peer dep eslint in the `package.json` of the SDK.
This was already in manager, so it does not impact the lockfile

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

Before when running `yarn install:all` this warning shows, with this fix, this warning should be gone
![image](https://user-images.githubusercontent.com/27222128/80129717-79361500-8565-11ea-99bc-6aa5f0d6a909.png)

