### PR TITLE
Reorganize OBJ Bucket request to fix other environments

### DIFF
--- a/packages/manager/src/components/Placeholder/Placeholder.tsx
+++ b/packages/manager/src/components/Placeholder/Placeholder.tsx
@@ -155,6 +155,7 @@ const Placeholder: React.StatelessComponent<CombinedProps> = props => {
                 className={classes.button}
                 {...thisButton}
                 data-qa-placeholder-button
+                data-testid="placeholder-button"
               />
             </Grid>
           ))}

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.test.tsx
@@ -1,51 +1,83 @@
-import { shallow } from 'enzyme';
+import { cleanup } from '@testing-library/react';
 import * as React from 'react';
-import { buckets } from 'src/__data__/buckets';
-import { objectStorageClusterDisplay } from 'src/constants';
-import { BucketLanding } from './BucketLanding';
+import {
+  objectStorageBucketFactory,
+  objectStorageClusterFactory
+} from 'src/factories/objectStorage';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+import BucketLanding, { CombinedProps } from './BucketLanding';
+
+afterEach(cleanup);
+
+const mockCloseBucketDrawer = jest.fn();
+const mockOpenBucketDrawer = jest.fn();
+
+const props: CombinedProps = {
+  isRestrictedUser: false,
+  openBucketDrawer: mockOpenBucketDrawer,
+  closeBucketDrawer: mockCloseBucketDrawer
+};
 
 describe('ObjectStorageLanding', () => {
-  const wrapper = shallow(
-    <BucketLanding
-      createBucket={jest.fn()}
-      bucketsData={buckets}
-      bucketsLoading={false}
-      openBucketDrawer={jest.fn()}
-      closeBucketDrawer={jest.fn()}
-      classes={{ copy: '' }}
-      deleteBucket={jest.fn()}
-      isRestrictedUser={false}
-    />
-  );
-
-  it('renders without crashing', () => {
-    expect(wrapper).toHaveLength(1);
+  it('renders a loading state', () => {
+    const { getByTestId } = renderWithTheme(<BucketLanding {...props} />);
+    getByTestId('loading-state');
   });
 
-  it('renders an "OrderBy" component, ordered by label', () => {
-    expect(wrapper.find('Connect(OrderBy)').prop('orderBy')).toBe('label');
-  });
-
-  it('renders a loading state when the data is loading', () => {
-    wrapper.setProps({ bucketsLoading: true });
-    expect(wrapper.find('[data-qa-loading-state]')).toHaveLength(1);
-  });
-
-  it('renders an empty state when there is no data', () => {
-    wrapper.setProps({ bucketsData: [], bucketsLoading: false });
-    expect(wrapper.find('[data-qa-empty-state]')).toHaveLength(1);
-  });
-
-  it('renders an error state when there is an error in each cluster', () => {
-    wrapper.setProps({
-      bucketErrors: Object.keys(objectStorageClusterDisplay).map(
-        thisClusterId => ({
-          error: [{ reason: 'An error occurred.' }],
-          clusterId: thisClusterId
-        })
-      ),
-      bucketsLoading: false
+  it('renders an empty state', () => {
+    const { getByTestId } = renderWithTheme(<BucketLanding {...props} />, {
+      customStore: { __resources: { buckets: { data: [], lastUpdated: 1 } } }
     });
-    expect(wrapper.find('[data-qa-error-state]')).toHaveLength(1);
+    getByTestId('placeholder-button');
+  });
+
+  it('renders per-cluster errors', () => {
+    const { getByText } = renderWithTheme(<BucketLanding {...props} />, {
+      customStore: {
+        __resources: {
+          buckets: {
+            loading: false,
+            lastUpdated: 1,
+            bucketErrors: [
+              { clusterId: 'us-east-1', error: { reason: 'An error occurred' } }
+            ]
+          }
+        }
+      }
+    });
+    getByText(/^There was an error loading buckets in Newark, NJ/);
+  });
+
+  it('renders general error state', () => {
+    const { getByText } = renderWithTheme(<BucketLanding {...props} />, {
+      customStore: {
+        __resources: {
+          buckets: {
+            loading: false,
+            lastUpdated: 1,
+            bucketErrors: [
+              { clusterId: 'us-east-1', error: { reason: 'An error occurred' } }
+            ]
+          },
+          clusters: {
+            entities: [objectStorageClusterFactory.build()]
+          }
+        }
+      }
+    });
+    getByText(/^There was an error retrieving your buckets/);
+  });
+
+  it('renders rows for each Bucket', () => {
+    const buckets = objectStorageBucketFactory.buildList(2);
+    const { getByText } = renderWithTheme(<BucketLanding {...props} />, {
+      customStore: {
+        __resources: {
+          buckets: { data: buckets, lastUpdated: 1 }
+        }
+      }
+    });
+    getByText(buckets[0].label);
+    getByText(buckets[1].label);
   });
 });

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
@@ -7,12 +7,7 @@ import AddNewLink from 'src/components/AddNewLink';
 import Button from 'src/components/Button';
 import CircleProgress from 'src/components/CircleProgress';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles
-} from 'src/components/core/styles';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import ErrorState from 'src/components/ErrorState';
@@ -22,13 +17,11 @@ import OrderBy from 'src/components/OrderBy';
 import Placeholder from 'src/components/Placeholder';
 import TextField from 'src/components/TextField';
 import { objectStorageClusterDisplay } from 'src/constants';
-import bucketContainer, { StateProps } from 'src/containers/bucket.container';
 import bucketDrawerContainer, {
   DispatchProps
 } from 'src/containers/bucketDrawer.container';
-import bucketRequestsContainer, {
-  BucketsRequests
-} from 'src/containers/bucketRequests.container';
+import useObjectStorageBuckets from 'src/hooks/useObjectStorageBuckets';
+import useObjectStorageClusters from 'src/hooks/useObjectStorageClusters';
 import useOpenClose from 'src/hooks/useOpenClose';
 import { BucketError } from 'src/store/bucket/types';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
@@ -39,34 +32,30 @@ import {
 import CancelNotice from '../CancelNotice';
 import BucketTable from './BucketTable';
 
-type ClassNames = 'copy';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    copy: {
-      marginTop: theme.spacing(1)
-    }
-  });
+const useStyles = makeStyles((theme: Theme) => ({
+  copy: {
+    marginTop: theme.spacing(1)
+  }
+}));
 
 interface Props {
   isRestrictedUser: boolean;
 }
 
-type CombinedProps = Props &
-  StateProps &
-  DispatchProps &
-  WithStyles<ClassNames> &
-  BucketsRequests;
+export type CombinedProps = Props & DispatchProps;
 
 export const BucketLanding: React.FC<CombinedProps> = props => {
+  const { isRestrictedUser, openBucketDrawer } = props;
+
+  const classes = useStyles();
+
+  const { objectStorageClusters } = useObjectStorageClusters();
   const {
-    classes,
-    bucketsData,
-    bucketsLoading,
-    bucketErrors,
-    isRestrictedUser,
-    openBucketDrawer
-  } = props;
+    objectStorageBuckets,
+    deleteObjectStorageBucket
+  } = useObjectStorageBuckets();
+
+  const { data, loading, bucketErrors, lastUpdated } = objectStorageBuckets;
 
   const removeBucketConfirmationDialog = useOpenClose();
   const [bucketToRemove, setBucketToRemove] = React.useState<
@@ -83,8 +72,6 @@ export const BucketLanding: React.FC<CombinedProps> = props => {
   };
 
   const removeBucket = () => {
-    const { deleteBucket } = props;
-
     // This shouldn't happen, but just in case (and to get TS to quit complaining...)
     if (!bucketToRemove) {
       return;
@@ -94,7 +81,7 @@ export const BucketLanding: React.FC<CombinedProps> = props => {
     setIsLoading(true);
 
     const { cluster, label } = bucketToRemove;
-    deleteBucket({ cluster, label })
+    deleteObjectStorageBucket({ cluster, label })
       .then(() => {
         removeBucketConfirmationDialog.close();
         setIsLoading(false);
@@ -112,13 +99,22 @@ export const BucketLanding: React.FC<CombinedProps> = props => {
       });
   };
 
+  const closeRemoveBucketConfirmationDialog = React.useCallback(() => {
+    removeBucketConfirmationDialog.close();
+  }, [removeBucketConfirmationDialog]);
+
+  const setConfirmBucketNameToInput = React.useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setConfirmBucketName(e.target.value);
+    },
+    []
+  );
+
   const actions = () => (
     <ActionsPanel>
       <Button
         buttonType="cancel"
-        onClick={() => {
-          removeBucketConfirmationDialog.close();
-        }}
+        onClick={closeRemoveBucketConfirmationDialog}
         data-qa-cancel
       >
         Cancel
@@ -167,7 +163,7 @@ export const BucketLanding: React.FC<CombinedProps> = props => {
       {/* If the user is attempting to delete their last Bucket, remind them
       that they will still be billed unless they cancel Object Storage in
       Account Settings. */}
-      {bucketsData.length === 1 && <CancelNotice className={classes.copy} />}
+      {data.length === 1 && <CancelNotice className={classes.copy} />}
       <Typography className={classes.copy}>
         To confirm deletion, type the name of the bucket (
         <b>{bucketToRemove.label}</b>) in the field below:
@@ -176,26 +172,26 @@ export const BucketLanding: React.FC<CombinedProps> = props => {
   ) : null;
 
   if (isRestrictedUser) {
-    return <RenderEmpty onClick={openBucketDrawer} data-qa-empty-state />;
+    return <RenderEmpty onClick={openBucketDrawer} />;
   }
 
-  if (bucketsLoading) {
-    return <RenderLoading data-qa-loading-state />;
+  if (lastUpdated === 0 || loading) {
+    return <RenderLoading />;
   }
 
   const allBucketRequestsFailed =
-    bucketErrors?.length === Object.keys(objectStorageClusterDisplay).length;
+    bucketErrors?.length === objectStorageClusters.entities.length;
 
   // Show a general error state if all the bucket requests failed.
   if (allBucketRequestsFailed) {
     return <RenderError data-qa-error-state />;
   }
 
-  if (bucketsData.length === 0) {
+  if (lastUpdated > 0 && data.length === 0) {
     return (
       <>
         {bucketErrors && <BucketErrorDisplay bucketErrors={bucketErrors} />}
-        <RenderEmpty onClick={openBucketDrawer} data-qa-empty-state />;
+        <RenderEmpty onClick={openBucketDrawer} />;
       </>
     );
   }
@@ -211,7 +207,7 @@ export const BucketLanding: React.FC<CombinedProps> = props => {
         </Grid>
         {bucketErrors && <BucketErrorDisplay bucketErrors={bucketErrors} />}
         <Grid item xs={12}>
-          <OrderBy data={bucketsData} order={'asc'} orderBy={'label'}>
+          <OrderBy data={data} order={'asc'} orderBy={'label'}>
             {({ data: orderedData, handleOrderChange, order, orderBy }) => {
               const bucketTableProps = {
                 orderBy,
@@ -226,9 +222,7 @@ export const BucketLanding: React.FC<CombinedProps> = props => {
         </Grid>
         <ConfirmationDialog
           open={removeBucketConfirmationDialog.isOpen}
-          onClose={() => {
-            removeBucketConfirmationDialog.close();
-          }}
+          onClose={closeRemoveBucketConfirmationDialog}
           title={
             bucketToRemove ? `Delete ${bucketToRemove.label}` : 'Delete bucket'
           }
@@ -237,9 +231,7 @@ export const BucketLanding: React.FC<CombinedProps> = props => {
         >
           {deleteBucketConfirmationMessage}
           <TextField
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-              setConfirmBucketName(e.target.value)
-            }
+            onChange={setConfirmBucketNameToInput}
             expand
             label="Bucket Name"
           />
@@ -250,7 +242,7 @@ export const BucketLanding: React.FC<CombinedProps> = props => {
 };
 
 const RenderLoading: React.StatelessComponent<{}> = () => {
-  return <CircleProgress />;
+  return <CircleProgress data-testid="loading-state" />;
 };
 
 const RenderError: React.StatelessComponent<{}> = () => {
@@ -299,12 +291,8 @@ const EmptyCopy = () => (
   </>
 );
 
-const styled = withStyles(styles);
-
 const enhanced = compose<CombinedProps, Props>(
-  styled,
-  bucketContainer,
-  bucketRequestsContainer,
+  React.memo,
   bucketDrawerContainer
 );
 

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
@@ -312,7 +312,9 @@ const BucketErrorDisplay: React.FC<BucketErrorDisplayProps> = React.memo(
     return (
       <Banner
         regionsAffected={bucketErrors.map(
-          thisError => objectStorageClusterDisplay[thisError.clusterId]
+          thisError =>
+            objectStorageClusterDisplay[thisError.clusterId] ??
+            thisError.clusterId
         )}
       />
     );

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
@@ -175,6 +175,11 @@ export const BucketLanding: React.FC<CombinedProps> = props => {
     return <RenderEmpty onClick={openBucketDrawer} />;
   }
 
+  // Show a general error state if there is a Cluster error.
+  if (objectStorageClusters.error) {
+    return <RenderError data-qa-error-state />;
+  }
+
   if (lastUpdated === 0 || loading) {
     return <RenderLoading />;
   }
@@ -183,7 +188,7 @@ export const BucketLanding: React.FC<CombinedProps> = props => {
     bucketErrors?.length === objectStorageClusters.entities.length;
 
   // Show a general error state if all the bucket requests failed.
-  if (allBucketRequestsFailed) {
+  if (allBucketRequestsFailed || objectStorageClusters.error) {
     return <RenderError data-qa-error-state />;
   }
 

--- a/packages/manager/src/features/ObjectStorage/ObjectStorageLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectStorageLanding.tsx
@@ -1,10 +1,5 @@
-import {
-  ObjectStorageBucket,
-  ObjectStorageCluster
-} from 'linode-js-sdk/lib/object-storage';
-import { pathOr } from 'ramda';
 import * as React from 'react';
-import { connect, MapDispatchToProps } from 'react-redux';
+import { connect } from 'react-redux';
 import {
   matchPath,
   Redirect,
@@ -13,8 +8,6 @@ import {
   Switch
 } from 'react-router-dom';
 import { compose } from 'recompose';
-import { Action } from 'redux';
-import { ThunkDispatch } from 'redux-thunk';
 import Breadcrumb from 'src/components/Breadcrumb';
 import AppBar from 'src/components/core/AppBar';
 import Box from 'src/components/core/Box';
@@ -27,10 +20,8 @@ import PromotionalOfferCard from 'src/components/PromotionalOfferCard/Promotiona
 import SuspenseLoader from 'src/components/SuspenseLoader';
 import TabLink from 'src/components/TabLink';
 import useFlags from 'src/hooks/useFlags';
-import { ApplicationState } from 'src/store';
-import { getAllBucketsFromAllClusters } from 'src/store/bucket/bucket.requests';
-import { BucketError } from 'src/store/bucket/types';
-import { requestClusters as _requestClusters } from 'src/store/clusters/clusters.actions';
+import useObjectStorageBuckets from 'src/hooks/useObjectStorageBuckets';
+import useObjectStorageClusters from 'src/hooks/useObjectStorageClusters';
 import { MapState } from 'src/store/types';
 import BucketDrawer from './BucketLanding/BucketDrawer';
 
@@ -45,13 +36,19 @@ const useStyles = makeStyles((theme: Theme) => ({
   }
 }));
 
-type CombinedProps = StateProps & DispatchProps & RouteComponentProps<{}>;
+type CombinedProps = StateProps & RouteComponentProps<{}>;
 
 export const ObjectStorageLanding: React.FC<CombinedProps> = props => {
   const classes = useStyles();
 
+  const { objectStorageClusters } = useObjectStorageClusters();
+  const {
+    objectStorageBuckets,
+    requestObjectStorageBuckets
+  } = useObjectStorageBuckets();
+
   const tabs = [
-    /* NB: These must correspond to the routes inside the Switch */
+    /* NB: These must correspond to the routes, inside the Switch */
     {
       title: 'Buckets',
       routeName: `${props.match.url}/buckets`
@@ -70,37 +67,38 @@ export const ObjectStorageLanding: React.FC<CombinedProps> = props => {
     props.history.push(`${routeName}`);
   };
 
-  React.useEffect(() => {
-    const {
-      bucketsLastUpdated,
-      bucketErrors,
-      clustersLastUpdated,
-      isRestrictedUser,
-      requestAllBucketsFromAllClusters,
-      requestClusters
-    } = props;
+  const { isRestrictedUser } = props;
 
-    // Object Storage is not available for restricted users, so we avoid these
-    // requests if the user is restricted.
+  const clustersLoaded = objectStorageClusters.lastUpdated > 0;
+
+  const bucketsLoadingOrLoaded =
+    objectStorageBuckets.loading ||
+    objectStorageBuckets.lastUpdated > 0 ||
+    objectStorageBuckets.bucketErrors;
+
+  React.useEffect(() => {
+    // Object Storage is not available for restricted users.
     if (isRestrictedUser) {
       return;
     }
 
-    // Request buckets if we haven't already, or if there are errors.
-    // @todo: use useReduxLoad for this.
-    if (bucketsLastUpdated === 0 || bucketErrors.length > 0) {
-      requestAllBucketsFromAllClusters().catch(err => {
-        /** We choose to do nothing, relying on the Redux error state. */
-      });
-    }
+    // Once the OBJ Clusters have been loaded, request buckets from each cluster.
+    if (clustersLoaded && !bucketsLoadingOrLoaded) {
+      const clusterIds = objectStorageClusters.entities.map(
+        thisCluster => thisCluster.id
+      );
 
-    // Request clusters if we haven't already
-    if (clustersLastUpdated === 0) {
-      requestClusters().catch(err => {
+      requestObjectStorageBuckets(clusterIds).catch(() => {
         /** We choose to do nothing, relying on the Redux error state. */
       });
     }
-  }, [props.isRestrictedUser]);
+  }, [
+    isRestrictedUser,
+    clustersLoaded,
+    bucketsLoadingOrLoaded,
+    objectStorageClusters,
+    requestObjectStorageBuckets
+  ]);
 
   const url = props.match.url;
   const matches = (p: string) => {
@@ -113,6 +111,16 @@ export const ObjectStorageLanding: React.FC<CombinedProps> = props => {
     flags.promotionalOffers ?? []
   ).filter(promotionalOffer =>
     promotionalOffer.features.includes('Object Storage')
+  );
+
+  const renderBucketLanding = React.useCallback(
+    () => <BucketLanding isRestrictedUser={props.isRestrictedUser} />,
+    [props.isRestrictedUser]
+  );
+
+  const renderAccessKeyLanding = React.useCallback(
+    () => <AccessKeyLanding isRestrictedUser={props.isRestrictedUser} />,
+    [props.isRestrictedUser]
   );
 
   return (
@@ -165,17 +173,13 @@ export const ObjectStorageLanding: React.FC<CombinedProps> = props => {
             exact
             strict
             path={`${url}/buckets`}
-            render={() => (
-              <BucketLanding isRestrictedUser={props.isRestrictedUser} />
-            )}
+            render={renderBucketLanding}
           />
           <Route
             exact
             strict
             path={`${url}/access-keys`}
-            render={() => (
-              <AccessKeyLanding isRestrictedUser={props.isRestrictedUser} />
-            )}
+            render={renderAccessKeyLanding}
           />
           <Redirect to={`${url}/buckets`} />
         </Switch>
@@ -186,39 +190,15 @@ export const ObjectStorageLanding: React.FC<CombinedProps> = props => {
 };
 
 interface StateProps {
-  bucketsLastUpdated: number;
-  clustersLastUpdated: number;
   isRestrictedUser: boolean;
-  bucketErrors: BucketError[];
 }
 
 const mapStateToProps: MapState<StateProps, {}> = state => ({
-  bucketsLastUpdated: state.__resources.buckets.lastUpdated,
-  bucketErrors: state.__resources.buckets.bucketErrors ?? [],
-  clustersLastUpdated: state.__resources.clusters.lastUpdated,
-  isRestrictedUser: pathOr(
-    true,
-    ['__resources', 'profile', 'data', 'restricted'],
-    state
-  )
+  isRestrictedUser: state.__resources.profile.data?.restricted ?? true
 });
 
-interface DispatchProps {
-  requestAllBucketsFromAllClusters: () => Promise<ObjectStorageBucket[]>;
-  requestClusters: () => Promise<ObjectStorageCluster[]>;
-}
+export const connected = connect(mapStateToProps);
 
-const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
-  dispatch: ThunkDispatch<ApplicationState, undefined, Action<any>>
-) => {
-  return {
-    requestAllBucketsFromAllClusters: () =>
-      dispatch(getAllBucketsFromAllClusters()),
-    requestClusters: () => dispatch(_requestClusters())
-  };
-};
+const enhanced = compose(connected, React.memo);
 
-export const connected = connect(mapStateToProps, mapDispatchToProps);
-
-const enhanced = compose<CombinedProps, {}>(connected);
 export default enhanced(ObjectStorageLanding);

--- a/packages/manager/src/features/ObjectStorage/ObjectStorageLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectStorageLanding.tsx
@@ -85,7 +85,7 @@ export const ObjectStorageLanding: React.FC<CombinedProps> = props => {
       return;
     }
 
-    // Once the OBJ Clusters have been loaded, request buckets from each cluster.
+    // Once the OBJ Clusters have been loaded, request Buckets from each Cluster.
     if (clustersLoaded && !bucketsLoadingOrLoaded) {
       const clusterIds = objectStorageClusters.entities.map(
         thisCluster => thisCluster.id

--- a/packages/manager/src/features/ObjectStorage/ObjectStorageLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectStorageLanding.tsx
@@ -24,6 +24,7 @@ import useObjectStorageBuckets from 'src/hooks/useObjectStorageBuckets';
 import useObjectStorageClusters from 'src/hooks/useObjectStorageClusters';
 import { MapState } from 'src/store/types';
 import BucketDrawer from './BucketLanding/BucketDrawer';
+import useReduxLoad from 'src/hooks/useReduxLoad';
 
 const BucketLanding = React.lazy(() => import('./BucketLanding/BucketLanding'));
 const AccessKeyLanding = React.lazy(() =>
@@ -40,6 +41,8 @@ type CombinedProps = StateProps & RouteComponentProps<{}>;
 
 export const ObjectStorageLanding: React.FC<CombinedProps> = props => {
   const classes = useStyles();
+
+  useReduxLoad(['clusters']);
 
   const { objectStorageClusters } = useObjectStorageClusters();
   const {

--- a/packages/manager/src/hooks/useObjectStorageBuckets.ts
+++ b/packages/manager/src/hooks/useObjectStorageBuckets.ts
@@ -1,0 +1,38 @@
+import {
+  ObjectStorageBucket,
+  ObjectStorageClusterID
+} from 'linode-js-sdk/lib/object-storage/types';
+import { useDispatch, useSelector } from 'react-redux';
+import { ApplicationState } from 'src/store';
+import { State } from 'src/store/bucket/bucket.reducer';
+import {
+  getAllBucketsFromAllClusters,
+  DeleteBucketRequest,
+  deleteBucket
+} from 'src/store/bucket/bucket.requests';
+import { Dispatch } from './types';
+
+export interface ObjectStorageBucketProps {
+  objectStorageBuckets: State;
+  requestObjectStorageBuckets: () => Promise<ObjectStorageBucket[]>;
+  deleteObjectStorageBucket: (request: DeleteBucketRequest) => Promise<{}>;
+}
+
+export const useObjectStorageBuckets = () => {
+  const dispatch: Dispatch = useDispatch();
+  const objectStorageBuckets = useSelector(
+    (state: ApplicationState) => state.__resources.buckets
+  );
+  const requestObjectStorageBuckets = (clusterIds: ObjectStorageClusterID[]) =>
+    dispatch(getAllBucketsFromAllClusters(clusterIds));
+  const deleteObjectStorageBucket = (options: DeleteBucketRequest) =>
+    dispatch(deleteBucket(options));
+
+  return {
+    objectStorageBuckets,
+    requestObjectStorageBuckets,
+    deleteObjectStorageBucket
+  };
+};
+
+export default useObjectStorageBuckets;

--- a/packages/manager/src/hooks/useObjectStorageClusters.ts
+++ b/packages/manager/src/hooks/useObjectStorageClusters.ts
@@ -1,0 +1,23 @@
+import { ObjectStorageCluster } from 'linode-js-sdk/lib/object-storage/types';
+import { useDispatch, useSelector } from 'react-redux';
+import { ApplicationState } from 'src/store';
+import { State } from 'src/store/clusters/clusters.reducer';
+import { requestClusters as _request } from 'src/store/clusters/clusters.actions';
+import { Dispatch } from './types';
+
+export interface ObjectStorageClusterProps {
+  objectStorageClusters: State;
+  requestObjectStorageClusters: () => Promise<ObjectStorageCluster[]>;
+}
+
+export const useObjectStorageClusters = () => {
+  const dispatch: Dispatch = useDispatch();
+  const objectStorageClusters = useSelector(
+    (state: ApplicationState) => state.__resources.clusters
+  );
+  const requestObjectStorageClusters = () => dispatch(_request());
+
+  return { objectStorageClusters, requestObjectStorageClusters };
+};
+
+export default useObjectStorageClusters;

--- a/packages/manager/src/hooks/useReduxLoad.ts
+++ b/packages/manager/src/hooks/useReduxLoad.ts
@@ -21,6 +21,7 @@ import { requestNotifications } from 'src/store/notification/notification.reques
 import { requestProfile } from 'src/store/profile/profile.requests';
 import { requestRegions } from 'src/store/regions/regions.actions';
 import { getAllVolumes } from 'src/store/volume/volume.requests';
+import { requestClusters } from 'src/store/clusters/clusters.actions';
 
 interface UseReduxPreload {
   _loading: boolean;
@@ -43,7 +44,8 @@ export type ReduxEntity =
   | 'types'
   | 'events'
   | 'longview'
-  | 'firewalls';
+  | 'firewalls'
+  | 'clusters';
 
 type RequestMap = Record<ReduxEntity, any>;
 const requestMap: RequestMap = {
@@ -63,7 +65,8 @@ const requestMap: RequestMap = {
   managedIssues: requestManagedIssues,
   kubernetes: requestKubernetesClusters,
   longview: getAllLongviewClients,
-  firewalls: getAllFirewalls
+  firewalls: getAllFirewalls,
+  clusters: requestClusters
 };
 
 export const useReduxLoad = (

--- a/packages/manager/src/store/bucket/bucket.reducer.ts
+++ b/packages/manager/src/store/bucket/bucket.reducer.ts
@@ -25,7 +25,7 @@ export type State = Omit<
 
 export const defaultState: State = {
   data: [],
-  loading: true,
+  loading: false,
   lastUpdated: 0,
   bucketErrors: undefined
 };

--- a/packages/manager/src/store/bucket/bucket.requests.test.ts
+++ b/packages/manager/src/store/bucket/bucket.requests.test.ts
@@ -13,21 +13,15 @@ import { BucketError } from './types';
 
 const mockStore = configureMockStore([thunk]);
 
-// Mock the cluster display map so the number of calls to getBucketsInCluster is deterministic.
-// We need this to stay the same even as we add new clusters, so that the mocked values work out.
-jest.mock('src/constants', () => ({
-  objectStorageClusterDisplay: {
-    'us-east-1': 'Newark, NJ',
-    'eu-central-1': 'Frankfurt, DE'
-  }
-}));
+const usEast1 = 'us-east-1';
+const euCentral1 = 'eu-central-1';
 
 jest.mock('linode-js-sdk/lib/object-storage', () => {
   const buckets1 = objectStorageBucketFactory.buildList(1, {
-    cluster: 'us-east-1'
+    cluster: usEast1
   });
   const buckets2 = objectStorageBucketFactory.buildList(1, {
-    cluster: 'eu-central-1'
+    cluster: euCentral1
   });
   return {
     getBucketsInCluster: jest
@@ -44,7 +38,9 @@ jest.mock('linode-js-sdk/lib/object-storage', () => {
 describe('getAllBucketsFromAllClusters', () => {
   it('handles successes', async () => {
     const store = mockStore();
-    await store.dispatch(getAllBucketsFromAllClusters() as any);
+    await store.dispatch(
+      getAllBucketsFromAllClusters([usEast1, euCentral1]) as any
+    );
     const [firstAction, secondAction] = store.getActions();
     expect(isType(firstAction, actions.started)).toBe(true);
     expect(isType(secondAction, actions.done)).toBe(true);
@@ -52,7 +48,9 @@ describe('getAllBucketsFromAllClusters', () => {
   });
   it('handles errors', async () => {
     const store = mockStore();
-    await store.dispatch(getAllBucketsFromAllClusters() as any);
+    await store.dispatch(
+      getAllBucketsFromAllClusters([usEast1, euCentral1]) as any
+    );
     const [, secondAction] = store.getActions();
     expect(isType(secondAction, actions.failed)).toBe(true);
     expect(secondAction.payload.error).toHaveLength(1);
@@ -70,7 +68,7 @@ describe('gatherDataAndErrors', () => {
   });
   const makeError = (): BucketError => ({
     error: { reason: 'An error occurred.' },
-    clusterId: 'us-east-1'
+    clusterId: usEast1
   });
 
   it('combines data', () => {

--- a/packages/manager/src/store/bucket/bucket.requests.ts
+++ b/packages/manager/src/store/bucket/bucket.requests.ts
@@ -4,10 +4,10 @@ import {
   getBucketsInCluster,
   ObjectStorageBucket,
   ObjectStorageBucketRequestPayload,
+  ObjectStorageClusterID,
   ObjectStorageDeleteBucketRequestPayload
 } from 'linode-js-sdk/lib/object-storage';
 import { APIError } from 'linode-js-sdk/lib/types';
-import { objectStorageClusterDisplay } from 'src/constants';
 import { GetAllData, getAllWithArguments } from 'src/utilities/getAll';
 import { createRequestThunk } from '../store.helpers';
 import { ThunkActionCreator } from '../types';
@@ -47,20 +47,13 @@ const _getAllBucketsInCluster = getAllWithArguments<ObjectStorageBucket>(
  * This method requests all buckets from each cluster concurrently.
  *
  * Note: a slight oddity here is that in the case of failure, both the `done` and `failed` actions
- * will be dispatched. The reducer handles this and it should be OK, but handle with caution.
+ * will be dispatched. The reducer handles this and it should be OK, but proceed with caution.
  */
-export const getAllBucketsFromAllClusters: ThunkActionCreator<Promise<
-  ObjectStorageBucket[]
->> = () => dispatch => {
+export const getAllBucketsFromAllClusters: ThunkActionCreator<
+  Promise<ObjectStorageBucket[]>,
+  ObjectStorageClusterID[]
+> = clusterIds => dispatch => {
   dispatch(getAllBucketsForAllClustersActions.started());
-
-  // We use the cluster display map as the source of truth for cluster IDs.
-  // From a philosophical point of view, it would be better to first request
-  // `/object-storage/clusters` and use the result as the list of clusters to
-  // request. This would be a relatively big performance hit, however, and we
-  // have to maintain the cluster display map anyway, so it should always
-  // be kept up-to-date with region support for OBJ.
-  const clusterIds = Object.keys(objectStorageClusterDisplay);
 
   const promises = clusterIds.map(thisClusterId =>
     _getAllBucketsInCluster([thisClusterId]).catch(err => ({

--- a/packages/manager/src/store/clusters/clusters.actions.ts
+++ b/packages/manager/src/store/clusters/clusters.actions.ts
@@ -14,9 +14,9 @@ export const clustersRequestActions = actionCreator.async<
   APIError[]
 >(`request`);
 
-export const requestClusters: ThunkActionCreator<
-  Promise<ObjectStorageCluster[]>
-> = () => dispatch => {
+export const requestClusters: ThunkActionCreator<Promise<
+  ObjectStorageCluster[]
+>> = () => dispatch => {
   dispatch(clustersRequestActions.started());
 
   return getClusters()

--- a/packages/manager/src/store/clusters/clusters.reducer.ts
+++ b/packages/manager/src/store/clusters/clusters.reducer.ts
@@ -12,7 +12,7 @@ export type State = EntityState<ObjectStorageCluster>;
 export const defaultState: State = {
   results: [],
   entities: [],
-  loading: true,
+  loading: false,
   lastUpdated: 0,
   error: undefined
 };

--- a/packages/manager/src/store/index.ts
+++ b/packages/manager/src/store/index.ts
@@ -233,7 +233,7 @@ export interface ApplicationState {
   longviewStats: LongviewStatsState;
 }
 
-const defaultState: ApplicationState = {
+export const defaultState: ApplicationState = {
   __resources: __resourcesDefaultState,
   authentication: authenticationDefaultState,
   backups: backupsDefaultState,

--- a/packages/manager/src/utilities/testHelpers.tsx
+++ b/packages/manager/src/utilities/testHelpers.tsx
@@ -1,4 +1,5 @@
 import { render, RenderResult } from '@testing-library/react';
+import { mergeDeepRight } from 'ramda';
 import { ResourcePage } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import { Provider } from 'react-redux';
@@ -8,7 +9,8 @@ import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { PromiseLoaderResponse } from 'src/components/PromiseLoader';
 import LinodeThemeWrapper from 'src/LinodeThemeWrapper';
-import store, { ApplicationState } from 'src/store';
+import store, { ApplicationState, defaultState } from 'src/store';
+import { DeepPartial } from 'redux';
 
 export const createPromiseLoaderResponse: <T>(
   r: T
@@ -24,7 +26,7 @@ export const createResourcePage: <T>(data: T[]) => ResourcePage<T> = data => ({
 
 interface Options {
   MemoryRouter?: MemoryRouterProps;
-  customStore?: Partial<ApplicationState>;
+  customStore?: DeepPartial<ApplicationState>;
 }
 
 /**
@@ -32,15 +34,10 @@ interface Options {
  * renderWithTheme() helper function, since the whole app is wrapped with
  * the TogglePreference component
  */
-export const baseStore = (customStore: Partial<ApplicationState> = {}) =>
-  configureStore<Partial<ApplicationState>>([thunk])({
-    preferences: {
-      data: {},
-      loading: false,
-      lastUpdated: 0
-    },
-    ...customStore
-  });
+export const baseStore = (customStore: DeepPartial<ApplicationState> = {}) =>
+  configureStore<DeepPartial<ApplicationState>>([thunk])(
+    mergeDeepRight(defaultState, customStore)
+  );
 
 export const wrapWithTheme = (ui: any, options: Options = {}) => {
   const { customStore } = options;


### PR DESCRIPTION
## Description

In https://github.com/linode/manager/pull/6269 I chose to use the hard-coded list of clusters to make bucket requests. One thing I hadn't considered is that this would break non-prod environments. 

In this PR, the behavior is changed such that the list of clusters is requested first, before making buckets requests. This wasn't just to fix the present issue; I decided that if this has _already_ bitten us, better to go the safe route, The /object-storage/clusters endpoint is pretty fast, too, so it's not a huge performance penalty.

Also some misc. items in this PR:

- Add `useObjectStorageBuckets()` and `useObjectStorageBuckets()` entity hooks.
- Resolve some ESLint warnings.
- Get rid of the containers in ObjectStorageLanding in favor of hooks.
- Rewrite ObjectStorageLanding tests to use RTL (throwing errors otherwise).
- Change behavior of the customStore test helper to use `deepMergeRight`, which makes testing a component with a custom store super easy.


## Note to Reviewers

Please test OBJ Landing under all success/failure scenarios.
