### PR TITLE
M3-4146 Fix: NodeBalancer Error Handling (SSL)

### DIFF
--- a/packages/linode-js-sdk/src/nodebalancers/nodebalancers.schema.ts
+++ b/packages/linode-js-sdk/src/nodebalancers/nodebalancers.schema.ts
@@ -2,6 +2,9 @@ import { array, boolean, mixed, number, object, string } from 'yup';
 
 import { NodeBalancerConfig } from './types';
 
+const PORT_WARNING = 'Port must be between 1 and 65535.';
+const LABEL_WARNING = 'Label must be between 3 and 32 characters.';
+
 export const nodeBalancerConfigNodeSchema = object({
   label: string()
     .matches(
@@ -22,8 +25,8 @@ export const nodeBalancerConfigNodeSchema = object({
   port: number()
     .typeError('Port must be a number.')
     .required('Port is required.')
-    .min(1, 'Port must be between 1 and 65535.')
-    .max(65535, 'Port must be between 1 and 65535.'),
+    .min(1, PORT_WARNING)
+    .max(65535, PORT_WARNING),
 
   weight: number()
     .typeError('Weight must be a number.')
@@ -60,8 +63,8 @@ export const createNodeBalancerConfigSchema = object({
   port: number()
     .integer()
     .required('Port is required')
-    .min(1, 'Port must be between 1 and 65535.')
-    .max(65535, 'Port must be between 1 and 65535.'),
+    .min(1, PORT_WARNING)
+    .max(65535, PORT_WARNING),
   protocol: mixed().oneOf(['http', 'https', 'tcp']),
   ssl_key: string().when('protocol', {
     is: protocol => protocol === 'https',
@@ -105,8 +108,8 @@ export const UpdateNodeBalancerConfigSchema = object({
   port: number()
     .typeError('Port must be a number.')
     .integer()
-    .min(1, 'Port must be between 1 and 65535.')
-    .max(65535, 'Port must be between 1 and 65535.'),
+    .min(1, PORT_WARNING)
+    .max(65535, PORT_WARNING),
   protocol: mixed().oneOf(['http', 'https', 'tcp']),
   ssl_key: string().when('protocol', {
     is: protocol => protocol === 'https',
@@ -122,8 +125,8 @@ export const UpdateNodeBalancerConfigSchema = object({
 
 export const NodeBalancerSchema = object({
   label: string()
-    .min(3, 'Label must be between 3 and 32 characters.')
-    .max(32, 'Label must be between 3 and 32 characters.')
+    .min(3, LABEL_WARNING)
+    .max(32, LABEL_WARNING)
     .matches(
       /^[a-zA-Z0-9-_]+$/,
       "Label can't contain special characters or spaces."
@@ -171,8 +174,8 @@ export const NodeBalancerSchema = object({
 
 export const UpdateNodeBalancerSchema = object({
   label: string()
-    .min(3, 'Label must be between 3 and 32 characters.')
-    .max(32, 'Label must be between 3 and 32 characters.')
+    .min(3, LABEL_WARNING)
+    .max(32, LABEL_WARNING)
     .matches(
       /^[a-zA-Z0-9-_]+$/,
       "Label can't contain special characters or spaces."

--- a/packages/manager/src/components/TextField.tsx
+++ b/packages/manager/src/components/TextField.tsx
@@ -106,7 +106,7 @@ const styles = (theme: Theme) =>
 interface BaseProps {
   errorText?: string;
   errorGroup?: string;
-  affirmative?: Boolean;
+  affirmative?: boolean;
   helperTextPosition?: 'top' | 'bottom';
   tooltipText?: string;
   className?: any;
@@ -125,6 +125,7 @@ interface BaseProps {
   noMarginTop?: boolean;
   loading?: boolean;
   hideLabel?: boolean;
+  inputId?: string;
 }
 
 interface TextFieldPropsOverrides extends TextFieldProps {
@@ -233,6 +234,7 @@ class LinodeTextField extends React.PureComponent<CombinedProps> {
       noMarginTop,
       label,
       loading,
+      inputId,
       ...textFieldProps
     } = this.props;
 
@@ -310,9 +312,11 @@ class LinodeTextField extends React.PureComponent<CombinedProps> {
             }}
             inputProps={{
               'data-testid': 'textfield-input',
-              id: this.props.label
-                ? convertToKebabCase(`${this.props.label}`)
-                : undefined,
+              id:
+                inputId ||
+                (this.props.label
+                  ? convertToKebabCase(`${this.props.label}`)
+                  : undefined),
               ...inputProps
             }}
             InputProps={{

--- a/packages/manager/src/features/NodeBalancers/ConfigNodeIPSelect.tsx
+++ b/packages/manager/src/features/NodeBalancers/ConfigNodeIPSelect.tsx
@@ -4,7 +4,6 @@ import { compose } from 'recompose';
 
 import {
   createStyles,
-  Theme,
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
@@ -15,7 +14,7 @@ import { privateIPRegex } from 'src/utilities/ipUtils';
 
 type ClassNames = 'labelOuter';
 
-const styles = (theme: Theme) =>
+const styles = () =>
   createStyles({
     labelOuter: {
       display: 'block'
@@ -29,7 +28,6 @@ interface Props {
   inputId?: string;
   errorText?: string;
   nodeAddress?: string;
-  workflow: 'create' | 'edit';
   textfieldProps: Omit<TextFieldProps, 'label'>;
 }
 
@@ -39,18 +37,10 @@ const ConfigNodeIPSelect: React.FC<CombinedProps> = props => {
   const [selectedLinode, setSelectedLinode] = React.useState<number | null>(
     null
   );
-  const {
-    classes,
-    selectedRegion,
-    handleChange: _handleChange,
-    workflow,
-    nodeIndex,
-    inputId
-  } = props;
+  const { classes, handleChange: _handleChange, inputId } = props;
 
   const handleChange = (linode: Linode) => {
     setSelectedLinode(linode.id);
-
     const thisLinodesPrivateIP = linode.ipv4.find(ipv4 =>
       ipv4.match(privateIPRegex)
     );
@@ -60,18 +50,6 @@ const ConfigNodeIPSelect: React.FC<CombinedProps> = props => {
      */
     _handleChange(props.nodeIndex, thisLinodesPrivateIP!);
   };
-
-  React.useEffect(() => {
-    /**
-     * In other words, when we select a new region in the create workflow
-     * clear out the selected IP Address because it might belong to a node
-     * NOT in the selected region
-     */
-    if (workflow === 'create') {
-      setSelectedLinode(null);
-      _handleChange(nodeIndex, '');
-    }
-  }, [selectedRegion, workflow, nodeIndex, _handleChange]);
 
   return (
     <LinodeSelect

--- a/packages/manager/src/features/NodeBalancers/ConfigNodeIPSelect.tsx
+++ b/packages/manager/src/features/NodeBalancers/ConfigNodeIPSelect.tsx
@@ -38,7 +38,13 @@ const ConfigNodeIPSelect: React.FC<CombinedProps> = props => {
   const [selectedLinode, setSelectedLinode] = React.useState<number | null>(
     null
   );
-  const { classes } = props;
+  const {
+    classes,
+    selectedRegion,
+    handleChange: _handleChange,
+    workflow,
+    nodeIndex
+  } = props;
 
   const handleChange = (linode: Linode) => {
     setSelectedLinode(linode.id);
@@ -50,7 +56,7 @@ const ConfigNodeIPSelect: React.FC<CombinedProps> = props => {
      * we can be sure the selection has a private IP because of the
      * filterCondition prop in the render method below
      */
-    props.handleChange(props.nodeIndex, thisLinodesPrivateIP!);
+    _handleChange(props.nodeIndex, thisLinodesPrivateIP!);
   };
 
   React.useEffect(() => {
@@ -59,11 +65,11 @@ const ConfigNodeIPSelect: React.FC<CombinedProps> = props => {
      * clear out the selected IP Address because it might belong to a node
      * NOT in the selected region
      */
-    if (props.workflow === 'create') {
+    if (workflow === 'create') {
       setSelectedLinode(null);
-      props.handleChange(props.nodeIndex, '');
+      _handleChange(nodeIndex, '');
     }
-  }, [props.selectedRegion]);
+  }, [selectedRegion, workflow, nodeIndex, _handleChange]);
 
   return (
     <LinodeSelect

--- a/packages/manager/src/features/NodeBalancers/ConfigNodeIPSelect.tsx
+++ b/packages/manager/src/features/NodeBalancers/ConfigNodeIPSelect.tsx
@@ -26,6 +26,7 @@ interface Props {
   selectedRegion?: string;
   handleChange: (nodeIndex: number, ipAddress: string) => void;
   nodeIndex: number;
+  inputId?: string;
   errorText?: string;
   nodeAddress?: string;
   workflow: 'create' | 'edit';
@@ -43,7 +44,8 @@ const ConfigNodeIPSelect: React.FC<CombinedProps> = props => {
     selectedRegion,
     handleChange: _handleChange,
     workflow,
-    nodeIndex
+    nodeIndex,
+    inputId
   } = props;
 
   const handleChange = (linode: Linode) => {
@@ -74,6 +76,7 @@ const ConfigNodeIPSelect: React.FC<CombinedProps> = props => {
   return (
     <LinodeSelect
       noMarginTop
+      inputId={inputId}
       textFieldProps={props.textfieldProps}
       value={
         props.nodeAddress

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigNode.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigNode.tsx
@@ -166,6 +166,7 @@ export const NodeBalancerConfigNode: React.FC<Props> = props => {
               errorText={nodesErrorMap.address}
               nodeAddress={node.address}
               workflow={forEdit ? 'edit' : 'create'}
+              inputId={`ip-select-node-${configIdx}-${idx}`}
             />
           </Grid>
           <Grid item xs={6} sm={3} lg={2}>
@@ -244,4 +245,4 @@ export const NodeBalancerConfigNode: React.FC<Props> = props => {
   );
 };
 
-export default NodeBalancerConfigNode;
+export default React.memo(NodeBalancerConfigNode);

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigNode.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigNode.tsx
@@ -46,6 +46,12 @@ const useStyles = makeStyles((theme: Theme) => ({
       backgroundColor: theme.color.grey2,
       color: theme.palette.text.primary
     }
+  },
+  'chip-UP': {
+    backgroundColor: theme.color.green
+  },
+  'chip-DOWN': {
+    backgroundColor: theme.color.red
   }
 }));
 

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigNode.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigNode.tsx
@@ -1,0 +1,246 @@
+import { NodeBalancerConfigNodeFields } from 'linode-js-sdk/lib/nodebalancers';
+import * as React from 'react';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
+import Chip from 'src/components/core/Chip';
+import Divider from 'src/components/core/Divider';
+import MenuItem from 'src/components/core/MenuItem';
+import Typography from 'src/components/core/Typography';
+import Grid from 'src/components/Grid';
+import Notice from 'src/components/Notice';
+import TextField from 'src/components/TextField';
+import { getErrorMap } from 'src/utilities/errorUtils';
+import SelectIP from './ConfigNodeIPSelect';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  divider: {
+    marginTop: theme.spacing(1),
+    marginBottom: theme.spacing(1)
+  },
+  backendIPAction: {
+    display: 'flex',
+    alignItems: 'flex-end',
+    paddingLeft: theme.spacing(2),
+    marginLeft: -theme.spacing(1),
+    [theme.breakpoints.down('md')]: {
+      marginTop: -theme.spacing(1)
+    },
+    [theme.breakpoints.down('xs')]: {
+      marginTop: 0
+    },
+    '& .remove': {
+      margin: 0,
+      padding: theme.spacing(2.5)
+    }
+  },
+  statusHeader: {
+    fontSize: '.9rem',
+    color: theme.color.label,
+    marginTop: theme.spacing(2) - 4
+  },
+  statusChip: {
+    marginTop: theme.spacing(1),
+    color: 'white',
+    '&.undefined': {
+      backgroundColor: theme.color.grey2,
+      color: theme.palette.text.primary
+    }
+  }
+}));
+
+export interface Props {
+  node: NodeBalancerConfigNodeFields;
+  idx: number;
+  forEdit: boolean;
+  disabled: boolean;
+  configIdx?: number;
+  nodeBalancerRegion?: string;
+  onNodeLabelChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onNodeAddressChange: (nodeIdx: number, value: string) => void;
+  onNodeWeightChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onNodeModeChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onNodePortChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  removeNode: (e: React.MouseEvent<HTMLElement>) => void;
+}
+
+export const NodeBalancerConfigNode: React.FC<Props> = props => {
+  const classes = useStyles();
+  const {
+    disabled,
+    node,
+    idx,
+    forEdit,
+    configIdx,
+    nodeBalancerRegion,
+    onNodeAddressChange,
+    onNodeLabelChange,
+    onNodeModeChange,
+    onNodeWeightChange,
+    onNodePortChange,
+    removeNode
+  } = props;
+  if (node.modifyStatus === 'delete') {
+    /* This node has been marked for deletion, don't display it */
+    return null;
+  }
+
+  const nodesErrorMap = getErrorMap(
+    ['label', 'address', 'weight', 'port', 'mode'],
+    node.errors
+  );
+
+  return (
+    <React.Fragment>
+      <Grid updateFor={[node, classes]} item data-qa-node xs={12}>
+        {idx !== 0 && (
+          <Grid item xs={12}>
+            <Divider
+              style={{
+                marginTop: forEdit ? 8 : 24,
+                marginBottom: 24
+              }}
+            />
+          </Grid>
+        )}
+        {nodesErrorMap.none && (
+          <Grid item>
+            <Notice error text={nodesErrorMap.none} />
+          </Grid>
+        )}
+        <Grid container>
+          <Grid item xs={6} sm={forEdit ? 4 : 6} lg={forEdit ? 2 : 4}>
+            <TextField
+              label="Label"
+              value={node.label}
+              inputProps={{ 'data-node-idx': idx }}
+              onChange={onNodeLabelChange}
+              errorText={nodesErrorMap.label}
+              errorGroup={forEdit ? `${configIdx}` : undefined}
+              data-qa-backend-ip-label
+              small
+              disabled={disabled}
+            />
+          </Grid>
+          {node.status && (
+            <Grid item xs={6} sm={4} lg={2}>
+              <Typography
+                variant="h3"
+                data-qa-active-checks-header
+                className={classes.statusHeader}
+              >
+                Status
+                <div>
+                  <Chip
+                    className={`
+                        ${classes.statusChip}
+                        ${classes[`chip-${node.status}`]}
+                      `}
+                    label={node.status}
+                    component="div"
+                  />
+                </div>
+              </Typography>
+            </Grid>
+          )}
+        </Grid>
+      </Grid>
+      <Grid item xs={12}>
+        <Grid
+          key={idx}
+          updateFor={[nodeBalancerRegion, node, configIdx, classes]}
+          container
+          data-qa-node
+        >
+          <Grid item xs={12} sm={3} lg={forEdit ? 2 : 4}>
+            <SelectIP
+              textfieldProps={{
+                dataAttrs: {
+                  'data-qa-backend-ip-address': true
+                }
+              }}
+              handleChange={onNodeAddressChange}
+              selectedRegion={nodeBalancerRegion}
+              nodeIndex={idx}
+              errorText={nodesErrorMap.address}
+              nodeAddress={node.address}
+              workflow={forEdit ? 'edit' : 'create'}
+            />
+          </Grid>
+          <Grid item xs={6} sm={3} lg={2}>
+            <TextField
+              type="number"
+              label="Port"
+              value={node.port}
+              inputProps={{ 'data-node-idx': idx }}
+              onChange={onNodePortChange}
+              errorText={nodesErrorMap.port}
+              errorGroup={forEdit ? `${configIdx}` : undefined}
+              data-qa-backend-ip-port
+              small
+              noMarginTop
+              disabled={disabled}
+            />
+          </Grid>
+          <Grid item xs={6} sm={3} lg={2}>
+            <TextField
+              type="number"
+              label="Weight"
+              value={node.weight}
+              inputProps={{ 'data-node-idx': idx }}
+              onChange={onNodeWeightChange}
+              errorText={nodesErrorMap.weight}
+              errorGroup={forEdit ? `${configIdx}` : undefined}
+              data-qa-backend-ip-weight
+              small
+              noMarginTop
+              disabled={disabled}
+            />
+          </Grid>
+          {forEdit && (
+            <Grid item xs={6} sm={3} lg={2}>
+              <TextField
+                label="Mode"
+                value={node.mode}
+                select
+                inputProps={{ 'data-node-idx': idx }}
+                onChange={onNodeModeChange}
+                errorText={nodesErrorMap.mode}
+                data-qa-backend-ip-mode
+                small
+                noMarginTop
+                disabled={disabled}
+              >
+                <MenuItem value="accept" data-node-idx={idx}>
+                  Accept
+                </MenuItem>
+                <MenuItem value="reject" data-node-idx={idx}>
+                  Reject
+                </MenuItem>
+                <MenuItem value="backup" data-node-idx={idx}>
+                  Backup
+                </MenuItem>
+                <MenuItem value="drain" data-node-idx={idx}>
+                  Drain
+                </MenuItem>
+              </TextField>
+            </Grid>
+          )}
+          <ActionsPanel className={classes.backendIPAction}>
+            {(forEdit || idx !== 0) && (
+              <Button
+                buttonType="remove"
+                data-node-idx={idx}
+                onClick={removeNode}
+                data-qa-remove-node
+                disabled={disabled}
+              />
+            )}
+          </ActionsPanel>
+        </Grid>
+      </Grid>
+    </React.Fragment>
+  );
+};
+
+export default NodeBalancerConfigNode;

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigNode.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigNode.tsx
@@ -113,6 +113,7 @@ export const NodeBalancerConfigNode: React.FC<Props> = props => {
             <TextField
               label="Label"
               value={node.label}
+              inputId={`node-label-${configIdx}-${idx}`}
               inputProps={{ 'data-node-idx': idx }}
               onChange={onNodeLabelChange}
               errorText={nodesErrorMap.label}

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigNode.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigNode.tsx
@@ -86,6 +86,7 @@ export const NodeBalancerConfigNode: React.FC<Props> = props => {
     onNodePortChange,
     removeNode
   } = props;
+
   if (node.modifyStatus === 'delete') {
     /* This node has been marked for deletion, don't display it */
     return null;
@@ -171,7 +172,6 @@ export const NodeBalancerConfigNode: React.FC<Props> = props => {
               nodeIndex={idx}
               errorText={nodesErrorMap.address}
               nodeAddress={node.address}
-              workflow={forEdit ? 'edit' : 'create'}
               inputId={`ip-select-node-${configIdx}-${idx}`}
             />
           </Grid>

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -249,13 +249,6 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
     }
   };
 
-  onNodeAddressChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const nodeIdx = e.currentTarget.getAttribute(DATA_NODE);
-    if (nodeIdx) {
-      this.props.onNodeAddressChange(+nodeIdx, e.target.value);
-    }
-  };
-
   onNodePortChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const nodeIdx = e.currentTarget.getAttribute(DATA_NODE);
     if (nodeIdx) {

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -601,6 +601,14 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
       disabled
     } = this.props;
 
+    // We don't want to end up with nodes[3].ip_address as errorMap.none
+    const filteredErrors = errors
+      ? errors.filter(
+          thisError =>
+            !thisError.field || !thisError.field.match(/nodes\[[0-9+]\]/)
+        )
+      : [];
+
     const errorMap = getErrorMap(
       [
         'algorithm',
@@ -618,7 +626,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
         'stickiness',
         'nodes'
       ],
-      errors
+      filteredErrors
     );
 
     const globalFormError = errorMap.none;

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -4,12 +4,10 @@ import * as React from 'react';
 import ActionsPanel from 'src/components/ActionsPanel';
 import AddNewLink from 'src/components/AddNewLink';
 import Button from 'src/components/Button';
-import Chip from 'src/components/core/Chip';
 import Divider from 'src/components/core/Divider';
 import FormControlLabel from 'src/components/core/FormControlLabel';
 import FormHelperText from 'src/components/core/FormHelperText';
 import InputAdornment from 'src/components/core/InputAdornment';
-import MenuItem from 'src/components/core/MenuItem';
 import Paper from 'src/components/core/Paper';
 import {
   createStyles,
@@ -24,8 +22,7 @@ import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
 import Toggle from 'src/components/Toggle';
 import { getErrorMap } from 'src/utilities/errorUtils';
-
-import SelectIP from './ConfigNodeIPSelect';
+import NodeBalancerConfigNode from './NodeBalancerConfigNode';
 
 type ClassNames =
   | 'divider'
@@ -33,8 +30,6 @@ type ClassNames =
   | 'suggestionsParent'
   | 'suggestions'
   | 'suggestionItem'
-  | 'chip-UP'
-  | 'chip-DOWN'
   | 'selectedSuggestionItem'
   | 'statusHeader'
   | 'statusChip'
@@ -92,12 +87,6 @@ const styles = (theme: Theme) =>
     selectedSuggestionItem: {
       backgroundColor: `${theme.palette.primary.main} !important`,
       color: '#fff !important'
-    },
-    'chip-UP': {
-      backgroundColor: theme.color.green
-    },
-    'chip-DOWN': {
-      backgroundColor: theme.color.red
     },
     statusHeader: {
       fontSize: '.9rem',
@@ -866,207 +855,23 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
               <Grid item xs={12} style={{ paddingBottom: 24 }}>
                 <Grid container>
                   {nodes &&
-                    nodes.map((node, idx) => {
-                      if (node.modifyStatus === 'delete') {
-                        /* This node has been marked for deletion, don't display it */
-                        return null;
-                      }
-
-                      const nodesErrorMap = getErrorMap(
-                        ['label', 'address', 'weight', 'port', 'mode'],
-                        node.errors
-                      );
-
-                      return (
-                        <React.Fragment key={`nb-node-${idx}`}>
-                          <Grid
-                            updateFor={[
-                              nodes.length,
-                              node,
-                              errors,
-                              configIdx,
-                              classes
-                            ]}
-                            item
-                            data-qa-node
-                            xs={12}
-                          >
-                            {idx !== 0 && (
-                              <Grid item xs={12}>
-                                <Divider
-                                  style={{
-                                    marginTop: forEdit ? 8 : 24,
-                                    marginBottom: 24
-                                  }}
-                                />
-                              </Grid>
-                            )}
-                            {nodesErrorMap.none && (
-                              <Grid item>
-                                <Notice error text={nodesErrorMap.none} />
-                              </Grid>
-                            )}
-                            <Grid container>
-                              <Grid
-                                item
-                                xs={6}
-                                sm={forEdit ? 4 : 6}
-                                lg={forEdit ? 2 : 4}
-                              >
-                                <TextField
-                                  label="Label"
-                                  value={node.label}
-                                  inputProps={{ 'data-node-idx': idx }}
-                                  onChange={this.onNodeLabelChange}
-                                  errorText={nodesErrorMap.label}
-                                  errorGroup={
-                                    forEdit ? `${configIdx}` : undefined
-                                  }
-                                  data-qa-backend-ip-label
-                                  small
-                                  disabled={disabled}
-                                />
-                              </Grid>
-                              {node.status && (
-                                <Grid item xs={6} sm={4} lg={2}>
-                                  <Typography
-                                    variant="h3"
-                                    data-qa-active-checks-header
-                                    className={classes.statusHeader}
-                                  >
-                                    Status
-                                    <div>
-                                      <Chip
-                                        className={`
-                                          ${classes.statusChip}
-                                          ${classes[`chip-${node.status}`]}
-                                        `}
-                                        label={node.status}
-                                        component="div"
-                                      />
-                                    </div>
-                                  </Typography>
-                                </Grid>
-                              )}
-                            </Grid>
-                          </Grid>
-                          <Grid item xs={12}>
-                            <Grid
-                              key={idx}
-                              updateFor={[
-                                nodes.length,
-                                this.props.nodeBalancerRegion,
-                                node,
-                                errors,
-                                configIdx,
-                                classes
-                              ]}
-                              container
-                              data-qa-node
-                            >
-                              <Grid item xs={12} sm={3} lg={forEdit ? 2 : 4}>
-                                <SelectIP
-                                  textfieldProps={{
-                                    dataAttrs: {
-                                      'data-qa-backend-ip-address': true
-                                    }
-                                  }}
-                                  handleChange={this.props.onNodeAddressChange}
-                                  selectedRegion={this.props.nodeBalancerRegion}
-                                  nodeIndex={idx}
-                                  errorText={nodesErrorMap.address}
-                                  nodeAddress={node.address}
-                                  workflow={forEdit ? 'edit' : 'create'}
-                                />
-                              </Grid>
-                              <Grid item xs={6} sm={3} lg={2}>
-                                <TextField
-                                  type="number"
-                                  label="Port"
-                                  value={node.port}
-                                  inputProps={{ 'data-node-idx': idx }}
-                                  onChange={this.onNodePortChange}
-                                  errorText={nodesErrorMap.port}
-                                  errorGroup={
-                                    forEdit ? `${configIdx}` : undefined
-                                  }
-                                  data-qa-backend-ip-port
-                                  small
-                                  noMarginTop
-                                  disabled={disabled}
-                                />
-                              </Grid>
-                              <Grid item xs={6} sm={3} lg={2}>
-                                <TextField
-                                  type="number"
-                                  label="Weight"
-                                  value={node.weight}
-                                  inputProps={{ 'data-node-idx': idx }}
-                                  onChange={this.onNodeWeightChange}
-                                  errorText={nodesErrorMap.weight}
-                                  errorGroup={
-                                    forEdit ? `${configIdx}` : undefined
-                                  }
-                                  data-qa-backend-ip-weight
-                                  small
-                                  noMarginTop
-                                  disabled={disabled}
-                                />
-                              </Grid>
-                              {forEdit && (
-                                <Grid item xs={6} sm={3} lg={2}>
-                                  <TextField
-                                    label="Mode"
-                                    value={node.mode}
-                                    select
-                                    inputProps={{ 'data-node-idx': idx }}
-                                    onChange={this.onNodeModeChange}
-                                    errorText={nodesErrorMap.mode}
-                                    data-qa-backend-ip-mode
-                                    small
-                                    noMarginTop
-                                    disabled={disabled}
-                                  >
-                                    <MenuItem
-                                      value="accept"
-                                      data-node-idx={idx}
-                                    >
-                                      Accept
-                                    </MenuItem>
-                                    <MenuItem
-                                      value="reject"
-                                      data-node-idx={idx}
-                                    >
-                                      Reject
-                                    </MenuItem>
-                                    <MenuItem
-                                      value="backup"
-                                      data-node-idx={idx}
-                                    >
-                                      Backup
-                                    </MenuItem>
-                                    <MenuItem value="drain" data-node-idx={idx}>
-                                      Drain
-                                    </MenuItem>
-                                  </TextField>
-                                </Grid>
-                              )}
-                              <ActionsPanel className={classes.backendIPAction}>
-                                {(forEdit || idx !== 0) && (
-                                  <Button
-                                    buttonType="remove"
-                                    data-node-idx={idx}
-                                    onClick={this.removeNode}
-                                    data-qa-remove-node
-                                    disabled={disabled}
-                                  />
-                                )}
-                              </ActionsPanel>
-                            </Grid>
-                          </Grid>
-                        </React.Fragment>
-                      );
-                    })}
+                    nodes.map((node, idx) => (
+                      <NodeBalancerConfigNode
+                        key={`nb-node-${idx}`}
+                        forEdit={Boolean(forEdit)}
+                        node={node}
+                        idx={idx}
+                        configIdx={configIdx}
+                        nodeBalancerRegion={this.props.nodeBalancerRegion}
+                        onNodeLabelChange={this.onNodeLabelChange}
+                        onNodeAddressChange={this.props.onNodeAddressChange}
+                        onNodeModeChange={this.onNodeModeChange}
+                        onNodeWeightChange={this.onNodeWeightChange}
+                        onNodePortChange={this.onNodePortChange}
+                        disabled={Boolean(disabled)}
+                        removeNode={this.removeNode}
+                      />
+                    ))}
                   <Grid
                     item
                     xs={12}

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -385,6 +385,11 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
               Active Health Checks
             </Typography>
           </Grid>
+          {errorMap.none && (
+            <Grid item>
+              <Notice error text={errorMap.none} />
+            </Grid>
+          )}
           <Grid
             updateFor={[
               protocol,
@@ -686,13 +691,14 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
               <Notice
                 className={`error-for-scroll-${configIdx}`}
                 text={globalFormError}
-                error={true}
+                error
               />
             )}
             <Grid
               updateFor={[
                 port,
                 errorMap.port,
+                errorMap.configs,
                 protocol,
                 errorMap.protocol,
                 algorithm,
@@ -913,6 +919,11 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                                     marginBottom: 24
                                   }}
                                 />
+                              </Grid>
+                            )}
+                            {nodesErrorMap.none && (
+                              <Grid item>
+                                <Notice error text={nodesErrorMap.none} />
                               </Grid>
                             )}
                             <Grid container>

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -318,12 +318,11 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
 
   onSave = this.props.onSave;
 
-  renderActiveCheck() {
+  renderActiveCheck(errorMap: Record<string, string | undefined>) {
     const {
       checkBody,
       checkPath,
       configIdx,
-      errors,
       forEdit,
       healthCheckAttempts,
       healthCheckInterval,
@@ -333,18 +332,6 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
       disabled,
       classes
     } = this.props;
-
-    const errorMap = getErrorMap(
-      [
-        'check_attempts',
-        'check_body',
-        'check_interval',
-        'check_path',
-        'check_timeout',
-        'check'
-      ],
-      errors
-    );
 
     const conditionalText = this.displayProtocolText(protocol);
 
@@ -630,11 +617,9 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
         'check_attempts',
         'check_body',
         'check_interval',
-        'check_passive',
         'check_path',
         'check_timeout',
         'check',
-        'cipher_suite',
         'configs',
         'port',
         'protocol',
@@ -850,7 +835,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
               </Grid>
             </Grid>
             <Grid container>
-              {this.renderActiveCheck()}
+              {this.renderActiveCheck(errorMap)}
               {this.renderPassiveCheck()}
               <Grid item xs={12}>
                 <Divider className={classes.divider} />

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -376,6 +376,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
               <Select
                 options={typeOptions}
                 label="Type"
+                inputId={`type-${configIdx}`}
                 value={defaultType || typeOptions[0]}
                 onChange={this.onHealthCheckTypeChange}
                 errorText={errorMap.check}
@@ -701,6 +702,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                   small
                   disabled={disabled}
                   noMarginTop
+                  InputProps={{ id: `port-${configIdx}` }}
                 />
                 <FormHelperText>Listen on this port</FormHelperText>
               </Grid>
@@ -708,6 +710,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                 <Select
                   options={protocolOptions}
                   label="Protocol"
+                  inputId={`protocol-${configIdx}`}
                   value={defaultProtocol || protocolOptions[0]}
                   onChange={this.onProtocolChange}
                   errorText={errorMap.protocol}
@@ -776,6 +779,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                 <Select
                   options={algOptions}
                   label="Algorithm"
+                  inputId={`algorithm-${configIdx}`}
                   value={defaultAlg || algOptions[0]}
                   onChange={this.onAlgorithmChange}
                   errorText={errorMap.algorithm}
@@ -801,6 +805,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                 <Select
                   options={sessionOptions}
                   label="Session Stickiness"
+                  inputId={`session-stickiness-${configIdx}`}
                   value={defaultSession || sessionOptions[1]}
                   onChange={this.onSessionStickinessChange}
                   errorText={errorMap.stickiness}
@@ -837,6 +842,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                 errors,
                 nodeMessage,
                 classes,
+                errorMap.nodes,
                 this.props.nodeBalancerRegion
               ]}
               container
@@ -855,12 +861,12 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
               <Grid item xs={12} style={{ paddingBottom: 24 }}>
                 <Grid container>
                   {nodes &&
-                    nodes.map((node, idx) => (
+                    nodes.map((node, nodeIdx) => (
                       <NodeBalancerConfigNode
-                        key={`nb-node-${idx}`}
+                        key={`nb-node-${nodeIdx}`}
                         forEdit={Boolean(forEdit)}
                         node={node}
-                        idx={idx}
+                        idx={nodeIdx}
                         configIdx={configIdx}
                         nodeBalancerRegion={this.props.nodeBalancerRegion}
                         onNodeLabelChange={this.onNodeLabelChange}

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -385,11 +385,6 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
               Active Health Checks
             </Typography>
           </Grid>
-          {errorMap.none && (
-            <Grid item>
-              <Notice error text={errorMap.none} />
-            </Grid>
-          )}
           <Grid
             updateFor={[
               protocol,

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -186,6 +186,8 @@ interface State {
   currentNodeAddressIndex: number | null;
 }
 
+const DATA_NODE = 'data-node-idx';
+
 class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
   state: State = {
     currentNodeAddressIndex: null
@@ -252,41 +254,41 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
     this.props.onSslCertificateChange(e.target.value);
 
   onNodeLabelChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const nodeIdx = e.currentTarget.getAttribute('data-node-idx');
+    const nodeIdx = e.currentTarget.getAttribute(DATA_NODE);
     if (nodeIdx) {
       this.props.onNodeLabelChange(+nodeIdx, e.target.value);
     }
   };
 
   onNodeAddressChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const nodeIdx = e.currentTarget.getAttribute('data-node-idx');
+    const nodeIdx = e.currentTarget.getAttribute(DATA_NODE);
     if (nodeIdx) {
       this.props.onNodeAddressChange(+nodeIdx, e.target.value);
     }
   };
 
   onNodePortChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const nodeIdx = e.currentTarget.getAttribute('data-node-idx');
+    const nodeIdx = e.currentTarget.getAttribute(DATA_NODE);
     if (nodeIdx) {
       this.props.onNodePortChange(+nodeIdx, e.target.value);
     }
   };
 
   onNodeWeightChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const nodeIdx = e.currentTarget.getAttribute('data-node-idx');
+    const nodeIdx = e.currentTarget.getAttribute(DATA_NODE);
     if (nodeIdx) {
       this.props.onNodeWeightChange(+nodeIdx, e.target.value);
     }
   };
 
   onNodeModeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const nodeIdx = e.currentTarget.getAttribute('data-node-idx');
+    const nodeIdx = e.currentTarget.getAttribute(DATA_NODE);
     if (nodeIdx) {
       this.props.onNodeModeChange!(+nodeIdx, e.target.value);
     }
   };
 
-  addNode = (e: React.MouseEvent<HTMLElement>) => {
+  addNode = () => {
     if (this.props.disabled) {
       return;
     }
@@ -297,9 +299,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
     if (this.props.disabled) {
       return;
     }
-    const nodeIdx: string | null = e.currentTarget.getAttribute(
-      'data-node-idx'
-    );
+    const nodeIdx: string | null = e.currentTarget.getAttribute(DATA_NODE);
     const { removeNode } = this.props;
     if (removeNode && nodeIdx) {
       return removeNode(+nodeIdx);
@@ -313,7 +313,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
     if (p === 'http' || p === 'https') {
       return `'HTTP Valid Status' requires a 2xx or 3xx response from the backend node. 'HTTP Body Regex' uses a regex to match against an expected result body.`;
     }
-    return;
+    return undefined;
   };
 
   onSave = this.props.onSave;
@@ -817,8 +817,8 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                 />
                 <FormHelperText>
                   Roundrobin. Least connections assigns connections to the
-                  backend with the least connections. Source uses the client's
-                  IPv4 address
+                  backend with the least connections. Source uses the
+                  client&#39;s IPv4 address
                 </FormHelperText>
               </Grid>
 
@@ -973,12 +973,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                               container
                               data-qa-node
                             >
-                              <Grid
-                                item
-                                xs={12}
-                                sm={forEdit ? 3 : 3}
-                                lg={forEdit ? 2 : 4}
-                              >
+                              <Grid item xs={12} sm={3} lg={forEdit ? 2 : 4}>
                                 <SelectIP
                                   textfieldProps={{
                                     dataAttrs: {

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -397,8 +397,33 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
     );
   };
 
+  resetNodeAddresses = () => {
+    /** Reset the IP addresses of all nodes at once */
+    const { configs } = this.state.nodeBalancerFields;
+    const newConfigs = configs.reduce((accum, thisConfig) => {
+      return [
+        ...accum,
+        {
+          ...thisConfig,
+          nodes: [
+            ...thisConfig.nodes.map(thisNode => {
+              return { ...thisNode, address: '' };
+            })
+          ]
+        }
+      ];
+    }, []);
+    this.setState(set(lensPath(['nodeBalancerFields', 'configs']), newConfigs));
+  };
+
   regionChange = (region: string) => {
+    // No change; no need to update the state.
+    if (this.state.nodeBalancerFields.region === region) {
+      return;
+    }
     this.setState(set(lensPath(['nodeBalancerFields', 'region']), region));
+    // We just changed the region so any selected IP addresses are likely invalid
+    this.resetNodeAddresses();
   };
 
   onCloseConfirmation = () =>

--- a/packages/manager/src/features/linodes/LinodeSelect/LinodeSelect.tsx
+++ b/packages/manager/src/features/linodes/LinodeSelect/LinodeSelect.tsx
@@ -40,6 +40,7 @@ interface Props {
   small?: boolean;
   noMarginTop?: boolean;
   value?: Item<any> | null;
+  inputId?: string;
 }
 
 type CombinedProps = Props & WithLinodesProps;
@@ -61,7 +62,8 @@ const LinodeSelect: React.StatelessComponent<CombinedProps> = props => {
     valueOverride,
     labelOverride,
     filterCondition,
-    value
+    value,
+    inputId
   } = props;
 
   const linodes = region
@@ -103,6 +105,7 @@ const LinodeSelect: React.StatelessComponent<CombinedProps> = props => {
       disabled={disabled}
       small={props.small}
       isLoading={linodesLoading}
+      inputId={inputId}
       onChange={(selected: Item<number>) => {
         return handleChange(selected.data);
       }}

--- a/packages/manager/src/utilities/errorUtils.ts
+++ b/packages/manager/src/utilities/errorUtils.ts
@@ -93,7 +93,9 @@ export const getErrorMap = <T extends string = string>(
       if (thisError.field && fields.includes(thisError.field as T)) {
         return {
           ...accum,
-          [thisError.field]: thisError.reason
+          // We generally want the first error that matches the field,
+          // so don't override it if it's already there
+          [thisError.field]: accum[thisError.field] || thisError.reason
         };
       } else {
         return {


### PR DESCRIPTION
## Description

This is a similar ticket to our recent attempts to fix error handling in NBs. In this case a customer was unable to update his SSL cert and key. I'm not able to reproduce this, and it's possible our earlier fixes took care of this too. To be safe, I made a few extra changes that might catch errors we're not accounting for, but it's hard to be sure. See my longer comment in the ticket.

- Linter fixes
- Resolve duplicate id errors (includes adding inputId prop to a few components and passing down to the underlying TextField)
- Extracted NodeBalancerConfigNode to a separate component. It's too hard to reason about all the updateFors and errorMaps and subrenders when everything is in a single file. Ideally there would be a bunch of React.memo'd components with explicit error fields.

## Note to Reviewers

The easiest way to check editing an SSL cert on a NB is to use openssl:

`openssl req -new -newkey rsa:4096 -x509 -sha256 -days 365 -nodes -out MyCertificate.crt -keyout MyKey.key`

Then select HTTPS as your protocol in the NB config panel and paste in the contents of those files (`cat MyKey.key | pbcopy` makes this easier).