### PR TITLE
M3-4150 Fix: StackScripts bugs

### DIFF
--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -82,7 +82,7 @@ type CombinedProps = StyleProps &
 
 interface HelperFunctions {
   getDataAtPage: (page: number, filter?: any, isSorting?: boolean) => any;
-  getNext: (e?: any) => void;
+  getNext: () => void;
 }
 
 export type StateProps = HelperFunctions & State;
@@ -149,7 +149,11 @@ const withStackScriptBase = (options: WithStackScriptBaseOptions) => (
       isSorting: boolean = false
     ) => {
       const { currentUser, category, request, stackScriptGrants } = this.props;
-      this.setState({ gettingMoreStackScripts: true, isSorting });
+      this.setState({
+        gettingMoreStackScripts: true,
+        isSorting,
+        currentPage: page
+      });
 
       const filteredUser = category === 'linode' ? 'linode' : currentUser;
 
@@ -228,7 +232,7 @@ const withStackScriptBase = (options: WithStackScriptBaseOptions) => (
         });
     };
 
-    getNext = (e?: any) => {
+    getNext = () => {
       if (!this.mounted) {
         return;
       }

--- a/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptPanel.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptPanel.tsx
@@ -137,17 +137,15 @@ class SelectStackScriptPanel extends React.Component<CombinedProps, {}> {
     const tabValue = getTabValueFromQueryString(queryString, StackScriptTabs);
 
     return (
-      <React.Fragment>
-        <TabbedPanel
-          error={error}
-          rootClass={classes.root}
-          shrinkTabContent={classes.creating}
-          tabs={this.createTabs}
-          header=""
-          value={tabValue}
-          handleTabChange={this.handleTabChange}
-        />
-      </React.Fragment>
+      <TabbedPanel
+        error={error}
+        rootClass={classes.root}
+        shrinkTabContent={classes.creating}
+        tabs={this.createTabs}
+        header=""
+        value={tabValue}
+        handleTabChange={this.handleTabChange}
+      />
     );
   }
 }

--- a/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptPanelContent.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptPanelContent.tsx
@@ -19,6 +19,8 @@ import Typography from 'src/components/core/Typography';
 
 interface DialogVariantProps {
   open: boolean;
+  submitting: boolean;
+  error?: string;
 }
 interface DialogState {
   makePublic: DialogVariantProps;
@@ -51,10 +53,12 @@ class StackScriptPanelContent extends React.Component<CombinedProps, State> {
     successMessage: '',
     dialog: {
       makePublic: {
-        open: false
+        open: false,
+        submitting: false
       },
       delete: {
-        open: false
+        open: false,
+        submitting: false
       },
       stackScriptID: undefined,
       stackScriptLabel: ''
@@ -75,10 +79,12 @@ class StackScriptPanelContent extends React.Component<CombinedProps, State> {
     this.setState({
       dialog: {
         delete: {
-          open: true
+          open: true,
+          submitting: false
         },
         makePublic: {
-          open: false
+          open: false,
+          submitting: false
         },
         stackScriptID: id,
         stackScriptLabel: label
@@ -90,10 +96,12 @@ class StackScriptPanelContent extends React.Component<CombinedProps, State> {
     this.setState({
       dialog: {
         delete: {
-          open: false
+          open: false,
+          submitting: false
         },
         makePublic: {
-          open: true
+          open: true,
+          submitting: false
         },
         stackScriptID: id,
         stackScriptLabel: label
@@ -106,28 +114,43 @@ class StackScriptPanelContent extends React.Component<CombinedProps, State> {
       dialog: {
         ...this.state.dialog,
         delete: {
-          open: false
+          open: false,
+          submitting: false
         },
         makePublic: {
-          open: false
+          open: false,
+          submitting: false
         }
       }
     });
   };
 
   handleDeleteStackScript = () => {
+    const { dialog } = this.state;
+    this.setState({
+      dialog: {
+        ...dialog,
+        delete: {
+          ...dialog.delete,
+          submitting: true,
+          error: undefined
+        }
+      }
+    });
     deleteStackScript(this.state.dialog.stackScriptID!)
-      .then(response => {
+      .then(_ => {
         if (!this.mounted) {
           return;
         }
         this.setState({
           dialog: {
             delete: {
-              open: false
+              open: false,
+              submitting: false
             },
             makePublic: {
-              open: false
+              open: false,
+              submitting: false
             },
             stackScriptID: undefined,
             stackScriptLabel: ''
@@ -141,17 +164,16 @@ class StackScriptPanelContent extends React.Component<CombinedProps, State> {
         }
         this.setState({
           dialog: {
+            ...dialog,
             delete: {
-              open: false
+              open: true,
+              submitting: false,
+              error: e[0].reason
             },
             makePublic: {
-              open: false
-            },
-            stackScriptID: undefined,
-            stackScriptLabel: ''
-          },
-          fieldError: {
-            reason: 'Unable to complete your request at this time'
+              open: false,
+              submitting: false
+            }
           }
         });
       });
@@ -162,7 +184,7 @@ class StackScriptPanelContent extends React.Component<CombinedProps, State> {
     const { currentFilter } = this.props;
 
     updateStackScript(dialog.stackScriptID!, { is_public: true })
-      .then(response => {
+      .then(_ => {
         if (!this.mounted) {
           return;
         }
@@ -170,10 +192,12 @@ class StackScriptPanelContent extends React.Component<CombinedProps, State> {
           successMessage: `${dialog.stackScriptLabel} successfully published to the public library`,
           dialog: {
             delete: {
-              open: false
+              open: false,
+              submitting: false
             },
             makePublic: {
-              open: false
+              open: false,
+              submitting: false
             },
             stackScriptID: undefined,
             stackScriptLabel: ''
@@ -181,17 +205,19 @@ class StackScriptPanelContent extends React.Component<CombinedProps, State> {
         });
         this.props.getDataAtPage(1, currentFilter, true);
       })
-      .catch(e => {
+      .catch(_ => {
         if (!this.mounted) {
           return;
         }
         this.setState({
           dialog: {
             delete: {
-              open: false
+              open: false,
+              submitting: false
             },
             makePublic: {
-              open: false
+              open: false,
+              submitting: false
             },
             stackScriptID: undefined,
             stackScriptLabel: ''
@@ -205,39 +231,36 @@ class StackScriptPanelContent extends React.Component<CombinedProps, State> {
 
   renderConfirmMakePublicActions = () => {
     return (
-      <React.Fragment>
-        <ActionsPanel>
-          <Button buttonType="cancel" onClick={this.handleCloseDialog}>
-            Cancel
-          </Button>
-          <Button
-            buttonType="secondary"
-            destructive
-            onClick={this.handleMakePublic}
-          >
-            Yes, make me a star!
-          </Button>
-        </ActionsPanel>
-      </React.Fragment>
+      <ActionsPanel>
+        <Button buttonType="cancel" onClick={this.handleCloseDialog}>
+          Cancel
+        </Button>
+        <Button
+          buttonType="secondary"
+          destructive
+          onClick={this.handleMakePublic}
+        >
+          Yes, make me a star!
+        </Button>
+      </ActionsPanel>
     );
   };
 
   renderConfirmDeleteActions = () => {
     return (
-      <React.Fragment>
-        <ActionsPanel>
-          <Button buttonType="cancel" onClick={this.handleCloseDialog}>
-            Cancel
-          </Button>
-          <Button
-            buttonType="secondary"
-            destructive
-            onClick={this.handleDeleteStackScript}
-          >
-            Delete
-          </Button>
-        </ActionsPanel>
-      </React.Fragment>
+      <ActionsPanel>
+        <Button buttonType="cancel" onClick={this.handleCloseDialog}>
+          Cancel
+        </Button>
+        <Button
+          buttonType="secondary"
+          destructive
+          onClick={this.handleDeleteStackScript}
+          loading={this.state.dialog.delete.submitting}
+        >
+          Delete
+        </Button>
+      </ActionsPanel>
     );
   };
 
@@ -250,6 +273,7 @@ class StackScriptPanelContent extends React.Component<CombinedProps, State> {
         open={dialog.delete.open}
         actions={this.renderConfirmDeleteActions}
         onClose={this.handleCloseDialog}
+        error={dialog.delete.error}
       >
         <Typography>
           Are you sure you want to delete this StackScript?

--- a/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptsSection.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptsSection.tsx
@@ -8,7 +8,6 @@ import { compose } from 'recompose';
 import CircleProgress from 'src/components/CircleProgress';
 import {
   createStyles,
-  Theme,
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
@@ -31,7 +30,7 @@ import StackScriptRow from './StackScriptRow';
 
 type ClassNames = 'root' | 'loadingWrapper';
 
-const styles = (theme: Theme) =>
+const styles = () =>
   createStyles({
     root: {},
     loadingWrapper: {


### PR DESCRIPTION
Fix bug when deleting a StackScript:

1. Scroll down past the waypoint and delete one of the stackscripts there.
2. Observe: you are redirected to the top of the page, but are unable
to trigger infinite scroll.

This happened because the delete handler was requesting the first page
of data (correctly) but wasn't updating the current page in state.

Fix error and loading handling when deleting:

There were no submitting states for the confirmation dialogs. Added one
for the delete dialog. In addition, the "fieldError" in state wasn't displayed
anywhere, and in any case it's our pattern to display errors like this inside
the confirmation dialog. Adjusted the dialog state and props to account for this.

## Note to reviewers

Prod test account 4 has a bunch of StackScripts on it, enough to trigger infinite scroll.

These components are in dire need of a larger refactor but trying to keep this reasonably small. I created a bug ticket for the make-public confirmation menu and a tdt ticket for refactoring.