### PR TITLE
M3-4144 Add LKE search results details

### DIFF
--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
@@ -164,8 +164,7 @@ export const KubeSummaryPanel: React.FunctionComponent<CombinedProps> = props =>
     return getKubeConfig(cluster.id).then(response => {
       // Convert to utf-8 from base64
       try {
-        const decodedFile = window.atob(response.kubeconfig);
-        return decodedFile;
+        return window.atob(response.kubeconfig);
       } catch (e) {
         reportException(e, {
           'Encoded response': response.kubeconfig
@@ -272,7 +271,7 @@ export const KubeSummaryPanel: React.FunctionComponent<CombinedProps> = props =>
   return (
     <React.Fragment>
       <Paper className={classes.root}>
-        <Grid 
+        <Grid
           container
           alignItems="flex-start"
           className={classes.mainGridContainer}

--- a/packages/manager/src/features/Kubernetes/kubeUtils.ts
+++ b/packages/manager/src/features/Kubernetes/kubeUtils.ts
@@ -1,5 +1,6 @@
 import { KubernetesCluster } from 'linode-js-sdk/lib/kubernetes';
 import { LinodeType } from 'linode-js-sdk/lib/linodes';
+import { pluralize } from 'src/utilities/pluralize';
 import { ExtendedCluster, ExtendedPoolNode, PoolNodeWithPrice } from './types';
 
 export const nodeWarning = `We recommend at least 3 nodes in each pool. Fewer nodes may affect availability.`;
@@ -96,3 +97,12 @@ export const getTotalNodesInCluster = (pools: PoolNodeWithPrice[]): number =>
   pools.reduce((accum, thisPool) => {
     return accum + thisPool.count;
   }, 0);
+
+export const getDescriptionForCluster = (cluster: ExtendedCluster) => {
+  const nodes = getTotalNodesInCluster(cluster.node_pools);
+  return `${pluralize('node', 'nodes', nodes)}, ${pluralize(
+    'CPU core',
+    'CPU cores',
+    cluster.totalCPU
+  )}, ${cluster.totalMemory / 1024}GB RAM`;
+};

--- a/packages/manager/src/store/selectors/getSearchEntities.ts
+++ b/packages/manager/src/store/selectors/getSearchEntities.ts
@@ -6,8 +6,14 @@ import { NodeBalancer } from 'linode-js-sdk/lib/nodebalancers';
 import { Volume } from 'linode-js-sdk/lib/volumes';
 import { createSelector } from 'reselect';
 import { displayType } from 'src/features/linodes/presentation';
+import {
+  extendCluster,
+  getDescriptionForCluster
+} from 'src/features/Kubernetes/kubeUtils';
+import { ExtendedCluster } from 'src/features/Kubernetes/types';
 import { SearchableItem } from 'src/features/Search/search.interfaces';
 import { ApplicationState } from 'src/store';
+import { ExtendedNodePool } from 'src/store/kubernetes/nodePools.actions';
 import getLinodeDescription from 'src/utilities/getLinodeDescription';
 
 type State = ApplicationState['__resources'];
@@ -122,7 +128,7 @@ const nodeBalToSearchableItem = (nodebal: NodeBalancer): SearchableItem => ({
 });
 
 const kubernetesClusterToSearchableItem = (
-  kubernetesCluster: KubernetesCluster
+  kubernetesCluster: ExtendedCluster
 ): SearchableItem => ({
   label: kubernetesCluster.label,
   value: kubernetesCluster.id,
@@ -136,7 +142,8 @@ const kubernetesClusterToSearchableItem = (
     label: kubernetesCluster.label,
     region: kubernetesCluster.region,
     k8s_version: kubernetesCluster.k8s_version,
-    tags: kubernetesCluster.tags
+    tags: kubernetesCluster.tags,
+    description: getDescriptionForCluster(kubernetesCluster)
   }
 });
 
@@ -150,6 +157,7 @@ const domainSelector = (state: State) =>
 const typesSelector = (state: State) => state.types.entities;
 const kubernetesClusterSelector = (state: State) =>
   Object.values(state.kubernetes.itemsById);
+const kubePoolSelector = (state: State) => state.nodePools.entities;
 
 export default createSelector<
   State,
@@ -160,6 +168,7 @@ export default createSelector<
   NodeBalancer[],
   LinodeType[],
   KubernetesCluster[],
+  ExtendedNodePool[],
   SearchableItem[]
 >(
   linodeSelector,
@@ -169,6 +178,7 @@ export default createSelector<
   nodebalSelector,
   typesSelector,
   kubernetesClusterSelector,
+  kubePoolSelector,
   (
     linodes,
     volumes,
@@ -176,7 +186,8 @@ export default createSelector<
     domains,
     nodebalancers,
     types,
-    kubernetesClusters
+    kubernetesClusters,
+    nodePools
   ) => {
     const arrOfImages = Object.values(images);
     const searchableLinodes = linodes.map(linode =>
@@ -186,9 +197,14 @@ export default createSelector<
     const searchableImages = arrOfImages.reduce(imageReducer, []);
     const searchableDomains = domains.map(domainToSearchableItem);
     const searchableNodebalancers = nodebalancers.map(nodeBalToSearchableItem);
-    const searchableKubernetesClusters = kubernetesClusters.map(
-      kubernetesClusterToSearchableItem
-    );
+    const searchableKubernetesClusters = kubernetesClusters
+      .map(thisCluster => {
+        const pools = nodePools.filter(
+          thisPool => thisPool.clusterID === thisCluster.id
+        );
+        return extendCluster(thisCluster, pools, types);
+      })
+      .map(kubernetesClusterToSearchableItem);
 
     return [
       ...searchableLinodes,

--- a/packages/manager/src/store/selectors/getSearchEntitites.test.ts
+++ b/packages/manager/src/store/selectors/getSearchEntitites.test.ts
@@ -27,6 +27,9 @@ describe('getSearchEntities selector', () => {
     },
     kubernetes: {
       itemsById: apiResponseToMappedState(kubernetesClusterFactory.buildList(2))
+    },
+    nodePools: {
+      entities: []
     }
   };
   it('should return an array of SearchableItems', () => {


### PR DESCRIPTION
Added a "description" field for LKE cluster search results.
Roughly matches what we show for Linodes, in this case the total
node count, CPU count, and RAM count for the cluster. Added a
getDescriptionForCluster method to kubeUtils.ts to provide this description.