### PR TITLE
M3-3678 Fix: Google Translate not translating Currency component correctly

### DIFF
--- a/packages/manager/src/components/Currency/Currency.tsx
+++ b/packages/manager/src/components/Currency/Currency.tsx
@@ -27,7 +27,7 @@ export const Currency: React.StatelessComponent<CurrencyFormatterProps> = props 
   }
 
   // eslint-disable-next-line
-  return <div className="notranslate">{output}</div>;
+  return <span className="notranslate">{output}</span>;
 };
 
 export default React.memo(Currency);

--- a/packages/manager/src/components/Currency/Currency.tsx
+++ b/packages/manager/src/components/Currency/Currency.tsx
@@ -27,7 +27,7 @@ export const Currency: React.StatelessComponent<CurrencyFormatterProps> = props 
   }
 
   // eslint-disable-next-line
-  return <>{output}</>;
+  return <div className="notranslate">{output}</div>;
 };
 
 export default React.memo(Currency);

--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/BillingSection.test.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/BillingSection.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, render } from '@testing-library/react';
 import * as React from 'react';
 
-import { wrapWithTheme } from 'src/utilities/testHelpers';
+import { withMarkup, wrapWithTheme } from 'src/utilities/testHelpers';
 
 import BillingSection from './BillingSection';
 
@@ -21,20 +21,20 @@ describe('BillingSection component', () => {
   });
 
   it('should render balance due as a positive number', () => {
-    const { queryAllByText } = renderComponent({ balance: 10.0 });
-    expect(queryAllByText('$10.00')).toHaveLength(1);
+    const { getByText } = renderComponent({ balance: 10.0 });
+    expect(withMarkup(getByText)('$10.00'));
   });
 
   it('should show a negative balance as a credit (parenthesized positive number) if the balance is negative', () => {
-    const { queryAllByText } = renderComponent({
+    const { getByText } = renderComponent({
       balance: -10.0,
       showNegativeAsCredit: true
     });
-    expect(queryAllByText('($10.00)')).toHaveLength(1);
+    expect(withMarkup(getByText)('($10.00)'));
   });
 
   it('should display a positive credit in parentheses', () => {
-    const { queryAllByText } = renderComponent({ credit: 10.0 });
-    expect(queryAllByText('($10.00)')).toHaveLength(1);
+    const { getByText } = renderComponent({ credit: 10.0 });
+    expect(withMarkup(getByText)('($10.00)'));
   });
 });

--- a/packages/manager/src/utilities/testHelpers.tsx
+++ b/packages/manager/src/utilities/testHelpers.tsx
@@ -1,4 +1,4 @@
-import { render, RenderResult } from '@testing-library/react';
+import { MatcherFunction, render, RenderResult } from '@testing-library/react';
 import { ResourcePage } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import { Provider } from 'react-redux';
@@ -141,3 +141,16 @@ export const includesActions = (
       : expect(query(action)).not.toBeInTheDocument();
   }
 };
+
+type Query = (f: MatcherFunction) => HTMLElement;
+
+export const withMarkup = (query: Query) => (text: string): HTMLElement =>
+  query((content: string, node: HTMLElement) => {
+    const hasText = (node: HTMLElement) => node.textContent === text;
+    const childrenDontHaveText = Array.from(node.children).every(
+      child => !hasText(child as HTMLElement)
+    );
+    return hasText(node) && childrenDontHaveText;
+  });
+
+export default withMarkup;

--- a/packages/manager/src/utilities/testHelpers.tsx
+++ b/packages/manager/src/utilities/testHelpers.tsx
@@ -144,6 +144,7 @@ export const includesActions = (
 
 type Query = (f: MatcherFunction) => HTMLElement;
 
+/** H/T to https://stackoverflow.com/questions/55509875/how-to-query-by-text-string-which-contains-html-tags-using-react-testing-library */
 export const withMarkup = (query: Query) => (text: string): HTMLElement =>
   query((content: string, node: HTMLElement) => {
     const hasText = (node: HTMLElement) => node.textContent === text;

--- a/packages/manager/src/utilities/testHelpers.tsx
+++ b/packages/manager/src/utilities/testHelpers.tsx
@@ -153,5 +153,3 @@ export const withMarkup = (query: Query) => (text: string): HTMLElement =>
     );
     return hasText(node) && childrenDontHaveText;
   });
-
-export default withMarkup;


### PR DESCRIPTION
## Description

Funny ticket/situation. A user asked Support for a refund because the price of his Linode was "$0" when he pressed create. This was due to how Google Translate parses our currency component. I'm not sure why it's just this component (tried both before and after John's changes, as well as just sending a raw number). But according to:

https://stackoverflow.com/questions/9628507/how-can-i-tell-google-translate-to-not-translate-a-section-of-a-website

...this is the Google-recommended solution.

## Note:

Adding this to the feature branch and not develop because this is what the Currency component is going to look like in the future, so it's best to make sure it works on the new version.

## To test:

Add the Google Translate extension to Chrome, go to the Linode create page, and choose "Translate Page" (This user was translating to Chinese I believe, but it shouldn't matter what you pick). Change your selected plan; without this change, the price doesn't update. With this, it should.