### PR TITLE
M3-4040 Fix: Remove invalid credits

### DIFF
--- a/packages/manager/src/factories/account.ts
+++ b/packages/manager/src/factories/account.ts
@@ -4,7 +4,7 @@ import { Account, ActivePromotion } from 'linode-js-sdk/lib/account/types';
 export const promoFactory = Factory.Sync.makeFactory<ActivePromotion>({
   image_url: '',
   summary: 'UBUNTU20',
-  description: 'SIgned up via Ubuntu 20.04 announcement $20/60 days',
+  description: 'Signed up via Ubuntu 20.04 announcement $20/60 days',
   expire_dt: '2025-05-01T03:59:59',
   credit_monthly_cap: '20.00',
   credit_remaining: '20.00',
@@ -13,7 +13,7 @@ export const promoFactory = Factory.Sync.makeFactory<ActivePromotion>({
 
 export const accountFactory = Factory.Sync.makeFactory<Account>({
   company: 'xrTHcxhFdaDW1XyYWSNWsccDa07iUy',
-  email: 'prod-test-004@linode.com',
+  email: 'my-email@example.com',
   first_name: 'XRbganOEO',
   last_name: 'demo2',
   address_1: '249 Arch St',
@@ -43,7 +43,7 @@ export const accountFactory = Factory.Sync.makeFactory<Account>({
     {
       image_url: '',
       summary: 'UBUNTU20',
-      description: 'SIgned up via Ubuntu 20.04 announcement $20/60 days',
+      description: 'Signed up via Ubuntu 20.04 announcement $20/60 days',
       expire_dt: '2025-05-01T03:59:59',
       credit_monthly_cap: '20.00',
       credit_remaining: '20.00',

--- a/packages/manager/src/factories/account.ts
+++ b/packages/manager/src/factories/account.ts
@@ -1,0 +1,64 @@
+import * as Factory from 'factory.ts';
+import { Account, ActivePromotion } from 'linode-js-sdk/lib/account/types';
+
+export const promoFactory = Factory.Sync.makeFactory<ActivePromotion>({
+  image_url: '',
+  summary: 'UBUNTU20',
+  description: 'SIgned up via Ubuntu 20.04 announcement $20/60 days',
+  expire_dt: '2025-05-01T03:59:59',
+  credit_monthly_cap: '20.00',
+  credit_remaining: '20.00',
+  this_month_credit_remaining: '20.00'
+});
+
+export const accountFactory = Factory.Sync.makeFactory<Account>({
+  company: 'xrTHcxhFdaDW1XyYWSNWsccDa07iUy',
+  email: 'prod-test-004@linode.com',
+  first_name: 'XRbganOEO',
+  last_name: 'demo2',
+  address_1: '249 Arch St',
+  address_2: '',
+  city: 'Colorado',
+  state: 'asdf',
+  zip: '19106',
+  country: 'AQ',
+  phone: '19005553221',
+  balance: 0.0,
+  tax_id: '111111111',
+  credit_card: {
+    last_four: '1111',
+    expiry: '01/2018',
+    cvv: '123'
+  },
+  balance_uninvoiced: 0.0,
+  active_since: '2018-07-03T12:15:25',
+  capabilities: [
+    'Linodes',
+    'NodeBalancers',
+    'Block Storage',
+    'Object Storage',
+    'Kubernetes'
+  ],
+  active_promotions: [
+    {
+      image_url: '',
+      summary: 'UBUNTU20',
+      description: 'SIgned up via Ubuntu 20.04 announcement $20/60 days',
+      expire_dt: '2025-05-01T03:59:59',
+      credit_monthly_cap: '20.00',
+      credit_remaining: '20.00',
+      this_month_credit_remaining: '20.00'
+    },
+    {
+      image_url: '',
+      summary: 'BAD_PROMO',
+      description:
+        'This promotion is invalid since it has an expiration of null',
+      expire_dt: null,
+      credit_monthly_cap: '20.00',
+      credit_remaining: '20.00',
+      this_month_credit_remaining: '20.00'
+    }
+  ],
+  euuid: '278EC57D-7424-4B3A-B35C3CE395787567'
+});

--- a/packages/manager/src/store/account/account.actions.ts
+++ b/packages/manager/src/store/account/account.actions.ts
@@ -7,11 +7,11 @@ import { actionCreatorFactory } from 'typescript-fsa';
  */
 export const actionCreator = actionCreatorFactory(`@@manager/account`);
 
-export const profileRequest = actionCreator('request');
-
-export const profileRequestSuccess = actionCreator<Account>('success');
-
-export const profileRequestFail = actionCreator<APIError[]>('fail');
+export const requestAccountActions = actionCreator.async<
+  void,
+  Account,
+  APIError[]
+>('request');
 
 // Separate action to update credit card information, since updating this info
 // is accomplished with a separate endpoint that doesn't return the new credit

--- a/packages/manager/src/store/account/account.reducer.ts
+++ b/packages/manager/src/store/account/account.reducer.ts
@@ -4,9 +4,7 @@ import { Reducer } from 'redux';
 import { RequestableDataWithEntityError } from 'src/store/types';
 import { isType } from 'typescript-fsa';
 import {
-  profileRequest,
-  profileRequestFail,
-  profileRequestSuccess,
+  requestAccountActions,
   saveCreditCard,
   updateAccountActions
 } from './account.actions';
@@ -28,24 +26,24 @@ export const defaultState: State = {
  */
 const reducer: Reducer<State> = (state: State = defaultState, action) => {
   return produce(state, draft => {
-    if (isType(action, profileRequest)) {
+    if (isType(action, requestAccountActions.started)) {
       draft.loading = true;
     }
 
-    if (isType(action, profileRequestSuccess)) {
-      const { payload } = action;
+    if (isType(action, requestAccountActions.done)) {
+      const { result } = action.payload;
 
       draft.loading = false;
-      draft.data = payload;
+      draft.data = result;
       draft.lastUpdated = Date.now();
       draft.error.read = undefined;
     }
 
-    if (isType(action, profileRequestFail)) {
-      const { payload } = action;
+    if (isType(action, requestAccountActions.failed)) {
+      const { error } = action.payload;
 
       draft.loading = false;
-      draft.error.read = payload;
+      draft.error.read = error;
     }
 
     if (isType(action, updateAccountActions.started)) {

--- a/packages/manager/src/store/account/account.requests.test.ts
+++ b/packages/manager/src/store/account/account.requests.test.ts
@@ -1,0 +1,43 @@
+import { accountFactory, promoFactory } from 'src/factories/account';
+import { requestAccount, updateAccount } from './account.requests';
+
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+const mockStore = configureMockStore([thunk]);
+
+jest.mock('linode-js-sdk/lib/account', () => {
+  const goodPromo = promoFactory.build();
+  const badPromo = promoFactory.build({ expire_dt: null });
+  const mockAccount = accountFactory.build({
+    active_promotions: [goodPromo, badPromo]
+  });
+  return {
+    getAccountInfo: jest.fn().mockResolvedValue(mockAccount),
+    updateAccountInfo: jest.fn().mockResolvedValue(mockAccount)
+  };
+});
+
+describe('Requesting account data', () => {
+  it('should strip out invalid promos when requesting data', async () => {
+    const store = mockStore();
+    const accountData = await store.dispatch(requestAccount() as any);
+    expect(accountData.active_promotions).toHaveLength(1);
+    expect(accountData.active_promotions[0]).not.toHaveProperty(
+      'expire_dt',
+      null
+    );
+  });
+
+  it('should strip out invalid promos from the response when updating data', async () => {
+    const store = mockStore();
+    const accountData = await store.dispatch(
+      updateAccount(accountFactory.build({ balance_uninvoiced: 1000 })) as any
+    );
+    expect(accountData.active_promotions).toHaveLength(1);
+    expect(accountData.active_promotions[0]).not.toHaveProperty(
+      'expire_dt',
+      null
+    );
+  });
+});

--- a/packages/manager/src/store/account/account.requests.ts
+++ b/packages/manager/src/store/account/account.requests.ts
@@ -1,4 +1,8 @@
-import { Account, getAccountInfo, updateAccountInfo } from 'linode-js-sdk/lib/account';
+import {
+  Account,
+  getAccountInfo,
+  updateAccountInfo
+} from 'linode-js-sdk/lib/account';
 
 import { ThunkActionCreator } from 'src/store/types';
 import { createRequestThunk } from '../store.helpers';
@@ -9,14 +13,35 @@ import {
   updateAccountActions
 } from './account.actions';
 
-/**
- * Async
- */
-export const requestAccount: ThunkActionCreator<
-  Promise<Account>
-> = () => (dispatch, getStore) => {
+export const stripInvalidPromos = (data: Account) => {
+  /**
+   * It's possible for an incorrectly created Expiring Credit
+   * to have an expire_dt of null. Admin and billing ignore
+   * such promos, but since we only display the first promo we find
+   * (there's only supposed to be one active per account), once
+   * a user has one of these "phantom" credits on their account
+   * that's all we'll ever show.
+   *
+   * Although this situation is unlikely to happen (again), since
+   * Admin ignores these we should strip them out. PDI 1268 has
+   * more details.
+   */
+  const { active_promotions } = data;
+  const filteredPromotions = active_promotions.filter(
+    thisPromotion => thisPromotion.expire_dt !== null
+  );
+  return {
+    ...data,
+    active_promotions: filteredPromotions
+  };
+};
+
+export const requestAccount: ThunkActionCreator<Promise<
+  Account
+>> = () => dispatch => {
   dispatch(profileRequest());
   return getAccountInfo()
+    .then(stripInvalidPromos)
     .then(response => {
       dispatch(profileRequestSuccess(response));
       return response;
@@ -29,5 +54,5 @@ export const requestAccount: ThunkActionCreator<
 
 export const updateAccount = createRequestThunk(
   updateAccountActions,
-  ({ ...data }) => updateAccountInfo(data)
+  ({ ...data }) => updateAccountInfo(data).then(stripInvalidPromos)
 );

--- a/packages/manager/src/store/account/account.requests.ts
+++ b/packages/manager/src/store/account/account.requests.ts
@@ -4,20 +4,15 @@ import {
   updateAccountInfo
 } from 'linode-js-sdk/lib/account';
 
-import { ThunkActionCreator } from 'src/store/types';
 import { createRequestThunk } from '../store.helpers';
-import {
-  profileRequest,
-  profileRequestFail,
-  profileRequestSuccess,
-  updateAccountActions
-} from './account.actions';
+import { requestAccountActions, updateAccountActions } from './account.actions';
 
 export const stripInvalidPromos = (data: Account) => {
   /**
    * It's possible for an incorrectly created Expiring Credit
    * to have an expire_dt of null. Admin and billing ignore
-   * such promos, but since we only display the first promo we find
+   * such promos, but since when showing billing info
+   * we only display the first promo we find
    * (there's only supposed to be one active per account), once
    * a user has one of these "phantom" credits on their account
    * that's all we'll ever show.
@@ -36,21 +31,9 @@ export const stripInvalidPromos = (data: Account) => {
   };
 };
 
-export const requestAccount: ThunkActionCreator<Promise<
-  Account
->> = () => dispatch => {
-  dispatch(profileRequest());
-  return getAccountInfo()
-    .then(stripInvalidPromos)
-    .then(response => {
-      dispatch(profileRequestSuccess(response));
-      return response;
-    })
-    .catch(err => {
-      dispatch(profileRequestFail(err));
-      return err;
-    });
-};
+export const requestAccount = createRequestThunk(requestAccountActions, () =>
+  getAccountInfo().then(stripInvalidPromos)
+);
 
 export const updateAccount = createRequestThunk(
   updateAccountActions,


### PR DESCRIPTION
## Description

A DB snafu resulted in some active_promotions with an expiry of null. This is invalid, since by definition an expiring credit must expire. Admin and billing ignore these credits (which are erased already btw), but we show them, resulting in a few confused customers who saw "ghost" credits being applied to their bills instead of the actual credits they were enrolled in.

This is unlikely to happen again, but to be safe we're stripping out anything with an expire_dt of `null`. I did this in account.requests for convenience, since we read promos in several places. I did a small refactor of the account Redux jawn (which I swear I remember doing 6 months ago) while I was at it.

## Note to Reviewers

~I'm working on an easier way to test this. For now, test account 4 has a valid promo code on it. You can use Charles to add an invalid code to the response, or some other proxy/hack. You could also review the unit tests.~

Thanks to @nbokoski dev account 4 now has the correct setup: 2 promos, one valid and one invalid. On develop, you should see both displayed. On this branch, the invalid one should be hidden. On this branch you should also see the correct amount ($50 rather than $25) applied to the billing summary.