### PR TITLE
[Billing] M3-4109: Edit Billing Contact Info (Panel and Drawer)

### DIFF
--- a/packages/manager/src/features/Billing/BillingDetail.tsx
+++ b/packages/manager/src/features/Billing/BillingDetail.tsx
@@ -1,3 +1,4 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
@@ -13,6 +14,10 @@ import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import BillingActivityPanel from './BillingPanels/BillingActivityPanel';
 import SummaryPanel from './BillingPanels/SummaryPanel';
 import BillingSummary from './BillingSummary';
+import ContactInfo from './BillingPanels/SummaryPanel/PanelCards/ContactInformation';
+import {
+  Props as AccountProps
+} from 'src/containers/account.container';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {},
@@ -27,7 +32,15 @@ const useStyles = makeStyles((theme: Theme) => ({
   }
 }));
 
-type CombinedProps = SetDocsProps & RouteComponentProps<{}>;
+interface AccountContextProps
+  extends Pick<
+    AccountProps,
+    'accountLoading' | 'accountLastUpdated' | 'accountData'
+  > {
+  _accountError?: APIError[];
+}
+
+type CombinedProps = SetDocsProps & RouteComponentProps<{}> & AccountContextProps;
 
 export const BillingDetail: React.FC<CombinedProps> = props => {
   const { account, requestAccount } = useAccount();
@@ -68,7 +81,23 @@ export const BillingDetail: React.FC<CombinedProps> = props => {
               promotion={account?.data?.active_promotions?.[0]}
               uninvoicedBalance={account?.data?.balance_uninvoiced ?? 0}
             />
-            <SummaryPanel data-qa-summary-panel history={props.history} />
+            <Grid container direction="row" wrap="nowrap">
+              <ContactInfo
+                company={account?.data?.company}
+                firstName={account?.data?.first_name}
+                lastName={account?.data?.last_name}
+                address1={account?.data?.address_1}
+                address2={account?.data?.address_2}
+                email={account?.data?.email}
+                phone={account?.data?.phone}
+                city={account?.data?.city}
+                state={account?.data?.state}
+                zip={account?.data?.zip}
+                history={props.history}
+                taxId={account?.data?.tax_id}
+              />
+              <SummaryPanel data-qa-summary-panel history={props.history} />
+            </Grid>
             <BillingActivityPanel />
           </Grid>
         </Grid>

--- a/packages/manager/src/features/Billing/BillingDetail.tsx
+++ b/packages/manager/src/features/Billing/BillingDetail.tsx
@@ -1,4 +1,3 @@
-import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
@@ -15,9 +14,6 @@ import BillingActivityPanel from './BillingPanels/BillingActivityPanel';
 import SummaryPanel from './BillingPanels/SummaryPanel';
 import BillingSummary from './BillingSummary';
 import ContactInfo from './BillingPanels/SummaryPanel/PanelCards/ContactInformation';
-import {
-  Props as AccountProps
-} from 'src/containers/account.container';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {},
@@ -32,21 +28,12 @@ const useStyles = makeStyles((theme: Theme) => ({
   }
 }));
 
-interface AccountContextProps
-  extends Pick<
-    AccountProps,
-    'accountLoading' | 'accountLastUpdated' | 'accountData'
-  > {
-  _accountError?: APIError[];
-}
-
-type CombinedProps = SetDocsProps & RouteComponentProps<{}> & AccountContextProps;
+type CombinedProps = SetDocsProps & RouteComponentProps<{}>;
 
 export const BillingDetail: React.FC<CombinedProps> = props => {
   const { account, requestAccount } = useAccount();
 
   const classes = useStyles();
-
   React.useEffect(() => {
     if (account.loading && account.lastUpdated === 0) {
       requestAccount();
@@ -65,6 +52,12 @@ export const BillingDetail: React.FC<CombinedProps> = props => {
     return <ErrorState errorText={errorText} />;
   }
 
+  /* This will never happen, /account is requested on app load
+  and the splash screen doesn't resolve until it succeeds */
+  if (!account.data) {
+    return null;
+  }
+
   return (
     <React.Fragment>
       <DocumentTitleSegment segment={`Account & Billing`} />
@@ -77,24 +70,24 @@ export const BillingDetail: React.FC<CombinedProps> = props => {
         <Grid container>
           <Grid item xs={12} md={12} lg={12} className={classes.main}>
             <BillingSummary
-              balance={account?.data?.balance ?? 0}
-              promotion={account?.data?.active_promotions?.[0]}
-              uninvoicedBalance={account?.data?.balance_uninvoiced ?? 0}
+              balance={account.data.balance ?? 0}
+              promotion={account.data.active_promotions?.[0] ?? []}
+              uninvoicedBalance={account.data.balance_uninvoiced ?? 0}
             />
             <Grid container direction="row" wrap="nowrap">
               <ContactInfo
-                company={account?.data?.company}
-                firstName={account?.data?.first_name}
-                lastName={account?.data?.last_name}
-                address1={account?.data?.address_1}
-                address2={account?.data?.address_2}
-                email={account?.data?.email}
-                phone={account?.data?.phone}
-                city={account?.data?.city}
-                state={account?.data?.state}
-                zip={account?.data?.zip}
+                company={account.data.company}
+                firstName={account.data.first_name}
+                lastName={account.data.last_name}
+                address1={account.data.address_1}
+                address2={account.data.address_2}
+                email={account.data.email}
+                phone={account.data.phone}
+                city={account.data.city}
+                state={account.data.state}
+                zip={account.data.zip}
                 history={props.history}
-                taxId={account?.data?.tax_id}
+                taxId={account.data.tax_id}
               />
               <SummaryPanel data-qa-summary-panel history={props.history} />
             </Grid>

--- a/packages/manager/src/features/Billing/BillingDetail.tsx
+++ b/packages/manager/src/features/Billing/BillingDetail.tsx
@@ -71,7 +71,7 @@ export const BillingDetail: React.FC<CombinedProps> = props => {
           <Grid item xs={12} md={12} lg={12} className={classes.main}>
             <BillingSummary
               balance={account.data.balance ?? 0}
-              promotion={account.data.active_promotions?.[0] ?? undefined}
+              promotion={account.data.active_promotions?.[0]}
               uninvoicedBalance={account.data.balance_uninvoiced ?? 0}
             />
             <Grid container direction="row" wrap="nowrap">

--- a/packages/manager/src/features/Billing/BillingDetail.tsx
+++ b/packages/manager/src/features/Billing/BillingDetail.tsx
@@ -71,7 +71,7 @@ export const BillingDetail: React.FC<CombinedProps> = props => {
           <Grid item xs={12} md={12} lg={12} className={classes.main}>
             <BillingSummary
               balance={account.data.balance ?? 0}
-              promotion={account.data.active_promotions?.[0] ?? []}
+              promotion={account.data.active_promotions?.[0] ?? undefined}
               uninvoicedBalance={account.data.balance_uninvoiced ?? 0}
             />
             <Grid container direction="row" wrap="nowrap">

--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
@@ -39,6 +39,13 @@ const useStyles = makeStyles((theme: Theme) => ({
       alignSelf: 'end'
     }
   },
+  sectionBreak: {
+    flexBasis: '100%',
+    width: 0,
+    height: '1rem',
+    overflow: 'hidden',
+    marginBottom: 8
+  },
   editBtn: {
     marginBottom: theme.spacing(1),
     ...theme.typography.body1,
@@ -156,15 +163,19 @@ const ContactInformation: React.FC<CombinedProps> = props => {
             <div className={classes.section} data-qa-contact-email>
               <div className={classes.wordWrap}>{email}</div>
             </div>
-
             {phone ? (
               <div className={classes.section} data-qa-contact-phone>
-                {phone ? phone : 'No Phone Number Provided'}
+                {phone}
               </div>
             ) : null}
 
             {taxId ? (
-              <div className={classes.section}>{'Tax ID ' + taxId}</div>
+              <div>
+                <div className={classes.sectionBreak}></div>
+                {/* The purpose of the above is to create a break row to align the Tax ID section to bottom */}
+
+                <div className={classes.section}>{'Tax ID ' + taxId}</div>
+              </div>
             ) : null}
           </Grid>
         </Grid>

--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
@@ -33,9 +33,21 @@ const useStyles = makeStyles((theme: Theme) => ({
         maxWidth: '78.8%'
       }
     },
-    display: 'grid',
-    flexDirection: 'row',
-    alignContent: 'space-between'
+    display: 'grid'
+  },
+  taxSection: {
+    marginBottom: theme.spacing(1),
+    ...theme.typography.body1,
+    '& .dif': {
+      position: 'relative',
+      width: 'auto',
+      '& .chip': {
+        position: 'absolute',
+        top: '-4px',
+        right: -10
+      }
+    },
+    alignSelf: 'flex-end'
   },
   editBtn: {
     marginBottom: theme.spacing(1),
@@ -140,6 +152,11 @@ const ContactInformation: React.FC<CombinedProps> = props => {
                 {!(address1 || address2 || city || state || zip) && 'None'}
                 <span>{address1}</span>
                 <div>{address2}</div>
+              </div>
+            </div>
+
+            <div className={classes.section}>
+              <div>
                 <div>{`${city}${city && state && ','} ${state} ${zip}`}</div>
               </div>
             </div>
@@ -157,7 +174,7 @@ const ContactInformation: React.FC<CombinedProps> = props => {
             ) : null}
 
             {taxId ? (
-              <div className={classes.section}>{'Tax ID ' + taxId}</div>
+              <div className={classes.taxSection}>{'Tax ID ' + taxId}</div>
             ) : null}
           </Grid>
         </Grid>

--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
@@ -33,21 +33,11 @@ const useStyles = makeStyles((theme: Theme) => ({
         maxWidth: '78.8%'
       }
     },
-    display: 'grid'
-  },
-  taxSection: {
-    marginBottom: theme.spacing(1),
-    ...theme.typography.body1,
-    '& .dif': {
-      position: 'relative',
-      width: 'auto',
-      '& .chip': {
-        position: 'absolute',
-        top: '-4px',
-        right: -10
-      }
-    },
-    alignSelf: 'flex-end'
+    display: 'grid',
+    alignContent: 'flex-start',
+    '& > div:last-child': {
+      alignSelf: 'end'
+    }
   },
   editBtn: {
     marginBottom: theme.spacing(1),
@@ -174,7 +164,7 @@ const ContactInformation: React.FC<CombinedProps> = props => {
             ) : null}
 
             {taxId ? (
-              <div className={classes.taxSection}>{'Tax ID ' + taxId}</div>
+              <div className={classes.section}>{'Tax ID ' + taxId}</div>
             ) : null}
           </Grid>
         </Grid>

--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
@@ -32,7 +32,10 @@ const useStyles = makeStyles((theme: Theme) => ({
       [theme.breakpoints.up('lg')]: {
         maxWidth: '78.8%'
       }
-    }
+    },
+    display: 'grid',
+    flexDirection: 'row',
+    alignContent: 'space-between'
   },
   editBtn: {
     marginBottom: theme.spacing(1),

--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
@@ -1,17 +1,13 @@
 import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
-import Button from 'src/components/Button';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Grid from 'src/components/Grid';
 
 import Paper from 'src/components/core/Paper';
 import Typography from 'src/components/core/Typography';
-import DateTimeDisplay from 'src/components/DateTimeDisplay';
 
 import BillingContactDrawer from './EditBillingContactDrawer';
-
-import Dialog from './CancelAccountDialog';
 
 import styled from 'src/containers/SummaryPanels.styles';
 
@@ -67,9 +63,6 @@ interface Props extends Pick<RouteComponentProps, 'history'> {
   address1: string;
   email: string;
   phone: string;
-  activeSince: string;
-  username: string;
-  isRestrictedUser: boolean;
   taxId: string;
 }
 

--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
@@ -48,7 +48,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
     cursor: 'pointer',
     color: '#3683dc',
-    fontWeight: 700
+    fontWeight: 700,
+    background: 'none',
+    border: 'none'
   }
 }));
 
@@ -104,9 +106,7 @@ const ContactInformation: React.FC<CombinedProps> = props => {
           </Grid>
 
           <Grid item>
-            <div
-              role="button"
-              tabIndex={0}
+            <button
               className={classes.editBtn}
               onClick={() => {
                 handleEditDrawerOpen();
@@ -118,7 +118,7 @@ const ContactInformation: React.FC<CombinedProps> = props => {
               }}
             >
               Edit
-            </div>
+            </button>
           </Grid>
         </Grid>
 

--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
@@ -55,17 +55,17 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 interface Props extends Pick<RouteComponentProps, 'history'> {
-  company: string | undefined;
-  lastName: string | undefined;
-  firstName: string | undefined;
-  zip: string | undefined;
-  state: string | undefined;
-  city: string | undefined;
-  address2: string | undefined;
-  address1: string | undefined;
-  email: string | undefined;
-  phone: string | undefined;
-  taxId: string | undefined;
+  company: string;
+  lastName: string;
+  firstName: string;
+  zip: string;
+  state: string;
+  city: string;
+  address2: string;
+  address1: string;
+  email: string;
+  phone: string;
+  taxId: string;
 }
 
 type CombinedProps = Props;

--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
@@ -86,14 +86,12 @@ const ContactInformation: React.FC<CombinedProps> = props => {
     address1,
     address2,
     email,
-    username,
     phone,
     taxId
   } = props;
 
   const classes = useStyles();
 
-  const [modalOpen, toggleModal] = React.useState<boolean>(false);
   const [editContactDrawerOpen, setEditContactDrawerOpen] = React.useState<
     boolean
   >(false);
@@ -167,12 +165,6 @@ const ContactInformation: React.FC<CombinedProps> = props => {
           </Grid>
         </Grid>
       </Paper>
-      <Dialog
-        username={username}
-        closeDialog={() => toggleModal(false)}
-        open={modalOpen}
-        history={props.history}
-      />
       <BillingContactDrawer
         open={editContactDrawerOpen}
         onClose={() => setEditContactDrawerOpen(false)}

--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
@@ -10,6 +10,7 @@ import Typography from 'src/components/core/Typography';
 import BillingContactDrawer from './EditBillingContactDrawer';
 
 import styled from 'src/containers/SummaryPanels.styles';
+import * as classNames from 'classnames';
 
 const useStyles = makeStyles((theme: Theme) => ({
   ...styled(theme),
@@ -32,19 +33,18 @@ const useStyles = makeStyles((theme: Theme) => ({
       [theme.breakpoints.up('lg')]: {
         maxWidth: '78.8%'
       }
-    },
-    display: 'grid',
+    }
+  },
+  switchWrapperFlex: {
+    display: 'flex',
+    flexDirection: 'column',
     alignContent: 'flex-start',
+    '& > div:nth-last-child(2)': {
+      flexGrow: 1
+    },
     '& > div:last-child': {
       alignSelf: 'end'
     }
-  },
-  sectionBreak: {
-    flexBasis: '100%',
-    width: 0,
-    height: '1rem',
-    overflow: 'hidden',
-    marginBottom: 8
   },
   editBtn: {
     marginBottom: theme.spacing(1),
@@ -159,7 +159,14 @@ const ContactInformation: React.FC<CombinedProps> = props => {
             </div>
           </Grid>
 
-          <Grid item className={classes.switchWrapper}>
+          <Grid
+            item
+            className={classNames({
+              [classes.switchWrapper]: true,
+              [classes.switchWrapperFlex]:
+                taxId !== undefined && taxId !== null && taxId !== ''
+            })}
+          >
             <div className={classes.section} data-qa-contact-email>
               <div className={classes.wordWrap}>{email}</div>
             </div>
@@ -170,12 +177,7 @@ const ContactInformation: React.FC<CombinedProps> = props => {
             ) : null}
 
             {taxId ? (
-              <div>
-                <div className={classes.sectionBreak}></div>
-                {/* The purpose of the above is to create a break row to align the Tax ID section to bottom */}
-
-                <div className={classes.section}>{'Tax ID ' + taxId}</div>
-              </div>
+              <div className={classes.section}>{'Tax ID ' + taxId}</div>
             ) : null}
           </Grid>
         </Grid>

--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
@@ -105,9 +105,15 @@ const ContactInformation: React.FC<CombinedProps> = props => {
 
           <Grid item>
             <div
+              role="button"
               className={classes.editBtn}
               onClick={() => {
                 handleEditDrawerOpen();
+              }}
+              onKeyPress={e => {
+                if (e.keyCode === 13) {
+                  handleEditDrawerOpen();
+                }
               }}
             >
               Edit

--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
@@ -111,11 +111,6 @@ const ContactInformation: React.FC<CombinedProps> = props => {
               onClick={() => {
                 handleEditDrawerOpen();
               }}
-              onKeyPress={e => {
-                if (e.keyCode === 13) {
-                  handleEditDrawerOpen();
-                }
-              }}
             >
               Edit
             </button>

--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
@@ -104,7 +104,6 @@ const ContactInformation: React.FC<CombinedProps> = props => {
           </Grid>
 
           <Grid item>
-            {/* need to fix styling, Edit should look like a link and be on same horizontal level as Billing Contact. */}
             <div
               className={classes.editBtn}
               onClick={() => {

--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
@@ -37,6 +37,22 @@ const useStyles = makeStyles((theme: Theme) => ({
         maxWidth: '78.8%'
       }
     }
+  },
+  editBtn: {
+    marginBottom: theme.spacing(1),
+    ...theme.typography.body1,
+    '& .dif': {
+      position: 'relative',
+      width: 'auto',
+      '& .chip': {
+        position: 'absolute',
+        top: '-4px',
+        right: -10
+      }
+    },
+    cursor: 'pointer',
+    color: '#3683dc',
+    fontWeight: 700
   }
 }));
 
@@ -99,7 +115,7 @@ const ContactInformation: React.FC<CombinedProps> = props => {
           <Grid item>
             {/* need to fix styling, Edit should look like a link and be on same horizontal level as Billing Contact. */}
             <div
-              className={classes.section}
+              className={classes.editBtn}
               onClick={() => {
                 handleEditDrawerOpen();
               }}
@@ -160,7 +176,7 @@ const ContactInformation: React.FC<CombinedProps> = props => {
       <BillingContactDrawer
         open={editContactDrawerOpen}
         onClose={() => setEditContactDrawerOpen(false)}
-      ></BillingContactDrawer>
+      />
     </React.Fragment>
   );
 };

--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
@@ -155,9 +155,6 @@ const ContactInformation: React.FC<CombinedProps> = props => {
       />
       <BillingContactDrawer
         open={editContactDrawerOpen}
-        onSubmit={() => {
-          console.log('Submitted');
-        }}
         onClose={() => setEditContactDrawerOpen(false)}
       ></BillingContactDrawer>
     </React.Fragment>

--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
@@ -53,17 +53,17 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 interface Props extends Pick<RouteComponentProps, 'history'> {
-  company: string;
-  lastName: string;
-  firstName: string;
-  zip: string;
-  state: string;
-  city: string;
-  address2: string;
-  address1: string;
-  email: string;
-  phone: string;
-  taxId: string;
+  company: string | undefined;
+  lastName: string | undefined;
+  firstName: string | undefined;
+  zip: string | undefined;
+  state: string | undefined;
+  city: string | undefined;
+  address2: string | undefined;
+  address1: string | undefined;
+  email: string | undefined;
+  phone: string | undefined;
+  taxId: string | undefined;
 }
 
 type CombinedProps = Props;
@@ -94,7 +94,7 @@ const ContactInformation: React.FC<CombinedProps> = props => {
   };
 
   return (
-    <React.Fragment>
+    <Grid item xs={6}>
       <Paper className={classes.summarySection} data-qa-contact-summary>
         <Grid container spacing={2} className={classes.grid}>
           <Grid item className={classes.switchWrapper}>
@@ -161,7 +161,7 @@ const ContactInformation: React.FC<CombinedProps> = props => {
         open={editContactDrawerOpen}
         onClose={() => setEditContactDrawerOpen(false)}
       />
-    </React.Fragment>
+    </Grid>
   );
 };
 

--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
@@ -1,10 +1,18 @@
 import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
-import Paper from 'src/components/core/Paper';
+import Button from 'src/components/Button';
 import { makeStyles, Theme } from 'src/components/core/styles';
+import Grid from 'src/components/Grid';
+
+import Paper from 'src/components/core/Paper';
 import Typography from 'src/components/core/Typography';
 import DateTimeDisplay from 'src/components/DateTimeDisplay';
+
+import BillingContactDrawer from './EditBillingContactDrawer';
+
+import Dialog from './CancelAccountDialog';
+
 import styled from 'src/containers/SummaryPanels.styles';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -14,6 +22,21 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   cancel: {
     marginTop: theme.spacing(2)
+  },
+  grid: {
+    [theme.breakpoints.up('lg')]: {
+      height: '100%'
+    }
+  },
+  switchWrapper: {
+    flex: 1,
+    maxWidth: '100%',
+    position: 'relative',
+    '&.mlMain': {
+      [theme.breakpoints.up('lg')]: {
+        maxWidth: '78.8%'
+      }
+    }
   }
 }));
 
@@ -29,13 +52,14 @@ interface Props extends Pick<RouteComponentProps, 'history'> {
   email: string;
   phone: string;
   activeSince: string;
+  username: string;
+  isRestrictedUser: boolean;
+  taxId: string;
 }
 
 type CombinedProps = Props;
 
 const ContactInformation: React.FC<CombinedProps> = props => {
-  const classes = useStyles();
-
   const {
     city,
     state,
@@ -46,49 +70,97 @@ const ContactInformation: React.FC<CombinedProps> = props => {
     address1,
     address2,
     email,
+    username,
     phone,
-    activeSince
+    activeSince,
+    isRestrictedUser,
+    taxId
   } = props;
 
-  return (
-    <Paper className={classes.summarySection} data-qa-contact-summary>
-      <Typography variant="h3" className={classes.title}>
-        Billing Contact
-      </Typography>
+  const classes = useStyles();
 
-      <div className={classes.section} data-qa-company>
-        <strong>Company Name:&nbsp;</strong>
-        <div className={classes.wordWrap}>{company ? company : 'None'}</div>
-      </div>
-      <div className={classes.section} data-qa-contact-name>
-        <strong>Name:&nbsp;</strong>
-        {!(firstName || lastName) && 'None'}
-        <div className={classes.wordWrap}>{`${firstName} ${lastName}`}</div>
-      </div>
-      <div className={classes.section} data-qa-contact-address>
-        <div>
-          <strong>Address:&nbsp;</strong>
-        </div>
-        <div>
-          {!(address1 || address2 || city || state || zip) && 'None'}
-          <span>{address1}</span>
-          <div>{address2}</div>
-          <div>{`${city}${city && state && ','} ${state} ${zip}`}</div>
-        </div>
-      </div>
-      <div className={classes.section} data-qa-contact-email>
-        <strong>Email:&nbsp;</strong>
-        <div className={classes.wordWrap}>{email}</div>
-      </div>
-      <div className={classes.section} data-qa-contact-phone>
-        <strong>Phone Number:&nbsp;</strong>
-        {phone ?? 'None'}
-      </div>
-      <div className={classes.section}>
-        <strong>Active Since:&nbsp;</strong>
-        <DateTimeDisplay value={activeSince} format="D MMM YYYY" />
-      </div>
-    </Paper>
+  const [modalOpen, toggleModal] = React.useState<boolean>(false);
+  const [editContactDrawerOpen, setEditContactDrawerOpen] = React.useState<
+    boolean
+  >(false);
+
+  const handleEditDrawerOpen = () => {
+    setEditContactDrawerOpen(true);
+  };
+
+  return (
+    <React.Fragment>
+      <Paper className={classes.summarySection} data-qa-contact-summary>
+        <Grid container spacing={2} className={classes.grid}>
+          <Grid item className={classes.switchWrapper}>
+            <Typography variant="h3" className={classes.title}>
+              Billing Contact
+            </Typography>
+          </Grid>
+
+          <Grid item>
+            {/* need to fix styling, Edit should look like a link and be on same horizontal level as Billing Contact. */}
+            <div
+              className={classes.section}
+              onClick={() => {
+                handleEditDrawerOpen();
+              }}
+            >
+              Edit
+            </div>
+          </Grid>
+        </Grid>
+
+        <Grid container spacing={2} className={classes.grid}>
+          <Grid item className={classes.switchWrapper}>
+            <div className={classes.section} data-qa-contact-name>
+              {!(firstName || lastName) && 'None'}
+              <div
+                className={classes.wordWrap}
+              >{`${firstName} ${lastName}`}</div>
+            </div>
+            <div className={classes.section} data-qa-company>
+              <div className={classes.wordWrap}>
+                {company ? company : 'No Company Name Provided'}
+              </div>
+            </div>
+            <div className={classes.section} data-qa-contact-address>
+              <div>
+                {!(address1 || address2 || city || state || zip) && 'None'}
+                <span>{address1}</span>
+                <div>{address2}</div>
+                <div>{`${city}${city && state && ','} ${state} ${zip}`}</div>
+              </div>
+            </div>
+          </Grid>
+
+          <Grid item className={classes.switchWrapper}>
+            <div className={classes.section} data-qa-contact-email>
+              <div className={classes.wordWrap}>{email}</div>
+            </div>
+            <div className={classes.section} data-qa-contact-phone>
+              {phone ? phone : 'No Phone Number Provided'}
+            </div>
+            <div className={classes.section}>
+              {taxId ? 'Tax ID ' + { taxId } : 'No Tax ID Provided'}
+            </div>
+          </Grid>
+        </Grid>
+      </Paper>
+      <Dialog
+        username={username}
+        closeDialog={() => toggleModal(false)}
+        open={modalOpen}
+        history={props.history}
+      />
+      <BillingContactDrawer
+        open={editContactDrawerOpen}
+        onSubmit={() => {
+          console.log('Submitted');
+        }}
+        onClose={() => setEditContactDrawerOpen(false)}
+      ></BillingContactDrawer>
+    </React.Fragment>
   );
 };
 

--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
@@ -106,6 +106,7 @@ const ContactInformation: React.FC<CombinedProps> = props => {
           <Grid item>
             <div
               role="button"
+              tabIndex={0}
               className={classes.editBtn}
               onClick={() => {
                 handleEditDrawerOpen();

--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
@@ -72,8 +72,6 @@ const ContactInformation: React.FC<CombinedProps> = props => {
     email,
     username,
     phone,
-    activeSince,
-    isRestrictedUser,
     taxId
   } = props;
 
@@ -119,11 +117,13 @@ const ContactInformation: React.FC<CombinedProps> = props => {
                 className={classes.wordWrap}
               >{`${firstName} ${lastName}`}</div>
             </div>
-            <div className={classes.section} data-qa-company>
-              <div className={classes.wordWrap}>
-                {company ? company : 'No Company Name Provided'}
+
+            {company ? (
+              <div className={classes.section} data-qa-company>
+                <div className={classes.wordWrap}>{company}</div>
               </div>
-            </div>
+            ) : null}
+
             <div className={classes.section} data-qa-contact-address>
               <div>
                 {!(address1 || address2 || city || state || zip) && 'None'}
@@ -138,12 +138,16 @@ const ContactInformation: React.FC<CombinedProps> = props => {
             <div className={classes.section} data-qa-contact-email>
               <div className={classes.wordWrap}>{email}</div>
             </div>
-            <div className={classes.section} data-qa-contact-phone>
-              {phone ? phone : 'No Phone Number Provided'}
-            </div>
-            <div className={classes.section}>
-              {taxId ? 'Tax ID ' + { taxId } : 'No Tax ID Provided'}
-            </div>
+
+            {phone ? (
+              <div className={classes.section} data-qa-contact-phone>
+                {phone ? phone : 'No Phone Number Provided'}
+              </div>
+            ) : null}
+
+            {taxId ? (
+              <div className={classes.section}>{'Tax ID ' + taxId}</div>
+            ) : null}
           </Grid>
         </Grid>
       </Paper>

--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/EditBillingContactDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/EditBillingContactDrawer.tsx
@@ -36,9 +36,7 @@ export const BillingContactDrawer: React.FC<CombinedProps> = props => {
       open={open}
       onClose={onClose}
     >
-      <UpdateContactInformationForm 
-        onClose={onClose}
-      />
+      <UpdateContactInformationForm open={open} onClose={onClose} />
     </Drawer>
   );
 };

--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/EditBillingContactDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/EditBillingContactDrawer.tsx
@@ -1,20 +1,6 @@
-import { IPAddress, updateIP } from 'linode-js-sdk/lib/networking';
-import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
-import ActionsPanel from 'src/components/ActionsPanel';
-import Button from 'src/components/Button';
-import FormHelperText from 'src/components/core/FormHelperText';
 import { makeStyles, Theme } from 'src/components/core/styles';
-import Typography from 'src/components/core/Typography';
 import Drawer from 'src/components/Drawer';
-import TextField from 'src/components/TextField';
-import AccountContainer, {
-  Props as AccountProps
-} from 'src/containers/account.container';
-import { arePropsEqual } from 'src/utilities/arePropsEqual';
-import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
-import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
-import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import UpdateContactInformationPanel from 'src/features/Billing/BillingPanels/UpdateContactInformationPanel';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -36,7 +22,7 @@ export interface Props {
   onClose: () => void;
 }
 
-type CombinedProps = Props & AccountProps;
+type CombinedProps = Props;
 
 export const BillingContactDrawer: React.FC<CombinedProps> = props => {
   const { open, onClose } = props;

--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/EditBillingContactDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/EditBillingContactDrawer.tsx
@@ -37,7 +37,7 @@ export const BillingContactDrawer: React.FC<CombinedProps> = props => {
       onClose={onClose}
     >
       <UpdateContactInformationForm 
-        onCancel={onClose}
+        onClose={onClose}
       />
     </Drawer>
   );

--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/EditBillingContactDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/EditBillingContactDrawer.tsx
@@ -1,0 +1,61 @@
+import { IPAddress, updateIP } from 'linode-js-sdk/lib/networking';
+import { APIError } from 'linode-js-sdk/lib/types';
+import * as React from 'react';
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
+import FormHelperText from 'src/components/core/FormHelperText';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+import Drawer from 'src/components/Drawer';
+import TextField from 'src/components/TextField';
+import AccountContainer, {
+    Props as AccountProps
+} from 'src/containers/account.container';
+import { arePropsEqual } from 'src/utilities/arePropsEqual';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
+import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
+import UpdateContactInformationPanel from 'src/features/Billing/BillingPanels/UpdateContactInformationPanel';
+
+const useStyles = makeStyles((theme: Theme) => ({
+    drawer: {
+        '& .MuiDrawer-paper': {
+          [theme.breakpoints.up('md')]: {
+            width: 480
+          },
+          overflowX: 'hidden'
+        },
+        '& .MuiGrid-root': {
+          marginBottom: 0
+        }
+    },
+
+}));
+
+export interface Props {
+    open: boolean;
+    onSubmit: () => void;
+    onClose: () => void;
+    // onSubmit: (type: string, count: number) => void;
+}
+
+type CombinedProps = Props & AccountProps;
+
+export const BillingContactDrawer: React.FC<CombinedProps> = props => {
+    const { open, onSubmit, onClose } = props;
+
+    const classes = useStyles();
+
+    return (
+        <Drawer
+            title='Edit Billing Contact Info'
+            className={classes.drawer}
+            open={open}
+            onClose={onClose}
+        >
+            <UpdateContactInformationPanel />
+        </Drawer>
+    )
+}
+
+export default BillingContactDrawer;

--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/EditBillingContactDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/EditBillingContactDrawer.tsx
@@ -33,15 +33,13 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 export interface Props {
   open: boolean;
-  onSubmit: () => void;
   onClose: () => void;
-  // onSubmit: (type: string, count: number) => void;
 }
 
 type CombinedProps = Props & AccountProps;
 
 export const BillingContactDrawer: React.FC<CombinedProps> = props => {
-  const { open, onSubmit, onClose } = props;
+  const { open, onClose } = props;
 
   const classes = useStyles();
 
@@ -52,7 +50,9 @@ export const BillingContactDrawer: React.FC<CombinedProps> = props => {
       open={open}
       onClose={onClose}
     >
-      <UpdateContactInformationPanel />
+      <UpdateContactInformationPanel 
+        onCancel={onClose}
+      />
     </Drawer>
   );
 };

--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/EditBillingContactDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/EditBillingContactDrawer.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Drawer from 'src/components/Drawer';
-import UpdateContactInformationPanel from 'src/features/Billing/BillingPanels/UpdateContactInformationPanel';
+import UpdateContactInformationForm from 'src/features/Billing/BillingPanels/UpdateContactInformationPanel';
 
 const useStyles = makeStyles((theme: Theme) => ({
   drawer: {
@@ -36,7 +36,7 @@ export const BillingContactDrawer: React.FC<CombinedProps> = props => {
       open={open}
       onClose={onClose}
     >
-      <UpdateContactInformationPanel 
+      <UpdateContactInformationForm 
         onCancel={onClose}
       />
     </Drawer>

--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/EditBillingContactDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/EditBillingContactDrawer.tsx
@@ -6,9 +6,6 @@ import UpdateContactInformationForm from 'src/features/Billing/BillingPanels/Upd
 const useStyles = makeStyles((theme: Theme) => ({
   drawer: {
     '& .MuiDrawer-paper': {
-      [theme.breakpoints.up('md')]: {
-        width: 480
-      },
       overflowX: 'hidden'
     },
     '& .MuiGrid-root': {

--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/EditBillingContactDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/EditBillingContactDrawer.tsx
@@ -9,7 +9,7 @@ import Typography from 'src/components/core/Typography';
 import Drawer from 'src/components/Drawer';
 import TextField from 'src/components/TextField';
 import AccountContainer, {
-    Props as AccountProps
+  Props as AccountProps
 } from 'src/containers/account.container';
 import { arePropsEqual } from 'src/utilities/arePropsEqual';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
@@ -18,44 +18,43 @@ import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import UpdateContactInformationPanel from 'src/features/Billing/BillingPanels/UpdateContactInformationPanel';
 
 const useStyles = makeStyles((theme: Theme) => ({
-    drawer: {
-        '& .MuiDrawer-paper': {
-          [theme.breakpoints.up('md')]: {
-            width: 480
-          },
-          overflowX: 'hidden'
-        },
-        '& .MuiGrid-root': {
-          marginBottom: 0
-        }
+  drawer: {
+    '& .MuiDrawer-paper': {
+      [theme.breakpoints.up('md')]: {
+        width: 480
+      },
+      overflowX: 'hidden'
     },
-
+    '& .MuiGrid-root': {
+      marginBottom: 0
+    }
+  }
 }));
 
 export interface Props {
-    open: boolean;
-    onSubmit: () => void;
-    onClose: () => void;
-    // onSubmit: (type: string, count: number) => void;
+  open: boolean;
+  onSubmit: () => void;
+  onClose: () => void;
+  // onSubmit: (type: string, count: number) => void;
 }
 
 type CombinedProps = Props & AccountProps;
 
 export const BillingContactDrawer: React.FC<CombinedProps> = props => {
-    const { open, onSubmit, onClose } = props;
+  const { open, onSubmit, onClose } = props;
 
-    const classes = useStyles();
+  const classes = useStyles();
 
-    return (
-        <Drawer
-            title='Edit Billing Contact Info'
-            className={classes.drawer}
-            open={open}
-            onClose={onClose}
-        >
-            <UpdateContactInformationPanel />
-        </Drawer>
-    )
-}
+  return (
+    <Drawer
+      title="Edit Billing Contact Info"
+      className={classes.drawer}
+      open={open}
+      onClose={onClose}
+    >
+      <UpdateContactInformationPanel />
+    </Drawer>
+  );
+};
 
 export default BillingContactDrawer;

--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/SummaryPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/SummaryPanel.tsx
@@ -10,7 +10,6 @@ import withAccount, {
   Props as AccountProps
 } from 'src/containers/account.container';
 import withProfile from 'src/containers/profile.container';
-import ContactInfo from './PanelCards/ContactInformation';
 import PaymentInformation from './PanelCards/PaymentInformation';
 
 interface AccountContextProps
@@ -56,33 +55,14 @@ export class SummaryPanel extends React.Component<CombinedProps, {}> {
     );
 
     return (
-      <Grid container direction="row" wrap="nowrap">
-        <Grid item xs={6}>
-          <ContactInfo
-            company={account.company}
-            firstName={account.first_name}
-            lastName={account.last_name}
-            address1={account.address_1}
-            address2={account.address_2}
-            email={account.email}
-            phone={account.phone}
-            city={account.city}
-            state={account.state}
-            zip={account.zip}
-            activeSince={account.active_since}
-            history={this.props.history}
-            taxId={account.tax_id}
-          />
-        </Grid>
-        <Grid item xs={6}>
-          <PaymentInformation
-            balance={account.balance}
-            balanceUninvoiced={account.balance_uninvoiced}
-            expiry={account.credit_card.expiry}
-            lastFour={account.credit_card.last_four}
-            promoCredit={promoCredit}
-          />
-        </Grid>
+      <Grid item xs={6}>
+        <PaymentInformation
+          balance={account.balance}
+          balanceUninvoiced={account.balance_uninvoiced}
+          expiry={account.credit_card.expiry}
+          lastFour={account.credit_card.last_four}
+          promoCredit={promoCredit}
+        />
       </Grid>
     );
   }

--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/SummaryPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/SummaryPanel.tsx
@@ -71,6 +71,7 @@ export class SummaryPanel extends React.Component<CombinedProps, {}> {
             zip={account.zip}
             activeSince={account.active_since}
             history={this.props.history}
+            taxId={account.tax_id}
           />
         </Grid>
         <Grid item xs={6}>

--- a/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationForm.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationForm.tsx
@@ -118,21 +118,19 @@ class UpdateContactInformationForm extends React.Component<
   }
 
   render() {
+    const { accountData: account } = this.props;
+
+    if (!account) {
+      return null;
+    }
+
     return (
       <form>
-        {this.renderContent()}
+        {this.renderForm(account)}
         {this.renderFormActions()}
       </form>
     );
   }
-
-  renderContent = () => {
-    const { accountData: account } = this.props;
-
-    if (account) {
-      return this.renderForm(account);
-    }
-  };
 
   renderForm = (account: Account) => {
     const { classes } = this.props;

--- a/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationForm.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationForm.tsx
@@ -41,7 +41,7 @@ const styles = (theme: Theme) =>
   });
 
 interface Props {
-  onCancel: () => void;
+  onClose: () => void;
 }
 
 interface State {
@@ -137,7 +137,7 @@ class UpdateContactInformationForm extends React.Component<
       return this.renderErrors(accountError.read || []);
     }
 
-    return account ? this.renderForm(account) : this.renderEmpty();
+    return this.renderForm(account);
   };
 
   renderLoading = () => null;
@@ -511,7 +511,7 @@ class UpdateContactInformationForm extends React.Component<
         </Button>
         <Button
           buttonType="secondary"
-          onClick={this.props.onCancel}
+          onClick={this.props.onClose}
           data-qa-reset-contact-info
         >
           Cancel
@@ -589,6 +589,7 @@ class UpdateContactInformationForm extends React.Component<
           success: 'Account information updated.',
           submitting: false
         });
+        this.props.onClose();
       })
       .catch(_ => {
         this.setState({

--- a/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationForm.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationForm.tsx
@@ -84,7 +84,7 @@ const L = {
   }
 };
 
-class UpdateContactInformationPanel extends React.Component<
+class UpdateContactInformationForm extends React.Component<
   CombinedProps,
   State
 > {
@@ -598,17 +598,6 @@ class UpdateContactInformationPanel extends React.Component<
         scrollErrorIntoView();
       });
   };
-
-  resetForm = () => {
-    const { accountData: account } = this.props;
-    this.setState({
-      fields: {
-        state: account ? account.state : undefined
-      },
-      submitting: false,
-      success: undefined
-    });
-  };
 }
 
 const styled = withStyles(styles);
@@ -618,5 +607,5 @@ const withAccount = AccountContainer();
 const enhanced = compose(styled, withAccount);
 
 export default enhanced(
-  UpdateContactInformationPanel
+  UpdateContactInformationForm
 ) as React.ComponentType<{}>;

--- a/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationForm.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationForm.tsx
@@ -106,10 +106,12 @@ class UpdateContactInformationForm extends React.Component<
   }
 
   componentDidUpdate(prevProps: CombinedProps) {
-    if (!prevProps.accountData && !!this.props.accountData) {
+    const { open } = this.props;
+
+    if (prevProps.open !== open) {
       this.setState({
         fields: {
-          state: this.props.accountData.state
+          state: this.props.accountData?.state
         }
       });
     }

--- a/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationForm.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationForm.tsx
@@ -254,7 +254,7 @@ class UpdateContactInformationForm extends React.Component<
           ]}
         >
           <Grid container>
-            <Grid item xs={12} sm={12}>
+            <Grid item xs={12}>
               <TextField
                 label="Company Name (optional)"
                 value={defaultTo(account.company, fields.company)}
@@ -269,7 +269,6 @@ class UpdateContactInformationForm extends React.Component<
         <Grid
           item
           xs={12}
-          sm={12}
           updateFor={[
             account.address_1,
             fields.address_1,
@@ -289,7 +288,6 @@ class UpdateContactInformationForm extends React.Component<
         <Grid
           item
           xs={12}
-          sm={12}
           updateFor={[
             account.address_2,
             fields.address_2,
@@ -431,7 +429,6 @@ class UpdateContactInformationForm extends React.Component<
         <Grid
           item
           xs={6}
-          sm={6}
           updateFor={[account.email, fields.email, errorMap.email, classes]}
         >
           <TextField
@@ -447,7 +444,6 @@ class UpdateContactInformationForm extends React.Component<
         <Grid
           item
           xs={6}
-          sm={6}
           updateFor={[account.phone, fields.phone, errorMap.phone, classes]}
         >
           <TextField
@@ -463,7 +459,6 @@ class UpdateContactInformationForm extends React.Component<
         <Grid
           item
           xs={12}
-          sm={12}
           updateFor={[account.tax_id, fields.tax_id, errorMap.tax_id, classes]}
         >
           <TextField

--- a/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationForm.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationForm.tsx
@@ -42,6 +42,7 @@ const styles = (theme: Theme) =>
 
 interface Props {
   onClose: () => void;
+  open: boolean;
 }
 
 interface State {
@@ -61,6 +62,7 @@ interface State {
     state?: string;
     country?: string;
   };
+  errResponse: string | undefined;
 }
 
 type CombinedProps = AccountProps & Props & WithStyles<ClassNames>;
@@ -90,7 +92,8 @@ class UpdateContactInformationForm extends React.Component<
 > {
   state: State = {
     submitting: false,
-    fields: {}
+    fields: {},
+    errResponse: undefined
   };
 
   composeState = composeState;
@@ -114,10 +117,10 @@ class UpdateContactInformationForm extends React.Component<
 
   render() {
     return (
-      <>
+      <form>
         {this.renderContent()}
         {this.renderFormActions()}
-      </>
+      </form>
     );
   }
 
@@ -137,7 +140,11 @@ class UpdateContactInformationForm extends React.Component<
       return this.renderErrors(accountError.read || []);
     }
 
-    return this.renderForm(account);
+    if (account) {
+      return this.renderForm(account);
+    }
+
+    return null;
   };
 
   renderLoading = () => null;
@@ -202,7 +209,7 @@ class UpdateContactInformationForm extends React.Component<
         className={classes.mainFormContainer}
         data-qa-update-contact
       >
-        {generalError && (
+        {generalError && this.state.errResponse !== undefined && (
           <Grid item xs={12}>
             <Notice error text={generalError} />
           </Grid>
@@ -587,14 +594,16 @@ class UpdateContactInformationForm extends React.Component<
       .then(_ => {
         this.setState({
           success: 'Account information updated.',
-          submitting: false
+          submitting: false,
+          errResponse: undefined
         });
         this.props.onClose();
       })
-      .catch(_ => {
+      .catch(errResponse => {
         this.setState({
           submitting: false,
-          success: undefined
+          success: undefined,
+          errResponse
         });
         scrollErrorIntoView();
       });
@@ -605,8 +614,6 @@ const styled = withStyles(styles);
 
 const withAccount = AccountContainer();
 
-const enhanced = compose(styled, withAccount);
+const enhanced = compose<CombinedProps, Props>(styled, withAccount);
 
-export default enhanced(
-  UpdateContactInformationForm
-) as React.ComponentType<{}>;
+export default enhanced(UpdateContactInformationForm);

--- a/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationForm.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationForm.tsx
@@ -62,7 +62,7 @@ interface State {
     state?: string;
     country?: string;
   };
-  errResponse: string | undefined;
+  errResponse: APIError[] | undefined;
 }
 
 type CombinedProps = AccountProps & Props & WithStyles<ClassNames>;
@@ -127,34 +127,15 @@ class UpdateContactInformationForm extends React.Component<
   }
 
   renderContent = () => {
-    const {
-      accountData: account,
-      accountLoading,
-      accountError,
-      accountLastUpdated
-    } = this.props;
-
-    if (accountLoading && accountLastUpdated === 0) {
-      return this.renderLoading();
-    }
-
-    if (accountError.read) {
-      return this.renderErrors(accountError.read || []);
-    }
+    const { accountData: account } = this.props;
 
     if (account) {
       return this.renderForm(account);
     }
-
-    return null;
   };
 
-  renderLoading = () => null;
-
-  renderErrors = (e: APIError[]) => null;
-
   renderForm = (account: Account) => {
-    const { classes, accountError } = this.props;
+    const { classes } = this.props;
     const { fields, success } = this.state;
 
     const errorMap = getErrorMap(
@@ -172,7 +153,7 @@ class UpdateContactInformationForm extends React.Component<
         'tax_id',
         'zip'
       ],
-      accountError.update
+      this.state.errResponse
     );
 
     const generalError = errorMap.none;
@@ -211,7 +192,7 @@ class UpdateContactInformationForm extends React.Component<
         className={classes.mainFormContainer}
         data-qa-update-contact
       >
-        {generalError && this.state.errResponse !== undefined && (
+        {generalError && (
           <Grid item xs={12}>
             <Notice error text={generalError} />
           </Grid>
@@ -354,9 +335,7 @@ class UpdateContactInformationForm extends React.Component<
             classes
           ]}
         >
-          <Grid container className={classes.stateZip}>
-            <Grid item xs={'auto'} sm={'auto'}>
-              {/*
+          {/*
                 @todo use the <EnhancedSelect /> in favor of the
                 <TextField /> when the DB and API remove the 24 character limit.
 
@@ -368,7 +347,7 @@ class UpdateContactInformationForm extends React.Component<
 
                 Follow DBA-1066 for more information.
               */}
-              {/* <EnhancedSelect
+          {/* <EnhancedSelect
                   label="State / Province"
                   errorText={errorMap.state}
                   onChange={this.updateState}
@@ -391,23 +370,21 @@ class UpdateContactInformationForm extends React.Component<
                     }
                   }}
                 /> */}
-              <TextField
-                label="State / Province"
-                placeholder="Enter a State or Province"
-                errorText={errorMap.state}
-                onChange={e =>
-                  this.updateState({
-                    label: e.target.value,
-                    value: e.target.value
-                  })
-                }
-                dataAttrs={{
-                  'data-qa-contact-province': true
-                }}
-                value={fields.state || ''}
-              />
-            </Grid>
-          </Grid>
+          <TextField
+            label="State / Province"
+            placeholder="Enter a State or Province"
+            errorText={errorMap.state}
+            onChange={e =>
+              this.updateState({
+                label: e.target.value,
+                value: e.target.value
+              })
+            }
+            dataAttrs={{
+              'data-qa-contact-province': true
+            }}
+            value={fields.state || ''}
+          />
         </Grid>
 
         <Grid item xs={12} sm={6}>

--- a/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationPanel.tsx
@@ -599,29 +599,6 @@ class UpdateContactInformationPanel extends React.Component<
       });
   };
 
-  cancelForm = () => {
-    this.setState({
-      success: undefined,
-      submitting: false
-    });
-
-    // this.props
-    //   .updateAccount(this.state.fields)
-    //   .then(_ => {
-    //     this.setState({
-    //       success: 'Account information updated.',
-    //       submitting: false
-    //     });
-    //   })
-    //   .catch(_ => {
-    //     this.setState({
-    //       submitting: false,
-    //       success: undefined
-    //     });
-    //     scrollErrorIntoView();
-    //   });
-  };
-
   resetForm = () => {
     const { accountData: account } = this.props;
     this.setState({

--- a/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationPanel.tsx
@@ -507,10 +507,10 @@ class UpdateContactInformationPanel extends React.Component<
         </Button>
         <Button
           buttonType="secondary"
-          onClick={this.resetForm}
+          onClick={this.cancelForm}
           data-qa-reset-contact-info
         >
-          Reset
+          Cancel
         </Button>
       </ActionsPanel>
     );
@@ -595,6 +595,29 @@ class UpdateContactInformationPanel extends React.Component<
       });
   };
 
+  cancelForm = () => {
+    this.setState({
+      success: undefined,
+      submitting: false
+    });
+
+    // this.props
+    //   .updateAccount(this.state.fields)
+    //   .then(_ => {
+    //     this.setState({
+    //       success: 'Account information updated.',
+    //       submitting: false
+    //     });
+    //   })
+    //   .catch(_ => {
+    //     this.setState({
+    //       submitting: false,
+    //       success: undefined
+    //     });
+    //     scrollErrorIntoView();
+    //   });
+  };
+
   resetForm = () => {
     const { accountData: account } = this.props;
     this.setState({
@@ -611,10 +634,7 @@ const styled = withStyles(styles);
 
 const withAccount = AccountContainer();
 
-const enhanced = compose(
-  styled,
-  withAccount
-);
+const enhanced = compose(styled, withAccount);
 
 export default enhanced(
   UpdateContactInformationPanel

--- a/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationPanel.tsx
@@ -13,7 +13,6 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 import EnhancedSelect, { Item } from 'src/components/EnhancedSelect/Select';
-import ExpansionPanel from 'src/components/ExpansionPanel';
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
@@ -111,12 +110,10 @@ class UpdateContactInformationPanel extends React.Component<
 
   render() {
     return (
-      <ExpansionPanel
-        heading="Update Contact Information"
-        actions={this.renderFormActions}
-      >
+      <>
         {this.renderContent()}
-      </ExpansionPanel>
+        {this.renderFormActions()}
+      </>
     );
   }
 
@@ -215,61 +212,6 @@ class UpdateContactInformationPanel extends React.Component<
         <Grid
           item
           xs={12}
-          updateFor={[
-            account.company,
-            fields.company,
-            errorMap.company,
-            classes
-          ]}
-        >
-          <Grid container>
-            <Grid item xs={12} sm={6}>
-              <TextField
-                label="Company Name"
-                value={defaultTo(account.company, fields.company)}
-                errorText={errorMap.company}
-                onChange={this.updateCompany}
-                data-qa-company
-              />
-            </Grid>
-          </Grid>
-        </Grid>
-
-        <Grid
-          item
-          xs={12}
-          sm={6}
-          updateFor={[account.email, fields.email, errorMap.email, classes]}
-        >
-          <TextField
-            label="Email"
-            type="email"
-            value={defaultTo(account.email, fields.email)}
-            errorText={errorMap.email}
-            onChange={this.updateEmail}
-            data-qa-contact-email
-          />
-        </Grid>
-
-        <Grid
-          item
-          xs={12}
-          sm={6}
-          updateFor={[account.phone, fields.phone, errorMap.phone, classes]}
-        >
-          <TextField
-            label="Phone Number"
-            type="tel"
-            value={defaultTo(account.phone, fields.phone)}
-            errorText={errorMap.phone}
-            onChange={this.updatePhone}
-            data-qa-contact-phone
-          />
-        </Grid>
-
-        <Grid
-          item
-          xs={12}
           sm={6}
           updateFor={[
             account.first_name,
@@ -310,7 +252,30 @@ class UpdateContactInformationPanel extends React.Component<
         <Grid
           item
           xs={12}
-          sm={6}
+          updateFor={[
+            account.company,
+            fields.company,
+            errorMap.company,
+            classes
+          ]}
+        >
+          <Grid container>
+            <Grid item xs={12} sm={12}>
+              <TextField
+                label="Company Name (optional)"
+                value={defaultTo(account.company, fields.company)}
+                errorText={errorMap.company}
+                onChange={this.updateCompany}
+                data-qa-company
+              />
+            </Grid>
+          </Grid>
+        </Grid>
+
+        <Grid
+          item
+          xs={12}
+          sm={12}
           updateFor={[
             account.address_1,
             fields.address_1,
@@ -330,7 +295,7 @@ class UpdateContactInformationPanel extends React.Component<
         <Grid
           item
           xs={12}
-          sm={6}
+          sm={12}
           updateFor={[
             account.address_2,
             fields.address_2,
@@ -377,7 +342,7 @@ class UpdateContactInformationPanel extends React.Component<
           ]}
         >
           <Grid container className={classes.stateZip}>
-            <Grid item xs={12} sm={7}>
+            <Grid item xs={'auto'} sm={'auto'}>
               {/*
                 @todo use the <EnhancedSelect /> in favor of the
                 <TextField /> when the DB and API remove the 24 character limit.
@@ -429,16 +394,17 @@ class UpdateContactInformationPanel extends React.Component<
                 value={fields.state || ''}
               />
             </Grid>
-            <Grid item xs={12} sm={5}>
-              <TextField
-                label="Zip / Postal Code"
-                value={defaultTo(account.zip, fields.zip)}
-                errorText={errorMap.zip}
-                onChange={this.updateZip}
-                data-qa-contact-post-code
-              />
-            </Grid>
           </Grid>
+        </Grid>
+
+        <Grid item xs={12} sm={6}>
+          <TextField
+            label="Zip / Postal Code"
+            value={defaultTo(account.zip, fields.zip)}
+            errorText={errorMap.zip}
+            onChange={this.updateZip}
+            data-qa-contact-post-code
+          />
         </Grid>
 
         <Grid
@@ -474,8 +440,40 @@ class UpdateContactInformationPanel extends React.Component<
 
         <Grid
           item
-          xs={12}
+          xs={6}
           sm={6}
+          updateFor={[account.email, fields.email, errorMap.email, classes]}
+        >
+          <TextField
+            label="Email"
+            type="email"
+            value={defaultTo(account.email, fields.email)}
+            errorText={errorMap.email}
+            onChange={this.updateEmail}
+            data-qa-contact-email
+          />
+        </Grid>
+
+        <Grid
+          item
+          xs={6}
+          sm={6}
+          updateFor={[account.phone, fields.phone, errorMap.phone, classes]}
+        >
+          <TextField
+            label="Phone"
+            type="tel"
+            value={defaultTo(account.phone, fields.phone)}
+            errorText={errorMap.phone}
+            onChange={this.updatePhone}
+            data-qa-contact-phone
+          />
+        </Grid>
+
+        <Grid
+          item
+          xs={12}
+          sm={12}
           updateFor={[account.tax_id, fields.tax_id, errorMap.tax_id, classes]}
         >
           <TextField

--- a/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationPanel.tsx
@@ -40,6 +40,10 @@ const styles = (theme: Theme) =>
     }
   });
 
+interface Props {
+  onCancel: () => void;
+}
+
 interface State {
   submitting: boolean;
   success?: string;
@@ -59,7 +63,7 @@ interface State {
   };
 }
 
-type CombinedProps = AccountProps & WithStyles<ClassNames>;
+type CombinedProps = AccountProps & Props & WithStyles<ClassNames>;
 
 const field = (path: string[]) => lensPath(['fields', ...path]);
 
@@ -507,7 +511,7 @@ class UpdateContactInformationPanel extends React.Component<
         </Button>
         <Button
           buttonType="secondary"
-          onClick={this.cancelForm}
+          onClick={this.props.onCancel}
           data-qa-reset-contact-info
         >
           Cancel

--- a/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/index.ts
+++ b/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/index.ts
@@ -1,2 +1,2 @@
-import UpdateContactInformationPanel from './UpdateContactInformationPanel';
-export default UpdateContactInformationPanel;
+import UpdateContactInformationForm from './UpdateContactInformationForm';
+export default UpdateContactInformationForm;


### PR DESCRIPTION
## Description
This moves the editing of Billing Contact Info into a drawer instead of an expansion panel

## Type of Change
- Non breaking change ('update', 'change')

## Notes
To-Dos:
- [x] Fix styling of "Edit" text
- [ ] Height of Billing Contact panel (?)
- [x] Collapse unpopulated fields in panel (e.g., if there is no Phone Number or Tax ID, collapse that field)
- [x] Link up error handling properly
- [x] Cancel button in drawer should close out the drawer
- [x] Clean up extraneous comments/unused imports/etc.
