### PR TITLE
M3-4157: Change 'S' in support tickets on the managed dashboard to lowercase

### DIFF
--- a/packages/manager/src/features/Dashboard/ManagedDashboardCard/MonitorTickets.tsx
+++ b/packages/manager/src/features/Dashboard/ManagedDashboardCard/MonitorTickets.tsx
@@ -57,10 +57,10 @@ export const MonitorTickets: React.FC<Props> = props => {
       <Grid item>
         <Typography variant="h2">
           {hasIssues
-            ? `${openIssues.length} open Support ${
+            ? `${openIssues.length} open support ${
                 openIssues.length === 1 ? 'ticket' : 'tickets'
               }`
-            : 'No open Support tickets'}
+            : 'No open support tickets'}
         </Typography>
       </Grid>
       <Grid item>


### PR DESCRIPTION
## Description
Since support is not referring to the team, it should be lowercase.

## Type of Change
- Non breaking change ('update', 'change')