### PR TITLE
[Billing] Billing and Payment history filtering

### DIFF
--- a/packages/manager/src/features/Billing/BillingDetail.tsx
+++ b/packages/manager/src/features/Billing/BillingDetail.tsx
@@ -9,12 +9,10 @@ import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
 import { AccountsAndPasswords, BillingAndPayments } from 'src/documentation';
 import { useAccount } from 'src/hooks/useAccount';
-import { useProfile } from 'src/hooks/useProfile';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import BillingActivityPanel from './BillingPanels/BillingActivityPanel';
 import SummaryPanel from './BillingPanels/SummaryPanel';
 import BillingSummary from './BillingSummary';
-import Dialog from './CancelAccountDialog';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {},
@@ -33,32 +31,14 @@ type CombinedProps = SetDocsProps & RouteComponentProps<{}>;
 
 export const BillingDetail: React.FC<CombinedProps> = props => {
   const { account, requestAccount } = useAccount();
-  const { profile, requestProfile } = useProfile();
 
   const classes = useStyles();
 
-  const [modalOpen, toggleModal] = React.useState<boolean>(false);
-
-  // @todo: useReduxLoad for account/profile requests?
   React.useEffect(() => {
     if (account.loading && account.lastUpdated === 0) {
       requestAccount();
     }
   }, [account.loading, account.lastUpdated, requestAccount]);
-
-  React.useEffect(() => {
-    if (profile.loading && profile.lastUpdated === 0) {
-      requestProfile();
-    }
-  }, [profile.loading, profile.lastUpdated, requestProfile]);
-
-  const closeDialog = React.useCallback(() => {
-    toggleModal(false);
-  }, []);
-
-  const openDialog = React.useCallback(() => {
-    toggleModal(true);
-  }, []);
 
   if (account.loading && account.lastUpdated === 0) {
     return <CircleProgress />;
@@ -89,20 +69,10 @@ export const BillingDetail: React.FC<CombinedProps> = props => {
               uninvoicedBalance={account?.data?.balance_uninvoiced ?? 0}
             />
             <SummaryPanel data-qa-summary-panel history={props.history} />
-            <BillingActivityPanel
-              accountActiveSince={account.data?.active_since}
-              openCloseAccountDialog={openDialog}
-              isRestrictedUser={profile.data?.restricted ?? false}
-            />
+            <BillingActivityPanel />
           </Grid>
         </Grid>
       </div>
-      <Dialog
-        username={profile.data?.username ?? ''}
-        closeDialog={closeDialog}
-        open={modalOpen}
-        history={props.history}
-      />
     </React.Fragment>
   );
 };

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.test.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.test.tsx
@@ -62,7 +62,7 @@ describe('BillingActivityPanel', () => {
     });
   });
 
-  it.only('should filter by item type', async () => {
+  it('should filter by item type', async () => {
     const { queryAllByTestId, queryByText, queryByTestId } = renderWithTheme(
       <BillingActivityPanel {...props} />
     );

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.test.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.test.tsx
@@ -5,7 +5,6 @@ import { renderWithTheme } from 'src/utilities/testHelpers';
 import BillingActivityPanel, {
   invoiceToActivityFeedItem,
   paymentToActivityFeedItem,
-  BillingActivityPanelProps,
   getCutoffFromDateRange
 } from './BillingActivityPanel';
 
@@ -43,17 +42,11 @@ jest.mock('linode-js-sdk/lib/account', () => {
 });
 jest.mock('src/components/EnhancedSelect/Select');
 
-const mockOpenCloseAccountDialog = jest.fn();
-
-const props: BillingActivityPanelProps = {
-  isRestrictedUser: false,
-  openCloseAccountDialog: mockOpenCloseAccountDialog,
-  accountActiveSince: '2018-01-01T00:00:00'
-};
+// const mockOpenCloseAccountDialog = jest.fn();
 
 describe('BillingActivityPanel', () => {
   it('renders the header and appropriate rows', async () => {
-    const { getByText } = renderWithTheme(<BillingActivityPanel {...props} />);
+    const { getByText } = renderWithTheme(<BillingActivityPanel />);
     await wait(() => {
       getByText('Billing & Payment History');
       getByText('Description');
@@ -64,7 +57,7 @@ describe('BillingActivityPanel', () => {
 
   it('renders a row for each payment and invoice', async () => {
     const { getByText, getByTestId } = renderWithTheme(
-      <BillingActivityPanel {...props} />
+      <BillingActivityPanel />
     );
     await wait(() => {
       getByText('Invoice #0');
@@ -76,7 +69,7 @@ describe('BillingActivityPanel', () => {
 
   it('should filter by item type', async () => {
     const { queryAllByTestId, queryByText, queryByTestId } = renderWithTheme(
-      <BillingActivityPanel {...props} />
+      <BillingActivityPanel />
     );
 
     // Test selecting "Invoices"
@@ -100,7 +93,7 @@ describe('BillingActivityPanel', () => {
 
   it('should filter by transaction date', async () => {
     const { queryAllByTestId, queryByText, queryByTestId } = renderWithTheme(
-      <BillingActivityPanel {...props} />
+      <BillingActivityPanel />
     );
 
     await wait(() => {
@@ -113,33 +106,8 @@ describe('BillingActivityPanel', () => {
     });
   });
 
-  it('should display "Account active since"', async () => {
-    const { getByText } = renderWithTheme(<BillingActivityPanel {...props} />);
-    await wait(() => {
-      getByText('Account active since 2018-01-01');
-    });
-  });
-
-  it('should display "Close Account" button if unrestricted', async () => {
-    const { getByText } = renderWithTheme(<BillingActivityPanel {...props} />);
-    await wait(() => {
-      const closeAccountButton = getByText('Close Account');
-      fireEvent.click(closeAccountButton);
-      expect(mockOpenCloseAccountDialog).toHaveBeenCalled();
-    });
-  });
-
-  it('should not display "Close Account" button if restricted', async () => {
-    const { queryByText } = renderWithTheme(
-      <BillingActivityPanel {...props} isRestrictedUser={true} />
-    );
-    await wait(() => {
-      expect(queryByText('Close Account')).toBeFalsy();
-    });
-  });
-
   it('should display transaction selection components with defaults', async () => {
-    const { getByText } = renderWithTheme(<BillingActivityPanel {...props} />);
+    const { getByText } = renderWithTheme(<BillingActivityPanel />);
     await wait(() => {
       getByText('All Transaction Types');
       getByText('90 Days');
@@ -153,11 +121,6 @@ describe('invoiceToActivityFeedItem', () => {
     const invoice1 = invoiceFactory.build({ label: 'Invoice #101', total: 1 });
     expect(invoiceToActivityFeedItem(invoice0).label).toBe('Invoice #100');
     expect(invoiceToActivityFeedItem(invoice1).label).toBe('Invoice #101');
-  });
-
-  it('renames the invoice to "Credit" if < 0', () => {
-    const invoice = invoiceFactory.build({ label: 'Invoice #102', total: -1 });
-    expect(invoiceToActivityFeedItem(invoice).label).toBe('Credit #102');
   });
 });
 
@@ -177,7 +140,7 @@ describe('paymentToActivityFeedItem', () => {
     const paymentNegative = paymentFactory.build({ usd: -1 });
     const paymentZero = paymentFactory.build({ usd: 0 });
     const paymentPositive = paymentFactory.build({ usd: 1 });
-    expect(paymentToActivityFeedItem(paymentNegative).total).toBe(-1);
+    expect(paymentToActivityFeedItem(paymentNegative).total).toBe(1);
     expect(paymentToActivityFeedItem(paymentZero).total).toBe(0);
     expect(paymentToActivityFeedItem(paymentPositive).total).toBe(-1);
   });

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.test.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.test.tsx
@@ -5,7 +5,8 @@ import { renderWithTheme } from 'src/utilities/testHelpers';
 import BillingActivityPanel, {
   invoiceToActivityFeedItem,
   paymentToActivityFeedItem,
-  getCutoffFromDateRange
+  getCutoffFromDateRange,
+  makeFilter
 } from './BillingActivityPanel';
 
 afterEach(cleanup);
@@ -166,6 +167,23 @@ describe('paymentToActivityFeedItem', () => {
       expect(getCutoffFromDateRange('All Time', testDate)).toBe(
         '1970-01-01 00:00:00'
       );
+    });
+  });
+
+  describe('makeFilter', () => {
+    const endDate = '2020-01-01T00:00:00';
+    it('always includes conditions to order by date desc', () => {
+      expect(makeFilter()).toHaveProperty('+order_by', 'date');
+      expect(makeFilter()).toHaveProperty('+order', 'desc');
+      expect(makeFilter(endDate)).toHaveProperty('+order_by', 'date');
+      expect(makeFilter(endDate)).toHaveProperty('+order', 'desc');
+    });
+
+    it('includes a date filter only if given an endDate', () => {
+      expect(makeFilter()).not.toHaveProperty('date');
+      expect(makeFilter(endDate)).toHaveProperty('date', {
+        '+gte': '2020-01-01 00:00:00'
+      });
     });
   });
 });

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.test.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.test.tsx
@@ -29,6 +29,7 @@ jest.mock('linode-js-sdk/lib/account', () => {
     })
   };
 });
+jest.mock('src/components/EnhancedSelect/Select');
 
 const mockOpenCloseAccountDialog = jest.fn();
 
@@ -58,6 +59,30 @@ describe('BillingActivityPanel', () => {
       getByText('Invoice #1');
       getByTestId(`payment-0`);
       getByTestId(`payment-1`);
+    });
+  });
+
+  it.only('should filter by item type', async () => {
+    const { queryAllByTestId, queryByText, queryByTestId } = renderWithTheme(
+      <BillingActivityPanel {...props} />
+    );
+
+    // Test selecting "Invoices"
+    await wait(() => {
+      const transactionTypeSelect = queryAllByTestId('select')?.[0];
+      fireEvent.change(transactionTypeSelect, {
+        target: { value: 'invoice' }
+      });
+      expect(queryByTestId('payment-0')).toBeFalsy();
+    });
+
+    // Test selecting "Payments"
+    await wait(() => {
+      const transactionTypeSelect = queryAllByTestId('select')?.[0];
+      fireEvent.change(transactionTypeSelect, {
+        target: { value: 'payment' }
+      });
+      expect(queryByText('Invoice #0')).toBeFalsy();
     });
   });
 

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.test.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.test.tsx
@@ -185,22 +185,22 @@ describe('paymentToActivityFeedItem', () => {
   describe('getCutoffFromDateRange', () => {
     it('returns the datetime of the range relative to given date', () => {
       const testDate = '2020-01-01T00:00:00';
-      expect(getCutoffFromDateRange(testDate, '30 Days')).toBe(
+      expect(getCutoffFromDateRange('30 Days', testDate)).toBe(
         '2019-12-02 00:00:00'
       );
-      expect(getCutoffFromDateRange(testDate, '60 Days')).toBe(
+      expect(getCutoffFromDateRange('60 Days', testDate)).toBe(
         '2019-11-02 00:00:00'
       );
-      expect(getCutoffFromDateRange(testDate, '90 Days')).toBe(
+      expect(getCutoffFromDateRange('90 Days', testDate)).toBe(
         '2019-10-03 00:00:00'
       );
-      expect(getCutoffFromDateRange(testDate, '6 Months')).toBe(
+      expect(getCutoffFromDateRange('6 Months', testDate)).toBe(
         '2019-07-01 00:00:00'
       );
-      expect(getCutoffFromDateRange(testDate, '12 Months')).toBe(
+      expect(getCutoffFromDateRange('12 Months', testDate)).toBe(
         '2019-01-01 00:00:00'
       );
-      expect(getCutoffFromDateRange(testDate, 'All Time')).toBe(
+      expect(getCutoffFromDateRange('All Time', testDate)).toBe(
         '1970-01-01 00:00:00'
       );
     });

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -173,14 +173,7 @@ export const BillingActivityPanel: React.FC<{}> = () => {
   >(defaultDateRange);
 
   const makeRequest = React.useCallback((endDate?: string) => {
-    const filter: any = {
-      '+order_by': 'date',
-      '+order': 'desc'
-    };
-
-    if (endDate) {
-      filter.date = { '+gte': moment.utc(endDate).format(ISO_FORMAT) };
-    }
+    const filter = makeFilter(endDate);
 
     setLoading(true);
 
@@ -337,10 +330,7 @@ export const BillingActivityPanel: React.FC<{}> = () => {
           : true;
 
       const dateCutoff = getCutoffFromDateRange(selectedTransactionDate);
-
-      const matchesDate = moment
-        .utc(thisBillingItem.date)
-        .isAfter(moment.utc(dateCutoff));
+      const matchesDate = isAfter(thisBillingItem.date, dateCutoff);
 
       return matchesType && matchesDate;
     });
@@ -428,13 +418,8 @@ const getAllPayments = getAll<Payment>(getPayments);
 export const invoiceToActivityFeedItem = (
   invoice: Invoice
 ): ActivityFeedItem => {
-  const { id, label, date, total } = invoice;
-
   return {
-    id,
-    label,
-    date,
-    total,
+    ...invoice,
     type: 'invoice'
   };
 };
@@ -489,4 +474,17 @@ export const getCutoffFromDateRange = (
   }
 
   return outputDate.format(ISO_FORMAT);
+};
+
+export const makeFilter = (endDate?: string) => {
+  const filter: any = {
+    '+order_by': 'date',
+    '+order': 'desc'
+  };
+
+  if (endDate) {
+    filter.date = { '+gte': moment.utc(endDate).format(ISO_FORMAT) };
+  }
+
+  return filter;
 };

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -294,6 +294,14 @@ export const BillingActivityPanel: React.FC<BillingActivityPanelProps> = props =
     ]
   );
 
+  const filteredData = React.useMemo(() => {
+    return selectedTransactionType !== 'all'
+      ? combinedData.filter(
+          thisBillingItem => thisBillingItem.type === selectedTransactionType
+        )
+      : combinedData;
+  }, [selectedTransactionType, combinedData]);
+
   return (
     <>
       <div className={classes.headerContainer}>
@@ -345,7 +353,7 @@ export const BillingActivityPanel: React.FC<BillingActivityPanelProps> = props =
           </div>
         </div>
       </div>
-      <OrderBy data={combinedData} orderBy={'date'} order={'desc'}>
+      <OrderBy data={filteredData} orderBy={'date'} order={'desc'}>
         {billingActivityPanel}
       </OrderBy>
     </>

--- a/packages/manager/src/utilities/date.ts
+++ b/packages/manager/src/utilities/date.ts
@@ -1,0 +1,9 @@
+import * as moment from 'moment';
+
+export const isBefore = (d1: string, d2: string) => {
+  return moment.utc(d1).isBefore(moment.utc(d2));
+};
+
+export const isAfter = (d1: string, d2: string) => {
+  return moment.utc(d1).isAfter(moment.utc(d2));
+};


### PR DESCRIPTION
## Description

This PR adds functionality to the "Transaction Type" and "Transaction Date" inputs.

Transaction Type is filtered entirely client-side. Transaction Date is filtered on with a combo of API/client-side filtering:

1. Default is "6 Months", so we only request invoices/payments from the last 6 months.
2. If a user selects a range smaller than 6 months (e.g. 30 days) we don't fetch more data, but we filter out items with dates greater than 30 days.
3. If a user selects a larger range (e.g. 12 months), we re-fetch all data for the last 12 months.

There's an additional optimization that could be made, which is that in step 3 above, it's only actually necessary to fetch invoices/payments from the time of the last invoice/payment to the date cutoff of 12 months. However, This would significantly increase the complexity of this component, and the gains would be very minimal (esp. with a max page size of 500).

Also included a few feedback items from review:

- "Cancel Account" button has been removed. Not sure where this will end up yet.
- "Credit #1234" for negative invoices isn't happening. 
- Negative payments are displayed as positive values and positive credits are displayed as negative values.
- Negative payments are labeled as "Refunds".

One more PR left: PDF downloads.

**To test:** use dev to give yourself credits/refunds/invoices.