### PR TITLE
Tab Refactor: LKE Details, Support Tickets Landing, Linode Clone Landing 

### DIFF
--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -9,7 +9,6 @@ import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
 import Breadcrumb from 'src/components/Breadcrumb';
 import CircleProgress from 'src/components/CircleProgress';
-import AppBar from 'src/components/core/AppBar';
 import Grid from 'src/components/core/Grid';
 import {
   createStyles,
@@ -17,8 +16,11 @@ import {
   WithStyles,
   withStyles
 } from 'src/components/core/styles';
-import Tab from 'src/components/core/Tab';
-import Tabs from 'src/components/core/Tabs';
+import TabPanel from 'src/components/core/ReachTabPanel';
+import TabPanels from 'src/components/core/ReachTabPanels';
+import Tabs from 'src/components/core/ReachTabs';
+import Tab from 'src/components/core/ReachTab';
+import TabList from 'src/components/core/ReachTabList';
 import DocumentationButton from 'src/components/DocumentationButton';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import ErrorState from 'src/components/ErrorState';
@@ -40,14 +42,17 @@ type ClassNames =
   | 'section'
   | 'button'
   | 'titleGridWrapper'
-  | 'tagHeading';
+  | 'tagHeading'
+  | 'tabList'
+  | 'tab';
 
 const styles = (theme: Theme) =>
   createStyles({
     root: {},
     title: {},
     tabBar: {
-      marginTop: 0
+      marginTop: 0,
+      position: 'relative'
     },
     backButton: {
       margin: '-6px 0 0 -16px',
@@ -76,6 +81,51 @@ const styles = (theme: Theme) =>
     },
     tagHeading: {
       marginBottom: theme.spacing(1) + 4
+    },
+    tab: {
+      '&[data-reach-tab]': {
+        // This was copied over from our MuiTab styling in themeFactory. Some of this could probably be cleaned up.
+        color: theme.color.tableHeaderText,
+        minWidth: 50,
+        textTransform: 'inherit',
+        fontSize: '0.93rem',
+        padding: '6px 16px',
+        position: 'relative',
+        overflow: 'hidden',
+        maxWidth: 264,
+        boxSizing: 'border-box',
+        borderBottom: '2px solid transparent',
+        minHeight: theme.spacing(1) * 6,
+        flexShrink: 0,
+        display: 'inline-flex',
+        alignItems: 'center',
+        verticalAlign: 'middle',
+        justifyContent: 'center',
+        appearance: 'none',
+        lineHeight: 1.3,
+        [theme.breakpoints.up('md')]: {
+          minWidth: 75
+        },
+        '&:hover': {
+          color: theme.color.blue
+        }
+      },
+      '&[data-reach-tab][data-selected]': {
+        fontFamily: theme.font.bold,
+        color: theme.color.headline,
+        borderBottom: `2px solid ${theme.color.blue}`
+      }
+    },
+    tabList: {
+      '&[data-reach-tab-list]': {
+        background: 'none !important',
+        boxShadow: `inset 0 -1px 0 ${theme.color.border2}`,
+        marginBottom: theme.spacing(3),
+        [theme.breakpoints.down('md')]: {
+          overflowX: 'scroll',
+          padding: 1
+        }
+      }
     }
   });
 interface KubernetesContainerProps {
@@ -295,65 +345,64 @@ export const KubernetesClusterDetail: React.FunctionComponent<CombinedProps> = p
           <DocumentationButton href="https://www.linode.com/docs/kubernetes/deploy-and-manage-a-cluster-with-linode-kubernetes-engine-a-tutorial/" />
         </Grid>
       </Grid>
-      <Grid item>
-        <Grid item xs={12}>
-          <AppBar position="static" color="default" role="tablist">
-            <Tabs
-              value={0}
-              indicatorColor="primary"
-              textColor="primary"
-              variant="scrollable"
-              scrollButtons="on"
-              className={classes.tabBar}
-            >
-              <Tab key="Summary" label="Summary" data-qa-tab="Summary" />}
-            </Tabs>
-          </AppBar>
-        </Grid>
-        <Grid item xs={12} className={classes.section}>
-          <KubeSummaryPanel
-            cluster={cluster}
-            endpoint={endpoint}
-            endpointError={endpointError}
-            endpointLoading={endpointLoading}
-            kubeconfigAvailable={kubeconfigAvailable}
-            kubeconfigError={kubeconfigError}
-            handleUpdateTags={(newTags: string[]) =>
-              props.updateCluster({
-                clusterID: cluster.id,
-                tags: newTags
-              })
-            }
-          />
-        </Grid>
-        <Grid item xs={12}>
-          <NodePoolsDisplay
-            clusterLabel={cluster.label}
-            pools={cluster.node_pools}
-            types={props.typesData || []}
-            addNodePool={(pool: PoolNodeWithPrice) =>
-              props.createNodePool({
-                clusterID: cluster.id,
-                type: pool.type,
-                count: pool.count
-              })
-            }
-            updatePool={(id: number, updatedPool: PoolNodeWithPrice) =>
-              props.updateNodePool({
-                clusterID: cluster.id,
-                nodePoolID: id,
-                type: updatedPool.type,
-                count: updatedPool.count
-              })
-            }
-            deletePool={(poolID: number) =>
-              props.deleteNodePool({
-                clusterID: cluster.id,
-                nodePoolID: poolID
-              })
-            }
-          />
-        </Grid>
+
+      <Grid item xs={12}>
+        <Tabs defaultIndex={0} className={classes.tabBar}>
+          <TabList className={classes.tabList}>
+            <Tab className={classes.tab} key="Summary" data-qa-tab="Summary">
+              Summary
+            </Tab>
+          </TabList>
+
+          <TabPanels>
+            <TabPanel>
+              <Grid item xs={12} className={classes.section}>
+                <KubeSummaryPanel
+                  cluster={cluster}
+                  endpoint={endpoint}
+                  endpointError={endpointError}
+                  endpointLoading={endpointLoading}
+                  kubeconfigAvailable={kubeconfigAvailable}
+                  kubeconfigError={kubeconfigError}
+                  handleUpdateTags={(newTags: string[]) =>
+                    props.updateCluster({
+                      clusterID: cluster.id,
+                      tags: newTags
+                    })
+                  }
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <NodePoolsDisplay
+                  clusterLabel={cluster.label}
+                  pools={cluster.node_pools}
+                  types={props.typesData || []}
+                  addNodePool={(pool: PoolNodeWithPrice) =>
+                    props.createNodePool({
+                      clusterID: cluster.id,
+                      type: pool.type,
+                      count: pool.count
+                    })
+                  }
+                  updatePool={(id: number, updatedPool: PoolNodeWithPrice) =>
+                    props.updateNodePool({
+                      clusterID: cluster.id,
+                      nodePoolID: id,
+                      type: updatedPool.type,
+                      count: updatedPool.count
+                    })
+                  }
+                  deletePool={(poolID: number) =>
+                    props.deleteNodePool({
+                      clusterID: cluster.id,
+                      nodePoolID: poolID
+                    })
+                  }
+                />
+              </Grid>
+            </TabPanel>
+          </TabPanels>
+        </Tabs>
       </Grid>
     </React.Fragment>
   );

--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketsLanding.test.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketsLanding.test.tsx
@@ -12,7 +12,13 @@ describe('Support Tickets Landing', () => {
       globalErrors={{}}
       setErrors={jest.fn()}
       clearErrors={jest.fn()}
-      classes={{ title: '', openTicketButton: '' }}
+      classes={{
+        title: '',
+        openTicketButton: '',
+        tabsWrapper: '',
+        tabList: '',
+        tab: ''
+      }}
       {...reactRouterProps}
     />
   );

--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketsLanding.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketsLanding.tsx
@@ -6,15 +6,17 @@ import { compose } from 'recompose';
 import AbuseTicketBanner from 'src/components/AbuseTicketBanner';
 import Breadcrumb from 'src/components/Breadcrumb';
 import Button from 'src/components/Button';
-import AppBar from 'src/components/core/AppBar';
 import {
   createStyles,
   Theme,
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
-import Tab from 'src/components/core/Tab';
-import Tabs from 'src/components/core/Tabs';
+import TabPanel from 'src/components/core/ReachTabPanel';
+import TabPanels from 'src/components/core/ReachTabPanels';
+import Tabs from 'src/components/core/ReachTabs';
+import Tab from 'src/components/core/ReachTab';
+import TabList from 'src/components/core/ReachTabList';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
@@ -27,7 +29,12 @@ import withGlobalErrors, {
   Props as GlobalErrorProps
 } from 'src/containers/globalErrors.container';
 
-type ClassNames = 'title' | 'openTicketButton';
+type ClassNames =
+  | 'title'
+  | 'openTicketButton'
+  | 'tabsWrapper'
+  | 'tab'
+  | 'tabList';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -38,6 +45,54 @@ const styles = (theme: Theme) =>
       minWidth: 150,
       paddingLeft: theme.spacing(1) + 4,
       paddingRight: theme.spacing(1) + 4
+    },
+    tabsWrapper: {
+      position: 'relative'
+    },
+    tab: {
+      '&[data-reach-tab]': {
+        // This was copied over from our MuiTab styling in themeFactory. Some of this could probably be cleaned up.
+        color: theme.color.tableHeaderText,
+        minWidth: 50,
+        textTransform: 'inherit',
+        fontSize: '0.93rem',
+        padding: '6px 16px',
+        position: 'relative',
+        overflow: 'hidden',
+        maxWidth: 264,
+        boxSizing: 'border-box',
+        borderBottom: '2px solid transparent',
+        minHeight: theme.spacing(1) * 6,
+        flexShrink: 0,
+        display: 'inline-flex',
+        alignItems: 'center',
+        verticalAlign: 'middle',
+        justifyContent: 'center',
+        appearance: 'none',
+        lineHeight: 1.3,
+        [theme.breakpoints.up('md')]: {
+          minWidth: 75
+        },
+        '&:hover': {
+          color: theme.color.blue
+        }
+      },
+      '&[data-reach-tab][data-selected]': {
+        fontFamily: theme.font.bold,
+        color: theme.color.headline,
+        borderBottom: `2px solid ${theme.color.blue}`
+      }
+    },
+    tabList: {
+      '&[data-reach-tab-list]': {
+        background: 'none !important',
+        boxShadow: `inset 0 -1px 0 ${theme.color.border2}`,
+        marginBottom: theme.spacing(3),
+        [theme.breakpoints.down('md')]: {
+          overflowX: 'scroll',
+          padding: 1
+        }
+      }
     }
   });
 
@@ -205,38 +260,25 @@ export class SupportTicketsLanding extends React.PureComponent<
           )}
         </Grid>
         {notice && <Notice success text={notice} />}
-        <AppBar position="static" color="default" role="tablist">
-          <Tabs
-            value={value}
-            onChange={this.handleChange}
-            indicatorColor="primary"
-            textColor="primary"
-            variant="scrollable"
-            scrollButtons="on"
-          >
-            <Tab
-              data-qa-tab="Open Tickets"
-              key={0}
-              label="Open Tickets"
-              id="tab-open-tickets"
-              role="tab"
-              aria-controls="tabpanel-open-tickets"
-            />
-            <Tab
-              data-qa-tab="Closed Tickets"
-              key={1}
-              label="Closed Tickets"
-              id="tab-closed-tickets"
-              role="tab"
-              aria-controls="tabpanel-closed-tickets"
-            />
-          </Tabs>
-        </AppBar>
-        {/* NB: 0 is the index of the open tickets tab, which evaluates to false */}
-        <TicketList
-          newTicket={newTicket}
-          filterStatus={value ? 'closed' : 'open'}
-        />
+        <Tabs defaultIndex={value} className={classes.tabsWrapper}>
+          <TabList className={classes.tabList}>
+            <Tab data-qa-tab="Open Tickets" key={0} className={classes.tab}>
+              Open Tickets
+            </Tab>
+            <Tab data-qa-tab="Closed Tickets" key={1} className={classes.tab}>
+              Closed Tickets
+            </Tab>
+          </TabList>
+          <TabPanels>
+            <TabPanel>
+              <TicketList newTicket={newTicket} filterStatus={'open'} />
+            </TabPanel>
+            <TabPanel>
+              <TicketList newTicket={newTicket} filterStatus={'closed'} />
+            </TabPanel>
+          </TabPanels>
+        </Tabs>
+
         {this.renderTicketDrawer()}
       </React.Fragment>
     );

--- a/packages/manager/src/features/Support/SupportTickets/TicketList.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/TicketList.tsx
@@ -132,11 +132,7 @@ export class TicketList extends React.Component<CombinedProps, {}> {
 
     return (
       <React.Fragment>
-        <Paper
-          role="tabpanel"
-          aria-labelledby={`tab-${this.props.filterStatus}-tickets`}
-          id={`tabpanel-${this.props.filterStatus}-tickets`}
-        >
+        <Paper>
           <Table aria-label="List of Tickets">
             <TableHead>
               <TableRow>

--- a/packages/manager/src/features/linodes/CloneLanding/CloneLanding.tsx
+++ b/packages/manager/src/features/linodes/CloneLanding/CloneLanding.tsx
@@ -120,15 +120,6 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
     }
   ];
 
-  // Update browser URL with tab change
-  // const handleTabChange = (
-  //   event: React.ChangeEvent<HTMLDivElement>,
-  //   value: number
-  // ) => {
-  //   const routeName = tabs[value].routeName;
-  //   history.push(`${routeName}`);
-  // };
-
   // Helper function for the <Tabs /> component
   const matches = (p: string) => {
     return Boolean(matchPath(p, { path: props.location.pathname }));

--- a/packages/manager/src/features/linodes/CloneLanding/CloneLanding.tsx
+++ b/packages/manager/src/features/linodes/CloneLanding/CloneLanding.tsx
@@ -13,7 +13,6 @@ import * as React from 'react';
 import { connect, MapDispatchToProps } from 'react-redux';
 import {
   matchPath,
-  Route,
   RouteComponentProps,
   Switch,
   withRouter
@@ -21,16 +20,16 @@ import {
 import { compose } from 'recompose';
 import { AnyAction } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
-import AppBar from 'src/components/core/AppBar';
 import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
-import Tab from 'src/components/core/Tab';
-import Tabs from 'src/components/core/Tabs';
+import TabPanel from 'src/components/core/ReachTabPanel';
+import TabPanels from 'src/components/core/ReachTabPanels';
+import Tabs from 'src/components/core/ReachTabs';
+import TabLinkList from 'src/components/TabLinkList';
 import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
 import SuspenseLoader from 'src/components/SuspenseLoader';
-import TabLink from 'src/components/TabLink';
 import withLinodes from 'src/containers/withLinodes.container';
 import { resetEventsPolling } from 'src/eventsPolling';
 import { ApplicationState } from 'src/store';
@@ -95,7 +94,6 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
     configs,
     disks,
     history,
-    match: { url },
     region,
     label,
     linodeId,
@@ -123,13 +121,13 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
   ];
 
   // Update browser URL with tab change
-  const handleTabChange = (
-    event: React.ChangeEvent<HTMLDivElement>,
-    value: number
-  ) => {
-    const routeName = tabs[value].routeName;
-    history.push(`${routeName}`);
-  };
+  // const handleTabChange = (
+  //   event: React.ChangeEvent<HTMLDivElement>,
+  //   value: number
+  // ) => {
+  //   const routeName = tabs[value].routeName;
+  //   history.push(`${routeName}`);
+  // };
 
   // Helper function for the <Tabs /> component
   const matches = (p: string) => {
@@ -342,66 +340,40 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
             >
               Clone
             </Typography>
-            <AppBar
-              className={classes.appBar}
-              position="static"
-              color="default"
-              role="tablist"
-            >
-              <Tabs
-                value={tabs.findIndex(tab => matches(tab.routeName))}
-                onChange={handleTabChange}
-                indicatorColor="primary"
-                textColor="primary"
-                variant="scrollable"
-                scrollButtons="on"
-              >
-                {tabs.map(tab => (
-                  <Tab
-                    key={tab.title}
-                    data-qa-tab={tab.title}
-                    component={React.forwardRef((forwardedProps, ref) => (
-                      <TabLink to={tab.routeName} title={tab.title} />
-                    ))}
-                  />
-                ))}
-              </Tabs>
-            </AppBar>
-            <Route
-              exact
-              path={`${url}(/configs)?`}
-              render={() => (
-                <div className={classes.outerContainer}>
-                  <Configs
-                    configs={configsInState}
-                    configSelection={state.configSelection}
-                    handleSelect={toggleConfig}
-                  />
-                </div>
-              )}
-            />
-            <Route
-              exact
-              path={`${url}/disks`}
-              render={() => (
-                <div className={classes.outerContainer}>
-                  <Typography>
-                    You can make a copy of a disk to the same or different
-                    Linode. We recommend you power off your Linode first, and
-                    keep it powered off until the disk has finished being
-                    cloned.
-                  </Typography>
-                  <div className={classes.diskContainer}>
-                    <Disks
-                      disks={disksInState}
-                      diskSelection={state.diskSelection}
-                      selectedConfigIds={selectedConfigIds}
-                      handleSelect={toggleDisk}
+
+            <Tabs defaultIndex={tabs.findIndex(tab => matches(tab.routeName))}>
+              <TabLinkList tabs={tabs} />
+              <TabPanels>
+                <TabPanel>
+                  <div className={classes.outerContainer}>
+                    <Configs
+                      configs={configsInState}
+                      configSelection={state.configSelection}
+                      handleSelect={toggleConfig}
                     />
                   </div>
-                </div>
-              )}
-            />
+                </TabPanel>
+
+                <TabPanel>
+                  <div className={classes.outerContainer}>
+                    <Typography>
+                      You can make a copy of a disk to the same or different
+                      Linode. We recommend you power off your Linode first, and
+                      keep it powered off until the disk has finished being
+                      cloned.
+                    </Typography>
+                    <div className={classes.diskContainer}>
+                      <Disks
+                        disks={disksInState}
+                        diskSelection={state.diskSelection}
+                        selectedConfigIds={selectedConfigIds}
+                        handleSelect={toggleDisk}
+                      />
+                    </div>
+                  </div>
+                </TabPanel>
+              </TabPanels>
+            </Tabs>
           </Paper>
         </Grid>
         <Grid item xs={12} md={4} lg={3}>

--- a/packages/manager/src/features/linodes/CloneLanding/Configs.tsx
+++ b/packages/manager/src/features/linodes/CloneLanding/Configs.tsx
@@ -42,11 +42,7 @@ export const Configs: React.FC<Props> = props => {
         count
       }) => {
         return (
-          <div
-            id="tabpanel-configurationProfiles"
-            role="tabpanel"
-            aria-labelledby="tab-configurationProfiles"
-          >
+          <div>
             <Table
               isResponsive={false}
               aria-label="List of Configurations"

--- a/packages/manager/src/features/linodes/CloneLanding/Disks.tsx
+++ b/packages/manager/src/features/linodes/CloneLanding/Disks.tsx
@@ -52,12 +52,7 @@ export const Disks: React.FC<Props> = props => {
       }) => {
         return (
           <React.Fragment>
-            <Grid
-              container
-              id="tabpanel-disks"
-              role="tabpanel"
-              aria-labelledby="tab-disks"
-            >
+            <Grid container>
               <Grid item xs={12} md={9}>
                 <Table isResponsive={false} aria-label="List of Disks" border>
                   <TableHead>


### PR DESCRIPTION
## Description

Refactoring to use Reach UI Tabs for LKE Details, Support Tickets landing, and Linode Clone landing. Ticket landing and LKE details are outliers from the other patterns, as neither TabbedPanel nor linked tab work for these particular cases. Instead, we're following the convention as described by Reach.

## Type of Change
- Non breaking change ('change')