### PR TITLE
M3-4039 @-expansion for Target field in Domain records

### DIFF
--- a/packages/manager/src/features/Domains/DomainRecordDrawer.test.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordDrawer.test.tsx
@@ -1,0 +1,39 @@
+import { resolve, shouldResolve } from './DomainRecordDrawer';
+
+const exampleDomain = 'example.com';
+
+describe('Domain record helper methods', () => {
+  describe('shouldResolve', () => {
+    it('should return true for the target of a CNAME', () => {
+      expect(shouldResolve('CNAME', 'target')).toBe(true);
+    });
+
+    it('should return false for other fields of a CNAME', () => {
+      expect(shouldResolve('CNAME', 'name')).toBe(false);
+    });
+
+    it('should return true for the name of an AAAA record', () => {
+      expect(shouldResolve('AAAA', 'name')).toBe(true);
+    });
+
+    it('should return false for other fields of an AAAA', () => {
+      expect(shouldResolve('AAAA', 'target')).toBe(false);
+    });
+
+    // @todo: test for fields we know will be ignored under all cases, once we know what those are.
+  });
+
+  describe('resolve()', () => {
+    it('should resolve a single @ to the Domain name', () => {
+      expect(resolve('mail.@', exampleDomain)).toBe('mail.example.com');
+    });
+
+    it('should return values with no @ unchanged', () => {
+      expect(resolve('mail', exampleDomain)).toBe('mail');
+    });
+
+    it('should ignore additional @s', () => {
+      expect(resolve('mail.@.@', exampleDomain)).toBe('mail.example.com.@');
+    });
+  });
+});

--- a/packages/manager/src/features/Domains/DomainRecordDrawer.test.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordDrawer.test.tsx
@@ -1,4 +1,4 @@
-import { resolve, shouldResolve } from './DomainRecordDrawer';
+import { resolve, resolveAlias, shouldResolve } from './DomainRecordDrawer';
 
 const exampleDomain = 'example.com';
 
@@ -34,6 +34,21 @@ describe('Domain record helper methods', () => {
 
     it('should ignore additional @s', () => {
       expect(resolve('mail.@.@', exampleDomain)).toBe('mail.example.com.@');
+    });
+  });
+
+  describe('resolveAlias helper', () => {
+    it('should resolve aliases where shouldResolve is true', () => {
+      const payload = {
+        name: 'my-name-@',
+        target: 'my-target-@'
+      };
+      const result = resolveAlias(payload, exampleDomain, 'CNAME');
+      expect(result).toHaveProperty('name', payload.name);
+      expect(result).toHaveProperty(
+        'target',
+        resolve(payload.target, exampleDomain)
+      );
     });
   });
 });

--- a/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
@@ -223,13 +223,13 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
   TargetField = ({ label }: { label: string }) => {
     const { domain } = this.props;
     const value = this.state.fields['target'];
-    const hasAliasToResolve = value === '@';
+    const hasAliasToResolve = value.indexOf('@') >= 0;
     return (
       <this.TextField
         field="target"
         label={label}
         placeholder={'hostname or @ for root'}
-        helperText={hasAliasToResolve ? resolve(value, domain) : value}
+        helperText={hasAliasToResolve ? resolve(value, domain) : undefined}
       />
     );
   };

--- a/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
@@ -24,10 +24,7 @@ import Drawer from 'src/components/Drawer';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import MultipleIPInput from 'src/components/MultipleIPInput';
 import Notice from 'src/components/Notice';
-import {
-  default as _TextField,
-  Props as TextFieldProps
-} from 'src/components/TextField';
+import TextField from 'src/components/TextField';
 import {
   DomainActionsProps,
   withDomainActions
@@ -46,10 +43,6 @@ import {
   isValidDomainRecord,
   transferHelperText as helperText
 } from './domainUtils';
-
-const TextField: React.StatelessComponent<TextFieldProps> = props => (
-  <_TextField {...props} />
-);
 
 interface Props extends EditableRecordFields, EditableDomainFields {
   open: boolean;
@@ -106,6 +99,7 @@ interface AdjustedTextFieldProps {
   field: keyof EditableRecordFields | keyof EditableDomainFields;
   min?: number;
   max?: number;
+  placeholder?: string;
 }
 
 interface NumberFieldProps extends AdjustedTextFieldProps {
@@ -177,7 +171,7 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
     this.updateField('axfr_ips')(axfr_ips);
   };
 
-  TextField = ({ label, field }: AdjustedTextFieldProps) => (
+  TextField = ({ label, field, placeholder }: AdjustedTextFieldProps) => (
     <TextField
       label={label}
       errorText={getAPIErrorsFor(
@@ -191,6 +185,7 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
       onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
         this.updateField(field)(e.target.value)
       }
+      placeholder={placeholder}
       data-qa-target={label}
     />
   );
@@ -219,7 +214,11 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
   );
 
   TargetField = ({ label }: { label: string }) => (
-    <this.TextField field="target" label={label} />
+    <this.TextField
+      field="target"
+      label={label}
+      placeholder={'hostname or @ for root'}
+    />
   );
 
   ServiceField = () => <this.TextField field="service" label="Service" />;
@@ -475,7 +474,7 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
       ...this.filterDataByType(this.state.fields, type)
     };
 
-    // Expand @ to the Domain
+    // Expand @ to the Domain in appropriate fields
     const data = resolveAlias(_data, domain);
 
     /**
@@ -767,11 +766,12 @@ const typeMap = {
   TXT: 'TXT'
 };
 
+const fieldsToResolve = ['target'];
 export const resolveAlias = (data: Record<string, any>, domain: string) => {
   // Replace a single @ with a reference to the Domain
   const clone = { ...data };
   for (const [key, value] of Object.entries(clone)) {
-    if (typeof value === 'string') {
+    if (fieldsToResolve.includes(key) && typeof value === 'string') {
       clone[key] = value.replace(/\@/, domain);
     }
   }

--- a/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
@@ -821,6 +821,8 @@ export const shouldResolve = (type: string, field: string) => {
   switch (type) {
     case 'AAAA':
       return field === 'name';
+    case 'SRV':
+      return field === 'target';
     case 'CNAME':
       return field === 'target';
     default:

--- a/packages/manager/src/features/Domains/DomainRecords.tsx
+++ b/packages/manager/src/features/Domains/DomainRecords.tsx
@@ -421,7 +421,10 @@ class DomainRecords extends React.Component<CombinedProps, State> {
         r => typeEq('AAAA', r) || typeEq('A', r)
       ),
       columns: [
-        { title: 'Hostname', render: (r: DomainRecord) => r.name },
+        {
+          title: 'Hostname',
+          render: (r: DomainRecord) => r.name || this.props.domain.domain
+        },
         { title: 'IP Address', render: (r: DomainRecord) => r.target },
         { title: 'TTL', render: getTTL },
         {
@@ -435,7 +438,7 @@ class DomainRecords extends React.Component<CombinedProps, State> {
                 ttl_sec
               }}
               onEdit={this.openForEditARecord}
-              label={name}
+              label={name || this.props.domain.domain}
               deleteData={{
                 recordID: id,
                 onDelete: this.confirmDeletion
@@ -523,7 +526,7 @@ class DomainRecords extends React.Component<CombinedProps, State> {
         { title: 'Name', render: (r: DomainRecord) => r.name },
         {
           title: 'Domain',
-          render: (r: DomainRecord) => this.props.domain.domain
+          render: () => this.props.domain.domain
         },
         {
           title: 'Priority',

--- a/packages/manager/src/features/Domains/DomainRecords.tsx
+++ b/packages/manager/src/features/Domains/DomainRecords.tsx
@@ -800,6 +800,7 @@ class DomainRecords extends React.Component<CombinedProps, State> {
         </ConfirmationDialog>
         <Drawer
           open={drawer.open}
+          domain={this.props.domain.domain}
           domainId={this.props.domain.id}
           onClose={this.resetDrawer}
           mode={drawer.mode}


### PR DESCRIPTION
## Description

See issue #5721. Allows users to use @ as an alias for the current Domain name when creating records. This isn't yet comprehensive; the differing usage of 'target' and 'name' fields makes it tricky and I want to validate the concept. Both CNAME and AAAA records should allow you to use a @ alias in the appropriate place (please make sure our intuitions about what is appropriate agree). Most record types will have a field where this makes sense, but again I want to validate the concept.

I started a larger refactor of this drawer, which is sloooooow. I will push that up as a follow-on PR because it will be pretty large.