### PR TITLE
M3-3954 Lazy load Linodes on BackupsDashboardCard

### DIFF
--- a/packages/manager/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.test.tsx
+++ b/packages/manager/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.test.tsx
@@ -19,14 +19,6 @@ const props = {
   ...reactRouterProps
 };
 
-// const component = shallow(
-//   <BackupsDashboardCard
-//     {...props}
-//     {...reactRouterProps}
-//     accountBackups={false}
-//   />
-// );
-
 describe('Backups dashboard card', () => {
   it('should render a link to /account/settings', () => {
     const { getByTestId } = renderWithTheme(

--- a/packages/manager/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.test.tsx
+++ b/packages/manager/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.test.tsx
@@ -1,60 +1,74 @@
-import { shallow } from 'enzyme';
+import { cleanup, fireEvent, wait } from '@testing-library/react';
 import * as React from 'react';
 
 import { reactRouterProps } from 'src/__data__/reactRouterProps';
+import { renderWithTheme } from 'src/utilities/testHelpers';
 
-import { BackupsDashboardCard } from './BackupsDashboardCard';
+import BackupsDashboardCard from './BackupsDashboardCard';
 
-const classes = {
-  root: '',
-  header: '',
-  icon: '',
-  itemTitle: '',
-  section: '',
-  sectionLink: '',
-  title: '',
-  ctaLink: ''
-};
+afterEach(cleanup);
+
+jest.mock('src/hooks/useReduxLoad', () => ({
+  useReduxLoad: () => ({ _loading: false })
+}));
 
 const props = {
   linodesWithoutBackups: 0,
   openBackupDrawer: jest.fn(),
-  classes
+  accountBackups: false,
+  ...reactRouterProps
 };
 
-const component = shallow(
-  <BackupsDashboardCard
-    {...props}
-    {...reactRouterProps}
-    accountBackups={false}
-  />
-);
+// const component = shallow(
+//   <BackupsDashboardCard
+//     {...props}
+//     {...reactRouterProps}
+//     accountBackups={false}
+//   />
+// );
 
 describe('Backups dashboard card', () => {
   it('should render a link to /account/settings', () => {
-    expect(component.find('[data-qa-account-link]')).toHaveLength(1);
+    const { getByTestId } = renderWithTheme(
+      <BackupsDashboardCard {...props} />
+    );
+    getByTestId('account-link');
   });
+
   it('should not render Enable Backups for Existing Linodes if there are no Linodes w/out backups', () => {
-    expect(component.find('[data-qa-backup-existing]')).toHaveLength(0);
+    const { queryAllByText } = renderWithTheme(
+      <BackupsDashboardCard {...props} />
+    );
+    expect(queryAllByText(/existing linodes/i)).toHaveLength(0);
   });
+
   it('should render the backup-existing section if there are Linodes to be backed up', () => {
-    component.setProps({ linodesWithoutBackups: 2 });
-    expect(component.find('[data-qa-backup-existing]')).toHaveLength(1);
+    const { queryAllByText } = renderWithTheme(
+      <BackupsDashboardCard {...props} linodesWithoutBackups={3} />
+    );
+    expect(queryAllByText(/existing linodes/i)).toHaveLength(1);
   });
-  it('should open the backup drawer when backup-existing is clicked', () => {
-    component.find('[data-qa-backup-existing]').simulate('click');
-    expect(props.openBackupDrawer).toHaveBeenCalled();
+
+  it('should open the backup drawer when backup-existing is clicked', async () => {
+    const { getByTestId } = renderWithTheme(
+      <BackupsDashboardCard {...props} linodesWithoutBackups={3} />
+    );
+    const button = getByTestId('back-up-existing-linodes');
+    await wait(() => fireEvent.click(button));
+    expect(props.openBackupDrawer).toHaveBeenCalledTimes(1);
   });
+
   it('should display the number of Linodes to be backed up', () => {
-    component.setProps({ linodesWithoutBackups: 3 });
-    expect(component.find('[data-qa-linodes-message]').text()).toMatch(
-      '3 Linodes'
+    const { getByText } = renderWithTheme(
+      <BackupsDashboardCard {...props} linodesWithoutBackups={3} />
     );
+    getByText(/3 linodes without backups/i);
   });
+
   it('should pluralize the displayed number of Linodes correctly', () => {
-    component.setProps({ linodesWithoutBackups: 1 });
-    expect(component.find('[data-qa-linodes-message]').text()).toMatch(
-      '1 Linode'
+    const { getByText } = renderWithTheme(
+      <BackupsDashboardCard {...props} linodesWithoutBackups={1} />
     );
+    getByText(/1 linode without backups/i);
   });
 });

--- a/packages/manager/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
@@ -5,65 +5,50 @@ import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
 import CircleProgress from 'src/components/CircleProgress';
 import Paper from 'src/components/core/Paper';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles
-} from 'src/components/core/styles';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import { isRestrictedUser } from 'src/features/Profile/permissionsHelpers';
 import { useReduxLoad } from 'src/hooks/useReduxLoad';
+import { pluralize } from 'src/utilities/pluralize';
 import DashboardCard from '../DashboardCard';
 
-type ClassNames =
-  | 'root'
-  | 'itemTitle'
-  | 'header'
-  | 'icon'
-  | 'section'
-  | 'sectionLink'
-  | 'title'
-  | 'ctaLink';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {
-      width: '100%'
-    },
-    header: {
-      textAlign: 'center',
-      fontSize: 18
-    },
-    icon: {
-      color: theme.color.blueDTwhite,
-      marginRight: theme.spacing(1),
-      marginLeft: theme.spacing(2),
-      fontSize: 32
-    },
-    itemTitle: {
-      marginBottom: theme.spacing(1),
-      color: theme.palette.primary.main
-    },
-    section: {
-      padding: theme.spacing(3),
-      borderBottom: `1px solid ${theme.palette.divider}`
-    },
-    sectionLink: {
-      cursor: 'pointer'
-    },
-    title: {
-      background: theme.bg.tableHeader,
-      display: 'flex',
-      flexFlow: 'row nowrap',
-      alignItems: 'center',
-      justifyContent: 'flex-start',
-      padding: `${theme.spacing(1)}px !important`
-    },
-    ctaLink: {
-      display: 'block'
-    }
-  });
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    width: '100%'
+  },
+  header: {
+    textAlign: 'center',
+    fontSize: 18
+  },
+  icon: {
+    color: theme.color.blueDTwhite,
+    marginRight: theme.spacing(1),
+    marginLeft: theme.spacing(2),
+    fontSize: 32
+  },
+  itemTitle: {
+    marginBottom: theme.spacing(1),
+    color: theme.palette.primary.main
+  },
+  section: {
+    padding: theme.spacing(3),
+    borderBottom: `1px solid ${theme.palette.divider}`
+  },
+  sectionLink: {
+    cursor: 'pointer'
+  },
+  title: {
+    background: theme.bg.tableHeader,
+    display: 'flex',
+    flexFlow: 'row nowrap',
+    alignItems: 'center',
+    justifyContent: 'flex-start',
+    padding: `${theme.spacing(1)}px !important`
+  },
+  ctaLink: {
+    display: 'block'
+  }
+}));
 
 interface Props {
   accountBackups: boolean;
@@ -71,17 +56,13 @@ interface Props {
   openBackupDrawer: () => void;
 }
 
-type CombinedProps = Props & RouteComponentProps<{}> & WithStyles<ClassNames>;
+type CombinedProps = Props & RouteComponentProps<{}>;
 
 export const BackupsDashboardCard: React.FC<CombinedProps> = props => {
-  const {
-    accountBackups,
-    classes,
-    linodesWithoutBackups,
-    openBackupDrawer
-  } = props;
+  const { accountBackups, linodesWithoutBackups, openBackupDrawer } = props;
 
   const { _loading } = useReduxLoad(['linodes']);
+  const classes = useStyles();
 
   const restricted = isRestrictedUser();
 
@@ -110,6 +91,7 @@ export const BackupsDashboardCard: React.FC<CombinedProps> = props => {
         <Link
           to="/account/settings"
           data-qa-account-link
+          data-testid="account-link"
           className={classes.ctaLink}
         >
           <Paper
@@ -134,6 +116,7 @@ export const BackupsDashboardCard: React.FC<CombinedProps> = props => {
           onClick={openBackupDrawer}
           onKeyPress={openBackupDrawer}
           data-qa-backup-existing
+          data-testid="back-up-existing-linodes"
           className={classes.ctaLink}
           role="button"
           tabIndex={0}
@@ -149,9 +132,7 @@ export const BackupsDashboardCard: React.FC<CombinedProps> = props => {
             </Typography>
             <Typography variant="body1" data-qa-linodes-message>
               {`You currently have
-                ${linodesWithoutBackups} ${
-                linodesWithoutBackups > 1 ? 'Linodes' : 'Linode'
-              }
+                ${pluralize('Linode', 'Linodes', linodesWithoutBackups)}
                 without backups. Enable backups to protect your data.`}
             </Typography>
           </Paper>
@@ -163,11 +144,8 @@ export const BackupsDashboardCard: React.FC<CombinedProps> = props => {
 
 BackupsDashboardCard.displayName = 'BackupsDashboardCard';
 
-const styled = withStyles(styles);
-
-const enhanced = compose<CombinedProps, Props>(
-  withRouter,
-  styled
-)(BackupsDashboardCard);
+const enhanced = compose<CombinedProps, Props>(withRouter)(
+  BackupsDashboardCard
+);
 
 export default enhanced;

--- a/packages/manager/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
@@ -3,6 +3,7 @@ import * as classNames from 'classnames';
 import * as React from 'react';
 import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
+import CircleProgress from 'src/components/CircleProgress';
 import Paper from 'src/components/core/Paper';
 import {
   createStyles,
@@ -12,6 +13,7 @@ import {
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import { isRestrictedUser } from 'src/features/Profile/permissionsHelpers';
+import { useReduxLoad } from 'src/hooks/useReduxLoad';
 import DashboardCard from '../DashboardCard';
 
 type ClassNames =
@@ -79,10 +81,16 @@ export const BackupsDashboardCard: React.FC<CombinedProps> = props => {
     openBackupDrawer
   } = props;
 
+  const { _loading } = useReduxLoad(['linodes']);
+
   const restricted = isRestrictedUser();
 
   if (restricted || (accountBackups && !linodesWithoutBackups)) {
     return null;
+  }
+
+  if (_loading) {
+    return <CircleProgress />;
   }
 
   return (
@@ -124,9 +132,11 @@ export const BackupsDashboardCard: React.FC<CombinedProps> = props => {
       {Boolean(linodesWithoutBackups) && (
         <div
           onClick={openBackupDrawer}
+          onKeyPress={openBackupDrawer}
           data-qa-backup-existing
           className={classes.ctaLink}
           role="button"
+          tabIndex={0}
         >
           <Paper
             className={classNames({

--- a/packages/manager/src/features/Dashboard/Dashboard.test.tsx
+++ b/packages/manager/src/features/Dashboard/Dashboard.test.tsx
@@ -29,15 +29,15 @@ const component = shallow(<Dashboard {...props} {...reactRouterProps} />);
 describe('Dashboard view', () => {
   describe('Backups CTA card', () => {
     it('display for non-managed users', () => {
-      expect(
-        component.find('withRouter(WithStyles(BackupsDashboardCard))')
-      ).toHaveLength(1);
+      expect(component.find('withRouter(BackupsDashboardCard)')).toHaveLength(
+        1
+      );
     });
     it('should never display for managed users', () => {
       component.setProps({ managed: true });
-      expect(
-        component.find('withRouter(WithStyles(BackupsDashboardCard))')
-      ).toHaveLength(0);
+      expect(component.find('withRouter(BackupsDashboardCard)')).toHaveLength(
+        0
+      );
     });
   });
 });

--- a/packages/manager/src/features/Dashboard/Dashboard.tsx
+++ b/packages/manager/src/features/Dashboard/Dashboard.tsx
@@ -7,13 +7,6 @@ import { connect, MapDispatchToProps } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
 import AbuseTicketBanner from 'src/components/AbuseTicketBanner';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles,
-  WithTheme
-} from 'src/components/core/styles';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
 import H1Header from 'src/components/H1Header';
@@ -36,13 +29,6 @@ import PromotionsBanner from './PromotionsBanner';
 import TransferDashboardCard from './TransferDashboardCard';
 import VolumesDashboardCard from './VolumesDashboardCard';
 
-type ClassNames = 'root';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {}
-  });
-
 interface StateProps {
   accountBackups: boolean;
   linodesWithoutBackups: Linode[];
@@ -61,11 +47,7 @@ interface DispatchProps {
   };
 }
 
-type CombinedProps = StateProps &
-  DispatchProps &
-  WithStyles<ClassNames> &
-  WithTheme &
-  RouteComponentProps<{}>;
+type CombinedProps = StateProps & DispatchProps & RouteComponentProps<{}>;
 
 export const Dashboard: React.StatelessComponent<CombinedProps> = props => {
   const {
@@ -141,7 +123,7 @@ export const Dashboard: React.StatelessComponent<CombinedProps> = props => {
   );
 };
 
-const mapStateToProps: MapState<StateProps, {}> = (state, ownProps) => {
+const mapStateToProps: MapState<StateProps, {}> = state => {
   const linodes = Object.values(state.__resources.linodes.itemsById);
   const notifications = state.__resources.notifications.data || [];
 
@@ -175,10 +157,7 @@ const mapStateToProps: MapState<StateProps, {}> = (state, ownProps) => {
   };
 };
 
-const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
-  dispatch,
-  ownProps
-) => {
+const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = dispatch => {
   return {
     actions: {
       openBackupDrawer: () => dispatch(handleOpen())
@@ -188,8 +167,6 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
 
 const connected = connect(mapStateToProps, mapDispatchToProps);
 
-const styled = withStyles(styles, { withTheme: true });
-
-const enhanced = compose<CombinedProps, {}>(styled, connected)(Dashboard);
+const enhanced = compose<CombinedProps, {}>(connected)(Dashboard);
 
 export default enhanced;


### PR DESCRIPTION
This is mostly future-proofing, since atm the app stays at the
splash screen until Linodes are loaded.

Adds loading state and useReduxLoad to BackupsDashboardCard.
Adds some accessibility props to a button to resolve linter warnings.
