### PR TITLE
Remove no-lambda rule

### DIFF
--- a/packages/manager/.eslintrc.js
+++ b/packages/manager/.eslintrc.js
@@ -94,8 +94,7 @@ module.exports = {
     'react/prop-types': 'off',
     'react/jsx-no-script-url': 'error',
     'react/jsx-no-useless-fragment': 'warn',
-    // A bind call or arrow function in a JSX prop will create a brand new function on every single render
-    'react/jsx-no-bind': 'warn',
+    'react/jsx-no-bind': 'off',
     'react/no-unescaped-entities': 'warn',
     // sonar
     'sonarjs/cognitive-complexity': 'off',


### PR DESCRIPTION
We originally had this rule, then got into a debate over whether it was helpful. The official React docs use lambdas in their examples, we've never observed a performance impact, and in many cases the stuff we had to do to resolve the warning was weird. The verdict at the time was to remove the rule, and as a result we now have dozens or hundreds of lambda functions in our renders. 

I'm open to more performance testing to determine if this is after all something worth fixing (in theory since we now have the useCallback hook it would be possible to wrap all of these things, although that introduces its own overhead), but in the meantime this falls into the category of things that we're not going to fix immediately, so the warnings will clutter up the linter output.