### PR TITLE
[For Release]: Remove semicolon from Object Storage landing page

### DIFF
--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
@@ -196,7 +196,7 @@ export const BucketLanding: React.FC<CombinedProps> = props => {
     return (
       <>
         {bucketErrors && <BucketErrorDisplay bucketErrors={bucketErrors} />}
-        <RenderEmpty onClick={openBucketDrawer} />;
+        <RenderEmpty onClick={openBucketDrawer} />
       </>
     );
   }


### PR DESCRIPTION
## Description
Remove stray semicolon from Object Storage landing page

## Type of Change
- Bug fix ('fix', 'repair', 'bug')
