### PR TITLE
Fix: Screen reader user cannot open up tickets on account

### DIFF
--- a/packages/manager/src/components/Drawer/Drawer.tsx
+++ b/packages/manager/src/components/Drawer/Drawer.tsx
@@ -10,6 +10,7 @@ import {
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
+import { convertForAria } from 'src/components/TabLink/TabLink';
 
 export interface Props extends DrawerProps {
   title: string;
@@ -72,6 +73,8 @@ type CombinedProps = Props & WithStyles<ClassNames>;
 const DDrawer: React.StatelessComponent<CombinedProps> = props => {
   const { title, classes, children, wide, ...rest } = props;
 
+  const titleID = convertForAria(title);
+
   return (
     <Drawer
       anchor="right"
@@ -83,7 +86,7 @@ const DDrawer: React.StatelessComponent<CombinedProps> = props => {
       }}
       data-qa-drawer
       role="dialog"
-      aria-labelledby={title}
+      aria-labelledby={titleID}
     >
       <Grid
         container
@@ -93,7 +96,7 @@ const DDrawer: React.StatelessComponent<CombinedProps> = props => {
         updateFor={[title, classes]}
       >
         <Grid item>
-          <Typography variant="h2" data-qa-drawer-title={title}>
+          <Typography variant="h2" id={titleID} data-qa-drawer-title={title}>
             {title}
           </Typography>
         </Grid>

--- a/packages/manager/src/components/Drawer/Drawer.tsx
+++ b/packages/manager/src/components/Drawer/Drawer.tsx
@@ -106,6 +106,7 @@ const DDrawer: React.StatelessComponent<CombinedProps> = props => {
             onClick={props.onClose as (e: any) => void}
             className={classes.button}
             data-qa-close-drawer
+            aria-label="Close drawer"
           >
             <Close />
           </Button>

--- a/packages/manager/src/components/TabLink/TabLink.tsx
+++ b/packages/manager/src/components/TabLink/TabLink.tsx
@@ -30,9 +30,7 @@ export const convertForAria = (str: string) => {
   return str
     .trim()
     .toLowerCase()
-    .replace(/([^A-Z0-9]+)(.)/gi, function(match) {
-      return arguments[2].toUpperCase();
-    });
+    .replace(/([^A-Z0-9]+)(.)/gi, (match, p1, p2) => p2.toUpperCase());
 };
 
 class TabLink extends React.Component<CombinedProps> {

--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
@@ -475,7 +475,15 @@ export const SupportTicketDrawer: React.FC<CombinedProps> = props => {
             </a>
             .
           </Typography>
-
+          <TextField
+            label="Title"
+            placeholder="Enter a title for your ticket."
+            required
+            value={summary}
+            onChange={handleSummaryInputChange}
+            errorText={summaryError}
+            data-qa-ticket-summary
+          />
           {props.hideProductSelection ? null : (
             <React.Fragment>
               <Select
@@ -508,15 +516,6 @@ export const SupportTicketDrawer: React.FC<CombinedProps> = props => {
               )}
             </React.Fragment>
           )}
-          <TextField
-            label="Title"
-            placeholder="Enter a title for your ticket."
-            required
-            value={summary}
-            onChange={handleSummaryInputChange}
-            errorText={summaryError}
-            data-qa-ticket-summary
-          />
           <TabbedReply
             required
             error={descriptionError}

--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketsLanding.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketsLanding.tsx
@@ -198,7 +198,7 @@ export class SupportTicketsLanding extends React.PureComponent<
                     className={classes.openTicketButton}
                     onKeyPress={e => {
                       if (e.keyCode === 13) {
-                        this.openDrawer;
+                        this.openDrawer();
                       }
                     }}
                   >

--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketsLanding.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketsLanding.tsx
@@ -196,6 +196,11 @@ export class SupportTicketsLanding extends React.PureComponent<
                     onClick={this.openDrawer}
                     data-qa-open-ticket-link
                     className={classes.openTicketButton}
+                    onKeyPress={e => {
+                      if (e.keyCode === 13) {
+                        this.openDrawer;
+                      }
+                    }}
                   >
                     Open New Ticket
                   </Button>


### PR DESCRIPTION
## Description

We got customer feedback that screen reader users were having trouble opening support tickets. I verified with JAWS that while the button/drawer functionality is fine, the drawer content itself was not providing any auditory cues, thus leading users to a bit of a dead-end. This fix should impact all drawers.

In addition to this fix, I also moved the required field to be the first input users would focus. 

## Type of Change
- Bug fix ('fix')

## Note to Reviewers

The only way to replicate this issue is with JAWS, if you need help getting setup with that, let me know. 

**For consideration:**  I'm thinking about hiding the "what is this regarding" select from SRs for now until we fix our select issues. It's not ideal, but I'm concerned this will lead to continued confusion for visually-impaired users and it doesn't necessarily add a ton of value for these users.. I'm curious what others may think! 
