### PR TITLE
M3-3960 Change: Initial vs. secondary requests

### DIFF
--- a/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
+++ b/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
@@ -59,20 +59,15 @@ export class AuthenticationWrapper extends React.Component<CombinedProps> {
     // Start events polling
     startEventsInterval();
 
-    Promise.all(dataFetchingPromises)
-      .then(() => this.props.markAppAsDoneLoading())
-      .then(() => this.makeSecondaryRequests())
-      .catch();
-
-    // try {
-    //   await Promise.all(dataFetchingPromises);
-    //   this.props.markAppAsDoneLoading();
-    //   Promise.all(secondaryRequests);
-    // } catch {
-    //   /** We choose to do nothing, relying on the Redux error state. */
-    //   this.props.markAppAsDoneLoading();
-    //   Promise.all(secondaryRequests);
-    // }
+    try {
+      await Promise.all(dataFetchingPromises);
+      this.props.markAppAsDoneLoading();
+      this.makeSecondaryRequests();
+    } catch {
+      /** We choose to do nothing, relying on the Redux error state. */
+      this.props.markAppAsDoneLoading();
+      this.makeSecondaryRequests();
+    }
   };
 
   makeSecondaryRequests = () => {

--- a/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
+++ b/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
@@ -38,6 +38,14 @@ export class AuthenticationWrapper extends React.Component<CombinedProps> {
     isAuthenticated: false
   };
 
+  /**
+   * We make a series of requests for data on app load. The flow is:
+   * 1. App begins load; users see splash screen
+   * 2. Initial requests (in makeInitialRequests) are made (account, profile, etc.)
+   * 3. Initial requests complete; app is marked as done loading
+   * 4. As splash screen goes away, secondary requests (in makeSecondaryRequests -- Linodes, types, regions)
+   * are kicked off
+   */
   makeInitialRequests = async () => {
     // When loading Lish we avoid all this extra data loading
     if (window.location?.pathname?.includes('/lish/')) {

--- a/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
+++ b/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
@@ -70,15 +70,20 @@ export class AuthenticationWrapper extends React.Component<CombinedProps> {
     }
   };
 
+  /** Secondary Requests (non-blocking)
+   * Make these once the user is past the
+   * splash screen, since they aren't needed
+   * for navigation, basic display, etc.
+   */
   makeSecondaryRequests = () => {
+    this.props.requestLinodes();
+    this.props.requestTypes();
     /**
      * We have cached Regions data that can be used
      * until the real data comes in; the only
      * likely difference will be the status of each
      * Region.
      */
-    this.props.requestLinodes();
-    this.props.requestTypes();
     this.props.requestRegions();
     this.props.requestNotifications();
   };
@@ -109,7 +114,7 @@ export class AuthenticationWrapper extends React.Component<CombinedProps> {
    * and redux has now been synced with what is in local storage
    */
   componentDidUpdate(prevProps: CombinedProps) {
-    /** if we were previously not authed and now we are authed */
+    /** if we were previously not authenticated and now we are */
     if (
       !prevProps.isAuthenticated &&
       this.props.isAuthenticated &&

--- a/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
+++ b/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
@@ -44,15 +44,29 @@ export class AuthenticationWrapper extends React.Component<CombinedProps> {
       return;
     }
 
-    // Initial Requests
+    // Initial Requests: Things we need immediately (before rendering the app)
     const dataFetchingPromises: Promise<any>[] = [
+      // Grants/what a user has permission to view
       this.props.requestAccount(),
+      // Username and whether a user is restricted
       this.props.requestProfile(),
+      // @todo move to secondaryRequests
       this.props.requestLinodes(),
-      this.props.requestNotifications(),
-      this.props.requestSettings(),
+      // Is a user managed
+      this.props.requestSettings()
+    ];
+
+    // Secondary Requests (non-app-blocking)
+    const secondaryRequests: Promise<any>[] = [
+      /**
+       * We have cached Regions data that can be used
+       * until the real data comes in; the only
+       * likely difference will be the status of each
+       * Region.
+       */
       this.props.requestTypes(),
-      this.props.requestRegions()
+      this.props.requestRegions(),
+      this.props.requestNotifications()
     ];
 
     // Start events polling
@@ -61,9 +75,11 @@ export class AuthenticationWrapper extends React.Component<CombinedProps> {
     try {
       await Promise.all(dataFetchingPromises);
       this.props.markAppAsDoneLoading();
+      Promise.all(secondaryRequests);
     } catch {
       /** We choose to do nothing, relying on the Redux error state. */
       this.props.markAppAsDoneLoading();
+      Promise.all(secondaryRequests);
     }
   };
 
@@ -113,6 +129,7 @@ export class AuthenticationWrapper extends React.Component<CombinedProps> {
   render() {
     const { children } = this.props;
     const { showChildren } = this.state;
+    // eslint-disable-next-line
     return <React.Fragment>{showChildren ? children : null}</React.Fragment>;
   }
 }

--- a/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
+++ b/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
@@ -56,32 +56,36 @@ export class AuthenticationWrapper extends React.Component<CombinedProps> {
       this.props.requestSettings()
     ];
 
-    // Secondary Requests (non-app-blocking)
-    const secondaryRequests: Promise<any>[] = [
-      /**
-       * We have cached Regions data that can be used
-       * until the real data comes in; the only
-       * likely difference will be the status of each
-       * Region.
-       */
-      this.props.requestLinodes(),
-      this.props.requestTypes(),
-      this.props.requestRegions(),
-      this.props.requestNotifications()
-    ];
-
     // Start events polling
     startEventsInterval();
 
-    try {
-      await Promise.all(dataFetchingPromises);
-      this.props.markAppAsDoneLoading();
-      Promise.all(secondaryRequests);
-    } catch {
-      /** We choose to do nothing, relying on the Redux error state. */
-      this.props.markAppAsDoneLoading();
-      Promise.all(secondaryRequests);
-    }
+    Promise.all(dataFetchingPromises)
+      .then(() => this.props.markAppAsDoneLoading())
+      .then(() => this.makeSecondaryRequests())
+      .catch();
+
+    // try {
+    //   await Promise.all(dataFetchingPromises);
+    //   this.props.markAppAsDoneLoading();
+    //   Promise.all(secondaryRequests);
+    // } catch {
+    //   /** We choose to do nothing, relying on the Redux error state. */
+    //   this.props.markAppAsDoneLoading();
+    //   Promise.all(secondaryRequests);
+    // }
+  };
+
+  makeSecondaryRequests = () => {
+    /**
+     * We have cached Regions data that can be used
+     * until the real data comes in; the only
+     * likely difference will be the status of each
+     * Region.
+     */
+    this.props.requestLinodes();
+    this.props.requestTypes();
+    this.props.requestRegions();
+    this.props.requestNotifications();
   };
 
   componentDidMount() {

--- a/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
+++ b/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
@@ -39,7 +39,7 @@ export class AuthenticationWrapper extends React.Component<CombinedProps> {
   };
 
   makeInitialRequests = async () => {
-    // When loading lish we avoid all this extra data loading
+    // When loading Lish we avoid all this extra data loading
     if (window.location?.pathname?.includes('/lish/')) {
       return;
     }
@@ -48,10 +48,10 @@ export class AuthenticationWrapper extends React.Component<CombinedProps> {
     const dataFetchingPromises: Promise<any>[] = [
       // Grants/what a user has permission to view
       this.props.requestAccount(),
+
       // Username and whether a user is restricted
       this.props.requestProfile(),
-      // @todo move to secondaryRequests
-      this.props.requestLinodes(),
+
       // Is a user managed
       this.props.requestSettings()
     ];
@@ -64,6 +64,7 @@ export class AuthenticationWrapper extends React.Component<CombinedProps> {
        * likely difference will be the status of each
        * Region.
        */
+      this.props.requestLinodes(),
       this.props.requestTypes(),
       this.props.requestRegions(),
       this.props.requestNotifications()

--- a/packages/manager/src/components/SplashScreen/SplashScreen.tsx
+++ b/packages/manager/src/components/SplashScreen/SplashScreen.tsx
@@ -42,23 +42,21 @@ const SplashScreen: React.FC<CombinedProps> = props => {
   }, []);
 
   return props.appIsLoading ? (
-    <>
-      <div
-        className={classNames({
-          [classes.root]: true
-        })}
-        aria-label="Loading Cloud Manager"
-      >
-        <div className={classes.logo}>
-          <Logo />
-          <div className="la-ball-beat la-dark">
-            <div />
-            <div />
-            <div />
-          </div>
+    <div
+      className={classNames({
+        [classes.root]: true
+      })}
+      aria-label="Loading Cloud Manager"
+    >
+      <div className={classes.logo}>
+        <Logo />
+        <div className="la-ball-beat la-dark">
+          <div />
+          <div />
+          <div />
         </div>
       </div>
-    </>
+    </div>
   ) : null;
 };
 
@@ -72,7 +70,4 @@ const mapStateToProps: MapState<StateProps, {}> = state => ({
 
 const connected = connect(mapStateToProps);
 
-export default compose<CombinedProps, {}>(
-  connected,
-  React.memo
-)(SplashScreen);
+export default compose<CombinedProps, {}>(connected, React.memo)(SplashScreen);

--- a/packages/manager/src/index.tsx
+++ b/packages/manager/src/index.tsx
@@ -94,21 +94,19 @@ const renderAuthentication = () => (
 );
 
 ReactDOM.render(
-  <React.Fragment>
-    {navigator.cookieEnabled ? (
-      <Provider store={store}>
-        <Router>
-          <Switch>
-            {/* A place to go that prevents the app from loading while injecting OAuth tokens */}
-            <Route exact path="/null" render={renderNull} />
-            <Route render={renderAuthentication} />
-          </Switch>
-        </Router>
-      </Provider>
-    ) : (
-      <CookieWarning />
-    )}
-  </React.Fragment>,
+  navigator.cookieEnabled ? (
+    <Provider store={store}>
+      <Router>
+        <Switch>
+          {/* A place to go that prevents the app from loading while injecting OAuth tokens */}
+          <Route exact path="/null" render={renderNull} />
+          <Route render={renderAuthentication} />
+        </Switch>
+      </Router>
+    </Provider>
+  ) : (
+    <CookieWarning />
+  ),
   document.getElementById('root') as HTMLElement
 );
 


### PR DESCRIPTION
## Description

This is an older ticket that's mostly already been completed. Taking it as an opportunity to separate out the requests that are urgent (can't load the app without them) and those that are needed for all users but don't block anything.

The number of requests made on app load should be unchanged by this PR. The new-ish flow is:

1. App begins load; users see splash screen
2. Initial requests are made (account, profile, etc.)
3. Initial requests complete; app is marked as done
4. As splash screen goes away, secondary requests (Linodes, types, regions) are kicked off