### PR TITLE
M3-3776: Add 'Last Modified' column to Domains landing page

### DIFF
--- a/packages/linode-js-sdk/src/domains/types.ts
+++ b/packages/linode-js-sdk/src/domains/types.ts
@@ -13,6 +13,7 @@ export interface Domain {
   axfr_ips: string[];
   group: string;
   type: DomainType;
+  updated: string;
 }
 
 export type DomainStatus = 'active' | 'disabled' | 'edit_mode' | 'has_errors';

--- a/packages/manager/src/__data__/domains.ts
+++ b/packages/manager/src/__data__/domains.ts
@@ -14,7 +14,8 @@ export const domain1: Domain = {
   retry_sec: 0,
   soa_email: 'user@host.com',
   status: 'active',
-  ttl_sec: 0
+  ttl_sec: 0,
+  updated: '2020-05-01 00:00:00'
 };
 
 export const domain2: Domain = {
@@ -31,7 +32,8 @@ export const domain2: Domain = {
   retry_sec: 0,
   soa_email: 'user@host.com',
   status: 'active',
-  ttl_sec: 0
+  ttl_sec: 0,
+  updated: '2020-05-02 00:00:00'
 };
 
 export const domain3: Domain = {
@@ -48,7 +50,8 @@ export const domain3: Domain = {
   retry_sec: 0,
   soa_email: 'user@host.com',
   status: 'active',
-  ttl_sec: 0
+  ttl_sec: 0,
+  updated: '2020-05-03 00:00:00'
 };
 
 export const domains = [domain1, domain2, domain3];

--- a/packages/manager/src/factories/domain.ts
+++ b/packages/manager/src/factories/domain.ts
@@ -15,5 +15,6 @@ export const domainFactory = Factory.Sync.makeFactory<Domain>({
   type: 'master',
   refresh_sec: 100,
   expire_sec: 100,
-  retry_sec: 100
+  retry_sec: 100,
+  updated: '2020-05-01 00:00:00'
 });

--- a/packages/manager/src/features/Domains/DomainTableRow.tsx
+++ b/packages/manager/src/features/Domains/DomainTableRow.tsx
@@ -13,6 +13,7 @@ import Grid from 'src/components/Grid';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import ActionMenu, { Handlers } from './DomainActionMenu';
+import DateTimeDisplay from 'src/components/DateTimeDisplay';
 
 type ClassNames =
   | 'domain'
@@ -46,6 +47,7 @@ interface Props extends Handlers {
   id: number;
   status: DomainStatus;
   type: 'master' | 'slave';
+  lastModified: string;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -72,6 +74,7 @@ class DomainTableRow extends React.Component<CombinedProps> {
       id,
       type,
       status,
+      lastModified,
       onClone,
       onRemove,
       onEdit
@@ -120,6 +123,9 @@ class DomainTableRow extends React.Component<CombinedProps> {
         </TableCell>
         <TableCell parentColumn="Status" data-qa-domain-status>
           {humanizeDomainStatus(status)}
+        </TableCell>
+        <TableCell parentColumn="Last Modified" data-qa-domain-lastmodified>
+          <DateTimeDisplay value={lastModified} />
         </TableCell>
         <TableCell>
           <ActionMenu

--- a/packages/manager/src/features/Domains/ListDomains.tsx
+++ b/packages/manager/src/features/Domains/ListDomains.tsx
@@ -76,6 +76,7 @@ const ListDomains: React.StatelessComponent<CombinedProps> = props => {
                   >
                     Domain
                   </TableSortCell>
+
                   <TableSortCell
                     data-qa-domain-type-header={order}
                     active={orderBy === 'type'}
@@ -85,6 +86,7 @@ const ListDomains: React.StatelessComponent<CombinedProps> = props => {
                   >
                     Type
                   </TableSortCell>
+
                   <TableSortCell
                     data-qa-domain-type-header={order}
                     active={orderBy === 'status'}
@@ -94,6 +96,17 @@ const ListDomains: React.StatelessComponent<CombinedProps> = props => {
                   >
                     Status
                   </TableSortCell>
+
+                  <TableSortCell
+                    data-qa-domain-type-header={order}
+                    active={orderBy === 'last_modified'}
+                    label="last_modified"
+                    direction={order}
+                    handleClick={handleOrderChange}
+                  >
+                    Last Modified
+                  </TableSortCell>
+
                   <TableCell />
                 </TableRow>
               </TableHead>
@@ -127,7 +140,7 @@ interface RenderDataProps extends Handlers {
   data: Domain[];
 }
 
-const RenderData: React.StatelessComponent<RenderDataProps> = props => {
+const RenderData: React.FunctionComponent<RenderDataProps> = props => {
   const { data, onClone, onEdit, onRemove, onDisableOrEnable } = props;
 
   return (
@@ -142,6 +155,7 @@ const RenderData: React.StatelessComponent<RenderDataProps> = props => {
           onRemove={onRemove}
           type={domain.type}
           status={domain.status}
+          lastModified={domain.updated}
           onDisableOrEnable={onDisableOrEnable}
         />
       ))}

--- a/packages/manager/src/features/Domains/ListDomains.tsx
+++ b/packages/manager/src/features/Domains/ListDomains.tsx
@@ -99,8 +99,8 @@ const ListDomains: React.StatelessComponent<CombinedProps> = props => {
 
                   <TableSortCell
                     data-qa-domain-type-header={order}
-                    active={orderBy === 'last_modified'}
-                    label="last_modified"
+                    active={orderBy === 'updated'}
+                    label="updated"
                     direction={order}
                     handleClick={handleOrderChange}
                   >

--- a/packages/manager/src/features/Domains/ListGroupedDomains.tsx
+++ b/packages/manager/src/features/Domains/ListGroupedDomains.tsx
@@ -137,6 +137,7 @@ const ListGroupedDomains: React.StatelessComponent<CombinedProps> = props => {
                           onRemove={onRemove}
                           type={domain.type}
                           status={domain.status}
+                          lastModified={domain.updated}
                           onDisableOrEnable={props.onDisableOrEnable}
                         />
                       ))}

--- a/packages/manager/src/features/Domains/SortableTableHead.tsx
+++ b/packages/manager/src/features/Domains/SortableTableHead.tsx
@@ -59,6 +59,15 @@ const SortableTableHead: React.StatelessComponent<combinedProps> = props => {
         >
           Status
         </TableSortCell>
+        <TableSortCell
+          data-qa-domain-type-header={order}
+          active={orderBy === 'updated'}
+          label="updated"
+          direction={order}
+          handleClick={handleOrderChange}
+        >
+          Last Modified
+        </TableSortCell>
         <TableCell />
       </TableRow>
     </TableHead>

--- a/packages/manager/src/store/selectors/getEntitiesWithGroupsToImport.test.tsx
+++ b/packages/manager/src/store/selectors/getEntitiesWithGroupsToImport.test.tsx
@@ -71,7 +71,8 @@ describe('Entities that have groups to import', () => {
         retry_sec: 0,
         soa_email: '',
         status: 'active',
-        ttl_sec: 0
+        ttl_sec: 0,
+        updated: '2020-05-01 00:00:00'
       };
 
       const newState = {


### PR DESCRIPTION
## Description
In the Classic Manager, users were able to see a "Last Modified" date for each domain on the DNS Manager page. This information is not currently shown in Cloud.

This PR brings that information into the Domains landing page with a new "Last Modified" column.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
