### PR TITLE
Ability to disable Paginate scroll

### DIFF
--- a/packages/manager/src/components/Paginate.ts
+++ b/packages/manager/src/components/Paginate.ts
@@ -42,6 +42,7 @@ interface Props {
   pageSize?: number;
   scrollToRef?: React.RefObject<any>;
   pageSizeSetter?: (v: number) => void;
+  shouldScroll?: boolean;
 }
 
 export default class Paginate extends React.Component<Props, State> {
@@ -51,8 +52,10 @@ export default class Paginate extends React.Component<Props, State> {
   };
 
   handlePageChange = (page: number) => {
-    const { scrollToRef } = this.props;
-    scrollTo(scrollToRef);
+    if (this.props.shouldScroll ?? true) {
+      const { scrollToRef } = this.props;
+      scrollTo(scrollToRef);
+    }
     this.setState({ page });
   };
 

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -260,7 +260,7 @@ export const BillingActivityPanel: React.FC<{}> = () => {
   // many invoices. @todo: Re-think how we use the OrderBy and Paginate combo in other components.
   const billingActivityPanel = React.useCallback(
     ({ data: orderedData }) => (
-      <Paginate pageSize={25} data={orderedData}>
+      <Paginate pageSize={25} data={orderedData} shouldScroll={false}>
         {({
           data: paginatedAndOrderedData,
           count,


### PR DESCRIPTION
## Description

This adds a `shouldScroll` option/prop to the `<Paginate />` component. The context the scrolling was bothering me in is the new Billing Activity feed, so that's the only place shouldScroll=false. Prod test account 1 has multiple pages of items so you can test it there.