### PR TITLE
M3-4176 Remove HTML from version string

### DIFF
--- a/packages/manager/src/formatted-text.css
+++ b/packages/manager/src/formatted-text.css
@@ -33,7 +33,7 @@
   width: 100%;
 }
 
-.formatted-text .version {
+.formatted-text p:last-of-type {
   display: block;
   margin-top: 32px;
 }

--- a/packages/manager/src/utilities/getVersionString.test.ts
+++ b/packages/manager/src/utilities/getVersionString.test.ts
@@ -14,8 +14,7 @@ describe('Append Cloud Manager Version', () => {
 
   it('returns the version as set by .env', () => {
     process.env.VERSION = '0.00.0';
-    // We're requiring a fresh module each time so that the module picks up
-    // ENV variable changes.
+    // We're requiring a fresh module each time so that the module picks up ENV variable changes.
     const versionString = require('./getVersionString').getVersionString();
     expect(versionString.includes('0.00.0')).toBeTruthy();
   });
@@ -23,17 +22,13 @@ describe('Append Cloud Manager Version', () => {
   it('prefixes the version with "Cloud Manager Version: "', () => {
     process.env.VERSION = '0.00.0';
     const versionString = require('./getVersionString').getVersionString();
-    expect(
-      versionString.startsWith('<span class="version">Cloud Manager Version: ')
-    ).toBeTruthy();
+    expect(versionString.startsWith('Cloud Manager Version: ')).toBeTruthy();
   });
 
   it('returns the prefix concatenated with the version', () => {
     process.env.VERSION = '0.00.0';
     const versionString = require('./getVersionString').getVersionString();
-    expect(versionString).toBe(
-      '<span class="version">Cloud Manager Version: 0.00.0</span>'
-    );
+    expect(versionString).toBe('Cloud Manager Version: 0.00.0');
   });
 
   it('returns an empty string if the version env variable cannot be found', () => {

--- a/packages/manager/src/utilities/getVersionString.ts
+++ b/packages/manager/src/utilities/getVersionString.ts
@@ -1,6 +1,4 @@
 const { VERSION } = process.env;
 
 export const getVersionString = () =>
-  VERSION
-    ? `<span class="version">Cloud Manager Version: ${VERSION}</span>`
-    : '';
+  VERSION ? `Cloud Manager Version: ${VERSION}` : '';


### PR DESCRIPTION
## Description
In https://github.com/linode/manager/pull/5355, HTML was added to the version string. I believe this was done so that it could be targeted for styling.

We actually lost the styling in a recent update to the markdown conversion anyway (by not allowing classes). 

This PR removes the HTML (which was showing up in emails) and targets the last `<p>` of `.formatted-text` and applies the styling that was intended.

## Note to Reviewers

Test new and old support tickets.