### PR TITLE
M3-4180 Fix isMulti Selects 

### DIFF
--- a/packages/manager/src/components/EnhancedSelect/Select.tsx
+++ b/packages/manager/src/components/EnhancedSelect/Select.tsx
@@ -119,7 +119,7 @@ class Select extends React.PureComponent<CombinedProps, {}> {
   // always assumed in be an array.)
   //
   // This essentially reverts the behavior of the v3 React-Select update. Long term, we should
-  // probably re-write our components to except `null` as well as an array.
+  // probably re-write our component handlers to accept `null` as well as an array.
   _onChange = (selected: Item | Item[] | null) => {
     const { isMulti, onChange } = this.props;
 

--- a/packages/manager/src/components/EnhancedSelect/Select.tsx
+++ b/packages/manager/src/components/EnhancedSelect/Select.tsx
@@ -119,7 +119,7 @@ class Select extends React.PureComponent<CombinedProps, {}> {
   // always assumed in be an array.)
   //
   // This essentially reverts the behavior of the v3 React-Select update. Long term, we should
-  // probably re-write our component handlers to accept `null` as well as an array.
+  // probably re-write our component handlers to expect `null` in addition to an array.
   _onChange = (selected: Item | Item[] | null) => {
     const { isMulti, onChange } = this.props;
 

--- a/packages/manager/src/components/EnhancedSelect/Select.tsx
+++ b/packages/manager/src/components/EnhancedSelect/Select.tsx
@@ -119,7 +119,7 @@ class Select extends React.PureComponent<CombinedProps, {}> {
   // always assumed in be an array.)
   //
   // This essentially reverts the behavior of the v3 React-Select update. Long term, we should
-  // probably re-write our component handlers to expect `null` in addition to an array.
+  // probably re-write our component handlers to expect EITHER an array OR `null`.
   _onChange = (selected: Item | Item[] | null) => {
     const { isMulti, onChange } = this.props;
 

--- a/packages/manager/src/components/EnhancedSelect/Select.tsx
+++ b/packages/manager/src/components/EnhancedSelect/Select.tsx
@@ -94,7 +94,7 @@ export interface BaseSelectProps
   /** retyped this */
   value?: Item | Item[] | null;
   /** making this required */
-  onChange: (selected: Item | Item[] | null, actionMeta: ActionMeta) => void;
+  onChange: (selected: Item | Item[] | null, actionMeta?: ActionMeta) => void;
   /** alias for onCreateOption */
   createNew?: (inputValue: string) => void;
   loadOptions?: (inputValue: string) => Promise<Item | Item[]> | undefined;
@@ -113,6 +113,23 @@ export interface BaseSelectProps
 interface CreatableProps extends CreatableSelectProps<any> {}
 
 class Select extends React.PureComponent<CombinedProps, {}> {
+  // React-Select changed the behavior of clearing isMulti Selects in v3.
+  // Previously, once the Select was empty, the value was `[]`. Now, it is `null`.
+  // This breaks many of our components, which rely on e.g. mapping through the value (which is
+  // always assumed in be an array.)
+  //
+  // This essentially reverts the behavior of the v3 React-Select update. Long term, we should
+  // probably re-write our components to except `null` as well as an array.
+  _onChange = (selected: Item | Item[] | null) => {
+    const { isMulti, onChange } = this.props;
+
+    if (isMulti && !selected) {
+      return onChange([]);
+    }
+
+    onChange(selected);
+  };
+
   render() {
     const {
       classes,
@@ -219,7 +236,7 @@ class Select extends React.PureComponent<CombinedProps, {}> {
         onBlur={onBlur}
         options={options}
         components={combinedComponents}
-        onChange={onChange}
+        onChange={this._onChange}
         onInputChange={onInputChange}
         onCreateOption={createNew}
         placeholder={placeholder || 'Select a value...'}


### PR DESCRIPTION
## Description

When upgrading React-Select, we missed this: https://github.com/JedWatson/react-select/pull/3416

To reproduce the bug: 

1. Go to https://cloud.linode.com/volumes/create
2. Select a Tag
3. Click "X". 
4. Observe: the page crashes.

This PR basically reverts the change React-Select made. The other option is to rewrite the handlers of components that use `isMulti` Selects. (Maybe better in the long term but bigger lift).
