### PR TITLE
M3-4161 Fix: Safe access ref

### DIFF
--- a/packages/manager/src/components/HighlightedMarkdown/HighlightedMarkdown.tsx
+++ b/packages/manager/src/components/HighlightedMarkdown/HighlightedMarkdown.tsx
@@ -72,12 +72,10 @@ export const HighlightedMarkdown: React.FC<HighlightedMarkdownProps> = props => 
   // All the safety checking is due to a reported error from certain versions of FireFox.
   React.useEffect(() => {
     if (rootRef.current) {
-      const blocks = rootRef.current.querySelectorAll('pre code');
-      if (blocks && Array.isArray(blocks)) {
-        blocks.forEach(block => {
-          hljs.highlightBlock(block);
-        });
-      }
+      const blocks = rootRef.current.querySelectorAll('pre code') ?? [];
+      blocks.forEach(block => {
+        hljs.highlightBlock(block);
+      });
     }
   }, [textOrMarkdown]);
 

--- a/packages/manager/src/components/HighlightedMarkdown/HighlightedMarkdown.tsx
+++ b/packages/manager/src/components/HighlightedMarkdown/HighlightedMarkdown.tsx
@@ -71,13 +71,17 @@ export const HighlightedMarkdown: React.FC<HighlightedMarkdownProps> = props => 
   // Adapted from https://stackblitz.com/edit/react-highlighted-markdown?file=highlighted-markdown.tsx
   // All the safety checking is due to a reported error from certain versions of FireFox.
   React.useEffect(() => {
-    if (rootRef.current) {
-      const blocks = rootRef.current.querySelectorAll('pre code') ?? [];
-      const len = blocks.length ?? 0;
-      let i = 0;
-      for (i; i < len; i++) {
-        hljs.highlightBlock(blocks[i]);
+    try {
+      if (rootRef.current) {
+        const blocks = rootRef.current.querySelectorAll('pre code') ?? [];
+        const len = blocks.length ?? 0;
+        let i = 0;
+        for (i; i < len; i++) {
+          hljs.highlightBlock(blocks[i]);
+        }
       }
+    } catch {
+      // do nothing, it's not the end of the world if we can't highlight Markdown.
     }
   }, [textOrMarkdown]);
 

--- a/packages/manager/src/components/HighlightedMarkdown/HighlightedMarkdown.tsx
+++ b/packages/manager/src/components/HighlightedMarkdown/HighlightedMarkdown.tsx
@@ -73,9 +73,11 @@ export const HighlightedMarkdown: React.FC<HighlightedMarkdownProps> = props => 
   React.useEffect(() => {
     if (rootRef.current) {
       const blocks = rootRef.current.querySelectorAll('pre code') ?? [];
-      blocks.forEach(block => {
-        hljs.highlightBlock(block);
-      });
+      const len = blocks.length ?? 0;
+      let i = 0;
+      for (i; i < len; i++) {
+        hljs.highlightBlock(blocks[i]);
+      }
     }
   }, [textOrMarkdown]);
 

--- a/packages/manager/src/components/HighlightedMarkdown/HighlightedMarkdown.tsx
+++ b/packages/manager/src/components/HighlightedMarkdown/HighlightedMarkdown.tsx
@@ -69,10 +69,16 @@ export const HighlightedMarkdown: React.FC<HighlightedMarkdownProps> = props => 
   const sanitizedHtml = sanitizeHTML(html);
 
   // Adapted from https://stackblitz.com/edit/react-highlighted-markdown?file=highlighted-markdown.tsx
+  // All the safety checking is due to a reported error from certain versions of FireFox.
   React.useEffect(() => {
-    rootRef.current?.querySelectorAll('pre code').forEach(block => {
-      hljs.highlightBlock(block);
-    });
+    if (rootRef.current) {
+      const blocks = rootRef.current.querySelectorAll('pre code');
+      if (blocks && Array.isArray(blocks)) {
+        blocks.forEach(block => {
+          hljs.highlightBlock(block);
+        });
+      }
+    }
   }, [textOrMarkdown]);
 
   return (


### PR DESCRIPTION
## Description
This is another one of those bugs that we haven't been able to reproduce (this one was reported by a single user on an older version of Firefox). We know the line of code that was causing the crash, and I've updated it to be as safe as I can make it.

Please check that syntax highlighting still works (in Support tickets and LKE kubeconfig view).