### PR TITLE
M3-3964 Part 1: Refactor PrimaryNav as FC

### DIFF
--- a/packages/manager/src/components/PrimaryNav/NavItem.tsx
+++ b/packages/manager/src/components/PrimaryNav/NavItem.tsx
@@ -46,8 +46,8 @@ const NavItem: React.SFC<CombinedProps> = props => {
   }
 
   return (
-    /* 
-     href takes priority here. So if an href and onClick 
+    /*
+     href takes priority here. So if an href and onClick
      are provided, the onClick will not be applied
     */
     <React.Fragment>
@@ -58,7 +58,7 @@ const NavItem: React.SFC<CombinedProps> = props => {
           data-qa-nav-item={QAKey}
           className={classNames({
             [linkClasses(href)]: true,
-            listItemCollpased: isCollapsed
+            listItemCollapsed: isCollapsed
           })}
         >
           {icon && isCollapsed && <div className="icon">{icon}</div>}
@@ -73,26 +73,24 @@ const NavItem: React.SFC<CombinedProps> = props => {
           />
         </Link>
       ) : (
-        <React.Fragment>
-          <Tooltip title={isDisabled ? isDisabled() : ''} placement="left-end">
-            <ListItem
-              onClick={e => {
-                props.closeMenu();
-                /* disregarding undefined is fine here because of the error handling thrown above */
-                onClick!();
-              }}
-              disabled={!!isDisabled ? !!isDisabled() : false}
-              data-qa-nav-item={QAKey}
-              className={linkClasses()}
-            >
-              <ListItemText
-                primary={display}
-                disableTypography={true}
-                className={listItemClasses}
-              />
-            </ListItem>
-          </Tooltip>
-        </React.Fragment>
+        <Tooltip title={isDisabled ? isDisabled() : ''} placement="left-end">
+          <ListItem
+            onClick={e => {
+              props.closeMenu();
+              /* disregarding undefined is fine here because of the error handling thrown above */
+              onClick!();
+            }}
+            disabled={!!isDisabled ? !!isDisabled() : false}
+            data-qa-nav-item={QAKey}
+            className={linkClasses()}
+          >
+            <ListItemText
+              primary={display}
+              disableTypography={true}
+              className={listItemClasses}
+            />
+          </ListItem>
+        </Tooltip>
       )}
       <Divider className={props.dividerClasses} />
     </React.Fragment>

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.styles.ts
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.styles.ts
@@ -1,250 +1,216 @@
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles,
-  WithTheme
-} from 'src/components/core/styles';
+import { makeStyles, Theme } from 'src/components/core/styles';
 
-export type ClassNames =
-  | 'menuGrid'
-  | 'fadeContainer'
-  | 'logoItem'
-  | 'logoCollapsed'
-  | 'logoItemCompact'
-  | 'listItem'
-  | 'collapsible'
-  | 'linkItem'
-  | 'active'
-  | 'activeLink'
-  | 'sublink'
-  | 'sublinkActive'
-  | 'arrow'
-  | 'sublinkPanel'
-  | 'spacer'
-  | 'listItemAccount'
-  | 'divider'
-  | 'menu'
-  | 'paper'
-  | 'settings'
-  | 'settingsCollapsed'
-  | 'activeSettings'
-  | 'settingsBackdrop';
-
-export type StyleProps = WithStyles<ClassNames> & WithTheme;
-
-const styles = (theme: Theme) =>
-  createStyles({
-    menuGrid: {
-      minHeight: 64,
-      width: '100%',
-      height: '100%',
-      margin: 0,
-      padding: 0,
-      [theme.breakpoints.up('sm')]: {
-        minHeight: 72
-      },
-      [theme.breakpoints.up('md')]: {
-        minHeight: 80
-      }
+const useStyles = makeStyles((theme: Theme) => ({
+  menuGrid: {
+    minHeight: 64,
+    width: '100%',
+    height: '100%',
+    margin: 0,
+    padding: 0,
+    [theme.breakpoints.up('sm')]: {
+      minHeight: 72
     },
-    fadeContainer: {
-      width: '100%',
-      height: 'calc(100% - 90px)',
-      display: 'flex',
-      flexDirection: 'column'
-    },
-    logoItem: {
-      minHeight: 64,
-      position: 'relative',
-      display: 'flex',
-      alignItems: 'center',
-      padding: `
+    [theme.breakpoints.up('md')]: {
+      minHeight: 80
+    }
+  },
+  fadeContainer: {
+    width: '100%',
+    height: 'calc(100% - 90px)',
+    display: 'flex',
+    flexDirection: 'column'
+  },
+  logoItem: {
+    minHeight: 64,
+    position: 'relative',
+    display: 'flex',
+    alignItems: 'center',
+    padding: `
         ${theme.spacing(2) - 2}px
         0
         ${theme.spacing(1) + theme.spacing(1) / 2}px
         ${theme.spacing(4)}px
       `,
-      '& svg': {
-        maxWidth: theme.spacing(3) + 91
-      }
-    },
-    logoCollapsed: {
-      '& .logoLetters': {
-        opacity: 0
-      }
-    },
-    listItem: {
-      display: 'flex',
-      alignItems: 'center',
-      position: 'relative',
-      cursor: 'pointer',
-      maxHeight: 42,
-      transition: theme.transitions.create(['background-color']),
-      padding: `
+    '& svg': {
+      maxWidth: theme.spacing(3) + 91
+    }
+  },
+  logoCollapsed: {
+    '& .logoLetters': {
+      opacity: 0
+    }
+  },
+  listItem: {
+    display: 'flex',
+    alignItems: 'center',
+    position: 'relative',
+    cursor: 'pointer',
+    maxHeight: 42,
+    transition: theme.transitions.create(['background-color']),
+    padding: `
         ${theme.spacing(1.5)}px
         ${theme.spacing(4) - 2}px
         ${theme.spacing(1.5) - 1}px
         ${theme.spacing(4) + 1}px
       `,
-      '&:hover': {
-        backgroundColor: theme.bg.primaryNavActiveBG,
-        '& $linkItem': {
-          color: 'white'
-        },
-        '& svg': {
-          fill: 'white',
-          '& *': {
-            stroke: 'white'
-          }
-        }
-      },
-      '& .icon': {
-        marginRight: theme.spacing(2),
-        '& svg': {
-          width: 26,
-          height: 26,
-          transform: 'scale(1.75)',
-          fill: theme.color.primaryNavText,
-          transition: theme.transitions.create(['fill']),
-          '&.small': {
-            transform: 'scale(1)'
-          },
-          '&:not(.wBorder) circle, & .circle': {
-            display: 'none'
-          },
-          '& *': {
-            transition: theme.transitions.create(['stroke']),
-            stroke: theme.color.primaryNavText
-          }
-        }
-      }
-    },
-    listItemCollpased: {},
-    collapsible: {
-      fontSize: '0.9rem'
-    },
-    linkItem: {
-      transition: theme.transitions.create(['color']),
-      color: theme.color.primaryNavText,
-      opacity: 1,
-      whiteSpace: 'nowrap',
-      fontFamily: 'LatoWebBold', // we keep this bold at all times
-      '&.hiddenWhenCollapsed': {
-        opacity: 0
-      }
-    },
-    active: {
+    '&:hover': {
       backgroundColor: theme.bg.primaryNavActiveBG,
-      '&:before': {
-        content: "''",
-        borderStyle: 'solid',
-        borderWidth: `
+      '& $linkItem': {
+        color: 'white'
+      },
+      '& svg': {
+        fill: 'white',
+        '& *': {
+          stroke: 'white'
+        }
+      }
+    },
+    '& .icon': {
+      marginRight: theme.spacing(2),
+      '& svg': {
+        width: 26,
+        height: 26,
+        transform: 'scale(1.75)',
+        fill: theme.color.primaryNavText,
+        transition: theme.transitions.create(['fill']),
+        '&.small': {
+          transform: 'scale(1)'
+        },
+        '&:not(.wBorder) circle, & .circle': {
+          display: 'none'
+        },
+        '& *': {
+          transition: theme.transitions.create(['stroke']),
+          stroke: theme.color.primaryNavText
+        }
+      }
+    }
+  },
+  listItemCollpased: {},
+  collapsible: {
+    fontSize: '0.9rem'
+  },
+  linkItem: {
+    transition: theme.transitions.create(['color']),
+    color: theme.color.primaryNavText,
+    opacity: 1,
+    whiteSpace: 'nowrap',
+    fontFamily: 'LatoWebBold', // we keep this bold at all times
+    '&.hiddenWhenCollapsed': {
+      opacity: 0
+    }
+  },
+  active: {
+    backgroundColor: theme.bg.primaryNavActiveBG,
+    '&:before': {
+      content: "''",
+      borderStyle: 'solid',
+      borderWidth: `
           ${theme.spacing(1) + 11}px
-          ${theme.spacing(1) + 6}px 
-          ${theme.spacing(1) + 11}px 
+          ${theme.spacing(1) + 6}px
+          ${theme.spacing(1) + 11}px
           0
         `,
-        borderColor: `transparent ${theme.bg.primaryNavActive} transparent transparent`,
-        position: 'absolute',
-        right: 0,
-        top: theme.spacing(1) === 8 ? 2 : 0
-      },
-      '&:hover': {
-        '&:before': {
-          content: "''",
-          borderColor: `transparent ${theme.bg.primaryNavActive} transparent transparent`
-        }
-      },
-      [theme.breakpoints.down('sm')]: {
-        '&:before': {
-          display: 'none'
-        }
-      },
-      '&.listItemCollpased': {
-        '&:before': {
-          top: theme.spacing(1) === 8 ? 2 : 4
-        }
+      borderColor: `transparent ${theme.bg.primaryNavActive} transparent transparent`,
+      position: 'absolute',
+      right: 0,
+      top: theme.spacing(1) === 8 ? 2 : 0
+    },
+    '&:hover': {
+      '&:before': {
+        content: "''",
+        borderColor: `transparent ${theme.bg.primaryNavActive} transparent transparent`
       }
     },
-    sublinkPanel: {
-      paddingLeft: theme.spacing(6),
-      paddingRight: theme.spacing(2),
-      fontSize: '.9rem',
-      flexShrink: 0,
-      listStyleType: 'none'
-    },
-    sublink: {
-      padding: `${theme.spacing(1) / 2}px 0 ${theme.spacing(1) /
-        2}px ${theme.spacing(1)}px`,
-      color: 'white',
-      display: 'block',
-      fontSize: '.8rem',
-      '&:hover, &:focus': {
-        textDecoration: 'underline',
-        outline: 0
+    [theme.breakpoints.down('sm')]: {
+      '&:before': {
+        display: 'none'
       }
     },
-    activeLink: {
-      color: 'white',
-      '& $arrow': {
-        transform: 'rotate(90deg)'
+    '&.listItemCollpased': {
+      '&:before': {
+        top: theme.spacing(1) === 8 ? 2 : 4
       }
-    },
-    sublinkActive: {
-      textDecoration: 'underline'
-    },
-    arrow: {
-      position: 'relative',
-      top: 4,
-      fontSize: '1.2rem',
-      margin: '0 4px 0 -7px',
+    }
+  },
+  sublinkPanel: {
+    paddingLeft: theme.spacing(6),
+    paddingRight: theme.spacing(2),
+    fontSize: '.9rem',
+    flexShrink: 0,
+    listStyleType: 'none'
+  },
+  sublink: {
+    padding: `${theme.spacing(1) / 2}px 0 ${theme.spacing(1) /
+      2}px ${theme.spacing(1)}px`,
+    color: 'white',
+    display: 'block',
+    fontSize: '.8rem',
+    '&:hover, &:focus': {
+      textDecoration: 'underline',
+      outline: 0
+    }
+  },
+  activeLink: {
+    color: 'white',
+    '& $arrow': {
+      transform: 'rotate(90deg)'
+    }
+  },
+  sublinkActive: {
+    textDecoration: 'underline'
+  },
+  arrow: {
+    position: 'relative',
+    top: 4,
+    fontSize: '1.2rem',
+    margin: '0 4px 0 -7px',
+    transition: theme.transitions.create(['transform'])
+  },
+  spacer: {
+    padding: 25
+  },
+  divider: {
+    backgroundColor: 'rgba(0, 0, 0, 0.12)'
+  },
+  settings: {
+    width: 30,
+    margin: `auto auto 16px`,
+    alignItems: 'center',
+    justifyContent: 'center',
+    display: 'flex',
+    color: '#e7e7e7',
+    transition: theme.transitions.create(['color']),
+    '& svg': {
       transition: theme.transitions.create(['transform'])
     },
-    spacer: {
-      padding: 25
-    },
-    divider: {
-      backgroundColor: 'rgba(0, 0, 0, 0.12)'
-    },
-    settings: {
-      width: 30,
-      margin: `auto auto 16px`,
-      alignItems: 'center',
-      justifyContent: 'center',
-      display: 'flex',
-      color: '#e7e7e7',
-      transition: theme.transitions.create(['color']),
-      '& svg': {
-        transition: theme.transitions.create(['transform'])
-      },
-      '&:hover': {
-        color: theme.color.green
-      }
-    },
-    settingsCollapsed: {
-      margin: `auto 16px 16px ${theme.spacing(4) - 1}px`
-    },
-    activeSettings: {
-      color: theme.color.green,
-      '& svg': {
-        transform: 'rotate(90deg)'
-      }
-    },
-    menu: {},
-    paper: {
-      maxWidth: 350,
-      padding: 8,
-      position: 'absolute',
-      backgroundColor: theme.bg.navy,
-      border: '1px solid #999',
-      outline: 0,
-      boxShadow: 'none',
-      minWidth: 185
-    },
-    settingsBackdrop: {
-      backgroundColor: 'rgba(0,0,0,.3)'
+    '&:hover': {
+      color: theme.color.green
     }
-  });
+  },
+  settingsCollapsed: {
+    margin: `auto 16px 16px ${theme.spacing(4) - 1}px`
+  },
+  activeSettings: {
+    color: theme.color.green,
+    '& svg': {
+      transform: 'rotate(90deg)'
+    }
+  },
+  menu: {},
+  paper: {
+    maxWidth: 350,
+    padding: 8,
+    position: 'absolute',
+    backgroundColor: theme.bg.navy,
+    border: '1px solid #999',
+    outline: 0,
+    boxShadow: 'none',
+    minWidth: 185
+  },
+  settingsBackdrop: {
+    backgroundColor: 'rgba(0,0,0,.3)'
+  }
+}));
 
-export default withStyles(styles, { withTheme: true });
+export default useStyles;

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.styles.ts
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.styles.ts
@@ -86,7 +86,7 @@ const useStyles = makeStyles((theme: Theme) => ({
       }
     }
   },
-  listItemCollpased: {},
+  listItemCollapsed: {},
   collapsible: {
     fontSize: '0.9rem'
   },
@@ -127,45 +127,11 @@ const useStyles = makeStyles((theme: Theme) => ({
         display: 'none'
       }
     },
-    '&.listItemCollpased': {
+    '&.listItemCollapsed': {
       '&:before': {
         top: theme.spacing(1) === 8 ? 2 : 4
       }
     }
-  },
-  sublinkPanel: {
-    paddingLeft: theme.spacing(6),
-    paddingRight: theme.spacing(2),
-    fontSize: '.9rem',
-    flexShrink: 0,
-    listStyleType: 'none'
-  },
-  sublink: {
-    padding: `${theme.spacing(1) / 2}px 0 ${theme.spacing(1) /
-      2}px ${theme.spacing(1)}px`,
-    color: 'white',
-    display: 'block',
-    fontSize: '.8rem',
-    '&:hover, &:focus': {
-      textDecoration: 'underline',
-      outline: 0
-    }
-  },
-  activeLink: {
-    color: 'white',
-    '& $arrow': {
-      transform: 'rotate(90deg)'
-    }
-  },
-  sublinkActive: {
-    textDecoration: 'underline'
-  },
-  arrow: {
-    position: 'relative',
-    top: 4,
-    fontSize: '1.2rem',
-    margin: '0 4px 0 -7px',
-    transition: theme.transitions.create(['transform'])
   },
   spacer: {
     padding: 25

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.test.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.test.tsx
@@ -1,203 +1,94 @@
-import { shallow, ShallowWrapper } from 'enzyme';
+import { cleanup } from '@testing-library/react';
 import * as React from 'react';
-import ldClient from 'src/__data__/ldClient';
-import { reactRouterProps } from 'src/__data__/reactRouterProps';
-import { light } from 'src/themes';
-import { PrimaryNav } from './PrimaryNav';
-import { ClassNames } from './PrimaryNav.styles';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+import PrimaryNav, { Props } from './PrimaryNav';
+import useFlags from 'src/hooks/useFlags';
 
-const findLinkIn = (w: ShallowWrapper) => (s: string) => {
-  return w.find(`[data-qa-nav-item="${s}"]`);
-};
-const mockClasses: Record<ClassNames, string> = {
-  active: '',
-  activeLink: '',
-  arrow: '',
-  collapsible: '',
-  divider: '',
-  fadeContainer: '',
-  linkItem: '',
-  listItem: '',
-  listItemAccount: '',
-  logoItem: '',
-  logoCollapsed: '',
-  logoItemCompact: '',
-  menuGrid: '',
-  spacer: '',
-  sublink: '',
-  sublinkActive: '',
-  sublinkPanel: '',
-  settings: '',
-  settingsCollapsed: '',
-  settingsBackdrop: '',
-  activeSettings: '',
-  menu: '',
-  paper: ''
+afterEach(cleanup);
+
+jest.mock('src/hooks/useFlags', () => ({
+  default: jest.fn().mockReturnValue({})
+}));
+
+const mockCloseMenu = jest.fn();
+const mockToggleSpacing = jest.fn();
+const mockToggleTheme = jest.fn();
+
+const props: Props = {
+  closeMenu: mockCloseMenu,
+  isCollapsed: false,
+  toggleSpacing: mockToggleSpacing,
+  toggleTheme: mockToggleTheme
 };
 
 describe('PrimaryNav', () => {
-  describe('default', () => {
-    let wrapper;
-    let findLinkInPrimaryNav: Function;
-
-    beforeAll(() => {
-      wrapper = shallow(
-        <PrimaryNav
-          classes={mockClasses}
-          theme={light(4)}
-          toggleSpacing={jest.fn()}
-          closeMenu={jest.fn()}
-          flags={{}}
-          ldClient={ldClient}
-          toggleTheme={jest.fn()}
-          hasAccountAccess={false}
-          accountCapabilities={[]}
-          accountLastUpdated={0}
-          isManagedAccount={true}
-          isCollapsed={false}
-          {...reactRouterProps}
-        />
-      );
-
-      findLinkInPrimaryNav = findLinkIn(wrapper);
-    });
-
-    it('should have a dashboard link', () => {
-      expect(findLinkInPrimaryNav('dashboard')).toHaveLength(1);
-    });
-
-    it('should have a linodes link', () => {
-      expect(findLinkInPrimaryNav('linodes')).toHaveLength(1);
-    });
-
-    it('should have a volumes link', () => {
-      expect(findLinkInPrimaryNav('volumes')).toHaveLength(1);
-    });
-
-    it('should have a nodebalancers link', () => {
-      expect(findLinkInPrimaryNav('nodebalancers')).toHaveLength(1);
-    });
-
-    it('should have a domains link', () => {
-      expect(findLinkInPrimaryNav('domains')).toHaveLength(1);
-    });
-
-    it('should have a longview link', () => {
-      expect(findLinkInPrimaryNav('longview')).toHaveLength(1);
-    });
-
-    it('should have a stackscripts link', () => {
-      expect(findLinkInPrimaryNav('stackscripts')).toHaveLength(1);
-    });
-
-    it('should have an images link', () => {
-      expect(findLinkInPrimaryNav('images')).toHaveLength(1);
-    });
-
-    it('should not have a account link', () => {
-      expect(findLinkInPrimaryNav('account')).toHaveLength(0);
-    });
-
-    it('should have a managed link', () => {
-      expect(findLinkInPrimaryNav('managed')).toHaveLength(1);
+  it('includes all unhidden links', () => {
+    const { getByText } = renderWithTheme(<PrimaryNav {...props} />);
+    [
+      'Dashboard',
+      'Linodes',
+      'Volumes',
+      'Object Storage',
+      'NodeBalancers',
+      'Domains',
+      'Marketplace',
+      'Longview',
+      'Kubernetes',
+      'StackScripts',
+      'Images',
+      'Get Help'
+    ].forEach(link => {
+      getByText(link);
     });
   });
 
-  describe('when user has account access', () => {
-    let wrapper;
-    let findLinkInPrimaryNav: Function;
+  it('includes "Firewalls" link only when flag is on', () => {
+    const { findByText } = renderWithTheme(<PrimaryNav {...props} />);
 
-    beforeAll(() => {
-      wrapper = shallow(
-        <PrimaryNav
-          classes={mockClasses}
-          theme={light(4)}
-          toggleSpacing={jest.fn()}
-          closeMenu={jest.fn()}
-          flags={{}}
-          ldClient={ldClient}
-          toggleTheme={jest.fn()}
-          hasAccountAccess={true}
-          accountCapabilities={[]}
-          accountLastUpdated={0}
-          isManagedAccount={true}
-          isCollapsed={false}
-          {...reactRouterProps}
-        />
-      );
+    expect(findByText('Firewalls')).not.toBeInTheDocument;
 
-      findLinkInPrimaryNav = findLinkIn(wrapper);
+    (useFlags as any).mockReturnValue({
+      firewalls: true
     });
 
-    it('should have a account link', () => {
-      expect(findLinkInPrimaryNav('account')).toHaveLength(1);
-    });
+    const { getByText } = renderWithTheme(<PrimaryNav {...props} />);
+    getByText('Firewalls');
   });
 
-  describe('when account is managed', () => {
-    let wrapper;
-    let findLinkInPrimaryNav: Function;
+  it('includes "Managed" link only when the account is Managed', () => {
+    const { findByText } = renderWithTheme(<PrimaryNav {...props} />);
 
-    beforeAll(() => {
-      wrapper = shallow(
-        <PrimaryNav
-          classes={mockClasses}
-          theme={light(4)}
-          toggleSpacing={jest.fn()}
-          closeMenu={jest.fn()}
-          flags={{}}
-          ldClient={ldClient}
-          toggleTheme={jest.fn()}
-          hasAccountAccess={false}
-          accountCapabilities={[]}
-          accountLastUpdated={0}
-          isManagedAccount={true}
-          isCollapsed={false}
-          {...reactRouterProps}
-        />
-      );
+    expect(findByText('Managed')).not.toBeInTheDocument;
 
-      findLinkInPrimaryNav = findLinkIn(wrapper);
+    const { getByText } = renderWithTheme(<PrimaryNav {...props} />, {
+      customStore: {
+        __resources: {
+          accountSettings: {
+            data: { managed: true } as any
+          }
+        }
+      }
     });
-
-    it('should have a managed link', () => {
-      expect(findLinkInPrimaryNav('managed')).toHaveLength(1);
-    });
+    getByText('Managed');
   });
 
-  describe('when customer has OBJ access', () => {
-    let wrapper;
-    let findLinkInPrimaryNav: Function;
+  it('includes "Account" link only when the user has account access', () => {
+    const { findByText } = renderWithTheme(<PrimaryNav {...props} />);
 
-    beforeAll(() => {
-      wrapper = shallow(
-        <PrimaryNav
-          classes={mockClasses}
-          theme={light(4)}
-          toggleSpacing={jest.fn()}
-          closeMenu={jest.fn()}
-          flags={{}}
-          ldClient={ldClient}
-          toggleTheme={jest.fn()}
-          hasAccountAccess={false}
-          accountCapabilities={[
-            'Linodes',
-            'NodeBalancers',
-            'Block Storage',
-            'Object Storage'
-          ]}
-          accountLastUpdated={0}
-          isManagedAccount={true}
-          isCollapsed={false}
-          {...reactRouterProps}
-        />
-      );
+    expect(findByText('Account')).not.toBeInTheDocument;
 
-      findLinkInPrimaryNav = findLinkIn(wrapper);
+    const { getByText } = renderWithTheme(<PrimaryNav {...props} />, {
+      customStore: {
+        __resources: {
+          profile: {
+            data: { restricted: false } as any
+          },
+          account: {
+            lastUpdated: 1
+          }
+        }
+      }
     });
-
-    it('should have an object storage link', () => {
-      expect(findLinkInPrimaryNav('object-storage')).toHaveLength(1);
-    });
+    getByText('Account');
   });
 });

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.test.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.test.tsx
@@ -1,6 +1,6 @@
-import { cleanup } from '@testing-library/react';
+import { cleanup, render } from '@testing-library/react';
 import * as React from 'react';
-import { renderWithTheme } from 'src/utilities/testHelpers';
+import { renderWithTheme, wrapWithTheme } from 'src/utilities/testHelpers';
 import PrimaryNav, { Props } from './PrimaryNav';
 import useFlags from 'src/hooks/useFlags';
 
@@ -56,39 +56,49 @@ describe('PrimaryNav', () => {
   });
 
   it('includes "Managed" link only when the account is Managed', () => {
-    const { findByText } = renderWithTheme(<PrimaryNav {...props} />);
+    const { findByText, rerender, getByText } = render(
+      wrapWithTheme(<PrimaryNav {...props} />)
+    );
 
     expect(findByText('Managed')).not.toBeInTheDocument;
 
-    const { getByText } = renderWithTheme(<PrimaryNav {...props} />, {
-      customStore: {
-        __resources: {
-          accountSettings: {
-            data: { managed: true } as any
+    rerender(
+      wrapWithTheme(<PrimaryNav {...props} />, {
+        customStore: {
+          __resources: {
+            accountSettings: {
+              data: { managed: true } as any
+            }
           }
         }
-      }
-    });
+      })
+    );
+
     getByText('Managed');
   });
 
   it('includes "Account" link only when the user has account access', () => {
-    const { findByText } = renderWithTheme(<PrimaryNav {...props} />);
+    const { findByText, getByText, rerender } = render(
+      wrapWithTheme(<PrimaryNav {...props} />)
+    );
 
     expect(findByText('Account')).not.toBeInTheDocument;
 
-    const { getByText } = renderWithTheme(<PrimaryNav {...props} />, {
-      customStore: {
-        __resources: {
-          profile: {
-            data: { restricted: false } as any
-          },
-          account: {
-            lastUpdated: 1
+    rerender(
+      wrapWithTheme(<PrimaryNav {...props} />, {
+        customStore: {
+          __resources: {
+            profile: {
+              data: { restricted: false } as any
+            },
+            account: {
+              lastUpdated: 1
+            }
           }
         }
-      }
-    });
+      })
+    );
+
     getByText('Account');
   });
 });

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -1,30 +1,7 @@
 import Settings from '@material-ui/icons/Settings';
 import * as classNames from 'classnames';
-import { AccountCapability } from 'linode-js-sdk/lib/account';
-import { Profile } from 'linode-js-sdk/lib/profile';
-import { clone, pathOr } from 'ramda';
 import * as React from 'react';
-import { connect } from 'react-redux';
-import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
-import { compose } from 'recompose';
-import Logo from 'src/assets/logo/new-logo.svg';
-import Divider from 'src/components/core/Divider';
-import Grid from 'src/components/core/Grid';
-import Hidden from 'src/components/core/Hidden';
-import IconButton from 'src/components/core/IconButton';
-import ListItemText from 'src/components/core/ListItemText';
-import Menu from 'src/components/core/Menu';
-import withFeatureFlagConsumer, {
-  FeatureFlagConsumerProps
-} from 'src/containers/withFeatureFlagConsumer.container';
-import { MapState } from 'src/store/types';
-import { sendOneClickNavigationEvent } from 'src/utilities/ga';
-import AdditionalMenuItems from './AdditionalMenuItems';
-import styled, { StyleProps } from './PrimaryNav.styles';
-import SpacingToggle from './SpacingToggle';
-import ThemeToggle from './ThemeToggle';
-import { linkIsActive } from './utils';
-
+import { Link } from 'react-router-dom';
 import Kubernetes from 'src/assets/addnewmenu/kubernetes.svg';
 import OCA from 'src/assets/addnewmenu/oneclick.svg';
 import Account from 'src/assets/icons/account.svg';
@@ -39,6 +16,22 @@ import StackScript from 'src/assets/icons/entityIcons/stackscript.svg';
 import Volume from 'src/assets/icons/entityIcons/volume.svg';
 import Longview from 'src/assets/icons/longview.svg';
 import Managed from 'src/assets/icons/managednav.svg';
+import Logo from 'src/assets/logo/new-logo.svg';
+import Divider from 'src/components/core/Divider';
+import Grid from 'src/components/core/Grid';
+import Hidden from 'src/components/core/Hidden';
+import IconButton from 'src/components/core/IconButton';
+import ListItemText from 'src/components/core/ListItemText';
+import Menu from 'src/components/core/Menu';
+import useAccountManagement from 'src/hooks/useAccountManagement';
+import useFlags from 'src/hooks/useFlags';
+import { sendOneClickNavigationEvent } from 'src/utilities/ga';
+import AdditionalMenuItems from './AdditionalMenuItems';
+import useStyles from './PrimaryNav.styles';
+import SpacingToggle from './SpacingToggle';
+import ThemeToggle from './ThemeToggle';
+import { linkIsActive } from './utils';
+import { useLocation } from 'react-router-dom';
 
 type NavEntity =
   | 'Linodes'
@@ -59,164 +52,81 @@ type NavEntity =
 interface PrimaryLink {
   display: NavEntity;
   href: string;
-  key: string;
   attr?: { [key: string]: any };
   icon?: JSX.Element;
   activeLinks?: Array<string>;
   onClick?: (e: React.ChangeEvent<any>) => void;
+  hide?: boolean;
 }
 
-interface Props {
+export interface Props {
   closeMenu: () => void;
   toggleTheme: () => void;
   toggleSpacing: () => void;
   isCollapsed: boolean;
 }
 
-interface State {
-  drawerOpen: boolean;
-  expandedMenus: Record<string, boolean>;
-  primaryLinks: PrimaryLink[];
-  anchorEl?: HTMLElement;
-}
+export const PrimaryNav: React.FC<Props> = props => {
+  const { closeMenu, isCollapsed, toggleTheme, toggleSpacing } = props;
+  const classes = useStyles();
 
-interface MenuItemReducer {
-  link: PrimaryLink;
-  insertAfter: NavEntity;
-  conditionToAdd: () => boolean;
-}
+  const [anchorEl, setAnchorEl] = React.useState<
+    (EventTarget & HTMLElement) | undefined
+  >();
 
-export type CombinedProps = Props &
-  StyleProps &
-  StateProps &
-  FeatureFlagConsumerProps &
-  FeatureFlagConsumerProps &
-  RouteComponentProps<{}>;
+  const flags = useFlags();
+  const location = useLocation();
 
-export class PrimaryNav extends React.Component<CombinedProps, State> {
-  state: State = {
-    drawerOpen: false,
-    expandedMenus: {
-      account: false,
-      support: false
-    },
-    primaryLinks: [],
-    anchorEl: undefined
-  };
+  const {
+    _hasAccountAccess,
+    _isManagedAccount,
+    account
+  } = useAccountManagement();
 
-  mounted: boolean = false;
-
-  componentDidMount() {
-    this.mounted = true;
-    this.createMenuItems();
-  }
-
-  componentWillUnmount() {
-    this.mounted = false;
-  }
-
-  componentDidUpdate(prevProps: CombinedProps) {
-    // Re-create menu items if account access has changed (via profile), or if account
-    // has been updated. If account has been updated (i.e. when it actually loads)
-    // there maybe be additional menu items we want to display, depending on
-    // `account.capabilities`.
-    if (
-      prevProps.hasAccountAccess !== this.props.hasAccountAccess ||
-      prevProps.accountLastUpdated !== this.props.accountLastUpdated ||
-      prevProps.isManagedAccount !== this.props.isManagedAccount ||
-      prevProps.accountLastUpdated !== this.props.accountLastUpdated ||
-      prevProps.flags !== this.props.flags
-    ) {
-      this.createMenuItems();
-    }
-  }
-
-  primaryNavManipulator = (): MenuItemReducer[] => {
-    const { hasAccountAccess, isManagedAccount, flags } = this.props;
-
-    return [
-      {
-        conditionToAdd: () => isManagedAccount,
-        insertAfter: 'Kubernetes',
-        link: {
-          display: 'Managed',
-          href: '/managed',
-          key: 'managed',
-          icon: <Managed />
-        }
-      },
-      {
-        conditionToAdd: () => hasAccountAccess,
-        insertAfter: 'Images',
-        link: {
-          display: 'Account',
-          href: '/account/billing',
-          key: 'account',
-          icon: <Account className="small" />,
-          activeLinks: [
-            '/account/billing',
-            '/account/users',
-            '/account/settings'
-          ]
-        }
-      },
-      {
-        conditionToAdd: () => !!flags.firewalls,
-        insertAfter: 'Domains',
-        link: {
-          display: 'Firewalls',
-          href: '/firewalls',
-          key: 'firewalls',
-          icon: <Firewall />
-        }
-      }
-    ];
-  };
-
-  createMenuItems = () => {
-    const primaryLinks: PrimaryLink[] = [
+  const primaryLinks: PrimaryLink[] = React.useMemo(
+    () => [
       {
         display: 'Dashboard',
         href: '/dashboard',
-        key: 'dashboard',
         icon: <Dashboard className="small" />
       },
       {
         display: 'Linodes',
         href: '/linodes',
         activeLinks: ['/linodes', '/linodes/create'],
-        key: 'linodes',
         icon: <Linode />
       },
       {
         display: 'Volumes',
         href: '/volumes',
-        key: 'volumes',
         icon: <Volume />
       },
       {
         display: 'Object Storage',
         href: '/object-storage/buckets',
         activeLinks: ['/object-storage/buckets', '/object-storage/access-keys'],
-        key: 'object-storage',
         icon: <Storage />
       },
       {
         display: 'NodeBalancers',
         href: '/nodebalancers',
-        key: 'nodebalancers',
         icon: <NodeBalancer />
       },
       {
         display: 'Domains',
         href: '/domains',
-        key: 'domains',
         icon: <Domain style={{ transform: 'scale(1.5)' }} />
+      },
+
+      {
+        hide: !flags.firewalls,
+        display: 'Firewalls',
+        href: '/firewalls',
+        icon: <Firewall />
       },
       {
         display: 'Marketplace',
         href: '/linodes/create?type=One-Click',
-        key: 'one-click',
         attr: { 'data-qa-one-click-nav-btn': true },
         icon: <OCA />,
         onClick: () => {
@@ -226,314 +136,239 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
       {
         display: 'Longview',
         href: '/longview',
-        key: 'longview',
         icon: <Longview className="small" />
       },
       {
         display: 'Kubernetes',
         href: '/kubernetes/clusters',
-        key: 'kubernetes',
         icon: <Kubernetes />
+      },
+      {
+        hide: !_isManagedAccount,
+        display: 'Managed',
+        href: '/managed',
+        icon: <Managed />
       },
       {
         display: 'StackScripts',
         href: '/stackscripts?type=account',
-        key: 'stackscripts',
         icon: <StackScript />
       },
       {
         display: 'Images',
         href: '/images',
-        key: 'images',
         icon: <Image className="small" />
-      }
-    ];
-
-    const potentialMenuItemsToAdd = this.primaryNavManipulator();
-
-    const finalMenuItems: PrimaryLink[] = potentialMenuItemsToAdd.reduce(
-      (acc, eachItem) => {
-        const indexOfFoundNavItem = acc.findIndex(
-          eachNavItem => eachNavItem.display === eachItem.insertAfter
-        );
-
-        /**
-         * if our passed boolean condition evaluates true,
-         * add it to the list of primary nav items.
-         */
-        if (eachItem.conditionToAdd()) {
-          acc.splice(indexOfFoundNavItem + 1, 0, eachItem.link);
-        }
-
-        return acc;
       },
-      clone(primaryLinks)
-    );
+      {
+        hide: account.lastUpdated === 0 || !_hasAccountAccess,
+        display: 'Account',
+        href: '/account/billing',
+        icon: <Account className="small" />,
+        activeLinks: ['/account/billing', '/account/users', '/account/settings']
+      }
+    ],
+    [flags.firewalls, _isManagedAccount, account.lastUpdated, _hasAccountAccess]
+  );
 
-    this.setState({ primaryLinks: finalMenuItems });
-  };
+  const filteredLinks = primaryLinks.filter(thisLink => !thisLink.hide);
 
-  navigate = (href: string) => {
-    const { history, closeMenu } = this.props;
-    history.push(href);
-    closeMenu();
-  };
-
-  goToHelp = () => {
-    this.navigate('/support');
-  };
-
-  goToProfile = () => {
-    this.navigate('/profile/display');
-  };
-
-  logOut = () => {
-    this.navigate('/logout');
-  };
-
-  handleClick = (event: React.MouseEvent<HTMLElement>) => {
-    this.setState({ anchorEl: event.currentTarget });
-  };
-
-  handleClose = () => {
-    this.setState({ anchorEl: undefined });
-  };
-
-  renderPrimaryLink = (primaryLink: PrimaryLink, isLast: boolean) => {
-    const { classes, isCollapsed } = this.props;
-
-    return (
-      <React.Fragment key={primaryLink.key}>
-        <Link
-          to={primaryLink.href}
-          onClick={(e: React.ChangeEvent<any>) => {
-            this.props.closeMenu();
-            if (primaryLink.onClick) {
-              primaryLink.onClick(e);
-            }
-          }}
-          data-qa-nav-item={primaryLink.key}
-          {...primaryLink.attr}
+  return (
+    <Grid
+      className={classes.menuGrid}
+      container
+      alignItems="flex-start"
+      justify="flex-start"
+      direction="column"
+      wrap="nowrap"
+      spacing={0}
+      component="nav"
+      role="navigation"
+    >
+      <Grid item>
+        <div
           className={classNames({
-            [classes.listItem]: true,
-            [classes.active]: linkIsActive(
-              primaryLink.href,
-              primaryLink.activeLinks
-            ),
-            listItemCollpased: isCollapsed
+            [classes.logoItem]: true,
+            [classes.logoCollapsed]: isCollapsed
           })}
         >
-          {primaryLink.icon && isCollapsed && (
-            <div className="icon">{primaryLink.icon}</div>
-          )}
-          <ListItemText
-            primary={primaryLink.display}
-            disableTypography={true}
-            className={classNames({
-              [classes.linkItem]: true,
-              primaryNavLink: true,
-              hiddenWhenCollapsed: isCollapsed
-            })}
+          <Link to={`/dashboard`} onClick={closeMenu} title="Dashboard">
+            <Logo width={115} height={43} />
+          </Link>
+        </div>
+      </Grid>
+      <div
+        className={classNames({
+          ['fade-in-table']: true,
+          [classes.fadeContainer]: true
+        })}
+      >
+        {filteredLinks.map(thisLink => (
+          <PrimaryLink
+            key={thisLink.display}
+            closeMenu={closeMenu}
+            isCollapsed={isCollapsed}
+            locationSearch={location.search}
+            locationPathname={location.pathname}
+            {...thisLink}
           />
-        </Link>
-        <Divider className={classes.divider} />
-      </React.Fragment>
-    );
-  };
+        ))}
 
-  render() {
-    const { classes, isCollapsed } = this.props;
-    const { expandedMenus, anchorEl } = this.state;
+        {/** menu items under the main navigation links */}
+        <AdditionalMenuItems
+          linkClasses={(href?: string) =>
+            classNames({
+              [classes.listItem]: true,
+              [classes.active]: href
+                ? linkIsActive(href, location.search, location.pathname)
+                : false
+            })
+          }
+          listItemClasses={classNames({
+            [classes.linkItem]: true
+          })}
+          closeMenu={closeMenu}
+          dividerClasses={classes.divider}
+          isCollapsed={isCollapsed}
+        />
 
-    return (
-      <React.Fragment>
-        <Grid
-          className={classes.menuGrid}
-          container
-          alignItems="flex-start"
-          justify="flex-start"
-          direction="column"
-          wrap="nowrap"
-          spacing={0}
-          component="nav"
-          role="navigation"
-        >
-          <Grid item>
-            <div
-              className={classNames({
-                [classes.logoItem]: true,
-                [classes.logoCollapsed]: isCollapsed
-              })}
-            >
-              <Link
-                to={`/dashboard`}
-                onClick={() => this.props.closeMenu()}
-                title="Dashboard"
-              >
-                <Logo width={115} height={43} />
-              </Link>
-            </div>
-          </Grid>
-          <div
+        <Hidden mdUp>
+          <Divider className={classes.divider} />
+          <Link
+            to="/profile/display"
+            onClick={closeMenu}
+            data-qa-nav-item="/profile/display"
             className={classNames({
-              ['fade-in-table']: true,
-              [classes.fadeContainer]: true
+              [classes.listItem]: true,
+              [classes.active]:
+                linkIsActive(
+                  '/profile/display',
+                  location.search,
+                  location.pathname
+                ) === true
             })}
           >
-            {this.state.primaryLinks.map((primaryLink, id, arr) =>
-              this.renderPrimaryLink(primaryLink, id === arr.length - 1)
-            )}
-
-            {/** menu items under the main navigation links */}
-            <AdditionalMenuItems
-              linkClasses={(href?: string) =>
-                classNames({
-                  [classes.listItem]: true,
-                  [classes.active]: href ? linkIsActive(href) : false
-                })
-              }
-              listItemClasses={classNames({
+            <ListItemText
+              primary="My Profile"
+              disableTypography={true}
+              className={classNames({
                 [classes.linkItem]: true
               })}
-              closeMenu={this.props.closeMenu}
-              dividerClasses={classes.divider}
-              isCollapsed={isCollapsed}
             />
-
-            <Hidden mdUp>
-              <Divider className={classes.divider} />
-              <Link
-                to="/profile/display"
-                onClick={this.props.closeMenu}
-                data-qa-nav-item="/profile/display"
-                className={classNames({
-                  [classes.listItem]: true,
-                  [classes.active]:
-                    expandedMenus.support ||
-                    linkIsActive('/profile/display') === true
-                })}
-              >
-                <ListItemText
-                  primary="My Profile"
-                  disableTypography={true}
-                  className={classNames({
-                    [classes.linkItem]: true
-                  })}
-                />
-              </Link>
-              <Link
-                to="/logout"
-                onClick={this.props.closeMenu}
-                data-qa-nav-item="/logout"
-                className={classNames({
-                  [classes.listItem]: true
-                })}
-              >
-                <ListItemText
-                  primary="Log Out"
-                  disableTypography={true}
-                  className={classNames({
-                    [classes.linkItem]: true
-                  })}
-                />
-              </Link>
-            </Hidden>
-            <div className={classes.spacer} />
-            <IconButton
-              onClick={this.handleClick}
+          </Link>
+          <Link
+            to="/logout"
+            onClick={closeMenu}
+            data-qa-nav-item="/logout"
+            className={classNames({
+              [classes.listItem]: true
+            })}
+          >
+            <ListItemText
+              primary="Log Out"
+              disableTypography={true}
               className={classNames({
-                [classes.settings]: true,
-                [classes.settingsCollapsed]: isCollapsed,
-                [classes.activeSettings]: anchorEl
+                [classes.linkItem]: true
               })}
-              aria-label="User settings"
-            >
-              <Settings />
-            </IconButton>
-            <Menu
-              id="settings-menu"
-              anchorEl={anchorEl}
-              open={Boolean(anchorEl)}
-              onClose={this.handleClose}
-              getContentAnchorEl={undefined}
-              PaperProps={{ square: true, className: classes.paper }}
-              anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
-              transformOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-              className={classes.menu}
-              BackdropProps={{
-                className: classes.settingsBackdrop
-              }}
-            >
-              <ThemeToggle toggleTheme={this.props.toggleTheme} />
-              <SpacingToggle toggleSpacing={this.props.toggleSpacing} />
-            </Menu>
-          </div>
-        </Grid>
-      </React.Fragment>
-    );
-  }
-}
-
-interface StateProps {
-  hasAccountAccess: boolean;
-  // isLongviewEnabled: boolean;
-  accountCapabilities: AccountCapability[];
-  accountLastUpdated: number;
-  isManagedAccount: boolean;
-}
-
-const userHasAccountAccess = (profile: Profile) => {
-  if (profile.restricted === false) {
-    return true;
-  }
-
-  const { grants } = profile;
-  if (!grants) {
-    return false;
-  }
-
-  return Boolean(grants.global.account_access);
+            />
+          </Link>
+        </Hidden>
+        <div className={classes.spacer} />
+        <IconButton
+          onClick={(event: React.MouseEvent<HTMLElement>) => {
+            setAnchorEl(event.currentTarget);
+          }}
+          className={classNames({
+            [classes.settings]: true,
+            [classes.settingsCollapsed]: isCollapsed,
+            [classes.activeSettings]: !!anchorEl
+          })}
+          aria-label="User settings"
+        >
+          <Settings />
+        </IconButton>
+        <Menu
+          id="settings-menu"
+          anchorEl={anchorEl}
+          open={Boolean(anchorEl)}
+          onClose={() => {
+            setAnchorEl(undefined);
+          }}
+          getContentAnchorEl={undefined}
+          PaperProps={{ square: true, className: classes.paper }}
+          anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+          transformOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+          className={classes.menu}
+          BackdropProps={{
+            className: classes.settingsBackdrop
+          }}
+        >
+          <ThemeToggle toggleTheme={toggleTheme} />
+          <SpacingToggle toggleSpacing={toggleSpacing} />
+        </Menu>
+      </div>
+    </Grid>
+  );
 };
 
-// const accountHasLongviewSubscription = (account: Linode.AccountSettings) => Boolean(account.longview_subscription);
+export default React.memo(PrimaryNav);
 
-const mapStateToProps: MapState<StateProps, Props> = (state, ownProps) => {
-  const account = state.__resources.accountSettings.data;
-  const profile = state.__resources.profile.data;
-  const accountLastUpdated = state.__resources.account.lastUpdated;
+interface PrimaryLinkProps extends PrimaryLink {
+  closeMenu: () => void;
+  isCollapsed: boolean;
+  locationSearch: string;
+  locationPathname: string;
+}
 
-  if (!account || !profile) {
-    return {
-      hasAccountAccess: false,
-      // isLongviewEnabled: false,
-      accountCapabilities: [],
-      accountLastUpdated,
-      isManagedAccount: false
-    };
-  }
+const PrimaryLink: React.FC<PrimaryLinkProps> = React.memo(props => {
+  const classes = useStyles();
 
-  return {
-    hasAccountAccess: userHasAccountAccess(profile),
-    // isLongviewEnabled: accountHasLongviewSubscription(account),
-    accountCapabilities: pathOr(
-      [],
-      ['__resources', 'account', 'data', 'capabilities'],
-      state
-    ),
-    accountLastUpdated,
-    isManagedAccount: pathOr(
-      false,
-      ['__resources', 'accountSettings', 'data', 'managed'],
-      state
-    )
-  };
-};
+  const {
+    isCollapsed,
+    closeMenu,
+    href,
+    onClick,
+    attr,
+    activeLinks,
+    icon,
+    display,
+    locationSearch,
+    locationPathname
+  } = props;
 
-const connected = connect(mapStateToProps);
-
-export default compose<CombinedProps, Props>(
-  withRouter,
-  withFeatureFlagConsumer,
-  connected,
-  styled
-)(PrimaryNav);
+  return (
+    <>
+      <Link
+        to={href}
+        onClick={(e: React.ChangeEvent<any>) => {
+          closeMenu();
+          if (onClick) {
+            onClick(e);
+          }
+        }}
+        {...attr}
+        className={classNames({
+          [classes.listItem]: true,
+          [classes.active]: linkIsActive(
+            href,
+            locationSearch,
+            locationPathname,
+            activeLinks
+          ),
+          listItemCollpased: isCollapsed
+        })}
+      >
+        {icon && isCollapsed && <div className="icon">{icon}</div>}
+        <ListItemText
+          primary={display}
+          disableTypography={true}
+          className={classNames({
+            [classes.linkItem]: true,
+            primaryNavLink: true,
+            hiddenWhenCollapsed: isCollapsed
+          })}
+        />
+      </Link>
+      <Divider className={classes.divider} />
+    </>
+  );
+});

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -354,7 +354,7 @@ const PrimaryLink: React.FC<PrimaryLinkProps> = React.memo(props => {
             locationPathname,
             activeLinks
           ),
-          listItemCollpased: isCollapsed
+          listItemCollapsed: isCollapsed
         })}
       >
         {icon && isCollapsed && <div className="icon">{icon}</div>}

--- a/packages/manager/src/components/PrimaryNav/utils.ts
+++ b/packages/manager/src/components/PrimaryNav/utils.ts
@@ -1,7 +1,12 @@
 import isPathOneOf from 'src/utilities/routing/isPathOneOf';
 
-export const linkIsActive = (href: string, activeLinks: Array<string> = []) => {
-  const currentlyOnOneClickTab = location.search.match(/one-click/gi);
+export const linkIsActive = (
+  href: string,
+  locationSearch: string,
+  locationPathname: string,
+  activeLinks: Array<string> = []
+) => {
+  const currentlyOnOneClickTab = locationSearch.match(/one-click/gi);
   const isOneClickTab = href.match(/one-click/gi);
 
   /**
@@ -12,5 +17,5 @@ export const linkIsActive = (href: string, activeLinks: Array<string> = []) => {
     return isOneClickTab;
   }
 
-  return isPathOneOf([href, ...activeLinks], location.pathname);
+  return isPathOneOf([href, ...activeLinks], locationPathname);
 };

--- a/packages/manager/src/hooks/useAccountManagement.ts
+++ b/packages/manager/src/hooks/useAccountManagement.ts
@@ -1,0 +1,51 @@
+import { useSelector } from 'react-redux';
+import { ApplicationState } from 'src/store';
+import { State as ProfileState } from 'src/store/profile/profile.reducer';
+import { State as AccountState } from 'src/store/account/account.reducer';
+import { State as AccountSettingsState } from 'src/store/accountSettings/accountSettings.reducer';
+import { GlobalGrantTypes } from 'linode-js-sdk/lib/account';
+
+export interface AccountManagementProps {
+  account: AccountState;
+  profile: ProfileState;
+  accountSettings: AccountSettingsState;
+  _isRestrictedUser: boolean;
+  _hasGrant: (grant: GlobalGrantTypes) => boolean;
+  _hasAccountAccess: boolean;
+  _isManagedAccount: boolean;
+}
+
+export const useAccountManagement = () => {
+  const profile = useSelector(
+    (state: ApplicationState) => state.__resources.profile
+  );
+
+  const account = useSelector(
+    (state: ApplicationState) => state.__resources.account
+  );
+
+  const accountSettings = useSelector(
+    (state: ApplicationState) => state.__resources.accountSettings
+  );
+
+  const _isRestrictedUser = profile.data?.restricted ?? false;
+
+  const _hasGrant = (grant: GlobalGrantTypes) =>
+    profile.data?.grants?.global?.[grant] ?? false;
+
+  const _hasAccountAccess = !_isRestrictedUser || _hasGrant('account_access');
+
+  const _isManagedAccount = accountSettings?.data?.managed ?? false;
+
+  return {
+    account,
+    accountSettings,
+    profile,
+    _isRestrictedUser,
+    _hasGrant,
+    _hasAccountAccess,
+    _isManagedAccount
+  };
+};
+
+export default useAccountManagement;

--- a/packages/manager/src/utilities/routing/isPathOneOf.ts
+++ b/packages/manager/src/utilities/routing/isPathOneOf.ts
@@ -10,7 +10,7 @@ export default (
   paths: string[],
   pathname: string,
   props?: RouteProps
-): Boolean => {
+): boolean => {
   return paths.reduce((result, path) => {
     return result || Boolean(matchPath(pathname, { ...props, path }));
   }, false);


### PR DESCRIPTION
## Description

This is a refactor of the PrimaryNav, which was a bit of a mess. This is the first part of M3-3964 (prefetch entities on hover) and I wanted to use some of our hooks, hence the refactor as a FunctionComponent.

I also hope that this cleans things up such that the re-working of the nav for CMR will be more straightforward.

Also new:

- Brand new tests for PrimaryNav with RTL.
- useAccountManagement hook. Often data is needed that is derived from account, profile, and/or settings. This hook conveniently bundles them together, along with a few pieces of derived data. Better name welcome.

The diff is pretty horrible, sorry.

## Note to Reviewers

This is a refactor – nothing should be different to the user. So please check all states (mobile, expanded), different browsers, etc.
