### PR TITLE
M3-4103: Remove image requirement from showing SSH keys

### DIFF
--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -387,9 +387,7 @@ class FromAppsContent extends React.PureComponent<CombinedProps, State> {
               ]}
               password={password}
               handleChange={updatePassword}
-              users={
-                userSSHKeys.length > 0 && selectedImageID ? userSSHKeys : []
-              }
+              users={userSSHKeys}
               requestKeys={requestKeys}
             />
           </form>

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -269,11 +269,7 @@ export class FromImageContent extends React.PureComponent<CombinedProps> {
                 userSSHKeys,
                 this.props.selectedImageID
               ]}
-              users={
-                userSSHKeys.length > 0 && this.props.selectedImageID
-                  ? userSSHKeys
-                  : []
-              }
+              users={userSSHKeys}
               requestKeys={requestKeys}
             />
             <AddonsPanel

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -382,9 +382,7 @@ export class FromStackScriptContent extends React.PureComponent<CombinedProps> {
               ]}
               password={password}
               handleChange={updatePassword}
-              users={
-                userSSHKeys.length > 0 && selectedImageID ? userSSHKeys : []
-              }
+              users={userSSHKeys}
               requestKeys={requestKeys}
             />
             <AddonsPanel


### PR DESCRIPTION
## Description
Previously, an image is required in order display SSH keys in the "Create Linode" flow. The reason the SSH keys were showing up in the table for some flows but not others is because a default image was selected for the user. This logic might have been leftover from the past but there is no need for this anymore so I removed it from everywhere that it's being used.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers
Please access the "Create Linode" flow from every entry point (via navbar, blue button and action menus) to make sure that the SSH keys are being displayed if they exist and that there are no regressions. 