### PR TITLE
HTML in support tickets [again]

### DIFF
--- a/packages/manager/src/features/Support/ExpandableTicketPanel.test.tsx
+++ b/packages/manager/src/features/Support/ExpandableTicketPanel.test.tsx
@@ -1,6 +1,7 @@
 import * as moment from 'moment';
 
 import { shouldRenderHively } from './Hively';
+import { replaceVersionStringWithHTML } from './ExpandableTicketPanel';
 
 const recent = moment()
   .subtract(6, 'days')
@@ -28,5 +29,29 @@ describe('shouldRenderHively function', () => {
   });
   it('should return false if the user is Linode', () => {
     expect(shouldRenderHively(false, recent, user)).toBeFalsy();
+  });
+});
+
+describe('replaceVersionStringWithHTML', () => {
+  it('should insert the version string into a <span />', () => {
+    expect(
+      replaceVersionStringWithHTML('Hello. Cloud Manager Version: 1.0.0')
+    ).toBe('Hello. <span>Cloud Manager Version: 1.0.0</span>');
+  });
+
+  it('only affects the last occurrence of a version string', () => {
+    expect(
+      replaceVersionStringWithHTML(
+        'Hello. Cloud Manager Version: 1.0.0. World. Cloud Manager Version: 1.0.0'
+      )
+    ).toBe(
+      'Hello. Cloud Manager Version: 1.0.0. World. <span>Cloud Manager Version: 1.0.0</span>'
+    );
+  });
+
+  it('leaves descriptions without a version string alone', () => {
+    expect(
+      replaceVersionStringWithHTML('This is a reply with no version string.')
+    ).toBe('This is a reply with no version string.');
   });
 });

--- a/packages/manager/src/features/Support/ExpandableTicketPanel.test.tsx
+++ b/packages/manager/src/features/Support/ExpandableTicketPanel.test.tsx
@@ -36,7 +36,7 @@ describe('replaceVersionStringWithHTML', () => {
   it('should insert the version string into a <span />', () => {
     expect(
       replaceVersionStringWithHTML('Hello. Cloud Manager Version: 1.0.0')
-    ).toBe('Hello. <span>Cloud Manager Version: 1.0.0</span>');
+    ).toBe('Hello. <span class="version">Cloud Manager Version: 1.0.0</span>');
   });
 
   it('only affects the last occurrence of a version string', () => {
@@ -45,7 +45,7 @@ describe('replaceVersionStringWithHTML', () => {
         'Hello. Cloud Manager Version: 1.0.0. World. Cloud Manager Version: 1.0.0'
       )
     ).toBe(
-      'Hello. Cloud Manager Version: 1.0.0. World. <span>Cloud Manager Version: 1.0.0</span>'
+      'Hello. Cloud Manager Version: 1.0.0. World. <span class="version">Cloud Manager Version: 1.0.0</span>'
     );
   });
 

--- a/packages/manager/src/features/Support/ExpandableTicketPanel.tsx
+++ b/packages/manager/src/features/Support/ExpandableTicketPanel.tsx
@@ -12,7 +12,7 @@ import {
 import Typography from 'src/components/core/Typography';
 import DateTimeDisplay from 'src/components/DateTimeDisplay';
 import Grid from 'src/components/Grid';
-
+import { versionStringRegex } from 'src/utilities/getVersionString';
 import { Hively, shouldRenderHively } from './Hively';
 import TicketDetailBody from './TicketDetailText';
 
@@ -225,7 +225,10 @@ export const ExpandableTicketPanel: React.FC<CombinedProps> = props => {
                   </Typography>
                 </Grid>
               </Grid>
-              <TicketDetailBody open={open} text={data.description} />
+              <TicketDetailBody
+                open={open}
+                text={replaceVersionStringWithHTML(data.description)}
+              />
               {shouldRenderHively(
                 data.from_linode,
                 data.updated,
@@ -251,3 +254,11 @@ export default compose<CombinedProps, Props>(
   React.memo,
   styled
 )(ExpandableTicketPanel);
+
+// Descriptions of Tickets (not replies) opened by users will end with the version string.
+// We'd like to apply a CSS class, so we insert it into a span.
+export const replaceVersionStringWithHTML = (description: string) => {
+  return description.replace(versionStringRegex, match => {
+    return `<span class="version">${match}</span>`;
+  });
+};

--- a/packages/manager/src/formatted-text.css
+++ b/packages/manager/src/formatted-text.css
@@ -33,7 +33,7 @@
   width: 100%;
 }
 
-.formatted-text p:last-of-type {
+.formatted-text .version {
   display: block;
   margin-top: 32px;
 }

--- a/packages/manager/src/utilities/getVersionString.ts
+++ b/packages/manager/src/utilities/getVersionString.ts
@@ -2,3 +2,5 @@ const { VERSION } = process.env;
 
 export const getVersionString = () =>
   VERSION ? `Cloud Manager Version: ${VERSION}` : '';
+
+export const versionStringRegex = /Cloud Manager Version: [0-9.]+$/g;

--- a/packages/manager/src/utilities/sanitize-html/sanitize-html.test.ts
+++ b/packages/manager/src/utilities/sanitize-html/sanitize-html.test.ts
@@ -12,6 +12,14 @@ describe('sanitizeHTML', () => {
   it('should strip invalid href values', () => {
     expect(sanitizeHTML('<a href="javascript:void"/>')).not.toContain('href');
   });
+
+  it('only allows "version" class, and only for spans', () => {
+    expect(sanitizeHTML('<div class="version" />')).not.toContain('class');
+    expect(sanitizeHTML('<div class="other-class" />')).not.toContain('class');
+
+    expect(sanitizeHTML('<span class="version" />')).toContain('class');
+    expect(sanitizeHTML('<span class="other-class" />')).not.toContain('class');
+  });
 });
 
 describe('isURLValid', () => {

--- a/packages/manager/src/utilities/sanitize-html/sanitizeHTML.ts
+++ b/packages/manager/src/utilities/sanitize-html/sanitizeHTML.ts
@@ -7,6 +7,9 @@ export const sanitizeHTML = (text: string) =>
     allowedAttributes: {
       '*': allowedHTMLAttr
     },
+    allowedClasses: {
+      span: ['version']
+    },
     transformTags: {
       a: (tagName, attribs) => {
         const href = attribs.href ?? '';


### PR DESCRIPTION
## Description

My solution to this issue in https://github.com/linode/manager/pull/6397 overshot a bit. There, I applied the CSS to the last "p" element of a Support Ticket. That's a problem though, since not everything has the version string attached (replies, subsequent updates, tickets opened by Linode).

This inserts a "span" with a class for the CSS to select on.

If you have a less-bad solution in mind, I'm all ears 🙂 

## Note to Reviewers

Please check new tickets, old tickets, ticket replies, etc.
