### PR TITLE
M3-2063: Fix visual regression for tags on mobile viewport

### DIFF
--- a/packages/manager/src/features/Dashboard/NodeBalancersDashboardCard/NodeBalancersDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/NodeBalancersDashboardCard/NodeBalancersDashboardCard.tsx
@@ -69,10 +69,10 @@ const styles = (theme: Theme) =>
       }
     },
     labelCol: {
-      width: '70%'
+      width: '75%'
     },
     moreCol: {
-      width: '30%'
+      width: '25%'
     },
     actionsCol: {
       width: '10%'

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -578,18 +578,6 @@ const themeDefaults: ThemeDefaults = ({ spacingOverride: spacingUnit }) => {
             width: 12,
             height: 12,
             borderRadius: '50%'
-          },
-          [breakpoints.down('xs')]: {
-            marginLeft: 8,
-            marginRight: -8,
-            marginTop: -6,
-            color: 'white !important',
-            '& svg': {
-              width: 20,
-              height: 20,
-              borderRadius: '50%',
-              backgroundColor: primaryColors.main
-            }
           }
         }
       },


### PR DESCRIPTION
## Description
The tags on the Linode detail view used to be a different style for mobile (blue circle with a white 'X' inside) which should no long be the case now.

## Type of Change
- Non breaking change ('update', 'change')
