### PR TITLE
Clarify auto-resize text

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -304,9 +304,10 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
             Resize
           </Typography>
           <Typography data-qa-description>
-            If you're expecting a temporary burst of traffic to your website, or
-            if you're not using your Linode as much as you thought, you can
-            temporarily or permanently resize your Linode to a different plan.{' '} 
+            If you&apos;re expecting a temporary burst of traffic to your
+            website, or if you&apos;re not using your Linode as much as you
+            thought, you can temporarily or permanently resize your Linode to a
+            different plan.{' '}
             <ExternalLink
               fixedIcon
               text="Learn more."
@@ -330,7 +331,7 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
                 className={classes.toolTip}
                 text={`Your disks cannot be automatically resized when moving to a smaller plan.`}
               />
-            ) : !_shouldEnableAutoResizeDiskOption ? (
+            ) : !_shouldEnableAutoResizeDiskOption || isSmaller ? (
               <HelpIcon
                 className={classes.toolTip}
                 text={`Your ext disk can only be automatically resized if you have one ext
@@ -348,13 +349,21 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
             onChange={this.handleToggleAutoDisksResize}
             text={
               !_shouldEnableAutoResizeDiskOption ? (
-                `Would you like your disk on this Linode automatically resized to
-            scale with this Linode's new size? We recommend you keep this option enabled.`
+                <Typography>
+                  Would you like your disk to be automatically scaled with this
+                  Linode&apos;s new size? We recommend you keep this option
+                  enabled when available. Automatic resizing is only available
+                  when moving to a larger plan, and when you have a single ext
+                  disk (or one ext and one swap disk) on your Linode.
+                </Typography>
               ) : (
                 <Typography>
                   Would you like the disk <strong>{diskToResize}</strong> to be
-                  automatically scaled with this Linode's new size? We recommend
-                  you keep this option enabled.
+                  automatically scaled with this Linode&apos;s new size? We
+                  recommend you keep this option enabled when available.
+                  Automatic resizing is only available when moving to a larger
+                  plan, and when you have a single ext disk (or one ext and one
+                  swap disk) on your Linode.
                 </Typography>
               )
             }
@@ -391,7 +400,7 @@ interface WithTypesProps {
   deprecatedTypesData: ExtendedType[];
 }
 
-const withTypes = connect((state: ApplicationState, ownProps) => ({
+const withTypes = connect((state: ApplicationState) => ({
   currentTypesData: state.__resources.types.entities
     .filter(eachType => eachType.successor === null)
     .map(LinodeResize.extendType),

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -331,7 +331,7 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
                 className={classes.toolTip}
                 text={`Your disks cannot be automatically resized when moving to a smaller plan.`}
               />
-            ) : !_shouldEnableAutoResizeDiskOption || isSmaller ? (
+            ) : !_shouldEnableAutoResizeDiskOption ? (
               <HelpIcon
                 className={classes.toolTip}
                 text={`Your ext disk can only be automatically resized if you have one ext

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -348,24 +348,19 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
             }
             onChange={this.handleToggleAutoDisksResize}
             text={
-              !_shouldEnableAutoResizeDiskOption ? (
-                <Typography>
-                  Would you like your disk to be automatically scaled with this
-                  Linode&apos;s new size? We recommend you keep this option
-                  enabled when available. Automatic resizing is only available
-                  when moving to a larger plan, and when you have a single ext
-                  disk (or one ext and one swap disk) on your Linode.
-                </Typography>
-              ) : (
-                <Typography>
-                  Would you like the disk <strong>{diskToResize}</strong> to be
-                  automatically scaled with this Linode&apos;s new size? We
-                  recommend you keep this option enabled when available.
-                  Automatic resizing is only available when moving to a larger
-                  plan, and when you have a single ext disk (or one ext and one
-                  swap disk) on your Linode.
-                </Typography>
-              )
+              <Typography>
+                Would you like{' '}
+                {_shouldEnableAutoResizeDiskOption ? (
+                  <strong>{diskToResize}</strong>
+                ) : (
+                  'your disk'
+                )}{' '}
+                to be automatically scaled with this Linode&apos;s new size? We
+                recommend you keep this option enabled when available. Automatic
+                resizing is only available when moving to a larger plan, and
+                when you have a single ext disk (or one ext and one swap disk)
+                on your Linode.
+              </Typography>
             }
           />
         </Paper>


### PR DESCRIPTION
## Description

A customer had expressed that our messaging about auto disk
resizes when resizing a Linode was unclear. We included relevant
information in tooltips (when the new plan was smaller or the user
had custom disks). I added some clarifying comments to the text
next to the checkbox, and left the tooltips as they were.