### PR TITLE
[Billing] Add Payment ID to Activity Feed

### DIFF
--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.test.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.test.tsx
@@ -133,9 +133,9 @@ describe('invoiceToActivityFeedItem', () => {
 
 describe('paymentToActivityFeedItem', () => {
   it('sets label as "Payment" if usd >= 0 ', () => {
-    const payment0 = paymentFactory.build({ usd: 0 });
-    expect(paymentToActivityFeedItem(payment0).label).toBe('Payment');
-    expect(paymentToActivityFeedItem(payment0).label).toBe('Payment');
+    const payment = paymentFactory.build({ usd: 0, id: 1 });
+    expect(paymentToActivityFeedItem(payment).label).toBe('Payment #1');
+    expect(paymentToActivityFeedItem(payment).label).toBe('Payment #1');
   });
 
   it('sets label as "Refund to Card" if usd < 0 ', () => {

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -581,7 +581,7 @@ export const paymentToActivityFeedItem = (
 ): ActivityFeedItem => {
   const { date, id, usd } = payment;
   // Refunds are issued as negative payments.
-  const label = usd < 0 ? 'Refund to Card' : 'Payment';
+  const label = usd < 0 ? 'Refund to Card' : `Payment #${payment.id}`;
 
   // Note: this is confusing.
   // We flip the polarity here, since we display a positive payment as e.g. "-($5.00)"


### PR DESCRIPTION
## Description

I forgot to add the Payment ID to the label in the Billing Activity Table, as described in the designs.
