### PR TITLE
[Billing] Disable scrolling on Activity Feed Paginate

### DIFF
--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -405,7 +405,7 @@ export const BillingActivityPanel: React.FC<Props> = props => {
       <OrderBy data={filteredData} orderBy={'date'} order={'desc'}>
         {React.useCallback(
           ({ data: orderedData }) => (
-            <Paginate pageSize={25} data={orderedData}>
+            <Paginate pageSize={25} data={orderedData} shouldScroll={false}>
               {({
                 data: paginatedAndOrderedData,
                 count,


### PR DESCRIPTION
## Description

Another small fix. This disables pagination for the Billing Activity Feed, which can be very jumpy.

To test, use an account with many invoices/payments. Select "All Time" then toggle the pagination footer controls.