### PR TITLE
[Billing] Adjustments to Close Account

### DIFF
--- a/packages/manager/src/features/Account/CloseAccountDialog.tsx
+++ b/packages/manager/src/features/Account/CloseAccountDialog.tsx
@@ -26,7 +26,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   }
 }));
 
-const CancelAccountDialog: React.FC<CombinedProps> = props => {
+const CloseAccountDialog: React.FC<CombinedProps> = props => {
   const [isCancelling, setCancelling] = React.useState<boolean>(false);
   const [errors, setErrors] = React.useState<APIError[] | undefined>(undefined);
   const [comments, setComments] = React.useState<string>('');
@@ -171,4 +171,4 @@ const Actions: React.FC<ActionsProps> = props => {
   );
 };
 
-export default compose<CombinedProps, Props>(React.memo)(CancelAccountDialog);
+export default compose<CombinedProps, Props>(React.memo)(CloseAccountDialog);

--- a/packages/manager/src/features/Account/CloseAccountDialog.tsx
+++ b/packages/manager/src/features/Account/CloseAccountDialog.tsx
@@ -27,7 +27,9 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 const CloseAccountDialog: React.FC<CombinedProps> = props => {
-  const [isCancelling, setCancelling] = React.useState<boolean>(false);
+  const [isClosingAccount, setIsClosingAccount] = React.useState<boolean>(
+    false
+  );
   const [errors, setErrors] = React.useState<APIError[] | undefined>(undefined);
   const [comments, setComments] = React.useState<string>('');
   const [inputtedUsername, setUsername] = React.useState<string>('');
@@ -75,7 +77,7 @@ const CloseAccountDialog: React.FC<CombinedProps> = props => {
   );
 
   const handleCancelAccount = () => {
-    setCancelling(true);
+    setIsClosingAccount(true);
     return cancelAccount({
       /**
        * we don't care about soliciting comments from the user
@@ -84,12 +86,12 @@ const CloseAccountDialog: React.FC<CombinedProps> = props => {
       comments
     })
       .then(response => {
-        setCancelling(false);
+        setIsClosingAccount(false);
         /** shoot the user off to survey monkey to answer some questions */
         history.push('/cancel', { survey_link: response.survey_link });
       })
       .catch((e: APIError[]) => {
-        setCancelling(false);
+        setIsClosingAccount(false);
         setErrors(e);
       });
   };
@@ -107,7 +109,7 @@ const CloseAccountDialog: React.FC<CombinedProps> = props => {
       actions={
         <Actions
           onClose={props.closeDialog}
-          isCancelling={isCancelling}
+          isCancelling={isClosingAccount}
           onSubmit={handleCancelAccount}
           disabled={!canSubmit}
         />

--- a/packages/manager/src/features/Account/CloseAccountSetting.tsx
+++ b/packages/manager/src/features/Account/CloseAccountSetting.tsx
@@ -4,12 +4,6 @@ import ExpansionPanel from 'src/components/ExpansionPanel';
 import Grid from 'src/components/Grid';
 import CloseAccountDialog from './CloseAccountDialog';
 
-// interface Props {
-//   activeSince?: string;
-// }
-
-// type CombinedProps = Props;
-
 const CancelAccountSetting: React.FC<{}> = () => {
   const [dialogOpen, setDialogOpen] = React.useState<boolean>(false);
 
@@ -17,14 +11,6 @@ const CancelAccountSetting: React.FC<{}> = () => {
     <>
       <ExpansionPanel heading="Close Account" defaultExpanded={true}>
         <Grid container direction="column">
-          {/* <Grid item>
-            {activeSince && (
-              <Typography variant="body1">
-                Your account has been active since{' '}
-                <DateTimeDisplay value={activeSince} format="YYYY-MM-DD" />.
-              </Typography>
-            )}
-          </Grid> */}
           <Grid item>
             <Button
               buttonType="secondary"
@@ -44,4 +30,4 @@ const CancelAccountSetting: React.FC<{}> = () => {
   );
 };
 
-export default CancelAccountSetting;
+export default React.memo(CancelAccountSetting);

--- a/packages/manager/src/features/Account/CloseAccountSetting.tsx
+++ b/packages/manager/src/features/Account/CloseAccountSetting.tsx
@@ -1,44 +1,42 @@
 import * as React from 'react';
 import Button from 'src/components/Button';
-import Typography from 'src/components/core/Typography';
-import DateTimeDisplay from 'src/components/DateTimeDisplay';
 import ExpansionPanel from 'src/components/ExpansionPanel';
 import Grid from 'src/components/Grid';
-import CancelAccountDialog from './CancelAccountDialog';
+import CloseAccountDialog from './CloseAccountDialog';
 
-interface Props {
-  activeSince?: string;
-}
+// interface Props {
+//   activeSince?: string;
+// }
 
-type CombinedProps = Props;
+// type CombinedProps = Props;
 
-const CancelAccountSetting: React.FC<CombinedProps> = ({ activeSince }) => {
+const CancelAccountSetting: React.FC<{}> = () => {
   const [dialogOpen, setDialogOpen] = React.useState<boolean>(false);
 
   return (
     <>
-      <ExpansionPanel heading="Account" defaultExpanded={true}>
+      <ExpansionPanel heading="Close Account" defaultExpanded={true}>
         <Grid container direction="column">
-          <Grid item>
+          {/* <Grid item>
             {activeSince && (
               <Typography variant="body1">
                 Your account has been active since{' '}
                 <DateTimeDisplay value={activeSince} format="YYYY-MM-DD" />.
               </Typography>
             )}
-          </Grid>
+          </Grid> */}
           <Grid item>
             <Button
               buttonType="secondary"
               destructive
               onClick={() => setDialogOpen(true)}
             >
-              Cancel Account
+              Close Account
             </Button>
           </Grid>
         </Grid>
       </ExpansionPanel>
-      <CancelAccountDialog
+      <CloseAccountDialog
         open={dialogOpen}
         closeDialog={() => setDialogOpen(false)}
       />

--- a/packages/manager/src/features/Account/CloseAccountSetting.tsx
+++ b/packages/manager/src/features/Account/CloseAccountSetting.tsx
@@ -4,7 +4,7 @@ import ExpansionPanel from 'src/components/ExpansionPanel';
 import Grid from 'src/components/Grid';
 import CloseAccountDialog from './CloseAccountDialog';
 
-const CancelAccountSetting: React.FC<{}> = () => {
+const CloseAccountSetting: React.FC<{}> = () => {
   const [dialogOpen, setDialogOpen] = React.useState<boolean>(false);
 
   return (
@@ -30,4 +30,4 @@ const CancelAccountSetting: React.FC<{}> = () => {
   );
 };
 
-export default React.memo(CancelAccountSetting);
+export default React.memo(CloseAccountSetting);

--- a/packages/manager/src/features/Account/GlobalSettings.tsx
+++ b/packages/manager/src/features/Account/GlobalSettings.tsx
@@ -33,7 +33,7 @@ import EnableManaged from './EnableManaged';
 import EnableObjectStorage from './EnableObjectStorage';
 import ImportGroupsAsTags from './ImportGroupsAsTags';
 import NetworkHelper from './NetworkHelper';
-import CancelAccountSetting from './CancelAccountSetting';
+import CloseAccountSetting from './CloseAccountSetting';
 
 interface StateProps {
   loading: boolean;
@@ -45,7 +45,6 @@ interface StateProps {
   entitiesWithGroupsToImport: GroupedEntitiesForImport;
   isManaged: boolean;
   object_storage: AccountSettings['object_storage'];
-  activeSince?: string;
 }
 
 interface DispatchProps {
@@ -140,7 +139,7 @@ const GlobalSettings: React.FC<CombinedProps> = props => {
       {shouldDisplayGroupImport(entitiesWithGroupsToImport) && (
         <ImportGroupsAsTags openDrawer={openImportDrawer} />
       )}
-      <CancelAccountSetting activeSince={props.activeSince} />
+      <CloseAccountSetting />
 
       <TagImportDrawer />
     </div>
@@ -175,8 +174,7 @@ const mapStateToProps: MapState<StateProps, {}> = state => ({
     'disabled',
     ['__resources', 'accountSettings', 'data', 'object_storage'],
     state
-  ),
-  activeSince: state.__resources.account.data?.active_since
+  )
 });
 const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
   dispatch: ThunkDispatch<ApplicationState, undefined, AnyAction>

--- a/packages/manager/src/features/Billing/BillingDetail.tsx
+++ b/packages/manager/src/features/Billing/BillingDetail.tsx
@@ -109,6 +109,7 @@ export const BillingDetail: React.FC<CombinedProps> = props => {
             <BillingActivityPanel
               mostRecentInvoiceId={mostRecentInvoiceId}
               setMostRecentInvoiceId={setMostRecentInvoiceId}
+              accountActiveSince={account?.data?.active_since}
             />
           </Grid>
         </Grid>

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.test.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.test.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { invoiceFactory, paymentFactory } from 'src/factories/billing';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 import BillingActivityPanel, {
+  Props,
   invoiceToActivityFeedItem,
   paymentToActivityFeedItem,
   getCutoffFromDateRange,
@@ -43,15 +44,13 @@ jest.mock('linode-js-sdk/lib/account', () => {
 });
 jest.mock('src/components/EnhancedSelect/Select');
 
-// const mockOpenCloseAccountDialog = jest.fn();
-
-const setMostRecentInvoiceId = (id: number) => id;
+const props: Props = {
+  setMostRecentInvoiceId: jest.fn()
+};
 
 describe('BillingActivityPanel', () => {
   it('renders the header and appropriate rows', async () => {
-    const { getByText } = renderWithTheme(
-      <BillingActivityPanel setMostRecentInvoiceId={setMostRecentInvoiceId} />
-    );
+    const { getByText } = renderWithTheme(<BillingActivityPanel {...props} />);
     await wait(() => {
       getByText('Billing & Payment History');
       getByText('Description');
@@ -62,7 +61,7 @@ describe('BillingActivityPanel', () => {
 
   it('renders a row for each payment and invoice', async () => {
     const { getByText, getByTestId } = renderWithTheme(
-      <BillingActivityPanel setMostRecentInvoiceId={setMostRecentInvoiceId} />
+      <BillingActivityPanel {...props} />
     );
     await wait(() => {
       getByText('Invoice #0');
@@ -74,7 +73,7 @@ describe('BillingActivityPanel', () => {
 
   it('should filter by item type', async () => {
     const { queryAllByTestId, queryByText, queryByTestId } = renderWithTheme(
-      <BillingActivityPanel setMostRecentInvoiceId={setMostRecentInvoiceId} />
+      <BillingActivityPanel {...props} />
     );
 
     // Test selecting "Invoices"
@@ -98,7 +97,7 @@ describe('BillingActivityPanel', () => {
 
   it('should filter by transaction date', async () => {
     const { queryAllByTestId, queryByText, queryByTestId } = renderWithTheme(
-      <BillingActivityPanel setMostRecentInvoiceId={setMostRecentInvoiceId} />
+      <BillingActivityPanel {...props} />
     );
 
     await wait(() => {
@@ -112,12 +111,19 @@ describe('BillingActivityPanel', () => {
   });
 
   it('should display transaction selection components with defaults', async () => {
-    const { getByText } = renderWithTheme(
-      <BillingActivityPanel setMostRecentInvoiceId={setMostRecentInvoiceId} />
-    );
+    const { getByText } = renderWithTheme(<BillingActivityPanel {...props} />);
     await wait(() => {
       getByText('All Transaction Types');
       getByText('90 Days');
+    });
+  });
+
+  it('should display "Account active since"', async () => {
+    const { getByText } = renderWithTheme(
+      <BillingActivityPanel {...props} accountActiveSince="2018-01-01" />
+    );
+    await wait(() => {
+      getByText('Account active since 2018-01-01');
     });
   });
 });

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -35,6 +35,7 @@ import useFlags from 'src/hooks/useFlags';
 import { useSet } from 'src/hooks/useSet';
 import { isAfter } from 'src/utilities/date';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import formatDate from 'src/utilities/formatDate';
 import { getAll, getAllWithArguments } from 'src/utilities/getAll';
 import { getTaxID } from '../RecentPaymentsPanel/RecentPaymentsPanel';
 
@@ -167,12 +168,19 @@ const defaultDateRange: DateRange = '6 Months';
 // =============================================================================
 // <BillingActivityPanel />
 // =============================================================================
-interface Props {
+export interface Props {
   mostRecentInvoiceId?: number;
   setMostRecentInvoiceId: (id: number) => void;
+  accountActiveSince?: string;
 }
 
 export const BillingActivityPanel: React.FC<Props> = props => {
+  const {
+    mostRecentInvoiceId,
+    setMostRecentInvoiceId,
+    accountActiveSince
+  } = props;
+
   const classes = useStyles();
   const flags = useFlags();
   const { account } = useAccount();
@@ -206,8 +214,8 @@ export const BillingActivityPanel: React.FC<Props> = props => {
           setInvoices(invoices.data);
           setPayments(payments.data);
 
-          if (!props.mostRecentInvoiceId && invoices.data.length > 0) {
-            props.setMostRecentInvoiceId(invoices.data[0].id);
+          if (!mostRecentInvoiceId && invoices.data.length > 0) {
+            setMostRecentInvoiceId(invoices.data[0].id);
           }
         })
         .catch(_error => {
@@ -220,7 +228,7 @@ export const BillingActivityPanel: React.FC<Props> = props => {
           setLoading(false);
         });
     },
-    []
+    [mostRecentInvoiceId, setMostRecentInvoiceId]
   );
 
   // Request all invoices and payments when component mounts.
@@ -366,6 +374,16 @@ export const BillingActivityPanel: React.FC<Props> = props => {
       <div className={classes.headerContainer}>
         <Typography variant="h2">Billing &amp; Payment History</Typography>
         <div className={classes.headerRight}>
+          {accountActiveSince && (
+            <div className={classes.flexContainer}>
+              <Typography variant="body1" className={classes.activeSince}>
+                Account active since{' '}
+                {formatDate(accountActiveSince, {
+                  format: 'YYYY-MM-DD'
+                })}
+              </Typography>
+            </div>
+          )}
           <div className={classes.flexContainer}>
             <Select
               className={classes.transactionType}


### PR DESCRIPTION
## Description

Based on feedback from Jay:

- Rename "Cancel Account" to "Close Account"
- Remove "Account Active Since" from Account -> Settings
- Add "Account Active Since" to it's previous position above the Billing Activity Feed

Also: 
- Clean up tests for Billing Activity Feed
- Add missing dependencies to a React.useCallback in the activity feed component

