### PR TITLE
[SDK] Remove Ramda dependency

### DIFF
--- a/packages/api-v4/package.json
+++ b/packages/api-v4/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "axios": "~0.19.0",
     "querystring": "^0.2.0",
-    "ramda": "^0.26.1",
     "yup": "^0.27.0"
   },
   "scripts": {
@@ -53,7 +52,6 @@
     "@babel/preset-typescript": "^7.6.0",
     "@types/jest": "^24.0.23",
     "@types/node": "^12.7.1",
-    "@types/ramda": "^0.26.33",
     "@types/yup": "^0.26.22",
     "axios-mock-adapter": "^1.18.1",
     "babel-plugin-module-resolver": "^3.2.0",

--- a/packages/api-v4/src/request.test.ts
+++ b/packages/api-v4/src/request.test.ts
@@ -3,6 +3,7 @@ import { object, string } from 'yup';
 
 import request, {
   baseRequest,
+  isEmpty,
   setData,
   setHeaders,
   setMethod,
@@ -143,6 +144,35 @@ describe('Linode JS SDK', () => {
 
         expect(spy).toHaveBeenCalledTimes(1);
         expect(mock.history.get).toHaveLength(0);
+      });
+    });
+  });
+
+  describe('Helpers', () => {
+    describe('isEmpty', () => {
+      it('returns true for undefined and null', () => {
+        expect(isEmpty(undefined)).toBe(true);
+        expect(isEmpty(null)).toBe(true);
+      });
+
+      it('returns true for an empty array', () => {
+        expect(isEmpty([])).toBe(true);
+      });
+
+      it('returns true for an empty object', () => {
+        expect(isEmpty({})).toBe(true);
+      });
+
+      it('returns true for an empty string', () => {
+        expect(isEmpty('')).toBe(true);
+      });
+
+      it('returns false for non-empty objects', () => {
+        expect(isEmpty(1)).toBe(false);
+        expect(isEmpty('five')).toBe(false);
+        expect(isEmpty([undefined, undefined, undefined])).toBe(false);
+        expect(isEmpty({ fruits: ['apple', 'orange'] })).toBe(false);
+        expect(isEmpty(new Date())).toBe(false);
       });
     });
   });

--- a/packages/api-v4/src/request.ts
+++ b/packages/api-v4/src/request.ts
@@ -11,6 +11,8 @@ interface RequestConfig extends AxiosRequestConfig {
   validationErrors?: APIError[];
 }
 
+type ConfigField = 'headers' | 'data' | 'params' | 'method' | 'url';
+
 export const baseRequest = Axios.create({
   baseURL: 'https://api.linode.com/v4'
 });
@@ -35,8 +37,8 @@ export const setToken = (token: string) => {
   });
 };
 
-const set = (field: string, value: any) => (object: any) => {
-  return { ...object, [field]: value };
+const set = (field: ConfigField, value: any) => (object: any) => {
+  return isNotEmpty(value) ? { ...object, [field]: value } : object;
 };
 
 const isNotEmpty = (v: any) =>
@@ -50,9 +52,7 @@ export const setMethod = (method: 'GET' | 'POST' | 'PUT' | 'DELETE') =>
   set('method', method);
 
 /** Param */
-export const setParams = (params: any = {}) => {
-  return isNotEmpty(params) ? set('params', params) : set('', '');
-};
+export const setParams = (params: any = {}) => set('params', params);
 
 export const setHeaders = (newHeaders: any = {}) => (object: any) => {
   return isNotEmpty(newHeaders)
@@ -129,12 +129,13 @@ const mapYupToLinodeAPIError = ({
 
 /** X-Filter */
 export const setXFilter = (xFilter: any) => {
-  return isNotEmpty(xFilter)
-    ? (object: any) => ({
-        ...object,
-        headers: { ...object.headers, 'X-Filter': JSON.stringify(xFilter) }
-      })
-    : set('', '');
+  return (object: any) =>
+    isNotEmpty(xFilter)
+      ? {
+          ...object,
+          headers: { ...object.headers, 'X-Filter': JSON.stringify(xFilter) }
+        }
+      : object;
 };
 
 /**

--- a/packages/api-v4/src/request.ts
+++ b/packages/api-v4/src/request.ts
@@ -38,11 +38,16 @@ export const setToken = (token: string) => {
 };
 
 const set = (field: ConfigField, value: any) => (object: any) => {
-  return isNotEmpty(value) ? { ...object, [field]: value } : object;
+  return !isEmpty(value) ? { ...object, [field]: value } : object;
 };
 
-const isNotEmpty = (v: any) =>
-  !(v === undefined || v === null || v.length === 0);
+export const isEmpty = (v: any) =>
+  v === undefined ||
+  v === null ||
+  v.length === 0 ||
+  (typeof v === 'object' &&
+    Object.keys(v).length === 0 &&
+    v.constructor === Object);
 
 /** URL */
 export const setURL = (url: string) => set('url', url);
@@ -55,7 +60,7 @@ export const setMethod = (method: 'GET' | 'POST' | 'PUT' | 'DELETE') =>
 export const setParams = (params: any = {}) => set('params', params);
 
 export const setHeaders = (newHeaders: any = {}) => (object: any) => {
-  return isNotEmpty(newHeaders)
+  return !isEmpty(newHeaders)
     ? { ...object, headers: { ...object.headers, ...newHeaders } }
     : object;
 };
@@ -130,7 +135,7 @@ const mapYupToLinodeAPIError = ({
 /** X-Filter */
 export const setXFilter = (xFilter: any) => {
   return (object: any) =>
-    isNotEmpty(xFilter)
+    !isEmpty(xFilter)
       ? {
           ...object,
           headers: { ...object.headers, 'X-Filter': JSON.stringify(xFilter) }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3062,13 +3062,6 @@
   resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.25.16.tgz#1d4eeb78d3247d1ceef971b458dd8469646cd1b4"
   integrity sha512-jNxaEg+kSJ58iaM9bBawJugDxexXVPnLU245yEI1p2BTcfR5pcgM6mpsyBhRRo2ozyfJUvTmasL2Ft+C6BNkVQ==
 
-"@types/ramda@^0.26.33":
-  version "0.26.38"
-  resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.26.38.tgz#9d19bb910bb15fc9a213402092e160cbbb5acc9b"
-  integrity sha512-legQx15y72vedr5fkVTb5xZaI/OXMzJgZYbMxVL5r269sOg7fZIeitEOumcevMPOMZdqH4cMoL35VuU13TLvVA==
-  dependencies:
-    ts-toolbelt "^4.12.0"
-
 "@types/reach__router@^1.2.3":
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/@types/reach__router/-/reach__router-1.2.6.tgz#b14cf1adbd1a365d204bbf6605cd9dd7b8816c87"
@@ -5456,7 +5449,7 @@ camelcase@^3.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
   integrity sha1-MvxLn82vhF/N9+c7uXysImHwqwo=
 
-camelcase@^4.0.0, camelcase@^4.1.0:
+camelcase@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
@@ -12795,25 +12788,10 @@ minimatch@3.0.4, minimatch@^3.0.2, minimatch@^3.0.4, minimatch@~3.0.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
-
-minimist@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-  integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
-
-minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
+minimist@0.0.8, minimist@1.2.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.3, minimist@~0.0.1:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
-
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
-  integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
 
 minipass-collect@^1.0.2:
   version "1.0.2"
@@ -14807,7 +14785,7 @@ ramda@0.25.0, ramda@~0.25.0:
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
   integrity sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==
 
-ramda@0.26.1, ramda@^0.26.1:
+ramda@0.26.1:
   version "0.26.1"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
   integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
@@ -17868,11 +17846,6 @@ ts-pnp@^1.1.2:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.5.tgz#840e0739c89fce5f3abd9037bb091dbff16d9dec"
   integrity sha512-ti7OGMOUOzo66wLF3liskw6YQIaSsBgc4GOAlWRnIEj8htCxJUxskanMUoJOD6MDCRAXo36goXJZch+nOS0VMA==
 
-ts-toolbelt@^4.12.0:
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-4.14.0.tgz#c174673c8d2e1d979ab7508d4f17a60b56ff1869"
-  integrity sha512-MZzo9lN3hj/ApO4Fqy8nasv9Cr3bauS2JGmZUJJ1XRBUS02fAZklbXdVI4Yz2ygrizFfww5Xs0zlzcKXYVSquw==
-
 tsconfig-paths-webpack-plugin@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-3.2.0.tgz#6e70bd42915ad0efb64d3385163f0c1270f3e04d"
@@ -18976,58 +18949,13 @@ yaml@^1.7.2:
   dependencies:
     "@babel/runtime" "^7.6.3"
 
-yargs-parser@10.x, yargs-parser@^10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
-  integrity sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==
-  dependencies:
-    camelcase "^4.1.0"
-
-yargs-parser@^11.1.1:
-  version "11.1.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-11.1.1.tgz#879a0865973bca9f6bab5cbdf3b1c67ec7d3bcf4"
-  integrity sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==
+yargs-parser@10.x, yargs-parser@^10.1.0, yargs-parser@^11.1.1, yargs-parser@^13.1.0, yargs-parser@^13.1.1, yargs-parser@^15.0.0, yargs-parser@^16.1.0, yargs-parser@^18.1.3, yargs-parser@^4.2.0, yargs-parser@^9.0.2:
+  version "18.1.3"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
+  integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
-
-yargs-parser@^13.1.0, yargs-parser@^13.1.1:
-  version "13.1.2"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
-  integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
-
-yargs-parser@^15.0.0:
-  version "15.0.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.1.tgz#54786af40b820dcb2fb8025b11b4d659d76323b3"
-  integrity sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
-
-yargs-parser@^16.1.0:
-  version "16.1.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-16.1.0.tgz#73747d53ae187e7b8dbe333f95714c76ea00ecf1"
-  integrity sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
-
-yargs-parser@^4.2.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-4.2.1.tgz#29cceac0dc4f03c6c87b4a9f217dd18c9f74871c"
-  integrity sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=
-  dependencies:
-    camelcase "^3.0.0"
-
-yargs-parser@^9.0.2:
-  version "9.0.2"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
-  integrity sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=
-  dependencies:
-    camelcase "^4.1.0"
 
 yargs@12.0.1:
   version "12.0.1"


### PR DESCRIPTION
## Description

Rewrite request.ts without using Ramda methods. This only saves ~2K from the final build bundle size, so it may not be worth it. otoh, fewer dependencies means fewer vulnerabilities/upgrades/management issues, and in this case we were only using a handful of methods.

The tests pass with the new refactor, but I'm not sure that every possible case is handled. Please check the app to make sure requests are being made properly, including more complicated cases such as pagination, filtering, etc.