### PR TITLE
M3-2868: Creating Domains with DNS records created from Linodes with no IPv6

### DIFF
--- a/packages/manager/src/features/Domains/DomainDrawer.test.tsx
+++ b/packages/manager/src/features/Domains/DomainDrawer.test.tsx
@@ -29,7 +29,7 @@ request.createDomainRecord = jest.fn().mockResolvedValue({
 const testDomain = 'example.com';
 const testDomainID = testLinode.id;
 const testIPv4 = testLinode.ipv4[0];
-const testIPv6 = testLinode.ipv6;
+const nullTestIPv6 = testLinode.ipv6;
 
 const notNullTestIPv6 = '2600:3c03:e000:3cb::2';
 
@@ -39,7 +39,7 @@ describe('Do not force IPv6 creation', () => {
       testDomain,
       testDomainID,
       testIPv4,
-      testIPv6
+      nullTestIPv6
     );
 
     // Because testIPv6 = null, generateDefaultDomainRecords() should only return the 3 baseIPv4Requests and skip the creation of the other 4 records for IPv6.

--- a/packages/manager/src/features/Domains/DomainDrawer.test.tsx
+++ b/packages/manager/src/features/Domains/DomainDrawer.test.tsx
@@ -9,7 +9,22 @@ const testLinode = linodeFactory.build({
   ipv6: null
 });
 
-jest.mock('linode-js-sdk/lib/domains');
+const request = require.requireMock('@linode/api-v4/lib/domains');
+jest.mock('@linode/api-v4/lib/domains');
+
+request.createDomainRecord = jest.fn().mockResolvedValue({
+  id: 2,
+  name: 'TestRecord',
+  port: 80,
+  priority: 1,
+  protocol: null,
+  service: null,
+  tag: null,
+  target: 'example.com',
+  ttl_sec: 100,
+  type: 'AAAA',
+  weight: 1
+});
 
 const testDomain = 'example.com';
 const testDomainID = testLinode.id;

--- a/packages/manager/src/features/Domains/DomainDrawer.test.tsx
+++ b/packages/manager/src/features/Domains/DomainDrawer.test.tsx
@@ -1,0 +1,45 @@
+import { cleanup } from '@testing-library/react';
+import { linodeFactory } from 'src/factories/linodes';
+
+import { generateDefaultDomainRecords } from './DomainDrawer';
+
+afterEach(cleanup);
+
+const testLinode = linodeFactory.build({
+  ipv6: null
+});
+
+jest.mock('linode-js-sdk/lib/domains');
+
+const testDomain = 'example.com';
+const testDomainID = testLinode.id;
+const testIPv4 = testLinode.ipv4[0];
+const testIPv6 = testLinode.ipv6;
+
+const notNullTestIPv6 = '2600:3c03:e000:3cb::2';
+
+describe('Do not force IPv6 creation', () => {
+  it('should not make IPv6 records for DNS records being created from a Linode with no IPv6', async () => {
+    const testDefaultDomainRecords = await generateDefaultDomainRecords(
+      testDomain,
+      testDomainID,
+      testIPv4,
+      testIPv6
+    );
+
+    // Because testIPv6 = null, generateDefaultDomainRecords() should only return the 3 baseIPv4Requests and skip the creation of the other 4 records for IPv6.
+    expect(testDefaultDomainRecords.length).toBe(3);
+  });
+
+  it('should make IPv6 records for DNS records being created from a Linode with an IPv6', async () => {
+    const testDefaultDomainRecords = await generateDefaultDomainRecords(
+      testDomain,
+      testDomainID,
+      testIPv4,
+      notNullTestIPv6
+    );
+
+    // Because testIPv6 is not null or undefined, generateDefaultDomainRecords() should return the 3 baseIPv4Requests and create the other 4 records for IPv6.
+    expect(testDefaultDomainRecords.length).toBe(7);
+  });
+});

--- a/packages/manager/src/features/Domains/DomainDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainDrawer.tsx
@@ -100,11 +100,11 @@ type CombinedProps = WithStyles<ClassNames> &
   StateProps &
   WithSnackbarProps;
 
-const generateDefaultDomainRecords = (
+export const generateDefaultDomainRecords = (
   domain: string,
   domainID: number,
   ipv4?: string,
-  ipv6?: string
+  ipv6?: string | null
 ) => {
   /**
    * at this point, the IPv6 is including the prefix and we need to strip that


### PR DESCRIPTION
## Description
To offer a concise explanation, there are Linodes that do not have IPv6 enabled.

When a user does: Add a Domain --> Insert Default Records: Insert default records from one of my Linodes, if the Linode they choose does not have an IPv6 record, the Domain that is subsequently created should not have an IPv6 that is force-created for it.

To prove that this behavior is taking place, I created the tests in `DomainDrawer.test.tsx`. The expected results are:

- If the IPv6 value is null, only the 3 base IPv4 records should be created.
- If the IPv6 value is not null and not undefined, the 3 base IPv4 records + 4 IPv6-related records should be created (so 7 records total).

I also made a small change to the ipv6 parameter type for `generateDefaultDomainRecords()` in `DomainDrawer.tsx`, so that it can be `null` also. 

## Type of Change
- Non breaking change ('update', 'change')

## Tests
`yarn test DomainDrawer.test.tsx`

## Note to Reviewers
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.