### PR TITLE
Copy fix for Profile -> Referrals 

### DIFF
--- a/packages/manager/src/features/Profile/Referrals/Referrals.tsx
+++ b/packages/manager/src/features/Profile/Referrals/Referrals.tsx
@@ -63,7 +63,7 @@ class Referrals extends React.Component<CombinedProps, {}> {
           <Grid item xs={12}>
             <Typography>
               Referrals reward you when you refer people to Linode. If someone
-              signs up using your referral code, you'll receive a credit of
+              signs up using your referral code, you&apos;ll receive a credit of
               $20.00, so long as the person you referred remains an active
               customer for 90 days and spends a minimum of $15.
             </Typography>
@@ -75,7 +75,7 @@ class Referrals extends React.Component<CombinedProps, {}> {
               <Grid item>
                 <Typography variant="h3" className={classes.results}>
                   You have {total} total referrals: {completed} completed ($
-                  {credit} ) and {pending} pending.
+                  {credit}) and {pending} pending.
                 </Typography>
               </Grid>
               <Grid item xs={12}>


### PR DESCRIPTION
## Description

Remove space before parenthesis. Also escaped apostrophe according to linter.

<img width="482" alt="Screen Shot 2020-05-19 at 4 39 13 PM" src="https://user-images.githubusercontent.com/16911484/82375893-490c5580-99ef-11ea-898f-f97d91b86bdf.png">

