### PR TITLE
[FW] Fix bug with ICMP ports

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
@@ -108,12 +108,6 @@ const FirewallRuleDrawer: React.FC<CombinedProps> = props => {
       addresses
     };
 
-    // The API will return an error if a `ports` attribute is present on a payload for an ICMP rule,
-    // so we do a bit of trickery here and delete it if necessary.
-    if (protocol === 'ICMP' && ports === '') {
-      delete payload.ports;
-    }
-
     props.onSubmit(category, payload);
     onClose();
   };
@@ -141,8 +135,8 @@ const FirewallRuleDrawer: React.FC<CombinedProps> = props => {
         }}
       </Formik>
       <Typography variant="body1">
-        Rule changes don't take effect immediately. You can add or delete rules
-        before saving all your changes to this Firewall.
+        Rule changes don&apos;t take effect immediately. You can add or delete
+        rules before saving all your changes to this Firewall.
       </Typography>
     </Drawer>
   );
@@ -198,12 +192,13 @@ const FirewallRuleForm: React.FC<FirewallRuleFormProps> = React.memo(props => {
   // Set form field errors for each error we have (except "addresses" errors, which are handled
   // by IP Error state).
   React.useEffect(() => {
+    // eslint-disable-next-line no-unused-expressions
     ruleErrors?.forEach(thisError => {
       if (thisError.formField !== 'addresses') {
         setFieldError(thisError.formField, thisError.reason);
       }
     });
-  }, [ruleErrors]);
+  }, [ruleErrors, setFieldError]);
 
   // These handlers are all memoized because the form was laggy when I tried them inline.
   const handleTypeChange = React.useCallback((item: Item | null) => {
@@ -237,7 +232,7 @@ const FirewallRuleForm: React.FC<FirewallRuleFormProps> = React.memo(props => {
 
       setFieldValue('protocol', item?.value);
     },
-    [formTouched]
+    [formTouched, setFieldValue]
   );
 
   const handleAddressesChange = React.useCallback(
@@ -250,7 +245,7 @@ const FirewallRuleForm: React.FC<FirewallRuleFormProps> = React.memo(props => {
       // Reset custom IPs
       setIPs([{ address: '' }]);
     },
-    [ips, formTouched]
+    [formTouched, setFieldValue, setFormTouched, setIPs]
   );
 
   const handlePortsChange = React.useCallback(
@@ -260,7 +255,7 @@ const FirewallRuleForm: React.FC<FirewallRuleFormProps> = React.memo(props => {
       }
       handleChange(e);
     },
-    [formTouched]
+    [formTouched, handleChange]
   );
 
   const handleIPChange = React.useCallback(
@@ -270,7 +265,7 @@ const FirewallRuleForm: React.FC<FirewallRuleFormProps> = React.memo(props => {
       }
       setIPs(_ips);
     },
-    [formTouched, ips]
+    [formTouched, setIPs]
   );
 
   const addressesValue = React.useMemo(() => {
@@ -284,7 +279,7 @@ const FirewallRuleForm: React.FC<FirewallRuleFormProps> = React.memo(props => {
   const typeValue = React.useMemo(() => {
     const _type = deriveTypeFromValuesAndIPs(values, ips);
     return typeOptions.find(thisOption => thisOption.value === _type) || null;
-  }, [values, ips, typeOptions]);
+  }, [values, ips]);
 
   return (
     <form onSubmit={handleSubmit}>
@@ -517,6 +512,7 @@ export const getInitialIPs = (
     ...addresses?.ipv6?.map(stringToExtendedIP)
   ];
 
+  // eslint-disable-next-line no-unused-expressions
   ruleToModify.errors?.forEach(thisError => {
     const { formField, ip } = thisError;
 

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/firewallRuleEditor.test.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/firewallRuleEditor.test.ts
@@ -2,7 +2,8 @@ import { last } from 'ramda';
 import { firewallRuleFactory } from 'src/factories/firewalls';
 import reducer, {
   editorStateToRules,
-  initRuleEditorState
+  initRuleEditorState,
+  prepareRules
 } from './firewallRuleEditor';
 
 const INITIAL_RULE_LENGTH = 2;
@@ -150,6 +151,21 @@ describe('Rule Editor', () => {
       rulesWithoutStatus.forEach(thisRule => {
         expect(thisRule).toBeDefined();
       });
+    });
+  });
+
+  describe('prepareRules', () => {
+    it('removes the `ports` field for ICMP rules if `ports` is an empty string', () => {
+      const rules = [
+        firewallRuleFactory.build({ protocol: 'ICMP', ports: '1234' }),
+        firewallRuleFactory.build({ protocol: 'ICMP', ports: '' }),
+        firewallRuleFactory.build({ protocol: 'TCP', ports: '' })
+      ];
+      const editorState = initRuleEditorState(rules);
+      const result = prepareRules(editorState);
+      expect(result[0]).toHaveProperty('ports', '1234');
+      expect(result[1]).not.toHaveProperty('ports');
+      expect(result[2]).toHaveProperty('ports', '');
     });
   });
 });

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/firewallRuleEditor.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/firewallRuleEditor.ts
@@ -170,6 +170,16 @@ export const stripExtendedFields = (
   rule: ExtendedFirewallRule
 ): FirewallRuleType => omit(['errors', 'status', 'index'], rule);
 
+// The API will return an error if a `ports` attribute is present on a payload for an ICMP rule,
+// so we do a bit of trickery here and delete it if necessary.
+export const removeICMPPort = (rules: ExtendedFirewallRule[]) =>
+  rules.map(thisRule => {
+    if (thisRule.protocol === 'ICMP' && thisRule.ports === '') {
+      delete thisRule.ports;
+    }
+    return thisRule;
+  });
+
 export const filterRulesPendingDeletion = (rules: ExtendedFirewallRule[]) =>
   rules.filter(thisRule => thisRule.status !== 'PENDING_DELETION');
 
@@ -177,6 +187,7 @@ export const appendIndex = (rules: ExtendedFirewallRule[]) =>
   rules.map((thisRule, index) => ({ ...thisRule, index }));
 
 export const prepareRules = compose(
+  removeICMPPort,
   filterRulesPendingDeletion,
   appendIndex,
   editorStateToRules


### PR DESCRIPTION
## Description

This fixes a bug where editing an existing non-ICMP rule will fail, since the port doesn't get cleared at the correct step in the pipeline.

Also fixed some linting errors and added a test case.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')


## Note to Reviewers

To reproduce the bug:

1. Create a non-ICMP rule with a value for "Port Range".
2. After creating that rule, refresh the page and edit it.
3. Change the protocol to ICMP and clear out the "Port Range" input.
4. Click "Edit Rule".
5. Observe: the "Port Range" has not be cleared in the Rule Table.
6. Click "Apply Changes"
7. Observe: an error explains that ICMP protocols must not have a port range.
