### PR TITLE
[for release] Fix c.match Sentry error

### DIFF
--- a/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
+++ b/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
@@ -69,10 +69,9 @@ export class AuthenticationWrapper extends React.Component<CombinedProps> {
 
     try {
       await Promise.all(dataFetchingPromises);
-      this.props.markAppAsDoneLoading();
-      this.makeSecondaryRequests();
     } catch {
       /** We choose to do nothing, relying on the Redux error state. */
+    } finally {
       this.props.markAppAsDoneLoading();
       this.makeSecondaryRequests();
     }

--- a/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
+++ b/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
@@ -83,17 +83,23 @@ export class AuthenticationWrapper extends React.Component<CombinedProps> {
    * splash screen, since they aren't needed
    * for navigation, basic display, etc.
    */
-  makeSecondaryRequests = () => {
-    this.props.requestLinodes();
-    this.props.requestTypes();
-    /**
-     * We have cached Regions data that can be used
-     * until the real data comes in; the only
-     * likely difference will be the status of each
-     * Region.
-     */
-    this.props.requestRegions();
-    this.props.requestNotifications();
+  makeSecondaryRequests = async () => {
+    try {
+      await Promise.all([
+        this.props.requestLinodes(),
+        this.props.requestTypes(),
+        /**
+         * We have cached Regions data that can be used
+         * until the real data comes in; the only
+         * likely difference will be the status of each
+         * Region.
+         */
+        this.props.requestRegions(),
+        this.props.requestNotifications()
+      ]);
+    } catch {
+      /** We choose to do nothing, relying on the Redux error state. */
+    }
   };
 
   componentDidMount() {

--- a/packages/manager/src/exceptionReporting.ts
+++ b/packages/manager/src/exceptionReporting.ts
@@ -17,7 +17,9 @@ const errorsToIgnore: string[] = [
 ];
 
 window.addEventListener('unhandledrejection', event => {
-  const stack: string = event?.reason?.stack ?? '';
+  const _stack = event?.reason?.stack;
+  // Enforce that `stack` is a string.
+  const stack = typeof _stack === 'string' ? _stack : '';
 
   if (stack.match(/launchdarkly/i)) {
     /**
@@ -27,7 +29,9 @@ window.addEventListener('unhandledrejection', event => {
     return;
   }
 
-  const firstReason = event.reason?.[0]?.reason ?? '';
+  const _firstReason = event.reason?.[0]?.reason;
+  // Enforce that `firstReason` is a string.
+  const firstReason = typeof _firstReason === 'string' ? _firstReason : '';
 
   /*
     if our error is an error we want to ignore, don't report to Sentry
@@ -64,11 +68,12 @@ export const reportException = (
 
   // Log the error to the console in non-production environments.
   if (process.env.NODE_ENV !== 'production') {
-    /* tslint:disable */
+    /* eslint-disable */
     console.error('====================================');
     console.error(error);
     console.log(extra);
     console.error('====================================');
+    /* eslint-enable */
   }
 
   // Create a local scope so we can add `extra` and `tags` to this specific


### PR DESCRIPTION
## Description

This addresses the `Cannot read property "c" of undefined` errors we were seeing with 1.9.0. This was a multi-part problem/solution.

- `exceptionReporting.ts` was throwing this error because we were trying to call `firstReason.match()`. We thought `firstReason` was a string, but sometimes it was an object. 
- **Why was it sometimes an Object?** Because we replace some error messages with... React components. I'd like to change this eventually, but for now, the fix was make sure `firstReason` is always a string.
- **But where were the unhandled rejections coming from?**  They were coming from unactivated users requesting Linodes and other _secondary request_ things. The problem is promise rejections happening in`makeSecondaryRequests()` are unhandled.
- To fix this, I added a Promise.all with a try/catch in `makeSecondaryRequests` (AuthenticationWraper.tsx)
- Also refactored `makePrimaryRequests` to use the try/catch/finally pattern for less repeated code.

To test the original error, log in as an unactivated user. Message for details.