### PR TITLE
Accessibility: fix textfield to use inputid for "for" attribute

### DIFF
--- a/packages/manager/cypress/integration/nodebalancers/smoke-create-nodebal.spec.js
+++ b/packages/manager/cypress/integration/nodebalancers/smoke-create-nodebal.spec.js
@@ -1,89 +1,98 @@
-
 import {
   deleteNodeBalancerByLabel,
   makeNodeBalLabel,
-  makeNodeBalCreateReq,
   testNodeBalTag
 } from '../../support/api/nodebalancers';
 import {
-    makeLinodeLabel,
-    createLinode,
-    deleteLinodeById
+  makeLinodeLabel,
+  createLinode,
+  deleteLinodeById
 } from '../../support/api/linodes';
 
-const deployNodeBalancer = ()=>{
-// This is not an error, the tag is deploy-linode
-cy.get('[data-qa-deploy-linode]').click();
+const deployNodeBalancer = () => {
+  // This is not an error, the tag is deploy-linode
+  cy.get('[data-qa-deploy-linode]').click();
 };
-const createNodeBalancerWithUI = (nodeBal) =>{
-    cy.visitWithLogin('/nodebalancers/create');
-    cy.findByText('NodeBalancer Settings');
-    cy.findByLabelText('NodeBalancer Label').click().type(nodeBal.label);
-    cy.contains('create a tag').click().type(testNodeBalTag);
-    // this will create the NB in newark, where the default Linode was created
-    cy.contains('Regions')
+const createNodeBalancerWithUI = nodeBal => {
+  cy.visitWithLogin('/nodebalancers/create');
+  cy.findByText('NodeBalancer Settings');
+  cy.findByLabelText('NodeBalancer Label')
+    .click()
+    .type(nodeBal.label);
+  cy.contains('create a tag')
+    .click()
+    .type(testNodeBalTag);
+  // this will create the NB in newark, where the default Linode was created
+  cy.contains('Regions')
     .click()
     .type('new {enter}');
 
-    // node backend config
-    cy.findByLabelText('Label').click().type(makeLinodeLabel());
-    cy.contains('Enter IP Address').click().type(`${nodeBal.linodePrivateIp}{enter}`);
-    deployNodeBalancer();
+  // node backend config
+  cy.findByLabelText('Label')
+    .click()
+    .type(makeLinodeLabel());
+  cy.contains('Enter IP Address')
+    .click()
+    .type(`${nodeBal.linodePrivateIp}{enter}`);
+  deployNodeBalancer();
 };
 
 describe('create NodeBalancer', () => {
-
   it('creates a nodebal - positive', () => {
-
     // create a linode in NW where the NB will be created
-    createLinode().then(linode=>{
-        const nodeBal={
-            label:makeNodeBalLabel(),
-            linodePrivateIp: linode.ipv4[1]
-            
-        };
+    createLinode().then(linode => {
+      const nodeBal = {
+        label: makeNodeBalLabel(),
+        linodePrivateIp: linode.ipv4[1]
+      };
 
-    cy.server();
-    cy.route({
-      method: 'POST',
-      url: '*/nodebalancers'
-    }).as('createNodeBalancer');
-        createNodeBalancerWithUI(nodeBal);
-        cy.wait('@createNodeBalancer')
-            .its('status')
-            .should('be', 200);
-    
-        deleteNodeBalancerByLabel(nodeBal.label);
-        deleteLinodeById(linode.id);
+      cy.server();
+      cy.route({
+        method: 'POST',
+        url: '*/nodebalancers'
+      }).as('createNodeBalancer');
+      createNodeBalancerWithUI(nodeBal);
+      cy.wait('@createNodeBalancer')
+        .its('status')
+        .should('be', 200);
+
+      deleteNodeBalancerByLabel(nodeBal.label);
+      deleteLinodeById(linode.id);
     });
   });
-  it('API error Handling',()=>{
-    createLinode().then(linode=>{
-    cy.server();
-    cy.route({
-      method: 'POST',
-      url: '*/nodebalancers'
-    }).as('createNodeBalancer');
-    createNodeBalancerWithUI({
-        label:'cy-test-dfghjk^uu7',
+  it('API error Handling', () => {
+    createLinode().then(linode => {
+      cy.server();
+      cy.route({
+        method: 'POST',
+        url: '*/nodebalancers'
+      }).as('createNodeBalancer');
+      createNodeBalancerWithUI({
+        label: 'cy-test-dfghjk^uu7',
         linodePrivateIp: linode.ipv4[1]
-    });
-    cy.findByText(`Label can't contain special characters or spaces.`).should('be.visible');
-    cy.findByLabelText('NodeBalancer Label').click().clear().type(makeNodeBalLabel());
-    cy.get('[data-qa-protocol-select]').click().type('TCP{enter}');
-    cy.get('[data-qa-session-stickiness-select]').click().type('HTTP Cookie{enter}');
-    deployNodeBalancer();
-    const errMessage = `Stickiness http_cookie requires protocol 'http' or 'https'`;
-    cy.wait('@createNodeBalancer')
+      });
+      cy.findByText(`Label can't contain special characters or spaces.`).should(
+        'be.visible'
+      );
+      cy.findByLabelText('NodeBalancer Label')
+        .click()
+        .clear()
+        .type(makeNodeBalLabel());
+      cy.get('[data-qa-protocol-select]')
+        .click()
+        .type('TCP{enter}');
+      cy.get('[data-qa-session-stickiness-select]')
+        .click()
+        .type('HTTP Cookie{enter}');
+      deployNodeBalancer();
+      const errMessage = `Stickiness http_cookie requires protocol 'http' or 'https'`;
+      cy.wait('@createNodeBalancer')
         .its('response.body')
         .should('deep.equal', {
-            errors:[
-                {field:'configs[0].stickiness',reason:errMessage}
-            ]
+          errors: [{ field: 'configs[0].stickiness', reason: errMessage }]
+        });
+      cy.findByText(errMessage).should('be.visible');
+      deleteLinodeById(linode.id);
     });
-    cy.findByText(errMessage).should('be.visible');
-    deleteLinodeById(linode.id);
-
   });
-});
 });

--- a/packages/manager/src/components/TextField.tsx
+++ b/packages/manager/src/components/TextField.tsx
@@ -252,7 +252,11 @@ class LinodeTextField extends React.PureComponent<CombinedProps> {
     const maybeRequiredLabel = !!this.props.required
       ? `${label} (required)`
       : label;
-
+    const validInputId =
+      inputId ||
+      (this.props.label
+        ? convertToKebabCase(`${this.props.label}`)
+        : undefined);
     return (
       <div
         className={classNames({
@@ -268,13 +272,9 @@ class LinodeTextField extends React.PureComponent<CombinedProps> {
               [classes.noTransform]: true,
               'visually-hidden': hideLabel
             })}
-            htmlFor={
-              this.props.label
-                ? convertToKebabCase(`${this.props.label}`)
-                : undefined
-            }
+            htmlFor={validInputId}
           >
-            {maybeRequiredLabel || ''}
+            {maybeRequiredLabel}
           </InputLabel>
         )}
         {helperText && helperTextPosition === 'top' && (
@@ -315,11 +315,7 @@ class LinodeTextField extends React.PureComponent<CombinedProps> {
             }}
             inputProps={{
               'data-testid': 'textfield-input',
-              id:
-                inputId ||
-                (this.props.label
-                  ? convertToKebabCase(`${this.props.label}`)
-                  : undefined),
+              id: validInputId,
               ...inputProps
             }}
             InputProps={{


### PR DESCRIPTION
## Description

Since https://github.com/linode/manager/pull/6356/files
we fixed the fact that Ids of the different configs when creating a NB where not the same,
Although as a consequence i think the `for="label"` part was forgotten.

Try to create a NodeBal: https://cloud.linode.com/nodebalancers/create
Look at this field. It cannot be found by label
![image](https://user-images.githubusercontent.com/27222128/82495962-efbd2880-9ab9-11ea-94ed-ddc4c11859a0.png)

Before
![image](https://user-images.githubusercontent.com/27222128/82495844-bf758a00-9ab9-11ea-92b5-cb78af099737.png)


After
![image](https://user-images.githubusercontent.com/27222128/82495778-9fde6180-9ab9-11ea-809e-02953bead82f.png)


This fixes the e2e that used the label to find the input
## Type of Change
- Bug fix ('fix', 'repair', 'bug')


Test e2e with `yarn cy:e2e --spec "./**/*nodebal.spec.js"` (assuming `yarn up` is running)