### PR TITLE
[for release] Dismiss TPA modal

### DIFF
--- a/packages/manager/src/features/Profile/AuthenticationSettings/ThirdPartyDialog.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/ThirdPartyDialog.tsx
@@ -87,13 +87,14 @@ const renderActions = (
         aria-describedby="external-site"
         buttonType="primary"
         loading={loading}
-        onClick={() =>
+        onClick={() => {
+          onClose();
           window.open(
             `${LOGIN_ROOT}/tpa/enable/` + `${provider}`,
             '_blank',
             'noopener'
-          )
-        }
+          );
+        }}
         data-qa-confirm
         data-testid={'dialog-confirm'}
       >


### PR DESCRIPTION
## Description

Small adjustment here. This dismisses the TPA modal when "Go to GitHub" is clicked. The ideal flow is a complete circle in the same tab, but until then, this at least makes it so that the modal isn't still open when you navigate back to your Cloud Manager tab after enabling TPA.