### PR TITLE
Fix: duplicate instances requests

### DIFF
--- a/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.test.tsx
+++ b/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.test.tsx
@@ -12,6 +12,8 @@ window.location.assign = jest.fn();
 const component = shallow<AuthenticationWrapper>(
   <AuthenticationWrapper
     isAuthenticated={false}
+    linodesLastUpdated={0}
+    linodesLoading={false}
     initSession={jest.fn()}
     requestAccount={jest.fn()}
     requestTypes={jest.fn()}

--- a/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
+++ b/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
@@ -83,9 +83,13 @@ export class AuthenticationWrapper extends React.Component<CombinedProps> {
    * for navigation, basic display, etc.
    */
   makeSecondaryRequests = async () => {
+    const { linodesLoading, linodesLastUpdated, requestLinodes } = this.props;
+    if (!linodesLoading && linodesLastUpdated === 0) {
+      // Only request Linodes if we haven't done that somewhere else already
+      requestLinodes().catch(_ => null);
+    }
     try {
       await Promise.all([
-        this.props.requestLinodes(),
         this.props.requestTypes(),
         /**
          * We have cached Regions data that can be used
@@ -154,10 +158,14 @@ export class AuthenticationWrapper extends React.Component<CombinedProps> {
 
 interface StateProps {
   isAuthenticated: boolean;
+  linodesLoading: boolean;
+  linodesLastUpdated: number;
 }
 
 const mapStateToProps: MapState<StateProps, {}> = state => ({
-  isAuthenticated: Boolean(state.authentication.token)
+  isAuthenticated: Boolean(state.authentication.token),
+  linodesLoading: state.__resources.linodes.loading,
+  linodesLastUpdated: state.__resources.linodes.lastUpdated
 });
 
 interface DispatchProps {

--- a/packages/manager/src/containers/withBackupCTA.container.ts
+++ b/packages/manager/src/containers/withBackupCTA.container.ts
@@ -5,7 +5,7 @@ export interface BackupCTAProps {
   backupsCTA: boolean;
 }
 
-export default connect((state: ApplicationState, ownProps) => ({
+export default connect((state: ApplicationState) => ({
   backupsCTA:
     Object.values(state.__resources.linodes.itemsById).some(
       l => !l.backups.enabled

--- a/packages/manager/src/features/Backups/BackupsCTA.tsx
+++ b/packages/manager/src/features/Backups/BackupsCTA.tsx
@@ -81,8 +81,8 @@ const BackupsCTA: React.StatelessComponent<CombinedProps> = props => {
         </Grid>
         <Grid item>
           <Typography>
-            We've got your back! Click below to enable Backups for all Linodes,
-            and be sure to read our guide on Backups{` `}
+            We&#39;ve got your back! Click below to enable Backups for all
+            Linodes, and be sure to read our guide on Backups{` `}
             <a
               target="_blank"
               aria-describedby="external-site"
@@ -129,15 +129,12 @@ interface DispatchProps {
   };
 }
 
-const mapStateToProps: MapState<StateProps, {}> = (state, ownProps) => ({
+const mapStateToProps: MapState<StateProps, {}> = state => ({
   linodesWithoutBackups: getLinodesWithoutBackups(state.__resources),
   managed: state?.__resources?.accountSettings?.data?.managed ?? false
 });
 
-const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
-  dispatch,
-  ownProps
-) => {
+const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = dispatch => {
   return {
     actions: {
       openBackupsDrawer: () => dispatch(handleOpen())

--- a/packages/manager/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
@@ -66,7 +66,7 @@ type CombinedProps = ConnectedProps & WithUpdatingLinodesProps & WithTypesProps;
 const LinodesDashboardCard: React.FC<CombinedProps> = props => {
   const classes = useStyles();
 
-  const { _loading } = useReduxLoad(['images']);
+  const { _loading } = useReduxLoad(['linodes', 'images']);
 
   const renderAction = () => {
     return props.linodeCount > 5 ? (

--- a/packages/manager/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
@@ -8,12 +8,7 @@ import { Link } from 'react-router-dom';
 import { compose as recompose } from 'recompose';
 import Hidden from 'src/components/core/Hidden';
 import Paper from 'src/components/core/Paper';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles
-} from 'src/components/core/styles';
+import { makeStyles } from 'src/components/core/styles';
 import Table from 'src/components/core/Table';
 import TableBody from 'src/components/core/TableBody';
 import TableCell from 'src/components/core/TableCell';
@@ -40,50 +35,38 @@ interface EntityEvent extends Omit<Event, 'entity'> {
   entity: Entity;
 }
 
-type ClassNames =
-  | 'root'
-  | 'linodeWrapper'
-  | 'labelCol'
-  | 'moreCol'
-  | 'actionsCol'
-  | 'wrapHeader';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {
-      marginTop: 0
-    },
-    linodeWrapper: {
-      display: 'inline-flex',
-      width: 'auto'
-    },
-    labelCol: {
-      width: '60%'
-    },
-    moreCol: {
-      width: '30%'
-    },
-    actionsCol: {
-      width: '10%'
-    },
-    wrapHeader: {
-      whiteSpace: 'nowrap'
-    }
-  });
+const useStyles = makeStyles(() => ({
+  root: {
+    marginTop: 0
+  },
+  linodeWrapper: {
+    display: 'inline-flex',
+    width: 'auto'
+  },
+  labelCol: {
+    width: '60%'
+  },
+  moreCol: {
+    width: '30%'
+  },
+  actionsCol: {
+    width: '10%'
+  },
+  wrapHeader: {
+    whiteSpace: 'nowrap'
+  }
+}));
 
 interface ConnectedProps {
   types: LinodeType[];
 }
 
-type CombinedProps = ConnectedProps &
-  WithUpdatingLinodesProps &
-  WithTypesProps &
-  WithStyles<ClassNames>;
+type CombinedProps = ConnectedProps & WithUpdatingLinodesProps & WithTypesProps;
 
 const LinodesDashboardCard: React.FC<CombinedProps> = props => {
-  const { classes } = props;
+  const classes = useStyles();
 
-  const { _loading } = useReduxLoad(['linodes', 'images']);
+  const { _loading } = useReduxLoad(['images']);
 
   const renderAction = () => {
     return props.linodeCount > 5 ? (
@@ -193,13 +176,12 @@ const LinodesDashboardCard: React.FC<CombinedProps> = props => {
     </DashboardCard>
   );
 };
-const styled = withStyles(styles);
 
 interface WithTypesProps {
   typesData: LinodeType[];
 }
 
-const withTypes = connect((state: ApplicationState, ownProps) => ({
+const withTypes = connect((state: ApplicationState) => ({
   typesData: state.__resources.types.entities
 }));
 
@@ -214,7 +196,7 @@ interface WithUpdatingLinodesProps {
   error?: APIError[];
 }
 
-const withUpdatingLinodes = connect((state: ApplicationState, ownProps: {}) => {
+const withUpdatingLinodes = connect((state: ApplicationState) => {
   const linodes = Object.values(state.__resources.linodes.itemsById);
   const notifications = state.__resources.notifications.data || [];
 
@@ -260,10 +242,6 @@ const isWantedEvent = (e: Event): e is EntityEvent => {
   return false;
 };
 
-const enhanced = recompose<CombinedProps, {}>(
-  withUpdatingLinodes,
-  styled,
-  withTypes
-);
+const enhanced = recompose<CombinedProps, {}>(withUpdatingLinodes, withTypes);
 
 export default enhanced(LinodesDashboardCard) as React.ComponentType<{}>;

--- a/packages/manager/src/features/Dashboard/ManagedDashboardCard/ManagedDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/ManagedDashboardCard/ManagedDashboardCard.tsx
@@ -208,9 +208,6 @@ const LoadingErrorOrContent: React.FC<ContentProps> = props => {
   );
 };
 
-const enhanced = compose<CombinedProps, {}>(
-  withManaged(),
-  withManagedIssues()
-);
+const enhanced = compose<CombinedProps, {}>(withManaged(), withManagedIssues());
 
 export default enhanced(ManagedDashboardCard);

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -312,7 +312,7 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
                               </Hidden>
 
                               <AddNewLink
-                                onClick={e => {
+                                onClick={_ => {
                                   this.props.history.push('/linodes/create');
                                 }}
                                 label="Add a Linode"
@@ -468,7 +468,7 @@ interface StateProps {
   someLinodesHaveScheduledMaintenance: boolean;
 }
 
-const mapStateToProps: MapState<StateProps, {}> = (state, ownProps) => {
+const mapStateToProps: MapState<StateProps, {}> = state => {
   const linodes = Object.values(state.__resources.linodes.itemsById);
   const notifications = state.__resources.notifications.data || [];
 

--- a/packages/manager/src/hooks/useReduxLoad.ts
+++ b/packages/manager/src/hooks/useReduxLoad.ts
@@ -90,7 +90,7 @@ export const useReduxLoad = (
     if (predicate && mountedRef.current) {
       requestDeps(state, dispatch, deps, refreshInterval, _setLoading);
     }
-  }, [predicate, mountedRef.current]);
+  }, [predicate, refreshInterval]);
 
   useEffect(() => {
     return () => {
@@ -117,7 +117,10 @@ export const requestDeps = (
       if (currentResource.lastUpdated === 0 && !currentResource.loading) {
         needsToLoad = true;
         requests.push(requestMap[deps[i]]);
-      } else if (Date.now() - currentResource.lastUpdated > refreshInterval) {
+      } else if (
+        Date.now() - currentResource.lastUpdated > refreshInterval &&
+        !currentResource.loading
+      ) {
         requests.push(requestMap[deps[i]]);
       }
     }

--- a/packages/manager/src/store/linodes/linodes.reducer.ts
+++ b/packages/manager/src/store/linodes/linodes.reducer.ts
@@ -30,7 +30,7 @@ export type State = MappedEntityState2<
   EntityError
 >;
 
-export const defaultState: State = createDefaultState({}, {});
+export const defaultState: State = createDefaultState();
 
 /**
  * Reducer


### PR DESCRIPTION
## Description

3 requests were being made to linode/instances on the Dashboard for
users viewing the Backups card. An extra request was also made on Linodes
landing.

Two problems were causing this:

- The new secondaryRequests logic was calling requestLinodes()
unconditionally. This wasn't a problem when it was in initial requests,
but now other components can fire useReduxLoad before the secondary requests
happen, resulting in extras.

- useReduxLoad's logic is a little wonky; if two useReduxLoad's mount
at the same time, it's possible for them both to look at Redux state,
determine that something hasn't been requested yet, then queue that
thing for requesting. This was causing the third request on the Dashboard.

Short term fix (this commit):
- make secondaryRequests for Linodes conditional
- Add an !isloading check to the second condition in useReduxLoad

Longer term considerations:
- rework useReduxLoad to use entity hooks. I don't like the deps array
in there now, which is a consequence of passing dispatch and state
into the useEffect.

- consider a single instance of useReduxLoad instead of letting every
component instantiate it.

- Remove Linodes from the secondaryRequests block (we were considering
this anyway) and have components request it when needed. Since most
sections of the app require Linode data, it'll almost always be requested
on app load anyway.

## Note to Reviewers

Open the network tab of dev tools and filter for instances. Load the app from the dashboard, Linodes landing, and other random places. Only one set of requests to instances should happen.