### PR TITLE
Support for environment switcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ lib
 # local restart script with keys
 restart.sh
 
+# local switch script with client IDs
+switch.sh
+
 # dotenv environment variables file
 .env*
 *env.

--- a/packages/manager/scripts/pre-push.sh
+++ b/packages/manager/scripts/pre-push.sh
@@ -1,9 +1,19 @@
 #!/bin/bash
 
+RED='\033[0;31m'
+
+# Fail if there are staged temporary constants defined in packages/manager/src/constants.ts
+HAS_STAGED_CONSTANTS=$(git diff --name-only --cached | grep "constants.ts")
+HAS_TMP_CONSTANTS=$(grep -q "// TMP - REMOVE ME" src/constants.ts > /dev/null; echo $?)
+if [ $HAS_STAGED_CONSTANTS ] && [ $HAS_TMP_CONSTANTS -eq 0 ]; then
+    echo -e "\n\n${RED}Temporary constants must be removed or unstaged.\nCheck packages/manager/src/constants.ts\n\n"
+    exit 1
+fi
+
 # Confirm Branch includes M3 Ticket
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
 BRANCH_INCLUDES_TICKET=$(git rev-parse --abbrev-ref HEAD | egrep -i '(M3-[0-9]*)|feature|patch|staging|develop|testing|master|release-.*|OBJ.*|LKE.*|OCA.*')
-RED='\033[0;31m'
+
 
 if [ $BRANCH_INCLUDES_TICKET ]
 then
@@ -15,3 +25,4 @@ else
     echo -e "\nExample: \"M3-111-Feature\"\n"
     exit 1
 fi
+gi

--- a/packages/manager/scripts/pre-push.sh
+++ b/packages/manager/scripts/pre-push.sh
@@ -25,4 +25,3 @@ else
     echo -e "\nExample: \"M3-111-Feature\"\n"
     exit 1
 fi
-gi

--- a/packages/manager/scripts/pre-push.sh
+++ b/packages/manager/scripts/pre-push.sh
@@ -5,7 +5,7 @@ RED='\033[0;31m'
 # Fail if there are staged temporary constants defined in packages/manager/src/constants.ts
 HAS_STAGED_CONSTANTS=$(git diff --name-only --cached | grep "constants.ts")
 HAS_TMP_CONSTANTS=$(grep -q "// TMP - REMOVE ME" src/constants.ts > /dev/null; echo $?)
-if [ $HAS_STAGED_CONSTANTS ] && [ $HAS_TMP_CONSTANTS -eq 0 ]; then
+if [ "$HAS_STAGED_CONSTANTS" ] && [ "$HAS_TMP_CONSTANTS" -eq 0 ]; then
     echo -e "\n\n${RED}Temporary constants must be removed or unstaged.\nCheck packages/manager/src/constants.ts\n\n"
     exit 1
 fi
@@ -15,7 +15,7 @@ BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
 BRANCH_INCLUDES_TICKET=$(git rev-parse --abbrev-ref HEAD | egrep -i '(M3-[0-9]*)|feature|patch|staging|develop|testing|master|release-.*|OBJ.*|LKE.*|OCA.*')
 
 
-if [ $BRANCH_INCLUDES_TICKET ]
+if [ "$BRANCH_INCLUDES_TICKET" ]
 then
     exit 0
 else


### PR DESCRIPTION
## Description

This adds support for a new environment switcher script. A _very hacky_ environment switcher script.

The script injects the variables into `src/constants.ts` directly, so all you need to do is run the script and refresh the page. It's awful, but saves about 1 minute each time you switch environments.

This just adds an entry to gitignore and a block to the pre-push hook to warn you if you try to push temporary variables.

Msg me for the actual `switch.sh` script.