### PR TITLE
M3-3932 Change: Improve UX for GPU selection

### DIFF
--- a/packages/api-v4/src/regions/index.ts
+++ b/packages/api-v4/src/regions/index.ts
@@ -1,37 +1,3 @@
-import { API_ROOT } from 'src/constants';
-import Request, { setMethod, setURL } from 'src/request';
-import { ResourcePage as Page } from '../types';
-import { Region } from './types';
+export * from './regions';
 
-/**
- * getRegions
- *
- * Return a list of available Regions (datacenters).
- * The response will be paginated, but the number of
- * available regions is small enough that multiple
- * pages are unlikely to be necessary.
- *
- * Filters are not included, as none of the fields
- * in a Region response object are filterable.
- *
- */
-export const getRegions = () =>
-  Request<Page<Region>>(setURL(`${API_ROOT}/regions`), setMethod('GET')).then(
-    response => response.data
-  );
-
-/**
- * getRegion
- *
- * Return detailed information about a particular region.
- *
- * @param regionID { string } The region to be retrieved.
- *
- */
-export const getRegion = (regionID: string) =>
-  Request<Page<Region>>(
-    setURL(`${API_ROOT}/regions/${regionID}`),
-    setMethod('GET')
-  ).then(response => response.data);
-
-export { Region };
+export * from './types';

--- a/packages/api-v4/src/regions/regions.ts
+++ b/packages/api-v4/src/regions/regions.ts
@@ -1,0 +1,37 @@
+import { API_ROOT } from 'src/constants';
+import Request, { setMethod, setURL } from 'src/request';
+import { ResourcePage as Page } from '../types';
+import { Region } from './types';
+
+/**
+ * getRegions
+ *
+ * Return a list of available Regions (datacenters).
+ * The response will be paginated, but the number of
+ * available regions is small enough that multiple
+ * pages are unlikely to be necessary.
+ *
+ * Filters are not included, as none of the fields
+ * in a Region response object are filterable.
+ *
+ */
+export const getRegions = () =>
+  Request<Page<Region>>(setURL(`${API_ROOT}/regions`), setMethod('GET')).then(
+    response => response.data
+  );
+
+/**
+ * getRegion
+ *
+ * Return detailed information about a particular region.
+ *
+ * @param regionID { string } The region to be retrieved.
+ *
+ */
+export const getRegion = (regionID: string) =>
+  Request<Page<Region>>(
+    setURL(`${API_ROOT}/regions/${regionID}`),
+    setMethod('GET')
+  ).then(response => response.data);
+
+export { Region };

--- a/packages/api-v4/src/regions/types.ts
+++ b/packages/api-v4/src/regions/types.ts
@@ -3,7 +3,8 @@ export type Capabilities =
   | 'NodeBalancers'
   | 'Block Storage'
   | 'Object Storage'
-  | 'Kubernetes';
+  | 'Kubernetes'
+  | 'GPU';
 
 export type RegionStatus = 'ok' | 'outage';
 

--- a/packages/api-v4/src/regions/types.ts
+++ b/packages/api-v4/src/regions/types.ts
@@ -4,7 +4,7 @@ export type Capabilities =
   | 'Block Storage'
   | 'Object Storage'
   | 'Kubernetes'
-  | 'GPU';
+  | 'GPU Linodes';
 
 export type RegionStatus = 'ok' | 'outage';
 

--- a/packages/manager/.eslintrc.js
+++ b/packages/manager/.eslintrc.js
@@ -34,7 +34,7 @@ module.exports = {
     'ramda',
     'cypress',
     'prettier',
-    'testing-library'
+    'testing-library',
     'scanjs-rules',
     'xss'
   ],

--- a/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionSelect.tsx
+++ b/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionSelect.tsx
@@ -10,7 +10,7 @@ import { Region } from '@linode/api-v4/lib/regions';
 import { groupBy } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
-import { makeStyles, Theme } from 'src/components/core/styles';
+import { makeStyles } from 'src/components/core/styles';
 import SingleValue from 'src/components/EnhancedSelect/components/SingleValue';
 import Select, {
   BaseSelectProps,
@@ -28,6 +28,7 @@ interface Props extends Omit<BaseSelectProps, 'onChange'> {
   handleSelection: (id: string) => void;
   selectedID: string | null;
   label: string;
+  helperText?: string;
 }
 
 export const flags = {
@@ -52,7 +53,7 @@ export const flags = {
 export const selectStyles = {
   menuList: (base: any) => ({ ...base, maxHeight: `40vh !important` })
 };
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles(() => ({
   root: {
     '& svg': {
       '& g': {
@@ -138,6 +139,7 @@ const SelectRegionPanel: React.FC<Props> = props => {
     label,
     disabled,
     handleSelection,
+    helperText,
     regions,
     selectedID,
     styles,
@@ -160,6 +162,9 @@ const SelectRegionPanel: React.FC<Props> = props => {
         onChange={(selection: RegionItem) => handleSelection(selection.value)}
         components={{ Option: RegionOption, SingleValue }}
         styles={styles || selectStyles}
+        textFieldProps={{
+          tooltipText: helperText
+        }}
         {...restOfReactSelectProps}
       />
     </div>

--- a/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
+++ b/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
@@ -37,6 +37,7 @@ interface Props {
   handleSelection: (id: string) => void;
   selectedID?: string;
   disabled?: boolean;
+  helperText?: string;
 }
 
 const SelectRegionPanel: React.FC<Props & WithStyles<ClassNames>> = props => {
@@ -46,6 +47,7 @@ const SelectRegionPanel: React.FC<Props & WithStyles<ClassNames>> = props => {
     disabled,
     error,
     handleSelection,
+    helperText,
     regions,
     selectedID
   } = props;
@@ -55,37 +57,36 @@ const SelectRegionPanel: React.FC<Props & WithStyles<ClassNames>> = props => {
   }
 
   return (
-    <>
-      <Paper className={classes.root}>
-        <Typography variant="h2" data-qa-tp="Region">
-          Region
+    <Paper className={classes.root}>
+      <Typography variant="h2" data-qa-tp="Region">
+        Region
+      </Typography>
+      {copy && (
+        <Typography variant="body1">
+          {copy}
+          {` `}
+          <a
+            target="_blank"
+            aria-describedby="external-site"
+            rel="noopener noreferrer"
+            href="https://www.linode.com/speedtest"
+          >
+            Use our speedtest page
+          </a>
+          {` `}
+          to find the best region for your current location.
         </Typography>
-        {copy && (
-          <Typography variant="body1">
-            {copy}
-            {` `}
-            <a
-              target="_blank"
-              aria-describedby="external-site"
-              rel="noopener noreferrer"
-              href="https://www.linode.com/speedtest"
-            >
-              Use our speedtest page
-            </a>
-            {` `}
-            to find the best region for your current location.
-          </Typography>
-        )}
-        <RegionSelect
-          errorText={error}
-          disabled={disabled}
-          handleSelection={handleSelection}
-          regions={regions}
-          selectedID={selectedID || null}
-          label="Select a Region"
-        />
-      </Paper>
-    </>
+      )}
+      <RegionSelect
+        errorText={error}
+        disabled={disabled}
+        handleSelection={handleSelection}
+        regions={regions}
+        selectedID={selectedID || null}
+        label="Select a Region"
+        helperText={helperText}
+      />
+    </Paper>
   );
 };
 

--- a/packages/manager/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/packages/manager/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -145,7 +145,7 @@ class SelectStackScriptPanel extends React.Component<CombinedProps, State> {
             stackScript.user_defined_fields
           );
         })
-        .catch(e => {
+        .catch(_ => {
           this.setState({ stackScriptLoading: false, stackScriptError: true });
         });
     }
@@ -177,6 +177,7 @@ class SelectStackScriptPanel extends React.Component<CombinedProps, State> {
               noOverflow={true}
               tableClass={classes.table}
               stickyHeader
+              data-qa-select-stackscript
             >
               <StackScriptTableHead
                 currentFilterType={null}

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -606,6 +606,11 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
           })
         : regionsData;
 
+    const regionHelperText =
+      (filteredRegions?.length ?? 0) !== (regionsData?.length ?? 0)
+        ? 'Only regions that support your selected plan are displayed.'
+        : undefined;
+
     return (
       <React.Fragment>
         <DocumentTitleSegment segment="Create a Linode" />
@@ -640,6 +645,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
             resetCreationState={this.clearCreationState}
             setBackupID={this.setBackupID}
             regionsData={filteredRegions}
+            regionHelperText={regionHelperText}
             {...restOfProps}
             {...restOfState}
           />

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -173,7 +173,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
     selectedTypeID: this.params.typeID,
     selectedRegionID: this.params.regionID,
     selectedImageID: this.params.imageID ?? DEFAULT_IMAGE,
-    // @todo: Abstract and test.
+    // @todo: Abstract and test. UPDATE 5/21/20: lol what does this mean
     selectedLinodeID: isNaN(+this.params.linodeID)
       ? undefined
       : +this.params.linodeID,
@@ -585,8 +585,27 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
   };
 
   render() {
-    const { enqueueSnackbar, closeSnackbar, ...restOfProps } = this.props;
+    const {
+      enqueueSnackbar,
+      closeSnackbar,
+      regionsData,
+      ...restOfProps
+    } = this.props;
     const { label, udfs: selectedUDFs, ...restOfState } = this.state;
+
+    // If the selected type is a GPU plan, only display region
+    // options that support GPUs.
+    const selectedType = this.props.typesData?.find(
+      thisType => thisType.id === this.state.selectedTypeID
+    );
+
+    const filteredRegions =
+      selectedType?.class === 'gpu'
+        ? regionsData?.filter(thisRegion => {
+            return thisRegion.capabilities.includes('GPU');
+          })
+        : regionsData;
+
     return (
       <React.Fragment>
         <DocumentTitleSegment segment="Create a Linode" />
@@ -620,6 +639,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
             handleSubmitForm={this.submitForm}
             resetCreationState={this.clearCreationState}
             setBackupID={this.setBackupID}
+            regionsData={filteredRegions}
             {...restOfProps}
             {...restOfState}
           />

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -2,8 +2,10 @@ import { Image } from '@linode/api-v4/lib/images';
 import {
   cloneLinode,
   CreateLinodeRequest,
-  Linode
+  Linode,
+  LinodeTypeClass
 } from '@linode/api-v4/lib/linodes';
+import { Region } from '@linode/api-v4/lib/regions';
 import { StackScript, UserDefinedField } from '@linode/api-v4/lib/stackscripts';
 import { APIError } from '@linode/api-v4/lib/types';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
@@ -100,6 +102,7 @@ interface State {
   appInstances?: StackScript[];
   appInstancesLoading: boolean;
   appInstancesError?: string;
+  disabledClasses?: LinodeTypeClass[];
 }
 
 type CombinedProps = WithSnackbarProps &
@@ -136,6 +139,16 @@ const defaultState: State = {
   appInstancesLoading: false
 };
 
+const getDisabledClasses = (regionID: string, regions: Region[] = []) => {
+  const selectedRegion = regions.find(thisRegion => thisRegion.id === regionID);
+  /** This approach is fine for just GPUs, which is all we have capability info for at this time.
+   *  Refactor to a switch or .map() if additional support is needed.
+   */
+  return selectedRegion?.capabilities.includes('GPU')
+    ? []
+    : (['gpu'] as LinodeTypeClass[]);
+};
+
 const trimOneClickFromLabel = (script: StackScript) => {
   return {
     ...script,
@@ -166,7 +179,8 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
       : +this.params.linodeID,
     selectedBackupID: isNaN(+this.params.backupID)
       ? undefined
-      : +this.params.backupID
+      : +this.params.backupID,
+    disabledClasses: []
   };
 
   componentDidUpdate(prevProps: CombinedProps) {
@@ -242,7 +256,10 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
     this.setState({ selectedBackupID: id });
   };
 
-  setRegionID = (id: string) => this.setState({ selectedRegionID: id });
+  setRegionID = (id: string) => {
+    const disabledClasses = getDisabledClasses(id, this.props.regionsData);
+    this.setState({ selectedRegionID: id, disabledClasses });
+  };
 
   setTypeID = (id: string) => this.setState({ selectedTypeID: id });
 
@@ -508,11 +525,9 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
      * safe to ignore possibility of "undefined"
      * null checking happens in CALinodeCreate
      */
-    const typeInfo = this.reshapeTypeInfo(
+    return this.reshapeTypeInfo(
       this.props.typesData!.find(type => type.id === selectedTypeID)
     );
-
-    return typeInfo;
   };
 
   reshapeTypeInfo = (type?: ExtendedType): TypeInfo | undefined => {

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -144,7 +144,7 @@ const getDisabledClasses = (regionID: string, regions: Region[] = []) => {
   /** This approach is fine for just GPUs, which is all we have capability info for at this time.
    *  Refactor to a switch or .map() if additional support is needed.
    */
-  return selectedRegion?.capabilities.includes('GPU')
+  return selectedRegion?.capabilities.includes('GPU Linodes')
     ? []
     : (['gpu'] as LinodeTypeClass[]);
 };
@@ -602,7 +602,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
     const filteredRegions =
       selectedType?.class === 'gpu'
         ? regionsData?.filter(thisRegion => {
-            return thisRegion.capabilities.includes('GPU');
+            return thisRegion.capabilities.includes('GPU Linodes');
           })
         : regionsData;
 

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.test.tsx
@@ -21,6 +21,9 @@ describe('Select Plan Panel', () => {
       currentPlanHeading="Linode 2GB"
       selectedID="test"
       onSelect={jest.fn()}
+      regionsData={[]}
+      regionsLoading={false}
+      regionsLastUpdated={0}
     />
   );
   it('should render TabbedPanel', () => {

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -86,6 +86,7 @@ interface Props {
   disabled?: boolean;
   header?: string;
   copy?: string;
+  disabledClasses?: LinodeTypeClass[];
 }
 
 const getNanodes = (types: ExtendedType[]) =>
@@ -108,6 +109,11 @@ export class SelectPlanPanel extends React.Component<
 > {
   onSelect = (id: string) => () => this.props.onSelect(id);
 
+  getDisabledClass = (thisClass: LinodeTypeClass) => {
+    const disabledClasses = this.props.disabledClasses ?? [];
+    return disabledClasses.includes(thisClass);
+  };
+
   renderSelection = (type: ExtendedType, idx: number) => {
     const { selectedID, currentPlanHeading, disabled, classes } = this.props;
     const selectedDiskSize = this.props.selectedDiskSize
@@ -117,6 +123,7 @@ export class SelectPlanPanel extends React.Component<
     const planTooSmall = selectedDiskSize > type.disk;
     const isSamePlan = type.heading === currentPlanHeading;
     const isGPU = type.class === 'gpu';
+    const isDisabledClass = this.getDisabledClass(type.class);
 
     if (planTooSmall) {
       tooltip = `This plan is too small for the selected image.`;
@@ -137,11 +144,16 @@ export class SelectPlanPanel extends React.Component<
             data-qa-plan-row={type.label}
             aria-label={rowAriaLabel}
             key={type.id}
-            onClick={!isSamePlan ? this.onSelect(type.id) : undefined}
+            onClick={
+              !isSamePlan && !isDisabledClass
+                ? this.onSelect(type.id)
+                : undefined
+            }
             rowLink={this.onSelect ? this.onSelect(type.id) : undefined}
-            aria-disabled={isSamePlan || planTooSmall}
+            aria-disabled={isSamePlan || planTooSmall || isDisabledClass}
             className={classnames({
-              [classes.disabledRow]: isSamePlan || planTooSmall
+              [classes.disabledRow]:
+                isSamePlan || planTooSmall || isDisabledClass
             })}
           >
             <TableCell className={classes.radioCell}>
@@ -154,7 +166,7 @@ export class SelectPlanPanel extends React.Component<
                     <Radio
                       checked={!planTooSmall && type.id === String(selectedID)}
                       onChange={this.onSelect(type.id)}
-                      disabled={planTooSmall || disabled}
+                      disabled={planTooSmall || disabled || isDisabledClass}
                       id={type.id}
                     />
                   }
@@ -206,7 +218,7 @@ export class SelectPlanPanel extends React.Component<
             onClick={this.onSelect(type.id)}
             heading={type.heading}
             subheadings={type.subHeadings}
-            disabled={planTooSmall || isSamePlan || disabled}
+            disabled={planTooSmall || isSamePlan || disabled || isDisabledClass}
             tooltip={tooltip}
             variant={'check'}
           />
@@ -270,7 +282,7 @@ export class SelectPlanPanel extends React.Component<
             <>
               <Typography data-qa-nanode className={classes.copy}>
                 Nanode instances are good for low-duty workloads, where
-                performance isn't critical.
+                performance isn&#39;t critical.
               </Typography>
               {this.renderPlanContainer(nanodes)}
             </>
@@ -337,7 +349,11 @@ export class SelectPlanPanel extends React.Component<
     }
 
     if (!isEmpty(gpu)) {
-      const programInfo = (
+      const programInfo = this.getDisabledClass('gpu') ? (
+        <Typography>
+          GPU instances are not available in the selected region.
+        </Typography>
+      ) : (
         <Typography>
           This is a pilot program for Linode GPU Instances.
           <a

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -435,6 +435,7 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
         copy={copy}
         tabs={tabs}
         initTab={initialTab}
+        data-qa-select-plan
       />
     );
   }

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -122,7 +122,7 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
   getRegionsWithGPU = () => {
     const regions = this.props.regionsData ?? [];
     const withGPU = regions
-      .filter(thisRegion => thisRegion.capabilities.includes('GPU'))
+      .filter(thisRegion => thisRegion.capabilities.includes('GPU Linodes'))
       .map(thisRegion => dcDisplayNames[thisRegion.id]);
     return arrayToList(withGPU);
   };

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -339,7 +339,8 @@ class FromAppsContent extends React.PureComponent<CombinedProps, State> {
             regions={regionsData}
             handleSelection={updateRegionID}
             selectedID={selectedRegionID}
-            updateFor={[selectedRegionID, errors]}
+            updateFor={[selectedRegionID, errors, regionsData]}
+            helperText={this.props.regionHelperText}
             copy="Determine the best location for your Linode."
             disabled={userCannotCreateLinode}
           />

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -350,6 +350,7 @@ class FromAppsContent extends React.PureComponent<CombinedProps, State> {
             updateFor={[selectedTypeID, errors]}
             selectedID={selectedTypeID}
             disabled={userCannotCreateLinode}
+            disabledClasses={this.props.disabledClasses}
           />
           <LabelAndTagsPanel
             labelFieldProps={{

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
@@ -325,8 +325,14 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
                 onSelect={updateTypeID}
                 selectedID={selectedTypeID}
                 selectedDiskSize={selectedDiskSize}
-                updateFor={[selectedTypeID, selectedDiskSize, errors]}
+                updateFor={[
+                  selectedTypeID,
+                  selectedDiskSize,
+                  errors,
+                  this.props.disabledClasses
+                ]}
                 disabled={disabled}
+                disabledClasses={this.props.disabledClasses}
               />
               <LabelAndTagsPanel
                 labelFieldProps={{

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -222,6 +222,7 @@ export class FromImageContent extends React.PureComponent<CombinedProps> {
               copy="Determine the best location for your Linode."
               updateFor={[this.props.selectedRegionID, regions, errors]}
               disabled={userCannotCreateLinode}
+              helperText={this.props.regionHelperText}
             />
             <SelectPlanPanel
               error={hasErrorFor.type}

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -128,9 +128,9 @@ export class FromImageContent extends React.PureComponent<CombinedProps> {
               renderAsSecondary
               copy={
                 <Typography variant="subtitle1">
-                  You don't have any private Images. Visit the{' '}
+                  You don&#39;t have any private Images. Visit the{' '}
                   <Link to="/images">Images section</Link> to create an Image
-                  from one of your Linode's disks.
+                  from one of your Linode&#39;s disks.
                 </Typography>
               }
             />
@@ -229,8 +229,13 @@ export class FromImageContent extends React.PureComponent<CombinedProps> {
               data-qa-select-plan-panel
               onSelect={this.props.updateTypeID}
               selectedID={this.props.selectedTypeID}
-              updateFor={[this.props.selectedTypeID, errors]}
+              updateFor={[
+                this.props.selectedTypeID,
+                this.props.disabledClasses,
+                errors
+              ]}
               disabled={userCannotCreateLinode}
+              disabledClasses={this.props.disabledClasses}
             />
             <LabelAndTagsPanel
               data-qa-label-and-tags-panel

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -220,7 +220,7 @@ export class FromImageContent extends React.PureComponent<CombinedProps> {
               handleSelection={this.props.updateRegionID}
               selectedID={this.props.selectedRegionID}
               copy="Determine the best location for your Linode."
-              updateFor={[this.props.selectedRegionID, errors]}
+              updateFor={[this.props.selectedRegionID, regions, errors]}
               disabled={userCannotCreateLinode}
             />
             <SelectPlanPanel

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.test.tsx
@@ -48,42 +48,28 @@ describe('FromImageContent', () => {
   );
 
   it('should render a Placeholder when linodes prop has no length', () => {
-    expect(
-      componentWithoutLinodes.find('WithStyles(Placeholder)')
-    ).toHaveLength(1);
+    expect(componentWithoutLinodes.find('[data-qa-placeholder]')).toHaveLength(
+      1
+    );
   });
 
   it('should render SelectLinode panel', () => {
-    expect(
-      component.find(
-        'WithTheme(WithRenderGuard(WithStyles(SelectLinodePanel)))'
-      )
-    ).toHaveLength(1);
+    expect(component.find('[data-qa-linode-panel]')).toHaveLength(1);
   });
 
   it('should render SelectRegion panel', () => {
-    expect(
-      component.find(
-        'WithTheme(WithRenderGuard(WithStyles(SelectRegionPanel)))'
-      )
-    ).toHaveLength(1);
+    expect(component.find('[data-qa-region-panel]')).toHaveLength(1);
   });
 
   it('should render SelectPlan panel', () => {
-    expect(
-      component.find('WithTheme(WithRenderGuard(WithStyles(SelectPlanPanel)))')
-    ).toHaveLength(1);
+    expect(component.find('[data-qa-select-plan-panel]')).toHaveLength(1);
   });
 
   it('should render SelectLabel panel', () => {
-    expect(
-      component.find('WithTheme(WithRenderGuard(WithStyles(InfoPanel)))')
-    ).toHaveLength(1);
+    expect(component.find('[data-qa-label-panel]')).toHaveLength(1);
   });
 
   it('should render SelectAddOns panel', () => {
-    expect(
-      component.find('WithTheme(WithRenderGuard(WithStyles(AddonsPanel)))')
-    ).toHaveLength(1);
+    expect(component.find('[data-qa-addons-panel]')).toHaveLength(1);
   });
 });

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
@@ -191,7 +191,8 @@ export class FromLinodeContent extends React.PureComponent<CombinedProps> {
                 handleSelection={this.props.updateRegionID}
                 selectedID={selectedRegionID}
                 copy="Determine the best location for your Linode."
-                updateFor={[selectedRegionID, errors]}
+                updateFor={[selectedRegionID, errors, regions]}
+                helperText={this.props.regionHelperText}
                 disabled={userCannotCreateLinode}
               />
               <SelectPlanPanel

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
@@ -141,6 +141,7 @@ export class FromLinodeContent extends React.PureComponent<CombinedProps> {
     }
 
     return (
+      // eslint-disable-next-line
       <React.Fragment>
         {linodes && linodes.length === 0 ? (
           <Grid
@@ -199,8 +200,14 @@ export class FromLinodeContent extends React.PureComponent<CombinedProps> {
                 onSelect={this.props.updateTypeID}
                 selectedID={selectedTypeID}
                 selectedDiskSize={selectedDiskSize}
-                updateFor={[selectedDiskSize, selectedTypeID, errors]}
+                updateFor={[
+                  selectedDiskSize,
+                  selectedTypeID,
+                  errors,
+                  this.props.disabledClasses
+                ]}
                 disabled={userCannotCreateLinode}
+                disabledClasses={this.props.disabledClasses}
               />
               <LabelAndTagsPanel
                 labelFieldProps={{

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
@@ -153,6 +153,7 @@ export class FromLinodeContent extends React.PureComponent<CombinedProps> {
           >
             <Paper>
               <Placeholder
+                data-qa-placeholder
                 icon={VolumeIcon}
                 renderAsSecondary
                 copy="You do not have any existing Linodes to clone from.
@@ -172,6 +173,7 @@ export class FromLinodeContent extends React.PureComponent<CombinedProps> {
             >
               <CreateLinodeDisabled isDisabled={userCannotCreateLinode} />
               <SelectLinodePanel
+                data-qa-linode-panel
                 error={hasErrorFor('linode_id')}
                 linodes={extendLinodes(linodes, images, types)}
                 selectedLinodeID={selectedLinodeID}
@@ -186,6 +188,7 @@ export class FromLinodeContent extends React.PureComponent<CombinedProps> {
                 }}
               />
               <SelectRegionPanel
+                data-qa-region-panel
                 error={hasErrorFor('region')}
                 regions={regions}
                 handleSelection={this.props.updateRegionID}
@@ -196,6 +199,7 @@ export class FromLinodeContent extends React.PureComponent<CombinedProps> {
                 disabled={userCannotCreateLinode}
               />
               <SelectPlanPanel
+                data-qa-select-plan-panel
                 error={hasErrorFor('type')}
                 types={types}
                 onSelect={this.props.updateTypeID}
@@ -211,6 +215,7 @@ export class FromLinodeContent extends React.PureComponent<CombinedProps> {
                 disabledClasses={this.props.disabledClasses}
               />
               <LabelAndTagsPanel
+                data-qa-label-panel
                 labelFieldProps={{
                   label: 'Linode Label',
                   value: label || '',
@@ -221,6 +226,7 @@ export class FromLinodeContent extends React.PureComponent<CombinedProps> {
                 updateFor={[label, errors]}
               />
               <AddonsPanel
+                data-qa-addons-panel
                 backups={backupsEnabled}
                 accountBackups={accountBackupsEnabled}
                 backupsMonthly={backupsMonthlyPrice}

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.test.tsx
@@ -57,27 +57,15 @@ describe('FromImageContent', () => {
   );
 
   it('should render SelectStackScript panel', () => {
-    expect(
-      component.find(
-        'Connect(WithTheme(WithRenderGuard(WithStyles(SelectStackScriptPanel))))'
-      )
-    ).toHaveLength(1);
+    expect(component.find('[data-qa-select-stackscript]')).toHaveLength(1);
   });
 
   it('should render UserDefinedFields panel', () => {
-    expect(
-      componentWithUDFs.find(
-        'WithTheme(WithRenderGuard(WithStyles(UserDefinedFieldsPanel)))'
-      )
-    ).toHaveLength(1);
+    expect(componentWithUDFs.find('[data-qa-udf-panel]')).toHaveLength(1);
   });
 
   it('should not render UserDefinedFields panel if no UDFs', () => {
-    expect(
-      component.find(
-        'WithTheme(WithRenderGuard(WithStyles(UserDefinedFieldsPanel)))'
-      )
-    ).toHaveLength(0);
+    expect(component.find('[data-qa-udf-panel]')).toHaveLength(0);
   });
 
   it('should not render SelectImage panel if no compatibleImages', () => {
@@ -91,34 +79,22 @@ describe('FromImageContent', () => {
   });
 
   it('should render SelectRegion panel', () => {
-    expect(
-      component.find(
-        'WithTheme(WithRenderGuard(WithStyles(SelectRegionPanel)))'
-      )
-    ).toHaveLength(1);
+    expect(component.find('[data-qa-select-region-panel]')).toHaveLength(1);
   });
 
   it('should render SelectPlan panel', () => {
-    expect(
-      component.find('WithTheme(WithRenderGuard(WithStyles(SelectPlanPanel)))')
-    ).toHaveLength(1);
+    expect(component.find('[data-qa-select-plan]')).toHaveLength(1);
   });
 
   it('should render SelectLabel panel', () => {
-    expect(
-      component.find('WithTheme(WithRenderGuard(WithStyles(InfoPanel)))')
-    ).toHaveLength(1);
+    expect(component.find('[data-qa-label-panel]')).toHaveLength(1);
   });
 
   it('should render SelectPassword panel', () => {
-    expect(
-      component.find('WithTheme(WithRenderGuard(WithStyles(AccessPanel)))')
-    ).toHaveLength(1);
+    expect(component.find('[data-qa-access-panel]')).toHaveLength(1);
   });
 
   it('should render SelectAddOns panel', () => {
-    expect(
-      component.find('WithTheme(WithRenderGuard(WithStyles(AddonsPanel)))')
-    ).toHaveLength(1);
+    expect(component.find('[data-qa-addons-panel]')).toHaveLength(1);
   });
 });

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -343,9 +343,10 @@ export class FromStackScriptContent extends React.PureComponent<CombinedProps> {
               error={hasErrorFor('type')}
               types={typesData}
               onSelect={updateTypeID}
-              updateFor={[selectedTypeID, errors]}
+              updateFor={[selectedTypeID, errors, this.props.disabledClasses]}
               selectedID={selectedTypeID}
               disabled={disabled}
+              disabledClasses={this.props.disabledClasses}
             />
             <LabelAndTagsPanel
               labelFieldProps={{

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -335,7 +335,8 @@ export class FromStackScriptContent extends React.PureComponent<CombinedProps> {
               regions={regionsData}
               handleSelection={updateRegionID}
               selectedID={selectedRegionID}
-              updateFor={[selectedRegionID, errors]}
+              updateFor={[selectedRegionID, errors, regionsData]}
+              helperText={this.props.regionHelperText}
               copy="Determine the best location for your Linode."
               disabled={disabled}
             />

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -279,6 +279,7 @@ export class FromStackScriptContent extends React.PureComponent<CombinedProps> {
           <form>
             <CreateLinodeDisabled isDisabled={disabled} />
             <SelectStackScriptPanel
+              data-qa-select-stackscript
               error={hasErrorFor('stackscript_id')}
               header={header}
               selectedId={selectedStackScriptID}
@@ -293,6 +294,7 @@ export class FromStackScriptContent extends React.PureComponent<CombinedProps> {
             />
             {!disabled && userDefinedFields && userDefinedFields.length > 0 && (
               <UserDefinedFieldsPanel
+                data-qa-udf-panel
                 errors={filterUDFErrors(errorResources, this.props.errors)}
                 selectedLabel={selectedStackScriptLabel || ''}
                 selectedUsername={selectedStackScriptUsername || ''}
@@ -331,6 +333,7 @@ export class FromStackScriptContent extends React.PureComponent<CombinedProps> {
               </Paper>
             )}
             <SelectRegionPanel
+              data-qa-select-region-panel
               error={hasErrorFor('region')}
               regions={regionsData}
               handleSelection={updateRegionID}
@@ -341,6 +344,7 @@ export class FromStackScriptContent extends React.PureComponent<CombinedProps> {
               disabled={disabled}
             />
             <SelectPlanPanel
+              data-qa-select-plan
               error={hasErrorFor('type')}
               types={typesData}
               onSelect={updateTypeID}
@@ -350,6 +354,7 @@ export class FromStackScriptContent extends React.PureComponent<CombinedProps> {
               disabledClasses={this.props.disabledClasses}
             />
             <LabelAndTagsPanel
+              data-qa-label-panel
               labelFieldProps={{
                 label: 'Linode Label',
                 value: label || '',
@@ -366,6 +371,7 @@ export class FromStackScriptContent extends React.PureComponent<CombinedProps> {
               updateFor={[tags, label, errors]}
             />
             <AccessPanel
+              data-qa-access-panel
               /* disable the password field if we haven't selected an image */
               disabled={!this.props.selectedImageID}
               disabledReason={
@@ -388,6 +394,7 @@ export class FromStackScriptContent extends React.PureComponent<CombinedProps> {
               requestKeys={requestKeys}
             />
             <AddonsPanel
+              data-qa-addons-panel
               backups={backupsEnabled}
               accountBackups={accountBackupsEnabled}
               backupsMonthly={backupsMonthlyPrice}

--- a/packages/manager/src/features/linodes/LinodesCreate/types.ts
+++ b/packages/manager/src/features/linodes/LinodesCreate/types.ts
@@ -1,5 +1,9 @@
 import { Image } from '@linode/api-v4/lib/images';
-import { CreateLinodeRequest, Linode } from '@linode/api-v4/lib/linodes';
+import {
+  CreateLinodeRequest,
+  Linode,
+  LinodeTypeClass
+} from '@linode/api-v4/lib/linodes';
 import { StackScript, UserDefinedField } from '@linode/api-v4/lib/stackscripts';
 import { APIError } from '@linode/api-v4/lib/types';
 import { ExtendedRegion } from 'src/components/EnhancedSelect/variants/RegionSelect';
@@ -89,6 +93,7 @@ export interface BaseFormStateAndHandlers {
   selectedImageID?: string;
   updateImageID: (id: string) => void;
   selectedRegionID?: string;
+  disabledClasses?: LinodeTypeClass[];
   updateRegionID: (id: string) => void;
   selectedTypeID?: string;
   updateTypeID: (id: string) => void;

--- a/packages/manager/src/features/linodes/LinodesCreate/types.ts
+++ b/packages/manager/src/features/linodes/LinodesCreate/types.ts
@@ -94,6 +94,7 @@ export interface BaseFormStateAndHandlers {
   updateImageID: (id: string) => void;
   selectedRegionID?: string;
   disabledClasses?: LinodeTypeClass[];
+  regionHelperText?: string;
   updateRegionID: (id: string) => void;
   selectedTypeID?: string;
   updateTypeID: (id: string) => void;

--- a/packages/manager/src/request.tsx
+++ b/packages/manager/src/request.tsx
@@ -41,7 +41,6 @@ export const handleError = (error: AxiosError) => {
   }
 
   const url = pathOr('', ['response', 'config', 'url'], error);
-  const method = pathOr('', ['response', 'config', 'method'], error);
   const status: number = pathOr<number>(0, ['response', 'status'], error);
   const errors: APIError[] = pathOr<APIError[]>(
     [{ reason: DEFAULT_ERROR_MESSAGE }],
@@ -59,14 +58,6 @@ export const handleError = (error: AxiosError) => {
   const requestedLinodeType = pathOr('', ['type'], requestData);
 
   const interceptedErrors = interceptErrors(errors, [
-    {
-      replacementText: `You are not authorized to ${
-        !method || method.match(/get/i)
-          ? 'view this feature.'
-          : 'take this action.'
-      }`,
-      condition: () => status === 403
-    },
     {
       replacementText: <GPUError />,
       condition: e =>

--- a/packages/manager/src/store/regions/regions.actions.ts
+++ b/packages/manager/src/store/regions/regions.actions.ts
@@ -32,7 +32,7 @@ export const requestRegions: RequestRegionsThunk = () => dispatch => {
  * One day soon, the API will return GPU as one of a region's capabilities.
  * Until that, we're faking it here.
  */
-const regionsWithGPUs = ['us-central'];
+const regionsWithGPUs = ['us-east'];
 const addGPUToRegion = (region: Region) =>
   regionsWithGPUs.includes(region.id)
     ? {

--- a/packages/manager/src/store/regions/regions.actions.ts
+++ b/packages/manager/src/store/regions/regions.actions.ts
@@ -37,6 +37,6 @@ const addGPUToRegion = (region: Region) =>
   regionsWithGPUs.includes(region.id)
     ? {
         ...region,
-        capabilities: [...region.capabilities, 'GPU'] as Capabilities[]
+        capabilities: [...region.capabilities, 'GPU Linodes'] as Capabilities[]
       }
     : region;

--- a/packages/manager/src/store/regions/regions.actions.ts
+++ b/packages/manager/src/store/regions/regions.actions.ts
@@ -1,4 +1,4 @@
-import { getRegions, Region } from '@linode/api-v4/lib/regions';
+import { Capabilities, getRegions, Region } from '@linode/api-v4/lib/regions';
 import { APIError } from '@linode/api-v4/lib/types';
 import { actionCreatorFactory } from 'typescript-fsa';
 
@@ -17,7 +17,9 @@ export const requestRegions: RequestRegionsThunk = () => dispatch => {
   dispatch(regionsRequestActions.started());
   return getRegions()
     .then(regions => {
-      dispatch(regionsRequestActions.done({ result: regions.data }));
+      dispatch(
+        regionsRequestActions.done({ result: regions.data.map(addGPUToRegion) })
+      );
       return regions;
     })
     .catch(error => {
@@ -25,3 +27,16 @@ export const requestRegions: RequestRegionsThunk = () => dispatch => {
       return error;
     });
 };
+
+/**
+ * One day soon, the API will return GPU as one of a region's capabilities.
+ * Until that, we're faking it here.
+ */
+const regionsWithGPUs = ['us-central'];
+const addGPUToRegion = (region: Region) =>
+  regionsWithGPUs.includes(region.id)
+    ? {
+        ...region,
+        capabilities: [...region.capabilities, 'GPU'] as Capabilities[]
+      }
+    : region;

--- a/packages/manager/src/utilities/arrayToCommaSeparatedList/arrayToList.test.ts
+++ b/packages/manager/src/utilities/arrayToCommaSeparatedList/arrayToList.test.ts
@@ -1,0 +1,21 @@
+import arrayToList from './arrayToList';
+
+describe('Array to comma-separated list', () => {
+  it('should return a single item as an unaltered string', () => {
+    expect(arrayToList(['hello'])).toEqual('hello');
+  });
+
+  it('should return a list with two items separated by "and"', () => {
+    expect(arrayToList(['hello', 'goodbye'])).toEqual('hello and goodbye');
+  });
+
+  it('should return a list with three or more items as Oxford comma separated', () => {
+    expect(arrayToList(['hello', 'goodbye', 'good riddance'])).toEqual(
+      'hello, goodbye, and good riddance'
+    );
+
+    expect(arrayToList(['apples', 'peas', 'carrots', 'peaches'])).toEqual(
+      'apples, peas, carrots, and peaches'
+    );
+  });
+});

--- a/packages/manager/src/utilities/arrayToCommaSeparatedList/arrayToList.ts
+++ b/packages/manager/src/utilities/arrayToCommaSeparatedList/arrayToList.ts
@@ -1,0 +1,12 @@
+export default (input: string[]): string => {
+  if (input.length === 1) {
+    return input[0];
+  }
+  if (input.length === 2) {
+    return `${input[0]} and ${input[1]}`;
+  } else {
+    const head = input.slice(0, -1);
+    const tail = input[input.length - 1];
+    return `${head.join(', ')}, and ${tail}`;
+  }
+};

--- a/packages/manager/src/utilities/arrayToCommaSeparatedList/index.ts
+++ b/packages/manager/src/utilities/arrayToCommaSeparatedList/index.ts
@@ -1,0 +1,1 @@
+export { default } from './arrayToList';


### PR DESCRIPTION
## Description

Solves a UX problem when creating a GPU Linode that we've had numerous reports of. Three problems, specifically:

1. We were showing all plans, including GPU, even when the user had selected a region that doesn't support GPUs (GPUs are only in Newark for now). This has been fixed by disabling the GPU plan tab if the user selects an invalid region.

2. We allow you to select a plan first, and we were allowing users to select an invalid region after selecting a GPU plan. This has been fixed by filtering the regions to those that support the selected plan and adding a tooltip to explain where all the other regions went.

3. When a user submitted an invalid combination, we were intercepting a useful API error message ("there is no availability for the selected plan in the selected region") and replacing it with a very unhelpful one ("you are not authorized to take this action"). This is because we were intercepting on status code rather than message. For now I've taken out this interceptor altogether, though we could re-add it using text matching.

These solutions are a bit messy and duplicative, much of which is due to the fact that Linode Create is sort of a mess. I tried to make it extensible (if bare metal is rolled out slowly and ends up on region.capabilities) and avoid any hard coding.

## Note

The API has a ticket this sprint to add 'GPU' as a region.capability. I essentially mocked what that response will look like so that it'll be easier to adjust when they release the change.