### PR TITLE
[FW] Fix DocumentTitleSegments

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
@@ -101,7 +101,7 @@ export const FirewallDetail: React.FC<CombinedProps> = props => {
 
   return (
     <React.Fragment>
-      <DocumentTitleSegment segment="Firewalls" />
+      <DocumentTitleSegment segment={thisFirewall.label} />
       <Box display="flex" flexDirection="row" justifyContent="space-between">
         <Breadcrumb
           pathname={props.location.pathname}

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallLanding.tsx
@@ -7,7 +7,6 @@ import Box from 'src/components/core/Box';
 import Divider from 'src/components/core/Divider';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import DocumentationButton from 'src/components/DocumentationButton';
-import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
 import withFirewalls, {
   Props as FireProps
@@ -70,7 +69,6 @@ const FirewallLanding: React.FC<CombinedProps> = props => {
   return (
     <React.Fragment>
       <Box display="flex" flexDirection="row" justifyContent="space-between">
-        <DocumentTitleSegment segment="List of Firewalls" />
         <Breadcrumb pathname={props.location.pathname} labelTitle="Firewalls" />
         <DocumentationButton href={'https://google.com'} />
       </Box>


### PR DESCRIPTION
## Description

This fixes two issues:

1. `List of Firewalls | Firewalls` document title segment on FW Landing.
2. `Firewalls | Firewalls` document title segment on FW Details.

<img width="219" alt="Screen Shot 2020-05-22 at 1 25 42 PM" src="https://user-images.githubusercontent.com/16911484/82693639-e3f37280-9c2f-11ea-98ff-b875764a1472.png">
<img width="224" alt="Screen Shot 2020-05-22 at 1 25 46 PM" src="https://user-images.githubusercontent.com/16911484/82693638-e3f37280-9c2f-11ea-9a07-b04349a4ec65.png">
