### PR TITLE
Ignore ChunkLoadErrors

### DIFF
--- a/packages/manager/src/initSentry.ts
+++ b/packages/manager/src/initSentry.ts
@@ -65,7 +65,9 @@ export const initSentry = () => {
         'bmi_SafeAddOnload',
         'EBCallBackMessageReceived',
         // See http://toolbar.conduit.com/Developer/HtmlAndGadget/Methods/JSInjection.aspx
-        'conduitPage'
+        'conduitPage',
+        // Don't report client network errors.
+        'ChunkLoadError'
       ],
       whitelistUrls: [
         /** anything from either *.linode.com/* or localhost:3000 */


### PR DESCRIPTION
## Description

This makes it so that client network errors aren't reported to Sentry.

To test:

1. On `develop`: make sure you're running Cloud locally with a SENTRY_URL
2. Request-block one of the chunk.js files on app load.
3. Observe: network request to Sentry is made.

Then, checkout this PR and do the same. No request is made to Sentry.

Also, make sure you're running on port 3000 (or change the code in initSentry to whitelist whatever port you're running on.) I've been running on 3050 lately and this stumped me for a bit.
