### PR TITLE
M3-3968: Replace React.StatelessComponent with React.FC throughout codebase

### DIFF
--- a/packages/manager/src/components/ActionMenu/__mocks__/ActionMenu.tsx
+++ b/packages/manager/src/components/ActionMenu/__mocks__/ActionMenu.tsx
@@ -5,7 +5,7 @@ interface Props {
   createActions: any;
 }
 
-const MockActionMenu: React.StatelessComponent<Props> = props => {
+const MockActionMenu: React.FC<Props> = props => {
   const { createActions } = props;
   const actions = createActions(() => null);
   return (

--- a/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
+++ b/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
@@ -32,7 +32,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const ActionPanel: React.StatelessComponent<CombinedProps> = props => {
+const ActionPanel: React.FC<CombinedProps> = props => {
   const { classes, className, style } = props;
 
   return (
@@ -52,7 +52,4 @@ const ActionPanel: React.StatelessComponent<CombinedProps> = props => {
 
 const styled = withStyles(styles);
 
-export default compose<any, any, any>(
-  styled,
-  RenderGuard
-)(ActionPanel);
+export default compose<any, any, any>(styled, RenderGuard)(ActionPanel);

--- a/packages/manager/src/components/AddNewLink/AddNewLink.tsx
+++ b/packages/manager/src/components/AddNewLink/AddNewLink.tsx
@@ -16,7 +16,7 @@ export interface Props extends Omit<TooltipProps, 'children' | 'title'> {
 
 type CombinedProps = Props;
 
-const AddNewLink: React.StatelessComponent<CombinedProps> = props => {
+const AddNewLink: React.FC<CombinedProps> = props => {
   const {
     onClick,
     label,

--- a/packages/manager/src/components/BackupStatus/BackupStatus.tsx
+++ b/packages/manager/src/components/BackupStatus/BackupStatus.tsx
@@ -54,7 +54,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const BackupStatus: React.StatelessComponent<CombinedProps> = props => {
+const BackupStatus: React.FC<CombinedProps> = props => {
   const { classes, mostRecentBackup, linodeId, backupsEnabled } = props;
 
   if (mostRecentBackup) {

--- a/packages/manager/src/components/Button/Button.tsx
+++ b/packages/manager/src/components/Button/Button.tsx
@@ -143,7 +143,7 @@ const getColor = cond([
 // Add invariant warning if loading destructive cancel
 // Add invariant warning if destructive cancel
 
-const wrappedButton: React.StatelessComponent<CombinedProps> = props => {
+const wrappedButton: React.FC<CombinedProps> = props => {
   const {
     classes,
     loading,

--- a/packages/manager/src/components/Button/ButtonLink.tsx
+++ b/packages/manager/src/components/Button/ButtonLink.tsx
@@ -13,7 +13,7 @@ export interface Props {
 
 type CombinedProps = Props;
 
-const ButtonLink: React.StatelessComponent<CombinedProps> = props => {
+const ButtonLink: React.FC<CombinedProps> = props => {
   const { to, linkText, secondary, className } = props;
 
   return (

--- a/packages/manager/src/components/CheckBox/CheckBox.tsx
+++ b/packages/manager/src/components/CheckBox/CheckBox.tsx
@@ -76,7 +76,7 @@ interface Props extends CheckboxProps {
 
 type FinalProps = Props & WithStyles<CSSClasses>;
 
-const LinodeCheckBox: React.StatelessComponent<FinalProps> = props => {
+const LinodeCheckBox: React.FC<FinalProps> = props => {
   const { toolTipText, text, classes, ...rest } = props;
 
   const classnames = classNames({

--- a/packages/manager/src/components/CreateLinodeDisabled/CreateLinodeDisabled.tsx
+++ b/packages/manager/src/components/CreateLinodeDisabled/CreateLinodeDisabled.tsx
@@ -5,7 +5,7 @@ export interface Props {
   isDisabled?: boolean;
 }
 
-export const CreateLinodeDisabled: React.StatelessComponent<Props> = props => {
+export const CreateLinodeDisabled: React.FC<Props> = props => {
   const { isDisabled } = props;
   if (!isDisabled) {
     return null;

--- a/packages/manager/src/components/Currency/Currency.tsx
+++ b/packages/manager/src/components/Currency/Currency.tsx
@@ -6,7 +6,7 @@ interface CurrencyFormatterProps {
   wrapInParentheses?: boolean;
 }
 
-export const Currency: React.StatelessComponent<CurrencyFormatterProps> = props => {
+export const Currency: React.FC<CurrencyFormatterProps> = props => {
   const { quantity, wrapInParentheses } = props;
 
   const formatter = new Intl.NumberFormat('en-US', {

--- a/packages/manager/src/components/DateTimeDisplay/DateTimeDisplay.tsx
+++ b/packages/manager/src/components/DateTimeDisplay/DateTimeDisplay.tsx
@@ -12,9 +12,7 @@ export interface Props {
 
 type CombinedProps = Props;
 
-export const DateTimeDisplay: React.StatelessComponent<
-  CombinedProps
-> = props => {
+export const DateTimeDisplay: React.FC<CombinedProps> = props => {
   const { format, humanizeCutoff, value, className } = props;
   return (
     <React.Fragment>

--- a/packages/manager/src/components/DisplayPrice/DisplayPrice.tsx
+++ b/packages/manager/src/components/DisplayPrice/DisplayPrice.tsx
@@ -35,7 +35,7 @@ type CombinedProps = Props & WithStyles<ClassNames>;
 
 export const displayPrice = (v: number) => `$${v.toFixed(2)}`;
 
-export const DisplayPrice: React.StatelessComponent<CombinedProps> = props => {
+export const DisplayPrice: React.FC<CombinedProps> = props => {
   const { classes, fontSize, interval, price } = props;
   return (
     <React.Fragment>

--- a/packages/manager/src/components/Drawer/Drawer.tsx
+++ b/packages/manager/src/components/Drawer/Drawer.tsx
@@ -70,7 +70,7 @@ const styles = (theme: Theme) =>
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const DDrawer: React.StatelessComponent<CombinedProps> = props => {
+const DDrawer: React.FC<CombinedProps> = props => {
   const { title, classes, children, wide, ...rest } = props;
 
   const titleID = convertForAria(title);

--- a/packages/manager/src/components/EnhancedSelect/components/Guidance.tsx
+++ b/packages/manager/src/components/EnhancedSelect/components/Guidance.tsx
@@ -34,7 +34,7 @@ interface GuidanceProps {
 }
 type CombinedProps = GuidanceProps & WithStyles<ClassNames>;
 
-const Guidance: React.StatelessComponent<CombinedProps> = props => {
+const Guidance: React.FC<CombinedProps> = props => {
   const { classes, text } = props;
   return (
     <div className={classes.guidance}>

--- a/packages/manager/src/components/EnhancedSelect/components/MenuList.tsx
+++ b/packages/manager/src/components/EnhancedSelect/components/MenuList.tsx
@@ -5,7 +5,7 @@ import Guidance from './Guidance';
 
 type CombinedProps = MenuListComponentProps<any>;
 
-const Menu: React.StatelessComponent<CombinedProps> = props => {
+const Menu: React.FC<CombinedProps> = props => {
   const { guidance } = props.selectProps;
 
   return (

--- a/packages/manager/src/components/EnhancedSelect/components/MultiValueLabel.tsx
+++ b/packages/manager/src/components/EnhancedSelect/components/MultiValueLabel.tsx
@@ -2,9 +2,7 @@ import * as React from 'react';
 import { components as reactSelectComponents } from 'react-select';
 import { MultiValueProps } from 'react-select';
 
-const MultiValueLabel: React.StatelessComponent<MultiValueProps<
-  any
->> = props => {
+const MultiValueLabel: React.FC<MultiValueProps<any>> = props => {
   return (
     <div data-qa-multi-option={props.children}>
       <reactSelectComponents.MultiValueLabel {...props} />

--- a/packages/manager/src/components/EnhancedSelect/components/MultiValueRemove.tsx
+++ b/packages/manager/src/components/EnhancedSelect/components/MultiValueRemove.tsx
@@ -7,7 +7,7 @@ interface Props extends MultiValueProps<any> {}
 
 type CombinedProps = Props;
 
-const MultiValueRemove: React.StatelessComponent<CombinedProps> = props => {
+const MultiValueRemove: React.FC<CombinedProps> = props => {
   return (
     <reactSelectComponents.MultiValueRemove {...props}>
       <Close data-qa-select-remove />

--- a/packages/manager/src/components/EnhancedSelect/components/NoOptionsMessage.tsx
+++ b/packages/manager/src/components/EnhancedSelect/components/NoOptionsMessage.tsx
@@ -6,7 +6,7 @@ interface Props extends NoticeProps<any> {}
 
 type CombinedProps = Props;
 
-const NoOptionsMessage: React.StatelessComponent<CombinedProps> = props => {
+const NoOptionsMessage: React.FC<CombinedProps> = props => {
   const { selectProps, innerProps, children } = props;
 
   return (

--- a/packages/manager/src/components/EnhancedSelect/components/Option.tsx
+++ b/packages/manager/src/components/EnhancedSelect/components/Option.tsx
@@ -6,7 +6,7 @@ interface Props extends OptionProps<any> {
   attrs?: Record<string, string | boolean>;
 }
 
-const Option: React.StatelessComponent<Props> = props => {
+const Option: React.FC<Props> = props => {
   return (
     <div data-qa-option={String(props.value)} {...props.attrs}>
       <components.Option {...props} />

--- a/packages/manager/src/components/EnhancedSelect/components/SelectControl.tsx
+++ b/packages/manager/src/components/EnhancedSelect/components/SelectControl.tsx
@@ -8,16 +8,13 @@ interface SelectProps {
   props: any;
 }
 
-const inputComponent: React.StatelessComponent<SelectProps> = ({
-  inputRef,
-  ...props
-}) => {
+const inputComponent: React.FC<SelectProps> = ({ inputRef, ...props }) => {
   return <div ref={inputRef} {...props} />;
 };
 
 interface Props extends ControlProps<any> {}
 
-const SelectControl: React.StatelessComponent<Props> = props => {
+const SelectControl: React.FC<Props> = props => {
   return (
     <TextField
       data-qa-enhanced-select={

--- a/packages/manager/src/components/EnhancedSelect/components/SelectPlaceholder.tsx
+++ b/packages/manager/src/components/EnhancedSelect/components/SelectPlaceholder.tsx
@@ -26,7 +26,7 @@ interface Props extends PlaceholderProps<any> {}
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const SelectPlaceholder: React.StatelessComponent<CombinedProps> = props => {
+const SelectPlaceholder: React.FC<CombinedProps> = props => {
   return (
     <Typography
       className={props.classes.root}

--- a/packages/manager/src/components/EnhancedSelect/components/SingleValue.tsx
+++ b/packages/manager/src/components/EnhancedSelect/components/SingleValue.tsx
@@ -21,7 +21,7 @@ interface Props extends SingleValueProps<any> {}
 
 type CombinedProps = Props;
 
-const _SingleValue: React.StatelessComponent<CombinedProps> = props => {
+const _SingleValue: React.FC<CombinedProps> = props => {
   const classes = useStyles();
   return (
     <>

--- a/packages/manager/src/components/EntityIcon/EntityIcon.tsx
+++ b/packages/manager/src/components/EntityIcon/EntityIcon.tsx
@@ -113,7 +113,7 @@ const getIcon = (variant: Variant) => {
   return iconMap[variant] ?? LinodeIcon;
 };
 
-const EntityIcon: React.StatelessComponent<CombinedProps> = props => {
+const EntityIcon: React.FC<CombinedProps> = props => {
   const {
     classes,
     variant,

--- a/packages/manager/src/components/EventListItem/EventListItem.tsx
+++ b/packages/manager/src/components/EventListItem/EventListItem.tsx
@@ -50,7 +50,7 @@ interface Props extends MenuItemProps {
 
 type FinalProps = Props & WithStyles<ClassNames>;
 
-const EventListItem: React.StatelessComponent<FinalProps> = props => {
+const EventListItem: React.FC<FinalProps> = props => {
   const {
     classes,
     title,
@@ -72,7 +72,7 @@ const EventListItem: React.StatelessComponent<FinalProps> = props => {
       })}
       role="menu"
       {...rest}
-      {...onClick && { onClick, onKeyPress: onClick }}
+      {...(onClick && { onClick, onKeyPress: onClick })}
       divider={true}
     >
       <ListItemText primary={title} secondary={content} />

--- a/packages/manager/src/components/ExtendedExpansionPanel/ExtendedExpansionPanel.tsx
+++ b/packages/manager/src/components/ExtendedExpansionPanel/ExtendedExpansionPanel.tsx
@@ -49,7 +49,7 @@ const renderContent = (
   return renderMainContent();
 };
 
-const ExtendedExpansionPanel: React.StatelessComponent<Props> = props => {
+const ExtendedExpansionPanel: React.FC<Props> = props => {
   const {
     error,
     heading,

--- a/packages/manager/src/components/Grid/Grid.tsx
+++ b/packages/manager/src/components/Grid/Grid.tsx
@@ -5,7 +5,7 @@ import RenderGuard from 'src/components/RenderGuard';
 /* tslint:disable-next-line */
 export interface Props extends GridProps {}
 
-const WrappedGrid: React.StatelessComponent<Props> = props => {
+const WrappedGrid: React.FC<Props> = props => {
   const updatedProps: GridProps = {
     ...props,
     /** re: https://github.com/mui-org/material-ui/pull/10768 */

--- a/packages/manager/src/components/HelpIcon/HelpIcon.tsx
+++ b/packages/manager/src/components/HelpIcon/HelpIcon.tsx
@@ -27,7 +27,7 @@ interface Props
 
 type CombinedProps = Props;
 
-const HelpIcon: React.StatelessComponent<CombinedProps> = props => {
+const HelpIcon: React.FC<CombinedProps> = props => {
   const {
     text,
     className,

--- a/packages/manager/src/components/IconButton/IconButton.tsx
+++ b/packages/manager/src/components/IconButton/IconButton.tsx
@@ -37,7 +37,7 @@ const styles = (theme: Theme) =>
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const IconButtonWrapper: React.StatelessComponent<CombinedProps> = props => {
+const IconButtonWrapper: React.FC<CombinedProps> = props => {
   const { classes, destructive, style, className, ...rest } = props;
 
   return (

--- a/packages/manager/src/components/IconTextLink/IconTextLink.tsx
+++ b/packages/manager/src/components/IconTextLink/IconTextLink.tsx
@@ -91,7 +91,7 @@ export interface Props {
 
 type FinalProps = Props & WithStyles<CSSClasses>;
 
-const IconTextLink: React.StatelessComponent<FinalProps> = props => {
+const IconTextLink: React.FC<FinalProps> = props => {
   const {
     SideIcon,
     classes,

--- a/packages/manager/src/components/LinearProgress/LinearProgress.tsx
+++ b/packages/manager/src/components/LinearProgress/LinearProgress.tsx
@@ -5,9 +5,7 @@ import LinearProgress, {
 
 type CombinedProps = LinearProgressProps;
 
-const LinearProgressComponent: React.StatelessComponent<
-  CombinedProps
-> = props => {
+const LinearProgressComponent: React.FC<CombinedProps> = props => {
   const variant =
     typeof props.value === 'number' ? 'determinate' : 'indeterminate';
   const value = typeof props.value === 'number' ? props.value : 0;

--- a/packages/manager/src/components/LoadingText.tsx
+++ b/packages/manager/src/components/LoadingText.tsx
@@ -25,7 +25,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const LoadingText: React.StatelessComponent<CombinedProps> = props => {
+const LoadingText: React.FC<CombinedProps> = props => {
   const { height, width } = props;
   const style = {
     width: `${width || 100}px`,

--- a/packages/manager/src/components/ModeSelect/ModeSelect.tsx
+++ b/packages/manager/src/components/ModeSelect/ModeSelect.tsx
@@ -16,7 +16,7 @@ interface Props {
 
 type CombinedProps = Props;
 
-export const ModeSelect: React.StatelessComponent<CombinedProps> = ({
+export const ModeSelect: React.FC<CombinedProps> = ({
   modes,
   onChange,
   selected

--- a/packages/manager/src/components/MonkeyWrench/MonkeyWrench.tsx
+++ b/packages/manager/src/components/MonkeyWrench/MonkeyWrench.tsx
@@ -9,7 +9,7 @@ interface Props {
   text?: string;
 }
 
-const MonekyWrench: React.StatelessComponent<Props> = props => {
+const MonekyWrench: React.FC<Props> = props => {
   throw Error(
     props.text || 'Oh no! Someone threw a monkey wrench in the works!'
   );

--- a/packages/manager/src/components/Notice/Notice.tsx
+++ b/packages/manager/src/components/Notice/Notice.tsx
@@ -150,7 +150,7 @@ interface Props extends GridProps {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const Notice: React.StatelessComponent<CombinedProps> = props => {
+const Notice: React.FC<CombinedProps> = props => {
   const {
     classes,
     className,

--- a/packages/manager/src/components/NullComponent.tsx
+++ b/packages/manager/src/components/NullComponent.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-const NullComponent: React.StatelessComponent = () => {
+const NullComponent: React.FC = () => {
   return null;
 };
 

--- a/packages/manager/src/components/PaginationControls/PageButton.tsx
+++ b/packages/manager/src/components/PaginationControls/PageButton.tsx
@@ -55,9 +55,7 @@ const styled = withStyles(styles);
 /* tslint:disable-next-line */
 export interface Props extends ButtonProps {}
 
-const PageButton: React.StatelessComponent<
-  Props & WithStyles<CSSClasses>
-> = props => {
+const PageButton: React.FC<Props & WithStyles<CSSClasses>> = props => {
   const { classes, children, ...rest } = props;
 
   return (

--- a/packages/manager/src/components/PasswordInput/StrengthIndicator.tsx
+++ b/packages/manager/src/components/PasswordInput/StrengthIndicator.tsx
@@ -59,7 +59,7 @@ const styled = withStyles(styles);
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const StrengthIndicator: React.StatelessComponent<CombinedProps> = props => {
+const StrengthIndicator: React.FC<CombinedProps> = props => {
   const { classes, strength, hideStrengthLabel } = props;
 
   return (

--- a/packages/manager/src/components/Placeholder/Placeholder.tsx
+++ b/packages/manager/src/components/Placeholder/Placeholder.tsx
@@ -103,7 +103,7 @@ export interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const Placeholder: React.StatelessComponent<CombinedProps> = props => {
+const Placeholder: React.FC<CombinedProps> = props => {
   const {
     animate,
     classes,

--- a/packages/manager/src/components/PrimaryNav/SpacingToggle.tsx
+++ b/packages/manager/src/components/PrimaryNav/SpacingToggle.tsx
@@ -47,7 +47,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames> & WithTheme;
 
-export const SpacingToggle: React.StatelessComponent<CombinedProps> = props => {
+export const SpacingToggle: React.FC<CombinedProps> = props => {
   const { classes, toggleSpacing, theme } = props;
   const spacingMode =
     theme.spacing() === COMPACT_SPACING_UNIT ? 'compact' : 'normal';

--- a/packages/manager/src/components/ProductNotification/ProductNotification.tsx
+++ b/packages/manager/src/components/ProductNotification/ProductNotification.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 type CombinedProps = Props;
 
-const ProductNotifications: React.StatelessComponent<CombinedProps> = props => {
+const ProductNotifications: React.FC<CombinedProps> = props => {
   const { text, severity } = props;
   const level = severityLevelMap[severity] ?? 'warning';
   return React.createElement(Notice, { flag: true, [level]: true }, text);

--- a/packages/manager/src/components/Radio/Radio.tsx
+++ b/packages/manager/src/components/Radio/Radio.tsx
@@ -72,7 +72,7 @@ interface Props extends RadioProps {
 
 type FinalProps = Props & WithStyles<CSSClasses>;
 
-const LinodeRadioControl: React.StatelessComponent<FinalProps> = props => {
+const LinodeRadioControl: React.FC<FinalProps> = props => {
   const { classes, ...rest } = props;
 
   const classnames = classNames({

--- a/packages/manager/src/components/TableHeader/TableHeader.tsx
+++ b/packages/manager/src/components/TableHeader/TableHeader.tsx
@@ -26,11 +26,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const TableHeader: React.StatelessComponent<CombinedProps> = ({
-  classes,
-  title,
-  action
-}) => {
+const TableHeader: React.FC<CombinedProps> = ({ classes, title, action }) => {
   return (
     <Grid container justify="space-between" alignItems="flex-end">
       <Grid item>

--- a/packages/manager/src/components/TableRowEmptyState/TableRowEmptyState.tsx
+++ b/packages/manager/src/components/TableRowEmptyState/TableRowEmptyState.tsx
@@ -24,7 +24,7 @@ export interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const TableRowEmptyState: React.StatelessComponent<CombinedProps> = props => {
+const TableRowEmptyState: React.FC<CombinedProps> = props => {
   const { classes } = props;
   return (
     <TableRow data-testid={'table-row-empty'}>

--- a/packages/manager/src/components/TableRowError/TableRowError.tsx
+++ b/packages/manager/src/components/TableRowError/TableRowError.tsx
@@ -10,7 +10,7 @@ export interface Props {
 
 type CombinedProps = Props;
 
-const TableRowError: React.StatelessComponent<CombinedProps> = props => {
+const TableRowError: React.FC<CombinedProps> = props => {
   return (
     <TableRow data-testid="table-row-error">
       <TableCell colSpan={props.colSpan}>

--- a/packages/manager/src/components/Toggle/Toggle.tsx
+++ b/packages/manager/src/components/Toggle/Toggle.tsx
@@ -29,7 +29,7 @@ interface Props {
 
 type CombinedProps = Props & SwitchProps & WithStyles<CSSClasses>;
 
-const LinodeSwitchControl: React.StatelessComponent<CombinedProps> = props => {
+const LinodeSwitchControl: React.FC<CombinedProps> = props => {
   const { classes, tooltipText, interactive, ...rest } = props;
 
   return (

--- a/packages/manager/src/components/ViewAllLink/ViewAllLink.tsx
+++ b/packages/manager/src/components/ViewAllLink/ViewAllLink.tsx
@@ -38,7 +38,7 @@ const styles = (theme: Theme) =>
     }
   });
 
-const ViewAllLink: React.StatelessComponent<CombinedProps> = props => {
+const ViewAllLink: React.FC<CombinedProps> = props => {
   const { classes, count, text, link, external, className } = props;
   return (
     <>

--- a/packages/manager/src/features/Account/AutoBackups.tsx
+++ b/packages/manager/src/features/Account/AutoBackups.tsx
@@ -54,7 +54,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const AutoBackups: React.StatelessComponent<CombinedProps> = props => {
+const AutoBackups: React.FC<CombinedProps> = props => {
   const {
     backups_enabled,
     classes,

--- a/packages/manager/src/features/Account/ImportGroupsAsTags.tsx
+++ b/packages/manager/src/features/Account/ImportGroupsAsTags.tsx
@@ -25,9 +25,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-export const ImportGroupsAsTags: React.StatelessComponent<
-  CombinedProps
-> = props => {
+export const ImportGroupsAsTags: React.FC<CombinedProps> = props => {
   const { classes, openDrawer } = props;
   return (
     <ExpansionPanel

--- a/packages/manager/src/features/Account/NetworkHelper.tsx
+++ b/packages/manager/src/features/Account/NetworkHelper.tsx
@@ -37,7 +37,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const NetworkHelper: React.StatelessComponent<CombinedProps> = props => {
+const NetworkHelper: React.FC<CombinedProps> = props => {
   const { classes, onChange, networkHelperEnabled } = props;
 
   return (

--- a/packages/manager/src/features/Backups/AutoEnroll.tsx
+++ b/packages/manager/src/features/Backups/AutoEnroll.tsx
@@ -44,7 +44,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-export const AutoEnroll: React.StatelessComponent<CombinedProps> = props => {
+export const AutoEnroll: React.FC<CombinedProps> = props => {
   const { classes, enabled, error, toggle } = props;
   return (
     <Paper className={classes.root}>

--- a/packages/manager/src/features/Backups/BackupLinodes.tsx
+++ b/packages/manager/src/features/Backups/BackupLinodes.tsx
@@ -42,7 +42,7 @@ const getLabel = (type?: LinodeType) => pathOr('Unknown', ['label'], type);
 const getPrice = (type?: LinodeType) =>
   pathOr('Unavailable', ['addons', 'backups', 'price', 'monthly'], type);
 
-export const BackupLinodes: React.StatelessComponent<CombinedProps> = props => {
+export const BackupLinodes: React.FC<CombinedProps> = props => {
   const { classes, linodes } = props;
   return (
     <React.Fragment>

--- a/packages/manager/src/features/Backups/BackupsCTA.tsx
+++ b/packages/manager/src/features/Backups/BackupsCTA.tsx
@@ -54,7 +54,7 @@ type CombinedProps = StateProps &
   DispatchProps &
   WithStyles<ClassNames>;
 
-const BackupsCTA: React.StatelessComponent<CombinedProps> = props => {
+const BackupsCTA: React.FC<CombinedProps> = props => {
   const {
     classes,
     linodesWithoutBackups,

--- a/packages/manager/src/features/Backups/BackupsTable.tsx
+++ b/packages/manager/src/features/Backups/BackupsTable.tsx
@@ -37,7 +37,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-export const BackupsTable: React.StatelessComponent<CombinedProps> = props => {
+export const BackupsTable: React.FC<CombinedProps> = props => {
   const { classes, linodes, loading } = props;
 
   return (

--- a/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
+++ b/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
@@ -20,7 +20,7 @@ interface Props {
   items?: InvoiceItem[];
 }
 
-const InvoiceTable: React.StatelessComponent<Props> = props => {
+const InvoiceTable: React.FC<Props> = props => {
   const { loading, errors, items } = props;
   return (
     <Table border aria-label="Invoice Details">
@@ -58,7 +58,7 @@ const renderUnitPrice = (v: null | number) => (v ? `$${v}` : null);
 
 const renderQuantity = (v: null | number) => (v ? v : null);
 
-const RenderData: React.StatelessComponent<{
+const RenderData: React.FC<{
   items: InvoiceItem[];
 }> = props => {
   const { items } = props;
@@ -126,11 +126,11 @@ const RenderData: React.StatelessComponent<{
   );
 };
 
-const RenderLoading: React.StatelessComponent<{}> = () => {
+const RenderLoading: React.FC<{}> = () => {
   return <TableRowLoading colSpan={8} />;
 };
 
-const RenderErrors: React.StatelessComponent<{
+const RenderErrors: React.FC<{
   errors: APIError[];
 }> = props => {
   return (
@@ -138,11 +138,11 @@ const RenderErrors: React.StatelessComponent<{
   );
 };
 
-const RenderEmpty: React.StatelessComponent<{}> = () => {
+const RenderEmpty: React.FC<{}> = () => {
   return <TableRowEmptyState colSpan={8} />;
 };
 
-const MaybeRenderContent: React.StatelessComponent<{
+const MaybeRenderContent: React.FC<{
   loading: boolean;
   errors?: APIError[];
   items?: any[];

--- a/packages/manager/src/features/Dashboard/Dashboard.tsx
+++ b/packages/manager/src/features/Dashboard/Dashboard.tsx
@@ -49,7 +49,7 @@ interface DispatchProps {
 
 type CombinedProps = StateProps & DispatchProps & RouteComponentProps<{}>;
 
-export const Dashboard: React.StatelessComponent<CombinedProps> = props => {
+export const Dashboard: React.FC<CombinedProps> = props => {
   const {
     accountBackups,
     actions: { openBackupDrawer },

--- a/packages/manager/src/features/Dashboard/DashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/DashboardCard.tsx
@@ -36,7 +36,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const DashboardCard: React.StatelessComponent<CombinedProps> = props => {
+const DashboardCard: React.FC<CombinedProps> = props => {
   const {
     alignHeader,
     title,

--- a/packages/manager/src/features/Dashboard/VolumesDashboardCard/VolumeDashboardRow.tsx
+++ b/packages/manager/src/features/Dashboard/VolumesDashboardCard/VolumeDashboardRow.tsx
@@ -76,9 +76,7 @@ export const getLinodeLabel = (linodeId: number | null) => {
   return attachedLinode ? attachedLinode.label : null;
 };
 
-export const VolumeDashboardRow: React.StatelessComponent<
-  CombinedProps
-> = props => {
+export const VolumeDashboardRow: React.FC<CombinedProps> = props => {
   const {
     classes,
     volume: { label, linode_id, region, size }

--- a/packages/manager/src/features/Domains/DomainsLanding.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.tsx
@@ -477,11 +477,11 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
   }
 }
 
-const RenderLoading: React.StatelessComponent<{}> = () => {
+const RenderLoading: React.FC<{}> = () => {
   return <CircleProgress />;
 };
 
-const RenderError: React.StatelessComponent<{}> = () => {
+const RenderError: React.FC<{}> = () => {
   return (
     <ErrorState errorText="There was an error retrieving your domains. Please reload and try again." />
   );
@@ -516,7 +516,7 @@ const EmptyCopy = () => (
   </>
 );
 
-const RenderEmpty: React.StatelessComponent<{
+const RenderEmpty: React.FC<{
   onCreateDomain: () => void;
   onImportZone: () => void;
 }> = props => {

--- a/packages/manager/src/features/Domains/DomainsTableWrapper.tsx
+++ b/packages/manager/src/features/Domains/DomainsTableWrapper.tsx
@@ -29,7 +29,7 @@ type CombinedProps = Omit<OrderByProps, 'data'> &
   WithStyles<ClassNames> &
   Props;
 
-const DomainsTableWrapper: React.StatelessComponent<CombinedProps> = props => {
+const DomainsTableWrapper: React.FC<CombinedProps> = props => {
   const { order, orderBy, handleOrderChange, classes, dataLength } = props;
 
   return (

--- a/packages/manager/src/features/Domains/ListDomains.tsx
+++ b/packages/manager/src/features/Domains/ListDomains.tsx
@@ -37,7 +37,7 @@ interface Props extends Handlers {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const ListDomains: React.StatelessComponent<CombinedProps> = props => {
+const ListDomains: React.FC<CombinedProps> = props => {
   const { data, orderBy, order, handleOrderChange, classes } = props;
 
   const { infinitePageSize, setInfinitePageSize } = useInfinitePageSize();

--- a/packages/manager/src/features/Domains/ListGroupedDomains.tsx
+++ b/packages/manager/src/features/Domains/ListGroupedDomains.tsx
@@ -73,7 +73,7 @@ interface Props extends Handlers {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const ListGroupedDomains: React.StatelessComponent<CombinedProps> = props => {
+const ListGroupedDomains: React.FC<CombinedProps> = props => {
   const {
     data,
     onClone,

--- a/packages/manager/src/features/Domains/SortableTableHead.tsx
+++ b/packages/manager/src/features/Domains/SortableTableHead.tsx
@@ -23,7 +23,7 @@ const styles = (theme: Theme) =>
 
 type combinedProps = Omit<OrderByProps, 'data'> & WithStyles<ClassNames>;
 
-const SortableTableHead: React.StatelessComponent<combinedProps> = props => {
+const SortableTableHead: React.FC<combinedProps> = props => {
   const { order, orderBy, handleOrderChange, classes } = props;
 
   const isActive = (label: string) => label === orderBy;

--- a/packages/manager/src/features/Events/EventRow.tsx
+++ b/packages/manager/src/features/Events/EventRow.tsx
@@ -47,7 +47,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames> & RouteComponentProps<{}>;
 
-export const EventRow: React.StatelessComponent<CombinedProps> = props => {
+export const EventRow: React.FC<CombinedProps> = props => {
   const { event, entityId, classes } = props;
   const type = pathOr<string>('linode', ['entity', 'type'], event);
   const id = pathOr<string | number>(-1, ['entity', 'id'], event);
@@ -87,7 +87,7 @@ export interface RowProps extends WithStyles<ClassNames> {
   duration: Event['duration'];
 }
 
-export const Row: React.StatelessComponent<RowProps> = props => {
+export const Row: React.FC<RowProps> = props => {
   const {
     action,
     classes,

--- a/packages/manager/src/features/Events/EventsLanding.tsx
+++ b/packages/manager/src/features/Events/EventsLanding.tsx
@@ -175,7 +175,7 @@ export const reducer: EventsReducer = (state, action) => {
   }
 };
 
-export const EventsLanding: React.StatelessComponent<CombinedProps> = props => {
+export const EventsLanding: React.FC<CombinedProps> = props => {
   const [loading, setLoading] = React.useState<boolean>(false);
   const [loadMoreEvents, setLoadMoreEvents] = React.useState<boolean>(false);
   const [error, setError] = React.useState<string | undefined>(undefined);

--- a/packages/manager/src/features/Help/Panels/SearchItem.tsx
+++ b/packages/manager/src/features/Help/Panels/SearchItem.tsx
@@ -14,7 +14,7 @@ interface Props extends OptionProps<any> {
   searchText: string;
 }
 
-const SearchItem: React.StatelessComponent<Props> = props => {
+const SearchItem: React.FC<Props> = props => {
   const getLabel = () => {
     if (isFinal) {
       return props.label ? `Search for "${props.label}"` : 'Search';

--- a/packages/manager/src/features/Help/SupportSearchLanding/DocumentationResults.tsx
+++ b/packages/manager/src/features/Help/SupportSearchLanding/DocumentationResults.tsx
@@ -78,7 +78,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const DocumentationResults: React.StatelessComponent<CombinedProps> = props => {
+const DocumentationResults: React.FC<CombinedProps> = props => {
   const { classes, results, sectionTitle, target } = props;
   const renderResults = () => {
     return results.map((result: SearchResult, idx: number) => (

--- a/packages/manager/src/features/Images/ImageRow.tsx
+++ b/packages/manager/src/features/Images/ImageRow.tsx
@@ -35,7 +35,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const ImageRow: React.StatelessComponent<CombinedProps> = props => {
+const ImageRow: React.FC<CombinedProps> = props => {
   const { classes, image, ...rest } = props;
   return (
     <TableRow key={image.id} data-qa-image-cell={image.id}>

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/NodeBalancerCreationErrors.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/NodeBalancerCreationErrors.tsx
@@ -29,9 +29,7 @@ interface Props {
 
 type CombinedProps = Props;
 
-const NodeBalancerCreationError: React.StatelessComponent<
-  CombinedProps
-> = props => {
+const NodeBalancerCreationError: React.FC<CombinedProps> = props => {
   const { errors } = props;
 
   return !errors || errors.length === 0 ? null : (

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/NodeBalancerSummary.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/NodeBalancerSummary.tsx
@@ -38,7 +38,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const NodeBalancerSummary: React.StatelessComponent<CombinedProps> = props => {
+const NodeBalancerSummary: React.FC<CombinedProps> = props => {
   const { nodeBalancer, errorResponses, classes } = props;
   return (
     <div role="tabpanel" id="tabpanel-summary" aria-labelledby="tab-summary">

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
@@ -53,7 +53,7 @@ interface Props {
 
 type CombinedProps = Props & StyleProps & WithStyles<ClassNames>;
 
-const SummaryPanel: React.StatelessComponent<CombinedProps> = props => {
+const SummaryPanel: React.FC<CombinedProps> = props => {
   const { nodeBalancer, classes } = props;
 
   return (

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerSelect.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerSelect.tsx
@@ -45,7 +45,7 @@ const nodeBalancerFromItems = (
   );
 };
 
-const NodeBalancerSelect: React.StatelessComponent<CombinedProps> = props => {
+const NodeBalancerSelect: React.FC<CombinedProps> = props => {
   const {
     disabled,
     generalError,

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/ListGroupedNodeBalancers.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/ListGroupedNodeBalancers.tsx
@@ -82,7 +82,7 @@ interface Props {
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
-const ListGroupedNodeBalancers: React.StatelessComponent<CombinedProps> = props => {
+const ListGroupedNodeBalancers: React.FC<CombinedProps> = props => {
   const {
     classes,
     data,

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/ListNodeBalancers.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/ListNodeBalancers.tsx
@@ -48,7 +48,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const ListNodeBalancers: React.StatelessComponent<CombinedProps> = props => {
+const ListNodeBalancers: React.FC<CombinedProps> = props => {
   const { data, orderBy, order, handleOrderChange, toggleDialog } = props;
 
   const dataLength = data.length;

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLandingEmptyState.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLandingEmptyState.tsx
@@ -8,9 +8,7 @@ import Placeholder from 'src/components/Placeholder';
 
 type CombinedProps = RouteComponentProps<any>;
 
-const NodeBalancerLandingEmptyState: React.StatelessComponent<
-  CombinedProps
-> = props => {
+const NodeBalancerLandingEmptyState: React.FC<CombinedProps> = props => {
   const { history } = props;
   return (
     <React.Fragment>

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLandingTableRows.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLandingTableRows.tsx
@@ -52,7 +52,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const NodeBalancersLandingTableRows: React.StatelessComponent<CombinedProps> = props => {
+const NodeBalancersLandingTableRows: React.FC<CombinedProps> = props => {
   const { classes, data, toggleDialog } = props;
 
   return (

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersTableWrapper.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersTableWrapper.tsx
@@ -29,7 +29,7 @@ type CombinedProps = Omit<OrderByProps, 'data'> &
   WithStyles<ClassNames> &
   Props;
 
-const NodeBalancersTableWrapper: React.StatelessComponent<CombinedProps> = props => {
+const NodeBalancersTableWrapper: React.FC<CombinedProps> = props => {
   const { order, orderBy, handleOrderChange, classes, dataLength } = props;
 
   return (

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/SortableTableHead.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/SortableTableHead.tsx
@@ -50,7 +50,7 @@ const styles = (theme: Theme) =>
 
 type CombinedProps = WithStyles<ClassNames> & Omit<OrderByProps, 'data'>;
 
-const SortableTableHead: React.StatelessComponent<CombinedProps> = props => {
+const SortableTableHead: React.FC<CombinedProps> = props => {
   const { classes, order, orderBy, handleOrderChange } = props;
 
   const isActive = (label: string) => label === orderBy;

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDisplayDialog.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDisplayDialog.tsx
@@ -33,9 +33,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-export const AccessKeyDisplayDialog: React.StatelessComponent<
-  CombinedProps
-> = props => {
+export const AccessKeyDisplayDialog: React.FC<CombinedProps> = props => {
   const { classes, objectStorageKey, isOpen, close } = props;
 
   // This should never happen, but just in case.

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
@@ -40,7 +40,7 @@ interface FormState {
   label: string;
 }
 
-export const AccessKeyDrawer: React.StatelessComponent<CombinedProps> = props => {
+export const AccessKeyDrawer: React.FC<CombinedProps> = props => {
   const {
     isRestrictedUser,
     open,

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyLanding.tsx
@@ -70,9 +70,7 @@ type CombinedProps = Props &
   ReduxStateProps &
   DispatchProps;
 
-export const AccessKeyLanding: React.StatelessComponent<
-  CombinedProps
-> = props => {
+export const AccessKeyLanding: React.FC<CombinedProps> = props => {
   const {
     classes,
     object_storage,
@@ -351,15 +349,8 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
   };
 };
 
-const connected = connect(
-  mapStateToProps,
-  mapDispatchToProps
-);
+const connected = connect(mapStateToProps, mapDispatchToProps);
 
-const enhanced = compose<CombinedProps, Props>(
-  styled,
-  paginated,
-  connected
-);
+const enhanced = compose<CombinedProps, Props>(styled, paginated, connected);
 
 export default enhanced(AccessKeyLanding);

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyMenu.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyMenu.tsx
@@ -16,7 +16,7 @@ interface Props {
 
 type CombinedProps = Props;
 
-const AccessKeyMenu: React.StatelessComponent<CombinedProps> = props => {
+const AccessKeyMenu: React.FC<CombinedProps> = props => {
   const createActions = () => {
     const { openRevokeDialog, objectStorageKey, openDrawerForEditing } = props;
 

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable.tsx
@@ -56,7 +56,7 @@ export type CombinedProps = Props &
   WithStyles<ClassNames> &
   PaginationProps<ObjectStorageKey>;
 
-export const AccessKeyTable: React.StatelessComponent<CombinedProps> = props => {
+export const AccessKeyTable: React.FC<CombinedProps> = props => {
   const {
     classes,
     data,

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/RevokeAccessKeyDialog.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/RevokeAccessKeyDialog.tsx
@@ -23,9 +23,7 @@ interface RevokeKeysDialogProps {
   errors?: APIError[];
 }
 
-export const RevokeAccessKeyDialog: React.StatelessComponent<
-  RevokeKeysDialogProps
-> = props => {
+export const RevokeAccessKeyDialog: React.FC<RevokeKeysDialogProps> = props => {
   const {
     label,
     isOpen,

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketActionMenu.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketActionMenu.tsx
@@ -6,7 +6,7 @@ export interface Props {
   label: string;
 }
 
-export const BucketActionMenu: React.StatelessComponent<Props> = props => {
+export const BucketActionMenu: React.FC<Props> = props => {
   const createActions = () => (closeMenu: Function): Action[] => {
     return [
       {

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDrawer.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 type CombinedProps = Props & StateProps & DispatchProps;
 
-export const BucketDrawer: React.StatelessComponent<CombinedProps> = props => {
+export const BucketDrawer: React.FC<CombinedProps> = props => {
   const { isOpen, isRestrictedUser, closeBucketDrawer } = props;
 
   return (

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
@@ -246,17 +246,17 @@ export const BucketLanding: React.FC<CombinedProps> = props => {
   );
 };
 
-const RenderLoading: React.StatelessComponent<{}> = () => {
+const RenderLoading: React.FC<{}> = () => {
   return <CircleProgress data-testid="loading-state" />;
 };
 
-const RenderError: React.StatelessComponent<{}> = () => {
+const RenderError: React.FC<{}> = () => {
   return (
     <ErrorState errorText="There was an error retrieving your buckets. Please reload and try again." />
   );
 };
 
-const RenderEmpty: React.StatelessComponent<{
+const RenderEmpty: React.FC<{
   onClick: () => void;
 }> = props => {
   return (

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTable.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTable.tsx
@@ -38,7 +38,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-export const BucketTable: React.StatelessComponent<CombinedProps> = props => {
+export const BucketTable: React.FC<CombinedProps> = props => {
   const {
     data,
     orderBy,
@@ -124,7 +124,7 @@ interface RenderDataProps {
   onRemove: (bucket: ObjectStorageBucket) => void;
 }
 
-const RenderData: React.StatelessComponent<RenderDataProps> = props => {
+const RenderData: React.FC<RenderDataProps> = props => {
   const { data, onRemove } = props;
 
   return (

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.tsx
@@ -41,7 +41,7 @@ interface BucketTableRowProps extends ObjectStorageBucket {
 
 type CombinedProps = BucketTableRowProps & WithStyles<ClassNames>;
 
-export const BucketTableRow: React.StatelessComponent<CombinedProps> = props => {
+export const BucketTableRow: React.FC<CombinedProps> = props => {
   const { classes, label, cluster, hostname, created, onRemove } = props;
 
   return (

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/ClusterSelect.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/ClusterSelect.tsx
@@ -15,7 +15,7 @@ interface Props {
 }
 
 type CombinedProps = Props & StateProps;
-export const ClusterSelect: React.StatelessComponent<CombinedProps> = props => {
+export const ClusterSelect: React.FC<CombinedProps> = props => {
   const {
     selectedCluster,
     error,

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.tsx
@@ -67,7 +67,7 @@ type CombinedProps = Props &
   ReduxStateProps &
   DispatchProps;
 
-export const CreateBucketForm: React.StatelessComponent<CombinedProps> = props => {
+export const CreateBucketForm: React.FC<CombinedProps> = props => {
   const {
     isRestrictedUser,
     onClose,

--- a/packages/manager/src/features/Profile/APITokens/APITokens.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokens.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import APITokenTable from './APITokenTable';
 
-export const APITokens: React.StatelessComponent = () => {
+export const APITokens: React.FC = () => {
   return (
     <div
       id="tabpanel-apiTokens"

--- a/packages/manager/src/features/Profile/AuthenticationSettings/TwoFactor/QRCodeForm.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/TwoFactor/QRCodeForm.tsx
@@ -39,7 +39,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const QRCodeForm: React.StatelessComponent<CombinedProps> = props => {
+const QRCodeForm: React.FC<CombinedProps> = props => {
   const { classes, secret, secretLink } = props;
   return (
     <React.Fragment>
@@ -70,7 +70,4 @@ const QRCodeForm: React.StatelessComponent<CombinedProps> = props => {
 
 const styled = withStyles(styles);
 
-export default compose<any, any, any>(
-  styled,
-  RenderGuard
-)(QRCodeForm);
+export default compose<any, any, any>(styled, RenderGuard)(QRCodeForm);

--- a/packages/manager/src/features/Profile/OAuthClients/OAuthFormDrawer.tsx
+++ b/packages/manager/src/features/Profile/OAuthClients/OAuthFormDrawer.tsx
@@ -27,7 +27,7 @@ interface Props {
 
 type CombinedProps = Props;
 
-const OAuthCreationDrawer: React.StatelessComponent<CombinedProps> = props => {
+const OAuthCreationDrawer: React.FC<CombinedProps> = props => {
   const {
     label,
     redirect_uri,

--- a/packages/manager/src/features/Search/ResultGroup.tsx
+++ b/packages/manager/src/features/Search/ResultGroup.tsx
@@ -63,7 +63,7 @@ interface HandlerProps {
 
 type CombinedProps = Props & HandlerProps & WithStyles<ClassNames>;
 
-export const ResultGroup: React.StatelessComponent<CombinedProps> = props => {
+export const ResultGroup: React.FC<CombinedProps> = props => {
   const { entity, classes, groupSize, results, toggle, showMore } = props;
 
   if (isEmpty(results)) {

--- a/packages/manager/src/features/Search/ResultRow.tsx
+++ b/packages/manager/src/features/Search/ResultRow.tsx
@@ -130,7 +130,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-export const ResultRow: React.StatelessComponent<CombinedProps> = props => {
+export const ResultRow: React.FC<CombinedProps> = props => {
   const { classes, result } = props;
   const icon = pathOr<string>('default', ['data', 'icon'], result);
   const status = result.data.status;

--- a/packages/manager/src/features/Search/withStoreSearch.tsx
+++ b/packages/manager/src/features/Search/withStoreSearch.tsx
@@ -43,7 +43,7 @@ export const search = (
 };
 
 export default () => (Component: React.ComponentType<any>) => {
-  const WrappedComponent: React.StatelessComponent<SearchProps> = props => {
+  const WrappedComponent: React.FC<SearchProps> = props => {
     return React.createElement(Component, {
       ...props
     });

--- a/packages/manager/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptsSection.tsx
+++ b/packages/manager/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptsSection.tsx
@@ -39,9 +39,7 @@ export interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const SelectStackScriptsSection: React.StatelessComponent<
-  CombinedProps
-> = props => {
+const SelectStackScriptsSection: React.FC<CombinedProps> = props => {
   const { onSelect, selectedId, data, isSorting, classes, disabled } = props;
 
   const selectStackScript = (s: StackScript) => (
@@ -78,6 +76,4 @@ const SelectStackScriptsSection: React.StatelessComponent<
 
 const styled = withStyles(styles);
 
-export default styled(SelectStackScriptsSection) as React.StatelessComponent<
-  Props
->;
+export default styled(SelectStackScriptsSection) as React.FC<Props>;

--- a/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptActionMenu.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptActionMenu.tsx
@@ -30,9 +30,7 @@ interface ProfileProps {
 
 type CombinedProps = Props & RouteComponentProps<{}> & ProfileProps;
 
-const StackScriptActionMenu: React.StatelessComponent<
-  CombinedProps
-> = props => {
+const StackScriptActionMenu: React.FC<CombinedProps> = props => {
   const {
     stackScriptID,
     stackScriptUsername,

--- a/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptsSection.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptsSection.tsx
@@ -55,7 +55,7 @@ export interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames> & StateProps;
 
-const StackScriptsSection: React.StatelessComponent<CombinedProps> = props => {
+const StackScriptsSection: React.FC<CombinedProps> = props => {
   const {
     data,
     isSorting,

--- a/packages/manager/src/features/Support/AttachFileListItem.tsx
+++ b/packages/manager/src/features/Support/AttachFileListItem.tsx
@@ -67,9 +67,7 @@ interface Props {
 
 type CombinedProps = Props & HandlerProps & WithStyles<ClassNames>;
 
-export const AttachFileListItem: React.StatelessComponent<
-  CombinedProps
-> = props => {
+export const AttachFileListItem: React.FC<CombinedProps> = props => {
   const { classes, file, inlineDisplay, onClick } = props;
   if (file.uploaded) {
     return null;

--- a/packages/manager/src/features/Support/SupportTicketDetail/AttachmentError.tsx
+++ b/packages/manager/src/features/Support/SupportTicketDetail/AttachmentError.tsx
@@ -12,7 +12,7 @@ const getText = (fileName: string, reason: string) => {
   return `Error attaching ${fileName}: ${reason}`;
 };
 
-const AttachmentError: React.StatelessComponent<CombinedProps> = props => {
+const AttachmentError: React.FC<CombinedProps> = props => {
   const { fileName, reason } = props;
   return <Notice error text={getText(fileName, reason)} />;
 };

--- a/packages/manager/src/features/Support/SupportTickets/TicketRow.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/TicketRow.tsx
@@ -49,7 +49,7 @@ const renderEntityLink = (ticket: SupportTicket) => {
   null;
 };
 
-const TicketRow: React.StatelessComponent<CombinedProps> = props => {
+const TicketRow: React.FC<CombinedProps> = props => {
   const { ticket, classes } = props;
   return (
     <TableRow

--- a/packages/manager/src/features/Support/TicketAttachmentList.tsx
+++ b/packages/manager/src/features/Support/TicketAttachmentList.tsx
@@ -58,9 +58,7 @@ export const addIconsToAttachments = (attachments: string[] = []) => {
   });
 };
 
-export const TicketAttachmentList: React.StatelessComponent<
-  CombinedProps
-> = props => {
+export const TicketAttachmentList: React.FC<CombinedProps> = props => {
   const { attachments, classes, showMoreAttachments, toggle } = props;
 
   if (isEmpty(attachments)) {

--- a/packages/manager/src/features/Support/TicketAttachmentRow.tsx
+++ b/packages/manager/src/features/Support/TicketAttachmentRow.tsx
@@ -50,9 +50,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-export const TicketAttachmentRow: React.StatelessComponent<
-  CombinedProps
-> = props => {
+export const TicketAttachmentRow: React.FC<CombinedProps> = props => {
   const { attachments, classes, icons } = props;
   return (
     <Grid item>

--- a/packages/manager/src/features/TagImport/DisplayGroupList.tsx
+++ b/packages/manager/src/features/TagImport/DisplayGroupList.tsx
@@ -32,9 +32,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-export const DisplayGroupList: React.StatelessComponent<
-  CombinedProps
-> = props => {
+export const DisplayGroupList: React.FC<CombinedProps> = props => {
   const { classes, entity, groups } = props;
 
   if (isEmpty(groups)) {

--- a/packages/manager/src/features/TagImport/TagImportDrawer.tsx
+++ b/packages/manager/src/features/TagImport/TagImportDrawer.tsx
@@ -61,7 +61,7 @@ export const getGroupImportList = (entities: GroupImportProps[]) => {
   return importList;
 };
 
-export const TagImportDrawer: React.StatelessComponent<CombinedProps> = props => {
+export const TagImportDrawer: React.FC<CombinedProps> = props => {
   const {
     actions: { close, update },
     entitiesWithGroupsToImport: { linodes, domains },

--- a/packages/manager/src/features/TheApplicationIsOnFire.tsx
+++ b/packages/manager/src/features/TheApplicationIsOnFire.tsx
@@ -19,7 +19,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   }
 }));
 
-const TheApplicationIsOnFire: React.StatelessComponent<{}> = props => {
+const TheApplicationIsOnFire: React.FC<{}> = props => {
   return (
     <Dialog
       open

--- a/packages/manager/src/features/TopMenu/UserEventsMenu/UserEventsButton.tsx
+++ b/packages/manager/src/features/TopMenu/UserEventsMenu/UserEventsButton.tsx
@@ -88,7 +88,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const UserEventsButton: React.StatelessComponent<CombinedProps> = ({
+const UserEventsButton: React.FC<CombinedProps> = ({
   classes,
   count,
   onClick,

--- a/packages/manager/src/features/TopMenu/UserEventsMenu/UserEventsList.tsx
+++ b/packages/manager/src/features/TopMenu/UserEventsMenu/UserEventsList.tsx
@@ -18,7 +18,7 @@ interface Props {
 
 type CombinedProps = Props & RouteComponentProps<void>;
 
-export const UserEventsList: React.StatelessComponent<CombinedProps> = props => {
+export const UserEventsList: React.FC<CombinedProps> = props => {
   const { events, closeMenu } = props;
 
   return (

--- a/packages/manager/src/features/TopMenu/UserNotificationsMenu/UserNotificationsButton.tsx
+++ b/packages/manager/src/features/TopMenu/UserNotificationsMenu/UserNotificationsButton.tsx
@@ -71,7 +71,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const userNotificationButton: React.StatelessComponent<CombinedProps> = ({
+const userNotificationButton: React.FC<CombinedProps> = ({
   classes,
   onClick,
   className,

--- a/packages/manager/src/features/linodes/DiskSelect/DiskSelect.tsx
+++ b/packages/manager/src/features/linodes/DiskSelect/DiskSelect.tsx
@@ -30,7 +30,7 @@ const diskFromValue = (
   return thisDisk ? thisDisk : null;
 };
 
-const DiskSelect: React.StatelessComponent<CombinedProps> = props => {
+const DiskSelect: React.FC<CombinedProps> = props => {
   const {
     disabled,
     disks,

--- a/packages/manager/src/features/linodes/LinodeSelect/LinodeSelect.tsx
+++ b/packages/manager/src/features/linodes/LinodeSelect/LinodeSelect.tsx
@@ -45,7 +45,7 @@ interface Props {
 
 type CombinedProps = Props & WithLinodesProps;
 
-const LinodeSelect: React.StatelessComponent<CombinedProps> = props => {
+const LinodeSelect: React.FC<CombinedProps> = props => {
   const {
     disabled,
     generalError,

--- a/packages/manager/src/features/linodes/LinodesCreate/Panel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/Panel.tsx
@@ -27,7 +27,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const Panel: React.StatelessComponent<CombinedProps> = props => {
+const Panel: React.FC<CombinedProps> = props => {
   const { classes, children, error, title } = props;
   return (
     <Paper

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/BackupTableRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/BackupTableRow.tsx
@@ -18,7 +18,7 @@ const typeMap = {
   snapshot: 'Manual'
 };
 
-const BackupTableRow: React.StatelessComponent<Props> = props => {
+const BackupTableRow: React.FC<Props> = props => {
   const onDeploy = () => {
     props.handleDeploy(props.backup);
   };

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/CreateIPv6Drawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/CreateIPv6Drawer.tsx
@@ -12,7 +12,7 @@ interface Props {
 
 type CombinedProps = Props;
 
-const CreateIPv6Drawer: React.StatelessComponent<CombinedProps> = props => {
+const CreateIPv6Drawer: React.FC<CombinedProps> = props => {
   return (
     <Drawer
       open={props.open}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingSummaryPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingSummaryPanel.tsx
@@ -60,7 +60,7 @@ interface Props {
 
 type CombinedProps = Props & StateProps & WithStyles<ClassNames>;
 
-const SummarySection: React.StatelessComponent<any> = props => {
+const SummarySection: React.FC<any> = props => {
   const { title, renderValue, classes, ...rest } = props;
 
   return (
@@ -83,7 +83,7 @@ const SummarySection: React.StatelessComponent<any> = props => {
 
 const StyledSummarySection = styled(SummarySection);
 
-const LinodeNetworkingSummaryPanel: React.StatelessComponent<CombinedProps> = props => {
+const LinodeNetworkingSummaryPanel: React.FC<CombinedProps> = props => {
   const { classes, sshIPAddress, username, linodeRegion, linodeLabel } = props;
 
   const v4Resolvers = getIPv4DNSResolvers(linodeRegion);

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/ViewIPDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/ViewIPDrawer.tsx
@@ -32,7 +32,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const ViewIPDrawer: React.StatelessComponent<CombinedProps> = props => {
+const ViewIPDrawer: React.FC<CombinedProps> = props => {
   const { classes } = props;
 
   return (

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/ViewRangeDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/ViewRangeDrawer.tsx
@@ -32,7 +32,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const ViewRangeDrawer: React.StatelessComponent<CombinedProps> = props => {
+const ViewRangeDrawer: React.FC<CombinedProps> = props => {
   const { classes, range } = props;
   const region = (range && range.region) || '';
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuild.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuild.tsx
@@ -44,7 +44,7 @@ const options = [
   { value: 'fromAccountStackScript', label: 'From Account StackScript' }
 ];
 
-const LinodeRebuild: React.StatelessComponent<CombinedProps> = props => {
+const LinodeRebuild: React.FC<CombinedProps> = props => {
   const { classes, linodeLabel, permissions } = props;
   const disabled = permissions === 'read_only';
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildDialog.tsx
@@ -11,9 +11,7 @@ interface RebuildDialogProps {
   handleSubmit: () => void;
 }
 
-export const RebuildDialog: React.StatelessComponent<
-  RebuildDialogProps
-> = props => {
+export const RebuildDialog: React.FC<RebuildDialogProps> = props => {
   const { isOpen, isLoading, handleClose, handleSubmit } = props;
 
   const actions = () => (

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
@@ -69,9 +69,7 @@ const initialValues: RebuildFromImageForm = {
   root_pass: ''
 };
 
-export const RebuildFromImage: React.StatelessComponent<
-  CombinedProps
-> = props => {
+export const RebuildFromImage: React.FC<CombinedProps> = props => {
   const {
     classes,
     imagesData,

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.tsx
@@ -95,7 +95,7 @@ const initialValues: RebuildFromStackScriptForm = {
   stackscript_id: ''
 };
 
-export const RebuildFromStackScript: React.StatelessComponent<CombinedProps> = props => {
+export const RebuildFromStackScript: React.FC<CombinedProps> = props => {
   const {
     classes,
     imagesData,

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/DeviceSelection.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/DeviceSelection.tsx
@@ -30,7 +30,7 @@ interface Props {
 
 type CombinedProps = Props;
 
-const DeviceSelection: React.StatelessComponent<CombinedProps> = props => {
+const DeviceSelection: React.FC<CombinedProps> = props => {
   const { devices, onChange, getSelected, slots, rescue, disabled } = props;
 
   const counter = defaultTo(0, props.counter) as number;

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/ImageAndPassword.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/ImageAndPassword.tsx
@@ -27,9 +27,7 @@ interface Props {
 
 type CombinedProps = Props & ContextProps & WithImages;
 
-export const ImageAndPassword: React.StatelessComponent<
-  CombinedProps
-> = props => {
+export const ImageAndPassword: React.FC<CombinedProps> = props => {
   const {
     imagesData,
     imagesError,

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettings.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettings.tsx
@@ -27,7 +27,7 @@ const styles = (theme: Theme) =>
 
 type CombinedProps = WithStyles<ClassNames>;
 
-const LinodeSettings: React.StatelessComponent<CombinedProps> = props => {
+const LinodeSettings: React.FC<CombinedProps> = props => {
   const { classes } = props;
 
   return (

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/ActivityRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/ActivityRow.tsx
@@ -32,7 +32,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-export const ActivityRow: React.StatelessComponent<CombinedProps> = props => {
+export const ActivityRow: React.FC<CombinedProps> = props => {
   const { classes, event } = props;
 
   const message = eventMessageGenerator(event);

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummaryContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummaryContent.tsx
@@ -31,9 +31,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-export const ActivitySummaryContent: React.StatelessComponent<
-  CombinedProps
-> = props => {
+export const ActivitySummaryContent: React.FC<CombinedProps> = props => {
   const { classes, error, loading, events } = props;
   if (error) {
     return <ErrorState data-qa-activity-error errorText={error} />;

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeBusyStatus.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeBusyStatus.tsx
@@ -34,7 +34,7 @@ interface LinodeDetailContextProps {
 
 type CombinedProps = LinodeDetailContextProps & WithStyles<ClassNames>;
 
-const LinodeBusyStatus: React.StatelessComponent<CombinedProps> = props => {
+const LinodeBusyStatus: React.FC<CombinedProps> = props => {
   const { classes, status, linodeEvents, linodeId } = props;
 
   const firstEventWithProgress = (linodeEvents || []).find(

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/StatsPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/StatsPanel.tsx
@@ -48,7 +48,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-export const StatsPanel: React.StatelessComponent<CombinedProps> = props => {
+export const StatsPanel: React.FC<CombinedProps> = props => {
   const {
     classes,
     error,

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetail.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetail.tsx
@@ -52,7 +52,7 @@ const styles = (theme: Theme) =>
     }
   });
 
-const LinodeDetail: React.StatelessComponent<CombinedProps> = props => {
+const LinodeDetail: React.FC<CombinedProps> = props => {
   const {
     dispatch,
     linode,

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeControls.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeControls.tsx
@@ -67,7 +67,7 @@ type CombinedProps = Props &
   RouteComponentProps<{}> &
   WithStyles<ClassNames>;
 
-const LinodeControls: React.StatelessComponent<CombinedProps> = props => {
+const LinodeControls: React.FC<CombinedProps> = props => {
   const {
     classes,
     linode,

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
@@ -11,7 +11,7 @@ import Notifications from './Notifications';
 
 type CombinedProps = LinodeContext;
 
-const LinodeDetailHeader: React.StatelessComponent<CombinedProps> = props => {
+const LinodeDetailHeader: React.FC<CombinedProps> = props => {
   const { linodeEvents, linodeStatus, linodeDisks } = props;
   const firstEventWithProgress = (linodeEvents || []).find(
     eachEvent => typeof eachEvent.percent_complete === 'number'

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/Notifications.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/Notifications.tsx
@@ -18,7 +18,7 @@ type CombinedProps = ProfileProps &
     requestNotifications: () => void;
   };
 
-const Notifications: React.StatelessComponent<CombinedProps> = props => {
+const Notifications: React.FC<CombinedProps> = props => {
   const {
     requestNotifications,
     linodeNotifications,

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation.tsx
@@ -32,7 +32,7 @@ type CombinedProps = ContextProps &
     linodeId: string;
   }>;
 
-const LinodesDetailNavigation: React.StatelessComponent<CombinedProps> = props => {
+const LinodesDetailNavigation: React.FC<CombinedProps> = props => {
   const {
     match: { url },
     linodeLabel,

--- a/packages/manager/src/features/linodes/LinodesLanding/CardView.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/CardView.tsx
@@ -26,7 +26,7 @@ interface Props {
 
 type CombinedProps = WithImagesProps & PaginationProps & Props;
 
-const CardView: React.StatelessComponent<CombinedProps> = props => {
+const CardView: React.FC<CombinedProps> = props => {
   const { data, imagesData, openDeleteDialog, openPowerActionDialog } = props;
 
   return (

--- a/packages/manager/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
@@ -81,7 +81,7 @@ interface Props {
 
 type CombinedProps = Props & OrderByProps & WithStyles<ClassNames>;
 
-const DisplayGroupedLinodes: React.StatelessComponent<CombinedProps> = props => {
+const DisplayGroupedLinodes: React.FC<CombinedProps> = props => {
   const {
     data,
     display,

--- a/packages/manager/src/features/linodes/LinodesLanding/DisplayLinodes.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/DisplayLinodes.tsx
@@ -25,7 +25,7 @@ interface Props {
 
 type CombinedProps = Props & OrderByProps;
 
-const DisplayLinodes: React.StatelessComponent<CombinedProps> = props => {
+const DisplayLinodes: React.FC<CombinedProps> = props => {
   const {
     data,
     display,

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeCard.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeCard.tsx
@@ -308,7 +308,7 @@ export default compose<CombinedProps, Props>(
   withSnackbar
 )(LinodeCard) as React.ComponentType<Props>;
 
-const ProgressDisplay: React.StatelessComponent<{
+const ProgressDisplay: React.FC<{
   progress: null | number;
   text: string;
   classes: {
@@ -338,7 +338,7 @@ const ProgressDisplay: React.StatelessComponent<{
   );
 };
 
-export const RenderTitle: React.StatelessComponent<{
+export const RenderTitle: React.FC<{
   classes: {
     linkWrapper: string;
     StatusIndicatorWrapper: string;
@@ -395,7 +395,7 @@ export const RenderTitle: React.StatelessComponent<{
 
 RenderTitle.displayName = `RenderTitle`;
 
-export const RenderFlag: React.StatelessComponent<{
+export const RenderFlag: React.FC<{
   mutationAvailable: boolean;
   linodeNotifications: Notification[];
   classes: any;

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
@@ -1,6 +1,10 @@
 import * as classNames from 'classnames';
 import { Notification } from '@linode/api-v4/lib/account';
-import { Config, LinodeBackups, LinodeStatus } from '@linode/api-v4/lib/linodes';
+import {
+  Config,
+  LinodeBackups,
+  LinodeStatus
+} from '@linode/api-v4/lib/linodes';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { compose } from 'recompose';
@@ -59,7 +63,7 @@ export type CombinedProps = Props &
   WithNotifications &
   StyleProps;
 
-export const LinodeRow: React.StatelessComponent<CombinedProps> = props => {
+export const LinodeRow: React.FC<CombinedProps> = props => {
   const {
     // linode props
     backups,
@@ -232,7 +236,7 @@ const enhanced = compose<CombinedProps, Props>(
 
 export default enhanced(LinodeRow);
 
-export const RenderFlag: React.StatelessComponent<{
+export const RenderFlag: React.FC<{
   mutationAvailable: boolean;
   linodeNotifications: Notification[];
   classes: any;

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowBackupCell.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowBackupCell.tsx
@@ -28,7 +28,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const LinodeRowBackupCell: React.StatelessComponent<CombinedProps> = props => {
+const LinodeRowBackupCell: React.FC<CombinedProps> = props => {
   const { classes, mostRecentBackup, backupsEnabled, linodeId } = props;
 
   return (

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
@@ -131,7 +131,7 @@ type CombinedProps = Props &
   Pick<WithImages, 'imagesData'> &
   WithStyles<ClassNames>;
 
-const LinodeRowHeadCell: React.StatelessComponent<CombinedProps> = props => {
+const LinodeRowHeadCell: React.FC<CombinedProps> = props => {
   const {
     // linode props
     label,
@@ -243,7 +243,7 @@ const enhanced = compose<CombinedProps, Props>(
 
 export default enhanced(LinodeRowHeadCell);
 
-const ProgressDisplay: React.StatelessComponent<{
+const ProgressDisplay: React.FC<{
   className: string;
   progress: null | number;
   text: string;

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowLoading.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowLoading.tsx
@@ -42,7 +42,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const LinodeRowLoading: React.StatelessComponent<CombinedProps> = props => {
+const LinodeRowLoading: React.FC<CombinedProps> = props => {
   const {
     classes,
     linodeId,
@@ -73,7 +73,7 @@ const styled = withStyles(styles);
 
 export default styled(LinodeRowLoading);
 
-const ProgressDisplay: React.StatelessComponent<{
+const ProgressDisplay: React.FC<{
   progress: null | number;
 }> = props => {
   const { progress } = props;

--- a/packages/manager/src/features/linodes/LinodesLanding/ListView.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/ListView.tsx
@@ -22,7 +22,7 @@ interface Props {
 
 type CombinedProps = Props & PaginationProps;
 
-export const ListView: React.StatelessComponent<CombinedProps> = props => {
+export const ListView: React.FC<CombinedProps> = props => {
   const { data, openDeleteDialog, openPowerActionDialog } = props;
   return (
     <>

--- a/packages/manager/src/features/linodes/LinodesLanding/SortableTableHead.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/SortableTableHead.tsx
@@ -26,7 +26,7 @@ const styles = (theme: Theme) =>
 
 type combinedProps = Omit<OrderByProps, 'data'> & WithStyles<ClassNames>;
 
-const SortableTableHead: React.StatelessComponent<combinedProps> = props => {
+const SortableTableHead: React.FC<combinedProps> = props => {
   const { order, orderBy, handleOrderChange, classes } = props;
 
   const isActive = (label: string) =>

--- a/packages/manager/src/features/linodes/LinodesLanding/TableWrapper.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/TableWrapper.tsx
@@ -29,7 +29,7 @@ type CombinedProps = Omit<OrderByProps, 'data'> &
   WithStyles<ClassNames> &
   Props;
 
-const TableWrapper: React.StatelessComponent<CombinedProps> = props => {
+const TableWrapper: React.FC<CombinedProps> = props => {
   const { order, orderBy, handleOrderChange, dataLength, classes } = props;
 
   return (

--- a/packages/manager/src/features/linodes/LinodesLanding/ToggleBox.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/ToggleBox.tsx
@@ -77,7 +77,7 @@ const styled = withStyles(styles);
 
 type CombinedProps = Props & WithStyles<CSSClasses>;
 
-export const ToggleBox: React.StatelessComponent<CombinedProps> = props => {
+export const ToggleBox: React.FC<CombinedProps> = props => {
   const { classes, handleClick, status } = props;
 
   return (


### PR DESCRIPTION
## Description
There are a lot of files here but the changes are simple and consistent -- `React.StatelessComponent` was replaced throughout the codebase with `React.FC` to make our code patterns current.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers
Please navigate through the app to ensure everything is working as intended, no console errors have been introduced, etc.