### PR TITLE
Refactor LinodeConfig reducer to use updated Redux patterns

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/linodeDetailContext.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/linodeDetailContext.tsx
@@ -118,7 +118,8 @@ export const linodeDetailContextFactory = (
     /** Linode Config actions */
     getLinodeConfig: configId =>
       dispatch(_getLinodeConfig({ linodeId, configId })),
-    getLinodeConfigs: () => dispatch(_getLinodeConfigs({ linodeId })),
+    getLinodeConfigs: () =>
+      dispatch(_getLinodeConfigs({ linodeId })).then(({ data }) => data),
     updateLinodeConfig: (configId, data) =>
       dispatch(_updateLinodeConfig({ linodeId, configId, ...data })),
     createLinodeConfig: data =>

--- a/packages/manager/src/store/linodes/config/config.actions.ts
+++ b/packages/manager/src/store/linodes/config/config.actions.ts
@@ -1,6 +1,7 @@
 import { LinodeConfigCreationData } from '@linode/api-v4/lib/linodes';
 import { APIError } from '@linode/api-v4/lib/types';
 import { actionCreatorFactory } from 'typescript-fsa';
+import { GetAllData } from 'src/utilities/getAll';
 import { Entity } from './config.types';
 
 const actionCreator = actionCreatorFactory(`@@manager/linodeConfigs`);
@@ -26,9 +27,9 @@ export type GetLinodeConfigsRequest = (
   params: GetLinodeConfigsParams
 ) => GetLinodeConfigsResponse;
 
-export const getLinodeConfigsActions = actionCreator.async<
+export const getLinodeConfigsPageActions = actionCreator.async<
   GetLinodeConfigsParams,
-  Entity[],
+  GetAllData<Entity>,
   APIError[]
 >(`get-page`);
 
@@ -43,7 +44,7 @@ export type GetAllLinodeConfigsRequest = (
 
 export const getAllLinodeConfigsActions = actionCreator.async<
   GetAllLinodeConfigsParams,
-  Entity[],
+  GetAllData<Entity>,
   APIError[]
 >(`get-all`);
 

--- a/packages/manager/src/store/linodes/config/config.reducer.test.ts
+++ b/packages/manager/src/store/linodes/config/config.reducer.test.ts
@@ -38,8 +38,8 @@ describe('config reducer', () => {
       );
       expect(newState).toHaveProperty(String(mockConfig1.linode_id));
       expect(newState[mockConfig1.linode_id]).toHaveProperty('loading', true);
-      expect(newState[mockConfig1.linode_id]).toHaveProperty(
-        'error',
+      expect(newState[mockConfig1.linode_id].error).toHaveProperty(
+        'read',
         undefined
       );
     });
@@ -65,8 +65,8 @@ describe('config reducer', () => {
       );
       expect(newState).toHaveProperty(String(mockConfig1.linode_id));
       expect(newState[mockConfig1.linode_id]).toHaveProperty('loading', true);
-      expect(newState[mockConfig1.linode_id]).toHaveProperty(
-        'error',
+      expect(newState[mockConfig1.linode_id].error).toHaveProperty(
+        'read',
         undefined
       );
     });
@@ -75,12 +75,12 @@ describe('config reducer', () => {
         defaultState,
         getAllLinodeConfigsActions.done({
           params: { linodeId: mockConfig1.linode_id },
-          result: [mockConfig1, mockConfig2]
+          result: { data: [mockConfig1, mockConfig2], results: 2 }
         })
       );
       verifyConfig(newState, mockConfig1);
       verifyConfig(newState, mockConfig2);
-      expect(newState[mockConfig1.linode_id].items.length).toBe(2);
+      expect(newState[mockConfig1.linode_id].results).toBe(2);
     });
     it('sets error.read when the request fails', () => {
       const errorMessage = 'An error occurred.';
@@ -138,16 +138,18 @@ describe('config reducer', () => {
   describe('deleteLinodeConfigActions', () => {
     const state: State = {
       [mockConfig1.linode_id]: {
-        items: [String(mockConfig1.id)],
+        results: 1,
         itemsById: { [mockConfig1.id]: mockConfig1 },
         lastUpdated: 1,
-        loading: false
+        loading: false,
+        error: {}
       },
       [mockConfig2.linode_id]: {
-        items: [String(mockConfig2.id)],
+        results: 1,
         itemsById: { [mockConfig2.id]: mockConfig2 },
         lastUpdated: 1,
-        loading: false
+        loading: false,
+        error: {}
       }
     };
 
@@ -175,7 +177,7 @@ describe('config reducer', () => {
       expect(
         newState[mockConfig1.linode_id].itemsById[mockConfig1.id]
       ).toBeUndefined();
-      expect(newState[mockConfig1.linode_id].items).toHaveLength(1);
+      expect(newState[mockConfig1.linode_id].results).toBe(1);
     });
   });
 
@@ -204,6 +206,8 @@ describe('config reducer', () => {
 
 const verifyConfig = (state: State, config: Entity) => {
   expect(state[config.linode_id].loading).toBe(false);
-  expect(state[config.linode_id].items.includes(String(config.id))).toBe(true);
+  expect(state[config.linode_id].results).toBe(
+    Object.keys(state[config.linode_id].itemsById).length
+  );
   expect(state[config.linode_id].itemsById[config.id]).toEqual(config);
 };

--- a/packages/manager/src/store/linodes/config/config.requests.ts
+++ b/packages/manager/src/store/linodes/config/config.requests.ts
@@ -19,7 +19,7 @@ import {
   getAllLinodeConfigsActions,
   GetAllLinodeConfigsParams,
   getLinodeConfigActions,
-  getLinodeConfigsActions,
+  getLinodeConfigsPageActions,
   updateLinodeConfigActions
 } from './config.actions';
 import { Entity } from './config.types';
@@ -36,11 +36,12 @@ export const createLinodeConfig = createRequestThunk(
 );
 
 export const getLinodeConfigs = createRequestThunk(
-  getLinodeConfigsActions,
+  getLinodeConfigsPageActions,
   ({ linodeId }) =>
-    _getLinodeConfigs(linodeId)
-      .then(({ data }) => data)
-      .then(configs => configs.map(addLinodeIdToConfig(linodeId)))
+    _getLinodeConfigs(linodeId).then(response => ({
+      data: response.data.map(addLinodeIdToConfig(linodeId)),
+      results: response.results
+    }))
 );
 
 export const getLinodeConfig = createRequestThunk(
@@ -74,9 +75,17 @@ export const getAllLinodeConfigs: ThunkActionCreator<
   );
 
   try {
-    const { data } = await req();
-    dispatch(done({ params, result: data.map(addLinodeIdToConfig(linodeId)) }));
-    return data;
+    const response = await req();
+    dispatch(
+      done({
+        params,
+        result: {
+          data: response.data.map(addLinodeIdToConfig(linodeId)),
+          results: response.results
+        }
+      })
+    );
+    return response.data;
   } catch (error) {
     dispatch(failed({ params, error }));
     return error;


### PR DESCRIPTION
## Description

Same changes, different part of the Redux store. Linode configs functionality should be unchanged, patterns should make sense.