### PR TITLE
M3-4096: Add progress bar for newly-created Images

### DIFF
--- a/packages/manager/src/features/Images/ImageRow.tsx
+++ b/packages/manager/src/features/Images/ImageRow.tsx
@@ -1,4 +1,5 @@
 import { Image } from '@linode/api-v4/lib/images';
+import { Event } from '@linode/api-v4/lib/account';
 import * as React from 'react';
 import {
   createStyles,
@@ -11,6 +12,7 @@ import RenderGuard from 'src/components/RenderGuard';
 import TableCell from 'src/components/TableCell';
 import { formatDate } from 'src/utilities/format-date-iso8601';
 import ActionMenu from './ImagesActionMenu';
+import LinearProgress from 'src/components/LinearProgress';
 
 type ClassNames = 'root' | 'label';
 
@@ -30,14 +32,36 @@ interface Props {
   onDelete: (image: string, imageID: string) => void;
   onRestore: (imageID: string) => void;
   onDeploy: (imageID: string) => void;
-  image: Image;
+  image: ImageWithEvent;
+}
+export interface ImageWithEvent extends Image {
+  event?: Event;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
+const progressFromEvent = (e?: Event) => {
+  return e?.status === 'started' && e?.percent_complete
+    ? e.percent_complete
+    : undefined;
+};
+
 const ImageRow: React.FC<CombinedProps> = props => {
   const { classes, image, ...rest } = props;
-  return (
+  return isImageUpdating(image.event) ? (
+    <TableRow key={image.id} data-qa-image-cell={image.id}>
+      <TableCell
+        parentColumn="Label"
+        className={classes.label}
+        data-qa-image-label
+      >
+        {image.label}
+      </TableCell>
+      <TableCell colSpan={4}>
+        <LinearProgress value={progressFromEvent(image.event)} />
+      </TableCell>
+    </TableRow>
+  ) : (
     <TableRow key={image.id} data-qa-image-cell={image.id}>
       <TableCell
         parentColumn="Label"
@@ -59,6 +83,16 @@ const ImageRow: React.FC<CombinedProps> = props => {
         <ActionMenu image={image} {...rest} />
       </TableCell>
     </TableRow>
+  );
+};
+
+export const isImageUpdating = (e?: Event) => {
+  // Make Typescript happy, since this function can otherwise technically return undefined
+  if (!e) {
+    return false;
+  }
+  return (
+    e?.action === 'disk_imagize' && ['scheduled', 'started'].includes(e.status)
   );
 };
 

--- a/packages/manager/src/features/Images/ImagesLanding.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding.tsx
@@ -1,5 +1,4 @@
 import produce from 'immer';
-import { Event } from '@linode/api-v4/lib/account';
 import { deleteImage, Image } from '@linode/api-v4/lib/images';
 import { APIError } from '@linode/api-v4/lib/types';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
@@ -43,7 +42,7 @@ import { ApplicationState } from 'src/store';
 import { requestImages as _requestImages } from 'src/store/image/image.requests';
 import imageEvents from 'src/store/selectors/imageEvents';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
-import ImageRow from './ImageRow';
+import ImageRow, { ImageWithEvent } from './ImageRow';
 import ImagesDrawer, { DrawerMode } from './ImagesDrawer';
 
 type ClassNames = 'root' | 'title';
@@ -492,10 +491,6 @@ const EmptyCopy = () => (
     </Typography>
   </>
 );
-
-interface ImageWithEvent extends Image {
-  event?: Event;
-}
 interface WithPrivateImages {
   imagesData: ImageWithEvent[];
   imagesLoading: boolean;

--- a/packages/manager/src/store/middleware/imageEvents.ts
+++ b/packages/manager/src/store/middleware/imageEvents.ts
@@ -10,10 +10,14 @@ const imageEventsHandler: EventHandler = (event, dispatch) => {
       return dispatch(removeImage(event.entity.id));
 
     /**
-     * I don't love this, but we dont have a choice. disk_imagize entity is the Linode
+     * I don't love this, but we don't have a choice. disk_imagize entity is the Linode
      * where the disk resides, not the image (as one would expect).
      */
     case 'disk_imagize':
+      if (event.status === 'failed' && event.secondary_entity) {
+        return dispatch(removeImage(event.secondary_entity.id));
+      }
+
       if (['finished', 'notification'].includes(event.status)) {
         return dispatch(requestImages());
       }


### PR DESCRIPTION
## Description
Currently, when a user creates an Image, a row is automatically added to the Image landing page for it, despite us not knowing at that point whether the creation will be successful or not. Additionally, the Image size displayed is inaccurate.

This PR adds a progress bar that fills the last 4 columns instead that goes away upon successful Image creation.

To-Do:
- [x] Make sure applicable error displays if there is an error upon creation.
- [x] Display action type and completion percentage

## Type of Change
- Non breaking change ('update', 'change')
