### PR TITLE
Allow clearable numeric inputs in DomainRecordsDrawer

### DIFF
--- a/packages/api-v4/src/domains/records.schema.ts
+++ b/packages/api-v4/src/domains/records.schema.ts
@@ -32,8 +32,4 @@ export const createRecordSchema = recordBaseSchema.shape({
     .oneOf(validRecordTypes)
 });
 
-export const updateRecordSchema = recordBaseSchema.shape({
-  type: mixed()
-    .required('Type is required.')
-    .oneOf(validRecordTypes)
-});
+export const updateRecordSchema = recordBaseSchema.shape({});

--- a/packages/manager/src/components/TextField.tsx
+++ b/packages/manager/src/components/TextField.tsx
@@ -167,7 +167,9 @@ class LinodeTextField extends React.PureComponent<CombinedProps> {
      * type matches a number type
      */
     const cleanedValue =
-      minAndMaxExist && numberTypes.some(eachType => eachType === type)
+      minAndMaxExist &&
+      numberTypes.some(eachType => eachType === type) &&
+      e.target.value !== ''
         ? clamp(min, max, +e.target.value)
         : e.target.value;
 

--- a/packages/manager/src/features/Domains/DomainRecordDrawer.test.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordDrawer.test.tsx
@@ -1,4 +1,9 @@
-import { resolve, resolveAlias, shouldResolve } from './DomainRecordDrawer';
+import {
+  castFormValuesToNumeric,
+  resolve,
+  resolveAlias,
+  shouldResolve
+} from './DomainRecordDrawer';
 
 const exampleDomain = 'example.com';
 
@@ -49,6 +54,26 @@ describe('Domain record helper methods', () => {
         'target',
         resolve(payload.target, exampleDomain)
       );
+    });
+  });
+
+  describe('castFormValuesToNumeric helper', () => {
+    it('should convert string values to numeric for all target fields', () => {
+      const formValues = { apple: '1', bear: '2', cat: '3' };
+      const result = castFormValuesToNumeric(formValues, ['apple', 'bear']);
+      expect(result).toEqual({
+        apple: 1,
+        bear: 2,
+        cat: '3'
+      });
+    });
+
+    it('should convert to undefined if the value is an empty string', () => {
+      const formValues = { apple: '' };
+      const result = castFormValuesToNumeric(formValues, ['apple']);
+      expect(result).toEqual({
+        apple: undefined
+      });
     });
   });
 });

--- a/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
@@ -540,9 +540,10 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
       ...this.filterDataByType(fields, type)
     };
 
-    // Replace a single @ with a reference to the Domain
-    const data = resolveAlias(_data, domain, type);
-
+    // Expand @ to the Domain in appropriate fields
+    let data = resolveAlias(_data, domain, type);
+    // Convert string values to numeric, replacing '' with undefined
+    data = castFormValuesToNumeric(data);
     updateDomainRecord(domainId, id, data)
       .then(this.handleRecordSubmissionSuccess)
       .catch(this.handleSubmissionErrors);

--- a/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
@@ -857,9 +857,12 @@ export const resolveAlias = (
 };
 
 const numericFields = ['port', 'weight', 'priority'];
-export const castFormValuesToNumeric = (data: Record<string, any>) => {
+export const castFormValuesToNumeric = (
+  data: Record<string, any>,
+  fieldNames: string[] = numericFields
+) => {
   return produce(data, draft => {
-    numericFields.forEach(thisField => {
+    fieldNames.forEach(thisField => {
       draft[thisField] = maybeCastToNumber(draft[thisField]);
     });
   });

--- a/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
@@ -1,11 +1,13 @@
 import {
   createDomainRecord,
+  Domain,
   DomainRecord,
   DomainType,
   RecordType,
   updateDomainRecord
 } from '@linode/api-v4/lib/domains';
 import { APIError } from '@linode/api-v4/lib/types';
+import produce from 'immer';
 import {
   cond,
   defaultTo,
@@ -36,6 +38,7 @@ import {
   extendedIPToString,
   stringToExtendedIP
 } from 'src/utilities/ipUtils';
+import { maybeCastToNumber } from 'src/utilities/maybeCastToNumber';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import {
   getInitialIPs,
@@ -44,7 +47,9 @@ import {
   transferHelperText as helperText
 } from './domainUtils';
 
-interface Props extends EditableRecordFields, EditableDomainFields {
+interface Props
+  extends Partial<Omit<DomainRecord, 'type'>>,
+    Partial<Omit<Domain, 'type'>> {
   open: boolean;
   onClose: () => void;
   domainId: number;
@@ -65,13 +70,13 @@ interface EditableSharedFields {
 }
 interface EditableRecordFields extends EditableSharedFields {
   name?: string;
-  port?: number;
-  priority?: number;
+  port?: string;
+  priority?: string;
   protocol?: null | string;
   service?: null | string;
   tag?: null | string;
   target?: string;
-  weight?: number;
+  weight?: string;
 }
 
 interface EditableDomainFields extends EditableSharedFields {
@@ -112,22 +117,22 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
    * editable data or defaults.
    */
   static defaultFieldsState = (props: Partial<CombinedProps>) => ({
-    id: pathOr(undefined, ['id'], props),
-    name: pathOr('', ['name'], props),
-    port: pathOr(80, ['port'], props),
-    priority: pathOr(10, ['priority'], props),
-    protocol: pathOr('tcp', ['protocol'], props),
-    service: pathOr('', ['service'], props),
-    tag: pathOr('issue', ['tag'], props),
-    target: pathOr('', ['target'], props),
-    ttl_sec: pathOr(0, ['ttl_sec'], props),
-    weight: pathOr(5, ['weight'], props),
-    domain: pathOr(undefined, ['domain'], props),
-    soa_email: pathOr('', ['soa_email'], props),
+    id: props.id,
+    name: props.name ?? '',
+    port: props.port ?? '80',
+    priority: props.priority ?? '10',
+    protocol: props.protocol ?? 'tcp',
+    service: props.service ?? '',
+    tag: props.tag ?? 'issue',
+    target: props.target ?? '',
+    ttl_sec: props.ttl_sec ?? 0,
+    weight: props.weight ?? '5',
+    domain: props.domain,
+    soa_email: props.soa_email ?? '',
     axfr_ips: getInitialIPs(props.axfr_ips),
-    refresh_sec: pathOr(0, ['refresh_sec'], props),
-    retry_sec: pathOr(0, ['retry_sec'], props),
-    expire_sec: pathOr(0, ['expire_sec'], props)
+    refresh_sec: props.refresh_sec ?? 0,
+    retry_sec: props.retry_sec ?? 0,
+    expire_sec: props.expire_sec ?? 0
   });
 
   state: State = {
@@ -207,7 +212,7 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
         )(field)}
         value={this.state.fields[field]}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-          this.updateField(field)(+e.target.value)
+          this.updateField(field)(e.target.value)
         }
         data-qa-target={label}
         {...rest}
@@ -492,7 +497,9 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
     };
 
     // Expand @ to the Domain in appropriate fields
-    const data = resolveAlias(_data, domain, type);
+    let data = resolveAlias(_data, domain, type);
+    // Convert string values to numeric, replacing '' with undefined
+    data = castFormValuesToNumeric(data);
 
     /**
      * Validation
@@ -846,6 +853,15 @@ export const resolveAlias = (
     }
   }
   return clone;
+};
+
+const numericFields = ['port', 'weight', 'priority'];
+export const castFormValuesToNumeric = (data: Record<string, any>) => {
+  return produce(data, draft => {
+    numericFields.forEach(thisField => {
+      draft[thisField] = maybeCastToNumber(draft[thisField]);
+    });
+  });
 };
 
 const enhanced = compose<CombinedProps, Props>(withDomainActions);

--- a/packages/manager/src/features/Domains/DomainRecords.tsx
+++ b/packages/manager/src/features/Domains/DomainRecords.tsx
@@ -241,7 +241,7 @@ class DomainRecords extends React.Component<CombinedProps, State> {
       .then(() => {
         this.props.updateRecords();
 
-        this.updateConfirmDialog(c => ({
+        this.updateConfirmDialog(_ => ({
           open: false,
           submitting: false,
           errors: undefined,
@@ -260,7 +260,7 @@ class DomainRecords extends React.Component<CombinedProps, State> {
   };
 
   handleOpenSOADrawer = (d: Domain) => {
-    d.type === 'master'
+    return d.type === 'master'
       ? this.openForEditMasterDomain(d)
       : this.openForEditSlaveDomain(d);
   };
@@ -698,7 +698,7 @@ class DomainRecords extends React.Component<CombinedProps, State> {
                 order={type.order}
                 orderBy={type.orderBy}
               >
-                {({ data: orderedData, handleOrderChange, order, orderBy }) => {
+                {({ data: orderedData }) => {
                   return (
                     <Paginate
                       data={orderedData}


### PR DESCRIPTION
We were using +e.target.value to coerce string inputs to numbers.
This allowed our types to play well together internally, but it had
the drawback of not allowing users to clear the input, since '' coerces
to 0.

The solution is pretty messy: we stop the coercion in the event handlers,
and instead handle conversion just before sending data to the API.

I had to update the typings in the drawer, and its parent, to make
this work. It is very messy, and this whole workflow is screaming
for a refactor.