### PR TITLE
Remove mocked GPU Linodes region.capabilities since API supports it

### DIFF
--- a/packages/manager/src/store/regions/regions.actions.ts
+++ b/packages/manager/src/store/regions/regions.actions.ts
@@ -1,4 +1,4 @@
-import { Capabilities, getRegions, Region } from '@linode/api-v4/lib/regions';
+import { getRegions, Region } from '@linode/api-v4/lib/regions';
 import { APIError } from '@linode/api-v4/lib/types';
 import { actionCreatorFactory } from 'typescript-fsa';
 
@@ -17,9 +17,7 @@ export const requestRegions: RequestRegionsThunk = () => dispatch => {
   dispatch(regionsRequestActions.started());
   return getRegions()
     .then(regions => {
-      dispatch(
-        regionsRequestActions.done({ result: regions.data.map(addGPUToRegion) })
-      );
+      dispatch(regionsRequestActions.done({ result: regions.data }));
       return regions;
     })
     .catch(error => {
@@ -27,16 +25,3 @@ export const requestRegions: RequestRegionsThunk = () => dispatch => {
       return error;
     });
 };
-
-/**
- * One day soon, the API will return GPU as one of a region's capabilities.
- * Until that, we're faking it here.
- */
-const regionsWithGPUs = ['us-east'];
-const addGPUToRegion = (region: Region) =>
-  regionsWithGPUs.includes(region.id)
-    ? {
-        ...region,
-        capabilities: [...region.capabilities, 'GPU Linodes'] as Capabilities[]
-      }
-    : region;


### PR DESCRIPTION
## Description

API is releasing their part of this on Monday, we should undo the fake stuff before we release.