### PR TITLE
Fix: Profile routing

### DIFF
--- a/packages/manager/src/features/Profile/Profile.tsx
+++ b/packages/manager/src/features/Profile/Profile.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {
   matchPath,
+  Redirect,
   Route,
   RouteComponentProps,
   Switch,
@@ -41,45 +42,46 @@ class Profile extends React.Component<Props> {
     /* NB: These must correspond to the routes inside the Switch */
     {
       title: 'Display',
-      routeName: `${this.props.match.url}/display`
+      routeName: `${this.props.match.path}/display`
     },
     {
       title: 'Password & Authentication',
-      routeName: `${this.props.match.url}/auth`
+      routeName: `${this.props.match.path}/auth`
     },
     {
       title: 'SSH Keys',
-      routeName: `${this.props.match.url}/keys`
+      routeName: `${this.props.match.path}/keys`
     },
     {
       title: 'LISH',
-      routeName: `${this.props.match.url}/lish`
+      routeName: `${this.props.match.path}/lish`
     },
     {
       title: 'API Tokens',
-      routeName: `${this.props.match.url}/tokens`
+      routeName: `${this.props.match.path}/tokens`
     },
     {
       title: 'OAuth Apps',
-      routeName: `${this.props.match.url}/clients`
+      routeName: `${this.props.match.path}/clients`
     },
     {
       title: 'Referrals',
-      routeName: `${this.props.match.url}/referrals`
+      routeName: `${this.props.match.path}/referrals`
     },
     {
       title: 'Settings',
-      routeName: `${this.props.match.url}/settings`
+      routeName: `${this.props.match.path}/settings`
     }
   ];
+
+  matches = (p: string) => {
+    return Boolean(matchPath(p, { path: this.props.location.pathname }));
+  };
 
   render() {
     const {
       match: { url }
     } = this.props;
-    const matches = (p: string) => {
-      return Boolean(matchPath(p, { path: this.props.location.pathname }));
-    };
 
     return (
       <React.Fragment>
@@ -87,7 +89,11 @@ class Profile extends React.Component<Props> {
         <H1Header title="My Profile" data-qa-profile-header />
         <AppBar position="static" color="default" role="tablist">
           <Tabs
-            value={this.tabs.findIndex(tab => matches(tab.routeName))}
+            // Prevent console error for -1 as invalid tab index if we're redirecting from e.g. /profile/invalid-route
+            value={Math.max(
+              0,
+              this.tabs.findIndex(tab => this.matches(tab.routeName))
+            )}
             onChange={this.handleTabChange}
             indicatorColor="primary"
             textColor="primary"
@@ -124,7 +130,8 @@ class Profile extends React.Component<Props> {
             <Route exact path={`${url}/lish`} component={LishSettings} />
             <Route exact path={`${url}/referrals`} component={Referrals} />
             <Route exact path={`${url}/keys`} component={SSHKeys} />
-            <Route path={`${url}`} component={DisplaySettings} />
+            <Route exact path={`${url}/display`} component={DisplaySettings} />
+            <Redirect to={`${url}/display`} />
           </Switch>
         </React.Suspense>
       </React.Fragment>

--- a/packages/manager/src/features/Profile/Profile.tsx
+++ b/packages/manager/src/features/Profile/Profile.tsx
@@ -28,115 +28,113 @@ const APITokens = React.lazy(() => import('./APITokens'));
 
 type Props = RouteComponentProps<{}>;
 
-class Profile extends React.Component<Props> {
-  handleTabChange = (
-    event: React.ChangeEvent<HTMLDivElement>,
-    value: number
-  ) => {
-    const { history } = this.props;
-    const routeName = this.tabs[value].routeName;
-    history.push(`${routeName}`);
-  };
+const Profile: React.FC<Props> = props => {
+  const {
+    match: { url }
+  } = props;
 
-  tabs = [
+  const tabs = [
     /* NB: These must correspond to the routes inside the Switch */
     {
       title: 'Display',
-      routeName: `${this.props.match.path}/display`
+      routeName: `${url}/display`
     },
     {
       title: 'Password & Authentication',
-      routeName: `${this.props.match.path}/auth`
+      routeName: `${url}/auth`
     },
     {
       title: 'SSH Keys',
-      routeName: `${this.props.match.path}/keys`
+      routeName: `${url}/keys`
     },
     {
       title: 'LISH',
-      routeName: `${this.props.match.path}/lish`
+      routeName: `${url}/lish`
     },
     {
       title: 'API Tokens',
-      routeName: `${this.props.match.path}/tokens`
+      routeName: `${url}/tokens`
     },
     {
       title: 'OAuth Apps',
-      routeName: `${this.props.match.path}/clients`
+      routeName: `${url}/clients`
     },
     {
       title: 'Referrals',
-      routeName: `${this.props.match.path}/referrals`
+      routeName: `${url}/referrals`
     },
     {
       title: 'Settings',
-      routeName: `${this.props.match.path}/settings`
+      routeName: `${url}/settings`
     }
   ];
 
-  matches = (p: string) => {
-    return Boolean(matchPath(p, { path: this.props.location.pathname }));
+  const handleTabChange = (
+    event: React.ChangeEvent<HTMLDivElement>,
+    value: number
+  ) => {
+    const { history } = props;
+    const routeName = tabs[value].routeName;
+    history.push(`${routeName}`);
   };
 
-  render() {
-    const {
-      match: { url }
-    } = this.props;
+  const matches = (p: string) => {
+    return Boolean(matchPath(p, { path: props.location.pathname }));
+  };
 
-    return (
-      <React.Fragment>
-        <DocumentTitleSegment segment="My Profile" />
-        <H1Header title="My Profile" data-qa-profile-header />
-        <AppBar position="static" color="default" role="tablist">
-          <Tabs
-            // Prevent console error for -1 as invalid tab index if we're redirecting from e.g. /profile/invalid-route
-            value={Math.max(
-              0,
-              this.tabs.findIndex(tab => this.matches(tab.routeName))
-            )}
-            onChange={this.handleTabChange}
-            indicatorColor="primary"
-            textColor="primary"
-            variant="scrollable"
-            scrollButtons="on"
-            data-qa-tabs
-          >
-            {this.tabs.map(tab => (
-              <Tab
-                key={tab.title}
-                data-qa-tab={tab.title}
-                component={React.forwardRef((props, ref) => (
-                  <TabLink
-                    to={tab.routeName}
-                    title={tab.title}
-                    {...props}
-                    ref={ref}
-                  />
-                ))}
-              />
-            ))}
-          </Tabs>
-        </AppBar>
-        <React.Suspense fallback={<SuspenseLoader />}>
-          <Switch>
-            <Route exact path={`${url}/settings`} component={Settings} />
-            <Route
-              exact
-              path={`${url}/auth`}
-              component={AuthenticationSettings}
+  return (
+    <React.Fragment>
+      <DocumentTitleSegment segment="My Profile" />
+      <H1Header title="My Profile" data-qa-profile-header />
+      <AppBar position="static" color="default" role="tablist">
+        <Tabs
+          // Prevent console error for -1 as invalid tab index if we're redirecting from e.g. /profile/invalid-route
+          value={Math.max(
+            0,
+            tabs.findIndex(tab => matches(tab.routeName))
+          )}
+          onChange={handleTabChange}
+          indicatorColor="primary"
+          textColor="primary"
+          variant="scrollable"
+          scrollButtons="on"
+          data-qa-tabs
+        >
+          {tabs.map(tab => (
+            <Tab
+              key={tab.title}
+              data-qa-tab={tab.title}
+              component={React.forwardRef((props, ref) => (
+                <TabLink
+                  to={tab.routeName}
+                  title={tab.title}
+                  {...props}
+                  ref={ref}
+                />
+              ))}
             />
-            <Route exact path={`${url}/tokens`} component={APITokens} />
-            <Route exact path={`${url}/clients`} component={OAuthClients} />
-            <Route exact path={`${url}/lish`} component={LishSettings} />
-            <Route exact path={`${url}/referrals`} component={Referrals} />
-            <Route exact path={`${url}/keys`} component={SSHKeys} />
-            <Route exact path={`${url}/display`} component={DisplaySettings} />
-            <Redirect to={`${url}/display`} />
-          </Switch>
-        </React.Suspense>
-      </React.Fragment>
-    );
-  }
-}
+          ))}
+        </Tabs>
+      </AppBar>
+      <React.Suspense fallback={<SuspenseLoader />}>
+        <Switch>
+          <Route exact path={`${url}/settings`} component={Settings} />
+          <Route
+            exact
+            path={`${url}/auth`}
+            component={AuthenticationSettings}
+          />
+          <Route exact path={`${url}/tokens`} component={APITokens} />
+          <Route exact path={`${url}/clients`} component={OAuthClients} />
+          <Route exact path={`${url}/lish`} component={LishSettings} />
+          <Route exact path={`${url}/referrals`} component={Referrals} />
+          <Route exact path={`${url}/keys`} component={SSHKeys} />
+          <Route exact path={`${url}/display`} component={DisplaySettings} />
+          <Redirect to={`${url}/display`} />
+        </Switch>
+      </React.Suspense>
+    </React.Fragment>
+  );
+};
 
 export default withRouter(Profile);

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation.tsx
@@ -99,7 +99,11 @@ const LinodesDetailNavigation: React.FC<CombinedProps> = props => {
     <>
       <AppBar position="static" color="default" role="tablist">
         <Tabs
-          value={tabs.findIndex(tab => matches(tab.routeName))}
+          // Prevent console error for -1 as invalid tab index if we're redirecting from e.g. /linodes/invalid-route
+          value={Math.max(
+            tabs.findIndex(tab => matches(tab.routeName)),
+            0
+          )}
           onChange={handleTabChange}
           indicatorColor="primary"
           textColor="primary"


### PR DESCRIPTION
## Description

Some of our routing is out of date and doesn't handle bad input
(e.g. cloud.linode.com/profile/garbage is a valid route in prod,
it shows you the /display page). It's also possible to break navigation
by navigating directly to profile/ (with the slash) then trying to
tab around, since the router tries to resolve profile//whatever.

![Screen Shot 2020-05-29 at 12 47 26 PM](https://user-images.githubusercontent.com/1624067/83286726-66d77880-a1ae-11ea-8715-32ae8da4753a.png)
