### PR TITLE
M3-4195 Move PrimaryNav

### DIFF
--- a/packages/manager/src/App.test.tsx
+++ b/packages/manager/src/App.test.tsx
@@ -39,6 +39,8 @@ it('renders without crashing.', () => {
             accountLoading={false}
             linodesLoading={false}
             accountSettingsLoading={false}
+            ldClient={{} as any}
+            flags={{}}
           />
         </StaticRouter>
       </LinodeThemeWrapper>

--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -16,6 +16,9 @@ import {
 } from 'src/components/DocumentTitle';
 
 import withFeatureFlagProvider from 'src/containers/withFeatureFlagProvider.container';
+import withFeatureFlagConsumer, {
+  FeatureFlagConsumerProps
+} from 'src/containers/withFeatureFlagConsumer.container';
 import { events$ } from 'src/events';
 import TheApplicationIsOnFire from 'src/features/TheApplicationIsOnFire';
 
@@ -24,6 +27,7 @@ import { MapState } from './store/types';
 
 import IdentifyUser from './IdentifyUser';
 import MainContent from './MainContent';
+import MainContent_CMR from './MainContent_CMR';
 
 interface Props {
   toggleTheme: () => void;
@@ -42,7 +46,8 @@ interface State {
 type CombinedProps = Props &
   StateProps &
   RouteComponentProps &
-  WithSnackbarProps;
+  WithSnackbarProps &
+  FeatureFlagConsumerProps;
 
 export class App extends React.Component<CombinedProps, State> {
   composeState = composeState;
@@ -181,18 +186,33 @@ export class App extends React.Component<CombinedProps, State> {
           euuid={this.props.euuid}
         />
         <DocumentTitleSegment segment="Linode Manager" />
-        <MainContent
-          accountCapabilities={accountCapabilities}
-          accountError={accountError}
-          accountLoading={accountLoading}
-          history={this.props.history}
-          location={this.props.location}
-          toggleSpacing={toggleSpacing}
-          toggleTheme={toggleTheme}
-          appIsLoading={this.props.appIsLoading}
-          isLoggedInAsCustomer={this.props.isLoggedInAsCustomer}
-          username={username}
-        />
+        {this.props.flags.cmr ? (
+          <MainContent_CMR
+            accountCapabilities={accountCapabilities}
+            accountError={accountError}
+            accountLoading={accountLoading}
+            history={this.props.history}
+            location={this.props.location}
+            toggleSpacing={toggleSpacing}
+            toggleTheme={toggleTheme}
+            appIsLoading={this.props.appIsLoading}
+            isLoggedInAsCustomer={this.props.isLoggedInAsCustomer}
+            username={username}
+          />
+        ) : (
+          <MainContent
+            accountCapabilities={accountCapabilities}
+            accountError={accountError}
+            accountLoading={accountLoading}
+            history={this.props.history}
+            location={this.props.location}
+            toggleSpacing={toggleSpacing}
+            toggleTheme={toggleTheme}
+            appIsLoading={this.props.appIsLoading}
+            isLoggedInAsCustomer={this.props.isLoggedInAsCustomer}
+            username={username}
+          />
+        )}
       </React.Fragment>
     );
   }
@@ -278,7 +298,8 @@ export default compose(
   connected,
   withDocumentTitleProvider,
   withSnackbar,
-  withFeatureFlagProvider
+  withFeatureFlagProvider,
+  withFeatureFlagConsumer
 )(App);
 
 export const hasOauthError = (...args: (Error | APIError[] | undefined)[]) => {

--- a/packages/manager/src/MainContent_CMR.tsx
+++ b/packages/manager/src/MainContent_CMR.tsx
@@ -1,0 +1,328 @@
+import * as classnames from 'classnames';
+import { AccountCapability } from '@linode/api-v4/lib/account';
+import { APIError } from '@linode/api-v4/lib/types';
+import * as React from 'react';
+import { Redirect, Route, RouteComponentProps, Switch } from 'react-router-dom';
+import { compose } from 'recompose';
+import Box from 'src/components/core/Box';
+import {
+  makeStyles,
+  Theme,
+  withTheme,
+  WithTheme
+} from 'src/components/core/styles';
+import RegionStatusBanner from 'src/components/RegionStatusBanner';
+
+import BackupDrawer from 'src/features/Backups';
+import DomainDrawer from 'src/features/Domains/DomainDrawer';
+import Footer from 'src/features/Footer';
+import ToastNotifications from 'src/features/ToastNotifications';
+import TopMenu from 'src/features/TopMenu';
+import VolumeDrawer from 'src/features/Volumes/VolumeDrawer';
+
+import Grid from 'src/components/Grid';
+import NotFound from 'src/components/NotFound';
+import PreferenceToggle, { ToggleProps } from 'src/components/PreferenceToggle';
+import SideMenu from 'src/components/SideMenu';
+import SuspenseLoader from 'src/components/SuspenseLoader';
+
+import withGlobalErrors, {
+  Props as GlobalErrorProps
+} from 'src/containers/globalErrors.container';
+import withFeatureFlags, {
+  FeatureFlagConsumerProps
+} from 'src/containers/withFeatureFlagConsumer.container.ts';
+
+import Logo from 'src/assets/logo/logo-text.svg';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  appFrame: {
+    position: 'relative',
+    display: 'flex',
+    minHeight: '100vh',
+    flexDirection: 'column',
+    backgroundColor: theme.bg.main,
+    zIndex: 1
+  },
+  wrapper: {
+    padding: theme.spacing(3),
+    transition: theme.transitions.create('opacity'),
+    [theme.breakpoints.down('sm')]: {
+      paddingTop: theme.spacing(2),
+      paddingLeft: theme.spacing(2),
+      paddingRight: theme.spacing(2)
+    }
+  },
+  content: {
+    flex: 1,
+    transition: 'margin-left .1s linear',
+    [theme.breakpoints.up('md')]: {
+      marginLeft: theme.spacing(14) + 103 // 215
+    },
+    [theme.breakpoints.up('xl')]: {
+      marginLeft: theme.spacing(22) + 99 // 275
+    }
+  },
+  fullWidthContent: {
+    marginLeft: 0,
+    [theme.breakpoints.up('md')]: {
+      marginLeft: theme.spacing(7) + 36
+    }
+  },
+  hidden: {
+    display: 'none',
+    overflow: 'hidden'
+  },
+  grid: {
+    [theme.breakpoints.up('lg')]: {
+      height: '100%'
+    }
+  },
+  switchWrapper: {
+    flex: 1,
+    maxWidth: '100%',
+    position: 'relative',
+    '&.mlMain': {
+      [theme.breakpoints.up('lg')]: {
+        maxWidth: '78.8%'
+      }
+    }
+  },
+  logo: {
+    '& > g': {
+      fill: theme.color.black
+    }
+  },
+  activationWrapper: {
+    padding: theme.spacing(4),
+    [theme.breakpoints.up('xl')]: {
+      width: '50%',
+      margin: '0 auto'
+    }
+  }
+}));
+
+interface Props {
+  accountLoading: boolean;
+  accountError?: APIError[];
+  accountCapabilities: AccountCapability[];
+  location: RouteComponentProps['location'];
+  history: RouteComponentProps['history'];
+  appIsLoading: boolean;
+  toggleTheme: () => void;
+  toggleSpacing: () => void;
+  username: string;
+  isLoggedInAsCustomer: boolean;
+}
+
+type CombinedProps = Props &
+  GlobalErrorProps &
+  WithTheme &
+  FeatureFlagConsumerProps;
+
+const Account = React.lazy(() => import('src/features/Account'));
+const LinodesRoutes = React.lazy(() => import('src/features/linodes'));
+const Volumes = React.lazy(() => import('src/features/Volumes'));
+const Domains = React.lazy(() => import('src/features/Domains'));
+const Images = React.lazy(() => import('src/features/Images'));
+const Kubernetes = React.lazy(() => import('src/features/Kubernetes'));
+const ObjectStorage = React.lazy(() => import('src/features/ObjectStorage'));
+const Profile = React.lazy(() => import('src/features/Profile'));
+const NodeBalancers = React.lazy(() => import('src/features/NodeBalancers'));
+const StackScripts = React.lazy(() => import('src/features/StackScripts'));
+const SupportTickets = React.lazy(() =>
+  import('src/features/Support/SupportTickets')
+);
+const SupportTicketDetail = React.lazy(() =>
+  import('src/features/Support/SupportTicketDetail')
+);
+const Longview = React.lazy(() => import('src/features/Longview'));
+const Managed = React.lazy(() => import('src/features/Managed'));
+const Dashboard = React.lazy(() => import('src/features/Dashboard'));
+const Help = React.lazy(() => import('src/features/Help'));
+const SupportSearchLanding = React.lazy(() =>
+  import('src/features/Help/SupportSearchLanding')
+);
+const SearchLanding = React.lazy(() => import('src/features/Search'));
+const EventsLanding = React.lazy(() =>
+  import('src/features/Events/EventsLanding')
+);
+const AccountActivationLanding = React.lazy(() =>
+  import('src/components/AccountActivation/AccountActivationLanding')
+);
+const Firewalls = React.lazy(() => import('src/features/Firewalls'));
+
+const MainContent: React.FC<CombinedProps> = props => {
+  const classes = useStyles();
+
+  const [menuIsOpen, toggleMenu] = React.useState<boolean>(false);
+
+  /**
+   * this is the case where the user has successfully completed signup
+   * but needs a manual review from Customer Support. In this case,
+   * the user is going to get 403 errors from almost every single endpoint.
+   *
+   * So in this case, we'll show something more user-friendly
+   */
+  if (props.globalErrors.account_unactivated) {
+    return (
+      <div
+        style={{
+          backgroundColor: props.theme.bg.main,
+          minHeight: '100vh'
+        }}
+      >
+        <div className={classes.activationWrapper}>
+          <Box
+            style={{
+              display: 'flex'
+              // justifyContent: 'flex-end'
+            }}
+          >
+            <Logo width={150} height={87} className={classes.logo} />
+          </Box>
+          <Switch>
+            <Route
+              exact
+              strict
+              path="/support/tickets"
+              component={SupportTickets}
+            />
+            <Route
+              path="/support/tickets/:ticketId"
+              component={SupportTicketDetail}
+              exact
+              strict
+            />
+            <Route exact path="/support" component={Help} />
+            <Route component={AccountActivationLanding} />
+          </Switch>
+        </div>
+      </div>
+    );
+  }
+
+  /**
+   * otherwise just show the rest of the app.
+   */
+  return (
+    <PreferenceToggle<boolean>
+      preferenceKey="desktop_sidebar_open"
+      preferenceOptions={[true, false]}
+    >
+      {({
+        preference: desktopMenuIsOpen,
+        togglePreference: desktopMenuToggle
+      }: ToggleProps<boolean>) => {
+        return (
+          <div
+            className={classnames({
+              [classes.appFrame]: true,
+              /**
+               * hidden to prevent some jankiness with the app loading before the splash screen
+               */
+              [classes.hidden]: props.appIsLoading
+            })}
+          >
+            <SideMenu
+              open={menuIsOpen}
+              desktopOpen={desktopMenuIsOpen || false}
+              closeMenu={() => toggleMenu(false)}
+              toggleTheme={props.toggleTheme}
+              toggleSpacing={props.toggleSpacing}
+            />
+            <div
+              className={`
+                ${classes.content}
+                ${
+                  desktopMenuIsOpen ||
+                  (desktopMenuIsOpen && desktopMenuIsOpen === true)
+                    ? classes.fullWidthContent
+                    : ''
+                }
+              `}
+            >
+              <TopMenu
+                openSideMenu={() => toggleMenu(true)}
+                desktopMenuToggle={desktopMenuToggle}
+                isLoggedInAsCustomer={props.isLoggedInAsCustomer}
+                username={props.username}
+              />
+              <main className={classes.wrapper} id="main-content" role="main">
+                <Grid container spacing={0} className={classes.grid}>
+                  <Grid item className={classes.switchWrapper}>
+                    <RegionStatusBanner />
+                    <React.Suspense fallback={<SuspenseLoader />}>
+                      <Switch>
+                        <Route path="/linodes" component={LinodesRoutes} />
+                        <Route path="/volumes" component={Volumes} />
+                        <Redirect path="/volumes*" to="/volumes" />
+                        <Route
+                          path="/nodebalancers"
+                          component={NodeBalancers}
+                        />
+                        <Route path="/domains" component={Domains} />
+                        <Route path="/managed" component={Managed} />
+                        <Route path="/longview" component={Longview} />
+                        <Route exact strict path="/images" component={Images} />
+                        <Redirect path="/images*" to="/images" />
+                        <Route path="/stackscripts" component={StackScripts} />
+                        <Route
+                          path="/object-storage"
+                          component={ObjectStorage}
+                        />
+                        <Route path="/kubernetes" component={Kubernetes} />
+                        <Route path="/account" component={Account} />
+                        <Route
+                          exact
+                          strict
+                          path="/support/tickets"
+                          component={SupportTickets}
+                        />
+                        <Route
+                          path="/support/tickets/:ticketId"
+                          component={SupportTicketDetail}
+                          exact
+                          strict
+                        />
+                        <Route path="/profile" component={Profile} />
+                        <Route exact path="/support" component={Help} />
+                        <Route path="/dashboard" component={Dashboard} />
+                        <Route path="/search" component={SearchLanding} />
+                        <Route
+                          exact
+                          strict
+                          path="/support/search/"
+                          component={SupportSearchLanding}
+                        />
+                        <Route path="/events" component={EventsLanding} />
+                        {props.flags.firewalls && (
+                          <Route path="/firewalls" component={Firewalls} />
+                        )}
+                        <Redirect exact from="/" to="/dashboard" />
+                        <Route component={NotFound} />
+                      </Switch>
+                    </React.Suspense>
+                  </Grid>
+                </Grid>
+              </main>
+            </div>
+
+            <Footer desktopMenuIsOpen={desktopMenuIsOpen} />
+            <ToastNotifications />
+            <DomainDrawer />
+            <VolumeDrawer />
+            <BackupDrawer />
+          </div>
+        );
+      }}
+    </PreferenceToggle>
+  );
+};
+
+export default compose<CombinedProps, Props>(
+  React.memo,
+  withGlobalErrors(),
+  withTheme,
+  withFeatureFlags
+)(MainContent);

--- a/packages/manager/src/MainContent_CMR.tsx
+++ b/packages/manager/src/MainContent_CMR.tsx
@@ -23,8 +23,9 @@ import VolumeDrawer from 'src/features/Volumes/VolumeDrawer';
 import Grid from 'src/components/Grid';
 import NotFound from 'src/components/NotFound';
 import PreferenceToggle, { ToggleProps } from 'src/components/PreferenceToggle';
-import SideMenu from 'src/components/SideMenu';
 import SuspenseLoader from 'src/components/SuspenseLoader';
+// @cmr
+import PrimaryNav_CMR from 'src/components/PrimaryNav/PrimaryNav_CMR';
 
 import withGlobalErrors, {
   Props as GlobalErrorProps
@@ -54,14 +55,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     }
   },
   content: {
-    flex: 1,
-    transition: 'margin-left .1s linear',
-    [theme.breakpoints.up('md')]: {
-      marginLeft: theme.spacing(14) + 103 // 215
-    },
-    [theme.breakpoints.up('xl')]: {
-      marginLeft: theme.spacing(22) + 99 // 275
-    }
+    flex: 1
   },
   fullWidthContent: {
     marginLeft: 0,
@@ -155,7 +149,7 @@ const Firewalls = React.lazy(() => import('src/features/Firewalls'));
 const MainContent: React.FC<CombinedProps> = props => {
   const classes = useStyles();
 
-  const [menuIsOpen, toggleMenu] = React.useState<boolean>(false);
+  const [, toggleMenu] = React.useState<boolean>(false);
 
   /**
    * this is the case where the user has successfully completed signup
@@ -224,9 +218,9 @@ const MainContent: React.FC<CombinedProps> = props => {
               [classes.hidden]: props.appIsLoading
             })}
           >
-            <SideMenu
-              open={menuIsOpen}
-              desktopOpen={desktopMenuIsOpen || false}
+            {/* @cmr */}
+            <PrimaryNav_CMR
+              isCollapsed={false}
               closeMenu={() => toggleMenu(false)}
               toggleTheme={props.toggleTheme}
               toggleSpacing={props.toggleSpacing}
@@ -307,7 +301,6 @@ const MainContent: React.FC<CombinedProps> = props => {
                 </Grid>
               </main>
             </div>
-
             <Footer desktopMenuIsOpen={desktopMenuIsOpen} />
             <ToastNotifications />
             <DomainDrawer />

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.styles.ts
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.styles.ts
@@ -1,0 +1,182 @@
+import { makeStyles, Theme } from 'src/components/core/styles';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  menuGrid: {
+    minHeight: 64,
+    width: '100%',
+    height: '100%',
+    margin: 0,
+    padding: 0,
+    [theme.breakpoints.up('sm')]: {
+      minHeight: 72
+    },
+    [theme.breakpoints.up('md')]: {
+      minHeight: 80
+    }
+  },
+  fadeContainer: {
+    width: '100%',
+    height: 'calc(100% - 90px)',
+    display: 'flex',
+    flexDirection: 'column'
+  },
+  logoItem: {
+    minHeight: 64,
+    position: 'relative',
+    display: 'flex',
+    alignItems: 'center',
+    padding: `
+        ${theme.spacing(2) - 2}px
+        0
+        ${theme.spacing(1) + theme.spacing(1) / 2}px
+        ${theme.spacing(4)}px
+      `,
+    '& svg': {
+      maxWidth: theme.spacing(3) + 91
+    }
+  },
+  logoCollapsed: {
+    '& .logoLetters': {
+      opacity: 0
+    }
+  },
+  listItem: {
+    display: 'flex',
+    alignItems: 'center',
+    position: 'relative',
+    cursor: 'pointer',
+    maxHeight: 42,
+    transition: theme.transitions.create(['background-color']),
+    padding: `
+        ${theme.spacing(1.5)}px
+        ${theme.spacing(4) - 2}px
+        ${theme.spacing(1.5) - 1}px
+        ${theme.spacing(4) + 1}px
+      `,
+    '&:hover': {
+      backgroundColor: theme.bg.primaryNavActiveBG,
+      '& $linkItem': {
+        color: 'white'
+      },
+      '& svg': {
+        fill: 'white',
+        '& *': {
+          stroke: 'white'
+        }
+      }
+    },
+    '& .icon': {
+      marginRight: theme.spacing(2),
+      '& svg': {
+        width: 26,
+        height: 26,
+        transform: 'scale(1.75)',
+        fill: theme.color.primaryNavText,
+        transition: theme.transitions.create(['fill']),
+        '&.small': {
+          transform: 'scale(1)'
+        },
+        '&:not(.wBorder) circle, & .circle': {
+          display: 'none'
+        },
+        '& *': {
+          transition: theme.transitions.create(['stroke']),
+          stroke: theme.color.primaryNavText
+        }
+      }
+    }
+  },
+  listItemCollapsed: {},
+  collapsible: {
+    fontSize: '0.9rem'
+  },
+  linkItem: {
+    transition: theme.transitions.create(['color']),
+    color: theme.color.primaryNavText,
+    opacity: 1,
+    whiteSpace: 'nowrap',
+    fontFamily: 'LatoWebBold', // we keep this bold at all times
+    '&.hiddenWhenCollapsed': {
+      opacity: 0
+    }
+  },
+  active: {
+    backgroundColor: theme.bg.primaryNavActiveBG,
+    '&:before': {
+      content: "''",
+      borderStyle: 'solid',
+      borderWidth: `
+          ${theme.spacing(1) + 11}px
+          ${theme.spacing(1) + 6}px
+          ${theme.spacing(1) + 11}px
+          0
+        `,
+      borderColor: `transparent ${theme.bg.primaryNavActive} transparent transparent`,
+      position: 'absolute',
+      right: 0,
+      top: theme.spacing(1) === 8 ? 2 : 0
+    },
+    '&:hover': {
+      '&:before': {
+        content: "''",
+        borderColor: `transparent ${theme.bg.primaryNavActive} transparent transparent`
+      }
+    },
+    [theme.breakpoints.down('sm')]: {
+      '&:before': {
+        display: 'none'
+      }
+    },
+    '&.listItemCollapsed': {
+      '&:before': {
+        top: theme.spacing(1) === 8 ? 2 : 4
+      }
+    }
+  },
+  spacer: {
+    padding: 25
+  },
+  divider: {
+    backgroundColor: 'rgba(0, 0, 0, 0.12)'
+  },
+  settings: {
+    width: 30,
+    margin: `auto auto 16px`,
+    alignItems: 'center',
+    justifyContent: 'center',
+    display: 'flex',
+    color: '#e7e7e7',
+    transition: theme.transitions.create(['color']),
+    '& svg': {
+      transition: theme.transitions.create(['transform'])
+    },
+    '&:hover': {
+      color: theme.color.green
+    }
+  },
+  settingsCollapsed: {
+    margin: `auto 16px 16px ${theme.spacing(4) - 1}px`
+  },
+  activeSettings: {
+    color: theme.color.green,
+    '& svg': {
+      transform: 'rotate(90deg)'
+    }
+  },
+  menu: {},
+  paper: {
+    maxWidth: 350,
+    padding: 8,
+    position: 'absolute',
+    backgroundColor: theme.bg.navy,
+    border: '1px solid #999',
+    outline: 0,
+    boxShadow: 'none',
+    minWidth: 185
+  },
+  settingsBackdrop: {
+    backgroundColor: 'rgba(0,0,0,.3)'
+  }
+}));
+
+export default useStyles;

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.styles.ts
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.styles.ts
@@ -2,38 +2,34 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 
 const useStyles = makeStyles((theme: Theme) => ({
   menuGrid: {
-    minHeight: 64,
+    minHeight: 50,
     width: '100%',
     height: '100%',
     margin: 0,
     padding: 0,
-    [theme.breakpoints.up('sm')]: {
-      minHeight: 72
-    },
-    [theme.breakpoints.up('md')]: {
-      minHeight: 80
+    backgroundColor: theme.bg.primaryNavPaper,
+    borderColor: theme.bg.primaryNavBorder,
+    left: 'inherit',
+    boxShadow: 'none',
+    transition: 'width linear .1s',
+    overflowX: 'scroll',
+    alignItems: 'center',
+    justifyContent: 'center',
+    [theme.breakpoints.down('md')]: {
+      justifyContent: 'left'
     }
   },
+  // @todo: better name for this container
   fadeContainer: {
-    width: '100%',
-    height: 'calc(100% - 90px)',
+    marginLeft: 8,
     display: 'flex',
-    flexDirection: 'column'
+    flexDirection: 'row',
+    alignItems: 'center'
   },
   logoItem: {
-    minHeight: 64,
     position: 'relative',
     display: 'flex',
-    alignItems: 'center',
-    padding: `
-        ${theme.spacing(2) - 2}px
-        0
-        ${theme.spacing(1) + theme.spacing(1) / 2}px
-        ${theme.spacing(4)}px
-      `,
-    '& svg': {
-      maxWidth: theme.spacing(3) + 91
-    }
+    alignItems: 'center'
   },
   logoCollapsed: {
     '& .logoLetters': {
@@ -45,52 +41,16 @@ const useStyles = makeStyles((theme: Theme) => ({
     alignItems: 'center',
     position: 'relative',
     cursor: 'pointer',
-    maxHeight: 42,
-    transition: theme.transitions.create(['background-color']),
-    padding: `
-        ${theme.spacing(1.5)}px
-        ${theme.spacing(4) - 2}px
-        ${theme.spacing(1.5) - 1}px
-        ${theme.spacing(4) + 1}px
-      `,
-    '&:hover': {
-      backgroundColor: theme.bg.primaryNavActiveBG,
-      '& $linkItem': {
-        color: 'white'
-      },
-      '& svg': {
-        fill: 'white',
-        '& *': {
-          stroke: 'white'
-        }
-      }
-    },
-    '& .icon': {
-      marginRight: theme.spacing(2),
-      '& svg': {
-        width: 26,
-        height: 26,
-        transform: 'scale(1.75)',
-        fill: theme.color.primaryNavText,
-        transition: theme.transitions.create(['fill']),
-        '&.small': {
-          transform: 'scale(1)'
-        },
-        '&:not(.wBorder) circle, & .circle': {
-          display: 'none'
-        },
-        '& *': {
-          transition: theme.transitions.create(['stroke']),
-          stroke: theme.color.primaryNavText
-        }
-      }
-    }
+    // temporary:
+    padding: `0 18px 0 18px`,
+    fontSize: '1rem'
   },
   listItemCollapsed: {},
   collapsible: {
     fontSize: '0.9rem'
   },
   linkItem: {
+    height: '100%',
     transition: theme.transitions.create(['color']),
     color: theme.color.primaryNavText,
     opacity: 1,
@@ -100,48 +60,10 @@ const useStyles = makeStyles((theme: Theme) => ({
       opacity: 0
     }
   },
-  active: {
-    backgroundColor: theme.bg.primaryNavActiveBG,
-    '&:before': {
-      content: "''",
-      borderStyle: 'solid',
-      borderWidth: `
-          ${theme.spacing(1) + 11}px
-          ${theme.spacing(1) + 6}px
-          ${theme.spacing(1) + 11}px
-          0
-        `,
-      borderColor: `transparent ${theme.bg.primaryNavActive} transparent transparent`,
-      position: 'absolute',
-      right: 0,
-      top: theme.spacing(1) === 8 ? 2 : 0
-    },
-    '&:hover': {
-      '&:before': {
-        content: "''",
-        borderColor: `transparent ${theme.bg.primaryNavActive} transparent transparent`
-      }
-    },
-    [theme.breakpoints.down('sm')]: {
-      '&:before': {
-        display: 'none'
-      }
-    },
-    '&.listItemCollapsed': {
-      '&:before': {
-        top: theme.spacing(1) === 8 ? 2 : 4
-      }
-    }
-  },
-  spacer: {
-    padding: 25
-  },
   divider: {
     backgroundColor: 'rgba(0, 0, 0, 0.12)'
   },
   settings: {
-    width: 30,
-    margin: `auto auto 16px`,
     alignItems: 'center',
     justifyContent: 'center',
     display: 'flex',

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.tsx
@@ -1,7 +1,7 @@
 import Settings from '@material-ui/icons/Settings';
 import * as classNames from 'classnames';
 import * as React from 'react';
-import { Link, useLocation, LinkProps } from 'react-router-dom';
+import { Link, LinkProps } from 'react-router-dom';
 import Kubernetes from 'src/assets/addnewmenu/kubernetes.svg';
 import OCA from 'src/assets/addnewmenu/oneclick.svg';
 import Account from 'src/assets/icons/account.svg';

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.tsx
@@ -28,10 +28,9 @@ import useFlags from 'src/hooks/useFlags';
 import usePrefetch from 'src/hooks/usePreFetch';
 import { sendOneClickNavigationEvent } from 'src/utilities/ga';
 import AdditionalMenuItems from './AdditionalMenuItems';
-import useStyles from './PrimaryNav.styles';
+import useStyles from './PrimaryNav_CMR.styles';
 import SpacingToggle from './SpacingToggle';
 import ThemeToggle from './ThemeToggle';
-import { linkIsActive } from './utils';
 import useDomains from 'src/hooks/useDomains';
 
 type NavEntity =
@@ -145,28 +144,33 @@ export const PrimaryNav: React.FC<Props> = props => {
         icon: <Longview className="small" />
       },
       {
+        hide: true,
         display: 'Kubernetes',
         href: '/kubernetes/clusters',
         icon: <Kubernetes />
       },
       {
-        hide: !_isManagedAccount,
+        hide: true,
+        // hide: !_isManagedAccount,
         display: 'Managed',
         href: '/managed',
         icon: <Managed />
       },
       {
+        hide: true,
         display: 'StackScripts',
         href: '/stackscripts?type=account',
         icon: <StackScript />
       },
       {
+        hide: true,
         display: 'Images',
         href: '/images',
         icon: <Image className="small" />
       },
       {
-        hide: account.lastUpdated === 0 || !_hasAccountAccess,
+        hide: true,
+        // hide: account.lastUpdated === 0 || !_hasAccountAccess,
         display: 'Account',
         href: '/account/billing',
         icon: <Account className="small" />,
@@ -192,7 +196,7 @@ export const PrimaryNav: React.FC<Props> = props => {
       container
       alignItems="flex-start"
       justify="flex-start"
-      direction="column"
+      direction="row"
       wrap="nowrap"
       spacing={0}
       component="nav"
@@ -206,7 +210,7 @@ export const PrimaryNav: React.FC<Props> = props => {
           })}
         >
           <Link to={`/dashboard`} onClick={closeMenu} title="Dashboard">
-            <Logo width={115} height={43} />
+            <Logo width={101} height={29} />
           </Link>
         </div>
       </Grid>
@@ -243,12 +247,9 @@ export const PrimaryNav: React.FC<Props> = props => {
 
         {/** menu items under the main navigation links */}
         <AdditionalMenuItems
-          linkClasses={(href?: string) =>
+          linkClasses={() =>
             classNames({
-              [classes.listItem]: true,
-              [classes.active]: href
-                ? linkIsActive(href, location.search, location.pathname)
-                : false
+              [classes.listItem]: true
             })
           }
           listItemClasses={classNames({
@@ -265,15 +266,7 @@ export const PrimaryNav: React.FC<Props> = props => {
             to="/profile/display"
             onClick={closeMenu}
             data-qa-nav-item="/profile/display"
-            className={classNames({
-              [classes.listItem]: true,
-              [classes.active]:
-                linkIsActive(
-                  '/profile/display',
-                  location.search,
-                  location.pathname
-                ) === true
-            })}
+            className={classes.listItem}
           >
             <ListItemText
               primary="My Profile"
@@ -300,7 +293,6 @@ export const PrimaryNav: React.FC<Props> = props => {
             />
           </Link>
         </Hidden>
-        <div className={classes.spacer} />
         <IconButton
           onClick={(event: React.MouseEvent<HTMLElement>) => {
             setAnchorEl(event.currentTarget);
@@ -362,11 +354,11 @@ const PrimaryLink: React.FC<PrimaryLinkProps> = React.memo(props => {
     href,
     onClick,
     attr,
-    activeLinks,
+    // activeLinks,
     icon,
     display,
-    locationSearch,
-    locationPathname,
+    // locationSearch,
+    // locationPathname,
     prefetchProps
   } = props;
 
@@ -382,16 +374,7 @@ const PrimaryLink: React.FC<PrimaryLinkProps> = React.memo(props => {
         }}
         {...prefetchProps}
         {...attr}
-        className={classNames({
-          [classes.listItem]: true,
-          [classes.active]: linkIsActive(
-            href,
-            locationSearch,
-            locationPathname,
-            activeLinks
-          ),
-          listItemCollapsed: isCollapsed
-        })}
+        className={classes.listItem}
       >
         {icon && isCollapsed && <div className="icon">{icon}</div>}
         <ListItemText

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.tsx
@@ -1,0 +1,433 @@
+import Settings from '@material-ui/icons/Settings';
+import * as classNames from 'classnames';
+import * as React from 'react';
+import { Link, useLocation, LinkProps } from 'react-router-dom';
+import Kubernetes from 'src/assets/addnewmenu/kubernetes.svg';
+import OCA from 'src/assets/addnewmenu/oneclick.svg';
+import Account from 'src/assets/icons/account.svg';
+import Dashboard from 'src/assets/icons/dashboard.svg';
+import Storage from 'src/assets/icons/entityIcons/bucket.svg';
+import Domain from 'src/assets/icons/entityIcons/domain.svg';
+import Firewall from 'src/assets/icons/entityIcons/firewall.svg';
+import Image from 'src/assets/icons/entityIcons/image.svg';
+import Linode from 'src/assets/icons/entityIcons/linode.svg';
+import NodeBalancer from 'src/assets/icons/entityIcons/nodebalancer.svg';
+import StackScript from 'src/assets/icons/entityIcons/stackscript.svg';
+import Volume from 'src/assets/icons/entityIcons/volume.svg';
+import Longview from 'src/assets/icons/longview.svg';
+import Managed from 'src/assets/icons/managednav.svg';
+import Logo from 'src/assets/logo/new-logo.svg';
+import Divider from 'src/components/core/Divider';
+import Grid from 'src/components/core/Grid';
+import Hidden from 'src/components/core/Hidden';
+import IconButton from 'src/components/core/IconButton';
+import ListItemText from 'src/components/core/ListItemText';
+import Menu from 'src/components/core/Menu';
+import useAccountManagement from 'src/hooks/useAccountManagement';
+import useFlags from 'src/hooks/useFlags';
+import usePrefetch from 'src/hooks/usePreFetch';
+import { sendOneClickNavigationEvent } from 'src/utilities/ga';
+import AdditionalMenuItems from './AdditionalMenuItems';
+import useStyles from './PrimaryNav.styles';
+import SpacingToggle from './SpacingToggle';
+import ThemeToggle from './ThemeToggle';
+import { linkIsActive } from './utils';
+import useDomains from 'src/hooks/useDomains';
+
+type NavEntity =
+  | 'Linodes'
+  | 'Volumes'
+  | 'NodeBalancers'
+  | 'Domains'
+  | 'Longview'
+  | 'Kubernetes'
+  | 'Object Storage'
+  | 'Managed'
+  | 'Marketplace'
+  | 'Images'
+  | 'Firewalls'
+  | 'Account'
+  | 'Dashboard'
+  | 'StackScripts';
+
+interface PrimaryLink {
+  display: NavEntity;
+  href: string;
+  attr?: { [key: string]: any };
+  icon?: JSX.Element;
+  activeLinks?: Array<string>;
+  onClick?: (e: React.ChangeEvent<any>) => void;
+  hide?: boolean;
+  prefetchRequestFn?: () => void;
+  prefetchRequestCondition?: boolean;
+}
+
+export interface Props {
+  closeMenu: () => void;
+  toggleTheme: () => void;
+  toggleSpacing: () => void;
+  isCollapsed: boolean;
+}
+
+export const PrimaryNav: React.FC<Props> = props => {
+  const { closeMenu, isCollapsed, toggleTheme, toggleSpacing } = props;
+  const classes = useStyles();
+
+  const [anchorEl, setAnchorEl] = React.useState<
+    (EventTarget & HTMLElement) | undefined
+  >();
+
+  const flags = useFlags();
+  const location = useLocation();
+  const { domains, requestDomains } = useDomains();
+
+  const {
+    _hasAccountAccess,
+    _isManagedAccount,
+    account
+  } = useAccountManagement();
+
+  const primaryLinks: PrimaryLink[] = React.useMemo(
+    () => [
+      {
+        display: 'Dashboard',
+        href: '/dashboard',
+        icon: <Dashboard className="small" />
+      },
+      {
+        display: 'Linodes',
+        href: '/linodes',
+        activeLinks: ['/linodes', '/linodes/create'],
+        icon: <Linode />
+      },
+      {
+        display: 'Volumes',
+        href: '/volumes',
+        icon: <Volume />
+      },
+      {
+        display: 'Object Storage',
+        href: '/object-storage/buckets',
+        activeLinks: ['/object-storage/buckets', '/object-storage/access-keys'],
+        icon: <Storage />
+      },
+      {
+        display: 'NodeBalancers',
+        href: '/nodebalancers',
+        icon: <NodeBalancer />
+      },
+      {
+        display: 'Domains',
+        href: '/domains',
+        icon: <Domain style={{ transform: 'scale(1.5)' }} />,
+        prefetchRequestFn: requestDomains,
+        prefetchRequestCondition: !domains.loading && domains.lastUpdated === 0
+      },
+
+      {
+        hide: !flags.firewalls,
+        display: 'Firewalls',
+        href: '/firewalls',
+        icon: <Firewall />
+      },
+      {
+        display: 'Marketplace',
+        href: '/linodes/create?type=One-Click',
+        attr: { 'data-qa-one-click-nav-btn': true },
+        icon: <OCA />,
+        onClick: () => {
+          sendOneClickNavigationEvent('Primary Nav');
+        }
+      },
+      {
+        display: 'Longview',
+        href: '/longview',
+        icon: <Longview className="small" />
+      },
+      {
+        display: 'Kubernetes',
+        href: '/kubernetes/clusters',
+        icon: <Kubernetes />
+      },
+      {
+        hide: !_isManagedAccount,
+        display: 'Managed',
+        href: '/managed',
+        icon: <Managed />
+      },
+      {
+        display: 'StackScripts',
+        href: '/stackscripts?type=account',
+        icon: <StackScript />
+      },
+      {
+        display: 'Images',
+        href: '/images',
+        icon: <Image className="small" />
+      },
+      {
+        hide: account.lastUpdated === 0 || !_hasAccountAccess,
+        display: 'Account',
+        href: '/account/billing',
+        icon: <Account className="small" />,
+        activeLinks: ['/account/billing', '/account/users', '/account/settings']
+      }
+    ],
+    [
+      flags.firewalls,
+      _isManagedAccount,
+      account.lastUpdated,
+      _hasAccountAccess,
+      domains.loading,
+      domains.lastUpdated,
+      requestDomains
+    ]
+  );
+
+  const filteredLinks = primaryLinks.filter(thisLink => !thisLink.hide);
+
+  return (
+    <Grid
+      className={classes.menuGrid}
+      container
+      alignItems="flex-start"
+      justify="flex-start"
+      direction="column"
+      wrap="nowrap"
+      spacing={0}
+      component="nav"
+      role="navigation"
+    >
+      <Grid item>
+        <div
+          className={classNames({
+            [classes.logoItem]: true,
+            [classes.logoCollapsed]: isCollapsed
+          })}
+        >
+          <Link to={`/dashboard`} onClick={closeMenu} title="Dashboard">
+            <Logo width={115} height={43} />
+          </Link>
+        </div>
+      </Grid>
+      <div
+        className={classNames({
+          ['fade-in-table']: true,
+          [classes.fadeContainer]: true
+        })}
+      >
+        {filteredLinks.map(thisLink => {
+          const props = {
+            key: thisLink.display,
+            closeMenu,
+            isCollapsed,
+            locationSearch: location.search,
+            locationPathname: location.pathname,
+            ...thisLink
+          };
+
+          // PrefetchPrimaryLink and PrimaryLink are two separate components because invocation of
+          // hooks cannot be conditional. <PrefetchPrimaryLink /> is a wrapper around <PrimaryLink />
+          // that includes the usePrefetch hook.
+          return thisLink.prefetchRequestFn &&
+            thisLink.prefetchRequestCondition !== undefined ? (
+            <PrefetchPrimaryLink
+              {...props}
+              prefetchRequestFn={thisLink.prefetchRequestFn}
+              prefetchRequestCondition={thisLink.prefetchRequestCondition}
+            />
+          ) : (
+            <PrimaryLink {...props} />
+          );
+        })}
+
+        {/** menu items under the main navigation links */}
+        <AdditionalMenuItems
+          linkClasses={(href?: string) =>
+            classNames({
+              [classes.listItem]: true,
+              [classes.active]: href
+                ? linkIsActive(href, location.search, location.pathname)
+                : false
+            })
+          }
+          listItemClasses={classNames({
+            [classes.linkItem]: true
+          })}
+          closeMenu={closeMenu}
+          dividerClasses={classes.divider}
+          isCollapsed={isCollapsed}
+        />
+
+        <Hidden mdUp>
+          <Divider className={classes.divider} />
+          <Link
+            to="/profile/display"
+            onClick={closeMenu}
+            data-qa-nav-item="/profile/display"
+            className={classNames({
+              [classes.listItem]: true,
+              [classes.active]:
+                linkIsActive(
+                  '/profile/display',
+                  location.search,
+                  location.pathname
+                ) === true
+            })}
+          >
+            <ListItemText
+              primary="My Profile"
+              disableTypography={true}
+              className={classNames({
+                [classes.linkItem]: true
+              })}
+            />
+          </Link>
+          <Link
+            to="/logout"
+            onClick={closeMenu}
+            data-qa-nav-item="/logout"
+            className={classNames({
+              [classes.listItem]: true
+            })}
+          >
+            <ListItemText
+              primary="Log Out"
+              disableTypography={true}
+              className={classNames({
+                [classes.linkItem]: true
+              })}
+            />
+          </Link>
+        </Hidden>
+        <div className={classes.spacer} />
+        <IconButton
+          onClick={(event: React.MouseEvent<HTMLElement>) => {
+            setAnchorEl(event.currentTarget);
+          }}
+          className={classNames({
+            [classes.settings]: true,
+            [classes.settingsCollapsed]: isCollapsed,
+            [classes.activeSettings]: !!anchorEl
+          })}
+          aria-label="User settings"
+        >
+          <Settings />
+        </IconButton>
+        <Menu
+          id="settings-menu"
+          anchorEl={anchorEl}
+          open={Boolean(anchorEl)}
+          onClose={() => {
+            setAnchorEl(undefined);
+          }}
+          getContentAnchorEl={undefined}
+          PaperProps={{ square: true, className: classes.paper }}
+          anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+          transformOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+          className={classes.menu}
+          BackdropProps={{
+            className: classes.settingsBackdrop
+          }}
+        >
+          <ThemeToggle toggleTheme={toggleTheme} />
+          <SpacingToggle toggleSpacing={toggleSpacing} />
+        </Menu>
+      </div>
+    </Grid>
+  );
+};
+
+export default React.memo(PrimaryNav);
+
+interface PrimaryLinkProps extends PrimaryLink {
+  closeMenu: () => void;
+  isCollapsed: boolean;
+  locationSearch: string;
+  locationPathname: string;
+  prefetchProps?: {
+    onMouseEnter: LinkProps['onMouseEnter'];
+    onMouseLeave: LinkProps['onMouseLeave'];
+    onFocus: LinkProps['onFocus'];
+    onBlur: LinkProps['onBlur'];
+  };
+}
+
+const PrimaryLink: React.FC<PrimaryLinkProps> = React.memo(props => {
+  const classes = useStyles();
+
+  const {
+    isCollapsed,
+    closeMenu,
+    href,
+    onClick,
+    attr,
+    activeLinks,
+    icon,
+    display,
+    locationSearch,
+    locationPathname,
+    prefetchProps
+  } = props;
+
+  return (
+    <>
+      <Link
+        to={href}
+        onClick={(e: React.ChangeEvent<any>) => {
+          closeMenu();
+          if (onClick) {
+            onClick(e);
+          }
+        }}
+        {...prefetchProps}
+        {...attr}
+        className={classNames({
+          [classes.listItem]: true,
+          [classes.active]: linkIsActive(
+            href,
+            locationSearch,
+            locationPathname,
+            activeLinks
+          ),
+          listItemCollapsed: isCollapsed
+        })}
+      >
+        {icon && isCollapsed && <div className="icon">{icon}</div>}
+        <ListItemText
+          primary={display}
+          disableTypography={true}
+          className={classNames({
+            [classes.linkItem]: true,
+            primaryNavLink: true,
+            hiddenWhenCollapsed: isCollapsed
+          })}
+        />
+      </Link>
+      <Divider className={classes.divider} />
+    </>
+  );
+});
+
+interface PrefetchPrimaryLinkProps {
+  prefetchRequestFn: () => void;
+  prefetchRequestCondition: boolean;
+}
+
+// Wrapper around PrimaryLink that includes the usePrefetchHook.
+export const PrefetchPrimaryLink: React.FC<PrimaryLinkProps &
+  PrefetchPrimaryLinkProps> = React.memo(props => {
+  const { makeRequest, cancelRequest } = usePrefetch(
+    props.prefetchRequestFn,
+    props.prefetchRequestCondition
+  );
+
+  const prefetchProps: PrimaryLinkProps['prefetchProps'] = {
+    onMouseEnter: makeRequest,
+    onFocus: makeRequest,
+    onMouseLeave: cancelRequest,
+    onBlur: cancelRequest
+  };
+
+  return <PrimaryLink {...props} prefetchProps={prefetchProps} />;
+});

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.tsx
@@ -77,7 +77,6 @@ export const PrimaryNav: React.FC<Props> = props => {
   >();
 
   const flags = useFlags();
-  const location = useLocation();
   const { domains, requestDomains } = useDomains();
 
   const {
@@ -225,8 +224,6 @@ export const PrimaryNav: React.FC<Props> = props => {
             key: thisLink.display,
             closeMenu,
             isCollapsed,
-            locationSearch: location.search,
-            locationPathname: location.pathname,
             ...thisLink
           };
 
@@ -335,8 +332,6 @@ export default React.memo(PrimaryNav);
 interface PrimaryLinkProps extends PrimaryLink {
   closeMenu: () => void;
   isCollapsed: boolean;
-  locationSearch: string;
-  locationPathname: string;
   prefetchProps?: {
     onMouseEnter: LinkProps['onMouseEnter'];
     onMouseLeave: LinkProps['onMouseLeave'];
@@ -354,11 +349,8 @@ const PrimaryLink: React.FC<PrimaryLinkProps> = React.memo(props => {
     href,
     onClick,
     attr,
-    // activeLinks,
     icon,
     display,
-    // locationSearch,
-    // locationPathname,
     prefetchProps
   } = props;
 

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -17,6 +17,7 @@ interface Flags {
   oneClickApps: OneClickApp;
   promotionalOffers: PromotionalOffer[];
   thirdPartyAuth: boolean;
+  cmr: boolean;
 }
 
 type PromotionalOfferFeature =


### PR DESCRIPTION
## Description

This PR moves the PrimaryNav from the left side of the viewport to the top. **Note** that the organization of the links will be done in the next PR. For now, I've hidden a few of the links so the proportions roughly match those of the designs.

Notes:
- Make sure you're testing in the LD testing environment.
- There's a noticeable shift when the flag is evaluated... in a separate PR I'm going to adjust this.
- The diff is going to be large for these PRs, but I structured the commits in such a way that if you de-select the first commit when viewing the diff, you should see an accurate representation of what actually changed.

Still to do:

- General markup/CSS cleanup. A lot of it is now unused so it can be removed.

<img width="1677" alt="Screen Shot 2020-05-29 at 5 46 07 PM" src="https://user-images.githubusercontent.com/16911484/83308482-d95b4f00-a1d4-11ea-833a-2ac87a133146.png">

