### PR TITLE
M3-4173: Show error when user reaches Volumes limit

### DIFF
--- a/packages/manager/src/features/Volumes/VolumeDrawer/ConfigSelect.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/ConfigSelect.tsx
@@ -16,15 +16,13 @@ interface Props {
 type ConfigTuple = [number, string];
 interface State {
   configs: ConfigTuple[];
-  loading: boolean;
 }
 
 type CombinedProps = Props;
 
 class ConfigSelect extends React.Component<CombinedProps, State> {
   state: State = {
-    configs: [],
-    loading: false
+    configs: []
   };
 
   setInitialState = () => {
@@ -96,9 +94,9 @@ class ConfigSelect extends React.Component<CombinedProps, State> {
 
   render() {
     const { error, onChange, name, onBlur, value, ...rest } = this.props;
-    const { loading, configs } = this.state;
+    const { configs } = this.state;
 
-    if (!loading && configs.length < 1) {
+    if (configs.length < 1) {
       return null;
     }
 

--- a/packages/manager/src/features/Volumes/VolumeDrawer/ConfigSelect.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/ConfigSelect.tsx
@@ -98,7 +98,7 @@ class ConfigSelect extends React.Component<CombinedProps, State> {
     const { error, onChange, name, onBlur, value, ...rest } = this.props;
     const { loading, configs } = this.state;
 
-    if (!loading && configs.length <= 1) {
+    if (!loading && configs.length < 1) {
       return null;
     }
 

--- a/packages/manager/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
@@ -101,7 +101,9 @@ const CreateVolumeForm: React.FC<CombinedProps> = props => {
           label,
           size: maybeCastToNumber(size),
           linode_id: maybeCastToNumber(linodeId),
-          config_id: maybeCastToNumber(config_id),
+          config_id:
+            // config_id still set to default value of -1? make it undefined, so volume gets created on back-end according to the API logic
+            config_id === -1 ? undefined : maybeCastToNumber(config_id),
           tags: tags.map(v => v.value)
         })
           .then(({ label: newLabel, filesystem_path }) => {
@@ -146,9 +148,16 @@ const CreateVolumeForm: React.FC<CombinedProps> = props => {
          * This form doesn't have a region select (the region is auto-populated)
          * so if the API returns an error with field === 'region' the field mapping
          * logic will pass over it. Explicitly use general error Notice in this case.
-         * If a config_id error is set, set the general error Notice to that.
+         * If configs are not available, set the general error Notice to the config_id error (so that the error still shows in the UI instead of creation failing silently).
          */
-        const generalError = status ? status.generalError : errors.region;
+
+        const { config_id } = values;
+
+        const generalError = status
+          ? status.generalError
+          : config_id === -1
+          ? errors.config_id
+          : errors.region;
 
         return (
           <Form>

--- a/packages/manager/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
@@ -56,7 +56,7 @@ const styles = (theme: Theme) =>
 
 interface Props {
   onClose: () => void;
-  linodeId: number;
+  linode_id: number;
   linodeLabel: string;
   linodeRegion: string;
   onSuccess: (
@@ -76,7 +76,7 @@ const CreateVolumeForm: React.FC<CombinedProps> = props => {
   const {
     onClose,
     onSuccess,
-    linodeId,
+    linode_id,
     linodeLabel,
     linodeRegion,
     actions,
@@ -100,9 +100,9 @@ const CreateVolumeForm: React.FC<CombinedProps> = props => {
         createVolume({
           label,
           size: maybeCastToNumber(size),
-          linode_id: maybeCastToNumber(linodeId),
+          linode_id: maybeCastToNumber(linode_id),
           config_id:
-            // config_id still set to default value of -1? make it undefined, so volume gets created on back-end according to the API logic
+            // If the config_id still set to default value of -1, set this to undefined, so volume gets created on back-end according to the API logic
             config_id === -1 ? undefined : maybeCastToNumber(config_id),
           tags: tags.map(v => v.value)
         })
@@ -217,7 +217,7 @@ const CreateVolumeForm: React.FC<CombinedProps> = props => {
 
             <ConfigSelect
               error={touched.config_id ? errors.config_id : undefined}
-              linodeId={linodeId}
+              linodeId={linode_id}
               name="configId"
               onBlur={handleBlur}
               onChange={(id: number) => setFieldValue('config_id', id)}
@@ -264,7 +264,7 @@ interface FormState {
   label: string;
   size: number;
   region: string;
-  linodeId: number;
+  linode_id: number;
   config_id: number;
   tags: Tag[];
 }
@@ -273,7 +273,7 @@ const initialValues: FormState = {
   label: '',
   size: 20,
   region: 'none',
-  linodeId: -1,
+  linode_id: -1,
   config_id: -1,
   tags: []
 };
@@ -294,7 +294,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, Props> = (
     switchToAttaching: () =>
       dispatch(
         openForAttaching(
-          ownProps.linodeId,
+          ownProps.linode_id,
           ownProps.linodeRegion,
           ownProps.linodeLabel
         )

--- a/packages/manager/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
@@ -90,7 +90,7 @@ const CreateVolumeForm: React.FC<CombinedProps> = props => {
       initialValues={initialValues}
       validationSchema={CreateVolumeSchema}
       onSubmit={(values, { setSubmitting, setStatus, setErrors }) => {
-        const { label, size, configId, tags } = values;
+        const { label, size, config_id, tags } = values;
 
         setSubmitting(true);
 
@@ -101,7 +101,7 @@ const CreateVolumeForm: React.FC<CombinedProps> = props => {
           label,
           size: maybeCastToNumber(size),
           linode_id: maybeCastToNumber(linodeId),
-          config_id: maybeCastToNumber(configId),
+          config_id: maybeCastToNumber(config_id),
           tags: tags.map(v => v.value)
         })
           .then(({ label: newLabel, filesystem_path }) => {
@@ -148,9 +148,7 @@ const CreateVolumeForm: React.FC<CombinedProps> = props => {
          * logic will pass over it. Explicitly use general error Notice in this case.
          * If a config_id error is set, set the general error Notice to that.
          */
-        const generalError = status
-          ? status.generalError
-          : errors.config_id ?? errors.region;
+        const generalError = status ? status.generalError : errors.region;
 
         return (
           <Form>
@@ -209,12 +207,12 @@ const CreateVolumeForm: React.FC<CombinedProps> = props => {
             />
 
             <ConfigSelect
-              error={touched.configId ? errors.configId : undefined}
+              error={touched.config_id ? errors.config_id : undefined}
               linodeId={linodeId}
               name="configId"
               onBlur={handleBlur}
-              onChange={(id: number) => setFieldValue('configId', id)}
-              value={values.configId}
+              onChange={(id: number) => setFieldValue('config_id', id)}
+              value={values.config_id}
               disabled={disabled}
             />
 
@@ -258,7 +256,7 @@ interface FormState {
   size: number;
   region: string;
   linodeId: number;
-  configId: number;
+  config_id: number;
   tags: Tag[];
 }
 
@@ -267,7 +265,7 @@ const initialValues: FormState = {
   size: 20,
   region: 'none',
   linodeId: -1,
-  configId: -1,
+  config_id: -1,
   tags: []
 };
 

--- a/packages/manager/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
@@ -146,8 +146,11 @@ const CreateVolumeForm: React.FC<CombinedProps> = props => {
          * This form doesn't have a region select (the region is auto-populated)
          * so if the API returns an error with field === 'region' the field mapping
          * logic will pass over it. Explicitly use general error Notice in this case.
+         * If a config_id error is set, set the general error Notice to that.
          */
-        const generalError = status ? status.generalError : errors.region;
+        const generalError = status
+          ? status.generalError
+          : errors.config_id ?? errors.region;
 
         return (
           <Form>
@@ -303,10 +306,7 @@ const mapStateToProps: MapState<StateProps, CombinedProps> = state => ({
   origin: state.volumeDrawer.origin
 });
 
-const connected = connect(
-  mapStateToProps,
-  mapDispatchToProps
-);
+const connected = connect(mapStateToProps, mapDispatchToProps);
 
 const enhanced = compose<CombinedProps, Props>(
   styled,

--- a/packages/manager/src/features/Volumes/VolumeDrawer/VolumeDrawer.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/VolumeDrawer.tsx
@@ -88,7 +88,7 @@ class VolumeDrawer extends React.PureComponent<CombinedProps> {
           linodeLabel !== undefined &&
           linodeRegion !== undefined && (
             <CreateVolumeForLinodeForm
-              linodeId={linodeId}
+              linode_id={linodeId}
               linodeLabel={linodeLabel}
               linodeRegion={linodeRegion}
               onSuccess={actions.openForConfig}
@@ -248,9 +248,6 @@ const titleFromState = (state: ApplicationState['volumeDrawer']) => {
   }
 };
 
-const connected = connect(
-  mapStateToProps,
-  mapDispatchToProps
-);
+const connected = connect(mapStateToProps, mapDispatchToProps);
 
 export default connected(VolumeDrawer);

--- a/packages/manager/src/utilities/formikErrorUtils.ts
+++ b/packages/manager/src/utilities/formikErrorUtils.ts
@@ -30,10 +30,7 @@ export const handleGeneralErrors = (
 
   const generalError = _apiErrors
     .reduce(
-      (result, { field, reason }) =>
-        field && !_apiErrors[0].reason.includes("Couldn't find room")
-          ? result
-          : [...result, reason],
+      (result, { field, reason }) => (field ? result : [...result, reason]),
       []
     )
     .join(',');

--- a/packages/manager/src/utilities/formikErrorUtils.ts
+++ b/packages/manager/src/utilities/formikErrorUtils.ts
@@ -30,7 +30,10 @@ export const handleGeneralErrors = (
 
   const generalError = _apiErrors
     .reduce(
-      (result, { field, reason }) => (field ? result : [...result, reason]),
+      (result, { field, reason }) =>
+        field && !_apiErrors[0].reason.includes("Couldn't find room")
+          ? result
+          : [...result, reason],
       []
     )
     .join(',');


### PR DESCRIPTION
## Description
Currently, if a user hits the limit for the number of Volumes on a Linode and attempts to add another Volume, the Create button spins and returns to its normal state, no error message is displayed, and a 400 response code hits the console.

This change is an attempt to ensure the API error message feeds through and displays.

Perhaps it is better to change the wording of the error displayed, instead of using the API error, to make it easier for users to understand.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers
To test:
1. Create 6 Volumes on an 8GB Linode
2. Attempt to create a 7th Volume
3. Observe: off this branch, the behavior described in the first paragraph of the Description; on this branch, you should see the error message displayed below

<img width="1437" alt="Screen Shot 2020-05-29 at 10 39 17 PM" src="https://user-images.githubusercontent.com/32860776/83317800-7cc05a00-a1fd-11ea-9cfd-880408577770.png">