### PR TITLE
Fix @webpack/svgr settings

### DIFF
--- a/packages/manager/config/webpack.config.dev.js
+++ b/packages/manager/config/webpack.config.dev.js
@@ -153,8 +153,8 @@ module.exports = {
               options: {
                 svgoConfig: {
                   plugins: [
-                    // by default preffixes classes with svg path or random string
-                    { prefixIds: false },
+                    // by default prefixes classes with svg path or random string
+                    { prefixIds: { prefixIds: true, prefixClassNames: false } },
                     // by default removes the viewbox attribute
                     { removeViewBox: false }
                   ]

--- a/packages/manager/config/webpack.config.prod.js
+++ b/packages/manager/config/webpack.config.prod.js
@@ -144,8 +144,8 @@ module.exports = {
               options: {
                 svgoConfig: {
                   plugins: [
-                    // by default preffixes classes with svg path or random string
-                    { prefixIds: false },
+                    // by default prefixes classes with svg path or random string
+                    { prefixIds: { prefixIds: true, prefixClassNames: false } },
                     // by default removes the viewbox attribute
                     { removeViewBox: false }
                   ]


### PR DESCRIPTION
## Description

Make our prefixing config more explicit, so that class names are not
auto-prefixed but ids are. We do some CSS targeting on class names
in SVGs, which prefixing breaks. Otoh id conflicts were causing
a visual bug in the Linode create flow, where the Mumbai flag svg
conflicted with the circle svg in the select plan panel.

## Note

To test: In the Linode create flow, select a type then choose Mumbai as your region. In prod the plan selection circle svg gets screwy, this should fix it. Other svg's throughout the app should be unchanged.