### PR TITLE
Update disabled state when selecting GPU plans

### DIFF
--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -60,7 +60,8 @@ const styles = (theme: Theme) =>
     },
     disabledRow: {
       backgroundColor: theme.bg.tableHeader,
-      cursor: 'not-allowed'
+      cursor: 'not-allowed',
+      opacity: 0.4
     },
     headingCellContainer: {
       display: 'flex',
@@ -155,7 +156,7 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
         <Hidden smDown>
           <TableRow
             data-qa-plan-row={type.label}
-            ariaLabel={rowAriaLabel}
+            aria-label={rowAriaLabel}
             key={type.id}
             onClick={
               !isSamePlan && !isDisabledClass

--- a/packages/manager/src/utilities/arrayToCommaSeparatedList/arrayToList.test.ts
+++ b/packages/manager/src/utilities/arrayToCommaSeparatedList/arrayToList.test.ts
@@ -18,4 +18,8 @@ describe('Array to comma-separated list', () => {
       'apples, peas, carrots, and peaches'
     );
   });
+
+  it('should handle undefined input', () => {
+    expect(arrayToList(undefined as any)).toEqual('');
+  });
 });

--- a/packages/manager/src/utilities/arrayToCommaSeparatedList/arrayToList.ts
+++ b/packages/manager/src/utilities/arrayToCommaSeparatedList/arrayToList.ts
@@ -1,4 +1,7 @@
 export default (input: string[]): string => {
+  if (!Array.isArray(input) || input.length === 0) {
+    return '';
+  }
   if (input.length === 1) {
     return input[0];
   }


### PR DESCRIPTION
- Reduce the opacity of disabled table rows in SelectPlanPanel
so it's more obvious that they're not active.

- Fix arrayToList to handle empty arrays or undefined input.

