### PR TITLE
Hotfix: remove required() from tags in Domain schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2020-06-03] - @linode/api-v4 v.0.27.1
+
+### Fixed
+
+Remove required from createDomain validation schema
+
 ## [2020-06-02] - v1.10.0
 
 ### Added:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed
 
-Remove required from createDomain validation schema
+- Remove required from createDomain validation schema
 
 ## [2020-06-02] - v1.10.0
 

--- a/packages/api-v4/package.json
+++ b/packages/api-v4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linode/api-v4",
-  "version": "0.27.0-alpha.0",
+  "version": "0.27.1-alpha.0",
   "homepage": "https://github.com/linode/manager/tree/develop/packages/api-v4",
   "bugs": {
     "url": "https://github.com/linode/manager/issues",

--- a/packages/api-v4/src/domains/domains.schema.ts
+++ b/packages/api-v4/src/domains/domains.schema.ts
@@ -32,9 +32,7 @@ export const createDomainSchema = domainSchemaBase.shape({
       /([a-zA-Z0-9-_]+\.)+([a-zA-Z]{2,3}\.)?([a-zA-Z]{2,16}|XN--[a-zA-Z0-9]+)/,
       'Domain is not valid.'
     ),
-  tags: array()
-    .of(string())
-    .required(),
+  tags: array().of(string()),
   type: mixed()
     .required()
     .oneOf(['master', 'slave']),

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -41,7 +41,7 @@
     "jspdf": "^1.5.3",
     "jspdf-autotable": "^3.2.4",
     "launchdarkly-react-client-sdk": "2.11.0",
-    "@linode/api-v4": "^0.27.0-alpha.0",
+    "@linode/api-v4": "^0.27.1-alpha.0",
     "logic-query-parser": "^0.0.5",
     "md5": "^2.2.1",
     "memoizee": "^0.4.14",


### PR DESCRIPTION
Tags should not be required when creating a Domain.