### PR TITLE
Add NPM publish action

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -31,8 +31,12 @@ jobs:
       with:
         name: lib
         path: packages/api-v4
-    # - name: Publish
-    #   run: yarn workspace @linode/api-v4 publish --dry-run
-    #   env:
-    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #     NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+    - name: Publish to npm
+      uses: JS-DevTools/npm-publish@v1
+      with:
+        token: ${{ secrets.NPM_AUTH_TOKEN }}
+        package: ./packages/api-v4/package.json
+
+    - if: steps.publish.type != 'none'
+      run: |
+        echo "Version changed: ${{ steps.publish.outputs.old-version }} => ${{ steps.publish.outputs.version }}"

--- a/packages/api-v4/package.json
+++ b/packages/api-v4/package.json
@@ -32,7 +32,6 @@
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",
     "lint": "yarn run eslint . --quiet --ext .js,.ts,.tsx",
     "typecheck": "tsc --noEmit true --emitDeclarationOnly false",
-    "prepublishOnly": "yarn lint && yarn typecheck && yarn format && yarn build",
     "precommit": "lint-staged"
   },
   "files": [


### PR DESCRIPTION
## Description

This will (hopefully) publish the JS client to NPM on every push to master, if the version in package.json has changed. Before our next release we can bump the version to beta (from alpha).

I'm a bit at a loss how to test this. There's no support for `--dry-run` in the action, so the only way to test it would be to run it from my fork, which would either publish it for real or publish it to my personal NPM account if I gave it a different token. Neither option seems awesome.

Our NPM access token is stored in Settings for this repo.