### PR TITLE
M3-4179 Save in-progress work when creating a StackScript

### DIFF
--- a/packages/manager/src/features/StackScripts/StackScriptForm/StackScriptForm.test.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptForm/StackScriptForm.test.tsx
@@ -8,21 +8,6 @@ import { normalizedImages as images } from 'src/__data__/images';
 describe('StackScriptCreate', () => {
   const component = shallow(
     <StackScriptForm
-      classes={{
-        titleWrapper: '',
-        root: '',
-        backButton: '',
-        createTitle: '',
-        labelField: '',
-        divider: '',
-        gridWithTips: '',
-        tips: '',
-        chipsContainer: '',
-        scriptTextarea: '',
-        revisionTextarea: '',
-        warning: '',
-        targetTag: ''
-      }}
       images={{
         available: images,
         selected: []
@@ -60,9 +45,5 @@ describe('StackScriptCreate', () => {
     expect(component.find('[data-qa-stackscript-target-select]')).toHaveLength(
       1
     );
-  });
-
-  it('should render a code text field', () => {
-    // not done yet!!
   });
 });

--- a/packages/manager/src/features/StackScripts/StackScriptForm/StackScriptForm.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptForm/StackScriptForm.tsx
@@ -6,12 +6,7 @@ import Button from 'src/components/Button';
 import Divider from 'src/components/core/Divider';
 import InputAdornment from 'src/components/core/InputAdornment';
 import Paper from 'src/components/core/Paper';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles
-} from 'src/components/core/styles';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import { Item } from 'src/components/EnhancedSelect/Select';
 import Grid from 'src/components/Grid';
@@ -21,88 +16,72 @@ import ImageSelect from 'src/features/Images/ImageSelect';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 import imageToItem from 'src/utilities/imageToItem';
 
-type ClassNames =
-  | 'root'
-  | 'backButton'
-  | 'titleWrapper'
-  | 'createTitle'
-  | 'labelField'
-  | 'divider'
-  | 'gridWithTips'
-  | 'tips'
-  | 'chipsContainer'
-  | 'scriptTextarea'
-  | 'revisionTextarea'
-  | 'warning'
-  | 'targetTag';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {
-      padding: theme.spacing(2)
-    },
-    backButton: {
-      margin: '5px 0 0 -16px',
-      '& svg': {
-        width: 34,
-        height: 34
-      }
-    },
-    createTitle: {
-      lineHeight: '2.25em'
-    },
-    divider: {
-      margin: `0 0 ${theme.spacing(2)}px 0`,
-      height: 0
-    },
-    labelField: {
-      '& input': {
-        paddingLeft: 0
-      }
-    },
-    titleWrapper: {
-      display: 'flex',
-      marginTop: 5
-    },
-    gridWithTips: {
-      maxWidth: '50%',
-      [theme.breakpoints.down('sm')]: {
-        maxWidth: '100%',
-        width: '100%'
-      }
-    },
-    tips: {
-      marginLeft: theme.spacing(4),
-      marginTop: `${theme.spacing(4)}px !important`,
-      padding: theme.spacing(4),
-      backgroundColor: theme.palette.divider,
-      [theme.breakpoints.down('lg')]: {
-        marginLeft: 0
-      },
-      [theme.breakpoints.down('md')]: {
-        paddingLeft: theme.spacing(2)
-      }
-    },
-    chipsContainer: {
-      maxWidth: 415
-    },
-    warning: {
-      marginTop: theme.spacing(4)
-    },
-    targetTag: {
-      margin: `${theme.spacing(1)}px ${theme.spacing(1)}px 0 0`
-    },
-    scriptTextarea: {
-      maxWidth: '100%',
-      height: 400,
-      '& textarea': {
-        height: '100%'
-      }
-    },
-    revisionTextarea: {
-      maxWidth: '100%'
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    padding: theme.spacing(2)
+  },
+  backButton: {
+    margin: '5px 0 0 -16px',
+    '& svg': {
+      width: 34,
+      height: 34
     }
-  });
+  },
+  createTitle: {
+    lineHeight: '2.25em'
+  },
+  divider: {
+    margin: `0 0 ${theme.spacing(2)}px 0`,
+    height: 0
+  },
+  labelField: {
+    '& input': {
+      paddingLeft: 0
+    }
+  },
+  titleWrapper: {
+    display: 'flex',
+    marginTop: 5
+  },
+  gridWithTips: {
+    maxWidth: '50%',
+    [theme.breakpoints.down('sm')]: {
+      maxWidth: '100%',
+      width: '100%'
+    }
+  },
+  tips: {
+    marginLeft: theme.spacing(4),
+    marginTop: `${theme.spacing(4)}px !important`,
+    padding: theme.spacing(4),
+    backgroundColor: theme.palette.divider,
+    [theme.breakpoints.down('lg')]: {
+      marginLeft: 0
+    },
+    [theme.breakpoints.down('md')]: {
+      paddingLeft: theme.spacing(2)
+    }
+  },
+  chipsContainer: {
+    maxWidth: 415
+  },
+  warning: {
+    marginTop: theme.spacing(4)
+  },
+  targetTag: {
+    margin: `${theme.spacing(1)}px ${theme.spacing(1)}px 0 0`
+  },
+  scriptTextarea: {
+    maxWidth: '100%',
+    height: 400,
+    '& textarea': {
+      height: '100%'
+    }
+  },
+  revisionTextarea: {
+    maxWidth: '100%'
+  }
+}));
 
 interface TextFieldHandler {
   value: string;
@@ -131,7 +110,7 @@ interface Props {
   disabled?: boolean;
 }
 
-type CombinedProps = Props & WithStyles<ClassNames>;
+type CombinedProps = Props;
 
 const errorResources = {
   label: 'A label',
@@ -141,143 +120,136 @@ const errorResources = {
 
 // exported as a class component, otherwise no display name
 // appears in tests
-export class StackScriptForm extends React.Component<CombinedProps> {
-  render() {
-    const {
-      currentUser,
-      classes,
-      label,
-      revision,
-      description,
-      script,
-      errors,
-      onSelectChange,
-      onSubmit,
-      onCancel,
-      isSubmitting,
-      images,
-      disabled
-    } = this.props;
+export const StackScriptForm: React.FC<CombinedProps> = props => {
+  const {
+    currentUser,
+    label,
+    revision,
+    description,
+    script,
+    errors,
+    onSelectChange,
+    onSubmit,
+    onCancel,
+    isSubmitting,
+    images,
+    disabled
+  } = props;
 
-    const hasErrorFor = getAPIErrorsFor(errorResources, errors);
-    const selectedImages = imageToItem(images.selected);
+  const classes = useStyles();
 
-    return (
-      <React.Fragment>
-        <Paper className={classes.root}>
-          <Grid container>
-            <Grid item className={classes.gridWithTips}>
-              <TextField
-                InputProps={{
-                  startAdornment: (
-                    <InputAdornment position="end">
-                      {currentUser} /
-                    </InputAdornment>
-                  )
-                }}
-                label="StackScript Label"
-                required
-                onChange={label.handler}
-                placeholder="Enter a label"
-                value={label.value}
-                errorText={hasErrorFor('label')}
-                tooltipText="Give your StackScript a label"
-                className={classes.labelField}
-                disabled={disabled}
-                data-qa-stackscript-label
-              />
-              <TextField
-                multiline
-                rows={1}
-                label="Description"
-                placeholder="Enter a description"
-                onChange={description.handler}
-                value={description.value}
-                tooltipText="Give your StackScript a description"
-                disabled={disabled}
-                data-qa-stackscript-description
-              />
-              <ImageSelect
-                images={Object.keys(images.available).map(
-                  eachKey => images.available[eachKey]
-                )}
-                onSelect={onSelectChange}
-                required
-                value={selectedImages}
-                isMulti
-                label="Target Images"
-                imageFieldError={hasErrorFor('images')}
-                helperText={
-                  'Select which images are compatible with this StackScript.'
-                }
-                disabled={disabled}
-                data-qa-stackscript-target-select
-              />
-            </Grid>
-            <Grid item className={classes.gridWithTips}>
-              <Notice className={classes.tips}>
-                <Typography variant="h2">Tips</Typography>
-                <Typography>
-                  There are four default environment variables provided to you:
-                </Typography>
-                <ul>
-                  <li>LINODE_ID</li>
-                  <li>LINODE_LISHUSERNAME</li>
-                  <li>LINODE_RAM</li>
-                  <li>LINODE_DATACENTERID</li>
-                </ul>
-              </Notice>
-            </Grid>
-          </Grid>
-          <Divider className={classes.divider} />
+  const hasErrorFor = getAPIErrorsFor(errorResources, errors);
+  const selectedImages = imageToItem(images.selected);
+
+  return (
+    <Paper className={classes.root}>
+      <Grid container>
+        <Grid item className={classes.gridWithTips}>
+          <TextField
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="end">{currentUser} /</InputAdornment>
+              )
+            }}
+            label="StackScript Label"
+            required
+            onChange={label.handler}
+            placeholder="Enter a label"
+            value={label.value}
+            errorText={hasErrorFor('label')}
+            tooltipText="Give your StackScript a label"
+            className={classes.labelField}
+            disabled={disabled}
+            data-qa-stackscript-label
+          />
           <TextField
             multiline
             rows={1}
-            label="Script"
-            placeholder={`#!/bin/bash \n\n# Your script goes here`}
-            onChange={script.handler}
-            value={script.value}
-            errorText={hasErrorFor('script')}
+            label="Description"
+            placeholder="Enter a description"
+            onChange={description.handler}
+            value={description.value}
+            tooltipText="Give your StackScript a description"
+            disabled={disabled}
+            data-qa-stackscript-description
+          />
+          <ImageSelect
+            images={Object.keys(images.available).map(
+              eachKey => images.available[eachKey]
+            )}
+            onSelect={onSelectChange}
             required
-            InputProps={{ className: classes.scriptTextarea }}
+            value={selectedImages}
+            isMulti
+            label="Target Images"
+            imageFieldError={hasErrorFor('images')}
+            helperText={
+              'Select which images are compatible with this StackScript.'
+            }
             disabled={disabled}
-            data-qa-stackscript-script
+            data-qa-stackscript-target-select
           />
-          <TextField
-            label="Revision Note"
-            placeholder="Enter a revision note"
-            onChange={revision.handler}
-            value={revision.value}
-            InputProps={{ className: classes.revisionTextarea }}
-            disabled={disabled}
-            data-qa-stackscript-revision
-          />
-          <ActionsPanel style={{ paddingBottom: 0 }}>
-            <Button
-              onClick={onSubmit}
-              buttonType="primary"
-              loading={isSubmitting}
-              disabled={disabled}
-              data-qa-save
-            >
-              Save
-            </Button>
-            <Button
-              onClick={onCancel}
-              buttonType="secondary"
-              className="cancel"
-              disabled={disabled}
-              data-qa-cancel
-            >
-              Reset
-            </Button>
-          </ActionsPanel>
-        </Paper>
-      </React.Fragment>
-    );
-  }
-}
+        </Grid>
+        <Grid item className={classes.gridWithTips}>
+          <Notice className={classes.tips}>
+            <Typography variant="h2">Tips</Typography>
+            <Typography>
+              There are four default environment variables provided to you:
+            </Typography>
+            <ul>
+              <li>LINODE_ID</li>
+              <li>LINODE_LISHUSERNAME</li>
+              <li>LINODE_RAM</li>
+              <li>LINODE_DATACENTERID</li>
+            </ul>
+          </Notice>
+        </Grid>
+      </Grid>
+      <Divider className={classes.divider} />
+      <TextField
+        multiline
+        rows={1}
+        label="Script"
+        placeholder={`#!/bin/bash \n\n# Your script goes here`}
+        onChange={script.handler}
+        value={script.value}
+        errorText={hasErrorFor('script')}
+        required
+        InputProps={{ className: classes.scriptTextarea }}
+        disabled={disabled}
+        data-qa-stackscript-script
+      />
+      <TextField
+        label="Revision Note"
+        placeholder="Enter a revision note"
+        onChange={revision.handler}
+        value={revision.value}
+        InputProps={{ className: classes.revisionTextarea }}
+        disabled={disabled}
+        data-qa-stackscript-revision
+      />
+      <ActionsPanel style={{ paddingBottom: 0 }}>
+        <Button
+          onClick={onSubmit}
+          buttonType="primary"
+          loading={isSubmitting}
+          disabled={disabled}
+          data-qa-save
+        >
+          Save
+        </Button>
+        <Button
+          onClick={onCancel}
+          buttonType="secondary"
+          className="cancel"
+          disabled={disabled}
+          data-qa-cancel
+        >
+          Reset
+        </Button>
+      </ActionsPanel>
+    </Paper>
+  );
+};
 
-const styled = withStyles(styles);
-
-export default styled(StackScriptForm);
+export default React.memo(StackScriptForm);

--- a/packages/manager/src/store/authentication/authentication.helpers.ts
+++ b/packages/manager/src/store/authentication/authentication.helpers.ts
@@ -1,4 +1,8 @@
-import { authentication, supportText } from 'src/utilities/storage';
+import {
+  authentication,
+  stackScriptInProgress,
+  supportText
+} from 'src/utilities/storage';
 
 export const clearLocalStorage = () => {
   authentication.token.set('');
@@ -12,4 +16,5 @@ export const clearUserInput = () => {
   // Support ticket title/description.
 
   supportText.set({ title: '', description: '' });
+  stackScriptInProgress.set({ label: '', script: '', images: [] });
 };

--- a/packages/manager/src/store/authentication/authentication.helpers.ts
+++ b/packages/manager/src/store/authentication/authentication.helpers.ts
@@ -16,5 +16,11 @@ export const clearUserInput = () => {
   // Support ticket title/description.
 
   supportText.set({ title: '', description: '' });
-  stackScriptInProgress.set({ label: '', script: '', images: [] });
+  stackScriptInProgress.set({
+    label: '',
+    script: '',
+    rev_note: '',
+    description: '',
+    images: []
+  });
 };

--- a/packages/manager/src/utilities/storage.ts
+++ b/packages/manager/src/utilities/storage.ts
@@ -1,3 +1,4 @@
+import { StackScriptPayload } from '@linode/api-v4/lib/stackscripts/types';
 const localStorageCache = {};
 
 export const getStorage = (key: string, fallback?: any) => {
@@ -45,6 +46,7 @@ const NONCE = 'authentication/nonce';
 const SCOPES = 'authentication/scopes';
 const EXPIRE = 'authentication/expire';
 const SUPPORT = 'support';
+const STACKSCRIPT = 'stackscript';
 
 export type PageSize = number;
 
@@ -80,6 +82,10 @@ export interface Storage {
   supportText: {
     get: () => SupportText;
     set: (v: SupportText) => void;
+  };
+  stackScriptInProgress: {
+    get: () => StackScriptPayload;
+    set: (s: StackScriptPayload) => void;
   };
 }
 
@@ -128,6 +134,18 @@ export const storage: Storage = {
   supportText: {
     get: () => getStorage(SUPPORT, { title: '', description: '' }),
     set: v => setStorage(SUPPORT, JSON.stringify(v))
+  },
+  stackScriptInProgress: {
+    get: () =>
+      getStorage(STACKSCRIPT, {
+        script: '',
+        label: '',
+        images: [],
+        description: '',
+        is_public: false,
+        rev_note: ''
+      }),
+    set: s => setStorage(STACKSCRIPT, JSON.stringify(s))
   }
 };
 

--- a/packages/manager/src/utilities/storage.ts
+++ b/packages/manager/src/utilities/storage.ts
@@ -140,13 +140,15 @@ export const storage: Storage = {
       getStorage(STACKSCRIPT, {
         script: '',
         label: '',
-        images: [],
-        description: '',
-        is_public: false,
-        rev_note: ''
+        images: []
       }),
     set: s => setStorage(STACKSCRIPT, JSON.stringify(s))
   }
 };
 
-export const { authentication, BackupsCtaDismissed, supportText } = storage;
+export const {
+  authentication,
+  BackupsCtaDismissed,
+  stackScriptInProgress,
+  supportText
+} = storage;


### PR DESCRIPTION
## Description

Does for StackScript creation what we did for Support Tickets. In-progress work is saved to localStorage and read when loading the component. Creating is simple, but editing is much harder and involves a lot of refactoring, which is why I'm breaking this into two PRs.

## Note

There is one broken test in StackscriptForm that I fixed in the editing work. Please disregard.