### PR TITLE
M3-4016: Some changes to clarify Linode password fields in Reset Root Password vs. Rebuild

### DIFF
--- a/packages/manager/src/components/AccessPanel/AccessPanel.tsx
+++ b/packages/manager/src/components/AccessPanel/AccessPanel.tsx
@@ -80,7 +80,6 @@ interface Props {
   isOptional?: boolean;
   hideHelperText?: boolean;
   passwordHelperText?: string;
-  passwordHelperTextPosition?: 'top' | 'bottom' | undefined;
 }
 
 export interface UserSSHKeyObject {
@@ -115,7 +114,6 @@ class AccessPanel extends React.Component<CombinedProps> {
       isOptional,
       hideHelperText,
       passwordHelperText,
-      passwordHelperTextPosition,
       requestKeys
     } = this.props;
 
@@ -147,7 +145,6 @@ class AccessPanel extends React.Component<CombinedProps> {
               hideStrengthLabel={hideStrengthLabel}
               hideHelperText={hideHelperText}
               helperText={passwordHelperText}
-              helperTextPosition={passwordHelperTextPosition}
             />
           </React.Suspense>
           {users && (

--- a/packages/manager/src/components/AccessPanel/AccessPanel.tsx
+++ b/packages/manager/src/components/AccessPanel/AccessPanel.tsx
@@ -79,6 +79,8 @@ interface Props {
   small?: boolean;
   isOptional?: boolean;
   hideHelperText?: boolean;
+  passwordHelperText?: string;
+  passwordHelperTextPosition?: 'top' | 'bottom' | undefined;
 }
 
 export interface UserSSHKeyObject {
@@ -112,6 +114,8 @@ class AccessPanel extends React.Component<CombinedProps> {
       small,
       isOptional,
       hideHelperText,
+      passwordHelperText,
+      passwordHelperTextPosition,
       requestKeys
     } = this.props;
 
@@ -142,6 +146,8 @@ class AccessPanel extends React.Component<CombinedProps> {
               onChange={this.handleChange}
               hideStrengthLabel={hideStrengthLabel}
               hideHelperText={hideHelperText}
+              helperText={passwordHelperText}
+              helperTextPosition={passwordHelperTextPosition}
             />
           </React.Suspense>
           {users && (

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuild.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuild.tsx
@@ -67,8 +67,12 @@ const LinodeRebuild: React.FC<CombinedProps> = props => {
         <Typography data-qa-rebuild-desc>
           If you can't rescue an existing disk, it's time to rebuild your
           Linode. There are a couple of different ways you can do this: either
-          restore from a backup or start over with a fresh Linux distribution.
-          Rebuilding will destroy all data on all existing disks on this Linode.
+          restore from a backup or start over with a fresh Linux
+          distribution.&nbsp;
+          <b>
+            Rebuilding will destroy all data on all existing disks on this
+            Linode.
+          </b>
         </Typography>
         <EnhancedSelect
           options={options}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuild.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuild.tsx
@@ -44,6 +44,8 @@ const options = [
   { value: 'fromAccountStackScript', label: 'From Account StackScript' }
 ];
 
+const passwordHelperText = 'Set a password for your rebuilt Linode.';
+
 const LinodeRebuild: React.FC<CombinedProps> = props => {
   const { classes, linodeLabel, permissions } = props;
   const disabled = permissions === 'read_only';
@@ -84,18 +86,18 @@ const LinodeRebuild: React.FC<CombinedProps> = props => {
         />
       </Paper>
       {mode === 'fromImage' && (
-        <RebuildFromImage passwordHelperText="Set a password for your rebuilt Linode." />
+        <RebuildFromImage passwordHelperText={passwordHelperText} />
       )}
       {mode === 'fromCommunityStackScript' && (
         <RebuildFromStackScript
           type="community"
-          passwordHelperText="Set a password for your rebuilt Linode."
+          passwordHelperText={passwordHelperText}
         />
       )}
       {mode === 'fromAccountStackScript' && (
         <RebuildFromStackScript
           type="account"
-          passwordHelperText="Set a password for your rebuilt Linode."
+          passwordHelperText={passwordHelperText}
         />
       )}
     </div>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuild.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuild.tsx
@@ -68,10 +68,10 @@ const LinodeRebuild: React.FC<CombinedProps> = props => {
           If you can&#39;t rescue an existing disk, it&#39;s time to rebuild
           your Linode. There are a couple of different ways you can do restore
           from a backup or start over with a fresh Linux distribution.&nbsp;
-          <b>
+          <strong>
             Rebuilding will destroy all data on all existing disks on this
             Linode.
-          </b>
+          </strong>
         </Typography>
         <EnhancedSelect
           options={options}
@@ -84,16 +84,19 @@ const LinodeRebuild: React.FC<CombinedProps> = props => {
         />
       </Paper>
       {mode === 'fromImage' && (
-        <RebuildFromImage
-          passwordHelperText="Set a password for your rebuilt Linode."
-          passwordHelperTextPosition="bottom"
-        />
+        <RebuildFromImage passwordHelperText="Set a password for your rebuilt Linode." />
       )}
       {mode === 'fromCommunityStackScript' && (
-        <RebuildFromStackScript type="community" />
+        <RebuildFromStackScript
+          type="community"
+          passwordHelperText="Set a password for your rebuilt Linode."
+        />
       )}
       {mode === 'fromAccountStackScript' && (
-        <RebuildFromStackScript type="account" />
+        <RebuildFromStackScript
+          type="account"
+          passwordHelperText="Set a password for your rebuilt Linode."
+        />
       )}
     </div>
   );

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuild.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuild.tsx
@@ -65,10 +65,9 @@ const LinodeRebuild: React.FC<CombinedProps> = props => {
           Rebuild
         </Typography>
         <Typography data-qa-rebuild-desc>
-          If you can't rescue an existing disk, it's time to rebuild your
-          Linode. There are a couple of different ways you can do this: either
-          restore from a backup or start over with a fresh Linux
-          distribution.&nbsp;
+          If you can&#39;t rescue an existing disk, it&#39;s time to rebuild
+          your Linode. There are a couple of different ways you can do restore
+          from a backup or start over with a fresh Linux distribution.&nbsp;
           <b>
             Rebuilding will destroy all data on all existing disks on this
             Linode.
@@ -84,7 +83,12 @@ const LinodeRebuild: React.FC<CombinedProps> = props => {
           hideLabel
         />
       </Paper>
-      {mode === 'fromImage' && <RebuildFromImage />}
+      {mode === 'fromImage' && (
+        <RebuildFromImage
+          passwordHelperText="Set a password for your rebuilt Linode."
+          passwordHelperTextPosition="bottom"
+        />
+      )}
       {mode === 'fromCommunityStackScript' && (
         <RebuildFromStackScript type="community" />
       )}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.test.tsx
@@ -33,7 +33,6 @@ const props: CombinedProps = {
   enqueueSnackbar: jest.fn(),
   permissions: 'read_write',
   passwordHelperText: '',
-  passwordHelperTextPosition: undefined,
   requestKeys: jest.fn(),
   ...reactRouterProps
 };

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.test.tsx
@@ -32,6 +32,8 @@ const props: CombinedProps = {
   closeSnackbar: jest.fn(),
   enqueueSnackbar: jest.fn(),
   permissions: 'read_write',
+  passwordHelperText: '',
+  passwordHelperTextPosition: undefined,
   requestKeys: jest.fn(),
   ...reactRouterProps
 };

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
@@ -54,7 +54,6 @@ interface ContextProps {
 
 interface Props {
   passwordHelperText: string;
-  passwordHelperTextPosition: 'top' | 'bottom' | undefined;
 }
 
 export type CombinedProps = Props &
@@ -87,8 +86,7 @@ export const RebuildFromImage: React.FC<CombinedProps> = props => {
     enqueueSnackbar,
     history,
     permissions,
-    passwordHelperText,
-    passwordHelperTextPosition
+    passwordHelperText
   } = props;
 
   const disabled = permissions === 'read_only';
@@ -207,7 +205,6 @@ export const RebuildFromImage: React.FC<CombinedProps> = props => {
                   : undefined
               }
               passwordHelperText={passwordHelperText}
-              passwordHelperTextPosition={passwordHelperTextPosition}
             />
             <ActionsPanel>
               <Button
@@ -240,7 +237,7 @@ const linodeContext = withLinodeDetailContext(({ linode }) => ({
   permissions: linode._permissions
 }));
 
-const enhanced = compose<CombinedProps, {}>(
+const enhanced = compose<CombinedProps, Props>(
   linodeContext,
   withImages(),
   userSSHKeyHoc,

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
@@ -52,7 +52,13 @@ interface ContextProps {
   permissions: GrantLevel;
 }
 
-export type CombinedProps = WithImages &
+interface Props {
+  passwordHelperText: string;
+  passwordHelperTextPosition: 'top' | 'bottom' | undefined;
+}
+
+export type CombinedProps = Props &
+  WithImages &
   WithStyles<ClassNames> &
   ContextProps &
   UserSSHKeyProps &
@@ -80,7 +86,9 @@ export const RebuildFromImage: React.FC<CombinedProps> = props => {
     linodeId,
     enqueueSnackbar,
     history,
-    permissions
+    permissions,
+    passwordHelperText,
+    passwordHelperTextPosition
   } = props;
 
   const disabled = permissions === 'read_only';
@@ -198,6 +206,8 @@ export const RebuildFromImage: React.FC<CombinedProps> = props => {
                   ? "You don't have permissions to modify this Linode"
                   : undefined
               }
+              passwordHelperText={passwordHelperText}
+              passwordHelperTextPosition={passwordHelperTextPosition}
             />
             <ActionsPanel>
               <Button

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.test.tsx
@@ -41,6 +41,7 @@ const props: CombinedProps = {
   userSSHKeys: [],
   closeSnackbar: jest.fn(),
   enqueueSnackbar: jest.fn(),
+  passwordHelperText: '',
   ...reactRouterProps
 };
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.tsx
@@ -69,6 +69,7 @@ const styles = (theme: Theme) =>
 
 interface Props {
   type: 'community' | 'account';
+  passwordHelperText: string;
 }
 
 interface ContextProps {
@@ -104,7 +105,8 @@ export const RebuildFromStackScript: React.FC<CombinedProps> = props => {
     requestKeys,
     linodeId,
     enqueueSnackbar,
-    history
+    history,
+    passwordHelperText
   } = props;
 
   const [
@@ -346,6 +348,7 @@ export const RebuildFromStackScript: React.FC<CombinedProps> = props => {
                 sshKeyError={sshError}
                 requestKeys={requestKeys}
                 data-qa-access-panel
+                passwordHelperText={passwordHelperText}
               />
             </form>
             <ActionsPanel>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
@@ -230,7 +230,7 @@ class LinodeSettingsPasswordPanel extends React.Component<
           <React.Suspense fallback={<SuspenseLoader />}>
             <PasswordInput
               autoComplete="new-password"
-              label="Password"
+              label="New Root Password"
               value={this.state.value}
               onChange={this.handlePasswordChange}
               errorText={passwordError}
@@ -243,8 +243,6 @@ class LinodeSettingsPasswordPanel extends React.Component<
                   ? "You don't have permissions to modify this Linode"
                   : undefined
               }
-              helperText="You may change your root password here for this Linode if it is fully powered down."
-              helperTextPosition="bottom"
             />
           </React.Suspense>
         </form>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
@@ -243,6 +243,8 @@ class LinodeSettingsPasswordPanel extends React.Component<
                   ? "You don't have permissions to modify this Linode"
                   : undefined
               }
+              helperText="You may change your root password here for this Linode if it is fully powered down."
+              helperTextPosition="bottom"
             />
           </React.Suspense>
         </form>


### PR DESCRIPTION
## Description
Some users trying to reset their passwords may be confused by the Root Password fields in the Rebuild & Settings tabs, because each field has the same guidance information re: password requirements. It might also be easy to overlook the fact that rebuilding will wipe the Linode.

I bolded the `"Rebuilding will destroy all data on all existing disks on this Linode."` text in the Rebuild tab to make it more prominent, and added some helper text to the Root Password fields in the Rebuild & Settings tabs. The exact verbiage is still preliminary; awaiting Jay's approval on it.

## Type of Change
- Non breaking change ('update', 'change')
