### PR TITLE
M3-3030 maintenance revisited

### DIFF
--- a/packages/api-v4/src/linodes/types.ts
+++ b/packages/api-v4/src/linodes/types.ts
@@ -143,7 +143,8 @@ export type LinodeStatus =
   | 'deleting'
   | 'migrating'
   | 'cloning'
-  | 'restoring';
+  | 'restoring'
+  | 'stopped';
 
 export interface Config {
   id: number;

--- a/packages/manager/src/features/linodes/LinodesDetail/HostMaintenanceError.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/HostMaintenanceError.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import Notice from 'src/components/Notice';
+
+const HostMaintenanceError = () => (
+  <Notice
+    warning
+    text="This action is unavailable while your Linode's host is undergoing maintenance."
+  />
+);
+
+export default HostMaintenanceError;

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.tsx
@@ -182,6 +182,7 @@ export class LinodePowerButton extends React.Component<CombinedProps, State> {
     const isBusy = linodeInTransition(status, firstEventWithPercent);
     const isRunning = !isBusy && status === 'running';
     const isOffline = !isBusy && status === 'offline';
+    const isStopped = status === 'stopped';
     const isUnknown = !isRunning && !isOffline;
 
     const buttonText = () => {
@@ -191,6 +192,8 @@ export class LinodePowerButton extends React.Component<CombinedProps, State> {
         return 'Running';
       } else if (isOffline) {
         return 'Offline';
+      } else if (isStopped) {
+        return 'Stopped';
       } else {
         return 'Offline';
       }

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuild.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuild.tsx
@@ -1,4 +1,5 @@
 import { GrantLevel } from '@linode/api-v4/lib/account';
+import { LinodeStatus } from '@linode/api-v4/lib/linodes';
 import * as React from 'react';
 import { compose } from 'recompose';
 import Paper from 'src/components/core/Paper';
@@ -12,6 +13,7 @@ import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import EnhancedSelect, { Item } from 'src/components/EnhancedSelect/Select';
 import { withLinodeDetailContext } from '../linodeDetailContext';
+import HostMaintenanceError from '../HostMaintenanceError';
 import LinodePermissionsError from '../LinodePermissionsError';
 import RebuildFromImage from './RebuildFromImage';
 import RebuildFromStackScript from './RebuildFromStackScript';
@@ -30,6 +32,7 @@ const styles = (theme: Theme) =>
 
 interface ContextProps {
   linodeLabel: string;
+  linodeStatus: LinodeStatus;
   permissions: GrantLevel;
 }
 type CombinedProps = WithStyles<ClassNames> & ContextProps;
@@ -45,8 +48,10 @@ const options = [
 ];
 
 const LinodeRebuild: React.FC<CombinedProps> = props => {
-  const { classes, linodeLabel, permissions } = props;
-  const disabled = permissions === 'read_only';
+  const { classes, linodeLabel, linodeStatus, permissions } = props;
+  const hostMaintenance = linodeStatus === 'stopped';
+  const unauthorized = permissions === 'read_only';
+  const disabled = hostMaintenance || unauthorized;
 
   const [mode, setMode] = React.useState<MODES>('fromImage');
 
@@ -54,7 +59,8 @@ const LinodeRebuild: React.FC<CombinedProps> = props => {
     <div id="tabpanel-rebuild" role="tabpanel" aria-labelledby="tab-rebuild">
       <DocumentTitleSegment segment={`${linodeLabel} - Rebuild`} />
       <Paper className={classes.root}>
-        {disabled && <LinodePermissionsError />}
+        {unauthorized && <LinodePermissionsError />}
+        {hostMaintenance && <HostMaintenanceError />}
         <Typography
           role="heading"
           aria-level={2}
@@ -65,10 +71,11 @@ const LinodeRebuild: React.FC<CombinedProps> = props => {
           Rebuild
         </Typography>
         <Typography data-qa-rebuild-desc>
-          If you can't rescue an existing disk, it's time to rebuild your
-          Linode. There are a couple of different ways you can do this: either
-          restore from a backup or start over with a fresh Linux distribution.
-          Rebuilding will destroy all data on all existing disks on this Linode.
+          If you can&#39;t rescue an existing disk, it&#39;s time to rebuild
+          your Linode. There are a couple of different ways you can do this:
+          either restore from a backup or start over with a fresh Linux
+          distribution. Rebuilding will destroy all data on all existing disks
+          on this Linode.
         </Typography>
         <EnhancedSelect
           options={options}
@@ -80,12 +87,12 @@ const LinodeRebuild: React.FC<CombinedProps> = props => {
           hideLabel
         />
       </Paper>
-      {mode === 'fromImage' && <RebuildFromImage />}
+      {mode === 'fromImage' && <RebuildFromImage disabled={disabled} />}
       {mode === 'fromCommunityStackScript' && (
-        <RebuildFromStackScript type="community" />
+        <RebuildFromStackScript type="community" disabled={disabled} />
       )}
       {mode === 'fromAccountStackScript' && (
-        <RebuildFromStackScript type="account" />
+        <RebuildFromStackScript type="account" disabled={disabled} />
       )}
     </div>
   );
@@ -93,6 +100,7 @@ const LinodeRebuild: React.FC<CombinedProps> = props => {
 
 const linodeContext = withLinodeDetailContext(({ linode }) => ({
   linodeLabel: linode.label,
+  linodeStatus: linode.status,
   permissions: linode._permissions
 }));
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.test.tsx
@@ -33,6 +33,7 @@ const props: CombinedProps = {
   enqueueSnackbar: jest.fn(),
   permissions: 'read_write',
   requestKeys: jest.fn(),
+  disabled: false,
   ...reactRouterProps
 };
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
@@ -47,12 +47,17 @@ const styles = (theme: Theme) =>
     }
   });
 
+interface Props {
+  disabled: boolean;
+}
+
 interface ContextProps {
   linodeId: number;
   permissions: GrantLevel;
 }
 
-export type CombinedProps = WithImages &
+export type CombinedProps = Props &
+  WithImages &
   WithStyles<ClassNames> &
   ContextProps &
   UserSSHKeyProps &
@@ -72,6 +77,7 @@ const initialValues: RebuildFromImageForm = {
 export const RebuildFromImage: React.FC<CombinedProps> = props => {
   const {
     classes,
+    disabled,
     imagesData,
     imagesError,
     userSSHKeys,
@@ -79,11 +85,8 @@ export const RebuildFromImage: React.FC<CombinedProps> = props => {
     requestKeys,
     linodeId,
     enqueueSnackbar,
-    history,
-    permissions
+    history
   } = props;
-
-  const disabled = permissions === 'read_only';
 
   const [isDialogOpen, setIsDialogOpen] = React.useState<boolean>(false);
 
@@ -181,6 +184,7 @@ export const RebuildFromImage: React.FC<CombinedProps> = props => {
               handleChange={input => setFieldValue('root_pass', input)}
               updateFor={[
                 classes,
+                disabled,
                 values.root_pass,
                 errors,
                 sshError,
@@ -193,11 +197,6 @@ export const RebuildFromImage: React.FC<CombinedProps> = props => {
               requestKeys={requestKeys}
               data-qa-access-panel
               disabled={disabled}
-              disabledReason={
-                disabled
-                  ? "You don't have permissions to modify this Linode"
-                  : undefined
-              }
             />
             <ActionsPanel>
               <Button
@@ -230,7 +229,7 @@ const linodeContext = withLinodeDetailContext(({ linode }) => ({
   permissions: linode._permissions
 }));
 
-const enhanced = compose<CombinedProps, {}>(
+const enhanced = compose<CombinedProps, Props>(
   linodeContext,
   withImages(),
   userSSHKeyHoc,

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.test.tsx
@@ -39,6 +39,7 @@ const props: CombinedProps = {
   imagesError: {},
   imagesLastUpdated: 0,
   userSSHKeys: [],
+  disabled: false,
   closeSnackbar: jest.fn(),
   enqueueSnackbar: jest.fn(),
   ...reactRouterProps

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.tsx
@@ -69,6 +69,7 @@ const styles = (theme: Theme) =>
 
 interface Props {
   type: 'community' | 'account';
+  disabled: boolean;
 }
 
 interface ContextProps {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.test.tsx
@@ -38,6 +38,7 @@ describe('LinodeRescue', () => {
         volumesLastUpdated={1}
         linodeLabel=""
         permissions="read_write"
+        linodeStatus="running"
       />
     );
     const rescueComponentProps = component.instance().props;

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.tsx
@@ -1,5 +1,5 @@
 import { GrantLevel } from '@linode/api-v4/lib/account';
-import { Config, rescueLinode } from '@linode/api-v4/lib/linodes';
+import { Config, LinodeStatus, rescueLinode } from '@linode/api-v4/lib/linodes';
 import { APIError } from '@linode/api-v4/lib/types';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import { assoc, clamp, pathOr } from 'ramda';
@@ -28,6 +28,7 @@ import createDevicesFromStrings, {
   DevicesAsStrings
 } from 'src/utilities/createDevicesFromStrings';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import HostMaintenanceError from '../HostMaintenanceError';
 import LinodePermissionsError from '../LinodePermissionsError';
 import DeviceSelection, {
   ExtendedDisk,
@@ -59,6 +60,7 @@ interface ContextProps {
   linodeRegion?: string;
   linodeLabel: string;
   linodeDisks?: ExtendedDisk[];
+  linodeStatus: LinodeStatus;
   permissions: GrantLevel;
 }
 
@@ -214,91 +216,91 @@ export class LinodeRescue extends React.Component<CombinedProps, State> {
       volumesError,
       classes,
       linodeLabel,
+      linodeStatus,
       permissions
     } = this.props;
-    const disabled = permissions === 'read_only';
+
+    const unauthorized = permissions === 'read_only';
+    const hostMaintenance = linodeStatus === 'stopped';
+
+    const disabled = unauthorized || hostMaintenance;
 
     if (diskError) {
       return (
-        <React.Fragment>
-          <div
-            id="tabpanel-linode-detail-rescue"
-            role="tabpanel"
-            aria-labelledby="tab-linode-detail-rescue"
-          >
-            <DocumentTitleSegment segment={`${linodeLabel} - Rescue`} />
-            <ErrorState errorText="There was an error retrieving Disks information." />
-          </div>
-        </React.Fragment>
+        <div
+          id="tabpanel-linode-detail-rescue"
+          role="tabpanel"
+          aria-labelledby="tab-linode-detail-rescue"
+        >
+          <DocumentTitleSegment segment={`${linodeLabel} - Rescue`} />
+          <ErrorState errorText="There was an error retrieving Disks information." />
+        </div>
       );
     }
 
     if (volumesError) {
       return (
-        <React.Fragment>
-          <div
-            id="tabpanel-linode-detail-rescue"
-            role="tabpanel"
-            aria-labelledby="tab-linode-detail-rescue"
-          >
-            <DocumentTitleSegment segment={`${linodeLabel} - Rescue`} />
-            <ErrorState errorText="There was an error retrieving Volumes information." />
-          </div>
-        </React.Fragment>
+        <div
+          id="tabpanel-linode-detail-rescue"
+          role="tabpanel"
+          aria-labelledby="tab-linode-detail-rescue"
+        >
+          <DocumentTitleSegment segment={`${linodeLabel} - Rescue`} />
+          <ErrorState errorText="There was an error retrieving Volumes information." />
+        </div>
       );
     }
 
     return (
-      <React.Fragment>
-        <div id="tabpanel-rescue" role="tabpanel" aria-labelledby="tab-rescue">
-          <DocumentTitleSegment segment={`${linodeLabel} - Rescue`} />
-          <Paper className={classes.root}>
-            {disabled && <LinodePermissionsError />}
-            <Typography
-              role="heading"
-              aria-level={2}
-              variant="h2"
-              className={classes.title}
-              data-qa-title
-            >
-              Rescue
-            </Typography>
-            <Typography className={classes.intro}>
-              If you suspect that your primary filesystem is corrupt, use the
-              Linode Manager to boot your Linode into Rescue Mode. This is a
-              safe environment for performing many system recovery and disk
-              management tasks.
-            </Typography>
-            <DeviceSelection
-              slots={['sda', 'sdb', 'sdc', 'sdd', 'sde', 'sdf', 'sdg']}
-              devices={devices}
-              onChange={this.onChange}
-              getSelected={slot =>
-                pathOr('', ['rescueDevices', slot], this.state)
-              }
-              counter={this.state.counter}
-              rescue
+      <div id="tabpanel-rescue" role="tabpanel" aria-labelledby="tab-rescue">
+        <DocumentTitleSegment segment={`${linodeLabel} - Rescue`} />
+        <Paper className={classes.root}>
+          {unauthorized && <LinodePermissionsError />}
+          {hostMaintenance && <HostMaintenanceError />}
+          <Typography
+            role="heading"
+            aria-level={2}
+            variant="h2"
+            className={classes.title}
+            data-qa-title
+          >
+            Rescue
+          </Typography>
+          <Typography className={classes.intro}>
+            If you suspect that your primary filesystem is corrupt, use the
+            Linode Manager to boot your Linode into Rescue Mode. This is a safe
+            environment for performing many system recovery and disk management
+            tasks.
+          </Typography>
+          <DeviceSelection
+            slots={['sda', 'sdb', 'sdc', 'sdd', 'sde', 'sdf', 'sdg']}
+            devices={devices}
+            onChange={this.onChange}
+            getSelected={slot =>
+              pathOr('', ['rescueDevices', slot], this.state)
+            }
+            counter={this.state.counter}
+            rescue
+            disabled={disabled}
+          />
+          <AddNewLink
+            onClick={this.incrementCounter}
+            label="Add Disk"
+            disabled={disabled || this.state.counter >= 6}
+            left
+          />
+          <ActionsPanel>
+            <Button
+              onClick={this.onSubmit}
+              buttonType="primary"
+              data-qa-submit
               disabled={disabled}
-            />
-            <AddNewLink
-              onClick={this.incrementCounter}
-              label="Add Disk"
-              disabled={disabled || this.state.counter >= 6}
-              left
-            />
-            <ActionsPanel>
-              <Button
-                onClick={this.onSubmit}
-                buttonType="primary"
-                data-qa-submit
-                disabled={disabled}
-              >
-                Reboot into Rescue Mode
-              </Button>
-            </ActionsPanel>
-          </Paper>
-        </div>
-      </React.Fragment>
+            >
+              Reboot into Rescue Mode
+            </Button>
+          </ActionsPanel>
+        </Paper>
+      </div>
     );
   }
 }
@@ -309,6 +311,7 @@ const linodeContext = withLinodeDetailContext(({ linode }) => ({
   linodeId: linode.id,
   linodeRegion: linode.region,
   linodeLabel: linode.label,
+  linodeStatus: linode.status,
   linodeDisks: linode._disks.map(disk => assoc('_id', `disk-${disk.id}`, disk)),
   permissions: linode._permissions
 }));

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -37,6 +37,7 @@ import { linodeInTransition } from 'src/features/linodes/transitions';
 import { ApplicationState } from 'src/store';
 import { requestLinodeForStore } from 'src/store/linodes/linode.requests';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import HostMaintenanceError from '../HostMaintenanceError';
 import LinodePermissionsError from '../LinodePermissionsError';
 import ResizeConfirmation from './ResizeConfirmationDialog';
 
@@ -264,13 +265,17 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
       linodeLabel,
       permissions,
       classes,
-      linodeDisks
+      linodeDisks,
+      linodeStatus
     } = this.props;
     const type = [...currentTypesData, ...deprecatedTypesData].find(
       t => t.id === linodeType
     );
 
-    const disabled = permissions === 'read_only';
+    const hostMaintenance = linodeStatus === 'stopped';
+    const unauthorized = permissions === 'read_only';
+
+    const disabled = hostMaintenance || unauthorized;
 
     const currentPlanHeading = linodeType
       ? type
@@ -293,7 +298,8 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
       <div id="tabpanel-resize" role="tabpanel" aria-labelledby="tab-resize">
         <DocumentTitleSegment segment={`${linodeLabel} - Resize`} />
         <Paper className={classes.root}>
-          {disabled && <LinodePermissionsError />}
+          {unauthorized && <LinodePermissionsError />}
+          {disabled && <HostMaintenanceError />}
           <Typography
             role="heading"
             aria-level={2}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/HostMaintenance.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/HostMaintenance.tsx
@@ -1,0 +1,35 @@
+import { LinodeStatus } from '@linode/api-v4/lib/linodes/types';
+import * as React from 'react';
+import Typography from 'src/components/core/Typography';
+import Notice from 'src/components/Notice';
+
+interface Props {
+  linodeStatus: LinodeStatus;
+}
+
+export type CombinedProps = Props;
+
+export const HostMaintenance: React.FC<Props> = props => {
+  const { linodeStatus } = props;
+  if (linodeStatus !== 'stopped') {
+    return null;
+  }
+  return (
+    <Notice important warning>
+      <Typography variant="h3" style={{ paddingBottom: '8px' }}>
+        <strong>
+          An issue affecting the physical host this Linode resides on has been
+          detected.
+        </strong>
+      </Typography>
+      <Typography variant="body1">
+        We are working to resolve the issue as quickly as possible and will
+        update you as soon as we have more information. Your Linode will return
+        to its previous state once the issue is resolved. Thank you for your
+        patience and understanding.
+      </Typography>
+    </Notice>
+  );
+};
+
+export default HostMaintenance;

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
@@ -5,6 +5,7 @@ import { compose } from 'recompose';
 import { linodeInTransition } from 'src/features/linodes/transitions';
 import { withLinodeDetailContext } from '../linodeDetailContext';
 import LinodeBusyStatus from '../LinodeSummary/LinodeBusyStatus';
+import HostMaintenance from './HostMaintenance';
 import LinodeControls from './LinodeControls';
 import MutationNotification from './MutationNotification';
 import Notifications from './Notifications';
@@ -19,6 +20,7 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
 
   return (
     <React.Fragment>
+      <HostMaintenance linodeStatus={linodeStatus} />
       <MutationNotification disks={linodeDisks} />
       <Notifications />
       <LinodeControls />

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/Notifications.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/Notifications.tsx
@@ -69,6 +69,7 @@ const Notifications: React.FC<CombinedProps> = props => {
   };
 
   return (
+    // eslint-disable-next-line
     <>
       {linodeNotifications.map((n, idx) => {
         return (

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
@@ -130,9 +130,17 @@ export class LinodeActionMenu extends React.Component<CombinedProps, State> {
     const readOnlyProps = readOnly
       ? {
           disabled: true,
-          tooltip: readOnly && "You don't have permission to modify this Linode"
+          tooltip: "You don't have permission to modify this Linode"
         }
       : {};
+
+    const hasHostMaintenance = linodeStatus === 'stopped';
+    const maintenanceProps = {
+      disabled: hasHostMaintenance,
+      tooltip: hasHostMaintenance
+        ? 'This action is unavailable while your Linode is undergoing host maintenance.'
+        : undefined
+    };
 
     const noConfigs = hasMadeConfigsRequest && configs.length === 0;
 
@@ -160,7 +168,8 @@ export class LinodeActionMenu extends React.Component<CombinedProps, State> {
             e.preventDefault();
             e.stopPropagation();
           },
-          ...readOnlyProps
+          ...readOnlyProps,
+          ...maintenanceProps
         },
         {
           title: 'Migrate',
@@ -183,7 +192,8 @@ export class LinodeActionMenu extends React.Component<CombinedProps, State> {
             e.preventDefault();
             e.stopPropagation();
           },
-          ...readOnlyProps
+          ...readOnlyProps,
+          ...maintenanceProps
         },
         linodeBackups.enabled
           ? {

--- a/packages/manager/src/store/linodes/linodes.reducer.ts
+++ b/packages/manager/src/store/linodes/linodes.reducer.ts
@@ -45,7 +45,11 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
     const {
       payload: { result }
     } = action;
-    return onGetAllSuccess(result.data, state, result.results);
+    return onGetAllSuccess(
+      result.data.map(thisLinode => ({ ...thisLinode, status: 'stopped' })),
+      state,
+      result.results
+    );
   }
 
   if (isType(action, getLinodesActions.failed)) {


### PR DESCRIPTION
## Description

The API has added a new status for Linodes, "stopped", which will
be the case when a Linode's host is undergoing maintenance. The API
will disallow certain actions in this case, but we should a) notify
the user and b) prevent them from submitting these actions in the
first place.

The actions are:
- reboot
- boot
- rescue
- resize
- rebuild
- shutdown
- clone