### PR TITLE
ActionMenu Styling

### DIFF
--- a/packages/manager/src/components/ActionMenu/ActionMenu.stories.tsx
+++ b/packages/manager/src/components/ActionMenu/ActionMenu.stories.tsx
@@ -9,33 +9,29 @@ interface Props {
 type CombinedProps = Props;
 
 class StoryActionMenu extends React.Component<CombinedProps> {
-  createActions = () => (closeMenu: Function): Action[] => {
+  createActions = () => (): Action[] => {
     return [
       {
         title: 'First Action',
         onClick: (e: React.MouseEvent<HTMLElement>) => {
-          closeMenu();
           e.preventDefault();
         }
       },
       {
         title: 'Action 1',
         onClick: (e: React.MouseEvent<HTMLElement>) => {
-          closeMenu();
           e.preventDefault();
         }
       },
       {
         title: 'Action 3',
         onClick: (e: React.MouseEvent<HTMLElement>) => {
-          closeMenu();
           e.preventDefault();
         }
       },
       {
         title: 'Last Action',
         onClick: (e: React.MouseEvent<HTMLElement>) => {
-          closeMenu();
           e.preventDefault();
         }
       }
@@ -50,19 +46,17 @@ class StoryActionMenu extends React.Component<CombinedProps> {
 }
 
 class StoryActionMenuWithTooltip extends React.Component<CombinedProps> {
-  createActions = () => (closeMenu: Function): Action[] => {
+  createActions = () => (): Action[] => {
     return [
       {
         title: 'First Action',
         onClick: (e: React.MouseEvent<HTMLElement>) => {
-          closeMenu();
           e.preventDefault();
         }
       },
       {
         title: 'Another Action',
         onClick: (e: React.MouseEvent<HTMLElement>) => {
-          closeMenu();
           e.preventDefault();
         }
       },
@@ -70,7 +64,6 @@ class StoryActionMenuWithTooltip extends React.Component<CombinedProps> {
         title: 'Disabled Action',
         disabled: true,
         onClick: (e: React.MouseEvent<HTMLElement>) => {
-          closeMenu();
           e.preventDefault();
         },
         tooltip: 'An explanation as to why this item is disabled'
@@ -86,7 +79,7 @@ class StoryActionMenuWithTooltip extends React.Component<CombinedProps> {
 }
 
 class StoryActionMenuWithOneAction extends React.Component<CombinedProps> {
-  createActions = () => (closeMenu: Function): Action[] => {
+  createActions = () => (): Action[] => {
     return [
       {
         title: 'Single Action',
@@ -105,17 +98,17 @@ class StoryActionMenuWithOneAction extends React.Component<CombinedProps> {
 
 storiesOf('Action Menu', module)
   .add('Action Menu', () => (
-    <div style={{ float: 'left' }}>
+    <div style={{ textAlign: 'center' }}>
       <StoryActionMenu />
     </div>
   ))
   .add('Action Menu with disabled menu item & tooltip', () => (
-    <div style={{ float: 'left' }}>
+    <div style={{ textAlign: 'center' }}>
       <StoryActionMenuWithTooltip />
     </div>
   ))
   .add('Action Menu with one menu item', () => (
-    <div style={{ float: 'left' }}>
+    <div style={{ textAlign: 'center' }}>
       <StoryActionMenuWithOneAction />
     </div>
   ));

--- a/packages/manager/src/components/ActionMenu/ActionMenu.stories.tsx
+++ b/packages/manager/src/components/ActionMenu/ActionMenu.stories.tsx
@@ -78,7 +78,7 @@ class StoryActionMenuWithTooltip extends React.Component<CombinedProps> {
   }
 }
 
-class StoryActionMenuWithOneAction extends React.Component<CombinedProps> {
+class StoryActionMenuWithInlineLabel extends React.Component<CombinedProps> {
   createActions = () => (): Action[] => {
     return [
       {
@@ -91,7 +91,11 @@ class StoryActionMenuWithOneAction extends React.Component<CombinedProps> {
   };
   render() {
     return (
-      <ActionMenu createActions={this.createActions()} ariaLabel="label" />
+      <ActionMenu
+        createActions={this.createActions()}
+        ariaLabel="label"
+        inlineLabel="More Actions"
+      />
     );
   }
 }
@@ -107,8 +111,8 @@ storiesOf('Action Menu', module)
       <StoryActionMenuWithTooltip />
     </div>
   ))
-  .add('Action Menu with one menu item', () => (
+  .add('Action Menu with inline label', () => (
     <div style={{ textAlign: 'center' }}>
-      <StoryActionMenuWithOneAction />
+      <StoryActionMenuWithInlineLabel />
     </div>
   ));

--- a/packages/manager/src/components/ActionMenu/ActionMenu.test.tsx
+++ b/packages/manager/src/components/ActionMenu/ActionMenu.test.tsx
@@ -5,7 +5,7 @@ import ActionMenu from './ActionMenu';
 
 describe('ActionMenu', () => {
   const action = { title: 'whatever', onClick: () => undefined };
-  const createActionsMany = (closeMenu: Function) => {
+  const createActionsMany = () => {
     return [action, action, action];
   };
 

--- a/packages/manager/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/manager/src/components/ActionMenu/ActionMenu.tsx
@@ -1,9 +1,18 @@
 import MoreHoriz from '@material-ui/icons/MoreHoriz';
+import {
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuItems,
+  MenuList,
+  MenuLink,
+  MenuPopover
+} from '@reach/menu-button';
+import '@reach/menu-button/styles.css';
 import * as React from 'react';
-import IconButton from 'src/components/core/IconButton';
-import Menu from 'src/components/core/Menu';
+// import Menu from 'src/components/core/Menu';
 import { makeStyles, Theme } from 'src/components/core/styles';
-import MenuItem from 'src/components/MenuItem';
+import MUIMenuItem from 'src/components/MenuItem';
 
 export interface Action {
   title: string;
@@ -101,51 +110,29 @@ const ActionMenu: React.FC<CombinedProps> = props => {
   }
 
   return (
-    <div className={`${classes.root} action-menu ${props.className ?? ''}`}>
-      <IconButton
-        disabled={disabled}
-        aria-owns={anchorEl ? 'action-menu' : undefined}
-        aria-expanded={anchorEl ? true : undefined}
-        aria-haspopup="true"
-        onClick={handleClick}
-        className={classes.button}
-        data-qa-action-menu
-        aria-label={ariaLabel}
-      >
+    <Menu>
+      <MenuButton aria-label={ariaLabel}>
         <MoreHoriz type="primary" className="kebob" />
-      </IconButton>
-      <Menu
-        id="action-menu"
-        className={classes.menu}
-        anchorEl={anchorEl}
-        getContentAnchorEl={undefined}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
-        open={Boolean(anchorEl)}
-        onClose={handleClose}
-        BackdropProps={{
-          style: {
-            backgroundColor: 'transparent'
-          }
-        }}
-      >
-        {(actions as Action[]).map((a, idx) => (
-          <MenuItem
-            key={idx}
-            onClick={a.onClick}
-            className={classes.item}
-            data-qa-action-menu-item={a.title}
-            disabled={a.disabled}
-            tooltip={a.tooltip}
-            isLoading={a.isLoading}
-            aria-describedby={a.ariaDescribedBy}
-            role="menuitem"
-          >
-            {a.title}
-          </MenuItem>
-        ))}
-      </Menu>
-    </div>
+      </MenuButton>
+      <MenuPopover className={classes.menuPopover} portal={false}>
+        <MenuItems>
+          {(actions as Action[]).map((a, idx) => (
+            <MenuItem
+              key={idx}
+              as={MUIMenuItem}
+              onClick={a.onClick}
+              className={classes.item}
+              data-qa-action-menu-item={a.title}
+              disabled={a.disabled}
+              tooltip={a.tooltip}
+              isLoading={a.isLoading}
+            >
+              {a.title}
+            </MenuItem>
+          ))}
+        </MenuItems>
+      </MenuPopover>
+    </Menu>
   );
 };
 

--- a/packages/manager/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/manager/src/components/ActionMenu/ActionMenu.tsx
@@ -1,3 +1,5 @@
+import * as classNames from 'classnames';
+import HelpOutline from '@material-ui/icons/HelpOutline';
 import MoreHoriz from '@material-ui/icons/MoreHoriz';
 import {
   Menu,
@@ -8,14 +10,13 @@ import {
 } from '@reach/menu-button';
 import '@reach/menu-button/styles.css';
 import * as React from 'react';
+import IconButton from 'src/components/core/IconButton';
 import { makeStyles, Theme } from 'src/components/core/styles';
 
 export interface Action {
   title: string;
   disabled?: boolean;
   tooltip?: string;
-  isLoading?: boolean;
-  ariaDescribedBy?: string;
   onClick: (e: React.MouseEvent<HTMLElement>) => void;
 }
 
@@ -26,7 +27,11 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   button: {
     '&[data-reach-menu-button]': {
+      display: 'flex',
+      alignItems: 'center',
       background: 'none',
+      fontSize: '1rem',
+      fontWeight: 'bold',
       border: 'none',
       padding: theme.spacing(1) + 2,
       color: '#3683dc',
@@ -37,19 +42,23 @@ const useStyles = makeStyles((theme: Theme) => ({
       }
     }
   },
+  buttonLabel: {
+    margin: `0 0 0 ${theme.spacing()}px`
+  },
   icon: {},
   popover: {
     '&[data-reach-menu-popover]': {
       right: 0,
       // Need this to 'merge the button and items wrapper due to the borderRadius on the wrapper
-      marginTop: -3
+      marginTop: -3,
+      zIndex: 1
     }
   },
   itemsOuter: {
     '&[data-reach-menu-items]': {
       padding: 0,
       width: 200,
-      backgroundColor: '#3683dc',
+      background: '#3683dc',
       borderRadius: 3,
       border: 'none',
       fontSize: 14,
@@ -61,11 +70,18 @@ const useStyles = makeStyles((theme: Theme) => ({
     '&[data-reach-menu-item]': {
       padding: theme.spacing(1) + 2,
       borderBottom: '1px solid #5294e0',
+      background: '#3683dc',
       color: '#fff',
       borderRadius: 3
     },
     '&[data-reach-menu-item][data-selected]': {
-      backgroundColor: '#226dc3'
+      background: '#226dc3'
+    }
+  },
+  disabled: {
+    '&[data-reach-menu-item]': {
+      color: '#93bcec',
+      cursor: 'auto'
     }
   }
 }));
@@ -78,6 +94,8 @@ export interface Props {
   ariaLabel: string;
   className?: string;
   disabled?: boolean;
+  // Displays inline next to the button icon
+  inlineLabel?: string;
 }
 
 type CombinedProps = Props;
@@ -92,7 +110,7 @@ const ActionMenu: React.FC<CombinedProps> = props => {
     setActions(createActions());
   }, [createActions]);
 
-  const { ariaLabel } = props;
+  const { ariaLabel, inlineLabel } = props;
 
   if (typeof actions === 'undefined') {
     return null;
@@ -102,20 +120,33 @@ const ActionMenu: React.FC<CombinedProps> = props => {
     <div className={classes.wrapper}>
       <Menu>
         <MenuButton className={classes.button} aria-label={ariaLabel}>
-          <MoreHoriz className={classes.icon} type="primary" />
+          <MoreHoriz aria-hidden className={classes.icon} type="primary" />
+          {inlineLabel && <p className={classes.buttonLabel}>{inlineLabel}</p>}
         </MenuButton>
         <MenuPopover className={classes.popover} portal={false}>
           <MenuItems className={classes.itemsOuter}>
             {(actions as Action[]).map((a, idx) => (
               <MenuLink
                 key={idx}
-                as="a"
-                href="#"
-                className={classes.item}
+                className={classNames({
+                  [classes.item]: true,
+                  [classes.disabled]: a.disabled
+                })}
                 onClick={a.onClick}
                 data-qa-action-menu-item={a.title}
+                // disabled={a.disabled}
               >
                 {a.title}
+                {a.tooltip && (
+                  <IconButton
+                    // className={classes.helpButton}
+                    // onClick={handleClick}
+                    data-qa-tooltip-icon
+                  >
+                    <HelpOutline />
+                  </IconButton>
+                )}
+                {/* {a.tooltip && <span data-qa-tooltip>{a.tooltip}</span>} */}
               </MenuLink>
             ))}
           </MenuItems>

--- a/packages/manager/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/manager/src/components/ActionMenu/ActionMenu.tsx
@@ -2,17 +2,13 @@ import MoreHoriz from '@material-ui/icons/MoreHoriz';
 import {
   Menu,
   MenuButton,
-  MenuItem,
   MenuItems,
-  MenuList,
   MenuLink,
   MenuPopover
 } from '@reach/menu-button';
 import '@reach/menu-button/styles.css';
 import * as React from 'react';
-// import Menu from 'src/components/core/Menu';
 import { makeStyles, Theme } from 'src/components/core/styles';
-import MUIMenuItem from 'src/components/MenuItem';
 
 export interface Action {
   title: string;
@@ -24,51 +20,58 @@ export interface Action {
 }
 
 const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'flex-end'
-  },
-  item: {
-    paddingLeft: theme.spacing(2),
-    paddingRight: theme.spacing(2),
-    paddingTop: theme.spacing(1) * 1.5,
-    paddingBottom: theme.spacing(1) * 1.5,
-    fontFamily: 'LatoWeb',
-    fontSize: '.9rem',
-    color: theme.color.blueDTwhite,
-    transition: `
-      ${'color 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, '}
-      ${'background-color 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms'}
-    `,
-    '&:hover, &:focus': {
-      backgroundColor: theme.palette.primary.main,
-      color: '#fff'
-    }
+  wrapper: {
+    display: 'inline-block',
+    position: 'relative'
   },
   button: {
-    width: 26,
-    padding: 0,
-    '& svg': {
-      fontSize: '28px'
-    },
-    '&[aria-expanded="true"] .kebob': {
-      fill: theme.palette.primary.dark
+    '&[data-reach-menu-button]': {
+      background: 'none',
+      border: 'none',
+      padding: theme.spacing(1) + 2,
+      color: '#3683dc',
+      cursor: 'pointer',
+      '&[aria-expanded="true"]': {
+        backgroundColor: '#3683dc',
+        color: '#fff'
+      }
     }
   },
-  actionSingleLink: {
-    marginRight: theme.spacing(1),
-    whiteSpace: 'nowrap',
-    float: 'right',
-    fontFamily: theme.font.bold
+  icon: {},
+  popover: {
+    '&[data-reach-menu-popover]': {
+      right: 0,
+      // Need this to 'merge the button and items wrapper due to the borderRadius on the wrapper
+      marginTop: -3
+    }
   },
-  menu: {
-    maxWidth: theme.spacing(25)
+  itemsOuter: {
+    '&[data-reach-menu-items]': {
+      padding: 0,
+      width: 200,
+      backgroundColor: '#3683dc',
+      borderRadius: 3,
+      border: 'none',
+      fontSize: 14,
+      color: '#fff',
+      textAlign: 'left'
+    }
+  },
+  item: {
+    '&[data-reach-menu-item]': {
+      padding: theme.spacing(1) + 2,
+      borderBottom: '1px solid #5294e0',
+      color: '#fff',
+      borderRadius: 3
+    },
+    '&[data-reach-menu-item][data-selected]': {
+      backgroundColor: '#226dc3'
+    }
   }
 }));
 
 export interface Props {
-  createActions: (closeMenu: Function) => Action[];
+  createActions: () => Action[];
   toggleOpenCallback?: () => void;
   // we want to require using aria label for these buttons
   // as they don't have text (just an icon)
@@ -84,55 +87,41 @@ const ActionMenu: React.FC<CombinedProps> = props => {
   const { createActions } = props;
 
   const [actions, setActions] = React.useState<Action[]>([]);
-  const [anchorEl, setAnchorEl] = React.useState<
-    (EventTarget & HTMLElement) | undefined
-  >(undefined);
 
   React.useEffect(() => {
-    setActions(createActions(handleClose));
+    setActions(createActions());
   }, [createActions]);
 
-  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
-    if (props.toggleOpenCallback) {
-      props.toggleOpenCallback();
-    }
-    setAnchorEl(event.currentTarget);
-  };
-
-  const handleClose = () => {
-    setAnchorEl(undefined);
-  };
-
-  const { ariaLabel, disabled } = props;
+  const { ariaLabel } = props;
 
   if (typeof actions === 'undefined') {
     return null;
   }
 
   return (
-    <Menu>
-      <MenuButton aria-label={ariaLabel}>
-        <MoreHoriz type="primary" className="kebob" />
-      </MenuButton>
-      <MenuPopover className={classes.menuPopover} portal={false}>
-        <MenuItems>
-          {(actions as Action[]).map((a, idx) => (
-            <MenuItem
-              key={idx}
-              as={MUIMenuItem}
-              onClick={a.onClick}
-              className={classes.item}
-              data-qa-action-menu-item={a.title}
-              disabled={a.disabled}
-              tooltip={a.tooltip}
-              isLoading={a.isLoading}
-            >
-              {a.title}
-            </MenuItem>
-          ))}
-        </MenuItems>
-      </MenuPopover>
-    </Menu>
+    <div className={classes.wrapper}>
+      <Menu>
+        <MenuButton className={classes.button} aria-label={ariaLabel}>
+          <MoreHoriz className={classes.icon} type="primary" />
+        </MenuButton>
+        <MenuPopover className={classes.popover} portal={false}>
+          <MenuItems className={classes.itemsOuter}>
+            {(actions as Action[]).map((a, idx) => (
+              <MenuLink
+                key={idx}
+                as="a"
+                href="#"
+                className={classes.item}
+                onClick={a.onClick}
+                data-qa-action-menu-item={a.title}
+              >
+                {a.title}
+              </MenuLink>
+            ))}
+          </MenuItems>
+        </MenuPopover>
+      </Menu>
+    </div>
   );
 };
 

--- a/packages/manager/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/manager/src/components/ActionMenu/ActionMenu.tsx
@@ -1,5 +1,4 @@
 import * as classNames from 'classnames';
-import HelpOutline from '@material-ui/icons/HelpOutline';
 import MoreHoriz from '@material-ui/icons/MoreHoriz';
 import {
   Menu,
@@ -10,7 +9,7 @@ import {
 } from '@reach/menu-button';
 import '@reach/menu-button/styles.css';
 import * as React from 'react';
-import IconButton from 'src/components/core/IconButton';
+import HelpIcon from 'src/components/HelpIcon';
 import { makeStyles, Theme } from 'src/components/core/styles';
 
 export interface Action {
@@ -82,7 +81,14 @@ const useStyles = makeStyles((theme: Theme) => ({
     '&[data-reach-menu-item]': {
       color: '#93bcec',
       cursor: 'auto'
+    },
+    '&[data-reach-menu-item][data-selected]': {
+      background: '#3683dc'
     }
+  },
+  tooltip: {
+    color: '#fff',
+    padding: '0 12px'
   }
 }));
 
@@ -134,19 +140,17 @@ const ActionMenu: React.FC<CombinedProps> = props => {
                 })}
                 onClick={a.onClick}
                 data-qa-action-menu-item={a.title}
-                // disabled={a.disabled}
+                disabled={a.disabled}
               >
                 {a.title}
                 {a.tooltip && (
-                  <IconButton
-                    // className={classes.helpButton}
-                    // onClick={handleClick}
+                  <HelpIcon
                     data-qa-tooltip-icon
-                  >
-                    <HelpOutline />
-                  </IconButton>
+                    text={a.tooltip}
+                    tooltipPosition="right"
+                    className={classes.tooltip}
+                  />
                 )}
-                {/* {a.tooltip && <span data-qa-tooltip>{a.tooltip}</span>} */}
               </MenuLink>
             ))}
           </MenuItems>

--- a/packages/manager/src/features/Domains/DomainActionMenu.tsx
+++ b/packages/manager/src/features/Domains/DomainActionMenu.tsx
@@ -44,13 +44,12 @@ export class DomainActionMenu extends React.Component<CombinedProps> {
     onClone(domain, id);
   };
 
-  createActions = () => (closeMenu: Function): Action[] => {
+  createActions = () => (): Action[] => {
     const baseActions = [
       {
         title: 'Edit',
         onClick: (e: React.MouseEvent<HTMLElement>) => {
           this.handleEdit();
-          closeMenu();
           e.preventDefault();
         }
       },
@@ -58,7 +57,6 @@ export class DomainActionMenu extends React.Component<CombinedProps> {
         title: 'Clone',
         onClick: (e: React.MouseEvent<HTMLElement>) => {
           this.handleClone();
-          closeMenu();
           e.preventDefault();
         }
       },
@@ -79,7 +77,7 @@ export class DomainActionMenu extends React.Component<CombinedProps> {
              */
             sendDomainStatusChangeEvent('Enable');
           }
-          closeMenu();
+
           e.preventDefault();
         }
       },
@@ -87,7 +85,6 @@ export class DomainActionMenu extends React.Component<CombinedProps> {
         title: 'Delete',
         onClick: (e: React.MouseEvent<HTMLElement>) => {
           this.handleRemove();
-          closeMenu();
           e.preventDefault();
         }
       }
@@ -99,7 +96,6 @@ export class DomainActionMenu extends React.Component<CombinedProps> {
           title: 'Edit DNS Records',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             this.goToDomain();
-            closeMenu();
             e.preventDefault();
           }
         },

--- a/packages/manager/src/features/Domains/DomainRecordActionMenu.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordActionMenu.tsx
@@ -44,7 +44,7 @@ class DomainRecordActionMenu extends React.Component<CombinedProps> {
     deleteData!.onDelete(deleteData!.recordID);
   };
 
-  createActions = () => (closeMenu: Function): Action[] =>
+  createActions = () => (): Action[] =>
     compose<Action[], Action[], Action[]>(
       when(
         () => has('deleteData', this.props),
@@ -52,7 +52,6 @@ class DomainRecordActionMenu extends React.Component<CombinedProps> {
           title: 'Delete',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             this.handleDelete();
-            closeMenu();
             e.preventDefault();
           }
         })
@@ -61,7 +60,6 @@ class DomainRecordActionMenu extends React.Component<CombinedProps> {
         title: 'Edit',
         onClick: (e: React.MouseEvent<HTMLElement>) => {
           this.handleEdit();
-          closeMenu();
           e.preventDefault();
         }
       })

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallDeviceActionMenu.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallDeviceActionMenu.tsx
@@ -17,12 +17,11 @@ const FirewallDeviceActionMenu: React.FC<CombinedProps> = props => {
   const { deviceID, deviceLabel, triggerRemoveDevice } = props;
 
   const createActions = () => {
-    return (closeMenu: Function): Action[] => [
+    return (): Action[] => [
       {
         title: 'Remove',
         onClick: () => {
           triggerRemoveDevice(deviceID, deviceLabel);
-          closeMenu();
         }
       }
     ];

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleActionMenu.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleActionMenu.tsx
@@ -18,18 +18,16 @@ const FirewallRuleActionMenu: React.FC<CombinedProps> = props => {
   } = props;
 
   const createActions = React.useCallback(() => {
-    return (closeMenu: Function): Action[] => [
+    return (): Action[] => [
       {
         title: 'Edit',
         onClick: () => {
-          closeMenu();
           triggerOpenRuleDrawerForEditing(idx);
         }
       },
       {
         title: 'Delete',
         onClick: () => {
-          closeMenu();
           triggerDeleteFirewallRule(idx);
         }
       }

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallActionMenu.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallActionMenu.tsx
@@ -30,7 +30,7 @@ const FirewallActionMenu: React.FC<CombinedProps> = props => {
   const history = useHistory();
 
   const createActions = () => {
-    return (closeMenu: Function): Action[] => [
+    return (): Action[] => [
       {
         title: firewallStatus === 'disabled' ? 'Enable' : 'Disable',
         onClick: () => {
@@ -40,14 +40,11 @@ const FirewallActionMenu: React.FC<CombinedProps> = props => {
               : triggerDisableFirewall(firewallID, firewallLabel);
 
           request();
-
-          closeMenu();
         }
       },
       {
         title: 'Edit',
         onClick: (e: React.MouseEvent<HTMLElement>) => {
-          closeMenu();
           history.push(`/firewalls/${firewallID}/rules`);
           e.preventDefault();
           e.stopPropagation();
@@ -56,7 +53,6 @@ const FirewallActionMenu: React.FC<CombinedProps> = props => {
       {
         title: 'Delete',
         onClick: () => {
-          closeMenu();
           triggerDeleteFirewall(firewallID, firewallLabel);
         }
       }

--- a/packages/manager/src/features/Images/ImagesActionMenu.tsx
+++ b/packages/manager/src/features/Images/ImagesActionMenu.tsx
@@ -18,13 +18,12 @@ class ImagesActionMenu extends React.Component<CombinedProps> {
   createActions = () => {
     const { onRestore, onDeploy, onEdit, onDelete, image } = this.props;
 
-    return (closeMenu: Function): Action[] => {
+    return (): Action[] => {
       const actions = [
         {
           title: 'Restore to Existing Linode',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             onRestore(image.id);
-            closeMenu();
             e.preventDefault();
           }
         },
@@ -40,7 +39,6 @@ class ImagesActionMenu extends React.Component<CombinedProps> {
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             const description = image.description ? image.description : ' ';
             onEdit(image.label, description, image.id);
-            closeMenu();
             e.preventDefault();
           }
         },
@@ -48,7 +46,6 @@ class ImagesActionMenu extends React.Component<CombinedProps> {
           title: 'Delete',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             onDelete(image.label, image.id);
-            closeMenu();
             e.preventDefault();
           }
         }

--- a/packages/manager/src/features/Kubernetes/ClusterList/ClusterActionMenu.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/ClusterActionMenu.tsx
@@ -17,9 +17,7 @@ interface Props {
 
 type CombinedProps = Props & RouteComponentProps<{}> & WithSnackbarProps;
 
-export const ClusterActionMenu: React.FunctionComponent<
-  CombinedProps
-> = props => {
+export const ClusterActionMenu: React.FunctionComponent<CombinedProps> = props => {
   const {
     clusterId,
     clusterLabel,
@@ -29,13 +27,13 @@ export const ClusterActionMenu: React.FunctionComponent<
   } = props;
 
   const createActions = () => {
-    return (closeMenu: Function): Action[] => {
+    return (): Action[] => {
       const actions = [
         {
           title: 'Download kubeconfig',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             downloadKubeConfig();
-            closeMenu();
+
             e.preventDefault();
           }
         },
@@ -54,7 +52,7 @@ export const ClusterActionMenu: React.FunctionComponent<
           title: 'Delete',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             openDialog();
-            closeMenu();
+
             e.preventDefault();
           }
         }
@@ -98,9 +96,6 @@ export const ClusterActionMenu: React.FunctionComponent<
   );
 };
 
-const enhanced = compose<CombinedProps, Props>(
-  withSnackbar,
-  withRouter
-);
+const enhanced = compose<CombinedProps, Props>(withSnackbar, withRouter);
 
 export default enhanced(ClusterActionMenu);

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeActionMenu.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeActionMenu.tsx
@@ -11,7 +11,7 @@ export const NodeActionMenu: React.FC<Props> = props => {
   const { instanceId, instanceLabel, openRecycleNodeDialog } = props;
 
   const createActions = () => {
-    return (closeMenu: Function): Action[] => {
+    return (): Action[] => {
       const actions = [
         {
           title: 'Recycle',
@@ -20,7 +20,7 @@ export const NodeActionMenu: React.FC<Props> = props => {
               return;
             }
             openRecycleNodeDialog(instanceId!, instanceLabel!);
-            closeMenu();
+
             e.preventDefault();
           },
           disabled: !instanceId || !instanceLabel

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewActionMenu.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewActionMenu.tsx
@@ -26,7 +26,7 @@ const LongviewActionMenu: React.FC<CombinedProps> = props => {
   } = props;
 
   const createActions = () => {
-    return (closeMenu: Function): Action[] => [
+    return (): Action[] => [
       {
         title: 'Delete',
         disabled: !userCanModifyClient,
@@ -34,7 +34,6 @@ const LongviewActionMenu: React.FC<CombinedProps> = props => {
           ? ''
           : 'Contact an account administrator for permission.',
         onClick: () => {
-          closeMenu();
           triggerDeleteLongviewClient(longviewClientID, longviewClientLabel);
         }
       }

--- a/packages/manager/src/features/Managed/Contacts/ContactsActionMenu.tsx
+++ b/packages/manager/src/features/Managed/Contacts/ContactsActionMenu.tsx
@@ -15,12 +15,11 @@ export type CombinedProps = Props;
 export const ContactsActionMenu: React.FC<CombinedProps> = props => {
   const { contactId, openDrawer, openDialog } = props;
 
-  const createActions = (closeMenu: Function): Action[] => {
+  const createActions = (): Action[] => {
     const actions = [
       {
         title: 'Edit',
         onClick: () => {
-          closeMenu();
           openDrawer(contactId);
         }
       },
@@ -28,7 +27,6 @@ export const ContactsActionMenu: React.FC<CombinedProps> = props => {
         title: 'Delete',
         onClick: () => {
           openDialog(contactId);
-          closeMenu();
         }
       }
     ];

--- a/packages/manager/src/features/Managed/Credentials/CredentialActionMenu.tsx
+++ b/packages/manager/src/features/Managed/Credentials/CredentialActionMenu.tsx
@@ -17,20 +17,18 @@ export class CredentialActionMenu extends React.Component<CombinedProps, {}> {
   createActions = () => {
     const { label, credentialID, openDialog, openForEdit } = this.props;
 
-    return (closeMenu: Function): Action[] => {
+    return (): Action[] => {
       const actions = [
         {
           title: 'Edit',
           onClick: () => {
             openForEdit(credentialID);
-            closeMenu();
           }
         },
         {
           title: 'Delete',
           onClick: () => {
             openDialog(credentialID, label);
-            closeMenu();
           }
         }
       ];

--- a/packages/manager/src/features/Managed/Monitors/MonitorActionMenu.tsx
+++ b/packages/manager/src/features/Managed/Monitors/MonitorActionMenu.tsx
@@ -40,7 +40,7 @@ export class MonitorActionMenu extends React.Component<CombinedProps, {}> {
       enqueueSnackbar(errMessage[0].reason, { variant: 'error' });
     };
 
-    return (closeMenu: Function): Action[] => {
+    return (): Action[] => {
       const actions = [
         status === 'disabled'
           ? {
@@ -55,7 +55,6 @@ export class MonitorActionMenu extends React.Component<CombinedProps, {}> {
                   .catch(e => {
                     handleError('Error enabling this Service Monitor.', e);
                   });
-                closeMenu();
               }
             }
           : {
@@ -70,28 +69,24 @@ export class MonitorActionMenu extends React.Component<CombinedProps, {}> {
                   .catch(e => {
                     handleError('Error disabling this Service Monitor.', e);
                   });
-                closeMenu();
               }
             },
         {
           title: 'View Issue History',
           onClick: () => {
             openHistoryDrawer(monitorID, label);
-            closeMenu();
           }
         },
         {
           title: 'Edit',
           onClick: () => {
             openMonitorDrawer(monitorID, 'edit');
-            closeMenu();
           }
         },
         {
           title: 'Delete',
           onClick: () => {
             openDialog(monitorID, label);
-            closeMenu();
           }
         }
       ];

--- a/packages/manager/src/features/Managed/SSHAccess/SSHAccessActionMenu.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/SSHAccessActionMenu.tsx
@@ -27,7 +27,7 @@ export const SSHAccessActionMenu: React.FC<CombinedProps> = props => {
     enqueueSnackbar(errMessage[0].reason, { variant: 'error' });
   };
 
-  const createActions = (closeMenu: Function): Action[] => {
+  const createActions = (): Action[] => {
     const actions = [
       isEnabled
         ? {
@@ -48,7 +48,6 @@ export const SSHAccessActionMenu: React.FC<CombinedProps> = props => {
                     err
                   );
                 });
-              closeMenu();
             }
           }
         : {
@@ -69,13 +68,11 @@ export const SSHAccessActionMenu: React.FC<CombinedProps> = props => {
                     err
                   );
                 });
-              closeMenu();
             }
           },
       {
         title: 'Edit',
         onClick: () => {
-          closeMenu();
           openDrawer(linodeId);
         }
       }

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancerActionMenu.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancerActionMenu.tsx
@@ -15,14 +15,13 @@ class NodeBalancerActionMenu extends React.Component<CombinedProps> {
   createLinodeActions = () => {
     const { nodeBalancerId, history, toggleDialog, label } = this.props;
 
-    return (closeMenu: Function): Action[] => {
+    return (): Action[] => {
       const actions = [
         {
           title: 'Summary',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             history.push(`/nodebalancers/${nodeBalancerId}/summary`);
             e.preventDefault();
-            closeMenu();
           }
         },
         {
@@ -30,7 +29,6 @@ class NodeBalancerActionMenu extends React.Component<CombinedProps> {
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             history.push(`/nodebalancers/${nodeBalancerId}/configurations`);
             e.preventDefault();
-            closeMenu();
           }
         },
         {
@@ -38,7 +36,6 @@ class NodeBalancerActionMenu extends React.Component<CombinedProps> {
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             history.push(`/nodebalancers/${nodeBalancerId}/settings`);
             e.preventDefault();
-            closeMenu();
           }
         },
         {
@@ -46,7 +43,6 @@ class NodeBalancerActionMenu extends React.Component<CombinedProps> {
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             e.preventDefault();
             toggleDialog(nodeBalancerId, label);
-            closeMenu();
           }
         }
       ];

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyMenu.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyMenu.tsx
@@ -20,20 +20,18 @@ const AccessKeyMenu: React.FC<CombinedProps> = props => {
   const createActions = () => {
     const { openRevokeDialog, objectStorageKey, openDrawerForEditing } = props;
 
-    return (closeMenu: Function): Action[] => {
+    return (): Action[] => {
       return [
         {
           title: 'Rename Access Key',
           onClick: () => {
             openDrawerForEditing(objectStorageKey);
-            closeMenu();
           }
         },
         {
           title: 'Revoke',
           onClick: () => {
             openRevokeDialog(objectStorageKey);
-            closeMenu();
           }
         }
       ];

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectActionMenu.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectActionMenu.tsx
@@ -8,14 +8,13 @@ export interface Props {
 }
 
 export const ObjectActionMenu: React.FC<Props> = props => {
-  const createActions = () => (closeMenu: Function): Action[] => {
+  const createActions = () => (): Action[] => {
     return [
       {
         title: 'Download',
         onClick: (e: React.MouseEvent<HTMLElement>) => {
           const shouldOpenInNewTab = true;
           props.handleClickDownload(props.objectName, shouldOpenInNewTab);
-          closeMenu();
           e.preventDefault();
         }
       },
@@ -23,7 +22,6 @@ export const ObjectActionMenu: React.FC<Props> = props => {
         title: 'Delete',
         onClick: (e: React.MouseEvent<HTMLElement>) => {
           props.handleClickDelete(props.objectName);
-          closeMenu();
           e.preventDefault();
         }
       }

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketActionMenu.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketActionMenu.tsx
@@ -7,13 +7,12 @@ export interface Props {
 }
 
 export const BucketActionMenu: React.FC<Props> = props => {
-  const createActions = () => (closeMenu: Function): Action[] => {
+  const createActions = () => (): Action[] => {
     return [
       {
         title: 'Delete',
         onClick: (e: React.MouseEvent<HTMLElement>) => {
           props.onRemove();
-          closeMenu();
           e.preventDefault();
         }
       }

--- a/packages/manager/src/features/Profile/APITokens/APITokenMenu.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokenMenu.tsx
@@ -25,28 +25,25 @@ class APITokenMenu extends React.Component<CombinedProps> {
       type
     } = this.props;
 
-    return (closeMenu: Function): Action[] => {
+    return (): Action[] => {
       const actions = !isThirdPartyAccessToken
         ? [
             {
               title: 'View Token Scopes',
               onClick: (e: React.MouseEvent<HTMLElement>) => {
                 openViewDrawer(token);
-                closeMenu();
               }
             },
             {
               title: 'Rename Token',
               onClick: (e: React.MouseEvent<HTMLElement>) => {
                 openEditDrawer(token);
-                closeMenu();
               }
             },
             {
               title: 'Revoke',
               onClick: (e: React.MouseEvent<HTMLElement>) => {
                 openRevokeDialog(token, type);
-                closeMenu();
               }
             }
           ]
@@ -55,14 +52,12 @@ class APITokenMenu extends React.Component<CombinedProps> {
               title: 'View Token Scopes',
               onClick: (e: React.MouseEvent<HTMLElement>) => {
                 openViewDrawer(token);
-                closeMenu();
               }
             },
             {
               title: 'Revoke',
               onClick: (e: React.MouseEvent<HTMLElement>) => {
                 openRevokeDialog(token, type);
-                closeMenu();
               }
             }
           ];

--- a/packages/manager/src/features/Profile/OAuthClients/OAuthClientActionMenu.tsx
+++ b/packages/manager/src/features/Profile/OAuthClients/OAuthClientActionMenu.tsx
@@ -21,26 +21,23 @@ type CombinedProps = Props;
 class OAuthClientActionMenu extends React.Component<CombinedProps> {
   createActions = () => {
     const { label, redirectUri, isPublic, clientID } = this.props;
-    return (closeMenu: Function): Action[] => {
+    return (): Action[] => {
       const actions = [
         {
           title: 'Edit',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             this.props.openEditDrawer(isPublic, redirectUri, label, clientID);
-            closeMenu();
           }
         },
         {
           title: 'Reset Secret',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
-            closeMenu();
             this.props.openSecretModal(clientID, label);
           }
         },
         {
           title: 'Delete',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
-            closeMenu();
             this.props.openDeleteModal(clientID, label);
           }
         }

--- a/packages/manager/src/features/Profile/SSHKeys/SSHKeyActionMenu.tsx
+++ b/packages/manager/src/features/Profile/SSHKeys/SSHKeyActionMenu.tsx
@@ -14,13 +14,12 @@ class SSHKeyActionMenu extends React.Component<CombinedProps> {
   createActions = () => {
     const { id, label, onDelete } = this.props;
 
-    return (closeMenu: Function): Action[] => {
+    return (): Action[] => {
       const actions = [
         {
           title: 'Delete',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             onDelete(id, label);
-            closeMenu();
             e.preventDefault();
           }
         }

--- a/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptActionMenu.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptActionMenu.tsx
@@ -53,7 +53,7 @@ const StackScriptActionMenu: React.FC<CombinedProps> = props => {
   };
 
   const createActions = () => {
-    return (closeMenu: Function): Action[] => {
+    return (): Action[] => {
       const actions: Action[] = [
         {
           title: 'Deploy New Linode',
@@ -75,7 +75,6 @@ const StackScriptActionMenu: React.FC<CombinedProps> = props => {
           title: 'Delete',
           ...readonlyProps,
           onClick: e => {
-            closeMenu();
             triggerDelete(stackScriptID, stackScriptLabel);
           }
         });
@@ -101,7 +100,7 @@ const StackScriptActionMenu: React.FC<CombinedProps> = props => {
           ...readonlyProps,
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             // open a modal here as well
-            closeMenu();
+
             triggerMakePublic(stackScriptID, stackScriptLabel);
           }
         });

--- a/packages/manager/src/features/Users/UsersActionMenu.tsx
+++ b/packages/manager/src/features/Users/UsersActionMenu.tsx
@@ -21,12 +21,11 @@ class UsersActionMenu extends React.Component<CombinedProps> {
       history: { push }
     } = this.props;
 
-    return (closeMenu: Function): Action[] => {
+    return (): Action[] => {
       const actions = [
         {
           title: 'User Profile',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
-            closeMenu();
             push(`/account/users/${username}`);
             e.preventDefault();
           }
@@ -34,7 +33,6 @@ class UsersActionMenu extends React.Component<CombinedProps> {
         {
           title: 'User Permissions',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
-            closeMenu();
             push(`/account/users/${username}/permissions`);
             e.preventDefault();
           }
@@ -44,7 +42,7 @@ class UsersActionMenu extends React.Component<CombinedProps> {
           title: 'Delete',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             onDelete(username);
-            closeMenu();
+
             e.preventDefault();
           },
           tooltip:

--- a/packages/manager/src/features/Volumes/VolumesActionMenu.tsx
+++ b/packages/manager/src/features/Volumes/VolumesActionMenu.tsx
@@ -80,13 +80,13 @@ export class VolumesActionMenu extends React.Component<CombinedProps> {
   createActions = () => {
     const { attached, poweredOff } = this.props;
 
-    return (closeMenu: Function): Action[] => {
+    return (): Action[] => {
       const actions = [
         {
           title: 'Show Configuration',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             this.handleShowConfig();
-            closeMenu();
+
             e.preventDefault();
           }
         },
@@ -94,7 +94,7 @@ export class VolumesActionMenu extends React.Component<CombinedProps> {
           title: 'Edit Volume',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             this.handleOpenEdit();
-            closeMenu();
+
             e.preventDefault();
           }
         },
@@ -102,7 +102,7 @@ export class VolumesActionMenu extends React.Component<CombinedProps> {
           title: 'Resize',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             this.handleResize();
-            closeMenu();
+
             e.preventDefault();
           }
         },
@@ -110,7 +110,7 @@ export class VolumesActionMenu extends React.Component<CombinedProps> {
           title: 'Clone',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             this.handleClone();
-            closeMenu();
+
             e.preventDefault();
           }
         }
@@ -121,7 +121,7 @@ export class VolumesActionMenu extends React.Component<CombinedProps> {
           title: 'Attach',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             this.handleAttach();
-            closeMenu();
+
             e.preventDefault();
           }
         });
@@ -130,7 +130,7 @@ export class VolumesActionMenu extends React.Component<CombinedProps> {
           title: 'Detach',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             this.handleDetach();
-            closeMenu();
+
             e.preventDefault();
           }
         });
@@ -141,7 +141,7 @@ export class VolumesActionMenu extends React.Component<CombinedProps> {
           title: 'Delete',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             this.handleDelete();
-            closeMenu();
+
             e.preventDefault();
           }
         });

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskActionMenu.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskActionMenu.tsx
@@ -18,7 +18,7 @@ interface Props {
 type CombinedProps = Props & RouteComponentProps;
 
 class DiskActionMenu extends React.Component<CombinedProps> {
-  createActions = () => (closeMenu: Function): Action[] => {
+  createActions = () => (): Action[] => {
     const { linodeStatus, linodeId, readOnly, history, diskId } = this.props;
     let tooltip;
     tooltip =
@@ -40,7 +40,6 @@ class DiskActionMenu extends React.Component<CombinedProps> {
         onClick: (e: React.MouseEvent<HTMLElement>) => {
           e.preventDefault();
           this.props.onRename();
-          closeMenu();
         },
         ...(readOnly ? disabledProps : {})
       },
@@ -49,7 +48,6 @@ class DiskActionMenu extends React.Component<CombinedProps> {
         onClick: (e: React.MouseEvent<HTMLElement>) => {
           e.preventDefault();
           this.props.onResize();
-          closeMenu();
         },
         ...disabledProps
       },
@@ -58,7 +56,6 @@ class DiskActionMenu extends React.Component<CombinedProps> {
         onClick: (e: React.MouseEvent<HTMLElement>) => {
           e.preventDefault();
           this.props.onImagize();
-          closeMenu();
         },
         ...(readOnly ? disabledProps : {})
       },
@@ -66,7 +63,6 @@ class DiskActionMenu extends React.Component<CombinedProps> {
         title: 'Clone',
         onClick: (e: React.MouseEvent<HTMLElement>) => {
           e.preventDefault();
-          closeMenu();
           history.push(
             `/linodes/${linodeId}/clone/disks?selectedDisk=${diskId}`
           );
@@ -78,7 +74,6 @@ class DiskActionMenu extends React.Component<CombinedProps> {
         onClick: (e: React.MouseEvent<HTMLElement>) => {
           e.preventDefault();
           this.props.onDelete();
-          closeMenu();
         },
         ...(readOnly ? disabledProps : {})
       }

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackupActionMenu.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackupActionMenu.tsx
@@ -23,13 +23,12 @@ class LinodeBackupActionMenu extends React.Component<CombinedProps> {
         : undefined
     };
 
-    return (closeMenu: Function): Action[] => {
+    return (): Action[] => {
       const actions = [
         {
           title: 'Restore to Existing Linode',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             onRestore(backup);
-            closeMenu();
             e.preventDefault();
           },
           ...disabledProps
@@ -38,7 +37,6 @@ class LinodeBackupActionMenu extends React.Component<CombinedProps> {
           title: 'Deploy New Linode',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             onDeploy(backup);
-            closeMenu();
             e.preventDefault();
           },
           ...disabledProps

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingActionMenu.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingActionMenu.tsx
@@ -36,13 +36,12 @@ class LinodeNetworkingActionMenu extends React.Component<CombinedProps> {
       readOnly
     } = this.props;
 
-    return (closeMenu: Function): Action[] => {
+    return (): Action[] => {
       const actions: Action[] = [
         {
           title: 'View',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             onView();
-            closeMenu();
             e.preventDefault();
           }
         }
@@ -63,7 +62,6 @@ class LinodeNetworkingActionMenu extends React.Component<CombinedProps> {
           title: 'Edit RDNS',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             onEdit(ipAddress);
-            closeMenu();
             e.preventDefault();
           },
           disabled: readOnly,
@@ -78,7 +76,7 @@ class LinodeNetworkingActionMenu extends React.Component<CombinedProps> {
           title: 'Delete IP',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             onRemove(ipAddress);
-            closeMenu();
+
             e.preventDefault();
           },
           disabled: readOnly,

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigActionMenu.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigActionMenu.tsx
@@ -39,7 +39,7 @@ class ConfigActionMenu extends React.Component<CombinedProps> {
     onBoot(linodeId, id, label);
   };
 
-  createConfigActions = () => (closeMenu: Function): Action[] => {
+  createConfigActions = () => (): Action[] => {
     const { readOnly, history, linodeId, config } = this.props;
     const tooltip = readOnly
       ? "You don't have permission to perform this action"
@@ -50,7 +50,6 @@ class ConfigActionMenu extends React.Component<CombinedProps> {
         onClick: (e: React.MouseEvent<HTMLElement>) => {
           e.preventDefault();
           this.handleBoot();
-          closeMenu();
         },
         disabled: readOnly,
         tooltip
@@ -60,7 +59,6 @@ class ConfigActionMenu extends React.Component<CombinedProps> {
         onClick: (e: React.MouseEvent<HTMLElement>) => {
           e.preventDefault();
           this.handleEdit();
-          closeMenu();
         },
         disabled: readOnly,
         tooltip
@@ -69,7 +67,7 @@ class ConfigActionMenu extends React.Component<CombinedProps> {
         title: 'Clone',
         onClick: (e: React.MouseEvent<HTMLElement>) => {
           e.preventDefault();
-          closeMenu();
+
           history.push(
             `/linodes/${linodeId}/clone/configs?selectedConfig=${config.id}`
           );
@@ -81,7 +79,6 @@ class ConfigActionMenu extends React.Component<CombinedProps> {
         onClick: (e: React.MouseEvent<HTMLElement>) => {
           e.preventDefault();
           this.handleDelete();
-          closeMenu();
         },
         disabled: readOnly,
         tooltip

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
@@ -146,7 +146,6 @@ export class LinodeActionMenu extends React.Component<CombinedProps, State> {
             e.preventDefault();
             e.stopPropagation();
           },
-          // ariaDescribedBy: 'new-window',
           ...readOnlyProps
         },
         {
@@ -233,7 +232,6 @@ export class LinodeActionMenu extends React.Component<CombinedProps, State> {
         actions.unshift({
           title: 'Power On',
           disabled: !hasMadeConfigsRequest || noConfigs || readOnly,
-          // isLoading: !hasMadeConfigsRequest,
           tooltip: this.state.configsError
             ? 'Could not load configs for this Linode.'
             : noConfigs
@@ -258,7 +256,6 @@ export class LinodeActionMenu extends React.Component<CombinedProps, State> {
           {
             title: 'Reboot',
             disabled: !hasMadeConfigsRequest || readOnly,
-            // isLoading: !hasMadeConfigsRequest,
             tooltip: readOnly
               ? "You don't have permission to modify this Linode."
               : this.state.configsError

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
@@ -136,7 +136,7 @@ export class LinodeActionMenu extends React.Component<CombinedProps, State> {
 
     const noConfigs = hasMadeConfigsRequest && configs.length === 0;
 
-    return (closeMenu: Function): Action[] => {
+    return (): Action[] => {
       const actions: Action[] = [
         {
           title: 'Launch Console',
@@ -224,7 +224,6 @@ export class LinodeActionMenu extends React.Component<CombinedProps, State> {
             e.preventDefault();
             e.stopPropagation();
             openDeleteDialog(linodeId, linodeLabel);
-            closeMenu();
           },
           ...readOnlyProps
         }
@@ -250,7 +249,6 @@ export class LinodeActionMenu extends React.Component<CombinedProps, State> {
               linodeLabel,
               this.state.configs
             );
-            closeMenu();
           }
         });
       }
@@ -276,7 +274,6 @@ export class LinodeActionMenu extends React.Component<CombinedProps, State> {
                 linodeLabel,
                 this.state.configs
               );
-              closeMenu();
             },
             ...readOnlyProps
           },
@@ -287,7 +284,6 @@ export class LinodeActionMenu extends React.Component<CombinedProps, State> {
               e.preventDefault();
               e.stopPropagation();
               openPowerActionDialog('Power Off', linodeId, linodeLabel, []);
-              closeMenu();
             },
             ...readOnlyProps
           }

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
@@ -146,7 +146,7 @@ export class LinodeActionMenu extends React.Component<CombinedProps, State> {
             e.preventDefault();
             e.stopPropagation();
           },
-          ariaDescribedBy: 'new-window',
+          // ariaDescribedBy: 'new-window',
           ...readOnlyProps
         },
         {
@@ -233,7 +233,7 @@ export class LinodeActionMenu extends React.Component<CombinedProps, State> {
         actions.unshift({
           title: 'Power On',
           disabled: !hasMadeConfigsRequest || noConfigs || readOnly,
-          isLoading: !hasMadeConfigsRequest,
+          // isLoading: !hasMadeConfigsRequest,
           tooltip: this.state.configsError
             ? 'Could not load configs for this Linode.'
             : noConfigs
@@ -258,7 +258,7 @@ export class LinodeActionMenu extends React.Component<CombinedProps, State> {
           {
             title: 'Reboot',
             disabled: !hasMadeConfigsRequest || readOnly,
-            isLoading: !hasMadeConfigsRequest,
+            // isLoading: !hasMadeConfigsRequest,
             tooltip: readOnly
               ? "You don't have permission to modify this Linode."
               : this.state.configsError


### PR DESCRIPTION
## Description

Updating the action menu to the new styling in addition to leveraging Reach's MenuButton component to make this fully accessible. Because of this, there was some additional cleanup. This is best viewed in Storybook. 

Standard usage:
<img width="227" alt="Screen Shot 2020-06-08 at 4 36 37 PM" src="https://user-images.githubusercontent.com/2565527/84078068-45447100-a9a6-11ea-9041-0352865f3ccc.png">

With inline label:
<img width="242" alt="Screen Shot 2020-06-08 at 4 36 44 PM" src="https://user-images.githubusercontent.com/2565527/84078070-46759e00-a9a6-11ea-9138-1a331bb1b7b3.png">

Please note that mobile and the menu item's tooltip state have not been finalized. 

## Type of Change
- Non breaking change ('update')

