### PR TITLE
Update documentation with testing techniques for mocking store and flags

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -119,6 +119,34 @@ Some components, such as our ActionMenu, don't lend themselves well to unit test
 
 Any `<ActionMenu>`s rendered by the test will be simplified versions that are easier to work with.
 
+#### Mocking Redux State
+
+The `wrapWithTheme` and `renderWithTheme` helper functions take a `customStore` option, used as follows:
+
+```tsx
+import { renderWithTheme } from 'src/utilities/testHelpers.ts`;
+
+const { getByTestId } = renderWithTheme(<MyComponent />, {
+  customStore: {} // <-- Redux store specified here
+});
+```
+
+The `customStore` prop is of type `DeepPartial<ApplicationState>`, so only the fields needed to satifsy the conditions of your test are needed.
+
+Several helpers are available in `src/utilities/testHelpersStore.ts` to simulate common scenarios (withManaged, withRestrictedUser, etc).
+
+#### Mocking Feature Flags
+
+Another option the `wrapWithTheme` and `renderWithTheme` helper functions exposes is `flags`, to supply custom feature flags:
+
+```tsx
+import { renderWithTheme } from 'src/utilities/testHelpers.ts`;
+
+const { getByTestId } = renderWithTheme(<MyComponent />, {
+  flags: { myFeature: true } // <-- Feature Flags specified here
+});
+```
+
 ## End-to-End Tests
 
 E2E tests use [Cypress](https://cypress.io).

--- a/TESTING.md
+++ b/TESTING.md
@@ -131,7 +131,7 @@ const { getByTestId } = renderWithTheme(<MyComponent />, {
 });
 ```
 
-The `customStore` prop is of type `DeepPartial<ApplicationState>`, so only the fields needed to satifsy the conditions of your test are needed.
+The `customStore` prop is of type `DeepPartial<ApplicationState>`, so only the fields needed to satisfy the conditions of your test are needed.
 
 Several helpers are available in `src/utilities/testHelpersStore.ts` to simulate common scenarios (withManaged, withRestrictedUser, etc).
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -137,7 +137,7 @@ Several helpers are available in `src/utilities/testHelpersStore.ts` to simulate
 
 #### Mocking Feature Flags
 
-Another option the `wrapWithTheme` and `renderWithTheme` helper functions exposes is `flags`, to supply custom feature flags:
+Another option the `wrapWithTheme` and `renderWithTheme` helper functions expose is `flags`, to supply custom feature flags:
 
 ```tsx
 import { renderWithTheme } from 'src/utilities/testHelpers.ts`;


### PR DESCRIPTION
## Description

https://github.com/linode/manager/pull/6508 adds a few helpers for mocking flags for testing; this updates the documentation for that and for mocking Redux state.

Question: should this live here in TESTING.MD or the new MOCKING_DATA.md? I'm leaning towards TESTING.MD.
