### PR TITLE
Dismissible main content banner

### DIFF
--- a/packages/manager/src/MainContent.test.tsx
+++ b/packages/manager/src/MainContent.test.tsx
@@ -7,7 +7,7 @@ const mainContentBanner = {
   text: 'Test Text',
   link: {
     text: 'Test anchor text',
-    url: 'https://linode.com/change'
+    url: 'https://linode.com'
   },
   key: 'Test Text Key'
 };

--- a/packages/manager/src/MainContent.test.tsx
+++ b/packages/manager/src/MainContent.test.tsx
@@ -1,0 +1,45 @@
+import {
+  checkFlagsForMainContentBanner,
+  checkPreferencesForBannerDismissal
+} from './MainContent';
+
+const mainContentBanner = {
+  text: 'Test Text',
+  link: {
+    text: 'Test anchor text',
+    url: 'https://linode.com/change'
+  },
+  key: 'Test Text Key'
+};
+
+describe('checkFlagsForMainContentBanner', () => {
+  it('returns `true` if a valid banner is present in the flag set', () => {
+    expect(checkFlagsForMainContentBanner({ mainContentBanner })).toBe(true);
+    expect(checkFlagsForMainContentBanner({})).toBe(false);
+    expect(
+      checkFlagsForMainContentBanner({ mainContentBanner: {} as any })
+    ).toBe(false);
+  });
+});
+
+describe('checkPreferencesForBannerDismissal', () => {
+  it('returns `true if the specified key is preset in preferences banner dismissals', () => {
+    expect(
+      checkPreferencesForBannerDismissal(
+        {
+          main_content_banner_dismissal: { key1: true }
+        },
+        'key1'
+      )
+    ).toBe(true);
+    expect(
+      checkPreferencesForBannerDismissal(
+        {
+          main_content_banner_dismissal: { key1: true }
+        },
+        'another-key'
+      )
+    ).toBe(false);
+    expect(checkPreferencesForBannerDismissal({}, 'key1')).toBe(false);
+  });
+});

--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -32,6 +32,9 @@ import SuspenseLoader from 'src/components/SuspenseLoader';
 import withGlobalErrors, {
   Props as GlobalErrorProps
 } from 'src/containers/globalErrors.container';
+import withPreferences, {
+  Props as PreferencesProps
+} from 'src/containers/preferences.container';
 
 import Logo from 'src/assets/logo/logo-text.svg';
 
@@ -115,7 +118,7 @@ interface Props {
   isLoggedInAsCustomer: boolean;
 }
 
-type CombinedProps = Props & GlobalErrorProps & WithTheme;
+type CombinedProps = Props & GlobalErrorProps & WithTheme & PreferencesProps;
 
 const Account = React.lazy(() => import('src/features/Account'));
 const LinodesRoutes = React.lazy(() => import('src/features/linodes'));
@@ -200,6 +203,15 @@ const MainContent: React.FC<CombinedProps> = props => {
     );
   }
 
+  // @todo: clean this up.
+  const shouldDisplayMainContentBanner =
+    flags.mainContentBanner &&
+    !isEmpty(flags.mainContentBanner) &&
+    flags.mainContentBanner.key &&
+    !props.preferences?.mainContentBannerDismissal?.[
+      flags?.mainContentBanner?.key ?? 'mainContentBannerKey'
+    ];
+
   /**
    * otherwise just show the rest of the app.
    */
@@ -222,11 +234,12 @@ const MainContent: React.FC<CombinedProps> = props => {
               [classes.hidden]: props.appIsLoading
             })}
           >
-            {flags.mainContentBanner && !isEmpty(flags.mainContentBanner) && (
+            {shouldDisplayMainContentBanner && (
               <MainContentBanner
                 bannerText={flags.mainContentBanner?.text ?? ''}
                 url={flags.mainContentBanner?.link?.url ?? ''}
                 linkText={flags.mainContentBanner?.link?.text ?? ''}
+                bannerKey={flags.mainContentBanner?.key ?? ''}
               />
             )}
             <SideMenu
@@ -328,5 +341,6 @@ const MainContent: React.FC<CombinedProps> = props => {
 export default compose<CombinedProps, Props>(
   React.memo,
   withGlobalErrors(),
-  withTheme
+  withTheme,
+  withPreferences()
 )(MainContent);

--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -37,6 +37,8 @@ import withPreferences, {
 } from 'src/containers/preferences.container';
 
 import Logo from 'src/assets/logo/logo-text.svg';
+import { FlagSet } from './featureFlags';
+import { UserPreferences } from './store/preferences/preferences.actions';
 
 const useStyles = makeStyles((theme: Theme) => ({
   appFrame: {
@@ -158,6 +160,8 @@ const MainContent: React.FC<CombinedProps> = props => {
 
   const [menuIsOpen, toggleMenu] = React.useState<boolean>(false);
 
+  const [bannerDismissed, setBannerDismissed] = React.useState<boolean>(false);
+
   /**
    * this is the case where the user has successfully completed signup
    * but needs a manual review from Customer Support. In this case,
@@ -203,14 +207,13 @@ const MainContent: React.FC<CombinedProps> = props => {
     );
   }
 
-  // @todo: clean this up.
   const shouldDisplayMainContentBanner =
-    flags.mainContentBanner &&
-    !isEmpty(flags.mainContentBanner) &&
-    flags.mainContentBanner.key &&
-    !props.preferences?.mainContentBannerDismissal?.[
-      flags?.mainContentBanner?.key ?? 'mainContentBannerKey'
-    ];
+    !bannerDismissed &&
+    checkFlagsForMainContentBanner(flags) &&
+    !checkPreferencesForBannerDismissal(
+      props.preferences,
+      flags?.mainContentBanner?.key
+    );
 
   /**
    * otherwise just show the rest of the app.
@@ -240,6 +243,7 @@ const MainContent: React.FC<CombinedProps> = props => {
                 url={flags.mainContentBanner?.link?.url ?? ''}
                 linkText={flags.mainContentBanner?.link?.text ?? ''}
                 bannerKey={flags.mainContentBanner?.key ?? ''}
+                onClose={() => setBannerDismissed(true)}
               />
             )}
             <SideMenu
@@ -344,3 +348,21 @@ export default compose<CombinedProps, Props>(
   withTheme,
   withPreferences()
 )(MainContent);
+
+// =============================================================================
+// Utilities
+// =============================================================================
+export const checkFlagsForMainContentBanner = (flags: FlagSet) => {
+  return Boolean(
+    flags.mainContentBanner &&
+      !isEmpty(flags.mainContentBanner) &&
+      flags.mainContentBanner.key
+  );
+};
+
+export const checkPreferencesForBannerDismissal = (
+  preferences: UserPreferences,
+  key = 'defaultKey'
+) => {
+  return Boolean(preferences?.main_content_banner_dismissal?.[key]);
+};

--- a/packages/manager/src/components/MainContentBanner.tsx
+++ b/packages/manager/src/components/MainContentBanner.tsx
@@ -43,6 +43,7 @@ interface Props {
   url: string;
   linkText: string;
   bannerKey: string;
+  onClose: () => void;
 }
 
 type CombinedProps = Props & PreferencesProps;
@@ -54,21 +55,26 @@ const MainContentBanner: React.FC<CombinedProps> = props => {
     linkText,
     bannerKey,
     getUserPreferences,
-    updateUserPreferences
+    updateUserPreferences,
+    onClose
   } = props;
 
   const classes = useStyles();
 
   const dismiss = () => {
-    getUserPreferences().then(preferences => {
-      updateUserPreferences({
-        ...preferences,
-        mainContentBannerDismissal: {
-          ...preferences.mainContentBannerDismissal,
-          [bannerKey]: true
-        }
-      });
-    });
+    onClose();
+    getUserPreferences()
+      .then(preferences => {
+        updateUserPreferences({
+          ...preferences,
+          main_content_banner_dismissal: {
+            ...preferences.main_content_banner_dismissal,
+            [bannerKey]: true
+          }
+        });
+      })
+      // It's OK if this fails (the banner is still dismissed in the UI due to local state).
+      .catch(_ => null);
   };
 
   return (

--- a/packages/manager/src/components/MainContentBanner.tsx
+++ b/packages/manager/src/components/MainContentBanner.tsx
@@ -1,8 +1,13 @@
 import * as React from 'react';
+import Close from '@material-ui/icons/Close';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Grid from 'src/components/core/Grid';
 import Typography from 'src/components/core/Typography';
 import { Link } from 'src/components/Link';
+import withPreferences, {
+  Props as PreferencesProps
+} from 'src/containers/preferences.container';
+import { compose } from 'recompose';
 
 const useStyles = makeStyles((theme: Theme) => ({
   bannerOuter: {
@@ -10,7 +15,10 @@ const useStyles = makeStyles((theme: Theme) => ({
     padding: theme.spacing(2),
     position: 'sticky',
     top: 0,
-    zIndex: 1110
+    zIndex: 1110,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center'
   },
   header: {
     color: '#fff',
@@ -19,6 +27,14 @@ const useStyles = makeStyles((theme: Theme) => ({
   link: {
     color: '#fff',
     textDecoration: 'underline'
+  },
+  closeIcon: {
+    position: 'absolute',
+    right: 4,
+    cursor: 'pointer',
+    border: 'none',
+    color: theme.palette.text.primary,
+    backgroundColor: 'transparent'
   }
 }));
 
@@ -26,12 +42,34 @@ interface Props {
   bannerText: string;
   url: string;
   linkText: string;
+  bannerKey: string;
 }
 
-const MainContentBanner: React.FC<Props> = props => {
-  const { bannerText, url, linkText } = props;
+type CombinedProps = Props & PreferencesProps;
+
+const MainContentBanner: React.FC<CombinedProps> = props => {
+  const {
+    bannerText,
+    url,
+    linkText,
+    bannerKey,
+    getUserPreferences,
+    updateUserPreferences
+  } = props;
 
   const classes = useStyles();
+
+  const dismiss = () => {
+    getUserPreferences().then(preferences => {
+      updateUserPreferences({
+        ...preferences,
+        mainContentBannerDismissal: {
+          ...preferences.mainContentBannerDismissal,
+          [bannerKey]: true
+        }
+      });
+    });
+  };
 
   return (
     <Grid className={classes.bannerOuter} item xs={12}>
@@ -43,8 +81,13 @@ const MainContentBanner: React.FC<Props> = props => {
           </Link>
         )}
       </Typography>
+      <button className={classes.closeIcon} onClick={dismiss}>
+        <Close />
+      </button>
     </Grid>
   );
 };
 
-export default React.memo(MainContentBanner);
+const enhanced = compose<CombinedProps, Props>(React.memo, withPreferences());
+
+export default enhanced(MainContentBanner);

--- a/packages/manager/src/components/MainContentBanner.tsx
+++ b/packages/manager/src/components/MainContentBanner.tsx
@@ -22,7 +22,10 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   header: {
     color: '#fff',
-    textAlign: 'center'
+    textAlign: 'center',
+    [theme.breakpoints.only('xs')]: {
+      paddingRight: 30
+    }
   },
   link: {
     color: '#fff',

--- a/packages/manager/src/components/MainContentBanner.tsx
+++ b/packages/manager/src/components/MainContentBanner.tsx
@@ -87,7 +87,11 @@ const MainContentBanner: React.FC<CombinedProps> = props => {
           </Link>
         )}
       </Typography>
-      <button className={classes.closeIcon} onClick={dismiss}>
+      <button
+        className={classes.closeIcon}
+        onClick={dismiss}
+        aria-label="Close"
+      >
         <Close />
       </button>
     </Grid>

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -57,4 +57,5 @@ export interface MainContentBanner {
     url: string;
   };
   text: string;
+  key: string;
 }

--- a/packages/manager/src/store/preferences/preferences.actions.ts
+++ b/packages/manager/src/store/preferences/preferences.actions.ts
@@ -24,6 +24,7 @@ export interface UserPreferences {
   spacing?: SpacingChoice;
   desktop_sidebar_open?: boolean;
   sortKeys?: Partial<Record<SortKey, OrderSet>>;
+  mainContentBannerDismissal?: Record<string, boolean>;
 }
 
 export const handleGetPreferences = actionCreator.async<

--- a/packages/manager/src/store/preferences/preferences.actions.ts
+++ b/packages/manager/src/store/preferences/preferences.actions.ts
@@ -24,7 +24,7 @@ export interface UserPreferences {
   spacing?: SpacingChoice;
   desktop_sidebar_open?: boolean;
   sortKeys?: Partial<Record<SortKey, OrderSet>>;
-  mainContentBannerDismissal?: Record<string, boolean>;
+  main_content_banner_dismissal?: Record<string, boolean>;
 }
 
 export const handleGetPreferences = actionCreator.async<


### PR DESCRIPTION
## Description

This makes the main content banner dismissible. 

The data shape for the main content banner flag now requires a unique `key` so we can map dismissals to specific banners (since we could potentially reuse this flag in the future).

## Note to Reviewers

To test, I recommend mocking a feature flag with a new key each time you want to test.
