### PR TITLE
M3-4152: Upon rebooting Linode into Rescue Mode, prevent dropdown from reverting to "None"

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.tsx
@@ -170,12 +170,12 @@ export class LinodeRescue extends React.Component<CombinedProps, State> {
 
     rescueLinode(linodeId, createDevicesFromStrings(rescueDevices))
       .then(_ => {
-        const [diskMap, counter] = getDefaultDeviceMapAndCounter(
+        const counter = getDefaultDeviceMapAndCounter(
           this.props.linodeDisks || []
-        );
+        )[1];
         this.setState({
           counter,
-          rescueDevices: diskMap
+          rescueDevices: this.state.rescueDevices
         });
         enqueueSnackbar('Linode rescue started.', {
           variant: 'info'


### PR DESCRIPTION
## Description
Currently, when a user clicks the button to reboot their Linode into Rescue Mode, their selection for /dev/sdc will revert to "None." This PR stops that unintended behavior.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')
