### PR TITLE
M3-4163: Handle negative amount on invoice details better

### DIFF
--- a/packages/manager/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
+++ b/packages/manager/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
@@ -73,7 +73,6 @@ export const InvoiceDetail: React.FC<CombinedProps> = props => {
   const [pdfGenerationError, setPDFGenerationError] = React.useState<any>(
     undefined
   );
-  const [isNegative, setIsNegative] = React.useState<boolean>(false);
 
   const flags = useFlags();
 
@@ -99,7 +98,6 @@ export const InvoiceDetail: React.FC<CombinedProps> = props => {
         setLoading(false);
         setInvoice(invoice);
         setItems(items);
-        setIsNegative(invoice.total < 0);
       })
       .catch(errorResponse => {
         setErrors(
@@ -165,7 +163,7 @@ export const InvoiceDetail: React.FC<CombinedProps> = props => {
                 <Typography variant="h2" data-qa-total={invoice.total}>
                   Total:{' '}
                   <Currency
-                    wrapInParentheses={isNegative}
+                    wrapInParentheses={invoice.total < 0}
                     quantity={invoice.total}
                   />
                 </Typography>
@@ -183,12 +181,7 @@ export const InvoiceDetail: React.FC<CombinedProps> = props => {
           > Send report</a>`}
             />
           )}
-          <InvoiceTable
-            loading={loading}
-            items={items}
-            errors={errors}
-            isNegative={isNegative}
-          />
+          <InvoiceTable loading={loading} items={items} errors={errors} />
         </Grid>
         <Grid item xs={12}>
           {invoice && (
@@ -197,7 +190,7 @@ export const InvoiceDetail: React.FC<CombinedProps> = props => {
                 <Typography variant="h2">
                   Subotal:{' '}
                   <Currency
-                    wrapInParentheses={isNegative}
+                    wrapInParentheses={invoice.subtotal < 0}
                     quantity={invoice.subtotal}
                   />
                 </Typography>
@@ -207,7 +200,7 @@ export const InvoiceDetail: React.FC<CombinedProps> = props => {
                 <Typography variant="h2">
                   Total:{' '}
                   <Currency
-                    wrapInParentheses={isNegative}
+                    wrapInParentheses={invoice.total < 0}
                     quantity={invoice.total}
                   />
                 </Typography>

--- a/packages/manager/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
+++ b/packages/manager/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
@@ -35,7 +35,7 @@ import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { getAll } from 'src/utilities/getAll';
 import InvoiceTable from './InvoiceTable';
 
-type ClassNames = 'root' | 'backButton' | 'titleWrapper' | 'totals';
+type ClassNames = 'root' | 'backButton' | 'titleWrapper' | 'totals' | 'm2';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -60,6 +60,9 @@ const styles = (theme: Theme) =>
         width: 34,
         height: 34
       }
+    },
+    m2: {
+      margin: theme.spacing()
     }
   });
 
@@ -69,6 +72,7 @@ interface State {
   loading: boolean;
   errors?: APIError[];
   pdfGenerationError?: any;
+  isNegative: boolean;
 }
 
 type CombinedProps = RouteComponentProps<{ invoiceId: string }> &
@@ -79,7 +83,8 @@ type CombinedProps = RouteComponentProps<{ invoiceId: string }> &
 class InvoiceDetail extends React.Component<CombinedProps, State> {
   state: State = {
     loading: false,
-    pdfGenerationError: undefined
+    pdfGenerationError: undefined,
+    isNegative: false
   };
 
   mounted: boolean = false;
@@ -106,7 +111,8 @@ class InvoiceDetail extends React.Component<CombinedProps, State> {
         this.setState({
           loading: false,
           invoice,
-          items
+          items,
+          isNegative: invoice.total < 0
         });
       })
       .catch(errorResponse => {
@@ -138,7 +144,14 @@ class InvoiceDetail extends React.Component<CombinedProps, State> {
 
   render() {
     const { classes, data } = this.props;
-    const { invoice, loading, errors, items, pdfGenerationError } = this.state;
+    const {
+      invoice,
+      loading,
+      errors,
+      items,
+      pdfGenerationError,
+      isNegative
+    } = this.state;
 
     return (
       <Paper className={classes.root}>
@@ -174,10 +187,13 @@ class InvoiceDetail extends React.Component<CombinedProps, State> {
                   </Button>
                 )}
               </Grid>
-              <Grid item className={classes.titleWrapper}>
+              <Grid item className={`${classes.titleWrapper} ${classes.m2}`}>
                 {invoice && (
                   <Typography variant="h2" data-qa-total={invoice.total}>
-                    Total: ${Number(invoice.total).toFixed(2)}
+                    Total:{' '}
+                    {isNegative
+                      ? '-($' + Number(invoice.total * -1).toFixed(2) + ')'
+                      : '$' + Number(invoice.total).toFixed(2)}
                   </Typography>
                 )}
               </Grid>
@@ -193,20 +209,34 @@ class InvoiceDetail extends React.Component<CombinedProps, State> {
             > Send report</a>`}
               />
             )}
-            <InvoiceTable loading={loading} items={items} errors={errors} />
+            <InvoiceTable
+              loading={loading}
+              items={items}
+              errors={errors}
+              isNegative={isNegative}
+            />
           </Grid>
           <Grid item xs={12}>
             {invoice && (
               <Grid container justify="flex-end">
                 <Grid item className={classes.totals}>
                   <Typography variant="h2">
-                    Subtotal: ${Number(invoice.subtotal).toFixed(2)}
+                    Subotal:{' '}
+                    {isNegative
+                      ? '-($' + Number(invoice.subtotal * -1).toFixed(2) + ')'
+                      : '$' + Number(invoice.subtotal).toFixed(2)}
                   </Typography>
                   <Typography variant="h2">
-                    Tax: ${Number(invoice.tax).toFixed(2)}
+                    Tax:{' '}
+                    {isNegative
+                      ? '-($' + Number(invoice.tax * -1).toFixed(2) + ')'
+                      : '$' + Number(invoice.tax).toFixed(2)}
                   </Typography>
                   <Typography variant="h2">
-                    Total: ${Number(invoice.total).toFixed(2)}
+                    Total:{' '}
+                    {isNegative
+                      ? '-($' + Number(invoice.total * -1).toFixed(2) + ')'
+                      : '$' + Number(invoice.total).toFixed(2)}
                   </Typography>
                 </Grid>
               </Grid>

--- a/packages/manager/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
+++ b/packages/manager/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
@@ -13,12 +13,7 @@ import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
 import Button from 'src/components/Button';
 import Paper from 'src/components/core/Paper';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles
-} from 'src/components/core/styles';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 import IconButton from 'src/components/IconButton';
@@ -35,71 +30,65 @@ import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { getAll } from 'src/utilities/getAll';
 import InvoiceTable from './InvoiceTable';
 
-type ClassNames = 'root' | 'backButton' | 'titleWrapper' | 'totals' | 'm2';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {
-      padding: `${theme.spacing(2)}px ${theme.spacing(3)}px`
-    },
-    totals: {
-      display: 'flex',
-      flexDirection: 'column',
-      textAlign: 'right',
-      '& h2': {
-        margin: theme.spacing(1)
-      }
-    },
-    titleWrapper: {
-      display: 'flex',
-      alignItems: 'center'
-    },
-    backButton: {
-      margin: '5px 0 0 -16px',
-      '& svg': {
-        width: 34,
-        height: 34
-      }
-    },
-    m2: {
-      margin: theme.spacing()
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    padding: `${theme.spacing(2)}px ${theme.spacing(3)}px`
+  },
+  totals: {
+    display: 'flex',
+    flexDirection: 'column',
+    textAlign: 'right',
+    '& h2': {
+      margin: theme.spacing(1)
     }
-  });
-
-interface State {
-  invoice?: Invoice;
-  items?: InvoiceItem[];
-  loading: boolean;
-  errors?: APIError[];
-  pdfGenerationError?: any;
-  isNegative: boolean;
-}
+  },
+  titleWrapper: {
+    display: 'flex',
+    alignItems: 'center'
+  },
+  backButton: {
+    margin: '5px 0 0 -16px',
+    '& svg': {
+      width: 34,
+      height: 34
+    }
+  },
+  m2: {
+    margin: theme.spacing()
+  }
+}));
 
 type CombinedProps = RouteComponentProps<{ invoiceId: string }> &
   StateProps &
-  FeatureFlagConsumerProps &
-  WithStyles<ClassNames>;
+  FeatureFlagConsumerProps;
 
-class InvoiceDetail extends React.Component<CombinedProps, State> {
-  state: State = {
-    loading: false,
-    pdfGenerationError: undefined,
-    isNegative: false
-  };
+export const InvoiceDetail: React.FC<CombinedProps> = props => {
+  const classes = useStyles();
 
-  mounted: boolean = false;
+  const { data } = props;
 
-  requestData = () => {
+  const [invoice, setInvoice] = React.useState<Invoice | undefined>(undefined);
+  const [items, setItems] = React.useState<InvoiceItem[] | undefined>(
+    undefined
+  );
+  const [loading, setLoading] = React.useState<boolean>(false);
+  const [errors, setErrors] = React.useState<APIError[] | undefined>();
+  const [pdfGenerationError, setPDFGenerationError] = React.useState<any>(
+    undefined
+  );
+  const [isNegative, setIsNegative] = React.useState<boolean>(false);
+
+  const requestData = () => {
     const {
       match: {
         params: { invoiceId }
       },
       data
-    } = this.props;
-    this.setState({ loading: true });
+    } = props;
+    setLoading(true);
 
     if (!data) {
-      this.props.requestAccount();
+      props.requestAccount();
     }
 
     const getAllInvoiceItems = getAll<InvoiceItem>((params, filter) =>
@@ -108,145 +97,129 @@ class InvoiceDetail extends React.Component<CombinedProps, State> {
 
     Promise.all([getInvoice(+invoiceId), getAllInvoiceItems()])
       .then(([invoice, { data: items }]) => {
-        this.setState({
-          loading: false,
-          invoice,
-          items,
-          isNegative: invoice.total < 0
-        });
+        setLoading(false);
+        setInvoice(invoice);
+        setItems(items);
+        setIsNegative(invoice.total < 0);
       })
       .catch(errorResponse => {
-        this.setState({
-          errors: getAPIErrorOrDefault(
+        setErrors(
+          getAPIErrorOrDefault(
             errorResponse,
             'Unable to retrieve invoice details. '
           )
-        });
+        );
       });
   };
 
-  componentDidMount() {
-    this.mounted = true;
-    this.requestData();
-  }
+  React.useEffect(() => {
+    requestData();
+  }, []);
 
-  componentWillUnmount() {
-    this.mounted = false;
-  }
-
-  printInvoice(account: Account, invoice: Invoice, items: InvoiceItem[]) {
-    const taxBanner = this.props.flags.taxBanner;
+  const printInvoicePDF = (
+    account: Account,
+    invoice: Invoice,
+    items: InvoiceItem[]
+  ) => {
+    const taxBanner = props.flags.taxBanner;
     const result = printInvoice(account, invoice, items, taxBanner);
-    this.setState({
-      pdfGenerationError: result.status === 'error' ? result.error : undefined
-    });
-  }
 
-  render() {
-    const { classes, data } = this.props;
-    const {
-      invoice,
-      loading,
-      errors,
-      items,
-      pdfGenerationError,
-      isNegative
-    } = this.state;
+    setPDFGenerationError(result.status === 'error' ? result.error : undefined);
+  };
 
-    return (
-      <Paper className={classes.root}>
-        <Grid container>
-          <Grid item xs={12}>
-            <Grid container justify="space-between">
-              <Grid item className={classes.titleWrapper} style={{ flex: 1 }}>
-                <Link to={`/account/billing`}>
-                  <IconButton
-                    className={classes.backButton}
-                    data-qa-back-to-billing
-                  >
-                    <KeyboardArrowLeft />
-                  </IconButton>
-                </Link>
-                {invoice && (
-                  <Typography variant="h2" data-qa-invoice-id>
-                    Invoice #{invoice.id}
-                  </Typography>
-                )}
-              </Grid>
-              <Grid
-                item
-                className={classes.titleWrapper}
-                data-qa-printable-invoice
-              >
-                {data && invoice && items && (
-                  <Button
-                    buttonType="primary"
-                    onClick={() => this.printInvoice(data, invoice, items)}
-                  >
-                    Download PDF
-                  </Button>
-                )}
-              </Grid>
-              <Grid item className={`${classes.titleWrapper} ${classes.m2}`}>
-                {invoice && (
-                  <Typography variant="h2" data-qa-total={invoice.total}>
-                    Total:{' '}
-                    {isNegative
-                      ? '-($' + Number(invoice.total * -1).toFixed(2) + ')'
-                      : '$' + Number(invoice.total).toFixed(2)}
-                  </Typography>
-                )}
-              </Grid>
+  return (
+    <Paper className={classes.root}>
+      <Grid container>
+        <Grid item xs={12}>
+          <Grid container justify="space-between">
+            <Grid item className={classes.titleWrapper} style={{ flex: 1 }}>
+              <Link to={`/account/billing`}>
+                <IconButton
+                  className={classes.backButton}
+                  data-qa-back-to-billing
+                >
+                  <KeyboardArrowLeft />
+                </IconButton>
+              </Link>
+              {invoice && (
+                <Typography variant="h2" data-qa-invoice-id>
+                  Invoice #{invoice.id}
+                </Typography>
+              )}
+            </Grid>
+            <Grid
+              item
+              className={classes.titleWrapper}
+              data-qa-printable-invoice
+            >
+              {data && invoice && items && (
+                <Button
+                  buttonType="primary"
+                  onClick={() => printInvoicePDF(data, invoice, items)}
+                >
+                  Download PDF
+                </Button>
+              )}
+            </Grid>
+            <Grid item className={`${classes.titleWrapper} ${classes.m2}`}>
+              {invoice && (
+                <Typography variant="h2" data-qa-total={invoice.total}>
+                  Total:{' '}
+                  {isNegative
+                    ? '-($' + Number(invoice.total * -1).toFixed(2) + ')'
+                    : '$' + Number(invoice.total).toFixed(2)}
+                </Typography>
+              )}
             </Grid>
           </Grid>
-          <Grid item xs={12}>
-            {pdfGenerationError && (
-              <Notice
-                error={true}
-                html={`Failed generating PDF. <a href="${createMailto(
-                  pdfGenerationError.stack
-                )}"
-            > Send report</a>`}
-              />
-            )}
-            <InvoiceTable
-              loading={loading}
-              items={items}
-              errors={errors}
-              isNegative={isNegative}
-            />
-          </Grid>
-          <Grid item xs={12}>
-            {invoice && (
-              <Grid container justify="flex-end">
-                <Grid item className={classes.totals}>
-                  <Typography variant="h2">
-                    Subotal:{' '}
-                    {isNegative
-                      ? '-($' + Number(invoice.subtotal * -1).toFixed(2) + ')'
-                      : '$' + Number(invoice.subtotal).toFixed(2)}
-                  </Typography>
-                  <Typography variant="h2">
-                    Tax:{' '}
-                    {isNegative
-                      ? '-($' + Number(invoice.tax * -1).toFixed(2) + ')'
-                      : '$' + Number(invoice.tax).toFixed(2)}
-                  </Typography>
-                  <Typography variant="h2">
-                    Total:{' '}
-                    {isNegative
-                      ? '-($' + Number(invoice.total * -1).toFixed(2) + ')'
-                      : '$' + Number(invoice.total).toFixed(2)}
-                  </Typography>
-                </Grid>
-              </Grid>
-            )}
-          </Grid>
         </Grid>
-      </Paper>
-    );
-  }
-}
+        <Grid item xs={12}>
+          {pdfGenerationError && (
+            <Notice
+              error={true}
+              html={`Failed generating PDF. <a href="${createMailto(
+                pdfGenerationError.stack
+              )}"
+          > Send report</a>`}
+            />
+          )}
+          <InvoiceTable
+            loading={loading}
+            items={items}
+            errors={errors}
+            isNegative={isNegative}
+          />
+        </Grid>
+        <Grid item xs={12}>
+          {invoice && (
+            <Grid container justify="flex-end">
+              <Grid item className={classes.totals}>
+                <Typography variant="h2">
+                  Subotal:{' '}
+                  {isNegative
+                    ? '-($' + Number(invoice.subtotal * -1).toFixed(2) + ')'
+                    : '$' + Number(invoice.subtotal).toFixed(2)}
+                </Typography>
+                <Typography variant="h2">
+                  Tax:{' '}
+                  {isNegative
+                    ? '-($' + Number(invoice.tax * -1).toFixed(2) + ')'
+                    : '$' + Number(invoice.tax).toFixed(2)}
+                </Typography>
+                <Typography variant="h2">
+                  Total:{' '}
+                  {isNegative
+                    ? '-($' + Number(invoice.total * -1).toFixed(2) + ')'
+                    : '$' + Number(invoice.total).toFixed(2)}
+                </Typography>
+              </Grid>
+            </Grid>
+          )}
+        </Grid>
+      </Grid>
+    </Paper>
+  );
+};
 
 type S = ApplicationState['__resources']['account'];
 
@@ -261,13 +234,6 @@ const connected = connect(
   })
 );
 
-const styled = withStyles(styles);
-
-const enhanced = compose<CombinedProps, {}>(
-  connected,
-  styled,
-  withRouter,
-  withFlags
-);
+const enhanced = compose<CombinedProps, {}>(connected, withRouter, withFlags);
 
 export default enhanced(InvoiceDetail);

--- a/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
+++ b/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
 import TableRow from 'src/components/core/TableRow';
+import Currency from 'src/components/Currency';
 import DateTimeDisplay from 'src/components/DateTimeDisplay';
 import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
@@ -103,13 +104,13 @@ const RenderData: React.FC<{
                   {renderUnitPrice(unit_price)}
                 </TableCell>
                 <TableCell parentColumn="Amount (USD)" data-qa-amount>
-                  {isNegative ? '-($' + amount * -1 + ')' : '$' + amount}
+                  <Currency wrapInParentheses={isNegative} quantity={amount} />
                 </TableCell>
                 <TableCell parentColumn="Tax (USD)" data-qa-tax>
-                  {isNegative ? '-($' + tax * -1 + ')' : '$' + tax}
+                  <Currency quantity={tax} />
                 </TableCell>
                 <TableCell parentColumn="Total (USD)" data-qa-total>
-                  {isNegative ? '-($' + total * -1 + ')' : '$' + total}
+                  <Currency wrapInParentheses={isNegative} quantity={total} />
                 </TableCell>
               </TableRow>
             )

--- a/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
+++ b/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
@@ -71,6 +71,8 @@ const RenderData: React.FC<{
 }> = props => {
   const { items, isNegative } = props;
 
+  const MIN_PAGE_SIZE = 25;
+
   return (
     <Paginate data={items} pageSize={25}>
       {({
@@ -112,7 +114,7 @@ const RenderData: React.FC<{
               </TableRow>
             )
           )}
-          {count > pageSize && (
+          {count > MIN_PAGE_SIZE && (
             <TableRow>
               <TableCell
                 style={{

--- a/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
+++ b/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
@@ -19,11 +19,10 @@ interface Props {
   loading: boolean;
   errors?: APIError[];
   items?: InvoiceItem[];
-  isNegative: boolean;
 }
 
 const InvoiceTable: React.FC<Props> = props => {
-  const { loading, errors, items, isNegative } = props;
+  const { loading, errors, items } = props;
 
   return (
     <Table border aria-label="Invoice Details">
@@ -42,12 +41,7 @@ const InvoiceTable: React.FC<Props> = props => {
         </TableRow>
       </TableHead>
       <TableBody>
-        <MaybeRenderContent
-          loading={loading}
-          errors={errors}
-          items={items}
-          isNegative={isNegative}
-        />
+        <MaybeRenderContent loading={loading} errors={errors} items={items} />
       </TableBody>
     </Table>
   );
@@ -68,9 +62,8 @@ const renderQuantity = (v: null | number) => (v ? v : null);
 
 const RenderData: React.FC<{
   items: InvoiceItem[];
-  isNegative: boolean;
 }> = props => {
-  const { items, isNegative } = props;
+  const { items } = props;
 
   const MIN_PAGE_SIZE = 25;
 
@@ -104,13 +97,13 @@ const RenderData: React.FC<{
                   {renderUnitPrice(unit_price)}
                 </TableCell>
                 <TableCell parentColumn="Amount (USD)" data-qa-amount>
-                  <Currency wrapInParentheses={isNegative} quantity={amount} />
+                  <Currency wrapInParentheses={amount < 0} quantity={amount} />
                 </TableCell>
                 <TableCell parentColumn="Tax (USD)" data-qa-tax>
                   <Currency quantity={tax} />
                 </TableCell>
                 <TableCell parentColumn="Total (USD)" data-qa-total>
-                  <Currency wrapInParentheses={isNegative} quantity={total} />
+                  <Currency wrapInParentheses={total < 0} quantity={total} />
                 </TableCell>
               </TableRow>
             )
@@ -160,9 +153,8 @@ const MaybeRenderContent: React.FC<{
   loading: boolean;
   errors?: APIError[];
   items?: any[];
-  isNegative: boolean;
 }> = props => {
-  const { loading, errors, items, isNegative } = props;
+  const { loading, errors, items } = props;
 
   if (loading) {
     return <RenderLoading />;
@@ -173,7 +165,7 @@ const MaybeRenderContent: React.FC<{
   }
 
   if (items && items.length > 0) {
-    return <RenderData items={items} isNegative={isNegative} />;
+    return <RenderData items={items} />;
   }
 
   return <RenderEmpty />;

--- a/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
+++ b/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
@@ -18,10 +18,11 @@ interface Props {
   loading: boolean;
   errors?: APIError[];
   items?: InvoiceItem[];
+  isNegative: boolean;
 }
 
 const InvoiceTable: React.FC<Props> = props => {
-  const { loading, errors, items } = props;
+  const { loading, errors, items, isNegative } = props;
   return (
     <Table border aria-label="Invoice Details">
       <TableHead>
@@ -39,7 +40,12 @@ const InvoiceTable: React.FC<Props> = props => {
         </TableRow>
       </TableHead>
       <TableBody>
-        <MaybeRenderContent loading={loading} errors={errors} items={items} />
+        <MaybeRenderContent
+          loading={loading}
+          errors={errors}
+          items={items}
+          isNegative={isNegative}
+        />
       </TableBody>
     </Table>
   );
@@ -60,8 +66,9 @@ const renderQuantity = (v: null | number) => (v ? v : null);
 
 const RenderData: React.FC<{
   items: InvoiceItem[];
+  isNegative: boolean;
 }> = props => {
-  const { items } = props;
+  const { items, isNegative } = props;
   return (
     <Paginate data={items} pageSize={25}>
       {({
@@ -92,13 +99,13 @@ const RenderData: React.FC<{
                   {renderUnitPrice(unit_price)}
                 </TableCell>
                 <TableCell parentColumn="Amount (USD)" data-qa-amount>
-                  ${amount}
+                  {isNegative ? '-($' + amount * -1 + ')' : '$' + amount}
                 </TableCell>
                 <TableCell parentColumn="Tax (USD)" data-qa-tax>
-                  ${tax}
+                  {isNegative ? '-($' + tax * -1 + ')' : '$' + tax}
                 </TableCell>
                 <TableCell parentColumn="Total (USD)" data-qa-total>
-                  ${total}
+                  {isNegative ? '-($' + total * -1 + ')' : '$' + total}
                 </TableCell>
               </TableRow>
             )
@@ -146,8 +153,9 @@ const MaybeRenderContent: React.FC<{
   loading: boolean;
   errors?: APIError[];
   items?: any[];
+  isNegative: boolean;
 }> = props => {
-  const { loading, errors, items } = props;
+  const { loading, errors, items, isNegative } = props;
 
   if (loading) {
     return <RenderLoading />;
@@ -158,7 +166,7 @@ const MaybeRenderContent: React.FC<{
   }
 
   if (items && items.length > 0) {
-    return <RenderData items={items} />;
+    return <RenderData items={items} isNegative={isNegative} />;
   }
 
   return <RenderEmpty />;

--- a/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
+++ b/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
@@ -23,6 +23,7 @@ interface Props {
 
 const InvoiceTable: React.FC<Props> = props => {
   const { loading, errors, items, isNegative } = props;
+
   return (
     <Table border aria-label="Invoice Details">
       <TableHead>
@@ -69,6 +70,7 @@ const RenderData: React.FC<{
   isNegative: boolean;
 }> = props => {
   const { items, isNegative } = props;
+
   return (
     <Paginate data={items} pageSize={25}>
       {({
@@ -110,23 +112,25 @@ const RenderData: React.FC<{
               </TableRow>
             )
           )}
-          <TableRow>
-            <TableCell
-              style={{
-                paddingTop: 2
-              }}
-              colSpan={8}
-            >
-              <PaginationFooter
-                eventCategory="invoice_items"
-                count={count}
-                page={page}
-                pageSize={pageSize}
-                handlePageChange={handlePageChange}
-                handleSizeChange={handlePageSizeChange}
-              />
-            </TableCell>
-          </TableRow>
+          {count > pageSize && (
+            <TableRow>
+              <TableCell
+                style={{
+                  paddingTop: 2
+                }}
+                colSpan={8}
+              >
+                <PaginationFooter
+                  eventCategory="invoice_items"
+                  count={count}
+                  page={page}
+                  pageSize={pageSize}
+                  handlePageChange={handlePageChange}
+                  handleSizeChange={handlePageSizeChange}
+                />
+              </TableCell>
+            </TableRow>
+          )}
         </React.Fragment>
       )}
     </Paginate>


### PR DESCRIPTION
## Description
Add a check for negative amounts and add the correct text if it is negative. 

Also lined up the margins for the total on the upper right with the invoice summary on the bottom and removed the empty row when there is no pagination.

**Before:**
<img width="1148" alt="Screen Shot 2020-06-09 at 3 59 09 PM" src="https://user-images.githubusercontent.com/7692354/84193894-2c9d8f00-aa6a-11ea-910c-de22efc98ba5.png">

**After:**
<img width="1148" alt="Screen Shot 2020-06-09 at 3 57 10 PM" src="https://user-images.githubusercontent.com/7692354/84193747-eb0ce400-aa69-11ea-851f-976d811e4c4b.png">

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers
### TODO:
- [x] Convert `InvoiceDetail.tsx` to a function component
- [ ] ~~Update how the generated PDF table handles negative amounts~~ (gave up, too difficult lol)