### PR TITLE
CMR action menu styling

### DIFF
--- a/packages/manager/src/components/ActionMenu_CMR/ActionMenu_CMR.spec.js
+++ b/packages/manager/src/components/ActionMenu_CMR/ActionMenu_CMR.spec.js
@@ -1,0 +1,70 @@
+const {
+  navigateToStory,
+  executeInAllStories
+} = require('../../../e2e/utils/storybook');
+
+describe('Action Menu Suite', () => {
+  const component = 'Action Menu';
+  const menuStories = [
+    'Action Menu',
+    'Action Menu with disabled menu item %26 tooltip'
+  ];
+  const actionMenu = '[data-qa-action-menu]';
+  const actionMenuItem = '[data-qa-action-menu-item]';
+
+  it('should display action menu element', () => {
+    navigateToStory(component, menuStories, () => {
+      $(actionMenu).waitForDisplayed();
+    });
+  });
+
+  it('should display action menu items', () => {
+    executeInAllStories(component, menuStories, () => {
+      $(actionMenu).click();
+      $(actionMenuItem).waitForDisplayed();
+      expect($$(actionMenuItem).length)
+        .withContext(`Missing menu items`)
+        .toBeGreaterThan(1);
+      $$(actionMenuItem).forEach(i => expect(i.getTagName()).toBe('li'));
+    });
+  });
+
+  it('should hide the menu items on select of an item', () => {
+    navigateToStory(component, menuStories[0]);
+    $(actionMenu).click();
+    $(actionMenuItem).waitForDisplayed();
+    $(actionMenuItem).click();
+    $(actionMenuItem).waitForExist(3000, true);
+  });
+
+  it('should display tooltip menu item', () => {
+    navigateToStory(component, menuStories[1]);
+
+    const disabledMenuItem = '[data-qa-action-menu-item="Disabled Action"]';
+    const tooltipIcon = '[data-qa-tooltip-icon]';
+    const tooltip = '[data-qa-tooltip]';
+
+    $(actionMenu).waitForDisplayed();
+    $(actionMenu).click();
+
+    $(disabledMenuItem).waitForDisplayed();
+
+    $(tooltipIcon).waitForDisplayed();
+    $(tooltipIcon).moveTo();
+    $(tooltipIcon).click();
+
+    $(tooltip).waitForDisplayed();
+    expect($(tooltip).getText())
+      .withContext(`Incorrect tooltip text`)
+      .toBe('An explanation as to why this item is disabled');
+    expect($(disabledMenuItem).getAttribute('class'))
+      .withContext(`Class should be disabled`)
+      .toContain('disabled');
+    expect($(tooltipIcon).isDisplayed())
+      .withContext(`Tooltip icon should be displayed`)
+      .toBe(true);
+    expect($(tooltipIcon).getTagName())
+      .withContext(`Incorrect tag name`)
+      .toBe('button');
+  });
+});

--- a/packages/manager/src/components/ActionMenu_CMR/ActionMenu_CMR.stories.tsx
+++ b/packages/manager/src/components/ActionMenu_CMR/ActionMenu_CMR.stories.tsx
@@ -1,0 +1,118 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import ActionMenu, { Action } from './ActionMenu_CMR';
+
+interface Props {
+  style?: any;
+}
+
+type CombinedProps = Props;
+
+class StoryActionMenu extends React.Component<CombinedProps> {
+  createActions = () => (): Action[] => {
+    return [
+      {
+        title: 'First Action',
+        onClick: (e: React.MouseEvent<HTMLElement>) => {
+          e.preventDefault();
+        }
+      },
+      {
+        title: 'Action 1',
+        onClick: (e: React.MouseEvent<HTMLElement>) => {
+          e.preventDefault();
+        }
+      },
+      {
+        title: 'Action 3',
+        onClick: (e: React.MouseEvent<HTMLElement>) => {
+          e.preventDefault();
+        }
+      },
+      {
+        title: 'Last Action',
+        onClick: (e: React.MouseEvent<HTMLElement>) => {
+          e.preventDefault();
+        }
+      }
+    ];
+  };
+
+  render() {
+    return (
+      <ActionMenu createActions={this.createActions()} ariaLabel="label" />
+    );
+  }
+}
+
+class StoryActionMenuWithTooltip extends React.Component<CombinedProps> {
+  createActions = () => (): Action[] => {
+    return [
+      {
+        title: 'First Action',
+        onClick: (e: React.MouseEvent<HTMLElement>) => {
+          e.preventDefault();
+        }
+      },
+      {
+        title: 'Another Action',
+        onClick: (e: React.MouseEvent<HTMLElement>) => {
+          e.preventDefault();
+        }
+      },
+      {
+        title: 'Disabled Action',
+        disabled: true,
+        onClick: (e: React.MouseEvent<HTMLElement>) => {
+          e.preventDefault();
+        },
+        tooltip: 'An explanation as to why this item is disabled'
+      }
+    ];
+  };
+
+  render() {
+    return (
+      <ActionMenu createActions={this.createActions()} ariaLabel="label" />
+    );
+  }
+}
+
+class StoryActionMenuWithInlineLabel extends React.Component<CombinedProps> {
+  createActions = () => (): Action[] => {
+    return [
+      {
+        title: 'Single Action',
+        onClick: (e: React.MouseEvent<HTMLElement>) => {
+          e.preventDefault();
+        }
+      }
+    ];
+  };
+  render() {
+    return (
+      <ActionMenu
+        createActions={this.createActions()}
+        ariaLabel="label"
+        inlineLabel="More Actions"
+      />
+    );
+  }
+}
+
+storiesOf('CMR Action Menu', module)
+  .add('Action Menu', () => (
+    <div style={{ textAlign: 'center' }}>
+      <StoryActionMenu />
+    </div>
+  ))
+  .add('Action Menu with disabled menu item & tooltip', () => (
+    <div style={{ textAlign: 'center' }}>
+      <StoryActionMenuWithTooltip />
+    </div>
+  ))
+  .add('Action Menu with inline label', () => (
+    <div style={{ textAlign: 'center' }}>
+      <StoryActionMenuWithInlineLabel />
+    </div>
+  ));

--- a/packages/manager/src/components/ActionMenu_CMR/ActionMenu_CMR.test.tsx
+++ b/packages/manager/src/components/ActionMenu_CMR/ActionMenu_CMR.test.tsx
@@ -1,0 +1,21 @@
+import { mount } from 'enzyme';
+import * as React from 'react';
+
+import ActionMenu_CMR from './ActionMenu_CMR';
+
+describe('ActionMenu', () => {
+  const action = { title: 'whatever', onClick: () => undefined };
+  const createActionsMany = () => {
+    return [action, action, action];
+  };
+
+  it.skip('should render a menu when provided many or one action(s).', () => {
+    const result = mount(
+      <ActionMenu_CMR createActions={createActionsMany} ariaLabel="label" />
+    );
+    expect(result.find('WithStyles(ActionMenu)')).toHaveLength(1);
+
+    result.find('IconButton').simulate('click');
+    expect(result.find('WithStyles(MenuItem)')).toHaveLength(4);
+  });
+});

--- a/packages/manager/src/components/ActionMenu_CMR/ActionMenu_CMR.tsx
+++ b/packages/manager/src/components/ActionMenu_CMR/ActionMenu_CMR.tsx
@@ -1,0 +1,163 @@
+import * as classNames from 'classnames';
+import MoreHoriz from '@material-ui/icons/MoreHoriz';
+import {
+  Menu,
+  MenuButton,
+  MenuItems,
+  MenuLink,
+  MenuPopover
+} from '@reach/menu-button';
+import '@reach/menu-button/styles.css';
+import * as React from 'react';
+import HelpIcon from 'src/components/HelpIcon';
+import { makeStyles, Theme } from 'src/components/core/styles';
+
+export interface Action {
+  title: string;
+  disabled?: boolean;
+  tooltip?: string;
+  onClick: (e: React.MouseEvent<HTMLElement>) => void;
+}
+
+const useStyles = makeStyles((theme: Theme) => ({
+  wrapper: {
+    display: 'inline-block',
+    position: 'relative'
+  },
+  button: {
+    '&[data-reach-menu-button]': {
+      display: 'flex',
+      alignItems: 'center',
+      background: 'none',
+      fontSize: '1rem',
+      fontWeight: 'bold',
+      border: 'none',
+      padding: theme.spacing(1) + 2,
+      color: '#3683dc',
+      cursor: 'pointer',
+      '&[aria-expanded="true"]': {
+        backgroundColor: '#3683dc',
+        color: '#fff'
+      }
+    }
+  },
+  buttonLabel: {
+    margin: `0 0 0 ${theme.spacing()}px`
+  },
+  icon: {},
+  popover: {
+    '&[data-reach-menu-popover]': {
+      right: 0,
+      // Need this to 'merge the button and items wrapper due to the borderRadius on the wrapper
+      marginTop: -3,
+      zIndex: 1
+    }
+  },
+  itemsOuter: {
+    '&[data-reach-menu-items]': {
+      padding: 0,
+      width: 200,
+      background: '#3683dc',
+      borderRadius: 3,
+      border: 'none',
+      fontSize: 14,
+      color: '#fff',
+      textAlign: 'left'
+    }
+  },
+  item: {
+    '&[data-reach-menu-item]': {
+      padding: theme.spacing(1) + 2,
+      borderBottom: '1px solid #5294e0',
+      background: '#3683dc',
+      color: '#fff',
+      borderRadius: 3
+    },
+    '&[data-reach-menu-item][data-selected]': {
+      background: '#226dc3'
+    }
+  },
+  disabled: {
+    '&[data-reach-menu-item]': {
+      color: '#93bcec',
+      cursor: 'auto'
+    },
+    '&[data-reach-menu-item][data-selected]': {
+      background: '#3683dc'
+    }
+  },
+  tooltip: {
+    color: '#fff',
+    padding: '0 12px'
+  }
+}));
+
+export interface Props {
+  createActions: () => Action[];
+  toggleOpenCallback?: () => void;
+  // we want to require using aria label for these buttons
+  // as they don't have text (just an icon)
+  ariaLabel: string;
+  className?: string;
+  disabled?: boolean;
+  // Displays inline next to the button icon
+  inlineLabel?: string;
+}
+
+type CombinedProps = Props;
+
+const ActionMenu: React.FC<CombinedProps> = props => {
+  const classes = useStyles();
+  const { createActions } = props;
+
+  const [actions, setActions] = React.useState<Action[]>([]);
+
+  React.useEffect(() => {
+    setActions(createActions());
+  }, [createActions]);
+
+  const { ariaLabel, inlineLabel } = props;
+
+  if (typeof actions === 'undefined') {
+    return null;
+  }
+
+  return (
+    <div className={classes.wrapper}>
+      <Menu>
+        <MenuButton className={classes.button} aria-label={ariaLabel}>
+          <MoreHoriz aria-hidden className={classes.icon} type="primary" />
+          {inlineLabel && <p className={classes.buttonLabel}>{inlineLabel}</p>}
+        </MenuButton>
+        <MenuPopover className={classes.popover} portal={false}>
+          <MenuItems className={classes.itemsOuter}>
+            {(actions as Action[]).map((a, idx) => (
+              <MenuLink
+                key={idx}
+                className={classNames({
+                  [classes.item]: true,
+                  [classes.disabled]: a.disabled
+                })}
+                onClick={a.onClick}
+                data-qa-action-menu-item={a.title}
+                disabled={a.disabled}
+              >
+                {a.title}
+                {a.tooltip && (
+                  <HelpIcon
+                    data-qa-tooltip-icon
+                    text={a.tooltip}
+                    tooltipPosition="right"
+                    className={classes.tooltip}
+                  />
+                )}
+              </MenuLink>
+            ))}
+          </MenuItems>
+        </MenuPopover>
+      </Menu>
+    </div>
+  );
+};
+
+export default ActionMenu;

--- a/packages/manager/src/components/ActionMenu_CMR/index.ts
+++ b/packages/manager/src/components/ActionMenu_CMR/index.ts
@@ -1,0 +1,9 @@
+import ActionMenu, { Action as _Action, Props } from './ActionMenu_CMR';
+
+/* tslint:disable-next-line */
+export interface ActionMenuProps extends Props {}
+
+/* tslint:disable-next-line */
+export interface Action extends _Action {}
+
+export default ActionMenu;


### PR DESCRIPTION
## Description

Updating the action menu to the new styling in addition to leveraging Reach's MenuButton component to make this fully accessible. This is best viewed in Storybook. 

Standard usage:
<img width="227" alt="Screen Shot 2020-06-08 at 4 36 37 PM" src="https://user-images.githubusercontent.com/2565527/84078068-45447100-a9a6-11ea-9041-0352865f3ccc.png">

With inline label:
<img width="242" alt="Screen Shot 2020-06-08 at 4 36 44 PM" src="https://user-images.githubusercontent.com/2565527/84078070-46759e00-a9a6-11ea-9138-1a331bb1b7b3.png">

Please note that mobile and the menu item's tooltip state have not been finalized. 

## Type of Change
- Non breaking change ('update')

