### PR TITLE
Patch Reach UI menu button

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "devDependencies": {
     "audit-ci": "^2.4.2",
     "husky": "^3.0.1",
+    "patch-package": "^6.1.0",
     "postinstall": "^0.6.0",
     "typescript": "~3.9.2",
     "wait-on": "^4.0.0"
@@ -20,7 +21,7 @@
     "cost-of-modules": "yarn global add cost-of-modules && cost-of-modules --less --no-install --include-dev",
     "install:all": "yarn install --frozen-lockfile",
     "upgrade:sdk": "yarn workspace @linode/api-v4 version --no-git-tag-version --no-commit-hooks && yarn workspace linode-manager upgrade @linode/api-v4",
-    "postinstall": "yarn workspaces run postinstall",
+    "postinstall": "yarn workspaces run postinstall && patch-package",
     "build:sdk": "yarn workspace @linode/api-v4 build",
     "build": "yarn build:sdk && yarn workspace linode-manager build",
     "build:analyze": "yarn build --bundle-analyze",

--- a/patches/@reach+menu-button+0.9.1.patch
+++ b/patches/@reach+menu-button+0.9.1.patch
@@ -1,0 +1,39 @@
+diff --git a/node_modules/@reach/menu-button/dist/menu-button.esm.js b/node_modules/@reach/menu-button/dist/menu-button.esm.js
+index 6526e01..60e6a0e 100644
+--- a/node_modules/@reach/menu-button/dist/menu-button.esm.js
++++ b/node_modules/@reach/menu-button/dist/menu-button.esm.js
+@@ -737,23 +737,19 @@ var MenuPopover = /*#__PURE__*/forwardRef(function MenuPopover(_ref8, forwardedR
+   var ref = useForkedRef(popoverRef, forwardedRef);
+   useEffect(function () {
+     function listener(event) {
+-      if (buttonClickedRef.current) {
+-        buttonClickedRef.current = false;
+-      } else {
+-        var relatedTarget = event.relatedTarget,
+-            target = event.target; // We on want to close only if focus rests outside the menu
++      var relatedTarget = event.relatedTarget,
++          target = event.target; // We on want to close only if focus rests outside the menu
+
+-        if (isOpen && popoverRef.current) {
+-          var _popoverRef$current;
++      if (isOpen && popoverRef.current) {
++        var _popoverRef$current;
+
+-          if (!((_popoverRef$current = popoverRef.current) === null || _popoverRef$current === void 0 ? void 0 : _popoverRef$current.contains(relatedTarget || target))) {
+-            dispatch({
+-              type: CLOSE_MENU,
+-              payload: {
+-                buttonRef: buttonRef
+-              }
+-            });
+-          }
++        if (!((_popoverRef$current = popoverRef.current) === null || _popoverRef$current === void 0 ? void 0 : _popoverRef$current.contains(relatedTarget || target))) {
++          dispatch({
++            type: CLOSE_MENU,
++            payload: {
++              buttonRef: buttonRef
++            }
++          });
+         }
+       }
+     }


### PR DESCRIPTION
## Description

⚠️  ~Wait until https://github.com/linode/manager/pull/6508 is merged to review this.~ done

There's a bug in the Reach UI Menu Button where _one_ menu doesn't always close when you click on _another_ menu. This leads to two menus being displayed at once.

![Screen Shot 2020-06-10 at 10 44 37 AM](https://user-images.githubusercontent.com/16911484/84318040-c84b0000-ab3b-11ea-8bcb-9e1d2f182e1e.png)

This has been reporting to the Reach UI maintainers [here](https://github.com/reach/reach-ui/issues/566) and apparently a fix is coming soon, but this applies a patch in the meantime. This patch essentially it removes [this branch](https://github.com/reach/reach-ui/blob/25840c3d15278e316cc74eaecf096fa01377f361/packages/menu-button/src/index.tsx#L858-L860).


## Note to Reviewers

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
