### PR TITLE
Support for OBJ Singapore

### DIFF
--- a/packages/api-v4/src/object-storage/types.ts
+++ b/packages/api-v4/src/object-storage/types.ts
@@ -49,7 +49,10 @@ export interface ObjectStorageObjectURLOptions {
 }
 
 // Enum containing IDs for each Cluster
-export type ObjectStorageClusterID = 'us-east-1' | 'eu-central-1';
+export type ObjectStorageClusterID =
+  | 'us-east-1'
+  | 'eu-central-1'
+  | 'ap-south-1';
 
 export interface ObjectStorageCluster {
   region: string;

--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -193,7 +193,8 @@ export const objectStorageClusterDisplay: Record<
   string
 > = {
   'us-east-1': 'Newark, NJ',
-  'eu-central-1': 'Frankfurt, DE'
+  'eu-central-1': 'Frankfurt, DE',
+  'ap-south-1': 'Singapore, SG'
 };
 
 export type ContinentKey = 'NA' | 'EU' | 'AS';


### PR DESCRIPTION
## Description

This adds support for OBJ Singapore. All we needed to do is update the display mapping; when `ap-south-1` is returned from `/object-storage/clusters`, a /bucket request to that region will be made. 

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

To test: 

- Mock `/object-storage/clusters` to include ap-south-1.
- Mock existing buckets to look like they're from ap-south-1.