### PR TITLE
Ignore ResizeObserver loop error

### DIFF
--- a/packages/manager/src/initSentry.ts
+++ b/packages/manager/src/initSentry.ts
@@ -67,7 +67,9 @@ export const initSentry = () => {
         // See http://toolbar.conduit.com/Developer/HtmlAndGadget/Methods/JSInjection.aspx
         'conduitPage',
         // Don't report client network errors.
-        'ChunkLoadError'
+        'ChunkLoadError',
+        // This is apparently a benign error: https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded
+        'ResizeObserver loop limit exceeded'
       ],
       whitelistUrls: [
         /** anything from either *.linode.com/* or localhost:3000 */


### PR DESCRIPTION
## Description

This ignores the "ResizeObserver loop limit reached" error we've been seeing. Apparently it is benign: https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded

Full disclosure: I was not able to reproduce this issue, and I'm not positive this will actually work to silence it.
