### PR TITLE
M3-4163: Hide unit price if none

### DIFF
--- a/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
+++ b/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
@@ -94,7 +94,7 @@ const RenderData: React.FC<{
                   {renderQuantity(quantity)}
                 </TableCell>
                 <TableCell parentColumn="Unit Price" data-qa-unit-price>
-                  {renderUnitPrice(unit_price)}
+                  {unit_price !== 'None' && renderUnitPrice(unit_price)}
                 </TableCell>
                 <TableCell parentColumn="Amount (USD)" data-qa-amount>
                   <Currency wrapInParentheses={amount < 0} quantity={amount} />


### PR DESCRIPTION
## Description
Hide unit price instead of having it show `$None` in the invoice table

## Type of Change
- Non breaking change ('update', 'change')