### PR TITLE
Fix regression for MuiChip and move it to appropriate CMR file

### DIFF
--- a/packages/manager/src/components/EntityHeader/EntityHeader.tsx
+++ b/packages/manager/src/components/EntityHeader/EntityHeader.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import Grid from 'src/components/Grid';
 import Paper from 'src/components/core/Paper';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import HeaderBreadCrumb, { BreadCrumbProps } from './HeaderBreadCrumb';
 
 export interface HeaderProps extends BreadCrumbProps {
@@ -9,8 +10,23 @@ export interface HeaderProps extends BreadCrumbProps {
   body: JSX.Element;
 }
 
+const useStyles = makeStyles((theme: Theme) => ({
+  chip: {
+    '& .MuiChip-root': {
+      height: 30,
+      borderRadius: 15,
+      marginTop: 1,
+      marginRight: 10,
+      fontSize: '.875rem',
+      letterSpacing: '.5px',
+      minWidth: 140
+    }
+  }
+}));
+
 export const EntityHeader: React.FC<HeaderProps> = props => {
   const { actions, body, iconType, parentLink, parentText, title } = props;
+  const classes = useStyles();
 
   return (
     <Paper>
@@ -23,7 +39,11 @@ export const EntityHeader: React.FC<HeaderProps> = props => {
               parentLink={parentLink}
               parentText={parentText}
             />
-            {body && <Grid item>{body}</Grid>}
+            {body && (
+              <Grid className={classes.chip} item>
+                {body}
+              </Grid>
+            )}
           </Grid>
         </Grid>
         <Grid item>{actions}</Grid>

--- a/packages/manager/src/components/EntityHeader/EntityHeader.tsx
+++ b/packages/manager/src/components/EntityHeader/EntityHeader.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import Grid from 'src/components/Grid';
 import Paper from 'src/components/core/Paper';
-import { makeStyles, Theme } from 'src/components/core/styles';
+import { makeStyles } from 'src/components/core/styles';
 import HeaderBreadCrumb, { BreadCrumbProps } from './HeaderBreadCrumb';
 
 export interface HeaderProps extends BreadCrumbProps {
@@ -10,7 +10,7 @@ export interface HeaderProps extends BreadCrumbProps {
   body: JSX.Element;
 }
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles(() => ({
   chip: {
     '& .MuiChip-root': {
       height: 30,

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -533,19 +533,17 @@ const themeDefaults: ThemeDefaults = ({ spacingOverride: spacingUnit }) => {
       MuiChip: {
         root: {
           backgroundColor: '#f4f4f4',
-          height: 30,
+          height: 20,
           display: 'inline-flex',
           alignItems: 'center',
-          borderRadius: 15,
-          marginTop: 1,
+          borderRadius: 4,
+          marginTop: 2,
           marginBottom: 2,
-          marginRight: 10,
+          marginRight: 4,
           paddingLeft: 2,
           paddingRight: 2,
           color: primaryColors.text,
-          fontSize: '.875rem',
-          letterSpacing: '.5px',
-          minWidth: 140,
+          fontSize: '.8rem',
           '&:last-child': {
             marginRight: 0
           },


### PR DESCRIPTION
I have a bad habit of editing the styles directly...this should keep the chip styles localized in CMR and prevent any regressions 