### PR TITLE
Convert ConfigSelect from class component to function component

### DIFF
--- a/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
@@ -103,7 +103,7 @@ const CreateVolumeForm: React.FC<CombinedProps> = props => {
     return state.__resources.linodeConfigs[linodeId] ?? { error: {} };
   });
 
-  const configErrorMessage = configsError?.read?.[0].reason
+  const configErrorMessage = configsError?.read
     ? 'Unable to load Configs for this Linode.' // More specific than the API error message
     : undefined;
 

--- a/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
@@ -252,16 +252,6 @@ const CreateVolumeForm: React.FC<CombinedProps> = props => {
                     disabled={disabled}
                   />
 
-                  <ConfigSelect
-                    error={touched.config_id ? errors.config_id : undefined}
-                    linodeId={linode_id}
-                    name="configId"
-                    onBlur={handleBlur}
-                    onChange={(id: number) => setFieldValue('config_id', id)}
-                    value={config_id}
-                    disabled={disabled}
-                  />
-
                   <RegionSelect
                     errorText={touched.region ? errors.region : undefined}
                     regions={props.regions
@@ -300,6 +290,16 @@ const CreateVolumeForm: React.FC<CombinedProps> = props => {
                     onChange={(id: number) => setFieldValue('linode_id', id)}
                     region={values.region}
                     shouldOnlyDisplayRegionsWithBlockStorage={true}
+                    disabled={disabled}
+                  />
+
+                  <ConfigSelect
+                    error={touched.config_id ? errors.config_id : undefined}
+                    linodeId={linode_id}
+                    name="configId"
+                    onBlur={handleBlur}
+                    onChange={(id: number) => setFieldValue('config_id', id)}
+                    value={config_id}
                     disabled={disabled}
                   />
 

--- a/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
@@ -160,12 +160,7 @@ const CreateVolumeForm: React.FC<CombinedProps> = props => {
 
         const { region, linode_id, tags, config_id } = values;
 
-        const linodeError =
-          config_id === -9999
-            ? 'This Linode has no valid configurations.'
-            : touched.linode_id
-            ? errors.linode_id
-            : undefined;
+        const linodeError = touched.linode_id ? errors.linode_id : undefined;
 
         const generalError = status
           ? status.generalError
@@ -328,7 +323,7 @@ const CreateVolumeForm: React.FC<CombinedProps> = props => {
                   heading={`${values.label || 'Volume'} Summary`}
                   onDeploy={handleSubmit}
                   calculatedPrice={values.size / 10}
-                  disabled={values.config_id === -9999 || disabled}
+                  disabled={disabled}
                   isMakingRequest={isSubmitting}
                 >
                   <DisplaySectionList displaySections={displaySections} />

--- a/packages/manager/src/features/Volumes/VolumeCreate/VolumeCreate.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate/VolumeCreate.tsx
@@ -116,7 +116,7 @@ const mapStateToProps: MapState<StateProps, {}> = state => {
 
   return {
     regions: state.__resources.regions.entities,
-    linodeId,
+    linode_id: linodeId,
     linodeLabel,
     linodeRegion,
     mode,

--- a/packages/manager/src/features/Volumes/VolumeDrawer/ConfigSelect.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/ConfigSelect.tsx
@@ -27,15 +27,24 @@ const ConfigSelect: React.FC<CombinedProps> = props => {
   const configs = Object.values(itemsById ?? {});
   const dispatch = useDispatch();
 
+  const configList = configs.map(config => {
+    return { label: config.label, value: config.id };
+  });
+
   React.useEffect(() => {
     if (lastUpdated === 0 || lastUpdated === undefined) {
       dispatch(getAllLinodeConfigs({ linodeId }));
     }
   }, [linodeId, lastUpdated, dispatch]);
 
-  const configList = configs.map(config => {
-    return { label: config.label, value: config.id };
-  });
+  React.useEffect(() => {
+    if (configList.length === 1) {
+      const newValue = configList[0].value;
+      if (value !== newValue) {
+        onChange(configList[0].value);
+      }
+    }
+  }, [configList, onChange, value]);
 
   if (configs.length < 1) {
     return null;

--- a/packages/manager/src/features/Volumes/VolumeDrawer/ConfigSelect.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/ConfigSelect.tsx
@@ -1,7 +1,9 @@
-import { getLinodeConfigs } from '@linode/api-v4/lib/linodes';
 import * as React from 'react';
 import FormControl from 'src/components/core/FormControl';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
+import { ApplicationState } from 'src/store';
+import { getAllLinodeConfigs } from 'src/store/linodes/config/config.requests';
+import { useSelector, useDispatch } from 'react-redux';
 
 interface Props {
   error?: string;
@@ -13,105 +15,37 @@ interface Props {
   disabled?: boolean;
 }
 
-type ConfigTuple = [number, string];
-interface State {
-  configs: ConfigTuple[];
-}
-
 type CombinedProps = Props;
 
-class ConfigSelect extends React.Component<CombinedProps, State> {
-  state: State = {
-    configs: []
-  };
+const ConfigSelect: React.FC<CombinedProps> = props => {
+  const { error, onChange, onBlur, linodeId, name, value, ...rest } = props;
 
-  setInitialState = () => {
-    /**
-     * Configs is [configId, configLabel][].
-     * We select the first config's ID and call onChange to automatically select the first config
-     */
-    const { onChange } = this.props;
-    const [firstConfig] = this.state.configs;
+  const { lastUpdated, itemsById } = useSelector((state: ApplicationState) => {
+    return state.__resources.linodeConfigs[linodeId] ?? {};
+  });
 
-    if (firstConfig) {
-      const [id] = firstConfig;
-      return onChange(id);
+  const configs = Object.values(itemsById ?? {});
+  const dispatch = useDispatch();
+
+  React.useEffect(() => {
+    if (lastUpdated === 0) {
+      dispatch(() => getAllLinodeConfigs({ linodeId }));
     }
+  }, [linodeId, lastUpdated, dispatch]);
 
-    /**
-     * We are unable to setup the initial state because there are no configs. We're setting the
-     * config Id to something unrealistic so we can key off that for validation.
-     */
-    onChange(-9999);
-  };
+  const configList = configs.map(config => {
+    return { label: config.label, value: config.id };
+  });
 
-  updateConfigs(linodeId: number) {
-    const { onChange } = this.props;
-
-    /**
-     * If we have a 'none' value, we dont need to make the request.
-     */
-    if (linodeId === -1) {
-      this.setState({ configs: [] });
-      return onChange(-1);
-    }
-
-    getLinodeConfigs(linodeId)
-      .then(({ data }) => {
-        this.setState(
-          {
-            configs: data.map(
-              config => [config.id, config.label] as ConfigTuple
-            )
-          },
-          () => {
-            this.setInitialState();
-          }
-        );
-      })
-      .catch(() => {
-        /*
-         * @note: If we can't get configs for the Linode, then the user can
-         * still create the volume, so we probably shouldn't show any error
-         * state if this fails.
-         */
-      });
-  }
-
-  componentDidMount() {
-    this.updateConfigs(this.props.linodeId);
-  }
-
-  componentDidUpdate(prevProps: CombinedProps) {
-    const { linodeId } = this.props;
-    /**
-     * If we have a new Linode Id we need to get the configs for said linode.
-     */
-    if (linodeId !== prevProps.linodeId) {
-      this.updateConfigs(Number(linodeId));
-    }
-  }
-
-  render() {
-    const { error, onChange, name, onBlur, value, ...rest } = this.props;
-    const { configs } = this.state;
-
-    if (configs.length < 1) {
-      return null;
-    }
-
-    const configList =
-      configs &&
-      configs.map(([v, label]) => {
-        return { label, value: v };
-      });
-
+  if (configs.length < 1) {
+    return null;
+  } else {
     return (
       <FormControl fullWidth>
         <Select
           options={configList}
           name={name}
-          defaultValue={configList[0]}
+          value={configList.find(thisConfig => thisConfig.value === value)}
           onChange={(e: Item) => {
             onChange(+e.value);
           }}
@@ -127,6 +61,6 @@ class ConfigSelect extends React.Component<CombinedProps, State> {
       </FormControl>
     );
   }
-}
+};
 
-export default ConfigSelect;
+export default React.memo(ConfigSelect);

--- a/packages/manager/src/features/Volumes/VolumeDrawer/ConfigSelect.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/ConfigSelect.tsx
@@ -17,14 +17,19 @@ interface Props {
 
 type CombinedProps = Props;
 
+export const initialValueDefaultId = -1;
+
 const ConfigSelect: React.FC<CombinedProps> = props => {
   const { error, onChange, onBlur, linodeId, name, value, ...rest } = props;
 
-  const { lastUpdated, itemsById } = useSelector((state: ApplicationState) => {
-    return state.__resources.linodeConfigs[linodeId] ?? {};
-  });
+  const { lastUpdated, error: configsError, loading, itemsById } = useSelector(
+    (state: ApplicationState) => {
+      return state.__resources.linodeConfigs[linodeId] ?? { error: {} };
+    }
+  );
 
   const configs = Object.values(itemsById ?? {});
+
   const dispatch = useDispatch();
 
   const configList = configs.map(config => {
@@ -32,10 +37,18 @@ const ConfigSelect: React.FC<CombinedProps> = props => {
   });
 
   React.useEffect(() => {
-    if (lastUpdated === 0 || lastUpdated === undefined) {
+    if (linodeId === initialValueDefaultId) {
+      return;
+    }
+
+    if (configsError?.read) {
+      return;
+    }
+
+    if (!loading && !lastUpdated) {
       dispatch(getAllLinodeConfigs({ linodeId }));
     }
-  }, [linodeId, lastUpdated, dispatch]);
+  }, [linodeId, lastUpdated, dispatch, loading, configsError]);
 
   React.useEffect(() => {
     if (configList.length === 1) {

--- a/packages/manager/src/features/Volumes/VolumeDrawer/ConfigSelect.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/ConfigSelect.tsx
@@ -28,8 +28,8 @@ const ConfigSelect: React.FC<CombinedProps> = props => {
   const dispatch = useDispatch();
 
   React.useEffect(() => {
-    if (lastUpdated === 0) {
-      dispatch(() => getAllLinodeConfigs({ linodeId }));
+    if (lastUpdated === 0 || lastUpdated === undefined) {
+      dispatch(getAllLinodeConfigs({ linodeId }));
     }
   }, [linodeId, lastUpdated, dispatch]);
 


### PR DESCRIPTION
## Description
Converted ConfigSelect from a class component to a function component.

In addition to the standard changes for class => function component conversions, this PR also retrieves configs from state to save an API request from being made.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers
Please ensure that creating and attaching volumes still work as they should.

I am planning on creating a test for this in a follow-up PR.