### PR TITLE
[WIP] [WAIT] [bug] make sure we're using bits everywhere for longview network units

### DIFF
--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/Network.test.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/Network.test.tsx
@@ -75,7 +75,7 @@ describe('Longview Network Gauge UI', () => {
       {}
     );
 
-    expect(innerText).toHaveTextContent('4 Mibit/s');
+    expect(innerText).toHaveTextContent('4 Mbit/s');
     expect(subtext).toHaveTextContent('Network');
   });
 });

--- a/packages/manager/src/features/Longview/shared/utilities.test.ts
+++ b/packages/manager/src/features/Longview/shared/utilities.test.ts
@@ -76,9 +76,9 @@ describe('Utility Functions', () => {
     it('should generate the correct units and values', () => {
       const oneKilobit = 1000;
       const oneMegabit = 1000000;
-      expect(generateNetworkUnits(oneKilobit)).toEqual('Kibit');
-      expect(generateNetworkUnits(oneMegabit)).toEqual('Mibit');
-      expect(generateNetworkUnits(100)).toEqual('b');
+      expect(generateNetworkUnits(oneKilobit)).toEqual('Kbit');
+      expect(generateNetworkUnits(oneMegabit)).toEqual('Mbit');
+      expect(generateNetworkUnits(100)).toEqual('bit');
     });
   });
 
@@ -365,9 +365,9 @@ describe('Utility Functions', () => {
   });
   describe('formatBitsPerSecond', () => {
     it('adds unit', () => {
-      expect(formatBitsPerSecond(12)).toBe('12 b/s');
-      expect(formatBitsPerSecond(0)).toBe('0 b/s');
-      expect(formatBitsPerSecond(123456789)).toBe('117.74 Mibit/s');
+      expect(formatBitsPerSecond(12)).toBe('12 bit/s');
+      expect(formatBitsPerSecond(0)).toBe('0 bit/s');
+      expect(formatBitsPerSecond(123456789)).toBe('117.74 Mbit/s');
     });
   });
 });

--- a/packages/manager/src/features/Longview/shared/utilities.ts
+++ b/packages/manager/src/features/Longview/shared/utilities.ts
@@ -320,11 +320,11 @@ export const generateNetworkUnits = (
   /** Thanks to http://www.matisse.net/bitcalc/ */
   const networkUsedToKilobits = (networkUsedInBytes * 8) / 1024;
   if (networkUsedToKilobits <= 1) {
-    return 'b';
+    return 'bit';
   } else if (networkUsedToKilobits <= 1000) {
-    return 'Kibit';
+    return 'Kbit';
   } else {
-    return 'Mibit';
+    return 'Mbit';
   }
 };
 
@@ -332,16 +332,16 @@ export const convertNetworkToUnit = (
   valueInBits: number,
   maxUnit: NetworkUnit
 ) => {
-  if (maxUnit === 'Mibit') {
+  if (maxUnit === 'Mbit') {
     // If the unit we're using for the graph is Mb, return the output in Mb.
     const valueInMegabits = valueInBits / 1024 / 1024;
     return valueInMegabits;
-  } else if (maxUnit === 'Kibit') {
+  } else if (maxUnit === 'Kbit') {
     // If the unit we're using for the graph is Kb, return the output in Kb.
     const valueInKilobits = valueInBits / 1024;
     return valueInKilobits;
   } else {
-    // Unit is 'b' so just return the unformatted value, rounded to the nearest bit.
+    // Unit is 'bit' so just return the unformatted value, rounded to the nearest bit.
     return Math.round(valueInBits);
   }
 };


### PR DESCRIPTION
## Description

This updates Longview code to use bits for network units in all places. I also expanded the label for "bit" from "b" to "bit" to match the other units.

## Type of Change
- Bug fix