### PR TITLE
M3-2020 Change: Add Formik to LinodeDiskDrawer

### DIFF
--- a/packages/api-v4/src/linodes/linodes.schema.ts
+++ b/packages/api-v4/src/linodes/linodes.schema.ts
@@ -252,7 +252,10 @@ export const UpdateLinodeDiskSchema = object({
   label: string()
     .notRequired()
     .min(1, 'Label must be between 1 and 48 characters.')
-    .max(48, 'Label must be between 1 and 48 characters.')
+    .max(48, 'Label must be between 1 and 48 characters.'),
+  filesystem: mixed()
+    .notRequired()
+    .oneOf(['raw', 'swap', 'ext3', 'ext4', 'initrd'])
 });
 
 export const CreateLinodeDiskFromImageSchema = CreateLinodeDiskSchema.clone().shape(

--- a/packages/api-v4/src/linodes/linodes.schema.ts
+++ b/packages/api-v4/src/linodes/linodes.schema.ts
@@ -33,7 +33,7 @@ const rootPasswordValidation = string()
 
 export const ResizeLinodeDiskSchema = object({
   size: number()
-    .required()
+    .required('Size is required.')
     .min(1)
 });
 

--- a/packages/api-v4/src/linodes/linodes.schema.ts
+++ b/packages/api-v4/src/linodes/linodes.schema.ts
@@ -247,3 +247,16 @@ export const CreateLinodeDiskSchema = object({
   stackscript_id: number(),
   stackscript_data
 });
+
+export const UpdateLinodeDiskSchema = object({
+  label: string()
+    .notRequired()
+    .min(1, 'Label must be between 1 and 48 characters.')
+    .max(48, 'Label must be between 1 and 48 characters.')
+});
+
+export const CreateLinodeDiskFromImageSchema = CreateLinodeDiskSchema.clone().shape(
+  {
+    image: string().required('An image is required.')
+  }
+);

--- a/packages/manager/src/components/AccessPanel/AccessPanel.tsx
+++ b/packages/manager/src/components/AccessPanel/AccessPanel.tsx
@@ -132,6 +132,7 @@ class AccessPanel extends React.Component<CombinedProps> {
           {error && <Notice text={error} error />}
           <React.Suspense fallback={<SuspenseLoader />}>
             <PasswordInput
+              name="password"
               data-qa-password-input
               className={classes.passwordInputOuter}
               required={required}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.test.tsx
@@ -1,53 +1,70 @@
-import { cleanup } from '@testing-library/react';
+import { cleanup, fireEvent, render, wait } from '@testing-library/react';
 import * as React from 'react';
-import { renderWithTheme } from 'src/utilities/testHelpers';
+import { wrapWithTheme } from 'src/utilities/testHelpers';
 
-import LinodeDiskDrawer, { modes } from './LinodeDiskDrawer';
+import LinodeDiskDrawer from './LinodeDiskDrawer';
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  jest.clearAllMocks();
+});
 
 const props = {
   mode: 'create' as any,
-  selectedMode: modes.EMPTY,
   maximumSize: 100,
   open: true,
-  submitting: false,
   onClose: jest.fn(),
-  onSubmit: jest.fn(),
-  onLabelChange: jest.fn(),
-  onImageChange: jest.fn(),
-  onFilesystemChange: jest.fn(),
-  onSizeChange: jest.fn(),
-  onPasswordChange: jest.fn(),
-  onResetImageMode: jest.fn(),
-  label: 'This drawer',
-  filesystem: 'ext4',
-  size: 50
+  onSubmit: jest.fn().mockResolvedValue({})
 };
 
-const component = renderWithTheme(<LinodeDiskDrawer {...props} />);
+const EMPTY_DISK_RADIO_LABEL = new RegExp('create empty disk', 'i');
+const DISK_FROM_IMAGE_RADIO_LABEL = new RegExp('create from image', 'i');
 
-describe.skip('Component', () => {
-  it('should render', () => {
-    expect(component).toBeDefined();
+describe('Component', () => {
+  it('should render a title based on the mode', () => {
+    const { getByText, rerender } = render(
+      wrapWithTheme(<LinodeDiskDrawer {...props} />)
+    );
+    // Create mode
+    getByText('Add Disk');
+    // Rename
+    rerender(wrapWithTheme(<LinodeDiskDrawer {...props} mode={'rename'} />));
+    getByText('Rename Disk');
+    // Resize
+    rerender(wrapWithTheme(<LinodeDiskDrawer {...props} mode={'resize'} />));
+    getByText('Resize Disk');
   });
   it('should display the mode toggle when creating', () => {
-    // expect(component.find('[data-qa-mode-toggle]')).toHaveLength(1);
+    const { getByText } = render(
+      wrapWithTheme(<LinodeDiskDrawer {...props} />)
+    );
+    getByText(EMPTY_DISK_RADIO_LABEL);
+    getByText(DISK_FROM_IMAGE_RADIO_LABEL);
   });
   it('should not display the mode toggle when resizing', () => {
-    // component.setProps({ mode: 'resize' as any });
-    // expect(component.find('[data-qa-mode-toggle]')).toHaveLength(0);
+    const { queryByText } = render(
+      wrapWithTheme(<LinodeDiskDrawer {...props} mode="resize" />)
+    );
+    expect(queryByText(EMPTY_DISK_RADIO_LABEL)).toBeNull();
   });
   it('should not display the mode toggle when renaming', () => {
-    // component.setProps({ mode: 'rename' as any });
-    // expect(component.find('[data-qa-mode-toggle]')).toHaveLength(0);
+    const { queryByText } = render(
+      wrapWithTheme(<LinodeDiskDrawer {...props} mode="rename" />)
+    );
+    expect(queryByText(EMPTY_DISK_RADIO_LABEL)).toBeNull();
   });
-  it('should call the submit handler when Submit is clicked', () => {
-    // component.find('[data-qa-disk-submit]').simulate('click');
-    // expect(props.onSubmit).toHaveBeenCalledTimes(1);
+  it('should call the submit handler when Submit is clicked', async () => {
+    const { getByTestId } = render(
+      wrapWithTheme(<LinodeDiskDrawer {...props} mode="rename" />)
+    );
+    await wait(() => fireEvent.click(getByTestId('submit-disk-form')));
+    expect(props.onSubmit).toHaveBeenCalledTimes(1);
   });
-  it('should call the cancel handler when Cancel is clicked', () => {
-    // component.find('[data-qa-disk-cancel]').simulate('click');
-    // expect(props.onClose).toHaveBeenCalledTimes(1);
+  it('should call the cancel handler when Cancel is clicked', async () => {
+    const { getByText } = render(
+      wrapWithTheme(<LinodeDiskDrawer {...props} mode="resize" />)
+    );
+    await wait(() => fireEvent.click(getByText(/cancel/i)));
+    expect(props.onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.test.tsx
@@ -2,7 +2,7 @@ import { cleanup } from '@testing-library/react';
 import * as React from 'react';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
-import { LinodeDiskDrawer, modes } from './LinodeDiskDrawer';
+import LinodeDiskDrawer, { modes } from './LinodeDiskDrawer';
 
 afterEach(cleanup);
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.test.tsx
@@ -1,15 +1,19 @@
 import { cleanup, fireEvent, render, wait } from '@testing-library/react';
 import * as React from 'react';
+import { diskFactory } from 'src/factories/disk';
 import { wrapWithTheme } from 'src/utilities/testHelpers';
 
-import LinodeDiskDrawer from './LinodeDiskDrawer';
+import LinodeDiskDrawer, { Props } from './LinodeDiskDrawer';
+
+const disk = diskFactory.build();
 
 afterEach(() => {
   cleanup();
   jest.clearAllMocks();
 });
 
-const props = {
+const props: Props = {
+  disk,
   mode: 'create' as any,
   maximumSize: 100,
   open: true,

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.test.tsx
@@ -1,15 +1,12 @@
-import { shallow } from 'enzyme';
+import { cleanup } from '@testing-library/react';
 import * as React from 'react';
+import { renderWithTheme } from 'src/utilities/testHelpers';
 
 import { LinodeDiskDrawer, modes } from './LinodeDiskDrawer';
 
-const classes = {
-  root: '',
-  section: '',
-  divider: ''
-};
+afterEach(cleanup);
+
 const props = {
-  classes,
   mode: 'create' as any,
   selectedMode: modes.EMPTY,
   maximumSize: 100,
@@ -28,29 +25,29 @@ const props = {
   size: 50
 };
 
-const component = shallow(<LinodeDiskDrawer {...props} />);
+const component = renderWithTheme(<LinodeDiskDrawer {...props} />);
 
-describe('Component', () => {
+describe.skip('Component', () => {
   it('should render', () => {
     expect(component).toBeDefined();
   });
   it('should display the mode toggle when creating', () => {
-    expect(component.find('[data-qa-mode-toggle]')).toHaveLength(1);
+    // expect(component.find('[data-qa-mode-toggle]')).toHaveLength(1);
   });
   it('should not display the mode toggle when resizing', () => {
-    component.setProps({ mode: 'resize' as any });
-    expect(component.find('[data-qa-mode-toggle]')).toHaveLength(0);
+    // component.setProps({ mode: 'resize' as any });
+    // expect(component.find('[data-qa-mode-toggle]')).toHaveLength(0);
   });
   it('should not display the mode toggle when renaming', () => {
-    component.setProps({ mode: 'rename' as any });
-    expect(component.find('[data-qa-mode-toggle]')).toHaveLength(0);
+    // component.setProps({ mode: 'rename' as any });
+    // expect(component.find('[data-qa-mode-toggle]')).toHaveLength(0);
   });
   it('should call the submit handler when Submit is clicked', () => {
-    component.find('[data-qa-disk-submit]').simulate('click');
-    expect(props.onSubmit).toHaveBeenCalledTimes(1);
+    // component.find('[data-qa-disk-submit]').simulate('click');
+    // expect(props.onSubmit).toHaveBeenCalledTimes(1);
   });
   it('should call the cancel handler when Cancel is clicked', () => {
-    component.find('[data-qa-disk-cancel]').simulate('click');
-    expect(props.onClose).toHaveBeenCalledTimes(1);
+    // component.find('[data-qa-disk-cancel]').simulate('click');
+    // expect(props.onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.tsx
@@ -240,7 +240,7 @@ export const DiskDrawer: React.FC<CombinedProps> = props => {
             {selectedMode === modes.IMAGE && (
               <ImageAndPassword
                 onImageChange={(selected: Item) =>
-                  formik.setFieldValue('image', selected.value)
+                  formik.setFieldValue('image', selected?.value ?? null)
                 }
                 imageFieldError={
                   formik.touched.image ? formik.errors.image : undefined

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.tsx
@@ -52,7 +52,7 @@ type FileSystem = 'raw' | 'swap' | 'ext3' | 'ext4' | 'initrd' | '_none_';
 
 type DrawerMode = 'create' | 'rename' | 'resize';
 
-interface Props {
+export interface Props {
   mode: DrawerMode;
   disk?: Disk;
   open: boolean;

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.tsx
@@ -122,10 +122,6 @@ export const DiskDrawer: React.FC<CombinedProps> = props => {
     formik.setStatus(undefined);
     formik.setErrors({});
 
-    if (values.label === '') {
-      values.label = undefined;
-    }
-
     onSubmit(values)
       .then(() => {
         formik.setSubmitting(false);
@@ -242,7 +238,7 @@ export const DiskDrawer: React.FC<CombinedProps> = props => {
               onClick={() => formik.handleSubmit()}
               buttonType="primary"
               loading={formik.isSubmitting}
-              data-qa-disk-submit
+              data-testid="submit-disk-form"
             >
               {submitLabelMap[mode]}
             </Button>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.tsx
@@ -126,15 +126,6 @@ export const LinodeDiskDrawer: React.FC<CombinedProps> = props => {
   //   };
   // }
 
-  // const onLabelChange = (e: React.ChangeEvent<HTMLInputElement>) =>
-  //   props.onLabelChange(e.target.value);
-
-  // const onSizeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-  //   const { valueAsNumber } = e.target;
-  //   if (isNaN(valueAsNumber)) {
-  //     return props.onSizeChange('');
-  //   }
-
   //   props.onSizeChange(valueAsNumber);
   // };
 
@@ -146,9 +137,6 @@ export const LinodeDiskDrawer: React.FC<CombinedProps> = props => {
   //   props.onResetImageMode(); // Reset image and root_pass
   // };
 
-  // const onImageChange = (selected: Item<string>) => {
-  //   props.onImageChange(selected ? selected.value : undefined);
-  // };
   const generalError = ''; // this.getErrors('none');
 
   return (
@@ -207,17 +195,21 @@ export const LinodeDiskDrawer: React.FC<CombinedProps> = props => {
                 ))}
               </TextField>
             )}
-            {/* {selectedMode === modes.IMAGE && (
+            {selectedMode === modes.IMAGE && (
               <ImageAndPassword
-                onImageChange={(selected: Item) => formik.handleChange('image')}
-                imageFieldError={imageFieldError}
+                onImageChange={(selected: Item) =>
+                  formik.setFieldValue('image', selected.value)
+                }
+                imageFieldError={formik.errors.image?.[0]}
                 password={formik.values.password}
-                passwordError={passwordError}
-                onPasswordChange={() => null}
+                passwordError={formik.errors.password?.[0]}
+                onPasswordChange={(password: string) =>
+                  formik.setFieldValue('password', password)
+                }
                 userSSHKeys={userSSHKeys || []}
                 requestKeys={requestKeys || (() => null)}
               />
-            )} */}
+            )}
             <TextField
               disabled={['rename'].includes(props.mode)}
               label="Size"

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.tsx
@@ -2,8 +2,7 @@ import {
   Disk,
   CreateLinodeDiskSchema,
   CreateLinodeDiskFromImageSchema,
-  ResizeLinodeDiskSchema,
-  UpdateLinodeDiskSchema
+  ResizeLinodeDiskSchema
 } from '@linode/api-v4/lib/linodes';
 import { useFormik } from 'formik';
 import * as React from 'react';
@@ -24,6 +23,7 @@ import {
   handleFieldErrors,
   handleGeneralErrors
 } from 'src/utilities/formikErrorUtils';
+import { object, string } from 'yup';
 
 import ImageAndPassword from '../LinodeSettings/ImageAndPassword';
 
@@ -35,6 +35,18 @@ const useStyles = makeStyles((theme: Theme) => ({
     width: `calc(100% - ${theme.spacing(2)}px)`
   }
 }));
+
+/**
+ * This is a situation-specific schemas that doesn't correspond to
+ * an API endpoint, which is why it lives here and not in api-v4.
+ *
+ */
+const RenameDiskSchema = object({
+  label: string()
+    .required('Label is required.')
+    .min(3, 'Label must contain between 3 and 32 characters.')
+    .max(32, 'Label must contain between 3 and 32 characters.')
+});
 
 type FileSystem = 'raw' | 'swap' | 'ext3' | 'ext4' | 'initrd' | '_none_';
 
@@ -98,7 +110,7 @@ const getSchema = (mode: DrawerMode, diskMode: diskMode) => {
         ? CreateLinodeDiskFromImageSchema
         : CreateLinodeDiskSchema;
     case 'rename':
-      return UpdateLinodeDiskSchema;
+      return RenameDiskSchema;
     case 'resize':
       return ResizeLinodeDiskSchema;
   }

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.tsx
@@ -1,4 +1,5 @@
 import { APIError } from '@linode/api-v4/lib/types';
+import { useFormik } from 'formik';
 import * as React from 'react';
 import { UserSSHKeyObject } from 'src/components/AccessPanel';
 import ActionsPanel from 'src/components/ActionsPanel';
@@ -25,11 +26,13 @@ const useStyles = makeStyles((theme: Theme) => ({
   }
 }));
 
+type FileSystem = 'raw' | 'swap' | 'ext3' | 'ext4' | 'initrd' | '_none_';
+
 interface EditableFields {
-  label: string;
-  filesystem: string;
-  size: number;
-  password?: string;
+  // label: string;
+  // filesystem: string;
+  // size: number;
+  // password?: string;
   passwordError?: string;
   userSSHKeys?: UserSSHKeyObject[];
   requestKeys?: () => void;
@@ -42,13 +45,13 @@ interface Props extends EditableFields {
   maximumSize: number;
   submitting: boolean;
   onClose: () => void;
-  onSubmit: () => void;
-  onLabelChange: (value: string) => void;
-  onFilesystemChange: (value: string) => void;
-  onSizeChange: (value: number | string) => void;
-  onImageChange: (selected: string | undefined) => void;
-  onPasswordChange: (password: string) => void;
-  onResetImageMode: () => void;
+  onSubmit: (values: any) => void;
+  // onLabelChange: (value: string) => void;
+  // onFilesystemChange: (value: string) => void;
+  // onSizeChange: (value: number | string) => void;
+  // onImageChange: (selected: string | undefined) => void;
+  // onPasswordChange: (password: string) => void;
+  // onResetImageMode: () => void;
 }
 
 type CombinedProps = Props;
@@ -91,9 +94,20 @@ const getTitle = (v: 'create' | 'rename' | 'resize') => {
 };
 
 export const LinodeDiskDrawer: React.FC<CombinedProps> = props => {
-  const { open, mode, submitting, password, userSSHKeys, requestKeys } = props;
+  const { open, mode, submitting, onSubmit, userSSHKeys, requestKeys } = props;
 
   const classes = useStyles();
+
+  const formik = useFormik({
+    initialValues: {
+      label: '',
+      filesystem: '_none_' as FileSystem,
+      size: 0,
+      image: '',
+      password: ''
+    },
+    onSubmit
+  });
 
   const [selectedMode, setSelectedMode] = React.useState<string>(modes.EMPTY);
 
@@ -112,91 +126,30 @@ export const LinodeDiskDrawer: React.FC<CombinedProps> = props => {
   //   };
   // }
 
-  const onLabelChange = (e: React.ChangeEvent<HTMLInputElement>) =>
-    props.onLabelChange(e.target.value);
+  // const onLabelChange = (e: React.ChangeEvent<HTMLInputElement>) =>
+  //   props.onLabelChange(e.target.value);
 
-  const onSizeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { valueAsNumber } = e.target;
-    if (isNaN(valueAsNumber)) {
-      return props.onSizeChange('');
-    }
+  // const onSizeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  //   const { valueAsNumber } = e.target;
+  //   if (isNaN(valueAsNumber)) {
+  //     return props.onSizeChange('');
+  //   }
 
-    props.onSizeChange(valueAsNumber);
-  };
+  //   props.onSizeChange(valueAsNumber);
+  // };
 
-  const onFilesystemChange = (e: React.ChangeEvent<HTMLInputElement>) =>
-    props.onFilesystemChange(e.target.value);
+  // const onFilesystemChange = (e: React.ChangeEvent<HTMLInputElement>) =>
+  //   props.onFilesystemChange(e.target.value);
 
-  const onModeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setSelectedMode(e.target.value as diskMode);
-    props.onResetImageMode(); // Reset image and root_pass
-  };
+  // const onModeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  //   setSelectedMode(e.target.value as diskMode);
+  //   props.onResetImageMode(); // Reset image and root_pass
+  // };
 
-  const onImageChange = (selected: Item<string>) => {
-    props.onImageChange(selected ? selected.value : undefined);
-  };
-
-  const getErrors = (key: string) => '';
-
-  const labelField = () => (
-    <TextField
-      disabled={['resize'].includes(props.mode)}
-      label="Label"
-      required
-      value={props.label}
-      onChange={onLabelChange}
-      errorText={getErrors('label')}
-      errorGroup="linode-disk-drawer"
-      data-qa-label
-    />
-  );
-
-  const filesystemField = () => (
-    <TextField
-      disabled={['resize', 'rename'].includes(props.mode)}
-      label="Filesystem"
-      select
-      value={props.filesystem}
-      onChange={onFilesystemChange}
-      errorText={getErrors('filesystem')}
-      errorGroup="linode-disk-drawer"
-    >
-      <MenuItem value="_none_">
-        <em>Select a Filesystem</em>
-      </MenuItem>
-      {['raw', 'swap', 'ext3', 'ext4', 'initrd'].map(fs => (
-        <MenuItem value={fs} key={fs}>
-          {fs}
-        </MenuItem>
-      ))}
-    </TextField>
-  );
-
-  const sizeField = () => (
-    <React.Fragment>
-      <TextField
-        disabled={['rename'].includes(props.mode)}
-        label="Size"
-        type="number"
-        required
-        value={props.size}
-        onChange={onSizeChange}
-        errorText={getErrors('size')}
-        errorGroup="linode-disk-drawer"
-        InputProps={{
-          endAdornment: <InputAdornment position="end">MB</InputAdornment>
-        }}
-        data-qa-disk-size
-      />
-      <FormHelperText style={{ marginTop: 8 }}>
-        Maximum Size: {props.maximumSize} MB
-      </FormHelperText>
-    </React.Fragment>
-  );
-
+  // const onImageChange = (selected: Item<string>) => {
+  //   props.onImageChange(selected ? selected.value : undefined);
+  // };
   const generalError = ''; // this.getErrors('none');
-  const passwordError = ''; // this.getErrors('root_pass');
-  const imageFieldError = ''; // this.getErrors('image');
 
   return (
     <Drawer title={getTitle(mode)} open={open} onClose={props.onClose}>
@@ -206,7 +159,7 @@ export const LinodeDiskDrawer: React.FC<CombinedProps> = props => {
             <ModeSelect
               modes={modeList}
               selected={selectedMode}
-              onChange={onModeChange}
+              onChange={e => setSelectedMode(e.target.value)}
             />
           </Grid>
         )}
@@ -222,26 +175,73 @@ export const LinodeDiskDrawer: React.FC<CombinedProps> = props => {
         </Grid>
         <Grid item xs={12} className={classes.section}>
           <form>
-            {labelField()}
-            {selectedMode === modes.EMPTY && filesystemField()}
-            {selectedMode === modes.IMAGE && (
+            <TextField
+              disabled={['resize'].includes(props.mode)}
+              label="Label"
+              name="label"
+              required
+              value={formik.values.label}
+              onChange={formik.handleChange}
+              errorText={formik.errors.label?.[0]}
+              errorGroup="linode-disk-drawer"
+              data-qa-label
+            />
+            {selectedMode === modes.EMPTY && (
+              <TextField
+                disabled={['resize', 'rename'].includes(props.mode)}
+                label="Filesystem"
+                name="filesystem"
+                select
+                value={formik.values.filesystem}
+                onChange={formik.handleChange}
+                errorText={formik.errors.filesystem?.[0]}
+                errorGroup="linode-disk-drawer"
+              >
+                <MenuItem value="_none_">
+                  <em>Select a Filesystem</em>
+                </MenuItem>
+                {['raw', 'swap', 'ext3', 'ext4', 'initrd'].map(fs => (
+                  <MenuItem value={fs} key={fs}>
+                    {fs}
+                  </MenuItem>
+                ))}
+              </TextField>
+            )}
+            {/* {selectedMode === modes.IMAGE && (
               <ImageAndPassword
-                onImageChange={onImageChange}
+                onImageChange={(selected: Item) => formik.handleChange('image')}
                 imageFieldError={imageFieldError}
-                password={password || ''}
+                password={formik.values.password}
                 passwordError={passwordError}
-                onPasswordChange={props.onPasswordChange}
+                onPasswordChange={() => null}
                 userSSHKeys={userSSHKeys || []}
                 requestKeys={requestKeys || (() => null)}
               />
-            )}
-            {sizeField()}
+            )} */}
+            <TextField
+              disabled={['rename'].includes(props.mode)}
+              label="Size"
+              type="number"
+              name="size"
+              required
+              value={formik.values.size}
+              onChange={formik.handleChange}
+              errorText={formik.errors.size?.[0]}
+              errorGroup="linode-disk-drawer"
+              InputProps={{
+                endAdornment: <InputAdornment position="end">MB</InputAdornment>
+              }}
+              data-qa-disk-size
+            />
+            <FormHelperText style={{ marginTop: 8 }}>
+              Maximum Size: {props.maximumSize} MB
+            </FormHelperText>
           </form>
         </Grid>
         <Grid item className={classes.section}>
           <ActionsPanel>
             <Button
-              onClick={props.onSubmit}
+              onClick={() => formik.handleSubmit()}
               buttonType="primary"
               loading={submitting}
               data-qa-disk-submit

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.tsx
@@ -125,9 +125,10 @@ export const DiskDrawer: React.FC<CombinedProps> = props => {
       filesystem: disk?.filesystem ?? ('ext4' as FileSystem),
       size: disk?.size || maximumSize || 0,
       image: '',
-      password: ''
+      root_pass: ''
     },
     validationSchema: getSchema(mode, selectedMode),
+    validateOnChange: true,
     onSubmit: values => submitForm(values)
   });
 
@@ -193,7 +194,8 @@ export const DiskDrawer: React.FC<CombinedProps> = props => {
               required
               value={formik.values.label}
               onChange={formik.handleChange}
-              errorText={formik.errors.label}
+              onBlur={formik.handleBlur}
+              errorText={formik.touched.label ? formik.errors.label : undefined}
               errorGroup="linode-disk-drawer"
               data-qa-label
             />
@@ -205,7 +207,12 @@ export const DiskDrawer: React.FC<CombinedProps> = props => {
                 select
                 value={formik.values.filesystem}
                 onChange={formik.handleChange}
-                errorText={formik.errors.filesystem}
+                onBlur={formik.handleBlur}
+                errorText={
+                  formik.touched.filesystem
+                    ? formik.errors.filesystem
+                    : undefined
+                }
                 errorGroup="linode-disk-drawer"
               >
                 <MenuItem value="_none_">
@@ -223,11 +230,15 @@ export const DiskDrawer: React.FC<CombinedProps> = props => {
                 onImageChange={(selected: Item) =>
                   formik.setFieldValue('image', selected.value)
                 }
-                imageFieldError={formik.errors.image}
-                password={formik.values.password}
-                passwordError={formik.errors.password}
-                onPasswordChange={(password: string) =>
-                  formik.setFieldValue('password', password)
+                imageFieldError={
+                  formik.touched.image ? formik.errors.image : undefined
+                }
+                password={formik.values.root_pass}
+                passwordError={
+                  formik.touched.root_pass ? formik.errors.root_pass : undefined
+                }
+                onPasswordChange={(root_pass: string) =>
+                  formik.setFieldValue('root_pass', root_pass)
                 }
                 userSSHKeys={userSSHKeys || []}
                 requestKeys={requestKeys || (() => null)}
@@ -241,7 +252,8 @@ export const DiskDrawer: React.FC<CombinedProps> = props => {
               required
               value={formik.values.size}
               onChange={formik.handleChange}
-              errorText={formik.errors.size}
+              onBlur={formik.handleBlur}
+              errorText={formik.touched.size ? formik.errors.size : undefined}
               errorGroup="linode-disk-drawer"
               InputProps={{
                 endAdornment: <InputAdornment position="end">MB</InputAdornment>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks.tsx
@@ -432,7 +432,7 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
 
   createDisk = (values: any) => {
     const { linodeId, userSSHKeys, createLinodeDisk } = this.props;
-    const { label, size, filesystem, image, password } = values;
+    const { label, size, filesystem, image, root_pass } = values;
     if (!linodeId) {
       // Safety check; should never happen.
       return Promise.reject({ reason: 'Invalid Linode' });
@@ -443,7 +443,7 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
       size,
       filesystem: filesystem === '_none_' ? undefined : filesystem,
       image: Boolean(image) ? image : undefined,
-      root_pass: Boolean(password) ? password : undefined,
+      root_pass: Boolean(root_pass) ? root_pass : undefined,
       authorized_users: userSSHKeys
         ? userSSHKeys.filter(u => u.selected).map(u => u.username)
         : undefined


### PR DESCRIPTION
## Description

This drawer was old, needed a lot of refactoring:

- Added Formik using the newish useFormik hook
-  Moved drawer state management (mostly) inside the drawer itself
- Refactored the drawer to a function component

Still coming:
- [x] Rewrite unit tests
- [ ] See if a dynamic schema validation will work (since there are multiple possible schemas). As is, we're relying on the Yup validation triggering when the request is made.