### PR TITLE
M3-4239 CMR table base

### DIFF
--- a/packages/manager/src/components/EntityTable/EntityTable_CMR.tsx
+++ b/packages/manager/src/components/EntityTable/EntityTable_CMR.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import TableCell from 'src/components/core/TableCell';
+import Typography from 'src/components/core/Typography';
+import OrderBy from 'src/components/OrderBy';
+import TableSortCell from 'src/components/TableSortCell';
+import GroupedEntitiesByTag from './GroupedEntitiesByTag';
+import ListEntities from './ListEntities';
+import { Handlers } from './types';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  hiddenHeaderCell: theme.visually.hidden
+}));
+
+export interface EntityTableRow<T> {
+  Component: React.ComponentType;
+  data: T[];
+  handlers?: Handlers;
+}
+
+interface Props {
+  entity: string;
+  headers: HeaderCell[];
+  groupByTag: boolean;
+  row: EntityTableRow<any>;
+}
+
+export type CombinedProps = Props;
+
+export const LandingTable: React.FC<Props> = props => {
+  const { entity, headers, groupByTag, row } = props;
+  const classes = useStyles();
+  return (
+    <OrderBy data={row.data} orderBy={'label'} order={'asc'}>
+      {({ data: orderedData, handleOrderChange, order, orderBy }) => {
+        const headerCells = headers.map((thisCell: HeaderCell) => {
+          return thisCell.sortable ? (
+            <TableSortCell
+              active={orderBy === thisCell.dataColumn}
+              label={thisCell.dataColumn}
+              direction={order}
+              handleClick={handleOrderChange}
+              style={{ width: thisCell.widthPercent }}
+              data-testid={`${thisCell.label}-header-cell`}
+            >
+              {thisCell.label}
+            </TableSortCell>
+          ) : (
+            <TableCell
+              data-testid={`${thisCell.label}-header-cell`}
+              style={{ width: thisCell.widthPercent }}
+            >
+              <Typography
+                className={
+                  thisCell.visuallyHidden ? classes.hiddenHeaderCell : undefined
+                }
+              >
+                {thisCell.label}
+              </Typography>
+            </TableCell>
+          );
+        });
+
+        const tableProps = {
+          data: orderedData,
+          RowComponent: row.Component,
+          headerCells,
+          entity,
+          handlers: row.handlers
+        };
+
+        if (groupByTag) {
+          return <GroupedEntitiesByTag {...tableProps} />;
+        }
+        return <ListEntities {...tableProps} />;
+      }}
+    </OrderBy>
+  );
+};
+
+export interface HeaderCell {
+  sortable: boolean;
+  label: string;
+  dataColumn: string;
+  widthPercent: number;
+  visuallyHidden?: boolean;
+}
+
+export default LandingTable;

--- a/packages/manager/src/components/EntityTable/GroupedEntitiesByTag_CMR.tsx
+++ b/packages/manager/src/components/EntityTable/GroupedEntitiesByTag_CMR.tsx
@@ -1,0 +1,134 @@
+import { compose } from 'ramda';
+import * as React from 'react';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import TableBody from 'src/components/core/TableBody';
+import TableHead from 'src/components/core/TableHead';
+import TableRow from 'src/components/core/TableRow';
+import Typography from 'src/components/core/Typography';
+import Paginate from 'src/components/Paginate';
+import PaginationFooter, {
+  MIN_PAGE_SIZE
+} from 'src/components/PaginationFooter';
+import Table from 'src/components/Table';
+import TableCell from 'src/components/TableCell';
+import { useInfinitePageSize } from 'src/hooks/useInfinitePageSize';
+import { groupByTags, sortGroups } from 'src/utilities/groupByTags';
+import { ListProps } from './types';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {},
+  tagGridRow: {
+    marginBottom: theme.spacing(2) + theme.spacing(1) / 2
+  },
+  tagHeaderRow: {
+    backgroundColor: theme.bg.main,
+    height: 'auto',
+    '& td': {
+      // This is maintaining the spacing between groups because of how tables handle margin/padding. Adjust with care!
+      padding: `${theme.spacing(2) + theme.spacing(1) / 2}px 0 ${theme.spacing(
+        1
+      ) + 2}px`,
+      borderBottom: 'none'
+    }
+  },
+  groupContainer: {
+    [theme.breakpoints.up('md')]: {
+      '& $tagHeaderRow > td': {
+        padding: `${theme.spacing(1) + 2}px 0`
+      }
+    }
+  },
+  tagHeader: {
+    marginBottom: 2
+  },
+  tagHeaderOuter: {},
+  paginationCell: {
+    paddingTop: 2,
+    '& div:first-child': {
+      marginTop: 0
+    }
+  }
+}));
+
+export type CombinedProps = ListProps;
+
+export const GroupedEntitiesByTag: React.FC<CombinedProps> = props => {
+  const { data, entity, handlers, headerCells, RowComponent } = props;
+  const groupedEntities = compose(sortGroups, groupByTags)(data);
+  const classes = useStyles();
+  const { infinitePageSize, setInfinitePageSize } = useInfinitePageSize();
+
+  return (
+    <Table aria-label={`List of ${entity}`}>
+      <TableHead>
+        <TableRow>{headerCells}</TableRow>
+      </TableHead>
+      {groupedEntities.map(([tag, domains]: [string, any[]]) => {
+        return (
+          <React.Fragment key={tag}>
+            <Paginate
+              data={domains}
+              pageSize={infinitePageSize}
+              pageSizeSetter={setInfinitePageSize}
+            >
+              {({
+                data: paginatedData,
+                handlePageChange,
+                handlePageSizeChange,
+                page,
+                pageSize,
+                count
+              }) => {
+                return (
+                  <TableBody
+                    className={classes.groupContainer}
+                    data-qa-tag-header={tag}
+                  >
+                    <TableRow className={classes.tagHeaderRow} role="cell">
+                      <TableCell colSpan={7}>
+                        <Typography
+                          variant="h2"
+                          component="h3"
+                          className={classes.tagHeader}
+                        >
+                          {tag}
+                        </Typography>
+                      </TableCell>
+                    </TableRow>
+                    {paginatedData.map(thisEntity => (
+                      <RowComponent
+                        key={thisEntity.id}
+                        {...thisEntity}
+                        {...handlers}
+                      />
+                    ))}
+                    {count > MIN_PAGE_SIZE && (
+                      <TableRow>
+                        <TableCell
+                          colSpan={7}
+                          className={classes.paginationCell}
+                        >
+                          <PaginationFooter
+                            count={count}
+                            handlePageChange={handlePageChange}
+                            handleSizeChange={handlePageSizeChange}
+                            pageSize={pageSize}
+                            page={page}
+                            eventCategory={'domains landing'}
+                            showAll
+                          />
+                        </TableCell>
+                      </TableRow>
+                    )}
+                  </TableBody>
+                );
+              }}
+            </Paginate>
+          </React.Fragment>
+        );
+      })}
+    </Table>
+  );
+};
+
+export default GroupedEntitiesByTag;

--- a/packages/manager/src/components/EntityTable/ListEntities_CMR.tsx
+++ b/packages/manager/src/components/EntityTable/ListEntities_CMR.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import Paper from 'src/components/core/Paper';
+import TableBody from 'src/components/core/TableBody';
+import TableHead from 'src/components/core/TableHead';
+import TableRow from 'src/components/core/TableRow';
+import Paginate from 'src/components/Paginate';
+import PaginationFooter from 'src/components/PaginationFooter';
+import Table from 'src/components/Table';
+import TableContentWrapper from 'src/components/TableContentWrapper';
+import { ListProps } from './types';
+
+export type CombinedProps = ListProps;
+
+export const ListEntities: React.FC<CombinedProps> = props => {
+  const { data, entity, handlers, headerCells, RowComponent } = props;
+  return (
+    <Paginate data={data}>
+      {({
+        data: paginatedAndOrderedData,
+        count,
+        handlePageChange,
+        handlePageSizeChange,
+        page,
+        pageSize
+      }) => (
+        <>
+          <Paper>
+            <Table aria-label={`List of ${entity}`}>
+              <TableHead>
+                <TableRow>{headerCells}</TableRow>
+              </TableHead>
+              <TableBody>
+                <TableContentWrapper
+                  length={paginatedAndOrderedData.length}
+                  loading={false}
+                  error={undefined}
+                  lastUpdated={100}
+                >
+                  {paginatedAndOrderedData.map(thisEntity => (
+                    <RowComponent
+                      key={thisEntity.id}
+                      {...thisEntity}
+                      {...handlers}
+                    />
+                  ))}
+                </TableContentWrapper>
+              </TableBody>
+            </Table>
+          </Paper>
+          <PaginationFooter
+            count={count}
+            handlePageChange={handlePageChange}
+            handleSizeChange={handlePageSizeChange}
+            page={page}
+            pageSize={pageSize}
+            eventCategory="Firewall Devices Table"
+          />
+        </>
+      )}
+    </Paginate>
+  );
+};
+
+export default ListEntities;

--- a/packages/manager/src/components/Table/Table_CMR.tsx
+++ b/packages/manager/src/components/Table/Table_CMR.tsx
@@ -140,7 +140,7 @@ class WrappedTable extends React.Component<CombinedProps> {
           'tableWrapper',
           {
             [classes.root]: !noOverflow,
-            [classes.responsive]: !(isResponsive === false), // must be explicity set to false
+            [classes.responsive]: isResponsive !== false, // must be explicity set to false
             [classes.border]: border,
             [classes.noMobileLabel]: removeLabelonMobile,
             [classes.stickyHeader]: stickyHeader

--- a/packages/manager/src/components/Table/Table_CMR.tsx
+++ b/packages/manager/src/components/Table/Table_CMR.tsx
@@ -1,0 +1,169 @@
+import * as classNames from 'classnames';
+import * as React from 'react';
+import {
+  createStyles,
+  Theme,
+  withStyles,
+  WithStyles
+} from 'src/components/core/styles';
+import Table, { TableProps } from 'src/components/core/Table';
+
+type ClassNames =
+  | 'root'
+  | 'border'
+  | 'responsive'
+  | 'noMobileLabel'
+  | 'stickyHeader';
+
+const styles = (theme: Theme) =>
+  createStyles({
+    root: {
+      overflowX: 'auto',
+      overflowY: 'hidden',
+      '& tbody': {
+        transition: theme.transitions.create(['opacity'])
+      },
+      '& tbody.sorting': {
+        opacity: 0.5
+      }
+    },
+    responsive: {
+      [theme.breakpoints.down('sm')]: {
+        '& .emptyCell': {
+          display: 'none'
+        },
+        '& thead': {
+          display: 'none'
+        },
+        '& tbody > tr': {
+          marginBottom: 0,
+          '& > td:first-child': {
+            backgroundColor: theme.bg.tableHeader,
+            '& .data': {
+              textAlign: 'right'
+            }
+          }
+        },
+        '& tr': {
+          display: 'block',
+          marginBottom: 20,
+          height: 'auto'
+        },
+        '& td': {
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          minHeight: 32
+        }
+      }
+    },
+    noMobileLabel: {
+      [theme.breakpoints.down('sm')]: {
+        '& tbody > tr > td:first-child': {
+          '& > span:first-child': {
+            display: 'none'
+          }
+        },
+        '& .data': {
+          marginLeft: 0
+        }
+      }
+    },
+    border: {
+      border: `1px solid ${theme.palette.divider}`,
+      borderBottom: 0
+    },
+    stickyHeader: {
+      borderTop: 0,
+      '& th': {
+        position: 'sticky',
+        backgroundColor: theme.bg.tableHeader,
+        paddingTop: 0,
+        paddingBottom: 0,
+        height: 48,
+        zIndex: 5,
+        borderTop: `1px solid ${theme.palette.divider}`,
+        '&:first-child::before': {
+          content: '""',
+          borderTop: `1px solid ${theme.palette.divider}`,
+          backgroundColor: theme.bg.tableHeader,
+          position: 'absolute',
+          width: 5,
+          top: -1,
+          borderBottom: `2px solid ${theme.palette.divider}`,
+          height: 48,
+          left: -5
+        }
+      }
+    }
+  });
+
+export interface Props extends TableProps {
+  className?: string;
+  noOverflow?: boolean;
+  tableClass?: string;
+  border?: boolean;
+  isResponsive?: boolean; // back-door for tables that don't need to be responsive
+  spacingTop?: 0 | 8 | 16 | 24;
+  spacingBottom?: 0 | 8 | 16 | 24;
+  stickyHeader?: boolean;
+  removeLabelonMobile?: boolean; // only for table instances where we want to hide the cell label for small screens
+  tableCaption?: string;
+  colCount?: number;
+  rowCount?: number;
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+class WrappedTable extends React.Component<CombinedProps> {
+  render() {
+    const {
+      classes,
+      className,
+      isResponsive,
+      tableClass,
+      border,
+      noOverflow,
+      spacingTop,
+      spacingBottom,
+      removeLabelonMobile,
+      stickyHeader,
+      tableCaption,
+      colCount,
+      rowCount,
+      ...rest
+    } = this.props;
+
+    return (
+      <div
+        className={classNames(
+          'tableWrapper',
+          {
+            [classes.root]: !noOverflow,
+            [classes.responsive]: !(isResponsive === false), // must be explicity set to false
+            [classes.border]: border,
+            [classes.noMobileLabel]: removeLabelonMobile,
+            [classes.stickyHeader]: stickyHeader
+          },
+          className
+        )}
+        style={{
+          marginTop: spacingTop !== undefined ? spacingTop : 0,
+          marginBottom: spacingBottom !== undefined ? spacingBottom : 0
+        }}
+      >
+        <Table
+          className={tableClass}
+          {...rest}
+          aria-colcount={colCount}
+          aria-rowcount={rowCount}
+          role="table"
+        >
+          {this.props.children}
+        </Table>
+      </div>
+    );
+  }
+}
+
+export default withStyles(styles)(WrappedTable);

--- a/packages/manager/src/components/TableCell/TableCell_CMR.tsx
+++ b/packages/manager/src/components/TableCell/TableCell_CMR.tsx
@@ -1,0 +1,112 @@
+import * as classNames from 'classnames';
+import * as React from 'react';
+import Hidden from 'src/components/core/Hidden';
+import {
+  createStyles,
+  Theme,
+  withStyles,
+  WithStyles
+} from 'src/components/core/styles';
+import TableCell, { TableCellProps } from 'src/components/core/TableCell';
+
+type ClassNames =
+  | 'root'
+  | 'noWrap'
+  | 'sortable'
+  | 'data'
+  | 'compact'
+  | 'parentColSpan';
+
+const styles = (theme: Theme) =>
+  createStyles({
+    root: {},
+    noWrap: {
+      whiteSpace: 'nowrap'
+    },
+    sortable: {
+      color: theme.color.headline,
+      fontWeight: 'normal',
+      cursor: 'pointer',
+      '& button, & button:focus': {
+        color: theme.color.headline,
+        fontWeight: 'normal',
+        fontSize: '.9rem'
+      },
+      '& .sortIcon': {
+        position: 'relative',
+        top: 2,
+        left: 10,
+        color: theme.palette.primary.main
+      }
+    },
+    data: {
+      [theme.breakpoints.down('sm')]: {
+        textAlign: 'right',
+        marginLeft: theme.spacing(3)
+      },
+      [theme.breakpoints.down('xs')]: {
+        width: '100%'
+      }
+    },
+    parentColSpan: {
+      width: '100%'
+    },
+    compact: {
+      padding: 6
+    }
+  });
+
+export interface Props extends TableCellProps {
+  noWrap?: boolean;
+  sortable?: boolean;
+  className?: string;
+  /*
+   * parent column will either be the name of the column this
+   * TableCell is listed under
+   */
+  parentColumn?: string;
+  compact?: boolean;
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+class WrappedTableCell extends React.Component<CombinedProps> {
+  render() {
+    const {
+      classes,
+      className,
+      parentColumn,
+      noWrap,
+      sortable,
+      compact,
+      ...rest
+    } = this.props;
+
+    return (
+      <TableCell
+        className={classNames(className, {
+          [classes.root]: true,
+          [classes.noWrap]: noWrap,
+          [classes.sortable]: sortable,
+          [classes.compact]: compact,
+          // hide the cell at small breakpoints if it's empty with no parent column
+          emptyCell: !parentColumn && !this.props.children
+        })}
+        {...rest}
+      >
+        {!!parentColumn ? (
+          <React.Fragment>
+            <Hidden mdUp>
+              <span className={classes.parentColSpan}>{parentColumn}</span>
+            </Hidden>
+            <div className={`${classes.data} data`}>{this.props.children}</div>
+          </React.Fragment>
+        ) : (
+          this.props.children
+        )}
+      </TableCell>
+    );
+  }
+}
+
+export default withStyles(styles)(WrappedTableCell);

--- a/packages/manager/src/components/TableContentWrapper/TableContentWrapper_CMR.tsx
+++ b/packages/manager/src/components/TableContentWrapper/TableContentWrapper_CMR.tsx
@@ -1,0 +1,43 @@
+import { APIError } from '@linode/api-v4/lib/types';
+import * as React from 'react';
+import { compose } from 'recompose';
+
+import TableRowEmpty from 'src/components/TableRowEmptyState';
+import TableRowError from 'src/components/TableRowError';
+import TableRowLoading from 'src/components/TableRowLoading';
+
+interface Props {
+  length: number;
+  loading: boolean;
+  lastUpdated?: number;
+  error?: APIError[];
+  emptyMessage?: string;
+}
+
+type CombinedProps = Props;
+
+const TableContentWrapper: React.FC<CombinedProps> = props => {
+  const { length, loading, emptyMessage, error, lastUpdated } = props;
+
+  if (loading) {
+    return <TableRowLoading colSpan={6} firstColWidth={25} oneLine />;
+  }
+
+  if (error && error.length > 0) {
+    return <TableRowError colSpan={6} message={error[0].reason} />;
+  }
+
+  if (lastUpdated !== 0 && length === 0) {
+    return (
+      <TableRowEmpty
+        colSpan={6}
+        message={emptyMessage ?? 'No data to display.'}
+      />
+    );
+  }
+
+  /* eslint-disable-next-line */
+  return <>{props.children}</>;
+};
+
+export default compose<CombinedProps, Props>(React.memo)(TableContentWrapper);

--- a/packages/manager/src/components/TableHeader/TableHeader_CMR.tsx
+++ b/packages/manager/src/components/TableHeader/TableHeader_CMR.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import {
+  createStyles,
+  Theme,
+  withStyles,
+  WithStyles
+} from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+import Grid from 'src/components/Grid';
+
+type ClassNames = 'root' | 'title';
+
+const styles = (theme: Theme) =>
+  createStyles({
+    root: {},
+    title: {
+      marginTop: theme.spacing(2),
+      marginBottom: theme.spacing(2)
+    }
+  });
+
+interface Props {
+  title: string;
+  action?: () => JSX.Element | JSX.Element[] | null;
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+const TableHeader: React.FC<CombinedProps> = ({ classes, title, action }) => {
+  return (
+    <Grid container justify="space-between" alignItems="flex-end">
+      <Grid item>
+        <Typography
+          variant="h2"
+          className={classes.title}
+          data-qa-table={title}
+        >
+          {title}
+        </Typography>
+      </Grid>
+      {action && <Grid item>{action()}</Grid>}
+    </Grid>
+  );
+};
+
+const styled = withStyles(styles);
+
+export default styled(TableHeader);

--- a/packages/manager/src/components/TableRow/TableRow_CMR.tsx
+++ b/packages/manager/src/components/TableRow/TableRow_CMR.tsx
@@ -161,23 +161,23 @@ export class TableRow extends React.Component<CombinedProps> {
     const isAnchor = e.target.tagName === 'A' || e.target.closest('a');
 
     if (
-      body.getAttribute('style') === null ||
-      body.getAttribute('style').indexOf('overflow: hidden') !== 0 ||
-      body.getAttribute('style') === ''
+      (body.getAttribute('style') === null ||
+        body.getAttribute('style').indexOf('overflow: hidden') !== 0 ||
+        body.getAttribute('style') === '') &&
+      !isButton &&
+      !isAnchor
     ) {
-      if (!isButton && !isAnchor) {
-        e.stopPropagation();
-        // return if no modal is open
-        if (typeof target === 'string') {
-          !ev.metaKey && !ev.ctrlKey
-            ? // if no meta or ctrl key is pressed (new tab)
-              this.props.history.push(target)
-            : // else open in new tab/window
-              window.open(target, '_blank', 'noopener');
-        }
-        if (typeof target === 'function') {
-          target(e);
-        }
+      e.stopPropagation();
+      // return if no modal is open
+      if (typeof target === 'string') {
+        !ev.metaKey && !ev.ctrlKey
+          ? // if no meta or ctrl key is pressed (new tab)
+            this.props.history.push(target)
+          : // else open in new tab/window
+            window.open(target, '_blank', 'noopener');
+      }
+      if (typeof target === 'function') {
+        target(e);
       }
     }
   };

--- a/packages/manager/src/components/TableRow/TableRow_CMR.tsx
+++ b/packages/manager/src/components/TableRow/TableRow_CMR.tsx
@@ -1,0 +1,248 @@
+import * as classNames from 'classnames';
+import * as React from 'react';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { compose } from 'recompose';
+import Hidden from 'src/components/core/Hidden';
+import {
+  createStyles,
+  Theme,
+  withStyles,
+  WithStyles
+} from 'src/components/core/styles';
+import _TableRow, {
+  TableRowProps as _TableRowProps
+} from 'src/components/core/TableRow';
+
+type ClassNames =
+  | 'root'
+  | 'selected'
+  | 'withForcedIndex'
+  | 'activeCaret'
+  | 'activeCaretOverlay'
+  | 'selectedOuter'
+  | 'highlight'
+  | 'disabled';
+
+const styles = (theme: Theme) =>
+  createStyles({
+    root: {
+      transition: theme.transitions.create(['box-shadow']),
+      [theme.breakpoints.up('md')]: {
+        boxShadow: `inset 3px 0 0 transparent`
+      }
+    },
+    withForcedIndex: {
+      '& td': {
+        transition: theme.transitions.create(['color'])
+      },
+      transition: theme.transitions.create(['border-color']),
+      '&:before': {
+        borderLeft: `1px solid transparent`,
+        paddingLeft: 4
+      },
+      '&:hover': {
+        cursor: 'pointer',
+        '& td': {
+          color: theme.palette.primary.light
+        }
+      },
+      '&:focus': {
+        backgroundColor: theme.bg.lightBlue
+      }
+    },
+    selected: {
+      backgroundColor: theme.bg.lightBlue,
+      transform: 'scale(1)',
+      boxShadow: `inset 3px 0 0 ${theme.bg.lightBlue}`,
+      '&:before': {
+        transition: 'none',
+        backgroundColor: theme.bg.lightBlue,
+        borderColor: theme.palette.primary.light
+      },
+      '& td': {
+        borderTopColor: theme.palette.primary.light,
+        borderBottomColor: theme.palette.primary.light,
+        position: 'relative',
+        '&:first-child': {
+          borderLeft: `1px solid ${theme.palette.primary.light}`
+        },
+        [theme.breakpoints.down('md')]: {
+          '&:last-child': {
+            borderRight: `1px solid ${theme.palette.primary.light}`
+          }
+        }
+      }
+    },
+    selectedOuter: {
+      padding: 0
+    },
+    activeCaret: {
+      '&:before': {
+        content: '""',
+        width: 15,
+        height: '50%',
+        position: 'absolute',
+        left: 0,
+        top: 0,
+        background: `linear-gradient(to right top, ${theme.palette.primary.light} 0%, ${theme.palette.primary.light} 49%, transparent 50.1%)`
+      },
+      '&:after': {
+        content: '""',
+        width: 15,
+        height: '50%',
+        position: 'absolute',
+        left: 0,
+        top: '50%',
+        background: `linear-gradient(to right bottom, ${theme.palette.primary.light} 0%, ${theme.palette.primary.light} 49%, transparent 50.1%)`
+      }
+    },
+    activeCaretOverlay: {
+      '&:before': {
+        content: '""',
+        position: 'absolute',
+        left: 0,
+        top: 0,
+        width: 15,
+        height: '50%',
+        background: `linear-gradient(to right top, ${theme.bg.lightBlue} 0%, ${theme.bg.lightBlue} 45%, transparent 46.1%)`
+      },
+      '&:after': {
+        content: '""',
+        position: 'absolute',
+        left: 0,
+        bottom: 0,
+        width: 15,
+        height: '50%',
+        background: `linear-gradient(to right bottom, ${theme.bg.lightBlue} 0%, ${theme.bg.lightBlue} 45%, transparent 46.1%)`
+      }
+    },
+    highlight: {
+      backgroundColor: theme.bg.lightBlue
+    },
+    disabled: {
+      backgroundColor: 'rgba(247, 247, 247, 0.25)',
+      '& td': {
+        color: '#D2D3D4'
+      }
+    }
+  });
+
+type onClickFn = (e: React.ChangeEvent<HTMLTableRowElement>) => void;
+
+export interface Props {
+  rowLink?: string | onClickFn;
+  onClick?: onClickFn;
+  onKeyUp?: any;
+  className?: string;
+  staticContext?: boolean;
+  htmlFor?: string;
+  selected?: boolean;
+  forceIndex?: boolean;
+  highlight?: boolean;
+  disabled?: boolean;
+  ariaLabel?: string;
+}
+
+export type CombinedProps = Props &
+  _TableRowProps &
+  RouteComponentProps<{}> &
+  WithStyles<ClassNames>;
+
+export class TableRow extends React.Component<CombinedProps> {
+  rowClick = (
+    e: React.ChangeEvent<HTMLTableRowElement>,
+    ev: React.MouseEvent<HTMLElement>, // added a second event for the purpose of capturing keyDown (open in new tab)
+    target: string | onClickFn
+  ) => {
+    const body = document.body as any;
+    // Inherit the ROW click unless the element is a <button> or an <a> or is contained within them
+    const isButton =
+      e.target.tagName === 'BUTTON' || e.target.closest('button');
+    const isAnchor = e.target.tagName === 'A' || e.target.closest('a');
+
+    if (
+      body.getAttribute('style') === null ||
+      body.getAttribute('style').indexOf('overflow: hidden') !== 0 ||
+      body.getAttribute('style') === ''
+    ) {
+      if (!isButton && !isAnchor) {
+        e.stopPropagation();
+        // return if no modal is open
+        if (typeof target === 'string') {
+          !ev.metaKey && !ev.ctrlKey
+            ? // if no meta or ctrl key is pressed (new tab)
+              this.props.history.push(target)
+            : // else open in new tab/window
+              window.open(target, '_blank', 'noopener');
+        }
+        if (typeof target === 'function') {
+          target(e);
+        }
+      }
+    }
+  };
+
+  render() {
+    const {
+      classes,
+      className,
+      rowLink,
+      staticContext,
+      selected,
+      forceIndex,
+      highlight,
+      disabled,
+      ariaLabel,
+      ...rest
+    } = this.props;
+
+    let role;
+    switch (typeof rowLink) {
+      case 'string':
+        role = 'link';
+        break;
+      case 'function':
+        role = 'button';
+        break;
+      default:
+        role = undefined;
+    }
+
+    return (
+      <_TableRow
+        onClick={(e: any) => rowLink && this.rowClick(e, e, rowLink)} // same argument, different methods (one to stop propagation, one to add the listener for meta/ctrl key)
+        onKeyUp={(e: any) =>
+          rowLink && e.keyCode === 13 && this.rowClick(e, e, rowLink)
+        }
+        hover={rowLink !== undefined}
+        role={role}
+        aria-label={ariaLabel ?? `View Details`}
+        className={classNames(className, {
+          [classes.root]: true,
+          [classes.selected]: selected,
+          [classes.withForcedIndex]: forceIndex,
+          [classes.highlight]: highlight,
+          [classes.disabled]: disabled
+        })}
+        {...rest}
+        tabIndex={rowLink || forceIndex ? 0 : -1}
+      >
+        {this.props.children}
+        {selected && (
+          <Hidden mdDown>
+            <td colSpan={0} className={classes.selectedOuter}>
+              <span className={classes.activeCaret} />
+              <span className={classes.activeCaretOverlay} />
+            </td>
+          </Hidden>
+        )}
+      </_TableRow>
+    );
+  }
+}
+
+const styled = withStyles(styles);
+
+const enhanced = compose<CombinedProps, Props>(withRouter, styled)(TableRow);
+
+export default enhanced;

--- a/packages/manager/src/components/TableRowEmptyState/TableRowEmptyState_CMR.tsx
+++ b/packages/manager/src/components/TableRowEmptyState/TableRowEmptyState_CMR.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import {
+  createStyles,
+  Theme,
+  withStyles,
+  WithStyles
+} from 'src/components/core/styles';
+import TableCell from 'src/components/core/TableCell';
+import TableRow from 'src/components/core/TableRow';
+
+type ClassNames = 'root';
+
+const styles = (theme: Theme) =>
+  createStyles({
+    root: {
+      textAlign: 'center'
+    }
+  });
+
+export interface Props {
+  colSpan: number;
+  message?: string;
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+const TableRowEmptyState: React.FC<CombinedProps> = props => {
+  const { classes } = props;
+  return (
+    <TableRow data-testid={'table-row-empty'}>
+      <TableCell colSpan={props.colSpan} className={classes.root}>
+        {props.message || 'No items to display.'}
+      </TableCell>
+    </TableRow>
+  );
+};
+
+const styled = withStyles(styles);
+
+export default styled(TableRowEmptyState);

--- a/packages/manager/src/components/TableRowError/TableRowError_CMR.tsx
+++ b/packages/manager/src/components/TableRowError/TableRowError_CMR.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import TableCell from 'src/components/core/TableCell';
+import TableRow from 'src/components/core/TableRow';
+import ErrorState from 'src/components/ErrorState';
+
+export interface Props {
+  colSpan: number;
+  message: string | JSX.Element;
+}
+
+type CombinedProps = Props;
+
+const TableRowError: React.FC<CombinedProps> = props => {
+  return (
+    <TableRow data-testid="table-row-error">
+      <TableCell colSpan={props.colSpan}>
+        <ErrorState errorText={props.message} compact />
+      </TableCell>
+    </TableRow>
+  );
+};
+
+export default TableRowError;

--- a/packages/manager/src/components/TableRowLoading/TableRowLoading_CMR.tsx
+++ b/packages/manager/src/components/TableRowLoading/TableRowLoading_CMR.tsx
@@ -1,0 +1,110 @@
+import * as classNames from 'classnames';
+import * as React from 'react';
+import {
+  createStyles,
+  Theme,
+  withStyles,
+  WithStyles
+} from 'src/components/core/styles';
+import TableCell from 'src/components/core/TableCell';
+import TableRow from 'src/components/core/TableRow';
+import Skeleton from 'src/components/Skeleton';
+
+type ClassNames = 'root' | 'tableCell' | 'transparent';
+
+const styles = (theme: Theme) =>
+  createStyles({
+    root: {},
+    tableCell: {
+      paddingTop: 0,
+      paddingBottom: 0,
+      textAlign: 'center'
+    },
+    transparent: {
+      backgroundColor: theme.bg.main
+    }
+  });
+
+type Columns = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+
+export interface Props {
+  colSpan: Columns;
+  numberOfRows?: number;
+  numberOfColumns?: Columns;
+  firstColWidth?: number;
+  transparent?: any;
+  oneLine?: boolean;
+  compact?: boolean;
+  hasEntityIcon?: boolean;
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+const tableRowLoading: React.FC<CombinedProps> = props => {
+  const {
+    classes,
+    transparent,
+    colSpan,
+    firstColWidth,
+    oneLine,
+    numberOfRows,
+    hasEntityIcon,
+    compact,
+    numberOfColumns
+  } = props;
+
+  // Default number of columns for the <Skeleton />.
+  let numColumns: Columns = 8;
+
+  // If the consumer has explicitly specified the number of columns to use, go with that.
+  // This may be different than colSpan... for example, if one column contains an Icon,
+  // we'd like colSpan to be numberOfColumns + 1.
+  if (numberOfColumns) {
+    numColumns = numberOfColumns;
+    // Otherwise if they've specified a colSpan, use that, since it's a pretty good guess.
+  } else if (colSpan) {
+    numColumns = colSpan;
+  }
+
+  const ifRows = numberOfRows ?? 1;
+  const rowBuilder = () => {
+    const rows: JSX.Element[] = [];
+    for (let rowCount = 0; rowCount <= ifRows - 1; rowCount++) {
+      rows.push(
+        <TableRow
+          className={classNames({
+            [classes.transparent]: transparent
+          })}
+          data-testid="table-row-loading"
+          aria-label="Table content is loading"
+          key={`table-row-loading-${rowCount}`}
+          style={compact ? { height: 'auto' } : undefined}
+        >
+          <TableCell
+            colSpan={colSpan}
+            className={classNames({
+              [classes.tableCell]: true,
+              [classes.transparent]: transparent
+            })}
+          >
+            <Skeleton
+              table
+              numColumns={numColumns}
+              firstColWidth={firstColWidth ? firstColWidth : undefined}
+              oneLine={oneLine}
+              compact={compact}
+              hasEntityIcon={hasEntityIcon}
+            />
+          </TableCell>
+        </TableRow>
+      );
+    }
+    return rows;
+  };
+
+  return <>{rowBuilder()}</>;
+};
+
+const styled = withStyles(styles);
+
+export default styled(tableRowLoading);

--- a/packages/manager/src/components/TableSortCell/TableSortCell_CMR.tsx
+++ b/packages/manager/src/components/TableSortCell/TableSortCell_CMR.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react';
+import CircleProgress from 'src/components/CircleProgress';
+import {
+  createStyles,
+  Theme,
+  withStyles,
+  WithStyles
+} from 'src/components/core/styles';
+import TableCell, { TableCellProps } from 'src/components/core/TableCell';
+import TableSortLabel from 'src/components/core/TableSortLabel';
+
+import Sort from 'src/assets/icons/sort.svg';
+import SortUp from 'src/assets/icons/sortUp.svg';
+
+type ClassNames = 'root' | 'initialIcon' | 'noWrap';
+
+const styles = (theme: Theme) =>
+  createStyles({
+    root: {
+      color: theme.palette.text.primary,
+      minHeight: 20
+    },
+    initialIcon: {
+      margin: '2px 4px 0 5px'
+    },
+    noWrap: {
+      whiteSpace: 'nowrap'
+    }
+  });
+
+export interface Props extends TableCellProps {
+  active: boolean;
+  isLoading?: boolean;
+  label: string;
+  direction: 'asc' | 'desc';
+  handleClick: (key: string, order?: 'asc' | 'desc') => void;
+  noWrap?: boolean;
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+class TableSortCell extends React.PureComponent<CombinedProps, {}> {
+  handleClick = () => {
+    const { label, direction, handleClick } = this.props;
+    const nextOrder = direction === 'asc' ? 'desc' : 'asc';
+    return handleClick(label, nextOrder);
+  };
+
+  render() {
+    const {
+      classes,
+      children,
+      direction,
+      label,
+      active,
+      handleClick,
+      noWrap,
+      isLoading,
+      ...rest
+    } = this.props;
+
+    return (
+      <TableCell
+        className={noWrap ? `${classes.noWrap}` : ''}
+        {...rest}
+        sortDirection={direction}
+        role="columnheader"
+      >
+        <TableSortLabel
+          active={active}
+          direction={direction}
+          onClick={this.handleClick}
+          className={classes.root}
+          IconComponent={SortUp}
+          hideSortIcon={true}
+          aria-label={`Sort by ${label}`}
+        >
+          {children}
+          {!active && <Sort className={classes.initialIcon} />}
+        </TableSortLabel>
+        {isLoading && <CircleProgress mini sort />}
+      </TableCell>
+    );
+  }
+}
+
+const styled = withStyles(styles);
+
+export default styled(TableSortCell);


### PR DESCRIPTION
## Description

This contains the "base" for CMR work on tables. I'm not exactly sure all of these components will be needed, but I included all of our components that deal with tables.

These new files are copy/pastes of the original. As a reminder, the idea is that CMR work is done in these new files/components, which are conditionally rendered:

```tsx
flags.cmr ? <Table_CMR /> : <Table />
```

When CMR is complete/deployed, we'll copy paste in reverse... (copy the CMR files and paste the contents in the original, to maintain some Git history).

Check out the second commit for a change I made to fix linting errors: https://github.com/linode/manager/pull/6538/commits/7005f0799649ddcea41355160ecd7a46df9dcca9.

There should be no change, as these components aren't in use anywhere yet. But please take a look through the codebase and try to catch anything I may have missed.