### PR TITLE
M3-4087 Update setDeletion logic for Events

### DIFF
--- a/packages/manager/src/features/Events/EventRow.tsx
+++ b/packages/manager/src/features/Events/EventRow.tsx
@@ -6,7 +6,6 @@ import { compose } from 'recompose';
 import Hidden from 'src/components/core/Hidden';
 import {
   createStyles,
-  Theme,
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
@@ -27,7 +26,7 @@ import { formatEventSeconds } from 'src/utilities/minute-conversion/minute-conve
 
 type ClassNames = 'root' | 'message' | 'occurredCell';
 
-const styles = (theme: Theme) =>
+const styles = () =>
   createStyles({
     root: {},
     message: {

--- a/packages/manager/src/features/TopMenu/UserEventsMenu/UserEventsList.tsx
+++ b/packages/manager/src/features/TopMenu/UserEventsMenu/UserEventsList.tsx
@@ -22,6 +22,7 @@ export const UserEventsList: React.FC<CombinedProps> = props => {
   const { events, closeMenu } = props;
 
   return (
+    // eslint-disable-next-line
     <React.Fragment>
       {(events as ExtendedEvent[])
         .reduce((result, event): UserEventsListItemProps[] => {

--- a/packages/manager/src/features/TopMenu/UserEventsMenu/UserEventsMenu.tsx
+++ b/packages/manager/src/features/TopMenu/UserEventsMenu/UserEventsMenu.tsx
@@ -148,7 +148,7 @@ export class UserEventsMenu extends React.Component<CombinedProps, State> {
     this.setState({ anchorEl: e.currentTarget });
   };
 
-  closeMenu = (e: React.MouseEvent<HTMLElement>) => {
+  closeMenu = (_: React.MouseEvent<HTMLElement>) => {
     const { markAllSeen } = this.props;
     markAllSeen();
     this.setState({ anchorEl: undefined });

--- a/packages/manager/src/store/events/event.helpers.ts
+++ b/packages/manager/src/store/events/event.helpers.ts
@@ -19,7 +19,7 @@ export const epoch = new Date(`1970-01-01T00:00:00.000`).getTime();
  * Returns `true` if the event:
  *   a) has _delete in its action (so it's a deletion event)
  *   b) is not a special case (see below).
- *   c) the event indicates a completed deletion action (its status is finished or notification)
+ *   c) the event indicates a non-failed deletion action
  *
  * If these conditions are met, the entity that the event is attached to
  * is assumed to no longer exist in the database.
@@ -39,9 +39,7 @@ export const isRelevantDeletionEvent = (
   if (ignoredDeletionEvents.includes(action)) {
     return false;
   }
-  return (
-    action.includes(`_delete`) && ['finished', 'notification'].includes(status)
-  );
+  return action.includes(`_delete`) && status !== 'failed';
 };
 
 /**
@@ -102,7 +100,7 @@ export const updateEvents = compose(
 
   /** Nested compose to get around Ramda's shotty typing. */
   compose(
-    /** Take only the last 25 events. */
+    /** Take only the last 100 events. */
     updateRight<Event[], Event[]>((prevEvents, events) => take(100, events)),
 
     /** Marked events "_deleted". */


### PR DESCRIPTION
To determine if an event was related to an entity that has been
deleted, we were checking (among other things) that the relevant
deletion event had a status of finished or notification. This caused
a slight problem when deleting a Linode, since a linode_shutdown
event is generated at exactly the same time as the linode_delete
event, and it was possible to click on this event in the events menu
before the delete had finished; however, the API already considered
this deleted ~(or maybe it was just our Redux store?)~ [Edit: no], so clicking
the event caused a 404.

I adjusted this logic so that we only check that the delete event
didn't fail (status !== failed). This handles the case above,
and should prevent the behavior the original logic was (I think)
intended to avoid: a long-ago failed deletion event should not
render all subsequent events pointing to that entity un-clickable.