### PR TITLE
[For release] Fix 404 issue

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetail.container.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetail.container.tsx
@@ -21,6 +21,6 @@ export default compose<InnerProps, OuterProps>(
   initLinodeConfigs,
   initLinodeDisks,
   maybeRenderError,
-  maybeRenderLoading,
-  maybeWithExtendedLinode
+  maybeWithExtendedLinode,
+  maybeRenderLoading
 );

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetail.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetail.tsx
@@ -65,7 +65,7 @@ const LinodeDetail: React.FC<CombinedProps> = props => {
    * Other portions of loading state handled by maybeRenderLoading
    * (Linode info, configs, disks, etc.)
    */
-  const { _loading } = useReduxLoad(['volumes', 'images']);
+  const { _loading } = useReduxLoad(['volumes', 'images', 'linodes']);
 
   if (props.loading || _loading) {
     return <CircleProgress />;

--- a/packages/manager/src/features/linodes/LinodesDetail/linodeDetailContext.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/linodeDetailContext.tsx
@@ -105,7 +105,7 @@ export interface LinodeDetailContext {
  * required Linode ID.
  */
 export const linodeDetailContextFactory = (
-  linode: ExtendedLinode | undefined,
+  linode: ExtendedLinode,
   dispatch: ThunkDispatch
 ): LinodeDetailContext => {
   const { id: linodeId } = linode;

--- a/packages/manager/src/features/linodes/LinodesDetail/linodeDetailContext.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/linodeDetailContext.tsx
@@ -101,11 +101,11 @@ export interface LinodeDetailContext {
 }
 
 /**
- * Create the Linode Detail Context including handlers preconfigured with the
+ * Create the Linode Detail Context including handlers pre-configured with the
  * required Linode ID.
  */
 export const linodeDetailContextFactory = (
-  linode: ExtendedLinode,
+  linode: ExtendedLinode | undefined,
   dispatch: ThunkDispatch
 ): LinodeDetailContext => {
   const { id: linodeId } = linode;

--- a/packages/manager/src/features/linodes/LinodesDetail/maybeRenderLoading.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/maybeRenderLoading.tsx
@@ -19,7 +19,6 @@ const collectLoadingState: MapState<InnerProps, OuterProps> = (
   ownProps
 ) => {
   const {
-    linodes,
     types,
     notifications,
     linodeConfigs,
@@ -31,7 +30,6 @@ const collectLoadingState: MapState<InnerProps, OuterProps> = (
     loading:
       configsLoading ||
       disksLoading ||
-      isLoading(linodes) ||
       isLoading(types) ||
       isLoading(notifications) ||
       (linodeConfigs[linodeId] && isLoading(linodeConfigs[linodeId])) ||

--- a/packages/manager/src/features/linodes/LinodesDetail/maybeWithExtendedLinode.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/maybeWithExtendedLinode.tsx
@@ -37,7 +37,7 @@ export const mapStateToProps: MapStateToProps<
   const { linodeId } = ownProps;
   const linode = state.__resources.linodes.itemsById[linodeId];
   if (!linode) {
-    return { linode: undefined };
+    return { linode: { id: -1, type: null } as ExtendedLinode };
   }
   const { type } = linode;
 

--- a/packages/manager/src/features/linodes/LinodesDetail/maybeWithExtendedLinode.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/maybeWithExtendedLinode.tsx
@@ -1,14 +1,10 @@
 import { Linode } from '@linode/api-v4/lib/linodes/types';
 import { pathOr } from 'ramda';
-import * as React from 'react';
 import { connect, MapStateToProps } from 'react-redux';
-import { branch, compose, renderComponent } from 'recompose';
-import NotFound from 'src/components/NotFound';
 import { ApplicationState } from 'src/store';
 import { eventsForLinode } from 'src/store/events/event.selectors';
 import { getLinodeConfigsForLinode } from 'src/store/linodes/config/config.selectors';
 import { getLinodeDisksForLinode } from 'src/store/linodes/disk/disk.selectors';
-import { findLinodeById } from 'src/store/linodes/linodes.selector';
 import { getPermissionsForLinode } from 'src/store/linodes/permissions/permissions.selector';
 import { getTypeById } from 'src/store/linodeType/linodeType.selector';
 import { getNotificationsForLinode } from 'src/store/notification/notification.selector';
@@ -38,7 +34,11 @@ export const mapStateToProps: MapStateToProps<
     linodeDisks,
     profile
   } = __resources;
-  const { linode, linodeId } = ownProps;
+  const { linodeId } = ownProps;
+  const linode = state.__resources.linodes.itemsById[linodeId];
+  if (!linode) {
+    return { linode: undefined };
+  }
   const { type } = linode;
 
   return {
@@ -59,25 +59,4 @@ export const mapStateToProps: MapStateToProps<
   };
 };
 
-/**
- * Retrieve the Linode and its extended information from Redux.
- * If the Linode cannot be found, render the NotFound component. (early return)
- */
-export default compose<InnerProps, OuterProps>(
-  connect((state: ApplicationState, ownProps: OuterProps) => {
-    const { linodeId } = ownProps;
-    return {
-      linode: findLinodeById(state.__resources.linodes, linodeId)
-    };
-  }),
-  branch(
-    /** If the Linode is found */
-    ({ linode }) => Boolean(linode),
-
-    /** Build the ExtendedLinode */
-    compose<InnerProps, OuterProps>(connect(mapStateToProps)),
-
-    /** Otherwise, render the NotFound component. */
-    renderComponent(() => <NotFound />)
-  )
-);
+export default connect(mapStateToProps);


### PR DESCRIPTION
This is a band-aid for the release, to resolve the issue where sometimes a 404 Not Found message is displayed when loading LinodesDetail.

There are 2 different "Not found" paths, which has previously been hidden since all Linodes were requested before LinodesDetail was ever loaded. Now you see both of these 404 messages in sequence (for a Linode that genuinely doesn't exist) or just the first one (for a Linode that hasn't been requested yet, or the request is in flight.)

A better solution will be to use `useReduxLoad` in LinodesDetail and only after `_loading` is false do all the things to extend the Linode, generate the needed actions/context/etc. This is too large a change for a patch to a release branch, so in the short term I adjusted what was already there to hide the duplicate 404 messages.