### PR TITLE
[for release] Fix Linode -> Resize bug

### DIFF
--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -397,7 +397,8 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
       error,
       header,
       types,
-      currentPlanHeading
+      currentPlanHeading,
+      selectedID
     } = this.props;
 
     const [tabs, tabOrder] = this.createTabs();
@@ -407,7 +408,9 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
     let selectedTypeClass: LinodeTypeClass = pathOr(
       'standard', // Use `standard` by default
       ['class'],
-      types.find(type => type.heading === currentPlanHeading)
+      types.find(
+        type => type.id === selectedID || type.heading === currentPlanHeading
+      )
     );
 
     // We don't have a "Nanodes" tab anymore, so use `standard` (labeled as "Shared CPU").

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -404,7 +404,7 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
 
     // Determine initial plan category tab based on current plan selection
     // (if there is one).
-    const selectedTypeClass: LinodeTypeClass = pathOr(
+    let selectedTypeClass: LinodeTypeClass = pathOr(
       'standard', // Use `standard` by default
       ['class'],
       types.find(type => type.heading === currentPlanHeading)

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -410,6 +410,11 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
       types.find(type => type.heading === currentPlanHeading)
     );
 
+    // We don't have a "Nanodes" tab anymore, so use `standard` (labeled as "Shared CPU").
+    if (selectedTypeClass === 'nanode') {
+      selectedTypeClass = 'standard';
+    }
+
     const initialTab = tabOrder.indexOf(selectedTypeClass);
 
     return (
@@ -419,7 +424,7 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
         header={header || 'Linode Plan'}
         copy={copy}
         tabs={tabs}
-        initTab={initialTab}
+        initTab={initialTab >= 0 ? initialTab : 0}
         data-qa-select-plan
       />
     );

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
@@ -284,38 +284,18 @@ export class SelectPlanPanel extends React.Component<
 
     const tabOrder: LinodeTypeClass[] = [];
 
-    if (!isEmpty(nanodes)) {
-      tabs.push({
-        render: () => {
-          return (
-            <>
-              {isOnCreate && (
-                <Typography data-qa-nanode className={classes.copy}>
-                  Nanode instances are good for low-duty workloads, where
-                  performance isn't critical.
-                </Typography>
-              )}
-              {this.renderPlanContainer(nanodes)}
-            </>
-          );
-        },
-        title: 'Nanode'
-      });
-      tabOrder.push('nanode');
-    }
+    const shared = [...nanodes, ...standards];
 
-    if (!isEmpty(standards)) {
+    if (!isEmpty(shared)) {
       tabs.push({
         render: () => {
           return (
             <>
-              {isOnCreate && (
-                <Typography data-qa-standard className={classes.copy}>
-                  Shared CPU instances are good for medium-duty workloads and
-                  are a good mix of performance, resources, and price.
-                </Typography>
-              )}
-              {this.renderPlanContainer(standards)}
+              <Typography data-qa-standard className={classes.copy}>
+                Shared CPU instances are good for medium-duty workloads and are
+                a good mix of performance, resources, and price.
+              </Typography>
+              {this.renderPlanContainer(shared)}
             </>
           );
         },
@@ -421,11 +401,16 @@ export class SelectPlanPanel extends React.Component<
 
     // Determine initial plan category tab based on current plan selection
     // (if there is one).
-    const selectedTypeClass: LinodeTypeClass = pathOr(
+    let selectedTypeClass: LinodeTypeClass = pathOr(
       'standard', // Use `standard` by default
       ['class'],
       types.find(type => type.heading === currentPlanHeading)
     );
+
+    // We don't have a "Nanodes" tab anymore, so use `standard` (labeled as "Shared CPU").
+    if (selectedTypeClass === 'nanode') {
+      selectedTypeClass = 'standard';
+    }
 
     const initialTab = tabOrder.indexOf(selectedTypeClass);
 
@@ -436,7 +421,7 @@ export class SelectPlanPanel extends React.Component<
         header={header || ' '}
         copy={copy}
         tabs={tabs}
-        initTab={initialTab}
+        initTab={initialTab >= 0 ? initialTab : 0}
         handleTabChange={() => resetValues()}
       />
     );

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
@@ -394,7 +394,8 @@ export class SelectPlanPanel extends React.Component<
       header,
       types,
       resetValues,
-      currentPlanHeading
+      currentPlanHeading,
+      selectedID
     } = this.props;
 
     const [tabs, tabOrder] = this.createTabs();
@@ -404,7 +405,9 @@ export class SelectPlanPanel extends React.Component<
     let selectedTypeClass: LinodeTypeClass = pathOr(
       'standard', // Use `standard` by default
       ['class'],
-      types.find(type => type.heading === currentPlanHeading)
+      types.find(
+        type => type.id === selectedID || type.heading === currentPlanHeading
+      )
     );
 
     // We don't have a "Nanodes" tab anymore, so use `standard` (labeled as "Shared CPU").


### PR DESCRIPTION
## Description

This fixes two regressions:

**Crashing bug on the Linode Resize tab when viewing a Nanode**
This happened when I removed the "Nanodes" tab, since it meant that the selected tab on Linode Resize was `-1`, which had bad consequences. To fix, I manually changed the selected class to "standard" for Nanodes, and added a tab select safeguard anyway. 

**Correct tab isn't selected when Cloning a Linode**
This fixes an old regression from here: https://github.com/linode/manager/commit/ccad3792cdf966f012b952b5fa3b82f12311a71c#diff-86d0256904fe6812859a8e7f376682f9R344 where cloning a Linode resulted in the Create page being opened without the correct plan tab selected.

Please test everything related to creating Linodes and viewing their details.
