### PR TITLE
[for release] Fix upgrade drawer for High Memory g6 -> g7 plans

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/MutationNotification.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/MutationNotification.tsx
@@ -164,7 +164,11 @@ const MutationNotification: React.FC<CombinedProps> = props => {
         <span
           className={classes.pendingMutationLink}
           onClick={openMutationDrawer}
-          onKeyDown={openMutationDrawer}
+          onKeyDown={e => {
+            if (e.key === 'Enter') {
+              openMutationDrawer();
+            }
+          }}
           role="button"
           tabIndex={0}
         >

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/MutationNotification.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/MutationNotification.tsx
@@ -164,7 +164,9 @@ const MutationNotification: React.FC<CombinedProps> = props => {
         <span
           className={classes.pendingMutationLink}
           onClick={openMutationDrawer}
+          onKeyDown={openMutationDrawer}
           role="button"
+          tabIndex={0}
         >
           click here.
         </span>
@@ -176,6 +178,10 @@ const MutationNotification: React.FC<CombinedProps> = props => {
         loading={mutationDrawerLoading}
         error={mutationDrawerError}
         handleClose={closeMutationDrawer}
+        isMovingFromSharedToDedicated={isMovingFromSharedToDedicated(
+          linodeType.id,
+          successorMetaData.id
+        )}
         mutateInfo={{
           vcpus:
             successorMetaData.vcpus !== vcpus ? successorMetaData.vcpus : null,
@@ -233,10 +239,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
   };
 };
 
-const connected = connect(
-  undefined,
-  mapDispatchToProps
-);
+const connected = connect(undefined, mapDispatchToProps);
 
 const enhanced = compose<CombinedProps, Props>(
   styled,
@@ -252,3 +255,8 @@ const enhanced = compose<CombinedProps, Props>(
 );
 
 export default enhanced(MutationNotification);
+
+// Hack solution to determine if a type is moving from shared CPU cores to dedicated.
+const isMovingFromSharedToDedicated = (typeA: string, typeB: string) => {
+  return typeA.startsWith('g6-highmem') && typeB.startsWith('g7-highmem');
+};

--- a/packages/manager/src/features/linodes/LinodesDetail/MutateDrawer/MutateDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/MutateDrawer/MutateDrawer.tsx
@@ -38,6 +38,7 @@ interface Props {
   loading: boolean;
   error: string;
   estimatedTimeToUpgradeInMins: number;
+  isMovingFromSharedToDedicated: boolean;
 }
 
 interface State {
@@ -110,30 +111,34 @@ class MutateDrawer extends React.Component<CombinedProps, State> {
           This Linode has pending upgrades. The resources that are affected
           include:
         </Typography>
-        <ul className="nonMUI-list">
-          {Object.keys(extendedUpgradeInfo).map(newSpec => {
-            const {
-              label,
-              currentAmount,
-              newAmount,
-              unit
-            } = extendedUpgradeInfo[newSpec];
+        {this.props.isMovingFromSharedToDedicated ? (
+          <HighmemG6ToG7 />
+        ) : (
+          <ul className="nonMUI-list">
+            {Object.keys(extendedUpgradeInfo).map(newSpec => {
+              const {
+                label,
+                currentAmount,
+                newAmount,
+                unit
+              } = extendedUpgradeInfo[newSpec];
 
-            if (newAmount === null) {
-              return;
-            }
-            return (
-              <ListItem key={label}>
-                <Typography>
-                  {label} goes from {currentAmount} {unit} to{' '}
-                  <strong>
-                    {newAmount} {unit}
-                  </strong>
-                </Typography>
-              </ListItem>
-            );
-          })}
-        </ul>
+              if (newAmount === null) {
+                return null;
+              }
+              return (
+                <ListItem key={label}>
+                  <Typography>
+                    {label} goes from {currentAmount} {unit} to{' '}
+                    <strong>
+                      {newAmount} {unit}
+                    </strong>
+                  </Typography>
+                </ListItem>
+              );
+            })}
+          </ul>
+        )}
         <Typography variant="h2" style={{ marginTop: 32, marginBottom: 16 }}>
           How it Works
         </Typography>
@@ -193,3 +198,15 @@ class MutateDrawer extends React.Component<CombinedProps, State> {
 }
 
 export default MutateDrawer;
+
+const HighmemG6ToG7: React.FC<{}> = () => {
+  return (
+    <ul className="nonMUI-list">
+      <ListItem>
+        <Typography>
+          Instance now contains <strong>dedicated CPU cores</strong>
+        </Typography>
+      </ListItem>
+    </ul>
+  );
+};


### PR DESCRIPTION
## Description

Currently there is logic to display a list of changing specs for upgrades. This doesn't work with g6 -> g7 High Memory upgrades, since the specs are the same. I added a hacky way around this.

## Note to Reviewers

To test, please try several combinations of different upgrades. Msg me for instructions if needed.
