### PR TITLE
M3-4085: Add a <Notice /> when user tries adding an NS record to a domain w/ no A/AAAA record

### DIFF
--- a/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
@@ -757,10 +757,17 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
 
   render() {
     const { submitting } = this.state;
-    const { open, mode, type } = this.props;
+    const { open, mode, type, records } = this.props;
     const { fields } = this.types[type];
     const isCreating = mode === 'create';
     const isDomain = type === 'master' || type === 'slave';
+
+    const recordsTypeA = records.filter(
+      record => record.type === 'A' || record.type === 'AAAA'
+    ); // Filter for & store any A/AAAA records. If populated and a user tries to add an NS record, they'll see a warning message asking them to add an A/AAAA record.
+
+    const noARecordsNoticeText =
+      'Please create an A/AAAA record for this domain.';
 
     const buttonProps: ButtonProps = {
       buttonType: 'primary',
@@ -790,6 +797,10 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
             return <Notice error key={index} text={err} />;
           })}
         {fields.map((field: any, idx: number) => field(idx))}
+
+        {recordsTypeA.length < 1 && type === 'NS' ? (
+          <Notice warning spacingTop={8} text={noARecordsNoticeText} />
+        ) : null}
         <ActionsPanel>
           <Button {...buttonProps} data-qa-record-save />
           <Button

--- a/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
@@ -796,9 +796,9 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
           otherErrors.map((err, index) => {
             return <Notice error key={index} text={err} />;
           })}
-        {!hasARecords && type === 'NS' ? (
+        {!hasARecords && type === 'NS' && (
           <Notice warning spacingTop={8} text={noARecordsNoticeText} />
-        ) : null}
+        )}
         {fields.map((field: any, idx: number) => field(idx))}
 
         <ActionsPanel>

--- a/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
@@ -762,12 +762,12 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
     const isCreating = mode === 'create';
     const isDomain = type === 'master' || type === 'slave';
 
-    const recordsTypeA = records.filter(
-      record => record.type === 'A' || record.type === 'AAAA'
-    ); // Filter for & store any A/AAAA records. If populated and a user tries to add an NS record, they'll see a warning message asking them to add an A/AAAA record.
+    const hasARecords = records.find(thisRecord =>
+      ['A', 'AAAA'].includes(thisRecord.type)
+    ); // If there are no A/AAAA records and a user tries to add an NS record, they'll see a warning message asking them to add an A/AAAA record.
 
     const noARecordsNoticeText =
-      'Please create an A/AAAA record for this domain.';
+      'Please create an A/AAAA record for this domain to avoid a Zone File invalidation.';
 
     const buttonProps: ButtonProps = {
       buttonType: 'primary',
@@ -796,11 +796,11 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
           otherErrors.map((err, index) => {
             return <Notice error key={index} text={err} />;
           })}
-        {fields.map((field: any, idx: number) => field(idx))}
-
-        {recordsTypeA.length < 1 && type === 'NS' ? (
+        {!hasARecords && type === 'NS' ? (
           <Notice warning spacingTop={8} text={noARecordsNoticeText} />
         ) : null}
+        {fields.map((field: any, idx: number) => field(idx))}
+
         <ActionsPanel>
           <Button {...buttonProps} data-qa-record-save />
           <Button


### PR DESCRIPTION
## Description
It is currently possible to create an NS record for a domain that does not have any A/AAAA records, but this results in an Invalid Zone file on the back-end.

After discussions with API, the consensus was that a solution on that end could be done, but would require some complicated checking and making users jump through hoops in a manner inconsistent with the specs. 

This PR sets out to reduce the number of these scenarios arising by displaying a notice to the user if they are trying to add an NS record on a domain that does not have an A/AAAA record.

## Type of Change
- Non breaking change ('update', 'change')
