### PR TITLE
STOR-34 Change: Added Size column on the OBJ Bucket Landing page

### DIFF
--- a/packages/api-v4/src/object-storage/types.ts
+++ b/packages/api-v4/src/object-storage/types.ts
@@ -24,6 +24,7 @@ export interface ObjectStorageBucket {
   created: string;
   cluster: string;
   hostname: string;
+  size: number; // Size of bucket in bytes
 }
 
 export interface ObjectStorageObject {

--- a/packages/manager/src/__data__/buckets.ts
+++ b/packages/manager/src/__data__/buckets.ts
@@ -5,12 +5,14 @@ export const buckets: ObjectStorageBucket[] = [
     label: 'test-bucket-001',
     created: '2019-02-20 18:46:15.516813',
     hostname: 'test-bucket-001.alpha.linodeobjects.com',
-    cluster: 'a-cluster'
+    cluster: 'us-east-1',
+    size: 5418860544
   },
   {
     label: 'test-bucket-002',
     created: '2019-02-24 18:46:15.516813',
     hostname: 'test-bucket-002.alpha.linodeobjects.com',
-    cluster: 'a-cluster'
+    cluster: 'a-cluster',
+    size: 1240
   }
 ];

--- a/packages/manager/src/factories/objectStorage.ts
+++ b/packages/manager/src/factories/objectStorage.ts
@@ -10,7 +10,8 @@ export const objectStorageBucketFactory = Factory.Sync.makeFactory<
   label: Factory.each(i => `obj-bucket-${i}`),
   hostname: Factory.each(i => `obj-bucket-${i}.us-east-1.linodeobjects.com`),
   cluster: 'us-east-1',
-  created: '2019-12-12T00:00:00'
+  created: '2019-12-12T00:00:00',
+  size: 999999
 });
 
 export const objectStorageClusterFactory = Factory.Sync.makeFactory<

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTable.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTable.test.tsx
@@ -30,6 +30,9 @@ describe('BucketTable', () => {
   it('renders a "Created" column', () => {
     expect(innerComponent.find('[data-qa-created]')).toHaveLength(1);
   });
+  it('renders a "Size" column', () => {
+    expect(innerComponent.find('[data-qa-size]')).toHaveLength(1);
+  });
   it('renders a RenderData component with the provided data', () => {
     expect(innerComponent.find('RenderData').prop('data')).toEqual(buckets);
   });

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTable.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTable.tsx
@@ -96,6 +96,15 @@ export const BucketTable: React.FC<CombinedProps> = props => {
                   >
                     Created
                   </TableSortCell>
+                  <TableSortCell
+                    active={orderBy === 'size'}
+                    label="size"
+                    direction={order}
+                    handleClick={handleOrderChange}
+                    data-qa-size
+                  >
+                    Size
+                  </TableSortCell>
                   {/* Empty TableCell for ActionMenu*/}
                   <TableCell />
                 </TableRow>

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.test.tsx
@@ -1,9 +1,11 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
+import { buckets } from 'src/__data__/buckets';
 import { Props as ActionMenuProps } from './BucketActionMenu';
 import { BucketTableRow } from './BucketTableRow';
 
 const mockOnRemove = jest.fn();
+const bucket = buckets[0];
 
 describe('BucketTableRow', () => {
   const wrapper = shallow(
@@ -13,10 +15,11 @@ describe('BucketTableRow', () => {
         bucketRow: '',
         link: ''
       }}
-      label="test-bucket-001"
-      created="2019-02-24 18:46:15.516813"
-      hostname="test-bucket-001.alpha.linodeobjects.com"
-      cluster="us-east-1"
+      label={bucket.label}
+      cluster={bucket.cluster}
+      hostname={bucket.hostname}
+      created={bucket.created}
+      size={bucket.size}
       onRemove={mockOnRemove}
     />
   );
@@ -54,8 +57,12 @@ describe('BucketTableRow', () => {
 
   it('should render a DateTimeDisplay with the provided date', () => {
     expect(wrapper.find('[data-qa-created]').prop('value')).toBe(
-      '2019-02-24 18:46:15.516813'
+      '2019-02-20 18:46:15.516813'
     );
+  });
+
+  it('should render a size with the correct size abbreviation', () => {
+    expect(wrapper.find('[data-qa-size]').text()).toBe('5.05 GB');
   });
 
   it('should render an Action Menu', () => {

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.tsx
@@ -13,6 +13,7 @@ import Grid from 'src/components/Grid';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import { formatObjectStorageCluster } from 'src/utilities/formatRegion';
+import { readableBytes } from 'src/utilities/unitConversions';
 import BucketActionMenu from './BucketActionMenu';
 
 type ClassNames = 'bucketNameWrapper' | 'bucketRow' | 'link';
@@ -42,7 +43,7 @@ interface BucketTableRowProps extends ObjectStorageBucket {
 type CombinedProps = BucketTableRowProps & WithStyles<ClassNames>;
 
 export const BucketTableRow: React.FC<CombinedProps> = props => {
-  const { classes, label, cluster, hostname, created, onRemove } = props;
+  const { classes, label, cluster, hostname, created, size, onRemove } = props;
 
   return (
     <TableRow
@@ -87,6 +88,11 @@ export const BucketTableRow: React.FC<CombinedProps> = props => {
           humanizeCutoff="month"
           data-qa-created
         />
+      </TableCell>
+      <TableCell parentColumn="Size">
+        <Typography variant="body2" data-qa-size>
+          {readableBytes(size).formatted}
+        </Typography>
       </TableCell>
       <TableCell>
         <BucketActionMenu

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.test.tsx
@@ -33,7 +33,7 @@ describe('CreateBucketForm', () => {
 
 describe('isDuplicateBucket helper function', () => {
   it('returns `true` if the label and cluster match a bucket in the data', () => {
-    const result = isDuplicateBucket(buckets, 'test-bucket-001', 'a-cluster');
+    const result = isDuplicateBucket(buckets, 'test-bucket-001', 'us-east-1');
     expect(result).toBe(true);
   });
   it('returns `false` if only the label matches', () => {


### PR DESCRIPTION
This will allow users to quickly see their total space utilization by bucket. This is still pending review from the API side before this PR is functional.

Once that side of things goes through, combined with this should resolve #6256.