### PR TITLE
Remove outdated command in Create Linode smoke test

### DIFF
--- a/packages/manager/cypress/integration/linodes/smoke-create-linode.spec.ts
+++ b/packages/manager/cypress/integration/linodes/smoke-create-linode.spec.ts
@@ -18,7 +18,6 @@ describe('create linode', () => {
     cy.contains('Regions')
       .click()
       .type('new {enter}');
-    cy.contains('Nanode').click();
     cy.get('[data-qa-plan-row="Nanode 1GB"]').click();
     cy.get('#linode-label')
       .click()


### PR DESCRIPTION
## Description

Now that the "Nanode" tab is gone, this line in the create Linode smoke test is unnecessary. 

## Note to Reviewers

**To test:** 

```
yarn cy:e2e --spec cypress/integration/linodes/smoke-create-linode.spec.ts
```
