### PR TITLE
Fix sort order on Domains Landing

### DIFF
--- a/packages/manager/src/__data__/domains.ts
+++ b/packages/manager/src/__data__/domains.ts
@@ -15,7 +15,7 @@ export const domain1: Domain = {
   soa_email: 'user@host.com',
   status: 'active',
   ttl_sec: 0,
-  updated: '2020-05-01 00:00:00'
+  updated: '2020-05-03 00:00:00'
 };
 
 export const domain2: Domain = {
@@ -51,7 +51,7 @@ export const domain3: Domain = {
   soa_email: 'user@host.com',
   status: 'active',
   ttl_sec: 0,
-  updated: '2020-05-03 00:00:00'
+  updated: '2020-05-01 00:00:00'
 };
 
 export const domains = [domain1, domain2, domain3];

--- a/packages/manager/src/components/EntityTable/EntityTable.tsx
+++ b/packages/manager/src/components/EntityTable/EntityTable.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import TableCell from 'src/components/core/TableCell';
 import Typography from 'src/components/core/Typography';
-import OrderBy from 'src/components/OrderBy';
+import OrderBy, { OrderByProps } from 'src/components/OrderBy';
 import TableSortCell from 'src/components/TableSortCell';
 import GroupedEntitiesByTag from './GroupedEntitiesByTag';
 import ListEntities from './ListEntities';
@@ -23,19 +23,28 @@ interface Props {
   headers: HeaderCell[];
   groupByTag: boolean;
   row: EntityTableRow<any>;
+  initialOrder?: {
+    order: OrderByProps['order'];
+    orderBy: OrderByProps['orderBy'];
+  };
 }
 
 export type CombinedProps = Props;
 
 export const LandingTable: React.FC<Props> = props => {
-  const { entity, headers, groupByTag, row } = props;
+  const { entity, headers, groupByTag, row, initialOrder } = props;
   const classes = useStyles();
   return (
-    <OrderBy data={row.data} orderBy={'label'} order={'asc'}>
+    <OrderBy
+      data={row.data}
+      orderBy={initialOrder?.orderBy}
+      order={initialOrder?.order}
+    >
       {({ data: orderedData, handleOrderChange, order, orderBy }) => {
         const headerCells = headers.map((thisCell: HeaderCell) => {
           return thisCell.sortable ? (
             <TableSortCell
+              key={thisCell.dataColumn}
               active={orderBy === thisCell.dataColumn}
               label={thisCell.dataColumn}
               direction={order}
@@ -47,6 +56,7 @@ export const LandingTable: React.FC<Props> = props => {
             </TableSortCell>
           ) : (
             <TableCell
+              key={thisCell.dataColumn}
               data-testid={`${thisCell.label}-header-cell`}
               style={{ width: thisCell.widthPercent }}
             >

--- a/packages/manager/src/components/EntityTable/EntityTable_CMR.tsx
+++ b/packages/manager/src/components/EntityTable/EntityTable_CMR.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import TableCell from 'src/components/core/TableCell';
 import Typography from 'src/components/core/Typography';
-import OrderBy from 'src/components/OrderBy';
+import OrderBy, { OrderByProps } from 'src/components/OrderBy';
 import TableSortCell from 'src/components/TableSortCell';
 import GroupedEntitiesByTag from './GroupedEntitiesByTag';
 import ListEntities from './ListEntities';
@@ -23,19 +23,28 @@ interface Props {
   headers: HeaderCell[];
   groupByTag: boolean;
   row: EntityTableRow<any>;
+  initialOrder?: {
+    order: OrderByProps['order'];
+    orderBy: OrderByProps['orderBy'];
+  };
 }
 
 export type CombinedProps = Props;
 
 export const LandingTable: React.FC<Props> = props => {
-  const { entity, headers, groupByTag, row } = props;
+  const { entity, headers, groupByTag, row, initialOrder } = props;
   const classes = useStyles();
   return (
-    <OrderBy data={row.data} orderBy={'label'} order={'asc'}>
+    <OrderBy
+      data={row.data}
+      orderBy={initialOrder?.orderBy}
+      order={initialOrder?.order}
+    >
       {({ data: orderedData, handleOrderChange, order, orderBy }) => {
         const headerCells = headers.map((thisCell: HeaderCell) => {
           return thisCell.sortable ? (
             <TableSortCell
+              key={thisCell.dataColumn}
               active={orderBy === thisCell.dataColumn}
               label={thisCell.dataColumn}
               direction={order}
@@ -47,6 +56,7 @@ export const LandingTable: React.FC<Props> = props => {
             </TableSortCell>
           ) : (
             <TableCell
+              key={thisCell.dataColumn}
               data-testid={`${thisCell.label}-header-cell`}
               style={{ width: thisCell.widthPercent }}
             >

--- a/packages/manager/src/features/Domains/DomainsLanding.test.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.test.tsx
@@ -1,9 +1,11 @@
-import { render } from '@testing-library/react';
+import { render, cleanup } from '@testing-library/react';
 import * as React from 'react';
 import { domains } from 'src/__data__/domains';
 import { reactRouterProps } from 'src/__data__/reactRouterProps';
-import { wrapWithTheme } from 'src/utilities/testHelpers';
+import { wrapWithTheme, assertOrder } from 'src/utilities/testHelpers';
 import { CombinedProps, DomainsLanding } from './DomainsLanding';
+
+afterEach(cleanup);
 
 const props: CombinedProps = {
   domainsData: domains,
@@ -13,7 +15,7 @@ const props: CombinedProps = {
   domainsResults: domains.length,
   isRestrictedUser: false,
   howManyLinodesOnAccount: 0,
-  shouldGroupDomains: true,
+  shouldGroupDomains: false,
   createDomain: jest.fn(),
   updateDomain: jest.fn(),
   deleteDomain: jest.fn(),
@@ -53,5 +55,15 @@ describe('Domains Landing', () => {
   it('should render a notice when there are no Linodes but at least 1 domain', () => {
     const { getByText } = render(wrapWithTheme(<DomainsLanding {...props} />));
     expect(getByText(/not being served/));
+  });
+
+  it('should sort by Domain name ascending by default', () => {
+    const { container } = render(wrapWithTheme(<DomainsLanding {...props} />));
+
+    assertOrder(container, '[data-qa-label]', [
+      'domain1.com',
+      'domain2.com',
+      'domain3.com'
+    ]);
   });
 });

--- a/packages/manager/src/features/Domains/DomainsLanding.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.tsx
@@ -477,6 +477,7 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
                     groupByTag={domainsAreGrouped}
                     row={domainRow}
                     headers={headers}
+                    initialOrder={{ order: 'asc', orderBy: 'domain' }}
                   />
                 </Grid>
               </React.Fragment>

--- a/packages/manager/src/utilities/testHelpers.tsx
+++ b/packages/manager/src/utilities/testHelpers.tsx
@@ -155,3 +155,24 @@ export const withMarkup = (query: Query) => (text: string): HTMLElement =>
     );
     return hasText(node) && childrenDontHaveText;
   });
+
+/**
+ * Assert that HTML elements appear in a specific order. `selectorAttribute` must select the parent
+ * node of each piece of text content you are selecting.
+ *
+ * Example usage:
+ * const { container } = render(<MyComponent />);
+ * assertOrder(container, '[data-qa-label]', ['el1', 'el2', 'el3']);
+ *
+ * Thanks to https://spectrum.chat/testing-library/general/how-to-test-the-order-of-elements~23c8eaee-0fab-4bc6-8ca9-aa00a9582f8c?m=MTU3MjU0NTM0MTgyNw==
+ */
+export const assertOrder = (
+  container: HTMLElement,
+  selectorAttribute: string,
+  expectedOrder: string[]
+) => {
+  const elements = container.querySelectorAll(selectorAttribute);
+  expect(Array.from(elements).map(el => el.textContent)).toMatchObject(
+    expectedOrder
+  );
+};


### PR DESCRIPTION
## Description

Originally reported in https://github.com/linode/manager/issues/6550. It looks like this was a regression from the EntityTable component.

To fix, I added an optional `initialOrder` prop to `<EntityTable />`, which is passed down to the `order` and `orderBy` props on `<OrderBy />`. 

This new prop is optional since `<OrderBy />` defaults them to `label` and `asc` anyway.

I also added a test to ensure default order (as well as a helper function for testing order of elements).

## Note to Reviewers

**To test,** have a handful of domains starting with different names. On page load, they should be sorted by Domain name ascending. All other sort functions should be unaffected.

To run new unit test: `yarn test packages/manager/src/utilities/testHelpers.tsx`
