### PR TITLE
readableBytes: handle invalid input better

### DIFF
--- a/packages/manager/src/utilities/unitConversions.test.ts
+++ b/packages/manager/src/utilities/unitConversions.test.ts
@@ -4,7 +4,7 @@ import {
   ReadableBytesOptions
 } from './unitConversions';
 
-describe('conversion helper functinos', () => {
+describe('conversion helper functions', () => {
   describe('readableBytes', () => {
     it('should return "0 bytes" if bytes === 0', () => {
       expect(readableBytes(0).formatted).toBe('0 bytes');
@@ -117,6 +117,18 @@ describe('conversion helper functinos', () => {
       expect(readableBytes(0.5, { round: 1 }).formatted).toBe('0.5 bytes');
       expect(readableBytes(0.05, { round: 1 }).formatted).toBe('0.1 bytes');
       expect(readableBytes(0.05, { round: 2 }).formatted).toBe('0.05 bytes');
+    });
+
+    it('returns 0 bytes if the input is invalid', () => {
+      // This behavior is debatable. It's for potential situations where we mistakenly pass a
+      // nun-number value to readableBytes (something we didn't handle/expect from the API, etc.).
+      // Before adding this behavior, we were displaying "NaN bytes" in these situations. We could
+      // throw an error and let consumers handle each case (or display an error message) but this
+      // seemed the most straightforward path to me.
+      expect(readableBytes(undefined as any).value).toBe(0);
+      expect(readableBytes(undefined as any).formatted).toBe('0 bytes');
+      expect(readableBytes('invalid' as any).formatted).toBe('0 bytes');
+      expect(readableBytes({} as any).formatted).toBe('0 bytes');
     });
 
     it('allows custom unit labels', () => {

--- a/packages/manager/src/utilities/unitConversions.ts
+++ b/packages/manager/src/utilities/unitConversions.ts
@@ -73,9 +73,12 @@ export const readableBytes = (
     });
   }
 
-  // If the value is 0, go ahead and return, because the
-  // subsequent math won't work out
-  if (num === 0 || (options.handleNegatives === false && num < 0)) {
+  // If the value is 0 or invalid, go ahead and return because the subsequent math won't work out
+  if (
+    num === 0 ||
+    (options.handleNegatives === false && num < 0) ||
+    typeof num !== 'number'
+  ) {
     return {
       value: 0,
       unit: storageUnits[0],


### PR DESCRIPTION
## Description

Our `readableBytes` function doesn't handle invalid input very well:

![Screen Shot 2020-06-18 at 9 17 25 AM](https://user-images.githubusercontent.com/16911484/85024808-968df680-b144-11ea-82d6-4bb66e0eab80.png)

Theoretically this shouldn't happen, but just in case, I changed the behavior to return `0 bytes` instead. 

## Note to Reviewers

Nothing should have changed, so just for regressions in places that use `readableBytes` and run the new tests.
