### PR TITLE
Remove unneeded .then() from K8s request in useKubernetes

### DIFF
--- a/packages/manager/src/hooks/useEntities.ts
+++ b/packages/manager/src/hooks/useEntities.ts
@@ -70,8 +70,7 @@ export const useEntities = () => {
     },
     kubernetesClusters: {
       data: kubernetesClusters,
-      request: () =>
-        requestKubernetesClusters().then(response => response.data),
+      request: () => requestKubernetesClusters(),
       lastUpdated: _kubernetesClusters.lastUpdated,
       error: _kubernetesClusters.error?.read
     },

--- a/packages/manager/src/hooks/useKubernetesClusters.ts
+++ b/packages/manager/src/hooks/useKubernetesClusters.ts
@@ -15,7 +15,8 @@ export const useKubernetesClusters = () => {
   const kubernetesClusters = useSelector(
     (state: ApplicationState) => state.__resources.kubernetes
   );
-  const requestKubernetesClusters = () => dispatch(_request());
+  const requestKubernetesClusters = () =>
+    dispatch(_request()).then(response => response.data);
 
   return { kubernetesClusters, requestKubernetesClusters };
 };

--- a/packages/manager/src/store/kubernetes/kubernetes.requests.ts
+++ b/packages/manager/src/store/kubernetes/kubernetes.requests.ts
@@ -36,7 +36,7 @@ export const requestKubernetesClusters: ThunkActionCreator<Promise<
           result: response
         })
       );
-      return response.data;
+      return response;
     })
     .catch(error => {
       dispatch(requestClustersActions.failed({ error }));


### PR DESCRIPTION
## Description

Regression/bug that was brought up through PIE. Selecting an LKE cluster when creating a support ticket worked only if you had previously navigated somewhere else in the app that requested clusters. The request was being made correctly in the drawer, but a type mismatch meant that the data returned from the request was `undefined`. 

To test:

1. Have at least one LKE cluster on your account
1. Go directly to /support/tickets
2. Reload the page to be safe
3. Select LKE as the entity type
4. Observe: a request should be made and the "Select a cluster" dropdown should be populated with your clusters.

NOTE: the back end for this is still not working correctly, so if you actually open a support ticket with a cluster id, the entity won't show up in the tickets table.