### PR TITLE
TDT: Images hooks and redux

### DIFF
--- a/packages/manager/src/containers/withImage.container.ts
+++ b/packages/manager/src/containers/withImage.container.ts
@@ -13,7 +13,7 @@ export default <TInner extends {}, TOuter extends {}>(
       return { image: null };
     }
 
-    const image = state.__resources.images.data[imageId];
+    const image = state.__resources.images.itemsById[imageId];
 
     return mapImageToProps(ownProps, image);
   });

--- a/packages/manager/src/containers/withImages.container.ts
+++ b/packages/manager/src/containers/withImages.container.ts
@@ -43,7 +43,7 @@ export default <TInner extends {}, TOuter extends {}>(
 ) =>
   connect((state: ApplicationState, ownProps: TOuter) => {
     const {
-      data: imagesData,
+      itemsById: imagesData,
       error: imagesError,
       loading,
       lastUpdated

--- a/packages/manager/src/features/Images/ImagesLanding.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding.tsx
@@ -510,9 +510,9 @@ const mapDispatchToProps: MapDispatchToProps<ImageDispatch, {}> = (
 
 const withPrivateImages = connect(
   (state: ApplicationState): WithPrivateImages => {
-    const { error, data, lastUpdated, loading } = state.__resources.images;
+    const { error, itemsById, lastUpdated, loading } = state.__resources.images;
     const events = imageEvents(state.events);
-    const privateImagesWithEvents = Object.values(data).reduce(
+    const privateImagesWithEvents = Object.values(itemsById).reduce(
       (accum, thisImage) =>
         produce(accum, draft => {
           if (!thisImage.is_public) {

--- a/packages/manager/src/features/linodes/MigrateLanding/MigrateLanding.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/MigrateLanding.tsx
@@ -280,9 +280,9 @@ const mapStateToProps: MapStateToProps<
   WithTypesAndImages,
   {},
   ApplicationState
-> = (state, ownProps) => ({
+> = state => ({
   types: state.__resources.types.entities,
-  images: state.__resources.images.data,
+  images: state.__resources.images.itemsById,
   notifications: state.__resources.notifications.data || []
 });
 
@@ -301,13 +301,11 @@ const getDisabledReason = (
   linodeID: number,
   notifications: Notification[]
 ) => {
-  if (events[0]) {
-    if (
-      events[0].action === 'linode_migrate_datacenter' &&
-      events[0].percent_complete !== 100
-    ) {
-      return `Your Linode is currently being migrated.`;
-    }
+  if (
+    events[0]?.action === 'linode_migrate_datacenter' &&
+    events[0]?.percent_complete !== 100
+  ) {
+    return `Your Linode is currently being migrated.`;
   }
 
   /**

--- a/packages/manager/src/hooks/useEntities.ts
+++ b/packages/manager/src/hooks/useEntities.ts
@@ -48,7 +48,7 @@ export const useEntities = () => {
 
   const domains = Object.values(_domains.itemsById);
   const linodes = Object.values(_linodes.itemsById);
-  const images = (Object.values(_images.data) ?? []).filter(
+  const images = (Object.values(_images.itemsById) ?? []).filter(
     thisImage => !thisImage.is_public
   );
   const volumes = Object.values(_volumes.itemsById);

--- a/packages/manager/src/hooks/useImages.test.ts
+++ b/packages/manager/src/hooks/useImages.test.ts
@@ -1,6 +1,7 @@
+import { renderHook } from '@testing-library/react-hooks';
 import { imageFactory } from 'src/factories/images';
 import { apiResponseToMappedState } from 'src/store/store.helpers';
-import { filterImages } from './useImages';
+import { filterImages, useImages } from './useImages';
 
 const publicImages = apiResponseToMappedState(
   imageFactory.buildList(10, { is_public: true })
@@ -13,16 +14,27 @@ const allImages = {
   ...privateImages
 };
 
-describe('Filtering images', () => {
-  it('should return public images only when public is specified', () => {
-    expect(filterImages('public', allImages)).toEqual(publicImages);
+describe('useHooks', () => {
+  describe('Filtering images', () => {
+    it('should return public images only when public is specified', () => {
+      expect(filterImages('public', allImages)).toEqual(publicImages);
+    });
+
+    it('should return private images only when private is specified', () => {
+      expect(filterImages('private', allImages)).toEqual(privateImages);
+    });
+
+    it('should return all images when all is specified', () => {
+      expect(filterImages('all', allImages)).toEqual(allImages);
+    });
   });
 
-  it('should return private images only when private is specified', () => {
-    expect(filterImages('private', allImages)).toEqual(privateImages);
-  });
-
-  it('should return all images when all is specified', () => {
-    expect(filterImages('all', allImages)).toEqual(allImages);
+  describe('basic hook usage', () => {
+    it('returns the correct data from Redux', () => {
+      // This test only works because of the cached Images data we use to
+      // initialize the store.
+      const { result } = renderHook(() => useImages());
+      expect(result.current.images.lastUpdated).toBe(0);
+    });
   });
 });

--- a/packages/manager/src/hooks/useImages.test.ts
+++ b/packages/manager/src/hooks/useImages.test.ts
@@ -1,0 +1,28 @@
+import { imageFactory } from 'src/factories/images';
+import { apiResponseToMappedState } from 'src/store/store.helpers';
+import { filterImages } from './useImages';
+
+const publicImages = apiResponseToMappedState(
+  imageFactory.buildList(10, { is_public: true })
+);
+const privateImages = apiResponseToMappedState(
+  imageFactory.buildList(10, { is_public: false })
+);
+const allImages = {
+  ...publicImages,
+  ...privateImages
+};
+
+describe('Filtering images', () => {
+  it('should return public images only when public is specified', () => {
+    expect(filterImages('public', allImages)).toEqual(publicImages);
+  });
+
+  it('should return private images only when private is specified', () => {
+    expect(filterImages('private', allImages)).toEqual(privateImages);
+  });
+
+  it('should return all images when all is specified', () => {
+    expect(filterImages('all', allImages)).toEqual(allImages);
+  });
+});

--- a/packages/manager/src/hooks/useImages.test.tsx
+++ b/packages/manager/src/hooks/useImages.test.tsx
@@ -1,5 +1,8 @@
 import { renderHook } from '@testing-library/react-hooks';
+import * as React from 'react';
+import { Provider } from 'react-redux';
 import { imageFactory } from 'src/factories/images';
+import store from 'src/store';
 import { apiResponseToMappedState } from 'src/store/store.helpers';
 import { filterImages, useImages } from './useImages';
 
@@ -33,7 +36,10 @@ describe('useHooks', () => {
     it('returns the correct data from Redux', () => {
       // This test only works because of the cached Images data we use to
       // initialize the store.
-      const { result } = renderHook(() => useImages());
+      const wrapper = ({ children }: any) => (
+        <Provider store={store}>{children}</Provider>
+      );
+      const { result } = renderHook(() => useImages(), { wrapper });
       expect(result.current.images.lastUpdated).toBe(0);
     });
   });

--- a/packages/manager/src/hooks/useImages.ts
+++ b/packages/manager/src/hooks/useImages.ts
@@ -12,12 +12,35 @@ export interface ImagesProps {
 
 export type Filter = 'public' | 'private' | 'all';
 
+/**
+ * This works the same as all of our other entity hooks,
+ * but since filtering public or private images is such
+ * a common task, it's included here as an optional argument.
+ *
+ * Usage:
+ *
+ * const { images } = useImages(); // This is totally fine!
+ * const { images: publicImages } = useImages('public');
+ *
+ * publicImages.itemsById will contain only public images.
+ * publicImages.results will be the number of public images.
+ *
+ * @param filter
+ */
 export const useImages = (filter: Filter = 'all') => {
   const dispatch: Dispatch = useDispatch();
-  const images = useSelector(
+  const _images = useSelector(
     (state: ApplicationState) => state.__resources.images
   );
   const requestImages = () => dispatch(_request());
+
+  const filteredImages = filterImages(filter, _images.itemsById);
+
+  const images = {
+    ..._images,
+    itemsById: filteredImages,
+    results: Object.keys(filteredImages).length
+  };
 
   return { images, requestImages };
 };

--- a/packages/manager/src/hooks/useImages.ts
+++ b/packages/manager/src/hooks/useImages.ts
@@ -10,7 +10,9 @@ export interface ImagesProps {
   requestImages: () => Promise<Image[]>;
 }
 
-export const useImages = () => {
+export type Filter = 'public' | 'private' | 'all';
+
+export const useImages = (filter: Filter = 'all') => {
   const dispatch: Dispatch = useDispatch();
   const images = useSelector(
     (state: ApplicationState) => state.__resources.images
@@ -18,6 +20,23 @@ export const useImages = () => {
   const requestImages = () => dispatch(_request());
 
   return { images, requestImages };
+};
+
+export const filterImages = (
+  filter: Filter,
+  images: Record<string, Image>
+): Record<string, Image> => {
+  if (filter === 'all') {
+    return images;
+  }
+
+  const isPublic = filter === 'public';
+
+  return Object.values(images).reduce((accum, thisImage) => {
+    return thisImage.is_public === isPublic
+      ? { ...accum, [thisImage.id]: thisImage }
+      : accum;
+  }, {});
 };
 
 export default useImages;

--- a/packages/manager/src/store/firewalls/firewalls.reducer.ts
+++ b/packages/manager/src/store/firewalls/firewalls.reducer.ts
@@ -43,7 +43,7 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
   }
 
   if (isType(action, createFirewallActions.started)) {
-    setError({ create: undefined }, state);
+    return setError({ create: undefined }, state);
   }
 
   if (isType(action, createFirewallActions.done)) {
@@ -61,7 +61,7 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
     isType(action, updateFirewallActions.started) ||
     isType(action, updateFirewallRulesActions.started)
   ) {
-    setError({ update: undefined }, state);
+    return setError({ update: undefined }, state);
   }
 
   if (isType(action, updateFirewallActions.done)) {

--- a/packages/manager/src/store/image/image.actions.ts
+++ b/packages/manager/src/store/image/image.actions.ts
@@ -36,3 +36,12 @@ export const requestImageForStoreActions = actionCreator.async<
   Image,
   APIError[]
 >('request-image');
+
+export interface DeleteImagePayload {
+  imageID: string;
+}
+export const deleteImageActions = actionCreator.async<
+  DeleteImagePayload,
+  {},
+  APIError[]
+>('delete');

--- a/packages/manager/src/store/image/image.reducer.test.ts
+++ b/packages/manager/src/store/image/image.reducer.test.ts
@@ -32,7 +32,7 @@ describe('Images reducer', () => {
         { ...defaultState, loading: true },
         requestImagesActions.done({ result: mockImages })
       );
-      expect(newState.data).toEqual(mockImagesNormalized);
+      expect(newState.itemsById).toEqual(mockImagesNormalized);
       expect(newState.results).toEqual(mockImages.length);
       expect(newState.loading).toBe(false);
       expect(newState.lastUpdated).toBeGreaterThan(0);
@@ -57,7 +57,7 @@ describe('Images reducer', () => {
       });
       const newState = reducer(withEntities, upsertImage(newImage));
       expect(newState.results).toEqual(mockImages.length + 1);
-      expect(newState.data['private/9999']).toEqual(newImage);
+      expect(newState.itemsById['private/9999']).toEqual(newImage);
     });
 
     it('should update an existing cluster', () => {
@@ -70,7 +70,7 @@ describe('Images reducer', () => {
       const newState = reducer(withEntities, upsertImage(updatedImage));
       // Length should be unchanged
       expect(newState.results).toEqual(mockImages.length);
-      expect(newState.data[mockImages[1].id]).toEqual(updatedImage);
+      expect(newState.itemsById[mockImages[1].id]).toEqual(updatedImage);
     });
   });
 
@@ -83,7 +83,7 @@ describe('Images reducer', () => {
       );
       const newState = reducer(withImages, removeImage(12345));
       expect(newState.results).toEqual(mockImages.length);
-      expect(newState.data['private/12345']).toBeUndefined();
+      expect(newState.itemsById['private/12345']).toBeUndefined();
     });
 
     it('should remove an image by full string id', () => {
@@ -94,7 +94,7 @@ describe('Images reducer', () => {
       );
       const newState = reducer(withImages, removeImage('private/12345'));
       expect(newState.results).toEqual(mockImages.length);
-      expect(newState.data['private/12345']).toBeUndefined();
+      expect(newState.itemsById['private/12345']).toBeUndefined();
     });
 
     it("should return the state unchanged if the id doesn't match", () => {
@@ -111,8 +111,7 @@ describe('Images reducer', () => {
         defaultState,
         createImageActions.done({ result: newImage, params: mockParams })
       );
-      expect(newState.data[newImage.id]).toEqual(newImage);
-      expect(newState.lastUpdated).toBeGreaterThan(0);
+      expect(newState.itemsById[newImage.id]).toEqual(newImage);
       expect(newState.results).toEqual(1);
       expect(newState.error.create).toBeUndefined();
     });
@@ -147,7 +146,7 @@ describe('Images reducer', () => {
           result: updatedImage
         })
       );
-      expect(newState.data[updatedImage.id]).toEqual(updatedImage);
+      expect(newState.itemsById[updatedImage.id]).toEqual(updatedImage);
     });
 
     it('should handle a failed update', () => {
@@ -163,14 +162,6 @@ describe('Images reducer', () => {
   });
 
   describe('Requesting a single Image', () => {
-    it('should initiate the request', () => {
-      const newState = reducer(
-        { ...defaultState, error: { read: mockError } },
-        requestImageForStoreActions.started('private/1234')
-      );
-      expect(newState.error.read).toBeUndefined();
-    });
-
     it('should handle a successful request', () => {
       const withEntities = addEntities();
       const updatedImage = { ...mockImages[3], label: 'my-label-is-updated' };
@@ -181,18 +172,7 @@ describe('Images reducer', () => {
           params: 'private/1234'
         })
       );
-      expect(newState.data[mockImages[3].id]).toEqual(updatedImage);
-    });
-
-    it('should handle a failed request', () => {
-      const newState = reducer(
-        defaultState,
-        requestImageForStoreActions.failed({
-          params: 'private/1234',
-          error: mockError
-        })
-      );
-      expect(newState.error.read).toEqual(mockError);
+      expect(newState.itemsById[mockImages[3].id]).toEqual(updatedImage);
     });
   });
 });

--- a/packages/manager/src/store/image/image.requests.ts
+++ b/packages/manager/src/store/image/image.requests.ts
@@ -1,5 +1,6 @@
 import {
   createImage as _create,
+  deleteImage as _delete,
   getImage,
   getImages,
   Image,
@@ -9,6 +10,7 @@ import { getAll } from 'src/utilities/getAll';
 import { createRequestThunk } from '../store.helpers';
 import {
   createImageActions,
+  deleteImageActions,
   requestImageForStoreActions,
   requestImagesActions,
   updateImageActions
@@ -38,4 +40,9 @@ export const updateImage = createRequestThunk(
   updateImageActions,
   ({ label, description, imageID }) =>
     _update(imageID, label, description).then(response => response.data)
+);
+
+export const deleteImage = createRequestThunk(
+  deleteImageActions,
+  ({ imageID }) => _delete(imageID)
 );

--- a/packages/manager/src/store/selectors/getSearchEntities.ts
+++ b/packages/manager/src/store/selectors/getSearchEntities.ts
@@ -151,7 +151,7 @@ const linodeSelector = (state: State) => Object.values(state.linodes.itemsById);
 const volumeSelector = ({ volumes }: State) => Object.values(volumes.itemsById);
 const nodebalSelector = ({ nodeBalancers }: State) =>
   Object.values(nodeBalancers.itemsById);
-const imageSelector = (state: State) => state.images.data || {};
+const imageSelector = (state: State) => state.images.itemsById || {};
 const domainSelector = (state: State) =>
   Object.values(state.domains.itemsById) || [];
 const typesSelector = (state: State) => state.types.entities;

--- a/packages/manager/src/store/selectors/getSearchEntitites.test.ts
+++ b/packages/manager/src/store/selectors/getSearchEntitites.test.ts
@@ -13,7 +13,7 @@ describe('getSearchEntities selector', () => {
     linodes: {
       itemsById: apiResponseToMappedState(linodes)
     },
-    images: { entities: images },
+    images: { itemsById: apiResponseToMappedState(images) },
     types: { entities: types },
     volumes: {
       itemsById: volumes.reduce((result, c) => ({ ...result, [c.id]: c }), {})

--- a/packages/manager/src/utilities/getEntityByIDFromStore.ts
+++ b/packages/manager/src/utilities/getEntityByIDFromStore.ts
@@ -46,7 +46,7 @@ const _getEntityByIDFromStore = (
     case 'linode':
       return linodes.itemsById[entityID];
     case 'image':
-      return (images.data || {})[entityID];
+      return (images.itemsById || {})[entityID];
     case 'nodebalancer':
       return nodeBalancers.itemsById[entityID];
     case 'domain':


### PR DESCRIPTION
## Description

Started out trying to add a `public` filter to the useImages hook, since it seemed useful. Led me down the usual TDT rabbit hole, I ended up:

- Refactoring Images in Redux to use the current state shape
- Added some tests for the useImages hook
- Fixed a few bugs in the Firewalls reducer

## Note

To test, please make sure that all Images functionality is unchanged (CRUD-ing images, displaying them in tables, searching for them, etc.)