### PR TITLE
M3-4255 Ignore network errors in Sentry

### DIFF
--- a/packages/manager/src/exceptionReporting.ts
+++ b/packages/manager/src/exceptionReporting.ts
@@ -16,6 +16,7 @@ const errorsToIgnore: string[] = [
   'TouchRipple'
 ];
 
+// eslint-disable-next-line
 window.addEventListener('unhandledrejection', event => {
   const _stack = event?.reason?.stack;
   // Enforce that `stack` is a string.

--- a/packages/manager/src/features/Longview/LongviewDetail/LongviewDetail.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/LongviewDetail.tsx
@@ -93,7 +93,8 @@ export const LongviewDetail: React.FC<CombinedProps> = props => {
   const { lastUpdated, lastUpdatedError, notifications } = useClientLastUpdated(
     clientAPIKey,
     clientAPIKey
-      ? _lastUpdated => props.getClientStats(clientAPIKey, _lastUpdated)
+      ? _lastUpdated =>
+          props.getClientStats(clientAPIKey, _lastUpdated).catch(_ => null)
       : undefined
   );
 

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
@@ -78,7 +78,7 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
     lastUpdatedError,
     authed
   } = useClientLastUpdated(clientAPIKey, _lastUpdated =>
-    props.getClientStats(clientAPIKey, _lastUpdated)
+    props.getClientStats(clientAPIKey, _lastUpdated).catch(_ => null)
   );
 
   /**

--- a/packages/manager/src/initSentry.ts
+++ b/packages/manager/src/initSentry.ts
@@ -68,6 +68,7 @@ export const initSentry = () => {
         'conduitPage',
         // Don't report client network errors.
         'ChunkLoadError',
+        'Network Error',
         // This is apparently a benign error: https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded
         'ResizeObserver loop limit exceeded'
       ],


### PR DESCRIPTION
## Description

- Added "Network Error" to our list of ignored errors
- Most of these seemed to be coming from calls to the Longview API,
and it turns out we weren't catching errors for some of those requests.
Added some catch => null blocks (errors are handled through Redux).

## Notes

A third type of error, "request aborted", also seems to be coming from calls to the LV API. 

I haven't been able to reproduce these errors (blocking requests to LV doesn't cause any exceptions or reporting, nor does anything else I've tried), but these are Good Changes and in theory ought to cut down on actual as well as reported errors. 