### PR TITLE
Feature flags for password validation

### DIFF
--- a/packages/api-v4/package.json
+++ b/packages/api-v4/package.json
@@ -23,8 +23,7 @@
   "dependencies": {
     "axios": "~0.19.0",
     "querystring": "^0.2.0",
-    "yup": "^0.27.0",
-    "zxcvbn": "^4.4.2"
+    "yup": "^0.27.0"
   },
   "scripts": {
     "start": "concurrently \"tsc -w\" \"babel src --watch --out-dir lib --extensions '.ts,.tsx'\" -n 'tsc,babel' -k",

--- a/packages/api-v4/src/linodes/linodes.schema.ts
+++ b/packages/api-v4/src/linodes/linodes.schema.ts
@@ -1,17 +1,17 @@
 import { array, boolean, mixed, number, object, string } from 'yup';
-import zxcvbn from 'zxcvbn';
-import { MINIMUM_PASSWORD_STRENGTH } from 'src/constants';
+// import zxcvbn from 'zxcvbn';
+// import { MINIMUM_PASSWORD_STRENGTH } from 'src/constants';
 
 const stackscript_data = array()
   .of(object())
   .nullable(true);
 
-const rootPasswordValidation = string().test(
-  'is-strong-password',
-  'Password does not meet strength requirements.',
-  (value: string) =>
-    Boolean(value) && zxcvbn(value).score >= MINIMUM_PASSWORD_STRENGTH
-);
+// const rootPasswordValidation = string().test(
+//   'is-strong-password',
+//   'Password does not meet strength requirements.',
+//   (value: string) =>
+//     Boolean(value) && zxcvbn(value).score >= MINIMUM_PASSWORD_STRENGTH
+// );
 
 export const ResizeLinodeDiskSchema = object({
   size: number()
@@ -20,9 +20,8 @@ export const ResizeLinodeDiskSchema = object({
 });
 
 export const UpdateLinodePasswordSchema = object({
-  password: string()
-    .required('Password is required.')
-    .concat(rootPasswordValidation)
+  password: string().required('Password is required.')
+  // .concat(rootPasswordValidation)
 });
 
 export const CreateLinodeSchema = object({
@@ -56,11 +55,10 @@ export const CreateLinodeSchema = object({
     .notRequired(),
   root_pass: string().when('image', {
     is: value => Boolean(value),
-    then: string()
-      .required(
-        'You must provide a root password when deploying from an image.'
-      )
-      .concat(rootPasswordValidation),
+    then: string().required(
+      'You must provide a root password when deploying from an image.'
+    ),
+    // .concat(rootPasswordValidation),
     otherwise: string().notRequired()
   })
 });
@@ -138,9 +136,8 @@ const SSHKeySchema = object({
 // Include `shape()` here so that the schema can be extended without TS complaining.
 export const RebuildLinodeSchema = object().shape({
   image: string().required('An image is required.'),
-  root_pass: string()
-    .required('Password is required.')
-    .concat(rootPasswordValidation),
+  root_pass: string().required('Password is required.'),
+  // .concat(rootPasswordValidation),
   authorized_keys: array().of(SSHKeySchema),
   authorized_users: array().of(string()),
   stackscript_id: number().notRequired(),
@@ -232,11 +229,10 @@ export const CreateLinodeDiskSchema = object({
   authorized_users: array().of(string()),
   root_pass: string().when('image', {
     is: value => Boolean(value),
-    then: string()
-      .required(
-        'You must provide a root password when deploying from an image.'
-      )
-      .concat(rootPasswordValidation),
+    then: string().required(
+      'You must provide a root password when deploying from an image.'
+    ),
+    // .concat(rootPasswordValidation),
     otherwise: string().notRequired()
   }),
   stackscript_id: number(),

--- a/packages/manager/config/webpack.config.prod.js
+++ b/packages/manager/config/webpack.config.prod.js
@@ -357,8 +357,8 @@ module.exports = {
   // See https://webpack.js.org/configuration/performance/
   performance: {
     hints: 'error',
-    maxEntrypointSize: 2000000, // ~1.9 MiB
-    maxAssetSize: 2000000, // ~1.9 MiB
+    maxEntrypointSize: 1180000, // ~1.12 MiB	    maxEntrypointSize: 2000000, // ~1.9 MiB
+    maxAssetSize: 1180000, // ~1.12 MiB
     assetFilter(assetFilename) {
       return !(
         assetFilename.endsWith('.chunk.js') || assetFilename.endsWith('.map')

--- a/packages/manager/src/components/AccessPanel/AccessPanel.tsx
+++ b/packages/manager/src/components/AccessPanel/AccessPanel.tsx
@@ -75,6 +75,7 @@ interface Props {
   disabled?: boolean;
   disabledReason?: string;
   hideStrengthLabel?: boolean;
+  hideHelperText?: boolean;
   className?: string;
   small?: boolean;
   isOptional?: boolean;
@@ -108,6 +109,7 @@ class AccessPanel extends React.Component<CombinedProps> {
       disabled,
       disabledReason,
       hideStrengthLabel,
+      hideHelperText,
       className,
       small,
       isOptional,
@@ -141,6 +143,7 @@ class AccessPanel extends React.Component<CombinedProps> {
               placeholder={placeholder || 'Enter a password.'}
               onChange={this.handleChange}
               hideStrengthLabel={hideStrengthLabel}
+              hideHelperText={hideHelperText}
               helperText={passwordHelperText}
             />
           </React.Suspense>

--- a/packages/manager/src/components/PasswordInput/PasswordInput.tsx
+++ b/packages/manager/src/components/PasswordInput/PasswordInput.tsx
@@ -2,8 +2,10 @@ import { isEmpty } from 'ramda';
 import * as React from 'react';
 
 import { makeStyles, Theme } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 import { Props as TextFieldProps } from 'src/components/TextField';
+import useFlags from 'src/hooks/useFlags';
 import * as zxcvbn from 'zxcvbn';
 import StrengthIndicator from '../PasswordInput/StrengthIndicator';
 import HideShowText from './HideShowText';
@@ -13,6 +15,7 @@ type Props = TextFieldProps & {
   required?: boolean;
   disabledReason?: string;
   hideStrengthLabel?: boolean;
+  hideHelperText?: boolean;
   hideValidation?: boolean;
 };
 
@@ -60,6 +63,8 @@ const useStyles = makeStyles((theme: Theme) => ({
 type CombinedProps = Props;
 
 const PasswordInput: React.FC<CombinedProps> = props => {
+  const flags = useFlags();
+
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (props.onChange) {
       props.onChange(e);
@@ -71,6 +76,7 @@ const PasswordInput: React.FC<CombinedProps> = props => {
     required,
     disabledReason,
     hideStrengthLabel,
+    hideHelperText,
     hideValidation,
     ...rest
   } = props;
@@ -106,6 +112,28 @@ const PasswordInput: React.FC<CombinedProps> = props => {
             strength={strength}
             hideStrengthLabel={hideStrengthLabel}
           />
+        </Grid>
+      )}
+      {!hideHelperText && flags.passwordValidation === 'length' && (
+        <Grid item xs={12}>
+          <div className={classes.requirementsListOuter}>
+            <Typography>Password must:</Typography>
+            <ul className={classes.requirementsList}>
+              <li>
+                <Typography component={'span'}>
+                  Be at least <strong>6 characters</strong>
+                </Typography>
+              </li>
+              <li>
+                <Typography component={'span'}>
+                  Contain at least{' '}
+                  <strong>two of the following character classes</strong>:
+                  uppercase letters, lowercase letters, numbers, and
+                  punctuation.
+                </Typography>
+              </li>
+            </ul>
+          </div>
         </Grid>
       )}
     </Grid>

--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -297,3 +297,6 @@ export const OBJECT_STORAGE_ROOT = 'linodeobjects.com';
  * to simulate folder traversal of a bucket.
  */
 export const OBJECT_STORAGE_DELIMITER = '/';
+
+// Value from  1-4 reflecting a minimum score from zxcvbn
+export const MINIMUM_PASSWORD_STRENGTH = 2;

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -19,6 +19,7 @@ interface Flags {
   thirdPartyAuth: boolean;
   cmr: boolean;
   mainContentBanner: MainContentBanner;
+  passwordValidation: PasswordValidationType;
 }
 
 type PromotionalOfferFeature =
@@ -59,3 +60,5 @@ export interface MainContentBanner {
   text: string;
   key: string;
 }
+
+export type PasswordValidationType = 'none' | 'length' | 'complexity';

--- a/packages/manager/src/features/Managed/Credentials/AddCredentialDrawer.tsx
+++ b/packages/manager/src/features/Managed/Credentials/AddCredentialDrawer.tsx
@@ -91,6 +91,7 @@ const CredentialDrawer: React.FC<CombinedProps> = props => {
                   onBlur={handleBlur}
                   // This credential could be anything so might be counterproductive to validate strength
                   hideValidation
+                  hideHelperText
                   required
                 />
               </React.Suspense>

--- a/packages/manager/src/features/Managed/Credentials/UpdateCredentialDrawer.tsx
+++ b/packages/manager/src/features/Managed/Credentials/UpdateCredentialDrawer.tsx
@@ -157,6 +157,7 @@ const CredentialDrawer: React.FC<CombinedProps> = props => {
                   onBlur={handleBlur}
                   // This credential could be anything so might be counterproductive to validate strength
                   hideValidation
+                  hideHelperText
                 />
               </React.Suspense>
               <ActionsPanel>

--- a/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedText.tsx
+++ b/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedText.tsx
@@ -60,6 +60,7 @@ class UserDefinedText extends React.Component<CombinedProps, {}> {
         placeholder={placeholder}
         error={error}
         hideStrengthLabel
+        hideHelperText
         className={!isOptional ? classes.accessPanel : ''}
         isOptional={isOptional}
         password={this.props.value}

--- a/packages/manager/src/utilities/validatePassword/index.ts
+++ b/packages/manager/src/utilities/validatePassword/index.ts
@@ -1,0 +1,1 @@
+export * from './validatePassword';

--- a/packages/manager/src/utilities/validatePassword/validatePassword.test.ts
+++ b/packages/manager/src/utilities/validatePassword/validatePassword.test.ts
@@ -1,0 +1,28 @@
+import { validatePassword } from './validatePassword';
+
+describe('Password validation', () => {
+  it('should return null if validation is set to none', () => {
+    expect(validatePassword('none', 'badpassword')).toBe(null);
+  });
+
+  it('should return true for a valid root password', () => {
+    expect(validatePassword('length', 'long!!secure!!pa$$word!')).toBe(null);
+    expect(
+      validatePassword('complexity', 'fdkj&34050ds2l2klfgF34*Djsd238SS')
+    ).toBe(null);
+  });
+
+  it('should return an error message for invalid passwords', () => {
+    expect(validatePassword('length', 'short')).toMatch(
+      'Password must be between 6 and 128 characters'
+    );
+
+    expect(validatePassword('length', 'longbutjustletters')).toMatch(
+      'Password must contain at least 2 of the following classes: uppercase letters, lowercase letters, numbers, and punctuation'
+    );
+
+    expect(validatePassword('complexity', 'password')).toMatch(
+      'Password does not meet complexity requirements'
+    );
+  });
+});

--- a/packages/manager/src/utilities/validatePassword/validatePassword.ts
+++ b/packages/manager/src/utilities/validatePassword/validatePassword.ts
@@ -1,0 +1,33 @@
+import { string } from 'yup';
+import { MINIMUM_PASSWORD_STRENGTH } from 'src/constants';
+import { PasswordValidationType } from 'src/featureFlags';
+import * as zxcvbn from 'zxcvbn';
+
+const passwordLengthAndCharacterSchema = string()
+  .min(6, 'Password must be between 6 and 128 characters.')
+  .max(128, 'Password must be between 6 and 128 characters.')
+  .matches(
+    /^(((?=.*[a-z])(?=.*[A-Z]))|((?=.*[a-z])(?=.*[0-9]))|((?=.*[A-Z])(?=.*[0-9]))|((?=.*[a-z])(?=.*[!"#$%&'()*+,-.\/:;<=>?@\[\]^_`{|}~\\]))|((?=.*[A-Z])(?=.*[!"#$%&'()*+,-.\/:;<=>?@\[\]^_`{|}~\\]))|((?=.*[0-9])(?=.*[!"#$%&'()*+,-.\/:;<=>?@\[\]^_`{|}~\\])))/,
+    'Password must contain at least 2 of the following classes: uppercase letters, lowercase letters, numbers, and punctuation.'
+  );
+
+export const validatePassword = (
+  validationType: PasswordValidationType,
+  password: string
+) => {
+  switch (validationType) {
+    case 'none':
+      return null;
+    case 'length':
+      try {
+        passwordLengthAndCharacterSchema.validateSync(password);
+        return null;
+      } catch (e) {
+        return e.message;
+      }
+    case 'complexity':
+      return zxcvbn(password).score >= MINIMUM_PASSWORD_STRENGTH
+        ? null
+        : 'Password does not meet complexity requirements.';
+  }
+};


### PR DESCRIPTION
## Description

- Add new feature flag for passwordValidation, and conditionally
re-add the previous helper text.

- Add a new validatePassword method that can handle different
types of validation.

- Remove zxcvbn from the JS client (commented out, as I hope to move all schemas to a separate workspace).

## Note to Reviewers

Toggle the flag in the test environment between `length` and `complexity`. You should see the helper text appear or disappear accordingly. 

This is phase 1. No client validation is currently being done on passwords (except for `.required()`). Phase two will use the new `validatePassword` wherever passwords are submitted. Eventually we'll use Formik everywhere and a simple dynamic schema will work (by then we'll be using complexity permanently, so even one schema should do it). 

