### PR TITLE
M3-4172 Make target field for TXT records multiline

### DIFF
--- a/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
@@ -105,6 +105,7 @@ interface AdjustedTextFieldProps {
   max?: number;
   placeholder?: string;
   helperText?: string;
+  multiline?: boolean;
 }
 
 interface NumberFieldProps extends AdjustedTextFieldProps {
@@ -180,7 +181,8 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
     label,
     field,
     helperText,
-    placeholder
+    placeholder,
+    multiline
   }: AdjustedTextFieldProps) => (
     <TextField
       label={label}
@@ -197,6 +199,7 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
       }
       placeholder={placeholder}
       helperText={helperText}
+      multiline={multiline}
       data-qa-target={label}
     />
   );
@@ -222,10 +225,12 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
 
   NameOrTargetField = ({
     label,
-    field
+    field,
+    multiline
   }: {
     label: string;
     field: 'name' | 'target';
+    multiline?: boolean;
   }) => {
     const { domain, type } = this.props;
     const value = this.state.fields[field];
@@ -235,6 +240,7 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
       <this.TextField
         field={field}
         label={label}
+        multiline={multiline}
         placeholder={
           shouldResolve(type, field) ? 'hostname or @ for root' : undefined
         }
@@ -703,7 +709,12 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
           <this.NameOrTargetField label="Hostname" field="name" key={idx} />
         ),
         (idx: number) => (
-          <this.NameOrTargetField label="Value" field="target" key={idx} />
+          <this.NameOrTargetField
+            label="Value"
+            field="target"
+            multiline
+            key={idx}
+          />
         ),
         (idx: number) => <this.TTLField key={idx} />
       ]

--- a/packages/manager/src/features/Domains/DomainRecords.tsx
+++ b/packages/manager/src/features/Domains/DomainRecords.tsx
@@ -49,6 +49,7 @@ import {
 } from 'src/utilities/errorUtils';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import { storage } from 'src/utilities/storage';
+import { truncateEnd } from 'src/utilities/truncate';
 import ActionMenu from './DomainRecordActionMenu';
 import Drawer from './DomainRecordDrawer';
 
@@ -492,7 +493,10 @@ class DomainRecords extends React.Component<CombinedProps, State> {
       data: this.props.domainRecords.filter(typeEq('TXT')),
       columns: [
         { title: 'Hostname', render: (r: DomainRecord) => r.name },
-        { title: 'Value', render: (r: DomainRecord) => r.target },
+        {
+          title: 'Value',
+          render: (r: DomainRecord) => truncateEnd(r.target, 255)
+        },
         { title: 'TTL', render: getTTL },
         {
           title: '',


### PR DESCRIPTION
## Description

The original issue (Support ticket link in JIRA) seems to have been mistaken: I logged in as the customer and saw that Cloud was displaying exactly what the API returned, which the user seems to think had been clipped. I'm not sure how the TXT record got into that state, but displaying what the API sends us is all we can do. Furthermore, I created a TXT record in production using the exact values the customer used, and was able to create, view, and edit the record normally.

However: it is a little weird, and a relic of the one-field-input-for-all-types pattern in this component, that we use a single-line text input for TXT records, which are frequently long (though not that long). I added some handling to turn the input into a textarea when working with TXT records.

## Note to Reviewers

Test account 4 has a few enormous TXT records for your convenience, or you can create your own. Editing, displaying, etc. should all work properly.

I decided to truncate values for extremely long records, because this looks a little odd: 

![Screen Shot 2020-06-25 at 8 54 20 AM](https://user-images.githubusercontent.com/1624067/85727405-f9dbd380-b6c4-11ea-85ff-439e8248d209.png)


I set the truncation at a high amount (255 characters); records longer than this are rare*, and in any case the full record can be viewed in the drawer.

We also have 2 separate `truncate` utilities, opened a ticket to clean these up.

* I have no data to support this.