### PR TITLE
M3-4242 Adjustments to the SelectPlan table

### DIFF
--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -215,12 +215,12 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
                 `$` + type.price.hourly
               )}
             </TableCell>
+            <TableCell data-qa-ram>
+              {convertMegabytesTo(type.memory, true)}
+            </TableCell>
             <TableCell data-qa-cpu>{type.vcpus}</TableCell>
             <TableCell data-qa-storage>
               {convertMegabytesTo(type.disk, true)}
-            </TableCell>
-            <TableCell data-qa-ram>
-              {convertMegabytesTo(type.memory, true)}
             </TableCell>
           </TableRow>
         </Hidden>

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -249,9 +249,9 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
           <TableCell data-qa-plan-header>Linode Plan</TableCell>
           <TableCell data-qa-monthly-header>Monthly</TableCell>
           <TableCell data-qa-hourly-header>Hourly</TableCell>
+          <TableCell data-qa-ram-header>RAM</TableCell>
           <TableCell data-qa-cpu-header>CPUs</TableCell>
           <TableCell data-qa-storage-header>Storage</TableCell>
-          <TableCell data-qa-ram-header>Ram</TableCell>
         </TableRow>
       </TableHead>
     );

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
@@ -174,12 +174,12 @@ export class SelectPlanPanel extends React.Component<
             </TableCell>
             <TableCell data-qa-monthly> ${type.price.monthly}</TableCell>
             <TableCell data-qa-hourly>{`$` + type.price.hourly}</TableCell>
+            <TableCell data-qa-ram>
+              {convertMegabytesTo(type.memory, true)}
+            </TableCell>
             <TableCell data-qa-cpu>{type.vcpus}</TableCell>
             <TableCell data-qa-storage>
               {convertMegabytesTo(type.disk, true)}
-            </TableCell>
-            <TableCell data-qa-ram>
-              {convertMegabytesTo(type.memory, true)}
             </TableCell>
             <TableCell>
               <div className={classes.enhancedInputOuter}>
@@ -241,9 +241,9 @@ export class SelectPlanPanel extends React.Component<
           <TableCell data-qa-plan-header>Plan</TableCell>
           <TableCell data-qa-monthly-header>Monthly</TableCell>
           <TableCell data-qa-hourly-header>Hourly</TableCell>
+          <TableCell data-qa-ram-header>RAM</TableCell>
           <TableCell data-qa-cpu-header>CPUs</TableCell>
           <TableCell data-qa-storage-header>Storage</TableCell>
-          <TableCell data-qa-ram-header>Ram</TableCell>
           <TableCell>
             <p className="visually-hidden">Quantity</p>
           </TableCell>


### PR DESCRIPTION
## Description

`renderPlanContainer` in `SelectPlanPanel.tsx` was reordered based on the ticket specifications:

- Ram was changed to RAM
- Table headers are now Plan > Monthly > Hourly > RAM > CPUs > Storage

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers
**Before**:
![Screen Shot 2020-06-25 at 11 21 30 AM](https://user-images.githubusercontent.com/6935357/85748892-627f7c00-b6d6-11ea-92a4-c23eac092f06.png)
**After**:
![Screen Shot 2020-06-25 at 11 41 30 AM](https://user-images.githubusercontent.com/6935357/85751767-d589f200-b6d8-11ea-8905-b8a41bdd0bb6.png)


