### PR TITLE
Create "button reset" CSS mixin

### DIFF
--- a/packages/manager/src/features/Account/AutoBackups.tsx
+++ b/packages/manager/src/features/Account/AutoBackups.tsx
@@ -24,15 +24,7 @@ const styles = (theme: Theme) =>
       cursor: 'pointer'
     },
     link: {
-      background: 'none',
-      color: theme.palette.primary.main,
-      border: 'none',
-      padding: 0,
-      font: 'inherit',
-      cursor: 'pointer',
-      '&:hover': {
-        textDecoration: 'underline'
-      }
+      ...theme.applyLinkStyles
     },
     icon: {
       display: 'inline-block',
@@ -127,7 +119,6 @@ const AutoBackups: React.FC<CombinedProps> = props => {
                   data-qa-backup-existing
                   className={classes.link}
                   onClick={openBackupsDrawer}
-                  role="button"
                   title="enable now"
                 >
                   enable now

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -118,15 +118,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     }
   },
   pdfDownloadButton: {
-    border: 'none',
-    backgroundColor: 'inherit',
-    cursor: 'pointer',
-    color: theme.palette.primary.main,
-    padding: 0,
-    font: 'inherit',
-    '&:hover': {
-      textDecoration: 'underline'
-    }
+    ...theme.applyLinkStyles
   },
   pdfError: {
     color: theme.color.red

--- a/packages/manager/src/features/Lish/Glish.tsx
+++ b/packages/manager/src/features/Lish/Glish.tsx
@@ -30,15 +30,7 @@ const styles = (theme: Theme) =>
       margin: theme.spacing(2)
     },
     link: {
-      background: 'none',
-      color: theme.palette.primary.main,
-      border: 'none',
-      padding: 0,
-      font: 'inherit',
-      cursor: 'pointer',
-      '&:hover': {
-        textDecoration: 'underline'
-      }
+      ...theme.applyLinkStyles
     },
     errorState: {
       '& *': {
@@ -188,7 +180,6 @@ class Glish extends React.Component<CombinedProps, State> {
           [classes.link]: true
         })}
         onClick={this.linodeOnClick(linodeID)}
-        role="button"
         title={linodeLabel}
       >
         {linodeLabel}

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewList.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewList.tsx
@@ -20,15 +20,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     justifyContent: 'center'
   },
   button: {
-    background: 'none',
-    color: theme.palette.primary.main,
-    border: 'none',
-    padding: 0,
-    font: 'inherit',
-    cursor: 'pointer',
-    '&:hover': {
-      textDecoration: 'underline'
-    }
+    ...theme.applyLinkStyles
   },
   emptyText: {
     fontSize: '1.1em'

--- a/packages/manager/src/features/ObjectStorage/ObjectStorageLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectStorageLanding.tsx
@@ -211,13 +211,7 @@ export default React.memo(ObjectStorageLanding);
 // ============================================================================
 const useBillingNoticeStyles = makeStyles((theme: Theme) => ({
   button: {
-    backgroundColor: 'inherit',
-    border: 'none',
-    fontFamily: 'inherit',
-    fontSize: 'inherit',
-    color: theme.color.blue,
-    padding: 0,
-    cursor: 'pointer'
+    ...theme.applyLinkStyles
   }
 }));
 

--- a/packages/manager/src/features/Support/SupportTicketDetail/CloseTicketLink.tsx
+++ b/packages/manager/src/features/Support/SupportTicketDetail/CloseTicketLink.tsx
@@ -19,15 +19,7 @@ type ClassNames = 'closeLink';
 const styles = (theme: Theme) =>
   createStyles({
     closeLink: {
-      background: 'none',
-      color: theme.palette.primary.main,
-      border: 'none',
-      padding: 0,
-      font: 'inherit',
-      cursor: 'pointer',
-      '&:hover': {
-        textDecoration: 'underline'
-      }
+      ...theme.applyLinkStyles
     }
   });
 

--- a/packages/manager/src/features/TheApplicationIsOnFire.tsx
+++ b/packages/manager/src/features/TheApplicationIsOnFire.tsx
@@ -7,15 +7,7 @@ import DialogTitle from 'src/components/DialogTitle';
 
 const useStyles = makeStyles((theme: Theme) => ({
   restartButton: {
-    background: 'none',
-    color: theme.palette.primary.main,
-    border: 'none',
-    padding: 0,
-    font: 'inherit',
-    cursor: 'pointer',
-    '&:hover': {
-      textDecoration: 'underline'
-    }
+    ...theme.applyLinkStyles
   }
 }));
 

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -48,6 +48,7 @@ declare module '@material-ui/core/styles/createMuiTheme' {
     font?: any;
     animateCircleIcon?: any;
     addCircleHoverEffect?: any;
+    applyLinkStyles?: any;
 
     notificationList: any;
     status: any;
@@ -111,6 +112,19 @@ const iconCircleHoverEffect = {
   },
   '& .insidePath *': {
     stroke: 'white'
+  }
+};
+
+// Used for styling html buttons to look like our generic links
+const genericLinkStyle = {
+  background: 'none',
+  color: primaryColors.main,
+  border: 'none',
+  padding: 0,
+  font: 'inherit',
+  cursor: 'pointer',
+  '&:hover': {
+    textDecoration: 'underline'
   }
 };
 
@@ -313,6 +327,9 @@ const themeDefaults: ThemeDefaults = ({ spacingOverride: spacingUnit }) => {
     },
     addCircleHoverEffect: {
       ...iconCircleHoverEffect
+    },
+    applyLinkStyles: {
+      ...genericLinkStyle
     },
     notificationList: {
       padding: '16px 32px 16px 23px',


### PR DESCRIPTION
## Description

We often restyle html buttons to look like links- to make this styling easier to implement, we can now spread the styling to other elements in the app, similar to a mixin. I applied this to places we're already restyling buttons, but if I missed any please call them out here.

## Type of Change
- Non breaking change ('update')

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Applicable E2E Tests

To run relevant E2E tests, run these commands in 3 separate terminals:

1. `yarn && yarn start`
2. `yarn selenium`
3. `yarn e2e --spec=COMMA_SEPARATED_LIST_OF_SPECS_HERE --browser=headlessChrome`

## Note to Reviewers

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
