### PR TITLE
Fixing casing for semi bold font variant

### DIFF
--- a/packages/manager/public/fonts/fonts.css
+++ b/packages/manager/public/fonts/fonts.css
@@ -13,12 +13,12 @@
 
 /* Webfont: Lato-SemiBold */
 @font-face {
-  font-family: 'LatoWebSemiBold';
-  src: url('fonts/Lato-SemiBold.eot'); /* IE9 Compat Modes */
-  src: url('fonts/Lato-SemiBold.eot?#iefix') format('embedded-opentype'),
-    /* IE6-IE8 */ url('fonts/Lato-SemiBold.woff2') format('woff2'),
-    /* Modern Browsers */ url('fonts/Lato-SemiBold.woff') format('woff'),
-    /* Modern Browsers */ url('fonts/Lato-SemiBold.ttf') format('truetype');
+  font-family: 'LatoWebSemibold';
+  src: url('fonts/Lato-Semibold.eot'); /* IE9 Compat Modes */
+  src: url('fonts/Lato-Semibold.eot?#iefix') format('embedded-opentype'),
+    /* IE6-IE8 */ url('fonts/Lato-Semibold.woff2') format('woff2'),
+    /* Modern Browsers */ url('fonts/Lato-Semibold.woff') format('woff'),
+    /* Modern Browsers */ url('fonts/Lato-Semibold.ttf') format('truetype');
   font-style: normal;
   font-weight: normal;
   text-rendering: optimizeLegibility;

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -84,7 +84,7 @@ const primaryColors = {
 
 const primaryFonts = {
   normal: '"LatoWeb", sans-serif',
-  semiBold: '"LatoWebSemiBold", sans-serif',
+  semiBold: '"LatoWebSemibold", sans-serif',
   bold: '"LatoWebBold", sans-serif'
 };
 


### PR DESCRIPTION
## Description

Casing was off and causing issues.

## Type of Change
- Bug fix ('fix')
- Non breaking change ('update', 'change')
- Breaking change ('break', 'deprecate')

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Applicable E2E Tests

To run relevant E2E tests, run these commands in 3 separate terminals:

1. `yarn && yarn start`
2. `yarn selenium`
3. `yarn e2e --spec=COMMA_SEPARATED_LIST_OF_SPECS_HERE --browser=headlessChrome`

## Note to Reviewers

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
