### PR TITLE
getBucket() after updating Objects

### DIFF
--- a/packages/api-v4/src/object-storage/buckets.ts
+++ b/packages/api-v4/src/object-storage/buckets.ts
@@ -17,6 +17,17 @@ import {
 } from './types';
 
 /**
+ * getBucket
+ *
+ * Get one Object Storage Bucket.
+ */
+export const getBucket = (clusterId: string, bucketName: string) =>
+  Request<ObjectStorageBucket>(
+    setMethod('GET'),
+    setURL(`${API_ROOT}/object-storage/buckets/${clusterId}/${bucketName}`)
+  ).then(response => response.data);
+
+/**
  * getBuckets
  *
  * Gets a list of a user's Object Storage Buckets.

--- a/packages/manager/src/containers/bucketRequests.container.ts
+++ b/packages/manager/src/containers/bucketRequests.container.ts
@@ -4,12 +4,15 @@ import {
   createBucket,
   CreateBucketRequest,
   deleteBucket,
-  DeleteBucketRequest
+  getBucket,
+  DeleteBucketRequest,
+  GetBucketRequest
 } from 'src/store/bucket/bucket.requests';
 
 export interface BucketsRequests {
   createBucket: (request: CreateBucketRequest) => Promise<ObjectStorageBucket>;
   deleteBucket: (request: DeleteBucketRequest) => Promise<{}>;
+  getBucket: (request: GetBucketRequest) => Promise<ObjectStorageBucket>;
 }
 
 export default connect(
@@ -17,6 +20,7 @@ export default connect(
   undefined,
   {
     createBucket,
-    deleteBucket
+    deleteBucket,
+    getBucket
   }
 );

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -88,6 +88,7 @@ const styles = (theme: Theme) =>
       color: theme.color.headline
     },
     tryAgainText: {
+      ...theme.applyLinkStyles,
       color: theme.palette.primary.main,
       textDecoration: 'underline',
       cursor: 'pointer'
@@ -291,8 +292,11 @@ export class BucketDetail extends React.Component<CombinedProps, {}> {
       );
 
       await deleteObject(url);
-      // Get the Bucket again so the updated size is reflected on the Landing page.
-      this.props.getBucket({ cluster: clusterId, label: bucketName });
+      // Request the Bucket again so the updated size is reflected on the Bucket Landing page.
+      this.props
+        .getBucket({ cluster: clusterId, label: bucketName })
+        // It's OK to swallow the error here, since this request is for a silent UI update.
+        .catch(_ => null);
 
       this.setState({
         deleteObjectLoading: false,
@@ -491,13 +495,12 @@ export class BucketDetail extends React.Component<CombinedProps, {}> {
               {nextPageError && (
                 <Typography variant="subtitle2" className={classes.footer}>
                   The next objects in the list failed to load.{' '}
-                  <span
+                  <button
                     className={classes.tryAgainText}
                     onClick={this.getNextPage}
-                    role="button"
                   >
                     Click here to try again.
-                  </span>
+                  </button>
                 </Typography>
               )}
 

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -38,6 +38,9 @@ import { getQueryParam } from 'src/utilities/queryParams';
 import { truncateMiddle } from 'src/utilities/truncate';
 import ObjectUploader from '../ObjectUploader';
 import { deleteObject } from '../requests';
+import bucketRequestsContainer, {
+  BucketsRequests
+} from 'src/containers/bucketRequests.container';
 import {
   displayName,
   ExtendedObject,
@@ -108,7 +111,8 @@ interface MatchProps {
 
 type CombinedProps = RouteComponentProps<MatchProps> &
   WithStyles<ClassNames> &
-  WithSnackbarProps;
+  WithSnackbarProps &
+  BucketsRequests;
 
 interface State {
   data: ExtendedObject[];
@@ -287,6 +291,8 @@ export class BucketDetail extends React.Component<CombinedProps, {}> {
       );
 
       await deleteObject(url);
+      // Get the Bucket again so the updated size is reflected on the Landing page.
+      this.props.getBucket({ cluster: clusterId, label: bucketName });
 
       this.setState({
         deleteObjectLoading: false,
@@ -542,6 +548,10 @@ export class BucketDetail extends React.Component<CombinedProps, {}> {
 
 const styled = withStyles(styles);
 
-const enhanced = compose<CombinedProps, {}>(styled, withSnackbar);
+const enhanced = compose<CombinedProps, {}>(
+  styled,
+  withSnackbar,
+  bucketRequestsContainer
+);
 
 export default enhanced(BucketDetail);

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.test.tsx
@@ -10,6 +10,7 @@ describe('CreateBucketForm', () => {
       onSuccess={jest.fn()}
       createBucket={jest.fn()}
       deleteBucket={jest.fn()}
+      getBucket={jest.fn()}
       bucketsData={[]}
       bucketsLoading={false}
       classes={{ root: '', textWrapper: '' }}

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/ObjectUploader.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/ObjectUploader.tsx
@@ -247,6 +247,7 @@ const ObjectUploader: React.FC<CombinedProps> = props => {
       const onUploadProgress = onUploadProgressFactory(dispatch, path);
 
       const handleSuccess = () => {
+        // Get the Bucket again so the updated size is reflected on the Landing page.
         debouncedGetBucket({
           cluster: props.clusterId,
           label: props.bucketName

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/ObjectUploader.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/ObjectUploader.tsx
@@ -15,6 +15,7 @@ import { truncateMiddle } from 'src/utilities/truncate';
 import { readableBytes } from 'src/utilities/unitConversions';
 import { uploadObject } from '../requests';
 import FileUpload from './FileUpload';
+import { debounce } from 'throttle-debounce';
 import {
   curriedObjectUploaderReducer,
   defaultState,
@@ -24,6 +25,9 @@ import {
   ObjectUploaderAction,
   pathOrFileName
 } from './reducer';
+import bucketRequestsContainer, {
+  BucketsRequests
+} from 'src/containers/bucketRequests.container';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -144,7 +148,7 @@ interface Props {
   maybeAddObjectToTable: (path: string, sizeInBytes: number) => void;
 }
 
-type CombinedProps = Props & WithSnackbarProps;
+type CombinedProps = Props & WithSnackbarProps & BucketsRequests;
 
 const ObjectUploader: React.FC<CombinedProps> = props => {
   const { clusterId, bucketName, prefix } = props;
@@ -206,6 +210,9 @@ const ObjectUploader: React.FC<CombinedProps> = props => {
     return queuedUploads.slice(0, MAX_PARALLEL_UPLOADS - state.numInProgress);
   }, [state.numQueued, state.numInProgress]);
 
+  const debouncedGetBucket = React.useRef(debounce(400, false, props.getBucket))
+    .current;
+
   // When `nextBatch` changes, upload the files.
   React.useEffect(() => {
     if (nextBatch.length === 0) {
@@ -240,6 +247,11 @@ const ObjectUploader: React.FC<CombinedProps> = props => {
       const onUploadProgress = onUploadProgressFactory(dispatch, path);
 
       const handleSuccess = () => {
+        debouncedGetBucket({
+          cluster: props.clusterId,
+          label: props.bucketName
+        });
+
         // We may want to add the object to the table, depending on the prefix
         // the user is currently viewing. Do this in the parent, which has the
         // current prefix in scope.
@@ -399,7 +411,8 @@ const ObjectUploader: React.FC<CombinedProps> = props => {
 
 const enhanced = compose<CombinedProps, Props>(
   withSnackbar,
-  React.memo
+  React.memo,
+  bucketRequestsContainer
 );
 
 export default enhanced(ObjectUploader);

--- a/packages/manager/src/store/bucket/bucket.actions.ts
+++ b/packages/manager/src/store/bucket/bucket.actions.ts
@@ -26,3 +26,9 @@ export const deleteBucketActions = actionCreator.async<
   {},
   APIError[]
 >('delete');
+
+export const getBucketActions = actionCreator.async<
+  ObjectStorageBucketRequestPayload,
+  ObjectStorageBucket,
+  APIError[]
+>('get');

--- a/packages/manager/src/store/bucket/bucket.reducer.ts
+++ b/packages/manager/src/store/bucket/bucket.reducer.ts
@@ -5,7 +5,8 @@ import { isType } from 'typescript-fsa';
 import {
   createBucketActions,
   deleteBucketActions,
-  getAllBucketsForAllClustersActions
+  getAllBucketsForAllClustersActions,
+  getBucketActions
 } from './bucket.actions';
 import { BucketError } from './types';
 
@@ -34,6 +35,32 @@ export const defaultState: State = {
  * Reducer
  */
 const reducer: Reducer<State> = (state = defaultState, action) => {
+  /**
+   * Get Bucket
+   */
+  if (isType(action, getBucketActions.done)) {
+    const { result } = action.payload;
+    const idx = state.data.findIndex(
+      thisBucket =>
+        thisBucket.label === result.label &&
+        thisBucket.cluster === result.cluster
+    );
+
+    const updatedData = [...state.data];
+    if (idx !== -1) {
+      updatedData[idx] = result;
+      return {
+        ...state,
+        data: updatedData
+      };
+    }
+
+    return {
+      ...state,
+      data: [...state.data, result]
+    };
+  }
+
   /*
    * Create Bucket
    **/

--- a/packages/manager/src/store/bucket/bucket.requests.ts
+++ b/packages/manager/src/store/bucket/bucket.requests.ts
@@ -1,6 +1,7 @@
 import {
   createBucket as _createBucket,
   deleteBucket as _deleteBucket,
+  getBucket as _getBucket,
   getBucketsInCluster,
   ObjectStorageBucket,
   ObjectStorageBucketRequestPayload,
@@ -14,7 +15,8 @@ import { ThunkActionCreator } from '../types';
 import {
   createBucketActions,
   deleteBucketActions,
-  getAllBucketsForAllClustersActions
+  getAllBucketsForAllClustersActions,
+  getBucketActions
 } from './bucket.actions';
 import { BucketError } from './types';
 
@@ -109,3 +111,13 @@ export const deleteBucket = createRequestThunk<
   {},
   APIError[]
 >(deleteBucketActions, data => _deleteBucket(data));
+
+/*
+ * Get a Bucket
+ */
+export type GetBucketRequest = ObjectStorageBucketRequestPayload;
+export const getBucket = createRequestThunk<
+  ObjectStorageBucketRequestPayload,
+  {},
+  APIError[]
+>(getBucketActions, data => _getBucket(data.cluster, data.label));

--- a/packages/manager/src/store/bucket/bucket.requests.ts
+++ b/packages/manager/src/store/bucket/bucket.requests.ts
@@ -8,7 +8,6 @@ import {
   ObjectStorageClusterID,
   ObjectStorageDeleteBucketRequestPayload
 } from '@linode/api-v4/lib/object-storage';
-import { APIError } from '@linode/api-v4/lib/types';
 import { GetAllData, getAllWithArguments } from 'src/utilities/getAll';
 import { createRequestThunk } from '../store.helpers';
 import { ThunkActionCreator } from '../types';
@@ -25,11 +24,9 @@ import { BucketError } from './types';
  */
 
 export type CreateBucketRequest = ObjectStorageBucketRequestPayload;
-export const createBucket = createRequestThunk<
-  CreateBucketRequest,
-  ObjectStorageBucket,
-  APIError[]
->(createBucketActions, data => _createBucket(data));
+export const createBucket = createRequestThunk(createBucketActions, data =>
+  _createBucket(data)
+);
 
 /*
  * Get All Buckets from All Clusters
@@ -106,18 +103,14 @@ export const gatherDataAndErrors = (
  * Delete Bucket
  */
 export type DeleteBucketRequest = ObjectStorageDeleteBucketRequestPayload;
-export const deleteBucket = createRequestThunk<
-  ObjectStorageDeleteBucketRequestPayload,
-  {},
-  APIError[]
->(deleteBucketActions, data => _deleteBucket(data));
+export const deleteBucket = createRequestThunk(deleteBucketActions, data =>
+  _deleteBucket(data)
+);
 
 /*
  * Get a Bucket
  */
 export type GetBucketRequest = ObjectStorageBucketRequestPayload;
-export const getBucket = createRequestThunk<
-  ObjectStorageBucketRequestPayload,
-  {},
-  APIError[]
->(getBucketActions, data => _getBucket(data.cluster, data.label));
+export const getBucket = createRequestThunk(getBucketActions, data =>
+  _getBucket(data.cluster, data.label)
+);


### PR DESCRIPTION
## Description

As suggested by @Jskobos in https://github.com/linode/manager/pull/6547#pullrequestreview-438264490

This adds getBucket() to Redux/containers etc. and calls is after updating Objects, so that the updated Bucket size will be displayed on the landing page.

The calls to getBucket after Object uploads are debounced, since many Objects can be uploaded at once.