### PR TITLE
Change: manual password validation

### DIFF
--- a/packages/api-v4/src/linodes/linodes.schema.ts
+++ b/packages/api-v4/src/linodes/linodes.schema.ts
@@ -137,7 +137,6 @@ const SSHKeySchema = object({
 export const RebuildLinodeSchema = object().shape({
   image: string().required('An image is required.'),
   root_pass: string().required('Password is required.'),
-  // .concat(rootPasswordValidation),
   authorized_keys: array().of(SSHKeySchema),
   authorized_users: array().of(string()),
   stackscript_id: number().notRequired(),

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.tsx
@@ -24,7 +24,7 @@ import {
   handleFieldErrors,
   handleGeneralErrors
 } from 'src/utilities/formikErrorUtils';
-import { validatePassword } from 'src/utilities/validatePassword';
+import { extendValidationSchema } from 'src/utilities/validatePassword';
 import { object, string } from 'yup';
 
 import ImageAndPassword from '../LinodeSettings/ImageAndPassword';
@@ -127,27 +127,10 @@ export const DiskDrawer: React.FC<CombinedProps> = props => {
    */
   const CreateFromImageSchema = React.useMemo(
     () =>
-      // @todo upgrade Yup and @types/yup to better handle this
-      (CreateLinodeDiskFromImageSchema as any).clone().shape({
-        root_pass: string()
-          .required('Password is required.')
-          .test({
-            name: 'root-password-strength',
-            // eslint-disable-next-line object-shorthand
-            test: function(value) {
-              const passwordError = validatePassword(
-                passwordValidation ?? 'none',
-                value
-              );
-              return Boolean(validatePassword)
-                ? this.createError({
-                    message: passwordError,
-                    path: 'root_pass'
-                  })
-                : true;
-            }
-          })
-      }),
+      extendValidationSchema(
+        passwordValidation ?? 'none',
+        CreateLinodeDiskFromImageSchema
+      ),
     [passwordValidation]
   );
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuild.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuild.tsx
@@ -12,13 +12,14 @@ import {
 import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import EnhancedSelect, { Item } from 'src/components/EnhancedSelect/Select';
+import useFlags from 'src/hooks/useFlags';
 import { withLinodeDetailContext } from '../linodeDetailContext';
 import HostMaintenanceError from '../HostMaintenanceError';
 import LinodePermissionsError from '../LinodePermissionsError';
 import RebuildFromImage from './RebuildFromImage';
 import RebuildFromStackScript from './RebuildFromStackScript';
 
-type ClassNames = 'root' | 'title';
+type ClassNames = 'root' | 'title' | 'helperText';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -27,6 +28,9 @@ const styles = (theme: Theme) =>
     },
     title: {
       marginBottom: theme.spacing(2)
+    },
+    helperText: {
+      paddingBottom: theme.spacing(2)
     }
   });
 
@@ -55,6 +59,10 @@ const LinodeRebuild: React.FC<CombinedProps> = props => {
   const unauthorized = permissions === 'read_only';
   const disabled = hostMaintenance || unauthorized;
 
+  const flags = useFlags();
+
+  const passwordValidation = flags.passwordValidation ?? 'none';
+
   const [mode, setMode] = React.useState<MODES>('fromImage');
 
   return (
@@ -72,7 +80,7 @@ const LinodeRebuild: React.FC<CombinedProps> = props => {
         >
           Rebuild
         </Typography>
-        <Typography data-qa-rebuild-desc>
+        <Typography data-qa-rebuild-desc className={classes.helperText}>
           If you can&#39;t rescue an existing disk, it&#39;s time to rebuild
           your Linode. There are a couple of different ways you can do restore
           from a backup or start over with a fresh Linux distribution.&nbsp;
@@ -94,6 +102,7 @@ const LinodeRebuild: React.FC<CombinedProps> = props => {
       {mode === 'fromImage' && (
         <RebuildFromImage
           passwordHelperText={passwordHelperText}
+          passwordValidation={passwordValidation}
           disabled={disabled}
         />
       )}
@@ -101,6 +110,7 @@ const LinodeRebuild: React.FC<CombinedProps> = props => {
         <RebuildFromStackScript
           type="community"
           passwordHelperText={passwordHelperText}
+          passwordValidation={passwordValidation}
           disabled={disabled}
         />
       )}
@@ -108,6 +118,7 @@ const LinodeRebuild: React.FC<CombinedProps> = props => {
         <RebuildFromStackScript
           type="account"
           passwordHelperText={passwordHelperText}
+          passwordValidation={passwordValidation}
           disabled={disabled}
         />
       )}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.test.tsx
@@ -34,6 +34,7 @@ const props: CombinedProps = {
   enqueueSnackbar: jest.fn(),
   permissions: 'read_write',
   passwordHelperText: '',
+  passwordValidation: 'complexity',
   requestKeys: jest.fn(),
   disabled: false,
   ...reactRouterProps

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
@@ -27,11 +27,13 @@ import { resetEventsPolling } from 'src/eventsPolling';
 import userSSHKeyHoc, {
   UserSSHKeyProps
 } from 'src/features/linodes/userSSHKeyHoc';
+import { PasswordValidationType } from 'src/featureFlags';
 import {
   handleFieldErrors,
   handleGeneralErrors
 } from 'src/utilities/formikErrorUtils';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
+import { extendValidationSchema } from 'src/utilities/validatePassword';
 import { withLinodeDetailContext } from '../linodeDetailContext';
 import { RebuildDialog } from './RebuildDialog';
 
@@ -50,6 +52,7 @@ const styles = (theme: Theme) =>
 interface Props {
   disabled: boolean;
   passwordHelperText: string;
+  passwordValidation: PasswordValidationType;
 }
 
 interface ContextProps {
@@ -87,8 +90,20 @@ export const RebuildFromImage: React.FC<CombinedProps> = props => {
     linodeId,
     enqueueSnackbar,
     history,
-    passwordHelperText
+    passwordHelperText,
+    passwordValidation
   } = props;
+
+  /**
+   * Dynamic validation schema, with password validation
+   * dependent on a value from a feature flag. Remove this
+   * once API password validation is stable.
+   */
+  const RebuildSchema = React.useMemo(
+    () =>
+      extendValidationSchema(passwordValidation ?? 'none', RebuildLinodeSchema),
+    [passwordValidation]
+  );
 
   const [isDialogOpen, setIsDialogOpen] = React.useState<boolean>(false);
 
@@ -137,7 +152,7 @@ export const RebuildFromImage: React.FC<CombinedProps> = props => {
   return (
     <Formik
       initialValues={initialValues}
-      validationSchema={RebuildLinodeSchema}
+      validationSchema={RebuildSchema}
       validateOnChange={false}
       onSubmit={handleFormSubmit}
       render={formikProps => {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.test.tsx
@@ -43,6 +43,7 @@ const props: CombinedProps = {
   closeSnackbar: jest.fn(),
   enqueueSnackbar: jest.fn(),
   passwordHelperText: '',
+  passwordValidation: 'complexity',
   ...reactRouterProps
 };
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.tsx
@@ -36,6 +36,7 @@ import {
   getMineAndAccountStackScripts
 } from 'src/features/StackScripts/stackScriptUtils';
 import UserDefinedFieldsPanel from 'src/features/StackScripts/UserDefinedFieldsPanel';
+import { PasswordValidationType } from 'src/featureFlags';
 import { useStackScript } from 'src/hooks/useStackScript';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import {
@@ -43,6 +44,7 @@ import {
   handleGeneralErrors
 } from 'src/utilities/formikErrorUtils';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
+import { extendValidationSchema } from 'src/utilities/validatePassword';
 import { withLinodeDetailContext } from '../linodeDetailContext';
 import { RebuildDialog } from './RebuildDialog';
 
@@ -71,6 +73,7 @@ interface Props {
   type: 'community' | 'account';
   disabled: boolean;
   passwordHelperText: string;
+  passwordValidation: PasswordValidationType;
 }
 
 interface ContextProps {
@@ -107,8 +110,23 @@ export const RebuildFromStackScript: React.FC<CombinedProps> = props => {
     linodeId,
     enqueueSnackbar,
     history,
-    passwordHelperText
+    passwordHelperText,
+    passwordValidation
   } = props;
+
+  /**
+   * Dynamic validation schema, with password validation
+   * dependent on a value from a feature flag. Remove this
+   * once API password validation is stable.
+   */
+  const RebuildSchema = React.useMemo(
+    () =>
+      extendValidationSchema(
+        passwordValidation ?? 'none',
+        RebuildLinodeFromStackScriptSchema
+      ),
+    [passwordValidation]
+  );
 
   const [
     ss,
@@ -219,7 +237,7 @@ export const RebuildFromStackScript: React.FC<CombinedProps> = props => {
   return (
     <Formik
       initialValues={initialValues}
-      validationSchema={RebuildLinodeFromStackScriptSchema}
+      validationSchema={RebuildSchema}
       validateOnChange={false}
       onSubmit={handleFormSubmit}
       render={formikProps => {

--- a/packages/manager/src/utilities/validatePassword/validatePassword.test.ts
+++ b/packages/manager/src/utilities/validatePassword/validatePassword.test.ts
@@ -5,6 +5,10 @@ describe('Password validation', () => {
     expect(validatePassword('none', 'badpassword')).toBe(null);
   });
 
+  it('should return null if no password is provided', () => {
+    expect(validatePassword('complexity', null as any)).toBe(null);
+  });
+
   it('should return null for a valid root password', () => {
     expect(validatePassword('length', 'long!!secure!!pa$$word!')).toBe(null);
     expect(

--- a/packages/manager/src/utilities/validatePassword/validatePassword.test.ts
+++ b/packages/manager/src/utilities/validatePassword/validatePassword.test.ts
@@ -5,7 +5,7 @@ describe('Password validation', () => {
     expect(validatePassword('none', 'badpassword')).toBe(null);
   });
 
-  it('should return true for a valid root password', () => {
+  it('should return null for a valid root password', () => {
     expect(validatePassword('length', 'long!!secure!!pa$$word!')).toBe(null);
     expect(
       validatePassword('complexity', 'fdkj&34050ds2l2klfgF34*Djsd238SS')

--- a/packages/manager/src/utilities/validatePassword/validatePassword.ts
+++ b/packages/manager/src/utilities/validatePassword/validatePassword.ts
@@ -16,6 +16,10 @@ export const validatePassword = (
   validationType: PasswordValidationType,
   password: string
 ) => {
+  // This method does not evaluate whether a password is required.
+  if (!password) {
+    return null;
+  }
   switch (validationType) {
     case 'none':
       return null;

--- a/packages/manager/src/utilities/validatePassword/validatePassword.ts
+++ b/packages/manager/src/utilities/validatePassword/validatePassword.ts
@@ -1,6 +1,7 @@
 import { string } from 'yup';
 import { MINIMUM_PASSWORD_STRENGTH } from 'src/constants';
 import { PasswordValidationType } from 'src/featureFlags';
+import { object } from 'yup';
 import * as zxcvbn from 'zxcvbn';
 
 const passwordLengthAndCharacterSchema = string()
@@ -30,4 +31,44 @@ export const validatePassword = (
         ? null
         : 'Password does not meet complexity requirements.';
   }
+};
+
+/**
+ * Extends a Yup schema with a password validation
+ * check. This check is dynamic based on the type
+ * of validation requested, normally controlled through
+ * a feature flag.
+ *
+ * Remove this method once API password validation
+ * is stable.
+ *
+ * @todo: Update Yup and typings to avoid the any
+ * dodge here
+ */
+export const extendValidationSchema = (
+  validationType: PasswordValidationType,
+  schema: any
+) => {
+  return (schema as any).concat(
+    object({
+      root_pass: string()
+        .required('Password is required.')
+        .test({
+          name: 'root-password-strength',
+          // eslint-disable-next-line object-shorthand
+          test: function(value) {
+            const passwordError = validatePassword(
+              validationType ?? 'none',
+              value
+            );
+            return Boolean(validatePassword)
+              ? this.createError({
+                  message: passwordError,
+                  path: 'root_pass'
+                })
+              : true;
+          }
+        })
+    })
+  );
 };


### PR DESCRIPTION
## Description

The previous PR (#6567) made our root password validation controllable by a feature flag, but it didn't actually use the new validation logic anywhere. This PR (should) manually validate root passwords in all the places where we previously validated them. I think this is a comprehensive list, but please check me:

- Linode creation (LinodeCreateContainer)
- Linode Disk creation
- Linode rebuild

Other places where we take password inputs, such as Managed credentials, never did client validation in the first place since they don't share the API's criteria.

## Note to Reviewers

Toggle the flag to each of its values (`none`, `length`, `complexity`) and make sure validation is working properly.