### PR TITLE
Fix Longview date formatting

### DIFF
--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientHeader.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientHeader.tsx
@@ -111,10 +111,9 @@ export const LongviewClientHeader: React.FC<CombinedProps> = props => {
   const numPackagesToUpdate = packages ? packages.length : 0;
   const packagesToUpdate = getPackageNoticeText(packages);
 
-  const utcLastUpdatedTime = new Date(longviewClientLastUpdated!).toUTCString();
   const formattedlastUpdatedTime =
     longviewClientLastUpdated !== undefined
-      ? `Last updated ${formatDate(utcLastUpdatedTime, {
+      ? `Last updated ${formatDate(longviewClientLastUpdated, {
           humanizeCutoff: 'never'
         })}`
       : 'Latest update time not available';

--- a/packages/manager/src/store/events/event.helpers.test.ts
+++ b/packages/manager/src/store/events/event.helpers.test.ts
@@ -83,9 +83,13 @@ describe('event.helpers', () => {
         mostRecentCreated(new Date(`1970-01-01T00:00:00`).getTime(), {
           created: `2018-12-03T22:37:20`
         })
-      ).toBe(DateTime.fromISO(`2018-12-03T22:37:20`).valueOf());
+      ).toBe(
+        DateTime.fromISO(`2018-12-03T22:37:20`, { zone: 'UTC' }).valueOf()
+      );
 
-      const recentTime = DateTime.fromISO(`2018-12-03T23:37:20`).valueOf();
+      const recentTime = DateTime.fromISO(`2018-12-03T23:37:20`, {
+        zone: 'UTC'
+      }).valueOf();
       expect(
         mostRecentCreated(recentTime, { created: `2018-12-03T22:37:20` })
       ).toBe(recentTime);

--- a/packages/manager/src/store/events/event.reducer.test.ts
+++ b/packages/manager/src/store/events/event.reducer.test.ts
@@ -67,7 +67,7 @@ describe('events.reducer', () => {
         it('should update the mostRecentEventTime', () => {
           expect(state).toHaveProperty(
             'mostRecentEventTime',
-            DateTime.fromISO('2018-12-03T22:34:09').valueOf()
+            DateTime.fromISO('2018-12-03T22:34:09', { zone: 'utc' }).valueOf()
           );
         });
 

--- a/packages/manager/src/store/linodes/linode.events.test.ts
+++ b/packages/manager/src/store/linodes/linode.events.test.ts
@@ -5,8 +5,8 @@ describe('shouldRequestNotifications', () => {
   const d1 = '2019-05-23T12:00:00';
   const d2 = '2019-05-23T12:00:01';
 
-  const d1InMilliseconds = DateTime.fromISO(d1).valueOf();
-  const d2InMilliseconds = DateTime.fromISO(d2).valueOf();
+  const d1InMilliseconds = DateTime.fromISO(d1, { zone: 'UTC' }).valueOf();
+  const d2InMilliseconds = DateTime.fromISO(d2, { zone: 'UTC' }).valueOf();
 
   it('should return `true` if there is a linode_resize event created AFTER the last time notifications were updated', () => {
     expect(

--- a/packages/manager/src/utilities/date.ts
+++ b/packages/manager/src/utilities/date.ts
@@ -3,9 +3,14 @@ import { DateTime } from 'luxon';
  * @returns a valid Luxon date if the format is API or ISO, Null if not
  * @param date date in either ISO 8606 (2019-01-02T12:34:42+00 or API format 2019-01-02 12:34:42
  */
-export const parseAPIDate = (date: string) => {
-  const date1 = DateTime.fromISO(date, { zone: 'utc' });
-  if (date1.isValid) {
+export const parseAPIDate = (date: string | number) => {
+  let date1;
+  if (typeof date === 'string') {
+    date1 = DateTime.fromISO(date, { zone: 'utc' });
+  } else if (typeof date === 'number') {
+    date1 = DateTime.fromMillis(date, { zone: 'utc' });
+  }
+  if (date1?.isValid) {
     return date1;
   }
   throw new Error(`invalid date format: ${date}`);

--- a/packages/manager/src/utilities/formatDate.ts
+++ b/packages/manager/src/utilities/formatDate.ts
@@ -44,7 +44,7 @@ interface FormatDateOptions {
  * @param options
  */
 export const formatDate = (
-  date: string,
+  date: string | number,
   options: FormatDateOptions = {}
 ): string => {
   let time;


### PR DESCRIPTION
Added a case for formatDate to accept a number. LongviewClientHeader
was passing an ISO string to formatDate, which it doesn't recognize.

By using fromMillis with the actual clientLastUpdated value, we can
avoid the back and forth conversion.

