### PR TITLE
Update OCA links for Nextcloud and Percona

### DIFF
--- a/packages/manager/src/features/OneClickApps/FakeSpec.ts
+++ b/packages/manager/src/features/OneClickApps/FakeSpec.ts
@@ -372,7 +372,7 @@ export const oneClickApps: OCA[] = [
       {
         title: 'Use a Block Storage Volume with Nextcloud',
         href:
-          'https://www.linode.com/docs/applications/cloud-storage/use-block-storage-volume-with-nextcloud/'
+          'https://www.linode.com/docs/platform/one-click/how-to-deploy-nextcloud-with-one-click-apps/'
       }
     ],
     logo_url: 'assets/nextcloud_color.svg'
@@ -404,7 +404,7 @@ export const oneClickApps: OCA[] = [
       {
         title: 'Percona Monitoring and Management',
         href:
-          'https://www.percona.com/software/database-tools/percona-monitoring-and-management'
+          'https://www.linode.com/docs/platform/one-click/how-to-deploy-percona-monitoring-management-with-one-click-apps/'
       }
     ],
     logo_url: 'assets/percona_color.svg'

--- a/packages/manager/src/features/OneClickApps/FakeSpec.ts
+++ b/packages/manager/src/features/OneClickApps/FakeSpec.ts
@@ -370,7 +370,7 @@ export const oneClickApps: OCA[] = [
     summary: `A file sharing service that allows you to store your important documents and images in one centralized location.`,
     related_guides: [
       {
-        title: 'Use a Block Storage Volume with Nextcloud',
+        title: 'Deploying Nextcloud on Linode with One-Click Apps',
         href:
           'https://www.linode.com/docs/platform/one-click/how-to-deploy-nextcloud-with-one-click-apps/'
       }
@@ -402,7 +402,8 @@ export const oneClickApps: OCA[] = [
       'An open source analytics and performance monitoring solution for databases with a focus on user-friendly metrics visualizations.',
     related_info: [
       {
-        title: 'Percona Monitoring and Management',
+        title:
+          'Deploying Percona Monitoring Management (PMM) with One-Click Apps',
         href:
           'https://www.linode.com/docs/platform/one-click/how-to-deploy-percona-monitoring-management-with-one-click-apps/'
       }


### PR DESCRIPTION
Note: These links don't currently point to valid guides. The apps will remain behind a flag until the guides are published.