### PR TITLE
fix disabling a graph line in linegraph

### DIFF
--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -286,9 +286,10 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
               </TableRow>
             </TableHead>
             <TableBody>
-              {legendRows?.map((tick: any, idx: number) => {
+              {legendRows?.map((_tick: any, idx: number) => {
                 const bgColor = data[idx].backgroundColor;
                 const title = data[idx].label;
+                const hidden = hiddenDatasets.includes(idx);
                 const { data: metricsData, format } = legendRows[idx];
                 return (
                   <TableRow key={idx}>
@@ -300,14 +301,14 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
                         className={classes.toggleButton}
                       >
                         <div
-                          className={`${classes.legendIcon} ${tick.hidden &&
+                          className={`${classes.legendIcon} ${hidden &&
                             classes.crossedOut}`}
                           style={{
                             background: bgColor,
                             borderColor: bgColor
                           }}
                         />
-                        <span className={tick.hidden ? classes.crossedOut : ''}>
+                        <span className={hidden ? classes.crossedOut : ''}>
                           {title}
                         </span>
                       </Button>


### PR DESCRIPTION
## Description

Fixing disabling a linegraph line should cross it out:
![image](https://user-images.githubusercontent.com/27222128/86147029-e6ff3f80-bac6-11ea-8f3e-1c5b74e1c8c4.png)


## Type of Change
- Bug fix ('fix', 'repair', 'bug')
