### PR TITLE
M3-4294: Analytics tab in Linode Details

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary_CMR.tsx
@@ -41,6 +41,7 @@ import NetworkGraph from './NetworkGraph';
 import StatsPanel from './StatsPanel';
 import { ChartProps } from './types';
 import { parseAPIDate } from 'src/utilities/date';
+import Paper from 'src/components/core/Paper';
 
 setUpCharts();
 
@@ -77,7 +78,7 @@ const styles = (theme: Theme) =>
     },
     chart: {
       position: 'relative',
-      paddingLeft: theme.spacing(1)
+      paddingLeft: theme.spacing(3)
     },
     bottomLegend: {
       margin: `${theme.spacing(2)}px ${theme.spacing(1)}px ${theme.spacing(
@@ -100,7 +101,8 @@ const styles = (theme: Theme) =>
       display: 'flex',
       alignItems: 'center',
       marginTop: theme.spacing(2),
-      marginBottom: theme.spacing(2)
+      marginBottom: theme.spacing(2),
+      paddingLeft: '32px'
     },
     chartSelect: {
       maxWidth: 150
@@ -405,7 +407,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
     }
 
     return (
-      <React.Fragment>
+      <Paper>
         <DocumentTitleSegment segment={`${linode.label} - Summary`} />
 
         <Grid
@@ -449,7 +451,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
             <NetworkGraph stats={this.state.stats} {...chartProps} />
           </Grid>
         </Grid>
-      </React.Fragment>
+      </Paper>
     );
   }
 }

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary_CMR.tsx
@@ -130,7 +130,6 @@ const styles = (theme: Theme) =>
       paddingRight: '1em'
     },
     graphGrids: {
-      paddingLeft: '8px',
       [theme.breakpoints.up('sm')]: {
         flexWrap: 'nowrap'
       }
@@ -417,49 +416,46 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
       <Paper>
         <DocumentTitleSegment segment={`${linode.label} - Summary`} />
 
-        <Grid
-          container
-          id="tabpanel-summary"
-          role="tabpanel"
-          aria-labelledby="tab-summary"
-        >
-          <Grid item className={classes.main}>
-            <Grid item className="py0">
-              <div className={classes.graphControls}>
-                <Typography variant="h2" className={classes.labelRangeSelect}>
-                  Resource Allocation
-                </Typography>
-                <Select
-                  options={this.rangeSelectOptions}
-                  defaultValue={this.rangeSelectOptions[0]}
-                  onChange={this.handleChartRangeChange}
-                  name="chartRange"
-                  id="chartRange"
-                  small
-                  label="Select Time Range"
-                  hideLabel
-                  className={classes.chartSelect}
-                  isClearable={false}
-                  data-qa-item="chartRange"
-                />
-              </div>
-            </Grid>
+        <Grid item className={classes.main}>
+          <Grid item className="py0">
+            <div className={classes.graphControls}>
+              <Typography variant="h2" className={classes.labelRangeSelect}>
+                Resource Allocation
+              </Typography>
+              <Select
+                options={this.rangeSelectOptions}
+                defaultValue={this.rangeSelectOptions[0]}
+                onChange={this.handleChartRangeChange}
+                name="chartRange"
+                id="chartRange"
+                small
+                label="Select Time Range"
+                hideLabel
+                className={classes.chartSelect}
+                isClearable={false}
+                data-qa-item="chartRange"
+              />
+            </div>
+          </Grid>
 
-            <Grid container direction="row" className={classes.graphGrids}>
+          <Grid container direction="row" className={classes.graphGrids}>
+            <Grid item>
               <StatsPanel
                 title="CPU (%)"
                 renderBody={this.renderCPUChart}
                 {...chartProps}
               />
+            </Grid>
+            <Grid item>
               <StatsPanel
                 title="Disk IO (blocks/s)"
                 renderBody={this.renderDiskIOChart}
                 {...chartProps}
               />
             </Grid>
-
-            <NetworkGraph stats={this.state.stats} {...chartProps} />
           </Grid>
+
+          <NetworkGraph stats={this.state.stats} {...chartProps} />
         </Grid>
       </Paper>
     );

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary_CMR.tsx
@@ -79,7 +79,8 @@ const styles = (theme: Theme) =>
     },
     chart: {
       position: 'relative',
-      paddingLeft: theme.spacing(3)
+      paddingLeft: theme.spacing(3),
+      width: '400px'
     },
     bottomLegend: {
       margin: `${theme.spacing(2)}px ${theme.spacing(1)}px ${theme.spacing(

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary_CMR.tsx
@@ -37,7 +37,7 @@ import {
   formatPercentage,
   getMetrics
 } from 'src/utilities/statMetrics';
-import NetworkGraph from './NetworkGraph';
+import NetworkGraph from './NetworkGraph_CMR';
 import StatsPanel from './StatsPanel';
 import { ChartProps } from './types';
 import { parseAPIDate } from 'src/utilities/date';
@@ -79,8 +79,7 @@ const styles = (theme: Theme) =>
     },
     chart: {
       position: 'relative',
-      paddingLeft: theme.spacing(3),
-      width: '400px'
+      paddingLeft: theme.spacing(3)
     },
     bottomLegend: {
       margin: `${theme.spacing(2)}px ${theme.spacing(1)}px ${theme.spacing(
@@ -131,7 +130,10 @@ const styles = (theme: Theme) =>
       paddingRight: '1em'
     },
     graphGrids: {
-      paddingLeft: '8px'
+      paddingLeft: '8px',
+      [theme.breakpoints.up('sm')]: {
+        flexWrap: 'nowrap'
+      }
     }
   });
 
@@ -158,7 +160,7 @@ type CombinedProps = LinodeContextProps &
   WithImages &
   WithStyles<ClassNames>;
 
-const chartHeight = 150;
+const chartHeight = 300;
 
 const statsFetchInterval = 30000;
 
@@ -421,7 +423,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
           role="tabpanel"
           aria-labelledby="tab-summary"
         >
-          <Grid item xs={12} md={8} lg={9} className={classes.main}>
+          <Grid item className={classes.main}>
             <Grid item className="py0">
               <div className={classes.graphControls}>
                 <Typography variant="h2" className={classes.labelRangeSelect}>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary_CMR.tsx
@@ -64,6 +64,7 @@ type ClassNames =
 const styles = (theme: Theme) =>
   createStyles({
     main: {
+      paddingTop: theme.spacing(1),
       [theme.breakpoints.up('md')]: {
         order: 1
       }

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary_CMR.tsx
@@ -440,14 +440,14 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
           </Grid>
 
           <Grid container direction="row" className={classes.graphGrids}>
-            <Grid item>
+            <Grid item xs={12}>
               <StatsPanel
                 title="CPU (%)"
                 renderBody={this.renderCPUChart}
                 {...chartProps}
               />
             </Grid>
-            <Grid item>
+            <Grid item xs={12}>
               <StatsPanel
                 title="Disk IO (blocks/s)"
                 renderBody={this.renderDiskIOChart}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary_CMR.tsx
@@ -58,7 +58,8 @@ type ClassNames =
   | 'subHeaderOuter'
   | 'textWrap'
   | 'headerOuter'
-  | 'labelRangeSelect';
+  | 'labelRangeSelect'
+  | 'graphGrids';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -127,6 +128,9 @@ const styles = (theme: Theme) =>
     },
     labelRangeSelect: {
       paddingRight: '1em'
+    },
+    graphGrids: {
+      paddingLeft: '8px'
     }
   });
 
@@ -153,7 +157,7 @@ type CombinedProps = LinodeContextProps &
   WithImages &
   WithStyles<ClassNames>;
 
-const chartHeight = 300;
+const chartHeight = 150;
 
 const statsFetchInterval = 30000;
 
@@ -438,16 +442,19 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
               </div>
             </Grid>
 
-            <StatsPanel
-              title="CPU (%)"
-              renderBody={this.renderCPUChart}
-              {...chartProps}
-            />
-            <StatsPanel
-              title="Disk IO (blocks/s)"
-              renderBody={this.renderDiskIOChart}
-              {...chartProps}
-            />
+            <Grid container direction="row" className={classes.graphGrids}>
+              <StatsPanel
+                title="CPU (%)"
+                renderBody={this.renderCPUChart}
+                {...chartProps}
+              />
+              <StatsPanel
+                title="Disk IO (blocks/s)"
+                renderBody={this.renderDiskIOChart}
+                {...chartProps}
+              />
+            </Grid>
+
             <NetworkGraph stats={this.state.stats} {...chartProps} />
           </Grid>
         </Grid>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph.tsx
@@ -31,7 +31,7 @@ const formatTotalTraffic = (value: number) => readableBytes(value).formatted;
 const useStyles = makeStyles((theme: Theme) => ({
   chart: {
     position: 'relative',
-    paddingLeft: theme.spacing(1)
+    paddingLeft: theme.spacing(3)
   },
   totalTraffic: {
     margin: '12px'

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph.tsx
@@ -139,7 +139,7 @@ export const NetworkGraph: React.FC<CombinedProps> = props => {
   return (
     <>
       <StatsPanel
-        title={`IPv4 Traffic (${v4Unit}/s)`}
+        title={`Network — IPv4 (${v4Unit}/s)`}
         renderBody={() => (
           <Graph
             data={v4Data}
@@ -152,7 +152,7 @@ export const NetworkGraph: React.FC<CombinedProps> = props => {
         {...rest}
       />
       <StatsPanel
-        title={`IPv6 Traffic (${v6Unit}/s)`}
+        title={`Network — IPv6 (${v6Unit}/s)`}
         renderBody={() => (
           <Graph
             data={v6Data}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph_CMR.tsx
@@ -31,7 +31,7 @@ const formatTotalTraffic = (value: number) => readableBytes(value).formatted;
 const useStyles = makeStyles((theme: Theme) => ({
   chart: {
     position: 'relative',
-    paddingLeft: theme.spacing(1)
+    paddingLeft: theme.spacing(3)
   },
   totalTraffic: {
     margin: '12px'
@@ -139,7 +139,7 @@ export const NetworkGraph: React.FC<CombinedProps> = props => {
   return (
     <>
       <StatsPanel
-        title={`IPv4 Traffic (${v4Unit}/s)`}
+        title={`Network — IPv4 (${v4Unit}/s)`}
         renderBody={() => (
           <Graph
             data={v4Data}
@@ -152,7 +152,7 @@ export const NetworkGraph: React.FC<CombinedProps> = props => {
         {...rest}
       />
       <StatsPanel
-        title={`IPv6 Traffic (${v6Unit}/s)`}
+        title={`Network — IPv6 (${v6Unit}/s)`}
         renderBody={() => (
           <Graph
             data={v6Data}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph_CMR.tsx
@@ -35,6 +35,12 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   totalTraffic: {
     margin: '12px'
+  },
+  graphGrids: {
+    paddingLeft: '8px',
+    [theme.breakpoints.up('sm')]: {
+      flexWrap: 'nowrap'
+    }
   }
 }));
 
@@ -71,6 +77,8 @@ const _getMetrics = (data: NetworkStats) => {
 
 export const NetworkGraph: React.FC<CombinedProps> = props => {
   const { rangeSelection, stats, theme, ...rest } = props;
+
+  const classes = useStyles();
 
   const v4Data: NetworkStats = {
     publicIn: pathOr([], ['data', 'netv4', 'in'], stats),
@@ -137,7 +145,7 @@ export const NetworkGraph: React.FC<CombinedProps> = props => {
   };
 
   return (
-    <>
+    <Grid container direction="row" className={classes.graphGrids}>
       <StatsPanel
         title={`Network — IPv4 (${v4Unit}/s)`}
         renderBody={() => (
@@ -164,7 +172,7 @@ export const NetworkGraph: React.FC<CombinedProps> = props => {
         )}
         {...rest}
       />
-    </>
+    </Grid>
   );
 };
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph_CMR.tsx
@@ -23,7 +23,7 @@ import {
 } from 'src/utilities/statMetrics';
 import { readableBytes } from 'src/utilities/unitConversions';
 import StatsPanel from './StatsPanel';
-import TotalTraffic, { TotalTrafficProps } from './TotalTraffic';
+import { TotalTrafficProps } from './TotalTraffic';
 import { ChartProps } from './types';
 
 const formatTotalTraffic = (value: number) => readableBytes(value).formatted;
@@ -200,8 +200,7 @@ const Graph: React.FC<GraphProps> = props => {
     rangeSelection,
     theme,
     timezone,
-    unit,
-    totalTraffic
+    unit
   } = props;
 
   const format = formatBitsPerSecond;
@@ -227,71 +226,60 @@ const Graph: React.FC<GraphProps> = props => {
   const convertedPrivateOut = data.privateOut;
 
   return (
-    <React.Fragment>
-      <div className={classes.chart}>
-        <LineGraph
-          timezone={timezone}
-          chartHeight={chartHeight}
-          unit={`/s`}
-          formatData={convertNetworkData}
-          formatTooltip={_formatTooltip}
-          showToday={rangeSelection === '24'}
-          data={[
-            {
-              borderColor: 'transparent',
-              backgroundColor: theme.graphs.network.inbound,
-              data: convertedPublicIn,
-              label: 'Public Inbound'
-            },
-            {
-              borderColor: 'transparent',
-              backgroundColor: theme.graphs.network.outbound,
-              data: convertedPublicOut,
-              label: 'Public Outbound'
-            },
-            {
-              borderColor: 'transparent',
-              backgroundColor: theme.graphs.purple,
-              data: convertedPrivateIn,
-              label: 'Private Inbound'
-            },
-            {
-              borderColor: 'transparent',
-              backgroundColor: theme.graphs.yellow,
-              data: convertedPrivateOut,
-              label: 'Private Outbound'
-            }
-          ]}
-          legendRows={[
-            {
-              data: metrics.publicIn,
-              format
-            },
-            {
-              data: metrics.publicOut,
-              format
-            },
-            {
-              data: metrics.privateIn,
-              format
-            },
-            {
-              data: metrics.privateOut,
-              format
-            }
-          ]}
-        />
-      </div>
-      {rangeSelection === '24' && (
-        <Grid item xs={12} lg={6} className={classes.totalTraffic}>
-          <TotalTraffic
-            inTraffic={totalTraffic.inTraffic}
-            outTraffic={totalTraffic.outTraffic}
-            combinedTraffic={totalTraffic.combinedTraffic}
-          />
-        </Grid>
-      )}
-    </React.Fragment>
+    <div className={classes.chart}>
+      <LineGraph
+        timezone={timezone}
+        chartHeight={chartHeight}
+        unit={`/s`}
+        formatData={convertNetworkData}
+        formatTooltip={_formatTooltip}
+        showToday={rangeSelection === '24'}
+        data={[
+          {
+            borderColor: 'transparent',
+            backgroundColor: theme.graphs.network.inbound,
+            data: convertedPublicIn,
+            label: 'Public Inbound'
+          },
+          {
+            borderColor: 'transparent',
+            backgroundColor: theme.graphs.network.outbound,
+            data: convertedPublicOut,
+            label: 'Public Outbound'
+          },
+          {
+            borderColor: 'transparent',
+            backgroundColor: theme.graphs.purple,
+            data: convertedPrivateIn,
+            label: 'Private Inbound'
+          },
+          {
+            borderColor: 'transparent',
+            backgroundColor: theme.graphs.yellow,
+            data: convertedPrivateOut,
+            label: 'Private Outbound'
+          }
+        ]}
+        legendRows={[
+          {
+            data: metrics.publicIn,
+            format
+          },
+          {
+            data: metrics.publicOut,
+            format
+          },
+          {
+            data: metrics.privateIn,
+            format
+          },
+          {
+            data: metrics.privateOut,
+            format
+          }
+        ]}
+      />
+    </div>
   );
 };
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph_CMR.tsx
@@ -146,7 +146,7 @@ export const NetworkGraph: React.FC<CombinedProps> = props => {
 
   return (
     <Grid container direction="row" className={classes.graphGrids}>
-      <Grid item>
+      <Grid item xs={12}>
         <StatsPanel
           title={`Network — IPv4 (${v4Unit}/s)`}
           renderBody={() => (
@@ -161,7 +161,7 @@ export const NetworkGraph: React.FC<CombinedProps> = props => {
           {...rest}
         />
       </Grid>
-      <Grid item>
+      <Grid item xs={12}>
         <StatsPanel
           title={`Network — IPv6 (${v6Unit}/s)`}
           renderBody={() => (

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph_CMR.tsx
@@ -146,32 +146,36 @@ export const NetworkGraph: React.FC<CombinedProps> = props => {
 
   return (
     <Grid container direction="row" className={classes.graphGrids}>
-      <StatsPanel
-        title={`Network — IPv4 (${v4Unit}/s)`}
-        renderBody={() => (
-          <Graph
-            data={v4Data}
-            unit={v4Unit}
-            totalTraffic={v4totalTraffic}
-            metrics={v4Metrics}
-            {...commonGraphProps}
-          />
-        )}
-        {...rest}
-      />
-      <StatsPanel
-        title={`Network — IPv6 (${v6Unit}/s)`}
-        renderBody={() => (
-          <Graph
-            data={v6Data}
-            unit={v6Unit}
-            totalTraffic={v6totalTraffic}
-            metrics={v6Metrics}
-            {...commonGraphProps}
-          />
-        )}
-        {...rest}
-      />
+      <Grid item>
+        <StatsPanel
+          title={`Network — IPv4 (${v4Unit}/s)`}
+          renderBody={() => (
+            <Graph
+              data={v4Data}
+              unit={v4Unit}
+              totalTraffic={v4totalTraffic}
+              metrics={v4Metrics}
+              {...commonGraphProps}
+            />
+          )}
+          {...rest}
+        />
+      </Grid>
+      <Grid item>
+        <StatsPanel
+          title={`Network — IPv6 (${v6Unit}/s)`}
+          renderBody={() => (
+            <Graph
+              data={v6Data}
+              unit={v6Unit}
+              totalTraffic={v6totalTraffic}
+              metrics={v6Metrics}
+              {...commonGraphProps}
+            />
+          )}
+          {...rest}
+        />
+      </Grid>
     </Grid>
   );
 };


### PR DESCRIPTION
## Description
Analytics tab in Linode Details as per the designs, with the old Summary tab used as a starting point.

## Type of Change
- Non breaking change ('update', 'change')

## To-Do

- [x] Two rows of two charts
- [x] Group charts together within a `<Paper>` element or something similar

## Note To Reviewers
The designs have a Longview section, but we do not have a way to tie those in presently to Linodes.
