### PR TITLE
Fix Percona name and matching logic

### DIFF
--- a/packages/manager/src/features/OneClickApps/AppDetailDrawer.tsx
+++ b/packages/manager/src/features/OneClickApps/AppDetailDrawer.tsx
@@ -65,13 +65,16 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-export const AppDetailDrawer: React.FunctionComponent<
-  CombinedProps
-> = props => {
+export const AppDetailDrawer: React.FunctionComponent<CombinedProps> = props => {
   const { classes, stackscriptID, open, onClose } = props;
-  const app = oneClickApps.find(eachApp =>
-    Boolean(stackscriptID.match(eachApp.name))
-  ); // This is horrible
+  const app = oneClickApps.find(eachApp => {
+    const cleanedAppName = eachApp.name.replace(
+      /[-\/\\^$*+?.()|[\]{}]/g,
+      '\\$&'
+    );
+    const regex = new RegExp(cleanedAppName);
+    return Boolean(stackscriptID.match(regex));
+  }); // This is horrible
   if (!app) {
     return null;
   }
@@ -107,17 +110,13 @@ export const AppDetailDrawer: React.FunctionComponent<
         </Grid>
         <Grid item>
           <Typography
-          variant="body1"
-          className={classes.description}
-          dangerouslySetInnerHTML={{ __html: sanitizeHTML(app.description) }}
+            variant="body1"
+            className={classes.description}
+            dangerouslySetInnerHTML={{ __html: sanitizeHTML(app.description) }}
           />
         </Grid>
         {app.related_info && (
-          <LinkSection
-            title="More info"
-            links={app.related_info}
-            icon={Link}
-          />
+          <LinkSection title="More info" links={app.related_info} icon={Link} />
         )}
         {app.related_guides && (
           <LinkSection
@@ -126,13 +125,7 @@ export const AppDetailDrawer: React.FunctionComponent<
             icon={LibraryBook}
           />
         )}
-        {app.tips && (
-          <TipSection
-          title="Tips"
-          tips={app.tips}
-          icon={Info}
-          />
-        )}
+        {app.tips && <TipSection title="Tips" tips={app.tips} icon={Info} />}
       </Grid>
     </Drawer>
   );

--- a/packages/manager/src/features/OneClickApps/FakeSpec.ts
+++ b/packages/manager/src/features/OneClickApps/FakeSpec.ts
@@ -396,7 +396,7 @@ export const oneClickApps: OCA[] = [
     logo_url: 'assets/plesk_color.svg'
   },
   {
-    name: 'Percona',
+    name: 'Percona (PMM)',
     description: `Percona Monitoring and Management (PMM) is an open source GUI for managing and monitoring the performance of your MySQL, MariaDB, PostgreSQL, and MongoDB databases. This tool helps you optimize your database’s performance, manage your database instances, and keep track of and identify security issues.`,
     summary:
       'An open source analytics and performance monitoring solution for databases with a focus on user-friendly metrics visualizations.',


### PR DESCRIPTION
- Rename Percona to Percona (PMM)

- Update matching logic in AppDetailDrawer so that app names
with parentheses don't break it.

