### PR TITLE
Restore threshold for audit-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   build-essential g++ google-chrome-stable curl
 install:
   - yarn install:all
-  - if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then audit-ci --moderate; fi
+  - if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then audit-ci --low; fi
 
 script:
   - yarn build


### PR DESCRIPTION
Restores the change made in https://github.com/linode/manager/pull/6596.