### PR TITLE
Handle null dates in invoice details logic

### DIFF
--- a/packages/manager/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
+++ b/packages/manager/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
@@ -100,10 +100,11 @@ export const InvoiceDetail: React.FC<CombinedProps> = props => {
         setItems(items);
       })
       .catch(errorResponse => {
+        setLoading(false);
         setErrors(
           getAPIErrorOrDefault(
             errorResponse,
-            'Unable to retrieve invoice details. '
+            'Unable to retrieve invoice details.'
           )
         );
       });

--- a/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
@@ -7,6 +7,7 @@ import {
   Payment
 } from '@linode/api-v4/lib/account';
 import { splitEvery } from 'ramda';
+import { ISO_DATE_FORMAT } from 'src/constants';
 import { reportException } from 'src/exceptionReporting';
 import { FlagSet } from 'src/featureFlags';
 import formatDate from 'src/utilities/formatDate';
@@ -18,7 +19,6 @@ import {
   createPaymentsTable,
   createPaymentsTotalsTable
 } from './utils';
-import {ISO_DATE_FORMAT}from 'src/constants'
 
 const leftMargin = 30; // space that needs to be applied to every parent element
 const baseFont = 'helvetica';
@@ -240,7 +240,7 @@ export const printPayment = (
   taxID?: string
 ): PdfResult => {
   try {
-    const date = formatDate(payment.date, { format:ISO_DATE_FORMAT});
+    const date = formatDate(payment.date, { format: ISO_DATE_FORMAT });
     const doc = new jsPDF({
       unit: 'px'
     });

--- a/packages/manager/src/features/Billing/PdfGenerator/utils.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/utils.ts
@@ -5,6 +5,10 @@ import formatDate from 'src/utilities/formatDate';
 import { ISO_DATE_FORMAT } from 'src/constants';
 
 const formatDateForTable = (date: string): [string, string] => {
+  if (!date) {
+    // Probably the to or from value is null (this is the case with credits/promos)
+    return ['', ''];
+  }
   /** gives us a datetime separated by a space. e.g. 2019-09-30 08:25:00 */
   const res = formatDate(date);
 


### PR DESCRIPTION
## Description

For some types of invoice, `to` and or `from` are `null`. This causes an error in `parseAPIDate`. We have try/catch logic in place, so there is no customer impact. However we'd like to prevent reporting errors like this to Sentry.

I added logic to the specific method that calls `formatDate` when viewing an invoice. I considered moving the null checking to parseAPIDate itself, but it seems like maybe that would have side effects; it's also hard to say what the default should be (an empty string maybe?)

Fixed a small state management bug that was causing the loading state to hang when requesting an invalid invoice (404).

## Note

To test: find an invoice that will cause this behavior. Lots of ways to do this, I logged in as the customer in the JIRA ticket and used the invoice ID from the Sentry error (linked in the ticket as well). On develop, accessing the invoice causes an error to appear in Sentry. On this branch, should be clean. Behavior should be unchanged.