### PR TITLE
M3-4311 Change: Use Promise.all instead of Bluebird.reduce for getAll

### DIFF
--- a/packages/manager/src/factories/kubernetesCluster.ts
+++ b/packages/manager/src/factories/kubernetesCluster.ts
@@ -1,9 +1,13 @@
 import * as Factory from 'factory.ts';
-import { PoolNodeResponse } from '@linode/api-v4/lib/kubernetes/types';
+import {
+  KubernetesEndpointResponse,
+  PoolNodeResponse
+} from '@linode/api-v4/lib/kubernetes/types';
 import {
   ExtendedCluster,
   PoolNodeWithPrice
 } from 'src/features/Kubernetes/types';
+import { v4 } from 'uuid';
 
 /**
  * These factories work with the "extended" types used in our logic.
@@ -49,8 +53,8 @@ export const kubernetesClusterFactory = Factory.Sync.makeFactory<
   ExtendedCluster
 >({
   id: Factory.each(id => id),
-  created: '2020-01-01 8:00',
-  updated: '2020-01-01 8:00',
+  created: '2020-04-08T16:58:21',
+  updated: '2020-04-08T16:58:21',
   region: 'us-central',
   status: 'ready',
   label: Factory.each(i => `test-cluster-${i}`),
@@ -60,4 +64,10 @@ export const kubernetesClusterFactory = Factory.Sync.makeFactory<
   totalCPU: 4,
   totalStorage: 1000,
   tags: []
+});
+
+export const kubeEndpointFactory = Factory.Sync.makeFactory<
+  KubernetesEndpointResponse
+>({
+  endpoint: `https://${v4()}`
 });

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -6,6 +6,8 @@ import {
   firewallFactory,
   firewallDeviceFactory,
   kubernetesClusterFactory,
+  kubeEndpointFactory,
+  nodePoolFactory,
   linodeConfigFactory,
   linodeDiskFactory,
   linodeFactory,
@@ -80,6 +82,19 @@ export const handlers = [
   rest.get('*/lke/clusters', async (req, res, ctx) => {
     const clusters = kubernetesClusterFactory.buildList(10);
     return res(ctx.json(makeResourcePage(clusters)));
+  }),
+  rest.get('*/lke/clusters/:clusterId', async (req, res, ctx) => {
+    const id = req.params.clusterId;
+    const cluster = kubernetesClusterFactory.build({ id });
+    return res(ctx.json(cluster));
+  }),
+  rest.get('*/lke/clusters/:clusterId/pools', async (req, res, ctx) => {
+    const pools = nodePoolFactory.buildList(2);
+    return res(ctx.json(makeResourcePage(pools, { page: 1, pages: 2 })));
+  }),
+  rest.get('*/lke/clusters/*/api-endpoints', async (req, res, ctx) => {
+    const endpoints = kubeEndpointFactory.buildList(2);
+    return res(ctx.json(makeResourcePage(endpoints)));
   }),
   rest.get('*/firewalls/', (req, res, ctx) => {
     const firewalls = firewallFactory.buildList(10);

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -7,6 +7,7 @@ import {
   firewallDeviceFactory,
   kubernetesClusterFactory,
   kubeEndpointFactory,
+  invoiceItemFactory,
   nodePoolFactory,
   linodeConfigFactory,
   linodeDiskFactory,
@@ -90,7 +91,7 @@ export const handlers = [
   }),
   rest.get('*/lke/clusters/:clusterId/pools', async (req, res, ctx) => {
     const pools = nodePoolFactory.buildList(2);
-    return res(ctx.json(makeResourcePage(pools, { page: 1, pages: 2 })));
+    return res(ctx.json(makeResourcePage(pools)));
   }),
   rest.get('*/lke/clusters/*/api-endpoints', async (req, res, ctx) => {
     const endpoints = kubeEndpointFactory.buildList(2);
@@ -121,5 +122,9 @@ export const handlers = [
   }),
   rest.get('*/kubeconfig', (req, res, ctx) => {
     return res(ctx.json({ kubeconfig: 'SSBhbSBhIHRlYXBvdA==' }));
+  }),
+  rest.get('*invoices/:invoiceId/items', (req, res, ctx) => {
+    const items = invoiceItemFactory.buildList(10);
+    return res(ctx.json(makeResourcePage(items, { page: 1, pages: 4 })));
   })
 ];

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -19,9 +19,12 @@ import {
 
 import cachedRegions from 'src/cachedData/regions.json';
 
-export const makeResourcePage = (e: any[]) => ({
-  page: 1,
-  pages: 1,
+export const makeResourcePage = (
+  e: any[],
+  override: { page: number; pages: number } = { page: 1, pages: 1 }
+) => ({
+  page: override.page ?? 1,
+  pages: override.pages ?? 1,
   results: e.length,
   data: e
 });
@@ -91,8 +94,8 @@ export const handlers = [
     return res(ctx.json(makeResourcePage(nodeBalancers)));
   }),
   rest.get('*/domains', (req, res, ctx) => {
-    const domains = domainFactory.buildList(10);
-    return res(ctx.json(makeResourcePage(domains)));
+    const domains = domainFactory.buildList(500);
+    return res(ctx.json(makeResourcePage(domains, { page: 1, pages: 5 })));
   }),
   rest.get('*/volumes', (req, res, ctx) => {
     const volumes = volumeFactory.buildList(10);

--- a/packages/manager/src/utilities/getAll.ts
+++ b/packages/manager/src/utilities/getAll.ts
@@ -1,15 +1,6 @@
-import * as Bluebird from 'bluebird';
-import { Domain, getDomains } from '@linode/api-v4/lib/domains';
-import { getLinodes, Linode } from '@linode/api-v4/lib/linodes';
-import {
-  getNodeBalancers,
-  NodeBalancer
-} from '@linode/api-v4/lib/nodebalancers';
-import { getVolumes, Volume } from '@linode/api-v4/lib/volumes';
 import { range } from 'ramda';
 
 import { API_MAX_PAGE_SIZE } from 'src/constants';
-import { sendFetchAllEvent } from 'src/utilities/ga';
 
 export interface APIResponsePage<T> {
   page: number;
@@ -71,13 +62,16 @@ export const getAll: <T>(
       // Create an iterable list of the remaining pages.
       const remainingPages = range(page + 1, pages + 1);
 
+      const promises: Promise<any>[] = [];
+      remainingPages.forEach(thisPage => {
+        const promise = getter({ ...pagination, page: thisPage }, filter).then(
+          response => response.data
+        );
+        promises.push(promise);
+      });
       //
       return (
-        Bluebird.map(remainingPages, nextPage =>
-          getter({ ...pagination, page: nextPage }, filter).then(
-            response => response.data
-          )
-        )
+        Promise.all(promises)
           /** We're given data[][], so we flatten that, and append the first page response. */
           .then(resultPages => {
             const combinedData = resultPages.reduce((result, nextPage) => {
@@ -114,15 +108,20 @@ export const getAllWithArguments: <T>(
 
       // Create an iterable list of the remaining pages.
       const remainingPages = range(page + 1, pages + 1);
+      const promises: Promise<any>[] = [];
+      remainingPages.forEach(thisPage => {
+        const promise = getter(
+          ...args,
+          { ...pagination, page: thisPage },
+          filter
+        ).then(response => response.data);
+        promises.push(promise);
+      });
 
       //
       return (
-        Bluebird.map(remainingPages, nextPage =>
-          getter(...args, { ...pagination, page: nextPage }, filter).then(
-            response => response.data
-          )
-        )
-          /** We're given NodeBalancer[][], so we flatten that, and append the first page response. */
+        Promise.all(promises)
+          // eslint-disable-next-line
           .then(resultPages => {
             const combinedData = resultPages.reduce((result, nextPage) => {
               return [...result, ...nextPage];
@@ -135,80 +134,4 @@ export const getAllWithArguments: <T>(
       );
     }
   );
-};
-
-export type GetAllHandler = (
-  linodes: Linode[],
-  nodebalancers: NodeBalancer[],
-  volumes: Volume[],
-  domains: Domain[]
-) => any;
-
-/**
- * getAllEntities
- *
- * Uses getAll to request all instances of each type of entity and return
- * a 2d array of the combined results.
- *
- * @param cb Function that will be called after all requests have completed
- * with a 2d array of all the returned entities.
- */
-export const getAllEntities = (cb: GetAllHandler) =>
-  Bluebird.join(
-    getAll<Linode>(getLinodes)(),
-    getAll<NodeBalancer>(getNodeBalancers)(),
-    getAll<Volume>(getVolumes)(),
-    getAll<Domain>(getDomains)(),
-    /** for some reason typescript thinks ...results is implicitly typed as 'any' */
-    // @ts-ignore
-    (...results) => {
-      const resultData = [
-        results[0].data,
-        results[1].data,
-        results[2].data,
-        results[3].data
-      ];
-
-      /** total number of entities returned, as determined by the results API property */
-      const numOfEntities =
-        results[0].results +
-        results[1].results +
-        results[2].results +
-        results[3].results;
-      sendGetAllRequestToAnalytics(numOfEntities);
-      /** for some reason typescript thinks ...results is implicitly typed as 'any' */
-      // @ts-ignore
-      cb(...resultData);
-    }
-  );
-
-/**
- * sends off an analytics event with how many entities came back from a search request
- * for the purposes of determining how many entities does an average user have.
- *
- * @param { number } howManyThingsRequested - how many entities came back in our
- * network request to get all the things
- */
-const sendGetAllRequestToAnalytics = (howManyThingsRequested: number) => {
-  /**
-   * We are splitting analytics tracking into a few different buckets
-   */
-  let bucketText = '';
-  if (howManyThingsRequested > 500) {
-    bucketText = '500+';
-  } else if (howManyThingsRequested > 100) {
-    bucketText = '100-499';
-  } else if (howManyThingsRequested > 25) {
-    bucketText = '26-100';
-  } else if (howManyThingsRequested > 10) {
-    bucketText = '11-26';
-  } else {
-    bucketText = '0-10';
-  }
-
-  /**
-   * send an event with the number of requested entities
-   * and the URL pathname and query string
-   */
-  sendFetchAllEvent(bucketText, howManyThingsRequested);
 };


### PR DESCRIPTION
## Description

The hope is that this will help us improve performance for huge accounts. That doesn't seem to be panning out so far, but removing Bluebird in favor of Promise.all is on our radar.

Updates our mock helpers to allow you to specify a number of pages to request from the API. Currently the mocks are set up to simulate an account with a very large number of Domains; these changes will be removed before merge.