### PR TITLE
Fix: Longview CPU formatting

### DIFF
--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/CPU.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/CPU.tsx
@@ -83,8 +83,7 @@ export const sumCPUUsage = (CPUData: Record<string, CPU> = {}) => {
 
 export const normalizeValue = (value: number, numCores: number) => {
   const clamped = clamp(0, 100 * numCores)(value);
-  const rounded = Math.round(clamped);
-  return rounded;
+  return Math.round(clamped);
 };
 
 export const innerText = (value: number, loading: boolean, error: boolean) => {

--- a/packages/manager/src/features/Longview/shared/formatters.ts
+++ b/packages/manager/src/features/Longview/shared/formatters.ts
@@ -3,7 +3,8 @@ import { Stat, StatWithDummyPoint } from '../request.types';
 
 // This formatting is from Classic
 export const formatCPU = (n: number) => {
-  if (!n || typeof n !== 'number') {
+  // Have to safety check because LV API is unreliable
+  if (typeof n !== 'number') {
     return 'No data';
   }
   const numDigits = n >= 1 || n <= 0.01 ? 0 : 2;

--- a/packages/manager/src/features/Longview/shared/formatters.ts
+++ b/packages/manager/src/features/Longview/shared/formatters.ts
@@ -3,6 +3,9 @@ import { Stat, StatWithDummyPoint } from '../request.types';
 
 // This formatting is from Classic
 export const formatCPU = (n: number) => {
+  if (!n || typeof n !== 'number') {
+    return 'No data';
+  }
   const numDigits = n >= 1 || n <= 0.01 ? 0 : 2;
   return n.toFixed(numDigits) + '%';
 };


### PR DESCRIPTION
## Description

Longview was crashing intermittently for a customer; one of the methods we thought would always receive a number was not always receiving a number.
