### PR TITLE
Secondary Nav Width

### DIFF
--- a/packages/manager/src/features/TopMenu/TopMenu_CMR.tsx
+++ b/packages/manager/src/features/TopMenu/TopMenu_CMR.tsx
@@ -14,7 +14,10 @@ const useStyles = makeStyles((theme: Theme) => ({
     color: theme.palette.text.primary,
     backgroundColor: theme.bg.topMenu,
     position: 'relative',
-    paddingRight: '0 !important'
+    paddingRight: '0 !important',
+    display: 'flex',
+    justifyContent: 'center',
+    flexDirection: 'row'
   },
   toolbar: {
     padding: 0,
@@ -26,7 +29,10 @@ const useStyles = makeStyles((theme: Theme) => ({
     [theme.breakpoints.up('lg')]: {
       paddingLeft: theme.spacing(3),
       paddingRight: theme.spacing(3)
-    }
+    },
+    width: 1280,
+    paddingLeft: '0px !important',
+    paddingRight: '0px !important'
   }
 }));
 


### PR DESCRIPTION
## Description

Adjust the width of the secondary nav to be 1280px, centered.

<img width="1374" alt="Screen Shot 2020-07-10 at 8 57 12 AM" src="https://user-images.githubusercontent.com/16911484/87156887-65a86980-c28b-11ea-88ea-c5d6adae5bff.png">
