### PR TITLE
Fix Linodes Landing crash after deletion

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize_CMR.tsx
@@ -460,6 +460,10 @@ const mapStateToProps: MapStateToProps<StateProps, Props> = (
   const linodeDisks = state.__resources.linodeDisks;
   const profile = state.__resources.profile;
 
+  if (!linode) {
+    return {};
+  }
+
   return {
     linodeId: linode.id,
     linodeType: linode.type,

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -44,6 +44,9 @@ export const handlers = [
     const linodes = linodeFactory.buildList(10);
     return res(ctx.json(makeResourcePage(linodes)));
   }),
+  rest.delete('*/instances/*', async (req, res, ctx) => {
+    return res(ctx.json({}));
+  }),
   rest.get('*/instances/*/configs', async (req, res, ctx) => {
     const configs = linodeConfigFactory.buildList(3);
     return res(ctx.json(makeResourcePage(configs)));


### PR DESCRIPTION
Safe access Linode data in mapStateToProps from the LinodeResize modal.
Moving it outside of the LinodeDetailContext means that it is always
present on the landing page, and it was being read with the deleted Linode's
ID after deletion, causing a crash.

In addition, added a mock for Linode deletion.

## Note to Reviewers

You can use the new mocks to test this, Linode deletion now works there.