### PR TITLE
M3-4301: Configs Tab improvements

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/ConfigRow_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/ConfigRow_CMR.tsx
@@ -37,7 +37,6 @@ export const ConfigRow: React.FC<CombinedProps> = props => {
   const {
     config,
     linodeId,
-    linodeMemory,
     linodeDisks,
     linodeKernel,
     onBoot,
@@ -54,14 +53,13 @@ export const ConfigRow: React.FC<CombinedProps> = props => {
     const rootDevice = config.root_device;
     const device = rootDevice.slice(-3); // Isolate the 'sda', 'sdc', etc. piece
 
-    const deviceId = config.devices[device].disk_id;
+    const deviceId = config.devices[device]?.disk_id;
 
     const matchingDisk = linodeDisks.find(disk => disk.id === deviceId);
     const label = matchingDisk ? ` – ${matchingDisk.label}` : '';
     setRootDeviceLabel(`${rootDevice}${label}`);
   }, [config, linodeDisks]);
 
-  // If config.memory_limit === 0, use linodeMemory; the API interprets a memory limit of 0 as the RAM of the Linode itself.
   return (
     <TableRow key={config.id} data-qa-config={config.label}>
       <TableCell>{config.label}</TableCell>
@@ -72,9 +70,7 @@ export const ConfigRow: React.FC<CombinedProps> = props => {
       </TableCell>
       <TableCell>{linodeKernel}</TableCell>
       <TableCell>
-        {config.memory_limit === 0
-          ? `${linodeMemory} GB`
-          : `${config.memory_limit} MB`}
+        {config.memory_limit === 0 ? 'No limit' : `${config.memory_limit} MB`}
       </TableCell>
       <TableCell>{rootDeviceLabel}</TableCell>
       <TableCell className={classes.actionInner}>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs_CMR.tsx
@@ -26,6 +26,7 @@ import TableCell from 'src/components/TableCell/TableCell_CMR.tsx';
 import TableSortCell from 'src/components/TableSortCell/TableSortCell_CMR';
 import TableHead from 'src/components/core/TableHead';
 import TableRow from 'src/components/core/TableRow';
+import TableRowLoading from 'src/components/TableRowLoading/TableRowLoading_CMR';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 import PaginationFooter from 'src/components/PaginationFooter';
@@ -223,7 +224,7 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
           title="Confirm Boot"
           error={this.state.confirmBoot.error}
           open={this.state.confirmBoot.open}
-          onClose={this.resetConfirmConfigBoot}
+          onClose={this.cancelBoot}
           actions={this.bootConfigConfirmationActions}
         >
           <Typography>
@@ -338,18 +339,6 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
         error: undefined,
         configId,
         label
-      }
-    });
-  };
-
-  resetConfirmConfigBoot = () => {
-    this.setState({
-      confirmBoot: {
-        open: false,
-        error: undefined,
-        configId: undefined,
-        label: undefined,
-        submitting: false
       }
     });
   };
@@ -497,7 +486,9 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
                           const kernel = this.state.kernels.find(
                             kernelName => kernelName.id === thisConfig.kernel
                           );
-                          return (
+                          return this.state.kernelsLoading ? (
+                            <TableRowLoading colSpan={6} />
+                          ) : (
                             <ConfigRow
                               key={`config-row-${thisConfig.id}`}
                               config={thisConfig}


### PR DESCRIPTION
## Description
Improvements to https://github.com/linode/manager/pull/6602:

- Use TableRowLoading when kernels are loading to prevent table jump
- Put cancelBoot back as onClose handler for Boot modal
- 'No limit' shown for memory limit when config.memory_limit === 0, instead of the Linode RAM

## Type of Change
- Non breaking change ('update', 'change')
