### PR TITLE
M3-4332 Change: Use API search for large accounts

### DIFF
--- a/packages/manager/src/features/Kubernetes/kubeUtils.ts
+++ b/packages/manager/src/features/Kubernetes/kubeUtils.ts
@@ -99,6 +99,9 @@ export const getTotalNodesInCluster = (pools: PoolNodeWithPrice[]): number =>
   }, 0);
 
 export const getDescriptionForCluster = (cluster: ExtendedCluster) => {
+  if (!cluster.node_pools) {
+    return '';
+  }
   const nodes = getTotalNodesInCluster(cluster.node_pools);
   return `${pluralize('node', 'nodes', nodes)}, ${pluralize(
     'CPU core',

--- a/packages/manager/src/features/Search/useAPISearch.tsx
+++ b/packages/manager/src/features/Search/useAPISearch.tsx
@@ -1,0 +1,47 @@
+import { useCallback } from 'react';
+import { getDomains } from '@linode/api-v4/lib/domains';
+import { refinedSearch } from './refinedSearch';
+// import {
+//   SearchableItem,
+//   SearchResults,
+//   SearchResultsByEntity
+// } from './search.interfaces';
+import { domainToSearchableItem } from 'src/store/selectors/getSearchEntities';
+
+import { emptyResults, separateResultsByEntity } from './utils';
+
+interface Search {
+  searchAPI: (query: string) => Promise<any>; // Promise<SearchResults>;
+}
+
+export const useAPISearch = (): Search => {
+  const searchAPI = useCallback((searchText: string) => {
+    if (!searchText || searchText === '') {
+      return Promise.resolve({
+        searchResultsByEntity: emptyResults,
+        combinedResults: []
+      });
+    }
+
+    return requestEntities(searchText).then(results => {
+      console.log(results);
+      const combinedResults = refinedSearch(searchText, []);
+      return {
+        combinedResults,
+        searchResultsByEntity: separateResultsByEntity(combinedResults)
+      };
+    });
+  }, []);
+  return { searchAPI };
+};
+
+const requestEntities = (searchText: string) => {
+  console.log('searching');
+  return Promise.all([
+    getDomains({}, { domain: { '+contains': searchText } }).then(results =>
+      results.data.map(domainToSearchableItem)
+    )
+  ]);
+};
+
+export default useAPISearch;

--- a/packages/manager/src/features/Search/useAPISearch.tsx
+++ b/packages/manager/src/features/Search/useAPISearch.tsx
@@ -1,12 +1,23 @@
+import { flatten } from 'ramda';
 import { useCallback } from 'react';
 import { getDomains } from '@linode/api-v4/lib/domains';
+import { getImages } from '@linode/api-v4/lib/images';
+import { getLinodes } from '@linode/api-v4/lib/linodes';
+import { getKubernetesClusters } from '@linode/api-v4/lib/kubernetes';
+import { getNodeBalancers } from '@linode/api-v4/lib/nodebalancers';
+import { getVolumes } from '@linode/api-v4/lib/volumes';
 import { refinedSearch } from './refinedSearch';
-// import {
-//   SearchableItem,
-//   SearchResults,
-//   SearchResultsByEntity
-// } from './search.interfaces';
-import { domainToSearchableItem } from 'src/store/selectors/getSearchEntities';
+import { SearchableItem } from './search.interfaces';
+import { useTypes } from 'src/hooks/useTypes';
+import { useImages } from 'src/hooks/useImages';
+import {
+  domainToSearchableItem,
+  formatLinode,
+  imageToSearchableItem,
+  kubernetesClusterToSearchableItem,
+  nodeBalToSearchableItem,
+  volumeToSearchableItem
+} from 'src/store/selectors/getSearchEntities';
 
 import { emptyResults, separateResultsByEntity } from './utils';
 
@@ -15,33 +26,59 @@ interface Search {
 }
 
 export const useAPISearch = (): Search => {
-  const searchAPI = useCallback((searchText: string) => {
-    if (!searchText || searchText === '') {
-      return Promise.resolve({
-        searchResultsByEntity: emptyResults,
-        combinedResults: []
-      });
-    }
+  const { images } = useImages('public');
+  const { types } = useTypes();
+  const searchAPI = useCallback(
+    (searchText: string) => {
+      if (!searchText || searchText === '') {
+        return Promise.resolve({
+          searchResultsByEntity: emptyResults,
+          combinedResults: []
+        });
+      }
 
-    return requestEntities(searchText).then(results => {
-      console.log(results);
-      const combinedResults = refinedSearch(searchText, []);
-      return {
-        combinedResults,
-        searchResultsByEntity: separateResultsByEntity(combinedResults)
-      };
-    });
-  }, []);
+      return requestEntities(searchText, types.entities, images.itemsById).then(
+        results => {
+          const combinedResults = refinedSearch(searchText, results);
+          return {
+            combinedResults,
+            searchResultsByEntity: separateResultsByEntity(combinedResults)
+          };
+        }
+      );
+    },
+    [images.itemsById, types.entities]
+  );
+
   return { searchAPI };
 };
 
-const requestEntities = (searchText: string) => {
-  console.log('searching');
+const requestEntities = (searchText: string, types: any, images: any) => {
   return Promise.all([
     getDomains({}, { domain: { '+contains': searchText } }).then(results =>
       results.data.map(domainToSearchableItem)
+    ),
+    getLinodes({}, { label: { '+contains': searchText } }).then(results =>
+      results.data.map(thisResult => formatLinode(thisResult, types, images))
+    ),
+    getImages(
+      {},
+      {
+        '+and': [{ label: { '+contains': searchText } }, { is_public: false }]
+      }
+    ).then(results => results.data.map(imageToSearchableItem)),
+    getVolumes({}, { label: { '+contains': searchText } }).then(results =>
+      results.data.map(volumeToSearchableItem)
+    ),
+    getNodeBalancers({}, { label: { '+contains': searchText } }).then(results =>
+      results.data.map(nodeBalToSearchableItem)
+    ),
+    getKubernetesClusters().then(results =>
+      // Can't filter LKE by label (or anything maybe?)
+      // But no one has more than 500, so this is fine for the short term.
+      results.data.map(kubernetesClusterToSearchableItem)
     )
-  ]);
+  ]).then(results => (flatten(results) as unknown) as SearchableItem[]);
 };
 
 export default useAPISearch;

--- a/packages/manager/src/features/Search/useAPISearch.tsx
+++ b/packages/manager/src/features/Search/useAPISearch.tsx
@@ -1,13 +1,13 @@
 import { flatten } from 'ramda';
 import { useCallback } from 'react';
 import { getDomains } from '@linode/api-v4/lib/domains';
-import { getImages } from '@linode/api-v4/lib/images';
-import { getLinodes } from '@linode/api-v4/lib/linodes';
+import { getImages, Image } from '@linode/api-v4/lib/images';
+import { getLinodes, LinodeType } from '@linode/api-v4/lib/linodes';
 import { getKubernetesClusters } from '@linode/api-v4/lib/kubernetes';
 import { getNodeBalancers } from '@linode/api-v4/lib/nodebalancers';
 import { getVolumes } from '@linode/api-v4/lib/volumes';
 import { refinedSearch } from './refinedSearch';
-import { SearchableItem } from './search.interfaces';
+import { SearchableItem, SearchResults } from './search.interfaces';
 import { useTypes } from 'src/hooks/useTypes';
 import { useImages } from 'src/hooks/useImages';
 import {
@@ -22,7 +22,7 @@ import {
 import { emptyResults, separateResultsByEntity } from './utils';
 
 interface Search {
-  searchAPI: (query: string) => Promise<any>; // Promise<SearchResults>;
+  searchAPI: (query: string) => Promise<SearchResults>;
 }
 
 export const useAPISearch = (): Search => {
@@ -66,7 +66,11 @@ const generateFilter = (text: string, labelFieldName: string = 'label') => {
   };
 };
 
-const requestEntities = (searchText: string, types: any, images: any) => {
+const requestEntities = (
+  searchText: string,
+  types: LinodeType[],
+  images: Record<string, Image>
+) => {
   return Promise.all([
     getDomains({}, generateFilter(searchText, 'domain')).then(results =>
       results.data.map(domainToSearchableItem)

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -13,6 +13,7 @@ import withImages, { WithImages } from 'src/containers/withImages.container';
 import withStoreSearch, {
   SearchProps
 } from 'src/features/Search/withStoreSearch';
+import useAPISearch from 'src/features/Search/useAPISearch';
 import { useReduxLoad } from 'src/hooks/useReduxLoad';
 import { sendSearchBarUsedEvent } from 'src/utilities/ga.ts';
 import { debounce } from 'throttle-debounce';
@@ -69,6 +70,8 @@ export const SearchBar: React.FC<CombinedProps> = props => {
   const [searchActive, setSearchActive] = React.useState<boolean>(false);
   const [menuOpen, setMenuOpen] = React.useState<boolean>(false);
 
+  const { searchAPI } = useAPISearch();
+
   const { _loading } = useReduxLoad(
     ['linodes', 'nodeBalancers', 'images', 'domains', 'volumes', 'kubernetes'],
     REFRESH_INTERVAL,
@@ -77,7 +80,8 @@ export const SearchBar: React.FC<CombinedProps> = props => {
 
   React.useEffect(() => {
     search(searchText);
-  }, [_loading, search, searchText]);
+    searchAPI(searchText);
+  }, [_loading, search, searchAPI, searchText]);
 
   const handleSearchChange = (_searchText: string): void => {
     setSearchText(_searchText);

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar_CMR.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar_CMR.tsx
@@ -33,7 +33,7 @@ const Control = (props: any) => <components.Control {...props} />;
  * This doesn't share the same shape as the rest of the results, so should use
  * the default styling. */
 const Option = (props: any) => {
-  return ['redirect', 'info'].includes(props.value) ? (
+  return ['redirect', 'info', 'error'].includes(props.value) ? (
     <components.Option {...props} />
   ) : (
     <SearchSuggestion {...props} />
@@ -191,7 +191,8 @@ export const SearchBar: React.FC<CombinedProps> = props => {
   const finalOptions = createFinalOptions(
     apiResults, // combinedResults,
     searchText,
-    _loading
+    _loading || apiSearchLoading,
+    Boolean(apiError)
   );
 
   return (
@@ -265,7 +266,8 @@ export default compose<CombinedProps, {}>(
 export const createFinalOptions = (
   results: Item[],
   searchText: string = '',
-  loading: boolean = false
+  loading: boolean = false,
+  error: boolean = false
 ) => {
   const redirectOption = {
     value: 'redirect',
@@ -280,10 +282,19 @@ export const createFinalOptions = (
     label: 'Loading results...'
   };
 
+  const searchError = {
+    value: 'error',
+    label: 'Error retrieving search results'
+  };
+
   // Results aren't final as we're loading data
 
   if (loading) {
     return [redirectOption, loadingResults];
+  }
+
+  if (error) {
+    return [searchError];
   }
 
   // NO RESULTS:

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar_CMR.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar_CMR.tsx
@@ -15,6 +15,7 @@ import withStoreSearch, {
 } from 'src/features/Search/withStoreSearch';
 import useAPISearch from 'src/features/Search/useAPISearch';
 import { useReduxLoad } from 'src/hooks/useReduxLoad';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { sendSearchBarUsedEvent } from 'src/utilities/ga.ts';
 import { debounce } from 'throttle-debounce';
 import styled, { StyleProps } from './SearchBar_CMR.styles';
@@ -70,6 +71,10 @@ export const SearchBar: React.FC<CombinedProps> = props => {
   const [searchActive, setSearchActive] = React.useState<boolean>(false);
   const [menuOpen, setMenuOpen] = React.useState<boolean>(false);
 
+  const [apiResults, setAPIResults] = React.useState<any[]>([]);
+  const [apiError, setAPIError] = React.useState<string | null>(null);
+  const [apiSearchLoading, setAPILoading] = React.useState<boolean>(false);
+
   const { _loading } = useReduxLoad(
     ['linodes', 'nodeBalancers', 'images', 'domains', 'volumes', 'kubernetes'],
     REFRESH_INTERVAL,
@@ -78,10 +83,29 @@ export const SearchBar: React.FC<CombinedProps> = props => {
 
   const { searchAPI } = useAPISearch();
 
+  const _searchAPI = React.useRef(
+    debounce(500, false, (_searchText: string) => {
+      setAPILoading(true);
+      searchAPI(_searchText)
+        .then(searchResults => {
+          setAPIResults(searchResults.combinedResults);
+          setAPILoading(false);
+          setAPIError(null);
+        })
+        .catch(error => {
+          setAPIError(
+            getAPIErrorOrDefault(error, 'Error loading search results')[0]
+              .reason
+          );
+          setAPILoading(false);
+        });
+    })
+  ).current;
+
   React.useEffect(() => {
     search(searchText);
-    searchAPI(searchText);
-  }, [_loading, search, searchText, searchAPI]);
+    _searchAPI(searchText);
+  }, [_loading, search, searchText, _searchAPI]);
 
   const handleSearchChange = (_searchText: string): void => {
     setSearchText(_searchText);
@@ -165,7 +189,7 @@ export const SearchBar: React.FC<CombinedProps> = props => {
   };
 
   const finalOptions = createFinalOptions(
-    combinedResults,
+    apiResults, // combinedResults,
     searchText,
     _loading
   );

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar_CMR.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar_CMR.tsx
@@ -13,6 +13,7 @@ import withImages, { WithImages } from 'src/containers/withImages.container';
 import withStoreSearch, {
   SearchProps
 } from 'src/features/Search/withStoreSearch';
+import useAPISearch from 'src/features/Search/useAPISearch';
 import { useReduxLoad } from 'src/hooks/useReduxLoad';
 import { sendSearchBarUsedEvent } from 'src/utilities/ga.ts';
 import { debounce } from 'throttle-debounce';
@@ -75,9 +76,12 @@ export const SearchBar: React.FC<CombinedProps> = props => {
     searchActive // Only request things if the search bar is open/active.
   );
 
+  const { searchAPI } = useAPISearch();
+
   React.useEffect(() => {
     search(searchText);
-  }, [_loading, search, searchText]);
+    searchAPI(searchText);
+  }, [_loading, search, searchText, searchAPI]);
 
   const handleSearchChange = (_searchText: string): void => {
     setSearchText(_searchText);

--- a/packages/manager/src/store/selectors/getSearchEntities.ts
+++ b/packages/manager/src/store/selectors/getSearchEntities.ts
@@ -37,7 +37,7 @@ export const getNodebalIps = (nodebal: NodeBalancer): string[] => {
   return ips;
 };
 
-const formatLinode = (
+export const formatLinode = (
   linode: Linode,
   types: LinodeType[],
   images: Record<string, Image>
@@ -65,7 +65,7 @@ const formatLinode = (
   }
 });
 
-const volumeToSearchableItem = (volume: Volume): SearchableItem => ({
+export const volumeToSearchableItem = (volume: Volume): SearchableItem => ({
   label: volume.label,
   value: volume.id,
   entityType: 'volume',
@@ -84,7 +84,7 @@ const imageReducer = (accumulator: SearchableItem[], image: Image) =>
     ? accumulator
     : [...accumulator, imageToSearchableItem(image)];
 
-const imageToSearchableItem = (image: Image): SearchableItem => ({
+export const imageToSearchableItem = (image: Image): SearchableItem => ({
   label: image.label,
   value: image.id,
   entityType: 'image',
@@ -113,7 +113,9 @@ export const domainToSearchableItem = (domain: Domain): SearchableItem => ({
   }
 });
 
-const nodeBalToSearchableItem = (nodebal: NodeBalancer): SearchableItem => ({
+export const nodeBalToSearchableItem = (
+  nodebal: NodeBalancer
+): SearchableItem => ({
   label: nodebal.label,
   value: nodebal.id,
   entityType: 'nodebalancer',
@@ -127,7 +129,7 @@ const nodeBalToSearchableItem = (nodebal: NodeBalancer): SearchableItem => ({
   }
 });
 
-const kubernetesClusterToSearchableItem = (
+export const kubernetesClusterToSearchableItem = (
   kubernetesCluster: ExtendedCluster
 ): SearchableItem => ({
   label: kubernetesCluster.label,

--- a/packages/manager/src/store/selectors/getSearchEntities.ts
+++ b/packages/manager/src/store/selectors/getSearchEntities.ts
@@ -99,7 +99,7 @@ const imageToSearchableItem = (image: Image): SearchableItem => ({
   }
 });
 
-const domainToSearchableItem = (domain: Domain): SearchableItem => ({
+export const domainToSearchableItem = (domain: Domain): SearchableItem => ({
   label: domain.domain,
   value: domain.id,
   entityType: 'domain',


### PR DESCRIPTION
## Description

This is part 1. It replaces the current client-based search with API based search. The search is debounced, so a set of requests is made .5 seconds after typing in the search bar stops.

There is duplication still, since the client search logic is still there and active (just not showing any of its results). Part 2 will add logic to determine whether or not the account is "large", and use the appropriate search accordingly.

For this, the eventual plan is to request the upcoming account summary endpoint on app load, since we'll be doing that anyway for the dashboard etc. Then we can store isBigAccount in Redux, or store the summary in Redux and derive the account type from that. But since that endpoint is weeks/months away and we can't wait that long, in the short term I plan to add a call to userPreferences if a getAll request turns up more than a single page of requests for any entity. The search bar will then read this preference from Redux to determine what search to use.