### PR TITLE
Fix "Create Object Storage Bucket" types.

### DIFF
--- a/packages/api-v4/src/object-storage/types.ts
+++ b/packages/api-v4/src/object-storage/types.ts
@@ -12,6 +12,8 @@ export interface ObjectStorageKeyRequest {
 export interface ObjectStorageBucketRequestPayload {
   label: string;
   cluster: string;
+  acl?: "private" | "public-read" | "authenticated-read" | "public-read-write";
+  cors_enabled?: boolean;
 }
 
 export interface ObjectStorageDeleteBucketRequestPayload {


### PR DESCRIPTION


## Description

Following the [API-Reference](https://developers.linode.com/api/v4/object-storage-buckets/#post) for the function the function "createBucket".

To be used in TypeScript right now, I had to use @ts-ignore | @ts-expect-error.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

