### PR TITLE
E2E fix: change case of Not Found

### DIFF
--- a/packages/manager/cypress/integration/linodes/smoke-delete-linode.spec.ts
+++ b/packages/manager/cypress/integration/linodes/smoke-delete-linode.spec.ts
@@ -33,7 +33,7 @@ describe('delete linode', () => {
         .should('eq', 200);
       cy.url().should('contain', '/linodes');
       cy.go('back');
-      cy.findByText('Not found');
+      cy.findByText('Not Found');
     });
   });
 });


### PR DESCRIPTION
## Description

The case of not found was making the test fail.
Interestingly i do not see when this would have been changed, so why would it have passed before?
did we change the styling of this in CMR?

## Type of Change
- Bug fix ('fix', 'repair', 'bug')
