### PR TITLE
M3-4338 CMR: Dashboard base

### DIFF
--- a/packages/manager/src/MainContent_CMR.tsx
+++ b/packages/manager/src/MainContent_CMR.tsx
@@ -141,7 +141,7 @@ const SupportTicketDetail = React.lazy(() =>
 );
 const Longview = React.lazy(() => import('src/features/Longview'));
 const Managed = React.lazy(() => import('src/features/Managed'));
-const Dashboard = React.lazy(() => import('src/features/Dashboard'));
+const Dashboard = React.lazy(() => import('src/features/Dashboard_CMR'));
 const Help = React.lazy(() => import('src/features/Help'));
 const SupportSearchLanding = React.lazy(() =>
   import('src/features/Help/SupportSearchLanding')

--- a/packages/manager/src/features/Dashboard_CMR/Dashboard.tsx
+++ b/packages/manager/src/features/Dashboard_CMR/Dashboard.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+import DashboardNotifications from './DashboardNotifications';
+
+export const Dashboard: React.FC<{}> = props => {
+  return (
+    <>
+      <DashboardNotifications />
+    </>
+  );
+};
+
+export default React.memo(Dashboard);

--- a/packages/manager/src/features/Dashboard_CMR/Dashboard.tsx
+++ b/packages/manager/src/features/Dashboard_CMR/Dashboard.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
 
 import DashboardNotifications from './DashboardNotifications';
+import LinodeDashboardContent from './LinodeDashboardContent';
 
 export const Dashboard: React.FC<{}> = props => {
   return (
     <>
       <DashboardNotifications />
+      <LinodeDashboardContent />
     </>
   );
 };

--- a/packages/manager/src/features/Dashboard_CMR/DashboardNotifications.tsx
+++ b/packages/manager/src/features/Dashboard_CMR/DashboardNotifications.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { makeStyles } from 'src/components/core/styles';
+
+const useStyles = makeStyles(() => ({
+  root: {
+    width: '1280px',
+    height: '350px',
+    backgroundColor: 'pink',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    margin: 'auto'
+  }
+}));
+
+export const Notifications: React.FC<{}> = _ => {
+  const classes = useStyles();
+  return <div className={classes.root}>DASHBOARD NOTIFICATIONS STUB</div>;
+};
+
+export default React.memo(Notifications);

--- a/packages/manager/src/features/Dashboard_CMR/LinodeDashboardContent/LinodeDashboardContent.tsx
+++ b/packages/manager/src/features/Dashboard_CMR/LinodeDashboardContent/LinodeDashboardContent.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import CircleProgress from 'src/components/CircleProgress';
+import useLinodes from 'src/hooks/useLinodes';
+import useReduxLoad from 'src/hooks/useReduxLoad';
+import SingleLinode from './SingleLinode';
+import MultipleLinodes from './MultipleLinodes';
+
+export const LinodeDashboardContent: React.FC<{}> = props => {
+  const { linodes } = useLinodes();
+  const { _loading } = useReduxLoad(['linodes']);
+
+  if (_loading) {
+    return <CircleProgress />;
+  }
+
+  const numLinodes = Object.keys(linodes.itemsById).length;
+
+  return numLinodes < 2 ? <SingleLinode /> : <MultipleLinodes />;
+};
+
+export default React.memo(LinodeDashboardContent);

--- a/packages/manager/src/features/Dashboard_CMR/LinodeDashboardContent/LinodeDashboardContent.tsx
+++ b/packages/manager/src/features/Dashboard_CMR/LinodeDashboardContent/LinodeDashboardContent.tsx
@@ -13,9 +13,8 @@ export const LinodeDashboardContent: React.FC<{}> = props => {
     return <CircleProgress />;
   }
 
-  const numLinodes = Object.keys(linodes.itemsById).length;
-
-  return numLinodes < 2 ? <SingleLinode /> : <MultipleLinodes />;
+  // @todo change this logic once there's a no-Linodes view
+  return linodes.results < 2 ? <SingleLinode /> : <MultipleLinodes />;
 };
 
 export default React.memo(LinodeDashboardContent);

--- a/packages/manager/src/features/Dashboard_CMR/LinodeDashboardContent/MultipleLinodes.tsx
+++ b/packages/manager/src/features/Dashboard_CMR/LinodeDashboardContent/MultipleLinodes.tsx
@@ -13,22 +13,9 @@ export const MultipleLinodes: React.FC<{}> = _ => {
   const classes = useStyles();
 
   const tabs: Tab[] = [
-    /* NB: These must correspond to the routes, inside the Switch */
     {
       title: 'Linodes',
       render: () => <div>Linodes Table</div>
-    },
-    {
-      title: 'Domains',
-      render: () => <div>Domains Table</div>
-    },
-    {
-      title: 'Volumes',
-      render: () => <div>Volumes Table</div>
-    },
-    {
-      title: 'Object Storage',
-      render: () => <div>Buckets Table</div>
     }
   ];
 

--- a/packages/manager/src/features/Dashboard_CMR/LinodeDashboardContent/MultipleLinodes.tsx
+++ b/packages/manager/src/features/Dashboard_CMR/LinodeDashboardContent/MultipleLinodes.tsx
@@ -1,110 +1,45 @@
 import * as React from 'react';
-import {
-  matchPath,
-  Redirect,
-  Route,
-  RouteComponentProps,
-  Switch,
-  withRouter
-} from 'react-router-dom';
-import { compose } from 'recompose';
-import Tab from 'src/components/core/Tab';
-import Tabs from 'src/components/core/Tabs';
-import TabLink from 'src/components/TabLink';
+import { makeStyles } from 'src/components/core/styles';
+import TabbedPanel from 'src/components/TabbedPanel';
+import { Tab } from 'src/components/TabbedPanel/TabbedPanel';
 
-export const MultipleLinodes: React.FC<RouteComponentProps> = props => {
-  const tabs = [
+const useStyles = makeStyles(() => ({
+  root: {
+    backgroundColor: 'transparent'
+  }
+}));
+
+export const MultipleLinodes: React.FC<{}> = _ => {
+  const classes = useStyles();
+
+  const tabs: Tab[] = [
     /* NB: These must correspond to the routes, inside the Switch */
     {
       title: 'Linodes',
-      routeName: `${props.match.url}/linodes`
+      render: () => <div>Linodes Table</div>
     },
     {
       title: 'Domains',
-      routeName: `${props.match.url}/domains`
+      render: () => <div>Domains Table</div>
     },
     {
       title: 'Volumes',
-      routeName: `${props.match.url}/volumes`
+      render: () => <div>Volumes Table</div>
     },
     {
       title: 'Object Storage',
-      routeName: `${props.match.url}/object-storage`
+      render: () => <div>Buckets Table</div>
     }
   ];
 
-  const matches = (p: string) => {
-    return Boolean(matchPath(p, { path: props.location.pathname }));
-  };
-
-  const handleTabChange = (
-    _: React.ChangeEvent<HTMLDivElement>,
-    value: number
-  ) => {
-    const routeName = tabs[value].routeName;
-    props.history.push(`${routeName}`);
-  };
-
-  const url = props.match.url;
-
   return (
-    <>
-      <Tabs
-        value={tabs.findIndex(tab => matches(tab.routeName))}
-        onChange={handleTabChange}
-        indicatorColor="primary"
-        textColor="primary"
-        variant="scrollable"
-        scrollButtons="on"
-      >
-        {tabs.map(tab => (
-          <Tab
-            key={tab.title}
-            data-qa-tab={tab.title}
-            component={React.forwardRef((forwardedProps, ref) => (
-              <TabLink
-                to={tab.routeName}
-                title={tab.title}
-                {...forwardedProps}
-                ref={ref}
-              />
-            ))}
-          />
-        ))}
-      </Tabs>
-      <Switch>
-        <Route
-          exact
-          strict
-          path={`${url}/linodes`}
-          render={() => <div>Linodes Table</div>}
-        />
-        <Route
-          exact
-          strict
-          path={`${url}/domains`}
-          render={() => <div>Domains Table</div>}
-        />
-        <Route
-          exact
-          strict
-          path={`${url}/volumes`}
-          render={() => <div>Volumes Table</div>}
-        />
-        <Route
-          exact
-          strict
-          path={`${url}/object-storage`}
-          render={() => <div>Buckets Table</div>}
-        />
-        <Redirect to={`${url}/linodes`} />
-      </Switch>
-    </>
+    <TabbedPanel
+      rootClass={`${classes.root} tabbedPanel`}
+      header={''}
+      tabs={tabs}
+      initTab={0}
+    />
   );
 };
 
-const enhanced = compose<RouteComponentProps, {}>(
-  React.memo,
-  withRouter
-)(MultipleLinodes);
-export default React.memo(enhanced);
+export default React.memo(MultipleLinodes);

--- a/packages/manager/src/features/Dashboard_CMR/LinodeDashboardContent/MultipleLinodes.tsx
+++ b/packages/manager/src/features/Dashboard_CMR/LinodeDashboardContent/MultipleLinodes.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+export const MultipleLinodes: React.FC<{}> = props => {
+  return <div>I have many Linodes!</div>;
+};
+
+export default React.memo(MultipleLinodes);

--- a/packages/manager/src/features/Dashboard_CMR/LinodeDashboardContent/MultipleLinodes.tsx
+++ b/packages/manager/src/features/Dashboard_CMR/LinodeDashboardContent/MultipleLinodes.tsx
@@ -1,7 +1,110 @@
 import * as React from 'react';
+import {
+  matchPath,
+  Redirect,
+  Route,
+  RouteComponentProps,
+  Switch,
+  withRouter
+} from 'react-router-dom';
+import { compose } from 'recompose';
+import Tab from 'src/components/core/Tab';
+import Tabs from 'src/components/core/Tabs';
+import TabLink from 'src/components/TabLink';
 
-export const MultipleLinodes: React.FC<{}> = props => {
-  return <div>I have many Linodes!</div>;
+export const MultipleLinodes: React.FC<RouteComponentProps> = props => {
+  const tabs = [
+    /* NB: These must correspond to the routes, inside the Switch */
+    {
+      title: 'Linodes',
+      routeName: `${props.match.url}/linodes`
+    },
+    {
+      title: 'Domains',
+      routeName: `${props.match.url}/domains`
+    },
+    {
+      title: 'Volumes',
+      routeName: `${props.match.url}/volumes`
+    },
+    {
+      title: 'Object Storage',
+      routeName: `${props.match.url}/object-storage`
+    }
+  ];
+
+  const matches = (p: string) => {
+    return Boolean(matchPath(p, { path: props.location.pathname }));
+  };
+
+  const handleTabChange = (
+    _: React.ChangeEvent<HTMLDivElement>,
+    value: number
+  ) => {
+    const routeName = tabs[value].routeName;
+    props.history.push(`${routeName}`);
+  };
+
+  const url = props.match.url;
+
+  return (
+    <>
+      <Tabs
+        value={tabs.findIndex(tab => matches(tab.routeName))}
+        onChange={handleTabChange}
+        indicatorColor="primary"
+        textColor="primary"
+        variant="scrollable"
+        scrollButtons="on"
+      >
+        {tabs.map(tab => (
+          <Tab
+            key={tab.title}
+            data-qa-tab={tab.title}
+            component={React.forwardRef((forwardedProps, ref) => (
+              <TabLink
+                to={tab.routeName}
+                title={tab.title}
+                {...forwardedProps}
+                ref={ref}
+              />
+            ))}
+          />
+        ))}
+      </Tabs>
+      <Switch>
+        <Route
+          exact
+          strict
+          path={`${url}/linodes`}
+          render={() => <div>Linodes Table</div>}
+        />
+        <Route
+          exact
+          strict
+          path={`${url}/domains`}
+          render={() => <div>Domains Table</div>}
+        />
+        <Route
+          exact
+          strict
+          path={`${url}/volumes`}
+          render={() => <div>Volumes Table</div>}
+        />
+        <Route
+          exact
+          strict
+          path={`${url}/object-storage`}
+          render={() => <div>Buckets Table</div>}
+        />
+        <Redirect to={`${url}/linodes`} />
+      </Switch>
+    </>
+  );
 };
 
-export default React.memo(MultipleLinodes);
+const enhanced = compose<RouteComponentProps, {}>(
+  React.memo,
+  withRouter
+)(MultipleLinodes);
+export default React.memo(enhanced);

--- a/packages/manager/src/features/Dashboard_CMR/LinodeDashboardContent/SingleLinode.tsx
+++ b/packages/manager/src/features/Dashboard_CMR/LinodeDashboardContent/SingleLinode.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+export const SingleLinode: React.FC<{}> = props => {
+  return <div>I have one Linode!</div>;
+};
+
+export default React.memo(SingleLinode);

--- a/packages/manager/src/features/Dashboard_CMR/LinodeDashboardContent/index.tsx
+++ b/packages/manager/src/features/Dashboard_CMR/LinodeDashboardContent/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './LinodeDashboardContent';

--- a/packages/manager/src/features/Dashboard_CMR/index.tsx
+++ b/packages/manager/src/features/Dashboard_CMR/index.tsx
@@ -1,0 +1,3 @@
+export { default } from './Dashboard';
+
+// @todo CMR: rename this directory to Dashboard and delete the old Dashboard directory


### PR DESCRIPTION
## Description

Add structure, tabs, and display logic for the new Dashboard. Shows:

- "notification center" placeholder
- 1 Linode placeholder when 1 or fewer Linodes on the account
- TabbedPanel with stubs when multiple Linodes are present.

I started with our standard Tabs pattern but changed my mind and used TabbedPanel instead, so that the URL is unchanged. Feel free to talk me out of this, but I think the routing is too messy to be worth it (since all of these tables will have permanent, dedicated URLs that people can bookmark). The main issue is: what happens if someone bookmarks dashboard/volumes when that table won't be visible unless they have both a) Volumes and b) 2+ Linodes? We could handle these in fancy ways but I think simple is better here.