### PR TITLE
Fix console warning

### DIFF
--- a/packages/manager/src/components/TableSortCell/TableSortCell_CMR.tsx
+++ b/packages/manager/src/components/TableSortCell/TableSortCell_CMR.tsx
@@ -58,6 +58,8 @@ export const TableSortCell: React.FC<CombinedProps> = props => {
     active,
     isLoading,
     noWrap,
+    // eslint-disable-next-line
+    handleClick,
     ...rest
   } = props;
 


### PR DESCRIPTION
Remove handleClick from ...props spread so it doesn't get passed
down to a `<th>` where it doesn't belong.

Fixes the console warning currently present on Linodes landing (and anywhere else SortableTableCell_CMR is used)