### PR TITLE
Add command to run Cypress tests in non-headless mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "e2e": "yarn workspace linode-manager e2e --color",
     "e2e:all": "yarn workspace linode-manager e2e:all --color",
     "e2e:modified": "yarn workspace linode-manager e2e:modified --color",
+    "cy:run": "yarn workspace linode-manager cy:run",
     "cy:e2e": "yarn workspace linode-manager cy:e2e",
     "cy:debug": "yarn workspace linode-manager cy:debug",
     "cy:rec-snap": "yarn workspace linode-manager cy:rec-snap",

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -101,6 +101,7 @@
     "storyshots:update": "export UPDATE=-u && docker-compose -f storyshots.yml up --build --exit-code-from manager-storyshots && unset UPDATE && docker-compose -f storyshots.yml down -v",
     "storyshots:test": "npx jest --config ./.storybook/storyshots.jest.config.js src/components/Storyshots.test.tsx --env=jsdom",
     "build-storybook": "build-storybook",
+    "cy:run": "cypress run -b chrome",
     "cy:e2e": "cypress run --headless -b chrome",
     "cy:debug": "cypress open",
     "cy:rec-snap": "cypress run --headless -b chrome --env visualRegMode=record --spec ./cypress/integration/**/*visual*.spec.js",


### PR DESCRIPTION
## Description

Our `cy:e2e` command runs Cypress in headless mode (`--headless)`. I like to use `yarn workspace linode-manager cypress run -b chrome` so I can watch the test running in the browser. This PR adds `yarn cy:run` as a shortcut.
