### PR TITLE
M3-4376 Linode Monthly Transfer Adjustments 

### DIFF
--- a/packages/manager/src/components/BarPercent/BarPercent_CMR.tsx
+++ b/packages/manager/src/components/BarPercent/BarPercent_CMR.tsx
@@ -1,0 +1,114 @@
+import * as classNames from 'classnames';
+import * as React from 'react';
+import LinearProgress from 'src/components/core/LinearProgress';
+import {
+  createStyles,
+  Theme,
+  withStyles,
+  WithStyles
+} from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+
+type ClassNames =
+  | 'root'
+  | 'primaryColor'
+  | 'overLimit'
+  | 'loadingText'
+  | 'rounded'
+  | 'secondaryColor'
+  | 'dashed';
+
+const styles = (theme: Theme) =>
+  createStyles({
+    root: {
+      padding: 14,
+      backgroundColor: theme.color.grey2
+    },
+    primaryColor: {
+      backgroundColor: '#5ad865'
+    },
+    secondaryColor: {
+      backgroundColor: '#99ec79'
+    },
+    overLimit: {
+      '& > div': {
+        backgroundColor: theme.palette.status.warningDark
+      }
+    },
+    rounded: {
+      borderRadius: theme.shape.borderRadius
+    },
+    loadingText: {
+      marginBottom: theme.spacing(2),
+      textAlign: 'center'
+    },
+    dashed: {
+      display: 'none'
+    }
+  });
+
+interface Props {
+  max: number;
+  value: number;
+  valueBuffer?: number;
+  isFetchingValue?: boolean;
+  loadingText?: string;
+  className?: string;
+  rounded?: boolean;
+  overLimit?: boolean;
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+export class BarPercent extends React.PureComponent<CombinedProps, {}> {
+  render() {
+    const {
+      classes,
+      className,
+      value,
+      valueBuffer,
+      max,
+      isFetchingValue,
+      loadingText,
+      rounded,
+      overLimit
+    } = this.props;
+    return (
+      <div className={className}>
+        {isFetchingValue && loadingText && (
+          <Typography className={classes.loadingText} variant="h3">
+            {loadingText}
+          </Typography>
+        )}
+        <LinearProgress
+          value={getPercentage(value, max)}
+          valueBuffer={valueBuffer}
+          variant={
+            isFetchingValue
+              ? 'indeterminate'
+              : valueBuffer
+              ? 'buffer'
+              : 'determinate'
+          }
+          classes={{
+            root: classes.root,
+            barColorPrimary: classes.primaryColor,
+            bar2Buffer: classes.secondaryColor,
+            dashed: classes.dashed
+          }}
+          className={classNames({
+            [classes.rounded]: rounded,
+            [classes.overLimit]: overLimit
+          })}
+        />
+      </div>
+    );
+  }
+}
+
+export const getPercentage = (value: number, max: number) =>
+  (value / max) * 100;
+
+const styled = withStyles(styles);
+
+export default styled(BarPercent);

--- a/packages/manager/src/factories/account.ts
+++ b/packages/manager/src/factories/account.ts
@@ -1,5 +1,9 @@
+import {
+  Account,
+  ActivePromotion,
+  NetworkUtilization
+} from '@linode/api-v4/lib/account/types';
 import * as Factory from 'factory.ts';
-import { Account, ActivePromotion } from '@linode/api-v4/lib/account/types';
 
 export const promoFactory = Factory.Sync.makeFactory<ActivePromotion>({
   image_url: '',
@@ -60,4 +64,12 @@ export const accountFactory = Factory.Sync.makeFactory<Account>({
     }
   ],
   euuid: '278EC57D-7424-4B3A-B35C3CE395787567'
+});
+
+export const accountTransferFactory = Factory.Sync.makeFactory<
+  NetworkUtilization
+>({
+  used: 50,
+  quota: 11347,
+  billable: 0
 });

--- a/packages/manager/src/factories/linodes.ts
+++ b/packages/manager/src/factories/linodes.ts
@@ -1,4 +1,4 @@
-import * as Factory from 'factory.ts';
+import { NetworkUtilization } from '@linode/api-v4/lib/account';
 import {
   Linode,
   LinodeAlerts,
@@ -9,6 +9,7 @@ import {
   Stats,
   StatsData
 } from '@linode/api-v4/lib/linodes/types';
+import * as Factory from 'factory.ts';
 
 export const linodeAlertsFactory = Factory.Sync.makeFactory<LinodeAlerts>({
   cpu: 10,
@@ -112,7 +113,9 @@ export const linodeBackupsFactory = Factory.Sync.makeFactory<LinodeBackups>({
   last_successful: '2020-01-01'
 });
 
-export const linodeTransferFactory = Factory.Sync.makeFactory<any>({
+export const linodeTransferFactory = Factory.Sync.makeFactory<
+  NetworkUtilization
+>({
   used: 13956637,
   quota: 1950,
   billable: 0

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking_CMR.tsx
@@ -508,6 +508,7 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
         <LinodeNetworkingSummaryPanel
           linodeRegion={zoneName}
           linodeID={linodeID}
+          linodeLabel={linodeLabel}
         />
 
         {this.renderIPTable()}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkTransfer.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkTransfer.test.tsx
@@ -1,0 +1,12 @@
+import { calculatePercentageWithCeiling } from './NetworkTransfer';
+
+describe('calculatePercentage', () => {
+  it('returns the correct percentage of a value in relation to a target', () => {
+    expect(calculatePercentageWithCeiling(50, 100)).toBe(50);
+    expect(calculatePercentageWithCeiling(50, 200)).toBe(25);
+    expect(calculatePercentageWithCeiling(50, 50)).toBe(100);
+  });
+  it('caps the percentage at 100', () => {
+    expect(calculatePercentageWithCeiling(101, 100)).toBe(100);
+  });
+});

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkTransfer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkTransfer.tsx
@@ -190,7 +190,6 @@ const TransferContent: React.FC<ContentProps> = props => {
       </Typography>
       {otherEntitiesUsedInGB > 0 && (
         <Typography className={`${classes.legendItem} ${classes.lightGreen}`}>
-          {/* Theoretically "otherEntitiesUsed" should  */}
           Other entities ({otherEntitiesUsedInGB} GB)
         </Typography>
       )}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkTransfer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkTransfer.tsx
@@ -87,7 +87,8 @@ export const NetworkTransfer: React.FC<Props> = props => {
   return (
     <div>
       <Typography className={classes.header}>
-        <strong>Monthly Network Transfer</strong> ({accountQuotaInGB} GB limit)
+        <strong>Monthly Network Transfer</strong>{' '}
+        {accountQuotaInGB > 0 && <>({accountQuotaInGB} GB limit)</>}
       </Typography>
       <TransferContent
         linodeUsedInGB={linodeUsedInGB}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkTransfer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkTransfer.tsx
@@ -12,7 +12,7 @@ import { readableBytes } from 'src/utilities/unitConversions';
 
 const useStyles = makeStyles((theme: Theme) => ({
   header: {
-    paddingBottom: theme.spacing() / 2
+    paddingBottom: 10
   },
   progressWrapper: {
     width: '290px'
@@ -25,7 +25,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     fontFamily: theme.font.bold
   },
   legendItem: {
-    marginTop: 14,
+    marginTop: 10,
     display: 'flex',
     alignItems: 'center',
     '&:before': {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkTransfer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkTransfer.tsx
@@ -127,6 +127,18 @@ const TransferContent: React.FC<ContentProps> = props => {
   } = props;
   const classes = useStyles();
 
+  /**
+   * In this component we display four pieces of information:
+   *
+   * 1. Account-level transfer quota for this month
+   * 2. The amount of transfer THIS Linode has used this month
+   * 3. The amount of transfer OTHER things on your account have used this month
+   * 4. The remaining transfer on your account this month
+   *
+   * The value for #3 comes from subtracting the transfer THIS Linode has used from the TOTAL
+   * transfer used on the account.
+   */
+
   const linodeUsagePercent = calculatePercentageWithCeiling(
     linodeUsedInGB,
     accountQuotaInGB

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkingSummaryPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkingSummaryPanel.tsx
@@ -18,12 +18,13 @@ const useStyles = makeStyles((theme: Theme) => ({
 interface Props {
   linodeRegion: ZoneName;
   linodeID: number;
+  linodeLabel: string;
 }
 
 type CombinedProps = Props;
 
 const LinodeNetworkingSummaryPanel: React.FC<CombinedProps> = props => {
-  const { linodeID, linodeRegion } = props;
+  const { linodeID, linodeRegion, linodeLabel } = props;
   const classes = useStyles();
 
   return (
@@ -36,7 +37,7 @@ const LinodeNetworkingSummaryPanel: React.FC<CombinedProps> = props => {
         alignItems="flex-start"
       >
         <Grid item xs={3}>
-          <NetworkTransfer linodeID={linodeID} />
+          <NetworkTransfer linodeID={linodeID} linodeLabel={linodeLabel} />
         </Grid>
         <Grid item>
           <TransferHistory />

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -17,7 +17,8 @@ import {
   linodeTransferFactory,
   nodeBalancerFactory,
   profileFactory,
-  volumeFactory
+  volumeFactory,
+  accountTransferFactory
 } from 'src/factories';
 
 import cachedRegions from 'src/cachedData/regions.json';
@@ -135,5 +136,9 @@ export const handlers = [
   rest.get('*invoices/:invoiceId/items', (req, res, ctx) => {
     const items = invoiceItemFactory.buildList(10);
     return res(ctx.json(makeResourcePage(items, { page: 1, pages: 4 })));
+  }),
+  rest.get('*/account/transfer', (req, res, ctx) => {
+    const transfer = accountTransferFactory.build();
+    return res(ctx.json(transfer));
   })
 ];


### PR DESCRIPTION
## Description
 
This contains adjustments to the Linode Monthly Transfer section.

Per the new designs, this combines Linode + Account transfer into the same bar graph. There are two reasons for this:

1. It's helpful to see how _this_ Linode contributes to your overall account-level monthly transfer.
2. The Dashboard Transfer section is going away.

The new designs for this were done in parallel with adjustments to the [historic network transfer graph](https://github.com/linode/manager/pull/6616) based on the info available from the API.

**Note: this does not handle for transfer overages. Jay is considering this and will provide guidance.**

<img width="460" alt="Screen Shot 2020-07-16 at 3 11 43 PM" src="https://user-images.githubusercontent.com/16911484/87712491-bd0c7500-c776-11ea-8b65-a239dcfd060a.png">


## Note to Reviewers

I added a new `account/transfer` handler in testHandlers.ts, so play around with values here as well as the `linode/{id}/transfer` handler.
