### PR TITLE
M- 4337 CMR: Dashboard -- Single Linode view

### DIFF
--- a/packages/manager/src/features/Dashboard_CMR/LinodeDashboardContent/LinodeDashboardContent.tsx
+++ b/packages/manager/src/features/Dashboard_CMR/LinodeDashboardContent/LinodeDashboardContent.tsx
@@ -5,7 +5,7 @@ import useReduxLoad from 'src/hooks/useReduxLoad';
 import SingleLinode from './SingleLinode';
 import MultipleLinodes from './MultipleLinodes';
 
-export const LinodeDashboardContent: React.FC<{}> = props => {
+export const LinodeDashboardContent: React.FC<{}> = _ => {
   const { linodes } = useLinodes();
   const { _loading } = useReduxLoad(['linodes']);
 
@@ -14,7 +14,7 @@ export const LinodeDashboardContent: React.FC<{}> = props => {
   }
 
   // @todo change this logic once there's a no-Linodes view
-  return linodes.results < 2 ? <SingleLinode /> : <MultipleLinodes />;
+  return linodes.results === 1 ? <SingleLinode /> : <MultipleLinodes />;
 };
 
 export default React.memo(LinodeDashboardContent);

--- a/packages/manager/src/features/Dashboard_CMR/LinodeDashboardContent/SingleLinode.tsx
+++ b/packages/manager/src/features/Dashboard_CMR/LinodeDashboardContent/SingleLinode.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
+import LinodeDetail from 'src/features/linodes/LinodesDetail';
 
 export const SingleLinode: React.FC<{}> = props => {
-  return <div>I have one Linode!</div>;
+  return <LinodeDetail linodeId={21280784} />;
 };
 
 export default React.memo(SingleLinode);

--- a/packages/manager/src/features/Dashboard_CMR/LinodeDashboardContent/SingleLinode.tsx
+++ b/packages/manager/src/features/Dashboard_CMR/LinodeDashboardContent/SingleLinode.tsx
@@ -10,7 +10,7 @@ export const SingleLinode: React.FC<{}> = _ => {
   // on the user's account.
 
   const linodeId = Object.keys(linodes.itemsById)[0];
-  return <LinodeDetail linodeId={linodeId} />;
+  return <LinodeDetail linodeId={linodeId} isDashboard />;
 };
 
 export default React.memo(SingleLinode);

--- a/packages/manager/src/features/Dashboard_CMR/LinodeDashboardContent/SingleLinode.tsx
+++ b/packages/manager/src/features/Dashboard_CMR/LinodeDashboardContent/SingleLinode.tsx
@@ -1,8 +1,16 @@
 import * as React from 'react';
 import LinodeDetail from 'src/features/linodes/LinodesDetail';
+import useLinodes from 'src/hooks/useLinodes';
 
-export const SingleLinode: React.FC<{}> = props => {
-  return <LinodeDetail linodeId={21280784} />;
+export const SingleLinode: React.FC<{}> = _ => {
+  const { linodes } = useLinodes();
+  // We've already loaded Linodes by the time we
+  // get this far down the tree. We've also already
+  // checked and there should only be a single Linode
+  // on the user's account.
+
+  const linodeId = Object.keys(linodes.itemsById)[0];
+  return <LinodeDetail linodeId={linodeId} />;
 };
 
 export default React.memo(SingleLinode);

--- a/packages/manager/src/features/Volumes/Volumes.tsx
+++ b/packages/manager/src/features/Volumes/Volumes.tsx
@@ -21,7 +21,14 @@ class Volumes extends React.Component<Props> {
 
     return (
       <Switch>
-        <Route component={VolumesLanding} path={path} exact strict />
+        <Route
+          render={routeProps => (
+            <VolumesLanding isVolumesLanding {...routeProps} />
+          )}
+          path={path}
+          exact
+          strict
+        />
         <Route component={VolumeCreate} path={`${path}/create`} exact strict />
         <Redirect to={path} />
       </Switch>

--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -143,6 +143,7 @@ const styles = (theme: Theme) =>
   });
 
 interface Props {
+  isVolumesLanding?: boolean;
   linodeId?: number;
   linodeLabel?: string;
   linodeRegion?: string;
@@ -430,14 +431,13 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
 
   renderEmpty = () => {
     const {
+      isVolumesLanding,
       linodeConfigs,
       linodeRegion,
       readOnly,
       regionsData,
       fromLinodes
     } = this.props;
-
-    const isVolumesLanding = this.props.match.params.linodeId === undefined;
 
     if (
       linodeRegion &&
@@ -503,9 +503,8 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
   };
 
   renderData = (volumes: ExtendedVolume[], volumesAreGrouped: boolean) => {
-    const isVolumesLanding = this.props.match.params.linodeId === undefined;
     const renderProps = {
-      isVolumesLanding,
+      isVolumesLanding: Boolean(this.props.isVolumesLanding),
       handleAttach: this.handleAttach,
       handleDelete: this.handleDelete,
       handleDetach: this.handleDetach,

--- a/packages/manager/src/features/Volumes/VolumesLanding_CMR.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding_CMR.tsx
@@ -88,6 +88,7 @@ const styles = (theme: Theme) =>
   });
 
 interface Props {
+  isVolumesLanding?: boolean;
   linodeId?: number;
   linodeLabel?: string;
   linodeRegion?: string;
@@ -339,6 +340,7 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
 
   renderData = (volumes: ExtendedVolume[]) => {
     const {
+      isVolumesLanding,
       linodeConfigs,
       linodeRegion,
       regionsData,
@@ -347,10 +349,8 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
 
     let error = '';
 
-    const isVolumesLanding = this.props.match.params.linodeId === undefined;
-
     const renderProps = {
-      isVolumesLanding,
+      isVolumesLanding: Boolean(isVolumesLanding),
       handleAttach: this.handleAttach,
       handleDelete: this.handleDelete,
       handleDetach: this.handleDetach,

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs_CMR.tsx
@@ -26,7 +26,6 @@ import TableCell from 'src/components/TableCell/TableCell_CMR.tsx';
 import TableSortCell from 'src/components/TableSortCell/TableSortCell_CMR';
 import TableHead from 'src/components/core/TableHead';
 import TableRow from 'src/components/core/TableRow';
-import TableRowLoading from 'src/components/TableRowLoading/TableRowLoading_CMR';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 import PaginationFooter from 'src/components/PaginationFooter';
@@ -477,7 +476,10 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
                     </TableHead>
                     <TableBody>
                       <TableContentWrapper
-                        loading={configsLoading && configsLastUpdated === 0}
+                        loading={
+                          (configsLoading && configsLastUpdated === 0) ||
+                          this.state.kernelsLoading
+                        }
                         lastUpdated={configsLastUpdated}
                         length={paginatedData.length}
                         error={configsError}
@@ -486,9 +488,7 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
                           const kernel = this.state.kernels.find(
                             kernelName => kernelName.id === thisConfig.kernel
                           );
-                          return this.state.kernelsLoading ? (
-                            <TableRowLoading colSpan={6} />
-                          ) : (
+                          return (
                             <ConfigRow
                               key={`config-row-${thisConfig.id}`}
                               config={thisConfig}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks_CMR.tsx
@@ -189,7 +189,7 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
       <React.Fragment>
         {!freeDiskSpace && (
           <Notice
-            error
+            warning
             text="You do not have enough unallocated storage to create a Disk."
           />
         )}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDashboardNavigation.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDashboardNavigation.tsx
@@ -42,6 +42,12 @@ type CombinedProps = ContextProps &
     linodeId: string;
   }>;
 
+const suspenseWrapper = (Component: React.ComponentType<any>) => (
+  <React.Suspense fallback={<SuspenseLoader />}>
+    <Component />
+  </React.Suspense>
+);
+
 const LinodesDetailNavigation: React.FC<CombinedProps> = props => {
   const {
     linodeLabel,
@@ -59,11 +65,11 @@ const LinodesDetailNavigation: React.FC<CombinedProps> = props => {
       /* NB: These must correspond to the routes inside the Switch */
       // Previously Summary
       {
-        render: () => <LinodeSummary_CMR />,
+        render: () => suspenseWrapper(LinodeSummary_CMR),
         title: 'Analytics'
       },
       {
-        render: () => <LinodeNetworking_CMR />,
+        render: () => suspenseWrapper(LinodeNetworking_CMR),
         title: 'Network'
       },
       // Previously Volumes
@@ -90,31 +96,31 @@ const LinodesDetailNavigation: React.FC<CombinedProps> = props => {
       },
       // Previously Disks/Configs
       {
-        render: () => <LinodeAdvanced_CMR />,
+        render: () => suspenseWrapper(LinodeAdvanced_CMR),
         title: 'Configurations'
       },
       {
-        render: () => <LinodeBackup_CMR />,
+        render: () => suspenseWrapper(LinodeBackup_CMR),
         title: 'Backups'
       },
       {
-        render: () => <LinodeResize />,
+        render: () => suspenseWrapper(LinodeResize),
         title: 'Resize'
       },
       {
-        render: () => <LinodeRescue />,
+        render: () => suspenseWrapper(LinodeRescue),
         title: 'Rescue'
       },
       {
-        render: () => <LinodeRebuild />,
+        render: () => suspenseWrapper(LinodeRebuild),
         title: 'Rebuild'
       },
       {
-        render: () => <LinodeActivity_CMR />,
+        render: () => suspenseWrapper(LinodeActivity_CMR),
         title: 'Activity Logs'
       },
       {
-        render: () => <LinodeSettings_CMR />,
+        render: () => suspenseWrapper(LinodeSettings_CMR),
         title: 'Settings'
       }
     ],
@@ -122,14 +128,12 @@ const LinodesDetailNavigation: React.FC<CombinedProps> = props => {
   );
 
   return (
-    <React.Suspense fallback={<SuspenseLoader />}>
-      <TabbedPanel
-        rootClass={`${classes.root} tabbedPanel`}
-        header={''}
-        tabs={tabs}
-        initTab={0}
-      />
-    </React.Suspense>
+    <TabbedPanel
+      rootClass={`${classes.root} tabbedPanel`}
+      header={''}
+      tabs={tabs}
+      initTab={0}
+    />
   );
 };
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDashboardNavigation.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDashboardNavigation.tsx
@@ -54,69 +54,72 @@ const LinodesDetailNavigation: React.FC<CombinedProps> = props => {
 
   const classes = useStyles();
 
-  const tabs: Tab[] = [
-    /* NB: These must correspond to the routes inside the Switch */
-    // Previously Summary
-    {
-      render: () => <LinodeSummary_CMR />,
-      title: 'Analytics'
-    },
-    {
-      render: () => <LinodeNetworking_CMR />,
-      title: 'Network'
-    },
-    // Previously Volumes
-    {
-      render: () => (
-        <div
-          id="tabpanel-storage"
-          role="tabpanel"
-          aria-labelledby="tab-storage"
-        >
-          <VolumesLanding_CMR
-            linodeId={linodeId}
-            linodeLabel={linodeLabel}
-            linodeRegion={linodeRegion}
-            linodeConfigs={linodeConfigs}
-            readOnly={readOnly}
-            fromLinodes
-            removeBreadCrumb
-            {...routeProps}
-          />
-        </div>
-      ),
-      title: 'Storage'
-    },
-    // Previously Disks/Configs
-    {
-      render: () => <LinodeAdvanced_CMR />,
-      title: 'Configurations'
-    },
-    {
-      render: () => <LinodeBackup_CMR />,
-      title: 'Backups'
-    },
-    {
-      render: () => <LinodeResize />,
-      title: 'Resize'
-    },
-    {
-      render: () => <LinodeRescue />,
-      title: 'Rescue'
-    },
-    {
-      render: () => <LinodeRebuild />,
-      title: 'Rebuild'
-    },
-    {
-      render: () => <LinodeActivity_CMR />,
-      title: 'Activity Logs'
-    },
-    {
-      render: () => <LinodeSettings_CMR />,
-      title: 'Settings'
-    }
-  ];
+  const tabs: Tab[] = React.useMemo(
+    () => [
+      /* NB: These must correspond to the routes inside the Switch */
+      // Previously Summary
+      {
+        render: () => <LinodeSummary_CMR />,
+        title: 'Analytics'
+      },
+      {
+        render: () => <LinodeNetworking_CMR />,
+        title: 'Network'
+      },
+      // Previously Volumes
+      {
+        render: () => (
+          <div
+            id="tabpanel-storage"
+            role="tabpanel"
+            aria-labelledby="tab-storage"
+          >
+            <VolumesLanding_CMR
+              linodeId={linodeId}
+              linodeLabel={linodeLabel}
+              linodeRegion={linodeRegion}
+              linodeConfigs={linodeConfigs}
+              readOnly={readOnly}
+              fromLinodes
+              removeBreadCrumb
+              {...routeProps}
+            />
+          </div>
+        ),
+        title: 'Storage'
+      },
+      // Previously Disks/Configs
+      {
+        render: () => <LinodeAdvanced_CMR />,
+        title: 'Configurations'
+      },
+      {
+        render: () => <LinodeBackup_CMR />,
+        title: 'Backups'
+      },
+      {
+        render: () => <LinodeResize />,
+        title: 'Resize'
+      },
+      {
+        render: () => <LinodeRescue />,
+        title: 'Rescue'
+      },
+      {
+        render: () => <LinodeRebuild />,
+        title: 'Rebuild'
+      },
+      {
+        render: () => <LinodeActivity_CMR />,
+        title: 'Activity Logs'
+      },
+      {
+        render: () => <LinodeSettings_CMR />,
+        title: 'Settings'
+      }
+    ],
+    [linodeId, linodeConfigs, linodeRegion, linodeLabel, readOnly, routeProps]
+  );
 
   return (
     <React.Suspense fallback={<SuspenseLoader />}>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDashboardNavigation.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDashboardNavigation.tsx
@@ -37,10 +37,7 @@ const LinodeSettings_CMR = React.lazy(() =>
   import('./LinodeSettings/LinodeSettings_CMR')
 );
 
-type CombinedProps = ContextProps &
-  RouteComponentProps<{
-    linodeId: string;
-  }>;
+type CombinedProps = ContextProps & RouteComponentProps<{}>;
 
 const suspenseWrapper = (Component: React.ComponentType<any>) => (
   <React.Suspense fallback={<SuspenseLoader />}>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDashboardNavigation.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDashboardNavigation.tsx
@@ -1,0 +1,152 @@
+import { Config } from '@linode/api-v4/lib/linodes';
+import * as React from 'react';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { compose } from 'recompose';
+import { makeStyles } from 'src/components/core/styles';
+import TabbedPanel from 'src/components/TabbedPanel';
+import { Tab } from 'src/components/TabbedPanel/TabbedPanel';
+import SuspenseLoader from 'src/components/SuspenseLoader';
+import VolumesLanding_CMR from 'src/features/Volumes/VolumesLanding_CMR';
+import { withLinodeDetailContext } from './linodeDetailContext';
+
+const useStyles = makeStyles(() => ({
+  root: {
+    backgroundColor: 'transparent'
+  }
+}));
+
+const LinodeSummary_CMR = React.lazy(() =>
+  import('./LinodeSummary/LinodeSummary_CMR')
+);
+const LinodeNetworking_CMR = React.lazy(() =>
+  import('./LinodeNetworking/LinodeNetworking_CMR')
+);
+const LinodeAdvanced_CMR = React.lazy(() =>
+  import('./LinodeAdvanced/LinodeAdvancedConfigurationsPanel_CMR')
+);
+const LinodeBackup_CMR = React.lazy(() =>
+  import('./LinodeBackup/LinodeBackup_CMR')
+);
+const LinodeResize = React.lazy(() => import('./LinodeResize'));
+const LinodeRescue = React.lazy(() => import('./LinodeRescue'));
+const LinodeRebuild = React.lazy(() => import('./LinodeRebuild'));
+const LinodeActivity_CMR = React.lazy(() =>
+  import('./LinodeActivity/LinodeActivity_CMR')
+);
+const LinodeSettings_CMR = React.lazy(() =>
+  import('./LinodeSettings/LinodeSettings_CMR')
+);
+
+type CombinedProps = ContextProps &
+  RouteComponentProps<{
+    linodeId: string;
+  }>;
+
+const LinodesDetailNavigation: React.FC<CombinedProps> = props => {
+  const {
+    linodeLabel,
+    linodeConfigs,
+    linodeId,
+    linodeRegion,
+    readOnly,
+    ...routeProps
+  } = props;
+
+  const classes = useStyles();
+
+  const tabs: Tab[] = [
+    /* NB: These must correspond to the routes inside the Switch */
+    // Previously Summary
+    {
+      render: () => <LinodeSummary_CMR />,
+      title: 'Analytics'
+    },
+    {
+      render: () => <LinodeNetworking_CMR />,
+      title: 'Network'
+    },
+    // Previously Volumes
+    {
+      render: () => (
+        <div
+          id="tabpanel-storage"
+          role="tabpanel"
+          aria-labelledby="tab-storage"
+        >
+          <VolumesLanding_CMR
+            linodeId={linodeId}
+            linodeLabel={linodeLabel}
+            linodeRegion={linodeRegion}
+            linodeConfigs={linodeConfigs}
+            readOnly={readOnly}
+            fromLinodes
+            removeBreadCrumb
+            {...routeProps}
+          />
+        </div>
+      ),
+      title: 'Storage'
+    },
+    // Previously Disks/Configs
+    {
+      render: () => <LinodeAdvanced_CMR />,
+      title: 'Configurations'
+    },
+    {
+      render: () => <LinodeBackup_CMR />,
+      title: 'Backups'
+    },
+    {
+      render: () => <LinodeResize />,
+      title: 'Resize'
+    },
+    {
+      render: () => <LinodeRescue />,
+      title: 'Rescue'
+    },
+    {
+      render: () => <LinodeRebuild />,
+      title: 'Rebuild'
+    },
+    {
+      render: () => <LinodeActivity_CMR />,
+      title: 'Activity Logs'
+    },
+    {
+      render: () => <LinodeSettings_CMR />,
+      title: 'Settings'
+    }
+  ];
+
+  return (
+    <React.Suspense fallback={<SuspenseLoader />}>
+      <TabbedPanel
+        rootClass={`${classes.root} tabbedPanel`}
+        header={''}
+        tabs={tabs}
+        initTab={0}
+      />
+    </React.Suspense>
+  );
+};
+
+interface ContextProps {
+  linodeId: number;
+  linodeConfigs: Config[];
+  linodeLabel: string;
+  linodeRegion: string;
+  readOnly: boolean;
+}
+
+const enhanced = compose<CombinedProps, {}>(
+  withRouter,
+  withLinodeDetailContext<ContextProps>(({ linode }) => ({
+    linodeId: linode.id,
+    linodeConfigs: linode._configs,
+    linodeLabel: linode.label,
+    linodeRegion: linode.region,
+    readOnly: linode._permissions === 'read_only'
+  }))
+);
+
+export default enhanced(LinodesDetailNavigation);

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetail.container.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetail.container.tsx
@@ -11,16 +11,20 @@ import { getAllLinodeDisks } from 'src/store/linodes/disk/disk.requests';
 import { getAllLinodeConfigs } from 'src/store/linodes/config/config.requests';
 import { shouldRequestEntity } from 'src/utilities/shouldRequestEntity';
 
+interface Props {
+  linodeId: number;
+}
+
 /**
  * We want to hold off loading this screen until Linode data is available.
  * If we have recently requested all Linode data, we're good. If not,
  * we show a loading spinner until the requests are complete.
  */
-export const LinodesDetailContainer: React.FC<{}> = _ => {
+export const LinodesDetailContainer: React.FC<Props> = props => {
   const { linodes } = useLinodes();
   const dispatch = useDispatch();
   const params = useParams<{ linodeId: string }>();
-  const linodeId = params.linodeId;
+  const linodeId = props.linodeId ? String(props.linodeId) : params.linodeId;
 
   const { _loading } = useReduxLoad(['images', 'volumes']);
   const { configs, disks } = useSelector((state: ApplicationState) => {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetail.container.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetail.container.tsx
@@ -12,7 +12,8 @@ import { getAllLinodeConfigs } from 'src/store/linodes/config/config.requests';
 import { shouldRequestEntity } from 'src/utilities/shouldRequestEntity';
 
 interface Props {
-  linodeId: string;
+  linodeId?: string;
+  isDashboard?: boolean;
 }
 
 /**
@@ -21,6 +22,7 @@ interface Props {
  * we show a loading spinner until the requests are complete.
  */
 export const LinodesDetailContainer: React.FC<Props> = props => {
+  const { isDashboard } = props;
   const { linodes } = useLinodes();
   const dispatch = useDispatch();
   const params = useParams<{ linodeId: string }>();
@@ -63,7 +65,9 @@ export const LinodesDetailContainer: React.FC<Props> = props => {
     return <CircleProgress />;
   }
 
-  return <LinodesDetail linodeId={linodeId} />;
+  return (
+    <LinodesDetail linodeId={linodeId} isDashboard={Boolean(isDashboard)} />
+  );
 };
 
 export default React.memo(LinodesDetailContainer);

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetail.container.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetail.container.tsx
@@ -12,7 +12,7 @@ import { getAllLinodeConfigs } from 'src/store/linodes/config/config.requests';
 import { shouldRequestEntity } from 'src/utilities/shouldRequestEntity';
 
 interface Props {
-  linodeId: number;
+  linodeId: string;
 }
 
 /**
@@ -24,7 +24,7 @@ export const LinodesDetailContainer: React.FC<Props> = props => {
   const { linodes } = useLinodes();
   const dispatch = useDispatch();
   const params = useParams<{ linodeId: string }>();
-  const linodeId = props.linodeId ? String(props.linodeId) : params.linodeId;
+  const linodeId = props.linodeId ? props.linodeId : params.linodeId;
 
   const { _loading } = useReduxLoad(['images', 'volumes']);
   const { configs, disks } = useSelector((state: ApplicationState) => {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetail.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetail.tsx
@@ -26,6 +26,9 @@ const LinodesDetailNavigation = React.lazy(() =>
 const LinodesDetailNavigation_CMR = React.lazy(() =>
   import('./LinodesDetailNavigation_CMR')
 );
+const LinodesDashboardNavigation = React.lazy(() =>
+  import('./LinodesDashboardNavigation')
+);
 const MigrateLanding = React.lazy(() => import('../MigrateLanding'));
 
 interface Props {
@@ -66,7 +69,12 @@ const LinodeDetail: React.FC<CombinedProps> = props => {
               <React.Fragment>
                 <LinodesDetailHeader />
                 {flags.cmr ? (
-                  <LinodesDetailNavigation_CMR />
+                  // fml
+                  path.match(/\/dashboard/) ? (
+                    <LinodesDashboardNavigation />
+                  ) : (
+                    <LinodesDetailNavigation_CMR />
+                  )
                 ) : (
                   <LinodesDetailNavigation />
                 )}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetail.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetail.tsx
@@ -33,12 +33,14 @@ const MigrateLanding = React.lazy(() => import('../MigrateLanding'));
 
 interface Props {
   linodeId: string;
+  isDashboard: boolean;
 }
 
 type CombinedProps = Props & RouteComponentProps<{ linodeId: string }>;
 
 const LinodeDetail: React.FC<CombinedProps> = props => {
   const {
+    isDashboard,
     linodeId,
     match: { path }
   } = props;
@@ -69,8 +71,10 @@ const LinodeDetail: React.FC<CombinedProps> = props => {
               <React.Fragment>
                 <LinodesDetailHeader />
                 {flags.cmr ? (
-                  // fml
-                  path.match(/\/dashboard/) ? (
+                  // We have separate routing for the version
+                  // rendered on the dashboard, to prevent the url
+                  // from changing when the active tab is changed.
+                  isDashboard ? (
                     <LinodesDashboardNavigation />
                   ) : (
                     <LinodesDetailNavigation_CMR />

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -47,7 +47,7 @@ export const handlers = [
     return res(ctx.json(makeResourcePage(images)));
   }),
   rest.get('*/instances', async (req, res, ctx) => {
-    const linodes = linodeFactory.buildList(10);
+    const linodes = linodeFactory.buildList(1);
     return res(ctx.json(makeResourcePage(linodes)));
   }),
   rest.delete('*/instances/*', async (req, res, ctx) => {


### PR DESCRIPTION
## Description

Renders LinodesDetail on the Dashboard if you have only one Linode on your account.

After discussion/experimentation, decided not to have the details tabs change the URL. This required adding a separate navigation component to LinodesDetail that gets used when we're on the dashboard.

@WilkinsKa1 How does this look tabs-wise? Will it port over easily to the Reach tabs?