### PR TITLE
Custom dev tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,5 @@ packages/manager/cypress/fixtures/example.json
 
 nohup.out
 packages/manager/bundle_analyzer_report.html
+
+**/manager/src/dev-tools/*.local.*

--- a/packages/manager/src/containers/withFeatureFlagConsumer.container.ts
+++ b/packages/manager/src/containers/withFeatureFlagConsumer.container.ts
@@ -1,13 +1,54 @@
 import { LDClient as _LDClient } from 'launchdarkly-js-client-sdk';
-import { withLDConsumer } from 'launchdarkly-react-client-sdk';
+import * as React from 'react';
+import { connect } from 'react-redux';
 import { FlagSet } from 'src/featureFlags';
+import { MockFeatureFlagState } from 'src/store/mockFeatureFlags';
+import { MapState } from 'src/store/types';
+import { compose } from 'recompose';
+import { withLDConsumer } from 'launchdarkly-react-client-sdk';
+import { LDProps } from 'launchdarkly-react-client-sdk/lib/withLDConsumer';
+
+/* eslint-disable-next-line */
+export interface LDClient extends _LDClient {}
 
 export interface FeatureFlagConsumerProps {
   flags: FlagSet;
   ldClient: LDClient;
 }
 
-/* tslint:disable-next-line */
-export interface LDClient extends _LDClient {}
+// We have to provide an HOC around the `withLDConsumer` HOC in order to retrieve mock flags
+// for the custom dev tools.
+export const withFeatureFlagConsumer = (
+  Component: React.ComponentType<any>
+) => {
+  class WrappedComponent extends React.Component<StateProps & LDProps> {
+    render() {
+      return React.createElement(Component, {
+        ...this.props,
+        flags: {
+          // Real LD flags from `withLDConsumer()`.
+          ...this.props.flags,
+          // Mock flags from Redux.
+          ...this.props.mockFlags
+        }
+      });
+    }
+  }
 
-export default withLDConsumer();
+  const enhanced = compose(connected, withLDConsumer());
+
+  return enhanced(WrappedComponent);
+};
+
+export default withFeatureFlagConsumer;
+
+// Redux connection for the wrapped component.
+interface StateProps {
+  mockFlags: MockFeatureFlagState;
+}
+
+const mapStateToProps: MapState<StateProps, {}> = state => ({
+  mockFlags: state.mockFeatureFlags
+});
+
+const connected = connect(mapStateToProps);

--- a/packages/manager/src/dev-tools/DEV_TOOLS.MD
+++ b/packages/manager/src/dev-tools/DEV_TOOLS.MD
@@ -1,0 +1,9 @@
+# Cloud Manager Dev Tools
+
+To facilitate development and debugging, Cloud Manager includes a "Dev Tools" mode. Currently the only feature this mode includes is a toggle for the "CMR" feature flag, though it can be extended to other feature flags, mock data, environments, etc.
+
+This mode is enabled by default while running the development server. To disable it, add `?dev-tools=false` to the URL, or `dev-tools: false` to local storage.
+
+This mode is disabled by default in production builds, but can be enabled by adding `?dev-tools=true` to the URL, or `dev-tools: true` to local storage.
+
+To add a dev tool feature without checking it into source control, create a file in `src/dev-tools` ending in `.local.tsx`. This is useful for environment switching, user switching, etc.

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { useDispatch } from 'react-redux';
+import withFeatureFlagProvider from 'src/containers/withFeatureFlagProvider.container';
+import { Flags, FlagSet } from 'src/featureFlags';
+import { Dispatch } from 'src/hooks/types';
+import useFlags from 'src/hooks/useFlags';
+import { setMockFeatureFlags } from 'src/store/mockFeatureFlags';
+
+const options: { label: string; flag: keyof Flags }[] = [
+  { label: 'CMR', flag: 'cmr' }
+];
+
+const FeatureFlagTool: React.FC<{}> = () => {
+  const dispatch: Dispatch = useDispatch();
+  const flags = useFlags();
+
+  const handleCheck = (
+    e: React.ChangeEvent<HTMLInputElement>,
+    flag: keyof FlagSet
+  ) => {
+    dispatch(setMockFeatureFlags({ [flag]: e.target.checked }));
+  };
+
+  return (
+    <div>
+      {options.map(thisOption => {
+        return (
+          <label key={thisOption.flag}>
+            {thisOption.label}{' '}
+            <input
+              type="checkbox"
+              checked={Boolean(flags[thisOption.flag])}
+              onChange={e => handleCheck(e, thisOption.flag)}
+            />
+          </label>
+        );
+      })}
+    </div>
+  );
+};
+
+export default withFeatureFlagProvider(FeatureFlagTool);

--- a/packages/manager/src/dev-tools/dev-tools.css
+++ b/packages/manager/src/dev-tools/dev-tools.css
@@ -1,0 +1,27 @@
+#dev-tools {
+  position: absolute;
+  bottom: 0;
+  background: black;
+  opacity: 0.4;
+  color: white;
+  width: 100%;
+  padding: 20px;
+  height: 60px;
+  width: 60px;
+  transition: all 0.3s;
+  z-index: 1;
+}
+
+#dev-tools:hover {
+  height: 300px;
+  width: 100%;
+  opacity: 0.9;
+}
+
+#dev-tools .tools {
+  display: none;
+}
+
+#dev-tools:hover .tools {
+  display: block;
+}

--- a/packages/manager/src/dev-tools/dev-tools.tsx
+++ b/packages/manager/src/dev-tools/dev-tools.tsx
@@ -1,0 +1,46 @@
+import './dev-tools.css';
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import FeatureFlagTool from './FeatureFlagTool';
+import store from 'src/store';
+import { Provider } from 'react-redux';
+
+function install() {
+  (window as any).devToolsEnabled = true;
+  // Load local dev tools, untracked by Git.
+  const requireDevToolsLocal = require.context(
+    './',
+    false,
+    /dev-tools\.local\.ts/
+  );
+  const local = requireDevToolsLocal.keys()[0];
+  let LocalDevTools: any;
+  if (local) {
+    LocalDevTools = requireDevToolsLocal(local).default;
+  }
+  LocalDevTools = LocalDevTools || (() => null);
+
+  function DevTools() {
+    return (
+      <div id="dev-tools">
+        <div>🛠</div>
+        <div className="tools">
+          <LocalDevTools />
+          <FeatureFlagTool />
+        </div>
+      </div>
+    );
+  }
+
+  const devToolsRoot = document.createElement('div');
+  document.body.appendChild(devToolsRoot);
+  ReactDOM.render(
+    <Provider store={store}>
+      <DevTools />
+    </Provider>,
+    devToolsRoot
+  );
+}
+
+export { install };

--- a/packages/manager/src/dev-tools/dev-tools.tsx
+++ b/packages/manager/src/dev-tools/dev-tools.tsx
@@ -9,11 +9,7 @@ import { Provider } from 'react-redux';
 function install() {
   (window as any).devToolsEnabled = true;
   // Load local dev tools, untracked by Git.
-  const requireDevToolsLocal = require.context(
-    './',
-    false,
-    /dev-tools\.local\.ts/
-  );
+  const requireDevToolsLocal = require.context('./', false, /\.local\.tsx/);
   const local = requireDevToolsLocal.keys()[0];
   let LocalDevTools: any;
   if (local) {

--- a/packages/manager/src/dev-tools/load.ts
+++ b/packages/manager/src/dev-tools/load.ts
@@ -1,0 +1,28 @@
+// Thanks to https://kentcdodds.com/blog/make-your-own-dev-tools
+
+function loadDevTools(callback: () => any) {
+  // this allows you to explicitly disable it in development for example
+  const explicitlyDisabled =
+    window.location.search.includes('dev-tools=false') ||
+    window.localStorage.getItem('dev-tools') === 'false';
+  const explicitlyEnabled =
+    window.location.search.includes('dev-tools=true') ||
+    window.localStorage.getItem('dev-tools') === 'true';
+  // we want it enabled by default everywhere but production and we also want
+  // to support the dev tools in production (to make us more productive triaging production issues).
+  // you can enable the DevTools via localStorage or the query string.
+  if (
+    !explicitlyDisabled &&
+    (process.env.NODE_ENV === 'development' || explicitlyEnabled)
+  ) {
+    // use a dynamic import so the dev-tools code isn't bundled with the regular
+    // app code so we don't worry about bundle size.
+    import('./dev-tools')
+      .then(devTools => devTools.install())
+      .finally(callback);
+  } else {
+    // if we don't need the DevTools, call the callback immediately.
+    callback();
+  }
+}
+export default loadDevTools;

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -8,7 +8,7 @@ interface TaxBanner {
 
 type OneClickApp = Record<string, string>;
 
-interface Flags {
+export interface Flags {
   promos: boolean;
   vatBanner: TaxBanner;
   taxBanner: TaxBanner;

--- a/packages/manager/src/features/Dashboard/Dashboard.test.tsx
+++ b/packages/manager/src/features/Dashboard/Dashboard.test.tsx
@@ -1,43 +1,48 @@
-import { shallow } from 'enzyme';
+import { cleanup } from '@testing-library/react';
 import * as React from 'react';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+import { withLinodesLoaded, withManaged } from 'src/utilities/testHelpersStore';
 import { reactRouterProps } from 'src/__data__/reactRouterProps';
-import { light } from 'src/themes';
-import { Dashboard } from './Dashboard';
+import Dashboard, { CombinedProps } from './Dashboard';
 
-const props = {
+afterEach(cleanup);
+
+const props: CombinedProps = {
   accountBackups: false,
   notifications: [],
   userTimezone: 'GMT',
   userTimezoneLoading: false,
   someLinodesHaveScheduledMaintenance: true,
   actions: {
-    openBackupDrawer: jest.fn(),
-    openImportDrawer: jest.fn()
+    openBackupDrawer: jest.fn()
   },
   linodesWithoutBackups: [],
-  managed: false,
   backupError: undefined,
-  entitiesWithGroupsToImport: { linodes: [], domains: [] },
-  classes: { root: '' },
-  theme: light(8)
+  managed: false,
+  ...reactRouterProps
 };
-
-jest.mock('src/store');
-
-const component = shallow(<Dashboard {...props} {...reactRouterProps} />);
 
 describe('Dashboard view', () => {
   describe('Backups CTA card', () => {
     it('display for non-managed users', () => {
-      expect(component.find('withRouter(BackupsDashboardCard)')).toHaveLength(
-        1
-      );
+      const { getByText } = renderWithTheme(<Dashboard {...props} />, {
+        customStore: {
+          ...withLinodesLoaded
+        }
+      });
+      getByText('Linode Backup Auto-Enrollment');
     });
     it('should never display for managed users', () => {
-      component.setProps({ managed: true });
-      expect(component.find('withRouter(BackupsDashboardCard)')).toHaveLength(
-        0
-      );
+      const _props = { ...props, managed: true };
+      const { queryByText } = renderWithTheme(<Dashboard {..._props} />, {
+        customStore: {
+          ...withLinodesLoaded,
+          ...withManaged
+        }
+      });
+      expect(
+        queryByText('Linode Backup Auto-Enrollment')
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/manager/src/features/Dashboard/Dashboard.tsx
+++ b/packages/manager/src/features/Dashboard/Dashboard.tsx
@@ -46,7 +46,9 @@ interface DispatchProps {
   };
 }
 
-type CombinedProps = StateProps & DispatchProps & RouteComponentProps<{}>;
+export type CombinedProps = StateProps &
+  DispatchProps &
+  RouteComponentProps<{}>;
 
 export const Dashboard: React.FC<CombinedProps> = props => {
   const {

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.test.tsx
@@ -1,68 +1,9 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { mockNotification } from 'src/__data__/notifications';
-import { light } from 'src/themes';
-import { CombinedProps, LinodeRow, RenderFlag } from './LinodeRow';
+import { RenderFlag } from './LinodeRow';
 
 describe('LinodeRow', () => {
-  const mockClasses = {
-    actionCell: '',
-    actionInner: '',
-    bodyRow: '',
-    ipCell: '',
-    ipCellWrapper: '',
-    planCell: '',
-    regionCell: '',
-    iconTableCell: '',
-    icon: '',
-    iconGridCell: '',
-    statusCell: '',
-    statusCellMaintenance: '',
-    statusHelpIcon: ''
-  };
-
-  const mockProps: CombinedProps = {
-    classes: mockClasses,
-    theme: light(4),
-    maintenanceStartTime: '',
-    recentEvent: undefined,
-    openDeleteDialog: jest.fn(),
-    openPowerActionDialog: jest.fn(),
-    openLinodeResize: jest.fn(),
-    mutationAvailable: false,
-    linodeNotifications: [],
-    type: 'whatever',
-    tags: [],
-    status: 'running',
-    displayStatus: 'running',
-    region: 'us-east',
-    label: 'my-linode',
-    ipv6: 'some.long.ipv6.address',
-    ipv4: ['123.123.123.123'],
-    id: 8675309,
-    backups: {
-      enabled: false,
-      schedule: { day: 'Friday', window: 'W0' },
-      last_successful: null
-    },
-    image: null,
-    memory: 0,
-    vcpus: 0,
-    disk: 0,
-    mostRecentBackup: null
-  };
-
-  it('should render', () => {
-    shallow(<LinodeRow {...mockProps} />);
-  });
-
-  it('should have a RenderFlag component', () => {
-    const wrapper = shallow(
-      <LinodeRow {...mockProps} linodeNotifications={[mockNotification]} />
-    );
-    expect(wrapper.find('RenderFlag')).toHaveLength(1);
-  });
-
   describe('when Linode has notification', () => {
     it('should render a Flag', () => {
       const wrapper = shallow(

--- a/packages/manager/src/hooks/useFlags.ts
+++ b/packages/manager/src/hooks/useFlags.ts
@@ -1,5 +1,7 @@
-import { useFlags } from 'launchdarkly-react-client-sdk';
+import { useFlags as ldUseFlags } from 'launchdarkly-react-client-sdk';
+import { useSelector } from 'react-redux';
 import { FlagSet } from 'src/featureFlags';
+import { ApplicationState } from 'src/store';
 export { useLDClient } from 'launchdarkly-react-client-sdk';
 
 /**
@@ -13,4 +15,20 @@ export { useLDClient } from 'launchdarkly-react-client-sdk';
  *
  * const flags = useFlags();
  */
-export default useFlags as () => FlagSet;
+// export default ldUseFlags as () => FlagSet;
+
+export const useFlags = () => {
+  const flags = ldUseFlags() as FlagSet;
+
+  // Mock flags are set by custom dev tools and saved in local storage, and override real flags.
+  const mockFlags = useSelector(
+    (state: ApplicationState) => state.mockFeatureFlags
+  );
+
+  return {
+    ...flags,
+    ...mockFlags
+  };
+};
+
+export default useFlags;

--- a/packages/manager/src/index.tsx
+++ b/packages/manager/src/index.tsx
@@ -20,6 +20,7 @@ import 'src/request';
 import store from 'src/store';
 import './index.css';
 import LinodeThemeWrapper from './LinodeThemeWrapper';
+import loadDevTools from './dev-tools/load';
 
 const Lish = React.lazy(() => import('src/features/Lish'));
 const App = React.lazy(() => import('./App'));
@@ -93,22 +94,27 @@ const renderAuthentication = () => (
   </React.Suspense>
 );
 
-ReactDOM.render(
-  navigator.cookieEnabled ? (
-    <Provider store={store}>
-      <Router>
-        <Switch>
-          {/* A place to go that prevents the app from loading while injecting OAuth tokens */}
-          <Route exact path="/null" render={renderNull} />
-          <Route render={renderAuthentication} />
-        </Switch>
-      </Router>
-    </Provider>
-  ) : (
-    <CookieWarning />
-  ),
-  document.getElementById('root') as HTMLElement
-);
+// Thanks to https://kentcdodds.com/blog/make-your-own-dev-tools
+//
+// Load dev tools if need be.
+loadDevTools(() => {
+  ReactDOM.render(
+    navigator.cookieEnabled ? (
+      <Provider store={store}>
+        <Router>
+          <Switch>
+            {/* A place to go that prevents the app from loading while injecting OAuth tokens */}
+            <Route exact path="/null" render={renderNull} />
+            <Route render={renderAuthentication} />
+          </Switch>
+        </Router>
+      </Provider>
+    ) : (
+      <CookieWarning />
+    ),
+    document.getElementById('root') as HTMLElement
+  );
+});
 
 if (module.hot && !isProductionBuild) {
   module.hot.accept();

--- a/packages/manager/src/store/index.ts
+++ b/packages/manager/src/store/index.ts
@@ -141,17 +141,21 @@ import volumeDrawer, {
   defaultState as volumeDrawerDefaultState,
   State as VolumeDrawerState
 } from 'src/store/volumeForm';
-import initialLoad, {
-  defaultState as initialLoadState,
-  State as InitialLoadState
-} from './initialLoad/initialLoad.reducer';
 import featureFlagsLoad, {
   defaultState as featureFlagsLoadState,
   State as FeatureFlagsLoadState
 } from './featureFlagsLoad/featureFlagsLoad.reducer';
+import initialLoad, {
+  defaultState as initialLoadState,
+  State as InitialLoadState
+} from './initialLoad/initialLoad.reducer';
 import diskEvents from './linodes/disk/disk.events';
 import combineEventsMiddleware from './middleware/combineEventsMiddleware';
 import imageEvents from './middleware/imageEvents';
+import mockFeatureFlags, {
+  defaultMockFeatureFlagState,
+  MockFeatureFlagState
+} from './mockFeatureFlags';
 import nodeBalancerEvents from './nodeBalancer/nodeBalancer.events';
 import nodeBalancerConfigEvents from './nodeBalancerConfig/nodeBalancerConfig.events';
 import notifications, {
@@ -236,6 +240,7 @@ export interface ApplicationState {
   globalErrors: GlobalErrorState;
   longviewClients: LongviewState;
   longviewStats: LongviewStatsState;
+  mockFeatureFlags: MockFeatureFlagState;
 }
 
 export const defaultState: ApplicationState = {
@@ -257,7 +262,8 @@ export const defaultState: ApplicationState = {
   firewallDevices: defaultFirewallDevicesState,
   globalErrors: defaultGlobalErrorState,
   longviewClients: defaultLongviewState,
-  longviewStats: defaultLongviewStatsState
+  longviewStats: defaultLongviewStatsState,
+  mockFeatureFlags: defaultMockFeatureFlagState
 };
 
 /**
@@ -305,7 +311,8 @@ const reducers = combineReducers<ApplicationState>({
   firewallDevices,
   globalErrors,
   longviewClients: longview,
-  longviewStats
+  longviewStats,
+  mockFeatureFlags
 });
 
 const enhancers = compose(

--- a/packages/manager/src/store/mockFeatureFlags/index.ts
+++ b/packages/manager/src/store/mockFeatureFlags/index.ts
@@ -1,0 +1,30 @@
+import actionCreatorFactory, { isType } from 'typescript-fsa';
+import { FlagSet } from 'src/featureFlags';
+import { Reducer } from 'redux';
+
+export const actionCreator = actionCreatorFactory(
+  '@@manager/mock-feature-flags'
+);
+
+export const setMockFeatureFlags = actionCreator<Partial<FlagSet>>(
+  'SET_MOCK_FEATURE_FLAGS'
+);
+
+export type MockFeatureFlagState = Partial<FlagSet>;
+
+export const defaultMockFeatureFlagState: MockFeatureFlagState = {};
+
+export const reducer: Reducer<MockFeatureFlagState> = (
+  state = defaultMockFeatureFlagState,
+  action
+) => {
+  if (isType(action, setMockFeatureFlags)) {
+    return {
+      ...state,
+      ...action.payload
+    };
+  }
+  return state;
+};
+
+export default reducer;

--- a/packages/manager/src/utilities/testHelpersStore.ts
+++ b/packages/manager/src/utilities/testHelpersStore.ts
@@ -51,3 +51,7 @@ export const withRestrictedUser: DeepPartial<ApplicationState> = {
     }
   }
 };
+
+export const withLinodesLoaded = {
+  __resources: { linodes: { loading: false, lastUpdated: 1 } }
+};


### PR DESCRIPTION
## Description

Following the lead of https://kentcdodds.com/blog/make-your-own-dev-tools.

This adds "custom dev tools" to Cloud. So far it only supports feature flags (and only CMR). To do this, I created a new slice of state, `mockFeatureFlags`, which the dev tools dispatches actions to when flag toggles are checked.

Both feature flag providers – the HOC and the hook – subscribe to this state and override the real feature flags with the mock feature flags.

The method of enabling the dev tools is the same from the blog post. They are enabled by default when running locally, and disabled by default when the prod bundle is built.

**This means the dev tools will be accessible in production by adding `?dev-tools=true` to the URL.** I think this is fine useful, but we should be mindful of what's allowed in them. There's a concept of importing "local", untracked dev tools present in the code (which I haven't tested) which will allow us to add tools to switch environments, for example, which is something we'd want locally but not expose in production.

https://www.loom.com/share/a2ec21b62f4645539fea727681cfec47

Still todo:
- [x] More testing
- [x] More documentation
