### PR TITLE
Fix Linode transfer "total" (non-CMR)

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeNetSummary.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeNetSummary.tsx
@@ -25,6 +25,7 @@ interface StateProps {
   used: number;
   loading: boolean;
   error: boolean;
+  total: number;
 }
 
 type CombinedProps = Props & StoreProps & StateProps & WithStyles<ClassNames>;
@@ -34,17 +35,19 @@ class LinodeNetSummary extends React.Component<CombinedProps, StateProps> {
   state = {
     used: 0,
     loading: true,
-    error: false
+    error: false,
+    total: 0
   };
 
   componentDidMount() {
     const { linodeId } = this.props;
     getLinodeTransfer(linodeId)
-      .then(({ used }) => {
+      .then(({ used, quota }) => {
         this.setState({
           used,
           loading: false,
-          error: false
+          error: false,
+          total: quota
         });
       })
       .catch(() => {
@@ -56,8 +59,8 @@ class LinodeNetSummary extends React.Component<CombinedProps, StateProps> {
   }
 
   render() {
-    const { total, classes, isTooEarlyForStats } = this.props;
-    const { used, loading, error } = this.state;
+    const { classes, isTooEarlyForStats } = this.props;
+    const { used, loading, error, total } = this.state;
 
     const usedInGb = used / 1024 / 1024 / 1024;
 
@@ -157,14 +160,12 @@ class LinodeNetSummary extends React.Component<CombinedProps, StateProps> {
 }
 
 interface StoreProps {
-  total: number;
   isTooEarlyForStats?: boolean;
 }
 
 const mapStateToProps: MapState<StoreProps, CombinedProps> = (state, props) => {
   const linode = state.__resources.linodes.itemsById[props.linodeId];
   return {
-    total: linode ? linode.specs.transfer : 0,
     isTooEarlyForStats:
       linode && isRecent(linode.created, DateTime.local().toISO())
   };

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeNetSummary.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeNetSummary.tsx
@@ -25,7 +25,7 @@ interface StateProps {
   used: number;
   loading: boolean;
   error: boolean;
-  total: number;
+  quota: number;
 }
 
 type CombinedProps = Props & StoreProps & StateProps & WithStyles<ClassNames>;
@@ -36,7 +36,7 @@ class LinodeNetSummary extends React.Component<CombinedProps, StateProps> {
     used: 0,
     loading: true,
     error: false,
-    total: 0
+    quota: 0
   };
 
   componentDidMount() {
@@ -47,7 +47,7 @@ class LinodeNetSummary extends React.Component<CombinedProps, StateProps> {
           used,
           loading: false,
           error: false,
-          total: quota
+          quota
         });
       })
       .catch(() => {
@@ -60,21 +60,21 @@ class LinodeNetSummary extends React.Component<CombinedProps, StateProps> {
 
   render() {
     const { classes, isTooEarlyForStats } = this.props;
-    const { used, loading, error, total } = this.state;
+    const { used, loading, error, quota } = this.state;
 
     const usedInGb = used / 1024 / 1024 / 1024;
 
-    const totalInBytes = total * 1024 * 1024 * 1024;
+    const quotaInBytes = quota * 1024 * 1024 * 1024;
 
     const usagePercent =
-      totalInBytes > used ? 100 - ((total - usedInGb) * 100) / total : 100;
+      quotaInBytes > used ? 100 - ((quota - usedInGb) * 100) / quota : 100;
 
     const readableUsed = readableBytes(used, {
       maxUnit: 'GB',
       round: { MB: 0, GB: 1 }
     });
 
-    const readableFree = readableBytes(totalInBytes - used, {
+    const readableFree = readableBytes(quotaInBytes - used, {
       maxUnit: 'GB',
       round: { MB: 0, GB: 1 },
       handleNegatives: true
@@ -132,7 +132,7 @@ class LinodeNetSummary extends React.Component<CombinedProps, StateProps> {
             value={Math.ceil(usagePercent)}
             className={classes.poolUsageProgress}
             rounded
-            overLimit={totalInBytes < used}
+            overLimit={quotaInBytes < used}
           />
           <Grid container justify="space-between">
             <Grid item style={{ marginRight: 10 }}>
@@ -142,7 +142,7 @@ class LinodeNetSummary extends React.Component<CombinedProps, StateProps> {
             </Grid>
             <Grid item>
               <Typography>
-                {totalInBytes >= used ? (
+                {quotaInBytes >= used ? (
                   <span>{readableFree.formatted} Available</span>
                 ) : (
                   <span className={classes.overLimit}>


### PR DESCRIPTION
## Description

Previously the `total` being used to calculate "remaining" was from `linode.specs.transfer`, which is the amount of transfer this Linode adds to your total pool each month. This is a static number, however, meaning that it doesn't account for prorated transfer if you create your Linode in the middle of the month, for example.

Instead, we should be using the `quota` from the `/linode/instances/:id/transfer` endpoint (which this component was already hooked into already).

![Screen Shot 2020-07-20 at 8 48 16 AM](https://user-images.githubusercontent.com/16911484/87939641-58973180-ca66-11ea-84fd-761110612f39.png)

Note: this is changing in CMR anyway, but since that's still a ways away, and this was a really simple fix, I went ahead and made the change.

## Note to Reviewers

Compare newly created Linodes with production. The "remaining" value should be different. Also compare older Linodes which have been around all billing cycle – these should be no different from production.
