### PR TITLE
M3-4314 Recycle all LKE cluster pool nodes

### DIFF
--- a/packages/api-v4/src/kubernetes/nodePools.ts
+++ b/packages/api-v4/src/kubernetes/nodePools.ts
@@ -72,3 +72,14 @@ export const deleteNodePool = (clusterID: number, nodePoolID: number) =>
     setMethod('DELETE'),
     setURL(`${API_ROOT}/lke/clusters/${clusterID}/pools/${nodePoolID}`)
   ).then(response => response.data);
+
+/**
+ * recycleAllNodes
+ *
+ * Recycles all nodes from the specified Cluster.
+ */
+export const recycleAllNodes = (clusterID: number, nodePoolID: number) =>
+  Request<{}>(
+    setMethod('POST'),
+    setURL(`${API_ROOT}/lke/clusters/${clusterID}/pools/${nodePoolID}/recycle`)
+  ).then(response => response.data);

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -269,7 +269,12 @@ export const KubernetesClusterDetail: React.FunctionComponent<CombinedProps> = p
   };
 
   const handleRecycleAllNodes = (nodePoolID: number) => {
-    return recycleAllNodes(cluster.id, nodePoolID);
+    return recycleAllNodes(cluster.id, nodePoolID).then(() => {
+      // Recycling nodes is an asynchronous process, and it probably won't make a difference to
+      // request Node Pools here (it could be several seconds before statuses change). I thought
+      // it was a good idea anyway, though.
+      props.requestNodePools(cluster.id);
+    });
   };
 
   return (

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -1,7 +1,8 @@
 import {
   getKubeConfig,
   getKubernetesClusterEndpoints,
-  KubernetesEndpointResponse
+  KubernetesEndpointResponse,
+  recycleAllNodes
 } from '@linode/api-v4/lib/kubernetes';
 import { APIError } from '@linode/api-v4/lib/types';
 import * as React from 'react';
@@ -267,6 +268,10 @@ export const KubernetesClusterDetail: React.FunctionComponent<CombinedProps> = p
     return cluster.label;
   };
 
+  const handleRecycleAllNodes = (nodePoolID: number) => {
+    return recycleAllNodes(cluster.id, nodePoolID);
+  };
+
   return (
     <React.Fragment>
       <DocumentTitleSegment segment={`Kubernetes Cluster ${cluster.label}`} />
@@ -352,6 +357,7 @@ export const KubernetesClusterDetail: React.FunctionComponent<CombinedProps> = p
                 nodePoolID: poolID
               })
             }
+            recycleAllNodes={(poolID: number) => handleRecycleAllNodes(poolID)}
           />
         </Grid>
       </Grid>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
@@ -1,8 +1,7 @@
 import { PoolNodeResponse } from '@linode/api-v4/lib/kubernetes';
 import * as React from 'react';
 import Collapse from 'src/assets/icons/collapse.svg';
-// Not yet supported by the API:
-// import Recycle from 'src/assets/icons/recycle.svg';
+import Recycle from 'src/assets/icons/recycle.svg';
 import Resize from 'src/assets/icons/resize.svg';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
@@ -41,16 +40,16 @@ interface Props {
   typeLabel: string;
   nodes: PoolNodeResponse[];
   openDeletePoolDialog: (poolId: number) => void;
+  openRecycleAllNodesDialog: (poolId: number) => void;
   openRecycleNodeDialog: (linodeId: number, linodeLabel: string) => void;
   handleClickResize: (poolId: number) => void;
-  // Not yet supported by the API:
-  // recycleNodes: (poolId: number) => void;
 }
 
 const NodePool: React.FC<Props> = props => {
   const {
     handleClickResize,
     openDeletePoolDialog,
+    openRecycleAllNodesDialog,
     openRecycleNodeDialog,
     nodes,
     typeLabel,
@@ -72,12 +71,12 @@ const NodePool: React.FC<Props> = props => {
             className={classes.icon}
           />
           {/* Not yet supported by the API: */}
-          {/* <IconTextLink
+          <IconTextLink
             text="Recycle Nodes"
             SideIcon={Recycle}
             title="Recycle Nodes"
-            onClick={() => recycleNodes(poolId)}
-          /> */}
+            onClick={() => openRecycleAllNodesDialog(poolId)}
+          />
           <IconTextLink
             text="Delete Pool"
             SideIcon={Collapse}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
@@ -70,7 +70,6 @@ const NodePool: React.FC<Props> = props => {
             onClick={() => handleClickResize(poolId)}
             className={classes.icon}
           />
-          {/* Not yet supported by the API: */}
           <IconTextLink
             text="Recycle Nodes"
             SideIcon={Recycle}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.test.tsx
@@ -33,6 +33,7 @@ const props: Props = {
   updatePool: jest.fn(),
   deletePool: jest.fn(),
   addNodePool: jest.fn(),
+  recycleAllNodes: jest.fn(),
   clusterLabel: 'a cluster'
 };
 

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -21,6 +21,7 @@ import ResizeNodePoolDrawer from '../ResizeNodePoolDrawer';
 import NodeDialog from './NodeDialog';
 import NodePool from './NodePool';
 import NodePoolDialog from './NodePoolDialog';
+import RecycleAllNodesDialog from './RecycleAllNodesDialog';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -68,6 +69,7 @@ export interface Props {
   ) => Promise<PoolNodeWithPrice>;
   deletePool: (poolID: number) => Promise<any>;
   addNodePool: (newPool: PoolNodeRequest) => Promise<PoolNodeResponse>;
+  recycleAllNodes: (poolID: number) => Promise<any>;
 }
 
 export const NodePoolsDisplay: React.FC<Props> = props => {
@@ -77,7 +79,8 @@ export const NodePoolsDisplay: React.FC<Props> = props => {
     types,
     addNodePool,
     updatePool,
-    deletePool
+    deletePool,
+    recycleAllNodes
   } = props;
 
   const classes = useStyles();
@@ -85,6 +88,7 @@ export const NodePoolsDisplay: React.FC<Props> = props => {
   const { deleteLinode } = useLinodes();
 
   const deletePoolDialog = useDialog<number>(deletePool);
+  const recycleAllNodesDialog = useDialog<number>(recycleAllNodes);
   const recycleNodeDialog = useDialog<number>(deleteLinode);
 
   const [addDrawerOpen, setAddDrawerOpen] = React.useState<boolean>(false);
@@ -170,6 +174,16 @@ export const NodePoolsDisplay: React.FC<Props> = props => {
     });
   };
 
+  const handleRecycleAllNodes = () => {
+    const { dialog, submitDialog, handleError } = recycleAllNodesDialog;
+    if (!dialog.entityID) {
+      return;
+    }
+    return submitDialog(dialog.entityID).catch(err => {
+      handleError(getAPIErrorOrDefault(err, 'Error recycling nodes')[0].reason);
+    });
+  };
+
   /**
    * If the API returns an error when fetching node pools,
    * we want to display this error to the user from the
@@ -237,6 +251,9 @@ export const NodePoolsDisplay: React.FC<Props> = props => {
                       nodes={nodes ?? []}
                       handleClickResize={handleOpenResizeDrawer}
                       openDeletePoolDialog={deletePoolDialog.openDialog}
+                      openRecycleAllNodesDialog={
+                        recycleAllNodesDialog.openDialog
+                      }
                       openRecycleNodeDialog={recycleNodeDialog.openDialog}
                     />
                   </div>
@@ -278,6 +295,13 @@ export const NodePoolsDisplay: React.FC<Props> = props => {
               error={recycleNodeDialog.dialog.error}
               loading={recycleNodeDialog.dialog.isLoading}
               label={recycleNodeDialog.dialog.entityLabel}
+            />
+            <RecycleAllNodesDialog
+              open={recycleAllNodesDialog.dialog.isOpen}
+              loading={recycleAllNodesDialog.dialog.isLoading}
+              error={recycleAllNodesDialog.dialog.error}
+              onClose={recycleAllNodesDialog.closeDialog}
+              onSubmit={handleRecycleAllNodes}
             />
           </Grid>
         )}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/RecycleAllNodesDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/RecycleAllNodesDialog.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
+import ConfirmationDialog from 'src/components/ConfirmationDialog';
+import Typography from 'src/components/core/Typography';
+import Notice from 'src/components/Notice';
+
+interface Props {
+  open: boolean;
+  loading: boolean;
+  error?: string;
+  onClose: () => void;
+  onSubmit: () => void;
+}
+
+const renderActions = (
+  loading: boolean,
+  onClose: () => void,
+  onSubmit: () => void
+) => {
+  return (
+    <ActionsPanel style={{ padding: 0 }}>
+      <Button
+        buttonType="cancel"
+        onClick={onClose}
+        data-qa-cancel
+        data-testid={'dialog-cancel'}
+      >
+        Cancel
+      </Button>
+      <Button
+        buttonType="secondary"
+        destructive
+        loading={loading}
+        onClick={onSubmit}
+        data-qa-confirm
+        data-testid={'dialog-confirm'}
+      >
+        Recycle all Nodes
+      </Button>
+    </ActionsPanel>
+  );
+};
+
+const RecycleAllNodesDialog: React.FC<Props> = props => {
+  const { error, loading, open, onClose, onSubmit } = props;
+
+  return (
+    <ConfirmationDialog
+      open={open}
+      title="Recycle all nodes?"
+      onClose={onClose}
+      actions={() => renderActions(loading, onClose, onSubmit)}
+    >
+      {error && <Notice error text={error} />}
+      <Typography>
+        Are you sure you want to recycle all nodes? All nodes belonging to the
+        pool will be removed and replaced with fresh nodes.
+      </Typography>
+    </ConfirmationDialog>
+  );
+};
+
+export default React.memo(RecycleAllNodesDialog);


### PR DESCRIPTION
## Description

This PR makes use of the new recycle nodes endpoint, currently available in dev only.

I didn't put this action into Redux since this kicks off an asynchronous process and it could be several seconds before anything changes. Since there's no immediate feedback that anything is happening, we should maybe include a note about this in the confirmation modal (which is sort of placeholder text right now anyway). @Jskobos what do you think?


## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Use dev. The "Recycle Nodes" option is now available on the Cluster Detail page.
