### PR TITLE
M3-4366: Fix placement of Backups CTA

### DIFF
--- a/packages/manager/src/components/Link.tsx
+++ b/packages/manager/src/components/Link.tsx
@@ -22,3 +22,5 @@ export const Link: React.FC<LinkProps> = props => {
     <RouterLink {...props} />
   );
 };
+
+export default Link;

--- a/packages/manager/src/features/Backups/BackupDrawer.tsx
+++ b/packages/manager/src/features/Backups/BackupDrawer.tsx
@@ -10,6 +10,7 @@ import Typography from 'src/components/core/Typography';
 import DisplayPrice from 'src/components/DisplayPrice';
 import Drawer from 'src/components/Drawer';
 import Grid from 'src/components/Grid';
+import Link from 'src/components/Link';
 import Notice from 'src/components/Notice';
 import { ApplicationState } from 'src/store';
 import {
@@ -139,17 +140,14 @@ export class BackupDrawer extends React.Component<CombinedProps, {}> {
               Three backup slots are executed and rotated automatically: a daily
               backup, a 2-7 day old backup, and an 8-14 day old backup. See our
               {` `}
-              <a
-                target="_blank"
-                aria-describedby="external-site"
-                rel="noopener noreferrer"
-                href={
+              <Link
+                to={
                   'https://www.linode.com/docs/platform' +
                   '/disk-images/linode-backup-service/'
                 }
               >
                 guide on Backups
-              </a>{' '}
+              </Link>{' '}
               for more information on features and limitations. Confirm to add
               backups to <strong data-qa-backup-count>{linodeCount}</strong>{' '}
               {linodeCount > 1 ? 'Linodes' : 'Linode'}.

--- a/packages/manager/src/features/Backups/BackupDrawer.tsx
+++ b/packages/manager/src/features/Backups/BackupDrawer.tsx
@@ -137,9 +137,21 @@ export class BackupDrawer extends React.Component<CombinedProps, {}> {
           <Grid item>
             <Typography variant="body1">
               Three backup slots are executed and rotated automatically: a daily
-              backup, a 2-7 day old backup, and an 8-14 day old backup. Confirm
-              to add backups to{' '}
-              <strong data-qa-backup-count>{linodeCount}</strong>{' '}
+              backup, a 2-7 day old backup, and an 8-14 day old backup. See our
+              {` `}
+              <a
+                target="_blank"
+                aria-describedby="external-site"
+                rel="noopener noreferrer"
+                href={
+                  'https://www.linode.com/docs/platform' +
+                  '/disk-images/linode-backup-service/'
+                }
+              >
+                guide on Backups
+              </a>{' '}
+              for more information on features and limitations. Confirm to add
+              backups to <strong data-qa-backup-count>{linodeCount}</strong>{' '}
               {linodeCount > 1 ? 'Linodes' : 'Linode'}.
             </Typography>
           </Grid>

--- a/packages/manager/src/features/Backups/BackupsCTA_CMR.tsx
+++ b/packages/manager/src/features/Backups/BackupsCTA_CMR.tsx
@@ -1,0 +1,133 @@
+import { Linode } from '@linode/api-v4/lib/linodes';
+import Close from '@material-ui/icons/Close';
+import { isEmpty } from 'ramda';
+import * as React from 'react';
+import { connect, MapDispatchToProps } from 'react-redux';
+import { compose } from 'recompose';
+import Button from 'src/components/Button';
+import Paper from 'src/components/core/Paper';
+import Hidden from 'src/components/core/Hidden';
+import {
+  createStyles,
+  Theme,
+  withStyles,
+  WithStyles
+} from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+import { isRestrictedUser } from 'src/features/Profile/permissionsHelpers';
+import { handleOpen } from 'src/store/backupDrawer';
+import { getLinodesWithoutBackups } from 'src/store/selectors/getLinodesWithBackups';
+import { MapState } from 'src/store/types';
+
+type ClassNames = 'root' | 'enableButton' | 'enableText' | 'closeIcon';
+
+interface Props {
+  dismissed: () => void;
+}
+
+const styles = (theme: Theme) =>
+  createStyles({
+    root: {
+      padding: theme.spacing(1),
+      paddingRight: theme.spacing(2),
+      margin: `${theme.spacing(1)}px 0 ${theme.spacing(3)}px 0`,
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignItems: 'center'
+    },
+    enableButton: {
+      borderRadius: 3,
+      height: 40,
+      padding: 0,
+      width: 152
+    },
+    enableText: {
+      ...theme.applyLinkStyles
+    },
+    closeIcon: {
+      ...theme.applyLinkStyles,
+      marginLeft: 12
+    }
+  });
+
+type CombinedProps = StateProps &
+  Props &
+  DispatchProps &
+  WithStyles<ClassNames>;
+
+const BackupsCTA: React.FC<CombinedProps> = props => {
+  const {
+    classes,
+    linodesWithoutBackups,
+    managed,
+    actions: { openBackupsDrawer },
+    dismissed
+  } = props;
+
+  const restricted = isRestrictedUser();
+
+  if (
+    restricted ||
+    managed ||
+    (linodesWithoutBackups && isEmpty(linodesWithoutBackups))
+  ) {
+    return null;
+  }
+
+  return (
+    <Paper className={classes.root}>
+      <Typography style={{ fontSize: '1rem' }}>
+        <button className={classes.enableText} onClick={openBackupsDrawer}>
+          Enable Linode Backups
+        </button>{' '}
+        to protect your data and recover quickly in an emergency
+      </Typography>
+      <span style={{ display: 'flex' }}>
+        <Hidden smDown>
+          <Button
+            buttonType="primary"
+            onClick={openBackupsDrawer}
+            className={classes.enableButton}
+          >
+            Enable Backups...
+          </Button>
+        </Hidden>
+        <button onClick={dismissed} className={classes.closeIcon}>
+          <Close />
+        </button>
+      </span>
+    </Paper>
+  );
+};
+
+interface StateProps {
+  linodesWithoutBackups: Linode[];
+  managed: boolean;
+}
+
+interface DispatchProps {
+  actions: {
+    openBackupsDrawer: () => void;
+  };
+}
+
+const mapStateToProps: MapState<StateProps, {}> = state => ({
+  linodesWithoutBackups: getLinodesWithoutBackups(state.__resources),
+  managed: state?.__resources?.accountSettings?.data?.managed ?? false
+});
+
+const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = dispatch => {
+  return {
+    actions: {
+      openBackupsDrawer: () => dispatch(handleOpen())
+    }
+  };
+};
+
+const styled = withStyles(styles);
+
+const connected = connect(mapStateToProps, mapDispatchToProps);
+
+const enhanced = compose<CombinedProps, Props>(styled, connected)(BackupsCTA);
+
+export default enhanced;

--- a/packages/manager/src/features/Backups/BackupsCTA_CMR.tsx
+++ b/packages/manager/src/features/Backups/BackupsCTA_CMR.tsx
@@ -80,7 +80,7 @@ const BackupsCTA: React.FC<CombinedProps> = props => {
         <button className={classes.enableText} onClick={openBackupsDrawer}>
           Enable Linode Backups
         </button>{' '}
-        to protect your data and recover quickly in an emergency
+        to protect your data and recover quickly in an emergency.
       </Typography>
       <span style={{ display: 'flex' }}>
         <Hidden smDown>

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -41,6 +41,7 @@ import withFeatureFlagConsumer, {
 import withImages, { WithImages } from 'src/containers/withImages.container';
 import { LinodeGettingStarted, SecuringYourServer } from 'src/documentation';
 import { BackupsCTA } from 'src/features/Backups';
+import BackupsCTA_CMR from 'src/features/Backups/BackupsCTA_CMR';
 import { ApplicationState } from 'src/store';
 import { deleteLinode } from 'src/store/linodes/linode.requests';
 import {
@@ -274,6 +275,8 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
       clickable: true
     };
 
+    const displayBackupsCTA = backupsCTA && !BackupsCtaDismissed.get();
+
     return (
       <React.Fragment>
         {this.props.flags.cmr && (
@@ -301,7 +304,7 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
             className={`${
               backupsCTA && !BackupsCtaDismissed.get() ? 'mlMain' : ''
             }`}
-            xs={!backupsCTA || (backupsCTA && BackupsCtaDismissed.get() && 12)}
+            xs={this.props.flags.cmr || !displayBackupsCTA ? 12 : undefined}
           >
             <DocumentTitleSegment segment="Linodes" />
             <PreferenceToggle<boolean>
@@ -347,6 +350,9 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
                         <React.Fragment>
                           {this.props.flags.cmr ? (
                             <React.Fragment>
+                              {displayBackupsCTA && (
+                                <BackupsCTA_CMR dismissed={this.dismissCTA} />
+                              )}
                               <Grid item xs={12}>
                                 <LandingHeader
                                   title="Linodes"
@@ -631,6 +637,11 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
               }}
             </PreferenceToggle>
           </Grid>
+          {displayBackupsCTA && !this.props.flags.cmr && (
+            <Grid item className="mlSidebar py0">
+              <BackupsCTA dismissed={this.dismissCTA} />
+            </Grid>
+          )}
         </Grid>
         {!!this.state.selectedLinodeID && !!this.state.selectedLinodeLabel && (
           <React.Fragment>
@@ -650,11 +661,6 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
               handleDelete={this.props.deleteLinode}
             />
           </React.Fragment>
-        )}
-        {backupsCTA && !BackupsCtaDismissed.get() && (
-          <Grid item className="mlSidebar py0">
-            <BackupsCTA dismissed={this.dismissCTA} />
-          </Grid>
         )}
       </React.Fragment>
     );


### PR DESCRIPTION
## Description

This does two things:

1. Fix placement of Linodes Landing Backups CTA in Production (non-CMR)
2. Add new CMR component for BackupsCTA implementing mockup from Jay

<img width="1324" alt="Screen Shot 2020-07-21 at 3 28 29 PM" src="https://user-images.githubusercontent.com/16911484/88097850-d6426680-cb66-11ea-8263-3ecfd21aa60b.png">

**Note:**

The new CTA doesn't have a link to the backups guide, so I included in the drawer, which is used by CMR _and_ Production. IMO it doesn't hurt to show it in both places for a little while.

## Note to Reviewers

To remove changes to the CTA:

```
git diff HEAD:packages/manager/src/features/Backups/BackupsCTA.tsx packages/manager/src/features/Backups/BackupsCTA_CMR.tsx
```

Please check all combos:

1. No local storage flag, Linodes without backups.
2. Local storage flag, Linodes without backups (i.e. "dismissed")

etc., for CMR and non-CMR.

