### PR TITLE
Utility/Easter Egg: user preferences editor

### DIFF
--- a/MOCKING_DATA.md
+++ b/MOCKING_DATA.md
@@ -30,3 +30,9 @@ options: {
   }
 }
 ```
+
+## Changing user preferences
+
+Since [user preferences are tied to OAuth clients](https://developers.linode.com/api/v4/profile-preferences), to change Cloud Manager preferences you must grab the short-lived token from the app and use that to curl.
+
+As a convenience, there is a preference editor in Cloud accessible by going to `/profile/settings?preferenceEditor=true`. It allows you to enter arbitrary JSON and submit it (validating that it's valid JSON first). This makes it easier to quickly edit preferences when developing features that depend on it.

--- a/packages/manager/src/components/Dialog/Dialog.tsx
+++ b/packages/manager/src/components/Dialog/Dialog.tsx
@@ -58,7 +58,6 @@ const useStyles = makeStyles((theme: Theme) =>
       padding: theme.spacing(2),
       paddingRight: theme.spacing(),
       margin: '8px -8px',
-      background: theme.color.white,
       zIndex: 1,
       width: '100%',
       display: 'flex',

--- a/packages/manager/src/components/Dialog/Dialog.tsx
+++ b/packages/manager/src/components/Dialog/Dialog.tsx
@@ -58,7 +58,6 @@ const useStyles = makeStyles((theme: Theme) =>
       padding: theme.spacing(),
       paddingTop: theme.spacing(4),
       marginBottom: 20,
-      background: theme.color.white,
       zIndex: 1,
       width: '100%',
       display: 'flex',

--- a/packages/manager/src/components/Dialog/index.tsx
+++ b/packages/manager/src/components/Dialog/index.tsx
@@ -1,3 +1,6 @@
-import Dialog from './Dialog';
+import Dialog, { DialogProps as _DialogProps } from './Dialog';
+
+// eslint-disable-next-line
+export interface DialogProps extends _DialogProps {}
 
 export default Dialog;

--- a/packages/manager/src/components/Link.tsx
+++ b/packages/manager/src/components/Link.tsx
@@ -22,3 +22,5 @@ export const Link: React.FC<LinkProps> = props => {
     <RouterLink {...props} />
   );
 };
+
+export default Link;

--- a/packages/manager/src/features/Profile/Settings/PreferenceEditor.tsx
+++ b/packages/manager/src/features/Profile/Settings/PreferenceEditor.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import Dialog, { DialogProps as _DialogProps } from 'src/components/Dialog';
 import Typography from 'src/components/core/Typography';
+import Link from 'src/components/Link';
 import withPreferences, {
   Props as PreferencesProps
 } from 'src/containers/preferences.container';
@@ -65,9 +66,9 @@ const PreferenceEditor: React.FC<CombinedProps> = props => {
       )}
       <Typography>
         Update user preferences tied to Cloud Manager. See the{' '}
-        <a href="https://developers.linode.com/api/v4/profile-preferences">
+        <Link to="https://developers.linode.com/api/v4/profile-preferences">
           Linode API documentation
-        </a>{' '}
+        </Link>{' '}
         for more information about user preferences.
       </Typography>
       {loading && <Typography>Loading...</Typography>}

--- a/packages/manager/src/features/Profile/Settings/PreferenceEditor.tsx
+++ b/packages/manager/src/features/Profile/Settings/PreferenceEditor.tsx
@@ -1,0 +1,100 @@
+import * as React from 'react';
+import Dialog, { DialogProps as _DialogProps } from 'src/components/Dialog';
+import Typography from 'src/components/core/Typography';
+import withPreferences, {
+  Props as PreferencesProps
+} from 'src/containers/preferences.container';
+import Button from 'src/components/Button';
+import Notice from 'src/components/Notice';
+import { compose } from 'recompose';
+
+type DialogProps = Pick<_DialogProps, 'onClose' | 'open'>;
+
+type CombinedProps = DialogProps & PreferencesProps;
+
+const PreferenceEditor: React.FC<CombinedProps> = props => {
+  const { getUserPreferences, updateUserPreferences } = props;
+
+  const [userPrefs, setUserPrefs] = React.useState('');
+  const [errorMessage, setErrorMessage] = React.useState('');
+  const [successMessage, setSuccessMessage] = React.useState('');
+  const [loading, setLoading] = React.useState(false);
+  const [submitting, setSubmitting] = React.useState(false);
+
+  React.useEffect(() => {
+    setLoading(true);
+    getUserPreferences()
+      .then(userPreferences => {
+        setLoading(false);
+        setUserPrefs(JSON.stringify(userPreferences, null, 2));
+      })
+      .catch(() => {
+        setErrorMessage('Unable to load user preferences');
+      });
+  }, [getUserPreferences]);
+
+  const handleSavePreferences = () => {
+    try {
+      const parsed = JSON.parse(userPrefs);
+      setSubmitting(true);
+      setSuccessMessage('');
+      setErrorMessage('');
+      updateUserPreferences(parsed as any)
+        .then(() => {
+          setSuccessMessage('Preferences updated successfully');
+          setSubmitting(false);
+        })
+        .catch(() => {
+          setErrorMessage('Unable to set preferences');
+        });
+    } catch {
+      setErrorMessage('Invalid JSON');
+    }
+  };
+
+  return (
+    <Dialog
+      title="Edit Preferences"
+      open={props.open}
+      onClose={props.onClose}
+      maxWidth="sm"
+    >
+      {errorMessage && <Notice spacingBottom={8} error text={errorMessage} />}
+      {successMessage && (
+        <Notice spacingBottom={8} success text={successMessage} />
+      )}
+      <Typography>
+        Update user preferences tied to Cloud Manager. See the{' '}
+        <a href="https://developers.linode.com/api/v4/profile-preferences">
+          Linode API documentation
+        </a>{' '}
+        for more information about user preferences.
+      </Typography>
+      {loading && <Typography>Loading...</Typography>}
+      <div>
+        <textarea
+          value={userPrefs}
+          style={{
+            marginTop: 16,
+            width: 400,
+            height: 300,
+            fontFamily: '"Ubuntu Mono", monospace"'
+          }}
+          onChange={e => setUserPrefs(e.target.value)}
+        ></textarea>
+      </div>
+      <Button
+        style={{ marginTop: 8 }}
+        buttonType="primary"
+        onClick={handleSavePreferences}
+        loading={submitting}
+      >
+        Submit
+      </Button>
+    </Dialog>
+  );
+};
+
+const enhanced = compose<CombinedProps, DialogProps>(withPreferences());
+
+export default enhanced(PreferenceEditor);

--- a/packages/manager/src/features/Profile/Settings/Settings.tsx
+++ b/packages/manager/src/features/Profile/Settings/Settings.tsx
@@ -1,4 +1,5 @@
 import { Profile } from '@linode/api-v4/lib/profile';
+import { getQueryParam } from 'src/utilities/queryParams';
 import { path } from 'ramda';
 import * as React from 'react';
 import { connect, MapDispatchToProps } from 'react-redux';
@@ -17,6 +18,7 @@ import Grid from 'src/components/Grid';
 import Toggle from 'src/components/Toggle';
 import { updateProfile as handleUpdateProfile } from 'src/store/profile/profile.requests';
 import { MapState } from 'src/store/types';
+import PreferenceEditor from './PreferenceEditor';
 
 type ClassNames = 'root' | 'title' | 'label';
 
@@ -36,17 +38,28 @@ const styles = (theme: Theme) =>
 
 interface State {
   submitting: boolean;
+  preferenceEditorOpen: boolean;
 }
 
 type CombinedProps = StateProps & DispatchProps & WithStyles<ClassNames>;
 
 class ProfileSettings extends React.Component<CombinedProps, State> {
   state: State = {
-    submitting: false
+    submitting: false,
+    preferenceEditorOpen: false
   };
+
+  componentDidMount() {
+    if (getQueryParam(window.location.search, 'preferenceEditor') === 'true') {
+      this.setState({ preferenceEditorOpen: true });
+    }
+  }
 
   render() {
     const { classes, status } = this.props;
+
+    const preferenceEditorMode =
+      getQueryParam(window.location.search, 'preferenceEditor') === 'true';
 
     return (
       <Paper
@@ -73,6 +86,12 @@ class ProfileSettings extends React.Component<CombinedProps, State> {
             />
           </Grid>
         </Grid>
+        {preferenceEditorMode && (
+          <PreferenceEditor
+            open={this.state.preferenceEditorOpen}
+            onClose={() => this.setState({ preferenceEditorOpen: false })}
+          />
+        )}
       </Paper>
     );
   }
@@ -110,14 +129,8 @@ const mapStateToProps: MapState<StateProps, {}> = state => ({
   status: path(['data', 'email_notifications'], state.__resources.profile)
 });
 
-const connected = connect(
-  mapStateToProps,
-  mapDispatchToProps
-);
+const connected = connect(mapStateToProps, mapDispatchToProps);
 
-const enhanced = compose<CombinedProps, {}>(
-  styled,
-  connected
-);
+const enhanced = compose<CombinedProps, {}>(styled, connected);
 
 export default enhanced(ProfileSettings);


### PR DESCRIPTION
## Description

Since [user preferences are tied to OAuth Clients](https://developers.linode.com/api/v4/profile-preferences), to change Cloud Manager preferences you must grab the short-lived token from the app and use that to curl. 

This adds a secret "user preference" editor directly in Cloud, accessible by going to `/profile/settings?preferenceEditor=true`. The editor is pretty simple; it allows you to enter arbitrary JSON and submit it (validating that it's valid JSON first). This makes it easier to quickly edit preferences when developing features that depend on it.

![Screen Shot 2020-07-22 at 8 15 17 AM](https://user-images.githubusercontent.com/16911484/88175731-4519d100-cbf4-11ea-94ac-d31a15a42484.png)

