### PR TITLE
M3-4351: CMR Table Styles for Volumes Landing page

### DIFF
--- a/packages/manager/src/components/EntityTable/types.ts
+++ b/packages/manager/src/components/EntityTable/types.ts
@@ -1,9 +1,10 @@
 import { Domain } from '@linode/api-v4/lib/domains/types';
 import { Firewall } from '@linode/api-v4/lib/firewalls/types';
 import { Linode } from '@linode/api-v4/lib/linodes/types';
+import { Volume } from '@linode/api-v4/lib/volumes/types';
 import { APIError } from '@linode/api-v4/lib/types';
 export type Handlers = Record<string, Function>;
-export type Entity = Linode | Domain | Firewall; // @todo add more here
+export type Entity = Linode | Domain | Firewall | Volume; // @todo add more here
 
 export interface BaseProps {
   error?: APIError[];

--- a/packages/manager/src/features/Volumes/RenderVolumeData_CMR.tsx
+++ b/packages/manager/src/features/Volumes/RenderVolumeData_CMR.tsx
@@ -1,7 +1,7 @@
 import { Event } from '@linode/api-v4/lib/account';
 import * as React from 'react';
 import { ExtendedVolume } from './types';
-import VolumeTableRow from './VolumeTableRow_CMR';
+import VolumeTableRow from './VolumeTableRow';
 
 export interface RenderVolumeDataProps {
   isVolumesLanding: boolean;

--- a/packages/manager/src/features/Volumes/VolumeTableRow_CMR.tsx
+++ b/packages/manager/src/features/Volumes/VolumeTableRow_CMR.tsx
@@ -1,5 +1,4 @@
 import { Event } from '@linode/api-v4/lib/account';
-import { pathOr } from 'ramda';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { makeStyles } from 'src/components/core/styles';
@@ -10,7 +9,8 @@ import LinearProgress from 'src/components/LinearProgress';
 import TableCell from 'src/components/TableCell/TableCell_CMR';
 import { formatRegion } from 'src/utilities';
 import { ExtendedVolume } from './types';
-import VolumesActionMenu from './VolumesActionMenu_CMR';
+import VolumesActionMenu, { ActionHandlers } from './VolumesActionMenu_CMR';
+import { compose } from 'recompose';
 
 const useStyles = makeStyles(() => ({
   root: {},
@@ -34,38 +34,7 @@ const useStyles = makeStyles(() => ({
   }
 }));
 
-interface Props {
-  volume: ExtendedVolume;
-  isUpdating: boolean;
-  isVolumesLanding: boolean;
-  openForEdit: (
-    volumeId: number,
-    volumeLabel: string,
-    volumeTags: string[]
-  ) => void;
-  openForResize: (
-    volumeId: number,
-    volumeSize: number,
-    volumeLabel: string
-  ) => void;
-  openForClone: (
-    volumeId: number,
-    volumeLabel: string,
-    volumeSize: number,
-    volumeRegion: string
-  ) => void;
-  openForConfig: (volumeLabel: string, volumePath: string) => void;
-  handleAttach: (volumeId: number, label: string, regionID: string) => void;
-  handleDetach: (
-    volumeId: number,
-    volumeLabel: string,
-    linodeLabel: string,
-    poweredOff: boolean
-  ) => void;
-  handleDelete: (volumeId: number, volumeLabel: string) => void;
-}
-
-type CombinedProps = Props;
+type CombinedProps = ExtendedVolume & ActionHandlers;
 
 const progressFromEvent = (e?: Event) => {
   if (!e) {
@@ -83,7 +52,6 @@ export const VolumeTableRow: React.FC<CombinedProps> = props => {
   const classes = useStyles();
   const {
     isUpdating,
-    isVolumesLanding,
     openForClone,
     openForConfig,
     openForEdit,
@@ -91,17 +59,25 @@ export const VolumeTableRow: React.FC<CombinedProps> = props => {
     handleAttach,
     handleDelete,
     handleDetach,
-    volume
+    id,
+    label,
+    tags,
+    size,
+    recentEvent,
+    filesystem_path: filesystemPath,
+    linodeLabel,
+    linode_id: linodeId,
+    linodeStatus
   } = props;
-  const label = volume?.label ?? '';
-  const size = volume?.size ?? '';
-  const filesystemPath =
-    volume?.filesystem_path ?? `/dev/disk/by-id/scsi-0Linode_Volume_${label}`;
-  const regionID = pathOr('', ['region'], volume);
-  const region = formatRegion(regionID);
+
+  const region = formatRegion(props.region);
 
   return isUpdating ? (
-    <TableRow key={volume.id} data-qa-volume-loading className="fade-in-table">
+    <TableRow
+      key={`volume-row-${id}`}
+      data-qa-volume-loading
+      className="fade-in-table"
+    >
       <TableCell data-qa-volume-cell-label={label}>
         <Grid container wrap="nowrap" alignItems="center">
           <Grid item>
@@ -110,27 +86,27 @@ export const VolumeTableRow: React.FC<CombinedProps> = props => {
         </Grid>
       </TableCell>
       <TableCell colSpan={5}>
-        <LinearProgress value={progressFromEvent(volume.recentEvent)} />
+        <LinearProgress value={progressFromEvent(recentEvent)} />
       </TableCell>
     </TableRow>
   ) : (
     <TableRow
-      key={volume.id}
-      data-qa-volume-cell={volume.id}
+      key={`volume-row-${id}`}
+      data-qa-volume-cell={id}
       // className="fade-in-table"
     >
       <TableCell
         className={classes.volumeLabel}
         parentColumn="Label"
-        data-qa-volume-cell-label={volume.label}
+        data-qa-volume-cell-label={label}
       >
         <Grid container wrap="nowrap" alignItems="center">
           <Grid item>
-            <div>{volume.label}</div>
+            <div>{label}</div>
           </Grid>
         </Grid>
       </TableCell>
-      {isVolumesLanding && (
+      {region && (
         <TableCell parentColumn="Region" data-qa-volume-region>
           {region}
         </TableCell>
@@ -149,47 +125,42 @@ export const VolumeTableRow: React.FC<CombinedProps> = props => {
       >
         {filesystemPath}
       </TableCell>
-      {isVolumesLanding && (
-        <TableCell
-          parentColumn="Attached To"
-          data-qa-volume-cell-attachment={volume.linodeLabel}
-        >
-          {volume.linodeLabel ? (
-            <Link
-              to={`/linodes/${volume.linode_id}`}
-              className="link secondaryLink"
-            >
-              {volume.linodeLabel}
-            </Link>
-          ) : (
-            <Typography data-qa-unattached>Unattached</Typography>
-          )}
-        </TableCell>
-      )}
+      <TableCell
+        parentColumn="Attached To"
+        data-qa-volume-cell-attachment={linodeLabel}
+      >
+        {linodeId ? (
+          <Link to={`/linodes/${linodeId}`} className="link secondaryLink">
+            {linodeLabel}
+          </Link>
+        ) : (
+          <Typography data-qa-unattached>Unattached</Typography>
+        )}
+      </TableCell>
       <TableCell className={classes.actionMenu}>
         <VolumesActionMenu
           onShowConfig={openForConfig}
           filesystemPath={filesystemPath}
-          linodeLabel={volume.linodeLabel || ''}
-          regionID={regionID}
-          volumeId={volume.id}
-          volumeTags={volume.tags}
+          linodeLabel={linodeLabel || ''}
+          regionID={region}
+          volumeId={id}
+          volumeTags={tags}
           size={size}
           label={label}
           onEdit={openForEdit}
           onResize={openForResize}
           onClone={openForClone}
-          volumeLabel={volume.label}
+          volumeLabel={label}
           /**
-           * This is a safer check than volume.linode_id (see logic in addAttachedLinodeInfoToVolume() from VolumesLanding)
+           * This is a safer check than linode_id (see logic in addAttachedLinodeInfoToVolume() from VolumesLanding)
            * as it actually checks to see if the Linode exists before adding linodeLabel and linodeStatus.
            * This avoids a bug (M3-2534) where a Volume attached to a just-deleted Linode
            * could sometimes get tagged as "attached" here.
            */
-          attached={Boolean(volume.linodeLabel)}
+          attached={Boolean(linodeLabel)}
           onAttach={handleAttach}
           onDetach={handleDetach}
-          poweredOff={volume.linodeStatus === 'offline'}
+          poweredOff={linodeStatus === 'offline'}
           onDelete={handleDelete}
         />
       </TableCell>
@@ -197,4 +168,6 @@ export const VolumeTableRow: React.FC<CombinedProps> = props => {
   );
 };
 
-export default VolumeTableRow;
+export default compose<CombinedProps, ActionHandlers & ExtendedVolume>(
+  React.memo
+)(VolumeTableRow);

--- a/packages/manager/src/features/Volumes/VolumeTableRow_CMR.tsx
+++ b/packages/manager/src/features/Volumes/VolumeTableRow_CMR.tsx
@@ -64,13 +64,14 @@ export const VolumeTableRow: React.FC<CombinedProps> = props => {
     tags,
     size,
     recentEvent,
+    region,
     filesystem_path: filesystemPath,
     linodeLabel,
     linode_id: linodeId,
     linodeStatus
   } = props;
 
-  const region = formatRegion(props.region);
+  const formattedRegion = formatRegion(region);
 
   return isUpdating ? (
     <TableRow
@@ -108,7 +109,7 @@ export const VolumeTableRow: React.FC<CombinedProps> = props => {
       </TableCell>
       {region && (
         <TableCell parentColumn="Region" data-qa-volume-region>
-          {region}
+          {formattedRegion}
         </TableCell>
       )}
       <TableCell

--- a/packages/manager/src/features/Volumes/Volumes.tsx
+++ b/packages/manager/src/features/Volumes/Volumes.tsx
@@ -6,34 +6,44 @@ import {
   Switch,
   withRouter
 } from 'react-router-dom';
+import useFlags from 'src/hooks/useFlags';
 
 const VolumesLanding = React.lazy(() => import('./VolumesLanding'));
+const VolumesLanding_CMR = React.lazy(() => import('./VolumesLanding_CMR'));
 
 const VolumeCreate = React.lazy(() => import('./VolumeCreate/VolumeCreate'));
 
 type Props = RouteComponentProps<{}>;
 
-class Volumes extends React.Component<Props> {
-  render() {
-    const {
-      match: { path }
-    } = this.props;
+const Volumes: React.FC<Props> = props => {
+  const {
+    match: { path }
+  } = props;
 
-    return (
-      <Switch>
-        <Route
-          render={routeProps => (
+  const flags = useFlags();
+
+  return (
+    <Switch>
+      <Route
+        render={routeProps =>
+          flags.cmr ? (
+            <VolumesLanding_CMR
+              isVolumesLanding
+              removeBreadCrumb
+              {...routeProps}
+            />
+          ) : (
             <VolumesLanding isVolumesLanding {...routeProps} />
-          )}
-          path={path}
-          exact
-          strict
-        />
-        <Route component={VolumeCreate} path={`${path}/create`} exact strict />
-        <Redirect to={path} />
-      </Switch>
-    );
-  }
-}
+          )
+        }
+        path={path}
+        exact
+        strict
+      />
+      <Route component={VolumeCreate} path={`${path}/create`} exact strict />
+      <Redirect to={path} />
+    </Switch>
+  );
+};
 
 export default withRouter(Volumes);

--- a/packages/manager/src/features/Volumes/VolumesActionMenu_CMR.tsx
+++ b/packages/manager/src/features/Volumes/VolumesActionMenu_CMR.tsx
@@ -33,26 +33,38 @@ const useStyles = makeStyles((theme: Theme) => ({
   }
 }));
 
-export interface Props {
-  onShowConfig: (volumeLabel: string, volumePath: string) => void;
-  onEdit: (volumeId: number, volumeLabel: string, volumeTags: string[]) => void;
-  onResize: (volumeId: number, volumeSize: number, volumeLabel: string) => void;
-  onClone: (
+export interface ActionHandlers {
+  openForConfig: (volumeLabel: string, volumePath: string) => void;
+  openForEdit: (
+    volumeId: number,
+    volumeLabel: string,
+    volumeTags: string[]
+  ) => void;
+  openForResize: (
+    volumeId: number,
+    volumeSize: number,
+    volumeLabel: string
+  ) => void;
+  openForClone: (
     volumeId: number,
     label: string,
     size: number,
     regionID: string
   ) => void;
-  attached: boolean;
-  onAttach: (volumeId: number, label: string, linodeRegion: string) => void;
-  onDetach: (
+  handleAttach: (volumeId: number, label: string, linodeRegion: string) => void;
+  handleDetach: (
     volumeId: number,
     volumeLabel: string,
     linodeLabel: string,
     poweredOff: boolean
   ) => void;
+  handleDelete: (volumeId: number, volumeLabel: string) => void;
+  [index: string]: any;
+}
+
+interface Props extends ActionHandlers {
+  attached: boolean;
   poweredOff: boolean;
-  onDelete: (volumeId: number, volumeLabel: string) => void;
   filesystemPath: string;
   label: string;
   linodeLabel: string;

--- a/packages/manager/src/features/Volumes/VolumesLanding_CMR.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding_CMR.tsx
@@ -99,7 +99,7 @@ type CombinedProps = Props &
 const volumeHeaders = [
   {
     label: 'Label',
-    dataColumn: 'Label',
+    dataColumn: 'label',
     sortable: true,
     widthPercent: 25
   },

--- a/packages/manager/src/features/Volumes/VolumesLanding_CMR.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding_CMR.tsx
@@ -139,6 +139,7 @@ const volumeHeaders = [
 export const VolumesLanding: React.FC<CombinedProps> = props => {
   const {
     volumesLoading,
+    getAllVolumes,
     mappedVolumesDataWithLinodes,
     volumesLastUpdated,
     volumesError,
@@ -174,12 +175,10 @@ export const VolumesLanding: React.FC<CombinedProps> = props => {
   });
 
   React.useEffect(() => {
-    const { getAllVolumes, volumesLastUpdated } = props;
-
     if (Date.now() - volumesLastUpdated > REFRESH_INTERVAL) {
       getAllVolumes().catch(_ => null); // Errors through Redux
     }
-  }, [props]);
+  }, [getAllVolumes, volumesLastUpdated]);
 
   const handleCloseAttachDrawer = () => {
     setAttachmentDrawer(attachmentDrawer => ({

--- a/packages/manager/src/features/Volumes/VolumesLanding_CMR.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding_CMR.tsx
@@ -253,7 +253,8 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
       removeBreadCrumb,
       fromLinodes,
       linodeRegion,
-      regionsData
+      regionsData,
+      isVolumesLanding
     } = this.props;
 
     if (volumesLoading) {
@@ -271,7 +272,7 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
     return (
       <React.Fragment>
         {readOnly && <LinodePermissionsError />}
-        <LinodeDisks />
+        {!isVolumesLanding && <LinodeDisks />}
         <Grid
           className={classes.root}
           container
@@ -304,7 +305,7 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
                 readOnly ||
                 (linodeRegion &&
                   !doesRegionSupportBlockStorage(linodeRegion, regionsData)) ||
-                data.length >= 10
+                (data.length >= 10 && !isVolumesLanding)
               }
             />
           </Grid>

--- a/packages/manager/src/features/Volumes/VolumesLanding_CMR.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding_CMR.tsx
@@ -7,21 +7,8 @@ import { connect } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
 import { bindActionCreators, Dispatch } from 'redux';
-import AddNewLink from 'src/components/AddNewLink/AddNewLink_CMR';
-import Breadcrumb from 'src/components/Breadcrumb';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles
-} from 'src/components/core/styles';
-import Typography from 'src/components/core/Typography';
-import setDocs from 'src/components/DocsSidebar/setDocs';
-import Grid from 'src/components/Grid';
 import Loading from 'src/components/LandingLoading';
-import OrderBy from 'src/components/OrderBy';
 import { PaginationProps } from 'src/components/Pagey';
-import { REFRESH_INTERVAL } from 'src/constants';
 import _withEvents, { EventsProps } from 'src/containers/events.container';
 import withRegions, {
   DefaultProps as RegionProps
@@ -35,10 +22,7 @@ import withVolumesRequests, {
 import withLinodes, {
   Props as WithLinodesProps
 } from 'src/containers/withLinodes.container';
-import { BlockStorage } from 'src/documentation';
 import { resetEventsPolling } from 'src/eventsPolling';
-import LinodeDisks from 'src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks_CMR';
-import LinodePermissionsError from 'src/features/linodes/LinodesDetail/LinodePermissionsError';
 import {
   LinodeOptions,
   openForClone,
@@ -48,44 +32,14 @@ import {
   openForResize,
   Origin as VolumeDrawerOrigin
 } from 'src/store/volumeForm';
-import { doesRegionSupportBlockStorage } from 'src/utilities/doesRegionSupportBlockStorage';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import DestructiveVolumeDialog from './DestructiveVolumeDialog';
-import ListVolumes from './ListVolumes_CMR';
 import VolumeAttachmentDrawer from './VolumeAttachmentDrawer';
 import { ExtendedVolume } from './types';
-
-type ClassNames = 'root' | 'headline' | 'addNewWrapper';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {
-      backgroundColor: theme.color.white,
-      margin: 0,
-      marginTop: 20,
-      width: '100%'
-    },
-    headline: {
-      marginTop: 8,
-      marginBottom: 8,
-      marginLeft: 15,
-      lineHeight: '1.5rem',
-      [theme.breakpoints.down('xs')]: {
-        marginBottom: 0,
-        marginTop: theme.spacing(2)
-      }
-    },
-    addNewWrapper: {
-      [theme.breakpoints.down('xs')]: {
-        width: '100%',
-        marginLeft: -(theme.spacing(1) + theme.spacing(1) / 2),
-        marginTop: -theme.spacing(1)
-      },
-      '&.MuiGrid-item': {
-        padding: 5
-      }
-    }
-  });
+import EntityTable_CMR from 'src/components/EntityTable/EntityTable_CMR';
+import LandingHeader from 'src/components/LandingHeader';
+import { ActionHandlers as VolumeHandlers } from './VolumesActionMenu_CMR';
+import VolumeTableRow from './VolumeTableRow_CMR';
 
 interface Props {
   isVolumesLanding?: boolean;
@@ -127,24 +81,6 @@ interface DispatchProps {
   openForConfig: (volumeLabel: string, volumePath: string) => void;
 }
 
-interface State {
-  attachmentDrawer: {
-    open: boolean;
-    volumeId?: number;
-    volumeLabel?: string;
-    linodeRegion?: string;
-  };
-  destructiveDialog: {
-    open: boolean;
-    mode: 'detach' | 'delete';
-    volumeLabel: string;
-    volumeId?: number;
-    linodeLabel: string;
-    poweredOff?: boolean;
-    error?: string;
-  };
-}
-
 type RouteProps = RouteComponentProps<{ linodeId: string }>;
 
 type CombinedProps = Props &
@@ -157,273 +93,142 @@ type CombinedProps = Props &
   RouteProps &
   WithSnackbarProps &
   WithMappedVolumesProps &
-  WithStyles<ClassNames> &
   RegionProps;
 
-class VolumesLanding extends React.Component<CombinedProps, State> {
-  state: State = {
-    attachmentDrawer: {
+const volumeHeaders = [
+  {
+    label: 'Label',
+    dataColumn: 'Label',
+    sortable: true,
+    widthPercent: 25
+  },
+  {
+    label: 'Region',
+    dataColumn: 'Region',
+    sortable: true,
+    widthPercent: 15
+  },
+  {
+    label: 'Size',
+    dataColumn: 'Size',
+    sortable: true,
+    widthPercent: 20
+  },
+  {
+    label: 'File System Path',
+    dataColumn: 'File System Path',
+    sortable: false,
+    widthPercent: 25
+  },
+  {
+    label: 'Attached To',
+    dataColumn: 'Attached To',
+    sortable: false,
+    widthPercent: 5
+  },
+  {
+    label: 'Action Menu',
+    visuallyHidden: true,
+    dataColumn: '',
+    sortable: false,
+    widthPercent: 5
+  }
+];
+
+export const VolumesLanding: React.FC<CombinedProps> = props => {
+  const {
+    volumesLoading,
+    mappedVolumesDataWithLinodes,
+    volumesLastUpdated,
+    volumesError,
+    openForConfig,
+    openForClone,
+    openForEdit,
+    openForResize
+  } = props;
+
+  const [attachmentDrawer, setAttachmentDrawer] = React.useState({
+    open: false,
+    volumeId: 0,
+    volumeLabel: '',
+    linodeRegion: ''
+  });
+
+  const [destructiveDialog, setDestructiveDialog] = React.useState<{
+    open: boolean;
+    mode: 'detach' | 'delete';
+    volumeId?: number;
+    volumeLabel: string;
+    linodeLabel: string;
+    error?: string;
+    poweredOff?: boolean;
+  }>({
+    open: false,
+    mode: 'detach',
+    volumeId: 0,
+    volumeLabel: '',
+    linodeLabel: '',
+    error: '',
+    poweredOff: false
+  });
+
+  const handleCloseAttachDrawer = () => {
+    setAttachmentDrawer(attachmentDrawer => ({
+      ...attachmentDrawer,
       open: false
-    },
-    destructiveDialog: {
-      open: false,
-      mode: 'detach',
-      volumeLabel: '',
-      linodeLabel: ''
-    }
+    }));
   };
 
-  mounted: boolean = false;
-
-  static docs: Linode.Doc[] = [
-    BlockStorage,
-    {
-      title: 'Boot a Linode from a Block Storage Volume',
-      src: `https://www.linode.com/docs/platform/block-storage/boot-from-block-storage-volume/`,
-      body: `This guide shows how to boot a Linode from a Block Storage Volume.`
-    }
-  ];
-
-  componentDidMount() {
-    const { getAllVolumes, volumesLastUpdated } = this.props;
-    this.mounted = true;
-    // If we haven't requested Volumes, or it's been a while, request them
-    if (Date.now() - volumesLastUpdated > REFRESH_INTERVAL) {
-      getAllVolumes().catch(_ => null); // Errors through Redux
-    }
-  }
-
-  componentWillUnmount() {
-    this.mounted = false;
-  }
-
-  handleCloseAttachDrawer = () => {
-    this.setState({ attachmentDrawer: { open: false } });
+  const handleAttach = (volumeId: number, label: string, regionID: string) => {
+    setAttachmentDrawer(attachmentDrawer => ({
+      ...attachmentDrawer,
+      open: true,
+      volumeId,
+      volumeLabel: label,
+      linodeRegion: regionID
+    }));
   };
 
-  handleAttach = (volumeId: number, label: string, regionID: string) => {
-    this.setState({
-      attachmentDrawer: {
-        open: true,
-        volumeId,
-        volumeLabel: label,
-        linodeRegion: regionID
-      }
-    });
-  };
-
-  handleDetach = (
+  const handleDetach = (
     volumeId: number,
     volumeLabel: string,
     linodeLabel: string,
     poweredOff: boolean
   ) => {
-    this.setState({
-      destructiveDialog: {
-        open: true,
-        mode: 'detach',
-        volumeId,
-        volumeLabel,
-        linodeLabel,
-        poweredOff,
-        error: undefined
-      }
-    });
+    setDestructiveDialog(destructiveDialog => ({
+      ...destructiveDialog,
+      open: true,
+      mode: 'detach',
+      volumeId,
+      volumeLabel,
+      linodeLabel,
+      poweredOff,
+      error: ''
+    }));
   };
 
-  handleDelete = (volumeId: number, volumeLabel: string) => {
-    this.setState({
-      destructiveDialog: {
-        open: true,
-        mode: 'delete',
-        volumeId,
-        volumeLabel,
-        linodeLabel: '',
-        error: undefined
-      }
-    });
+  const handleDelete = (volumeId: number, volumeLabel: string) => {
+    setDestructiveDialog(destructiveDialog => ({
+      ...destructiveDialog,
+      open: true,
+      mode: 'delete',
+      volumeId,
+      volumeLabel,
+      linodeLabel: '',
+      error: ''
+    }));
   };
 
-  render() {
-    const {
-      classes,
-      volumesLoading,
-      mappedVolumesDataWithLinodes,
-      readOnly,
-      removeBreadCrumb,
-      fromLinodes,
-      linodeRegion,
-      regionsData,
-      isVolumesLanding
-    } = this.props;
-
-    if (volumesLoading) {
-      return <Loading shouldDelay />;
-    }
-
-    // If this is the Volumes tab on a Linode, we want ONLY the Volumes attached to this Linode.
-    const data =
-      mappedVolumesDataWithLinodes && this.props.linodeId
-        ? mappedVolumesDataWithLinodes.filter(
-            vol => vol.linode_id === this.props.linodeId
-          )
-        : mappedVolumesDataWithLinodes;
-
-    return (
-      <React.Fragment>
-        {readOnly && <LinodePermissionsError />}
-        {!isVolumesLanding && <LinodeDisks />}
-        <Grid
-          className={classes.root}
-          container
-          alignItems={removeBreadCrumb ? 'center' : 'flex-end'}
-          justify="space-between"
-        >
-          <Grid item className="p0">
-            {removeBreadCrumb ? (
-              <Typography variant="h3" className={classes.headline}>
-                Volumes
-              </Typography>
-            ) : (
-              <Breadcrumb
-                labelTitle="Volumes"
-                pathname={this.props.location.pathname}
-              />
-            )}
-          </Grid>
-          <Grid item className={classes.addNewWrapper}>
-            <AddNewLink
-              label="Add a Volume..."
-              onClick={
-                fromLinodes
-                  ? this.openCreateVolumeDrawer
-                  : () => {
-                      this.props.history.push('/volumes/create');
-                    }
-              }
-              disabled={
-                readOnly ||
-                (linodeRegion &&
-                  !doesRegionSupportBlockStorage(linodeRegion, regionsData)) ||
-                (data.length >= 10 && !isVolumesLanding)
-              }
-            />
-          </Grid>
-        </Grid>
-        {this.renderData(data)}
-
-        <VolumeAttachmentDrawer
-          open={this.state.attachmentDrawer.open}
-          volumeId={this.state.attachmentDrawer.volumeId || 0}
-          volumeLabel={this.state.attachmentDrawer.volumeLabel || ''}
-          linodeRegion={this.state.attachmentDrawer.linodeRegion || ''}
-          onClose={this.handleCloseAttachDrawer}
-        />
-        <DestructiveVolumeDialog
-          open={this.state.destructiveDialog.open}
-          error={this.state.destructiveDialog.error}
-          volumeLabel={this.state.destructiveDialog.volumeLabel}
-          linodeLabel={this.state.destructiveDialog.linodeLabel}
-          poweredOff={this.state.destructiveDialog.poweredOff || false}
-          mode={this.state.destructiveDialog.mode}
-          onClose={this.closeDestructiveDialog}
-          onDetach={this.detachVolume}
-          onDelete={this.deleteVolume}
-        />
-      </React.Fragment>
-    );
-  }
-
-  goToSettings = () => {
-    const { history, linodeId } = this.props;
-    history.push(`/linodes/${linodeId}/settings`);
+  const closeDestructiveDialog = () => {
+    setDestructiveDialog(destructiveDialog => ({
+      ...destructiveDialog,
+      open: false
+    }));
   };
 
-  renderData = (volumes: ExtendedVolume[]) => {
-    const {
-      isVolumesLanding,
-      linodeConfigs,
-      linodeRegion,
-      regionsData,
-      volumesError
-    } = this.props;
-
-    let error = '';
-
-    const renderProps = {
-      isVolumesLanding: Boolean(isVolumesLanding),
-      handleAttach: this.handleAttach,
-      handleDelete: this.handleDelete,
-      handleDetach: this.handleDetach,
-      openForEdit: this.props.openForEdit,
-      openForClone: this.props.openForClone,
-      openForConfig: this.props.openForConfig,
-      openForResize: this.props.openForResize
-    };
-
-    if (
-      linodeRegion &&
-      !doesRegionSupportBlockStorage(linodeRegion, regionsData)
-    ) {
-      error = 'Volumes are not available in this region.';
-    }
-
-    if (linodeConfigs && linodeConfigs.length === 0) {
-      error = 'No configs available.';
-    }
-
-    return (
-      <OrderBy data={volumes} order={'asc'} orderBy={'label'}>
-        {({ data: orderedData, handleOrderChange, order, orderBy }) => {
-          const orderProps = {
-            data: orderedData,
-            handleOrderChange,
-            order,
-            orderBy
-          };
-
-          return (
-            <ListVolumes
-              {...orderProps}
-              renderProps={{ ...renderProps }}
-              error={error}
-              volumesError={volumesError}
-            />
-          );
-        }}
-      </OrderBy>
-    );
-  };
-
-  closeDestructiveDialog = () => {
-    this.setState({
-      destructiveDialog: {
-        ...this.state.destructiveDialog,
-        open: false
-      }
-    });
-  };
-
-  openCreateVolumeDrawer = (e: any) => {
-    const { linodeId, linodeLabel, linodeRegion } = this.props;
-    if (linodeId && linodeLabel && linodeRegion) {
-      return this.props.openForCreating('Created from Linode Details', {
-        linodeId,
-        linodeLabel,
-        linodeRegion
-      });
-    }
-
-    this.props.openForCreating('Created from Volumes Landing');
-
-    e.preventDefault();
-  };
-
-  detachVolume = () => {
-    const {
-      destructiveDialog: { volumeId }
-    } = this.state;
-    const { detachVolume } = this.props;
+  const detachVolume = () => {
+    const { volumeId } = destructiveDialog;
+    const { detachVolume } = props;
     if (!volumeId) {
       return;
     }
@@ -431,28 +236,24 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
     detachVolume({ volumeId })
       .then(_ => {
         /* @todo: show a progress bar for volume detachment */
-        this.props.enqueueSnackbar('Volume detachment started', {
+        props.enqueueSnackbar('Volume detachment started', {
           variant: 'info'
         });
-        this.closeDestructiveDialog();
+        closeDestructiveDialog();
         resetEventsPolling();
       })
       .catch(error => {
-        this.setState({
-          destructiveDialog: {
-            ...this.state.destructiveDialog,
-            error: getAPIErrorOrDefault(error, 'Unable to detach Volume.')[0]
-              .reason
-          }
-        });
+        setDestructiveDialog(destructiveDialog => ({
+          ...destructiveDialog,
+          error: getAPIErrorOrDefault(error, 'Unable to detach Volume.')[0]
+            .reason
+        }));
       });
   };
 
-  deleteVolume = () => {
-    const {
-      destructiveDialog: { volumeId }
-    } = this.state;
-    const { deleteVolume } = this.props;
+  const deleteVolume = () => {
+    const { volumeId } = destructiveDialog;
+    const { deleteVolume } = props;
 
     if (!volumeId) {
       return;
@@ -460,20 +261,78 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
 
     deleteVolume({ volumeId })
       .then(() => {
-        this.closeDestructiveDialog();
+        closeDestructiveDialog();
         resetEventsPolling();
       })
       .catch(error => {
-        this.setState({
-          destructiveDialog: {
-            ...this.state.destructiveDialog,
-            error: getAPIErrorOrDefault(error, 'Unable to delete Volume.')[0]
-              .reason
-          }
-        });
+        setDestructiveDialog(destructiveDialog => ({
+          ...destructiveDialog,
+          error: getAPIErrorOrDefault(error, 'Unable to delete Volume.')[0]
+            .reason
+        }));
       });
   };
-}
+
+  if (volumesLoading) {
+    return <Loading shouldDelay />;
+  }
+
+  const handlers: VolumeHandlers = {
+    openForConfig,
+    openForEdit,
+    openForResize,
+    openForClone,
+    handleAttach,
+    handleDetach,
+    handleDelete
+  };
+
+  const volumeRow = {
+    handlers,
+    Component: VolumeTableRow,
+    data: mappedVolumesDataWithLinodes ?? [], // [],
+    loading: volumesLoading,
+    lastUpdated: volumesLastUpdated,
+    error: volumesError.read
+  };
+
+  return (
+    <React.Fragment>
+      <LandingHeader
+        title="Volumes"
+        entity="Volume"
+        onAddNew={() => props.history.push('/volumes/create')}
+        iconType="volume"
+        docsLink="https://www.linode.com/docs/platform/block-storage/how-to-use-block-storage-with-your-linode/"
+      />
+      <EntityTable_CMR
+        entity="volume"
+        headers={volumeHeaders}
+        groupByTag={false}
+        row={volumeRow}
+        initialOrder={{ order: 'asc', orderBy: 'label' }}
+      />
+      <VolumeAttachmentDrawer
+        open={attachmentDrawer.open}
+        volumeId={attachmentDrawer.volumeId || 0}
+        volumeLabel={attachmentDrawer.volumeLabel || ''}
+        linodeRegion={attachmentDrawer.linodeRegion || ''}
+        onClose={handleCloseAttachDrawer}
+      />
+      <DestructiveVolumeDialog
+        open={destructiveDialog.open}
+        error={destructiveDialog.error}
+        volumeLabel={destructiveDialog.volumeLabel}
+        linodeLabel={destructiveDialog.linodeLabel}
+        poweredOff={destructiveDialog.poweredOff || false}
+        mode={destructiveDialog.mode}
+        onClose={closeDestructiveDialog}
+        onDetach={detachVolume}
+        onDelete={deleteVolume}
+      />
+    </React.Fragment>
+  );
+};
 
 const mapDispatchToProps = (dispatch: Dispatch) =>
   bindActionCreators(
@@ -488,10 +347,6 @@ const mapDispatchToProps = (dispatch: Dispatch) =>
   );
 
 const connected = connect(undefined, mapDispatchToProps);
-
-const documented = setDocs(VolumesLanding.docs);
-
-const styled = withStyles(styles);
 
 const addAttachedLinodeInfoToVolume = (
   volume: Volume,
@@ -531,7 +386,6 @@ const filterVolumeEvents = (event: Event): boolean => {
 
 export default compose<CombinedProps, Props>(
   connected,
-  documented,
   withVolumesRequests,
   _withEvents((ownProps: CombinedProps, eventsData) => ({
     ...ownProps,
@@ -568,6 +422,5 @@ export default compose<CombinedProps, Props>(
     }
   ),
   withRegions(),
-  withSnackbar,
-  styled
+  withSnackbar
 )(VolumesLanding);

--- a/packages/manager/src/features/Volumes/VolumesLanding_CMR.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding_CMR.tsx
@@ -105,13 +105,13 @@ const volumeHeaders = [
   },
   {
     label: 'Region',
-    dataColumn: 'Region',
+    dataColumn: 'region',
     sortable: true,
     widthPercent: 15
   },
   {
     label: 'Size',
-    dataColumn: 'Size',
+    dataColumn: 'size',
     sortable: true,
     widthPercent: 20
   },

--- a/packages/manager/src/features/Volumes/VolumesLanding_CMR.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding_CMR.tsx
@@ -9,6 +9,7 @@ import { compose } from 'recompose';
 import { bindActionCreators, Dispatch } from 'redux';
 import Loading from 'src/components/LandingLoading';
 import { PaginationProps } from 'src/components/Pagey';
+import { REFRESH_INTERVAL } from 'src/constants';
 import _withEvents, { EventsProps } from 'src/containers/events.container';
 import withRegions, {
   DefaultProps as RegionProps
@@ -171,6 +172,14 @@ export const VolumesLanding: React.FC<CombinedProps> = props => {
     error: '',
     poweredOff: false
   });
+
+  React.useEffect(() => {
+    const { getAllVolumes, volumesLastUpdated } = props;
+
+    if (Date.now() - volumesLastUpdated > REFRESH_INTERVAL) {
+      getAllVolumes().catch(_ => null); // Errors through Redux
+    }
+  }, [props]);
 
   const handleCloseAttachDrawer = () => {
     setAttachmentDrawer(attachmentDrawer => ({


### PR DESCRIPTION
## Description
~~Converted `Volumes.tsx` to a function component; tweaked logic in `VolumesLanding_CMR.tsx` to show proper conditional formatting and sections.~~

Separate the VolumesLanding view from the Linode-level list of Volumes.

- [x] VolumesLanding view

Linode-level list of Volumes (Storage tab) coming in follow-up PR.

## Type of Change
- Non breaking change ('update', 'change')