### PR TITLE
CMR: Add balance check and invoice request to PastDue.tsx

### DIFF
--- a/packages/manager/src/features/Dashboard_CMR/DashboardNotifications.tsx
+++ b/packages/manager/src/features/Dashboard_CMR/DashboardNotifications.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Grid from 'src/components/Grid';
+import useAccount from 'src/hooks/useAccount';
 
 import {
   AccountActivity,
@@ -26,9 +27,12 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 export const Notifications: React.FC<{}> = _ => {
   const classes = useStyles();
+  const { account } = useAccount();
+  const balance = account.data?.balance ?? 0;
+
   return (
     <Paper className={classes.root}>
-      <PastDue />
+      {balance > 0 && <PastDue balance={balance} />}
       <Grid container direction="row" justify="space-between">
         <Grid item className={classes.column}>
           <Grid container direction="column">

--- a/packages/manager/src/features/NotificationCenter/PastDue.tsx
+++ b/packages/manager/src/features/NotificationCenter/PastDue.tsx
@@ -7,6 +7,7 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Currency from 'src/components/Currency';
 import IconTextLink from 'src/components/IconTextLink';
+import PaymentDrawer from 'src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer';
 import { formatDate } from 'src/utilities/formatDate';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -48,10 +49,26 @@ interface Props {
 
 export const PastDue: React.FC<Props> = props => {
   const { balance } = props;
+  const classes = useStyles();
+
+  /**
+   * Payment Drawer Handlers
+   */
+  const [paymentDrawerOpen, setPaymentDrawerOpen] = React.useState(false);
+  const openPaymentDrawer = React.useCallback(
+    () => setPaymentDrawerOpen(true),
+    []
+  );
+  const closePaymentDrawer = React.useCallback(
+    () => setPaymentDrawerOpen(false),
+    []
+  );
+
+  /**
+   * Request Invoices
+   */
   const [invoiceLoading, setInvoiceLoading] = React.useState(false);
   const [mostRecentInvoice, setMostRecentInvoice] = React.useState<Invoice>();
-  const openPaymentDrawer = () => null;
-  const classes = useStyles();
 
   React.useEffect(() => {
     setInvoiceLoading(true);
@@ -74,39 +91,42 @@ export const PastDue: React.FC<Props> = props => {
     );
   }
   return (
-    <div className={classes.root}>
-      <Typography className={classes.headline}>
-        <Currency quantity={balance} /> Past Due
-      </Typography>
-      <Typography>
-        {mostRecentInvoice && (
-          <>
-            Your payment was due on{' '}
-            {formatDate(mostRecentInvoice.date, { format: 'dd-LLL-yyyy' })}
-            {`. `}
-          </>
-        )}
-        Please make a payment immediately to avoid service disruption.
-      </Typography>
-      <div className={classes.actions}>
-        <IconTextLink
-          SideIcon={CreditCard}
-          text="Make a payment"
-          title="Make a payment"
-          onClick={openPaymentDrawer}
-          className={classes.iconButton}
-        />
+    <>
+      <div className={classes.root}>
+        <Typography className={classes.headline}>
+          <Currency quantity={balance} /> Past Due
+        </Typography>
+        <Typography>
+          {mostRecentInvoice && (
+            <>
+              Your payment was due on{' '}
+              {formatDate(mostRecentInvoice.date, { format: 'dd-LLL-yyyy' })}
+              {`. `}
+            </>
+          )}
+          Please make a payment immediately to avoid service disruption.
+        </Typography>
+        <div className={classes.actions}>
+          <IconTextLink
+            SideIcon={CreditCard}
+            text="Make a payment"
+            title="Make a payment"
+            onClick={openPaymentDrawer}
+            className={classes.iconButton}
+          />
 
-        <IconTextLink
-          SideIcon={InvoiceIcon}
-          text="View most recent invoice"
-          title="View most recent invoice"
-          to={`/account/billing/invoices/${mostRecentInvoice?.id}`}
-          className={classes.iconButton}
-          disabled={!mostRecentInvoice?.id}
-        />
+          <IconTextLink
+            SideIcon={InvoiceIcon}
+            text="View most recent invoice"
+            title="View most recent invoice"
+            to={`/account/billing/invoices/${mostRecentInvoice?.id}`}
+            className={classes.iconButton}
+            disabled={!mostRecentInvoice?.id}
+          />
+        </div>
       </div>
-    </div>
+      <PaymentDrawer open={paymentDrawerOpen} onClose={closePaymentDrawer} />
+    </>
   );
 };
 

--- a/packages/manager/src/features/NotificationCenter/PastDue.tsx
+++ b/packages/manager/src/features/NotificationCenter/PastDue.tsx
@@ -1,9 +1,13 @@
+import { getInvoices, Invoice } from '@linode/api-v4/lib/account';
 import * as React from 'react';
 import CreditCard from 'src/assets/icons/credit-card.svg';
 import InvoiceIcon from 'src/assets/icons/invoice.svg';
+import CircleProgress from 'src/components/CircleProgress';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
+import Currency from 'src/components/Currency';
 import IconTextLink from 'src/components/IconTextLink';
+import { formatDate } from 'src/utilities/formatDate';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -11,7 +15,8 @@ const useStyles = makeStyles((theme: Theme) => ({
     padding: theme.spacing(3) + 1,
     border: `solid 1px ${theme.color.borderBilling}`,
     borderRadius: 8,
-    backgroundColor: theme.bg.billingHeader
+    backgroundColor: theme.bg.billingHeader,
+    height: 160
   },
   iconButton: {
     paddingLeft: 0,
@@ -37,18 +42,51 @@ const useStyles = makeStyles((theme: Theme) => ({
   }
 }));
 
-interface Props {}
+interface Props {
+  balance: number;
+}
 
-export const PastDue: React.FC<Props> = _ => {
-  const mostRecentInvoiceId = 5;
+export const PastDue: React.FC<Props> = props => {
+  const { balance } = props;
+  const [invoiceLoading, setInvoiceLoading] = React.useState(false);
+  const [mostRecentInvoice, setMostRecentInvoice] = React.useState<Invoice>();
   const openPaymentDrawer = () => null;
   const classes = useStyles();
+
+  React.useEffect(() => {
+    setInvoiceLoading(true);
+    getInvoices({}, { '+order': 'desc', '+order_by': 'date' })
+      .then(response => {
+        setMostRecentInvoice(response.data?.[0]);
+        setInvoiceLoading(false);
+      })
+      .catch(_ => setInvoiceLoading(false)); // Just leave the invoice as undefined
+  }, []);
+
+  if (invoiceLoading) {
+    return (
+      <div
+        className={classes.root}
+        style={{ display: 'flex', justifyContent: 'center' }}
+      >
+        <CircleProgress mini />
+      </div>
+    );
+  }
   return (
     <div className={classes.root}>
-      <Typography className={classes.headline}>$50.00 Past Due</Typography>
+      <Typography className={classes.headline}>
+        <Currency quantity={balance} /> Past Due
+      </Typography>
       <Typography>
-        Your payment was due on 01-July-2020. Please make a payment immediately
-        to avoid disruption.
+        {mostRecentInvoice && (
+          <>
+            Your payment was due on{' '}
+            {formatDate(mostRecentInvoice.date, { format: 'dd-LLL-yyyy' })}
+            {`. `}
+          </>
+        )}
+        Please make a payment immediately to avoid service disruption.
       </Typography>
       <div className={classes.actions}>
         <IconTextLink
@@ -63,9 +101,9 @@ export const PastDue: React.FC<Props> = _ => {
           SideIcon={InvoiceIcon}
           text="View most recent invoice"
           title="View most recent invoice"
-          to={`/account/billing/invoices/${mostRecentInvoiceId}`}
+          to={`/account/billing/invoices/${mostRecentInvoice?.id}`}
           className={classes.iconButton}
-          disabled={!mostRecentInvoiceId}
+          disabled={!mostRecentInvoice?.id}
         />
       </div>
     </div>

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -1,6 +1,7 @@
 import { rest } from 'msw';
 
 import {
+  accountFactory,
   domainFactory,
   imageFactory,
   firewallFactory,
@@ -136,6 +137,10 @@ export const handlers = [
   rest.get('*invoices/:invoiceId/items', (req, res, ctx) => {
     const items = invoiceItemFactory.buildList(10);
     return res(ctx.json(makeResourcePage(items, { page: 1, pages: 4 })));
+  }),
+  rest.get('*/account', (req, res, ctx) => {
+    const account = accountFactory.build({ balance: 50 });
+    return res(ctx.json(account));
   }),
   rest.get('*/account/transfer', (req, res, ctx) => {
     const transfer = accountTransferFactory.build();


### PR DESCRIPTION
## Description

Going to add live data to the Dashboard notifications section in chunks. This is the Balance banner. You'll have to fake a positive balance to see it (the mocks are set up to give you a balance of $50 if you use them).

## Note 

On my Macbook display (none of my other monitors) the focus ends up jumping down to halfway down the view. Is this happening for anyone else? Any ideas why?