### PR TITLE
Adjust grid sizes to prevent EntityHeader elements from wrapping

### DIFF
--- a/packages/manager/src/components/EntityHeader/EntityHeader.tsx
+++ b/packages/manager/src/components/EntityHeader/EntityHeader.tsx
@@ -59,7 +59,7 @@ export const EntityHeader: React.FC<HeaderProps> = props => {
         [classes.rootHasBreadcrumb]: Boolean(parentLink)
       })}
     >
-      <Grid item xs={Boolean(actions) ? 6 : 12}>
+      <Grid item xs={Boolean(actions) ? 7 : 12}>
         <Grid container direction="row" alignItems="center">
           <HeaderBreadCrumb
             iconType={iconType}
@@ -81,7 +81,7 @@ export const EntityHeader: React.FC<HeaderProps> = props => {
         </Grid>
       </Grid>
       {Boolean(actions) && (
-        <Grid container item xs={6} justify="flex-end" alignItems="center">
+        <Grid container item xs={5} justify="flex-end" alignItems="center">
           {actions}
         </Grid>
       )}


### PR DESCRIPTION
I hate grids

![Screen Shot 2020-07-23 at 9 53 18 AM](https://user-images.githubusercontent.com/1624067/88294555-677e1e00-ccca-11ea-8d28-56aa85dcb5c5.png)
