### PR TITLE
fix brasilia time to GMT-3

### DIFF
--- a/packages/manager/src/assets/timezones/timezones.ts
+++ b/packages/manager/src/assets/timezones/timezones.ts
@@ -708,7 +708,7 @@ export default [
   {
     label: 'Brasilia Time',
     name: 'America/Sao_Paulo',
-    offset: -2
+    offset: -3
   },
   {
     label: 'Fernando de Noronha Standard Time',


### PR DESCRIPTION
## Description

This is a simple fix pointed by a user.

Although i have a larger concern about the fact that we use a constant table in assets while this is mostly built in luxon (and was in moment) which is why this bug was not fixed by the update of these libraries.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')
