### PR TITLE
Hide search tips for large accounts

### DIFF
--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -180,6 +180,11 @@ export const SearchBar: React.FC<CombinedProps> = props => {
   };
 
   const guidanceText = () => {
+    if (_isLargeAccount) {
+      // This fancy stuff won't work if we're using API
+      // based search; don't confuse users by displaying this.
+      return undefined;
+    }
     return (
       <>
         <b>By field:</b> “tag:my-app” “label:my-linode” &nbsp;&nbsp;

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar_CMR.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar_CMR.tsx
@@ -181,6 +181,11 @@ export const SearchBar: React.FC<CombinedProps> = props => {
   };
 
   const guidanceText = () => {
+    if (_isLargeAccount) {
+      // This fancy stuff won't work if we're using API
+      // based search; don't confuse users by displaying this.
+      return undefined;
+    }
     return (
       <>
         <b>By field:</b> “tag:my-app” “label:my-linode” &nbsp;&nbsp;


### PR DESCRIPTION
## Description

Suggestion from @WilkinsKa1 to hide the search helper text (with tips on advanced search techniques) for large accounts, since the fancy-pants is:linode stuff won't work with API search.

## Note to Reviewers

A large account (test #1 for instance) should not display the helper text in the search bar, normal accounts still should. Please check both CMR and non-CMR.