### PR TITLE
M3-4308: Community Updates in Dashboard Notifications

### DIFF
--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -178,6 +178,7 @@ export type EventAction =
   | 'backups_enable'
   | 'backups_restore'
   | 'community_like'
+  | 'community_mention'
   | 'community_question_reply'
   | 'credit_card_updated'
   | 'disk_create'

--- a/packages/api-v4/src/profile/profile.ts
+++ b/packages/api-v4/src/profile/profile.ts
@@ -9,7 +9,7 @@ import Request, {
 } from '../request';
 import { ResourcePage } from '../types';
 import { updateProfileSchema } from './profile.schema';
-import { Profile, TrustedDevice, UserPreferences } from './types';
+import { Profile, TrustedDevice, UserPreferences, ProfileLogin } from './types';
 
 /**
  * getProfile
@@ -115,5 +115,14 @@ export const updateUserPreferences = (payload: UserPreferences) => {
     setURL(`${API_ROOT}/profile/preferences`),
     setData(payload),
     setMethod('PUT')
+  ).then(response => response.data);
+};
+
+export const getLogins = (params: any, filter: any) => {
+  return Request<ProfileLogin>(
+    setURL(`${API_ROOT}/profile/logins`),
+    setMethod('GET'),
+    setXFilter(filter),
+    setParams(params)
   ).then(response => response.data);
 };

--- a/packages/api-v4/src/profile/profile.ts
+++ b/packages/api-v4/src/profile/profile.ts
@@ -119,7 +119,7 @@ export const updateUserPreferences = (payload: UserPreferences) => {
 };
 
 export const getLogins = (params: any, filter: any) => {
-  return Request<ProfileLogin>(
+  return Request<ResourcePage<ProfileLogin>>(
     setURL(`${API_ROOT}/profile/logins`),
     setMethod('GET'),
     setXFilter(filter),

--- a/packages/api-v4/src/profile/types.ts
+++ b/packages/api-v4/src/profile/types.ts
@@ -62,3 +62,11 @@ export interface Secret {
 }
 
 export type UserPreferences = Record<string, any>;
+
+export interface ProfileLogin {
+  id: number;
+  datetime: string;
+  ip: string;
+  username: string;
+  restricted: boolean;
+}

--- a/packages/manager/src/factories/events.ts
+++ b/packages/manager/src/factories/events.ts
@@ -1,5 +1,6 @@
 import * as Factory from 'factory.ts';
 import { Entity, Event } from '@linode/api-v4/lib/account/types';
+import { DateTime } from 'luxon';
 
 export const entityFactory = Factory.Sync.makeFactory<Entity>({
   id: Factory.each(id => id),
@@ -10,7 +11,7 @@ export const entityFactory = Factory.Sync.makeFactory<Entity>({
 
 export const eventFactory = Factory.Sync.makeFactory<Event>({
   id: Factory.each(id => id),
-  created: new Date().toDateString(),
+  created: DateTime.local().toISO(),
   entity: null,
   secondary_entity: null,
   status: 'started',

--- a/packages/manager/src/features/Dashboard_CMR/DashboardNotifications.tsx
+++ b/packages/manager/src/features/Dashboard_CMR/DashboardNotifications.tsx
@@ -47,7 +47,7 @@ export const Notifications: React.FC<{}> = _ => {
   React.useEffect(() => {
     getLogins({}, { '+order_by': 'datetime', '+order': 'desc' })
       .then(response => {
-        const mostRecentLogin = response[0]?.datetime;
+        const mostRecentLogin = response.data[0]?.datetime;
 
         getEvents(
           {},

--- a/packages/manager/src/features/Dashboard_CMR/DashboardNotifications.tsx
+++ b/packages/manager/src/features/Dashboard_CMR/DashboardNotifications.tsx
@@ -3,6 +3,9 @@ import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Grid from 'src/components/Grid';
 import useAccount from 'src/hooks/useAccount';
+import { getLogins } from '@linode/api-v4/lib/profile';
+import { getEvents, Event } from '@linode/api-v4/lib/account';
+import CircleProgress from 'src/components/CircleProgress';
 
 import {
   AccountActivity,
@@ -30,7 +33,71 @@ export const Notifications: React.FC<{}> = _ => {
   const { account } = useAccount();
   const balance = account.data?.balance ?? 0;
 
-  return (
+  /**
+   * 1. Figure out most recent login for this user
+   * 2. Request events since that time
+   * 3. Pass the ones we want to the Community component below
+   * (community_like, community_question_reply)
+   */
+
+  const [events, setEvents] = React.useState<Event[]>([]);
+  const [error, setError] = React.useState<string | null>(null);
+  const [loading, setLoading] = React.useState<boolean>(true);
+
+  React.useEffect(() => {
+    getLogins({}, { '+order_by': 'datetime', '+order': 'desc' })
+      .then(response => {
+        const mostRecentLogin = response[0]?.datetime; // maybe 2nd to last, experiment and see.
+
+        getEvents(
+          // may have to use getAll method
+          {},
+          {
+            created: {
+              '+gt': mostRecentLogin
+            }
+          }
+        ).then(response => {
+          // setEvents(response.data); // temporarily commented out here and set below for development purposes
+          setEvents([
+            {
+              id: 99724720,
+              created: '2020-07-23T21:42:02',
+              seen: false,
+              read: false,
+              percent_complete: null,
+              time_remaining: null,
+              rate: null,
+              duration: null,
+              action: 'community_like',
+              username: 'jskobos',
+              entity: {
+                id: 17566,
+                type: 'community_like',
+                label:
+                  '1 user liked your answer to: How do I deploy an image to an existing Linode?',
+                url: 'https://linode.com/community/questions/17566#answer-67728'
+              },
+              status: 'notification',
+              secondary_entity: null
+            }
+          ]);
+
+          setLoading(false);
+        });
+      })
+      .catch(error => {
+        setError(error[0].reason);
+      });
+  }, []);
+
+  const communityEvents = events.filter(event =>
+    ['community_like', 'community_question_reply'].includes(event.action)
+  );
+
+  return loading ? (
+    <CircleProgress />
+  ) : (
     <Paper className={classes.root}>
       {balance > 0 && <PastDue balance={balance} />}
       <Grid container direction="row" justify="space-between">
@@ -53,7 +120,7 @@ export const Notifications: React.FC<{}> = _ => {
         <Grid item className={classes.column}>
           <Grid container direction="column">
             <Grid item>
-              <Community />
+              <Community communityEvents={communityEvents} />
             </Grid>
             <Grid item>
               <AccountActivity />

--- a/packages/manager/src/features/Dashboard_CMR/DashboardNotifications.tsx
+++ b/packages/manager/src/features/Dashboard_CMR/DashboardNotifications.tsx
@@ -6,6 +6,7 @@ import useAccount from 'src/hooks/useAccount';
 import { getLogins } from '@linode/api-v4/lib/profile';
 import { getEvents, Event } from '@linode/api-v4/lib/account';
 import CircleProgress from 'src/components/CircleProgress';
+import ErrorState from 'src/components/ErrorState';
 
 import {
   AccountActivity,
@@ -33,70 +34,56 @@ export const Notifications: React.FC<{}> = _ => {
   const { account } = useAccount();
   const balance = account.data?.balance ?? 0;
 
-  /**
-   * 1. Figure out most recent login for this user
-   * 2. Request events since that time
-   * 3. Pass the ones we want to the Community component below
-   * (community_like, community_question_reply)
-   */
-
   const [events, setEvents] = React.useState<Event[]>([]);
   const [error, setError] = React.useState<string | null>(null);
   const [loading, setLoading] = React.useState<boolean>(true);
 
+  /**
+   * 1. Figure out most recent login for this user
+   * 2. Request events since that time
+   * 3. Pass the ones we want to the Community component below
+   */
+
   React.useEffect(() => {
     getLogins({}, { '+order_by': 'datetime', '+order': 'desc' })
       .then(response => {
-        const mostRecentLogin = response[0]?.datetime; // maybe 2nd to last, experiment and see.
+        const mostRecentLogin = response[0]?.datetime;
 
         getEvents(
-          // may have to use getAll method
           {},
           {
             created: {
               '+gt': mostRecentLogin
             }
           }
-        ).then(response => {
-          // setEvents(response.data); // temporarily commented out here and set below for development purposes
-          setEvents([
-            {
-              id: 99724720,
-              created: '2020-07-23T21:42:02',
-              seen: false,
-              read: false,
-              percent_complete: null,
-              time_remaining: null,
-              rate: null,
-              duration: null,
-              action: 'community_like',
-              username: 'jskobos',
-              entity: {
-                id: 17566,
-                type: 'community_like',
-                label:
-                  '1 user liked your answer to: How do I deploy an image to an existing Linode?',
-                url: 'https://linode.com/community/questions/17566#answer-67728'
-              },
-              status: 'notification',
-              secondary_entity: null
-            }
-          ]);
-
-          setLoading(false);
-        });
+        )
+          .then(response => {
+            setEvents(response.data);
+            setLoading(false);
+          })
+          .catch(error => {
+            setError(error[0].reason);
+            setLoading(false);
+          });
       })
       .catch(error => {
         setError(error[0].reason);
+        setLoading(false);
       });
-  }, []);
+  }, [error]);
 
   const communityEvents = events.filter(event =>
-    ['community_like', 'community_question_reply'].includes(event.action)
+    [
+      'community_like',
+      'community_question_reply',
+      'community_mention'
+    ].includes(event.action)
   );
 
   return loading ? (
     <CircleProgress />
+  ) : error ? (
+    <ErrorState errorText={error} />
   ) : (
     <Paper className={classes.root}>
       {balance > 0 && <PastDue balance={balance} />}

--- a/packages/manager/src/features/Dashboard_CMR/DashboardNotifications.tsx
+++ b/packages/manager/src/features/Dashboard_CMR/DashboardNotifications.tsx
@@ -35,7 +35,7 @@ export const Notifications: React.FC<{}> = _ => {
   const balance = account.data?.balance ?? 0;
 
   const [events, setEvents] = React.useState<Event[]>([]);
-  const [error, setError] = React.useState<string | null>(null);
+  const [eventsError, setEventsError] = React.useState<string | null>(null);
   const [loading, setLoading] = React.useState<boolean>(true);
 
   /**
@@ -62,15 +62,15 @@ export const Notifications: React.FC<{}> = _ => {
             setLoading(false);
           })
           .catch(error => {
-            setError(error[0].reason);
+            setEventsError(error[0].reason);
             setLoading(false);
           });
       })
       .catch(error => {
-        setError(error[0].reason);
+        setEventsError(error[0].reason);
         setLoading(false);
       });
-  }, [error]);
+  });
 
   const communityEvents = events.filter(event =>
     [
@@ -82,8 +82,8 @@ export const Notifications: React.FC<{}> = _ => {
 
   return loading ? (
     <CircleProgress />
-  ) : error ? (
-    <ErrorState errorText={error} />
+  ) : eventsError ? (
+    <ErrorState errorText={eventsError} />
   ) : (
     <Paper className={classes.root}>
       {balance > 0 && <PastDue balance={balance} />}

--- a/packages/manager/src/features/NotificationCenter/Community.tsx
+++ b/packages/manager/src/features/NotificationCenter/Community.tsx
@@ -3,60 +3,21 @@ import { Link } from 'react-router-dom';
 import CommunityIcon from 'src/assets/community.svg';
 import Typography from 'src/components/core/Typography';
 import NotificationSection, { NotificationItem } from './NotificationSection';
+import { Event } from '@linode/api-v4/lib/account';
 
-export const Community: React.FC<{}> = _ => {
-  const communityUpdates: NotificationItem[] = [
-    {
-      id: 'community-12345',
-      body: (
-        <Typography>
-          <Link to="/">mlogan</Link> replied to{' '}
-          <Link to="/">&quot;NGINX as Node.js front end?&quot;</Link>
-        </Typography>
-      ),
-      timeStamp: '2020-07-20T19:03:37'
-    },
-    {
-      id: 'community-12346',
-      body: (
-        <Typography>
-          <Link to="/">mlogan</Link> replied to{' '}
-          <Link to="/">&quot;PostgreSQL performance tuning&quot;</Link>
-        </Typography>
-      ),
-      timeStamp: '2020-07-20T19:03:37'
-    },
-    {
-      id: 'community-18347',
-      body: (
-        <Typography>
-          <Link to="/">dsweeney</Link> replied to{' '}
-          <Link to="/">&quot;Lost my ssh key...help!&quot;</Link>
-        </Typography>
-      ),
-      timeStamp: '2020-07-20T16:03:37'
-    },
-    {
-      id: 'community-12347',
-      body: (
-        <Typography>
-          <Link to="/">mcintosh</Link> replied to{' '}
-          <Link to="/">&quot;N+1 query problem&quot;</Link>
-        </Typography>
-      ),
-      timeStamp: '2020-07-20T14:03:37'
-    },
-    {
-      id: 'community-12445',
-      body: (
-        <Typography>
-          <Link to="/">jschaeffer</Link> replied to{' '}
-          <Link to="/">&quot;Golang is a useless vanity project&quot;</Link>
-        </Typography>
-      ),
-      timeStamp: '2020-07-20T12:03:37'
-    }
-  ];
+interface Props {
+  communityEvents: Event[];
+}
+
+type CombinedProps = Props;
+
+export const Community: React.FC<CombinedProps> = props => {
+  const { communityEvents } = props;
+
+  const communityUpdates: NotificationItem[] = communityEvents.map(
+    communityEvent => eventToNotificationItem(communityEvent)
+  );
+
   return (
     <NotificationSection
       content={communityUpdates}
@@ -64,6 +25,41 @@ export const Community: React.FC<{}> = _ => {
       icon={<CommunityIcon />}
     />
   );
+};
+
+const eventToNotificationItem = (event: Event) => {
+  const eventLabel = event.entity?.label;
+  const postTitle = eventLabel?.split(':', 2)[1];
+
+  if (event.action === 'community_question_reply') {
+    return {
+      id: event.entity?.id.toString(),
+      body: (
+        <Typography>
+          <Link to="/">{event.username}</Link> replied to{' '}
+          <Link to="/">{postTitle}</Link>
+        </Typography>
+      ),
+      timeStamp: event.created
+    };
+  } else if (event.action === 'community_like') {
+    return {
+      id: event.entity?.id.toString(),
+      body: (
+        <Typography>
+          <Link to="/">{event.username}</Link> liked{' '}
+          <Link to="/">{postTitle}</Link>
+        </Typography>
+      ),
+      timeStamp: event.created
+    };
+  } else {
+    return {
+      id: '',
+      body: '',
+      timeStamp: ''
+    };
+  }
 };
 
 export default React.memo(Community);

--- a/packages/manager/src/features/NotificationCenter/Community.tsx
+++ b/packages/manager/src/features/NotificationCenter/Community.tsx
@@ -48,7 +48,7 @@ const eventsToNotificationItems = (events: Event[]): NotificationItem[] => {
                 <Link to={`${userHref}${event.username}`}>
                   {event.username}
                 </Link>{' '}
-                replied to <Link to="/">{eventLabel}</Link>
+                replied to <Link to={`${entity.url}`}>{eventLabel}</Link>
               </Typography>
             ),
             timeStamp: event.created
@@ -69,13 +69,13 @@ const eventsToNotificationItems = (events: Event[]): NotificationItem[] => {
           };
 
         case 'community_like':
-          const [preamble, postTitle] = eventLabel.split(':');
+          const [likeSummary, postTitle] = eventLabel.split(':');
 
           return {
             id: `community-update-${entity.id}`,
             body: (
               <Typography>
-                {preamble}: <Link to={`${entity.url}`}>{postTitle}</Link>
+                {likeSummary}: <Link to={`${entity.url}`}>{postTitle}</Link>
               </Typography>
             ),
             timeStamp: event.created

--- a/packages/manager/src/features/NotificationCenter/Community.tsx
+++ b/packages/manager/src/features/NotificationCenter/Community.tsx
@@ -39,10 +39,12 @@ const eventsToNotificationItems = (events: Event[]): NotificationItem[] => {
       }
       const eventLabel = entity.label;
 
+      const id = `community-update-${entity.id}`;
+
       switch (event.action) {
         case 'community_question_reply':
           return {
-            id: `community-update-${entity.id}`,
+            id,
             body: (
               <Typography>
                 <Link to={`${userHref}${event.username}`}>
@@ -56,7 +58,7 @@ const eventsToNotificationItems = (events: Event[]): NotificationItem[] => {
 
         case 'community_mention':
           return {
-            id: `community-update-${entity.id ?? 0}`,
+            id,
             body: (
               <Typography>
                 <Link to={`${userHref}${event.username}`}>
@@ -72,7 +74,7 @@ const eventsToNotificationItems = (events: Event[]): NotificationItem[] => {
           const [likeSummary, postTitle] = eventLabel.split(':');
 
           return {
-            id: `community-update-${entity.id}`,
+            id,
             body: (
               <Typography>
                 {likeSummary}: <Link to={`${entity.url}`}>{postTitle}</Link>

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -19,7 +19,8 @@ import {
   nodeBalancerFactory,
   profileFactory,
   volumeFactory,
-  accountTransferFactory
+  accountTransferFactory,
+  eventFactory
 } from 'src/factories';
 
 import cachedRegions from 'src/cachedData/regions.json';
@@ -149,5 +150,56 @@ export const handlers = [
   rest.get('*/account/transfer', (req, res, ctx) => {
     const transfer = accountTransferFactory.build();
     return res(ctx.json(transfer));
+  }),
+  rest.get('*/events', (req, res, ctx) => {
+    const events = eventFactory.buildList(10);
+    const communityLike = eventFactory.build({
+      seen: false,
+      read: false,
+      action: 'community_like',
+      username: 'demo-user',
+      entity: {
+        id: 17566,
+        type: 'community_like',
+        label:
+          '1 user liked your answer to: How do I deploy an image to an existing Linode?',
+        url: 'https://linode.com/community/questions/1#answer-1'
+      },
+      status: 'notification'
+    });
+    const communityReply = eventFactory.build({
+      seen: false,
+      read: false,
+      percent_complete: null,
+      action: 'community_question_reply',
+      username: 'demo-user-2',
+      entity: {
+        id: 17567,
+        type: 'community_reply',
+        label: 'How do I deploy an image to an existing Linode?',
+        url: 'https://linode.com/community/questions/2#answer-1'
+      },
+      status: 'notification'
+    });
+    const communityMention = eventFactory.build({
+      seen: true,
+      read: false,
+      action: 'community_mention',
+      username: 'prod-test-001',
+      entity: {
+        id: 17568,
+        type: 'community_question',
+        label: 'How do I deploy an image to an existing Linode?',
+        url: 'https://linode.com/community/questions/17566#answer-73511'
+      },
+      status: 'notification'
+    });
+    const _events = [
+      ...events,
+      communityLike,
+      communityReply,
+      communityMention
+    ];
+    return res(ctx.json(makeResourcePage(_events)));
   })
 ];


### PR DESCRIPTION
## Description
Request events since user last logged in and extract out the `community_like`'s, `community_question_reply`'s, and `community_mention`'s to add to the "Community Updates" section.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers
I added some mock data which you can use for testing by enabling the mock service worker in your .env file.