### PR TITLE
Adjust Firewalls flag logic

### DIFF
--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -33,7 +33,8 @@ export type AccountCapability =
   | 'NodeBalancers'
   | 'Block Storage'
   | 'Object Storage'
-  | 'Kubernetes';
+  | 'Kubernetes'
+  | 'Cloud Firewall';
 
 export interface AccountSettings {
   managed: boolean;

--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -35,6 +35,8 @@ import withGlobalErrors, {
 import withPreferences, {
   Props as PreferencesProps
 } from 'src/containers/preferences.container';
+import { isFeatureEnabled } from 'src/utilities/accountCapabilities';
+import useAccountManagement from 'src/hooks/useAccountManagement';
 
 import Logo from 'src/assets/logo/logo-text.svg';
 import { FlagSet } from './featureFlags';
@@ -157,6 +159,14 @@ const Firewalls = React.lazy(() => import('src/features/Firewalls'));
 const MainContent: React.FC<CombinedProps> = props => {
   const classes = useStyles();
   const flags = useFlags();
+
+  const { account } = useAccountManagement();
+
+  const showFirewalls = isFeatureEnabled(
+    'Cloud Firewall',
+    Boolean(flags.firewalls),
+    account.data?.capabilities ?? []
+  );
 
   const [menuIsOpen, toggleMenu] = React.useState<boolean>(false);
 
@@ -318,7 +328,7 @@ const MainContent: React.FC<CombinedProps> = props => {
                           component={SupportSearchLanding}
                         />
                         <Route path="/events" component={EventsLanding} />
-                        {flags.firewalls && (
+                        {showFirewalls && (
                           <Route path="/firewalls" component={Firewalls} />
                         )}
                         <Redirect exact from="/" to="/dashboard" />

--- a/packages/manager/src/MainContent_CMR.tsx
+++ b/packages/manager/src/MainContent_CMR.tsx
@@ -19,6 +19,7 @@ import Footer from 'src/features/Footer';
 import ToastNotifications from 'src/features/ToastNotifications';
 import TopMenu from 'src/features/TopMenu/TopMenu_CMR';
 import VolumeDrawer from 'src/features/Volumes/VolumeDrawer';
+import useAccountManagement from 'src/hooks/useAccountManagement';
 
 import Grid from 'src/components/Grid';
 import NotFound from 'src/components/NotFound';
@@ -32,6 +33,7 @@ import withGlobalErrors, {
 import withFeatureFlags, {
   FeatureFlagConsumerProps
 } from 'src/containers/withFeatureFlagConsumer.container.ts';
+import { isFeatureEnabled } from 'src/utilities/accountCapabilities';
 
 import Logo from 'src/assets/logo/logo-text.svg';
 
@@ -159,6 +161,13 @@ const MainContent: React.FC<CombinedProps> = props => {
   const classes = useStyles();
 
   const [, toggleMenu] = React.useState<boolean>(false);
+  const { account } = useAccountManagement();
+
+  const showFirewalls = isFeatureEnabled(
+    'Cloud Firewall',
+    Boolean(props.flags.firewalls),
+    account.data?.capabilities ?? []
+  );
 
   /**
    * this is the case where the user has successfully completed signup
@@ -272,7 +281,7 @@ const MainContent: React.FC<CombinedProps> = props => {
                     component={SupportSearchLanding}
                   />
                   <Route path="/events" component={EventsLanding} />
-                  {props.flags.firewalls && (
+                  {showFirewalls && (
                     <Route path="/firewalls" component={Firewalls} />
                   )}
                   <Redirect exact from="/" to="/dashboard" />

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -33,6 +33,7 @@ import SpacingToggle from './SpacingToggle';
 import ThemeToggle from './ThemeToggle';
 import { linkIsActive } from './utils';
 import useDomains from 'src/hooks/useDomains';
+import { isFeatureEnabled } from 'src/utilities/accountCapabilities';
 
 type NavEntity =
   | 'Linodes'
@@ -87,6 +88,12 @@ export const PrimaryNav: React.FC<Props> = props => {
     account
   } = useAccountManagement();
 
+  const showFirewalls = isFeatureEnabled(
+    'Cloud Firewall',
+    Boolean(flags.firewalls),
+    account?.data?.capabilities ?? []
+  );
+
   const primaryLinks: PrimaryLink[] = React.useMemo(
     () => [
       {
@@ -125,7 +132,7 @@ export const PrimaryNav: React.FC<Props> = props => {
       },
 
       {
-        hide: !flags.firewalls,
+        hide: !showFirewalls,
         display: 'Firewalls',
         href: '/firewalls',
         icon: <Firewall />
@@ -174,7 +181,7 @@ export const PrimaryNav: React.FC<Props> = props => {
       }
     ],
     [
-      flags.firewalls,
+      showFirewalls,
       _isManagedAccount,
       account.lastUpdated,
       _hasAccountAccess,

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.tsx
@@ -39,6 +39,7 @@ import useAccountManagement from 'src/hooks/useAccountManagement';
 import useDomains from 'src/hooks/useDomains';
 import useFlags from 'src/hooks/useFlags';
 import usePrefetch from 'src/hooks/usePreFetch';
+import { isFeatureEnabled } from 'src/utilities/accountCapabilities';
 import usePrimaryNavStyles from './PrimaryNav_CMR.styles';
 import SpacingToggle from './SpacingToggle';
 import ThemeToggle from './ThemeToggle';
@@ -110,6 +111,12 @@ export const PrimaryNav: React.FC<PrimaryNavProps> = props => {
     account
   } = useAccountManagement();
 
+  const showFirewalls = isFeatureEnabled(
+    'Cloud Firewall',
+    Boolean(flags.firewalls),
+    account?.data?.capabilities ?? []
+  );
+
   const primaryLinkGroups: {
     group: NavGroup;
     links: PrimaryLink[];
@@ -171,7 +178,7 @@ export const PrimaryNav: React.FC<PrimaryNavProps> = props => {
             display: 'Firewalls',
             href: '/firewalls',
             icon: <Firewall />,
-            hide: !flags.firewalls
+            hide: !showFirewalls
           }
         ]
       },
@@ -223,7 +230,7 @@ export const PrimaryNav: React.FC<PrimaryNavProps> = props => {
       }
     ],
     [
-      flags.firewalls,
+      showFirewalls,
       _isManagedAccount,
       account.lastUpdated,
       _hasAccountAccess,


### PR DESCRIPTION
Use existing isFeatureEnabled logic so that Firewalls will be
displayed if *either* the feature flag in LD is on *or*
a user's account.capabilities array includes Cloud Firewall.

This allows us to support a public beta, which is generally managed
by adding customer tags rather than through LD. In addition, while
we display the section if the LD flag is active, the API is working on 
the customer tag, so that the section is unusable for someone if
we only turn on the LD flag for them.

## Note

The update to account.capabilities is available in dev. To test, use dev services, turn the LD flag off. Please test all permutations:

In dev, Firewalls should always work, with or without the LD flag. (account.capabilities is true there for all users)
Against prod services, Firewalls should ONLY work with the LD flag. 

...and then, with and without CMR.


