### PR TITLE
Don't pass is_public when creating or editing a StackScript

### DIFF
--- a/packages/manager/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
@@ -311,7 +311,6 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
       label,
       images,
       description,
-      is_public: false,
       rev_note: revisionNote
     };
   };


### PR DESCRIPTION
## Description

We were explicitly passing `is_public: false` when creating a StackScript (which is not necessary as it defaults to false), and when I combined create and edit forms a few months back (part of the save progress work) this started being passed when editing a script, as well. This is never necessary, and passing `is_public: false` to a script that's already public results in an error, since you can't un-publish a StackScript. I removed this part of the payload.

Please make sure that creating and editing scripts works correctly, with both public and private scripts.