### PR TITLE
M3-4381: Fix OAuth Table bug

### DIFF
--- a/packages/api-v4/src/profile/types.ts
+++ b/packages/api-v4/src/profile/types.ts
@@ -35,7 +35,7 @@ export interface Token {
   label: string;
   created: string;
   token?: string;
-  expiry: string;
+  expiry: string | null;
   website?: string;
   thumbnail_url?: null | string;
 }

--- a/packages/manager/src/features/Profile/APITokens/APITokenDrawer.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokenDrawer.tsx
@@ -117,7 +117,7 @@ interface RadioButton extends HTMLInputElement {
 interface Props {
   label?: string;
   scopes?: string;
-  expiry?: string;
+  expiry?: string | null;
   submitting?: boolean;
   perms: string[];
   permNameMap: Record<string, string>;

--- a/packages/manager/src/features/Profile/APITokens/APITokenTable.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokenTable.tsx
@@ -176,7 +176,7 @@ export class APITokenTable extends React.Component<CombinedProps, State> {
         id: token.id,
         values: {
           scopes: token.scopes,
-          expiry: token.expiry,
+          expiry: token.expiry ?? '',
           label: token.label
         }
       }
@@ -192,7 +192,7 @@ export class APITokenTable extends React.Component<CombinedProps, State> {
         id: token.id,
         values: {
           scopes: token.scopes,
-          expiry: token.expiry,
+          expiry: token.expiry ?? '',
           label: token.label
         }
       }
@@ -496,7 +496,7 @@ export class APITokenTable extends React.Component<CombinedProps, State> {
              The expiry time of apps that don't expire until revoked come back as 'null'.
              In this case, we display an expiry time of "never" as well.
              */
-            isWayInTheFuture(token.expiry) || token.expiry === null ? (
+            token.expiry === null || isWayInTheFuture(token.expiry) ? (
               'never'
             ) : (
               <DateTimeDisplay value={token.expiry} humanizeCutoff="month" />


### PR DESCRIPTION
## Description

This fixes a bug where the `/profile/tokens` page crashes when you have an OAuth token with an expiry of `null`.

Our types (and the API documentation) wrongly assumed that “expiry” was always a string, so TypeScript hadn’t caught this.

If you want to test this for real, you’ll need to create a private OAuth client (authorization flow) and grab a token (it's pretty easy, just follow: https://developers.linode.com/api/v4/#o-auth)

Or, you can mock an expiry of `null` using your favorite method.