### PR TITLE
M3-4292 Add "Group by tag" toggle to Linode Table

### DIFF
--- a/packages/manager/src/components/Table/Table.stories.tsx
+++ b/packages/manager/src/components/Table/Table.stories.tsx
@@ -42,7 +42,12 @@ class StoryTable extends React.Component {
                 order={order}
                 orderBy={orderBy}
                 handleOrderChange={handleOrderChange}
+                toggleLinodeView={() => 'grid'}
+                linodesAreGrouped={false}
+                toggleGroupLinodes={() => true}
+                linodeViewPreference={'list'}
               />
+
               <TableBody>
                 {orderedData.map(linode => (
                   <LinodeRow_CMR

--- a/packages/manager/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
@@ -82,6 +82,8 @@ interface Props {
   component: any;
   data: ExtendedLinode[];
   someLinodesHaveMaintenance: boolean;
+  toggleLinodeView: () => 'grid' | 'list';
+  toggleGroupLinodes: () => boolean;
 }
 
 type CombinedProps = Props & OrderByProps & WithStyles<ClassNames>;
@@ -95,6 +97,8 @@ const DisplayGroupedLinodes: React.FC<CombinedProps> = props => {
     orderBy,
     handleOrderChange,
     classes,
+    toggleLinodeView,
+    toggleGroupLinodes,
     ...rest
   } = props;
 
@@ -205,7 +209,13 @@ const DisplayGroupedLinodes: React.FC<CombinedProps> = props => {
       // eslint-disable-next-line
       <React.Fragment>
         {flags.cmr ? (
-          <TableWrapper_CMR {...tableWrapperProps}>
+          <TableWrapper_CMR
+            {...tableWrapperProps}
+            linodeViewPreference="list"
+            linodesAreGrouped={true}
+            toggleLinodeView={toggleLinodeView}
+            toggleGroupLinodes={toggleGroupLinodes}
+          >
             {orderedGroupedLinodes.map(([tag, linodes]) => {
               return (
                 <React.Fragment key={tag}>

--- a/packages/manager/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
@@ -26,6 +26,9 @@ import { ExtendedLinode } from '../LinodesDetail/types';
 import useFlags from 'src/hooks/useFlags';
 import TableWrapper from './TableWrapper';
 import TableWrapper_CMR from './TableWrapper_CMR';
+import IconButton from 'src/components/core/IconButton';
+import GroupByTag from 'src/assets/icons/group-by-tag.svg';
+import TableView from 'src/assets/icons/table-view.svg';
 
 type ClassNames =
   | 'root'
@@ -34,7 +37,9 @@ type ClassNames =
   | 'tagHeader'
   | 'tagHeaderOuter'
   | 'paginationCell'
-  | 'groupContainer';
+  | 'groupContainer'
+  | 'controlHeader'
+  | 'toggleButton';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -67,6 +72,19 @@ const styles = (theme: Theme) =>
       '& div:first-child': {
         marginTop: 0
       }
+    },
+    controlHeader: {
+      backgroundColor: theme.bg.controlHeader,
+      marginBottom: 28,
+      display: 'flex',
+      justifyContent: 'flex-end'
+    },
+    toggleButton: {
+      padding: 10,
+      '&:focus': {
+        // Browser default until we get styling direction for focus states
+        outline: '1px dotted #999'
+      }
     }
   });
 
@@ -84,6 +102,8 @@ interface Props {
   someLinodesHaveMaintenance: boolean;
   toggleLinodeView: () => 'grid' | 'list';
   toggleGroupLinodes: () => boolean;
+  linodeViewPreference: 'grid' | 'list';
+  linodesAreGrouped: boolean;
 }
 
 type CombinedProps = Props & OrderByProps & WithStyles<ClassNames>;
@@ -99,6 +119,8 @@ const DisplayGroupedLinodes: React.FC<CombinedProps> = props => {
     classes,
     toggleLinodeView,
     toggleGroupLinodes,
+    linodeViewPreference,
+    linodesAreGrouped,
     ...rest
   } = props;
 
@@ -127,6 +149,39 @@ const DisplayGroupedLinodes: React.FC<CombinedProps> = props => {
     return (
       // eslint-disable-next-line
       <>
+        <Grid item xs={12} className={'px0'}>
+          <div className={classes.controlHeader}>
+            <div id="displayViewDescription" className="visually-hidden">
+              Currently in {linodeViewPreference} view
+            </div>
+            <IconButton
+              aria-label="Toggle display"
+              aria-describedby={'displayViewDescription'}
+              title={`Toggle display`}
+              onClick={toggleLinodeView}
+              disableRipple
+              className={classes.toggleButton}
+            >
+              <TableView />
+            </IconButton>
+
+            <div id="groupByDescription" className="visually-hidden">
+              {linodesAreGrouped
+                ? 'group by tag is currently enabled'
+                : 'group by tag is currently disabled'}
+            </div>
+            <IconButton
+              aria-label={`Toggle group by tag`}
+              aria-describedby={'groupByDescription'}
+              title={`Toggle group by tag`}
+              onClick={toggleGroupLinodes}
+              disableRipple
+              className={classes.toggleButton}
+            >
+              <GroupByTag />
+            </IconButton>
+          </div>
+        </Grid>
         {orderedGroupedLinodes.map(([tag, linodes]) => {
           return (
             <div

--- a/packages/manager/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
@@ -147,7 +147,6 @@ const DisplayGroupedLinodes: React.FC<CombinedProps> = props => {
 
   if (display === 'grid') {
     return (
-      // eslint-disable-next-line
       <>
         <Grid item xs={12} className={'px0'}>
           <div className={classes.controlHeader}>

--- a/packages/manager/src/features/linodes/LinodesLanding/DisplayLinodes.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/DisplayLinodes.tsx
@@ -25,6 +25,8 @@ interface Props {
   component: any;
   data: ExtendedLinode[];
   someLinodesHaveMaintenance: boolean;
+  toggleLinodeView: () => 'grid' | 'list';
+  toggleGroupLinodes: () => boolean;
 }
 
 type CombinedProps = Props & OrderByProps;
@@ -37,6 +39,8 @@ const DisplayLinodes: React.FC<CombinedProps> = props => {
     order,
     orderBy,
     handleOrderChange,
+    toggleLinodeView,
+    toggleGroupLinodes,
     ...rest
   } = props;
 
@@ -89,7 +93,13 @@ const DisplayLinodes: React.FC<CombinedProps> = props => {
           <React.Fragment>
             {display === 'list' &&
               (flags.cmr ? (
-                <TableWrapper_CMR {...tableWrapperProps}>
+                <TableWrapper_CMR
+                  {...tableWrapperProps}
+                  linodeViewPreference="list"
+                  linodesAreGrouped={false}
+                  toggleLinodeView={toggleLinodeView}
+                  toggleGroupLinodes={toggleGroupLinodes}
+                >
                   <TableBody>
                     <Component showHead {...componentProps} />
                   </TableBody>

--- a/packages/manager/src/features/linodes/LinodesLanding/DisplayLinodes.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/DisplayLinodes.tsx
@@ -1,6 +1,7 @@
 import { Config } from '@linode/api-v4/lib/linodes';
 import * as React from 'react';
 import TableBody from 'src/components/core/TableBody';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Grid from 'src/components/Grid';
 import { OrderByProps } from 'src/components/OrderBy';
 import Paginate from 'src/components/Paginate';
@@ -13,6 +14,26 @@ import { useInfinitePageSize } from 'src/hooks/useInfinitePageSize';
 import { ExtendedLinode } from '../LinodesDetail/types';
 import TableWrapper from './TableWrapper';
 import TableWrapper_CMR from './TableWrapper_CMR';
+import IconButton from 'src/components/core/IconButton';
+import GroupByTag from 'src/assets/icons/group-by-tag.svg';
+import TableView from 'src/assets/icons/table-view.svg';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  controlHeader: {
+    backgroundColor: theme.bg.controlHeader,
+    marginBottom: 28,
+    display: 'flex',
+    justifyContent: 'flex-end'
+  },
+  toggleButton: {
+    padding: 10,
+    '&:focus': {
+      // Browser default until we get styling direction for focus states
+      outline: '1px dotted #999'
+    }
+  }
+}));
+
 interface Props {
   openDialog: (type: DialogType, linodeID: number, linodeLabel: string) => void;
   openPowerActionDialog: (
@@ -27,11 +48,14 @@ interface Props {
   someLinodesHaveMaintenance: boolean;
   toggleLinodeView: () => 'grid' | 'list';
   toggleGroupLinodes: () => boolean;
+  linodeViewPreference: 'grid' | 'list';
+  linodesAreGrouped: boolean;
 }
 
 type CombinedProps = Props & OrderByProps;
 
 const DisplayLinodes: React.FC<CombinedProps> = props => {
+  const classes = useStyles();
   const {
     data,
     display,
@@ -41,6 +65,8 @@ const DisplayLinodes: React.FC<CombinedProps> = props => {
     handleOrderChange,
     toggleLinodeView,
     toggleGroupLinodes,
+    linodeViewPreference,
+    linodesAreGrouped,
     ...rest
   } = props;
 
@@ -95,8 +121,8 @@ const DisplayLinodes: React.FC<CombinedProps> = props => {
               (flags.cmr ? (
                 <TableWrapper_CMR
                   {...tableWrapperProps}
-                  linodeViewPreference="list"
-                  linodesAreGrouped={false}
+                  linodeViewPreference={linodeViewPreference}
+                  linodesAreGrouped={linodesAreGrouped}
                   toggleLinodeView={toggleLinodeView}
                   toggleGroupLinodes={toggleGroupLinodes}
                 >
@@ -111,7 +137,47 @@ const DisplayLinodes: React.FC<CombinedProps> = props => {
                   </TableBody>
                 </TableWrapper>
               ))}
-            {display === 'grid' && <Component showHead {...componentProps} />}
+            {display === 'grid' && (
+              <>
+                <Grid item xs={12} className={'px0'}>
+                  <div className={classes.controlHeader}>
+                    <div
+                      id="displayViewDescription"
+                      className="visually-hidden"
+                    >
+                      Currently in {linodeViewPreference} view
+                    </div>
+                    <IconButton
+                      aria-label="Toggle display"
+                      aria-describedby={'displayViewDescription'}
+                      title={`Toggle display`}
+                      onClick={toggleLinodeView}
+                      disableRipple
+                      className={classes.toggleButton}
+                    >
+                      <TableView />
+                    </IconButton>
+
+                    <div id="groupByDescription" className="visually-hidden">
+                      {linodesAreGrouped
+                        ? 'group by tag is currently enabled'
+                        : 'group by tag is currently disabled'}
+                    </div>
+                    <IconButton
+                      aria-label={`Toggle group by tag`}
+                      aria-describedby={'groupByDescription'}
+                      title={`Toggle group by tag`}
+                      onClick={toggleGroupLinodes}
+                      disableRipple
+                      className={classes.toggleButton}
+                    >
+                      <GroupByTag />
+                    </IconButton>
+                  </div>
+                </Grid>
+                <Component showHead {...componentProps} />
+              </>
+            )}
             <Grid item xs={12}>
               {
                 <PaginationFooter

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.styles.ts
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.styles.ts
@@ -16,8 +16,6 @@ type ClassNames =
   | 'chipRunning'
   | 'chipPending'
   | 'chipOffline'
-  | 'controlHeader'
-  | 'toggleButton'
   | 'clearFilters';
 
 const styles = (theme: Theme) =>
@@ -64,19 +62,6 @@ const styles = (theme: Theme) =>
     chipOffline: {
       '&:before': {
         backgroundColor: theme.color.grey10
-      }
-    },
-    controlHeader: {
-      backgroundColor: theme.bg.controlHeader,
-      marginBottom: 28,
-      display: 'flex',
-      justifyContent: 'flex-end'
-    },
-    toggleButton: {
-      padding: 10,
-      '&:focus': {
-        // Browser default until we get styling direction for focus states
-        outline: '1px dotted #999'
       }
     },
     clearFilters: {

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -1,7 +1,6 @@
 import { Config, LinodeStatus } from '@linode/api-v4/lib/linodes/types';
 import { APIError } from '@linode/api-v4/lib/types';
 import Close from '@material-ui/icons/Close';
-import IconButton from '@material-ui/core/IconButton';
 import * as classNames from 'classnames';
 import { DateTime } from 'luxon';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
@@ -13,8 +12,6 @@ import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
 import { AnyAction } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
-import GroupByTag from 'src/assets/icons/group-by-tag.svg';
-import TableView from 'src/assets/icons/table-view.svg';
 import AddNewLink from 'src/components/AddNewLink';
 import Breadcrumb from 'src/components/Breadcrumb';
 import CircleProgress from 'src/components/CircleProgress';
@@ -433,51 +430,6 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
                                   }
                                 />
                               </Grid>
-                              <Hidden xsDown>
-                                {params.view === 'grid' && (
-                                  <Grid item xs={12} className={'px0'}>
-                                    <div className={classes.controlHeader}>
-                                      <div
-                                        id="displayViewDescription"
-                                        className="visually-hidden"
-                                      >
-                                        Currently in {linodeViewPreference} view
-                                      </div>
-                                      <IconButton
-                                        aria-label="Toggle display"
-                                        aria-describedby={
-                                          'displayViewDescription'
-                                        }
-                                        title={`Toggle display`}
-                                        onClick={toggleLinodeView}
-                                        disableRipple
-                                        className={classes.toggleButton}
-                                      >
-                                        <TableView />
-                                      </IconButton>
-
-                                      <div
-                                        id="groupByDescription"
-                                        className="visually-hidden"
-                                      >
-                                        {linodesAreGrouped
-                                          ? 'group by tag is currently enabled'
-                                          : 'group by tag is currently disabled'}
-                                      </div>
-                                      <IconButton
-                                        aria-label={`Toggle group by tag`}
-                                        aria-describedby={'groupByDescription'}
-                                        title={`Toggle group by tag`}
-                                        onClick={toggleGroupLinodes}
-                                        disableRipple
-                                        className={classes.toggleButton}
-                                      >
-                                        <GroupByTag />
-                                      </IconButton>
-                                    </div>
-                                  </Grid>
-                                )}
-                              </Hidden>
                             </React.Fragment>
                           ) : (
                             <Grid
@@ -578,6 +530,8 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
                                     display={linodeViewPreference}
                                     toggleLinodeView={toggleLinodeView}
                                     toggleGroupLinodes={toggleGroupLinodes}
+                                    linodesAreGrouped={true}
+                                    linodeViewPreference={linodeViewPreference}
                                     component={
                                       linodeViewPreference === 'grid'
                                         ? CardView
@@ -590,6 +544,8 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
                                     display={linodeViewPreference}
                                     toggleLinodeView={toggleLinodeView}
                                     toggleGroupLinodes={toggleGroupLinodes}
+                                    linodesAreGrouped={false}
+                                    linodeViewPreference={linodeViewPreference}
                                     component={
                                       linodeViewPreference === 'grid'
                                         ? CardView

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -576,6 +576,8 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
                                   <DisplayGroupedLinodes
                                     {...finalProps}
                                     display={linodeViewPreference}
+                                    toggleLinodeView={toggleLinodeView}
+                                    toggleGroupLinodes={toggleGroupLinodes}
                                     component={
                                       linodeViewPreference === 'grid'
                                         ? CardView
@@ -586,6 +588,8 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
                                   <DisplayLinodes
                                     {...finalProps}
                                     display={linodeViewPreference}
+                                    toggleLinodeView={toggleLinodeView}
+                                    toggleGroupLinodes={toggleGroupLinodes}
                                     component={
                                       linodeViewPreference === 'grid'
                                         ? CardView

--- a/packages/manager/src/features/linodes/LinodesLanding/SortableTableHead_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/SortableTableHead_CMR.tsx
@@ -5,11 +5,47 @@ import TableCell from 'src/components/TableCell/TableCell_CMR';
 import TableRow from 'src/components/TableRow/TableRow_CMR';
 import TableSortCell from 'src/components/TableSortCell/TableSortCell_CMR';
 import Hidden from 'src/components/core/Hidden';
+import IconButton from 'src/components/core/IconButton';
+import GroupByTag from 'src/assets/icons/group-by-tag.svg';
+import TableView from 'src/assets/icons/table-view.svg';
+import { makeStyles, Theme } from 'src/components/core/styles';
 
-type CombinedProps = Omit<OrderByProps, 'data'>;
+const useStyles = makeStyles((theme: Theme) => ({
+  controlHeader: {
+    backgroundColor: theme.bg.controlHeader,
+    display: 'flex',
+    justifyContent: 'flex-end'
+  },
+  toggleButton: {
+    padding: '0 10px',
+    '&:focus': {
+      // Browser default until we get styling direction for focus states
+      outline: '1px dotted #999'
+    }
+  }
+}));
+
+interface Props {
+  toggleLinodeView: () => 'list' | 'grid';
+  linodeViewPreference: 'list' | 'grid';
+  toggleGroupLinodes: () => boolean;
+  linodesAreGrouped: boolean;
+}
+
+type CombinedProps = Props & Omit<OrderByProps, 'data'>;
 
 const SortableTableHead: React.FC<CombinedProps> = props => {
-  const { handleOrderChange, order, orderBy } = props;
+  const classes = useStyles();
+
+  const {
+    handleOrderChange,
+    order,
+    orderBy,
+    toggleLinodeView,
+    linodeViewPreference,
+    toggleGroupLinodes,
+    linodesAreGrouped
+  } = props;
 
   const isActive = (label: string) =>
     label.toLowerCase() === orderBy.toLowerCase();
@@ -66,7 +102,39 @@ const SortableTableHead: React.FC<CombinedProps> = props => {
         <Hidden mdDown>
           <TableCell>Tags</TableCell>
         </Hidden>
-        <TableCell />
+        <TableCell>
+          <div className={classes.controlHeader}>
+            <div id="displayViewDescription" className="visually-hidden">
+              Currently in {linodeViewPreference} view
+            </div>
+            <IconButton
+              aria-label="Toggle display"
+              aria-describedby={'displayViewDescription'}
+              title={`Toggle display`}
+              onClick={toggleLinodeView}
+              disableRipple
+              className={classes.toggleButton}
+            >
+              <TableView />
+            </IconButton>
+
+            <div id="groupByDescription" className="visually-hidden">
+              {linodesAreGrouped
+                ? 'group by tag is currently enabled'
+                : 'group by tag is currently disabled'}
+            </div>
+            <IconButton
+              aria-label={`Toggle group by tag`}
+              aria-describedby={'groupByDescription'}
+              title={`Toggle group by tag`}
+              onClick={toggleGroupLinodes}
+              disableRipple
+              className={classes.toggleButton}
+            >
+              <GroupByTag />
+            </IconButton>
+          </div>
+        </TableCell>
       </TableRow>
     </TableHead>
   );

--- a/packages/manager/src/features/linodes/LinodesLanding/TableWrapper_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/TableWrapper_CMR.tsx
@@ -14,6 +14,10 @@ const useStyles = makeStyles(() => ({
 
 interface Props {
   dataLength: number;
+  toggleLinodeView: () => 'list' | 'grid';
+  linodeViewPreference: 'list' | 'grid';
+  toggleGroupLinodes: () => boolean;
+  linodesAreGrouped: boolean;
 }
 
 type CombinedProps = Omit<OrderByProps, 'data'> & Props;
@@ -21,7 +25,16 @@ type CombinedProps = Omit<OrderByProps, 'data'> & Props;
 const TableWrapper: React.FC<CombinedProps> = props => {
   const classes = useStyles();
 
-  const { dataLength, order, orderBy, handleOrderChange } = props;
+  const {
+    dataLength,
+    order,
+    orderBy,
+    handleOrderChange,
+    toggleLinodeView,
+    linodeViewPreference,
+    toggleGroupLinodes,
+    linodesAreGrouped
+  } = props;
 
   return (
     <Paper className={classes.paperWrapper}>
@@ -36,6 +49,10 @@ const TableWrapper: React.FC<CombinedProps> = props => {
               order={order}
               orderBy={orderBy}
               handleOrderChange={handleOrderChange}
+              toggleGroupLinodes={toggleGroupLinodes}
+              linodeViewPreference={linodeViewPreference}
+              toggleLinodeView={toggleLinodeView}
+              linodesAreGrouped={linodesAreGrouped}
             />
             {props.children}
           </Table>


### PR DESCRIPTION
## Description

Adding group by tag toggle and list/grid view toggle to the Linode table header for CMR.

<img width="1287" alt="Screen Shot 2020-07-30 at 12 12 39 PM" src="https://user-images.githubusercontent.com/2565527/88947095-0cb26c80-d25e-11ea-90fa-bc6256b9eb7c.png">

## Type of Change
- Non breaking change ('update'
