### PR TITLE
M3-4310 CMR: Notification context

### DIFF
--- a/packages/manager/src/MainContent_CMR.tsx
+++ b/packages/manager/src/MainContent_CMR.tsx
@@ -16,6 +16,10 @@ import RegionStatusBanner from 'src/components/RegionStatusBanner';
 import BackupDrawer from 'src/features/Backups';
 import DomainDrawer from 'src/features/Domains/DomainDrawer';
 import Footer from 'src/features/Footer';
+import {
+  notificationContext,
+  useNotificationContext
+} from 'src/features/NotificationCenter/NotificationContext';
 import ToastNotifications from 'src/features/ToastNotifications';
 import TopMenu from 'src/features/TopMenu/TopMenu_CMR';
 import VolumeDrawer from 'src/features/Volumes/VolumeDrawer';
@@ -160,6 +164,9 @@ const Firewalls = React.lazy(() => import('src/features/Firewalls'));
 const MainContent: React.FC<CombinedProps> = props => {
   const classes = useStyles();
 
+  const NotificationProvider = notificationContext.Provider;
+  const contextValue = useNotificationContext();
+
   const [, toggleMenu] = React.useState<boolean>(false);
   const { account } = useAccountManagement();
 
@@ -234,64 +241,66 @@ const MainContent: React.FC<CombinedProps> = props => {
         toggleTheme={props.toggleTheme}
         toggleSpacing={props.toggleSpacing}
       />
-      <div className={classes.content}>
-        <TopMenu
-          isLoggedInAsCustomer={props.isLoggedInAsCustomer}
-          username={props.username}
-        />
-        <main className={classes.cmrWrapper} id="main-content" role="main">
-          <Grid container spacing={0} className={classes.grid}>
-            <Grid item className={classes.switchWrapper}>
-              <RegionStatusBanner />
-              <React.Suspense fallback={<SuspenseLoader />}>
-                <Switch>
-                  <Route path="/linodes" component={LinodesRoutes} />
-                  <Route path="/volumes" component={Volumes} />
-                  <Redirect path="/volumes*" to="/volumes" />
-                  <Route path="/nodebalancers" component={NodeBalancers} />
-                  <Route path="/domains" component={Domains} />
-                  <Route path="/managed" component={Managed} />
-                  <Route path="/longview" component={Longview} />
-                  <Route exact strict path="/images" component={Images} />
-                  <Redirect path="/images*" to="/images" />
-                  <Route path="/stackscripts" component={StackScripts} />
-                  <Route path="/object-storage" component={ObjectStorage} />
-                  <Route path="/kubernetes" component={Kubernetes} />
-                  <Route path="/account" component={Account} />
-                  <Route
-                    exact
-                    strict
-                    path="/support/tickets"
-                    component={SupportTickets}
-                  />
-                  <Route
-                    path="/support/tickets/:ticketId"
-                    component={SupportTicketDetail}
-                    exact
-                    strict
-                  />
-                  <Route path="/profile" component={Profile} />
-                  <Route exact path="/support" component={Help} />
-                  <Route path="/dashboard" component={Dashboard} />
-                  <Route path="/search" component={SearchLanding} />
-                  <Route
-                    exact
-                    strict
-                    path="/support/search/"
-                    component={SupportSearchLanding}
-                  />
-                  <Route path="/events" component={EventsLanding} />
-                  {showFirewalls && (
-                    <Route path="/firewalls" component={Firewalls} />
-                  )}
-                  <Redirect exact from="/" to="/dashboard" />
-                  <Route component={NotFound} />
-                </Switch>
-              </React.Suspense>
+      <NotificationProvider value={contextValue}>
+        <div className={classes.content}>
+          <TopMenu
+            isLoggedInAsCustomer={props.isLoggedInAsCustomer}
+            username={props.username}
+          />
+          <main className={classes.cmrWrapper} id="main-content" role="main">
+            <Grid container spacing={0} className={classes.grid}>
+              <Grid item className={classes.switchWrapper}>
+                <RegionStatusBanner />
+                <React.Suspense fallback={<SuspenseLoader />}>
+                  <Switch>
+                    <Route path="/linodes" component={LinodesRoutes} />
+                    <Route path="/volumes" component={Volumes} />
+                    <Redirect path="/volumes*" to="/volumes" />
+                    <Route path="/nodebalancers" component={NodeBalancers} />
+                    <Route path="/domains" component={Domains} />
+                    <Route path="/managed" component={Managed} />
+                    <Route path="/longview" component={Longview} />
+                    <Route exact strict path="/images" component={Images} />
+                    <Redirect path="/images*" to="/images" />
+                    <Route path="/stackscripts" component={StackScripts} />
+                    <Route path="/object-storage" component={ObjectStorage} />
+                    <Route path="/kubernetes" component={Kubernetes} />
+                    <Route path="/account" component={Account} />
+                    <Route
+                      exact
+                      strict
+                      path="/support/tickets"
+                      component={SupportTickets}
+                    />
+                    <Route
+                      path="/support/tickets/:ticketId"
+                      component={SupportTicketDetail}
+                      exact
+                      strict
+                    />
+                    <Route path="/profile" component={Profile} />
+                    <Route exact path="/support" component={Help} />
+                    <Route path="/dashboard" component={Dashboard} />
+                    <Route path="/search" component={SearchLanding} />
+                    <Route
+                      exact
+                      strict
+                      path="/support/search/"
+                      component={SupportSearchLanding}
+                    />
+                    <Route path="/events" component={EventsLanding} />
+                    {showFirewalls && (
+                      <Route path="/firewalls" component={Firewalls} />
+                    )}
+                    <Redirect exact from="/" to="/dashboard" />
+                    <Route component={NotFound} />
+                  </Switch>
+                </React.Suspense>
+              </Grid>
             </Grid>
-          </Grid>
-        </main>
-      </div>
+          </main>
+        </div>
+      </NotificationProvider>
       <Footer desktopMenuIsOpen={false} />
       <ToastNotifications />
       <DomainDrawer />

--- a/packages/manager/src/features/NotificationCenter/NotificationContext.ts
+++ b/packages/manager/src/features/NotificationCenter/NotificationContext.ts
@@ -1,0 +1,63 @@
+import { getLogins } from '@linode/api-v4/lib/profile';
+import { getEvents, Event } from '@linode/api-v4/lib/account';
+import { createContext, useCallback, useEffect, useState } from 'react';
+
+export interface NotificationContextProps {
+  events: Event[];
+  loading: boolean;
+  error?: string;
+  requestEvents: () => void;
+}
+
+const defaultContext = {
+  events: [],
+  loading: false,
+  requestEvents: () => null
+};
+
+export const notificationContext = createContext<NotificationContextProps>(
+  defaultContext
+);
+
+export const useNotificationContext = (): NotificationContextProps => {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | undefined>();
+  const [events, setEvents] = useState<Event[]>([]);
+
+  const [mostRecentLogin, setRecentLogin] = useState<string | undefined>();
+
+  const request = useCallback(() => {
+    getEvents(
+      {},
+      {
+        created: {
+          '+gt': mostRecentLogin
+        }
+      }
+    )
+      .then(response => {
+        setEvents(response.data);
+        setLoading(false);
+      })
+      .catch(error => {
+        setError(error[0].reason);
+        setLoading(false);
+      });
+  }, [mostRecentLogin]);
+
+  useEffect(() => {
+    getLogins({}, { '+order_by': 'datetime', '+order': 'desc' }).then(
+      response => {
+        setRecentLogin(response.data[0]?.datetime);
+        request();
+      }
+    );
+  }, [request]);
+
+  return {
+    events,
+    loading,
+    error,
+    requestEvents: request
+  };
+};


### PR DESCRIPTION
## Description

CMR's notifications drawer/dashboard center share the same set of events, which are different from the events we store in Redux. (in short, we show all events in certain categories since the user's last login, whereas in Redux we store the last ~100 events on a user's account regardless of login status).

Since the two are separate in the component tree, and we don't need the usual set of Redux actions, I decided to make a simple context to allow the drawer and dashboard to share data.

The only place using this data atm is the Community Events section of the Dashboard Notification center. You may have to use the mock server to have events in this category; but the behavior of that section should be unchanged from develop.