### PR TITLE
M3-4310 CMR Notifications: pending actions

### DIFF
--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -277,7 +277,7 @@ export interface Event {
   read: boolean;
   seen: boolean;
   status: EventStatus;
-  time_remaining: null | number;
+  time_remaining: null | string;
   username: string;
   secondary_entity: Entity | null;
   _initial?: boolean;

--- a/packages/manager/src/__data__/events.ts
+++ b/packages/manager/src/__data__/events.ts
@@ -4,7 +4,7 @@ import { ExtendedEvent } from 'src/store/events/event.types';
 export const events: Event[] = [
   {
     id: 18029754,
-    time_remaining: 0,
+    time_remaining: null,
     seen: true,
     created: '2018-12-03T22:37:20',
     action: 'linode_reboot',
@@ -24,7 +24,7 @@ export const events: Event[] = [
   },
   {
     id: 18029767,
-    time_remaining: 0,
+    time_remaining: null,
     secondary_entity: null,
     seen: true,
     created: '2018-12-03T22:38:16',
@@ -44,7 +44,7 @@ export const events: Event[] = [
   },
   {
     id: 18029572,
-    time_remaining: 0,
+    time_remaining: null,
     secondary_entity: null,
     seen: true,
     created: '2018-12-03T22:34:09',
@@ -64,7 +64,7 @@ export const events: Event[] = [
   },
   {
     id: 18022171,
-    time_remaining: 0,
+    time_remaining: null,
     secondary_entity: null,
     seen: true,
     created: '2018-12-03T19:59:53',
@@ -84,7 +84,7 @@ export const events: Event[] = [
   },
   {
     id: 18022021,
-    time_remaining: 0,
+    time_remaining: null,
     secondary_entity: null,
     seen: true,
     created: '2018-12-03T19:54:28',
@@ -104,7 +104,7 @@ export const events: Event[] = [
   },
   {
     id: 18021942,
-    time_remaining: 0,
+    time_remaining: null,
     secondary_entity: null,
     seen: true,
     created: '2018-12-03T19:53:26',
@@ -124,7 +124,7 @@ export const events: Event[] = [
   },
   {
     id: 17957943,
-    time_remaining: 0,
+    time_remaining: null,
     secondary_entity: null,
     seen: true,
     created: '2018-12-02T23:15:45',
@@ -144,7 +144,7 @@ export const events: Event[] = [
   },
   {
     id: 17957944,
-    time_remaining: 0,
+    time_remaining: null,
     secondary_entity: null,
     seen: true,
     created: '2018-12-02T23:15:45',
@@ -164,7 +164,7 @@ export const events: Event[] = [
   },
   {
     id: 17957718,
-    time_remaining: 0,
+    time_remaining: null,
     secondary_entity: null,
     seen: true,
     created: '2018-12-02T23:08:38',
@@ -184,7 +184,7 @@ export const events: Event[] = [
   },
   {
     id: 17957108,
-    time_remaining: 0,
+    time_remaining: null,
     secondary_entity: null,
     seen: true,
     created: '2018-12-02T22:55:43',
@@ -204,7 +204,7 @@ export const events: Event[] = [
   },
   {
     id: 17956743,
-    time_remaining: 0,
+    time_remaining: null,
     secondary_entity: null,
     seen: true,
     created: '2018-12-02T22:48:37',
@@ -224,7 +224,7 @@ export const events: Event[] = [
   },
   {
     id: 17956360,
-    time_remaining: 0,
+    time_remaining: null,
     secondary_entity: null,
     seen: true,
     created: '2018-12-02T22:38:36',
@@ -244,7 +244,7 @@ export const events: Event[] = [
   },
   {
     id: 17955994,
-    time_remaining: 0,
+    time_remaining: null,
     secondary_entity: null,
     seen: true,
     created: '2018-12-02T22:31:24',
@@ -264,7 +264,7 @@ export const events: Event[] = [
   },
   {
     id: 17955841,
-    time_remaining: 0,
+    time_remaining: null,
     secondary_entity: null,
     seen: true,
     created: '2018-12-02T22:29:02',
@@ -284,7 +284,7 @@ export const events: Event[] = [
   },
   {
     id: 17955781,
-    time_remaining: 0,
+    time_remaining: null,
     seen: true,
     created: '2018-12-02T22:25:39',
     action: 'linode_shutdown',
@@ -304,7 +304,7 @@ export const events: Event[] = [
   },
   {
     id: 17955694,
-    time_remaining: 0,
+    time_remaining: null,
     seen: true,
     created: '2018-12-02T22:23:58',
     action: 'linode_boot',
@@ -324,7 +324,7 @@ export const events: Event[] = [
   },
   {
     id: 17955636,
-    time_remaining: 0,
+    time_remaining: null,
     seen: true,
     created: '2018-12-02T22:21:51',
     action: 'linode_shutdown',
@@ -344,7 +344,7 @@ export const events: Event[] = [
   },
   {
     id: 17955613,
-    time_remaining: 0,
+    time_remaining: null,
     seen: true,
     secondary_entity: null,
     created: '2018-12-02T22:20:43',
@@ -364,7 +364,7 @@ export const events: Event[] = [
   },
   {
     id: 17955464,
-    time_remaining: 0,
+    time_remaining: null,
     seen: true,
     secondary_entity: null,
     created: '2018-12-02T22:19:10',
@@ -384,7 +384,7 @@ export const events: Event[] = [
   },
   {
     id: 17954738,
-    time_remaining: 0,
+    time_remaining: null,
     seen: true,
     secondary_entity: null,
     created: '2018-12-02T22:03:38',
@@ -404,7 +404,7 @@ export const events: Event[] = [
   },
   {
     id: 17951319,
-    time_remaining: 0,
+    time_remaining: null,
     seen: true,
     secondary_entity: null,
     created: '2018-12-02T20:45:52',
@@ -424,7 +424,7 @@ export const events: Event[] = [
   },
   {
     id: 17951106,
-    time_remaining: 0,
+    time_remaining: null,
     seen: true,
     secondary_entity: null,
     created: '2018-12-02T20:39:36',
@@ -444,7 +444,7 @@ export const events: Event[] = [
   },
   {
     id: 17950945,
-    time_remaining: 0,
+    time_remaining: null,
     seen: true,
     secondary_entity: null,
     created: '2018-12-02T20:35:54',
@@ -464,7 +464,7 @@ export const events: Event[] = [
   },
   {
     id: 17950407,
-    time_remaining: 0,
+    time_remaining: null,
     seen: true,
     secondary_entity: null,
     created: '2018-12-02T20:23:43',
@@ -484,7 +484,7 @@ export const events: Event[] = [
   },
   {
     id: 17950183,
-    time_remaining: 0,
+    time_remaining: null,
     seen: true,
     secondary_entity: null,
     created: '2018-12-02T20:21:11',
@@ -507,7 +507,7 @@ export const events: Event[] = [
 export const uniqueEvents: Event[] = [
   {
     id: 1231234,
-    time_remaining: 50,
+    time_remaining: null,
     secondary_entity: null,
     seen: true,
     created: '2018-12-02T20:23:43',
@@ -527,7 +527,7 @@ export const uniqueEvents: Event[] = [
   },
   {
     id: 17950407,
-    time_remaining: 0,
+    time_remaining: null,
     secondary_entity: null,
     seen: true,
     created: '2018-12-02T20:23:43',
@@ -551,7 +551,7 @@ export const reduxEvent: ExtendedEvent = {
   _initial: false,
   id: 123551234,
   secondary_entity: null,
-  time_remaining: 50,
+  time_remaining: null,
   seen: true,
   created: '2018-12-02T20:23:43',
   action: 'linode_boot',

--- a/packages/manager/src/eventMessageGenerator_CMR.tsx
+++ b/packages/manager/src/eventMessageGenerator_CMR.tsx
@@ -48,10 +48,18 @@ export const eventMessageGenerator = (
       );
     case 'disk_resize':
       return 'disk resize';
+    case 'disk_duplicate':
+      return 'disk duplicate';
     case 'backups_restore':
       return 'backup restore';
     case 'linode_snapshot':
       return 'snapshot backup in progress';
+    case 'linode_mutate':
+      return 'upgrade in progress';
+    case 'linode_rebuild':
+      return 'rebuild';
+    case 'linode_create':
+      return 'provisioning';
 
     default:
       // If we haven't handled it explicitly here, it doesn't count as

--- a/packages/manager/src/eventMessageGenerator_CMR.tsx
+++ b/packages/manager/src/eventMessageGenerator_CMR.tsx
@@ -1,0 +1,45 @@
+import { Event } from '@linode/api-v4/lib/account';
+import { Linode, LinodeType } from '@linode/api-v4/lib/linodes';
+import { dcDisplayNames } from 'src/constants';
+
+export const eventMessageGenerator = (
+  e: Event,
+  linodes: Linode[] = [],
+  types: LinodeType[] = []
+) => {
+  const eventLinode = linodes.find(
+    thisLinode => thisLinode.id === e.entity?.id
+  );
+  switch (e.action) {
+    case 'linode_resize':
+      const eventLinodeType = types.find(
+        thisType => thisType.id === eventLinode?.type
+      );
+      return `resize ${
+        eventLinodeType ? `to ${eventLinodeType.label} Plan` : ''
+      }`;
+    case 'linode_migrate':
+    case 'linode_migrate_datacenter':
+      return `migrate ${
+        eventLinode ? `to ${dcDisplayNames[eventLinode.region]}` : ''
+      }`;
+    case 'disk_imagize':
+      return `is being created`;
+    case 'linode_boot':
+      return `boot with ${e.secondary_entity?.label}`;
+    case 'linode_reboot':
+      return `reboot with ${e.secondary_entity?.label}`;
+    case 'linode_shutdown':
+      return 'is shutting down';
+
+    default:
+      return null;
+  }
+};
+
+export const eventLabelGenerator = (e: Event) => {
+  if (['disk_imagize'].includes(e.action)) {
+    return e.secondary_entity?.label;
+  }
+  return e.entity?.label;
+};

--- a/packages/manager/src/eventMessageGenerator_CMR.tsx
+++ b/packages/manager/src/eventMessageGenerator_CMR.tsx
@@ -46,6 +46,12 @@ export const eventMessageGenerator = (
           </Link>
         </>
       );
+    case 'disk_resize':
+      return 'disk resize';
+    case 'backups_restore':
+      return 'backup restore';
+    case 'linode_snapshot':
+      return 'snapshot backup in progress';
 
     default:
       // If we haven't handled it explicitly here, it doesn't count as

--- a/packages/manager/src/eventMessageGenerator_CMR.tsx
+++ b/packages/manager/src/eventMessageGenerator_CMR.tsx
@@ -1,5 +1,7 @@
+import * as React from 'react';
 import { Event } from '@linode/api-v4/lib/account';
 import { Linode, LinodeType } from '@linode/api-v4/lib/linodes';
+import Link from 'src/components/Link';
 import { dcDisplayNames } from 'src/constants';
 
 export const eventMessageGenerator = (
@@ -35,6 +37,15 @@ export const eventMessageGenerator = (
       return `reboot with ${e.secondary_entity?.label}`;
     case 'linode_shutdown':
       return 'is shutting down';
+    case 'linode_clone':
+      return (
+        <>
+          clone to{` `}
+          <Link to={`/linodes/${e.secondary_entity?.id}`}>
+            {e.secondary_entity?.label}
+          </Link>
+        </>
+      );
 
     default:
       // If we haven't handled it explicitly here, it doesn't count as

--- a/packages/manager/src/eventMessageGenerator_CMR.tsx
+++ b/packages/manager/src/eventMessageGenerator_CMR.tsx
@@ -24,15 +24,21 @@ export const eventMessageGenerator = (
         eventLinode ? `to ${dcDisplayNames[eventLinode.region]}` : ''
       }`;
     case 'disk_imagize':
-      return `is being created`;
+      return `creating from ${e.entity?.label}`;
     case 'linode_boot':
       return `boot with ${e.secondary_entity?.label}`;
+    case 'host_reboot':
+      return 'reboot (Host initiated restart)';
+    case 'lassie_reboot':
+      return 'reboot (Lassie watchdog service)';
     case 'linode_reboot':
       return `reboot with ${e.secondary_entity?.label}`;
     case 'linode_shutdown':
       return 'is shutting down';
 
     default:
+      // If we haven't handled it explicitly here, it doesn't count as
+      // a "Pending Action" for our purposes.
       return null;
   }
 };

--- a/packages/manager/src/factories/events.ts
+++ b/packages/manager/src/factories/events.ts
@@ -21,6 +21,6 @@ export const eventFactory = Factory.Sync.makeFactory<Event>({
   read: false,
   action: 'linode_boot',
   percent_complete: 10,
-  time_remaining: 0,
+  time_remaining: null,
   duration: 0
 });

--- a/packages/manager/src/features/Events/EventsLanding.test.ts
+++ b/packages/manager/src/features/Events/EventsLanding.test.ts
@@ -5,7 +5,7 @@ import { reducer, ReducerActions, ReducerState } from './EventsLanding';
 const someEvent: Event[] = [
   {
     id: 1234,
-    time_remaining: 50,
+    time_remaining: null,
     secondary_entity: null,
     seen: true,
     created: '2018-12-02T20:23:43',

--- a/packages/manager/src/features/NotificationCenter/NotificationSection.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationSection.tsx
@@ -103,7 +103,9 @@ const ContentRow: React.FC<{
   const classes = useStyles();
   return (
     <div className={classes.notificationItem}>
-      <div className={classes.body}>{item.body}</div>
+      <div className={item.timeStamp ? classes.body : undefined}>
+        {item.body}
+      </div>
       {item.timeStamp && (
         <Typography>
           {formatDate(item.timeStamp, { humanizeCutoff: 'week' })}

--- a/packages/manager/src/features/NotificationCenter/PendingActions.test.tsx
+++ b/packages/manager/src/features/NotificationCenter/PendingActions.test.tsx
@@ -1,0 +1,30 @@
+import { formatTimeRemaining } from './PendingActions';
+
+describe('Pending Actions', () => {
+  describe('formatTimeRemaining helper', () => {
+    it('should return null for invalid input', () => {
+      expect(formatTimeRemaining(4959348 as any)).toBe(null);
+      expect(formatTimeRemaining('')).toBe(null);
+      expect(formatTimeRemaining('1 hour')).toBe(null);
+      expect(formatTimeRemaining('08:34')).toBe(null);
+    });
+
+    it('should return a short duration as minutes remaining', () => {
+      expect(formatTimeRemaining('00:15:00')).toMatch('15 minutes remaining');
+    });
+
+    it('should round to the nearest minute', () => {
+      expect(formatTimeRemaining('00:08:28')).toMatch('8 minutes remaining');
+      expect(formatTimeRemaining('00:08:31')).toMatch('9 minutes remaining');
+    });
+
+    it('should return a long duration as hours remaining', () => {
+      expect(formatTimeRemaining('2:15:00')).toMatch('2 hours remaining');
+    });
+
+    it('should round to the nearest hour', () => {
+      expect(formatTimeRemaining('7:40:28')).toMatch('8 hours remaining');
+      expect(formatTimeRemaining('7:19:28')).toMatch('7 hours remaining');
+    });
+  });
+});

--- a/packages/manager/src/features/NotificationCenter/PendingActions.tsx
+++ b/packages/manager/src/features/NotificationCenter/PendingActions.tsx
@@ -62,15 +62,13 @@ export const PendingActions: React.FC<{}> = _ => {
               {message}
               {timeRemaining}
             </Typography>
-            {event.percent_complete ? (
-              <BarPercent
-                className={classes.bar}
-                max={100}
-                value={event.percent_complete}
-                rounded
-                narrow
-              />
-            ) : null}
+            <BarPercent
+              className={classes.bar}
+              max={100}
+              value={event.percent_complete ?? 0}
+              rounded
+              narrow
+            />
           </div>
         )
       };

--- a/packages/manager/src/features/NotificationCenter/PendingActions.tsx
+++ b/packages/manager/src/features/NotificationCenter/PendingActions.tsx
@@ -1,9 +1,13 @@
 import * as React from 'react';
-import { Link } from 'react-router-dom';
+// import { Link } from 'react-router-dom';
 import BarPercent from 'src/components/BarPercent/BarPercent_CMR';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
-import NotificationSection from './NotificationSection';
+import useEvents from 'src/hooks/useEvents';
+import { ExtendedEvent } from 'src/store/events/event.types';
+import eventMessageGenerator from 'src/eventMessageGenerator';
+// import createLinkHandlerForNotification from 'src/utilities/getEventsActionLinkStrings';
+import NotificationSection, { NotificationItem } from './NotificationSection';
 
 const useStyles = makeStyles((theme: Theme) => ({
   action: {
@@ -17,27 +21,37 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 export const PendingActions: React.FC<{}> = _ => {
   const classes = useStyles();
-  const actions = [
-    {
-      id: 'resize-1',
-      body: (
-        <div className={classes.action}>
-          <Typography>
-            Linode <Link to="/linode/instances/2">linode-1</Link>
-            {` `}
-            resize to Linode 64GB Plan (~5 minutes)
-          </Typography>
-          <BarPercent
-            className={classes.bar}
-            max={100}
-            value={75}
-            rounded
-            narrow
-          />
-        </div>
-      )
-    }
-  ];
+  const { inProgressEvents } = useEvents();
+
+  const formatEventForDisplay = React.useCallback(
+    (event: ExtendedEvent): NotificationItem => {
+      return {
+        id: `pending-action-${event.id}`,
+        body: (
+          <div className={classes.action}>
+            <Typography>
+              {eventMessageGenerator(event)}
+              {event.time_remaining
+                ? ` (~${event.time_remaining} remaining)`
+                : null}
+            </Typography>
+            {event.percent_complete ? (
+              <BarPercent
+                className={classes.bar}
+                max={100}
+                value={event.percent_complete}
+                rounded
+                narrow
+              />
+            ) : null}
+          </div>
+        )
+      };
+    },
+    [classes]
+  );
+
+  const actions = inProgressEvents.map(formatEventForDisplay);
   return (
     <NotificationSection
       content={actions}

--- a/packages/manager/src/features/NotificationCenter/PendingActions.tsx
+++ b/packages/manager/src/features/NotificationCenter/PendingActions.tsx
@@ -1,3 +1,4 @@
+import { Duration } from 'luxon';
 import * as React from 'react';
 import BarPercent from 'src/components/BarPercent/BarPercent_CMR';
 import { makeStyles, Theme } from 'src/components/core/styles';
@@ -39,7 +40,7 @@ export const PendingActions: React.FC<{}> = _ => {
         return null;
       }
       const timeRemaining = event.time_remaining
-        ? ` (~${event.time_remaining} remaining)`
+        ? ` (~${formatTimeRemaining(event.time_remaining)})`
         : null;
       const linkTarget = createLinkHandlerForNotification(
         event.action,
@@ -88,6 +89,28 @@ export const PendingActions: React.FC<{}> = _ => {
       showMoreTarget={'/events'}
     />
   );
+};
+
+export const formatTimeRemaining = (time: string) => {
+  try {
+    const [hours, minutes, seconds] = time.split(':').map(Number);
+    if (
+      [hours, minutes, seconds].some(
+        thisNumber => typeof thisNumber === 'undefined'
+      ) ||
+      [hours, minutes, seconds].some(isNaN)
+    ) {
+      // Bad input, don't display a duration
+      return null;
+    }
+    const duration = Duration.fromObject({ hours, minutes, seconds });
+    return hours > 0
+      ? `${Math.round(duration.as('hours'))} hours remaining`
+      : `${Math.round(duration.as('minutes'))} minutes remaining`;
+  } catch {
+    // Broken/unexpected input
+    return null;
+  }
 };
 
 export default React.memo(PendingActions);

--- a/packages/manager/src/hooks/useEvents.ts
+++ b/packages/manager/src/hooks/useEvents.ts
@@ -1,0 +1,21 @@
+import { useSelector } from 'react-redux';
+import { ApplicationState } from 'src/store';
+import { ExtendedEvent } from 'src/store/events/event.types';
+
+export interface UseEvents {
+  events: ExtendedEvent[];
+  inProgressEvents: ExtendedEvent[];
+}
+
+export const useEvents = () => {
+  const eventState = useSelector((state: ApplicationState) => state.events);
+  const events = eventState.events;
+  const inProgressIDs = Object.keys(eventState.inProgressEvents);
+  const inProgressEvents = events.filter(thisEvent =>
+    inProgressIDs.includes(String(thisEvent.id))
+  );
+
+  return { events, inProgressEvents };
+};
+
+export default useEvents;

--- a/packages/manager/src/store/events/event.helpers.test.ts
+++ b/packages/manager/src/store/events/event.helpers.test.ts
@@ -101,7 +101,7 @@ describe('event.helpers', () => {
       const events: Event[] = [
         {
           id: 17957944,
-          time_remaining: 0,
+          time_remaining: null,
           secondary_entity: null,
           seen: true,
           created: '2018-12-02T23:15:45',
@@ -121,7 +121,7 @@ describe('event.helpers', () => {
         },
         {
           id: 17957108,
-          time_remaining: 0,
+          time_remaining: null,
           secondary_entity: null,
           seen: true,
           created: '2018-12-02T22:55:43',
@@ -144,7 +144,7 @@ describe('event.helpers', () => {
       const expected: ExtendedEvent[] = [
         {
           id: 17957944,
-          time_remaining: 0,
+          time_remaining: null,
           secondary_entity: null,
           seen: true,
           created: '2018-12-02T23:15:45',
@@ -165,7 +165,7 @@ describe('event.helpers', () => {
         },
         {
           id: 17957108,
-          time_remaining: 0,
+          time_remaining: null,
           secondary_entity: null,
           seen: true,
           created: '2018-12-02T22:55:43',
@@ -196,7 +196,7 @@ describe('event.helpers', () => {
       const prevEvents: Event[] = [
         {
           id: 17957944,
-          time_remaining: 0,
+          time_remaining: null,
           secondary_entity: null,
           seen: true,
           created: '2018-12-02T23:15:45',
@@ -211,7 +211,7 @@ describe('event.helpers', () => {
         },
         {
           id: 17957718,
-          time_remaining: 0,
+          time_remaining: null,
           secondary_entity: null,
           seen: true,
           created: '2018-12-02T23:08:38',
@@ -226,7 +226,7 @@ describe('event.helpers', () => {
         },
         {
           id: 17957108,
-          time_remaining: 0,
+          time_remaining: null,
           secondary_entity: null,
           seen: true,
           created: '2018-12-02T22:55:43',
@@ -243,7 +243,7 @@ describe('event.helpers', () => {
       const events: Event[] = [
         {
           id: 17957718,
-          time_remaining: 0,
+          time_remaining: null,
           secondary_entity: null,
           seen: true,
           created: '2018-12-02T23:08:38',
@@ -262,7 +262,7 @@ describe('event.helpers', () => {
       expect(result).toEqual([
         {
           id: 17957944,
-          time_remaining: 0,
+          time_remaining: null,
           seen: true,
           created: '2018-12-02T23:15:45',
           action: 'linode_delete',
@@ -277,7 +277,7 @@ describe('event.helpers', () => {
         },
         {
           id: 17957718,
-          time_remaining: 0,
+          time_remaining: null,
           seen: true,
           created: '2018-12-02T23:08:38',
           action: 'linode_shutdown',
@@ -292,7 +292,7 @@ describe('event.helpers', () => {
         },
         {
           id: 17957108,
-          time_remaining: 0,
+          time_remaining: null,
           secondary_entity: null,
           seen: true,
           created: '2018-12-02T22:55:43',

--- a/packages/manager/src/store/events/event.reducer.test.ts
+++ b/packages/manager/src/store/events/event.reducer.test.ts
@@ -18,7 +18,7 @@ describe('events.reducer', () => {
         const events: Event[] = [
           {
             id: 18029572,
-            time_remaining: 0,
+            time_remaining: null,
             secondary_entity: null,
             seen: true,
             created: '2018-12-03T22:34:09',
@@ -38,7 +38,7 @@ describe('events.reducer', () => {
           },
           {
             id: 18022171,
-            time_remaining: 0,
+            time_remaining: null,
             secondary_entity: null,
             seen: false,
             created: '2018-12-03T19:59:53',

--- a/packages/manager/src/utilities/eventUtils.ts
+++ b/packages/manager/src/utilities/eventUtils.ts
@@ -1,4 +1,4 @@
-import { Event, EventAction } from '@linode/api-v4/lib/account'
+import { Event, EventAction } from '@linode/api-v4/lib/account';
 
 // Removes events we don't want to display.
 export const removeBlacklistedEvents = (

--- a/packages/manager/src/utilities/getEventsActionLinkStrings.ts
+++ b/packages/manager/src/utilities/getEventsActionLinkStrings.ts
@@ -57,16 +57,8 @@ export default (
     return;
   }
 
-  /**
-   * Images and their events are the bane of our existence.
-   * If these events ever start returning the ID of the actual
-   * Image, we can link to it. But linking to the Linode that
-   * the imagized disk was imagized from, which is what we
-   * would do by default, is too confusing. Just don't link.
-   */
-
   if (action === 'disk_imagize') {
-    return;
+    return `/images`;
   }
 
   switch (type) {


### PR DESCRIPTION
## Description

Pending Actions section of the Dashboard/Notification drawer. The designs specify a different event message format than we use currently, so I had to patch data together from a bunch of places.

The spec is a little vague (see Jira ticket); this section is intended to display long-running actions. I had to do individual handling for all such actions, and made a few judgment calls. For example: volume creation technically has progress events, but it is generally extremely fast and I didn't include it here. If you see anything I missed, or disagree with any of my assessments, please say so!