### PR TITLE
fix default zone if no user timezone

### DIFF
--- a/packages/manager/src/utilities/formatDate.ts
+++ b/packages/manager/src/utilities/formatDate.ts
@@ -49,8 +49,9 @@ export const formatDate = (
 ): string => {
   let time;
   /** get the timezone from redux and use it as the timezone */
-  const state = store.getState();
-  const userTimezone = state.__resources?.profile?.data?.timezone ?? 'utc';
+  const stateTz = store.getState().__resources?.profile?.data?.timezone;
+  const userTimezone =
+    stateTz && stateTz != '' && IANAZone.isValidZone(stateTz) ? stateTz : 'utc';
   if (
     IANAZone.isValidSpecifier(userTimezone) &&
     IANAZone.isValidZone(userTimezone)

--- a/packages/manager/src/utilities/formatDate.ts
+++ b/packages/manager/src/utilities/formatDate.ts
@@ -47,19 +47,11 @@ export const formatDate = (
   date: string | number,
   options: FormatDateOptions = {}
 ): string => {
-  let time;
   /** get the timezone from redux and use it as the timezone */
   const stateTz = store.getState().__resources?.profile?.data?.timezone;
   const userTimezone =
     stateTz && stateTz != '' && IANAZone.isValidZone(stateTz) ? stateTz : 'utc';
-  if (
-    IANAZone.isValidSpecifier(userTimezone) &&
-    IANAZone.isValidZone(userTimezone)
-  ) {
-    time = parseAPIDate(date).setZone(userTimezone);
-  } else {
-    time = parseAPIDate(date).toLocal();
-  }
+  const time = parseAPIDate(date).setZone(userTimezone);
 
   const expectedFormat = options.format || DATETIME_DISPLAY_FORMAT;
   const now = DateTime.local();

--- a/packages/manager/src/utilities/formatDate.ts
+++ b/packages/manager/src/utilities/formatDate.ts
@@ -50,8 +50,7 @@ export const formatDate = (
   let time;
   /** get the timezone from redux and use it as the timezone */
   const state = store.getState();
-  const userTimezone =
-    state.__resources?.profile?.data?.timezone ?? DateTime.local().zoneName;
+  const userTimezone = state.__resources?.profile?.data?.timezone ?? 'utc';
   if (
     IANAZone.isValidSpecifier(userTimezone) &&
     IANAZone.isValidZone(userTimezone)


### PR DESCRIPTION
## Description

Fixes unit tests
if the userTimezone is not defined or empty or incorrect we default to 'utc', date API format.

**If we want to default to the local zone as suggested done in this PR, we would have to check this is the behavior intended in a few tests and the app itself, as we would default to this but this would not set the userTimezone in the API**

## Type of Change
- Bug fix ('fix', 'repair', 'bug')
