### PR TITLE
always show tax id of customer in invoice if available

### DIFF
--- a/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
@@ -99,6 +99,9 @@ const addRightHeader = (doc: jsPDF, account: Account) => {
   }
   addLine(`${city}, ${state}, ${zip}`);
   addLine(`${country}`);
+  if (account.tax_id) {
+    addLine(`Tax ID: ${account.tax_id}`);
+  }
 
   return currentLine;
 };
@@ -187,28 +190,9 @@ export const printInvoice = (
       );
       const rightHeaderYPosition = addRightHeader(doc, account);
 
-      /** only show tax ID if there is one provided */
-      const strings = account.tax_id
-        ? [
-            {
-              text: `Invoice: #${invoiceId}`
-            },
-            {
-              /*
-          300px left margin is a hacky way of aligning the text to the right
-          because this library stinks
-         */
-              text: `Tax ID: ${account.tax_id}`,
-              leftMargin: 300
-            }
-          ]
-        : [{ text: `Invoice: #${invoiceId}` }];
-
-      addTitle(
-        doc,
-        Math.max(leftHeaderYPosition, rightHeaderYPosition) + 4,
-        ...strings
-      );
+      addTitle(doc, Math.max(leftHeaderYPosition, rightHeaderYPosition) + 4, {
+        text: `Invoice: #${invoiceId}`
+      });
 
       createInvoiceItemsTable(doc, itemsChunk);
       createFooter(doc, baseFont);

--- a/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
@@ -188,22 +188,21 @@ export const printInvoice = (
       const rightHeaderYPosition = addRightHeader(doc, account);
 
       /** only show tax ID if there is one provided */
-      const strings =
-        account.tax_id && hasTax
-          ? [
-              {
-                text: `Invoice: #${invoiceId}`
-              },
-              {
-                /*
+      const strings = account.tax_id
+        ? [
+            {
+              text: `Invoice: #${invoiceId}`
+            },
+            {
+              /*
           300px left margin is a hacky way of aligning the text to the right
           because this library stinks
          */
-                text: `Tax ID: ${account.tax_id}`,
-                leftMargin: 300
-              }
-            ]
-          : [{ text: `Invoice: #${invoiceId}` }];
+              text: `Tax ID: ${account.tax_id}`,
+              leftMargin: 300
+            }
+          ]
+        : [{ text: `Invoice: #${invoiceId}` }];
 
       addTitle(
         doc,

--- a/packages/manager/src/features/Billing/PdfGenerator/utils.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/utils.ts
@@ -63,7 +63,7 @@ export const createPaymentsTotalsTable = (doc: JSPDF, payment: Payment) => {
  */
 export const createInvoiceItemsTable = (doc: JSPDF, items: InvoiceItem[]) => {
   (doc as any).autoTable({
-    startY: 150,
+    startY: 155,
     styles: {
       lineWidth: 1
     },


### PR DESCRIPTION
## Description

currently it seems that we hide the tax id of a customer if we do not have a tax agreement with this country.
But customer are requesting that we show this, which we do in the admin tools generated invoice
*check jira ticket*

## Type of Change
- Bug fix ('fix', 'repair', 'bug')