### PR TITLE
M3-4310 CMR: Support Tickets and loading state

### DIFF
--- a/packages/api-v4/src/support/support.ts
+++ b/packages/api-v4/src/support/support.ts
@@ -31,7 +31,7 @@ export const getTickets = (params?: any, filter?: any) =>
     setMethod('GET'),
     setParams(params),
     setXFilter(filter)
-  );
+  ).then(response => response.data);
 
 /**
  * getTicket

--- a/packages/manager/src/features/Domains/DomainActionMenu_CMR.tsx
+++ b/packages/manager/src/features/Domains/DomainActionMenu_CMR.tsx
@@ -135,7 +135,7 @@ export const DomainActionMenu: React.FC<CombinedProps> = props => {
   return (
     <>
       <Hidden smDown>
-        <div className="flex-center">
+        <div className="flexCenter">
           <button className={classes.button} onClick={handleEdit}>
             Edit
           </button>

--- a/packages/manager/src/features/NotificationCenter/NotificationSection.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationSection.tsx
@@ -101,6 +101,9 @@ export const NotificationSection: React.FC<Props> = props => {
   );
 };
 
+// =============================================================================
+// Body
+// =============================================================================
 interface BodyProps {
   header: string;
   loading: boolean;
@@ -134,6 +137,9 @@ const ContentBody: React.FC<BodyProps> = React.memo(props => {
   );
 });
 
+// =============================================================================
+// Row
+// =============================================================================
 const ContentRow: React.FC<{
   item: NotificationItem;
 }> = React.memo(props => {

--- a/packages/manager/src/features/NotificationCenter/NotificationSection.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationSection.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import CircleProgress from 'src/components/CircleProgress';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import { Link } from 'src/components/Link';
@@ -19,6 +20,10 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   content: {
     width: '100%'
+  },
+  loading: {
+    display: 'flex',
+    justifyContent: 'center'
   },
   icon: {
     marginRight: theme.spacing(),
@@ -52,13 +57,24 @@ interface Props {
   showMoreTarget?: string;
   content: NotificationItem[];
   showMore?: JSX.Element;
+  loading?: boolean;
+  emptyMessage?: string;
 }
 
 export type CombinedProps = Props;
 
 export const NotificationSection: React.FC<Props> = props => {
-  const { content, header, showMore, showMoreText, showMoreTarget } = props;
+  const {
+    content,
+    header,
+    emptyMessage,
+    loading,
+    showMoreText,
+    showMoreTarget
+  } = props;
+  const _loading = Boolean(loading); // false if not provided
   const classes = useStyles();
+
   return (
     <div className={classes.root}>
       <div className={classes.content}>
@@ -74,27 +90,49 @@ export const NotificationSection: React.FC<Props> = props => {
             </Typography>
           )}
         </div>
-        {content.length > 0 ? (
-          content.map(thisItem => (
-            <ContentRow
-              key={`notification-row-${thisItem.id}`}
-              item={thisItem}
-            />
-          ))
-        ) : (
-          <Typography className={classes.notificationItem}>
-            You have no {header.toLocaleLowerCase()}.
-          </Typography>
-        )}
-        {showMore && (
-          <Typography className={classes.notificationItem}>
-            {showMore}
-          </Typography>
-        )}
+        <ContentBody
+          loading={_loading}
+          content={content}
+          header={header}
+          emptyMessage={emptyMessage}
+        />
       </div>
     </div>
   );
 };
+
+interface BodyProps {
+  header: string;
+  loading: boolean;
+  content: NotificationItem[];
+  emptyMessage?: string;
+}
+
+const ContentBody: React.FC<BodyProps> = React.memo(props => {
+  const { content, emptyMessage, header, loading } = props;
+  const classes = useStyles();
+  if (loading) {
+    return (
+      <div className={classes.loading}>
+        <CircleProgress mini />
+      </div>
+    );
+  }
+  return content.length > 0 ? (
+    // eslint-disable-next-line
+    <>
+      {content.map(thisItem => (
+        <ContentRow key={`notification-row-${thisItem.id}`} item={thisItem} />
+      ))}
+    </>
+  ) : (
+    <Typography className={classes.notificationItem}>
+      {emptyMessage
+        ? emptyMessage
+        : `You have no ${header.toLocaleLowerCase()}.`}
+    </Typography>
+  );
+});
 
 const ContentRow: React.FC<{
   item: NotificationItem;

--- a/packages/manager/src/features/NotificationCenter/OpenSupportTickets.tsx
+++ b/packages/manager/src/features/NotificationCenter/OpenSupportTickets.tsx
@@ -1,29 +1,63 @@
+import { SupportTicket } from '@linode/api-v4/lib/support';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import Typography from 'src/components/core/Typography';
+import { useAPIRequest } from 'src/hooks/useAPIRequest';
+import { getTicketsPage } from 'src/features/Support/SupportTickets/ticketUtils';
 import NotificationSection, { NotificationItem } from './NotificationSection';
 
 export const OpenSupportTickets: React.FC<{}> = _ => {
-  const openTickets: NotificationItem[] = [
-    {
-      id: 'ticket-12345',
-      body: (
-        <Typography>
-          <Link to="/support/tickets/1">Support ticket 1</Link> was updated by
-          jjones
-        </Typography>
+  /**
+   * Unlike some other sections of the notifications center,
+   * we want to show all open support tickets, not just ones
+   * that have been updated since the user's last login.
+   *
+   * Fortunately, the SupportTicket object makes this easy;
+   * we just have to request a user's open tickets here,
+   * since these are never cached in Redux.
+   */
+  const ticketsRequest = useAPIRequest(
+    () =>
+      getTicketsPage({}, {}, 'open').then(response =>
+        response.data.map(ticketToNotification)
       ),
-      timeStamp: '2020-07-20T19:03:37'
-    }
-  ];
+    []
+  );
+
+  if (ticketsRequest.error) {
+    // Open for debate. I'd like to avoid showing separate
+    // error states for all of these, as they take up screen
+    // real estate.
+    return null;
+  }
+
   return (
     <NotificationSection
-      content={openTickets}
+      content={ticketsRequest.data}
       header="Open Support Tickets"
       showMoreText="View all tickets"
       showMoreTarget="/support/tickets"
+      loading={ticketsRequest.loading}
     />
   );
+};
+
+const ticketToNotification = (ticket: SupportTicket): NotificationItem => {
+  return {
+    id: `ticket-notification-item-${ticket.id}`,
+    body: (
+      <Typography>
+        <Link to={`/support/tickets/${ticket.id}`}>
+          #{ticket.id} {ticket.summary}
+        </Link>{' '}
+        {/** updated_by is nullable, but opened_by is guaranteed to be defined */}
+        {ticket.updated_by
+          ? `was updated by ${ticket.updated_by}`
+          : `was opened by ${ticket.opened_by}`}
+      </Typography>
+    ),
+    timeStamp: ticket.updated || ticket.opened
+  };
 };
 
 export default React.memo(OpenSupportTickets);

--- a/packages/manager/src/features/NotificationCenter/OpenSupportTickets.tsx
+++ b/packages/manager/src/features/NotificationCenter/OpenSupportTickets.tsx
@@ -1,14 +1,14 @@
 import { SupportTicket } from '@linode/api-v4/lib/support';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { makeStyles, Theme } from 'src/components/core/styles';
+import { makeStyles } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import { useAPIRequest } from 'src/hooks/useAPIRequest';
 import useNotifications from 'src/hooks/useNotifications';
 import { getTicketsPage } from 'src/features/Support/SupportTickets/ticketUtils';
 import NotificationSection, { NotificationItem } from './NotificationSection';
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles(() => ({
   abuseTicket: {
     position: 'relative',
     color: '#cf1e1e',

--- a/packages/manager/src/features/NotificationCenter/OpenSupportTickets.tsx
+++ b/packages/manager/src/features/NotificationCenter/OpenSupportTickets.tsx
@@ -26,11 +26,6 @@ const useStyles = makeStyles(() => ({
       left: 0,
       top: 0
     }
-  },
-  icon: {},
-  abuseIcon: {
-    backgroundColor: '#cf1e1e',
-    color: 'white'
   }
 }));
 

--- a/packages/manager/src/features/Support/SupportTickets/TicketList.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/TicketList.tsx
@@ -220,9 +220,7 @@ export class TicketList extends React.Component<CombinedProps, {}> {
 const styled = withStyles(styles);
 
 const updatedRequest = (ownProps: Props, params: any, filters: any) => {
-  return getTicketsPage(params, filters, ownProps.filterStatus).then(
-    response => response
-  );
+  return getTicketsPage(params, filters, ownProps.filterStatus);
 };
 
 const paginated = Pagey(updatedRequest);

--- a/packages/manager/src/features/Support/SupportTickets/ticketUtils.ts
+++ b/packages/manager/src/features/Support/SupportTickets/ticketUtils.ts
@@ -41,5 +41,5 @@ export const getTicketsPage = (
   const status = getStatusFilter(ticketStatus);
   const ordering = { '+order_by': 'opened', '+order': 'desc' };
   const filter = { ...status, ...ordering, ...filters };
-  return getTickets(params, filter).then(response => response.data);
+  return getTickets(params, filter);
 };

--- a/packages/manager/src/hooks/useNotifications.ts
+++ b/packages/manager/src/hooks/useNotifications.ts
@@ -1,0 +1,12 @@
+import { useSelector } from 'react-redux';
+import { ApplicationState } from 'src/store';
+
+export const useNotifications = () => {
+  const notifications = useSelector(
+    (state: ApplicationState) => state.__resources.notifications
+  );
+
+  return notifications.data ?? [];
+};
+
+export default useNotifications;


### PR DESCRIPTION
## Description

- Add request for support tickets to OpenSupportTickets.tsx
- Add function to convert SupportTicket[] to NotificationItem[]
- Fix getTickets return (missing the then(response => response.data) we
use everywhere else)
- Refactor NotificationItem.tsx to allow a loading state. This got messy
so I extracted a ContentBody component.

Still to come: 
- [ ] Cap items at 5 and add a "show more" (separate PR)
- [x] Handling for abuse/important tickets (pending Jay's response)