### PR TITLE
M3-4302 CMR Tag Styles

### DIFF
--- a/packages/manager/src/components/Tag/Tag_CMR.tsx
+++ b/packages/manager/src/components/Tag/Tag_CMR.tsx
@@ -33,26 +33,26 @@ const styles = (theme: Theme) =>
       paddingRight: 0,
       // Overrides MUI chip default styles so these appear as separate elements.
       '&:hover': {
-        backgroundColor: theme.bg.lightBlue,
+        backgroundColor: theme.color.tagButton,
         '& $deleteButton': {
-          color: '#7daee8'
+          color: theme.color.tagIcon
         }
       },
       '&:focus': {
-        backgroundColor: theme.bg.lightBlue,
+        backgroundColor: theme.color.tagButton,
         '& $deleteButton': {
-          color: '#7daee8'
+          color: theme.color.tagIcon
         }
       },
       // Targets first span (tag label)
       '& > span': {
         padding: '7px 10px',
         fontSize: 14,
-        color: '#3a3f46',
+        color: theme.color.tagText,
         borderRadius: 3,
         borderTopRightRadius: 0,
         borderBottomRightRadius: 0,
-        borderRight: '1px solid white'
+        borderRight: `1px solid ${theme.color.tagBorder}`
       },
       '&:last-child': {
         marginRight: 8
@@ -71,7 +71,7 @@ const styles = (theme: Theme) =>
         borderRadius: 0,
         width: 15,
         height: 15,
-        color: '#7daee8'
+        color: theme.color.tagIcon
       },
       '&:hover': {
         backgroundColor: `${theme.palette.primary.main} !important`,
@@ -113,14 +113,14 @@ const styles = (theme: Theme) =>
       }
     },
     lightBlue: {
-      backgroundColor: '#f1f7fd',
+      backgroundColor: theme.color.tagButton,
       '& > span': {
         '&:hover': {
           backgroundColor: theme.palette.primary.main,
           color: 'white'
         },
         '&:focus': {
-          backgroundColor: '#f1f7fd',
+          backgroundColor: theme.color.tagButton,
           color: theme.color.black
         }
       }

--- a/packages/manager/src/components/Tag/Tag_CMR.tsx
+++ b/packages/manager/src/components/Tag/Tag_CMR.tsx
@@ -3,7 +3,6 @@ import * as classNames from 'classnames';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
-import Button from 'src/components/core/Button';
 import Chip, { ChipProps } from 'src/components/core/Chip';
 import {
   createStyles,
@@ -32,9 +31,20 @@ const styles = (theme: Theme) =>
       height: 30,
       paddingLeft: 0,
       paddingRight: 0,
+      // Overrides MUI chip default styles so these appear as separate elements.
       '&:hover': {
-        backgroundColor: theme.bg.lightBlue
+        backgroundColor: theme.bg.lightBlue,
+        '& $deleteButton': {
+          color: '#7daee8'
+        }
       },
+      '&:focus': {
+        backgroundColor: theme.bg.lightBlue,
+        '& $deleteButton': {
+          color: '#7daee8'
+        }
+      },
+      // Targets first span (tag label)
       '& > span': {
         padding: '7px 10px',
         fontSize: 14,
@@ -53,17 +63,22 @@ const styles = (theme: Theme) =>
       margin: 0,
       width: 30,
       height: 30,
+      padding: 8,
       borderRadius: 0,
       borderTopRightRadius: 3,
       borderBottomRightRadius: 3,
       '& svg': {
         borderRadius: 0,
-        width: 20,
-        height: 20
+        width: 15,
+        height: 15,
+        color: '#7daee8'
       },
       '&:hover': {
         backgroundColor: `${theme.palette.primary.main} !important`,
-        color: 'white !important'
+        color: 'white !important',
+        '& svg': {
+          color: 'white'
+        }
       },
       '&:focus': {
         backgroundColor: theme.bg.lightBlue,
@@ -98,14 +113,14 @@ const styles = (theme: Theme) =>
       }
     },
     lightBlue: {
-      backgroundColor: theme.bg.lightBlue,
+      backgroundColor: '#f1f7fd',
       '& > span': {
         '&:hover': {
           backgroundColor: theme.palette.primary.main,
           color: 'white'
         },
         '&:focus': {
-          backgroundColor: theme.bg.lightBlue,
+          backgroundColor: '#f1f7fd',
           color: theme.color.black
         }
       }
@@ -189,8 +204,10 @@ class Tag extends React.Component<CombinedProps, {}> {
             <button
               data-qa-delete-tag
               className={classes.deleteButton}
+              title="Delete tag"
               aria-label={`Delete Tag "${this.props.label}"`}
             >
+              {/* @todo CMR: update icon */}
               <Close />
             </button>
           ) : (

--- a/packages/manager/src/components/Tag/Tag_CMR.tsx
+++ b/packages/manager/src/components/Tag/Tag_CMR.tsx
@@ -29,14 +29,46 @@ const styles = (theme: Theme) =>
   createStyles({
     label: {},
     root: {
-      height: '30px',
+      height: 30,
+      paddingLeft: 0,
+      paddingRight: 0,
+      '&:hover': {
+        backgroundColor: theme.bg.lightBlue
+      },
+      '& > span': {
+        padding: '7px 10px',
+        fontSize: 14,
+        color: '#3a3f46',
+        borderRadius: 3,
+        borderTopRightRadius: 0,
+        borderBottomRightRadius: 0,
+        borderRight: '1px solid white'
+      },
       '&:last-child': {
         marginRight: 8
       }
     },
     deleteButton: {
-      minWidth: 'auto',
-      marginLeft: theme.spacing()
+      ...theme.applyLinkStyles,
+      margin: 0,
+      width: 30,
+      height: 30,
+      borderRadius: 0,
+      borderTopRightRadius: 3,
+      borderBottomRightRadius: 3,
+      '& svg': {
+        borderRadius: 0,
+        width: 20,
+        height: 20
+      },
+      '&:hover': {
+        backgroundColor: `${theme.palette.primary.main} !important`,
+        color: 'white !important'
+      },
+      '&:focus': {
+        backgroundColor: theme.bg.lightBlue,
+        color: theme.color.black
+      }
     },
     white: {
       backgroundColor: theme.color.white,
@@ -67,13 +99,15 @@ const styles = (theme: Theme) =>
     },
     lightBlue: {
       backgroundColor: theme.bg.lightBlue,
-      '&:hover': {
-        backgroundColor: theme.palette.primary.main,
-        color: 'white'
-      },
-      '&:focus': {
-        backgroundColor: theme.bg.lightBlue,
-        color: theme.color.black
+      '& > span': {
+        '&:hover': {
+          backgroundColor: theme.palette.primary.main,
+          color: 'white'
+        },
+        '&:focus': {
+          backgroundColor: theme.bg.lightBlue,
+          color: theme.color.black
+        }
       }
     },
     green: {
@@ -152,13 +186,13 @@ class Tag extends React.Component<CombinedProps, {}> {
         })}
         deleteIcon={
           chipProps.onDelete ? (
-            <Button
+            <button
               data-qa-delete-tag
               className={classes.deleteButton}
               aria-label={`Delete Tag "${this.props.label}"`}
             >
               <Close />
-            </Button>
+            </button>
           ) : (
             undefined
           )

--- a/packages/manager/src/components/TagCell/TagCell.tsx
+++ b/packages/manager/src/components/TagCell/TagCell.tsx
@@ -25,9 +25,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: theme.bg.lightBlue,
+    backgroundColor: theme.color.tagButton,
     '& svg': {
-      color: theme.palette.primary.main
+      color: theme.color.tagIcon
     },
     '&:hover': {
       backgroundColor: theme.palette.primary.main,
@@ -55,7 +55,8 @@ const useStyles = makeStyles((theme: Theme) => ({
     padding: 0,
     marginLeft: theme.spacing(),
     width: '40px',
-    backgroundColor: theme.bg.lightBlue,
+    backgroundColor: theme.color.tagButton,
+    color: theme.color.tagIcon,
     borderRadius: 0,
     '&:hover': {
       backgroundColor: theme.palette.primary.main,
@@ -81,7 +82,7 @@ const useStyles = makeStyles((theme: Theme) => ({
       marginLeft: 10,
       width: 10,
       height: 10,
-      color: '#7daee8'
+      color: theme.color.tagIcon
     }
   }
 }));

--- a/packages/manager/src/components/TagCell/TagDrawer.tsx
+++ b/packages/manager/src/components/TagCell/TagDrawer.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Drawer from 'src/components/Drawer';
 import Notice from 'src/components/Notice';
-import Tag from 'src/components/Tag';
+import Tag from 'src/components/Tag/Tag_CMR';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import AddTag from './AddTag';
 

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -284,7 +284,10 @@ const themeDefaults: ThemeDefaults = ({ spacingOverride: spacingUnit }) => {
       primaryNavText: '#fff',
       borderBilling: '#cce2ff',
       billingText: '#313335',
-      tagButton: '#f1f7fd'
+      tagButton: '#f1f7fd',
+      tagText: '#3a3f46',
+      tagIcon: '#7daee8',
+      tagBorder: '#fff'
     },
     graphs: {
       load: `rgba(255, 220, 77, ${graphTransparency})`,

--- a/packages/manager/src/themes.ts
+++ b/packages/manager/src/themes.ts
@@ -126,7 +126,10 @@ const darkThemeOptions = {
     primaryNavText: '#fff',
     borderBilling: primaryColors.light,
     billingText: '#fff',
-    tagButton: '#222'
+    tagButton: '#364863',
+    tagText: '#9caec9',
+    tagIcon: '#9caec9',
+    tagBorder: '#2e3238'
   },
   animateCircleIcon: {
     ...iconCircleAnimation


### PR DESCRIPTION
## Description

Updating CMR tag styles (please view the prototype to see how the hover state should look):

<img width="460" alt="Screen Shot 2020-08-04 at 4 17 20 PM" src="https://user-images.githubusercontent.com/2565527/89340726-2f81be00-d66e-11ea-9dfb-f7f39d1d7fc0.png">

This updates their styling in Linodes table, Linode detail header (both grid and details view), and the Tag drawer. Please let me know if I'm missing a location where these should be updated!
 

## Type of Change
- Non breaking change ('update')