### PR TITLE
CMR Notifications: Add context to Drawer

### DIFF
--- a/packages/manager/src/features/NotificationCenter/NotificationDrawer.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationDrawer.tsx
@@ -1,3 +1,4 @@
+import { Event } from '@linode/api-v4/lib/account/types';
 import * as React from 'react';
 import Clock from 'src/assets/icons/clock.svg';
 import { makeStyles, Theme } from 'src/components/core/styles';
@@ -36,6 +37,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 interface Props {
   open: boolean;
+  events: Event[];
   onClose: () => void;
 }
 

--- a/packages/manager/src/features/TopMenu/NotificationButton.tsx
+++ b/packages/manager/src/features/TopMenu/NotificationButton.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import Bell from 'src/assets/icons/bell.svg';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import { NotificationDrawer } from 'src/features/NotificationCenter';
+import { notificationContext } from 'src/features/NotificationCenter/NotificationContext';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -25,15 +26,27 @@ const useStyles = makeStyles((theme: Theme) => ({
   }
 }));
 
+const notificationEventTypes = [
+  'community_like',
+  'community_question_reply',
+  'community_mention'
+];
+// @todo add more here, or filter our events request directly once we
+// have a list of all relevant actions.
+
 export const NotificationButton: React.FC<{}> = _ => {
   const [drawerOpen, setDrawerOpen] = React.useState(false);
 
   const classes = useStyles();
 
+  const context = React.useContext(notificationContext);
+
   const openDrawer = () => setDrawerOpen(true);
   const closeDrawer = () => setDrawerOpen(false);
 
-  const numEvents = 42;
+  const numEvents = context.events.filter(thisEvent =>
+    notificationEventTypes.includes(thisEvent.action)
+  ).length;
 
   return (
     <>
@@ -45,7 +58,11 @@ export const NotificationButton: React.FC<{}> = _ => {
         <Bell aria-hidden />
         <strong className={classes.text}>{numEvents}</strong>
       </button>
-      <NotificationDrawer open={drawerOpen} onClose={closeDrawer} />
+      <NotificationDrawer
+        open={drawerOpen}
+        onClose={closeDrawer}
+        events={context.events}
+      />
     </>
   );
 };

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -156,53 +156,6 @@ export const handlers = [
   }),
   rest.get('*/events', (req, res, ctx) => {
     const events = eventFactory.buildList(10);
-    const communityLike = eventFactory.build({
-      seen: false,
-      read: false,
-      action: 'community_like',
-      username: 'demo-user',
-      entity: {
-        id: 17566,
-        type: 'community_like',
-        label:
-          '1 user liked your answer to: How do I deploy an image to an existing Linode?',
-        url: 'https://linode.com/community/questions/1#answer-1'
-      },
-      status: 'notification'
-    });
-    const communityReply = eventFactory.build({
-      seen: false,
-      read: false,
-      percent_complete: null,
-      action: 'community_question_reply',
-      username: 'demo-user-2',
-      entity: {
-        id: 17567,
-        type: 'community_reply',
-        label: 'How do I deploy an image to an existing Linode?',
-        url: 'https://linode.com/community/questions/2#answer-1'
-      },
-      status: 'notification'
-    });
-    const communityMention = eventFactory.build({
-      seen: true,
-      read: false,
-      action: 'community_mention',
-      username: 'prod-test-001',
-      entity: {
-        id: 17568,
-        type: 'community_question',
-        label: 'How do I deploy an image to an existing Linode?',
-        url: 'https://linode.com/community/questions/17566#answer-73511'
-      },
-      status: 'notification'
-    });
-    const _events = [
-      ...events,
-      communityLike,
-      communityReply,
-      communityMention
-    ];
-    return res(ctx.json(makeResourcePage(_events)));
+    return res(ctx.json(makeResourcePage(events)));
   })
 ];


### PR DESCRIPTION
## Description

- Hook up event context to NotificationDrawer so it gets real events
- Update the count next to the bell (still in progress)
- Removed temporary community event mocking from serverHandlers
(mocking events like that causes pileups from our normal events polling
and so can't be left as a normal part of our mock server)

