### PR TITLE
CMR: Add static banner to Linode changelog

### DIFF
--- a/packages/manager/src/features/Dashboard_CMR/DashboardNotifications.tsx
+++ b/packages/manager/src/features/Dashboard_CMR/DashboardNotifications.tsx
@@ -9,6 +9,7 @@ import { useAPIRequest } from 'src/hooks/useAPIRequest';
 import CircleProgress from 'src/components/CircleProgress';
 import ErrorState from 'src/components/ErrorState';
 import BillingSummary from 'src/features/Billing/BillingPanels/BillingSummary';
+import LinodeNews from './LinodeNews';
 
 import {
   Alerts,
@@ -90,6 +91,7 @@ export const Notifications: React.FC<{}> = _ => {
           </Grid>
         </Grid>
       </Paper>
+      <LinodeNews />
     </>
   );
 };

--- a/packages/manager/src/features/Dashboard_CMR/LinodeNews.tsx
+++ b/packages/manager/src/features/Dashboard_CMR/LinodeNews.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import Logo from 'src/assets/logo/logo.svg';
+import Paper from 'src/components/core/Paper';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+import Link from 'src/components/Link';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    padding: theme.spacing(2),
+    margin: `${theme.spacing(3)}px 0px`,
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between'
+  },
+  logo: {
+    height: 30,
+    width: 30,
+    paddingRight: theme.spacing()
+  }
+}));
+
+export const LinodeNews: React.FC<{}> = _ => {
+  const classes = useStyles();
+  const { VERSION } = process.env || null;
+  if (!VERSION) {
+    return null;
+  }
+  return (
+    <Paper className={classes.root}>
+      <div className="flexCenter">
+        <Logo className={classes.logo} />
+        <Typography style={{ fontSize: '1rem' }}>
+          Cloud Manager v{VERSION} has been released! {` `}
+          <Link
+            to={`https://github.com/linode/manager/releases/tag/linode-manager@v${VERSION}`}
+          >
+            Read the release notes{` `}
+          </Link>
+          for details.
+        </Typography>
+      </div>
+    </Paper>
+  );
+};
+
+export default React.memo(LinodeNews);

--- a/packages/manager/src/features/Dashboard_CMR/LinodeNews.tsx
+++ b/packages/manager/src/features/Dashboard_CMR/LinodeNews.tsx
@@ -8,7 +8,7 @@ import Link from 'src/components/Link';
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
     padding: theme.spacing(2),
-    margin: `${theme.spacing(3)}px 0px`,
+    marginTop: theme.spacing(5),
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',


### PR DESCRIPTION
## Description

As per the designs, add a banner below the Notification section on the Dashboard with info about our most recent release and a link to the release notes (GitHub release). This banner will be made dismissible in a follow-on PR.

A little farther down the road, there will be some "flavor text" included (see designs for an example) but I don't see a plausible way to set that up before the internal beta starts, so holding off for now.