### PR TITLE
Fixes for responsive Firewall Tables

### DIFF
--- a/packages/manager/src/components/EntityTable/EntityTableHeader.tsx
+++ b/packages/manager/src/components/EntityTable/EntityTableHeader.tsx
@@ -73,20 +73,45 @@ export const EntityTableHeader: React.FC<Props> = props => {
               </SortCell>
             )
           ) : (
-            <TableCell
-              key={thisCell.dataColumn}
-              data-testid={`${thisCell.label}-header-cell`}
-              className={classes.thead}
-              style={{ width: thisCell.widthPercent }}
-            >
-              <span
-                className={
-                  thisCell.visuallyHidden ? classes.hiddenHeaderCell : undefined
-                }
-              >
-                {thisCell.label}
-              </span>
-            </TableCell>
+            [
+              thisCell.hideOnMobile ? (
+                <Hidden xsDown>
+                  <TableCell
+                    key={thisCell.dataColumn}
+                    data-testid={`${thisCell.label}-header-cell`}
+                    className={classes.thead}
+                    style={{ width: thisCell.widthPercent }}
+                  >
+                    <span
+                      className={
+                        thisCell.visuallyHidden
+                          ? classes.hiddenHeaderCell
+                          : undefined
+                      }
+                    >
+                      {thisCell.label}
+                    </span>
+                  </TableCell>
+                </Hidden>
+              ) : (
+                <TableCell
+                  key={thisCell.dataColumn}
+                  data-testid={`${thisCell.label}-header-cell`}
+                  className={classes.thead}
+                  style={{ width: thisCell.widthPercent }}
+                >
+                  <span
+                    className={
+                      thisCell.visuallyHidden
+                        ? classes.hiddenHeaderCell
+                        : undefined
+                    }
+                  >
+                    {thisCell.label}
+                  </span>
+                </TableCell>
+              )
+            ]
           )
         )}
       </TableRow>

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallDeviceActionMenu_CMR.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallDeviceActionMenu_CMR.tsx
@@ -1,8 +1,5 @@
 import * as React from 'react';
-
-import ActionMenu, {
-  Action
-} from 'src/components/ActionMenu_CMR/ActionMenu_CMR';
+import InlineMenuAction from 'src/components/InlineMenuAction/InlineMenuAction';
 
 export interface ActionHandlers {
   triggerRemoveDevice: (deviceID: number, label: string) => void;
@@ -18,21 +15,11 @@ type CombinedProps = Props;
 const FirewallDeviceActionMenu: React.FC<CombinedProps> = props => {
   const { deviceID, deviceLabel, triggerRemoveDevice } = props;
 
-  const createActions = () => {
-    return (): Action[] => [
-      {
-        title: 'Remove',
-        onClick: () => {
-          triggerRemoveDevice(deviceID, deviceLabel);
-        }
-      }
-    ];
-  };
-
   return (
-    <ActionMenu
-      createActions={createActions()}
-      ariaLabel={`Action menu for Firewall Device ${deviceLabel}`}
+    <InlineMenuAction
+      key="Remove"
+      actionText="Remove"
+      onClick={() => triggerRemoveDevice(deviceID, deviceLabel)}
     />
   );
 };

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallActionMenu_CMR.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallActionMenu_CMR.tsx
@@ -92,7 +92,7 @@ const FirewallActionMenu: React.FC<CombinedProps> = props => {
 
   const inlineActions = [
     {
-      actionText: 'Edit',
+      actionText: 'Details',
       className: classes.link,
       href: `/firewalls/${firewallID}`
     },
@@ -103,6 +103,12 @@ const FirewallActionMenu: React.FC<CombinedProps> = props => {
       onClick: (e: React.MouseEvent<HTMLElement>) => {
         e.preventDefault();
         handleEnableDisable();
+      }
+    },
+    {
+      actionText: 'Delete',
+      onClick: () => {
+        triggerDeleteFirewall(firewallID, firewallLabel);
       }
     }
   ];
@@ -116,7 +122,26 @@ const FirewallActionMenu: React.FC<CombinedProps> = props => {
   };
 
   const createActions = () => (): Action[] => {
-    const actions: Action[] = [
+    return [
+      {
+        title: 'Details',
+        onClick: (e: React.MouseEvent<HTMLElement>) => {
+          history.push({
+            pathname: `/firewalls/${firewallID}`
+          });
+          e.preventDefault();
+        }
+      },
+      {
+        title:
+          firewallStatus === ('enabled' as FirewallStatus)
+            ? 'Disable'
+            : 'Enable',
+        onClick: (e: React.MouseEvent<HTMLElement>) => {
+          e.preventDefault();
+          handleEnableDisable();
+        }
+      },
       {
         title: 'Delete',
         onClick: () => {
@@ -124,32 +149,6 @@ const FirewallActionMenu: React.FC<CombinedProps> = props => {
         }
       }
     ];
-
-    if (matchesSmDown) {
-      actions.unshift(
-        {
-          title: 'Edit',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
-            history.push({
-              pathname: `/firewalls/${firewallID}`
-            });
-            e.preventDefault();
-          }
-        },
-        {
-          title:
-            firewallStatus === ('enabled' as FirewallStatus)
-              ? 'Disable'
-              : 'Enable',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
-            e.preventDefault();
-            handleEnableDisable();
-          }
-        }
-      );
-    }
-
-    return actions;
   };
 
   return (
@@ -166,10 +165,12 @@ const FirewallActionMenu: React.FC<CombinedProps> = props => {
             />
           );
         })}
-      <ActionMenu
-        createActions={createActions()}
-        ariaLabel={`Action menu for Firewall ${props.firewallLabel}`}
-      />
+      {matchesSmDown && (
+        <ActionMenu
+          createActions={createActions()}
+          ariaLabel={`Action menu for Firewall ${props.firewallLabel}`}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
Changes to the Firewall ActionMenu items and fixes the headers that are showing up on mobile (as a result, this also fixes it for domains)