### PR TITLE
[CMR] Adjust column widths for Volumes table

### DIFF
--- a/packages/manager/src/features/Volumes/VolumeTableRow_CMR.tsx
+++ b/packages/manager/src/features/Volumes/VolumeTableRow_CMR.tsx
@@ -90,32 +90,19 @@ export const VolumeTableRow: React.FC<CombinedProps> = props => {
       data-qa-volume-cell={id}
       // className="fade-in-table"
     >
-      <TableCell parentColumn="Label" data-qa-volume-cell-label={label}>
+      <TableCell data-qa-volume-cell-label={label}>
         <Grid container wrap="nowrap" alignItems="center">
           <Grid item>
             <div>{label}</div>
           </Grid>
         </Grid>
       </TableCell>
-      {region && (
-        <TableCell parentColumn="Region" data-qa-volume-region>
-          {formattedRegion}
-        </TableCell>
-      )}
-      <TableCell parentColumn="Size" data-qa-volume-size>
-        {size} GiB
-      </TableCell>
-      <TableCell
-        className={classes.volumePath}
-        parentColumn="File System Path"
-        data-qa-fs-path
-      >
+      {region && <TableCell data-qa-volume-region>{formattedRegion}</TableCell>}
+      <TableCell data-qa-volume-size>{size} GiB</TableCell>
+      <TableCell className={classes.volumePath} data-qa-fs-path>
         {filesystemPath}
       </TableCell>
-      <TableCell
-        parentColumn="Attached To"
-        data-qa-volume-cell-attachment={linodeLabel}
-      >
+      <TableCell data-qa-volume-cell-attachment={linodeLabel}>
         {linodeId ? (
           <Link to={`/linodes/${linodeId}`} className="link secondaryLink">
             {linodeLabel}

--- a/packages/manager/src/features/Volumes/VolumeTableRow_CMR.tsx
+++ b/packages/manager/src/features/Volumes/VolumeTableRow_CMR.tsx
@@ -14,12 +14,6 @@ import { compose } from 'recompose';
 
 const useStyles = makeStyles(() => ({
   root: {},
-  volumeLabel: {
-    width: '25%'
-  },
-  volumeSize: {
-    width: '10%'
-  },
   volumePath: {
     width: '35%',
     wordBreak: 'break-all'
@@ -96,11 +90,7 @@ export const VolumeTableRow: React.FC<CombinedProps> = props => {
       data-qa-volume-cell={id}
       // className="fade-in-table"
     >
-      <TableCell
-        className={classes.volumeLabel}
-        parentColumn="Label"
-        data-qa-volume-cell-label={label}
-      >
+      <TableCell parentColumn="Label" data-qa-volume-cell-label={label}>
         <Grid container wrap="nowrap" alignItems="center">
           <Grid item>
             <div>{label}</div>
@@ -112,11 +102,7 @@ export const VolumeTableRow: React.FC<CombinedProps> = props => {
           {formattedRegion}
         </TableCell>
       )}
-      <TableCell
-        className={classes.volumeSize}
-        parentColumn="Size"
-        data-qa-volume-size
-      >
+      <TableCell parentColumn="Size" data-qa-volume-size>
         {size} GiB
       </TableCell>
       <TableCell


### PR DESCRIPTION
## Description
Removed classes setting widths of label and size columns; this was unnecessarily overriding widths being set with `headers` in the new RowComponent/EntityTable pattern and resulting in the "Attached To" header wrapping.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')