### PR TITLE
M3-4401 Fix SSH fingerprints 

### DIFF
--- a/packages/manager/src/utilities/ssh-fingerprint.test.ts
+++ b/packages/manager/src/utilities/ssh-fingerprint.test.ts
@@ -1,12 +1,24 @@
 import fingerprint from './ssh-fingerprint';
 
-const ed2 =
-  'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGL5mQV7syfg8qndLQ70tSUKPAfERhslyURfuv5X8drO jcoffman@stellarwind';
+const rsa =
+  'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC0XgxNfQEPJBzd9kCOqMxOY60Z10gMLoqh1qx9eGlYORKoMAbnl2+gnGdrSHuc7ZPlV3+xiQRbcLp8R6LM/zKJECsFY7daNjwI/yeJz8Yv3V7cIcybf6O1neyrweNMW3XTc18cmoHS69KJX9BAecmpWsqJ8CFH/1/Fs16jCH8fyAe14TTvR6KBYcySqaBVZgtjGAV8FvmCP/1PNE2g2POnBZkSgnYdyq2dC8V9fHYece0KP38qyzR8vnMZVzLTTYa0/z1uyCUfkGlXEBbz1ULGvLJQUn5QhRWZXjHgzhMCTv18lPhmvythZ+gQAKVjDNUFgSHus7ZoVA2IuOoHIYyrOfmRTP2WxWpwSPOXlUhbnFj+0OSMAYxzmhAABCw1YQBVltBJ11JM9GdCKKqXmiRpRSn046niybm/m5xw8eQydkL5B48TkTZKE4TmuWZOb3bogPNvXOunfIDtte+6vHGzfL6Unx4chvlYItQyO4cDvmJVbk83eh5fxJOxNwvrYwU= jared@ganymede';
+const rsaFingerprint = 'c0:44:ef:87:81:20:47:78:3d:32:ce:ea:6c:c7:48:e5';
+
+const ed25519 =
+  'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKDsowlNFz0LVJvyImuOMRCxW59+BY3eWXYtD4DI8ZO+ jared@ganymede';
+
+const edFingerprint = '79:48:dc:ed:c9:d4:bc:e1:98:5a:ec:65:bc:a2:0c:54';
 
 describe('Generating SSH key fingerprints', () => {
-  it('should use the correct algorithm', () => {
-    expect(fingerprint(ed2)).toMatch(
-      '95:54:c0:82:c0:9b:5c:74:3f:4f:15:4a:41:bf:07:97'
-    );
+  it('should correctly fingerprint an ssh-rsa key', () => {
+    expect(fingerprint(rsa)).toMatch(rsaFingerprint);
+  });
+
+  it('should correctly fingerprint an ssh-ed25519 key', () => {
+    expect(fingerprint(ed25519)).toMatch(edFingerprint);
+  });
+
+  it('should return a message in the event of an error', () => {
+    expect(fingerprint(null as any)).toMatch('Error generating fingerprint');
   });
 });

--- a/packages/manager/src/utilities/ssh-fingerprint.test.ts
+++ b/packages/manager/src/utilities/ssh-fingerprint.test.ts
@@ -1,0 +1,12 @@
+import fingerprint from './ssh-fingerprint';
+
+const ed2 =
+  'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGL5mQV7syfg8qndLQ70tSUKPAfERhslyURfuv5X8drO jcoffman@stellarwind';
+
+describe('Generating SSH key fingerprints', () => {
+  it('should use the correct algorithm', () => {
+    expect(fingerprint(ed2)).toMatch(
+      '95:54:c0:82:c0:9b:5c:74:3f:4f:15:4a:41:bf:07:97'
+    );
+  });
+});

--- a/packages/manager/src/utilities/ssh-fingerprint.ts
+++ b/packages/manager/src/utilities/ssh-fingerprint.ts
@@ -1,13 +1,17 @@
 import * as crypto from 'crypto';
-
-const pubre = /^(ssh-[dr]s[as]\s+)|(\s+.+)|\n/g;
+import { reportException } from 'src/exceptionReporting';
 
 export default (pub: string, alg: string = 'md5') => {
-  const cleanpub = pub.replace(pubre, '');
-  const pubbuffer = new Buffer(cleanpub, 'base64');
-  const key = hash(pubbuffer, alg);
+  try {
+    const cleanpub = pub.split(' ')?.[1] ?? '';
+    const pubbuffer = Buffer.from(cleanpub, 'base64');
+    const key = hash(pubbuffer, alg);
 
-  return colons(key);
+    return colons(key);
+  } catch (e) {
+    reportException(`Error ${e} when parsing SSH pubkey: ${pub}`);
+    return 'Error generating fingerprint';
+  }
 };
 
 // hash a string with the given alg

--- a/packages/manager/src/utilities/ssh-fingerprint.ts
+++ b/packages/manager/src/utilities/ssh-fingerprint.ts
@@ -1,6 +1,13 @@
 import * as crypto from 'crypto';
 import { reportException } from 'src/exceptionReporting';
 
+/**
+ * Return the fingerprint of an SSH pubkey.
+ * Defaults to md5 as that's what e.g. GitHub displays.
+ *
+ * Originally taken from https://github.com/bahamas10/node-ssh-fingerprint/blob/master/ssh-fingerprint.js
+ * As of 8/20, replaced because the regex-based method does not handle ed25519 keys correctly.
+ */
 export default (pub: string, alg: string = 'md5') => {
   try {
     const cleanpub = pub.split(' ')?.[1] ?? '';


### PR DESCRIPTION
## Description

Customer reported that their SSH key fingerprints (at /profile/keys) were displayed incorrectly. In fact, the same fingerprint
was displayed for 2 different keys.

Our fingerprint() function was borrowed (copy/pasted) from an obsolete NPM library, from back in the days when only 
RSA and DSA were available as signing algorithms. As a result, the user's Ed25519 keys were breaking the logic.
 
I'm using a...much simpler approach. Seems to work for multiple key types generated with `ssh-keygen`, but needs more investigation.

## Note to Reviewers

Add an SSH key to Cloud, and check that the fingerprint shown at profile/keys matches the output of `ssh-keygen -lf $1 -E md5;` where `$1` is the path to your public key.
