### PR TITLE
M3-4373 Confirm enabling backups

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/BackupsPlaceholder.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/BackupsPlaceholder.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+import VolumeIcon from 'src/assets/addnewmenu/volume.svg';
+import Typography from 'src/components/core/Typography';
+import Currency from 'src/components/Currency';
+import Placeholder from 'src/components/Placeholder';
+import LinodePermissionsError from '../LinodePermissionsError';
+import EnableBackupsDialog from './EnableBackupsDialog';
+
+interface Props {
+  backupsMonthlyPrice?: number;
+  disabled: boolean;
+  linodeId: number;
+}
+
+export type CombinedProps = Props;
+
+export const BackupsPlaceholder: React.FC<Props> = props => {
+  const { backupsMonthlyPrice, linodeId, disabled } = props;
+
+  const [dialogOpen, setDialogOpen] = React.useState(false);
+
+  const backupPlaceholderText = backupsMonthlyPrice ? (
+    <Typography variant="subtitle1">
+      Three backup slots are executed and rotated automatically: a daily backup,
+      a 2-7 day old backup, and 8-14 day old backup. To enable backups for just{' '}
+      <strong>
+        <Currency quantity={backupsMonthlyPrice} /> per month
+      </strong>
+      , click below.
+    </Typography>
+  ) : (
+    <Typography variant="subtitle1">
+      Three backup slots are executed and rotated automatically: a daily backup,
+      a 2-7 day old backup, and 8-14 day old backup. To enable backups just
+      click below.
+    </Typography>
+  );
+
+  return (
+    <>
+      {disabled && <LinodePermissionsError />}
+      <Placeholder
+        icon={VolumeIcon}
+        title="Backups"
+        renderAsSecondary
+        copy={backupPlaceholderText}
+        buttonProps={[
+          {
+            onClick: () => setDialogOpen(true),
+            children: 'Enable Backups',
+            disabled
+          }
+        ]}
+      />
+      <EnableBackupsDialog
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+        linodeId={linodeId}
+        price={backupsMonthlyPrice ?? 0}
+      />
+    </>
+  );
+};
+
+export default React.memo(BackupsPlaceholder);

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/BackupsPlaceholder.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/BackupsPlaceholder.tsx
@@ -22,7 +22,8 @@ export const BackupsPlaceholder: React.FC<Props> = props => {
   const backupPlaceholderText = backupsMonthlyPrice ? (
     <Typography variant="subtitle1">
       Three backup slots are executed and rotated automatically: a daily backup,
-      a 2-7 day old backup, and 8-14 day old backup. To enable backups for just{' '}
+      a 2-7 day old backup, and an 8-14 day old backup. To enable backups for
+      just{' '}
       <strong>
         <Currency quantity={backupsMonthlyPrice} /> per month
       </strong>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/EnableBackupsDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/EnableBackupsDialog.tsx
@@ -1,0 +1,89 @@
+import { enableBackups } from '@linode/api-v4/lib/linodes';
+import { useSnackbar } from 'notistack';
+import * as React from 'react';
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
+import Typography from 'src/components/core/Typography';
+import ConfirmationDialog from 'src/components/ConfirmationDialog';
+import Currency from 'src/components/Currency';
+import Notice from 'src/components/Notice';
+import { resetEventsPolling } from 'src/eventsPolling';
+
+interface Props {
+  linodeId: number;
+  price: number;
+  onClose: () => void;
+  open: boolean;
+}
+
+export type CombinedProps = Props;
+
+export const EnableBackupsDialog: React.FC<Props> = props => {
+  const { linodeId, onClose, open, price } = props;
+  const [submitting, setSubmitting] = React.useState(false);
+  const [error, setError] = React.useState<string | undefined>();
+
+  const { enqueueSnackbar } = useSnackbar();
+
+  const handleEnableBackups = React.useCallback(() => {
+    setSubmitting(true);
+    enableBackups(linodeId)
+      .then(() => {
+        setSubmitting(false);
+        resetEventsPolling();
+        enqueueSnackbar('Backups are being enabled for this Linode.', {
+          variant: 'success'
+        });
+        onClose();
+      })
+      .catch(error => {
+        setError(error[0].reason);
+        setSubmitting(false);
+      });
+  }, [linodeId, onClose, enqueueSnackbar]);
+
+  React.useEffect(() => {
+    if (open) {
+      setError(undefined);
+    }
+  }, [open]);
+
+  const actions = React.useMemo(() => {
+    return (
+      <ActionsPanel style={{ padding: 0 }}>
+        <Button buttonType="cancel" onClick={onClose} data-qa-cancel-cancel>
+          Close
+        </Button>
+        <Button
+          buttonType="secondary"
+          loading={submitting}
+          onClick={handleEnableBackups}
+          data-qa-confirm-enable-backups
+        >
+          Enable Backups
+        </Button>
+      </ActionsPanel>
+    );
+  }, [onClose, submitting, handleEnableBackups]);
+
+  return (
+    <ConfirmationDialog
+      title="Enable backups?"
+      actions={actions}
+      open={open}
+      onClose={onClose}
+    >
+      <>
+        <Typography>
+          Are you sure you want to enable backups on this Linode?{` `}
+          This will add <Currency quantity={price} />
+          {` `}
+          to your monthly bill.
+        </Typography>
+        {error && <Notice error text={error} spacingTop={8} />}
+      </>
+    </ConfirmationDialog>
+  );
+};
+
+export default React.memo(EnableBackupsDialog);

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup_CMR.tsx
@@ -2,7 +2,6 @@ import { GrantLevel } from '@linode/api-v4/lib/account';
 import {
   cancelBackups,
   Day,
-  enableBackups,
   getLinodeBackups,
   getType,
   LinodeBackup,
@@ -15,14 +14,13 @@ import {
 import { APIError } from '@linode/api-v4/lib/types';
 import { DateTime } from 'luxon';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
-import { path, pathOr, sortBy } from 'ramda';
+import { pathOr, sortBy } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
 import 'rxjs/add/operator/filter';
 import { Subscription } from 'rxjs/Subscription';
-import VolumeIcon from 'src/assets/addnewmenu/volume.svg';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
@@ -40,12 +38,10 @@ import TableHead from 'src/components/core/TableHead';
 import TableRow from 'src/components/core/TableRow';
 import Tooltip from 'src/components/core/Tooltip';
 import Typography from 'src/components/core/Typography';
-import Currency from 'src/components/Currency';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import ErrorState from 'src/components/ErrorState';
 import Notice from 'src/components/Notice';
-import Placeholder from 'src/components/Placeholder';
 import PromiseLoader, {
   PromiseLoaderResponse
 } from 'src/components/PromiseLoader';
@@ -62,14 +58,12 @@ import {
 import { MapState } from 'src/store/types';
 import { getAPIErrorOrDefault, getErrorMap } from 'src/utilities/errorUtils';
 import { formatDate } from 'src/utilities/formatDate';
-import {
-  sendBackupsDisabledEvent,
-  sendBackupsEnabledEvent
-} from 'src/utilities/ga';
+import { sendBackupsDisabledEvent } from 'src/utilities/ga';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import { withLinodeDetailContext } from '../linodeDetailContext';
 import LinodePermissionsError from '../LinodePermissionsError';
+import BackupsPlaceholder from './BackupsPlaceholder';
 import BackupTableRow from './BackupTableRow';
 import RestoreToLinodeDrawer from './RestoreToLinodeDrawer';
 
@@ -251,7 +245,7 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
         ].includes(e.action)
       )
       .filter(e => !e._initial && e.status === 'finished')
-      .subscribe(e => {
+      .subscribe(_ => {
         getLinodeBackups(this.props.linodeID)
           .then(data => {
             this.setState({ backups: data });
@@ -261,10 +255,6 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
             this.setState({ enabling: false });
           });
       });
-    const { enableOnLoad } = pathOr(false, ['location', 'state'], this.props);
-    if (enableOnLoad && !this.props.backupsEnabled) {
-      this.enableBackups();
-    }
   }
 
   componentWillUnmount() {
@@ -308,28 +298,6 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
       ['Saturday', 'Saturday']
     ];
   }
-
-  enableBackups = () => {
-    this.setState({ enabling: true });
-    const { linodeID, enqueueSnackbar } = this.props;
-    enableBackups(linodeID)
-      .then(() => {
-        enqueueSnackbar('Backups are being enabled for this Linode', {
-          variant: 'info'
-        });
-        resetEventsPolling();
-        // GA Event
-        sendBackupsEnabledEvent('From Backups tab');
-      })
-      .catch(errorResponse => {
-        getAPIErrorOrDefault(errorResponse).forEach((err: APIError) =>
-          enqueueSnackbar(err.reason, {
-            variant: 'error'
-          })
-        );
-        this.setState({ enabling: false });
-      });
-  };
 
   cancelBackups = () => {
     const { enqueueSnackbar } = this.props;
@@ -530,86 +498,36 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
     });
   };
 
-  Placeholder = (): JSX.Element | null => {
-    const { enabling } = this.state;
-    const { permissions } = this.props;
-    const disabled = isReadOnly(permissions);
-    const backupsMonthlyPrice = path<number>(
-      ['types', 'response', 'addons', 'backups', 'price', 'monthly'],
-      this.props
-    );
-
-    const backupPlaceholderText = backupsMonthlyPrice ? (
-      <Typography variant="subtitle1">
-        Three backup slots are executed and rotated automatically: a daily
-        backup, a 2-7 day old backup, and 8-14 day old backup. To enable backups
-        for just{' '}
-        <strong>
-          <Currency quantity={backupsMonthlyPrice} /> per month
-        </strong>
-        , click below.
-      </Typography>
-    ) : (
-      <Typography variant="subtitle1">
-        Three backup slots are executed and rotated automatically: a daily
-        backup, a 2-7 day old backup, and 8-14 day old backup. To enable backups
-        just click below.
-      </Typography>
-    );
-
-    return (
-      <React.Fragment>
-        {disabled && <LinodePermissionsError />}
-        <Placeholder
-          icon={VolumeIcon}
-          title="Backups"
-          renderAsSecondary
-          copy={backupPlaceholderText}
-          buttonProps={[
-            {
-              onClick: () => this.enableBackups(),
-              children: 'Enable Backups',
-              loading: enabling,
-              disabled
-            }
-          ]}
-        />
-      </React.Fragment>
-    );
-  };
-
   Table = ({ backups }: { backups: LinodeBackup[] }): JSX.Element | null => {
     const { classes, permissions } = this.props;
     const disabled = isReadOnly(permissions);
 
     return (
-      <React.Fragment>
-        <Paper className={classes.paper} style={{ padding: 0 }}>
-          <Table aria-label="List of Backups">
-            <TableHead>
-              <TableRow>
-                <TableCell>Label</TableCell>
-                <TableCell>Date Created</TableCell>
-                <TableCell>Duration</TableCell>
-                <TableCell>Disks</TableCell>
-                <TableCell>Space Required</TableCell>
-                <TableCell />
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {backups.map((backup: LinodeBackup, idx: number) => (
-                <BackupTableRow
-                  key={idx}
-                  backup={backup}
-                  disabled={disabled}
-                  handleDeploy={this.handleDeploy}
-                  handleRestore={this.handleRestore}
-                />
-              ))}
-            </TableBody>
-          </Table>
-        </Paper>
-      </React.Fragment>
+      <Paper className={classes.paper} style={{ padding: 0 }}>
+        <Table aria-label="List of Backups">
+          <TableHead>
+            <TableRow>
+              <TableCell>Label</TableCell>
+              <TableCell>Date Created</TableCell>
+              <TableCell>Duration</TableCell>
+              <TableCell>Disks</TableCell>
+              <TableCell>Space Required</TableCell>
+              <TableCell />
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {backups.map((backup: LinodeBackup, idx: number) => (
+              <BackupTableRow
+                key={idx}
+                backup={backup}
+                disabled={disabled}
+                handleDeploy={this.handleDeploy}
+                handleRestore={this.handleRestore}
+              />
+            ))}
+          </TableBody>
+        </Table>
+      </Paper>
     );
   };
 
@@ -717,73 +635,71 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
     });
 
     return (
-      <React.Fragment>
-        <Paper className={classes.paper}>
-          <Typography
-            variant="h2"
-            className={classes.subTitle}
-            data-qa-settings-heading
-          >
-            Settings
-          </Typography>
-          <Typography variant="body1" data-qa-settings-desc>
-            Configure when automatic backups are initiated. The Linode Backup
-            Service will generate a backup between the selected hours every day,
-            and will overwrite the previous daily backup. The selected day is
-            when the backup is promoted to the weekly slot. Up to two weekly
-            backups are saved.
-          </Typography>
-          <FormControl className={classes.chooseTime}>
-            <Select
-              textFieldProps={{
-                dataAttrs: {
-                  'data-qa-time-select': true
-                }
-              }}
-              options={timeSelection}
-              onChange={this.handleSelectBackupWindow}
-              label="Time of Day"
-              placeholder="Choose a time"
-              isClearable={false}
-              defaultValue={defaultTimeSelection}
-              name="Time of Day"
-              noMarginTop
-            />
-            <FormHelperText>
-              Windows displayed in {this.props.timezone}
-            </FormHelperText>
-          </FormControl>
+      <Paper className={classes.paper}>
+        <Typography
+          variant="h2"
+          className={classes.subTitle}
+          data-qa-settings-heading
+        >
+          Settings
+        </Typography>
+        <Typography variant="body1" data-qa-settings-desc>
+          Configure when automatic backups are initiated. The Linode Backup
+          Service will generate a backup between the selected hours every day,
+          and will overwrite the previous daily backup. The selected day is when
+          the backup is promoted to the weekly slot. Up to two weekly backups
+          are saved.
+        </Typography>
+        <FormControl className={classes.chooseTime}>
+          <Select
+            textFieldProps={{
+              dataAttrs: {
+                'data-qa-time-select': true
+              }
+            }}
+            options={timeSelection}
+            onChange={this.handleSelectBackupWindow}
+            label="Time of Day"
+            placeholder="Choose a time"
+            isClearable={false}
+            defaultValue={defaultTimeSelection}
+            name="Time of Day"
+            noMarginTop
+          />
+          <FormHelperText>
+            Windows displayed in {this.props.timezone}
+          </FormHelperText>
+        </FormControl>
 
-          <FormControl className={classes.chooseDay}>
-            <Select
-              textFieldProps={{
-                dataAttrs: {
-                  'data-qa-weekday-select': true
-                }
-              }}
-              options={daySelection}
-              defaultValue={defaultDaySelection}
-              onChange={this.handleSelectBackupTime}
-              label="Day of Week"
-              placeholder="Choose a day"
-              isClearable={false}
-              noMarginTop
-            />
-          </FormControl>
-          <ActionsPanel className={classes.scheduleAction}>
-            <Button
-              buttonType="primary"
-              onClick={this.saveSettings}
-              disabled={isReadOnly(permissions)}
-              loading={this.state.settingsForm.loading}
-              data-qa-schedule
-            >
-              Save Schedule
-            </Button>
-          </ActionsPanel>
-          {errorText && <FormHelperText error>{errorText}</FormHelperText>}
-        </Paper>
-      </React.Fragment>
+        <FormControl className={classes.chooseDay}>
+          <Select
+            textFieldProps={{
+              dataAttrs: {
+                'data-qa-weekday-select': true
+              }
+            }}
+            options={daySelection}
+            defaultValue={defaultDaySelection}
+            onChange={this.handleSelectBackupTime}
+            label="Day of Week"
+            placeholder="Choose a day"
+            isClearable={false}
+            noMarginTop
+          />
+        </FormControl>
+        <ActionsPanel className={classes.scheduleAction}>
+          <Button
+            buttonType="primary"
+            onClick={this.saveSettings}
+            disabled={isReadOnly(permissions)}
+            loading={this.state.settingsForm.loading}
+            data-qa-schedule
+          >
+            Save Schedule
+          </Button>
+        </ActionsPanel>
+        {errorText && <FormHelperText error>{errorText}</FormHelperText>}
+      </Paper>
     );
   };
 
@@ -878,7 +794,7 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
   };
 
   render() {
-    const { backupsEnabled, linodeLabel } = this.props;
+    const { backupsEnabled, linodeLabel, permissions, type } = this.props;
 
     if (this.props.backups.error) {
       /** @todo remove promise loader and source backups from Redux */
@@ -887,20 +803,29 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
       );
     }
 
+    const backupsMonthlyPrice =
+      type?.response.addons.backups.price.monthly ?? 0;
+
     return (
-      <React.Fragment>
-        <div>
-          <DocumentTitleSegment segment={`${linodeLabel} - Backups`} />
-          {backupsEnabled ? <this.Management /> : <this.Placeholder />}
-        </div>
-      </React.Fragment>
+      <div>
+        <DocumentTitleSegment segment={`${linodeLabel} - Backups`} />
+        {backupsEnabled ? (
+          <this.Management />
+        ) : (
+          <BackupsPlaceholder
+            linodeId={this.props.linodeID}
+            backupsMonthlyPrice={backupsMonthlyPrice}
+            disabled={isReadOnly(permissions)}
+          />
+        )}
+      </div>
     );
   }
 }
 
 const preloaded = PromiseLoader<ContextProps>({
   backups: props => getLinodeBackups(props.linodeID),
-  types: ({ linodeType }) => {
+  type: ({ linodeType }) => {
     if (!linodeType) {
       return Promise.resolve(undefined);
     }
@@ -915,10 +840,7 @@ interface StateProps {
   timezone: string;
 }
 
-const mapStateToProps: MapState<StateProps, CombinedProps> = (
-  state,
-  ownProps
-) => ({
+const mapStateToProps: MapState<StateProps, CombinedProps> = state => ({
   timezone: pathOr('GMT', ['data', 'timezone'], state.__resources.profile)
 });
 


### PR DESCRIPTION
## Description

When enabling backups from either the Linode action menu or Linode
detail /backups tab, we didn't ask for confirmation. Since this is a billing
change, we should show a confirmation modal in these cases. This is especially
true now that we're using Reach components for the action menu.

This was supposed to be a small change, but our pattern here was janky. When a user
clicked the action menu for Enable Backups, we were:

1. Redirecting to /backups
2. Passing router state such that
3. in the cDM of LinodeBackups, we called enableBackups() automatically
if the state had been passed.

In the new pattern, we'll use a single confirmation dialog, reused in both locations.
When the action menu is clicked, it will:

1. Open the dialog
2. The dialog can be submitted, enabling backups
3. Once that's complete, redirect to /backups as before.

This is part 1, which adds the confirmation modal to the /backups tab.
It breaks the action menu, which will have no effect (other than redirecting
to the /backups tab) until part 2 is merged.

- Broke out the Placeholder and EnableConfirmationDialog into separate components
- Allowed the dialog component to manage its own state and API calls, so that
it can also be used from the action menu.

## Note to Reviewers

Make sure Managed is not enabled on your account, and either create or otherwise have a Linode without backups enabled. Go to linodes/:id/backups and press the button to enable backups. Note that doing this from the Linode action menu will not work on this branch; part 2 will connect those dots.