### PR TITLE
Mark events as seen when requesting in the notificationContext

### DIFF
--- a/packages/manager/src/features/NotificationCenter/NotificationContext.ts
+++ b/packages/manager/src/features/NotificationCenter/NotificationContext.ts
@@ -1,5 +1,5 @@
 import { getLogins } from '@linode/api-v4/lib/profile';
-import { getEvents, Event } from '@linode/api-v4/lib/account';
+import { getEvents, Event, markEventSeen } from '@linode/api-v4/lib/account';
 import { createContext, useCallback, useEffect, useState } from 'react';
 
 export interface NotificationContextProps {
@@ -26,6 +26,12 @@ export const useNotificationContext = (): NotificationContextProps => {
 
   const [mostRecentLogin, setRecentLogin] = useState<string | undefined>();
 
+  /**
+   * If we know the most recent time a user logged in,
+   * request all events that have occurred on this account
+   * since that time. This is a special case for the Dashboard
+   * notifications center and notifications drawer.
+   */
   const request = useCallback(() => {
     if (mostRecentLogin) {
       getEvents(
@@ -55,6 +61,23 @@ export const useNotificationContext = (): NotificationContextProps => {
       }
     );
   }, [request]);
+
+  useEffect(() => {
+    /**
+     * If we have new events, mark them as seen.
+     * This doesn't affect how we display them,
+     * but consumers of the API should be made
+     * aware that the events have been viewed.
+     *
+     * Swallow errors, since failure at this step
+     * doesn't affect anything.
+     */
+    events.forEach(thisEvent => {
+      if (!thisEvent.seen) {
+        markEventSeen(thisEvent.id).catch(_ => null);
+      }
+    });
+  }, [events]);
 
   return {
     events,


### PR DESCRIPTION
## Description

Doesn't affect our display of events, but as a good-practice thing it's nice to do. Once we've finalized what events we actually need, we can filter our request so we're not marking things as seen unless we've actually shown them to the user.