### PR TITLE
M3-4310 completed progress events

### DIFF
--- a/packages/manager/src/eventMessageGenerator_CMR.tsx
+++ b/packages/manager/src/eventMessageGenerator_CMR.tsx
@@ -26,7 +26,7 @@ export const eventMessageGenerator = (
         eventLinode ? `to ${dcDisplayNames[eventLinode.region]}` : ''
       }`;
     case 'disk_imagize':
-      return `creating from ${e.entity?.label}`;
+      return `create from ${e.entity?.label}`;
     case 'linode_boot':
       return `boot with ${e.secondary_entity?.label}`;
     case 'host_reboot':
@@ -36,7 +36,7 @@ export const eventMessageGenerator = (
     case 'linode_reboot':
       return `reboot with ${e.secondary_entity?.label}`;
     case 'linode_shutdown':
-      return 'is shutting down';
+      return 'shutdown';
     case 'linode_clone':
       return (
         <>
@@ -53,9 +53,9 @@ export const eventMessageGenerator = (
     case 'backups_restore':
       return 'backup restore';
     case 'linode_snapshot':
-      return 'snapshot backup in progress';
+      return 'snapshot backup';
     case 'linode_mutate':
-      return 'upgrade in progress';
+      return 'upgrade';
     case 'linode_rebuild':
       return 'rebuild';
     case 'linode_create':

--- a/packages/manager/src/features/NotificationCenter/PendingActions.tsx
+++ b/packages/manager/src/features/NotificationCenter/PendingActions.tsx
@@ -15,6 +15,7 @@ import {
 import NotificationSection, { NotificationItem } from './NotificationSection';
 import createLinkHandlerForNotification from 'src/utilities/getEventsActionLinkStrings';
 import { Link } from 'src/components/Link';
+import { formatEventSeconds } from 'src/utilities/minute-conversion/minute-conversion';
 import { reducer } from './eventQueue';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -50,9 +51,13 @@ export const PendingActions: React.FC<{}> = _ => {
       if (message === null) {
         return null;
       }
+      const completed = event.percent_complete === 100;
       const timeRemaining = event.time_remaining
         ? ` (~${formatTimeRemaining(event.time_remaining)})`
         : null;
+
+      const duration = formatEventSeconds(event.duration);
+
       const linkTarget = createLinkHandlerForNotification(
         event.action,
         event.entity,
@@ -72,8 +77,13 @@ export const PendingActions: React.FC<{}> = _ => {
               {` `}
               {message}
               {timeRemaining}
+              {completed
+                ? event.status === 'failed'
+                  ? ` (failed after ${duration})`
+                  : ` (completed in ${duration})`
+                : null}
             </Typography>
-            {event.percent_complete ?? 0 < 100 ? (
+            {!completed ? (
               <BarPercent
                 className={classes.bar}
                 max={100}
@@ -81,9 +91,7 @@ export const PendingActions: React.FC<{}> = _ => {
                 rounded
                 narrow
               />
-            ) : (
-              <Typography>Complete</Typography>
-            )}
+            ) : null}
           </div>
         )
       };

--- a/packages/manager/src/features/NotificationCenter/RenderEvent.test.tsx
+++ b/packages/manager/src/features/NotificationCenter/RenderEvent.test.tsx
@@ -1,4 +1,4 @@
-import { formatTimeRemaining } from './PendingActions';
+import { formatTimeRemaining } from './RenderEvent';
 
 describe('Pending Actions', () => {
   describe('formatTimeRemaining helper', () => {

--- a/packages/manager/src/features/NotificationCenter/RenderEvent.tsx
+++ b/packages/manager/src/features/NotificationCenter/RenderEvent.tsx
@@ -1,0 +1,114 @@
+import { Event } from '@linode/api-v4/lib/account/types';
+import { Duration } from 'luxon';
+import * as React from 'react';
+import BarPercent from 'src/components/BarPercent/BarPercent_CMR';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+import { Link } from 'src/components/Link';
+import {
+  eventLabelGenerator,
+  eventMessageGenerator
+} from 'src/eventMessageGenerator_CMR';
+import useLinodes from 'src/hooks/useLinodes';
+import { useTypes } from 'src/hooks/useTypes';
+import createLinkHandlerForNotification from 'src/utilities/getEventsActionLinkStrings';
+import { formatEventSeconds } from 'src/utilities/minute-conversion/minute-conversion';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  action: {
+    display: 'flex',
+    flexFlow: 'column nowrap'
+  },
+  bar: {
+    marginTop: theme.spacing()
+  }
+}));
+
+interface Props {
+  event: Event;
+}
+
+export type CombinedProps = Props;
+
+export const RenderEvent: React.FC<Props> = props => {
+  const { event } = props;
+  const classes = useStyles();
+
+  const { linodes } = useLinodes();
+  const { types } = useTypes();
+  const _linodes = Object.values(linodes.itemsById);
+  const _types = types.entities;
+
+  const message = eventMessageGenerator(event, _linodes, _types);
+
+  if (message === null) {
+    return null;
+  }
+
+  const completed = event.percent_complete === 100;
+  const timeRemaining = event.time_remaining
+    ? ` (~${formatTimeRemaining(event.time_remaining)})`
+    : null;
+
+  const duration = formatEventSeconds(event.duration);
+
+  const linkTarget = createLinkHandlerForNotification(
+    event.action,
+    event.entity,
+    false
+  );
+  const label = linkTarget ? (
+    <Link to={linkTarget}>{eventLabelGenerator(event)}</Link>
+  ) : (
+    event.entity?.label
+  );
+  return (
+    <div className={classes.action}>
+      <Typography>
+        {label}
+        {` `}
+        {message}
+        {/** duration and timeRemaining will never overlap, but check just in case */}
+        {!completed ? timeRemaining : null}
+        {completed
+          ? event.status === 'failed'
+            ? ` (failed after ${duration})`
+            : ` (completed in ${duration})`
+          : null}
+      </Typography>
+      {!completed ? (
+        <BarPercent
+          className={classes.bar}
+          max={100}
+          value={event.percent_complete ?? 0}
+          rounded
+          narrow
+        />
+      ) : null}
+    </div>
+  );
+};
+
+export const formatTimeRemaining = (time: string) => {
+  try {
+    const [hours, minutes, seconds] = time.split(':').map(Number);
+    if (
+      [hours, minutes, seconds].some(
+        thisNumber => typeof thisNumber === 'undefined'
+      ) ||
+      [hours, minutes, seconds].some(isNaN)
+    ) {
+      // Bad input, don't display a duration
+      return null;
+    }
+    const duration = Duration.fromObject({ hours, minutes, seconds });
+    return hours > 0
+      ? `${Math.round(duration.as('hours'))} hours remaining`
+      : `${Math.round(duration.as('minutes'))} minutes remaining`;
+  } catch {
+    // Broken/unexpected input
+    return null;
+  }
+};
+
+export default React.memo(RenderEvent);

--- a/packages/manager/src/features/NotificationCenter/eventQueue.tsx
+++ b/packages/manager/src/features/NotificationCenter/eventQueue.tsx
@@ -1,0 +1,45 @@
+import { Event } from '@linode/api-v4/lib/account/types';
+import { isInProgressEvent } from 'src/store/events/event.helpers';
+interface Payload {
+  eventsFromRedux: Event[];
+}
+
+export interface ReducerState {
+  inProgressEvents: Event[];
+  completedEvents: Event[];
+}
+
+export interface ReducerActions {
+  type: 'update';
+  payload: Payload;
+}
+
+export const initEventReducerState: ReducerState = {
+  inProgressEvents: [],
+  completedEvents: []
+};
+
+type EventsReducer = React.Reducer<ReducerState, ReducerActions>;
+
+export const reducer: EventsReducer = (state, action) => {
+  const {
+    payload: { eventsFromRedux }
+  } = action;
+
+  if (action.type === 'update') {
+    const newInProgressEvents = eventsFromRedux.filter(isInProgressEvent);
+    const currentEventIds = state.inProgressEvents.map(e => e.id);
+    const newlyCompletedEvents = eventsFromRedux.filter(thisEvent => {
+      return (
+        currentEventIds.includes(thisEvent.id) &&
+        thisEvent.percent_complete === 100
+      );
+    });
+    return {
+      inProgressEvents: newInProgressEvents,
+      completedEvents: [...state.completedEvents, ...newlyCompletedEvents]
+    };
+  } else {
+    return state;
+  }
+};


### PR DESCRIPTION
## Description

Feedback from design was that in-progress actions in the Pending Actions section of the Dashboard/drawer should not disappear after completion but instead remain in the section marked as "completed".

No design for this scenario so I'm winging it a bit, feedback welcome. Also, the API really doesn't have the concept of an event queue, which is what this is; we want to display new in-progress events as they come in, and move them to completed as they finish. To do this, I added a reducer which keeps track of the in progress events and moves them to a completed state once they've finished. Logic here seems to work but could probably be improved, feedback welcome for this as well.

## Note to Reviewers

Load the dashboard and/or Notification drawer and trigger a bunch of progress events. Try to get a few events to fail (creating an enormous image, for example).

Todo: 

- [ ] Unit tests for the reducer