### PR TITLE
CMR Linode Table Adjustments

### DIFF
--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow_CMR.style.ts
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow_CMR.style.ts
@@ -20,7 +20,8 @@ type ClassNames =
   | 'planCell'
   | 'progressDisplay'
   | 'regionCell'
-  | 'tagCell';
+  | 'tagCell'
+  | 'maintenanceOuter';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -95,6 +96,10 @@ const styles = (theme: Theme) =>
     },
     tagCell: {
       borderRight: 'none'
+    },
+    maintenanceOuter: {
+      display: 'flex',
+      alignItems: 'center'
     }
   });
 

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow_CMR.tsx
@@ -89,7 +89,7 @@ export const LinodeRow: React.FC<CombinedProps> = props => {
     id,
     ipv4,
     ipv6,
-    //maintenanceStartTime,
+    maintenanceStartTime,
     label,
     region,
     status,
@@ -113,9 +113,6 @@ export const LinodeRow: React.FC<CombinedProps> = props => {
   } = props;
 
   const { updateLinode } = useLinodes();
-
-  // TODO delete before merge
-  const maintenanceStartTime = '2020-08-22 18:58:41';
 
   const loading = linodeInTransition(status, recentEvent);
   const dateTime = parseMaintenanceStartTime(maintenanceStartTime).split(' ');

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow_CMR.tsx
@@ -152,7 +152,7 @@ export const LinodeRow: React.FC<CombinedProps> = props => {
   const MaintenanceText = () => {
     return (
       <>
-        Your maintenance window for this entity is{' '}
+        Maintenance is scheduled for{' '}
         {linodeMaintenanceWindowString(dateTime[0], dateTime[1])}. For more
         information, please see your{' '}
         <Link to="/support/tickets?type=open">open support tickets.</Link>
@@ -226,7 +226,7 @@ export const LinodeRow: React.FC<CombinedProps> = props => {
             </>
           )
         ) : (
-          <div>
+          <div className={classes.maintenanceOuter}>
             <strong>Maintenance Scheduled</strong>
             <HelpIcon
               text={<MaintenanceText />}

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow_CMR.tsx
@@ -149,7 +149,9 @@ export const LinodeRow: React.FC<CombinedProps> = props => {
   const MaintenanceText = () => {
     return (
       <>
-        For more information, please see your{' '}
+        Your maintenance window for this entity is{' '}
+        {linodeMaintenanceWindowString(dateTime[0], dateTime[1])}. For more
+        information, please see your{' '}
         <Link to="/support/tickets?type=open">open support tickets.</Link>
       </>
     );
@@ -222,14 +224,7 @@ export const LinodeRow: React.FC<CombinedProps> = props => {
           )
         ) : (
           <>
-            <div>
-              <div>
-                <strong>Maintenance Scheduled</strong>
-              </div>
-              <div>
-                {linodeMaintenanceWindowString(dateTime[0], dateTime[1])}
-              </div>
-            </div>
+            <strong>Maintenance Scheduled</strong>
             <HelpIcon
               text={<MaintenanceText />}
               className={classes.statusHelpIcon}

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow_CMR.tsx
@@ -89,7 +89,7 @@ export const LinodeRow: React.FC<CombinedProps> = props => {
     id,
     ipv4,
     ipv6,
-    maintenanceStartTime,
+    //maintenanceStartTime,
     label,
     region,
     status,
@@ -113,6 +113,9 @@ export const LinodeRow: React.FC<CombinedProps> = props => {
   } = props;
 
   const { updateLinode } = useLinodes();
+
+  // TODO delete before merge
+  const maintenanceStartTime = '2020-08-22 18:58:41';
 
   const loading = linodeInTransition(status, recentEvent);
   const dateTime = parseMaintenanceStartTime(maintenanceStartTime).split(' ');
@@ -223,7 +226,7 @@ export const LinodeRow: React.FC<CombinedProps> = props => {
             </>
           )
         ) : (
-          <>
+          <div>
             <strong>Maintenance Scheduled</strong>
             <HelpIcon
               text={<MaintenanceText />}
@@ -231,7 +234,7 @@ export const LinodeRow: React.FC<CombinedProps> = props => {
               tooltipPosition="top"
               interactive
             />
-          </>
+          </div>
         )}
       </TableCell>
       <Hidden xsDown>


### PR DESCRIPTION
## Description

Based off some feedback in the project channel, we updated maintenance information to live inside the tooltip to reduce the size of the table cell. There will still be a scroll present on larger screens because the table exceeds the 1280 width, but it's not as long as it was before. Please note I did add a fake maintenance date to this PR to ease testing, will of course remove that pre-merge.

## Type of Change
- Non breaking change ('update')

