### PR TITLE
M3-4373 CMR: Backups enable from Linode action menu

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/BackupsPlaceholder.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/BackupsPlaceholder.tsx
@@ -57,7 +57,6 @@ export const BackupsPlaceholder: React.FC<Props> = props => {
         open={dialogOpen}
         onClose={() => setDialogOpen(false)}
         linodeId={linodeId}
-        price={backupsMonthlyPrice ?? 0}
       />
     </>
   );

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/EnableBackupsDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/EnableBackupsDialog.tsx
@@ -15,13 +15,12 @@ interface Props {
   linodeId: number;
   onClose: () => void;
   open: boolean;
-  onSuccess?: () => void;
 }
 
 export type CombinedProps = Props;
 
 export const EnableBackupsDialog: React.FC<Props> = props => {
-  const { linodeId, onClose, onSuccess, open } = props;
+  const { linodeId, onClose, open } = props;
   /**
    * Calculate the monthly backup price here.
    * Since this component is used in LinodesLanding
@@ -51,16 +50,13 @@ export const EnableBackupsDialog: React.FC<Props> = props => {
         enqueueSnackbar('Backups are being enabled for this Linode.', {
           variant: 'success'
         });
-        if (onSuccess) {
-          onSuccess();
-        }
         onClose();
       })
       .catch(error => {
         setError(error[0].reason);
         setSubmitting(false);
       });
-  }, [linodeId, onClose, enqueueSnackbar, onSuccess]);
+  }, [linodeId, onClose, enqueueSnackbar]);
 
   React.useEffect(() => {
     if (open) {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader_CMR.tsx
@@ -223,10 +223,6 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
     return deleteLinode(linodeId);
   };
 
-  const handleEnableBackups = (linodeId: number) => {
-    history.push(`/linodes/${linodeId}/backup`);
-  };
-
   return (
     <React.Fragment>
       <HostMaintenance linodeStatus={linodeStatus} />
@@ -288,7 +284,6 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
         linodeId={backupsDialog.linodeID}
         open={backupsDialog.open}
         onClose={closeDialogs}
-        onSuccess={() => handleEnableBackups(backupsDialog.linodeID)}
       />
     </React.Fragment>
   );

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader_CMR.tsx
@@ -28,6 +28,7 @@ import DeleteDialog from '../../LinodesLanding/DeleteDialog';
 import RescueDialog from '../LinodeRescue/RescueDialog';
 import LinodeResize_CMR from '../LinodeResize/LinodeResize_CMR';
 import MigrateLinode from '../../MigrateLanding/MigrateLinode';
+import EnableBackupDialog from '../LinodeBackup/EnableBackupsDialog';
 import { useHistory } from 'react-router-dom';
 
 interface Props {
@@ -93,6 +94,11 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
     linodeID: 0
   });
 
+  const [backupsDialog, setBackupsDialog] = React.useState<DialogProps>({
+    open: false,
+    linodeID: 0
+  });
+
   const [tagDrawer, setTagDrawer] = React.useState<TagDrawerProps>({
     open: false,
     tags: []
@@ -150,6 +156,14 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
           open: true,
           linodeID
         }));
+        break;
+      case 'enable_backups':
+        setBackupsDialog(backupsDialog => ({
+          ...backupsDialog,
+          open: true,
+          linodeID
+        }));
+        break;
     }
   };
 
@@ -159,6 +173,7 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
     setResizeDialog(resizeDialog => ({ ...resizeDialog, open: false }));
     setMigrateDialog(migrateDialog => ({ ...migrateDialog, open: false }));
     setRescueDialog(rescueDialog => ({ ...rescueDialog, open: false }));
+    setBackupsDialog(backupsDialog => ({ ...backupsDialog, open: false }));
   };
 
   const closeTagDrawer = () => {
@@ -206,6 +221,10 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
   const handleDeleteLinode = (linodeId: number) => {
     history.push('/linodes');
     return deleteLinode(linodeId);
+  };
+
+  const handleEnableBackups = (linodeId: number) => {
+    history.push(`/linodes/${linodeId}/backup`);
   };
 
   return (
@@ -264,6 +283,12 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
         addTag={(newTag: string) => addTag(linode.id, newTag)}
         deleteTag={(tag: string) => deleteTag(linode.id, tag)}
         onClose={closeTagDrawer}
+      />
+      <EnableBackupDialog
+        linodeId={backupsDialog.linodeID}
+        open={backupsDialog.open}
+        onClose={closeDialogs}
+        onSuccess={() => handleEnableBackups(backupsDialog.linodeID)}
       />
     </React.Fragment>
   );

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu_CMR.tsx
@@ -190,10 +190,7 @@ export const LinodeActionMenu: React.FC<CombinedProps> = props => {
               title: 'Enable Backups',
               onClick: (e: React.MouseEvent<HTMLElement>) => {
                 sendLinodeActionMenuItemEvent('Enable Backups');
-                history.push({
-                  pathname: `/linodes/${linodeId}/backup`,
-                  state: { enableOnLoad: true }
-                });
+                openDialog('enable_backups', linodeId);
                 e.preventDefault();
                 e.stopPropagation();
               },

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -67,6 +67,7 @@ import styled, { StyleProps } from './LinodesLanding.styles';
 import ListLinodesEmptyState from './ListLinodesEmptyState';
 import ListView from './ListView';
 import ToggleBox from './ToggleBox';
+import EnableBackupsDialog from '../LinodesDetail/LinodeBackup/EnableBackupsDialog';
 import { ExtendedStatus, statusToPriority } from './utils';
 
 type FilterStatus = 'running' | 'busy' | 'offline' | 'all';
@@ -74,6 +75,7 @@ type FilterStatus = 'running' | 'busy' | 'offline' | 'all';
 interface State {
   powerDialogOpen: boolean;
   powerDialogAction?: Action;
+  enableBackupsDialogOpen: boolean;
   selectedLinodeConfigs?: Config[];
   selectedLinodeID?: number;
   selectedLinodeLabel?: string;
@@ -105,6 +107,7 @@ type CombinedProps = WithImages &
 
 export class ListLinodes extends React.Component<CombinedProps, State> {
   state: State = {
+    enableBackupsDialogOpen: false,
     powerDialogOpen: false,
     deleteDialogOpen: false,
     rescueDialogOpen: false,
@@ -175,6 +178,11 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
           rescueDialogOpen: true
         });
         break;
+      case 'enable_backups':
+        this.setState({
+          enableBackupsDialogOpen: true
+        });
+        break;
     }
     this.setState({
       selectedLinodeID: linodeID,
@@ -188,7 +196,8 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
       deleteDialogOpen: false,
       rescueDialogOpen: false,
       linodeResizeOpen: false,
-      linodeMigrateOpen: false
+      linodeMigrateOpen: false,
+      enableBackupsDialogOpen: false
     });
   };
 
@@ -201,6 +210,10 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
 
   setFilterStatus = (status: FilterStatus) => {
     this.setState({ filterStatus: status });
+  };
+
+  onBackupsEnableSuccess = () => {
+    this.props.history.push(`linodes/${this.state.selectedLinodeID}/backup`);
   };
 
   render() {
@@ -313,6 +326,12 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
             <RescueDialog
               open={this.state.rescueDialogOpen}
               onClose={this.closeDialogs}
+              linodeId={this.state.selectedLinodeID ?? -1}
+            />
+            <EnableBackupsDialog
+              open={this.state.enableBackupsDialogOpen}
+              onClose={this.closeDialogs}
+              onSuccess={this.onBackupsEnableSuccess}
               linodeId={this.state.selectedLinodeID ?? -1}
             />
           </>

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -212,10 +212,6 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
     this.setState({ filterStatus: status });
   };
 
-  onBackupsEnableSuccess = () => {
-    this.props.history.push(`linodes/${this.state.selectedLinodeID}/backup`);
-  };
-
   render() {
     const {
       imagesError,
@@ -331,7 +327,6 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
             <EnableBackupsDialog
               open={this.state.enableBackupsDialogOpen}
               onClose={this.closeDialogs}
-              onSuccess={this.onBackupsEnableSuccess}
               linodeId={this.state.selectedLinodeID ?? -1}
             />
           </>

--- a/packages/manager/src/features/linodes/types.ts
+++ b/packages/manager/src/features/linodes/types.ts
@@ -1,4 +1,9 @@
-export type DialogType = 'delete' | 'migrate' | 'resize' | 'rescue';
+export type DialogType =
+  | 'delete'
+  | 'enable_backups'
+  | 'migrate'
+  | 'resize'
+  | 'rescue';
 export type OpenDialog = (
   type: DialogType,
   linodeID: number,


### PR DESCRIPTION
## Description

As promised, un-break the Enable Backups action from the Linode action menu. I ended up removing the redirect to the /backup tab after enabling succeeds; there are so many places where the action menu can be found now that in some of them at least being redirected would be jarring. Additionally, we used to redirect to Linode Detail for many of the actions in the menu, but since we're not doing that anymore this would be the odd action out. Happy to add that back in if needed.

## Note to Reviewers

Please enable Linodes from all possible action menus (dashboard, detail header, grid view, list view)