### PR TITLE
Updating language to 'allowlist' and 'blocklist'

### DIFF
--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -67,7 +67,7 @@ export class App extends React.Component<CombinedProps, State> {
 
   componentDidMount() {
     /**
-     * Send pageviews unless blacklisted.
+     * Send pageviews unless blocklisted.
      */
     this.props.history.listen(({ pathname }) => {
       if ((window as any).ga) {

--- a/packages/manager/src/components/DownloadCSV/DownloadCSV.tsx
+++ b/packages/manager/src/components/DownloadCSV/DownloadCSV.tsx
@@ -67,7 +67,7 @@ export const cleanCSVData = (data: any): any => {
   /**
    * fairly confident this should be typecast as a string by now
    * basically, prefix the cell with : if the first character is a
-   * blacklisted math operator
+   * blocklisted math operator
    */
   if (`${data}`.charAt(0).match(/[-|+|=|*]/g)) {
     return `:${data}`;

--- a/packages/manager/src/features/Events/EventsLanding.tsx
+++ b/packages/manager/src/features/Events/EventsLanding.tsx
@@ -27,7 +27,7 @@ import { ApplicationState } from 'src/store';
 import { setDeletedEvents } from 'src/store/events/event.helpers';
 import { ExtendedEvent } from 'src/store/events/event.types';
 import areEntitiesLoading from 'src/store/selectors/entitiesLoading';
-import { removeBlacklistedEvents } from 'src/utilities/eventUtils';
+import { removeBlocklistedEvents } from 'src/utilities/eventUtils';
 
 import { filterUniqueEvents, shouldUpdateEvents } from './Event.helpers';
 import EventRow from './EventRow';
@@ -344,7 +344,7 @@ export const renderTableBody = (
   events?: Event[],
   emptyMessage = "You don't have any events on your account."
 ) => {
-  const filteredEvents = removeBlacklistedEvents(events, ['profile_update']);
+  const filteredEvents = removeBlocklistedEvents(events, ['profile_update']);
 
   if (loading) {
     return (

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRulesLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRulesLanding.tsx
@@ -263,7 +263,7 @@ const FirewallRulesLanding: React.FC<CombinedProps> = props => {
       </Prompt>
 
       <Typography variant="body1" className={classes.copy}>
-        Firewall rules act as a whitelist, allowing network traffic that meets
+        Firewall rules act as an allowlist, allowing network traffic that meets
         the rules’ parameters to pass through. Any traffic not explicitly
         permitted by a rule is blocked.
       </Typography>

--- a/packages/manager/src/features/Profile/AuthenticationSettings/AuthenticationSettings.test.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/AuthenticationSettings.test.tsx
@@ -10,12 +10,12 @@ import {
 
 afterEach(cleanup);
 
-const WHITELIST = 'whitelisting-form';
+const ALLOWLIST = 'allowlisting-form';
 
 const props: CombinedProps = {
   loading: false,
   authType: 'password',
-  ipWhitelisting: true,
+  ipAllowlisting: true,
   twoFactor: true,
   username: 'username',
   updateProfile: jest.fn()
@@ -29,27 +29,27 @@ describe('Authentication settings profile tab', () => {
     expect(getByTestId('authSettings'));
   });
 
-  it('should not render the whitelisting form when loading', () => {
+  it('should not render the allowlisting form when loading', () => {
     const { getByTestId, queryAllByTestId, rerender } = render(
       wrapWithTheme(<AuthenticationSettings {...props} />)
     );
-    getByTestId(WHITELIST);
+    getByTestId(ALLOWLIST);
     rerender(
       wrapWithTheme(<AuthenticationSettings {...props} loading={true} />)
     );
-    expect(queryAllByTestId(WHITELIST)).toHaveLength(0);
+    expect(queryAllByTestId(ALLOWLIST)).toHaveLength(0);
   });
 
-  it('should not render the whitelisting form if the user does not have this setting enabled', () => {
+  it('should not render the allowlisting form if the user does not have this setting enabled', () => {
     const { getByTestId, queryAllByTestId, rerender } = render(
       wrapWithTheme(<AuthenticationSettings {...props} />)
     );
-    getByTestId(WHITELIST);
+    getByTestId(ALLOWLIST);
     rerender(
       wrapWithTheme(
-        <AuthenticationSettings {...props} ipWhitelisting={false} />
+        <AuthenticationSettings {...props} ipAllowlisting={false} />
       )
     );
-    expect(queryAllByTestId(WHITELIST)).toHaveLength(0);
+    expect(queryAllByTestId(ALLOWLIST)).toHaveLength(0);
   });
 });

--- a/packages/manager/src/features/Profile/AuthenticationSettings/AuthenticationSettings.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/AuthenticationSettings.tsx
@@ -33,7 +33,7 @@ export const AuthenticationSettings: React.FC<CombinedProps> = props => {
   const {
     loading,
     authType,
-    ipWhitelisting,
+    ipAllowlisting,
     twoFactor,
     username,
     updateProfile
@@ -48,8 +48,8 @@ export const AuthenticationSettings: React.FC<CombinedProps> = props => {
   const clearState = () => {
     setSuccess(undefined);
   };
-  const onWhitelistingDisable = () => {
-    setSuccess('IP whitelisting disabled. This feature cannot be re-enabled.');
+  const onAllowlistingDisable = () => {
+    setSuccess('IP allowlisting disabled. This feature cannot be re-enabled.');
   };
 
   const tabs = [
@@ -71,13 +71,13 @@ export const AuthenticationSettings: React.FC<CombinedProps> = props => {
           ) : (
             <TrustedDevices disabled={thirdPartyEnabled} />
           )}
-          {ipWhitelisting && (
+          {ipAllowlisting && (
             <SecuritySettings
               updateProfile={updateProfile}
-              onSuccess={onWhitelistingDisable}
+              onSuccess={onAllowlistingDisable}
               updateProfileError={props.profileUpdateError}
-              ipWhitelistingEnabled={ipWhitelisting}
-              data-qa-whitelisting-form
+              ipAllowlistingEnabled={ipAllowlisting}
+              data-qa-allowlisting-form
             />
           )}
         </React.Fragment>
@@ -117,7 +117,7 @@ const docs = [AccountsAndPasswords, SecurityControls];
 interface StateProps {
   loading: boolean;
   authType: TPAProvider;
-  ipWhitelisting: boolean;
+  ipAllowlisting: boolean;
   twoFactor?: boolean;
   username?: string;
   profileUpdateError?: APIError[];
@@ -129,7 +129,7 @@ const mapStateToProps: MapState<StateProps, {}> = state => {
   return {
     loading: profile.loading,
     authType: profile?.data?.authentication_type ?? 'password',
-    ipWhitelisting: profile?.data?.ip_whitelist_enabled ?? false,
+    ipAllowlisting: profile?.data?.ip_whitelist_enabled ?? false,
     twoFactor: profile?.data?.two_factor_auth,
     username: profile?.data?.username,
     profileUpdateError: profile.error?.update

--- a/packages/manager/src/features/Profile/AuthenticationSettings/SecuritySettings.test.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/SecuritySettings.test.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import { SecuritySettings } from './SecuritySettings';
 
-describe('Security settings (IP whitelisting) form', () => {
+describe('Security settings (IP allowlisting) form', () => {
   const onSuccess = jest.fn();
   const updateProfile = jest.fn();
 
@@ -13,7 +13,7 @@ describe('Security settings (IP whitelisting) form', () => {
         root: '',
         title: ''
       }}
-      ipWhitelistingEnabled={false}
+      ipAllowlistingEnabled={false}
       onSuccess={onSuccess}
       updateProfile={updateProfile}
     />

--- a/packages/manager/src/features/Profile/AuthenticationSettings/SecuritySettings.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/SecuritySettings.tsx
@@ -34,7 +34,7 @@ interface Props {
   onSuccess: () => void;
   updateProfile: (v: Partial<Profile>) => Promise<Profile>;
   updateProfileError?: APIError[];
-  ipWhitelistingEnabled: boolean;
+  ipAllowlistingEnabled: boolean;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -52,14 +52,14 @@ export class SecuritySettings extends React.Component<CombinedProps, {}> {
 
   onSubmit = () => {
     const { onSuccess } = this.props;
-    if (this.props.ipWhitelistingEnabled) {
+    if (this.props.ipAllowlistingEnabled) {
       return;
     }
 
     // This feature can only be disabled.
     this.props
       .updateProfile({
-        ip_whitelist_enabled: !this.props.ipWhitelistingEnabled
+        ip_whitelist_enabled: !this.props.ipAllowlistingEnabled
       })
       .then(() => {
         onSuccess();
@@ -71,28 +71,28 @@ export class SecuritySettings extends React.Component<CombinedProps, {}> {
   };
 
   render() {
-    const { classes, updateProfileError, ipWhitelistingEnabled } = this.props;
+    const { classes, updateProfileError, ipAllowlistingEnabled } = this.props;
     const hasErrorFor = getAPIErrorFor({}, updateProfileError);
     const generalError = hasErrorFor('none');
 
     return (
       <React.Fragment>
-        <Paper className={classes.root} data-testid="whitelisting-form">
+        <Paper className={classes.root} data-testid="allowlisting-form">
           <Typography variant="h2" className={classes.title}>
-            IP Whitelisting (Legacy)
+            IP Allowlisting (Legacy)
           </Typography>
           {generalError && <Notice error text={generalError} />}
           <Typography variant="body1" data-qa-copy>
-            Logins for your user will only be allowed from whitelisted IPs. This
+            Logins for your user will only be allowed from allowlisted IPs. This
             setting is currently deprecated, and cannot be enabled. If you
             disable this setting, you will not be able to re-enable it.
           </Typography>
           <FormControl fullWidth>
             <FormControlLabel
-              label={ipWhitelistingEnabled ? 'Enabled' : 'Disabled'}
+              label={ipAllowlistingEnabled ? 'Enabled' : 'Disabled'}
               control={
                 <Toggle
-                  checked={ipWhitelistingEnabled}
+                  checked={ipAllowlistingEnabled}
                   onChange={this.onSubmit}
                 />
               }

--- a/packages/manager/src/features/TopMenu/UserEventsMenu/UserEventsMenu.tsx
+++ b/packages/manager/src/features/TopMenu/UserEventsMenu/UserEventsMenu.tsx
@@ -17,7 +17,7 @@ import {
 import { getNumUnseenEvents } from 'src/store/events/event.helpers';
 import { markAllSeen as _markAllSeen } from 'src/store/events/event.request';
 import { MapState, ThunkDispatch } from 'src/store/types';
-import { removeBlacklistedEvents } from 'src/utilities/eventUtils';
+import { removeBlocklistedEvents } from 'src/utilities/eventUtils';
 import UserEventsButton from './UserEventsButton';
 import UserEventsList from './UserEventsList';
 
@@ -81,7 +81,7 @@ export class UserEventsMenu extends React.Component<CombinedProps, State> {
       history: { push }
     } = this.props;
 
-    const filteredEvents = removeBlacklistedEvents(events, ['profile_update']);
+    const filteredEvents = removeBlocklistedEvents(events, ['profile_update']);
     const unseenCount = getNumUnseenEvents(filteredEvents);
 
     return (

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.tsx
@@ -19,7 +19,7 @@ import {
   shouldUpdateEvents
 } from 'src/features/Events/Event.helpers';
 import { ExtendedEvent } from 'src/store/events/event.types';
-import { removeBlacklistedEvents } from 'src/utilities/eventUtils';
+import { removeBlocklistedEvents } from 'src/utilities/eventUtils';
 
 type ClassNames = 'root' | 'header' | 'viewMore';
 
@@ -94,9 +94,9 @@ export class ActivitySummary extends React.Component<CombinedProps, State> {
             return (
               /** all events from Redux will have this flag as a boolean value */
               !eachEvent._initial &&
-              (eachEvent.entity &&
+              eachEvent.entity &&
                 eachEvent.entity.id === this.props.linodeId &&
-                eachEvent.entity.type === 'linode')
+                eachEvent.entity.type === 'linode'
             );
           }),
           /*
@@ -135,7 +135,7 @@ export class ActivitySummary extends React.Component<CombinedProps, State> {
     const { classes, linodeId } = this.props;
     const { events, error, loading } = this.state;
 
-    const filteredEvents = removeBlacklistedEvents(events);
+    const filteredEvents = removeBlocklistedEvents(events);
 
     return (
       <>

--- a/packages/manager/src/utilities/eventUtils.ts
+++ b/packages/manager/src/utilities/eventUtils.ts
@@ -1,12 +1,12 @@
 import { Event, EventAction } from '@linode/api-v4/lib/account';
 
 // Removes events we don't want to display.
-export const removeBlacklistedEvents = (
+export const removeBlocklistedEvents = (
   events: Event[] = [],
-  blacklist: string[] = []
+  blocklist: string[] = []
 ) => {
-  const _blacklist = [...blackListedEvents, ...blacklist];
-  return events.filter(eachEvent => !_blacklist.includes(eachEvent.action));
+  const _blocklist = [...blockListedEvents, ...blocklist];
+  return events.filter(eachEvent => !_blocklist.includes(eachEvent.action));
 };
 
 // We don't want to display these events because they precede similar events.
@@ -14,7 +14,7 @@ export const removeBlacklistedEvents = (
 // get a `linode_mutate_create` event from the API. Moments later, we get back
 // ANOTHER event, `linode_mutate`, with a status of `scheduled`. That's the event
 // we want to display, because it will be updated via other events with the same ID.
-const blackListedEvents: EventAction[] = [
+const blockListedEvents: EventAction[] = [
   'linode_mutate_create', // This event occurs when an upgrade is first initiated.
   'linode_resize_create', // This event occurs when a resize is first initiated.
   'linode_migrate_datacenter_create' // This event occurs when a cross DC migration is first initiated.

--- a/packages/manager/src/utilities/sanitize-html/sanitize-html.test.ts
+++ b/packages/manager/src/utilities/sanitize-html/sanitize-html.test.ts
@@ -1,12 +1,12 @@
 import { isURLValid, sanitizeHTML } from './sanitizeHTML';
 
 describe('sanitizeHTML', () => {
-  it('should escape non-whitelisted tags', () => {
+  it('should escape non-allowlisted tags', () => {
     // safe
     expect(sanitizeHTML('<script>')).not.toContain('<script>');
   });
 
-  it('should strip non-whitelisted attributes', () => {
+  it('should strip non-allowlisted attributes', () => {
     // safe
     expect(sanitizeHTML('<a onmouseover>')).not.toContain('onmouseover');
   });


### PR DESCRIPTION
## Description

The original ask was for the Firewalls feature, but I went ahead and updated our terminology for user-facing and CM-controlled code for whitelist/blacklist to be allowlist/blocklist based on the guide here: https://tools.ietf.org/id/draft-knodel-terminology-00.html#:~:text=Replace%20the%20oppressive%20term%20%E2%80%9Cblacklist,suggested%20alternatives%20at%20Section%201.2 

## Type of Change
- Non breaking change ('update')