### PR TITLE
PIE-1578: Update SupportTicketDrawer.tsx to enforce 64 character limit in text field on Ticket Summary

### DIFF
--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
@@ -475,6 +475,7 @@ export const SupportTicketDrawer: React.FC<CombinedProps> = props => {
             required
             value={summary}
             onChange={handleSummaryInputChange}
+            inputProps={{ maxLength: 64 }}
             errorText={summaryError}
             data-qa-ticket-summary
           />


### PR DESCRIPTION
## Description

Added inputProps in the "Ticket Title" TextField to restrict character entry to 64 characters. This stops the user from entering more than 64 characters (which is currently disallowed; they will receive an error if they try to submit a title of longer length).

## Type of Change
- Non breaking change ('update', 'change')