### PR TITLE
M3-4310 Flavor text in LinodeNews banner

### DIFF
--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -8,6 +8,11 @@ interface TaxBanner {
 
 type OneClickApp = Record<string, string>;
 
+interface Changelog {
+  version: string;
+  message: string;
+}
+
 export interface Flags {
   promos: boolean;
   vatBanner: TaxBanner;
@@ -20,6 +25,7 @@ export interface Flags {
   cmr: boolean;
   mainContentBanner: MainContentBanner;
   passwordValidation: PasswordValidationType;
+  changelog: Changelog;
 }
 
 type PromotionalOfferFeature =

--- a/packages/manager/src/features/Dashboard_CMR/LinodeNews.tsx
+++ b/packages/manager/src/features/Dashboard_CMR/LinodeNews.tsx
@@ -4,11 +4,12 @@ import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Link from 'src/components/Link';
+import useFlags from 'src/hooks/useFlags';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
     padding: theme.spacing(2),
-    marginTop: theme.spacing(5),
+    marginBottom: theme.spacing(2),
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',
@@ -23,6 +24,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 export const LinodeNews: React.FC<{}> = _ => {
   const classes = useStyles();
+  const flags = useFlags();
   const { VERSION } = process.env || null;
   if (!VERSION) {
     return null;
@@ -33,6 +35,10 @@ export const LinodeNews: React.FC<{}> = _ => {
         <Logo className={classes.logo} />
         <Typography style={{ fontSize: '1rem' }}>
           Cloud Manager v{VERSION} has been released! {` `}
+          {/** If changelog text for this version is present in LaunchDarkly, display it here. */}
+          {flags.changelog?.version === VERSION
+            ? `${flags.changelog.message} `
+            : null}
           <Link
             to={`https://github.com/linode/manager/releases/tag/linode-manager@v${VERSION}`}
           >


### PR DESCRIPTION
Designs for the link to the most recent Cloud changelog on the dashboard
included possible "flavor text" summarizing the release changes. Decided
that the best way to do this is through LaunchDarkly. If the version
of the changelog flag matches the currently deployed version, the notes
are shown. If the flag is off, or the versions don't match, nothing
is displayed. This way, the display is safe: if we forget to write
a message for a given release (which seems very likely), nothing will
go wrong and no incorrect information will be displayed.

The downside of this is that we're once again relying on LD as a
pseudo CMS. Especially given the cost of the service, we shouldn't
be increasing our reliance on it for non-flag-related things.

## Note

Play around with the version and text in the LD interface to see how it will work. Long messages pose a problem, but the messages in the design were all short.