### PR TITLE
Change: Make Linode News banner dismissible

### DIFF
--- a/packages/manager/src/features/Dashboard_CMR/LinodeNews.tsx
+++ b/packages/manager/src/features/Dashboard_CMR/LinodeNews.tsx
@@ -37,10 +37,10 @@ export const LinodeNews: React.FC<{}> = _ => {
    * Rather than wait for the request to clear, when the banner is dismissed
    * immediately hide it.
    */
-  const [optimisticallyHidden, optimisticallyHide] = React.useState(false);
+  const [optimisticallyHidden, setOptimisticallyHidden] = React.useState(false);
 
   const handleClick = () => {
-    optimisticallyHide(true);
+    setOptimisticallyHidden(true);
     updatePreferences({ linode_news_banner_dismissed: true });
   };
 

--- a/packages/manager/src/features/Dashboard_CMR/LinodeNews.tsx
+++ b/packages/manager/src/features/Dashboard_CMR/LinodeNews.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import Logo from 'src/assets/logo/logo.svg';
+import Close from '@material-ui/icons/Close';
 import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Link from 'src/components/Link';
 import useFlags from 'src/hooks/useFlags';
+import usePreferences from 'src/hooks/usePreferences';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -19,16 +21,37 @@ const useStyles = makeStyles((theme: Theme) => ({
     height: 30,
     width: 30,
     paddingRight: theme.spacing()
+  },
+  icon: {
+    ...theme.applyLinkStyles
   }
 }));
 
 export const LinodeNews: React.FC<{}> = _ => {
   const classes = useStyles();
   const flags = useFlags();
+  const { preferences, updatePreferences } = usePreferences();
   const { VERSION } = process.env || null;
-  if (!VERSION) {
+
+  /**
+   * Rather than wait for the request to clear, when the banner is dismissed
+   * immediately hide it.
+   */
+  const [optimisticallyHidden, optimisticallyHide] = React.useState(false);
+
+  const handleClick = () => {
+    optimisticallyHide(true);
+    updatePreferences({ linode_news_banner_dismissed: true });
+  };
+
+  if (
+    !VERSION ||
+    preferences?.linode_news_banner_dismissed ||
+    optimisticallyHidden
+  ) {
     return null;
   }
+
   return (
     <Paper className={classes.root}>
       <div className="flexCenter">
@@ -47,6 +70,9 @@ export const LinodeNews: React.FC<{}> = _ => {
           for details.
         </Typography>
       </div>
+      <button onClick={handleClick} className={classes.icon}>
+        <Close />
+      </button>
     </Paper>
   );
 };

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -129,7 +129,6 @@ const withStackScriptBase = (options: WithStackScriptBaseOptions) => (
 
     componentDidMount() {
       this.mounted = true;
-
       // If the URL contains a QS param called "query" treat it as a filter.
       const query = getQueryParam(this.props.location.search, 'query');
       if (query) {
@@ -579,14 +578,13 @@ const withStackScriptBase = (options: WithStackScriptBaseOptions) => (
                * Otherwise, try to lazy load some more dang stackscripts
                */}
               {!getMoreStackScriptsFailed ? (
-                <Waypoint onEnter={this.getNext}>
+                <Waypoint onEnter={() => this.getNext}>
                   {/*
                    * The reason for this empty div is that there was some wonkiness when
                    * scrolling to the waypoint with trackpads. For some reason, the Waypoint
                    * would never be scrolled into view no matter how much you scrolled on the
                    * trackpad. Especially finicky at zoomed in browser sizes
                    */}
-                  <div style={{ minHeight: '150px' }} />
                 </Waypoint>
               ) : (
                 <Button

--- a/packages/manager/src/store/preferences/preferences.actions.ts
+++ b/packages/manager/src/store/preferences/preferences.actions.ts
@@ -26,6 +26,7 @@ export interface UserPreferences {
   sortKeys?: Partial<Record<SortKey, OrderSet>>;
   main_content_banner_dismissal?: Record<string, boolean>;
   is_large_account?: boolean;
+  linode_news_banner_dismissed?: boolean;
 }
 
 export const handleGetPreferences = actionCreator.async<


### PR DESCRIPTION
## Description

Use preferences to make the Linode News banner dismissible. Needs to be rebased after #6748 is merged.