### PR TITLE
Hotfix/longview plans

### DIFF
--- a/packages/api-v4/src/longview/longview.ts
+++ b/packages/api-v4/src/longview/longview.ts
@@ -11,6 +11,7 @@ import { longviewClientCreate } from './longview.schema';
 import {
   LongviewClient,
   LongviewSubscription,
+  LongviewSubscriptionPayload,
   ActiveLongviewPlan
 } from './types';
 
@@ -64,4 +65,18 @@ export const getActiveLongviewPlan = () =>
   Request<ActiveLongviewPlan>(
     setURL(`${API_ROOT}/longview/plan`),
     setMethod('GET')
+  ).then(response => response.data);
+
+/**
+ * updateActiveLongviewPlan
+ *
+ * Change this account's Longview subscription. To move from a
+ * paid Longview Pro plan back to the free plan, submit an empty
+ * object.
+ */
+export const updateActiveLongviewPlan = (plan: LongviewSubscriptionPayload) =>
+  Request<ActiveLongviewPlan>(
+    setURL(`${API_ROOT}/longview/plan`),
+    setData(plan),
+    setMethod('PUT')
   ).then(response => response.data);

--- a/packages/api-v4/src/longview/types.ts
+++ b/packages/api-v4/src/longview/types.ts
@@ -18,6 +18,10 @@ export interface LongviewSubscription {
   };
 }
 
+export interface LongviewSubscriptionPayload {
+  longview_subscription?: string;
+}
+
 /** If the user is on the free plan ActiveLongviewPlan is empty
  */
 export type ActiveLongviewPlan = LongviewSubscription | {};

--- a/packages/manager/src/factories/longviewSubscription.ts
+++ b/packages/manager/src/factories/longviewSubscription.ts
@@ -1,5 +1,8 @@
 import * as Factory from 'factory.ts';
-import { LongviewSubscription } from '@linode/api-v4/lib/longview/types';
+import {
+  ActiveLongviewPlan,
+  LongviewSubscription
+} from '@linode/api-v4/lib/longview/types';
 
 export const longviewSubscriptionFactory = Factory.Sync.makeFactory<
   LongviewSubscription
@@ -11,4 +14,16 @@ export const longviewSubscriptionFactory = Factory.Sync.makeFactory<
     hourly: 0.03,
     monthly: 200
   }
+});
+
+export const longviewActivePlanFactory = Factory.Sync.makeFactory<
+  ActiveLongviewPlan
+>({
+  id: 'longview-3',
+  label: 'Longview Pro 3 pack',
+  price: {
+    hourly: 0.03,
+    monthly: 20
+  },
+  clients_included: 100
 });

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewPlans.test.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewPlans.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, within } from '@testing-library/react';
+import { act, cleanup, within } from '@testing-library/react';
 import * as React from 'react';
 import { accountSettings } from 'src/__data__/account';
 import { withDocumentTitleProvider } from 'src/components/DocumentTitle';
@@ -82,21 +82,14 @@ describe('LongviewPlans', () => {
   });
 
   it('highlights the LV subscription currently on the account', async () => {
-    const currentLVSub = 'longview-3';
+    await act(async () => {
+      /** @todo fix this test, either by upgrading rtl or passing activeSub as prop */
+      const { findByTestId } = renderWithTheme(
+        <LongviewPlans accountSettings={accountSettings} {...props} />
+      );
 
-    const { getByTestId } = renderWithTheme(
-      <LongviewPlans
-        accountSettings={{
-          ...accountSettings,
-          longview_subscription: currentLVSub
-        }}
-        {...props}
-      />
-    );
-
-    within(getByTestId(`lv-sub-table-row-${currentLVSub}`)).getByText(
-      'Current Plan'
-    );
+      await findByTestId('current-plan-longview-3');
+    });
   });
 
   it('displays a notice if the user does not have permissions to modify', () => {

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewPlans.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewPlans.tsx
@@ -451,7 +451,7 @@ export const LongviewSubscriptionRow: React.FC<LongviewSubscriptionRowProps> = R
             {plan}
             {currentSubscriptionOnAccount === id && (
               <Chip
-                data-testid="current-plan"
+                data-testid={`current-plan-${id}`}
                 label="Current Plan"
                 className={styles.chip}
               />

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewPlans.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewPlans.tsx
@@ -1,6 +1,9 @@
 import * as classnames from 'classnames';
-import { AccountSettings } from '@linode/api-v4/lib/account';
-import { LongviewSubscription } from '@linode/api-v4/lib/longview/types';
+import {
+  getActiveLongviewPlan,
+  updateActiveLongviewPlan,
+  LongviewSubscription
+} from '@linode/api-v4/lib/longview';
 import { APIError } from '@linode/api-v4/lib/types';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -129,8 +132,8 @@ const useStyles = makeStyles((theme: Theme) => {
 });
 
 // If an account has the "free" Longview plan,
-// accountSettings.longview_subscription will be `null`. We'd rather use
-// a string identifer in this component to be keep track of the "free" plan, so
+// longview_subscription will be {}. We'd rather use
+// a string identifer in this component to keep track of the "free" plan, so
 // we'll create a fake ID for it.
 export const LONGVIEW_FREE_ID = 'longview-free';
 
@@ -157,26 +160,36 @@ export const LongviewPlans: React.FC<CombinedProps> = props => {
   const {
     accountSettings,
     subscriptionRequestHook: subscriptions,
-    updateAccountSettings,
-    mayUserViewAccountSettings,
     mayUserModifyLVSubscription
   } = props;
   const styles = useStyles();
 
-  const currentSubscriptionOnAccount = getCurrentSubscriptionOnAccount(
-    mayUserViewAccountSettings,
-    accountSettings
-  );
+  const [currentSubscription, setCurrentSubscription] = React.useState<
+    string | undefined
+  >(undefined);
 
   const [selectedSub, setSelectedSub] = React.useState<string>(
-    currentSubscriptionOnAccount || ''
+    currentSubscription || ''
   );
   const [updateLoading, setUpdateLoading] = React.useState<boolean>(false);
   const [updateErrorMsg, setUpdateErrorMsg] = React.useState<string>('');
+  const [updateSuccessMsg, setUpdateSuccessMsg] = React.useState<string>('');
+
+  React.useEffect(() => {
+    getActiveLongviewPlan()
+      .then((plan: LongviewSubscription) => {
+        const activeID = plan.id ?? LONGVIEW_FREE_ID;
+        setCurrentSubscription(activeID);
+        setSelectedSub(activeID);
+      })
+      .catch(_ => {
+        setUpdateErrorMsg('Error loading your current Longview plan');
+      });
+  }, []);
 
   const onSubmit = () => {
     // No need to do anything if the user hasn't selected a different plan.
-    if (selectedSub === currentSubscriptionOnAccount) {
+    if (selectedSub === currentSubscription) {
       return;
     }
 
@@ -184,21 +197,17 @@ export const LongviewPlans: React.FC<CombinedProps> = props => {
     setUpdateErrorMsg('');
 
     // If the user has selected the free plan, which need to make a switch for
-    // `null`, which is what the API wants.
-    const newSubscriptionID =
-      selectedSub === LONGVIEW_FREE_ID ? null : selectedSub;
+    // {}, which is what the API wants.
+    const payload =
+      selectedSub === LONGVIEW_FREE_ID
+        ? {}
+        : { longview_subscription: selectedSub };
 
-    updateAccountSettings({
-      longview_subscription: newSubscriptionID
-    })
+    updateActiveLongviewPlan(payload)
       .then(_ => {
         setUpdateLoading(false);
-        // If the user has selected the free plan, the response to the PUT
-        // request will have the old longview_subscription. I don't know why.
-        // We need to manually update the store in this case.
-        if (selectedSub === LONGVIEW_FREE_ID) {
-          props.updateAccountSettingsInStore({ longview_subscription: null });
-        }
+        setUpdateSuccessMsg('Plan updated successfully.');
+        setCurrentSubscription(selectedSub);
       })
       .catch(err => {
         const normalizedError = getAPIErrorOrDefault(
@@ -220,7 +229,7 @@ export const LongviewPlans: React.FC<CombinedProps> = props => {
 
   const isButtonDisabled =
     Boolean(subscriptions.error) ||
-    currentSubscriptionOnAccount === selectedSub ||
+    currentSubscription === selectedSub ||
     !mayUserModifyLVSubscription;
 
   return (
@@ -240,6 +249,7 @@ export const LongviewPlans: React.FC<CombinedProps> = props => {
             text="You don't have permissions to change the Longview plan. Please contact an account administrator for details."
           />
         )}
+        {updateSuccessMsg && <Notice success text={updateSuccessMsg} />}
         {isManaged && <Notice success text={managedText} />}
         {!isManaged && (
           <>
@@ -264,7 +274,7 @@ export const LongviewPlans: React.FC<CombinedProps> = props => {
                   subscriptions={subscriptions.data}
                   onRadioSelect={onRadioSelect}
                   onRowSelect={setSelectedSub}
-                  currentSubscriptionOnAccount={currentSubscriptionOnAccount}
+                  currentSubscriptionOnAccount={currentSubscription}
                   selectedSub={selectedSub}
                   disabled={!mayUserModifyLVSubscription}
                 />
@@ -482,22 +492,4 @@ export const LongviewSubscriptionRow: React.FC<LongviewSubscriptionRowProps> = R
 // =============================================================================
 export const formatPrice = (price: LongviewSubscription['price']): string => {
   return `$${price.hourly.toFixed(2)}/hr ($${price.monthly}/mo)`;
-};
-
-// Return the Longview subscription on the account, or the default if
-// accountSettings is undefined or if the account has the "free" plan enabled
-// (in which case accountSettings.longview_subscription will be `null`).
-export const getCurrentSubscriptionOnAccount = (
-  mayUserViewAccountSettings: boolean,
-  accountSettings?: AccountSettings,
-  defaultSubscriptionID = LONGVIEW_FREE_ID
-) => {
-  if (!mayUserViewAccountSettings) {
-    return undefined;
-  }
-
-  return accountSettings &&
-    typeof accountSettings.longview_subscription === 'string'
-    ? accountSettings.longview_subscription
-    : defaultSubscriptionID;
 };

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewPlans.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewPlans.tsx
@@ -195,6 +195,7 @@ export const LongviewPlans: React.FC<CombinedProps> = props => {
 
     setUpdateLoading(true);
     setUpdateErrorMsg('');
+    setUpdateSuccessMsg('');
 
     // If the user has selected the free plan, which need to make a switch for
     // {}, which is what the API wants.

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -16,6 +16,7 @@ import {
   linodeIPFactory,
   linodeStatsFactory,
   linodeTransferFactory,
+  longviewActivePlanFactory,
   nodeBalancerFactory,
   profileFactory,
   supportTicketFactory,
@@ -162,5 +163,12 @@ export const handlers = [
   rest.get('*/support/tickets', (req, res, ctx) => {
     const tickets = supportTicketFactory.buildList(15, { status: 'open' });
     return res(ctx.json(makeResourcePage(tickets)));
+  }),
+  rest.put('*/longview/plan', (req, res, ctx) => {
+    return res(ctx.json({}));
+  }),
+  rest.get('*/longview/plan', (req, res, ctx) => {
+    const plan = longviewActivePlanFactory.build();
+    return res(ctx.json(plan));
   })
 ];


### PR DESCRIPTION
## Description

Fix use of deprecated API endpoint for changing an account's Longview plan.

While I was in there, did the same thing so that our long-broken-for-restricted-users time select in LongviewDetail.

Since we're reading this response value in 3 places, it should be either put in Redux or lifted to the Longview root level. Will open a ticket.

## Note

To test: go to longview/plans and switch your plan a few times. Try to test error states as well. If you have a Longview client, go to its detail view and make sure that the time select dropdown has the correct options (30 minutes/24 hours if you're on the free plan, a bunch of much longer options if you're on pro)