### PR TITLE
Hotfix/StackScript linking & create from setup

### DIFF
--- a/packages/manager/src/features/StackScripts/stackScriptUtils.ts
+++ b/packages/manager/src/features/StackScripts/stackScriptUtils.ts
@@ -231,13 +231,13 @@ export const getStackScriptUrl = (
     case currentUser:
       // My StackScripts
       // @todo: handle account stackscripts
-      type = 'My%20Images';
-      subtype = 'Account%20StackScripts';
+      type = 'StackScripts';
+      subtype = 'Account';
       break;
     default:
       // Community StackScripts
-      type = 'One-Click';
-      subtype = 'Community%20StackScripts';
+      type = 'StackScripts';
+      subtype = 'Community';
   }
   return `/linodes/create?type=${type}&subtype=${subtype}&stackScriptID=${id}`;
 };

--- a/packages/manager/src/store/linodeCreate/linodeCreate.reducer.ts
+++ b/packages/manager/src/store/linodeCreate/linodeCreate.reducer.ts
@@ -28,7 +28,7 @@ export const getInitialType = (): CreateTypes => {
        * we have a subtype in the query string so now we need to deduce what
        * endpoint we should be POSTing to based on what is in the query params
        */
-      if (normalizedSubtype.includes('stackscript')) {
+      if (normalizedSubtype.includes('community' || 'account')) {
         return 'fromStackScript';
       } else if (normalizedSubtype.includes('clone')) {
         return 'fromLinode';


### PR DESCRIPTION
## Description

To test this bug, navigate to `/StackScripts`, select a StackScript and click 'deploy new Linode' (either from button or action menu). Notice you are redirected to marketplace instead of StackScript selection. 

In this PR, that link is adjusted to go straight to StackScript tab with the proper StackScript selected. There was an additional side effect once this was fixed, which was StackScripts were still considered `fromApp` for the docs logic, and so a long list of docs would show up (those should only be present for one-click apps). This is fixed here as well.

## Type of Change
- Bug fix ('fix')
