### PR TITLE
HOTFIX: NodeBalancers- defaulting tabindex to 0 if path doesn't match tab routeName

### DIFF
--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
@@ -280,8 +280,6 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
       updateTags: this.updateTags
     };
 
-    const findTabIndex = this.tabs.findIndex(tab => matches(tab.routeName));
-
     return (
       <NodeBalancerProvider value={p}>
         <React.Fragment>
@@ -289,14 +287,7 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
             <Grid item>
               <Breadcrumb
                 pathname={location.pathname}
-                labelOptions={{ linkTo: this.getLabelLink() }}
-                crumbOverrides={[
-                  {
-                    position: 1,
-                    label: 'NodeBalancers'
-                  }
-                ]}
-                removeCrumbX={2}
+                firstAndLastOnly
                 onEditHandlers={{
                   editableTextTitle: nodeBalancerLabel,
                   onEdit: this.updateLabel,
@@ -307,7 +298,12 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
             </Grid>
           </Grid>
           {errorMap.none && <Notice error text={errorMap.none} />}
-          <Tabs defaultIndex={findTabIndex}>
+          <Tabs
+            defaultIndex={Math.max(
+              this.tabs.findIndex(tab => matches(tab.routeName)),
+              0
+            )}
+          >
             <TabLinkList tabs={this.tabs} />
 
             <TabPanels>


### PR DESCRIPTION
## Description

NodeBalancer tabs were expecting an exact match in the routeName to render any specific tab's content. This PR updates the index to check for routeName matching but default to 0 (or first tab) if the route doesn't match exactly. Also updated the breadcrumb props as a consequence.

## Type of Change
- Bug fix ('fix')

## Note to Reviewers

Please test the various places one can link to a NodeBalancer detail page- dashboard, landing, etc.
