### PR TITLE
M3 fix routing

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.tsx
@@ -5,7 +5,7 @@ import { withSnackbar, WithSnackbarProps } from 'notistack';
 import { assoc, clamp, pathOr } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { RouteComponentProps } from 'react-router-dom';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
 import ActionsPanel from 'src/components/ActionsPanel';
 import AddNewLink from 'src/components/AddNewLink';
@@ -223,23 +223,19 @@ export class LinodeRescue extends React.Component<CombinedProps, State> {
 
     if (diskError) {
       return (
-        <React.Fragment>
-          <div>
-            <DocumentTitleSegment segment={`${linodeLabel} - Rescue`} />
-            <ErrorState errorText="There was an error retrieving Disks information." />
-          </div>
-        </React.Fragment>
+        <div>
+          <DocumentTitleSegment segment={`${linodeLabel} - Rescue`} />
+          <ErrorState errorText="There was an error retrieving Disks information." />
+        </div>
       );
     }
 
     if (volumesError) {
       return (
-        <React.Fragment>
-          <div>
-            <DocumentTitleSegment segment={`${linodeLabel} - Rescue`} />
-            <ErrorState errorText="There was an error retrieving Volumes information." />
-          </div>
-        </React.Fragment>
+        <div>
+          <DocumentTitleSegment segment={`${linodeLabel} - Rescue`} />
+          <ErrorState errorText="There was an error retrieving Volumes information." />
+        </div>
       );
     }
 
@@ -317,6 +313,7 @@ export default compose<CombinedProps, {}>(
   SectionErrorBoundary,
   styled,
   withSnackbar,
+  withRouter,
   withVolumes(
     (
       ownProps,

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation.tsx
@@ -80,13 +80,25 @@ const LinodesDetailNavigation: React.FC<CombinedProps> = props => {
     }
   ];
 
+  const getIndex = React.useCallback(() => {
+    return Math.max(
+      tabs.findIndex(tab => matches(tab.routeName)),
+      0
+    );
+  }, [tabs]);
+
+  const [idx, setIndex] = React.useState(0);
+
+  React.useEffect(() => {
+    setIndex(getIndex());
+  }, [props.match, tabs, getIndex]);
+
+  const navToURL = (index: number) => {
+    props.history.push(tabs[index].routeName);
+  };
+
   return (
-    <Tabs
-      defaultIndex={Math.max(
-        tabs.findIndex(tab => matches(tab.routeName)),
-        0
-      )}
-    >
+    <Tabs index={idx} onChange={navToURL}>
       <TabLinkList tabs={tabs} />
 
       <React.Suspense fallback={<SuspenseLoader />}>


### PR DESCRIPTION
## Description

This "fixes" the routing, in the sense that it keeps the url and the active tab in sync. There is a cost, navigation is now _very_ slow. I don't think this is necessary for the hotfix, we can take more time to find a better approach.

## Note to Reviewers

On non-CMR Linode Detail, tab through the sections. The url should update as you tab. history.pushes (such as when you rescue a Linode) should work as well. All this will happen slowly.