### PR TITLE
Hotfix: App & Stackscript Creation bug

### DIFF
--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -2,38 +2,69 @@ import { Image } from '@linode/api-v4/lib/images';
 import { UserDefinedField } from '@linode/api-v4/lib/stackscripts';
 import { assocPath } from 'ramda';
 import * as React from 'react';
+import { connect, MapStateToProps } from 'react-redux';
+import { compose } from 'recompose';
+
 import Paper from 'src/components/core/Paper';
-import { makeStyles, Theme } from 'src/components/core/styles';
+import {
+  createStyles,
+  Theme,
+  withStyles,
+  WithStyles
+} from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
+import CreateLinodeDisabled from 'src/components/CreateLinodeDisabled';
+
+import setDocs, { SetDocsProps } from 'src/components/DocsSidebar/setDocs';
 import Grid from 'src/components/Grid';
 import ImageSelect from 'src/components/ImageSelect';
-import Notice from 'src/components/Notice';
+
+import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 import { AppDetailDrawer } from 'src/features/OneClickApps';
 import UserDefinedFieldsPanel from 'src/features/StackScripts/UserDefinedFieldsPanel';
-import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
-import { filterUDFErrors } from './formUtilities';
+
 import SelectAppPanel from '../SelectAppPanel';
+
+import { filterUDFErrors } from './formUtilities';
+
+import { AppsDocs } from 'src/documentation';
+
+import { ApplicationState } from 'src/store';
+
 import {
   AppsData,
   ReduxStateProps,
   StackScriptFormStateHandlers,
   WithTypesRegionsAndImages
 } from '../types';
+import Notice from 'src/components/Notice';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  main: {
-    [theme.breakpoints.up('md')]: {
-      maxWidth: '100%'
+type ClassNames =
+  | 'main'
+  | 'sidebar'
+  | 'emptyImagePanel'
+  | 'emptyImagePanelText';
+
+const styles = (theme: Theme) =>
+  createStyles({
+    sidebar: {
+      [theme.breakpoints.up('md')]: {
+        marginTop: '-130px !important'
+      }
+    },
+    main: {
+      [theme.breakpoints.up('md')]: {
+        maxWidth: '100%'
+      }
+    },
+    emptyImagePanel: {
+      padding: theme.spacing(3)
+    },
+    emptyImagePanelText: {
+      marginTop: theme.spacing(1),
+      padding: `${theme.spacing(1)}px 0`
     }
-  },
-  emptyImagePanel: {
-    padding: theme.spacing(3)
-  },
-  emptyImagePanelText: {
-    marginTop: theme.spacing(1),
-    padding: `${theme.spacing(1)}px 0`
-  }
-}));
+  });
 
 const errorResources = {
   type: 'A plan selection',
@@ -45,46 +76,37 @@ const errorResources = {
   stackscript_id: 'The selected App'
 };
 
-type CombinedProps = AppsData &
+type InnerProps = AppsData &
   ReduxStateProps &
   StackScriptFormStateHandlers &
   WithTypesRegionsAndImages;
 
-export const FromAppsContent: React.FC<CombinedProps> = props => {
-  const classes = useStyles();
+type CombinedProps = WithStyles<ClassNames> &
+  InnerProps &
+  StateProps &
+  SetDocsProps;
 
-  const {
-    appInstances,
-    appInstancesError,
-    appInstancesLoading,
-    errors,
-    imagesData,
-    userCannotCreateLinode,
-    selectedImageID,
-    selectedStackScriptID,
-    selectedStackScriptLabel,
-    selectedUDFs: udf_data,
-    availableUserDefinedFields: userDefinedFields,
-    availableStackScriptImages: compatibleImages,
-    updateImageID
-  } = props;
+interface State {
+  detailDrawerOpen: boolean;
+  selectedScriptForDrawer: string;
+}
 
-  const [detailDrawerOpen, setDetailDrawerOpen] = React.useState<boolean>(
-    false
-  );
-  const [selectedScriptForDrawer, setSelectedScriptForDrawer] = React.useState<
-    string
-  >('');
+class FromAppsContent extends React.PureComponent<CombinedProps, State> {
+  state: State = {
+    detailDrawerOpen: false,
+    selectedScriptForDrawer: ''
+  };
 
-  const handleSelectStackScript = (
+  handleSelectStackScript = (
     id: number,
     label: string,
     username: string,
     stackScriptImages: string[],
     userDefinedFields: UserDefinedField[]
   ) => {
+    const { imagesData } = this.props;
     /**
-     * Based on the list of images we get back from the API, compare those
+     * based on the list of images we get back from the API, compare those
      * to our list of master images supported by Linode and filter out the ones
      * that aren't compatible with our selected StackScript
      */
@@ -97,7 +119,7 @@ export const FromAppsContent: React.FC<CombinedProps> = props => {
     }, [] as Image[]);
 
     /**
-     * If a UDF field comes back from the API with a "default"
+     * if a UDF field comes back from the API with a "default"
      * value, it means we need to pre-populate the field and form state
      */
     const defaultUDFData = userDefinedFields.reduce((accum, eachField) => {
@@ -107,7 +129,7 @@ export const FromAppsContent: React.FC<CombinedProps> = props => {
       return accum;
     }, {});
 
-    props.updateStackScript(
+    this.props.updateStackScript(
       id,
       label,
       username,
@@ -117,86 +139,155 @@ export const FromAppsContent: React.FC<CombinedProps> = props => {
     );
   };
 
-  const handleChangeUDF = (key: string, value: string) => {
-    // Either overwrite or create new selection
-    const newUDFData = assocPath([key], value, props.selectedUDFs);
-    props.handleSelectUDFs({ ...props.selectedUDFs, ...newUDFData });
+  handleChangeUDF = (key: string, value: string) => {
+    // either overwrite or create new selection
+    const newUDFData = assocPath([key], value, this.props.selectedUDFs);
+
+    this.props.handleSelectUDFs({ ...this.props.selectedUDFs, ...newUDFData });
   };
 
-  const openDrawer = (stackScriptLabel: string) => {
-    setDetailDrawerOpen(true);
-    setSelectedScriptForDrawer(stackScriptLabel);
+  openDrawer = (stackScriptLabel: string) => {
+    this.setState({
+      detailDrawerOpen: true,
+      selectedScriptForDrawer: stackScriptLabel
+    });
   };
 
-  const closeDrawer = () => {
-    setDetailDrawerOpen(false);
+  closeDrawer = () => {
+    this.setState({
+      detailDrawerOpen: false
+    });
   };
 
-  const hasErrorFor = getAPIErrorsFor(errorResources, errors);
+  render() {
+    const {
+      classes,
+      selectedImageID,
+      selectedStackScriptID,
+      selectedStackScriptLabel,
+      selectedUDFs: udf_data,
+      availableUserDefinedFields: userDefinedFields,
+      availableStackScriptImages: compatibleImages,
+      updateImageID,
+      errors,
+      appInstances,
+      appInstancesError,
+      appInstancesLoading,
+      userCannotCreateLinode
+    } = this.props;
 
-  return (
-    <React.Fragment>
-      <Grid item className={`${classes.main} mlMain py0`}>
-        <SelectAppPanel
-          appInstances={appInstances}
-          appInstancesError={appInstancesError}
-          appInstancesLoading={appInstancesLoading}
-          selectedStackScriptID={selectedStackScriptID}
-          disabled={userCannotCreateLinode}
-          handleClick={handleSelectStackScript}
-          openDrawer={openDrawer}
-          error={hasErrorFor('stackscript_id')}
-        />
-        {!userCannotCreateLinode &&
-          userDefinedFields &&
-          userDefinedFields.length > 0 && (
-            <UserDefinedFieldsPanel
-              errors={filterUDFErrors(errorResources, errors)}
-              selectedLabel={selectedStackScriptLabel || ''}
-              selectedUsername="Linode"
-              handleChange={handleChangeUDF}
-              userDefinedFields={userDefinedFields}
-              updateFor={[userDefinedFields, udf_data, errors]}
-              udf_data={udf_data || {}}
-            />
-          )}
-        {!userCannotCreateLinode &&
-        compatibleImages &&
-        compatibleImages.length > 0 ? (
-          <ImageSelect
-            title="Select an Image"
-            images={compatibleImages}
-            handleSelectImage={updateImageID}
-            selectedImageID={selectedImageID}
-            error={hasErrorFor('image')}
-            variant="public"
+    const hasErrorFor = getAPIErrorsFor(errorResources, errors);
+
+    return (
+      <React.Fragment>
+        <Grid item className={`${classes.main} mlMain py0`}>
+          <CreateLinodeDisabled isDisabled={userCannotCreateLinode} />
+          <SelectAppPanel
+            appInstances={appInstances}
+            appInstancesError={appInstancesError}
+            appInstancesLoading={appInstancesLoading}
+            selectedStackScriptID={selectedStackScriptID}
+            disabled={userCannotCreateLinode}
+            handleClick={this.handleSelectStackScript}
+            openDrawer={this.openDrawer}
+            error={hasErrorFor('stackscript_id')}
           />
-        ) : (
-          <Paper className={classes.emptyImagePanel}>
-            {/* Empty state for images */}
-            {hasErrorFor('image') && (
-              <Notice error={true} text={hasErrorFor('image')} />
+          {!userCannotCreateLinode &&
+            userDefinedFields &&
+            userDefinedFields.length > 0 && (
+              <UserDefinedFieldsPanel
+                errors={filterUDFErrors(errorResources, errors)}
+                selectedLabel={selectedStackScriptLabel || ''}
+                selectedUsername="Linode"
+                handleChange={this.handleChangeUDF}
+                userDefinedFields={userDefinedFields}
+                updateFor={[userDefinedFields, udf_data, errors]}
+                udf_data={udf_data || {}}
+              />
             )}
-            <Typography variant="h2" data-qa-tp="Select Image">
-              Select Image
-            </Typography>
-            <Typography
-              data-qa-no-compatible-images
-              variant="body1"
-              className={classes.emptyImagePanelText}
-            >
-              No Compatible Images Available
-            </Typography>
-          </Paper>
-        )}
-      </Grid>
-      <AppDetailDrawer
-        open={detailDrawerOpen}
-        stackscriptID={selectedScriptForDrawer}
-        onClose={closeDrawer}
-      />
-    </React.Fragment>
-  );
+          {!userCannotCreateLinode &&
+          compatibleImages &&
+          compatibleImages.length > 0 ? (
+            <ImageSelect
+              title="Select an Image"
+              images={compatibleImages}
+              handleSelectImage={updateImageID}
+              selectedImageID={selectedImageID}
+              error={hasErrorFor('image')}
+              variant="public"
+            />
+          ) : (
+            <Paper className={classes.emptyImagePanel}>
+              {/* empty state for images */}
+              {hasErrorFor('image') && (
+                <Notice error={true} text={hasErrorFor('image')} />
+              )}
+              <Typography variant="h2" data-qa-tp="Select Image">
+                Select Image
+              </Typography>
+              <Typography
+                variant="body1"
+                className={classes.emptyImagePanelText}
+                data-qa-no-compatible-images
+              >
+                No Compatible Images Available
+              </Typography>
+            </Paper>
+          )}
+        </Grid>
+
+        <AppDetailDrawer
+          open={this.state.detailDrawerOpen}
+          stackscriptID={this.state.selectedScriptForDrawer}
+          onClose={this.closeDrawer}
+        />
+      </React.Fragment>
+    );
+  }
+}
+
+const styled = withStyles(styles);
+
+interface StateProps {
+  documentation: Linode.Doc[];
+}
+
+const mapStateToProps: MapStateToProps<
+  StateProps,
+  CombinedProps,
+  ApplicationState
+> = state => ({
+  documentation: state.documentation
+});
+
+const connected = connect(mapStateToProps);
+
+const generateDocs = (ownProps: InnerProps & StateProps) => {
+  const { selectedStackScriptLabel } = ownProps;
+  if (!!selectedStackScriptLabel) {
+    const foundDocs = AppsDocs.filter(eachDoc => {
+      return eachDoc.title
+        .toLowerCase()
+        .includes(
+          selectedStackScriptLabel
+            .substr(0, selectedStackScriptLabel.indexOf(' '))
+            .toLowerCase()
+        );
+    });
+    return foundDocs.length ? foundDocs : [];
+  }
+  return [];
 };
 
-export default FromAppsContent;
+const updateCond = (
+  prevProps: InnerProps & StateProps,
+  nextProps: InnerProps & StateProps
+) => {
+  return prevProps.selectedStackScriptID !== nextProps.selectedStackScriptID;
+};
+
+export default compose<CombinedProps, InnerProps>(
+  connected,
+  setDocs(generateDocs, updateCond),
+  styled
+)(FromAppsContent);

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.test.tsx
@@ -12,18 +12,23 @@ import { Provider } from 'react-redux';
 
 const mockProps: CombinedProps = {
   category: 'community',
+  classes: {
+    main: '',
+    emptyImagePanel: '',
+    emptyImagePanelText: ''
+  },
+  accountBackupsEnabled: false,
   updateImageID: jest.fn(),
   updateRegionID: jest.fn(),
   updateTypeID: jest.fn(),
   imagesData: {},
   regionsData: [],
   typesData: [],
+  userCannotCreateLinode: false,
   request: jest.fn(),
   header: '',
   updateStackScript: jest.fn(),
-  handleSelectUDFs: jest.fn(),
-  accountBackupsEnabled: false,
-  userCannotCreateLinode: false
+  handleSelectUDFs: jest.fn()
 };
 
 describe('FromImageContent', () => {


### PR DESCRIPTION
## Description

To recreate this issue, navigate to  `/linodes/create?type=One-Click`, select Wordpress, and try to edit email field, and admin username field in the UDF panel- in prod, updates to either input is wiping out the other. In this PR, this should no longer occur and creation of a WP one-click app should be successful.

I mostly fixed this by switching this component back to a class-based component (for now) and removing the repeat content we no longer need in lieu of the tab refactor work (in prod but not impacting to this bug)

## Type of Change
- Bug fix ('fix')