### PR TITLE
Clear UDF data on tab change

### DIFF
--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -96,7 +96,7 @@ interface State {
   backupsEnabled: boolean;
   privateIPEnabled: boolean;
   password: string;
-  udfs?: any[];
+  udfs?: any;
   tags?: Tag[];
   errors?: APIError[];
   formIsSubmitting: boolean;
@@ -135,6 +135,7 @@ const defaultState: State = {
   selectedRegionID: undefined,
   selectedTypeID: undefined,
   tags: [],
+  udfs: undefined,
   formIsSubmitting: false,
   errors: undefined,
   appInstancesLoading: false
@@ -334,7 +335,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
 
   setTags = (tags: Tag[]) => this.setState({ tags });
 
-  setUDFs = (udfs: any[]) => this.setState({ udfs });
+  setUDFs = (udfs: any) => this.setState({ udfs });
 
   generateLabel = () => {
     const { createType, getLabel, imagesData, regionsData } = this.props;

--- a/packages/manager/src/features/linodes/LinodesCreate/types.ts
+++ b/packages/manager/src/features/linodes/LinodesCreate/types.ts
@@ -157,7 +157,7 @@ export interface StackScriptFormStateHandlers extends BasicFromContentProps {
     defaultData?: any
   ) => void;
   selectedUDFs?: any;
-  handleSelectUDFs: (stackScripts: any[]) => void;
+  handleSelectUDFs: (stackScripts: any) => void;
 }
 
 /**


### PR DESCRIPTION
## Description

Small oversight that was causing a glitch. UDF data wasn't included in the default state, so it wasn't being reset on tab change. If you went to the Marketplace tab, selected an app, then went to a different non-StackScript tab and submitted the form, `stackscript_data` was included in the API request, causing an error.

## To test

1. Open the Linode create flow
2. Navigate to Marketplace
3. Select an app that has UDFs (Wordpress is fine)
4. Navigate to Distributions
5. Submit the form normally
6. Observe: on develop, the request to the API includes stale data, and an error is displayed ( Requires stackscript_id for StackScripts). Should be fixed in this branch.