### PR TITLE
Hotfix/backup create

### DIFF
--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -477,6 +477,7 @@ export class LinodeCreate extends React.PureComponent<
               </SafeTabPanel>
               <SafeTabPanel index={4}>
                 <FromBackupsContent
+                  errors={errors}
                   imagesData={imagesData!}
                   regionsData={regionsData!}
                   typesData={typesData!}

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -490,6 +490,7 @@ export class LinodeCreate extends React.PureComponent<
               </SafeTabPanel>
               <SafeTabPanel index={5}>
                 <FromLinodeContent
+                  errors={errors}
                   imagesData={imagesData!}
                   regionsData={regionsData!}
                   typesData={typesData!}

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -279,6 +279,7 @@ export class LinodeCreate extends React.PureComponent<
           .map(u => u.username),
         booted: true,
         backups_enabled: this.props.backupsEnabled,
+        backup_id: this.props.selectedBackupID,
         private_ip: this.props.privateIPEnabled,
 
         // StackScripts

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
@@ -64,7 +64,8 @@ const errorResources = {
   region: 'A region selection',
   label: 'A label',
   root_pass: 'A root password',
-  tags: 'Tags for this Linode'
+  tags: 'Tags for this Linode',
+  backup_id: 'Backup ID'
 };
 
 const filterLinodesWithBackups = (linodes: Linode[]) =>

--- a/packages/manager/src/store/linodeCreate/linodeCreate.reducer.ts
+++ b/packages/manager/src/store/linodeCreate/linodeCreate.reducer.ts
@@ -54,6 +54,8 @@ export const getInitialType = (): CreateTypes => {
         return 'fromImage';
       } else if (normalizedType.includes('backup')) {
         return 'fromBackup';
+      } else if (normalizedType.includes('clone')) {
+        return 'fromLinode';
       } else {
         return 'fromImage';
       }

--- a/packages/manager/src/store/linodeCreate/linodeCreate.reducer.ts
+++ b/packages/manager/src/store/linodeCreate/linodeCreate.reducer.ts
@@ -11,7 +11,7 @@ export const getInitialType = (): CreateTypes => {
   let queryParams;
   try {
     queryParams = parse(location.search.replace('?', '').toLowerCase());
-  } catch {
+  } catch (e) {
     // Broken query params shouldn't break the app, just default to fromImage
     return 'fromImage';
   }
@@ -52,6 +52,8 @@ export const getInitialType = (): CreateTypes => {
         return 'fromApp';
       } else if (normalizedType.includes('images')) {
         return 'fromImage';
+      } else if (normalizedType.includes('backup')) {
+        return 'fromBackup';
       } else {
         return 'fromImage';
       }


### PR DESCRIPTION
## Description

3 small bugs in the fromBackups tab:

1. backup_id was not being attached to the payload (so the Linode was being created empty)
2. Errors were not being sent to the FromBackupsContent component, so submitting the form without selecting a backup didn't show an error to the user.
3. The conditional logic in linodeCreate.reducer was expecting "backup" to be a subtype, not a type. Loading the create flow directly on the backups tab resulted in the app thinking the user was creating from an image, which made it possible to successfully submit the form without selecting a backup.