### PR TITLE
Can't edit username in account/users

### DIFF
--- a/packages/manager/cypress/integration/account/change-username.spec.ts
+++ b/packages/manager/cypress/integration/account/change-username.spec.ts
@@ -1,0 +1,25 @@
+import { getProfile } from '../../support/api/account';
+import { waitForAppLoad } from '../../support/ui/common';
+const testText = 'testing123';
+
+describe('username', () => {
+  it('can type new username', () => {
+    cy.visitWithLogin(`/dashboard`);
+    getProfile().then(profile => {
+      const username = profile.body.username;
+      cy.server();
+      cy.route({
+        method: 'GET',
+        url: '*/account/events'
+      }).as('textAvailable');
+      waitForAppLoad(`account/users/${username}`, false);
+      cy.findByText('Username').should('be.visible');
+      cy.wait('@textAvailable');
+      cy.findByLabelText('Username').type(testText);
+      cy.get('[data-testid="textfield-input"]').should(
+        'have.value',
+        `${username}${testText}`
+      );
+    });
+  });
+});

--- a/packages/manager/src/features/Users/UserDetail.tsx
+++ b/packages/manager/src/features/Users/UserDetail.tsx
@@ -286,18 +286,12 @@ class UserDetail extends React.Component<CombinedProps> {
   };
 
   render() {
-    const {
-      classes,
-      match: {
-        params: { username }
-      },
-      location,
-      profileUsername
-    } = this.props;
+    const { classes, location, profileUsername } = this.props;
     const {
       error,
       gravatarUrl,
       createdUsername,
+      username,
       email,
       profileSaving,
       profileSuccess,


### PR DESCRIPTION
Type:
bugfix: M3-4437

The bug is a little weirder than not being able to change a username from the `account/users/<username>` page. You actually can make changes. Currently you can make exactly one change, but it won't update the UI. For example, if your username was `natedukatz` and you focused on the username table view and then typed `backspace`, `a`, `b` and then clicked save, the username would change to `natedukatzb`. or if you were to type: `a`, `b`, `backspace` then save, the username would change to `natedukat` from the original username (`natedukatz`). In other words, whatever the last thing you typed before saving is the only change that will take effect.  I poked around in the user pages for a while and this is what I traced it back to, though I'm not 100% positive why this worked haha. I'm sure there is probably a different solution. I did verify that this works on the api level as well. I've noticed that it now also simultaneously changes the `data-qa-header` to whatever you are typing. Not sure if that is desired or not. 