### PR TITLE
Notification drawer: chronological display

### DIFF
--- a/packages/manager/src/features/NotificationCenter/NotificationDrawer.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationDrawer.tsx
@@ -9,6 +9,7 @@ import OpenSupportTickets from './OpenSupportTickets';
 import PastDue from './PastDue';
 import PendingActions from './PendingActions';
 import useAccount from 'src/hooks/useAccount';
+import usePreferences from 'src/hooks/usePreferences';
 import IconButton from 'src/components/core/IconButton';
 import { NotificationData } from './NotificationData/useNotificationData';
 import { ContentRow, NotificationItem } from './NotificationSection';
@@ -59,14 +60,31 @@ export const NotificationDrawer: React.FC<Props> = props => {
   const { data, open, onClose } = props;
   const { account } = useAccount();
   const classes = useStyles();
-  const balance = (account.data?.balance ?? 0) + 50;
+  const balance = account.data?.balance ?? 0;
   const { community, pendingActions, support } = data;
 
-  const [chronologicalView, setChronologicalView] = React.useState(false);
+  const { preferences, updatePreferences } = usePreferences();
+
+  const currentView = preferences?.notification_drawer_view ?? 'grouped';
+
+  const [chronologicalView, setChronologicalView] = React.useState(
+    currentView === 'list'
+  );
 
   const handleToggleView = () => {
     setChronologicalView(currentView => !currentView);
   };
+
+  React.useEffect(() => {
+    const newPreference = chronologicalView ? 'list' : 'grouped';
+    if (newPreference !== currentView) {
+      updatePreferences({
+        notification_drawer_view: newPreference
+      });
+    }
+
+    // eslint-disable-next-line
+  }, [chronologicalView, currentView]);
 
   const chronologicalNotificationList = React.useMemo(() => {
     return [...community.events, ...pendingActions, ...support.data].sort(

--- a/packages/manager/src/features/NotificationCenter/NotificationDrawer.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationDrawer.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import Clock from 'src/assets/icons/clock.svg';
 import { makeStyles, Theme } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
 import Drawer from 'src/components/Drawer';
 import Community from './Community';
 import Maintenance from './Maintenance';
@@ -8,7 +9,9 @@ import OpenSupportTickets from './OpenSupportTickets';
 import PastDue from './PastDue';
 import PendingActions from './PendingActions';
 import useAccount from 'src/hooks/useAccount';
+import IconButton from 'src/components/core/IconButton';
 import { NotificationData } from './NotificationData/useNotificationData';
+import { ContentRow, NotificationItem } from './NotificationSection';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -40,6 +43,18 @@ interface Props {
   onClose: () => void;
 }
 
+const chronologicalSort = (a: NotificationItem, b: NotificationItem) => {
+  const timeA = a.timeStamp ?? Infinity;
+  const timeB = b.timeStamp ?? Infinity;
+  if (timeA < timeB) {
+    return 1;
+  }
+  if (timeA > timeB) {
+    return -1;
+  }
+  return 0;
+};
+
 export const NotificationDrawer: React.FC<Props> = props => {
   const { data, open, onClose } = props;
   const { account } = useAccount();
@@ -47,28 +62,71 @@ export const NotificationDrawer: React.FC<Props> = props => {
   const balance = (account.data?.balance ?? 0) + 50;
   const { community, pendingActions, support } = data;
 
+  const [chronologicalView, setChronologicalView] = React.useState(false);
+
+  const handleToggleView = () => {
+    setChronologicalView(currentView => !currentView);
+  };
+
+  const chronologicalNotificationList = React.useMemo(() => {
+    return [...community.events, ...pendingActions, ...support.data].sort(
+      chronologicalSort
+    );
+  }, [community.events, pendingActions, support.data]);
+
   return (
     <Drawer open={open} onClose={onClose} title="" className={classes.root}>
       {balance > 0 ? <PastDue balance={balance} /> : null}
       <div className={classes.actionHeader}>
-        <Clock />
+        <IconButton
+          aria-label="Toggle chronological display"
+          aria-describedby={'displayViewDescription'}
+          title={`Toggle chronological display`}
+          onClick={handleToggleView}
+          disableRipple
+        >
+          <Clock />
+        </IconButton>
       </div>
-      <div className={classes.notificationSectionContainer}>
-        <PendingActions pendingActions={pendingActions} />
-        <Maintenance />
-        <OpenSupportTickets
-          loading={support.loading}
-          error={Boolean(support.error)}
-          openTickets={support.data}
-        />
-        <Community
-          communityEvents={community.events}
-          loading={community.loading}
-          error={Boolean(community.error)}
-        />
-      </div>
+
+      {chronologicalView ? (
+        <ChronologicalView notifications={chronologicalNotificationList} />
+      ) : (
+        <div className={classes.notificationSectionContainer}>
+          <PendingActions pendingActions={pendingActions} />
+          <Maintenance />
+          <OpenSupportTickets
+            loading={support.loading}
+            error={Boolean(support.error)}
+            openTickets={support.data}
+          />
+          <Community
+            communityEvents={community.events}
+            loading={community.loading}
+            error={Boolean(community.error)}
+          />
+        </div>
+      )}
     </Drawer>
   );
 };
 
 export default React.memo(NotificationDrawer);
+
+interface ChronoProps {
+  notifications: NotificationItem[];
+}
+const ChronologicalView: React.FC<ChronoProps> = props => {
+  const { notifications } = props;
+  if (notifications.length === 0) {
+    return <Typography>No notifications to display.</Typography>;
+  }
+  return (
+    <>
+      {' '}
+      {notifications.map(thisItem => (
+        <ContentRow key={`chronological-list-${thisItem.id}`} item={thisItem} />
+      ))}
+    </>
+  );
+};

--- a/packages/manager/src/features/NotificationCenter/NotificationDrawer.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationDrawer.tsx
@@ -95,10 +95,10 @@ export const NotificationDrawer: React.FC<Props> = props => {
   return (
     <Drawer open={open} onClose={onClose} title="" className={classes.root}>
       {balance > 0 ? <PastDue balance={balance} /> : null}
-      <div className={classes.actionHeader}>
+      <div id="viewToggle" className={classes.actionHeader}>
         <IconButton
           aria-label="Toggle chronological display"
-          aria-describedby={'displayViewDescription'}
+          aria-describedby={'viewToggle'}
           title={`Toggle chronological display`}
           onClick={handleToggleView}
           disableRipple

--- a/packages/manager/src/features/NotificationCenter/NotificationSection.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationSection.tsx
@@ -201,7 +201,7 @@ const ContentBody: React.FC<BodyProps> = React.memo(props => {
 // =============================================================================
 // Row
 // =============================================================================
-const ContentRow: React.FC<{
+export const ContentRow: React.FC<{
   item: NotificationItem;
 }> = React.memo(props => {
   const { item } = props;

--- a/packages/manager/src/store/preferences/preferences.actions.ts
+++ b/packages/manager/src/store/preferences/preferences.actions.ts
@@ -27,6 +27,7 @@ export interface UserPreferences {
   main_content_banner_dismissal?: Record<string, boolean>;
   is_large_account?: boolean;
   linode_news_banner_dismissed?: boolean;
+  notification_drawer_view?: 'list' | 'grouped';
 }
 
 export const handleGetPreferences = actionCreator.async<


### PR DESCRIPTION
## Description

Add "chronological view," which is all the things that would be in the drawer in a single giant chronological list rather than notification groups. The user's choice is stored in user preferences.

## Note

To test, you'll have to mock the various things that can cause notifications. Unfortunately there's no single way to handle every type of event, so you'll need to be creative. Some suggestions:
- Use a dev account for the support tickets
- Use the cli to trigger a bunch of boots/create events for progress events
- Use prod test account 4 and remove the time filter from the API request in NotificationContext.ts.

I think the useEffect logic is robust enough to spamming it (toggling the view back and forth repeatedly), but please have fun verifying this.