### PR TITLE
Notification drawer loading state

### DIFF
--- a/packages/manager/src/features/NotificationCenter/PastDue.tsx
+++ b/packages/manager/src/features/NotificationCenter/PastDue.tsx
@@ -80,7 +80,11 @@ export const PastDue: React.FC<Props> = props => {
     return (
       <div
         className={classes.root}
-        style={{ display: 'flex', justifyContent: 'center' }}
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center'
+        }}
       >
         <CircleProgress mini />
       </div>

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -8,6 +8,7 @@ import {
   firewallDeviceFactory,
   kubernetesClusterFactory,
   kubeEndpointFactory,
+  invoiceFactory,
   invoiceItemFactory,
   nodePoolFactory,
   linodeConfigFactory,
@@ -155,6 +156,10 @@ export const handlers = [
   rest.get('*/account/transfer', (req, res, ctx) => {
     const transfer = accountTransferFactory.build();
     return res(ctx.json(transfer));
+  }),
+  rest.get('*/account/invoices', (req, res, ctx) => {
+    const invoices = invoiceFactory.buildList(10);
+    return res(ctx.delay(5000), ctx.json(makeResourcePage(invoices)));
   }),
   rest.get('*/events', (req, res, ctx) => {
     const events = eventFactory.buildList(10);


### PR DESCRIPTION
## Description

Fix loading spinner in Notification Drawer; add invoice mocking

## Note to Reviewers

Left the ctx.delay() in the mocks to make testing easier. Open the drawer and you'll see the loading state for 5 seconds (have to be using the mock service worker). I'll remove this before merge.