### PR TITLE
M3-3792 Add Longview processes tables to preferences sortKeys

### DIFF
--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Processes/ProcessesTable.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Processes/ProcessesTable.tsx
@@ -48,89 +48,90 @@ export const ProcessesTable: React.FC<CombinedProps> = props => {
   const { width } = useWindowDimensions();
 
   return (
-    <>
-      <OrderBy data={processesData} orderBy={'name'} order={'asc'}>
-        {({ data: orderedData, handleOrderChange, order, orderBy }) => (
-          <>
-            <Table
-              spacingTop={16}
-              // This prop is necessary to show the "ActiveCaret", and we only
-              // want it on large viewports.
-              noOverflow={width >= 1280}
-              isResponsive={false}
-            >
-              <TableHead>
-                <TableRow>
-                  <TableSortCell
-                    active={orderBy === 'name'}
-                    label="name"
-                    direction={order}
-                    handleClick={handleOrderChange}
-                    style={{ width: '20%' }}
-                  >
-                    Process
-                  </TableSortCell>
-                  <TableSortCell
-                    active={orderBy === 'user'}
-                    label="user"
-                    direction={order}
-                    handleClick={handleOrderChange}
-                    style={{ width: '20%' }}
-                  >
-                    User
-                  </TableSortCell>
-                  <TableSortCell
-                    active={orderBy === 'maxCount'}
-                    label="maxCount"
-                    direction={order}
-                    handleClick={handleOrderChange}
-                    style={{ width: '15%' }}
-                  >
-                    Max Count
-                  </TableSortCell>
-                  <TableSortCell
-                    active={orderBy === 'averageIO'}
-                    label="averageIO"
-                    direction={order}
-                    handleClick={handleOrderChange}
-                    style={{ width: '15%' }}
-                  >
-                    Avg IO
-                  </TableSortCell>
-                  <TableSortCell
-                    active={orderBy === 'averageCPU'}
-                    label="averageCPU"
-                    direction={order}
-                    handleClick={handleOrderChange}
-                    style={{ width: '15%' }}
-                  >
-                    Avg CPU
-                  </TableSortCell>
-                  <TableSortCell
-                    active={orderBy === 'averageMem'}
-                    label="averageMem"
-                    direction={order}
-                    handleClick={handleOrderChange}
-                    style={{ width: '15%' }}
-                  >
-                    Avg Mem
-                  </TableSortCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {renderLoadingErrorData(
-                  processesLoading,
-                  orderedData,
-                  selectedProcess,
-                  setSelectedProcess,
-                  error
-                )}
-              </TableBody>
-            </Table>
-          </>
-        )}
-      </OrderBy>
-    </>
+    <OrderBy
+      data={processesData}
+      orderBy={'name'}
+      order={'asc'}
+      preferenceKey="lv-detail-processes"
+    >
+      {({ data: orderedData, handleOrderChange, order, orderBy }) => (
+        <Table
+          spacingTop={16}
+          // This prop is necessary to show the "ActiveCaret", and we only
+          // want it on large viewports.
+          noOverflow={width >= 1280}
+          isResponsive={false}
+        >
+          <TableHead>
+            <TableRow>
+              <TableSortCell
+                active={orderBy === 'name'}
+                label="name"
+                direction={order}
+                handleClick={handleOrderChange}
+                style={{ width: '20%' }}
+              >
+                Process
+              </TableSortCell>
+              <TableSortCell
+                active={orderBy === 'user'}
+                label="user"
+                direction={order}
+                handleClick={handleOrderChange}
+                style={{ width: '20%' }}
+              >
+                User
+              </TableSortCell>
+              <TableSortCell
+                active={orderBy === 'maxCount'}
+                label="maxCount"
+                direction={order}
+                handleClick={handleOrderChange}
+                style={{ width: '15%' }}
+              >
+                Max Count
+              </TableSortCell>
+              <TableSortCell
+                active={orderBy === 'averageIO'}
+                label="averageIO"
+                direction={order}
+                handleClick={handleOrderChange}
+                style={{ width: '15%' }}
+              >
+                Avg IO
+              </TableSortCell>
+              <TableSortCell
+                active={orderBy === 'averageCPU'}
+                label="averageCPU"
+                direction={order}
+                handleClick={handleOrderChange}
+                style={{ width: '15%' }}
+              >
+                Avg CPU
+              </TableSortCell>
+              <TableSortCell
+                active={orderBy === 'averageMem'}
+                label="averageMem"
+                direction={order}
+                handleClick={handleOrderChange}
+                style={{ width: '15%' }}
+              >
+                Avg Mem
+              </TableSortCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {renderLoadingErrorData(
+              processesLoading,
+              orderedData,
+              selectedProcess,
+              setSelectedProcess,
+              error
+            )}
+          </TableBody>
+        </Table>
+      )}
+    </OrderBy>
   );
 };
 

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/TopProcesses.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/TopProcesses.tsx
@@ -62,53 +62,52 @@ export const TopProcesses: React.FC<Props> = props => {
         data={extendTopProcesses(topProcessesData)}
         orderBy={'cpu'}
         order={'desc'}
+        preferenceKey="top-processes"
       >
         {({ data: orderedData, handleOrderChange, order, orderBy }) => (
-          <>
-            <Table spacingTop={16} aria-label="List of Top Processes">
-              <TableHead>
-                <TableRow>
-                  <TableSortCell
-                    data-qa-table-header="Process"
-                    active={orderBy === 'name'}
-                    label="name"
-                    direction={order}
-                    handleClick={handleOrderChange}
-                    style={{ width: '40%' }}
-                  >
-                    Process
-                  </TableSortCell>
-                  <TableSortCell
-                    data-qa-table-header="CPU"
-                    active={orderBy === 'cpu'}
-                    label="cpu"
-                    direction={order}
-                    handleClick={handleOrderChange}
-                    style={{ width: '25%' }}
-                  >
-                    CPU
-                  </TableSortCell>
-                  <TableSortCell
-                    data-qa-table-header="Memory"
-                    active={orderBy === 'mem'}
-                    label="mem"
-                    direction={order}
-                    handleClick={handleOrderChange}
-                    style={{ width: '15%' }}
-                  >
-                    Memory
-                  </TableSortCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {renderLoadingErrorData(
-                  orderedData,
-                  topProcessesLoading,
-                  errorMessage
-                )}
-              </TableBody>
-            </Table>
-          </>
+          <Table spacingTop={16} aria-label="List of Top Processes">
+            <TableHead>
+              <TableRow>
+                <TableSortCell
+                  data-qa-table-header="Process"
+                  active={orderBy === 'name'}
+                  label="name"
+                  direction={order}
+                  handleClick={handleOrderChange}
+                  style={{ width: '40%' }}
+                >
+                  Process
+                </TableSortCell>
+                <TableSortCell
+                  data-qa-table-header="CPU"
+                  active={orderBy === 'cpu'}
+                  label="cpu"
+                  direction={order}
+                  handleClick={handleOrderChange}
+                  style={{ width: '25%' }}
+                >
+                  CPU
+                </TableSortCell>
+                <TableSortCell
+                  data-qa-table-header="Memory"
+                  active={orderBy === 'mem'}
+                  label="mem"
+                  direction={order}
+                  handleClick={handleOrderChange}
+                  style={{ width: '15%' }}
+                >
+                  Memory
+                </TableSortCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {renderLoadingErrorData(
+                orderedData,
+                topProcessesLoading,
+                errorMessage
+              )}
+            </TableBody>
+          </Table>
         )}
       </OrderBy>
     </Grid>

--- a/packages/manager/src/store/preferences/preferences.actions.ts
+++ b/packages/manager/src/store/preferences/preferences.actions.ts
@@ -11,7 +11,12 @@ export interface OrderSet {
   orderBy: string;
 }
 
-export type SortKey = 'listening-services' | 'active-connections';
+export type SortKey =
+  | 'listening-services'
+  | 'active-connections'
+  | 'top-processes'
+  | 'lv-detail-processes';
+
 export interface UserPreferences {
   longviewTimeRange?: string;
   gst_banner_dismissed?: boolean;


### PR DESCRIPTION
## Description

Store user's selected sort key (in Longview tables) in user preferences. We already set this up for other Longview tables a few months ago, which makes this an easy lift.

## Note to Reviewers

Please verify that every table in Longview retains the selected sort order on page reload.