### PR TITLE
delete linode test fixes for CMR updates

### DIFF
--- a/packages/manager/cypress/integration/linodes/smoke-delete-linode.spec.ts
+++ b/packages/manager/cypress/integration/linodes/smoke-delete-linode.spec.ts
@@ -1,7 +1,8 @@
-import { createLinode } from '../../support/api/linodes';
+/* eslint-disable sonarjs/no-duplicate-string */
+import { createLinode, clickLinodeActionMenu } from '../../support/api/linodes';
 
 describe('delete linode', () => {
-  it('deletes test nanode', () => {
+  it('deletes linode from linodes page', () => {
     cy.visitWithLogin('/linodes');
     createLinode().then(linode => {
       cy.server();
@@ -10,30 +11,28 @@ describe('delete linode', () => {
         url: '*/linode/instances/*'
       }).as('deleteLinode');
 
-      cy.visit(`/linodes/${linode.id}/settings`);
+      clickLinodeActionMenu(linode.label);
 
-      cy.findByText('Delete Linode').click();
+      // delete linode
+      cy.get('[data-qa-action-menu-item="Delete"]')
+        .first()
+        .should('be.visible')
+        .click();
 
-      // here i query using text to check the UI and there is only 1 Delete button
-      // cy.get('[data-qa-delete-linode]').click();
-      cy.get('[data-qa-delete-linode="true"').click();
-      cy.findByText(linode.label).should('exist');
+      cy.findByText(linode.label).should('be.visible');
+
+      cy.get('[data-qa-loading="false"]')
+        .should('have.text', 'Delete')
+        .should('be.visible')
+        .click();
 
       // confirm delete
-      // there is now 2 delete on the page so i use the attribute selector
-      // cy.findByText('Delete').debug()
-      cy.get('[data-qa-confirm-delete]').click();
-
-      // Here if the request is against a local route
-      // this is because we use a proxy in webpack config
-      // this redirects localhost:3000/api to api.linode.com/api
-      // Thanks to this we can use cy.server, cy.route and cy.wait
       cy.wait('@deleteLinode')
         .its('status')
         .should('eq', 200);
       cy.url().should('contain', '/linodes');
-      cy.go('back');
-      cy.findByText('Not Found');
+      cy.findByText(linode.label).should('not.be.visible');
     });
   });
+  // will add a test for deleting from the dashboard here and maybe one for deleting from linode detail
 });

--- a/packages/manager/cypress/support/api/linodes.ts
+++ b/packages/manager/cypress/support/api/linodes.ts
@@ -111,3 +111,7 @@ export const deleteAllTestLinodes = () => {
     });
   });
 };
+
+export const clickLinodeActionMenu = title => {
+  cy.get(`[aria-label="Action menu for Linode ${title}"]`).click();
+};


### PR DESCRIPTION
**How to verify that that the test works:**
- yarn up
- yarn cy:debug
- Choose test file(s) in the cypress test runner
- Test(s) should pass

**Extra check (runs headless):**
- yarn cy:e2e -s <test file(s)>
- Result should be "✔  All specs passed!"

Make sure your .env contains:
REACT_APP_LOGIN_ROOT='https://login.linode.com'
REACT_APP_API_ROOT='https://api.linode.com/v4'
REACT_APP_APP_ROOT='http://localhost:3000'
REACT_APP_LAUNCH_DARKLY_ID='*************************' (CMR flag)
REACT_APP_CLIENT_ID='********************' (https://cloud.linode.com/profile/clients, copy ID)
MANAGER_OAUTH='**************************************************************************' 
(create in https://cloud.linode.com/profile/tokens > "Add a Person Access Token", Save the token that appears in the modal, you will only see it once)