### PR TITLE
force resolution of property-expr to 2.0.3 due to vuln

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "minimist": "^1.2.3",
     "yargs-parser": "^18.1.3",
     "kind-of": "^6.0.3",
-    "dot-prop": "^5.2.0"
+    "dot-prop": "^5.2.0",
+    "property-expr": "^2.0.3"
   },
   "workspaces": {
     "packages": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -15652,10 +15652,10 @@ prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0,
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
-property-expr@^1.5.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-1.5.1.tgz#22e8706894a0c8e28d58735804f6ba3a3673314f"
-  integrity sha512-CGuc0VUTGthpJXL36ydB6jnbyOf/rAHFvmVrJlH+Rg0DqqLFQGAP6hIaxD/G0OAmBJPhXDHuEJigrp0e0wFV6g==
+property-expr@^1.5.0, property-expr@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.3.tgz#0a3fce936515da358aca0b74d5844a3dc34139bd"
+  integrity sha512-TEMKBo6s4gZUKmNYwaMkS2JdDxdWgUijW/U/jLAOHVyLZfU1KHXv+mC1J9gkfGOr8532XHqMJytko1lSjc0kmw==
 
 property-information@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
** this is a quick fix, the better fix is to upgrade yup to v0.29.5 but this raises a lot of type errors **

https://snyk.io/vuln/npm:property-expr has to be upgraded to 2.0.3 or above

This error scanned by snyk
![image](https://user-images.githubusercontent.com/27222128/90779068-66d9a700-e2cb-11ea-8b9c-2872d5a5f4c1.png)
