### PR TITLE
Use CMR action menu for Longview client rows

### DIFF
--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewActionMenu_CMR.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewActionMenu_CMR.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+
+import ActionMenu from 'src/components/ActionMenu_CMR/ActionMenu_CMR';
+
+export interface ActionHandlers {
+  triggerDeleteLongviewClient: (
+    longviewClientID: number,
+    longviewClientLabel: string
+  ) => void;
+}
+
+interface Props extends ActionHandlers {
+  longviewClientID: number;
+  longviewClientLabel: string;
+  userCanModifyClient: boolean;
+}
+
+type CombinedProps = Props;
+
+const LongviewActionMenu: React.FC<CombinedProps> = props => {
+  const {
+    longviewClientID,
+    longviewClientLabel,
+    triggerDeleteLongviewClient,
+    userCanModifyClient
+  } = props;
+
+  const createActions = () => {
+    return [
+      {
+        title: 'Delete',
+        disabled: !userCanModifyClient,
+        tooltip: userCanModifyClient
+          ? ''
+          : 'Contact an account administrator for permission.',
+        onClick: () => {
+          triggerDeleteLongviewClient(longviewClientID, longviewClientLabel);
+        }
+      }
+    ];
+  };
+
+  return (
+    <ActionMenu
+      createActions={createActions}
+      ariaLabel={`Action menu for Longview Client ${props.longviewClientLabel}`}
+    />
+  );
+};
+
+export default React.memo(LongviewActionMenu);

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
@@ -2,12 +2,11 @@ import { Grant } from '@linode/api-v4/lib/account';
 import { pathOr } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
-
 import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Grid from 'src/components/Grid';
+import useFlags from 'src/hooks/useFlags';
 import CPUGauge from './Gauges/CPU';
-
 import { useClientLastUpdated } from '../shared/useClientLastUpdated';
 import LoadGauge from './Gauges/Load';
 import NetworkGauge from './Gauges/Network';
@@ -15,9 +14,9 @@ import RAMGauge from './Gauges/RAM';
 import StorageGauge from './Gauges/Storage';
 import SwapGauge from './Gauges/Swap';
 import ActionMenu, { ActionHandlers } from './LongviewActionMenu';
+import ActionMenu_CMR from './LongviewActionMenu_CMR';
 import LongviewClientHeader from './LongviewClientHeader';
 import LongviewClientInstructions from './LongviewClientInstructions';
-
 import withLongviewClients, {
   DispatchProps
 } from 'src/containers/longview.container';
@@ -61,6 +60,9 @@ type CombinedProps = Props & LVDataProps & DispatchProps & GrantProps;
 
 const LongviewClientRow: React.FC<CombinedProps> = props => {
   const classes = useStyles();
+  const flags = useFlags();
+
+  const Menu = flags.cmr ? ActionMenu_CMR : ActionMenu;
 
   const {
     clientID,
@@ -167,7 +169,7 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
         <Grid item xs={1}>
           <Grid container justify="flex-end">
             <Grid item>
-              <ActionMenu
+              <Menu
                 longviewClientID={clientID}
                 longviewClientLabel={clientLabel}
                 triggerDeleteLongviewClient={triggerDeleteLongviewClient}

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewListRows.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewListRows.tsx
@@ -23,6 +23,7 @@ const LongviewListRows: React.FC<CombinedProps> = props => {
   } = props;
 
   return (
+    // eslint-disable-next-line
     <React.Fragment>
       {longviewClientsData.map(eachClient => {
         return (


### PR DESCRIPTION
## Description

We used an action menu rather than an inline action way back in the day for style reasons, so I left it that way for now. (Longview client rows aren't tables which makes it a special case). We can make it an inline action if folks vote that way, for now I wanted to make sure we don't overlook this when releasing CMR.