### PR TITLE
M3-4460 Make getAllDomains request from inside Domains landing

### DIFF
--- a/packages/manager/src/features/Domains/DomainDetail/DomainDetail.tsx
+++ b/packages/manager/src/features/Domains/DomainDetail/DomainDetail.tsx
@@ -23,7 +23,7 @@ import { getAllWithArguments } from 'src/utilities/getAll';
 
 import Loading from 'src/components/LandingLoading';
 
-import DomainRecords from './DomainRecordsWrapper';
+import DomainRecords from '../DomainRecordsWrapper';
 
 type RouteProps = RouteComponentProps<{ domainId?: string }>;
 

--- a/packages/manager/src/features/Domains/DomainDetail/index.tsx
+++ b/packages/manager/src/features/Domains/DomainDetail/index.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { RouteComponentProps } from 'react-router-dom';
+import CircleProgress from 'src/components/CircleProgress';
+import NotFound from 'src/components/NotFound';
+import { useAPIRequest } from 'src/hooks/useAPIRequest';
+import useDomains from 'src/hooks/useDomains';
+const DomainsLanding = React.lazy(() => import('../DomainsLanding'));
+const DomainDetail = React.lazy(() => import('./DomainDetail'));
+
+export const DomainDetailRouting: React.FC<RouteComponentProps<{
+  domainId: string;
+}>> = props => {
+  const domainId = Number(props.match.params.domainId);
+  const { domains, requestDomain } = useDomains();
+  const request = useAPIRequest(() => requestDomain(domainId), undefined);
+
+  // The Domain from the store that matches this ID.
+  const foundDomain = Object.values(domains.itemsById).find(
+    thisDomain => thisDomain.id === domainId
+  );
+
+  if (!foundDomain) {
+    // Did we complete a request for Domains yet? If so, this Domain doesn't exist.
+    if (!request.loading) {
+      return <NotFound />;
+    }
+    // If not, we don't know if the Domain exists yet so we have to stall
+    return <CircleProgress />;
+  }
+  // Master Domains have a Detail page.
+  if (foundDomain.type === 'master') {
+    return <DomainDetail {...props} />;
+  }
+
+  // Slave Domains do not have a Detail page, so render the Landing
+  // page with an open drawer.
+  return (
+    <DomainsLanding
+      domainForEditing={{
+        domainId: foundDomain.id,
+        domainLabel: foundDomain.domain
+      }}
+      {...props}
+    />
+  );
+};
+
+export default DomainDetailRouting;

--- a/packages/manager/src/features/Domains/DomainDetail/index.tsx
+++ b/packages/manager/src/features/Domains/DomainDetail/index.tsx
@@ -21,7 +21,7 @@ export const DomainDetailRouting: React.FC<RouteComponentProps<{
 
   if (!foundDomain) {
     // Did we complete a request for Domains yet? If so, this Domain doesn't exist.
-    if (!request.loading) {
+    if (!request.loading && request.lastUpdated > 0) {
       return <NotFound />;
     }
     // If not, we don't know if the Domain exists yet so we have to stall

--- a/packages/manager/src/features/Domains/DomainsLanding.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.tsx
@@ -192,11 +192,20 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
   static docs: Linode.Doc[] = [Domains];
 
   componentDidMount = () => {
-    const { domainForEditing, openForEditing } = this.props;
+    const {
+      domainForEditing,
+      isLargeAccount,
+      openForEditing,
+      getAllDomains
+    } = this.props;
     // Open the "Edit Domain" drawer if so specified by this component's props.
     if (domainForEditing) {
       const { domainId, domainLabel } = domainForEditing;
       openForEditing(domainLabel, domainId);
+    }
+
+    if (!isLargeAccount) {
+      getAllDomains();
     }
   };
 

--- a/packages/manager/src/features/Domains/DomainsLanding.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.tsx
@@ -194,6 +194,7 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
   componentDidMount = () => {
     const {
       domainForEditing,
+      domainsLastUpdated,
       isLargeAccount,
       openForEditing,
       getAllDomains
@@ -204,7 +205,7 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
       openForEditing(domainLabel, domainId);
     }
 
-    if (!isLargeAccount) {
+    if (!isLargeAccount && domainsLastUpdated === 0) {
       getAllDomains();
     }
   };

--- a/packages/manager/src/features/Domains/index.tsx
+++ b/packages/manager/src/features/Domains/index.tsx
@@ -7,13 +7,8 @@ import {
   withRouter
 } from 'react-router-dom';
 import { compose } from 'recompose';
-import CircleProgress from 'src/components/CircleProgress';
-import NotFound from 'src/components/NotFound';
+
 import SuspenseLoader from 'src/components/SuspenseLoader';
-import { REFRESH_INTERVAL } from 'src/constants';
-import useAccountManagement from 'src/hooks/useAccountManagement';
-import useDomains from 'src/hooks/useDomains';
-import useReduxLoad from 'src/hooks/useReduxLoad';
 
 const DomainsLanding = React.lazy(() => import('./DomainsLanding'));
 const DomainDetail = React.lazy(() => import('./DomainDetail'));
@@ -25,77 +20,17 @@ const DomainsRoutes: React.FC<CombinedProps> = props => {
     match: { path }
   } = props;
 
-  const { domains } = useDomains();
-  const domainsLastUpdated = domains.lastUpdated;
-  const domainsData = Object.values(domains.itemsById);
-
-  const { _isLargeAccount } = useAccountManagement();
-  useReduxLoad(['domains'], REFRESH_INTERVAL, !_isLargeAccount);
-
   return (
     <React.Suspense fallback={<SuspenseLoader />}>
       <Switch>
         <Route
-          path={`${path}/:domainId`}
+          path={`${path}/:domainId/records`}
           exact
           strict
-          render={routerProps => {
-            // There are two types of Domains:
-            //
-            // 1. Master Domain
-            // 2. Slave Domain
-            //
-            // Master Domains have a Detail page. Slave Domains do not.
-            //
-            // On the Domain Landing page, clicking on Slave Domain does not
-            // navigate the user away from the Domain Landing page. Instead,
-            // the "Edit Domain" drawer opens.
-            //
-            // We need to handle routing such that going to /domains/:domainId
-            // takes the user to the Domain Landing page with the "Edit Domain"
-            // drawer open.
-            //
-            // Thus, if this routing is matched, we look through the user's
-            // domains to determine if the selected domain is a Slave Domain and
-            // render the components appropriately.
-
-            // The domainId from the URL, i.e. /domains/:domainId
-            const domainId = Number(routerProps.match.params.domainId);
-
-            // The Domain from the store that matches this ID.
-            const foundDomain = (domainsData || []).find(
-              thisDomain => thisDomain.id === domainId
-            );
-
-            if (!foundDomain) {
-              // Did we complete a request for Domains yet? If so, this Domain doesn't exist.
-              if (domainsLastUpdated > 0) {
-                return <NotFound />;
-              }
-              // If not, we don't know if the Domain exists yet so we have to stall
-              return <CircleProgress />;
-            }
-
-            // Master Domains have a Detail page.
-            if (foundDomain.type === 'master') {
-              return <DomainDetail {...routerProps} />;
-            }
-
-            // Slave Domains do not have a Detail page, so render the Landing
-            // page with an open drawer.
-            return (
-              <DomainsLanding
-                domainForEditing={{
-                  domainId: foundDomain.id,
-                  domainLabel: foundDomain.domain
-                }}
-                {...routerProps}
-              />
-            );
-          }}
+          component={DomainDetail}
         />
         <Route
-          path={`${path}/:domainId/records`}
+          path={`${path}/:domainId`}
           exact
           strict
           component={DomainDetail}

--- a/packages/manager/src/hooks/useDomains.ts
+++ b/packages/manager/src/hooks/useDomains.ts
@@ -7,6 +7,7 @@ import {
 } from 'src/store/domains/domains.actions';
 import { State } from 'src/store/domains/domains.reducer';
 import {
+  requestDomainForStore as _requestOne,
   requestDomains as _request,
   updateDomain as _update
 } from 'src/store/domains/domains.requests';
@@ -15,6 +16,7 @@ import { Dispatch } from './types';
 export interface DomainsProps {
   domains: State;
   requestDomains: () => Promise<Domain[]>;
+  requestDomain: (domainId: number) => Promise<void>;
   updateDomain: (params: UpdateDomainParams & DomainId) => Promise<Domain>;
 }
 
@@ -24,10 +26,11 @@ export const useDomains = (): DomainsProps => {
     (state: ApplicationState) => state.__resources.domains
   );
   const requestDomains = () => dispatch(_request());
+  const requestDomain = (domainId: number) => dispatch(_requestOne(domainId));
   const updateDomain = (params: DomainId & UpdateDomainParams) =>
     dispatch(_update(params));
 
-  return { domains, requestDomains, updateDomain };
+  return { domains, requestDomains, requestDomain, updateDomain };
 };
 
 export default useDomains;

--- a/packages/manager/src/store/domains/domains.requests.ts
+++ b/packages/manager/src/store/domains/domains.requests.ts
@@ -69,10 +69,10 @@ export const requestDomains: ThunkActionCreator<Promise<Domain[]>> = () => (
     });
 };
 
-type RequestDomainForStoreThunk = ThunkActionCreator<void, number>;
+type RequestDomainForStoreThunk = ThunkActionCreator<Promise<void>, number>;
 export const requestDomainForStore: RequestDomainForStoreThunk = id => dispatch => {
-  getDomain(id).then(domain => {
-    return dispatch(upsertDomain(domain));
+  return getDomain(id).then(domain => {
+    dispatch(upsertDomain(domain));
   });
 };
 


### PR DESCRIPTION
## Description

For historical reasons, DomainsDetail pages were relying on a getAllDomains() request from domains/index.tsx (the routing page for both landing and detail pages).

A change I put in 2 releases ago means that for large accounts, we no longer getAll() from the routing page (since this crashes the app for v large accounts), and instead relies on API pagination in the landing page table. 

The detail page doesn't have this pagination logic (obviously), and as a result no request for domains was being made. In addition, since the large account logic doesn't touch Redux, the Details page (which reads state from Redux) had no data to look at even when navigating from the landing view. Due to quirks of the routing logic, this meant an infinite loading spinner for anyone on a large account attempting to view a Domain's landing page directly.

I had trouble making the getDomain() request from the top level, so it made more sense to move the requests down one level. In principle, the change is simple:

1. When loading DomainsDetail from any angle, request the domain specified in the query params (we do this elsewhere)
2. Move the conditional getAll() request down to DomainsLanding, so that for smaller accounts there's no double request when loading a detail page

In practice, lots of plumbing had to shift around to accommodate this. I've logged in as some of the affected accounts and confirmed this fixes the issue, but please verify. In addition, check all possible Domain functionality:

- Landing page (small and large accounts)
- Details page (small and large accounts, from landing and loading directly, master and slave domains)
etc.
