### PR TITLE
M3-4461 -- Fix params for new-Linode backup restoration URLs

### DIFF
--- a/packages/manager/cypress/support/ui/constants.ts
+++ b/packages/manager/cypress/support/ui/constants.ts
@@ -80,7 +80,7 @@ export const pages = [
   },
   {
     name: 'Linode/Create/FromBackup',
-    url: `${routes.createLinode}?type=My%20Images&subtype=Backups`,
+    url: `${routes.createLinode}?type=Backups`,
     assertIsLoaded: () => cy.findByText('Select Backup').should('be.visible')
   },
   {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -514,7 +514,7 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
     const { history, linodeID } = this.props;
     history.push(
       '/linodes/create' +
-        `?type=My%20Images&subtype=Backups&backupID=${backup.id}&linodeID=${linodeID}`
+        `?type=Backups&backupID=${backup.id}&linodeID=${linodeID}`
     );
   };
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup_CMR.tsx
@@ -483,7 +483,7 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
     const { history, linodeID } = this.props;
     history.push(
       '/linodes/create' +
-        `?type=My%20Images&subtype=Backups&backupID=${backup.id}&linodeID=${linodeID}`
+        `?type=Backups&backupID=${backup.id}&linodeID=${linodeID}`
     );
   };
 


### PR DESCRIPTION
## Description

The URLs were mentioning a "subtype" parameter which appears to be deprecated at this point. Removing the existing "type" parameter and changing the "subtype" parameter to "type" seems to fix this.

Confirmed to work with the expected results in my locally deployed Cloud Manager environment. You should be able to replicate these working results on your end.

## TODO

- [ ] lots of `type=this&subtype=that` mentions throughout the code... these should probably be adjusted to the correct `type=` values throughout the entire codebase