### PR TITLE
For Release: Fix params for new Linode from Clone, from Image

### DIFF
--- a/packages/manager/cypress/support/ui/constants.ts
+++ b/packages/manager/cypress/support/ui/constants.ts
@@ -75,17 +75,17 @@ export const pages = [
   },
   {
     name: 'Linode/Create/FromImages',
-    url: `${routes.createLinode}?type=My%20Images&subtype=Images`,
+    url: `${routes.createLinode}?type=Images`,
     assertIsLoaded: () => cy.findByText('Choose an Image').should('be.visible')
   },
   {
     name: 'Linode/Create/FromBackup',
-    url: `${routes.createLinode}?type=My%20Images&subtype=Backups`,
+    url: `${routes.createLinode}?type=Backups`,
     assertIsLoaded: () => cy.findByText('Select Backup').should('be.visible')
   },
   {
     name: 'Linode/Create/Clone',
-    url: `${routes.createLinode}?type=My%20Images&subtype=Clone%20Linode`,
+    url: `${routes.createLinode}?type=Clone%20Linode`,
     assertIsLoaded: () =>
       cy.findByText('Select Linode to Clone From').should('be.visible')
   },

--- a/packages/manager/src/features/Images/ImagesLanding.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding.tsx
@@ -234,7 +234,7 @@ export const ImagesLanding: React.FC<CombinedProps> = props => {
     const { history } = props;
     history.push({
       pathname: `/linodes/create/`,
-      search: `?type=My%20Images&imageID=${imageID}`,
+      search: `?type=Images&imageID=${imageID}`,
       state: { selectedImageId: imageID }
     });
   };

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.test.tsx
@@ -34,10 +34,9 @@ describe('LinodeActionMenu', () => {
   const wrapper = shallow<LinodeActionMenu>(<LinodeActionMenu {...props} />);
 
   describe('buildQueryStringForLinodeClone', () => {
-    it('returns `type`, `subtype`, and `linodeID` params', () => {
+    it('returns `type` and `linodeID` params', () => {
       const result = wrapper.instance().buildQueryStringForLinodeClone();
       expect(result).toMatch('type=');
-      expect(result).toMatch('subtype=');
       expect(result).toMatch('linodeID=');
     });
 

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
@@ -96,8 +96,7 @@ export class LinodeActionMenu extends React.Component<CombinedProps, State> {
     } = this.props;
 
     const params: Record<string, string> = {
-      type: 'My Images',
-      subtype: 'Clone Linode',
+      type: 'Clone Linode',
       linodeID: String(linodeId)
     };
 

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu_CMR.tsx
@@ -118,8 +118,7 @@ export const LinodeActionMenu: React.FC<CombinedProps> = props => {
     const { linodeId, linodeRegion, linodeType } = props;
 
     const params: Record<string, string> = {
-      type: 'My Images',
-      subtype: 'Clone Linode',
+      type: 'Clone Linode',
       linodeID: String(linodeId)
     };
 

--- a/packages/manager/src/store/linodeCreate/linodeCreate.reducer.ts
+++ b/packages/manager/src/store/linodeCreate/linodeCreate.reducer.ts
@@ -30,10 +30,6 @@ export const getInitialType = (): CreateTypes => {
        */
       if (normalizedSubtype.includes('community' || 'account')) {
         return 'fromStackScript';
-      } else if (normalizedSubtype.includes('clone')) {
-        return 'fromLinode';
-      } else if (normalizedSubtype.includes('backup')) {
-        return 'fromBackup';
       } else {
         return 'fromApp';
       }
@@ -50,12 +46,6 @@ export const getInitialType = (): CreateTypes => {
        */
       if (normalizedType.includes('one-click')) {
         return 'fromApp';
-      } else if (normalizedType.includes('images')) {
-        return 'fromImage';
-      } else if (normalizedType.includes('backup')) {
-        return 'fromBackup';
-      } else if (normalizedType.includes('clone')) {
-        return 'fromLinode';
       } else {
         return 'fromImage';
       }

--- a/packages/manager/src/store/linodeCreate/linodeCreate.reducer.ts
+++ b/packages/manager/src/store/linodeCreate/linodeCreate.reducer.ts
@@ -30,6 +30,10 @@ export const getInitialType = (): CreateTypes => {
        */
       if (normalizedSubtype.includes('community' || 'account')) {
         return 'fromStackScript';
+      } else if (normalizedSubtype.includes('clone')) {
+        return 'fromLinode';
+      } else if (normalizedSubtype.includes('backup')) {
+        return 'fromBackup';
       } else {
         return 'fromApp';
       }


### PR DESCRIPTION
## Description

This PR addresses the links to create flow that determine the params needed for preselection in the Create flow, focusing on Images and Clone flows. Please note the work for backups references was addressed here: https://github.com/linode/manager/pull/6805 

## Type of Change
- Bug fix ('fix')

## Note to Reviewers

To test: 
• Select 'Deploy New Linode' from an Image action menu -> should take you to the Images tab in the create flow with that particular image selected. 
• Select 'Clone' from a Linode action menu  -> should take you to the Clone tab with the intended Linode preselected. 
