### PR TITLE
reduce GA hits by cutting theme events

### DIFF
--- a/packages/manager/src/utilities/ga.ts
+++ b/packages/manager/src/utilities/ga.ts
@@ -57,11 +57,12 @@ export const sendPaginationEvent = (
 
 // LinodeThemeWrapper.tsx
 export const sendCurrentThemeSettingsEvent = (eventAction: string) => {
-  sendEvent({
-    category: 'Theme Choice',
-    action: eventAction,
-    label: location.pathname
-  });
+  // AC 9/24/2020: disabling this event to reduce hits on GA as this seems to not be used
+  // sendEvent({
+  //   category: 'Theme Choice',
+  //   action: eventAction,
+  //   label: location.pathname
+  // });
 };
 
 // CreateVolumeForm.tsx
@@ -124,20 +125,22 @@ export const sendImportDisplayGroupSubmitEvent = (
 
 // LinodeThemeWrapper.tsx
 export const sendSpacingToggleEvent = (eventLabel: string) => {
-  sendEvent({
-    category: 'Theme Choice',
-    action: 'Spacing Toggle',
-    label: eventLabel
-  });
+  // AC 9/24/2020: disabling this event to reduce hits on GA as this seems to not be used
+  // sendEvent({
+  //   category: 'Theme Choice',
+  //   action: 'Spacing Toggle',
+  //   label: eventLabel
+  // });
 };
 
 // LinodeThemeWrapper.tsx
 export const sendThemeToggleEvent = (eventLabel: string) => {
-  sendEvent({
-    category: 'Theme Choice',
-    action: 'Theme Toggle',
-    label: eventLabel
-  });
+  // AC 9/24/2020: disabling this event to reduce hits on GA as this seems to not be used
+  // sendEvent({
+  //   category: 'Theme Choice',
+  //   action: 'Theme Toggle',
+  //   label: eventLabel
+  // });
 };
 
 // backupDrawer/index.ts

--- a/packages/manager/src/utilities/ga.ts
+++ b/packages/manager/src/utilities/ga.ts
@@ -57,7 +57,7 @@ export const sendPaginationEvent = (
 
 // LinodeThemeWrapper.tsx
 export const sendCurrentThemeSettingsEvent = (eventAction: string) => {
-  // AC 9/24/2020: disabling this event to reduce hits on GA as this seems to not be used
+  // AC 8/24/2020: disabling this event to reduce hits on GA as this seems to not be used
   // sendEvent({
   //   category: 'Theme Choice',
   //   action: eventAction,
@@ -125,7 +125,7 @@ export const sendImportDisplayGroupSubmitEvent = (
 
 // LinodeThemeWrapper.tsx
 export const sendSpacingToggleEvent = (eventLabel: string) => {
-  // AC 9/24/2020: disabling this event to reduce hits on GA as this seems to not be used
+  // AC 8/24/2020: disabling this event to reduce hits on GA as this seems to not be used
   // sendEvent({
   //   category: 'Theme Choice',
   //   action: 'Spacing Toggle',


### PR DESCRIPTION
## Description

Following discussion w/ Market we would want to reduce the hits on GA to avoid reaching our limit,
As a starting point to avoid reaching this limit We can cut the theme related `sendEvents`

We will further discuss with marketing how to rationalize our use of GA events.
If this change is not affecting anybody in the long term we will simply delete this code, not just comment it.


## Type of Change
- Non breaking change ('update', 'change')
