### PR TITLE
fix link when clicking on label link in details

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeControls.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeControls.tsx
@@ -101,10 +101,9 @@ const LinodeControls: React.FC<CombinedProps> = props => {
 
   const getLabelLink = (): string | undefined => {
     return last(location.pathname.split('/')) !== 'summary'
-      ? 'summary'
+      ? `${linode.id}/summary`
       : undefined;
   };
-
   return (
     <Grid
       container

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeControls.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeControls.tsx
@@ -114,7 +114,7 @@ const LinodeControls: React.FC<CombinedProps> = props => {
       <Grid item>
         <Breadcrumb
           pathname={props.location.pathname}
-          removeCrumbX={2}
+          firstAndLastOnly
           labelOptions={{ linkTo: getLabelLink() }}
           className={classes.breadCrumbs}
           onEditHandlers={


### PR DESCRIPTION
## Description

Fix to avoid click on label to return not found

I do not really like the fix though as it change the page look, any idea?
https://www.loom.com/share/8525fa39553949e58be23296151a1d64

## Type of Change
- Bug fix ('fix', 'repair', 'bug')
