### PR TITLE
Adding type back for determining createType

### DIFF
--- a/packages/manager/src/store/linodeCreate/linodeCreate.reducer.ts
+++ b/packages/manager/src/store/linodeCreate/linodeCreate.reducer.ts
@@ -47,9 +47,14 @@ export const getInitialType = (): CreateTypes => {
        * here we know we don't have a subtype in the query string
        * but we do have a type (AKA a parent tab is selected). In this case,
        * we can assume the first child tab is selected within the parent tabs
+       * This is needed to determine the createType for conditional logic in the UI.
        */
       if (normalizedType.includes('one-click')) {
         return 'fromApp';
+      } else if (normalizedType.includes('clone')) {
+        return 'fromLinode';
+      } else if (normalizedType.includes('backup')) {
+        return 'fromBackup';
       } else {
         return 'fromImage';
       }


### PR DESCRIPTION
## Description

These were originally removed for cleanup, but these actually determine what should be conditionally hidden in the UI. To test, can compare against staging:

• Try deploying a new Linode from clone. Note that on staging, the access (password) panel is displayed. In this PR, it should be hidden but preselection of clone selection will persist. 
• Try deploying a new Linode from backup. Note that on staging, the access panel and region sections are displayed. In this PR, those sections are hidden and preselections still persist.

## Type of Change
- Bug fix ('fix')