### PR TITLE
[CMR] M3-4472: Move ManagedDashboardCard to Dashboard

### DIFF
--- a/packages/manager/src/features/Dashboard/DashboardCard_CMR.tsx
+++ b/packages/manager/src/features/Dashboard/DashboardCard_CMR.tsx
@@ -1,0 +1,90 @@
+import * as classNames from 'classnames';
+import * as React from 'react';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+import Grid from 'src/components/Grid';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {},
+  container: {
+    marginTop: theme.spacing(3)
+  },
+  header: {
+    padding: theme.spacing(3),
+    paddingBottom: 0
+  },
+  headerAction: {
+    position: 'relative',
+    top: 6,
+    left: -theme.spacing(2),
+    marginLeft: theme.spacing(1) / 2
+  }
+}));
+
+interface Props {
+  title?: string;
+  className?: string;
+  alignHeader?: 'flex-start' | 'space-between';
+  alignItems?: 'center' | 'flex-start';
+  headerAction?: () => JSX.Element | JSX.Element[] | null;
+  noHeaderActionStyles?: boolean;
+}
+
+type CombinedProps = Props;
+
+const DashboardCard: React.FC<CombinedProps> = props => {
+  const classes = useStyles();
+
+  const {
+    alignHeader,
+    title,
+    headerAction,
+    noHeaderActionStyles,
+    className,
+    alignItems
+  } = props;
+
+  return (
+    <Grid
+      container
+      className={classNames(className, {
+        [classes.container]: true
+      })}
+      data-qa-card={title}
+    >
+      {(title || headerAction) && (
+        <Grid item xs={12}>
+          <Grid
+            container
+            className={classes.header}
+            alignItems={alignItems || 'flex-start'}
+            justify={alignHeader || 'space-between'}
+          >
+            {title && (
+              <Grid item className={'p0'}>
+                <Typography variant="h2">{title}</Typography>
+              </Grid>
+            )}
+            {headerAction && (
+              <Grid item className={'p0'}>
+                <Typography
+                  variant="body1"
+                  className={
+                    !noHeaderActionStyles ? classes.headerAction : undefined
+                  }
+                >
+                  {headerAction()}
+                </Typography>
+              </Grid>
+            )}
+          </Grid>
+        </Grid>
+      )}
+      <Grid item xs={12}>
+        {props.children}
+      </Grid>
+    </Grid>
+  );
+};
+
+export default DashboardCard;

--- a/packages/manager/src/features/Dashboard/ManagedDashboardCard/ManagedDashboardCard_CMR.tsx
+++ b/packages/manager/src/features/Dashboard/ManagedDashboardCard/ManagedDashboardCard_CMR.tsx
@@ -1,0 +1,207 @@
+import { getManagedStats, ManagedStatsData } from '@linode/api-v4/lib/managed';
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { compose } from 'recompose';
+import CircleProgress from 'src/components/CircleProgress';
+import Paper from 'src/components/core/Paper';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import ErrorState from 'src/components/ErrorState';
+import Grid from 'src/components/Grid';
+import withManagedIssues, {
+  DispatchProps as IssueDispatch,
+  ManagedIssuesProps
+} from 'src/containers/managedIssues.container';
+import withManaged, {
+  DispatchProps,
+  ManagedProps
+} from 'src/containers/managedServices.container';
+import { useAPIRequest } from 'src/hooks/useAPIRequest';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+
+import DashboardCard from '../DashboardCard_CMR';
+import ManagedChartPanel from './ManagedChartPanel';
+import MonitorStatus from './MonitorStatus';
+import MonitorTickets from './MonitorTickets';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    backgroundColor: theme.color.white,
+    margin: 0,
+    width: '100%',
+    [theme.breakpoints.up('sm')]: {
+      marginBottom: theme.spacing(3)
+    }
+  },
+  status: {
+    position: 'relative',
+    [theme.breakpoints.up('sm')]: {
+      margin: `${theme.spacing(3)}px ${theme.spacing(1)}px !important`
+    }
+  },
+  outerContainer: {
+    [theme.breakpoints.up('sm')]: {
+      flexWrap: 'nowrap'
+    }
+  },
+  detailsLink: {
+    fontSize: 14,
+    fontWeight: 'bold'
+  },
+  monitorStatusOuter: {
+    marginBottom: theme.spacing(1),
+    [theme.breakpoints.up('lg')]: {
+      marginBottom: theme.spacing(3) + 2
+    }
+  }
+}));
+
+type CombinedProps = ManagedProps &
+  DispatchProps &
+  ManagedIssuesProps &
+  IssueDispatch;
+
+export const ManagedDashboardCard: React.FC<CombinedProps> = props => {
+  const classes = useStyles();
+  const {
+    data,
+    loading,
+    lastUpdated,
+    error,
+    update
+  } = useAPIRequest<ManagedStatsData | null>(
+    () => getManagedStats().then(response => response.data),
+    null
+  );
+
+  React.useEffect(() => {
+    // Rely on Redux error handling.
+    props.requestManagedServices().catch(_ => null);
+    props.requestManagedIssues().catch(_ => null);
+
+    const interval = setInterval(() => {
+      props.requestManagedServices().catch(_ => null);
+      props.requestManagedIssues().catch(_ => null);
+      update();
+    }, 10000);
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, []);
+
+  const statsError =
+    error && data === null
+      ? getAPIErrorOrDefault(error, 'Unable to load your usage statistics.')[0]
+          .reason
+      : undefined;
+  const statsLoading = loading && lastUpdated === 0;
+
+  return (
+    <DashboardCard
+      title="Linode Managed"
+      alignHeader="space-between"
+      alignItems="center"
+      className={classes.root}
+      noHeaderActionStyles
+      headerAction={() => (
+        <Link to="/managed" className={classes.detailsLink}>
+          View details
+        </Link>
+      )}
+      data-qa-dash-managed
+    >
+      <Paper>
+        <LoadingErrorOrContent
+          {...props}
+          data={data}
+          statsError={statsError}
+          statsLoading={statsLoading}
+        />
+      </Paper>
+    </DashboardCard>
+  );
+};
+
+interface ContentProps extends CombinedProps {
+  data: ManagedStatsData | null;
+  statsLoading: boolean;
+  statsError?: string;
+}
+
+const LoadingErrorOrContent: React.FC<ContentProps> = props => {
+  const {
+    data,
+    issues,
+    managedError,
+    managedLoading,
+    monitors,
+    managedLastUpdated,
+    issuesLoading,
+    issuesError,
+    issuesLastUpdated,
+    statsError,
+    statsLoading
+  } = props;
+  const classes = useStyles();
+
+  /**
+   * Don't show error state if we've successfully retrieved
+   * monitor data but then a subsequent poll fails
+   */
+  if (
+    (managedError.read && managedLastUpdated === 0) ||
+    (issuesError.read && issuesLastUpdated === 0)
+  ) {
+    const errorString = getAPIErrorOrDefault(
+      managedError.read || issuesError.read || [],
+      'Error loading your Managed service information.'
+    )[0].reason;
+    return <ErrorState errorText={errorString} compact />;
+  }
+
+  if (
+    (managedLoading && managedLastUpdated === 0) ||
+    (issuesLoading && issuesLastUpdated === 0)
+  ) {
+    return <CircleProgress />;
+  }
+
+  return (
+    <Grid
+      container
+      direction="row"
+      justify="center"
+      alignItems="center"
+      className={classes.outerContainer}
+    >
+      <Grid
+        container
+        item
+        direction="column"
+        justify="space-around"
+        alignItems="center"
+        xs={12}
+        sm={5}
+        className={classes.status}
+      >
+        <Grid item className={classes.monitorStatusOuter}>
+          <MonitorStatus monitors={monitors} />
+        </Grid>
+        <Grid item>
+          <MonitorTickets issues={issues} />
+        </Grid>
+      </Grid>
+      <Grid item xs={12} sm={8} className="p0">
+        <ManagedChartPanel
+          data={data}
+          loading={statsLoading}
+          error={statsError}
+        />
+      </Grid>
+    </Grid>
+  );
+};
+
+const enhanced = compose<CombinedProps, {}>(withManaged(), withManagedIssues());
+
+export default enhanced(ManagedDashboardCard);

--- a/packages/manager/src/features/Dashboard_CMR/DashboardNotifications.tsx
+++ b/packages/manager/src/features/Dashboard_CMR/DashboardNotifications.tsx
@@ -1,8 +1,5 @@
 import { getInvoices } from '@linode/api-v4/lib/account';
-import { pathOr } from 'ramda';
 import * as React from 'react';
-import { connect } from 'react-redux';
-import { compose } from 'recompose';
 import Hidden from 'src/components/core/Hidden';
 import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
@@ -16,14 +13,10 @@ import {
 } from 'src/features/NotificationCenter';
 import useNotificationData from 'src/features/NotificationCenter/NotificationData/useNotificationData';
 import useAccount from 'src/hooks/useAccount';
+import useAccountManagement from 'src/hooks/useAccountManagement';
 import { useAPIRequest } from 'src/hooks/useAPIRequest';
-import { MapState } from 'src/store/types';
 import LinodeNews from './LinodeNews';
 import ManagedDashboardCard from '../Dashboard/ManagedDashboardCard/ManagedDashboardCard_CMR';
-
-interface StateProps {
-  managed: boolean;
-}
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -40,15 +33,13 @@ const useStyles = makeStyles((theme: Theme) => ({
   }
 }));
 
-export type CombinedProps = StateProps;
-
-export const Notifications: React.FC<CombinedProps> = props => {
+export const Notifications: React.FC<{}> = _ => {
   const classes = useStyles();
   const { account } = useAccount();
   const balance = account.data?.balance ?? 0;
   const balanceUninvoiced = account.data?.balance_uninvoiced ?? 0;
 
-  const { managed } = props;
+  const { _isManagedAccount } = useAccountManagement();
   const { community, pendingActions, support } = useNotificationData();
 
   const mostRecentInvoiceRequest = useAPIRequest<number | undefined>(
@@ -68,7 +59,7 @@ export const Notifications: React.FC<CombinedProps> = props => {
           mostRecentInvoiceId={mostRecentInvoiceRequest.data}
         />
       </Hidden>
-      {managed && <ManagedDashboardCard />}
+      {_isManagedAccount && <ManagedDashboardCard />}
       <Paper className={classes.root}>
         <Grid
           container
@@ -138,18 +129,4 @@ export const Notifications: React.FC<CombinedProps> = props => {
   );
 };
 
-const mapStateToProps: MapState<StateProps, {}> = state => {
-  return {
-    managed: pathOr(
-      false,
-      ['__resources', 'accountSettings', 'data', 'managed'],
-      state
-    )
-  };
-};
-
-const connected = connect(mapStateToProps);
-
-const enhanced = compose<CombinedProps, {}>(connected)(Notifications);
-
-export default enhanced;
+export default React.memo(Notifications);

--- a/packages/manager/src/features/Dashboard_CMR/DashboardNotifications.tsx
+++ b/packages/manager/src/features/Dashboard_CMR/DashboardNotifications.tsx
@@ -1,21 +1,29 @@
 import { getInvoices } from '@linode/api-v4/lib/account';
+import { pathOr } from 'ramda';
 import * as React from 'react';
+import { connect } from 'react-redux';
+import { compose } from 'recompose';
+import Hidden from 'src/components/core/Hidden';
 import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Grid from 'src/components/Grid';
-import useNotificationData from 'src/features/NotificationCenter/NotificationData/useNotificationData';
-import useAccount from 'src/hooks/useAccount';
-import { useAPIRequest } from 'src/hooks/useAPIRequest';
 import BillingSummary from 'src/features/Billing/BillingPanels/BillingSummary';
-import LinodeNews from './LinodeNews';
-
 import {
   Community,
   Maintenance,
   OpenSupportTickets,
   PendingActions
 } from 'src/features/NotificationCenter';
-import Hidden from 'src/components/core/Hidden';
+import useNotificationData from 'src/features/NotificationCenter/NotificationData/useNotificationData';
+import useAccount from 'src/hooks/useAccount';
+import { useAPIRequest } from 'src/hooks/useAPIRequest';
+import { MapState } from 'src/store/types';
+import LinodeNews from './LinodeNews';
+import ManagedDashboardCard from '../Dashboard/ManagedDashboardCard/ManagedDashboardCard_CMR';
+
+interface StateProps {
+  managed: boolean;
+}
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -32,12 +40,15 @@ const useStyles = makeStyles((theme: Theme) => ({
   }
 }));
 
-export const Notifications: React.FC<{}> = _ => {
+export type CombinedProps = StateProps;
+
+export const Notifications: React.FC<CombinedProps> = props => {
   const classes = useStyles();
   const { account } = useAccount();
   const balance = account.data?.balance ?? 0;
   const balanceUninvoiced = account.data?.balance_uninvoiced ?? 0;
 
+  const { managed } = props;
   const { community, pendingActions, support } = useNotificationData();
 
   const mostRecentInvoiceRequest = useAPIRequest<number | undefined>(
@@ -57,6 +68,7 @@ export const Notifications: React.FC<{}> = _ => {
           mostRecentInvoiceId={mostRecentInvoiceRequest.data}
         />
       </Hidden>
+      {managed && <ManagedDashboardCard />}
       <Paper className={classes.root}>
         <Grid
           container
@@ -126,4 +138,18 @@ export const Notifications: React.FC<{}> = _ => {
   );
 };
 
-export default React.memo(Notifications);
+const mapStateToProps: MapState<StateProps, {}> = state => {
+  return {
+    managed: pathOr(
+      false,
+      ['__resources', 'accountSettings', 'data', 'managed'],
+      state
+    )
+  };
+};
+
+const connected = connect(mapStateToProps);
+
+const enhanced = compose<CombinedProps, {}>(connected)(Notifications);
+
+export default enhanced;


### PR DESCRIPTION
Basically what the title says ☝️ 

Make sure managed is enabled in order to see the card and I made some minor styling changes to make it better match the CMR styles
- Adding a white background to the title and "View Details" link
- Making the padding/margin match the other Dashboard components

Before:
<img width="1243" alt="Screen Shot 2020-08-26 at 11 17 02 AM" src="https://user-images.githubusercontent.com/7692354/91322433-bc132e00-e78d-11ea-8cd3-73771f1fa9ce.png">

After:
<img width="1300" alt="Screen Shot 2020-08-26 at 11 16 53 AM" src="https://user-images.githubusercontent.com/7692354/91322417-b7e71080-e78d-11ea-8109-6f12ef546739.png">