### PR TITLE
removing event in GA for toggling action menu

### DIFF
--- a/packages/manager/src/utilities/ga.ts
+++ b/packages/manager/src/utilities/ga.ts
@@ -19,10 +19,11 @@ export const sendEvent = (eventPayload: AnalyticsEvent) => {
 
 // LinodeActionMenu.tsx
 export const sendLinodeActionEvent = () => {
-  sendEvent({
-    category: 'Linode Action Menu',
-    action: 'Open Action Menu'
-  });
+  // AC 8/26/2020: disabling this event to reduce hits on GA as this seems to not be used
+  // sendEvent({
+  //   category: 'Linode Action Menu',
+  //   action: 'Open Action Menu'
+  // });
 };
 
 // LinodeActionMenu.tsx


### PR DESCRIPTION
## Description

Removing a redundant event in GA from my POv.
today we track both:
- toggle of linode action menu
- select an action in action menu

Here are the hits
Linode Action Menu	117,749
Linode Action Menu Item	111,068

we can see that except if we wanted to know how often a user ens up not selecting an option the 1st event is pretty redundant

## Type of Change
- Non breaking change ('update', 'change')