### PR TITLE
Adding CMR header to the config/disk clone landing

### DIFF
--- a/packages/manager/src/features/linodes/CloneLanding/CloneLanding.tsx
+++ b/packages/manager/src/features/linodes/CloneLanding/CloneLanding.tsx
@@ -61,8 +61,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginTop: theme.spacing(1)
   },
   paper: {
-    paddingTop: theme.spacing(3),
-    paddingLeft: theme.spacing(3)
+    padding: `${theme.spacing(3)}px ${theme.spacing(3)}px 0`
   },
   appBar: {
     '& > div': {

--- a/packages/manager/src/features/linodes/CloneLanding/CloneLanding.tsx
+++ b/packages/manager/src/features/linodes/CloneLanding/CloneLanding.tsx
@@ -48,9 +48,13 @@ import {
   curriedCloneLandingReducer,
   defaultState
 } from './utilities';
+import useFlags from 'src/hooks/useFlags';
 
 const Configs = React.lazy(() => import('./Configs'));
 const Disks = React.lazy(() => import('./Disks'));
+const LinodesDetailHeader_CMR = React.lazy(() =>
+  import('../LinodesDetail/LinodesDetailHeader/LinodeDetailHeader_CMR')
+);
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -104,6 +108,7 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
   } = props;
 
   const classes = useStyles();
+  const flags = useFlags();
 
   /**
    * ROUTING
@@ -300,22 +305,26 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
       */}
       <MutationNotification disks={props.disks} />
       <Notifications />
-      <LinodeControls
-        breadcrumbProps={{
-          removeCrumbX: 4,
-          crumbOverrides: [
-            {
-              label,
-              position: 2,
-              linkTo: {
-                pathname: `/linodes/${linodeId}/summary`
-              },
-              noCap: true
-            }
-          ],
-          onEditHandlers: undefined
-        }}
-      />
+      {flags.cmr ? (
+        <LinodesDetailHeader_CMR />
+      ) : (
+        <LinodeControls
+          breadcrumbProps={{
+            removeCrumbX: 4,
+            crumbOverrides: [
+              {
+                label,
+                position: 2,
+                linkTo: {
+                  pathname: `/linodes/${linodeId}/summary`
+                },
+                noCap: true
+              }
+            ],
+            onEditHandlers: undefined
+          }}
+        />
+      )}
       {linodeInTransition(linodeStatus, firstEventWithProgress) && (
         <LinodeBusyStatus />
       )}

--- a/packages/manager/src/features/linodes/CloneLanding/CloneLanding.tsx
+++ b/packages/manager/src/features/linodes/CloneLanding/CloneLanding.tsx
@@ -278,7 +278,9 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
         setSubmitting(false);
         resetEventsPolling();
         requestDisks(linodeId);
-        history.push(`/linodes/${linodeId}/advanced`);
+        flags.cmr
+          ? history.push(`/linodes/${linodeId}/configurations`)
+          : history.push(`/linodes/${linodeId}/advanced`);
       })
       .catch(errors => {
         setSubmitting(false);
@@ -308,25 +310,27 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
       {flags.cmr ? (
         <LinodesDetailHeader_CMR />
       ) : (
-        <LinodeControls
-          breadcrumbProps={{
-            removeCrumbX: 4,
-            crumbOverrides: [
-              {
-                label,
-                position: 2,
-                linkTo: {
-                  pathname: `/linodes/${linodeId}/summary`
-                },
-                noCap: true
-              }
-            ],
-            onEditHandlers: undefined
-          }}
-        />
-      )}
-      {linodeInTransition(linodeStatus, firstEventWithProgress) && (
-        <LinodeBusyStatus />
+        <>
+          <LinodeControls
+            breadcrumbProps={{
+              removeCrumbX: 4,
+              crumbOverrides: [
+                {
+                  label,
+                  position: 2,
+                  linkTo: {
+                    pathname: `/linodes/${linodeId}/summary`
+                  },
+                  noCap: true
+                }
+              ],
+              onEditHandlers: undefined
+            }}
+          />
+          {linodeInTransition(linodeStatus, firstEventWithProgress) && (
+            <LinodeBusyStatus />
+          )}
+        </>
       )}
       <Grid container className={classes.root}>
         <Grid item xs={12} md={8} lg={9}>


### PR DESCRIPTION
## Description

Some background: Please note there are plans to make additional adjustments to this section post-CMR to more closely align with the new CMR patterns, but as John pointed out this is a complex part of the UI. Being this close to CMR's initial beta release, it is not worth adding any additional risk with this work.

**To view**: navigate to a Linode details page,  go to ‘Configurations’ tab, select ‘Clone’ from action menu. This will navigate you to an independent page for cloning a config/disk to a Linode. You should see the CMR header instead of the 'old' header UI.

## Type of Change
- Non breaking change ('update')