### PR TITLE
M3-4004: Graph labels hidden for mobile

### DIFF
--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -12,7 +12,12 @@ import 'chartjs-adapter-luxon';
 
 import LineChartIcon from 'src/assets/icons/line-chart.svg';
 import Button from 'src/components/Button';
-import { makeStyles, Theme } from 'src/components/core/styles';
+import {
+  makeStyles,
+  Theme,
+  useTheme,
+  useMediaQuery
+} from 'src/components/core/styles';
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
 import TableRow from 'src/components/core/TableRow';
@@ -81,6 +86,9 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
   const [hiddenDatasets, setHiddenDatasets] = React.useState<number[]>([]);
 
   const classes = useStyles();
+  const theme = useTheme<Theme>();
+  const matchesSmDown = useMediaQuery(theme.breakpoints.down(960));
+
   const {
     chartHeight,
     formatData,
@@ -260,30 +268,61 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
       {legendRendered && legendRows && (
         <div className={classes.container}>
           <Table aria-label="Stats and metrics" className={classes.root}>
-            <TableHead>
-              <TableRow>
-                <TableCell className={classes.tableHeadInner}>
-                  <Typography
-                    variant="body2"
-                    component="span"
-                    className={classes.text}
-                  >
-                    Toggle Graphs
-                  </Typography>
-                  <LineChartIcon className={classes.chartIcon} />
-                </TableCell>
-                {finalRowHeaders.map((section, i) => (
-                  <TableCell
-                    key={i}
-                    data-qa-header-cell
-                    className={classes.tableHeadInner}
-                  >
-                    <Typography variant="body2" className={classes.text}>
-                      {section}
+            <TableHead className={classes.tableHead}>
+              {matchesSmDown ? (
+                data.map((section, i) => (
+                  // eslint-disable-next-line react/jsx-key
+                  <TableRow>
+                    <TableCell
+                      className={`${classes.tableHeadInner} ${classes.toggle}`}
+                    >
+                      <Typography
+                        variant="body2"
+                        component="span"
+                        className={classes.text}
+                      >
+                        Toggle Graphs
+                      </Typography>
+                      <LineChartIcon className={classes.chartIcon} />
+                    </TableCell>
+                    {finalRowHeaders.map((section, i) => (
+                      <TableCell
+                        key={i}
+                        data-qa-header-cell
+                        className={classes.tableHeadInner}
+                      >
+                        <Typography variant="body2" className={classes.text}>
+                          {section}
+                        </Typography>
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))
+              ) : (
+                <TableRow>
+                  <TableCell className={classes.tableHeadInner}>
+                    <Typography
+                      variant="body2"
+                      component="span"
+                      className={`${classes.text} ${classes.toggle}`}
+                    >
+                      Toggle Graphs
                     </Typography>
+                    <LineChartIcon className={classes.chartIcon} />
                   </TableCell>
-                ))}
-              </TableRow>
+                  {finalRowHeaders.map((section, i) => (
+                    <TableCell
+                      key={i}
+                      data-qa-header-cell
+                      className={classes.tableHeadInner}
+                    >
+                      <Typography variant="body2" className={classes.text}>
+                        {section}
+                      </Typography>
+                    </TableCell>
+                  ))}
+                </TableRow>
+              )}
             </TableHead>
             <TableBody>
               {legendRows?.map((_tick: any, idx: number) => {

--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -269,22 +269,10 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
         <div className={classes.container}>
           <Table aria-label="Stats and metrics" className={classes.root}>
             <TableHead className={classes.tableHead}>
+              {/* Remove "Toggle Graph" label and repeat legend for each data set for mobile */}
               {matchesSmDown ? (
-                data.map((section, i) => (
-                  // eslint-disable-next-line react/jsx-key
-                  <TableRow>
-                    <TableCell
-                      className={`${classes.tableHeadInner} ${classes.toggle}`}
-                    >
-                      <Typography
-                        variant="body2"
-                        component="span"
-                        className={classes.text}
-                      >
-                        Toggle Graphs
-                      </Typography>
-                      <LineChartIcon className={classes.chartIcon} />
-                    </TableCell>
+                data.map(section => (
+                  <TableRow key={section.label}>
                     {finalRowHeaders.map((section, i) => (
                       <TableCell
                         key={i}
@@ -304,7 +292,7 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
                     <Typography
                       variant="body2"
                       component="span"
-                      className={`${classes.text} ${classes.toggle}`}
+                      className={classes.text}
                     >
                       Toggle Graphs
                     </Typography>

--- a/packages/manager/src/components/LineGraph/NewMetricDisplay.styles.ts
+++ b/packages/manager/src/components/LineGraph/NewMetricDisplay.styles.ts
@@ -12,6 +12,8 @@ export type ClassNames =
   | 'blue'
   | 'green'
   | 'text'
+  | 'toggle'
+  | 'tableHead'
   | 'tableHeadInner'
   | 'simpleLegend'
   | 'simpleLegendRoot'
@@ -60,12 +62,13 @@ const newMetricDisplayStyles = (theme: Theme) =>
       },
       [theme.breakpoints.down('sm')]: {
         maxWidth: '100%',
+        '& table': {
+          display: 'flex'
+        },
         '& td': {
           justifyContent: 'normal',
           minHeight: 'auto'
-        }
-      },
-      [theme.breakpoints.only('xs')]: {
+        },
         '& tr:not(:first-child) td': {
           '&:first-child': {
             marginTop: theme.spacing(2)
@@ -73,16 +76,28 @@ const newMetricDisplayStyles = (theme: Theme) =>
         }
       },
       [theme.breakpoints.only('sm')]: {
-        '& tr:not(:nth-last-child(n+3)) td:first-child': {
-          marginTop: theme.spacing(2)
-        },
         '& tbody': {
           display: 'flex',
           flexWrap: 'wrap',
           justifyContent: 'space-between'
         },
         '& tr': {
-          flexBasis: '45%'
+          flexBasis: '100%'
+        }
+      }
+    },
+    tableHead: {
+      [theme.breakpoints.down('sm')]: {
+        display: 'block !important',
+        '& tr': {
+          display: 'flex',
+          flexDirection: 'column',
+          marginTop: 26,
+          marginBottom: 42,
+          marginRight: theme.spacing(2),
+          '&:last-of-type': {
+            marginBottom: 0
+          }
         }
       }
     },
@@ -113,6 +128,11 @@ const newMetricDisplayStyles = (theme: Theme) =>
     },
     text: {
       color: theme.color.black
+    },
+    toggle: {
+      [theme.breakpoints.down('sm')]: {
+        display: 'none'
+      }
     },
     simpleLegendRoot: {
       maxWidth: 'initial',

--- a/packages/manager/src/components/LineGraph/NewMetricDisplay.styles.ts
+++ b/packages/manager/src/components/LineGraph/NewMetricDisplay.styles.ts
@@ -12,7 +12,6 @@ export type ClassNames =
   | 'blue'
   | 'green'
   | 'text'
-  | 'toggle'
   | 'tableHead'
   | 'tableHeadInner'
   | 'simpleLegend'
@@ -50,7 +49,10 @@ const newMetricDisplayStyles = (theme: Theme) =>
         backgroundColor: 'transparent'
       },
       '& td:first-child': {
-        backgroundColor: 'transparent !important'
+        backgroundColor: 'transparent !important',
+        [theme.breakpoints.down('sm')]: {
+          marginLeft: -50
+        }
       },
       '& .data': {
         minWidth: 100
@@ -128,11 +130,6 @@ const newMetricDisplayStyles = (theme: Theme) =>
     },
     text: {
       color: theme.color.black
-    },
-    toggle: {
-      [theme.breakpoints.down('sm')]: {
-        display: 'none'
-      }
     },
     simpleLegendRoot: {
       maxWidth: 'initial',


### PR DESCRIPTION
The labels for graphs on the Linode Detail view were previously hidden for mobile so I unhid them, changed the orientation of them to match the data and repeated the labels for each data set
