### PR TITLE
M3-4383 Always honor Linodes "group by tag"

### DIFF
--- a/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -367,14 +367,6 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
               preferenceOptions={[false, true]}
               preferenceKey="linodes_group_by_tag"
               toggleCallbackFnDebounced={sendGroupByAnalytic}
-              value={
-                // If some Linodes need maintenance, default to NOT grouping by tag.
-                // This is because the "Group by Tag" view can reduce visibility of Linodes needing
-                // maintenance, since the ordering of groups is alphanumeric and can't be changed.
-                this.props.someLinodesHaveScheduledMaintenance
-                  ? false
-                  : undefined
-              }
             >
               {({
                 preference: linodesAreGrouped,


### PR DESCRIPTION
## Description

I introduced a change [here](https://github.com/linode/manager/pull/6594/files#diff-117f855269a2f760c3c15da2fb97afd4R307) which meant that the “Group by Tag” toggle setting would be ignored if there are Linodes with pending maintenance. This was to ensure Linodes with maintenance always appeared at the top of the list.

We’ve gotten a lot of feedback from customers that are unhappy with this behavior. In retrospect, I can see how this is behavior is frustrating.

This PR reverses that "feature". I figure with the upcoming changes to the CMR dashboard, Linodes with pending maintenance will still be plenty visible.

## Note to Reviewers

**To test,** you'll need to mock a maintenance notification. Run the app with MSW, and either comment out the `/preferences` handlers, or change L156 of serverHandlers.ts to this:

```ts
return res(ctx.json({ display: 'compact', linodes_group_by_tag: true }));
```
