### PR TITLE
Fix "Cannot read property 'searchText' of undefined" error

### DIFF
--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -149,7 +149,7 @@ export const SearchBar: React.FC<CombinedProps> = props => {
       return;
     }
 
-    const text = item.data.searchText;
+    const text = item?.data?.searchText ?? '';
 
     if (item.value === 'redirect') {
       props.history.push({

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -205,7 +205,10 @@ export const SearchBar: React.FC<CombinedProps> = props => {
     _isLargeAccount ? apiResults : combinedResults,
     searchText,
     _loading || apiSearchLoading,
-    Boolean(apiError)
+    // Ignore "Unauthorized" errors, since these will always happen on LKE
+    // endpoints for restricted users. It's not really an "error" in this case.
+    // We still want these users to be able to use the search feature.
+    Boolean(apiError) && apiError !== 'Unauthorized'
   );
 
   return (

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -144,11 +144,12 @@ export const SearchBar: React.FC<CombinedProps> = props => {
     if (!item || item.label === '') {
       return;
     }
-    const text = item.data.searchText;
 
-    if (item.value === 'info') {
+    if (item.value === 'info' || item.value === 'error') {
       return;
     }
+
+    const text = item.data.searchText;
 
     if (item.value === 'redirect') {
       props.history.push({

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar_CMR.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar_CMR.tsx
@@ -145,11 +145,12 @@ export const SearchBar: React.FC<CombinedProps> = props => {
     if (!item || item.label === '') {
       return;
     }
-    const text = item.data.searchText;
 
-    if (item.value === 'info') {
+    if (item.value === 'info' || item.value === 'error') {
       return;
     }
+
+    const text = item.data.searchText;
 
     if (item.value === 'redirect') {
       props.history.push({

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar_CMR.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar_CMR.tsx
@@ -150,7 +150,7 @@ export const SearchBar: React.FC<CombinedProps> = props => {
       return;
     }
 
-    const text = item.data.searchText;
+    const text = item?.data?.searchText ?? '';
 
     if (item.value === 'redirect') {
       props.history.push({

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar_CMR.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar_CMR.tsx
@@ -206,7 +206,10 @@ export const SearchBar: React.FC<CombinedProps> = props => {
     _isLargeAccount ? apiResults : combinedResults,
     searchText,
     _loading || apiSearchLoading,
-    Boolean(apiError)
+    // Ignore "Unauthorized" errors, since these will always happen on LKE
+    // endpoints for restricted users. It's not really an "error" in this case.
+    // We still want these users to be able to use the search feature.
+    Boolean(apiError) && apiError !== 'Unauthorized'
   );
 
   return (


### PR DESCRIPTION
## Description

This error was being reported via Sentry. AFAICT this was happening when a user clicks the error message in the Search Bar. It doesn't crash the app or anything, but this will clean up some noise.

Zooming out, it looks like _some_ of the search errors were happening when a restricted users on a large account (and thus, using the API search) uses the search bar. In this case, LKE requests return a 403, resulting in an API error, making the search feature unusable. This also includes a (hacky) fix for that.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

**To test,** use a restricted user and change this line: https://github.com/linode/manager/blob/e504be951e013f733c0f4a55ca93701989a562c0/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx#L110 to `if (true)` to use the API search method. Type in the search bar. On develop, you'll see an error, and clicking the error results in a console error. With this branch, the error shouldn't be there to begin with (but if you do simulate one and click on it, there should be no console noise.

Please check CMR and non-CMR, and verify the search bar otherwise works correctly.
