### PR TITLE
Fix tab change handler

### DIFF
--- a/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
+++ b/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
@@ -95,7 +95,7 @@ interface Props {
   initTab?: number;
   bodyClass?: string;
   noPadding?: boolean;
-  handleTabChange?: (e: any, value: number) => void;
+  handleTabChange?: (index: number) => void;
   value?: number;
 }
 
@@ -130,7 +130,7 @@ export const TabbedPanel: React.FC<CombinedProps> = props => {
           </Typography>
         )}
 
-        <Tabs className={classes.tabsWrapper}>
+        <Tabs className={classes.tabsWrapper} onChange={handleTabChange}>
           <TabList className={classes.tabList}>
             {tabs.map((tab, idx) => (
               <Tab className={classes.tab} key={`tabs-${tab.title}-${idx}`}>
@@ -143,7 +143,6 @@ export const TabbedPanel: React.FC<CombinedProps> = props => {
             {tabs.map((tab, idx) => (
               <TabPanel
                 className={classes.tabPanel}
-                onChange={handleTabChange}
                 key={`tabs-panel-${tab.title}-${idx}`}
               >
                 {tab.render(rest.children)}


### PR DESCRIPTION
## Description

This fixes an issue with the StackScript Landing tabs. Two things were happening:

1. The handleTabChange function was happening on every keystroke from the search bar, resulting in a “Cannot read property 'category' of undefined” error (reported via Sentry).
2. The query string was not being properly updated when switching tabs.

These things were happening because the `handleTabChange` prop was incorrectly being passed to `<TabPanels />` instead of `<Tabs />` in TabbedPanel.tsx.

This also fixes the fact that the Select Plan panel wasn’t resetting in the LKE “Add a pool” drawer when switching tabs. 

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

To test, go to the StackScript landing page and experiment with the search bar. Please also check the LKE "Add a Node Pool" drawer, and tab functionality elsewhere in the app.
