### PR TITLE
Change: All IPv6 for Firewalls should be read as ::/0

### DIFF
--- a/packages/manager/cypress/integration/firewall/migrate-linode-with-firewall.spec.ts
+++ b/packages/manager/cypress/integration/firewall/migrate-linode-with-firewall.spec.ts
@@ -43,14 +43,14 @@ describe('Migrate Linode With Firewall', () => {
                 {
                   ports: '80',
                   protocol: 'TCP',
-                  addresses: { ipv4: ['0.0.0.0/0'], ipv6: ['::0/0'] }
+                  addresses: { ipv4: ['0.0.0.0/0'], ipv6: ['::/0'] }
                 }
               ],
               outbound: [
                 {
                   ports: '80',
                   protocol: 'TCP',
-                  addresses: { ipv4: ['0.0.0.0/0'], ipv6: ['::0/0'] }
+                  addresses: { ipv4: ['0.0.0.0/0'], ipv6: ['::/0'] }
                 }
               ]
             },

--- a/packages/manager/src/factories/firewalls.ts
+++ b/packages/manager/src/factories/firewalls.ts
@@ -12,7 +12,7 @@ export const firewallRuleFactory = Factory.Sync.makeFactory<FirewallRuleType>({
   protocol: 'TCP',
   addresses: {
     ipv4: ['0.0.0.0/0'],
-    ipv6: ['::0/0']
+    ipv6: ['::/0']
   }
 });
 

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.test.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.test.tsx
@@ -47,7 +47,7 @@ describe('utilities', () => {
       });
       expect(formValueToIPs('allIPv6', [''].map(stringToExtendedIP))).toEqual({
         ipv4: [],
-        ipv6: ['::0/0']
+        ipv6: ['::/0']
       });
       expect(
         formValueToIPs('ip/netmask', ['1.1.1.1'].map(stringToExtendedIP))

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.test.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.test.tsx
@@ -6,7 +6,7 @@ describe('firewallRuleToRowData', () => {
     const rule: ExtendedFirewallRule = {
       ports: '22',
       protocol: 'TCP',
-      addresses: { ipv4: ['0.0.0.0/0'], ipv6: ['::0/0'] },
+      addresses: { ipv4: ['0.0.0.0/0'], ipv6: ['::/0'] },
       status: 'NOT_MODIFIED'
     };
     expect(firewallRuleToRowData([rule])[0]).toHaveProperty('type', 'SSH');

--- a/packages/manager/src/features/Firewalls/shared.test.ts
+++ b/packages/manager/src/features/Firewalls/shared.test.ts
@@ -128,7 +128,7 @@ describe('generateAddressLabel', () => {
     expect(
       generateAddressesLabel({
         ipv4: ['1.1.1.1', '2.2.2.2', '3.3.3.3', '4.4.4.4', '5.5.5.5'],
-        ipv6: ['::0/0']
+        ipv6: ['::/0']
       })
     ).toBe('All IPv6, 1.1.1.1, 2.2.2.2, plus 3 more');
   });

--- a/packages/manager/src/features/Firewalls/shared.ts
+++ b/packages/manager/src/features/Firewalls/shared.ts
@@ -78,7 +78,7 @@ export const portPresets: Record<FirewallPreset, string> = {
 };
 
 export const allIPv4 = '0.0.0.0/0';
-export const allIPv6 = '::0/0';
+export const allIPv6 = '::/0';
 
 export const allIPs = {
   ipv4: [allIPv4],


### PR DESCRIPTION
## Description

Apparently the value we were sending to the API for "Allow All IPv6" (`::0/0`) can possibly break things on Debian 10. Use the correct value (`::/0`)