### PR TITLE
Firewalls: Fix handling of empty IPv6 responses

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
@@ -507,10 +507,10 @@ export const getInitialIPs = (
 ): ExtendedIP[] => {
   const { addresses } = ruleToModify;
 
-  const ips: ExtendedIP[] = [
-    ...addresses?.ipv4?.map(stringToExtendedIP),
-    ...addresses?.ipv6?.map(stringToExtendedIP)
-  ];
+  const extendedIPv4 = (addresses?.ipv4 ?? []).map(stringToExtendedIP);
+  const extendedIPv6 = (addresses?.ipv6 ?? []).map(stringToExtendedIP);
+
+  const ips: ExtendedIP[] = [...extendedIPv4, ...extendedIPv6];
 
   // eslint-disable-next-line no-unused-expressions
   ruleToModify.errors?.forEach(thisError => {
@@ -547,6 +547,7 @@ export const validateForm = (protocol?: string, ports?: string) => {
   const errors: Partial<Form> = {};
 
   if (!protocol) {
+    // eslint-disable-next-line
     errors.protocol = 'Protocol is required.';
   }
 


### PR DESCRIPTION
If a user uses the API to manually set their Addresses field for a rule
and leaves either ipv6 or ipv6 undefined (instead of an empty array, which
is how we handle this), the app will crash when trying to open the edit drawer.

Not sure that `undefined` should be a valid value here, but since the API allows
it for now we should handle the edge case.

## Note

To test: set a firewall rule's `address` to have either ipv4 or ipv6 be an array of strings, but the other undefined. On develop, the app will crash when opening the Edit rule drawer. This should fix it.