### PR TITLE
M3-4486 Fix: Move domains banner above table

### DIFF
--- a/packages/manager/src/features/Domains/DomainsLanding.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.tsx
@@ -429,6 +429,18 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
     return (
       <React.Fragment>
         <DocumentTitleSegment segment="Domains" />
+        {shouldShowBanner && (
+          <Notice warning important className={classes.dnsWarning}>
+            <Typography variant="h3">
+              Your DNS zones are not being served.
+            </Typography>
+            <Typography>
+              Your domains will not be served by Linode&#39;s nameservers unless
+              you have at least one active Linode on your account.
+              <Link to="/linodes/create"> You can create one here.</Link>
+            </Typography>
+          </Notice>
+        )}
         <PreferenceToggle<boolean>
           preferenceKey="domains_group_by_tag"
           preferenceOptions={[false, true]}
@@ -523,22 +535,7 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
                     </Grid>
                   </Grid>
                 )}
-                {shouldShowBanner && (
-                  <Notice warning important className={classes.dnsWarning}>
-                    <Typography variant="h3">
-                      Your DNS zones are not being served.
-                    </Typography>
-                    <Typography>
-                      Your domains will not be served by Linode&#39;s
-                      nameservers unless you have at least one active Linode on
-                      your account.
-                      <Link to="/linodes/create">
-                        {' '}
-                        You can create one here.
-                      </Link>
-                    </Typography>
-                  </Notice>
-                )}
+
                 {this.props.location.state &&
                   this.props.location.state.recordError && (
                     <Notice

--- a/packages/manager/src/features/Domains/DomainsLanding.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.tsx
@@ -441,6 +441,9 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
             </Typography>
           </Notice>
         )}
+        {this.props.location.state?.recordError && (
+          <Notice error text={this.props.location.state.recordError} />
+        )}
         <PreferenceToggle<boolean>
           preferenceKey="domains_group_by_tag"
           preferenceOptions={[false, true]}
@@ -535,14 +538,6 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
                     </Grid>
                   </Grid>
                 )}
-
-                {this.props.location.state &&
-                  this.props.location.state.recordError && (
-                    <Notice
-                      error
-                      text={this.props.location.state.recordError}
-                    />
-                  )}
                 <Table
                   entity="domain"
                   groupByTag={domainsAreGrouped}


### PR DESCRIPTION
## Description

We display a banner to users who have Domains but not Linodes, letting them know that their Domains aren't being served. This banner is sandwiched between the CMR table header and table, which looks weird. Moved it above all the headers. 

I moved an error Notice while I was at it; I'm not sure it's possible for this error to ever be displayed, but maybe I'm reading the logic incorrectly. Had to hardcode to test it.

## Note to Reviewers

Have at least one Domain and exactly 0 Linodes on your account, and go to Domains landing. Please check with and without CMR.