### PR TITLE
Prevent error message overlap on Firewalls detail

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
@@ -90,7 +90,12 @@ export const FirewallDetail: React.FC<CombinedProps> = props => {
   return (
     <React.Fragment>
       <DocumentTitleSegment segment={thisFirewall.label} />
-      <Box display="flex" flexDirection="row" justifyContent="space-between">
+      <Box
+        display="flex"
+        flexDirection="row"
+        justifyContent="space-between"
+        paddingBottom={'20px'}
+      >
         <Breadcrumb
           pathname={props.location.pathname}
           removeCrumbX={2}


### PR DESCRIPTION
## Description

Before:

![Screen Shot 2020-08-28 at 10 05 13 AM](https://user-images.githubusercontent.com/1624067/91576991-1b03af00-e916-11ea-94ed-ded28d418aac.png)


After:

![Screen Shot 2020-08-28 at 10 03 34 AM](https://user-images.githubusercontent.com/1624067/91577002-1e973600-e916-11ea-89c8-1c2174de2e67.png)


## Note to Reviewers

Try changing a firewall's name to something illegal (add whitespace for example) using the editable breadcrumb on the Firewall detail page.