### PR TITLE
M3-4385 fix: NodeBalancer Config form submission

### DIFF
--- a/packages/manager/src/factories/nodebalancer.ts
+++ b/packages/manager/src/factories/nodebalancer.ts
@@ -1,5 +1,9 @@
 import * as Factory from 'factory.ts';
-import { NodeBalancer } from '@linode/api-v4/lib/nodebalancers/types';
+import {
+  NodeBalancer,
+  NodeBalancerConfig,
+  NodeBalancerConfigNode
+} from '@linode/api-v4/lib/nodebalancers/types';
 
 export const nodeBalancerFactory = Factory.Sync.makeFactory<NodeBalancer>({
   id: Factory.each(id => id),
@@ -17,4 +21,42 @@ export const nodeBalancerFactory = Factory.Sync.makeFactory<NodeBalancer>({
     total: 0
   },
   tags: []
+});
+
+export const nodeBalancerConfigFactory = Factory.Sync.makeFactory<
+  NodeBalancerConfig
+>({
+  id: Factory.each(id => id),
+  algorithm: 'roundrobin',
+  check: 'connection',
+  check_attempts: 2,
+  check_body: '',
+  check_interval: 5,
+  check_passive: true,
+  check_path: '/ping_me',
+  check_timeout: 3,
+  cipher_suite: 'recommended',
+  nodebalancer_id: Factory.each(id => id),
+  nodes_status: { up: 0, down: 1 },
+  port: 80,
+  protocol: 'http',
+  nodes: [],
+  ssl_cert: '',
+  ssl_commonname: '',
+  ssl_fingerprint: '',
+  ssl_key: '',
+  stickiness: 'table'
+});
+
+export const nodeBalancerConfigNodeFactory = Factory.Sync.makeFactory<
+  NodeBalancerConfigNode
+>({
+  id: Factory.each(id => id),
+  address: '192.168.0.1:80',
+  config_id: Factory.each(id => id),
+  label: 'test',
+  mode: 'accept',
+  nodebalancer_id: Factory.each(id => id),
+  status: 'DOWN',
+  weight: 100
 });

--- a/packages/manager/src/features/NodeBalancers/utils.ts
+++ b/packages/manager/src/features/NodeBalancers/utils.ts
@@ -157,5 +157,5 @@ export const shouldIncludeCheckPath = (config: NodeBalancerConfigFields) => {
 };
 
 export const shouldIncludeCheckBody = (config: NodeBalancerConfigFields) => {
-  return config.check === 'http_body' && config.check_path;
+  return config.check === 'http_body' && config.check_body;
 };

--- a/packages/manager/src/features/NodeBalancers/utils.ts
+++ b/packages/manager/src/features/NodeBalancers/utils.ts
@@ -88,7 +88,6 @@ export const transformConfigsForRequest = (
       /* remove the (key: value) pairs that we set to undefined */
       el => el !== undefined,
       {
-        check_path: config.check_path || undefined,
         protocol:
           /*
            * If the provided protocol is "https" and the cert and key are set
@@ -113,7 +112,12 @@ export const transformConfigsForRequest = (
           ? +config.check_attempts
           : undefined,
         port: config.port ? +config.port : undefined,
-        check_body: config.check_body || undefined,
+        check_path: shouldIncludeCheckPath(config)
+          ? config.check_path
+          : undefined,
+        check_body: shouldIncludeCheckBody(config)
+          ? config.check_body
+          : undefined,
         check_passive: config.check_passive /* will be boolean or undefined */,
         cipher_suite: config.cipher_suite || undefined,
         ssl_cert:
@@ -143,4 +147,15 @@ export const transformConfigNodesForRequest = (
   return nodes.map((node: NodeBalancerConfigNodeFields) =>
     nodeForRequest(node)
   );
+};
+
+export const shouldIncludeCheckPath = (config: NodeBalancerConfigFields) => {
+  return (
+    (config.check === 'http' || config.check === 'http_body') &&
+    config.check_path
+  );
+};
+
+export const shouldIncludeCheckBody = (config: NodeBalancerConfigFields) => {
+  return config.check === 'http_body' && config.check_path;
 };

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -29,7 +29,9 @@ import {
   volumeFactory,
   accountTransferFactory,
   eventFactory,
-  tagFactory
+  tagFactory,
+  nodeBalancerConfigFactory,
+  nodeBalancerConfigNodeFactory
 } from 'src/factories';
 
 import cachedRegions from 'src/cachedData/regions.json';
@@ -141,6 +143,27 @@ export const handlers = [
     const nodeBalancers = nodeBalancerFactory.buildList(10);
     return res(ctx.json(makeResourcePage(nodeBalancers)));
   }),
+  rest.get('*/nodebalancers/:nodeBalancerID', (req, res, ctx) => {
+    const nodeBalancer = nodeBalancerFactory.build({
+      id: req.params.nodeBalancerID
+    });
+    return res(ctx.json(nodeBalancer));
+  }),
+  rest.get('*/nodebalancers/:nodeBalancerID/configs', (req, res, ctx) => {
+    const configs = nodeBalancerConfigFactory.buildList(2, {
+      nodebalancer_id: req.params.nodeBalancerID
+    });
+    return res(ctx.json(makeResourcePage(configs)));
+  }),
+  rest.get(
+    '*/nodebalancers/:nodeBalancerID/configs/:configID/nodes',
+    (req, res, ctx) => {
+      const configs = nodeBalancerConfigNodeFactory.buildList(2, {
+        nodebalancer_id: req.params.nodeBalancerID
+      });
+      return res(ctx.json(makeResourcePage(configs)));
+    }
+  ),
   rest.get('*/domains', (req, res, ctx) => {
     const domains = domainFactory.buildList(25);
     return res(ctx.json(makeResourcePage(domains)));


### PR DESCRIPTION
## Description

This is a fun one. The basic problem here is that the "Check HTTP Path" and "Expected HTTP Body" form fields are _only shown_ when "HTTP Status" or "HTTP Body" is selected as the health check type.

As a result, if there are _errors for these fields_ upon form submission, the error message is displayed **only if one of these types is selected.** 

This scenario only happens when updating an existing config _with a check_path/body,_ because we **re-submit all existing fields on the config** when making the PUT request.

The most straightforward way to find yourself in this state:

**When editing a config:**
- Select "Check HTTP Path" as the health check type. 
- Enter an invalid HTTP Path (e.g. `/ping_me`). 
- Change the health check type to "None". 
- Submit the form. 
- Observe: since the correct health check type isn't selected, the form submission fails silently. It even sort of seems like it _works_, which has caused great confusion for users.

To fix this issue, we simply don't submit `check_path` or `check_body` unless the appropriate health check type has been selected.

**Check the ticket for a few more details.**

## Note to Reviewers

To test, follow the steps above.
