### PR TITLE
fixes mysql tab not rendering if not nginx

### DIFF
--- a/packages/manager/src/features/Longview/LongviewDetail/LongviewDetail.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/LongviewDetail.tsx
@@ -274,7 +274,7 @@ export const LongviewDetail: React.FC<CombinedProps> = props => {
             </SafeTabPanel>
 
             {client && client.apps.apache && (
-              <SafeTabPanel index={client && client.apps.apache ? 4 : null}>
+              <SafeTabPanel index={4}>
                 <Apache
                   timezone={timezone}
                   clientAPIKey={clientAPIKey}
@@ -285,7 +285,7 @@ export const LongviewDetail: React.FC<CombinedProps> = props => {
             )}
 
             {client && client.apps.nginx && (
-              <SafeTabPanel index={4 + (client.apps.apache ? 1 : 0)}>
+              <SafeTabPanel index={client.apps.apache ? 5 : 4}>
                 <NGINX
                   timezone={timezone}
                   clientAPIKey={clientAPIKey}

--- a/packages/manager/src/features/Longview/LongviewDetail/LongviewDetail.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/LongviewDetail.tsx
@@ -115,6 +115,7 @@ export const LongviewDetail: React.FC<CombinedProps> = props => {
     { Ports: { listening: [], active: [] } },
     [clientAPIKey, lastUpdated]
   );
+  console.warn('route to match', props.match.url, client?.apps.mysql);
 
   const tabOptions = [
     {
@@ -285,15 +286,7 @@ export const LongviewDetail: React.FC<CombinedProps> = props => {
             )}
 
             {client && client.apps.nginx && (
-              <SafeTabPanel
-                index={
-                  client.apps.nginx && client.apps.apache
-                    ? 5
-                    : client.apps.nginx && !client.apps.apache
-                    ? 4
-                    : null
-                }
-              >
+              <SafeTabPanel index={4 + (client.apps.apache ? 1 : 0)}>
                 <NGINX
                   timezone={timezone}
                   clientAPIKey={clientAPIKey}
@@ -306,16 +299,7 @@ export const LongviewDetail: React.FC<CombinedProps> = props => {
             {client && client.apps.mysql && (
               <SafeTabPanel
                 index={
-                  client.apps.mysql && client.apps.nginx && client.apps.apache
-                    ? 6
-                    : (client.apps.mysql && !client.apps.apache) ||
-                      !client.apps.nginx
-                    ? 5
-                    : client.apps.mysql &&
-                      !client.apps.apache &&
-                      !client.apps.nginx
-                    ? 4
-                    : null
+                  4 + (client.apps.nginx ? 1 : 0) + (client.apps.apache ? 1 : 0)
                 }
               >
                 <MySQLLanding

--- a/packages/manager/src/features/Longview/LongviewDetail/LongviewDetail.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/LongviewDetail.tsx
@@ -115,7 +115,6 @@ export const LongviewDetail: React.FC<CombinedProps> = props => {
     { Ports: { listening: [], active: [] } },
     [clientAPIKey, lastUpdated]
   );
-  console.warn('route to match', props.match.url, client?.apps.mysql);
 
   const tabOptions = [
     {


### PR DESCRIPTION
## Description

So this is to fix the logix to compute the tab index based on what processes are running on the client machine. in a client case mysql was not rendered (tabindex null) due to a case not handled by the previous code

see ticket M3-4491
## Type of Change
- Bug fix ('fix', 'repair', 'bug')