### PR TITLE
M3-4382: Don't set Redux error when "getOneLinode" request fails

### DIFF
--- a/packages/manager/src/store/linodes/linodes.reducer.ts
+++ b/packages/manager/src/store/linodes/linodes.reducer.ts
@@ -7,8 +7,7 @@ import {
   onError,
   onGetAllSuccess,
   onGetOneSuccess,
-  onStart,
-  onGetOneFailure
+  onStart
 } from 'src/store/store.helpers.tmp';
 import { EntityError, MappedEntityState2 } from 'src/store/types';
 import { isType } from 'typescript-fsa';
@@ -74,7 +73,7 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
   }
 
   if (isType(action, getLinodeActions.failed)) {
-    return onGetOneFailure(state);
+    return onError({}, state);
   }
 
   if (isType(action, upsertLinode)) {

--- a/packages/manager/src/store/linodes/linodes.reducer.ts
+++ b/packages/manager/src/store/linodes/linodes.reducer.ts
@@ -7,7 +7,8 @@ import {
   onError,
   onGetAllSuccess,
   onGetOneSuccess,
-  onStart
+  onStart,
+  onGetOneFailure
 } from 'src/store/store.helpers.tmp';
 import { EntityError, MappedEntityState2 } from 'src/store/types';
 import { isType } from 'typescript-fsa';
@@ -73,14 +74,7 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
   }
 
   if (isType(action, getLinodeActions.failed)) {
-    const { error } = action.payload;
-
-    return onError(
-      {
-        read: error
-      },
-      state
-    );
+    return onGetOneFailure(state);
   }
 
   if (isType(action, upsertLinode)) {

--- a/packages/manager/src/store/store.helpers.tmp.ts
+++ b/packages/manager/src/store/store.helpers.tmp.ts
@@ -209,11 +209,3 @@ export const onGetOneSuccess = <E extends Entity>(
     results: Object.keys(state.itemsById).length,
     itemsById: { ...state.itemsById, [entity.id]: entity }
   });
-
-// Don't set the global `error.read` state when a request to get only ONE item fails.
-export const onGetOneFailure = <E extends Entity>(
-  state: MappedEntityState<E>
-): MappedEntityState<E> =>
-  Object.assign({}, state, {
-    loading: false
-  });

--- a/packages/manager/src/store/store.helpers.tmp.ts
+++ b/packages/manager/src/store/store.helpers.tmp.ts
@@ -210,8 +210,7 @@ export const onGetOneSuccess = <E extends Entity>(
     itemsById: { ...state.itemsById, [entity.id]: entity }
   });
 
-// We don't want to set the global `error.read` state when a request to
-// get ONE item fails. This error is reserved for `getMany` failures.
+// Don't set the global `error.read` state when a request to get only ONE item fails.
 export const onGetOneFailure = <E extends Entity>(
   state: MappedEntityState<E>
 ): MappedEntityState<E> =>

--- a/packages/manager/src/store/store.helpers.tmp.ts
+++ b/packages/manager/src/store/store.helpers.tmp.ts
@@ -209,3 +209,12 @@ export const onGetOneSuccess = <E extends Entity>(
     results: Object.keys(state.itemsById).length,
     itemsById: { ...state.itemsById, [entity.id]: entity }
   });
+
+// We don't want to set the global `error.read` state when a request to
+// get ONE item fails. This error is reserved for `getMany` failures.
+export const onGetOneFailure = <E extends Entity>(
+  state: MappedEntityState<E>
+): MappedEntityState<E> =>
+  Object.assign({}, state, {
+    loading: false
+  });


### PR DESCRIPTION
## Description

Previously, a failed request to get one Linode set the Redux error state (i.e. linodes.error.read). This meant that, for example:

1. Navigate to /linode/instances/hello/
2. Observe the 404 page.
3. Navigate to the Linodes List page.
4. Observe: "Not found" error.

This removes the setting of that error, which AFAICT isn't being used in this context anywhere.

I went through our Redux code to see if this issue was happening with other entities, but didn't find anything.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')


## Note to Reviewers

To test, please verify the bug fix with the steps above. Also please check general Redux-y Linodes things around the app (simulating loading failures, updating Linodes, etc.) to check for regressions.