### PR TITLE
Remove console warning from env switcher

### DIFF
--- a/packages/manager/src/dev-tools/EnvironmentToggleTool.tsx
+++ b/packages/manager/src/dev-tools/EnvironmentToggleTool.tsx
@@ -66,18 +66,15 @@ const EnvironmentToggleTool: React.FC<{}> = () => {
             );
             setSelectedOption(Math.max(selectedIndex, 0));
           }}
+          defaultValue={currentEnvLabel}
         >
-          <option value="" disabled selected>
+          <option value="" disabled>
             Select an environment
           </option>
           {options.map(thisOption => {
             const { label } = thisOption;
             return (
-              <option
-                key={label}
-                value={label}
-                selected={currentEnvLabel === label}
-              >
+              <option key={label} value={label}>
                 {label}
               </option>
             );


### PR DESCRIPTION
## Description

Fixes a console warning coming from the environment switcher:

![Screen Shot 2020-08-28 at 10 27 49 PM](https://user-images.githubusercontent.com/16911484/91626510-b5e3a400-e97d-11ea-9e35-8d5baa72f528.png)
