### PR TITLE
Change: Don't set outbound rules for firewall presets

### DIFF
--- a/packages/api-v4/src/firewalls/firewalls.schema.ts
+++ b/packages/api-v4/src/firewalls/firewalls.schema.ts
@@ -24,12 +24,8 @@ const FirewallRuleTypeSchema = object().shape({
 });
 
 export const FirewallRuleSchema = object().shape({
-  inbound: array(FirewallRuleTypeSchema)
-    .required('You must provide a set of Firewall rules.')
-    .nullable(true),
-  outbound: array(FirewallRuleTypeSchema)
-    .required('You must provide a set of Firewall rules.')
-    .nullable(true)
+  inbound: array(FirewallRuleTypeSchema).nullable(true),
+  outbound: array(FirewallRuleTypeSchema).nullable(true)
 });
 
 export const CreateFirewallSchema = object().shape({

--- a/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.tsx
@@ -71,8 +71,8 @@ export const mergeRules = (
         return acc;
       }
       return {
-        inbound: [...acc.inbound, ...rule.inbound],
-        outbound: [...acc.outbound, ...rule.outbound]
+        inbound: [...(acc?.inbound ?? []), ...(rule.inbound ?? [])],
+        outbound: [...(acc?.outbound ?? []), ...(rule.outbound ?? [])]
       };
     },
     {
@@ -103,6 +103,14 @@ const AddFirewallDrawer: React.FC<CombinedProps> = props => {
 
     if (values.label === '') {
       values.label = undefined;
+    }
+
+    if (values.rules.inbound === []) {
+      values.rules.inbound = undefined;
+    }
+
+    if (values.rules.outbound === []) {
+      values.rules.outbound = undefined;
     }
 
     onSubmit(values)

--- a/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.tsx
@@ -105,11 +105,17 @@ const AddFirewallDrawer: React.FC<CombinedProps> = props => {
       values.label = undefined;
     }
 
-    if (values.rules.inbound === []) {
+    if (
+      Array.isArray(values.rules.inbound) &&
+      values.rules.inbound.length === 0
+    ) {
       values.rules.inbound = undefined;
     }
 
-    if (values.rules.outbound === []) {
+    if (
+      Array.isArray(values.rules.outbound) &&
+      values.rules.outbound.length === 0
+    ) {
       values.rules.outbound = undefined;
     }
 

--- a/packages/manager/src/features/Firewalls/shared.ts
+++ b/packages/manager/src/features/Firewalls/shared.ts
@@ -98,25 +98,11 @@ export const predefinedFirewalls: Record<FirewallPreset, PredefinedFirewall> = {
         protocol: 'TCP',
         addresses: allIPs
       }
-    ],
-    outbound: [
-      {
-        ports: portPresets.ssh,
-        protocol: 'TCP',
-        addresses: allIPs
-      }
     ]
   },
   http: {
     label: 'HTTP',
     inbound: [
-      {
-        ports: portPresets.http,
-        protocol: 'TCP',
-        addresses: allIPs
-      }
-    ],
-    outbound: [
       {
         ports: portPresets.http,
         protocol: 'TCP',
@@ -132,13 +118,6 @@ export const predefinedFirewalls: Record<FirewallPreset, PredefinedFirewall> = {
         protocol: 'TCP',
         addresses: allIPs
       }
-    ],
-    outbound: [
-      {
-        ports: portPresets.https,
-        protocol: 'TCP',
-        addresses: allIPs
-      }
     ]
   },
   mysql: {
@@ -149,25 +128,11 @@ export const predefinedFirewalls: Record<FirewallPreset, PredefinedFirewall> = {
         protocol: 'TCP',
         addresses: allIPs
       }
-    ],
-    outbound: [
-      {
-        ports: portPresets.mysql,
-        protocol: 'TCP',
-        addresses: allIPs
-      }
     ]
   },
   dns: {
     label: 'DNS',
     inbound: [
-      {
-        ports: portPresets.dns,
-        protocol: 'TCP',
-        addresses: allIPs
-      }
-    ],
-    outbound: [
       {
         ports: portPresets.dns,
         protocol: 'TCP',


### PR DESCRIPTION
## Description

Confirmed with Jott that none of our templates should include outbound rules. (As an example, if you create a firewall with the SSH preset, you'll be able to ssh into your Linode but things like `apt-get` will fail.)

## Note

~This will crash until #6827 is merged.~