### PR TITLE
M3-4483: Routing for Linode Modals

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetail.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetail.tsx
@@ -68,7 +68,21 @@ const LinodeDetail: React.FC<CombinedProps> = props => {
           have to reload all the configs, disks, etc. once we get to the CloneLanding page.
           */}
           <Route path={`${path}/clone`} component={CloneLanding} />
-          <Route path={`${path}/migrate`} component={MigrateLanding} />
+          {/* With CMR, the Migrate screen no longer has its own route, so some
+          conditional rendering is required here. */}
+          <Route
+            path={`${path}/migrate`}
+            render={() => {
+              return flags.cmr ? (
+                <React.Fragment>
+                  <LinodesDetailHeader_CMR />
+                  <LinodesDetailNavigation_CMR />
+                </React.Fragment>
+              ) : (
+                <MigrateLanding />
+              );
+            }}
+          />
           <Route
             render={() =>
               flags.cmr ? (

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader_CMR.tsx
@@ -30,7 +30,7 @@ import RescueDialog from '../LinodeRescue/RescueDialog';
 import LinodeResize_CMR from '../LinodeResize/LinodeResize_CMR';
 import MigrateLinode from '../../MigrateLanding/MigrateLinode';
 import EnableBackupDialog from '../LinodeBackup/EnableBackupsDialog';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useRouteMatch } from 'react-router-dom';
 
 interface Props {
   numVolumes: number;
@@ -60,6 +60,15 @@ interface DialogProps {
 type CombinedProps = Props & LinodeDetailContext & LinodeContext;
 
 const LinodeDetailHeader: React.FC<CombinedProps> = props => {
+  // Several routes that used to have dedicated pages (e.g. /resize, /rescue)
+  // now show their content in modals instead. Use this matching to determine
+  // if a modal should be open when this component is first rendered.
+  const match = useRouteMatch<{ linodeId: string; action: string }>({
+    path: '/linodes/:linodeId/:action'
+  });
+  const isAction = (action: string) => match?.params?.action === action;
+  const matchedLinodeId = Number(match?.params?.linodeId ?? 0);
+
   const {
     linode,
     linodeEvents,
@@ -81,23 +90,23 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
   });
 
   const [resizeDialog, setResizeDialog] = React.useState<DialogProps>({
-    open: false,
-    linodeID: 0
+    open: isAction('resize'),
+    linodeID: matchedLinodeId
   });
 
   const [migrateDialog, setMigrateDialog] = React.useState<DialogProps>({
-    open: false,
-    linodeID: 0
+    open: isAction('migrate'),
+    linodeID: matchedLinodeId
   });
 
   const [rescueDialog, setRescueDialog] = React.useState<DialogProps>({
-    open: false,
-    linodeID: 0
+    open: isAction('rescue'),
+    linodeID: matchedLinodeId
   });
 
   const [rebuildDialog, setRebuildDialog] = React.useState<DialogProps>({
-    open: false,
-    linodeID: 0
+    open: isAction('rebuild'),
+    linodeID: matchedLinodeId
   });
 
   const [backupsDialog, setBackupsDialog] = React.useState<DialogProps>({


### PR DESCRIPTION
## Description

Several Linode screens that used to have dedicates routes now just feature their content in modals (/resize, /rescue, etc.).

This makes URLs to those screens backwards compatible. Now, visiting `https://cloud.linode.com/linodes/:id/resize` will take you to the details page with the Resize Modal already open (same for the other routes).

We have at least one link to one of these screens within Cloud Manager, and I imagine a lot of these links are floating around docs, etc.

To do this, I used the `useRouteMatch` router hook (new to our codebase), which I think works really well.

## Note to Reviewers

**To test,** try out the new routes and existing routes within Linodes (details, list, CMR, non-CMR, etc).
