### PR TITLE
Fix Firewall detail breadcrumb

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
@@ -98,6 +98,7 @@ export const FirewallDetail: React.FC<CombinedProps> = props => {
       >
         <Breadcrumb
           pathname={props.location.pathname}
+          firstAndLastOnly
           onEditHandlers={{
             editableTextTitle: thisFirewall.label,
             onEdit: handleLabelChange,

--- a/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
@@ -98,7 +98,6 @@ export const FirewallDetail: React.FC<CombinedProps> = props => {
       >
         <Breadcrumb
           pathname={props.location.pathname}
-          removeCrumbX={2}
           onEditHandlers={{
             editableTextTitle: thisFirewall.label,
             onEdit: handleLabelChange,


### PR DESCRIPTION
## Description

 I never quite understand what the removeCrumbX is for, but in this case removing it seems to give us the correct behavior on Firewall Detail for both CMR and non-CMR. 