### PR TITLE
Change: Firewall labels are not required when creating a Firewall

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.tsx
@@ -157,7 +157,6 @@ const AddFirewallDrawer: React.FC<CombinedProps> = props => {
               onChange={handleChange}
               errorText={errors.label}
               onBlur={handleBlur}
-              required
               inputProps={{
                 autoFocus: true
               }}


### PR DESCRIPTION
Labels are not required when creating a firewall; we reflect this in our schema, and explicitly replace an empty string with `undefined` when submitting the form. However, the textfield itself still is labeled as "required", which is confusing.