### PR TITLE
Fix type of getRegion JS Client method

### DIFF
--- a/packages/api-v4/src/regions/regions.ts
+++ b/packages/api-v4/src/regions/regions.ts
@@ -29,7 +29,7 @@ export const getRegions = () =>
  *
  */
 export const getRegion = (regionID: string) =>
-  Request<Page<Region>>(
+  Request<Region>(
     setURL(`${API_ROOT}/regions/${regionID}`),
     setMethod('GET')
   ).then(response => response.data);


### PR DESCRIPTION
## Description

Fixes the issue reported in https://github.com/linode/manager/issues/6774.

![Screen Shot 2020-08-31 at 3 08 52 PM](https://user-images.githubusercontent.com/16911484/91757238-fde01200-eb9b-11ea-8415-5c90f1ae42a1.png)


## Note to Reviewers

As far as I can tell, this method isn't currently used in Cloud Manager code. You'll need to import `getRegion` somewhere to try it out.
