### PR TITLE
M3-4485 Change: Disable port range when selecting ICMP

### DIFF
--- a/packages/manager/src/components/EnhancedSelect/__mocks__/Select.tsx
+++ b/packages/manager/src/components/EnhancedSelect/__mocks__/Select.tsx
@@ -19,6 +19,7 @@ export default ({
   label,
   onChange,
   errorText,
+  placeholder,
   isMulti
 }: any) => {
   const handleChange = (event: any) => {
@@ -32,8 +33,10 @@ export default ({
   const _options = groupsToItems(options);
   return (
     <>
-      <div>{label}</div>
+      <label htmlFor="select">{label}</label>
       <select
+        placeholder={placeholder}
+        name="select"
         data-testid="select"
         value={value ?? ''}
         onBlur={handleChange}

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.test.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.test.tsx
@@ -1,3 +1,5 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 import { allIPs } from 'src/features/Firewalls/shared';
 import { stringToExtendedIP } from 'src/utilities/ipUtils';
@@ -18,6 +20,8 @@ import { FirewallRuleError } from './shared';
 const mockOnClose = jest.fn();
 const mockOnSubmit = jest.fn();
 
+jest.mock('src/components/EnhancedSelect/Select');
+
 const props: CombinedProps = {
   category: 'inbound',
   mode: 'create',
@@ -32,6 +36,13 @@ describe('AddRuleDrawer', () => {
       <RuleDrawer {...props} mode="create" category="inbound" />
     );
     getByText('Add an Inbound Rule');
+  });
+
+  it('disables the port input when the ICMP protocol is selected', () => {
+    renderWithTheme(<RuleDrawer {...props} mode="create" category="inbound" />);
+    expect(screen.getByPlaceholderText(/port/i)).not.toBeDisabled();
+    userEvent.selectOptions(screen.getByPlaceholderText(/protocol/i), 'ICMP');
+    expect(screen.getByPlaceholderText(/port/i)).toBeDisabled();
   });
 });
 

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
@@ -231,6 +231,10 @@ const FirewallRuleForm: React.FC<FirewallRuleFormProps> = React.memo(props => {
       }
 
       setFieldValue('protocol', item?.value);
+      if (item?.value === 'ICMP') {
+        // Submitting the form with ICMP and defined ports causes an error
+        setFieldValue('ports', '');
+      }
     },
     [formTouched, setFieldValue]
   );

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
@@ -323,6 +323,11 @@ const FirewallRuleForm: React.FC<FirewallRuleFormProps> = React.memo(props => {
         onChange={handlePortsChange}
         onBlur={handleBlur}
         disabled={values.protocol === 'ICMP'}
+        tooltipText={
+          values.protocol === 'ICMP'
+            ? 'Ports are not allowed for ICMP protocols.'
+            : undefined
+        }
       />
       <Select
         label={`${capitalize(addressesLabel)}s`}

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
@@ -322,6 +322,7 @@ const FirewallRuleForm: React.FC<FirewallRuleFormProps> = React.memo(props => {
         errorText={errors.ports}
         onChange={handlePortsChange}
         onBlur={handleBlur}
+        disabled={values.protocol === 'ICMP'}
       />
       <Select
         label={`${capitalize(addressesLabel)}s`}


### PR DESCRIPTION
## Description

We had client validation that would prevent users from submitting port ranges when using the ICMP protocol for a Firewall (matching the API's validation). We got some feedback saying that allowing the user to type in ports, then only later telling them it wasn't allowed, was weird. This PR disables the ports input (with helper text) as long as ICMP is selected.

## Note to Reviewers

Add a rule to a Firewall; select the ICMP protocol. The ports field below it should be disabled.