### PR TITLE
Don't return AxiosResponse in Linode JS Client methods

### DIFF
--- a/packages/api-v4/src/linodes/linodes.ts
+++ b/packages/api-v4/src/linodes/linodes.ts
@@ -22,7 +22,7 @@ export const getLinode = (linodeId: number) =>
   Request<Linode>(
     setURL(`${API_ROOT}/linode/instances/${linodeId}`),
     setMethod('GET')
-  );
+  ).then(response => response.data);
 
 /**
  * getLinodeLishToken
@@ -35,7 +35,7 @@ export const getLinodeLishToken = (linodeId: number) =>
   Request<{ lish_token: string }>(
     setURL(`${API_ROOT}/linode/instances/${linodeId}/lish_token`),
     setMethod('POST')
-  );
+  ).then(response => response.data);
 
 /**
  * getLinodeVolumes
@@ -116,4 +116,4 @@ export const deleteLinode = (linodeId: number) =>
   Request<{}>(
     setURL(`${API_ROOT}/linode/instances/${linodeId}`),
     setMethod('DELETE')
-  );
+  ).then(response => response.data);

--- a/packages/manager/src/features/Lish/Lish.tsx
+++ b/packages/manager/src/features/Lish/Lish.tsx
@@ -102,8 +102,7 @@ class Lish extends React.Component<CombinedProps, State> {
     }
 
     getLinode(+linodeId)
-      .then(response => {
-        const { data: linode } = response;
+      .then(linode => {
         if (!this.mounted) {
           return;
         }
@@ -172,15 +171,12 @@ class Lish extends React.Component<CombinedProps, State> {
     }
 
     return getLinodeLishToken(+linodeId)
-      .then(response => {
-        const {
-          data: { lish_token: token }
-        } = response;
+      .then(tokenResponse => {
         if (!this.mounted) {
           return;
         }
         this.setState({
-          token,
+          token: tokenResponse.lish_token,
           loading: false
         });
       })

--- a/packages/manager/src/features/Volumes/WithEvents.tsx
+++ b/packages/manager/src/features/Volumes/WithEvents.tsx
@@ -111,9 +111,7 @@ export default () => (WrappedComponent: React.ComponentType<any>) => {
              * Linode info in the table row
              */
             if (!!volume.linode_id) {
-              return getLinode(volume.linode_id).then(response => {
-                const linode = response.data;
-
+              return getLinode(volume.linode_id).then(linode => {
                 /*
                  * Now add our new volume, include the newly attached
                  * Linode data to the master list

--- a/packages/manager/src/store/linodes/linode.requests.ts
+++ b/packages/manager/src/store/linodes/linode.requests.ts
@@ -21,7 +21,7 @@ import {
 } from './linodes.actions';
 
 export const getLinode = createRequestThunk(getLinodeActions, ({ linodeId }) =>
-  _getLinode(linodeId).then(({ data }) => data)
+  _getLinode(linodeId)
 );
 
 export const updateLinode = createRequestThunk(
@@ -65,7 +65,6 @@ export const requestLinodeForStore: RequestLinodeForStoreThunk = (
     Boolean(state.__resources.linodes.itemsById[id])
   ) {
     return _getLinode(id)
-      .then(response => response.data)
       .then(linode => {
         return dispatch(upsertLinode(linode));
       })


### PR DESCRIPTION
## Description

⚠️  **This is a breaking change for the JS Client! Do not merge yet.** ⚠️ 

Reported in https://github.com/linode/manager/issues/6775, `getLinode` (and a few other methods) don't do the normal resolving of `response.data`, and instead return the entire AxiosResponse object. This fixes the Linode methods.

See the ticket for a few more discussion points. We should audit the entire JS Client and fix all at once and release with our next major version release. cc @DevDW @Jskobos.
