### PR TITLE
M3-4477 fix: Managed Issue Drawer crash

### DIFF
--- a/packages/manager/src/utilities/useTimezone.ts
+++ b/packages/manager/src/utilities/useTimezone.ts
@@ -1,15 +1,9 @@
-import { pathOr } from 'ramda';
 import store from 'src/store';
+import getUserTimezone from './getUserTimezone';
 
 export const useTimezone = (): string => {
   const state = store.getState();
-  const timezone = pathOr(
-    'GMT',
-    ['__resources', 'profile', 'data', 'timezone'],
-    state
-  );
-
-  return timezone;
+  return getUserTimezone(state);
 };
 
 export default useTimezone;


### PR DESCRIPTION
## Description

The Issue History drawer was crashing on prod test account 4. This was happening because the timezone on this account is set to `""` (empty string). The `useTimezone` function in use by the drawer gets the raw value (defaulting to GMT if undefined), and didn't make sure it was a valid timezone before parsing, hence the crash. 

To fix this I modified useTimezone to call `getUserTimezone()`, which ensures the timezone is valid. Feel free to disagree with this behavior. A case could be made for `useTimezone` returning _whatever the user has set_, though it seems more useful to ensure the zone is valid. To get the raw value, a consumer could always use `useAccountManagement` to get profile data directly. 

## Note to Reviewers

To test the bug, use test account 4, or set your own timezone to `""` with the API. Open the Managed Issue History drawer... it should not crash on this branch.
