### PR TITLE
Show disabled select option for Atlanta

### DIFF
--- a/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionOption.tsx
+++ b/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionOption.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 import * as React from 'react';
 import { OptionProps } from 'react-select';
 import { makeStyles, Theme } from 'src/components/core/styles';
+import Tooltip from 'src/components/core/Tooltip';
 import { Item } from 'src/components/EnhancedSelect';
 import Option from 'src/components/EnhancedSelect/components/Option';
 import Grid from 'src/components/Grid';
@@ -13,12 +14,16 @@ const useStyles = makeStyles((theme: Theme) => ({
   focused: {
     backgroundColor: theme.palette.primary.main,
     color: 'white'
+  },
+  disabled: {
+    cursor: 'not-allowed !important'
   }
 }));
 
 export interface RegionItem extends Item<string> {
   flag: () => JSX.Element | null;
   country: string;
+  disabledMessage?: string | JSX.Element;
 }
 interface RegionOptionProps extends OptionProps<any> {
   data: RegionItem;
@@ -29,22 +34,50 @@ type CombinedProps = RegionOptionProps;
 export const RegionOption: React.FC<CombinedProps> = props => {
   const classes = useStyles();
   const { data, label } = props;
+  const isDisabled = Boolean(data.disabledMessage);
   return (
     <Option
       className={classNames({
         [classes.root]: true,
-        [classes.focused]: props.isFocused
+        [classes.focused]: props.isFocused,
+        [classes.disabled]: isDisabled
       })}
       value={data.value}
       attrs={{ ['data-qa-region-select-item']: data.value }}
       {...props}
     >
-      <Grid container direction="row" alignItems="center" justify="flex-start">
-        <Grid item className="py0">
-          {data.flag && data.flag()}
+      {isDisabled ? (
+        <Tooltip
+          title={data.disabledMessage ?? ''}
+          enterTouchDelay={500}
+          enterDelay={500}
+          interactive
+        >
+          <Grid
+            container
+            direction="row"
+            alignItems="center"
+            justify="flex-start"
+          >
+            <Grid item className="py0">
+              {data.flag && data.flag()}
+            </Grid>
+            <Grid item>{label} (Not available)</Grid>
+          </Grid>
+        </Tooltip>
+      ) : (
+        <Grid
+          container
+          direction="row"
+          alignItems="center"
+          justify="flex-start"
+        >
+          <Grid item className="py0">
+            {data.flag && data.flag()}
+          </Grid>
+          <Grid item>{label}</Grid>
         </Grid>
-        <Grid item>{label}</Grid>
-      </Grid>
+      )}
     </Option>
   );
 };

--- a/packages/manager/src/components/HelpIcon/HelpIcon.tsx
+++ b/packages/manager/src/components/HelpIcon/HelpIcon.tsx
@@ -38,22 +38,20 @@ const HelpIcon: React.FC<CombinedProps> = props => {
   } = props;
 
   return (
-    <React.Fragment>
-      <Tooltip
-        title={text}
-        data-qa-help-tooltip
-        enterTouchDelay={0}
-        leaveTouchDelay={5000}
-        leaveDelay={leaveDelay ? 3000 : undefined}
-        interactive={interactive && interactive}
-        placement={tooltipPosition ? tooltipPosition : 'bottom'}
-        classes={classes}
-      >
-        <IconButton className={className} data-qa-help-button>
-          <HelpOutline />
-        </IconButton>
-      </Tooltip>
-    </React.Fragment>
+    <Tooltip
+      title={text}
+      data-qa-help-tooltip
+      enterTouchDelay={0}
+      leaveTouchDelay={5000}
+      leaveDelay={leaveDelay ? 3000 : undefined}
+      interactive={interactive}
+      placement={tooltipPosition ? tooltipPosition : 'bottom'}
+      classes={classes}
+    >
+      <IconButton className={className} data-qa-help-button>
+        <HelpOutline />
+      </IconButton>
+    </Tooltip>
   );
 };
 


### PR DESCRIPTION
Since it's unclear how much of this deprecation process will
be consistent in the future, this is a mostly manual attempt
to prevent users from accessing the Atlanta datacenter.

It manually checks the region id inside the RegionSelect, and if
it matches Atlanta it marks the option as disabled.

- Add a tooltip with explanation text and a link to the blog post
- Add a check that only disables the option if the user doesn't
already have Linodes in Atlanta

