### PR TITLE
M3-4503: Hide hidden links from mobile nav

### DIFF
--- a/packages/manager/src/components/PrimaryNav/MobileNav.test.tsx
+++ b/packages/manager/src/components/PrimaryNav/MobileNav.test.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+import MobileNav from './MobileNav';
+
+describe('MobileNav', () => {
+  it('should not display hidden links', () => {
+    const { queryByTestId } = renderWithTheme(
+      <MobileNav
+        groups={[
+          {
+            group: 'Monitors',
+            links: [
+              {
+                display: 'Longview',
+                href: '/longview'
+              },
+              {
+                display: 'Managed',
+                href: '/managed',
+                hide: true
+              }
+            ]
+          }
+        ]}
+      />
+    );
+    expect(queryByTestId('menu-item-Longview')).toBeInTheDocument();
+    expect(queryByTestId('menu-item-Managed')).not.toBeInTheDocument();
+  });
+});

--- a/packages/manager/src/components/PrimaryNav/MobileNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/MobileNav.tsx
@@ -238,7 +238,7 @@ export const MobileNav: React.FC<Props> = props => {
                   </MenuButton>
                   <MenuPopover className={classes.menuPopover} portal={false}>
                     <MenuItems className={classes.menuItemList} key={thisGroup}>
-                      {thisGroup.links.map((thisLink: any) => (
+                      {filteredLinks.map((thisLink: any) => (
                         <MenuLink
                           data-testid={`menu-item-${thisLink.display}`}
                           key={thisLink.display}

--- a/packages/manager/src/components/PrimaryNav/MobileNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/MobileNav.tsx
@@ -240,6 +240,7 @@ export const MobileNav: React.FC<Props> = props => {
                     <MenuItems className={classes.menuItemList} key={thisGroup}>
                       {thisGroup.links.map((thisLink: any) => (
                         <MenuLink
+                          data-testid={`menu-item-${thisLink.display}`}
                           key={thisLink.display}
                           as={Link}
                           to={thisLink.href}


### PR DESCRIPTION
## Description

This fixes a bug where hidden links were not filtered out in the Mobile Nav.

First commit is a failing unit test, second commit fixes it.

To test manually, view the MobileNav as a user without Managed. On this branch, you shouldn't be able to see the "Managed" link.
