### PR TITLE
M3-4420: Tweak error message display when there's a failure in VolumeAttachmentDrawer

### DIFF
--- a/packages/manager/src/features/Volumes/VolumeAttachmentDrawer.tsx
+++ b/packages/manager/src/features/Volumes/VolumeAttachmentDrawer.tsx
@@ -180,17 +180,17 @@ class VolumeAttachmentDrawer extends React.Component<CombinedProps, State> {
             important
           />
         )}
+        {generalError && <Notice text={generalError} error={true} />}
         <LinodeSelect
           selectedLinode={selectedLinode}
           region={linodeRegion}
           handleChange={linode => this.changeSelectedLinode(linode.id)}
           linodeError={linodeError}
-          generalError={generalError}
           disabled={disabled || readOnly}
         />
-        {!(linodeError || generalError || linodesError) && (
+        {!(linodeError || linodesError) && (
           <FormHelperText>
-            Only Linodes in this Volume's region are displayed.
+            Only Linodes in this Volume&#39;s region are displayed.
           </FormHelperText>
         )}
 


### PR DESCRIPTION
## Description
Move the `generalError` into a `<Notice />` instead of having it display below the LinodeSelect field.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers
To test, please block requests to `*attach*`, go to the Volumes landing page, and try to attach a volume to a Linode. You should see the error message below the drawer title.
