### PR TITLE
M3-4465 Reduce GA events

### DIFF
--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -26,7 +26,6 @@ import Menu from 'src/components/core/Menu';
 import useAccountManagement from 'src/hooks/useAccountManagement';
 import useFlags from 'src/hooks/useFlags';
 import usePrefetch from 'src/hooks/usePreFetch';
-import { sendOneClickNavigationEvent } from 'src/utilities/ga';
 import AdditionalMenuItems from './AdditionalMenuItems';
 import useStyles from './PrimaryNav.styles';
 import SpacingToggle from './SpacingToggle';
@@ -143,10 +142,7 @@ export const PrimaryNav: React.FC<Props> = props => {
         display: 'Marketplace',
         href: '/linodes/create?type=One-Click',
         attr: { 'data-qa-one-click-nav-btn': true },
-        icon: <OCA />,
-        onClick: () => {
-          sendOneClickNavigationEvent('Primary Nav');
-        }
+        icon: <OCA />
       },
       {
         display: 'Longview',

--- a/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -32,8 +32,6 @@ import { openForCreating as openDomainDrawerForCreating } from 'src/store/domain
 import { MapState } from 'src/store/types';
 import AddNewMenuItem from './AddNewMenuItem';
 
-import { sendOneClickNavigationEvent } from 'src/utilities/ga';
-
 type CSSClasses =
   | 'wrapper'
   | 'button'
@@ -206,9 +204,6 @@ class AddNewMenu extends React.Component<CombinedProps> {
               <MenuLink
                 as={Link}
                 to="/linodes/create?type=One-Click"
-                onClick={() => {
-                  sendOneClickNavigationEvent('Add New Menu');
-                }}
                 className={classes.menuItemLink}
               >
                 <AddNewMenuItem

--- a/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu_CMR.tsx
+++ b/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu_CMR.tsx
@@ -31,8 +31,6 @@ import { openForCreating as openDomainDrawerForCreating } from 'src/store/domain
 import { MapState } from 'src/store/types';
 import AddNewMenuItem from './AddNewMenuItem';
 
-import { sendOneClickNavigationEvent } from 'src/utilities/ga';
-
 type CSSClasses =
   | 'wrapper'
   | 'button'
@@ -192,9 +190,6 @@ class AddNewMenu extends React.Component<CombinedProps> {
               <MenuLink
                 as={Link}
                 to="/linodes/create?type=One-Click"
-                onClick={() => {
-                  sendOneClickNavigationEvent('Add New Menu');
-                }}
                 className={classes.menuItemLink}
               >
                 <AddNewMenuItem

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -151,7 +151,7 @@ export const SearchBar: React.FC<CombinedProps> = props => {
       });
       return;
     }
-    sendSearchBarUsedEvent('Search Select');
+    sendSearchBarUsedEvent();
     props.history.push(item.data.path);
   };
 

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -62,9 +62,6 @@ export const selectStyles = {
   menu: (base: any) => ({ ...base, maxWidth: '100% !important' })
 };
 
-// Timeout of 1sec in debounce to avoid sending too many events to GA
-const debouncedSearchAutoEvent = debounce(1000, false, sendSearchBarUsedEvent);
-
 export const SearchBar: React.FC<CombinedProps> = props => {
   const { classes, combinedResults, entitiesLoading, search } = props;
 
@@ -116,10 +113,6 @@ export const SearchBar: React.FC<CombinedProps> = props => {
 
   const handleSearchChange = (_searchText: string): void => {
     setSearchText(_searchText);
-    // do not trigger debounce for empty text
-    if (searchText !== '') {
-      debouncedSearchAutoEvent('Search Auto', searchText);
-    }
     props.search(_searchText);
   };
 
@@ -156,12 +149,9 @@ export const SearchBar: React.FC<CombinedProps> = props => {
         pathname: `/search`,
         search: `?query=${encodeURIComponent(text)}`
       });
-      // we are selecting the View all option sending the user to the landing,
-      // this is like key down enter
-      sendSearchBarUsedEvent('Search Landing', text);
       return;
     }
-    sendSearchBarUsedEvent('Search Select', text);
+    sendSearchBarUsedEvent('Search Select');
     props.history.push(item.data.path);
   };
 
@@ -175,7 +165,6 @@ export const SearchBar: React.FC<CombinedProps> = props => {
         pathname: `/search`,
         search: `?query=${encodeURIComponent(searchText)}`
       });
-      sendSearchBarUsedEvent('Search Landing', searchText);
       onClose();
     }
   };

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar_CMR.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar_CMR.tsx
@@ -152,7 +152,7 @@ export const SearchBar: React.FC<CombinedProps> = props => {
       });
       return;
     }
-    sendSearchBarUsedEvent('Search Select');
+    sendSearchBarUsedEvent();
     props.history.push(item.data.path);
   };
 

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar_CMR.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar_CMR.tsx
@@ -62,9 +62,6 @@ export const selectStyles = {
   menu: (base: any) => ({ ...base, maxWidth: '100% !important' })
 };
 
-// Timeout of 1sec in debounce to avoid sending too many events to GA
-const debouncedSearchAutoEvent = debounce(1000, false, sendSearchBarUsedEvent);
-
 export const SearchBar: React.FC<CombinedProps> = props => {
   const { classes, combinedResults, entitiesLoading, search } = props;
 
@@ -117,10 +114,6 @@ export const SearchBar: React.FC<CombinedProps> = props => {
 
   const handleSearchChange = (_searchText: string): void => {
     setSearchText(_searchText);
-    // do not trigger debounce for empty text
-    if (searchText !== '') {
-      debouncedSearchAutoEvent('Search Auto', searchText);
-    }
     props.search(_searchText);
   };
 
@@ -157,12 +150,9 @@ export const SearchBar: React.FC<CombinedProps> = props => {
         pathname: `/search`,
         search: `?query=${encodeURIComponent(text)}`
       });
-      // we are selecting the View all option sending the user to the landing,
-      // this is like key down enter
-      sendSearchBarUsedEvent('Search Landing', text);
       return;
     }
-    sendSearchBarUsedEvent('Search Select', text);
+    sendSearchBarUsedEvent('Search Select');
     props.history.push(item.data.path);
   };
 
@@ -176,7 +166,6 @@ export const SearchBar: React.FC<CombinedProps> = props => {
         pathname: `/search`,
         search: `?query=${encodeURIComponent(searchText)}`
       });
-      sendSearchBarUsedEvent('Search Landing', searchText);
       onClose();
     }
   };

--- a/packages/manager/src/utilities/ga.ts
+++ b/packages/manager/src/utilities/ga.ts
@@ -304,15 +304,6 @@ export const generateTimeOfDay = (currentHour: number) => {
   return currentTimeOfDay;
 };
 
-export const sendOneClickNavigationEvent = (
-  whichButton: 'Add New Menu' | 'Primary Nav'
-) => {
-  return sendEvent({
-    category: 'One Click App Navigation',
-    action: `From ${whichButton}`
-  });
-};
-
 export const sendDomainStatusChangeEvent = (action: 'Enable' | 'Disable') => {
   return sendEvent({
     category: 'Domain Status Change',
@@ -336,15 +327,11 @@ export const sendObjectsQueuedForUploadEvent = (numObjects: number) => {
 };
 
 export const sendSearchBarUsedEvent = (
-  category: 'Search Landing' | 'Search Select' | 'Search Auto',
-  searchText: string
+  action: 'Search Landing' | 'Search Select' | 'Search Auto'
 ) => {
-  if (searchText === '') {
-    return;
-  }
   sendEvent({
-    category,
-    action: searchText,
+    category: 'Search',
+    action,
     label: window.location.pathname
   });
 };

--- a/packages/manager/src/utilities/ga.ts
+++ b/packages/manager/src/utilities/ga.ts
@@ -326,12 +326,10 @@ export const sendObjectsQueuedForUploadEvent = (numObjects: number) => {
   });
 };
 
-export const sendSearchBarUsedEvent = (
-  action: 'Search Landing' | 'Search Select' | 'Search Auto'
-) => {
+export const sendSearchBarUsedEvent = () => {
   sendEvent({
     category: 'Search',
-    action,
+    action: 'Search Select',
     label: window.location.pathname
   });
 };


### PR DESCRIPTION
## Description

This consolidates the "Search" GA events, replacing the three categories ("Search Auto", "Search Select", "Search Landing") with one category ("Search"), and encoding the previous categories as actions. Example:

```
Category: "Search"
Action: "Search Select"
```

(For now, I removed the reporting of "Auto" and "Landing".)

I also removed the OCA events.


**To test,** run the app with GA (let me know if you need instructions) and verify the appropriate events are going through. Verify everything with the search bar, primary nav, and create button is working as expected.
