### PR TITLE
Improve handling of unknown regions

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
@@ -33,7 +33,6 @@ import TableCell from 'src/components/TableCell';
 import TableRowError from 'src/components/TableRowError';
 import TableRowLoading from 'src/components/TableRowLoading';
 import { ZONES } from 'src/constants';
-import { reportException } from 'src/exceptionReporting';
 import { upsertLinode as _upsertLinode } from 'src/store/linodes/linodes.actions';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { getAll } from 'src/utilities/getAll';
@@ -516,12 +515,6 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
     }
 
     const zoneName = ZONES[linodeRegion];
-
-    if (!zoneName) {
-      reportException(`Unknown region: ${linodeRegion}`, {
-        linodeID
-      });
-    }
 
     const ipsWithRDNS =
       currentlySelectedIPRange && currentlySelectedIPRange.prefix

--- a/packages/manager/src/utilities/formatRegion.ts
+++ b/packages/manager/src/utilities/formatRegion.ts
@@ -6,7 +6,7 @@ import {
 export const formatRegion = (region: string) => {
   const city = dcDisplayNames[region];
 
-  return `${city || ''}`;
+  return `${city || region}`;
 
   /**
    * There doesn't seem to be a good way to format Country, City, Province/State inline.


### PR DESCRIPTION
## Description

The “Unknown Region” reporting has yet to prove useful (and IMO it’s unlikely to in the future). Instead it is frequently (and noisily) reported during internal usage. This removes that exception report, and adds a better fallback for the `formatRegion` function (just display the raw value).

## Note to Reviewers

To test, mock a Linode with an unknown region, i.e. one not found here, and vist the Linode Networking page: https://github.com/linode/manager/blob/c16f448a82e6343eb802b26e06b4fe0e7594cb62/packages/manager/src/constants.ts#L103
