### PR TITLE
M3-4506 Close action menu after action is selected

### DIFF
--- a/packages/manager/src/components/ActionMenu_CMR/ActionMenu_CMR.stories.tsx
+++ b/packages/manager/src/components/ActionMenu_CMR/ActionMenu_CMR.stories.tsx
@@ -13,19 +13,19 @@ class StoryActionMenu extends React.Component<CombinedProps> {
     return [
       {
         title: 'First Action',
-        onClick: jest.fn()
+        onClick: () => null
       },
       {
         title: 'Action 1',
-        onClick: jest.fn()
+        onClick: () => null
       },
       {
         title: 'Action 3',
-        onClick: jest.fn()
+        onClick: () => null
       },
       {
         title: 'Last Action',
-        onClick: jest.fn()
+        onClick: () => null
       }
     ];
   };
@@ -42,16 +42,16 @@ class StoryActionMenuWithTooltip extends React.Component<CombinedProps> {
     return [
       {
         title: 'First Action',
-        onClick: jest.fn()
+        onClick: () => null
       },
       {
         title: 'Another Action',
-        onClick: jest.fn()
+        onClick: () => null
       },
       {
         title: 'Disabled Action',
         disabled: true,
-        onClick: jest.fn(),
+        onClick: () => null,
         tooltip: 'An explanation as to why this item is disabled'
       }
     ];
@@ -69,7 +69,7 @@ class StoryActionMenuWithInlineLabel extends React.Component<CombinedProps> {
     return [
       {
         title: 'Single Action',
-        onClick: jest.fn()
+        onClick: () => null
       }
     ];
   };

--- a/packages/manager/src/components/ActionMenu_CMR/ActionMenu_CMR.stories.tsx
+++ b/packages/manager/src/components/ActionMenu_CMR/ActionMenu_CMR.stories.tsx
@@ -13,27 +13,19 @@ class StoryActionMenu extends React.Component<CombinedProps> {
     return [
       {
         title: 'First Action',
-        onClick: (e: React.MouseEvent<HTMLElement>) => {
-          e.preventDefault();
-        }
+        onClick: jest.fn()
       },
       {
         title: 'Action 1',
-        onClick: (e: React.MouseEvent<HTMLElement>) => {
-          e.preventDefault();
-        }
+        onClick: jest.fn()
       },
       {
         title: 'Action 3',
-        onClick: (e: React.MouseEvent<HTMLElement>) => {
-          e.preventDefault();
-        }
+        onClick: jest.fn()
       },
       {
         title: 'Last Action',
-        onClick: (e: React.MouseEvent<HTMLElement>) => {
-          e.preventDefault();
-        }
+        onClick: jest.fn()
       }
     ];
   };
@@ -50,22 +42,16 @@ class StoryActionMenuWithTooltip extends React.Component<CombinedProps> {
     return [
       {
         title: 'First Action',
-        onClick: (e: React.MouseEvent<HTMLElement>) => {
-          e.preventDefault();
-        }
+        onClick: jest.fn()
       },
       {
         title: 'Another Action',
-        onClick: (e: React.MouseEvent<HTMLElement>) => {
-          e.preventDefault();
-        }
+        onClick: jest.fn()
       },
       {
         title: 'Disabled Action',
         disabled: true,
-        onClick: (e: React.MouseEvent<HTMLElement>) => {
-          e.preventDefault();
-        },
+        onClick: jest.fn(),
         tooltip: 'An explanation as to why this item is disabled'
       }
     ];
@@ -83,9 +69,7 @@ class StoryActionMenuWithInlineLabel extends React.Component<CombinedProps> {
     return [
       {
         title: 'Single Action',
-        onClick: (e: React.MouseEvent<HTMLElement>) => {
-          e.preventDefault();
-        }
+        onClick: jest.fn()
       }
     ];
   };

--- a/packages/manager/src/components/ActionMenu_CMR/ActionMenu_CMR.tsx
+++ b/packages/manager/src/components/ActionMenu_CMR/ActionMenu_CMR.tsx
@@ -3,8 +3,8 @@ import KebabIcon from 'src/assets/icons/kebab.svg';
 import {
   Menu,
   MenuButton,
+  MenuItem,
   MenuItems,
-  MenuLink,
   MenuPopover
 } from '@reach/menu-button';
 import '@reach/menu-button/styles.css';
@@ -17,7 +17,7 @@ export interface Action {
   title: string;
   disabled?: boolean;
   tooltip?: string;
-  onClick: (e: React.MouseEvent<HTMLElement>) => void;
+  onClick: () => void;
 }
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -164,17 +164,16 @@ const ActionMenu: React.FC<CombinedProps> = props => {
         <MenuPopover className={classes.popover} position={positionRight}>
           <MenuItems className={classes.itemsOuter}>
             {(actions as Action[]).map((a, idx) => (
-              <MenuLink
+              <MenuItem
                 key={idx}
                 className={classNames({
                   [classes.item]: true,
                   [classes.disabled]: a.disabled
                 })}
-                onClick={(e: React.MouseEvent<HTMLElement, MouseEvent>) => {
+                onSelect={() => {
                   if (!a.disabled) {
-                    return a.onClick(e);
+                    return a.onClick();
                   }
-                  e.preventDefault();
                 }}
                 data-qa-action-menu-item={a.title}
                 disabled={a.disabled}
@@ -188,7 +187,7 @@ const ActionMenu: React.FC<CombinedProps> = props => {
                     className={classes.tooltip}
                   />
                 )}
-              </MenuLink>
+              </MenuItem>
             ))}
           </MenuItems>
         </MenuPopover>

--- a/packages/manager/src/features/Domains/DomainActionMenu_CMR.tsx
+++ b/packages/manager/src/features/Domains/DomainActionMenu_CMR.tsx
@@ -84,16 +84,14 @@ export const DomainActionMenu: React.FC<CombinedProps> = props => {
     const baseActions = [
       {
         title: 'Clone',
-        onClick: (e: React.MouseEvent<HTMLElement>) => {
+        onClick: () => {
           handleClone();
-          e.preventDefault();
         }
       },
       {
         title: 'Delete',
-        onClick: (e: React.MouseEvent<HTMLElement>) => {
+        onClick: () => {
           handleRemove();
-          e.preventDefault();
         }
       }
     ];
@@ -102,14 +100,14 @@ export const DomainActionMenu: React.FC<CombinedProps> = props => {
       if (type === 'master') {
         baseActions.unshift({
           title: 'Edit',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
+          onClick: () => {
             handleEdit();
           }
         });
       }
       baseActions.unshift({
         title: status === 'active' ? 'Disable' : 'Enable',
-        onClick: (e: React.MouseEvent<HTMLElement>) => {
+        onClick: () => {
           onDisableOrEnable(
             status === 'active' ? 'disable' : 'enable',
             domain,
@@ -119,7 +117,7 @@ export const DomainActionMenu: React.FC<CombinedProps> = props => {
       });
       baseActions.unshift({
         title: 'Details',
-        onClick: (e: React.MouseEvent<HTMLElement>) => {
+        onClick: () => {
           type === 'master' ? goToDomain() : handleEdit();
         }
       });
@@ -129,7 +127,7 @@ export const DomainActionMenu: React.FC<CombinedProps> = props => {
       return [
         {
           title: 'Edit',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
+          onClick: () => {
             handleEdit();
           }
         },

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallActionMenu_CMR.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallActionMenu_CMR.tsx
@@ -100,8 +100,7 @@ const FirewallActionMenu: React.FC<CombinedProps> = props => {
       actionText:
         firewallStatus === ('enabled' as FirewallStatus) ? 'Disable' : 'Enable',
       className: classes.button,
-      onClick: (e: React.MouseEvent<HTMLElement>) => {
-        e.preventDefault();
+      onClick: () => {
         handleEnableDisable();
       }
     },
@@ -125,11 +124,10 @@ const FirewallActionMenu: React.FC<CombinedProps> = props => {
     return [
       {
         title: 'Details',
-        onClick: (e: React.MouseEvent<HTMLElement>) => {
+        onClick: () => {
           history.push({
             pathname: `/firewalls/${firewallID}`
           });
-          e.preventDefault();
         }
       },
       {
@@ -137,8 +135,7 @@ const FirewallActionMenu: React.FC<CombinedProps> = props => {
           firewallStatus === ('enabled' as FirewallStatus)
             ? 'Disable'
             : 'Enable',
-        onClick: (e: React.MouseEvent<HTMLElement>) => {
-          e.preventDefault();
+        onClick: () => {
           handleEnableDisable();
         }
       },

--- a/packages/manager/src/features/Images/ImagesActionMenu_CMR.tsx
+++ b/packages/manager/src/features/Images/ImagesActionMenu_CMR.tsx
@@ -41,16 +41,14 @@ export const ImagesActionMenu: React.FC<CombinedProps> = props => {
   const inlineActions = [
     {
       actionText: 'Details',
-      onClick: (e: React.MouseEvent<HTMLElement>) => {
+      onClick: () => {
         onEdit(label, description ?? ' ', id);
-        e.preventDefault();
       }
     },
     {
       actionText: 'Deploy New Linode',
-      onClick: (e: React.MouseEvent<HTMLElement>) => {
+      onClick: () => {
         onDeploy(id);
-        e.preventDefault();
       }
     }
   ];
@@ -59,16 +57,14 @@ export const ImagesActionMenu: React.FC<CombinedProps> = props => {
     const actions: Action[] = [
       {
         title: 'Restore to Existing Linode',
-        onClick: (e: React.MouseEvent<HTMLElement>) => {
+        onClick: () => {
           onRestore(id);
-          e.preventDefault();
         }
       },
       {
         title: 'Delete',
-        onClick: (e: React.MouseEvent<HTMLElement>) => {
+        onClick: () => {
           onDelete(label, id);
-          e.preventDefault();
         }
       }
     ];
@@ -77,16 +73,14 @@ export const ImagesActionMenu: React.FC<CombinedProps> = props => {
       actions.unshift(
         {
           title: 'Details',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
+          onClick: () => {
             onEdit(label, description ?? ' ', id);
-            e.preventDefault();
           }
         },
         {
           title: 'Deploy New Linode',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
+          onClick: () => {
             onDeploy(id);
-            e.preventDefault();
           }
         }
       );

--- a/packages/manager/src/features/Kubernetes/ClusterList/ClusterActionMenu_CMR.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/ClusterActionMenu_CMR.tsx
@@ -70,35 +70,28 @@ export const ClusterActionMenu: React.FunctionComponent<CombinedProps> = props =
 
   const createActions = () => {
     return (): Action[] => {
-      const actions = [
+      return [
         {
           title: 'Details',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
+          onClick: () => {
             history.push({
               pathname: `/kubernetes/clusters/${clusterId}`
             });
-            e.preventDefault();
           }
         },
         {
           title: 'Download kubeconfig',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
-            e.preventDefault();
-            e.stopPropagation();
+          onClick: () => {
             downloadKubeConfig();
           }
         },
         {
           title: 'Delete',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
+          onClick: () => {
             openDialog();
-
-            e.preventDefault();
           }
         }
       ];
-
-      return actions;
     };
   };
 

--- a/packages/manager/src/features/Managed/Credentials/CredentialActionMenu_CMR.tsx
+++ b/packages/manager/src/features/Managed/Credentials/CredentialActionMenu_CMR.tsx
@@ -39,14 +39,12 @@ const CredentialActionMenu: React.FC<CombinedProps> = props => {
   const theme = useTheme<Theme>();
   const matchesSmDown = useMediaQuery(theme.breakpoints.down('sm'));
 
-  const onClickForEdit = (e: React.MouseEvent<HTMLElement>) => {
+  const onClickForEdit = () => {
     openForEdit(credentialID);
-    e.preventDefault();
   };
 
-  const onClickForDelete = (e: React.MouseEvent<HTMLElement>) => {
+  const onClickForDelete = () => {
     openDialog(credentialID, label);
-    e.preventDefault();
   };
 
   const actions: Action[] = [

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancerActionMenu_CMR.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancerActionMenu_CMR.tsx
@@ -45,15 +45,13 @@ export const NodeBalancerActionMenu: React.FC<CombinedProps> = props => {
       const actions = [
         {
           title: 'Settings',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
+          onClick: () => {
             history.push(`/nodebalancers/${nodeBalancerId}/settings`);
-            e.preventDefault();
           }
         },
         {
           title: 'Delete',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
-            e.preventDefault();
+          onClick: () => {
             toggleDialog(nodeBalancerId, label);
           }
         }

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketActionMenu_CMR.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketActionMenu_CMR.tsx
@@ -43,26 +43,22 @@ export const BucketActionMenu: React.FC<Props> = props => {
 
   const createActions = () => {
     return (): Action[] => {
-      const actions = [
+      return [
         {
           title: 'Details',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
+          onClick: () => {
             history.push({
               pathname: `/object-storage/buckets/${props.cluster}/${props.label}`
             });
-            e.preventDefault();
           }
         },
         {
           title: 'Delete',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
+          onClick: () => {
             props.onRemove();
-            e.preventDefault();
           }
         }
       ];
-
-      return actions;
     };
   };
 

--- a/packages/manager/src/features/Profile/SSHKeys/SSHKeyActionMenu_CMR.tsx
+++ b/packages/manager/src/features/Profile/SSHKeys/SSHKeyActionMenu_CMR.tsx
@@ -16,9 +16,8 @@ export const SSHKeyActionMenu: React.FC<CombinedProps> = props => {
     <InlineMenuAction
       key="Delete"
       actionText="Delete"
-      onClick={(e: React.MouseEvent<HTMLElement>) => {
+      onClick={() => {
         onDelete(id, label);
-        e.preventDefault();
       }}
     />
   );

--- a/packages/manager/src/features/Users/UsersActionMenu_CMR.tsx
+++ b/packages/manager/src/features/Users/UsersActionMenu_CMR.tsx
@@ -44,24 +44,21 @@ const UsersActionMenu: React.FC<CombinedProps> = props => {
   const actions: Action[] = [
     {
       title: 'User Profile',
-      onClick: (e: React.MouseEvent<HTMLElement>) => {
+      onClick: () => {
         history.push(`/account/users/${username}`);
-        e.preventDefault();
       }
     },
     {
       title: 'User Permissions',
-      onClick: (e: React.MouseEvent<HTMLElement>) => {
+      onClick: () => {
         history.push(`/account/users/${username}/permissions`);
-        e.preventDefault();
       }
     },
     {
       disabled: username === profileUsername,
       title: 'Delete',
-      onClick: (e: React.MouseEvent<HTMLElement>) => {
+      onClick: () => {
         onDelete(username);
-        e.preventDefault();
       },
       tooltip:
         username === profileUsername

--- a/packages/manager/src/features/Volumes/VolumesActionMenu_CMR.tsx
+++ b/packages/manager/src/features/Volumes/VolumesActionMenu_CMR.tsx
@@ -131,15 +131,13 @@ export const VolumesActionMenu: React.FC<CombinedProps> = props => {
       const actions = [
         {
           title: 'Resize',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
-            e.preventDefault();
+          onClick: () => {
             handleResize();
           }
         },
         {
           title: 'Clone',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
-            e.preventDefault();
+          onClick: () => {
             handleClone();
           }
         }
@@ -148,15 +146,13 @@ export const VolumesActionMenu: React.FC<CombinedProps> = props => {
       if (matchesSmDown) {
         actions.unshift({
           title: 'Edit',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
-            e.preventDefault();
+          onClick: () => {
             handleOpenEdit();
           }
         });
         actions.unshift({
           title: 'Details',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
-            e.preventDefault();
+          onClick: () => {
             handleShowConfig();
           }
         });
@@ -165,16 +161,14 @@ export const VolumesActionMenu: React.FC<CombinedProps> = props => {
       if (!attached && isVolumesLanding) {
         actions.push({
           title: 'Attach',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
-            e.preventDefault();
+          onClick: () => {
             handleAttach();
           }
         });
       } else {
         actions.push({
           title: 'Detach',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
-            e.preventDefault();
+          onClick: () => {
             handleDetach();
           }
         });
@@ -183,8 +177,7 @@ export const VolumesActionMenu: React.FC<CombinedProps> = props => {
       if (!attached || poweredOff) {
         actions.push({
           title: 'Delete',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
-            e.preventDefault();
+          onClick: () => {
             handleDelete();
           }
         });

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskActionMenu_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskActionMenu_CMR.tsx
@@ -71,16 +71,14 @@ export const DiskActionMenu: React.FC<CombinedProps> = props => {
     return [
       {
         title: 'Imagize',
-        onClick: (e: React.MouseEvent<HTMLElement>) => {
-          e.preventDefault();
+        onClick: () => {
           props.onImagize();
         },
         ...(readOnly ? disabledProps : {})
       },
       {
         title: 'Clone',
-        onClick: (e: React.MouseEvent<HTMLElement>) => {
-          e.preventDefault();
+        onClick: () => {
           history.push(
             `/linodes/${linodeId}/clone/disks?selectedDisk=${diskId}`
           );
@@ -89,8 +87,7 @@ export const DiskActionMenu: React.FC<CombinedProps> = props => {
       },
       {
         title: 'Delete',
-        onClick: (e: React.MouseEvent<HTMLElement>) => {
-          e.preventDefault();
+        onClick: () => {
           props.onDelete();
         },
         ...(readOnly ? disabledProps : {})

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigActionMenu.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigActionMenu.tsx
@@ -44,7 +44,7 @@ class ConfigActionMenu extends React.Component<CombinedProps> {
     const tooltip = readOnly
       ? "You don't have permission to perform this action"
       : undefined;
-    const actions = [
+    return [
       {
         title: 'Boot This Config',
         onClick: (e: React.MouseEvent<HTMLElement>) => {
@@ -87,8 +87,6 @@ class ConfigActionMenu extends React.Component<CombinedProps> {
         tooltip
       }
     ];
-
-    return actions;
   };
 
   render() {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigActionMenu_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigActionMenu_CMR.tsx
@@ -75,8 +75,7 @@ const ConfigActionMenu: React.FC<CombinedProps> = props => {
     return [
       {
         title: 'Clone',
-        onClick: (e: React.MouseEvent<HTMLElement>) => {
-          e.preventDefault();
+        onClick: () => {
           history.push(
             `/linodes/${linodeId}/clone/configs?selectedConfig=${config.id}`
           );
@@ -85,8 +84,7 @@ const ConfigActionMenu: React.FC<CombinedProps> = props => {
       },
       {
         title: 'Delete',
-        onClick: (e: React.MouseEvent<HTMLElement>) => {
-          e.preventDefault();
+        onClick: () => {
           handleDelete();
         },
         disabled: readOnly,
@@ -98,15 +96,13 @@ const ConfigActionMenu: React.FC<CombinedProps> = props => {
   const inlineActions = [
     {
       actionText: 'Boot',
-      onClick: (e: React.MouseEvent<HTMLElement>) => {
-        e.preventDefault();
+      onClick: () => {
         handleBoot();
       }
     },
     {
       actionText: 'Edit',
-      onClick: (e: React.MouseEvent<HTMLElement>) => {
-        e.preventDefault();
+      onClick: () => {
         handleEdit();
       }
     }

--- a/packages/manager/src/features/linodes/LinodesLanding/DisplayLinodes.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/DisplayLinodes.tsx
@@ -200,4 +200,4 @@ const DisplayLinodes: React.FC<CombinedProps> = props => {
   );
 };
 
-export default DisplayLinodes;
+export default React.memo(DisplayLinodes);

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu_CMR.tsx
@@ -139,6 +139,17 @@ export const LinodeActionMenu: React.FC<CombinedProps> = props => {
     return stringify(params);
   };
 
+  const handlePowerAction = () => {
+    const action = linodeStatus === 'running' ? 'Power Off' : 'Power On';
+    sendLinodeActionMenuItemEvent(`${action} Linode`);
+    openPowerActionDialog(
+      `${action}` as BootAction,
+      linodeId,
+      linodeLabel,
+      linodeStatus === 'running' ? configs : []
+    );
+  };
+
   const createLinodeActions = () => {
     const {
       linodeId,
@@ -170,96 +181,79 @@ export const LinodeActionMenu: React.FC<CombinedProps> = props => {
       const actions: Action[] = [
         {
           title: 'Settings',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
+          onClick: () => {
             sendLinodeActionMenuItemEvent('Navigate to Settings Page');
             history.push(`/linodes/${linodeId}/settings`);
-            e.preventDefault();
-            e.stopPropagation();
           }
         },
         linodeBackups.enabled
           ? {
               title: 'View Backups',
-              onClick: (e: React.MouseEvent<HTMLElement>) => {
+              onClick: () => {
                 sendLinodeActionMenuItemEvent('Navigate to Backups Page');
                 history.push(`/linodes/${linodeId}/backup`);
-                e.preventDefault();
-                e.stopPropagation();
               }
             }
           : {
               title: 'Enable Backups',
-              onClick: (e: React.MouseEvent<HTMLElement>) => {
+              onClick: () => {
                 sendLinodeActionMenuItemEvent('Enable Backups');
                 openDialog('enable_backups', linodeId);
-                e.preventDefault();
-                e.stopPropagation();
               },
               ...readOnlyProps
             },
         {
           title: 'Clone',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
+          onClick: () => {
             sendLinodeActionMenuItemEvent('Clone');
             history.push({
               pathname: '/linodes/create',
               search: buildQueryStringForLinodeClone()
             });
-            e.preventDefault();
-            e.stopPropagation();
           },
           ...maintenanceProps,
           ...readOnlyProps
         },
         {
           title: 'Resize',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
+          onClick: () => {
             openDialog('resize', linodeId);
-            e.preventDefault();
-            e.stopPropagation();
           },
           ...maintenanceProps,
           ...readOnlyProps
         },
         {
           title: 'Rebuild',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
+          onClick: () => {
             sendLinodeActionMenuItemEvent('Navigate to Rebuild Page');
             openDialog('rebuild', linodeId);
-            e.preventDefault();
-            e.stopPropagation();
           },
           ...maintenanceProps,
           ...readOnlyProps
         },
         {
           title: 'Rescue',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
+          onClick: () => {
             sendLinodeActionMenuItemEvent('Navigate to Rescue Page');
             openDialog('rescue', linodeId);
-            e.preventDefault();
-            e.stopPropagation();
           },
           ...maintenanceProps,
           ...readOnlyProps
         },
         {
           title: 'Migrate',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
+          onClick: () => {
             sendMigrationNavigationEvent('/linodes');
             sendLinodeActionMenuItemEvent('Migrate');
             openDialog('migrate', linodeId);
-            e.preventDefault();
-            e.stopPropagation();
           },
           ...readOnlyProps
         },
         {
           title: 'Delete',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
+          onClick: () => {
             sendLinodeActionMenuItemEvent('Delete Linode');
-            e.preventDefault();
-            e.stopPropagation();
+
             openDialog('delete', linodeId, linodeLabel);
           },
           ...readOnlyProps
@@ -281,10 +275,8 @@ export const LinodeActionMenu: React.FC<CombinedProps> = props => {
             : configsError
             ? 'Could not load configs for this Linode.'
             : undefined,
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
+          onClick: () => {
             sendLinodeActionMenuItemEvent('Reboot Linode');
-            e.preventDefault();
-            e.stopPropagation();
             openPowerActionDialog('Reboot', linodeId, linodeLabel, configs);
           },
           ...readOnlyProps
@@ -294,11 +286,9 @@ export const LinodeActionMenu: React.FC<CombinedProps> = props => {
       if (matchesSmDown || inTableContext) {
         actions.unshift({
           title: 'Launch Console',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
+          onClick: () => {
             sendLinodeActionMenuItemEvent('Launch Console');
             lishLaunch(linodeId);
-            e.preventDefault();
-            e.stopPropagation();
           },
           ...readOnlyProps
         });
@@ -307,19 +297,7 @@ export const LinodeActionMenu: React.FC<CombinedProps> = props => {
       if (matchesSmDown && inTableContext) {
         actions.unshift({
           title: linodeStatus === 'running' ? 'Power Off' : 'Power On',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
-            const action =
-              linodeStatus === 'running' ? 'Power Off' : 'Power On';
-            sendLinodeActionMenuItemEvent(`${action} Linode`);
-            e.preventDefault();
-            e.stopPropagation();
-            openPowerActionDialog(
-              `${action}` as BootAction,
-              linodeId,
-              linodeLabel,
-              linodeStatus === 'running' ? configs : []
-            );
-          },
+          onClick: handlePowerAction,
           disabled: !['running', 'offline'].includes(linodeStatus)
         });
       }
@@ -330,11 +308,10 @@ export const LinodeActionMenu: React.FC<CombinedProps> = props => {
       ) {
         actions.unshift({
           title: 'Details',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
+          onClick: () => {
             history.push({
               pathname: `/linodes/${linodeId}`
             });
-            e.preventDefault();
           }
         });
       }
@@ -362,18 +339,7 @@ export const LinodeActionMenu: React.FC<CombinedProps> = props => {
       actionText: linodeStatus === 'running' ? 'Power Off' : 'Power On',
       disabled: !['running', 'offline'].includes(linodeStatus),
       className: classes.powerOnOrOff,
-      onClick: (e: React.MouseEvent<HTMLElement>) => {
-        const action = linodeStatus === 'running' ? 'Power Off' : 'Power On';
-        sendLinodeActionMenuItemEvent(`${action} Linode`);
-        e.preventDefault();
-        e.stopPropagation();
-        openPowerActionDialog(
-          `${action}` as BootAction,
-          linodeId,
-          linodeLabel,
-          linodeStatus === 'running' ? configs : []
-        );
-      }
+      onClick: handlePowerAction
     }
   ];
 


### PR DESCRIPTION
## Description

Please see the commit messages (pasted below) for details. tldr;
Action menus weren't closing because we were in the habit of (inconsistently)
calling e.preventDefault() and e.stopPropagation() in our action callbacks.

That is (I think) cruft left over from MUI. The Reach [docs](https://reach.tech/menu-button/#menupopover)
say that their action menus don't call the native events directly, and it seems like
our preventDefault() etc. was preventing their handlers from doing things like closing the menu.

In short, I:
- replaced MenuLink with MenuItem
- Changed the signature of onClick to match the onSelect method of MenuItem
- Deleted every e.preventDefault() to match the new typing

In the long term:
- actions that act as links can be differentiated somehow (action.href or something), and ActionMenu can conditionally
use the MenuLink for them

----------

Our old ActionMenu, which was based on MUI, triggered underlying
events when an action in the menu was clicked. This caused some
issues, which we fixed by adding e.preventDefault() and (sometimes!)
e.stopPropagation() in our action handlers in individual actionmenu
consumers.

This logic was carried over into the new ActionMenu, which uses
Reach UI and doesn't seem to fire these events. According to their
docs (at https://reach.tech/menu-button/#menulink-onselect):

This won't work because we actually do not call the onClick handler to activate Menu or select MenuItem or MenuLink components. This is because a user may mouse down on a menu button, drag over a menu item and then select it by releasing the mouse trigger. A user may also start clicking one item, then drag to another item before mouseup to change their selectiion.

One consequence of this difference is that when an action is triggered,
our existing preventDefault() logic prevents Reach from doing its thing,
which in this case includes closing the action menu. MUI took an onClose()
as a prop, which we were calling from many individual actions to resolve this.

Removing our default prevention logic causes the menus to function correctly.

The MUI-to-Reach refactor used the MenuLink component for our actions,
even though none of our actions are true links (in the sense of providing
an href). This was done because the interface most closely matched the MUI
pattern we were used to. This turns out to be a bit of a hack that could
have more consequences besides the menu close issues in the previous commit.

The correct thing to do (I think) is use MenuItem and provide an onSelect
handler instead of onClick. onSelect will close the menu and execute our
function, without calling any of the actual onClick handlers of e.g. a button
or <a>.

----

As a bonus for reading this far, here's some extra details:

MenuLink has an onClick handler that is called before the onSelect handler. It's not intended to be used as we were using it, the docs give some very specific examples that are hard to do otherwise.  Putting our action handlers in the onClick of MenuLink, with preventDefault calls, was short-circuiting their logic. One interesting side effect of this was, because the menu wasn't closing, the action itself was pretty snappy. When I made the change, there was a noticeable lag in the Linodes action menu (from list view) between clicking an action and e.g. the opening of a modal. Figured out this was because every row was re-rendering as part of the menu closing. Adding React.memo seems to help with this.