### PR TITLE
Set ts-jest diagnostics to "warnOnly"

### DIFF
--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -322,7 +322,10 @@
     ],
     "globals": {
       "ts-jest": {
-        "tsConfig": "tsconfig.test.json"
+        "tsConfig": "tsconfig.test.json",
+        "diagnostics": {
+          "warnOnly": true
+        }
       }
     }
   },


### PR DESCRIPTION
## Description

Currently when there are TS errors, our unit tests fail. This can be really annoying when you're developing a test, for example if you comment something out and run a test, the test may fail due to a "unused import". 

This sets `ts-jest` diagnostics to "warnOnly". 

## Note to Reviewers

From **develop**:

1. Add an unused import to a test, e.g. `import { LISH_ROOT } from 'src/constants';` in "src/utilities/sanitize-html.test.ts".
2. `yarn test packages/manager/src/utilities/sanitize-html/sanitize-html.test.ts`
3. **Observe:** test fails because of the unused import.
4. Checkout this branch.
5. Clear your Jest cache: `yarn test --clearCache`
6. Run the test again: `yarn test packages/manager/src/utilities/sanitize-html/sanitize-html.test.ts`
7. Observe: test passes but the warning is still shown.