### PR TITLE
Change Minecraft OCA to Minecraft: Java Edition

### DIFF
--- a/packages/manager/src/features/OneClickApps/FakeSpec.ts
+++ b/packages/manager/src/features/OneClickApps/FakeSpec.ts
@@ -695,7 +695,7 @@ export const oneClickApps: OCA[] = [
     logo_url: 'assets/openvpn_color.svg'
   },
   {
-    name: 'Minecraft - Java Edition',
+    name: 'Minecraft: Java Edition',
     description: `With over 100 million users around the world, Minecraft is the most popular
       online game of all time. Less of a game and more of a lifestyle choice, you
       and other players are free to build and explore in a 3D generated world made

--- a/packages/manager/src/features/OneClickApps/FakeSpec.ts
+++ b/packages/manager/src/features/OneClickApps/FakeSpec.ts
@@ -695,7 +695,7 @@ export const oneClickApps: OCA[] = [
     logo_url: 'assets/openvpn_color.svg'
   },
   {
-    name: 'Minecraft',
+    name: 'Minecraft - Java Edition',
     description: `With over 100 million users around the world, Minecraft is the most popular
       online game of all time. Less of a game and more of a lifestyle choice, you
       and other players are free to build and explore in a 3D generated world made


### PR DESCRIPTION
## Description

Renaming an OCA. This won't change anything until the StackScript name itself is updated, so you'll have to mock to test.

## Note to Reviewers

Please see provided patch for testing this with mocks. When mocked correctly, clicking the i icon in the marketplace view will open a drawer with details about the app.