### PR TITLE
Fix casing of NodeBalancer breadcrumb

### DIFF
--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
@@ -248,7 +248,7 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
   render() {
     const matches = (pathName: string) =>
       Boolean(matchPath(this.props.location.pathname, { path: pathName }));
-    const { error, loading, location } = this.props;
+    const { error, loading } = this.props;
     const { nodeBalancer } = this.state;
 
     /** Loading State */
@@ -286,7 +286,7 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
           <Grid container justify="space-between">
             <Grid item>
               <Breadcrumb
-                pathname={location.pathname}
+                pathname={`/NodeBalancers/${nodeBalancerLabel}`}
                 firstAndLastOnly
                 onEditHandlers={{
                   editableTextTitle: nodeBalancerLabel,


### PR DESCRIPTION
## Description

Fixes this error in prod:
<img width="423" alt="Screen Shot 2020-09-04 at 2 30 52 PM" src="https://user-images.githubusercontent.com/16911484/92274489-56c0ea80-eebb-11ea-92b9-dff432bf19b1.png">

