### PR TITLE
Fix console error (isResponsive prop not recognized)

### DIFF
--- a/packages/manager/src/components/Table/Table.tsx
+++ b/packages/manager/src/components/Table/Table.tsx
@@ -140,7 +140,7 @@ class WrappedTable extends React.Component<CombinedProps> {
           'tableWrapper',
           {
             [classes.root]: !noOverflow,
-            [classes.responsive]: !(isResponsive === false), // must be explicity set to false
+            [classes.responsive]: isResponsive !== false, // must be explicity set to false
             [classes.border]: border,
             [classes.noMobileLabel]: removeLabelonMobile,
             [classes.stickyHeader]: stickyHeader

--- a/packages/manager/src/components/Table/Table_CMR.tsx
+++ b/packages/manager/src/components/Table/Table_CMR.tsx
@@ -74,7 +74,6 @@ export interface Props extends TableProps {
   noOverflow?: boolean;
   tableClass?: string;
   border?: boolean;
-  isResponsive?: boolean; // back-door for tables that don't need to be responsive
   spacingTop?: 0 | 8 | 16 | 24;
   spacingBottom?: 0 | 8 | 16 | 24;
   stickyHeader?: boolean;

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable_CMR.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable_CMR.tsx
@@ -132,7 +132,7 @@ const FirewallRuleTable: React.FC<CombinedProps> = props => {
           const allRows = [...sortedUnmodifiedRows, ...modifiedRows];
 
           return (
-            <Table isResponsive={false}>
+            <Table>
               <TableHead>
                 <TableRow>
                   <TableSortCell

--- a/packages/manager/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel_CMR.tsx
+++ b/packages/manager/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel_CMR.tsx
@@ -167,7 +167,6 @@ class SelectStackScriptPanel extends React.Component<CombinedProps, State> {
         return (
           <React.Fragment>
             <Table
-              isResponsive={false}
               aria-label="List of StackScripts"
               noOverflow={true}
               tableClass={classes.table}

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -539,7 +539,6 @@ const withStackScriptBase = (options: WithStackScriptBaseOptions) => (
                 />
               </div>
               <_Table
-                isResponsive={!isSelecting}
                 aria-label="List of StackScripts"
                 rowCount={listOfStackScripts.length}
                 colCount={isSelecting ? 1 : 4}

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -318,7 +318,6 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
           <Grid item xs={12} lg={10}>
             {flags?.cmr ? (
               <Table_CMR
-                isResponsive={false}
                 border
                 spacingBottom={16}
                 aria-label="List of Linode Plans"

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs_CMR.tsx
@@ -461,11 +461,7 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
               } = this.props;
               return (
                 <React.Fragment>
-                  <Table
-                    isResponsive={false}
-                    aria-label="List of Configurations"
-                    border
-                  >
+                  <Table aria-label="List of Configurations" border>
                     <TableHead>
                       <TableRow>
                         <TableSortCell

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks_CMR.tsx
@@ -228,7 +228,7 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
                   <React.Fragment>
                     <Grid container>
                       <Grid item xs={12}>
-                        <Table isResponsive={false} aria-label="List of Disks">
+                        <Table aria-label="List of Disks">
                           <TableHead>
                             <TableRow>
                               <TableSortCell


### PR DESCRIPTION
Our non-CMR Table component had an optional isResponsive prop.
The CMR version does not use this prop, though it was copied over
in the props interface and included in many instances of the table.

However, since it isn't used anywhere, it ends up being passed down
to the underlying component as an html attribute as part of the ...rest
spread, which triggers a React console warning.

Removed isResponsive from the CMR table interface and used that
to hunt down all the CMR tables that were using it.

Please visit some CMR tables (LinodeDisks, LinodeConfigs, FirewallRules, Stackscripts) and make sure the console is clean.

Note:

One regression is introduced here; the StackScript table loses its conditional isResponsive declaration, which means under certain circumstances (I'm not 100% clear) it will be responsive where it previously wasn't. This can be patched if we want, but it would be awkward and hacky (I'd probably re-add isResponsive to the Table_CMR interface and do some conditional stuff in the StackScriptBase _Table); I didn't think it was worth it since CMR will be flipped in the next few weeks.
