### PR TITLE
[CMR] Add ellipsis to 'Add a User' button

### DIFF
--- a/packages/manager/src/features/Users/UsersLanding_CMR.tsx
+++ b/packages/manager/src/features/Users/UsersLanding_CMR.tsx
@@ -266,7 +266,7 @@ const UsersLanding: React.FC<CombinedProps> = props => {
                   : undefined
               }
               onClick={openForCreate}
-              label="Add a User"
+              label="Add a User..."
             />
           </Grid>
         </Grid>


### PR DESCRIPTION
## Description
Extremely minor change, but added an ellipsis to the "Add a User" button on the Account > Users page to be consistent with other Create/Add buttons.

## Type of Change
- Non breaking change ('update', 'change')