### PR TITLE
[CMR] M3-4511: Remove container around StackScript table

### DIFF
--- a/packages/manager/src/components/EntityHeader/HeaderBreadCrumb.tsx
+++ b/packages/manager/src/components/EntityHeader/HeaderBreadCrumb.tsx
@@ -172,7 +172,10 @@ export const HeaderBreadCrumb: React.FC<BreadCrumbProps> = props => {
         </Grid>
       )}
       <Grid item>
-        <Typography variant="h2" className={classes.titleText}>
+        <Typography
+          variant="h2"
+          className={iconType ? classes.titleText : 'p0'}
+        >
           {title}
         </Typography>
       </Grid>

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.styles.ts
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.styles.ts
@@ -12,7 +12,8 @@ type ClassNames =
   | 'table'
   | 'searchWrapper'
   | 'searchBar'
-  | 'stackscriptPlaceholder';
+  | 'stackscriptPlaceholder'
+  | 'cmrSpacing';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -44,6 +45,11 @@ const styles = (theme: Theme) =>
       '& > div': {
         marginRight: 0
       }
+    },
+    cmrSpacing: {
+      paddingTop: 4,
+      paddingBottom: `4px !important`,
+      paddingLeft: 4
     },
     // Styles to override base placeholder styles for StackScript null state
     stackscriptPlaceholder: {

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -520,7 +520,10 @@ const withStackScriptBase = (options: WithStackScriptBaseOptions) => (
             </div>
           ) : (
             <React.Fragment>
-              <div className={classes.searchWrapper}>
+              <div
+                className={`${classes.searchWrapper} ${this.props.flags.cmr &&
+                  classes.cmrSpacing}`}
+              >
                 <DebouncedSearch
                   placeholder="Search by Label, Username, or Description"
                   onSearch={this.handleSearch}

--- a/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptPanel_CMR.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptPanel_CMR.tsx
@@ -31,14 +31,13 @@ export interface ExtendedLinode extends Linode {
   subHeadings: string[];
 }
 
-type ClassNames = 'root';
+type ClassNames = 'root' | 'cmrSpacing';
 
 const styles = (theme: Theme) =>
   createStyles({
     root: {
-      backgroundColor: theme.color.white,
       marginBottom: theme.spacing(3),
-      padding: theme.spacing(3)
+      padding: '0 !important'
     }
   });
 

--- a/packages/manager/src/features/StackScripts/StackScriptsLanding_CMR.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptsLanding_CMR.tsx
@@ -12,10 +12,11 @@ import withImagesContainer, {
 } from 'src/containers/withImages.container';
 import { useReduxLoad } from 'src/hooks/useReduxLoad';
 import { filterImagesByType } from 'src/store/image/image.helpers';
-import StackScriptPanel from './StackScriptPanel';
+import StackScriptPanel from './StackScriptPanel/StackScriptPanel_CMR';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
+    marginBottom: theme.spacing(3),
     // Temporary fix for the negative padding since it's a part of the LandingHeader component
     '& > .MuiGrid-root > .MuiGrid-root': {
       paddingTop: 8

--- a/packages/manager/src/features/StackScripts/StackScriptsLanding_CMR.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptsLanding_CMR.tsx
@@ -16,11 +16,7 @@ import StackScriptPanel from './StackScriptPanel/StackScriptPanel_CMR';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
-    marginBottom: theme.spacing(3),
-    // Temporary fix for the negative padding since it's a part of the LandingHeader component
-    '& > .MuiGrid-root > .MuiGrid-root': {
-      paddingTop: 8
-    }
+    marginBottom: theme.spacing(3)
   },
   panel: {
     '& > div': {


### PR DESCRIPTION
Remove the white container around the table and adjust the spacing to improve the grouping as mentioned in the demo prep