### PR TITLE
M3-4524: Prevent removeLabelonMobile console error

### DIFF
--- a/packages/manager/src/components/Table/Table_CMR.tsx
+++ b/packages/manager/src/components/Table/Table_CMR.tsx
@@ -77,7 +77,6 @@ export interface Props extends TableProps {
   spacingTop?: 0 | 8 | 16 | 24;
   spacingBottom?: 0 | 8 | 16 | 24;
   stickyHeader?: boolean;
-  removeLabelonMobile?: boolean; // only for table instances where we want to hide the cell label for small screens
   tableCaption?: string;
   colCount?: number;
   rowCount?: number;

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTable_CMR.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTable_CMR.tsx
@@ -84,7 +84,7 @@ export const BucketTable: React.FC<CombinedProps> = props => {
         }) => (
           <React.Fragment>
             <div className={classes.root}>
-              <Table removeLabelonMobile aria-label="List of your Buckets">
+              <Table aria-label="List of your Buckets">
                 <TableHead>
                   <TableRow>
                     <TableSortCell

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -477,8 +477,6 @@ const withStackScriptBase = (options: WithStackScriptBaseOptions) => (
         ? getQueryParam(this.props.location.search, 'query')
         : undefined;
 
-      const _Table = this.props.flags.cmr ? Table_CMR : Table;
-
       return (
         <React.Fragment>
           {fieldError && fieldError.reason && (
@@ -538,39 +536,55 @@ const withStackScriptBase = (options: WithStackScriptBaseOptions) => (
                   defaultValue={query}
                 />
               </div>
-              <_Table
-                aria-label="List of StackScripts"
-                rowCount={listOfStackScripts.length}
-                colCount={isSelecting ? 1 : 4}
-                noOverflow={true}
-                tableClass={classes.table}
-                removeLabelonMobile={!isSelecting}
-                border
-                stickyHeader
-              >
-                {this.props.flags.cmr ? (
+              {this.props.flags.cmr ? (
+                <Table_CMR
+                  aria-label="List of StackScripts"
+                  rowCount={listOfStackScripts.length}
+                  colCount={isSelecting ? 1 : 4}
+                  noOverflow={true}
+                  tableClass={classes.table}
+                  border
+                  stickyHeader
+                >
                   <StackScriptTableHead_CMR
                     handleClickTableHeader={this.handleClickTableHeader}
                     sortOrder={sortOrder}
                     currentFilterType={currentFilterType}
                     isSelecting={isSelecting}
                   />
-                ) : (
+                  <Component
+                    {...this.props}
+                    {...this.state}
+                    getDataAtPage={this.getDataAtPage}
+                    getNext={this.getNext}
+                  />
+                </Table_CMR>
+              ) : (
+                <Table
+                  aria-label="List of StackScripts"
+                  rowCount={listOfStackScripts.length}
+                  colCount={isSelecting ? 1 : 4}
+                  noOverflow={true}
+                  tableClass={classes.table}
+                  removeLabelonMobile={!isSelecting}
+                  border
+                  stickyHeader
+                >
                   <StackScriptTableHead
                     handleClickTableHeader={this.handleClickTableHeader}
                     sortOrder={sortOrder}
                     currentFilterType={currentFilterType}
                     isSelecting={isSelecting}
                   />
-                )}
+                  <Component
+                    {...this.props}
+                    {...this.state}
+                    getDataAtPage={this.getDataAtPage}
+                    getNext={this.getNext}
+                  />
+                </Table>
+              )}
 
-                <Component
-                  {...this.props}
-                  {...this.state}
-                  getDataAtPage={this.getDataAtPage}
-                  getNext={this.getNext}
-                />
-              </_Table>
               {/*
                * show loading indicator if we're getting more stackscripts
                * and if we're not showing the "get more stackscripts" button


### PR DESCRIPTION
## Description
Similar to https://github.com/linode/manager/pull/6876, the `removeLabelonMobile` prop was an artifact carried over into `Table_CMR` from the old table, and passed to it as a prop in `BucketTable_CMR`. This PR removes the prop and does a small refactor in `StackScriptBase.tsx` to avoid TypeScript errors.

## Type of Change
- Non breaking change ('update', 'change')
