### PR TITLE
M3-4526: Fix MigrateLanding routing bug

### DIFF
--- a/packages/manager/src/features/linodes/MigrateLanding/MigrateLanding.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/MigrateLanding.tsx
@@ -11,7 +11,7 @@ import { APIError as APIErrorType } from '@linode/api-v4/lib/types';
 import { Volume } from '@linode/api-v4/lib/volumes';
 import * as React from 'react';
 import { connect, MapStateToProps } from 'react-redux';
-import { RouteComponentProps } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 import { compose } from 'recompose';
 
 import Button from 'src/components/Button';
@@ -56,13 +56,12 @@ const useStyles = makeStyles((theme: Theme) => ({
   }
 }));
 
-type CombinedProps = LinodeContextProps &
-  WithTypesAndImages &
-  RegionProps &
-  RouteComponentProps<{}>;
+type CombinedProps = LinodeContextProps & WithTypesAndImages & RegionProps;
 
 const MigrateLanding: React.FC<CombinedProps> = props => {
   const classes = useStyles();
+
+  const history = useHistory();
 
   const [selectedRegion, handleSelectRegion] = React.useState<string | null>(
     null
@@ -128,7 +127,7 @@ const MigrateLanding: React.FC<CombinedProps> = props => {
             format: 'H'
           })
         );
-        props.history.push(`/linodes/${linodeId}`);
+        history.push(`/linodes/${linodeId}`);
       })
       .catch((e: APIErrorType[]) => {
         setLoading(false);


### PR DESCRIPTION
## Description

**Edit:** this is for the non-CMR component only, so you'll need to test without the feature flag.

Because of the change I made here: https://github.com/linode/manager/pull/6838/files#diff-79f01013d6e7dec6cc15eef8a4760ee1R82, MigrateLanding no longer implicitly inherited router props. Thus the call to `props.history.push()` failed, causing an error (reported via Sentry).

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

To reproduce the bug:
- Migrate a Linode
- Observe: you are not redirected to the Details page, and there is a console error.
