### PR TITLE
M3-4495 Globalize JS client extraction of data from Axios response

### DIFF
--- a/packages/api-v4/src/account/account.ts
+++ b/packages/api-v4/src/account/account.ts
@@ -20,9 +20,7 @@ import {
  *
  */
 export const getAccountInfo = () => {
-  return Request<Account>(setURL(`${API_ROOT}/account`), setMethod('GET')).then(
-    response => response.data
-  );
+  return Request<Account>(setURL(`${API_ROOT}/account`), setMethod('GET'));
 };
 
 /**
@@ -35,7 +33,7 @@ export const getNetworkUtilization = () =>
   Request<NetworkUtilization>(
     setURL(`${API_ROOT}/account/transfer`),
     setMethod('GET')
-  ).then(response => response.data);
+  );
 
 /**
  * updateAccountInfo
@@ -48,7 +46,7 @@ export const updateAccountInfo = (data: Partial<Account>) =>
     setURL(`${API_ROOT}/account`),
     setMethod('PUT'),
     setData(data, updateAccountSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * getAccountSettings
@@ -60,7 +58,7 @@ export const getAccountSettings = () =>
   Request<AccountSettings>(
     setURL(`${API_ROOT}/account/settings`),
     setMethod('GET')
-  ).then(response => response.data);
+  );
 
 /**
  * updateAccountSettings
@@ -73,7 +71,7 @@ export const updateAccountSettings = (data: Partial<AccountSettings>) =>
     setURL(`${API_ROOT}/account/settings`),
     setMethod('PUT'),
     setData(data, UpdateAccountSettingsSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * cancelAccount
@@ -85,5 +83,5 @@ export const cancelAccount = (data: CancelAccountPayload) => {
     setURL(`${API_ROOT}/account/cancel`),
     setMethod('POST'),
     setData(data)
-  ).then(response => response.data);
+  );
 };

--- a/packages/api-v4/src/account/events.ts
+++ b/packages/api-v4/src/account/events.ts
@@ -15,7 +15,7 @@ export const getEvents = (params: any = {}, filter: any = {}) =>
     setMethod('GET'),
     setXFilter(filter),
     setParams(params)
-  ).then(response => response.data);
+  );
 
 /**
  * getEvent
@@ -68,4 +68,4 @@ export const getNotifications = (params?: any, filter?: any) =>
     setMethod('GET'),
     setParams(params),
     setXFilter(filter)
-  ).then(response => response.data);
+  );

--- a/packages/api-v4/src/account/invoices.ts
+++ b/packages/api-v4/src/account/invoices.ts
@@ -15,7 +15,7 @@ export const getInvoices = (params?: any, filter?: any) =>
     setMethod('GET'),
     setParams(params),
     setXFilter(filter)
-  ).then(response => response.data);
+  );
 
 /**
  * getInvoice
@@ -29,7 +29,7 @@ export const getInvoice = (invoiceId: number) =>
   Request<Invoice>(
     setURL(`${API_ROOT}/account/invoices/${invoiceId}`),
     setMethod('GET')
-  ).then(response => response.data);
+  );
 
 /**
  * getInvoiceItems
@@ -50,4 +50,4 @@ export const getInvoiceItems = (
     setMethod('GET'),
     setParams(params),
     setXFilter(filter)
-  ).then(response => response.data);
+  );

--- a/packages/api-v4/src/account/oauth.ts
+++ b/packages/api-v4/src/account/oauth.ts
@@ -25,7 +25,7 @@ export const getOAuthClients = (params?: any, filter?: any) =>
     setMethod('GET'),
     setParams(params),
     setXFilter(filter)
-  ).then(response => response.data);
+  );
 
 /**
  * getOAuthClient
@@ -39,7 +39,7 @@ export const getOAuthClient = (clientId: number) =>
   Request<string>(
     setURL(`${API_ROOT}/account/oauth-clients/${clientId}`),
     setMethod('GET')
-  ).then(response => response.data);
+  );
 
 /**
  * createOAuthClient
@@ -56,7 +56,7 @@ export const createOAuthClient = (data: OAuthClientRequest) =>
     setURL(`${API_ROOT}/account/oauth-clients`),
     setMethod('POST'),
     setData(data, createOAuthClientSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * resetOAuthClientSecret
@@ -72,7 +72,7 @@ export const resetOAuthClientSecret = (clientId: number | string) =>
   Request<OAuthClient & { secret: string }>(
     setURL(`${API_ROOT}/account/oauth-clients/${clientId}/reset-secret`),
     setMethod('POST')
-  ).then(response => response.data);
+  );
 
 /**
  * updateOAuthClient
@@ -89,7 +89,7 @@ export const updateOAuthClient = (
     setURL(`${API_ROOT}/account/oauth-clients/${clientId}`),
     setMethod('PUT'),
     setData(data, updateOAuthClientSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * deleteOAuthClient

--- a/packages/api-v4/src/account/payments.ts
+++ b/packages/api-v4/src/account/payments.ts
@@ -28,7 +28,7 @@ export const getPayments = (params?: any, filter?: any) =>
     setMethod('GET'),
     setParams(params),
     setXFilter(filter)
-  ).then(response => response.data);
+  );
 
 /**
  * makePayment
@@ -69,7 +69,7 @@ export const makePayment = (data: { usd: string; cvv?: string }) => {
     setURL(`${API_ROOT}/account/payments`),
     setMethod('POST'),
     setData(data, PaymentSchema)
-  ).then(response => response.data);
+  );
 };
 
 interface StagePaypalData {
@@ -95,7 +95,7 @@ export const stagePaypalPayment = (data: Paypal) =>
     setURL(`${API_ROOT}/account/payments/paypal`),
     setMethod('POST'),
     setData(data, StagePaypalPaymentSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * executePaypalPayment
@@ -114,7 +114,7 @@ export const executePaypalPayment = (data: ExecutePayload) =>
     setURL(`${API_ROOT}/account/payments/paypal/execute`),
     setMethod('POST'),
     setData(data, ExecutePaypalPaymentSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * saveCreditCard
@@ -133,5 +133,5 @@ export const saveCreditCard = (data: SaveCreditCardData) => {
     setURL(`${API_ROOT}/account/credit-card`),
     setMethod('POST'),
     setData(data, CreditCardSchema)
-  ).then(response => response.data);
+  );
 };

--- a/packages/api-v4/src/account/users.ts
+++ b/packages/api-v4/src/account/users.ts
@@ -22,7 +22,7 @@ export const getUsers = (params?: any, filters?: any) =>
     setMethod('GET'),
     setParams(params),
     setXFilter(filters)
-  ).then(response => response.data);
+  );
 
 /**
  * getUser
@@ -37,7 +37,7 @@ export const getUser = (username: string) =>
   Request<User>(
     setURL(`${API_ROOT}/account/users/${username}`),
     setMethod('GET')
-  ).then(response => response.data);
+  );
 
 /**
  * createUser
@@ -52,7 +52,7 @@ export const createUser = (data: Partial<User>) =>
     setURL(`${API_ROOT}/account/users`),
     setMethod('POST'),
     setData(data, CreateUserSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * updateUser
@@ -69,7 +69,7 @@ export const updateUser = (username: string, data: Partial<User>) =>
     setURL(`${API_ROOT}/account/users/${username}`),
     setMethod('PUT'),
     setData(data, UpdateUserSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * deleteUser
@@ -84,7 +84,7 @@ export const deleteUser = (username: string) =>
   Request<{}>(
     setURL(`${API_ROOT}/account/users/${username}`),
     setMethod('DELETE')
-  ).then(response => response.data);
+  );
 
 /**
  * getGrants
@@ -101,7 +101,7 @@ export const getGrants = (username: string) =>
   Request<Grants>(
     setURL(`${API_ROOT}/account/users/${username}/grants`),
     setMethod('GET')
-  ).then(response => response.data);
+  );
 
 /**
  * updateGrants
@@ -120,4 +120,4 @@ export const updateGrants = (username: string, data: Partial<Grants>) =>
     setURL(`${API_ROOT}/account/users/${username}/grants`),
     setMethod('PUT'),
     setData(data)
-  ).then(response => response.data);
+  );

--- a/packages/api-v4/src/authentication/index.ts
+++ b/packages/api-v4/src/authentication/index.ts
@@ -23,6 +23,6 @@ export const revokeToken = (client_id: string, token: string) =>
     setHeaders({
       'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8'
     })
-  ).then(response => response.data);
+  );
 
 export { Success };

--- a/packages/api-v4/src/domains/domains.ts
+++ b/packages/api-v4/src/domains/domains.ts
@@ -25,7 +25,7 @@ export const getDomains = (params?: any, filters?: any) =>
     setMethod('GET'),
     setParams(params),
     setXFilter(filters)
-  ).then(response => response.data);
+  );
 
 /**
  * Returns all of the information about a specified Domain.
@@ -33,10 +33,7 @@ export const getDomains = (params?: any, filters?: any) =>
  * @param domainId { number } The ID of the Domain to access.
  */
 export const getDomain = (domainId: number) =>
-  Request<Domain>(
-    setURL(`${API_ROOT}/domains/${domainId}`),
-    setMethod('GET')
-  ).then(response => response.data);
+  Request<Domain>(setURL(`${API_ROOT}/domains/${domainId}`), setMethod('GET'));
 
 /**
  * Adds a new Domain to Linode's DNS Manager.
@@ -48,7 +45,7 @@ export const createDomain = (data: Partial<Domain>) =>
     setData(data, createDomainSchema),
     setURL(`${API_ROOT}/domains`),
     setMethod('POST')
-  ).then(response => response.data);
+  );
 
 /**
  * Update information about a Domain in Linode's DNS Manager.
@@ -61,7 +58,7 @@ export const updateDomain = (domainId: number, data: Partial<Domain>) =>
     setURL(`${API_ROOT}/domains/${domainId}`),
     setMethod('PUT'),
     setData(data, updateDomainSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * Deletes a Domain from Linode's DNS Manager. The Domain will be removed from Linode's nameservers shortly after this
@@ -83,7 +80,7 @@ export const cloneDomain = (domainId: number, cloneName: string) =>
     setData({ domain: cloneName }),
     setURL(`${API_ROOT}/domains/${domainId}/clone`),
     setMethod('POST')
-  ).then(response => response.data);
+  );
 
 /**
  * Imports a domain zone from a remote nameserver.
@@ -96,4 +93,4 @@ export const importZone = (domain: string, remote_nameserver: string) =>
     setData({ domain, remote_nameserver }, importZoneSchema),
     setURL(`${API_ROOT}/domains/import`),
     setMethod('POST')
-  ).then(response => response.data);
+  );

--- a/packages/api-v4/src/domains/records.ts
+++ b/packages/api-v4/src/domains/records.ts
@@ -18,7 +18,7 @@ export const getDomainRecords = (domainId: number, params?: any) =>
     setURL(`${API_ROOT}/domains/${domainId}/records`),
     setParams(params),
     setMethod('GET')
-  ).then(response => response.data);
+  );
 
 /**
  * View a single Record on this Domain.
@@ -30,7 +30,7 @@ export const getDomainRecord = (domainId: number, recordId: number) =>
   Request<DomainRecord>(
     setURL(`${API_ROOT}/domains/${domainId}/records/${recordId}`),
     setMethod('GET')
-  ).then(response => response.data);
+  );
 
 /**
  * Adds a new Domain Record to the zonefile this Domain represents.
@@ -46,7 +46,7 @@ export const createDomainRecord = (
     setURL(`${API_ROOT}/domains/${domainId}/records`),
     setMethod('POST'),
     setData(data, createRecordSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * Updates a single Record on this Domain.
@@ -64,7 +64,7 @@ export const updateDomainRecord = (
     setURL(`${API_ROOT}/domains/${domainId}/records/${recordId}`),
     setMethod('PUT'),
     setData(data, updateRecordSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * Deletes a Record on this Domain..
@@ -76,4 +76,4 @@ export const deleteDomainRecord = (domainId: number, recordId: number) =>
   Request<{}>(
     setURL(`${API_ROOT}/domains/${domainId}/records/${recordId}`),
     setMethod('DELETE')
-  ).then(response => response.data);
+  );

--- a/packages/api-v4/src/firewalls/firewalls.ts
+++ b/packages/api-v4/src/firewalls/firewalls.ts
@@ -34,7 +34,7 @@ export const getFirewalls = (params?: any, filters?: any) =>
     setParams(params),
     setXFilter(filters),
     setURL(`${BETA_API_ROOT}/networking/firewalls`)
-  ).then(response => response.data);
+  );
 
 /**
  * getFirewall
@@ -47,7 +47,7 @@ export const getFirewall = (firewallID: number) =>
   Request<Firewall>(
     setMethod('GET'),
     setURL(`${BETA_API_ROOT}/networking/firewalls/${firewallID}`)
-  ).then(response => response.data);
+  );
 
 /**
  * createFirewall
@@ -65,7 +65,7 @@ export const createFirewall = (data: CreateFirewallPayload) =>
     setMethod('POST'),
     setData(data, CreateFirewallSchema),
     setURL(`${BETA_API_ROOT}/networking/firewalls`)
-  ).then(response => response.data);
+  );
 
 /**
  * updateFirewall
@@ -82,7 +82,7 @@ export const updateFirewall = (
     setMethod('PUT'),
     setData(data, UpdateFirewallSchema),
     setURL(`${BETA_API_ROOT}/networking/firewalls/${firewallID}`)
-  ).then(response => response.data);
+  );
 
 /**
  * enableFirewall
@@ -114,7 +114,7 @@ export const deleteFirewall = (firewallID: number) =>
   Request<{}>(
     setMethod('DELETE'),
     setURL(`${BETA_API_ROOT}/networking/firewalls/${firewallID}`)
-  ).then(response => response.data);
+  );
 
 // FIREWALL RULES
 
@@ -133,7 +133,7 @@ export const getFirewallRules = (
     setParams(params),
     setXFilter(filters),
     setURL(`${BETA_API_ROOT}/networking/firewalls/${firewallID}/rules`)
-  ).then(response => response.data);
+  );
 
 /**
  * updateFirewallRules
@@ -146,7 +146,7 @@ export const updateFirewallRules = (firewallID: number, data: FirewallRules) =>
     setMethod('PUT'),
     setData(data), // Validation is too complicated for these; leave it to the API.
     setURL(`${BETA_API_ROOT}/networking/firewalls/${firewallID}/rules`)
-  ).then(response => response.data);
+  );
 
 // DEVICES
 
@@ -166,7 +166,7 @@ export const getFirewallDevices = (
     setParams(params),
     setXFilter(filters),
     setURL(`${BETA_API_ROOT}/networking/firewalls/${firewallID}/devices`)
-  ).then(response => response.data);
+  );
 
 /**
  * getFirewallDevice
@@ -180,7 +180,7 @@ export const getFirewallDevice = (firewallID: number, deviceID: number) =>
     setURL(
       `${BETA_API_ROOT}/networking/firewalls/${firewallID}/devices/${deviceID}`
     )
-  ).then(response => response.data);
+  );
 
 /**
  * addFirewallDevice
@@ -202,7 +202,7 @@ export const addFirewallDevice = (
     setMethod('POST'),
     setURL(`${BETA_API_ROOT}/networking/firewalls/${firewallID}/devices`),
     setData(data, FirewallDeviceSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * deleteFirewallDevice
@@ -218,4 +218,4 @@ export const deleteFirewallDevice = (firewallID: number, deviceID: number) =>
     setURL(
       `${BETA_API_ROOT}/networking/firewalls/${firewallID}/devices/${deviceID}`
     )
-  ).then(response => response.data);
+  );

--- a/packages/api-v4/src/images/images.ts
+++ b/packages/api-v4/src/images/images.ts
@@ -16,10 +16,7 @@ import { Image } from './types';
  * @param imageId { string } ID of the Image to look up.
  */
 export const getImage = (imageId: string) =>
-  Request<Image>(
-    setURL(`${API_ROOT}/images/${imageId}`),
-    setMethod('GET')
-  ).then(response => response.data);
+  Request<Image>(setURL(`${API_ROOT}/images/${imageId}`), setMethod('GET'));
 
 /**
  * Returns a paginated list of Images.
@@ -31,7 +28,7 @@ export const getImages = (params: any = {}, filters: any = {}) =>
     setMethod('GET'),
     setParams(params),
     setXFilter(filters)
-  ).then(response => response.data);
+  );
 
 /**
  * Create a private gold-master Image from a Linode Disk.

--- a/packages/api-v4/src/kubernetes/kubernetes.ts
+++ b/packages/api-v4/src/kubernetes/kubernetes.ts
@@ -27,7 +27,7 @@ export const getKubernetesClusters = (params?: any, filters?: any) =>
     setParams(params),
     setXFilter(filters),
     setURL(`${API_ROOT}/lke/clusters`)
-  ).then(response => response.data);
+  );
 
 /**
  * getKubernetesCluster
@@ -38,7 +38,7 @@ export const getKubernetesCluster = (clusterID: number) =>
   Request<KubernetesCluster>(
     setMethod('GET'),
     setURL(`${API_ROOT}/lke/clusters/${clusterID}`)
-  ).then(response => response.data);
+  );
 
 /**
  * createKubernetesClusters
@@ -50,7 +50,7 @@ export const createKubernetesCluster = (data: CreateKubeClusterPayload) =>
     setMethod('POST'),
     setURL(`${API_ROOT}/lke/clusters`),
     setData(data, createKubeClusterSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * updateKubernetesCluster
@@ -65,7 +65,7 @@ export const updateKubernetesCluster = (
     setMethod('PUT'),
     setURL(`${API_ROOT}/lke/clusters/${clusterID}`),
     setData(data)
-  ).then(response => response.data);
+  );
 
 /**
  * deleteKubernetesCluster
@@ -76,7 +76,7 @@ export const deleteKubernetesCluster = (clusterID: number) =>
   Request<{}>(
     setMethod('DELETE'),
     setURL(`${API_ROOT}/lke/clusters/${clusterID}`)
-  ).then(response => response.data);
+  );
 
 /** getKubeConfig
  *
@@ -89,7 +89,7 @@ export const getKubeConfig = (clusterId: number) =>
   Request<KubeConfigResponse>(
     setMethod('GET'),
     setURL(`${API_ROOT}/lke/clusters/${clusterId}/kubeconfig`)
-  ).then(response => response.data);
+  );
 
 /** getKubernetesVersions
  *
@@ -101,7 +101,7 @@ export const getKubernetesVersions = () =>
   Request<Page<KubernetesVersion>>(
     setMethod('GET'),
     setURL(`${API_ROOT}/lke/versions`)
-  ).then(response => response.data);
+  );
 
 /** getKubernetesVersion
  *
@@ -113,7 +113,7 @@ export const getKubernetesVersion = (versionID: string) =>
   Request<KubernetesVersion>(
     setMethod('GET'),
     setURL(`${API_ROOT}/lke/versions/${versionID}`)
-  ).then(response => response.data);
+  );
 
 /** getKubernetesClusterEndpoint
  *
@@ -125,4 +125,4 @@ export const getKubernetesClusterEndpoints = (clusterID: number) =>
   Request<Page<KubernetesEndpointResponse>>(
     setMethod('GET'),
     setURL(`${API_ROOT}/lke/clusters/${clusterID}/api-endpoints`)
-  ).then(response => response.data);
+  );

--- a/packages/api-v4/src/kubernetes/nodePools.ts
+++ b/packages/api-v4/src/kubernetes/nodePools.ts
@@ -21,7 +21,7 @@ export const getNodePools = (clusterID: number, params?: any, filters?: any) =>
     setParams(params),
     setXFilter(filters),
     setURL(`${API_ROOT}/lke/clusters/${clusterID}/pools`)
-  ).then(response => response.data);
+  );
 
 /**
  * getNodePool
@@ -32,7 +32,7 @@ export const getNodePool = (clusterID: number, nodePoolID: number) =>
   Request<KubeNodePoolResponse>(
     setMethod('GET'),
     setURL(`${API_ROOT}/lke/clusters/${clusterID}/pools/${nodePoolID}`)
-  ).then(response => response.data);
+  );
 
 /**
  * createNodePool
@@ -44,7 +44,7 @@ export const createNodePool = (clusterID: number, data: PoolNodeRequest) =>
     setMethod('POST'),
     setURL(`${API_ROOT}/lke/clusters/${clusterID}/pools`),
     setData(data, nodePoolSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * updateNodePool
@@ -60,7 +60,7 @@ export const updateNodePool = (
     setMethod('PUT'),
     setURL(`${API_ROOT}/lke/clusters/${clusterID}/pools/${nodePoolID}`),
     setData(data, nodePoolSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * deleteNodePool
@@ -71,7 +71,7 @@ export const deleteNodePool = (clusterID: number, nodePoolID: number) =>
   Request<{}>(
     setMethod('DELETE'),
     setURL(`${API_ROOT}/lke/clusters/${clusterID}/pools/${nodePoolID}`)
-  ).then(response => response.data);
+  );
 
 /**
  * recycleAllNodes
@@ -82,4 +82,4 @@ export const recycleAllNodes = (clusterID: number, nodePoolID: number) =>
   Request<{}>(
     setMethod('POST'),
     setURL(`${API_ROOT}/lke/clusters/${clusterID}/pools/${nodePoolID}/recycle`)
-  ).then(response => response.data);
+  );

--- a/packages/api-v4/src/linodes/actions.ts
+++ b/packages/api-v4/src/linodes/actions.ts
@@ -105,7 +105,7 @@ export const rebuildLinode = (linodeId: number, data: RebuildRequest) =>
     setURL(`${API_ROOT}/linode/instances/${linodeId}/rebuild`),
     setMethod('POST'),
     setData(data, RebuildLinodeSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * rescueLinode
@@ -150,7 +150,7 @@ export const cloneLinode = (sourceLinodeId: number, data: LinodeCloneData) => {
     setURL(`${API_ROOT}/linode/instances/${sourceLinodeId}/clone`),
     setMethod('POST'),
     setData(data)
-  ).then(response => response.data);
+  );
 };
 
 /**
@@ -168,7 +168,7 @@ export const startMutation = (linodeID: number) => {
   return Request<{}>(
     setURL(`${API_ROOT}/linode/instances/${linodeID}/mutate`),
     setMethod('POST')
-  ).then(response => response.data);
+  );
 };
 
 /**

--- a/packages/api-v4/src/linodes/backups.ts
+++ b/packages/api-v4/src/linodes/backups.ts
@@ -18,7 +18,7 @@ export const getLinodeBackups = (id: number) =>
   Request<LinodeBackupsResponse>(
     setURL(`${API_ROOT}/linode/instances/${id}/backups`),
     setMethod('GET')
-  ).then(response => response.data);
+  );
 
 /**
  * enableBackups
@@ -85,4 +85,4 @@ export const restoreBackup = (
     ),
     setMethod('POST'),
     setData({ linode_id: targetLinodeId, overwrite })
-  ).then(response => response.data);
+  );

--- a/packages/api-v4/src/linodes/configs.ts
+++ b/packages/api-v4/src/linodes/configs.ts
@@ -31,7 +31,7 @@ export const getLinodeConfigs = (
     setMethod('GET'),
     setParams(params),
     setXFilter(filters)
-  ).then(response => response.data);
+  );
 
 /**
  * getLinodeConfig
@@ -45,7 +45,7 @@ export const getLinodeConfig = (linodeId: number, configId: number) =>
   Request<Config>(
     setURL(`${API_ROOT}/linode/instances/${linodeId}/configs/${configId}`),
     setMethod('GET')
-  ).then(response => response.data);
+  );
 
 /**
  * createLinodeConfig
@@ -62,7 +62,7 @@ export const createLinodeConfig = (
     setURL(`${API_ROOT}/linode/instances/${linodeId}/configs`),
     setMethod('POST'),
     setData(data, CreateLinodeConfigSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * deleteLinodeConfig
@@ -76,7 +76,7 @@ export const deleteLinodeConfig = (linodeId: number, configId: number) =>
   Request<{}>(
     setMethod('DELETE'),
     setURL(`${API_ROOT}/linode/instances/${linodeId}/configs/${configId}`)
-  ).then(response => response.data);
+  );
 
 /**
  * updateLinodeConfig
@@ -95,4 +95,4 @@ export const updateLinodeConfig = (
     setURL(`${API_ROOT}/linode/instances/${linodeId}/configs/${configId}`),
     setMethod('PUT'),
     setData(data, UpdateLinodeConfigSchema)
-  ).then(response => response.data);
+  );

--- a/packages/api-v4/src/linodes/disks.ts
+++ b/packages/api-v4/src/linodes/disks.ts
@@ -27,7 +27,7 @@ export const getLinodeDisks = (linodeId: number, params?: any, filter?: any) =>
     setMethod('GET'),
     setParams(params),
     setXFilter(filter)
-  ).then(response => response.data);
+  );
 
 /**
  * createLinodeDisk
@@ -44,7 +44,7 @@ export const createLinodeDisk = (
     setURL(`${API_ROOT}/linode/instances/${linodeId}/disks`),
     setMethod('POST'),
     setData(data, CreateLinodeDiskSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * getLinodeDisk
@@ -58,7 +58,7 @@ export const getLinodeDisk = (linodeId: number, diskId: number) =>
   Request<Disk>(
     setURL(`${API_ROOT}/linode/instances/${linodeId}/disks/${diskId}`),
     setMethod('GET')
-  ).then(response => response.data);
+  );
 
 /**
  * updateLinodeDisk
@@ -77,7 +77,7 @@ export const updateLinodeDisk = (
     setURL(`${API_ROOT}/linode/instances/${linodeId}/disks/${diskId}`),
     setMethod('PUT'),
     setData(data)
-  ).then(response => response.data);
+  );
 
 /**
  * resizeLinodeDisk
@@ -115,7 +115,7 @@ export const cloneLinodeDisk = (linodeId: number, diskId: number) =>
   Request<Disk>(
     setURL(`${API_ROOT}/linode/instances/${linodeId}/disks/${diskId}/clone`),
     setMethod('POST')
-  ).then(response => response.data);
+  );
 
 /**
  * deleteLinodeDisk
@@ -129,7 +129,7 @@ export const deleteLinodeDisk = (linodeId: number, diskId: number) =>
   Request<{}>(
     setURL(`${API_ROOT}/linode/instances/${linodeId}/disks/${diskId}`),
     setMethod('DELETE')
-  ).then(response => response.data);
+  );
 
 /**
  * changeLinodeDiskPassword
@@ -149,4 +149,4 @@ export const changeLinodeDiskPassword = (
     setURL(`${API_ROOT}/linode/instances/${linodeId}/disks/${diskId}/password`),
     setMethod('POST'),
     setData({ password }, UpdateLinodePasswordSchema)
-  ).then(response => response.data);
+  );

--- a/packages/api-v4/src/linodes/info.ts
+++ b/packages/api-v4/src/linodes/info.ts
@@ -15,7 +15,7 @@ export const getLinodeStats = (linodeId: number) =>
   Request<Stats>(
     setURL(`${API_ROOT}/linode/instances/${linodeId}/stats`),
     setMethod('GET')
-  ).then(response => response.data);
+  );
 
 /**
  * getLinodeStats
@@ -36,7 +36,7 @@ export const getLinodeStatsByDate = (
   Request<Stats>(
     setURL(`${API_ROOT}/linode/instances/${linodeId}/stats/${year}/${month}`),
     setMethod('GET')
-  ).then(response => response.data);
+  );
 
 /**
  * getLinodeTransfer
@@ -49,7 +49,7 @@ export const getLinodeTransfer = (linodeId: number) =>
   Request<NetworkUtilization>(
     setURL(`${API_ROOT}/linode/instances/${linodeId}/transfer`),
     setMethod('GET')
-  ).then(response => response.data);
+  );
 
 /**
  * getLinodeTransferByDate
@@ -70,7 +70,7 @@ export const getLinodeTransferByDate = (
       `${API_ROOT}/linode/instances/${linodeId}/transfer/${year}/${month}`
     ),
     setMethod('GET')
-  ).then(response => response.data);
+  );
 
 /**
  * getLinodeKernels
@@ -85,7 +85,7 @@ export const getLinodeKernels = (params?: any, filter?: any) =>
     setMethod('GET'),
     setParams(params),
     setXFilter(filter)
-  ).then(response => response.data);
+  );
 
 /**
  * getLinodeKernel
@@ -100,7 +100,7 @@ export const getLinodeKernel = (kernelId: string) =>
   Request<Page<Kernel>>(
     setURL(`${API_ROOT}/linode/kernels/${kernelId}`),
     setMethod('GET')
-  ).then(response => response.data);
+  );
 
 /**
  * getLinodeTypes
@@ -109,10 +109,7 @@ export const getLinodeKernel = (kernelId: string) =>
  * This endpoint does not require authentication.
  */
 export const getLinodeTypes = () =>
-  Request<Page<Type>>(
-    setURL(`${API_ROOT}/linode/types`),
-    setMethod('GET')
-  ).then(response => response.data);
+  Request<Page<Type>>(setURL(`${API_ROOT}/linode/types`), setMethod('GET'));
 
 /**
  * getType
@@ -123,10 +120,7 @@ export const getLinodeTypes = () =>
  * @param typeId { number } The id of the Linode type to retrieve.
  */
 export const getType = (typeId: string) =>
-  Request<Type>(
-    setURL(`${API_ROOT}/linode/types/${typeId}`),
-    setMethod('GET')
-  ).then(response => response.data);
+  Request<Type>(setURL(`${API_ROOT}/linode/types/${typeId}`), setMethod('GET'));
 
 /**
  * getDeprecatedLinodeTypes
@@ -139,4 +133,4 @@ export const getDeprecatedLinodeTypes = () =>
   Request<Page<Type>>(
     setURL(`${API_ROOT}/linode/types-legacy`),
     setMethod('GET')
-  ).then(response => response.data);
+  );

--- a/packages/api-v4/src/linodes/ips.ts
+++ b/packages/api-v4/src/linodes/ips.ts
@@ -15,7 +15,7 @@ export const getLinodeIPs = (id: number) =>
   Request<LinodeIPsResponse>(
     setURL(`${API_ROOT}/linode/instances/${id}/ips`),
     setMethod('GET')
-  ).then(response => response.data);
+  );
 
 /**
  * allocateIPAddress
@@ -35,7 +35,7 @@ export const allocateIPAddress = (
     setURL(`${API_ROOT}/linode/instances/${linodeID}/ips`),
     setMethod('POST'),
     setData(data, IPAllocationSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * removeIPAddress

--- a/packages/api-v4/src/linodes/linodes.ts
+++ b/packages/api-v4/src/linodes/linodes.ts
@@ -55,7 +55,7 @@ export const getLinodeVolumes = (
     setMethod('GET'),
     setXFilter(filter),
     setParams(params)
-  ).then(response => response.data);
+  );
 
 /**
  * getLinodes
@@ -70,7 +70,7 @@ export const getLinodes = (params?: any, filter?: any) =>
     setMethod('GET'),
     setXFilter(filter),
     setParams(params)
-  ).then(response => response.data);
+  );
 
 /**
  * createLinode
@@ -87,7 +87,7 @@ export const createLinode = (data: CreateLinodeRequest) =>
     setURL(`${API_ROOT}/linode/instances`),
     setMethod('POST'),
     setData(data, CreateLinodeSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * updateLinode
@@ -103,7 +103,7 @@ export const updateLinode = (linodeId: number, values: DeepPartial<Linode>) =>
     setURL(`${API_ROOT}/linode/instances/${linodeId}`),
     setMethod('PUT'),
     setData(values, UpdateLinodeSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * deleteLinode

--- a/packages/api-v4/src/longview/longview.ts
+++ b/packages/api-v4/src/longview/longview.ts
@@ -25,7 +25,7 @@ export const createLongviewClient = (label?: string) => {
       longviewClientCreate
     ),
     setMethod('POST')
-  ).then(response => response.data);
+  );
 };
 
 export const getLongviewClients = (params?: any, filter?: any) =>
@@ -34,13 +34,13 @@ export const getLongviewClients = (params?: any, filter?: any) =>
     setParams(params),
     setXFilter(filter),
     setMethod('GET')
-  ).then(response => response.data);
+  );
 
 export const deleteLongviewClient = (id: number) =>
   Request<{}>(
     setURL(`${API_ROOT}/longview/clients/${id}`),
     setMethod('DELETE')
-  ).then(response => response.data);
+  );
 
 export const updateLongviewClient = (id: number, label: string) => {
   return Request<LongviewClient>(
@@ -52,20 +52,20 @@ export const updateLongviewClient = (id: number, label: string) => {
       longviewClientCreate
     ),
     setMethod('PUT')
-  ).then(response => response.data);
+  );
 };
 
 export const getLongviewSubscriptions = () =>
   Request<ResourcePage<LongviewSubscription>>(
     setURL(`${API_ROOT}/longview/subscriptions`),
     setMethod('GET')
-  ).then(response => response.data);
+  );
 
 export const getActiveLongviewPlan = () =>
   Request<ActiveLongviewPlan>(
     setURL(`${API_ROOT}/longview/plan`),
     setMethod('GET')
-  ).then(response => response.data);
+  );
 
 /**
  * updateActiveLongviewPlan
@@ -79,4 +79,4 @@ export const updateActiveLongviewPlan = (plan: LongviewSubscriptionPayload) =>
     setURL(`${API_ROOT}/longview/plan`),
     setData(plan),
     setMethod('PUT')
-  ).then(response => response.data);
+  );

--- a/packages/api-v4/src/managed/managed.ts
+++ b/packages/api-v4/src/managed/managed.ts
@@ -58,7 +58,7 @@ export const getServices = (params?: any, filters?: any) =>
     setParams(params),
     setXFilter(filters),
     setURL(`${API_ROOT}/managed/services`)
-  ).then(response => response.data);
+  );
 
 /**
  * disableServiceMonitor
@@ -69,7 +69,7 @@ export const disableServiceMonitor = (serviceID: number) =>
   Request<ManagedServiceMonitor>(
     setMethod('POST'),
     setURL(`${API_ROOT}/managed/services/${serviceID}/disable`)
-  ).then(response => response.data);
+  );
 
 /**
  * enableServiceMonitor
@@ -80,7 +80,7 @@ export const enableServiceMonitor = (serviceID: number) =>
   Request<ManagedServiceMonitor>(
     setMethod('POST'),
     setURL(`${API_ROOT}/managed/services/${serviceID}/enable`)
-  ).then(response => response.data);
+  );
 
 /**
  * deleteServiceMonitor
@@ -91,7 +91,7 @@ export const deleteServiceMonitor = (serviceID: number) =>
   Request<{}>(
     setMethod('DELETE'),
     setURL(`${API_ROOT}/managed/services/${serviceID}`)
-  ).then(response => response.data);
+  );
 
 /**
  * getLinodeSettings
@@ -104,7 +104,7 @@ export const getLinodeSettings = (params?: any, filters?: any) =>
     setParams(params),
     setXFilter(filters),
     setURL(`${API_ROOT}/managed/linode-settings`)
-  ).then(response => response.data);
+  );
 
 /**
  * createServiceMonitor
@@ -116,7 +116,7 @@ export const createServiceMonitor = (data: ManagedServicePayload) =>
     setMethod('POST'),
     setURL(`${API_ROOT}/managed/services`),
     setData(data, createServiceMonitorSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * updateServiceMonitor
@@ -131,7 +131,7 @@ export const updateServiceMonitor = (
     setMethod('PUT'),
     setURL(`${API_ROOT}/managed/services/${monitorID}`),
     setData(data, createServiceMonitorSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * getCredentials
@@ -144,7 +144,7 @@ export const getCredentials = (params?: any, filters?: any) =>
     setParams(params),
     setXFilter(filters),
     setURL(`${API_ROOT}/managed/credentials`)
-  ).then(response => response.data);
+  );
 
 /**
  * updateCredential
@@ -160,7 +160,7 @@ export const updateCredential = (
     setMethod('PUT'),
     setData(data, updateCredentialSchema),
     setURL(`${API_ROOT}/managed/credentials/${credentialID}`)
-  ).then(response => response.data);
+  );
 
 /**
  * updatePassword
@@ -175,7 +175,7 @@ export const updatePassword = (
     setMethod('POST'),
     setData(data, updatePasswordSchema),
     setURL(`${API_ROOT}/managed/credentials/${credentialID}/update`)
-  ).then(response => response.data);
+  );
 
 /**
  * deleteCredential
@@ -186,7 +186,7 @@ export const deleteCredential = (credentialID: number) =>
   Request<{}>(
     setMethod('POST'),
     setURL(`${API_ROOT}/managed/credentials/${credentialID}/revoke`)
-  ).then(response => response.data);
+  );
 
 /*
  * createCredential
@@ -198,7 +198,7 @@ export const createCredential = (data: CredentialPayload) =>
     setMethod('POST'),
     setURL(`${API_ROOT}/managed/credentials`),
     setData(data, createCredentialSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * getSSHKey
@@ -211,7 +211,7 @@ export const getSSHPubKey = () =>
   Request<ManagedSSHPubKey>(
     setMethod('GET'),
     setURL(`${API_ROOT}/managed/credentials/sshkey`)
-  ).then(response => response.data);
+  );
 
 /**
  * updateLinodeSettings
@@ -227,7 +227,7 @@ export const updateLinodeSettings = (
     setURL(`${API_ROOT}/managed/linode-settings/${linodeId}`),
     setMethod('PUT'),
     setData(data, updateManagedLinodeSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * getManagedContacts
@@ -240,7 +240,7 @@ export const getManagedContacts = (params?: any, filters?: any) =>
     setParams(params),
     setXFilter(filters),
     setURL(`${API_ROOT}/managed/contacts`)
-  ).then(response => response.data);
+  );
 
 /**
  * createContact
@@ -252,7 +252,7 @@ export const createContact = (data: ContactPayload) =>
     setMethod('POST'),
     setURL(`${API_ROOT}/managed/contacts`),
     setData(data, createContactSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * updateContact
@@ -267,7 +267,7 @@ export const updateContact = (
     setMethod('PUT'),
     setURL(`${API_ROOT}/managed/contacts/${contactId}`),
     setData(data, createContactSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * deleteContact
@@ -278,7 +278,7 @@ export const deleteContact = (contactId: number) =>
   Request<{}>(
     setMethod('DELETE'),
     setURL(`${API_ROOT}/managed/contacts/${contactId}`)
-  ).then(response => response.data);
+  );
 
 /**
  * getManagedIssues
@@ -289,7 +289,7 @@ export const getManagedIssues = () =>
   Request<Page<ManagedIssue>>(
     setMethod('GET'),
     setURL(`${API_ROOT}/managed/issues`)
-  ).then(response => response.data);
+  );
 
 /**
  * getManagedStats
@@ -297,7 +297,4 @@ export const getManagedIssues = () =>
  * Returns usage data for all of the Linodes on a Managed customer's account.
  */
 export const getManagedStats = () =>
-  Request<ManagedStats>(
-    setMethod('GET'),
-    setURL(`${API_ROOT}/managed/stats`)
-  ).then(response => response.data);
+  Request<ManagedStats>(setMethod('GET'), setURL(`${API_ROOT}/managed/stats`));

--- a/packages/api-v4/src/networking/networking.ts
+++ b/packages/api-v4/src/networking/networking.ts
@@ -27,7 +27,7 @@ export const getIPs = (params?: any, filters?: any) =>
     setMethod('GET'),
     setParams(params),
     setXFilter(filters)
-  ).then(response => response.data);
+  );
 
 /**
  * Returns information about a single IP Address on your Account.
@@ -38,7 +38,7 @@ export const getIP = (address: string) =>
   Request<IPAddress>(
     setURL(`${API_ROOT}/networking/ips/${address}`),
     setMethod('GET')
-  ).then(response => response.data);
+  );
 
 /**
  * Sets RDNS on an IP Address. Forward DNS must already be set up for reverse
@@ -55,7 +55,7 @@ export const updateIP = (address: string, rdns: string | null = null) =>
     setURL(`${API_ROOT}/networking/ips/${address}`),
     setData({ rdns }, updateIPSchema),
     setMethod('PUT')
-  ).then(response => response.data);
+  );
 
 /**
  * Allocates a new IPv4 Address on your Account. The Linode must be configured
@@ -75,7 +75,7 @@ export const allocateIp = (payload: any) =>
     setURL(`${API_ROOT}/networking/ips/`),
     setData(payload, allocateIPSchema),
     setMethod('POST')
-  ).then(response => response.data);
+  );
 
 /**
  * Assign multiple IPs to multiple Linodes in one Region. This allows swapping,
@@ -126,7 +126,7 @@ export const getIPv6Pools = (params?: any) =>
     setURL(`${API_ROOT}/networking/ipv6/pools`),
     setMethod('GET'),
     setParams(params)
-  ).then(response => response.data);
+  );
 
 /**
  * Displays the IPv6 ranges on your Account.
@@ -137,4 +137,4 @@ export const getIPv6Ranges = (params?: any) =>
     setURL(`${API_ROOT}/networking/ipv6/ranges`),
     setMethod('GET'),
     setParams(params)
-  ).then(response => response.data);
+  );

--- a/packages/api-v4/src/nodebalancers/nodebalancer-config-nodes.ts
+++ b/packages/api-v4/src/nodebalancers/nodebalancer-config-nodes.ts
@@ -27,7 +27,7 @@ export const getNodeBalancerConfigNodes = (
     setURL(
       `${API_ROOT}/nodebalancers/${nodeBalancerId}/configs/${configId}/nodes`
     )
-  ).then(response => response.data);
+  );
 
 /**
  * getNodeBalancerConfigNode
@@ -48,7 +48,7 @@ export const getNodeBalancerConfigNode = (
     setURL(
       `${API_ROOT}/nodebalancers/${nodeBalancerId}/configs/${configId}/nodes/${nodeId}`
     )
-  ).then(response => response.data);
+  );
 /**
  * createNodeBalancerConfigNode
  *
@@ -84,7 +84,7 @@ export const createNodeBalancerConfigNode = (
       `${API_ROOT}/nodebalancers/${nodeBalancerId}/configs/${configId}/nodes`
     ),
     setData(data, nodeBalancerConfigNodeSchema, mergeAddressAndPort)
-  ).then(response => response.data);
+  );
 
 /**
  * createNodeBalancerConfigNode
@@ -121,7 +121,7 @@ export const updateNodeBalancerConfigNode = (
       `${API_ROOT}/nodebalancers/${nodeBalancerId}/configs/${configId}/nodes/${nodeId}`
     ),
     setData(data, nodeBalancerConfigNodeSchema, mergeAddressAndPort)
-  ).then(response => response.data);
+  );
 
 /**
  * deleteNodeBalancerConfigNode
@@ -142,4 +142,4 @@ export const deleteNodeBalancerConfigNode = (
     setURL(
       `${API_ROOT}/nodebalancers/${nodeBalancerId}/configs/${configId}/nodes/${nodeId}`
     )
-  ).then(response => response.data);
+  );

--- a/packages/api-v4/src/nodebalancers/nodebalancer-configs.ts
+++ b/packages/api-v4/src/nodebalancers/nodebalancer-configs.ts
@@ -23,7 +23,7 @@ export const getNodeBalancerConfigs = (nodeBalancerId: number) =>
   Request<Page<NodeBalancerConfig>>(
     setURL(`${API_ROOT}/nodebalancers/${nodeBalancerId}/configs`),
     setMethod('GET')
-  ).then(response => response.data);
+  );
 
 /**
  * getNodeBalancerConfig
@@ -39,7 +39,7 @@ export const getNodeBalancerConfig = (
   Request<Page<NodeBalancerConfig>>(
     setURL(`${API_ROOT}/nodebalancers/${nodeBalancerId}/configs/${configId}`),
     setMethod('GET')
-  ).then(response => response.data);
+  );
 
 /**
  * createNodeBalancerConfig
@@ -61,7 +61,7 @@ export const createNodeBalancerConfig = (
       createNodeBalancerConfigSchema,
       combineConfigNodeAddressAndPort
     )
-  ).then(response => response.data);
+  );
 
 /**
  * updateNodeBalancerConfig
@@ -80,7 +80,7 @@ export const updateNodeBalancerConfig = (
     setMethod('PUT'),
     setURL(`${API_ROOT}/nodebalancers/${nodeBalancerId}/configs/${configId}`),
     setData(data, UpdateNodeBalancerConfigSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * deleteNodeBalancerConfig
@@ -97,4 +97,4 @@ export const deleteNodeBalancerConfig = (
   Request<{}>(
     setMethod('DELETE'),
     setURL(`${API_ROOT}/nodebalancers/${nodeBalancerId}/configs/${configId}`)
-  ).then(response => response.data);
+  );

--- a/packages/api-v4/src/nodebalancers/nodebalancers.ts
+++ b/packages/api-v4/src/nodebalancers/nodebalancers.ts
@@ -29,7 +29,7 @@ export const getNodeBalancers = (params?: any, filters?: any) =>
     setMethod('GET'),
     setParams(params),
     setXFilter(filters)
-  ).then(response => response.data);
+  );
 
 /**
  * getNodeBalancer
@@ -42,7 +42,7 @@ export const getNodeBalancer = (nodeBalancerId: number) =>
   Request<NodeBalancer>(
     setURL(`${API_ROOT}/nodebalancers/${nodeBalancerId}`),
     setMethod('GET')
-  ).then(response => response.data);
+  );
 
 /**
  * updateNodeBalancer
@@ -61,7 +61,7 @@ export const updateNodeBalancer = (
     setURL(`${API_ROOT}/nodebalancers/${nodeBalancerId}`),
     setMethod('PUT'),
     setData(data, UpdateNodeBalancerSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * createNodeBalancer
@@ -77,7 +77,7 @@ export const createNodeBalancer = (data: CreateNodeBalancerPayload) =>
       NodeBalancerSchema,
       combineNodeBalancerConfigNodeAddressAndPort
     )
-  ).then(response => response.data);
+  );
 
 /**
  * deleteNodeBalancer
@@ -90,7 +90,7 @@ export const deleteNodeBalancer = (nodeBalancerId: number) =>
   Request<{}>(
     setMethod('DELETE'),
     setURL(`${API_ROOT}/nodebalancers/${nodeBalancerId}`)
-  ).then(response => response.data);
+  );
 
 /**
  * getNodeBalancerStats
@@ -103,5 +103,5 @@ export const getNodeBalancerStats = (nodeBalancerId: number) => {
   return Request<NodeBalancerStats>(
     setURL(`${API_ROOT}/nodebalancers/${nodeBalancerId}/stats`),
     setMethod('GET')
-  ).then(response => response.data);
+  );
 };

--- a/packages/api-v4/src/object-storage/account.ts
+++ b/packages/api-v4/src/object-storage/account.ts
@@ -7,7 +7,4 @@ import Request, { setMethod, setURL } from '../request';
  * Cancels Object Storage service
  */
 export const cancelObjectStorage = () =>
-  Request<{}>(
-    setMethod('POST'),
-    setURL(`${API_ROOT}/object-storage/cancel`)
-  ).then(response => response.data);
+  Request<{}>(setMethod('POST'), setURL(`${API_ROOT}/object-storage/cancel`));

--- a/packages/api-v4/src/object-storage/buckets.ts
+++ b/packages/api-v4/src/object-storage/buckets.ts
@@ -25,7 +25,7 @@ export const getBucket = (clusterId: string, bucketName: string) =>
   Request<ObjectStorageBucket>(
     setMethod('GET'),
     setURL(`${API_ROOT}/object-storage/buckets/${clusterId}/${bucketName}`)
-  ).then(response => response.data);
+  );
 
 /**
  * getBuckets
@@ -38,7 +38,7 @@ export const getBuckets = (params?: any, filters?: any) =>
     setParams(params),
     setXFilter(filters),
     setURL(`${API_ROOT}/object-storage/buckets`)
-  ).then(response => response.data);
+  );
 
 /**
  * getBucketsInCluster
@@ -55,7 +55,7 @@ export const getBucketsInCluster = (
     setParams(params),
     setXFilter(filters),
     setURL(`${API_ROOT}/object-storage/buckets/${clusterId}`)
-  ).then(response => response.data);
+  );
 
 /**
  * createBucket
@@ -70,7 +70,7 @@ export const createBucket = (data: ObjectStorageBucketRequestPayload) =>
     setURL(`${API_ROOT}/object-storage/buckets`),
     setMethod('POST'),
     setData(data, CreateBucketSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * deleteBucket
@@ -102,4 +102,4 @@ export const getObjectList = (
     setURL(
       `${API_ROOT}/object-storage/buckets/${clusterId}/${bucketName}/object-list`
     )
-  ).then(response => response.data);
+  );

--- a/packages/api-v4/src/object-storage/clusters.ts
+++ b/packages/api-v4/src/object-storage/clusters.ts
@@ -14,4 +14,4 @@ export const getClusters = (params?: any, filters?: any) =>
     setParams(params),
     setXFilter(filters),
     setURL(`${API_ROOT}/object-storage/clusters`)
-  ).then(response => response.data);
+  );

--- a/packages/api-v4/src/object-storage/objectStorageKeys.ts
+++ b/packages/api-v4/src/object-storage/objectStorageKeys.ts
@@ -21,7 +21,7 @@ export const getObjectStorageKeys = (params?: any, filters?: any) =>
     setParams(params),
     setXFilter(filters),
     setURL(`${API_ROOT}/object-storage/keys`)
-  ).then(response => response.data);
+  );
 
 /**
  * createObjectStorageKeys
@@ -33,7 +33,7 @@ export const createObjectStorageKeys = (data: ObjectStorageKeyRequest) =>
     setMethod('POST'),
     setURL(`${API_ROOT}/object-storage/keys`),
     setData(data, createObjectStorageKeysSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * updateObjectStorageKeys
@@ -48,7 +48,7 @@ export const updateObjectStorageKey = (
     setMethod('PUT'),
     setURL(`${API_ROOT}/object-storage/keys/${id}`),
     setData(data, createObjectStorageKeysSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * revokeObjectStorageKey
@@ -59,4 +59,4 @@ export const revokeObjectStorageKey = (id: number) =>
   Request<ObjectStorageKey>(
     setMethod('DELETE'),
     setURL(`${API_ROOT}/object-storage/keys/${id}`)
-  ).then(response => response.data);
+  );

--- a/packages/api-v4/src/object-storage/objects.ts
+++ b/packages/api-v4/src/object-storage/objects.ts
@@ -18,4 +18,4 @@ export const getObjectURL = (
       `${API_ROOT}/object-storage/buckets/${clusterId}/${bucketName}/object-url`
     ),
     setData({ name, method, ...options })
-  ).then(response => response.data);
+  );

--- a/packages/api-v4/src/profile/accessTokens.ts
+++ b/packages/api-v4/src/profile/accessTokens.ts
@@ -22,7 +22,7 @@ export const getPersonalAccessTokens = (params?: any, filters?: any) =>
     setParams(params),
     setXFilter(filters),
     setURL(`${API_ROOT}/profile/tokens`)
-  ).then(response => response.data);
+  );
 
 /**
  * getPersonalAccessToken
@@ -33,10 +33,7 @@ export const getPersonalAccessTokens = (params?: any, filters?: any) =>
  *
  */
 export const getPersonalAccessToken = (id: number) =>
-  Request<Token>(
-    setMethod('GET'),
-    setURL(`${API_ROOT}/profile/tokens/${id}`)
-  ).then(response => response.data);
+  Request<Token>(setMethod('GET'), setURL(`${API_ROOT}/profile/tokens/${id}`));
 
 /**
  * createPersonalAccessToken
@@ -60,7 +57,7 @@ export const createPersonalAccessToken = (data: TokenRequest) =>
     setMethod('POST'),
     setURL(`${API_ROOT}/profile/tokens`),
     setData(data, createPersonalAccessTokenSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * updatePersonalAccessToken
@@ -81,7 +78,7 @@ export const updatePersonalAccessToken = (
     setURL(`${API_ROOT}/profile/tokens/${tokenId}`),
     setMethod('PUT'),
     setData(data, createPersonalAccessTokenSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * deletePersonalAccessToken

--- a/packages/api-v4/src/profile/appTokens.ts
+++ b/packages/api-v4/src/profile/appTokens.ts
@@ -15,7 +15,7 @@ export const getAppTokens = (params?: any, filters?: any) =>
     setParams(params),
     setXFilter(filters),
     setURL(`${API_ROOT}/profile/apps`)
-  ).then(response => response.data);
+  );
 
 /**
  * getAppToken
@@ -28,7 +28,7 @@ export const getAppToken = (tokenId: number) =>
   Request<Token>(
     setMethod('GET'),
     setURL(`${API_ROOT}/profile/apps/${tokenId}`)
-  ).then(response => response.data);
+  );
 
 /**
  * deleteAppToken

--- a/packages/api-v4/src/profile/profile.ts
+++ b/packages/api-v4/src/profile/profile.ts
@@ -18,9 +18,7 @@ import { Profile, TrustedDevice, UserPreferences, ProfileLogin } from './types';
  *
  */
 export const getProfile = () =>
-  Request<Profile>(setURL(`${API_ROOT}/profile`), setMethod('GET')).then(
-    response => response.data
-  );
+  Request<Profile>(setURL(`${API_ROOT}/profile`), setMethod('GET'));
 
 /**
  * updateProfile
@@ -35,7 +33,7 @@ export const updateProfile = (data: any) =>
     setURL(`${API_ROOT}/profile`),
     setMethod('PUT'),
     setData(data, updateProfileSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * listGrants
@@ -49,9 +47,7 @@ export const updateProfile = (data: any) =>
  * This endpoint is unauthenticated.
  */
 export const listGrants = () =>
-  Request<Grants>(setURL(`${API_ROOT}/profile/grants`)).then(
-    response => response.data
-  );
+  Request<Grants>(setURL(`${API_ROOT}/profile/grants`));
 
 /**
  * getMyGrants
@@ -64,9 +60,7 @@ export const listGrants = () =>
  *
  */
 export const getMyGrants = () =>
-  Request<Grants>(setURL(`${API_ROOT}/profile/grants`), setMethod('GET')).then(
-    response => response.data
-  );
+  Request<Grants>(setURL(`${API_ROOT}/profile/grants`), setMethod('GET'));
 
 /**
  * getTrustedDevices
@@ -79,7 +73,7 @@ export const getTrustedDevices = (params: any, filter: any) =>
     setMethod('GET'),
     setXFilter(filter),
     setParams(params)
-  ).then(response => response.data);
+  );
 
 /**
  * deleteTrustedDevice
@@ -87,10 +81,7 @@ export const getTrustedDevices = (params: any, filter: any) =>
  * Deletes a trusted device from a user's profile
  */
 export const deleteTrustedDevice = (id: number) =>
-  Request<{}>(
-    setURL(`${API_ROOT}/profile/devices/${id}`),
-    setMethod('DELETE')
-  ).then(response => response.data);
+  Request<{}>(setURL(`${API_ROOT}/profile/devices/${id}`), setMethod('DELETE'));
 
 /**
  * getUserPreferences
@@ -101,7 +92,7 @@ export const deleteTrustedDevice = (id: number) =>
 export const getUserPreferences = () => {
   return Request<Record<string, any>>(
     setURL(`${API_ROOT}/profile/preferences`)
-  ).then(response => response.data);
+  );
 };
 
 /**
@@ -115,7 +106,7 @@ export const updateUserPreferences = (payload: UserPreferences) => {
     setURL(`${API_ROOT}/profile/preferences`),
     setData(payload),
     setMethod('PUT')
-  ).then(response => response.data);
+  );
 };
 
 export const getLogins = (params: any, filter: any) => {
@@ -124,5 +115,5 @@ export const getLogins = (params: any, filter: any) => {
     setMethod('GET'),
     setXFilter(filter),
     setParams(params)
-  ).then(response => response.data);
+  );
 };

--- a/packages/api-v4/src/profile/sshkeys.ts
+++ b/packages/api-v4/src/profile/sshkeys.ts
@@ -22,7 +22,7 @@ export const getSSHKeys = (params?: any, filters?: any) =>
     setParams(params),
     setXFilter(filters),
     setURL(`${API_ROOT}/profile/sshkeys`)
-  ).then(response => response.data);
+  );
 
 /**
  * getSSHKey
@@ -34,7 +34,7 @@ export const getSSHKey = (keyId: number) =>
   Request<SSHKey>(
     setMethod('GET'),
     setURL(`${API_ROOT}/profile/sshkeys/${keyId}`)
-  ).then(response => response.data);
+  );
 
 /**
  * createSSHKey
@@ -47,7 +47,7 @@ export const createSSHKey = (data: { label: string; ssh_key: string }) =>
     setMethod('POST'),
     setURL(`${API_ROOT}/profile/sshkeys`),
     setData(data, createSSHKeySchema)
-  ).then(response => response.data);
+  );
 
 /**
  * updateSSHKey
@@ -62,7 +62,7 @@ export const updateSSHKey = (keyId: number, data: Partial<SSHKey>) =>
     setMethod('DELETE'),
     setURL(`${API_ROOT}/profile/sshkeys/${keyId}`),
     setData(data, createSSHKeySchema)
-  ).then(response => response.data);
+  );
 
 /**
  * deleteSSHKey
@@ -76,4 +76,4 @@ export const deleteSSHKey = (keyId: number) =>
   Request<{}>(
     setMethod('DELETE'),
     setURL(`${API_ROOT}/profile/sshkeys/${keyId}`)
-  ).then(response => response.data);
+  );

--- a/packages/api-v4/src/profile/twofactor.ts
+++ b/packages/api-v4/src/profile/twofactor.ts
@@ -47,4 +47,4 @@ export const confirmTwoFactor = (tfa_code: string) =>
     setMethod('POST'),
     setURL(`${API_ROOT}/profile/tfa-enable-confirm`),
     setData({ tfa_code }, enableTwoFactorSchema)
-  ).then(response => response.data);
+  );

--- a/packages/api-v4/src/regions/regions.ts
+++ b/packages/api-v4/src/regions/regions.ts
@@ -16,9 +16,7 @@ import { Region } from './types';
  *
  */
 export const getRegions = () =>
-  Request<Page<Region>>(setURL(`${API_ROOT}/regions`), setMethod('GET')).then(
-    response => response.data
-  );
+  Request<Page<Region>>(setURL(`${API_ROOT}/regions`), setMethod('GET'));
 
 /**
  * getRegion
@@ -29,9 +27,6 @@ export const getRegions = () =>
  *
  */
 export const getRegion = (regionID: string) =>
-  Request<Region>(
-    setURL(`${API_ROOT}/regions/${regionID}`),
-    setMethod('GET')
-  ).then(response => response.data);
+  Request<Region>(setURL(`${API_ROOT}/regions/${regionID}`), setMethod('GET'));
 
 export { Region };

--- a/packages/api-v4/src/request.ts
+++ b/packages/api-v4/src/request.ts
@@ -165,10 +165,7 @@ export const requestGenerator = <T>(...fns: Function[]): Promise<T> => {
       config.validationErrors // All failed requests, client or server errors, should be APIError[]
     );
   }
-  return baseRequest(config).then(response => {
-    console.log(response);
-    return response.data;
-  });
+  return baseRequest(config).then(response => response.data);
 
   /*
    * If in the future, we want to hook into every single

--- a/packages/api-v4/src/request.ts
+++ b/packages/api-v4/src/request.ts
@@ -1,9 +1,4 @@
-import Axios, {
-  AxiosError,
-  AxiosPromise,
-  AxiosRequestConfig,
-  AxiosResponse
-} from 'axios';
+import Axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
 import { ObjectSchema, ValidationError } from 'yup';
 import { APIError } from './types';
 
@@ -163,14 +158,17 @@ const reduceRequestConfig = (...fns: Function[]): RequestConfig =>
   });
 
 /** Generator */
-export const requestGenerator = <T>(...fns: Function[]): AxiosPromise<T> => {
+export const requestGenerator = <T>(...fns: Function[]): Promise<T> => {
   const config = reduceRequestConfig(...fns);
   if (config.validationErrors) {
     return Promise.reject(
       config.validationErrors // All failed requests, client or server errors, should be APIError[]
     );
   }
-  return baseRequest(config);
+  return baseRequest(config).then(response => {
+    console.log(response);
+    return response.data;
+  });
 
   /*
    * If in the future, we want to hook into every single

--- a/packages/api-v4/src/stackscripts/stackscripts.ts
+++ b/packages/api-v4/src/stackscripts/stackscripts.ts
@@ -23,7 +23,7 @@ export const getStackScripts = (params?: any, filter?: any) =>
     setMethod('GET'),
     setParams(params),
     setXFilter(filter)
-  ).then(response => response.data);
+  );
 
 /**
  * Returns all of the information about a specified StackScript, including the contents of the script.
@@ -34,7 +34,7 @@ export const getStackScript = (stackscriptId: number) =>
   Request<StackScript>(
     setURL(`${API_ROOT}/linode/stackscripts/${stackscriptId}`),
     setMethod('GET')
-  ).then(response => response.data);
+  );
 
 /**
  * Creates a StackScript in your Account.
@@ -55,7 +55,7 @@ export const createStackScript = (payload: StackScriptPayload) =>
     setURL(`${API_ROOT}/linode/stackscripts`),
     setMethod('POST'),
     setData(payload, stackScriptSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * Updates a StackScript.
@@ -80,7 +80,7 @@ export const updateStackScript = (
     setURL(`${API_ROOT}/linode/stackscripts/${stackscriptId}`),
     setMethod('PUT'),
     setData(payload, updateStackScriptSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * Deletes a private StackScript you have permission to read_write. You cannot delete a public StackScript.
@@ -91,4 +91,4 @@ export const deleteStackScript = (stackscriptId: number) =>
   Request<{}>(
     setURL(`${API_ROOT}/linode/stackscripts/${stackscriptId}`),
     setMethod('DELETE')
-  ).then(response => response.data);
+  );

--- a/packages/api-v4/src/support/support.ts
+++ b/packages/api-v4/src/support/support.ts
@@ -31,7 +31,7 @@ export const getTickets = (params?: any, filter?: any) =>
     setMethod('GET'),
     setParams(params),
     setXFilter(filter)
-  ).then(response => response.data);
+  );
 
 /**
  * getTicket
@@ -47,7 +47,7 @@ export const getTicket = (ticketID: number) =>
   Request<SupportTicket>(
     setURL(`${API_ROOT}/support/tickets/${ticketID}`),
     setMethod('GET')
-  ).then(response => response.data);
+  );
 
 /**
  * getTicketReplies
@@ -71,7 +71,7 @@ export const getTicketReplies = (
     setMethod('GET'),
     setParams(params),
     setXFilter(filter)
-  ).then(response => response.data);
+  );
 
 /**
  * createSupportTicket
@@ -88,7 +88,7 @@ export const createSupportTicket = (data: TicketRequest) =>
     setURL(`${API_ROOT}/support/tickets`),
     setMethod('POST'),
     setData(data, createSupportTicketSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * closeSupportTicket
@@ -104,7 +104,7 @@ export const closeSupportTicket = (ticketId: number) =>
   Request<{}>(
     setURL(`${API_ROOT}/support/tickets/${ticketId}/close`),
     setMethod('POST')
-  ).then(response => response.data);
+  );
 
 /**
  * createReply
@@ -122,7 +122,7 @@ export const createReply = (data: ReplyRequest) =>
     setURL(`${API_ROOT}/support/tickets/${data.ticket_id}/replies`),
     setMethod('POST'),
     setData(data, createReplySchema)
-  ).then(response => response.data);
+  );
 
 /**
  * uploadAttachment
@@ -138,4 +138,4 @@ export const uploadAttachment = (ticketId: number, formData: FormData) =>
     setURL(`${API_ROOT}/support/tickets/${ticketId}/attachments`),
     setMethod('POST'),
     setData(formData)
-  ).then(response => response.data);
+  );

--- a/packages/api-v4/src/tags/tags.ts
+++ b/packages/api-v4/src/tags/tags.ts
@@ -15,16 +15,10 @@ export const getTags = (params?: any, filter?: any) =>
     setMethod('GET'),
     setParams(params),
     setXFilter(filter)
-  ).then(response => response.data);
+  );
 
 export const createTag = (data: TagRequest) =>
-  Request<Tag>(
-    setURL(`${API_ROOT}/tags`),
-    setMethod('POST'),
-    setData(data)
-  ).then(response => response.data);
+  Request<Tag>(setURL(`${API_ROOT}/tags`), setMethod('POST'), setData(data));
 
 export const deleteTag = (label: string) =>
-  Request<Tag>(setURL(`${API_ROOT}/tags/${label}`), setMethod('DELETE')).then(
-    response => response.data
-  );
+  Request<Tag>(setURL(`${API_ROOT}/tags/${label}`), setMethod('DELETE'));

--- a/packages/api-v4/src/volumes/volumes.ts
+++ b/packages/api-v4/src/volumes/volumes.ts
@@ -29,10 +29,7 @@ import {
  * @param volumeId { number } The ID of the volume to be retrieved.
  */
 export const getVolume = (volumeId: number) =>
-  Request<Volume>(
-    setURL(`${API_ROOT}/volumes/${volumeId}`),
-    setMethod('GET')
-  ).then(response => response.data);
+  Request<Volume>(setURL(`${API_ROOT}/volumes/${volumeId}`), setMethod('GET'));
 
 /**
  * getVolumes
@@ -46,7 +43,7 @@ export const getVolumes = (params?: any, filters?: any) =>
     setMethod('GET'),
     setParams(params),
     setXFilter(filters)
-  ).then(response => response.data);
+  );
 
 /**
  * attachVolume
@@ -66,7 +63,7 @@ export const attachVolume = (volumeId: number, payload: AttachVolumePayload) =>
     setURL(`${API_ROOT}/volumes/${volumeId}/attach`),
     setMethod('POST'),
     setData(payload)
-  ).then(response => response.data);
+  );
 
 /**
  * detachVolume
@@ -80,7 +77,7 @@ export const detachVolume = (volumeId: number) =>
   Request<{}>(
     setURL(`${API_ROOT}/volumes/${volumeId}/detach`),
     setMethod('POST')
-  ).then(response => response.data);
+  );
 
 /**
  * deleteVolume
@@ -92,10 +89,7 @@ export const detachVolume = (volumeId: number) =>
  *
  */
 export const deleteVolume = (volumeId: number) =>
-  Request<{}>(
-    setURL(`${API_ROOT}/volumes/${volumeId}`),
-    setMethod('DELETE')
-  ).then(response => response.data);
+  Request<{}>(setURL(`${API_ROOT}/volumes/${volumeId}`), setMethod('DELETE'));
 
 /**
  * cloneVolume
@@ -113,7 +107,7 @@ export const cloneVolume = (volumeId: number, data: CloneVolumePayload) =>
     setURL(`${API_ROOT}/volumes/${volumeId}/clone`),
     setMethod('POST'),
     setData(data, CloneVolumeSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * resizeVolume
@@ -134,7 +128,7 @@ export const resizeVolume = (volumeId: number, data: ResizeVolumePayload) =>
      * absolute min so it's safe to set here.
      */
     setData(data, ResizeVolumeSchema(10))
-  ).then(response => response.data);
+  );
 
 export interface UpdateVolumeRequest {
   label: string;
@@ -155,7 +149,7 @@ export const updateVolume = (volumeId: number, data: UpdateVolumeRequest) =>
     setURL(`${API_ROOT}/volumes/${volumeId}`),
     setMethod('PUT'),
     setData(data, UpdateVolumeSchema)
-  ).then(response => response.data);
+  );
 
 /**
  * createVolume
@@ -172,4 +166,4 @@ export const createVolume = (data: VolumeRequestPayload) =>
     setURL(`${API_ROOT}/volumes`),
     setMethod('POST'),
     setData(data, CreateVolumeSchema)
-  ).then(response => response.data);
+  );

--- a/packages/manager/src/features/Lish/Lish.tsx
+++ b/packages/manager/src/features/Lish/Lish.tsx
@@ -103,7 +103,7 @@ class Lish extends React.Component<CombinedProps, State> {
 
     getLinode(+linodeId)
       .then(response => {
-        const { data: linode } = response;
+        const linode = response;
         if (!this.mounted) {
           return;
         }
@@ -173,9 +173,7 @@ class Lish extends React.Component<CombinedProps, State> {
 
     return getLinodeLishToken(+linodeId)
       .then(response => {
-        const {
-          data: { lish_token: token }
-        } = response;
+        const { lish_token: token } = response;
         if (!this.mounted) {
           return;
         }

--- a/packages/manager/src/features/Profile/AuthenticationSettings/TwoFactor/TwoFactor.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/TwoFactor/TwoFactor.tsx
@@ -141,7 +141,7 @@ export const TwoFactor: React.FC<CombinedProps> = props => {
     setLoading(true);
     return getTFAToken()
       .then(response => {
-        setSecret(response.data.secret);
+        setSecret(response.secret);
         setLoading(false);
         setErrors(undefined);
       })

--- a/packages/manager/src/features/Volumes/WithEvents.tsx
+++ b/packages/manager/src/features/Volumes/WithEvents.tsx
@@ -112,7 +112,7 @@ export default () => (WrappedComponent: React.ComponentType<any>) => {
              */
             if (!!volume.linode_id) {
               return getLinode(volume.linode_id).then(response => {
-                const linode = response.data;
+                const linode = response;
 
                 /*
                  * Now add our new volume, include the newly attached

--- a/packages/manager/src/store/image/image.requests.ts
+++ b/packages/manager/src/store/image/image.requests.ts
@@ -27,8 +27,7 @@ export const requestImages = createRequestThunk(requestImagesActions, () =>
 
 export const createImage = createRequestThunk(
   createImageActions,
-  ({ diskID, label, description }) =>
-    _create(diskID, label, description).then(response => response.data)
+  ({ diskID, label, description }) => _create(diskID, label, description)
 );
 
 export const requestImageForStore = createRequestThunk(
@@ -38,8 +37,7 @@ export const requestImageForStore = createRequestThunk(
 
 export const updateImage = createRequestThunk(
   updateImageActions,
-  ({ label, description, imageID }) =>
-    _update(imageID, label, description).then(response => response.data)
+  ({ label, description, imageID }) => _update(imageID, label, description)
 );
 
 export const deleteImage = createRequestThunk(

--- a/packages/manager/src/store/linodes/disk/disk.requests.ts
+++ b/packages/manager/src/store/linodes/disk/disk.requests.ts
@@ -75,7 +75,5 @@ export const deleteLinodeDisk = createRequestThunk(
 export const resizeLinodeDisk = createRequestThunk(
   resizeLinodeDiskActions,
   ({ linodeId, diskId, size }) =>
-    _resizeLinodeDisk(linodeId, diskId, size)
-      .then(({ data }) => data)
-      .then(addLinodeIdToDisk(linodeId))
+    _resizeLinodeDisk(linodeId, diskId, size).then(addLinodeIdToDisk(linodeId))
 );

--- a/packages/manager/src/store/linodes/linode.requests.ts
+++ b/packages/manager/src/store/linodes/linode.requests.ts
@@ -21,7 +21,7 @@ import {
 } from './linodes.actions';
 
 export const getLinode = createRequestThunk(getLinodeActions, ({ linodeId }) =>
-  _getLinode(linodeId).then(({ data }) => data)
+  _getLinode(linodeId)
 );
 
 export const updateLinode = createRequestThunk(
@@ -65,7 +65,6 @@ export const requestLinodeForStore: RequestLinodeForStoreThunk = (
     Boolean(state.__resources.linodes.itemsById[id])
   ) {
     return _getLinode(id)
-      .then(response => response.data)
       .then(linode => {
         return dispatch(upsertLinode(linode));
       })

--- a/packages/manager/src/store/regions/regions.actions.ts
+++ b/packages/manager/src/store/regions/regions.actions.ts
@@ -17,7 +17,7 @@ export const requestRegions: RequestRegionsThunk = () => dispatch => {
   dispatch(regionsRequestActions.started());
   return getRegions()
     .then(regions => {
-      dispatch(regionsRequestActions.done({ result: regions }));
+      dispatch(regionsRequestActions.done({ result: regions.data }));
       return regions;
     })
     .catch(error => {

--- a/packages/manager/src/store/regions/regions.actions.ts
+++ b/packages/manager/src/store/regions/regions.actions.ts
@@ -17,7 +17,7 @@ export const requestRegions: RequestRegionsThunk = () => dispatch => {
   dispatch(regionsRequestActions.started());
   return getRegions()
     .then(regions => {
-      dispatch(regionsRequestActions.done({ result: regions.data }));
+      dispatch(regionsRequestActions.done({ result: regions }));
       return regions;
     })
     .catch(error => {


### PR DESCRIPTION
## Description

In the JS client, virtually every method includes a `.then(response =>
response.data)` to extract the actual API response from the Axios wrapper.
This led to problems in the few cases where we forgot to do this.

Moving the extraction to request.ts ensures that we never forget; I
changed the type of the request object to return a Promise<T> instead
of `AxiosPromise<T>`. This means that TypeScript should pick
up on any place in Manager that tries to use the incorrect access pattern,
and won't allow client methods to do the response.data thing. Also saves
a lot of typing and boilerplate.


## Note to Reviewers

Major change, I'm pretty confident about TypeScript's ability to handle this and I've CRUDded all the things to test, but much more testing is necessary. This shouldn't change the behavior of the app in any way.