### PR TITLE
[CMR] M3-4509: Remove animation across the app

### DIFF
--- a/packages/manager/src/components/Button/Button.tsx
+++ b/packages/manager/src/components/Button/Button.tsx
@@ -46,6 +46,7 @@ const styles = (theme: Theme) =>
       minWidth: '105px',
       paddingLeft: theme.spacing(3) + 4,
       paddingRight: theme.spacing(3) + 4,
+      transition: 'none',
       '&.cancel': {
         border: `1px solid transparent`,
         transition: theme.transitions.create(['color', 'border-color']),

--- a/packages/manager/src/features/linodes/LinodesLanding/TableWrapper_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/TableWrapper_CMR.tsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles(() => ({
   },
   table: {
     '& .statusOther': {
-      animation: '$blink 1.25s linear infinite'
+      animation: '$blink 2s linear infinite'
     }
   }
 }));


### PR DESCRIPTION
## Description
Combing through the app and removing unnecessary animations

### Current changes so far:
- Extending the blinking duration for Linode other statuses
- Remove the transition for MUI buttons

### To Do:
- [ ] Select components (current transition involves the border-color changing, not sure if there's more to this)

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers
If you see any other animations that need to be changed, lmk

Also waiting for Jay to see what other animations/transitions he wants gone