### PR TITLE
M3-4468 Update mocks for LKE cluster detail page

### DIFF
--- a/packages/manager/src/__data__/ExtendedType.ts
+++ b/packages/manager/src/__data__/ExtendedType.ts
@@ -1,13 +1,11 @@
 import { types } from './types';
 
 const extendTypes = () => {
-  return types.map(type => {
-    return {
-      ...type,
-      heading: 'test',
-      subHeadings: ['test', 'test'] as [string, string]
-    };
-  });
+  return types.map(type => ({
+    ...type,
+    heading: 'test',
+    subHeadings: ['test', 'test'] as [string, string]
+  }));
 };
 
 export const extendedTypes = extendTypes();

--- a/packages/manager/src/__data__/types.ts
+++ b/packages/manager/src/__data__/types.ts
@@ -8,7 +8,7 @@ export const types: LinodeType[] = [
       monthly: 10.0,
       hourly: 0.015
     },
-    id: 'g6-standard-1',
+    id: 'g5-standard-1',
     label: 'Linode 2GB',
     class: 'standard',
     addons: {
@@ -31,7 +31,7 @@ export const types: LinodeType[] = [
       monthly: 20.0,
       hourly: 0.03
     },
-    id: 'g6-standard-2',
+    id: 'g5-standard-2',
     label: 'Linode 4096',
     class: 'standard',
     addons: {
@@ -54,7 +54,7 @@ export const types: LinodeType[] = [
       monthly: 40.0,
       hourly: 0.06
     },
-    id: 'g6-standard-4',
+    id: 'g5-standard-4',
     label: 'Linode 8192',
     class: 'standard',
     addons: {
@@ -77,7 +77,7 @@ export const types: LinodeType[] = [
       monthly: 80.0,
       hourly: 0.12
     },
-    id: 'g6-standard-6',
+    id: 'g5-standard-6',
     label: 'Linode 12288',
     class: 'standard',
     addons: {
@@ -100,7 +100,7 @@ export const types: LinodeType[] = [
       monthly: 160.0,
       hourly: 0.24
     },
-    id: 'g6-standard-8',
+    id: 'g5-standard-8',
     label: 'Linode 24576',
     class: 'standard',
     addons: {
@@ -123,7 +123,7 @@ export const types: LinodeType[] = [
       monthly: 320.0,
       hourly: 0.48
     },
-    id: 'g6-standard-12',
+    id: 'g5-standard-12',
     label: 'Linode 49152',
     class: 'standard',
     addons: {
@@ -146,7 +146,7 @@ export const types: LinodeType[] = [
       monthly: 480.0,
       hourly: 0.72
     },
-    id: 'g6-standard-16',
+    id: 'g5-standard-16',
     label: 'Linode 65536',
     class: 'standard',
     addons: {
@@ -169,7 +169,7 @@ export const types: LinodeType[] = [
       monthly: 640.0,
       hourly: 0.96
     },
-    id: 'g6-standard-20',
+    id: 'g5-standard-20',
     label: 'Linode 81920',
     class: 'standard',
     addons: {
@@ -192,7 +192,7 @@ export const types: LinodeType[] = [
       monthly: 5.0,
       hourly: 0.0075
     },
-    id: 'g6-nanode-1',
+    id: 'g5-nanode-1',
     label: 'Linode 1024',
     class: 'nanode',
     addons: {
@@ -215,7 +215,7 @@ export const types: LinodeType[] = [
       monthly: 60.0,
       hourly: 0.09
     },
-    id: 'g6-highmem-1',
+    id: 'g5-highmem-1',
     label: 'Linode 16384',
     class: 'highmem',
     addons: {
@@ -238,7 +238,7 @@ export const types: LinodeType[] = [
       monthly: 120.0,
       hourly: 0.18
     },
-    id: 'g6-highmem-2',
+    id: 'g5-highmem-2',
     label: 'Linode 32768',
     class: 'highmem',
     addons: {
@@ -261,7 +261,7 @@ export const types: LinodeType[] = [
       monthly: 240.0,
       hourly: 0.36
     },
-    id: 'g6-highmem-4',
+    id: 'g5-highmem-4',
     label: 'Linode 61440',
     class: 'highmem',
     addons: {
@@ -284,7 +284,7 @@ export const types: LinodeType[] = [
       monthly: 480.0,
       hourly: 0.72
     },
-    id: 'g6-highmem-8',
+    id: 'g5-highmem-8',
     label: 'Linode 102400',
     class: 'highmem',
     addons: {
@@ -307,7 +307,7 @@ export const types: LinodeType[] = [
       monthly: 960.0,
       hourly: 1.44
     },
-    id: 'g6-highmem-16',
+    id: 'g5-highmem-16',
     label: 'Linode 204800',
     class: 'highmem',
     addons: {

--- a/packages/manager/src/__data__/types.ts
+++ b/packages/manager/src/__data__/types.ts
@@ -8,7 +8,7 @@ export const types: LinodeType[] = [
       monthly: 10.0,
       hourly: 0.015
     },
-    id: 'g5-standard-1',
+    id: 'g6-standard-1',
     label: 'Linode 2GB',
     class: 'standard',
     addons: {
@@ -31,7 +31,7 @@ export const types: LinodeType[] = [
       monthly: 20.0,
       hourly: 0.03
     },
-    id: 'g5-standard-2',
+    id: 'g6-standard-2',
     label: 'Linode 4096',
     class: 'standard',
     addons: {
@@ -54,7 +54,7 @@ export const types: LinodeType[] = [
       monthly: 40.0,
       hourly: 0.06
     },
-    id: 'g5-standard-4',
+    id: 'g6-standard-4',
     label: 'Linode 8192',
     class: 'standard',
     addons: {
@@ -77,7 +77,7 @@ export const types: LinodeType[] = [
       monthly: 80.0,
       hourly: 0.12
     },
-    id: 'g5-standard-6',
+    id: 'g6-standard-6',
     label: 'Linode 12288',
     class: 'standard',
     addons: {
@@ -100,7 +100,7 @@ export const types: LinodeType[] = [
       monthly: 160.0,
       hourly: 0.24
     },
-    id: 'g5-standard-8',
+    id: 'g6-standard-8',
     label: 'Linode 24576',
     class: 'standard',
     addons: {
@@ -123,7 +123,7 @@ export const types: LinodeType[] = [
       monthly: 320.0,
       hourly: 0.48
     },
-    id: 'g5-standard-12',
+    id: 'g6-standard-12',
     label: 'Linode 49152',
     class: 'standard',
     addons: {
@@ -146,7 +146,7 @@ export const types: LinodeType[] = [
       monthly: 480.0,
       hourly: 0.72
     },
-    id: 'g5-standard-16',
+    id: 'g6-standard-16',
     label: 'Linode 65536',
     class: 'standard',
     addons: {
@@ -169,7 +169,7 @@ export const types: LinodeType[] = [
       monthly: 640.0,
       hourly: 0.96
     },
-    id: 'g5-standard-20',
+    id: 'g6-standard-20',
     label: 'Linode 81920',
     class: 'standard',
     addons: {
@@ -192,7 +192,7 @@ export const types: LinodeType[] = [
       monthly: 5.0,
       hourly: 0.0075
     },
-    id: 'g5-nanode-1',
+    id: 'g6-nanode-1',
     label: 'Linode 1024',
     class: 'nanode',
     addons: {
@@ -215,7 +215,7 @@ export const types: LinodeType[] = [
       monthly: 60.0,
       hourly: 0.09
     },
-    id: 'g5-highmem-1',
+    id: 'g6-highmem-1',
     label: 'Linode 16384',
     class: 'highmem',
     addons: {
@@ -238,7 +238,7 @@ export const types: LinodeType[] = [
       monthly: 120.0,
       hourly: 0.18
     },
-    id: 'g5-highmem-2',
+    id: 'g6-highmem-2',
     label: 'Linode 32768',
     class: 'highmem',
     addons: {
@@ -261,7 +261,7 @@ export const types: LinodeType[] = [
       monthly: 240.0,
       hourly: 0.36
     },
-    id: 'g5-highmem-4',
+    id: 'g6-highmem-4',
     label: 'Linode 61440',
     class: 'highmem',
     addons: {
@@ -284,7 +284,7 @@ export const types: LinodeType[] = [
       monthly: 480.0,
       hourly: 0.72
     },
-    id: 'g5-highmem-8',
+    id: 'g6-highmem-8',
     label: 'Linode 102400',
     class: 'highmem',
     addons: {
@@ -307,7 +307,7 @@ export const types: LinodeType[] = [
       monthly: 960.0,
       hourly: 1.44
     },
-    id: 'g5-highmem-16',
+    id: 'g6-highmem-16',
     label: 'Linode 204800',
     class: 'highmem',
     addons: {

--- a/packages/manager/src/factories/kubernetesCluster.ts
+++ b/packages/manager/src/factories/kubernetesCluster.ts
@@ -36,14 +36,14 @@ export const nodePoolAPIFactory = Factory.Sync.makeFactory<
 >({
   id: Factory.each(id => id),
   count: 3,
-  type: 'g5-standard-1',
+  type: 'g6-standard-1',
   nodes: kubeLinodeFactory.buildList(3)
 });
 
 export const _nodePoolFactory = Factory.Sync.makeFactory<PoolNodeWithPrice>({
   id: Factory.each(id => id),
   count: 3,
-  type: 'g5-standard-1',
+  type: 'g6-standard-1',
   totalMonthlyPrice: 1000
 });
 

--- a/packages/manager/src/factories/kubernetesCluster.ts
+++ b/packages/manager/src/factories/kubernetesCluster.ts
@@ -11,20 +11,6 @@ import {
 } from 'src/features/Kubernetes/types';
 import { v4 } from 'uuid';
 
-/**
- * These factories work with the "extended" types used in our logic.
- * Separate factories will be needed to work with API response types,
- * or typing will have to be adjusted to combine the 2.
- *
- * It looks like factory.ts does not allow you to override the type when
- * extending a factory. If we could do:
- *
- * baseClusterFactory = makeFactory<KubernetesCluster>(...)
- * extendedClusterFactory = baseClusterFactory.extend<ExtendedCluster>(...)
- *
- * ...we would be set.
- */
-
 export const kubeLinodeFactory = Factory.Sync.makeFactory<PoolNodeResponse>({
   id: Factory.each(id => `id-${id}`),
   instance_id: Factory.each(id => id),

--- a/packages/manager/src/factories/kubernetesCluster.ts
+++ b/packages/manager/src/factories/kubernetesCluster.ts
@@ -1,6 +1,8 @@
 import * as Factory from 'factory.ts';
 import {
+  KubernetesCluster,
   KubernetesEndpointResponse,
+  KubeNodePoolResponse,
   PoolNodeResponse
 } from '@linode/api-v4/lib/kubernetes/types';
 import {
@@ -27,6 +29,15 @@ export const kubeLinodeFactory = Factory.Sync.makeFactory<PoolNodeResponse>({
   id: Factory.each(id => `id-${id}`),
   instance_id: Factory.each(id => id),
   status: 'ready'
+});
+
+export const nodePoolAPIFactory = Factory.Sync.makeFactory<
+  KubeNodePoolResponse
+>({
+  id: Factory.each(id => id),
+  count: 3,
+  type: 'g5-standard-1',
+  nodes: kubeLinodeFactory.buildList(3)
 });
 
 export const _nodePoolFactory = Factory.Sync.makeFactory<PoolNodeWithPrice>({
@@ -70,4 +81,17 @@ export const kubeEndpointFactory = Factory.Sync.makeFactory<
   KubernetesEndpointResponse
 >({
   endpoint: `https://${v4()}`
+});
+
+export const kubernetesAPIResponse = Factory.Sync.makeFactory<
+  KubernetesCluster
+>({
+  id: Factory.each(id => id),
+  created: '2020-04-08T16:58:21',
+  updated: '2020-04-08T16:58:21',
+  region: 'us-central',
+  status: 'ready',
+  label: Factory.each(i => `test-cluster-${i}`),
+  k8s_version: '1.17',
+  tags: []
 });

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.test.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { extendedTypes } from 'src/__data__/ExtendedType';
 import { nodePoolFactory } from 'src/factories/kubernetesCluster';
 import { renderWithTheme } from 'src/utilities/testHelpers';
-
 import KubeCheckoutBar, { Props } from './KubeCheckoutBar';
+
+const types = require('src/cachedData/types.json');
 
 const pools = nodePoolFactory.buildList(5, { count: 3 });
 
@@ -13,7 +13,7 @@ const props: Props = {
   updatePool: jest.fn(),
   removePool: jest.fn(),
   createCluster: jest.fn(),
-  typesData: extendedTypes
+  typesData: types.data
 };
 
 const renderComponent = (_props: Props) =>

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -7,7 +7,7 @@ import {
   imageFactory,
   firewallFactory,
   firewallDeviceFactory,
-  kubernetesClusterFactory,
+  kubernetesAPIResponse,
   kubeEndpointFactory,
   invoiceFactory,
   invoiceItemFactory,
@@ -109,16 +109,17 @@ export const handlers = [
     return res(ctx.json(linode));
   }),
   rest.get('*/lke/clusters', async (req, res, ctx) => {
-    const clusters = kubernetesClusterFactory.buildList(10);
+    const clusters = kubernetesAPIResponse.buildList(10);
     return res(ctx.json(makeResourcePage(clusters)));
   }),
   rest.get('*/lke/clusters/:clusterId', async (req, res, ctx) => {
     const id = req.params.clusterId;
-    const cluster = kubernetesClusterFactory.build({ id });
+    const cluster = kubernetesAPIResponse.build({ id });
     return res(ctx.json(cluster));
   }),
   rest.get('*/lke/clusters/:clusterId/pools', async (req, res, ctx) => {
     const pools = nodePoolFactory.buildList(2);
+    nodePoolFactory.resetSequenceNumber();
     return res(ctx.json(makeResourcePage(pools)));
   }),
   rest.get('*/lke/clusters/*/api-endpoints', async (req, res, ctx) => {

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -113,12 +113,12 @@ export const handlers = [
     return res(ctx.json(makeResourcePage(clusters)));
   }),
   rest.get('*/lke/clusters/:clusterId', async (req, res, ctx) => {
-    const id = req.params.clusterId;
+    const id = Number(req.params.clusterId);
     const cluster = kubernetesAPIResponse.build({ id });
     return res(ctx.json(cluster));
   }),
   rest.get('*/lke/clusters/:clusterId/pools', async (req, res, ctx) => {
-    const pools = nodePoolFactory.buildList(2);
+    const pools = nodePoolFactory.buildList(10);
     nodePoolFactory.resetSequenceNumber();
     return res(ctx.json(makeResourcePage(pools)));
   }),


### PR DESCRIPTION
## Description

This is prep work to the real ticket, which is fixing calculations and display for huge LKE clusters. Thought I'd keep the PR's separate and small.

## Note to Reviewers

Load the mock service worker and visit a k8s cluster detail. Node pools should be displayed accurately.
