### PR TITLE
M3-4522: Add Proxy Protocol field to NodeBalancer Settings

### DIFF
--- a/packages/api-v4/src/nodebalancers/nodebalancers.schema.ts
+++ b/packages/api-v4/src/nodebalancers/nodebalancers.schema.ts
@@ -55,6 +55,7 @@ export const createNodeBalancerConfigSchema = object({
       is: check => check === 'http_body',
       then: string().required()
     }),
+  proxy_protocol: string().oneOf(['none', 'v1', 'v2']),
   check_timeout: number()
     .typeError('Timeout must be a number.')
     .integer(),
@@ -100,6 +101,7 @@ export const UpdateNodeBalancerConfigSchema = object({
       is: check => check === 'http_body',
       then: string().required()
     }),
+  proxy_protocol: string().oneOf(['none', 'v1', 'v2']),
   check_timeout: number()
     .typeError('Timeout must be a number.')
     .integer(),

--- a/packages/api-v4/src/nodebalancers/types.ts
+++ b/packages/api-v4/src/nodebalancers/types.ts
@@ -51,7 +51,7 @@ export interface NodeBalancerConfig {
   check_timeout: number;
   check_body: string;
   check_path: string;
-  proxy_protocol: 'none' | 'v1' | 'v2';
+  proxy_protocol: NodeBalancerProxyProtocol;
   check: 'none' | 'connection' | 'http' | 'http_body';
   ssl_key: string;
   stickiness: 'none' | 'table' | 'http_cookie';
@@ -61,6 +61,8 @@ export interface NodeBalancerConfig {
   nodes: NodeBalancerConfigNode[];
   modifyStatus?: 'new';
 }
+
+export type NodeBalancerProxyProtocol = 'none' | 'v1' | 'v2';
 
 export interface NodeBalancerConfigPort {
   configId: number;

--- a/packages/api-v4/src/nodebalancers/types.ts
+++ b/packages/api-v4/src/nodebalancers/types.ts
@@ -51,6 +51,7 @@ export interface NodeBalancerConfig {
   check_timeout: number;
   check_body: string;
   check_path: string;
+  proxy_protocol: 'none' | 'v1' | 'v2';
   check: 'none' | 'connection' | 'http' | 'http_body';
   ssl_key: string;
   stickiness: 'none' | 'table' | 'http_cookie';

--- a/packages/manager/src/factories/nodebalancer.ts
+++ b/packages/manager/src/factories/nodebalancer.ts
@@ -34,6 +34,7 @@ export const nodeBalancerConfigFactory = Factory.Sync.makeFactory<
   check_interval: 5,
   check_passive: true,
   check_path: '/ping_me',
+  proxy_protocol: 'none',
   check_timeout: 3,
   cipher_suite: 'recommended',
   nodebalancer_id: Factory.each(id => id),

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -192,10 +192,6 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
     );
   };
 
-  afterProxyProtocolUpdate = () => () => {
-    return;
-  };
-
   afterHealthCheckTypeUpdate = (L: { [key: string]: Lens }) => () => {
     this.setState(
       compose(
@@ -618,9 +614,7 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
                           this.afterProtocolUpdate
                         )}
                         onProxyProtocolChange={this.updateState(
-                          L.proxyProtocolLens,
-                          L,
-                          this.afterProxyProtocolUpdate
+                          L.proxyProtocolLens
                         )}
                         healthCheckType={view(
                           L.healthCheckTypeLens,

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -192,6 +192,10 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
     );
   };
 
+  afterProxyProtocolUpdate = () => () => {
+    return;
+  };
+
   afterHealthCheckTypeUpdate = (L: { [key: string]: Lens }) => () => {
     this.setState(
       compose(
@@ -573,6 +577,7 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
                     checkPathLens: lensTo(['check_path']),
                     portLens: lensTo(['port']),
                     protocolLens: lensTo(['protocol']),
+                    proxyProtocolLens: lensTo(['proxy_protocol']),
                     healthCheckTypeLens: lensTo(['check']),
                     healthCheckAttemptsLens: lensTo(['check_attempts']),
                     healthCheckIntervalLens: lensTo(['check_interval']),
@@ -606,10 +611,16 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
                         port={view(L.portLens, this.state)}
                         onPortChange={this.updateState(L.portLens)}
                         protocol={view(L.protocolLens, this.state)}
+                        proxyProtocol={view(L.proxyProtocolLens, this.state)}
                         onProtocolChange={this.updateState(
                           L.protocolLens,
                           L,
                           this.afterProtocolUpdate
+                        )}
+                        onProxyProtocolChange={this.updateState(
+                          L.proxyProtocolLens,
+                          L,
+                          this.afterProxyProtocolUpdate
                         )}
                         healthCheckType={view(
                           L.healthCheckTypeLens,

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerConfigurations.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerConfigurations.tsx
@@ -865,6 +865,10 @@ class NodeBalancerConfigurations extends React.Component<CombinedProps, State> {
     );
   };
 
+  afterProxyProtocolUpdate = () => () => {
+    return;
+  };
+
   afterHealthCheckTypeUpdate = (L: { [key: string]: Lens }) => () => {
     this.setState(
       compose(
@@ -967,6 +971,7 @@ class NodeBalancerConfigurations extends React.Component<CombinedProps, State> {
       checkPathLens: lensTo(['check_path']),
       portLens: lensTo(['port']),
       protocolLens: lensTo(['protocol']),
+      proxyProtocolLens: lensTo(['proxy_protocol']),
       healthCheckTypeLens: lensTo(['check']),
       healthCheckAttemptsLens: lensTo(['check_attempts']),
       healthCheckIntervalLens: lensTo(['check_interval']),
@@ -1021,10 +1026,16 @@ class NodeBalancerConfigurations extends React.Component<CombinedProps, State> {
           port={view(L.portLens, this.state)}
           onPortChange={this.updateState(L.portLens)}
           protocol={view(L.protocolLens, this.state)}
+          proxyProtocol={view(L.proxyProtocolLens, this.state)}
           onProtocolChange={this.updateState(
             L.protocolLens,
             L,
             this.afterProtocolUpdate
+          )}
+          onProxyProtocolChange={this.updateState(
+            L.proxyProtocolLens,
+            L,
+            this.afterProxyProtocolUpdate
           )}
           healthCheckType={view(L.healthCheckTypeLens, this.state)}
           onHealthCheckTypeChange={this.updateState(

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerConfigurations.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerConfigurations.tsx
@@ -865,10 +865,6 @@ class NodeBalancerConfigurations extends React.Component<CombinedProps, State> {
     );
   };
 
-  afterProxyProtocolUpdate = () => () => {
-    return;
-  };
-
   afterHealthCheckTypeUpdate = (L: { [key: string]: Lens }) => () => {
     this.setState(
       compose(
@@ -1032,11 +1028,7 @@ class NodeBalancerConfigurations extends React.Component<CombinedProps, State> {
             L,
             this.afterProtocolUpdate
           )}
-          onProxyProtocolChange={this.updateState(
-            L.proxyProtocolLens,
-            L,
-            this.afterProxyProtocolUpdate
-          )}
+          onProxyProtocolChange={this.updateState(L.proxyProtocolLens)}
           healthCheckType={view(L.healthCheckTypeLens, this.state)}
           onHealthCheckTypeChange={this.updateState(
             L.healthCheckTypeLens,

--- a/packages/manager/src/features/NodeBalancers/types.ts
+++ b/packages/manager/src/features/NodeBalancers/types.ts
@@ -1,7 +1,8 @@
 import {
   NodeBalancer,
   NodeBalancerConfigPort,
-  NodeBalancerConfigNodeMode
+  NodeBalancerConfigNodeMode,
+  NodeBalancerProxyProtocol
 } from '@linode/api-v4/lib/nodebalancers/types';
 import { APIError } from '@linode/api-v4/lib/types';
 
@@ -32,6 +33,7 @@ export interface NodeBalancerConfigFields {
   cipher_suite?: 'recommended' | 'legacy';
   port?: number /** 1..65535 */;
   protocol?: 'http' | 'https' | 'tcp';
+  proxy_protocol?: NodeBalancerProxyProtocol;
   ssl_cert?: string;
   ssl_key?: string;
   stickiness?: 'none' | 'table' | 'http_cookie';

--- a/packages/manager/src/features/NodeBalancers/utils.ts
+++ b/packages/manager/src/features/NodeBalancers/utils.ts
@@ -41,6 +41,7 @@ export const createNewNodeBalancerConfig = (
   cipher_suite: undefined,
   port: withDefaultPort ? 80 : undefined,
   protocol: 'http',
+  proxy_protocol: 'none',
   ssl_cert: undefined,
   ssl_key: undefined,
   stickiness: 'table',
@@ -99,6 +100,8 @@ export const transformConfigsForRequest = (
           config.ssl_key === '<REDACTED>'
             ? undefined
             : config.protocol || undefined,
+        proxy_protocol:
+          config.protocol === 'tcp' ? config.proxy_protocol : undefined,
         algorithm: config.algorithm || undefined,
         stickiness: config.stickiness || undefined,
         check: config.check || undefined,

--- a/packages/manager/src/features/NodeBalancers/utils.ts
+++ b/packages/manager/src/features/NodeBalancers/utils.ts
@@ -101,7 +101,7 @@ export const transformConfigsForRequest = (
             ? undefined
             : config.protocol || undefined,
         proxy_protocol:
-          config.protocol === 'tcp' ? config.proxy_protocol : undefined,
+          config.protocol === 'tcp' ? config.proxy_protocol : 'none',
         algorithm: config.algorithm || undefined,
         stickiness: config.stickiness || undefined,
         check: config.check || undefined,


### PR DESCRIPTION
## Description
The API now supports a `Proxy Protocol` field, so this PR adds support for this field in the NodeBalancer Create and configuration change (individual NodeBalancer > Configurations tab) flows when the user selects TCP for the Protocol.

## Type of Change
- Non breaking change ('update', 'change')

## To-Do:
- [x] Testing
- [x] Some cleanup