### PR TITLE
CMR: Fix document titles

### DIFF
--- a/packages/manager/src/features/Dashboard_CMR/Dashboard.tsx
+++ b/packages/manager/src/features/Dashboard_CMR/Dashboard.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
 
+import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import DashboardNotifications from './DashboardNotifications';
 import LinodeDashboardContent from './LinodeDashboardContent';
 
 export const Dashboard: React.FC<{}> = _ => {
   return (
     <>
+      <DocumentTitleSegment segment="Dashboard" />
       <DashboardNotifications />
       <LinodeDashboardContent />
     </>

--- a/packages/manager/src/features/Dashboard_CMR/LinodeDashboardContent/MultipleLinodes.tsx
+++ b/packages/manager/src/features/Dashboard_CMR/LinodeDashboardContent/MultipleLinodes.tsx
@@ -19,7 +19,7 @@ export const MultipleLinodes: React.FC<{}> = _ => {
   const tabs: Tab[] = [
     {
       title: 'Linodes',
-      render: () => <LinodesLanding />
+      render: () => <LinodesLanding isDashboard />
     }
   ];
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup_CMR.tsx
@@ -38,7 +38,6 @@ import TableHead from 'src/components/core/TableHead';
 import TableRow from 'src/components/core/TableRow';
 import Tooltip from 'src/components/core/Tooltip';
 import Typography from 'src/components/core/Typography';
-import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import ErrorState from 'src/components/ErrorState';
 import Notice from 'src/components/Notice';
@@ -794,7 +793,7 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
   };
 
   render() {
-    const { backupsEnabled, linodeLabel, permissions, type } = this.props;
+    const { backupsEnabled, permissions, type } = this.props;
 
     if (this.props.backups.error) {
       /** @todo remove promise loader and source backups from Redux */
@@ -808,7 +807,6 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
 
     return (
       <div>
-        <DocumentTitleSegment segment={`${linodeLabel} - Backups`} />
         {backupsEnabled ? (
           <this.Management />
         ) : (

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking_CMR.tsx
@@ -22,7 +22,6 @@ import {
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
 import Typography from 'src/components/core/Typography';
-import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import EntityHeader from 'src/components/EntityHeader';
 import ErrorState from 'src/components/ErrorState';
 import OrderBy from 'src/components/OrderBy';
@@ -509,7 +508,6 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
 
     return (
       <div>
-        <DocumentTitleSegment segment={`${linodeLabel} - Networking`} />
         {readOnly && <LinodePermissionsError />}
         <LinodeNetworkingSummaryPanel
           linodeRegion={linodeRegion}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettings_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettings_CMR.tsx
@@ -6,7 +6,6 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
-import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { LinodeDetailContextConsumer } from '../linodeDetailContext';
 import LinodePermissionsError from '../LinodePermissionsError';
 import LinodeSettingsAlertsPanel from './LinodeSettingsAlertsPanel';
@@ -44,7 +43,6 @@ const LinodeSettings: React.FC<CombinedProps> = props => {
 
         return (
           <div>
-            <DocumentTitleSegment segment={`${linode.label} - Settings`} />
             {permissionsError}
             <Typography
               variant="h2"

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary_CMR.tsx
@@ -21,7 +21,6 @@ import {
   withTheme
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
-import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import Grid from 'src/components/Grid';
 import LineGraph from 'src/components/LineGraph';
@@ -417,8 +416,6 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
 
     return (
       <Paper>
-        <DocumentTitleSegment segment={`${linode.label} - Summary`} />
-
         <Grid item className={classes.main}>
           <Grid item className="py0">
             <div className={classes.graphControls}>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDashboardNavigation.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDashboardNavigation.tsx
@@ -31,9 +31,6 @@ const LinodeAdvanced_CMR = React.lazy(() =>
 const LinodeBackup_CMR = React.lazy(() =>
   import('./LinodeBackup/LinodeBackup_CMR')
 );
-const LinodeResize = React.lazy(() => import('./LinodeResize'));
-const LinodeRescue = React.lazy(() => import('./LinodeRescue'));
-const LinodeRebuild = React.lazy(() => import('./LinodeRebuild'));
 const LinodeActivity_CMR = React.lazy(() =>
   import('./LinodeActivity/LinodeActivity_CMR')
 );
@@ -77,18 +74,6 @@ const LinodesDetailNavigation: React.FC<CombinedProps> = () => {
       {
         render: () => suspenseWrapper(LinodeBackup_CMR),
         title: 'Backups'
-      },
-      {
-        render: () => suspenseWrapper(LinodeResize),
-        title: 'Resize'
-      },
-      {
-        render: () => suspenseWrapper(LinodeRescue),
-        title: 'Rescue'
-      },
-      {
-        render: () => suspenseWrapper(LinodeRebuild),
-        title: 'Rebuild'
       },
       {
         render: () => suspenseWrapper(LinodeActivity_CMR),

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation_CMR.tsx
@@ -77,13 +77,20 @@ const LinodesDetailNavigation: React.FC<CombinedProps> = props => {
     return Boolean(matchPath(p, { path: location.pathname }));
   };
 
-  const activeTabIndex = tabs.findIndex(tab => matches(tab.routeName));
+  const defaultIndex = tabs.findIndex(tab => matches(tab.routeName));
+
+  const [tabIndex, setTabIndex] = React.useState(Math.max(defaultIndex, 0));
+
+  const handleTabChange = (index: number) => {
+    setTabIndex(index);
+  };
+
   return (
     <>
       <DocumentTitleSegment
-        segment={`${linodeLabel} - ${tabs[activeTabIndex].title}`}
+        segment={`${linodeLabel} - ${tabs[tabIndex]?.title ?? 'Detail View'}`}
       />
-      <Tabs defaultIndex={Math.max(activeTabIndex, 0)}>
+      <Tabs index={tabIndex} onChange={handleTabChange}>
         <TabLinkList tabs={tabs} />
 
         <React.Suspense fallback={<SuspenseLoader />}>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation_CMR.tsx
@@ -8,7 +8,7 @@ import Tabs from 'src/components/core/ReachTabs';
 import TabLinkList from 'src/components/TabLinkList';
 import SuspenseLoader from 'src/components/SuspenseLoader';
 import { withLinodeDetailContext } from './linodeDetailContext';
-
+import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 const LinodeSummary_CMR = React.lazy(() =>
   import('./LinodeSummary/LinodeSummary_CMR')
 );
@@ -36,12 +36,11 @@ type CombinedProps = ContextProps &
 
 const LinodesDetailNavigation: React.FC<CombinedProps> = props => {
   const {
+    linodeLabel,
     match: { url }
   } = props;
 
   const tabs = [
-    /* NB: These must correspond to the routes inside the Switch */
-    // Previously Summary
     {
       routeName: `${url}/analytics`,
       title: 'Analytics'
@@ -78,47 +77,48 @@ const LinodesDetailNavigation: React.FC<CombinedProps> = props => {
     return Boolean(matchPath(p, { path: location.pathname }));
   };
 
+  const activeTabIndex = tabs.findIndex(tab => matches(tab.routeName));
   return (
-    <Tabs
-      defaultIndex={Math.max(
-        tabs.findIndex(tab => matches(tab.routeName)),
-        0
-      )}
-    >
-      <TabLinkList tabs={tabs} />
+    <>
+      <DocumentTitleSegment
+        segment={`${linodeLabel} - ${tabs[activeTabIndex].title}`}
+      />
+      <Tabs defaultIndex={Math.max(activeTabIndex, 0)}>
+        <TabLinkList tabs={tabs} />
 
-      <React.Suspense fallback={<SuspenseLoader />}>
-        <TabPanels>
-          <SafeTabPanel index={0}>
-            <LinodeSummary_CMR />
-          </SafeTabPanel>
+        <React.Suspense fallback={<SuspenseLoader />}>
+          <TabPanels>
+            <SafeTabPanel index={0}>
+              <LinodeSummary_CMR />
+            </SafeTabPanel>
 
-          <SafeTabPanel index={1}>
-            <LinodeNetworking_CMR />
-          </SafeTabPanel>
+            <SafeTabPanel index={1}>
+              <LinodeNetworking_CMR />
+            </SafeTabPanel>
 
-          <SafeTabPanel index={2}>
-            <LinodeStorage />
-          </SafeTabPanel>
+            <SafeTabPanel index={2}>
+              <LinodeStorage />
+            </SafeTabPanel>
 
-          <SafeTabPanel index={3}>
-            <LinodeAdvanced_CMR />
-          </SafeTabPanel>
+            <SafeTabPanel index={3}>
+              <LinodeAdvanced_CMR />
+            </SafeTabPanel>
 
-          <SafeTabPanel index={4}>
-            <LinodeBackup_CMR />
-          </SafeTabPanel>
+            <SafeTabPanel index={4}>
+              <LinodeBackup_CMR />
+            </SafeTabPanel>
 
-          <SafeTabPanel index={5}>
-            <LinodeActivity_CMR />
-          </SafeTabPanel>
+            <SafeTabPanel index={5}>
+              <LinodeActivity_CMR />
+            </SafeTabPanel>
 
-          <SafeTabPanel index={6}>
-            <LinodeSettings_CMR />
-          </SafeTabPanel>
-        </TabPanels>
-      </React.Suspense>
-    </Tabs>
+            <SafeTabPanel index={6}>
+              <LinodeSettings_CMR />
+            </SafeTabPanel>
+          </TabPanels>
+        </React.Suspense>
+      </Tabs>
+    </>
   );
 };
 

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -98,7 +98,12 @@ interface Params {
 
 type RouteProps = RouteComponentProps<Params>;
 
-type CombinedProps = WithImages &
+interface Props {
+  isDashboard?: boolean;
+}
+
+type CombinedProps = Props &
+  WithImages &
   StateProps &
   DispatchProps &
   RouteProps &
@@ -271,7 +276,10 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
 
       return (
         <React.Fragment>
-          <DocumentTitleSegment segment="Linodes" />
+          {/** Don't override the document title if we're rendering this on the Dashboard */}
+          {!this.props.isDashboard ? (
+            <DocumentTitleSegment segment="Linodes" />
+          ) : null}
           <ErrorState errorText={errorText} />
         </React.Fragment>
       );
@@ -361,7 +369,10 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
             }`}
             xs={this.props.flags.cmr || !displayBackupsCTA ? 12 : undefined}
           >
-            <DocumentTitleSegment segment="Linodes" />
+            {/** Don't override the document title if we're rendering this on the Dashboard */}
+            {!this.props.isDashboard ? (
+              <DocumentTitleSegment segment="Linodes" />
+            ) : null}
             <PreferenceToggle<boolean>
               localStorageKey="GROUP_LINODES"
               preferenceOptions={[false, true]}
@@ -769,7 +780,7 @@ const updateParams = <T extends any>(params: string, updater: (s: T) => T) => {
   return stringify(updater(paramsAsObject));
 };
 
-export const enhanced = compose<CombinedProps, {}>(
+export const enhanced = compose<CombinedProps, Props>(
   withRouter,
   setDocs(ListLinodes.docs),
   withSnackbar,

--- a/packages/manager/src/features/linodes/LinodesLanding/index.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/index.tsx
@@ -2,9 +2,17 @@ import * as React from 'react';
 import CircleProgress from 'src/components/CircleProgress';
 import { useReduxLoad } from 'src/hooks/useReduxLoad';
 
-const LinodesLanding: React.FC<{}> = _ => {
+interface Props {
+  isDashboard?: boolean;
+}
+
+const LinodesLanding: React.FC<Props> = props => {
   const { _loading } = useReduxLoad(['linodes', 'images']);
-  return _loading ? <CircleProgress /> : <_LinodesLanding />;
+  return _loading ? (
+    <CircleProgress />
+  ) : (
+    <_LinodesLanding isDashboard={props.isDashboard} />
+  );
 };
 
 import _LinodesLanding from './LinodesLanding';


### PR DESCRIPTION
## Description

In the old days, each tab of Linode Detail rendered its own DocumentTitleSegment.
This no longer works, because:
- the tabs are sometimes rendered on the dashboard and override the segment there
- the version of LinodeDetail we use on the dashboard renders all tabs at once,
which results in a document title with all of the tab annotations in it.

Added a single title segment to LinodeDashboardNavigation that is dynamic
depending on the selected tab. The dynamic part only works on page load for now
because of a lack of communication between Reach Router and React Router
(location.history is not updated when changing tabs).

Other changes:

- Removed title segments from the individual tabs
- Added a segment to the CMR dashboard
- Removed rescue/rebuild/resize tabs from the Dashboard version of LinodeDetail

## Note to Reviewers

I don't think anything I did will affect non-CMR, but it doesn't hurt to check. Otherwise, please check all variations of Linodes landing/detail/dashboard:

- Actual landing page
- Actual detail page
- dashboard - 1 Linode
- dashboard - many Linodes