### PR TITLE
Filter firewall rules inside OrderBy

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -96,14 +96,6 @@ const FirewallRuleTable: React.FC<CombinedProps> = props => {
     props.openRuleDrawer(props.category, 'create');
   }, []);
 
-  // Modified rows will be unsorted and will appear at the bottom of the table.
-  const unmodifiedRows = rowData.filter(
-    thisRow => thisRow.status === 'NOT_MODIFIED'
-  );
-  const modifiedRows = rowData.filter(
-    thisRow => thisRow.status !== 'NOT_MODIFIED'
-  );
-
   return (
     <>
       <div className={classes.header}>
@@ -113,14 +105,17 @@ const FirewallRuleTable: React.FC<CombinedProps> = props => {
           label={`Add an ${capitalize(category)} Rule`}
         />
       </div>
-      <OrderBy data={unmodifiedRows} orderBy={'type'} order={'asc'}>
-        {({
-          data: sortedUnmodifiedRows,
-          handleOrderChange,
-          order,
-          orderBy
-        }) => {
-          const allRows = [...sortedUnmodifiedRows, ...modifiedRows];
+      <OrderBy data={rowData} orderBy={'type'} order={'asc'}>
+        {({ data: sortedRows, handleOrderChange, order, orderBy }) => {
+          // Modified rows will be unsorted and will appear at the bottom of the table.
+          const unmodifiedRows = sortedRows.filter(
+            thisRow => thisRow.status === 'NOT_MODIFIED'
+          );
+          const modifiedRows = sortedRows.filter(
+            thisRow => thisRow.status !== 'NOT_MODIFIED'
+          );
+
+          const allRows = [...unmodifiedRows, ...modifiedRows];
 
           return (
             <Table isResponsive={false} tableClass={classes.table}>
@@ -284,6 +279,7 @@ export const ConditionalError: React.FC<ConditionalErrorProps> = React.memo(
     const uniqueByFormField = uniqBy(prop('formField'), errors ?? []);
 
     return (
+      // eslint-disable-next-line
       <>
         {uniqueByFormField.map(thisError => {
           if (formField !== thisError.formField || !thisError.reason) {

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable_CMR.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable_CMR.tsx
@@ -104,14 +104,6 @@ const FirewallRuleTable: React.FC<CombinedProps> = props => {
     openRuleDrawer(category, 'create');
   }, [openRuleDrawer, category]);
 
-  // Modified rows will be unsorted and will appear at the bottom of the table.
-  const unmodifiedRows = rowData.filter(
-    thisRow => thisRow.status === 'NOT_MODIFIED'
-  );
-  const modifiedRows = rowData.filter(
-    thisRow => thisRow.status !== 'NOT_MODIFIED'
-  );
-
   return (
     <>
       <div className={classes.header}>
@@ -122,14 +114,16 @@ const FirewallRuleTable: React.FC<CombinedProps> = props => {
           className={classes.link}
         />
       </div>
-      <OrderBy data={unmodifiedRows} orderBy={'type'} order={'asc'}>
-        {({
-          data: sortedUnmodifiedRows,
-          handleOrderChange,
-          order,
-          orderBy
-        }) => {
-          const allRows = [...sortedUnmodifiedRows, ...modifiedRows];
+      <OrderBy data={rowData} orderBy={'type'} order={'asc'}>
+        {({ data: sortedRows, handleOrderChange, order, orderBy }) => {
+          // Modified rows will be unsorted and will appear at the bottom of the table.
+          const unmodifiedRows = sortedRows.filter(
+            thisRow => thisRow.status === 'NOT_MODIFIED'
+          );
+          const modifiedRows = sortedRows.filter(
+            thisRow => thisRow.status !== 'NOT_MODIFIED'
+          );
+          const allRows = [...unmodifiedRows, ...modifiedRows];
 
           return (
             <Table>


### PR DESCRIPTION
Fixes a regression in the Firewall rules table caused by recent changes to the OrderBy component we use for sorting table data.

Previously, modified and unmodified firewall rules were filtered
into separate lists in the FirewallRulesTable, and only unmodified rules
were passed to OrderBy. This was so that modified rules appeared unsorted
at the bottom of the list (in the order in which they were added).

This worked until recently, when changes to OrderBy caused a very
confusing react key collision. To avoid this, this commit moves
the filtering to after the OrderBy sorting.

