### PR TITLE
M3-4529 fix OrderBy lifecycle bug

### DIFF
--- a/packages/manager/src/components/OrderBy.tsx
+++ b/packages/manager/src/components/OrderBy.tsx
@@ -15,7 +15,6 @@ import {
   sortByUTFDate
 } from 'src/utilities/sort-by';
 import { debounce } from 'throttle-debounce';
-import { isArray } from 'util';
 
 export interface OrderByProps extends State {
   handleOrderChange: (orderBy: string, order: Order) => void;
@@ -107,7 +106,7 @@ export const sortData = (orderBy: string, order: Order) => {
     const aValue = pathOr('', !!orderByProp ? orderByProp : [orderBy], a);
     const bValue = pathOr('', !!orderByProp ? orderByProp : [orderBy], b);
 
-    if (isArray(aValue) && isArray(bValue)) {
+    if (Array.isArray(aValue) && Array.isArray(bValue)) {
       return sortByArrayLength(aValue, bValue, order);
     }
 

--- a/packages/manager/src/components/OrderBy.tsx
+++ b/packages/manager/src/components/OrderBy.tsx
@@ -137,7 +137,7 @@ export const OrderBy: React.FC<CombinedProps> = props => {
   // Stash a copy of the previous data for equality check.
   const prevData = usePrevious(props.data);
 
-  // Our working copy of the data to be sorted,.
+  // Our working copy of the data to be sorted.
   const dataToSort = React.useRef(props.data);
 
   // If `props.data` has changed, that's the data we should sort.


### PR DESCRIPTION
## Description

Fixes a bug in OrderBy that led to the FW regression yesterday. This makes use of refs and does the equality check in the function body itself instead of useEffects, which are run _after_ render.

While I was here I again tried to get rid of this equality check with no luck. I tried storing previous values of `order` and `orderBy` but this becomes very complicated (you need to keep track of previous values on a stack) and I'm not sure the tradeoff is worth it. 

We _do_ have performance issues when sorting large lists, but AFAICT the issues come from the massive DOM tree and not the actual `equals()` calls.

