### PR TITLE
M3-4468 LKE: handling for large clusters

### DIFF
--- a/packages/manager/src/features/Events/EventsLanding.tsx
+++ b/packages/manager/src/features/Events/EventsLanding.tsx
@@ -319,7 +319,7 @@ export const EventsLanding: React.FC<CombinedProps> = props => {
         </Table>
       </Paper>
       {loadMoreEvents && initialLoaded && !isLoading ? (
-        <Waypoint onEnter={getNext} scrollableAncestor="window">
+        <Waypoint onEnter={getNext}>
           <div />
         </Waypoint>
       ) : (

--- a/packages/manager/src/features/Events/EventsLanding.tsx
+++ b/packages/manager/src/features/Events/EventsLanding.tsx
@@ -319,7 +319,7 @@ export const EventsLanding: React.FC<CombinedProps> = props => {
         </Table>
       </Paper>
       {loadMoreEvents && initialLoaded && !isLoading ? (
-        <Waypoint onEnter={getNext}>
+        <Waypoint onEnter={getNext} scrollableAncestor="window">
           <div />
         </Waypoint>
       ) : (

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -4,6 +4,7 @@ import {
 } from '@linode/api-v4/lib/kubernetes/types';
 import * as React from 'react';
 import { useSelector } from 'react-redux';
+import { Waypoint } from 'react-waypoint';
 import AddNewLink from 'src/components/AddNewLink';
 import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
@@ -90,6 +91,13 @@ export const NodePoolsDisplay: React.FC<Props> = props => {
   const deletePoolDialog = useDialog<number>(deletePool);
   const recycleAllNodesDialog = useDialog<number>(recycleAllNodes);
   const recycleNodeDialog = useDialog<number>(deleteLinode);
+
+  const [numPoolsToDisplay, setNumPoolsToDisplay] = React.useState(25);
+  const handleShowMore = () => {
+    if (numPoolsToDisplay < pools.length) {
+      setNumPoolsToDisplay(Math.min(numPoolsToDisplay + 25, pools.length));
+    }
+  };
 
   const [addDrawerOpen, setAddDrawerOpen] = React.useState<boolean>(false);
   const [resizeDrawerOpen, setResizeDrawerOpen] = React.useState<boolean>(
@@ -184,6 +192,8 @@ export const NodePoolsDisplay: React.FC<Props> = props => {
     });
   };
 
+  const _pools = pools.slice(0, numPoolsToDisplay);
+
   /**
    * If the API returns an error when fetching node pools,
    * we want to display this error to the user from the
@@ -234,7 +244,7 @@ export const NodePoolsDisplay: React.FC<Props> = props => {
         ) : (
           <Grid container direction="column">
             <Grid item xs={12} className={classes.displayTable}>
-              {pools.map(thisPool => {
+              {_pools.map(thisPool => {
                 const { id, nodes } = thisPool;
 
                 const thisPoolType = types.find(
@@ -259,7 +269,13 @@ export const NodePoolsDisplay: React.FC<Props> = props => {
                   </div>
                 );
               })}
+              {pools.length > numPoolsToDisplay && (
+                <Waypoint onEnter={handleShowMore} scrollableAncestor="window">
+                  <div style={{ minHeight: 50 }} />
+                </Waypoint>
+              )}
             </Grid>
+
             <AddNodePoolDrawer
               clusterLabel={clusterLabel}
               open={addDrawerOpen}

--- a/packages/manager/src/store/kubernetes/nodePools.requests.ts
+++ b/packages/manager/src/store/kubernetes/nodePools.requests.ts
@@ -6,7 +6,7 @@ import {
   KubeNodePoolResponse,
   updateNodePool as _updateNodePool
 } from '@linode/api-v4/lib/kubernetes';
-import { getAll } from 'src/utilities/getAll';
+import { getAllWithArguments } from 'src/utilities/getAll';
 import { createRequestThunk } from '../store.helpers';
 import { ThunkActionCreator } from '../types';
 import {
@@ -18,8 +18,7 @@ import {
   upsertNodePool
 } from './nodePools.actions';
 
-const getAllNodePools = (clusterID: number) =>
-  getAll<KubeNodePoolResponse>(() => getNodePools(clusterID));
+const getAllNodePools = getAllWithArguments<KubeNodePoolResponse>(getNodePools);
 
 export const extendNodePools = (
   clusterID: number,
@@ -43,7 +42,7 @@ export const requestNodePoolsForCluster: ThunkActionCreator<
 > = ({ clusterID }) => dispatch => {
   dispatch(requestNodePoolsActions.started());
 
-  return getAllNodePools(clusterID)()
+  return getAllNodePools([clusterID])
     .then(({ data }) => {
       return extendNodePools(clusterID, data);
     })


### PR DESCRIPTION
## Description

- Use getAllWithArguments rather than getAll, which was not properly
passing pagination params through to the API. This lead to weird behavior
for clusters with more than 100 node pools; essentially the same pools were
being returned twice, resulting in 200 pools being displayed.

- Add Waypoint to node pools display table for accounts with many pools

## Note to Reviewers

Mocking doesn't quite capture the bug for some reason, I've put a giant cluster on test account 4 for your use. On develop, you can see the summary panel basing its calcs on 200 pools (e.g. 400 cpus). This branch should accurately calculate based on what the API is returning.