### PR TITLE
M3-4480 Object Details Drawer

### DIFF
--- a/packages/manager/src/components/CopyTooltip/CopyTooltip.tsx
+++ b/packages/manager/src/components/CopyTooltip/CopyTooltip.tsx
@@ -8,19 +8,21 @@ import {
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
 
 interface Props {
   text: string;
   className?: string;
   standAlone?: boolean;
   ariaLabel?: string;
+  displayText?: string;
 }
 
 interface State {
   copied: boolean;
 }
 
-type CSSClasses = 'root' | 'copied' | 'standAlone';
+type CSSClasses = 'root' | 'copied' | 'standAlone' | 'displayText' | 'flex';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -73,6 +75,15 @@ const styles = (theme: Theme) =>
       '& svg': {
         width: 14
       }
+    },
+    flex: {
+      display: 'flex'
+    },
+    displayText: {
+      alignSelf: 'flex-end',
+      marginLeft: 6,
+      fontSize: '1rem',
+      color: theme.color.blue
     }
   });
 
@@ -92,7 +103,7 @@ class CopyTooltip extends React.Component<CombinedProps, State> {
   };
 
   render() {
-    const { classes, text, className, standAlone } = this.props;
+    const { classes, text, className, standAlone, displayText } = this.props;
     const { copied } = this.state;
 
     return (
@@ -103,7 +114,8 @@ class CopyTooltip extends React.Component<CombinedProps, State> {
         onClick={this.clickIcon}
         className={classNames(className, {
           [classes.root]: true,
-          [classes.standAlone]: standAlone
+          [classes.standAlone]: standAlone,
+          [classes.flex]: Boolean(displayText)
         })}
       >
         {copied && (
@@ -112,6 +124,9 @@ class CopyTooltip extends React.Component<CombinedProps, State> {
           </span>
         )}
         <FileCopy />
+        {displayText && (
+          <Typography className={classes.displayText}>{displayText}</Typography>
+        )}
       </button>
     );
   }

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -48,6 +48,7 @@ import {
   displayName,
   ExtendedObject,
   extendObject,
+  generateObjectUrl,
   tableUpdateAction
 } from '../utilities';
 import BucketBreadcrumb from './BucketBreadcrumb';
@@ -418,7 +419,9 @@ export class BucketDetail extends React.Component<CombinedProps, State> {
       objectToDelete,
       deleteObjectLoading,
       deleteObjectError,
-      deleteObjectDialogOpen
+      deleteObjectDialogOpen,
+      selectedObject,
+      objectDetailDrawerOpen
     } = this.state;
 
     const { bucketName, clusterId } = this.props.match.params;
@@ -605,13 +608,17 @@ export class BucketDetail extends React.Component<CombinedProps, State> {
           </Grid>
         </Grid>
         <ObjectDetailDrawer
-          open={this.state.objectDetailDrawerOpen}
+          open={objectDetailDrawerOpen}
           onClose={() => this.setState({ objectDetailDrawerOpen: false })}
-          name={this.state.selectedObject?._displayName}
-          lastModified={this.state.selectedObject?.last_modified}
-          size={this.state.selectedObject?.size}
-          // @todo: get the full url
-          url={bucketName}
+          name={selectedObject?._displayName}
+          lastModified={selectedObject?.last_modified}
+          size={selectedObject?.size}
+          url={
+            selectedObject
+              ? generateObjectUrl(clusterId, bucketName, selectedObject.name)
+                  .absolute
+              : undefined
+          }
         />
       </>
     );

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -56,6 +56,7 @@ import withFeatureFlags, {
   FeatureFlagConsumerProps
 } from 'src/containers/withFeatureFlagConsumer.container.ts';
 import Hidden from 'src/components/core/Hidden';
+import ObjectDetailDrawer from './ObjectDetailDrawer';
 
 const page_size = 100;
 
@@ -134,9 +135,11 @@ interface State {
   generalError?: APIError[];
   nextPageError?: APIError[];
   objectToDelete?: string;
+  objectDetailDrawerOpen: boolean;
+  selectedObject?: ExtendedObject;
 }
 
-export class BucketDetail extends React.Component<CombinedProps, {}> {
+export class BucketDetail extends React.Component<CombinedProps, State> {
   state: State = {
     data: [],
     loading: false,
@@ -145,7 +148,8 @@ export class BucketDetail extends React.Component<CombinedProps, {}> {
     deleteObjectDialogOpen: false,
     deleteObjectLoading: false,
     generalError: undefined,
-    nextPageError: undefined
+    nextPageError: undefined,
+    objectDetailDrawerOpen: false
   };
 
   fetchData() {
@@ -485,6 +489,12 @@ export class BucketDetail extends React.Component<CombinedProps, {}> {
                         prefix={prefix}
                         handleClickDownload={this.handleDownload}
                         handleClickDelete={this.handleClickDelete}
+                        handleClickDetails={(selectedObject: ExtendedObject) =>
+                          this.setState({
+                            selectedObject,
+                            objectDetailDrawerOpen: true
+                          })
+                        }
                       />
                     </TableBody>
                   </Table_CMR>
@@ -517,6 +527,14 @@ export class BucketDetail extends React.Component<CombinedProps, {}> {
                         prefix={prefix}
                         handleClickDownload={this.handleDownload}
                         handleClickDelete={this.handleClickDelete}
+                        handleClickDetails={(
+                          selectedObject: ExtendedObject
+                        ) => {
+                          this.setState({
+                            selectedObject,
+                            objectDetailDrawerOpen: true
+                          });
+                        }}
                       />
                     </TableBody>
                   </Table>
@@ -586,6 +604,15 @@ export class BucketDetail extends React.Component<CombinedProps, {}> {
             </>
           </Grid>
         </Grid>
+        <ObjectDetailDrawer
+          open={this.state.objectDetailDrawerOpen}
+          onClose={() => this.setState({ objectDetailDrawerOpen: false })}
+          name={this.state.selectedObject?._displayName}
+          lastModified={this.state.selectedObject?.last_modified}
+          size={this.state.selectedObject?.size}
+          // @todo: get the full url
+          url={bucketName}
+        />
       </>
     );
   }

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -57,7 +57,7 @@ import withFeatureFlags, {
   FeatureFlagConsumerProps
 } from 'src/containers/withFeatureFlagConsumer.container.ts';
 import Hidden from 'src/components/core/Hidden';
-import ObjectDetailDrawer from './ObjectDetailDrawer';
+import ObjectDetailDrawer from './ObjectDetailsDrawer';
 
 const page_size = 100;
 

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -286,6 +286,13 @@ export class BucketDetail extends React.Component<CombinedProps, State> {
     });
   };
 
+  handleClickDetails = (selectedObject: ExtendedObject) => {
+    this.setState({
+      selectedObject,
+      objectDetailDrawerOpen: true
+    });
+  };
+
   deleteObject = async () => {
     const { clusterId, bucketName } = this.props.match.params;
     const { objectToDelete } = this.state;
@@ -408,6 +415,10 @@ export class BucketDetail extends React.Component<CombinedProps, State> {
     });
   };
 
+  closeObjectDetailsDrawer = () => {
+    this.setState({ objectDetailDrawerOpen: false });
+  };
+
   render() {
     const { classes, flags } = this.props;
     const {
@@ -492,12 +503,7 @@ export class BucketDetail extends React.Component<CombinedProps, State> {
                         prefix={prefix}
                         handleClickDownload={this.handleDownload}
                         handleClickDelete={this.handleClickDelete}
-                        handleClickDetails={(selectedObject: ExtendedObject) =>
-                          this.setState({
-                            selectedObject,
-                            objectDetailDrawerOpen: true
-                          })
-                        }
+                        handleClickDetails={this.handleClickDetails}
                       />
                     </TableBody>
                   </Table_CMR>
@@ -530,14 +536,7 @@ export class BucketDetail extends React.Component<CombinedProps, State> {
                         prefix={prefix}
                         handleClickDownload={this.handleDownload}
                         handleClickDelete={this.handleClickDelete}
-                        handleClickDetails={(
-                          selectedObject: ExtendedObject
-                        ) => {
-                          this.setState({
-                            selectedObject,
-                            objectDetailDrawerOpen: true
-                          });
-                        }}
+                        handleClickDetails={this.handleClickDetails}
                       />
                     </TableBody>
                   </Table>
@@ -609,7 +608,7 @@ export class BucketDetail extends React.Component<CombinedProps, State> {
         </Grid>
         <ObjectDetailDrawer
           open={objectDetailDrawerOpen}
-          onClose={() => this.setState({ objectDetailDrawerOpen: false })}
+          onClose={this.closeObjectDetailsDrawer}
           name={selectedObject?._displayName}
           lastModified={selectedObject?.last_modified}
           size={selectedObject?.size}

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectActionMenu.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectActionMenu.test.tsx
@@ -7,10 +7,12 @@ jest.mock('src/components/ActionMenu/ActionMenu');
 
 const mockHandleClickDelete = jest.fn();
 const mockHandleClickDownload = jest.fn();
+const mockHandleClickDetails = jest.fn();
 
 const props: Props = {
   handleClickDownload: mockHandleClickDownload,
   handleClickDelete: mockHandleClickDelete,
+  handleClickDetails: mockHandleClickDetails,
   objectName: 'my-object'
 };
 

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectActionMenu.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectActionMenu.tsx
@@ -5,11 +5,20 @@ export interface Props {
   objectName: string;
   handleClickDownload: (objectName: string, newTab: boolean) => void;
   handleClickDelete: (objectName: string) => void;
+  handleClickDetails: () => void;
 }
 
 export const ObjectActionMenu: React.FC<Props> = props => {
   const createActions = () => (closeMenu: Function): Action[] => {
     return [
+      {
+        title: 'Details',
+        onClick: (e: React.MouseEvent<HTMLElement>) => {
+          props.handleClickDetails();
+          closeMenu();
+          e.preventDefault();
+        }
+      },
       {
         title: 'Download',
         onClick: (e: React.MouseEvent<HTMLElement>) => {

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectActionMenu_CMR.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectActionMenu_CMR.tsx
@@ -8,6 +8,7 @@ import InlineMenuAction from 'src/components/InlineMenuAction/InlineMenuAction';
 export interface Handlers {
   handleClickDownload: (objectName: string, newTab: boolean) => void;
   handleClickDelete: (objectName: string) => void;
+  handleClickDetails: (objectName: string) => void;
 }
 
 interface Props extends Handlers {
@@ -18,9 +19,20 @@ export const ObjectActionMenu: React.FC<Props> = props => {
   const theme = useTheme<Theme>();
   const matchesSmDown = useMediaQuery(theme.breakpoints.down('sm'));
 
-  const { handleClickDownload, handleClickDelete, objectName } = props;
+  const {
+    handleClickDownload,
+    handleClickDelete,
+    handleClickDetails,
+    objectName
+  } = props;
 
   const actions: Action[] = [
+    {
+      title: 'Details',
+      onClick: () => {
+        handleClickDetails(objectName);
+      }
+    },
     {
       title: 'Download',
       onClick: () => {

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailDrawer.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+
+// import { makeStyles, Theme } from 'src/components/core/styles';
+import Drawer from 'src/components/Drawer';
+import Typography from 'src/components/core/Typography';
+import { readableBytes } from 'src/utilities/unitConversions';
+import ExternalLink from 'src/components/ExternalLink';
+import { truncateMiddle } from 'src/utilities/truncate';
+
+// const useStyles = makeStyles((theme: Theme) => ({
+//   root: {}
+// }));
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  name?: string;
+  size?: number | null;
+  lastModified?: string | null;
+  // enablePublicURL: () => void;
+  url?: string;
+}
+
+const ObjectDetailDrawer: React.FC<Props> = props => {
+  const { open, onClose, name, size, lastModified, url } = props;
+
+  // const classes = useStyles();
+
+  return (
+    <Drawer open={open} onClose={onClose} title={name ?? 'Object Detail'}>
+      {size && <Typography>{readableBytes(size).formatted}</Typography>}
+      {lastModified && <Typography>Last modified: {lastModified}</Typography>}
+      {/* ENABLE PUBLIC URL TOGGLE */}
+      {url && <ExternalLink link={url} text={truncateMiddle(url)} />}
+      {/* COPY TO CLIPBOARD */}
+      {/* OPEN */}
+    </Drawer>
+  );
+};
+
+export default ObjectDetailDrawer;

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailDrawer.tsx
@@ -1,15 +1,23 @@
 import * as React from 'react';
-
-// import { makeStyles, Theme } from 'src/components/core/styles';
-import Drawer from 'src/components/Drawer';
+import CopyTooltip from 'src/components/CopyTooltip';
+import Divider from 'src/components/core/Divider';
+import { makeStyles } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
-import { readableBytes } from 'src/utilities/unitConversions';
+import Drawer from 'src/components/Drawer';
 import ExternalLink from 'src/components/ExternalLink';
+import formatDate from 'src/utilities/formatDate';
 import { truncateMiddle } from 'src/utilities/truncate';
+import { readableBytes } from 'src/utilities/unitConversions';
 
-// const useStyles = makeStyles((theme: Theme) => ({
-//   root: {}
-// }));
+const useStyles = makeStyles(() => ({
+  divider: {
+    marginTop: 16,
+    marginBottom: 16,
+    height: 1,
+    backgroundColor: '#EBEBEB'
+  },
+  copy: { marginTop: 16, padding: 0 }
+}));
 
 interface Props {
   open: boolean;
@@ -24,16 +32,42 @@ interface Props {
 const ObjectDetailDrawer: React.FC<Props> = props => {
   const { open, onClose, name, size, lastModified, url } = props;
 
-  // const classes = useStyles();
+  let formattedLastModified;
+  try {
+    if (lastModified) {
+      formattedLastModified = formatDate(lastModified);
+    }
+  } catch {}
+
+  const classes = useStyles();
 
   return (
     <Drawer open={open} onClose={onClose} title={name ?? 'Object Detail'}>
-      {size && <Typography>{readableBytes(size).formatted}</Typography>}
-      {lastModified && <Typography>Last modified: {lastModified}</Typography>}
-      {/* ENABLE PUBLIC URL TOGGLE */}
-      {url && <ExternalLink link={url} text={truncateMiddle(url)} />}
-      {/* COPY TO CLIPBOARD */}
-      {/* OPEN */}
+      {size && (
+        <Typography variant="subtitle2">
+          {readableBytes(size).formatted}
+        </Typography>
+      )}
+      {formattedLastModified && (
+        <Typography variant="subtitle2">
+          Last modified: {formattedLastModified}
+        </Typography>
+      )}
+
+      <Divider className={classes.divider} />
+
+      {/* ENABLE PUBLIC URL TOGGLE GOES HERE*/}
+
+      {url && (
+        <>
+          <ExternalLink link={url} text={truncateMiddle(url, 50)} />
+          <CopyTooltip
+            className={classes.copy}
+            text={url}
+            displayText="Copy to clipboard"
+          />
+        </>
+      )}
     </Drawer>
   );
 };

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.test.tsx
@@ -15,7 +15,7 @@ describe('ObjectDetailsDrawer', () => {
   it('renders formatted size, formatted last modified, truncated URL', () => {
     const { getByText } = renderWithTheme(<ObjectDetailsDrawer {...props} />);
     getByText('12.1 KB');
-    getByText('Last modified: 2019-12-31 18:59:59');
+    getByText(/^Last modified: 2019-12-31/);
     getByText(/^https:\/\/my-bucket/);
   });
 

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.test.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+import ObjectDetailsDrawer, { Props } from './ObjectDetailsDrawer';
+
+const props: Props = {
+  onClose: jest.fn(),
+  open: true,
+  lastModified: '2019-12-31T23:59:59Z',
+  name: 'my-image.png',
+  size: 12345,
+  url: 'https://my-bucket.cluster-id.linodeobjects.com/my-image.png'
+};
+
+describe('ObjectDetailsDrawer', () => {
+  it('renders formatted size, formatted last modified, truncated URL', () => {
+    const { getByText } = renderWithTheme(<ObjectDetailsDrawer {...props} />);
+    getByText('12.1 KB');
+    getByText('Last modified: 2019-12-31 18:59:59');
+    getByText(/^https:\/\/my-bucket/);
+  });
+
+  it("doesn't show last modified if the the time is invalid", () => {
+    const { queryByTestId } = renderWithTheme(
+      <ObjectDetailsDrawer {...props} lastModified="INVALID DATE" />
+    );
+    expect(queryByTestId('lastModified')).not.toBeInTheDocument();
+  });
+});

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.tsx
@@ -42,7 +42,11 @@ const ObjectDetailsDrawer: React.FC<Props> = props => {
   const classes = useStyles();
 
   return (
-    <Drawer open={open} onClose={onClose} title={name ?? 'Object Detail'}>
+    <Drawer
+      open={open}
+      onClose={onClose}
+      title={truncateMiddle(name ?? 'Object Detail')}
+    >
       {size && (
         <Typography variant="subtitle2">
           {readableBytes(size).formatted}

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.tsx
@@ -76,4 +76,4 @@ const ObjectDetailsDrawer: React.FC<Props> = props => {
   );
 };
 
-export default ObjectDetailsDrawer;
+export default React.memo(ObjectDetailsDrawer);

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.tsx
@@ -47,22 +47,22 @@ const ObjectDetailsDrawer: React.FC<Props> = props => {
       onClose={onClose}
       title={truncateMiddle(name ?? 'Object Detail')}
     >
-      {size && (
+      {size ? (
         <Typography variant="subtitle2">
           {readableBytes(size).formatted}
         </Typography>
-      )}
-      {formattedLastModified && (
+      ) : null}
+      {formattedLastModified ? (
         <Typography variant="subtitle2" data-testid="lastModified">
           Last modified: {formattedLastModified}
         </Typography>
-      )}
+      ) : null}
 
       <Divider className={classes.divider} />
 
       {/* ENABLE PUBLIC URL TOGGLE GOES HERE*/}
 
-      {url && (
+      {url ? (
         <>
           <ExternalLink link={url} text={truncateMiddle(url, 50)} />
           <CopyTooltip
@@ -71,7 +71,7 @@ const ObjectDetailsDrawer: React.FC<Props> = props => {
             displayText="Copy to clipboard"
           />
         </>
-      )}
+      ) : null}
     </Drawer>
   );
 };

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.tsx
@@ -19,7 +19,7 @@ const useStyles = makeStyles(() => ({
   copy: { marginTop: 16, padding: 0 }
 }));
 
-interface Props {
+export interface Props {
   open: boolean;
   onClose: () => void;
   name?: string;
@@ -29,7 +29,7 @@ interface Props {
   url?: string;
 }
 
-const ObjectDetailDrawer: React.FC<Props> = props => {
+const ObjectDetailsDrawer: React.FC<Props> = props => {
   const { open, onClose, name, size, lastModified, url } = props;
 
   let formattedLastModified;
@@ -49,7 +49,7 @@ const ObjectDetailDrawer: React.FC<Props> = props => {
         </Typography>
       )}
       {formattedLastModified && (
-        <Typography variant="subtitle2">
+        <Typography variant="subtitle2" data-testid="lastModified">
           Last modified: {formattedLastModified}
         </Typography>
       )}
@@ -72,4 +72,4 @@ const ObjectDetailDrawer: React.FC<Props> = props => {
   );
 };
 
-export default ObjectDetailDrawer;
+export default ObjectDetailsDrawer;

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableContent.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableContent.tsx
@@ -144,6 +144,7 @@ const ObjectTableContent: React.FC<Props> = props => {
             manuallyCreated={object._manuallyCreated}
             handleClickDownload={handleClickDownload}
             handleClickDelete={handleClickDelete}
+            handleClickDetails={() => handleClickDetails(object)}
           />
         );
       })}

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableContent.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableContent.tsx
@@ -21,6 +21,7 @@ interface Props {
   prefix: string;
   handleClickDownload: (objectName: string, newTab: boolean) => void;
   handleClickDelete: (objectName: string) => void;
+  handleClickDetails: (object: ExtendedObject) => void;
 }
 
 const ObjectTableContent: React.FC<Props> = props => {
@@ -30,7 +31,8 @@ const ObjectTableContent: React.FC<Props> = props => {
     error,
     prefix,
     handleClickDownload,
-    handleClickDelete
+    handleClickDelete,
+    handleClickDetails
   } = props;
 
   const flags = useFlags();
@@ -124,6 +126,7 @@ const ObjectTableContent: React.FC<Props> = props => {
             manuallyCreated={object._manuallyCreated}
             handleClickDownload={handleClickDownload}
             handleClickDelete={handleClickDelete}
+            handleClickDetails={() => handleClickDetails(object)}
           />
         ) : (
           <ObjectTableRow

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableRow.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableRow.tsx
@@ -38,6 +38,7 @@ interface Props {
   objectLastModified: string;
   handleClickDownload: (objectName: string, newTab: boolean) => void;
   handleClickDelete: (objectName: string) => void;
+  handleClickDetails: () => void;
   manuallyCreated: boolean;
 }
 
@@ -49,6 +50,7 @@ const ObjectTableRow: React.FC<Props> = props => {
     objectLastModified,
     handleClickDownload,
     handleClickDelete,
+    handleClickDetails,
     manuallyCreated
   } = props;
 
@@ -58,6 +60,7 @@ const ObjectTableRow: React.FC<Props> = props => {
     <TableRow
       ariaLabel={displayName}
       className={manuallyCreated ? classes.manuallyCreated : ''}
+      rowLink={handleClickDetails}
     >
       <TableCell>
         <Grid container wrap="nowrap" alignItems="center">
@@ -85,6 +88,7 @@ const ObjectTableRow: React.FC<Props> = props => {
         <ObjectActionMenu
           handleClickDownload={handleClickDownload}
           handleClickDelete={handleClickDelete}
+          handleClickDetails={handleClickDetails}
           objectName={fullName}
         />
       </TableCell>

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableRow_CMR.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableRow_CMR.tsx
@@ -45,6 +45,7 @@ interface Props {
   objectLastModified: string;
   handleClickDownload: (objectName: string, newTab: boolean) => void;
   handleClickDelete: (objectName: string) => void;
+  handleClickDetails: () => void;
   manuallyCreated: boolean;
 }
 
@@ -56,6 +57,7 @@ const ObjectTableRow: React.FC<Props> = props => {
     objectLastModified,
     handleClickDownload,
     handleClickDelete,
+    handleClickDetails,
     manuallyCreated
   } = props;
 
@@ -94,6 +96,7 @@ const ObjectTableRow: React.FC<Props> = props => {
         <ObjectActionMenu
           handleClickDownload={handleClickDownload}
           handleClickDelete={handleClickDelete}
+          handleClickDetails={handleClickDetails}
           objectName={fullName}
         />
       </TableCell>

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableRow_CMR.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableRow_CMR.tsx
@@ -35,6 +35,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     alignItems: 'center',
     justifyContent: 'flex-end',
     padding: 0
+  },
+  objectNameButton: {
+    ...theme.applyLinkStyles
   }
 }));
 
@@ -80,7 +83,12 @@ const ObjectTableRow: React.FC<Props> = props => {
           <Grid item>
             <Box display="flex" alignItems="center">
               <Typography>
-                <strong>{displayName}</strong>
+                <button
+                  className={classes.objectNameButton}
+                  onClick={handleClickDetails}
+                >
+                  <strong>{displayName}</strong>
+                </button>
               </Typography>
             </Box>
           </Grid>


### PR DESCRIPTION
## Description

This adds the Object Details Drawer.

![Screen Shot 2020-09-16 at 7 00 30 AM](https://user-images.githubusercontent.com/16911484/93328888-59d8a680-f7ea-11ea-8242-93df11ab0fba.png)

It's accessible by a new action menu item ("Details") and by clicking the row (non-CMR) or Object name (CMR).

**Note:** we're waiting on API work to be able to do the "Enable Public URL" toggle in the designs. 

Another deviation from the designs: I didn't include the "Open" link at the bottom, since clicking on the URL does the thing you'd expect.

## Type of Change
- Non breaking change ('update', 'change')
