### PR TITLE
M3-4478 Add: access management for OBJ access keys

### DIFF
--- a/packages/api-v4/src/object-storage/types.ts
+++ b/packages/api-v4/src/object-storage/types.ts
@@ -5,7 +5,7 @@ export interface ObjectStorageKey {
   secret_key: string;
 }
 
-export type AccessType = 'read-only' | 'read-write' | 'none';
+export type AccessType = 'read_only' | 'read_write' | 'none';
 export interface Scope {
   bucket: string;
   cluster: string;

--- a/packages/api-v4/src/object-storage/types.ts
+++ b/packages/api-v4/src/object-storage/types.ts
@@ -16,7 +16,7 @@ export interface Scope {
 
 export interface ObjectStorageKeyRequest {
   label: string;
-  bucket_access?: Scope[]; // sent only when creating a limited access key
+  bucket_access: Scope[] | null;
 }
 
 export interface ObjectStorageBucketRequestPayload {

--- a/packages/api-v4/src/object-storage/types.ts
+++ b/packages/api-v4/src/object-storage/types.ts
@@ -3,18 +3,20 @@ export interface ObjectStorageKey {
   id: number;
   label: string;
   secret_key: string;
+  limited: boolean;
+  bucket_access: Scope[] | null;
 }
 
 export type AccessType = 'read_only' | 'read_write' | 'none';
 export interface Scope {
-  bucket: string;
+  bucket_name: string;
   cluster: string;
-  access: AccessType;
+  permissions: AccessType;
 }
 
 export interface ObjectStorageKeyRequest {
   label: string;
-  permissions?: Scope[]; // sent only when creating a limited access key
+  bucket_access?: Scope[]; // sent only when creating a limited access key
 }
 
 export interface ObjectStorageBucketRequestPayload {

--- a/packages/api-v4/src/object-storage/types.ts
+++ b/packages/api-v4/src/object-storage/types.ts
@@ -5,8 +5,16 @@ export interface ObjectStorageKey {
   secret_key: string;
 }
 
+export type AccessType = 'read-only' | 'read-write' | 'none';
+export interface Scope {
+  bucket: string;
+  cluster: string;
+  access: AccessType;
+}
+
 export interface ObjectStorageKeyRequest {
   label: string;
+  permissions?: Scope[]; // sent only when creating a limited access key
 }
 
 export interface ObjectStorageBucketRequestPayload {

--- a/packages/manager/src/__data__/objectStorageKeys.ts
+++ b/packages/manager/src/__data__/objectStorageKeys.ts
@@ -4,21 +4,27 @@ export const objectStorageKey1: ObjectStorageKey = {
   id: 1,
   label: 'test-obj-storage-key-01',
   access_key: '123ABC',
-  secret_key: '[REDACTED]'
+  secret_key: '[REDACTED]',
+  limited: false,
+  bucket_access: null
 };
 
 export const objectStorageKey2: ObjectStorageKey = {
   id: 2,
   label: 'test-obj-storage-key-02',
   access_key: '234BCD',
-  secret_key: '[REDACTED]'
+  secret_key: '[REDACTED]',
+  limited: false,
+  bucket_access: null
 };
 
 export const objectStorageKey3: ObjectStorageKey = {
   id: 3,
   label: 'test-obj-storage-key-03',
   access_key: '345CDE',
-  secret_key: '[REDACTED]'
+  secret_key: '[REDACTED]',
+  limited: false,
+  bucket_access: null
 };
 
 export default [objectStorageKey1, objectStorageKey2, objectStorageKey3];

--- a/packages/manager/src/components/TableRow/TableRow_CMR.tsx
+++ b/packages/manager/src/components/TableRow/TableRow_CMR.tsx
@@ -171,6 +171,9 @@ export const TableRow: React.FC<CombinedProps> = props => {
   );
 };
 
-const enhanced = compose<CombinedProps, Props>(withRouter)(TableRow);
+const enhanced = compose<CombinedProps, Props>(
+  withRouter,
+  React.memo
+)(TableRow);
 
 export default enhanced;

--- a/packages/manager/src/features/Account/AutoBackups.tsx
+++ b/packages/manager/src/features/Account/AutoBackups.tsx
@@ -57,79 +57,77 @@ const AutoBackups: React.FC<CombinedProps> = props => {
   } = props;
 
   return (
-    <React.Fragment>
-      <ExpansionPanel heading="Backup Auto Enrollment" defaultExpanded={true}>
-        <Grid container direction="column" className={classes.root}>
-          <Grid item>
-            <Typography variant="h2">
-              Back Up All New Linodes
-              {!!isManagedCustomer && (
-                <HelpIcon
-                  className={classes.toolTip}
-                  text={`You're a Managed customer, which means your Linodes are already automatically
+    <ExpansionPanel heading="Backup Auto Enrollment" defaultExpanded={true}>
+      <Grid container direction="column" className={classes.root}>
+        <Grid item>
+          <Typography variant="h2">
+            Back Up All New Linodes
+            {!!isManagedCustomer && (
+              <HelpIcon
+                className={classes.toolTip}
+                text={`You're a Managed customer, which means your Linodes are already automatically
               backed up - no need to toggle this setting.`}
-                />
-              )}
-            </Typography>
-          </Grid>
+              />
+            )}
+          </Typography>
+        </Grid>
+        <Grid item>
+          <Typography variant="body1">
+            This controls whether Linode Backups are enabled, by default, for
+            all Linodes when they are initially created. For each Linode with
+            Backups enabled, your account will be billed the additional hourly
+            rate noted on the
+            <a
+              data-qa-backups-price
+              href="https://linode.com/backups"
+              target="_blank"
+              aria-describedby="external-site"
+              rel="noopener noreferrer"
+            >
+              {` Backups pricing page`}
+              <OpenInNew className={classes.icon} />
+            </a>
+            .
+          </Typography>
+        </Grid>
+        <Grid item container direction="row" alignItems="center">
           <Grid item>
-            <Typography variant="body1">
-              This controls whether Linode Backups are enabled, by default, for
-              all Linodes when they are initially created. For each Linode with
-              Backups enabled, your account will be billed the additional hourly
-              rate noted on the
-              <a
-                data-qa-backups-price
-                href="https://linode.com/backups"
-                target="_blank"
-                aria-describedby="external-site"
-                rel="noopener noreferrer"
+            <FormControlLabel
+              // className="toggleLabel"
+              control={
+                <Toggle
+                  onChange={onChange}
+                  checked={!!isManagedCustomer ? true : backups_enabled}
+                  data-qa-toggle-auto-backup
+                  disabled={!!isManagedCustomer}
+                />
+              }
+              label={
+                backups_enabled || isManagedCustomer
+                  ? 'Enabled (Auto enroll all new Linodes in Backups)'
+                  : "Disabled (Don't enroll new Linodes in Backups automatically)"
+              }
+            />
+          </Grid>
+        </Grid>
+        {!isManagedCustomer && !backups_enabled && hasLinodesWithoutBackups && (
+          <Grid item>
+            <Typography variant="body1" className={classes.footnote}>
+              {`For existing Linodes without backups, `}
+              <button
+                data-qa-backup-existing
+                className={classes.link}
+                onClick={openBackupsDrawer}
+                title="enable now"
               >
-                {` Backups pricing page`}
-                <OpenInNew className={classes.icon} />
-              </a>
+                enable now
+              </button>
               .
             </Typography>
           </Grid>
-          <Grid item container direction="row" alignItems="center">
-            <Grid item>
-              <FormControlLabel
-                // className="toggleLabel"
-                control={
-                  <Toggle
-                    onChange={onChange}
-                    checked={!!isManagedCustomer ? true : backups_enabled}
-                    data-qa-toggle-auto-backup
-                    disabled={!!isManagedCustomer}
-                  />
-                }
-                label={
-                  backups_enabled || isManagedCustomer
-                    ? 'Enabled (Auto enroll all new Linodes in Backups)'
-                    : "Disabled (Don't enroll new Linodes in Backups automatically)"
-                }
-              />
-            </Grid>
-          </Grid>
-          {!isManagedCustomer && !backups_enabled && hasLinodesWithoutBackups && (
-            <Grid item>
-              <Typography variant="body1" className={classes.footnote}>
-                {`For existing Linodes without backups, `}
-                <button
-                  data-qa-backup-existing
-                  className={classes.link}
-                  onClick={openBackupsDrawer}
-                  title="enable now"
-                >
-                  enable now
-                </button>
-                .
-              </Typography>
-            </Grid>
-          )}
-        </Grid>
-      </ExpansionPanel>
-    </React.Fragment>
+        )}
+      </Grid>
+    </ExpansionPanel>
   );
 };
 

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDisplayDialog.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDisplayDialog.tsx
@@ -56,7 +56,7 @@ export const AccessKeyDisplayDialog: React.FC<CombinedProps> = props => {
       <Typography variant="body1" className={classes.helperText}>
         Your keys have been generated. For security purposes, we can only
         display your Secret Key once, after which it can’t be recovered.{' '}
-        <strong>Be sure to keep it in a safe place</strong>
+        <strong>Be sure to keep it in a safe place.</strong>
       </Typography>
 
       <Typography>

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.test.tsx
@@ -1,3 +1,4 @@
+import { Scope } from '@linode/api-v4/lib/object-storage/types';
 import { screen } from '@testing-library/react';
 import * as React from 'react';
 import { objectStorageBucketFactory } from 'src/factories/objectStorage';
@@ -5,6 +6,7 @@ import { renderWithTheme } from 'src/utilities/testHelpers';
 import {
   AccessKeyDrawer,
   getDefaultScopes,
+  getUpdatedScopes,
   MODES,
   Props
 } from './AccessKeyDrawer';
@@ -51,6 +53,37 @@ describe('AccessKeyDrawer', () => {
       expect(
         getDefaultScopes(unsortedBuckets).map(scope => scope.cluster)
       ).toEqual(['ap-south-1', 'eu-central-1', 'us-east-1']);
+    });
+  });
+
+  describe('Updating scopes', () => {
+    const mockBuckets = objectStorageBucketFactory.buildList(3);
+
+    const mockScopes = getDefaultScopes(mockBuckets);
+
+    it('should update the correct scope', () => {
+      const newScope = { ...mockScopes[2], access: 'read-write' } as Scope;
+      expect(getUpdatedScopes(mockScopes, newScope)[2]).toHaveProperty(
+        'access',
+        'read-write'
+      );
+    });
+
+    it('should leave other scopes unchanged', () => {
+      const newScope = { ...mockScopes[2], access: 'read-write' } as Scope;
+      const updatedScopes = getUpdatedScopes(mockScopes, newScope);
+      expect(updatedScopes[0]).toEqual(mockScopes[0]);
+      expect(updatedScopes[1]).toEqual(mockScopes[1]);
+      expect(updatedScopes.length).toEqual(mockScopes.length);
+    });
+
+    it('should handle crappy input', () => {
+      const newScope = {
+        cluster: 'totally-fake',
+        bucket: 'not-real',
+        access: 'read-only'
+      } as Scope;
+      expect(getUpdatedScopes(mockScopes, newScope)).toEqual(mockScopes);
     });
   });
 });

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.test.tsx
@@ -1,7 +1,13 @@
 import { screen } from '@testing-library/react';
 import * as React from 'react';
+import { objectStorageBucketFactory } from 'src/factories/objectStorage';
 import { renderWithTheme } from 'src/utilities/testHelpers';
-import { AccessKeyDrawer, MODES, Props } from './AccessKeyDrawer';
+import {
+  AccessKeyDrawer,
+  getDefaultScopes,
+  MODES,
+  Props
+} from './AccessKeyDrawer';
 
 describe('AccessKeyDrawer', () => {
   const props: Props = {
@@ -14,5 +20,37 @@ describe('AccessKeyDrawer', () => {
   renderWithTheme(<AccessKeyDrawer {...props} />);
   it('renders without crashing', () => {
     expect(screen.getByText(/create an access key/i)).toBeInTheDocument();
+  });
+
+  describe('default scopes helper method', () => {
+    const mockBuckets = objectStorageBucketFactory.buildList(5);
+    it('should return an item for each bucket', () => {
+      expect(getDefaultScopes(mockBuckets)).toHaveLength(mockBuckets.length);
+    });
+
+    it('should return objects with the correct shape', () => {
+      const bucket = mockBuckets[0];
+      expect(getDefaultScopes([bucket])[0]).toEqual({
+        cluster: bucket.cluster,
+        bucket: bucket.label,
+        access: 'none'
+      });
+    });
+
+    it('should sort the permissions by cluster', () => {
+      const usaBucket = objectStorageBucketFactory.build({
+        cluster: 'us-east-1'
+      });
+      const germanBucket = objectStorageBucketFactory.build({
+        cluster: 'eu-central-1'
+      });
+      const asiaBucket = objectStorageBucketFactory.build({
+        cluster: 'ap-south-1'
+      });
+      const unsortedBuckets = [usaBucket, germanBucket, asiaBucket];
+      expect(
+        getDefaultScopes(unsortedBuckets).map(scope => scope.cluster)
+      ).toEqual(['ap-south-1', 'eu-central-1', 'us-east-1']);
+    });
   });
 });

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.test.tsx
@@ -34,8 +34,8 @@ describe('AccessKeyDrawer', () => {
       const bucket = mockBuckets[0];
       expect(getDefaultScopes([bucket])[0]).toEqual({
         cluster: bucket.cluster,
-        bucket: bucket.label,
-        access: 'none'
+        bucket_name: bucket.label,
+        permissions: 'none'
       });
     });
 
@@ -62,9 +62,9 @@ describe('AccessKeyDrawer', () => {
     const mockScopes = getDefaultScopes(mockBuckets);
 
     it('should update the correct scope', () => {
-      const newScope = { ...mockScopes[2], access: 'read_write' } as Scope;
+      const newScope = { ...mockScopes[2], permissions: 'read_write' } as Scope;
       expect(getUpdatedScopes(mockScopes, newScope)[2]).toHaveProperty(
-        'access',
+        'permissions',
         'read-write'
       );
     });
@@ -80,8 +80,8 @@ describe('AccessKeyDrawer', () => {
     it('should handle crappy input', () => {
       const newScope = {
         cluster: 'totally-fake',
-        bucket: 'not-real',
-        access: 'read_only'
+        bucket_name: 'not-real',
+        permissions: 'read_only'
       } as Scope;
       expect(getUpdatedScopes(mockScopes, newScope)).toEqual(mockScopes);
     });

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.test.tsx
@@ -62,7 +62,7 @@ describe('AccessKeyDrawer', () => {
     const mockScopes = getDefaultScopes(mockBuckets);
 
     it('should update the correct scope', () => {
-      const newScope = { ...mockScopes[2], access: 'read-write' } as Scope;
+      const newScope = { ...mockScopes[2], access: 'read_write' } as Scope;
       expect(getUpdatedScopes(mockScopes, newScope)[2]).toHaveProperty(
         'access',
         'read-write'
@@ -70,7 +70,7 @@ describe('AccessKeyDrawer', () => {
     });
 
     it('should leave other scopes unchanged', () => {
-      const newScope = { ...mockScopes[2], access: 'read-write' } as Scope;
+      const newScope = { ...mockScopes[2], access: 'read_write' } as Scope;
       const updatedScopes = getUpdatedScopes(mockScopes, newScope);
       expect(updatedScopes[0]).toEqual(mockScopes[0]);
       expect(updatedScopes[1]).toEqual(mockScopes[1]);
@@ -81,7 +81,7 @@ describe('AccessKeyDrawer', () => {
       const newScope = {
         cluster: 'totally-fake',
         bucket: 'not-real',
-        access: 'read-only'
+        access: 'read_only'
       } as Scope;
       expect(getUpdatedScopes(mockScopes, newScope)).toEqual(mockScopes);
     });

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.test.tsx
@@ -65,7 +65,7 @@ describe('AccessKeyDrawer', () => {
       const newScope = { ...mockScopes[2], permissions: 'read_write' } as Scope;
       expect(getUpdatedScopes(mockScopes, newScope)[2]).toHaveProperty(
         'permissions',
-        'read-write'
+        'read_write'
       );
     });
 

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.test.tsx
@@ -6,10 +6,10 @@ import { renderWithTheme } from 'src/utilities/testHelpers';
 import {
   AccessKeyDrawer,
   getDefaultScopes,
-  getUpdatedScopes,
   MODES,
   Props
 } from './AccessKeyDrawer';
+import { getUpdatedScopes } from './LimitedAccessControls';
 
 describe('AccessKeyDrawer', () => {
   const props: Props = {

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.test.tsx
@@ -1,23 +1,18 @@
-import { shallow } from 'enzyme';
-import { AccountSettings } from '@linode/api-v4/lib/account';
+import { screen } from '@testing-library/react';
 import * as React from 'react';
+import { renderWithTheme } from 'src/utilities/testHelpers';
 import { AccessKeyDrawer, MODES, Props } from './AccessKeyDrawer';
 
 describe('AccessKeyDrawer', () => {
-  const props = {
-    classes: { root: '' },
+  const props: Props = {
     open: true,
     onSubmit: jest.fn(),
     onClose: jest.fn(),
-    label: 'test-label',
-    updateLabel: jest.fn(),
-    isLoading: false,
     mode: 'creating' as MODES,
-    isRestrictedUser: false,
-    object_storage: 'active' as AccountSettings['object_storage']
+    isRestrictedUser: false
   };
-  const wrapper = shallow<Props>(<AccessKeyDrawer {...props} />);
+  renderWithTheme(<AccessKeyDrawer {...props} />);
   it('renders without crashing', () => {
-    expect(wrapper).toHaveLength(1);
+    expect(screen.getByText(/create an access key/i)).toBeInTheDocument();
   });
 });

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
@@ -107,8 +107,16 @@ export const AccessKeyDrawer: React.FC<CombinedProps> = props => {
   const handleSubmit = (values: ObjectStorageKeyRequest, formikProps: any) => {
     // If the user hasn't toggled the Limited Access button,
     // don't include any bucket_access information in the payload.
+
+    // If any/all values are 'none', don't include them in the response.
+    const access = values.bucket_access ?? [];
     const payload = limitedAccessChecked
-      ? values
+      ? {
+          ...values,
+          bucket_access: access.filter(
+            thisAccess => thisAccess.permissions !== 'none'
+          )
+        }
       : { ...values, bucket_access: null };
 
     return onSubmit(payload, formikProps);

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
@@ -7,7 +7,6 @@ import {
   ObjectStorageKeyRequest,
   Scope
 } from '@linode/api-v4/lib/object-storage';
-import { update } from 'ramda';
 import * as React from 'react';
 import { useSelector } from 'react-redux';
 import ActionsPanel from 'src/components/ActionsPanel';
@@ -65,22 +64,6 @@ export const getDefaultScopes = (buckets: ObjectStorageBucket[]): Scope[] =>
       access: 'none' as AccessType
     }))
     .sort(sortByCluster);
-
-export const getUpdatedScopes = (
-  oldScopes: Scope[],
-  newScope: Scope
-): Scope[] => {
-  // Cluster and bucket together form a primary key
-  const scopeToUpdate = oldScopes.findIndex(
-    thisScope =>
-      thisScope.bucket === newScope.bucket &&
-      thisScope.cluster === newScope.cluster
-  );
-  if (scopeToUpdate < 0) {
-    return oldScopes;
-  }
-  return update(scopeToUpdate, newScope, oldScopes);
-};
 
 export const AccessKeyDrawer: React.FC<CombinedProps> = props => {
   const {
@@ -142,8 +125,7 @@ export const AccessKeyDrawer: React.FC<CombinedProps> = props => {
             );
           };
 
-          const handleScopeUpdate = (newScope: Scope) => {
-            const newScopes = getUpdatedScopes(values.scopes ?? [], newScope);
+          const handleScopeUpdate = (newScopes: Scope[]) => {
             setFieldValue('scopes', newScopes);
           };
 

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
@@ -17,6 +17,7 @@ import TextField from 'src/components/TextField';
 import { ApplicationState } from 'src/store';
 import EnableObjectStorageModal from '../EnableObjectStorageModal';
 import { confirmObjectStorage } from '../utilities';
+import LimitedAccessControls from './LimitedAccessControls';
 
 export type MODES = 'creating' | 'editing';
 
@@ -51,6 +52,9 @@ export const AccessKeyDrawer: React.FC<CombinedProps> = props => {
   } = props;
 
   const [dialogOpen, setDialogOpen] = React.useState<boolean>(false);
+  // This is for local display management only, not part of the payload
+  // and so not included in Formik's types
+  const [limitedAccessChecked, setLimitedAccessChecked] = React.useState(false);
 
   const title =
     mode === 'creating' ? 'Create an Access Key' : 'Edit Access Key';
@@ -131,6 +135,12 @@ export const AccessKeyDrawer: React.FC<CombinedProps> = props => {
                 onChange={handleChange}
                 onBlur={handleBlur}
                 disabled={isRestrictedUser}
+              />
+              <LimitedAccessControls
+                handleToggle={() =>
+                  setLimitedAccessChecked(checked => !checked)
+                }
+                checked={limitedAccessChecked}
               />
               <ActionsPanel>
                 <Button

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
@@ -37,7 +37,7 @@ type CombinedProps = Props;
 
 interface FormState {
   label: string;
-  bucket_access?: Scope[];
+  bucket_access: Scope[] | null;
 }
 
 /**
@@ -87,6 +87,12 @@ export const AccessKeyDrawer: React.FC<CombinedProps> = props => {
   // and so not included in Formik's types
   const [limitedAccessChecked, setLimitedAccessChecked] = React.useState(false);
 
+  React.useEffect(() => {
+    if (open) {
+      setLimitedAccessChecked(false);
+    }
+  }, [open]);
+
   const title =
     mode === 'creating' ? 'Create an Access Key' : 'Edit Access Key';
 
@@ -103,7 +109,7 @@ export const AccessKeyDrawer: React.FC<CombinedProps> = props => {
     // don't include any bucket_access information in the payload.
     const payload = limitedAccessChecked
       ? values
-      : { ...values, bucket_access: undefined };
+      : { ...values, bucket_access: null };
 
     return onSubmit(payload, formikProps);
   };

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
@@ -46,7 +46,7 @@ interface FormState {
  * permissions in the shape the API will expect,
  * sorted by cluster.
  */
-const sortByCluster = (a: Scope, b: Scope) => {
+export const sortByCluster = (a: Scope, b: Scope) => {
   if (a.cluster > b.cluster) {
     return 1;
   }

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
@@ -67,7 +67,7 @@ export const AccessKeyDrawer: React.FC<CombinedProps> = props => {
   };
 
   return (
-    <Drawer title={title} open={open} onClose={onClose}>
+    <Drawer title={title} open={open} onClose={onClose} wide>
       <Formik
         initialValues={initialValues}
         validationSchema={createObjectStorageKeysSchema}
@@ -137,6 +137,7 @@ export const AccessKeyDrawer: React.FC<CombinedProps> = props => {
                 disabled={isRestrictedUser}
               />
               <LimitedAccessControls
+                mode={mode}
                 handleToggle={() =>
                   setLimitedAccessChecked(checked => !checked)
                 }

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
@@ -37,13 +37,13 @@ type CombinedProps = Props;
 
 interface FormState {
   label: string;
-  permissions?: Scope[];
+  bucket_access?: Scope[];
 }
 
 /**
  * Helpers for converting a list of buckets
  * on the user's account into a list of
- * permissions in the shape the API will expect,
+ * bucket_access in the shape the API will expect,
  * sorted by cluster.
  */
 export const sortByCluster = (a: Scope, b: Scope) => {
@@ -60,8 +60,8 @@ export const getDefaultScopes = (buckets: ObjectStorageBucket[]): Scope[] =>
   buckets
     .map(thisBucket => ({
       cluster: thisBucket.cluster,
-      bucket: thisBucket.label,
-      access: 'none' as AccessType
+      bucket_name: thisBucket.label,
+      permissions: 'none' as AccessType
     }))
     .sort(sortByCluster);
 
@@ -95,15 +95,15 @@ export const AccessKeyDrawer: React.FC<CombinedProps> = props => {
 
   const initialValues: FormState = {
     label: initialLabelValue,
-    permissions: getDefaultScopes(buckets.data)
+    bucket_access: getDefaultScopes(buckets.data)
   };
 
   const handleSubmit = (values: ObjectStorageKeyRequest, formikProps: any) => {
     // If the user hasn't toggled the Limited Access button,
-    // don't include any permissions information in the payload.
+    // don't include any bucket_access information in the payload.
     const payload = limitedAccessChecked
       ? values
-      : { ...values, permissions: undefined };
+      : { ...values, bucket_access: undefined };
 
     return onSubmit(payload, formikProps);
   };
@@ -136,7 +136,7 @@ export const AccessKeyDrawer: React.FC<CombinedProps> = props => {
           };
 
           const handleScopeUpdate = (newScopes: Scope[]) => {
-            setFieldValue('permissions', newScopes);
+            setFieldValue('bucket_access', newScopes);
           };
 
           return (
@@ -149,7 +149,7 @@ export const AccessKeyDrawer: React.FC<CombinedProps> = props => {
                 <Notice
                   error
                   important
-                  text="You don't have permissions to create an Access Key. Please contact an account administrator for details."
+                  text="You don't have bucket_access to create an Access Key. Please contact an account administrator for details."
                 />
               )}
 
@@ -183,7 +183,7 @@ export const AccessKeyDrawer: React.FC<CombinedProps> = props => {
               />
               <LimitedAccessControls
                 mode={mode}
-                permissions={values.permissions}
+                bucket_access={values.bucket_access}
                 updateScopes={handleScopeUpdate}
                 handleToggle={() =>
                   setLimitedAccessChecked(checked => !checked)

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
@@ -145,6 +145,12 @@ export const AccessKeyDrawer: React.FC<CombinedProps> = props => {
             setFieldValue('bucket_access', newScopes);
           };
 
+          const handleToggleAccess = () => {
+            setLimitedAccessChecked(checked => !checked);
+            // Reset scopes
+            setFieldValue('bucket_access', getDefaultScopes(buckets.data));
+          };
+
           return (
             <>
               {status && (
@@ -191,9 +197,7 @@ export const AccessKeyDrawer: React.FC<CombinedProps> = props => {
                 mode={mode}
                 bucket_access={values.bucket_access}
                 updateScopes={handleScopeUpdate}
-                handleToggle={() =>
-                  setLimitedAccessChecked(checked => !checked)
-                }
+                handleToggle={handleToggleAccess}
                 checked={limitedAccessChecked}
               />
               <ActionsPanel>

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
@@ -1,5 +1,4 @@
 import { Formik } from 'formik';
-import { AccountSettings } from '@linode/api-v4/lib/account';
 import {
   AccessType,
   createObjectStorageKeysSchema,
@@ -8,9 +7,8 @@ import {
   ObjectStorageKeyRequest,
   Scope
 } from '@linode/api-v4/lib/object-storage';
-import { pathOr } from 'ramda';
 import * as React from 'react';
-import { connect } from 'react-redux';
+import { useSelector } from 'react-redux';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import Typography from 'src/components/core/Typography';
@@ -35,11 +33,7 @@ export interface Props {
   isRestrictedUser: boolean;
 }
 
-interface ReduxStateProps {
-  object_storage: AccountSettings['object_storage'];
-}
-
-type CombinedProps = Props & ReduxStateProps;
+type CombinedProps = Props;
 
 interface FormState {
   label: string;
@@ -81,6 +75,11 @@ export const AccessKeyDrawer: React.FC<CombinedProps> = props => {
     objectStorageKey
   } = props;
 
+  const object_storage = useSelector(
+    (state: ApplicationState) =>
+      state.__resources.accountSettings.data?.object_storage ?? 'disabled'
+  );
+
   const { objectStorageBuckets: buckets } = useBuckets();
 
   const [dialogOpen, setDialogOpen] = React.useState<boolean>(false);
@@ -120,10 +119,8 @@ export const AccessKeyDrawer: React.FC<CombinedProps> = props => {
           } = formikProps;
 
           const beforeSubmit = () => {
-            confirmObjectStorage<FormState>(
-              props.object_storage,
-              formikProps,
-              () => setDialogOpen(true)
+            confirmObjectStorage<FormState>(object_storage, formikProps, () =>
+              setDialogOpen(true)
             );
           };
 
@@ -209,16 +206,4 @@ export const AccessKeyDrawer: React.FC<CombinedProps> = props => {
   );
 };
 
-const mapStateToProps = (state: ApplicationState) => {
-  return {
-    object_storage: pathOr<AccountSettings['object_storage']>(
-      'disabled',
-      ['data', 'object_storage'],
-      state.__resources.accountSettings
-    )
-  };
-};
-
-const connected = connect(mapStateToProps);
-
-export default connected(AccessKeyDrawer);
+export default React.memo(AccessKeyDrawer);

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
@@ -37,7 +37,7 @@ type CombinedProps = Props;
 
 interface FormState {
   label: string;
-  scopes?: Scope[];
+  permissions?: Scope[];
 }
 
 /**
@@ -95,7 +95,17 @@ export const AccessKeyDrawer: React.FC<CombinedProps> = props => {
 
   const initialValues: FormState = {
     label: initialLabelValue,
-    scopes: getDefaultScopes(buckets.data)
+    permissions: getDefaultScopes(buckets.data)
+  };
+
+  const handleSubmit = (values: ObjectStorageKeyRequest, formikProps: any) => {
+    // If the user hasn't toggled the Limited Access button,
+    // don't include any permissions information in the payload.
+    const payload = limitedAccessChecked
+      ? values
+      : { ...values, permissions: undefined };
+
+    return onSubmit(payload, formikProps);
   };
 
   return (
@@ -105,7 +115,7 @@ export const AccessKeyDrawer: React.FC<CombinedProps> = props => {
         validationSchema={createObjectStorageKeysSchema}
         validateOnChange={false}
         validateOnBlur={true}
-        onSubmit={onSubmit}
+        onSubmit={handleSubmit}
       >
         {formikProps => {
           const {
@@ -126,7 +136,7 @@ export const AccessKeyDrawer: React.FC<CombinedProps> = props => {
           };
 
           const handleScopeUpdate = (newScopes: Scope[]) => {
-            setFieldValue('scopes', newScopes);
+            setFieldValue('permissions', newScopes);
           };
 
           return (
@@ -173,7 +183,7 @@ export const AccessKeyDrawer: React.FC<CombinedProps> = props => {
               />
               <LimitedAccessControls
                 mode={mode}
-                scopes={values.scopes}
+                permissions={values.permissions}
                 updateScopes={handleScopeUpdate}
                 handleToggle={() =>
                   setLimitedAccessChecked(checked => !checked)

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/LimitedAccessControls.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/LimitedAccessControls.tsx
@@ -13,6 +13,7 @@ interface Props {
   mode: 'creating' | 'editing';
   checked: boolean;
   scopes?: Scope[];
+  updateScopes: (newScope: Scope) => void;
   handleToggle: () => void;
 }
 
@@ -40,7 +41,7 @@ interface Props {
 // ];
 
 export const LimitedAccessControls: React.FC<Props> = props => {
-  const { checked, handleToggle, mode, scopes } = props;
+  const { checked, handleToggle, ...rest } = props;
   return (
     <>
       <FormControlLabel
@@ -53,7 +54,7 @@ export const LimitedAccessControls: React.FC<Props> = props => {
         }
         label={'Limited Access'}
       />
-      <AccessTable mode={mode} scopes={scopes ?? []} />
+      <AccessTable {...rest} />
     </>
   );
 };
@@ -62,11 +63,16 @@ export default React.memo(LimitedAccessControls);
 
 interface TableProps {
   mode: 'creating' | 'editing';
-  scopes: Scope[];
+  scopes?: Scope[];
+  updateScopes: (newScope: Scope) => void;
 }
 
 const AccessTable: React.FC<TableProps> = props => {
-  const { mode, scopes } = props;
+  const { mode, scopes, updateScopes } = props;
+  if (!scopes) {
+    return null;
+  }
+
   return (
     <Table
       aria-label="Personal Access Token Permissions"
@@ -184,7 +190,9 @@ const AccessTable: React.FC<TableProps> = props => {
                   disabled={mode !== 'creating' && thisScope.access !== 'none'}
                   checked={thisScope.access === 'none'}
                   value="none"
-                  onChange={() => null}
+                  onChange={() =>
+                    updateScopes({ ...thisScope, access: 'none' })
+                  }
                   data-qa-perm-none-radio
                   inputProps={{
                     'aria-label': `no access for ${thisScope.cluster}`
@@ -203,7 +211,9 @@ const AccessTable: React.FC<TableProps> = props => {
                   }
                   checked={thisScope.access === 'read-only'}
                   value="read-only"
-                  onChange={() => null}
+                  onChange={() =>
+                    updateScopes({ ...thisScope, access: 'read-only' })
+                  }
                   data-qa-perm-read-radio
                   inputProps={{
                     'aria-label': `read-only for ${scopeName}`
@@ -220,7 +230,9 @@ const AccessTable: React.FC<TableProps> = props => {
                   disabled={mode !== 'creating'}
                   checked={thisScope.access === 'read-write'}
                   value="read-write"
-                  onChange={() => null}
+                  onChange={() =>
+                    updateScopes({ ...thisScope, access: 'read-write' })
+                  }
                   data-qa-perm-rw-radio
                   data-testid="perm-rw-radio"
                   inputProps={{

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/LimitedAccessControls.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/LimitedAccessControls.tsx
@@ -36,8 +36,8 @@ export const getUpdatedScopes = (
 
 export const SCOPES: Record<string, AccessType> = {
   none: 'none',
-  read: 'read-only',
-  write: 'read-write'
+  read: 'read_only',
+  write: 'read_write'
 };
 
 export const LimitedAccessControls: React.FC<Props> = props => {
@@ -144,10 +144,10 @@ const AccessTable: React.FC<TableProps> = props => {
             >
               <Radio
                 name="Select All"
-                checked={allScopesEqual('read-only')}
+                checked={allScopesEqual('read_only')}
                 value="read-only"
                 data-testid="set-all-read"
-                onChange={() => updateAllScopes('read-only')}
+                onChange={() => updateAllScopes('read_only')}
                 data-qa-perm-read-radio
                 inputProps={{
                   'aria-label': 'Select read-only for all'

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/LimitedAccessControls.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/LimitedAccessControls.tsx
@@ -3,17 +3,30 @@ import { update } from 'ramda';
 import * as React from 'react';
 import Toggle from 'src/components/Toggle';
 import FormControlLabel from 'src/components/core/FormControlLabel';
+import { makeStyles } from 'src/components/core/styles';
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
 import TableRow from 'src/components/core/TableRow';
 import Radio from 'src/components/Radio';
-import Table from 'src/components/Table';
-import TableCell from 'src/components/TableCell';
+import Table from 'src/components/Table/Table_CMR';
+import TableCell from 'src/components/TableCell/TableCell_CMR';
+
+const useStyles = makeStyles(() => ({
+  clusterCell: {
+    width: '25%'
+  },
+  bucketCell: {
+    width: '35%'
+  },
+  radioCell: {
+    width: '15%'
+  }
+}));
 
 interface Props {
   mode: 'creating' | 'editing';
   checked: boolean;
-  bucket_access?: Scope[];
+  bucket_access: Scope[] | null;
   updateScopes: (newScopes: Scope[]) => void;
   handleToggle: () => void;
 }
@@ -63,12 +76,15 @@ export default React.memo(LimitedAccessControls);
 
 interface TableProps {
   mode: 'creating' | 'editing';
-  bucket_access?: Scope[];
+  bucket_access: Scope[] | null;
   updateScopes: (newScopes: Scope[]) => void;
 }
 
 const AccessTable: React.FC<TableProps> = props => {
   const { mode, bucket_access, updateScopes } = props;
+
+  const classes = useStyles();
+
   if (!bucket_access) {
     return null;
   }
@@ -93,11 +109,7 @@ const AccessTable: React.FC<TableProps> = props => {
   };
 
   return (
-    <Table
-      aria-label="Personal Access Token Permissions"
-      // className={classes.permsTable}
-      spacingTop={24}
-    >
+    <Table aria-label="Personal Access Token Permissions" spacingTop={24}>
       <TableHead>
         <TableRow>
           <TableCell data-qa-perm-cluster>Cluster</TableCell>
@@ -110,23 +122,10 @@ const AccessTable: React.FC<TableProps> = props => {
       <TableBody>
         {mode === 'creating' && (
           <TableRow data-qa-row="Select All">
-            <TableCell
-              parentColumn="Cluster"
-              padding="checkbox"
-              // className={classes.selectCell}
-            >
-              Select All
+            <TableCell parentColumn="Cluster" padding="checkbox" colSpan={2}>
+              <strong>Select All</strong>
             </TableCell>
-            <TableCell
-              parentColumn="Bucket"
-              padding="checkbox"
-              // className={classes.selectCell}
-            />
-            <TableCell
-              parentColumn="None"
-              padding="checkbox"
-              // className={classes.noneCell}
-            >
+            <TableCell parentColumn="None" padding="checkbox">
               <Radio
                 name="Select All"
                 checked={allScopesEqual(SCOPES.none)}
@@ -139,11 +138,7 @@ const AccessTable: React.FC<TableProps> = props => {
                 }}
               />
             </TableCell>
-            <TableCell
-              parentColumn="Read Only"
-              padding="checkbox"
-              // className={classes.readOnlyCell}
-            >
+            <TableCell parentColumn="Read Only" padding="checkbox">
               <Radio
                 name="Select All"
                 checked={allScopesEqual('read_only')}
@@ -156,11 +151,7 @@ const AccessTable: React.FC<TableProps> = props => {
                 }}
               />
             </TableCell>
-            <TableCell
-              parentColumn="Read/Write"
-              padding="checkbox"
-              // className={classes.readWritecell}
-            >
+            <TableCell parentColumn="Read/Write" padding="checkbox">
               <Radio
                 name="Select All"
                 checked={allScopesEqual(SCOPES.write)}
@@ -179,25 +170,13 @@ const AccessTable: React.FC<TableProps> = props => {
           const scopeName = `${thisScope.cluster}-${thisScope.bucket_name}`;
           return (
             <TableRow key={scopeName} data-testid={scopeName}>
-              <TableCell
-                parentColumn="Cluster"
-                padding="checkbox"
-                // className={classes.accessCell}
-              >
+              <TableCell padding="checkbox" className={classes.clusterCell}>
                 {thisScope.cluster}
               </TableCell>
-              <TableCell
-                parentColumn="Bucket"
-                padding="checkbox"
-                // className={classes.accessCell}
-              >
+              <TableCell padding="checkbox" className={classes.bucketCell}>
                 {thisScope.bucket_name}
               </TableCell>
-              <TableCell
-                parentColumn="None"
-                padding="checkbox"
-                // className={classes.noneCell}
-              >
+              <TableCell padding="checkbox" className={classes.radioCell}>
                 <Radio
                   name={thisScope.bucket_name}
                   disabled={
@@ -217,11 +196,7 @@ const AccessTable: React.FC<TableProps> = props => {
                   }}
                 />
               </TableCell>
-              <TableCell
-                parentColumn="Read Only"
-                padding="checkbox"
-                // className={classes.readOnlyCell}
-              >
+              <TableCell padding="checkbox" className={classes.radioCell}>
                 <Radio
                   name={scopeName}
                   disabled={
@@ -241,11 +216,7 @@ const AccessTable: React.FC<TableProps> = props => {
                   }}
                 />
               </TableCell>
-              <TableCell
-                parentColumn="Read/Write"
-                padding="checkbox"
-                // className={classes.readWritecell}
-              >
+              <TableCell padding="checkbox" className={classes.radioCell}>
                 <Radio
                   name={scopeName}
                   disabled={mode !== 'creating'}

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/LimitedAccessControls.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/LimitedAccessControls.tsx
@@ -1,26 +1,241 @@
 import * as React from 'react';
 import Toggle from 'src/components/Toggle';
 import FormControlLabel from 'src/components/core/FormControlLabel';
+import TableBody from 'src/components/core/TableBody';
+import TableHead from 'src/components/core/TableHead';
+import TableRow from 'src/components/core/TableRow';
+import Radio from 'src/components/Radio';
+import Table from 'src/components/Table';
+import TableCell from 'src/components/TableCell';
 
 interface Props {
+  mode: 'creating' | 'editing';
   checked: boolean;
   handleToggle: () => void;
 }
 
+const fakeScopes = [
+  {
+    cluster: 'us-east-1',
+    bucket: 'bucket-name-1',
+    access: 'read-only'
+  },
+  {
+    cluster: 'us-east-1',
+    bucket: 'bucket-name-2',
+    access: 'read-write'
+  },
+  {
+    cluster: 'eu-central-1',
+    bucket: 'bucket-name-3',
+    access: 'none'
+  },
+  {
+    cluster: 'ap-south-1',
+    bucket: 'bucket-name-4',
+    access: 'none'
+  }
+];
+
 export const LimitedAccessControls: React.FC<Props> = props => {
-  const { checked, handleToggle } = props;
+  const { checked, handleToggle, mode } = props;
   return (
-    <FormControlLabel
-      control={
-        <Toggle
-          onChange={handleToggle}
-          checked={checked}
-          data-testid="limited-access-toggle"
-        />
-      }
-      label={'Limited Access'}
-    />
+    <>
+      <FormControlLabel
+        control={
+          <Toggle
+            onChange={handleToggle}
+            checked={checked}
+            data-testid="limited-access-toggle"
+          />
+        }
+        label={'Limited Access'}
+      />
+      <AccessTable mode={mode} scopes={fakeScopes as any} />
+    </>
   );
 };
 
 export default React.memo(LimitedAccessControls);
+
+export interface Scope {
+  bucket: string;
+  cluster: string;
+  access: 'read-only' | 'read-write' | 'none';
+}
+
+interface TableProps {
+  mode: 'creating' | 'editing';
+  scopes: Scope[];
+}
+
+const AccessTable: React.FC<TableProps> = props => {
+  const { mode, scopes } = props;
+  return (
+    <Table
+      aria-label="Personal Access Token Permissions"
+      // className={classes.permsTable}
+      spacingTop={24}
+    >
+      <TableHead>
+        <TableRow>
+          <TableCell data-qa-perm-cluster>Cluster</TableCell>
+          <TableCell data-qa-perm-bucket>Bucket</TableCell>
+          <TableCell data-qa-perm-none>None</TableCell>
+          <TableCell data-qa-perm-read>Read Only</TableCell>
+          <TableCell data-qa-perm-rw>Read/Write</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {mode === 'creating' && (
+          <TableRow data-qa-row="Select All">
+            <TableCell
+              parentColumn="Cluster"
+              padding="checkbox"
+              // className={classes.selectCell}
+            >
+              Select All
+            </TableCell>
+            <TableCell
+              parentColumn="Bucket"
+              padding="checkbox"
+              // className={classes.selectCell}
+            />
+            <TableCell
+              parentColumn="None"
+              padding="checkbox"
+              // className={classes.noneCell}
+            >
+              <Radio
+                name="Select All"
+                checked={
+                  false // selectAllSelectedScope === 0 && this.allScopesIdentical()
+                }
+                data-testid="set-all-none"
+                value="none"
+                onChange={() => null}
+                data-qa-perm-none-radio
+                inputProps={{
+                  'aria-label': 'Select none for all'
+                }}
+              />
+            </TableCell>
+            <TableCell
+              parentColumn="Read Only"
+              padding="checkbox"
+              // className={classes.readOnlyCell}
+            >
+              <Radio
+                name="Select All"
+                checked={
+                  false // selectAllSelectedScope === 1 && this.allScopesIdentical()
+                }
+                value="read-only"
+                data-testid="set-all-read"
+                onChange={() => null}
+                data-qa-perm-read-radio
+                inputProps={{
+                  'aria-label': 'Select read-only for all'
+                }}
+              />
+            </TableCell>
+            <TableCell
+              parentColumn="Read/Write"
+              padding="checkbox"
+              // className={classes.readWritecell}
+            >
+              <Radio
+                name="Select All"
+                checked={
+                  false // selectAllSelectedScope === 2 && this.allScopesIdentical()
+                }
+                data-testid="set-all-write"
+                value="read-write"
+                onChange={() => null}
+                data-qa-perm-rw-radio
+                inputProps={{
+                  'aria-label': 'Select read/write for all'
+                }}
+              />
+            </TableCell>
+          </TableRow>
+        )}
+        {scopes.map(thisScope => {
+          const scopeName = `${thisScope.cluster}-${thisScope.bucket}`;
+          return (
+            <TableRow key={scopeName} data-testid={scopeName}>
+              <TableCell
+                parentColumn="Cluster"
+                padding="checkbox"
+                // className={classes.accessCell}
+              >
+                {thisScope.cluster}
+              </TableCell>
+              <TableCell
+                parentColumn="Bucket"
+                padding="checkbox"
+                // className={classes.accessCell}
+              >
+                {thisScope.bucket}
+              </TableCell>
+              <TableCell
+                parentColumn="None"
+                padding="checkbox"
+                // className={classes.noneCell}
+              >
+                <Radio
+                  name={thisScope.bucket}
+                  disabled={mode !== 'creating' && thisScope.access !== 'none'}
+                  checked={thisScope.access === 'none'}
+                  value="none"
+                  onChange={() => null}
+                  data-qa-perm-none-radio
+                  inputProps={{
+                    'aria-label': `no access for ${thisScope.cluster}`
+                  }}
+                />
+              </TableCell>
+              <TableCell
+                parentColumn="Read Only"
+                padding="checkbox"
+                // className={classes.readOnlyCell}
+              >
+                <Radio
+                  name={scopeName}
+                  disabled={
+                    mode !== 'creating' && thisScope.access !== 'read-only'
+                  }
+                  checked={thisScope.access === 'read-only'}
+                  value="read-only"
+                  onChange={() => null}
+                  data-qa-perm-read-radio
+                  inputProps={{
+                    'aria-label': `read-only for ${scopeName}`
+                  }}
+                />
+              </TableCell>
+              <TableCell
+                parentColumn="Read/Write"
+                padding="checkbox"
+                // className={classes.readWritecell}
+              >
+                <Radio
+                  name={scopeName}
+                  disabled={mode !== 'creating'}
+                  checked={thisScope.access === 'read-write'}
+                  value="read-write"
+                  onChange={() => null}
+                  data-qa-perm-rw-radio
+                  data-testid="perm-rw-radio"
+                  inputProps={{
+                    'aria-label': `read/write for ${scopeName}`
+                  }}
+                />
+              </TableCell>
+            </TableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
+  );
+};

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/LimitedAccessControls.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/LimitedAccessControls.tsx
@@ -26,6 +26,10 @@ const useStyles = makeStyles((theme: Theme) => ({
     backgroundColor: theme.bg.tableHeader,
     cursor: 'not-allowed',
     opacity: 0.4
+  },
+  tableRoot: {
+    maxHeight: 750,
+    overflowY: 'scroll'
   }
 }));
 
@@ -70,6 +74,7 @@ export const LimitedAccessControls: React.FC<Props> = props => {
             onChange={handleToggle}
             checked={checked}
             data-testid="limited-permissions-toggle"
+            disabled={props.mode !== 'creating'}
           />
         }
         label={'Limited Access'}
@@ -93,7 +98,7 @@ interface TableProps {
   updateScopes: (newScopes: Scope[]) => void;
 }
 
-const AccessTable: React.FC<TableProps> = props => {
+const AccessTable: React.FC<TableProps> = React.memo(props => {
   const { checked, mode, bucket_access, updateScopes } = props;
 
   const classes = useStyles();
@@ -124,7 +129,11 @@ const AccessTable: React.FC<TableProps> = props => {
   const disabled = mode !== 'creating' || !checked;
 
   return (
-    <Table aria-label="Personal Access Token Permissions" spacingTop={24}>
+    <Table
+      aria-label="Object Storage Access Key Permissions"
+      spacingTop={24}
+      className={classes.tableRoot}
+    >
       <TableHead>
         <TableRow>
           <TableCell data-qa-perm-cluster>Cluster</TableCell>
@@ -262,4 +271,4 @@ const AccessTable: React.FC<TableProps> = props => {
       </TableBody>
     </Table>
   );
-};
+});

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/LimitedAccessControls.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/LimitedAccessControls.tsx
@@ -7,6 +7,7 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
 import TableRow from 'src/components/core/TableRow';
+import Typography from 'src/components/core/Typography';
 import Radio from 'src/components/Radio';
 import Table from 'src/components/Table/Table_CMR';
 import TableCell from 'src/components/TableCell/TableCell_CMR';
@@ -73,6 +74,11 @@ export const LimitedAccessControls: React.FC<Props> = props => {
         }
         label={'Limited Access'}
       />
+      <Typography>
+        Limited access keys can list all buckets, regardless of access. They can
+        also create new buckets, but will not have access to the buckets they
+        create.
+      </Typography>
       <AccessTable key={String(checked)} checked={checked} {...rest} />
     </>
   );

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/LimitedAccessControls.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/LimitedAccessControls.tsx
@@ -12,34 +12,35 @@ import TableCell from 'src/components/TableCell';
 interface Props {
   mode: 'creating' | 'editing';
   checked: boolean;
+  scopes?: Scope[];
   handleToggle: () => void;
 }
 
-const fakeScopes = [
-  {
-    cluster: 'us-east-1',
-    bucket: 'bucket-name-1',
-    access: 'read-only'
-  },
-  {
-    cluster: 'us-east-1',
-    bucket: 'bucket-name-2',
-    access: 'read-write'
-  },
-  {
-    cluster: 'eu-central-1',
-    bucket: 'bucket-name-3',
-    access: 'none'
-  },
-  {
-    cluster: 'ap-south-1',
-    bucket: 'bucket-name-4',
-    access: 'none'
-  }
-];
+// const fakeScopes = [
+//   {
+//     cluster: 'us-east-1',
+//     bucket: 'bucket-name-1',
+//     access: 'read-only'
+//   },
+//   {
+//     cluster: 'us-east-1',
+//     bucket: 'bucket-name-2',
+//     access: 'read-write'
+//   },
+//   {
+//     cluster: 'eu-central-1',
+//     bucket: 'bucket-name-3',
+//     access: 'none'
+//   },
+//   {
+//     cluster: 'ap-south-1',
+//     bucket: 'bucket-name-4',
+//     access: 'none'
+//   }
+// ];
 
 export const LimitedAccessControls: React.FC<Props> = props => {
-  const { checked, handleToggle, mode } = props;
+  const { checked, handleToggle, mode, scopes } = props;
   return (
     <>
       <FormControlLabel
@@ -52,7 +53,7 @@ export const LimitedAccessControls: React.FC<Props> = props => {
         }
         label={'Limited Access'}
       />
-      <AccessTable mode={mode} scopes={fakeScopes as any} />
+      <AccessTable mode={mode} scopes={scopes ?? []} />
     </>
   );
 };

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/LimitedAccessControls.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/LimitedAccessControls.tsx
@@ -13,7 +13,7 @@ import TableCell from 'src/components/TableCell';
 interface Props {
   mode: 'creating' | 'editing';
   checked: boolean;
-  scopes?: Scope[];
+  permissions?: Scope[];
   updateScopes: (newScopes: Scope[]) => void;
   handleToggle: () => void;
 }
@@ -32,6 +32,12 @@ export const getUpdatedScopes = (
     return oldScopes;
   }
   return update(scopeToUpdate, newScope, oldScopes);
+};
+
+export const SCOPES: Record<string, AccessType> = {
+  none: 'none',
+  read: 'read-only',
+  write: 'read-write'
 };
 
 export const LimitedAccessControls: React.FC<Props> = props => {
@@ -57,23 +63,23 @@ export default React.memo(LimitedAccessControls);
 
 interface TableProps {
   mode: 'creating' | 'editing';
-  scopes?: Scope[];
+  permissions?: Scope[];
   updateScopes: (newScopes: Scope[]) => void;
 }
 
 const AccessTable: React.FC<TableProps> = props => {
-  const { mode, scopes, updateScopes } = props;
-  if (!scopes) {
+  const { mode, permissions, updateScopes } = props;
+  if (!permissions) {
     return null;
   }
 
   const updateSingleScope = (newScope: Scope) => {
-    const newScopes = getUpdatedScopes(scopes, newScope);
+    const newScopes = getUpdatedScopes(permissions, newScope);
     updateScopes(newScopes);
   };
 
   const updateAllScopes = (accessType: AccessType) => {
-    const newScopes = scopes.map(thisScope => ({
+    const newScopes = permissions.map(thisScope => ({
       ...thisScope,
       access: accessType
     }));
@@ -81,7 +87,7 @@ const AccessTable: React.FC<TableProps> = props => {
   };
 
   const allScopesEqual = (accessType: AccessType) => {
-    return scopes.every(thisScope => thisScope.access === accessType);
+    return permissions.every(thisScope => thisScope.access === accessType);
   };
 
   return (
@@ -121,10 +127,10 @@ const AccessTable: React.FC<TableProps> = props => {
             >
               <Radio
                 name="Select All"
-                checked={allScopesEqual('none')}
+                checked={allScopesEqual(SCOPES.none)}
                 data-testid="set-all-none"
                 value="none"
-                onChange={() => updateAllScopes('none')}
+                onChange={() => updateAllScopes(SCOPES.none)}
                 data-qa-perm-none-radio
                 inputProps={{
                   'aria-label': 'Select none for all'
@@ -155,10 +161,10 @@ const AccessTable: React.FC<TableProps> = props => {
             >
               <Radio
                 name="Select All"
-                checked={allScopesEqual('read-write')}
+                checked={allScopesEqual(SCOPES.write)}
                 data-testid="set-all-write"
                 value="read-write"
-                onChange={() => updateAllScopes('read-write')}
+                onChange={() => updateAllScopes(SCOPES.write)}
                 data-qa-perm-rw-radio
                 inputProps={{
                   'aria-label': 'Select read/write for all'
@@ -167,7 +173,7 @@ const AccessTable: React.FC<TableProps> = props => {
             </TableCell>
           </TableRow>
         )}
-        {scopes.map(thisScope => {
+        {permissions.map(thisScope => {
           const scopeName = `${thisScope.cluster}-${thisScope.bucket}`;
           return (
             <TableRow key={scopeName} data-testid={scopeName}>
@@ -192,11 +198,13 @@ const AccessTable: React.FC<TableProps> = props => {
               >
                 <Radio
                   name={thisScope.bucket}
-                  disabled={mode !== 'creating' && thisScope.access !== 'none'}
-                  checked={thisScope.access === 'none'}
+                  disabled={
+                    mode !== 'creating' && thisScope.access !== SCOPES.none
+                  }
+                  checked={thisScope.access === SCOPES.none}
                   value="none"
                   onChange={() =>
-                    updateSingleScope({ ...thisScope, access: 'none' })
+                    updateSingleScope({ ...thisScope, access: SCOPES.none })
                   }
                   data-qa-perm-none-radio
                   inputProps={{
@@ -212,12 +220,12 @@ const AccessTable: React.FC<TableProps> = props => {
                 <Radio
                   name={scopeName}
                   disabled={
-                    mode !== 'creating' && thisScope.access !== 'read-only'
+                    mode !== 'creating' && thisScope.access !== SCOPES.read
                   }
-                  checked={thisScope.access === 'read-only'}
+                  checked={thisScope.access === SCOPES.read}
                   value="read-only"
                   onChange={() =>
-                    updateSingleScope({ ...thisScope, access: 'read-only' })
+                    updateSingleScope({ ...thisScope, access: SCOPES.read })
                   }
                   data-qa-perm-read-radio
                   inputProps={{
@@ -233,10 +241,10 @@ const AccessTable: React.FC<TableProps> = props => {
                 <Radio
                   name={scopeName}
                   disabled={mode !== 'creating'}
-                  checked={thisScope.access === 'read-write'}
+                  checked={thisScope.access === SCOPES.write}
                   value="read-write"
                   onChange={() =>
-                    updateSingleScope({ ...thisScope, access: 'read-write' })
+                    updateSingleScope({ ...thisScope, access: SCOPES.write })
                   }
                   data-qa-perm-rw-radio
                   data-testid="perm-rw-radio"

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/LimitedAccessControls.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/LimitedAccessControls.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import Toggle from 'src/components/Toggle';
+import FormControlLabel from 'src/components/core/FormControlLabel';
+
+interface Props {
+  checked: boolean;
+  handleToggle: () => void;
+}
+
+export const LimitedAccessControls: React.FC<Props> = props => {
+  const { checked, handleToggle } = props;
+  return (
+    <FormControlLabel
+      control={
+        <Toggle
+          onChange={handleToggle}
+          checked={checked}
+          data-testid="limited-access-toggle"
+        />
+      }
+      label={'Limited Access'}
+    />
+  );
+};
+
+export default React.memo(LimitedAccessControls);

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/LimitedAccessControls.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/LimitedAccessControls.tsx
@@ -1,3 +1,4 @@
+import { Scope } from '@linode/api-v4/lib/object-storage/types';
 import * as React from 'react';
 import Toggle from 'src/components/Toggle';
 import FormControlLabel from 'src/components/core/FormControlLabel';
@@ -57,12 +58,6 @@ export const LimitedAccessControls: React.FC<Props> = props => {
 };
 
 export default React.memo(LimitedAccessControls);
-
-export interface Scope {
-  bucket: string;
-  cluster: string;
-  access: 'read-only' | 'read-write' | 'none';
-}
 
 interface TableProps {
   mode: 'creating' | 'editing';

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/LimitedAccessControls.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/LimitedAccessControls.tsx
@@ -1,16 +1,16 @@
 import { AccessType, Scope } from '@linode/api-v4/lib/object-storage/types';
 import { update } from 'ramda';
 import * as React from 'react';
-import Toggle from 'src/components/Toggle';
 import FormControlLabel from 'src/components/core/FormControlLabel';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
-import TableRow from 'src/components/core/TableRow';
 import Typography from 'src/components/core/Typography';
 import Radio from 'src/components/Radio';
 import Table from 'src/components/Table/Table_CMR';
 import TableCell from 'src/components/TableCell/TableCell_CMR';
+import TableRow from 'src/components/TableRow/TableRow_CMR';
+import Toggle from 'src/components/Toggle';
 
 const useStyles = makeStyles((theme: Theme) => ({
   clusterCell: {
@@ -28,7 +28,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     opacity: 0.4
   },
   tableRoot: {
-    maxHeight: 750,
+    maxHeight: 800,
     overflowY: 'scroll'
   }
 }));

--- a/packages/manager/src/features/Profile/APITokens/utils.ts
+++ b/packages/manager/src/features/Profile/APITokens/utils.ts
@@ -123,15 +123,10 @@ export const scopeStringToPermTuples = (
     scopeMap
   );
 
-  const permTuples = perms.reduce(
-    (tups: Permission[], permName: string): Permission[] => {
-      const tup = [permName, combinedScopeMap[permName]] as Permission;
-      return [...tups, tup];
-    },
-    []
-  );
-
-  return permTuples;
+  return perms.reduce((tups: Permission[], permName: string): Permission[] => {
+    const tup = [permName, combinedScopeMap[permName]] as Permission;
+    return [...tups, tup];
+  }, []);
 };
 
 export const allMaxPerm = (

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -23,6 +23,7 @@ import {
   monitorFactory,
   nodeBalancerFactory,
   notificationFactory,
+  objectStorageBucketFactory,
   profileFactory,
   supportReplyFactory,
   supportTicketFactory,
@@ -182,6 +183,10 @@ export const handlers = [
       return res(ctx.json(makeResourcePage(configs)));
     }
   ),
+  rest.get('*/object-storage/buckets/*', (req, res, ctx) => {
+    const buckets = objectStorageBucketFactory.buildList(20);
+    return res(ctx.json(makeResourcePage(buckets)));
+  }),
   rest.get('*/domains', (req, res, ctx) => {
     const domains = domainFactory.buildList(25);
     return res(ctx.json(makeResourcePage(domains)));


### PR DESCRIPTION
## Description

Add limited access controls for OBJ access keys. See the JIRA ticket for details.

## Note to Reviewers

Work for this is done, but some changes to the API for this endpoint are in the works, so marking it `wait` until that's ironed out.

To test:

Create access keys of both varieties (with and without the "Limited Access" toggle active). Check the payload and API response, if limited is not toggled, `bucket_access: null` should be sent, and that should come back from the API along with `limited: false`. If the switch is toggled, the selected permissions should be included in request and response payloads.

If you try to create a key with access to 0 buckets (select "limited access" and set all the radio buttons to "none"), you'll end up with a non-limited key--this is the bit the API has to fix.