### PR TITLE
Check margin around headers above tables for consistency

### DIFF
--- a/packages/manager/src/components/PrimaryNav/MobileNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/MobileNav.tsx
@@ -150,7 +150,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     backgroundColor: 'rgba(50, 54, 60, 0.5)',
     top: 50,
     left: 0,
-    zIndex: 1
+    zIndex: 6
   }
 }));
 

--- a/packages/manager/src/components/Table/Table_CMR.tsx
+++ b/packages/manager/src/components/Table/Table_CMR.tsx
@@ -8,7 +8,7 @@ import {
 } from 'src/components/core/styles';
 import Table, { TableProps } from 'src/components/core/Table';
 
-type ClassNames = 'root' | 'border' | 'stickyHeader';
+type ClassNames = 'root' | 'border';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -43,29 +43,6 @@ const styles = (theme: Theme) =>
     border: {
       border: `1px solid ${theme.palette.divider}`,
       borderBottom: 0
-    },
-    stickyHeader: {
-      borderTop: 0,
-      '& th': {
-        position: 'sticky',
-        backgroundColor: theme.bg.tableHeader,
-        paddingTop: 0,
-        paddingBottom: 0,
-        height: 48,
-        zIndex: 5,
-        borderTop: `1px solid ${theme.palette.divider}`,
-        '&:first-child::before': {
-          content: '""',
-          borderTop: `1px solid ${theme.palette.divider}`,
-          backgroundColor: theme.bg.tableHeader,
-          position: 'absolute',
-          width: 5,
-          top: -1,
-          borderBottom: `2px solid ${theme.palette.divider}`,
-          height: 48,
-          left: -5
-        }
-      }
     }
   });
 
@@ -76,7 +53,7 @@ export interface Props extends TableProps {
   border?: boolean;
   spacingTop?: 0 | 8 | 16 | 24;
   spacingBottom?: 0 | 8 | 16 | 24;
-  stickyHeader?: boolean;
+
   tableCaption?: string;
   colCount?: number;
   rowCount?: number;
@@ -94,7 +71,6 @@ class WrappedTable extends React.Component<CombinedProps> {
       noOverflow,
       spacingTop,
       spacingBottom,
-      stickyHeader,
       colCount,
       rowCount,
       ...rest
@@ -106,8 +82,7 @@ class WrappedTable extends React.Component<CombinedProps> {
           'tableWrapper',
           {
             [classes.root]: !noOverflow,
-            [classes.border]: border,
-            [classes.stickyHeader]: stickyHeader
+            [classes.border]: border
           },
           className
         )}

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable_CMR.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable_CMR.tsx
@@ -29,6 +29,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   header: {
     display: 'flex',
     justifyContent: 'space-between',
+    alignItems: 'center',
     flexDirection: 'row',
     [theme.breakpoints.down('md')]: {
       marginLeft: theme.spacing(),

--- a/packages/manager/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/packages/manager/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -176,7 +176,6 @@ class SelectStackScriptPanel extends React.Component<CombinedProps, State> {
               aria-label="List of StackScripts"
               noOverflow={true}
               tableClass={classes.table}
-              stickyHeader
               data-qa-select-stackscript
             >
               <StackScriptTableHead

--- a/packages/manager/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/packages/manager/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -108,6 +108,7 @@ interface Props extends RenderGuardProps {
   ) => Promise<ResourcePage<any>>;
   category: string;
   header: string;
+  isOnCreate?: boolean;
 }
 
 type CombinedProps = Props &
@@ -230,6 +231,7 @@ class SelectStackScriptPanel extends React.Component<CombinedProps, State> {
               key={category + '-tab'}
               category={category}
               disabled={this.props.disabled}
+              isOnCreate={this.props.isOnCreate}
             />
           </Paper>
         </div>

--- a/packages/manager/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/packages/manager/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -176,6 +176,7 @@ class SelectStackScriptPanel extends React.Component<CombinedProps, State> {
               aria-label="List of StackScripts"
               noOverflow={true}
               tableClass={classes.table}
+              stickyHeader
               data-qa-select-stackscript
             >
               <StackScriptTableHead

--- a/packages/manager/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanelContent.tsx
+++ b/packages/manager/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanelContent.tsx
@@ -28,6 +28,7 @@ interface Props {
   ) => Promise<ResourcePage<StackScript>>;
   category: string;
   disabled?: boolean;
+  isOnCreate?: boolean;
 }
 
 type CombinedProps = StateProps & Props;

--- a/packages/manager/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel_CMR.tsx
+++ b/packages/manager/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel_CMR.tsx
@@ -170,7 +170,6 @@ class SelectStackScriptPanel extends React.Component<CombinedProps, State> {
               aria-label="List of StackScripts"
               noOverflow={true}
               tableClass={classes.table}
-              stickyHeader
               data-qa-select-stackscript
             >
               <StackScriptTableHead

--- a/packages/manager/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel_CMR.tsx
+++ b/packages/manager/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel_CMR.tsx
@@ -103,6 +103,7 @@ interface Props extends RenderGuardProps {
   ) => Promise<ResourcePage<any>>;
   category: string;
   header: string;
+  isOnCreate?: boolean;
 }
 
 type CombinedProps = Props &
@@ -223,6 +224,7 @@ class SelectStackScriptPanel extends React.Component<CombinedProps, State> {
               key={category + '-tab'}
               category={category}
               disabled={this.props.disabled}
+              isOnCreate={this.props.isOnCreate}
             />
           </Paper>
         </div>

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.styles.ts
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.styles.ts
@@ -13,7 +13,11 @@ type ClassNames =
   | 'searchWrapper'
   | 'searchBar'
   | 'stackscriptPlaceholder'
-  | 'cmrSpacing';
+  | 'cmrSpacing'
+  | 'button'
+  | 'cmrHeaderWrapper'
+  | 'searchBarCMR'
+  | 'cmrActions';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -39,12 +43,22 @@ const styles = (theme: Theme) =>
       paddingBottom: '40px !important',
       backgroundColor: theme.bg.white
     },
+    cmrHeaderWrapper: {
+      [theme.breakpoints.up('sm')]: {
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between'
+      }
+    },
     searchBar: {
       marginTop: 0,
       backgroundColor: theme.color.white,
       '& > div': {
         marginRight: 0
       }
+    },
+    searchBarCMR: {
+      flexBasis: '100%'
     },
     cmrSpacing: {
       paddingTop: 4,
@@ -56,6 +70,17 @@ const styles = (theme: Theme) =>
       padding: `${theme.spacing(1)}px 0`,
       margin: 0,
       width: '100%'
+    },
+    button: {
+      width: 180,
+      borderRadius: 3,
+      height: 34,
+      padding: 0,
+      marginRight: 8
+    },
+    cmrActions: {
+      display: 'flex',
+      alignItems: 'center'
     }
   });
 

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.styles.ts
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.styles.ts
@@ -63,7 +63,7 @@ const styles = (theme: Theme) =>
     },
     cmrSpacing: {
       paddingTop: 4,
-      paddingBottom: `4px !important`,
+      paddingBottom: `0 !important`,
       paddingLeft: 4
     },
     // Styles to override base placeholder styles for StackScript null state

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.styles.ts
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.styles.ts
@@ -44,6 +44,7 @@ const styles = (theme: Theme) =>
       backgroundColor: theme.bg.white
     },
     cmrHeaderWrapper: {
+      position: 'static',
       [theme.breakpoints.up('sm')]: {
         display: 'flex',
         alignItems: 'center',

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -1,3 +1,4 @@
+import * as classnames from 'classnames';
 import { Grant } from '@linode/api-v4/lib/account';
 import { Image } from '@linode/api-v4/lib/images';
 import { StackScript } from '@linode/api-v4/lib/stackscripts';
@@ -12,6 +13,7 @@ import { compose } from 'recompose';
 import StackScriptsIcon from 'src/assets/addnewmenu/stackscripts.svg';
 import Button from 'src/components/Button';
 import CircleProgress from 'src/components/CircleProgress';
+import DocumentationButton from 'src/components/CMR_DocumentationButton';
 import Typography from 'src/components/core/Typography';
 import DebouncedSearch from 'src/components/DebouncedSearchTextField';
 import ErrorState from 'src/components/ErrorState';
@@ -519,25 +521,46 @@ const withStackScriptBase = (options: WithStackScriptBaseOptions) => (
           ) : (
             <React.Fragment>
               <div
-                className={`${classes.searchWrapper} ${this.props.flags.cmr &&
-                  classes.cmrSpacing}`}
+                className={classnames({
+                  [classes.searchWrapper]: true,
+                  [classes.cmrSpacing]: this.props.flags.cmr,
+                  [classes.cmrHeaderWrapper]: this.props.flags.cmr
+                })}
               >
-                <DebouncedSearch
-                  placeholder="Search by Label, Username, or Description"
-                  onSearch={this.handleSearch}
-                  debounceTime={400}
-                  className={classes.searchBar}
-                  isSearching={isSearching}
-                  tooltipText={
-                    this.props.category === 'community'
-                      ? `Hint: try searching for a specific item by prepending your
+                <div
+                  className={classnames({
+                    [classes.searchBarCMR]: this.props.flags.cmr
+                  })}
+                >
+                  <DebouncedSearch
+                    placeholder="Search by Label, Username, or Description"
+                    onSearch={this.handleSearch}
+                    debounceTime={400}
+                    className={classes.searchBar}
+                    isSearching={isSearching}
+                    tooltipText={
+                      this.props.category === 'community'
+                        ? `Hint: try searching for a specific item by prepending your
                   search term with "username:", "label:", or "description:"`
-                      : ''
-                  }
-                  label="Search by Label, Username, or Description"
-                  hideLabel
-                  defaultValue={query}
-                />
+                        : ''
+                    }
+                    label="Search by Label, Username, or Description"
+                    hideLabel
+                    defaultValue={query}
+                  />
+                </div>
+
+                <div className={classes.cmrActions}>
+                  <Button
+                    buttonType="primary"
+                    className={classes.button}
+                    onClick={this.goToCreateStackScript}
+                  >
+                    Create a StackScript...
+                  </Button>
+
+                  <DocumentationButton href="https://www.linode.com/docs/platform/stackscripts" />
+                </div>
               </div>
               {this.props.flags.cmr ? (
                 <Table_CMR
@@ -547,7 +570,6 @@ const withStackScriptBase = (options: WithStackScriptBaseOptions) => (
                   noOverflow={true}
                   tableClass={classes.table}
                   border
-                  stickyHeader
                 >
                   <StackScriptTableHead_CMR
                     handleClickTableHeader={this.handleClickTableHeader}
@@ -571,7 +593,6 @@ const withStackScriptBase = (options: WithStackScriptBaseOptions) => (
                   tableClass={classes.table}
                   removeLabelonMobile={!isSelecting}
                   border
-                  stickyHeader
                 >
                   <StackScriptTableHead
                     handleClickTableHeader={this.handleClickTableHeader}

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -76,6 +76,7 @@ export interface State {
 interface StoreProps {
   stackScriptGrants?: Grant[];
   userCannotCreateStackScripts: boolean;
+  isOnCreate?: boolean;
 }
 
 type CombinedProps = StyleProps &
@@ -447,7 +448,7 @@ const withStackScriptBase = (options: WithStackScriptBaseOptions) => (
         getMoreStackScriptsFailed
       } = this.state;
 
-      const { classes, userCannotCreateStackScripts } = this.props;
+      const { classes, userCannotCreateStackScripts, isOnCreate } = this.props;
 
       if (error) {
         return (
@@ -550,7 +551,7 @@ const withStackScriptBase = (options: WithStackScriptBaseOptions) => (
                   />
                 </div>
 
-                {this.props.flags.cmr && (
+                {this.props.flags.cmr && !isOnCreate && (
                   <div className={classes.cmrActions}>
                     <Button
                       buttonType="primary"

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -595,6 +595,7 @@ const withStackScriptBase = (options: WithStackScriptBaseOptions) => (
                   tableClass={classes.table}
                   removeLabelonMobile={!isSelecting}
                   border
+                  stickyHeader
                 >
                   <StackScriptTableHead
                     handleClickTableHeader={this.handleClickTableHeader}

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -550,17 +550,19 @@ const withStackScriptBase = (options: WithStackScriptBaseOptions) => (
                   />
                 </div>
 
-                <div className={classes.cmrActions}>
-                  <Button
-                    buttonType="primary"
-                    className={classes.button}
-                    onClick={this.goToCreateStackScript}
-                  >
-                    Create a StackScript...
-                  </Button>
+                {this.props.flags.cmr && (
+                  <div className={classes.cmrActions}>
+                    <Button
+                      buttonType="primary"
+                      className={classes.button}
+                      onClick={this.goToCreateStackScript}
+                    >
+                      Create a StackScript...
+                    </Button>
 
-                  <DocumentationButton href="https://www.linode.com/docs/platform/stackscripts" />
-                </div>
+                    <DocumentationButton href="https://www.linode.com/docs/platform/stackscripts" />
+                  </div>
+                )}
               </div>
               {this.props.flags.cmr ? (
                 <Table_CMR

--- a/packages/manager/src/features/StackScripts/StackScriptsLanding_CMR.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptsLanding_CMR.tsx
@@ -2,10 +2,11 @@ import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
 import CircleProgress from 'src/components/CircleProgress';
+
+import Breadcrumb from 'src/components/Breadcrumb';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
-import LandingHeader from 'src/components/LandingHeader';
 import Notice from 'src/components/Notice';
 import withImagesContainer, {
   WithImages
@@ -32,10 +33,6 @@ export const StackScriptsLanding: React.FC<CombinedProps> = props => {
   const { _loading } = useReduxLoad(['images']);
   const classes = useStyles();
 
-  const goToCreateStackScript = () => {
-    history.push('/stackscripts/create');
-  };
-
   return (
     <React.Fragment>
       <DocumentTitleSegment segment="StackScripts" />
@@ -43,12 +40,10 @@ export const StackScriptsLanding: React.FC<CombinedProps> = props => {
         <Notice success text={history.location.state.successMessage} />
       )}
       <div className={classes.root}>
-        <LandingHeader
-          title="StackScripts"
-          entity="StackScript"
-          onAddNew={goToCreateStackScript}
-          docsLink="https://www.linode.com/docs/platform/stackscripts/"
-          createButtonWidth={180}
+        <Breadcrumb
+          pathname={location.pathname}
+          labelTitle="StackScripts"
+          removeCrumbX={1}
         />
       </div>
       <Grid container>

--- a/packages/manager/src/features/StackScripts/StackScriptsLanding_CMR.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptsLanding_CMR.tsx
@@ -16,9 +16,7 @@ import { filterImagesByType } from 'src/store/image/image.helpers';
 import StackScriptPanel from './StackScriptPanel/StackScriptPanel_CMR';
 
 const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    marginBottom: theme.spacing(3)
-  },
+  root: {},
   panel: {
     '& > div': {
       padding: theme.spacing(2)

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -175,6 +175,7 @@ export class FromStackScriptContent extends React.PureComponent<CombinedProps> {
               disabled={userCannotCreateLinode}
               request={request}
               category={this.props.category}
+              isOnCreate
             />
           ) : (
             <SelectStackScriptPanel
@@ -190,6 +191,7 @@ export class FromStackScriptContent extends React.PureComponent<CombinedProps> {
               disabled={userCannotCreateLinode}
               request={request}
               category={this.props.category}
+              isOnCreate
             />
           )}
           {!userCannotCreateLinode &&

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs_CMR.tsx
@@ -70,15 +70,10 @@ const styles = (theme: Theme) =>
     headline: {
       marginBottom: 3,
       marginLeft: 8,
-      lineHeight: '1.5rem',
-      [theme.breakpoints.down('xs')]: {
-        marginBottom: 0,
-        marginTop: theme.spacing(2)
-      }
+      lineHeight: '1.5rem'
     },
     addNewWrapper: {
       [theme.breakpoints.down('xs')]: {
-        width: '100%',
         marginLeft: -(theme.spacing(1) + theme.spacing(1) / 2),
         marginTop: -theme.spacing(1)
       }

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks_CMR.tsx
@@ -66,15 +66,10 @@ const styles = (theme: Theme) =>
       marginTop: 8,
       marginBottom: 8,
       marginLeft: 15,
-      lineHeight: '1.5rem',
-      [theme.breakpoints.down('xs')]: {
-        marginBottom: 0,
-        marginTop: theme.spacing(2)
-      }
+      lineHeight: '1.5rem'
     },
     addNewWrapper: {
       [theme.breakpoints.down('xs')]: {
-        width: '100%',
         marginLeft: -(theme.spacing(1) + theme.spacing(1) / 2),
         marginTop: -theme.spacing(1)
       },

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeVolumes.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeVolumes.tsx
@@ -50,15 +50,10 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginTop: 8,
     marginBottom: 8,
     marginLeft: 15,
-    lineHeight: '1.5rem',
-    [theme.breakpoints.down('xs')]: {
-      marginBottom: 0,
-      marginTop: theme.spacing(2)
-    }
+    lineHeight: '1.5rem'
   },
   addNewWrapper: {
     [theme.breakpoints.down('xs')]: {
-      width: '100%',
       marginLeft: -(theme.spacing(1) + theme.spacing(1) / 2),
       marginTop: -theme.spacing(1)
     },


### PR DESCRIPTION
## Description

As I was working through this, discovered some additional fixes that I've added here (comments throughout). What has been addressed:

• Approved by Jay: StackScripts landing header/element adjustments (made to match pattern for landings with tabs such as OBJ, Managed, etc.)
• Z-indexing issue for mobile nav overlay vs page content
• Sticky header issue for tables (StackScripts on Linode Create was most noticeable offender)
• Misaligned mobile table headers on some Linode detail tabs


## Type of Change
- Bug fix ('fix')