### PR TITLE
Make casing slightly more consistent and fix typo in config helper label for automount devtmpfs

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -604,20 +604,20 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
               />
 
               <FormControlLabel
-                label="automount devtpmfs"
+                label="Automount devtmpfs"
                 className={classes.formControlToggle}
                 control={
                   <Toggle
                     checked={helpers.devtmpfs_automount}
                     onChange={this.handleToggleAutoMountHelper}
-                    disabled={readOnly}
+                    disabled={readOnl}
                     tooltipText="Controls if pv_ops kernels automount devtmpfs at boot"
                   />
                 }
               />
 
               <FormControlLabel
-                label="auto-configure networking"
+                label="Auto-configure networking"
                 className={classes.formControlToggle}
                 control={
                   <Toggle

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -565,7 +565,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
           >
             <FormGroup>
               <FormControlLabel
-                label="Distro Helper"
+                label="Enable distro helper"
                 className={classes.formControlToggle}
                 control={
                   <Toggle
@@ -591,7 +591,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
               />
 
               <FormControlLabel
-                label="modules.dep Helper"
+                label="Enable modules.dep helper"
                 className={classes.formControlToggle}
                 control={
                   <Toggle
@@ -604,7 +604,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
               />
 
               <FormControlLabel
-                label="automount devtmpfs"
+                label="Auto-mount devtmpfs"
                 className={classes.formControlToggle}
                 control={
                   <Toggle
@@ -617,7 +617,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
               />
 
               <FormControlLabel
-                label="Auto-configure Networking"
+                label="Auto-configure networking"
                 className={classes.formControlToggle}
                 control={
                   <Toggle

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -617,7 +617,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
               />
 
               <FormControlLabel
-                label="Auto-configure networking"
+                label="Auto-configure Networking"
                 className={classes.formControlToggle}
                 control={
                   <Toggle

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -604,13 +604,13 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
               />
 
               <FormControlLabel
-                label="Automount devtmpfs"
+                label="automount devtmpfs"
                 className={classes.formControlToggle}
                 control={
                   <Toggle
                     checked={helpers.devtmpfs_automount}
                     onChange={this.handleToggleAutoMountHelper}
-                    disabled={readOnl}
+                    disabled={readOnly}
                     tooltipText="Controls if pv_ops kernels automount devtmpfs at boot"
                   />
                 }

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer_CMR.tsx
@@ -601,7 +601,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
               />
 
               <FormControlLabel
-                label="automount devtpmfs"
+                label="automount devtmpfs"
                 className={classes.formControlToggle}
                 control={
                   <Toggle
@@ -614,7 +614,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
               />
 
               <FormControlLabel
-                label="auto-configure networking"
+                label="Auto-configure Networking"
                 className={classes.formControlToggle}
                 control={
                   <Toggle

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer_CMR.tsx
@@ -562,7 +562,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
           >
             <FormGroup>
               <FormControlLabel
-                label="Distro Helper"
+                label="Enable distro helper"
                 className={classes.formControlToggle}
                 control={
                   <Toggle
@@ -588,7 +588,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
               />
 
               <FormControlLabel
-                label="modules.dep Helper"
+                label="Enable modules.dep helper"
                 className={classes.formControlToggle}
                 control={
                   <Toggle
@@ -601,7 +601,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
               />
 
               <FormControlLabel
-                label="automount devtmpfs"
+                label="Auto-mount devtmpfs"
                 className={classes.formControlToggle}
                 control={
                   <Toggle
@@ -614,7 +614,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
               />
 
               <FormControlLabel
-                label="Auto-configure Networking"
+                label="Auto-configure networking"
                 className={classes.formControlToggle}
                 control={
                   <Toggle


### PR DESCRIPTION
Trying to make casing a little more consistent here - fixed a typo while I was at it