### PR TITLE
Fix StackScript network calls

### DIFF
--- a/packages/manager/src/MainContent_CMR.tsx
+++ b/packages/manager/src/MainContent_CMR.tsx
@@ -59,9 +59,7 @@ const useStyles = makeStyles((theme: Theme) => ({
       paddingRight: theme.spacing(2)
     }
   },
-  // Removed padding here so width is full 1280- will further refine this when the breakpoint work is handled
   cmrWrapper: {
-    overflowX: 'hidden',
     padding: `${theme.spacing(3)}px 0`,
     transition: theme.transitions.create('opacity'),
     [theme.breakpoints.down('sm')]: {


### PR DESCRIPTION
Not sure why the `overflowX` is causing StackScripts issues but I removed it

We'll need to come up with another way to prevent the app from scrolling horizontally when the viewport is either mobile or tablet