### PR TITLE
Mobile Menu: Adding check to toggle overflow hidden class on body

### DIFF
--- a/packages/manager/src/components/PrimaryNav/MobileNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/MobileNav.tsx
@@ -162,6 +162,12 @@ export const MobileNav: React.FC<Props> = props => {
   return (
     <ReachMenu key={window.location.pathname}>
       {({ isExpanded }) => {
+        // How we are preventing scroll on the body
+        if (isExpanded) {
+          document.body.classList.add('overflow-hidden');
+        } else {
+          document.body.classList.remove('overflow-hidden');
+        }
         return (
           <>
             <MenuButton


### PR DESCRIPTION
## Description

@tiffwong noticed in a separate PR that the disabled scroll on mobile menu activation got lost in the shuffle from some of the menu adjustments made last week. I don't love the location of this if/else, but it works because we need to be able to access the `isExpanded` prop. Open to suggestions if there's a better way to do this that will be consistent!

## Type of Change
- Bug fix ('repair')

