### PR TITLE
Use arrayToList to list allowed regions when creating or adding Linodes to a Firewall

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddDeviceDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddDeviceDrawer.tsx
@@ -6,7 +6,9 @@ import Button from 'src/components/Button';
 import Drawer from 'src/components/Drawer';
 import LinodeMultiSelect from 'src/components/LinodeMultiSelect';
 import Notice from 'src/components/Notice';
+import { dcDisplayNames } from 'src/constants';
 import useRegions from 'src/hooks/useRegions';
+import arrayToList from 'src/utilities/arrayToCommaSeparatedList';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import v4 from 'uuid';
 
@@ -79,8 +81,10 @@ export const AddDeviceDrawer: React.FC<Props> = props => {
           key={key}
           allowedRegions={regionsWithFirewalls}
           handleChange={selected => setSelectedLinodes(selected)}
-          helperText="You can assign one or more Linodes to this Firewall. Only Linodes
-          in regions that currently support Firewalls will be displayed as options."
+          helperText={`You can assign one or more Linodes to this Firewall. Only Linodes
+          in regions that currently support Firewalls (${arrayToList(
+            regionsWithFirewalls.map(thisId => dcDisplayNames[thisId])
+          )}) will be displayed as options.`}
           filteredLinodes={currentDevices}
         />
         <ActionsPanel>

--- a/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.tsx
@@ -13,7 +13,9 @@ import Drawer, { DrawerProps } from 'src/components/Drawer';
 import LinodeMultiSelect from 'src/components/LinodeMultiSelect';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
+import { dcDisplayNames } from 'src/constants';
 import useRegions from 'src/hooks/useRegions';
+import arrayToList from 'src/utilities/arrayToCommaSeparatedList';
 import {
   handleFieldErrors,
   handleGeneralErrors
@@ -153,7 +155,9 @@ const AddFirewallDrawer: React.FC<CombinedProps> = props => {
                 allowedRegions={regionsWithFirewalls}
                 helperText={`Assign one or more Linodes to this firewall. You can add
                  Linodes later if you want to customize your rules first. Only Linodes in
-                 regions that support Firewalls will be displayed as options.`}
+                 regions that support Firewalls (${arrayToList(
+                   regionsWithFirewalls.map(thisId => dcDisplayNames[thisId])
+                 )}) will be displayed as options.`}
                 errorText={errors['devices.linodes']}
                 handleChange={(selected: number[]) =>
                   setFieldValue('devices.linodes', selected)


### PR DESCRIPTION
Per feedback, add an explicit list of which regions are available to our helper text ("Only Linodes in regions that support Firewalls (eg, eg, eg)").

This should work with current prod and display Sydney. You can mock a few other regions with "Cloud Firewall" in the region.capabilities array to see how it handles them.