### PR TITLE
M3-4534 Inject EUUID to /profile from HTTP header

### DIFF
--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -290,7 +290,7 @@ const mapStateToProps: MapState<StateProps, Props> = state => ({
   nodeBalancersError: path(['read'], state.__resources.nodeBalancers.error),
   appIsLoading: state.initialLoad.appIsLoading,
   featureFlagsLoading: state.featureFlagsLoad.featureFlagsLoading,
-  euuid: state.__resources.account.data?.euuid
+  euuid: state.__resources.profile.data?._euuidFromHttpHeader
 });
 
 export const connected = connect(mapStateToProps);

--- a/packages/manager/src/request.test.tsx
+++ b/packages/manager/src/request.test.tsx
@@ -153,31 +153,3 @@ describe('injectEuuidToProfile', () => {
     expect(injectEuuidToProfile(accountResponse as any).data).toEqual(profile);
   });
 });
-
-// describe('isSuccessfulGETProfileResponse', () => {
-// const response: Partial<AxiosResponse> = {
-//   data: profileFactory.build(),
-//   status: 200,
-//   config: { url: '/profile', method: 'get' },
-//   headers: { 'x-customer-uuid': '1234 ' }
-// };
-// it('returns `false` for non-GET requests', () => {
-//   const postResponse = {
-//     ...response,
-//     config: { ...response.config, method: 'post' }
-//   };
-//   expect(isSuccessfulGETProfileResponse(postResponse as any)).toBe(false);
-// });
-// it('returns `false` for failed requests', () => {
-//   expect(
-//     isSuccessfulGETProfileResponse({ ...response, status: 400 } as any)
-//   ).toBe(false);
-// });
-// it('returns `false` for requests not to /profile', () => {
-//   const accountResponse = { ...response, config: { url: '/account' } };
-//   expect(isSuccessfulGETProfileResponse(accountResponse as any)).toBe(false);
-// });
-// it('returns `true` for successful GET requests to /profile', () => {
-//   expect(isSuccessfulGETProfileResponse(response as any)).toBe(true);
-// });
-// });

--- a/packages/manager/src/store/profile/profile.actions.ts
+++ b/packages/manager/src/store/profile/profile.actions.ts
@@ -5,6 +5,11 @@ import { actionCreatorFactory } from 'typescript-fsa';
 
 export interface ExtendedProfile extends Profile {
   grants?: Grants;
+  // A user's external UUID can be found on the response to /account.
+  // Since that endpoint is not available to restricted users, the API also
+  // returns it as an HTTP header ("X-Customer-Uuid"). This header is injected
+  // in the response to `/profile` so that it's available in Redux.
+  _euuidFromHttpHeader?: string;
 }
 
 const actionCreator = actionCreatorFactory(`@@manager/profile`);


### PR DESCRIPTION
## Description

Currently we read a user's EUUID from `/account`. Unfortunately this endpoint is not available to restricted users, so the API will start returning an `X-Customer-Uuid` HTTP header with this value.

This adds a `_euuidFromHttpHeader` field to our `ExtendedProfile` type, (which is injected by Axios middleware) so that this value can be used for non-restricted and restricted users alike.

## Note to Reviewers

This header actually isn't accessible by JS unless it's same-origin (which is the case in Prod), so you'll need to configure your Webpack Dev Server to proxy the API... reach out for a snippet to use (you'll also need to use `testing` services).

However, do test without the proxy to see what happens if the header isn't there for some reason. Please test restricted and non-restricted users.