### PR TITLE
Close notification drawer on internal links

### DIFF
--- a/packages/manager/src/features/NotificationCenter/NotificationDrawer.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationDrawer.tsx
@@ -114,12 +114,13 @@ export const NotificationDrawer: React.FC<Props> = props => {
         <ChronologicalView notifications={chronologicalNotificationList} />
       ) : (
         <div className={classes.notificationSectionContainer}>
-          <PendingActions pendingActions={pendingActions} />
+          <PendingActions pendingActions={pendingActions} onClose={onClose} />
           <Maintenance statusNotifications={statusNotifications} />
           <OpenSupportTickets
             loading={support.loading}
             error={Boolean(support.error)}
             openTickets={support.data}
+            onClose={onClose}
           />
           <Community
             communityEvents={community.events}

--- a/packages/manager/src/features/NotificationCenter/NotificationSection.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationSection.tsx
@@ -76,6 +76,7 @@ interface Props {
   content: NotificationItem[];
   loading?: boolean;
   emptyMessage?: string;
+  onClose?: () => void;
 }
 
 export type CombinedProps = Props;
@@ -87,7 +88,8 @@ export const NotificationSection: React.FC<Props> = props => {
     emptyMessage,
     loading,
     showMoreText,
-    showMoreTarget
+    showMoreTarget,
+    onClose
   } = props;
 
   const _loading = Boolean(loading); // false if not provided
@@ -114,7 +116,14 @@ export const NotificationSection: React.FC<Props> = props => {
               {showMoreTarget && (
                 <Typography variant="body1">
                   <strong>
-                    <Link to={showMoreTarget}>
+                    <Link
+                      to={showMoreTarget}
+                      onClick={() => {
+                        if (onClose) {
+                          onClose();
+                        }
+                      }}
+                    >
                       {showMoreText ?? 'View history'}
                     </Link>
                   </strong>

--- a/packages/manager/src/features/NotificationCenter/OpenSupportTickets.tsx
+++ b/packages/manager/src/features/NotificationCenter/OpenSupportTickets.tsx
@@ -5,10 +5,11 @@ interface Props {
   error?: boolean;
   loading: boolean;
   openTickets: NotificationItem[];
+  onClose?: () => void;
 }
 
 export const OpenSupportTickets: React.FC<Props> = props => {
-  const { error, loading, openTickets } = props;
+  const { error, loading, openTickets, onClose } = props;
 
   if (error) {
     // Open for debate. I'd like to avoid showing separate
@@ -24,6 +25,7 @@ export const OpenSupportTickets: React.FC<Props> = props => {
       showMoreText="View all tickets"
       showMoreTarget="/support/tickets"
       loading={loading}
+      onClose={onClose}
     />
   );
 };

--- a/packages/manager/src/features/NotificationCenter/PendingActions.tsx
+++ b/packages/manager/src/features/NotificationCenter/PendingActions.tsx
@@ -3,10 +3,11 @@ import NotificationSection, { NotificationItem } from './NotificationSection';
 
 interface Props {
   pendingActions: NotificationItem[];
+  onClose?: () => void;
 }
 
 export const PendingActions: React.FC<Props> = props => {
-  const { pendingActions } = props;
+  const { pendingActions, onClose } = props;
 
   return (
     <NotificationSection
@@ -14,6 +15,7 @@ export const PendingActions: React.FC<Props> = props => {
       header="Pending Actions"
       showMoreTarget={'/events'}
       emptyMessage="There are no pending actions."
+      onClose={onClose}
     />
   );
 };


### PR DESCRIPTION
## Description

This makes it so that the new CMR notification drawer closes when you click "View history" (pending actions) or "View all tickets" (open support tickets).