### PR TITLE
Add feature flag logic for VLANS

### DIFF
--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -34,7 +34,8 @@ export type AccountCapability =
   | 'Block Storage'
   | 'Object Storage'
   | 'Kubernetes'
-  | 'Cloud Firewall';
+  | 'Cloud Firewall'
+  | 'Vlans';
 
 export interface AccountSettings {
   managed: boolean;

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.tsx
@@ -50,7 +50,8 @@ type NavEntity =
   | 'Dashboard'
   | 'StackScripts'
   | 'Help & Support'
-  | 'Community';
+  | 'Community'
+  | 'Virtual LANS';
 
 type NavGroup =
   | 'Compute'
@@ -112,6 +113,12 @@ export const PrimaryNav: React.FC<PrimaryNavProps> = props => {
     account?.data?.capabilities ?? []
   );
 
+  const showVlans = isFeatureEnabled(
+    'Vlans',
+    Boolean(flags.vlans),
+    account?.data?.capabilities ?? []
+  );
+
   const primaryLinkGroups: {
     group: NavGroup;
     links: PrimaryLink[];
@@ -167,6 +174,11 @@ export const PrimaryNav: React.FC<PrimaryNavProps> = props => {
             display: 'Firewalls',
             href: '/firewalls',
             hide: !showFirewalls
+          },
+          {
+            display: 'Virtual LANS',
+            href: '/vlans',
+            hide: !showVlans
           }
         ]
       },

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -26,6 +26,7 @@ export interface Flags {
   mainContentBanner: MainContentBanner;
   passwordValidation: PasswordValidationType;
   changelog: Changelog;
+  vlans: boolean;
 }
 
 type PromotionalOfferFeature =


### PR DESCRIPTION
## Description

Add feature flag logic for VLANS. 

## Note to Reviewers

Flag is in Launch Darkly. It also looks at account.capabilities, but there's a bug there in the API and no one is getting 'Vlans' in their list even on dev services.

On CMR, and only CMR, you should see a VLans option in the primary nav when the flag is toggled on. The page it goes to doesn't exist yet.
