### PR TITLE
Add view mode to access key drawer

### DIFF
--- a/packages/manager/src/components/InlineMenuAction/index.tsx
+++ b/packages/manager/src/components/InlineMenuAction/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './InlineMenuAction';

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.test.tsx
@@ -3,20 +3,15 @@ import { screen } from '@testing-library/react';
 import * as React from 'react';
 import { objectStorageBucketFactory } from 'src/factories/objectStorage';
 import { renderWithTheme } from 'src/utilities/testHelpers';
-import {
-  AccessKeyDrawer,
-  getDefaultScopes,
-  MODES,
-  Props
-} from './AccessKeyDrawer';
-import { getUpdatedScopes } from './LimitedAccessControls';
+import { AccessKeyDrawer, getDefaultScopes, Props } from './AccessKeyDrawer';
+import { getUpdatedScopes, MODE } from './LimitedAccessControls';
 
 describe('AccessKeyDrawer', () => {
   const props: Props = {
     open: true,
     onSubmit: jest.fn(),
     onClose: jest.fn(),
-    mode: 'creating' as MODES,
+    mode: 'creating' as MODE,
     isRestrictedUser: false
   };
   renderWithTheme(<AccessKeyDrawer {...props} />);

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.test.tsx
@@ -4,7 +4,8 @@ import * as React from 'react';
 import { objectStorageBucketFactory } from 'src/factories/objectStorage';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 import { AccessKeyDrawer, getDefaultScopes, Props } from './AccessKeyDrawer';
-import { getUpdatedScopes, MODE } from './LimitedAccessControls';
+import { getUpdatedScopes } from './LimitedAccessControls';
+import { MODE } from './types';
 
 describe('AccessKeyDrawer', () => {
   const props: Props = {

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
@@ -19,15 +19,12 @@ import useBuckets from 'src/hooks/useObjectStorageBuckets';
 import { ApplicationState } from 'src/store';
 import EnableObjectStorageModal from '../EnableObjectStorageModal';
 import { confirmObjectStorage } from '../utilities';
-import LimitedAccessControls from './LimitedAccessControls';
-
-export type MODES = 'creating' | 'editing';
-
+import LimitedAccessControls, { MODE } from './LimitedAccessControls';
 export interface Props {
   open: boolean;
   onClose: () => void;
   onSubmit: (values: ObjectStorageKeyRequest, formikProps: any) => void;
-  mode: MODES;
+  mode: MODE;
   // If the mode is 'editing', we should have an ObjectStorageKey to edit
   objectStorageKey?: ObjectStorageKey;
   isRestrictedUser: boolean;
@@ -94,10 +91,10 @@ export const AccessKeyDrawer: React.FC<CombinedProps> = props => {
   }, [open]);
 
   const title =
-    mode === 'creating' ? 'Create an Access Key' : 'Edit Access Key';
+    mode === 'creating' ? 'Create an Access Key' : 'Edit Access Key Label';
 
   const initialLabelValue =
-    mode === 'editing' && objectStorageKey ? objectStorageKey.label : '';
+    mode !== 'creating' && objectStorageKey ? objectStorageKey.label : '';
 
   const initialValues: FormState = {
     label: initialLabelValue,
@@ -199,15 +196,17 @@ export const AccessKeyDrawer: React.FC<CombinedProps> = props => {
                 errorText={errors.label}
                 onChange={handleChange}
                 onBlur={handleBlur}
-                disabled={isRestrictedUser}
+                disabled={isRestrictedUser || mode === 'viewing'}
               />
-              <LimitedAccessControls
-                mode={mode}
-                bucket_access={values.bucket_access}
-                updateScopes={handleScopeUpdate}
-                handleToggle={handleToggleAccess}
-                checked={limitedAccessChecked}
-              />
+              {mode === 'creating' && (
+                <LimitedAccessControls
+                  mode={mode}
+                  bucket_access={values.bucket_access}
+                  updateScopes={handleScopeUpdate}
+                  handleToggle={handleToggleAccess}
+                  checked={limitedAccessChecked}
+                />
+              )}
               <ActionsPanel>
                 <Button
                   buttonType="primary"

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
@@ -122,7 +122,12 @@ export const AccessKeyDrawer: React.FC<CombinedProps> = props => {
   };
 
   return (
-    <Drawer title={title} open={open} onClose={onClose} wide>
+    <Drawer
+      title={title}
+      open={open}
+      onClose={onClose}
+      wide={mode === 'creating'}
+    >
       {buckets.loading ? (
         <CircleProgress />
       ) : (

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
@@ -11,6 +11,7 @@ import * as React from 'react';
 import { useSelector } from 'react-redux';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
+import CircleProgress from 'src/components/CircleProgress';
 import Typography from 'src/components/core/Typography';
 import Drawer from 'src/components/Drawer';
 import Notice from 'src/components/Notice';
@@ -19,7 +20,8 @@ import useBuckets from 'src/hooks/useObjectStorageBuckets';
 import { ApplicationState } from 'src/store';
 import EnableObjectStorageModal from '../EnableObjectStorageModal';
 import { confirmObjectStorage } from '../utilities';
-import LimitedAccessControls, { MODE } from './LimitedAccessControls';
+import LimitedAccessControls from './LimitedAccessControls';
+import { MODE } from './types';
 export interface Props {
   open: boolean;
   onClose: () => void;
@@ -121,120 +123,124 @@ export const AccessKeyDrawer: React.FC<CombinedProps> = props => {
 
   return (
     <Drawer title={title} open={open} onClose={onClose} wide>
-      <Formik
-        initialValues={initialValues}
-        validationSchema={createObjectStorageKeysSchema}
-        validateOnChange={false}
-        validateOnBlur={true}
-        onSubmit={handleSubmit}
-      >
-        {formikProps => {
-          const {
-            values,
-            errors,
-            handleChange,
-            handleBlur,
-            handleSubmit,
-            setFieldValue,
-            isSubmitting,
-            status
-          } = formikProps;
+      {buckets.loading ? (
+        <CircleProgress />
+      ) : (
+        <Formik
+          initialValues={initialValues}
+          validationSchema={createObjectStorageKeysSchema}
+          validateOnChange={false}
+          validateOnBlur={true}
+          onSubmit={handleSubmit}
+        >
+          {formikProps => {
+            const {
+              values,
+              errors,
+              handleChange,
+              handleBlur,
+              handleSubmit,
+              setFieldValue,
+              isSubmitting,
+              status
+            } = formikProps;
 
-          const beforeSubmit = () => {
-            confirmObjectStorage<FormState>(object_storage, formikProps, () =>
-              setDialogOpen(true)
-            );
-          };
+            const beforeSubmit = () => {
+              confirmObjectStorage<FormState>(object_storage, formikProps, () =>
+                setDialogOpen(true)
+              );
+            };
 
-          const handleScopeUpdate = (newScopes: Scope[]) => {
-            setFieldValue('bucket_access', newScopes);
-          };
+            const handleScopeUpdate = (newScopes: Scope[]) => {
+              setFieldValue('bucket_access', newScopes);
+            };
 
-          const handleToggleAccess = () => {
-            setLimitedAccessChecked(checked => !checked);
-            // Reset scopes
-            setFieldValue('bucket_access', getDefaultScopes(buckets.data));
-          };
+            const handleToggleAccess = () => {
+              setLimitedAccessChecked(checked => !checked);
+              // Reset scopes
+              setFieldValue('bucket_access', getDefaultScopes(buckets.data));
+            };
 
-          return (
-            <>
-              {status && (
-                <Notice key={status} text={status} error data-qa-error />
-              )}
+            return (
+              <>
+                {status && (
+                  <Notice key={status} text={status} error data-qa-error />
+                )}
 
-              {isRestrictedUser && (
-                <Notice
-                  error
-                  important
-                  text="You don't have bucket_access to create an Access Key. Please contact an account administrator for details."
+                {isRestrictedUser && (
+                  <Notice
+                    error
+                    important
+                    text="You don't have bucket_access to create an Access Key. Please contact an account administrator for details."
+                  />
+                )}
+
+                {/* Explainer copy if we're in 'creating' mode */}
+                {mode === 'creating' && (
+                  <Typography>
+                    Generate an Access Key for use with an{' '}
+                    <a
+                      href="https://linode.com/docs/platform/object-storage/how-to-use-object-storage/#object-storage-tools"
+                      target="_blank"
+                      aria-describedby="external-site"
+                      rel="noopener noreferrer"
+                      className="h-u"
+                    >
+                      S3-compatible client
+                    </a>
+                    .
+                  </Typography>
+                )}
+
+                <TextField
+                  name="label"
+                  label="Label"
+                  data-qa-add-label
+                  value={values.label}
+                  error={!!errors.label}
+                  errorText={errors.label}
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                  disabled={isRestrictedUser || mode === 'viewing'}
                 />
-              )}
-
-              {/* Explainer copy if we're in 'creating' mode */}
-              {mode === 'creating' && (
-                <Typography>
-                  Generate an Access Key for use with an{' '}
-                  <a
-                    href="https://linode.com/docs/platform/object-storage/how-to-use-object-storage/#object-storage-tools"
-                    target="_blank"
-                    aria-describedby="external-site"
-                    rel="noopener noreferrer"
-                    className="h-u"
+                {mode === 'creating' && (
+                  <LimitedAccessControls
+                    mode={mode}
+                    bucket_access={values.bucket_access}
+                    updateScopes={handleScopeUpdate}
+                    handleToggle={handleToggleAccess}
+                    checked={limitedAccessChecked}
+                  />
+                )}
+                <ActionsPanel>
+                  <Button
+                    buttonType="primary"
+                    onClick={beforeSubmit}
+                    loading={isSubmitting}
+                    disabled={isRestrictedUser}
+                    data-qa-submit
                   >
-                    S3-compatible client
-                  </a>
-                  .
-                </Typography>
-              )}
-
-              <TextField
-                name="label"
-                label="Label"
-                data-qa-add-label
-                value={values.label}
-                error={!!errors.label}
-                errorText={errors.label}
-                onChange={handleChange}
-                onBlur={handleBlur}
-                disabled={isRestrictedUser || mode === 'viewing'}
-              />
-              {mode === 'creating' && (
-                <LimitedAccessControls
-                  mode={mode}
-                  bucket_access={values.bucket_access}
-                  updateScopes={handleScopeUpdate}
-                  handleToggle={handleToggleAccess}
-                  checked={limitedAccessChecked}
+                    Submit
+                  </Button>
+                  <Button
+                    onClick={onClose}
+                    data-qa-cancel
+                    buttonType="secondary"
+                    className="cancel"
+                  >
+                    Cancel
+                  </Button>
+                </ActionsPanel>
+                <EnableObjectStorageModal
+                  open={dialogOpen}
+                  onClose={() => setDialogOpen(false)}
+                  handleSubmit={handleSubmit}
                 />
-              )}
-              <ActionsPanel>
-                <Button
-                  buttonType="primary"
-                  onClick={beforeSubmit}
-                  loading={isSubmitting}
-                  disabled={isRestrictedUser}
-                  data-qa-submit
-                >
-                  Submit
-                </Button>
-                <Button
-                  onClick={onClose}
-                  data-qa-cancel
-                  buttonType="secondary"
-                  className="cancel"
-                >
-                  Cancel
-                </Button>
-              </ActionsPanel>
-              <EnableObjectStorageModal
-                open={dialogOpen}
-                onClose={() => setDialogOpen(false)}
-                handleSubmit={handleSubmit}
-              />
-            </>
-          );
-        }}
-      </Formik>
+              </>
+            );
+          }}
+        </Formik>
+      )}
     </Drawer>
   );
 };

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyLanding.tsx
@@ -1,4 +1,3 @@
-import { FormikBag } from 'formik';
 import { AccountSettings } from '@linode/api-v4/lib/account';
 import {
   createObjectStorageKeys,
@@ -8,6 +7,7 @@ import {
   revokeObjectStorageKey,
   updateObjectStorageKey
 } from '@linode/api-v4/lib/object-storage';
+import { FormikBag } from 'formik';
 import { pathOr } from 'ramda';
 import * as React from 'react';
 import { connect, MapDispatchToProps } from 'react-redux';
@@ -26,6 +26,7 @@ import Grid from 'src/components/Grid';
 import Pagey, { PaginationProps } from 'src/components/Pagey';
 import PaginationFooter from 'src/components/PaginationFooter';
 import { useErrors } from 'src/hooks/useErrors';
+import useFlags from 'src/hooks/useFlags';
 import { useOpenClose } from 'src/hooks/useOpenClose';
 import { ApplicationState } from 'src/store';
 import { requestAccountSettings } from 'src/store/accountSettings/accountSettings.requests';
@@ -37,12 +38,11 @@ import {
 } from 'src/utilities/ga';
 import AccessKeyDisplayDialog from './AccessKeyDisplayDialog';
 import AccessKeyDrawer from './AccessKeyDrawer';
-import { MODE } from './LimitedAccessControls';
 import AccessKeyTable from './AccessKeyTable';
 import AccessKeyTable_CMR from './AccessKeyTable_CMR';
 import RevokeAccessKeyDialog from './RevokeAccessKeyDialog';
+import { MODE, OpenAccessDrawer } from './types';
 import ViewPermissionsDrawer from './ViewPermissionsDrawer';
-import useFlags from 'src/hooks/useFlags';
 
 type ClassNames = 'headline';
 
@@ -247,21 +247,20 @@ export const AccessKeyLanding: React.FC<CombinedProps> = props => {
       });
   };
 
-  const openDrawerForCreating = () => {
-    setMode('creating');
-    setKeyToEdit(null);
-    createOrEditDrawer.open();
-  };
-
-  const openDrawerForEditing = (objectStorageKey: ObjectStorageKey) => {
-    setMode('editing');
+  const openDrawer: OpenAccessDrawer = (
+    mode: MODE,
+    objectStorageKey: ObjectStorageKey | null = null
+  ) => {
+    setMode(mode);
     setKeyToEdit(objectStorageKey);
-    createOrEditDrawer.open();
-  };
-
-  const openDrawerForViewing = (objectStorageKey: ObjectStorageKey) => {
-    setKeyToEdit(objectStorageKey);
-    viewPermissionsDrawer.open();
+    switch (mode) {
+      case 'creating':
+      case 'editing':
+        createOrEditDrawer.open();
+        break;
+      case 'viewing':
+        viewPermissionsDrawer.open();
+    }
   };
 
   const openRevokeDialog = (objectStorageKey: ObjectStorageKey) => {
@@ -283,7 +282,7 @@ export const AccessKeyLanding: React.FC<CombinedProps> = props => {
         <Grid container justify="flex-end">
           <Grid item>
             <AddNewLink
-              onClick={openDrawerForCreating}
+              onClick={() => openDrawer('creating')}
               label="Create an Access Key"
             />
           </Grid>
@@ -291,10 +290,8 @@ export const AccessKeyLanding: React.FC<CombinedProps> = props => {
       )}
       <KeyTable
         {...paginationProps}
-        openDrawerForEditing={openDrawerForEditing}
+        openDrawer={openDrawer}
         openRevokeDialog={openRevokeDialog}
-        openDrawerForCreating={openDrawerForCreating}
-        openDrawerForViewing={openDrawerForViewing}
         data-qa-access-key-table
       />
 

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyLanding.tsx
@@ -36,10 +36,12 @@ import {
   sendRevokeAccessKeyEvent
 } from 'src/utilities/ga';
 import AccessKeyDisplayDialog from './AccessKeyDisplayDialog';
-import AccessKeyDrawer, { MODES } from './AccessKeyDrawer';
+import AccessKeyDrawer from './AccessKeyDrawer';
+import { MODE } from './LimitedAccessControls';
 import AccessKeyTable from './AccessKeyTable';
 import AccessKeyTable_CMR from './AccessKeyTable_CMR';
 import RevokeAccessKeyDialog from './RevokeAccessKeyDialog';
+import ViewPermissionsDrawer from './ViewPermissionsDrawer';
 import useFlags from 'src/hooks/useFlags';
 
 type ClassNames = 'headline';
@@ -77,7 +79,7 @@ export const AccessKeyLanding: React.FC<CombinedProps> = props => {
 
   const flags = useFlags();
 
-  const [mode, setMode] = React.useState<MODES>('creating');
+  const [mode, setMode] = React.useState<MODE>('creating');
 
   // Key to display in Confirmation Modal upon creation
   const [
@@ -100,6 +102,7 @@ export const AccessKeyLanding: React.FC<CombinedProps> = props => {
   const displayKeysDialog = useOpenClose();
   const revokeKeysDialog = useOpenClose();
   const createOrEditDrawer = useOpenClose();
+  const viewPermissionsDrawer = useOpenClose();
 
   // Request object storage key when component is first rendered
   React.useEffect(() => {
@@ -246,6 +249,7 @@ export const AccessKeyLanding: React.FC<CombinedProps> = props => {
 
   const openDrawerForCreating = () => {
     setMode('creating');
+    setKeyToEdit(null);
     createOrEditDrawer.open();
   };
 
@@ -253,6 +257,11 @@ export const AccessKeyLanding: React.FC<CombinedProps> = props => {
     setMode('editing');
     setKeyToEdit(objectStorageKey);
     createOrEditDrawer.open();
+  };
+
+  const openDrawerForViewing = (objectStorageKey: ObjectStorageKey) => {
+    setKeyToEdit(objectStorageKey);
+    viewPermissionsDrawer.open();
   };
 
   const openRevokeDialog = (objectStorageKey: ObjectStorageKey) => {
@@ -285,6 +294,7 @@ export const AccessKeyLanding: React.FC<CombinedProps> = props => {
         openDrawerForEditing={openDrawerForEditing}
         openRevokeDialog={openRevokeDialog}
         openDrawerForCreating={openDrawerForCreating}
+        openDrawerForViewing={openDrawerForViewing}
         data-qa-access-key-table
       />
 
@@ -304,6 +314,12 @@ export const AccessKeyLanding: React.FC<CombinedProps> = props => {
         mode={mode}
         objectStorageKey={keyToEdit ? keyToEdit : undefined}
         isRestrictedUser={props.isRestrictedUser}
+      />
+
+      <ViewPermissionsDrawer
+        open={viewPermissionsDrawer.isOpen}
+        onClose={viewPermissionsDrawer.close}
+        objectStorageKey={keyToEdit}
       />
 
       <AccessKeyDisplayDialog

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyMenu.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyMenu.tsx
@@ -11,6 +11,7 @@ interface Props {
   // ObjectStorageKeys --> ObjectStorageKeyTable --> HERE
   openRevokeDialog: (key: ObjectStorageKey) => void;
   openDrawerForEditing: (key: ObjectStorageKey) => void;
+  openDrawerForViewing: (key: ObjectStorageKey) => void;
   label: string;
 }
 
@@ -18,7 +19,12 @@ type CombinedProps = Props;
 
 const AccessKeyMenu: React.FC<CombinedProps> = props => {
   const createActions = () => {
-    const { openRevokeDialog, objectStorageKey, openDrawerForEditing } = props;
+    const {
+      openRevokeDialog,
+      objectStorageKey,
+      openDrawerForEditing,
+      openDrawerForViewing
+    } = props;
 
     return (closeMenu: Function): Action[] => {
       return [
@@ -26,6 +32,13 @@ const AccessKeyMenu: React.FC<CombinedProps> = props => {
           title: 'Rename Access Key',
           onClick: () => {
             openDrawerForEditing(objectStorageKey);
+            closeMenu();
+          }
+        },
+        {
+          title: 'View Permissions',
+          onClick: () => {
+            openDrawerForViewing(objectStorageKey);
             closeMenu();
           }
         },

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyMenu.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyMenu.tsx
@@ -2,6 +2,7 @@ import { ObjectStorageKey } from '@linode/api-v4/lib/object-storage';
 import * as React from 'react';
 
 import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
+import { OpenAccessDrawer } from './types';
 
 interface Props {
   // prop-drilled from parent
@@ -10,8 +11,8 @@ interface Props {
   // prop-drilled from grandparent:
   // ObjectStorageKeys --> ObjectStorageKeyTable --> HERE
   openRevokeDialog: (key: ObjectStorageKey) => void;
-  openDrawerForEditing: (key: ObjectStorageKey) => void;
-  openDrawerForViewing: (key: ObjectStorageKey) => void;
+  openDrawer: OpenAccessDrawer;
+
   label: string;
 }
 
@@ -19,26 +20,21 @@ type CombinedProps = Props;
 
 const AccessKeyMenu: React.FC<CombinedProps> = props => {
   const createActions = () => {
-    const {
-      openRevokeDialog,
-      objectStorageKey,
-      openDrawerForEditing,
-      openDrawerForViewing
-    } = props;
+    const { openRevokeDialog, objectStorageKey, openDrawer } = props;
 
     return (closeMenu: Function): Action[] => {
       return [
         {
           title: 'Rename Access Key',
           onClick: () => {
-            openDrawerForEditing(objectStorageKey);
+            openDrawer('editing', objectStorageKey);
             closeMenu();
           }
         },
         {
           title: 'View Permissions',
           onClick: () => {
-            openDrawerForViewing(objectStorageKey);
+            openDrawer('viewing', objectStorageKey);
             closeMenu();
           }
         },

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyMenu_CMR.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyMenu_CMR.tsx
@@ -4,6 +4,7 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 import ActionMenu from 'src/components/ActionMenu_CMR';
 import Hidden from 'src/components/core/Hidden';
 import InlineAction from 'src/components/InlineMenuAction';
+import { OpenAccessDrawer } from './types';
 
 const useStyles = makeStyles((theme: Theme) => ({
   inlineActions: {
@@ -38,8 +39,7 @@ interface Props {
   // prop-drilled from grandparent:
   // ObjectStorageKeys --> ObjectStorageKeyTable --> HERE
   openRevokeDialog: (key: ObjectStorageKey) => void;
-  openDrawerForEditing: (key: ObjectStorageKey) => void;
-  openDrawerForViewing: (key: ObjectStorageKey) => void;
+  openDrawer: OpenAccessDrawer;
   label: string;
 }
 
@@ -47,24 +47,19 @@ type CombinedProps = Props;
 
 const AccessKeyMenu: React.FC<CombinedProps> = props => {
   const classes = useStyles();
-  const {
-    openRevokeDialog,
-    objectStorageKey,
-    openDrawerForEditing,
-    openDrawerForViewing
-  } = props;
+  const { openRevokeDialog, objectStorageKey, openDrawer } = props;
 
   const actions = [
     {
       title: 'Edit label',
       onClick: () => {
-        openDrawerForEditing(objectStorageKey);
+        openDrawer('editing', objectStorageKey);
       }
     },
     {
       title: 'View permissions',
       onClick: () => {
-        openDrawerForViewing(objectStorageKey);
+        openDrawer('viewing', objectStorageKey);
       }
     },
     {

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyMenu_CMR.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyMenu_CMR.tsx
@@ -1,9 +1,9 @@
 import { ObjectStorageKey } from '@linode/api-v4/lib/object-storage';
 import * as React from 'react';
 import { makeStyles, Theme } from 'src/components/core/styles';
-import ActionMenu, { Action } from 'src/components/ActionMenu_CMR';
-import Button from 'src/components/Button';
+import ActionMenu from 'src/components/ActionMenu_CMR';
 import Hidden from 'src/components/core/Hidden';
+import InlineAction from 'src/components/InlineMenuAction';
 
 const useStyles = makeStyles((theme: Theme) => ({
   inlineActions: {
@@ -39,6 +39,7 @@ interface Props {
   // ObjectStorageKeys --> ObjectStorageKeyTable --> HERE
   openRevokeDialog: (key: ObjectStorageKey) => void;
   openDrawerForEditing: (key: ObjectStorageKey) => void;
+  openDrawerForViewing: (key: ObjectStorageKey) => void;
   label: string;
 }
 
@@ -46,52 +47,48 @@ type CombinedProps = Props;
 
 const AccessKeyMenu: React.FC<CombinedProps> = props => {
   const classes = useStyles();
-  const { openRevokeDialog, objectStorageKey, openDrawerForEditing } = props;
+  const {
+    openRevokeDialog,
+    objectStorageKey,
+    openDrawerForEditing,
+    openDrawerForViewing
+  } = props;
 
-  const createActions = () => {
-    return (): Action[] => {
-      const actions = [
-        {
-          title: 'Edit label',
-          onClick: () => {
-            openDrawerForEditing(objectStorageKey);
-          }
-        },
-        {
-          title: 'Revoke',
-          onClick: () => {
-            openRevokeDialog(objectStorageKey);
-          }
-        }
-      ];
-
-      return actions;
-    };
-  };
+  const actions = [
+    {
+      title: 'Edit label',
+      onClick: () => {
+        openDrawerForEditing(objectStorageKey);
+      }
+    },
+    {
+      title: 'View permissions',
+      onClick: () => {
+        openDrawerForViewing(objectStorageKey);
+      }
+    },
+    {
+      title: 'Revoke',
+      onClick: () => {
+        openRevokeDialog(objectStorageKey);
+      }
+    }
+  ];
 
   return (
     <div className={classes.inlineActions}>
       <Hidden smDown>
-        <Button
-          className={classes.button}
-          onClick={() => {
-            openDrawerForEditing(objectStorageKey);
-          }}
-        >
-          Edit label
-        </Button>
-        <Button
-          className={classes.button}
-          onClick={() => {
-            openRevokeDialog(objectStorageKey);
-          }}
-        >
-          Revoke
-        </Button>
+        {actions.map(thisAction => (
+          <InlineAction
+            key={thisAction.title}
+            actionText={thisAction.title}
+            onClick={thisAction.onClick}
+          />
+        ))}
       </Hidden>
       <Hidden mdUp>
         <ActionMenu
-          createActions={createActions()}
+          createActions={() => actions}
           ariaLabel={`Action menu for Object Storage Key ${props.label}`}
         />
       </Hidden>

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable.test.tsx
@@ -17,8 +17,7 @@ describe('ObjectStorageKeyTable', () => {
           labelCell: '',
           copyIcon: ''
         }}
-        openDrawerForEditing={jest.fn()}
-        openDrawerForViewing={jest.fn()}
+        openDrawer={jest.fn()}
         openRevokeDialog={jest.fn()}
         isRestrictedUser={false}
         {...pageyProps}

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable.test.tsx
@@ -18,6 +18,7 @@ describe('ObjectStorageKeyTable', () => {
           copyIcon: ''
         }}
         openDrawerForEditing={jest.fn()}
+        openDrawerForViewing={jest.fn()}
         openRevokeDialog={jest.fn()}
         isRestrictedUser={false}
         {...pageyProps}

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable.tsx
@@ -20,6 +20,7 @@ import TableRowEmptyState from 'src/components/TableRowEmptyState';
 import TableRowError from 'src/components/TableRowError';
 import TableRowLoading from 'src/components/TableRowLoading';
 import AccessKeyMenu from './AccessKeyMenu';
+import { OpenAccessDrawer } from './types';
 
 type ClassNames = 'root' | 'headline' | 'paper' | 'labelCell' | 'copyIcon';
 
@@ -49,8 +50,7 @@ const styles = (theme: Theme) =>
 interface Props {
   isRestrictedUser: boolean;
   openRevokeDialog: (objectStorageKey: ObjectStorageKey) => void;
-  openDrawerForEditing: (objectStorageKey: ObjectStorageKey) => void;
-  openDrawerForViewing: (objectStorageKey: ObjectStorageKey) => void;
+  openDrawer: OpenAccessDrawer;
 }
 
 export type CombinedProps = Props &
@@ -65,8 +65,7 @@ export const AccessKeyTable: React.FC<CombinedProps> = props => {
     error,
     isRestrictedUser,
     openRevokeDialog,
-    openDrawerForEditing,
-    openDrawerForViewing
+    openDrawer
   } = props;
 
   const renderContent = () => {
@@ -115,8 +114,7 @@ export const AccessKeyTable: React.FC<CombinedProps> = props => {
           <AccessKeyMenu
             objectStorageKey={eachKey}
             openRevokeDialog={openRevokeDialog}
-            openDrawerForEditing={openDrawerForEditing}
-            openDrawerForViewing={openDrawerForViewing}
+            openDrawer={openDrawer}
             label={eachKey.label}
           />
         </TableCell>

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable.tsx
@@ -50,6 +50,7 @@ interface Props {
   isRestrictedUser: boolean;
   openRevokeDialog: (objectStorageKey: ObjectStorageKey) => void;
   openDrawerForEditing: (objectStorageKey: ObjectStorageKey) => void;
+  openDrawerForViewing: (objectStorageKey: ObjectStorageKey) => void;
 }
 
 export type CombinedProps = Props &
@@ -64,7 +65,8 @@ export const AccessKeyTable: React.FC<CombinedProps> = props => {
     error,
     isRestrictedUser,
     openRevokeDialog,
-    openDrawerForEditing
+    openDrawerForEditing,
+    openDrawerForViewing
   } = props;
 
   const renderContent = () => {
@@ -114,6 +116,7 @@ export const AccessKeyTable: React.FC<CombinedProps> = props => {
             objectStorageKey={eachKey}
             openRevokeDialog={openRevokeDialog}
             openDrawerForEditing={openDrawerForEditing}
+            openDrawerForViewing={openDrawerForViewing}
             label={eachKey.label}
           />
         </TableCell>
@@ -122,29 +125,27 @@ export const AccessKeyTable: React.FC<CombinedProps> = props => {
   };
 
   return (
-    <React.Fragment>
-      <Paper className={classes.paper}>
-        <Table
-          aria-label="List of Object Storage Access Keys"
-          rowCount={data && data.length}
-          colCount={2}
-        >
-          <TableHead>
-            <TableRow data-qa-table-head role="rowgroup">
-              <TableCell className={classes.labelCell} data-qa-header-label>
-                Label
-              </TableCell>
-              <TableCell className={classes.labelCell} data-qa-header-key>
-                Access Key
-              </TableCell>
-              {/* empty cell for kebab menu */}
-              <TableCell />
-            </TableRow>
-          </TableHead>
-          <TableBody>{renderContent()}</TableBody>
-        </Table>
-      </Paper>
-    </React.Fragment>
+    <Paper className={classes.paper}>
+      <Table
+        aria-label="List of Object Storage Access Keys"
+        rowCount={data && data.length}
+        colCount={2}
+      >
+        <TableHead>
+          <TableRow data-qa-table-head role="rowgroup">
+            <TableCell className={classes.labelCell} data-qa-header-label>
+              Label
+            </TableCell>
+            <TableCell className={classes.labelCell} data-qa-header-key>
+              Access Key
+            </TableCell>
+            {/* empty cell for kebab menu */}
+            <TableCell />
+          </TableRow>
+        </TableHead>
+        <TableBody>{renderContent()}</TableBody>
+      </Table>
+    </Paper>
   );
 };
 

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable_CMR.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable_CMR.tsx
@@ -40,7 +40,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     }
   },
   labelCell: {
-    width: '48%'
+    width: '35%'
   },
   copyIcon: {
     '& svg': {
@@ -56,6 +56,7 @@ interface Props {
   isRestrictedUser: boolean;
   openRevokeDialog: (objectStorageKey: ObjectStorageKey) => void;
   openDrawerForEditing: (objectStorageKey: ObjectStorageKey) => void;
+  openDrawerForViewing: (objectStorageKey: ObjectStorageKey) => void;
   openDrawerForCreating: () => void;
 }
 
@@ -69,7 +70,8 @@ export const AccessKeyTable: React.FC<CombinedProps> = props => {
     isRestrictedUser,
     openRevokeDialog,
     openDrawerForEditing,
-    openDrawerForCreating
+    openDrawerForCreating,
+    openDrawerForViewing
   } = props;
 
   const classes = useStyles();
@@ -121,6 +123,7 @@ export const AccessKeyTable: React.FC<CombinedProps> = props => {
             objectStorageKey={eachKey}
             openRevokeDialog={openRevokeDialog}
             openDrawerForEditing={openDrawerForEditing}
+            openDrawerForViewing={openDrawerForViewing}
             label={eachKey.label}
           />
         </TableCell>

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable_CMR.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable_CMR.tsx
@@ -15,6 +15,7 @@ import TableRowError from 'src/components/TableRowError';
 import TableRowLoading from 'src/components/TableRowLoading';
 import AccessKeyMenu from './AccessKeyMenu_CMR';
 import AddNewLink from 'src/components/AddNewLink/AddNewLink_CMR';
+import { OpenAccessDrawer } from './types';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -55,9 +56,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 interface Props {
   isRestrictedUser: boolean;
   openRevokeDialog: (objectStorageKey: ObjectStorageKey) => void;
-  openDrawerForEditing: (objectStorageKey: ObjectStorageKey) => void;
-  openDrawerForViewing: (objectStorageKey: ObjectStorageKey) => void;
-  openDrawerForCreating: () => void;
+  openDrawer: OpenAccessDrawer;
 }
 
 export type CombinedProps = Props & PaginationProps<ObjectStorageKey>;
@@ -69,9 +68,7 @@ export const AccessKeyTable: React.FC<CombinedProps> = props => {
     error,
     isRestrictedUser,
     openRevokeDialog,
-    openDrawerForEditing,
-    openDrawerForCreating,
-    openDrawerForViewing
+    openDrawer
   } = props;
 
   const classes = useStyles();
@@ -122,8 +119,7 @@ export const AccessKeyTable: React.FC<CombinedProps> = props => {
           <AccessKeyMenu
             objectStorageKey={eachKey}
             openRevokeDialog={openRevokeDialog}
-            openDrawerForEditing={openDrawerForEditing}
-            openDrawerForViewing={openDrawerForViewing}
+            openDrawer={openDrawer}
             label={eachKey.label}
           />
         </TableCell>
@@ -146,7 +142,7 @@ export const AccessKeyTable: React.FC<CombinedProps> = props => {
         </Grid>
         <Grid item className={classes.addNewWrapper}>
           <AddNewLink
-            onClick={openDrawerForCreating}
+            onClick={() => openDrawer('creating')}
             label="Add an Access Key..."
           />
         </Grid>

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/LimitedAccessControls.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/LimitedAccessControls.tsx
@@ -11,8 +11,7 @@ import Table from 'src/components/Table/Table_CMR';
 import TableCell from 'src/components/TableCell/TableCell_CMR';
 import TableRow from 'src/components/TableRow/TableRow_CMR';
 import Toggle from 'src/components/Toggle';
-
-export type MODE = 'creating' | 'editing' | 'viewing';
+import { MODE } from './types';
 
 const useStyles = makeStyles((theme: Theme) => ({
   clusterCell: {

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/ViewPermissionsDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/ViewPermissionsDrawer.tsx
@@ -1,0 +1,50 @@
+import { ObjectStorageKey } from '@linode/api-v4/lib/object-storage';
+import * as React from 'react';
+import Typography from 'src/components/core/Typography';
+import Drawer from 'src/components/Drawer';
+
+import { AccessTable } from './LimitedAccessControls';
+export interface Props {
+  open: boolean;
+  onClose: () => void;
+  objectStorageKey: ObjectStorageKey | null;
+}
+
+type CombinedProps = Props;
+
+export const ViewPermissionsDrawer: React.FC<CombinedProps> = props => {
+  const { open, onClose, objectStorageKey } = props;
+
+  if (objectStorageKey === null) {
+    return null;
+  }
+
+  return (
+    <Drawer
+      title={`Permissions for ${objectStorageKey.label}`}
+      open={open}
+      onClose={onClose}
+      wide
+    >
+      {objectStorageKey.bucket_access === null ? (
+        <Typography>
+          This key has unlimited access to all buckets on your account.
+        </Typography>
+      ) : (
+        <>
+          <Typography>
+            This access key has the following permissions:
+          </Typography>
+          <AccessTable
+            mode={'viewing'}
+            bucket_access={objectStorageKey.bucket_access}
+            updateScopes={() => null}
+            checked={objectStorageKey.limited}
+          />
+        </>
+      )}
+    </Drawer>
+  );
+};
+
+export default React.memo(ViewPermissionsDrawer);

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/types.ts
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/types.ts
@@ -1,0 +1,8 @@
+import { ObjectStorageKey } from '@linode/api-v4/lib/object-storage/types';
+
+export type MODE = 'creating' | 'editing' | 'viewing';
+
+export type OpenAccessDrawer = (
+  mode: MODE,
+  objectStorageKey?: ObjectStorageKey | null
+) => void;


### PR DESCRIPTION
## Description

Add "View Permissions" to the access key action menu and open a separate view-only drawer. I went away from the ticket requirements in a few ways:

- Separate drawer: did this because juggling all the "modes" has proven to be bug-prone in the past, and the logic was getting dicey when I tried it here. There's a little duplication but not much.

- Hide table when editing: When you select "Edit label", the drawer that opens only has the label field. I did this because it was confusing to have the read-only permissions table in two different contexts, with slightly different behaviors.

- Hide label etc. from view only drawer: The ticket specified that the label input and toggle would be present in view mode, but disabled. Once I had decided to use a separate drawer, this no longer seemed to make sense. I also added a special state for unrestricted keys, which wouldn't have worked well using the label/toggle/table setup.

Happy to be talked out of any of these, please let me know what you think.
