### PR TITLE
Updated Resize error message and added link

### DIFF
--- a/packages/manager/src/components/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/packages/manager/src/components/ConfirmationDialog/ConfirmationDialog.tsx
@@ -27,7 +27,7 @@ const styles = (theme: Theme) =>
 
 interface Props extends DialogProps {
   actions?: ((props: any) => JSX.Element) | JSX.Element;
-  error?: string;
+  error?: string | JSX.Element;
   onClose: () => void;
   title: string;
 }

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LInodeResize.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LInodeResize.test.tsx
@@ -34,7 +34,8 @@ describe('LinodeResize', () => {
         resizeTitle: '',
         toolTip: '',
         checkbox: '',
-        currentHeaderEmptyCell: ''
+        currentHeaderEmptyCell: '',
+        errorLink: ''
       }}
       linodeId={12}
       permissions={{} as any}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LInodeResize.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LInodeResize.test.tsx
@@ -34,8 +34,7 @@ describe('LinodeResize', () => {
         resizeTitle: '',
         toolTip: '',
         checkbox: '',
-        currentHeaderEmptyCell: '',
-        error: ''
+        currentHeaderEmptyCell: ''
       }}
       linodeId={12}
       permissions={{} as any}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LInodeResize.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LInodeResize.test.tsx
@@ -34,7 +34,8 @@ describe('LinodeResize', () => {
         resizeTitle: '',
         toolTip: '',
         checkbox: '',
-        currentHeaderEmptyCell: ''
+        currentHeaderEmptyCell: '',
+        error: ''
       }}
       linodeId={12}
       permissions={{} as any}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -48,7 +48,8 @@ type ClassNames =
   | 'currentPlanContainer'
   | 'resizeTitle'
   | 'checkbox'
-  | 'currentHeaderEmptyCell';
+  | 'currentHeaderEmptyCell'
+  | 'errorLink';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -86,6 +87,10 @@ const styles = (theme: Theme) =>
     },
     currentHeaderEmptyCell: {
       width: '13%'
+    },
+    errorLink: {
+      color: '#c44742',
+      textDecoration: 'underline'
     }
   });
 
@@ -161,6 +166,7 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
 
   onSubmit = () => {
     const {
+      classes,
       linodeId,
       linodeType,
       enqueueSnackbar,
@@ -221,6 +227,7 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
               service plan. Please resize your disk to accommodate the new plan.
               You can read our{' '}
               <ExternalLink
+                className={classes.errorLink}
                 hideIcon
                 text="Resize Your Linode"
                 link="https://www.linode.com/docs/platform/disk-images/resizing-a-linode/"

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -48,8 +48,7 @@ type ClassNames =
   | 'currentPlanContainer'
   | 'resizeTitle'
   | 'checkbox'
-  | 'currentHeaderEmptyCell'
-  | 'error';
+  | 'currentHeaderEmptyCell';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -87,10 +86,6 @@ const styles = (theme: Theme) =>
     },
     currentHeaderEmptyCell: {
       width: '13%'
-    },
-    error: {
-      color: '#C44742',
-      marginTop: theme.spacing(2)
     }
   });
 
@@ -221,7 +216,7 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
         let error: string | JSX.Element = '';
         if (errorResponse[0].reason.match(/allocated more disk/i)) {
           error = (
-            <Typography className={this.props.classes.error}>
+            <>
               The current disk size of your Linode is too large for the new
               service plan. Please resize your disk to accommodate the new plan.
               You can read our{' '}
@@ -231,7 +226,7 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
                 link="https://www.linode.com/docs/platform/disk-images/resizing-a-linode/"
               />{' '}
               guide for more detailed instructions.
-            </Typography>
+            </>
           );
         } else {
           error = getAPIErrorOrDefault(

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize_CMR.tsx
@@ -55,8 +55,7 @@ type ClassNames =
   | 'checkbox'
   | 'currentHeaderEmptyCell'
   | 'tabbedPanelInnerClass'
-  | 'selectPlanPanel'
-  | 'error';
+  | 'selectPlanPanel';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -91,9 +90,6 @@ const styles = (theme: Theme) =>
     },
     selectPlanPanel: {
       marginTop: theme.spacing(5)
-    },
-    error: {
-      color: '#C44742'
     }
   });
 
@@ -181,7 +177,7 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
         let error: string | JSX.Element = '';
         if (errorResponse[0].reason.match(/allocated more disk/i)) {
           error = (
-            <Typography className={this.props.classes.error}>
+            <Typography>
               The current disk size of your Linode is too large for the new
               service plan. Please resize your disk to accommodate the new plan.
               You can read our{' '}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/ResizeConfirmationDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/ResizeConfirmationDialog.tsx
@@ -6,7 +6,7 @@ import Typography from 'src/components/core/Typography';
 
 export interface Props {
   isOpen: boolean;
-  error?: string;
+  error?: string | JSX.Element;
   submitting: boolean;
   currentPlan: string;
   targetPlan: string;


### PR DESCRIPTION
When a customer tries to resize their Linode to a smaller plan without first resizing their disks, they trigger an error message. 

I updated the copy of this error message, and added a link to our "Resize a Linode" document for instructions on how to size down a plan. 
