### PR TITLE
M3-4272: Longview CMR tables follow-up

### DIFF
--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ActiveConnections/ActiveConnections.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ActiveConnections/ActiveConnections.tsx
@@ -95,7 +95,9 @@ export const ConnectionsTable: React.FC<TableProps> = props => {
             <>
               <Table
                 spacingTop={16}
-                tableClass={`${connections.length > 0 ? classes.table : ''}`}
+                tableClass={`${
+                  connections.length > 0 && !cmrFlag ? classes.table : ''
+                }`}
               >
                 <TableHead>
                   <TableRow>

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ActiveConnections/ActiveConnections.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ActiveConnections/ActiveConnections.tsx
@@ -183,6 +183,7 @@ const renderLoadingErrorData = (
     <ConnectionRow
       key={`longview-active-connection-${idx}`}
       connection={thisConnection}
+      cmrFlag={cmrFlag}
     />
   ));
 };

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ActiveConnections/ConnectionRow.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ActiveConnections/ConnectionRow.tsx
@@ -1,14 +1,21 @@
 import * as React from 'react';
-import TableCell from 'src/components/TableCell';
-import TableRow from 'src/components/TableRow';
+import TableCell_PreCMR from 'src/components/TableCell';
+import TableCell_CMR from 'src/components/TableCell/TableCell_CMR';
+import TableRow_PreCMR from 'src/components/TableRow';
+import TableRow_CMR from 'src/components/TableRow/TableRow_CMR';
 import { LongviewPort } from 'src/features/Longview/request.types';
 
 interface Props {
   connection: LongviewPort;
+  cmrFlag?: boolean;
 }
 
 export const ConnectionRow: React.FC<Props> = props => {
-  const { connection } = props;
+  const { connection, cmrFlag } = props;
+
+  const TableCell = cmrFlag ? TableCell_CMR : TableCell_PreCMR;
+  const TableRow = cmrFlag ? TableRow_CMR : TableRow_PreCMR;
+
   return (
     <TableRow ariaLabel={connection.name} data-testid="longview-connection-row">
       <TableCell parentColumn="Name" data-qa-active-connection-name>

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ListeningServices/ListeningServices.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ListeningServices/ListeningServices.tsx
@@ -90,7 +90,9 @@ export const ServicesTable: React.FC<TableProps> = props => {
             <>
               <Table
                 spacingTop={16}
-                tableClass={`${services.length > 0 ? classes.table : ''}`}
+                tableClass={`${
+                  services.length > 0 && !cmrFlag ? classes.table : ''
+                }`}
               >
                 <TableHead>
                   <TableRow>

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ListeningServices/ListeningServices.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ListeningServices/ListeningServices.tsx
@@ -196,7 +196,11 @@ const renderLoadingErrorData = (
   }
 
   return data.map((thisService, idx) => (
-    <LongviewServiceRow key={`longview-service-${idx}`} service={thisService} />
+    <LongviewServiceRow
+      key={`longview-service-${idx}`}
+      service={thisService}
+      cmrFlag={cmrFlag}
+    />
   ));
 };
 

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ListeningServices/LongviewServiceRow.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ListeningServices/LongviewServiceRow.tsx
@@ -1,14 +1,21 @@
 import * as React from 'react';
-import TableCell from 'src/components/TableCell';
-import TableRow from 'src/components/TableRow';
+import TableCell_PreCMR from 'src/components/TableCell';
+import TableCell_CMR from 'src/components/TableCell/TableCell_CMR';
+import TableRow_PreCMR from 'src/components/TableRow';
+import TableRow_CMR from 'src/components/TableRow/TableRow_CMR';
 import { LongviewService } from 'src/features/Longview/request.types';
 
 interface Props {
   service: LongviewService;
+  cmrFlag?: boolean;
 }
 
 export const LongviewServiceRow: React.FC<Props> = props => {
-  const { service } = props;
+  const { service, cmrFlag } = props;
+
+  const TableCell = cmrFlag ? TableCell_CMR : TableCell_PreCMR;
+  const TableRow = cmrFlag ? TableRow_CMR : TableRow_PreCMR;
+
   return (
     <TableRow ariaLabel={service.name} data-testid="longview-service-row">
       <TableCell parentColumn="Process" data-qa-service-process>


### PR DESCRIPTION
## Description
Follow-up to https://github.com/linode/manager/pull/6914 -- the Listening Services and Active Connections table rows needed to be CMR also, along with having TableCell_CMR.

## Type of Change
- Non breaking change ('update', 'change')
