### PR TITLE
Re-request Linode when id changes in URL

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
@@ -200,6 +200,12 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
     this.refreshIPs();
   }
 
+  componentDidUpdate(prevProps: CombinedProps) {
+    if (prevProps.linode.id !== this.props.linode.id) {
+      this.refreshIPs();
+    }
+  }
+
   openRemoveIPDialog = (IPToRemove: IPAddress) => {
     this.setState({
       removeIPDialogOpen: !this.state.removeIPDialogOpen,

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking_CMR.tsx
@@ -180,6 +180,12 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
     this.refreshIPs();
   }
 
+  componentDidUpdate(prevProps: CombinedProps) {
+    if (prevProps.linode.id !== this.props.linode.id) {
+      this.refreshIPs();
+    }
+  }
+
   openRemoveIPDialog = (IPToRemove: IPAddress) => {
     this.setState({
       removeIPDialogOpen: !this.state.removeIPDialogOpen,


### PR DESCRIPTION
## Description

When the url changes on Linode Detail, make sure we re-request IP addresses on the Network tab.

## Note to Reviewers

In both CMR and non-CMR, visit a Linode's network tab, then search `is:linode` in the search bar and select one of the results. On develop, the IP addresses don't update; here they should.