### PR TITLE
Prevent overflow of resolvers

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkingSummaryPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkingSummaryPanel.tsx
@@ -10,6 +10,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   root: {
     display: 'flex',
     flexFlow: 'row nowrap',
+    justifyContent: 'space-between',
     padding: theme.spacing(3),
     paddingBottom: theme.spacing(2) + theme.spacing(1) / 2,
     [theme.breakpoints.down('xs')]: {
@@ -18,7 +19,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   transferHistoryContainer: {
     padding: '16px 0px',
-    flex: 1.3,
     [theme.breakpoints.up('md')]: {
       padding: '0px 32px'
     },
@@ -36,7 +36,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     }
   },
   dnsResolverContainer: {
-    flex: 1,
     paddingTop: 8,
     [theme.breakpoints.up('md')]: {
       paddingTop: 0

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkingSummaryPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkingSummaryPanel.tsx
@@ -19,11 +19,12 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   transferHistoryContainer: {
     padding: '16px 0px',
-    [theme.breakpoints.up('md')]: {
-      padding: '0px 32px'
-    },
+    flex: 1,
     [theme.breakpoints.up('sm')]: {
       padding: '0px 16px'
+    },
+    [theme.breakpoints.up('md')]: {
+      maxWidth: 600
     },
     [theme.breakpoints.down('sm')]: {
       paddingRight: 0,

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkingSummaryPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkingSummaryPanel.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
-import Grid from 'src/components/Grid';
 import DNSResolvers from './DNSResolvers';
 import NetworkTransfer from './NetworkTransfer';
 import TransferHistory from './TransferHistory';
@@ -50,16 +49,14 @@ const LinodeNetworkingSummaryPanel: React.FC<CombinedProps> = props => {
 
   return (
     <Paper className={classes.root}>
-      <Grid item>
-        <NetworkTransfer linodeID={linodeID} linodeLabel={linodeLabel} />
-      </Grid>
-      <Grid item className={classes.transferHistoryContainer}>
+      <NetworkTransfer linodeID={linodeID} linodeLabel={linodeLabel} />
+      <div className={classes.transferHistoryContainer}>
         <TransferHistory linodeID={linodeID} linodeCreated={linodeCreated} />
-      </Grid>
+      </div>
       <Hidden smDown>
-        <Grid item className={classes.dnsResolverContainer}>
+        <div className={classes.dnsResolverContainer}>
           <DNSResolvers region={linodeRegion} />
-        </Grid>
+        </div>
       </Hidden>
     </Paper>
   );

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkingSummaryPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkingSummaryPanel.tsx
@@ -9,11 +9,16 @@ import Hidden from 'src/components/core/Hidden';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
+    display: 'flex',
+    flexFlow: 'row-nowrap',
+    justifyContent: 'flex-start',
+    alignItems: 'start',
     padding: theme.spacing(3),
     paddingBottom: theme.spacing(2) + theme.spacing(1) / 2
   },
   transferHistoryContainer: {
     padding: '16px 0px',
+    flex: 1.3,
     [theme.breakpoints.up('sm')]: {
       padding: '0px 16px'
     },
@@ -22,6 +27,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     }
   },
   dnsResolverContainer: {
+    flex: 1,
     paddingTop: 8,
     [theme.breakpoints.up('md')]: {
       paddingTop: 0
@@ -44,31 +50,17 @@ const LinodeNetworkingSummaryPanel: React.FC<CombinedProps> = props => {
 
   return (
     <Paper className={classes.root}>
-      <Grid
-        container
-        direction="row"
-        justify="space-between"
-        alignItems="flex-start"
-      >
-        <Grid xs={12} sm={3} item>
-          <NetworkTransfer linodeID={linodeID} linodeLabel={linodeLabel} />
-        </Grid>
-        <Grid
-          item
-          xs={12}
-          sm={9}
-          md={6}
-          lg={7}
-          className={classes.transferHistoryContainer}
-        >
-          <TransferHistory linodeID={linodeID} linodeCreated={linodeCreated} />
-        </Grid>
-        <Hidden smDown>
-          <Grid item md={3} lg={2} className={classes.dnsResolverContainer}>
-            <DNSResolvers region={linodeRegion} />
-          </Grid>
-        </Hidden>
+      <Grid item>
+        <NetworkTransfer linodeID={linodeID} linodeLabel={linodeLabel} />
       </Grid>
+      <Grid item className={classes.transferHistoryContainer}>
+        <TransferHistory linodeID={linodeID} linodeCreated={linodeCreated} />
+      </Grid>
+      <Hidden smDown>
+        <Grid item className={classes.dnsResolverContainer}>
+          <DNSResolvers region={linodeRegion} />
+        </Grid>
+      </Hidden>
     </Paper>
   );
 };

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkingSummaryPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkingSummaryPanel.tsx
@@ -9,20 +9,30 @@ import Hidden from 'src/components/core/Hidden';
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
     display: 'flex',
-    flexFlow: 'row-nowrap',
-    justifyContent: 'flex-start',
-    alignItems: 'start',
+    flexFlow: 'row nowrap',
     padding: theme.spacing(3),
-    paddingBottom: theme.spacing(2) + theme.spacing(1) / 2
+    paddingBottom: theme.spacing(2) + theme.spacing(1) / 2,
+    [theme.breakpoints.down('xs')]: {
+      flexDirection: 'column'
+    }
   },
   transferHistoryContainer: {
     padding: '16px 0px',
     flex: 1.3,
+    [theme.breakpoints.up('md')]: {
+      padding: '0px 32px'
+    },
     [theme.breakpoints.up('sm')]: {
       padding: '0px 16px'
     },
-    [theme.breakpoints.up('md')]: {
-      padding: '0px 32px'
+    [theme.breakpoints.down('sm')]: {
+      paddingRight: 0,
+      width: '50%'
+    },
+    [theme.breakpoints.down('xs')]: {
+      paddingTop: theme.spacing(3),
+      paddingBottom: 0,
+      width: '100%'
     }
   },
   dnsResolverContainer: {


### PR DESCRIPTION
Think we got a little too fancy here:

![Screen Shot 2020-09-22 at 1 05 29 PM](https://user-images.githubusercontent.com/1624067/93916365-6d4aac80-fcd7-11ea-9e91-ecac7ee9c253.png)

Not sure the mobile handling here is the best, but I think it's ok.
