### PR TITLE
Fix crashing localization bug

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/TransferHistory.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/TransferHistory.test.tsx
@@ -1,3 +1,4 @@
+import { DateTime } from 'luxon';
 import {
   sumPublicOutboundTraffic,
   parseMonthOffset,
@@ -36,7 +37,7 @@ describe('combineGraphData', () => {
   });
 });
 
-const now = new Date('2020-07-01T12:00:00');
+const now = DateTime.fromISO('2020-07-01T12:00:00');
 
 describe('getYearAndMonthFromOffset', () => {
   it('returns the current year and month with an offset is 0', () => {
@@ -67,9 +68,9 @@ describe('getYearAndMonthFromOffset', () => {
 
 describe('getOffsetFromDate', () => {
   it('returns the number needed to offset the current date from the target date', () => {
-    const d1 = new Date('2020-06-01T12:00:00');
-    const d2 = new Date('2020-05-01T12:00:00');
-    const d3 = new Date('2020-05-15T12:00:00');
+    const d1 = DateTime.fromISO('2020-06-01T12:00:00');
+    const d2 = DateTime.fromISO('2020-05-01T12:00:00');
+    const d3 = DateTime.fromISO('2020-05-15T12:00:00');
 
     // Test from the beginning of the month.
     expect(getOffsetFromDate(now, d1)).toBe(-1);
@@ -77,7 +78,7 @@ describe('getOffsetFromDate', () => {
     expect(getOffsetFromDate(now, d3)).toBe(-2);
 
     // Test from the middle of the month
-    const midMonth = new Date('2020-07-15T12:00:00');
+    const midMonth = DateTime.fromISO('2020-07-15T12:00:00');
     expect(getOffsetFromDate(midMonth, now)).toBe(0);
     expect(getOffsetFromDate(midMonth, d1)).toBe(-1);
     expect(getOffsetFromDate(midMonth, d2)).toBe(-2);

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/TransferHistory.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/TransferHistory.tsx
@@ -59,7 +59,7 @@ export const TransferHistory: React.FC<TransferHistoryProps> = props => {
   // `-1` represents the previous month, etc. This value should not be greater than `0`.
   const [monthOffset, setMonthOffset] = React.useState(0);
 
-  const now = new Date();
+  const now = DateTime.utc();
 
   const { year, month, humanizedDate } = parseMonthOffset(monthOffset, now);
 
@@ -105,7 +105,10 @@ export const TransferHistory: React.FC<TransferHistoryProps> = props => {
   const _formatTooltip = (valueInBytes: number) =>
     formatNetworkTooltip(valueInBytes / 8);
 
-  const maxMonthOffset = getOffsetFromDate(now, new Date(props.linodeCreated));
+  const maxMonthOffset = getOffsetFromDate(
+    now,
+    DateTime.fromISO(props.linodeCreated, { zone: 'utc' })
+  );
   const minMonthOffset = 0;
 
   const decrementOffset = () =>
@@ -232,14 +235,12 @@ export const sumPublicOutboundTraffic = (stats: Stats) => {
 
 // Get the year, month, and humanized month/year, assuming an offset of `0` refers to "now".
 // An offset of `-1` refers to the previous month, `-2` refers to two months ago, etc.
-export const parseMonthOffset = (offset: number, date: Date) => {
+export const parseMonthOffset = (offset: number, date: DateTime) => {
   if (offset > 0) {
     throw Error('Offset must be <= 0');
   }
 
-  const datetime = DateTime.fromJSDate(date);
-
-  const resultingDate = datetime.minus({ months: Math.abs(offset) });
+  const resultingDate = date.minus({ months: Math.abs(offset) });
 
   const year = String(resultingDate.year);
   const month = String(resultingDate.month).padStart(2, '0');
@@ -250,7 +251,7 @@ export const parseMonthOffset = (offset: number, date: Date) => {
 
 // We don't want to allow the user to scroll back further than the Linode was created,
 // so we determine the max offset given "now" and a target date (i.e. Linode Created date).
-export const getOffsetFromDate = (now: Date, target: Date) => {
+export const getOffsetFromDate = (now: DateTime, target: DateTime) => {
   const interval = Interval.fromDateTimes(target, now);
   // Need to subtract `1` here, because Luxon considers these intervals to be inclusive.
   const count = interval.count('month') - 1;


### PR DESCRIPTION
## Description


The offset logic in TransferHistory.tsx was creating dates
using the native JS Date object (one for the current time and one
based off the Linode's create date). These Dates were then converted
to Luxon DateTime/Intervals inside various helper methods.

This approach works fine in almost all cases, but in the case
where a Linode has recently been created, the API returns the timestamp
in UTC, which will be after Date.now() if you run them both through
new Date(). This causes Interval.fromDateTimes() to crash since the
interval end is before the start.

As a result, clicking the < on a new Linode causes the app to crash.

Using Luxon DateTimes from the start and explicitly comparing both
in UTC allows us to avoid this issue.


## Note to Reviewers

1. Have a Linode created in the past ~2 hours
2. Go to the Linode's network tab
3. Press the `<` in the transfer history widget (which should be disabled but isn't)
4. 💥 

Your mileage might be different depending on your profile's timezone, so please toggle that off and on to make sure everything is working under all cases.