### PR TITLE
M3-4553 Fix tab-based navigation 

### DIFF
--- a/packages/manager/src/features/Account/AccountLanding.tsx
+++ b/packages/manager/src/features/Account/AccountLanding.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { matchPath, RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
 import Breadcrumb from 'src/components/Breadcrumb';
-import TabPanel from 'src/components/core/ReachTabPanel';
+import SafeTabPanel from 'src/components/SafeTabPanel';
 import TabPanels from 'src/components/core/ReachTabPanels';
 import Tabs from 'src/components/core/ReachTabs';
 import TabLinkList from 'src/components/TabLinkList';
@@ -51,6 +51,23 @@ const AccountLanding: React.FC<Props> = props => {
     return Boolean(matchPath(p, { path: location.pathname }));
   };
 
+  const getIndex = React.useCallback(() => {
+    return Math.max(
+      tabs.findIndex(tab => matches(tab.routeName)),
+      0
+    );
+  }, [tabs]);
+
+  const [idx, setIndex] = React.useState(0);
+
+  React.useEffect(() => {
+    setIndex(getIndex());
+  }, [props.match, tabs, getIndex]);
+
+  const navToURL = (index: number) => {
+    props.history.push(tabs[index].routeName);
+  };
+
   return (
     <React.Fragment>
       <DocumentTitleSegment segment="Account Settings" />
@@ -61,20 +78,20 @@ const AccountLanding: React.FC<Props> = props => {
         removeCrumbX={1}
         data-qa-profile-header
       />
-      <Tabs defaultIndex={tabs.findIndex(tab => matches(tab.routeName))}>
+      <Tabs index={idx} onChange={navToURL}>
         <TabLinkList tabs={tabs} />
 
         <React.Suspense fallback={<SuspenseLoader />}>
           <TabPanels>
-            <TabPanel>
+            <SafeTabPanel index={0}>
               <Billing />
-            </TabPanel>
-            <TabPanel>
+            </SafeTabPanel>
+            <SafeTabPanel index={1}>
               <Users isRestrictedUser={props.isRestrictedUser} />
-            </TabPanel>
-            <TabPanel>
+            </SafeTabPanel>
+            <SafeTabPanel index={2}>
               <GlobalSettings />
-            </TabPanel>
+            </SafeTabPanel>
           </TabPanels>
         </React.Suspense>
       </Tabs>

--- a/packages/manager/src/features/Account/AccountLanding.tsx
+++ b/packages/manager/src/features/Account/AccountLanding.tsx
@@ -51,19 +51,6 @@ const AccountLanding: React.FC<Props> = props => {
     return Boolean(matchPath(p, { path: location.pathname }));
   };
 
-  const getIndex = React.useCallback(() => {
-    return Math.max(
-      tabs.findIndex(tab => matches(tab.routeName)),
-      0
-    );
-  }, [tabs]);
-
-  const [idx, setIndex] = React.useState(0);
-
-  React.useEffect(() => {
-    setIndex(getIndex());
-  }, [props.match, tabs, getIndex]);
-
   const navToURL = (index: number) => {
     props.history.push(tabs[index].routeName);
   };
@@ -78,7 +65,14 @@ const AccountLanding: React.FC<Props> = props => {
         removeCrumbX={1}
         data-qa-profile-header
       />
-      <Tabs index={idx} onChange={navToURL}>
+
+      <Tabs
+        index={Math.max(
+          tabs.findIndex(tab => matches(tab.routeName)),
+          0
+        )}
+        onChange={navToURL}
+      >
         <TabLinkList tabs={tabs} />
 
         <React.Suspense fallback={<SuspenseLoader />}>

--- a/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
@@ -48,18 +48,6 @@ export const FirewallDetail: React.FC<CombinedProps> = props => {
   };
 
   const [updateError, setUpdateError] = React.useState<string | undefined>();
-  const [idx, setIndex] = React.useState(0);
-
-  const getIndex = React.useCallback(() => {
-    return Math.max(
-      tabs.findIndex(tab => matches(tab.routeName)),
-      0
-    );
-  }, [tabs]);
-
-  React.useEffect(() => {
-    setIndex(getIndex());
-  }, [props.match, tabs, getIndex]);
 
   const navToURL = (index: number) => {
     props.history.push(tabs[index].routeName);
@@ -124,7 +112,13 @@ export const FirewallDetail: React.FC<CombinedProps> = props => {
         />
         <DocumentationButton href="https://linode.com/docs/platform/cloud-firewall/getting-started-with-cloud-firewall/" />
       </Box>
-      <Tabs index={idx} onChange={navToURL}>
+      <Tabs
+        index={Math.max(
+          tabs.findIndex(tab => matches(tab.routeName)),
+          0
+        )}
+        onChange={navToURL}
+      >
         <TabLinkList tabs={tabs} />
 
         <TabPanels>

--- a/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
@@ -5,7 +5,7 @@ import Breadcrumb from 'src/components/Breadcrumb';
 import CircleProgress from 'src/components/CircleProgress';
 
 import Box from 'src/components/core/Box';
-import TabPanel from 'src/components/core/ReachTabPanel';
+import SafeTabPanel from 'src/components/SafeTabPanel';
 import TabPanels from 'src/components/core/ReachTabPanels';
 import Tabs from 'src/components/core/ReachTabs';
 import TabLinkList from 'src/components/TabLinkList';
@@ -30,7 +30,40 @@ export const FirewallDetail: React.FC<CombinedProps> = props => {
   // Source the Firewall's ID from the /:id path param.
   const thisFirewallId = props.match.params.id;
 
+  const URL = props.match.url;
+
+  const tabs = [
+    {
+      title: 'Rules',
+      routeName: `${URL}/rules`
+    },
+    {
+      title: 'Linodes',
+      routeName: `${URL}/linodes`
+    }
+  ];
+
+  const matches = (p: string) => {
+    return Boolean(matchPath(p, { path: props.location.pathname }));
+  };
+
   const [updateError, setUpdateError] = React.useState<string | undefined>();
+  const [idx, setIndex] = React.useState(0);
+
+  const getIndex = React.useCallback(() => {
+    return Math.max(
+      tabs.findIndex(tab => matches(tab.routeName)),
+      0
+    );
+  }, [tabs]);
+
+  React.useEffect(() => {
+    setIndex(getIndex());
+  }, [props.match, tabs, getIndex]);
+
+  const navToURL = (index: number) => {
+    props.history.push(tabs[index].routeName);
+  };
 
   // Find the Firewall in the store.
   const thisFirewall = props.itemsById[thisFirewallId];
@@ -53,23 +86,6 @@ export const FirewallDetail: React.FC<CombinedProps> = props => {
   if (!thisFirewall) {
     return <NotFound />;
   }
-
-  const URL = props.match.url;
-
-  const tabs = [
-    {
-      title: 'Rules',
-      routeName: `${URL}/rules`
-    },
-    {
-      title: 'Linodes',
-      routeName: `${URL}/linodes`
-    }
-  ];
-
-  const matches = (p: string) => {
-    return Boolean(matchPath(p, { path: props.location.pathname }));
-  };
 
   const handleLabelChange = (newLabel: string) => {
     setUpdateError(undefined);
@@ -108,22 +124,22 @@ export const FirewallDetail: React.FC<CombinedProps> = props => {
         />
         <DocumentationButton href="https://linode.com/docs/platform/cloud-firewall/getting-started-with-cloud-firewall/" />
       </Box>
-      <Tabs defaultIndex={tabs.findIndex(tab => matches(tab.routeName))}>
+      <Tabs index={idx} onChange={navToURL}>
         <TabLinkList tabs={tabs} />
 
         <TabPanels>
-          <TabPanel>
+          <SafeTabPanel index={0}>
             <FirewallRulesLanding
               firewallID={+thisFirewallId}
               rules={thisFirewall.rules}
             />
-          </TabPanel>
-          <TabPanel>
+          </SafeTabPanel>
+          <SafeTabPanel index={1}>
             <FirewallLinodesLanding
               firewallID={+thisFirewallId}
               firewallLabel={thisFirewall.label}
             />
-          </TabPanel>
+          </SafeTabPanel>
         </TabPanels>
       </Tabs>
     </React.Fragment>

--- a/packages/manager/src/features/Lish/Lish.tsx
+++ b/packages/manager/src/features/Lish/Lish.tsx
@@ -211,6 +211,10 @@ class Lish extends React.Component<CombinedProps, State> {
     const { classes } = this.props;
     const { authenticated, loading, linode, token } = this.state;
 
+    const navToURL = (index: number) => {
+      this.props.history.push(this.tabs[index].routeName);
+    };
+
     // If the window.close() logic above fails, we render an error state as a fallback
     if (!authenticated) {
       return (
@@ -227,7 +231,7 @@ class Lish extends React.Component<CombinedProps, State> {
 
     return (
       <React.Fragment>
-        <Tabs className={classes.tabs}>
+        <Tabs className={classes.tabs} onChange={navToURL}>
           <TabLinkList className={classes.lish} tabs={this.tabs} />
           <TabPanels>
             {linode && token && (

--- a/packages/manager/src/features/Longview/LongviewDetail/LongviewDetail.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/LongviewDetail.tsx
@@ -166,19 +166,6 @@ export const LongviewDetail: React.FC<CombinedProps> = props => {
     return Boolean(matchPath(p, { path: props.location.pathname }));
   };
 
-  const getIndex = React.useCallback(() => {
-    return Math.max(
-      tabs.findIndex(tab => matches(tab.routeName)),
-      0
-    );
-  }, [tabs]);
-
-  const [idx, setIndex] = React.useState(0);
-
-  React.useEffect(() => {
-    setIndex(getIndex());
-  }, [props.match, tabs, getIndex]);
-
   const navToURL = (index: number) => {
     props.history.push(tabs[index].routeName);
   };
@@ -237,7 +224,14 @@ export const LongviewDetail: React.FC<CombinedProps> = props => {
           text={thisNotification.TEXT}
         />
       ))}
-      <Tabs index={idx} onChange={navToURL} className={classes.tabList}>
+      <Tabs
+        index={Math.max(
+          tabs.findIndex(tab => matches(tab.routeName)),
+          0
+        )}
+        onChange={navToURL}
+        className={classes.tabList}
+      >
         <TabLinkList tabs={tabs} />
 
         <React.Suspense fallback={<SuspenseLoader />}>

--- a/packages/manager/src/features/Longview/LongviewDetail/LongviewDetail.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/LongviewDetail.tsx
@@ -166,6 +166,23 @@ export const LongviewDetail: React.FC<CombinedProps> = props => {
     return Boolean(matchPath(p, { path: props.location.pathname }));
   };
 
+  const getIndex = React.useCallback(() => {
+    return Math.max(
+      tabs.findIndex(tab => matches(tab.routeName)),
+      0
+    );
+  }, [tabs]);
+
+  const [idx, setIndex] = React.useState(0);
+
+  React.useEffect(() => {
+    setIndex(getIndex());
+  }, [props.match, tabs, getIndex]);
+
+  const navToURL = (index: number) => {
+    props.history.push(tabs[index].routeName);
+  };
+
   if (longviewClientsLoading && longviewClientsLastUpdated === 0) {
     return (
       <Paper>
@@ -220,10 +237,7 @@ export const LongviewDetail: React.FC<CombinedProps> = props => {
           text={thisNotification.TEXT}
         />
       ))}
-      <Tabs
-        defaultIndex={tabs.findIndex(tab => matches(tab.routeName)) || 0}
-        className={classes.tabList}
-      >
+      <Tabs index={idx} onChange={navToURL} className={classes.tabList}>
         <TabLinkList tabs={tabs} />
 
         <React.Suspense fallback={<SuspenseLoader />}>

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewLanding.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewLanding.tsx
@@ -49,19 +49,6 @@ export const LongviewLanding: React.FunctionComponent<CombinedProps> = props => 
     return Boolean(matchPath(p, { path: props.location.pathname }));
   };
 
-  const getIndex = React.useCallback(() => {
-    return Math.max(
-      tabs.findIndex(tab => matches(tab.routeName)),
-      0
-    );
-  }, [tabs]);
-
-  const [idx, setIndex] = React.useState(0);
-
-  React.useEffect(() => {
-    setIndex(getIndex());
-  }, [props.match, tabs, getIndex]);
-
   const navToURL = (index: number) => {
     props.history.push(tabs[index].routeName);
   };
@@ -78,7 +65,13 @@ export const LongviewLanding: React.FunctionComponent<CombinedProps> = props => 
           href={'https://www.linode.com/docs/platform/longview/longview/'}
         />
       </Box>
-      <Tabs index={idx} onChange={navToURL}>
+      <Tabs
+        index={Math.max(
+          tabs.findIndex(tab => matches(tab.routeName)),
+          0
+        )}
+        onChange={navToURL}
+      >
         <TabLinkList tabs={tabs} />
 
         <React.Suspense fallback={<SuspenseLoader />}>

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewLanding.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewLanding.tsx
@@ -49,6 +49,23 @@ export const LongviewLanding: React.FunctionComponent<CombinedProps> = props => 
     return Boolean(matchPath(p, { path: props.location.pathname }));
   };
 
+  const getIndex = React.useCallback(() => {
+    return Math.max(
+      tabs.findIndex(tab => matches(tab.routeName)),
+      0
+    );
+  }, [tabs]);
+
+  const [idx, setIndex] = React.useState(0);
+
+  React.useEffect(() => {
+    setIndex(getIndex());
+  }, [props.match, tabs, getIndex]);
+
+  const navToURL = (index: number) => {
+    props.history.push(tabs[index].routeName);
+  };
+
   return (
     <React.Fragment>
       <Box display="flex" flexDirection="row" justifyContent="space-between">
@@ -61,7 +78,7 @@ export const LongviewLanding: React.FunctionComponent<CombinedProps> = props => 
           href={'https://www.linode.com/docs/platform/longview/longview/'}
         />
       </Box>
-      <Tabs defaultIndex={tabs.findIndex(tab => matches(tab.routeName))}>
+      <Tabs index={idx} onChange={navToURL}>
         <TabLinkList tabs={tabs} />
 
         <React.Suspense fallback={<SuspenseLoader />}>

--- a/packages/manager/src/features/Managed/ManagedLandingContent.tsx
+++ b/packages/manager/src/features/Managed/ManagedLandingContent.tsx
@@ -103,19 +103,6 @@ export const ManagedLandingContent: React.FC<CombinedProps> = props => {
     return Boolean(matchPath(p, { path: props.location.pathname }));
   };
 
-  const getIndex = React.useCallback(() => {
-    return Math.max(
-      tabs.findIndex(tab => matches(tab.routeName)),
-      0
-    );
-  }, [tabs]);
-
-  const [idx, setIndex] = React.useState(0);
-
-  React.useEffect(() => {
-    setIndex(getIndex());
-  }, [props.match, tabs, getIndex]);
-
   const navToURL = (index: number) => {
     props.history.push(tabs[index].routeName);
   };
@@ -147,7 +134,13 @@ export const ManagedLandingContent: React.FC<CombinedProps> = props => {
           </Grid>
         </Grid>
       </Box>
-      <Tabs index={idx} onChange={navToURL}>
+      <Tabs
+        index={Math.max(
+          tabs.findIndex(tab => matches(tab.routeName)),
+          0
+        )}
+        onChange={navToURL}
+      >
         <TabLinkList tabs={tabs} />
 
         <React.Suspense fallback={<SuspenseLoader />}>

--- a/packages/manager/src/features/Managed/ManagedLandingContent.tsx
+++ b/packages/manager/src/features/Managed/ManagedLandingContent.tsx
@@ -103,6 +103,23 @@ export const ManagedLandingContent: React.FC<CombinedProps> = props => {
     return Boolean(matchPath(p, { path: props.location.pathname }));
   };
 
+  const getIndex = React.useCallback(() => {
+    return Math.max(
+      tabs.findIndex(tab => matches(tab.routeName)),
+      0
+    );
+  }, [tabs]);
+
+  const [idx, setIndex] = React.useState(0);
+
+  React.useEffect(() => {
+    setIndex(getIndex());
+  }, [props.match, tabs, getIndex]);
+
+  const navToURL = (index: number) => {
+    props.history.push(tabs[index].routeName);
+  };
+
   const ContactsTable = flags.cmr ? Contacts_CMR : Contacts;
   const Credentials = flags.cmr ? CredentialList_CMR : CredentialList;
 
@@ -130,7 +147,7 @@ export const ManagedLandingContent: React.FC<CombinedProps> = props => {
           </Grid>
         </Grid>
       </Box>
-      <Tabs defaultIndex={tabs.findIndex(tab => matches(tab.routeName))}>
+      <Tabs index={idx} onChange={navToURL}>
         <TabLinkList tabs={tabs} />
 
         <React.Suspense fallback={<SuspenseLoader />}>

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
@@ -280,6 +280,10 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
       updateTags: this.updateTags
     };
 
+    const navToURL = (index: number) => {
+      this.props.history.push(this.tabs[index].routeName);
+    };
+
     return (
       <NodeBalancerProvider value={p}>
         <React.Fragment>
@@ -299,10 +303,11 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
           </Grid>
           {errorMap.none && <Notice error text={errorMap.none} />}
           <Tabs
-            defaultIndex={Math.max(
+            index={Math.max(
               this.tabs.findIndex(tab => matches(tab.routeName)),
               0
             )}
+            onChange={navToURL}
           >
             <TabLinkList tabs={this.tabs} />
 

--- a/packages/manager/src/features/ObjectStorage/ObjectStorageLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectStorageLanding.tsx
@@ -96,6 +96,23 @@ export const ObjectStorageLanding: React.FC<CombinedProps> = props => {
     return Boolean(matchPath(p, { path: props.location.pathname }));
   };
 
+  const getIndex = React.useCallback(() => {
+    return Math.max(
+      tabs.findIndex(tab => matches(tab.routeName)),
+      0
+    );
+  }, [tabs]);
+
+  const [idx, setIndex] = React.useState(0);
+
+  React.useEffect(() => {
+    setIndex(getIndex());
+  }, [props.match, tabs, getIndex]);
+
+  const navToURL = (index: number) => {
+    props.history.push(tabs[index].routeName);
+  };
+
   const flags = useFlags();
 
   const objPromotionalOffers = (
@@ -125,7 +142,7 @@ export const ObjectStorageLanding: React.FC<CombinedProps> = props => {
           <DocumentationButton href="https://www.linode.com/docs/platform/object-storage/" />
         )}
       </Box>
-      <Tabs defaultIndex={tabs.findIndex(tab => matches(tab.routeName))}>
+      <Tabs index={idx} onChange={navToURL}>
         <TabLinkList tabs={tabs} />
 
         {objPromotionalOffers.map(promotionalOffer => (

--- a/packages/manager/src/features/ObjectStorage/ObjectStorageLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectStorageLanding.tsx
@@ -96,19 +96,6 @@ export const ObjectStorageLanding: React.FC<CombinedProps> = props => {
     return Boolean(matchPath(p, { path: props.location.pathname }));
   };
 
-  const getIndex = React.useCallback(() => {
-    return Math.max(
-      tabs.findIndex(tab => matches(tab.routeName)),
-      0
-    );
-  }, [tabs]);
-
-  const [idx, setIndex] = React.useState(0);
-
-  React.useEffect(() => {
-    setIndex(getIndex());
-  }, [props.match, tabs, getIndex]);
-
   const navToURL = (index: number) => {
     props.history.push(tabs[index].routeName);
   };
@@ -142,7 +129,13 @@ export const ObjectStorageLanding: React.FC<CombinedProps> = props => {
           <DocumentationButton href="https://www.linode.com/docs/platform/object-storage/" />
         )}
       </Box>
-      <Tabs index={idx} onChange={navToURL}>
+      <Tabs
+        index={Math.max(
+          tabs.findIndex(tab => matches(tab.routeName)),
+          0
+        )}
+        onChange={navToURL}
+      >
         <TabLinkList tabs={tabs} />
 
         {objPromotionalOffers.map(promotionalOffer => (

--- a/packages/manager/src/features/Profile/Profile.tsx
+++ b/packages/manager/src/features/Profile/Profile.tsx
@@ -73,14 +73,28 @@ const Profile: React.FC<Props> = props => {
     return Boolean(matchPath(p, { path: location.pathname }));
   };
 
+  const getIndex = React.useCallback(() => {
+    return Math.max(
+      tabs.findIndex(tab => matches(tab.routeName)),
+      0
+    );
+  }, [tabs]);
+
+  const [idx, setIndex] = React.useState(0);
+
+  React.useEffect(() => {
+    setIndex(getIndex());
+  }, [props.match, tabs, getIndex]);
+
+  const navToURL = (index: number) => {
+    props.history.push(tabs[index].routeName);
+  };
+
   return (
     <React.Fragment>
       <DocumentTitleSegment segment="My Profile " />
       <H1Header title="My Profile" data-qa-profile-header />
-      <Tabs
-        defaultIndex={tabs.findIndex(tab => matches(tab.routeName))}
-        data-qa-tabs
-      >
+      <Tabs index={idx} onChange={navToURL} data-qa-tabs>
         <TabLinkList tabs={tabs} />
 
         <React.Suspense fallback={<SuspenseLoader />}>

--- a/packages/manager/src/features/Profile/Profile.tsx
+++ b/packages/manager/src/features/Profile/Profile.tsx
@@ -73,19 +73,6 @@ const Profile: React.FC<Props> = props => {
     return Boolean(matchPath(p, { path: location.pathname }));
   };
 
-  const getIndex = React.useCallback(() => {
-    return Math.max(
-      tabs.findIndex(tab => matches(tab.routeName)),
-      0
-    );
-  }, [tabs]);
-
-  const [idx, setIndex] = React.useState(0);
-
-  React.useEffect(() => {
-    setIndex(getIndex());
-  }, [props.match, tabs, getIndex]);
-
   const navToURL = (index: number) => {
     props.history.push(tabs[index].routeName);
   };
@@ -94,7 +81,14 @@ const Profile: React.FC<Props> = props => {
     <React.Fragment>
       <DocumentTitleSegment segment="My Profile " />
       <H1Header title="My Profile" data-qa-profile-header />
-      <Tabs index={idx} onChange={navToURL} data-qa-tabs>
+      <Tabs
+        index={Math.max(
+          tabs.findIndex(tab => matches(tab.routeName)),
+          0
+        )}
+        onChange={navToURL}
+        data-qa-tabs
+      >
         <TabLinkList tabs={tabs} />
 
         <React.Suspense fallback={<SuspenseLoader />}>

--- a/packages/manager/src/features/Users/UserDetail.tsx
+++ b/packages/manager/src/features/Users/UserDetail.tsx
@@ -331,6 +331,10 @@ class UserDetail extends React.Component<CombinedProps> {
         />
       );
 
+    const navToURL = (index: number) => {
+      this.props.history.push(this.tabs[index].routeName);
+    };
+
     return (
       <React.Fragment>
         <Grid container justify="space-between">
@@ -347,7 +351,7 @@ class UserDetail extends React.Component<CombinedProps> {
             />
           </Grid>
         </Grid>
-        <Tabs defaultIndex={this.clampTabChoice()}>
+        <Tabs defaultIndex={this.clampTabChoice()} onChange={navToURL}>
           <TabLinkList tabs={this.tabs} />
 
           {createdUsername && (

--- a/packages/manager/src/features/linodes/CloneLanding/CloneLanding.tsx
+++ b/packages/manager/src/features/linodes/CloneLanding/CloneLanding.tsx
@@ -22,7 +22,7 @@ import { AnyAction } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
-import TabPanel from 'src/components/core/ReachTabPanel';
+import SafeTabPanel from 'src/components/SafeTabPanel';
 import TabPanels from 'src/components/core/ReachTabPanels';
 import Tabs from 'src/components/core/ReachTabs';
 import TabLinkList from 'src/components/TabLinkList';
@@ -127,6 +127,23 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
   // Helper function for the <Tabs /> component
   const matches = (p: string) => {
     return Boolean(matchPath(p, { path: props.location.pathname }));
+  };
+
+  const getIndex = React.useCallback(() => {
+    return Math.max(
+      tabs.findIndex(tab => matches(tab.routeName)),
+      0
+    );
+  }, [tabs]);
+
+  const [idx, setIndex] = React.useState(0);
+
+  React.useEffect(() => {
+    setIndex(getIndex());
+  }, [props.match, tabs, getIndex]);
+
+  const navToURL = (index: number) => {
+    props.history.push(tabs[index].routeName);
   };
 
   /**
@@ -344,10 +361,10 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
               Clone
             </Typography>
 
-            <Tabs defaultIndex={tabs.findIndex(tab => matches(tab.routeName))}>
+            <Tabs index={idx} onChange={navToURL}>
               <TabLinkList tabs={tabs} />
               <TabPanels>
-                <TabPanel>
+                <SafeTabPanel index={0}>
                   <div className={classes.outerContainer}>
                     <Configs
                       configs={configsInState}
@@ -355,9 +372,9 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
                       handleSelect={toggleConfig}
                     />
                   </div>
-                </TabPanel>
+                </SafeTabPanel>
 
-                <TabPanel>
+                <SafeTabPanel index={1}>
                   <div className={classes.outerContainer}>
                     <Typography>
                       You can make a copy of a disk to the same or different
@@ -374,7 +391,7 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
                       />
                     </div>
                   </div>
-                </TabPanel>
+                </SafeTabPanel>
               </TabPanels>
             </Tabs>
           </Paper>

--- a/packages/manager/src/features/linodes/CloneLanding/CloneLanding.tsx
+++ b/packages/manager/src/features/linodes/CloneLanding/CloneLanding.tsx
@@ -129,19 +129,6 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
     return Boolean(matchPath(p, { path: props.location.pathname }));
   };
 
-  const getIndex = React.useCallback(() => {
-    return Math.max(
-      tabs.findIndex(tab => matches(tab.routeName)),
-      0
-    );
-  }, [tabs]);
-
-  const [idx, setIndex] = React.useState(0);
-
-  React.useEffect(() => {
-    setIndex(getIndex());
-  }, [props.match, tabs, getIndex]);
-
   const navToURL = (index: number) => {
     props.history.push(tabs[index].routeName);
   };
@@ -361,7 +348,13 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
               Clone
             </Typography>
 
-            <Tabs index={idx} onChange={navToURL}>
+            <Tabs
+              index={Math.max(
+                tabs.findIndex(tab => matches(tab.routeName)),
+                0
+              )}
+              onChange={navToURL}
+            >
               <TabLinkList tabs={tabs} />
               <TabPanels>
                 <SafeTabPanel index={0}>

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -223,9 +223,6 @@ export class LinodeCreate extends React.PureComponent<
   handleTabChange = (index: number) => {
     this.props.resetCreationState();
 
-    // Update URL to match tab change
-    this.props.history.push(this.tabs[index].routeName);
-
     /** set the tab in redux state */
     this.props.setTab(this.tabs[index].type);
 

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -266,14 +266,14 @@ export class LinodeCreate extends React.PureComponent<
 
   stackScriptTabs: CreateTab[] = [
     {
-      title: 'Community StackScripts',
-      type: 'fromStackScript',
-      routeName: `${this.props.match.url}?type=StackScripts&subtype=Community`
-    },
-    {
       title: 'Account StackScripts',
       type: 'fromStackScript',
       routeName: `${this.props.match.url}?type=StackScripts&subtype=Account`
+    },
+    {
+      title: 'Community StackScripts',
+      type: 'fromStackScript',
+      routeName: `${this.props.match.url}?type=StackScripts&subtype=Community`
     }
   ];
 
@@ -453,10 +453,10 @@ export class LinodeCreate extends React.PureComponent<
                     <TabPanels className={classes.imageSelect}>
                       <SafeTabPanel index={0}>
                         <FromStackScriptContent
-                          category="community"
+                          category="account"
                           accountBackupsEnabled={accountBackupsEnabled}
                           userCannotCreateLinode={userCannotCreateLinode}
-                          request={getCommunityStackscripts}
+                          request={getMineAndAccountStackScripts}
                           header={'Select a StackScript'}
                           imagesData={imagesData!}
                           regionsData={regionsData!}
@@ -466,10 +466,10 @@ export class LinodeCreate extends React.PureComponent<
                       </SafeTabPanel>
                       <SafeTabPanel index={1}>
                         <FromStackScriptContent
-                          category="account"
+                          category="community"
                           accountBackupsEnabled={accountBackupsEnabled}
                           userCannotCreateLinode={userCannotCreateLinode}
-                          request={getMineAndAccountStackScripts}
+                          request={getCommunityStackscripts}
                           header={'Select a StackScript'}
                           imagesData={imagesData!}
                           regionsData={regionsData!}

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -223,6 +223,9 @@ export class LinodeCreate extends React.PureComponent<
   handleTabChange = (index: number) => {
     this.props.resetCreationState();
 
+    // Update URL to match tab change
+    this.props.history.push(this.tabs[index].routeName);
+
     /** set the tab in redux state */
     this.props.setTab(this.tabs[index].type);
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation.tsx
@@ -80,25 +80,22 @@ const LinodesDetailNavigation: React.FC<CombinedProps> = props => {
     }
   ];
 
-  const getIndex = React.useCallback(() => {
-    return Math.max(
-      tabs.findIndex(tab => matches(tab.routeName)),
-      0
-    );
-  }, [tabs]);
-
-  const [idx, setIndex] = React.useState(0);
-
-  React.useEffect(() => {
-    setIndex(getIndex());
-  }, [props.match, tabs, getIndex]);
+  const matches = (p: string) => {
+    return Boolean(matchPath(p, { path: location.pathname }));
+  };
 
   const navToURL = (index: number) => {
     props.history.push(tabs[index].routeName);
   };
 
   return (
-    <Tabs index={idx} onChange={navToURL}>
+    <Tabs
+      index={Math.max(
+        tabs.findIndex(tab => matches(tab.routeName)),
+        0
+      )}
+      onChange={navToURL}
+    >
       <TabLinkList tabs={tabs} />
 
       <React.Suspense fallback={<SuspenseLoader />}>
@@ -153,10 +150,6 @@ const LinodesDetailNavigation: React.FC<CombinedProps> = props => {
       </React.Suspense>
     </Tabs>
   );
-};
-
-const matches = (p: string) => {
-  return Boolean(matchPath(p, { path: location.pathname }));
 };
 
 interface ContextProps {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation.tsx
@@ -80,13 +80,25 @@ const LinodesDetailNavigation: React.FC<CombinedProps> = props => {
     }
   ];
 
+  const getIndex = React.useCallback(() => {
+    return Math.max(
+      tabs.findIndex(tab => matches(tab.routeName)),
+      0
+    );
+  }, [tabs]);
+
+  const [idx, setIndex] = React.useState(0);
+
+  React.useEffect(() => {
+    setIndex(getIndex());
+  }, [props.match, tabs, getIndex]);
+
+  const navToURL = (index: number) => {
+    props.history.push(tabs[index].routeName);
+  };
+
   return (
-    <Tabs
-      defaultIndex={Math.max(
-        tabs.findIndex(tab => matches(tab.routeName)),
-        0
-      )}
-    >
+    <Tabs index={idx} onChange={navToURL}>
       <TabLinkList tabs={tabs} />
 
       <React.Suspense fallback={<SuspenseLoader />}>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation_CMR.tsx
@@ -77,20 +77,29 @@ const LinodesDetailNavigation: React.FC<CombinedProps> = props => {
     return Boolean(matchPath(p, { path: location.pathname }));
   };
 
-  const defaultIndex = tabs.findIndex(tab => matches(tab.routeName));
+  const getIndex = React.useCallback(() => {
+    return Math.max(
+      tabs.findIndex(tab => matches(tab.routeName)),
+      0
+    );
+  }, [tabs]);
 
-  const [tabIndex, setTabIndex] = React.useState(Math.max(defaultIndex, 0));
+  const [idx, setIndex] = React.useState(0);
 
-  const handleTabChange = (index: number) => {
-    setTabIndex(index);
+  React.useEffect(() => {
+    setIndex(getIndex());
+  }, [props.match, tabs, getIndex]);
+
+  const navToURL = (index: number) => {
+    props.history.push(tabs[index].routeName);
   };
 
   return (
     <>
       <DocumentTitleSegment
-        segment={`${linodeLabel} - ${tabs[tabIndex]?.title ?? 'Detail View'}`}
+        segment={`${linodeLabel} - ${tabs[idx]?.title ?? 'Detail View'}`}
       />
-      <Tabs index={tabIndex} onChange={handleTabChange}>
+      <Tabs index={idx} onChange={navToURL}>
         <TabLinkList tabs={tabs} />
 
         <React.Suspense fallback={<SuspenseLoader />}>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation_CMR.tsx
@@ -77,18 +77,12 @@ const LinodesDetailNavigation: React.FC<CombinedProps> = props => {
     return Boolean(matchPath(p, { path: location.pathname }));
   };
 
-  const getIndex = React.useCallback(() => {
+  const getIndex = () => {
     return Math.max(
       tabs.findIndex(tab => matches(tab.routeName)),
       0
     );
-  }, [tabs]);
-
-  const [idx, setIndex] = React.useState(0);
-
-  React.useEffect(() => {
-    setIndex(getIndex());
-  }, [props.match, tabs, getIndex]);
+  };
 
   const navToURL = (index: number) => {
     props.history.push(tabs[index].routeName);
@@ -97,9 +91,9 @@ const LinodesDetailNavigation: React.FC<CombinedProps> = props => {
   return (
     <>
       <DocumentTitleSegment
-        segment={`${linodeLabel} - ${tabs[idx]?.title ?? 'Detail View'}`}
+        segment={`${linodeLabel} - ${tabs[getIndex()]?.title ?? 'Detail View'}`}
       />
-      <Tabs index={idx} onChange={navToURL}>
+      <Tabs index={getIndex()} onChange={navToURL}>
         <TabLinkList tabs={tabs} />
 
         <React.Suspense fallback={<SuspenseLoader />}>


### PR DESCRIPTION
## Description

When we made the switch to reach tabs, the active tab was only reflected in the UI, not in the url (unless you hard-refresh). This fixes that as you switch tabs, either via click or with keyboard, the url will be updated. This is based off work Jared had done here: https://github.com/linode/manager/pull/6757/ and converts any tab components using TabLinkList to follow this pattern (as that component is using Link from react-router under the hood). The one section I'm a little hesitant on is the Linode Create flow- this section feels noticeably slower but we're also updating create type in redux so there is a bit more complexity going on here than elsewhere. 

## Type of Change
- Bug fix ('repair')

## Note to Reviewers

I looked into converting to reach-router instead, but this [article](https://reacttraining.com/blog/reach-react-router-future/#:~:text=React%20Router%20will%20offer%20an,to%20pick%20%40reach%2Frouter.&text=If%20you%20have%20a%20lot,want%20to%20pick%20React%20Router)  convinced me to not for 2 reasons:

• React Router will be the true 'surviving' project, though Reach will still be maintained via bug fixes.
• "If you have a lot of routes, especially with a lot of nested Route and Switch components, you may want to pick React Router. It will be 100% backward compatible, offering an incremental migration path to the new hook-based APIs."- I feel that this fits our uses more, since we use tabs/React-Router pretty extensively throughout the app and in more complex ways than I think Reach Router is designed to support.
