### PR TITLE
M3-4541 Add: VLAN methods/types to JS Client

### DIFF
--- a/packages/api-v4/.eslintrc.js
+++ b/packages/api-v4/.eslintrc.js
@@ -2,7 +2,7 @@ module.exports = {
   ignorePatterns: ['node_modules', 'lib', 'index.js', '!.eslintrc.js'],
   parser: '@typescript-eslint/parser', // Specifies the ESLint parser
   parserOptions: {
-    // Warning if you want to set tsconfig.json, you ll need laso to set `tsconfigRootDir:__dirname`
+    // Warning if you want to set tsconfig.json, you'll need to also set `tsconfigRootDir:__dirname`
     // BUT we decided not to use this feature due to a very important performance impact
     // project: 'tsconfig.json',
     ecmaVersion: 2020,

--- a/packages/api-v4/src/index.ts
+++ b/packages/api-v4/src/index.ts
@@ -28,6 +28,8 @@ export * from './support';
 
 export * from './tags';
 
+export * from './vlans';
+
 export * from './volumes';
 
 export { baseRequest, setToken } from './request';

--- a/packages/api-v4/src/linodes/index.ts
+++ b/packages/api-v4/src/linodes/index.ts
@@ -8,6 +8,8 @@ export * from './disks';
 
 export * from './info';
 
+export * from './interfaces';
+
 export * from './ips';
 
 export * from './linodes.schema';

--- a/packages/api-v4/src/linodes/interfaces.ts
+++ b/packages/api-v4/src/linodes/interfaces.ts
@@ -20,7 +20,7 @@ import { LinodeInterface, LinodeInterfacePayload } from './types';
  */
 export const getInterfaces = (linodeID: number, params?: any, filters?: any) =>
   Request<Page<LinodeInterface>>(
-    setURL(`${API_ROOT}/linode/instances/${linodeID}`),
+    setURL(`${API_ROOT}/linode/instances/${linodeID}/interfaces`),
     setMethod('GET'),
     setXFilter(filters),
     setParams(params)
@@ -34,7 +34,9 @@ export const getInterfaces = (linodeID: number, params?: any, filters?: any) =>
  */
 export const getInterface = (linodeID: number, interfaceID: number) =>
   Request<LinodeInterface>(
-    setURL(`${API_ROOT}/linode/instances/${linodeID}/${interfaceID}`),
+    setURL(
+      `${API_ROOT}/linode/instances/${linodeID}/interfaces/${interfaceID}`
+    ),
     setMethod('GET')
   );
 
@@ -52,7 +54,7 @@ export const createInterface = (
   data: LinodeInterfacePayload
 ) =>
   Request<LinodeInterface>(
-    setURL(`${API_ROOT}/linode/instances/${linodeID}`),
+    setURL(`${API_ROOT}/linode/instances/${linodeID}/interfaces`),
     setMethod('POST'),
     setData(data)
   );
@@ -65,6 +67,8 @@ export const createInterface = (
  */
 export const deleteInterface = (linodeID: number, interfaceID: number) =>
   Request<LinodeInterface>(
-    setURL(`${API_ROOT}/linode/instances/${linodeID}/${interfaceID}`),
+    setURL(
+      `${API_ROOT}/linode/instances/${linodeID}/interfaces/${interfaceID}`
+    ),
     setMethod('DELETE')
   );

--- a/packages/api-v4/src/linodes/interfaces.ts
+++ b/packages/api-v4/src/linodes/interfaces.ts
@@ -1,0 +1,70 @@
+// @todo use beta api root once API bug is fixed
+import { API_ROOT } from 'src/constants';
+import Request, {
+  setData,
+  setMethod,
+  setParams,
+  setURL,
+  setXFilter
+} from 'src/request';
+import { ResourcePage as Page } from '../types';
+
+import { LinodeInterface, LinodeInterfacePayload } from './types';
+
+/**
+ * getInterfaces
+ *
+ * Return a list of network interfaces attached to the current
+ * Linode
+ *
+ */
+export const getInterfaces = (linodeID: number, params?: any, filters?: any) =>
+  Request<Page<LinodeInterface>>(
+    setURL(`${API_ROOT}/linode/instances/${linodeID}`),
+    setMethod('GET'),
+    setXFilter(filters),
+    setParams(params)
+  );
+
+/**
+ * getInterface
+ *
+ * Return details about a single Linode interface
+ *
+ */
+export const getInterface = (linodeID: number, interfaceID: number) =>
+  Request<LinodeInterface>(
+    setURL(`${API_ROOT}/linode/instances/${linodeID}/${interfaceID}`),
+    setMethod('GET')
+  );
+
+/**
+ * createInterface
+ *
+ * Attach a new interface to a Linode. Two types of interface are
+ * supported, default (which creates a public interface)
+ * and additional. When creating an additional interface, a vlan_id
+ * is required.
+ *
+ */
+export const createInterface = (
+  linodeID: number,
+  data: LinodeInterfacePayload
+) =>
+  Request<LinodeInterface>(
+    setURL(`${API_ROOT}/linode/instances/${linodeID}`),
+    setMethod('POST'),
+    setData(data)
+  );
+
+/**
+ * deleteInterface
+ *
+ * Return details about a single Linode interface
+ *
+ */
+export const deleteInterface = (linodeID: number, interfaceID: number) =>
+  Request<LinodeInterface>(
+    setURL(`${API_ROOT}/linode/instances/${linodeID}/${interfaceID}`),
+    setMethod('DELETE')
+  );

--- a/packages/api-v4/src/linodes/linodes.schema.ts
+++ b/packages/api-v4/src/linodes/linodes.schema.ts
@@ -1,4 +1,4 @@
-import { array, boolean, mixed, number, object, string } from 'yup';
+import { array, boolean, lazy, mixed, number, object, string } from 'yup';
 // import zxcvbn from 'zxcvbn';
 // import { MINIMUM_PASSWORD_STRENGTH } from 'src/constants';
 
@@ -186,6 +186,25 @@ const helpers = object({
   devtmpfs_automount: boolean()
 });
 
+/**
+ * Interfaces are Record<string, InterfaceItem>
+ *
+ * {
+ *  "eth0": { "id": 10 },
+ *  "eth1": { "id": 12 }
+ * }
+ *
+ * .default() and .lazy() below are required to
+ * make this dynamic field naming work out
+ */
+export const linodeInterfaceItemSchema = object({
+  id: number().required('Interface ID is required.')
+}).default(undefined);
+
+export const linodeInterfaceSchema = lazy((obj: Record<any, any>) =>
+  object(Object.keys(obj).map(_ => linodeInterfaceItemSchema))
+);
+
 export const CreateLinodeConfigSchema = object({
   label: string()
     .required('Label is required.')
@@ -198,7 +217,8 @@ export const CreateLinodeConfigSchema = object({
   run_level: mixed().oneOf(['default', 'single', 'binbash']),
   virt_mode: mixed().oneOf(['paravirt', 'fullvirt']),
   helpers,
-  root_device: string()
+  root_device: string(),
+  interfaces: linodeInterfaceSchema
 });
 
 export const UpdateLinodeConfigSchema = object({
@@ -212,7 +232,8 @@ export const UpdateLinodeConfigSchema = object({
   run_level: mixed().oneOf(['default', 'single', 'binbash']),
   virt_mode: mixed().oneOf(['paravirt', 'fullvirt']),
   helpers,
-  root_device: string()
+  root_device: string(),
+  interfaces: linodeInterfaceSchema
 });
 
 export const CreateLinodeDiskSchema = object({

--- a/packages/api-v4/src/linodes/types.ts
+++ b/packages/api-v4/src/linodes/types.ts
@@ -146,7 +146,7 @@ export type LinodeStatus =
   | 'restoring'
   | 'stopped';
 
-export type InterfaceSlot = Record<string, InterfaceBody>;
+export type InterfaceSlot = Record<string, InterfaceBody>; // e.g. { "eth0": { "id": 111 }}
 
 export interface InterfaceBody {
   id: number;
@@ -255,6 +255,7 @@ export interface LinodeConfigCreationData {
     devtmpfs_automount: boolean;
   };
   root_device: string;
+  interfaces?: InterfaceSlot;
 }
 
 export interface PriceObject {

--- a/packages/api-v4/src/linodes/types.ts
+++ b/packages/api-v4/src/linodes/types.ts
@@ -146,6 +146,11 @@ export type LinodeStatus =
   | 'restoring'
   | 'stopped';
 
+export type InterfaceSlot = Record<string, InterfaceBody>;
+
+export interface InterfaceBody {
+  id: number;
+}
 export interface Config {
   id: number;
   kernel: string;
@@ -160,6 +165,7 @@ export interface Config {
   created: string;
   updated: string;
   initrd: string | null;
+  interfaces: InterfaceSlot;
 }
 
 export interface DiskDevice {
@@ -339,4 +345,21 @@ export interface LinodeDiskCreationData {
   root_pass?: string;
   stackscript_id?: number;
   stackscript_data?: any;
+}
+
+export type InterfaceType = 'default' | 'additional';
+
+export interface LinodeInterfacePayload {
+  type: InterfaceType;
+  vlan_id?: number;
+}
+
+export interface LinodeInterface {
+  id: number;
+  type: InterfaceType;
+  description: string;
+  linode_id: number;
+  vlan_id: number;
+  mac_address: string;
+  ip_address: string;
 }

--- a/packages/api-v4/src/vlans/index.ts
+++ b/packages/api-v4/src/vlans/index.ts
@@ -1,0 +1,5 @@
+export * from './types';
+
+export * from './vlans';
+
+export * from './vlans.schema';

--- a/packages/api-v4/src/vlans/types.ts
+++ b/packages/api-v4/src/vlans/types.ts
@@ -1,0 +1,7 @@
+export interface VLAN {
+  id: number;
+  description: string;
+  region: string;
+  linodes: number[];
+  cidr_block: string;
+}

--- a/packages/api-v4/src/vlans/vlans.schema.ts
+++ b/packages/api-v4/src/vlans/vlans.schema.ts
@@ -1,0 +1,9 @@
+import { array, object, string, number } from 'yup';
+
+export const createVlanSchema = object({
+  description: string()
+    .notRequired()
+    .max(255, 'Description must be 255 characters or less'),
+  region: string().required('Region is required'),
+  linodes: array().of(number())
+});

--- a/packages/api-v4/src/vlans/vlans.ts
+++ b/packages/api-v4/src/vlans/vlans.ts
@@ -1,0 +1,62 @@
+// @todo use beta api root once API bug is fixed
+import { API_ROOT } from 'src/constants';
+import Request, {
+  setData,
+  setMethod,
+  setParams,
+  setURL,
+  setXFilter
+} from 'src/request';
+import { ResourcePage as Page } from '../types';
+
+import { VLAN } from './types';
+
+/**
+ * getVlans
+ *
+ * Return a paginated list of Virtual LANS (VLANS) on this account.
+ *
+ */
+export const getVlans = (params?: any, filters?: any) =>
+  Request<Page<VLAN>>(
+    setURL(`${API_ROOT}/networking/vlans`),
+    setMethod('GET'),
+    setParams(params),
+    setXFilter(filters)
+  );
+
+/**
+ * getVlan
+ *
+ * Return detailed information about a single VLAN
+ *
+ */
+export const getVlan = (vlanID: number) =>
+  Request<Page<VLAN>>(
+    setURL(`${API_ROOT}/networking/vlans/${vlanID}`),
+    setMethod('GET')
+  );
+
+/**
+ * createVlan
+ *
+ * Create a Virtual LAN (VLAN) in the specified region.
+ *
+ */
+export const createVlan = (data: VLAN) =>
+  Request<VLAN>(
+    setURL(`${API_ROOT}/networking/vlans`),
+    setMethod('POST'),
+    setData(data)
+  );
+
+/**
+ * deleteVlan
+ *
+ * Delete a single VLAN
+ */
+export const deleteVlan = (vlanID: number) =>
+  Request<VLAN>(
+    setURL(`${API_ROOT}/networking/vlans/${vlanID}`),
+    setMethod('DELETE')
+  );

--- a/packages/manager/src/__data__/linodeConfigs.ts
+++ b/packages/manager/src/__data__/linodeConfigs.ts
@@ -38,7 +38,8 @@ export const linodeConfigs: Config[] = [
       sdg: null,
       sde: null
     },
-    kernel: 'linode/grub2'
+    kernel: 'linode/grub2',
+    interfaces: {}
   }
 ];
 export const linodeConfig2: Config = {
@@ -78,5 +79,6 @@ export const linodeConfig2: Config = {
     sdg: null,
     sde: null
   },
-  kernel: 'linode/grub2'
+  kernel: 'linode/grub2',
+  interfaces: {}
 };

--- a/packages/manager/src/factories/config.ts
+++ b/packages/manager/src/factories/config.ts
@@ -29,5 +29,6 @@ export const configFactory = Factory.Sync.makeFactory<Config>({
   memory_limit: 0,
   root_device: 'sda',
   run_level: 'default',
-  virt_mode: 'paravirt'
+  virt_mode: 'paravirt',
+  interfaces: {}
 });

--- a/packages/manager/src/factories/linodeConfigs.ts
+++ b/packages/manager/src/factories/linodeConfigs.ts
@@ -40,5 +40,6 @@ export const linodeConfigFactory = Factory.Sync.makeFactory<Config>({
     sdg: null,
     sde: null
   },
-  kernel: 'linode/grub2'
+  kernel: 'linode/grub2',
+  interfaces: {}
 });


### PR DESCRIPTION
## Description

First round of JS stuff for the VLAN API methods. Creating a VLAN seems to only work in dev (no availability errors in prod). I tested the endpoints and payloads in Insomnia, see below for testing suggestions.

Includes: 

- CRUD for VLANS
- CRUD for linode/instances/:id/interfaces (creating/deleting network interfaces on individual Linodes)
- Updating payload for `/linode/instances/:id/configs/:id`, which now returns `interfaces` and allows you to POST to add interfaces to an existing config.

There are a few endpoints in the work, `vlans/id/attach` and `/detach`, which I'm leaving out for now because I don't know when they'll be merged/released on the API side.

## Note to Reviewers

At this point it's fine to focus on the code, response types, etc. To actually use the methods, you can import them in Cloud or use the terminal:

```
cd manager
yarn workspace @linode/api-v4 run build
node
const client = require('@linode/api-v4');
client.setToken(<YOUR TOKEN>);
client.getVLans().then(console.log)
// ..etc

```