### PR TITLE
Added isOpen: False to clear resize modal after confirmation

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -196,7 +196,8 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
           selectedId: '',
           confirmationDialog: {
             ...this.state.confirmationDialog,
-            submitting: false
+            submitting: false,
+            isOpen: false
           }
         });
         resetEventsPolling();


### PR DESCRIPTION
This looks to fix the issue of the Resize modal not disappearing after one confirms the plan resize at cloud.linode.com/linodes/$LINODE_ID/resize. Currently, after confirming the resize the modal hangs around, requiring the user to either click 'Cancel' to close the modal or refresh the page.