### PR TITLE
Add: Redux for VLANs

### DIFF
--- a/packages/api-v4/src/vlans/types.ts
+++ b/packages/api-v4/src/vlans/types.ts
@@ -5,3 +5,10 @@ export interface VLAN {
   linodes: number[];
   cidr_block: string;
 }
+
+export interface CreateVLANPayload {
+  description?: string;
+  region: string;
+  linodes?: number[];
+  cidr_block?: string;
+}

--- a/packages/api-v4/src/vlans/vlans.ts
+++ b/packages/api-v4/src/vlans/vlans.ts
@@ -60,3 +60,31 @@ export const deleteVlan = (vlanID: number) =>
     setURL(`${API_ROOT}/networking/vlans/${vlanID}`),
     setMethod('DELETE')
   );
+
+/**
+ * connectVlan
+ *
+ * Connect one or more Linodes from a VLAN. The VLAN
+ * will be attached to an interface on every config
+ * on each target Linode.
+ */
+export const connectVlan = (vlanID: number, linodes: number[]) =>
+  Request<VLAN>(
+    setURL(`${API_ROOT}/networking/vlans/${vlanID}/connect`),
+    setMethod('POST'),
+    setData({ linodes })
+  );
+
+/**
+ * disconnectVlan
+ *
+ * Disconnect one or more Linodes from a VLAN. The VLAN
+ * will be detached from every config
+ * on each target Linode.
+ */
+export const disconnectVlan = (vlanID: number, linodes: number[]) =>
+  Request<VLAN>(
+    setURL(`${API_ROOT}/networking/vlans/${vlanID}/disconnect`),
+    setMethod('POST'),
+    setData({ linodes })
+  );

--- a/packages/manager/src/store/index.ts
+++ b/packages/manager/src/store/index.ts
@@ -167,6 +167,10 @@ import preferences, {
   State as PreferencesState
 } from './preferences/preferences.reducer';
 import { initReselectDevtools } from './selectors';
+import vlans, {
+  defaultState as defaultVLANState,
+  State as VlanState
+} from './vlans/vlans.reducer';
 
 const reduxDevTools = (window as any).__REDUX_DEVTOOLS_EXTENSION__;
 initReselectDevtools();
@@ -194,7 +198,8 @@ const __resourcesDefaultState = {
   types: defaultTypesState,
   volumes: defaultVolumesState,
   buckets: defaultBucketsState,
-  clusters: defaultClustersState
+  clusters: defaultClustersState,
+  vlans: defaultVLANState
 };
 
 export interface ResourcesState {
@@ -218,6 +223,7 @@ export interface ResourcesState {
   volumes: VolumesState;
   buckets: BucketsState;
   clusters: ClustersState;
+  vlans: VlanState;
 }
 
 export interface ApplicationState {
@@ -289,7 +295,8 @@ const __resources = combineReducers({
   types,
   volumes,
   buckets,
-  clusters
+  clusters,
+  vlans
 });
 
 const reducers = combineReducers<ApplicationState>({

--- a/packages/manager/src/store/vlans/vlans.actions.ts
+++ b/packages/manager/src/store/vlans/vlans.actions.ts
@@ -3,7 +3,7 @@ import { APIError } from '@linode/api-v4/lib/types';
 import { GetAllData } from 'src/utilities/getAll';
 import actionCreatorFactory from 'typescript-fsa';
 
-export const actionCreator = actionCreatorFactory(`@@manager/firewalls`);
+export const actionCreator = actionCreatorFactory(`@@manager/vlans`);
 
 export const getVlansActions = actionCreator.async<
   {

--- a/packages/manager/src/store/vlans/vlans.actions.ts
+++ b/packages/manager/src/store/vlans/vlans.actions.ts
@@ -1,0 +1,43 @@
+import { CreateVLANPayload, VLAN } from '@linode/api-v4/lib/vlans';
+import { APIError } from '@linode/api-v4/lib/types';
+import { GetAllData } from 'src/utilities/getAll';
+import actionCreatorFactory from 'typescript-fsa';
+
+export const actionCreator = actionCreatorFactory(`@@manager/firewalls`);
+
+export const getVlansActions = actionCreator.async<
+  {
+    params?: any;
+    filter?: any;
+  },
+  GetAllData<VLAN>,
+  APIError[]
+>(`get-all`);
+
+export const createVlanActions = actionCreator.async<
+  CreateVLANPayload,
+  VLAN,
+  APIError[]
+>(`create`);
+
+export const deleteVlanActions = actionCreator.async<
+  { vlanID: number },
+  {},
+  APIError[]
+>(`delete`);
+
+export interface VLANConnectionParams {
+  vlanID: number;
+  linodes: number[];
+}
+export const connectVlanActions = actionCreator.async<
+  VLANConnectionParams,
+  VLAN,
+  APIError[]
+>(`connect`);
+
+export const disconnectVlanActions = actionCreator.async<
+  VLANConnectionParams,
+  VLAN,
+  APIError[]
+>(`disconnect`);

--- a/packages/manager/src/store/vlans/vlans.reducer.ts
+++ b/packages/manager/src/store/vlans/vlans.reducer.ts
@@ -1,0 +1,102 @@
+import { VLAN } from '@linode/api-v4/lib/vlans';
+import { Reducer } from 'redux';
+import { isType } from 'typescript-fsa';
+import {
+  createDefaultState,
+  onCreateOrUpdate,
+  onDeleteSuccess,
+  onError,
+  onGetAllSuccess,
+  onStart,
+  setError
+} from '../store.helpers.tmp';
+import { MappedEntityState2 as MappedEntityState } from '../types';
+import {
+  createVlanActions,
+  deleteVlanActions,
+  getVlansActions,
+  connectVlanActions,
+  disconnectVlanActions
+} from './vlans.actions';
+
+export type State = MappedEntityState<VLAN>;
+
+export const defaultState: State = createDefaultState();
+
+/**
+ * Reducer
+ */
+const reducer: Reducer<State> = (state = defaultState, action) => {
+  if (isType(action, getVlansActions.started)) {
+    return onStart(state);
+  }
+
+  if (isType(action, getVlansActions.done)) {
+    const { result } = action.payload;
+    return onGetAllSuccess(result.data, state, result.results);
+  }
+
+  if (isType(action, getVlansActions.failed)) {
+    const { error } = action.payload;
+
+    return onError({ read: error }, state);
+  }
+
+  if (isType(action, createVlanActions.started)) {
+    return setError({ create: undefined }, state);
+  }
+
+  if (isType(action, createVlanActions.done)) {
+    const newVlan = action.payload.result;
+    return onCreateOrUpdate(newVlan, state);
+  }
+
+  if (isType(action, createVlanActions.failed)) {
+    const { error } = action.payload;
+
+    return onError({ create: error }, state);
+  }
+
+  if (
+    isType(action, connectVlanActions.started) ||
+    isType(action, disconnectVlanActions.started)
+  ) {
+    return setError({ update: undefined }, state);
+  }
+
+  if (
+    isType(action, connectVlanActions.done) ||
+    isType(action, disconnectVlanActions.done)
+  ) {
+    const { result } = action.payload;
+    return onCreateOrUpdate(result, state);
+  }
+
+  if (
+    isType(action, connectVlanActions.failed) ||
+    isType(action, disconnectVlanActions.failed)
+  ) {
+    const { error } = action.payload;
+
+    return onError({ update: error }, state);
+  }
+
+  if (isType(action, deleteVlanActions.started)) {
+    return setError({ delete: undefined }, state);
+  }
+
+  if (isType(action, deleteVlanActions.done)) {
+    const { vlanID } = action.payload.params;
+    return onDeleteSuccess(vlanID, state);
+  }
+
+  if (isType(action, deleteVlanActions.failed)) {
+    const { error } = action.payload;
+
+    return onError({ delete: error }, state);
+  }
+
+  return state;
+};
+
+export default reducer;

--- a/packages/manager/src/store/vlans/vlans.requests.ts
+++ b/packages/manager/src/store/vlans/vlans.requests.ts
@@ -1,0 +1,42 @@
+import {
+  createVlan as _create,
+  deleteVlan as _delete,
+  VLAN,
+  getVlans,
+  connectVlan as _connect,
+  disconnectVlan as _disconnect
+} from '@linode/api-v4/lib/vlans';
+import { getAll } from 'src/utilities/getAll';
+import { createRequestThunk } from '../store.helpers.tmp';
+import {
+  createVlanActions,
+  deleteVlanActions,
+  getVlansActions,
+  connectVlanActions,
+  disconnectVlanActions
+} from './vlans.actions';
+
+const getAllVlansRequest = (payload: { params?: any; filter?: any }) =>
+  getAll<VLAN>((passedParams, passedFilter) =>
+    getVlans(passedParams, passedFilter)
+  )(payload.params, payload.filter);
+
+export const getAllVlans = createRequestThunk(
+  getVlansActions,
+  getAllVlansRequest
+);
+
+export const createVlan = createRequestThunk(createVlanActions, _create);
+export const deleteVlan = createRequestThunk(deleteVlanActions, ({ vlanID }) =>
+  _delete(vlanID)
+);
+
+export const connectVlan = createRequestThunk(
+  connectVlanActions,
+  ({ vlanID, linodes }) => _connect(vlanID, linodes)
+);
+
+export const disconnectVlan = createRequestThunk(
+  disconnectVlanActions,
+  ({ vlanID, linodes }) => _disconnect(vlanID, linodes)
+);


### PR DESCRIPTION
## Description

Redux boilerplate for Vlans. No tests for the reducer this time because we entirely rely on the store.helpers methods, which are well-tested elsewhere.

## Note to Reviewers

You can dispatch the thunks from anywhere (VlanLanding is a function component so you can use `const dispatch = useDispatch()`). Make sure the correct actions are called and the state is correct in the Redux dev tools.