### PR TITLE
M3-4482 Part 1: bucket tabs

### DIFF
--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketAccess.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketAccess.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+export const BucketAccess: React.FC<{}> = _ => {
+  return <h2>Bucket Access</h2>;
+};
+
+export default React.memo(BucketAccess);

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -12,12 +12,10 @@ import { RouteComponentProps } from 'react-router-dom';
 import { Waypoint } from 'react-waypoint';
 import { compose } from 'recompose';
 import ActionsPanel from 'src/components/ActionsPanel';
-import Breadcrumb from 'src/components/Breadcrumb';
 import Button from 'src/components/Button';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
-import Box from 'src/components/core/Box';
-import Divider from 'src/components/core/Divider';
 import Grid from 'src/components/core/Grid';
+import Hidden from 'src/components/core/Hidden';
 import Paper from 'src/components/core/Paper';
 import {
   createStyles,
@@ -28,7 +26,6 @@ import {
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
 import Typography from 'src/components/core/Typography';
-import DocumentationButton from 'src/components/DocumentationButton';
 import Table from 'src/components/Table';
 import Table_CMR from 'src/components/Table/Table_CMR';
 import TableCell from 'src/components/TableCell';
@@ -36,14 +33,17 @@ import TableCell_CMR from 'src/components/TableCell/TableCell_CMR';
 import TableRow from 'src/components/TableRow';
 import TableRow_CMR from 'src/components/TableRow/TableRow_CMR';
 import { OBJECT_STORAGE_DELIMITER as delimiter } from 'src/constants';
+import bucketRequestsContainer, {
+  BucketsRequests
+} from 'src/containers/bucketRequests.container';
+import withFeatureFlags, {
+  FeatureFlagConsumerProps
+} from 'src/containers/withFeatureFlagConsumer.container.ts';
 import { sendDownloadObjectEvent } from 'src/utilities/ga';
 import { getQueryParam } from 'src/utilities/queryParams';
 import { truncateMiddle } from 'src/utilities/truncate';
 import ObjectUploader from '../ObjectUploader';
 import { deleteObject } from '../requests';
-import bucketRequestsContainer, {
-  BucketsRequests
-} from 'src/containers/bucketRequests.container';
 import {
   displayName,
   ExtendedObject,
@@ -52,17 +52,12 @@ import {
   tableUpdateAction
 } from '../utilities';
 import BucketBreadcrumb from './BucketBreadcrumb';
-import ObjectTableContent from './ObjectTableContent';
-import withFeatureFlags, {
-  FeatureFlagConsumerProps
-} from 'src/containers/withFeatureFlagConsumer.container.ts';
-import Hidden from 'src/components/core/Hidden';
 import ObjectDetailDrawer from './ObjectDetailsDrawer';
+import ObjectTableContent from './ObjectTableContent';
 
 const page_size = 100;
 
 type ClassNames =
-  | 'divider'
   | 'tableContainer'
   | 'uploaderContainer'
   | 'objectTable'
@@ -74,11 +69,6 @@ type ClassNames =
 
 const styles = (theme: Theme) =>
   createStyles({
-    divider: {
-      marginTop: theme.spacing(4),
-      marginBottom: theme.spacing(2),
-      backgroundColor: theme.color.grey3
-    },
     objectTable: {
       marginTop: theme.spacing(2)
     },
@@ -444,23 +434,6 @@ export class BucketDetail extends React.Component<CombinedProps, State> {
 
     return (
       <>
-        <Box display="flex" flexDirection="row" justifyContent="space-between">
-          <Breadcrumb
-            // The actual pathname doesn't match what we want` in the Breadcrumb,
-            // so we create a custom one.
-            pathname={`/object-storage/${bucketName}`}
-            crumbOverrides={[
-              {
-                position: 1,
-                label: 'Object Storage'
-              }
-            ]}
-            labelOptions={{ noCap: true }}
-          />
-          <DocumentationButton href="https://www.linode.com/docs/platform/object-storage/" />
-        </Box>
-        <Divider className={classes.divider} />
-
         <BucketBreadcrumb
           prefix={prefix}
           history={this.props.history}
@@ -626,7 +599,7 @@ export class BucketDetail extends React.Component<CombinedProps, State> {
 
 const styled = withStyles(styles);
 
-const enhanced = compose<CombinedProps, {}>(
+const enhanced = compose<CombinedProps, RouteComponentProps<MatchProps>>(
   styled,
   withSnackbar,
   bucketRequestsContainer,

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketSSL.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketSSL.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+export const BucketSSL: React.FC<{}> = _ => {
+  return <h2>Bucket SSL</h2>;
+};
+
+export default React.memo(BucketSSL);

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketSettings.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketSettings.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+export const BucketSettings: React.FC<{}> = _ => {
+  return <h2>Bucket Settings</h2>;
+};
+
+export default React.memo(BucketSettings);

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketSettings.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketSettings.tsx
@@ -1,7 +1,0 @@
-import * as React from 'react';
-
-export const BucketSettings: React.FC<{}> = _ => {
-  return <h2>Bucket Settings</h2>;
-};
-
-export default React.memo(BucketSettings);

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/index.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/index.tsx
@@ -12,7 +12,8 @@ import SuspenseLoader from 'src/components/SuspenseLoader';
 import TabLinkList from 'src/components/TabLinkList';
 
 const ObjectList = React.lazy(() => import('./BucketDetail'));
-const Settings = React.lazy(() => import('./BucketSettings'));
+const Access = React.lazy(() => import('./BucketAccess'));
+const BucketSSL = React.lazy(() => import('./BucketSSL'));
 
 const useStyles = makeStyles((theme: Theme) => ({
   headerBox: {
@@ -37,13 +38,15 @@ export const BucketDetailLanding: React.FC<CombinedProps> = props => {
   const tabs = [
     {
       title: 'Objects',
-      display: true,
       routeName: `${props.match.url}/objects`
     },
     {
-      title: 'Settings',
-      display: true,
-      routeName: `${props.match.url}/settings`
+      title: 'Access',
+      routeName: `${props.match.url}/access`
+    },
+    {
+      title: 'SSL',
+      routeName: `${props.match.url}/ssl`
     }
   ];
   return (
@@ -78,7 +81,10 @@ export const BucketDetailLanding: React.FC<CombinedProps> = props => {
               <ObjectList {...props} />
             </SafeTabPanel>
             <SafeTabPanel index={1}>
-              <Settings />
+              <Access />
+            </SafeTabPanel>
+            <SafeTabPanel index={2}>
+              <BucketSSL />
             </SafeTabPanel>
           </TabPanels>
         </React.Suspense>

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/index.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/index.tsx
@@ -49,6 +49,16 @@ export const BucketDetailLanding: React.FC<CombinedProps> = props => {
       routeName: `${props.match.url}/ssl`
     }
   ];
+
+  const [index, setIndex] = React.useState(
+    tabs.findIndex(tab => matches(tab.routeName)) || 0
+  );
+
+  const handleTabChange = (index: number) => {
+    setIndex(index);
+    props.history.push(tabs[index].routeName);
+  };
+
   return (
     <>
       <Box
@@ -72,7 +82,7 @@ export const BucketDetailLanding: React.FC<CombinedProps> = props => {
         <DocumentationButton href="https://www.linode.com/docs/platform/object-storage/" />
       </Box>
 
-      <Tabs defaultIndex={tabs.findIndex(tab => matches(tab.routeName)) || 0}>
+      <Tabs index={index} onChange={handleTabChange}>
         <TabLinkList tabs={tabs} />
 
         <React.Suspense fallback={<SuspenseLoader />}>

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/index.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/index.tsx
@@ -1,0 +1,90 @@
+import { ObjectStorageClusterID } from '@linode/api-v4/lib/object-storage';
+import * as React from 'react';
+import { matchPath, RouteComponentProps } from 'react-router-dom';
+import Breadcrumb from 'src/components/Breadcrumb';
+import Box from 'src/components/core/Box';
+import TabPanels from 'src/components/core/ReachTabPanels';
+import Tabs from 'src/components/core/ReachTabs';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import DocumentationButton from 'src/components/DocumentationButton';
+import SafeTabPanel from 'src/components/SafeTabPanel';
+import SuspenseLoader from 'src/components/SuspenseLoader';
+import TabLinkList from 'src/components/TabLinkList';
+
+const ObjectList = React.lazy(() => import('./BucketDetail'));
+const Settings = React.lazy(() => import('./BucketSettings'));
+
+const useStyles = makeStyles((theme: Theme) => ({
+  headerBox: {
+    marginBottom: theme.spacing(2)
+  }
+}));
+
+interface MatchProps {
+  clusterId: ObjectStorageClusterID;
+  bucketName: string;
+}
+
+type CombinedProps = RouteComponentProps<MatchProps>;
+
+export const BucketDetailLanding: React.FC<CombinedProps> = props => {
+  const classes = useStyles();
+  const matches = (p: string) => {
+    return Boolean(matchPath(p, { path: props.location.pathname }));
+  };
+  const { bucketName } = props.match.params;
+
+  const tabs = [
+    {
+      title: 'Objects',
+      display: true,
+      routeName: `${props.match.url}/objects`
+    },
+    {
+      title: 'Settings',
+      display: true,
+      routeName: `${props.match.url}/settings`
+    }
+  ];
+  return (
+    <>
+      <Box
+        display="flex"
+        flexDirection="row"
+        justifyContent="space-between"
+        className={classes.headerBox}
+      >
+        <Breadcrumb
+          // The actual pathname doesn't match what we want` in the Breadcrumb,
+          // so we create a custom one.
+          pathname={`/object-storage/${bucketName}`}
+          crumbOverrides={[
+            {
+              position: 1,
+              label: 'Object Storage'
+            }
+          ]}
+          labelOptions={{ noCap: true }}
+        />
+        <DocumentationButton href="https://www.linode.com/docs/platform/object-storage/" />
+      </Box>
+
+      <Tabs defaultIndex={tabs.findIndex(tab => matches(tab.routeName)) || 0}>
+        <TabLinkList tabs={tabs} />
+
+        <React.Suspense fallback={<SuspenseLoader />}>
+          <TabPanels>
+            <SafeTabPanel index={0}>
+              <ObjectList {...props} />
+            </SafeTabPanel>
+            <SafeTabPanel index={1}>
+              <Settings />
+            </SafeTabPanel>
+          </TabPanels>
+        </React.Suspense>
+      </Tabs>
+    </>
+  );
+};
+
+export default React.memo(BucketDetailLanding);

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/index.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/index.tsx
@@ -12,7 +12,7 @@ import SuspenseLoader from 'src/components/SuspenseLoader';
 import TabLinkList from 'src/components/TabLinkList';
 
 const ObjectList = React.lazy(() => import('./BucketDetail'));
-const Access = React.lazy(() => import('./BucketAccess'));
+// const Access = React.lazy(() => import('./BucketAccess'));
 const BucketSSL = React.lazy(() => import('./BucketSSL'));
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -40,10 +40,10 @@ export const BucketDetailLanding: React.FC<CombinedProps> = props => {
       title: 'Objects',
       routeName: `${props.match.url}/objects`
     },
-    {
-      title: 'Access',
-      routeName: `${props.match.url}/access`
-    },
+    // {
+    //   title: 'Access',
+    //   routeName: `${props.match.url}/access`
+    // },
     {
       title: 'SSL',
       routeName: `${props.match.url}/ssl`
@@ -90,10 +90,10 @@ export const BucketDetailLanding: React.FC<CombinedProps> = props => {
             <SafeTabPanel index={0}>
               <ObjectList {...props} />
             </SafeTabPanel>
-            <SafeTabPanel index={1}>
+            {/* <SafeTabPanel index={1}>
               <Access />
-            </SafeTabPanel>
-            <SafeTabPanel index={2}>
+            </SafeTabPanel> */}
+            <SafeTabPanel index={1}>
               <BucketSSL />
             </SafeTabPanel>
           </TabPanels>

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/index.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/index.tsx
@@ -68,7 +68,7 @@ export const BucketDetailLanding: React.FC<CombinedProps> = props => {
         className={classes.headerBox}
       >
         <Breadcrumb
-          // The actual pathname doesn't match what we want` in the Breadcrumb,
+          // The actual pathname doesn't match what we want in the Breadcrumb,
           // so we create a custom one.
           pathname={`/object-storage/${bucketName}`}
           crumbOverrides={[

--- a/packages/manager/src/features/ObjectStorage/index.tsx
+++ b/packages/manager/src/features/ObjectStorage/index.tsx
@@ -3,7 +3,7 @@ import { Route, RouteComponentProps, Switch } from 'react-router-dom';
 import SuspenseLoader from 'src/components/SuspenseLoader';
 
 const ObjectStorageLanding = React.lazy(() => import('./ObjectStorageLanding'));
-const BucketDetail = React.lazy(() => import('./BucketDetail/BucketDetail'));
+const BucketDetail = React.lazy(() => import('./BucketDetail'));
 
 type CombinedProps = RouteComponentProps;
 


### PR DESCRIPTION
## Description

This ticket is to add inputs to allow users to upload SSL certs to an object storage bucket. In order to make room for these inputs, this PR converts Bucket detail to a tabbed interface.

## Note to Reviewers

We may end up commenting out /access for the next release, since it isn't likely to be ready.

I hoisted a bunch of stuff from BucketDetail to the new BucketDetail/index.tsx, shouldn't affect the functionality.