### PR TITLE
M3-4558 Add: VLAN attachment option to Linode create flow

### DIFF
--- a/packages/api-v4/src/linodes/linodes.schema.ts
+++ b/packages/api-v4/src/linodes/linodes.schema.ts
@@ -21,8 +21,10 @@ export const linodeInterfaceItemSchema = object({
   id: number().required('Interface ID is required.')
 }).default(undefined);
 
-export const linodeInterfaceSchema = lazy((obj: Record<any, any>) =>
-  object(Object.keys(obj).map(_ => linodeInterfaceItemSchema))
+export const linodeInterfaceSchema = lazy((obj?: Record<any, any>) =>
+  typeof obj === 'undefined'
+    ? object().notRequired()
+    : object(Object.keys(obj).map(_ => linodeInterfaceItemSchema))
 );
 
 // const rootPasswordValidation = string().test(

--- a/packages/api-v4/src/linodes/linodes.schema.ts
+++ b/packages/api-v4/src/linodes/linodes.schema.ts
@@ -6,6 +6,25 @@ const stackscript_data = array()
   .of(object())
   .nullable(true);
 
+/**
+ * Interfaces are Record<string, InterfaceItem>
+ *
+ * {
+ *  "eth0": { "id": 10 },
+ *  "eth1": { "id": 12 }
+ * }
+ *
+ * .default() and .lazy() below are required to
+ * make this dynamic field naming work out
+ */
+export const linodeInterfaceItemSchema = object({
+  id: number().required('Interface ID is required.')
+}).default(undefined);
+
+export const linodeInterfaceSchema = lazy((obj: Record<any, any>) =>
+  object(Object.keys(obj).map(_ => linodeInterfaceItemSchema))
+);
+
 // const rootPasswordValidation = string().test(
 //   'is-strong-password',
 //   'Password does not meet strength requirements.',
@@ -60,7 +79,8 @@ export const CreateLinodeSchema = object({
     ),
     // .concat(rootPasswordValidation),
     otherwise: string().notRequired()
-  })
+  }),
+  interfaces: linodeInterfaceSchema
 });
 
 const alerts = object({
@@ -185,25 +205,6 @@ const helpers = object({
   network: boolean(),
   devtmpfs_automount: boolean()
 });
-
-/**
- * Interfaces are Record<string, InterfaceItem>
- *
- * {
- *  "eth0": { "id": 10 },
- *  "eth1": { "id": 12 }
- * }
- *
- * .default() and .lazy() below are required to
- * make this dynamic field naming work out
- */
-export const linodeInterfaceItemSchema = object({
-  id: number().required('Interface ID is required.')
-}).default(undefined);
-
-export const linodeInterfaceSchema = lazy((obj: Record<any, any>) =>
-  object(Object.keys(obj).map(_ => linodeInterfaceItemSchema))
-);
 
 export const CreateLinodeConfigSchema = object({
   label: string()

--- a/packages/api-v4/src/linodes/types.ts
+++ b/packages/api-v4/src/linodes/types.ts
@@ -307,6 +307,7 @@ export interface CreateLinodeRequest {
   tags?: string[];
   private_ip?: boolean;
   authorized_users?: string[];
+  interfaces?: Record<string, LinodeInterfacePayload>;
 }
 
 export type RescueRequestObject = Pick<

--- a/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
@@ -60,7 +60,12 @@ const useStyles = makeStyles((theme: Theme) => ({
     }
   },
   vlanSelect: {
-    paddingLeft: '54px !important'
+    paddingLeft: theme.spacing(2) + 24,
+    paddingTop: theme.spacing(),
+    paddingBottom: theme.spacing(),
+    [theme.breakpoints.up('md')]: {
+      paddingLeft: theme.spacing(4) + 24
+    }
   }
 }));
 

--- a/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
@@ -1,85 +1,64 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { compose } from 'recompose';
 import CheckBox from 'src/components/CheckBox';
 import Divider from 'src/components/core/Divider';
 import FormControlLabel from 'src/components/core/FormControlLabel';
 import Paper from 'src/components/core/Paper';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles
-} from 'src/components/core/styles';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Currency from 'src/components/Currency';
 import Grid from 'src/components/Grid';
-import RenderGuard, { RenderGuardProps } from 'src/components/RenderGuard';
+import SelectVLAN from './SelectVLAN';
 
-type ClassNames =
-  | 'root'
-  | 'flex'
-  | 'title'
-  | 'divider'
-  | 'lastItem'
-  | 'inner'
-  | 'panelBody'
-  | 'label'
-  | 'subLabel'
-  | 'caption';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {
-      flexGrow: 1,
-      width: '100%',
-      marginTop: theme.spacing(3),
-      backgroundColor: theme.color.white
-    },
-    flex: {
-      flex: 1
-    },
-    title: {
-      marginBottom: theme.spacing(2)
-    },
-    divider: {
-      marginTop: theme.spacing(1)
-    },
-    lastItem: {
-      paddingBottom: '0 !important'
-    },
-    inner: {
-      padding: theme.spacing(3)
-    },
-    panelBody: {
-      padding: `${theme.spacing(3)}px 0 ${theme.spacing(1)}px`
-    },
-    label: {
-      '& > span:last-child': {
-        color: theme.color.headline,
-        fontFamily: theme.font.bold,
-        fontSize: '1rem',
-        lineHeight: '1.2em',
-        [theme.breakpoints.up('md')]: {
-          marginLeft: theme.spacing(2)
-        }
-      }
-    },
-    subLabel: {
-      display: 'inline-block',
-      position: 'relative',
-      top: 3
-    },
-    caption: {
-      marginTop: -8,
-      paddingLeft: theme.spacing(2) + 18, // 34,
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    flexGrow: 1,
+    width: '100%',
+    marginTop: theme.spacing(3),
+    backgroundColor: theme.color.white
+  },
+  flex: {
+    flex: 1
+  },
+  title: {
+    marginBottom: theme.spacing(2)
+  },
+  divider: {
+    marginTop: theme.spacing(1)
+  },
+  lastItem: {
+    paddingBottom: '0 !important'
+  },
+  inner: {
+    padding: theme.spacing(3)
+  },
+  panelBody: {
+    padding: `${theme.spacing(3)}px 0 ${theme.spacing(1)}px`
+  },
+  label: {
+    '& > span:last-child': {
+      color: theme.color.headline,
+      fontFamily: theme.font.bold,
+      fontSize: '1rem',
+      lineHeight: '1.2em',
       [theme.breakpoints.up('md')]: {
-        paddingLeft: theme.spacing(4) + 18 // 50
+        marginLeft: theme.spacing(2)
       }
     }
-  });
-
-const styled = withStyles(styles);
+  },
+  subLabel: {
+    display: 'inline-block',
+    position: 'relative',
+    top: 3
+  },
+  caption: {
+    marginTop: -8,
+    paddingLeft: theme.spacing(2) + 18, // 34,
+    [theme.breakpoints.up('md')]: {
+      paddingLeft: theme.spacing(4) + 18 // 50
+    }
+  }
+}));
 
 interface Props {
   backups: boolean;
@@ -88,14 +67,34 @@ interface Props {
   privateIP: boolean;
   changeBackups: () => void;
   changePrivateIP: () => void;
+  changeSelectedVLAN: (vlanID: number | null) => void;
   disabled?: boolean;
   hidePrivateIP?: boolean;
+  selectedVlanID: number | null;
+  selectedRegionID?: string; // Used for filtering VLANs
 }
 
-type CombinedProps = Props & WithStyles<ClassNames>;
-class AddonsPanel extends React.Component<CombinedProps> {
-  renderBackupsPrice = () => {
-    const { classes, backupsMonthly } = this.props;
+type CombinedProps = Props;
+const AddonsPanel: React.FC<CombinedProps> = props => {
+  const {
+    accountBackups,
+    changeBackups,
+    changePrivateIP,
+    changeSelectedVLAN,
+    disabled
+  } = props;
+
+  const handleVlanChange = React.useCallback(
+    (vlan: number | null) => {
+      changeSelectedVLAN(vlan);
+    },
+    [changeSelectedVLAN]
+  );
+
+  const classes = useStyles();
+
+  const renderBackupsPrice = () => {
+    const { backupsMonthly } = props;
     return (
       backupsMonthly && (
         <Grid item className={classes.subLabel}>
@@ -107,94 +106,88 @@ class AddonsPanel extends React.Component<CombinedProps> {
     );
   };
 
-  render() {
-    const {
-      accountBackups,
-      classes,
-      changeBackups,
-      changePrivateIP,
-      disabled
-    } = this.props;
-
-    return (
-      <Paper className={classes.root} data-qa-add-ons>
-        <div className={classes.inner}>
-          <Typography variant="h2" className={classes.title}>
-            Optional Add-ons
-          </Typography>
-          <Grid container>
-            <Grid item xs={12}>
-              <FormControlLabel
-                className={classes.label}
-                control={
-                  <CheckBox
-                    checked={accountBackups || this.props.backups}
-                    onChange={changeBackups}
-                    disabled={accountBackups || disabled}
-                    data-qa-check-backups={
-                      accountBackups
-                        ? 'auto backup enabled'
-                        : 'auto backup disabled'
-                    }
-                  />
-                }
-                label="Backups"
-              />
-              {this.renderBackupsPrice()}
-              <Typography variant="body1" className={classes.caption}>
-                {accountBackups ? (
-                  <React.Fragment>
-                    You have enabled automatic backups for your account. This
-                    Linode will automatically have backups enabled. To change
-                    this setting,{' '}
-                    <Link to={'/account/settings'}>click here.</Link>
-                  </React.Fragment>
-                ) : (
-                  <React.Fragment>
-                    Three backup slots are executed and rotated automatically: a
-                    daily backup, a 2-7 day old backup, and an 8-14 day old
-                    backup. Plans are priced according to the Linode plan
-                    selected above.
-                  </React.Fragment>
-                )}
-              </Typography>
-            </Grid>
+  return (
+    <Paper className={classes.root} data-qa-add-ons>
+      <div className={classes.inner}>
+        <Typography variant="h2" className={classes.title}>
+          Optional Add-ons
+        </Typography>
+        <Grid container>
+          <Grid item xs={12}>
+            <FormControlLabel
+              className={classes.label}
+              control={
+                <CheckBox
+                  checked={accountBackups || props.backups}
+                  onChange={changeBackups}
+                  disabled={accountBackups || disabled}
+                  data-qa-check-backups={
+                    accountBackups
+                      ? 'auto backup enabled'
+                      : 'auto backup disabled'
+                  }
+                />
+              }
+              label="Backups"
+            />
+            {renderBackupsPrice()}
+            <Typography variant="body1" className={classes.caption}>
+              {accountBackups ? (
+                <React.Fragment>
+                  You have enabled automatic backups for your account. This
+                  Linode will automatically have backups enabled. To change this
+                  setting, <Link to={'/account/settings'}>click here.</Link>
+                </React.Fragment>
+              ) : (
+                <React.Fragment>
+                  Three backup slots are executed and rotated automatically: a
+                  daily backup, a 2-7 day old backup, and an 8-14 day old
+                  backup. Plans are priced according to the Linode plan selected
+                  above.
+                </React.Fragment>
+              )}
+            </Typography>
           </Grid>
-          {/** /v4/linodes/instances/clone does *not* support the private IP flag */
-          this.props.hidePrivateIP ? (
-            <React.Fragment />
-          ) : (
-            <React.Fragment>
-              <Grid container className={classes.divider}>
-                <Grid item xs={12}>
-                  <Divider />
-                </Grid>
+        </Grid>
+        {/** /v4/linodes/instances/clone does *not* support the private IP flag */
+        props.hidePrivateIP ? null : (
+          <React.Fragment>
+            <Grid container className={classes.divider}>
+              <Grid item xs={12}>
+                <Divider />
               </Grid>
-              <Grid container>
-                <Grid item xs={12} className={classes.lastItem}>
-                  <FormControlLabel
-                    className={classes.label}
-                    control={
-                      <CheckBox
-                        checked={this.props.privateIP}
-                        onChange={() => changePrivateIP()}
-                        data-qa-check-private-ip
-                        disabled={disabled}
-                      />
-                    }
-                    label="Private IP"
-                  />
-                </Grid>
+            </Grid>
+            <Grid container>
+              <Grid item xs={12} className={classes.lastItem}>
+                <FormControlLabel
+                  className={classes.label}
+                  control={
+                    <CheckBox
+                      checked={props.privateIP}
+                      onChange={() => changePrivateIP()}
+                      data-qa-check-private-ip
+                      disabled={disabled}
+                    />
+                  }
+                  label="Private IP"
+                />
               </Grid>
-            </React.Fragment>
-          )}
-        </div>
-      </Paper>
-    );
-  }
-}
+            </Grid>
+          </React.Fragment>
+        )}
+        {true ? (
+          <>
+            <Divider className={classes.divider} />
+            <SelectVLAN
+              selectedRegionID={props.selectedRegionID}
+              selectedVlanID={props.selectedVlanID}
+              handleSelectVLAN={handleVlanChange}
+            />
+          </>
+        ) : null}
+      </div>
+    </Paper>
+  );
+};
 
-export default compose<CombinedProps, Props & RenderGuardProps>(
-  RenderGuard,
-  styled
-)(AddonsPanel);
+export default React.memo(AddonsPanel);

--- a/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
@@ -24,8 +24,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginBottom: theme.spacing(2)
   },
   divider: {
-    marginTop: theme.spacing(1),
-    marginBottom: theme.spacing(1)
+    marginTop: theme.spacing(1)
   },
   lastItem: {
     paddingBottom: '0 !important'
@@ -58,6 +57,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     [theme.breakpoints.up('md')]: {
       paddingLeft: theme.spacing(4) + 18 // 50
     }
+  },
+  vlanSelect: {
+    paddingLeft: '54px !important'
   }
 }));
 
@@ -161,7 +163,7 @@ const AddonsPanel: React.FC<CombinedProps> = props => {
               </Grid>
             </Grid>
             <Grid container>
-              <Grid item xs={12} className={classes.lastItem}>
+              <Grid item xs={12}>
                 <FormControlLabel
                   className={classes.label}
                   control={
@@ -179,15 +181,19 @@ const AddonsPanel: React.FC<CombinedProps> = props => {
           </React.Fragment>
         )}
         {true ? (
-          <>
-            <Divider className={classes.divider} />
-            <SelectVLAN
-              selectedRegionID={props.selectedRegionID}
-              selectedVlanID={props.selectedVlanID}
-              handleSelectVLAN={handleVlanChange}
-              error={vlanError}
-            />
-          </>
+          <Grid container className={classes.lastItem}>
+            <Grid item xs={12}>
+              <Divider className={classes.divider} />
+            </Grid>
+            <div className={classes.vlanSelect}>
+              <SelectVLAN
+                selectedRegionID={props.selectedRegionID}
+                selectedVlanID={props.selectedVlanID}
+                handleSelectVLAN={handleVlanChange}
+                error={vlanError}
+              />
+            </div>
+          </Grid>
         ) : null}
       </div>
     </Paper>

--- a/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
@@ -71,6 +71,7 @@ interface Props {
   disabled?: boolean;
   hidePrivateIP?: boolean;
   selectedVlanID: number | null;
+  vlanError?: string;
   selectedRegionID?: string; // Used for filtering VLANs
 }
 
@@ -81,6 +82,7 @@ const AddonsPanel: React.FC<CombinedProps> = props => {
     changeBackups,
     changePrivateIP,
     changeSelectedVLAN,
+    vlanError,
     disabled
   } = props;
 
@@ -182,6 +184,7 @@ const AddonsPanel: React.FC<CombinedProps> = props => {
               selectedRegionID={props.selectedRegionID}
               selectedVlanID={props.selectedVlanID}
               handleSelectVLAN={handleVlanChange}
+              error={vlanError}
             />
           </>
         ) : null}

--- a/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
@@ -183,7 +183,7 @@ const AddonsPanel: React.FC<CombinedProps> = props => {
             </Grid>
           </React.Fragment>
         )}
-        {flags.cmr ? (
+        {flags.cmr && flags.vlans ? (
           <Grid container className={classes.lastItem}>
             <Grid item xs={12}>
               <Divider className={classes.divider} />

--- a/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
@@ -8,6 +8,7 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Currency from 'src/components/Currency';
 import Grid from 'src/components/Grid';
+import useFlags from 'src/hooks/useFlags';
 import SelectVLAN from './SelectVLAN';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -88,6 +89,8 @@ const AddonsPanel: React.FC<CombinedProps> = props => {
     vlanError,
     disabled
   } = props;
+
+  const flags = useFlags();
 
   const handleVlanChange = React.useCallback(
     (vlan: number | null) => {
@@ -180,7 +183,7 @@ const AddonsPanel: React.FC<CombinedProps> = props => {
             </Grid>
           </React.Fragment>
         )}
-        {true ? (
+        {flags.cmr ? (
           <Grid container className={classes.lastItem}>
             <Grid item xs={12}>
               <Divider className={classes.divider} />

--- a/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
@@ -24,7 +24,8 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginBottom: theme.spacing(2)
   },
   divider: {
-    marginTop: theme.spacing(1)
+    marginTop: theme.spacing(1),
+    marginBottom: theme.spacing(1)
   },
   lastItem: {
     paddingBottom: '0 !important'

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -145,7 +145,8 @@ const errorMap = [
   'region',
   'root_pass',
   'stackscript_id',
-  'type'
+  'type',
+  'interfaces'
 ];
 
 type InnerProps = WithTypesRegionsAndImages &
@@ -604,6 +605,7 @@ export class LinodeCreate extends React.PureComponent<
             changeSelectedVLAN={this.props.setVlanID}
             selectedVlanID={this.props.selectedVlanID}
             selectedRegionID={this.props.selectedRegionID}
+            vlanError={hasErrorFor.interfaces}
           />
         </Grid>
         <Grid item className="mlSidebar">

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -134,6 +134,7 @@ interface Props {
   resetCreationState: () => void;
   setBackupID: (id: number) => void;
   showGeneralError?: boolean;
+  setVlanID: (id: number | null) => void;
 }
 
 const errorMap = [
@@ -598,14 +599,11 @@ export class LinodeCreate extends React.PureComponent<
             privateIP={this.props.privateIPEnabled}
             changeBackups={this.props.toggleBackupsEnabled}
             changePrivateIP={this.props.togglePrivateIPEnabled}
-            updateFor={[
-              this.props.privateIPEnabled,
-              this.props.backupsEnabled,
-              this.props.selectedTypeID,
-              this.props.createType
-            ]}
             disabled={userCannotCreateLinode}
             hidePrivateIP={this.props.createType === 'fromLinode'}
+            changeSelectedVLAN={this.props.setVlanID}
+            selectedVlanID={this.props.selectedVlanID}
+            selectedRegionID={this.props.selectedRegionID}
           />
         </Grid>
         <Grid item className="mlSidebar">

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -410,9 +410,9 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
     return getLabel(arg1, arg2, arg3);
   };
 
-  submitForm: HandleSubmit = (payload, linodeID?: number) => {
+  submitForm: HandleSubmit = (_payload, linodeID?: number) => {
     const { createType } = this.props;
-
+    const payload = { ..._payload };
     /**
      * Do manual password validation (someday we'll use Formik and
      * not need this). Only run this check if a password is present
@@ -423,6 +423,13 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
      * The downside of this approach is that only the password error
      * will be displayed, even if other required fields are missing.
      */
+
+    if (this.state.selectedVlanID) {
+      payload.interfaces = {
+        eth0: { type: 'default' },
+        eth1: { type: 'additional', vlan_id: this.state.selectedVlanID }
+      };
+    }
 
     if (payload.root_pass) {
       const passwordError = validatePassword(

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -104,6 +104,7 @@ interface State {
   appInstancesLoading: boolean;
   appInstancesError?: string;
   disabledClasses?: LinodeTypeClass[];
+  selectedVlanID: number | null;
 }
 
 type CombinedProps = WithSnackbarProps &
@@ -138,7 +139,8 @@ const defaultState: State = {
   udfs: undefined,
   formIsSubmitting: false,
   errors: undefined,
-  appInstancesLoading: false
+  appInstancesLoading: false,
+  selectedVlanID: null
 };
 
 const getDisabledClasses = (regionID: string, regions: Region[] = []) => {
@@ -336,6 +338,10 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
   setTags = (tags: Tag[]) => this.setState({ tags });
 
   setUDFs = (udfs: any) => this.setState({ udfs });
+
+  setVlanID = (vlanID: number | null) => {
+    this.setState({ selectedVlanID: vlanID });
+  };
 
   generateLabel = () => {
     const { createType, getLabel, imagesData, regionsData } = this.props;
@@ -680,6 +686,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
             regionsData={filteredRegions!}
             regionHelperText={regionHelperText}
             typesData={typesData}
+            setVlanID={this.setVlanID}
             {...restOfProps}
             {...restOfState}
           />

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectVLAN.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectVLAN.tsx
@@ -5,6 +5,7 @@ import Tooltip from 'src/components/core/Tooltip';
 import Typography from 'src/components/core/Typography';
 import useReduxLoad from 'src/hooks/useReduxLoad';
 import useVlans from 'src/hooks/useVlans';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
 const useStyles = makeStyles((theme: Theme) => ({
   header: {
@@ -63,6 +64,10 @@ export const SelectVLAN: React.FC<Props> = props => {
     handleSelectVLAN(value);
   };
 
+  const vlanError = vlans.error.read
+    ? getAPIErrorOrDefault(vlans.error.read, 'Error loading VLANs')[0].reason
+    : undefined;
+
   const _Select = (
     <>
       <Typography className={classes.header}>
@@ -80,7 +85,7 @@ export const SelectVLAN: React.FC<Props> = props => {
         }
         label={''}
         disabled={disabled}
-        errorText={error}
+        errorText={error || vlanError}
         noOptionsMessage={() => 'No VLANS available in the selected region.'}
         placeholder="Select a VLAN"
         onChange={onChange}

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectVLAN.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectVLAN.tsx
@@ -83,7 +83,9 @@ export const SelectVLAN: React.FC<Props> = props => {
           options.find(thisOption => thisOption.value === selectedVlanID) ??
           null
         }
-        label={''}
+        label={'Select a VLAN'}
+        aria-describedby={helperText}
+        hideLabel
         disabled={disabled}
         errorText={error || vlanError}
         noOptionsMessage={() => 'No VLANS available in the selected region.'}

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectVLAN.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectVLAN.tsx
@@ -1,8 +1,23 @@
 import * as React from 'react';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Tooltip from 'src/components/core/Tooltip';
+import Typography from 'src/components/core/Typography';
 import useReduxLoad from 'src/hooks/useReduxLoad';
 import useVlans from 'src/hooks/useVlans';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  header: {
+    color: theme.color.headline,
+    fontFamily: theme.font.bold,
+    fontSize: '1rem',
+    lineHeight: '1.2em'
+  },
+  helperText: {
+    paddingTop: theme.spacing(),
+    paddingBottom: theme.spacing()
+  }
+}));
 
 export interface Props {
   selectedRegionID?: string;
@@ -14,6 +29,7 @@ export interface Props {
 export const SelectVLAN: React.FC<Props> = props => {
   const { error, selectedRegionID, selectedVlanID, handleSelectVLAN } = props;
   useReduxLoad(['vlans']);
+  const classes = useStyles();
 
   React.useEffect(() => {
     /**
@@ -48,23 +64,28 @@ export const SelectVLAN: React.FC<Props> = props => {
   };
 
   const _Select = (
-    <Select
-      options={options}
-      isClearable
-      value={
-        options.find(thisOption => thisOption.value === selectedVlanID) ?? null
-      }
-      label={'Virtual LAN'}
-      disabled={disabled}
-      errorText={error}
-      noOptionsMessage={() => 'No VLANS available in the selected region.'}
-      placeholder="Select a VLAN"
-      onChange={onChange}
-      textFieldProps={{
-        helperText: 'Attach the new Linode to a Virtual LAN',
-        helperTextPosition: 'top'
-      }}
-    />
+    <>
+      <Typography className={classes.header}>
+        <strong>Virtual LAN</strong>
+      </Typography>
+      <Typography className={classes.helperText}>
+        Attach the new Linode to a virtual LAN.
+      </Typography>
+      <Select
+        options={options}
+        isClearable
+        value={
+          options.find(thisOption => thisOption.value === selectedVlanID) ??
+          null
+        }
+        label={''}
+        disabled={disabled}
+        errorText={error}
+        noOptionsMessage={() => 'No VLANS available in the selected region.'}
+        placeholder="Select a VLAN"
+        onChange={onChange}
+      />
+    </>
   );
 
   return disabled ? (

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectVLAN.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectVLAN.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import Select, { Item } from 'src/components/EnhancedSelect/Select';
+import Tooltip from 'src/components/core/Tooltip';
+import useReduxLoad from 'src/hooks/useReduxLoad';
+import useVlans from 'src/hooks/useVlans';
+
+export interface Props {
+  selectedRegionID?: string;
+  selectedVlanID: number | null;
+  handleSelectVLAN: (vlanID: number | null) => void;
+}
+
+export const SelectVLAN: React.FC<Props> = props => {
+  const { selectedRegionID, selectedVlanID, handleSelectVLAN } = props;
+  useReduxLoad(['vlans']);
+
+  React.useEffect(() => {
+    /**
+     * If the user changes the selected region,
+     * clear the VLAN selection, since VLANs can
+     * only be attached to Linodes in the same data
+     * center.
+     */
+    handleSelectVLAN(null);
+  }, [selectedRegionID, handleSelectVLAN]);
+
+  const disabled = !Boolean(selectedRegionID);
+
+  const helperText = disabled
+    ? 'You must select a region before choosing a VLAN.'
+    : undefined;
+
+  const { vlans } = useVlans();
+
+  const options = React.useMemo(() => {
+    return Object.values(vlans.itemsById).map(thisVlan => ({
+      label: thisVlan.description || thisVlan.id,
+      value: thisVlan.id
+    }));
+  }, [vlans]);
+
+  const onChange = (selected: Item<number> | null) => {
+    const value = selected === null ? selected : selected.value;
+    handleSelectVLAN(value);
+  };
+
+  const _Select = (
+    <Select
+      options={options}
+      isClearable
+      value={
+        options.find(thisOption => thisOption.value === selectedVlanID) ?? null
+      }
+      label={'Virtual LAN'}
+      disabled={disabled}
+      emptyMessage="No VLANS available in the selected region."
+      placeholder="Select a VLAN"
+      onChange={onChange}
+      textFieldProps={{
+        helperText: 'Attach the new Linode to a Virtual LAN',
+        helperTextPosition: 'top'
+      }}
+    />
+  );
+
+  return disabled ? (
+    <Tooltip title={helperText} placement="bottom-start">
+      <div>{_Select}</div>
+    </Tooltip>
+  ) : (
+    _Select
+  );
+};
+
+export default React.memo(SelectVLAN);

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectVLAN.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectVLAN.tsx
@@ -33,11 +33,13 @@ export const SelectVLAN: React.FC<Props> = props => {
   const { vlans } = useVlans();
 
   const options = React.useMemo(() => {
-    return Object.values(vlans.itemsById).map(thisVlan => ({
-      label: thisVlan.description || thisVlan.id,
-      value: thisVlan.id
-    }));
-  }, [vlans]);
+    return Object.values(vlans.itemsById)
+      .filter(thisVlan => thisVlan.region === selectedRegionID)
+      .map(thisVlan => ({
+        label: thisVlan.description || thisVlan.id,
+        value: thisVlan.id
+      }));
+  }, [selectedRegionID, vlans]);
 
   const onChange = (selected: Item<number> | null) => {
     const value = selected === null ? selected : selected.value;
@@ -53,7 +55,7 @@ export const SelectVLAN: React.FC<Props> = props => {
       }
       label={'Virtual LAN'}
       disabled={disabled}
-      emptyMessage="No VLANS available in the selected region."
+      noOptionsMessage={() => 'No VLANS available in the selected region.'}
       placeholder="Select a VLAN"
       onChange={onChange}
       textFieldProps={{

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectVLAN.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectVLAN.tsx
@@ -7,11 +7,12 @@ import useVlans from 'src/hooks/useVlans';
 export interface Props {
   selectedRegionID?: string;
   selectedVlanID: number | null;
+  error?: string;
   handleSelectVLAN: (vlanID: number | null) => void;
 }
 
 export const SelectVLAN: React.FC<Props> = props => {
-  const { selectedRegionID, selectedVlanID, handleSelectVLAN } = props;
+  const { error, selectedRegionID, selectedVlanID, handleSelectVLAN } = props;
   useReduxLoad(['vlans']);
 
   React.useEffect(() => {
@@ -55,6 +56,7 @@ export const SelectVLAN: React.FC<Props> = props => {
       }
       label={'Virtual LAN'}
       disabled={disabled}
+      errorText={error}
       noOptionsMessage={() => 'No VLANS available in the selected region.'}
       placeholder="Select a VLAN"
       onChange={onChange}

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectVLAN.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectVLAN.tsx
@@ -88,7 +88,7 @@ export const SelectVLAN: React.FC<Props> = props => {
         hideLabel
         disabled={disabled}
         errorText={error || vlanError}
-        noOptionsMessage={() => 'No VLANS available in the selected region.'}
+        noOptionsMessage={() => 'No VLANs available in the selected region.'}
         placeholder="Select a VLAN"
         onChange={onChange}
       />

--- a/packages/manager/src/features/linodes/LinodesCreate/types.ts
+++ b/packages/manager/src/features/linodes/LinodesCreate/types.ts
@@ -126,6 +126,8 @@ export interface BaseFormStateAndHandlers {
   updateTags: (tags: Tag[]) => void;
   resetCreationState: () => void;
   resetSSHKeys: () => void;
+  selectedVlanID: number | null;
+  setVlanID: (id: number | null) => void;
 }
 
 /**

--- a/packages/manager/src/hooks/useReduxLoad.ts
+++ b/packages/manager/src/hooks/useReduxLoad.ts
@@ -22,6 +22,7 @@ import { requestProfile } from 'src/store/profile/profile.requests';
 import { requestRegions } from 'src/store/regions/regions.actions';
 import { getAllVolumes } from 'src/store/volume/volume.requests';
 import { requestClusters } from 'src/store/clusters/clusters.actions';
+import { getAllVlans } from 'src/store/vlans/vlans.requests';
 
 interface UseReduxPreload {
   _loading: boolean;
@@ -45,7 +46,8 @@ export type ReduxEntity =
   | 'events'
   | 'longview'
   | 'firewalls'
-  | 'clusters';
+  | 'clusters'
+  | 'vlans';
 
 type RequestMap = Record<ReduxEntity, any>;
 const requestMap: RequestMap = {
@@ -66,7 +68,8 @@ const requestMap: RequestMap = {
   kubernetes: requestKubernetesClusters,
   longview: getAllLongviewClients,
   firewalls: () => getAllFirewalls({}),
-  clusters: requestClusters
+  clusters: requestClusters,
+  vlans: () => getAllVlans({})
 };
 
 export const useReduxLoad = (

--- a/packages/manager/src/hooks/useVlans.ts
+++ b/packages/manager/src/hooks/useVlans.ts
@@ -1,0 +1,23 @@
+import { VLAN } from '@linode/api-v4/lib/vlans/types';
+import { useDispatch, useSelector } from 'react-redux';
+import { ApplicationState } from 'src/store';
+import { State } from 'src/store/vlans/vlans.reducer';
+import { getAllVlans as _request } from 'src/store/vlans/vlans.requests';
+import { Dispatch } from './types';
+
+export interface NodeBalancersProps {
+  vlans: State;
+  requestVLANs: () => Promise<VLAN[]>;
+}
+
+export const useVlans = () => {
+  const dispatch: Dispatch = useDispatch();
+  const vlans = useSelector(
+    (state: ApplicationState) => state.__resources.vlans
+  );
+  const requestVLANs = () => dispatch(_request({}));
+
+  return { vlans, requestVLANs };
+};
+
+export default useVlans;


### PR DESCRIPTION
## Description

Add an "Attach to a VLAN" select to the optional addons panel in the Linode create flow.

## Note to Reviewers

I'm not at all sold on the styling, and there is no design for this. Feel free to propose any style changes, or argue for a different placement entirely (e.g. in its own panel).

Create Linodes both with and without specifying a VLAN. Make sure the payment is sent correctly in each case, and that the Linode ends up being attached to the VLAN as planned.
