### PR TITLE
M3-4482 Add: Ability to upload a TLS certificate for a Bucket

### DIFF
--- a/packages/api-v4/src/object-storage/buckets.schema.ts
+++ b/packages/api-v4/src/object-storage/buckets.schema.ts
@@ -9,3 +9,8 @@ export const CreateBucketSchema = object({
     .max(63, 'Label must be between 3 and 63 characters.'),
   cluster: string().required('Cluster is required.')
 });
+
+export const UploadCertificateSchema = object({
+  certificate: string().required('Certificate is required.'),
+  private_key: string().required('Private key is required.')
+});

--- a/packages/api-v4/src/object-storage/buckets.ts
+++ b/packages/api-v4/src/object-storage/buckets.ts
@@ -7,7 +7,7 @@ import Request, {
   setXFilter
 } from '../request';
 import { ResourcePage as Page } from '../types';
-import { CreateBucketSchema } from './buckets.schema';
+import { CreateBucketSchema, UploadCertificateSchema } from './buckets.schema';
 import {
   ObjectStorageBucket,
   ObjectStorageBucketRequestPayload,
@@ -116,7 +116,7 @@ export const uploadSSLCert = (
 ) =>
   Request<ObjectStorageBucketSSLResponse>(
     setMethod('POST'),
-    setData(data),
+    setData(data, UploadCertificateSchema),
     setURL(`${API_ROOT}/object-storage/buckets/${clusterId}/${bucketName}/ssl`)
   );
 

--- a/packages/api-v4/src/object-storage/buckets.ts
+++ b/packages/api-v4/src/object-storage/buckets.ts
@@ -11,6 +11,7 @@ import { CreateBucketSchema } from './buckets.schema';
 import {
   ObjectStorageBucket,
   ObjectStorageBucketRequestPayload,
+  ObjectStorageBucketSSLRequest,
   ObjectStorageBucketSSLResponse,
   ObjectStorageDeleteBucketRequestPayload,
   ObjectStorageObjectListParams,
@@ -111,11 +112,11 @@ export const getObjectList = (
 export const uploadSSLCert = (
   clusterId: string,
   bucketName: string,
-  cert: any
+  data: ObjectStorageBucketSSLRequest
 ) =>
-  Request<{}>(
+  Request<ObjectStorageBucketSSLResponse>(
     setMethod('POST'),
-    setData(cert),
+    setData(data),
     setURL(`${API_ROOT}/object-storage/buckets/${clusterId}/${bucketName}/ssl`)
   );
 

--- a/packages/api-v4/src/object-storage/buckets.ts
+++ b/packages/api-v4/src/object-storage/buckets.ts
@@ -11,6 +11,7 @@ import { CreateBucketSchema } from './buckets.schema';
 import {
   ObjectStorageBucket,
   ObjectStorageBucketRequestPayload,
+  ObjectStorageBucketSSLResponse,
   ObjectStorageDeleteBucketRequestPayload,
   ObjectStorageObjectListParams,
   ObjectStorageObjectListResponse
@@ -102,4 +103,43 @@ export const getObjectList = (
     setURL(
       `${API_ROOT}/object-storage/buckets/${clusterId}/${bucketName}/object-list`
     )
+  );
+
+/**
+ * uploadSSLCert
+ */
+export const uploadSSLCert = (
+  clusterId: string,
+  bucketName: string,
+  cert: any
+) =>
+  Request<{}>(
+    setMethod('POST'),
+    setData(cert),
+    setURL(`${API_ROOT}/object-storage/buckets/${clusterId}/${bucketName}/ssl`)
+  );
+
+/**
+ * getSSLCert
+ *
+ * Returns { ssl: true } if there is an SSL certificate available for
+ * the specified bucket, { ssl: false } otherwise.
+ */
+export const getSSLCert = (clusterId: string, bucketName: string) =>
+  Request<ObjectStorageBucketSSLResponse>(
+    setMethod('GET'),
+    setURL(`${API_ROOT}/object-storage/buckets/${clusterId}/${bucketName}/ssl`)
+  );
+
+/**
+ * deleteSSLCert
+ *
+ * Removes any SSL cert associated with the specified bucket. Certs are
+ * removed automatically when a bucket is deleted; this endpoint is only
+ * for removing certs without altering the bucket.
+ */
+export const deleteSSLCert = (clusterId: string, bucketName: string) =>
+  Request<ObjectStorageBucketSSLResponse>(
+    setMethod('DELETE'),
+    setURL(`${API_ROOT}/object-storage/buckets/${clusterId}/${bucketName}/ssl`)
   );

--- a/packages/api-v4/src/object-storage/types.ts
+++ b/packages/api-v4/src/object-storage/types.ts
@@ -87,3 +87,7 @@ export interface ObjectStorageObjectListResponse {
   next_marker: string | null;
   is_truncated: boolean;
 }
+
+export interface ObjectStorageBucketSSLResponse {
+  ssl: boolean;
+}

--- a/packages/api-v4/src/object-storage/types.ts
+++ b/packages/api-v4/src/object-storage/types.ts
@@ -88,6 +88,11 @@ export interface ObjectStorageObjectListResponse {
   is_truncated: boolean;
 }
 
+export interface ObjectStorageBucketSSLRequest {
+  certificate: string;
+  private_key: string;
+}
+
 export interface ObjectStorageBucketSSLResponse {
   ssl: boolean;
 }

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketSSL.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketSSL.tsx
@@ -29,6 +29,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   helperText: {
     paddingTop: theme.spacing(),
     lineHeight: 1.5
+  },
+  textArea: {
+    minWidth: '100%'
   }
 }));
 
@@ -98,6 +101,8 @@ export const AddCertForm: React.FC<FormProps> = props => {
 
   const errorMap = getErrorMap(['certificate', 'private_key'], error);
 
+  const classes = useStyles();
+
   const onSubmit = () => {
     setSubmitting(true);
     setError(undefined);
@@ -120,30 +125,43 @@ export const AddCertForm: React.FC<FormProps> = props => {
         <Notice error text={errorMap.none} spacingTop={8} spacingBottom={0} />
       )}
       <Grid container>
-        <Grid item xs={6}>
-          <TextField
-            label="Certificate"
-            onChange={(e: any) => setCertificate(e.target.value)}
-            value={certificate}
-            multiline
-            fullWidth={false}
-            rows="4"
-            // className={classes.keyTextarea}
-            data-testid="ssl-cert-input"
-            errorText={errorMap.certificate}
-          />
-        </Grid>
-        <Grid item xs={6}>
-          <TextField
-            label="Private Key"
-            onChange={(e: any) => setSSLKey(e.target.value)}
-            value={sslKey}
-            multiline
-            rows="4"
-            // className={classes.keyTextarea}
-            data-testid="ssl-cert-input"
-            errorText={errorMap.private_key}
-          />
+        <Grid
+          container
+          direction="row"
+          alignItems="center"
+          justify="center"
+          spacing={4}
+        >
+          <Grid item xs={6}>
+            <TextField
+              label="Certificate"
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                setCertificate(e.target.value)
+              }
+              value={certificate}
+              multiline
+              fullWidth={false}
+              rows="4"
+              className={classes.textArea}
+              data-testid="ssl-cert-input"
+              errorText={errorMap.certificate}
+            />
+          </Grid>
+          <Grid item xs={6}>
+            <TextField
+              label="Private Key"
+              fullWidth
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                setSSLKey(e.target.value)
+              }
+              value={sslKey}
+              className={classes.textArea}
+              multiline
+              rows="4"
+              data-testid="ssl-cert-input"
+              errorText={errorMap.private_key}
+            />
+          </Grid>
         </Grid>
         <Grid item>
           <ActionsPanel>

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketSSL.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketSSL.tsx
@@ -78,7 +78,7 @@ export const SSLBody: React.FC<BodyProps> = props => {
   }
 
   if (request.error) {
-    return <ErrorState errorText="Error loading TSL cert data" />;
+    return <ErrorState errorText="Error loading TLS cert data" />;
   }
 
   if (hasSSL) {

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketSSL.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketSSL.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react';
+import TextField from 'src/components/TextField';
 
 export const BucketSSL: React.FC<{}> = _ => {
-  return <h2>Bucket SSL</h2>;
+  return (
+    <div>
+      <TextField value={0} label="SSL Cert" />
+    </div>
+  );
 };
 
 export default React.memo(BucketSSL);

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketSSL.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketSSL.tsx
@@ -7,9 +7,11 @@ import {
 import * as React from 'react';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
+import CircleProgress from 'src/components/CircleProgress';
 import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
+import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
 import Typography from 'src/components/core/Typography';
@@ -25,7 +27,8 @@ const useStyles = makeStyles((theme: Theme) => ({
     ...theme.applyLinkStyles
   },
   helperText: {
-    paddingTop: theme.spacing()
+    paddingTop: theme.spacing(),
+    lineHeight: 1.5
   }
 }));
 
@@ -36,17 +39,64 @@ interface Props {
 
 export const BucketSSL: React.FC<Props> = props => {
   const { bucketName, clusterId } = props;
-  const [certificate, setCertificate] = React.useState('');
-  const [sslKey, setSSLKey] = React.useState('');
-  const [submitting, setSubmitting] = React.useState(false);
-  const [error, setError] = React.useState<APIError[] | undefined>(undefined);
-
   const classes = useStyles();
+
+  return (
+    <Paper className={classes.root}>
+      <Typography variant="h2">SSL/TLS Certificate</Typography>
+      <Typography className={classes.helperText}>
+        Object Storage buckets are automatically served with a default TLS
+        certificate that is valid for subdomains of linodeobjects.com. You can
+        upload a custom certificate that will be used for the TLS portion of the
+        HTTPS request instead.
+      </Typography>
+      <SSLBody bucketName={bucketName} clusterId={clusterId} />
+    </Paper>
+  );
+};
+
+interface BodyProps {
+  bucketName: string;
+  clusterId: string;
+}
+
+export const SSLBody: React.FC<BodyProps> = props => {
+  const { bucketName, clusterId } = props;
 
   const request = useAPIRequest(
     () => getSSLCert(clusterId, bucketName).then(response => response.ssl),
     false
   );
+
+  const hasSSL = request.data;
+
+  if (request.loading) {
+    return <CircleProgress />;
+  }
+
+  if (request.error) {
+    return <ErrorState errorText="Error loading TSL cert data" />;
+  }
+
+  if (hasSSL) {
+    return <RemoveCertForm {...props} update={request.update} />;
+  }
+
+  return <AddCertForm {...props} update={request.update} />;
+};
+
+export interface FormProps extends BodyProps {
+  update: () => void;
+}
+
+export const AddCertForm: React.FC<FormProps> = props => {
+  const { bucketName, clusterId, update } = props;
+  const [certificate, setCertificate] = React.useState('');
+  const [sslKey, setSSLKey] = React.useState('');
+  const [submitting, setSubmitting] = React.useState(false);
+  const [error, setError] = React.useState<APIError[] | undefined>(undefined);
+
+  const errorMap = getErrorMap(['certificate', 'private_key'], error);
 
   const onSubmit = () => {
     setSubmitting(true);
@@ -54,7 +104,7 @@ export const BucketSSL: React.FC<Props> = props => {
     uploadSSLCert(clusterId, bucketName, { certificate, private_key: sslKey })
       .then(_ => {
         setSubmitting(false);
-        request.update();
+        update();
         setCertificate('');
         setSSLKey('');
       })
@@ -64,6 +114,55 @@ export const BucketSSL: React.FC<Props> = props => {
       });
   };
 
+  return (
+    <>
+      {errorMap.none && (
+        <Notice error text={errorMap.none} spacingTop={8} spacingBottom={0} />
+      )}
+      <Grid container>
+        <Grid item xs={6}>
+          <TextField
+            label="Certificate"
+            onChange={(e: any) => setCertificate(e.target.value)}
+            value={certificate}
+            multiline
+            fullWidth={false}
+            rows="4"
+            // className={classes.keyTextarea}
+            data-testid="ssl-cert-input"
+            errorText={errorMap.certificate}
+          />
+        </Grid>
+        <Grid item xs={6}>
+          <TextField
+            label="Private Key"
+            onChange={(e: any) => setSSLKey(e.target.value)}
+            value={sslKey}
+            multiline
+            rows="4"
+            // className={classes.keyTextarea}
+            data-testid="ssl-cert-input"
+            errorText={errorMap.private_key}
+          />
+        </Grid>
+        <Grid item>
+          <ActionsPanel>
+            <Button
+              onClick={onSubmit}
+              loading={submitting}
+              buttonType="primary"
+            >
+              Upload Certificate
+            </Button>
+          </ActionsPanel>
+        </Grid>
+      </Grid>
+    </>
+  );
+};
+
+export const RemoveCertForm: React.FC<FormProps> = props => {
+  const { bucketName, clusterId, update } = props;
   const [open, setOpen] = React.useState(false);
 
   const [submittingDialog, setSubmittingDialog] = React.useState(false);
@@ -73,19 +172,17 @@ export const BucketSSL: React.FC<Props> = props => {
 
   const removeCertificate = () => {
     setSubmittingDialog(true);
-    setError(undefined);
     deleteSSLCert(clusterId, bucketName)
       .then(() => {
         setOpen(false);
         setSubmittingDialog(false);
-        request.update();
+        update();
       })
       .catch(error => {
         setDialogError(error[0].reason);
         setSubmittingDialog(false);
       });
   };
-
   const createActions = () => (
     <ActionsPanel>
       <Button
@@ -104,92 +201,15 @@ export const BucketSSL: React.FC<Props> = props => {
       </Button>
     </ActionsPanel>
   );
-
-  const hasSSL = request.data;
-
-  const errorMap = getErrorMap(['certificate', 'private_key'], error);
-
-  const getNoticeText = () => {
-    return request.loading ? (
-      'Loading...'
-    ) : (
-      <>
-        This bucket {hasSSL ? 'has' : 'does not have'} a TLS certificate
-        available.{' '}
-        {hasSSL ? (
-          <button className={classes.button} onClick={() => setOpen(true)}>
-            Remove
-          </button>
-        ) : null}
-      </>
-    );
-  };
-
   return (
     <>
-      <Paper className={classes.root}>
-        <Typography variant="h2">SSL/TLS Certificate</Typography>
-        <Notice
-          success={hasSSL}
-          warning={!hasSSL}
-          spacingTop={8}
-          spacingBottom={0}
-          text={getNoticeText()}
-        />
-        <Typography className={classes.helperText}>
-          Object Storage buckets are automatically served with a default TLS
-          certificate that is valid for subdomains of linodeobjects.com. You can
-          upload a custom certificate that will be used for the TLS portion of
-          the HTTPS request instead.
-        </Typography>
-        <Grid container>
-          <Grid item xs={6}>
-            <TextField
-              label="Certificate"
-              onChange={(e: any) => setCertificate(e.target.value)}
-              value={certificate}
-              multiline
-              fullWidth={false}
-              rows="4"
-              // className={classes.keyTextarea}
-              data-testid="ssl-cert-input"
-              errorText={errorMap.certificate}
-            />
-          </Grid>
-          <Grid item xs={6}>
-            <TextField
-              label="Private Key"
-              onChange={(e: any) => setSSLKey(e.target.value)}
-              value={sslKey}
-              multiline
-              rows="4"
-              // className={classes.keyTextarea}
-              data-testid="ssl-cert-input"
-              errorText={errorMap.private_key}
-            />
-          </Grid>
-
-          <Grid item>
-            {errorMap.none && (
-              <Notice
-                error
-                text={errorMap.none}
-                spacingTop={8}
-                spacingBottom={0}
-              />
-            )}
-            <ActionsPanel>
-              <Button
-                onClick={onSubmit}
-                loading={submitting}
-                buttonType="primary"
-              >
-                Upload Certificate
-              </Button>
-            </ActionsPanel>
-          </Grid>
-        </Grid>
-      </Paper>
+      <Notice success spacingTop={8}>
+        A TLS certificate has already been uploaded for this Bucket. To upload a
+        new certificate, remove the current certificate.{` `}
+      </Notice>
+      <Button destructive onClick={() => setOpen(true)} buttonType="secondary">
+        Remove Certificate
+      </Button>
       <ConfirmationDialog
         title={'Remove TLS certificate'}
         open={open}

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketSSL.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketSSL.tsx
@@ -1,11 +1,182 @@
-import * as React from 'react';
-import TextField from 'src/components/TextField';
+import {
+  getSSLCert,
+  deleteSSLCert,
+  uploadSSLCert
+} from '@linode/api-v4/lib/object-storage';
 
-export const BucketSSL: React.FC<{}> = _ => {
+import * as React from 'react';
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
+// import Box from 'src/components/core/Box';
+import Paper from 'src/components/core/Paper';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import Dialog from 'src/components/core/Dialog';
+import Grid from 'src/components/Grid';
+import Notice from 'src/components/Notice';
+import Typography from 'src/components/core/Typography';
+import TextField from 'src/components/TextField';
+import { useAPIRequest } from 'src/hooks/useAPIRequest';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    padding: theme.spacing(3)
+  },
+  banner: {
+    padding: theme.spacing(3),
+    marginBottom: theme.spacing(2),
+    fontSize: '1rem'
+  }
+}));
+
+interface Props {
+  bucketName: string;
+  clusterId: string;
+}
+
+export const BucketSSL: React.FC<Props> = props => {
+  const { bucketName, clusterId } = props;
+  const [certificate, setCertificate] = React.useState('');
+  const [sslKey, setSSLKey] = React.useState('');
+  const [submitting, setSubmitting] = React.useState(false);
+  const [error, setError] = React.useState<string | undefined>(undefined);
+
+  const classes = useStyles();
+
+  const request = useAPIRequest(
+    () => getSSLCert(clusterId, bucketName).then(response => response.ssl),
+    false
+  );
+
+  const onSubmit = () => {
+    setSubmitting(true);
+    setError(undefined);
+    uploadSSLCert(clusterId, bucketName, { certificate, private_key: sslKey })
+      .then(response => {
+        console.log(response);
+        setSubmitting(false);
+      })
+      .catch(error => {
+        console.error(error);
+        setSubmitting(false);
+        setError(error[0].reason);
+      });
+  };
+
   return (
-    <div>
-      <TextField value={0} label="SSL Cert" />
-    </div>
+    <>
+      <TLSBanner
+        hasSSL={request.data}
+        loading={request.loading}
+        bucketName={bucketName}
+        clusterId={clusterId}
+      />
+      <Paper className={classes.root}>
+        <Typography variant="h2">SSL/TLS Certificate</Typography>
+        {error && <Notice error text={error} spacingTop={4} />}
+        <Typography>
+          Object Storage buckets are automatically served with a default TLS
+          certificate that is valid for subdomains of linodeobjects.com. You can
+          upload a custom certificate that will be used for the TLS portion of
+          the HTTPS request instead.
+        </Typography>
+        <Grid container>
+          <Grid item xs={6}>
+            <TextField
+              label="Certificate"
+              onChange={(e: any) => setCertificate(e.target.value)}
+              value={certificate}
+              multiline
+              fullWidth={false}
+              rows="4"
+              // className={classes.keyTextarea}
+              data-testid="ssl-cert-input"
+            />
+          </Grid>
+          <Grid item xs={6}>
+            <TextField
+              label="Private Key"
+              onChange={(e: any) => setSSLKey(e.target.value)}
+              value={sslKey}
+              multiline
+              rows="4"
+              // className={classes.keyTextarea}
+              data-testid="ssl-cert-input"
+            />
+          </Grid>
+          <Grid item>
+            <ActionsPanel>
+              <Button
+                onClick={onSubmit}
+                loading={submitting}
+                buttonType="primary"
+              >
+                Upload Certificate
+              </Button>
+            </ActionsPanel>
+          </Grid>
+        </Grid>
+      </Paper>
+    </>
+  );
+};
+
+interface BannerProps {
+  hasSSL: boolean;
+  loading: boolean;
+  bucketName: string;
+  clusterId: string;
+}
+
+export const TLSBanner: React.FC<BannerProps> = props => {
+  const { bucketName, clusterId, hasSSL } = props;
+  const classes = useStyles();
+  const [open, setOpen] = React.useState(false);
+
+  const [submitting, setSubmitDialog] = React.useState(false);
+  const [error, setError] = React.useState<string | undefined>(undefined);
+  const removeCertificate = () => {
+    deleteSSLCert(clusterId, bucketName);
+  };
+
+  return (
+    <>
+      <Paper className={classes.banner}>
+        <Typography>
+          This bucket {hasSSL ? 'has' : 'does not have'} a TLS certificate
+          available.
+        </Typography>
+        {hasSSL && (
+          <Button onClick={() => setOpen(true)} buttonType="remove">
+            Remove
+          </Button>
+        )}
+      </Paper>
+      <Dialog
+        title={'Remove TLS certificate'}
+        open={open}
+        onClose={() => setOpen(false)}
+      >
+        <Typography>
+          Are you sure you want to remove all certificates from this Bucket?
+        </Typography>
+        <ActionsPanel>
+          <Button
+            loading={submitting}
+            onClick={removeCertificate}
+            buttonType="remove"
+          >
+            Save
+          </Button>
+          <Button
+            disabled={submitting}
+            onClick={() => setOpen(false)}
+            buttonType="secondary"
+          >
+            Reset Form
+          </Button>
+        </ActionsPanel>
+      </Dialog>
+    </>
   );
 };
 

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/index.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/index.tsx
@@ -33,7 +33,7 @@ export const BucketDetailLanding: React.FC<CombinedProps> = props => {
   const matches = (p: string) => {
     return Boolean(matchPath(p, { path: props.location.pathname }));
   };
-  const { bucketName } = props.match.params;
+  const { bucketName, clusterId } = props.match.params;
 
   const tabs = [
     {
@@ -94,7 +94,7 @@ export const BucketDetailLanding: React.FC<CombinedProps> = props => {
               <Access />
             </SafeTabPanel> */}
             <SafeTabPanel index={1}>
-              <BucketSSL />
+              <BucketSSL bucketName={bucketName} clusterId={clusterId} />
             </SafeTabPanel>
           </TabPanels>
         </React.Suspense>


### PR DESCRIPTION
## Description

Fill in the SSL tab (which may end up renamed to Settings) with a form to allow users to upload an SSL/TLS cert

Includes: 

- JS client methods for uploading, getting, and deleting certs
- BucketSSL component

Todo: 

- [ ] Unit test the things
- [ ] Add a link to the Linode doc below (once it's been updated to reflect this capability).

## Note to Reviewers

There were no designs for this, and I had to make a bunch of judgment calls. I decided to hide the SSL inputs if you already have a cert on your bucket, since trying to submit the form in this case always causes a "Please delete existing certs first" error. Please give feedback on the approach.

To test this properly (successfully upload a cert), you have to create a cert that's valid for the bucket. I followed a combination of these two guides:

https://www.linode.com/docs/platform/object-storage/host-static-site-object-storage/
https://medium.com/@deepak13245/hosting-a-https-static-websites-using-s3-and-lets-encrypt-6f3e53014ff2

Reach out if you run into trouble.