### PR TITLE
M3-4535 Add "Message" column to the Activity Feed table

### DIFF
--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -282,6 +282,7 @@ export interface Event {
   username: string;
   secondary_entity: Entity | null;
   _initial?: boolean;
+  message: string | null;
 }
 /**
  * Represents an event which has an entity. For use with type guards.

--- a/packages/manager/src/__data__/events.ts
+++ b/packages/manager/src/__data__/events.ts
@@ -20,7 +20,8 @@ export const events: Event[] = [
       url: '/v4/linode/instances/11241778'
     },
     status: 'finished',
-    duration: 0
+    duration: 0,
+    message: null
   },
   {
     id: 18029767,
@@ -40,7 +41,8 @@ export const events: Event[] = [
       url: '/v4/linode/instances/11241778'
     },
     status: 'finished',
-    duration: 0
+    duration: 0,
+    message: null
   },
   {
     id: 18029572,
@@ -60,7 +62,8 @@ export const events: Event[] = [
       url: '/v4/linode/instances/11241778'
     },
     status: 'finished',
-    duration: 0
+    duration: 0,
+    message: null
   },
   {
     id: 18022171,
@@ -80,7 +83,8 @@ export const events: Event[] = [
       url: '/v4/linode/instances/11642886'
     },
     status: 'finished',
-    duration: 0
+    duration: 0,
+    message: null
   },
   {
     id: 18022021,
@@ -100,7 +104,8 @@ export const events: Event[] = [
       url: '/v4/linode/instances/11642886'
     },
     status: 'finished',
-    duration: 0
+    duration: 0,
+    message: null
   },
   {
     id: 18021942,
@@ -120,7 +125,8 @@ export const events: Event[] = [
       url: '/v4/linode/instances/11241778'
     },
     status: 'finished',
-    duration: 0
+    duration: 0,
+    message: null
   },
   {
     id: 17957943,
@@ -140,7 +146,8 @@ export const events: Event[] = [
       url: '/v4/linode/instances/11440645'
     },
     status: 'finished',
-    duration: 0
+    duration: 0,
+    message: null
   },
   {
     id: 17957944,
@@ -160,7 +167,8 @@ export const events: Event[] = [
       url: '/v4/linode/instances/11440645'
     },
     status: 'finished',
-    duration: 0
+    duration: 0,
+    message: null
   },
   {
     id: 17957718,
@@ -180,7 +188,8 @@ export const events: Event[] = [
       url: '/v4/linode/instances/11440645'
     },
     status: 'finished',
-    duration: 0
+    duration: 0,
+    message: null
   },
   {
     id: 17957108,
@@ -200,7 +209,8 @@ export const events: Event[] = [
       url: '/v4/linode/instances/11440645'
     },
     status: 'finished',
-    duration: 0
+    duration: 0,
+    message: null
   },
   {
     id: 17956743,
@@ -220,7 +230,8 @@ export const events: Event[] = [
       url: '/v4/linode/instances/11440645'
     },
     status: 'finished',
-    duration: 0
+    duration: 0,
+    message: null
   },
   {
     id: 17956360,
@@ -240,7 +251,8 @@ export const events: Event[] = [
       url: '/v4/linode/instances/11440645'
     },
     status: 'finished',
-    duration: 0
+    duration: 0,
+    message: null
   },
   {
     id: 17955994,
@@ -260,7 +272,8 @@ export const events: Event[] = [
       url: '/v4/linode/instances/11440645'
     },
     status: 'finished',
-    duration: 0
+    duration: 0,
+    message: null
   },
   {
     id: 17955841,
@@ -280,7 +293,8 @@ export const events: Event[] = [
       url: '/v4/linode/instances/11440645'
     },
     status: 'finished',
-    duration: 0
+    duration: 0,
+    message: null
   },
   {
     id: 17955781,
@@ -300,7 +314,8 @@ export const events: Event[] = [
       url: '/v4/linode/instances/11440645'
     },
     status: 'finished',
-    duration: 0
+    duration: 0,
+    message: null
   },
   {
     id: 17955694,
@@ -320,7 +335,8 @@ export const events: Event[] = [
       url: '/v4/linode/instances/11440645'
     },
     status: 'finished',
-    duration: 0
+    duration: 0,
+    message: null
   },
   {
     id: 17955636,
@@ -340,7 +356,8 @@ export const events: Event[] = [
       url: '/v4/linode/instances/11440645'
     },
     status: 'finished',
-    duration: 0
+    duration: 0,
+    message: null
   },
   {
     id: 17955613,
@@ -360,7 +377,8 @@ export const events: Event[] = [
       url: '/v4/linode/instances/11440645'
     },
     status: 'finished',
-    duration: 0
+    duration: 0,
+    message: null
   },
   {
     id: 17955464,
@@ -380,7 +398,8 @@ export const events: Event[] = [
       url: '/v4/linode/instances/11440645'
     },
     status: 'finished',
-    duration: 0
+    duration: 0,
+    message: null
   },
   {
     id: 17954738,
@@ -400,7 +419,8 @@ export const events: Event[] = [
       url: '/v4/linode/instances/11440645'
     },
     status: 'finished',
-    duration: 0
+    duration: 0,
+    message: null
   },
   {
     id: 17951319,
@@ -420,7 +440,8 @@ export const events: Event[] = [
       url: '/v4/linode/instances/11440645'
     },
     status: 'finished',
-    duration: 0
+    duration: 0,
+    message: null
   },
   {
     id: 17951106,
@@ -440,7 +461,8 @@ export const events: Event[] = [
       url: '/v4/linode/instances/11440645'
     },
     status: 'finished',
-    duration: 0
+    duration: 0,
+    message: null
   },
   {
     id: 17950945,
@@ -460,7 +482,8 @@ export const events: Event[] = [
       url: '/v4/linode/instances/11440645'
     },
     status: 'finished',
-    duration: 0
+    duration: 0,
+    message: null
   },
   {
     id: 17950407,
@@ -480,7 +503,8 @@ export const events: Event[] = [
       url: '/v4/linode/instances/11440645'
     },
     status: 'finished',
-    duration: 0
+    duration: 0,
+    message: null
   },
   {
     id: 17950183,
@@ -500,7 +524,8 @@ export const events: Event[] = [
       url: '/v4/linode/instances/11440645'
     },
     status: 'finished',
-    duration: 0
+    duration: 0,
+    message: null
   }
 ];
 
@@ -523,7 +548,8 @@ export const uniqueEvents: Event[] = [
       url: '/v4/linode/instances/11440645'
     },
     status: 'finished',
-    duration: 0
+    duration: 0,
+    message: null
   },
   {
     id: 17950407,
@@ -543,7 +569,8 @@ export const uniqueEvents: Event[] = [
       url: '/v4/linode/instances/11440645'
     },
     status: 'finished',
-    duration: 0
+    duration: 0,
+    message: null
   }
 ];
 
@@ -566,5 +593,6 @@ export const reduxEvent: ExtendedEvent = {
     url: '/v4/linode/instances/11440645'
   },
   status: 'finished',
-  duration: 0
+  duration: 0,
+  message: null
 };

--- a/packages/manager/src/factories/events.ts
+++ b/packages/manager/src/factories/events.ts
@@ -22,5 +22,6 @@ export const eventFactory = Factory.Sync.makeFactory<Event>({
   action: 'linode_boot',
   percent_complete: 10,
   time_remaining: null,
-  duration: 0
+  duration: 0,
+  message: null
 });

--- a/packages/manager/src/features/Events/EventRow.test.tsx
+++ b/packages/manager/src/features/Events/EventRow.test.tsx
@@ -15,7 +15,8 @@ const props: RowProps = {
   type: 'linode',
   created: '2018-01-01',
   username: null,
-  linkTarget: jest.fn()
+  linkTarget: jest.fn(),
+  eventMessage: null
 };
 
 describe('EventRow component', () => {

--- a/packages/manager/src/features/Events/EventRow.tsx
+++ b/packages/manager/src/features/Events/EventRow.tsx
@@ -58,7 +58,9 @@ export const EventRow: React.FC<CombinedProps> = props => {
     entityId,
     duration: event.duration,
     username: event.username,
-    action: event.action
+    action: event.action,
+    // This references the message field we get from API, whereas the generic 'message' prop is constructed by Cloud above.
+    eventMessage: event.message
   };
 
   return <Row {...rowProps} data-qa-events-row={event.id} />;
@@ -74,6 +76,7 @@ export interface RowProps {
   created: string;
   username: string | null;
   duration: Event['duration'];
+  eventMessage: string | null;
 }
 
 export const Row: React.FC<RowProps> = props => {
@@ -88,7 +91,8 @@ export const Row: React.FC<RowProps> = props => {
     type,
     created,
     username,
-    duration
+    duration,
+    eventMessage
   } = props;
 
   /** Some event types may not be handled by our system (or new types
@@ -130,6 +134,10 @@ export const Row: React.FC<RowProps> = props => {
           {displayedMessage}
         </Typography>
       </TableCell>
+      <TableCell parentColumn="Message">
+        <Typography variant="body1">{eventMessage}</Typography>
+      </TableCell>
+
       <TableCell parentColumn="Duration">
         <Typography variant="body1">
           {/* There is currently an API bug where host_reboot event durations are

--- a/packages/manager/src/features/Events/EventRow.tsx
+++ b/packages/manager/src/features/Events/EventRow.tsx
@@ -134,9 +134,6 @@ export const Row: React.FC<RowProps> = props => {
           {displayedMessage}
         </Typography>
       </TableCell>
-      <TableCell parentColumn="Message">
-        <Typography variant="body1">{eventMessage}</Typography>
-      </TableCell>
 
       <TableCell parentColumn="Duration">
         <Typography variant="body1">
@@ -148,6 +145,9 @@ export const Row: React.FC<RowProps> = props => {
       </TableCell>
       <TableCell parentColumn={'When'} data-qa-event-created-cell>
         <DateTimeDisplay value={created} />
+      </TableCell>
+      <TableCell parentColumn={'Message'}>
+        <Typography variant="body1">{eventMessage}</Typography>
       </TableCell>
     </TableRow>
   );

--- a/packages/manager/src/features/Events/EventsLanding.test.ts
+++ b/packages/manager/src/features/Events/EventsLanding.test.ts
@@ -21,7 +21,8 @@ const someEvent: Event[] = [
       url: '/v4/linode/instances/11440645'
     },
     status: 'finished',
-    duration: 0
+    duration: 0,
+    message: null
   }
 ];
 

--- a/packages/manager/src/features/Events/EventsLanding.tsx
+++ b/packages/manager/src/features/Events/EventsLanding.tsx
@@ -37,9 +37,12 @@ const useStyles = makeStyles((theme: Theme) => ({
     textAlign: 'center'
   },
   labelCell: {
-    width: '60%',
+    width: '40%',
     minWidth: 200,
     paddingLeft: 10
+  },
+  messageCell: {
+    width: '30%'
   }
 }));
 
@@ -275,7 +278,7 @@ export const EventsLanding: React.FC<CombinedProps> = props => {
               </TableCell>
               <TableCell data-qa-events-duration-header>Duration</TableCell>
               <TableCell data-qa-events-time-header>When</TableCell>
-              <TableCell>Message</TableCell>
+              <TableCell className={classes.messageCell}>Message</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -322,12 +325,11 @@ export const renderTableBody = (
   if (loading) {
     return (
       <TableRowLoading
-        colSpan={4}
+        colSpan={5}
         numberOfRows={10}
-        numberOfColumns={3}
+        numberOfColumns={4}
         oneLine
         data-qa-events-table-loading
-        firstColWidth={60}
         compact
       />
     );
@@ -359,12 +361,11 @@ export const renderTableBody = (
         ))}
         {isRequesting && (
           <TableRowLoading
-            colSpan={4}
-            numberOfColumns={3}
+            colSpan={5}
+            numberOfColumns={4}
             numberOfRows={4}
             oneLine
             compact
-            firstColWidth={60}
             transparent
           />
         )}

--- a/packages/manager/src/features/Events/EventsLanding.tsx
+++ b/packages/manager/src/features/Events/EventsLanding.tsx
@@ -273,9 +273,9 @@ export const EventsLanding: React.FC<CombinedProps> = props => {
               >
                 Event
               </TableCell>
-              <TableCell data-qa-message-header>Message</TableCell>
               <TableCell data-qa-events-duration-header>Duration</TableCell>
               <TableCell data-qa-events-time-header>When</TableCell>
+              <TableCell>Message</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>

--- a/packages/manager/src/features/Events/EventsLanding.tsx
+++ b/packages/manager/src/features/Events/EventsLanding.tsx
@@ -273,6 +273,7 @@ export const EventsLanding: React.FC<CombinedProps> = props => {
               >
                 Event
               </TableCell>
+              <TableCell data-qa-message-header>Message</TableCell>
               <TableCell data-qa-events-duration-header>Duration</TableCell>
               <TableCell data-qa-events-time-header>When</TableCell>
             </TableRow>

--- a/packages/manager/src/features/linodes/transitions.test.ts
+++ b/packages/manager/src/features/linodes/transitions.test.ts
@@ -16,7 +16,8 @@ describe('transitionText helper', () => {
         status: 'started',
         time_remaining: null,
         username: 'linode',
-        duration: 0
+        duration: 0,
+        message: null
       })
     ).toEqual('Snapshot');
   });
@@ -40,7 +41,8 @@ describe('transitionText helper', () => {
         status: 'started',
         time_remaining: null,
         username: 'linode',
-        duration: 0
+        duration: 0,
+        message: null
       })
     ).toEqual('Optimus');
   });

--- a/packages/manager/src/store/events/event.helpers.test.ts
+++ b/packages/manager/src/store/events/event.helpers.test.ts
@@ -117,7 +117,8 @@ describe('event.helpers', () => {
             url: '/v4/linode/instances/11440645'
           },
           status: 'finished',
-          duration: 0
+          duration: 0,
+          message: null
         },
         {
           id: 17957108,
@@ -137,7 +138,8 @@ describe('event.helpers', () => {
             url: '/v4/linode/instances/11440645'
           },
           status: 'finished',
-          duration: 0
+          duration: 0,
+          message: null
         }
       ];
 
@@ -161,7 +163,8 @@ describe('event.helpers', () => {
           },
           status: 'finished',
           _deleted: '2018-12-02T23:15:45',
-          duration: 0
+          duration: 0,
+          message: null
         },
         {
           id: 17957108,
@@ -182,7 +185,8 @@ describe('event.helpers', () => {
           },
           status: 'finished',
           _deleted: '2018-12-02T23:15:45',
-          duration: 0
+          duration: 0,
+          message: null
         }
       ];
 
@@ -207,7 +211,8 @@ describe('event.helpers', () => {
           rate: null,
           entity: null,
           status: 'finished',
-          duration: 0
+          duration: 0,
+          message: null
         },
         {
           id: 17957718,
@@ -222,7 +227,8 @@ describe('event.helpers', () => {
           rate: null,
           entity: null,
           status: 'started',
-          duration: 0
+          duration: 0,
+          message: null
         },
         {
           id: 17957108,
@@ -237,7 +243,8 @@ describe('event.helpers', () => {
           rate: null,
           entity: null,
           status: 'finished',
-          duration: 0
+          duration: 0,
+          message: null
         }
       ];
       const events: Event[] = [
@@ -254,7 +261,8 @@ describe('event.helpers', () => {
           rate: null,
           entity: null,
           status: 'started',
-          duration: 0
+          duration: 0,
+          message: null
         }
       ];
       const result = addToEvents(prevEvents, events);

--- a/packages/manager/src/store/events/event.helpers.test.ts
+++ b/packages/manager/src/store/events/event.helpers.test.ts
@@ -281,7 +281,8 @@ describe('event.helpers', () => {
           rate: null,
           entity: null,
           status: 'finished',
-          duration: 0
+          duration: 0,
+          message: null
         },
         {
           id: 17957718,
@@ -296,7 +297,8 @@ describe('event.helpers', () => {
           rate: null,
           entity: null,
           status: 'started',
-          duration: 0
+          duration: 0,
+          message: null
         },
         {
           id: 17957108,
@@ -311,7 +313,8 @@ describe('event.helpers', () => {
           rate: null,
           entity: null,
           status: 'finished',
-          duration: 0
+          duration: 0,
+          message: null
         }
       ]);
     });

--- a/packages/manager/src/store/events/event.reducer.test.ts
+++ b/packages/manager/src/store/events/event.reducer.test.ts
@@ -34,7 +34,8 @@ describe('events.reducer', () => {
               url: '/v4/linode/instances/11241778'
             },
             status: 'finished',
-            duration: 0
+            duration: 0,
+            message: null
           },
           {
             id: 18022171,
@@ -54,7 +55,8 @@ describe('events.reducer', () => {
               url: '/v4/linode/instances/11642886'
             },
             status: 'started',
-            duration: 0
+            duration: 0,
+            message: null
           }
         ];
         const action = addEvents(events);


### PR DESCRIPTION
## Description

Please note that you'll need to use dev services to see the message field return for Events. Most of the time this field will be an empty string or null, which is why I placed it on the end of the row.

## Type of Change
- Non breaking change ('update')