### PR TITLE
M3-4566 CMR Action menu refinements

### DIFF
--- a/packages/manager/src/components/IconTextLink/IconTextLink.tsx
+++ b/packages/manager/src/components/IconTextLink/IconTextLink.tsx
@@ -41,7 +41,8 @@ const styles = (theme: Theme) =>
         '& .border': {
           color: theme.palette.primary.light
         }
-      }
+      },
+      '&:focus': { outline: '1px dotted #999' }
     },
     active: {
       color: '#1f64b6'
@@ -130,6 +131,7 @@ const IconTextLink: React.FC<FinalProps> = props => {
         title={title}
         onClick={onClick}
         data-qa-icon-text-link={title}
+        disableRipple
       >
         <SideIcon className={`${classes.icon} ${hideText === true && 'm0'}`} />
         <span

--- a/packages/manager/src/components/IconTextLink/IconTextLink.tsx
+++ b/packages/manager/src/components/IconTextLink/IconTextLink.tsx
@@ -28,7 +28,7 @@ const styles = (theme: Theme) =>
       cursor: 'pointer',
       padding: theme.spacing(1) + theme.spacing(1) / 2,
       color: theme.palette.primary.main,
-      transition: theme.transitions.create(['color']),
+      transition: 'none',
       margin: `0 -${theme.spacing(1) + theme.spacing(1) / 2}px 2px 0`,
       minHeight: 'auto',
       '&:hover': {
@@ -56,12 +56,12 @@ const styles = (theme: Theme) =>
       }
     },
     icon: {
-      transition: theme.transitions.create(['fill', 'color']),
+      transition: 'none',
       fontSize: 18,
       marginRight: theme.spacing(0.5),
       color: theme.palette.primary.main,
       '& .border': {
-        transition: theme.transitions.create(['color'])
+        transition: 'none'
       }
     },
     left: {

--- a/packages/manager/src/components/IconTextLink/IconTextLink_CMR.tsx
+++ b/packages/manager/src/components/IconTextLink/IconTextLink_CMR.tsx
@@ -87,6 +87,7 @@ const IconTextLink: React.FC<CombinedProps> = props => {
         )}
         title={title}
         onClick={onClick}
+        disableRipple
         data-qa-icon-text-link={title}
       >
         <span className={classes.label}>{text}</span>

--- a/packages/manager/src/components/IconTextLink/IconTextLink_CMR.tsx
+++ b/packages/manager/src/components/IconTextLink/IconTextLink_CMR.tsx
@@ -15,7 +15,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     margin: 'auto',
     minHeight: 'auto',
     padding: 5,
-    transition: theme.transitions.create(['color']),
+    transition: 'none',
     width: 200,
     '&:focus': {
       backgroundColor: theme.palette.primary.main

--- a/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
+++ b/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
@@ -212,7 +212,8 @@ const useHeaderStyles = makeStyles((theme: Theme) => ({
   actionItem: {
     marginRight: 10,
     marginBottom: 0,
-    padding: 10,
+    padding: '15px 10px',
+    transition: 'none',
     '& svg': {
       height: 20,
       width: 20,
@@ -229,9 +230,20 @@ const useHeaderStyles = makeStyles((theme: Theme) => ({
       }
     },
     '&:hover': {
+      color: 'white',
+      backgroundColor: theme.color.blue,
       '& svg': {
-        color: theme.color.blue
+        fill: 'white',
+        '& g': {
+          stroke: 'white'
+        },
+        '& path': {
+          stroke: 'white'
+        }
       }
+    },
+    '&:focus': {
+      outline: '1px dotted #999'
     }
   },
   statusChip: {

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu_CMR.tsx
@@ -179,29 +179,29 @@ export const LinodeActionMenu: React.FC<CombinedProps> = props => {
 
     return (): Action[] => {
       const actions: Action[] = [
-        {
-          title: 'Settings',
-          onClick: () => {
-            sendLinodeActionMenuItemEvent('Navigate to Settings Page');
-            history.push(`/linodes/${linodeId}/settings`);
-          }
-        },
-        linodeBackups.enabled
-          ? {
-              title: 'View Backups',
-              onClick: () => {
-                sendLinodeActionMenuItemEvent('Navigate to Backups Page');
-                history.push(`/linodes/${linodeId}/backup`);
-              }
-            }
-          : {
-              title: 'Enable Backups',
-              onClick: () => {
-                sendLinodeActionMenuItemEvent('Enable Backups');
-                openDialog('enable_backups', linodeId);
-              },
-              ...readOnlyProps
-            },
+        // inLandingDetailContext && {
+        //   title: 'Settings',
+        //   onClick: () => {
+        //     sendLinodeActionMenuItemEvent('Navigate to Settings Page');
+        //     history.push(`/linodes/${linodeId}/settings`);
+        //   }
+        // },
+        // linodeBackups.enabled
+        //   ? {
+        //       title: 'View Backups',
+        //       onClick: () => {
+        //         sendLinodeActionMenuItemEvent('Navigate to Backups Page');
+        //         history.push(`/linodes/${linodeId}/backup`);
+        //       }
+        //     }
+        //   : {
+        //       title: 'Enable Backups',
+        //       onClick: () => {
+        //         sendLinodeActionMenuItemEvent('Enable Backups');
+        //         openDialog('enable_backups', linodeId);
+        //       },
+        //       ...readOnlyProps
+        //     },
         {
           title: 'Clone',
           onClick: () => {
@@ -261,7 +261,7 @@ export const LinodeActionMenu: React.FC<CombinedProps> = props => {
       ];
 
       if (
-        (linodeStatus === 'running' && inTableContext) ||
+        linodeStatus === 'running' ||
         (linodeStatus === 'running' && !inTableContext && matchesSmDown)
       ) {
         actions.unshift({

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu_CMR.tsx
@@ -154,7 +154,6 @@ export const LinodeActionMenu: React.FC<CombinedProps> = props => {
     const {
       linodeId,
       linodeLabel,
-      linodeBackups,
       linodeStatus,
       openDialog,
       openPowerActionDialog,
@@ -179,29 +178,6 @@ export const LinodeActionMenu: React.FC<CombinedProps> = props => {
 
     return (): Action[] => {
       const actions: Action[] = [
-        // inLandingDetailContext && {
-        //   title: 'Settings',
-        //   onClick: () => {
-        //     sendLinodeActionMenuItemEvent('Navigate to Settings Page');
-        //     history.push(`/linodes/${linodeId}/settings`);
-        //   }
-        // },
-        // linodeBackups.enabled
-        //   ? {
-        //       title: 'View Backups',
-        //       onClick: () => {
-        //         sendLinodeActionMenuItemEvent('Navigate to Backups Page');
-        //         history.push(`/linodes/${linodeId}/backup`);
-        //       }
-        //     }
-        //   : {
-        //       title: 'Enable Backups',
-        //       onClick: () => {
-        //         sendLinodeActionMenuItemEvent('Enable Backups');
-        //         openDialog('enable_backups', linodeId);
-        //       },
-        //       ...readOnlyProps
-        //     },
         {
           title: 'Clone',
           onClick: () => {
@@ -260,8 +236,19 @@ export const LinodeActionMenu: React.FC<CombinedProps> = props => {
         }
       ];
 
+      if (matchesSmDown || inTableContext) {
+        actions.unshift({
+          title: 'Launch Console',
+          onClick: () => {
+            sendLinodeActionMenuItemEvent('Launch Console');
+            lishLaunch(linodeId);
+          },
+          ...readOnlyProps
+        });
+      }
+
       if (
-        linodeStatus === 'running' ||
+        (linodeStatus === 'running' && inTableContext) ||
         (linodeStatus === 'running' && !inTableContext && matchesSmDown)
       ) {
         actions.unshift({
@@ -278,17 +265,6 @@ export const LinodeActionMenu: React.FC<CombinedProps> = props => {
           onClick: () => {
             sendLinodeActionMenuItemEvent('Reboot Linode');
             openPowerActionDialog('Reboot', linodeId, linodeLabel, configs);
-          },
-          ...readOnlyProps
-        });
-      }
-
-      if (matchesSmDown || inTableContext) {
-        actions.unshift({
-          title: 'Launch Console',
-          onClick: () => {
-            sendLinodeActionMenuItemEvent('Launch Console');
-            lishLaunch(linodeId);
           },
           ...readOnlyProps
         });


### PR DESCRIPTION
## Description

More action menu refinements from Jay: 
• Updating styles for focus/hover states on the inline actions on details landing/details
• Removing 'View Backups' and 'Settings' actions from all Linode action menu variants
• Making 'Reboot' second action (after power on/off, before launch console for all variants)- when reviewing please note we only display 'Reboot' on powered on Linodes.

## Type of Change
- Non breaking change ('update')