### PR TITLE
[CMR] M3-4569: (Mostly) Linode Details Refinements

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDashboardNavigation.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDashboardNavigation.tsx
@@ -2,16 +2,22 @@ import { Config } from '@linode/api-v4/lib/linodes';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
-import { makeStyles } from 'src/components/core/styles';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import TabbedPanel from 'src/components/TabbedPanel';
 import { Tab } from 'src/components/TabbedPanel/TabbedPanel';
 import SuspenseLoader from 'src/components/SuspenseLoader';
 import { withLinodeDetailContext } from './linodeDetailContext';
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((theme: Theme) => ({
   root: {
     backgroundColor: 'transparent',
-    marginTop: 10
+    marginTop: 10,
+    '& [data-reach-tab-list]': {
+      marginTop: 22
+    },
+    '& [data-reach-tab]': {
+      color: theme.color.blue
+    }
   },
   innerClass: {
     padding: 0

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetail.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetail.tsx
@@ -7,18 +7,17 @@ import {
   withRouter
 } from 'react-router-dom';
 import { compose } from 'recompose';
+import NotFound from 'src/components/NotFound';
 import SuspenseLoader from 'src/components/SuspenseLoader';
-import LinodeDetailErrorBoundary from './LinodeDetailErrorBoundary';
 import useExtendedLinode from 'src/hooks/useExtendedLinode';
 import useFlags from 'src/hooks/useFlags';
-import NotFound from 'src/components/NotFound';
+import LinodeDetailErrorBoundary from './LinodeDetailErrorBoundary';
 import {
   LinodeDetailContext,
   linodeDetailContextFactory as createLinodeDetailContext,
   LinodeDetailContextProvider
 } from './linodeDetailContext';
 
-const CloneLanding = React.lazy(() => import('../CloneLanding'));
 const LinodesDetailHeader = React.lazy(() => import('./LinodesDetailHeader'));
 const LinodesDetailHeader_CMR = React.lazy(() =>
   import('./LinodesDetailHeader/LinodeDetailHeader_CMR')
@@ -32,6 +31,7 @@ const LinodesDetailNavigation_CMR = React.lazy(() =>
 const LinodesDashboardNavigation = React.lazy(() =>
   import('./LinodesDashboardNavigation')
 );
+const CloneLanding = React.lazy(() => import('../CloneLanding'));
 const MigrateLanding = React.lazy(() => import('../MigrateLanding'));
 
 interface Props {
@@ -47,6 +47,7 @@ const LinodeDetail: React.FC<CombinedProps> = props => {
     linodeId,
     match: { path }
   } = props;
+
   const dispatch = useDispatch();
   const linode = useExtendedLinode(+linodeId);
   const flags = useFlags();

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader_CMR.tsx
@@ -1,4 +1,3 @@
-import { Event } from '@linode/api-v4/lib/account';
 import { Config, Disk, LinodeStatus } from '@linode/api-v4/lib/linodes';
 import * as React from 'react';
 import { useHistory, useRouteMatch } from 'react-router-dom';
@@ -10,7 +9,6 @@ import LinodeEntityDetail from 'src/features/linodes/LinodeEntityDetail';
 import PowerDialogOrDrawer, {
   Action as BootAction
 } from 'src/features/linodes/PowerActionsDialogOrDrawer';
-import { linodeInTransition } from 'src/features/linodes/transitions';
 import { DialogType } from 'src/features/linodes/types';
 import { NotificationDrawer } from 'src/features/NotificationCenter';
 import useNotificationData from 'src/features/NotificationCenter/NotificationData/useNotificationData';
@@ -30,7 +28,6 @@ import {
 import LinodeRebuildDialog from '../LinodeRebuild/LinodeRebuildDialog';
 import RescueDialog from '../LinodeRescue/RescueDialog';
 import LinodeResize_CMR from '../LinodeResize/LinodeResize_CMR';
-import LinodeBusyStatus from '../LinodeSummary/LinodeBusyStatus';
 
 import MigrateLinode from '../../MigrateLanding/MigrateLinode';
 import DeleteDialog from '../../LinodesLanding/DeleteDialog';
@@ -94,13 +91,7 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
   const classes = useStyles();
   const notificationData = useNotificationData();
 
-  const {
-    linode,
-    linodeEvents,
-    linodeStatus,
-    linodeDisks,
-    linodeConfigs
-  } = props;
+  const { linode, linodeStatus, linodeDisks, linodeConfigs } = props;
 
   const [powerDialog, setPowerDialog] = React.useState<PowerDialogProps>({
     open: false,
@@ -262,9 +253,6 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
       setTagDrawer(tagDrawer => ({ ...tagDrawer, tags: _tags }));
     });
   };
-  const firstEventWithProgress = (linodeEvents || []).find(
-    eachEvent => typeof eachEvent.percent_complete === 'number'
-  );
   const { profile } = useProfile();
   const { _loading } = useReduxLoad(['volumes']);
   const { volumes } = useVolumes();
@@ -305,9 +293,6 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
         openPowerActionDialog={openPowerActionDialog}
         openNotificationDrawer={openNotificationDrawer}
       />
-      {linodeInTransition(linodeStatus, firstEventWithProgress) && (
-        <LinodeBusyStatus />
-      )}
       <PowerDialogOrDrawer
         isOpen={powerDialog.open}
         action={powerDialog.bootAction}
@@ -367,7 +352,6 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
 
 interface LinodeContext {
   linodeStatus: LinodeStatus;
-  linodeEvents: Event[];
   linodeDisks: Disk[];
 }
 
@@ -375,7 +359,6 @@ export default compose<CombinedProps, {}>(
   withLinodeDetailContext<LinodeContext>(({ linode }) => ({
     linode,
     linodeStatus: linode.status,
-    linodeEvents: linode._events,
     linodeDisks: linode._disks,
     configs: linode._configs
   }))


### PR DESCRIPTION
## Description
Fixes include:
- [x] Remove progress bars for events under the summary section
- [x] Because I can't read, I applied the changes to update the font color and margins on the single linode dashboard here

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers
The changes for the font size in EntityHeader and linode detail tabs are in [https://github.com/linode/manager/pull/6958](https://github.com/linode/manager/pull/6958), oops
