### PR TITLE
[CMR] M3-4578: Linode status chips and notification icon cut off

### DIFF
--- a/packages/manager/src/features/TopMenu/NotificationButton.tsx
+++ b/packages/manager/src/features/TopMenu/NotificationButton.tsx
@@ -9,7 +9,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     order: 3,
     width: 74,
     height: 34,
-    padding: theme.spacing(2),
+    padding: `0px theme.spacing(2)`,
     backgroundColor: theme.bg.lightBlue, // '#e5f1ff',
     border: 'none',
     borderRadius: 3,

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.styles.ts
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.styles.ts
@@ -44,6 +44,8 @@ const styles = (theme: Theme) =>
     },
     chip: {
       ...theme.applyStatusPillStyles,
+      paddingTop: '0px !important',
+      paddingBottom: '0px !important',
       '&:hover, &:focus, &:active': {
         backgroundColor: theme.bg.chipActive
       }


### PR DESCRIPTION
## Description
The Linode status chip on the dashboard and the notification icon on the secondary nav is being cut off. You can reproduce this on Safari and certain phones on dev and beta.

![Image from iOS](https://user-images.githubusercontent.com/7692354/94961852-80bdfa80-04c3-11eb-996b-49e171eac11b.jpg)

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers
Please check different browsers and resolutions and other places that the EntityHeader is used such as Linode Details summary view
