### PR TITLE
M3-4560 - Fixed Longview navigation bug

### DIFF
--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/LongviewDetailOverview.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/LongviewDetailOverview.tsx
@@ -112,6 +112,7 @@ export const LongviewDetailOverview: React.FC<CombinedProps> = props => {
                 lastUpdatedError={lastUpdatedError}
               />
               <TopProcesses
+                clientID={clientID}
                 topProcessesData={topProcessesData}
                 topProcessesLoading={topProcessesLoading}
                 topProcessesError={topProcessesError}

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/TopProcesses.test.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/TopProcesses.test.tsx
@@ -7,7 +7,8 @@ import { extendTopProcesses, Props, TopProcesses } from './TopProcesses';
 
 const props: Props = {
   topProcessesData: longviewTopProcessesFactory.build(),
-  topProcessesLoading: false
+  topProcessesLoading: false,
+  clientID: 1
 };
 
 describe('Top Processes', () => {
@@ -48,6 +49,7 @@ describe('Top Processes', () => {
           <TopProcesses
             topProcessesData={{ Processes: {} }}
             topProcessesLoading={true}
+            clientID={1}
           />
         )
       );

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/TopProcesses.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/TopProcesses.tsx
@@ -44,6 +44,7 @@ export interface Props {
   topProcessesError?: APIError[];
   lastUpdatedError?: APIError[];
   cmrFlag?: boolean;
+  clientID: number;
 }
 
 export const TopProcesses: React.FC<Props> = props => {
@@ -53,8 +54,10 @@ export const TopProcesses: React.FC<Props> = props => {
     topProcessesLoading,
     topProcessesError,
     lastUpdatedError,
-    cmrFlag
+    cmrFlag,
+    clientID
   } = props;
+
   const errorMessage = Boolean(topProcessesError || lastUpdatedError)
     ? 'There was an error getting Top Processes.'
     : undefined;
@@ -62,12 +65,14 @@ export const TopProcesses: React.FC<Props> = props => {
   const Table = cmrFlag ? Table_CMR : Table_PreCMR;
   const TableRow = cmrFlag ? TableRow_CMR : TableRow_PreCMR;
   const TableSortCell = cmrFlag ? TableSortCell_CMR : TableSortCell_PreCMR;
-
   return (
     <Grid item xs={12} lg={4}>
       <Box display="flex" flexDirection="row" justifyContent="space-between">
         <Typography variant="h2">Top Processes</Typography>
-        <Link to="processes" className={classes.detailsLink}>
+        <Link
+          to={`/longview/clients/${clientID}/processes`}
+          className={classes.detailsLink}
+        >
           View Details
         </Link>
       </Box>


### PR DESCRIPTION
Used an absolute rather than relative path when linking to the processes tab.

Steps to Reproduce: 
1. If you visit this URL: `http://localhost:3000/longview/clients/:clientID/overview ` and click view details, it works. 
2. It doesn't work if you visit this URL: `http://localhost:3000/longview/clients/:clientID` and click view details. 

This PR should fix that. 


