### PR TITLE
CMR: Fix Lish link

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/utilities.ts
+++ b/packages/manager/src/features/linodes/LinodesDetail/utilities.ts
@@ -1,3 +1,5 @@
+import { ZONES } from 'src/constants';
+
 export const sshLink = (ipv4: string) => {
   return `ssh root@${ipv4}`;
 };
@@ -7,5 +9,6 @@ export const lishLink = (
   region: string,
   linodeLabel: string
 ) => {
-  return `ssh -t ${username}@lish-${region}.linode.com ${linodeLabel}`;
+  const zoneName = ZONES[region];
+  return `ssh -t ${username}@lish-${zoneName}.linode.com ${linodeLabel}`;
 };


### PR DESCRIPTION
## Description

Use the ZoneName instead of the region ID to construct the correct Lish Link (currently in CMR the link is incorrect).

## Note to Reviewers
Have a few Linodes in a few regions and compare the Lish link (in the LinodeEntityDetail component) with production.
