### PR TITLE
CMR: Table too wide when cloning Linodes (status column is expanded, causing overflow)

### DIFF
--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow_CMR.style.ts
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow_CMR.style.ts
@@ -56,9 +56,7 @@ const styles = (theme: Theme) =>
       }
     },
     progressDisplay: {
-      display: 'flex',
-      whiteSpace: 'pre-wrap',
-      textAlign: 'left'
+      display: 'inline-block'
     },
     statusCell: {
       whiteSpace: 'nowrap',

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow_CMR.style.ts
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow_CMR.style.ts
@@ -56,7 +56,9 @@ const styles = (theme: Theme) =>
       }
     },
     progressDisplay: {
-      display: 'inline-block'
+      display: 'flex',
+      whiteSpace: 'pre-wrap',
+      textAlign: 'left'
     },
     statusCell: {
       whiteSpace: 'nowrap',

--- a/packages/manager/src/features/linodes/transitions.ts
+++ b/packages/manager/src/features/linodes/transitions.ts
@@ -50,8 +50,7 @@ export const linodeInTransition = (
 export const transitionText = (
   status: string,
   linodeId: number,
-  recentEvent?: Event,
-  cmr?: boolean
+  recentEvent?: Event
 ): string => {
   // `linode_mutate` is a special case, because we want to display
   // "Upgrading" instead of "Mutate".
@@ -62,10 +61,11 @@ export const transitionText = (
   }
 
   if (recentEvent?.action === 'linode_clone') {
-    if (cmr === true) {
-      return buildLinodeCloneTransitionText(recentEvent, linodeId, true);
-    } else {
-      return buildLinodeCloneTransitionText(recentEvent, linodeId);
+    if (isPrimaryEntity(recentEvent, linodeId)) {
+      return 'Cloning';
+    }
+    if (isSecondaryEntity(recentEvent, linodeId)) {
+      return 'Creating';
     }
   }
 


### PR DESCRIPTION
## Description

This fixes the issue of table overflow, the result is that a longer status (such as clone) will become scrunched up, depending on the label. Unless we consider truncation, I can't think of a better way to handle for this 🤷‍♀️ Open to suggestions/feedback!

<img width="388" alt="Screen Shot 2020-10-08 at 3 30 22 PM" src="https://user-images.githubusercontent.com/2565527/95505555-86608800-097c-11eb-9cb4-327479bc32c2.png">


## Type of Change
- Non breaking change ('update')