### PR TITLE
M3-4590: Store Linode Interfaces in Redux

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/VLANPanel/LinodeVLANs.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/VLANPanel/LinodeVLANs.tsx
@@ -88,14 +88,7 @@ const vlanHeaders = [
 ];
 
 export const LinodeVLANs: React.FC<CombinedProps> = props => {
-  const {
-    configs,
-    linodeId,
-    linodeLabel,
-    linodeRegion,
-    interfacesList,
-    readOnly
-  } = props;
+  const { configs, linodeId, linodeLabel, linodeRegion, readOnly } = props;
 
   const classes = useStyles();
 
@@ -104,6 +97,9 @@ export const LinodeVLANs: React.FC<CombinedProps> = props => {
     number | undefined
   >(undefined);
   const [selectedVlanLabel, setSelectedVlanLabel] = React.useState<string>('');
+  const [interfacesList, setInterfacesList] = React.useState<LinodeInterface[]>(
+    []
+  );
 
   const { vlans, detachVlan } = useVlans();
 
@@ -112,6 +108,12 @@ export const LinodeVLANs: React.FC<CombinedProps> = props => {
     requestInterfaces
   } = useInterfaces();
   const thisLinodeInterfaces = reduxInterfacesObject[linodeId];
+
+  React.useEffect(() => {
+    if (thisLinodeInterfaces) {
+      setInterfacesList(Object.values(thisLinodeInterfaces.itemsById));
+    }
+  }, [thisLinodeInterfaces]);
 
   const { _loading } = useReduxLoad(['vlans']);
 
@@ -126,7 +128,7 @@ export const LinodeVLANs: React.FC<CombinedProps> = props => {
 
   const vlanData = React.useMemo(
     () =>
-      Object.values(interfacesList ?? {})
+      interfacesList
         .map(thisInterface => {
           // The interface is tied to the linode. If the interface has a vlan_id, we want to grab that VLAN from Redux
           const thisVlan = vlans.itemsById[thisInterface.vlan_id];
@@ -231,7 +233,6 @@ interface LinodeContextProps {
   linodeLabel: string;
   linodeRegion: string;
   configs: Config[];
-  interfacesList: LinodeInterface[];
   readOnly: boolean;
 }
 
@@ -240,7 +241,6 @@ const linodeContext = withLinodeDetailContext(({ linode }) => ({
   linodeLabel: linode.label,
   linodeRegion: linode.region,
   configs: linode._configs,
-  interfacesList: linode._interfaces,
   readOnly: linode._permissions === 'read_only'
 }));
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/VLANPanel/LinodeVLANs.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/VLANPanel/LinodeVLANs.tsx
@@ -204,7 +204,7 @@ export const LinodeVLANs: React.FC<CombinedProps> = props => {
         selectedVlanLabel={selectedVlanLabel}
         linodeId={linodeId}
         closeDialog={() => toggleRemoveModal(false)}
-        refreshInterfaces={requestInterfaces}
+        refreshInterfaces={() => requestInterfaces(linodeId)}
       />
       <AttachVlanDrawer
         open={drawerOpen}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/VLANPanel/LinodeVLANs.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/VLANPanel/LinodeVLANs.tsx
@@ -1,4 +1,4 @@
-import { Config, LinodeInterface } from '@linode/api-v4/lib/linodes';
+import { Config } from '@linode/api-v4/lib/linodes';
 import { VLAN } from '@linode/api-v4/lib/vlans/types';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import * as React from 'react';
@@ -97,9 +97,6 @@ export const LinodeVLANs: React.FC<CombinedProps> = props => {
     number | undefined
   >(undefined);
   const [selectedVlanLabel, setSelectedVlanLabel] = React.useState<string>('');
-  const [interfacesList, setInterfacesList] = React.useState<LinodeInterface[]>(
-    []
-  );
 
   const { vlans, detachVlan } = useVlans();
 
@@ -108,12 +105,7 @@ export const LinodeVLANs: React.FC<CombinedProps> = props => {
     requestInterfaces
   } = useInterfaces();
   const thisLinodeInterfaces = reduxInterfacesObject[linodeId];
-
-  React.useEffect(() => {
-    if (thisLinodeInterfaces) {
-      setInterfacesList(Object.values(thisLinodeInterfaces.itemsById));
-    }
-  }, [thisLinodeInterfaces]);
+  const interfacesList = Object.values(thisLinodeInterfaces?.itemsById ?? {});
 
   const { _loading } = useReduxLoad(['vlans']);
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/VLANPanel/LinodeVLANs.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/VLANPanel/LinodeVLANs.tsx
@@ -1,28 +1,24 @@
+import { Config } from '@linode/api-v4/lib/linodes';
+import { VLAN } from '@linode/api-v4/lib/vlans/types';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
-import Loading from 'src/components/LandingLoading';
-import { Props as WithLinodesProps } from 'src/containers/withLinodes.container';
-import EntityTable_CMR from 'src/components/EntityTable/EntityTable_CMR';
-import Typography from 'src/components/core/Typography';
-import Grid from 'src/components/Grid';
 import AddNewLink from 'src/components/AddNewLink/AddNewLink_CMR';
 import { makeStyles, Theme } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+import EntityTable_CMR from 'src/components/EntityTable/EntityTable_CMR';
+import Grid from 'src/components/Grid';
+import Loading from 'src/components/LandingLoading';
+import { Props as WithLinodesProps } from 'src/containers/withLinodes.container';
 import { withLinodeDetailContext } from 'src/features/linodes/LinodesDetail/linodeDetailContext';
-import { getInterfaces } from '@linode/api-v4/lib/linodes/interfaces';
-import VlanTableRow from './VlanTableRow';
-import { AttachVlanDrawer } from './AttachVlanDrawer';
-import { ActionHandlers as VlanHandlers } from './VlanActionMenu';
-import RemoveVlanDialog from './RemoveVlanDialog';
+import useInterfaces from 'src/hooks/useInterfaces';
 import useReduxLoad from 'src/hooks/useReduxLoad';
 import useVlans from 'src/hooks/useVlans';
-import { Config, LinodeInterface } from '@linode/api-v4/lib/linodes';
-import useFlags from 'src/hooks/useFlags';
-import { isFeatureEnabled } from 'src/utilities/accountCapabilities';
-import useAccountManagement from 'src/hooks/useAccountManagement';
-import { APIError } from '@linode/api-v4/lib/types';
-import { VLAN } from '@linode/api-v4/lib/vlans/types';
+import { AttachVlanDrawer } from './AttachVlanDrawer';
+import RemoveVlanDialog from './RemoveVlanDialog';
+import { ActionHandlers as VlanHandlers } from './VlanActionMenu';
+import VlanTableRow from './VlanTableRow';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -102,51 +98,11 @@ export const LinodeVLANs: React.FC<CombinedProps> = props => {
   >(undefined);
   const [selectedVlanLabel, setSelectedVlanLabel] = React.useState<string>('');
 
-  // Local state to manage requested interfaces.
-  const [interfaceData, setInterfaceData] = React.useState<LinodeInterface[]>(
-    []
-  );
-  const [interfaceRequestError, setInterfaceRequestError] = React.useState<
-    APIError[] | undefined
-  >(undefined);
-  const [interfaceDataLoading, setInterfaceDataLoading] = React.useState<
-    boolean
-  >(false);
-  const [interfacesLastUpdated, setInterfacesLastUpdated] = React.useState<
-    number
-  >(0);
-
   const { vlans, detachVlan } = useVlans();
+  const { interfaces, requestInterfaces } = useInterfaces();
+  const thisLinodeInterfaces = interfaces[linodeId] ?? {};
 
-  const { account } = useAccountManagement();
-  const flags = useFlags();
-
-  const vlansEnabled = isFeatureEnabled(
-    'Vlans',
-    Boolean(flags.vlans),
-    account?.data?.capabilities ?? []
-  );
-
-  const { _loading } = useReduxLoad(['vlans'], undefined, vlansEnabled);
-
-  const requestInterfaces = React.useCallback(() => {
-    setInterfaceRequestError(undefined);
-
-    getInterfaces(linodeId)
-      .then(interfaces => {
-        const privateInterfaces = interfaces.data.filter(
-          individualInterface => individualInterface.type !== 'default'
-        );
-
-        setInterfaceData(privateInterfaces);
-        setInterfacesLastUpdated(Date.now());
-        setInterfaceDataLoading(false);
-      })
-      .catch(err => {
-        setInterfaceRequestError(err);
-        setInterfaceDataLoading(false);
-      });
-  }, [linodeId]);
+  const { _loading } = useReduxLoad(['vlans']);
 
   // Local state to manage drawer for attaching VLANs.
   const [drawerOpen, setDrawerOpen] = React.useState<boolean>(false);
@@ -159,15 +115,12 @@ export const LinodeVLANs: React.FC<CombinedProps> = props => {
 
   React.useEffect(() => {
     // Request interfaces upon page first loading.
-    if (vlansEnabled && interfacesLastUpdated === 0) {
-      setInterfaceDataLoading(true);
-      requestInterfaces();
-    }
-  }, [vlansEnabled, interfacesLastUpdated, requestInterfaces, linodeId]);
+    requestInterfaces(linodeId);
+  }, [linodeId]);
 
   const vlanData = React.useMemo(
     () =>
-      interfaceData
+      Object.values(thisLinodeInterfaces.itemsById ?? {})
         .map(thisInterface => {
           // The interface is tied to the linode. If the interface has a vlan_id, we want to grab that VLAN from Redux
           const thisVlan = vlans.itemsById[thisInterface.vlan_id];
@@ -184,7 +137,13 @@ export const LinodeVLANs: React.FC<CombinedProps> = props => {
           };
         })
         .filter(Boolean) as VlanData[],
-    [interfaceData, vlans.itemsById, configs, linodeId, readOnly]
+    [
+      thisLinodeInterfaces.itemsById,
+      vlans.itemsById,
+      configs,
+      linodeId,
+      readOnly
+    ]
   );
 
   const vlansAvailableForAttaching = getVlansAvailableForAttaching(
@@ -192,6 +151,10 @@ export const LinodeVLANs: React.FC<CombinedProps> = props => {
     vlanData,
     linodeRegion
   );
+
+  if (thisLinodeInterfaces?.loading || _loading) {
+    return <Loading shouldDelay />;
+  }
 
   const handleOpenRemoveVlanModal = (id: number, label: string) => {
     setSelectedVlanID(id);
@@ -207,16 +170,12 @@ export const LinodeVLANs: React.FC<CombinedProps> = props => {
     handlers,
     Component: VlanTableRow,
     data: vlanData ?? [],
-    loading: interfaceDataLoading,
-    lastUpdated: interfacesLastUpdated,
-    error: interfaceRequestError || vlans.error.read
+    loading: thisLinodeInterfaces.loading,
+    lastUpdated: thisLinodeInterfaces.lastUpdated,
+    error: thisLinodeInterfaces?.error?.read || vlans.error.read
   };
 
-  if (interfaceDataLoading || _loading) {
-    return <Loading shouldDelay />;
-  }
-
-  return vlansEnabled ? (
+  return (
     <div className={classes.vlansPanel}>
       <Grid
         container
@@ -261,10 +220,10 @@ export const LinodeVLANs: React.FC<CombinedProps> = props => {
         linodeId={linodeId}
         vlans={vlansAvailableForAttaching}
         readOnly={readOnly}
-        refreshInterfaces={requestInterfaces}
+        refreshInterfaces={() => requestInterfaces(linodeId)}
       />
     </div>
-  ) : null;
+  );
 };
 
 interface LinodeContextProps {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetail.container.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetail.container.tsx
@@ -1,15 +1,16 @@
 import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
-import { useLinodes } from 'src/hooks/useLinodes';
 import CircleProgress from 'src/components/CircleProgress';
-import LinodesDetail from './LinodesDetail';
+import { useLinodes } from 'src/hooks/useLinodes';
 import useReduxLoad from 'src/hooks/useReduxLoad';
-import { getLinode as _getLinode } from 'src/store/linodes/linode.requests';
 import { ApplicationState } from 'src/store';
-import { getAllLinodeDisks } from 'src/store/linodes/disk/disk.requests';
 import { getAllLinodeConfigs } from 'src/store/linodes/config/config.requests';
+import { getAllLinodeDisks } from 'src/store/linodes/disk/disk.requests';
+import { getAllLinodeInterfaces } from 'src/store/linodes/interfaces/interfaces.requests';
+import { getLinode as _getLinode } from 'src/store/linodes/linode.requests';
 import { shouldRequestEntity } from 'src/utilities/shouldRequestEntity';
+import LinodesDetail from './LinodesDetail';
 
 interface Props {
   linodeId?: string;
@@ -29,11 +30,14 @@ export const LinodesDetailContainer: React.FC<Props> = props => {
   const linodeId = props.linodeId ? props.linodeId : params.linodeId;
 
   const { _loading } = useReduxLoad(['images', 'volumes']);
-  const { configs, disks } = useSelector((state: ApplicationState) => {
-    const disks = state.__resources.linodeDisks[linodeId];
-    const configs = state.__resources.linodeConfigs[linodeId];
-    return { disks, configs };
-  });
+  const { configs, disks, interfaces } = useSelector(
+    (state: ApplicationState) => {
+      const disks = state.__resources.linodeDisks[linodeId];
+      const configs = state.__resources.linodeConfigs[linodeId];
+      const interfaces = state.__resources.interfaces[linodeId];
+      return { disks, configs, interfaces };
+    }
+  );
 
   React.useEffect(() => {
     // Unconditionally request data for the Linode being viewed
@@ -46,12 +50,12 @@ export const LinodesDetailContainer: React.FC<Props> = props => {
       return;
     }
 
-    if (configs?.error.read || disks?.error.read) {
+    if (configs?.error.read || disks?.error.read || interfaces?.error.read) {
       // We don't want an infinite loop.
       return;
     }
 
-    // Make sure we've requested config and disk information for this Linode
+    // Make sure we've requested config, disk, and interface information for this Linode
     if (shouldRequestEntity(configs)) {
       dispatch(getAllLinodeConfigs({ linodeId: +linodeId }));
     }
@@ -59,7 +63,11 @@ export const LinodesDetailContainer: React.FC<Props> = props => {
     if (shouldRequestEntity(disks)) {
       dispatch(getAllLinodeDisks({ linodeId: +linodeId }));
     }
-  }, [dispatch, configs, disks, linodeId, linodes]);
+
+    if (shouldRequestEntity(interfaces)) {
+      dispatch(getAllLinodeInterfaces({ linodeId: +linodeId }));
+    }
+  }, [dispatch, configs, disks, interfaces, linodeId, linodes]);
 
   if ((linodes.lastUpdated === 0 && linodes.loading) || _loading) {
     return <CircleProgress />;

--- a/packages/manager/src/features/linodes/LinodesDetail/types.ts
+++ b/packages/manager/src/features/linodes/LinodesDetail/types.ts
@@ -1,5 +1,10 @@
 import { Event, GrantLevel, Notification } from '@linode/api-v4/lib/account';
-import { Config, Disk, LinodeType } from '@linode/api-v4/lib/linodes';
+import {
+  Config,
+  Disk,
+  LinodeType,
+  LinodeInterface
+} from '@linode/api-v4/lib/linodes';
 import { APIError } from '@linode/api-v4/lib/types';
 import { Volume } from '@linode/api-v4/lib/volumes';
 import { LinodeWithMaintenance } from 'src/store/linodes/linodes.helpers';
@@ -7,6 +12,7 @@ import { LinodeWithMaintenance } from 'src/store/linodes/linodes.helpers';
 export interface ExtendedLinode extends LinodeWithMaintenance {
   _configs: Config[];
   _disks: Disk[];
+  _interfaces: LinodeInterface[];
   _events: Event[];
   _notifications: Notification[];
   _volumes: Volume[];

--- a/packages/manager/src/hooks/useExtendedLinode.ts
+++ b/packages/manager/src/hooks/useExtendedLinode.ts
@@ -1,5 +1,10 @@
 import { Event, GrantLevel, Notification } from '@linode/api-v4/lib/account';
-import { Config, Disk, LinodeType } from '@linode/api-v4/lib/linodes';
+import {
+  Config,
+  Disk,
+  LinodeInterface,
+  LinodeType
+} from '@linode/api-v4/lib/linodes';
 import { APIError } from '@linode/api-v4/lib/types';
 import { Volume } from '@linode/api-v4/lib/volumes';
 import { useSelector } from 'react-redux';
@@ -16,6 +21,7 @@ import { getVolumesForLinode } from 'src/store/volume/volume.selector';
 export interface ExtendedLinode extends LinodeWithMaintenance {
   _configs: Config[];
   _disks: Disk[];
+  _interfaces: LinodeInterface[];
   _events: Event[];
   _notifications: Notification[];
   _volumes: Volume[];
@@ -33,6 +39,7 @@ export const useExtendedLinode = (linodeId: number): ExtendedLinode | null => {
       types,
       linodeConfigs,
       linodeDisks,
+      interfaces,
       profile
     } = __resources;
     const linode = state.__resources.linodes.itemsById[linodeId];
@@ -51,6 +58,7 @@ export const useExtendedLinode = (linodeId: number): ExtendedLinode | null => {
       _events: eventsForLinode(events, linodeId),
       _configs: getLinodeConfigsForLinode(linodeConfigs, linodeId),
       _disks: getLinodeDisksForLinode(linodeDisks, linodeId),
+      _interfaces: Object.values(interfaces[linodeId]?.itemsById ?? {}),
       _permissions: getPermissionsForLinode(profile.data ?? null, linodeId)
     };
   });

--- a/packages/manager/src/hooks/useInterfaces.ts
+++ b/packages/manager/src/hooks/useInterfaces.ts
@@ -1,0 +1,25 @@
+import { LinodeInterface } from '@linode/api-v4/lib/linodes/types';
+import { useDispatch, useSelector } from 'react-redux';
+import { ApplicationState } from 'src/store';
+import { State } from 'src/store/linodes/interfaces/interfaces.reducer';
+import { getAllLinodeInterfaces } from 'src/store/linodes/interfaces/interfaces.requests';
+import { Dispatch } from './types';
+
+export interface NodeBalancersProps {
+  interfaces: State;
+  requestInterfaces: () => Promise<LinodeInterface[]>;
+}
+
+export const useInterfaces = () => {
+  const dispatch: Dispatch = useDispatch();
+  const interfaces = useSelector(
+    (state: ApplicationState) => state.__resources.interfaces
+  );
+
+  const requestInterfaces = (linodeId: number) =>
+    dispatch(getAllLinodeInterfaces({ linodeId }));
+
+  return { interfaces, requestInterfaces };
+};
+
+export default useInterfaces;

--- a/packages/manager/src/store/index.ts
+++ b/packages/manager/src/store/index.ts
@@ -94,6 +94,10 @@ import linodeDisks, {
   defaultState as defaultLinodeDisksState,
   State as LinodeDisksState
 } from 'src/store/linodes/disk/disk.reducer';
+import interfaces, {
+  defaultState as defaultInterfacesState,
+  State as InterfacesState
+} from 'src/store/linodes/interfaces/interfaces.reducer';
 import linodeEvents from 'src/store/linodes/linodes.events';
 import linodes, {
   defaultState as defaultLinodesState,
@@ -198,6 +202,7 @@ const __resourcesDefaultState = {
   databaseTypes: defaultDatabaseTypesState,
   domains: defaultDomainsState,
   images: defaultImagesState,
+  interfaces: defaultInterfacesState,
   kubernetes: defaultKubernetesState,
   managed: defaultManagedState,
   managedIssues: defaultManagedIssuesState,
@@ -225,6 +230,7 @@ export interface ResourcesState {
   databaseTypes: DatabaseTypesState;
   domains: DomainsState;
   images: ImagesState;
+  interfaces: InterfacesState;
   kubernetes: KubernetesState;
   managed: ManagedState;
   managedIssues: ManagedIssuesState;
@@ -265,7 +271,6 @@ export interface ApplicationState {
   longviewClients: LongviewState;
   longviewStats: LongviewStatsState;
   mockFeatureFlags: MockFeatureFlagState;
-  vlans: VlanState;
 }
 
 export const defaultState: ApplicationState = {
@@ -288,8 +293,7 @@ export const defaultState: ApplicationState = {
   globalErrors: defaultGlobalErrorState,
   longviewClients: defaultLongviewState,
   longviewStats: defaultLongviewStatsState,
-  mockFeatureFlags: defaultMockFeatureFlagState,
-  vlans: defaultVLANState
+  mockFeatureFlags: defaultMockFeatureFlagState
 };
 
 /**
@@ -303,6 +307,7 @@ const __resources = combineReducers({
   databaseTypes,
   domains,
   images,
+  interfaces,
   kubernetes,
   nodePools,
   linodes,
@@ -342,8 +347,7 @@ const reducers = combineReducers<ApplicationState>({
   globalErrors,
   longviewClients: longview,
   longviewStats,
-  mockFeatureFlags,
-  vlans
+  mockFeatureFlags
 });
 
 const enhancers = compose(

--- a/packages/manager/src/store/linodes/interfaces/interfaces.actions.ts
+++ b/packages/manager/src/store/linodes/interfaces/interfaces.actions.ts
@@ -3,8 +3,8 @@ import {
   LinodeInterfacePayload
 } from '@linode/api-v4/lib/linodes';
 import { APIError } from '@linode/api-v4/lib/types';
-import { actionCreatorFactory } from 'typescript-fsa';
 import { GetAllData } from 'src/utilities/getAll';
+import { actionCreatorFactory } from 'typescript-fsa';
 
 const actionCreator = actionCreatorFactory(`@@manager/linodeInterfaces`);
 
@@ -23,12 +23,6 @@ export type GetLinodeInterfacesResponse = Promise<GetAllData<LinodeInterface>>;
 export type GetLinodeInterfacesRequest = (
   params: GetLinodeInterfacesParams
 ) => GetLinodeInterfacesResponse;
-
-export const getLinodeInterfacesActions = actionCreator.async<
-  GetLinodeInterfacesParams,
-  GetAllData<LinodeInterface>,
-  APIError[]
->(`get-page`);
 
 /** Get Linode Interfaces (all) */
 export type GetAllLinodeInterfacesParams = GetLinodeInterfacesParams;

--- a/packages/manager/src/store/linodes/interfaces/interfaces.actions.ts
+++ b/packages/manager/src/store/linodes/interfaces/interfaces.actions.ts
@@ -34,7 +34,7 @@ export type GetAllLinodeInterfacesRequest = (
 
 export const getAllLinodeInterfacesActions = actionCreator.async<
   GetAllLinodeInterfacesParams,
-  GetAllData<LinodeInterface>,
+  GetAllLinodeInterfacesResponse,
   APIError[]
 >(`get-all`);
 

--- a/packages/manager/src/store/linodes/interfaces/interfaces.actions.ts
+++ b/packages/manager/src/store/linodes/interfaces/interfaces.actions.ts
@@ -1,0 +1,88 @@
+import {
+  LinodeInterface,
+  LinodeInterfacePayload
+} from '@linode/api-v4/lib/linodes';
+import { APIError } from '@linode/api-v4/lib/types';
+import { actionCreatorFactory } from 'typescript-fsa';
+import { GetAllData } from 'src/utilities/getAll';
+
+const actionCreator = actionCreatorFactory(`@@manager/linodeInterfaces`);
+
+interface LinodeIdParam {
+  linodeId: number;
+}
+
+interface InterfaceIdParam {
+  interfaceId: number;
+}
+
+/** Get Linode Interfaces (page) */
+export type GetLinodeInterfacesParams = LinodeIdParam;
+export type GetLinodeInterfacesResponse = Promise<GetAllData<LinodeInterface>>;
+
+export type GetLinodeInterfacesRequest = (
+  params: GetLinodeInterfacesParams
+) => GetLinodeInterfacesResponse;
+
+export const getLinodeInterfacesActions = actionCreator.async<
+  GetLinodeInterfacesParams,
+  GetAllData<LinodeInterface>,
+  APIError[]
+>(`get-page`);
+
+/** Get Linode Interfaces (all) */
+export type GetAllLinodeInterfacesParams = GetLinodeInterfacesParams;
+export type GetAllLinodeInterfacesResponse = GetAllData<LinodeInterface>;
+
+export type GetAllLinodeInterfacesRequest = (
+  params: GetAllLinodeInterfacesParams
+) => GetAllLinodeInterfacesResponse;
+
+export const getAllLinodeInterfacesActions = actionCreator.async<
+  GetAllLinodeInterfacesParams,
+  GetAllData<LinodeInterface>,
+  APIError[]
+>(`get-all`);
+
+/** Get Linode Interface */
+export type GetLinodeInterfaceParams = LinodeIdParam & InterfaceIdParam;
+export type GetLinodeInterfaceResponse = Promise<LinodeInterface>;
+
+export type GetLinodeInterfaceRequest = (
+  params: GetLinodeInterfaceParams
+) => GetLinodeInterfaceResponse;
+
+export const getLinodeInterfaceActions = actionCreator.async<
+  GetLinodeInterfaceParams,
+  LinodeInterface,
+  APIError[]
+>(`get`);
+
+/** Create Linode Interface */
+export type CreateLinodeInterfaceParams = LinodeIdParam &
+  LinodeInterfacePayload;
+export type CreateLinodeInterfaceResponse = Promise<LinodeInterface>;
+
+export type CreateLinodeInterfaceRequest = (
+  params: CreateLinodeInterfaceParams
+) => CreateLinodeInterfaceResponse;
+
+export const createLinodeInterfaceActions = actionCreator.async<
+  CreateLinodeInterfaceParams,
+  LinodeInterface,
+  APIError[]
+>(`create`);
+
+/** Delete Linode Interface */
+export type DeleteLinodeInterfaceParams = GetLinodeInterfaceParams;
+export type DeleteLinodeInterfaceResponse = Promise<{}>;
+
+export type DeleteLinodeInterfaceRequest = (
+  params: DeleteLinodeInterfaceParams
+) => DeleteLinodeInterfaceResponse;
+
+export const deleteLinodeInterfaceActions = actionCreator.async<
+  DeleteLinodeInterfaceParams,
+  {},
+  APIError[]
+>(`delete`);

--- a/packages/manager/src/store/linodes/interfaces/interfaces.reducer.ts
+++ b/packages/manager/src/store/linodes/interfaces/interfaces.reducer.ts
@@ -1,0 +1,54 @@
+import produce from 'immer';
+import { Reducer } from 'redux';
+import {
+  addMany,
+  ensureInitializedNestedState,
+  onCreateOrUpdate,
+  onDeleteSuccess,
+  onError,
+  onGetAllSuccess,
+  onStart
+} from 'src/store/store.helpers.tmp';
+import {
+  EntityError,
+  MappedEntityState2 as MappedEntityState
+} from 'src/store/types';
+import { isType } from 'typescript-fsa';
+import { deleteLinode, deleteLinodeActions } from '../linodes.actions';
+import {
+  getLinodeInterfacesActions,
+  getAllLinodeInterfacesActions,
+  getLinodeInterfaceActions,
+  createLinodeInterfaceActions,
+  deleteLinodeInterfaceActions
+} from './interfaces.actions';
+import {
+  LinodeInterface,
+  LinodeInterfacePayload
+} from '@linode/api-v4/lib/linodes';
+
+export type State = Record<
+  number,
+  MappedEntityState<LinodeInterface, EntityError>
+>;
+
+export const defaultState: State = {};
+
+const reducer: Reducer<State> = (state = defaultState, action) =>
+  produce(state, draft => {
+    // getLinodeInterfacesActions
+    // getAllLinodeInterfacesActions
+    if (
+      isType(action, getLinodeInterfacesActions.started) ||
+      isType(action, getAllLinodeInterfacesActions.started)
+    ) {
+    }
+
+    if (isType(action, getLinodeInterfacesActions.done)) {
+    }
+
+    if (isType(action, getAllLinodeInterfacesActions.done)) {
+    }
+  });
+
+export default reducer;

--- a/packages/manager/src/store/linodes/interfaces/interfaces.reducer.ts
+++ b/packages/manager/src/store/linodes/interfaces/interfaces.reducer.ts
@@ -14,7 +14,6 @@ import {
   MappedEntityState2 as MappedEntityState
 } from 'src/store/types';
 import { isType } from 'typescript-fsa';
-import { deleteLinode, deleteLinodeActions } from '../linodes.actions';
 import {
   createLinodeInterfaceActions,
   deleteLinodeInterfaceActions,
@@ -95,24 +94,6 @@ const reducer: Reducer<State> = (state = defaultState, action) =>
       } = action.payload;
       draft = ensureInitializedNestedState(draft, linodeId);
       draft[linodeId] = onDeleteSuccess(InterfaceId, draft[linodeId]);
-    }
-
-    // deleteLinode (sync – used to respond to events)
-    // deleteLinodeActions (async – used when a delete Linode request is made)
-    //
-    // The reducer result is the same, but these need to be two code blocks
-    // because the linodeId is located in different places between the actions.
-    if (isType(action, deleteLinode)) {
-      const linodeId = action.payload;
-      delete draft[linodeId];
-    }
-
-    if (isType(action, deleteLinodeActions.done)) {
-      const {
-        params: { linodeId }
-      } = action.payload;
-
-      delete draft[linodeId];
     }
   });
 

--- a/packages/manager/src/store/linodes/interfaces/interfaces.reducer.ts
+++ b/packages/manager/src/store/linodes/interfaces/interfaces.reducer.ts
@@ -1,7 +1,7 @@
+import { LinodeInterface } from '@linode/api-v4/lib/linodes';
 import produce from 'immer';
 import { Reducer } from 'redux';
 import {
-  addMany,
   ensureInitializedNestedState,
   onCreateOrUpdate,
   onDeleteSuccess,
@@ -16,13 +16,11 @@ import {
 import { isType } from 'typescript-fsa';
 import { deleteLinode, deleteLinodeActions } from '../linodes.actions';
 import {
-  getLinodeInterfacesActions,
-  getAllLinodeInterfacesActions,
-  getLinodeInterfaceActions,
   createLinodeInterfaceActions,
-  deleteLinodeInterfaceActions
+  deleteLinodeInterfaceActions,
+  getAllLinodeInterfacesActions,
+  getLinodeInterfaceActions
 } from './interfaces.actions';
-import { LinodeInterface } from '@linode/api-v4/lib/linodes';
 
 export type State = Record<
   number,
@@ -33,25 +31,12 @@ export const defaultState: State = {};
 
 const reducer: Reducer<State> = (state = defaultState, action) =>
   produce(state, draft => {
-    // getLinodeInterfacesActions
     // getAllLinodeInterfacesActions
-    if (
-      isType(action, getLinodeInterfacesActions.started) ||
-      isType(action, getAllLinodeInterfacesActions.started)
-    ) {
+    if (isType(action, getAllLinodeInterfacesActions.started)) {
       const { linodeId } = action.payload;
       draft = ensureInitializedNestedState(draft, linodeId);
 
       draft[linodeId] = onStart(draft[linodeId]);
-    }
-
-    if (isType(action, getLinodeInterfacesActions.done)) {
-      const { result } = action.payload;
-      const { linodeId } = action.payload.params;
-      draft = ensureInitializedNestedState(draft, linodeId);
-
-      draft[linodeId].loading = false;
-      draft[linodeId] = addMany(result.data, draft[linodeId], result.results);
     }
 
     if (isType(action, getAllLinodeInterfacesActions.done)) {

--- a/packages/manager/src/store/linodes/interfaces/interfaces.requests.ts
+++ b/packages/manager/src/store/linodes/interfaces/interfaces.requests.ts
@@ -1,0 +1,46 @@
+import {
+  LinodeInterface,
+  createInterface as _createInterface,
+  deleteInterface as _deleteInterface,
+  getInterface as _getInterface,
+  getInterfaces as _getInterfaces
+} from '@linode/api-v4/lib/linodes';
+import { createRequestThunk } from 'src/store/store.helpers';
+import { getAllWithArguments } from 'src/utilities/getAll';
+import {
+  getAllLinodeInterfacesActions,
+  getLinodeInterfaceActions,
+  createLinodeInterfaceActions,
+  deleteLinodeInterfaceActions
+} from './interfaces.actions';
+
+export const createLinodeInterface = createRequestThunk(
+  createLinodeInterfaceActions,
+  ({ linodeId, ...data }) => _createInterface(linodeId, data)
+);
+
+export const requestAll = (payload: {
+  linodeId: number;
+  params?: any;
+  filter?: any;
+}) =>
+  getAllWithArguments<LinodeInterface>(_getInterfaces)(
+    [payload.linodeId],
+    payload.params,
+    payload.filter
+  );
+
+export const getAllLinodeInterfaces = createRequestThunk(
+  getAllLinodeInterfacesActions,
+  requestAll
+);
+
+export const getLinodeInterface = createRequestThunk(
+  getLinodeInterfaceActions,
+  ({ linodeId, interfaceId }) => _getInterface(linodeId, interfaceId)
+);
+
+export const deleteLinodeInterface = createRequestThunk(
+  deleteLinodeInterfaceActions,
+  ({ linodeId, interfaceId }) => _deleteInterface(linodeId, interfaceId)
+);


### PR DESCRIPTION
## Description
Add actions, reducer, etc. for Linode Interfaces to enable data to be shared across the Linode Network and Configurations tabs easily.

## Type of Change
- Non breaking change ('update', 'change')
