### PR TITLE
M3-4563 Fix: Search results not displaying for some restricted users

### DIFF
--- a/packages/manager/src/features/Search/SearchLanding.tsx
+++ b/packages/manager/src/features/Search/SearchLanding.tsx
@@ -8,6 +8,7 @@ import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 import H1Header from 'src/components/H1Header';
 import Notice from 'src/components/Notice';
+import { REFRESH_INTERVAL } from 'src/constants';
 import reloadableWithRouter from 'src/features/linodes/LinodesDetail/reloadableWithRouter';
 import useAPISearch from 'src/features/Search/useAPISearch';
 import useAccountManagement from 'src/hooks/useAccountManagement';
@@ -120,14 +121,11 @@ export const SearchLanding: React.FC<CombinedProps> = props => {
     queryError = true;
   }
 
-  const { _loading } = useReduxLoad([
-    'linodes',
-    'volumes',
-    'nodeBalancers',
-    'images',
-    'domains',
-    'kubernetes'
-  ]);
+  const { _loading } = useReduxLoad(
+    ['linodes', 'volumes', 'nodeBalancers', 'images', 'domains', 'kubernetes'],
+    REFRESH_INTERVAL,
+    !_isLargeAccount
+  );
 
   const { searchAPI } = useAPISearch();
 

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar_CMR.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar_CMR.tsx
@@ -15,7 +15,7 @@ import withStoreSearch, {
 } from 'src/features/Search/withStoreSearch';
 import useAPISearch from 'src/features/Search/useAPISearch';
 import useAccountManagement from 'src/hooks/useAccountManagement';
-import { useReduxLoad } from 'src/hooks/useReduxLoad';
+import { ReduxEntity, useReduxLoad } from 'src/hooks/useReduxLoad';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { sendSearchBarUsedEvent } from 'src/utilities/ga.ts';
 import { debounce } from 'throttle-debounce';
@@ -62,6 +62,15 @@ export const selectStyles = {
   menu: (base: any) => ({ ...base, maxWidth: '100% !important' })
 };
 
+const searchDeps: ReduxEntity[] = [
+  'linodes',
+  'nodeBalancers',
+  'images',
+  'domains',
+  'volumes',
+  'kubernetes'
+];
+
 export const SearchBar: React.FC<CombinedProps> = props => {
   const { classes, combinedResults, entitiesLoading, search } = props;
 
@@ -76,7 +85,7 @@ export const SearchBar: React.FC<CombinedProps> = props => {
   const { _isLargeAccount } = useAccountManagement();
 
   const { _loading } = useReduxLoad(
-    ['linodes', 'nodeBalancers', 'images', 'domains', 'volumes', 'kubernetes'],
+    searchDeps,
     REFRESH_INTERVAL,
     searchActive && !_isLargeAccount // Only request things if the search bar is open/active.
   );
@@ -114,7 +123,6 @@ export const SearchBar: React.FC<CombinedProps> = props => {
 
   const handleSearchChange = (_searchText: string): void => {
     setSearchText(_searchText);
-    props.search(_searchText);
   };
 
   const toggleSearch = () => {

--- a/packages/manager/src/hooks/useReduxLoad.ts
+++ b/packages/manager/src/hooks/useReduxLoad.ts
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useDispatch, useStore } from 'react-redux';
 import { Dispatch } from 'redux';
 import { REFRESH_INTERVAL } from 'src/constants';
+import useAccountManagement from 'src/hooks/useAccountManagement';
 import { ApplicationState } from 'src/store';
 import { requestAccount } from 'src/store/account/account.requests';
 import { requestAccountSettings } from 'src/store/accountSettings/accountSettings.requests';
@@ -80,6 +81,15 @@ export const useReduxLoad = (
   const [_loading, setLoading] = useState<boolean>(false);
   const dispatch = useDispatch();
   const state = useStore<ApplicationState>().getState();
+  /**
+   * Restricted users get a 403 from /lke/clusters,
+   * which gums up the works. We want to prevent that particular
+   * request for a restricted user.
+   */
+  const { _isRestrictedUser } = useAccountManagement();
+  if (_isRestrictedUser) {
+    requestMap.kubernetes = () => Promise.resolve([]);
+  }
 
   const mountedRef = useRef<boolean>(true);
 


### PR DESCRIPTION
When a user has >500 Domains, we trigger our useApiSearch() logic,
to prevent the search bar from crashing. A corner case was recently
discovered that broke this logic:

If a restricted user has access to >500 Domains, the search bar
returns an empty results list inline, and the search landing page
displays an error.

This is because restricted users, regardless of access/grants, always
receive a 403 when attempting to access /lke/clusters. This may change
at some point, but is not expected until at least 2021.

Since we were making API search requests to /lke/clusters unconditionally,
this meant that we always ended up in the .catch() block of our search
logic, and results were not displayed. (Promise.all() bails as soon as
a single request fails).

By making this particular request only for nonrestricted users, we can
avoid this situation. I return Promise.resolve([]) for restricted users
for Kubernetes, which loses some UI (before we showed an error message
on the landing page saying "couldn't retrieve results for: Kubernetes",
which will now not work at all for large accounts).

I also added a conditional to useReduxLoad in the search landing page,
which was unconditionally loading all entities on page load even
for large accounts.

## Note to reviewers

This happens _if_ you are a restricted user _and_ your account has more than 500 Domains _and_ you have at least read access to at least 500 of those Domains. Please test all permutations to make sure things are all working:

1. Test account 1 has plenty of domains and the default user is unrestricted
2. Add/use a restricted user on that account and grant access to Domains (I have one set up, reach out for creds)
3. Test a normal/small account with an unrestricted user
4. And a small account with a restricted user