### PR TITLE
Update VLAN Linodes typing

### DIFF
--- a/packages/api-v4/src/vlans/types.ts
+++ b/packages/api-v4/src/vlans/types.ts
@@ -2,8 +2,9 @@ export interface VLAN {
   id: number;
   description: string;
   region: string;
-  linodes: number[];
+  linodes: { id: number; ip: string }[];
   cidr_block: string;
+  created: string;
 }
 
 export interface CreateVLANPayload {

--- a/packages/api-v4/src/vlans/types.ts
+++ b/packages/api-v4/src/vlans/types.ts
@@ -2,7 +2,7 @@ export interface VLAN {
   id: number;
   description: string;
   region: string;
-  linodes: { id: number; ip: string }[];
+  linodes: { id: number; ipv4_address: string; mac_address: string }[];
   cidr_block: string;
   created: string;
 }

--- a/packages/manager/src/factories/vlans.ts
+++ b/packages/manager/src/factories/vlans.ts
@@ -6,9 +6,9 @@ export const VLANFactory = Factory.Sync.makeFactory<VLAN>({
   description: Factory.each(i => `vlan-${i}`),
   region: 'us-east',
   linodes: [
-    { id: 0, ip: '10.0.0.1' },
-    { id: 1, ip: '10.0.0.2' },
-    { id: 2, ip: '10.0.0.3' }
+    { id: 0, ipv4_address: '10.0.0.1', mac_address: 'a4-ac-39-b7-6e-42' },
+    { id: 1, ipv4_address: '10.0.0.2', mac_address: 'a4-ac-39-b7-6e-43' },
+    { id: 2, ipv4_address: '10.0.0.3', mac_address: 'a4-ac-39-b7-6e-44' }
   ],
   cidr_block: '10.0.0.0/24',
   created: '2020-10-01 00:00:00'

--- a/packages/manager/src/factories/vlans.ts
+++ b/packages/manager/src/factories/vlans.ts
@@ -6,9 +6,9 @@ export const VLANFactory = Factory.Sync.makeFactory<VLAN>({
   description: Factory.each(i => `vlan-${i}`),
   region: 'us-east',
   linodes: [
-    { id: 0, ipv4_address: '10.0.0.1', mac_address: 'a4-ac-39-b7-6e-42' },
-    { id: 1, ipv4_address: '10.0.0.2', mac_address: 'a4-ac-39-b7-6e-43' },
-    { id: 2, ipv4_address: '10.0.0.3', mac_address: 'a4-ac-39-b7-6e-44' }
+    { id: 0, ipv4_address: '10.0.0.1', mac_address: 'a4:ac:39:b7:6e:42' },
+    { id: 1, ipv4_address: '10.0.0.2', mac_address: 'a4:ac:39:b7:6e:43' },
+    { id: 2, ipv4_address: '10.0.0.3', mac_address: 'a4:ac:39:b7:6e:44' }
   ],
   cidr_block: '10.0.0.0/24',
   created: '2020-10-01 00:00:00'

--- a/packages/manager/src/factories/vlans.ts
+++ b/packages/manager/src/factories/vlans.ts
@@ -5,6 +5,11 @@ export const VLANFactory = Factory.Sync.makeFactory<VLAN>({
   id: Factory.each(i => i),
   description: Factory.each(i => `vlan-${i}`),
   region: 'us-east',
-  linodes: [0, 1, 2],
-  cidr_block: '10.0.0.0/24'
+  linodes: [
+    { id: 0, ip: '10.0.0.1' },
+    { id: 1, ip: '10.0.0.2' },
+    { id: 2, ip: '10.0.0.3' }
+  ],
+  cidr_block: '10.0.0.0/24',
+  created: '2020-10-01 00:00:00'
 });

--- a/packages/manager/src/features/Vlans/CreateVLANDialog/CreateVLANDialog.tsx
+++ b/packages/manager/src/features/Vlans/CreateVLANDialog/CreateVLANDialog.tsx
@@ -127,7 +127,9 @@ export const CreateVLANDialog: React.FC<{}> = _ => {
         if (rebootOnCreate) {
           // If we've been asked to do this, reboot every Linode we just
           // attached to the VLAN.
-          response.linodes.forEach(thisLinode => linodeReboot(thisLinode));
+          response.linodes.forEach(thisVLANLinode =>
+            linodeReboot(thisVLANLinode.id)
+          );
         }
         context.close();
         history.push('/vlans');
@@ -184,7 +186,7 @@ export const CreateVLANDialog: React.FC<{}> = _ => {
           <TextField
             label="IP Range / Netmask"
             name="cidr_block"
-            helperText={`You can specify the IP range with a netmask (10.0.0.0/16) 
+            helperText={`You can specify the IP range with a netmask (10.0.0.0/16)
           or starting and ending IPs (10.0.0.0-10.0.0.20).`}
             helperTextPosition="top"
             value={formik.values.cidr_block}

--- a/packages/manager/src/features/Vlans/VlanLanding/VlanRow.tsx
+++ b/packages/manager/src/features/Vlans/VlanLanding/VlanRow.tsx
@@ -43,7 +43,7 @@ export const VlanRow: React.FC<CombinedProps> = props => {
   const classes = useStyles();
 
   const getLinodesCellString = (
-    data: number[],
+    vlanLinodes: VLAN['linodes'],
     loading: boolean,
     error?: APIError[]
   ): string | JSX.Element => {
@@ -55,25 +55,25 @@ export const VlanRow: React.FC<CombinedProps> = props => {
       return 'Error retrieving Linodes';
     }
 
-    if (data.length === 0) {
+    if (vlanLinodes.length === 0) {
       return 'None assigned';
     }
 
-    return getLinodeLinks(data);
+    return getLinodeLinks(vlanLinodes);
   };
 
-  const getLinodeLinks = (data: number[]): JSX.Element => {
+  const getLinodeLinks = (vlanLinodes: VLAN['linodes']): JSX.Element => {
     return (
       // eslint-disable-next-line
       <>
-        {data.map(linodeID => (
+        {vlanLinodes.map(thisVLANLinode => (
           <Link
             className={classes.link}
-            key={linodeID}
-            to={`/linodes/${linodeID}`}
+            key={thisVLANLinode.id}
+            to={`/linodes/${thisVLANLinode.id}`}
             data-testid="vlan-row-link"
           >
-            {getLinodeLabel(linodeID)}
+            {getLinodeLabel(thisVLANLinode.id)}
           </Link>
         ))}
       </>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/VLANPanel/VlanTableRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/VLANPanel/VlanTableRow.tsx
@@ -9,6 +9,7 @@ import Grid from 'src/components/Grid';
 import VlanActionMenu, { ActionHandlers } from './VlanActionMenu';
 import { getLinodeLabel } from 'src/features/Dashboard/VolumesDashboardCard/VolumeDashboardRow';
 import { VlanData } from './LinodeVLANs';
+import { VLAN } from '@linode/api-v4/lib/vlans';
 
 export const MAX_LINODES_VLANATTACHED_DISPLAY = 50;
 
@@ -31,7 +32,7 @@ export const VlanTableRow: React.FC<CombinedProps> = props => {
   const vlanLabel = description.length > 32 ? `vlan-${id}` : description;
 
   const getLinodesCellString = (
-    data: number[],
+    data: VLAN['linodes'],
     loading: boolean,
     error?: APIError[]
   ): string | JSX.Element => {
@@ -50,20 +51,20 @@ export const VlanTableRow: React.FC<CombinedProps> = props => {
     return getLinodeLinks(data);
   };
 
-  const getLinodeLinks = (data: number[]): JSX.Element => {
+  const getLinodeLinks = (vlanLinodes: VLAN['linodes']): JSX.Element => {
     // Remove the Linode the user is currently on from the array of Linode IDs the VLAN is attached to, and render that linode's label first in the list as a non-link.
-    const indexOfCurrentLinodeId = data.findIndex(
-      element => element === currentLinodeId
+    const indexOfCurrentLinodeId = vlanLinodes.findIndex(
+      thisVLANLinode => thisVLANLinode.id === currentLinodeId
     );
-    data.splice(indexOfCurrentLinodeId, 1);
+    vlanLinodes.splice(indexOfCurrentLinodeId, 1);
 
-    const generatedLinks = data.map(linodeID => (
+    const generatedLinks = vlanLinodes.map(thisVLANLinode => (
       <Link
-        key={linodeID}
-        to={`/linodes/${linodeID}/networking`}
+        key={thisVLANLinode.id}
+        to={`/linodes/${thisVLANLinode.id}/networking`}
         data-testid="vlan-row-link"
       >
-        {getLinodeLabel(linodeID)}
+        {getLinodeLabel(thisVLANLinode.id)}
       </Link>
     ));
 
@@ -71,7 +72,7 @@ export const VlanTableRow: React.FC<CombinedProps> = props => {
       // eslint-disable-next-line react/jsx-no-useless-fragment
       <>
         {getLinodeLabel(currentLinodeId)}
-        {data.length > 0 && `, `}
+        {vlanLinodes.length > 0 && `, `}
         {truncateAndJoinJSXList(
           generatedLinks,
           MAX_LINODES_VLANATTACHED_DISPLAY


### PR DESCRIPTION
## Description

`vlan.linode` is now `{ id: number, mac_address: string, ipv4_address: string }[]` instead of `number[]`.

There's also a new `created` field.

To test, use dev services.
