### PR TITLE
Change: Request Domains on load to determine account size

### DIFF
--- a/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.test.tsx
+++ b/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.test.tsx
@@ -18,6 +18,7 @@ const component = shallow<AuthenticationWrapper>(
     requestSettings={jest.fn()}
     markAppAsDoneLoading={jest.fn()}
     requestLinodeType={jest.fn()}
+    checkAccountSize={jest.fn()}
     linodes={[]}
     typesLastUpdated={0}
     types={[]}

--- a/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
+++ b/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
@@ -15,6 +15,7 @@ import { startEventsInterval } from 'src/events';
 import { redirectToLogin } from 'src/session';
 import { ApplicationState } from 'src/store';
 import { requestAccount } from 'src/store/account/account.requests';
+import { checkAccountSize } from 'src/store/accountManagement/accountManagement.requests';
 import { requestAccountSettings } from 'src/store/accountSettings/accountSettings.requests';
 import { handleInitTokens } from 'src/store/authentication/authentication.actions';
 import { handleLoadingDone } from 'src/store/initialLoad/initialLoad.actions';
@@ -65,7 +66,10 @@ export class AuthenticationWrapper extends React.Component<CombinedProps> {
       this.props.requestProfile(),
 
       // Is a user managed
-      this.props.requestSettings()
+      this.props.requestSettings(),
+
+      // Is this a large account? (should we use API or Redux-based search/pagination)
+      this.props.checkAccountSize()
     ];
 
     // Start events polling
@@ -217,6 +221,7 @@ const mapStateToProps: MapState<StateProps, {}> = state => ({
 
 interface DispatchProps {
   initSession: () => void;
+  checkAccountSize: () => Promise<null>;
   requestAccount: () => Promise<Account>;
   requestLinodes: () => Promise<GetAllData<Linode>>;
   requestNotifications: () => Promise<GetAllData<Notification>>;
@@ -232,6 +237,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
   dispatch: ThunkDispatch<ApplicationState, undefined, Action<any>>
 ) => ({
   initSession: () => dispatch(handleInitTokens()),
+  checkAccountSize: () => dispatch(checkAccountSize()),
   requestAccount: () => dispatch(requestAccount()),
   requestLinodes: () => dispatch(requestLinodes({})),
   requestNotifications: () => dispatch(requestNotifications()),

--- a/packages/manager/src/features/Domains/DomainsLanding.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.tsx
@@ -685,8 +685,7 @@ const mapStateToProps: MapStateToProps<
     ['__resources', 'profile', 'data', 'restricted'],
     state
   ),
-  // @todo remove this when ARB-2091 is merged
-  isLargeAccount: state.preferences.data?.is_large_account ?? false,
+  isLargeAccount: state.__resources.accountManagement.isLargeAccount,
   domainsByID: state.__resources.domains.itemsById
 });
 

--- a/packages/manager/src/hooks/useAccountManagement.ts
+++ b/packages/manager/src/hooks/useAccountManagement.ts
@@ -29,15 +29,11 @@ export const useAccountManagement = () => {
     (state: ApplicationState) => state.__resources.accountSettings
   );
 
-  /**
-   * @todo After ARB-2091 is merged, update this to something like:
-   * Object.values(state.accountSummary)
-   *   .some(thisEntity => thisEntity > LARGE_ACCOUNT_THRESHOLD)
-   */
   const _isLargeAccount = useSelector(
     (state: ApplicationState) =>
-      state.preferences.data?.is_large_account ?? false
+      state.__resources.accountManagement.isLargeAccount
   );
+
   const _isRestrictedUser = profile.data?.restricted ?? false;
 
   const _hasGrant = (grant: GlobalGrantTypes) =>

--- a/packages/manager/src/store/accountManagement/accountManagement.actions.ts
+++ b/packages/manager/src/store/accountManagement/accountManagement.actions.ts
@@ -1,0 +1,5 @@
+import { actionCreatorFactory } from 'typescript-fsa';
+
+const actionCreator = actionCreatorFactory(`@@manager/accountManagement`);
+
+export const setLargeAccount = actionCreator<boolean>(`set-large-account`);

--- a/packages/manager/src/store/accountManagement/accountManagement.reducer.ts
+++ b/packages/manager/src/store/accountManagement/accountManagement.reducer.ts
@@ -19,11 +19,6 @@ const reducer: Reducer<State> = reducerWithInitialState(defaultState)
     return {
       ...state,
       isLargeAccount: action.payload
-      /**
-       * intentionally not resetting error state here because it will cause
-       * the PreferenceToggle.tsx component to re-render, causing the entire app
-       * to re-render unnecessarily
-       */
     };
   })
   .default(state => state);

--- a/packages/manager/src/store/accountManagement/accountManagement.reducer.ts
+++ b/packages/manager/src/store/accountManagement/accountManagement.reducer.ts
@@ -1,0 +1,31 @@
+import { Reducer } from 'redux';
+import { reducerWithInitialState } from 'typescript-fsa-reducers';
+import { setLargeAccount } from './accountManagement.actions';
+
+/** State */
+
+export interface State {
+  isLargeAccount: boolean;
+}
+
+export const defaultState: State = {
+  isLargeAccount: false
+};
+
+/** Reducer */
+
+const reducer: Reducer<State> = reducerWithInitialState(defaultState)
+  .caseWithAction(setLargeAccount, (state, action) => {
+    return {
+      ...state,
+      isLargeAccount: action.payload
+      /**
+       * intentionally not resetting error state here because it will cause
+       * the PreferenceToggle.tsx component to re-render, causing the entire app
+       * to re-render unnecessarily
+       */
+    };
+  })
+  .default(state => state);
+
+export default reducer;

--- a/packages/manager/src/store/accountManagement/accountManagement.requests.ts
+++ b/packages/manager/src/store/accountManagement/accountManagement.requests.ts
@@ -1,0 +1,26 @@
+import { LARGE_ACCOUNT_THRESHOLD } from 'src/constants';
+import { getDomainsPage } from '../domains/domains.requests';
+import { setLargeAccount } from './accountManagement.actions';
+import { ThunkActionCreator, ThunkDispatch } from '../types';
+
+export const checkAccountSize: ThunkActionCreator<Promise<null>> = () => (
+  dispatch: ThunkDispatch
+) => {
+  /**
+   * getDomainsPage will automatically check if this is a "full request"
+   * (that is, if the total number of Domains matches the number of Domains
+   * on the account). If so, it will bump lastUpdated and store the info in
+   * Redux.
+   */
+  return (
+    dispatch(getDomainsPage({ params: { page_size: 100 } }))
+      .then(result => {
+        const { results } = result;
+        dispatch(setLargeAccount(results > LARGE_ACCOUNT_THRESHOLD));
+        return null;
+      })
+      // We default the state to false, which gives the intended default behavior for the app.
+      // No need to do anything special here.
+      .catch(_ => null)
+  );
+};

--- a/packages/manager/src/store/domains/domains.requests.ts
+++ b/packages/manager/src/store/domains/domains.requests.ts
@@ -7,15 +7,12 @@ import {
   getDomains,
   updateDomain as _updateDomain
 } from '@linode/api-v4/lib/domains';
-import { getUserPreferences } from '@linode/api-v4/lib/profile';
 import { APIError } from '@linode/api-v4/lib/types';
 import { Dispatch } from 'redux';
-import { LARGE_ACCOUNT_THRESHOLD } from 'src/constants';
-import { updateUserPreferences } from 'src/store/preferences/preferences.requests';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { getAll } from 'src/utilities/getAll';
 import { createRequestThunk } from '../store.helpers';
-import { ThunkActionCreator, ThunkDispatch } from '../types';
+import { ThunkActionCreator } from '../types';
 import {
   createDomainActions,
   deleteDomainActions,
@@ -47,14 +44,11 @@ export const updateDomain = createRequestThunk<
 );
 
 export const requestDomains: ThunkActionCreator<Promise<Domain[]>> = () => (
-  dispatch: Dispatch<any>,
-  getState
+  dispatch: Dispatch<any>
 ) => {
   dispatch(getDomainsActions.started());
 
-  return getAll<Domain>(getDomains, undefined, (results: number) =>
-    markAccountAsLarge(results, dispatch, getState)
-  )({}, {})
+  return getAll<Domain>(getDomains, undefined)({}, {})
     .then(domains => {
       dispatch(getDomainsActions.done({ result: domains }));
       return domains.data;
@@ -83,39 +77,3 @@ export const getDomainsPage = createRequestThunk(
   getDomainsPageActions,
   ({ params, filters }) => getDomains(params, filters)
 );
-
-// @todo export and use in linodes.requests if necessary
-const markAccountAsLarge = (
-  results: number,
-  dispatch: ThunkDispatch,
-  getState: () => any
-) => {
-  const isMarkedAsLargeAccount =
-    getState().preferences?.data?.is_large_account ?? false;
-
-  if (results >= LARGE_ACCOUNT_THRESHOLD) {
-    // If we haven't already marked this account as large, do that here.
-    // Conversely, if it's a large account that has become small, update
-    // preferences to reflect that.
-    // @todo remove all this logic once ARB-2091 is merged.
-    if (!isMarkedAsLargeAccount) {
-      getUserPreferences().then(response => {
-        const updatedPreferences = {
-          ...response,
-          is_large_account: true
-        };
-        dispatch(updateUserPreferences(updatedPreferences));
-      });
-    }
-  } else {
-    if (isMarkedAsLargeAccount) {
-      getUserPreferences().then(response => {
-        const updatedPreferences = {
-          ...response,
-          is_large_account: false
-        };
-        dispatch(updateUserPreferences(updatedPreferences));
-      });
-    }
-  }
-};

--- a/packages/manager/src/store/index.ts
+++ b/packages/manager/src/store/index.ts
@@ -4,6 +4,10 @@ import account, {
   defaultState as defaultAccountState,
   State as AccountState
 } from 'src/store/account/account.reducer';
+import accountManagement, {
+  defaultState as defaultAccountManagementState,
+  State as AccountManagementState
+} from 'src/store/accountManagement/accountManagement.reducer';
 import accountSettings, {
   defaultState as defaultAccountSettingsState,
   State as AccountSettingsState
@@ -180,6 +184,7 @@ initReselectDevtools();
  */
 const __resourcesDefaultState = {
   account: defaultAccountState,
+  accountManagement: defaultAccountManagementState,
   accountSettings: defaultAccountSettingsState,
   domains: defaultDomainsState,
   images: defaultImagesState,
@@ -204,6 +209,7 @@ const __resourcesDefaultState = {
 
 export interface ResourcesState {
   account: AccountState;
+  accountManagement: AccountManagementState;
   accountSettings: AccountSettingsState;
   domains: DomainsState;
   images: ImagesState;
@@ -279,6 +285,7 @@ export const defaultState: ApplicationState = {
  */
 const __resources = combineReducers({
   account,
+  accountManagement,
   accountSettings,
   domains,
   images,

--- a/packages/manager/src/store/preferences/preferences.actions.ts
+++ b/packages/manager/src/store/preferences/preferences.actions.ts
@@ -30,7 +30,6 @@ export interface UserPreferences {
   desktop_sidebar_open?: boolean;
   sortKeys?: Partial<Record<SortKey, OrderSet>>;
   main_content_banner_dismissal?: Record<string, boolean>;
-  is_large_account?: boolean;
   linode_news_banner_dismissed?: boolean;
   notification_drawer_view?: 'list' | 'grouped';
 }


### PR DESCRIPTION
Since the API has determined that a "thing count" endpoint
is not feasible, and our existing logic (which waits for
a getAllDomains request to be triggered, then saves is_large_account
to user preferences if > 500 results come back) has caused
frustration in customers from huge accounts who don't like the
initial crash of their accounts, we need to update our approach.

I added a new Redux state, accountManagement, to the __resources
envelope. This is debatable; we could have stored this data in
a context, or added it to an existing state component. I chose
this way because it's fairly clear and our Redux structure makes
it easy to bring in thunks from other parts of the state.

In practice, the checkAccountSize thunk is called on app load.
It requests a single page of Domains (page size of 100 to keep
the request fast, although it probably doesn't matter that much).
If the response.results from that request tells us that there
are a higher number of Domains than our threshold (currently 500),
it dispatches an action that marks the account as large in Redux.
We then read this value, rather than one from user preferences,
to determine whether to use API or redux-based pagination/search.

In addition, once we've made this request, the getDomainsPage
thunk we're using will check if the total number of domains
has been returned by the single request (this is existing
behavior for this thunk). In this way, for an account with few
Domains, the request we make on initial load obviates the need
for further requests when navigating to /domains or searching.

Finally, I removed all the existing user preferences logic. Since
we need to make this request when the app loads anyway (or make it
conditional based on whether we already have a value in preferences),
going through a separate endpoint is an unnecessary detour. This also
makes it simple to handle the case of an account that has 500+ Domains
and then deletes ~100, bringing them under the threshold.

## Notes

This shouldn't change behavior, with the exception that an enormous account won't crash
the first time search or /domains is loaded.
