### PR TITLE
Remove flag-based dynamic password validation logic

### DIFF
--- a/packages/manager/src/components/AccessPanel/AccessPanel.tsx
+++ b/packages/manager/src/components/AccessPanel/AccessPanel.tsx
@@ -75,7 +75,6 @@ interface Props {
   disabled?: boolean;
   disabledReason?: string;
   hideStrengthLabel?: boolean;
-  hideHelperText?: boolean;
   className?: string;
   small?: boolean;
   isOptional?: boolean;
@@ -109,7 +108,6 @@ class AccessPanel extends React.Component<CombinedProps> {
       disabled,
       disabledReason,
       hideStrengthLabel,
-      hideHelperText,
       className,
       small,
       isOptional,
@@ -144,7 +142,6 @@ class AccessPanel extends React.Component<CombinedProps> {
               placeholder={placeholder || 'Enter a password.'}
               onChange={this.handleChange}
               hideStrengthLabel={hideStrengthLabel}
-              hideHelperText={hideHelperText}
               helperText={passwordHelperText}
             />
           </React.Suspense>

--- a/packages/manager/src/components/PasswordInput/PasswordInput.tsx
+++ b/packages/manager/src/components/PasswordInput/PasswordInput.tsx
@@ -1,11 +1,8 @@
 import { isEmpty } from 'ramda';
 import * as React from 'react';
-
 import { makeStyles, Theme } from 'src/components/core/styles';
-import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 import { Props as TextFieldProps } from 'src/components/TextField';
-import useFlags from 'src/hooks/useFlags';
 import * as zxcvbn from 'zxcvbn';
 import StrengthIndicator from '../PasswordInput/StrengthIndicator';
 import HideShowText from './HideShowText';
@@ -15,7 +12,6 @@ type Props = TextFieldProps & {
   required?: boolean;
   disabledReason?: string;
   hideStrengthLabel?: boolean;
-  hideHelperText?: boolean;
   hideValidation?: boolean;
 };
 
@@ -63,8 +59,6 @@ const useStyles = makeStyles((theme: Theme) => ({
 type CombinedProps = Props;
 
 const PasswordInput: React.FC<CombinedProps> = props => {
-  const flags = useFlags();
-
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (props.onChange) {
       props.onChange(e);
@@ -76,7 +70,6 @@ const PasswordInput: React.FC<CombinedProps> = props => {
     required,
     disabledReason,
     hideStrengthLabel,
-    hideHelperText,
     hideValidation,
     ...rest
   } = props;
@@ -112,28 +105,6 @@ const PasswordInput: React.FC<CombinedProps> = props => {
             strength={strength}
             hideStrengthLabel={hideStrengthLabel}
           />
-        </Grid>
-      )}
-      {!hideHelperText && flags.passwordValidation === 'length' && (
-        <Grid item xs={12}>
-          <div className={classes.requirementsListOuter}>
-            <Typography>Password must:</Typography>
-            <ul className={classes.requirementsList}>
-              <li>
-                <Typography component={'span'}>
-                  Be at least <strong>6 characters</strong>
-                </Typography>
-              </li>
-              <li>
-                <Typography component={'span'}>
-                  Contain at least{' '}
-                  <strong>two of the following character classes</strong>:
-                  uppercase letters, lowercase letters, numbers, and
-                  punctuation.
-                </Typography>
-              </li>
-            </ul>
-          </div>
         </Grid>
       )}
     </Grid>

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -24,7 +24,6 @@ export interface Flags {
   thirdPartyAuth: boolean;
   cmr: boolean;
   mainContentBanner: MainContentBanner;
-  passwordValidation: PasswordValidationType;
   changelog: Changelog;
   vlans: boolean;
   cvvRequired: boolean;
@@ -68,5 +67,3 @@ export interface MainContentBanner {
   text: string;
   key: string;
 }
-
-export type PasswordValidationType = 'none' | 'length' | 'complexity';

--- a/packages/manager/src/features/Managed/Credentials/AddCredentialDrawer.tsx
+++ b/packages/manager/src/features/Managed/Credentials/AddCredentialDrawer.tsx
@@ -91,7 +91,6 @@ const CredentialDrawer: React.FC<CombinedProps> = props => {
                   onBlur={handleBlur}
                   // This credential could be anything so might be counterproductive to validate strength
                   hideValidation
-                  hideHelperText
                   required
                 />
               </React.Suspense>

--- a/packages/manager/src/features/Managed/Credentials/UpdateCredentialDrawer.tsx
+++ b/packages/manager/src/features/Managed/Credentials/UpdateCredentialDrawer.tsx
@@ -157,7 +157,6 @@ const CredentialDrawer: React.FC<CombinedProps> = props => {
                   onBlur={handleBlur}
                   // This credential could be anything so might be counterproductive to validate strength
                   hideValidation
-                  hideHelperText
                 />
               </React.Suspense>
               <ActionsPanel>

--- a/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedText.tsx
+++ b/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedText.tsx
@@ -60,7 +60,6 @@ class UserDefinedText extends React.Component<CombinedProps, {}> {
         placeholder={placeholder}
         error={error}
         hideStrengthLabel
-        hideHelperText
         className={!isOptional ? classes.accessPanel : ''}
         isOptional={isOptional}
         password={this.props.value}

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -432,10 +432,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
     }
 
     if (payload.root_pass) {
-      const passwordError = validatePassword(
-        this.props.flags.passwordValidation ?? 'none',
-        payload.root_pass
-      );
+      const passwordError = validatePassword(payload.root_pass);
 
       if (passwordError) {
         this.setState({

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.tsx
@@ -19,7 +19,6 @@ import Grid from 'src/components/Grid';
 import ModeSelect, { Mode } from 'src/components/ModeSelect';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
-import useFlags from 'src/hooks/useFlags';
 import {
   handleFieldErrors,
   handleGeneralErrors
@@ -117,38 +116,21 @@ export const DiskDrawer: React.FC<CombinedProps> = props => {
     requestKeys
   } = props;
 
-  const { passwordValidation } = useFlags();
+  const CreateFromImageSchema = () =>
+    extendValidationSchema(CreateLinodeDiskFromImageSchema);
 
-  /**
-   * CreateFromImageSchema is dynamic wrt the passwordValidation
-   * flag, so these have to live inside the component. When validation
-   * is constant and stable (on the API side), these can be
-   * moved back out.
-   */
-  const CreateFromImageSchema = React.useMemo(
-    () =>
-      extendValidationSchema(
-        passwordValidation ?? 'none',
-        CreateLinodeDiskFromImageSchema
-      ),
-    [passwordValidation]
-  );
-
-  const getSchema = React.useCallback(
-    (mode: DrawerMode, diskMode: diskMode) => {
-      switch (mode) {
-        case 'create':
-          return diskMode === 'from_image'
-            ? CreateFromImageSchema
-            : CreateLinodeDiskSchema;
-        case 'rename':
-          return RenameDiskSchema;
-        case 'resize':
-          return ResizeLinodeDiskSchema;
-      }
-    },
-    [CreateFromImageSchema]
-  );
+  const getSchema = (mode: DrawerMode, diskMode: diskMode) => {
+    switch (mode) {
+      case 'create':
+        return diskMode === 'from_image'
+          ? CreateFromImageSchema
+          : CreateLinodeDiskSchema;
+      case 'rename':
+        return RenameDiskSchema;
+      case 'resize':
+        return ResizeLinodeDiskSchema;
+    }
+  };
 
   const classes = useStyles();
   const [selectedMode, setSelectedMode] = React.useState<diskMode>(modes.EMPTY);

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuild.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuild.tsx
@@ -12,7 +12,6 @@ import {
 import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import EnhancedSelect, { Item } from 'src/components/EnhancedSelect/Select';
-import useFlags from 'src/hooks/useFlags';
 import { withLinodeDetailContext } from '../linodeDetailContext';
 import HostMaintenanceError from '../HostMaintenanceError';
 import LinodePermissionsError from '../LinodePermissionsError';
@@ -59,10 +58,6 @@ const LinodeRebuild: React.FC<CombinedProps> = props => {
   const unauthorized = permissions === 'read_only';
   const disabled = hostMaintenance || unauthorized;
 
-  const flags = useFlags();
-
-  const passwordValidation = flags.passwordValidation ?? 'none';
-
   const [mode, setMode] = React.useState<MODES>('fromImage');
 
   return (
@@ -103,7 +98,6 @@ const LinodeRebuild: React.FC<CombinedProps> = props => {
       {mode === 'fromImage' && (
         <RebuildFromImage
           passwordHelperText={passwordHelperText}
-          passwordValidation={passwordValidation}
           disabled={disabled}
         />
       )}
@@ -111,7 +105,6 @@ const LinodeRebuild: React.FC<CombinedProps> = props => {
         <RebuildFromStackScript
           type="community"
           passwordHelperText={passwordHelperText}
-          passwordValidation={passwordValidation}
           disabled={disabled}
         />
       )}
@@ -119,7 +112,6 @@ const LinodeRebuild: React.FC<CombinedProps> = props => {
         <RebuildFromStackScript
           type="account"
           passwordHelperText={passwordHelperText}
-          passwordValidation={passwordValidation}
           disabled={disabled}
         />
       )}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuildDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuildDialog.tsx
@@ -3,7 +3,6 @@ import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import EnhancedSelect, { Item } from 'src/components/EnhancedSelect/Select';
-import useFlags from 'src/hooks/useFlags';
 import HostMaintenanceError from '../HostMaintenanceError';
 import LinodePermissionsError from '../LinodePermissionsError';
 import RebuildFromImage from './RebuildFromImage_CMR';
@@ -71,9 +70,6 @@ const LinodeRebuildDialog: React.FC<CombinedProps> = props => {
   const disabled = hostMaintenance || unauthorized;
 
   const classes = useStyles();
-  const flags = useFlags();
-
-  const passwordValidation = flags.passwordValidation ?? 'none';
 
   const [mode, setMode] = React.useState<MODES>('fromImage');
   const [rebuildError, setRebuildError] = React.useState<string>('');
@@ -127,7 +123,6 @@ const LinodeRebuildDialog: React.FC<CombinedProps> = props => {
       {mode === 'fromImage' && (
         <RebuildFromImage
           passwordHelperText={passwordHelperText}
-          passwordValidation={passwordValidation}
           disabled={disabled}
           linodeId={linodeId}
           linodeLabel={linodeLabel}
@@ -139,7 +134,6 @@ const LinodeRebuildDialog: React.FC<CombinedProps> = props => {
         <RebuildFromStackScript
           type="community"
           passwordHelperText={passwordHelperText}
-          passwordValidation={passwordValidation}
           disabled={disabled}
           linodeId={linodeId}
           linodeLabel={linodeLabel}
@@ -151,7 +145,6 @@ const LinodeRebuildDialog: React.FC<CombinedProps> = props => {
         <RebuildFromStackScript
           type="account"
           passwordHelperText={passwordHelperText}
-          passwordValidation={passwordValidation}
           disabled={disabled}
           linodeId={linodeId}
           linodeLabel={linodeLabel}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.test.tsx
@@ -26,7 +26,6 @@ const props: CombinedProps = {
   enqueueSnackbar: jest.fn(),
   permissions: 'read_write',
   passwordHelperText: '',
-  passwordValidation: 'complexity',
   requestKeys: jest.fn(),
   disabled: false,
   ...reactRouterProps

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
@@ -27,7 +27,6 @@ import { resetEventsPolling } from 'src/eventsPolling';
 import userSSHKeyHoc, {
   UserSSHKeyProps
 } from 'src/features/linodes/userSSHKeyHoc';
-import { PasswordValidationType } from 'src/featureFlags';
 import {
   handleFieldErrors,
   handleGeneralErrors
@@ -52,7 +51,6 @@ const styles = (theme: Theme) =>
 interface Props {
   disabled: boolean;
   passwordHelperText: string;
-  passwordValidation: PasswordValidationType;
 }
 
 interface ContextProps {
@@ -90,20 +88,10 @@ export const RebuildFromImage: React.FC<CombinedProps> = props => {
     linodeId,
     enqueueSnackbar,
     history,
-    passwordHelperText,
-    passwordValidation
+    passwordHelperText
   } = props;
 
-  /**
-   * Dynamic validation schema, with password validation
-   * dependent on a value from a feature flag. Remove this
-   * once API password validation is stable.
-   */
-  const RebuildSchema = React.useMemo(
-    () =>
-      extendValidationSchema(passwordValidation ?? 'none', RebuildLinodeSchema),
-    [passwordValidation]
-  );
+  const RebuildSchema = () => extendValidationSchema(RebuildLinodeSchema);
 
   const [isDialogOpen, setIsDialogOpen] = React.useState<boolean>(false);
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage_CMR.tsx
@@ -20,7 +20,6 @@ import { resetEventsPolling } from 'src/eventsPolling';
 import userSSHKeyHoc, {
   UserSSHKeyProps
 } from 'src/features/linodes/userSSHKeyHoc';
-import { PasswordValidationType } from 'src/featureFlags';
 import {
   handleFieldErrors,
   handleGeneralErrors
@@ -42,7 +41,6 @@ const useStyles = makeStyles((theme: Theme) => ({
 interface Props {
   disabled: boolean;
   passwordHelperText: string;
-  passwordValidation: PasswordValidationType;
   linodeId: number;
   linodeLabel?: string;
   handleRebuildError: (status: string) => void;
@@ -78,22 +76,12 @@ export const RebuildFromImage: React.FC<CombinedProps> = props => {
     handleRebuildError,
     onClose,
     enqueueSnackbar,
-    passwordHelperText,
-    passwordValidation
+    passwordHelperText
   } = props;
 
   const classes = useStyles();
 
-  /**
-   * Dynamic validation schema, with password validation
-   * dependent on a value from a feature flag. Remove this
-   * once API password validation is stable.
-   */
-  const RebuildSchema = React.useMemo(
-    () =>
-      extendValidationSchema(passwordValidation ?? 'none', RebuildLinodeSchema),
-    [passwordValidation]
-  );
+  const RebuildSchema = () => extendValidationSchema(RebuildLinodeSchema);
 
   const [confirmationText, setConfirmationText] = React.useState<string>('');
   const submitButtonDisabled = confirmationText !== linodeLabel;

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.test.tsx
@@ -36,7 +36,6 @@ const props: CombinedProps = {
   closeSnackbar: jest.fn(),
   enqueueSnackbar: jest.fn(),
   passwordHelperText: '',
-  passwordValidation: 'complexity',
   ...reactRouterProps
 };
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.tsx
@@ -36,7 +36,6 @@ import {
   getMineAndAccountStackScripts
 } from 'src/features/StackScripts/stackScriptUtils';
 import UserDefinedFieldsPanel from 'src/features/StackScripts/UserDefinedFieldsPanel';
-import { PasswordValidationType } from 'src/featureFlags';
 import { useStackScript } from 'src/hooks/useStackScript';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import {
@@ -73,7 +72,6 @@ interface Props {
   type: 'community' | 'account';
   disabled: boolean;
   passwordHelperText: string;
-  passwordValidation: PasswordValidationType;
 }
 
 interface ContextProps {
@@ -110,23 +108,11 @@ export const RebuildFromStackScript: React.FC<CombinedProps> = props => {
     linodeId,
     enqueueSnackbar,
     history,
-    passwordHelperText,
-    passwordValidation
+    passwordHelperText
   } = props;
 
-  /**
-   * Dynamic validation schema, with password validation
-   * dependent on a value from a feature flag. Remove this
-   * once API password validation is stable.
-   */
-  const RebuildSchema = React.useMemo(
-    () =>
-      extendValidationSchema(
-        passwordValidation ?? 'none',
-        RebuildLinodeFromStackScriptSchema
-      ),
-    [passwordValidation]
-  );
+  const RebuildSchema = () =>
+    extendValidationSchema(RebuildLinodeFromStackScriptSchema);
 
   const [
     ss,

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript_CMR.tsx
@@ -31,7 +31,6 @@ import {
   getMineAndAccountStackScripts
 } from 'src/features/StackScripts/stackScriptUtils';
 import UserDefinedFieldsPanel from 'src/features/StackScripts/UserDefinedFieldsPanel';
-import { PasswordValidationType } from 'src/featureFlags';
 import { useStackScript } from 'src/hooks/useStackScript';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import {
@@ -64,7 +63,6 @@ interface Props {
   type: 'community' | 'account';
   disabled: boolean;
   passwordHelperText: string;
-  passwordValidation: PasswordValidationType;
   linodeId: number;
   linodeLabel?: string;
   handleRebuildError: (status: string) => void;
@@ -100,8 +98,7 @@ export const RebuildFromStackScript: React.FC<CombinedProps> = props => {
     handleRebuildError,
     onClose,
     enqueueSnackbar,
-    passwordHelperText,
-    passwordValidation
+    passwordHelperText
   } = props;
 
   const classes = useStyles();
@@ -111,14 +108,8 @@ export const RebuildFromStackScript: React.FC<CombinedProps> = props => {
    * dependent on a value from a feature flag. Remove this
    * once API password validation is stable.
    */
-  const RebuildSchema = React.useMemo(
-    () =>
-      extendValidationSchema(
-        passwordValidation ?? 'none',
-        RebuildLinodeFromStackScriptSchema
-      ),
-    [passwordValidation]
-  );
+  const RebuildSchema = () =>
+    extendValidationSchema(RebuildLinodeFromStackScriptSchema);
 
   const [confirmationText, setConfirmationText] = React.useState<string>('');
   const submitButtonDisabled = confirmationText !== linodeLabel;

--- a/packages/manager/src/utilities/validatePassword/validatePassword.test.ts
+++ b/packages/manager/src/utilities/validatePassword/validatePassword.test.ts
@@ -1,31 +1,16 @@
 import { validatePassword } from './validatePassword';
 
 describe('Password validation', () => {
-  it('should return null if validation is set to none', () => {
-    expect(validatePassword('none', 'badpassword')).toBe(null);
-  });
-
   it('should return null if no password is provided', () => {
-    expect(validatePassword('complexity', null as any)).toBe(null);
+    expect(validatePassword(null as any)).toBe(null);
   });
 
   it('should return null for a valid root password', () => {
-    expect(validatePassword('length', 'long!!secure!!pa$$word!')).toBe(null);
-    expect(
-      validatePassword('complexity', 'fdkj&34050ds2l2klfgF34*Djsd238SS')
-    ).toBe(null);
+    expect(validatePassword('fdkj&34050ds2l2klfgF34*Djsd238SS')).toBe(null);
   });
 
   it('should return an error message for invalid passwords', () => {
-    expect(validatePassword('length', 'short')).toMatch(
-      'Password must be between 6 and 128 characters'
-    );
-
-    expect(validatePassword('length', 'longbutjustletters')).toMatch(
-      'Password must contain at least 2 of the following classes: uppercase letters, lowercase letters, numbers, and punctuation'
-    );
-
-    expect(validatePassword('complexity', 'password')).toMatch(
+    expect(validatePassword('password')).toMatch(
       'Password does not meet complexity requirements'
     );
   });

--- a/packages/manager/src/utilities/validatePassword/validatePassword.ts
+++ b/packages/manager/src/utilities/validatePassword/validatePassword.ts
@@ -1,58 +1,27 @@
 import { string } from 'yup';
 import { MINIMUM_PASSWORD_STRENGTH } from 'src/constants';
-import { PasswordValidationType } from 'src/featureFlags';
 import { object } from 'yup';
 import * as zxcvbn from 'zxcvbn';
 
-const passwordLengthAndCharacterSchema = string()
-  .min(6, 'Password must be between 6 and 128 characters.')
-  .max(128, 'Password must be between 6 and 128 characters.')
-  .matches(
-    /^(((?=.*[a-z])(?=.*[A-Z]))|((?=.*[a-z])(?=.*[0-9]))|((?=.*[A-Z])(?=.*[0-9]))|((?=.*[a-z])(?=.*[!"#$%&'()*+,-.\/:;<=>?@\[\]^_`{|}~\\]))|((?=.*[A-Z])(?=.*[!"#$%&'()*+,-.\/:;<=>?@\[\]^_`{|}~\\]))|((?=.*[0-9])(?=.*[!"#$%&'()*+,-.\/:;<=>?@\[\]^_`{|}~\\])))/,
-    'Password must contain at least 2 of the following classes: uppercase letters, lowercase letters, numbers, and punctuation.'
-  );
-
-export const validatePassword = (
-  validationType: PasswordValidationType,
-  password: string
-) => {
+export const validatePassword = (password: string) => {
   // This method does not evaluate whether a password is required.
   if (!password) {
     return null;
   }
-  switch (validationType) {
-    case 'none':
-      return null;
-    case 'length':
-      try {
-        passwordLengthAndCharacterSchema.validateSync(password);
-        return null;
-      } catch (e) {
-        return e.message;
-      }
-    case 'complexity':
-      return zxcvbn(password).score >= MINIMUM_PASSWORD_STRENGTH
-        ? null
-        : 'Password does not meet complexity requirements.';
-  }
+
+  return zxcvbn(password).score >= MINIMUM_PASSWORD_STRENGTH
+    ? null
+    : 'Password does not meet complexity requirements.';
 };
 
 /**
  * Extends a Yup schema with a password validation
- * check. This check is dynamic based on the type
- * of validation requested, normally controlled through
- * a feature flag.
- *
- * Remove this method once API password validation
- * is stable.
+ * check.
  *
  * @todo: Update Yup and typings to avoid the any
  * dodge here
  */
-export const extendValidationSchema = (
-  validationType: PasswordValidationType,
-  schema: any
-) => {
+export const extendValidationSchema = (schema: any) => {
   return (schema as any).concat(
     object({
       root_pass: string()
@@ -61,11 +30,8 @@ export const extendValidationSchema = (
           name: 'root-password-strength',
           // eslint-disable-next-line object-shorthand
           test: function(value) {
-            const passwordError = validatePassword(
-              validationType ?? 'none',
-              value
-            );
-            return Boolean(validatePassword)
+            const passwordError = validatePassword(value);
+            return passwordError !== null
               ? this.createError({
                   message: passwordError,
                   path: 'root_pass'


### PR DESCRIPTION
## Description

I think our zxcvbn validation (which matches the API's) is stable enough now to remove a bunch of conditional logic that's reading a value from LD.

Please check all of our password fields (Linode creation, StackScripts, disk creation, managed credentials) to make sure we're validating as expected.