### PR TITLE
CMR: updating Reboot in action menu display logic

### DIFF
--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu_CMR.tsx
@@ -247,13 +247,11 @@ export const LinodeActionMenu: React.FC<CombinedProps> = props => {
         });
       }
 
-      if (
-        (linodeStatus === 'running' && inTableContext) ||
-        (linodeStatus === 'running' && !inTableContext && matchesSmDown)
-      ) {
+      if (matchesSmDown || inTableContext) {
         actions.unshift({
           title: 'Reboot',
           disabled:
+            linodeStatus !== 'running' ||
             !hasMadeConfigsRequest ||
             readOnly ||
             Boolean(configsError?.[0]?.reason),


### PR DESCRIPTION
## Description

Based on feedback that came out of demo prep, updating our logic to always display the Reboot action in action menu regardless of view context or Linode status. You should now see reboot in the following scenarios:

**Table view**: 
- in action menu, disabled if linode is not online

**Details view:** 
- in inline view, disabled if linode is not online.
- in action menu on smaller screens, disabled if linode is not online.

## Type of Change
- Non breaking change ('update')

