### PR TITLE
M3-4595 Detach Linode from VLAN

### DIFF
--- a/packages/manager/src/features/Vlans/DetachLinodeDialog/DetachLinodeDialog.tsx
+++ b/packages/manager/src/features/Vlans/DetachLinodeDialog/DetachLinodeDialog.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react';
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
+import Dialog from 'src/components/ConfirmationDialog';
+import useVlans from 'src/hooks/useVlans';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+
+interface Props {
+  open: boolean;
+  closeDialog: () => void;
+  vlanLabel: string;
+  vlanID: number;
+  linodeID: number;
+  linodeLabel: string;
+}
+
+type CombinedProps = Props;
+
+const DetachLinodeDialog: React.FC<CombinedProps> = props => {
+  const { disconnectVlan } = useVlans();
+
+  const [isSubmitting, setSubmitting] = React.useState<boolean>(false);
+  const [error, setError] = React.useState<string | undefined>(undefined);
+
+  const { open, closeDialog, vlanID, vlanLabel, linodeID, linodeLabel } = props;
+
+  /** reset error on open */
+  React.useEffect(() => {
+    if (open) {
+      setError(undefined);
+    }
+  }, [open]);
+
+  const handleSubmit = () => {
+    const defaultError = 'There was an issue detaching this Linode.';
+    if (!vlanID) {
+      return setError(defaultError);
+    }
+
+    setSubmitting(true);
+    setError(undefined);
+
+    disconnectVlan(vlanID, [linodeID])
+      .then(_ => {
+        setSubmitting(false);
+        closeDialog();
+      })
+      .catch(e => {
+        setSubmitting(false);
+        setError(getAPIErrorOrDefault(e, defaultError)[0].reason);
+      });
+  };
+
+  return (
+    <Dialog
+      open={open}
+      title={`Detach ${linodeLabel}?`}
+      onClose={props.closeDialog}
+      error={error}
+      actions={
+        <Actions
+          onClose={props.closeDialog}
+          isSubmitting={isSubmitting}
+          onSubmit={handleSubmit}
+        />
+      }
+    >
+      Are you sure you want to detach Linode {linodeLabel} from {vlanLabel}?
+    </Dialog>
+  );
+};
+
+interface ActionsProps {
+  onClose: () => void;
+  onSubmit: () => void;
+  isSubmitting: boolean;
+}
+
+const Actions: React.FC<ActionsProps> = props => {
+  return (
+    <ActionsPanel>
+      <Button onClick={props.onClose} buttonType="cancel">
+        Cancel
+      </Button>
+      <Button
+        onClick={props.onSubmit}
+        loading={props.isSubmitting}
+        destructive
+        buttonType="secondary"
+      >
+        Detach
+      </Button>
+    </ActionsPanel>
+  );
+};
+
+export default React.memo(DetachLinodeDialog);

--- a/packages/manager/src/features/Vlans/VlanDetail/VlanDetail.tsx
+++ b/packages/manager/src/features/Vlans/VlanDetail/VlanDetail.tsx
@@ -67,6 +67,8 @@ const VlanDetail: React.FC<CombinedProps> = props => {
       <div style={{ marginTop: 20 }}>
         <LinodesLanding
           isVLAN
+          vlanID={thisVlan.id}
+          vlanLabel={thisVlan.description}
           filterLinodesFn={filterLinodesFn}
           extendLinodesFn={extendLinodesFn}
           LandingHeader={

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu_CMR.tsx
@@ -272,7 +272,7 @@ export const LinodeActionMenu: React.FC<CombinedProps> = props => {
         });
       }
 
-      if (matchesSmDown && inTableContext) {
+      if ((matchesSmDown && inTableContext) || inVLANContext) {
         actions.unshift({
           title: linodeStatus === 'running' ? 'Power Off' : 'Power On',
           onClick: handlePowerAction,

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu_CMR.tsx
@@ -77,6 +77,7 @@ export interface Props {
   inlineLabel?: string;
   inTableContext?: boolean;
   inLandingDetailContext?: boolean;
+  inVLANContext?: boolean;
 }
 
 export type CombinedProps = Props & StateProps;
@@ -158,7 +159,8 @@ export const LinodeActionMenu: React.FC<CombinedProps> = props => {
       openDialog,
       openPowerActionDialog,
       readOnly,
-      inLandingDetailContext
+      inLandingDetailContext,
+      inVLANContext
     } = props;
 
     const readOnlyProps = readOnly
@@ -278,6 +280,13 @@ export const LinodeActionMenu: React.FC<CombinedProps> = props => {
         });
       }
 
+      if (matchesSmDown && inVLANContext) {
+        actions.unshift({
+          title: 'Detach',
+          onClick: () => openDialog('detach_vlan', linodeId, linodeLabel)
+        });
+      }
+
       if (
         (matchesSmDown && inLandingDetailContext) ||
         (matchesSmDown && inTableContext)
@@ -302,7 +311,9 @@ export const LinodeActionMenu: React.FC<CombinedProps> = props => {
     linodeStatus,
     openPowerActionDialog,
     inlineLabel,
-    inTableContext
+    inTableContext,
+    inVLANContext,
+    openDialog
   } = props;
 
   const inlineActions = [
@@ -311,12 +322,17 @@ export const LinodeActionMenu: React.FC<CombinedProps> = props => {
       className: classes.link,
       href: `/linodes/${linodeId}`
     },
-    {
-      actionText: linodeStatus === 'running' ? 'Power Off' : 'Power On',
-      disabled: !['running', 'offline'].includes(linodeStatus),
-      className: classes.powerOnOrOff,
-      onClick: handlePowerAction
-    }
+    inVLANContext
+      ? {
+          actionText: 'Detach',
+          onClick: () => openDialog('detach_vlan', linodeId, linodeLabel)
+        }
+      : {
+          actionText: linodeStatus === 'running' ? 'Power Off' : 'Power On',
+          disabled: !['running', 'offline'].includes(linodeStatus),
+          className: classes.powerOnOrOff,
+          onClick: handlePowerAction
+        }
   ];
 
   return (

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow_CMR.tsx
@@ -299,6 +299,7 @@ export const LinodeRow: React.FC<CombinedProps> = props => {
             openPowerActionDialog={openPowerActionDialog}
             noImage={!image}
             inTableContext
+            inVLANContext={isVLAN}
           />
         </div>
       </TableCell>

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -71,6 +71,7 @@ import ToggleBox from './ToggleBox';
 import EnableBackupsDialog from '../LinodesDetail/LinodeBackup/EnableBackupsDialog';
 import { ExtendedStatus, statusToPriority } from './utils';
 import getUserTimezone from 'src/utilities/getUserTimezone';
+import DetachLinodeDialog from 'src/features/Vlans/DetachLinodeDialog/DetachLinodeDialog';
 
 type FilterStatus = 'running' | 'busy' | 'offline' | 'all';
 
@@ -88,6 +89,7 @@ interface State {
   CtaDismissed: boolean;
   linodeResizeOpen: boolean;
   linodeMigrateOpen: boolean;
+  detachLinodeFromVlanDialogOpen: boolean;
   filterStatus: FilterStatus;
 }
 
@@ -101,6 +103,8 @@ type RouteProps = RouteComponentProps<Params>;
 export interface Props {
   isDashboard?: boolean;
   isVLAN?: boolean;
+  vlanID?: number;
+  vlanLabel?: string;
   filterLinodesFn?: (linode: Linode) => boolean;
   extendLinodesFn?: (linode: Linode) => any;
   LandingHeader?: React.ReactElement;
@@ -128,6 +132,7 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
     CtaDismissed: BackupsCtaDismissed.get(),
     linodeResizeOpen: false,
     linodeMigrateOpen: false,
+    detachLinodeFromVlanDialogOpen: false,
     filterStatus: 'all'
   };
 
@@ -201,6 +206,10 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
           enableBackupsDialogOpen: true
         });
         break;
+      case 'detach_vlan':
+        this.setState({
+          detachLinodeFromVlanDialogOpen: true
+        });
     }
     this.setState({
       selectedLinodeID: linodeID,
@@ -216,7 +225,8 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
       rescueDialogOpen: false,
       linodeResizeOpen: false,
       linodeMigrateOpen: false,
-      enableBackupsDialogOpen: false
+      enableBackupsDialogOpen: false,
+      detachLinodeFromVlanDialogOpen: false
     });
   };
 
@@ -717,6 +727,18 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
               linodeLabel={this.state.selectedLinodeLabel}
               handleDelete={this.props.deleteLinode}
             />
+            {this.props.isVLAN &&
+            !!this.props.vlanID &&
+            !!this.props.vlanLabel ? (
+              <DetachLinodeDialog
+                open={this.state.detachLinodeFromVlanDialogOpen}
+                closeDialog={this.closeDialogs}
+                vlanID={this.props.vlanID}
+                vlanLabel={this.props.vlanLabel}
+                linodeID={this.state.selectedLinodeID}
+                linodeLabel={this.state.selectedLinodeLabel}
+              />
+            ) : null}
           </React.Fragment>
         )}
       </React.Fragment>

--- a/packages/manager/src/features/linodes/types.ts
+++ b/packages/manager/src/features/linodes/types.ts
@@ -4,7 +4,8 @@ export type DialogType =
   | 'migrate'
   | 'resize'
   | 'rescue'
-  | 'rebuild';
+  | 'rebuild'
+  | 'detach_vlan';
 export type OpenDialog = (
   type: DialogType,
   linodeID: number,


### PR DESCRIPTION
## Description

Adds the "Detach" button to the Action Menu on the VLAN Details page:

<img width="1342" alt="Screen Shot 2020-10-15 at 3 30 21 PM" src="https://user-images.githubusercontent.com/16911484/96177152-66404400-0efb-11eb-831c-744d32b340ab.png">

Though the conditional stuff is not ideal, it's not as awful as I thought it'd be. I stuck with the existing patterns as far as opening dialogs from the Linode Action menu goes.

In a different PR, I'll do the same for the Card/Detail view.