### PR TITLE
Fix repeated updatePreferences calls in Notification Drawer

### DIFF
--- a/packages/manager/src/features/NotificationCenter/NotificationDrawer.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationDrawer.tsx
@@ -73,19 +73,11 @@ export const NotificationDrawer: React.FC<Props> = props => {
   );
 
   const handleToggleView = () => {
+    updatePreferences({
+      notification_drawer_view: chronologicalView ? 'grouped' : 'list'
+    });
     setChronologicalView(currentView => !currentView);
   };
-
-  React.useEffect(() => {
-    const newPreference = chronologicalView ? 'list' : 'grouped';
-    if (newPreference !== currentView) {
-      updatePreferences({
-        notification_drawer_view: newPreference
-      });
-    }
-
-    // eslint-disable-next-line
-  }, [chronologicalView, currentView]);
 
   const chronologicalNotificationList = React.useMemo(() => {
     return [


### PR DESCRIPTION
## Description

This fixes a bug in production (beta) where toggling the chronological display in the Notification Drawer causes repeated `updatePreferences` calls. 

This was happening in an effect, which was being called every time preferences updated (so, an infinite loop).