### PR TITLE
Replace underscores in Linode statuses in LinodeEntityDetail

### DIFF
--- a/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
+++ b/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
@@ -346,7 +346,7 @@ const Header: React.FC<HeaderProps> = props => {
               [classes.statusOther]: isOther,
               statusOther: isOther
             })}
-            label={linodeStatus.toUpperCase()}
+            label={linodeStatus.replace('_', ' ').toUpperCase()}
             component="span"
             clickable={isOther ? true : false}
             {...(isOther && { onClick: openNotificationDrawer })}


### PR DESCRIPTION
## Description
Stumbled across this while reviewing another PR -- currently, if you are on the Linode Detail page or Linode landing with grid view on, if you power off a linode, the status chip will say "SHUTTING_DOWN" while that is in progress. This PR fixes that to remove the underscore.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')
