### PR TITLE
M3-4532: Remove duplicated, unusued formatRegion() function

### DIFF
--- a/packages/manager/src/features/linodes/presentation.ts
+++ b/packages/manager/src/features/linodes/presentation.ts
@@ -1,14 +1,7 @@
 import { LinodeType } from '@linode/api-v4/lib/linodes';
-import { dcDisplayCountry, dcDisplayNames } from 'src/constants';
 
 export const titlecase = (string: string): string => {
   return `${string.substr(0, 1).toUpperCase()}${string.substr(1)}`;
-};
-
-export const formatRegion = (region: string) => {
-  const country = dcDisplayCountry[region];
-  const city = dcDisplayNames[region];
-  return `${country || ''} ${city || ''}`;
 };
 
 export const typeLabelLong = (


### PR DESCRIPTION
## Description
I went through the codebase and didn't see anywhere the `formatRegion()` function in `linodes/presentation.ts` was being used (the one in `utilities/formatRegion.ts` is the one used throughout the codebase), so this PR removes it from that file and deletes the now-unused imports in it.

## Type of Change
- Non breaking change ('update', 'change')
