### PR TITLE
Use --runInBand option when running unit tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
 
 script:
   - yarn build
-  - yarn test --runInBand
+  - yarn test --maxWorkers=4
 #- 'pkill -f selenium-standalone || :'
 #- pkill -f storybook
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
 
 script:
   - yarn build
-  - yarn test
+  - yarn test --runInBand
 #- 'pkill -f selenium-standalone || :'
 #- pkill -f storybook
 env:


### PR DESCRIPTION
Giving this a shot to see if it improves performance of unit tests on Travis.

See: 
https://jestjs.io/docs/en/troubleshooting#tests-are-extremely-slow-on-docker-andor-continuous-integration-ci-server
