### PR TITLE
M3-4614 Add: DbaaS in Redux

### DIFF
--- a/packages/api-v4/src/databases/databases.ts
+++ b/packages/api-v4/src/databases/databases.ts
@@ -66,10 +66,12 @@ export const getDatabaseConnection = (databaseID: number) =>
  * Return a paginated list of available plans/types for MySQL databases
  *
  */
-export const getMySQLTypes = () =>
+export const getMySQLTypes = (params?: any, filters?: any) =>
   Request<Page<DatabaseType>>(
     setURL(`${API_ROOT}/databases/mysql/types`),
-    setMethod('GET')
+    setMethod('GET'),
+    setParams(params),
+    setXFilter(filters)
   );
 
 /**

--- a/packages/api-v4/src/databases/index.ts
+++ b/packages/api-v4/src/databases/index.ts
@@ -1,0 +1,3 @@
+export * from './databases';
+export * from './databases.schema';
+export * from './types';

--- a/packages/api-v4/src/databases/types.ts
+++ b/packages/api-v4/src/databases/types.ts
@@ -1,5 +1,5 @@
 export interface DatabaseType {
-  id: number;
+  id: string;
   label: string;
   price: {
     hourly: number;

--- a/packages/manager/src/factories/databases.ts
+++ b/packages/manager/src/factories/databases.ts
@@ -1,0 +1,34 @@
+import { Database, DatabaseType } from '@linode/api-v4/lib/databases/types';
+import * as Factory from 'factory.ts';
+
+export const databaseFactory = Factory.Sync.makeFactory<Database>({
+  id: Factory.each(i => i),
+  label: Factory.each(i => `vlan-${i}`),
+  status: 'ready',
+  // region: 'us-east', @todo add this in when the API supports it
+  maintenance_schedule: {
+    day: 'Wednesday',
+    window: 'W0'
+  },
+  tags: ['tag1', 'tag2'],
+  availability: 'standard',
+  vcpus: 1,
+  memory: 1024,
+  disk: 25,
+  created: '2020-10-01T00:00:00',
+  updated: '2020-10-20T17:15:12'
+});
+
+export const databaseTypeFactory = Factory.Sync.makeFactory<DatabaseType>({
+  id: 'g1-mysql-ha-2',
+  label: 'MySQL HA Tier 2',
+  price: {
+    hourly: 0.4,
+    monthly: 60
+  },
+  memory: 2048,
+  disk: 40,
+  transfer: null,
+  vcpus: 2,
+  availability: 'high'
+});

--- a/packages/manager/src/factories/databases.ts
+++ b/packages/manager/src/factories/databases.ts
@@ -3,7 +3,7 @@ import * as Factory from 'factory.ts';
 
 export const databaseFactory = Factory.Sync.makeFactory<Database>({
   id: Factory.each(i => i),
-  label: Factory.each(i => `vlan-${i}`),
+  label: Factory.each(i => `database-${i}`),
   status: 'ready',
   // region: 'us-east', @todo add this in when the API supports it
   maintenance_schedule: {

--- a/packages/manager/src/hooks/useDatabaseTypes.ts
+++ b/packages/manager/src/hooks/useDatabaseTypes.ts
@@ -13,7 +13,7 @@ export interface DatabaseTypesProps {
 export const useDatabaseTypes = () => {
   const dispatch: Dispatch = useDispatch();
   const databaseTypes = useSelector(
-    (state: ApplicationState) => state.__resources.vlans
+    (state: ApplicationState) => state.__resources.databaseTypes
   );
   const requestDatabaseTypes = (params?: any, filter?: any) =>
     dispatch(getAllMySQLTypes({ params, filter }));

--- a/packages/manager/src/hooks/useDatabaseTypes.ts
+++ b/packages/manager/src/hooks/useDatabaseTypes.ts
@@ -1,0 +1,24 @@
+import { DatabaseType } from '@linode/api-v4/lib/databases/types';
+import { useDispatch, useSelector } from 'react-redux';
+import { ApplicationState } from 'src/store';
+import { State } from 'src/store/vlans/vlans.reducer';
+import { getAllMySQLTypes } from 'src/store/databases/types.requests';
+import { Dispatch } from './types';
+
+export interface DatabaseTypesProps {
+  databaseTypes: State;
+  requestDatabaseTypes: (params?: any, filter?: any) => Promise<DatabaseType[]>;
+}
+
+export const useDatabaseTypes = () => {
+  const dispatch: Dispatch = useDispatch();
+  const databaseTypes = useSelector(
+    (state: ApplicationState) => state.__resources.vlans
+  );
+  const requestDatabaseTypes = (params?: any, filter?: any) =>
+    dispatch(getAllMySQLTypes({ params, filter }));
+
+  return { databaseTypes, requestDatabaseTypes };
+};
+
+export default useDatabaseTypes;

--- a/packages/manager/src/hooks/useDatabases.ts
+++ b/packages/manager/src/hooks/useDatabases.ts
@@ -1,0 +1,51 @@
+import {
+  CreateDatabasePayload,
+  Database,
+  UpdateDatabasePayload
+} from '@linode/api-v4/lib/databases/types';
+import { useDispatch, useSelector } from 'react-redux';
+import { ApplicationState } from 'src/store';
+import { State } from 'src/store/vlans/vlans.reducer';
+import {
+  createDatabase as _create,
+  deleteDatabase as _delete,
+  getAllDatabases as _request,
+  updateDatabase as _update
+} from 'src/store/databases/databases.requests';
+import { Dispatch } from './types';
+
+export interface DatabasesProps {
+  databases: State;
+  requestDatabases: () => Promise<Database[]>;
+  createDatabase: () => Promise<Database>;
+  deleteDatabase: (databaseID: number) => Promise<{}>;
+  updateDatabase: (databaseID: number) => Promise<Database>;
+}
+
+export const useDatabases = () => {
+  const dispatch: Dispatch = useDispatch();
+  const databases = useSelector(
+    (state: ApplicationState) => state.__resources.databases
+  );
+  const requestDatabases = () => dispatch(_request({}));
+  const createDatabase = (payload: CreateDatabasePayload) =>
+    dispatch(_create(payload));
+  const deleteDatabase = (databaseID: number) =>
+    dispatch(_delete({ databaseID }));
+  const updateDatabase = (
+    databaseID: number,
+    payload: UpdateDatabasePayload
+  ) => {
+    dispatch(_update({ databaseID, ...payload }));
+  };
+
+  return {
+    databases,
+    requestDatabases,
+    createDatabase,
+    deleteDatabase,
+    updateDatabase
+  };
+};
+
+export default useDatabases;

--- a/packages/manager/src/store/databases/databases.actions.ts
+++ b/packages/manager/src/store/databases/databases.actions.ts
@@ -1,0 +1,40 @@
+import {
+  CreateDatabasePayload,
+  Database,
+  UpdateDatabasePayload
+} from '@linode/api-v4/lib/databases';
+import { APIError } from '@linode/api-v4/lib/types';
+import { GetAllData } from 'src/utilities/getAll';
+import actionCreatorFactory from 'typescript-fsa';
+
+export const actionCreator = actionCreatorFactory(`@@manager/databases`);
+
+export const getDatabasesActions = actionCreator.async<
+  {
+    params?: any;
+    filter?: any;
+  },
+  GetAllData<Database>,
+  APIError[]
+>(`get-all`);
+
+export const createDatabaseActions = actionCreator.async<
+  CreateDatabasePayload,
+  Database,
+  APIError[]
+>(`create`);
+
+export const deleteDatabaseActions = actionCreator.async<
+  { databaseID: number },
+  {},
+  APIError[]
+>(`delete`);
+
+export interface UpdateDatabaseParams extends UpdateDatabasePayload {
+  databaseID: number;
+}
+export const updateDatabaseActions = actionCreator.async<
+  UpdateDatabaseParams,
+  Database,
+  APIError[]
+>(`update`);

--- a/packages/manager/src/store/databases/databases.reducer.ts
+++ b/packages/manager/src/store/databases/databases.reducer.ts
@@ -1,0 +1,92 @@
+import { Database } from '@linode/api-v4/lib/databases';
+import { Reducer } from 'redux';
+import { isType } from 'typescript-fsa';
+import {
+  createDefaultState,
+  onCreateOrUpdate,
+  onDeleteSuccess,
+  onError,
+  onGetAllSuccess,
+  onStart,
+  setError
+} from '../store.helpers.tmp';
+import { MappedEntityState2 as MappedEntityState } from '../types';
+import {
+  createDatabaseActions,
+  deleteDatabaseActions,
+  getDatabasesActions,
+  updateDatabaseActions
+} from './databases.actions';
+
+export type State = MappedEntityState<Database>;
+
+export const defaultState: State = createDefaultState();
+
+/**
+ * Reducer
+ */
+const reducer: Reducer<State> = (state = defaultState, action) => {
+  if (isType(action, getDatabasesActions.started)) {
+    return onStart(state);
+  }
+
+  if (isType(action, getDatabasesActions.done)) {
+    const { result } = action.payload;
+    return onGetAllSuccess(result.data, state, result.results);
+  }
+
+  if (isType(action, getDatabasesActions.failed)) {
+    const { error } = action.payload;
+
+    return onError({ read: error }, state);
+  }
+
+  if (isType(action, createDatabaseActions.started)) {
+    return setError({ create: undefined }, state);
+  }
+
+  if (isType(action, createDatabaseActions.done)) {
+    const newDatabase = action.payload.result;
+    return onCreateOrUpdate(newDatabase, state);
+  }
+
+  if (isType(action, createDatabaseActions.failed)) {
+    const { error } = action.payload;
+
+    return onError({ create: error }, state);
+  }
+
+  if (isType(action, deleteDatabaseActions.started)) {
+    return setError({ delete: undefined }, state);
+  }
+
+  if (isType(action, deleteDatabaseActions.done)) {
+    const { databaseID } = action.payload.params;
+    return onDeleteSuccess(databaseID, state);
+  }
+
+  if (isType(action, deleteDatabaseActions.failed)) {
+    const { error } = action.payload;
+
+    return onError({ delete: error }, state);
+  }
+
+  if (isType(action, updateDatabaseActions.started)) {
+    return setError({ update: undefined }, state);
+  }
+
+  if (isType(action, updateDatabaseActions.done)) {
+    const { result } = action.payload;
+    return onCreateOrUpdate(result, state);
+  }
+
+  if (isType(action, updateDatabaseActions.failed)) {
+    const { error } = action.payload;
+
+    return onError({ update: error }, state);
+  }
+
+  return state;
+};
+
+export default reducer;

--- a/packages/manager/src/store/databases/databases.requests.ts
+++ b/packages/manager/src/store/databases/databases.requests.ts
@@ -1,0 +1,40 @@
+import {
+  createDatabase as _create,
+  deleteDatabase as _delete,
+  Database,
+  getDatabases,
+  updateDatabase as _update
+} from '@linode/api-v4/lib/databases';
+import { getAll } from 'src/utilities/getAll';
+import { createRequestThunk } from '../store.helpers.tmp';
+import {
+  createDatabaseActions,
+  deleteDatabaseActions,
+  getDatabasesActions,
+  updateDatabaseActions
+} from './databases.actions';
+
+const getAllDatabasesRequest = (payload?: { params?: any; filter?: any }) =>
+  getAll<Database>((passedParams, passedFilter) =>
+    getDatabases(passedParams, passedFilter)
+  )(payload?.params, payload?.filter);
+
+export const getAllDatabases = createRequestThunk(
+  getDatabasesActions,
+  getAllDatabasesRequest
+);
+
+export const createDatabase = createRequestThunk(
+  createDatabaseActions,
+  _create
+);
+
+export const deleteDatabase = createRequestThunk(
+  deleteDatabaseActions,
+  ({ databaseID }) => _delete(databaseID)
+);
+
+export const updateDatabase = createRequestThunk(
+  updateDatabaseActions,
+  ({ databaseID, ...payload }) => _update(databaseID, payload)
+);

--- a/packages/manager/src/store/databases/types.actions.ts
+++ b/packages/manager/src/store/databases/types.actions.ts
@@ -1,0 +1,15 @@
+import { DatabaseType } from '@linode/api-v4/lib/databases';
+import { APIError } from '@linode/api-v4/lib/types';
+import { GetAllData } from 'src/utilities/getAll';
+import actionCreatorFactory from 'typescript-fsa';
+
+export const actionCreator = actionCreatorFactory(`@@manager/databases/types`);
+
+export const getDatabaseTypesActions = actionCreator.async<
+  {
+    params?: any;
+    filter?: any;
+  },
+  GetAllData<DatabaseType>,
+  APIError[]
+>(`get-all`);

--- a/packages/manager/src/store/databases/types.reducer.test.ts
+++ b/packages/manager/src/store/databases/types.reducer.test.ts
@@ -1,0 +1,39 @@
+import { databaseTypeFactory } from 'src/factories/databases';
+import { getDatabaseTypesActions } from './types.actions';
+import reducer, { defaultState } from './types.reducer';
+
+describe('Database types reducer', () => {
+  it('should handle a get.start action correctly', () => {
+    const newState = reducer(defaultState, getDatabaseTypesActions.started({}));
+    expect(newState.loading).toBe(true);
+    expect(newState.lastUpdated).toEqual(0), expect(newState.error).toEqual({});
+  });
+
+  it('should handle a get.done action correctly', () => {
+    const mockTypes = databaseTypeFactory.buildList(10);
+    const newState = reducer(
+      defaultState,
+      getDatabaseTypesActions.done({
+        params: {},
+        result: {
+          data: mockTypes,
+          results: mockTypes.length
+        }
+      })
+    );
+    expect(newState.loading).toBe(false);
+    expect(newState.lastUpdated).toBeGreaterThan(0);
+    expect(newState.data).toEqual(mockTypes);
+  });
+
+  it('should handle a get.failed action correctly', () => {
+    const mockError = [{ reason: 'An error' }];
+    const newState = reducer(
+      defaultState,
+      getDatabaseTypesActions.failed({ error: mockError, params: {} })
+    );
+    expect(newState.loading).toBe(false);
+    expect(newState.error.read).toEqual(mockError);
+    expect(newState.lastUpdated).toEqual(0);
+  });
+});

--- a/packages/manager/src/store/databases/types.reducer.ts
+++ b/packages/manager/src/store/databases/types.reducer.ts
@@ -1,0 +1,44 @@
+import produce from 'immer';
+import { DatabaseType } from '@linode/api-v4/lib/databases';
+import { Reducer } from 'redux';
+import { isType } from 'typescript-fsa';
+import { RequestableDataWithEntityError } from '../types';
+import { getDatabaseTypesActions } from './types.actions';
+
+export type State = RequestableDataWithEntityError<DatabaseType[]>;
+
+export const defaultState: State = {
+  loading: false,
+  lastUpdated: 0,
+  results: 0,
+  error: {}
+};
+
+/**
+ * Reducer
+ */
+const reducer: Reducer<State> = (state = defaultState, action) => {
+  return produce(state, draft => {
+    if (isType(action, getDatabaseTypesActions.started)) {
+      draft.loading = true;
+      draft.error.read = undefined;
+    }
+
+    if (isType(action, getDatabaseTypesActions.done)) {
+      const { result } = action.payload;
+      draft.loading = false;
+      draft.lastUpdated = Date.now();
+      draft.data = result.data;
+      draft.results = result.results;
+    }
+
+    if (isType(action, getDatabaseTypesActions.failed)) {
+      const { error } = action.payload;
+
+      draft.loading = false;
+      draft.error.read = error;
+    }
+  });
+};
+
+export default reducer;

--- a/packages/manager/src/store/databases/types.requests.ts
+++ b/packages/manager/src/store/databases/types.requests.ts
@@ -1,0 +1,17 @@
+import {
+  getMySQLTypes as _get,
+  DatabaseType
+} from '@linode/api-v4/lib/databases';
+import { getAllWithArguments } from 'src/utilities/getAll';
+import { createRequestThunk } from '../store.helpers.tmp';
+import { getDatabaseTypesActions } from './types.actions';
+
+const typesRequest = (payload?: { params?: any; filter?: any }) =>
+  getAllWithArguments<DatabaseType>((passedParams, passedFilter) =>
+    _get(passedParams, passedFilter)
+  )(payload?.params, payload?.filter);
+
+export const getAllMySQLTypes = createRequestThunk(
+  getDatabaseTypesActions,
+  typesRequest
+);

--- a/packages/manager/src/store/index.ts
+++ b/packages/manager/src/store/index.ts
@@ -32,6 +32,14 @@ import clusters, {
   defaultState as defaultClustersState,
   State as ClustersState
 } from 'src/store/clusters/clusters.reducer';
+import databases, {
+  defaultState as defaultDatabasesState,
+  State as DatabasesState
+} from 'src/store/databases/databases.reducer';
+import databaseTypes, {
+  defaultState as defaultDatabaseTypesState,
+  State as DatabaseTypesState
+} from 'src/store/databases/types.reducer';
 import documentation, {
   defaultState as documentationDefaultState,
   State as DocumentationState
@@ -186,6 +194,8 @@ const __resourcesDefaultState = {
   account: defaultAccountState,
   accountManagement: defaultAccountManagementState,
   accountSettings: defaultAccountSettingsState,
+  databases: defaultDatabasesState,
+  databaseTypes: defaultDatabaseTypesState,
   domains: defaultDomainsState,
   images: defaultImagesState,
   kubernetes: defaultKubernetesState,
@@ -211,6 +221,8 @@ export interface ResourcesState {
   account: AccountState;
   accountManagement: AccountManagementState;
   accountSettings: AccountSettingsState;
+  databases: DatabasesState;
+  databaseTypes: DatabaseTypesState;
   domains: DomainsState;
   images: ImagesState;
   kubernetes: KubernetesState;
@@ -287,6 +299,8 @@ const __resources = combineReducers({
   account,
   accountManagement,
   accountSettings,
+  databases,
+  databaseTypes,
   domains,
   images,
   kubernetes,


### PR DESCRIPTION
## Description

Redux, a few factories, and hooks for databases and database types.

## Note to Reviewers

~depends on #7021 ; will rebase once that's merged.~

You can import the new hooks anywhere in a FC and make sure state is populated correctly in Redux.