### PR TITLE
Make sure we don't filter private images containing 'kube'

### DIFF
--- a/packages/manager/src/store/image/image.reducer.ts
+++ b/packages/manager/src/store/image/image.reducer.ts
@@ -39,7 +39,7 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
     const { result } = action.payload;
     const images = result.filter(thisImage => {
       // NOTE: Temporarily hide public Kubernetes images until ImageSelect redesign.
-      return !thisImage.label.match(/kube/i);
+      return thisImage.is_public || !thisImage.label.match(/kube/i);
     });
     return onGetAllSuccess(images, state, Object.keys(images).length);
   }

--- a/packages/manager/src/store/image/image.reducer.ts
+++ b/packages/manager/src/store/image/image.reducer.ts
@@ -39,7 +39,7 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
     const { result } = action.payload;
     const images = result.filter(thisImage => {
       // NOTE: Temporarily hide public Kubernetes images.
-      return thisImage.is_public ? !thisImage.label.match(/kube/i) : true;
+      return !thisImage.is_public || !thisImage.label.match(/kube/i);
     });
     return onGetAllSuccess(images, state, Object.keys(images).length);
   }

--- a/packages/manager/src/store/image/image.reducer.ts
+++ b/packages/manager/src/store/image/image.reducer.ts
@@ -38,8 +38,8 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
   if (isType(action, requestImagesActions.done)) {
     const { result } = action.payload;
     const images = result.filter(thisImage => {
-      // NOTE: Temporarily hide public Kubernetes images until ImageSelect redesign.
-      return thisImage.is_public || !thisImage.label.match(/kube/i);
+      // NOTE: Temporarily hide public Kubernetes images.
+      return thisImage.is_public ? !thisImage.label.match(/kube/i) : true;
     });
     return onGetAllSuccess(images, state, Object.keys(images).length);
   }


### PR DESCRIPTION
## Description

The filter I added a year ago to prevent users from deploying from public LKE images was incomplete, and as a result if you have a private image containing "kube" it isn't available. This updates the filter.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

