### PR TITLE
Rename prop for RemoveVlanDialog for consistency

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/VLANPanel/LinodeVLANs.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/VLANPanel/LinodeVLANs.tsx
@@ -253,7 +253,7 @@ export const LinodeVLANs: React.FC<CombinedProps> = props => {
         selectedVlanLabel={selectedVlanLabel}
         linodeId={linodeId}
         closeDialog={() => toggleRemoveModal(false)}
-        resetInterfaces={requestInterfaces}
+        refreshInterfaces={requestInterfaces}
       />
       <AttachVlanDrawer
         open={drawerOpen}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/VLANPanel/RemoveVlanDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/VLANPanel/RemoveVlanDialog.tsx
@@ -14,7 +14,7 @@ interface Props {
   selectedVlanLabel: string;
   linodeId: number;
   removeVlan: (vlanID: number, linodes: number[]) => Promise<VLAN>;
-  resetInterfaces: () => void;
+  refreshInterfaces: () => void;
 }
 
 type CombinedProps = Props;
@@ -30,7 +30,7 @@ const RemoveVlanDialog: React.FC<CombinedProps> = props => {
     selectedVlanID,
     selectedVlanLabel: label,
     linodeId,
-    resetInterfaces
+    refreshInterfaces
   } = props;
 
   const dispatch = useDispatch();
@@ -56,7 +56,7 @@ const RemoveVlanDialog: React.FC<CombinedProps> = props => {
         setSubmitting(false);
         closeDialog();
         dispatch(getLinodeConfigs({ linodeId })); // Re-request Linode Configs so that the page refreshes.
-        resetInterfaces();
+        refreshInterfaces();
       })
       .catch(e => {
         setSubmitting(false);


### PR DESCRIPTION
## Description
Fixes small oversight in https://github.com/linode/manager/pull/6981 -- renames `resetInterfaces` to `refreshInterfaces` in `RemoveVlanDialog.tsx` to be consistent with prop name for `AttachVlanDrawer.tsx`.

## Type of Change
- Non breaking change ('update', 'change')
