### PR TITLE
[VLAN] Add ID label to detail page

### DIFF
--- a/packages/manager/src/features/Vlans/VlanDetail/VlanEntityDetail.tsx
+++ b/packages/manager/src/features/Vlans/VlanDetail/VlanEntityDetail.tsx
@@ -241,7 +241,7 @@ export const Footer: React.FC<FooterProps> = React.memo(props => {
               [classes.listItemLast]: true
             })}
           >
-            {id}
+            ID {id}
           </Typography>
           <Hidden xsDown>
             <Typography className={classes.created}>


### PR DESCRIPTION
Forgot to include the ID label on the details page