### PR TITLE
M3-4613 Add: dbaas landing and row

### DIFF
--- a/packages/api-v4/src/databases/databases.schema.ts
+++ b/packages/api-v4/src/databases/databases.schema.ts
@@ -1,5 +1,7 @@
 import { array, mixed, object, string } from 'yup';
 
+const LABEL_MESSAGE = 'Label must be between 3 and 32 characters';
+
 export const maintenanceScheduleSchema = object({
   day: mixed()
     .required('Day is required')
@@ -28,13 +30,15 @@ export const maintenanceScheduleSchema = object({
       'W20',
       'W22'
     ])
-});
+})
+  .notRequired()
+  .default(undefined);
 
 export const createDatabaseSchema = object({
   label: string()
     .notRequired()
-    .min(3, 'Label must be between 3 and 32 characters')
-    .max(32, 'Label must be between 3 and 32 characters'),
+    .min(3, LABEL_MESSAGE)
+    .max(32, LABEL_MESSAGE),
   region: string().required('Region is required'),
   type: string().required('Type is required'),
   root_password: string().required('Root password is required'),
@@ -45,9 +49,11 @@ export const createDatabaseSchema = object({
 export const updateDatabaseSchema = object({
   label: string()
     .notRequired()
-    .min(3, 'Label must be between 3 and 32 characters')
-    .max(32, 'Label must be between 3 and 32 characters'),
-  tags: array().of(string()),
+    .min(3, LABEL_MESSAGE)
+    .max(32, LABEL_MESSAGE),
+  tags: array()
+    .of(string())
+    .notRequired(),
   maintenance_schedule: maintenanceScheduleSchema.notRequired()
 });
 

--- a/packages/manager/src/components/TagCell/TagDrawer.tsx
+++ b/packages/manager/src/components/TagCell/TagDrawer.tsx
@@ -13,6 +13,8 @@ const useStyles = makeStyles((theme: Theme) => ({
   tag: {}
 }));
 
+export type OpenTagDrawer = (id: number, label: string, tags: string[]) => void;
+
 interface Props {
   entityLabel: string;
   tags: string[];
@@ -26,7 +28,7 @@ export interface TagDrawerProps {
   label: string;
   tags: string[];
   open: boolean;
-  linodeID: number;
+  entityID: number;
 }
 
 export type CombinedProps = Props;

--- a/packages/manager/src/factories/index.ts
+++ b/packages/manager/src/factories/index.ts
@@ -2,6 +2,7 @@ export * from './account';
 export * from './accountSettings';
 export * from './billing';
 export * from './config';
+export * from './databases';
 export * from './disk';
 export * from './domain';
 export * from './events';

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseEntityDetail.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseEntityDetail.tsx
@@ -202,6 +202,7 @@ const Header: React.FC<HeaderProps> = props => {
               databaseID={1234}
               databaseLabel=""
               inlineLabel={matchesMdDown ? undefined : 'More Actions'}
+              triggerDeleteDatabase={() => null}
             />
           </div>
           <Hidden smDown>

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseActionMenu.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseActionMenu.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
-import { makeStyles, Theme } from 'src/components/core/styles';
 import ActionMenu, { Action } from 'src/components/ActionMenu_CMR';
+import {
+  makeStyles,
+  Theme,
+  useMediaQuery,
+  useTheme
+} from 'src/components/core/styles';
+import InlineAction from 'src/components/InlineMenuAction';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -54,7 +60,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 export interface ActionHandlers {
-  triggerDeleteDatabase?: (databaseID: number, databaseLabel: string) => void;
+  triggerDeleteDatabase: (databaseID: number, databaseLabel: string) => void;
   [index: string]: any;
 }
 
@@ -69,19 +75,22 @@ type CombinedProps = Props;
 const DatabaseActionMenu: React.FC<CombinedProps> = props => {
   const classes = useStyles();
   const history = useHistory();
+  const theme = useTheme<Theme>();
 
-  const {
-    databaseID,
-    databaseLabel,
-    inlineLabel,
-    triggerDeleteDatabase
-  } = props;
+  const { databaseID, databaseLabel, triggerDeleteDatabase } = props;
+  const matchesSmDown = useMediaQuery(theme.breakpoints.down('sm'));
 
   const actions: Action[] = [
     {
       title: 'Details',
       onClick: () => {
         history.push({ pathname: `/databases/${databaseID}` });
+      }
+    },
+    {
+      title: 'Resize',
+      onClick: () => {
+        alert('Resize not yet implemented');
       }
     },
     {
@@ -96,11 +105,22 @@ const DatabaseActionMenu: React.FC<CombinedProps> = props => {
 
   return (
     <div className={classes.root}>
-      <ActionMenu
-        createActions={() => actions}
-        inlineLabel={inlineLabel}
-        ariaLabel={`Action menu for Database ${props.databaseLabel}`}
-      />
+      {!matchesSmDown &&
+        actions.map(thisAction => {
+          return (
+            <InlineAction
+              key={thisAction.title}
+              actionText={thisAction.title}
+              onClick={thisAction.onClick}
+            />
+          );
+        })}
+      {matchesSmDown && (
+        <ActionMenu
+          createActions={() => actions}
+          ariaLabel={`Action menu for Database ${props.databaseLabel}`}
+        />
+      )}
     </div>
   );
 };

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
@@ -1,73 +1,271 @@
+import { Database, DatabaseStatus } from '@linode/api-v4/lib/databases/types';
+import Close from '@material-ui/icons/Close';
+import * as classNames from 'classnames';
+import { groupBy, prop } from 'ramda';
 import * as React from 'react';
-import { RouteComponentProps } from 'react-router-dom';
-import { compose } from 'recompose';
+import Chip from 'src/components/core/Chip';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import DeletionDialog from 'src/components/DeletionDialog';
 import EntityTable from 'src/components/EntityTable/EntityTable_CMR';
+import ErrorState from 'src/components/ErrorState';
+import IconTextLink from 'src/components/IconTextLink';
 import LandingHeader from 'src/components/LandingHeader';
+import TagDrawer, {
+  OpenTagDrawer,
+  TagDrawerProps
+} from 'src/components/TagCell/TagDrawer';
+import useDatabases from 'src/hooks/useDatabases';
+import { useDialog } from 'src/hooks/useDialog';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import { ActionHandlers as DatabaseHandlers } from './DatabaseActionMenu';
 import DatabaseRow from './DatabaseRow';
-// import { ActionHandlers as DatabaseHandlers } from './DatabaseActionMenu';
 
-type CombinedProps = RouteComponentProps<{}>;
-
-const DatabaseLanding: React.FC<CombinedProps> = props => {
-  const headers = [
-    {
-      label: 'Label',
-      dataColumn: 'description',
-      sortable: true,
-      widthPercent: 15
-    },
-    {
-      label: 'Status',
-      dataColumn: 'status',
-      sortable: true,
-      widthPercent: 10
-    },
-    {
-      label: 'Region',
-      dataColumn: 'region',
-      sortable: true,
-      widthPercent: 10
-    },
-    {
-      label: 'Hostname',
-      dataColumn: 'hostname',
-      sortable: true,
-      widthPercent: 15
-    },
-    {
-      label: 'Port',
-      dataColumn: 'port',
-      sortable: true,
-      widthPercent: 5
-    },
-    {
-      label: 'Last Backup',
-      dataColumn: 'backup',
-      sortable: true,
-      widthPercent: 10
-    },
-    {
-      label: 'Tags',
-      dataColumn: 'tags',
-      sortable: false,
-      widthPercent: 15
-    },
-    {
-      label: 'Action Menu',
-      visuallyHidden: true,
-      dataColumn: '',
-      sortable: false,
-      widthPercent: 5
+const useStyles = makeStyles((theme: Theme) => ({
+  chip: {
+    ...theme.applyStatusPillStyles,
+    paddingTop: '0px !important',
+    paddingBottom: '0px !important',
+    '&:hover, &:focus, &:active': {
+      backgroundColor: theme.bg.chipActive
     }
-  ];
+  },
+  chipActive: {
+    backgroundColor: theme.bg.chipActive
+  },
+  chipRunning: {
+    '&:before': {
+      backgroundColor: theme.cmrIconColors.iGreen
+    }
+  },
+  chipError: {
+    '&:before': {
+      backgroundColor: theme.cmrIconColors.iRed
+    }
+  },
+  chipOffline: {
+    '&:before': {
+      backgroundColor: theme.cmrIconColors.iGrey
+    }
+  },
+  chipPending: {
+    '&:before': {
+      backgroundColor: theme.cmrIconColors.iOrange
+    }
+  },
+  clearFilters: {
+    margin: '1px 0 0 0',
+    padding: 0,
+    '&:hover': {
+      '& svg': {
+        color: `${theme.palette.primary.main} !important`
+      }
+    }
+  }
+}));
+
+const headers = [
+  {
+    label: 'Label',
+    dataColumn: 'label',
+    sortable: true,
+    widthPercent: 15
+  },
+  {
+    label: 'Status',
+    dataColumn: 'status',
+    sortable: true,
+    widthPercent: 10
+  },
+  {
+    label: 'Region',
+    dataColumn: 'region',
+    sortable: true,
+    widthPercent: 10
+  },
+  {
+    label: 'Hostname',
+    dataColumn: 'hostname',
+    sortable: true,
+    widthPercent: 15,
+    hideOnMobile: true
+  },
+  {
+    label: 'Port',
+    dataColumn: 'port',
+    sortable: true,
+    widthPercent: 5,
+    hideOnMobile: true
+  },
+  {
+    label: 'Last Backup',
+    dataColumn: 'backup',
+    sortable: true,
+    widthPercent: 10,
+    hideOnMobile: true
+  },
+  {
+    label: 'Tags',
+    dataColumn: 'tags',
+    sortable: false,
+    widthPercent: 15,
+    hideOnMobile: true
+  },
+  {
+    label: 'Action Menu',
+    visuallyHidden: true,
+    dataColumn: '',
+    sortable: false,
+    widthPercent: 5
+  }
+];
+
+interface CombinedHandlers extends DatabaseHandlers {
+  openTagDrawer: OpenTagDrawer;
+}
+
+type FilterStatus = DatabaseStatus | 'all';
+
+const DatabaseLanding: React.FC<{}> = _ => {
+  const classes = useStyles();
+  const { databases, deleteDatabase, updateDatabase } = useDatabases();
+  const { dialog, closeDialog, openDialog, submitDialog } = useDialog(
+    deleteDatabase
+  );
+
+  const databaseData = Object.values(databases.itemsById ?? {});
+
+  const [filterStatus, setFilterStatus] = React.useState<FilterStatus>('all');
+
+  const [tagDrawer, setTagDrawer] = React.useState<TagDrawerProps>({
+    open: false,
+    tags: [],
+    label: '',
+    entityID: 0
+  });
+
+  const openTagDrawer: OpenTagDrawer = (
+    id: number,
+    label: string,
+    tags: string[]
+  ) =>
+    setTagDrawer({
+      open: true,
+      tags,
+      label,
+      entityID: id
+    });
+
+  const closeTagDrawer = () => {
+    setTagDrawer({ ...tagDrawer, open: false });
+  };
+
+  const addTag = (databaseID: number, newTag: string) => {
+    const _tags = [...tagDrawer.tags, newTag];
+    return updateDatabase(databaseID, { tags: _tags }).then(_ => {
+      setTagDrawer({ ...tagDrawer, tags: _tags });
+    });
+  };
+
+  const deleteTag = (databaseID: number, tagToDelete: string) => {
+    const _tags = tagDrawer.tags.filter(thisTag => thisTag !== tagToDelete);
+    return updateDatabase(databaseID, { tags: _tags }).then(_ => {
+      setTagDrawer({ ...tagDrawer, tags: _tags });
+    });
+  };
+
+  const counts = getChipCounts(databaseData);
+  const filteredData =
+    filterStatus === 'all' ? databaseData : counts[filterStatus];
+
+  const handlers: CombinedHandlers = {
+    triggerDeleteDatabase: openDialog,
+    openTagDrawer
+  };
 
   const _DatabaseRow = {
     Component: DatabaseRow,
-    data: [],
-    loading: false,
-    lastUpdated: 1234,
-    error: undefined
+    handlers,
+    data: filteredData,
+    loading: databases.loading,
+    lastUpdated: databases.lastUpdated,
+    error: databases.error.read
   };
+
+  if (databases.error.read) {
+    const message = getAPIErrorOrDefault(
+      databases.error.read,
+      'Error loading your databases.'
+    )[0].reason;
+    return <ErrorState errorText={message} />;
+  }
+
+  const chipProps = {
+    component: 'button',
+    clickable: true
+  };
+
+  const { ready, error, initializing, unknown } = counts;
+  const chips = (
+    <>
+      {ready.length !== 0 && (
+        <Chip
+          className={classNames({
+            [classes.chip]: true,
+            [classes.chipRunning]: true,
+            [classes.chipActive]: filterStatus === 'ready'
+          })}
+          label={`${ready.length} READY`}
+          onClick={() => setFilterStatus('ready')}
+          {...chipProps}
+        />
+      )}
+      {unknown.length !== 0 && (
+        <Chip
+          className={classNames({
+            [classes.chip]: true,
+            [classes.chipOffline]: true,
+            [classes.chipActive]: filterStatus === 'unknown'
+          })}
+          onClick={() => setFilterStatus('unknown')}
+          label={`${unknown.length} UNKNOWN`}
+          {...chipProps}
+        />
+      )}
+      {error.length !== 0 && (
+        <Chip
+          className={classNames({
+            [classes.chip]: true,
+            [classes.chipError]: true,
+            [classes.chipActive]: filterStatus === 'error'
+          })}
+          onClick={() => setFilterStatus('error')}
+          label={`${error.length} ERROR`}
+          {...chipProps}
+        />
+      )}
+      {initializing.length !== 0 && (
+        <Chip
+          className={classNames({
+            [classes.chip]: true,
+            [classes.chipPending]: true,
+            [classes.chipActive]: filterStatus === 'initializing'
+          })}
+          onClick={() => setFilterStatus('initializing')}
+          label={`${initializing.length} INITIALIZING`}
+          {...chipProps}
+        />
+      )}
+      {filterStatus !== 'all' && (
+        <IconTextLink
+          SideIcon={Close}
+          text="CLEAR FILTERS"
+          title="CLEAR FILTERS"
+          className={`${classes.clearFilters}`}
+          onClick={() => setFilterStatus('all')}
+        />
+      )}
+    </>
+  );
 
   return (
     <React.Fragment>
@@ -76,7 +274,7 @@ const DatabaseLanding: React.FC<CombinedProps> = props => {
         entity="Database"
         iconType="linode"
         docsLink="http://google.com"
-        headerOnly
+        body={chips}
       />
       <EntityTable
         entity="databases"
@@ -85,15 +283,41 @@ const DatabaseLanding: React.FC<CombinedProps> = props => {
         headers={headers}
         initialOrder={{ order: 'asc', orderBy: 'label' }}
       />
-      {/* <DatabaseDialog
-        open={modalOpen}
-        deleteVlan={deleteDatabase}
-        selectedVlanID={selectedDatabaseID}
-        selectedVlanLabel={selectedDatabaseLabel}
-        closeDialog={() => toggleModal(false)}
-      /> */}
+      <DeletionDialog
+        label={dialog.entityLabel ?? ''}
+        error={dialog.error}
+        open={dialog.isOpen}
+        loading={dialog.isLoading}
+        onClose={closeDialog}
+        onDelete={() => submitDialog(dialog.entityID)}
+      />
+      <TagDrawer
+        entityLabel={tagDrawer.label}
+        open={tagDrawer.open}
+        tags={tagDrawer.tags}
+        addTag={(newTag: string) => addTag(tagDrawer.entityID, newTag)}
+        deleteTag={(tag: string) => deleteTag(tagDrawer.entityID, tag)}
+        onClose={closeTagDrawer}
+      />
     </React.Fragment>
   );
 };
 
-export default compose<CombinedProps, {}>(React.memo)(DatabaseLanding);
+interface ChipCounts {
+  ready: Database[];
+  error: Database[];
+  unknown: Database[];
+  initializing: Database[];
+}
+
+export const getChipCounts = (databases: Database[]): ChipCounts => {
+  const groups = groupBy(prop('status'), databases);
+  return {
+    ready: groups.ready ?? [],
+    error: groups.error ?? [],
+    unknown: groups.unknown ?? [],
+    initializing: groups.initializing ?? []
+  };
+};
+
+export default React.memo(DatabaseLanding);

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
@@ -76,38 +76,39 @@ const headers = [
     sortable: true,
     widthPercent: 10
   },
-  {
-    label: 'Region',
-    dataColumn: 'region',
-    sortable: true,
-    widthPercent: 10
-  },
-  {
-    label: 'Hostname',
-    dataColumn: 'hostname',
-    sortable: true,
-    widthPercent: 15,
-    hideOnMobile: true
-  },
-  {
-    label: 'Port',
-    dataColumn: 'port',
-    sortable: true,
-    widthPercent: 5,
-    hideOnMobile: true
-  },
-  {
-    label: 'Last Backup',
-    dataColumn: 'backup',
-    sortable: true,
-    widthPercent: 10,
-    hideOnMobile: true
-  },
+  // @todo Pending API work
+  // {
+  //   label: 'Region',
+  //   dataColumn: 'region',
+  //   sortable: true,
+  //   widthPercent: 10
+  // },
+  // {
+  //   label: 'Hostname',
+  //   dataColumn: 'hostname',
+  //   sortable: true,
+  //   widthPercent: 15,
+  //   hideOnMobile: true
+  // },
+  // {
+  //   label: 'Port',
+  //   dataColumn: 'port',
+  //   sortable: true,
+  //   widthPercent: 5,
+  //   hideOnMobile: true
+  // },
+  // {
+  //   label: 'Last Backup',
+  //   dataColumn: 'backup',
+  //   sortable: true,
+  //   widthPercent: 10,
+  //   hideOnMobile: true
+  // },
   {
     label: 'Tags',
     dataColumn: 'tags',
     sortable: false,
-    widthPercent: 15,
+    widthPercent: 30,
     hideOnMobile: true
   },
   {

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseRow.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseRow.tsx
@@ -34,7 +34,6 @@ const getDisplayStatus = (status: DatabaseStatus) => {
 };
 
 export const DatabaseRow: React.FC<Props> = props => {
-  // const classes = useStyles();
   const { id, label, status, tags, openTagDrawer, ...actionHandlers } = props;
   const _tags = tags ?? [];
 
@@ -82,11 +81,11 @@ export const DatabaseRow: React.FC<Props> = props => {
         <StatusIcon status={displayStatus} />
         {capitalize(status)}
       </TableCell>
-      <TableCell>Newark, NJ</TableCell>
-      <Hidden smDown>
-        <TableCell>Hostname</TableCell>
+      <Hidden xsDown>
+        {/** Pending API work */}
+        {/* <TableCell>Hostname</TableCell>
         <TableCell>Port</TableCell>
-        <TableCell>Last Backup</TableCell>
+        <TableCell>Last Backup</TableCell> */}
         <TagCell
           tags={_tags}
           width={250}

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseRow.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseRow.tsx
@@ -1,37 +1,107 @@
-// import { APIError } from '@linode/api-v4/lib/types';
+import { DatabaseStatus } from '@linode/api-v4/lib/databases/types';
+import { useSnackbar } from 'notistack';
 import * as React from 'react';
-// import { Link } from 'react-router-dom';
-import { compose } from 'recompose';
+import { Link } from 'react-router-dom';
+import Hidden from 'src/components/core/Hidden';
+import StatusIcon from 'src/components/StatusIcon';
 import TableCell from 'src/components/TableCell/TableCell_CMR';
 import TableRow from 'src/components/TableRow/TableRow_CMR';
-// import ActionMenu, { ActionHandlers } from './DatabaseActionMenu';
+import TagCell from 'src/components/TagCell';
+import useDatabases from 'src/hooks/useDatabases';
+import { capitalize } from 'src/utilities/capitalize';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import ActionMenu, { ActionHandlers } from './DatabaseActionMenu';
 
-export const DatabaseRow: React.FC = () => {
+interface Props extends ActionHandlers {
+  id: number;
+  label: string;
+  status: DatabaseStatus;
+  region?: string; // @todo should be required when the API adds it
+  tags?: string[];
+}
+
+const getDisplayStatus = (status: DatabaseStatus) => {
+  switch (status) {
+    case 'ready':
+      return 'active';
+    case 'error':
+      return 'error';
+    case 'unknown':
+      return 'inactive';
+    case 'initializing':
+      return 'other';
+  }
+};
+
+export const DatabaseRow: React.FC<Props> = props => {
   // const classes = useStyles();
+  const { id, label, status, tags, openTagDrawer, ...actionHandlers } = props;
+  const _tags = tags ?? [];
 
+  const { enqueueSnackbar } = useSnackbar();
+  const { updateDatabase } = useDatabases();
+
+  const displayStatus = getDisplayStatus(status);
+
+  const addTag = React.useCallback(
+    (tag: string) => {
+      const newTags = [..._tags, tag];
+      updateDatabase(id, { tags: newTags }).catch(e =>
+        enqueueSnackbar(getAPIErrorOrDefault(e, 'Error adding tag')[0].reason, {
+          variant: 'error'
+        })
+      );
+    },
+    [_tags, id, updateDatabase, enqueueSnackbar]
+  );
+
+  const deleteTag = React.useCallback(
+    (tag: string) => {
+      const newTags = _tags.filter(thisTag => thisTag !== tag);
+      updateDatabase(id, { tags: newTags }).catch(e =>
+        enqueueSnackbar(
+          getAPIErrorOrDefault(e, 'Error deleting tag')[0].reason,
+          {
+            variant: 'error'
+          }
+        )
+      );
+    },
+    [_tags, id, updateDatabase, enqueueSnackbar]
+  );
   return (
     <TableRow
-    // key={`database-row-${id}`}
-    // data-testid={`database-row-${id}`}
-    // ariaLabel={`Database ${description}`}
+      key={`database-row-${id}`}
+      data-testid={`database-row-${id}`}
+      ariaLabel={`Database ${label}`}
     >
-      <TableCell>Label</TableCell>
-      <TableCell>Status</TableCell>
-      <TableCell>Region</TableCell>
-      <TableCell>Hostname</TableCell>
-      <TableCell>Port</TableCell>
-      <TableCell>Last Backup</TableCell>
-      <TableCell>Tags</TableCell>
+      <TableCell>
+        <Link to={`/databases/${id}`}>{label}</Link>
+      </TableCell>
+      <TableCell>
+        <StatusIcon status={displayStatus} />
+        {capitalize(status)}
+      </TableCell>
+      <TableCell>Newark, NJ</TableCell>
+      <Hidden smDown>
+        <TableCell>Hostname</TableCell>
+        <TableCell>Port</TableCell>
+        <TableCell>Last Backup</TableCell>
+        <TagCell
+          tags={_tags}
+          width={250}
+          addTag={addTag}
+          deleteTag={deleteTag}
+          listAllTags={() => openTagDrawer(id, label, _tags)}
+          inTableContext
+        />
+      </Hidden>
 
       <TableCell>
-        {/* <ActionMenu
-          databaseID={id}
-          databaseLabel={description}
-          {...actionHandlers}
-        /> */}
+        <ActionMenu databaseID={id} databaseLabel={label} {...actionHandlers} />
       </TableCell>
     </TableRow>
   );
 };
 
-export default compose(React.memo)(DatabaseRow);
+export default React.memo(DatabaseRow);

--- a/packages/manager/src/features/Databases/index.tsx
+++ b/packages/manager/src/features/Databases/index.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Redirect, Route, RouteComponentProps, Switch } from 'react-router-dom';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import SuspenseLoader from 'src/components/SuspenseLoader';
+import useReduxLoad from 'src/hooks/useReduxLoad';
 
 const DatabaseLanding = React.lazy(() => import('./DatabaseLanding'));
 const DatabaseDetail = React.lazy(() => import('./DatabaseDetail'));
@@ -14,6 +15,8 @@ const Database: React.FC<CombinedProps> = props => {
   const {
     match: { path }
   } = props;
+
+  useReduxLoad(['databases']);
 
   return (
     <React.Suspense fallback={<SuspenseLoader />}>

--- a/packages/manager/src/features/linodes/LinodesLanding/CardView.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/CardView.tsx
@@ -69,7 +69,7 @@ const CardView: React.FC<CombinedProps> = props => {
     open: false,
     tags: [],
     label: '',
-    linodeID: 0
+    entityID: 0
   });
 
   const closeTagDrawer = () => {
@@ -81,13 +81,13 @@ const CardView: React.FC<CombinedProps> = props => {
       open: true,
       label: linodeLabel,
       tags,
-      linodeID
+      entityID: linodeID
     });
   };
 
-  const addTag = (linodeID: number, newTag: string) => {
+  const addTag = (linodeId: number, newTag: string) => {
     const _tags = [...tagDrawer.tags, newTag];
-    return updateLinode({ linodeId: linodeID, tags: _tags }).then(_ => {
+    return updateLinode({ linodeId, tags: _tags }).then(_ => {
       setTagDrawer({ ...tagDrawer, tags: _tags });
     });
   };
@@ -182,8 +182,8 @@ const CardView: React.FC<CombinedProps> = props => {
         entityLabel={tagDrawer.label}
         open={tagDrawer.open}
         tags={tagDrawer.tags}
-        addTag={(newTag: string) => addTag(tagDrawer.linodeID, newTag)}
-        deleteTag={(tag: string) => deleteTag(tagDrawer.linodeID, tag)}
+        addTag={(newTag: string) => addTag(tagDrawer.entityID, newTag)}
+        deleteTag={(tag: string) => deleteTag(tagDrawer.entityID, tag)}
         onClose={closeTagDrawer}
       />
     </React.Fragment>

--- a/packages/manager/src/features/linodes/LinodesLanding/ListView.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/ListView.tsx
@@ -36,7 +36,7 @@ export const ListView: React.FC<CombinedProps> = props => {
     open: false,
     tags: [],
     label: '',
-    linodeID: 0
+    entityID: 0
   });
 
   const { updateLinode } = useLinodes();
@@ -57,7 +57,7 @@ export const ListView: React.FC<CombinedProps> = props => {
       open: true,
       label: linodeLabel,
       tags,
-      linodeID
+      entityID: linodeID
     });
   };
 
@@ -128,8 +128,8 @@ export const ListView: React.FC<CombinedProps> = props => {
         entityLabel={tagDrawer.label}
         open={tagDrawer.open}
         tags={tagDrawer.tags}
-        addTag={(newTag: string) => addTag(tagDrawer.linodeID, newTag)}
-        deleteTag={(tag: string) => deleteTag(tagDrawer.linodeID, tag)}
+        addTag={(newTag: string) => addTag(tagDrawer.entityID, newTag)}
+        deleteTag={(tag: string) => deleteTag(tagDrawer.entityID, tag)}
         onClose={closeTagDrawer}
       />
     </>

--- a/packages/manager/src/hooks/useDatabases.ts
+++ b/packages/manager/src/hooks/useDatabases.ts
@@ -32,12 +32,8 @@ export const useDatabases = () => {
     dispatch(_create(payload));
   const deleteDatabase = (databaseID: number) =>
     dispatch(_delete({ databaseID }));
-  const updateDatabase = (
-    databaseID: number,
-    payload: UpdateDatabasePayload
-  ) => {
+  const updateDatabase = (databaseID: number, payload: UpdateDatabasePayload) =>
     dispatch(_update({ databaseID, ...payload }));
-  };
 
   return {
     databases,

--- a/packages/manager/src/hooks/useReduxLoad.ts
+++ b/packages/manager/src/hooks/useReduxLoad.ts
@@ -23,6 +23,7 @@ import { requestRegions } from 'src/store/regions/regions.actions';
 import { getAllVolumes } from 'src/store/volume/volume.requests';
 import { requestClusters } from 'src/store/clusters/clusters.actions';
 import { getAllVlans } from 'src/store/vlans/vlans.requests';
+import { getAllDatabases } from 'src/store/databases/databases.requests';
 
 interface UseReduxPreload {
   _loading: boolean;
@@ -33,6 +34,7 @@ export type ReduxEntity =
   | 'volumes'
   | 'account'
   | 'accountSettings'
+  | 'databases'
   | 'domains'
   | 'images'
   | 'kubernetes'
@@ -55,6 +57,7 @@ const requestMap: RequestMap = {
   volumes: getAllVolumes,
   account: requestAccount,
   accountSettings: requestAccountSettings,
+  databases: () => getAllDatabases({}),
   domains: requestDomains,
   nodeBalancers: getAllNodeBalancers,
   images: requestImages,

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -2,6 +2,7 @@ import { rest, RequestHandler } from 'msw';
 
 import {
   accountFactory,
+  databaseFactory,
   domainFactory,
   domainRecordFactory,
   imageFactory,
@@ -73,7 +74,7 @@ export const handlers = [
     const images = [...privateImages, ...publicImages];
     return res(ctx.json(makeResourcePage(images)));
   }),
-  rest.get('*/instances', async (req, res, ctx) => {
+  rest.get('*/linode/instances', async (req, res, ctx) => {
     const onlineLinodes = linodeFactory.buildList(3, {
       backups: { enabled: false }
     });
@@ -329,6 +330,14 @@ export const handlers = [
   }),
   rest.post('*/networking/vlans', (req, res, ctx) => {
     return res(ctx.json({}));
+  }),
+  rest.get('*/databases/mysql/instances', (req, res, ctx) => {
+    const online = databaseFactory.build({ status: 'ready' });
+    const initializing = databaseFactory.build({ status: 'initializing' });
+    const error = databaseFactory.build({ status: 'error' });
+    const unknown = databaseFactory.build({ status: 'unknown' });
+    const databases = [online, initializing, error, unknown];
+    return res(ctx.json(makeResourcePage(databases)));
   })
 ];
 
@@ -338,7 +347,7 @@ export const mockDataHandlers: Record<
   (count: number) => RequestHandler
 > = {
   linode: count =>
-    rest.get('*/instances', async (req, res, ctx) => {
+    rest.get('*/linode/instances', async (req, res, ctx) => {
       const linodes = linodeFactory.buildList(count);
       return res(ctx.json(makeResourcePage(linodes)));
     })


### PR DESCRIPTION
## Description

Landing page for DbaaS. Thoughts:

1. The chips add a lot of boilerplate; I want to work out a way to abstract them so we don't have to go through all this for every landing page. BUT Chris has expressed that he doesn't like them, so I'm not in a hurry to put in that work until this is demoed.
2. Known bug: blocked requests to /databases/ will result in an infinite request loop. Separate PR will fix this (it also occurs on DB detail and VLANs).
3. Known issue: the delete modal should be type-to-confirm. I want to make that change in DeletionDialog.tsx, which is too large for here. I'll do a follow on.


## Note to Reviewers

Mocks are set up if you'd like to use them.