### PR TITLE
Fix: Don't filter out VLANs without an IP address

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/VLANPanel/LinodeVLANs.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/VLANPanel/LinodeVLANs.tsx
@@ -135,9 +135,7 @@ export const LinodeVLANs: React.FC<CombinedProps> = props => {
     getInterfaces(linodeId)
       .then(interfaces => {
         const privateInterfaces = interfaces.data.filter(
-          individualInterface =>
-            individualInterface.type !== 'default' &&
-            individualInterface.ip_address !== ''
+          individualInterface => individualInterface.type !== 'default'
         );
 
         setInterfaceData(privateInterfaces);

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/VLANPanel/VlanTableRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/VLANPanel/VlanTableRow.tsx
@@ -96,7 +96,9 @@ export const VlanTableRow: React.FC<CombinedProps> = props => {
           </Grid>
         </Grid>
       </TableCell>
-      <TableCell data-qa-vlan-address>{ipAddress}</TableCell>
+      <TableCell data-qa-vlan-address>
+        {ipAddress !== '' ? ipAddress : 'None'}
+      </TableCell>
       <TableCell data-qa-vlan-interface>{interfaceName}</TableCell>
       <TableCell data-qa-vlan-linodes>{linodesList}</TableCell>
       <TableCell>


### PR DESCRIPTION
In the linode/networking tab. Anton reached out to say that it's perfectly valid to create a VLAN without an IP address.