### PR TITLE
Fix re-request bug in useReduxLoad

### DIFF
--- a/packages/manager/src/hooks/useReduxLoad.test.ts
+++ b/packages/manager/src/hooks/useReduxLoad.test.ts
@@ -1,0 +1,20 @@
+import { hasReadError } from './useReduxLoad';
+
+const errorMessage = 'An error occurred.';
+
+describe('hasReadError utility function', () => {
+  it('returns `true` only if a "read" error is present', () => {
+    expect(hasReadError({ read: errorMessage })).toBe(true);
+    expect(hasReadError({})).toBe(false);
+  });
+
+  it('handles any input you throw at it', () => {
+    expect(hasReadError(undefined)).toBe(false);
+    expect(hasReadError(null)).toBe(false);
+    expect(hasReadError(1234)).toBe(false);
+    expect(hasReadError('1234')).toBe(false);
+    expect(hasReadError(true)).toBe(false);
+    expect(hasReadError(false)).toBe(false);
+    expect(hasReadError([])).toBe(false);
+  });
+});

--- a/packages/manager/src/hooks/useReduxLoad.test.ts
+++ b/packages/manager/src/hooks/useReduxLoad.test.ts
@@ -1,20 +1,25 @@
-import { hasReadError } from './useReduxLoad';
+import { hasError } from './useReduxLoad';
 
 const errorMessage = 'An error occurred.';
 
-describe('hasReadError utility function', () => {
-  it('returns `true` only if a "read" error is present', () => {
-    expect(hasReadError({ read: errorMessage })).toBe(true);
-    expect(hasReadError({})).toBe(false);
+describe('hasError utility function', () => {
+  it('EntityError: returns `true` only if a "read" error is present', () => {
+    expect(hasError({ read: errorMessage })).toBe(true);
+    expect(hasError({})).toBe(false);
+  });
+
+  it('APIError[]: returns `true` if an error is present', () => {
+    expect(hasError([{ reason: errorMessage }])).toBe(true);
+    expect(hasError([])).toBe(false);
   });
 
   it('handles any input you throw at it', () => {
-    expect(hasReadError(undefined)).toBe(false);
-    expect(hasReadError(null)).toBe(false);
-    expect(hasReadError(1234)).toBe(false);
-    expect(hasReadError('1234')).toBe(false);
-    expect(hasReadError(true)).toBe(false);
-    expect(hasReadError(false)).toBe(false);
-    expect(hasReadError([])).toBe(false);
+    expect(hasError(undefined)).toBe(false);
+    expect(hasError(null)).toBe(false);
+    expect(hasError(1234)).toBe(false);
+    expect(hasError('1234')).toBe(false);
+    expect(hasError(true)).toBe(false);
+    expect(hasError(false)).toBe(false);
+    expect(hasError([])).toBe(false);
   });
 });

--- a/packages/manager/src/hooks/useReduxLoad.ts
+++ b/packages/manager/src/hooks/useReduxLoad.ts
@@ -136,7 +136,7 @@ export const requestDeps = (
     const currentResource = state.__resources[deps[i]] || state[deps[i]];
 
     if (currentResource) {
-      const currentResourceHasReadError = hasReadError(currentResource.error);
+      const currentResourceHasReadError = hasReadError(currentResource?.error);
       if (
         currentResource.lastUpdated === 0 &&
         !currentResource.loading &&

--- a/packages/manager/src/hooks/useReduxLoad.ts
+++ b/packages/manager/src/hooks/useReduxLoad.ts
@@ -136,18 +136,18 @@ export const requestDeps = (
     const currentResource = state.__resources[deps[i]] || state[deps[i]];
 
     if (currentResource) {
-      const currentResourceHasReadError = hasReadError(currentResource?.error);
+      const currentResourcehasError = hasError(currentResource?.error);
       if (
         currentResource.lastUpdated === 0 &&
         !currentResource.loading &&
-        !currentResourceHasReadError
+        !currentResourcehasError
       ) {
         needsToLoad = true;
         requests.push(requestMap[deps[i]]);
       } else if (
         Date.now() - currentResource.lastUpdated > refreshInterval &&
         !currentResource.loading &&
-        !currentResourceHasReadError
+        !currentResourcehasError
       ) {
         requests.push(requestMap[deps[i]]);
       }
@@ -169,6 +169,10 @@ export const requestDeps = (
 
 export default useReduxLoad;
 
-export const hasReadError = (resourceError: any) => {
+export const hasError = (resourceError: any) => {
+  if (Array.isArray(resourceError) && resourceError.length > 0) {
+    return true;
+  }
+
   return resourceError?.read !== undefined;
 };

--- a/packages/manager/src/hooks/useReduxLoad.ts
+++ b/packages/manager/src/hooks/useReduxLoad.ts
@@ -136,18 +136,18 @@ export const requestDeps = (
     const currentResource = state.__resources[deps[i]] || state[deps[i]];
 
     if (currentResource) {
-      const currentResourcehasError = hasError(currentResource?.error);
+      const currentResourceHasError = hasError(currentResource?.error);
       if (
         currentResource.lastUpdated === 0 &&
         !currentResource.loading &&
-        !currentResourcehasError
+        !currentResourceHasError
       ) {
         needsToLoad = true;
         requests.push(requestMap[deps[i]]);
       } else if (
         Date.now() - currentResource.lastUpdated > refreshInterval &&
         !currentResource.loading &&
-        !currentResourcehasError
+        !currentResourceHasError
       ) {
         requests.push(requestMap[deps[i]]);
       }

--- a/packages/manager/src/hooks/useReduxLoad.ts
+++ b/packages/manager/src/hooks/useReduxLoad.ts
@@ -39,14 +39,14 @@ export type ReduxEntity =
   | 'managed'
   | 'managedIssues'
   | 'nodeBalancers'
-  | 'notifications' // has APIError[]
+  | 'notifications'
   | 'profile'
-  | 'regions' // has APIError[]
+  | 'regions'
   | 'types'
-  | 'events' // has no error
+  | 'events'
   | 'longview'
   | 'firewalls'
-  | 'clusters' // has APIError[]
+  | 'clusters'
   | 'vlans';
 
 type RequestMap = Record<ReduxEntity, any>;


### PR DESCRIPTION
## Description

This fixes a bug where `useReduxLoad` continues to make requests to a resource after if fails, so you can for example:

1. Block requests to /images
2. Go to the Images Landing
3. Observe: infinite failed request loop to /images.

This handles both EntityError and APIError[] shapes. For an example of this working with APIError[], visit the Object Storage Landing page and block /clusters.
