### PR TITLE
Fix Lish bug

### DIFF
--- a/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
+++ b/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
@@ -53,7 +53,7 @@ export class AuthenticationWrapper extends React.Component<CombinedProps> {
    */
   makeInitialRequests = async () => {
     // When loading Lish we avoid all this extra data loading
-    if (window.location?.pathname?.includes('/lish/')) {
+    if (window.location?.pathname?.match(/weblish|glish/)) {
       return;
     }
 

--- a/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
+++ b/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
@@ -53,7 +53,7 @@ export class AuthenticationWrapper extends React.Component<CombinedProps> {
    */
   makeInitialRequests = async () => {
     // When loading Lish we avoid all this extra data loading
-    if (window.location?.pathname?.match(/weblish|glish/)) {
+    if (window.location?.pathname?.match(/linodes\/[0-9]+\/lish/)) {
       return;
     }
 


### PR DESCRIPTION
In AuthenticationWrapper, before launching all of our requests (to
profile, account, etc.) we first check to see if we're rendering Lish,
and abort requests if so, since this data is not necessary in that
case and the requests will slow things down.

However, we were matching too casually (just checking to see if the
url contained "/lish/"), and as a result if you navigated directly
to a url like profile/lish/garbage, you'd end up with an infinite loading
state.

Matching more precisely with a regex for the actual paths used (weblish or
glish) fixes this situation.


## Note to Reviewers

On develop, go to localhost:3000/profile/lish/blahblah; observe the infinite loading state. Shouldn't happen here. Lish and Glish should still work normally, with no extra requests (you can check this by typing http://localhost:3000/linodes/{id}/lish/weblish in the navbar and loading the page directly with devtools open).