### PR TITLE
Poll events/Linodes less aggressively

### DIFF
--- a/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
+++ b/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
@@ -266,10 +266,6 @@ const useHeaderStyles = makeStyles((theme: Theme) => ({
   actionItemsOuter: {
     display: 'flex',
     alignItems: 'center'
-  },
-  progressDisplay: {
-    display: 'inline-block',
-    fontFamily: theme.font.bold
   }
 }));
 

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeCard.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeCard.tsx
@@ -238,10 +238,10 @@ export class LinodeCard extends React.PureComponent<CombinedProps, State> {
           <CardContent
             className={`${classes.cardContent} ${classes.customeMQ}`}
           >
-            {recentEvent && linodeInTransition(status, recentEvent) && (
+            {linodeInTransition(status, recentEvent) && (
               <ProgressDisplay
                 text={transitionText(status, id, recentEvent)}
-                progress={recentEvent.percent_complete}
+                progress={recentEvent?.percent_complete ?? 100}
                 classes={{
                   statusProgress: classes.statusProgress,
                   cardSection: classes.cardSection
@@ -394,9 +394,7 @@ export const RenderTitle: React.FC<{
           <EntityIcon
             variant="linode"
             status={linodeStatus}
-            loading={
-              recentEvent && linodeInTransition(linodeStatus, recentEvent)
-            }
+            loading={linodeInTransition(linodeStatus, recentEvent)}
             size={38}
           />
         </Grid>

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeCard.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeCard.tsx
@@ -30,6 +30,7 @@ import withFeatureFlagConsumerContainer, {
 } from 'src/containers/withFeatureFlagConsumer.container';
 import { Action } from 'src/features/linodes/PowerActionsDialogOrDrawer';
 import {
+  getProgressOrDefault,
   linodeInTransition,
   transitionText
 } from 'src/features/linodes/transitions';
@@ -241,7 +242,7 @@ export class LinodeCard extends React.PureComponent<CombinedProps, State> {
             {linodeInTransition(status, recentEvent) && (
               <ProgressDisplay
                 text={transitionText(status, id, recentEvent)}
-                progress={recentEvent?.percent_complete ?? 100}
+                progress={getProgressOrDefault(recentEvent)}
                 classes={{
                   statusProgress: classes.statusProgress,
                   cardSection: classes.cardSection

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
@@ -185,11 +185,11 @@ const LinodeRowHeadCell: React.FC<CombinedProps> = props => {
         </Grid>
         <Grid item>
           <div className={loading ? classes.labelWrapper : ''}>
-            {recentEvent && linodeInTransition(status, recentEvent) && (
+            {linodeInTransition(status, recentEvent) && (
               <ProgressDisplay
                 className={classes.loadingStatus}
                 text={transitionText(status, id, recentEvent)}
-                progress={recentEvent.percent_complete}
+                progress={recentEvent?.percent_complete ?? 100}
               />
             )}
             <div className={classes.labelStatusWrapper}>

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
@@ -17,6 +17,7 @@ import Notice from 'src/components/Notice';
 import TableCell from 'src/components/TableCell';
 import withImages, { WithImages } from 'src/containers/withImages.container';
 import {
+  getProgressOrDefault,
   linodeInTransition,
   transitionText
 } from 'src/features/linodes/transitions';
@@ -189,7 +190,7 @@ const LinodeRowHeadCell: React.FC<CombinedProps> = props => {
               <ProgressDisplay
                 className={classes.loadingStatus}
                 text={transitionText(status, id, recentEvent)}
-                progress={recentEvent?.percent_complete ?? 100}
+                progress={getProgressOrDefault(recentEvent)}
               />
             )}
             <div className={classes.labelStatusWrapper}>

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowLoading.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowLoading.tsx
@@ -60,10 +60,11 @@ const LinodeRowLoading: React.FC<CombinedProps> = props => {
     >
       {children}
       <TableCell colSpan={5} className={classes.bodyCell}>
-        {linodeRecentEvent &&
-          linodeInTransition(linodeStatus, linodeRecentEvent) && (
-            <ProgressDisplay progress={linodeRecentEvent.percent_complete} />
-          )}
+        {linodeInTransition(linodeStatus, linodeRecentEvent) && (
+          <ProgressDisplay
+            progress={linodeRecentEvent?.percent_complete ?? 100}
+          />
+        )}
       </TableCell>
     </TableRow>
   );

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowLoading.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowLoading.tsx
@@ -10,7 +10,10 @@ import {
 import LinearProgress from 'src/components/LinearProgress';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
-import { linodeInTransition } from 'src/features/linodes/transitions';
+import {
+  getProgressOrDefault,
+  linodeInTransition
+} from 'src/features/linodes/transitions';
 
 type ClassNames = 'bodyRow' | 'status' | 'bodyCell';
 
@@ -61,9 +64,7 @@ const LinodeRowLoading: React.FC<CombinedProps> = props => {
       {children}
       <TableCell colSpan={5} className={classes.bodyCell}>
         {linodeInTransition(linodeStatus, linodeRecentEvent) && (
-          <ProgressDisplay
-            progress={linodeRecentEvent?.percent_complete ?? 100}
-          />
+          <ProgressDisplay progress={getProgressOrDefault(linodeRecentEvent)} />
         )}
       </TableCell>
     </TableRow>

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow_CMR.tsx
@@ -20,6 +20,7 @@ import TableRow from 'src/components/TableRow/TableRow_CMR';
 import TagCell from 'src/components/TagCell';
 import { Action } from 'src/features/linodes/PowerActionsDialogOrDrawer';
 import {
+  getProgressOrDefault,
   linodeInTransition,
   transitionText
 } from 'src/features/linodes/transitions';
@@ -221,7 +222,7 @@ export const LinodeRow: React.FC<CombinedProps> = props => {
               >
                 <ProgressDisplay
                   className={classes.progressDisplay}
-                  progress={recentEvent?.percent_complete ?? 100}
+                  progress={getProgressOrDefault(recentEvent)}
                   text={transitionText(status, id, recentEvent)}
                 />
               </button>

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow_CMR.tsx
@@ -213,21 +213,19 @@ export const LinodeRow: React.FC<CombinedProps> = props => {
       >
         {!maintenanceStartTime ? (
           loading ? (
-            recentEvent && (
-              <>
-                <StatusIcon status={iconStatus} />
-                <button
-                  className={classes.statusLink}
-                  onClick={() => openNotificationDrawer()}
-                >
-                  <ProgressDisplay
-                    className={classes.progressDisplay}
-                    progress={recentEvent.percent_complete}
-                    text={transitionText(status, id, recentEvent)}
-                  />
-                </button>
-              </>
-            )
+            <>
+              <StatusIcon status={iconStatus} />
+              <button
+                className={classes.statusLink}
+                onClick={() => openNotificationDrawer()}
+              >
+                <ProgressDisplay
+                  className={classes.progressDisplay}
+                  progress={recentEvent?.percent_complete ?? 100}
+                  text={transitionText(status, id, recentEvent)}
+                />
+              </button>
+            </>
           ) : (
             <>
               <StatusIcon status={iconStatus} />

--- a/packages/manager/src/features/linodes/transitions.ts
+++ b/packages/manager/src/features/linodes/transitions.ts
@@ -35,15 +35,15 @@ export const linodeInTransition = (
   status: string,
   recentEvent?: Event
 ): boolean => {
-  if (!recentEvent) {
-    return false;
+  if (transitionStatus.includes(status)) {
+    return true;
   }
 
   return (
-    transitionStatus.includes(status) ||
-    (transitionAction.includes(recentEvent.action || '') &&
-      recentEvent.percent_complete !== null &&
-      recentEvent.percent_complete < 100)
+    recentEvent !== undefined &&
+    transitionAction.includes(recentEvent?.action || '') &&
+    recentEvent?.percent_complete !== null &&
+    recentEvent?.percent_complete < 100
   );
 };
 

--- a/packages/manager/src/features/linodes/transitions.ts
+++ b/packages/manager/src/features/linodes/transitions.ts
@@ -137,7 +137,7 @@ export const linodesInTransition = (events: Event[]) => {
 // Return the progress of an event if one is given, otherwise return a default
 // of 100. This is useful in the situation where a Linode has recently completed
 // an in-progress event, but we don't have the updated status from the API  yet.
-// In this cause it doesn't have a recentEvent attached (since it has completed),
+// In this case it doesn't have a recentEvent attached (since it has completed),
 // but its status is still briefly in transition, so give it a progress of 100.
 export const getProgressOrDefault = (
   event?: ExtendedEvent,

--- a/packages/manager/src/features/linodes/transitions.ts
+++ b/packages/manager/src/features/linodes/transitions.ts
@@ -42,9 +42,9 @@ export const linodeInTransition = (
 
   return (
     recentEvent !== undefined &&
-    transitionAction.includes(recentEvent?.action || '') &&
-    recentEvent?.percent_complete !== null &&
-    recentEvent?.percent_complete < 100
+    transitionAction.includes(recentEvent.action || '') &&
+    recentEvent.percent_complete !== null &&
+    recentEvent.percent_complete < 100
   );
 };
 

--- a/packages/manager/src/features/linodes/transitions.ts
+++ b/packages/manager/src/features/linodes/transitions.ts
@@ -5,6 +5,7 @@ import {
 } from 'src/store/events/event.selectors';
 import { capitalizeAllWords } from 'src/utilities/capitalize';
 import { isInProgressEvent } from 'src/store/events/event.helpers';
+import { ExtendedEvent } from 'src/store/events/event.types';
 
 export const transitionStatus = [
   'booting',
@@ -132,3 +133,13 @@ export const linodesInTransition = (events: Event[]) => {
 
   return set;
 };
+
+// Return the progress of an event if one is given, otherwise return a default
+// of 100. This is useful in the situation where a Linode has recently completed
+// an in-progress event, but we don't have the updated status from the API  yet.
+// In this cause it doesn't have a recentEvent attached (since it has completed),
+// but its status is still briefly in transition, so give it a progress of 100.
+export const getProgressOrDefault = (
+  event?: ExtendedEvent,
+  defaultProgress = 100
+) => event?.percent_complete ?? defaultProgress;

--- a/packages/manager/src/store/events/event.helpers.ts
+++ b/packages/manager/src/store/events/event.helpers.ts
@@ -153,6 +153,15 @@ export const isInProgressEvent = ({
 }: Pick<Event, 'percent_complete'>) =>
   percent_complete !== null && percent_complete < 100;
 
+export const isLongRunningProgressEventAction = (eventAction: EventAction) => {
+  const longRunningProgressEventActions: EventAction[] = [
+    'linode_resize',
+    'linode_migrate',
+    'linode_migrate_datacenter'
+  ];
+  return longRunningProgressEventActions.includes(eventAction);
+};
+
 export const isCompletedEvent = ({
   percent_complete
 }: Pick<Event, 'percent_complete'>) =>

--- a/packages/manager/src/store/linodes/linodes.events.ts
+++ b/packages/manager/src/store/linodes/linodes.events.ts
@@ -288,7 +288,7 @@ export const updateLinodeOnFirstScheduledEvent = (
   status: EventStatus,
   prevStatus?: EventStatus
 ) => {
-  if (status === 'scheduled' && !prevStatus) {
+  if ((status === 'scheduled' || status === 'started') && !prevStatus) {
     dispatch(requestLinodeForStore(linodeID, true));
   }
 };

--- a/packages/manager/src/store/linodes/linodes.events.ts
+++ b/packages/manager/src/store/linodes/linodes.events.ts
@@ -128,7 +128,7 @@ const handleLinodeMigrate = (
   id: number,
   prevStatus?: EventStatus
 ) => {
-  updateLinodeOnFirstScheduledAndStartedEvent(dispatch, id, status, prevStatus);
+  updateLinodeOnFirstRelevantEvent(dispatch, id, status, prevStatus);
 
   switch (status) {
     case 'failed':
@@ -161,7 +161,7 @@ const handleLinodeUpdate = (
   id: number,
   prevStatus?: EventStatus
 ) => {
-  updateLinodeOnFirstScheduledAndStartedEvent(dispatch, id, status, prevStatus);
+  updateLinodeOnFirstRelevantEvent(dispatch, id, status, prevStatus);
 
   switch (status) {
     case 'failed':
@@ -204,7 +204,7 @@ const handleLinodeCreation = (
   id: number,
   prevStatus?: EventStatus
 ) => {
-  updateLinodeOnFirstScheduledAndStartedEvent(dispatch, id, status, prevStatus);
+  updateLinodeOnFirstRelevantEvent(dispatch, id, status, prevStatus);
 
   switch (status) {
     case 'failed':
@@ -278,18 +278,15 @@ const eventsWithRelevantNotifications: EventAction[] = [
   'linode_migrate_datacenter'
 ];
 
-// If this is the first "scheduled" or "started" event coming in for the Linode,
-// request the Linode from the API to update its status.
-export const updateLinodeOnFirstScheduledAndStartedEvent = (
+// If this is the first event coming in for the Linode, or if it's the first
+// "started" event, request the Linode from the API to update its status.
+export const updateLinodeOnFirstRelevantEvent = (
   dispatch: Dispatch<any>,
   linodeID: number,
   status: EventStatus,
   prevStatus?: EventStatus
 ) => {
-  if (
-    (status === 'scheduled' && !prevStatus) ||
-    (status === 'started' && prevStatus === 'scheduled')
-  ) {
+  if (!prevStatus || (status === 'started' && prevStatus === 'scheduled')) {
     dispatch(requestLinodeForStore(linodeID, true));
   }
 };

--- a/packages/manager/src/store/linodes/linodes.events.ts
+++ b/packages/manager/src/store/linodes/linodes.events.ts
@@ -280,8 +280,8 @@ const eventsWithRelevantNotifications: EventAction[] = [
   'linode_migrate_datacenter'
 ];
 
-// If this is the first "scheduled" event coming through for the Linode,
-// request it from the API to update its status.
+// If this is the first event coming in for the Linode, request the Linode from
+// the API to update its status.
 export const updateLinodeOnFirstScheduledEvent = (
   dispatch: Dispatch<any>,
   linodeID: number,

--- a/packages/manager/src/store/linodes/linodes.events.ts
+++ b/packages/manager/src/store/linodes/linodes.events.ts
@@ -97,17 +97,12 @@ const handleLinodeRebuild = (
   percent_complete: number | null,
   prevStatus?: EventStatus
 ) => {
+  updateLinodeOnFirstScheduledEvent(dispatch, id, status, prevStatus);
+
   /**
    * Rebuilding is a special case, because the rebuilt Linode
    * has new disks, which need to be updated in our store.
    */
-
-  // If this is the first "scheduled" event coming through for the Linode,
-  // request it to update its status.
-  if (status === 'scheduled' && !prevStatus) {
-    return dispatch(requestLinodeForStore(id, true));
-  }
-
   if (status === 'started' && percent_complete === 100) {
     // Get the new disks and update the store.
     dispatch(getAllLinodeDisks({ linodeId: id }));
@@ -134,11 +129,7 @@ const handleLinodeMigrate = (
   id: number,
   prevStatus?: EventStatus
 ) => {
-  // If this is the first "scheduled" event coming through for the Linode,
-  // request it to update its status.
-  if (status === 'scheduled' && !prevStatus) {
-    return dispatch(requestLinodeForStore(id, true));
-  }
+  updateLinodeOnFirstScheduledEvent(dispatch, id, status, prevStatus);
 
   switch (status) {
     case 'failed':
@@ -171,11 +162,7 @@ const handleLinodeUpdate = (
   id: number,
   prevStatus?: EventStatus
 ) => {
-  // If this is the first "scheduled" event coming through for the Linode,
-  // request it to update its status.
-  if (status === 'scheduled' && !prevStatus) {
-    return dispatch(requestLinodeForStore(id, true));
-  }
+  updateLinodeOnFirstScheduledEvent(dispatch, id, status, prevStatus);
 
   switch (status) {
     case 'failed':
@@ -218,11 +205,7 @@ const handleLinodeCreation = (
   id: number,
   prevStatus?: EventStatus
 ) => {
-  // If this is the first "scheduled" event coming through for the Linode,
-  // request it to update its status.
-  if (status === 'scheduled' && !prevStatus) {
-    return dispatch(requestLinodeForStore(id, true));
-  }
+  updateLinodeOnFirstScheduledEvent(dispatch, id, status, prevStatus);
 
   switch (status) {
     case 'failed':
@@ -296,3 +279,16 @@ const eventsWithRelevantNotifications: EventAction[] = [
   'linode_migrate_datacenter_create',
   'linode_migrate_datacenter'
 ];
+
+// If this is the first "scheduled" event coming through for the Linode,
+// request it from the API to update its status.
+export const updateLinodeOnFirstScheduledEvent = (
+  dispatch: Dispatch<any>,
+  linodeID: number,
+  status: EventStatus,
+  prevStatus?: EventStatus
+) => {
+  if (status === 'scheduled' && !prevStatus) {
+    dispatch(requestLinodeForStore(linodeID, true));
+  }
+};

--- a/packages/manager/src/store/middleware/combineEventsMiddleware.ts
+++ b/packages/manager/src/store/middleware/combineEventsMiddleware.ts
@@ -54,7 +54,7 @@ const eventsMiddlewareFactory = (
        */
       if (isInProgressEvent(event)) {
         // If the event is in_progress, we poll more aggressively
-        resetEventsPolling();
+        resetEventsPolling(1.5);
       }
     }
   }

--- a/packages/manager/src/store/middleware/combineEventsMiddleware.ts
+++ b/packages/manager/src/store/middleware/combineEventsMiddleware.ts
@@ -3,7 +3,8 @@ import { Middleware } from 'redux';
 import { resetEventsPolling } from 'src/eventsPolling';
 import {
   isEntityEvent,
-  isInProgressEvent
+  isInProgressEvent,
+  isLongRunningProgressEventAction
 } from 'src/store/events/event.helpers';
 import { EventHandler } from 'src/store/types';
 import { isType } from 'typescript-fsa';
@@ -52,8 +53,11 @@ const eventsMiddlewareFactory = (
        * Finally, if any of these events were in-progress we want to reset the events polling
        * interval to keep things moving quickly.
        */
-      if (isInProgressEvent(event)) {
-        // If the event is in_progress, we poll more aggressively
+      if (
+        isInProgressEvent(event) &&
+        // Don't poll aggressively on long-running progress events (like migration).
+        !isLongRunningProgressEventAction(event.action)
+      ) {
         resetEventsPolling(1.5);
       }
     }


### PR DESCRIPTION
## Description

This does three things:

- Poll events every **1.5s** during progress events instead of every **1s**.
- Don't aggressively poll for long-running events like resizing and migration.
- Don't re-request the Linode every `scheduled` and `started` event. Instead, re-request the Linode only on first of these event types, and on `failed`, `notification`, and `finished` events (with the exception of Linode Rebuild: explanation in comment).

The 3rd item caused a rough UI transition. Just after the event is `finished`(but before we've gotten back the updated Linode status from the API) the old status of e.g. "rebooting" was displayed, but the Linode wasn't considered to be in "transition", so we didn't show progress or the pending status icon.

This is because our "transition" logic _requires_ there to be a recent event for a Linode.

To fix this, I changed our logic such that if a Linode has a "transition" status like `rebooting`, it is always considered to be in transition, regardless of recent events.

If a Linode is in transition but there is no recent event, our Progress Display component assumes the `percent_complete` to be 100. (This debatable... I don't love it but provided the best UX and I haven't found edge cases yet).

### Testing:
These events/progress changes are always tricky to verify. Please check CMR, non-CMR, list view, card/detail view, etc. Also check a wide variety of events: rebooting, cloning, resizing, etc.
