### PR TITLE
M3-4602 DBaaS Detail Backups table 

### DIFF
--- a/packages/api-v4/src/databases/types.ts
+++ b/packages/api-v4/src/databases/types.ts
@@ -24,7 +24,7 @@ export type DatabaseBackupStatus =
   | 'unknown';
 
 export interface DatabaseBackup {
-  id: number;
+  id: string;
   status: DatabaseBackupStatus;
   created: string;
   finished: string;

--- a/packages/manager/src/factories/databaseBackups.ts
+++ b/packages/manager/src/factories/databaseBackups.ts
@@ -1,0 +1,9 @@
+import { DatabaseBackup } from '@linode/api-v4/lib/databases';
+import * as Factory from 'factory.ts';
+
+export const DatabaseBackupFactory = Factory.Sync.makeFactory<DatabaseBackup>({
+  id: Factory.each(i => i),
+  status: 'running',
+  created: '2020-10-01T00:00:00',
+  finished: '2020-10-02T00:00:00'
+});

--- a/packages/manager/src/factories/databaseBackups.ts
+++ b/packages/manager/src/factories/databaseBackups.ts
@@ -1,9 +1,10 @@
 import { DatabaseBackup } from '@linode/api-v4/lib/databases';
 import * as Factory from 'factory.ts';
+import { v4 } from 'uuid';
 
 export const DatabaseBackupFactory = Factory.Sync.makeFactory<DatabaseBackup>({
-  id: Factory.each(i => i),
+  id: Factory.each(() => v4()),
   status: 'running',
   created: '2020-10-01T00:00:00',
-  finished: '2020-10-02T00:00:00'
+  finished: '2020-10-01T00:00:25'
 });

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackupActionMenu.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackupActionMenu.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import ActionMenu from 'src/components/ActionMenu_CMR';
+import Hidden from 'src/components/core/Hidden';
+import InlineAction from 'src/components/InlineMenuAction';
+import { DatabaseBackup } from '@linode/api-v4/lib/databases';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  inlineActions: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'flex-end'
+  },
+  button: {
+    ...theme.applyLinkStyles,
+    color: theme.cmrTextColors.linkActiveLight,
+    height: '100%',
+    minWidth: 'auto',
+    padding: '12px 10px',
+    whiteSpace: 'nowrap',
+    '&:hover': {
+      backgroundColor: '#3683dc',
+      color: '#ffffff'
+    },
+    '&[disabled]': {
+      color: '#cdd0d5',
+      cursor: 'default',
+      '&:hover': {
+        backgroundColor: 'inherit'
+      }
+    }
+  }
+}));
+
+interface Props {
+  backup: DatabaseBackup;
+}
+
+type CombinedProps = Props;
+
+const AccessKeyMenu: React.FC<CombinedProps> = props => {
+  const classes = useStyles();
+
+  // @todo add actions functionality when API work is finalized
+  const actions = [
+    {
+      title: 'Restore',
+      onClick: () => {
+        alert('Restore');
+      }
+    },
+    {
+      title: 'Delete',
+      onClick: () => {
+        alert('Delete');
+      }
+    }
+  ];
+
+  return (
+    <div className={classes.inlineActions}>
+      <Hidden smDown>
+        {actions.map(thisAction => (
+          <InlineAction
+            key={thisAction.title}
+            actionText={thisAction.title}
+            onClick={thisAction.onClick}
+          />
+        ))}
+      </Hidden>
+      <Hidden mdUp>
+        <ActionMenu
+          createActions={() => actions}
+          ariaLabel={`Action menu for database backup ${props.backup.id}`}
+        />
+      </Hidden>
+    </div>
+  );
+};
+
+export default AccessKeyMenu;

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackupActionMenu.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackupActionMenu.tsx
@@ -38,7 +38,7 @@ interface Props {
 
 type CombinedProps = Props;
 
-const AccessKeyMenu: React.FC<CombinedProps> = props => {
+const DatabaseBackupActionMenu: React.FC<CombinedProps> = props => {
   const classes = useStyles();
 
   // @todo add actions functionality when API work is finalized
@@ -78,4 +78,4 @@ const AccessKeyMenu: React.FC<CombinedProps> = props => {
   );
 };
 
-export default AccessKeyMenu;
+export default DatabaseBackupActionMenu;

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackupTableRow.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackupTableRow.tsx
@@ -6,6 +6,7 @@ import TableCell from 'src/components/TableCell/TableCell_CMR';
 import DatabaseBackupActionMenu from './DatabaseBackupActionMenu';
 import { formatDuration } from 'src/utilities/formatDuration';
 import { parseAPIDate } from 'src/utilities/date';
+import DateTimeDisplay from 'src/components/DateTimeDisplay';
 
 interface Props {
   backup: DatabaseBackup;
@@ -21,7 +22,9 @@ const BackupTableRow: React.FC<Props> = props => {
     <TableRow key={backup.id} data-qa-backup>
       <TableCell data-qa-backup-name={backup.id}>{backup.id}</TableCell>
       <TableCell>{backup.status}</TableCell>
-      <TableCell>{backup.created}</TableCell>
+      <TableCell>
+        <DateTimeDisplay value={backup.created} />
+      </TableCell>
       <TableCell>
         {formatDuration(
           Duration.fromMillis(

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackupTableRow.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackupTableRow.tsx
@@ -1,0 +1,44 @@
+import { DatabaseBackup } from '@linode/api-v4/lib/databases';
+import { Duration } from 'luxon';
+import * as React from 'react';
+import TableRow from 'src/components/core/TableRow';
+import TableCell from 'src/components/TableCell/TableCell_CMR';
+// import LinodeBackupActionMenu from './LinodeBackupActionMenu';
+import { formatDuration } from 'src/utilities/formatDuration';
+import { parseAPIDate } from 'src/utilities/date';
+
+interface Props {
+  backup: DatabaseBackup;
+  // disabled: boolean;
+  // handleRestore: (backup: DatabaseBackup) => void;
+  // handleDeploy: (backup: DatabaseBackup) => void;
+}
+
+const BackupTableRow: React.FC<Props> = props => {
+  const { backup } = props;
+  return (
+    <TableRow key={backup.id} data-qa-backup>
+      <TableCell data-qa-backup-name={backup.id}>{backup.id}</TableCell>
+      <TableCell>{backup.status}</TableCell>
+      <TableCell>{backup.created}</TableCell>
+      <TableCell>
+        {formatDuration(
+          Duration.fromMillis(
+            parseAPIDate(backup.finished).toMillis() -
+              parseAPIDate(backup.created).toMillis()
+          )
+        )}
+      </TableCell>
+      <TableCell>
+        {/* <LinodeBackupActionMenu
+          backup={backup}
+          disabled={disabled}
+          onRestore={handleRestore}
+          onDeploy={onDeploy}
+        /> */}
+      </TableCell>
+    </TableRow>
+  );
+};
+
+export default BackupTableRow;

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackupTableRow.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackupTableRow.tsx
@@ -3,15 +3,16 @@ import { Duration } from 'luxon';
 import * as React from 'react';
 import TableRow from 'src/components/core/TableRow';
 import TableCell from 'src/components/TableCell/TableCell_CMR';
-// import LinodeBackupActionMenu from './LinodeBackupActionMenu';
+import DatabaseBackupActionMenu from './DatabaseBackupActionMenu';
 import { formatDuration } from 'src/utilities/formatDuration';
 import { parseAPIDate } from 'src/utilities/date';
 
 interface Props {
   backup: DatabaseBackup;
-  // disabled: boolean;
+  // TBD As of 10/23/20, Restore and Delete are the only documented actions that can be taken for db backups.
+  // @todo add in when API work is finalized
   // handleRestore: (backup: DatabaseBackup) => void;
-  // handleDeploy: (backup: DatabaseBackup) => void;
+  // handleDelete: (backup: DatabaseBackup) => void;
 }
 
 const BackupTableRow: React.FC<Props> = props => {
@@ -30,12 +31,7 @@ const BackupTableRow: React.FC<Props> = props => {
         )}
       </TableCell>
       <TableCell>
-        {/* <LinodeBackupActionMenu
-          backup={backup}
-          disabled={disabled}
-          onRestore={handleRestore}
-          onDeploy={onDeploy}
-        /> */}
+        <DatabaseBackupActionMenu backup={backup} />
       </TableCell>
     </TableRow>
   );

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
@@ -13,7 +13,8 @@ import Typography from 'src/components/core/Typography';
 
 const useStyles = makeStyles((theme: Theme) => ({
   heading: {
-    marginBottom: theme.spacing(2)
+    marginBottom: theme.spacing(2),
+    paddingLeft: theme.spacing(2)
   }
 }));
 

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
@@ -4,7 +4,7 @@ import Paper from 'src/components/core/Paper';
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
 import TableRow from 'src/components/core/TableRow';
-import Table from 'src/components/Table';
+import Table from 'src/components/Table/Table_CMR';
 import TableCell from 'src/components/TableCell/TableCell_CMR';
 import BackupTableRow from './DatabaseBackupTableRow';
 import { DatabaseBackupFactory } from 'src/factories/databaseBackups';

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
@@ -8,18 +8,13 @@ import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
 import BackupTableRow from './DatabaseBackupTableRow';
 
-interface Props {
-  backups: DatabaseBackup[];
-}
-
-type CombinedProps = Props;
-
-export const DatabaseBackups: React.FC<CombinedProps> = props => {
-  const { backups } = props;
+export const DatabaseBackups: React.FC<{}> = () => {
+  // @todo replace with actual db info
+  const backups: DatabaseBackup[] = [];
 
   return (
     <Paper style={{ padding: 0 }}>
-      <Table aria-label="List of Backups">
+      <Table aria-label="List of database backups">
         <TableHead>
           <TableRow>
             <TableCell>Backup ID</TableCell>

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
@@ -5,12 +5,13 @@ import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
 import TableRow from 'src/components/core/TableRow';
 import Table from 'src/components/Table';
-import TableCell from 'src/components/TableCell';
+import TableCell from 'src/components/TableCell/TableCell_CMR';
 import BackupTableRow from './DatabaseBackupTableRow';
+import { DatabaseBackupFactory } from 'src/factories/databaseBackups';
 
 export const DatabaseBackups: React.FC<{}> = () => {
   // @todo replace with actual db info
-  const backups: DatabaseBackup[] = [];
+  const backups = DatabaseBackupFactory.buildList(3);
 
   return (
     <Paper style={{ padding: 0 }}>

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
@@ -1,7 +1,42 @@
+import { DatabaseBackup } from '@linode/api-v4/lib/databases';
 import * as React from 'react';
+import Paper from 'src/components/core/Paper';
+import TableBody from 'src/components/core/TableBody';
+import TableHead from 'src/components/core/TableHead';
+import TableRow from 'src/components/core/TableRow';
+import Table from 'src/components/Table';
+import TableCell from 'src/components/TableCell';
+import BackupTableRow from './DatabaseBackupTableRow';
 
-export const DatabaseBackups: React.FC<{}> = () => {
-  return <span>Backups</span>;
+interface Props {
+  backups: DatabaseBackup[];
+}
+
+type CombinedProps = Props;
+
+export const DatabaseBackups: React.FC<CombinedProps> = props => {
+  const { backups } = props;
+
+  return (
+    <Paper style={{ padding: 0 }}>
+      <Table aria-label="List of Backups">
+        <TableHead>
+          <TableRow>
+            <TableCell>Backup ID</TableCell>
+            <TableCell>Status</TableCell>
+            <TableCell>Date Created</TableCell>
+            <TableCell>Duration</TableCell>
+            <TableCell />
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {backups.map((backup: DatabaseBackup, idx: number) => (
+            <BackupTableRow key={idx} backup={backup} />
+          ))}
+        </TableBody>
+      </Table>
+    </Paper>
+  );
 };
 
 export default DatabaseBackups;

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
@@ -1,5 +1,6 @@
 import { DatabaseBackup } from '@linode/api-v4/lib/databases';
 import * as React from 'react';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Paper from 'src/components/core/Paper';
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
@@ -8,30 +9,42 @@ import Table from 'src/components/Table/Table_CMR';
 import TableCell from 'src/components/TableCell/TableCell_CMR';
 import BackupTableRow from './DatabaseBackupTableRow';
 import { DatabaseBackupFactory } from 'src/factories/databaseBackups';
+import Typography from 'src/components/core/Typography';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  heading: {
+    marginBottom: theme.spacing(2)
+  }
+}));
 
 export const DatabaseBackups: React.FC<{}> = () => {
   // @todo replace with actual db info
   const backups = DatabaseBackupFactory.buildList(3);
-
+  const classes = useStyles();
   return (
-    <Paper style={{ padding: 0 }}>
-      <Table aria-label="List of database backups">
-        <TableHead>
-          <TableRow>
-            <TableCell>Backup ID</TableCell>
-            <TableCell>Status</TableCell>
-            <TableCell>Date Created</TableCell>
-            <TableCell>Duration</TableCell>
-            <TableCell />
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {backups.map((backup: DatabaseBackup, idx: number) => (
-            <BackupTableRow key={idx} backup={backup} />
-          ))}
-        </TableBody>
-      </Table>
-    </Paper>
+    <>
+      <Typography className={classes.heading} variant="h2">
+        Backups
+      </Typography>
+      <Paper style={{ padding: 0 }}>
+        <Table aria-label="List of database backups">
+          <TableHead>
+            <TableRow>
+              <TableCell>Backup ID</TableCell>
+              <TableCell>Status</TableCell>
+              <TableCell>Date Created</TableCell>
+              <TableCell>Duration</TableCell>
+              <TableCell />
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {backups.map((backup: DatabaseBackup, idx: number) => (
+              <BackupTableRow key={idx} backup={backup} />
+            ))}
+          </TableBody>
+        </Table>
+      </Paper>
+    </>
   );
 };
 


### PR DESCRIPTION
## Description

Please consider this a glorified boilerplate for the backups table. To view, navigate to `/databases/1234/backups`. I've applied a factory to aid with testing. 

I've commented todos and notes throughout the code, but I made guesses on what we'd like to display on the table based on what exists on Linode backups/the response we get back for Dbaas backups (including actions, which currently do not work at all). Please let me know what you think. 

## Type of Change
- Non breaking change ('change')
