### PR TITLE
M3-4316 Add type-to-confirm to DeletionDialog

### DIFF
--- a/packages/manager/src/components/DeletionDialog/DeletionDialog.tsx
+++ b/packages/manager/src/components/DeletionDialog/DeletionDialog.tsx
@@ -50,6 +50,7 @@ const DeletionDialog: React.FC<CombinedProps> = props => {
   );
 
   React.useEffect(() => {
+    /** Reset confirmation text when the modal opens */
     if (open) {
       setConfirmationText('');
     }

--- a/packages/manager/src/components/DeletionDialog/DeletionDialog.tsx
+++ b/packages/manager/src/components/DeletionDialog/DeletionDialog.tsx
@@ -2,56 +2,84 @@ import * as React from 'react';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Notice from 'src/components/Notice';
+import TextField from 'src/components/TextField';
+import { capitalize } from 'src/utilities/capitalize';
 
 interface Props {
   open: boolean;
   error?: string;
+  entity: string;
   onClose: () => void;
   onDelete: () => void;
   label: string;
   loading: boolean;
 }
 
+const useStyles = makeStyles((theme: Theme) => ({
+  text: {
+    paddingTop: theme.spacing(2),
+    paddingBottom: theme.spacing()
+  }
+}));
+
 type CombinedProps = Props;
 
-class DeletionDialog extends React.PureComponent<CombinedProps, {}> {
-  renderActions = () => {
-    const { onClose, onDelete, loading } = this.props;
-    return (
-      <ActionsPanel style={{ padding: 0 }}>
-        <Button buttonType="cancel" onClick={onClose} data-qa-cancel>
-          Cancel
-        </Button>
-        <Button
-          buttonType="secondary"
-          destructive
-          onClick={onDelete}
-          loading={loading}
-          data-qa-confirm
-        >
-          Delete
-        </Button>
-      </ActionsPanel>
-    );
-  };
-
-  render() {
-    const { error, label } = this.props;
-
-    return (
-      <ConfirmationDialog
-        open={this.props.open}
-        title={`Delete ${label}?`}
-        onClose={this.props.onClose}
-        actions={this.renderActions}
+const DeletionDialog: React.FC<CombinedProps> = props => {
+  const classes = useStyles();
+  const { entity, error, label, onClose, onDelete, open, loading } = props;
+  const [confirmationText, setConfirmationText] = React.useState('');
+  const renderActions = () => (
+    <ActionsPanel style={{ padding: 0 }}>
+      <Button buttonType="cancel" onClick={onClose} data-qa-cancel>
+        Cancel
+      </Button>
+      <Button
+        buttonType="secondary"
+        destructive
+        onClick={onDelete}
+        loading={loading}
+        disabled={confirmationText !== label}
+        data-qa-confirm
       >
-        {error && <Notice error text={error} />}
-        <Typography>Are you sure you want to delete {label}?</Typography>
-      </ConfirmationDialog>
-    );
-  }
-}
+        Delete
+      </Button>
+    </ActionsPanel>
+  );
 
-export default DeletionDialog;
+  React.useEffect(() => {
+    if (open) {
+      setConfirmationText('');
+    }
+  }, [open]);
+
+  return (
+    <ConfirmationDialog
+      open={open}
+      title={`Delete ${label}?`}
+      onClose={onClose}
+      actions={renderActions}
+    >
+      {error && <Notice error text={error} />}
+      <Typography>
+        Deleting this {entity} is permanent and can&apos;t be undone.
+      </Typography>
+      <Typography className={classes.text}>
+        To confirm deletion, type the name of the {entity} (
+        <strong>{label}</strong>) in the field below:
+      </Typography>
+      <TextField
+        label={`${capitalize(entity)} Name:`}
+        value={confirmationText}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+          setConfirmationText(e.target.value)
+        }
+        placeholder={label}
+      />
+    </ConfirmationDialog>
+  );
+};
+
+export default React.memo(DeletionDialog);

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
@@ -286,6 +286,7 @@ const DatabaseLanding: React.FC<{}> = _ => {
       />
       <DeletionDialog
         label={dialog.entityLabel ?? ''}
+        entity="database"
         error={dialog.error}
         open={dialog.isOpen}
         loading={dialog.isLoading}

--- a/packages/manager/src/features/Domains/DeleteDomain.test.tsx
+++ b/packages/manager/src/features/Domains/DeleteDomain.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 import { reactRouterProps } from 'src/__data__/reactRouterProps';
 import { wrapWithTheme } from 'src/utilities/testHelpers';
@@ -30,12 +31,24 @@ describe('DeleteDomain', () => {
   it('displays the modal when the button is clicked', () => {
     const { getByText } = render(wrapWithTheme(<DeleteDomain {...props} />));
     fireEvent.click(getByText('Delete Domain'));
-    getByText(/Are you sure you want to delete/);
+    expect(getByText(/delete example.com/i)).toBeInTheDocument();
+  });
+
+  it("doesn't submit anything if the user hasn't typed confirmation text", async () => {
+    const { getByText } = render(wrapWithTheme(<DeleteDomain {...props} />));
+
+    fireEvent.click(getByText('Delete Domain'));
+    fireEvent.click(getByText('Delete'));
+    await waitFor(() => expect(mockDeleteDomain).not.toHaveBeenCalled);
   });
 
   it('dispatches the deleteDomain action when the "Delete" button is clicked', async () => {
-    const { getByText } = render(wrapWithTheme(<DeleteDomain {...props} />));
+    const { getByLabelText, getByText } = render(
+      wrapWithTheme(<DeleteDomain {...props} />)
+    );
+
     fireEvent.click(getByText('Delete Domain'));
+    userEvent.type(getByLabelText('Domain Name:'), 'example.com');
     fireEvent.click(getByText('Delete'));
     await waitFor(() =>
       expect(mockDeleteDomain).toHaveBeenCalledWith({ domainId })

--- a/packages/manager/src/features/Domains/DeleteDomain.tsx
+++ b/packages/manager/src/features/Domains/DeleteDomain.tsx
@@ -55,6 +55,7 @@ export const DeleteDomain: React.FC<CombinedProps> = props => {
         Delete Domain
       </Button>
       <DeletionDialog
+        entity="domain"
         open={dialog.isOpen}
         label={dialog.entityLabel || ''}
         loading={dialog.isLoading}

--- a/packages/manager/src/features/Managed/Contacts/Contacts.tsx
+++ b/packages/manager/src/features/Managed/Contacts/Contacts.tsx
@@ -248,6 +248,7 @@ const Contacts: React.FC<CombinedProps> = props => {
         </OrderBy>
         <DeletionDialog
           open={dialog.isOpen}
+          entity="contact"
           label={dialog.entityLabel || ''}
           loading={dialog.isLoading}
           error={dialog.error}

--- a/packages/manager/src/features/Managed/Contacts/Contacts_CMR.tsx
+++ b/packages/manager/src/features/Managed/Contacts/Contacts_CMR.tsx
@@ -267,6 +267,7 @@ const Contacts: React.FC<CombinedProps> = props => {
         <DeletionDialog
           open={dialog.isOpen}
           label={dialog.entityLabel || ''}
+          entity="contact"
           loading={dialog.isLoading}
           error={dialog.error}
           onClose={closeDialog}

--- a/packages/manager/src/features/Managed/Credentials/CredentialList.tsx
+++ b/packages/manager/src/features/Managed/Credentials/CredentialList.tsx
@@ -292,6 +292,7 @@ export const CredentialList: React.FC<CombinedProps> = props => {
       </OrderBy>
       <DeletionDialog
         open={dialog.isOpen}
+        entity="credential"
         label={dialog.entityLabel || ''}
         loading={dialog.isLoading}
         error={dialog.error}

--- a/packages/manager/src/features/Managed/Credentials/CredentialList_CMR.tsx
+++ b/packages/manager/src/features/Managed/Credentials/CredentialList_CMR.tsx
@@ -316,6 +316,7 @@ export const CredentialList: React.FC<CombinedProps> = props => {
       </div>
       <DeletionDialog
         open={dialog.isOpen}
+        entity="credential"
         label={dialog.entityLabel || ''}
         loading={dialog.isLoading}
         error={dialog.error}

--- a/packages/manager/src/features/Managed/Monitors/MonitorTable.tsx
+++ b/packages/manager/src/features/Managed/Monitors/MonitorTable.tsx
@@ -274,6 +274,7 @@ export const MonitorTable: React.FC<CombinedProps> = props => {
       </OrderBy>
       <DeletionDialog
         label={dialog.entityLabel || ''}
+        entity="monitor"
         onDelete={handleDelete}
         onClose={closeDialog}
         open={dialog.isOpen}
@@ -302,8 +303,5 @@ export const MonitorTable: React.FC<CombinedProps> = props => {
 };
 
 const styled = withStyles(styles);
-const enhanced = compose<CombinedProps, Props>(
-  withSnackbar,
-  styled
-);
+const enhanced = compose<CombinedProps, Props>(withSnackbar, styled);
 export default enhanced(MonitorTable);

--- a/packages/manager/src/features/Managed/Monitors/MonitorTable_CMR.tsx
+++ b/packages/manager/src/features/Managed/Monitors/MonitorTable_CMR.tsx
@@ -288,6 +288,7 @@ export const MonitorTable: React.FC<CombinedProps> = props => {
       </OrderBy>
       <DeletionDialog
         label={dialog.entityLabel || ''}
+        entity="monitor"
         onDelete={handleDelete}
         onClose={closeDialog}
         open={dialog.isOpen}


### PR DESCRIPTION
## Description

Jay has asked that we make all deletion type-to-confirm, app-wide. We created a DeletionDialog component a while ago, mostly forgot about it, then I ended up using it for DatabasesLanding. Putting the two together, adding type-to-confirm to this component both matches the DBaaS designs and brings some of the older dialogs up to spec.

NOTE: by chance, this component is used in some of the places--Managed contacts etc.--where it's hardest to justify type-to-confirm. It would be easy to make this controllable by prop, say `confirmDeletion` or something. I haven't done that because Jay has repeatedly said that _all_ deletion should have this behavior. Please weigh in.

## Note to Reviewers

This should show up when trying to delete:
- Databases
- Domains (only from within the drawer)
- Managed monitors, contacts, and credentials
