### PR TITLE
Refine VlanTableRow logic to prevent comma visual display bug

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/VLANPanel/VlanTableRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/VLANPanel/VlanTableRow.tsx
@@ -33,7 +33,7 @@ export const VlanTableRow: React.FC<CombinedProps> = props => {
   const vlanLabel = description.length > 32 ? `vlan-${id}` : description;
 
   const getLinodesCellString = (
-    data: VLAN['linodes'],
+    vlanLinodes: VLAN['linodes'],
     loading: boolean,
     error?: APIError[]
   ): string | JSX.Element => {
@@ -45,25 +45,25 @@ export const VlanTableRow: React.FC<CombinedProps> = props => {
       return 'Error retrieving Linodes';
     }
 
-    if (data.length === 0) {
+    if (vlanLinodes.length === 0) {
       return 'None assigned';
     }
 
-    return getLinodeLinks(data);
+    return getLinodeLinks(vlanLinodes);
   };
 
-  const getLinodeLinks = (data: VLAN['linodes']): JSX.Element => {
+  const getLinodeLinks = (vlanLinodes: VLAN['linodes']): JSX.Element => {
     // To render the label of the linode the user is currently on first in the list as  non-link, exclude it from the list of linodes the VLAN is attached to.
 
     // If the element is the current linode's ID, or the linode ID is not found in the store, filter it out. The second check avoids an edge case where deleted linodes still attached to VLANs cause a manifestation of the comma display bug.
-    const filteredData = data.filter(datum => {
+    const filteredLinodes = vlanLinodes.filter(vlanLinode => {
       return (
-        datum.id !== currentLinodeId &&
-        getEntityByIDFromStore('linode', datum.id)
+        vlanLinode.id !== currentLinodeId &&
+        getEntityByIDFromStore('linode', vlanLinode.id)
       );
     });
 
-    const generatedLinks = filteredData.map(linode => (
+    const generatedLinks = filteredLinodes.map(linode => (
       <Link
         key={linode.id}
         to={`/linodes/${linode.id}/networking`}
@@ -77,7 +77,7 @@ export const VlanTableRow: React.FC<CombinedProps> = props => {
       // eslint-disable-next-line react/jsx-no-useless-fragment
       <>
         {getLinodeLabel(currentLinodeId)}
-        {filteredData.length >= 1 && `, `}
+        {filteredLinodes.length >= 1 && `, `}
         {truncateAndJoinJSXList(
           generatedLinks,
           MAX_LINODES_VLANATTACHED_DISPLAY

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/VLANPanel/VlanTableRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/VLANPanel/VlanTableRow.tsx
@@ -1,16 +1,16 @@
 import { APIError } from '@linode/api-v4/lib/types';
+import { VLAN } from '@linode/api-v4/lib/vlans';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { compose } from 'recompose';
-import TableCell from 'src/components/TableCell/TableCell_CMR';
-import TableRow from 'src/components/TableRow/TableRow_CMR';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
-import VlanActionMenu, { ActionHandlers } from './VlanActionMenu';
+import TableCell from 'src/components/TableCell/TableCell_CMR';
+import TableRow from 'src/components/TableRow/TableRow_CMR';
 import { getLinodeLabel } from 'src/features/Dashboard/VolumesDashboardCard/VolumeDashboardRow';
-import { VlanData } from './LinodeVLANs';
-import { VLAN } from '@linode/api-v4/lib/vlans';
 import { getEntityByIDFromStore } from 'src/utilities/getEntityByIDFromStore';
+import { VlanData } from './LinodeVLANs';
+import VlanActionMenu, { ActionHandlers } from './VlanActionMenu';
 
 export const MAX_LINODES_VLANATTACHED_DISPLAY = 50;
 
@@ -54,22 +54,14 @@ export const VlanTableRow: React.FC<CombinedProps> = props => {
 
   const getLinodeLinks = (data: VLAN['linodes']): JSX.Element => {
     // To render the label of the linode the user is currently on first in the list as  non-link, exclude it from the list of linodes the VLAN is attached to.
-    const filterData = (data: VLAN['linodes']) => {
-      const _data: VLAN['linodes'] = [];
 
-      // If the element is the current linode's ID, or the linode ID is not found in the store, do not add it to the _data array. The additional linodeExists check avoids an edge case where deleted linodes still attached to VLANs cause a manifestation of the comma display bug.
-      for (let i = data.length - 1; i >= 0; i--) {
-        const linodeExists = getEntityByIDFromStore('linode', data[i].id);
-
-        if (data[i].id !== currentLinodeId && linodeExists) {
-          _data.push(data[i]);
-        }
-      }
-
-      return _data;
-    };
-
-    const filteredData = filterData(data);
+    // If the element is the current linode's ID, or the linode ID is not found in the store, filter it out. The second check avoids an edge case where deleted linodes still attached to VLANs cause a manifestation of the comma display bug.
+    const filteredData = data.filter(datum => {
+      return (
+        datum.id !== currentLinodeId &&
+        getEntityByIDFromStore('linode', datum.id)
+      );
+    });
 
     const generatedLinks = filteredData.map(linode => (
       <Link


### PR DESCRIPTION
## Description
Add some additional logic to prevent the extra commas display bug in the Linodes column of the VLAN panel on the Network tab.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')
