### PR TITLE
Improve unit test speed by setting maxWorkers to 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "up": "yarn install:all && yarn build:sdk && yarn start:all",
     "start:all": "concurrently \"yarn workspace @linode/api-v4 start\" \"yarn workspace linode-manager start\"",
     "clean": "rm -rf node_modules && rm -rf packages/@linode/api-v4/node_modules && rm -rf packages/manager/node_modules",
-    "test": "yarn workspace linode-manager test",
+    "test": "yarn workspace linode-manager test --maxWorkers=4",
     "selenium:install": "yarn workspace linode-manager selenium:install",
     "storybook": "yarn workspace linode-manager storybook",
     "storybook:e2e": "yarn workspace linode-manager storybook:e2e",


### PR DESCRIPTION
On my machine, this reduced unit test runs (all of them – `yarn test`) from ~500s to ~100s.