### PR TITLE
M3-4628 Change: allow multi-select when adding VLANs during Linode create

### DIFF
--- a/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
@@ -76,10 +76,10 @@ interface Props {
   privateIP: boolean;
   changeBackups: () => void;
   changePrivateIP: () => void;
-  changeSelectedVLAN: (vlanID: number | null) => void;
+  changeSelectedVLAN: (vlanID: number[]) => void;
   disabled?: boolean;
   hidePrivateIP?: boolean;
-  selectedVlanID: number | null;
+  selectedVlanIDs: number[];
   vlanError?: string;
   selectedRegionID?: string; // Used for filtering VLANs
 }
@@ -98,8 +98,8 @@ const AddonsPanel: React.FC<CombinedProps> = props => {
   const flags = useFlags();
 
   const handleVlanChange = React.useCallback(
-    (vlan: number | null) => {
-      changeSelectedVLAN(vlan);
+    (vlans: number[]) => {
+      changeSelectedVLAN(vlans);
     },
     [changeSelectedVLAN]
   );
@@ -196,7 +196,7 @@ const AddonsPanel: React.FC<CombinedProps> = props => {
             <div className={classes.vlanSelect}>
               <SelectVLAN
                 selectedRegionID={props.selectedRegionID}
-                selectedVlanID={props.selectedVlanID}
+                selectedVlanIDs={props.selectedVlanIDs}
                 handleSelectVLAN={handleVlanChange}
                 error={vlanError}
               />

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -134,7 +134,7 @@ interface Props {
   resetCreationState: () => void;
   setBackupID: (id: number) => void;
   showGeneralError?: boolean;
-  setVlanID: (id: number | null) => void;
+  setVlanID: (ids: number[]) => void;
 }
 
 const errorMap = [
@@ -603,7 +603,7 @@ export class LinodeCreate extends React.PureComponent<
             disabled={userCannotCreateLinode}
             hidePrivateIP={this.props.createType === 'fromLinode'}
             changeSelectedVLAN={this.props.setVlanID}
-            selectedVlanID={this.props.selectedVlanID}
+            selectedVlanIDs={this.props.selectedVlanIDs}
             selectedRegionID={this.props.selectedRegionID}
             vlanError={hasErrorFor.interfaces}
           />

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.test.tsx
@@ -1,0 +1,25 @@
+import { getInterfacePayload } from './LinodeCreateContainer';
+
+describe('Linode Create container', () => {
+  describe('interface payload helper method', () => {
+    it('should handle a single VLAN correctly', () => {
+      const ids = [1];
+      const payload = getInterfacePayload(ids);
+      expect(payload).toEqual({
+        eth0: { type: 'default' },
+        eth1: { type: 'additional', vlan_id: ids[0] }
+      });
+    });
+
+    it('should handle multiple VLANs correctly', () => {
+      const ids = [1, 2, 3];
+      const payload = getInterfacePayload(ids);
+      expect(payload).toEqual({
+        eth0: { type: 'default' },
+        eth1: { type: 'additional', vlan_id: ids[0] },
+        eth2: { type: 'additional', vlan_id: ids[1] },
+        eth3: { type: 'additional', vlan_id: ids[2] }
+      });
+    });
+  });
+});

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -104,7 +104,7 @@ interface State {
   appInstancesLoading: boolean;
   appInstancesError?: string;
   disabledClasses?: LinodeTypeClass[];
-  selectedVlanID: number | null;
+  selectedVlanIDs: number[];
 }
 
 type CombinedProps = WithSnackbarProps &
@@ -140,7 +140,7 @@ const defaultState: State = {
   formIsSubmitting: false,
   errors: undefined,
   appInstancesLoading: false,
-  selectedVlanID: null
+  selectedVlanIDs: []
 };
 
 const getDisabledClasses = (regionID: string, regions: Region[] = []) => {
@@ -339,8 +339,8 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
 
   setUDFs = (udfs: any) => this.setState({ udfs });
 
-  setVlanID = (vlanID: number | null) => {
-    this.setState({ selectedVlanID: vlanID });
+  setVlanID = (vlanIDs: number[]) => {
+    this.setState({ selectedVlanIDs: vlanIDs });
   };
 
   generateLabel = () => {
@@ -424,11 +424,17 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
      * will be displayed, even if other required fields are missing.
      */
 
-    if (this.state.selectedVlanID) {
-      payload.interfaces = {
-        eth0: { type: 'default' },
-        eth1: { type: 'additional', vlan_id: this.state.selectedVlanID }
-      };
+    if (this.state.selectedVlanIDs.length > 0) {
+      payload.interfaces = this.state.selectedVlanIDs.reduce(
+        (acc, thisVLAN, currentIdx) => {
+          const slot = `eth${currentIdx + 1}`;
+          return {
+            ...acc,
+            [slot]: { type: 'additional', vlan_id: thisVLAN }
+          };
+        },
+        { eth0: { type: 'default' } }
+      );
     }
 
     if (payload.root_pass) {

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -3,6 +3,7 @@ import {
   cloneLinode,
   CreateLinodeRequest,
   Linode,
+  LinodeInterfacePayload,
   LinodeTypeClass
 } from '@linode/api-v4/lib/linodes';
 import { Region } from '@linode/api-v4/lib/regions';
@@ -425,16 +426,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
      */
 
     if (this.state.selectedVlanIDs.length > 0) {
-      payload.interfaces = this.state.selectedVlanIDs.reduce(
-        (acc, thisVLAN, currentIdx) => {
-          const slot = `eth${currentIdx + 1}`;
-          return {
-            ...acc,
-            [slot]: { type: 'additional', vlan_id: thisVLAN }
-          };
-        },
-        { eth0: { type: 'default' } }
-      );
+      payload.interfaces = getInterfacePayload(this.state.selectedVlanIDs);
     }
 
     if (payload.root_pass) {
@@ -795,3 +787,17 @@ const handleAnalytics = (
 
   sendCreateLinodeEvent(eventAction, eventLabel);
 };
+
+export const getInterfacePayload = (
+  vlanIDs: number[]
+): Record<string, LinodeInterfacePayload> =>
+  vlanIDs.reduce(
+    (acc, thisVLAN, currentIdx) => {
+      const slot = `eth${currentIdx + 1}`;
+      return {
+        ...acc,
+        [slot]: { type: 'additional', vlan_id: thisVLAN }
+      };
+    },
+    { eth0: { type: 'default' } }
+  );

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectVLAN.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectVLAN.tsx
@@ -22,13 +22,13 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 export interface Props {
   selectedRegionID?: string;
-  selectedVlanID: number | null;
+  selectedVlanIDs: number[];
   error?: string;
-  handleSelectVLAN: (vlanID: number | null) => void;
+  handleSelectVLAN: (vlanIDs: number[]) => void;
 }
 
 export const SelectVLAN: React.FC<Props> = props => {
-  const { error, selectedRegionID, selectedVlanID, handleSelectVLAN } = props;
+  const { error, selectedRegionID, selectedVlanIDs, handleSelectVLAN } = props;
   useReduxLoad(['vlans']);
   const classes = useStyles();
 
@@ -39,7 +39,7 @@ export const SelectVLAN: React.FC<Props> = props => {
      * only be attached to Linodes in the same data
      * center.
      */
-    handleSelectVLAN(null);
+    handleSelectVLAN([]);
   }, [selectedRegionID, handleSelectVLAN]);
 
   const disabled = !Boolean(selectedRegionID);
@@ -59,9 +59,14 @@ export const SelectVLAN: React.FC<Props> = props => {
       }));
   }, [selectedRegionID, vlans]);
 
-  const onChange = (selected: Item<number> | null) => {
-    const value = selected === null ? selected : selected.value;
-    handleSelectVLAN(value);
+  const selected = selectedVlanIDs.map(thisID => ({
+    label: vlans.itemsById[thisID].description,
+    value: thisID
+  }));
+
+  const onChange = (selected: Item<number>[]) => {
+    const ids = selected.map(i => i.value);
+    handleSelectVLAN(ids);
   };
 
   const vlanError = vlans.error.read
@@ -78,11 +83,9 @@ export const SelectVLAN: React.FC<Props> = props => {
       </Typography>
       <Select
         options={options}
+        isMulti
         isClearable
-        value={
-          options.find(thisOption => thisOption.value === selectedVlanID) ??
-          null
-        }
+        value={selected}
         label={'Select a VLAN'}
         aria-describedby={helperText}
         hideLabel

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectVLAN.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectVLAN.tsx
@@ -79,20 +79,20 @@ export const SelectVLAN: React.FC<Props> = props => {
         <strong>Virtual LAN</strong>
       </Typography>
       <Typography className={classes.helperText}>
-        Attach the new Linode to a virtual LAN.
+        Attach the new Linode to one or more virtual LANs.
       </Typography>
       <Select
         options={options}
         isMulti
         isClearable
         value={selected}
-        label={'Select a VLAN'}
+        label={'Select VLANs'}
         aria-describedby={helperText}
         hideLabel
         disabled={disabled}
         errorText={error || vlanError}
         noOptionsMessage={() => 'No VLANs available in the selected region.'}
-        placeholder="Select a VLAN"
+        placeholder="Select one or more VLANs"
         onChange={onChange}
       />
     </>

--- a/packages/manager/src/features/linodes/LinodesCreate/types.ts
+++ b/packages/manager/src/features/linodes/LinodesCreate/types.ts
@@ -126,8 +126,8 @@ export interface BaseFormStateAndHandlers {
   updateTags: (tags: Tag[]) => void;
   resetCreationState: () => void;
   resetSSHKeys: () => void;
-  selectedVlanID: number | null;
-  setVlanID: (id: number | null) => void;
+  selectedVlanIDs: number[];
+  setVlanID: (ids: number[]) => void;
 }
 
 /**


### PR DESCRIPTION
## Description

For most customers the max number of VLANs you can attach to a Linode is 2, and the payload is not what you'd expect (not a list of VLAN ids) so I made this select a single-value dropdown.

Feedback received is that this is bad, so this PR updates it to a multi select.

Known issues:
- I'm relying on the API to throw an error if the user selects too many VLANs. More than 2 is rare, but it's configured on the customer record so we don't know for sure until we fire. I brought this up with Anton as a case for exposing thing limits as we're considering elsewhere.
- The error message in this case is unhelpful. I'd go so far as to call it a bug (it includes the Linode ID, even though the Linode doesn't exist yet); for this reason, I'm going to follow up on their end rather than add error intercepting logic on our end.
- Multiple VLANs makes creating a Linode sloooow.
