### PR TITLE
Fix "null" progress on CMR Dashboard

### DIFF
--- a/packages/manager/src/features/NotificationCenter/NotificationData/RenderEvent.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/RenderEvent.tsx
@@ -93,7 +93,7 @@ export const RenderEvent: React.FC<Props> = props => {
 };
 
 export const formatTimeRemaining = (time: string | null) => {
-  if (!time || time === null) {
+  if (!time) {
     return null;
   }
 

--- a/packages/manager/src/features/NotificationCenter/NotificationData/RenderEvent.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/RenderEvent.tsx
@@ -46,8 +46,11 @@ export const RenderEvent: React.FC<Props> = props => {
   }
 
   const completed = event.percent_complete === 100;
-  const timeRemaining = event.time_remaining
-    ? ` (~${formatTimeRemaining(event.time_remaining)})`
+
+  const parsedTimeRemaining = formatTimeRemaining(event.time_remaining);
+
+  const formattedTimeRemaining = parsedTimeRemaining
+    ? ` (~${parsedTimeRemaining})`
     : null;
 
   const duration = formatEventSeconds(event.duration);
@@ -69,7 +72,7 @@ export const RenderEvent: React.FC<Props> = props => {
         {` `}
         {message}
         {/** duration and timeRemaining will never overlap, but check just in case */}
-        {!completed ? timeRemaining : null}
+        {!completed ? formattedTimeRemaining : null}
         {completed
           ? event.status === 'failed'
             ? ` (failed after ${duration})`
@@ -89,7 +92,11 @@ export const RenderEvent: React.FC<Props> = props => {
   );
 };
 
-export const formatTimeRemaining = (time: string) => {
+export const formatTimeRemaining = (time: string | null) => {
+  if (!time || time === null) {
+    return null;
+  }
+
   try {
     const [hours, minutes, seconds] = time.split(':').map(Number);
     if (


### PR DESCRIPTION
## Description

Spotted by @DevDW here: https://github.com/linode/manager/pull/7041#pullrequestreview-517073193

To reproduce: 

- Kick off a Linode Resize
- Watch the Dashboard
- When the event is almost finished, you'll see `(~null)` in the progress display

To fix, I moved some things around to check for `null`.
