### PR TITLE
Remove default value for IP range and mark Region as required

### DIFF
--- a/packages/manager/src/components/EnhancedSelect/__mocks__/Select.tsx
+++ b/packages/manager/src/components/EnhancedSelect/__mocks__/Select.tsx
@@ -31,16 +31,17 @@ export default ({
   };
 
   const _options = groupsToItems(options);
+  const _label = label.replace(/\W/g, '');
   return (
     <>
-      <label htmlFor={label} id={`${label}-label`}>
-        {label}
+      <label htmlFor={_label} id={`${_label}-label`}>
+        {_label}
       </label>
       <select
         placeholder={placeholder}
-        name={label}
+        name={_label}
         data-testid="select"
-        aria-labelledby={`${label}-label`}
+        aria-labelledby={`${_label}-label`}
         value={value ?? ''}
         onBlur={handleChange}
         onChange={handleChange}

--- a/packages/manager/src/features/Vlans/CreateVLANDialog/CreateVLANDialog.tsx
+++ b/packages/manager/src/features/Vlans/CreateVLANDialog/CreateVLANDialog.tsx
@@ -58,7 +58,7 @@ export const CreateVLANDialog: React.FC<{}> = _ => {
   const { resetForm, ...formik } = useFormik({
     initialValues: {
       description: '',
-      cidr_block: '10.0.0.0/24',
+      cidr_block: '',
       region: '',
       linodes: []
     },
@@ -161,12 +161,13 @@ export const CreateVLANDialog: React.FC<{}> = _ => {
       <form className={classes.form} onSubmit={formik.handleSubmit}>
         <div className={classes.formSection}>
           <RegionSelect
-            label={'Region'}
+            label={'Region (required)'}
             placeholder={'Regions'}
             errorText={formik.errors.region}
             handleSelection={handleRegionSelect}
             regions={regionsWithVLANS}
             selectedID={formik.values.region}
+            required
           />
         </div>
         <div className={classes.formSection} data-testid="label-input">


### PR DESCRIPTION
## Description

Feedback from stakeholders was that the IP range field when creating a VLAN looked like it was required; we were asked to make it clear that it was optional. I cleared the default value and marked Region, the only actual required field, as (required).
