### PR TITLE
[CMR] Remove Linode status filter hover transition

### DIFF
--- a/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.styles.ts
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.styles.ts
@@ -46,6 +46,7 @@ const styles = (theme: Theme) =>
       ...theme.applyStatusPillStyles,
       paddingTop: '0px !important',
       paddingBottom: '0px !important',
+      transition: 'none',
       '&:hover, &:focus, &:active': {
         backgroundColor: theme.bg.chipActive
       }


### PR DESCRIPTION
Remove the transition when hovering over the Linode status filters at the top of the table