### PR TITLE
Add warning when attaching Linodes to a VLAN that the Linode must be rebooted

### DIFF
--- a/packages/manager/src/features/Vlans/AttachVLANDrawer/AttachVLANDrawer.tsx
+++ b/packages/manager/src/features/Vlans/AttachVLANDrawer/AttachVLANDrawer.tsx
@@ -56,6 +56,10 @@ export const AttachVLANDrawer: React.FC<Props> = props => {
   return (
     <Drawer title="Attach a Linode" open={isOpen} onClose={onClose}>
       {generalError && <Notice error text={generalError} />}
+      <Notice
+        warning
+        text="Please note that any newly attached Linode(s) must be rebooted for changes to take effect."
+      />
       <LinodeMultiSelect
         filteredLinodes={linodes}
         handleChange={(selected: number[]) => setSelectedLinodes(selected)}


### PR DESCRIPTION
## Description

Adding a warning notice to the linode attach drawer for VLANs. Please feel free to suggest copy/placement changes.

## Type of Change
- Non breaking change ('update')

