### PR TITLE
M3-4603: Refinements for Create Database modal

### DIFF
--- a/packages/manager/src/features/Databases/CreateDatabaseDialog/CreateDatabaseDialog.tsx
+++ b/packages/manager/src/features/Databases/CreateDatabaseDialog/CreateDatabaseDialog.tsx
@@ -62,7 +62,10 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginRight: theme.spacing(4.5)
   },
   chooseTime: {
-    marginRight: theme.spacing(2)
+    marginRight: theme.spacing(2),
+    [theme.breakpoints.up('md')]: {
+      paddingLeft: '2.25em'
+    }
   }
 }));
 

--- a/packages/manager/src/features/Databases/CreateDatabaseDialog/CreateDatabaseDialog.tsx
+++ b/packages/manager/src/features/Databases/CreateDatabaseDialog/CreateDatabaseDialog.tsx
@@ -95,6 +95,17 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
     });
   };
 
+  // Function for selecting random maintenance window for users that they can choose to clear/change if desired (if maintenance window not specified, a random one is assigned on backend)
+  const generateRandomMaintenanceSelection = (
+    optionsList: SelectMenuOptions[]
+  ) => {
+    const randomSelection = Math.floor(Math.random() * optionsList.length - 1);
+
+    return randomSelection >= 0
+      ? optionsList[randomSelection].value
+      : optionsList[0].value;
+  };
+
   // Maintenance Day
   const daySelection = [
     'Sunday',
@@ -186,22 +197,38 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
     formik.setFieldValue('tags', tagStrings);
   };
 
-  // Preselect random maintenance window for users that they can choose to clear/change if desired (if maintenance window not specified, a random one is assigned on backend)
-  const generateRandomMaintenanceSelection = (
-    optionsList: SelectMenuOptions[],
-    formikFieldToSet?: string
-  ) => {
-    const randomSelection = Math.floor(Math.random() * optionsList.length - 1);
+  const [randomMaintenanceDay, setRandomMaintenanceDay] = React.useState<
+    string | undefined
+  >(undefined);
+  const [randomMaintenanceWindow, setRandomMaintenanceWindow] = React.useState<
+    string | undefined
+  >(undefined);
 
-    // @todo: Set the Formik value in here also.
+  React.useEffect(() => {
+    if (!randomMaintenanceDay && !randomMaintenanceWindow) {
+      const randomDay = generateRandomMaintenanceSelection(daySelection);
+      const randomWindow = generateRandomMaintenanceSelection(windowSelection);
 
-    return optionsList[randomSelection];
-  };
+      setRandomMaintenanceDay(randomDay);
+      formik.setFieldValue('maintenance_schedule.day', randomDay);
+
+      setRandomMaintenanceWindow(randomWindow);
+      formik.setFieldValue('maintenance_schedule.window', randomWindow);
+    }
+  }, [
+    daySelection,
+    windowSelection,
+    randomMaintenanceDay,
+    randomMaintenanceWindow,
+    formik
+  ]);
 
   /** Reset errors and state when the modal opens */
   React.useEffect(() => {
     if (context.isOpen) {
       resetForm();
+      setRandomMaintenanceDay(undefined);
+      setRandomMaintenanceWindow(undefined);
     }
   }, [context.isOpen, resetForm]);
 
@@ -325,8 +352,8 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
               <FormControl fullWidth className={classes.chooseDay}>
                 <Select
                   options={daySelection}
-                  defaultValue={generateRandomMaintenanceSelection(
-                    daySelection
+                  defaultValue={daySelection.find(
+                    ({ value }) => value === randomMaintenanceDay
                   )}
                   onChange={handleDaySelection}
                   name="maintenanceDay"
@@ -343,8 +370,8 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
               <FormControl fullWidth className={classes.chooseTime}>
                 <Select
                   options={windowSelection}
-                  defaultValue={generateRandomMaintenanceSelection(
-                    windowSelection
+                  defaultValue={windowSelection.find(
+                    ({ value }) => value === randomMaintenanceWindow
                   )}
                   onChange={handleWindowSelection}
                   name="maintenanceWindow"

--- a/packages/manager/src/features/Databases/CreateDatabaseDialog/CreateDatabaseDialog.tsx
+++ b/packages/manager/src/features/Databases/CreateDatabaseDialog/CreateDatabaseDialog.tsx
@@ -76,9 +76,13 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
   const timezone = useTimezone();
   const { createDatabase } = useDatabases();
 
-  const regionsWithDatabases: ExtendedRegion[] = regions.entities
-    //   .filter(thisRegion => thisRegion.capabilities.includes('Databases')) // temporarily commented out until Capabilities is squared away
-    .map(r => ({ ...r, display: dcDisplayNames[r.id] }));
+  const regionsWithDatabases: ExtendedRegion[] = React.useMemo(() => {
+    return (
+      regions.entities
+        //   .filter(thisRegion => thisRegion.capabilities.includes('Databases')) // temporarily commented out until Capabilities is squared away
+        .map(r => ({ ...r, display: dcDisplayNames[r.id] }))
+    );
+  }, [regions]);
 
   const handleRegionSelect = (regionID: string) => {
     formik.setFieldValue('region', regionID);
@@ -127,11 +131,15 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
     return windows;
   };
 
-  const maintenanceWindowSelectOptions = initWindows(timezone);
+  const maintenanceWindowSelectOptions = React.useMemo(
+    () => initWindows(timezone),
+    [timezone]
+  );
   const maintenanceWindowHelperText =
     'Select the time of day you’d prefer maintenance to occur. On Standard Availability plans, there may be downtime during this window.';
-  const windowSelection = structureOptionsForSelect(
-    maintenanceWindowSelectOptions
+  const windowSelection = React.useMemo(
+    () => structureOptionsForSelect(maintenanceWindowSelectOptions),
+    [maintenanceWindowSelectOptions]
   );
 
   const handleWindowSelection = (item: Item) => {

--- a/packages/manager/src/features/Databases/CreateDatabaseDialog/CreateDatabaseDialog.tsx
+++ b/packages/manager/src/features/Databases/CreateDatabaseDialog/CreateDatabaseDialog.tsx
@@ -94,9 +94,7 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
   };
 
   // Function for selecting random maintenance window for users that they can choose to clear/change if desired (if maintenance window not specified, a random one is assigned on backend)
-  const generateRandomMaintenanceSelection = (
-    optionsList: SelectMenuOptions[]
-  ) => {
+  const generateRandomMaintenanceSelection = (optionsList: Item<string>[]) => {
     const randomSelection = Math.floor(Math.random() * optionsList.length - 1);
 
     return randomSelection >= 0
@@ -334,7 +332,7 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
                 <Select
                   options={daySelection}
                   defaultValue={daySelection.find(
-                    ({ value }) => value === randomMaintenanceDay
+                    day => day.value === randomMaintenanceDay
                   )}
                   onChange={handleDaySelection}
                   name="maintenanceDay"
@@ -352,7 +350,7 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
                 <Select
                   options={windowSelection}
                   defaultValue={windowSelection.find(
-                    ({ value }) => value === randomMaintenanceWindow
+                    window => window.value === randomMaintenanceWindow
                   )}
                   onChange={handleWindowSelection}
                   name="maintenanceWindow"
@@ -405,8 +403,3 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
 };
 
 export default React.memo(CreateDatabaseDialog);
-
-interface SelectMenuOptions {
-  label: string;
-  value: string;
-}

--- a/packages/manager/src/features/Databases/CreateDatabaseDialog/CreateDatabaseDialog.tsx
+++ b/packages/manager/src/features/Databases/CreateDatabaseDialog/CreateDatabaseDialog.tsx
@@ -106,11 +106,7 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
   }));
 
   const handleDaySelection = (item: Item) => {
-    if (item) {
-      formik.setFieldValue('maintenance_schedule.day', item.value);
-    } else {
-      formik.setFieldValue('maintenance_schedule.day', undefined);
-    }
+    formik.setFieldValue('maintenance_schedule.day', item?.value);
   };
 
   // Maintenance Window
@@ -139,11 +135,7 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
   );
 
   const handleWindowSelection = (item: Item) => {
-    if (item) {
-      formik.setFieldValue('maintenance_schedule.window', item.value);
-    } else {
-      formik.setFieldValue('maintenance_schedule.window', undefined);
-    }
+    formik.setFieldValue('maintenance_schedule.window', item?.value);
   };
 
   const { databaseTypes } = useDatabaseTypes();
@@ -269,7 +261,7 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
         </div>
         <div className={classes.formSection} data-testid="region-select">
           <RegionSelect
-            label={'Region'}
+            label={'Region (required)'}
             placeholder={' '}
             errorText={formik.errors.region}
             handleSelection={handleRegionSelect}
@@ -290,13 +282,14 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
         <div className={classes.formSection}>
           <PasswordInput
             name="password"
-            label="Root Password"
+            label="MySQL Password"
             type="password"
             data-qa-add-password
             value={formik.values.root_password}
             error={!!formik.errors.root_password}
             errorText={formik.errors.root_password}
             onChange={handlePasswordChange}
+            required
           />
         </div>
         <div

--- a/packages/manager/src/features/Databases/CreateDatabaseDialog/CreateDatabaseDialog.tsx
+++ b/packages/manager/src/features/Databases/CreateDatabaseDialog/CreateDatabaseDialog.tsx
@@ -66,6 +66,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     [theme.breakpoints.up('md')]: {
       paddingLeft: '2.25em'
     }
+  },
+  timeHelperText: {
+    fontSize: '0.8em'
   }
 }));
 
@@ -321,7 +324,7 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
                   isClearable={true}
                   data-qa-item="maintenanceWindow"
                 />
-                <FormHelperText style={{ fontSize: '0.8em' }}>
+                <FormHelperText className={classes.timeHelperText}>
                   Time displayed in {timezone}
                 </FormHelperText>
               </FormControl>

--- a/packages/manager/src/features/Databases/CreateDatabaseDialog/CreateDatabaseDialog.tsx
+++ b/packages/manager/src/features/Databases/CreateDatabaseDialog/CreateDatabaseDialog.tsx
@@ -186,6 +186,18 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
     formik.setFieldValue('tags', tagStrings);
   };
 
+  // Preselect random maintenance window for users that they can choose to clear/change if desired (if maintenance window not specified, a random one is assigned on backend)
+  const generateRandomMaintenanceSelection = (
+    optionsList: SelectMenuOptions[],
+    formikFieldToSet?: string
+  ) => {
+    const randomSelection = Math.floor(Math.random() * optionsList.length - 1);
+
+    // @todo: Set the Formik value in here also.
+
+    return optionsList[randomSelection];
+  };
+
   /** Reset errors and state when the modal opens */
   React.useEffect(() => {
     if (context.isOpen) {
@@ -313,6 +325,9 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
               <FormControl fullWidth className={classes.chooseDay}>
                 <Select
                   options={daySelection}
+                  defaultValue={generateRandomMaintenanceSelection(
+                    daySelection
+                  )}
                   onChange={handleDaySelection}
                   name="maintenanceDay"
                   id="maintenanceDay"
@@ -328,6 +343,9 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
               <FormControl fullWidth className={classes.chooseTime}>
                 <Select
                   options={windowSelection}
+                  defaultValue={generateRandomMaintenanceSelection(
+                    windowSelection
+                  )}
                   onChange={handleWindowSelection}
                   name="maintenanceWindow"
                   id="maintenanceWindow"
@@ -379,3 +397,8 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
 };
 
 export default React.memo(CreateDatabaseDialog);
+
+interface SelectMenuOptions {
+  label: string;
+  value: string;
+}

--- a/packages/manager/src/features/Databases/CreateDatabaseDialog/CreateDatabaseDialog.tsx
+++ b/packages/manager/src/features/Databases/CreateDatabaseDialog/CreateDatabaseDialog.tsx
@@ -83,7 +83,7 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
   }, [regions]);
 
   const handleRegionSelect = (regionID: string) => {
-    formik.setFieldValue('region', regionID);
+    setFieldValue('region', regionID);
   };
 
   const structureOptionsForSelect = (optionsData: string[][]) => {
@@ -94,7 +94,7 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
   };
 
   const handleDaySelection = (item: Item) => {
-    formik.setFieldValue('maintenance_schedule.day', item?.value);
+    setFieldValue('maintenance_schedule.day', item?.value);
   };
 
   // Maintenance Window
@@ -110,7 +110,7 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
   );
 
   const handleWindowSelection = (item: Item) => {
-    formik.setFieldValue('maintenance_schedule.window', item?.value);
+    setFieldValue('maintenance_schedule.window', item?.value);
   };
 
   const { databaseTypes } = useDatabaseTypes();
@@ -120,12 +120,12 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
     context.isOpen
   );
 
-  const [selectedPlanId, setSelectedPlanId] = React.useState<string>('');
-
-  const randomNumberForDaySelection = Math.floor(Math.random() * 6);
+  const randomNumberForDaySelection = Math.floor(
+    Math.random() * (daySelection.length - 1)
+  );
   const randomNumberForWindowSelection = Math.floor(Math.random() * 12);
 
-  const { resetForm, ...formik } = useFormik({
+  const { resetForm, setFieldValue, ...formik } = useFormik({
     initialValues: {
       label: '',
       region: '',
@@ -133,10 +133,10 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
       root_password: '',
       tags: [] as string[],
       maintenance_schedule: {
-        day: daySelection[randomNumberForDaySelection]
-          .value as DatabaseMaintenanceSchedule['day'],
-        window: windowSelection[randomNumberForWindowSelection]
-          .value as DatabaseMaintenanceSchedule['window']
+        day: (daySelection[randomNumberForDaySelection]?.value ??
+          '') as DatabaseMaintenanceSchedule['day'],
+        window: (windowSelection[randomNumberForWindowSelection]?.value ??
+          '') as DatabaseMaintenanceSchedule['window']
       }
     },
     validationSchema: createDatabaseSchema,
@@ -145,17 +145,19 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
   });
 
   const handlePasswordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    formik.setFieldValue('root_password', e.target.value);
+    setFieldValue('root_password', e.target.value);
   };
 
-  const handlePlanChange = (id: string) => {
-    setSelectedPlanId(id);
-    formik.setFieldValue('type', id);
-  };
+  const handlePlanChange = React.useCallback(
+    (id: string) => {
+      setFieldValue('type', id);
+    },
+    [setFieldValue]
+  );
 
   const handleTagChange = (selected: Item[]) => {
     const tagStrings = selected.map(selectedItem => selectedItem.value);
-    formik.setFieldValue('tags', tagStrings);
+    setFieldValue('tags', tagStrings);
   };
 
   /** Reset errors and state when the modal opens */
@@ -255,7 +257,7 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
           <SelectDBPlanPanel
             databasePlans={databaseTypes.data ?? []}
             onPlanSelect={handlePlanChange}
-            selectedPlanId={selectedPlanId}
+            selectedPlanId={formik.values.type}
             errorText={formik.errors.type}
           />
         )}

--- a/packages/manager/src/features/Databases/CreateDatabaseDialog/CreateDatabaseDialog.tsx
+++ b/packages/manager/src/features/Databases/CreateDatabaseDialog/CreateDatabaseDialog.tsx
@@ -56,13 +56,12 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   maintenanceSelectsInner: {
     display: 'inline-block',
-    minWidth: '200px',
     [theme.breakpoints.down('xs')]: {
       display: 'block'
     }
   },
   chooseDay: {
-    marginRight: theme.spacing(2)
+    marginRight: theme.spacing(4.5)
   },
   chooseTime: {
     marginRight: theme.spacing(2)
@@ -337,6 +336,9 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
                   isClearable={true}
                   data-qa-item="maintenanceWindow"
                 />
+                <FormHelperText style={{ fontSize: '0.8em' }}>
+                  Time displayed in {timezone}
+                </FormHelperText>
               </FormControl>
             </div>
           </div>

--- a/packages/manager/src/features/Databases/CreateDatabaseDialog/CreateDatabaseDialog.tsx
+++ b/packages/manager/src/features/Databases/CreateDatabaseDialog/CreateDatabaseDialog.tsx
@@ -5,8 +5,6 @@ import {
 } from '@linode/api-v4/lib/databases/types';
 import { APIError } from '@linode/api-v4/lib/types';
 import { useFormik } from 'formik';
-import { DateTime } from 'luxon';
-import { sortBy } from 'ramda';
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 import Button from 'src/components/Button';
@@ -30,7 +28,7 @@ import { useDatabaseTypes } from 'src/hooks/useDatabaseTypes';
 import { useReduxLoad } from 'src/hooks/useReduxLoad';
 import useRegions from 'src/hooks/useRegions';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
-import { evenizeNumber } from 'src/utilities/evenizeNumber';
+import { initWindows } from 'src/utilities/initWindows';
 import {
   handleFieldErrors,
   handleGeneralErrors
@@ -125,23 +123,6 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
   };
 
   // Maintenance Window
-  const initWindows = (timezone: string) => {
-    let windows = [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22].map(hour => {
-      const start = DateTime.fromObject({ hour, zone: 'utc' }).setZone(
-        timezone
-      );
-      const finish = start.plus({ hours: 2 });
-      return [
-        `${start.toFormat('HH:mm')} - ${finish.toFormat('HH:mm')}`,
-        `W${evenizeNumber(start.setZone('utc').hour)}`
-      ];
-    });
-
-    windows = sortBy<string[]>(window => window[0], windows);
-
-    return windows;
-  };
-
   const maintenanceWindowSelectOptions = React.useMemo(
     () => initWindows(timezone),
     [timezone]

--- a/packages/manager/src/features/Databases/CreateDatabaseDialog/CreateDatabaseDialog.tsx
+++ b/packages/manager/src/features/Databases/CreateDatabaseDialog/CreateDatabaseDialog.tsx
@@ -117,6 +117,7 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
   }));
 
   const handleDaySelection = (item: Item) => {
+    setMaintenanceDay(item?.value as string);
     formik.setFieldValue('maintenance_schedule.day', item?.value);
   };
 
@@ -133,8 +134,16 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
   );
 
   const handleWindowSelection = (item: Item) => {
+    setMaintenanceWindow(item?.value as string);
     formik.setFieldValue('maintenance_schedule.window', item?.value);
   };
+
+  const [maintenanceDay, setMaintenanceDay] = React.useState<
+    string | undefined
+  >(undefined);
+  const [maintenanceWindow, setMaintenanceWindow] = React.useState<
+    string | undefined
+  >(undefined);
 
   const { databaseTypes } = useDatabaseTypes();
   const { _loading } = useReduxLoad(
@@ -176,38 +185,27 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
     formik.setFieldValue('tags', tagStrings);
   };
 
-  const [randomMaintenanceDay, setRandomMaintenanceDay] = React.useState<
-    string | undefined
-  >(undefined);
-  const [randomMaintenanceWindow, setRandomMaintenanceWindow] = React.useState<
-    string | undefined
-  >(undefined);
-
   React.useEffect(() => {
-    if (!randomMaintenanceDay && !randomMaintenanceWindow) {
-      const randomDay = generateRandomMaintenanceSelection(daySelection);
-      const randomWindow = generateRandomMaintenanceSelection(windowSelection);
+    if (context.isOpen && !maintenanceDay && !maintenanceWindow) {
+      setMaintenanceDay(generateRandomMaintenanceSelection(daySelection));
+      formik.setFieldValue('maintenance_schedule.day', maintenanceDay);
 
-      setRandomMaintenanceDay(randomDay);
-      formik.setFieldValue('maintenance_schedule.day', randomDay);
-
-      setRandomMaintenanceWindow(randomWindow);
-      formik.setFieldValue('maintenance_schedule.window', randomWindow);
+      setMaintenanceWindow(generateRandomMaintenanceSelection(windowSelection));
+      formik.setFieldValue('maintenance_schedule.window', maintenanceWindow);
     }
   }, [
+    context.isOpen,
     daySelection,
-    windowSelection,
-    randomMaintenanceDay,
-    randomMaintenanceWindow,
-    formik
+    formik,
+    maintenanceDay,
+    maintenanceWindow,
+    windowSelection
   ]);
 
   /** Reset errors and state when the modal opens */
   React.useEffect(() => {
     if (context.isOpen) {
       resetForm();
-      setRandomMaintenanceDay(undefined);
-      setRandomMaintenanceWindow(undefined);
     }
   }, [context.isOpen, resetForm]);
 
@@ -331,9 +329,7 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
               <FormControl fullWidth className={classes.chooseDay}>
                 <Select
                   options={daySelection}
-                  defaultValue={daySelection.find(
-                    day => day.value === randomMaintenanceDay
-                  )}
+                  value={daySelection.find(day => day.value === maintenanceDay)}
                   onChange={handleDaySelection}
                   name="maintenanceDay"
                   id="maintenanceDay"
@@ -349,8 +345,8 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
               <FormControl fullWidth className={classes.chooseTime}>
                 <Select
                   options={windowSelection}
-                  defaultValue={windowSelection.find(
-                    window => window.value === randomMaintenanceWindow
+                  value={windowSelection.find(
+                    window => window.value === maintenanceWindow
                   )}
                   onChange={handleWindowSelection}
                   name="maintenanceWindow"

--- a/packages/manager/src/features/Databases/CreateDatabaseDialog/CreateDatabaseDialog.tsx
+++ b/packages/manager/src/features/Databases/CreateDatabaseDialog/CreateDatabaseDialog.tsx
@@ -93,31 +93,7 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
     });
   };
 
-  // Function for selecting random maintenance window for users that they can choose to clear/change if desired (if maintenance window not specified, a random one is assigned on backend)
-  const generateRandomMaintenanceSelection = (optionsList: Item<string>[]) => {
-    const randomSelection = Math.floor(Math.random() * optionsList.length - 1);
-
-    return randomSelection >= 0
-      ? optionsList[randomSelection].value
-      : optionsList[0].value;
-  };
-
-  // Maintenance Day
-  const daySelection = [
-    'Sunday',
-    'Monday',
-    'Tuesday',
-    'Wednesday',
-    'Thursday',
-    'Friday',
-    'Saturday'
-  ].map(thisDay => ({
-    label: thisDay,
-    value: thisDay
-  }));
-
   const handleDaySelection = (item: Item) => {
-    setMaintenanceDay(item?.value as string);
     formik.setFieldValue('maintenance_schedule.day', item?.value);
   };
 
@@ -134,16 +110,8 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
   );
 
   const handleWindowSelection = (item: Item) => {
-    setMaintenanceWindow(item?.value as string);
     formik.setFieldValue('maintenance_schedule.window', item?.value);
   };
-
-  const [maintenanceDay, setMaintenanceDay] = React.useState<
-    string | undefined
-  >(undefined);
-  const [maintenanceWindow, setMaintenanceWindow] = React.useState<
-    string | undefined
-  >(undefined);
 
   const { databaseTypes } = useDatabaseTypes();
   const { _loading } = useReduxLoad(
@@ -154,6 +122,9 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
 
   const [selectedPlanId, setSelectedPlanId] = React.useState<string>('');
 
+  const randomNumberForDaySelection = Math.floor(Math.random() * 6);
+  const randomNumberForWindowSelection = Math.floor(Math.random() * 12);
+
   const { resetForm, ...formik } = useFormik({
     initialValues: {
       label: '',
@@ -162,8 +133,10 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
       root_password: '',
       tags: [] as string[],
       maintenance_schedule: {
-        day: '' as DatabaseMaintenanceSchedule['day'],
-        window: '' as DatabaseMaintenanceSchedule['window']
+        day: daySelection[randomNumberForDaySelection]
+          .value as DatabaseMaintenanceSchedule['day'],
+        window: windowSelection[randomNumberForWindowSelection]
+          .value as DatabaseMaintenanceSchedule['window']
       }
     },
     validationSchema: createDatabaseSchema,
@@ -184,23 +157,6 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
     const tagStrings = selected.map(selectedItem => selectedItem.value);
     formik.setFieldValue('tags', tagStrings);
   };
-
-  React.useEffect(() => {
-    if (context.isOpen && !maintenanceDay && !maintenanceWindow) {
-      setMaintenanceDay(generateRandomMaintenanceSelection(daySelection));
-      formik.setFieldValue('maintenance_schedule.day', maintenanceDay);
-
-      setMaintenanceWindow(generateRandomMaintenanceSelection(windowSelection));
-      formik.setFieldValue('maintenance_schedule.window', maintenanceWindow);
-    }
-  }, [
-    context.isOpen,
-    daySelection,
-    formik,
-    maintenanceDay,
-    maintenanceWindow,
-    windowSelection
-  ]);
 
   /** Reset errors and state when the modal opens */
   React.useEffect(() => {
@@ -329,7 +285,9 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
               <FormControl fullWidth className={classes.chooseDay}>
                 <Select
                   options={daySelection}
-                  value={daySelection.find(day => day.value === maintenanceDay)}
+                  value={daySelection.find(
+                    day => day.value === formik.values.maintenance_schedule.day
+                  )}
                   onChange={handleDaySelection}
                   name="maintenanceDay"
                   id="maintenanceDay"
@@ -346,7 +304,8 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
                 <Select
                   options={windowSelection}
                   value={windowSelection.find(
-                    window => window.value === maintenanceWindow
+                    window =>
+                      window.value === formik.values.maintenance_schedule.window
                   )}
                   onChange={handleWindowSelection}
                   name="maintenanceWindow"
@@ -399,3 +358,16 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
 };
 
 export default React.memo(CreateDatabaseDialog);
+
+const daySelection = [
+  'Sunday',
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday'
+].map(thisDay => ({
+  label: thisDay,
+  value: thisDay
+}));

--- a/packages/manager/src/features/Databases/CreateDatabaseDialog/SelectDBPlanPanel.tsx
+++ b/packages/manager/src/features/Databases/CreateDatabaseDialog/SelectDBPlanPanel.tsx
@@ -25,7 +25,7 @@ import { convertMegabytesTo } from 'src/utilities/unitConversions';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
-    // marginTop: theme.spacing(3),
+    backgroundColor: 'transparent',
     width: '100%'
   },
   headingCellContainer: {

--- a/packages/manager/src/features/Databases/CreateDatabaseDialog/SelectDBPlanPanel.tsx
+++ b/packages/manager/src/features/Databases/CreateDatabaseDialog/SelectDBPlanPanel.tsx
@@ -241,4 +241,4 @@ export const SelectDBPlanPanel: React.FC<CombinedProps> = props => {
   );
 };
 
-export default SelectDBPlanPanel;
+export default React.memo(SelectDBPlanPanel);

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsMaintenancePanel.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsMaintenancePanel.tsx
@@ -2,8 +2,6 @@ import { DatabaseMaintenanceSchedule } from '@linode/api-v4/lib/databases/types'
 import { APIError } from '@linode/api-v4/lib/types';
 import FormControl from '@material-ui/core/FormControl';
 import FormHelperText from '@material-ui/core/FormHelperText';
-import { DateTime } from 'luxon';
-import { sortBy } from 'ramda';
 import * as React from 'react';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
@@ -13,7 +11,7 @@ import ExpansionPanel from 'src/components/ExpansionPanel';
 import Notice from 'src/components/Notice';
 import useDatabases from 'src/hooks/useDatabases';
 import { getAPIErrorOrDefault, getErrorMap } from 'src/utilities/errorUtils';
-import { evenizeNumber } from 'src/utilities/evenizeNumber';
+import { initWindows } from 'src/utilities/initWindows';
 import useTimezone from 'src/utilities/useTimezone';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -93,22 +91,6 @@ export const DatabaseSettingsMaintenancePanel: React.FC<CombinedProps> = props =
   };
 
   // Maintenance Window
-  const initWindows = (timezone: string) => {
-    let windows = [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22].map(hour => {
-      const start = DateTime.fromObject({ hour, zone: 'utc' }).setZone(
-        timezone
-      );
-      const finish = start.plus({ hours: 2 });
-      return [
-        `${start.toFormat('HH:mm')} - ${finish.toFormat('HH:mm')}`,
-        `W${evenizeNumber(start.setZone('utc').hour)}`
-      ];
-    });
-
-    windows = sortBy<string[]>(window => window[0], windows);
-    return windows;
-  };
-
   const maintenanceWindowSelectOptions = initWindows(timezone);
   const maintenanceWindowHelperText =
     'Select the time of day you’d prefer maintenance to occur. On Standard Availability plans, there may be downtime during this window.';

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -13,9 +13,8 @@ import {
   Window
 } from '@linode/api-v4/lib/linodes';
 import { APIError } from '@linode/api-v4/lib/types';
-import { DateTime } from 'luxon';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
-import { path, pathOr, sortBy } from 'ramda';
+import { path, pathOr } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
@@ -26,7 +25,6 @@ import VolumeIcon from 'src/assets/addnewmenu/volume.svg';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
-import { evenizeNumber } from 'src/utilities/evenizeNumber';
 import FormControl from 'src/components/core/FormControl';
 import FormHelperText from 'src/components/core/FormHelperText';
 import Paper from 'src/components/core/Paper';
@@ -73,6 +71,7 @@ import { withLinodeDetailContext } from '../linodeDetailContext';
 import LinodePermissionsError from '../LinodePermissionsError';
 import BackupTableRow from './BackupTableRow';
 import RestoreToLinodeDrawer from './RestoreToLinodeDrawer';
+import { initWindows } from 'src/utilities/initWindows';
 
 import DestructiveSnapshotDialog from './DestructiveSnapshotDialog';
 
@@ -266,30 +265,11 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
     this.eventSubscription.unsubscribe();
   }
 
-  initWindows(timezone: string) {
-    let windows = [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22].map(hour => {
-      const start = DateTime.fromObject({ hour, zone: 'utc' }).setZone(
-        timezone
-      );
-      const finish = start.plus({ hours: 2 });
-      return [
-        `${start.toFormat('HH:mm')} - ${finish.toFormat('HH:mm')}`,
-        `W${evenizeNumber(start.setZone('utc').hour)}`
-      ];
-    });
-
-    windows = sortBy<string[]>(window => window[0], windows);
-
-    windows.unshift(['Choose a time', 'Scheduling']);
-
-    return windows;
-  }
-
   constructor(props: CombinedProps) {
     super(props);
 
     /* TODO: use the timezone from the user's profile */
-    this.windows = this.initWindows(this.props.timezone);
+    this.windows = initWindows(this.props.timezone, true);
 
     this.days = [
       ['Choose a day', 'Scheduling'],

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup_CMR.tsx
@@ -12,9 +12,8 @@ import {
   Window
 } from '@linode/api-v4/lib/linodes';
 import { APIError } from '@linode/api-v4/lib/types';
-import { DateTime } from 'luxon';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
-import { pathOr, sortBy } from 'ramda';
+import { pathOr } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
@@ -24,7 +23,6 @@ import { Subscription } from 'rxjs/Subscription';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
-import { evenizeNumber } from 'src/utilities/evenizeNumber';
 import FormControl from 'src/components/core/FormControl';
 import FormHelperText from 'src/components/core/FormHelperText';
 import Paper from 'src/components/core/Paper';
@@ -60,14 +58,14 @@ import { getAPIErrorOrDefault, getErrorMap } from 'src/utilities/errorUtils';
 import { formatDate } from 'src/utilities/formatDate';
 import { sendBackupsDisabledEvent } from 'src/utilities/ga';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
+import { initWindows } from 'src/utilities/initWindows';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import { withLinodeDetailContext } from '../linodeDetailContext';
 import LinodePermissionsError from '../LinodePermissionsError';
 import BackupsPlaceholder from './BackupsPlaceholder';
 import BackupTableRow from './BackupTableRow';
-import RestoreToLinodeDrawer from './RestoreToLinodeDrawer';
-
 import DestructiveSnapshotDialog from './DestructiveSnapshotDialog';
+import RestoreToLinodeDrawer from './RestoreToLinodeDrawer';
 
 type ClassNames =
   | 'paper'
@@ -269,30 +267,11 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
     this.eventSubscription.unsubscribe();
   }
 
-  initWindows(timezone: string) {
-    let windows = [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22].map(hour => {
-      const start = DateTime.fromObject({ hour, zone: 'utc' }).setZone(
-        timezone
-      );
-      const finish = start.plus({ hours: 2 });
-      return [
-        `${start.toFormat('HH:mm')} - ${finish.toFormat('HH:mm')}`,
-        `W${evenizeNumber(start.setZone('utc').hour)}`
-      ];
-    });
-
-    windows = sortBy<string[]>(window => window[0], windows);
-
-    windows.unshift(['Choose a time', 'Scheduling']);
-
-    return windows;
-  }
-
   constructor(props: CombinedProps) {
     super(props);
 
     /* TODO: use the timezone from the user's profile */
-    this.windows = this.initWindows(this.props.timezone);
+    this.windows = initWindows(this.props.timezone, true);
 
     this.days = [
       ['Choose a day', 'Scheduling'],

--- a/packages/manager/src/utilities/initWindows.test.ts
+++ b/packages/manager/src/utilities/initWindows.test.ts
@@ -1,0 +1,16 @@
+import { initWindows } from './initWindows';
+
+const timezone1 = 'America/New_York';
+const timezone2 = 'Europe/London';
+
+describe('initWindows', () => {
+  it('should have "Choose a Time" as the first option if the "unshift" argument is true', () => {
+    expect(initWindows(timezone1, true)[0][0]).toEqual('Choose a time');
+    expect(initWindows(timezone1, true)).toHaveLength(13); // Twelve 2-hour windows, plus the 'Choose a time' element
+  });
+
+  it('should not have "Choose a Time" as the first option if the "unshift" argument is not true', () => {
+    expect(initWindows(timezone2)[0][0]).not.toEqual('Choose a time');
+    expect(initWindows(timezone2)).toHaveLength(12);
+  });
+});

--- a/packages/manager/src/utilities/initWindows.ts
+++ b/packages/manager/src/utilities/initWindows.ts
@@ -1,0 +1,22 @@
+import { DateTime } from 'luxon';
+import { sortBy } from 'ramda';
+import { evenizeNumber } from './evenizeNumber';
+
+export const initWindows = (timezone: string, unshift?: boolean) => {
+  let windows = [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22].map(hour => {
+    const start = DateTime.fromObject({ hour, zone: 'utc' }).setZone(timezone);
+    const finish = start.plus({ hours: 2 });
+    return [
+      `${start.toFormat('HH:mm')} - ${finish.toFormat('HH:mm')}`,
+      `W${evenizeNumber(start.setZone('utc').hour)}`
+    ];
+  });
+
+  windows = sortBy<string[]>(window => window[0], windows);
+
+  if (unshift) {
+    windows.unshift(['Choose a time', 'Scheduling']);
+  }
+
+  return windows;
+};


### PR DESCRIPTION
## Description
Follow-up to https://github.com/linode/manager/pull/7026. Various improvements and cleanups for the Create Database modal

## Type of Change
- Non breaking change ('update', 'change')

## To-Do:
- [x] Helper text for Maintenance Time of Day field
- [x] initWindows refactor, create utility file
- [x] Memoization where appropriate to speed up form
- [x] Terser lines
- [x] TypeScript tweaks (?)
- [x] Demo feedback: indicate Required fields
- [x] Demo feedback: Rename "Root Password" label to "MySQL Password"
