### PR TITLE
M3-4592 Fix:  IP popover bug

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/AddIPDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/AddIPDrawer.tsx
@@ -121,10 +121,10 @@ const AddIPDrawer: React.FC<CombinedProps> = props => {
     </Button>
   );
 
-  const _tooltipCopy = selected
+  const _tooltipCopy = disabled
     ? readOnly
       ? 'You do not have permission to modify this Linode.'
-      : tooltipCopy[selected]
+      : tooltipCopy[selected ?? '']
     : null;
 
   return (

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/AddIPDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/AddIPDrawer.tsx
@@ -121,11 +121,12 @@ const AddIPDrawer: React.FC<CombinedProps> = props => {
     </Button>
   );
 
-  const _tooltipCopy = disabled
-    ? readOnly
-      ? 'You do not have permission to modify this Linode.'
-      : tooltipCopy[selected ?? '']
-    : null;
+  const _tooltipCopy =
+    disabled && selected
+      ? readOnly
+        ? 'You do not have permission to modify this Linode.'
+        : tooltipCopy[selected]
+      : null;
 
   return (
     <Drawer open={open} onClose={onClose} title="Add an IP Address">


### PR DESCRIPTION
## Description

Cleaned up some boolean logic in AddIPDrawer. There was a case (IPv6 was selected
in the dropdown, the user did not already have an IPv6 address) where an incorrect
tooltip was displayed ("This Linode already has a private IPv6 address).

## Note to Reviewers

Please check all paths:

- restricted user w/o IPv6 on the Linode
- normal user with IPv6
- normal user without IPv6
- All of the above with the select unselected
