### PR TITLE
M3-4006 Add: progress bar to LinodeDiskRow when resizing

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskRow.tsx
@@ -60,7 +60,9 @@ export const LinodeDiskRow: React.FC<Props> = props => {
   } = props;
 
   const resizeEvent = inProgressEvents.find(
-    thisEvent => thisEvent.secondary_entity?.id === disk.id
+    thisEvent =>
+      thisEvent.secondary_entity?.id === disk.id &&
+      ['disk_create', 'disk_resize'].includes(thisEvent.action)
   );
 
   return (

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskRow.tsx
@@ -1,0 +1,72 @@
+import { Disk } from '@linode/api-v4/lib/linodes';
+import * as React from 'react';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import TableCell from 'src/components/TableCell/TableCell_CMR';
+import TableRow from 'src/components/TableRow/TableRow_CMR';
+import LinodeDiskActionMenu from './LinodeDiskActionMenu_CMR';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  diskLabel: {
+    width: '23%'
+  },
+  diskType: {
+    width: '8%'
+  },
+  diskSize: {
+    width: '9%'
+  },
+  actionMenu: {
+    paddingTop: 0,
+    paddingBottom: 0,
+    '&.MuiTableCell-root': {
+      paddingRight: 0
+    }
+  }
+}));
+
+interface Props {
+  disk: Disk;
+  linodeId?: number;
+  linodeStatus: string;
+  readOnly: boolean;
+  onRename: () => void;
+  onResize: () => void;
+  onImagize: () => void;
+  onDelete: () => void;
+}
+
+export const LinodeDiskRow: React.FC<Props> = props => {
+  const classes = useStyles();
+  const {
+    disk,
+    linodeId,
+    onDelete,
+    onImagize,
+    onRename,
+    onResize,
+    readOnly
+  } = props;
+
+  return (
+    <TableRow data-qa-disk={disk.label}>
+      <TableCell className={classes.diskLabel}>{disk.label}</TableCell>
+      <TableCell className={classes.diskType}>{disk.filesystem}</TableCell>
+      <TableCell className={classes.diskSize}>{disk.size} MB</TableCell>
+      <TableCell className={classes.actionMenu}>
+        <LinodeDiskActionMenu
+          linodeStatus={status || 'offline'}
+          linodeId={linodeId}
+          diskId={disk.id}
+          label={disk.label}
+          onRename={onRename}
+          onResize={onResize}
+          onImagize={onImagize}
+          onDelete={onDelete}
+          readOnly={readOnly}
+        />
+      </TableCell>
+    </TableRow>
+  );
+};
+
+export default React.memo(LinodeDiskRow);

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskRow.tsx
@@ -1,5 +1,6 @@
 import { Disk } from '@linode/api-v4/lib/linodes';
 import * as React from 'react';
+import BarPercent from 'src/components/BarPercent/BarPercent_CMR';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import TableCell from 'src/components/TableCell/TableCell_CMR';
 import TableRow from 'src/components/TableRow/TableRow_CMR';
@@ -7,13 +8,13 @@ import LinodeDiskActionMenu from './LinodeDiskActionMenu_CMR';
 
 const useStyles = makeStyles((theme: Theme) => ({
   diskLabel: {
-    width: '23%'
+    width: '20%'
   },
   diskType: {
-    width: '8%'
+    width: '10%'
   },
   diskSize: {
-    width: '9%'
+    width: '30%'
   },
   actionMenu: {
     paddingTop: 0,
@@ -47,11 +48,23 @@ export const LinodeDiskRow: React.FC<Props> = props => {
     readOnly
   } = props;
 
+  const isResizing = true;
+
   return (
     <TableRow data-qa-disk={disk.label}>
       <TableCell className={classes.diskLabel}>{disk.label}</TableCell>
       <TableCell className={classes.diskType}>{disk.filesystem}</TableCell>
-      <TableCell className={classes.diskSize}>{disk.size} MB</TableCell>
+
+      <TableCell className={classes.diskSize}>
+        {isResizing ? (
+          <div>
+            Resizing ({25}%)
+            <BarPercent max={100} value={100 ?? 0} rounded narrow />
+          </div>
+        ) : (
+          `${disk.size} MB`
+        )}
+      </TableCell>
       <TableCell className={classes.actionMenu}>
         <LinodeDiskActionMenu
           linodeStatus={status || 'offline'}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskRow.tsx
@@ -4,6 +4,7 @@ import BarPercent from 'src/components/BarPercent/BarPercent_CMR';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import TableCell from 'src/components/TableCell/TableCell_CMR';
 import TableRow from 'src/components/TableRow/TableRow_CMR';
+import useEvents from 'src/hooks/useEvents';
 import LinodeDiskActionMenu from './LinodeDiskActionMenu_CMR';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -22,6 +23,15 @@ const useStyles = makeStyles((theme: Theme) => ({
     '&.MuiTableCell-root': {
       paddingRight: 0
     }
+  },
+  progressBar: {
+    display: 'flex',
+    flexFlow: 'row nowrap',
+    alignItems: 'center'
+  },
+  bar: {
+    paddingLeft: theme.spacing(),
+    width: 250
   }
 }));
 
@@ -38,6 +48,7 @@ interface Props {
 
 export const LinodeDiskRow: React.FC<Props> = props => {
   const classes = useStyles();
+  const { inProgressEvents } = useEvents();
   const {
     disk,
     linodeId,
@@ -48,7 +59,9 @@ export const LinodeDiskRow: React.FC<Props> = props => {
     readOnly
   } = props;
 
-  const isResizing = true;
+  const resizeEvent = inProgressEvents.find(
+    thisEvent => thisEvent.secondary_entity?.id === disk.id
+  );
 
   return (
     <TableRow data-qa-disk={disk.label}>
@@ -56,10 +69,16 @@ export const LinodeDiskRow: React.FC<Props> = props => {
       <TableCell className={classes.diskType}>{disk.filesystem}</TableCell>
 
       <TableCell className={classes.diskSize}>
-        {isResizing ? (
-          <div>
-            Resizing ({25}%)
-            <BarPercent max={100} value={100 ?? 0} rounded narrow />
+        {Boolean(resizeEvent) ? (
+          <div className={classes.progressBar}>
+            Resizing ({resizeEvent?.percent_complete}%)
+            <BarPercent
+              className={classes.bar}
+              max={100}
+              value={resizeEvent?.percent_complete ?? 0}
+              rounded
+              narrow
+            />
           </div>
         ) : (
           `${disk.size} MB`

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks_CMR.tsx
@@ -483,7 +483,7 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
       authorized_users: userSSHKeys
         ? userSSHKeys.filter(u => u.selected).map(u => u.username)
         : undefined
-    });
+    }).then(_ => resetEventsPolling());
   };
 
   renameDisk = (label: string) => {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks_CMR.tsx
@@ -40,20 +40,12 @@ import userSSHKeyHoc, {
   UserSSHKeyProps
 } from 'src/features/linodes/userSSHKeyHoc';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
-import LinodeDiskActionMenu from './LinodeDiskActionMenu_CMR';
 import LinodeDiskDrawer from './LinodeDiskDrawer';
+import LinodeDiskRow from './LinodeDiskRow';
 
 import Paginate from 'src/components/Paginate';
 
-type ClassNames =
-  | 'root'
-  | 'headline'
-  | 'addNewWrapper'
-  | 'emptyCell'
-  | 'diskLabel'
-  | 'diskType'
-  | 'diskSize'
-  | 'actionMenu';
+type ClassNames = 'root' | 'headline' | 'addNewWrapper' | 'emptyCell';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -75,22 +67,6 @@ const styles = (theme: Theme) =>
       },
       '&.MuiGrid-item': {
         padding: 5
-      }
-    },
-    diskLabel: {
-      width: '23%'
-    },
-    diskType: {
-      width: '8%'
-    },
-    diskSize: {
-      width: '9%'
-    },
-    actionMenu: {
-      paddingTop: 0,
-      paddingBottom: 0,
-      '&.MuiTableCell-root': {
-        paddingRight: 0
       }
     }
   });
@@ -283,8 +259,8 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
     );
   }
 
-  renderTableContent = (data: Disk[], status?: string) => {
-    const { classes, errors, linodeId, readOnly } = this.props;
+  renderTableContent = (disks: Disk[], status?: string) => {
+    const { errors, linodeId, readOnly } = this.props;
 
     if (errors) {
       return (
@@ -295,29 +271,22 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
       );
     }
 
-    if (data.length === 0) {
+    if (disks.length === 0) {
       return <TableRowEmptyState colSpan={4} />;
     }
 
-    return data.map(disk => (
-      <TableRow key={disk.id} data-qa-disk={disk.label}>
-        <TableCell className={classes.diskLabel}>{disk.label}</TableCell>
-        <TableCell className={classes.diskType}>{disk.filesystem}</TableCell>
-        <TableCell className={classes.diskSize}>{disk.size} MB</TableCell>
-        <TableCell className={classes.actionMenu}>
-          <LinodeDiskActionMenu
-            linodeStatus={status || 'offline'}
-            linodeId={linodeId}
-            diskId={disk.id}
-            label={disk.label}
-            onRename={this.openDrawerForRename(disk)}
-            onResize={this.openDrawerForResize(disk)}
-            onImagize={this.openImagizeDrawer(disk)}
-            onDelete={this.openConfirmDelete(disk)}
-            readOnly={readOnly}
-          />
-        </TableCell>
-      </TableRow>
+    return disks.map(disk => (
+      <LinodeDiskRow
+        key={disk.id}
+        disk={disk}
+        linodeId={linodeId}
+        linodeStatus={status || 'offline'}
+        onRename={this.openDrawerForRename(disk.id)}
+        onResize={this.openDrawerForResize(disk)}
+        onImagize={this.openImagizeDrawer(disk)}
+        onDelete={this.openConfirmDelete(disk)}
+        readOnly={readOnly}
+      />
     ));
   };
 
@@ -551,7 +520,7 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
       });
   };
 
-  openDrawerForRename = ({ id: diskId }: Disk) => () => {
+  openDrawerForRename = (diskId: number) => () => {
     this.setDrawer({
       diskId,
       mode: 'rename',

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -256,7 +256,16 @@ export const handlers = [
       percent_complete: 15,
       entity: { type: 'linode', id: 999, label: 'linode-1' }
     });
-    return res.once(ctx.json(makeResourcePage(events)));
+    const diskResize = eventFactory.build({
+      action: 'disk_resize',
+      percent_complete: 75,
+      secondary_entity: {
+        type: 'disk',
+        id: 1,
+        label: 'my-disk'
+      }
+    });
+    return res.once(ctx.json(makeResourcePage([...events, diskResize])));
   }),
   rest.get('*/support/tickets', (req, res, ctx) => {
     const tickets = supportTicketFactory.buildList(15, { status: 'open' });


### PR DESCRIPTION
## Description

Refactor LinodeDisks so that LinodeDiskRow is a separate component. Each row now looks to see if there's a matching `disk_resize` event for the current disk, and if so shows a progress bar instead of a value for the "size" field.

The acid test, which kicked off this ticket, will be:

1. Create a small Alpine disk
2. Imagize it
3. Create a new disk from the image, specifying a size a bit larger than the image itself.
4. Observe: we display an incorrect size in the table when the creation is complete.

This is because a disk resize is kicked off in the background after the disk is created. Previously we couldn't detect the resize because no events were created, and as of Monday afternoon we still can't do much because the newly-added events don't contain information about which disk they pertain to. But soon we can test this full flow, and avoid displaying incorrect information to users.

## Note to Reviewers

~The code here is ready, we're waiting on the API to merge a related PR to add the `secondary_entity` to `disk_resize` events. You can use the provided mocks to test in the meantime.~

Good to go. Dev account 4 has a small Alpine image already set up (please don't use a public Linode alpine image; it has to be create a Linode/disk from Alpine, then imagize the disk as one of your private images).

Note: even after resetting the polling, there's a second or so where the incorrect disk size is shown. I can't think of a way around this that isn't hacky---the API is explicitly returning a non-final disk size and we're showing it--but I think this is already much better, and the immediate resize makes it clearer what's going on.