### PR TITLE
Events refactor

### DIFF
--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -2,6 +2,7 @@ import { Event } from '@linode/api-v4/lib/account';
 import { path } from 'ramda';
 import { isProductionBuild } from 'src/constants';
 import { reportException } from 'src/exceptionReporting';
+import { capitalizeAllWords } from 'src/utilities/capitalize';
 
 type EventMessageCreator = (e: Event) => string;
 
@@ -635,11 +636,21 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
   }
 };
 
+export const formatEventWithAPIMessage = (e: Event) => {
+  return `${capitalizeAllWords(e.action.replace('_', ' '))}: ${e.message}`;
+};
+
 export default (e: Event): string => {
   const fn = path<EventMessageCreator>(
     [e.action, e.status],
     eventMessageCreators
   );
+
+  if (e.message) {
+    // If the API has specified a message for this event, rely on that instead of
+    // our custom logic.
+    return formatEventWithAPIMessage(e);
+  }
 
   /** we couldn't find the event in our list above */
   if (!fn) {

--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -2,7 +2,6 @@ import { Event } from '@linode/api-v4/lib/account';
 import { path } from 'ramda';
 import { isProductionBuild } from 'src/constants';
 import { reportException } from 'src/exceptionReporting';
-import { capitalizeAllWords } from 'src/utilities/capitalize';
 
 type EventMessageCreator = (e: Event) => string;
 
@@ -637,7 +636,13 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
 };
 
 export const formatEventWithAPIMessage = (e: Event) => {
-  return `${capitalizeAllWords(e.action.replace('_', ' '))}: ${e.message}`;
+  /**
+   * It would be great to format this better, but:
+   * 1. Action names include gotchas that prevent simple capitalization or trimming rules.
+   * 2. Provided API messages *should* make it clear what action they're referring to,
+   *    but we don't have such a guarantee.
+   */
+  return `${e.action}: ${e.message}`;
 };
 
 export default (e: Event): string => {

--- a/packages/manager/src/eventMessageGenerator_CMR.tsx
+++ b/packages/manager/src/eventMessageGenerator_CMR.tsx
@@ -3,6 +3,7 @@ import { Event } from '@linode/api-v4/lib/account';
 import { Linode, LinodeType } from '@linode/api-v4/lib/linodes';
 import Link from 'src/components/Link';
 import { dcDisplayNames } from 'src/constants';
+import { formatEventWithAPIMessage } from 'src/eventMessageGenerator';
 
 export const eventMessageGenerator = (
   e: Event,
@@ -12,6 +13,9 @@ export const eventMessageGenerator = (
   const eventLinode = linodes.find(
     thisLinode => thisLinode.id === e.entity?.id
   );
+  if (e.message) {
+    return formatEventWithAPIMessage(e);
+  }
   switch (e.action) {
     case 'linode_resize':
       const eventLinodeType = types.find(

--- a/packages/manager/src/features/Events/Event.helpers.ts
+++ b/packages/manager/src/features/Events/Event.helpers.ts
@@ -63,11 +63,11 @@ interface Payload {
 export const shouldUpdateEvents = (prevProps: Payload, nextProps: Payload) => {
   return (
     !equals(prevProps.mostRecentEventTime, nextProps.mostRecentEventTime) ||
-    (!equals(prevProps.inProgressEvents, nextProps.inProgressEvents) ||
-      percentCompleteHasUpdated(
-        prevProps.inProgressEvents,
-        nextProps.inProgressEvents
-      ))
+    !equals(prevProps.inProgressEvents, nextProps.inProgressEvents) ||
+    percentCompleteHasUpdated(
+      prevProps.inProgressEvents,
+      nextProps.inProgressEvents
+    )
   );
 };
 

--- a/packages/manager/src/features/Events/EventRow.test.tsx
+++ b/packages/manager/src/features/Events/EventRow.test.tsx
@@ -15,8 +15,7 @@ const props: RowProps = {
   type: 'linode',
   created: '2018-01-01',
   username: null,
-  linkTarget: jest.fn(),
-  eventMessage: null
+  linkTarget: jest.fn()
 };
 
 describe('EventRow component', () => {

--- a/packages/manager/src/features/Events/EventRow.tsx
+++ b/packages/manager/src/features/Events/EventRow.tsx
@@ -21,9 +21,7 @@ import { formatEventWithUsername } from './Event.helpers';
 import { formatEventSeconds } from 'src/utilities/minute-conversion/minute-conversion';
 
 const useStyles = makeStyles(() => ({
-  message: {
-    wordBreak: 'break-all'
-  }
+  message: {}
 }));
 
 interface ExtendedEvent extends Event {

--- a/packages/manager/src/features/Events/EventRow.tsx
+++ b/packages/manager/src/features/Events/EventRow.tsx
@@ -58,9 +58,7 @@ export const EventRow: React.FC<CombinedProps> = props => {
     entityId,
     duration: event.duration,
     username: event.username,
-    action: event.action,
-    // This references the message field we get from API, whereas the generic 'message' prop is constructed by Cloud above.
-    eventMessage: event.message
+    action: event.action
   };
 
   return <Row {...rowProps} data-qa-events-row={event.id} />;
@@ -76,7 +74,6 @@ export interface RowProps {
   created: string;
   username: string | null;
   duration: Event['duration'];
-  eventMessage: string | null;
 }
 
 export const Row: React.FC<RowProps> = props => {
@@ -91,8 +88,7 @@ export const Row: React.FC<RowProps> = props => {
     type,
     created,
     username,
-    duration,
-    eventMessage
+    duration
   } = props;
 
   /** Some event types may not be handled by our system (or new types
@@ -145,9 +141,6 @@ export const Row: React.FC<RowProps> = props => {
       </TableCell>
       <TableCell parentColumn={'When'} data-qa-event-created-cell>
         <DateTimeDisplay value={created} />
-      </TableCell>
-      <TableCell parentColumn={'Message'}>
-        <Typography variant="body1">{eventMessage}</Typography>
       </TableCell>
     </TableRow>
   );

--- a/packages/manager/src/features/Events/EventsLanding.tsx
+++ b/packages/manager/src/features/Events/EventsLanding.tsx
@@ -37,7 +37,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     textAlign: 'center'
   },
   labelCell: {
-    width: '40%',
+    width: '60%',
     minWidth: 200,
     paddingLeft: 10
   }

--- a/packages/manager/src/features/Events/EventsLanding.tsx
+++ b/packages/manager/src/features/Events/EventsLanding.tsx
@@ -40,9 +40,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     width: '40%',
     minWidth: 200,
     paddingLeft: 10
-  },
-  messageCell: {
-    width: '30%'
   }
 }));
 
@@ -278,7 +275,6 @@ export const EventsLanding: React.FC<CombinedProps> = props => {
               </TableCell>
               <TableCell data-qa-events-duration-header>Duration</TableCell>
               <TableCell data-qa-events-time-header>When</TableCell>
-              <TableCell className={classes.messageCell}>Message</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -252,7 +252,7 @@ export const handlers = [
   }),
   rest.get('*/events', (req, res, ctx) => {
     const events = eventFactory.buildList(1, {
-      action: 'linode_reboot',
+      action: 'lke_node_create',
       percent_complete: 15,
       entity: { type: 'linode', id: 999, label: 'linode-1' },
       message:

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -254,7 +254,9 @@ export const handlers = [
     const events = eventFactory.buildList(1, {
       action: 'linode_reboot',
       percent_complete: 15,
-      entity: { type: 'linode', id: 999, label: 'linode-1' }
+      entity: { type: 'linode', id: 999, label: 'linode-1' },
+      message:
+        'Rebooting this thing and showing an extremely long event message for no discernible reason other than the fairly obvious reason that we want to do some testing of whether or not these messages wrap.'
     });
     return res.once(ctx.json(makeResourcePage(events)));
   }),


### PR DESCRIPTION
## Description

No one asked for this, exactly, but I think it's helpful. I added a bit to our event message generators that uses the `event.message` API message when it's provided. Almost all events don't have one still, so the fallback (our existing logic) will usually be used. 

I also removed the Message column in the event table, since this information will now appear in the main Label column instead.

Please feel free to push back on or discuss any of this.