### PR TITLE
Visual bug with Object Storage Browse Files button (dark theme)

### DIFF
--- a/packages/manager/src/assets/icons/fileUploadComplete.svg
+++ b/packages/manager/src/assets/icons/fileUploadComplete.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-  <path fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5.625 14.3741667L19.9555822.0435844341M5.625 14.3741667L.133252532 8.8824192" transform="translate(2 5)"/>
+  <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5.625 14.3741667L19.9555822.0435844341M5.625 14.3741667L.133252532 8.8824192" transform="translate(2 5)"/>
 </svg>

--- a/packages/manager/src/assets/icons/uploadPending.svg
+++ b/packages/manager/src/assets/icons/uploadPending.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-  <g fill="none" fill-rule="evenodd" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" transform="translate(1 3)">
+  <g fill="none" fill-rule="evenodd" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" transform="translate(1 3)">
     <polyline points="4.813 11.227 4.813 15.352 .688 15.352"/>
     <polyline points="17.188 7.102 17.188 2.977 21.313 2.977"/>
     <path d="M17.446 2.97458333C20.3778244 6.02901249 20.7648664 10.721236 18.3731571 14.2147813 15.9814479 17.7083265 11.4670057 19.0449544 7.55883333 17.4166667M4.55308333 15.3550833C1.62777321 12.2992727 1.24462928 7.61143277 3.63491941 4.12117043 6.02520954.630908093 10.5345873-.706310807 14.4411667.916666667"/>

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -99,7 +99,8 @@ const styles = (theme: Theme) =>
     },
     uploaderContainer: {
       [theme.breakpoints.up('lg')]: {
-        order: 2
+        order: 2,
+        minHeight: 300
       }
     }
   });

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/FileUpload.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/FileUpload.tsx
@@ -60,14 +60,10 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   iconLeft: {
     marginRight: theme.spacing(1),
-    '& g': {
-      stroke: theme.color.offBlack
-    }
+    color: theme.cmrIconColors.iCheckmark
   },
   iconRight: {
-    '& g': {
-      stroke: theme.color.offBlack
-    }
+    color: theme.cmrIconColors.iCheckmark
   },
   rotate: {
     animation: '$rotate 2s linear infinite'
@@ -158,7 +154,9 @@ const FileUpload: React.FC<Props> = props => {
       })}
       key={props.displayName}
       onClick={handleClickRow}
+      onKeyPress={handleClickRow}
       role="button"
+      tabIndex={0}
     >
       <LinearProgress
         variant="determinate"

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/ObjectUploader.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/ObjectUploader.tsx
@@ -45,7 +45,8 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
     [theme.breakpoints.up('lg')]: {
       minHeight: 200,
-      height: `calc(100vh - (220px + ${theme.spacing(20)}px))`
+      height: `calc(100vh - (220px + ${theme.spacing(20)}px))`,
+      marginBottom: 80
     }
   },
   dropzone: {

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/ObjectUploader.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/ObjectUploader.tsx
@@ -110,7 +110,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   UploadZoneActiveButton: {
     position: 'absolute',
     zIndex: 10,
-    backgroundColor: theme.palette.divider,
+    backgroundColor: 'transparent',
     bottom: -70,
     left: theme.spacing(2),
     width: `calc(100% - ${theme.spacing(4)}px)`,

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -131,7 +131,8 @@ const cmrIconColors = {
   iOrange: '#ffb31a',
   iRed: '#cf1e1e',
   // Offline status
-  iGrey: '#dbdde1'
+  iGrey: '#dbdde1',
+  iCheckmark: '#444'
 };
 
 const primaryColors = {

--- a/packages/manager/src/themes.ts
+++ b/packages/manager/src/themes.ts
@@ -67,7 +67,8 @@ const cmrIconColors = {
   iOrange: '#ffb31a',
   iRed: '#cf1e1e',
   // Offline status
-  iGrey: '#dbdde1'
+  iGrey: '#dbdde1',
+  iCheckmark: '#fff'
 };
 
 const primaryColors = {


### PR DESCRIPTION
## Description

Adjustments to some dark theme colors for the 'browse' button on OBJ Details and some of the file icons- also added some fixes to appease the a11y linter. 

## Type of Change
- Bug fix ('fix')