### PR TITLE
RFC: add notice about migrating with VLANs attached

### DIFF
--- a/packages/manager/src/features/linodes/MigrateLanding/CautionNotice.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/CautionNotice.tsx
@@ -84,7 +84,7 @@ const CautionNotice: React.FC<CombinedProps> = props => {
           <li>
             Any attached VLANs will be inaccessible if the destination region
             does not support VLANs.{` `}
-            <Link to="https://linode.com/docs/networking/vlans/configure-your-linode-for-vlans/">
+            <Link to="https://linode.com/docs/products/networking/vlans/">
               Check VLAN region compatibility.
             </Link>
           </li>

--- a/packages/manager/src/features/linodes/MigrateLanding/CautionNotice.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/CautionNotice.tsx
@@ -76,6 +76,18 @@ const CautionNotice: React.FC<CombinedProps> = props => {
             Configure Your Linode for Reverse DNS (rDNS).
           </a>
         </li>
+        <li>
+          Any attached VLAN will be inaccesible if the Destination Datacenter does not
+          support VLANs you can use the <Link to="/vlans">VLAN Manager</Link> or{' '}
+          <a
+            href="https://linode.com/docs/networking/vlans/configure-your-linode-for-vlans/"
+            target="_blank"
+            aria-describedby="external-site"
+            rel="noopener noreferrer"
+          >
+            Check VLAN Datacenter compatibility.
+          </a>
+        </li>
         <li>Your Linode will be powered off.</li>
         <li>
           Block Storage can't be migrated to other regions.{' '}

--- a/packages/manager/src/features/linodes/MigrateLanding/CautionNotice.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/CautionNotice.tsx
@@ -1,13 +1,15 @@
 import { Volume } from '@linode/api-v4/lib/volumes';
 import { DateTime } from 'luxon';
 import * as React from 'react';
-import { Link } from 'src/components/Link';
 import { compose } from 'recompose';
-import { makeStyles, Theme } from 'src/components/core/styles';
-
 import Checkbox from 'src/components/CheckBox';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
+import { Link } from 'src/components/Link';
 import Notice from 'src/components/Notice';
+import { useAccount } from 'src/hooks/useAccount';
+import useFlags from 'src/hooks/useFlags';
+import { isFeatureEnabled } from 'src/utilities/accountCapabilities';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -46,6 +48,13 @@ type CombinedProps = Props;
 
 const CautionNotice: React.FC<CombinedProps> = props => {
   const classes = useStyles();
+  const { vlans } = useFlags();
+  const { account } = useAccount();
+  const vlansEnabled = isFeatureEnabled(
+    'Vlans',
+    Boolean(vlans),
+    account?.data?.capabilities ?? []
+  );
 
   const amountOfAttachedVolumes = props.linodeVolumes.length;
 
@@ -71,13 +80,15 @@ const CautionNotice: React.FC<CombinedProps> = props => {
             Configure Your Linode for Reverse DNS (rDNS).
           </Link>
         </li>
-        <li>
-          Any attached VLANs will be inaccessible if the destination region does
-          not support VLANs.{` `}
-          <Link to="https://linode.com/docs/networking/vlans/configure-your-linode-for-vlans/">
-            Check VLAN region compatibility.
-          </Link>
-        </li>
+        {vlansEnabled && (
+          <li>
+            Any attached VLANs will be inaccessible if the destination region
+            does not support VLANs.{` `}
+            <Link to="https://linode.com/docs/networking/vlans/configure-your-linode-for-vlans/">
+              Check VLAN region compatibility.
+            </Link>
+          </li>
+        )}
         <li>Your Linode will be powered off.</li>
         <li>
           Block Storage can&apos;t be migrated to other regions.{' '}

--- a/packages/manager/src/features/linodes/MigrateLanding/CautionNotice.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/CautionNotice.tsx
@@ -1,7 +1,7 @@
 import { Volume } from '@linode/api-v4/lib/volumes';
 import { DateTime } from 'luxon';
 import * as React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'src/components/Link';
 import { compose } from 'recompose';
 import { makeStyles, Theme } from 'src/components/core/styles';
 
@@ -56,7 +56,7 @@ const CautionNotice: React.FC<CombinedProps> = props => {
       </Typography>
       <ul>
         <li>
-          You'll be assigned new IPv4 and IPv6 addresses, which will be
+          You&apos;ll be assigned new IPv4 and IPv6 addresses, which will be
           accessible once your migration is complete.
         </li>
         <li>
@@ -67,30 +67,20 @@ const CautionNotice: React.FC<CombinedProps> = props => {
         <li>
           Any DNS records (including Reverse DNS) will need to be updated. You
           can use the <Link to="/domains">DNS Manager</Link> or{' '}
-          <a
-            href="https://linode.com/docs/networking/dns/configure-your-linode-for-reverse-dns/"
-            target="_blank"
-            aria-describedby="external-site"
-            rel="noopener noreferrer"
-          >
+          <Link to="https://linode.com/docs/networking/dns/configure-your-linode-for-reverse-dns/">
             Configure Your Linode for Reverse DNS (rDNS).
-          </a>
+          </Link>
         </li>
         <li>
-          Any attached VLAN will be inaccesible if the Destination Datacenter does not
-          support VLANs you can use the <Link to="/vlans">VLAN Manager</Link> or{' '}
-          <a
-            href="https://linode.com/docs/networking/vlans/configure-your-linode-for-vlans/"
-            target="_blank"
-            aria-describedby="external-site"
-            rel="noopener noreferrer"
-          >
-            Check VLAN Datacenter compatibility.
-          </a>
+          Any attached VLANs will be inaccessible if the destination region does
+          not support VLANs.{` `}
+          <Link to="https://linode.com/docs/networking/vlans/configure-your-linode-for-vlans/">
+            Check VLAN region compatibility.
+          </Link>
         </li>
         <li>Your Linode will be powered off.</li>
         <li>
-          Block Storage can't be migrated to other regions.{' '}
+          Block Storage can&apos;t be migrated to other regions.{' '}
           {amountOfAttachedVolumes > 0 && (
             <React.Fragment>
               The following


### PR DESCRIPTION
Depending on which method we decide to go with, if we decide to allow
the migration then migrating to a datacenter where vlans aren't
supported with cause the VLAN not to work for a given Linode so we
should include an informational message about this.

If we go with not allowing the migration to proceed in the API then this
PR will not be needed.