### PR TITLE
M3-4623: Preventing dialog title and content from overlapping

### DIFF
--- a/packages/manager/src/components/Dialog/Dialog.tsx
+++ b/packages/manager/src/components/Dialog/Dialog.tsx
@@ -61,6 +61,7 @@ const useStyles = makeStyles((theme: Theme) =>
       backgroundColor: theme.color.drawerBackdrop
     },
     sticky: {
+      backgroundColor: theme.color.white,
       position: 'sticky',
       top: 0,
       padding: theme.spacing(),


### PR DESCRIPTION
## Description
Because the dialog title and close button stays on top of the modal, the content overlaps while the user scrolls as seen here: [https://www.loom.com/share/0d31e8c37a6c46808015915c050b0709](https://www.loom.com/share/0d31e8c37a6c46808015915c050b0709) 

To fix this, I added a background to the container containing the title and the close button

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers
There shouldn't be any regressions since the background I added matches the existing dialog background but it can't hurt to keep an eye out in case I missed something
