### PR TITLE
M3-4646: Implement Bucket Details Drawer

### DIFF
--- a/packages/api-v4/src/object-storage/types.ts
+++ b/packages/api-v4/src/object-storage/types.ts
@@ -37,6 +37,7 @@ export interface ObjectStorageBucket {
   cluster: string;
   hostname: string;
   size: number; // Size of bucket in bytes
+  objects: number;
 }
 
 export interface ObjectStorageObject {

--- a/packages/manager/src/__data__/buckets.ts
+++ b/packages/manager/src/__data__/buckets.ts
@@ -6,13 +6,15 @@ export const buckets: ObjectStorageBucket[] = [
     created: '2019-02-20 18:46:15.516813',
     hostname: 'test-bucket-001.alpha.linodeobjects.com',
     cluster: 'us-east-1',
-    size: 5418860544
+    size: 5418860544,
+    objects: 2
   },
   {
     label: 'test-bucket-002',
     created: '2019-02-24 18:46:15.516813',
     hostname: 'test-bucket-002.alpha.linodeobjects.com',
     cluster: 'a-cluster',
-    size: 1240
+    size: 1240,
+    objects: 4
   }
 ];

--- a/packages/manager/src/factories/objectStorage.ts
+++ b/packages/manager/src/factories/objectStorage.ts
@@ -11,7 +11,8 @@ export const objectStorageBucketFactory = Factory.Sync.makeFactory<
   hostname: Factory.each(i => `obj-bucket-${i}.us-east-1.linodeobjects.com`),
   cluster: 'us-east-1',
   created: '2019-12-12T00:00:00',
-  size: 999999
+  size: 999999,
+  objects: 103
 });
 
 export const objectStorageClusterFactory = Factory.Sync.makeFactory<

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketActionMenu_CMR.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketActionMenu_CMR.tsx
@@ -3,7 +3,6 @@ import ActionMenu, { Action } from 'src/components/ActionMenu_CMR/';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Hidden from 'src/components/core/Hidden';
 import Button from 'src/components/Button';
-import { Link, useHistory } from 'react-router-dom';
 
 const useStyles = makeStyles((theme: Theme) => ({
   inlineActions: {
@@ -34,13 +33,13 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 export interface Props {
   onRemove: () => void;
+  onDetails: () => void;
   label: string;
   cluster: string;
 }
 
 export const BucketActionMenu: React.FC<Props> = props => {
   const classes = useStyles();
-  const history = useHistory();
 
   const createActions = () => {
     return (): Action[] => {
@@ -48,9 +47,7 @@ export const BucketActionMenu: React.FC<Props> = props => {
         {
           title: 'Details',
           onClick: () => {
-            history.push({
-              pathname: `/object-storage/buckets/${props.cluster}/${props.label}`
-            });
+            props.onDetails();
           }
         },
         {
@@ -66,12 +63,14 @@ export const BucketActionMenu: React.FC<Props> = props => {
   return (
     <div className={classes.inlineActions}>
       <Hidden smDown>
-        <Link
+        <Button
           className={classes.button}
-          to={`/object-storage/buckets/${props.cluster}/${props.label}`}
+          onClick={() => {
+            props.onDetails();
+          }}
         >
           Details
-        </Link>
+        </Button>
         <Button
           className={classes.button}
           onClick={() => {

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDetailsDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDetailsDrawer.tsx
@@ -1,0 +1,109 @@
+import * as React from 'react';
+import Divider from 'src/components/core/Divider';
+import { makeStyles } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+import Drawer from 'src/components/Drawer';
+import formatDate from 'src/utilities/formatDate';
+import { truncateMiddle } from 'src/utilities/truncate';
+import { readableBytes } from 'src/utilities/unitConversions';
+
+const useStyles = makeStyles(() => ({
+  divider: {
+    marginTop: 16,
+    marginBottom: 16,
+    height: 1,
+    backgroundColor: '#EBEBEB'
+  },
+  copy: { marginTop: 16, padding: 0 }
+}));
+
+export interface Props {
+  open: boolean;
+  onClose: () => void;
+  bucketLabel?: string;
+  hostname?: string;
+  created?: string;
+  cluster?: string;
+  size?: number | null;
+  objectsNumber?: number;
+  aclControl?: any;
+  corsControl?: any;
+}
+
+const BucketDetailsDrawer: React.FC<Props> = props => {
+  const {
+    open,
+    onClose,
+    bucketLabel,
+    hostname,
+    created,
+    cluster,
+    size,
+    objectsNumber,
+    aclControl,
+    corsControl
+  } = props;
+
+  let formattedCreated;
+  try {
+    if (created) {
+      formattedCreated = formatDate(created);
+    }
+  } catch {}
+
+  const classes = useStyles();
+
+  return (
+    <Drawer
+      open={open}
+      onClose={onClose}
+      title={truncateMiddle(bucketLabel ?? 'Bucket Detail')}
+    >
+      {hostname ? (
+        <Typography variant="subtitle2" data-testid="hostname">
+          {hostname}
+        </Typography>
+      ) : null}
+
+      {formattedCreated ? (
+        <Typography variant="subtitle2" data-testid="createdTime">
+          Created: {formattedCreated}
+        </Typography>
+      ) : null}
+
+      {cluster ? (
+        <Typography variant="subtitle2" data-testid="cluster">
+          Cluster: {cluster}
+        </Typography>
+      ) : null}
+
+      {(hostname || formattedCreated || cluster) && (
+        <Divider className={classes.divider} />
+      )}
+
+      {size ? (
+        <Typography variant="subtitle2">
+          {readableBytes(size).formatted}
+        </Typography>
+      ) : null}
+
+      {objectsNumber ? (
+        <Typography variant="subtitle2">
+          Number of Objects: {objectsNumber}
+        </Typography>
+      ) : null}
+
+      {size || objectsNumber ? <Divider className={classes.divider} /> : null}
+
+      {aclControl ? (
+        <Typography variant="subtitle2">{aclControl}</Typography>
+      ) : null}
+
+      {corsControl ? (
+        <Typography variant="subtitle2">{corsControl}</Typography>
+      ) : null}
+    </Drawer>
+  );
+};
+
+export default React.memo(BucketDetailsDrawer);

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDetailsDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDetailsDrawer.tsx
@@ -95,7 +95,7 @@ const BucketDetailsDrawer: React.FC<Props> = props => {
         </Link>
       ) : null}
 
-      {typeof size === 'number' || objectsNumber ? (
+      {typeof size === 'number' || typeof objectsNumber === 'number' ? (
         <Divider className={classes.divider} />
       ) : null}
 

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDetailsDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDetailsDrawer.tsx
@@ -8,6 +8,7 @@ import Drawer from 'src/components/Drawer';
 import ExternalLink from 'src/components/ExternalLink';
 import formatDate from 'src/utilities/formatDate';
 import { formatObjectStorageCluster } from 'src/utilities/formatRegion';
+import { pluralize } from 'src/utilities/pluralize';
 import { truncateMiddle } from 'src/utilities/truncate';
 import { readableBytes } from 'src/utilities/unitConversions';
 
@@ -90,7 +91,7 @@ const BucketDetailsDrawer: React.FC<Props> = props => {
 
       {typeof objectsNumber === 'number' ? (
         <Link to={`/object-storage/buckets/${cluster}/${bucketLabel}`}>
-          {objectsNumber} objects
+          {pluralize('object', 'objects', objectsNumber)}
         </Link>
       ) : null}
 

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDetailsDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDetailsDrawer.tsx
@@ -1,9 +1,13 @@
 import * as React from 'react';
+import { Link } from 'react-router-dom';
+import CopyTooltip from 'src/components/CopyTooltip';
 import Divider from 'src/components/core/Divider';
 import { makeStyles } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Drawer from 'src/components/Drawer';
+import ExternalLink from 'src/components/ExternalLink';
 import formatDate from 'src/utilities/formatDate';
+import { formatObjectStorageCluster } from 'src/utilities/formatRegion';
 import { truncateMiddle } from 'src/utilities/truncate';
 import { readableBytes } from 'src/utilities/unitConversions';
 
@@ -59,12 +63,6 @@ const BucketDetailsDrawer: React.FC<Props> = props => {
       onClose={onClose}
       title={truncateMiddle(bucketLabel ?? 'Bucket Detail')}
     >
-      {hostname ? (
-        <Typography variant="subtitle2" data-testid="hostname">
-          {hostname}
-        </Typography>
-      ) : null}
-
       {formattedCreated ? (
         <Typography variant="subtitle2" data-testid="createdTime">
           Created: {formattedCreated}
@@ -73,27 +71,29 @@ const BucketDetailsDrawer: React.FC<Props> = props => {
 
       {cluster ? (
         <Typography variant="subtitle2" data-testid="cluster">
-          Cluster: {cluster}
+          {formatObjectStorageCluster(cluster)}
         </Typography>
       ) : null}
 
-      {hostname || formattedCreated || cluster ? (
+      {formattedCreated || cluster ? (
         <Divider className={classes.divider} />
       ) : null}
 
-      {size ? (
+      {typeof size === 'number' ? (
         <Typography variant="subtitle2">
           {readableBytes(size).formatted}
         </Typography>
       ) : null}
 
       {objectsNumber ? (
-        <Typography variant="subtitle2">
-          Number of Objects: {objectsNumber}
-        </Typography>
+        <Link to={`/object-storage/buckets/${cluster}/${bucketLabel}`}>
+          {objectsNumber} objects
+        </Link>
       ) : null}
 
-      {size || objectsNumber ? <Divider className={classes.divider} /> : null}
+      {typeof size === 'number' || objectsNumber ? (
+        <Divider className={classes.divider} />
+      ) : null}
 
       {aclControl ? (
         <Typography variant="subtitle2">{aclControl}</Typography>
@@ -102,6 +102,19 @@ const BucketDetailsDrawer: React.FC<Props> = props => {
       <Typography variant="subtitle2">
         {corsControl ? 'CORS enabled' : 'CORS disabled'}
       </Typography>
+
+      {hostname ? <Divider className={classes.divider} /> : null}
+
+      {hostname ? (
+        <>
+          <ExternalLink link={hostname} text={truncateMiddle(hostname, 50)} />
+          <CopyTooltip
+            className={classes.copy}
+            text={hostname}
+            displayText="Copy to clipboard"
+          />
+        </>
+      ) : null}
     </Drawer>
   );
 };

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDetailsDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDetailsDrawer.tsx
@@ -18,7 +18,10 @@ const useStyles = makeStyles(() => ({
     height: 1,
     backgroundColor: '#EBEBEB'
   },
-  copy: { marginTop: 16, padding: 0 }
+  copy: {
+    marginTop: 16,
+    padding: 0
+  }
 }));
 
 export interface Props {
@@ -85,7 +88,7 @@ const BucketDetailsDrawer: React.FC<Props> = props => {
         </Typography>
       ) : null}
 
-      {objectsNumber ? (
+      {typeof objectsNumber === 'number' ? (
         <Link to={`/object-storage/buckets/${cluster}/${bucketLabel}`}>
           {objectsNumber} objects
         </Link>

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDetailsDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDetailsDrawer.tsx
@@ -77,9 +77,9 @@ const BucketDetailsDrawer: React.FC<Props> = props => {
         </Typography>
       ) : null}
 
-      {(hostname || formattedCreated || cluster) && (
+      {hostname || formattedCreated || cluster ? (
         <Divider className={classes.divider} />
-      )}
+      ) : null}
 
       {size ? (
         <Typography variant="subtitle2">
@@ -99,9 +99,9 @@ const BucketDetailsDrawer: React.FC<Props> = props => {
         <Typography variant="subtitle2">{aclControl}</Typography>
       ) : null}
 
-      {corsControl ? (
-        <Typography variant="subtitle2">{corsControl}</Typography>
-      ) : null}
+      <Typography variant="subtitle2">
+        {corsControl ? 'CORS enabled' : 'CORS disabled'}
+      </Typography>
     </Drawer>
   );
 };

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
@@ -277,7 +277,7 @@ export const BucketLanding: React.FC<CombinedProps> = props => {
         size={bucketForDetails?.size}
         objectsNumber={bucketForDetails?.objects}
         aclControl={'ACL Control'}
-        corsControl={'CORS Control'}
+        corsControl={false}
       />
     </React.Fragment>
   );

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
@@ -33,6 +33,7 @@ import CancelNotice from '../CancelNotice';
 import BucketTable from './BucketTable';
 import BucketTable_CMR from './BucketTable_CMR';
 import useFlags from 'src/hooks/useFlags';
+import BucketDetailsDrawer from './BucketDetailsDrawer';
 
 const useStyles = makeStyles((theme: Theme) => ({
   copy: {
@@ -67,6 +68,21 @@ export const BucketLanding: React.FC<CombinedProps> = props => {
   const [isLoading, setIsLoading] = React.useState<boolean>(false);
   const [error, setError] = React.useState<string>('');
   const [confirmBucketName, setConfirmBucketName] = React.useState<string>('');
+  const [bucketDetailDrawerOpen, setBucketDetailDrawerOpen] = React.useState<
+    boolean
+  >(false);
+  const [bucketForDetails, setBucketForDetails] = React.useState<
+    ObjectStorageBucket | undefined
+  >(undefined);
+
+  const handleClickDetails = (bucket: ObjectStorageBucket) => {
+    setBucketDetailDrawerOpen(true);
+    setBucketForDetails(bucket);
+  };
+
+  const closeBucketDetailDrawer = () => {
+    setBucketDetailDrawerOpen(false);
+  };
 
   const handleClickRemove = (bucket: ObjectStorageBucket) => {
     setBucketToRemove(bucket);
@@ -226,6 +242,7 @@ export const BucketLanding: React.FC<CombinedProps> = props => {
                 order,
                 handleOrderChange,
                 handleClickRemove,
+                handleClickDetails,
                 openBucketDrawer,
                 data: orderedData
               };
@@ -250,6 +267,18 @@ export const BucketLanding: React.FC<CombinedProps> = props => {
           />
         </ConfirmationDialog>
       </div>
+      <BucketDetailsDrawer
+        open={bucketDetailDrawerOpen}
+        onClose={closeBucketDetailDrawer}
+        bucketLabel={bucketForDetails?.label}
+        hostname={bucketForDetails?.hostname}
+        created={bucketForDetails?.created}
+        cluster={bucketForDetails?.cluster}
+        size={bucketForDetails?.size}
+        objectsNumber={bucketForDetails?.objects}
+        aclControl={'ACL Control'}
+        corsControl={'CORS Control'}
+      />
     </React.Fragment>
   );
 };

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.test.tsx
@@ -20,6 +20,7 @@ describe('BucketTableRow', () => {
       hostname={bucket.hostname}
       created={bucket.created}
       size={bucket.size}
+      objects={bucket.objects}
       onRemove={mockOnRemove}
     />
   );

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow_CMR.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow_CMR.tsx
@@ -42,12 +42,22 @@ const styles = (theme: Theme) =>
 
 interface BucketTableRowProps extends ObjectStorageBucket {
   onRemove: () => void;
+  onDetails: () => void;
 }
 
 type CombinedProps = BucketTableRowProps & WithStyles<ClassNames>;
 
 export const BucketTableRow: React.FC<CombinedProps> = props => {
-  const { classes, label, cluster, hostname, created, size, onRemove } = props;
+  const {
+    classes,
+    label,
+    cluster,
+    hostname,
+    created,
+    size,
+    onRemove,
+    onDetails
+  } = props;
 
   return (
     <TableRow
@@ -101,6 +111,7 @@ export const BucketTableRow: React.FC<CombinedProps> = props => {
       <TableCell>
         <BucketActionMenu
           onRemove={onRemove}
+          onDetails={onDetails}
           label={label}
           cluster={cluster}
           data-qa-action-menu

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTable_CMR.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTable_CMR.tsx
@@ -48,6 +48,7 @@ interface Props {
   handleOrderChange: (orderBy: string, order?: 'asc' | 'desc') => void;
   openBucketDrawer: () => void;
   handleClickRemove: (bucket: ObjectStorageBucket) => void;
+  handleClickDetails: (bucket: ObjectStorageBucket) => void;
 }
 
 type CombinedProps = Props;
@@ -59,7 +60,8 @@ export const BucketTable: React.FC<CombinedProps> = props => {
     order,
     handleOrderChange,
     openBucketDrawer,
-    handleClickRemove
+    handleClickRemove,
+    handleClickDetails
   } = props;
 
   const classes = useStyles();
@@ -136,6 +138,7 @@ export const BucketTable: React.FC<CombinedProps> = props => {
                   <RenderData
                     data={paginatedData}
                     onRemove={handleClickRemove}
+                    onDetails={handleClickDetails}
                   />
                 </TableBody>
               </Table>
@@ -158,10 +161,11 @@ export const BucketTable: React.FC<CombinedProps> = props => {
 interface RenderDataProps {
   data: ObjectStorageBucket[];
   onRemove: (bucket: ObjectStorageBucket) => void;
+  onDetails: (bucket: ObjectStorageBucket) => void;
 }
 
 const RenderData: React.FC<RenderDataProps> = props => {
-  const { data, onRemove } = props;
+  const { data, onRemove, onDetails } = props;
 
   return (
     // eslint-disable-next-line react/jsx-no-useless-fragment
@@ -171,6 +175,7 @@ const RenderData: React.FC<RenderDataProps> = props => {
           {...bucket}
           key={`${bucket.label}-${bucket.cluster}`}
           onRemove={() => onRemove(bucket)}
+          onDetails={() => onDetails(bucket)}
         />
       ))}
     </>


### PR DESCRIPTION
## Description
When a user clicks the "Details" button of a bucket listed on the Buckets landing page, open a drawer for that bucket listing details about it.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers
The JSX and props for ACL and CORS pieces can be commented out prior to merging as those are just stubbed for now.
