### PR TITLE
Sentry cleanup Items

### DIFF
--- a/packages/manager/src/exceptionReporting.ts
+++ b/packages/manager/src/exceptionReporting.ts
@@ -4,57 +4,6 @@ import { initSentry } from 'src/initSentry';
 
 initSentry();
 
-const errorsToIgnore: string[] = [
-  'Invalid OAuth Token',
-  'Not Found',
-  'You are not authorized',
-  'safari-extension',
-  'chrome-extension',
-  // We know this is a problem. @todo: implement flow control in Lish.
-  'write data discarded, use flow control to avoid losing data',
-  // This is an error coming from the MUI Ripple effect.
-  'TouchRipple'
-];
-
-// eslint-disable-next-line
-window.addEventListener('unhandledrejection', event => {
-  const _stack = event?.reason?.stack;
-  // Enforce that `stack` is a string.
-  const stack = typeof _stack === 'string' ? _stack : '';
-
-  if (stack.match(/launchdarkly/i)) {
-    /**
-     * This doesn't affect error reporting, but avoids some console noise
-     * until we've cleaned up Sentry.
-     */
-    return;
-  }
-
-  const _firstReason = event.reason?.[0]?.reason;
-  // Enforce that `firstReason` is a string.
-  const firstReason = typeof _firstReason === 'string' ? _firstReason : '';
-
-  /*
-    if our error is an error we want to ignore, don't report to Sentry
-
-    Ideally we shouldn't be doing this because the goal app-wide should be to
-    catch every and all promise, but because of time and resources that just isn't a
-    possibility. For now, just ignore OAuth and "Not Found" errors and don't report them
-    to Sentry
-   */
-  if (
-    errorsToIgnore.some(eachString => {
-      const regex = new RegExp(eachString, 'gmi');
-      return !!firstReason.match(regex) || stack.match(regex);
-    })
-  ) {
-    return;
-  }
-
-  /* otherwise report to sentry as normal */
-  reportException(event.reason);
-});
-
 // Wrapper around Sentry's `captureException` function. A local scope is created
 // so that we can add `extra` and `tags` to this specific Sentry event.
 export const reportException = (

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetail.container.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetail.container.tsx
@@ -11,6 +11,7 @@ import { getAllLinodeConfigs } from 'src/store/linodes/config/config.requests';
 import { getAllLinodeDisks } from 'src/store/linodes/disk/disk.requests';
 import { getAllLinodeInterfaces } from 'src/store/linodes/interfaces/interfaces.requests';
 import { getLinode as _getLinode } from 'src/store/linodes/linode.requests';
+import { ThunkDispatch } from 'src/store/types';
 import { isFeatureEnabled } from 'src/utilities/accountCapabilities';
 import { shouldRequestEntity } from 'src/utilities/shouldRequestEntity';
 import LinodesDetail from './LinodesDetail';
@@ -28,7 +29,7 @@ interface Props {
 export const LinodesDetailContainer: React.FC<Props> = props => {
   const { isDashboard } = props;
   const { linodes } = useLinodes();
-  const dispatch = useDispatch();
+  const dispatch = useDispatch<ThunkDispatch>();
   const flags = useFlags();
   const { account } = useAccountManagement();
 
@@ -53,7 +54,7 @@ export const LinodesDetailContainer: React.FC<Props> = props => {
 
   React.useEffect(() => {
     // Unconditionally request data for the Linode being viewed
-    dispatch(_getLinode({ linodeId: +linodeId }));
+    dispatch(_getLinode({ linodeId: +linodeId })).catch(_ => null);
   }, [linodeId, dispatch]);
 
   React.useEffect(() => {

--- a/packages/manager/src/hooks/useLinodes.ts
+++ b/packages/manager/src/hooks/useLinodes.ts
@@ -10,11 +10,7 @@ import {
 import { UpdateLinodeParams } from 'src/store/linodes/linodes.actions';
 import { shallowExtendLinodes } from 'src/store/linodes/linodes.helpers';
 import { ShallowExtendedLinode } from 'src/store/linodes/types';
-import {
-  EntityError,
-  MappedEntityState2,
-  ThunkDispatch
-} from 'src/store/types';
+import { EntityError, MappedEntityState2 } from 'src/store/types';
 import { Dispatch } from './types';
 import useEvents from './useEvents';
 import useNotifications from './useNotifications';
@@ -28,7 +24,7 @@ export interface LinodesProps {
 }
 
 export const useLinodes = (): LinodesProps => {
-  const dispatch: Dispatch = useDispatch<ThunkDispatch>();
+  const dispatch: Dispatch = useDispatch();
 
   const linodes = useSelector(
     (state: ApplicationState) => state.__resources.linodes

--- a/packages/manager/src/hooks/useLinodes.ts
+++ b/packages/manager/src/hooks/useLinodes.ts
@@ -10,7 +10,11 @@ import {
 import { UpdateLinodeParams } from 'src/store/linodes/linodes.actions';
 import { shallowExtendLinodes } from 'src/store/linodes/linodes.helpers';
 import { ShallowExtendedLinode } from 'src/store/linodes/types';
-import { EntityError, MappedEntityState2 } from 'src/store/types';
+import {
+  EntityError,
+  MappedEntityState2,
+  ThunkDispatch
+} from 'src/store/types';
 import { Dispatch } from './types';
 import useEvents from './useEvents';
 import useNotifications from './useNotifications';
@@ -24,7 +28,7 @@ export interface LinodesProps {
 }
 
 export const useLinodes = (): LinodesProps => {
-  const dispatch: Dispatch = useDispatch();
+  const dispatch: Dispatch = useDispatch<ThunkDispatch>();
 
   const linodes = useSelector(
     (state: ApplicationState) => state.__resources.linodes

--- a/packages/manager/src/initSentry.test.ts
+++ b/packages/manager/src/initSentry.test.ts
@@ -1,0 +1,22 @@
+import { APIError } from '@linode/api-v4/lib/types';
+import { normalizeErrorMessage } from './initSentry';
+
+const INVALID_TOKEN = 'Invalid Token';
+
+describe('normalizeErrorMessage', () => {
+  it("returns the input untouched if it's already a string", () => {
+    expect(normalizeErrorMessage(INVALID_TOKEN)).toBe(INVALID_TOKEN);
+  });
+
+  it("returns the API error reason if it's one APIError", () => {
+    const apiError: APIError[] = [{ reason: INVALID_TOKEN }];
+    expect(normalizeErrorMessage(apiError as any)).toBe(INVALID_TOKEN);
+  });
+
+  it("returns the input stringified if it's anything else", () => {
+    expect(normalizeErrorMessage([INVALID_TOKEN] as any)).toBe(
+      '["Invalid Token"]'
+    );
+    expect(normalizeErrorMessage(null as any)).toBe('null');
+  });
+});

--- a/packages/manager/src/initSentry.ts
+++ b/packages/manager/src/initSentry.ts
@@ -73,7 +73,7 @@ export const initSentry = () => {
   }
 };
 
-const beforeSend: BrowserOptions['beforeSend'] = sentryEvent => {
+const beforeSend: BrowserOptions['beforeSend'] = (sentryEvent, hint) => {
   const normalizedErrorMessage = normalizeErrorMessage(sentryEvent.message);
 
   if (
@@ -114,24 +114,20 @@ export const errorsToIgnore: RegExp[] = [
 // actually be something like a (Linode) API Error instead of a string. We need
 // to ensure we're  dealing with strings so we can determine if we should ignore
 // the error, or appropriately report the message to Sentry (i.e. not "<unknown>").
-export const normalizeErrorMessage = (
-  sentryErrorMessage: SentryEvent['message']
-): string => {
-  const sentryErrorMessageCopy = sentryErrorMessage as any;
-
-  if (typeof sentryErrorMessageCopy === 'string') {
-    return sentryErrorMessageCopy;
+export const normalizeErrorMessage = (sentryErrorMessage: any): string => {
+  if (typeof sentryErrorMessage === 'string') {
+    return sentryErrorMessage;
   }
 
   if (
-    Array.isArray(sentryErrorMessageCopy) &&
-    sentryErrorMessageCopy!.length === 1 &&
-    sentryErrorMessageCopy[0]?.reason
+    Array.isArray(sentryErrorMessage) &&
+    sentryErrorMessage!.length === 1 &&
+    sentryErrorMessage[0]?.reason
   ) {
-    return sentryErrorMessageCopy[0].reason;
+    return sentryErrorMessage[0].reason;
   }
 
-  return JSON.stringify(sentryErrorMessageCopy);
+  return JSON.stringify(sentryErrorMessage);
 };
 
 const maybeAddCustomFingerprint = (event: SentryEvent): SentryEvent => {

--- a/packages/manager/src/initSentry.ts
+++ b/packages/manager/src/initSentry.ts
@@ -3,17 +3,6 @@ import { SENTRY_URL } from 'src/constants';
 import redactAccessToken from 'src/utilities/redactAccessToken';
 import deepStringTransform from 'src/utilities/deepStringTransform';
 
-const beforeSend: BrowserOptions['beforeSend'] = sentryEvent => {
-  /** remove the user's access token from the event if one exists */
-  const eventWithoutSensitiveInfo = deepStringTransform(
-    sentryEvent,
-    redactAccessToken
-  );
-
-  /** maybe add a custom fingerprint if this error is relevant */
-  return maybeAddCustomFingerprint(eventWithoutSensitiveInfo);
-};
-
 export const initSentry = () => {
   if (SENTRY_URL) {
     init({
@@ -82,6 +71,67 @@ export const initSentry = () => {
       ]
     });
   }
+};
+
+const beforeSend: BrowserOptions['beforeSend'] = sentryEvent => {
+  const normalizedErrorMessage = normalizeErrorMessage(sentryEvent.message);
+
+  if (
+    errorsToIgnore.some(eachRegex =>
+      Boolean(normalizedErrorMessage.match(eachRegex))
+    )
+  ) {
+    return null;
+  }
+
+  sentryEvent.message = normalizedErrorMessage;
+
+  /** remove the user's access token from the event if one exists */
+  const eventWithoutSensitiveInfo = deepStringTransform(
+    sentryEvent,
+    redactAccessToken
+  );
+
+  /** maybe add a custom fingerprint if this error is relevant */
+  return maybeAddCustomFingerprint(eventWithoutSensitiveInfo);
+};
+
+export const errorsToIgnore: RegExp[] = [
+  /Invalid (OAuth )?Token/gi,
+  /Not Found/gi,
+  /You are not authorized/gi,
+  /Unauthorized/gi,
+  /This Linode has been suspended/gi,
+  /safari-extension/gi,
+  /chrome-extension/gi,
+  // We know this is a problem. @todo: implement flow control in Lish.
+  /write data discarded, use flow control to avoid losing data/gi,
+  // This is an error coming from the MUI Ripple effect.
+  /TouchRipple/gi
+];
+
+// We can't trust the type of the "message" on a Sentry event, since it may
+// actually be something like a (Linode) API Error instead of a string. We need
+// to ensure we're  dealing with strings so we can determine if we should ignore
+// the error, or appropriately report the message to Sentry (i.e. not "<unknown>").
+export const normalizeErrorMessage = (
+  sentryErrorMessage: SentryEvent['message']
+): string => {
+  const sentryErrorMessageCopy = sentryErrorMessage as any;
+
+  if (typeof sentryErrorMessageCopy === 'string') {
+    return sentryErrorMessageCopy;
+  }
+
+  if (
+    Array.isArray(sentryErrorMessageCopy) &&
+    sentryErrorMessageCopy!.length === 1 &&
+    sentryErrorMessageCopy[0]?.reason
+  ) {
+    return sentryErrorMessageCopy[0].reason;
+  }
+
+  return JSON.stringify(sentryErrorMessageCopy);
 };
 
 const maybeAddCustomFingerprint = (event: SentryEvent): SentryEvent => {


### PR DESCRIPTION
## Description

A few Sentry cleanup things:

**1. Remove global `unhandledrejection` error reporting.** 
Looking through the Sentry dashboard with a search filter of `mechanism:onunhandledrejection`, these are just not very helpful and sometimes result in double reporting.

**2. Normalize error messages.** 
Many errors are going through sentry with an `APIError[]` as the message type. This means that Sentry's built in `ignoreErrors` functionality isn't working for these. To address this, I added a function to ensure the error messages are strings.

**3. Catch getLinode errors**
There's a problem with the way we tend to use thunks created with `createRequestThunk`. Namely, the generator function returns a rejected promise on failure, but we don't always catch the errors. This means, for example, if you go to localhost:3000/linodes/1234 (a LinodeID that doesn't belong to you) what you see in the console is an unhandled promise rejection, resulting in a Sentry error. I added a .catch handler to the two places we use getLinodes, though there are undoubtedly similar instances around the app.

## Note to Reviewers

To test (on develop):

1. Run the app with Sentry 
2. Open the network tab in dev tools
3. Go to localhost:3000/linodes/1234
4. Observe: we POST to Sentry several unnecessary errors.

With this PR, no Sentry request is made. 

You can also test the ever-present "Invalid Token" error by submitting an API request with an invalid token (but not redirecting to Login)... you'll have to play around with the code to simulate that scenario.

