### PR TITLE
Polling followup

### DIFF
--- a/packages/manager/src/events.ts
+++ b/packages/manager/src/events.ts
@@ -51,9 +51,6 @@ export const startEventsInterval = () =>
       const now = Date.now();
       const pollIteration = getPollingInterval();
       const eventRequestDeadline = getRequestDeadline();
-      // For PR review purposes; delete before merge
-      // console.count('iteration');
-      // console.table({ pollIteration, eventRequestDeadline });
 
       if (now > eventRequestDeadline) {
         /**
@@ -63,6 +60,11 @@ export const startEventsInterval = () =>
         if (inProgress) {
           /** leaving this commented out for now because I'm not sure if it'll break anything */
           // pollIteration = 1;
+          return;
+        }
+
+        if (document.visibilityState !== 'visible') {
+          // don't request events in an inactive/minimized tab.
           return;
         }
 

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -29,6 +29,7 @@ import KubeContainer, {
   DispatchProps
 } from 'src/containers/kubernetes.container';
 import withTypes, { WithTypesProps } from 'src/containers/types.container';
+import usePolling from 'src/hooks/usePolling';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { getAllWithArguments } from 'src/utilities/getAll';
 import { ExtendedCluster, PoolNodeWithPrice } from '.././types';
@@ -176,6 +177,8 @@ export const KubernetesClusterDetail: React.FunctionComponent<CombinedProps> = p
   const endpointAvailabilityInterval = React.useRef<number>();
   const kubeconfigAvailabilityInterval = React.useRef<number>();
 
+  usePolling([() => props.requestNodePools(+props.match.params.clusterID)]);
+
   const getEndpointToDisplay = (endpoints: string[]) => {
     // Per discussions with the API team and UX, we should display only the endpoint with port 443, so we are matching on that.
     return endpoints.find(thisResponse =>
@@ -270,13 +273,7 @@ export const KubernetesClusterDetail: React.FunctionComponent<CombinedProps> = p
       kubeconfigAvailabilityCheck(clusterID, true);
     }
 
-    const interval = setInterval(
-      () => props.requestNodePools(+props.match.params.clusterID),
-      10000
-    );
-
     return () => {
-      clearInterval(interval);
       clearInterval(endpointAvailabilityInterval.current);
       clearInterval(kubeconfigAvailabilityInterval.current);
     };

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/useGraphs.ts
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/useGraphs.ts
@@ -8,57 +8,62 @@ export const useGraphs = (
   start: number,
   end: number
 ) => {
-  let mounted = true;
-  let requestInterval: NodeJS.Timeout;
+  const requestInterval = React.useRef<number>(0);
+  const mounted = React.useRef(false);
 
   const [data, setData] = React.useState<Partial<AllData>>({});
   const [loading, setLoading] = React.useState<boolean>(false);
   const [error, setError] = React.useState<string | undefined>();
-  const request = (isLoading: boolean = true) => {
-    if (!mounted) {
-      return;
-    }
-    if (!start || !end || !clientAPIKey) {
-      return;
-    }
-    if (isLoading) {
-      setLoading(true);
-      setData({});
-    }
-    return getValues(clientAPIKey, {
-      fields: requestFields,
-      start,
-      end
-    })
-      .then(response => {
-        if (mounted) {
-          setLoading(false);
-          setError(undefined);
-          setData(response.DATA);
-        }
+  const request = React.useCallback(
+    (isLoading: boolean = true) => {
+      if (!mounted) {
+        return;
+      }
+      if (!start || !end || !clientAPIKey) {
+        return;
+      }
+      if (isLoading) {
+        setLoading(true);
+        setData({});
+      }
+      return getValues(clientAPIKey, {
+        fields: requestFields,
+        start,
+        end
       })
-      .catch(e => {
-        if (mounted) {
-          setLoading(false);
-          setError(e.NOTIFICATIONS?.[0]?.TEXT ?? 'Unable to retrieve data.');
-        }
-      });
-  };
+        .then(response => {
+          if (mounted.current) {
+            setLoading(false);
+            setError(undefined);
+            setData(response.DATA);
+          }
+        })
+        .catch(e => {
+          if (mounted.current) {
+            setLoading(false);
+            setError(e.NOTIFICATIONS?.[0]?.TEXT ?? 'Unable to retrieve data.');
+          }
+        });
+    },
+    [start, end, clientAPIKey, requestFields]
+  );
 
   // Poll the data. Reset/refresh the interval if the clientAPIKey changes.
   React.useEffect(() => {
     if (!clientAPIKey) {
       return;
     }
-    requestInterval = setInterval(() => {
-      request(false);
+    requestInterval.current = window.setInterval(() => {
+      if (document.visibilityState === 'visible') {
+        request(false);
+      }
     }, 10000);
 
     return () => {
-      mounted = false;
-      clearInterval(requestInterval);
+      mounted.current = false;
+      clearInterval(requestInterval.current);
     };
-  }, [clientAPIKey]);
+  }, [clientAPIKey, request]);
 
   return { error, data, loading, request };
 };

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/Load.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/Load.tsx
@@ -54,11 +54,9 @@ const LoadGauge: React.FC<CombinedProps> = props => {
     return {
       innerText: `${(load || 0).toFixed(2)}`,
       subTitle: (
-        <React.Fragment>
-          <Typography>
-            <strong>Load</strong>
-          </Typography>
-        </React.Fragment>
+        <Typography>
+          <strong>Load</strong>
+        </Typography>
       )
     };
   };

--- a/packages/manager/src/features/Longview/shared/useClientLastUpdated.ts
+++ b/packages/manager/src/features/Longview/shared/useClientLastUpdated.ts
@@ -1,6 +1,6 @@
 import { APIError } from '@linode/api-v4/lib/types';
 import { pathOr } from 'ramda';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { getLastUpdated } from '../request';
 import { LongviewNotification } from '../request.types';
 
@@ -8,8 +8,9 @@ export const useClientLastUpdated = (
   clientAPIKey?: string,
   callback?: (lastUpdated?: number) => void
 ) => {
-  let mounted = true;
-  let requestInterval: NodeJS.Timeout;
+  const mounted = useRef(true);
+  const requestInterval = useRef(0);
+  const _callback = useRef(callback);
 
   /*
    lastUpdated _might_ come back from the endpoint as 0, so it's important
@@ -25,67 +26,70 @@ export const useClientLastUpdated = (
   >();
   const [authed, setAuthed] = useState<boolean>(true);
 
-  const requestAndSetLastUpdated = (apiKey: string) => {
-    /*
+  const requestAndSetLastUpdated = useCallback(
+    (apiKey: string) => {
+      /*
      get the current last updated value
 
      This function is called as a closure inside the onMount useEffect
      so we need to use a ref to get the new value
     */
-    const { current: newLastUpdated } = currentLastUpdated;
+      const { current: newLastUpdated } = currentLastUpdated;
 
-    setLastUpdatedError(undefined);
+      setLastUpdatedError(undefined);
 
-    // Use a function argument for the API key instead `clientAPIKey` from the
-    // lexical scope, since it is a dependency in the effect that will call
-    // this function.
-    return getLastUpdated(apiKey)
-      .then(response => {
-        /**
-         * If there are any warnings in the response (found at response.NOTIFICATIONS)
-         * we want to set them to state here so that consumers of this component
-         * can handle them (usually by setting a banner). We choose to do this
-         * here as these are high-level requests, made most frequently, and
-         * notifications are not field-specific.
-         */
-        setNotifications(response.NOTIFICATIONS);
-        /*
+      // Use a function argument for the API key instead `clientAPIKey` from the
+      // lexical scope, since it is a dependency in the effect that will call
+      // this function.
+      return getLastUpdated(apiKey)
+        .then(response => {
+          /**
+           * If there are any warnings in the response (found at response.NOTIFICATIONS)
+           * we want to set them to state here so that consumers of this component
+           * can handle them (usually by setting a banner). We choose to do this
+           * here as these are high-level requests, made most frequently, and
+           * notifications are not field-specific.
+           */
+          setNotifications(response.NOTIFICATIONS);
+          /*
           only update _lastUpdated_ state if it hasn't already been set
           or the API response is in a time past what's already been set.
         */
 
-        const _lastUpdated = response.DATA?.updated ?? 0;
+          const _lastUpdated = response.DATA?.updated ?? 0;
 
-        if (
-          mounted &&
-          (typeof newLastUpdated === 'undefined' ||
-            _lastUpdated > newLastUpdated)
-        ) {
-          setLastUpdated(_lastUpdated);
-          if (callback) {
-            callback(_lastUpdated);
+          if (
+            mounted.current &&
+            (typeof newLastUpdated === 'undefined' ||
+              _lastUpdated > newLastUpdated)
+          ) {
+            setLastUpdated(_lastUpdated);
+            if (_callback.current) {
+              _callback.current(_lastUpdated);
+            }
           }
-        }
-      })
-      .catch(e => {
-        /**
-         * The first request we make after creating a new client will almost always
-         * return an authentication failed error.
-         */
-        const reason = pathOr('', [0, 'TEXT'], e);
+        })
+        .catch(e => {
+          /**
+           * The first request we make after creating a new client will almost always
+           * return an authentication failed error.
+           */
+          const reason = pathOr('', [0, 'TEXT'], e);
 
-        if (mounted) {
-          if (reason.match(/authentication/i)) {
-            setAuthed(false);
-          }
+          if (mounted.current) {
+            if (reason.match(/authentication/i)) {
+              setAuthed(false);
+            }
 
-          /* only set lastUpdated error if we haven't already gotten data before */
-          if (typeof newLastUpdated === 'undefined') {
-            setLastUpdatedError(e);
+            /* only set lastUpdated error if we haven't already gotten data before */
+            if (typeof newLastUpdated === 'undefined') {
+              setLastUpdatedError(e);
+            }
           }
-        }
-      });
-  };
+        });
+    },
+    [_callback]
+  );
 
   useEffect(() => {
     /*
@@ -110,16 +114,18 @@ export const useClientLastUpdated = (
       return;
     }
     requestAndSetLastUpdated(clientAPIKey).then(() => {
-      requestInterval = setInterval(() => {
-        requestAndSetLastUpdated(clientAPIKey);
+      requestInterval.current = window.setInterval(() => {
+        if (document.visibilityState === 'visible') {
+          requestAndSetLastUpdated(clientAPIKey);
+        }
       }, 10000);
     });
 
     return () => {
-      mounted = false;
-      clearInterval(requestInterval);
+      mounted.current = false;
+      clearInterval(requestInterval.current);
     };
-  }, [clientAPIKey]);
+  }, [clientAPIKey, requestAndSetLastUpdated]);
 
   return { lastUpdated, lastUpdatedError, authed, notifications };
 };

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
@@ -128,10 +128,11 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
     this.requestNodeBalancer(+nodeBalancerId);
 
     // Update NB information every 30 seconds, so that we have an accurate picture of nodes
-    this.pollInterval = window.setInterval(
-      () => this.requestNodeBalancer(+nodeBalancerId),
-      30 * 1000
-    );
+    this.pollInterval = window.setInterval(() => {
+      if (document.visibilityState === 'visible') {
+        this.requestNodeBalancer(+nodeBalancerId);
+      }
+    }, 30 * 1000);
   }
 
   componentWillUnmount() {

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.tsx
@@ -200,10 +200,11 @@ export class NodeBalancersLanding extends React.Component<
      * To keep NB node status up to date, poll NodeBalancers and configs every 30 seconds while the
      * user is on this page.
      */
-    this.pollInterval = window.setInterval(
-      () => getAllNodeBalancersWithConfigs(),
-      30 * 1000
-    );
+    this.pollInterval = window.setInterval(() => {
+      if (document.visibilityState === 'visible') {
+        getAllNodeBalancersWithConfigs();
+      }
+    }, 30 * 1000);
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
## Description

The original idea here was to use the new usePolling hook to everywhere in the app that does polling. Didn't work out that way, because a lot of the polling logic is customized and not a good fit, or else in old class components. Fortunately, the underlying API is very simple so it's easy to skip polling when the page is not visible.