### PR TITLE
M3-4479 Object ACLs

### DIFF
--- a/packages/api-v4/src/object-storage/objects.ts
+++ b/packages/api-v4/src/object-storage/objects.ts
@@ -1,6 +1,11 @@
 import { API_ROOT } from 'src/constants';
 import Request, { setData, setMethod, setURL } from '../request';
-import { ObjectStorageObjectURL, ObjectStorageObjectURLOptions } from './types';
+import {
+  ACLType,
+  ObjectStorageObjectACL,
+  ObjectStorageObjectURL,
+  ObjectStorageObjectURLOptions
+} from './types';
 
 /**
  * Gets a URL to upload/download/delete objects from a bucket.
@@ -31,9 +36,29 @@ export const getObjectACL = (
   bucketName: string,
   name: string
 ) =>
-  Request<ObjectStorageObjectURL>(
+  Request<ObjectStorageObjectACL>(
     setMethod('GET'),
     setURL(
       `${API_ROOT}/object-storage/buckets/${clusterId}/${bucketName}/object-acl?name=${name}`
     )
+  );
+
+/**
+ *
+ * updateObjectACL
+ *
+ * Gets the ACL for a given object
+ */
+export const updateObjectACL = (
+  clusterId: string,
+  bucketName: string,
+  name: string,
+  acl: Omit<ACLType, 'custom'>
+) =>
+  Request<ObjectStorageObjectACL>(
+    setMethod('PUT'),
+    setURL(
+      `${API_ROOT}/object-storage/buckets/${clusterId}/${bucketName}/object-acl`
+    ),
+    setData({ acl, name })
   );

--- a/packages/api-v4/src/object-storage/objects.ts
+++ b/packages/api-v4/src/object-storage/objects.ts
@@ -8,7 +8,7 @@ import {
 } from './types';
 
 /**
- * Gets a URL to upload/download/delete objects from a bucket.
+ * Gets a URL to upload/download/delete Objects from a Bucket.
  */
 export const getObjectURL = (
   clusterId: string,
@@ -29,7 +29,7 @@ export const getObjectURL = (
  *
  * getObjectACL
  *
- * Gets the ACL for a given object
+ * Gets the ACL for a given Object.
  */
 export const getObjectACL = (
   clusterId: string,
@@ -47,7 +47,7 @@ export const getObjectACL = (
  *
  * updateObjectACL
  *
- * Gets the ACL for a given object
+ * Updates the ACL for a given Object.
  */
 export const updateObjectACL = (
   clusterId: string,

--- a/packages/api-v4/src/object-storage/objects.ts
+++ b/packages/api-v4/src/object-storage/objects.ts
@@ -19,3 +19,21 @@ export const getObjectURL = (
     ),
     setData({ name, method, ...options })
   );
+
+/**
+ *
+ * getObjectACL
+ *
+ * Gets the ACL for a given object
+ */
+export const getObjectACL = (
+  clusterId: string,
+  bucketName: string,
+  name: string
+) =>
+  Request<ObjectStorageObjectURL>(
+    setMethod('GET'),
+    setURL(
+      `${API_ROOT}/object-storage/buckets/${clusterId}/${bucketName}/object-acl?name=${name}`
+    )
+  );

--- a/packages/api-v4/src/object-storage/types.ts
+++ b/packages/api-v4/src/object-storage/types.ts
@@ -52,6 +52,18 @@ export interface ObjectStorageObjectURL {
   url: string;
 }
 
+export type ACLType =
+  | 'private'
+  | 'public-read'
+  | 'authenticated-read'
+  | 'public-read-write'
+  | 'custom';
+
+export interface ObjectStorageObjectACL {
+  acl: ACLType;
+  acl_xml: string;
+}
+
 export interface ObjectStorageObjectURLOptions {
   expires_in?: number;
   // "Content-Type" is normally an HTTP header, but here it is used in the body

--- a/packages/manager/src/components/EnhancedSelect/__mocks__/Select.tsx
+++ b/packages/manager/src/components/EnhancedSelect/__mocks__/Select.tsx
@@ -51,7 +51,7 @@ export default ({
           <option
             key={thisOption.value ?? ''}
             value={thisOption.value ?? ''}
-            aria-selected={thisOption.value === value}
+            aria-selected={thisOption.value === value?.value}
             data-testid={`mock-option`}
           >
             {thisOption.label}

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ACLSelect.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ACLSelect.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+import ACLSelect, { Props } from './ACLSelect';
+
+jest.mock('src/components/EnhancedSelect/Select');
+
+const mockGetACL = jest.fn();
+const mockUpdateACL = jest.fn();
+
+const props: Props = {
+  getACL: mockGetACL.mockResolvedValue({ acl: 'public-read' }),
+  updateACL: mockUpdateACL.mockResolvedValue({}),
+  name: 'my-object-name'
+};
+
+describe('ACLSelect', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows the ACL', async () => {
+    renderWithTheme(<ACLSelect {...props} />);
+    await waitFor(() => {
+      expect(screen.getByText('Public Read')).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+    });
+  });
+
+  it('updates the ACL and submits the appropriate value', async () => {
+    renderWithTheme(<ACLSelect {...props} />);
+
+    await waitFor(() => {
+      const aclSelect = screen.getByTestId('select');
+      fireEvent.change(aclSelect, {
+        target: { value: 'private' }
+      });
+
+      expect(screen.getByText('Private')).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+
+      const saveButton = screen.getByText('Save');
+      fireEvent.click(saveButton);
+
+      expect(mockUpdateACL).toHaveBeenCalledWith('private');
+    });
+  });
+});

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ACLSelect.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ACLSelect.tsx
@@ -1,0 +1,167 @@
+import {
+  ACLType,
+  ObjectStorageObjectACL
+} from '@linode/api-v4/lib/object-storage';
+import * as React from 'react';
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
+import ConfirmationDialog from 'src/components/ConfirmationDialog';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import EnhancedSelect from 'src/components/EnhancedSelect';
+import { Item } from 'src/components/EnhancedSelect/Select';
+import Notice from 'src/components/Notice';
+import useOpenClose from 'src/hooks/useOpenClose';
+import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
+import { aclOptions } from '../utilities';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  submitButton: { marginTop: theme.spacing(2) }
+}));
+
+export interface Props {
+  getACL: () => Promise<ObjectStorageObjectACL>; // | ObjectStorageBucketACL
+  updateACL: (acl: ACLType) => Promise<ObjectStorageObjectACL>; // | ObjectStorageBucketACL
+  name: string;
+  // @todo: CORS?
+}
+
+type CombinedProps = Props;
+
+const ACLSelect: React.FC<CombinedProps> = props => {
+  const classes = useStyles();
+
+  const { getACL, updateACL, name } = props;
+
+  // ACL data for this Object (from the API).
+  const [aclData, setACLData] = React.useState<ACLType | null>(null);
+  const [aclLoading, setACLLoading] = React.useState(false);
+  const [aclError, setACLError] = React.useState('');
+
+  // The ACL Option currently selected in the <EnhancedSelect /> component.
+  const [selectedACL, setSelectedACL] = React.useState<ACLType | null>(null);
+
+  // State for submitting the ACL option.
+  const [updateACLLoading, setUpdateACLLoading] = React.useState(false);
+  const [updateACLError, setUpdateACLError] = React.useState('');
+  const [updateACLSuccess, setUpdateACLSuccess] = React.useState(false);
+
+  // State for dealing with the confirmation modal when selecting read/write.
+  const { open: openDialog, isOpen, close: closeDialog } = useOpenClose();
+
+  React.useEffect(() => {
+    setUpdateACLError('');
+    setACLError('');
+    setUpdateACLSuccess(false);
+    setACLLoading(true);
+    getACL()
+      .then(({ acl }) => {
+        setACLLoading(false);
+        setACLData(acl);
+        setSelectedACL(acl);
+      })
+      .catch(err => {
+        setACLLoading(false);
+        setACLError(getErrorStringOrDefault(err));
+      });
+  }, [getACL]);
+
+  const handleSubmit = () => {
+    // TS safety check.
+    if (!name || !selectedACL) {
+      return;
+    }
+
+    setUpdateACLSuccess(false);
+    setUpdateACLLoading(true);
+    setUpdateACLError('');
+    setACLError('');
+    closeDialog();
+
+    updateACL(selectedACL)
+      .then(() => {
+        setUpdateACLSuccess(true);
+        setACLData(selectedACL);
+        setUpdateACLLoading(false);
+      })
+      .catch(err => {
+        setUpdateACLLoading(false);
+        setUpdateACLError(getErrorStringOrDefault(err));
+      });
+  };
+
+  // An Object/Bucket's ACL is "custom" is the user has done things with the s3
+  // API directly (instead of using one of the canned ACLs). "Custom" is not a
+  // selectable option, but it is (potentially) returned by the API, so we
+  // present it here as a disabled option.
+  const _options =
+    aclData === 'custom'
+      ? [{ label: 'Custom', value: 'custom' }, ...aclOptions]
+      : aclOptions;
+
+  return (
+    <>
+      {updateACLSuccess ? (
+        <Notice success text="Object access updated successfully." />
+      ) : null}
+
+      <EnhancedSelect
+        label="Access (Object ACL)"
+        placeholder={aclLoading ? 'Loading access...' : 'Select an ACL...'}
+        isClearable={false}
+        options={_options}
+        isLoading={aclLoading}
+        disabled={aclLoading || aclError}
+        errorText={aclError || updateACLError}
+        onChange={(selected: Item<ACLType> | null) => {
+          if (selected) {
+            setUpdateACLSuccess(false);
+            setUpdateACLError('');
+            setSelectedACL(selected.value);
+          }
+        }}
+        isOptionDisabled={(item: Item<ACLType>) => item.value === 'custom'}
+        value={_options.find(
+          thisOption => thisOption.value === selectedACL ?? 'private'
+        )}
+        data-testid="acl-select"
+      />
+
+      <Button
+        className={classes.submitButton}
+        buttonType="primary"
+        onClick={() => {
+          if (selectedACL === 'public-read-write') {
+            openDialog();
+          } else {
+            handleSubmit();
+          }
+        }}
+        disabled={aclData === selectedACL}
+        loading={updateACLLoading}
+      >
+        Save
+      </Button>
+
+      <ConfirmationDialog
+        title={`Confirm Object Access`}
+        open={isOpen}
+        onClose={closeDialog}
+        actions={() => (
+          <ActionsPanel style={{ padding: 0 }}>
+            <Button buttonType="cancel" onClick={closeDialog} data-qa-cancel>
+              Cancel
+            </Button>
+            <Button buttonType="secondary" destructive onClick={handleSubmit}>
+              Confirm
+            </Button>
+          </ActionsPanel>
+        )}
+      >
+        Are you sure want make {name} writable by everyone? This is not
+        recommended for most use cases.
+      </ConfirmationDialog>
+    </>
+  );
+};
+
+export default ACLSelect;

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -584,7 +584,8 @@ export class BucketDetail extends React.Component<CombinedProps, State> {
           onClose={this.closeObjectDetailsDrawer}
           bucketName={bucketName}
           clusterId={clusterId}
-          name={selectedObject?._displayName}
+          displayName={selectedObject?._displayName}
+          name={selectedObject?.name}
           lastModified={selectedObject?.last_modified}
           size={selectedObject?.size}
           url={

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -582,6 +582,8 @@ export class BucketDetail extends React.Component<CombinedProps, State> {
         <ObjectDetailDrawer
           open={objectDetailDrawerOpen}
           onClose={this.closeObjectDetailsDrawer}
+          bucketName={bucketName}
+          clusterId={clusterId}
           name={selectedObject?._displayName}
           lastModified={selectedObject?.last_modified}
           size={selectedObject?.size}

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.test.tsx
@@ -1,12 +1,32 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import * as React from 'react';
+import * as objectStorage from '@linode/api-v4/lib/object-storage/objects';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 import ObjectDetailsDrawer, { Props } from './ObjectDetailsDrawer';
+
+jest.mock('@linode/api-v4/lib/object-storage/objects', () => {
+  return {
+    getObjectACL: jest.fn().mockResolvedValue({
+      acl: 'public-read',
+      acl_xml: 'long xml string'
+    }),
+    updateObjectACL: jest.fn().mockResolvedValue({})
+  };
+});
+
+const mockUpdateObjectACL = jest.spyOn<any, any>(
+  objectStorage,
+  'updateObjectACL'
+);
+
+jest.mock('src/components/EnhancedSelect/Select');
 
 const props: Props = {
   onClose: jest.fn(),
   open: true,
   lastModified: '2019-12-31T23:59:59Z',
-  name: 'my-image.png',
+  displayName: 'my-image.png',
+  name: 'my-dir/my-image.png',
   size: 12345,
   url: 'https://my-bucket.cluster-id.linodeobjects.com/my-image.png',
   bucketName: 'my-bucket',
@@ -14,17 +34,64 @@ const props: Props = {
 };
 
 describe('ObjectDetailsDrawer', () => {
-  it('renders formatted size, formatted last modified, truncated URL', () => {
-    const { getByText } = renderWithTheme(<ObjectDetailsDrawer {...props} />);
-    getByText('12.1 KB');
-    getByText(/^Last modified: 2019-12-31/);
-    getByText(/^https:\/\/my-bucket/);
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it('renders formatted size, formatted last modified, truncated URL', async () => {
+    renderWithTheme(<ObjectDetailsDrawer {...props} />);
+    await waitFor(() =>
+      expect(screen.getByText('12.1 KB')).toBeInTheDocument()
+    );
+    await waitFor(() =>
+      expect(screen.getByText(/^Last modified: 2019-12-31/)).toBeInTheDocument()
+    );
+    await waitFor(() =>
+      expect(screen.getByText(/^https:\/\/my-bucket/)).toBeInTheDocument()
+    );
   });
 
-  it("doesn't show last modified if the the time is invalid", () => {
-    const { queryByTestId } = renderWithTheme(
+  it("doesn't show last modified if the the time is invalid", async () => {
+    renderWithTheme(
       <ObjectDetailsDrawer {...props} lastModified="INVALID DATE" />
     );
-    expect(queryByTestId('lastModified')).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.queryByTestId('lastModified')).not.toBeInTheDocument()
+    );
+  });
+
+  it("shows the Object's ACL", async () => {
+    renderWithTheme(<ObjectDetailsDrawer {...props} />);
+    await waitFor(() => {
+      expect(screen.getByText('Public Read')).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+    });
+  });
+
+  it('updates the ACL and submits the appropriate value', async () => {
+    renderWithTheme(<ObjectDetailsDrawer {...props} />);
+
+    await waitFor(() => {
+      const aclSelect = screen.getByTestId('select');
+      fireEvent.change(aclSelect, {
+        target: { value: 'private' }
+      });
+
+      expect(screen.getByText('Private')).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+
+      const saveButton = screen.getByText('Save');
+      fireEvent.click(saveButton);
+
+      expect(mockUpdateObjectACL).toHaveBeenCalledWith(
+        'cluster-id',
+        'my-bucket',
+        'my-dir/my-image.png',
+        'private'
+      );
+    });
   });
 });

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.test.tsx
@@ -8,7 +8,9 @@ const props: Props = {
   lastModified: '2019-12-31T23:59:59Z',
   name: 'my-image.png',
   size: 12345,
-  url: 'https://my-bucket.cluster-id.linodeobjects.com/my-image.png'
+  url: 'https://my-bucket.cluster-id.linodeobjects.com/my-image.png',
+  bucketName: 'my-bucket',
+  clusterId: 'cluster-id'
 };
 
 describe('ObjectDetailsDrawer', () => {

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.test.tsx
@@ -1,6 +1,5 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import * as React from 'react';
-import * as objectStorage from '@linode/api-v4/lib/object-storage/objects';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 import ObjectDetailsDrawer, { Props } from './ObjectDetailsDrawer';
 
@@ -13,11 +12,6 @@ jest.mock('@linode/api-v4/lib/object-storage/objects', () => {
     updateObjectACL: jest.fn().mockResolvedValue({})
   };
 });
-
-const mockUpdateObjectACL = jest.spyOn<any, any>(
-  objectStorage,
-  'updateObjectACL'
-);
 
 jest.mock('src/components/EnhancedSelect/Select');
 
@@ -57,41 +51,5 @@ describe('ObjectDetailsDrawer', () => {
     await waitFor(() =>
       expect(screen.queryByTestId('lastModified')).not.toBeInTheDocument()
     );
-  });
-
-  it("shows the Object's ACL", async () => {
-    renderWithTheme(<ObjectDetailsDrawer {...props} />);
-    await waitFor(() => {
-      expect(screen.getByText('Public Read')).toHaveAttribute(
-        'aria-selected',
-        'true'
-      );
-    });
-  });
-
-  it('updates the ACL and submits the appropriate value', async () => {
-    renderWithTheme(<ObjectDetailsDrawer {...props} />);
-
-    await waitFor(() => {
-      const aclSelect = screen.getByTestId('select');
-      fireEvent.change(aclSelect, {
-        target: { value: 'private' }
-      });
-
-      expect(screen.getByText('Private')).toHaveAttribute(
-        'aria-selected',
-        'true'
-      );
-
-      const saveButton = screen.getByText('Save');
-      fireEvent.click(saveButton);
-
-      expect(mockUpdateObjectACL).toHaveBeenCalledWith(
-        'cluster-id',
-        'my-bucket',
-        'my-dir/my-image.png',
-        'private'
-      );
-    });
   });
 });

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.tsx
@@ -1,33 +1,44 @@
+import {
+  ACLType,
+  getObjectACL,
+  updateObjectACL
+} from '@linode/api-v4/lib/object-storage';
 import * as React from 'react';
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
+import ConfirmationDialog from 'src/components/ConfirmationDialog';
 import CopyTooltip from 'src/components/CopyTooltip';
 import Divider from 'src/components/core/Divider';
-import { makeStyles } from 'src/components/core/styles';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Drawer from 'src/components/Drawer';
+import EnhancedSelect from 'src/components/EnhancedSelect';
+import { Item } from 'src/components/EnhancedSelect/Select';
 import ExternalLink from 'src/components/ExternalLink';
-import { useAPIRequest } from 'src/hooks/useAPIRequest';
+import Notice from 'src/components/Notice';
+import useOpenClose from 'src/hooks/useOpenClose';
+import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import formatDate from 'src/utilities/formatDate';
 import { truncateMiddle } from 'src/utilities/truncate';
 import { readableBytes } from 'src/utilities/unitConversions';
-import {
-  getObjectACL,
-  ObjectStorageObjectACL
-} from '@linode/api-v4/lib/object-storage';
+import { aclOptions } from '../utilities';
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((theme: Theme) => ({
   divider: {
     marginTop: 16,
     marginBottom: 16,
     height: 1,
     backgroundColor: '#EBEBEB'
   },
-  copy: { marginTop: 16, padding: 0 }
+  copy: { marginTop: 16, padding: 0 },
+  submitButton: { marginTop: theme.spacing(2) }
 }));
 
 export interface Props {
   open: boolean;
   onClose: () => void;
   name?: string;
+  displayName?: string;
   size?: number | null;
   lastModified?: string | null;
   // enablePublicURL: () => void;
@@ -37,10 +48,13 @@ export interface Props {
 }
 
 const ObjectDetailsDrawer: React.FC<Props> = props => {
+  const classes = useStyles();
+
   const {
     open,
     onClose,
     name,
+    displayName,
     size,
     lastModified,
     url,
@@ -48,11 +62,56 @@ const ObjectDetailsDrawer: React.FC<Props> = props => {
     clusterId
   } = props;
 
-  const { data, loading, error } = useAPIRequest<ObjectStorageObjectACL | null>(
-    open ? () => getObjectACL(clusterId, bucketName, name) : null,
-    null,
-    [open]
-  );
+  const [aclData, setACLData] = React.useState<ACLType | null>(null);
+  const [aclLoading, setACLLoading] = React.useState(false);
+  const [aclError, setACLError] = React.useState('');
+
+  const [selectedACL, setSelectedACL] = React.useState<ACLType | null>(null);
+  const [updateACLLoading, setUpdateACLLoading] = React.useState(false);
+  const [updateACLError, setUpdateACLError] = React.useState('');
+  const [updateACLSuccess, setUpdateACLSuccess] = React.useState(false);
+
+  const { open: openDialog, isOpen, close } = useOpenClose();
+
+  React.useEffect(() => {
+    if (open && name) {
+      setACLData(null);
+      setSelectedACL(null);
+      setACLLoading(true);
+      setUpdateACLSuccess(false);
+      getObjectACL(clusterId, bucketName, name)
+        .then(({ acl }) => {
+          setACLLoading(false);
+          setACLData(acl);
+          setSelectedACL(acl);
+        })
+        .catch(err => {
+          setACLLoading(false);
+          setACLError(getErrorStringOrDefault(err));
+        });
+    }
+  }, [open, clusterId, bucketName, name]);
+
+  const handleSubmit = () => {
+    // TS safety check.
+    if (!name || !selectedACL) {
+      return;
+    }
+
+    setUpdateACLSuccess(false);
+    setUpdateACLLoading(true);
+
+    updateObjectACL(clusterId, bucketName, name, selectedACL)
+      .then(() => {
+        setUpdateACLSuccess(true);
+        setACLData(selectedACL);
+        setUpdateACLLoading(false);
+      })
+      .catch(err => {
+        setUpdateACLLoading(false);
+        setUpdateACLError(getErrorStringOrDefault(err));
+      });
+  };
 
   let formattedLastModified;
   try {
@@ -61,13 +120,20 @@ const ObjectDetailsDrawer: React.FC<Props> = props => {
     }
   } catch {}
 
-  const classes = useStyles();
+  // An Object's ACL is "custom" is the user has done some stuff with the
+  // S3 API directly (instead of using one of the canned ACLs). "Custom"
+  // is not a selectable option, but it is (potentially) returned by the
+  // API, so we present it as a disabled option here.
+  const _options =
+    aclData === 'custom'
+      ? [{ label: 'Custom', value: 'custom' }, ...aclOptions]
+      : aclOptions;
 
   return (
     <Drawer
       open={open}
       onClose={onClose}
-      title={truncateMiddle(name ?? 'Object Detail')}
+      title={truncateMiddle(displayName ?? 'Object Detail')}
     >
       {size ? (
         <Typography variant="subtitle2">
@@ -82,8 +148,6 @@ const ObjectDetailsDrawer: React.FC<Props> = props => {
 
       <Divider className={classes.divider} />
 
-      {/* ENABLE PUBLIC URL TOGGLE GOES HERE*/}
-
       {url ? (
         <>
           <ExternalLink link={url} text={truncateMiddle(url, 50)} />
@@ -94,6 +158,67 @@ const ObjectDetailsDrawer: React.FC<Props> = props => {
           />
         </>
       ) : null}
+
+      <Divider className={classes.divider} />
+
+      {updateACLSuccess ? (
+        <Notice success text="Object access updated successfully." />
+      ) : null}
+
+      <EnhancedSelect
+        label="Access (Object ACL)"
+        placeholder="Loading access..."
+        isClearable={false}
+        options={_options}
+        isLoading={aclLoading}
+        disabled={aclLoading}
+        errorText={aclError || updateACLError}
+        onChange={(selected: Item<ACLType> | null) => {
+          if (selected) {
+            setUpdateACLSuccess(false);
+            setSelectedACL(selected.value);
+          }
+        }}
+        isOptionDisabled={(item: Item<ACLType>) => item.value === 'custom'}
+        value={_options.find(
+          thisOption => thisOption.value === selectedACL ?? 'private'
+        )}
+      />
+
+      <Button
+        className={classes.submitButton}
+        buttonType="primary"
+        onClick={() => {
+          if (selectedACL === 'public-read-write') {
+            openDialog();
+          } else {
+            handleSubmit();
+          }
+        }}
+        disabled={aclData === selectedACL}
+        loading={updateACLLoading}
+      >
+        Save
+      </Button>
+
+      <ConfirmationDialog
+        title={`Confirm Object Access`}
+        open={isOpen}
+        onClose={close}
+        actions={() => (
+          <ActionsPanel style={{ padding: 0 }}>
+            <Button buttonType="cancel" onClick={close} data-qa-cancel>
+              Cancel
+            </Button>
+            <Button buttonType="secondary" destructive onClick={handleSubmit}>
+              Confirm
+            </Button>
+          </ActionsPanel>
+        )}
+      >
+        Are you sure want make {name} writable by everyone? This is not
+        recommended for most use cases.
+      </ConfirmationDialog>
     </Drawer>
   );
 };

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.tsx
@@ -79,15 +79,20 @@ const ObjectDetailsDrawer: React.FC<Props> = props => {
 
   React.useEffect(() => {
     // When the drawer is opened, clear out all old state.
-    if (open && name) {
+    if (open) {
       setACLData(null);
       setSelectedACL(null);
-      setACLLoading(true);
       setUpdateACLError('');
       setACLError('');
       setUpdateACLSuccess(false);
 
+      // TS safety check.
+      if (!name) {
+        return;
+      }
+
       // Then, get the current Object's ACL information.
+      setACLLoading(true);
       getObjectACL(clusterId, bucketName, name)
         .then(({ acl }) => {
           setACLLoading(false);
@@ -194,6 +199,7 @@ const ObjectDetailsDrawer: React.FC<Props> = props => {
         value={_options.find(
           thisOption => thisOption.value === selectedACL ?? 'private'
         )}
+        data-testid="acl-select"
       />
 
       <Button

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.tsx
@@ -41,7 +41,6 @@ export interface Props {
   displayName?: string;
   size?: number | null;
   lastModified?: string | null;
-  // enablePublicURL: () => void;
   url?: string;
   bucketName: string;
   clusterId: string;
@@ -62,23 +61,33 @@ const ObjectDetailsDrawer: React.FC<Props> = props => {
     clusterId
   } = props;
 
+  // ACL data for this Object (from the API).
   const [aclData, setACLData] = React.useState<ACLType | null>(null);
   const [aclLoading, setACLLoading] = React.useState(false);
   const [aclError, setACLError] = React.useState('');
 
+  // The ACL Option currently selected in the <EnhancedSelect /> component.
   const [selectedACL, setSelectedACL] = React.useState<ACLType | null>(null);
+
+  // State for submitting the ACL option.
   const [updateACLLoading, setUpdateACLLoading] = React.useState(false);
   const [updateACLError, setUpdateACLError] = React.useState('');
   const [updateACLSuccess, setUpdateACLSuccess] = React.useState(false);
 
+  // State for dealing with the confirmation modal when selecting read/write.
   const { open: openDialog, isOpen, close } = useOpenClose();
 
   React.useEffect(() => {
+    // When the drawer is opened, clear out all old state.
     if (open && name) {
       setACLData(null);
       setSelectedACL(null);
       setACLLoading(true);
+      setUpdateACLError('');
+      setACLError('');
       setUpdateACLSuccess(false);
+
+      // Then, get the current Object's ACL information.
       getObjectACL(clusterId, bucketName, name)
         .then(({ acl }) => {
           setACLLoading(false);
@@ -100,6 +109,8 @@ const ObjectDetailsDrawer: React.FC<Props> = props => {
 
     setUpdateACLSuccess(false);
     setUpdateACLLoading(true);
+    setUpdateACLError('');
+    setACLError('');
 
     updateObjectACL(clusterId, bucketName, name, selectedACL)
       .then(() => {
@@ -113,21 +124,21 @@ const ObjectDetailsDrawer: React.FC<Props> = props => {
       });
   };
 
+  // An Object's ACL is "custom" is the user has done things with the s3 API
+  // directly (instead of using one of the canned ACLs). "Custom" s not a
+  // selectable option, but it is (potentially) returned by the API, so we
+  // present it here as a disabled option.
+  const _options =
+    aclData === 'custom'
+      ? [{ label: 'Custom', value: 'custom' }, ...aclOptions]
+      : aclOptions;
+
   let formattedLastModified;
   try {
     if (lastModified) {
       formattedLastModified = formatDate(lastModified);
     }
   } catch {}
-
-  // An Object's ACL is "custom" is the user has done some stuff with the
-  // S3 API directly (instead of using one of the canned ACLs). "Custom"
-  // is not a selectable option, but it is (potentially) returned by the
-  // API, so we present it as a disabled option here.
-  const _options =
-    aclData === 'custom'
-      ? [{ label: 'Custom', value: 'custom' }, ...aclOptions]
-      : aclOptions;
 
   return (
     <Drawer

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.tsx
@@ -5,9 +5,14 @@ import { makeStyles } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Drawer from 'src/components/Drawer';
 import ExternalLink from 'src/components/ExternalLink';
+import { useAPIRequest } from 'src/hooks/useAPIRequest';
 import formatDate from 'src/utilities/formatDate';
 import { truncateMiddle } from 'src/utilities/truncate';
 import { readableBytes } from 'src/utilities/unitConversions';
+import {
+  getObjectACL,
+  ObjectStorageObjectACL
+} from '@linode/api-v4/lib/object-storage';
 
 const useStyles = makeStyles(() => ({
   divider: {
@@ -27,10 +32,27 @@ export interface Props {
   lastModified?: string | null;
   // enablePublicURL: () => void;
   url?: string;
+  bucketName: string;
+  clusterId: string;
 }
 
 const ObjectDetailsDrawer: React.FC<Props> = props => {
-  const { open, onClose, name, size, lastModified, url } = props;
+  const {
+    open,
+    onClose,
+    name,
+    size,
+    lastModified,
+    url,
+    bucketName,
+    clusterId
+  } = props;
+
+  const { data, loading, error } = useAPIRequest<ObjectStorageObjectACL | null>(
+    open ? () => getObjectACL(clusterId, bucketName, name) : null,
+    null,
+    [open]
+  );
 
   let formattedLastModified;
   try {

--- a/packages/manager/src/features/ObjectStorage/utilities.ts
+++ b/packages/manager/src/features/ObjectStorage/utilities.ts
@@ -2,9 +2,11 @@ import { FormikProps } from 'formik';
 import { AccountSettings } from '@linode/api-v4/lib/account';
 import {
   ObjectStorageClusterID,
-  ObjectStorageObject
+  ObjectStorageObject,
+  ACLType
 } from '@linode/api-v4/lib/object-storage';
 import { OBJECT_STORAGE_DELIMITER, OBJECT_STORAGE_ROOT } from 'src/constants';
+import { Item } from 'src/components/EnhancedSelect/Select';
 
 export const generateObjectUrl = (
   clusterId: ObjectStorageClusterID,
@@ -149,4 +151,19 @@ export const confirmObjectStorage = <T extends {}>(
   } else {
     formikProps.handleSubmit();
   }
+};
+
+export const aclOptions: Item<ACLType>[] = [
+  { label: 'Private', value: 'private' },
+  { label: 'Public Read', value: 'public-read' },
+  { label: 'Authenticated Read', value: 'authenticated-read' },
+  { label: 'Public Read/Write', value: 'public-read-write' }
+];
+
+export const objectACLHelperText: Record<ACLType, string> = {
+  private: 'Private ACL',
+  'public-read': 'Public Read ACL',
+  'authenticated-read': 'Authenticated Read ACL',
+  'public-read-write': 'Public Read/Write ACL',
+  custom: 'Custom ACL'
 };


### PR DESCRIPTION
## Description

Adds ACL selection to the Object Details drawer.

- Two new methods for the JS Client.
- GET the Object's ACL when the drawer is opened.
- Allow the user the make an ACL selection.
- If they've selected "Public Read/Write" display a confirmation modal upon clicking "Save".
- Fix the EnhancedSelect mock to correctly account for the selected value

I created a new component, ACLSelect, since we'll need almost identical components/logic for Buckets.

## Note to Reviewers

To test an Object having a "Custom" ACL, use the s3 API directly (reach out if you need help).
