### PR TITLE
Small refactor of NavTabs to accept "render" prop

### DIFF
--- a/packages/manager/src/components/NavTabs/NavTabs.tsx
+++ b/packages/manager/src/components/NavTabs/NavTabs.tsx
@@ -10,9 +10,10 @@ import TabPanel from 'src/components/core/ReachTabPanel';
 export interface NavTab {
   title: string;
   routeName: string;
-  component:
+  component?:
     | React.ComponentType
     | React.LazyExoticComponent<React.ComponentType>;
+  render?: JSX.Element;
   // Whether or not this tab should be rendered in the background (even when
   // not on screen). Consumers should consider performance implications,
   // especially when a component behind a tab performs network requests.
@@ -62,13 +63,21 @@ const NavTabs: React.FC<CombinedProps> = props => {
       <React.Suspense fallback={<SuspenseLoader />}>
         <TabPanels>
           {tabs.map((thisTab, i) => {
+            if (!thisTab.render && !thisTab.component) {
+              return null;
+            }
+
             const _TabPanelComponent = thisTab.backgroundRendering
               ? TabPanel
               : SafeTabPanel;
 
             return (
               <_TabPanelComponent key={thisTab.routeName} index={i}>
-                <thisTab.component />
+                {thisTab.component ? (
+                  <thisTab.component />
+                ) : thisTab.render ? (
+                  thisTab.render
+                ) : null}
               </_TabPanelComponent>
             );
           })}

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
@@ -3,7 +3,6 @@ import {
   getDatabaseBackups
 } from '@linode/api-v4/lib/databases';
 import * as React from 'react';
-import { useRouteMatch } from 'react-router-dom';
 import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import TableBody from 'src/components/core/TableBody';
@@ -23,19 +22,17 @@ const useStyles = makeStyles((theme: Theme) => ({
   }
 }));
 
-export const DatabaseBackups: React.FC<{}> = () => {
+interface Props {
+  databaseID: number;
+}
+
+export const DatabaseBackups: React.FC<Props> = props => {
   const classes = useStyles();
 
-  // @todo: get this ID as a prop
-  const match = useRouteMatch<{ id: string }>('/databases/:id');
-
-  const thisDatabaseID = match?.params?.id;
+  const { databaseID } = props;
 
   const backups = useAPIRequest<DatabaseBackup[]>(
-    // @todo: clean up when ID is a required prop
-    thisDatabaseID
-      ? () => getDatabaseBackups(Number(thisDatabaseID)).then(res => res.data)
-      : null,
+    () => getDatabaseBackups(Number(databaseID)).then(res => res.data),
     []
   );
 

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseDetail.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseDetail.tsx
@@ -19,7 +19,7 @@ const DatabaseDetail: React.FC<CombinedProps> = () => {
 
   const thisDatabase = databases.databases.itemsById[thisDatabaseID ?? '-1'];
 
-  if (!thisDatabase || !match) {
+  if (!thisDatabaseID || !thisDatabase || !match) {
     return null;
   }
 
@@ -29,13 +29,13 @@ const DatabaseDetail: React.FC<CombinedProps> = () => {
     {
       title: 'Backups',
       routeName: `${baseURL}/backups`,
-      component: DatabaseBackups,
+      render: <DatabaseBackups databaseID={Number(thisDatabaseID)} />,
       backgroundRendering: true
     },
     {
       title: 'Settings',
       routeName: `${baseURL}/settings`,
-      component: DatabaseSettings,
+      render: <DatabaseSettings databaseID={Number(thisDatabaseID)} />,
       backgroundRendering: true
     }
   ];

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettings.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettings.tsx
@@ -1,18 +1,19 @@
 import * as React from 'react';
-import { useRouteMatch } from 'react-router-dom';
 import useDatabases from 'src/hooks/useDatabases';
-import useReduxLoad from 'src/hooks/useReduxLoad';
 import DatabaseSettingsLabelPanel from './DatabaseSettingsLabelPanel';
 import DatabaseSettingsMaintenancePanel from './DatabaseSettingsMaintenancePanel';
 import DatabaseSettingsPasswordPanel from './DatabaseSettingsPasswordPanel';
 
-export const DatabaseSettings: React.FC<{}> = () => {
-  const match = useRouteMatch<{ id: string }>('/databases/:id');
-  const databases = useDatabases();
-  useReduxLoad(['databases']);
+interface Props {
+  databaseID: number;
+}
 
-  const thisDatabaseID = match?.params?.id;
-  const thisDatabase = databases.databases.itemsById[thisDatabaseID ?? '-1'];
+export const DatabaseSettings: React.FC<Props> = props => {
+  const databases = useDatabases();
+
+  const { databaseID } = props;
+
+  const thisDatabase = databases.databases.itemsById[databaseID];
 
   return (
     <>


### PR DESCRIPTION
## Description

Similar to React Router's API, NavTabs now accepts a `render` prop in addition to the existing `component` prop. The new `render` prop is useful if you need more control of the props that the child component receives (as is the case with DBaaS, which I've updated here).

## Note to Reviewers

No existing functionality should have changed; please check the places where NavTabs is used (DBaaS, Profile).
