### PR TITLE
M3-4650 Remove filtering of app tokens

### DIFF
--- a/packages/manager/src/factories/index.ts
+++ b/packages/manager/src/factories/index.ts
@@ -22,6 +22,7 @@ export * from './managed';
 export * from './networking';
 export * from './nodebalancer';
 export * from './notification';
+export * from './oauth';
 export * from './objectStorage';
 export * from './profile';
 export * from './promotionalOffer';

--- a/packages/manager/src/factories/oauth.ts
+++ b/packages/manager/src/factories/oauth.ts
@@ -1,0 +1,12 @@
+import { Token } from '@linode/api-v4/lib/profile/types';
+import * as Factory from 'factory.ts';
+
+export const appTokenFactory = Factory.Sync.makeFactory<Token>({
+  id: Factory.each(i => i),
+  label: 'test-token',
+  thumbnail_url: null,
+  scopes: 'linodes:create',
+  created: '2020-01-01T12:00:00',
+  expiry: null,
+  website: 'http://cloud.linode.com'
+});

--- a/packages/manager/src/features/Profile/APITokens/APITokenTable.test.ts
+++ b/packages/manager/src/features/Profile/APITokens/APITokenTable.test.ts
@@ -1,5 +1,5 @@
 import { DateTime } from 'luxon';
-import { filterOutLinodeApps, isWayInTheFuture } from './APITokenTable';
+import { isWayInTheFuture } from './APITokenTable';
 
 describe('isWayInTheFuture', () => {
   it('should return true if past 100 years in the future', () => {
@@ -15,57 +15,5 @@ describe('isWayInTheFuture', () => {
       .plus({ years: 55 })
       .toISO();
     expect(isWayInTheFuture(todayPlus55Years)).toBeFalsy();
-  });
-});
-
-describe('filterOutLinodeApps', () => {
-  it("should filter out tokens with linode's domain website", () => {
-    const tokens = [
-      {
-        created: '2018-12-20T15:56:13',
-        expiry: '2019-01-25T16:10:59',
-        id: 438787,
-        label: 'Linode Community Questions',
-        scopes: 'events:modify',
-        thumbnail_url: null
-      },
-      {
-        created: '2018-12-20T15:56:13',
-        expiry: '2019-01-25T16:10:59',
-        id: 438788,
-        label: 'Linode Community Questions',
-        scopes: 'events:modify',
-        thumbnail_url: null,
-        website: 'https://www.myapp.com'
-      },
-      {
-        created: '2018-12-20T15:56:13',
-        expiry: '2019-01-25T16:10:59',
-        id: 438789,
-        label: 'Linode Community Questions',
-        scopes: 'events:modify',
-        thumbnail_url: null,
-        website: 'https://www.linode.com'
-      },
-      {
-        created: '2019-01-24T18:15:29',
-        expiry: '2019-01-24T20:15:29',
-        id: 523760,
-        label: 'Linode Manager',
-        scopes: '*',
-        thumbnail_url: '/account/oauth-clients/04b4276a4094ce378d27/thumbnail',
-        website: 'https://cloud.linode.com'
-      },
-      {
-        created: '2019-01-24T18:15:29',
-        expiry: '2019-01-24T20:15:29',
-        id: 523761,
-        label: 'Linode Manager',
-        scopes: '*',
-        thumbnail_url: '/account/oauth-clients/04b4276a4094ce378d27/thumbnail',
-        website: 'https://cloud.linode.com'
-      }
-    ];
-    expect(tokens.filter(filterOutLinodeApps)).toHaveLength(2);
   });
 });

--- a/packages/manager/src/features/Profile/APITokens/APITokenTable.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokenTable.tsx
@@ -114,9 +114,6 @@ type CombinedProps = Props &
   WithStyles<ClassNames> &
   AccountStateProps;
 
-export const filterOutLinodeApps = (token: Token) =>
-  !token.website || !/.linode.com$/.test(token.website);
-
 export class APITokenTable extends React.Component<CombinedProps, State> {
   static defaultState: State = {
     form: {
@@ -458,10 +455,10 @@ export class APITokenTable extends React.Component<CombinedProps, State> {
       return <TableRowError colSpan={6} message={error[0].reason} />;
     }
 
-    const filteredData = data ? data.filter(filterOutLinodeApps) : [];
+    const tokens = data ?? [];
 
-    return filteredData.length > 0 ? (
-      this.renderRows(filteredData)
+    return tokens.length > 0 ? (
+      this.renderRows(tokens)
     ) : (
       <TableRowEmptyState colSpan={6} />
     );
@@ -642,26 +639,24 @@ export class APITokenTable extends React.Component<CombinedProps, State> {
 
   renderRevokeConfirmationActions = () => {
     return (
-      <React.Fragment>
-        <ActionsPanel>
-          <Button
-            buttonType="cancel"
-            onClick={this.closeRevokeDialog}
-            data-qa-button-cancel
-          >
-            Cancel
-          </Button>
-          <Button
-            buttonType="secondary"
-            loading={this.state.dialog.submittingDialog}
-            destructive
-            onClick={this.revokeAction}
-            data-qa-button-confirm
-          >
-            Revoke
-          </Button>
-        </ActionsPanel>
-      </React.Fragment>
+      <ActionsPanel>
+        <Button
+          buttonType="cancel"
+          onClick={this.closeRevokeDialog}
+          data-qa-button-cancel
+        >
+          Cancel
+        </Button>
+        <Button
+          buttonType="secondary"
+          loading={this.state.dialog.submittingDialog}
+          destructive
+          onClick={this.revokeAction}
+          data-qa-button-confirm
+        >
+          Revoke
+        </Button>
+      </ActionsPanel>
     );
   };
 

--- a/packages/manager/src/features/Profile/APITokens/APITokenTable_CMR.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokenTable_CMR.tsx
@@ -139,9 +139,6 @@ type CombinedProps = Props &
   WithStyles<ClassNames> &
   AccountStateProps;
 
-export const filterOutLinodeApps = (token: Token) =>
-  !token.website || !/.linode.com$/.test(token.website);
-
 export class APITokenTable extends React.Component<CombinedProps, State> {
   static defaultState: State = {
     form: {
@@ -481,10 +478,10 @@ export class APITokenTable extends React.Component<CombinedProps, State> {
       return <TableRowError colSpan={6} message={error[0].reason} />;
     }
 
-    const filteredData = data ? data.filter(filterOutLinodeApps) : [];
+    const tokens = data ?? [];
 
-    return filteredData.length > 0 ? (
-      this.renderRows(filteredData)
+    return tokens.length > 0 ? (
+      this.renderRows(tokens)
     ) : (
       <TableRowEmptyState colSpan={6} />
     );

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -2,6 +2,7 @@ import { rest, RequestHandler } from 'msw';
 
 import {
   accountFactory,
+  appTokenFactory,
   databaseFactory,
   domainFactory,
   domainRecordFactory,
@@ -61,6 +62,10 @@ export const handlers = [
   }),
   rest.put('*/profile', (req, res, ctx) => {
     return res(ctx.json({ ...profileFactory.build(), ...(req.body as any) }));
+  }),
+  rest.get('*/profile/apps', (req, res, ctx) => {
+    const tokens = appTokenFactory.buildList(5);
+    return res(ctx.json(makeResourcePage(tokens)));
   }),
   rest.get('*/regions', async (req, res, ctx) => {
     return res(ctx.json(cachedRegions));


### PR DESCRIPTION
We previously filtered results from profile/apps to remove anything
pointing at a callback url containing "linode.com". This was to prevent
us from showing "official" Linode apps in the list. However, the API
now does this, so it's no longer necessary. Additionally, a user who
has such a token is unable to revoke it. This PR removes the filtering.

## Note 

It's pretty hard to get a "real" token that will test this, but you can use the provided mocks.