### PR TITLE
M3-4278: Lazy load OBJ Buckets

### DIFF
--- a/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.tsx
@@ -132,10 +132,19 @@ export const PrimaryNav: React.FC<PrimaryNavProps> = props => {
   const clustersLoaded = objectStorageClusters.lastUpdated > 0;
 
   React.useEffect(() => {
-    if (!clustersLoaded && !_isRestrictedUser) {
+    if (
+      !clustersLoaded &&
+      !objectStorageClusters.loading &&
+      !_isRestrictedUser
+    ) {
       requestObjectStorageClusters();
     }
-  }, [_isRestrictedUser, clustersLoaded, requestObjectStorageClusters]);
+  }, [
+    _isRestrictedUser,
+    clustersLoaded,
+    objectStorageClusters.loading,
+    requestObjectStorageClusters
+  ]);
 
   const clusterIds = objectStorageClusters.entities.map(
     thisCluster => thisCluster.id

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.tsx
@@ -129,20 +129,16 @@ export const PrimaryNav: React.FC<PrimaryNavProps> = props => {
     account?.data?.capabilities ?? []
   );
 
-  const clustersLoaded = objectStorageClusters.lastUpdated > 0;
+  const clustersLoadedOrLoading =
+    objectStorageClusters.lastUpdated > 0 || objectStorageClusters.loading;
 
   React.useEffect(() => {
-    if (
-      !clustersLoaded &&
-      !objectStorageClusters.loading &&
-      !_isRestrictedUser
-    ) {
+    if (!clustersLoadedOrLoading && !_isRestrictedUser) {
       requestObjectStorageClusters();
     }
   }, [
     _isRestrictedUser,
-    clustersLoaded,
-    objectStorageClusters.loading,
+    clustersLoadedOrLoading,
     requestObjectStorageClusters
   ]);
 

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.tsx
@@ -129,16 +129,18 @@ export const PrimaryNav: React.FC<PrimaryNavProps> = props => {
     account?.data?.capabilities ?? []
   );
 
-  const clustersLoadedOrLoading =
-    objectStorageClusters.lastUpdated > 0 || objectStorageClusters.loading;
+  const clustersLoadedOrLoadingOrHasError =
+    objectStorageClusters.lastUpdated > 0 ||
+    objectStorageClusters.loading ||
+    objectStorageClusters.error;
 
   React.useEffect(() => {
-    if (!clustersLoadedOrLoading && !_isRestrictedUser) {
+    if (!clustersLoadedOrLoadingOrHasError && !_isRestrictedUser) {
       requestObjectStorageClusters();
     }
   }, [
     _isRestrictedUser,
-    clustersLoadedOrLoading,
+    clustersLoadedOrLoadingOrHasError,
     requestObjectStorageClusters
   ]);
 


### PR DESCRIPTION
## Description
Lazy load OBJ buckets

## Type of Change
- Non breaking change ('update', 'change')

## To-Do:
- [x] Test PrimaryNav hover approach vs. alternative

It doesn't seem that loading them in the background in `MainContent_CMR.tsx` offers any significant improvement, so I'm sticking with the approach in this PR