### PR TITLE
M3-3799 Add Buckets to Search Bar

### DIFF
--- a/packages/manager/src/features/Search/SearchLanding.test.tsx
+++ b/packages/manager/src/features/Search/SearchLanding.test.tsx
@@ -22,7 +22,9 @@ const props: Props = {
     nodebalancers: false,
     images: false,
     volumes: false,
-    kubernetes: false
+    kubernetes: false,
+    objectStorageClusters: false,
+    objectStorageBuckets: false
   },
   ...reactRouterProps
 };

--- a/packages/manager/src/features/Search/SearchLanding.test.tsx
+++ b/packages/manager/src/features/Search/SearchLanding.test.tsx
@@ -39,6 +39,10 @@ jest.mock('src/hooks/useReduxLoad', () => ({
   useReduxLoad: () => jest.fn().mockReturnValue({ _loading: false })
 }));
 
+jest.mock('src/hooks/useObjectStorageBuckets', () => ({
+  useObjectStorage: () => jest.fn().mockReturnValue({ loading: false })
+}));
+
 describe('Component', () => {
   it('should render', () => {
     const { getByText } = renderWithTheme(<SearchLanding {...props} />);

--- a/packages/manager/src/features/Search/SearchLanding.tsx
+++ b/packages/manager/src/features/Search/SearchLanding.tsx
@@ -65,7 +65,8 @@ const displayMap = {
   volumes: 'Volumes',
   nodebalancers: 'NodeBalancers',
   images: 'Images',
-  kubernetesClusters: 'Kubernetes'
+  kubernetesClusters: 'Kubernetes',
+  buckets: 'Buckets'
 };
 
 export type CombinedProps = SearchProps & RouteComponentProps<{}>;
@@ -122,7 +123,15 @@ export const SearchLanding: React.FC<CombinedProps> = props => {
   }
 
   const { _loading } = useReduxLoad(
-    ['linodes', 'volumes', 'nodeBalancers', 'images', 'domains', 'kubernetes'],
+    [
+      'linodes',
+      'volumes',
+      'nodeBalancers',
+      'images',
+      'domains',
+      'kubernetes',
+      'buckets'
+    ],
     REFRESH_INTERVAL,
     !_isLargeAccount
   );

--- a/packages/manager/src/features/Search/search.interfaces.ts
+++ b/packages/manager/src/features/Search/search.interfaces.ts
@@ -16,7 +16,8 @@ export type SearchableEntityType =
   | 'domain'
   | 'image'
   | 'nodebalancer'
-  | 'kubernetesCluster';
+  | 'kubernetesCluster'
+  | 'bucket';
 
 // These are the properties on our entities we'd like to search
 export type SearchField = 'tags' | 'label' | 'ips' | 'type';
@@ -28,4 +29,5 @@ export interface SearchResultsByEntity {
   domains: SearchableItem[];
   images: SearchableItem[];
   kubernetesClusters: SearchableItem[];
+  buckets: SearchableItem[];
 }

--- a/packages/manager/src/features/Search/useAPISearch.tsx
+++ b/packages/manager/src/features/Search/useAPISearch.tsx
@@ -110,6 +110,7 @@ const requestEntities = (
           results.data.map(kubernetesClusterToSearchableItem)
         )
       : Promise.resolve([])
+    // Filtering on Object Storage buckets does not work.
   ]).then(results => (flatten(results) as unknown) as SearchableItem[]);
 };
 

--- a/packages/manager/src/features/Search/useAPISearch.tsx
+++ b/packages/manager/src/features/Search/useAPISearch.tsx
@@ -110,7 +110,7 @@ const requestEntities = (
           results.data.map(kubernetesClusterToSearchableItem)
         )
       : Promise.resolve([])
-    // Filtering on Object Storage buckets does not work.
+    // API filtering on Object Storage buckets does not work.
   ]).then(results => (flatten(results) as unknown) as SearchableItem[]);
 };
 

--- a/packages/manager/src/features/Search/utils.test.ts
+++ b/packages/manager/src/features/Search/utils.test.ts
@@ -13,6 +13,7 @@ describe('separate results by entity', () => {
     expect(results).toHaveProperty('images');
     expect(results).toHaveProperty('nodebalancers');
     expect(results).toHaveProperty('kubernetesClusters');
+    expect(results).toHaveProperty('buckets');
   });
 
   it('the value of each entity type is an array', () => {
@@ -22,6 +23,7 @@ describe('separate results by entity', () => {
     expect(results.images).toBeInstanceOf(Array);
     expect(results.nodebalancers).toBeInstanceOf(Array);
     expect(results.kubernetesClusters).toBeInstanceOf(Array);
+    expect(results.buckets).toBeInstanceOf(Array);
   });
 
   it('returns empty results if there is no data', () => {
@@ -32,7 +34,8 @@ describe('separate results by entity', () => {
       domains: [],
       images: [],
       nodebalancers: [],
-      kubernetesClusters: []
+      kubernetesClusters: [],
+      buckets: []
     });
   });
 });

--- a/packages/manager/src/features/Search/utils.ts
+++ b/packages/manager/src/features/Search/utils.ts
@@ -6,7 +6,8 @@ export const emptyResults: SearchResultsByEntity = {
   domains: [],
   images: [],
   nodebalancers: [],
-  kubernetesClusters: []
+  kubernetesClusters: [],
+  buckets: []
 };
 
 export const separateResultsByEntity = (
@@ -18,7 +19,8 @@ export const separateResultsByEntity = (
     domains: [],
     images: [],
     nodebalancers: [],
-    kubernetesClusters: []
+    kubernetesClusters: [],
+    buckets: []
   };
 
   searchResults.forEach(result => {

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar_CMR.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar_CMR.tsx
@@ -68,7 +68,8 @@ const searchDeps: ReduxEntity[] = [
   'images',
   'domains',
   'volumes',
-  'kubernetes'
+  'kubernetes',
+  'buckets'
 ];
 
 export const SearchBar: React.FC<CombinedProps> = props => {

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar_CMR.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar_CMR.tsx
@@ -21,6 +21,7 @@ import { sendSearchBarUsedEvent } from 'src/utilities/ga.ts';
 import { debounce } from 'throttle-debounce';
 import styled, { StyleProps } from './SearchBar_CMR.styles';
 import SearchSuggestion from './SearchSuggestion';
+import { useObjectStorage } from 'src/hooks/useObjectStorageBuckets';
 
 type CombinedProps = WithTypesProps &
   WithImages &
@@ -68,8 +69,7 @@ const searchDeps: ReduxEntity[] = [
   'images',
   'domains',
   'volumes',
-  'kubernetes',
-  'buckets'
+  'kubernetes'
 ];
 
 export const SearchBar: React.FC<CombinedProps> = props => {
@@ -85,10 +85,17 @@ export const SearchBar: React.FC<CombinedProps> = props => {
 
   const { _isLargeAccount } = useAccountManagement();
 
+  // Only request things if the search bar is open/active.
+  const shouldMakeRequests = searchActive && !_isLargeAccount;
+
   const { _loading } = useReduxLoad(
     searchDeps,
     REFRESH_INTERVAL,
-    searchActive && !_isLargeAccount // Only request things if the search bar is open/active.
+    shouldMakeRequests
+  );
+
+  const { loading: objectStorageLoading } = useObjectStorage(
+    shouldMakeRequests
   );
 
   const { searchAPI } = useAPISearch();
@@ -120,7 +127,14 @@ export const SearchBar: React.FC<CombinedProps> = props => {
     } else {
       search(searchText);
     }
-  }, [_loading, search, searchText, _searchAPI, _isLargeAccount]);
+  }, [
+    _loading,
+    objectStorageLoading,
+    search,
+    searchText,
+    _searchAPI,
+    _isLargeAccount
+  ]);
 
   const handleSearchChange = (_searchText: string): void => {
     setSearchText(_searchText);
@@ -203,7 +217,7 @@ export const SearchBar: React.FC<CombinedProps> = props => {
   const finalOptions = createFinalOptions(
     _isLargeAccount ? apiResults : combinedResults,
     searchText,
-    _loading || apiSearchLoading,
+    _loading || apiSearchLoading || objectStorageLoading,
     // Ignore "Unauthorized" errors, since these will always happen on LKE
     // endpoints for restricted users. It's not really an "error" in this case.
     // We still want these users to be able to use the search feature.

--- a/packages/manager/src/hooks/useObjectStorageBuckets.ts
+++ b/packages/manager/src/hooks/useObjectStorageBuckets.ts
@@ -2,15 +2,19 @@ import {
   ObjectStorageBucket,
   ObjectStorageClusterID
 } from '@linode/api-v4/lib/object-storage/types';
+import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { REFRESH_INTERVAL } from 'src/constants';
 import { ApplicationState } from 'src/store';
 import { State } from 'src/store/bucket/bucket.reducer';
 import {
-  getAllBucketsFromAllClusters,
+  deleteBucket,
   DeleteBucketRequest,
-  deleteBucket
+  getAllBucketsFromClusters
 } from 'src/store/bucket/bucket.requests';
 import { Dispatch } from './types';
+import useAccountManagement from './useAccountManagement';
+import useReduxLoad from './useReduxLoad';
 
 export interface ObjectStorageBucketProps {
   objectStorageBuckets: State;
@@ -24,7 +28,7 @@ export const useObjectStorageBuckets = () => {
     (state: ApplicationState) => state.__resources.buckets
   );
   const requestObjectStorageBuckets = (clusterIds: ObjectStorageClusterID[]) =>
-    dispatch(getAllBucketsFromAllClusters(clusterIds));
+    dispatch(getAllBucketsFromClusters(clusterIds));
   const deleteObjectStorageBucket = (options: DeleteBucketRequest) =>
     dispatch(deleteBucket(options));
 
@@ -36,3 +40,63 @@ export const useObjectStorageBuckets = () => {
 };
 
 export default useObjectStorageBuckets;
+
+// Object Storage Redux integration is slightly complicated in that to requests
+// a user's Buckets, we must first request Clusters. This hook neatly abstracts
+// that logic, so that `const { objectStorageBuckets } = useObjectStorage();`
+// is all you need to appropriately get Bucket data into your component.
+//
+// The hook accepts a `predicate` argument, which, if false, prevents Cluster
+// and Bucket data from being loaded.
+//
+// @todo: use this hook everywhere Cluster and/or Bucket data is needed.
+export const useObjectStorage = (predicate?: boolean) => {
+  const dispatch: Dispatch = useDispatch();
+
+  useReduxLoad(['clusters'], REFRESH_INTERVAL, predicate);
+
+  const { _isRestrictedUser } = useAccountManagement();
+
+  const objectStorageClusters = useSelector(
+    (state: ApplicationState) => state.__resources.clusters
+  );
+  const objectStorageBuckets = useSelector(
+    (state: ApplicationState) => state.__resources.buckets
+  );
+
+  const clustersLoaded = objectStorageClusters.lastUpdated > 0;
+
+  const bucketsLoadingOrLoaded =
+    objectStorageBuckets.loading ||
+    objectStorageBuckets.lastUpdated > 0 ||
+    objectStorageBuckets.bucketErrors;
+
+  useEffect(() => {
+    // Object Storage is not available for restricted users.
+    if (_isRestrictedUser || (typeof predicate === 'boolean' && !predicate)) {
+      return;
+    }
+
+    // Once the OBJ Clusters have been loaded, request Buckets from each Cluster.
+    if (clustersLoaded && !bucketsLoadingOrLoaded) {
+      const clusterIds = objectStorageClusters.entities.map(
+        thisCluster => thisCluster.id
+      );
+
+      dispatch(getAllBucketsFromClusters(clusterIds)).catch(_ => null);
+    }
+  }, [
+    _isRestrictedUser,
+    clustersLoaded,
+    bucketsLoadingOrLoaded,
+    objectStorageClusters,
+    dispatch,
+    predicate
+  ]);
+
+  return {
+    objectStorageBuckets,
+    objectStorageClusters,
+    loading: objectStorageClusters.loading || objectStorageBuckets.loading
+  };
+};

--- a/packages/manager/src/hooks/useObjectStorageBuckets.ts
+++ b/packages/manager/src/hooks/useObjectStorageBuckets.ts
@@ -41,7 +41,7 @@ export const useObjectStorageBuckets = () => {
 
 export default useObjectStorageBuckets;
 
-// Object Storage Redux integration is slightly complicated in that to requests
+// Object Storage Redux integration is slightly complicated in that to request
 // a user's Buckets, we must first request Clusters. This hook neatly abstracts
 // that logic, so that `const { objectStorageBuckets } = useObjectStorage();`
 // is all you need to appropriately get Bucket data into your component.

--- a/packages/manager/src/hooks/useObjectStorageBuckets.ts
+++ b/packages/manager/src/hooks/useObjectStorageBuckets.ts
@@ -53,9 +53,9 @@ export default useObjectStorageBuckets;
 export const useObjectStorage = (predicate?: boolean) => {
   const dispatch: Dispatch = useDispatch();
 
-  useReduxLoad(['clusters'], REFRESH_INTERVAL, predicate);
-
   const { _isRestrictedUser } = useAccountManagement();
+
+  useReduxLoad(['clusters'], REFRESH_INTERVAL, predicate || _isRestrictedUser);
 
   const objectStorageClusters = useSelector(
     (state: ApplicationState) => state.__resources.clusters

--- a/packages/manager/src/hooks/useReduxLoad.ts
+++ b/packages/manager/src/hooks/useReduxLoad.ts
@@ -7,7 +7,6 @@ import usePageVisibility from 'src/hooks/usePageVisibility';
 import { ApplicationState } from 'src/store';
 import { requestAccount } from 'src/store/account/account.requests';
 import { requestAccountSettings } from 'src/store/accountSettings/accountSettings.requests';
-import { getAllClustersAndAllBuckets } from 'src/store/bucket/bucket.requests';
 import { requestClusters } from 'src/store/clusters/clusters.actions';
 import { getAllDatabases } from 'src/store/databases/databases.requests';
 import { getAllMySQLTypes } from 'src/store/databases/types.requests';
@@ -54,8 +53,7 @@ export type ReduxEntity =
   | 'clusters'
   | 'vlans'
   | 'databases'
-  | 'databaseTypes'
-  | 'buckets';
+  | 'databaseTypes';
 
 // The Buckets request is a special case since it depends on Clusters.
 type RequestMap = Record<ReduxEntity, any>;
@@ -80,8 +78,7 @@ const requestMap: RequestMap = {
   firewalls: () => getAllFirewalls({}),
   clusters: requestClusters,
   vlans: () => getAllVlans({}),
-  databaseTypes: () => getAllMySQLTypes({}),
-  buckets: () => getAllClustersAndAllBuckets()
+  databaseTypes: () => getAllMySQLTypes({})
 };
 
 export const useReduxLoad = (
@@ -149,9 +146,7 @@ export const requestDeps = (
     const currentResource = state.__resources[deps[i]] || state[deps[i]];
 
     if (currentResource) {
-      const currentResourceHasError = hasError(
-        currentResource?.error || currentResource?.bucketErrors
-      );
+      const currentResourceHasError = hasError(currentResource?.error);
       if (
         currentResource.lastUpdated === 0 &&
         !currentResource.loading &&

--- a/packages/manager/src/store/bucket/bucket.requests.test.ts
+++ b/packages/manager/src/store/bucket/bucket.requests.test.ts
@@ -7,7 +7,7 @@ import { isType } from 'typescript-fsa';
 import { getAllBucketsForAllClustersActions as actions } from './bucket.actions';
 import {
   gatherDataAndErrors,
-  getAllBucketsFromAllClusters
+  getAllBucketsFromClusters
 } from './bucket.requests';
 import { BucketError } from './types';
 
@@ -39,7 +39,7 @@ describe('getAllBucketsFromAllClusters', () => {
   it('handles successes', async () => {
     const store = mockStore();
     await store.dispatch(
-      getAllBucketsFromAllClusters([usEast1, euCentral1]) as any
+      getAllBucketsFromClusters([usEast1, euCentral1]) as any
     );
     const [firstAction, secondAction] = store.getActions();
     expect(isType(firstAction, actions.started)).toBe(true);
@@ -49,7 +49,7 @@ describe('getAllBucketsFromAllClusters', () => {
   it('handles errors', async () => {
     const store = mockStore();
     await store.dispatch(
-      getAllBucketsFromAllClusters([usEast1, euCentral1]) as any
+      getAllBucketsFromClusters([usEast1, euCentral1]) as any
     );
     const [, secondAction] = store.getActions();
     expect(isType(secondAction, actions.failed)).toBe(true);

--- a/packages/manager/src/store/bucket/bucket.requests.ts
+++ b/packages/manager/src/store/bucket/bucket.requests.ts
@@ -9,6 +9,7 @@ import {
   ObjectStorageDeleteBucketRequestPayload
 } from '@linode/api-v4/lib/object-storage';
 import { GetAllData, getAllWithArguments } from 'src/utilities/getAll';
+import { requestClusters } from '../clusters/clusters.actions';
 import { createRequestThunk } from '../store.helpers';
 import { ThunkActionCreator } from '../types';
 import {
@@ -74,6 +75,26 @@ export const getAllBucketsFromAllClusters: ThunkActionCreator<
 
     return data;
   });
+};
+
+export const getAllClustersAndAllBuckets: ThunkActionCreator<Promise<
+  ObjectStorageBucket[]
+>> = () => (dispatch, getState) => {
+  const clustersFromState = getState().__resources.clusters.entities;
+
+  if (clustersFromState.length > 0) {
+    return dispatch(
+      getAllBucketsFromAllClusters(
+        clustersFromState.map(thisCluster => thisCluster.id)
+      )
+    );
+  }
+
+  return dispatch(requestClusters()).then(clusters =>
+    dispatch(
+      getAllBucketsFromAllClusters(clusters.map(thisCluster => thisCluster.id))
+    )
+  );
 };
 
 export const gatherDataAndErrors = (

--- a/packages/manager/src/store/bucket/bucket.requests.ts
+++ b/packages/manager/src/store/bucket/bucket.requests.ts
@@ -9,7 +9,6 @@ import {
   ObjectStorageDeleteBucketRequestPayload
 } from '@linode/api-v4/lib/object-storage';
 import { GetAllData, getAllWithArguments } from 'src/utilities/getAll';
-import { requestClusters } from '../clusters/clusters.actions';
 import { createRequestThunk } from '../store.helpers';
 import { ThunkActionCreator } from '../types';
 import {
@@ -49,7 +48,7 @@ const _getAllBucketsInCluster = getAllWithArguments<ObjectStorageBucket>(
  * Note: a slight oddity here is that in the case of failure, both the `done` and `failed` actions
  * will be dispatched. The reducer handles this and it should be OK, but proceed with caution.
  */
-export const getAllBucketsFromAllClusters: ThunkActionCreator<
+export const getAllBucketsFromClusters: ThunkActionCreator<
   Promise<ObjectStorageBucket[]>,
   ObjectStorageClusterID[]
 > = clusterIds => dispatch => {
@@ -74,31 +73,6 @@ export const getAllBucketsFromAllClusters: ThunkActionCreator<
     dispatch(getAllBucketsForAllClustersActions.done({ result: data }));
 
     return data;
-  });
-};
-
-export const getAllClustersAndAllBuckets: ThunkActionCreator<Promise<
-  ObjectStorageBucket[]
->> = () => (dispatch, getState) => {
-  const clustersFromState = getState().__resources.clusters.entities;
-
-  if (clustersFromState.length > 0) {
-    return dispatch(
-      getAllBucketsFromAllClusters(
-        clustersFromState.map(thisCluster => thisCluster.id)
-      )
-    );
-  }
-
-  dispatch(getAllBucketsForAllClustersActions.started());
-  return dispatch(requestClusters()).then(clusters => {
-    // In the event of a failure, `clusters` will be of type APIError[], so
-    // filter those out first.
-    const _clusters = clusters.filter(thisCluster => Boolean(thisCluster.id));
-
-    return dispatch(
-      getAllBucketsFromAllClusters(_clusters.map(thisCluster => thisCluster.id))
-    );
   });
 };
 

--- a/packages/manager/src/store/bucket/bucket.requests.ts
+++ b/packages/manager/src/store/bucket/bucket.requests.ts
@@ -91,11 +91,15 @@ export const getAllClustersAndAllBuckets: ThunkActionCreator<Promise<
   }
 
   dispatch(getAllBucketsForAllClustersActions.started());
-  return dispatch(requestClusters()).then(clusters =>
-    dispatch(
-      getAllBucketsFromAllClusters(clusters.map(thisCluster => thisCluster.id))
-    )
-  );
+  return dispatch(requestClusters()).then(clusters => {
+    // In the event of a failure, `clusters` will be of type APIError[], so
+    // filter those out first.
+    const _clusters = clusters.filter(thisCluster => Boolean(thisCluster.id));
+
+    return dispatch(
+      getAllBucketsFromAllClusters(_clusters.map(thisCluster => thisCluster.id))
+    );
+  });
 };
 
 export const gatherDataAndErrors = (

--- a/packages/manager/src/store/bucket/bucket.requests.ts
+++ b/packages/manager/src/store/bucket/bucket.requests.ts
@@ -90,6 +90,7 @@ export const getAllClustersAndAllBuckets: ThunkActionCreator<Promise<
     );
   }
 
+  dispatch(getAllBucketsForAllClustersActions.started());
   return dispatch(requestClusters()).then(clusters =>
     dispatch(
       getAllBucketsFromAllClusters(clusters.map(thisCluster => thisCluster.id))

--- a/packages/manager/src/store/selectors/entitiesErrors.ts
+++ b/packages/manager/src/store/selectors/entitiesErrors.ts
@@ -12,6 +12,8 @@ export interface ErrorObject {
   images: boolean;
   nodebalancers: boolean;
   kubernetes: boolean;
+  objectStorageClusters: boolean;
+  objectStorageBuckets: boolean;
 }
 
 export const linodesErrorSelector = (state: State) => {
@@ -28,9 +30,15 @@ export const typesErrorSelector = (state: State) =>
   Boolean(state.types.error && state.types.error.length > 0);
 export const kubernetesErrorSelector = (state: State) =>
   Object.values(state.kubernetes.error ?? {}).some(Boolean);
+export const objectStorageClustersSelector = (state: State) =>
+  Object.values(state.clusters.error ?? {}).some(Boolean);
+export const objectStorageBucketsSelector = (state: State) =>
+  Object.values(state.buckets.bucketErrors ?? {}).some(Boolean);
 
 export default createSelector<
   State,
+  boolean,
+  boolean,
   boolean,
   boolean,
   boolean,
@@ -45,14 +53,34 @@ export default createSelector<
   domainsErrorSelector,
   imagesErrorSelector,
   kubernetesErrorSelector,
-  (linodes, volumes, nodebalancers, domains, images, kubernetes) => ({
+  objectStorageClustersSelector,
+  objectStorageBucketsSelector,
+  (
     linodes,
     volumes,
     nodebalancers,
     domains,
     images,
     kubernetes,
+    objectStorageClusters,
+    objectStorageBuckets
+  ) => ({
+    linodes,
+    volumes,
+    nodebalancers,
+    domains,
+    images,
+    kubernetes,
+    objectStorageClusters,
+    objectStorageBuckets,
     hasErrors:
-      linodes || volumes || nodebalancers || domains || images || kubernetes
+      linodes ||
+      volumes ||
+      nodebalancers ||
+      domains ||
+      images ||
+      kubernetes ||
+      objectStorageClusters ||
+      objectStorageBuckets
   })
 );

--- a/packages/manager/src/store/selectors/getSearchEntities.ts
+++ b/packages/manager/src/store/selectors/getSearchEntities.ts
@@ -15,6 +15,9 @@ import { SearchableItem } from 'src/features/Search/search.interfaces';
 import { ApplicationState } from 'src/store';
 import { ExtendedNodePool } from 'src/store/kubernetes/nodePools.actions';
 import getLinodeDescription from 'src/utilities/getLinodeDescription';
+import { ObjectStorageBucket } from '@linode/api-v4/lib/object-storage';
+import { objectStorageClusterDisplay } from 'src/constants';
+import { readableBytes } from 'src/utilities/unitConversions';
 
 type State = ApplicationState['__resources'];
 
@@ -149,6 +152,22 @@ export const kubernetesClusterToSearchableItem = (
   }
 });
 
+export const bucketToSearchableItem = (
+  bucket: ObjectStorageBucket
+): SearchableItem => ({
+  label: bucket.label,
+  value: `${bucket.cluster}/${bucket.label}`,
+  entityType: 'bucket',
+  data: {
+    icon: 'bucket',
+    path: `/object-storage/buckets/${bucket.cluster}/${bucket.label}`,
+    created: bucket.created,
+    label: bucket.label,
+    region: objectStorageClusterDisplay[bucket.cluster],
+    description: readableBytes(bucket.size).formatted
+  }
+});
+
 const linodeSelector = (state: State) => Object.values(state.linodes.itemsById);
 const volumeSelector = ({ volumes }: State) => Object.values(volumes.itemsById);
 const nodebalSelector = ({ nodeBalancers }: State) =>
@@ -160,6 +179,7 @@ const typesSelector = (state: State) => state.types.entities;
 const kubernetesClusterSelector = (state: State) =>
   Object.values(state.kubernetes.itemsById);
 const kubePoolSelector = (state: State) => state.nodePools.entities;
+const bucketSelector = (state: State) => state.buckets.data;
 
 export default createSelector<
   State,
@@ -171,6 +191,7 @@ export default createSelector<
   LinodeType[],
   KubernetesCluster[],
   ExtendedNodePool[],
+  ObjectStorageBucket[],
   SearchableItem[]
 >(
   linodeSelector,
@@ -181,6 +202,7 @@ export default createSelector<
   typesSelector,
   kubernetesClusterSelector,
   kubePoolSelector,
+  bucketSelector,
   (
     linodes,
     volumes,
@@ -189,7 +211,8 @@ export default createSelector<
     nodebalancers,
     types,
     kubernetesClusters,
-    nodePools
+    nodePools,
+    buckets
   ) => {
     const arrOfImages = Object.values(images);
     const searchableLinodes = linodes.map(linode =>
@@ -207,6 +230,7 @@ export default createSelector<
         return extendCluster(thisCluster, pools, types);
       })
       .map(kubernetesClusterToSearchableItem);
+    const searchableObjectStorageBuckets = buckets.map(bucketToSearchableItem);
 
     return [
       ...searchableLinodes,
@@ -214,7 +238,8 @@ export default createSelector<
       ...searchableImages,
       ...searchableDomains,
       ...searchableNodebalancers,
-      ...searchableKubernetesClusters
+      ...searchableKubernetesClusters,
+      ...searchableObjectStorageBuckets
     ];
   }
 );

--- a/packages/manager/src/store/selectors/getSearchEntitites.test.ts
+++ b/packages/manager/src/store/selectors/getSearchEntitites.test.ts
@@ -26,6 +26,9 @@ describe('getSearchEntities selector', () => {
     },
     nodePools: {
       entities: []
+    },
+    buckets: {
+      data: []
     }
   };
   it('should return an array of SearchableItems', () => {


### PR DESCRIPTION
## Description

Adds Object Storage Buckets to the Search Results (search bar and landing page).

Only works in CMR and on non-large accounts.

I ended up creating a new `useObjectStorage` hook which abstracts away the need to first request Clusters. A remaining TODO item is to use this hook everywhere that depends on Object Storage.

(Note: the dependency on first requesting Clusters is why I didn't end up adding this to `useReduxLoad`... I could make it work but it would be really messy for not much gain.

Note: This adds a few seconds of latency to the search experience. One possible remedy is to trigger the requests when the user clicks on the search bar (instead of typing). Curious to hear your thoughts.

## Note to Reviewers

Please try out the search bar, search landing page, etc. on large accounts, small accounts, restricted accounts.