### PR TITLE
Change: Make typeToConfirm optional in DeletionDialog

### DIFF
--- a/packages/manager/src/components/DeletionDialog/DeletionDialog.tsx
+++ b/packages/manager/src/components/DeletionDialog/DeletionDialog.tsx
@@ -16,6 +16,7 @@ interface Props {
   onDelete: () => void;
   label: string;
   loading: boolean;
+  typeToConfirm?: boolean;
 }
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -29,7 +30,16 @@ type CombinedProps = Props;
 
 const DeletionDialog: React.FC<CombinedProps> = props => {
   const classes = useStyles();
-  const { entity, error, label, onClose, onDelete, open, loading } = props;
+  const {
+    entity,
+    error,
+    label,
+    onClose,
+    onDelete,
+    open,
+    loading,
+    typeToConfirm
+  } = props;
   const [confirmationText, setConfirmationText] = React.useState('');
   const renderActions = () => (
     <ActionsPanel style={{ padding: 0 }}>
@@ -41,7 +51,7 @@ const DeletionDialog: React.FC<CombinedProps> = props => {
         destructive
         onClick={onDelete}
         loading={loading}
-        disabled={confirmationText !== label}
+        disabled={typeToConfirm && confirmationText !== label}
         data-qa-confirm
       >
         Delete
@@ -67,18 +77,22 @@ const DeletionDialog: React.FC<CombinedProps> = props => {
       <Typography>
         Deleting this {entity} is permanent and can&apos;t be undone.
       </Typography>
-      <Typography className={classes.text}>
-        To confirm deletion, type the name of the {entity} (
-        <strong>{label}</strong>) in the field below:
-      </Typography>
-      <TextField
-        label={`${capitalize(entity)} Name:`}
-        value={confirmationText}
-        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-          setConfirmationText(e.target.value)
-        }
-        placeholder={label}
-      />
+      {typeToConfirm && (
+        <>
+          <Typography className={classes.text}>
+            To confirm deletion, type the name of the {entity} (
+            <strong>{label}</strong>) in the field below:
+          </Typography>
+          <TextField
+            label={`${capitalize(entity)} Name:`}
+            value={confirmationText}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setConfirmationText(e.target.value)
+            }
+            placeholder={label}
+          />
+        </>
+      )}
     </ConfirmationDialog>
   );
 };

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseEntityDetail.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseEntityDetail.tsx
@@ -93,6 +93,7 @@ const DatabaseEntityDetail: React.FC<DatabaseEntityDetailProps> = props => {
         }
       />
       <DeletionDialog
+        typeToConfirm
         label={dialog.entityLabel ?? ''}
         entity="database"
         error={dialog.error}

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
@@ -285,6 +285,7 @@ const DatabaseLanding: React.FC<{}> = _ => {
         initialOrder={{ order: 'asc', orderBy: 'label' }}
       />
       <DeletionDialog
+        typeToConfirm
         label={dialog.entityLabel ?? ''}
         entity="database"
         error={dialog.error}

--- a/packages/manager/src/features/Domains/DeleteDomain.tsx
+++ b/packages/manager/src/features/Domains/DeleteDomain.tsx
@@ -55,6 +55,7 @@ export const DeleteDomain: React.FC<CombinedProps> = props => {
         Delete Domain
       </Button>
       <DeletionDialog
+        typeToConfirm
         entity="domain"
         open={dialog.isOpen}
         label={dialog.entityLabel || ''}


### PR DESCRIPTION
## Description

Follow-on from last sprint. Makes the typeToConfirm behavior of DeletionDialog conditional on a prop. Makes it so you can delete a Managed contact without typing the contact name.

While I was in there, I also updated DomainsLanding to use this pattern, since the dialog you got when deleting a Domain was previously dependent on where you tried to delete from.