### PR TITLE
Make service worker dependent on dev tools rather than env variable

### DIFF
--- a/packages/manager/src/dev-tools/MockDataTool.tsx
+++ b/packages/manager/src/dev-tools/MockDataTool.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import withFeatureFlagProvider from 'src/containers/withFeatureFlagProvider.container';
 import Grid from 'src/components/core/Grid';
 import { MockData, mockDataController } from './mockDataController';
+import ServiceWorkerTool from './ServiceWorkerTool';
 
 const options: { label: string; key: keyof MockData }[] = [
   { label: 'Linodes', key: 'linode' }
@@ -51,6 +52,9 @@ const MockDataTool: React.FC<{}> = () => {
             </div>
           );
         })}
+      </Grid>
+      <Grid item xs={12}>
+        <ServiceWorkerTool />
       </Grid>
     </Grid>
   );

--- a/packages/manager/src/dev-tools/ServiceWorkerTool.tsx
+++ b/packages/manager/src/dev-tools/ServiceWorkerTool.tsx
@@ -9,17 +9,16 @@ export const ServiceWorkerTool: React.FC<{}> = _ => {
   React.useEffect(() => {
     if (workerActive) {
       worker.start();
+    } else {
+      worker.stop();
     }
   }, [workerActive]);
 
   const handleToggleWorker = (e: React.ChangeEvent<HTMLInputElement>) => {
     const checked = e.target.checked;
-    if (!checked) {
-      worker.stop();
-    }
     localStorage.setItem(
       'mock-service-worker-enabled',
-      e.target.checked ? 'enabled' : 'disabled'
+      checked ? 'enabled' : 'disabled'
     );
     window.location.reload();
   };

--- a/packages/manager/src/dev-tools/ServiceWorkerTool.tsx
+++ b/packages/manager/src/dev-tools/ServiceWorkerTool.tsx
@@ -3,7 +3,7 @@ import { worker } from '../mocks/testBrowser';
 
 export const ServiceWorkerTool: React.FC<{}> = _ => {
   const _workerActive =
-    localStorage.getItem('mock-service-worker-enabled') ?? 'disabled';
+    localStorage.getItem('devTools/mock-service-worker-enabled') ?? 'disabled';
   const workerActive = _workerActive === 'enabled';
 
   React.useEffect(() => {
@@ -17,7 +17,7 @@ export const ServiceWorkerTool: React.FC<{}> = _ => {
   const handleToggleWorker = (e: React.ChangeEvent<HTMLInputElement>) => {
     const checked = e.target.checked;
     localStorage.setItem(
-      'mock-service-worker-enabled',
+      'devTools/mock-service-worker-enabled',
       checked ? 'enabled' : 'disabled'
     );
     window.location.reload();

--- a/packages/manager/src/dev-tools/ServiceWorkerTool.tsx
+++ b/packages/manager/src/dev-tools/ServiceWorkerTool.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { worker } from '../mocks/testBrowser';
+
+export const ServiceWorkerTool: React.FC<{}> = _ => {
+  const _workerActive =
+    localStorage.getItem('mock-service-worker-enabled') ?? 'disabled';
+  const workerActive = _workerActive === 'enabled';
+
+  React.useEffect(() => {
+    if (workerActive) {
+      worker.start();
+    }
+  }, [workerActive]);
+
+  const handleToggleWorker = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const checked = e.target.checked;
+    if (!checked) {
+      worker.stop();
+    }
+    localStorage.setItem(
+      'mock-service-worker-enabled',
+      e.target.checked ? 'enabled' : 'disabled'
+    );
+    window.location.reload();
+  };
+
+  return (
+    <>
+      <span>Mock Service Worker: {workerActive ? 'Enabled' : 'Disabled'}</span>
+      <input
+        type="checkbox"
+        checked={workerActive}
+        onChange={e => handleToggleWorker(e)}
+      />
+    </>
+  );
+};
+
+export default ServiceWorkerTool;

--- a/packages/manager/src/dev-tools/dev-tools.tsx
+++ b/packages/manager/src/dev-tools/dev-tools.tsx
@@ -7,7 +7,7 @@ import EnvironmentToggleTool from './EnvironmentToggleTool';
 import store from 'src/store';
 import { Provider } from 'react-redux';
 import MockDataTool from './MockDataTool';
-import { MOCK_SERVICE_WORKER } from 'src/constants';
+import { isProductionBuild } from 'src/constants';
 import Grid from 'src/components/core/Grid';
 
 function install() {
@@ -26,7 +26,7 @@ function install() {
               <EnvironmentToggleTool />
             </Grid>
           )}
-          {MOCK_SERVICE_WORKER && (
+          {!isProductionBuild && (
             <Grid item xs={2}>
               <MockDataTool />
             </Grid>

--- a/packages/manager/src/mocks/testBrowser.ts
+++ b/packages/manager/src/mocks/testBrowser.ts
@@ -1,17 +1,15 @@
 import { setupWorker } from 'msw';
-import { MOCK_SERVICE_WORKER } from 'src/constants';
+import { SetupWorkerApi } from 'msw/lib/types/setupWorker/setupWorker';
+import { isProductionBuild } from 'src/constants';
 import { MockData, mockDataController } from 'src/dev-tools/mockDataController';
 import store, { ApplicationState } from 'src/store';
 import { requestLinodes } from 'src/store/linodes/linode.requests';
 import { handlers, mockDataHandlers } from './serverHandlers';
 
-/**
- * If the .env tells us to mock the API, load
- * the mocks.
- */
-if (MOCK_SERVICE_WORKER) {
-  const worker = setupWorker(...handlers);
-  worker.start();
+let worker: SetupWorkerApi;
+
+if (!isProductionBuild) {
+  worker = setupWorker(...handlers);
 
   // Subscribe to changes from the mockDataController, which is updated by local dev tools.
   mockDataController.subscribe(mockData => {
@@ -33,3 +31,5 @@ const requestEntities = (mockData: MockData, reduxState: ApplicationState) => {
     store.dispatch(requestLinodes({}) as any);
   }
 };
+
+export { worker };


### PR DESCRIPTION
## Description

I've never mucked with the devtools before, I hope I didn't break anything. Note that this will completely remove the old way of activating the mocks--nothing you have in your .env will affect those anymore.