### PR TITLE
M3-4655 Change: Handle warnings after a successful payment.

### DIFF
--- a/packages/api-v4/src/account/payments.ts
+++ b/packages/api-v4/src/account/payments.ts
@@ -13,7 +13,14 @@ import {
   PaymentSchema,
   StagePaypalPaymentSchema
 } from './account.schema';
-import { ExecutePayload, Payment, Paypal, SaveCreditCardData } from './types';
+import {
+  ExecutePayload,
+  Payment,
+  PaymentResponse,
+  Paypal,
+  PaypalResponse,
+  SaveCreditCardData
+} from './types';
 
 /**
  * getPayments
@@ -65,7 +72,7 @@ export const makePayment = (data: { usd: string; cvv?: string }) => {
     delete data.cvv;
   }
 
-  return Request<Payment>(
+  return Request<PaymentResponse>(
     setURL(`${API_ROOT}/account/payments`),
     setMethod('POST'),
     setData(data, PaymentSchema)
@@ -110,7 +117,7 @@ export const stagePaypalPayment = (data: Paypal) =>
  *
  */
 export const executePaypalPayment = (data: ExecutePayload) =>
-  Request<{}>(
+  Request<PaypalResponse>(
     setURL(`${API_ROOT}/account/payments/paypal/execute`),
     setMethod('POST'),
     setData(data, ExecutePaypalPaymentSchema)

--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -1,3 +1,5 @@
+import { APIWarning } from '../types';
+
 export interface User {
   username: string;
   email: string;
@@ -85,6 +87,14 @@ export interface Payment {
   id: number;
   date: string;
   usd: number;
+}
+
+export interface PaymentResponse extends Payment {
+  warnings?: APIWarning[];
+}
+
+export interface PaypalResponse {
+  warnings?: APIWarning[];
 }
 
 export type GrantLevel = null | 'read_only' | 'read_write';

--- a/packages/api-v4/src/types.ts
+++ b/packages/api-v4/src/types.ts
@@ -3,6 +3,11 @@ export interface APIError {
   reason: string;
 }
 
+export interface APIWarning {
+  title: string;
+  detail: string;
+}
+
 export interface ConfigOverride {
   baseURL?: string;
 }

--- a/packages/manager/src/components/MigrateError.tsx
+++ b/packages/manager/src/components/MigrateError.tsx
@@ -5,15 +5,13 @@ import SupportLink from 'src/components/SupportLink';
 
 export const MigrateError: React.FC<{}> = () => {
   return (
-    <>
-      <Typography>
-        Self-serve migrations are currently disabled on this account. {` `}
-        <SupportLink
-          title="Request for Inter-DC Migration"
-          description=""
-          text="Please contact Support."
-        />
-      </Typography>
-    </>
+    <Typography>
+      Self-serve migrations are currently disabled on this account. {` `}
+      <SupportLink
+        title="Request for Inter-DC Migration"
+        description=""
+        text="Please contact Support."
+      />
+    </Typography>
   );
 };

--- a/packages/manager/src/factories/billing.ts
+++ b/packages/manager/src/factories/billing.ts
@@ -1,5 +1,12 @@
 import * as Factory from 'factory.ts';
-import { InvoiceItem, Payment, Invoice } from '@linode/api-v4/lib/account';
+import { APIWarning } from '@linode/api-v4/lib/types';
+import {
+  InvoiceItem,
+  Payment,
+  PaymentResponse,
+  PaypalResponse,
+  Invoice
+} from '@linode/api-v4/lib/account';
 
 export const invoiceItemFactory = Factory.Sync.makeFactory<InvoiceItem>({
   label: Factory.each(i => `Nanode 1GB - my-linode-${i} (${i})`),
@@ -34,4 +41,24 @@ export const invoiceFactory = Factory.Sync.makeFactory<Invoice>({
   tax: 1,
   total: 6,
   label: Factory.each(i => `Invoice #${i}`)
+});
+
+export const warningFactory = Factory.Sync.makeFactory<APIWarning>({
+  title:
+    'Your payment has been processed but we encountered an error releasing your resources.',
+  detail:
+    'Object Storage could not be reactivated, please open a support ticket.'
+});
+
+export const creditPaymentResponseFactory = Factory.Sync.makeFactory<
+  PaymentResponse
+>({
+  id: Factory.each(i => i),
+  usd: 10,
+  date: '2020-01-01T12:00:00',
+  warnings: warningFactory.buildList(1)
+});
+
+export const paypalResponseFactory = Factory.Sync.makeFactory<PaypalResponse>({
+  warnings: warningFactory.buildList(1)
 });

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCardPayment.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCardPayment.tsx
@@ -8,6 +8,7 @@ import TextField from 'src/components/TextField';
 import { cleanCVV } from 'src/features/Billing/billingUtils';
 import CreditCardDialog from './PaymentBits/CreditCardDialog';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import { SetSuccess } from './types';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -41,7 +42,7 @@ export interface Props {
   expiry: string;
   usd: string;
   minimumPayment: string;
-  setSuccess: (message: string | null, paymentWasMade?: boolean) => void;
+  setSuccess: SetSuccess;
 }
 
 export const CreditCard: React.FC<Props> = props => {
@@ -76,10 +77,14 @@ export const CreditCard: React.FC<Props> = props => {
       usd: (+usd).toFixed(2),
       cvv
     })
-      .then(_ => {
+      .then(response => {
         setSubmitting(false);
         setDialogOpen(false);
-        setSuccess(`Payment for $${usd} submitted successfully`, true);
+        setSuccess(
+          `Payment for $${usd} submitted successfully`,
+          true,
+          response.warnings
+        );
       })
       .catch(errorResponse => {
         setSubmitting(false);

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentBits/CreditCardDialog.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentBits/CreditCardDialog.tsx
@@ -51,6 +51,7 @@ class DialogActions extends React.PureComponent<Actions> {
           loading={this.props.isMakingPayment}
           onClick={this.props.executePayment}
           data-qa-submit
+          data-testid="credit-card-submit"
         >
           Confirm Payment
         </Button>

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.test.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.test.tsx
@@ -1,6 +1,27 @@
-import { getMinimumPayment } from './PaymentDrawer';
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { paymentFactory } from 'src/factories/billing';
+import { rest, server } from 'src/mocks/testServer';
+import PaymentDrawer, {
+  CombinedProps,
+  getMinimumPayment
+} from './PaymentDrawer';
+import { wrapWithTheme } from 'src/utilities/testHelpers';
 
 import { isAllowedUSDAmount, shouldEnablePaypalButton } from './Paypal';
+
+const props: CombinedProps = {
+  open: true,
+  onClose: jest.fn(),
+  accountLoading: false,
+  balance: 50,
+  lastFour: '9999',
+  expiry: '',
+  requestAccount: jest.fn(),
+  updateAccount: jest.fn(),
+  saveCreditCard: jest.fn()
+};
 
 describe('Make a Payment Panel', () => {
   it('should return false for invalid USD amount', () => {
@@ -40,6 +61,34 @@ describe('Make a Payment Panel', () => {
 
     it('should return 5 if the balance due is greater than 5', () => {
       expect(getMinimumPayment(100000)).toBe('5.00');
+    });
+  });
+
+  describe('Jailbreak warnings', () => {
+    it('should display a jailbreak warning if returned from the API', async () => {
+      render(wrapWithTheme(<PaymentDrawer {...props} />));
+      userEvent.click(screen.getByText(/pay now/i));
+      userEvent.click(screen.getByTestId('credit-card-submit'));
+      expect(
+        await screen.findByText(/your payment has been processed but/i)
+      ).toBeInTheDocument();
+    });
+
+    it('should not display a warning for a normal successful payment', async () => {
+      server.use(
+        rest.post('*/account/payments', (req, res, ctx) => {
+          return res(ctx.json(paymentFactory.build()));
+        })
+      );
+      render(wrapWithTheme(<PaymentDrawer {...props} />));
+      userEvent.click(screen.getByText(/pay now/i));
+      userEvent.click(screen.getByTestId('credit-card-submit'));
+      expect(
+        await screen.findByText(/submitted successfully/i)
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(/your payment has been processed but/i)
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
@@ -96,7 +96,7 @@ export const PaymentDrawer: React.FC<CombinedProps> = props => {
       setPayPalKey(v4());
       props.requestAccount();
     }
-    if (warnings) {
+    if (warnings && warnings.length > 0) {
       setWarning(warnings[0]);
     }
   };
@@ -116,7 +116,7 @@ export const PaymentDrawer: React.FC<CombinedProps> = props => {
       <Grid container>
         <Grid item xs={12}>
           {successMessage && <Notice success text={successMessage ?? ''} />}
-          {warning && <Warning warning={warning} />}
+          {warning ? <Warning warning={warning} /> : null}
           {balance !== false && (
             <Grid item>
               <Typography variant="h3" className={classes.currentBalance}>
@@ -166,7 +166,7 @@ const Warning: React.FC<WarningProps> = props => {
   /** The most common API warning includes "please open a Support ticket",
    * which we'd like to be a link.
    */
-  const ticketLink = warning.detail.match(/open a support ticket/i) ? (
+  const ticketLink = warning.detail.match(/open a support ticket\./i) ? (
     <>
       {warning.detail.replace(/open a support ticket\./i, '')}
       <SupportLink

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
@@ -1,3 +1,4 @@
+import { APIWarning } from '@linode/api-v4/lib/types';
 import * as React from 'react';
 import { compose } from 'recompose';
 import { makeStyles, Theme } from 'src/components/core/styles';
@@ -7,6 +8,7 @@ import Drawer from 'src/components/Drawer';
 import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
+import SupportLink from 'src/components/SupportLink';
 import TextField from 'src/components/TextField';
 import AccountContainer, {
   DispatchProps as AccountDispatchProps
@@ -15,6 +17,7 @@ import { v4 } from 'uuid';
 
 import CreditCard from './CreditCardPayment';
 import PayPal from './Paypal';
+import { SetSuccess } from './types';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {},
@@ -60,6 +63,7 @@ export const PaymentDrawer: React.FC<CombinedProps> = props => {
   const [successMessage, setSuccessMessage] = React.useState<string | null>(
     null
   );
+  const [warning, setWarning] = React.useState<APIWarning | null>(null);
 
   const [creditCardKey, setCreditCardKey] = React.useState<string>(v4());
   const [payPalKey, setPayPalKey] = React.useState<string>(v4());
@@ -78,9 +82,10 @@ export const PaymentDrawer: React.FC<CombinedProps> = props => {
     setUSD(e.target.value || '');
   };
 
-  const setSuccess = (
-    message: string | null,
-    paymentWasMade: boolean = false
+  const setSuccess: SetSuccess = (
+    message,
+    paymentWasMade = false,
+    warnings = undefined
   ) => {
     setSuccessMessage(message);
     if (paymentWasMade) {
@@ -89,6 +94,9 @@ export const PaymentDrawer: React.FC<CombinedProps> = props => {
       setCreditCardKey(v4());
       setPayPalKey(v4());
       props.requestAccount();
+    }
+    if (warnings) {
+      setWarning(warnings[0]);
     }
   };
 
@@ -107,6 +115,7 @@ export const PaymentDrawer: React.FC<CombinedProps> = props => {
       <Grid container>
         <Grid item xs={12}>
           {successMessage && <Notice success text={successMessage ?? ''} />}
+          {warning && <Warning warning={warning} />}
           {balance !== false && (
             <Grid item>
               <Typography variant="h3" className={classes.currentBalance}>
@@ -145,6 +154,35 @@ export const PaymentDrawer: React.FC<CombinedProps> = props => {
       </Grid>
     </Drawer>
   );
+};
+
+interface WarningProps {
+  warning: APIWarning;
+}
+
+const Warning: React.FC<WarningProps> = props => {
+  const { warning } = props;
+  /** The most common API warning includes "please open a Support ticket",
+   * which we'd like to be a link.
+   */
+  const ticketLink = warning.detail.match(/open a support ticket/i) ? (
+    <>
+      {warning.detail.replace(/open a support ticket\./i, '')}
+      <SupportLink
+        text="open a Support ticket"
+        title={`Re: ${warning.detail}`}
+      />
+      .
+    </>
+  ) : (
+    warning.detail
+  );
+  const message = (
+    <>
+      {warning.title} {ticketLink}
+    </>
+  );
+  return <Notice warning text={message} />;
 };
 
 const withAccount = AccountContainer(

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
@@ -39,7 +39,7 @@ interface AccountContextProps {
   expiry: string;
 }
 
-type CombinedProps = Props & AccountContextProps & AccountDispatchProps;
+export type CombinedProps = Props & AccountContextProps & AccountDispatchProps;
 
 export const getMinimumPayment = (balance: number | false) => {
   if (!balance || balance <= 0) {

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
@@ -75,6 +75,7 @@ export const PaymentDrawer: React.FC<CombinedProps> = props => {
   React.useEffect(() => {
     if (open) {
       setSuccessMessage(null);
+      setWarning(null);
     }
   }, [open]);
 

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/Paypal.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/Paypal.tsx
@@ -36,6 +36,7 @@ import { PAYPAL_CLIENT_ENV } from 'src/constants';
 import PaypalDialog from './PaymentBits/PaypalDialog';
 import { reportException } from 'src/exceptionReporting';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import { SetSuccess } from './types';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -73,7 +74,7 @@ interface PaypalScript {
 
 export interface Props {
   usd: string;
-  setSuccess: (message: string | null, paymentWasMade?: boolean) => void;
+  setSuccess: SetSuccess;
 }
 
 type CombinedProps = Props & PaypalScript;
@@ -149,10 +150,14 @@ export const PayPalDisplay: React.FC<CombinedProps> = props => {
       payer_id: payerID,
       payment_id: paymentID
     })
-      .then(() => {
+      .then(response => {
         setExecuting(false);
         setDialogOpen(false);
-        setSuccess(`Payment for $${usd} successfully submitted`, true);
+        setSuccess(
+          `Payment for $${usd} successfully submitted`,
+          true,
+          response.warnings
+        );
       })
       .catch(_ => {
         setExecuting(false);

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/types.ts
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/types.ts
@@ -1,0 +1,6 @@
+import { APIWarning } from '@linode/api-v4/lib/types';
+export type SetSuccess = (
+  message: string | null,
+  paymentWasMade?: boolean,
+  warning?: APIWarning[]
+) => void;

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -3,6 +3,7 @@ import { rest, RequestHandler } from 'msw';
 import {
   accountFactory,
   appTokenFactory,
+  creditPaymentResponseFactory,
   databaseFactory,
   domainFactory,
   domainRecordFactory,
@@ -346,6 +347,9 @@ export const handlers = [
   }),
   rest.post('*/networking/vlans', (req, res, ctx) => {
     return res(ctx.json({}));
+  }),
+  rest.post('*/account/payments', (req, res, ctx) => {
+    return res(ctx.json(creditPaymentResponseFactory.build()));
   }),
   rest.get('*/databases/mysql/instances', (req, res, ctx) => {
     const online = databaseFactory.build({ status: 'ready' });


### PR DESCRIPTION
The API recently added an optional "warnings" field to the envelope
for responses. It's currently only used when making a payment (for
a rare edge case where jailbreaking fails even when the payment succeeds).

This PR adds that to the appropriate types, and displays any warnings
to the user in the payment drawer.

Note: we've had some feedback that leaving the drawer open after a successful
payment is confusing and has led to multiple payments. In a separate PR, we can
move all of this up a level to the billing info page.

Still needs some:

- [x] Unit tests

## Note to Reviewers

It isn't easy/possible to go through this process for real. Turn on the service worker and make a credit card payment (mocking the PayPal equivalent is much harder and I haven't worked it out).