### PR TITLE
M3-4647: Hide OBJ Access Key permissions table if user has no buckets

### DIFF
--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
@@ -80,6 +80,7 @@ export const AccessKeyDrawer: React.FC<CombinedProps> = props => {
   );
 
   const { objectStorageBuckets: buckets } = useBuckets();
+  const hidePermissionsTable = buckets.data.length === 0;
 
   const [dialogOpen, setDialogOpen] = React.useState<boolean>(false);
   // This is for local display management only, not part of the payload
@@ -208,7 +209,7 @@ export const AccessKeyDrawer: React.FC<CombinedProps> = props => {
                   onBlur={handleBlur}
                   disabled={isRestrictedUser || mode === 'viewing'}
                 />
-                {mode === 'creating' && (
+                {mode === 'creating' && !hidePermissionsTable ? (
                   <LimitedAccessControls
                     mode={mode}
                     bucket_access={values.bucket_access}
@@ -216,7 +217,7 @@ export const AccessKeyDrawer: React.FC<CombinedProps> = props => {
                     handleToggle={handleToggleAccess}
                     checked={limitedAccessChecked}
                   />
-                )}
+                ) : null}
                 <ActionsPanel>
                   <Button
                     buttonType="primary"


### PR DESCRIPTION
## Description
When a user has no Object Storage buckets and goes to create an access key, the permissions table in the drawer is now hidden. Previously it was shown and was able to be interacted with, which wasn't useful and probably confusing. I opted to hide it instead of disable it to streamline the drawer and maximize clarity for users.

## Type of Change
- Non breaking change ('update', 'change')

