### PR TITLE
M3-4328 Query sorting

### DIFF
--- a/packages/manager/src/components/EntityTable/ListEntities_CMR.tsx
+++ b/packages/manager/src/components/EntityTable/ListEntities_CMR.tsx
@@ -23,11 +23,13 @@ export const ListEntities: React.FC<CombinedProps> = props => {
     lastUpdated,
     RowComponent
   } = props;
+
   return (
     <OrderBy
       data={data}
       orderBy={initialOrder?.orderBy}
       order={initialOrder?.order}
+      preferenceKey={entity}
     >
       {({ data: orderedData, handleOrderChange, order, orderBy }) => (
         <Paginate data={orderedData}>

--- a/packages/manager/src/components/OrderBy.test.tsx
+++ b/packages/manager/src/components/OrderBy.test.tsx
@@ -67,11 +67,23 @@ describe('OrderBy', () => {
         }
       }
     };
+    it('should return values from query params if available', () => {
+      expect(
+        getInitialValuesFromUserPreferences(
+          '',
+          preferences,
+          { order: 'desc', orderBy: 'test-key' },
+          'default',
+          'asc'
+        )
+      ).toEqual({ order: 'desc', orderBy: 'test-key' });
+    });
     it('should return values from preferences if the preference key exists', () => {
       expect(
         getInitialValuesFromUserPreferences(
           'listening-services',
           preferences,
+          {},
           'default',
           'desc'
         )
@@ -83,6 +95,7 @@ describe('OrderBy', () => {
         getInitialValuesFromUserPreferences(
           'listening-services',
           {},
+          {},
           'default',
           'asc'
         )
@@ -91,7 +104,13 @@ describe('OrderBy', () => {
 
     it('should return the defaults if there is no preference key provided', () => {
       expect(
-        getInitialValuesFromUserPreferences('', preferences, 'default', 'asc')
+        getInitialValuesFromUserPreferences(
+          '',
+          preferences,
+          {},
+          'default',
+          'asc'
+        )
       ).toEqual({ order: 'asc', orderBy: 'default' });
     });
   });

--- a/packages/manager/src/components/OrderBy.tsx
+++ b/packages/manager/src/components/OrderBy.tsx
@@ -199,7 +199,7 @@ export const OrderBy: React.FC<CombinedProps> = props => {
     setOrder(newOrder);
 
     // Update the URL query params so that the current sort is bookmark-able
-    history.push({ search: `?order=${newOrder}&orderBy=${newOrderBy}` });
+    history.replace({ search: `?order=${newOrder}&orderBy=${newOrderBy}` });
 
     debouncedUpdateUserPreferences(newOrderBy, newOrder);
   };

--- a/packages/manager/src/components/OrderBy.tsx
+++ b/packages/manager/src/components/OrderBy.tsx
@@ -13,7 +13,7 @@ import {
 } from 'src/utilities/sort-by';
 import { debounce } from 'throttle-debounce';
 import { getParamsFromUrl } from 'src/utilities/queryParams';
-import { useLocation } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 
 export interface OrderByProps extends State {
   handleOrderChange: (orderBy: string, order: Order) => void;
@@ -63,7 +63,6 @@ export const getInitialValuesFromUserPreferences = (
    * 2. user preferences (if saved)
    * 3. anything passed as props
    * 4. default values
-   *
    *
    */
   if (['asc', 'desc'].includes(params.order) && params.orderBy) {
@@ -140,6 +139,7 @@ export const sortData = (orderBy: string, order: Order) => {
 export const OrderBy: React.FC<CombinedProps> = props => {
   const { preferences, updatePreferences } = usePreferences();
   const location = useLocation();
+  const history = useHistory();
   const params = getParamsFromUrl(location.search);
 
   const initialValues = getInitialValuesFromUserPreferences(
@@ -197,6 +197,9 @@ export const OrderBy: React.FC<CombinedProps> = props => {
   const handleOrderChange = (newOrderBy: string, newOrder: Order) => {
     setOrderBy(newOrderBy);
     setOrder(newOrder);
+
+    // Update the URL query params so that the current sort is bookmark-able
+    history.push({ search: `?order=${newOrder}&orderBy=${newOrderBy}` });
 
     debouncedUpdateUserPreferences(newOrderBy, newOrder);
   };

--- a/packages/manager/src/store/preferences/preferences.actions.ts
+++ b/packages/manager/src/store/preferences/preferences.actions.ts
@@ -11,12 +11,6 @@ export interface OrderSet {
   orderBy: string;
 }
 
-export type SortKey =
-  | 'listening-services'
-  | 'active-connections'
-  | 'top-processes'
-  | 'lv-detail-processes';
-
 export interface UserPreferences {
   longviewTimeRange?: string;
   gst_banner_dismissed?: boolean;
@@ -28,7 +22,7 @@ export interface UserPreferences {
   theme?: ThemeChoice;
   spacing?: SpacingChoice;
   desktop_sidebar_open?: boolean;
-  sortKeys?: Partial<Record<SortKey, OrderSet>>;
+  sortKeys?: Partial<Record<string, OrderSet>>;
   main_content_banner_dismissal?: Record<string, boolean>;
   linode_news_banner_dismissed?: boolean;
   notification_drawer_view?: 'list' | 'grouped';


### PR DESCRIPTION
Adjust query sorting

- Save entity table sorting in user preferences
- Since this is dynamic, remove the SortKey type and wing it
- Read query params in OrderBy, and assign the default sort in the
following precedence:
  1. query params
  2. user preferences
  3. component-specific values
  4. default values


## Note to Reviewers

One quirk of this approach is that if the url contains a garbage sort key (e.g. "label" on the Domains table), we revert back to the defaults, since query params are highest priority and the sort keys are unknown (in OrderBy where this is happening). I think this is ok--you can always sort the table yourself after loading, and if you click a bad url it isn't exactly our fault. Open to feedback though.