### PR TITLE
M3-4630: Refactor Domain Create workflow

### DIFF
--- a/packages/manager/src/features/Domains/CreateDomain/CreateDomain.tsx
+++ b/packages/manager/src/features/Domains/CreateDomain/CreateDomain.tsx
@@ -58,7 +58,7 @@ import {
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import { getInitialIPs } from '../domainUtils';
 
-type ClassNames = 'title' | 'main' | 'inner' | 'radio' | 'helperText';
+type ClassNames = 'title' | 'main' | 'inner' | 'radio' | 'ip' | 'helperText';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -87,6 +87,9 @@ const styles = (theme: Theme) =>
       '& label:first-child .MuiButtonBase-root': {
         marginLeft: -10
       }
+    },
+    ip: {
+      maxWidth: 468
     },
     helperText: {
       maxWidth: 'none'
@@ -328,7 +331,7 @@ class CreateDomain extends React.Component<CombinedProps, State> {
                 />
               </RadioGroup>
               <TextField
-                errorText={'' && errorMap.domain}
+                errorText={errorMap.domain}
                 value={domain}
                 disabled={disabled}
                 label="Domain"
@@ -350,6 +353,7 @@ class CreateDomain extends React.Component<CombinedProps, State> {
               {isCreatingSlaveDomain && (
                 <MultipleIPInput
                   title="Master Nameserver IP Address"
+                  className={classes.ip}
                   ips={this.state.master_ips.map(stringToExtendedIP)}
                   onChange={this.updateMasterIPAddress}
                   error={masterIPsError}
@@ -407,6 +411,7 @@ class CreateDomain extends React.Component<CombinedProps, State> {
                           ? this.state.selectedDefaultLinode.id
                           : null
                       }
+                      disabled={disabled}
                     />
                     {!errorMap.defaultLinode && (
                       <FormHelperText>
@@ -663,7 +668,7 @@ class CreateDomain extends React.Component<CombinedProps, State> {
   updateType = (
     e: React.ChangeEvent<HTMLInputElement>,
     value: 'master' | 'slave'
-  ) => this.setState({ type: value });
+  ) => this.setState({ type: value, errors: [] });
 
   updateMasterIPAddress = (newIPs: ExtendedIP[]) => {
     const master_ips =

--- a/packages/manager/src/features/Domains/CreateDomain/CreateDomain.tsx
+++ b/packages/manager/src/features/Domains/CreateDomain/CreateDomain.tsx
@@ -521,6 +521,7 @@ export const CreateDomain: React.FC<CombinedProps> = props => {
                         'Insert default records from one of my NodeBalancers.'
                     }
                   ]}
+                  disabled={disabled}
                 />
                 <FormHelperText className={classes.helperText}>
                   If specified, we can automatically create some domain records
@@ -561,6 +562,7 @@ export const CreateDomain: React.FC<CombinedProps> = props => {
                         ? selectedDefaultNodeBalancer.id
                         : null
                     }
+                    disabled={disabled}
                   />
                   {!errorMap.defaultNodeBalancer && (
                     <FormHelperText>

--- a/packages/manager/src/features/Domains/CreateDomain/CreateDomain.tsx
+++ b/packages/manager/src/features/Domains/CreateDomain/CreateDomain.tsx
@@ -124,11 +124,11 @@ export const generateDefaultDomainRecords = (
   ipv6?: string | null
 ) => {
   /**
-   * at this point, the IPv6 is including the prefix and we need to strip that
+   * At this point, the IPv6 is including the prefix and we need to strip that
    *
    * BUT
    *
-   * this logic only applies to Linodes' ipv6, not nodebalancers. No stripping
+   * this logic only applies to Linodes' ipv6, not NodeBalancers. No stripping
    * needed for NodeBalancers.
    */
   const cleanedIPv6 =

--- a/packages/manager/src/features/Domains/CreateDomain/CreateDomain.tsx
+++ b/packages/manager/src/features/Domains/CreateDomain/CreateDomain.tsx
@@ -1,0 +1,739 @@
+import { createDomainRecord, Domain } from '@linode/api-v4/lib/domains';
+import { Linode } from '@linode/api-v4/lib/linodes';
+import { NodeBalancer } from '@linode/api-v4/lib/nodebalancers';
+import { APIError } from '@linode/api-v4/lib/types';
+import { withSnackbar, WithSnackbarProps } from 'notistack';
+import { path } from 'ramda';
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { compose } from 'recompose';
+import { bindActionCreators, Dispatch } from 'redux';
+import ActionsPanel from 'src/components/ActionsPanel';
+import Breadcrumb from 'src/components/Breadcrumb';
+import Button from 'src/components/Button';
+import DocumentationButton from 'src/components/DocumentationButton';
+import FormControlLabel from 'src/components/core/FormControlLabel';
+import FormHelperText from 'src/components/core/FormHelperText';
+import Grid from 'src/components/core/Grid';
+import RadioGroup from 'src/components/core/RadioGroup';
+import {
+  createStyles,
+  Theme,
+  withStyles,
+  WithStyles
+} from 'src/components/core/styles';
+import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import Select, { Item } from 'src/components/EnhancedSelect/Select';
+import MultipleIPInput from 'src/components/MultipleIPInput';
+import Notice from 'src/components/Notice';
+import Radio from 'src/components/Radio';
+import TagsInput, { Tag } from 'src/components/TagsInput';
+import TextField from 'src/components/TextField';
+import { reportException } from 'src/exceptionReporting';
+import LinodeSelect from 'src/features/linodes/LinodeSelect';
+import NodeBalancerSelect from 'src/features/NodeBalancers/NodeBalancerSelect';
+import {
+  hasGrant,
+  isRestrictedUser
+} from 'src/features/Profile/permissionsHelpers';
+import { ApplicationState } from 'src/store';
+import {
+  Origin as DomainDrawerOrigin,
+  resetDrawer
+} from 'src/store/domainDrawer';
+import { upsertDomain } from 'src/store/domains/domains.actions';
+import {
+  DomainActionsProps,
+  withDomainActions
+} from 'src/store/domains/domains.container';
+import { getAPIErrorOrDefault, getErrorMap } from 'src/utilities/errorUtils';
+import { sendCreateDomainEvent } from 'src/utilities/ga';
+import {
+  ExtendedIP,
+  extendedIPToString,
+  stringToExtendedIP
+} from 'src/utilities/ipUtils';
+import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
+import { getInitialIPs } from '../domainUtils';
+import Paper from 'src/components/core/Paper';
+
+type ClassNames = 'root' | 'title' | 'inner' | 'radio' | 'helperText';
+
+const styles = (theme: Theme) =>
+  createStyles({
+    root: {
+      '& .mlMain': {
+        maxWidth: '100%',
+        flexBasis: '100%',
+        [theme.breakpoints.up('lg')]: {
+          maxWidth: '78.8%',
+          flexBasis: '78.8%'
+        }
+      },
+      '& .mlSidebar': {
+        position: 'static',
+        width: '100%',
+        flexBasis: '100%',
+        maxWidth: '100%',
+        [theme.breakpoints.up('lg')]: {
+          position: 'sticky',
+          maxWidth: '21.2%',
+          flexBasis: '21.2%'
+        }
+      }
+    },
+    title: {
+      marginTop: theme.spacing(1),
+      marginBottom: theme.spacing(3)
+    },
+    inner: {
+      padding: theme.spacing(3),
+      paddingTop: theme.spacing(2),
+      '& > div': {
+        marginBottom: theme.spacing(2)
+      },
+      '& label': {
+        color: theme.color.headline,
+        fontWeight: 600,
+        lineHeight: '1.33rem',
+        letterSpacing: '0.25px',
+        margin: 0
+      }
+    },
+    radio: {
+      '& label:first-child .MuiButtonBase-root': {
+        marginLeft: -10
+      }
+    },
+    helperText: {
+      maxWidth: 'none'
+    }
+  });
+
+type DefaultRecordsType = 'none' | 'linode' | 'nodebalancer';
+
+interface State {
+  domain: string;
+  type: 'master' | 'slave';
+  soaEmail: string;
+  cloneName: string;
+  tags: Tag[];
+  errors?: APIError[];
+  submitting: boolean;
+  master_ips: string[];
+  axfr_ips: string[];
+  defaultRecordsSetting: DefaultRecordsType;
+  selectedDefaultLinode?: Linode;
+  selectedDefaultNodeBalancer?: NodeBalancer;
+}
+
+type CombinedProps = WithStyles<ClassNames> &
+  DomainActionsProps &
+  DispatchProps &
+  RouteComponentProps<{}> &
+  StateProps &
+  WithSnackbarProps;
+
+export const generateDefaultDomainRecords = (
+  domain: string,
+  domainID: number,
+  ipv4?: string,
+  ipv6?: string | null
+) => {
+  /**
+   * at this point, the IPv6 is including the prefix and we need to strip that
+   *
+   * BUT
+   *
+   * this logic only applies to Linodes' ipv6, not nodebalancers. No stripping
+   * needed for NodeBalancers.
+   */
+  const cleanedIPv6 =
+    ipv6 && ipv6.includes('/') ? ipv6.substr(0, ipv6.indexOf('/')) : ipv6;
+
+  const baseIPv4Requests = [
+    createDomainRecord(domainID, {
+      type: 'A',
+      target: ipv4
+    }),
+    createDomainRecord(domainID, {
+      type: 'A',
+      target: ipv4,
+      name: 'www'
+    }),
+    createDomainRecord(domainID, {
+      type: 'A',
+      target: ipv4,
+      name: 'mail'
+    })
+  ];
+
+  return Promise.all(
+    /** ipv6 can be null so don't try to create domain records in that case */
+    !!cleanedIPv6
+      ? [
+          ...baseIPv4Requests,
+          createDomainRecord(domainID, {
+            type: 'AAAA',
+            target: cleanedIPv6
+          }),
+          createDomainRecord(domainID, {
+            type: 'AAAA',
+            target: cleanedIPv6,
+            name: 'www'
+          }),
+          createDomainRecord(domainID, {
+            type: 'AAAA',
+            target: cleanedIPv6,
+            name: 'mail'
+          }),
+          createDomainRecord(domainID, {
+            type: 'MX',
+            priority: 10,
+            target: `mail.${domain}`
+          })
+        ]
+      : baseIPv4Requests
+  );
+};
+
+class CreateDomain extends React.Component<CombinedProps, State> {
+  mounted: boolean = false;
+  defaultState: State = {
+    domain: '',
+    type: 'master',
+    soaEmail: '',
+    cloneName: '',
+    tags: [],
+    submitting: false,
+    errors: [],
+    master_ips: [''],
+    axfr_ips: [''],
+    defaultRecordsSetting: 'none',
+    selectedDefaultLinode: undefined,
+    selectedDefaultNodeBalancer: undefined
+  };
+
+  state: State = {
+    ...this.defaultState
+  };
+
+  componentDidMount() {
+    this.mounted = true;
+  }
+
+  componentWillUnmount() {
+    this.mounted = false;
+  }
+
+  componentDidUpdate(prevProps: CombinedProps, prevState: State) {
+    if (
+      this.props.domainProps && // there are domain props for an update and ...
+      (!prevProps.domainProps || // it just appeared
+        prevProps.domainProps.id !== this.props.domainProps.id)
+    ) {
+      // or the domain for editing has changed
+
+      // then put it props into state to populate fields
+      const {
+        axfr_ips,
+        domain,
+        tags,
+        master_ips,
+        type,
+        soa_email
+      } = this.props.domainProps;
+      this.setState({
+        tags: tags.map(tag => ({ label: tag, value: tag })),
+        type,
+        domain,
+        master_ips: getInitialIPs(master_ips),
+        axfr_ips: getInitialIPs(axfr_ips),
+        soaEmail: soa_email
+      });
+    }
+  }
+
+  render() {
+    const { classes, disabled } = this.props;
+    const { type, domain, soaEmail, errors, submitting, tags } = this.state;
+
+    const errorMap = getErrorMap(
+      [
+        'axfr_ips',
+        'master_ips',
+        'domain',
+        'type',
+        'soa_email',
+        'tags',
+        'defaultNodeBalancer',
+        'defaultLinode'
+      ],
+      errors
+    );
+
+    const generalError = errorMap.none;
+    const masterIPsError = errorMap.master_ips;
+
+    const isCreatingMasterDomain = type === 'master';
+    const isCreatingSlaveDomain = type === 'slave';
+
+    return (
+      <Grid container className={classes.root}>
+        <DocumentTitleSegment segment="Create a Domain" />
+        <Grid
+          container
+          justify="space-between"
+          alignItems="flex-end"
+          className={classes.title}
+        >
+          <Grid item>
+            <Breadcrumb
+              pathname={location.pathname}
+              labelTitle="Create a Domain"
+              labelOptions={{ noCap: true }}
+            />
+          </Grid>
+          <Grid item>
+            <Grid container alignItems="flex-end">
+              <Grid item className="pt0">
+                <DocumentationButton href="https://www.linode.com/docs/guides/dns-manager/" />
+              </Grid>
+            </Grid>
+          </Grid>
+        </Grid>
+
+        <Grid item className={`mlMain py0`}>
+          {generalError && !disabled && (
+            <Notice error spacingTop={8}>
+              {generalError}
+            </Notice>
+          )}
+          {disabled && (
+            <Notice
+              text={
+                "You don't have permissions to create a new Domain. Please contact an account administrator for details."
+              }
+              error
+              important
+            />
+          )}
+
+          <Paper data-qa-label-header>
+            <div className={classes.inner}>
+              <RadioGroup
+                aria-label="type"
+                className={classes.radio}
+                name="type"
+                onChange={this.updateType}
+                row
+                value={type}
+              >
+                <FormControlLabel
+                  value="master"
+                  label="Master"
+                  control={<Radio />}
+                  data-qa-domain-radio="Master"
+                  disabled={disabled}
+                />
+                <FormControlLabel
+                  value="slave"
+                  label="Slave"
+                  control={<Radio />}
+                  data-qa-domain-radio="Slave"
+                  disabled={disabled}
+                />
+              </RadioGroup>
+              <TextField
+                errorText={'' && errorMap.domain}
+                value={domain}
+                disabled={disabled}
+                label="Domain"
+                onChange={this.updateLabel}
+                data-qa-domain-name
+                data-testid="domain-name-input"
+              />
+              {isCreatingMasterDomain && (
+                <TextField
+                  errorText={errorMap.soa_email}
+                  value={soaEmail}
+                  label="SOA Email Address"
+                  onChange={this.updateEmailAddress}
+                  data-qa-soa-email
+                  data-testid="soa-email-input"
+                  disabled={disabled}
+                />
+              )}
+              {isCreatingSlaveDomain && (
+                <MultipleIPInput
+                  title="Master Nameserver IP Address"
+                  ips={this.state.master_ips.map(stringToExtendedIP)}
+                  onChange={this.updateMasterIPAddress}
+                  error={masterIPsError}
+                />
+              )}
+              <TagsInput
+                value={tags}
+                onChange={this.updateTags}
+                tagError={errorMap.tags}
+                disabled={disabled}
+              />
+              {isCreatingMasterDomain && (
+                <React.Fragment>
+                  <Select
+                    isClearable={false}
+                    onChange={(value: Item<DefaultRecordsType>) =>
+                      this.updateInsertDefaultRecords(value.value)
+                    }
+                    defaultValue={{
+                      value: 'none',
+                      label: 'Do not insert default records for me.'
+                    }}
+                    label="Insert Default Records"
+                    options={[
+                      {
+                        value: 'none',
+                        label: 'Do not insert default records for me.'
+                      },
+                      {
+                        value: 'linode',
+                        label: 'Insert default records from one of my Linodes.'
+                      },
+                      {
+                        value: 'nodebalancer',
+                        label:
+                          'Insert default records from one of my NodeBalancers.'
+                      }
+                    ]}
+                  />
+                  <FormHelperText className={classes.helperText}>
+                    If specified, we can automatically create some domain
+                    records (A/AAAA and MX) to get you started, based on one of
+                    your Linodes or NodeBalancers.
+                  </FormHelperText>
+                </React.Fragment>
+              )}
+              {isCreatingMasterDomain &&
+                this.state.defaultRecordsSetting === 'linode' && (
+                  <React.Fragment>
+                    <LinodeSelect
+                      linodeError={errorMap.defaultLinode}
+                      handleChange={this.updateSelectedLinode}
+                      selectedLinode={
+                        this.state.selectedDefaultLinode
+                          ? this.state.selectedDefaultLinode.id
+                          : null
+                      }
+                    />
+                    {!errorMap.defaultLinode && (
+                      <FormHelperText>
+                        {this.state.selectedDefaultLinode &&
+                        !this.state.selectedDefaultLinode.ipv6
+                          ? `We'll automatically create domains for the first IPv4 address on this
+                    Linode.`
+                          : `We'll automatically create domain records for both the first
+                    IPv4 and IPv6 addresses on this Linode.`}
+                      </FormHelperText>
+                    )}
+                  </React.Fragment>
+                )}
+              {isCreatingMasterDomain &&
+                this.state.defaultRecordsSetting === 'nodebalancer' && (
+                  <React.Fragment>
+                    <NodeBalancerSelect
+                      nodeBalancerError={errorMap.defaultNodeBalancer}
+                      handleChange={this.updateSelectedNodeBalancer}
+                      selectedNodeBalancer={
+                        this.state.selectedDefaultNodeBalancer
+                          ? this.state.selectedDefaultNodeBalancer.id
+                          : null
+                      }
+                    />
+                    {!errorMap.defaultNodeBalancer && (
+                      <FormHelperText>
+                        {this.state.selectedDefaultNodeBalancer &&
+                        !this.state.selectedDefaultNodeBalancer.ipv6
+                          ? `We'll automatically create domains for the first IPv4 address on this
+                  NodeBalancer.`
+                          : `We'll automatically create domain records for both the first
+                  IPv4 and IPv6 addresses on this NodeBalancer.`}
+                      </FormHelperText>
+                    )}
+                  </React.Fragment>
+                )}
+              <ActionsPanel>
+                <Button
+                  buttonType="primary"
+                  onClick={this.submit}
+                  data-qa-submit
+                  data-testid="create-domain-submit"
+                  loading={submitting}
+                  disabled={disabled}
+                >
+                  Create
+                </Button>
+              </ActionsPanel>
+            </div>
+          </Paper>
+        </Grid>
+      </Grid>
+    );
+  }
+
+  handleTransferInput = (newIPs: ExtendedIP[]) => {
+    const axfr_ips = newIPs.length > 0 ? newIPs.map(extendedIPToString) : [''];
+    if (this.mounted) {
+      this.setState({ axfr_ips });
+    }
+  };
+
+  redirect = (id: number | '', state?: Record<string, string>) => {
+    const returnPath = !!id ? `/domains/${id}` : '/domains';
+    this.props.history.push(returnPath, state);
+  };
+
+  redirectToLandingOrDetail = (
+    type: 'master' | 'slave',
+    domainID: number,
+    state: Record<string, string> = {}
+  ) => {
+    if (type === 'master' && domainID) {
+      this.redirect(domainID, state);
+    } else {
+      this.redirect('', state);
+    }
+  };
+
+  create = () => {
+    const {
+      domain,
+      type,
+      soaEmail,
+      master_ips,
+      defaultRecordsSetting,
+      selectedDefaultLinode,
+      selectedDefaultNodeBalancer
+    } = this.state;
+    const { domainActions, origin } = this.props;
+
+    const tags = this.state.tags.map(tag => tag.value);
+
+    const finalMasterIPs = master_ips.filter(v => v !== '');
+
+    if (type === 'slave' && finalMasterIPs.length === 0) {
+      this.setState({
+        submitting: false,
+        errors: [
+          {
+            field: 'master_ips',
+            reason: 'You must provide at least one Master Nameserver IP Address'
+          }
+        ]
+      });
+      return;
+    }
+
+    /**
+     * In this case, the user wants default domain records created, but
+     * they haven't supplied a Linode or NodeBalancer
+     */
+    if (defaultRecordsSetting === 'linode' && !selectedDefaultLinode) {
+      return this.setState({
+        errors: [
+          {
+            reason: 'Please select a Linode.',
+            field: 'defaultLinode'
+          }
+        ]
+      });
+    }
+
+    if (
+      defaultRecordsSetting === 'nodebalancer' &&
+      !selectedDefaultNodeBalancer
+    ) {
+      return this.setState({
+        errors: [
+          {
+            reason: 'Please select a NodeBalancer.',
+            field: 'defaultNodeBalancer'
+          }
+        ]
+      });
+    }
+
+    const data =
+      type === 'master'
+        ? { domain, type, tags, soa_email: soaEmail }
+        : { domain, type, tags, master_ips: finalMasterIPs };
+
+    this.setState({ submitting: true });
+    domainActions
+      .createDomain(data)
+      .then((domainData: Domain) => {
+        if (!this.mounted) {
+          return;
+        }
+        sendCreateDomainEvent(origin);
+        /**
+         * now we check to see if the user wanted us to automatically create
+         * domain records for them. If so, create some A/AAAA and MX records
+         * with the first IPv4 and IPv6 from the Linode or NodeBalancer they
+         * selected.
+         *
+         * This only applies to master domains.
+         */
+        if (type === 'master') {
+          if (defaultRecordsSetting === 'linode') {
+            return generateDefaultDomainRecords(
+              domainData.domain,
+              domainData.id,
+              path(['ipv4', 0], selectedDefaultLinode),
+              path(['ipv6'], selectedDefaultLinode)
+            )
+              .then(() => {
+                return this.redirectToLandingOrDetail(type, domainData.id);
+              })
+              .catch((e: APIError[]) => {
+                reportException(
+                  `Default DNS Records couldn't be created from Linode: ${e[0].reason}`,
+                  {
+                    selectedLinode: this.state.selectedDefaultLinode!.id,
+                    domainID: domainData.id,
+                    ipv4: path(['ipv4', 0], selectedDefaultLinode),
+                    ipv6: path(['ipv6'], selectedDefaultLinode)
+                  }
+                );
+                return this.redirectToLandingOrDetail(type, domainData.id, {
+                  recordError:
+                    'There was an issue creating default domain records.'
+                });
+              });
+          }
+
+          if (defaultRecordsSetting === 'nodebalancer') {
+            return generateDefaultDomainRecords(
+              domainData.domain,
+              domainData.id,
+              path(['ipv4'], selectedDefaultNodeBalancer),
+              path(['ipv6'], selectedDefaultNodeBalancer)
+            )
+              .then(() => {
+                return this.redirectToLandingOrDetail(type, domainData.id);
+              })
+              .catch((e: APIError[]) => {
+                reportException(
+                  `Default DNS Records couldn't be created from NodeBalancer: ${e[0].reason}`,
+                  {
+                    selectedNodeBalancer: this.state
+                      .selectedDefaultNodeBalancer!.id,
+                    domainID: domainData.id,
+                    ipv4: path(['ipv4'], selectedDefaultNodeBalancer),
+                    ipv6: path(['ipv6'], selectedDefaultNodeBalancer)
+                  }
+                );
+                return this.redirectToLandingOrDetail(type, domainData.id, {
+                  recordError:
+                    'There was an issue creating default domain records.'
+                });
+              });
+          }
+        }
+        return this.redirectToLandingOrDetail(type, domainData.id);
+      })
+      .catch(err => {
+        if (!this.mounted) {
+          return;
+        }
+        this.setState(
+          {
+            submitting: false,
+            errors: getAPIErrorOrDefault(err)
+          },
+          () => {
+            scrollErrorIntoView();
+          }
+        );
+      });
+  };
+
+  submit = () => {
+    this.create();
+  };
+
+  updateLabel = (e: React.ChangeEvent<HTMLInputElement>) =>
+    this.setState({ domain: e.target.value });
+
+  updateEmailAddress = (e: React.ChangeEvent<HTMLInputElement>) =>
+    this.setState({ soaEmail: e.target.value });
+
+  updateSelectedLinode = (linode: Linode) =>
+    this.setState({ selectedDefaultLinode: linode });
+
+  updateSelectedNodeBalancer = (nodebalancer: NodeBalancer) =>
+    this.setState({ selectedDefaultNodeBalancer: nodebalancer });
+
+  updateTags = (selected: Tag[]) => {
+    this.setState({ tags: selected });
+  };
+
+  updateInsertDefaultRecords = (value: DefaultRecordsType) => {
+    this.setState({ defaultRecordsSetting: value });
+  };
+
+  updateType = (
+    e: React.ChangeEvent<HTMLInputElement>,
+    value: 'master' | 'slave'
+  ) => this.setState({ type: value });
+
+  updateMasterIPAddress = (newIPs: ExtendedIP[]) => {
+    const master_ips =
+      newIPs.length > 0 ? newIPs.map(extendedIPToString) : [''];
+    if (this.mounted) {
+      this.setState({ master_ips });
+    }
+  };
+}
+
+const styled = withStyles(styles);
+
+interface DispatchProps {
+  resetDrawer: () => void;
+  upsertDomain: (domain: Domain) => void;
+}
+
+const mapDispatchToProps = (dispatch: Dispatch) =>
+  bindActionCreators({ resetDrawer, upsertDomain }, dispatch);
+
+interface StateProps {
+  domain?: string;
+  domainProps?: Domain;
+  id?: number;
+  disabled: boolean;
+  origin: DomainDrawerOrigin;
+}
+
+const mapStateToProps = (state: ApplicationState) => {
+  const id = state.domainDrawer?.id ?? '0';
+  const domainEntities = state.__resources.domains.itemsById;
+  const domainProps = domainEntities[String(id)];
+  return {
+    domain: path(['domainDrawer', 'domain'], state),
+    domainProps,
+    id,
+    // disabled if the profile is restricted and doesn't have add_domains grant
+    disabled: isRestrictedUser(state) && !hasGrant(state, 'add_domains'),
+    origin: state.domainDrawer.origin
+  };
+};
+
+const connected = connect(mapStateToProps, mapDispatchToProps);
+
+export default compose<CombinedProps, {}>(
+  withDomainActions,
+  styled,
+  connected,
+  withRouter,
+  withSnackbar
+)(CreateDomain);

--- a/packages/manager/src/features/Domains/CreateDomain/CreateDomain.tsx
+++ b/packages/manager/src/features/Domains/CreateDomain/CreateDomain.tsx
@@ -16,6 +16,7 @@ import DocumentationButton from 'src/components/DocumentationButton';
 import FormControlLabel from 'src/components/core/FormControlLabel';
 import FormHelperText from 'src/components/core/FormHelperText';
 import Grid from 'src/components/core/Grid';
+import Paper from 'src/components/core/Paper';
 import RadioGroup from 'src/components/core/RadioGroup';
 import {
   createStyles,
@@ -56,36 +57,17 @@ import {
 } from 'src/utilities/ipUtils';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import { getInitialIPs } from '../domainUtils';
-import Paper from 'src/components/core/Paper';
 
-type ClassNames = 'root' | 'title' | 'inner' | 'radio' | 'helperText';
+type ClassNames = 'title' | 'main' | 'inner' | 'radio' | 'helperText';
 
 const styles = (theme: Theme) =>
   createStyles({
-    root: {
-      '& .mlMain': {
-        maxWidth: '100%',
-        flexBasis: '100%',
-        [theme.breakpoints.up('lg')]: {
-          maxWidth: '78.8%',
-          flexBasis: '78.8%'
-        }
-      },
-      '& .mlSidebar': {
-        position: 'static',
-        width: '100%',
-        flexBasis: '100%',
-        maxWidth: '100%',
-        [theme.breakpoints.up('lg')]: {
-          position: 'sticky',
-          maxWidth: '21.2%',
-          flexBasis: '21.2%'
-        }
-      }
-    },
     title: {
       marginTop: theme.spacing(1),
       marginBottom: theme.spacing(3)
+    },
+    main: {
+      width: '100%'
     },
     inner: {
       padding: theme.spacing(3),
@@ -280,7 +262,7 @@ class CreateDomain extends React.Component<CombinedProps, State> {
     const isCreatingSlaveDomain = type === 'slave';
 
     return (
-      <Grid container className={classes.root}>
+      <Grid container>
         <DocumentTitleSegment segment="Create a Domain" />
         <Grid
           container
@@ -304,7 +286,7 @@ class CreateDomain extends React.Component<CombinedProps, State> {
           </Grid>
         </Grid>
 
-        <Grid item className={`mlMain py0`}>
+        <Grid item className={classes.main}>
           {generalError && !disabled && (
             <Notice error spacingTop={8}>
               {generalError}
@@ -465,7 +447,7 @@ class CreateDomain extends React.Component<CombinedProps, State> {
               <ActionsPanel>
                 <Button
                   buttonType="primary"
-                  onClick={this.submit}
+                  onClick={this.create}
                   data-qa-submit
                   data-testid="create-domain-submit"
                   loading={submitting}
@@ -656,10 +638,6 @@ class CreateDomain extends React.Component<CombinedProps, State> {
           }
         );
       });
-  };
-
-  submit = () => {
-    this.create();
   };
 
   updateLabel = (e: React.ChangeEvent<HTMLInputElement>) =>

--- a/packages/manager/src/features/Domains/CreateDomain/CreateDomain.tsx
+++ b/packages/manager/src/features/Domains/CreateDomain/CreateDomain.tsx
@@ -1,4 +1,8 @@
-import { createDomainRecord, Domain } from '@linode/api-v4/lib/domains';
+import {
+  createDomainRecord,
+  Domain,
+  DomainType
+} from '@linode/api-v4/lib/domains';
 import { Linode } from '@linode/api-v4/lib/linodes';
 import { NodeBalancer } from '@linode/api-v4/lib/nodebalancers';
 import { APIError } from '@linode/api-v4/lib/types';
@@ -18,12 +22,7 @@ import FormHelperText from 'src/components/core/FormHelperText';
 import Grid from 'src/components/core/Grid';
 import Paper from 'src/components/core/Paper';
 import RadioGroup from 'src/components/core/RadioGroup';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles
-} from 'src/components/core/styles';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import MultipleIPInput from 'src/components/MultipleIPInput';
@@ -56,65 +55,45 @@ import {
   stringToExtendedIP
 } from 'src/utilities/ipUtils';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
-import { getInitialIPs } from '../domainUtils';
 
-type ClassNames = 'title' | 'main' | 'inner' | 'radio' | 'ip' | 'helperText';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    title: {
-      marginTop: theme.spacing(1),
-      marginBottom: theme.spacing(3)
+const useStyles = makeStyles((theme: Theme) => ({
+  title: {
+    marginTop: theme.spacing(1),
+    marginBottom: theme.spacing(3)
+  },
+  main: {
+    width: '100%'
+  },
+  inner: {
+    padding: theme.spacing(3),
+    paddingTop: theme.spacing(2),
+    '& > div': {
+      marginBottom: theme.spacing(2)
     },
-    main: {
-      width: '100%'
-    },
-    inner: {
-      padding: theme.spacing(3),
-      paddingTop: theme.spacing(2),
-      '& > div': {
-        marginBottom: theme.spacing(2)
-      },
-      '& label': {
-        color: theme.color.headline,
-        fontWeight: 600,
-        lineHeight: '1.33rem',
-        letterSpacing: '0.25px',
-        margin: 0
-      }
-    },
-    radio: {
-      '& label:first-child .MuiButtonBase-root': {
-        marginLeft: -10
-      }
-    },
-    ip: {
-      maxWidth: 468
-    },
-    helperText: {
-      maxWidth: 'none'
+    '& label': {
+      color: theme.color.headline,
+      fontWeight: 600,
+      lineHeight: '1.33rem',
+      letterSpacing: '0.25px',
+      margin: 0
     }
-  });
+  },
+  radio: {
+    '& label:first-child .MuiButtonBase-root': {
+      marginLeft: -10
+    }
+  },
+  ip: {
+    maxWidth: 468
+  },
+  helperText: {
+    maxWidth: 'none'
+  }
+}));
 
 type DefaultRecordsType = 'none' | 'linode' | 'nodebalancer';
 
-interface State {
-  domain: string;
-  type: 'master' | 'slave';
-  soaEmail: string;
-  cloneName: string;
-  tags: Tag[];
-  errors?: APIError[];
-  submitting: boolean;
-  master_ips: string[];
-  axfr_ips: string[];
-  defaultRecordsSetting: DefaultRecordsType;
-  selectedDefaultLinode?: Linode;
-  selectedDefaultNodeBalancer?: NodeBalancer;
-}
-
-type CombinedProps = WithStyles<ClassNames> &
-  DomainActionsProps &
+type CombinedProps = DomainActionsProps &
   DispatchProps &
   RouteComponentProps<{}> &
   StateProps &
@@ -183,341 +162,88 @@ export const generateDefaultDomainRecords = (
   );
 };
 
-class CreateDomain extends React.Component<CombinedProps, State> {
-  mounted: boolean = false;
-  defaultState: State = {
-    domain: '',
-    type: 'master',
-    soaEmail: '',
-    cloneName: '',
-    tags: [],
-    submitting: false,
-    errors: [],
-    master_ips: [''],
-    axfr_ips: [''],
-    defaultRecordsSetting: 'none',
-    selectedDefaultLinode: undefined,
-    selectedDefaultNodeBalancer: undefined
-  };
+export const CreateDomain: React.FC<CombinedProps> = props => {
+  const classes = useStyles();
 
-  state: State = {
-    ...this.defaultState
-  };
+  const { disabled, domainActions, origin } = props;
 
-  componentDidMount() {
-    this.mounted = true;
-  }
+  const [mounted, setMounted] = React.useState<boolean>(false);
 
-  componentWillUnmount() {
-    this.mounted = false;
-  }
+  const [domain, setDomain] = React.useState<string>('');
+  const [type, setType] = React.useState<DomainType>('master');
+  const [soaEmail, setSOAEmail] = React.useState<string>('');
+  const [tags, setTags] = React.useState<Tag[]>([]);
+  const [submitting, setSubmitting] = React.useState<boolean>(false);
+  const [errors, setErrors] = React.useState<APIError[]>([]);
+  const [master_ips, setMaster_IPS] = React.useState<string[]>([]);
+  const [defaultRecordsSetting, setDefaultRecordsSetting] = React.useState<
+    DefaultRecordsType
+  >('none');
+  const [selectedDefaultLinode, setSelectedDefaultLinode] = React.useState<
+    Linode | undefined
+  >(undefined);
+  const [
+    selectedDefaultNodeBalancer,
+    setSelectedDefaultNodeBalancer
+  ] = React.useState<NodeBalancer | undefined>(undefined);
 
-  componentDidUpdate(prevProps: CombinedProps, prevState: State) {
-    if (
-      this.props.domainProps && // there are domain props for an update and ...
-      (!prevProps.domainProps || // it just appeared
-        prevProps.domainProps.id !== this.props.domainProps.id)
-    ) {
-      // or the domain for editing has changed
+  React.useEffect(() => {
+    setMounted(true);
 
-      // then put it props into state to populate fields
-      const {
-        axfr_ips,
-        domain,
-        tags,
-        master_ips,
-        type,
-        soa_email
-      } = this.props.domainProps;
-      this.setState({
-        tags: tags.map(tag => ({ label: tag, value: tag })),
-        type,
-        domain,
-        master_ips: getInitialIPs(master_ips),
-        axfr_ips: getInitialIPs(axfr_ips),
-        soaEmail: soa_email
-      });
-    }
-  }
+    return () => {
+      setMounted(false);
+    };
+  }, []);
 
-  render() {
-    const { classes, disabled } = this.props;
-    const { type, domain, soaEmail, errors, submitting, tags } = this.state;
+  const errorMap = getErrorMap(
+    [
+      'master_ips',
+      'domain',
+      'type',
+      'soa_email',
+      'tags',
+      'defaultNodeBalancer',
+      'defaultLinode'
+    ],
+    errors
+  );
 
-    const errorMap = getErrorMap(
-      [
-        'axfr_ips',
-        'master_ips',
-        'domain',
-        'type',
-        'soa_email',
-        'tags',
-        'defaultNodeBalancer',
-        'defaultLinode'
-      ],
-      errors
-    );
+  const generalError = errorMap.none;
+  const masterIPsError = errorMap.master_ips;
 
-    const generalError = errorMap.none;
-    const masterIPsError = errorMap.master_ips;
+  const isCreatingMasterDomain = type === 'master';
+  const isCreatingSlaveDomain = type === 'slave';
 
-    const isCreatingMasterDomain = type === 'master';
-    const isCreatingSlaveDomain = type === 'slave';
-
-    return (
-      <Grid container>
-        <DocumentTitleSegment segment="Create a Domain" />
-        <Grid
-          container
-          justify="space-between"
-          alignItems="flex-end"
-          className={classes.title}
-        >
-          <Grid item>
-            <Breadcrumb
-              pathname={location.pathname}
-              labelTitle="Create a Domain"
-              labelOptions={{ noCap: true }}
-            />
-          </Grid>
-          <Grid item>
-            <Grid container alignItems="flex-end">
-              <Grid item className="pt0">
-                <DocumentationButton href="https://www.linode.com/docs/guides/dns-manager/" />
-              </Grid>
-            </Grid>
-          </Grid>
-        </Grid>
-
-        <Grid item className={classes.main}>
-          {generalError && !disabled && (
-            <Notice error spacingTop={8}>
-              {generalError}
-            </Notice>
-          )}
-          {disabled && (
-            <Notice
-              text={
-                "You don't have permissions to create a new Domain. Please contact an account administrator for details."
-              }
-              error
-              important
-            />
-          )}
-
-          <Paper data-qa-label-header>
-            <div className={classes.inner}>
-              <RadioGroup
-                aria-label="type"
-                className={classes.radio}
-                name="type"
-                onChange={this.updateType}
-                row
-                value={type}
-              >
-                <FormControlLabel
-                  value="master"
-                  label="Master"
-                  control={<Radio />}
-                  data-qa-domain-radio="Master"
-                  disabled={disabled}
-                />
-                <FormControlLabel
-                  value="slave"
-                  label="Slave"
-                  control={<Radio />}
-                  data-qa-domain-radio="Slave"
-                  disabled={disabled}
-                />
-              </RadioGroup>
-              <TextField
-                errorText={errorMap.domain}
-                value={domain}
-                disabled={disabled}
-                label="Domain"
-                onChange={this.updateLabel}
-                data-qa-domain-name
-                data-testid="domain-name-input"
-              />
-              {isCreatingMasterDomain && (
-                <TextField
-                  errorText={errorMap.soa_email}
-                  value={soaEmail}
-                  label="SOA Email Address"
-                  onChange={this.updateEmailAddress}
-                  data-qa-soa-email
-                  data-testid="soa-email-input"
-                  disabled={disabled}
-                />
-              )}
-              {isCreatingSlaveDomain && (
-                <MultipleIPInput
-                  title="Master Nameserver IP Address"
-                  className={classes.ip}
-                  ips={this.state.master_ips.map(stringToExtendedIP)}
-                  onChange={this.updateMasterIPAddress}
-                  error={masterIPsError}
-                />
-              )}
-              <TagsInput
-                value={tags}
-                onChange={this.updateTags}
-                tagError={errorMap.tags}
-                disabled={disabled}
-              />
-              {isCreatingMasterDomain && (
-                <React.Fragment>
-                  <Select
-                    isClearable={false}
-                    onChange={(value: Item<DefaultRecordsType>) =>
-                      this.updateInsertDefaultRecords(value.value)
-                    }
-                    defaultValue={{
-                      value: 'none',
-                      label: 'Do not insert default records for me.'
-                    }}
-                    label="Insert Default Records"
-                    options={[
-                      {
-                        value: 'none',
-                        label: 'Do not insert default records for me.'
-                      },
-                      {
-                        value: 'linode',
-                        label: 'Insert default records from one of my Linodes.'
-                      },
-                      {
-                        value: 'nodebalancer',
-                        label:
-                          'Insert default records from one of my NodeBalancers.'
-                      }
-                    ]}
-                  />
-                  <FormHelperText className={classes.helperText}>
-                    If specified, we can automatically create some domain
-                    records (A/AAAA and MX) to get you started, based on one of
-                    your Linodes or NodeBalancers.
-                  </FormHelperText>
-                </React.Fragment>
-              )}
-              {isCreatingMasterDomain &&
-                this.state.defaultRecordsSetting === 'linode' && (
-                  <React.Fragment>
-                    <LinodeSelect
-                      linodeError={errorMap.defaultLinode}
-                      handleChange={this.updateSelectedLinode}
-                      selectedLinode={
-                        this.state.selectedDefaultLinode
-                          ? this.state.selectedDefaultLinode.id
-                          : null
-                      }
-                      disabled={disabled}
-                    />
-                    {!errorMap.defaultLinode && (
-                      <FormHelperText>
-                        {this.state.selectedDefaultLinode &&
-                        !this.state.selectedDefaultLinode.ipv6
-                          ? `We'll automatically create domains for the first IPv4 address on this
-                    Linode.`
-                          : `We'll automatically create domain records for both the first
-                    IPv4 and IPv6 addresses on this Linode.`}
-                      </FormHelperText>
-                    )}
-                  </React.Fragment>
-                )}
-              {isCreatingMasterDomain &&
-                this.state.defaultRecordsSetting === 'nodebalancer' && (
-                  <React.Fragment>
-                    <NodeBalancerSelect
-                      nodeBalancerError={errorMap.defaultNodeBalancer}
-                      handleChange={this.updateSelectedNodeBalancer}
-                      selectedNodeBalancer={
-                        this.state.selectedDefaultNodeBalancer
-                          ? this.state.selectedDefaultNodeBalancer.id
-                          : null
-                      }
-                    />
-                    {!errorMap.defaultNodeBalancer && (
-                      <FormHelperText>
-                        {this.state.selectedDefaultNodeBalancer &&
-                        !this.state.selectedDefaultNodeBalancer.ipv6
-                          ? `We'll automatically create domains for the first IPv4 address on this
-                  NodeBalancer.`
-                          : `We'll automatically create domain records for both the first
-                  IPv4 and IPv6 addresses on this NodeBalancer.`}
-                      </FormHelperText>
-                    )}
-                  </React.Fragment>
-                )}
-              <ActionsPanel>
-                <Button
-                  buttonType="primary"
-                  onClick={this.create}
-                  data-qa-submit
-                  data-testid="create-domain-submit"
-                  loading={submitting}
-                  disabled={disabled}
-                >
-                  Create
-                </Button>
-              </ActionsPanel>
-            </div>
-          </Paper>
-        </Grid>
-      </Grid>
-    );
-  }
-
-  handleTransferInput = (newIPs: ExtendedIP[]) => {
-    const axfr_ips = newIPs.length > 0 ? newIPs.map(extendedIPToString) : [''];
-    if (this.mounted) {
-      this.setState({ axfr_ips });
-    }
-  };
-
-  redirect = (id: number | '', state?: Record<string, string>) => {
+  const redirect = (id: number | '', state?: Record<string, string>) => {
     const returnPath = !!id ? `/domains/${id}` : '/domains';
-    this.props.history.push(returnPath, state);
+    props.history.push(returnPath, state);
   };
 
-  redirectToLandingOrDetail = (
+  const redirectToLandingOrDetail = (
     type: 'master' | 'slave',
     domainID: number,
     state: Record<string, string> = {}
   ) => {
     if (type === 'master' && domainID) {
-      this.redirect(domainID, state);
+      redirect(domainID, state);
     } else {
-      this.redirect('', state);
+      redirect('', state);
     }
   };
 
-  create = () => {
-    const {
-      domain,
-      type,
-      soaEmail,
-      master_ips,
-      defaultRecordsSetting,
-      selectedDefaultLinode,
-      selectedDefaultNodeBalancer
-    } = this.state;
-    const { domainActions, origin } = this.props;
-
-    const tags = this.state.tags.map(tag => tag.value);
+  const create = () => {
+    const _tags = tags.map(tag => tag.value);
 
     const finalMasterIPs = master_ips.filter(v => v !== '');
 
     if (type === 'slave' && finalMasterIPs.length === 0) {
-      this.setState({
-        submitting: false,
-        errors: [
-          {
-            field: 'master_ips',
-            reason: 'You must provide at least one Master Nameserver IP Address'
-          }
-        ]
-      });
+      setSubmitting(false);
+      setErrors([
+        {
+          field: 'master_ips',
+          reason: 'You must provide at least one Master Nameserver IP Address'
+        }
+      ]);
       return;
     }
 
@@ -526,45 +252,41 @@ class CreateDomain extends React.Component<CombinedProps, State> {
      * they haven't supplied a Linode or NodeBalancer
      */
     if (defaultRecordsSetting === 'linode' && !selectedDefaultLinode) {
-      return this.setState({
-        errors: [
-          {
-            reason: 'Please select a Linode.',
-            field: 'defaultLinode'
-          }
-        ]
-      });
+      return setErrors([
+        {
+          reason: 'Please select a Linode.',
+          field: 'defaultLinode'
+        }
+      ]);
     }
 
     if (
       defaultRecordsSetting === 'nodebalancer' &&
       !selectedDefaultNodeBalancer
     ) {
-      return this.setState({
-        errors: [
-          {
-            reason: 'Please select a NodeBalancer.',
-            field: 'defaultNodeBalancer'
-          }
-        ]
-      });
+      return setErrors([
+        {
+          reason: 'Please select a NodeBalancer.',
+          field: 'defaultNodeBalancer'
+        }
+      ]);
     }
 
     const data =
       type === 'master'
-        ? { domain, type, tags, soa_email: soaEmail }
-        : { domain, type, tags, master_ips: finalMasterIPs };
+        ? { domain, type, _tags, soa_email: soaEmail }
+        : { domain, type, _tags, master_ips: finalMasterIPs };
 
-    this.setState({ submitting: true });
+    setSubmitting(true);
     domainActions
       .createDomain(data)
       .then((domainData: Domain) => {
-        if (!this.mounted) {
+        if (!mounted) {
           return;
         }
         sendCreateDomainEvent(origin);
         /**
-         * now we check to see if the user wanted us to automatically create
+         * Now we check to see if the user wanted us to automatically create
          * domain records for them. If so, create some A/AAAA and MX records
          * with the first IPv4 and IPv6 from the Linode or NodeBalancer they
          * selected.
@@ -580,19 +302,19 @@ class CreateDomain extends React.Component<CombinedProps, State> {
               path(['ipv6'], selectedDefaultLinode)
             )
               .then(() => {
-                return this.redirectToLandingOrDetail(type, domainData.id);
+                return redirectToLandingOrDetail(type, domainData.id);
               })
               .catch((e: APIError[]) => {
                 reportException(
                   `Default DNS Records couldn't be created from Linode: ${e[0].reason}`,
                   {
-                    selectedLinode: this.state.selectedDefaultLinode!.id,
+                    selectedLinode: selectedDefaultLinode!.id,
                     domainID: domainData.id,
                     ipv4: path(['ipv4', 0], selectedDefaultLinode),
                     ipv6: path(['ipv6'], selectedDefaultLinode)
                   }
                 );
-                return this.redirectToLandingOrDetail(type, domainData.id, {
+                return redirectToLandingOrDetail(type, domainData.id, {
                   recordError:
                     'There was an issue creating default domain records.'
                 });
@@ -607,79 +329,269 @@ class CreateDomain extends React.Component<CombinedProps, State> {
               path(['ipv6'], selectedDefaultNodeBalancer)
             )
               .then(() => {
-                return this.redirectToLandingOrDetail(type, domainData.id);
+                return redirectToLandingOrDetail(type, domainData.id);
               })
               .catch((e: APIError[]) => {
                 reportException(
                   `Default DNS Records couldn't be created from NodeBalancer: ${e[0].reason}`,
                   {
-                    selectedNodeBalancer: this.state
-                      .selectedDefaultNodeBalancer!.id,
+                    selectedNodeBalancer: selectedDefaultNodeBalancer!.id,
                     domainID: domainData.id,
                     ipv4: path(['ipv4'], selectedDefaultNodeBalancer),
                     ipv6: path(['ipv6'], selectedDefaultNodeBalancer)
                   }
                 );
-                return this.redirectToLandingOrDetail(type, domainData.id, {
+                return redirectToLandingOrDetail(type, domainData.id, {
                   recordError:
                     'There was an issue creating default domain records.'
                 });
               });
           }
         }
-        return this.redirectToLandingOrDetail(type, domainData.id);
+        return redirectToLandingOrDetail(type, domainData.id);
       })
       .catch(err => {
-        if (!this.mounted) {
+        if (!mounted) {
           return;
         }
-        this.setState(
-          {
-            submitting: false,
-            errors: getAPIErrorOrDefault(err)
-          },
-          () => {
-            scrollErrorIntoView();
-          }
-        );
+        setSubmitting(false);
+        setErrors(getAPIErrorOrDefault(err));
+        scrollErrorIntoView();
       });
   };
 
-  updateLabel = (e: React.ChangeEvent<HTMLInputElement>) =>
-    this.setState({ domain: e.target.value });
+  const updateLabel = (e: React.ChangeEvent<HTMLInputElement>) =>
+    setDomain(e.target.value);
 
-  updateEmailAddress = (e: React.ChangeEvent<HTMLInputElement>) =>
-    this.setState({ soaEmail: e.target.value });
+  const updateEmailAddress = (e: React.ChangeEvent<HTMLInputElement>) =>
+    setSOAEmail(e.target.value);
 
-  updateSelectedLinode = (linode: Linode) =>
-    this.setState({ selectedDefaultLinode: linode });
+  const updateSelectedLinode = (linode: Linode) =>
+    setSelectedDefaultLinode(linode);
 
-  updateSelectedNodeBalancer = (nodebalancer: NodeBalancer) =>
-    this.setState({ selectedDefaultNodeBalancer: nodebalancer });
+  const updateSelectedNodeBalancer = (nodebalancer: NodeBalancer) =>
+    setSelectedDefaultNodeBalancer(nodebalancer);
 
-  updateTags = (selected: Tag[]) => {
-    this.setState({ tags: selected });
-  };
+  const updateTags = (selected: Tag[]) => setTags(selected);
 
-  updateInsertDefaultRecords = (value: DefaultRecordsType) => {
-    this.setState({ defaultRecordsSetting: value });
-  };
+  const updateInsertDefaultRecords = (value: DefaultRecordsType) =>
+    setDefaultRecordsSetting(value);
 
-  updateType = (
+  const updateType = (
     e: React.ChangeEvent<HTMLInputElement>,
     value: 'master' | 'slave'
-  ) => this.setState({ type: value, errors: [] });
+  ) => {
+    setType(value);
+    setErrors([]);
+  };
 
-  updateMasterIPAddress = (newIPs: ExtendedIP[]) => {
+  const updateMasterIPAddress = (newIPs: ExtendedIP[]) => {
     const master_ips =
       newIPs.length > 0 ? newIPs.map(extendedIPToString) : [''];
-    if (this.mounted) {
-      this.setState({ master_ips });
+    if (mounted) {
+      setMaster_IPS(master_ips);
     }
   };
-}
 
-const styled = withStyles(styles);
+  return (
+    <Grid container>
+      <DocumentTitleSegment segment="Create a Domain" />
+      <Grid
+        container
+        justify="space-between"
+        alignItems="flex-end"
+        className={classes.title}
+      >
+        <Grid item>
+          <Breadcrumb
+            pathname={location.pathname}
+            labelTitle="Create a Domain"
+            labelOptions={{ noCap: true }}
+          />
+        </Grid>
+        <Grid item>
+          <Grid container alignItems="flex-end">
+            <Grid item className="pt0">
+              <DocumentationButton href="https://www.linode.com/docs/guides/dns-manager/" />
+            </Grid>
+          </Grid>
+        </Grid>
+      </Grid>
+
+      <Grid item className={classes.main}>
+        {generalError && !disabled && (
+          <Notice error spacingTop={8}>
+            {generalError}
+          </Notice>
+        )}
+        {disabled && (
+          <Notice
+            text={
+              "You don't have permissions to create a new Domain. Please contact an account administrator for details."
+            }
+            error
+            important
+          />
+        )}
+
+        <Paper data-qa-label-header>
+          <div className={classes.inner}>
+            <RadioGroup
+              aria-label="type"
+              className={classes.radio}
+              name="type"
+              onChange={updateType}
+              row
+              value={type}
+            >
+              <FormControlLabel
+                value="master"
+                label="Master"
+                control={<Radio />}
+                data-qa-domain-radio="Master"
+                disabled={disabled}
+              />
+              <FormControlLabel
+                value="slave"
+                label="Slave"
+                control={<Radio />}
+                data-qa-domain-radio="Slave"
+                disabled={disabled}
+              />
+            </RadioGroup>
+            <TextField
+              errorText={errorMap.domain}
+              value={domain}
+              disabled={disabled}
+              label="Domain"
+              onChange={updateLabel}
+              data-qa-domain-name
+              data-testid="domain-name-input"
+            />
+            {isCreatingMasterDomain && (
+              <TextField
+                errorText={errorMap.soa_email}
+                value={soaEmail}
+                label="SOA Email Address"
+                onChange={updateEmailAddress}
+                data-qa-soa-email
+                data-testid="soa-email-input"
+                disabled={disabled}
+              />
+            )}
+            {isCreatingSlaveDomain && (
+              <MultipleIPInput
+                title="Master Nameserver IP Address"
+                className={classes.ip}
+                ips={master_ips.map(stringToExtendedIP)}
+                onChange={updateMasterIPAddress}
+                error={masterIPsError}
+              />
+            )}
+            <TagsInput
+              value={tags}
+              onChange={updateTags}
+              tagError={errorMap.tags}
+              disabled={disabled}
+            />
+            {isCreatingMasterDomain && (
+              <React.Fragment>
+                <Select
+                  isClearable={false}
+                  onChange={(value: Item<DefaultRecordsType>) =>
+                    updateInsertDefaultRecords(value.value)
+                  }
+                  defaultValue={{
+                    value: 'none',
+                    label: 'Do not insert default records for me.'
+                  }}
+                  label="Insert Default Records"
+                  options={[
+                    {
+                      value: 'none',
+                      label: 'Do not insert default records for me.'
+                    },
+                    {
+                      value: 'linode',
+                      label: 'Insert default records from one of my Linodes.'
+                    },
+                    {
+                      value: 'nodebalancer',
+                      label:
+                        'Insert default records from one of my NodeBalancers.'
+                    }
+                  ]}
+                />
+                <FormHelperText className={classes.helperText}>
+                  If specified, we can automatically create some domain records
+                  (A/AAAA and MX) to get you started, based on one of your
+                  Linodes or NodeBalancers.
+                </FormHelperText>
+              </React.Fragment>
+            )}
+            {isCreatingMasterDomain && defaultRecordsSetting === 'linode' && (
+              <React.Fragment>
+                <LinodeSelect
+                  linodeError={errorMap.defaultLinode}
+                  handleChange={updateSelectedLinode}
+                  selectedLinode={
+                    selectedDefaultLinode ? selectedDefaultLinode.id : null
+                  }
+                  disabled={disabled}
+                />
+                {!errorMap.defaultLinode && (
+                  <FormHelperText>
+                    {selectedDefaultLinode && !selectedDefaultLinode.ipv6
+                      ? `We'll automatically create domains for the first IPv4 address on this
+                  Linode.`
+                      : `We'll automatically create domain records for both the first
+                  IPv4 and IPv6 addresses on this Linode.`}
+                  </FormHelperText>
+                )}
+              </React.Fragment>
+            )}
+            {isCreatingMasterDomain &&
+              defaultRecordsSetting === 'nodebalancer' && (
+                <React.Fragment>
+                  <NodeBalancerSelect
+                    nodeBalancerError={errorMap.defaultNodeBalancer}
+                    handleChange={updateSelectedNodeBalancer}
+                    selectedNodeBalancer={
+                      selectedDefaultNodeBalancer
+                        ? selectedDefaultNodeBalancer.id
+                        : null
+                    }
+                  />
+                  {!errorMap.defaultNodeBalancer && (
+                    <FormHelperText>
+                      {selectedDefaultNodeBalancer &&
+                      !selectedDefaultNodeBalancer.ipv6
+                        ? `We'll automatically create domains for the first IPv4 address on this
+                NodeBalancer.`
+                        : `We'll automatically create domain records for both the first
+                IPv4 and IPv6 addresses on this NodeBalancer.`}
+                    </FormHelperText>
+                  )}
+                </React.Fragment>
+              )}
+            <ActionsPanel>
+              <Button
+                buttonType="primary"
+                onClick={create}
+                data-qa-submit
+                data-testid="create-domain-submit"
+                loading={submitting}
+                disabled={disabled}
+              >
+                Create
+              </Button>
+            </ActionsPanel>
+          </div>
+        </Paper>
+      </Grid>
+    </Grid>
+  );
+};
 
 interface DispatchProps {
   resetDrawer: () => void;
@@ -705,7 +617,7 @@ const mapStateToProps = (state: ApplicationState) => {
     domain: path(['domainDrawer', 'domain'], state),
     domainProps,
     id,
-    // disabled if the profile is restricted and doesn't have add_domains grant
+    // Disabled if the profile is restricted and doesn't have add_domains grant
     disabled: isRestrictedUser(state) && !hasGrant(state, 'add_domains'),
     origin: state.domainDrawer.origin
   };
@@ -715,7 +627,6 @@ const connected = connect(mapStateToProps, mapDispatchToProps);
 
 export default compose<CombinedProps, {}>(
   withDomainActions,
-  styled,
   connected,
   withRouter,
   withSnackbar

--- a/packages/manager/src/features/Domains/CreateDomain/index.tsx
+++ b/packages/manager/src/features/Domains/CreateDomain/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './CreateDomain';

--- a/packages/manager/src/features/Domains/DomainDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainDrawer.tsx
@@ -17,7 +17,6 @@ import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import Divider from 'src/components/core/Divider';
 import FormControlLabel from 'src/components/core/FormControlLabel';
-import FormHelperText from 'src/components/core/FormHelperText';
 import RadioGroup from 'src/components/core/RadioGroup';
 import {
   createStyles,
@@ -26,15 +25,11 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 import Drawer from 'src/components/Drawer';
-import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import MultipleIPInput from 'src/components/MultipleIPInput';
 import Notice from 'src/components/Notice';
 import Radio from 'src/components/Radio';
 import TagsInput, { Tag } from 'src/components/TagsInput';
 import TextField from 'src/components/TextField';
-import { reportException } from 'src/exceptionReporting';
-import LinodeSelect from 'src/features/linodes/LinodeSelect';
-import NodeBalancerSelect from 'src/features/NodeBalancers/NodeBalancerSelect';
 import {
   hasGrant,
   isRestrictedUser
@@ -42,7 +37,6 @@ import {
 import { ApplicationState } from 'src/store';
 import {
   CLONING,
-  CREATING,
   EDITING,
   Origin as DomainDrawerOrigin,
   resetDrawer
@@ -53,7 +47,6 @@ import {
   withDomainActions
 } from 'src/store/domains/domains.container';
 import { getAPIErrorOrDefault, getErrorMap } from 'src/utilities/errorUtils';
-import { sendCreateDomainEvent } from 'src/utilities/ga';
 import {
   ExtendedIP,
   extendedIPToString,
@@ -63,14 +56,10 @@ import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import DeleteDomain from './DeleteDomain';
 import { getInitialIPs, transferHelperText as helperText } from './domainUtils';
 
-type ClassNames = 'root' | 'addIP' | 'divider';
+type ClassNames = 'divider';
 
 const styles = (theme: Theme) =>
   createStyles({
-    root: {},
-    addIP: {
-      left: -theme.spacing(2) + 3
-    },
     divider: {
       marginTop: theme.spacing(2),
       marginBottom: theme.spacing(4)
@@ -108,11 +97,11 @@ export const generateDefaultDomainRecords = (
   ipv6?: string | null
 ) => {
   /**
-   * at this point, the IPv6 is including the prefix and we need to strip that
+   * At this point, the IPv6 is including the prefix and we need to strip that
    *
    * BUT
    *
-   * this logic only applies to Linodes' ipv6, not nodebalancers. No stripping
+   * this logic only applies to Linodes' ipv6, not NodeBalancers. No stripping
    * needed for NodeBalancers.
    */
   const cleanedIPv6 =
@@ -259,9 +248,7 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
 
     const title = mode === EDITING ? 'Edit Domain' : 'Add a new Domain';
 
-    const isCreatingMasterDomain = mode === CREATING && type === 'master';
     const isEditingMasterDomain = mode === EDITING && type === 'master';
-    const isCreatingSlaveDomain = mode === CREATING && type === 'slave';
     const isEditingSlaveDomain = mode === EDITING && type === 'slave';
 
     return (
@@ -303,9 +290,7 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
           />
         </RadioGroup>
         <TextField
-          errorText={
-            (mode === CREATING || mode === EDITING || '') && errorMap.domain
-          }
+          errorText={(mode === EDITING || '') && errorMap.domain}
           value={domain}
           disabled={mode === CLONING || disabled}
           label="Domain"
@@ -323,7 +308,7 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
             disabled={disabled}
           />
         )}
-        {(isCreatingMasterDomain || isEditingMasterDomain) && (
+        {isEditingMasterDomain && (
           <TextField
             errorText={errorMap.soa_email}
             value={soaEmail}
@@ -334,7 +319,7 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
             disabled={disabled}
           />
         )}
-        {(isCreatingSlaveDomain || isEditingSlaveDomain) && (
+        {isEditingSlaveDomain && (
           <React.Fragment>
             <MultipleIPInput
               title="Master Nameserver IP Address"
@@ -362,88 +347,6 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
             disabled={disabled}
           />
         )}
-        {isCreatingMasterDomain && (
-          <React.Fragment>
-            <Select
-              isClearable={false}
-              onChange={(value: Item<DefaultRecordsType>) =>
-                this.updateInsertDefaultRecords(value.value)
-              }
-              defaultValue={{
-                value: 'none',
-                label: 'Do not insert default records for me.'
-              }}
-              label="Insert Default Records"
-              options={[
-                {
-                  value: 'none',
-                  label: 'Do not insert default records for me.'
-                },
-                {
-                  value: 'linode',
-                  label: 'Insert default records from one of my Linodes.'
-                },
-                {
-                  value: 'nodebalancer',
-                  label: 'Insert default records from one of my NodeBalancers.'
-                }
-              ]}
-            />
-            <FormHelperText>
-              If specified, we can automatically create some domain records
-              (A/AAAA and MX) to get you started, based on one of your Linodes
-              or NodeBalancers.
-            </FormHelperText>
-          </React.Fragment>
-        )}
-        {isCreatingMasterDomain &&
-          this.state.defaultRecordsSetting === 'linode' && (
-            <React.Fragment>
-              <LinodeSelect
-                linodeError={errorMap.defaultLinode}
-                handleChange={this.updateSelectedLinode}
-                selectedLinode={
-                  this.state.selectedDefaultLinode
-                    ? this.state.selectedDefaultLinode.id
-                    : null
-                }
-              />
-              {!errorMap.defaultLinode && (
-                <FormHelperText>
-                  {this.state.selectedDefaultLinode &&
-                  !this.state.selectedDefaultLinode.ipv6
-                    ? `We'll automatically create domains for the first IPv4 address on this
-                    Linode.`
-                    : `We'll automatically create domain records for both the first
-                    IPv4 and IPv6 addresses on this Linode.`}
-                </FormHelperText>
-              )}
-            </React.Fragment>
-          )}
-        {isCreatingMasterDomain &&
-          this.state.defaultRecordsSetting === 'nodebalancer' && (
-            <React.Fragment>
-              <NodeBalancerSelect
-                nodeBalancerError={errorMap.defaultNodeBalancer}
-                handleChange={this.updateSelectedNodeBalancer}
-                selectedNodeBalancer={
-                  this.state.selectedDefaultNodeBalancer
-                    ? this.state.selectedDefaultNodeBalancer.id
-                    : null
-                }
-              />
-              {!errorMap.defaultNodeBalancer && (
-                <FormHelperText>
-                  {this.state.selectedDefaultNodeBalancer &&
-                  !this.state.selectedDefaultNodeBalancer.ipv6
-                    ? `We'll automatically create domains for the first IPv4 address on this
-                  NodeBalancer.`
-                    : `We'll automatically create domain records for both the first
-                  IPv4 and IPv6 addresses on this NodeBalancer.`}
-                </FormHelperText>
-              )}
-            </React.Fragment>
-          )}
         <ActionsPanel>
           <Button
             buttonType="primary"
@@ -502,159 +405,6 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
       this.redirect('', state);
     }
     this.closeDrawer();
-  };
-
-  create = () => {
-    const {
-      domain,
-      type,
-      soaEmail,
-      master_ips,
-      defaultRecordsSetting,
-      selectedDefaultLinode,
-      selectedDefaultNodeBalancer
-    } = this.state;
-    const { domainActions, origin } = this.props;
-
-    const tags = this.state.tags.map(tag => tag.value);
-
-    const finalMasterIPs = master_ips.filter(v => v !== '');
-
-    if (type === 'slave' && finalMasterIPs.length === 0) {
-      this.setState({
-        submitting: false,
-        errors: [
-          {
-            field: 'master_ips',
-            reason: 'You must provide at least one Master Nameserver IP Address'
-          }
-        ]
-      });
-      return;
-    }
-
-    /**
-     * In this case, the user wants default domain records created, but
-     * they haven't supplied a Linode or NodeBalancer
-     */
-    if (defaultRecordsSetting === 'linode' && !selectedDefaultLinode) {
-      return this.setState({
-        errors: [
-          {
-            reason: 'Please select a Linode.',
-            field: 'defaultLinode'
-          }
-        ]
-      });
-    }
-
-    if (
-      defaultRecordsSetting === 'nodebalancer' &&
-      !selectedDefaultNodeBalancer
-    ) {
-      return this.setState({
-        errors: [
-          {
-            reason: 'Please select a NodeBalancer.',
-            field: 'defaultNodeBalancer'
-          }
-        ]
-      });
-    }
-
-    const data =
-      type === 'master'
-        ? { domain, type, tags, soa_email: soaEmail }
-        : { domain, type, tags, master_ips: finalMasterIPs };
-
-    this.setState({ submitting: true });
-    domainActions
-      .createDomain(data)
-      .then((domainData: Domain) => {
-        if (!this.mounted) {
-          return;
-        }
-        sendCreateDomainEvent(origin);
-        /**
-         * now we check to see if the user wanted us to automatically create
-         * domain records for them. If so, create some A/AAAA and MX records
-         * with the first IPv4 and IPv6 from the Linode or NodeBalancer they
-         * selected.
-         *
-         * This only applies to master domains.
-         */
-        if (type === 'master') {
-          if (defaultRecordsSetting === 'linode') {
-            return generateDefaultDomainRecords(
-              domainData.domain,
-              domainData.id,
-              path(['ipv4', 0], selectedDefaultLinode),
-              path(['ipv6'], selectedDefaultLinode)
-            )
-              .then(() => {
-                return this.redirectToLandingOrDetail(type, domainData.id);
-              })
-              .catch((e: APIError[]) => {
-                reportException(
-                  `Default DNS Records couldn't be created from Linode: ${e[0].reason}`,
-                  {
-                    selectedLinode: this.state.selectedDefaultLinode!.id,
-                    domainID: domainData.id,
-                    ipv4: path(['ipv4', 0], selectedDefaultLinode),
-                    ipv6: path(['ipv6'], selectedDefaultLinode)
-                  }
-                );
-                return this.redirectToLandingOrDetail(type, domainData.id, {
-                  recordError:
-                    'There was an issue creating default domain records.'
-                });
-              });
-          }
-
-          if (defaultRecordsSetting === 'nodebalancer') {
-            return generateDefaultDomainRecords(
-              domainData.domain,
-              domainData.id,
-              path(['ipv4'], selectedDefaultNodeBalancer),
-              path(['ipv6'], selectedDefaultNodeBalancer)
-            )
-              .then(() => {
-                return this.redirectToLandingOrDetail(type, domainData.id);
-              })
-              .catch((e: APIError[]) => {
-                reportException(
-                  `Default DNS Records couldn't be created from NodeBalancer: ${e[0].reason}`,
-                  {
-                    selectedNodeBalancer: this.state
-                      .selectedDefaultNodeBalancer!.id,
-                    domainID: domainData.id,
-                    ipv4: path(['ipv4'], selectedDefaultNodeBalancer),
-                    ipv6: path(['ipv6'], selectedDefaultNodeBalancer)
-                  }
-                );
-                return this.redirectToLandingOrDetail(type, domainData.id, {
-                  recordError:
-                    'There was an issue creating default domain records.'
-                });
-              });
-          }
-        }
-        return this.redirectToLandingOrDetail(type, domainData.id);
-      })
-      .catch(err => {
-        if (!this.mounted) {
-          return;
-        }
-        this.setState(
-          {
-            submitting: false,
-            errors: getAPIErrorOrDefault(err)
-          },
-          () => {
-            scrollErrorIntoView();
-          }
-        );
-      });
   };
 
   clone = () => {
@@ -761,9 +511,7 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
   };
 
   submit = () => {
-    if (this.props.mode === CREATING) {
-      this.create();
-    } else if (this.props.mode === CLONING) {
+    if (this.props.mode === CLONING) {
       this.clone();
     } else if (this.props.mode === EDITING) {
       this.update();
@@ -784,18 +532,8 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
   updateEmailAddress = (e: React.ChangeEvent<HTMLInputElement>) =>
     this.setState({ soaEmail: e.target.value });
 
-  updateSelectedLinode = (linode: Linode) =>
-    this.setState({ selectedDefaultLinode: linode });
-
-  updateSelectedNodeBalancer = (nodebalancer: NodeBalancer) =>
-    this.setState({ selectedDefaultNodeBalancer: nodebalancer });
-
   updateTags = (selected: Tag[]) => {
     this.setState({ tags: selected });
-  };
-
-  updateInsertDefaultRecords = (value: DefaultRecordsType) => {
-    this.setState({ defaultRecordsSetting: value });
   };
 
   updateType = (
@@ -823,7 +561,7 @@ const mapDispatchToProps = (dispatch: Dispatch) =>
   bindActionCreators({ resetDrawer, upsertDomain }, dispatch);
 
 interface StateProps {
-  mode: typeof CLONING | typeof CREATING | typeof EDITING;
+  mode: typeof CLONING | typeof EDITING;
   open: boolean;
   domain?: string;
   domainProps?: Domain;
@@ -837,7 +575,7 @@ const mapStateToProps = (state: ApplicationState) => {
   const domainEntities = state.__resources.domains.itemsById;
   const domainProps = domainEntities[String(id)];
   return {
-    mode: state.domainDrawer?.mode ?? CREATING,
+    mode: state.domainDrawer?.mode,
     open: state.domainDrawer?.open ?? false,
     domain: path(['domainDrawer', 'domain'], state),
     domainProps,

--- a/packages/manager/src/features/Domains/DomainDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainDrawer.tsx
@@ -191,12 +191,11 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
     }
 
     if (
-      this.props.domainProps && // there are domain props for an update and ...
+      this.props.domainProps && // There are domain props for an update and ...
       (!prevProps.domainProps || // it just appeared
         prevProps.domainProps.id !== this.props.domainProps.id)
     ) {
       // or the domain for editing has changed
-
       // then put it props into state to populate fields
       const {
         axfr_ips,
@@ -451,7 +450,7 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
     const tags = this.state.tags.map(tag => tag.value);
 
     if (!id) {
-      // weird case if the id was not passed
+      // Weird case if the id was not passed
       this.closeDrawer();
       return;
     }
@@ -474,7 +473,7 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
 
     const data =
       type === 'master'
-        ? // not sending type for master. There is a bug on server and it returns an error that `master_ips` is required
+        ? // Not sending type for master. There is a bug on server and it returns an error that `master_ips` is required
           { domain, tags, soa_email: soaEmail, domainId: id }
         : {
             domain,
@@ -580,7 +579,7 @@ const mapStateToProps = (state: ApplicationState) => {
     domain: path(['domainDrawer', 'domain'], state),
     domainProps,
     id,
-    // disabled if the profile is restricted and doesn't have add_domains grant
+    // Disabled if the profile is restricted and doesn't have add_domains grant
     disabled: isRestrictedUser(state) && !hasGrant(state, 'add_domains'),
     origin: state.domainDrawer.origin
   };

--- a/packages/manager/src/features/Domains/DomainsLanding.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.tsx
@@ -478,7 +478,9 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
                       </Button>
                     }
                     entity="Domain"
-                    onAddNew={this.openCreateDomainDrawer}
+                    onAddNew={() => {
+                      this.props.history.push('/domains/create');
+                    }}
                     iconType="domain"
                     docsLink="https://www.linode.com/docs/platform/manager/dns-manager/"
                   />
@@ -531,7 +533,9 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
                         <Grid item className="pt0">
                           <AddNewLink
                             data-testid="create-domain"
-                            onClick={this.openCreateDomainDrawer}
+                            onClick={() => {
+                              this.props.history.push('/domains/create');
+                            }}
                             label="Add a Domain"
                           />
                         </Grid>

--- a/packages/manager/src/features/Domains/index.tsx
+++ b/packages/manager/src/features/Domains/index.tsx
@@ -10,6 +10,7 @@ import { compose } from 'recompose';
 
 import SuspenseLoader from 'src/components/SuspenseLoader';
 
+const DomainCreate = React.lazy(() => import('./CreateDomain'));
 const DomainsLanding = React.lazy(() => import('./DomainsLanding'));
 const DomainDetail = React.lazy(() => import('./DomainDetail'));
 
@@ -23,6 +24,7 @@ const DomainsRoutes: React.FC<CombinedProps> = props => {
   return (
     <React.Suspense fallback={<SuspenseLoader />}>
       <Switch>
+        <Route component={DomainCreate} exact path={`${path}/create`} />
         <Route
           path={`${path}/:domainId/records`}
           exact

--- a/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -4,7 +4,6 @@ import { AccountCapability } from '@linode/api-v4/lib/account';
 import {
   Menu,
   MenuButton,
-  MenuItem,
   MenuItems,
   MenuLink,
   MenuPopover
@@ -15,7 +14,6 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
-import { bindActionCreators, Dispatch } from 'redux';
 import DomainIcon from 'src/assets/addnewmenu/domain.svg';
 import KubernetesIcon from 'src/assets/addnewmenu/kubernetes.svg';
 import LinodeIcon from 'src/assets/addnewmenu/linode.svg';
@@ -28,7 +26,6 @@ import {
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
-import { openForCreating as openDomainDrawerForCreating } from 'src/store/domainDrawer';
 import { MapState } from 'src/store/types';
 import AddNewMenuItem from './AddNewMenuItem';
 
@@ -128,13 +125,7 @@ const styles = (theme: Theme) =>
     }
   });
 
-interface Props {
-  // openVolumeDrawerForCreating: typeof openVolumeDrawerForCreating;
-  openDomainDrawerForCreating: typeof openDomainDrawerForCreating;
-}
-
-type CombinedProps = Props &
-  WithStyles<CSSClasses> &
+type CombinedProps = WithStyles<CSSClasses> &
   RouteComponentProps<{}> &
   DispatchProps &
   StateProps;
@@ -187,12 +178,9 @@ class AddNewMenu extends React.Component<CombinedProps> {
                   ItemIcon={NodebalancerIcon}
                 />
               </MenuLink>
-              <MenuItem
-                onSelect={() => {
-                  this.props.openDomainDrawerForCreating(
-                    'Created from Add New Menu'
-                  );
-                }}
+              <MenuLink
+                as={Link}
+                to="/domains/create"
                 className={classes.menuItemLink}
               >
                 <AddNewMenuItem
@@ -200,7 +188,7 @@ class AddNewMenu extends React.Component<CombinedProps> {
                   body="Manage your DNS records using Linode’s high-availability name servers"
                   ItemIcon={DomainIcon}
                 />
-              </MenuItem>
+              </MenuLink>
               <MenuLink
                 as={Link}
                 to="/linodes/create?type=One-Click"
@@ -235,7 +223,6 @@ class AddNewMenu extends React.Component<CombinedProps> {
 export const styledComponent = styled(AddNewMenu);
 
 interface DispatchProps {
-  openDomainDrawerForCreating: () => void;
   openVolumeDrawerForCreating: () => void;
 }
 
@@ -249,10 +236,7 @@ const mapStateToProps: MapState<StateProps, CombinedProps> = state => {
   };
 };
 
-const mapDispatchToProps = (dispatch: Dispatch) =>
-  bindActionCreators({ openDomainDrawerForCreating }, dispatch);
-
-const connected = connect(mapStateToProps, mapDispatchToProps);
+const connected = connect(mapStateToProps);
 
 export default compose<CombinedProps, {}>(
   connected,

--- a/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu_CMR.tsx
+++ b/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu_CMR.tsx
@@ -12,7 +12,6 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
-import { bindActionCreators, Dispatch } from 'redux';
 import DomainIcon from 'src/assets/addnewmenu/domain.svg';
 import KubernetesIcon from 'src/assets/addnewmenu/kubernetes.svg';
 import LinodeIcon from 'src/assets/addnewmenu/linode.svg';
@@ -29,7 +28,6 @@ import withFeatureFlags, {
   FeatureFlagConsumerProps
 } from 'src/containers/withFeatureFlagConsumer.container';
 import { vlanContext, dbaasContext } from 'src/context';
-import { openForCreating as openDomainDrawerForCreating } from 'src/store/domainDrawer';
 import { MapState } from 'src/store/types';
 import { isFeatureEnabled } from 'src/utilities/accountCapabilities';
 import AddNewMenuItem from './AddNewMenuItem';
@@ -118,13 +116,7 @@ const styles = (theme: Theme) =>
     }
   });
 
-interface Props {
-  // openVolumeDrawerForCreating: typeof openVolumeDrawerForCreating;
-  openDomainDrawerForCreating: typeof openDomainDrawerForCreating;
-}
-
-type CombinedProps = Props &
-  WithStyles<CSSClasses> &
+type CombinedProps = WithStyles<CSSClasses> &
   RouteComponentProps<{}> &
   DispatchProps &
   StateProps &
@@ -262,7 +254,6 @@ class AddNewMenu extends React.Component<CombinedProps> {
 export const styledComponent = styled(AddNewMenu);
 
 interface DispatchProps {
-  openDomainDrawerForCreating: () => void;
   openVolumeDrawerForCreating: () => void;
 }
 
@@ -276,10 +267,7 @@ const mapStateToProps: MapState<StateProps, CombinedProps> = state => {
   };
 };
 
-const mapDispatchToProps = (dispatch: Dispatch) =>
-  bindActionCreators({ openDomainDrawerForCreating }, dispatch);
-
-const connected = connect(mapStateToProps, mapDispatchToProps);
+const connected = connect(mapStateToProps);
 
 const enhanced = compose<CombinedProps, {}>(
   connected,

--- a/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu_CMR.tsx
+++ b/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu_CMR.tsx
@@ -189,12 +189,9 @@ class AddNewMenu extends React.Component<CombinedProps> {
                           ItemIcon={NodebalancerIcon}
                         />
                       </MenuLink>
-                      <MenuItem
-                        onSelect={() => {
-                          this.props.openDomainDrawerForCreating(
-                            'Created from Add New Menu'
-                          );
-                        }}
+                      <MenuLink
+                        as={Link}
+                        to="/domains/create"
                         className={classes.menuItemLink}
                       >
                         <AddNewMenuItem
@@ -202,7 +199,7 @@ class AddNewMenu extends React.Component<CombinedProps> {
                           body="Manage your DNS records using Linode’s high-availability name servers"
                           ItemIcon={DomainIcon}
                         />
-                      </MenuItem>
+                      </MenuLink>
                       <MenuLink
                         as={Link}
                         to="/linodes/create?type=One-Click"


### PR DESCRIPTION
## Description
As mentioned in [https://github.com/linode/manager/pull/5646](https://github.com/linode/manager/pull/5646), the Domain Create flow is inconsistent with the rest of Cloud's creation flows. To fix this, Domain Create has been moved to it's own page with a corresponding route, `/domains/create`.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers
Please check the different paths that lead to the Domain Create workflow including non-CMR and CMR.