### PR TITLE
Cloud Firewalls: Clean up "Sources" input

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
@@ -342,6 +342,7 @@ const FirewallRuleForm: React.FC<FirewallRuleFormProps> = React.memo(props => {
         value={addressesValue}
         onChange={handleAddressesChange}
         onBlur={handleBlur}
+        isClearable={false}
       />
       {/* Show this field only if "IP / Netmask has been selected." */}
       {values.addresses === 'ip/netmask' && (
@@ -420,6 +421,8 @@ export const formValueToIPs = (
       return { ipv4: [allIPv4], ipv6: [] };
     case 'allIPv6':
       return { ipv4: [], ipv6: [allIPv6] };
+    case 'none':
+      return { ipv4: [], ipv6: [] };
     default:
       // The user has selected "IP / Netmask" and entered custom IPs, so we need
       // to separate those into v4 and v6 addresses.

--- a/packages/manager/src/features/Firewalls/shared.ts
+++ b/packages/manager/src/features/Firewalls/shared.ts
@@ -63,6 +63,7 @@ export const protocolOptions: Item<FirewallRuleProtocol>[] = [
 ];
 
 export const addressOptions = [
+  { label: 'None', value: 'none' },
   { label: 'All', value: 'all' },
   { label: 'All IPv4', value: 'allIPv4' },
   { label: 'All IPv6', value: 'allIPv6' },


### PR DESCRIPTION
## Description

This input section is a little confusing. Bigger changes may be coming later, but in the meantime, two small improvements: 

- Make the "Sources" input non-clearable.
- Make "None" an option.