### PR TITLE
Small fixes

### DIFF
--- a/packages/manager/src/components/PrimaryNav/MobileNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/MobileNav.tsx
@@ -233,6 +233,7 @@ export const MobileNav: React.FC<Props> = props => {
 
                 return (
                   <ListItem
+                    key={`menu-item-${link.display}`}
                     data-testid={`menu-item-${link.display}`}
                     className={classes.menuItemLinkNoGroup}
                     style={{
@@ -248,14 +249,13 @@ export const MobileNav: React.FC<Props> = props => {
 
               // Otherwise return a NavGroup (dropdown menu)
               return (
-                <>
+                <React.Fragment key={thisGroup.group}>
                   <ListItem
                     aria-controls={`menu-${thisGroup.group}`}
                     aria-haspopup="true"
                     button
                     className={classes.menuItemLink}
                     id={`button-${thisGroup.group}`}
-                    key={thisGroup.group}
                     onClick={() => handleClick(thisGroup.group)}
                   >
                     <ListItemText primary={thisGroup.group} />
@@ -278,7 +278,7 @@ export const MobileNav: React.FC<Props> = props => {
                         <ListItem
                           className={classes.nestedLink}
                           data-testid={`menu-item-${thisLink.display}`}
-                          key={thisLink.group}
+                          key={`list-item-${thisLink.group}`}
                           role="menuitem"
                         >
                           <Link
@@ -291,7 +291,7 @@ export const MobileNav: React.FC<Props> = props => {
                       ))}
                     </List>
                   </Collapse>
-                </>
+                </React.Fragment>
               );
             })}
           </List>

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -26,6 +26,7 @@ import {
   nodeBalancerFactory,
   notificationFactory,
   objectStorageBucketFactory,
+  objectStorageClusterFactory,
   profileFactory,
   supportReplyFactory,
   supportTicketFactory,
@@ -203,6 +204,10 @@ export const handlers = [
   rest.get('*/object-storage/buckets/*', (req, res, ctx) => {
     const buckets = objectStorageBucketFactory.buildList(20);
     return res(ctx.json(makeResourcePage(buckets)));
+  }),
+  rest.get('*object-storage/clusters', (req, res, ctx) => {
+    const clusters = objectStorageClusterFactory.buildList(3);
+    return res(ctx.json(makeResourcePage(clusters)));
   }),
   rest.get('*/domains', (req, res, ctx) => {
     const domains = domainFactory.buildList(25);


### PR DESCRIPTION
- Add a mock handler for OBJ clusters (the PrimaryNav_CMR test
was hitting the actual API several times against this endpoint,
with warnings logged in the test output)

- Fix a key warning in MobileNav


## Note

`yarn test primarynav` will run all the affected tests.