### PR TITLE
Remove 'Copy to Clipboard' text in OBJ drawers

### DIFF
--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.tsx
@@ -22,7 +22,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     height: 1,
     backgroundColor: '#EBEBEB'
   },
-  copy: { marginTop: 16, padding: 0 },
+  copy: { marginLeft: '1em', padding: 0 },
   submitButton: { marginTop: theme.spacing(2) }
 }));
 
@@ -81,25 +81,22 @@ const ObjectDetailsDrawer: React.FC<Props> = props => {
 
       {url ? (
         <>
-          <ExternalLink link={url} text={truncateMiddle(url, 50)} />
-          <CopyTooltip
-            className={classes.copy}
-            text={url}
-            displayText="Copy to clipboard"
-          />
+          <ExternalLink hideIcon link={url} text={truncateMiddle(url, 50)} />
+          <CopyTooltip className={classes.copy} text={url} />
         </>
       ) : null}
 
-      <Divider className={classes.divider} />
-
       {open && name ? (
-        <ACLSelect
-          name={name}
-          getACL={() => getObjectACL(clusterId, bucketName, name)}
-          updateACL={(acl: ACLType) =>
-            updateObjectACL(clusterId, bucketName, name, acl)
-          }
-        />
+        <>
+          <Divider className={classes.divider} />
+          <ACLSelect
+            name={name}
+            getACL={() => getObjectACL(clusterId, bucketName, name)}
+            updateACL={(acl: ACLType) =>
+              updateObjectACL(clusterId, bucketName, name, acl)
+            }
+          />
+        </>
       ) : null}
     </Drawer>
   );

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDetailsDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDetailsDrawer.tsx
@@ -21,6 +21,7 @@ const useStyles = makeStyles(() => ({
   },
   copy: {
     marginTop: 16,
+    marginLeft: '1em',
     padding: 0
   }
 }));
@@ -111,12 +112,12 @@ const BucketDetailsDrawer: React.FC<Props> = props => {
 
       {hostname ? (
         <>
-          <ExternalLink link={hostname} text={truncateMiddle(hostname, 50)} />
-          <CopyTooltip
-            className={classes.copy}
-            text={hostname}
-            displayText="Copy to clipboard"
+          <ExternalLink
+            hideIcon
+            link={hostname}
+            text={truncateMiddle(hostname, 50)}
           />
+          <CopyTooltip className={classes.copy} text={hostname} />
         </>
       ) : null}
     </Drawer>


### PR DESCRIPTION
## Description
As discussed in demo prep, remove the "Copy to Clipboard" text in the OBJ Bucket Details and Object Details drawers.

## Type of Change
- Non breaking change ('update', 'change')
