### PR TITLE
for release: Enable Bucket searching in production environment

### DIFF
--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -79,7 +79,7 @@ export const SearchBar: React.FC<CombinedProps> = props => {
   const { _loading } = useReduxLoad(
     ['linodes', 'nodeBalancers', 'images', 'domains', 'volumes', 'kubernetes'],
     REFRESH_INTERVAL,
-    searchActive && !_isLargeAccount // Only request things if the search bar is open/active.
+    shouldMakeRequests
   );
 
   const { loading: objectStorageLoading } = useObjectStorage(


### PR DESCRIPTION
## Description

This enables Bucket searching in the non-CMR Search Bar. Honestly I’d be fine leaving it CMR only, but currently search DOES work if you’ve already loaded Buckets (by going to /object-storage) so as-is it’s a confusing experience.

Corresponds to the changes here: https://github.com/linode/manager/pull/7094/files#diff-411faeadb41c7310302cd47315602e2925c730ecf57ce66bc0c243c3fa27e0d6R24

