### PR TITLE
M3-4656 Rename domains: phase 1

### DIFF
--- a/packages/manager/src/features/Dashboard/DomainsDashboardCard/DomainsDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/DomainsDashboardCard/DomainsDashboardCard.tsx
@@ -29,6 +29,7 @@ import withDomains, {
   DomainActionsProps
 } from 'src/containers/domains.container';
 import withEvents, { EventsProps } from 'src/containers/events.container';
+import { getDomainDisplayType } from 'src/features/Domains/domainUtils';
 import { openForEditing } from 'src/store/domainDrawer';
 import {
   isEntityEvent,
@@ -179,7 +180,9 @@ const DomainsDashboardCard: React.FC<CombinedProps> = props => {
                   </Typography>
                 )}
               </div>
-              <Typography className={classes.description}>{type}</Typography>
+              <Typography className={classes.description}>
+                {getDomainDisplayType(type)}
+              </Typography>
             </Grid>
           </Grid>
         </TableCell>

--- a/packages/manager/src/features/Domains/CreateDomain/CreateDomain.tsx
+++ b/packages/manager/src/features/Domains/CreateDomain/CreateDomain.tsx
@@ -209,10 +209,10 @@ export const CreateDomain: React.FC<CombinedProps> = props => {
   );
 
   const generalError = errorMap.none;
-  const masterIPsError = errorMap.master_ips;
+  const primaryIPsError = errorMap.master_ips;
 
-  const isCreatingMasterDomain = type === 'master';
-  const isCreatingSlaveDomain = type === 'slave';
+  const isCreatingPrimaryDomain = type === 'master';
+  const isCreatingSecondaryDomain = type === 'slave';
 
   const redirect = (id: number | '', state?: Record<string, string>) => {
     const returnPath = !!id ? `/domains/${id}` : '/domains';
@@ -234,14 +234,14 @@ export const CreateDomain: React.FC<CombinedProps> = props => {
   const create = () => {
     const _tags = tags.map(tag => tag.value);
 
-    const finalMasterIPs = master_ips.filter(v => v !== '');
+    const primaryIPs = master_ips.filter(v => v !== '');
 
-    if (type === 'slave' && finalMasterIPs.length === 0) {
+    if (type === 'slave' && primaryIPs.length === 0) {
       setSubmitting(false);
       setErrors([
         {
           field: 'master_ips',
-          reason: 'You must provide at least one Master Nameserver IP Address'
+          reason: 'You must provide at least one Primary Nameserver IP Address'
         }
       ]);
       return;
@@ -275,7 +275,7 @@ export const CreateDomain: React.FC<CombinedProps> = props => {
     const data =
       type === 'master'
         ? { domain, type, _tags, soa_email: soaEmail }
-        : { domain, type, _tags, master_ips: finalMasterIPs };
+        : { domain, type, _tags, master_ips: primaryIPs };
 
     setSubmitting(true);
     domainActions
@@ -385,7 +385,7 @@ export const CreateDomain: React.FC<CombinedProps> = props => {
     setErrors([]);
   };
 
-  const updateMasterIPAddress = (newIPs: ExtendedIP[]) => {
+  const updatePrimaryIPAddress = (newIPs: ExtendedIP[]) => {
     const master_ips =
       newIPs.length > 0 ? newIPs.map(extendedIPToString) : [''];
     if (mounted) {
@@ -446,16 +446,16 @@ export const CreateDomain: React.FC<CombinedProps> = props => {
             >
               <FormControlLabel
                 value="master"
-                label="Master"
+                label="Primary"
                 control={<Radio />}
-                data-qa-domain-radio="Master"
+                data-qa-domain-radio="Primary"
                 disabled={disabled}
               />
               <FormControlLabel
                 value="slave"
-                label="Slave"
+                label="Secondary"
                 control={<Radio />}
-                data-qa-domain-radio="Slave"
+                data-qa-domain-radio="Secondary"
                 disabled={disabled}
               />
             </RadioGroup>
@@ -468,7 +468,7 @@ export const CreateDomain: React.FC<CombinedProps> = props => {
               data-qa-domain-name
               data-testid="domain-name-input"
             />
-            {isCreatingMasterDomain && (
+            {isCreatingPrimaryDomain && (
               <TextField
                 errorText={errorMap.soa_email}
                 value={soaEmail}
@@ -479,13 +479,13 @@ export const CreateDomain: React.FC<CombinedProps> = props => {
                 disabled={disabled}
               />
             )}
-            {isCreatingSlaveDomain && (
+            {isCreatingSecondaryDomain && (
               <MultipleIPInput
-                title="Master Nameserver IP Address"
+                title="Primary Nameserver IP Address"
                 className={classes.ip}
                 ips={master_ips.map(stringToExtendedIP)}
-                onChange={updateMasterIPAddress}
-                error={masterIPsError}
+                onChange={updatePrimaryIPAddress}
+                error={primaryIPsError}
               />
             )}
             <TagsInput
@@ -494,7 +494,7 @@ export const CreateDomain: React.FC<CombinedProps> = props => {
               tagError={errorMap.tags}
               disabled={disabled}
             />
-            {isCreatingMasterDomain && (
+            {isCreatingPrimaryDomain && (
               <React.Fragment>
                 <Select
                   isClearable={false}
@@ -530,7 +530,7 @@ export const CreateDomain: React.FC<CombinedProps> = props => {
                 </FormHelperText>
               </React.Fragment>
             )}
-            {isCreatingMasterDomain && defaultRecordsSetting === 'linode' && (
+            {isCreatingPrimaryDomain && defaultRecordsSetting === 'linode' && (
               <React.Fragment>
                 <LinodeSelect
                   linodeError={errorMap.defaultLinode}
@@ -551,7 +551,7 @@ export const CreateDomain: React.FC<CombinedProps> = props => {
                 )}
               </React.Fragment>
             )}
-            {isCreatingMasterDomain &&
+            {isCreatingPrimaryDomain &&
               defaultRecordsSetting === 'nodebalancer' && (
                 <React.Fragment>
                   <NodeBalancerSelect

--- a/packages/manager/src/features/Domains/DomainActionMenu.test.tsx
+++ b/packages/manager/src/features/Domains/DomainActionMenu.test.tsx
@@ -25,12 +25,12 @@ describe('Domain action menu', () => {
     includesActions(['Edit', 'Clone', 'Delete'], queryByText);
   });
 
-  it('master Domains should include Edit DNS records action', () => {
+  it('primary Domains should include Edit DNS records action', () => {
     const { queryByText } = renderWithTheme(<DomainActionMenu {...props} />);
     includesActions(['Edit DNS Records'], queryByText);
   });
 
-  it('slave Domains should not include Edit DNS records action', () => {
+  it('secondary Domains should not include Edit DNS records action', () => {
     const { queryByText } = renderWithTheme(
       <DomainActionMenu {...props} type={'slave'} />
     );

--- a/packages/manager/src/features/Domains/DomainDetail/index.tsx
+++ b/packages/manager/src/features/Domains/DomainDetail/index.tsx
@@ -27,12 +27,12 @@ export const DomainDetailRouting: React.FC<RouteComponentProps<{
     // If not, we don't know if the Domain exists yet so we have to stall
     return <CircleProgress />;
   }
-  // Master Domains have a Detail page.
+  // Primary Domains have a Detail page.
   if (foundDomain.type === 'master') {
     return <DomainDetail {...props} />;
   }
 
-  // Slave Domains do not have a Detail page, so render the Landing
+  // Secondary Domains do not have a Detail page, so render the Landing
   // page with an open drawer.
   return (
     <DomainsLanding

--- a/packages/manager/src/features/Domains/DomainDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainDrawer.tsx
@@ -243,12 +243,12 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
     );
 
     const generalError = errorMap.none;
-    const masterIPsError = errorMap.master_ips;
+    const primaryIPsError = errorMap.master_ips;
 
     const title = mode === EDITING ? 'Edit Domain' : 'Add a new Domain';
 
-    const isEditingMasterDomain = mode === EDITING && type === 'master';
-    const isEditingSlaveDomain = mode === EDITING && type === 'slave';
+    const isEditingPrimaryDomain = mode === EDITING && type === 'master';
+    const isEditingSecondaryDomain = mode === EDITING && type === 'slave';
 
     return (
       <Drawer title={title} open={open} onClose={this.closeDrawer}>
@@ -275,16 +275,16 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
         >
           <FormControlLabel
             value="master"
-            label="Master"
+            label="Primary"
             control={<Radio />}
-            data-qa-domain-radio="Master"
+            data-qa-domain-radio="Primary"
             disabled={mode === EDITING || mode === CLONING || disabled}
           />
           <FormControlLabel
             value="slave"
-            label="Slave"
+            label="Secondary"
             control={<Radio />}
-            data-qa-domain-radio="Slave"
+            data-qa-domain-radio="Secondary"
             disabled={mode === EDITING || mode === CLONING || disabled}
           />
         </RadioGroup>
@@ -307,7 +307,7 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
             disabled={disabled}
           />
         )}
-        {isEditingMasterDomain && (
+        {isEditingPrimaryDomain && (
           <TextField
             errorText={errorMap.soa_email}
             value={soaEmail}
@@ -318,15 +318,15 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
             disabled={disabled}
           />
         )}
-        {isEditingSlaveDomain && (
+        {isEditingSecondaryDomain && (
           <React.Fragment>
             <MultipleIPInput
-              title="Master Nameserver IP Address"
+              title="Primary Nameserver IP Address"
               ips={this.state.master_ips.map(stringToExtendedIP)}
-              onChange={this.updateMasterIPAddress}
-              error={masterIPsError}
+              onChange={this.updatePrimaryIPAddress}
+              error={primaryIPsError}
             />
-            {isEditingSlaveDomain && (
+            {isEditingSecondaryDomain && (
               // Only when editing
               <MultipleIPInput
                 title="Domain Transfer IPs"
@@ -455,16 +455,17 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
       return;
     }
 
-    const finalMasterIPs = master_ips.filter(v => v !== '');
+    const primaryIPs = master_ips.filter(v => v !== '');
     const finalTransferIPs = axfr_ips.filter(v => v !== '');
 
-    if (type === 'slave' && finalMasterIPs.length === 0) {
+    if (type === 'slave' && primaryIPs.length === 0) {
       this.setState({
         submitting: false,
         errors: [
           {
             field: 'master_ips',
-            reason: 'You must provide at least one Master Nameserver IP Address'
+            reason:
+              'You must provide at least one Primary Nameserver IP Address'
           }
         ]
       });
@@ -479,7 +480,7 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
             domain,
             type,
             tags,
-            master_ips: finalMasterIPs,
+            master_ips: primaryIPs,
             domainId: id,
             axfr_ips: finalTransferIPs
           };
@@ -540,7 +541,7 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
     value: 'master' | 'slave'
   ) => this.setState({ type: value });
 
-  updateMasterIPAddress = (newIPs: ExtendedIP[]) => {
+  updatePrimaryIPAddress = (newIPs: ExtendedIP[]) => {
     const master_ips =
       newIPs.length > 0 ? newIPs.map(extendedIPToString) : [''];
     if (this.mounted) {

--- a/packages/manager/src/features/Domains/DomainRecords.tsx
+++ b/packages/manager/src/features/Domains/DomainRecords.tsx
@@ -189,10 +189,10 @@ class DomainRecords extends React.Component<CombinedProps, State> {
       fields
     }));
 
-  openForEditMasterDomain = (f: Partial<Domain>) =>
+  openForEditPrimaryDomain = (f: Partial<Domain>) =>
     this.openForEditing('master', f);
 
-  openForEditSlaveDomain = (f: Partial<Domain>) =>
+  openForEditSecondaryDomain = (f: Partial<Domain>) =>
     this.openForEditing('slave', f);
 
   openForCreateNSRecord = () => this.openForCreation('NS');
@@ -281,8 +281,8 @@ class DomainRecords extends React.Component<CombinedProps, State> {
 
   handleOpenSOADrawer = (d: Domain) => {
     return d.type === 'master'
-      ? this.openForEditMasterDomain(d)
-      : this.openForEditSlaveDomain(d);
+      ? this.openForEditPrimaryDomain(d)
+      : this.openForEditSecondaryDomain(d);
   };
 
   generateTypes = (): IType[] => [

--- a/packages/manager/src/features/Domains/DomainTableRow.tsx
+++ b/packages/manager/src/features/Domains/DomainTableRow.tsx
@@ -8,12 +8,13 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
+import DateTimeDisplay from 'src/components/DateTimeDisplay';
 import EntityIcon from 'src/components/EntityIcon';
 import Grid from 'src/components/Grid';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import ActionMenu, { Handlers } from './DomainActionMenu';
-import DateTimeDisplay from 'src/components/DateTimeDisplay';
+import { getDomainDisplayType } from './domainUtils';
 
 type ClassNames =
   | 'domain'
@@ -112,7 +113,7 @@ class DomainTableRow extends React.Component<CombinedProps> {
           </Grid>
         </TableCell>
         <TableCell parentColumn="Type" data-qa-domain-type>
-          {type}
+          {getDomainDisplayType(type)}
         </TableCell>
         <TableCell parentColumn="Status" data-qa-domain-status>
           {humanizeDomainStatus(status)}

--- a/packages/manager/src/features/Domains/DomainTableRow_CMR.tsx
+++ b/packages/manager/src/features/Domains/DomainTableRow_CMR.tsx
@@ -1,13 +1,14 @@
 import { Domain, DomainStatus } from '@linode/api-v4/lib/domains';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
+import Hidden from 'src/components/core/Hidden';
 import { makeStyles, Theme } from 'src/components/core/styles';
+import DateTimeDisplay from 'src/components/DateTimeDisplay';
 import StatusIcon from 'src/components/StatusIcon';
 import TableCell from 'src/components/TableCell/TableCell_CMR';
 import TableRow from 'src/components/TableRow/TableRow_CMR';
 import ActionMenu, { Handlers } from './DomainActionMenu_CMR';
-import DateTimeDisplay from 'src/components/DateTimeDisplay';
-import Hidden from 'src/components/core/Hidden';
+import { getDomainDisplayType } from './domainUtils';
 
 const useStyles = makeStyles((theme: Theme) => ({
   link: {
@@ -99,7 +100,7 @@ const DomainTableRow: React.FC<CombinedProps> = props => {
         {humanizeDomainStatus(status)}
       </TableCell>
       <Hidden xsDown>
-        <TableCell data-qa-domain-type>{type}</TableCell>
+        <TableCell data-qa-domain-type>{getDomainDisplayType(type)}</TableCell>
         <TableCell data-qa-domain-lastmodified>
           <DateTimeDisplay value={updated} />
         </TableCell>

--- a/packages/manager/src/features/Domains/DomainsLanding.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.tsx
@@ -123,7 +123,7 @@ interface State {
 interface Props {
   /** purely so we can force a preference to get the unit tests to pass */
   shouldGroupDomains?: boolean;
-  // Since Slave Domains do not have a Detail page, we allow the consumer to
+  // Since secondary Domains do not have a Detail page, we allow the consumer to
   // render this component with the "Edit Domain" drawer already opened.
   domainForEditing?: {
     domainId: number;

--- a/packages/manager/src/features/Domains/domainUtils.ts
+++ b/packages/manager/src/features/Domains/domainUtils.ts
@@ -1,4 +1,4 @@
-import { DomainRecord } from '@linode/api-v4/lib/domains';
+import { DomainRecord, DomainType } from '@linode/api-v4/lib/domains';
 
 export const isValidDomainRecord = (
   hostname: string,
@@ -36,3 +36,12 @@ export const isEditableNameServer = (nameServerId: number) => {
 
   return nameServerDummyId !== nameServerId ? true : false;
 };
+
+/**
+ * This is for Phase 1 of the conversion process, which
+ * assumes the API is still returning either master or slave
+ * for the Domain type. It can be adjusted to handle all
+ * possible values once the API is confirmed to support them.
+ */
+export const getDomainDisplayType = (domainType: DomainType) =>
+  domainType === 'master' ? 'primary' : 'secondary';

--- a/packages/manager/src/features/Volumes/WithEvents.tsx
+++ b/packages/manager/src/features/Volumes/WithEvents.tsx
@@ -116,7 +116,7 @@ export default () => (WrappedComponent: React.ComponentType<any>) => {
 
                 /*
                  * Now add our new volume, include the newly attached
-                 * Linode data to the master list
+                 * Linode data to the list
                  */
                 clonedVolumes[targetIndex] = {
                   ...volume,
@@ -125,20 +125,20 @@ export default () => (WrappedComponent: React.ComponentType<any>) => {
                   linodeStatus: linode.status
                 };
 
-                // finally update the master list of volumes in state
+                // finally update the list of volumes in state
                 this.setState({
                   volumes: clonedVolumes
                 });
               });
             }
 
-            // now add our new volume with the event data to the master list of volumes
+            // now add our new volume with the event data to the list of volumes
             clonedVolumes[targetIndex] = {
               ...volume,
               ...maybeAddEvent(event, volume)
             };
 
-            // finally update the master list of volumes
+            // finally update the list of volumes
             this.setState({
               volumes: clonedVolumes
             });

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -107,7 +107,7 @@ class FromAppsContent extends React.PureComponent<CombinedProps, State> {
     const { imagesData } = this.props;
     /**
      * based on the list of images we get back from the API, compare those
-     * to our list of master images supported by Linode and filter out the ones
+     * to our list of public images supported by Linode and filter out the ones
      * that aren't compatible with our selected StackScript
      */
     const compatibleImages = Object.keys(imagesData).reduce((acc, eachKey) => {

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -94,7 +94,7 @@ export class FromStackScriptContent extends React.PureComponent<CombinedProps> {
     const { imagesData } = this.props;
     /**
      * based on the list of images we get back from the API, compare those
-     * to our list of master images supported by Linode and filter out the ones
+     * to our list of public images supported by Linode and filter out the ones
      * that aren't compatible with our selected StackScript
      */
     const compatibleImages = Object.keys(imagesData).reduce((acc, eachKey) => {


### PR DESCRIPTION
Replace all customer-facing usage of "master/slave" Domains with
primary/secondary. Also rename methods, update comments where appropriate.

API response types and our handling of them remain unchanged. A follow-on
will update these for forward-backward compatibility once the API has decided
on an approach.

