### PR TITLE
Hotfix/create domain

### DIFF
--- a/packages/manager/src/features/Domains/DomainsLanding.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.tsx
@@ -59,6 +59,8 @@ import DomainRow from './DomainTableRow';
 import DomainRow_CMR from './DomainTableRow_CMR';
 import DomainZoneImportDrawer from './DomainZoneImportDrawer';
 
+const DOMAIN_CREATE_ROUTE = '/domains/create';
+
 type ClassNames =
   | 'root'
   | 'titleWrapper'
@@ -382,7 +384,7 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
       return (
         <React.Fragment>
           <RenderEmpty
-            onCreateDomain={this.openCreateDomainDrawer}
+            onCreateDomain={() => this.props.history.push(DOMAIN_CREATE_ROUTE)}
             onImportZone={this.openImportZoneDrawer}
           />
           <DomainZoneImportDrawer
@@ -464,7 +466,7 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
                     }
                     entity="Domain"
                     onAddNew={() => {
-                      this.props.history.push('/domains/create');
+                      this.props.history.push(DOMAIN_CREATE_ROUTE);
                     }}
                     iconType="domain"
                     docsLink="https://www.linode.com/docs/platform/manager/dns-manager/"
@@ -519,7 +521,7 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
                           <AddNewLink
                             data-testid="create-domain"
                             onClick={() => {
-                              this.props.history.push('/domains/create');
+                              this.props.history.push(DOMAIN_CREATE_ROUTE);
                             }}
                             label="Add a Domain"
                           />

--- a/packages/manager/src/features/Domains/DomainsLanding.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.tsx
@@ -327,6 +327,10 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
     this.props.openForCreating('Created from Domain Landing');
   };
 
+  navigateToCreate = () => {
+    this.props.history.push(DOMAIN_CREATE_ROUTE);
+  };
+
   render() {
     const { classes } = this.props;
     const {
@@ -384,7 +388,7 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
       return (
         <React.Fragment>
           <RenderEmpty
-            onCreateDomain={() => this.props.history.push(DOMAIN_CREATE_ROUTE)}
+            onCreateDomain={this.navigateToCreate}
             onImportZone={this.openImportZoneDrawer}
           />
           <DomainZoneImportDrawer
@@ -465,9 +469,7 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
                       </Button>
                     }
                     entity="Domain"
-                    onAddNew={() => {
-                      this.props.history.push(DOMAIN_CREATE_ROUTE);
-                    }}
+                    onAddNew={this.navigateToCreate}
                     iconType="domain"
                     docsLink="https://www.linode.com/docs/platform/manager/dns-manager/"
                   />
@@ -520,9 +522,7 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
                         <Grid item className="pt0">
                           <AddNewLink
                             data-testid="create-domain"
-                            onClick={() => {
-                              this.props.history.push(DOMAIN_CREATE_ROUTE);
-                            }}
+                            onClick={this.navigateToCreate}
                             label="Add a Domain"
                           />
                         </Grid>

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -211,7 +211,7 @@ export const handlers = [
     return res(ctx.json(makeResourcePage(clusters)));
   }),
   rest.get('*/domains', (req, res, ctx) => {
-    const domains = domainFactory.buildList(25);
+    const domains = domainFactory.buildList(0);
     return res(ctx.json(makeResourcePage(domains)));
   }),
   rest.post('*/domains/*/records', (req, res, ctx) => {


### PR DESCRIPTION
Use the mocks to check; with 0 Domains, pressing "Add a Domain" on the placeholder page should take you to /create/domains, not open the create drawer.