### PR TITLE
M3-3783: Replace react-async-script-loader package w/ react-async-script

### DIFF
--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -62,7 +62,7 @@
     "qs": "^6.6.0",
     "ramda": "~0.25.0",
     "react": "~16.12.0",
-    "react-async-script-loader": "^0.3.0",
+    "react-async-script": "^1.2.0",
     "react-csv": "^1.1.2",
     "react-dom": "~16.12.0",
     "react-dropzone": "~10.2.1",

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
@@ -55,6 +55,8 @@ export const getMinimumPayment = (balance: number | false) => {
   return Math.min(5, balance).toFixed(2);
 };
 
+const AsyncPaypal = makeAsyncScriptLoader(paypalScriptSrc())(PayPal);
+
 export const PaymentDrawer: React.FC<CombinedProps> = props => {
   const { accountLoading, balance, expiry, lastFour, open, onClose } = props;
   const classes = useStyles();
@@ -70,8 +72,6 @@ export const PaymentDrawer: React.FC<CombinedProps> = props => {
   const [isPaypalScriptLoaded, setIsPaypalScriptLoaded] = React.useState<
     boolean
   >(false);
-
-  const AsyncPaypal = makeAsyncScriptLoader(paypalScriptSrc())(PayPal);
 
   React.useEffect(() => {
     setUSD(getMinimumPayment(balance));

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
@@ -67,6 +67,9 @@ export const PaymentDrawer: React.FC<CombinedProps> = props => {
 
   const [creditCardKey, setCreditCardKey] = React.useState<string>(v4());
   const [payPalKey, setPayPalKey] = React.useState<string>(v4());
+  const [isPaypalScriptLoaded, setIsPaypalScriptLoaded] = React.useState<
+    boolean
+  >(false);
 
   React.useEffect(() => {
     setUSD(getMinimumPayment(balance));
@@ -111,6 +114,10 @@ export const PaymentDrawer: React.FC<CombinedProps> = props => {
     );
   }
 
+  const onScriptLoad = () => {
+    setIsPaypalScriptLoaded(true);
+  };
+
   return (
     <Drawer title="Make a Payment" open={open} onClose={onClose}>
       <Grid container>
@@ -150,7 +157,13 @@ export const PaymentDrawer: React.FC<CombinedProps> = props => {
             setSuccess={setSuccess}
           />
 
-          <PayPal key={payPalKey} usd={usd} setSuccess={setSuccess} />
+          <PayPal
+            key={payPalKey}
+            usd={usd}
+            setSuccess={setSuccess}
+            asyncScriptOnLoad={onScriptLoad}
+            isScriptLoaded={isPaypalScriptLoaded}
+          />
         </Grid>
       </Grid>
     </Drawer>

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
@@ -1,5 +1,6 @@
 import { APIWarning } from '@linode/api-v4/lib/types';
 import * as React from 'react';
+import makeAsyncScriptLoader from 'react-async-script';
 import { compose } from 'recompose';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
@@ -14,9 +15,8 @@ import AccountContainer, {
   DispatchProps as AccountDispatchProps
 } from 'src/containers/account.container';
 import { v4 } from 'uuid';
-
 import CreditCard from './CreditCardPayment';
-import PayPal from './Paypal';
+import PayPal, { paypalScriptSrc } from './Paypal';
 import { SetSuccess } from './types';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -70,6 +70,8 @@ export const PaymentDrawer: React.FC<CombinedProps> = props => {
   const [isPaypalScriptLoaded, setIsPaypalScriptLoaded] = React.useState<
     boolean
   >(false);
+
+  const AsyncPaypal = makeAsyncScriptLoader(paypalScriptSrc())(PayPal);
 
   React.useEffect(() => {
     setUSD(getMinimumPayment(balance));
@@ -157,7 +159,7 @@ export const PaymentDrawer: React.FC<CombinedProps> = props => {
             setSuccess={setSuccess}
           />
 
-          <PayPal
+          <AsyncPaypal
             key={payPalKey}
             usd={usd}
             setSuccess={setSuccess}

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/Paypal.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/Paypal.tsx
@@ -119,9 +119,10 @@ export const PayPalDisplay: React.FC<CombinedProps> = props => {
   const [shouldRenderButton, setShouldRenderButton] = React.useState<boolean>(
     false
   );
-  const [paypalScriptLoadError, setPaypalScriptLoadError] = React.useState<
-    boolean | undefined
-  >();
+  const [
+    errorLoadingPaypalScript,
+    setErrorLoadingPaypalScript
+  ] = React.useState<boolean | undefined>();
 
   React.useEffect(() => {
     const isPayPalInitialized = window.hasOwnProperty('paypal');
@@ -137,7 +138,7 @@ export const PayPalDisplay: React.FC<CombinedProps> = props => {
         React,
         ReactDOM
       });
-      setPaypalScriptLoadError(false);
+      setErrorLoadingPaypalScript(false);
       setShouldRenderButton(true);
     }
   }, [isScriptLoaded, shouldRenderButton]);
@@ -147,7 +148,7 @@ export const PayPalDisplay: React.FC<CombinedProps> = props => {
 
     if ('paypal' in window === false) {
       timeout = setTimeout(() => {
-        setPaypalScriptLoadError(true);
+        setErrorLoadingPaypalScript(true);
       }, 2000);
     }
 
@@ -257,7 +258,7 @@ export const PayPalDisplay: React.FC<CombinedProps> = props => {
 
   const enabled = shouldEnablePaypalButton(+usd);
 
-  if (typeof paypalScriptLoadError === 'undefined') {
+  if (typeof errorLoadingPaypalScript === 'undefined') {
     return (
       <Grid container direction="column" className={classes.root}>
         <CircleProgress mini />
@@ -265,7 +266,7 @@ export const PayPalDisplay: React.FC<CombinedProps> = props => {
     );
   }
 
-  if (paypalScriptLoadError) {
+  if (errorLoadingPaypalScript) {
     return (
       <Grid container direction="column" className={classes.root}>
         <Notice error text="There was an error connecting with PayPal." />

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/Paypal.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/Paypal.tsx
@@ -24,10 +24,8 @@ import {
   executePaypalPayment,
   stagePaypalPayment
 } from '@linode/api-v4/lib/account';
-import makeAsyncScriptLoader from 'react-async-script';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { compose } from 'recompose';
 import { Theme, makeStyles } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
@@ -66,14 +64,15 @@ const useStyles = makeStyles((theme: Theme) => ({
   }
 }));
 
+interface PaypalScript {
+  isScriptLoaded?: boolean;
+}
 export interface Props {
   usd: string;
   setSuccess: SetSuccess;
-  asyncScriptOnLoad?: () => void;
-  isScriptLoaded?: boolean;
 }
 
-type CombinedProps = Props;
+type CombinedProps = Props & PaypalScript;
 
 type PaypalButtonType = React.ComponentType<Paypal.PayButtonProps> | undefined;
 
@@ -89,7 +88,7 @@ const client = {
 
 const paypalSrcQueryParams = `&disable-funding=card,credit&currency=USD&commit=false&intent=capture`;
 
-const paypalScriptSrc = () => {
+export const paypalScriptSrc = () => {
   return `https://www.paypal.com/sdk/js?client-id=${client[PAYPAL_CLIENT_ENV]}${paypalSrcQueryParams}`;
 };
 
@@ -318,7 +317,4 @@ export const shouldEnablePaypalButton = (value: number | undefined) => {
   return true;
 };
 
-export default compose<CombinedProps, Props>(
-  React.memo,
-  makeAsyncScriptLoader(paypalScriptSrc())
-)(PayPalDisplay);
+export default React.memo(PayPalDisplay);

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/Paypal.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/Paypal.tsx
@@ -24,7 +24,7 @@ import {
   executePaypalPayment,
   stagePaypalPayment
 } from '@linode/api-v4/lib/account';
-import scriptLoader from 'react-async-script-loader';
+import makeAsyncScriptLoader from 'react-async-script';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { compose } from 'recompose';
@@ -66,18 +66,14 @@ const useStyles = makeStyles((theme: Theme) => ({
   }
 }));
 
-interface PaypalScript {
-  isScriptLoadSucceed?: boolean;
-  isScriptLoaded?: boolean;
-  onScriptLoaded?: () => void;
-}
-
 export interface Props {
   usd: string;
   setSuccess: SetSuccess;
+  asyncScriptOnLoad?: () => void;
+  isScriptLoaded?: boolean;
 }
 
-type CombinedProps = Props & PaypalScript;
+type CombinedProps = Props;
 
 type PaypalButtonType = React.ComponentType<Paypal.PayButtonProps> | undefined;
 
@@ -324,5 +320,5 @@ export const shouldEnablePaypalButton = (value: number | undefined) => {
 
 export default compose<CombinedProps, Props>(
   React.memo,
-  scriptLoader(paypalScriptSrc())
+  makeAsyncScriptLoader(paypalScriptSrc())
 )(PayPalDisplay);

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/Paypal.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/Paypal.tsx
@@ -144,13 +144,11 @@ export const PayPalDisplay: React.FC<CombinedProps> = props => {
   }, [isScriptLoaded, shouldRenderButton]);
 
   React.useEffect(() => {
-    let timeout: NodeJS.Timeout;
-
-    if ('paypal' in window === false) {
-      timeout = setTimeout(() => {
+    const timeout: NodeJS.Timeout = setTimeout(() => {
+      if ('paypal' in window === false) {
         setErrorLoadingPaypalScript(true);
-      }, 2000);
-    }
+      }
+    }, 2000);
 
     return () => clearTimeout(timeout);
   }, []);

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/react-async-script-loader.d.ts
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/react-async-script-loader.d.ts
@@ -1,1 +1,0 @@
-declare module 'react-async-script-loader';

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/react-async-script.d.ts
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/react-async-script.d.ts
@@ -1,0 +1,1 @@
+declare module 'react-async-script';

--- a/yarn.lock
+++ b/yarn.lock
@@ -10143,11 +10143,6 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^1.0.3:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
-  integrity sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs=
-
 hoist-non-react-statics@^2.3.1:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
@@ -15101,7 +15096,7 @@ prop-types-exact@^1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.0.0, prop-types@^15.5.0, prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -15384,12 +15379,13 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-async-script-loader@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/react-async-script-loader/-/react-async-script-loader-0.3.0.tgz#c742b3ca25e08ba61ab7eb64371f814027692b86"
-  integrity sha1-x0KzyiXgi6Yat+tkNx+BQCdpK4Y=
+react-async-script@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/react-async-script/-/react-async-script-1.2.0.tgz#ab9412a26f0b83f5e2e00de1d2befc9400834b21"
+  integrity sha512-bCpkbm9JiAuMGhkqoAiC0lLkb40DJ0HOEJIku+9JDjxX3Rcs+ztEOG13wbrOskt3n2DTrjshhaQ/iay+SnGg5Q==
   dependencies:
-    hoist-non-react-statics "^1.0.3"
+    hoist-non-react-statics "^3.3.0"
+    prop-types "^15.5.0"
 
 react-clientside-effect@^1.2.2:
   version "1.2.2"


### PR DESCRIPTION
## Description
Replace [react-async-script-loader](https://www.npmjs.com/package/react-async-script-loader), which hasn't been updated in several years, with [react-async-script](https://www.npmjs.com/package/react-async-script).

The only place this was being used was the Payment drawer. I don't believe that `react-async-script` passes props as `react-async-script-loader` did, so this will require some adjusting to keep working as intended.

## Type of Change
- Non breaking change ('update', 'change')

## To-Do
- [x] Further tweaking and testing with `react-async-script` to ensure this is actually working
