### PR TITLE
Hotfix: separate linode actions from useLinodes hook

### DIFF
--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -15,7 +15,7 @@ import Grid from 'src/components/Grid';
 import { ExtendedType } from 'src/store/linodeType/linodeType.reducer';
 import { useDialog } from 'src/hooks/useDialog';
 import useFlags from 'src/hooks/useFlags';
-import useLinodes from 'src/hooks/useLinodes';
+import useLinodeActions from 'src/hooks/useLinodeActions';
 import { ApplicationState } from 'src/store';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { PoolNodeWithPrice } from '../../types';
@@ -95,7 +95,7 @@ export const NodePoolsDisplay: React.FC<Props> = props => {
   const classes = useStyles();
   const flags = useFlags();
 
-  const { deleteLinode } = useLinodes();
+  const { deleteLinode } = useLinodeActions();
 
   const deletePoolDialog = useDialog<number>(deletePool);
   const recycleAllNodesDialog = useDialog<number>(recycleAllNodes);

--- a/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
+++ b/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
@@ -40,7 +40,7 @@ import { Action as BootAction } from 'src/features/linodes/PowerActionsDialogOrD
 import { OpenDialog } from 'src/features/linodes/types';
 import { lishLaunch } from 'src/features/Lish/lishUtils';
 import useImages from 'src/hooks/useImages';
-import useLinodes from 'src/hooks/useLinodes';
+import useLinodeActions from 'src/hooks/useLinodeActions';
 import useReduxLoad from 'src/hooks/useReduxLoad';
 import { useTypes } from 'src/hooks/useTypes';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
@@ -764,7 +764,7 @@ export const Footer: React.FC<FooterProps> = React.memo(props => {
 
   const classes = useFooterStyles();
 
-  const { updateLinode } = useLinodes();
+  const { updateLinode } = useLinodeActions();
   const { enqueueSnackbar } = useSnackbar();
 
   const addTag = React.useCallback(

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader_CMR.tsx
@@ -10,7 +10,7 @@ import PowerDialogOrDrawer, {
 } from 'src/features/linodes/PowerActionsDialogOrDrawer';
 import { DialogType } from 'src/features/linodes/types';
 import { notificationContext as _notificationContext } from 'src/features/NotificationCenter/NotificationContext';
-import useLinodes from 'src/hooks/useLinodes';
+import useLinodeActions from 'src/hooks/useLinodeActions';
 import useProfile from 'src/hooks/useProfile';
 import useReduxLoad from 'src/hooks/useReduxLoad';
 import useVolumes from 'src/hooks/useVolumes';
@@ -112,7 +112,7 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
     tags: []
   });
 
-  const { updateLinode, deleteLinode } = useLinodes();
+  const { updateLinode, deleteLinode } = useLinodeActions();
   const history = useHistory();
 
   const openPowerActionDialog = (

--- a/packages/manager/src/features/linodes/LinodesLanding/CardView.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/CardView.tsx
@@ -14,7 +14,7 @@ import { Action } from 'src/features/linodes/PowerActionsDialogOrDrawer';
 import { DialogType } from 'src/features/linodes/types';
 import { notificationContext as _notificationContext } from 'src/features/NotificationCenter/NotificationContext';
 import useFlags from 'src/hooks/useFlags';
-import useLinodes from 'src/hooks/useLinodes';
+import useLinodeActions from 'src/hooks/useLinodeActions';
 import useProfile from 'src/hooks/useProfile';
 import useReduxLoad from 'src/hooks/useReduxLoad';
 import useVolumes from 'src/hooks/useVolumes';
@@ -61,7 +61,7 @@ const CardView: React.FC<CombinedProps> = props => {
   const flags = useFlags();
   const notificationContext = React.useContext(_notificationContext);
 
-  const { updateLinode } = useLinodes();
+  const { updateLinode } = useLinodeActions();
   const { profile } = useProfile();
   const { _loading } = useReduxLoad(['volumes']);
   const { volumes } = useVolumes();

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow_CMR.tsx
@@ -25,7 +25,7 @@ import {
   transitionText
 } from 'src/features/linodes/transitions';
 import { DialogType } from 'src/features/linodes/types';
-import useLinodes from 'src/hooks/useLinodes';
+import useLinodeActions from 'src/hooks/useLinodeActions';
 import { capitalize, capitalizeAllWords } from 'src/utilities/capitalize';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { linodeMaintenanceWindowString } from '../../utilities';
@@ -119,7 +119,7 @@ export const LinodeRow: React.FC<CombinedProps> = props => {
     isVLAN
   } = props;
 
-  const { updateLinode } = useLinodes();
+  const { updateLinode } = useLinodeActions();
   const { enqueueSnackbar } = useSnackbar();
 
   const loading = linodeInTransition(status, recentEvent);

--- a/packages/manager/src/features/linodes/LinodesLanding/ListView.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/ListView.tsx
@@ -8,7 +8,7 @@ import { Action } from 'src/features/linodes/PowerActionsDialogOrDrawer';
 import { DialogType } from 'src/features/linodes/types';
 import { notificationContext as _notificationContext } from 'src/features/NotificationCenter/NotificationContext';
 import useFlags from 'src/hooks/useFlags';
-import useLinodes from 'src/hooks/useLinodes';
+import useLinodeActions from 'src/hooks/useLinodeActions';
 import { ShallowExtendedLinode } from 'src/store/linodes/types';
 import formatDate from 'src/utilities/formatDate';
 import LinodeRow from './LinodeRow/LinodeRow';
@@ -39,7 +39,7 @@ export const ListView: React.FC<CombinedProps> = props => {
     entityID: 0
   });
 
-  const { updateLinode } = useLinodes();
+  const { updateLinode } = useLinodeActions();
   const flags = useFlags();
 
   const notificationContext = React.useContext(_notificationContext);

--- a/packages/manager/src/hooks/useEntities.ts
+++ b/packages/manager/src/hooks/useEntities.ts
@@ -2,6 +2,7 @@ import { APIError } from '@linode/api-v4/lib/types';
 import useDomains from './useDomains';
 import useImages from './useImages';
 import useKubernetesClusters from './useKubernetesClusters';
+import useLinodeActions from './useLinodeActions';
 import useLinodes from './useLinodes';
 import useNodeBalancers from './useNodeBalancers';
 import useVolumes from './useVolumes';
@@ -24,7 +25,8 @@ export interface Entity<T> {
  * if (linodes.lastUpdated === 0) { linodes.request(); }
  */
 export const useEntities = () => {
-  const { linodes: _linodes, requestLinodes } = useLinodes();
+  const { linodes: _linodes } = useLinodes();
+  const { requestLinodes } = useLinodeActions();
   const { domains: _domains, requestDomains } = useDomains();
   const { images: _images, requestImages } = useImages();
   const { volumes: _volumes, requestVolumes } = useVolumes();

--- a/packages/manager/src/hooks/useLinodeActions.ts
+++ b/packages/manager/src/hooks/useLinodeActions.ts
@@ -1,0 +1,41 @@
+import { Linode } from '@linode/api-v4/lib/linodes/types';
+import { useDispatch } from 'react-redux';
+import {
+  deleteLinode as _deleteLinode,
+  getLinode as _getLinode,
+  requestLinodes as _requestLinodes,
+  updateLinode as _updateLinode
+} from 'src/store/linodes/linode.requests';
+import { UpdateLinodeParams } from 'src/store/linodes/linodes.actions';
+import { Dispatch } from './types';
+
+export interface LinodesProps {
+  requestLinodes: () => Promise<Linode[]>;
+  getLinode: (linodeId: number) => Promise<Linode>;
+  deleteLinode: (linodeId: number) => Promise<{}>;
+  updateLinode: (params: UpdateLinodeParams) => Promise<Linode>;
+}
+
+export const useLinodes = (): LinodesProps => {
+  const dispatch: Dispatch = useDispatch();
+
+  const requestLinodes = () =>
+    dispatch(_requestLinodes({})).then(response => response.data);
+
+  const getLinode = (linodeId: number) => dispatch(_getLinode({ linodeId }));
+
+  const deleteLinode = (linodeId: number) =>
+    dispatch(_deleteLinode({ linodeId }));
+
+  const updateLinode = (params: UpdateLinodeParams) =>
+    dispatch(_updateLinode(params));
+
+  return {
+    requestLinodes,
+    getLinode,
+    deleteLinode,
+    updateLinode
+  };
+};
+
+export default useLinodes;

--- a/packages/manager/src/hooks/useLinodeActions.ts
+++ b/packages/manager/src/hooks/useLinodeActions.ts
@@ -16,7 +16,7 @@ export interface LinodesProps {
   updateLinode: (params: UpdateLinodeParams) => Promise<Linode>;
 }
 
-export const useLinodes = (): LinodesProps => {
+export const useLinodeActions = (): LinodesProps => {
   const dispatch: Dispatch = useDispatch();
 
   const requestLinodes = () =>
@@ -38,4 +38,4 @@ export const useLinodes = (): LinodesProps => {
   };
 };
 
-export default useLinodes;
+export default useLinodeActions;

--- a/packages/manager/src/hooks/useLinodes.ts
+++ b/packages/manager/src/hooks/useLinodes.ts
@@ -1,31 +1,16 @@
-import { Linode } from '@linode/api-v4/lib/linodes/types';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { ApplicationState } from 'src/store';
-import {
-  deleteLinode as _deleteLinode,
-  getLinode as _getLinode,
-  requestLinodes as _requestLinodes,
-  updateLinode as _updateLinode
-} from 'src/store/linodes/linode.requests';
-import { UpdateLinodeParams } from 'src/store/linodes/linodes.actions';
 import { shallowExtendLinodes } from 'src/store/linodes/linodes.helpers';
 import { ShallowExtendedLinode } from 'src/store/linodes/types';
 import { EntityError, MappedEntityState2 } from 'src/store/types';
-import { Dispatch } from './types';
 import useEvents from './useEvents';
 import useNotifications from './useNotifications';
 
 export interface LinodesProps {
   linodes: MappedEntityState2<ShallowExtendedLinode, EntityError>;
-  requestLinodes: () => Promise<Linode[]>;
-  getLinode: (linodeId: number) => Promise<Linode>;
-  deleteLinode: (linodeId: number) => Promise<{}>;
-  updateLinode: (params: UpdateLinodeParams) => Promise<Linode>;
 }
 
 export const useLinodes = (): LinodesProps => {
-  const dispatch: Dispatch = useDispatch();
-
   const linodes = useSelector(
     (state: ApplicationState) => state.__resources.linodes
   );
@@ -38,17 +23,6 @@ export const useLinodes = (): LinodesProps => {
     events.events
   );
 
-  const requestLinodes = () =>
-    dispatch(_requestLinodes({})).then(response => response.data);
-
-  const getLinode = (linodeId: number) => dispatch(_getLinode({ linodeId }));
-
-  const deleteLinode = (linodeId: number) =>
-    dispatch(_deleteLinode({ linodeId }));
-
-  const updateLinode = (params: UpdateLinodeParams) =>
-    dispatch(_updateLinode(params));
-
   return {
     linodes: {
       ...linodes,
@@ -56,11 +30,7 @@ export const useLinodes = (): LinodesProps => {
         (itemsById, item) => ({ ...itemsById, [item.id]: item }),
         {}
       )
-    },
-    requestLinodes,
-    getLinode,
-    deleteLinode,
-    updateLinode
+    }
   };
 };
 


### PR DESCRIPTION
We were using const { updateLinode } = useLinodes() in several places.
Because of hooks weirdness and rerendering, this was causing an enormous
amount of processing (we were mapping through Linodes to extend them
~10 times per each actual Linode). By separating the actions to a separate
file, we can use this hook from consumers without triggering any of the state-based
Redux logic.

