### PR TITLE
Fix LV gauges and graphs

### DIFF
--- a/packages/manager/src/features/Longview/shared/useClientLastUpdated.ts
+++ b/packages/manager/src/features/Longview/shared/useClientLastUpdated.ts
@@ -1,6 +1,6 @@
 import { APIError } from '@linode/api-v4/lib/types';
 import { pathOr } from 'ramda';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { getLastUpdated } from '../request';
 import { LongviewNotification } from '../request.types';
 
@@ -10,7 +10,6 @@ export const useClientLastUpdated = (
 ) => {
   const mounted = useRef(true);
   const requestInterval = useRef(0);
-  const _callback = useRef(callback);
 
   /*
    lastUpdated _might_ come back from the endpoint as 0, so it's important
@@ -26,70 +25,67 @@ export const useClientLastUpdated = (
   >();
   const [authed, setAuthed] = useState<boolean>(true);
 
-  const requestAndSetLastUpdated = useCallback(
-    (apiKey: string) => {
-      /*
+  const requestAndSetLastUpdated = (apiKey: string) => {
+    /*
      get the current last updated value
 
      This function is called as a closure inside the onMount useEffect
      so we need to use a ref to get the new value
     */
-      const { current: newLastUpdated } = currentLastUpdated;
+    const { current: newLastUpdated } = currentLastUpdated;
 
-      setLastUpdatedError(undefined);
+    setLastUpdatedError(undefined);
 
-      // Use a function argument for the API key instead `clientAPIKey` from the
-      // lexical scope, since it is a dependency in the effect that will call
-      // this function.
-      return getLastUpdated(apiKey)
-        .then(response => {
-          /**
-           * If there are any warnings in the response (found at response.NOTIFICATIONS)
-           * we want to set them to state here so that consumers of this component
-           * can handle them (usually by setting a banner). We choose to do this
-           * here as these are high-level requests, made most frequently, and
-           * notifications are not field-specific.
-           */
-          setNotifications(response.NOTIFICATIONS);
-          /*
+    // Use a function argument for the API key instead `clientAPIKey` from the
+    // lexical scope, since it is a dependency in the effect that will call
+    // this function.
+    return getLastUpdated(apiKey)
+      .then(response => {
+        /**
+         * If there are any warnings in the response (found at response.NOTIFICATIONS)
+         * we want to set them to state here so that consumers of this component
+         * can handle them (usually by setting a banner). We choose to do this
+         * here as these are high-level requests, made most frequently, and
+         * notifications are not field-specific.
+         */
+        setNotifications(response.NOTIFICATIONS);
+        /*
           only update _lastUpdated_ state if it hasn't already been set
           or the API response is in a time past what's already been set.
         */
 
-          const _lastUpdated = response.DATA?.updated ?? 0;
+        const _lastUpdated = response.DATA?.updated ?? 0;
 
-          if (
-            mounted.current &&
-            (typeof newLastUpdated === 'undefined' ||
-              _lastUpdated > newLastUpdated)
-          ) {
-            setLastUpdated(_lastUpdated);
-            if (_callback.current) {
-              _callback.current(_lastUpdated);
-            }
+        if (
+          mounted.current &&
+          (typeof newLastUpdated === 'undefined' ||
+            _lastUpdated > newLastUpdated)
+        ) {
+          setLastUpdated(_lastUpdated);
+          if (callback) {
+            callback(_lastUpdated);
           }
-        })
-        .catch(e => {
-          /**
-           * The first request we make after creating a new client will almost always
-           * return an authentication failed error.
-           */
-          const reason = pathOr('', [0, 'TEXT'], e);
+        }
+      })
+      .catch(e => {
+        /**
+         * The first request we make after creating a new client will almost always
+         * return an authentication failed error.
+         */
+        const reason = pathOr('', [0, 'TEXT'], e);
 
-          if (mounted.current) {
-            if (reason.match(/authentication/i)) {
-              setAuthed(false);
-            }
-
-            /* only set lastUpdated error if we haven't already gotten data before */
-            if (typeof newLastUpdated === 'undefined') {
-              setLastUpdatedError(e);
-            }
+        if (mounted.current) {
+          if (reason.match(/authentication/i)) {
+            setAuthed(false);
           }
-        });
-    },
-    [_callback]
-  );
+
+          /* only set lastUpdated error if we haven't already gotten data before */
+          if (typeof newLastUpdated === 'undefined') {
+            setLastUpdatedError(e);
+          }
+        }
+      });
+  };
 
   useEffect(() => {
     /*
@@ -125,7 +121,8 @@ export const useClientLastUpdated = (
       mounted.current = false;
       clearInterval(requestInterval.current);
     };
-  }, [clientAPIKey, requestAndSetLastUpdated]);
+    // @todo: fix deps.
+  }, [clientAPIKey]);
 
   return { lastUpdated, lastUpdatedError, authed, notifications };
 };


### PR DESCRIPTION
## Description

The recent polling work introduced two LV bugs:

- Gauge data not loading most of the time
- Graph data never loading

The gauge bug was due to the callback argument of useClientLastUpdated being saved to a ref [here](https://github.com/linode/manager/pull/7085/files#diff-dfb08f57563f1c45e69b6c65cf85d07697eaf835951feac2ea8e554efd8716b4R13). This was a problem because LongviewDetail gives this [argument conditionally](https://github.com/linode/manager/blob/89d3b30d2362cc43cd6b4203039bec2cd249e27f/packages/manager/src/features/Longview/LongviewDetail/LongviewDetail.tsx#L89).

The graph bug is trickier. For one thing, the mounted ref was incorrectly initialized to `false`, but it took removing the `useCallback()` wrapper for it to work.
