### PR TITLE
M3-4663 Change: move abuse ticket banner to global notifications

### DIFF
--- a/packages/manager/src/components/AbuseTicketBanner/AbuseTicketBanner.test.tsx
+++ b/packages/manager/src/components/AbuseTicketBanner/AbuseTicketBanner.test.tsx
@@ -1,56 +1,66 @@
+import { Notification } from '@linode/api-v4/lib/account/types';
 import { render } from '@testing-library/react';
 import * as React from 'react';
 
 import {
-  abuseTicketNotification,
-  mockNotification
-} from 'src/__data__/notifications';
+  abuseTicketNotificationFactory,
+  notificationFactory
+} from 'src/factories/notification';
 import { wrapWithTheme } from 'src/utilities/testHelpers';
 import { AbuseTicketBanner } from './AbuseTicketBanner';
 
 import filterAbuseTickets from 'src/store/selectors/getAbuseTicket';
 
+const makeMockStore = (notifications: Notification[]) => {
+  return {
+    __resources: {
+      notifications: {
+        data: notifications
+      }
+    }
+  };
+};
+
 describe('Abuse ticket banner', () => {
   it('should render a banner for an abuse ticket', () => {
     const { queryAllByText } = render(
-      wrapWithTheme(
-        <AbuseTicketBanner abuseTickets={[abuseTicketNotification]} />
-      )
+      wrapWithTheme(<AbuseTicketBanner />, {
+        customStore: makeMockStore(abuseTicketNotificationFactory.buildList(1))
+      })
     );
     expect(queryAllByText(/an open abuse ticket/)).toHaveLength(1);
   });
 
   it('should aggregate multiple abuse tickets', () => {
     const { queryAllByText } = render(
-      wrapWithTheme(
-        <AbuseTicketBanner
-          abuseTickets={[abuseTicketNotification, abuseTicketNotification]}
-        />
-      )
+      wrapWithTheme(<AbuseTicketBanner />, {
+        customStore: makeMockStore(abuseTicketNotificationFactory.buildList(2))
+      })
     );
     expect(queryAllByText(/2 open abuse tickets/)).toHaveLength(1);
   });
 
   it('should link to the ticket', () => {
+    const mockAbuseTicket = abuseTicketNotificationFactory.build();
     const { getByTestId } = render(
-      wrapWithTheme(
-        <AbuseTicketBanner abuseTickets={[abuseTicketNotification]} />
-      )
+      wrapWithTheme(<AbuseTicketBanner />, {
+        customStore: makeMockStore([mockAbuseTicket])
+      })
     );
     const link = getByTestId('abuse-ticket-link');
-    expect(link).toHaveAttribute('href', abuseTicketNotification.entity!.url);
+    expect(link).toHaveAttribute('href', mockAbuseTicket.entity!.url);
   });
 
   it('should return null if there are no abuse tickets', () => {
-    const { queryByTestId } = render(
-      wrapWithTheme(<AbuseTicketBanner abuseTickets={[]} />)
-    );
+    const { queryByTestId } = render(wrapWithTheme(<AbuseTicketBanner />));
 
     expect(queryByTestId('abuse-ticket-link')).toBeNull();
   });
 
   describe('integration tests', () => {
     it('should filter out abuse ticket notifications from the store', () => {
+      const mockNotification = notificationFactory.build();
+      const abuseTicketNotification = abuseTicketNotificationFactory.build();
       const tickets = filterAbuseTickets({
         notifications: {
           data: [mockNotification, abuseTicketNotification]

--- a/packages/manager/src/components/AbuseTicketBanner/AbuseTicketBanner.tsx
+++ b/packages/manager/src/components/AbuseTicketBanner/AbuseTicketBanner.tsx
@@ -1,59 +1,54 @@
-import { Notification } from '@linode/api-v4/lib/account';
 import * as React from 'react';
-import { connect } from 'react-redux';
-import { Link } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { Link, useLocation } from 'react-router-dom';
 
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
 import getAbuseTicket from 'src/store/selectors/getAbuseTicket';
-import { MapState } from 'src/store/types';
-import { compose } from 'recompose';
+import { ApplicationState } from 'src/store';
 
-interface ReduxStateProps {
-  abuseTickets: Notification[];
-}
+export const AbuseTicketBanner: React.FC<{}> = _ => {
+  const abuseTickets = useSelector((state: ApplicationState) =>
+    getAbuseTicket(state.__resources)
+  );
+  const location = useLocation();
 
-type CombinedProps = ReduxStateProps;
-
-export class AbuseTicketBanner extends React.Component<CombinedProps> {
-  render() {
-    const { abuseTickets } = this.props;
-
-    if (!abuseTickets || abuseTickets.length === 0) {
-      return null;
-    }
-
-    const count = abuseTickets.length;
-    const multiple = count > 1;
-
-    const message = `You have ${multiple ? count : `an`} open abuse ticket${
-      multiple ? 's' : ''
-    }.`;
-
-    /**
-     * The ticket list page doesn't indicate which tickets are abuse tickets
-     * so for now, the link can just take the user to the first ticket.
-     */
-    const href = abuseTickets[0].entity!.url;
-
-    return (
-      <Grid item xs={12}>
-        <Notice important error dismissible={false}>
-          {message} Please{' '}
-          <Link data-testid="abuse-ticket-link" to={href}>
-            click here
-          </Link>{' '}
-          to view {`${multiple ? 'these tickets' : 'this ticket'}.`}
-        </Notice>
-      </Grid>
-    );
+  if (!abuseTickets || abuseTickets.length === 0) {
+    return null;
   }
-}
 
-const mapStateToProps: MapState<ReduxStateProps, {}> = state => ({
-  abuseTickets: getAbuseTicket(state.__resources)
-});
+  const count = abuseTickets.length;
+  const multiple = count > 1;
 
-const connected = connect<ReduxStateProps, any, {}>(mapStateToProps, undefined);
+  const message = `You have ${multiple ? count : `an`} open abuse ticket${
+    multiple ? 's' : ''
+  }.`;
 
-export default compose(connected)(AbuseTicketBanner) as React.ComponentType<{}>;
+  /**
+   * The ticket list page doesn't indicate which tickets are abuse tickets
+   * so for now, the link can just take the user to the first ticket.
+   */
+  const href = abuseTickets[0].entity!.url;
+  const isViewingTicket = location.pathname.match(href);
+
+  return (
+    <Grid item xs={12}>
+      <Notice important error dismissible={false}>
+        {message}
+        {/** Don't link to /support/tickets if we're already on the landing page. */}
+        {!isViewingTicket ? (
+          <>
+            {' '}
+            Please{' '}
+            <Link data-testid="abuse-ticket-link" to={href}>
+              click here
+            </Link>{' '}
+            to view {`${multiple ? 'these tickets' : 'this ticket'}.`}
+          </>
+        ) : null}
+      </Notice>
+    </Grid>
+  );
+};
+
+export default React.memo(AbuseTicketBanner);

--- a/packages/manager/src/components/AbuseTicketBanner/AbuseTicketBanner.tsx
+++ b/packages/manager/src/components/AbuseTicketBanner/AbuseTicketBanner.tsx
@@ -50,7 +50,7 @@ export class AbuseTicketBanner extends React.Component<CombinedProps> {
   }
 }
 
-const mapStateToProps: MapState<ReduxStateProps, {}> = (state, ownProps) => ({
+const mapStateToProps: MapState<ReduxStateProps, {}> = state => ({
   abuseTickets: getAbuseTicket(state.__resources)
 });
 

--- a/packages/manager/src/factories/notification.ts
+++ b/packages/manager/src/factories/notification.ts
@@ -2,11 +2,14 @@ import * as Factory from 'factory.ts';
 import { DateTime } from 'luxon';
 import { Notification, Entity } from '@linode/api-v4/lib/account';
 
-const generateEntity = (id: number): Entity => ({
+const generateEntity = (
+  id: number,
+  url: string = 'linode/instances'
+): Entity => ({
   type: 'linode',
   label: `linode-${id}`,
   id,
-  url: `/linode/instances/${id}`
+  url: `/${url}/${id}`
 });
 
 export const notificationFactory = Factory.Sync.makeFactory<Notification>({
@@ -25,7 +28,7 @@ export const notificationFactory = Factory.Sync.makeFactory<Notification>({
 
 export const abuseTicketNotificationFactory = notificationFactory.extend({
   type: 'ticket_abuse',
-  entity: Factory.each(i => generateEntity(i)),
+  entity: Factory.each(i => generateEntity(i, 'support/tickets')),
   when: null,
   message: 'You have an open abuse ticket!',
   label: 'You have an open abuse ticket!',

--- a/packages/manager/src/features/Dashboard/Dashboard.tsx
+++ b/packages/manager/src/features/Dashboard/Dashboard.tsx
@@ -5,7 +5,6 @@ import * as React from 'react';
 import { connect, MapDispatchToProps } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
-import AbuseTicketBanner from 'src/components/AbuseTicketBanner';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
 import H1Header from 'src/components/H1Header';
@@ -86,7 +85,6 @@ export const Dashboard: React.FC<CombinedProps> = props => {
         />
       )}
       <Grid container spacing={3}>
-        <AbuseTicketBanner />
         <TaxBanner location={location} marginBottom={8} />
         <DocumentTitleSegment segment="Dashboard" />
         <Grid item xs={12}>

--- a/packages/manager/src/features/GlobalNotifications/GlobalNotifications.tsx
+++ b/packages/manager/src/features/GlobalNotifications/GlobalNotifications.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import AbuseTicketBanner from 'src/components/AbuseTicketBanner';
 import RegionStatusBanner from './RegionStatusBanner';
 import { EmailBounceNotificationSection } from './EmailBounce';
 
@@ -7,6 +8,7 @@ const GlobalNotifications: React.FC<{}> = () => {
     <>
       <EmailBounceNotificationSection />
       <RegionStatusBanner />
+      <AbuseTicketBanner />
     </>
   );
 };

--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketsLanding.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketsLanding.tsx
@@ -3,7 +3,6 @@ import { pathOr } from 'ramda';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
-import AbuseTicketBanner from 'src/components/AbuseTicketBanner';
 import Breadcrumb from 'src/components/Breadcrumb';
 import Button from 'src/components/Button';
 import {
@@ -230,7 +229,6 @@ export class SupportTicketsLanding extends React.PureComponent<
     return (
       <React.Fragment>
         <DocumentTitleSegment segment="Support Tickets" />
-        <AbuseTicketBanner />
         <Grid
           container
           justify="space-between"

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -1,6 +1,7 @@
 import { rest, RequestHandler } from 'msw';
 
 import {
+  abuseTicketNotificationFactory,
   accountFactory,
   appTokenFactory,
   creditPaymentResponseFactory,
@@ -310,9 +311,6 @@ export const handlers = [
     const tags = tagFactory.buildList(5);
     return res(ctx.json(makeResourcePage(tags)));
   }),
-  rest.get('*/account/notifications*', (req, res, ctx) => {
-    return res(ctx.json(makeResourcePage([])));
-  }),
   rest.get('*gravatar*', (req, res, ctx) => {
     return res(ctx.status(400), ctx.json({}));
   }),
@@ -341,10 +339,13 @@ export const handlers = [
     //   until: null,
     //   body: null
     // });
+    const abuseTicket = abuseTicketNotificationFactory.build();
+
     return res(
       ctx.json(
         makeResourcePage([
-          ...notificationFactory.buildList(1)
+          ...notificationFactory.buildList(1),
+          abuseTicket
           // emailBounce
         ])
       )

--- a/packages/manager/src/store/selectors/getAbuseTicket.ts
+++ b/packages/manager/src/store/selectors/getAbuseTicket.ts
@@ -1,11 +1,10 @@
-import { Notification } from '@linode/api-v4/lib/account'
+import { Notification } from '@linode/api-v4/lib/account';
 import { pathOr } from 'ramda';
 import { ResourcesState } from 'src/store';
 
 export default (state: ResourcesState) => {
   const notifications = pathOr([], ['notifications', 'data'], state);
   return notifications.filter(
-    (thisNotification: Notification) =>
-      thisNotification.type === 'ticket_abuse'
+    (thisNotification: Notification) => thisNotification.type === 'ticket_abuse'
   );
 };


### PR DESCRIPTION
## Description

Now that we no longer have a dashboard, abuse ticket notifications were shown only on the support landing page. Now 

## Note to Reviewers

Turn on the mocks to view an abuse ticket.