### PR TITLE
Fix: Flag logic for attaching VLANs when creating a Linode

### DIFF
--- a/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
@@ -8,8 +8,10 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Currency from 'src/components/Currency';
 import Grid from 'src/components/Grid';
+import useAccount from 'src/hooks/useAccount';
 import useFlags from 'src/hooks/useFlags';
 import SelectVLAN from './SelectVLAN';
+import { isFeatureEnabled } from 'src/utilities/accountCapabilities';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -96,6 +98,7 @@ const AddonsPanel: React.FC<CombinedProps> = props => {
   } = props;
 
   const flags = useFlags();
+  const { account } = useAccount();
 
   const handleVlanChange = React.useCallback(
     (vlans: number[]) => {
@@ -105,6 +108,12 @@ const AddonsPanel: React.FC<CombinedProps> = props => {
   );
 
   const classes = useStyles();
+
+  const showVlans = isFeatureEnabled(
+    'Vlans',
+    Boolean(flags.vlans),
+    account?.data?.capabilities ?? []
+  );
 
   const renderBackupsPrice = () => {
     const { backupsMonthly } = props;
@@ -188,7 +197,7 @@ const AddonsPanel: React.FC<CombinedProps> = props => {
             </Grid>
           </React.Fragment>
         )}
-        {flags.cmr && flags.vlans ? (
+        {flags.cmr && showVlans ? (
           <Grid container className={classes.lastItem}>
             <Grid item xs={12}>
               <Divider className={classes.divider} />


### PR DESCRIPTION
I turned off the LD flag for this yesterday since we have account.capabilities and should rely on that. But Anton couldn't see the VLAN select when creating a Linode, because that particular UI bit was looking only at flags.vlans.