### PR TITLE
CMR Documentation Button - Phase 1

### DIFF
--- a/packages/manager/src/assets/icons/docs.svg
+++ b/packages/manager/src/assets/icons/docs.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
+    <g fill="none" fill-rule="evenodd" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.25">
+        <path d="M1.974 19.375c-.727 0-1.316-.56-1.316-1.25V1.875c0-.69.589-1.25 1.316-1.25h13.158c.343 0 .672.127.918.355l2.632 2.402c.254.236.397.558.397.895v15.098H1.974zM4.605 6.875L15.132 6.875M4.605 10.625L9.868 10.625M4.605 14.375L12.105 14.5"/>
+    </g>
+</svg>

--- a/packages/manager/src/components/CMR_DocumentationButton/DocumentationButton.stories.tsx
+++ b/packages/manager/src/components/CMR_DocumentationButton/DocumentationButton.stories.tsx
@@ -1,0 +1,9 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import DocumentationButton from './DocumentationButton';
+
+storiesOf('Documentation Button', module).add('Default', () => (
+  <div style={{ padding: 20, width: 104 }}>
+    <DocumentationButton href="" />
+  </div>
+));

--- a/packages/manager/src/components/CMR_DocumentationButton/DocumentationButton.tsx
+++ b/packages/manager/src/components/CMR_DocumentationButton/DocumentationButton.tsx
@@ -1,27 +1,54 @@
 import * as React from 'react';
-import TicketIcon from 'src/assets/icons/ticket.svg';
-import { makeStyles, Theme } from 'src/components/core/styles';
+import ArrowIcon from 'src/assets/icons/diagonalArrow.svg';
+import DocsIcon from 'src/assets/icons/docs.svg';
+import {
+  makeStyles,
+  Theme,
+  useMediaQuery,
+  useTheme
+} from 'src/components/core/styles';
+import Grid from 'src/components/Grid';
 import IconTextLink from '../IconTextLink';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
+    display: 'flex',
     alignItems: 'center',
-    borderLeft: `1px solid ${theme.cmrBorderColors.borderTable}`,
-    fontFamily: `${theme.font.normal} !important`,
+    flexFlow: 'row nowrap',
+    position: 'relative'
+  },
+  docs: {
+    alignItems: 'center',
     height: 50,
     lineHeight: 'normal',
-    marginBottom: 0,
-    marginRight: theme.spacing(2),
+    margin: 0,
     minWidth: 'auto',
-    paddingLeft: theme.spacing(2),
     padding: 0,
     '& svg': {
-      marginRight: theme.spacing(1.5),
-      width: 24
+      marginRight: theme.spacing()
     },
-    '&:hover svg': {
-      color: theme.palette.primary.main
+    '&:focus': {
+      backgroundColor: 'transparent'
+    },
+    '&:hover': {
+      textDecoration: 'underline',
+      '& svg': {
+        color: theme.palette.primary.light
+      },
+      '& + $externalLinkIcon': {
+        opacity: 1
+      }
+    },
+    [theme.breakpoints.down(1100)]: {
+      marginRight: theme.spacing()
     }
+  },
+  externalLinkIcon: {
+    color: theme.palette.primary.main,
+    marginTop: 3,
+    opacity: 0,
+    position: 'absolute',
+    right: -20
   }
 }));
 
@@ -34,19 +61,27 @@ type CombinedProps = Props;
 
 export const DocumentationButton: React.FC<CombinedProps> = props => {
   const classes = useStyles();
+  const theme = useTheme<Theme>();
+  // Only show external link arrow if there's enough space for
+  // max content width (1100px), arrow icon width on the left and
+  // right side (22px * 2), and whitespace
+  const matchesMdUp = useMediaQuery(theme.breakpoints.up(1155));
+
   const { href, hideText } = props;
+
   return (
-    <IconTextLink
-      className={classes.root}
-      SideIcon={TicketIcon}
-      hideText={hideText}
-      text="Docs"
-      title="Docs"
-      onClick={() => window.open(href, '_blank', 'noopener')}
-      aria-describedby="external-site"
-    >
-      Docs
-    </IconTextLink>
+    <Grid item className={classes.root}>
+      <IconTextLink
+        className={classes.docs}
+        SideIcon={DocsIcon}
+        hideText={hideText}
+        text="Docs"
+        title="Docs"
+        onClick={() => window.open(href, '_blank', 'noopener')}
+        aria-describedby="external-site"
+      />
+      {matchesMdUp && <ArrowIcon className={classes.externalLinkIcon} />}
+    </Grid>
   );
 };
 

--- a/packages/manager/src/components/EntityHeader/EntityHeader.tsx
+++ b/packages/manager/src/components/EntityHeader/EntityHeader.tsx
@@ -5,10 +5,12 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 import { BreadCrumbProps } from './HeaderBreadCrumb';
 import Hidden from '../core/Hidden';
 import Breadcrumb from '../Breadcrumb';
+import DocumentationButton from '../CMR_DocumentationButton';
 
 export interface HeaderProps extends BreadCrumbProps {
   actions?: JSX.Element;
   body?: JSX.Element;
+  docsLink?: string;
   title: string | JSX.Element;
   bodyClassName?: string;
   isLanding?: boolean;
@@ -19,12 +21,15 @@ export interface HeaderProps extends BreadCrumbProps {
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
-    backgroundColor: theme.cmrBGColors.bgSecondaryActions
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between'
   },
   breadcrumbOuter: {
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',
+    backgroundColor: theme.cmrBGColors.bgSecondaryActions,
     padding: '4px 15px',
     [theme.breakpoints.down('sm')]: {
       borderBottom: `1px solid ${theme.cmrBorderColors.borderTable}`
@@ -74,77 +79,65 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 export const EntityHeader: React.FC<HeaderProps> = props => {
+  const classes = useStyles();
+
   const {
     actions,
     body,
-    //iconType,
+    docsLink,
     parentLink,
-    //parentText,
-    // title,
     isLanding,
     bodyClassName,
     isSecondary,
     isDetailLanding
-    // headerOnly,
-    // displayIcon
   } = props;
-  const classes = useStyles();
 
   return (
     <>
-      {isLanding && <Breadcrumb pathname={location.pathname} data-qa-title />}
       <Grid item className={classes.root}>
-        {/* <HeaderBreadCrumb
-          iconType={iconType}
-          displayIcon={displayIcon}
-          title={title}
-          parentLink={parentLink}
-          parentText={parentText}
-          headerOnly={headerOnly}
-        /> */}
-        <Grid
-          item
-          xs={12}
-          className={classnames({
-            [classes.breadcrumbOuter]: true,
-            [classes.breadCrumbDetail]: Boolean(parentLink),
-            [classes.breadCrumbSecondary]: Boolean(isSecondary),
-            [classes.breadCrumbDetailLanding]: Boolean(isDetailLanding)
-          })}
-        >
-          <Hidden smDown>
-            {body ? (
-              <Grid
-                className={classnames({
-                  [classes.contentOuter]: true,
-                  [bodyClassName ?? '']: Boolean(bodyClassName)
-                })}
-                item
-              >
-                {body}
-              </Grid>
-            ) : null}
-          </Hidden>
-
-          {/* I think only Landing variant uses this? */}
-          {actions}
-        </Grid>
-        <Hidden mdUp>
+        {isLanding && <Breadcrumb pathname={location.pathname} data-qa-title />}
+        {docsLink && <DocumentationButton href={docsLink} />}
+      </Grid>
+      <Grid
+        item
+        xs={12}
+        className={classnames({
+          [classes.breadcrumbOuter]: true,
+          [classes.breadCrumbDetail]: Boolean(parentLink),
+          [classes.breadCrumbSecondary]: Boolean(isSecondary),
+          [classes.breadCrumbDetailLanding]: Boolean(isDetailLanding)
+        })}
+      >
+        <Hidden smDown>
           {body ? (
             <Grid
-              item
-              xs={12}
               className={classnames({
                 [classes.contentOuter]: true,
-                [classes.bodyDetailVariant]:
-                  Boolean(parentLink) || Boolean(isDetailLanding)
+                [bodyClassName ?? '']: Boolean(bodyClassName)
               })}
+              item
             >
               {body}
             </Grid>
           ) : null}
         </Hidden>
+        {actions}
       </Grid>
+      <Hidden mdUp>
+        {body ? (
+          <Grid
+            item
+            xs={12}
+            className={classnames({
+              [classes.contentOuter]: true,
+              [classes.bodyDetailVariant]:
+                Boolean(parentLink) || Boolean(isDetailLanding)
+            })}
+          >
+            {body}
+          </Grid>
+        ) : null}
+      </Hidden>
     </>
   );
 };

--- a/packages/manager/src/components/LandingHeader/LandingHeader.tsx
+++ b/packages/manager/src/components/LandingHeader/LandingHeader.tsx
@@ -1,13 +1,7 @@
 import * as React from 'react';
 import Grid from 'src/components/Grid';
 import Button from 'src/components/Button';
-import {
-  makeStyles,
-  Theme,
-  useTheme,
-  useMediaQuery
-} from 'src/components/core/styles';
-import DocumentationButton from 'src/components/CMR_DocumentationButton';
+import { makeStyles } from 'src/components/core/styles';
 import EntityHeader, {
   HeaderProps
 } from 'src/components/EntityHeader/EntityHeader';
@@ -39,8 +33,6 @@ interface Props extends Omit<HeaderProps, 'actions'> {
 
 export const LandingHeader: React.FC<Props> = props => {
   const classes = useStyles();
-  const theme = useTheme<Theme>();
-  const matchesSmDown = useMediaQuery(theme.breakpoints.down('sm'));
 
   const {
     docsLink,
@@ -84,9 +76,6 @@ export const LandingHeader: React.FC<Props> = props => {
             </Button>
           </Grid>
         )}
-        {docsLink && (
-          <DocumentationButton href={docsLink} hideText={matchesSmDown} />
-        )}
       </Grid>
     ),
     [
@@ -95,14 +84,15 @@ export const LandingHeader: React.FC<Props> = props => {
       onAddNew,
       classes.button,
       extraActions,
-      matchesSmDown,
       createButtonWidth,
       startsWithVowel,
       createButtonText
     ]
   );
 
-  return <EntityHeader isLanding actions={actions} {...props} />;
+  return (
+    <EntityHeader isLanding actions={actions} docsLink={docsLink} {...props} />
+  );
 };
 
 export default LandingHeader;

--- a/packages/manager/src/features/Footer/Footer_CMR.tsx
+++ b/packages/manager/src/features/Footer/Footer_CMR.tsx
@@ -28,7 +28,7 @@ const styles = (theme: Theme) =>
   createStyles({
     container: {
       margin: `0 auto`,
-      maxWidth: 1280,
+      maxWidth: 1100,
       width: '100%',
       [theme.breakpoints.down('xs')]: {
         flexDirection: 'column',
@@ -37,7 +37,7 @@ const styles = (theme: Theme) =>
     },
     desktopMenuIsOpen: {
       paddingLeft: 0,
-      [theme.breakpoints.up('md')]: {
+      [theme.breakpoints.up(1100)]: {
         paddingLeft: theme.spacing(7) + 36
       }
     },

--- a/packages/manager/src/features/linodes/LinodesLanding/CardView.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/CardView.tsx
@@ -3,7 +3,7 @@ import { Config } from '@linode/api-v4/lib/linodes';
 import * as React from 'react';
 import { compose } from 'recompose';
 import CircleProgress from 'src/components/CircleProgress';
-import { makeStyles } from 'src/components/core/styles';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 import { PaginationProps } from 'src/components/Paginate';
@@ -24,13 +24,14 @@ import formatDate from 'src/utilities/formatDate';
 import { safeGetImageLabel } from 'src/utilities/safeGetImageLabel';
 import LinodeCard from './LinodeCard';
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((theme: Theme) => ({
   '@keyframes pulse': {
     to: {
       backgroundColor: `hsla(40, 100%, 55%, 0)`
     }
   },
   summaryOuter: {
+    backgroundColor: theme.cmrBGColors.bgPaper,
     marginBottom: 20,
     '& .statusOther:before': {
       animation: '$pulse 1.5s ease-in-out infinite'


### PR DESCRIPTION
## Description
- Revert to the previous style (inline with breadcrumb but convert text to "Docs")
- Add underline and external link arrow on hover
- Create storybook entry
- Also changed the max-width for the footer to 1100px

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers
The scope of phase 1 is to optimize the DocumentationButton for Linodes Landing and add it to storybook while phase 2 will add the component to the rest of the app
