### PR TITLE
Global Button & Link updates

### DIFF
--- a/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
+++ b/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
@@ -14,7 +14,6 @@ type ClassNames = 'root';
 const styles = (theme: Theme) =>
   createStyles({
     root: {
-      backgroundColor: theme.bg.white,
       paddingTop: theme.spacing(2),
       paddingBottom: theme.spacing(1),
       '& > button': {

--- a/packages/manager/src/components/Button/Button.tsx
+++ b/packages/manager/src/components/Button/Button.tsx
@@ -43,8 +43,6 @@ const styles = (theme: Theme) =>
     },
     root: {
       minWidth: '105px',
-      paddingLeft: theme.spacing(3) + 4,
-      paddingRight: theme.spacing(3) + 4,
       transition: 'none'
       // '&.cancel': {
       //   border: `1px solid transparent`,

--- a/packages/manager/src/components/Button/Button.tsx
+++ b/packages/manager/src/components/Button/Button.tsx
@@ -15,7 +15,6 @@ type ClassNames =
   | 'root'
   | 'loading'
   | 'loadingText'
-  | 'destructive'
   | 'compact'
   | 'superCompact'
   | 'reg';
@@ -46,26 +45,26 @@ const styles = (theme: Theme) =>
       minWidth: '105px',
       paddingLeft: theme.spacing(3) + 4,
       paddingRight: theme.spacing(3) + 4,
-      transition: 'none',
-      '&.cancel': {
-        border: `1px solid transparent`,
-        transition: theme.transitions.create(['color', 'border-color']),
-        '&:hover, &:focus': {
-          color: theme.palette.primary.light,
-          borderColor: theme.palette.primary.light
-        }
-      },
-      '&.remove': {
-        fontSize: '.9rem',
-        border: 0,
-        color: '#C44742',
-        padding: `${theme.spacing(2) + 2}px  ${theme.spacing(2) +
-          2}px ${theme.spacing(3) + 2}px ${theme.spacing(2) + 2}px`,
-        transition: theme.transitions.create(['color', 'border-color']),
-        '&:hover, &:focus': {
-          color: '#DF6560'
-        }
-      }
+      transition: 'none'
+      // '&.cancel': {
+      //   border: `1px solid transparent`,
+      //   transition: theme.transitions.create(['color', 'border-color']),
+      //   '&:hover, &:focus': {
+      //     color: theme.palette.primary.light,
+      //     borderColor: theme.palette.primary.light
+      //   }
+      // },
+      // '&.remove': {
+      //   fontSize: '.9rem',
+      //   border: 0,
+      //   color: '#C44742',
+      //   padding: `${theme.spacing(2) + 2}px  ${theme.spacing(2) +
+      //     2}px ${theme.spacing(3) + 2}px ${theme.spacing(2) + 2}px`,
+      //   transition: theme.transitions.create(['color', 'border-color']),
+      //   '&:hover, &:focus': {
+      //     color: '#DF6560'
+      //   }
+      // }
     },
     loading: {
       '& svg': {
@@ -78,34 +77,34 @@ const styles = (theme: Theme) =>
     loadingText: {
       marginRight: 8
     },
-    destructive: {
-      borderColor: '#C44742',
-      color: '#C44742',
-      background: theme.color.white,
-      '&.primary:not(.disabled)': {
-        backgroundColor: '#C44742',
-        color: theme.color.white,
-        '&:hover, &:focus': {
-          backgroundColor: '#DF6560',
-          color: theme.color.white
-        }
-      },
-      '&:hover, &:focus': {
-        background: theme.color.white,
-        color: '#DF6560',
-        borderColor: '#DF6560'
-      },
-      '&:active': {
-        color: '#963530',
-        borderColor: '#963530'
-      },
-      '&$loading': {
-        color: '#C44742 !important',
-        '&.primary': {
-          background: 'rgba(0, 0, 0, 0.12) !important'
-        }
-      }
-    },
+    // destructive: {
+    //   borderColor: '#C44742',
+    //   color: '#C44742',
+    //   background: theme.color.white,
+    //   '&.primary:not(.disabled)': {
+    //     backgroundColor: '#C44742',
+    //     color: theme.color.white,
+    //     '&:hover, &:focus': {
+    //       backgroundColor: '#DF6560',
+    //       color: theme.color.white
+    //     }
+    //   },
+    //   '&:hover, &:focus': {
+    //     background: theme.color.white,
+    //     color: '#DF6560',
+    //     borderColor: '#DF6560'
+    //   },
+    //   '&:active': {
+    //     color: '#963530',
+    //     borderColor: '#963530'
+    //   },
+    //   '&$loading': {
+    //     color: '#C44742 !important',
+    //     '&.primary': {
+    //       background: 'rgba(0, 0, 0, 0.12) !important'
+    //     }
+    //   }
+    // },
     compact: {
       paddingLeft: theme.spacing(2) - 2,
       paddingRight: theme.spacing(2) - 2,
@@ -136,7 +135,8 @@ const getVariant = cond([
 const getColor = cond([
   [propEq('buttonType', 'primary'), always('primary')],
   [propEq('buttonType', 'secondary'), always('secondary')],
-  [propEq('buttonType', 'remove'), always('secondary')],
+  [propEq('buttonType', 'remove'), always('primary')],
+  [propEq('buttonType', 'destructive'), always('primary')],
   [propEq('buttonType', 'cancel'), always('secondary')],
   [() => true, always(undefined)]
 ]);
@@ -172,7 +172,6 @@ const wrappedButton: React.FC<CombinedProps> = props => {
             [classes.root]: true,
             [classes.loading]: loading,
             loading,
-            [classes.destructive]: destructive,
             [classes.compact]: compact,
             [classes.superCompact]: superCompact,
             disabled: props.disabled

--- a/packages/manager/src/components/DeletionDialog/DeletionDialog.tsx
+++ b/packages/manager/src/components/DeletionDialog/DeletionDialog.tsx
@@ -47,7 +47,7 @@ const DeletionDialog: React.FC<CombinedProps> = props => {
         Cancel
       </Button>
       <Button
-        buttonType="secondary"
+        buttonType="primary"
         destructive
         onClick={onDelete}
         loading={loading}

--- a/packages/manager/src/components/IconTextLink/IconTextLink.tsx
+++ b/packages/manager/src/components/IconTextLink/IconTextLink.tsx
@@ -31,12 +31,13 @@ const styles = (theme: Theme) =>
       transition: 'none',
       margin: `0 -${theme.spacing(1) + theme.spacing(1) / 2}px 2px 0`,
       minHeight: 'auto',
+      borderRadius: 0,
       '&:hover': {
         color: theme.palette.primary.light,
         backgroundColor: 'transparent',
         '& svg': {
           fill: theme.palette.primary.light,
-          color: 'white'
+          color: 'currentColor'
         },
         '& .border': {
           color: theme.palette.primary.light
@@ -59,7 +60,7 @@ const styles = (theme: Theme) =>
       transition: 'none',
       fontSize: 18,
       marginRight: theme.spacing(0.5),
-      color: theme.cmrIconColors.iActiveLight,
+      color: 'inherit',
       '& .border': {
         transition: 'none'
       }
@@ -74,7 +75,10 @@ const styles = (theme: Theme) =>
     },
     linkWrapper: {
       display: 'flex',
-      justifyContent: 'center'
+      justifyContent: 'center',
+      '&:hover, &:focus': {
+        textDecoration: 'none'
+      }
     }
   });
 

--- a/packages/manager/src/components/IconTextLink/IconTextLink.tsx
+++ b/packages/manager/src/components/IconTextLink/IconTextLink.tsx
@@ -35,10 +35,6 @@ const styles = (theme: Theme) =>
       '&:hover': {
         color: theme.palette.primary.light,
         backgroundColor: 'transparent',
-        '& svg': {
-          fill: theme.palette.primary.light,
-          color: 'currentColor'
-        },
         '& .border': {
           color: theme.palette.primary.light
         }

--- a/packages/manager/src/components/InlineMenuAction/InlineMenuAction.tsx
+++ b/packages/manager/src/components/InlineMenuAction/InlineMenuAction.tsx
@@ -9,24 +9,29 @@ const useStyles = makeStyles((theme: Theme) => ({
     padding: '12px 10px',
     minWidth: 0,
     color: theme.cmrTextColors.linkActiveLight,
+    borderRadius: 0,
     '&:hover, &:focus': {
       backgroundColor: '#3683dc',
-      color: '#ffffff'
+      color: '#ffffff',
+      textDecoration: 'none'
     },
     '&[disabled]': {
       color: '#cdd0d5',
       cursor: 'default',
       '&:hover': {
-        backgroundColor: 'inherit'
+        backgroundColor: 'inherit',
+        textDecoration: 'none'
       }
     }
   },
   linkRoot: {
     textAlign: 'center',
     color: theme.cmrTextColors.linkActiveLight,
+    borderRadius: 0,
     '&:hover, &:focus': {
       backgroundColor: '#3683dc',
-      color: '#ffffff'
+      color: '#ffffff',
+      textDecoration: 'none'
     }
   }
 }));

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.styles.ts
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.styles.ts
@@ -53,8 +53,9 @@ const useStyles = makeStyles((theme: Theme) => ({
         ${theme.spacing(1.5) - 1}px
         ${theme.spacing(4) + 1}px
       `,
-    '&:hover': {
+    '&:hover, &:focus': {
       backgroundColor: theme.bg.primaryNavActiveBG,
+      textDecoration: 'none',
       '& $linkItem': {
         color: 'white'
       },
@@ -117,6 +118,7 @@ const useStyles = makeStyles((theme: Theme) => ({
       top: theme.spacing(1) === 8 ? 2 : 0
     },
     '&:hover': {
+      textDecoration: 'none',
       '&:before': {
         content: "''",
         borderColor: `transparent ${theme.bg.primaryNavActive} transparent transparent`

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.styles.ts
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.styles.ts
@@ -106,10 +106,12 @@ const useStyles = makeStyles((theme: Theme) => ({
     paddingRight: 15,
     position: 'relative',
     '&:hover': {
-      backgroundColor: theme.cmrBGColors.bgPrimaryNavActive
+      backgroundColor: theme.cmrBGColors.bgPrimaryNavActive,
+      textDecoration: 'none'
     },
     '&:focus': {
-      backgroundColor: theme.cmrBGColors.bgPrimaryNavActive
+      backgroundColor: theme.cmrBGColors.bgPrimaryNavActive,
+      textDecoration: 'none'
     },
     '& .icon': {
       [theme.breakpoints.down('md')]: {
@@ -242,10 +244,12 @@ const useStyles = makeStyles((theme: Theme) => ({
       paddingLeft: 15,
       paddingRight: 40,
       '&:hover': {
-        backgroundColor: theme.cmrBGColors.bgPrimaryNavActive
+        backgroundColor: theme.cmrBGColors.bgPrimaryNavActive,
+        textDecoration: 'none'
       },
       '&:focus': {
-        backgroundColor: theme.cmrBGColors.bgPrimaryNavActive
+        backgroundColor: theme.cmrBGColors.bgPrimaryNavActive,
+        textDecoration: 'none'
       },
       [theme.breakpoints.down('sm')]: {
         paddingTop: 10,

--- a/packages/manager/src/components/TabLinkList/TabLinkList.tsx
+++ b/packages/manager/src/components/TabLinkList/TabLinkList.tsx
@@ -26,11 +26,13 @@ const useStyles = makeStyles((theme: Theme) => ({
       padding: '6px 16px',
       position: 'relative',
       textTransform: 'inherit',
+      textDecoration: 'none',
       [theme.breakpoints.up('md')]: {
         minWidth: 75
       },
       '&:hover': {
-        color: theme.color.blue
+        color: theme.color.blue,
+        textDecoration: 'none'
       }
     },
     '&[data-reach-tab][data-selected]': {

--- a/packages/manager/src/components/TagsPanel/TagsPanel.tsx
+++ b/packages/manager/src/components/TagsPanel/TagsPanel.tsx
@@ -72,8 +72,10 @@ const styles = (theme: Theme) =>
       '& svg': {
         marginRight: theme.spacing(1)
       },
-      '&:hover p': {
-        color: theme.palette.primary.main
+      '&:hover': {
+        '& p': {
+          color: theme.palette.primary.main
+        }
       }
     },
     tagsPanelItemWrapper: {

--- a/packages/manager/src/components/TagsPanel/TagsPanel.tsx
+++ b/packages/manager/src/components/TagsPanel/TagsPanel.tsx
@@ -1,11 +1,10 @@
-import AddCircle from '@material-ui/icons/AddCircle';
 import * as classNames from 'classnames';
 import { getTags } from '@linode/api-v4/lib/tags';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import { clone } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
-import Button from 'src/components/Button';
+import AddNewLink from 'src/components/AddNewLink';
 import CircleProgress from 'src/components/CircleProgress';
 import {
   createStyles,
@@ -13,7 +12,6 @@ import {
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
-import Typography from 'src/components/core/Typography';
 import Select from 'src/components/EnhancedSelect/Select';
 import Notice from 'src/components/Notice';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
@@ -399,7 +397,6 @@ class TagsPanel extends React.Component<CombinedProps, State> {
             hideLabel
             value={tagInputValue}
             createOptionPosition="first"
-            autoFocus
             className={classes.selectTag}
             blurInputOnSelect={false}
             menuIsOpen={!loading && !tagError}
@@ -411,17 +408,12 @@ class TagsPanel extends React.Component<CombinedProps, State> {
               [classes.hasError]: tagError
             })}
           >
-            <Button
+            <AddNewLink
+              label="Add New Tag"
+              disabled={loading || disabled}
               onClick={this.toggleTagInput}
               className={classes.addButton}
-              disableFocusRipple
-              disableRipple
-              disabled={loading || disabled}
-              data-qa-add-tag-btn
-            >
-              <AddCircle data-qa-add-tag />
-              <Typography data-qa-tag-p>Add New Tag</Typography>
-            </Button>
+            />
           </div>
         )}
       </div>
@@ -431,7 +423,4 @@ class TagsPanel extends React.Component<CombinedProps, State> {
 
 const styled = withStyles(styles);
 
-export default compose<CombinedProps, Props>(
-  styled,
-  withSnackbar
-)(TagsPanel);
+export default compose<CombinedProps, Props>(styled, withSnackbar)(TagsPanel);

--- a/packages/manager/src/features/Account/CloseAccountDialog.tsx
+++ b/packages/manager/src/features/Account/CloseAccountDialog.tsx
@@ -165,7 +165,7 @@ const Actions: React.FC<ActionsProps> = props => {
         onClick={props.onSubmit}
         loading={props.isCancelling}
         destructive
-        buttonType="secondary"
+        buttonType="primary"
       >
         Close Account
       </Button>

--- a/packages/manager/src/features/Account/CloseAccountSetting.tsx
+++ b/packages/manager/src/features/Account/CloseAccountSetting.tsx
@@ -13,7 +13,7 @@ const CloseAccountSetting: React.FC<{}> = () => {
         <Grid container direction="column">
           <Grid item>
             <Button
-              buttonType="secondary"
+              buttonType="primary"
               destructive
               onClick={() => setDialogOpen(true)}
             >

--- a/packages/manager/src/features/Account/EnableObjectStorage.tsx
+++ b/packages/manager/src/features/Account/EnableObjectStorage.tsx
@@ -45,7 +45,7 @@ export const ObjectStorageContent: React.FC<ContentProps> = props => {
         </Grid>
         <Grid item>
           <Button
-            buttonType="secondary"
+            buttonType="primary"
             destructive
             onClick={openConfirmationModal}
           >
@@ -106,7 +106,7 @@ export const EnableObjectStorage: React.FC<CombinedProps> = props => {
       </Button>
 
       <Button
-        buttonType="secondary"
+        buttonType="primary"
         destructive
         onClick={handleSubmit}
         loading={isLoading}

--- a/packages/manager/src/features/Backups/BackupsCTA.tsx
+++ b/packages/manager/src/features/Backups/BackupsCTA.tsx
@@ -106,7 +106,7 @@ const BackupsCTA: React.FC<CombinedProps> = props => {
           </Button>
           <Button
             data-qa-backup-existing
-            variant="text"
+            buttonType="secondary"
             className={classes.dismiss}
             onClick={dismissed}
           >

--- a/packages/manager/src/features/Backups/BackupsCTA.tsx
+++ b/packages/manager/src/features/Backups/BackupsCTA.tsx
@@ -45,7 +45,8 @@ const styles = (theme: Theme) =>
     dismiss: {
       paddingLeft: theme.spacing(2),
       paddingRight: theme.spacing(2),
-      minWidth: 'auto'
+      minWidth: 'auto',
+      marginTop: 10
     }
   });
 

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
@@ -95,9 +95,13 @@ const useStyles = makeStyles((theme: Theme) => ({
       paddingBottom: 0
     },
     '&:hover': {
+      textDecoration: 'none',
       '& svg': {
         color: `${theme.palette.primary.main} !important`
       }
+    },
+    '&:focus': {
+      textDecoration: 'none'
     }
   },
   infoIcon: {

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentBits/CreditCardDialog.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentBits/CreditCardDialog.tsx
@@ -47,7 +47,7 @@ class DialogActions extends React.PureComponent<Actions> {
           Cancel
         </Button>
         <Button
-          buttonType="secondary"
+          buttonType="primary"
           loading={this.props.isMakingPayment}
           onClick={this.props.executePayment}
           data-qa-submit

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentBits/PaypalDialogActionButtons.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentBits/PaypalDialogActionButtons.tsx
@@ -51,7 +51,7 @@ const PaypalDialogActionButtons: React.SFC<CombinedProps> = props => {
           Cancel
         </Button>
         <Button
-          buttonType="secondary"
+          buttonType="primary"
           loading={isExecutingPayment}
           onClick={initExecutePayment}
           data-qa-submit

--- a/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/ContactInformation.tsx
@@ -54,7 +54,12 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginBottom: theme.spacing(2),
     marginRight: theme.spacing(1),
     minWidth: 'auto',
-    padding: 0
+    padding: 0,
+    '&:hover, &:focus': {
+      backgroundColor: 'transparent',
+      color: 'inherit',
+      textDecoration: 'underline'
+    }
   }
 }));
 

--- a/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/ContactInformation.tsx
@@ -49,6 +49,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   editBtn: {
     fontFamily: theme.font.normal,
+    color: theme.palette.primary.main,
     fontSize: '.875rem',
     fontWeight: 700,
     marginBottom: theme.spacing(2),

--- a/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/ContactInformation.tsx
@@ -57,7 +57,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     padding: 0,
     '&:hover, &:focus': {
       backgroundColor: 'transparent',
-      color: 'inherit',
+      color: theme.palette.primary.main,
       textDecoration: 'underline'
     }
   }

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.tsx
@@ -35,7 +35,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     padding: 0,
     '&:hover, &:focus': {
       backgroundColor: 'transparent',
-      color: 'inherit',
+      color: theme.palette.primary.main,
       textDecoration: 'underline'
     }
   }

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.tsx
@@ -32,7 +32,12 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginBottom: theme.spacing(2),
     marginRight: theme.spacing(1),
     minWidth: 'auto',
-    padding: 0
+    padding: 0,
+    '&:hover, &:focus': {
+      backgroundColor: 'transparent',
+      color: 'inherit',
+      textDecoration: 'underline'
+    }
   }
 }));
 

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.tsx
@@ -27,6 +27,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   edit: {
     fontFamily: theme.font.normal,
+    color: theme.palette.primary.main,
     fontSize: '.875rem',
     fontWeight: 700,
     marginBottom: theme.spacing(2),

--- a/packages/manager/src/features/Domains/DeleteDomain.tsx
+++ b/packages/manager/src/features/Domains/DeleteDomain.tsx
@@ -48,7 +48,7 @@ export const DeleteDomain: React.FC<CombinedProps> = props => {
   return (
     <>
       <Button
-        buttonType="secondary"
+        buttonType="primary"
         destructive
         onClick={() => openDialog(props.domainId, props.domainLabel)}
       >

--- a/packages/manager/src/features/Domains/DisableDomainDialog.tsx
+++ b/packages/manager/src/features/Domains/DisableDomainDialog.tsx
@@ -92,7 +92,7 @@ const Actions: React.FC<ActionsProps> = props => {
         onClick={props.onSubmit}
         loading={props.isSubmitting}
         destructive
-        buttonType="secondary"
+        buttonType="primary"
       >
         Disable
       </Button>

--- a/packages/manager/src/features/Domains/DomainRecords.tsx
+++ b/packages/manager/src/features/Domains/DomainRecords.tsx
@@ -57,7 +57,13 @@ import { storage } from 'src/utilities/storage';
 import ActionMenu from './DomainRecordActionMenu';
 import Drawer from './DomainRecordDrawer';
 
-type ClassNames = 'root' | 'cells' | 'titles' | 'linkContainer' | 'cmrSpacing';
+type ClassNames =
+  | 'root'
+  | 'cells'
+  | 'titles'
+  | 'linkContainer'
+  | 'cmrSpacing'
+  | 'addNewLink';
 
 const styles = (theme: Theme) =>
   createStyles({

--- a/packages/manager/src/features/Domains/DomainRecords.tsx
+++ b/packages/manager/src/features/Domains/DomainRecords.tsx
@@ -671,7 +671,7 @@ class DomainRecords extends React.Component<CombinedProps, State> {
           Cancel
         </Button>
         <Button
-          buttonType="secondary"
+          buttonType="primary"
           destructive
           onClick={this.deleteDomainRecord}
         >

--- a/packages/manager/src/features/Domains/DomainTableRow_CMR.tsx
+++ b/packages/manager/src/features/Domains/DomainTableRow_CMR.tsx
@@ -14,15 +14,19 @@ const useStyles = makeStyles((theme: Theme) => ({
     display: 'block',
     fontFamily: theme.font.bold,
     lineHeight: '1.125rem',
-    textDecoration: 'underline',
-    color: theme.cmrTextColors.linkActiveLight
+    color: theme.cmrTextColors.linkActiveLight,
+    '&:hover, &:focus': {
+      textDecoration: 'underline'
+    }
   },
   button: {
     ...theme.applyLinkStyles,
     display: 'block',
     fontFamily: theme.font.bold,
     lineHeight: '1.125rem',
-    textDecoration: 'underline'
+    '&:hover, &:focus': {
+      textDecoration: 'underline'
+    }
   },
   domain: {
     width: '60%'

--- a/packages/manager/src/features/Domains/DomainTableRow_CMR.tsx
+++ b/packages/manager/src/features/Domains/DomainTableRow_CMR.tsx
@@ -23,6 +23,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     ...theme.applyLinkStyles,
     display: 'block',
     fontFamily: theme.font.bold,
+    color: theme.cmrTextColors.linkActiveLight,
     lineHeight: '1.125rem',
     '&:hover, &:focus': {
       textDecoration: 'underline'

--- a/packages/manager/src/features/Domains/DomainsLanding.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.tsx
@@ -458,13 +458,17 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
                         <Button
                           className={classes.importButton}
                           onClick={this.openImportZoneDrawer}
+                          buttonType="secondary"
                         >
                           Import a Zone
                         </Button>
                       </Hidden>
                     }
                     extraActions={
-                      <Button onClick={this.openImportZoneDrawer}>
+                      <Button
+                        onClick={this.openImportZoneDrawer}
+                        buttonType="secondary"
+                      >
                         Import a Zone
                       </Button>
                     }

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/RemoveDeviceDialog.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/RemoveDeviceDialog.tsx
@@ -56,7 +56,7 @@ const renderActions = (
         Cancel
       </Button>
       <Button
-        buttonType="secondary"
+        buttonType="primary"
         destructive
         loading={loading}
         onClick={onDelete}

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallActionMenu_CMR.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallActionMenu_CMR.tsx
@@ -28,7 +28,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     padding: '12px 10px',
     textAlign: 'center',
 
-    '&:hover': {
+    '&:hover, &:focus': {
       backgroundColor: '#3683dc',
       '& span': {
         color: '#ffffff'
@@ -48,9 +48,10 @@ const useStyles = makeStyles((theme: Theme) => ({
     height: '100%',
     padding: '12px 10px',
     whiteSpace: 'nowrap',
-    '&:hover': {
+    '&:hover, &:focus': {
       backgroundColor: '#3683dc',
-      color: '#ffffff'
+      color: '#ffffff',
+      textDecoration: 'none'
     },
     '&[disabled]': {
       color: '#cdd0d5',

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallDialog.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallDialog.tsx
@@ -121,7 +121,7 @@ const Actions: React.FC<ActionsProps> = props => {
         onClick={props.onSubmit}
         loading={props.isSubmitting}
         destructive={props.mode === 'delete'}
-        buttonType="secondary"
+        buttonType="primary"
       >
         {capitalize(props.mode)}
       </Button>

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallRow_CMR.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallRow_CMR.tsx
@@ -20,7 +20,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     color: theme.cmrTextColors.linkActiveLight,
     fontSize: '.875rem',
     lineHeight: '1.125rem',
-    textDecoration: 'underline'
+    '&:hover, &:focus': {
+      textDecoration: 'underline'
+    }
   },
   labelWrapper: {
     display: 'flex',

--- a/packages/manager/src/features/GlobalNotifications/EmailBounce.tsx
+++ b/packages/manager/src/features/GlobalNotifications/EmailBounce.tsx
@@ -161,7 +161,7 @@ const EmailBounceNotification: React.FC<CombinedProps> = React.memo(props => {
             className={classes.buttonContainer}
           >
             <Button
-              buttonType="secondary"
+              buttonType="primary"
               onClick={handleConfirm}
               loading={loading}
               data-testid="confirmButton"
@@ -170,7 +170,7 @@ const EmailBounceNotification: React.FC<CombinedProps> = React.memo(props => {
             </Button>
             <Button
               className={classes.updateButton}
-              buttonType="primary"
+              buttonType="secondary"
               onClick={changeEmail}
               data-testid="updateButton"
             >

--- a/packages/manager/src/features/Images/ImagesLanding.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding.tsx
@@ -278,7 +278,7 @@ export const ImagesLanding: React.FC<CombinedProps> = props => {
           Cancel
         </Button>
         <Button
-          buttonType="secondary"
+          buttonType="primary"
           destructive
           loading={dialog.submitting}
           onClick={handleRemoveImage}

--- a/packages/manager/src/features/Kubernetes/ClusterList/ClusterActionMenu_CMR.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/ClusterActionMenu_CMR.tsx
@@ -21,8 +21,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   link: {
     padding: '12px 10px',
     textAlign: 'center',
-    '&:hover': {
+    '&:hover, &:focus': {
       backgroundColor: '#3683dc',
+      textDecoration: 'none',
       '& span': {
         color: theme.color.white
       }
@@ -40,15 +41,18 @@ const useStyles = makeStyles((theme: Theme) => ({
     minWidth: 'auto',
     padding: '12px 10px',
     whiteSpace: 'nowrap',
-    '&:hover': {
+    borderRadius: 0,
+    '&:hover, &:focus': {
       backgroundColor: '#3683dc',
-      color: theme.color.white
+      color: theme.color.white,
+      textDecoration: 'none'
     },
     '&[disabled]': {
       color: '#cdd0d5',
       cursor: 'default',
-      '&:hover': {
-        backgroundColor: 'inherit'
+      '&:hover, &:focus': {
+        backgroundColor: 'inherit',
+        textDecoration: 'none'
       }
     }
   }

--- a/packages/manager/src/features/Kubernetes/ClusterList/ClusterActionMenu_CMR.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/ClusterActionMenu_CMR.tsx
@@ -25,11 +25,11 @@ const useStyles = makeStyles((theme: Theme) => ({
       backgroundColor: '#3683dc',
       textDecoration: 'none',
       '& span': {
-        color: theme.color.white
+        color: '#fff'
       }
     },
     '& span': {
-      color: '#3683dc'
+      color: theme.cmrTextColors.linkActiveLight
     }
   },
   action: {
@@ -37,6 +37,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   button: {
     ...theme.applyLinkStyles,
+    color: theme.cmrTextColors.linkActiveLight,
     height: '100%',
     minWidth: 'auto',
     padding: '12px 10px',
@@ -44,7 +45,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     borderRadius: 0,
     '&:hover, &:focus': {
       backgroundColor: '#3683dc',
-      color: theme.color.white,
+      color: '#fff',
       textDecoration: 'none'
     },
     '&[disabled]': {

--- a/packages/manager/src/features/Kubernetes/ClusterList/ClusterRow_CMR.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/ClusterRow_CMR.tsx
@@ -32,8 +32,10 @@ const styles = (theme: Theme) =>
       fontFamily: theme.font.bold,
       fontSize: '.875rem',
       lineHeight: '1.125rem',
-      textDecoration: 'underline',
-      color: theme.cmrTextColors.linkActiveLight
+      color: theme.cmrTextColors.linkActiveLight,
+      '&:hover, &:focus': {
+        textDecoration: 'underline'
+      }
     },
     labelStatusWrapper: {
       display: 'flex',

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesDialog.tsx
@@ -36,7 +36,7 @@ const renderActions = (
         Cancel
       </Button>
       <Button
-        buttonType="secondary"
+        buttonType="primary"
         disabled={disabled}
         destructive
         loading={loading}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeDialog.tsx
@@ -30,7 +30,7 @@ const renderActions = (
         Cancel
       </Button>
       <Button
-        buttonType="secondary"
+        buttonType="primary"
         destructive
         loading={loading}
         onClick={onDelete}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolDialog.tsx
@@ -33,7 +33,7 @@ const renderActions = (
         Cancel
       </Button>
       <Button
-        buttonType="secondary"
+        buttonType="primary"
         destructive
         loading={loading}
         onClick={onDelete}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/RecycleAllNodesDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/RecycleAllNodesDialog.tsx
@@ -29,7 +29,7 @@ const renderActions = (
         Cancel
       </Button>
       <Button
-        buttonType="secondary"
+        buttonType="primary"
         destructive
         loading={loading}
         onClick={onSubmit}

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientHeader.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientHeader.tsx
@@ -168,7 +168,6 @@ export const LongviewClientHeader: React.FC<CombinedProps> = props => {
           to={`/longview/clients/${clientID}`}
           linkText="View details"
           className={classes.link}
-          secondary
         />
         {!loading && (
           <div className={classes.lastUpdatedOuter}>

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
@@ -81,13 +81,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     [theme.breakpoints.down(1100)]: {
       marginRight: theme.spacing(2)
     }
-  },
-  addNewButton: {
-    '&:hover': {
-      '& svg': {
-        color: '#fff'
-      }
-    }
   }
 }));
 
@@ -314,7 +307,6 @@ export const LongviewClients: React.FC<CombinedProps> = props => {
         >
           <AddNewLink
             onClick={handleAddClient}
-            className={classes.addNewButton}
             label={newClientLoading ? 'Loading...' : 'Add a Client'}
             disabled={!userCanCreateClient}
             disabledReason={

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
@@ -81,6 +81,13 @@ const useStyles = makeStyles((theme: Theme) => ({
     [theme.breakpoints.down(1100)]: {
       marginRight: theme.spacing(2)
     }
+  },
+  addNewButton: {
+    '&:hover': {
+      '& svg': {
+        color: '#fff'
+      }
+    }
   }
 }));
 
@@ -307,6 +314,7 @@ export const LongviewClients: React.FC<CombinedProps> = props => {
         >
           <AddNewLink
             onClick={handleAddClient}
+            className={classes.addNewButton}
             label={newClientLoading ? 'Loading...' : 'Add a Client'}
             disabled={!userCanCreateClient}
             disabledReason={

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewDeleteDialog.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewDeleteDialog.tsx
@@ -91,7 +91,7 @@ const Actions: React.FC<ActionsProps> = props => {
         onClick={props.onSubmit}
         loading={props.isDeleting}
         destructive
-        buttonType="secondary"
+        buttonType="primary"
         data-testid="delete-button"
       >
         Delete

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -987,7 +987,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                       {(forEdit || configIdx !== 0) && (
                         <Button
                           onClick={this.props.onDelete}
-                          buttonType="secondary"
+                          buttonType="primary"
                           destructive
                           data-qa-delete-config
                           disabled={disabled}

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -490,7 +490,7 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
       <Button
         data-qa-confirm-cancel
         onClick={this.onRemoveConfig}
-        buttonType="secondary"
+        buttonType="primary"
         destructive
         loading={this.state.deleteConfigConfirmDialog.submitting}
       >

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerConfigurations.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerConfigurations.tsx
@@ -1088,7 +1088,7 @@ class NodeBalancerConfigurations extends React.Component<CombinedProps, State> {
       <Button
         data-qa-confirm-cancel
         onClick={this.deleteConfig}
-        buttonType="secondary"
+        buttonType="primary"
         destructive
         loading={this.state.deleteConfigConfirmDialog.submitting}
       >

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancerTableRow_CMR.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancerTableRow_CMR.tsx
@@ -31,7 +31,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     fontFamily: theme.font.bold,
     color: theme.cmrTextColors.linkActiveLight,
     lineHeight: '1.125rem',
-    textDecoration: 'underline'
+    '&:hover, &:focus': {
+      textDecoration: 'underline'
+    }
   },
   ipsWrapper: {
     display: 'inline-flex',

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.tsx
@@ -429,7 +429,7 @@ export class NodeBalancersLanding extends React.Component<
         <Button
           data-qa-confirm-cancel
           onClick={this.onSubmitDelete}
-          buttonType="secondary"
+          buttonType="primary"
           destructive
           loading={this.state.deleteConfirmDialog.submitting}
         >

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable_CMR.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable_CMR.tsx
@@ -51,9 +51,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
     marginLeft: theme.spacing(1)
   },
-  label: {
-    color: theme.cmrTextColors.linkActiveLight
-  }
+  label: {}
 }));
 
 interface Props {

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/RevokeAccessKeyDialog.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/RevokeAccessKeyDialog.tsx
@@ -42,7 +42,7 @@ export const RevokeAccessKeyDialog: React.FC<RevokeKeysDialogProps> = props => {
         Cancel
       </Button>
       <Button
-        buttonType="secondary"
+        buttonType="primary"
         destructive
         onClick={handleSubmit}
         loading={isLoading}

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/AccessSelect.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/AccessSelect.tsx
@@ -229,7 +229,7 @@ const AccessSelect: React.FC<CombinedProps> = props => {
             <Button buttonType="cancel" onClick={closeDialog} data-qa-cancel>
               Cancel
             </Button>
-            <Button buttonType="secondary" destructive onClick={handleSubmit}>
+            <Button buttonType="primary" destructive onClick={handleSubmit}>
               Confirm
             </Button>
           </ActionsPanel>

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketBreadcrumb.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketBreadcrumb.tsx
@@ -50,8 +50,11 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginLeft: 4
   },
   link: {
-    color: theme.palette.primary.main,
-    cursor: 'pointer'
+    color: theme.cmrTextColors.linkActiveLight,
+    cursor: 'pointer',
+    '&:hover': {
+      textDecoration: 'underline'
+    }
   },
   copied: {
     fontSize: '.85rem',

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -563,7 +563,7 @@ export class BucketDetail extends React.Component<CombinedProps, State> {
                       Cancel
                     </Button>
                     <Button
-                      buttonType="secondary"
+                      buttonType="primary"
                       destructive
                       onClick={this.deleteObject}
                       data-qa-submit-rebuild

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketSSL.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketSSL.tsx
@@ -227,18 +227,19 @@ export const RemoveCertForm: React.FC<FormProps> = props => {
   const createActions = () => (
     <ActionsPanel>
       <Button
+        disabled={submittingDialog}
+        onClick={() => setOpen(false)}
+        buttonType="cancel"
+      >
+        Cancel
+      </Button>
+      <Button
         loading={submittingDialog}
         onClick={removeCertificate}
         destructive
+        buttonType="primary"
       >
         Remove certificate
-      </Button>
-      <Button
-        disabled={submittingDialog}
-        onClick={() => setOpen(false)}
-        buttonType="secondary"
-      >
-        Cancel
       </Button>
     </ActionsPanel>
   );
@@ -248,7 +249,7 @@ export const RemoveCertForm: React.FC<FormProps> = props => {
         A TLS certificate has already been uploaded for this Bucket. To upload a
         new certificate, remove the current certificate.{` `}
       </Notice>
-      <Button destructive onClick={() => setOpen(true)} buttonType="secondary">
+      <Button destructive onClick={() => setOpen(true)} buttonType="primary">
         Remove Certificate
       </Button>
       <ConfirmationDialog

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableRow_CMR.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableRow_CMR.tsx
@@ -37,7 +37,8 @@ const useStyles = makeStyles((theme: Theme) => ({
     padding: 0
   },
   objectNameButton: {
-    ...theme.applyLinkStyles
+    ...theme.applyLinkStyles,
+    color: theme.cmrTextColors.linkActiveLight
   }
 }));
 

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketActionMenu_CMR.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketActionMenu_CMR.tsx
@@ -17,6 +17,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     minWidth: 'auto',
     padding: '12px 10px',
     whiteSpace: 'nowrap',
+    borderRadius: 0,
     '&:hover, &:focus': {
       backgroundColor: '#3683dc',
       color: '#ffffff'

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketActionMenu_CMR.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketActionMenu_CMR.tsx
@@ -20,13 +20,15 @@ const useStyles = makeStyles((theme: Theme) => ({
     borderRadius: 0,
     '&:hover, &:focus': {
       backgroundColor: '#3683dc',
-      color: '#ffffff'
+      color: '#ffffff',
+      textDecoration: 'none'
     },
     '&[disabled]': {
       color: '#cdd0d5',
       cursor: 'default',
       '&:hover': {
-        backgroundColor: 'inherit'
+        backgroundColor: 'inherit',
+        textDecoration: 'none'
       }
     }
   }

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
@@ -140,7 +140,7 @@ export const BucketLanding: React.FC<CombinedProps> = props => {
         Cancel
       </Button>
       <Button
-        buttonType="secondary"
+        buttonType="primary"
         destructive
         onClick={removeBucket}
         data-qa-submit-rebuild

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow_CMR.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow_CMR.tsx
@@ -36,7 +36,11 @@ const styles = (theme: Theme) =>
       }
     },
     bucketLabel: {
-      color: theme.cmrTextColors.linkActiveLight
+      color: theme.cmrTextColors.linkActiveLight,
+      fontFamily: theme.font.bold,
+      '&:hover, &:focus': {
+        textDecoration: 'underline'
+      }
     }
   });
 

--- a/packages/manager/src/features/Profile/APITokens/APITokenTable.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokenTable.tsx
@@ -648,7 +648,7 @@ export class APITokenTable extends React.Component<CombinedProps, State> {
           Cancel
         </Button>
         <Button
-          buttonType="secondary"
+          buttonType="primary"
           loading={this.state.dialog.submittingDialog}
           destructive
           onClick={this.revokeAction}

--- a/packages/manager/src/features/Profile/APITokens/APITokenTable_CMR.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokenTable_CMR.tsx
@@ -699,7 +699,7 @@ export class APITokenTable extends React.Component<CombinedProps, State> {
           Cancel
         </Button>
         <Button
-          buttonType="secondary"
+          buttonType="primary"
           loading={this.state.dialog.submittingDialog}
           destructive
           onClick={this.revokeAction}

--- a/packages/manager/src/features/Profile/AuthenticationSettings/TwoFactor/DisableTwoFactorDialog.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/TwoFactor/DisableTwoFactorDialog.tsx
@@ -98,7 +98,7 @@ class DialogActions extends React.PureComponent<ActionsProps, {}> {
           Cancel
         </Button>
         <Button
-          buttonType="secondary"
+          buttonType="primary"
           destructive
           loading={this.props.loading}
           onClick={this.handleSubmit}

--- a/packages/manager/src/features/Profile/AuthenticationSettings/TwoFactor/TwoFactor.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/TwoFactor/TwoFactor.tsx
@@ -233,7 +233,7 @@ export const TwoFactor: React.FC<CombinedProps> = props => {
                   <div className={classes.container}>
                     {showQRCode ? (
                       <Button
-                        buttonType="secondary"
+                        buttonType="primary"
                         className={classes.visibility}
                         onClick={toggleHidden}
                         destructive

--- a/packages/manager/src/features/Profile/OAuthClients/Modals.tsx
+++ b/packages/manager/src/features/Profile/OAuthClients/Modals.tsx
@@ -123,7 +123,7 @@ const resetDialogActions = ({
         </Button>
         <Button
           destructive
-          buttonType="secondary"
+          buttonType="primary"
           onClick={resetSecret}
           data-qa-button-confirm
           loading={loading}
@@ -158,7 +158,7 @@ const deleteDialogActions = ({
         </Button>
         <Button
           destructive
-          buttonType="secondary"
+          buttonType="primary"
           onClick={deleteSecret}
           data-qa-button-confirm
           loading={loading}

--- a/packages/manager/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
@@ -378,7 +378,7 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
           Cancel
         </Button>
         <Button
-          buttonType="secondary"
+          buttonType="primary"
           destructive
           onClick={() => this.resetAllFields(this.state.apiResponse)}
           data-qa-confirm-cancel

--- a/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptPanelContent.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptPanelContent.tsx
@@ -239,7 +239,7 @@ class StackScriptPanelContent extends React.Component<CombinedProps, State> {
           Cancel
         </Button>
         <Button
-          buttonType="secondary"
+          buttonType="primary"
           destructive
           onClick={this.handleMakePublic}
         >
@@ -256,7 +256,7 @@ class StackScriptPanelContent extends React.Component<CombinedProps, State> {
           Cancel
         </Button>
         <Button
-          buttonType="secondary"
+          buttonType="primary"
           destructive
           onClick={this.handleDeleteStackScript}
           loading={this.state.dialog.delete.submitting}

--- a/packages/manager/src/features/StackScripts/StackScriptsDetail.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptsDetail.tsx
@@ -327,7 +327,7 @@ export class StackScriptsDetail extends React.Component<CombinedProps, {}> {
           Cancel
         </Button>
         <Button
-          buttonType="secondary"
+          buttonType="primary"
           destructive
           onClick={this.handleMakePublic}
         >
@@ -344,7 +344,7 @@ export class StackScriptsDetail extends React.Component<CombinedProps, {}> {
           Cancel
         </Button>
         <Button
-          buttonType="secondary"
+          buttonType="primary"
           destructive
           onClick={this.handleDeleteStackScript}
           loading={this.state.dialog.delete.submitting}

--- a/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -1,4 +1,3 @@
-import KeyboardArrowDown from '@material-ui/icons/KeyboardArrowDown';
 import { AccountCapability } from '@linode/api-v4/lib/account';
 
 import {
@@ -50,24 +49,22 @@ const styles = (theme: Theme) =>
     button: {
       '&[data-reach-menu-button]': {
         textTransform: 'inherit',
-        borderRadius: 0,
+        borderRadius: '3px',
         fontSize: '1rem',
         lineHeight: 1,
         fontFamily: theme.spacing() === 4 ? theme.font.normal : theme.font.bold,
         backgroundColor: theme.palette.primary.main,
         color: '#fff',
-        padding: `${theme.spacing() * 2}px ${theme.spacing() * 3 +
-          theme.spacing() / 2}px ${theme.spacing() * 2}px`,
-        maxHeight: 48,
+        padding: `2px 20px`,
+        maxHeight: 34,
         position: 'relative',
-        minHeight: `${theme.spacing(2) + 34}px`,
-        paddingRight: `calc(${theme.spacing(3)}px + 24px)`,
+        minHeight: `34px`,
         cursor: 'pointer',
         border: 'none',
         [theme.breakpoints.down('sm')]: {
-          padding: '6px 34px 7px 11px',
-          maxHeight: 50,
-          minWidth: 105
+          marginLeft: theme.spacing(),
+          maxHeight: 34,
+          minWidth: 100
         },
         '&:hover': {
           backgroundColor: theme.palette.primary.light
@@ -76,10 +73,7 @@ const styles = (theme: Theme) =>
           backgroundColor: theme.palette.primary.light
         },
         '&[aria-expanded="true"]': {
-          backgroundColor: theme.palette.primary.light,
-          '& $caret': {
-            transform: 'rotate(180deg)'
-          }
+          backgroundColor: theme.palette.primary.light
         }
       }
     },
@@ -140,8 +134,7 @@ class AddNewMenu extends React.Component<CombinedProps> {
       <div className={classes.wrapper}>
         <Menu>
           <MenuButton className={classes.button} data-qa-add-new-menu-button>
-            Create
-            <KeyboardArrowDown className={classes.caret} />
+            Create...
           </MenuButton>
           <MenuPopover className={classes.menuPopover} portal={false}>
             <MenuItems className={classes.menuItemList}>

--- a/packages/manager/src/features/TopMenu/UserMenu/UserMenu_CMR.tsx
+++ b/packages/manager/src/features/TopMenu/UserMenu/UserMenu_CMR.tsx
@@ -122,10 +122,12 @@ const useStyles = makeStyles((theme: Theme) => ({
       fontSize: '1rem',
       padding: '12px 40px 12px 15px',
       '&:hover': {
-        backgroundColor: theme.cmrBGColors.bgPrimaryNavActive
+        backgroundColor: theme.cmrBGColors.bgPrimaryNavActive,
+        textDecoration: 'none'
       },
       '&:focus': {
-        backgroundColor: theme.cmrBGColors.bgPrimaryNavActive
+        backgroundColor: theme.cmrBGColors.bgPrimaryNavActive,
+        textDecoration: 'none'
       }
     },
     '&[data-reach-menu-item][data-selected]': {

--- a/packages/manager/src/features/Users/UserDeleteConfirmationDialog.tsx
+++ b/packages/manager/src/features/Users/UserDeleteConfirmationDialog.tsx
@@ -26,9 +26,7 @@ class UserDeleteConfirmationDialog extends React.PureComponent<
         actions={this.renderActionsPanel}
         open={this.props.open}
       >
-        {`User ${
-          this.props.username
-        } will be permanently deleted. Are you sure?`}
+        {`User ${this.props.username} will be permanently deleted. Are you sure?`}
       </ConfirmationDialog>
     );
   }
@@ -44,7 +42,7 @@ class UserDeleteConfirmationDialog extends React.PureComponent<
           Cancel
         </Button>
         <Button
-          buttonType="secondary"
+          buttonType="primary"
           destructive
           onClick={this.deleteUser}
           data-qa-confirm-delete

--- a/packages/manager/src/features/Users/UserProfile.tsx
+++ b/packages/manager/src/features/Users/UserProfile.tsx
@@ -258,7 +258,7 @@ class UserProfile extends React.Component<CombinedProps> {
           <Button
             disabled={profileUsername === toDeleteUsername}
             className={classes.topMargin}
-            buttonType="secondary"
+            buttonType="primary"
             destructive
             onClick={this.onDelete}
             data-qa-confirm-delete

--- a/packages/manager/src/features/Vlans/DetachLinodeDialog/DetachLinodeDialog.tsx
+++ b/packages/manager/src/features/Vlans/DetachLinodeDialog/DetachLinodeDialog.tsx
@@ -86,7 +86,7 @@ const Actions: React.FC<ActionsProps> = props => {
         onClick={props.onSubmit}
         loading={props.isSubmitting}
         destructive
-        buttonType="secondary"
+        buttonType="primary"
       >
         Detach
       </Button>

--- a/packages/manager/src/features/Vlans/VlanLanding/VlanDialog.tsx
+++ b/packages/manager/src/features/Vlans/VlanLanding/VlanDialog.tsx
@@ -102,7 +102,7 @@ const Actions: React.FC<ActionsProps> = props => {
         onClick={props.onSubmit}
         loading={props.isSubmitting}
         destructive
-        buttonType="secondary"
+        buttonType="primary"
       >
         Delete
       </Button>

--- a/packages/manager/src/features/Vlans/VlanLanding/VlanRow.tsx
+++ b/packages/manager/src/features/Vlans/VlanLanding/VlanRow.tsx
@@ -14,7 +14,10 @@ const useStyles = makeStyles((theme: Theme) => ({
     display: 'block',
     fontFamily: theme.font.bold,
     fontSize: '.875rem',
-    lineHeight: '1.14rem'
+    lineHeight: '1.14rem',
+    '&:hover, &:focus': {
+      textDecoration: 'underline'
+    }
   },
   linodesWrapper: {
     padding: '8px 0'

--- a/packages/manager/src/features/Vlans/VlanLanding/VlanRow.tsx
+++ b/packages/manager/src/features/Vlans/VlanLanding/VlanRow.tsx
@@ -13,6 +13,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   link: {
     display: 'block',
     fontFamily: theme.font.bold,
+    color: theme.cmrTextColors.linkActiveLight,
     fontSize: '.875rem',
     lineHeight: '1.14rem',
     '&:hover, &:focus': {

--- a/packages/manager/src/features/Volumes/DestructiveVolumeDialog.tsx
+++ b/packages/manager/src/features/Volumes/DestructiveVolumeDialog.tsx
@@ -53,7 +53,7 @@ class DestructiveVolumeDialog extends React.PureComponent<CombinedProps, {}> {
           Cancel
         </Button>
         <Button
-          buttonType="secondary"
+          buttonType="primary"
           destructive
           onClick={method}
           data-qa-confirm

--- a/packages/manager/src/features/Volumes/VolumeAttachmentDrawer.tsx
+++ b/packages/manager/src/features/Volumes/VolumeAttachmentDrawer.tsx
@@ -232,7 +232,7 @@ class VolumeAttachmentDrawer extends React.Component<CombinedProps, State> {
           >
             Save
           </Button>
-          <Button onClick={this.handleClose} data-qa-cancel>
+          <Button onClick={this.handleClose} buttonType="cancel" data-qa-cancel>
             Cancel
           </Button>
         </ActionsPanel>

--- a/packages/manager/src/features/Volumes/VolumesActionMenu_CMR.tsx
+++ b/packages/manager/src/features/Volumes/VolumesActionMenu_CMR.tsx
@@ -29,13 +29,14 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   button: {
     ...theme.applyLinkStyles,
+    color: theme.cmrTextColors.linkActiveLight,
     height: '100%',
     padding: '12px 15px',
     minWidth: 'auto',
     borderRadius: 0,
     '&:hover, &:focus': {
       backgroundColor: theme.palette.primary.main,
-      color: theme.color.white,
+      color: '#fff',
       textDecoration: 'none'
     }
   }

--- a/packages/manager/src/features/Volumes/VolumesActionMenu_CMR.tsx
+++ b/packages/manager/src/features/Volumes/VolumesActionMenu_CMR.tsx
@@ -32,9 +32,11 @@ const useStyles = makeStyles((theme: Theme) => ({
     height: '100%',
     padding: '12px 15px',
     minWidth: 'auto',
-    '&:hover': {
+    borderRadius: 0,
+    '&:hover, &:focus': {
       backgroundColor: theme.palette.primary.main,
-      color: theme.color.white
+      color: theme.color.white,
+      textDecoration: 'none'
     }
   }
 }));

--- a/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
+++ b/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
@@ -697,7 +697,10 @@ const useFooterStyles = makeStyles((theme: Theme) => ({
     lineHeight: 1,
     '& a': {
       color: theme.color.blue,
-      fontFamily: theme.font.bold
+      fontFamily: theme.font.bold,
+      '&:hover, &:focus': {
+        textDecoration: 'underline'
+      }
     }
   },
   listItem: {
@@ -716,10 +719,7 @@ const useFooterStyles = makeStyles((theme: Theme) => ({
     padding: `0px 10px`,
     borderRight: `1px solid ${theme.cmrBorderColors.borderTypography}`,
     fontSize: '.875rem',
-    fontWeight: 'bold',
-    '&:hover': {
-      textDecoration: 'none'
-    }
+    fontWeight: 'bold'
   },
   linodeCreated: {
     paddingLeft: 10,

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs.tsx
@@ -152,7 +152,7 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
         Cancel
       </Button>
       <Button
-        buttonType="secondary"
+        buttonType="primary"
         destructive
         loading={this.state.confirmDelete.submitting}
         onClick={this.deleteConfig}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs_CMR.tsx
@@ -322,7 +322,7 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
         Cancel
       </Button>
       <Button
-        buttonType="secondary"
+        buttonType="primary"
         destructive
         loading={this.state.confirmDelete.submitting}
         onClick={this.deleteConfig}
@@ -343,7 +343,7 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
         Cancel
       </Button>
       <Button
-        buttonType="secondary"
+        buttonType="primary"
         destructive
         loading={this.state.confirmBoot.submitting}
         onClick={this.handleBoot}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskActionMenu_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskActionMenu_CMR.tsx
@@ -27,6 +27,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     height: '100%',
     padding: '12px 15px',
     minWidth: 'auto',
+    borderRadius: 0,
     '&:hover': {
       backgroundColor: theme.palette.primary.main,
       color: '#ffffff'

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks.tsx
@@ -291,7 +291,7 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
           Cancel
         </Button>
         <Button
-          buttonType="secondary"
+          buttonType="primary"
           destructive
           loading={submitting}
           onClick={this.deleteDisk}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks_CMR.tsx
@@ -327,7 +327,7 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
           Cancel
         </Button>
         <Button
-          buttonType="secondary"
+          buttonType="primary"
           destructive
           loading={submitting}
           onClick={this.deleteDisk}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/DestructiveSnapshotDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/DestructiveSnapshotDialog.tsx
@@ -38,7 +38,7 @@ class DestructiveSnapshotDialog extends React.PureComponent<CombinedProps, {}> {
           Cancel
         </Button>
         <Button
-          buttonType="secondary"
+          buttonType="primary"
           destructive
           onClick={this.props.onSnapshot}
           data-qa-confirm

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -792,7 +792,7 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
         <this.SnapshotForm />
         <this.SettingsForm />
         <Button
-          buttonType="secondary"
+          buttonType="primary"
           destructive
           className={classes.cancelButton}
           onClick={this.handleOpenBackupsAlert}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup_CMR.tsx
@@ -718,7 +718,7 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
         <this.SnapshotForm />
         <this.SettingsForm />
         <Button
-          buttonType="secondary"
+          buttonType="primary"
           destructive
           className={classes.cancelButton}
           onClick={this.handleOpenBackupsAlert}
@@ -775,7 +775,7 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
           Close
         </Button>
         <Button
-          buttonType="secondary"
+          buttonType="primary"
           destructive
           onClick={this.cancelBackups}
           data-qa-confirm-cancel

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/DeleteIPActions.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/DeleteIPActions.tsx
@@ -30,7 +30,7 @@ class DeleteIPActions extends React.PureComponent<CombinedProps> {
           Cancel
         </Button>
         <Button
-          buttonType="secondary"
+          buttonType="primary"
           destructive
           onClick={this.handleDeleteIP}
           loading={loading}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking_CMR.tsx
@@ -648,12 +648,14 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
               <Button
                 style={{ paddingTop: 5, paddingBottom: 5 }}
                 onClick={this.openTransferDialog}
+                buttonType="secondary"
               >
                 IP Transfer
               </Button>
               <Button
                 style={{ paddingTop: 5, paddingBottom: 5 }}
                 onClick={this.openSharingDialog}
+                buttonType="secondary"
               >
                 IP Sharing
               </Button>
@@ -665,12 +667,14 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
                 <Button
                   style={{ padding: '16px 14px' }}
                   onClick={this.openTransferDialog}
+                  buttonType="secondary"
                 >
                   IP Transfer
                 </Button>
                 <Button
                   style={{ padding: '16px 28px 16px 14px' }}
                   onClick={this.openSharingDialog}
+                  buttonType="secondary"
                 >
                   IP Sharing
                 </Button>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/VLANPanel/RemoveVlanDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/VLANPanel/RemoveVlanDialog.tsx
@@ -101,7 +101,7 @@ const Actions: React.FC<ActionsProps> = props => {
         onClick={props.onSubmit}
         loading={props.isSubmitting}
         destructive
-        buttonType="secondary"
+        buttonType="primary"
       >
         Remove
       </Button>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildDialog.tsx
@@ -21,7 +21,7 @@ export const RebuildDialog: React.FC<RebuildDialogProps> = props => {
         Cancel
       </Button>
       <Button
-        buttonType="secondary"
+        buttonType="primary"
         destructive
         onClick={handleSubmit}
         data-qa-submit-rebuild

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
@@ -207,7 +207,7 @@ export const RebuildFromImage: React.FC<CombinedProps> = props => {
             </form>
             <ActionsPanel>
               <Button
-                buttonType="secondary"
+                buttonType="primary"
                 className="destructive"
                 onClick={handleRebuildButtonClick}
                 data-testid="rebuild-button"

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage_CMR.tsx
@@ -209,7 +209,7 @@ export const RebuildFromImage: React.FC<CombinedProps> = props => {
                 />
                 <Button
                   disabled={submitButtonDisabled || disabled}
-                  buttonType="secondary"
+                  buttonType="primary"
                   className="destructive"
                   onClick={handleRebuildButtonClick}
                   data-testid="rebuild-button"

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.tsx
@@ -357,7 +357,7 @@ export const RebuildFromStackScript: React.FC<CombinedProps> = props => {
             </form>
             <ActionsPanel>
               <Button
-                buttonType="secondary"
+                buttonType="primary"
                 className="destructive"
                 onClick={handleRebuildButtonClick}
                 data-qa-rebuild

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript_CMR.tsx
@@ -361,7 +361,7 @@ export const RebuildFromStackScript: React.FC<CombinedProps> = props => {
                 />
                 <Button
                   disabled={submitButtonDisabled}
-                  buttonType="secondary"
+                  buttonType="primary"
                   className="destructive"
                   onClick={handleRebuildButtonClick}
                   data-qa-rebuild

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsDeletePanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsDeletePanel.tsx
@@ -71,7 +71,7 @@ class LinodeSettingsDeletePanel extends React.Component<CombinedProps, State> {
       <React.Fragment>
         <Accordion heading="Delete Linode">
           <Button
-            buttonType="secondary"
+            buttonType="primary"
             destructive
             style={{ marginBottom: 8 }}
             onClick={this.openDeleteDialog}
@@ -110,7 +110,7 @@ class LinodeSettingsDeletePanel extends React.Component<CombinedProps, State> {
         Cancel
       </Button>
       <Button
-        buttonType="secondary"
+        buttonType="primary"
         destructive
         onClick={this.deleteLinode}
         data-qa-confirm-delete

--- a/packages/manager/src/features/linodes/LinodesLanding/DeleteDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/DeleteDialog.tsx
@@ -87,7 +87,7 @@ const Actions: React.FC<ActionsProps> = props => {
         onClick={props.onSubmit}
         loading={props.loading}
         destructive
-        buttonType="secondary"
+        buttonType="primary"
       >
         Delete
       </Button>

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell_CMR.tsx
@@ -20,8 +20,10 @@ const useStyles = makeStyles((theme: Theme) => ({
     fontFamily: theme.font.bold,
     fontSize: '.875rem',
     lineHeight: '1.125rem',
-    textDecoration: 'underline',
-    color: theme.cmrTextColors.linkActiveLight
+    color: theme.cmrTextColors.linkActiveLight,
+    '&:hover, &:focus': {
+      textDecoration: 'underline'
+    }
   },
   root: {
     '& h3': {

--- a/packages/manager/src/features/linodes/PowerActionsDialogOrDrawer.tsx
+++ b/packages/manager/src/features/linodes/PowerActionsDialogOrDrawer.tsx
@@ -200,14 +200,7 @@ const Actions: React.FC<ActionsProps> = props => {
       <Button
         onClick={props.onSubmit}
         loading={props.loading}
-        destructive={
-          ['Power On', 'Reboot'].includes(props.action) ? false : true
-        }
-        buttonType={
-          ['Power On', 'Reboot'].includes(props.action)
-            ? 'primary'
-            : 'secondary'
-        }
+        buttonType="primary"
       >
         {props.action}
       </Button>

--- a/packages/manager/src/index.css
+++ b/packages/manager/src/index.css
@@ -169,6 +169,11 @@ a {
   cursor: pointer;
 }
 
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
 a.h-u:hover {
   text-decoration: underline;
 }

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -535,7 +535,6 @@ const themeDefaults: ThemeDefaults = ({ spacingOverride: spacingUnit }) => {
         },
         root: {
           textTransform: 'inherit',
-          borderRadius: '3px',
           fontSize: '1rem',
           lineHeight: 1,
           fontFamily:
@@ -554,10 +553,8 @@ const themeDefaults: ThemeDefaults = ({ spacingOverride: spacingUnit }) => {
             minWidth: 100
           },
           '&:hover': {
-            backgroundColor: primaryColors.light
-          },
-          '&:focus': {
-            backgroundColor: primaryColors.light
+            backgroundColor: primaryColors.light,
+            color: '#fff'
           },
           '&[aria-expanded="true"]': {
             backgroundColor: primaryColors.light
@@ -569,15 +566,16 @@ const themeDefaults: ThemeDefaults = ({ spacingOverride: spacingUnit }) => {
             color: primaryColors.text
           }
         },
-        text: {
-          padding: `${spacingUnit * 2}px ${spacingUnit * 3 +
-            spacingUnit / 2}px ${spacingUnit * 2}px`,
-          '&:hover': {
-            color: primaryColors.light
-          }
-        },
+        // text: {
+        //   padding: `${spacingUnit * 2}px ${spacingUnit * 3 +
+        //     spacingUnit / 2}px ${spacingUnit * 2}px`,
+        //   '&:hover': {
+        //     color: primaryColors.light
+        //   }
+        // },
         containedPrimary: {
           backgroundColor: primaryColors.main,
+          borderRadius: '3px',
           color: '#fff',
           padding: `2px 20px`,
           maxHeight: 34,
@@ -604,7 +602,7 @@ const themeDefaults: ThemeDefaults = ({ spacingOverride: spacingUnit }) => {
         containedSecondary: {
           backgroundColor: 'transparent',
           color: primaryColors.main,
-          border: `1px solid ${primaryColors.main}`,
+          //border: `1px solid ${primaryColors.main}`,
           // padding: `${spacingUnit * 2 - 1}px ${spacingUnit * 3 +
           //   spacingUnit / 2}px ${spacingUnit * 2 - 1}px`,
           // transition: 'border 225ms ease-in-out, color 225ms ease-in-out',
@@ -623,31 +621,30 @@ const themeDefaults: ThemeDefaults = ({ spacingOverride: spacingUnit }) => {
             backgroundColor: 'transparent',
             color: '#c9cacb'
           },
-          '&.cancel': {
-            borderColor: 'transparent',
-            '&:hover, &:focus': {
-              borderColor: primaryColors.light,
-              backgroundColor: 'transparent'
-            }
-          },
-          '&.destructive': {
-            borderColor: '#c44742',
-            color: '#c44742',
-            '&:hover, &:focus': {
-              color: '#df6560',
-              borderColor: '#df6560',
-              backgroundColor: 'transparent'
-            },
-            '&:active': {
-              color: '#963530',
-              borderColor: '#963530'
-            },
-            '&$disabled': {
-              borderColor: '#c9cacb',
-              backgroundColor: 'transparent',
-              color: '#c9cacb'
-            }
-          },
+          // '&.cancel': {
+          //   borderColor: 'transparent',
+          //   '&:hover, &:focus': {
+          //     borderColor: primaryColors.light,
+          //     backgroundColor: 'transparent'
+          //   }
+          // },
+          // '&.destructive': {
+          //   backgroundColor: primaryColors.main,
+          //   color: '#fff',
+          //   '&:hover, &:focus': {
+          //     color: '#fff',
+          //     backgroundColor: primaryColors.light
+          //   },
+          //   '&:active': {
+          //     color: '#963530',
+          //     borderColor: '#963530'
+          //   },
+          //   '&$disabled': {
+          //     borderColor: '#c9cacb',
+          //     backgroundColor: 'transparent',
+          //     color: '#c9cacb'
+          //   }
+          // },
           '&.loading': {
             borderColor: primaryColors.text,
             color: primaryColors.text,

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -1551,17 +1551,13 @@ const themeDefaults: ThemeDefaults = ({ spacingOverride: spacingUnit }) => {
           '&$colorSecondary': {
             backgroundColor: 'transparent',
             color: primaryColors.main,
-            border: `1px solid ${primaryColors.main}`,
-            transition: 'border 225ms ease-in-out, color 225ms ease-in-out',
             '&:hover, &:focus': {
               backgroundColor: 'transparent !important',
-              color: primaryColors.light,
-              borderColor: primaryColors.light
+              color: primaryColors.light
             },
             '&:active': {
               backgroundColor: 'transparent',
-              color: primaryColors.light,
-              borderColor: primaryColors.light
+              color: primaryColors.light
             }
           }
         }

--- a/packages/manager/src/themes.ts
+++ b/packages/manager/src/themes.ts
@@ -287,11 +287,11 @@ const darkThemeOptions = {
           color: primaryColors.text
         }
       },
-      text: {
-        '&:hover': {
-          backgroundColor: 'transparent'
-        }
-      },
+      // text: {
+      //   '&:hover': {
+      //     backgroundColor: 'transparent'
+      //   }
+      // },
       containedPrimary: {
         '&:hover, &:focus': {
           backgroundColor: primaryColors.light
@@ -332,19 +332,19 @@ const darkThemeOptions = {
             borderColor: primaryColors.light
           }
         },
-        '&.destructive': {
-          borderColor: '#c44742',
-          color: '#c44742',
-          '&:hover, &:focus': {
-            color: '#df6560',
-            borderColor: '#df6560',
-            backgroundColor: 'transparent'
-          },
-          '&:active': {
-            color: '#963530',
-            borderColor: '#963530'
-          }
-        },
+        // '&.destructive': {
+        //   borderColor: '#c44742',
+        //   color: '#c44742',
+        //   '&:hover, &:focus': {
+        //     color: '#df6560',
+        //     borderColor: '#df6560',
+        //     backgroundColor: 'transparent'
+        //   },
+        //   '&:active': {
+        //     color: '#963530',
+        //     borderColor: '#963530'
+        //   }
+        // },
         '&.loading': {
           borderColor: primaryColors.text,
           color: primaryColors.text,

--- a/packages/manager/src/themes.ts
+++ b/packages/manager/src/themes.ts
@@ -313,17 +313,14 @@ const darkThemeOptions = {
       },
       containedSecondary: {
         color: primaryColors.main,
-        border: `1px solid ${primaryColors.main}`,
         '&:hover, &:focus': {
-          color: primaryColors.light,
-          borderColor: primaryColors.light
+          color: primaryColors.light
         },
         '&:active': {
           color: primaryColors.dark,
           borderColor: primaryColors.dark
         },
         '&$disabled': {
-          borderColor: '#c9cacb',
           color: '#c9cacb'
         },
         '&.cancel': {
@@ -346,7 +343,6 @@ const darkThemeOptions = {
         //   }
         // },
         '&.loading': {
-          borderColor: primaryColors.text,
           color: primaryColors.text,
           minWidth: 100,
           '& svg': {


### PR DESCRIPTION
## Description

Major changes here, impacting **BOTH** CMR and non-CMR:

• Removal of destruction/cancel styling (no more red- more on this below)
• Adding underline to regular links on hover

There should now be **3 types of buttons**:
• primary (blue bg, white text, rounded corners)
• secondary (bolded, blue text, no border)
• secondary w/ icon
Since we got rid of the red destructive styling, those buttons now inherit as primary buttons, and 'cancel' inherit as secondary buttons.

## Type of Change
- Non breaking change ('change')

## Note to Reviewers

Please comb through the app, both versions, both color themes, for discrepancies. I was pretty thorough but there's so much going on it's likely I missed something. Also let me know if you'd like me to delete the commented out styling in the theme files- I kept it for now in case it was needed but would help with cleaning up the code a bit more.
