### PR TITLE
Add fallback template function in webpack config

### DIFF
--- a/packages/manager/config/webpack.config.dev.js
+++ b/packages/manager/config/webpack.config.dev.js
@@ -74,8 +74,20 @@ module.exports = {
     // This is the URL that app is served from. We use "/" in development.
     publicPath,
     // Point sourcemap entries to original disk location (format as URL on Windows)
-    devtoolModuleFilenameTemplate: info =>
-      path.resolve(info.absoluteResourcePath).replace(/\\/g, '/')
+    devtoolModuleFilenameTemplate: info => {
+      return path
+        .relative(paths.appSrc, info.absoluteResourcePath)
+        .replace(/\\/g, '/');
+    },
+    // Our CSS loader chain results in duplicates for some files. It's unclear
+    // to me why this is happening, but we use this fallback template function
+    // to correct the sourcemaps for these files.
+    devtoolFallbackModuleFilenameTemplate: info => {
+      const filePath = path
+        .relative(paths.appSrc, info.absoluteResourcePath)
+        .replace(/\\/g, '/');
+      return `${filePath}?${info.hash}`;
+    }
   },
   resolve: {
     // This allows you to set a fallback for where Webpack should look for modules.

--- a/packages/manager/config/webpack.config.prod.js
+++ b/packages/manager/config/webpack.config.prod.js
@@ -62,8 +62,20 @@ module.exports = {
     // We inferred the "public path" (such as / or /my-project) from homepage.
     publicPath,
     // Point sourcemap entries to original disk location (format as URL on Windows)
-    devtoolModuleFilenameTemplate: info =>
-      path.relative(paths.appSrc, info.absoluteResourcePath).replace(/\\/g, '/')
+    devtoolModuleFilenameTemplate: info => {
+      return path
+        .relative(paths.appSrc, info.absoluteResourcePath)
+        .replace(/\\/g, '/');
+    },
+    // Our CSS loader chain results in duplicates for some files. It's unclear
+    // to me why this is happening, but we use this fallback template function
+    // to correct the sourcemaps for these files.
+    devtoolFallbackModuleFilenameTemplate: info => {
+      const filePath = path
+        .relative(paths.appSrc, info.absoluteResourcePath)
+        .replace(/\\/g, '/');
+      return `${filePath}?${info.hash}`;
+    }
   },
   resolve: {
     // This allows you to set a fallback for where Webpack should look for modules.


### PR DESCRIPTION
This fixes an issue where a few CSS source map files were being duplicated during our webpack builds. I'm not sure of the root cause here (something to do with css-loader + style-loader and the way we're importing the files, maybe), but this at least cleans up the source map names.