### PR TITLE
M3-4673 Change: try to speed up Longview Landing

### DIFF
--- a/packages/manager/src/components/PaginationFooter/PaginationFooter.tsx
+++ b/packages/manager/src/components/PaginationFooter/PaginationFooter.tsx
@@ -30,6 +30,7 @@ export interface PaginationProps {
   pageSize: number;
   eventCategory: string;
   showAll?: boolean;
+  fixedSize?: boolean;
 }
 
 interface Props extends PaginationProps {
@@ -56,6 +57,7 @@ class PaginationFooter extends React.PureComponent<CombinedProps> {
     const {
       classes,
       count,
+      fixedSize,
       page,
       pageSize,
       handlePageChange,
@@ -64,7 +66,7 @@ class PaginationFooter extends React.PureComponent<CombinedProps> {
       showAll
     } = this.props;
 
-    if (count <= MIN_PAGE_SIZE) {
+    if (count <= MIN_PAGE_SIZE && !fixedSize) {
       return null;
     }
 
@@ -102,19 +104,21 @@ class PaginationFooter extends React.PureComponent<CombinedProps> {
             />
           )}
         </Grid>
-        <Grid item>
-          <Select
-            options={finalOptions}
-            defaultValue={defaultPagination}
-            onChange={this.handleSizeChange}
-            label="Number of items to show"
-            hideLabel
-            isClearable={false}
-            noMarginTop
-            menuPlacement="top"
-            medium
-          />
-        </Grid>
+        {!fixedSize ? (
+          <Grid item>
+            <Select
+              options={finalOptions}
+              defaultValue={defaultPagination}
+              onChange={this.handleSizeChange}
+              label="Number of items to show"
+              hideLabel
+              isClearable={false}
+              noMarginTop
+              menuPlacement="top"
+              medium
+            />
+          </Grid>
+        ) : null}
       </Grid>
     );
   }

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
@@ -100,6 +100,7 @@ export type CombinedProps = Props &
 type SortKey = 'name' | 'cpu' | 'ram' | 'swap' | 'load' | 'network' | 'storage';
 
 export const LongviewClients: React.FC<CombinedProps> = props => {
+  const { getLongviewClients } = props;
   const [newClientLoading, setNewClientLoading] = React.useState<boolean>(
     false
   );
@@ -158,17 +159,14 @@ export const LongviewClients: React.FC<CombinedProps> = props => {
   const flags = useFlags();
 
   React.useEffect(() => {
-    props.getLongviewClients();
-  }, []);
+    getLongviewClients();
+  }, [getLongviewClients]);
 
-  const openDeleteDialog = React.useCallback(
-    (id: number, label: string) => {
-      toggleDeleteDialog(true);
-      setClientID(id);
-      setClientLabel(label);
-    },
-    [selectedClientID, selectedClientLabel]
-  );
+  const openDeleteDialog = React.useCallback((id: number, label: string) => {
+    toggleDeleteDialog(true);
+    setClientID(id);
+    setClientLabel(label);
+  }, []);
 
   const handleSubmit = () => {
     const {
@@ -207,8 +205,8 @@ export const LongviewClients: React.FC<CombinedProps> = props => {
               'Error creating Longview client.'
             )[0].reason,
             { variant: 'error' }
-          ),
-            setNewClientLoading(false);
+          );
+          setNewClientLoading(false);
         }
       });
   };
@@ -219,14 +217,11 @@ export const LongviewClients: React.FC<CombinedProps> = props => {
    */
   const [drawerOpen, setDrawerOpen] = React.useState<boolean>(false);
 
-  const handleDrawerOpen = React.useCallback(
-    (id: number, label: string) => {
-      setClientID(id);
-      setClientLabel(label);
-      setDrawerOpen(true);
-    },
-    [selectedClientID, selectedClientLabel]
-  );
+  const handleDrawerOpen = React.useCallback((id: number, label: string) => {
+    setClientID(id);
+    setClientLabel(label);
+    setDrawerOpen(true);
+  }, []);
 
   const {
     longviewClientsData,

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewList.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewList.tsx
@@ -115,7 +115,7 @@ const LongviewList: React.FC<CombinedProps> = props => {
   return (
     // Don't use the value from local storage for this case,
     // since displaying a large number of client rows has performance impacts.
-    <Paginate data={filteredData} pageSize={25}>
+    <Paginate data={filteredData} pageSize={5}>
       {({
         data: paginatedAndOrderedData,
         count,
@@ -139,6 +139,7 @@ const LongviewList: React.FC<CombinedProps> = props => {
             page={page}
             pageSize={pageSize}
             eventCategory="Longview Table"
+            fixedSize
           />
         </>
       )}

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewList.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewList.tsx
@@ -113,36 +113,36 @@ const LongviewList: React.FC<CombinedProps> = props => {
   }
 
   return (
-    <React.Fragment>
-      <Paginate data={filteredData}>
-        {({
-          data: paginatedAndOrderedData,
-          count,
-          handlePageChange,
-          handlePageSizeChange,
-          page,
-          pageSize
-        }) => (
-          <>
-            <Box flexDirection="column">
-              <LongviewRows
-                longviewClientsData={paginatedAndOrderedData}
-                triggerDeleteLongviewClient={triggerDeleteLongviewClient}
-                openPackageDrawer={openPackageDrawer}
-              />
-            </Box>
-            <PaginationFooter
-              count={count}
-              handlePageChange={handlePageChange}
-              handleSizeChange={handlePageSizeChange}
-              page={page}
-              pageSize={pageSize}
-              eventCategory="Longview Table"
+    // Don't use the value from local storage for this case,
+    // since displaying a large number of client rows has performance impacts.
+    <Paginate data={filteredData} pageSize={25}>
+      {({
+        data: paginatedAndOrderedData,
+        count,
+        handlePageChange,
+        handlePageSizeChange,
+        page,
+        pageSize
+      }) => (
+        <>
+          <Box flexDirection="column">
+            <LongviewRows
+              longviewClientsData={paginatedAndOrderedData}
+              triggerDeleteLongviewClient={triggerDeleteLongviewClient}
+              openPackageDrawer={openPackageDrawer}
             />
-          </>
-        )}
-      </Paginate>
-    </React.Fragment>
+          </Box>
+          <PaginationFooter
+            count={count}
+            handlePageChange={handlePageChange}
+            handleSizeChange={handlePageSizeChange}
+            page={page}
+            pageSize={pageSize}
+            eventCategory="Longview Table"
+          />
+        </>
+      )}
+    </Paginate>
   );
 };
 

--- a/packages/manager/src/features/Longview/shared/useClientLastUpdated.ts
+++ b/packages/manager/src/features/Longview/shared/useClientLastUpdated.ts
@@ -114,7 +114,7 @@ export const useClientLastUpdated = (
         if (document.visibilityState === 'visible') {
           requestAndSetLastUpdated(clientAPIKey);
         }
-      }, 10000);
+      }, 30000);
     });
 
     return () => {


### PR DESCRIPTION
## Description

We've had a few reports of users with large numbers of Longview clients having performance problems on longview landing. This is unsurprising, since we poll the Longview API fairly aggressively for _each client_. I thought maybe paginating this view would help, but it's already paginated. I made a few small changes, none of which I'm thrilled about:

- Ignore user preferences and make the page size 25 on load for the Longview page. 100 clients is ridiculous given the way LV works right now, and unfortunately many of these customers have their account-wide items-per-page preference set to 100.
- Poll for client last updated values less aggressively (every 30 seconds instead of 10)
- General linter and effect clean up

There doesn't seem to be a lot of waste, no runaway effects etc. We're doing what's intended, polling to see when each client has been updated, in which case make the necessary requests to get the data we need to display. There's not much we can do to prevent this from getting out of hand with large client counts. I'd recommend making it a higher priority to revisit Longview.

## Note to Reviewers

You can reach out for info to log in as the customer who reported this issue. Empty Longview clients are easy to create and demonstrate how many requests we're making but aren't a great test of actual performance.