### PR TITLE
UI Minor Fixes

### DIFF
--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/Paypal.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/Paypal.tsx
@@ -55,6 +55,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   paypalButtonWrapper: {
     position: 'relative',
+    left: theme.spacing(),
     zIndex: 1,
     transition: theme.transitions.create(['opacity'])
   },

--- a/packages/manager/src/features/Managed/Credentials/CredentialList_CMR.tsx
+++ b/packages/manager/src/features/Managed/Credentials/CredentialList_CMR.tsx
@@ -65,8 +65,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   actionCell: {
     '&.emptyCell': {
-      fontSize: '0.875em !important',
-      borderTop: '2px solid #f4f5f6'
+      fontSize: '0.875em !important'
     }
   }
 }));


### PR DESCRIPTION
## Description

Some things I noticed when I was combing through the app:
- Paypal button wasn't aligned, 
<img width="180" alt="Screen Shot 2020-11-23 at 1 54 54 PM" src="https://user-images.githubusercontent.com/7692354/100005849-97801f80-2d97-11eb-9eaf-4d5ab2eb4aff.png">

- White border above the ActionMenu cell in Managed / Credentials,
<img width="1116" alt="Screen Shot 2020-11-23 at 2 03 05 PM" src="https://user-images.githubusercontent.com/7692354/100005883-a36be180-2d97-11eb-9926-09c4e4005d5f.png">

## Type of Change
- Non breaking change ('update', 'change')