### PR TITLE
M3-4155: Fix Ada Chatbot overlapping buttons

### DIFF
--- a/packages/manager/src/features/Footer/AdaLink.tsx
+++ b/packages/manager/src/features/Footer/AdaLink.tsx
@@ -42,7 +42,9 @@ const AdaLink: React.FC<CombinedProps> = props => {
      * Script is included in index.html
      */
     if ('AdaChaperone' in window) {
-      ada = new (window as any).AdaChaperone('linode');
+      ada = new (window as any).AdaChaperone('linode', {
+        customStyles: '#topBar > div:nth-child(2) > div { margin-right: 2.5em }'
+      });
     } else {
       setAdaError(
         'There was an issue loading the support bot. Please try again later.'
@@ -79,7 +81,4 @@ const AdaLink: React.FC<CombinedProps> = props => {
 
 const styled = withStyles(styles);
 
-export default compose<CombinedProps, Props>(
-  React.memo,
-  styled
-)(AdaLink);
+export default compose<CombinedProps, Props>(React.memo, styled)(AdaLink);


### PR DESCRIPTION
## Description
Adds some right padding to the "End Chat" button in the Ada chatbot window.

Currently:
<img width="622" alt="Screen Shot 2020-11-23 at 4 33 05 PM" src="https://user-images.githubusercontent.com/32860776/100017937-a2dc4680-2da9-11eb-8033-ec3d9de5e5ff.png">

vs.

This PR:
<img width="622" alt="Screen Shot 2020-11-23 at 4 33 23 PM" src="https://user-images.githubusercontent.com/32860776/100017967-af609f00-2da9-11eb-9965-3bbd5f13c3cf.png">

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers
In figuring out how to target the right element, I realized that [Ada Chaperone has been deprecated](https://github.com/AdaSupport/docs/blob/master/chaperone.md). I'll check for/create a ticket to upgrade to their new [Embed2 script](https://adasupport.github.io/documentation/#introduction) (we never switched to Embed1 so we'll skip that).