### PR TITLE
M3-4677 Resize error

### DIFF
--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -412,12 +412,12 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
 
     if (!isEmpty(gpu)) {
       const programInfo = this.getDisabledClass('gpu') ? (
-        <Typography>
+        <>
           GPU instances are not available in the selected region. Currently
           these plans are only available in {this.getRegionsWithGPU()}.
-        </Typography>
+        </>
       ) : (
-        <Typography>
+        <>
           This is a pilot program for Linode GPU Instances.
           <a
             href="https://www.linode.com/docs/platform/linode-gpu/getting-started-with-gpu/"
@@ -430,7 +430,7 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
           with more information. This program has finite resources and may not
           be available at the time of your request. Some additional verification
           may be required to access these services.
-        </Typography>
+        </>
       );
       tabs.push({
         render: () => {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -229,7 +229,11 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
       })
       .catch(errorResponse => {
         let error: string | JSX.Element = '';
-        if (errorResponse[0].reason.match(/allocated more disk/i)) {
+        const reason = errorResponse[0]?.reason ?? '';
+        if (
+          typeof reason === 'string' &&
+          reason.match(/allocated more disk/i)
+        ) {
           error = (
             <>
               The current disk size of your Linode is too large for the new

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize_CMR.tsx
@@ -399,6 +399,7 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
               tableDisabled ||
               submitButtonDisabled
             }
+            loading={this.state.submitting}
             buttonType="primary"
             onClick={this.onSubmit}
             data-qa-resize

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize_CMR.tsx
@@ -175,7 +175,22 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
       })
       .catch(errorResponse => {
         let error: string | JSX.Element = '';
-        if (errorResponse[0].reason.match(/allocated more disk/i)) {
+        const reason = errorResponse[0]?.reason ?? '';
+        /**
+         * The logic below is to manually intercept a certain
+         * error and add some JSX with a hyperlink to it.
+         *
+         * Unfortunately, we have global error interceptors that
+         * do the same thing, as is the case when your reputation
+         * score is too low to do what you're trying to do.
+         *
+         * If one of those already-intercepted errors comes through here,
+         * it will break the logic (since error[0].reason is not a string).
+         */
+        if (
+          typeof reason === 'string' &&
+          reason.match(/allocated more disk/i)
+        ) {
           error = (
             <Typography>
               The current disk size of your Linode is too large for the new

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize_CMR.tsx
@@ -211,7 +211,8 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
           )[0].reason;
         }
         this.setState({
-          submissionError: error
+          submissionError: error,
+          submitting: false
         });
         // Set to "block: end" since the sticky header would otherwise interfere.
         scrollErrorIntoView(undefined, { block: 'end' });


### PR DESCRIPTION
This is a recent regression. When intercepting the disk size error
message, we forgot that other errors could have already been intercepted
at a higher level (in request.tsx). This is the case for the reputation error,
which can fire if your score is low and you try to resize a Linode.

This adds some special handling to that, and resolves a DOM nesting error
where Typography's got nested inside each other in the GPU tab header of the
SelectPlanPanel.

## Note

Please test all possible errors:

- No error response (block requests to /resize)
- Additional verification required (set your account's reputation to 1)
- Disks too small (try to resize to a smaller plan without resizing disks first)
- CMR and non
- Normal API error (use the service worker)
