### PR TITLE
M3-4672 upgrade y18n

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "property-expr": "^2.0.3",
     "csv-parse": "^4.6.3",
     "node-fetch": "^2.6.1",
-    "bl": "^3.0.1"
+    "bl": "^3.0.1",
+    "y18n": "^4.0.0"
   },
   "workspaces": {
     "packages": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -19507,12 +19507,7 @@ xterm@^4.2.0:
   resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.4.0.tgz#5915d3c4c8800fadbcf555a0a603c672ab9df589"
   integrity sha512-JGIpigWM3EBWvnS3rtBuefkiToIILSK1HYMXy4BCsUpO+O4UeeV+/U1AdAXgCB6qJrnPNb7yLgBsVCQUNMteig==
 
-y18n@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
-  integrity sha1-bRX7qITAhnnA136I53WegR4H+kE=
-
-"y18n@^3.2.1 || ^4.0.0", y18n@^4.0.0:
+y18n@^3.2.1, "y18n@^3.2.1 || ^4.0.0", y18n@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==


### PR DESCRIPTION
## Description

This manually resolves y18n to ^4.0.0.  

## Note to Reviewers

AFAICT this package is only in use by Storybook, so make sure that works. Also check other commands for good measure, like `yarn test`, `yarn build`, etc. 