### PR TITLE
Change: add warning when migrating a Linode with VLANs to a region w/o VLANs

### DIFF
--- a/packages/manager/src/features/linodes/MigrateLanding/CautionNotice.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/CautionNotice.tsx
@@ -15,7 +15,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     borderRadius: 3,
     marginTop: 24,
     marginBottom: theme.spacing(2),
-    padding: theme.spacing(),
+    padding: '4px 16px',
     backgroundColor: theme.bg.white,
     borderLeft: `5px solid ${theme.palette.status.warningDark}`,
     '& ul:first-of-type': {

--- a/packages/manager/src/features/linodes/MigrateLanding/CautionNotice.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/CautionNotice.tsx
@@ -1,7 +1,6 @@
 import { Volume } from '@linode/api-v4/lib/volumes';
 import { DateTime } from 'luxon';
 import * as React from 'react';
-import { compose } from 'recompose';
 import Checkbox from 'src/components/CheckBox';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
@@ -13,7 +12,12 @@ import { isFeatureEnabled } from 'src/utilities/accountCapabilities';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
+    borderRadius: 3,
+    marginTop: 24,
+    marginBottom: theme.spacing(2),
+    padding: theme.spacing(),
     backgroundColor: theme.bg.white,
+    borderLeft: `5px solid ${theme.palette.status.warningDark}`,
     '& ul:first-of-type': {
       fontFamily: theme.font.normal,
       '& li': {
@@ -59,7 +63,7 @@ const CautionNotice: React.FC<CombinedProps> = props => {
   const amountOfAttachedVolumes = props.linodeVolumes.length;
 
   return (
-    <Notice warning className={classes.root} spacingTop={24}>
+    <div className={classes.root}>
       <Typography className={classes.header}>
         <strong>Caution:</strong>
       </Typography>
@@ -120,8 +124,8 @@ const CautionNotice: React.FC<CombinedProps> = props => {
         onChange={() => props.setConfirmed(!props.hasConfirmed)}
         checked={props.hasConfirmed}
       />
-    </Notice>
+    </div>
   );
 };
 
-export default compose<CombinedProps, Props>(React.memo)(CautionNotice);
+export default React.memo(CautionNotice);

--- a/packages/manager/src/features/linodes/MigrateLanding/ConfigureForm.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/ConfigureForm.tsx
@@ -1,21 +1,18 @@
 import { Region } from '@linode/api-v4/lib/regions';
 import { pathOr } from 'ramda';
 import * as React from 'react';
-import { compose } from 'recompose';
-import { makeStyles, Theme } from 'src/components/core/styles';
-
 import Paper from 'src/components/core/Paper';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import RegionSelect, {
   flags
 } from 'src/components/EnhancedSelect/variants/RegionSelect';
-
 import { dcDisplayNames } from 'src/constants';
+import { useFlags } from 'src/hooks/useFlags';
 import {
   formatRegion,
   getHumanReadableCountry
 } from 'src/utilities/formatRegion';
-import { useFlags } from 'src/hooks/useFlags';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -55,6 +52,7 @@ interface Props {
   handleSelectRegion: (id: string) => void;
   selectedRegion: string | null;
   errorText?: string;
+  helperText?: string;
 }
 
 type CombinedProps = Props;
@@ -89,6 +87,9 @@ const ConfigureForm: React.FC<CombinedProps> = props => {
         handleSelection={props.handleSelectRegion}
         selectedID={props.selectedRegion}
         errorText={props.errorText}
+        textFieldProps={{
+          helperText: props.helperText
+        }}
         menuPlacement="top"
         styles={{
           menuList: (base: any) => ({ ...base, maxHeight: `30vh !important` })
@@ -99,4 +100,4 @@ const ConfigureForm: React.FC<CombinedProps> = props => {
   );
 };
 
-export default compose<CombinedProps, Props>(React.memo)(ConfigureForm);
+export default React.memo(ConfigureForm);

--- a/packages/manager/src/features/linodes/MigrateLanding/MigrateLinode.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/MigrateLinode.tsx
@@ -228,7 +228,7 @@ const MigrateLanding: React.FC<CombinedProps> = props => {
         errorText={regionError}
         helperText={
           shouldWarnAboutVlans
-            ? 'Note: this region does not support VLANs.'
+            ? 'Note: This region does not support VLANs.'
             : undefined
         }
       />

--- a/packages/manager/src/features/linodes/MigrateLanding/MigrateLinode.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/MigrateLinode.tsx
@@ -2,6 +2,9 @@ import { Event, Notification } from '@linode/api-v4/lib/account';
 import { scheduleOrQueueMigration } from '@linode/api-v4/lib/linodes';
 import { APIError as APIErrorType } from '@linode/api-v4/lib/types';
 import { useSnackbar } from 'notistack';
+import { useAccount } from 'src/hooks/useAccount';
+import { useFlags } from 'src/hooks/useFlags';
+import { isFeatureEnabled } from 'src/utilities/accountCapabilities';
 import * as React from 'react';
 import { connect, MapStateToProps } from 'react-redux';
 import { compose } from 'recompose';
@@ -36,6 +39,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   actionWrapper: {
     marginTop: theme.spacing(2),
     marginBottom: theme.spacing(2)
+  },
+  vlanHelperText: {
+    marginTop: theme.spacing() / 2
   }
 }));
 
@@ -56,6 +62,13 @@ const MigrateLanding: React.FC<CombinedProps> = props => {
   const { types } = useTypes();
   const linode = useExtendedLinode(linodeID);
   const { images } = useImages();
+  const { vlans } = useFlags();
+  const { account } = useAccount();
+  const vlansEnabled = isFeatureEnabled(
+    'Vlans',
+    Boolean(vlans),
+    account?.data?.capabilities ?? []
+  );
 
   const [selectedRegion, handleSelectRegion] = React.useState<string | null>(
     null
@@ -165,6 +178,16 @@ const MigrateLanding: React.FC<CombinedProps> = props => {
     addUsedDiskSpace(linode._disks) / MBpsInterDC / 60
   );
 
+  /**
+   * If this user has access to VLANs, the current Linode has a VLAN attached,
+   * the user has selected a region to migrate to, AND the target region does NOT
+   * support VLANs, we want to show a warning.
+   */
+  const shouldWarnAboutVlans =
+    vlansEnabled &&
+    selectedRegion !== null &&
+    !regions.entities[selectedRegion ?? '']?.capabilities.includes('Vlans');
+
   return (
     <Dialog
       title={`Migrate ${linode.label ?? ''}`}
@@ -200,10 +223,15 @@ const MigrateLanding: React.FC<CombinedProps> = props => {
         handleSelectRegion={handleSelectRegion}
         selectedRegion={selectedRegion}
         errorText={regionError}
+        helperText={
+          shouldWarnAboutVlans
+            ? 'Note: this region does not support VLANs.'
+            : undefined
+        }
       />
       <div className={classes.actionWrapper}>
         <Button
-          disabled={!!disabledText}
+          disabled={!!disabledText || !hasConfirmed}
           buttonType="primary"
           onClick={handleMigrate}
           loading={isLoading}

--- a/packages/manager/src/features/linodes/MigrateLanding/MigrateLinode.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/MigrateLinode.tsx
@@ -187,7 +187,9 @@ const MigrateLanding: React.FC<CombinedProps> = props => {
     vlansEnabled &&
     selectedRegion !== null &&
     linode._interfaces.some(thisInterface => Boolean(thisInterface.vlan_id)) &&
-    !regions.entities[selectedRegion ?? '']?.capabilities.includes('Vlans');
+    !regions.entities
+      .find(thisRegion => thisRegion.id === selectedRegion)
+      ?.capabilities.includes('Vlans');
 
   return (
     <Dialog

--- a/packages/manager/src/features/linodes/MigrateLanding/MigrateLinode.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/MigrateLinode.tsx
@@ -186,6 +186,7 @@ const MigrateLanding: React.FC<CombinedProps> = props => {
   const shouldWarnAboutVlans =
     vlansEnabled &&
     selectedRegion !== null &&
+    linode._interfaces.some(thisInterface => Boolean(thisInterface.vlan_id)) &&
     !regions.entities[selectedRegion ?? '']?.capabilities.includes('Vlans');
 
   return (


### PR DESCRIPTION
## Description

- Check if the region to be migrated to supports VLANs.
- If it doesn't, show a note under the region input letting them know.
- Fix DOM nesting validation (we need to be more careful what we
  put inside a `<Notice />`).
- Fix a glitch where you could submit the form without accepting the
  conditions.

Todo: 

- [ ] Nothing about migration has any unit tests at all. Ought to fix this!