### PR TITLE
M3-4682 Domain Tags section width

### DIFF
--- a/packages/manager/src/features/Domains/DomainRecordsWrapper.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordsWrapper.tsx
@@ -28,18 +28,14 @@ const useStyles = makeStyles((theme: Theme) => ({
       order: 1
     }
   },
-  sidebar: {
+  tagsSection: {
     [theme.breakpoints.up('md')]: {
       marginTop: theme.spacing(1),
       order: 2
-    }
-  },
-  cmrSidebar: {
-    [theme.breakpoints.down('md')]: {
-      '&.MuiGrid-item': {
-        paddingLeft: 0,
-        paddingRight: 0
-      }
+    },
+    '&.MuiGrid-item': {
+      paddingLeft: 0,
+      paddingRight: 0
     }
   },
   cmrSpacing: {
@@ -79,8 +75,7 @@ const DomainRecordsWrapper: React.FC<CombinedProps> = props => {
       <Grid
         item
         xs={12}
-        className={`${hookClasses.sidebar} ${flags.cmr &&
-          hookClasses.cmrSidebar}`}
+        className={hookClasses.tagsSection}
         id="domains-tag-section"
       >
         <Paper className={classes.summarySection}>


### PR DESCRIPTION
## Description

This fixes a regression where the Tags section is narrower than the records:

<img width="1310" alt="Screen Shot 2020-11-24 at 3 55 09 PM" src="https://user-images.githubusercontent.com/16911484/100150385-8570b080-2e6d-11eb-9abb-939ad0147325.png">


## Note to Reviewers
The normal stuff, check CMR, non, mobile, tablet, desktop.
