### PR TITLE
Object Storage Cluster Select enhancement

### DIFF
--- a/packages/manager/src/__data__/objectStorageClusters.ts
+++ b/packages/manager/src/__data__/objectStorageClusters.ts
@@ -1,0 +1,25 @@
+import { ObjectStorageCluster } from '@linode/api-v4/lib/object-storage';
+
+export const objectStorageClusters: ObjectStorageCluster[] = [
+  {
+    id: 'us-east-1',
+    region: 'us-east',
+    status: 'available',
+    domain: 'us-east-1.linodeobjects.com',
+    static_site_domain: 'website-us-east-1.linodeobjects.com'
+  },
+  {
+    id: 'eu-central-1',
+    region: 'eu-central',
+    status: 'available',
+    domain: 'eu-central-1.linodeobjects.com',
+    static_site_domain: 'website-eu-central-1.linodeobjects.com'
+  },
+  {
+    id: 'ap-south-1',
+    region: 'ap-south',
+    status: 'available',
+    domain: 'ap-south-1.linodeobjects.com',
+    static_site_domain: 'website-ap-south-1.linodeobjects.com'
+  }
+];

--- a/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionSelect.tsx
+++ b/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionSelect.tsx
@@ -50,7 +50,7 @@ interface Props extends Omit<BaseSelectProps, 'onChange'> {
   regions: ExtendedRegion[];
   handleSelection: (id: string) => void;
   selectedID: string | null;
-  label: string;
+  label?: string;
   helperText?: string;
 }
 
@@ -194,9 +194,9 @@ const SelectRegionPanel: React.FC<Props> = props => {
       <Select
         isClearable={false}
         value={getSelectedRegionById(selectedID || '', options)}
-        label={label}
+        label={label ?? 'Region'}
         disabled={disabled}
-        placeholder="Regions"
+        placeholder="Select a Region"
         options={options}
         onChange={onChange}
         components={{ Option: RegionOption, SingleValue }}

--- a/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
+++ b/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
@@ -83,7 +83,6 @@ const SelectRegionPanel: React.FC<Props & WithStyles<ClassNames>> = props => {
         handleSelection={handleSelection}
         regions={regions}
         selectedID={selectedID || null}
-        label="Select a Region"
         helperText={helperText}
       />
     </Paper>

--- a/packages/manager/src/factories/objectStorage.ts
+++ b/packages/manager/src/factories/objectStorage.ts
@@ -20,7 +20,7 @@ export const objectStorageClusterFactory = Factory.Sync.makeFactory<
 >({
   id: Factory.each(id => `cluster-${id}`) as any,
   domain: Factory.each(id => `cluster-${id}.linodeobjects.com`),
-  region: Factory.each(id => `region-${id}`),
+  region: 'us-east',
   static_site_domain: Factory.each(
     id => `website-cluster-${id}.linodeobjects.com`
   ),

--- a/packages/manager/src/features/Databases/CreateDatabaseDialog/CreateDatabaseDialog.tsx
+++ b/packages/manager/src/features/Databases/CreateDatabaseDialog/CreateDatabaseDialog.tsx
@@ -249,7 +249,6 @@ export const CreateDatabaseDialog: React.FC<{}> = _ => {
         <div className={classes.formSection} data-testid="region-select">
           <RegionSelect
             label={'Region (required)'}
-            placeholder={' '}
             errorText={formik.errors.region}
             handleSelection={handleRegionSelect}
             regions={regionsWithDatabases}

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -322,8 +322,6 @@ export const CreateCluster: React.FC<CombinedProps> = props => {
               </Grid>
               <Grid item>
                 <RegionSelect
-                  label={'Region'}
-                  placeholder={' '}
                   className={classes.regionSubtitle}
                   errorText={errorMap.region}
                   handleSelection={(regionID: string) =>

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/ClusterSelect.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/ClusterSelect.test.tsx
@@ -1,14 +1,13 @@
-import { objectStorageClusters } from 'src/__data__/objectStorageClusters';
-import { regions } from 'src/__data__/regionsData';
+import { objectStorageClusterFactory } from 'src/factories';
 import { objectStorageClusterToExtendedRegion } from './ClusterSelect';
+
+const regions = require('src/cachedData/regions.json');
 
 describe('objectStorageClusterToExtendedRegion', () => {
   it('transforms a list of OBJ clusters to a list of extended regions', () => {
-    const result = objectStorageClusterToExtendedRegion(
-      objectStorageClusters,
-      regions
-    );
-    expect(result.length).toBe(objectStorageClusters.length);
+    const clusters = objectStorageClusterFactory.buildList(2);
+    const result = objectStorageClusterToExtendedRegion(clusters, regions.data);
+    expect(result.length).toBe(clusters.length);
     result.forEach(thisExtendedRegion => {
       expect(thisExtendedRegion).toHaveProperty('country');
       expect(thisExtendedRegion).toHaveProperty('display');

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/ClusterSelect.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/ClusterSelect.test.tsx
@@ -1,34 +1,17 @@
-import { shallow } from 'enzyme';
-import * as React from 'react';
-import { ClusterSelect } from './ClusterSelect';
+import { objectStorageClusters } from 'src/__data__/objectStorageClusters';
+import { regions } from 'src/__data__/regionsData';
+import { objectStorageClusterToExtendedRegion } from './ClusterSelect';
 
-describe('ClusterSelect', () => {
-  const onChangeMock = jest.fn();
-  const onBlurMock = jest.fn();
-
-  const wrapper = shallow(
-    <ClusterSelect
-      selectedCluster="a-cluster"
-      onChange={onChangeMock}
-      onBlur={onBlurMock}
-      clustersData={[]}
-      clustersLoading={false}
-    />
-  );
-
-  it('should render without crashing', () => {
-    expect(wrapper).toHaveLength(1);
-  });
-
-  it('should pass down error messages to <Select />', () => {
-    wrapper.setProps({ clustersError: 'error' });
-    expect(
-      wrapper.find('WithStyles(WithTheme(Select))').prop('errorText')
-    ).toBe('Error loading Regions');
-
-    wrapper.setProps({ error: 'Field Error', clustersError: undefined });
-    expect(
-      wrapper.find('WithStyles(WithTheme(Select))').prop('errorText')
-    ).toBe('Field Error');
+describe('objectStorageClusterToExtendedRegion', () => {
+  it('transforms a list of OBJ clusters to a list of extended regions', () => {
+    const result = objectStorageClusterToExtendedRegion(
+      objectStorageClusters,
+      regions
+    );
+    expect(result.length).toBe(objectStorageClusters.length);
+    result.forEach(thisExtendedRegion => {
+      expect(thisExtendedRegion).toHaveProperty('country');
+      expect(thisExtendedRegion).toHaveProperty('display');
+    });
   });
 });

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/ClusterSelect.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/ClusterSelect.tsx
@@ -1,9 +1,15 @@
+import { ObjectStorageCluster } from '@linode/api-v4/lib/object-storage';
+import { Region } from '@linode/api-v4/lib/regions';
 import * as React from 'react';
 import { compose } from 'recompose';
-import Select, { Item } from 'src/components/EnhancedSelect/Select';
+import { Item } from 'src/components/EnhancedSelect/Select';
+import RegionSelect from 'src/components/EnhancedSelect/variants/RegionSelect';
+import { ExtendedRegion } from 'src/components/EnhancedSelect/variants/RegionSelect/RegionSelect';
+import { dcDisplayNames } from 'src/constants';
 import clustersContainer, {
   StateProps
 } from 'src/containers/clusters.container';
+import useRegions from 'src/hooks/useRegions';
 import { formatRegion } from 'src/utilities/formatRegion';
 
 interface Props {
@@ -31,13 +37,20 @@ export const ClusterSelect: React.FC<CombinedProps> = props => {
     label: formatRegion(eachCluster.region) || eachCluster.region
   }));
 
-  React.useEffect(() => {
-    // If there's only one option, we want it to selected by default.
-    // If it isn't already selected, call `onChange` with it so Formik knows about it.
-    if (options.length === 1 && selectedCluster !== options[0].value) {
-      onChange(options[0].value);
-    }
-  }, []);
+  const { entities } = useRegions();
+
+  const regions = React.useMemo(
+    () => objectStorageClusterToExtendedRegion(clustersData, entities),
+    [clustersData, entities]
+  );
+
+  // React.useEffect(() => {
+  //   // If there's only one option, we want it to selected by default.
+  //   // If it isn't already selected, call `onChange` with it so Formik knows about it.
+  //   if (options.length === 1 && selectedCluster !== options[0].value) {
+  //     onChange(options[0].value);
+  //   }
+  // }, []);
 
   // Error could be: 1. General Clusters error, 2. Field error, 3. Nothing
   const errorText = clustersError
@@ -47,13 +60,14 @@ export const ClusterSelect: React.FC<CombinedProps> = props => {
     : undefined;
 
   return (
-    <Select
+    <RegionSelect
       data-qa-select-cluster
       name="cluster"
       label="Region"
-      options={options}
-      placeholder="All Regions"
-      onChange={(item: Item<string>) => onChange(item.value)}
+      regions={regions}
+      selectedID={selectedCluster}
+      placeholder="Select a Region"
+      handleSelection={(id: string) => onChange(id)}
       onBlur={onBlur}
       isSearchable={false}
       isClearable={false}
@@ -67,3 +81,26 @@ export const ClusterSelect: React.FC<CombinedProps> = props => {
 const enhanced = compose<CombinedProps, Props>(clustersContainer);
 
 export default enhanced(ClusterSelect);
+
+// This bit of hackery transforms a list of OBJ Clusters to Extended Region by
+// matching up their IDs. We do this so RegionSelect understands the datatype we
+// give it. The nested loop doesn't bother me since the inputs are small and the
+// function is memoized using React.useMemo().
+export const objectStorageClusterToExtendedRegion = (
+  clusters: ObjectStorageCluster[],
+  regions: Region[]
+): ExtendedRegion[] => {
+  return clusters.reduce<ExtendedRegion[]>((acc, thisCluster) => {
+    const region = regions.find(
+      thisRegion => thisRegion.id === thisCluster.region
+    );
+    if (region) {
+      acc.push({
+        ...region,
+        id: thisCluster.id,
+        display: dcDisplayNames[region.id]
+      });
+    }
+    return acc;
+  }, []);
+};

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/ClusterSelect.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/ClusterSelect.tsx
@@ -2,7 +2,6 @@ import { ObjectStorageCluster } from '@linode/api-v4/lib/object-storage';
 import { Region } from '@linode/api-v4/lib/regions';
 import * as React from 'react';
 import { compose } from 'recompose';
-import { Item } from 'src/components/EnhancedSelect/Select';
 import RegionSelect from 'src/components/EnhancedSelect/variants/RegionSelect';
 import { ExtendedRegion } from 'src/components/EnhancedSelect/variants/RegionSelect/RegionSelect';
 import { dcDisplayNames } from 'src/constants';
@@ -10,7 +9,6 @@ import clustersContainer, {
   StateProps
 } from 'src/containers/clusters.container';
 import useRegions from 'src/hooks/useRegions';
-import { formatRegion } from 'src/utilities/formatRegion';
 
 interface Props {
   selectedCluster: string;
@@ -32,25 +30,12 @@ export const ClusterSelect: React.FC<CombinedProps> = props => {
     disabled
   } = props;
 
-  const options: Item<string>[] = clustersData.map(eachCluster => ({
-    value: eachCluster.id,
-    label: formatRegion(eachCluster.region) || eachCluster.region
-  }));
-
   const { entities } = useRegions();
 
   const regions = React.useMemo(
     () => objectStorageClusterToExtendedRegion(clustersData, entities),
     [clustersData, entities]
   );
-
-  // React.useEffect(() => {
-  //   // If there's only one option, we want it to selected by default.
-  //   // If it isn't already selected, call `onChange` with it so Formik knows about it.
-  //   if (options.length === 1 && selectedCluster !== options[0].value) {
-  //     onChange(options[0].value);
-  //   }
-  // }, []);
 
   // Error could be: 1. General Clusters error, 2. Field error, 3. Nothing
   const errorText = clustersError
@@ -67,12 +52,11 @@ export const ClusterSelect: React.FC<CombinedProps> = props => {
       regions={regions}
       selectedID={selectedCluster}
       placeholder="Select a Region"
-      handleSelection={(id: string) => onChange(id)}
+      handleSelection={id => onChange(id)}
       onBlur={onBlur}
       isSearchable={false}
       isClearable={false}
       errorText={errorText}
-      defaultValue={options.length === 1 && options[0]}
       disabled={disabled}
     />
   );

--- a/packages/manager/src/features/Vlans/CreateVLANDialog/CreateVLANDialog.tsx
+++ b/packages/manager/src/features/Vlans/CreateVLANDialog/CreateVLANDialog.tsx
@@ -162,7 +162,6 @@ export const CreateVLANDialog: React.FC<{}> = _ => {
         <div className={classes.formSection}>
           <RegionSelect
             label={'Region (required)'}
-            placeholder={'Regions'}
             errorText={formik.errors.region}
             handleSelection={handleRegionSelect}
             regions={regionsWithVLANS}

--- a/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
@@ -268,7 +268,6 @@ const CreateVolumeForm: React.FC<CombinedProps> = props => {
                     selectedID={values.region}
                     handleSelection={value => setFieldValue('region', value)}
                     disabled={disabled}
-                    label={'Select a Region'}
                     styles={{
                       /** altering styles for mobile-view */
                       menuList: (base: any) => ({

--- a/packages/manager/src/features/linodes/MigrateLanding/ConfigureForm.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/ConfigureForm.tsx
@@ -93,7 +93,6 @@ const ConfigureForm: React.FC<CombinedProps> = props => {
         styles={{
           menuList: (base: any) => ({ ...base, maxHeight: `30vh !important` })
         }}
-        label="Select a Region"
       />
     </Paper>
   );


### PR DESCRIPTION
## Description

This enhances the Object Storage Cluster Select so that it uses a RegionSelect under the hood. This gives us group-by-country as well as country flags (makes it look like a RegionSelect).

<img width="476" alt="Screen Shot 2020-11-24 at 6 49 40 PM" src="https://user-images.githubusercontent.com/16911484/100164557-18b5e000-2e86-11eb-93eb-420e7c972144.png">

I also went through and made the labels and placeholders for the RegionSelect more consistent.

Todo: 
- [ ] Rewrite existing tests now that there’s a hook and invariant violations are thrown.


