### PR TITLE
Use Redux action for VLAN creation

### DIFF
--- a/packages/manager/src/features/Vlans/CreateVLANDialog/CreateVLANDialog.test.tsx
+++ b/packages/manager/src/features/Vlans/CreateVLANDialog/CreateVLANDialog.test.tsx
@@ -1,8 +1,8 @@
-import * as request from '@linode/api-v4/lib/vlans/vlans';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 import { vlanContext } from 'src/context';
+import * as request from 'src/store/vlans/vlans.requests';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 import CreateVLANDialog from './CreateVLANDialog';
 

--- a/packages/manager/src/features/Vlans/CreateVLANDialog/CreateVLANDialog.tsx
+++ b/packages/manager/src/features/Vlans/CreateVLANDialog/CreateVLANDialog.tsx
@@ -1,9 +1,5 @@
 import { linodeReboot } from '@linode/api-v4/lib/linodes';
-import {
-  createVlan,
-  CreateVLANPayload,
-  createVlanSchema
-} from '@linode/api-v4/lib/vlans';
+import { CreateVLANPayload, createVlanSchema } from '@linode/api-v4/lib/vlans';
 import { useFormik } from 'formik';
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
@@ -20,13 +16,14 @@ import LinodeMultiSelect from 'src/components/LinodeMultiSelect';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
 import { dcDisplayNames } from 'src/constants';
+import { vlanContext } from 'src/context';
 import useLinodes from 'src/hooks/useLinodes';
 import useRegions from 'src/hooks/useRegions';
+import useVlans from 'src/hooks/useVlans';
 import {
   handleFieldErrors,
   handleGeneralErrors
 } from 'src/utilities/formikErrorUtils';
-import { vlanContext } from 'src/context';
 
 const useStyles = makeStyles((theme: Theme) => ({
   form: {},
@@ -52,6 +49,8 @@ export const CreateVLANDialog: React.FC<{}> = _ => {
   const regionIDsWithVLANs = React.useMemo(() => {
     return regionsWithVLANS.map(thisRegion => thisRegion.id);
   }, [regionsWithVLANS]);
+
+  const { createVlan } = useVlans();
 
   const context = React.useContext(vlanContext);
 

--- a/packages/manager/src/hooks/useVlans.ts
+++ b/packages/manager/src/hooks/useVlans.ts
@@ -1,4 +1,4 @@
-import { VLAN } from '@linode/api-v4/lib/vlans/types';
+import { CreateVLANPayload, VLAN } from '@linode/api-v4/lib/vlans/types';
 import { useDispatch, useSelector } from 'react-redux';
 import { ApplicationState } from 'src/store';
 import { State } from 'src/store/vlans/vlans.reducer';
@@ -6,7 +6,8 @@ import {
   getAllVlans as _request,
   attachVlan as _attach,
   detachVlan as _detach,
-  deleteVlan as _delete
+  deleteVlan as _delete,
+  createVlan as _create
 } from 'src/store/vlans/vlans.requests';
 import { Dispatch } from './types';
 
@@ -28,9 +29,17 @@ export const useVlans = () => {
     dispatch(_attach({ vlanID, linodes }));
   const detachVlan = (vlanID: number, linodes: number[]) =>
     dispatch(_detach({ vlanID, linodes }));
+  const createVlan = (payload: CreateVLANPayload) => dispatch(_create(payload));
   const deleteVlan = (vlanID: number) => dispatch(_delete({ vlanID }));
 
-  return { vlans, requestVLANs, attachVlan, detachVlan, deleteVlan };
+  return {
+    vlans,
+    requestVLANs,
+    attachVlan,
+    detachVlan,
+    createVlan,
+    deleteVlan
+  };
 };
 
 export default useVlans;


### PR DESCRIPTION
## Description

Simple change: use the Redux action instead of the API method directly for VLAN creation. This way the store is updated (previously, if you were already on the VLAN landing page and created a new one, you wouldn't see the UI update).