### PR TITLE
M3-4649: Add componentDidUpdate() in LinodeRescue.tsx to keep disks in state accurate

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.tsx
@@ -150,6 +150,17 @@ export class LinodeRescue extends React.Component<CombinedProps, State> {
     };
   }
 
+  componentDidUpdate(prevProps: CombinedProps) {
+    if (!prevProps.linodeDisks && this.props.linodeDisks) {
+      this.setState({
+        devices: {
+          ...this.state.devices,
+          disks: this.props.linodeDisks as ExtendedDisk[]
+        }
+      });
+    }
+  }
+
   getFilteredVolumes = () => {
     const { linodeId, linodeRegion, volumesData } = this.props;
     return volumesData

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.tsx
@@ -151,7 +151,10 @@ export class LinodeRescue extends React.Component<CombinedProps, State> {
   }
 
   componentDidUpdate(prevProps: CombinedProps) {
-    if (!prevProps.linodeDisks && this.props.linodeDisks) {
+    if (
+      prevProps?.linodeDisks?.length === 0 &&
+      this.props.linodeDisks!.length > 0
+    ) {
       this.setState({
         devices: {
           ...this.state.devices,

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.tsx
@@ -60,7 +60,7 @@ interface ContextProps {
   linodeId: number;
   linodeRegion?: string;
   linodeLabel: string;
-  linodeDisks?: ExtendedDisk[];
+  linodeDisks: ExtendedDisk[];
   linodeStatus: LinodeStatus;
   permissions: GrantLevel;
 }
@@ -153,7 +153,7 @@ export class LinodeRescue extends React.Component<CombinedProps, State> {
   componentDidUpdate(prevProps: CombinedProps) {
     if (
       prevProps?.linodeDisks?.length === 0 &&
-      this.props.linodeDisks!.length > 0
+      this.props.linodeDisks.length > 0
     ) {
       this.setState({
         devices: {


### PR DESCRIPTION
## Description
Occasionally, depending on the speed of the `/linode/instances/:id/disks` request, the component may render faster than the request completes. In this case the state is not updated with the correct disks since it is initialized with an empty array if `props.linodeDisks` is undefined. Adding a `componentDidUpdate()` in which the disks are properly set should fix this.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers
I only encountered the bug once, before writing this fix, and haven't ran into it since, so I haven't had the chance to test this fully. But the intent is: if the props change, and `linodeDisks` was previously unpopulated but is now populated, set `disks` in state to `props.linodeDisks`.
