### PR TITLE
M3-4685 Change: use CMR style for Node Pools

### DIFF
--- a/packages/manager/src/assets/icons/resize.svg
+++ b/packages/manager/src/assets/icons/resize.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-    <g fill="none" fill-rule="evenodd" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round">
+    <g fill="none" fill-rule="evenodd" stroke="#3683DC" stroke-linecap="round" stroke-linejoin="round">
         <path d="M7.526 2.499L7.526 13.499M10.001 4.999L7.526 2.499 5.05 4.999M10.001 10.999L7.526 13.499 5.05 10.999M14.952.499L.1.499M14.952 15.499L.1 15.499" transform="translate(.5)"/>
     </g>
 </svg>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
@@ -1,6 +1,7 @@
 import { PoolNodeResponse } from '@linode/api-v4/lib/kubernetes';
 import { APIError } from '@linode/api-v4/lib/types';
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import TableBody from 'src/components/core/TableBody';
@@ -208,14 +209,20 @@ export const NodeRow: React.FC<NodeRowProps> = React.memo(props => {
   const displayIP = ip ?? '';
 
   return (
-    <TableRow rowLink={rowLink} ariaLabel={label}>
+    <TableRow ariaLabel={label}>
       <TableCell>
         <Grid container wrap="nowrap" alignItems="center">
           <Grid item>
             <StatusIndicator status={statusIndicator} />
           </Grid>
           <Grid item>
-            <Typography variant="h3">{displayLabel}</Typography>
+            <Typography variant="h3">
+              {rowLink ? (
+                <Link to={rowLink}>{displayLabel}</Link>
+              ) : (
+                displayLabel
+              )}
+            </Typography>
           </Grid>
         </Grid>
       </TableCell>


### PR DESCRIPTION
## Description

Follow-up from #7154. Fixes NodePool rows so that they use the same CMR behavior as other table rows (the row itself is not clickable, the entity label is a link to the entity).

This affects both CMR and non-CMR, some flag logic can be added if necessary to separate them.

## Note to Reviewers

You can add nodes to a node pool to see the unlinked state (which will eventually transition to the linked state)