### PR TITLE
M3-4582 Change: Use a shared component for view-only permissions tables.

### DIFF
--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessCell.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessCell.tsx
@@ -37,7 +37,10 @@ export const AccessCell: React.FC<AccessCellProps> = props => {
       return null;
     }
     return (
-      <span className={classes.checkIcon}>
+      <span
+        className={classes.checkIcon}
+        aria-label={`This token has ${scope} access for ${scopeDisplay}`}
+      >
         <Check />
       </span>
     );

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessCell.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessCell.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import Check from 'src/assets/icons/monitor-ok.svg';
+import Radio from 'src/components/Radio';
+import { makeStyles } from 'src/components/core/styles';
+
+const useStyles = makeStyles(() => ({
+  checkIcon: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    '& svg': {
+      height: 25,
+      width: 25
+    }
+  }
+}));
+
+interface RadioButton extends HTMLInputElement {
+  name: string;
+}
+
+interface AccessCellProps {
+  disabled: boolean;
+  active: boolean;
+  viewOnly: boolean;
+  scope: string;
+  scopeDisplay: string;
+  onChange: (e: React.SyntheticEvent<RadioButton>) => void;
+}
+
+export const AccessCell: React.FC<AccessCellProps> = props => {
+  const { active, disabled, onChange, scope, scopeDisplay, viewOnly } = props;
+  const classes = useStyles();
+
+  if (viewOnly) {
+    if (!active) {
+      return null;
+    }
+    return (
+      <span className={classes.checkIcon}>
+        <Check />
+      </span>
+    );
+  }
+
+  return (
+    <Radio
+      name={scopeDisplay}
+      disabled={disabled}
+      checked={active}
+      value={scope}
+      onChange={onChange}
+      data-testid={`perm-${scopeDisplay}-radio`}
+      inputProps={{
+        'aria-label': `${scope} for ${scopeDisplay}`
+      }}
+    />
+  );
+};
+
+export default React.memo(AccessCell);

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessCell.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessCell.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/no-noninteractive-tabindex */
 import * as React from 'react';
 import Check from 'src/assets/icons/monitor-ok.svg';
 import Radio from 'src/components/Radio';
@@ -40,6 +41,7 @@ export const AccessCell: React.FC<AccessCellProps> = props => {
       <span
         className={classes.checkIcon}
         aria-label={`This token has ${scope} access for ${scopeDisplay}`}
+        tabIndex={0}
       >
         <Check />
       </span>

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/LimitedAccessControls.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/LimitedAccessControls.tsx
@@ -11,6 +11,7 @@ import Table from 'src/components/Table/Table_CMR';
 import TableCell from 'src/components/TableCell/TableCell_CMR';
 import TableRow from 'src/components/TableRow/TableRow_CMR';
 import Toggle from 'src/components/Toggle';
+import AccessCell from './AccessCell';
 import { MODE } from './types';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -129,13 +130,6 @@ export const AccessTable: React.FC<TableProps> = React.memo(props => {
 
   const disabled = !checked;
 
-  const radioDisabled = (scope: Scope, access: AccessType) => {
-    if (mode !== 'viewing') {
-      return disabled;
-    }
-    return scope.permissions !== access;
-  };
-
   return (
     <Table
       aria-label="Object Storage Access Key Permissions"
@@ -221,58 +215,48 @@ export const AccessTable: React.FC<TableProps> = React.memo(props => {
                 {thisScope.bucket_name}
               </TableCell>
               <TableCell padding="checkbox" className={classes.radioCell}>
-                <Radio
-                  name={thisScope.bucket_name}
-                  disabled={radioDisabled(thisScope, SCOPES.none)}
-                  checked={thisScope.permissions === SCOPES.none}
-                  value="none"
+                <AccessCell
+                  active={thisScope.permissions === SCOPES.none}
+                  scope="none"
+                  scopeDisplay={scopeName}
+                  viewOnly={mode === 'viewing'}
+                  disabled={disabled}
                   onChange={() =>
                     updateSingleScope({
                       ...thisScope,
                       permissions: SCOPES.none
                     })
                   }
-                  data-qa-perm-none-radio
-                  inputProps={{
-                    'aria-label': `no permissions for ${thisScope.cluster}`
-                  }}
                 />
               </TableCell>
               <TableCell padding="checkbox" className={classes.radioCell}>
-                <Radio
-                  name={scopeName}
-                  disabled={radioDisabled(thisScope, SCOPES.read)}
-                  checked={thisScope.permissions === SCOPES.read}
-                  value="read-only"
+                <AccessCell
+                  active={thisScope.permissions === SCOPES.read}
+                  scope="read-only"
+                  scopeDisplay={scopeName}
+                  viewOnly={mode === 'viewing'}
+                  disabled={disabled}
                   onChange={() =>
                     updateSingleScope({
                       ...thisScope,
                       permissions: SCOPES.read
                     })
                   }
-                  data-qa-perm-read-radio
-                  inputProps={{
-                    'aria-label': `read-only for ${scopeName}`
-                  }}
                 />
               </TableCell>
               <TableCell padding="checkbox" className={classes.radioCell}>
-                <Radio
-                  name={scopeName}
-                  disabled={radioDisabled(thisScope, SCOPES.write)}
-                  checked={thisScope.permissions === SCOPES.write}
-                  value="read-write"
+                <AccessCell
+                  active={thisScope.permissions === SCOPES.write}
+                  scope="read-write"
+                  scopeDisplay={scopeName}
+                  viewOnly={mode === 'viewing'}
+                  disabled={disabled}
                   onChange={() =>
                     updateSingleScope({
                       ...thisScope,
                       permissions: SCOPES.write
                     })
                   }
-                  data-qa-perm-rw-radio
-                  data-testid="perm-rw-radio"
-                  inputProps={{
-                    'aria-label': `read/write for ${scopeName}`
-                  }}
                 />
               </TableCell>
             </TableRow>

--- a/packages/manager/src/features/Profile/APITokens/APITokenDrawer.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokenDrawer.tsx
@@ -311,7 +311,7 @@ export class APITokenDrawer extends React.Component<CombinedProps, State> {
                 >
                   <AccessCell
                     active={scopeTup[1] === 0}
-                    scope="2"
+                    scope="0"
                     scopeDisplay={scopeTup[0]}
                     viewOnly={mode === 'view'}
                     disabled={false}

--- a/packages/manager/src/features/Profile/APITokens/APITokenDrawer.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokenDrawer.tsx
@@ -24,6 +24,7 @@ import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
 import TextField from 'src/components/TextField';
 import { ISO_DATETIME_NO_TZ_FORMAT } from 'src/constants';
+import AccessCell from 'src/features/ObjectStorage/AccessKeyLanding/AccessCell';
 import { getErrorMap } from 'src/utilities/errorUtils';
 import {
   Permission,
@@ -308,16 +309,13 @@ export class APITokenDrawer extends React.Component<CombinedProps, State> {
                   padding="checkbox"
                   className={classes.noneCell}
                 >
-                  <Radio
-                    name={scopeTup[0]}
-                    disabled={mode !== 'create' && scopeTup[1] !== 0}
-                    checked={scopeTup[1] === 0}
-                    value="0"
+                  <AccessCell
+                    active={scopeTup[1] === 0}
+                    scope="2"
+                    scopeDisplay={scopeTup[0]}
+                    viewOnly={mode === 'view'}
+                    disabled={false}
                     onChange={this.handleScopeChange}
-                    data-qa-perm-none-radio
-                    inputProps={{
-                      'aria-label': `no access for ${scopeTup[0]}`
-                    }}
                   />
                 </TableCell>
                 <TableCell
@@ -325,16 +323,13 @@ export class APITokenDrawer extends React.Component<CombinedProps, State> {
                   padding="checkbox"
                   className={classes.readOnlyCell}
                 >
-                  <Radio
-                    name={scopeTup[0]}
-                    disabled={mode !== 'create' && scopeTup[1] !== 1}
-                    checked={scopeTup[1] === 1}
-                    value="1"
+                  <AccessCell
+                    active={scopeTup[1] === 1}
+                    scope="1"
+                    scopeDisplay={scopeTup[0]}
+                    viewOnly={mode === 'view'}
+                    disabled={false}
                     onChange={this.handleScopeChange}
-                    data-qa-perm-read-radio
-                    inputProps={{
-                      'aria-label': `read-only for ${scopeTup[0]}`
-                    }}
                   />
                 </TableCell>
                 <TableCell
@@ -342,17 +337,13 @@ export class APITokenDrawer extends React.Component<CombinedProps, State> {
                   padding="checkbox"
                   className={classes.readWritecell}
                 >
-                  <Radio
-                    name={scopeTup[0]}
-                    disabled={mode !== 'create' && scopeTup[1] !== 2}
-                    checked={scopeTup[1] === 2}
-                    value="2"
+                  <AccessCell
+                    active={scopeTup[1] === 2}
+                    scope="2"
+                    scopeDisplay={scopeTup[0]}
+                    viewOnly={mode === 'view'}
+                    disabled={false}
                     onChange={this.handleScopeChange}
-                    data-qa-perm-rw-radio
-                    data-testid="perm-rw-radio"
-                    inputProps={{
-                      'aria-label': `read/write for ${scopeTup[0]}`
-                    }}
                   />
                 </TableCell>
               </TableRow>

--- a/packages/manager/src/features/Profile/APITokens/APITokenMenu.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokenMenu.tsx
@@ -26,25 +26,25 @@ class APITokenMenu extends React.Component<CombinedProps> {
     } = this.props;
 
     return (closeMenu: Function): Action[] => {
-      const actions = !isThirdPartyAccessToken
+      return !isThirdPartyAccessToken
         ? [
             {
               title: 'View Token Scopes',
-              onClick: (e: React.MouseEvent<HTMLElement>) => {
+              onClick: () => {
                 openViewDrawer(token);
                 closeMenu();
               }
             },
             {
               title: 'Rename Token',
-              onClick: (e: React.MouseEvent<HTMLElement>) => {
+              onClick: () => {
                 openEditDrawer(token);
                 closeMenu();
               }
             },
             {
               title: 'Revoke',
-              onClick: (e: React.MouseEvent<HTMLElement>) => {
+              onClick: () => {
                 openRevokeDialog(token, type);
                 closeMenu();
               }
@@ -53,20 +53,19 @@ class APITokenMenu extends React.Component<CombinedProps> {
         : [
             {
               title: 'View Token Scopes',
-              onClick: (e: React.MouseEvent<HTMLElement>) => {
+              onClick: () => {
                 openViewDrawer(token);
                 closeMenu();
               }
             },
             {
               title: 'Revoke',
-              onClick: (e: React.MouseEvent<HTMLElement>) => {
+              onClick: () => {
                 openRevokeDialog(token, type);
                 closeMenu();
               }
             }
           ];
-      return actions;
     };
   };
 


### PR DESCRIPTION
## Description

For OBJ access tokens and API access tokens, instead of showing a disabled version of the scopes form (with a bunch of radio buttons), if a user is in view-only mode instead use check marks for selected permissions. I opted to go with a shared (new) component for this, though it isn't clear if it's worth it in this case.

![Screen Shot 2020-12-01 at 4 04 07 PM](https://user-images.githubusercontent.com/1624067/100796558-da24a600-33ee-11eb-97bb-70ba01b3f89b.png)


@ndukatz there are a few existing e2e tests that used data-qa attributes that are lost using this approach (nothing in Cypress though). Please let me know if I broke anything you're working on.

@tiffwong making this change meant that the aria stuff needed to be dynamic. The results are a bit different but I think they're ok. Please let me know.

- [ ] unit tests
