### PR TITLE
M3-4687 Move PrimaryNav back to the side

### DIFF
--- a/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.styles.ts
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.styles.ts
@@ -2,149 +2,132 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 
 const useStyles = makeStyles((theme: Theme) => ({
   menuGrid: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: theme.cmrBGColors.bgPrimaryNav,
-    borderColor: theme.bg.primaryNavBorder,
-    boxShadow: 'none',
-    height: '100%',
+    minHeight: 64,
     width: '100%',
-    left: 'inherit',
+    height: '100%',
     margin: 0,
     padding: 0,
-    minHeight: 50,
-    overflowX: 'auto',
-    transition: 'width linear .1s'
-  },
-  menuGridInner: {
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    width: '100%',
-
-    [theme.breakpoints.up('lg')]: {
-      width: 1345
+    [theme.breakpoints.up('sm')]: {
+      minHeight: 72
+    },
+    [theme.breakpoints.up('md')]: {
+      minHeight: 80
     }
   },
-  primaryLinksContainer: {
+  fadeContainer: {
+    width: '100%',
+    height: 'calc(100% - 90px)',
     display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center'
+    flexDirection: 'column'
   },
   logoItem: {
-    '& > a': {
-      display: 'flex',
-      alignItems: 'center'
+    minHeight: 64,
+    position: 'relative',
+    display: 'flex',
+    alignItems: 'center',
+    padding: `
+        ${theme.spacing(2) - 2}px
+        0
+        ${theme.spacing(1) + theme.spacing(1) / 2}px
+        ${theme.spacing(4)}px
+      `,
+    '& svg': {
+      maxWidth: theme.spacing(3) + 91
     }
   },
   logoCollapsed: {
-    marginLeft: 7.5,
-    marginRight: 7.5
-  },
-  navIcon: {
-    display: 'flex',
-    backgroundColor: 'transparent',
-    border: 'none',
-    color: theme.color.white,
-    fontSize: '1.125rem',
-    lineHeight: '20px',
-    '& svg': {
-      marginTop: -2,
-      marginRight: 10
-    },
-    [theme.breakpoints.up(750)]: {
-      display: 'none'
+    '& .logoLetters': {
+      opacity: 0
     }
   },
-  hideOnMobile: {
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
-
-    [theme.breakpoints.down(750)]: {
-      display: 'none'
-    }
-  },
-  secondaryLinksContainer: {
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'flex-end',
-    width: '100%',
-
-    '&  > a': {
-      [theme.breakpoints.down('sm')]: {
-        paddingLeft: 7.5,
-        paddingRight: 7.5
-      },
-      [theme.breakpoints.down(750)]: {
-        paddingLeft: 12.5,
-        paddingRight: 12.5
-      }
-    }
-  },
-  primaryNavLinkIcon: {
-    display: 'flex',
-    alignItems: 'center',
-    marginRight: 10
-  },
-  linkItem: {
-    color: theme.color.primaryNavText,
-    fontFamily: theme.font.normal,
-    opacity: 1,
-    transition: theme.transitions.create(['color']),
-    whiteSpace: 'nowrap'
+  linkGroup: {
+    marginBottom: theme.spacing(3)
   },
   listItem: {
     display: 'flex',
     alignItems: 'center',
-    fontSize: '1rem',
-    height: 50,
-    lineHeight: 1,
-    paddingLeft: 15,
-    paddingRight: 15,
     position: 'relative',
+    cursor: 'pointer',
+    maxHeight: 42,
+    transition: theme.transitions.create(['background-color']),
+    padding: `
+        ${theme.spacing(1.5)}px
+        ${theme.spacing(4) - 2}px
+        ${theme.spacing(1.5) - 1}px
+        ${theme.spacing(4) + 1}px
+      `,
     '&:hover': {
-      backgroundColor: theme.cmrBGColors.bgPrimaryNavActive
-    },
-    '&:focus': {
-      backgroundColor: theme.cmrBGColors.bgPrimaryNavActive
-    },
-    '& .icon': {
-      [theme.breakpoints.down('md')]: {
-        margin: 0
+      // @todo: make this gradient correct.
+      backgroundImage: 'linear-gradient(to right, #395149 , #395149)',
+      '& $linkItem': {
+        color: 'white'
+      },
+      '& svg': {
+        fill: 'white',
+        '& *': {
+          stroke: 'white'
+        }
       }
     },
-    [theme.breakpoints.down('sm')]: {
-      paddingLeft: 7.5,
-      paddingRight: 7.5
+    '& .icon': {
+      marginRight: theme.spacing(2),
+      '& svg': {
+        width: 26,
+        height: 26,
+        transform: 'scale(1.75)',
+        fill: theme.color.primaryNavText,
+        transition: theme.transitions.create(['fill']),
+        '&.small': {
+          transform: 'scale(1)'
+        },
+        '&:not(.wBorder) circle, & .circle': {
+          display: 'none'
+        },
+        '& *': {
+          transition: theme.transitions.create(['stroke']),
+          stroke: theme.color.primaryNavText
+        }
+      }
     }
   },
   listItemCollapsed: {},
-  settings: {
-    display: 'flex',
-    alignItems: 'center',
-    alignSelf: 'stretch',
-    justifyContent: 'center',
-    borderRadius: 0,
-    color: '#e7e7e7',
-    paddingLeft: 15,
-    paddingRight: 15,
+  collapsible: {
+    fontSize: '0.9rem'
+  },
+  linkItem: {
     transition: theme.transitions.create(['color']),
-    '&:focus': {
-      borderRadius: 0
+    color: theme.color.primaryNavText,
+    opacity: 1,
+    whiteSpace: 'nowrap',
+    fontFamily: 'LatoWebBold', // we keep this bold at all times
+    '&.hiddenWhenCollapsed': {
+      opacity: 0
+    }
+  },
+  active: {
+    // @todo: make this gradient correct.
+    backgroundImage: 'linear-gradient(to right, #395149 , #395149)',
+    '&:hover': {}
+  },
+  spacer: {
+    padding: 25
+  },
+  divider: {
+    backgroundColor: 'rgba(0, 0, 0, 0.12)'
+  },
+  settings: {
+    width: 30,
+    margin: `auto auto 16px`,
+    alignItems: 'center',
+    justifyContent: 'center',
+    display: 'flex',
+    color: '#e7e7e7',
+    transition: theme.transitions.create(['color']),
+    '& svg': {
+      transition: theme.transitions.create(['transform'])
     },
     '&:hover': {
-      backgroundColor: theme.cmrBGColors.bgPrimaryNavActive
-    },
-    [theme.breakpoints.down('sm')]: {
-      paddingLeft: 7.5,
-      paddingRight: 7.5
-    },
-    [theme.breakpoints.down(750)]: {
-      paddingLeft: 12.5,
-      paddingRight: 12.5
+      color: theme.color.green
     }
   },
   settingsCollapsed: {
@@ -156,112 +139,19 @@ const useStyles = makeStyles((theme: Theme) => ({
       transform: 'rotate(90deg)'
     }
   },
+  menu: {},
   paper: {
-    backgroundColor: theme.bg.navy,
-    boxShadow: 'none',
     maxWidth: 350,
-    minWidth: 185,
-    outline: 0,
     padding: 8,
     position: 'absolute',
-    top: 25
+    backgroundColor: theme.bg.navy,
+    border: '1px solid #999',
+    outline: 0,
+    boxShadow: 'none',
+    minWidth: 185
   },
-  menuWrapper: {
-    display: 'flex',
-    alignItems: 'center',
-    '&:hover': {
-      backgroundColor: theme.cmrBGColors.bgPrimaryNavActive
-    },
-    '&:focus': {
-      backgroundColor: theme.cmrBGColors.bgPrimaryNavActive
-    }
-  },
-  menuButton: {
-    display: 'flex',
-    alignItems: 'center',
-    lineHeight: 1,
-    padding: 0,
-    '&[data-reach-menu-button]': {
-      backgroundColor: theme.cmrBGColors.bgPrimaryNav,
-      border: 'none',
-      borderRadius: 0,
-      color: theme.color.primaryNavText,
-      cursor: 'pointer',
-      fontSize: '1rem',
-      height: 50,
-      paddingLeft: 15,
-      paddingRight: 6,
-      textTransform: 'inherit',
-      '&[aria-expanded="true"]': {
-        backgroundColor: theme.cmrBGColors.bgPrimaryNavActive,
-        '& $caret': {
-          transform: 'rotate(180deg)'
-        }
-      },
-      [theme.breakpoints.down('sm')]: {
-        paddingLeft: 7.5,
-        paddingRight: 7.5
-      }
-    },
-    '&:hover': {
-      backgroundColor: theme.cmrBGColors.bgPrimaryNavActive
-    },
-    '&:focus': {
-      backgroundColor: theme.cmrBGColors.bgPrimaryNavActive
-    }
-  },
-  caret: {
-    color: '#9ea4ae',
-    marginTop: 4,
-    marginLeft: 2
-  },
-  menuPopover: {
-    '&[data-reach-menu], &[data-reach-menu-popover]': {
-      position: 'absolute',
-      top: 50,
-      zIndex: 3000
-    }
-  },
-  menuItemList: {
-    '&[data-reach-menu-items]': {
-      backgroundColor: theme.cmrBGColors.bgPrimaryNav,
-      border: 'none',
-      padding: 0,
-      whiteSpace: 'normal'
-    }
-  },
-  menuItemLink: {
-    '&[data-reach-menu-item]': {
-      display: 'flex',
-      alignItems: 'center',
-      backgroundColor: theme.cmrBGColors.bgPrimaryNav,
-      color: theme.color.primaryNavText,
-      fontSize: '1rem',
-      paddingTop: 12,
-      paddingBottom: 12,
-      paddingLeft: 15,
-      paddingRight: 40,
-      '&:hover': {
-        backgroundColor: theme.cmrBGColors.bgPrimaryNavActive
-      },
-      '&:focus': {
-        backgroundColor: theme.cmrBGColors.bgPrimaryNavActive
-      },
-      [theme.breakpoints.down('sm')]: {
-        paddingTop: 10,
-        paddingBottom: 10,
-        paddingLeft: 7.5
-      }
-    },
-    '&[data-reach-menu-item][data-selected]': {
-      backgroundColor: theme.cmrBGColors.bgPrimaryNavActive
-    }
-  },
-  mobileNav: {
-    position: 'absolute',
-    top: 0,
-    left: theme.spacing(4),
-    zIndex: 1200
+  settingsBackdrop: {
+    backgroundColor: 'rgba(0,0,0,.3)'
   }
 }));
 

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.test.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.test.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { renderWithTheme, wrapWithTheme } from 'src/utilities/testHelpers';
 import { withManaged, withoutManaged } from 'src/utilities/testHelpersStore';
-import PrimaryNav_CMR, { PrimaryNavProps } from './PrimaryNav_CMR';
+import PrimaryNav_CMR from './PrimaryNav_CMR';
 
-const props: PrimaryNavProps = {
+const props = {
   closeMenu: jest.fn(),
   toggleTheme: jest.fn(),
+  toggleSpacing: jest.fn(),
   isCollapsed: false
 };
 

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.test.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.test.tsx
@@ -11,14 +11,6 @@ const props = {
 };
 
 describe('PrimaryNav_CMR', () => {
-  it('contains all nav groups', () => {
-    const { getByTestId } = renderWithTheme(<PrimaryNav_CMR {...props} />);
-    getByTestId('nav-group-Compute');
-    getByTestId('nav-group-Network');
-    getByTestId('nav-group-Storage');
-    getByTestId('nav-group-Monitors');
-  });
-
   it('only contains a "Managed" menu link if the user has Managed services.', () => {
     const { getByTestId, rerender, queryByTestId } = renderWithTheme(
       <PrimaryNav_CMR {...props} />,

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.tsx
@@ -260,6 +260,25 @@ export const PrimaryNav: React.FC<Props> = props => {
         <Hidden mdUp>
           <Divider className={classes.divider} />
           <Link
+            to="/account"
+            onClick={closeMenu}
+            data-qa-nav-item="/account"
+            className={classNames({
+              [classes.listItem]: true,
+              [classes.active]:
+                linkIsActive('/account', location.search, location.pathname) ===
+                true
+            })}
+          >
+            <ListItemText
+              primary="Account"
+              disableTypography={true}
+              className={classNames({
+                [classes.linkItem]: true
+              })}
+            />
+          </Link>
+          <Link
             to="/profile/display"
             onClick={closeMenu}
             data-qa-nav-item="/profile/display"
@@ -390,6 +409,7 @@ const PrimaryLink: React.FC<PrimaryLinkProps> = React.memo(props => {
           ),
           listItemCollapsed: isCollapsed
         })}
+        data-testid={`menu-item-${display}`}
       >
         {icon && isCollapsed && (
           <div className="icon" aria-hidden>

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.tsx
@@ -45,7 +45,8 @@ type NavEntity =
   | 'Firewalls'
   | 'Account'
   | 'Dashboard'
-  | 'StackScripts';
+  | 'StackScripts'
+  | 'Databases';
 
 interface PrimaryLink {
   display: NavEntity;
@@ -90,6 +91,15 @@ export const PrimaryNav: React.FC<Props> = props => {
     account?.data?.capabilities ?? []
   );
 
+  const showVlans = isFeatureEnabled(
+    'Vlans',
+    Boolean(flags.vlans),
+    account?.data?.capabilities ?? []
+  );
+
+  // No account capability returned yet.
+  const showDatabases = flags.databases;
+
   const primaryLinkGroups: PrimaryLink[][] = React.useMemo(
     () => [
       [
@@ -113,6 +123,7 @@ export const PrimaryNav: React.FC<Props> = props => {
           icon: <Volume />
         },
         {
+          hide: !showVlans,
           display: 'VLANS',
           href: '/vlans',
           icon: <Linode />
@@ -155,6 +166,12 @@ export const PrimaryNav: React.FC<Props> = props => {
           icon: <Kubernetes />
         },
         {
+          hide: !showDatabases,
+          display: 'Databases',
+          href: '/databases',
+          icon: <Storage />
+        },
+        {
           display: 'Object Storage',
           href: '/object-storage/buckets',
           activeLinks: [
@@ -178,6 +195,8 @@ export const PrimaryNav: React.FC<Props> = props => {
     ],
     [
       showFirewalls,
+      showVlans,
+      showDatabases,
       _isManagedAccount,
       domains.loading,
       domains.lastUpdated,

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.tsx
@@ -1,42 +1,39 @@
-import KeyboardArrowDown from '@material-ui/icons/KeyboardArrowDown';
-import {
-  Menu as ReachMenu,
-  MenuButton,
-  MenuItems,
-  MenuLink,
-  MenuLinkProps,
-  MenuPopover
-} from '@reach/menu-button';
+import Settings from '@material-ui/icons/Settings';
 import * as classNames from 'classnames';
 import * as React from 'react';
-import { Link as ReactRouterLink } from 'react-router-dom';
-import Community from 'src/assets/community.svg';
-import Gear from 'src/assets/icons/gear.svg';
-import LogoIcon from 'src/assets/logo/logo.svg';
+import { Link, useLocation, LinkProps } from 'react-router-dom';
+import Kubernetes from 'src/assets/addnewmenu/kubernetes.svg';
+import OCA from 'src/assets/addnewmenu/oneclick.svg';
+import Storage from 'src/assets/icons/entityIcons/bucket.svg';
+import Domain from 'src/assets/icons/entityIcons/domain.svg';
+import Firewall from 'src/assets/icons/entityIcons/firewall.svg';
+import Image from 'src/assets/icons/entityIcons/image.svg';
+import Linode from 'src/assets/icons/entityIcons/linode.svg';
+import NodeBalancer from 'src/assets/icons/entityIcons/nodebalancer.svg';
+import StackScript from 'src/assets/icons/entityIcons/stackscript.svg';
+import Volume from 'src/assets/icons/entityIcons/volume.svg';
+import Longview from 'src/assets/icons/longview.svg';
+import Managed from 'src/assets/icons/managednav.svg';
 import Logo from 'src/assets/logo/new-logo.svg';
-import Help from 'src/assets/primary-nav-help.svg';
+import Divider from 'src/components/core/Divider';
 import Grid from 'src/components/core/Grid';
-import Hidden, { HiddenProps } from 'src/components/core/Hidden';
+import Hidden from 'src/components/core/Hidden';
 import IconButton from 'src/components/core/IconButton';
 import ListItemText from 'src/components/core/ListItemText';
 import Menu from 'src/components/core/Menu';
-import { useMediaQuery } from 'src/components/core/styles';
-import { Link } from 'src/components/Link';
-import UserMenu from 'src/features/TopMenu/UserMenu/UserMenu_CMR';
 import useAccountManagement from 'src/hooks/useAccountManagement';
-import useDomains from 'src/hooks/useDomains';
 import useFlags from 'src/hooks/useFlags';
-import useObjectStorageBuckets from 'src/hooks/useObjectStorageBuckets';
-import useObjectStorageClusters from 'src/hooks/useObjectStorageClusters';
 import usePrefetch from 'src/hooks/usePreFetch';
-import { isFeatureEnabled } from 'src/utilities/accountCapabilities';
-import MobileNav from './MobileNav';
-import usePrimaryNavStyles from './PrimaryNav_CMR.styles';
+import useStyles from './PrimaryNav_CMR.styles';
 import ThemeToggle from './ThemeToggle';
+import { linkIsActive } from './utils';
+import useDomains from 'src/hooks/useDomains';
+import { isFeatureEnabled } from 'src/utilities/accountCapabilities';
 
 type NavEntity =
   | 'Linodes'
   | 'Volumes'
+  | 'VLANS'
   | 'NodeBalancers'
   | 'Domains'
   | 'Longview'
@@ -47,21 +44,8 @@ type NavEntity =
   | 'Images'
   | 'Firewalls'
   | 'Account'
-  | 'StackScripts'
-  | 'Help & Support'
-  | 'Community'
-  | 'Virtual LANs'
-  | 'Databases';
-
-type NavGroup =
-  | 'Compute'
-  | 'Network'
-  | 'Storage'
-  | 'Monitors'
-  | 'Marketplace'
-  | 'Help & Support'
-  | 'Community'
-  | 'None';
+  | 'Dashboard'
+  | 'StackScripts';
 
 interface PrimaryLink {
   display: NavEntity;
@@ -75,41 +59,28 @@ interface PrimaryLink {
   prefetchRequestCondition?: boolean;
 }
 
-// =============================================================================
-// PrimaryNav
-// =============================================================================
-export interface PrimaryNavProps {
+export interface Props {
   closeMenu: () => void;
-  isCollapsed: boolean;
   toggleTheme: () => void;
+  toggleSpacing: () => void; // to keep props same for non-cmr
+  isCollapsed: boolean;
 }
 
-export const PrimaryNav: React.FC<PrimaryNavProps> = props => {
-  const classes = usePrimaryNavStyles();
-  const matchesMobile = useMediaQuery('(max-width:750px)');
-  const matchesTablet = useMediaQuery('(max-width:1190px)');
-
+export const PrimaryNav: React.FC<Props> = props => {
   const { closeMenu, isCollapsed, toggleTheme } = props;
+  const classes = useStyles();
 
   const [anchorEl, setAnchorEl] = React.useState<
     (EventTarget & HTMLElement) | undefined
   >();
 
   const flags = useFlags();
+  const location = useLocation();
   const { domains, requestDomains } = useDomains();
-  const {
-    objectStorageClusters,
-    requestObjectStorageClusters
-  } = useObjectStorageClusters();
-  const {
-    objectStorageBuckets,
-    requestObjectStorageBuckets
-  } = useObjectStorageBuckets();
 
   const {
     _isManagedAccount,
     _isLargeAccount,
-    _isRestrictedUser,
     account
   } = useAccountManagement();
 
@@ -119,148 +90,99 @@ export const PrimaryNav: React.FC<PrimaryNavProps> = props => {
     account?.data?.capabilities ?? []
   );
 
-  const showVlans = isFeatureEnabled(
-    'Vlans',
-    Boolean(flags.vlans),
-    account?.data?.capabilities ?? []
-  );
-
-  const clustersLoadedOrLoadingOrHasError =
-    objectStorageClusters.lastUpdated > 0 ||
-    objectStorageClusters.loading ||
-    objectStorageClusters.error;
-
-  React.useEffect(() => {
-    if (!clustersLoadedOrLoadingOrHasError && !_isRestrictedUser) {
-      requestObjectStorageClusters();
-    }
-  }, [
-    _isRestrictedUser,
-    clustersLoadedOrLoadingOrHasError,
-    requestObjectStorageClusters
-  ]);
-
-  const clusterIds = objectStorageClusters.entities.map(
-    thisCluster => thisCluster.id
-  );
-
-  const primaryLinkGroups: {
-    group: NavGroup;
-    links: PrimaryLink[];
-  }[] = React.useMemo(
+  const primaryLinkGroups: PrimaryLink[][] = React.useMemo(
     () => [
-      {
-        group: 'Compute',
-        links: [
-          {
-            display: 'Linodes',
-            href: '/linodes',
-            activeLinks: ['/linodes', '/linodes/create']
-          },
-          {
-            display: 'Kubernetes',
-            href: '/kubernetes/clusters'
-          },
-          {
-            display: 'StackScripts',
-            href: '/stackscripts?type=account'
-          },
-          {
-            display: 'Images',
-            href: '/images'
-          }
-        ]
-      },
-      {
-        group: 'Network',
-        links: [
-          {
-            display: 'Domains',
-            href: '/domains',
-            prefetchRequestFn: requestDomains,
-            prefetchRequestCondition:
-              !domains.loading && domains.lastUpdated === 0 && !_isLargeAccount
-          },
-          {
-            display: 'Firewalls',
-            href: '/firewalls',
-            hide: !showFirewalls
-          },
-          {
-            display: 'NodeBalancers',
-            href: '/nodebalancers'
-          },
-          {
-            display: 'Virtual LANs',
-            href: '/vlans',
-            hide: !showVlans
-          }
-        ]
-      },
-      {
-        group: 'Storage',
-        links: [
-          {
-            display: 'Volumes',
-            href: '/volumes'
-          },
-          {
-            display: 'Object Storage',
-            href: '/object-storage/buckets',
-            prefetchRequestFn: () => requestObjectStorageBuckets(clusterIds),
-            prefetchRequestCondition:
-              !objectStorageBuckets.loading &&
-              objectStorageBuckets.lastUpdated === 0,
-            activeLinks: [
-              '/object-storage/buckets',
-              '/object-storage/access-keys'
-            ]
-          },
-          {
-            display: 'Databases',
-            href: '/databases',
-            hide: !flags.databases
-          }
-        ]
-      },
-      {
-        group: 'Monitors',
-        links: [
-          {
-            display: 'Longview',
-            href: '/longview'
-          },
-          {
-            display: 'Managed',
-            href: '/managed',
-            hide: !_isManagedAccount
-          }
-        ]
-      },
-      {
-        group: 'None',
-        links: [
-          {
-            display: 'Marketplace',
-            href: '/linodes/create?type=One-Click',
-            attr: { 'data-qa-one-click-nav-btn': true }
-          }
-        ]
-      }
+      [
+        {
+          hide: !_isManagedAccount,
+          display: 'Managed',
+          href: '/managed',
+          icon: <Managed />
+        }
+      ],
+      [
+        {
+          display: 'Linodes',
+          href: '/linodes',
+          activeLinks: ['/linodes', '/linodes/create'],
+          icon: <Linode />
+        },
+        {
+          display: 'Volumes',
+          href: '/volumes',
+          icon: <Volume />
+        },
+        {
+          display: 'VLANS',
+          href: '/vlans',
+          icon: <Linode />
+        },
+        {
+          display: 'NodeBalancers',
+          href: '/nodebalancers',
+          icon: <NodeBalancer />
+        },
+
+        {
+          hide: !showFirewalls,
+          display: 'Firewalls',
+          href: '/firewalls',
+          icon: <Firewall />
+        },
+        {
+          display: 'StackScripts',
+          href: '/stackscripts?type=account',
+          icon: <StackScript />
+        },
+        {
+          display: 'Images',
+          href: '/images',
+          icon: <Image className="small" />
+        }
+      ],
+      [
+        {
+          display: 'Domains',
+          href: '/domains',
+          icon: <Domain style={{ transform: 'scale(1.5)' }} />,
+          prefetchRequestFn: requestDomains,
+          prefetchRequestCondition:
+            !domains.loading && domains.lastUpdated === 0 && !_isLargeAccount
+        },
+        {
+          display: 'Kubernetes',
+          href: '/kubernetes/clusters',
+          icon: <Kubernetes />
+        },
+        {
+          display: 'Object Storage',
+          href: '/object-storage/buckets',
+          activeLinks: [
+            '/object-storage/buckets',
+            '/object-storage/access-keys'
+          ],
+          icon: <Storage />
+        },
+        {
+          display: 'Longview',
+          href: '/longview',
+          icon: <Longview className="small" />
+        },
+        {
+          display: 'Marketplace',
+          href: '/linodes/create?type=One-Click',
+          attr: { 'data-qa-one-click-nav-btn': true },
+          icon: <OCA />
+        }
+      ]
     ],
     [
-      requestDomains,
+      showFirewalls,
+      _isManagedAccount,
       domains.loading,
       domains.lastUpdated,
-      _isLargeAccount,
-      showFirewalls,
-      showVlans,
-      objectStorageBuckets.loading,
-      objectStorageBuckets.lastUpdated,
-      flags.databases,
-      _isManagedAccount,
-      requestObjectStorageBuckets,
-      clusterIds
+      requestDomains,
+      _isLargeAccount
     ]
   );
 
@@ -268,119 +190,146 @@ export const PrimaryNav: React.FC<PrimaryNavProps> = props => {
     <Grid
       className={classes.menuGrid}
       container
-      direction="row"
       alignItems="flex-start"
       justify="flex-start"
+      direction="column"
       wrap="nowrap"
+      spacing={0}
       component="nav"
       role="navigation"
       id="main-navigation"
-      spacing={0}
     >
-      <div className={classes.menuGridInner}>
-        <div className={classes.primaryLinksContainer}>
-          <Grid item>
-            <div
-              className={classNames({
-                [classes.logoItem]: true,
-                [classes.logoCollapsed]: matchesTablet
-              })}
-            >
-              <Link to={`/linodes`} title="Linodes">
-                {matchesTablet ? (
-                  <LogoIcon width={25} height={29} />
-                ) : (
-                  <Logo width={101} height={29} style={{ marginRight: 15 }} />
-                )}
-              </Link>
-            </div>
-          </Grid>
-          {matchesMobile && (
-            <Grid item className={classes.mobileNav}>
-              <MobileNav groups={primaryLinkGroups} />
-            </Grid>
-          )}
-          <div className={classes.hideOnMobile}>
-            {primaryLinkGroups.map(thisGroup => {
-              // For each group, filter out hidden links.
-              const filteredLinks = thisGroup.links.filter(
-                thisLink => !thisLink.hide
-              );
-              if (filteredLinks.length === 0) {
-                return null;
-              }
-              // Render a singular PrimaryNavLink for links without a group.
-              if (thisGroup.group === 'None' && filteredLinks.length === 1) {
-                const link = filteredLinks[0];
+      <Grid item>
+        <div
+          className={classNames({
+            [classes.logoItem]: true,
+            [classes.logoCollapsed]: isCollapsed
+          })}
+        >
+          <Link
+            to={`/dashboard`}
+            onClick={closeMenu}
+            aria-label="Dashboard"
+            title="Dashboard"
+          >
+            <Logo width={115} height={43} />
+          </Link>
+        </div>
+      </Grid>
+      <div
+        className={classNames({
+          ['fade-in-table']: true,
+          [classes.fadeContainer]: true
+        })}
+      >
+        {primaryLinkGroups.map((thisGroup, idx) => {
+          const filteredLinks = thisGroup.filter(thisLink => !thisLink.hide);
+          if (filteredLinks.length === 0) {
+            return null;
+          }
+          return (
+            <div key={idx} className={classes.linkGroup}>
+              {filteredLinks.map(thisLink => {
+                const props = {
+                  key: thisLink.display,
+                  closeMenu,
+                  isCollapsed,
+                  locationSearch: location.search,
+                  locationPathname: location.pathname,
+                  ...thisLink
+                };
 
-                return (
-                  <PrimaryNavLink
-                    key={link.display}
-                    display={link.display}
-                    href={link.href}
-                    closeMenu={closeMenu}
-                    prefetchRequestFn={link.prefetchRequestFn}
-                    prefetchRequestCondition={link.prefetchRequestCondition}
+                // PrefetchPrimaryLink and PrimaryLink are two separate components because invocation of
+                // hooks cannot be conditional. <PrefetchPrimaryLink /> is a wrapper around <PrimaryLink />
+                // that includes the usePrefetch hook.
+                return thisLink.prefetchRequestFn &&
+                  thisLink.prefetchRequestCondition !== undefined ? (
+                  <PrefetchPrimaryLink
+                    {...props}
+                    prefetchRequestFn={thisLink.prefetchRequestFn}
+                    prefetchRequestCondition={thisLink.prefetchRequestCondition}
                   />
+                ) : (
+                  <PrimaryLink {...props} />
                 );
-              }
-              // Otherwise return a NavGroup (dropdown menu).
-              return (
-                <NavGroup
-                  key={thisGroup.group}
-                  group={thisGroup.group}
-                  links={filteredLinks}
-                />
-              );
-            })}
-          </div>
-        </div>
+              })}
+            </div>
+          );
+        })}
 
-        <div className={classes.secondaryLinksContainer}>
-          <PrimaryNavLink
-            key="Help & Support"
-            display="Help & Support"
-            href={'/support'}
-            icon={<Help />}
-            closeMenu={closeMenu}
-            textHiddenProps={{ mdDown: true }}
-          />
-          <PrimaryNavLink
-            key="Community"
-            display="Community"
-            href="https://www.linode.com/community"
-            icon={<Community />}
-            closeMenu={closeMenu}
-            textHiddenProps={{ mdDown: true }}
-          />
-          <IconButton
-            aria-label="User settings"
+        <Hidden mdUp>
+          <Divider className={classes.divider} />
+          <Link
+            to="/profile/display"
+            onClick={closeMenu}
+            data-qa-nav-item="/profile/display"
             className={classNames({
-              [classes.settings]: true,
-              [classes.settingsCollapsed]: isCollapsed,
-              [classes.activeSettings]: !!anchorEl
+              [classes.listItem]: true,
+              [classes.active]:
+                linkIsActive(
+                  '/profile/display',
+                  location.search,
+                  location.pathname
+                ) === true
             })}
-            onClick={(event: React.MouseEvent<HTMLElement>) => {
-              setAnchorEl(event.currentTarget);
-            }}
           >
-            <Gear />
-          </IconButton>
-          <Menu
-            id="settings-menu"
-            anchorEl={anchorEl}
-            open={Boolean(anchorEl)}
-            onClose={() => {
-              setAnchorEl(undefined);
-            }}
-            getContentAnchorEl={undefined}
-            PaperProps={{ square: true, className: classes.paper }}
-            anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+            <ListItemText
+              primary="My Profile"
+              disableTypography={true}
+              className={classNames({
+                [classes.linkItem]: true
+              })}
+            />
+          </Link>
+          <Link
+            to="/logout"
+            onClick={closeMenu}
+            data-qa-nav-item="/logout"
+            className={classNames({
+              [classes.listItem]: true
+            })}
           >
-            <ThemeToggle toggleTheme={toggleTheme} />
-          </Menu>
-          <UserMenu />
-        </div>
+            <ListItemText
+              primary="Log Out"
+              disableTypography={true}
+              className={classNames({
+                [classes.linkItem]: true
+              })}
+            />
+          </Link>
+        </Hidden>
+        <div className={classes.spacer} />
+        <IconButton
+          onClick={(event: React.MouseEvent<HTMLElement>) => {
+            setAnchorEl(event.currentTarget);
+          }}
+          className={classNames({
+            [classes.settings]: true,
+            [classes.settingsCollapsed]: isCollapsed,
+            [classes.activeSettings]: !!anchorEl
+          })}
+          aria-label="User settings"
+        >
+          <Settings />
+        </IconButton>
+        <Menu
+          id="settings-menu"
+          anchorEl={anchorEl}
+          open={Boolean(anchorEl)}
+          onClose={() => {
+            setAnchorEl(undefined);
+          }}
+          getContentAnchorEl={undefined}
+          PaperProps={{ square: true, className: classes.paper }}
+          anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+          transformOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+          className={classes.menu}
+          BackdropProps={{
+            className: classes.settingsBackdrop
+          }}
+        >
+          <ThemeToggle toggleTheme={toggleTheme} />
+        </Menu>
       </div>
     </Grid>
   );
@@ -388,153 +337,98 @@ export const PrimaryNav: React.FC<PrimaryNavProps> = props => {
 
 export default React.memo(PrimaryNav);
 
-// =============================================================================
-// NavGroup
-// =============================================================================
-export interface NavGroupProps {
-  group: NavGroup;
-  links: PrimaryLink[];
-}
-
-export const NavGroup: React.FC<NavGroupProps> = props => {
-  const classes = usePrimaryNavStyles();
-
-  const { group, links } = props;
-
-  return (
-    <div className={classes.menuWrapper}>
-      <ReachMenu>
-        <MenuButton
-          className={`${classes.menuButton} ${classes.linkItem}`}
-          data-testid={`nav-group-${group}`}
-        >
-          {group}
-          <KeyboardArrowDown className={classes.caret} />
-        </MenuButton>
-        <MenuPopover className={classes.menuPopover} portal={false}>
-          <MenuItems className={classes.menuItemList}>
-            {links.map(thisLink => {
-              const {
-                display,
-                href,
-                prefetchRequestCondition,
-                prefetchRequestFn
-              } = thisLink;
-
-              return (
-                <PrimaryNavMenuLink
-                  key={display}
-                  to={href}
-                  display={display}
-                  prefetchRequestFn={prefetchRequestFn}
-                  prefetchRequestCondition={prefetchRequestCondition}
-                >
-                  {display}
-                </PrimaryNavMenuLink>
-              );
-            })}
-          </MenuItems>
-        </MenuPopover>
-      </ReachMenu>
-    </div>
-  );
-};
-
-// =============================================================================
-// PrimaryNavMenuLink
-// =============================================================================
-interface PrimaryNavMenuLinkProps extends MenuLinkProps {
-  display: string;
-  prefetchRequestFn?: () => void;
-  prefetchRequestCondition?: boolean;
-  to: string;
-}
-
-export const PrimaryNavMenuLink: React.FC<PrimaryNavMenuLinkProps> = React.memo(
-  props => {
-    const classes = usePrimaryNavStyles();
-
-    const {
-      display,
-      prefetchRequestFn,
-      prefetchRequestCondition,
-      ...rest
-    } = props;
-
-    const { handlers } = usePrefetch(
-      prefetchRequestFn,
-      prefetchRequestCondition
-    );
-
-    return (
-      <MenuLink
-        as={ReactRouterLink}
-        className={classes.menuItemLink}
-        data-testid={`menu-item-${display}`}
-        {...handlers}
-        {...rest}
-      >
-        {display}
-      </MenuLink>
-    );
-  }
-);
-
-// =============================================================================
-// PrimaryNavLink
-// =============================================================================
-interface PrimaryNavLink extends PrimaryLink {
+interface PrimaryLinkProps extends PrimaryLink {
   closeMenu: () => void;
-  prefetchRequestFn?: () => void;
-  prefetchRequestCondition?: boolean;
-  textHiddenProps?: HiddenProps;
+  isCollapsed: boolean;
+  locationSearch: string;
+  locationPathname: string;
+  prefetchProps?: {
+    onMouseEnter: LinkProps['onMouseEnter'];
+    onMouseLeave: LinkProps['onMouseLeave'];
+    onFocus: LinkProps['onFocus'];
+    onBlur: LinkProps['onBlur'];
+  };
 }
 
-export const PrimaryNavLink: React.FC<PrimaryNavLink> = React.memo(props => {
-  const classes = usePrimaryNavStyles();
-
-  const { handlers } = usePrefetch(
-    props.prefetchRequestFn,
-    props.prefetchRequestCondition
-  );
+const PrimaryLink: React.FC<PrimaryLinkProps> = React.memo(props => {
+  const classes = useStyles();
 
   const {
+    isCollapsed,
     closeMenu,
     href,
     onClick,
     attr,
+    activeLinks,
     icon,
     display,
-    textHiddenProps: hiddenProps
+    locationSearch,
+    locationPathname,
+    prefetchProps
   } = props;
 
-  // @todo: handle external link
   return (
-    <Link
-      to={href}
-      className={classes.listItem}
-      onClick={(e: React.ChangeEvent<any>) => {
-        closeMenu();
-        if (onClick) {
-          onClick(e);
-        }
-      }}
-      {...handlers}
-      {...attr}
-    >
-      {icon && (
-        <div className={`icon ${classes.primaryNavLinkIcon}`}>{icon}</div>
-      )}
-      <Hidden {...hiddenProps}>
-        <ListItemText
-          primary={display}
+    <>
+      <Divider className={classes.divider} />
+      <Link
+        to={href}
+        onClick={(e: React.ChangeEvent<any>) => {
+          closeMenu();
+          if (onClick) {
+            onClick(e);
+          }
+        }}
+        {...prefetchProps}
+        {...attr}
+        className={classNames({
+          [classes.listItem]: true,
+          [classes.active]: linkIsActive(
+            href,
+            locationSearch,
+            locationPathname,
+            activeLinks
+          ),
+          listItemCollapsed: isCollapsed
+        })}
+      >
+        {icon && isCollapsed && (
+          <div className="icon" aria-hidden>
+            {icon}
+          </div>
+        )}
+        <p
           className={classNames({
             [classes.linkItem]: true,
-            primaryNavLink: true
+            primaryNavLink: true,
+            hiddenWhenCollapsed: isCollapsed
           })}
-          disableTypography={true}
-        />
-      </Hidden>
-    </Link>
+        >
+          {display}
+        </p>
+      </Link>
+    </>
   );
+});
+
+interface PrefetchPrimaryLinkProps {
+  prefetchRequestFn: () => void;
+  prefetchRequestCondition: boolean;
+}
+
+// Wrapper around PrimaryLink that includes the usePrefetchHook.
+export const PrefetchPrimaryLink: React.FC<PrimaryLinkProps &
+  PrefetchPrimaryLinkProps> = React.memo(props => {
+  const { makeRequest, cancelRequest } = usePrefetch(
+    props.prefetchRequestFn,
+    props.prefetchRequestCondition
+  );
+
+  const prefetchProps: PrimaryLinkProps['prefetchProps'] = {
+    onMouseEnter: makeRequest,
+    onFocus: makeRequest,
+    onMouseLeave: cancelRequest,
+    onBlur: cancelRequest
+  };
+
+  return <PrimaryLink {...props} prefetchProps={prefetchProps} />;
 });

--- a/packages/manager/src/components/SideMenu.tsx
+++ b/packages/manager/src/components/SideMenu.tsx
@@ -8,9 +8,15 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 import PrimaryNav from 'src/components/PrimaryNav';
+import { compose } from 'recompose';
+import withFeatureFlagConsumer, {
+  FeatureFlagConsumerProps
+} from 'src/containers/withFeatureFlagConsumer.container';
+import PrimaryNav_CMR from './PrimaryNav/PrimaryNav_CMR';
 
 type ClassNames =
   | 'menuPaper'
+  | 'menuPaperCMR'
   | 'menuDocked'
   | 'desktopMenu'
   | 'collapsedDesktopMenu';
@@ -29,6 +35,16 @@ const styles = (theme: Theme) =>
       [theme.breakpoints.up('xl')]: {
         width: theme.spacing(22) + 99 // 275
       }
+    },
+    menuPaperCMR: {
+      height: '100%',
+      width: 200,
+      backgroundColor: theme.bg.primaryNavPaper,
+      borderRight: 'none',
+      left: 'inherit',
+      boxShadow: 'none',
+      transition: 'width linear .1s',
+      overflowX: 'hidden'
     },
     menuDocked: {
       height: '100%'
@@ -55,7 +71,7 @@ interface Props {
   toggleSpacing: () => void;
 }
 
-type CombinedProps = Props & WithStyles<ClassNames>;
+type CombinedProps = Props & WithStyles<ClassNames> & FeatureFlagConsumerProps;
 
 class SideMenu extends React.Component<CombinedProps> {
   render() {
@@ -65,8 +81,11 @@ class SideMenu extends React.Component<CombinedProps> {
       desktopOpen,
       closeMenu,
       toggleSpacing,
-      toggleTheme
+      toggleTheme,
+      flags
     } = this.props;
+
+    const PrimaryNavComponent = flags.cmr ? PrimaryNav_CMR : PrimaryNav;
 
     return (
       <React.Fragment>
@@ -74,13 +93,15 @@ class SideMenu extends React.Component<CombinedProps> {
           <Drawer
             variant="temporary"
             open={open}
-            classes={{ paper: classes.menuPaper }}
+            classes={{
+              paper: flags.cmr ? classes.menuPaperCMR : classes.menuPaper
+            }}
             onClose={closeMenu}
             ModalProps={{
               keepMounted: true // Better open performance on mobile.
             }}
           >
-            <PrimaryNav
+            <PrimaryNavComponent
               closeMenu={closeMenu}
               toggleTheme={toggleTheme}
               toggleSpacing={toggleSpacing}
@@ -93,14 +114,14 @@ class SideMenu extends React.Component<CombinedProps> {
             variant="permanent"
             open
             classes={{
-              paper: `${classes.menuPaper} ${
+              paper: `${flags.cmr ? classes.menuPaperCMR : classes.menuPaper} ${
                 desktopOpen ? classes.collapsedDesktopMenu : ''
               }`,
               docked: classes.menuDocked
             }}
             className={classes.desktopMenu}
           >
-            <PrimaryNav
+            <PrimaryNavComponent
               closeMenu={closeMenu}
               toggleTheme={toggleTheme}
               toggleSpacing={toggleSpacing}
@@ -113,6 +134,9 @@ class SideMenu extends React.Component<CombinedProps> {
   }
 }
 
-const styled = withStyles(styles);
+const enhanced = compose<CombinedProps, Props>(
+  withStyles(styles),
+  withFeatureFlagConsumer
+);
 
-export default styled(SideMenu);
+export default enhanced(SideMenu);

--- a/packages/manager/src/features/Footer/Footer_CMR.tsx
+++ b/packages/manager/src/features/Footer/Footer_CMR.tsx
@@ -27,12 +27,15 @@ type CSSClasses =
 const styles = (theme: Theme) =>
   createStyles({
     container: {
-      margin: `0 auto`,
-      maxWidth: 1280,
       width: '100%',
+      backgroundColor: theme.bg.main,
+      margin: 0,
       [theme.breakpoints.down('xs')]: {
         flexDirection: 'column',
         alignItems: 'flex-start'
+      },
+      [theme.breakpoints.up('md')]: {
+        paddingLeft: 200
       }
     },
     desktopMenuIsOpen: {
@@ -42,6 +45,7 @@ const styles = (theme: Theme) =>
       }
     },
     version: {
+      marginLeft: 24,
       flex: 1,
       '&.MuiGrid-item': {
         paddingLeft: 0


### PR DESCRIPTION
## Description

To do this, I re-copied what was in `PrimaryNav.tsx` into `PrimaryNav_CMR.tsx` and made the following adjustments:

1. Group nav items (denoted by margin)
2. Replace hover state with gradient

I also adjusted the main content spacing to work with the new (old) layout.

**Notes:**

- I'm waiting on the designs for final spacing/placement + logos. This can be reviewed/merged as-is, though.
- The preferences "gear icon" will eventually be moved somewhere else, but I left it in for now so we can easily toggle dark theme.

![Screen Shot 2020-12-02 at 2 44 50 PM](https://user-images.githubusercontent.com/16911484/100923263-eff8a080-34ac-11eb-88c4-0426f317ab62.png)
