### PR TITLE
M3-4717 Change: Hide empty notification sections in drawer

### DIFF
--- a/packages/manager/src/features/NotificationCenter/NotificationDrawer.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationDrawer.tsx
@@ -1,19 +1,20 @@
 import * as React from 'react';
 import Clock from 'src/assets/icons/clock.svg';
+import IconButton from 'src/components/core/IconButton';
 import { makeStyles, Theme } from 'src/components/core/styles';
+import Tooltip from 'src/components/core/Tooltip';
 import Typography from 'src/components/core/Typography';
 import Drawer from 'src/components/Drawer';
+import Link from 'src/components/Link';
+import useAccount from 'src/hooks/useAccount';
+import usePreferences from 'src/hooks/usePreferences';
 import Community from './Community';
 import Maintenance from './Maintenance';
+import { NotificationData } from './NotificationData/useNotificationData';
+import { ContentRow, NotificationItem } from './NotificationSection';
 import OpenSupportTickets from './OpenSupportTickets';
 import PastDue from './PastDue';
 import PendingActions from './PendingActions';
-import useAccount from 'src/hooks/useAccount';
-import usePreferences from 'src/hooks/usePreferences';
-import IconButton from 'src/components/core/IconButton';
-import { NotificationData } from './NotificationData/useNotificationData';
-import { ContentRow, NotificationItem } from './NotificationSection';
-import Tooltip from 'src/components/core/Tooltip';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -105,12 +106,15 @@ export const NotificationDrawer: React.FC<Props> = props => {
       </div>
 
       {chronologicalView ? (
-        <ChronologicalView notifications={chronologicalNotificationList} />
+        <ChronologicalView
+          notifications={chronologicalNotificationList}
+          onClose={onClose}
+        />
       ) : (
         <div className={classes.notificationSectionContainer}>
           {chronologicalNotificationList.length === 0 ? (
             // If this list is empty there's nothing to show regardless of selected view.
-            <Typography>No notifications to display.</Typography>
+            <EmptyMessage onClose={onClose} />
           ) : null}
           <PendingActions pendingActions={pendingActions} onClose={onClose} />
           <Maintenance statusNotifications={statusNotifications} />
@@ -133,13 +137,25 @@ export const NotificationDrawer: React.FC<Props> = props => {
 
 export default React.memo(NotificationDrawer);
 
+const EmptyMessage: React.FC<{ onClose: () => void }> = React.memo(props => {
+  return (
+    <Typography>
+      No notifications to display.{' '}
+      <Link to="/events" onClick={props.onClose}>
+        View event history.
+      </Link>
+    </Typography>
+  );
+});
+
 interface ChronoProps {
   notifications: NotificationItem[];
+  onClose: () => void;
 }
 const ChronologicalView: React.FC<ChronoProps> = props => {
-  const { notifications } = props;
+  const { notifications, onClose } = props;
   if (notifications.length === 0) {
-    return <Typography>No notifications to display.</Typography>;
+    return <EmptyMessage onClose={onClose} />;
   }
   return (
     <>

--- a/packages/manager/src/features/NotificationCenter/NotificationDrawer.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationDrawer.tsx
@@ -108,6 +108,10 @@ export const NotificationDrawer: React.FC<Props> = props => {
         <ChronologicalView notifications={chronologicalNotificationList} />
       ) : (
         <div className={classes.notificationSectionContainer}>
+          {chronologicalNotificationList.length === 0 ? (
+            // If this list is empty there's nothing to show regardless of selected view.
+            <Typography>No notifications to display.</Typography>
+          ) : null}
           <PendingActions pendingActions={pendingActions} onClose={onClose} />
           <Maintenance statusNotifications={statusNotifications} />
           <OpenSupportTickets

--- a/packages/manager/src/features/NotificationCenter/NotificationSection.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationSection.tsx
@@ -95,6 +95,10 @@ export const NotificationSection: React.FC<Props> = props => {
   const _loading = Boolean(loading); // false if not provided
   const classes = useStyles();
 
+  if (content.length === 0) {
+    return null;
+  }
+
   const innerContent = () => {
     return (
       <ContentBody


### PR DESCRIPTION
## Description


- Change NotificationSection to return null if the passed list
of notifications is empty
- Add a message for section view saying "nothing to see here"
if all sections are empty (chronological view already has this message)

