### PR TITLE
Left-align billing buttons

### DIFF
--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
@@ -85,8 +85,25 @@ const useStyles = makeStyles((theme: Theme) => ({
   iconButtonOuter: {
     display: 'flex',
     justifyContent: 'space-between',
-    [theme.breakpoints.between('sm', 'md')]: {
+    '& button, & a': {
+      justifyContent: 'flex-start'
+    },
+    [theme.breakpoints.down('md')]: {
+      justifyContent: 'flex-start'
+    },
+    [theme.breakpoints.only('xs')]: {
       flexDirection: 'column'
+    },
+    [theme.breakpoints.only('md')]: {
+      flexDirection: 'column'
+    }
+  },
+  invoiceButton: {
+    [theme.breakpoints.only('sm')]: {
+      paddingLeft: 32
+    },
+    '& button': {
+      paddingLeft: '0'
     }
   },
   iconButton: {
@@ -193,15 +210,15 @@ export const BillingSummary: React.FC<Props> = props => {
                 onClick={openPaymentDrawer}
                 className={classes.iconButton}
               />
-
-              <IconTextLink
-                SideIcon={InvoiceIcon}
-                text="View last invoice"
-                title="View last invoice"
-                to={`/account/billing/invoices/${mostRecentInvoiceId}`}
-                className={classes.iconButton}
-                disabled={!mostRecentInvoiceId}
-              />
+              <span className={`${classes.invoiceButton}`}>
+                <IconTextLink
+                  SideIcon={InvoiceIcon}
+                  text="View last invoice"
+                  title="View last invoice"
+                  to={`/account/billing/invoices/${mostRecentInvoiceId}`}
+                  disabled={!mostRecentInvoiceId}
+                />
+              </span>
             </div>
           </Grid>
           <Grid item xs={12} md={4} className={classes.gridItem}>

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
@@ -210,7 +210,7 @@ export const BillingSummary: React.FC<Props> = props => {
                 onClick={openPaymentDrawer}
                 className={classes.iconButton}
               />
-              <span className={`${classes.invoiceButton}`}>
+              <span className={classes.invoiceButton}>
                 <IconTextLink
                   SideIcon={InvoiceIcon}
                   text="View last invoice"


### PR DESCRIPTION
## Description

Improve alignment of the "Make a Payment" and "View last invoice" buttons: 

![Screen Shot 2020-12-08 at 1 19 35 PM](https://user-images.githubusercontent.com/16911484/101524590-22e0df80-3958-11eb-8c45-952db8f3ba1f.png)

Please check all viewport sizes.