### PR TITLE
M3-4702 Change: Update empty states for all entities

### DIFF
--- a/packages/manager/src/components/EntityTable/EntityTableHeader.tsx
+++ b/packages/manager/src/components/EntityTable/EntityTableHeader.tsx
@@ -110,6 +110,7 @@ export const EntityTableHeader: React.FC<Props> = props => {
             ) : (
               <_SortCell
                 thisCell={thisCell}
+                key={thisCell.dataColumn}
                 order={order}
                 orderBy={orderBy}
                 handleOrderChange={handleOrderChange}

--- a/packages/manager/src/components/NotFound.tsx
+++ b/packages/manager/src/components/NotFound.tsx
@@ -13,7 +13,6 @@ const NotFound = (props: Props) => {
     <Placeholder
       icon={ErrorOutline}
       title="Not Found"
-      copy=""
       animate={false}
       className={props.className}
     />

--- a/packages/manager/src/components/Placeholder/Placeholder.tsx
+++ b/packages/manager/src/components/Placeholder/Placeholder.tsx
@@ -77,7 +77,8 @@ const styles = (theme: Theme) =>
       color: theme.color.green
     },
     title: {
-      textAlign: 'center'
+      textAlign: 'center',
+      marginBottom: theme.spacing(2)
     },
     '& .insidePath path': {
       opacity: 0,

--- a/packages/manager/src/components/Placeholder/Placeholder.tsx
+++ b/packages/manager/src/components/Placeholder/Placeholder.tsx
@@ -11,7 +11,7 @@ import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 import H1Header from 'src/components/H1Header';
 
-type ClassNames = 'root' | 'title' | 'copy' | 'icon' | 'button';
+type ClassNames = 'root' | 'title' | 'copy' | 'icon' | 'button' | 'entity';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -71,6 +71,11 @@ const styles = (theme: Theme) =>
         fill: theme.palette.primary.main
       }
     },
+    entity: {
+      borderRadius: '50%',
+      backgroundColor: theme.bg.offWhite,
+      color: theme.color.green
+    },
     title: {
       textAlign: 'center'
     },
@@ -94,10 +99,11 @@ export interface ExtendedButtonProps extends ButtonProps {
 export interface Props {
   icon?: React.ComponentType<any>;
   animate?: boolean;
-  copy?: string | React.ReactNode;
+  children?: string | React.ReactNode;
   title: string;
   buttonProps?: ExtendedButtonProps[];
   className?: string;
+  isEntity?: boolean;
   renderAsSecondary?: boolean;
 }
 
@@ -107,7 +113,7 @@ const Placeholder: React.FC<CombinedProps> = props => {
   const {
     animate,
     classes,
-    copy,
+    isEntity,
     title,
     icon: Icon,
     buttonProps,
@@ -123,7 +129,12 @@ const Placeholder: React.FC<CombinedProps> = props => {
       className={`${classes.root} ${props.className}`}
     >
       <Grid item xs={12}>
-        {Icon && <Icon className={`${classes.icon} ${animate && 'animate'}`} />}
+        {Icon && (
+          <Icon
+            className={`${classes.icon} ${animate && 'animate'} ${isEntity &&
+              classes.entity}`}
+          />
+        )}
       </Grid>
       <Grid item xs={12}>
         <H1Header
@@ -134,10 +145,10 @@ const Placeholder: React.FC<CombinedProps> = props => {
         />
       </Grid>
       <Grid item xs={12} lg={10} className={classes.copy}>
-        {typeof copy === 'string' ? (
-          <Typography variant="subtitle1">{copy}</Typography>
+        {typeof props.children === 'string' ? (
+          <Typography variant="subtitle1">{props.children}</Typography>
         ) : (
-          copy
+          props.children
         )}
       </Grid>
       {buttonProps && (
@@ -167,9 +178,6 @@ const Placeholder: React.FC<CombinedProps> = props => {
 
 Placeholder.defaultProps = {
   icon: LinodeIcon,
-  copy:
-    'The feature you are looking for is currently in development. Please check back soon.',
-  title: 'Feature in Progress',
   animate: true
 };
 

--- a/packages/manager/src/components/Typography.stories.tsx
+++ b/packages/manager/src/components/Typography.stories.tsx
@@ -42,10 +42,9 @@ storiesOf('Typography', module).add('Headings', () => (
       list state.
     </Typography>
     <Divider />
-    <Placeholder
-      title="Placeholder/Null Heading"
-      copy="This is a separate component utilized for null state headings."
-    />
+    <Placeholder title="Placeholder/Null Heading">
+      This is a separate component utilized for null state headings.
+    </Placeholder>
     <Divider />
   </React.Fragment>
 ));

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseEmptyState.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseEmptyState.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import Typography from 'src/components/core/Typography';
+import Link from 'src/components/Link';
+import Placeholder from 'src/components/Placeholder';
+import DatabaseIcon from 'src/assets/icons/entityIcons/bucket.svg';
+
+interface Props {
+  openAddDatabaseDrawer?: () => void;
+}
+
+const FirewallEmptyState: React.FC<Props> = props => {
+  const { openAddDatabaseDrawer } = props;
+  return (
+    <Placeholder
+      title={'Databases'}
+      icon={DatabaseIcon}
+      isEntity
+      buttonProps={[
+        {
+          onClick: openAddDatabaseDrawer,
+          children: 'Add a Database'
+        }
+      ]}
+    >
+      <Typography variant="subtitle1">
+        <div>Take control of your data with managed MySQL Databases.</div>
+        <Link to="https://www.linode.com/docs">
+          Get started with Databases.
+        </Link>
+      </Typography>
+    </Placeholder>
+  );
+};
+
+export default React.memo(FirewallEmptyState);

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
@@ -1,6 +1,7 @@
 import { Database } from '@linode/api-v4/lib/databases/types';
 import { groupBy, prop } from 'ramda';
 import * as React from 'react';
+import CircleProgress from 'src/components/CircleProgress';
 import Chip from 'src/components/core/Chip';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import DeletionDialog from 'src/components/DeletionDialog';
@@ -11,10 +12,12 @@ import TagDrawer, {
   OpenTagDrawer,
   TagDrawerProps
 } from 'src/components/TagCell/TagDrawer';
+import { dbaasContext } from 'src/context';
 import useDatabases from 'src/hooks/useDatabases';
 import { useDialog } from 'src/hooks/useDialog';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { ActionHandlers as DatabaseHandlers } from './DatabaseActionMenu';
+import DatabaseEmptyState from './DatabaseEmptyState';
 import DatabaseRow from './DatabaseRow';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -118,6 +121,7 @@ const DatabaseLanding: React.FC<{}> = _ => {
   );
 
   const databaseData = Object.values(databases.itemsById ?? {});
+  const openCreateDialog = React.useContext(dbaasContext).open;
 
   const [tagDrawer, setTagDrawer] = React.useState<TagDrawerProps>({
     open: false,
@@ -178,6 +182,14 @@ const DatabaseLanding: React.FC<{}> = _ => {
       'Error loading your databases.'
     )[0].reason;
     return <ErrorState errorText={message} />;
+  }
+
+  if (databases.loading) {
+    return <CircleProgress />;
+  }
+
+  if (databaseData.length === 0) {
+    return <DatabaseEmptyState openAddDatabaseDrawer={openCreateDialog} />;
   }
 
   const { ready, error, initializing, unknown } = counts;

--- a/packages/manager/src/features/Domains/DomainsLanding.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 import { connect, MapStateToProps } from 'react-redux';
 import { Link, RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
-import DomainIcon from 'src/assets/addnewmenu/domain.svg';
+import DomainIcon from 'src/assets/icons/entityIcons/domain.svg';
 import AddNewLink from 'src/components/AddNewLink';
 import Breadcrumb from 'src/components/Breadcrumb';
 import Button from 'src/components/Button';
@@ -583,35 +583,6 @@ const RenderError: React.FC<{}> = () => {
   );
 };
 
-const EmptyCopy = () => (
-  <>
-    <Typography variant="subtitle1">
-      Create a Domain, add Domain records, import zones and domains.
-    </Typography>
-    <Typography variant="subtitle1">
-      <a
-        href="https://www.linode.com/docs/platform/manager/dns-manager-new-manager/"
-        target="_blank"
-        aria-describedby="external-site"
-        rel="noopener noreferrer"
-        className="h-u"
-      >
-        Find out how to setup your domains associated with your Linodes
-      </a>
-      &nbsp;or&nbsp;
-      <a
-        href="https://www.linode.com/docs/"
-        target="_blank"
-        aria-describedby="external-site"
-        rel="noopener noreferrer"
-        className="h-u"
-      >
-        visit our guides and tutorials.
-      </a>
-    </Typography>
-  </>
-);
-
 const RenderEmpty: React.FC<{
   onCreateDomain: () => void;
   onImportZone: () => void;
@@ -620,8 +591,8 @@ const RenderEmpty: React.FC<{
     <React.Fragment>
       <DocumentTitleSegment segment="Domains" />
       <Placeholder
-        title="Manage your Domains"
-        copy={<EmptyCopy />}
+        title="Domains"
+        isEntity
         icon={DomainIcon}
         buttonProps={[
           {
@@ -633,7 +604,32 @@ const RenderEmpty: React.FC<{
             children: 'Import a Zone'
           }
         ]}
-      />
+      >
+        <Typography variant="subtitle1">
+          Create a Domain, add Domain records, import zones and domains.
+        </Typography>
+        <Typography variant="subtitle1">
+          <a
+            href="https://www.linode.com/docs/platform/manager/dns-manager-new-manager/"
+            target="_blank"
+            aria-describedby="external-site"
+            rel="noopener noreferrer"
+            className="h-u"
+          >
+            Find out how to setup your domains associated with your Linodes
+          </a>
+          &nbsp;or&nbsp;
+          <a
+            href="https://www.linode.com/docs/"
+            target="_blank"
+            aria-describedby="external-site"
+            rel="noopener noreferrer"
+            className="h-u"
+          >
+            visit our guides and tutorials.
+          </a>
+        </Typography>
+      </Placeholder>
     </React.Fragment>
   );
 };

--- a/packages/manager/src/features/Domains/DomainsLanding.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.tsx
@@ -4,14 +4,13 @@ import { withSnackbar, WithSnackbarProps } from 'notistack';
 import { equals, pathOr } from 'ramda';
 import * as React from 'react';
 import { connect, MapStateToProps } from 'react-redux';
-import { Link, RouteComponentProps } from 'react-router-dom';
+import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
 import DomainIcon from 'src/assets/icons/entityIcons/domain.svg';
 import AddNewLink from 'src/components/AddNewLink';
 import Breadcrumb from 'src/components/Breadcrumb';
 import Button from 'src/components/Button';
 import CircleProgress from 'src/components/CircleProgress';
-import DeletionDialog from 'src/components/DeletionDialog';
 import FormControlLabel from 'src/components/core/FormControlLabel';
 import {
   createStyles,
@@ -20,6 +19,7 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
+import DeletionDialog from 'src/components/DeletionDialog';
 import setDocs from 'src/components/DocsSidebar/setDocs';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import EntityTable, {
@@ -30,6 +30,7 @@ import EntityTable_CMR from 'src/components/EntityTable/EntityTable_CMR';
 import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
 import LandingHeader from 'src/components/LandingHeader';
+import Link from 'src/components/Link';
 import Notice from 'src/components/Notice';
 import { Order } from 'src/components/Pagey';
 import Placeholder from 'src/components/Placeholder';
@@ -609,25 +610,13 @@ const RenderEmpty: React.FC<{
           Create a Domain, add Domain records, import zones and domains.
         </Typography>
         <Typography variant="subtitle1">
-          <a
-            href="https://www.linode.com/docs/platform/manager/dns-manager-new-manager/"
-            target="_blank"
-            aria-describedby="external-site"
-            rel="noopener noreferrer"
-            className="h-u"
-          >
-            Find out how to setup your domains associated with your Linodes
-          </a>
+          <Link to="https://www.linode.com/docs/platform/manager/dns-manager-new-manager/">
+            Get help managing your Domains
+          </Link>
           &nbsp;or&nbsp;
-          <a
-            href="https://www.linode.com/docs/"
-            target="_blank"
-            aria-describedby="external-site"
-            rel="noopener noreferrer"
-            className="h-u"
-          >
+          <Link to="https://www.linode.com/docs/">
             visit our guides and tutorials.
-          </a>
+          </Link>
         </Typography>
       </Placeholder>
     </React.Fragment>

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallEmptyState.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallEmptyState.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import Typography from 'src/components/core/Typography';
+import Link from 'src/components/Link';
+import Placeholder from 'src/components/Placeholder';
+import FirewallIcon from 'src/assets/icons/entityIcons/firewall.svg';
+
+interface Props {
+  openAddFirewallDrawer: () => void;
+}
+
+const FirewallEmptyState: React.FC<Props> = props => {
+  const { openAddFirewallDrawer } = props;
+  return (
+    <Placeholder
+      title={'Firewalls'}
+      icon={FirewallIcon}
+      isEntity
+      buttonProps={[
+        {
+          onClick: openAddFirewallDrawer,
+          children: 'Add a Firewall'
+        }
+      ]}
+    >
+      <Typography variant="subtitle1">
+        <div>Control network access to your Linodes from the Cloud.</div>
+        <Link to="https://www.linode.com/docs/guides/getting-started-with-cloud-firewall/">
+          Get started with Cloud Firewalls.
+        </Link>
+      </Typography>
+    </Placeholder>
+  );
+};
+
+export default React.memo(FirewallEmptyState);

--- a/packages/manager/src/features/Images/ImagesLanding.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding.tsx
@@ -1,6 +1,6 @@
-import produce from 'immer';
 import { Image } from '@linode/api-v4/lib/images';
 import { APIError } from '@linode/api-v4/lib/types';
+import produce from 'immer';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import * as React from 'react';
 import { connect, MapDispatchToProps } from 'react-redux';
@@ -8,6 +8,7 @@ import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
 import { AnyAction } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
+import ImageIcon from 'src/assets/icons/entityIcons/image.svg';
 import ActionsPanel from 'src/components/ActionsPanel';
 import AddNewLink from 'src/components/AddNewLink';
 import Breadcrumb from 'src/components/Breadcrumb';
@@ -26,11 +27,13 @@ import EntityTable_CMR from 'src/components/EntityTable/EntityTable_CMR';
 import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
 import LandingHeader from 'src/components/LandingHeader';
+import Link from 'src/components/Link';
 import Notice from 'src/components/Notice';
 import Placeholder from 'src/components/Placeholder';
 import useFlags from 'src/hooks/useFlags';
 import useReduxLoad from 'src/hooks/useReduxLoad';
 import { ApplicationState } from 'src/store';
+import { DeleteImagePayload } from 'src/store/image/image.actions';
 import {
   deleteImage as _deleteImage,
   requestImages as _requestImages
@@ -41,7 +44,6 @@ import ImageRow, { ImageWithEvent } from './ImageRow';
 import ImageRow_CMR from './ImageRow_CMR';
 import { Handlers as ImageHandlers } from './ImagesActionMenu';
 import ImagesDrawer, { DrawerMode } from './ImagesDrawer';
-import { DeleteImagePayload } from 'src/store/image/image.actions';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {},
@@ -351,15 +353,29 @@ export const ImagesLanding: React.FC<CombinedProps> = props => {
       <React.Fragment>
         <DocumentTitleSegment segment="Images" />
         <Placeholder
-          title="Add an Image"
-          copy={<EmptyCopy />}
+          title="Images"
+          icon={ImageIcon}
+          isEntity
           buttonProps={[
             {
               onClick: openForCreate,
               children: 'Add an Image'
             }
           ]}
-        />
+        >
+          <Typography variant="subtitle1">
+            Adding an image is easy. Click here to
+          </Typography>
+          <Typography variant="subtitle1">
+            <Link to="https://linode.com/docs/platform/disk-images/linode-images-new-manager/">
+              learn more about Images
+            </Link>
+            &nbsp;or&nbsp;
+            <Link to="https://linode.com/docs/quick-answers/linode-platform/deploy-an-image-to-a-linode">
+              deploy an Image to a Linode.
+            </Link>
+          </Typography>
+        </Placeholder>
         {renderImageDrawer()}
       </React.Fragment>
     );
@@ -434,35 +450,6 @@ export const ImagesLanding: React.FC<CombinedProps> = props => {
     </React.Fragment>
   );
 };
-
-const EmptyCopy = () => (
-  <>
-    <Typography variant="subtitle1">
-      Adding an image is easy. Click here to
-    </Typography>
-    <Typography variant="subtitle1">
-      <a
-        href="https://linode.com/docs/platform/disk-images/linode-images-new-manager/"
-        target="_blank"
-        aria-describedby="external-site"
-        rel="noopener noreferrer"
-        className="h-u"
-      >
-        learn more about Images
-      </a>
-      &nbsp;or&nbsp;
-      <a
-        href="https://linode.com/docs/quick-answers/linode-platform/deploy-an-image-to-a-linode"
-        target="_blank"
-        aria-describedby="external-site"
-        rel="noopener noreferrer"
-        className="h-u"
-      >
-        deploy an Image to a Linode.
-      </a>
-    </Typography>
-  </>
-);
 interface WithPrivateImages {
   imagesData: ImageWithEvent[];
   imagesLoading: boolean;

--- a/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLandingEmptyState.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLandingEmptyState.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'redux';
-import KubernetesSvg from 'src/assets/addnewmenu/kubernetes.svg';
+import KubernetesSvg from 'src/assets/icons/entityIcons/kubernetes.svg';
 import Typography from 'src/components/core/Typography';
 import Placeholder from 'src/components/Placeholder';
 
@@ -9,8 +9,19 @@ type Props = RouteComponentProps<{}>;
 
 class KubernetesEmptyState extends React.Component<Props> {
   render() {
-    const SubtitleCopy = () => (
-      <>
+    return (
+      <Placeholder
+        title="Kubernetes Clusters"
+        isEntity
+        icon={KubernetesSvg}
+        buttonProps={[
+          {
+            onClick: () => this.props.history.push('/kubernetes/create'),
+            children: 'Create a Cluster'
+          }
+        ]}
+      >
+        {' '}
         <Typography variant="subtitle1">Need help getting started?</Typography>
         <Typography variant="subtitle1">
           <a
@@ -22,21 +33,7 @@ class KubernetesEmptyState extends React.Component<Props> {
             Learn more about getting started with LKE.
           </a>
         </Typography>
-      </>
-    );
-
-    return (
-      <Placeholder
-        title="Add your first Kubernetes cluster!"
-        copy={<SubtitleCopy />}
-        icon={KubernetesSvg}
-        buttonProps={[
-          {
-            onClick: () => this.props.history.push('/kubernetes/create'),
-            children: 'Create a Cluster'
-          }
-        ]}
-      />
+      </Placeholder>
     );
   }
 }

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Disks/Disks.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Disks/Disks.tsx
@@ -96,11 +96,9 @@ const Disks: React.FC<CombinedProps> = props => {
     if (!loading && sortedKeys.length === 0) {
       // Empty state
       return (
-        <Placeholder
-          title="No disks detected"
-          copy="The Longview agent has not detected any disks that it can monitor."
-          renderAsSecondary
-        />
+        <Placeholder title="No disks detected" renderAsSecondary>
+          The Longview agent has not detected any disks that it can monitor.
+        </Placeholder>
       );
     }
 

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Network/NetworkGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Network/NetworkGraphs.tsx
@@ -63,11 +63,9 @@ export const NetworkGraphs: React.FC<CombinedProps> = props => {
   if (interfaces.length === 0 && !loading) {
     // Empty state
     return (
-      <Placeholder
-        title="No network interfaces detected"
-        copy="The Longview agent has not detected any interfaces that it can monitor."
-        renderAsSecondary
-      />
+      <Placeholder title="No network interfaces detected" renderAsSecondary>
+        The Longview agent has not detected any interfaces that it can monitor.
+      </Placeholder>
     );
   }
 

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLandingEmptyState.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLandingEmptyState.tsx
@@ -1,21 +1,19 @@
 import * as React from 'react';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
-import { compose } from 'recompose';
-import NodeBalancer from 'src/assets/addnewmenu/nodebalancer.svg';
+import { useHistory } from 'react-router-dom';
+import NodeBalancer from 'src/assets/icons/entityIcons/nodebalancer.svg';
 import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import Link from 'src/components/Link';
 import Placeholder from 'src/components/Placeholder';
 
-type CombinedProps = RouteComponentProps<any>;
-
-const NodeBalancerLandingEmptyState: React.FC<CombinedProps> = props => {
-  const { history } = props;
+const NodeBalancerLandingEmptyState: React.FC<{}> = _ => {
+  const history = useHistory();
   return (
     <React.Fragment>
       <DocumentTitleSegment segment="NodeBalancers" />
       <Placeholder
-        title="Add NodeBalancers!"
-        copy={<EmptyCopy />}
+        title="NodeBalancers"
+        isEntity
         icon={NodeBalancer}
         buttonProps={[
           {
@@ -23,37 +21,19 @@ const NodeBalancerLandingEmptyState: React.FC<CombinedProps> = props => {
             children: 'Add a NodeBalancer'
           }
         ]}
-      />
+      >
+        <Typography variant="subtitle1">
+          <Link to="https://www.linode.com/docs/platform/nodebalancer/getting-started-with-nodebalancers/">
+            Learn how to use NodeBalancers with your Linode
+          </Link>
+          &nbsp;or&nbsp;
+          <Link to="https://www.linode.com/docs/">
+            visit our guides and tutorials.
+          </Link>
+        </Typography>
+      </Placeholder>
     </React.Fragment>
   );
 };
 
-const EmptyCopy = () => (
-  <>
-    <Typography variant="subtitle1">
-      <a
-        href="https://www.linode.com/docs/platform/nodebalancer/getting-started-with-nodebalancers/"
-        target="_blank"
-        aria-describedby="external-site"
-        rel="noopener noreferrer"
-        className="h-u"
-      >
-        Learn how to use NodeBalancers with your Linode
-      </a>
-      &nbsp;or&nbsp;
-      <a
-        href="https://www.linode.com/docs/"
-        target="_blank"
-        aria-describedby="external-site"
-        rel="noopener noreferrer"
-        className="h-u"
-      >
-        visit our guides and tutorials.
-      </a>
-    </Typography>
-  </>
-);
-
-const enhanced = compose<CombinedProps, {}>(withRouter);
-
-export default enhanced(NodeBalancerLandingEmptyState);
+export default React.memo(NodeBalancerLandingEmptyState);

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
@@ -311,7 +311,7 @@ const RenderEmpty: React.FC<{
       <DocumentTitleSegment segment="Buckets" />
       <Placeholder
         title="Object Storage"
-        copy={<EmptyCopy />}
+        isEntity
         icon={BucketIcon}
         renderAsSecondary
         buttonProps={[
@@ -320,28 +320,24 @@ const RenderEmpty: React.FC<{
             children: 'Add a Bucket'
           }
         ]}
-      />
+      >
+        <Typography variant="subtitle1">Need help getting started?</Typography>
+        <Typography variant="subtitle1">
+          <a
+            href="https://linode.com/docs/platform/object-storage"
+            target="_blank"
+            aria-describedby="external-site"
+            rel="noopener noreferrer"
+            className="h-u"
+          >
+            Learn more about storage options for your multimedia, archives, and
+            data backups here.
+          </a>
+        </Typography>
+      </Placeholder>
     </React.Fragment>
   );
 };
-
-const EmptyCopy = () => (
-  <>
-    <Typography variant="subtitle1">Need help getting started?</Typography>
-    <Typography variant="subtitle1">
-      <a
-        href="https://linode.com/docs/platform/object-storage"
-        target="_blank"
-        aria-describedby="external-site"
-        rel="noopener noreferrer"
-        className="h-u"
-      >
-        Learn more about storage options for your multimedia, archives, and data
-        backups here.
-      </a>
-    </Typography>
-  </>
-);
 
 const enhanced = compose<CombinedProps, Props>(
   React.memo,

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { Waypoint } from 'react-waypoint';
 import { compose } from 'recompose';
-import StackScriptsIcon from 'src/assets/addnewmenu/stackscripts.svg';
+import StackScriptsIcon from 'src/assets/icons/entityIcons/stackscript.svg';
 import Button from 'src/components/Button';
 import CircleProgress from 'src/components/CircleProgress';
 import Typography from 'src/components/core/Typography';
@@ -497,17 +497,19 @@ const withStackScriptBase = (options: WithStackScriptBaseOptions) => (
               {userCannotCreateStackScripts ? (
                 <Placeholder
                   icon={StackScriptsIcon}
+                  isEntity
                   renderAsSecondary
                   title="StackScripts"
-                  copy="You don't have any StackScripts to select from."
                   className={classes.stackscriptPlaceholder}
-                />
+                >
+                  You don&apos;t have any StackScripts to select from.
+                </Placeholder>
               ) : (
                 <Placeholder
                   icon={StackScriptsIcon}
                   renderAsSecondary
+                  isEntity
                   title="StackScripts"
-                  copy={<EmptyCopy />}
                   buttonProps={[
                     {
                       children: 'Create New StackScript',
@@ -515,7 +517,32 @@ const withStackScriptBase = (options: WithStackScriptBaseOptions) => (
                     }
                   ]}
                   className={classes.stackscriptPlaceholder}
-                />
+                >
+                  <Typography variant="subtitle1">
+                    Automate Deployment with StackScripts!
+                  </Typography>
+                  <Typography variant="subtitle1">
+                    <a
+                      href="https://linode.com/docs/platform/stackscripts-new-manager/"
+                      target="_blank"
+                      aria-describedby="external-site"
+                      rel="noopener noreferrer"
+                      className="h-u"
+                    >
+                      Learn more about getting started
+                    </a>
+                    &nbsp;or&nbsp;
+                    <a
+                      href="https://www.linode.com/docs/"
+                      target="_blank"
+                      aria-describedby="external-site"
+                      rel="noopener noreferrer"
+                      className="h-u"
+                    >
+                      visit our guides and tutorials.
+                    </a>
+                  </Typography>
+                </Placeholder>
               )}
             </div>
           ) : (
@@ -673,35 +700,6 @@ const withStackScriptBase = (options: WithStackScriptBaseOptions) => (
     userCannotCreateStackScripts:
       isRestrictedUser(state) && !hasGrant(state, 'add_stackscripts')
   });
-
-  const EmptyCopy = () => (
-    <>
-      <Typography variant="subtitle1">
-        Automate Deployment with StackScripts!
-      </Typography>
-      <Typography variant="subtitle1">
-        <a
-          href="https://linode.com/docs/platform/stackscripts-new-manager/"
-          target="_blank"
-          aria-describedby="external-site"
-          rel="noopener noreferrer"
-          className="h-u"
-        >
-          Learn more about getting started
-        </a>
-        &nbsp;or&nbsp;
-        <a
-          href="https://www.linode.com/docs/"
-          target="_blank"
-          aria-describedby="external-site"
-          rel="noopener noreferrer"
-          className="h-u"
-        >
-          visit our guides and tutorials.
-        </a>
-      </Typography>
-    </>
-  );
 
   const connected = connect(mapStateToProps);
 

--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
 import { bindActionCreators, Dispatch } from 'redux';
-import VolumesIcon from 'src/assets/addnewmenu/volume.svg';
+import VolumesIcon from 'src/assets/icons/entityIcons/volume.svg';
 import AddNewLink from 'src/components/AddNewLink';
 import Breadcrumb from 'src/components/Breadcrumb';
 import FormControlLabel from 'src/components/core/FormControlLabel';
@@ -447,7 +447,7 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
           <DocumentTitleSegment segment="Volumes" />
           <Placeholder
             title="Volumes are not available in this region"
-            copy=""
+            isEntity
             icon={VolumesIcon}
             renderAsSecondary={!isVolumesLanding}
           />
@@ -461,7 +461,7 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
           <DocumentTitleSegment segment="Volumes" />
           <Placeholder
             title="No configs available."
-            copy="This Linode has no configurations. Click below to create a configuration."
+            isEntity
             icon={VolumesIcon}
             buttonProps={[
               {
@@ -470,7 +470,10 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
               }
             ]}
             renderAsSecondary={!isVolumesLanding}
-          />
+          >
+            This Linode has no configurations. Click below to create a
+            configuration.
+          </Placeholder>
         </React.Fragment>
       );
     }
@@ -481,7 +484,7 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
         {readOnly && <LinodePermissionsError />}
         <Placeholder
           title="Add Block Storage!"
-          copy={<EmptyCopy />}
+          isEntity
           icon={VolumesIcon}
           renderAsSecondary={!isVolumesLanding}
           buttonProps={[
@@ -496,7 +499,30 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
               disabled: readOnly
             }
           ]}
-        />
+        >
+          <Typography variant="subtitle1">Need additional storage?</Typography>
+          <Typography variant="subtitle1">
+            <a
+              href="https://linode.com/docs/platform/block-storage/how-to-use-block-storage-with-your-linode-new-manager/"
+              target="_blank"
+              aria-describedby="external-site"
+              rel="noopener noreferrer"
+              className="h-u"
+            >
+              Here&apos;s how to use Block Storage with your Linode
+            </a>
+            &nbsp;or&nbsp;
+            <a
+              href="https://www.linode.com/docs/"
+              target="_blank"
+              aria-describedby="external-site"
+              rel="noopener noreferrer"
+              className="h-u"
+            >
+              visit our guides and tutorials.
+            </a>
+          </Typography>
+        </Placeholder>
       </React.Fragment>
     );
   };
@@ -620,33 +646,6 @@ const eventCategory = `volumes landing`;
 
 const toggleVolumesGroupBy = (checked: boolean) =>
   sendGroupByTagEnabledEvent(eventCategory, checked);
-
-const EmptyCopy = () => (
-  <>
-    <Typography variant="subtitle1">Need additional storage?</Typography>
-    <Typography variant="subtitle1">
-      <a
-        href="https://linode.com/docs/platform/block-storage/how-to-use-block-storage-with-your-linode-new-manager/"
-        target="_blank"
-        aria-describedby="external-site"
-        rel="noopener noreferrer"
-        className="h-u"
-      >
-        Here's how to use Block Storage with your Linode
-      </a>
-      &nbsp;or&nbsp;
-      <a
-        href="https://www.linode.com/docs/"
-        target="_blank"
-        aria-describedby="external-site"
-        rel="noopener noreferrer"
-        className="h-u"
-      >
-        visit our guides and tutorials.
-      </a>
-    </Typography>
-  </>
-);
 
 const mapDispatchToProps = (dispatch: Dispatch) =>
   bindActionCreators(

--- a/packages/manager/src/features/Volumes/VolumesLanding_CMR.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding_CMR.tsx
@@ -4,6 +4,10 @@ import { Volume } from '@linode/api-v4/lib/volumes';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import * as React from 'react';
 import { connect } from 'react-redux';
+import VolumeIcon from 'src/assets/icons/entityIcons/volume.svg';
+import Placeholder from 'src/components/Placeholder';
+import Typography from 'src/components/core/Typography';
+import Link from 'src/components/Link';
 import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
 import { bindActionCreators, Dispatch } from 'redux';
@@ -280,6 +284,34 @@ export const VolumesLanding: React.FC<CombinedProps> = props => {
 
   if (_loading) {
     return <Loading shouldDelay />;
+  }
+
+  if (mappedVolumesDataWithLinodes.length === 0) {
+    return (
+      <React.Fragment>
+        <DocumentTitleSegment segment="Images" />
+        <Placeholder
+          title="Volumes"
+          icon={VolumeIcon}
+          isEntity
+          buttonProps={[
+            {
+              onClick: () => props.history.push('/volumes/create'),
+              children: 'Add a Volume'
+            }
+          ]}
+        >
+          <Typography variant="subtitle1">
+            Attach additional storage to your Linode.
+          </Typography>
+          <Typography variant="subtitle1">
+            <Link to="https://www.linode.com/docs/products/storage/block-storage/">
+              Learn more about Linode Block Storage Volumes.
+            </Link>
+          </Typography>
+        </Placeholder>
+      </React.Fragment>
+    );
   }
 
   const handlers: VolumeHandlers = {

--- a/packages/manager/src/features/Volumes/VolumesLanding_CMR.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding_CMR.tsx
@@ -283,13 +283,17 @@ export const VolumesLanding: React.FC<CombinedProps> = props => {
   };
 
   if (_loading) {
-    return <Loading shouldDelay />;
+    return <Loading />;
   }
 
-  if (mappedVolumesDataWithLinodes.length === 0) {
+  if (
+    mappedVolumesDataWithLinodes.length === 0 &&
+    !volumesError.read &&
+    volumesLastUpdated > 0
+  ) {
     return (
       <React.Fragment>
-        <DocumentTitleSegment segment="Images" />
+        <DocumentTitleSegment segment="Volumes" />
         <Placeholder
           title="Volumes"
           icon={VolumeIcon}
@@ -327,7 +331,7 @@ export const VolumesLanding: React.FC<CombinedProps> = props => {
   const volumeRow = {
     handlers,
     Component: VolumeTableRow,
-    data: mappedVolumesDataWithLinodes ?? [], // [],
+    data: mappedVolumesDataWithLinodes ?? [],
     loading: volumesLoading,
     lastUpdated: volumesLastUpdated,
     error: volumesError.read

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
@@ -5,7 +5,7 @@ import {
 } from '@linode/api-v4/lib/linodes';
 import { compose as ramdaCompose } from 'ramda';
 import * as React from 'react';
-import VolumeIcon from 'src/assets/addnewmenu/volume.svg';
+import VolumeIcon from 'src/assets/icons/entityIcons/volume.svg';
 import Paper from 'src/components/core/Paper';
 import {
   createStyles,
@@ -185,11 +185,14 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
         {!userHasBackups ? (
           <Paper>
             <Placeholder
+              isEntity
               icon={VolumeIcon}
-              copy="You do not have backups enabled for your Linodes. Please visit the Backups panel in the Linode Details view."
               title="Create from Backup"
               renderAsSecondary
-            />
+            >
+              You do not have backups enabled for your Linodes. Please visit the
+              Backups panel in the Linode Details view.
+            </Placeholder>
           </Paper>
         ) : (
           <React.Fragment>

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -49,17 +49,13 @@ export const FromImageContent: React.FC<CombinedProps> = props => {
     return (
       <Grid item className={`${classes.main} mlMain py0`}>
         <Paper>
-          <Placeholder
-            title="My Images"
-            renderAsSecondary
-            copy={
-              <Typography variant="subtitle1">
-                You don&#39;t have any private Images. Visit the{' '}
-                <Link to="/images">Images section</Link> to create an Image from
-                one of your Linode&#39;s disks.
-              </Typography>
-            }
-          />
+          <Placeholder title="My Images" renderAsSecondary>
+            <Typography variant="subtitle1">
+              You don&#39;t have any private Images. Visit the{' '}
+              <Link to="/images">Images section</Link> to create an Image from
+              one of your Linode&#39;s disks.
+            </Typography>
+          </Placeholder>
         </Paper>
       </Grid>
     );

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import VolumeIcon from 'src/assets/addnewmenu/volume.svg';
+import VolumeIcon from 'src/assets/icons/entityIcons/volume.svg';
 import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Grid from 'src/components/Grid';
@@ -65,11 +65,14 @@ export const FromLinodeContent: React.FC<CombinedProps> = props => {
           <Paper>
             <Placeholder
               data-qa-placeholder
+              isEntity
               icon={VolumeIcon}
               renderAsSecondary
-              copy="You do not have any existing Linodes to clone from. Please first create a Linode from either an Image or StackScript."
               title="Clone from Existing Linode"
-            />
+            >
+              You do not have any existing Linodes to clone from. Please first
+              create a Linode from either an Image or StackScript.
+            </Placeholder>
           </Paper>
         </Grid>
       ) : (

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/BackupsPlaceholder.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/BackupsPlaceholder.tsx
@@ -44,7 +44,6 @@ export const BackupsPlaceholder: React.FC<Props> = props => {
         icon={VolumeIcon}
         title="Backups"
         renderAsSecondary
-        copy={backupPlaceholderText}
         buttonProps={[
           {
             onClick: () => setDialogOpen(true),
@@ -52,7 +51,9 @@ export const BackupsPlaceholder: React.FC<Props> = props => {
             disabled
           }
         ]}
-      />
+      >
+        {backupPlaceholderText}
+      </Placeholder>
       <EnableBackupsDialog
         open={dialogOpen}
         onClose={() => setDialogOpen(false)}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -21,7 +21,7 @@ import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
 import 'rxjs/add/operator/filter';
 import { Subscription } from 'rxjs/Subscription';
-import VolumeIcon from 'src/assets/addnewmenu/volume.svg';
+import VolumeIcon from 'src/assets/icons/entityIcons/volume.svg';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
@@ -537,8 +537,8 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
         <Placeholder
           icon={VolumeIcon}
           title="Backups"
+          isEntity
           renderAsSecondary
-          copy={backupPlaceholderText}
           buttonProps={[
             {
               onClick: () => this.enableBackups(),
@@ -547,7 +547,9 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
               disabled
             }
           ]}
-        />
+        >
+          {backupPlaceholderText}
+        </Placeholder>
       </React.Fragment>
     );
   };
@@ -557,33 +559,31 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
     const disabled = isReadOnly(permissions);
 
     return (
-      <React.Fragment>
-        <Paper className={classes.paper} style={{ padding: 0 }}>
-          <Table aria-label="List of Backups">
-            <TableHead>
-              <TableRow>
-                <TableCell>Label</TableCell>
-                <TableCell>Date Created</TableCell>
-                <TableCell>Duration</TableCell>
-                <TableCell>Disks</TableCell>
-                <TableCell>Space Required</TableCell>
-                <TableCell />
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {backups.map((backup: LinodeBackup, idx: number) => (
-                <BackupTableRow
-                  key={idx}
-                  backup={backup}
-                  disabled={disabled}
-                  handleDeploy={this.handleDeploy}
-                  handleRestore={this.handleRestore}
-                />
-              ))}
-            </TableBody>
-          </Table>
-        </Paper>
-      </React.Fragment>
+      <Paper className={classes.paper} style={{ padding: 0 }}>
+        <Table aria-label="List of Backups">
+          <TableHead>
+            <TableRow>
+              <TableCell>Label</TableCell>
+              <TableCell>Date Created</TableCell>
+              <TableCell>Duration</TableCell>
+              <TableCell>Disks</TableCell>
+              <TableCell>Space Required</TableCell>
+              <TableCell />
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {backups.map((backup: LinodeBackup, idx: number) => (
+              <BackupTableRow
+                key={idx}
+                backup={backup}
+                disabled={disabled}
+                handleDeploy={this.handleDeploy}
+                handleRestore={this.handleRestore}
+              />
+            ))}
+          </TableBody>
+        </Table>
+      </Paper>
     );
   };
 
@@ -691,73 +691,71 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
     });
 
     return (
-      <React.Fragment>
-        <Paper className={classes.paper}>
-          <Typography
-            variant="h2"
-            className={classes.subTitle}
-            data-qa-settings-heading
-          >
-            Settings
-          </Typography>
-          <Typography variant="body1" data-qa-settings-desc>
-            Configure when automatic backups are initiated. The Linode Backup
-            Service will generate a backup between the selected hours every day,
-            and will overwrite the previous daily backup. The selected day is
-            when the backup is promoted to the weekly slot. Up to two weekly
-            backups are saved.
-          </Typography>
-          <FormControl className={classes.chooseTime}>
-            <Select
-              textFieldProps={{
-                dataAttrs: {
-                  'data-qa-time-select': true
-                }
-              }}
-              options={timeSelection}
-              onChange={this.handleSelectBackupWindow}
-              label="Time of Day"
-              placeholder="Choose a time"
-              isClearable={false}
-              defaultValue={defaultTimeSelection}
-              name="Time of Day"
-              noMarginTop
-            />
-            <FormHelperText>
-              Windows displayed in {this.props.timezone}
-            </FormHelperText>
-          </FormControl>
+      <Paper className={classes.paper}>
+        <Typography
+          variant="h2"
+          className={classes.subTitle}
+          data-qa-settings-heading
+        >
+          Settings
+        </Typography>
+        <Typography variant="body1" data-qa-settings-desc>
+          Configure when automatic backups are initiated. The Linode Backup
+          Service will generate a backup between the selected hours every day,
+          and will overwrite the previous daily backup. The selected day is when
+          the backup is promoted to the weekly slot. Up to two weekly backups
+          are saved.
+        </Typography>
+        <FormControl className={classes.chooseTime}>
+          <Select
+            textFieldProps={{
+              dataAttrs: {
+                'data-qa-time-select': true
+              }
+            }}
+            options={timeSelection}
+            onChange={this.handleSelectBackupWindow}
+            label="Time of Day"
+            placeholder="Choose a time"
+            isClearable={false}
+            defaultValue={defaultTimeSelection}
+            name="Time of Day"
+            noMarginTop
+          />
+          <FormHelperText>
+            Windows displayed in {this.props.timezone}
+          </FormHelperText>
+        </FormControl>
 
-          <FormControl className={classes.chooseDay}>
-            <Select
-              textFieldProps={{
-                dataAttrs: {
-                  'data-qa-weekday-select': true
-                }
-              }}
-              options={daySelection}
-              defaultValue={defaultDaySelection}
-              onChange={this.handleSelectBackupTime}
-              label="Day of Week"
-              placeholder="Choose a day"
-              isClearable={false}
-              noMarginTop
-            />
-          </FormControl>
-          <ActionsPanel className={classes.scheduleAction}>
-            <Button
-              buttonType="primary"
-              onClick={this.saveSettings}
-              disabled={isReadOnly(permissions)}
-              loading={this.state.settingsForm.loading}
-              data-qa-schedule
-            >
-              Save Schedule
-            </Button>
-          </ActionsPanel>
-          {errorText && <FormHelperText error>{errorText}</FormHelperText>}
-        </Paper>
-      </React.Fragment>
+        <FormControl className={classes.chooseDay}>
+          <Select
+            textFieldProps={{
+              dataAttrs: {
+                'data-qa-weekday-select': true
+              }
+            }}
+            options={daySelection}
+            defaultValue={defaultDaySelection}
+            onChange={this.handleSelectBackupTime}
+            label="Day of Week"
+            placeholder="Choose a day"
+            isClearable={false}
+            noMarginTop
+          />
+        </FormControl>
+        <ActionsPanel className={classes.scheduleAction}>
+          <Button
+            buttonType="primary"
+            onClick={this.saveSettings}
+            disabled={isReadOnly(permissions)}
+            loading={this.state.settingsForm.loading}
+            data-qa-schedule
+          >
+            Save Schedule
+          </Button>
+        </ActionsPanel>
+        {errorText && <FormHelperText error>{errorText}</FormHelperText>}
+      </Paper>
     );
   };
 
@@ -867,12 +865,10 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
     }
 
     return (
-      <React.Fragment>
-        <div>
-          <DocumentTitleSegment segment={`${linodeLabel} - Backups`} />
-          {backupsEnabled ? <this.Management /> : <this.Placeholder />}
-        </div>
-      </React.Fragment>
+      <div>
+        <DocumentTitleSegment segment={`${linodeLabel} - Backups`} />
+        {backupsEnabled ? <this.Management /> : <this.Placeholder />}
+      </div>
     );
   }
 }

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.test.tsx
@@ -56,6 +56,6 @@ describe('ListLinodes', () => {
       )
     );
 
-    expect(getByText('Add your first Linode!')).toBeInTheDocument();
+    expect(getByText('Add a Linode')).toBeInTheDocument();
   });
 });

--- a/packages/manager/src/features/linodes/LinodesLanding/ListLinodesEmptyState.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/ListLinodesEmptyState.tsx
@@ -1,136 +1,40 @@
 import * as React from 'react';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
-import { compose } from 'redux';
-import LinodeSvg from 'src/assets/addnewmenu/linode.svg';
-import Button from 'src/components/Button';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles
-} from 'src/components/core/styles';
+import { useHistory } from 'react-router-dom';
+import LinodeSvg from 'src/assets/icons/entityIcons/linode.svg';
 import Typography from 'src/components/core/Typography';
-import Grid from 'src/components/Grid';
-import H1Header from 'src/components/H1Header';
+import Link from 'src/components/Link';
+import Placeholder from 'src/components/Placeholder';
 
-type CSSClasses = 'root' | 'copy' | 'icon' | 'title';
+export const ListLinodesEmptyState: React.FC<{}> = _ => {
+  const { push } = useHistory();
 
-const styles = (theme: Theme) =>
-  createStyles({
-    '@keyframes scaleIn': {
-      from: {
-        transform: 'translateX( -10px ) rotateY( -180deg )'
-      },
-      to: {
-        transformOrigin: 'center center'
-      }
-    },
-    '@keyframes fadeIn': {
-      from: {
-        opacity: 0
-      },
-      to: {
-        opacity: 1
-      }
-    },
-    root: {
-      padding: `${theme.spacing(2)}px 0`,
-      [theme.breakpoints.up('md')]: {
-        padding: `${theme.spacing(10)}px 0`
-      }
-    },
-    copy: {
-      textAlign: 'center',
-      maxWidth: 800
-    },
-    icon: {
-      animation: '$scaleIn .5s ease-in-out',
-      width: 150,
-      height: 150,
-      '& use': {
-        fill: theme.bg.main
-      },
-      '& .outerCircle': {
-        fill: theme.color.absWhite,
-        stroke: theme.bg.offWhite
-      },
-      '& .insidePath path': {
-        opacity: 0,
-        animation: '$fadeIn .2s ease-in-out forwards .3s',
-        stroke: theme.palette.primary.main
-      }
-    },
-    title: {
-      fontFamily: theme.font.bold,
-      textAlign: 'center'
-    }
-  });
+  return (
+    <Placeholder
+      title={'Linodes'}
+      icon={LinodeSvg}
+      isEntity
+      buttonProps={[
+        {
+          onClick: () => push('/linodes/create'),
+          children: 'Add a Linode'
+        }
+      ]}
+    >
+      <Typography variant="subtitle1">
+        Choose a plan, select an image, and deploy within minutes. Need help
+        getting started?
+      </Typography>
+      <Typography variant="subtitle1">
+        <Link to="https://linode.com/docs/getting-started-new-manager/">
+          Learn more about getting started
+        </Link>
+        &nbsp;or&nbsp;
+        <Link to="https://www.linode.com/docs/">
+          visit our guides and tutorials.
+        </Link>
+      </Typography>
+    </Placeholder>
+  );
+};
 
-type PropsWithStyles = WithStyles<CSSClasses> & RouteComponentProps<{}>;
-
-class ListLinodesEmptyState extends React.Component<PropsWithStyles> {
-  render() {
-    const { classes } = this.props;
-
-    return (
-      <Grid
-        container
-        spacing={3}
-        alignItems="center"
-        direction="column"
-        justify="center"
-        className={classes.root}
-      >
-        <Grid item xs={12}>
-          <LinodeSvg className={classes.icon} />
-        </Grid>
-        <H1Header
-          title="Add your first Linode!"
-          className={classes.title}
-          data-qa-placeholder-title
-        />
-        <Grid item xs={12} lg={10} className={classes.copy}>
-          <Typography variant="subtitle1">
-            Choose a plan, select an image, and deploy within minutes. Need help
-            getting started?
-          </Typography>
-          <Typography variant="subtitle1">
-            <a
-              href="https://linode.com/docs/getting-started-new-manager/"
-              target="_blank"
-              aria-describedby="external-site"
-              rel="noopener noreferrer"
-              className="h-u"
-            >
-              Learn more about getting started
-            </a>
-            &nbsp;or&nbsp;
-            <a
-              href="https://www.linode.com/docs/"
-              target="_blank"
-              aria-describedby="external-site"
-              rel="noopener noreferrer"
-              className="h-u"
-            >
-              visit our guides and tutorials.
-            </a>
-          </Typography>
-        </Grid>
-        <Grid item xs={12} lg={10} className={classes.copy}>
-          <Button
-            buttonType="primary"
-            onClick={() => this.props.history.push('/linodes/create')}
-          >
-            Create a Linode
-          </Button>
-        </Grid>
-      </Grid>
-    );
-  }
-}
-const enhanced = compose(
-  withRouter,
-  withStyles(styles)
-);
-
-export default enhanced(ListLinodesEmptyState);
+export default React.memo(ListLinodesEmptyState);

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -375,7 +375,7 @@ export const handlers = [
     const error = databaseFactory.build({ status: 'error' });
     const unknown = databaseFactory.build({ status: 'unknown' });
     const databases = [online, initializing, error, unknown];
-    return res(ctx.delay(2000), ctx.json(makeResourcePage(databases)));
+    return res(ctx.json(makeResourcePage(databases)));
   })
 ];
 

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -77,8 +77,8 @@ export const handlers = [
     return res(ctx.json(cachedTypes));
   }),
   rest.get('*/images', async (req, res, ctx) => {
-    const privateImages = imageFactory.buildList(10);
-    const publicImages = imageFactory.buildList(10, { is_public: true });
+    const privateImages = imageFactory.buildList(0);
+    const publicImages = imageFactory.buildList(0, { is_public: true });
     const images = [...privateImages, ...publicImages];
     return res(ctx.json(makeResourcePage(images)));
   }),
@@ -152,7 +152,7 @@ export const handlers = [
     return res(ctx.json(linode));
   }),
   rest.get('*/lke/clusters', async (req, res, ctx) => {
-    const clusters = kubernetesAPIResponse.buildList(10);
+    const clusters = kubernetesAPIResponse.buildList(0);
     return res(ctx.json(makeResourcePage(clusters)));
   }),
   rest.get('*/lke/clusters/:clusterId', async (req, res, ctx) => {
@@ -170,7 +170,7 @@ export const handlers = [
     return res(ctx.json(makeResourcePage(endpoints)));
   }),
   rest.get('*/firewalls/', (req, res, ctx) => {
-    const firewalls = firewallFactory.buildList(10);
+    const firewalls = firewallFactory.buildList(0);
     return res(ctx.json(makeResourcePage(firewalls)));
   }),
   rest.get('*/firewalls/*/devices', (req, res, ctx) => {
@@ -191,7 +191,7 @@ export const handlers = [
     return res(ctx.json(newFirewall));
   }),
   rest.get('*/nodebalancers', (req, res, ctx) => {
-    const nodeBalancers = nodeBalancerFactory.buildList(10);
+    const nodeBalancers = nodeBalancerFactory.buildList(0);
     return res(ctx.json(makeResourcePage(nodeBalancers)));
   }),
   rest.get('*/nodebalancers/:nodeBalancerID', (req, res, ctx) => {
@@ -216,7 +216,7 @@ export const handlers = [
     }
   ),
   rest.get('*/object-storage/buckets/*', (req, res, ctx) => {
-    const buckets = objectStorageBucketFactory.buildList(20);
+    const buckets = objectStorageBucketFactory.buildList(0);
     return res(ctx.json(makeResourcePage(buckets)));
   }),
   rest.get('*object-storage/clusters', (req, res, ctx) => {
@@ -232,11 +232,11 @@ export const handlers = [
     return res(ctx.json(record));
   }),
   rest.get('*/volumes', (req, res, ctx) => {
-    const volumes = volumeFactory.buildList(10);
+    const volumes = volumeFactory.buildList(0);
     return res(ctx.json(makeResourcePage(volumes)));
   }),
   rest.get('*/vlans', (req, res, ctx) => {
-    const vlans = VLANFactory.buildList(4);
+    const vlans = VLANFactory.buildList(0);
     return res(ctx.json(makeResourcePage(vlans)));
   }),
   rest.get('*/profile/preferences', (req, res, ctx) => {
@@ -375,7 +375,7 @@ export const handlers = [
     const error = databaseFactory.build({ status: 'error' });
     const unknown = databaseFactory.build({ status: 'unknown' });
     const databases = [online, initializing, error, unknown];
-    return res(ctx.json(makeResourcePage(databases)));
+    return res(ctx.delay(2000), ctx.json(makeResourcePage(databases)));
   })
 ];
 


### PR DESCRIPTION
## Description

- Update icons for the empty state placeholders for each entity
- Tweak styling to match newest designs
- Refactor Placeholder.tsx to use props.children instead of `copy=<EmptyCopy />`
- Add empty state placeholders for entities that didn't have them (except VLANs because you know)
- Make adjustments as necessary to get all this to hang together.

## Note to Reviewers

Mocks are set up so that almost all entities have 0, which should trigger the placeholder. Please check loading and error states for all entities as well, and placeholders used elsewhere (the 404 not found screen, for instance) to make sure they're unchanged.