### PR TITLE
Patch/linode large accounts

### DIFF
--- a/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
+++ b/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
@@ -91,11 +91,6 @@ export class AuthenticationWrapper extends React.Component<CombinedProps> {
    * for navigation, basic display, etc.
    */
   makeSecondaryRequests = async () => {
-    const { linodesLoading, linodesLastUpdated, requestLinodes } = this.props;
-    if (!linodesLoading && linodesLastUpdated === 0) {
-      // Only request Linodes if we haven't done that somewhere else already
-      requestLinodes().catch(_ => null);
-    }
     try {
       await Promise.all([
         this.props.requestTypes(),

--- a/packages/manager/src/features/Volumes/VolumesLanding_CMR.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding_CMR.tsx
@@ -175,7 +175,7 @@ export const VolumesLanding: React.FC<CombinedProps> = props => {
     poweredOff: false
   });
 
-  const { _loading } = useReduxLoad(['volumes']);
+  const { _loading } = useReduxLoad(['volumes', 'linodes']);
 
   const handleCloseAttachDrawer = () => {
     setAttachmentDrawer(attachmentDrawer => ({

--- a/packages/manager/src/features/linodes/LinodeSelect/LinodeSelect.tsx
+++ b/packages/manager/src/features/linodes/LinodeSelect/LinodeSelect.tsx
@@ -10,6 +10,7 @@ import EnhancedSelect, {
 import RenderGuard, { RenderGuardProps } from 'src/components/RenderGuard';
 import { Props as TextFieldProps } from 'src/components/TextField';
 import withLinodes from 'src/containers/withLinodes.container';
+import { useReduxLoad } from 'src/hooks/useReduxLoad';
 import { formatRegion } from 'src/utilities';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 
@@ -66,6 +67,8 @@ const LinodeSelect: React.FC<CombinedProps> = props => {
     inputId
   } = props;
 
+  const { _loading } = useReduxLoad(['linodes']);
+
   const linodes = region
     ? linodesData.filter(thisLinode => thisLinode.region === region)
     : linodesData;
@@ -104,7 +107,7 @@ const LinodeSelect: React.FC<CombinedProps> = props => {
       options={options}
       disabled={disabled}
       small={props.small}
-      isLoading={linodesLoading}
+      isLoading={linodesLoading || _loading}
       inputId={inputId}
       onChange={(selected: Item<number>) => {
         return handleChange(selected.data);
@@ -191,7 +194,7 @@ export const linodesToGroupedItems = (
     maybeFilteredLinodes
   );
 
-  const groupedItems = Object.keys(groupedByRegion).map(region => {
+  return Object.keys(groupedByRegion).map(region => {
     return {
       label: formatRegion(region),
       options: linodesToItems(
@@ -201,8 +204,6 @@ export const linodesToGroupedItems = (
       )
     };
   });
-
-  return groupedItems;
 };
 
 export const linodeFromGroupedItems = (

--- a/packages/manager/src/store/accountManagement/accountManagement.requests.ts
+++ b/packages/manager/src/store/accountManagement/accountManagement.requests.ts
@@ -1,9 +1,10 @@
 import { LARGE_ACCOUNT_THRESHOLD } from 'src/constants';
 import { getDomainsPage } from '../domains/domains.requests';
+import { getLinodesPage } from '../linodes/linode.requests';
 import { setLargeAccount } from './accountManagement.actions';
 import { ThunkActionCreator, ThunkDispatch } from '../types';
 
-export const checkAccountSize: ThunkActionCreator<Promise<null>> = () => (
+export const checkAccountSize: ThunkActionCreator<Promise<null>> = () => async (
   dispatch: ThunkDispatch
 ) => {
   /**
@@ -12,15 +13,20 @@ export const checkAccountSize: ThunkActionCreator<Promise<null>> = () => (
    * on the account). If so, it will bump lastUpdated and store the info in
    * Redux.
    */
-  return (
-    dispatch(getDomainsPage({ params: { page_size: 100 } }))
-      .then(result => {
-        const { results } = result;
-        dispatch(setLargeAccount(results > LARGE_ACCOUNT_THRESHOLD));
-        return null;
-      })
-      // We default the state to false, which gives the intended default behavior for the app.
-      // No need to do anything special here.
-      .catch(_ => null)
-  );
+  return Promise.all([
+    dispatch(getDomainsPage({ params: { page_size: 100 } })),
+    dispatch(getLinodesPage({ params: { page_size: 100 } }))
+  ])
+    .then(combinedResults => {
+      dispatch(
+        setLargeAccount(
+          combinedResults.some(
+            thisResult => thisResult.results > LARGE_ACCOUNT_THRESHOLD
+          )
+        )
+      );
+
+      return null;
+    })
+    .catch(_ => null);
 };

--- a/packages/manager/src/store/linodes/linode.requests.ts
+++ b/packages/manager/src/store/linodes/linode.requests.ts
@@ -15,6 +15,7 @@ import {
   deleteLinodeActions,
   getLinodeActions,
   getLinodesActions,
+  getLinodesPageActions,
   rebootLinodeActions,
   updateLinodeActions,
   upsertLinode
@@ -51,6 +52,14 @@ const getAllLinodes = (payload: { params?: any; filter?: any }) =>
 export const requestLinodes = createRequestThunk(
   getLinodesActions,
   ({ params, filter }) => getAllLinodes({ params, filter })
+);
+
+/**
+ * Single page of Linodes
+ */
+export const getLinodesPage = createRequestThunk(
+  getLinodesPageActions,
+  ({ params, filters }) => getLinodes(params, filters)
 );
 
 type RequestLinodeForStoreThunk = ThunkActionCreator<void, number>;

--- a/packages/manager/src/store/linodes/linodes.actions.ts
+++ b/packages/manager/src/store/linodes/linodes.actions.ts
@@ -1,5 +1,5 @@
 import { CreateLinodeRequest, Linode } from '@linode/api-v4/lib/linodes';
-import { APIError, DeepPartial } from '@linode/api-v4/lib/types';
+import { APIError, DeepPartial, ResourcePage } from '@linode/api-v4/lib/types';
 import { GetAllData } from 'src/utilities/getAll';
 import actionCreatorFactory from 'typescript-fsa';
 
@@ -67,3 +67,13 @@ export const rebootLinodeActions = actionCreator.async<
   {},
   APIError[]
 >('reboot');
+
+export interface PageParams {
+  params?: any;
+  filters?: any;
+}
+export const getLinodesPageActions = actionCreator.async<
+  PageParams,
+  ResourcePage<Linode>,
+  APIError[]
+>('get-page');

--- a/packages/manager/src/store/linodes/linodes.reducer.ts
+++ b/packages/manager/src/store/linodes/linodes.reducer.ts
@@ -6,6 +6,7 @@ import {
   onDeleteSuccess,
   onError,
   onGetAllSuccess,
+  onGetPageSuccess,
   onGetOneSuccess,
   onStart
 } from 'src/store/store.helpers.tmp';
@@ -16,6 +17,7 @@ import {
   deleteLinode,
   deleteLinodeActions,
   getLinodesActions,
+  getLinodesPageActions,
   getLinodeActions,
   updateLinodeActions,
   updateMultipleLinodes,
@@ -109,6 +111,21 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
       params: { linodeId }
     } = action.payload;
     return onDeleteSuccess(linodeId, state);
+  }
+
+  if (isType(action, getLinodesPageActions.started)) {
+    return onStart(state);
+  }
+
+  if (isType(action, getLinodesPageActions.done)) {
+    const { result } = action.payload;
+
+    return onGetPageSuccess(result.data, state, result.results);
+  }
+
+  if (isType(action, getLinodesPageActions.failed)) {
+    const { error } = action.payload;
+    return onError({ read: error }, state);
   }
 
   return state;

--- a/packages/manager/src/store/store.helpers.tmp.ts
+++ b/packages/manager/src/store/store.helpers.tmp.ts
@@ -129,9 +129,10 @@ export const onGetPageSuccess = <E extends Entity>(
   return isFullRequest
     ? {
         ...newState,
-        lastUpdated: Date.now()
+        lastUpdated: Date.now(),
+        loading: false
       }
-    : newState;
+    : { ...newState, loading: false };
 };
 
 export const createRequestThunk = <Req extends any, Res extends any, Err>(


### PR DESCRIPTION
## Description

Mark accounts with >500 Linodes as "large", which won't affect how Linodes are displayed or requested but will make sure that the search bar always uses API search.