### PR TITLE
Condense primary nav and add icon to expanded state 

### DIFF
--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -260,7 +260,6 @@ const MainContent: React.FC<CombinedProps> = props => {
               open={menuIsOpen}
               desktopOpen={desktopMenuIsOpen || false}
               closeMenu={() => toggleMenu(false)}
-              toggleTheme={props.toggleTheme}
               toggleSpacing={props.toggleSpacing}
             />
             <div

--- a/packages/manager/src/MainContent_CMR.tsx
+++ b/packages/manager/src/MainContent_CMR.tsx
@@ -296,7 +296,6 @@ const MainContent: React.FC<CombinedProps> = props => {
                     open={menuIsOpen}
                     desktopOpen={desktopMenuIsOpen || false}
                     closeMenu={() => toggleMenu(false)}
-                    toggleTheme={props.toggleTheme}
                     toggleSpacing={props.toggleSpacing}
                   />
                   <div

--- a/packages/manager/src/MainContent_CMR.tsx
+++ b/packages/manager/src/MainContent_CMR.tsx
@@ -82,13 +82,13 @@ const useStyles = makeStyles((theme: Theme) => ({
     flex: 1,
     transition: 'margin-left .1s linear',
     [theme.breakpoints.up('md')]: {
-      marginLeft: 200
+      marginLeft: 190
     }
   },
   fullWidthContent: {
     marginLeft: 0,
     [theme.breakpoints.up('md')]: {
-      marginLeft: theme.spacing(7) + 36
+      marginLeft: 60
     }
   },
   hidden: {

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.styles.ts
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.styles.ts
@@ -25,12 +25,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     position: 'relative',
     display: 'flex',
     alignItems: 'center',
-    padding: `
-        ${theme.spacing(2) - 2}px
-        0
-        ${theme.spacing(1) + theme.spacing(1) / 2}px
-        ${theme.spacing(4)}px
-      `,
+    padding: '14px 14px 12px',
     '& svg': {
       maxWidth: theme.spacing(3) + 91
     }
@@ -55,12 +50,7 @@ const useStyles = makeStyles((theme: Theme) => ({
       marginTop: 0,
       marginBottom: 0
     },
-    padding: `
-        ${theme.spacing(1.5)}px
-        ${theme.spacing(4) - 2}px
-        ${theme.spacing(1.5)}px
-        ${theme.spacing(4) + 1}px
-      `,
+    padding: '12px 20px',
     '&:focus': {
       textDecoration: 'none'
     },
@@ -77,24 +67,19 @@ const useStyles = makeStyles((theme: Theme) => ({
       }
     },
     '& .icon': {
+      color: theme.cmrIconColors.iGrey,
       marginRight: theme.spacing(2),
-      color: theme.color.primaryNavText,
       '& svg': {
-        width: 20,
-        height: 20,
         display: 'flex',
         alignItems: 'center',
-        fill: theme.color.primaryNavText,
-        '&.small': {
-          transform: 'scale(1)'
-        },
+        width: 20,
+        height: 20,
         '&:not(.wBorder) circle, & .circle': {
           display: 'none'
         }
       }
     }
   },
-  listItemCollapsed: {},
   collapsible: {
     fontSize: '0.9rem'
   },
@@ -112,10 +97,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     backgroundImage: 'linear-gradient(98deg, #38584B 1%, #3A5049 166%)',
     textDecoration: 'none',
     '& svg': {
-      color: theme.color.greenCyan,
-      '& *': {
-        // stroke: theme.color.greenCyan
-      }
+      color: theme.color.greenCyan
     },
     '&:hover': {}
   },

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav_CMR.tsx
@@ -360,13 +360,11 @@ const PrimaryLink: React.FC<PrimaryLinkProps> = React.memo(props => {
             locationSearch,
             locationPathname,
             activeLinks
-          ),
-          listItemCollapsed: isCollapsed
+          )
         })}
         data-testid={`menu-item-${display}`}
       >
-        {/* <div style={{ display: 'flex', alignItems: 'center' }}> */}
-        {icon && isCollapsed && (
+        {icon && (
           <div className="icon" aria-hidden>
             {icon}
           </div>
@@ -380,7 +378,6 @@ const PrimaryLink: React.FC<PrimaryLinkProps> = React.memo(props => {
         >
           {display}
         </p>
-        {/* </div> */}
       </Link>
     </>
   );

--- a/packages/manager/src/components/SideMenu.tsx
+++ b/packages/manager/src/components/SideMenu.tsx
@@ -38,7 +38,7 @@ const styles = (theme: Theme) =>
     },
     menuPaperCMR: {
       height: '100%',
-      width: 200,
+      width: 190,
       backgroundColor: theme.bg.primaryNavPaper,
       borderRight: 'none',
       left: 'inherit',
@@ -53,9 +53,9 @@ const styles = (theme: Theme) =>
       transform: 'none'
     },
     collapsedDesktopMenu: {
-      width: theme.spacing(7) + 36,
+      width: 60,
       '&:hover': {
-        width: theme.spacing(9) + 150,
+        width: 190,
         '& .logoLetters, & .primaryNavLink': {
           opacity: 1
         }
@@ -85,8 +85,6 @@ class SideMenu extends React.Component<CombinedProps> {
       flags
     } = this.props;
 
-    const PrimaryNavComponent = flags.cmr ? PrimaryNav_CMR : PrimaryNav;
-
     return (
       <React.Fragment>
         <Hidden mdUp>
@@ -101,12 +99,20 @@ class SideMenu extends React.Component<CombinedProps> {
               keepMounted: true // Better open performance on mobile.
             }}
           >
-            <PrimaryNavComponent
-              closeMenu={closeMenu}
-              toggleTheme={toggleTheme}
-              toggleSpacing={toggleSpacing}
-              isCollapsed={false}
-            />
+            {flags.cmr ? (
+              <PrimaryNav_CMR
+                closeMenu={closeMenu}
+                toggleSpacing={toggleSpacing}
+                isCollapsed={false}
+              />
+            ) : (
+              <PrimaryNav
+                closeMenu={closeMenu}
+                toggleTheme={toggleTheme}
+                toggleSpacing={toggleSpacing}
+                isCollapsed={false}
+              />
+            )}
           </Drawer>
         </Hidden>
         <Hidden smDown implementation="css">
@@ -121,12 +127,20 @@ class SideMenu extends React.Component<CombinedProps> {
             }}
             className={classes.desktopMenu}
           >
-            <PrimaryNavComponent
-              closeMenu={closeMenu}
-              toggleTheme={toggleTheme}
-              toggleSpacing={toggleSpacing}
-              isCollapsed={desktopOpen}
-            />
+            {flags.cmr ? (
+              <PrimaryNav_CMR
+                closeMenu={closeMenu}
+                toggleSpacing={toggleSpacing}
+                isCollapsed={desktopOpen}
+              />
+            ) : (
+              <PrimaryNav
+                closeMenu={closeMenu}
+                toggleTheme={toggleTheme}
+                toggleSpacing={toggleSpacing}
+                isCollapsed={desktopOpen}
+              />
+            )}
           </Drawer>
         </Hidden>
       </React.Fragment>

--- a/packages/manager/src/components/SideMenu.tsx
+++ b/packages/manager/src/components/SideMenu.tsx
@@ -7,16 +7,14 @@ import {
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
-import PrimaryNav from 'src/components/PrimaryNav';
 import { compose } from 'recompose';
 import withFeatureFlagConsumer, {
   FeatureFlagConsumerProps
 } from 'src/containers/withFeatureFlagConsumer.container';
-import PrimaryNav_CMR from './PrimaryNav/PrimaryNav_CMR';
+import PrimaryNav from './PrimaryNav/PrimaryNav_CMR';
 
 type ClassNames =
   | 'menuPaper'
-  | 'menuPaperCMR'
   | 'menuDocked'
   | 'desktopMenu'
   | 'collapsedDesktopMenu';
@@ -24,19 +22,6 @@ type ClassNames =
 const styles = (theme: Theme) =>
   createStyles({
     menuPaper: {
-      height: '100%',
-      width: theme.spacing(14) + 103, // 215
-      backgroundColor: theme.bg.primaryNavPaper,
-      borderRight: 'none',
-      left: 'inherit',
-      boxShadow: 'none',
-      transition: 'width linear .1s',
-      overflowX: 'hidden',
-      [theme.breakpoints.up('xl')]: {
-        width: theme.spacing(22) + 99 // 275
-      }
-    },
-    menuPaperCMR: {
       height: '100%',
       width: 190,
       backgroundColor: theme.bg.primaryNavPaper,
@@ -67,7 +52,6 @@ interface Props {
   open: boolean;
   desktopOpen: boolean;
   closeMenu: () => void;
-  toggleTheme: () => void;
   toggleSpacing: () => void;
 }
 
@@ -75,15 +59,7 @@ type CombinedProps = Props & WithStyles<ClassNames> & FeatureFlagConsumerProps;
 
 class SideMenu extends React.Component<CombinedProps> {
   render() {
-    const {
-      classes,
-      open,
-      desktopOpen,
-      closeMenu,
-      toggleSpacing,
-      toggleTheme,
-      flags
-    } = this.props;
+    const { classes, open, desktopOpen, closeMenu, toggleSpacing } = this.props;
 
     return (
       <React.Fragment>
@@ -92,27 +68,18 @@ class SideMenu extends React.Component<CombinedProps> {
             variant="temporary"
             open={open}
             classes={{
-              paper: flags.cmr ? classes.menuPaperCMR : classes.menuPaper
+              paper: classes.menuPaper
             }}
             onClose={closeMenu}
             ModalProps={{
               keepMounted: true // Better open performance on mobile.
             }}
           >
-            {flags.cmr ? (
-              <PrimaryNav_CMR
-                closeMenu={closeMenu}
-                toggleSpacing={toggleSpacing}
-                isCollapsed={false}
-              />
-            ) : (
-              <PrimaryNav
-                closeMenu={closeMenu}
-                toggleTheme={toggleTheme}
-                toggleSpacing={toggleSpacing}
-                isCollapsed={false}
-              />
-            )}
+            <PrimaryNav
+              closeMenu={closeMenu}
+              toggleSpacing={toggleSpacing}
+              isCollapsed={false}
+            />
           </Drawer>
         </Hidden>
         <Hidden smDown implementation="css">
@@ -120,27 +87,17 @@ class SideMenu extends React.Component<CombinedProps> {
             variant="permanent"
             open
             classes={{
-              paper: `${flags.cmr ? classes.menuPaperCMR : classes.menuPaper} ${
-                desktopOpen ? classes.collapsedDesktopMenu : ''
-              }`,
+              paper: `${classes.menuPaper} ${desktopOpen &&
+                classes.collapsedDesktopMenu}`,
               docked: classes.menuDocked
             }}
             className={classes.desktopMenu}
           >
-            {flags.cmr ? (
-              <PrimaryNav_CMR
-                closeMenu={closeMenu}
-                toggleSpacing={toggleSpacing}
-                isCollapsed={desktopOpen}
-              />
-            ) : (
-              <PrimaryNav
-                closeMenu={closeMenu}
-                toggleTheme={toggleTheme}
-                toggleSpacing={toggleSpacing}
-                isCollapsed={desktopOpen}
-              />
-            )}
+            <PrimaryNav
+              closeMenu={closeMenu}
+              toggleSpacing={toggleSpacing}
+              isCollapsed={desktopOpen}
+            />
           </Drawer>
         </Hidden>
       </React.Fragment>

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
@@ -9,7 +9,6 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { Link, RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
-import AddNewLink from 'src/components/AddNewLink';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Search from 'src/components/DebouncedSearchTextField';

--- a/packages/manager/src/features/TopMenu/UserMenu/UserMenu_CMR.tsx
+++ b/packages/manager/src/features/TopMenu/UserMenu/UserMenu_CMR.tsx
@@ -157,7 +157,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginBottom: theme.spacing(),
     marginLeft: theme.spacing(3),
     marginRight: theme.spacing(3),
-    padding: '16px 0',
+    padding: '16px 0 8px',
     textTransform: 'uppercase'
   },
   profileWrapper: {


### PR DESCRIPTION
Basically, the primary nav will always have the icon visible