### PR TITLE
Restore IP Controls, Group NBs, Volumes, Domains by Tag

### DIFF
--- a/packages/manager/src/components/EntityHeader/EntityHeader.tsx
+++ b/packages/manager/src/components/EntityHeader/EntityHeader.tsx
@@ -5,6 +5,7 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 import HeaderBreadCrumb, { BreadCrumbProps } from './HeaderBreadCrumb';
 import Breadcrumb from '../Breadcrumb';
 import DocumentationButton from '../CMR_DocumentationButton';
+import Typography from 'src/components/core/Typography';
 
 export interface HeaderProps extends BreadCrumbProps {
   actions?: JSX.Element;
@@ -57,7 +58,12 @@ const useStyles = makeStyles((theme: Theme) => ({
     padding: 0
   },
   breadCrumbSecondary: {
-    justifyContent: 'space-between'
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center'
+  },
+  label: {
+    marginLeft: 15
   },
   breadCrumbDetailLanding: {
     margin: 0,
@@ -87,6 +93,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   }
 }));
 
+// @todo: Refactor this whole thing now that we have less variants.
 export const EntityHeader: React.FC<HeaderProps> = props => {
   const classes = useStyles();
 
@@ -157,6 +164,11 @@ export const EntityHeader: React.FC<HeaderProps> = props => {
             [classes.breadCrumbDetailLanding]: Boolean(isDetailLanding)
           })}
         >
+          {isSecondary ? (
+            <Typography variant="h3" className={classes.label}>
+              {labelTitle}
+            </Typography>
+          ) : null}
           {body && (
             <Grid
               className={classnames({
@@ -168,6 +180,7 @@ export const EntityHeader: React.FC<HeaderProps> = props => {
               {body}
             </Grid>
           )}
+          {isSecondary ? actions : null}
         </Grid>
       </Grid>
     </>

--- a/packages/manager/src/components/EntityHeader/EntityHeader.tsx
+++ b/packages/manager/src/components/EntityHeader/EntityHeader.tsx
@@ -93,7 +93,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   }
 }));
 
-// @todo: Refactor this whole thing now that we have less variants.
+// @todo: Refactor this entire component now that we have less variants.
 export const EntityHeader: React.FC<HeaderProps> = props => {
   const classes = useStyles();
 

--- a/packages/manager/src/components/EntityTable/EntityTable.tsx
+++ b/packages/manager/src/components/EntityTable/EntityTable.tsx
@@ -14,6 +14,7 @@ export interface EntityTableRow<T> extends BaseProps {
 interface Props {
   entity: string;
   headers: HeaderCell[];
+  toggleGroupByTag?: () => boolean;
   groupByTag: boolean;
   row: EntityTableRow<any>;
   initialOrder?: {

--- a/packages/manager/src/components/EntityTable/EntityTableHeader.tsx
+++ b/packages/manager/src/components/EntityTable/EntityTableHeader.tsx
@@ -1,10 +1,14 @@
 import * as React from 'react';
-import { makeStyles, Theme } from 'src/components/core/styles';
-import { OrderByProps } from 'src/components/OrderBy';
-import TableCell from 'src/components/TableCell';
+import GridView from 'src/assets/icons/grid-view.svg';
+import GroupByTag from 'src/assets/icons/group-by-tag.svg';
 import Hidden from 'src/components/core/Hidden';
+import IconButton from 'src/components/core/IconButton';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import TableHead from 'src/components/core/TableHead';
 import TableRow from 'src/components/core/TableRow';
+import Tooltip from 'src/components/core/Tooltip';
+import { OrderByProps } from 'src/components/OrderBy';
+import TableCell from 'src/components/TableCell';
 import TableSortCell from 'src/components/TableSortCell';
 import TableSortCell_CMR from 'src/components/TableSortCell/TableSortCell_CMR';
 import useFlags from 'src/hooks/useFlags';
@@ -27,11 +31,25 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   '& .MuiTableCell-head': {
     borderBottom: 0
+  },
+  controlHeader: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    backgroundColor: theme.cmrBGColors.bgTableHeader
+  },
+  toggleButton: {
+    padding: '0 10px',
+    '&:focus': {
+      // Browser default until we get styling direction for focus states
+      outline: '1px dotted #999'
+    }
   }
 }));
 
 interface Props extends Omit<OrderByProps, 'data'> {
   headers: HeaderCell[];
+  toggleGroupByTag?: () => boolean;
+  isGroupedByTag?: boolean;
 }
 
 interface SortCellProps extends Omit<Props, 'headers'> {
@@ -43,7 +61,14 @@ interface NormalCellProps {
 }
 
 export const EntityTableHeader: React.FC<Props> = props => {
-  const { headers, handleOrderChange, order, orderBy } = props;
+  const {
+    headers,
+    handleOrderChange,
+    order,
+    orderBy,
+    toggleGroupByTag,
+    isGroupedByTag
+  } = props;
   const classes = useStyles();
   const flags = useFlags();
 
@@ -132,6 +157,29 @@ export const EntityTableHeader: React.FC<Props> = props => {
             ]
           )
         )}
+        <TableCell>
+          <div className={classes.controlHeader}>
+            <div id="groupByDescription" className="visually-hidden">
+              {isGroupedByTag
+                ? 'group by tag is currently enabled'
+                : 'group by tag is currently disabled'}
+            </div>
+            <Tooltip
+              placement="top-end"
+              title={`${isGroupedByTag ? 'Ungroup' : 'Group'} by tag`}
+            >
+              <IconButton
+                aria-label={`Toggle group by tag`}
+                aria-describedby={'groupByDescription'}
+                onClick={toggleGroupByTag}
+                disableRipple
+                className={classes.toggleButton}
+              >
+                <GroupByTag />
+              </IconButton>
+            </Tooltip>
+          </div>
+        </TableCell>
       </TableRow>
     </TableHead>
   );

--- a/packages/manager/src/components/EntityTable/EntityTableHeader.tsx
+++ b/packages/manager/src/components/EntityTable/EntityTableHeader.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import GridView from 'src/assets/icons/grid-view.svg';
 import GroupByTag from 'src/assets/icons/group-by-tag.svg';
 import Hidden from 'src/components/core/Hidden';
 import IconButton from 'src/components/core/IconButton';

--- a/packages/manager/src/components/EntityTable/EntityTableHeader.tsx
+++ b/packages/manager/src/components/EntityTable/EntityTableHeader.tsx
@@ -31,17 +31,10 @@ const useStyles = makeStyles((theme: Theme) => ({
   '& .MuiTableCell-head': {
     borderBottom: 0
   },
-  controlHeader: {
-    display: 'flex',
-    justifyContent: 'flex-end',
-    backgroundColor: theme.cmrBGColors.bgTableHeader
-  },
-  toggleButton: {
-    padding: '0 10px',
-    '&:focus': {
-      // Browser default until we get styling direction for focus states
-      outline: '1px dotted #999'
-    }
+  groupByTagCell: {
+    textAlign: 'right',
+    backgroundColor: theme.cmrBGColors.bgTableHeader,
+    paddingRight: `0px !important`
   }
 }));
 
@@ -156,32 +149,69 @@ export const EntityTableHeader: React.FC<Props> = props => {
             ]
           )
         )}
-        <TableCell>
-          <div className={classes.controlHeader}>
-            <div id="groupByDescription" className="visually-hidden">
-              {isGroupedByTag
-                ? 'group by tag is currently enabled'
-                : 'group by tag is currently disabled'}
-            </div>
-            <Tooltip
-              placement="top-end"
-              title={`${isGroupedByTag ? 'Ungroup' : 'Group'} by tag`}
-            >
-              <IconButton
-                aria-label={`Toggle group by tag`}
-                aria-describedby={'groupByDescription'}
-                onClick={toggleGroupByTag}
-                disableRipple
-                className={classes.toggleButton}
-              >
-                <GroupByTag />
-              </IconButton>
-            </Tooltip>
-          </div>
-        </TableCell>
+        {toggleGroupByTag && typeof isGroupedByTag !== 'undefined' ? (
+          <TableCell className={classes.groupByTagCell}>
+            <GroupByTagToggle
+              toggleGroupByTag={toggleGroupByTag}
+              isGroupedByTag={isGroupedByTag}
+            />
+          </TableCell>
+        ) : null}
       </TableRow>
     </TableHead>
   );
 };
 
 export default React.memo(EntityTableHeader);
+
+// =============================================================================
+// <GroupByTagToggle />
+// =============================================================================
+interface GroupByTagToggleProps {
+  toggleGroupByTag: () => boolean;
+  isGroupedByTag: boolean;
+}
+
+const useGroupByTagToggleStyles = makeStyles((theme: Theme) => ({
+  controlHeader: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    backgroundColor: theme.cmrBGColors.bgTableHeader
+  },
+  toggleButton: {
+    padding: '0 10px',
+    '&:focus': {
+      outline: '1px dotted #999'
+    }
+  }
+}));
+
+export const GroupByTagToggle: React.FC<GroupByTagToggleProps> = props => {
+  const classes = useGroupByTagToggleStyles();
+
+  const { toggleGroupByTag, isGroupedByTag } = props;
+
+  return (
+    <>
+      <div id="groupByDescription" className="visually-hidden">
+        {isGroupedByTag
+          ? 'group by tag is currently enabled'
+          : 'group by tag is currently disabled'}
+      </div>
+      <Tooltip
+        placement="top-end"
+        title={`${isGroupedByTag ? 'Ungroup' : 'Group'} by tag`}
+      >
+        <IconButton
+          aria-label={`Toggle group by tag`}
+          aria-describedby={'groupByDescription'}
+          onClick={toggleGroupByTag}
+          disableRipple
+          className={classes.toggleButton}
+        >
+          <GroupByTag />
+        </IconButton>
+      </Tooltip>
+    </>
+  );
+};

--- a/packages/manager/src/components/EntityTable/EntityTableHeader.tsx
+++ b/packages/manager/src/components/EntityTable/EntityTableHeader.tsx
@@ -172,12 +172,7 @@ interface GroupByTagToggleProps {
   isGroupedByTag: boolean;
 }
 
-const useGroupByTagToggleStyles = makeStyles((theme: Theme) => ({
-  controlHeader: {
-    display: 'flex',
-    justifyContent: 'flex-end',
-    backgroundColor: theme.cmrBGColors.bgTableHeader
-  },
+const useGroupByTagToggleStyles = makeStyles(() => ({
   toggleButton: {
     padding: '0 10px',
     '&:focus': {
@@ -186,32 +181,34 @@ const useGroupByTagToggleStyles = makeStyles((theme: Theme) => ({
   }
 }));
 
-export const GroupByTagToggle: React.FC<GroupByTagToggleProps> = props => {
-  const classes = useGroupByTagToggleStyles();
+export const GroupByTagToggle: React.FC<GroupByTagToggleProps> = React.memo(
+  props => {
+    const classes = useGroupByTagToggleStyles();
 
-  const { toggleGroupByTag, isGroupedByTag } = props;
+    const { toggleGroupByTag, isGroupedByTag } = props;
 
-  return (
-    <>
-      <div id="groupByDescription" className="visually-hidden">
-        {isGroupedByTag
-          ? 'group by tag is currently enabled'
-          : 'group by tag is currently disabled'}
-      </div>
-      <Tooltip
-        placement="top-end"
-        title={`${isGroupedByTag ? 'Ungroup' : 'Group'} by tag`}
-      >
-        <IconButton
-          aria-label={`Toggle group by tag`}
-          aria-describedby={'groupByDescription'}
-          onClick={toggleGroupByTag}
-          disableRipple
-          className={classes.toggleButton}
+    return (
+      <>
+        <div id="groupByDescription" className="visually-hidden">
+          {isGroupedByTag
+            ? 'group by tag is currently enabled'
+            : 'group by tag is currently disabled'}
+        </div>
+        <Tooltip
+          placement="top-end"
+          title={`${isGroupedByTag ? 'Ungroup' : 'Group'} by tag`}
         >
-          <GroupByTag />
-        </IconButton>
-      </Tooltip>
-    </>
-  );
-};
+          <IconButton
+            aria-label={`Toggle group by tag`}
+            aria-describedby={'groupByDescription'}
+            onClick={toggleGroupByTag}
+            disableRipple
+            className={classes.toggleButton}
+          >
+            <GroupByTag />
+          </IconButton>
+        </Tooltip>
+      </>
+    );
+  }
+);

--- a/packages/manager/src/components/EntityTable/EntityTable_CMR.tsx
+++ b/packages/manager/src/components/EntityTable/EntityTable_CMR.tsx
@@ -29,7 +29,6 @@ const useStyles = makeStyles((theme: Theme) => ({
 interface Props {
   entity: string;
   headers: HeaderCell[];
-  groupByTag: boolean;
   toggleGroupByTag?: () => boolean;
   isGroupedByTag?: boolean;
   row: EntityTableRow<any>;
@@ -45,7 +44,6 @@ export const LandingTable: React.FC<CombinedProps> = props => {
   const {
     entity,
     headers,
-    groupByTag,
     row,
     initialOrder,
     toggleGroupByTag,
@@ -78,7 +76,7 @@ export const LandingTable: React.FC<CombinedProps> = props => {
     );
   }
 
-  if (groupByTag) {
+  if (isGroupedByTag) {
     return (
       <div className={classes.root}>
         <GroupedEntitiesByTag {...tableProps} />

--- a/packages/manager/src/components/EntityTable/EntityTable_CMR.tsx
+++ b/packages/manager/src/components/EntityTable/EntityTable_CMR.tsx
@@ -30,6 +30,8 @@ interface Props {
   entity: string;
   headers: HeaderCell[];
   groupByTag: boolean;
+  toggleGroupByTag?: () => boolean;
+  isGroupedByTag?: boolean;
   row: EntityTableRow<any>;
   initialOrder?: {
     order: OrderByProps['order'];
@@ -40,7 +42,15 @@ interface Props {
 export type CombinedProps = Props & PageyIntegrationProps;
 
 export const LandingTable: React.FC<CombinedProps> = props => {
-  const { entity, headers, groupByTag, row, initialOrder } = props;
+  const {
+    entity,
+    headers,
+    groupByTag,
+    row,
+    initialOrder,
+    toggleGroupByTag,
+    isGroupedByTag
+  } = props;
   const classes = useStyles();
   const tableProps = {
     data: row.data,
@@ -52,7 +62,9 @@ export const LandingTable: React.FC<CombinedProps> = props => {
     headers,
     initialOrder,
     entity,
-    handlers: row.handlers
+    handlers: row.handlers,
+    toggleGroupByTag,
+    isGroupedByTag
   };
 
   if (row.request) {

--- a/packages/manager/src/components/EntityTable/GroupedEntitiesByTag_CMR.tsx
+++ b/packages/manager/src/components/EntityTable/GroupedEntitiesByTag_CMR.tsx
@@ -56,7 +56,16 @@ const useStyles = makeStyles((theme: Theme) => ({
 export type CombinedProps = ListProps;
 
 export const GroupedEntitiesByTag: React.FC<CombinedProps> = props => {
-  const { data, entity, handlers, headers, initialOrder, RowComponent } = props;
+  const {
+    data,
+    entity,
+    handlers,
+    headers,
+    initialOrder,
+    RowComponent,
+    toggleGroupByTag,
+    isGroupedByTag
+  } = props;
   const classes = useStyles();
   const { infinitePageSize, setInfinitePageSize } = useInfinitePageSize();
 
@@ -75,6 +84,8 @@ export const GroupedEntitiesByTag: React.FC<CombinedProps> = props => {
               handleOrderChange={handleOrderChange}
               order={order}
               orderBy={orderBy}
+              toggleGroupByTag={toggleGroupByTag}
+              isGroupedByTag={isGroupedByTag}
             />
             {groupedEntities.map(([tag, domains]: [string, any[]]) => {
               return (

--- a/packages/manager/src/components/EntityTable/ListEntities_CMR.tsx
+++ b/packages/manager/src/components/EntityTable/ListEntities_CMR.tsx
@@ -21,7 +21,9 @@ export const ListEntities: React.FC<CombinedProps> = props => {
     initialOrder,
     loading,
     lastUpdated,
-    RowComponent
+    RowComponent,
+    toggleGroupByTag,
+    isGroupedByTag
   } = props;
 
   return (
@@ -49,6 +51,8 @@ export const ListEntities: React.FC<CombinedProps> = props => {
                     handleOrderChange={handleOrderChange}
                     order={order}
                     orderBy={orderBy}
+                    toggleGroupByTag={toggleGroupByTag}
+                    isGroupedByTag={isGroupedByTag}
                   />
 
                   <TableBody>

--- a/packages/manager/src/components/EntityTable/types.ts
+++ b/packages/manager/src/components/EntityTable/types.ts
@@ -32,6 +32,8 @@ export interface ListProps extends BaseProps {
     order: OrderByProps['order'];
     orderBy: OrderByProps['orderBy'];
   };
+  toggleGroupByTag?: () => boolean;
+  isGroupedByTag?: boolean;
 }
 
 export interface EntityTableRow<T> extends BaseProps {

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
@@ -232,7 +232,6 @@ const DatabaseLanding: React.FC<{}> = _ => {
       />
       <EntityTable
         entity="databases"
-        groupByTag={false}
         row={_DatabaseRow}
         headers={headers}
         initialOrder={{ order: 'asc', orderBy: 'label' }}

--- a/packages/manager/src/features/Domains/DomainsLanding.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.tsx
@@ -22,10 +22,7 @@ import Typography from 'src/components/core/Typography';
 import DeletionDialog from 'src/components/DeletionDialog';
 import setDocs from 'src/components/DocsSidebar/setDocs';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
-import EntityTable, {
-  EntityTableRow,
-  HeaderCell
-} from 'src/components/EntityTable';
+import { EntityTableRow, HeaderCell } from 'src/components/EntityTable';
 import EntityTable_CMR from 'src/components/EntityTable/EntityTable_CMR';
 import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
@@ -170,13 +167,6 @@ const headers: HeaderCell[] = [
     sortable: true,
     widthPercent: 20,
     hideOnMobile: true
-  },
-  {
-    label: 'Action Menu',
-    visuallyHidden: true,
-    dataColumn: '',
-    sortable: false,
-    widthPercent: 5
   }
 ];
 
@@ -345,7 +335,7 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
       linodesLoading
     } = this.props;
 
-    const Table = flags.cmr ? EntityTable_CMR : EntityTable;
+    const Table = EntityTable_CMR;
 
     const handlers: DomainHandlers = {
       onClone: this.props.openForCloning,
@@ -525,7 +515,8 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
                 )}
                 <Table
                   entity="domain"
-                  groupByTag={domainsAreGrouped}
+                  toggleGroupByTag={toggleGroupDomains}
+                  isGroupedByTag={domainsAreGrouped}
                   row={domainRow}
                   headers={headers}
                   initialOrder={initialOrder}

--- a/packages/manager/src/features/Domains/DomainsLanding.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.tsx
@@ -335,8 +335,6 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
       linodesLoading
     } = this.props;
 
-    const Table = EntityTable_CMR;
-
     const handlers: DomainHandlers = {
       onClone: this.props.openForCloning,
       onEdit: this.props.openForEditing,
@@ -513,7 +511,7 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
                     </Grid>
                   </Grid>
                 )}
-                <Table
+                <EntityTable_CMR
                   entity="domain"
                   toggleGroupByTag={toggleGroupDomains}
                   isGroupedByTag={domainsAreGrouped}

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallLanding_CMR.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallLanding_CMR.tsx
@@ -168,7 +168,6 @@ const FirewallLanding: React.FC<CombinedProps> = props => {
       />
       <EntityTable
         entity="firewall"
-        groupByTag={false}
         row={firewallRow}
         headers={headers}
         initialOrder={{ order: 'asc', orderBy: 'domain' }}

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.tsx
@@ -24,10 +24,7 @@ import {
 import Typography from 'src/components/core/Typography';
 import setDocs, { SetDocsProps } from 'src/components/DocsSidebar/setDocs';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
-import EntityTable, {
-  EntityTableRow,
-  HeaderCell
-} from 'src/components/EntityTable';
+import { EntityTableRow, HeaderCell } from 'src/components/EntityTable';
 import EntityTable_CMR from 'src/components/EntityTable/EntityTable_CMR';
 import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
@@ -163,13 +160,6 @@ const headers: HeaderCell[] = [
     sortable: true,
     widthPercent: 5,
     hideOnMobile: true
-  },
-  {
-    label: 'Action Menu',
-    visuallyHidden: true,
-    dataColumn: '',
-    sortable: false,
-    widthPercent: 5
   }
 ];
 
@@ -301,8 +291,6 @@ export class NodeBalancersLanding extends React.Component<
       return <NodeBalancersLandingEmptyState />;
     }
 
-    const Table = flags.cmr ? EntityTable_CMR : EntityTable;
-
     const nodeBalancerRow: EntityTableRow<NodeBalancer> = {
       Component: flags.cmr ? NodeBalancerTableRow_CMR : NodeBalancerTableRow,
       data: Object.values(nodeBalancersData),
@@ -387,9 +375,10 @@ export class NodeBalancersLanding extends React.Component<
                     </Grid>
                   </Grid>
                 )}
-                <Table
+                <EntityTable_CMR
                   entity="nodebalancer"
-                  groupByTag={nodeBalancersAreGrouped}
+                  isGroupedByTag={nodeBalancersAreGrouped}
+                  toggleGroupByTag={toggleNodeBalancerGroupByTag}
                   row={nodeBalancerRow}
                   headers={headers}
                   initialOrder={{ order: 'desc', orderBy: 'label' }}

--- a/packages/manager/src/features/Vlans/VlanLanding/VlanLanding.tsx
+++ b/packages/manager/src/features/Vlans/VlanLanding/VlanLanding.tsx
@@ -83,7 +83,6 @@ const VlanLanding: React.FC<CombinedProps> = () => {
       />
       <EntityTable
         entity="vlans"
-        groupByTag={false}
         row={vLanRow}
         headers={headers}
         initialOrder={{ order: 'asc', orderBy: 'label' }}

--- a/packages/manager/src/features/Volumes/VolumesLanding_CMR.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding_CMR.tsx
@@ -351,7 +351,6 @@ export const VolumesLanding: React.FC<CombinedProps> = props => {
         preferenceKey="volumes_group_by_tag"
         preferenceOptions={[false, true]}
         localStorageKey="GROUP_VOLUMES"
-        // toggleCallbackFnDebounced={toggleVolumesGroupBy}
       >
         {({
           preference: volumesAreGrouped,

--- a/packages/manager/src/features/Volumes/VolumesLanding_CMR.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding_CMR.tsx
@@ -47,6 +47,8 @@ import { ActionHandlers as VolumeHandlers } from './VolumesActionMenu_CMR';
 import VolumeTableRow from './VolumeTableRow_CMR';
 import useReduxLoad from 'src/hooks/useReduxLoad';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import PreferenceToggle from 'src/components/PreferenceToggle';
+import { ToggleProps } from 'src/components/PreferenceToggle/PreferenceToggle';
 
 interface Props {
   isVolumesLanding?: boolean;
@@ -352,37 +354,55 @@ export const VolumesLanding: React.FC<CombinedProps> = props => {
   return (
     <React.Fragment>
       <DocumentTitleSegment segment="Volumes" />
-      <LandingHeader
-        title="Volumes"
-        entity="Volume"
-        onAddNew={() => props.history.push('/volumes/create')}
-        docsLink="https://www.linode.com/docs/platform/block-storage/how-to-use-block-storage-with-your-linode/"
-      />
-      <EntityTable_CMR
-        entity="volume"
-        headers={volumeHeaders}
-        groupByTag={false}
-        row={volumeRow}
-        initialOrder={{ order: 'asc', orderBy: 'label' }}
-      />
-      <VolumeAttachmentDrawer
-        open={attachmentDrawer.open}
-        volumeId={attachmentDrawer.volumeId || 0}
-        volumeLabel={attachmentDrawer.volumeLabel || ''}
-        linodeRegion={attachmentDrawer.linodeRegion || ''}
-        onClose={handleCloseAttachDrawer}
-      />
-      <DestructiveVolumeDialog
-        open={destructiveDialog.open}
-        error={destructiveDialog.error}
-        volumeLabel={destructiveDialog.volumeLabel}
-        linodeLabel={destructiveDialog.linodeLabel}
-        poweredOff={destructiveDialog.poweredOff || false}
-        mode={destructiveDialog.mode}
-        onClose={closeDestructiveDialog}
-        onDetach={detachVolume}
-        onDelete={deleteVolume}
-      />
+      <PreferenceToggle<boolean>
+        preferenceKey="volumes_group_by_tag"
+        preferenceOptions={[false, true]}
+        localStorageKey="GROUP_VOLUMES"
+        // toggleCallbackFnDebounced={toggleVolumesGroupBy}
+      >
+        {({
+          preference: volumesAreGrouped,
+          togglePreference: toggleGroupVolumes
+        }: ToggleProps<boolean>) => {
+          return (
+            <>
+              <LandingHeader
+                title="Volumes"
+                entity="Volume"
+                onAddNew={() => props.history.push('/volumes/create')}
+                docsLink="https://www.linode.com/docs/platform/block-storage/how-to-use-block-storage-with-your-linode/"
+              />
+              <EntityTable_CMR
+                entity="volume"
+                headers={volumeHeaders}
+                groupByTag={volumesAreGrouped}
+                isGroupedByTag={volumesAreGrouped}
+                toggleGroupByTag={toggleGroupVolumes}
+                row={volumeRow}
+                initialOrder={{ order: 'asc', orderBy: 'label' }}
+              />
+              <VolumeAttachmentDrawer
+                open={attachmentDrawer.open}
+                volumeId={attachmentDrawer.volumeId || 0}
+                volumeLabel={attachmentDrawer.volumeLabel || ''}
+                linodeRegion={attachmentDrawer.linodeRegion || ''}
+                onClose={handleCloseAttachDrawer}
+              />
+              <DestructiveVolumeDialog
+                open={destructiveDialog.open}
+                error={destructiveDialog.error}
+                volumeLabel={destructiveDialog.volumeLabel}
+                linodeLabel={destructiveDialog.linodeLabel}
+                poweredOff={destructiveDialog.poweredOff || false}
+                mode={destructiveDialog.mode}
+                onClose={closeDestructiveDialog}
+                onDetach={detachVolume}
+                onDelete={deleteVolume}
+              />
+            </>
+          );
+        }}
+      </PreferenceToggle>
     </React.Fragment>
   );
 };

--- a/packages/manager/src/features/Volumes/VolumesLanding_CMR.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding_CMR.tsx
@@ -135,13 +135,6 @@ const volumeHeaders = [
     dataColumn: 'Attached To',
     sortable: false,
     widthPercent: 20
-  },
-  {
-    label: 'Action Menu',
-    visuallyHidden: true,
-    dataColumn: '',
-    sortable: false,
-    widthPercent: 5
   }
 ];
 

--- a/packages/manager/src/features/Volumes/VolumesLanding_CMR.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding_CMR.tsx
@@ -368,7 +368,6 @@ export const VolumesLanding: React.FC<CombinedProps> = props => {
               <EntityTable_CMR
                 entity="volume"
                 headers={volumeHeaders}
-                groupByTag={volumesAreGrouped}
                 isGroupedByTag={volumesAreGrouped}
                 toggleGroupByTag={toggleGroupVolumes}
                 row={volumeRow}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeVolumes.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeVolumes.tsx
@@ -340,7 +340,6 @@ export const LinodeStorage: React.FC<CombinedProps> = props => {
       <EntityTable_CMR
         entity="volume"
         headers={volumeHeaders}
-        groupByTag={false}
         row={volumeRow}
         initialOrder={{ order: 'asc', orderBy: 'label' }}
       />

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking_CMR.tsx
@@ -645,27 +645,36 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
         <EntityHeader
           title="IP Addresses"
           isSecondary
+          // @todo: Clean these body/actions props when EntityHeader is refactored.
           body={
             <Hidden mdUp>
-              <Button
-                style={{ paddingTop: 5, paddingBottom: 5 }}
-                onClick={this.openTransferDialog}
-                buttonType="secondary"
-              >
-                IP Transfer
-              </Button>
-              <Button
-                style={{ paddingTop: 5, paddingBottom: 5 }}
-                onClick={this.openSharingDialog}
-                buttonType="secondary"
-              >
-                IP Sharing
-              </Button>
+              <div style={{ marginRight: 5 }}>
+                <Hidden xsDown>
+                  <Button
+                    style={{ paddingTop: 5, paddingBottom: 5 }}
+                    onClick={this.openTransferDialog}
+                    buttonType="secondary"
+                  >
+                    IP Transfer
+                  </Button>
+                  <Button
+                    style={{ paddingTop: 5, paddingBottom: 5 }}
+                    onClick={this.openSharingDialog}
+                    buttonType="secondary"
+                  >
+                    IP Sharing
+                  </Button>
+                </Hidden>
+                <AddNewLink
+                  label="Add an IP Address"
+                  onClick={this.openAddIPDrawer}
+                />
+              </div>
             </Hidden>
           }
           actions={
-            <div>
-              <Hidden smDown>
+            <Hidden smDown>
+              <div style={{ marginRight: 5 }}>
                 <Button
                   style={{ padding: '16px 14px' }}
                   onClick={this.openTransferDialog}
@@ -680,12 +689,12 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
                 >
                   IP Sharing
                 </Button>
-              </Hidden>
-              <AddNewLink
-                label="Add an IP Address"
-                onClick={this.openAddIPDrawer}
-              />
-            </div>
+                <AddNewLink
+                  label="Add an IP Address"
+                  onClick={this.openAddIPDrawer}
+                />
+              </div>
+            </Hidden>
           }
         />
         <Paper style={{ padding: 0 }}>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking_CMR.tsx
@@ -645,7 +645,7 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
         <EntityHeader
           title="IP Addresses"
           isSecondary
-          // @todo: Clean these body/actions props when EntityHeader is refactored.
+          // @todo: Clean these props when EntityHeader is refactored.
           body={
             <Hidden mdUp>
               <div style={{ marginRight: 5 }}>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/VLANPanel/LinodeVLANs.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/VLANPanel/LinodeVLANs.tsx
@@ -193,7 +193,6 @@ export const LinodeVLANs: React.FC<CombinedProps> = props => {
       <EntityTable_CMR
         entity="vlan"
         headers={vlanHeaders}
-        groupByTag={false}
         row={vlanRow}
         initialOrder={{ order: 'asc', orderBy: 'label' }}
       />

--- a/packages/manager/src/features/linodes/LinodesLanding/SortableTableHead_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/SortableTableHead_CMR.tsx
@@ -20,7 +20,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   toggleButton: {
     padding: '0 10px',
     '&:focus': {
-      // Browser default until we get styling direction for focus states
       outline: '1px dotted #999'
     }
   }

--- a/packages/manager/src/features/linodes/LinodesLanding/SortableTableHead_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/SortableTableHead_CMR.tsx
@@ -8,8 +8,8 @@ import Hidden from 'src/components/core/Hidden';
 import IconButton from 'src/components/core/IconButton';
 import Tooltip from 'src/components/core/Tooltip';
 import GridView from 'src/assets/icons/grid-view.svg';
-import GroupByTag from 'src/assets/icons/group-by-tag.svg';
 import { makeStyles, Theme } from 'src/components/core/styles';
+import { GroupByTagToggle } from 'src/components/EntityTable/EntityTableHeader';
 
 const useStyles = makeStyles((theme: Theme) => ({
   controlHeader: {
@@ -134,25 +134,10 @@ const SortableTableHead: React.FC<CombinedProps> = props => {
                 <GridView />
               </IconButton>
             </Tooltip>
-            <div id="groupByDescription" className="visually-hidden">
-              {linodesAreGrouped
-                ? 'group by tag is currently enabled'
-                : 'group by tag is currently disabled'}
-            </div>
-            <Tooltip
-              placement="top-end"
-              title={`${linodesAreGrouped ? 'Ungroup' : 'Group'} by tag`}
-            >
-              <IconButton
-                aria-label={`Toggle group by tag`}
-                aria-describedby={'groupByDescription'}
-                onClick={toggleGroupLinodes}
-                disableRipple
-                className={classes.toggleButton}
-              >
-                <GroupByTag />
-              </IconButton>
-            </Tooltip>
+            <GroupByTagToggle
+              toggleGroupByTag={toggleGroupLinodes}
+              isGroupedByTag={linodesAreGrouped}
+            />
           </div>
         </TableCell>
       </TableRow>


### PR DESCRIPTION
## Description

- Fix regression where IP buttons (IP Transfer, Sharing, Add IP) went missing from the table in the Linode Networking tab. (This was due to re-arranging of the EntityHeader.)
- Add GroupByTag controls to Volumes, NodeBalancers, Domains for parity with production.
