### PR TITLE
Add "secondary status" to Linodes

### DIFF
--- a/packages/manager/src/components/EntityDetail/EntityDetail.stories.tsx
+++ b/packages/manager/src/components/EntityDetail/EntityDetail.stories.tsx
@@ -13,6 +13,7 @@ storiesOf('EntityDetail', module).add('Linode', () => (
       <LinodeEntityDetail
         variant="details"
         numVolumes={2}
+        id={0}
         linode={linodeFactory.build()}
         username="linode-user"
         openTagDrawer={() => null}
@@ -27,6 +28,7 @@ storiesOf('EntityDetail', module).add('Linode', () => (
       <LinodeEntityDetail
         variant="landing"
         numVolumes={2}
+        id={0}
         linode={linodeFactory.build()}
         username="linode-user"
         openTagDrawer={() => null}

--- a/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
+++ b/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
@@ -224,7 +224,9 @@ const useHeaderStyles = makeStyles((theme: Theme) => ({
   },
   statusChip: {
     ...theme.applyStatusPillStyles,
-    marginLeft: theme.spacing()
+    marginLeft: theme.spacing(),
+    height: `24px !important`,
+    borderRadius: 0
   },
   statusRunning: {
     '&:before': {
@@ -240,6 +242,10 @@ const useHeaderStyles = makeStyles((theme: Theme) => ({
     '&:before': {
       backgroundColor: theme.cmrIconColors.iOrange
     }
+  },
+  divider: {
+    borderRight: `1px solid ${theme.cmrBorderColors.borderTypography}`,
+    paddingRight: `16px !important`
   },
   actionItemsOuter: {
     display: 'flex',
@@ -297,6 +303,9 @@ const Header: React.FC<HeaderProps> = props => {
     lishLaunch(id);
   };
 
+  const hasSecondaryStatus =
+    typeof progress !== 'undefined' && typeof transitionText !== 'undefined';
+
   return (
     <EntityHeader
       parentLink={isDetails ? '/linodes' : undefined}
@@ -323,6 +332,7 @@ const Header: React.FC<HeaderProps> = props => {
                   [classes.statusRunning]: isRunning,
                   [classes.statusOffline]: isOffline,
                   [classes.statusOther]: isOther,
+                  [classes.divider]: hasSecondaryStatus,
                   statusOtherDetail: isOther
                 })}
                 label={linodeStatus.replace('_', ' ').toUpperCase()}
@@ -330,21 +340,19 @@ const Header: React.FC<HeaderProps> = props => {
                 {...isOther}
               />
             </Grid>
-            {typeof progress !== 'undefined' &&
-            typeof transitionText !== 'undefined' ? (
+            {hasSecondaryStatus ? (
               <Grid
                 item
                 className="py0"
-                style={{ marginLeft: 24, marginBottom: 2 }}
+                style={{ marginLeft: 16, marginBottom: 2 }}
               >
                 <button
                   className={classes.statusLink}
                   onClick={openNotificationDrawer}
                 >
                   <ProgressDisplay
-                    // className={classes.progressDisplay}
-                    progress={progress}
-                    text={transitionText.toUpperCase() ?? ''}
+                    progress={progress!}
+                    text={transitionText!.toUpperCase() ?? ''}
                   />
                 </button>
               </Grid>

--- a/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
+++ b/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
@@ -8,6 +8,7 @@ import { HashLink } from 'react-router-hash-link';
 import { compose } from 'recompose';
 import Button from 'src/components/Button';
 import CopyTooltip from 'src/components/CopyTooltip';
+import Box from 'src/components/core/Box';
 import Chip from 'src/components/core/Chip';
 import Hidden from 'src/components/core/Hidden';
 import {
@@ -46,6 +47,7 @@ import withRecentEvent, {
 } from './LinodesLanding/withRecentEvent';
 import {
   getProgressOrDefault,
+  isEventWithSecondaryLinodeStatus,
   transitionText as _transitionText
 } from './transitions';
 
@@ -108,8 +110,12 @@ const LinodeEntityDetail: React.FC<CombinedProps> = props => {
 
   const linodeRegionDisplay = dcDisplayNames[linode.region] ?? null;
 
-  const progress = getProgressOrDefault(recentEvent);
-  const transitionText = _transitionText(linode.status, linode.id, recentEvent);
+  let progress;
+  let transitionText;
+  if (recentEvent && isEventWithSecondaryLinodeStatus(recentEvent, linode.id)) {
+    progress = getProgressOrDefault(recentEvent);
+    transitionText = _transitionText(linode.status, linode.id, recentEvent);
+  }
 
   return (
     <EntityDetail
@@ -193,7 +199,7 @@ export interface HeaderProps {
   linodeConfigs: Config[];
   isDetailLanding?: boolean;
   openNotificationDrawer: () => void;
-  progress: number;
+  progress?: number;
   transitionText?: string;
 }
 
@@ -309,32 +315,41 @@ const Header: React.FC<HeaderProps> = props => {
           alignItems="center"
           justify="space-between"
         >
-          <Grid item className="py0">
-            <Chip
-              className={classnames({
-                [classes.statusChip]: true,
-                [classes.statusRunning]: isRunning,
-                [classes.statusOffline]: isOffline,
-                [classes.statusOther]: isOther,
-                statusOtherDetail: isOther
-              })}
-              label={linodeStatus.replace('_', ' ').toUpperCase()}
-              component="span"
-              {...isOther}
-            />
-          </Grid>
-          <Grid item className="py0">
-            <button
-              className={classes.statusLink}
-              onClick={openNotificationDrawer}
-            >
-              <ProgressDisplay
-                // className={classes.progressDisplay}
-                progress={progress}
-                text={transitionText ?? ''}
+          <Box display="flex" alignItems="center">
+            <Grid item className="py0">
+              <Chip
+                className={classnames({
+                  [classes.statusChip]: true,
+                  [classes.statusRunning]: isRunning,
+                  [classes.statusOffline]: isOffline,
+                  [classes.statusOther]: isOther,
+                  statusOtherDetail: isOther
+                })}
+                label={linodeStatus.replace('_', ' ').toUpperCase()}
+                component="span"
+                {...isOther}
               />
-            </button>
-          </Grid>
+            </Grid>
+            {typeof progress !== 'undefined' &&
+            typeof transitionText !== 'undefined' ? (
+              <Grid
+                item
+                className="py0"
+                style={{ marginLeft: 24, marginBottom: 2 }}
+              >
+                <button
+                  className={classes.statusLink}
+                  onClick={openNotificationDrawer}
+                >
+                  <ProgressDisplay
+                    // className={classes.progressDisplay}
+                    progress={progress}
+                    text={transitionText.toUpperCase() ?? ''}
+                  />
+                </button>
+              </Grid>
+            ) : null}
+          </Box>
           <Grid item className={`${classes.actionItemsOuter} py0`}>
             <Hidden smDown>
               <Button

--- a/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
+++ b/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
@@ -303,8 +303,15 @@ const Header: React.FC<HeaderProps> = props => {
     lishLaunch(id);
   };
 
+  const formattedStatus = linodeStatus.replace('_', ' ').toUpperCase();
+  const formattedTransitionText = (transitionText ?? '').toUpperCase();
+
   const hasSecondaryStatus =
-    typeof progress !== 'undefined' && typeof transitionText !== 'undefined';
+    typeof progress !== 'undefined' &&
+    typeof transitionText !== 'undefined' &&
+    // Kind of a hacky way to avoid "CLONING | CLONING (50%)" until we add logic
+    // to display "Cloning to 'destination-linode'.
+    formattedTransitionText !== formattedStatus;
 
   return (
     <EntityHeader
@@ -335,7 +342,7 @@ const Header: React.FC<HeaderProps> = props => {
                   [classes.divider]: hasSecondaryStatus,
                   statusOtherDetail: isOther
                 })}
-                label={linodeStatus.replace('_', ' ').toUpperCase()}
+                label={formattedStatus}
                 component="span"
                 {...isOther}
               />
@@ -351,8 +358,8 @@ const Header: React.FC<HeaderProps> = props => {
                   onClick={openNotificationDrawer}
                 >
                   <ProgressDisplay
-                    progress={progress!}
-                    text={transitionText!.toUpperCase() ?? ''}
+                    progress={progress ?? 0}
+                    text={formattedTransitionText}
                   />
                 </button>
               </Grid>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader_CMR.tsx
@@ -255,6 +255,7 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
       <LinodeDetailsBreadcrumb />
       <LinodeEntityDetail
         variant="details"
+        id={linode.id}
         linode={linode}
         numVolumes={getVolumesByLinode(linode.id)}
         username={profile.data?.username}

--- a/packages/manager/src/features/linodes/LinodesLanding/CardView.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/CardView.tsx
@@ -142,6 +142,7 @@ const CardView: React.FC<CombinedProps> = props => {
                 <Grid item xs={12} className={`${classes.summaryOuter} py0`}>
                   <LinodeEntityDetail
                     variant="landing"
+                    id={linode.id}
                     linode={linode}
                     isDetailLanding
                     numVolumes={getVolumesByLinode(linode.id)}

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow_CMR.tsx
@@ -311,7 +311,7 @@ export const RenderFlag: React.FC<{
 
 RenderFlag.displayName = `RenderFlag`;
 
-const ProgressDisplay: React.FC<{
+export const ProgressDisplay: React.FC<{
   className?: string;
   progress: null | number;
   text: string;

--- a/packages/manager/src/features/linodes/transitions.ts
+++ b/packages/manager/src/features/linodes/transitions.ts
@@ -143,3 +143,5 @@ export const getProgressOrDefault = (
   event?: ExtendedEvent,
   defaultProgress = 100
 ) => event?.percent_complete ?? defaultProgress;
+
+export const isSecondaryStatus = (event: Event) => {};

--- a/packages/manager/src/features/linodes/transitions.ts
+++ b/packages/manager/src/features/linodes/transitions.ts
@@ -1,5 +1,6 @@
-import { Event } from '@linode/api-v4/lib/account';
+import { Event, EventAction } from '@linode/api-v4/lib/account';
 import {
+  isEventRelevantToLinode,
   isPrimaryEntity,
   isSecondaryEntity
 } from 'src/store/events/event.selectors';
@@ -144,4 +145,28 @@ export const getProgressOrDefault = (
   defaultProgress = 100
 ) => event?.percent_complete ?? defaultProgress;
 
-export const isSecondaryStatus = (event: Event) => {};
+// Linodes have a literal "status" given by the API (linode.status). There are
+// states the Linode can be in which aren't entirely communicated with the
+// status field, however. Example: Linode A can be cloning to another Linode,
+// but have an unrelated status like "running" or "offline". These states can be
+// determined by events with the following actions.
+const eventsWithSecondaryStatus: EventAction[] = [
+  'disk_duplicate',
+  'disk_resize',
+  'disk_imagize',
+  'linode_clone',
+  'linode_snapshot',
+  'linode_migrate',
+  'linode_migrate_datacenter',
+  'linode_mutate'
+];
+
+export const isEventWithSecondaryLinodeStatus = (
+  event: Event,
+  linodeId: number
+) => {
+  return (
+    isEventRelevantToLinode(event, linodeId) &&
+    eventsWithSecondaryStatus.includes(event.action)
+  );
+};


### PR DESCRIPTION
## Description

Adds support for states like "disk duplicating" and "cloning" to the Entity Detail header.
<img width="354" alt="Screen Shot 2020-12-14 at 9 41 10 AM" src="https://user-images.githubusercontent.com/16911484/102094705-a1260180-3df0-11eb-99c4-c44ac29a2d00.png">
