### PR TITLE
UI Fixes

### DIFF
--- a/packages/manager/src/components/ActionMenu_CMR/ActionMenu_CMR.tsx
+++ b/packages/manager/src/components/ActionMenu_CMR/ActionMenu_CMR.tsx
@@ -38,8 +38,7 @@ const useStyles = makeStyles((theme: Theme) => ({
       },
       '&[aria-expanded="true"]': {
         backgroundColor: '#3683dc',
-        color: '#fff',
-        width: '100%'
+        color: '#fff'
       }
     }
   },

--- a/packages/manager/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/manager/src/components/Breadcrumb/Breadcrumb.tsx
@@ -21,7 +21,10 @@ export type CombinedProps = Props;
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
     display: 'flex',
-    alignItems: 'center'
+    alignItems: 'center',
+    [theme.breakpoints.down('sm')]: {
+      marginLeft: theme.spacing()
+    }
   },
   preContainer: {
     display: 'flex',

--- a/packages/manager/src/components/CheckoutBar/styles.ts
+++ b/packages/manager/src/components/CheckoutBar/styles.ts
@@ -24,7 +24,12 @@ export const useStyles = makeStyles((theme: Theme) => ({
     opacity: 0,
     padding: `${theme.spacing(2)}px 0`,
     borderTop: `1px solid ${theme.color.border2}`,
-    animation: '$fadeIn 225ms linear forwards'
+    animation: '$fadeIn 225ms linear forwards',
+    [theme.breakpoints.down('sm')]: {
+      '& button': {
+        marginLeft: 0
+      }
+    }
   },
   noBorder: {
     border: 0

--- a/packages/manager/src/components/EntityHeader/EntityHeader.tsx
+++ b/packages/manager/src/components/EntityHeader/EntityHeader.tsx
@@ -138,7 +138,7 @@ export const EntityHeader: React.FC<HeaderProps> = props => {
             alignItems="center"
             justify="flex-end"
             wrap="nowrap"
-            // xs={12}
+            xs={12}
             sm={8}
           >
             {docsLink && (

--- a/packages/manager/src/components/EntityHeader/EntityHeader.tsx
+++ b/packages/manager/src/components/EntityHeader/EntityHeader.tsx
@@ -27,10 +27,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     alignItems: 'center',
     justifyContent: 'space-between',
     margin: 0,
-    width: '100%',
-    [theme.breakpoints.down('xs')]: {
-      marginLeft: theme.spacing()
-    }
+    width: '100%'
   },
   landing: {
     marginBottom: 0,
@@ -91,6 +88,11 @@ const useStyles = makeStyles((theme: Theme) => ({
     flexWrap: 'nowrap',
     justifyContent: 'space-between',
     padding: 0
+  },
+  actionsWrapper: {
+    [theme.breakpoints.down('sm')]: {
+      marginRight: 0
+    }
   }
 }));
 
@@ -130,12 +132,13 @@ export const EntityHeader: React.FC<HeaderProps> = props => {
             />
           </Grid>
           <Grid
+            className={classes.actionsWrapper}
             container
             item
             alignItems="center"
             justify="flex-end"
             wrap="nowrap"
-            xs={12}
+            // xs={12}
             sm={8}
           >
             {docsLink && (

--- a/packages/manager/src/components/EntityHeader/EntityHeader.tsx
+++ b/packages/manager/src/components/EntityHeader/EntityHeader.tsx
@@ -88,11 +88,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     flexWrap: 'nowrap',
     justifyContent: 'space-between',
     padding: 0
-  },
-  actionsWrapper: {
-    [theme.breakpoints.down('sm')]: {
-      marginRight: 0
-    }
   }
 }));
 
@@ -132,7 +127,6 @@ export const EntityHeader: React.FC<HeaderProps> = props => {
             />
           </Grid>
           <Grid
-            className={classes.actionsWrapper}
             container
             item
             alignItems="center"

--- a/packages/manager/src/components/EntityHeader/EntityHeader.tsx
+++ b/packages/manager/src/components/EntityHeader/EntityHeader.tsx
@@ -88,6 +88,14 @@ const useStyles = makeStyles((theme: Theme) => ({
     flexWrap: 'nowrap',
     justifyContent: 'space-between',
     padding: 0
+  },
+  actionsWrapper: {
+    [theme.breakpoints.only('sm')]: {
+      marginRight: 0
+    },
+    [theme.breakpoints.down('xs')]: {
+      paddingRight: '0px !important'
+    }
   }
 }));
 
@@ -127,6 +135,7 @@ export const EntityHeader: React.FC<HeaderProps> = props => {
             />
           </Grid>
           <Grid
+            className={classes.actionsWrapper}
             container
             item
             alignItems="center"

--- a/packages/manager/src/components/NotFound.tsx
+++ b/packages/manager/src/components/NotFound.tsx
@@ -13,7 +13,6 @@ const NotFound = (props: Props) => {
     <Placeholder
       icon={ErrorOutline}
       title="Not Found"
-      animate={false}
       className={props.className}
     />
   );

--- a/packages/manager/src/components/Placeholder/Placeholder.tsx
+++ b/packages/manager/src/components/Placeholder/Placeholder.tsx
@@ -47,9 +47,6 @@ const styles = (theme: Theme) =>
     },
     icon: {
       padding: theme.spacing(2),
-      '&.animate': {
-        animation: '$scaleIn .5s ease-in-out'
-      },
       width: '160px',
       height: '160px',
       '& .outerCircle': {
@@ -61,7 +58,6 @@ const styles = (theme: Theme) =>
       },
       '& .insidePath path': {
         opacity: 0,
-        animation: '$fadeIn .2s ease-in-out forwards .3s',
         stroke: theme.palette.primary.main
       },
       '& .bucket.insidePath path': {
@@ -99,7 +95,6 @@ export interface ExtendedButtonProps extends ButtonProps {
 
 export interface Props {
   icon?: React.ComponentType<any>;
-  animate?: boolean;
   children?: string | React.ReactNode;
   title: string;
   buttonProps?: ExtendedButtonProps[];
@@ -112,7 +107,6 @@ type CombinedProps = Props & WithStyles<ClassNames>;
 
 const Placeholder: React.FC<CombinedProps> = props => {
   const {
-    animate,
     classes,
     isEntity,
     title,
@@ -130,9 +124,7 @@ const Placeholder: React.FC<CombinedProps> = props => {
       className={`${classes.root} ${props.className}`}
     >
       <Grid item xs={12} className={isEntity ? classes.entity : ''}>
-        {Icon && (
-          <Icon className={`${classes.icon} ${animate && 'animate'} `} />
-        )}
+        {Icon && <Icon className={`${classes.icon}`} />}
       </Grid>
       <Grid item xs={12}>
         <H1Header
@@ -175,8 +167,7 @@ const Placeholder: React.FC<CombinedProps> = props => {
 };
 
 Placeholder.defaultProps = {
-  icon: LinodeIcon,
-  animate: true
+  icon: LinodeIcon
 };
 
 const styled = withStyles(styles);

--- a/packages/manager/src/components/Placeholder/Placeholder.tsx
+++ b/packages/manager/src/components/Placeholder/Placeholder.tsx
@@ -124,7 +124,7 @@ const Placeholder: React.FC<CombinedProps> = props => {
       className={`${classes.root} ${props.className}`}
     >
       <Grid item xs={12} className={isEntity ? classes.entity : ''}>
-        {Icon && <Icon className={`${classes.icon}`} />}
+        {Icon && <Icon className={classes.icon} />}
       </Grid>
       <Grid item xs={12}>
         <H1Header

--- a/packages/manager/src/features/Domains/DomainDetail/DomainDetail.tsx
+++ b/packages/manager/src/features/Domains/DomainDetail/DomainDetail.tsx
@@ -128,7 +128,7 @@ const DomainDetail: React.FC<CombinedProps> = props => {
             labelOptions={{ noCap: true }}
           />
         </Grid>
-        <Grid item className={`${classes.cta} px0`}>
+        <Grid item className={`${classes.cta}`}>
           <Button
             buttonType="secondary"
             className={classes.tagsButton}

--- a/packages/manager/src/features/Domains/DomainDetail/DomainDetail.tsx
+++ b/packages/manager/src/features/Domains/DomainDetail/DomainDetail.tsx
@@ -128,7 +128,7 @@ const DomainDetail: React.FC<CombinedProps> = props => {
             labelOptions={{ noCap: true }}
           />
         </Grid>
-        <Grid item className={`${classes.cta}`}>
+        <Grid item className={`${classes.cta} px0`}>
           <Button
             buttonType="secondary"
             className={classes.tagsButton}

--- a/packages/manager/src/features/StackScripts/SelectStackScriptPanel/StackScriptSelectionRow.tsx
+++ b/packages/manager/src/features/StackScripts/SelectStackScriptPanel/StackScriptSelectionRow.tsx
@@ -86,6 +86,7 @@ export class StackScriptSelectionRow extends React.Component<
           <Grid item>
             <Button
               compact
+              buttonType="secondary"
               className={classes.detailsButton}
               onClick={openDrawer}
             >

--- a/packages/manager/src/features/Volumes/VolumeTableRow_CMR.tsx
+++ b/packages/manager/src/features/Volumes/VolumeTableRow_CMR.tsx
@@ -122,33 +122,35 @@ export const VolumeTableRow: React.FC<CombinedProps> = props => {
           )}
         </TableCell>
       )}
-      <TableCell className={classes.actionCell}>
-        <VolumesActionMenu
-          onShowConfig={openForConfig}
-          filesystemPath={filesystemPath}
-          linodeLabel={linodeLabel || ''}
-          regionID={region}
-          volumeId={id}
-          volumeTags={tags}
-          size={size}
-          label={label}
-          onEdit={openForEdit}
-          onResize={openForResize}
-          onClone={openForClone}
-          volumeLabel={label}
-          /**
-           * This is a safer check than linode_id (see logic in addAttachedLinodeInfoToVolume() from VolumesLanding)
-           * as it actually checks to see if the Linode exists before adding linodeLabel and linodeStatus.
-           * This avoids a bug (M3-2534) where a Volume attached to a just-deleted Linode
-           * could sometimes get tagged as "attached" here.
-           */
-          attached={Boolean(linodeLabel)}
-          isVolumesLanding={isVolumesLanding} // Passing this down to govern logic re: showing Attach or Detach in action menu.
-          onAttach={handleAttach}
-          onDetach={handleDetach}
-          poweredOff={linodeStatus === 'offline'}
-          onDelete={handleDelete}
-        />
+      <TableCell>
+        <div className={classes.actionCell}>
+          <VolumesActionMenu
+            onShowConfig={openForConfig}
+            filesystemPath={filesystemPath}
+            linodeLabel={linodeLabel || ''}
+            regionID={region}
+            volumeId={id}
+            volumeTags={tags}
+            size={size}
+            label={label}
+            onEdit={openForEdit}
+            onResize={openForResize}
+            onClone={openForClone}
+            volumeLabel={label}
+            /**
+             * This is a safer check than linode_id (see logic in addAttachedLinodeInfoToVolume() from VolumesLanding)
+             * as it actually checks to see if the Linode exists before adding linodeLabel and linodeStatus.
+             * This avoids a bug (M3-2534) where a Volume attached to a just-deleted Linode
+             * could sometimes get tagged as "attached" here.
+             */
+            attached={Boolean(linodeLabel)}
+            isVolumesLanding={isVolumesLanding} // Passing this down to govern logic re: showing Attach or Detach in action menu.
+            onAttach={handleAttach}
+            onDetach={handleDetach}
+            poweredOff={linodeStatus === 'offline'}
+            onDelete={handleDelete}
+          />
+        </div>
       </TableCell>
     </TableRow>
   );

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -7,6 +7,7 @@ import Grid from 'src/components/Grid';
 import ImageSelect from 'src/components/ImageSelect';
 import Placeholder from 'src/components/Placeholder';
 import { filterImagesByType } from 'src/store/image/image.helpers';
+import ImageIcon from 'src/assets/icons/entityIcons/image.svg';
 import {
   BasicFromContentProps,
   ReduxStateProps,
@@ -49,7 +50,7 @@ export const FromImageContent: React.FC<CombinedProps> = props => {
     return (
       <Grid item className={`${classes.main} mlMain py0`}>
         <Paper>
-          <Placeholder title="My Images" renderAsSecondary>
+          <Placeholder title="My Images" icon={ImageIcon} isEntity>
             <Typography variant="subtitle1">
               You don&#39;t have any private Images. Visit the{' '}
               <Link to="/images">Images section</Link> to create an Image from

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs.tsx
@@ -54,7 +54,8 @@ const styles = (theme: Theme) =>
         width: '100%',
         marginLeft: -(theme.spacing(1) + theme.spacing(1) / 2),
         marginTop: -theme.spacing(1)
-      }
+      },
+      paddingRight: 5
     }
   });
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs_CMR.tsx
@@ -87,7 +87,8 @@ const styles = (theme: Theme) =>
       [theme.breakpoints.down('xs')]: {
         marginLeft: -(theme.spacing(1) + theme.spacing(1) / 2),
         marginTop: -theme.spacing(1)
-      }
+      },
+      paddingRight: '5px !important'
     },
     labelCell: {
       width: '25%'

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs_CMR.tsx
@@ -79,8 +79,9 @@ const styles = (theme: Theme) =>
       width: '100%'
     },
     headline: {
-      marginBottom: 3,
-      marginLeft: 8,
+      marginTop: 8,
+      marginBottom: 8,
+      marginLeft: 15,
       lineHeight: '1.5rem'
     },
     addNewWrapper: {
@@ -88,7 +89,7 @@ const styles = (theme: Theme) =>
         marginLeft: -(theme.spacing(1) + theme.spacing(1) / 2),
         marginTop: -theme.spacing(1)
       },
-      paddingRight: '5px !important'
+      padding: '5px !important'
     },
     labelCell: {
       width: '25%'
@@ -261,7 +262,7 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
           className={classes.root}
         >
           <RootRef rootRef={this.configsPanel}>
-            <Grid item>
+            <Grid item className="p0">
               <Typography variant="h3" className={classes.headline}>
                 Configurations
               </Typography>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailsBreadcrumb.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailsBreadcrumb.tsx
@@ -22,10 +22,15 @@ import withEditableLabelState, {
   EditableLabelProps
 } from './editableLabelState';
 
-type ClassNames = 'breadcrumb' | 'controls' | 'launchButton' | 'docs';
+type ClassNames = 'root' | 'breadcrumb' | 'controls' | 'launchButton' | 'docs';
 
 const styles = (theme: Theme) =>
   createStyles({
+    root: {
+      [theme.breakpoints.down('sm')]: {
+        paddingRight: `${theme.spacing()}px !important`
+      }
+    },
     controls: {
       position: 'relative',
       marginTop: 9 - theme.spacing(1) / 2, // 4
@@ -107,8 +112,8 @@ const LinodeControls: React.FC<CombinedProps> = props => {
   };
   return (
     <Grid
+      className={`${classes.root} m0`}
       container
-      className="m0"
       alignItems="center"
       justify="space-between"
       data-qa-linode={linode.label}

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu_CMR.tsx
@@ -43,7 +43,6 @@ const useStyles = makeStyles(() => ({
   },
   powerOnOrOff: {
     borderRadius: 0,
-    height: '100%',
     minWidth: 'auto',
     whiteSpace: 'nowrap',
     '&:hover': {


### PR DESCRIPTION
## Description

- VolumeTable wonkiness around 700px
![Screen Shot 2020-12-14 at 5 13 57 PM](https://user-images.githubusercontent.com/16911484/102146586-3f3cba80-3e37-11eb-87b3-b035cf5ae111.png)

- Safari: table row alignment issue
![Screen Shot 2020-12-14 at 4 12 17 PM](https://user-images.githubusercontent.com/16911484/102146628-524f8a80-3e37-11eb-9afe-c527023b9d21.png)
- Safari: row moves 1px when the action menu is clicked
- "Add a Config" button: make right padding consistent with similar buttons on the storage tab.
- Add left margin to Breadcrumb (globally) at <= sm viewports
- Update lingering Image icon at Create Linode > Images (when you have no images)

<img width="861" alt="Screen Shot 2020-12-15 at 8 36 25 AM" src="https://user-images.githubusercontent.com/16911484/102221984-d560f700-3eb0-11eb-8a8f-6270739b03d5.png">


- Remove placeholder icon animation as discussed during the demo.