### PR TITLE
Restore Details button for Buckets

### DIFF
--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketActionMenu_CMR.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketActionMenu_CMR.tsx
@@ -16,7 +16,7 @@ export const BucketActionMenu: React.FC<Props> = props => {
       {
         title: 'Details',
         onClick: () => {
-          props.onRemove();
+          props.onDetails();
         }
       },
       {
@@ -34,7 +34,7 @@ export const BucketActionMenu: React.FC<Props> = props => {
         <InlineMenuAction
           actionText="Details"
           onClick={() => {
-            props.onRemove();
+            props.onDetails();
           }}
         />
         <InlineMenuAction

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketActionMenu_CMR.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketActionMenu_CMR.tsx
@@ -14,6 +14,12 @@ export const BucketActionMenu: React.FC<Props> = props => {
   const createActions = () => (): Action[] => {
     return [
       {
+        title: 'Details',
+        onClick: () => {
+          props.onRemove();
+        }
+      },
+      {
         title: 'Delete',
         onClick: () => {
           props.onRemove();
@@ -25,6 +31,12 @@ export const BucketActionMenu: React.FC<Props> = props => {
   return (
     <>
       <Hidden smDown>
+        <InlineMenuAction
+          actionText="Details"
+          onClick={() => {
+            props.onRemove();
+          }}
+        />
         <InlineMenuAction
           actionText="Delete"
           onClick={() => {


### PR DESCRIPTION
## Description

When we removed the Details button from all TableRows, we didn't consider the fact that the only way to open the Bucket Details drawer is to use this button (clicking the title takes you to the object listing page).

Obviously the pattern isn't ideal and the Bucket Detail page should have an Entity Header, but this will have to do for now.
