### PR TITLE
Use link styles (previously destructive button) in 2FA form

### DIFF
--- a/packages/manager/src/features/Profile/AuthenticationSettings/TwoFactor/TwoFactor.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/TwoFactor/TwoFactor.tsx
@@ -227,25 +227,17 @@ export const TwoFactor: React.FC<CombinedProps> = props => {
                 )}
                 {twoFactorEnabled && (
                   <div className={classes.container}>
-                    {showQRCode ? (
-                      <button
-                        className={classes.button}
-                        onClick={toggleHidden}
-                        data-qa-hide-show-code
-                      >
-                        Hide QR Code
-                      </button>
-                    ) : (
-                      <button
-                        className={classes.button}
-                        onClick={toggleHidden}
-                        data-qa-hide-show-code
-                      >
-                        {twoFactorConfirmed
-                          ? 'Reset two-factor authentication'
-                          : 'Show QR Code'}
-                      </button>
-                    )}
+                    <button
+                      className={classes.button}
+                      onClick={toggleHidden}
+                      data-qa-hide-show-code
+                    >
+                      {showQRCode
+                        ? 'Hide QR Code'
+                        : twoFactorConfirmed
+                        ? 'Reset two-factor authentication'
+                        : 'Show QR Code'}
+                    </button>
                   </div>
                 )}
                 {twoFactorEnabled &&

--- a/packages/manager/src/features/Profile/AuthenticationSettings/TwoFactor/TwoFactor.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/TwoFactor/TwoFactor.tsx
@@ -1,11 +1,9 @@
-import SettingsBackupRestore from '@material-ui/icons/SettingsBackupRestore';
 import { getTFAToken, Profile } from '@linode/api-v4/lib/profile';
 import { APIError } from '@linode/api-v4/lib/types';
 import { path } from 'ramda';
 import * as React from 'react';
 import { connect, MapDispatchToProps } from 'react-redux';
 import { compose } from 'recompose';
-import Button from 'src/components/Button';
 import FormControl from 'src/components/core/FormControl';
 import FormControlLabel from 'src/components/core/FormControlLabel';
 import Paper from 'src/components/core/Paper';
@@ -47,10 +45,8 @@ const useStyles = makeStyles((theme: Theme) => ({
     padding: 0,
     border: 0
   },
-  showHideText: {
-    fontSize: '1rem',
-    marginLeft: theme.spacing(2),
-    color: theme.palette.text.primary
+  button: {
+    ...theme.applyLinkStyles
   },
   disabled: {
     '& *': {
@@ -232,32 +228,23 @@ export const TwoFactor: React.FC<CombinedProps> = props => {
                 {twoFactorEnabled && (
                   <div className={classes.container}>
                     {showQRCode ? (
-                      <Button
-                        buttonType="primary"
-                        className={classes.visibility}
+                      <button
+                        className={classes.button}
                         onClick={toggleHidden}
-                        destructive
                         data-qa-hide-show-code
                       >
-                        <SettingsBackupRestore />
-                        <span className={classes.showHideText}>
-                          Hide QR Code
-                        </span>
-                      </Button>
+                        Hide QR Code
+                      </button>
                     ) : (
-                      <Button
-                        buttonType="secondary"
-                        className={classes.visibility}
+                      <button
+                        className={classes.button}
                         onClick={toggleHidden}
                         data-qa-hide-show-code
                       >
-                        <SettingsBackupRestore />
-                        <span className={classes.showHideText}>
-                          {twoFactorConfirmed
-                            ? 'Reset two-factor authentication'
-                            : 'Show QR Code'}
-                        </span>
-                      </Button>
+                        {twoFactorConfirmed
+                          ? 'Reset two-factor authentication'
+                          : 'Show QR Code'}
+                      </button>
                     )}
                   </div>
                 )}


### PR DESCRIPTION
## Description

The button refactor from a few weeks back caused a visual regression in the 2FA form (reach out for a link to the Trello item).

To test:

1. Go to profile/authentication
2. Toggle 2FA
3. The QR code will pop up with (hopefully) a properly styled link above it to toggle showing/hiding the code.