### PR TITLE
Change create menu entity name color and fix focus state for top nav

### DIFF
--- a/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu_CMR.tsx
+++ b/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu_CMR.tsx
@@ -99,7 +99,15 @@ const styles = (theme: Theme) =>
       '&[data-reach-menu-item]': {
         padding: 0,
         cursor: 'pointer',
-        textDecoration: 'none'
+        textDecoration: 'none',
+        '& h3': {
+          color: theme.cmrTextColors.linkActiveLight
+        },
+        '&:hover': {
+          '& h3': {
+            textDecoration: 'underline'
+          }
+        }
       },
       '&[data-reach-menu-item][data-selected]': {
         background: theme.bg.main,

--- a/packages/manager/src/features/TopMenu/TopMenu_CMR.tsx
+++ b/packages/manager/src/features/TopMenu/TopMenu_CMR.tsx
@@ -27,15 +27,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   toolbar: {
     padding: 0,
     height: `50px !important`,
-    width: '100%',
-    [theme.breakpoints.down('lg')]: {
-      paddingLeft: theme.spacing(1),
-      paddingRight: theme.spacing(1)
-    },
-    [theme.breakpoints.up('lg')]: {
-      paddingLeft: 0,
-      paddingRight: 0
-    }
+    width: '100%'
   }
 }));
 

--- a/packages/manager/src/features/TopMenu/UserMenu/UserMenu_CMR.tsx
+++ b/packages/manager/src/features/TopMenu/UserMenu/UserMenu_CMR.tsx
@@ -95,7 +95,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     display: 'flex',
     alignItems: 'center',
     lineHeight: 1,
-    marginLeft: theme.spacing(2),
+    paddingLeft: 12,
     '&[data-reach-menu-button]': {
       backgroundColor: 'transparent',
       border: 'none',

--- a/packages/manager/src/features/TopMenu/iconStyles.ts
+++ b/packages/manager/src/features/TopMenu/iconStyles.ts
@@ -2,16 +2,21 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 
 export const useStyles = makeStyles((theme: Theme) => ({
   icon: {
-    cursor: 'pointer',
-    position: 'relative',
-    padding: theme.spacing(),
-    marginLeft: theme.spacing(),
-    marginTop: 4,
-    color: '#c9c7c7',
-    border: 'none',
+    display: 'flex',
+    alignItems: 'center',
     backgroundColor: 'inherit',
+    border: 'none',
+    color: '#c9c7c7',
+    cursor: 'pointer',
+    height: '100%',
+    outlineOffset: 'initial',
+    padding: '8px 12px',
+    position: 'relative',
     '&:hover, &:focus': {
       color: '#c1c1c0'
+    },
+    '&:first-of-type': {
+      marginLeft: theme.spacing()
     },
     '& svg': {
       width: 20,


### PR DESCRIPTION
## Description
Make entity name in the create menu blue and add underline on hover

Fix focus states for the top nav: 
**Before:**
<img width="498" alt="Screen Shot 2020-12-15 at 3 21 01 PM" src="https://user-images.githubusercontent.com/7692354/102269541-c8f99000-3eea-11eb-943a-a7d5969bc3f6.png">
**After:**
<img width="469" alt="Screen Shot 2020-12-15 at 3 21 33 PM" src="https://user-images.githubusercontent.com/7692354/102269555-cc8d1700-3eea-11eb-8302-58545c74930a.png">
