### PR TITLE
Fix: Unable to update label of OBJ limited access key

### DIFF
--- a/packages/api-v4/src/object-storage/objectStorageKeys.ts
+++ b/packages/api-v4/src/object-storage/objectStorageKeys.ts
@@ -8,7 +8,11 @@ import Request, {
 } from '../request';
 import { ResourcePage as Page } from '../types';
 import { createObjectStorageKeysSchema } from './objectStorageKeys.schema';
-import { ObjectStorageKey, ObjectStorageKeyRequest } from './types';
+import {
+  ObjectStorageKey,
+  ObjectStorageKeyRequest,
+  UpdateObjectStorageKeyRequest
+} from './types';
 
 /**
  * getObjectStorageKeys
@@ -42,7 +46,7 @@ export const createObjectStorageKeys = (data: ObjectStorageKeyRequest) =>
  */
 export const updateObjectStorageKey = (
   id: number,
-  data: ObjectStorageKeyRequest
+  data: UpdateObjectStorageKeyRequest
 ) =>
   Request<ObjectStorageKey>(
     setMethod('PUT'),

--- a/packages/api-v4/src/object-storage/types.ts
+++ b/packages/api-v4/src/object-storage/types.ts
@@ -19,6 +19,10 @@ export interface ObjectStorageKeyRequest {
   bucket_access: Scope[] | null;
 }
 
+export interface UpdateObjectStorageKeyRequest {
+  label: string;
+}
+
 export interface ObjectStorageBucketRequestPayload {
   label: string;
   cluster: string;

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyLanding.tsx
@@ -194,7 +194,7 @@ export const AccessKeyLanding: React.FC<CombinedProps> = props => {
 
     setSubmitting(true);
 
-    updateObjectStorageKey(keyToEdit.id, values)
+    updateObjectStorageKey(keyToEdit.id, { label: values.label })
       .then(_ => {
         setSubmitting(false);
 


### PR DESCRIPTION
## Description

This bug exists in production, too. You can only edit the label of OBJ access keys if the key is not limited access.

## Note to Reviewers

Please try the edit label action for both restricted and unrestricted keys.