### PR TITLE
Fix color scheme for Dark Mode toggle button's enabled state

### DIFF
--- a/packages/manager/src/features/Profile/Settings/Settings.tsx
+++ b/packages/manager/src/features/Profile/Settings/Settings.tsx
@@ -23,7 +23,7 @@ import { updateProfile as handleUpdateProfile } from 'src/store/profile/profile.
 import { MapState } from 'src/store/types';
 import { getQueryParam } from 'src/utilities/queryParams';
 import PreferenceEditor from './PreferenceEditor';
-import ThemeToggle_CMR from './ThemeToggle_CMR';
+import ThemeToggle from './ThemeToggle';
 
 type ClassNames = 'root' | 'title' | 'label';
 
@@ -109,7 +109,7 @@ class ProfileSettings extends React.Component<CombinedProps, State> {
             <Grid container alignItems="center">
               <Grid item xs={12}>
                 <FormControlLabel
-                  control={<ThemeToggle_CMR toggleTheme={toggleTheme} />}
+                  control={<ThemeToggle toggleTheme={toggleTheme} />}
                   label={`
                 Dark mode is ${
                   this.props.theme.name === 'darkTheme' ? 'enabled' : 'disabled'

--- a/packages/manager/src/features/Profile/Settings/ThemeToggle.tsx
+++ b/packages/manager/src/features/Profile/Settings/ThemeToggle.tsx
@@ -2,27 +2,12 @@ import * as classNames from 'classnames';
 import * as React from 'react';
 import {
   createStyles,
-  Theme,
   withStyles,
-  WithStyles,
   WithTheme
 } from 'src/components/core/styles';
 import Toggle from 'src/components/Toggle';
 
-type ClassNames = 'switchWrapper' | 'switchText' | 'toggle';
-
-export const styles = (theme: Theme) =>
-  createStyles({
-    switchText: {
-      color: '#777',
-      fontSize: '.8rem',
-      transition: theme.transitions.create(['color']),
-      '&.active': {
-        transition: theme.transitions.create(['color']),
-        color: '#C9CACB'
-      }
-    }
-  });
+export const styles = () => createStyles({});
 
 interface Props {
   toggleTheme: () => void;
@@ -32,11 +17,11 @@ const onClickHandler = () => {
   document.body.classList.add('no-transition');
 };
 
-type CombinedProps = Props & WithStyles<ClassNames> & WithTheme;
+type CombinedProps = Props & WithTheme;
 
 export class ThemeToggle extends React.Component<CombinedProps> {
   render() {
-    const { classes, toggleTheme, theme } = this.props;
+    const { toggleTheme, theme } = this.props;
     const { name: themeName } = theme;
 
     const toggle = () => {
@@ -45,7 +30,7 @@ export class ThemeToggle extends React.Component<CombinedProps> {
     };
 
     return (
-      <div className={classes.switchWrapper}>
+      <div>
         <Toggle
           onChange={toggle}
           checked={themeName !== 'lightTheme'}

--- a/packages/manager/src/features/Profile/Settings/ThemeToggle_CMR.tsx
+++ b/packages/manager/src/features/Profile/Settings/ThemeToggle_CMR.tsx
@@ -21,15 +21,6 @@ export const styles = (theme: Theme) =>
         transition: theme.transitions.create(['color']),
         color: '#C9CACB'
       }
-    },
-    toggle: {
-      '& > span:last-child': {
-        backgroundColor: '#f4f4f4 !important' as '#f4f4f4',
-        opacity: '0.38 !important' as any
-      },
-      '&.darkTheme .square': {
-        fill: '#444 !important'
-      }
     }
   });
 
@@ -59,7 +50,6 @@ export class ThemeToggle extends React.Component<CombinedProps> {
           onChange={toggle}
           checked={themeName !== 'lightTheme'}
           className={classNames({
-            [classes.toggle]: true,
             [themeName]: true
           })}
           aria-label="Switch Theme"


### PR DESCRIPTION
## Description
The enabled state of the Dark Mode toggle looks like this currently:

<img width="395" alt="Screen_Shot_2020-12-08_at_1 28 54_PM" src="https://user-images.githubusercontent.com/32860776/102523942-48f83500-4066-11eb-8ee1-e15dba86a508.png">

This PR makes it match the look of the Notifications toggle when enabled (blue and white).

## Type of Change
- Bug fix ('fix', 'repair', 'bug')
