### PR TITLE
Turn Longview "View Details" ButtonLink into a regular button with link styling

### DIFF
--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientHeader.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientHeader.tsx
@@ -32,13 +32,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     }
   },
   link: {
-    ...theme.applyLinkStyles,
-    '& .buttonSpan': {
-      padding: `${theme.spacing(1)}px ${theme.spacing(2)}px`
-    },
-    [theme.breakpoints.down('md')]: {
-      top: -4
-    }
+    ...theme.applyLinkStyles
   },
   packageButton: {
     fontSize: '0.875rem',

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientHeader.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientHeader.tsx
@@ -31,9 +31,6 @@ const useStyles = makeStyles((theme: Theme) => ({
       marginRight: theme.spacing(2)
     }
   },
-  link: {
-    ...theme.applyLinkStyles
-  },
   packageButton: {
     fontSize: '0.875rem',
     padding: 0,
@@ -162,9 +159,7 @@ export const LongviewClientHeader: React.FC<CombinedProps> = props => {
         )}
       </Grid>
       <Grid item>
-        <button className={classes.link}>
-          <Link to={`/longview/clients/${clientID}`}>View Details</Link>
-        </button>
+        <Link to={`/longview/clients/${clientID}`}>View Details</Link>
         {!loading && (
           <div className={classes.lastUpdatedOuter}>
             <Typography variant="caption" className={classes.lastUpdatedText}>

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientHeader.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientHeader.tsx
@@ -3,11 +3,11 @@ import { pathOr } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
 import Button from 'src/components/Button';
-import ButtonLink from 'src/components/Button/ButtonLink';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import EditableEntityLabel from 'src/components/EditableEntityLabel';
 import Grid from 'src/components/Grid';
+import Link from 'src/components/Link';
 import { DispatchProps } from 'src/containers/longview.container';
 import withClientStats, {
   Props as LVDataProps
@@ -32,6 +32,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     }
   },
   link: {
+    ...theme.applyLinkStyles,
     '& .buttonSpan': {
       padding: `${theme.spacing(1)}px ${theme.spacing(2)}px`
     },
@@ -47,11 +48,6 @@ const useStyles = makeStyles((theme: Theme) => ({
       textDecoration: 'underline',
       color: 'inherit',
       backgroundColor: 'inherit'
-    }
-  },
-  detailsContainer: {
-    '& > a': {
-      textDecoration: 'none !important'
     }
   },
   lastUpdatedOuter: {
@@ -171,12 +167,10 @@ export const LongviewClientHeader: React.FC<CombinedProps> = props => {
           </>
         )}
       </Grid>
-      <Grid item className={classes.detailsContainer}>
-        <ButtonLink
-          to={`/longview/clients/${clientID}`}
-          linkText="View details"
-          className={classes.link}
-        />
+      <Grid item>
+        <button className={classes.link}>
+          <Link to={`/longview/clients/${clientID}`}>View Details</Link>
+        </button>
         {!loading && (
           <div className={classes.lastUpdatedOuter}>
             <Typography variant="caption" className={classes.lastUpdatedText}>


### PR DESCRIPTION
## Description
Following up on https://github.com/linode/manager/pull/7233#discussion_r543717446 and Matthew's confirmation, this PR changes the "View Details" `ButtonLink` for a Longview client on the Longview landing page to a regular button with link styling.

## Type of Change
- Non breaking change ('update', 'change')
