### PR TITLE
M3-4756 Object List not showing more than 100 objects

### DIFF
--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -32,7 +32,6 @@ import { OBJECT_STORAGE_DELIMITER as delimiter } from 'src/constants';
 import bucketRequestsContainer, {
   BucketsRequests
 } from 'src/containers/bucketRequests.container';
-import { FeatureFlagConsumerProps } from 'src/containers/withFeatureFlagConsumer.container.ts';
 import { sendDownloadObjectEvent } from 'src/utilities/ga';
 import { getQueryParam } from 'src/utilities/queryParams';
 import { truncateMiddle } from 'src/utilities/truncate';
@@ -107,8 +106,7 @@ interface MatchProps {
 type CombinedProps = RouteComponentProps<MatchProps> &
   WithStyles<ClassNames> &
   WithSnackbarProps &
-  BucketsRequests &
-  FeatureFlagConsumerProps;
+  BucketsRequests;
 
 interface State {
   data: ExtendedObject[];

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -16,7 +16,6 @@ import Button from 'src/components/Button';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
 import Grid from 'src/components/core/Grid';
 import Hidden from 'src/components/core/Hidden';
-import Paper from 'src/components/core/Paper';
 import {
   createStyles,
   Theme,
@@ -26,19 +25,14 @@ import {
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
 import Typography from 'src/components/core/Typography';
-import Table from 'src/components/Table';
 import Table_CMR from 'src/components/Table/Table_CMR';
-import TableCell from 'src/components/TableCell';
 import TableCell_CMR from 'src/components/TableCell/TableCell_CMR';
-import TableRow from 'src/components/TableRow';
 import TableRow_CMR from 'src/components/TableRow/TableRow_CMR';
 import { OBJECT_STORAGE_DELIMITER as delimiter } from 'src/constants';
 import bucketRequestsContainer, {
   BucketsRequests
 } from 'src/containers/bucketRequests.container';
-import withFeatureFlags, {
-  FeatureFlagConsumerProps
-} from 'src/containers/withFeatureFlagConsumer.container.ts';
+import { FeatureFlagConsumerProps } from 'src/containers/withFeatureFlagConsumer.container.ts';
 import { sendDownloadObjectEvent } from 'src/utilities/ga';
 import { getQueryParam } from 'src/utilities/queryParams';
 import { truncateMiddle } from 'src/utilities/truncate';
@@ -411,7 +405,7 @@ export class BucketDetail extends React.Component<CombinedProps, State> {
   };
 
   render() {
-    const { classes, flags } = this.props;
+    const { classes } = this.props;
     const {
       data,
       loading,
@@ -451,83 +445,48 @@ export class BucketDetail extends React.Component<CombinedProps, State> {
           </Grid>
           <Grid item xs={12} lg={8} className={classes.tableContainer}>
             <>
-              {flags.cmr ? (
-                <div className={classes.objectTable}>
-                  <Table_CMR aria-label="List of Bucket Objects">
-                    <TableHead>
-                      <TableRow_CMR>
-                        <TableCell_CMR className={classes.nameColumn}>
-                          Object
-                        </TableCell_CMR>
-                        <TableCell_CMR className={classes.sizeColumn}>
-                          Size
-                        </TableCell_CMR>
-                        <Hidden smDown>
-                          <TableCell_CMR>Last Modified</TableCell_CMR>
-                        </Hidden>
-                        {/* Empty TableCell for Action Menu */}
-                        <TableCell_CMR />
-                      </TableRow_CMR>
-                    </TableHead>
-                    <TableBody>
-                      <ObjectTableContent
-                        data={data}
-                        loading={loading}
-                        error={generalError}
-                        prefix={prefix}
-                        handleClickDownload={this.handleDownload}
-                        handleClickDelete={this.handleClickDelete}
-                        handleClickDetails={this.handleClickDetails}
-                      />
-                    </TableBody>
-                  </Table_CMR>
-                </div>
-              ) : (
-                <Paper className={classes.objectTable}>
-                  <Table
-                    removeLabelonMobile
-                    aria-label="List of Bucket Objects"
-                    isResponsive={false}
-                  >
-                    <TableHead>
-                      <TableRow>
-                        <TableCell className={classes.nameColumn}>
-                          Object
-                        </TableCell>
-                        <TableCell className={classes.sizeColumn}>
-                          Size
-                        </TableCell>
-                        <TableCell>Last Modified</TableCell>
-                        {/* Empty TableCell for Action Menu */}
-                        <TableCell />
-                      </TableRow>
-                    </TableHead>
-                    <TableBody>
-                      <ObjectTableContent
-                        data={data}
-                        loading={loading}
-                        error={generalError}
-                        prefix={prefix}
-                        handleClickDownload={this.handleDownload}
-                        handleClickDelete={this.handleClickDelete}
-                        handleClickDetails={this.handleClickDetails}
-                      />
-                    </TableBody>
-                  </Table>
-                  {/* We shouldn't allow infinite scrolling if we're still loading,
+              <div className={classes.objectTable}>
+                <Table_CMR aria-label="List of Bucket Objects">
+                  <TableHead>
+                    <TableRow_CMR>
+                      <TableCell_CMR className={classes.nameColumn}>
+                        Object
+                      </TableCell_CMR>
+                      <TableCell_CMR className={classes.sizeColumn}>
+                        Size
+                      </TableCell_CMR>
+                      <Hidden smDown>
+                        <TableCell_CMR>Last Modified</TableCell_CMR>
+                      </Hidden>
+                      {/* Empty TableCell for Action Menu */}
+                      <TableCell_CMR />
+                    </TableRow_CMR>
+                  </TableHead>
+                  <TableBody>
+                    <ObjectTableContent
+                      data={data}
+                      loading={loading}
+                      error={generalError}
+                      prefix={prefix}
+                      handleClickDownload={this.handleDownload}
+                      handleClickDelete={this.handleClickDelete}
+                      handleClickDetails={this.handleClickDetails}
+                    />
+                  </TableBody>
+                </Table_CMR>
+                {/* We shouldn't allow infinite scrolling if we're still loading,
                 if we've gotten all objects in the bucket (or folder), or if there
                 are errors. */}
-                  {!loading &&
-                    !allObjectsFetched &&
-                    !generalError &&
-                    !nextPageError &&
-                    data.length >= 100 && (
-                      <Waypoint onEnter={this.getNextPage}>
-                        <div />
-                      </Waypoint>
-                    )}
-                </Paper>
-              )}
+                {!loading &&
+                  !allObjectsFetched &&
+                  !generalError &&
+                  !nextPageError &&
+                  data.length >= 100 && (
+                    <Waypoint onEnter={this.getNextPage}>
+                      <div />
+                    </Waypoint>
+                  )}
+              </div>
               {nextPageError && (
                 <Typography variant="subtitle2" className={classes.footer}>
                   The next objects in the list failed to load.{' '}
@@ -606,8 +565,7 @@ const styled = withStyles(styles);
 const enhanced = compose<CombinedProps, RouteComponentProps<MatchProps>>(
   styled,
   withSnackbar,
-  bucketRequestsContainer,
-  withFeatureFlags
+  bucketRequestsContainer
 );
 
 export default enhanced(BucketDetail);


### PR DESCRIPTION
## Description

The`<Waypoint />` component on Bucket Details got lost in translation with CMR, so we're only showing the first 100 objects of a Bucket. This fixes that and gets rid of the conditional CMR rendering.

For testing: production tests account 9 has a Bucket with many objects.