### PR TITLE
Change: Refactor Domain creation and disable submission until required fields are present

### DIFF
--- a/packages/api-v4/src/domains/domains.schema.ts
+++ b/packages/api-v4/src/domains/domains.schema.ts
@@ -43,13 +43,15 @@ export const createDomainSchema = domainSchemaBase.shape({
       otherwise: string()
     })
     .email('SOA Email is not valid.'),
-  master_ips: array().when('type', {
-    is: type => type === 'slave',
-    then: array()
-      .of(string())
-      .required('At least one primary IP address is required.'),
-    otherwise: array().of(string())
-  })
+  master_ips: array()
+    .of(string())
+    .when('type', {
+      is: type => type === 'slave',
+      then: array()
+        .of(string())
+        .required('At least one primary IP address is required.'),
+      otherwise: array().of(string())
+    })
 });
 
 export const updateDomainSchema = domainSchemaBase.shape({

--- a/packages/api-v4/src/domains/domains.schema.ts
+++ b/packages/api-v4/src/domains/domains.schema.ts
@@ -42,7 +42,14 @@ export const createDomainSchema = domainSchemaBase.shape({
       then: string().required('SOA Email is required.'),
       otherwise: string()
     })
-    .email('SOA Email is not valid.')
+    .email('SOA Email is not valid.'),
+  master_ips: array().when('type', {
+    is: type => type === 'slave',
+    then: array()
+      .of(string())
+      .required('At least one primary IP address is required.'),
+    otherwise: array().of(string())
+  })
 });
 
 export const updateDomainSchema = domainSchemaBase.shape({

--- a/packages/api-v4/src/domains/domains.schema.ts
+++ b/packages/api-v4/src/domains/domains.schema.ts
@@ -49,7 +49,10 @@ export const createDomainSchema = domainSchemaBase.shape({
       is: type => type === 'slave',
       then: array()
         .of(string())
-        .required('At least one primary IP address is required.'),
+        .compact()
+        .ensure()
+        .required('At least one primary IP address is required.')
+        .min(1, 'At least one primary IP address is required.'),
       otherwise: array().of(string())
     })
 });

--- a/packages/api-v4/src/domains/domains.ts
+++ b/packages/api-v4/src/domains/domains.ts
@@ -13,7 +13,7 @@ import {
 } from './domains.schema';
 
 import { ResourcePage as Page } from '../types';
-import { Domain } from './types';
+import { Domain, CreateDomainPayload, UpdateDomainPayload } from './types';
 
 /**
  * Returns a paginated list of Domains.
@@ -40,7 +40,7 @@ export const getDomain = (domainId: number) =>
  *
  * @param data { object } Options for type, status, etc.
  */
-export const createDomain = (data: Partial<Domain>) =>
+export const createDomain = (data: CreateDomainPayload) =>
   Request<Domain>(
     setData(data, createDomainSchema),
     setURL(`${API_ROOT}/domains`),
@@ -53,7 +53,7 @@ export const createDomain = (data: Partial<Domain>) =>
  * @param domainId { number } The ID of the Domain to access.
  * @param data { object } Options for type, status, etc.
  */
-export const updateDomain = (domainId: number, data: Partial<Domain>) =>
+export const updateDomain = (domainId: number, data: UpdateDomainPayload) =>
   Request<Domain>(
     setURL(`${API_ROOT}/domains/${domainId}`),
     setMethod('PUT'),

--- a/packages/api-v4/src/domains/index.ts
+++ b/packages/api-v4/src/domains/index.ts
@@ -3,3 +3,7 @@ export * from './domains';
 export * from './records';
 
 export * from './types';
+
+export * from './domains.schema';
+
+export * from './records.schema';

--- a/packages/api-v4/src/domains/types.ts
+++ b/packages/api-v4/src/domains/types.ts
@@ -47,5 +47,24 @@ export interface DomainRecord {
   updated: string;
 }
 
-export type CreateDomainPayload = Partial<Domain>;
-export type UpdateDomainPayload = Partial<Domain>;
+export interface CreateDomainPayload {
+  domain: string;
+  type: DomainType;
+  master_ips?: string[];
+  soa_email?: string;
+  tags?: string[];
+}
+export interface UpdateDomainPayload {
+  domain?: string;
+  soa_email?: string;
+  description?: string;
+  refresh_sec?: number;
+  retry_sec?: number;
+  expire_sec?: number;
+  ttl_sec?: number;
+  status?: DomainStatus;
+  tags?: string[];
+  master_ips?: string[];
+  axfr_ips?: string[];
+  group?: string;
+}

--- a/packages/manager/src/components/MultipleIPInput/MultipleIPInput.tsx
+++ b/packages/manager/src/components/MultipleIPInput/MultipleIPInput.tsx
@@ -52,6 +52,7 @@ export interface Props {
   error?: string;
   ips: ExtendedIP[];
   onChange: (ips: ExtendedIP[]) => void;
+  onBlur?: () => void;
   inputProps?: InputBaseProps;
   className?: string;
 }

--- a/packages/manager/src/features/Domains/CreateDomain/CreateDomain.tsx
+++ b/packages/manager/src/features/Domains/CreateDomain/CreateDomain.tsx
@@ -388,7 +388,6 @@ export const CreateDomain: React.FC<CombinedProps> = props => {
       newIPs.length > 0 ? newIPs.map(extendedIPToString) : [''];
     if (mounted) {
       formik.setFieldValue('master_ips', master_ips);
-      formik.setFieldTouched('master_ips');
     }
   };
 

--- a/packages/manager/src/features/Domains/CreateDomain/CreateDomain.tsx
+++ b/packages/manager/src/features/Domains/CreateDomain/CreateDomain.tsx
@@ -241,8 +241,6 @@ export const CreateDomain: React.FC<CombinedProps> = props => {
   const create = (_values: CreateDomainPayload) => {
     const { domain, type, master_ips, soa_email: soaEmail, tags } = _values;
 
-    const primaryIPs = (master_ips ?? []).filter(v => v !== '');
-
     /**
      * In this case, the user wants default domain records created, but
      * they haven't supplied a Linode or NodeBalancer
@@ -271,7 +269,7 @@ export const CreateDomain: React.FC<CombinedProps> = props => {
     const data =
       type === 'master'
         ? { domain, type, tags, soa_email: soaEmail }
-        : { domain, type, tags, master_ips: primaryIPs };
+        : { domain, type, tags, master_ips };
 
     formik.setSubmitting(true);
     domainActions

--- a/packages/manager/src/features/Domains/CreateDomain/CreateDomain.tsx
+++ b/packages/manager/src/features/Domains/CreateDomain/CreateDomain.tsx
@@ -192,12 +192,14 @@ export const CreateDomain: React.FC<CombinedProps> = props => {
       type: 'master' as DomainType,
       soa_email: '',
       master_ips: [],
-      tags: []
+      tags: [] as Item<string>[]
     },
     validationSchema: createDomainSchema,
     validateOnChange: true,
     validateOnMount: true,
-    onSubmit: values => create(values)
+    onSubmit: values =>
+      // Map from Item[] to string[] for tags
+      create({ ...values, tags: values.tags.map(thisTag => thisTag.value) })
   });
 
   React.useEffect(() => {
@@ -238,10 +240,6 @@ export const CreateDomain: React.FC<CombinedProps> = props => {
 
   const create = (_values: CreateDomainPayload) => {
     const { domain, type, master_ips, soa_email: soaEmail, tags } = _values;
-    const _tags = tags;
-    // Array.isArray(tags) && tags.length > 0
-    //   ? tags.map(tag => tag?.value ?? '')
-    //   : undefined;
 
     const primaryIPs = (master_ips ?? []).filter(v => v !== '');
 
@@ -272,8 +270,8 @@ export const CreateDomain: React.FC<CombinedProps> = props => {
 
     const data =
       type === 'master'
-        ? { domain, type, _tags, soa_email: soaEmail }
-        : { domain, type, _tags, master_ips: primaryIPs };
+        ? { domain, type, tags, soa_email: soaEmail }
+        : { domain, type, tags, master_ips: primaryIPs };
 
     formik.setSubmitting(true);
     domainActions
@@ -496,7 +494,7 @@ export const CreateDomain: React.FC<CombinedProps> = props => {
             <TagsInput
               value={values.tags}
               onChange={updateTags}
-              tagError={formik.errors?.tags?.[0]}
+              tagError={formik.errors?.tags as string}
               disabled={disabled}
             />
             {isCreatingPrimaryDomain && (

--- a/packages/manager/src/features/Domains/CreateDomain/CreateDomain.tsx
+++ b/packages/manager/src/features/Domains/CreateDomain/CreateDomain.tsx
@@ -389,6 +389,12 @@ export const CreateDomain: React.FC<CombinedProps> = props => {
     }
   };
 
+  // Required values depend on what type of Domain is being created.
+  const hasEnteredAllRequiredValues =
+    Boolean(domain) && isCreatingPrimaryDomain
+      ? Boolean(soaEmail)
+      : master_ips.length > 0;
+
   return (
     <Grid container>
       <DocumentTitleSegment segment="Create a Domain" />
@@ -447,6 +453,7 @@ export const CreateDomain: React.FC<CombinedProps> = props => {
               />
             </RadioGroup>
             <TextField
+              required
               errorText={errorMap.domain}
               value={domain}
               disabled={disabled}
@@ -457,6 +464,7 @@ export const CreateDomain: React.FC<CombinedProps> = props => {
             />
             {isCreatingPrimaryDomain && (
               <TextField
+                required
                 errorText={errorMap.soa_email}
                 value={soaEmail}
                 label="SOA Email Address"
@@ -468,7 +476,7 @@ export const CreateDomain: React.FC<CombinedProps> = props => {
             )}
             {isCreatingSecondaryDomain && (
               <MultipleIPInput
-                title="Primary Nameserver IP Address"
+                title="Primary Nameserver IP Address (required)"
                 className={classes.ip}
                 ips={master_ips.map(stringToExtendedIP)}
                 onChange={updatePrimaryIPAddress}
@@ -570,7 +578,7 @@ export const CreateDomain: React.FC<CombinedProps> = props => {
                 data-qa-submit
                 data-testid="create-domain-submit"
                 loading={submitting}
-                disabled={disabled}
+                disabled={disabled || !hasEnteredAllRequiredValues}
               >
                 Create Domain
               </Button>

--- a/packages/manager/src/store/domains/domains.reducer.test.ts
+++ b/packages/manager/src/store/domains/domains.reducer.test.ts
@@ -31,6 +31,8 @@ const addEntities = () => {
   );
 };
 
+const createDomainParams = { domain: 'my-domain', type: 'master' as any };
+
 describe('Domains Redux store', () => {
   describe('Reducer', () => {
     it('should handle a getPage.started request', () => {
@@ -119,7 +121,7 @@ describe('Domains Redux store', () => {
     it('should handle a createDomain.started action', () => {
       const newState = reducer(
         { ...defaultState, error: { create: mockError } },
-        actions.createDomainActions.started({})
+        actions.createDomainActions.started(createDomainParams)
       );
       expect(newState).toEqual(defaultState);
     });
@@ -130,7 +132,7 @@ describe('Domains Redux store', () => {
         defaultState,
         actions.createDomainActions.done({
           result: newDomain,
-          params: {}
+          params: createDomainParams
         })
       );
       expect(newState.itemsById).toHaveProperty(
@@ -145,7 +147,7 @@ describe('Domains Redux store', () => {
         defaultState,
         actions.createDomainActions.failed({
           error: mockError,
-          params: {}
+          params: createDomainParams
         })
       );
       expect(newState.error.create).toEqual(mockError);


### PR DESCRIPTION
## Description

The task here was to disable the create button until the required fields were filled in. Since required fields differ based on what kind of Domain you're creating, I added some conditional logic that felt yucky.

Then I thought, It's Christmas, Jared. Why not do it the hard way? So I did. This PR:

- Refactors the create domain modal to use Formik
- Updates Domains types and tests to be accurate (we were using `Partial<Domain>` for both create and update payloads)
- Does a lot of fancy schmancy stuff with the live validation

## Note to Reviewers

Please make sure I didn't break anything. Creating primary and secondary Domains, with and without tags or default records, should all work as before, including error states.