### PR TITLE
POC: "Go To" functionality

### DIFF
--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -204,8 +204,8 @@ export class App extends React.Component<CombinedProps, State> {
             Opens an external site in a new window
           </span>
         </div>
-        {/** Update the LD client with the user's id as soon as we know it */}
         <GoTo open={this.state.goToOpen} onClose={this.goToClose} />
+        {/** Update the LD client with the user's id as soon as we know it */}
         <IdentifyUser
           userID={userId}
           username={username}

--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -88,10 +88,7 @@ export class App extends React.Component<CombinedProps, State> {
       if (event.ctrlKey && event.shiftKey && event.key === 'D') {
         this.props.toggleTheme();
       }
-    });
 
-    // eslint-disable-next-line
-    document.addEventListener('keydown', (event: KeyboardEvent) => {
       if (event.metaKey && event.key === 'k') {
         this.setState(prevState => ({
           ...prevState,

--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -31,6 +31,7 @@ import { MapState } from './store/types';
 
 import IdentifyUser from './IdentifyUser';
 import MainContent from './MainContent';
+import GoTo from './GoTo';
 
 interface Props {
   toggleTheme: () => void;
@@ -43,6 +44,7 @@ interface State {
   menuOpen: boolean;
   welcomeBanner: boolean;
   hasError: boolean;
+  goToOpen: boolean;
 }
 
 type CombinedProps = Props &
@@ -59,7 +61,8 @@ export class App extends React.Component<CombinedProps, State> {
   state: State = {
     menuOpen: false,
     welcomeBanner: false,
-    hasError: false
+    hasError: false,
+    goToOpen: false
   };
 
   componentDidCatch() {
@@ -84,6 +87,16 @@ export class App extends React.Component<CombinedProps, State> {
     document.addEventListener('keydown', (event: KeyboardEvent) => {
       if (event.ctrlKey && event.shiftKey && event.key === 'D') {
         this.props.toggleTheme();
+      }
+    });
+
+    // eslint-disable-next-line
+    document.addEventListener('keydown', (event: KeyboardEvent) => {
+      if (event.metaKey && event.key === 'k') {
+        this.setState(prevState => ({
+          ...prevState,
+          goToOpen: !prevState.goToOpen
+        }));
       }
     });
 
@@ -118,6 +131,10 @@ export class App extends React.Component<CombinedProps, State> {
         }
       });
   }
+
+  goToClose = () => {
+    this.setState({ goToOpen: false });
+  };
 
   render() {
     const { hasError } = this.state;
@@ -188,6 +205,7 @@ export class App extends React.Component<CombinedProps, State> {
           </span>
         </div>
         {/** Update the LD client with the user's id as soon as we know it */}
+        <GoTo open={this.state.goToOpen} onClose={this.goToClose} />
         <IdentifyUser
           userID={userId}
           username={username}

--- a/packages/manager/src/GoTo.tsx
+++ b/packages/manager/src/GoTo.tsx
@@ -1,55 +1,59 @@
 import * as React from 'react';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import EnhancedSelect, { Item } from 'src/components/EnhancedSelect/Select';
-import MUIDialog, {
-  DialogProps as _DialogProps
-} from 'src/components/core/Dialog';
+import MUIDialog from 'src/components/core/Dialog';
 import { useHistory } from 'react-router-dom';
+import useFlags from './hooks/useFlags';
+import { isFeatureEnabled } from './utilities/accountCapabilities';
+import useAccountManagement from './hooks/useAccountManagement';
 
 const useStyles = makeStyles((theme: Theme) => ({
   paper: {
     position: 'absolute',
     top: '10%',
-    overflow: 'visible'
+    overflow: 'visible',
+    '& .react-select__menu-list': {
+      padding: 0,
+      overflowX: 'auto',
+      maxHeight: '100% !important'
+    },
+    '& .react-select__control': {
+      backgroundColor: 'transparent'
+    },
+    '& .react-select__value-container': {
+      overflow: 'auto',
+      '& p': {
+        fontSize: '1rem',
+        overflow: 'visible'
+      }
+    },
+    '& .react-select__indicators': {
+      display: 'none'
+    },
+    '& .react-select__menu': {
+      marginTop: 12,
+      boxShadow: `0 0 10px ${theme.color.boxShadowDark}`,
+      maxWidth: '100% !important',
+      border: 0,
+      borderRadius: 4
+    },
+    '& .react-select__option': {
+      ...theme.applyLinkStyles,
+      padding: `8px, 8px, 8px, 12px`
+    },
+    '& .react-select__option--is-focused': {
+      backgroundColor: theme.palette.primary.main,
+      color: 'white'
+    },
+    '& .MuiInput-root': {
+      boxShadow: `0 0 10px ${theme.color.boxShadowDark}`,
+      border: 0
+    }
   },
   input: {
     width: '100%'
   }
 }));
-
-export const selectStyles = {
-  control: (base: any) => ({
-    ...base,
-    backgroundColor: '#f4f4f4',
-    margin: 0,
-    width: '100%',
-    height: 460,
-    border: 0
-  }),
-  // container: (base: any) => ({ height: 460 }),
-  input: (base: any) => ({
-    ...base,
-    margin: 0,
-    width: '100%',
-    border: 0
-  }),
-  selectContainer: (base: any) => ({
-    ...base,
-    width: '100%',
-    margin: 0,
-    border: 0
-  }),
-  dropdownIndicator: () => ({ display: 'none' }),
-  placeholder: (base: any) => ({ ...base, color: 'blue' }),
-  menu: (base: any) => ({
-    ...base,
-    maxWidth: '100% !important'
-  }),
-  menuList: (base: any) => ({
-    ...base,
-    maxHeight: '100% !important'
-  })
-};
 
 interface Props {
   open: boolean;
@@ -58,91 +62,117 @@ interface Props {
 
 type CombinedProps = Props;
 
-const links = [
-  {
-    display: 'Linodes',
-    href: '/linodes',
-    activeLinks: ['/linodes', '/linodes/create']
-  },
-  {
-    display: 'Volumes',
-    href: '/volumes'
-  },
-  {
-    display: 'Object Storage',
-    href: '/object-storage/buckets',
-    activeLinks: ['/object-storage/buckets', '/object-storage/access-keys']
-  },
-  {
-    display: 'NodeBalancers',
-    href: '/nodebalancers'
-  },
-  {
-    display: 'Domains',
-    href: '/domains'
-  },
-  {
-    // hide: !showFirewalls,
-    display: 'Firewalls',
-    href: '/firewalls'
-  },
-  {
-    display: 'Marketplace',
-    href: '/linodes/create?type=One-Click'
-  },
-  {
-    display: 'Longview',
-    href: '/longview'
-  },
-  {
-    display: 'Kubernetes',
-    href: '/kubernetes/clusters'
-  },
-  {
-    // hide: !_isManagedAccount,
-    display: 'Managed',
-    href: '/managed'
-  },
-  {
-    display: 'StackScripts',
-    href: '/stackscripts?type=account'
-  },
-  {
-    display: 'Images',
-    href: '/images'
-  },
-  {
-    // hide: account.lastUpdated === 0 || !_hasAccountAccess,
-    display: 'Account',
-    href: '/account/billing'
-  }
-];
-
 const GoTo: React.FC<CombinedProps> = props => {
   const classes = useStyles();
-
   const routerHistory = useHistory();
+  const flags = useFlags();
+  const {
+    _isManagedAccount,
+    _hasAccountAccess,
+    account
+  } = useAccountManagement();
+
+  const showFirewalls = isFeatureEnabled(
+    'Cloud Firewall',
+    Boolean(flags.firewalls),
+    account?.data?.capabilities ?? []
+  );
 
   const onSelect = (item: Item<string>) => {
     routerHistory.push(item.value);
     props.onClose();
   };
 
-  const options: Item[] = links.map(thisLink => ({
-    label: thisLink.display,
-    value: thisLink.href
-  }));
+  const links = React.useMemo(
+    () => [
+      {
+        display: 'Linodes',
+        href: '/linodes',
+        activeLinks: ['/linodes', '/linodes/create']
+      },
+      {
+        display: 'Volumes',
+        href: '/volumes'
+      },
+      {
+        display: 'Object Storage',
+        href: '/object-storage/buckets',
+        activeLinks: ['/object-storage/buckets', '/object-storage/access-keys']
+      },
+      {
+        display: 'NodeBalancers',
+        href: '/nodebalancers'
+      },
+      {
+        display: 'Domains',
+        href: '/domains'
+      },
+      {
+        hide: !showFirewalls,
+        display: 'Firewalls',
+        href: '/firewalls'
+      },
+      {
+        display: 'Marketplace',
+        href: '/linodes/create?type=One-Click'
+      },
+      {
+        display: 'Longview',
+        href: '/longview'
+      },
+      {
+        display: 'Kubernetes',
+        href: '/kubernetes/clusters'
+      },
+      {
+        hide: !_isManagedAccount,
+        display: 'Managed',
+        href: '/managed'
+      },
+      {
+        display: 'StackScripts',
+        href: '/stackscripts'
+      },
+      {
+        display: 'Images',
+        href: '/images'
+      },
+      {
+        display: 'Profile',
+        href: '/profile/display'
+      },
+      {
+        hide: account.lastUpdated === 0 || !_hasAccountAccess,
+        display: 'Account',
+        href: '/account/billing'
+      }
+    ],
+    [showFirewalls, _hasAccountAccess, _isManagedAccount, account.lastUpdated]
+  );
+
+  const options: Item[] = React.useMemo(
+    () =>
+      links.map(thisLink => ({
+        label: thisLink.display,
+        value: thisLink.href
+      })),
+    [links]
+  );
+
+  const dialogClasses = React.useMemo(() => ({ paper: classes.paper }), [
+    classes
+  ]);
 
   return (
     <MUIDialog
-      classes={{ paper: classes.paper }}
+      classes={dialogClasses}
       title="Go To..."
       open={props.open}
       onClose={props.onClose}
     >
       <div style={{ width: 400, maxHeight: 600 }}>
         <EnhancedSelect
-          label="Main search"
+          label="Go To"
           hideLabel
           // eslint-disable-next-line
           autoFocus
@@ -150,7 +180,6 @@ const GoTo: React.FC<CombinedProps> = props => {
           options={options}
           onChange={onSelect}
           placeholder="Go to..."
-          styles={selectStyles}
           openMenuOnFocus={false}
           openMenuOnClick={false}
           isClearable={false}
@@ -163,4 +192,4 @@ const GoTo: React.FC<CombinedProps> = props => {
   );
 };
 
-export default GoTo;
+export default React.memo(GoTo);

--- a/packages/manager/src/GoTo.tsx
+++ b/packages/manager/src/GoTo.tsx
@@ -170,6 +170,9 @@ const GoTo: React.FC<CombinedProps> = props => {
       open={props.open}
       onClose={props.onClose}
     >
+      {/* I was about to put a "@todo" item for mobile display, but realized
+      keyboard shortcuts are not realistic on mobile devices. So I think an
+      absolute width here is fine. */}
       <div style={{ width: 400, maxHeight: 600 }}>
         <EnhancedSelect
           label="Go To"

--- a/packages/manager/src/GoTo.tsx
+++ b/packages/manager/src/GoTo.tsx
@@ -1,0 +1,166 @@
+import * as React from 'react';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import EnhancedSelect, { Item } from 'src/components/EnhancedSelect/Select';
+import MUIDialog, {
+  DialogProps as _DialogProps
+} from 'src/components/core/Dialog';
+import { useHistory } from 'react-router-dom';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  paper: {
+    position: 'absolute',
+    top: '10%',
+    overflow: 'visible'
+  },
+  input: {
+    width: '100%'
+  }
+}));
+
+export const selectStyles = {
+  control: (base: any) => ({
+    ...base,
+    backgroundColor: '#f4f4f4',
+    margin: 0,
+    width: '100%',
+    height: 460,
+    border: 0
+  }),
+  // container: (base: any) => ({ height: 460 }),
+  input: (base: any) => ({
+    ...base,
+    margin: 0,
+    width: '100%',
+    border: 0
+  }),
+  selectContainer: (base: any) => ({
+    ...base,
+    width: '100%',
+    margin: 0,
+    border: 0
+  }),
+  dropdownIndicator: () => ({ display: 'none' }),
+  placeholder: (base: any) => ({ ...base, color: 'blue' }),
+  menu: (base: any) => ({
+    ...base,
+    maxWidth: '100% !important'
+  }),
+  menuList: (base: any) => ({
+    ...base,
+    maxHeight: '100% !important'
+  })
+};
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+type CombinedProps = Props;
+
+const links = [
+  {
+    display: 'Linodes',
+    href: '/linodes',
+    activeLinks: ['/linodes', '/linodes/create']
+  },
+  {
+    display: 'Volumes',
+    href: '/volumes'
+  },
+  {
+    display: 'Object Storage',
+    href: '/object-storage/buckets',
+    activeLinks: ['/object-storage/buckets', '/object-storage/access-keys']
+  },
+  {
+    display: 'NodeBalancers',
+    href: '/nodebalancers'
+  },
+  {
+    display: 'Domains',
+    href: '/domains'
+  },
+  {
+    // hide: !showFirewalls,
+    display: 'Firewalls',
+    href: '/firewalls'
+  },
+  {
+    display: 'Marketplace',
+    href: '/linodes/create?type=One-Click'
+  },
+  {
+    display: 'Longview',
+    href: '/longview'
+  },
+  {
+    display: 'Kubernetes',
+    href: '/kubernetes/clusters'
+  },
+  {
+    // hide: !_isManagedAccount,
+    display: 'Managed',
+    href: '/managed'
+  },
+  {
+    display: 'StackScripts',
+    href: '/stackscripts?type=account'
+  },
+  {
+    display: 'Images',
+    href: '/images'
+  },
+  {
+    // hide: account.lastUpdated === 0 || !_hasAccountAccess,
+    display: 'Account',
+    href: '/account/billing'
+  }
+];
+
+const GoTo: React.FC<CombinedProps> = props => {
+  const classes = useStyles();
+
+  const routerHistory = useHistory();
+
+  const onSelect = (item: Item<string>) => {
+    routerHistory.push(item.value);
+    props.onClose();
+  };
+
+  const options: Item[] = links.map(thisLink => ({
+    label: thisLink.display,
+    value: thisLink.href
+  }));
+
+  return (
+    <MUIDialog
+      classes={{ paper: classes.paper }}
+      title="Go To..."
+      open={props.open}
+      onClose={props.onClose}
+    >
+      <div style={{ width: 400, maxHeight: 600 }}>
+        <EnhancedSelect
+          label="Main search"
+          hideLabel
+          // eslint-disable-next-line
+          autoFocus
+          blurInputOnSelect
+          options={options}
+          onChange={onSelect}
+          placeholder="Go to..."
+          styles={selectStyles}
+          openMenuOnFocus={false}
+          openMenuOnClick={false}
+          isClearable={false}
+          isMulti={false}
+          value={false}
+          menuIsOpen={true}
+        />
+      </div>
+    </MUIDialog>
+  );
+};
+
+export default GoTo;


### PR DESCRIPTION
## Description

I was inspired by @Jskobos's keyboard shortcut for light/dark mode toggle, so I started this on FTFF. This one is "CMD+K" and brings up a "Go To" component for quick navigation around the app.

![Screen Shot 2020-12-22 at 4 52 27 PM](https://user-images.githubusercontent.com/16911484/102936638-87329180-4476-11eb-98d6-c08eff125912.png)


Still needs a bit of testing, some styling updates (I copied over a lot of styles from SearchBar.styles), etc. 

