### PR TITLE
M3-4767: Add padding to the right of the create button on mobile

### DIFF
--- a/packages/manager/src/components/CMR_DocumentationButton/DocumentationButton.tsx
+++ b/packages/manager/src/components/CMR_DocumentationButton/DocumentationButton.tsx
@@ -36,7 +36,7 @@ export const DocumentationButton: React.FC<CombinedProps> = props => {
 
   return (
     <IconTextLink
-      className={classes.root}
+      className={`${classes.root} docsButton`}
       SideIcon={DocsIcon}
       text="Docs"
       title="Docs"

--- a/packages/manager/src/components/EntityHeader/EntityHeader.tsx
+++ b/packages/manager/src/components/EntityHeader/EntityHeader.tsx
@@ -102,7 +102,7 @@ const useStyles = makeStyles((theme: Theme) => ({
       marginRight: 0
     },
     [theme.breakpoints.down('xs')]: {
-      paddingRight: '0px !important'
+      marginBottom: 0
     }
   }
 }));

--- a/packages/manager/src/features/Domains/DomainsLanding.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.tsx
@@ -63,6 +63,14 @@ type ClassNames =
 
 const styles = (theme: Theme) =>
   createStyles({
+    root: {
+      // Adds spacing when the docs button wraps to make it look a little less awkward
+      [theme.breakpoints.down(380)]: {
+        '& .docsButton': {
+          paddingBottom: theme.spacing(2)
+        }
+      }
+    },
     titleWrapper: {
       flex: 1
     },
@@ -428,7 +436,7 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
             togglePreference: toggleGroupDomains
           }: ToggleProps<boolean>) => {
             return (
-              <React.Fragment>
+              <div className={classes.root}>
                 <LandingHeader
                   title="Domains"
                   extraActions={
@@ -463,7 +471,7 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
                     this.props.upsertMultipleDomains(data);
                   }}
                 />
-              </React.Fragment>
+              </div>
             );
           }}
         </PreferenceToggle>


### PR DESCRIPTION
Prevent the create button on landing pages from being flush to the edge of the screen