### PR TITLE
M3-4740 Change: Disable Firewall/Image create flows for restricted users.

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.tsx
@@ -14,6 +14,7 @@ import LinodeMultiSelect from 'src/components/LinodeMultiSelect';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
 import { dcDisplayNames } from 'src/constants';
+import { useAccountManagement } from 'src/hooks/useAccountManagement';
 import useRegions from 'src/hooks/useRegions';
 import arrayToList from 'src/utilities/arrayToCommaSeparatedList';
 import {
@@ -46,6 +47,12 @@ const initialValues: CreateFirewallPayload = {
 
 const AddFirewallDrawer: React.FC<CombinedProps> = props => {
   const { onClose, onSubmit, ...restOfDrawerProps } = props;
+
+  /**
+   * We'll eventually want to check the read_write firewall
+   * grant here too, but it doesn't exist yet.
+   */
+  const { _isRestrictedUser } = useAccountManagement();
 
   const regions = useRegions();
 
@@ -114,8 +121,7 @@ const AddFirewallDrawer: React.FC<CombinedProps> = props => {
           handleBlur,
           handleSubmit,
           isSubmitting,
-          setFieldValue,
-          validateField
+          setFieldValue
         }) => {
           const generalError =
             status?.generalError ||
@@ -125,6 +131,12 @@ const AddFirewallDrawer: React.FC<CombinedProps> = props => {
 
           return (
             <form onSubmit={handleSubmit}>
+              {_isRestrictedUser ? (
+                <Notice
+                  error
+                  text="You don't have permissions to create a new Firewall. Please contact an account administrator for details."
+                />
+              ) : null}
               {generalError && (
                 <Notice
                   key={status}
@@ -141,6 +153,7 @@ const AddFirewallDrawer: React.FC<CombinedProps> = props => {
               <TextField
                 aria-label="Label for your new Firewall"
                 label="Label"
+                disabled={_isRestrictedUser}
                 name="label"
                 value={values.label}
                 onChange={handleChange}
@@ -152,6 +165,7 @@ const AddFirewallDrawer: React.FC<CombinedProps> = props => {
               />
               <LinodeMultiSelect
                 showAllOption
+                disabled={_isRestrictedUser}
                 allowedRegions={regionsWithFirewalls}
                 helperText={`Assign one or more Linodes to this firewall. You can add
                  Linodes later if you want to customize your rules first. Only Linodes in
@@ -171,10 +185,16 @@ const AddFirewallDrawer: React.FC<CombinedProps> = props => {
                   data-qa-submit
                   data-testid="add-firewall-submit"
                   loading={isSubmitting}
+                  disabled={_isRestrictedUser}
                 >
                   Create
                 </Button>
-                <Button onClick={onClose} buttonType="cancel" data-qa-cancel>
+                <Button
+                  onClick={onClose}
+                  buttonType="cancel"
+                  disabled={_isRestrictedUser}
+                  data-qa-cancel
+                >
                   Cancel
                 </Button>
               </ActionsPanel>

--- a/packages/manager/src/features/Firewalls/shared.ts
+++ b/packages/manager/src/features/Firewalls/shared.ts
@@ -1,6 +1,5 @@
 import {
   FirewallRuleProtocol,
-  FirewallRules,
   FirewallRuleType
 } from '@linode/api-v4/lib/firewalls/types';
 import { Item } from 'src/components/EnhancedSelect/Select';
@@ -85,7 +84,8 @@ export const allIPs = {
   ipv6: [allIPv6]
 };
 
-export interface PredefinedFirewall extends FirewallRules {
+export interface PredefinedFirewall {
+  inbound: FirewallRuleType[];
   label: string;
 }
 

--- a/packages/manager/src/features/Images/ImagesDrawer.tsx
+++ b/packages/manager/src/features/Images/ImagesDrawer.tsx
@@ -22,6 +22,7 @@ import { IMAGE_DEFAULT_LIMIT } from 'src/constants';
 import withImages, {
   ImagesDispatch
 } from 'src/containers/withImages.container';
+import withProfile from 'src/containers/profile.container';
 import { resetEventsPolling } from 'src/eventsPolling';
 import DiskSelect from 'src/features/linodes/DiskSelect';
 import LinodeSelect from 'src/features/linodes/LinodeSelect';
@@ -73,6 +74,7 @@ type CombinedProps = Props &
   WithStyles<ClassNames> &
   RouteComponentProps<{}> &
   WithSnackbarProps &
+  ProfileProps &
   ImagesDispatch;
 
 export type DrawerMode = 'closed' | 'create' | 'imagize' | 'restore' | 'edit';
@@ -115,7 +117,7 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
     this.mounted = false;
   }
 
-  componentDidUpdate(prevProps: CombinedProps, prevState: State) {
+  componentDidUpdate(prevProps: CombinedProps) {
     if (this.props.disks && !equals(this.props.disks, prevProps.disks)) {
       // for the 'imagizing' mode
       this.setState({ disks: this.props.disks });
@@ -314,6 +316,7 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
       selectedDisk,
       selectedLinode,
       mode,
+      canCreateImage,
       changeLabel,
       changeDescription,
       classes
@@ -344,6 +347,12 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
         onClose={this.props.onClose}
         title={titleMap[mode]}
       >
+        {!canCreateImage ? (
+          <Notice
+            error
+            text="You don't have permissions to create a new Image. Please contact an account administrator for details."
+          />
+        ) : null}
         {generalError && <Notice error text={generalError} data-qa-notice />}
 
         {notice && <Notice success text={notice} data-qa-notice />}
@@ -352,6 +361,7 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
           <LinodeSelect
             selectedLinode={selectedLinode}
             linodeError={linodeError}
+            disabled={!canCreateImage}
             handleChange={linode => this.handleLinodeChange(linode.id)}
             updateFor={[selectedLinode, linodeError, classes]}
           />
@@ -365,7 +375,7 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
               diskError={diskError}
               handleChange={this.handleDiskChange}
               updateFor={[disks, selectedDisk, diskError, classes]}
-              disabled={mode === 'imagize'}
+              disabled={mode === 'imagize' || !canCreateImage}
               data-qa-disk-select
             />
             <Typography className={classes.helperText} variant="body1">
@@ -387,6 +397,7 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
               onChange={changeLabel}
               error={Boolean(labelError)}
               errorText={labelError}
+              disabled={!canCreateImage}
               data-qa-image-label
             />
 
@@ -398,6 +409,7 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
               onChange={changeDescription}
               error={Boolean(descriptionError)}
               errorText={descriptionError}
+              disabled={!canCreateImage}
               data-qa-image-description
             />
           </React.Fragment>
@@ -409,7 +421,7 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
         >
           <Button
             onClick={this.onSubmit}
-            disabled={requirementsMet}
+            disabled={requirementsMet || !canCreateImage}
             loading={submitting}
             buttonType="primary"
             data-qa-submit
@@ -420,6 +432,7 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
             onClick={this.close}
             buttonType="secondary"
             className="cancel"
+            disabled={!canCreateImage}
             data-qa-cancel
           >
             Cancel
@@ -432,10 +445,19 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
 
 const styled = withStyles(styles);
 
+interface ProfileProps {
+  canCreateImage: boolean;
+}
+
 export default compose<CombinedProps, Props>(
   styled,
   withRouter,
   withImages(),
   withSnackbar,
-  SectionErrorBoundary
+  SectionErrorBoundary,
+  withProfile<ProfileProps, {}>((undefined, { profileData: profile }) => ({
+    canCreateImage:
+      Boolean(!profile?.restricted) ||
+      Boolean(profile?.grants?.global.add_images)
+  }))
 )(ImageDrawer);


### PR DESCRIPTION
## Description

Disable all fields and show the usual banner for users unable to create the appropriate things.

## Note to Reviewers

- To test, use a restricted user with and without the `add_images` grant and make sure things are disabled.
- Please also make sure behavior is unchanged for unrestricted users.
- There is no `add_firewall` grant and it's not on the immediate agenda.
- I noticed we were showing all Linodes in the Linode select when creating an Image. This causes an API error
  if you try to imagize a disk on a Linode you don't have read_write access to. I added some filtering to account for this. To test, give your restricted user read_write access to one or more Linodes and make sure those are the only ones that show up in the dropdown.