### PR TITLE
Fix: Update read_only grant description for account access

### DIFF
--- a/packages/manager/src/features/Users/UserPermissions.tsx
+++ b/packages/manager/src/features/Users/UserPermissions.tsx
@@ -465,9 +465,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
           />
           <SelectionCard
             heading="Read Only"
-            subheadings={[
-              'Can view invoices, view billing info, and will receive copies of all invoices and payment emails.'
-            ]}
+            subheadings={['Can view invoices and billing info.']}
             checked={grants.global.account_access === 'read_only'}
             onClick={this.billingPermOnClick('read_only')}
             variant="check"
@@ -476,7 +474,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
           <SelectionCard
             heading="Read-Write"
             subheadings={[
-              'Can make payments, update contact and billing info, and will receive copies of all invoices and payment emails'
+              'Can make payments, update contact and billing info, and will receive copies of all invoices and payment emails.'
             ]}
             checked={grants.global.account_access === 'read_write'}
             onClick={this.billingPermOnClick('read_write')}


### PR DESCRIPTION
## Description

Just a little housecleaning; see ticket for details.

Update text to accurately reflect what read_only account access lets you do


