### PR TITLE
Improve spacing of dev-tools columns for smaller viewports

### DIFF
--- a/packages/manager/src/dev-tools/EnvironmentToggleTool.tsx
+++ b/packages/manager/src/dev-tools/EnvironmentToggleTool.tsx
@@ -56,7 +56,7 @@ const EnvironmentToggleTool: React.FC<{}> = () => {
   return (
     <Grid container>
       <Grid item xs={12}>
-        <h4>Environment</h4>
+        <h4 style={{ marginBottom: 8 }}>Environment</h4>
       </Grid>
       <Grid item xs={12}>
         <select
@@ -67,6 +67,7 @@ const EnvironmentToggleTool: React.FC<{}> = () => {
             setSelectedOption(Math.max(selectedIndex, 0));
           }}
           defaultValue={currentEnvLabel}
+          style={{ marginRight: 8 }}
         >
           <option value="" disabled>
             Select an environment
@@ -81,7 +82,6 @@ const EnvironmentToggleTool: React.FC<{}> = () => {
           })}
         </select>
         <button
-          style={{ marginLeft: 8 }}
           onClick={() => {
             const selected = options[selectedOption];
             if (selected) {

--- a/packages/manager/src/dev-tools/MockDataTool.tsx
+++ b/packages/manager/src/dev-tools/MockDataTool.tsx
@@ -33,15 +33,14 @@ const MockDataTool: React.FC<{}> = () => {
   return (
     <Grid>
       <Grid item xs={12}>
-        <h4>Mock Data</h4>
+        <h4 style={{ marginBottom: 8 }}>Mock Data</h4>
       </Grid>
       <Grid item xs={12}>
         {options.map(thisOption => {
           return (
             <div key={thisOption.key} style={{ marginTop: 4 }}>
-              <label>{thisOption.label}: </label>
+              <label style={{ marginRight: 4 }}>{thisOption.label}: </label>
               <input
-                style={{ marginLeft: 4 }}
                 type="number"
                 min="0"
                 onChange={e =>

--- a/packages/manager/src/dev-tools/ServiceWorkerTool.tsx
+++ b/packages/manager/src/dev-tools/ServiceWorkerTool.tsx
@@ -25,11 +25,15 @@ export const ServiceWorkerTool: React.FC<{}> = _ => {
 
   return (
     <>
-      <span>Mock Service Worker: {workerActive ? 'Enabled' : 'Disabled'}</span>
+      <span style={{ marginRight: 8 }}>
+        <span style={{ marginRight: 8 }}>Mock Service Worker:</span>
+        {workerActive ? 'Enabled' : 'Disabled'}
+      </span>
       <input
         type="checkbox"
         checked={workerActive}
         onChange={e => handleToggleWorker(e)}
+        style={{ margin: 0 }}
       />
     </>
   );

--- a/packages/manager/src/dev-tools/dev-tools.css
+++ b/packages/manager/src/dev-tools/dev-tools.css
@@ -25,3 +25,13 @@
 #dev-tools:hover .tools {
   display: flex;
 }
+
+@media only screen and (max-width: 960px) {
+  #dev-tools:hover .tools {
+    justify-content: space-between;
+  }
+
+  #dev-tools:hover .column {
+    margin: 0 1em 0 1em;
+  }
+}

--- a/packages/manager/src/dev-tools/dev-tools.css
+++ b/packages/manager/src/dev-tools/dev-tools.css
@@ -30,8 +30,4 @@
   #dev-tools:hover .tools {
     justify-content: space-between;
   }
-
-  #dev-tools:hover .column {
-    margin: 0 1em 0 1em;
-  }
 }

--- a/packages/manager/src/dev-tools/dev-tools.tsx
+++ b/packages/manager/src/dev-tools/dev-tools.tsx
@@ -18,16 +18,16 @@ function install() {
       <div id="dev-tools">
         <div>🛠</div>
         <Grid container spacing={2} className="tools">
-          <Grid item xs={4} sm={2} className="column">
+          <Grid item xs={4} sm={2}>
             <FeatureFlagTool />
           </Grid>
           {process.env.NODE_ENV === 'development' && (
-            <Grid item xs={4} sm={5} md={3} className="column">
+            <Grid item xs={4} sm={5} md={3}>
               <EnvironmentToggleTool />
             </Grid>
           )}
           {!isProductionBuild && (
-            <Grid item xs={4} sm={5} md={3} className="column">
+            <Grid item xs={4} sm={5} md={3}>
               <MockDataTool />
             </Grid>
           )}

--- a/packages/manager/src/dev-tools/dev-tools.tsx
+++ b/packages/manager/src/dev-tools/dev-tools.tsx
@@ -18,16 +18,16 @@ function install() {
       <div id="dev-tools">
         <div>🛠</div>
         <Grid container spacing={2} className="tools">
-          <Grid item xs={2} className="column">
+          <Grid item xs={4} sm={2} className="column">
             <FeatureFlagTool />
           </Grid>
           {process.env.NODE_ENV === 'development' && (
-            <Grid item xs={2} className="column">
+            <Grid item xs={4} sm={5} md={3} className="column">
               <EnvironmentToggleTool />
             </Grid>
           )}
           {!isProductionBuild && (
-            <Grid item xs={2} className="column">
+            <Grid item xs={4} sm={5} md={3} className="column">
               <MockDataTool />
             </Grid>
           )}

--- a/packages/manager/src/dev-tools/dev-tools.tsx
+++ b/packages/manager/src/dev-tools/dev-tools.tsx
@@ -18,16 +18,16 @@ function install() {
       <div id="dev-tools">
         <div>🛠</div>
         <Grid container spacing={2} className="tools">
-          <Grid item xs={2}>
+          <Grid item xs={2} className="column">
             <FeatureFlagTool />
           </Grid>
           {process.env.NODE_ENV === 'development' && (
-            <Grid item xs={2}>
+            <Grid item xs={2} className="column">
               <EnvironmentToggleTool />
             </Grid>
           )}
           {!isProductionBuild && (
-            <Grid item xs={2}>
+            <Grid item xs={2} className="column">
               <MockDataTool />
             </Grid>
           )}


### PR DESCRIPTION
## Description
The goal here was to clean up the dev-tools column spacing at smaller viewports to make things cleaner. Particularly with some new options for mock data being added shortly, this could've become slightly messy.

Before:
<img width="497" alt="Screen Shot 2021-01-05 at 11 32 21 AM" src="https://user-images.githubusercontent.com/32860776/103672362-34fb7100-4f4a-11eb-8b96-1e2047dc3820.png">

After: 
<img width="497" alt="Screen Shot 2021-01-05 at 11 34 33 AM" src="https://user-images.githubusercontent.com/32860776/103672374-388ef800-4f4a-11eb-8213-dab772a67bd1.png">

## Type of Change
- Non breaking change ('update', 'change')
