### PR TITLE
Convert Support ticket drawer to a dialog and make inputs bigger

### DIFF
--- a/packages/manager/src/features/Support/SupportTicketDetail/TabbedReply/PreviewReply.tsx
+++ b/packages/manager/src/features/Support/SupportTicketDetail/TabbedReply/PreviewReply.tsx
@@ -14,7 +14,7 @@ const styles = () =>
   createStyles({
     root: {
       border: '1px solid #ccc',
-      height: 420,
+      height: 320,
       padding: `9px 12px 9px 12px`,
       overflowY: 'auto'
     }

--- a/packages/manager/src/features/Support/SupportTicketDetail/TabbedReply/PreviewReply.tsx
+++ b/packages/manager/src/features/Support/SupportTicketDetail/TabbedReply/PreviewReply.tsx
@@ -3,7 +3,6 @@ import { compose } from 'recompose';
 import Paper from 'src/components/core/Paper';
 import {
   createStyles,
-  Theme,
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
@@ -11,11 +10,11 @@ import HighlightedMarkdown from 'src/components/HighlightedMarkdown';
 
 type ClassNames = 'root';
 
-const styles = (theme: Theme) =>
+const styles = () =>
   createStyles({
     root: {
       border: '1px solid #ccc',
-      height: 200,
+      height: 420,
       padding: `9px 12px 9px 12px`,
       overflowY: 'auto'
     }

--- a/packages/manager/src/features/Support/SupportTicketDetail/TabbedReply/TicketReply.tsx
+++ b/packages/manager/src/features/Support/SupportTicketDetail/TabbedReply/TicketReply.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {
   createStyles,
-  Theme,
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
@@ -9,10 +8,10 @@ import TextField from 'src/components/TextField';
 
 type ClassNames = 'replyField';
 
-const styles = (theme: Theme) =>
+const styles = () =>
   createStyles({
     replyField: {
-      maxHeight: 200,
+      height: 420,
       marginTop: 0,
       '& > div': {
         maxWidth: '100% !important'
@@ -37,7 +36,7 @@ class TicketReply extends React.Component<CombinedProps> {
       <TextField
         className={classes.replyField}
         multiline
-        rows={9}
+        rows={20}
         value={value}
         placeholder={placeholder || 'Enter your reply'}
         data-qa-ticket-description

--- a/packages/manager/src/features/Support/SupportTicketDetail/TabbedReply/TicketReply.tsx
+++ b/packages/manager/src/features/Support/SupportTicketDetail/TabbedReply/TicketReply.tsx
@@ -11,7 +11,7 @@ type ClassNames = 'replyField';
 const styles = () =>
   createStyles({
     replyField: {
-      height: 420,
+      height: 320,
       marginTop: 0,
       '& > div': {
         maxWidth: '100% !important'
@@ -36,7 +36,7 @@ class TicketReply extends React.Component<CombinedProps> {
       <TextField
         className={classes.replyField}
         multiline
-        rows={20}
+        rows={15}
         value={value}
         placeholder={placeholder || 'Enter your reply'}
         data-qa-ticket-description

--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
@@ -14,7 +14,7 @@ import Button from 'src/components/Button';
 import FormHelperText from 'src/components/core/FormHelperText';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
-import Drawer from 'src/components/Drawer';
+import Dialog from 'src/components/Dialog';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import Accordion from 'src/components/Accordion';
 import Notice from 'src/components/Notice';
@@ -450,7 +450,13 @@ export const SupportTicketDrawer: React.FC<CombinedProps> = props => {
     data.find(thisEntity => String(thisEntity.value) === entityID) || null;
 
   return (
-    <Drawer open={open} onClose={close} title="Open a Support Ticket">
+    <Dialog
+      open={open}
+      onClose={close}
+      fullHeight
+      fullWidth
+      title="Open a Support Ticket"
+    >
       {props.children || (
         <React.Fragment>
           {generalError && <Notice error text={generalError} data-qa-notice />}
@@ -556,7 +562,7 @@ export const SupportTicketDrawer: React.FC<CombinedProps> = props => {
           </ActionsPanel>
         </React.Fragment>
       )}
-    </Drawer>
+    </Dialog>
   );
 };
 


### PR DESCRIPTION
## Description

Customers had mentioned that they don't always have enough room to fill out ticket text. Expanded everything to improve the situation.