### PR TITLE
Fix: Set highlight.js theme on app load

### DIFF
--- a/packages/manager/src/LinodeThemeWrapper.tsx
+++ b/packages/manager/src/LinodeThemeWrapper.tsx
@@ -37,23 +37,27 @@ const themes = { light, dark };
 
 type CombinedProps = Props & PreferencesActionsProps;
 
+const setActiveHighlightTheme = (value: ThemeChoice) => {
+  /**
+   * Disable the inactive highlight.js theme when we toggle
+   * the app theme. This looks horrible but it is the recommended approach:
+   * https://github.com/highlightjs/highlight.js/blob/master/demo/demo.js
+   */
+  const inactiveTheme = value === 'dark' ? 'a11y-light' : 'a11y-dark';
+  const links = document.querySelectorAll('style');
+  links.forEach((thisLink: any) => {
+    const content = thisLink?.textContent ?? '';
+    // We're matching a comment in the style tag's text contents :groan:
+    thisLink.disabled = content.match(inactiveTheme);
+  });
+};
+
 const LinodeThemeWrapper: React.FC<CombinedProps> = props => {
   const toggleTheme = (value: ThemeChoice) => {
     setTimeout(() => {
       document.body.classList.remove('no-transition');
     }, 500);
-    /**
-     * Disable the inactive highlight.js theme when we toggle
-     * the app theme. This looks horrible but it is the recommended approach:
-     * https://github.com/highlightjs/highlight.js/blob/master/demo/demo.js
-     */
-    const inactiveTheme = value === 'dark' ? 'a11y-light' : 'a11y-dark';
-    const links = document.querySelectorAll('style');
-    links.forEach((thisLink: any) => {
-      const content = thisLink?.textContent ?? '';
-      // We're matching a comment in the style tag's text contents :groan:
-      thisLink.disabled = content.match(inactiveTheme);
-    });
+    setActiveHighlightTheme(value);
     /** send to GA */
     sendThemeToggleEvent(value);
   };
@@ -72,6 +76,9 @@ const LinodeThemeWrapper: React.FC<CombinedProps> = props => {
     /** request the user preferences on app load */
     props
       .getUserPreferences()
+      .then(response => {
+        setActiveHighlightTheme(response?.theme ?? 'light');
+      })
       .catch(
         () =>
           /** swallow the error. PreferenceToggle.tsx handles failures gracefully */ null

--- a/packages/manager/src/LinodeThemeWrapper.tsx
+++ b/packages/manager/src/LinodeThemeWrapper.tsx
@@ -77,7 +77,12 @@ const LinodeThemeWrapper: React.FC<CombinedProps> = props => {
     props
       .getUserPreferences()
       .then(response => {
-        setActiveHighlightTheme(response?.theme ?? 'light');
+        // Without the timeout a race condition sometimes runs the theme
+        // highlight checker before the stylesheets have fully loaded.
+        window.setTimeout(
+          () => setActiveHighlightTheme(response?.theme ?? 'light'),
+          1000
+        );
       })
       .catch(
         () =>


### PR DESCRIPTION
The logic to deactivate the inactive theme for code syntax
highlighting was only run when the theme was toggled, not on
page load. This meant that users loading the app with light theme
enabled saw dark/bad highlighting everywhere HighlightedMarkdown
was used.

Extracted this logic to a function and called it in the existing
useEffect.

