### PR TITLE
M3-4710: Remove icons from Domain Detail buttons

### DIFF
--- a/packages/manager/src/components/Toggle/Toggle.stories.tsx
+++ b/packages/manager/src/components/Toggle/Toggle.stories.tsx
@@ -12,11 +12,14 @@ class Example extends React.Component<{}, { value?: string }> {
 
   render() {
     return (
-      <FormControlLabel
-        className="toggleLabel"
-        control={<Toggle />}
-        label="Example Label"
-      />
+      <>
+        <FormControlLabel
+          className="toggleLabel"
+          control={<Toggle />}
+          label="Example Label"
+        />
+        <Toggle checked={true} />
+      </>
     );
   }
 }

--- a/packages/manager/src/components/Toggle/Toggle.stories.tsx
+++ b/packages/manager/src/components/Toggle/Toggle.stories.tsx
@@ -12,14 +12,11 @@ class Example extends React.Component<{}, { value?: string }> {
 
   render() {
     return (
-      <>
-        <FormControlLabel
-          className="toggleLabel"
-          control={<Toggle />}
-          label="Example Label"
-        />
-        <Toggle checked={true} />
-      </>
+      <FormControlLabel
+        className="toggleLabel"
+        control={<Toggle />}
+        label="Example Label"
+      />
     );
   }
 }

--- a/packages/manager/src/features/Domains/DomainDetail/DomainDetail.tsx
+++ b/packages/manager/src/features/Domains/DomainDetail/DomainDetail.tsx
@@ -1,12 +1,10 @@
-import Edit from '@material-ui/icons/Edit';
 import { DomainRecord, getDomainRecords } from '@linode/api-v4/lib/domains';
 import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
 import Breadcrumb from 'src/components/Breadcrumb';
-import Button from 'src/components/Button';
-import { makeStyles, Theme } from 'src/components/core/styles';
 import DocumentationButton from 'src/components/CMR_DocumentationButton';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
 import Loading from 'src/components/LandingLoading';
@@ -23,29 +21,18 @@ type RouteProps = RouteComponentProps<{ domainId?: string }>;
 
 const useStyles = makeStyles((theme: Theme) => ({
   ...summaryPanelStyles(theme),
+  root: {
+    margin: 0,
+    [theme.breakpoints.down('xs')]: {
+      paddingLeft: theme.spacing()
+    },
+    [theme.breakpoints.down('sm')]: {
+      paddingRight: theme.spacing()
+    }
+  },
   error: {
     marginTop: `${theme.spacing(3)}px !important`,
     marginBottom: `0 !important`
-  },
-  cta: {
-    display: 'flex',
-    alignItems: 'center',
-    marginLeft: theme.spacing()
-  },
-  tagsButton: {
-    height: 34,
-    marginLeft: 0,
-    marginRight: theme.spacing(3),
-    minWidth: 'auto',
-    padding: 0,
-    '&:hover': {
-      textDecoration: 'underline'
-    }
-  },
-  editIcon: {
-    width: 20,
-    height: 20,
-    marginRight: theme.spacing()
   }
 }));
 
@@ -70,11 +57,6 @@ const DomainDetail: React.FC<CombinedProps> = props => {
     refreshDomainRecords();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  const tagSection = document.getElementById('domains-tag-section');
-  const scrollToTags = () => {
-    return tagSection && tagSection.scrollIntoView({ behavior: 'smooth' });
-  };
 
   const handleUpdateTags = (tagsList: string[]) => {
     if (!domainId) {
@@ -112,31 +94,19 @@ const DomainDetail: React.FC<CombinedProps> = props => {
   }
 
   return (
-    <React.Fragment>
+    <>
       <Grid
         container
-        className="m0"
+        className={classes.root}
         alignItems="center"
         justify="space-between"
       >
-        <Grid item className="p0">
-          <Breadcrumb
-            pathname={location.pathname}
-            labelTitle={domain.domain}
-            labelOptions={{ noCap: true }}
-          />
-        </Grid>
-        <Grid item className={`${classes.cta} p0`}>
-          <Button
-            buttonType="secondary"
-            className={classes.tagsButton}
-            onClick={() => scrollToTags()}
-            aria-label={`Manage tags for "${domain.domain}"`}
-          >
-            <Edit className={classes.editIcon} /> Tags
-          </Button>
-          <DocumentationButton href="https://www.linode.com/docs/guides/dns-manager/" />
-        </Grid>
+        <Breadcrumb
+          pathname={location.pathname}
+          labelTitle={domain.domain}
+          labelOptions={{ noCap: true }}
+        />
+        <DocumentationButton href="https://www.linode.com/docs/guides/dns-manager/" />
       </Grid>
       {props.location.state && props.location.state.recordError && (
         <Notice
@@ -151,7 +121,7 @@ const DomainDetail: React.FC<CombinedProps> = props => {
         records={records}
         domain={domain}
       />
-    </React.Fragment>
+    </>
   );
 };
 

--- a/packages/manager/src/features/Domains/DomainRecords.tsx
+++ b/packages/manager/src/features/Domains/DomainRecords.tsx
@@ -6,7 +6,6 @@ import {
   RecordType
 } from '@linode/api-v4/lib/domains';
 import { APIError } from '@linode/api-v4/lib/types';
-import * as classnames from 'classnames';
 import {
   compose,
   equals,
@@ -23,7 +22,6 @@ import * as React from 'react';
 import { compose as recompose } from 'recompose';
 import { Subscription } from 'rxjs/Subscription';
 import ActionsPanel from 'src/components/ActionsPanel';
-import AddNewLink from 'src/components/AddNewLink';
 import Button from 'src/components/Button';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
 import Paper from 'src/components/core/Paper';
@@ -57,20 +55,18 @@ import { storage } from 'src/utilities/storage';
 import ActionMenu from './DomainRecordActionMenu';
 import Drawer from './DomainRecordDrawer';
 
-type ClassNames =
-  | 'root'
-  | 'cells'
-  | 'titles'
-  | 'linkContainer'
-  | 'cmrSpacing'
-  | 'addNewLink';
+type ClassNames = 'root' | 'cells' | 'linkContainer' | 'addNewLink';
 
 const styles = (theme: Theme) =>
   createStyles({
     root: {
-      [theme.breakpoints.down('xs')]: {
-        flexDirection: 'column',
-        alignItems: 'flex-start'
+      margin: 0,
+      '& .MuiGrid-item': {
+        paddingLeft: 0
+      },
+      [theme.breakpoints.down('sm')]: {
+        marginLeft: theme.spacing(),
+        marginRight: theme.spacing()
       }
     },
     cells: {
@@ -81,31 +77,15 @@ const styles = (theme: Theme) =>
       '& .data': {
         maxWidth: 300,
         overflow: 'hidden',
-        whiteSpace: 'nowrap',
         textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
         [theme.breakpoints.up('md')]: {
           maxWidth: 750
         }
       }
     },
-    titles: {
-      marginBottom: theme.spacing(1),
-      [theme.breakpoints.down('xs')]: {
-        marginTop: theme.spacing(2)
-      }
-    },
     linkContainer: {
-      position: 'relative',
-      top: theme.spacing(1) + 2,
-      [theme.breakpoints.down('xs')]: {
-        top: -10,
-        '& button': {
-          padding: 0
-        }
-      }
-    },
-    cmrSpacing: {
-      [theme.breakpoints.down('md')]: {
+      [theme.breakpoints.down('sm')]: {
         marginLeft: theme.spacing(),
         marginRight: theme.spacing()
       }
@@ -153,7 +133,9 @@ interface IType {
 }
 
 const createLink = (title: string, handler: () => void) => (
-  <AddNewLink onClick={handler} label={title} />
+  <Button buttonType="secondary" onClick={handler}>
+    {title}
+  </Button>
 );
 
 class DomainRecords extends React.Component<CombinedProps, State> {
@@ -688,11 +670,11 @@ class DomainRecords extends React.Component<CombinedProps, State> {
   };
 
   render() {
-    const { domain, domainRecords, classes, flags } = this.props;
+    const { domain, domainRecords, classes } = this.props;
     const { drawer, confirmDialog } = this.state;
 
     return (
-      <React.Fragment>
+      <>
         <DocumentTitleSegment segment={`${domain.domain} - DNS Records`} />
         {this.state.types.map((type, eachTypeIdx) => {
           const ref: React.Ref<any> = React.createRef();
@@ -702,7 +684,7 @@ class DomainRecords extends React.Component<CombinedProps, State> {
               <Grid
                 container
                 justify="space-between"
-                alignItems="flex-end"
+                alignItems="center"
                 className={classes.root}
               >
                 <Grid item ref={ref}>
@@ -710,10 +692,7 @@ class DomainRecords extends React.Component<CombinedProps, State> {
                     role="heading"
                     aria-level={2}
                     variant="h2"
-                    className={classnames({
-                      [classes.titles]: true,
-                      [classes.cmrSpacing]: flags.cmr
-                    })}
+                    className="m0"
                     data-qa-domain-record={type.title}
                   >
                     {type.title}
@@ -722,12 +701,7 @@ class DomainRecords extends React.Component<CombinedProps, State> {
                 {type.link && (
                   <Grid item>
                     {' '}
-                    <div
-                      className={classnames({
-                        [classes.linkContainer]: true,
-                        [classes.cmrSpacing]: flags.cmr
-                      })}
-                    >
+                    <div className={classes.linkContainer}>
                       {type.link()}
                     </div>{' '}
                   </Grid>
@@ -852,7 +826,7 @@ class DomainRecords extends React.Component<CombinedProps, State> {
           updateRecords={this.props.updateRecords}
           {...drawer.fields}
         />
-      </React.Fragment>
+      </>
     );
   }
 }


### PR DESCRIPTION
Remove the plus icons and the tags button from the upper right since all it did was scroll to the tags section at the bottom of the page