### PR TITLE
Change: Re-add and rework recycling for individual nodes

### DIFF
--- a/packages/api-v4/src/kubernetes/nodePools.ts
+++ b/packages/api-v4/src/kubernetes/nodePools.ts
@@ -83,3 +83,14 @@ export const recycleAllNodes = (clusterID: number, nodePoolID: number) =>
     setMethod('POST'),
     setURL(`${API_ROOT}/lke/clusters/${clusterID}/pools/${nodePoolID}/recycle`)
   );
+
+/**
+ * recycleNode
+ *
+ * Recycles a single nodes by id.
+ */
+export const recycleNode = (clusterID: number, nodeID: string) =>
+  Request<{}>(
+    setMethod('POST'),
+    setURL(`${API_ROOT}/lke/clusters/${clusterID}/nodes/${nodeID}/recycle`)
+  );

--- a/packages/api-v4/src/kubernetes/nodePools.ts
+++ b/packages/api-v4/src/kubernetes/nodePools.ts
@@ -87,7 +87,7 @@ export const recycleAllNodes = (clusterID: number, nodePoolID: number) =>
 /**
  * recycleNode
  *
- * Recycles a single nodes by id.
+ * Recycles a single node by id.
  */
 export const recycleNode = (clusterID: number, nodeID: string) =>
   Request<{}>(

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -2,7 +2,8 @@ import {
   getKubeConfig,
   getKubernetesClusterEndpoints,
   KubernetesEndpointResponse,
-  recycleAllNodes
+  recycleAllNodes,
+  recycleNode
 } from '@linode/api-v4/lib/kubernetes';
 import { APIError } from '@linode/api-v4/lib/types';
 import * as React from 'react';
@@ -279,12 +280,17 @@ export const KubernetesClusterDetail: React.FunctionComponent<CombinedProps> = p
   };
 
   const handleRecycleAllNodes = (nodePoolID: number) => {
-    return recycleAllNodes(cluster.id, nodePoolID).then(() => {
+    return recycleAllNodes(cluster.id, nodePoolID).then(response => {
       // Recycling nodes is an asynchronous process, and it probably won't make a difference to
       // request Node Pools here (it could be several seconds before statuses change). I thought
       // it was a good idea anyway, though.
       props.requestNodePools(cluster.id);
+      return response;
     });
+  };
+
+  const handleRecycleNode = (nodeID: string) => {
+    return recycleNode(cluster.id, nodeID);
   };
 
   return (
@@ -369,6 +375,7 @@ export const KubernetesClusterDetail: React.FunctionComponent<CombinedProps> = p
                   recycleAllNodes={(poolID: number) =>
                     handleRecycleAllNodes(poolID)
                   }
+                  recycleNode={handleRecycleNode}
                 />
               </Grid>
             </TabPanel>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeActionMenu.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeActionMenu.tsx
@@ -1,39 +1,48 @@
 import * as React from 'react';
-import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
+import ActionMenu from 'src/components/ActionMenu_CMR';
+import InlineMenuAction from 'src/components/InlineMenuAction';
+import { Theme, useMediaQuery, useTheme } from 'src/components/core/styles';
 
 interface Props {
-  instanceId?: number;
+  nodeId?: string;
   instanceLabel?: string;
-  openRecycleNodeDialog: (linodeId: number, linodeLabel: string) => void;
+  openRecycleNodeDialog: (nodeID: string, linodeLabel: string) => void;
 }
 
 export const NodeActionMenu: React.FC<Props> = props => {
-  const { instanceId, instanceLabel, openRecycleNodeDialog } = props;
+  const { nodeId, instanceLabel, openRecycleNodeDialog } = props;
+  const theme = useTheme<Theme>();
+  const matchesSmDown = useMediaQuery(theme.breakpoints.down('sm'));
 
-  const createActions = () => {
-    return (closeMenu: Function): Action[] => {
-      const actions = [
-        {
-          title: 'Recycle',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
-            if (!instanceId || !instanceLabel) {
-              return;
-            }
-            openRecycleNodeDialog(instanceId!, instanceLabel!);
-            closeMenu();
-            e.preventDefault();
-          },
-          disabled: !instanceId || !instanceLabel
+  const actions = [
+    {
+      title: 'Recycle',
+      onClick: () => {
+        if (!nodeId || !instanceLabel) {
+          return;
         }
-      ];
+        openRecycleNodeDialog(nodeId!, instanceLabel!);
+      },
+      disabled: !nodeId || !instanceLabel
+    }
+  ];
 
-      return actions;
-    };
-  };
-
-  return (
+  return !matchesSmDown ? (
+    // eslint-disable-next-line
+    <>
+      {actions.map(action => {
+        return (
+          <InlineMenuAction
+            key={action.title}
+            actionText={action.title}
+            onClick={action.onClick}
+          />
+        );
+      })}
+    </>
+  ) : (
     <ActionMenu
-      createActions={createActions()}
+      actionsList={actions}
       ariaLabel={`Action menu for Node ${instanceLabel}`}
     />
   );

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeActionMenu.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeActionMenu.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react';
 import ActionMenu from 'src/components/ActionMenu_CMR';
 import InlineMenuAction from 'src/components/InlineMenuAction';
-import { Theme, useMediaQuery, useTheme } from 'src/components/core/styles';
+import {
+  makeStyles,
+  Theme,
+  useMediaQuery,
+  useTheme
+} from 'src/components/core/styles';
 
 interface Props {
   nodeId?: string;
@@ -9,9 +14,18 @@ interface Props {
   openRecycleNodeDialog: (nodeID: string, linodeLabel: string) => void;
 }
 
+const useStyles = makeStyles(() => ({
+  root: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    alignItems: 'center'
+  }
+}));
+
 export const NodeActionMenu: React.FC<Props> = props => {
   const { nodeId, instanceLabel, openRecycleNodeDialog } = props;
   const theme = useTheme<Theme>();
+  const classes = useStyles();
   const matchesSmDown = useMediaQuery(theme.breakpoints.down('sm'));
 
   const actions = [
@@ -27,24 +41,24 @@ export const NodeActionMenu: React.FC<Props> = props => {
     }
   ];
 
-  return !matchesSmDown ? (
-    // eslint-disable-next-line
-    <>
-      {actions.map(action => {
-        return (
+  return (
+    <div className={classes.root}>
+      {!matchesSmDown ? (
+        actions.map(action => (
           <InlineMenuAction
             key={action.title}
             actionText={action.title}
             onClick={action.onClick}
+            disabled={action.disabled}
           />
-        );
-      })}
-    </>
-  ) : (
-    <ActionMenu
-      actionsList={actions}
-      ariaLabel={`Action menu for Node ${instanceLabel}`}
-    />
+        ))
+      ) : (
+        <ActionMenu
+          actionsList={actions}
+          ariaLabel={`Action menu for Node ${instanceLabel}`}
+        />
+      )}
+    </div>
   );
 };
 

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeDialog.tsx
@@ -55,9 +55,10 @@ const NodeDialog: React.FC<Props> = props => {
     >
       {error && <Notice error text={error} />}
       <Typography>
-        Are you sure you want to recycle this Node? The Linode will be deleted
-        and its data will be lost. A new Linode we be created to take its place.
-        It may take up to 30 minutes for the recycled Node to come back online.
+        Are you sure you want to recycle this node? The node will be deleted and
+        a new node will be created to replace it. Any local storage (such as
+        &quot;hostPath&quot; volumes) will be erased. This may take several
+        minutes.
       </Typography>
     </ConfirmationDialog>
   );

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
@@ -11,7 +11,7 @@ interface Props {
   nodes: PoolNodeResponse[];
   openDeletePoolDialog: (poolId: number) => void;
   openRecycleAllNodesDialog: (poolId: number) => void;
-  openRecycleNodeDialog: (linodeId: number, linodeLabel: string) => void;
+  openRecycleNodeDialog: (nodeID: string, linodeLabel: string) => void;
   handleClickResize: (poolId: number) => void;
 }
 

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.test.tsx
@@ -14,6 +14,7 @@ const props: Props = {
   deletePool: jest.fn(),
   addNodePool: jest.fn(),
   recycleAllNodes: jest.fn(),
+  recycleNode: jest.fn(),
   clusterLabel: 'a cluster'
 };
 

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -1,7 +1,7 @@
 import {
   PoolNodeRequest,
   PoolNodeResponse
-} from '@linode/api-v4/lib/kubernetes/types';
+} from '@linode/api-v4/lib/kubernetes';
 import classnames from 'classnames';
 import * as React from 'react';
 import { useSelector } from 'react-redux';
@@ -14,7 +14,6 @@ import Grid from 'src/components/Grid';
 import { ExtendedType } from 'src/store/linodeType/linodeType.reducer';
 import { useDialog } from 'src/hooks/useDialog';
 import useFlags from 'src/hooks/useFlags';
-import useLinodeActions from 'src/hooks/useLinodeActions';
 import { ApplicationState } from 'src/store';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { PoolNodeWithPrice } from '../../types';
@@ -73,7 +72,8 @@ export interface Props {
   ) => Promise<PoolNodeWithPrice>;
   deletePool: (poolID: number) => Promise<any>;
   addNodePool: (newPool: PoolNodeRequest) => Promise<PoolNodeResponse>;
-  recycleAllNodes: (poolID: number) => Promise<any>;
+  recycleAllNodes: (poolID: number) => Promise<{}>;
+  recycleNode: (nodeID: string) => Promise<{}>;
 }
 
 export const NodePoolsDisplay: React.FC<Props> = props => {
@@ -84,17 +84,16 @@ export const NodePoolsDisplay: React.FC<Props> = props => {
     addNodePool,
     updatePool,
     deletePool,
-    recycleAllNodes
+    recycleAllNodes,
+    recycleNode
   } = props;
 
   const classes = useStyles();
   const flags = useFlags();
 
-  const { deleteLinode } = useLinodeActions();
-
   const deletePoolDialog = useDialog<number>(deletePool);
   const recycleAllNodesDialog = useDialog<number>(recycleAllNodes);
-  const recycleNodeDialog = useDialog<number>(deleteLinode);
+  const recycleNodeDialog = useDialog<string>(recycleNode);
 
   const [numPoolsToDisplay, setNumPoolsToDisplay] = React.useState(25);
   const handleShowMore = () => {
@@ -174,7 +173,7 @@ export const NodePoolsDisplay: React.FC<Props> = props => {
     });
   };
 
-  const handleDeleteNode = () => {
+  const handleRecycleNode = () => {
     const { dialog, submitDialog, handleError } = recycleNodeDialog;
     if (!dialog.entityID) {
       return;
@@ -316,7 +315,7 @@ export const NodePoolsDisplay: React.FC<Props> = props => {
               loading={deletePoolDialog.dialog.isLoading}
             />
             <NodeDialog
-              onDelete={handleDeleteNode}
+              onDelete={handleRecycleNode}
               onClose={recycleNodeDialog.closeDialog}
               open={recycleNodeDialog.dialog.isOpen}
               error={recycleNodeDialog.dialog.error}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -3,6 +3,7 @@ import {
   PoolNodeResponse
 } from '@linode/api-v4/lib/kubernetes';
 import classnames from 'classnames';
+import { useSnackbar } from 'notistack';
 import * as React from 'react';
 import { useSelector } from 'react-redux';
 import { Waypoint } from 'react-waypoint';
@@ -90,6 +91,7 @@ export const NodePoolsDisplay: React.FC<Props> = props => {
 
   const classes = useStyles();
   const flags = useFlags();
+  const { enqueueSnackbar } = useSnackbar();
 
   const deletePoolDialog = useDialog<number>(deletePool);
   const recycleAllNodesDialog = useDialog<number>(recycleAllNodes);
@@ -178,11 +180,15 @@ export const NodePoolsDisplay: React.FC<Props> = props => {
     if (!dialog.entityID) {
       return;
     }
-    submitDialog(dialog.entityID).catch(err => {
-      handleError(
-        getAPIErrorOrDefault(err, 'Error recycling this node.')[0].reason
-      );
-    });
+    submitDialog(dialog.entityID)
+      .then(_ => {
+        enqueueSnackbar('Node queued for recycling.', { variant: 'success' });
+      })
+      .catch(err => {
+        handleError(
+          getAPIErrorOrDefault(err, 'Error recycling this node.')[0].reason
+        );
+      });
   };
 
   const handleRecycleAllNodes = () => {

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -180,7 +180,7 @@ export const NodePoolsDisplay: React.FC<Props> = props => {
     }
     submitDialog(dialog.entityID).catch(err => {
       handleError(
-        getAPIErrorOrDefault(err, 'Error deleting this Linode.')[0].reason
+        getAPIErrorOrDefault(err, 'Error recycling this node.')[0].reason
       );
     });
   };

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
@@ -23,8 +23,7 @@ import useLinodes from 'src/hooks/useLinodes';
 import { useReduxLoad } from 'src/hooks/useReduxLoad';
 import { LinodeWithMaintenanceAndDisplayStatus } from 'src/store/linodes/types';
 import { useRecentEventForLinode } from 'src/store/selectors/recentEventForLinode';
-// Temporarily hidden; @todo reactivate
-// import NodeActionMenu from './NodeActionMenu';
+import NodeActionMenu from './NodeActionMenu';
 
 const useStyles = makeStyles((theme: Theme) => ({
   labelCell: {
@@ -35,6 +34,12 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   ipCell: {
     width: '25%'
+  },
+  actionMenu: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    padding: 0
   },
   error: {
     color: theme.color.red
@@ -48,7 +53,7 @@ export interface Props {
   poolId: number;
   nodes: PoolNodeResponse[];
   typeLabel: string;
-  openRecycleNodeDialog: (linodeId: number, linodeLabel: string) => void;
+  openRecycleNodeDialog: (nodeID: string, linodeLabel: string) => void;
 }
 
 export const NodeTable: React.FC<Props> = props => {
@@ -110,8 +115,7 @@ export const NodeTable: React.FC<Props> = props => {
                       >
                         IP Address
                       </TableSortCell>
-                      {/* Hiding action menu until backend can support it properly. */}
-                      {/* <TableCell /> */}
+                      <TableCell className={classes.actionMenu} />
                     </TableRow>
                   </TableHead>
                   <TableBody>
@@ -124,6 +128,7 @@ export const NodeTable: React.FC<Props> = props => {
                         return (
                           <NodeRow
                             key={`node-row-${eachRow.nodeId}`}
+                            nodeId={eachRow.nodeId}
                             instanceId={eachRow.instanceId}
                             label={eachRow.label}
                             instanceStatus={eachRow.instanceStatus}
@@ -176,21 +181,23 @@ interface NodeRow {
   nodeStatus: string;
 }
 
-type NodeRowProps = Omit<NodeRow, 'nodeId'> & {
+interface NodeRowProps extends NodeRow {
   typeLabel: string;
   linodeError?: APIError[];
-  openRecycleNodeDialog: (linodeId: number, linodeLabel: string) => void;
-};
+  openRecycleNodeDialog: (nodeID: string, linodeLabel: string) => void;
+}
 
 export const NodeRow: React.FC<NodeRowProps> = React.memo(props => {
   const {
+    nodeId,
     instanceId,
     label,
     instanceStatus,
     ip,
     typeLabel,
     nodeStatus,
-    linodeError
+    linodeError,
+    openRecycleNodeDialog
   } = props;
 
   const classes = useStyles();
@@ -242,14 +249,13 @@ export const NodeRow: React.FC<NodeRowProps> = React.memo(props => {
           displayIP
         )}
       </TableCell>
-      {/* Hiding action menu until backend can support it properly. */}
-      {/* <TableCell>
-        {<NodeActionMenu
-          instanceId={instanceId}
+      <TableCell className={classes.actionMenu}>
+        <NodeActionMenu
+          nodeId={nodeId}
           instanceLabel={label}
           openRecycleNodeDialog={openRecycleNodeDialog}
         />
-      </TableCell> */}
+      </TableCell>
     </TableRow>
   );
 });
@@ -271,7 +277,6 @@ export const nodeToRow = (
 
   return {
     nodeId: node.id,
-    instanceId: foundLinode?.id,
     label: foundLinode?.label,
     instanceStatus: foundLinode?.status,
     ip: foundLinode?.ipv4[0],

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
@@ -13,11 +13,11 @@ import OrderBy from 'src/components/OrderBy';
 import Paginate from 'src/components/Paginate';
 import PaginationFooter from 'src/components/PaginationFooter';
 import StatusIndicator from 'src/components/StatusIndicator';
-import Table from 'src/components/Table';
-import TableCell from 'src/components/TableCell';
+import Table from 'src/components/Table/Table_CMR';
+import TableCell from 'src/components/TableCell/TableCell_CMR';
 import TableContentWrapper from 'src/components/TableContentWrapper';
 import TableRow from 'src/components/TableRow';
-import TableSortCell from 'src/components/TableSortCell';
+import TableSortCell from 'src/components/TableSortCell/TableSortCell_CMR';
 import { transitionText } from 'src/features/linodes/transitions';
 import useLinodes from 'src/hooks/useLinodes';
 import { useReduxLoad } from 'src/hooks/useReduxLoad';
@@ -34,12 +34,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   ipCell: {
     width: '25%'
-  },
-  actionMenu: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'flex-end',
-    padding: 0
   },
   error: {
     color: theme.color.red
@@ -82,10 +76,7 @@ export const NodeTable: React.FC<Props> = props => {
           }) => (
             <>
               <Paper>
-                <Table
-                  aria-label="List of Your Cluster Nodes"
-                  isResponsive={false}
-                >
+                <Table aria-label="List of Your Cluster Nodes">
                   <TableHead>
                     <TableRow>
                       <TableSortCell
@@ -115,7 +106,7 @@ export const NodeTable: React.FC<Props> = props => {
                       >
                         IP Address
                       </TableSortCell>
-                      <TableCell className={classes.actionMenu} />
+                      <TableCell />
                     </TableRow>
                   </TableHead>
                   <TableBody>
@@ -249,7 +240,7 @@ export const NodeRow: React.FC<NodeRowProps> = React.memo(props => {
           displayIP
         )}
       </TableCell>
-      <TableCell className={classes.actionMenu}>
+      <TableCell>
         <NodeActionMenu
           nodeId={nodeId}
           instanceLabel={label}

--- a/packages/manager/src/hooks/useDialog.ts
+++ b/packages/manager/src/hooks/useDialog.ts
@@ -1,10 +1,10 @@
 import { APIError } from '@linode/api-v4/lib/types';
 import * as React from 'react';
 
-export interface DialogState {
+export interface DialogState<T> {
   isOpen: boolean;
   isLoading: boolean;
-  entityID: number;
+  entityID: T;
   entityLabel?: string;
   error?: string;
 }
@@ -48,11 +48,11 @@ export interface DialogState {
  * @param request
  */
 
-export const useDialog = <T>(
+export const useDialog = <T extends string | number>(
   request: (params?: T) => Promise<any>
 ): {
-  dialog: DialogState;
-  openDialog: (id: number, label?: string) => void;
+  dialog: DialogState<T>;
+  openDialog: (id: T, label?: string) => void;
   closeDialog: () => void;
   submitDialog: (params: T) => Promise<any>;
   handleError: (e: string) => void;
@@ -60,7 +60,7 @@ export const useDialog = <T>(
   const [error, setErrors] = React.useState<string | undefined>();
   const [isOpen, setOpen] = React.useState<boolean>(false);
   const [isLoading, setLoading] = React.useState<boolean>(false);
-  const [entityID, setEntityID] = React.useState<number>(-1);
+  const [entityID, setEntityID] = React.useState<T>(-1 as T);
   const [entityLabel, setEntityLabel] = React.useState<string>('');
 
   const mountedRef = React.useRef<boolean>(true);
@@ -91,7 +91,7 @@ export const useDialog = <T>(
       });
   };
 
-  const openDialog = (id: number, label: string = '') => {
+  const openDialog = (id: T, label: string = '') => {
     setEntityLabel(label);
     setEntityID(id);
     setErrors(undefined);


### PR DESCRIPTION
## Description

- Add new undocumented API method for recycling a single node
- Uncomment the old NodeActionMenu and bring it up to date
- Adjust types and props to handle passing around the node ID
- Make useDialog's entityID `string | number`. Bit of chicanery involved.