### PR TITLE
M3-4782: Clearer explanation of implications of not having any Outbound FW rules

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable_CMR.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable_CMR.tsx
@@ -109,6 +109,9 @@ const FirewallRuleTable: React.FC<CombinedProps> = props => {
     openRuleDrawer(category, 'create');
   }, [openRuleDrawer, category]);
 
+  const zeroOutboundRulesMessage =
+    'No outbound rules have been added. When no outbound rules are present, all outbound traffic is allowed.';
+
   return (
     <>
       <div className={classes.header}>
@@ -179,7 +182,10 @@ const FirewallRuleTable: React.FC<CombinedProps> = props => {
               </TableHead>
               <TableBody>
                 {allRows.length === 0 ? (
-                  <TableRowEmptyState colSpan={5} />
+                  <TableRowEmptyState
+                    colSpan={5}
+                    message={zeroOutboundRulesMessage}
+                  />
                 ) : (
                   allRows.map((thisRuleRow: RuleRow) => (
                     <FirewallRuleTableRow


### PR DESCRIPTION
## Description
When no outbound rules are present for a firewall, all outbound traffic is allowed. The empty state of the Outbound Rules table now contains text stating this.

## Type of Change
- Non breaking change ('update', 'change')