### PR TITLE
M3-4747: Improve responsiveness of Linode Network Summary

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/DNSResolvers.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/DNSResolvers.tsx
@@ -17,12 +17,15 @@ const useStyles = makeStyles((theme: Theme) => ({
     }
   },
   wrapper: {
+    marginTop: 2,
+    marginRight: 0,
+    width: '100%',
     [theme.breakpoints.down('xs')]: {
       justifyContent: 'space-between'
     }
   },
   header: {
-    paddingBottom: theme.spacing() / 2
+    position: 'absolute'
   },
   ipAddress: {
     lineHeight: 1.43
@@ -63,7 +66,7 @@ export const DNSResolvers: React.FC<Props> = props => {
             </Typography>
           ))}
         </Grid>
-        <Grid item>
+        <Grid item style={{ paddingRight: 0 }}>
           {v6Resolvers.map(thisAddress => (
             <Typography
               key={`ip-resolver-item-${thisAddress}`}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/DNSResolvers.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/DNSResolvers.tsx
@@ -11,6 +11,7 @@ interface Props {
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
     overflowX: 'scroll',
+    overflowY: 'hidden',
     [theme.breakpoints.down('xs')]: {
       width: '100%'
     }

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/DNSResolvers.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/DNSResolvers.tsx
@@ -9,6 +9,17 @@ interface Props {
 }
 
 const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    overflowX: 'scroll',
+    [theme.breakpoints.down('xs')]: {
+      width: '100%'
+    }
+  },
+  wrapper: {
+    [theme.breakpoints.down('xs')]: {
+      justifyContent: 'space-between'
+    }
+  },
   header: {
     paddingBottom: theme.spacing() / 2
   },
@@ -30,11 +41,17 @@ export const DNSResolvers: React.FC<Props> = props => {
   const v6Resolvers = linodeRegion?.resolvers?.ipv6.split(',') ?? [];
 
   return (
-    <div>
+    <div className={classes.root}>
       <Typography className={classes.header}>
         <strong>DNS Resolvers</strong>
       </Typography>
-      <Grid container direction="row" wrap="nowrap" spacing={4}>
+      <Grid
+        container
+        direction="row"
+        wrap="nowrap"
+        spacing={4}
+        className={classes.wrapper}
+      >
         <Grid item>
           {v4Resolvers.map(thisAddress => (
             <Typography

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkingSummaryPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkingSummaryPanel.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
+import Grid from 'src/components/Grid';
 import DNSResolvers from './DNSResolvers';
 import NetworkTransfer from './NetworkTransfer';
 import TransferHistory from './TransferHistory';
-import Hidden from 'src/components/core/Hidden';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -18,28 +18,25 @@ const useStyles = makeStyles((theme: Theme) => ({
     }
   },
   transferHistoryContainer: {
-    padding: '16px 0px',
-    flex: 1,
-    [theme.breakpoints.up('sm')]: {
-      padding: '0px 16px'
-    },
-    [theme.breakpoints.up('md')]: {
+    [theme.breakpoints.up('lg')]: {
       maxWidth: 600
     },
     [theme.breakpoints.down('sm')]: {
-      paddingRight: 0,
-      width: '50%'
-    },
-    [theme.breakpoints.down('xs')]: {
-      paddingTop: theme.spacing(3),
-      paddingBottom: 0,
-      width: '100%'
+      order: 3
     }
   },
   dnsResolverContainer: {
-    paddingTop: 8,
-    [theme.breakpoints.up('md')]: {
-      paddingTop: 0
+    display: 'flex',
+    justifyContent: 'flex-end',
+    minWidth: 200,
+    [theme.breakpoints.up('sm')]: {
+      paddingRight: theme.spacing()
+    },
+    [theme.breakpoints.down('sm')]: {
+      order: 2
+    },
+    [theme.breakpoints.down('xs')]: {
+      justifyContent: 'center'
     }
   }
 }));
@@ -59,15 +56,23 @@ const LinodeNetworkingSummaryPanel: React.FC<CombinedProps> = props => {
 
   return (
     <Paper className={classes.root}>
-      <NetworkTransfer linodeID={linodeID} linodeLabel={linodeLabel} />
-      <div className={classes.transferHistoryContainer}>
-        <TransferHistory linodeID={linodeID} linodeCreated={linodeCreated} />
-      </div>
-      <Hidden smDown>
-        <div className={classes.dnsResolverContainer}>
+      <Grid container justify="space-between">
+        <Grid item xs={12} sm={6} md={3}>
+          <NetworkTransfer linodeID={linodeID} linodeLabel={linodeLabel} />
+        </Grid>
+        <Grid item xs={12} md={6} className={classes.transferHistoryContainer}>
+          <TransferHistory linodeID={linodeID} linodeCreated={linodeCreated} />
+        </Grid>
+        <Grid
+          item
+          xs={12}
+          sm={6}
+          md={3}
+          className={classes.dnsResolverContainer}
+        >
           <DNSResolvers region={linodeRegion} />
-        </div>
-      </Hidden>
+        </Grid>
+      </Grid>
     </Paper>
   );
 };

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkingSummaryPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkingSummaryPanel.tsx
@@ -18,9 +18,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     }
   },
   transferHistoryContainer: {
-    [theme.breakpoints.up('lg')]: {
-      maxWidth: 600
-    },
     [theme.breakpoints.down('sm')]: {
       order: 3
     }
@@ -28,7 +25,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   dnsResolverContainer: {
     display: 'flex',
     justifyContent: 'flex-end',
-    minWidth: 200,
     [theme.breakpoints.up('sm')]: {
       paddingRight: theme.spacing()
     },

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/TransferHistory.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/TransferHistory.tsx
@@ -187,7 +187,7 @@ export const TransferHistory: React.FC<TransferHistoryProps> = props => {
       ) : (
         <LineGraph
           timezone={profile.data?.timezone ?? 'UTC'}
-          chartHeight={140}
+          chartHeight={190}
           unit={`/s`}
           formatData={convertNetworkData}
           formatTooltip={_formatTooltip}


### PR DESCRIPTION
Instead of hiding the "DNS Resolvers" column, I swapped the order with the "Network Transfer History" graph and moved that to its own row starting at 960px

Since the content in the "DNS Resolvers" column also varies, I added a horizontal scroll to prevent it from overlapping with the "Network Transfer History" graph

---

**Screenshots**
<details>
<summary>Before</summary>
1280px:
<img width="1067" alt="Screen Shot 2021-01-13 at 11 22 35 AM" src="https://user-images.githubusercontent.com/7692354/104479624-a57d4000-5591-11eb-91cb-252327a76e39.png">
< 960px:
<img width="964" alt="Screen Shot 2021-01-13 at 11 22 13 AM" src="https://user-images.githubusercontent.com/7692354/104479647-ac0bb780-5591-11eb-92e3-3b2d8eda5557.png">
< 600px:
<br>
<img width="603" alt="Screen Shot 2021-01-13 at 11 21 57 AM" src="https://user-images.githubusercontent.com/7692354/104479690-b8901000-5591-11eb-958f-639387a5d022.png">
</details>

<details>
<summary>After</summary>
1280px:
<img width="1075" alt="Screen Shot 2021-01-13 at 11 01 19 AM" src="https://user-images.githubusercontent.com/7692354/104477128-d6a84100-558e-11eb-983a-f88af601af3b.png">
< 960px:
<img width="965" alt="Screen Shot 2021-01-13 at 11 06 09 AM" src="https://user-images.githubusercontent.com/7692354/104477678-65b55900-558f-11eb-8140-27331f29dd23.png">
< 600px:
<br>
<img width="606" alt="Screen Shot 2021-01-13 at 11 11 40 AM" src="https://user-images.githubusercontent.com/7692354/104478424-466afb80-5590-11eb-91f2-11de93dc357d.png">
</details>