### PR TITLE
M3-4763: Update URL appropriately when opening, closing, and navigating to Resize, Rebuild, Rescue, & Migrate modals

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
@@ -1,6 +1,6 @@
 import { Config, Disk, LinodeStatus } from '@linode/api-v4/lib/linodes';
 import * as React from 'react';
-import { useHistory, useRouteMatch } from 'react-router-dom';
+import { useHistory, useRouteMatch, useLocation } from 'react-router-dom';
 import { compose } from 'recompose';
 import CircleProgress from 'src/components/CircleProgress';
 import TagDrawer from 'src/components/TagCell/TagDrawer';
@@ -65,6 +65,13 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
     path: '/linodes/:linodeId/:subpath'
   });
   const isSubpath = (subpath: string) => match?.params?.subpath === subpath;
+
+  // Related to the above, you should also be able to navigate directly to a Linode
+  // detail tab and have the correct modal open based on the query parameter, if provided.
+  const location = useLocation();
+  const isQueryParameter = (queryParam: string) =>
+    location.search === queryParam;
+
   const matchedLinodeId = Number(match?.params?.linodeId ?? 0);
 
   const notificationContext = React.useContext(_notificationContext);
@@ -84,22 +91,22 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
   });
 
   const [resizeDialog, setResizeDialog] = React.useState<DialogProps>({
-    open: isSubpath('resize'),
+    open: isSubpath('resize') || isQueryParameter('?resize=true'),
     linodeID: matchedLinodeId
   });
 
   const [migrateDialog, setMigrateDialog] = React.useState<DialogProps>({
-    open: isSubpath('migrate'),
+    open: isSubpath('migrate') || isQueryParameter('?migrate=true'),
     linodeID: matchedLinodeId
   });
 
   const [rescueDialog, setRescueDialog] = React.useState<DialogProps>({
-    open: isSubpath('rescue'),
+    open: isSubpath('rescue') || isQueryParameter('?rescue=true'),
     linodeID: matchedLinodeId
   });
 
   const [rebuildDialog, setRebuildDialog] = React.useState<DialogProps>({
-    open: isSubpath('rebuild'),
+    open: isSubpath('rebuild') || isQueryParameter('?rebuild=true'),
     linodeID: matchedLinodeId
   });
 
@@ -151,6 +158,7 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
           open: true,
           linodeID
         }));
+        history.push(`?migrate=true`);
         break;
       case 'resize':
         setResizeDialog(resizeDialog => ({
@@ -158,6 +166,7 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
           open: true,
           linodeID
         }));
+        history.push(`?resize=true`);
         break;
       case 'rescue':
         setRescueDialog(rescueDialog => ({
@@ -165,6 +174,7 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
           open: true,
           linodeID
         }));
+        history.push(`?rescue=true`);
         break;
       case 'rebuild':
         setRebuildDialog(rebuildDialog => ({
@@ -172,6 +182,7 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
           open: true,
           linodeID
         }));
+        history.push(`?rebuild=true`);
         break;
       case 'enable_backups':
         setBackupsDialog(backupsDialog => ({
@@ -194,6 +205,20 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
     ) {
       history.replace(`/linodes/${match?.params.linodeId}`);
     }
+
+    // If the user is on a Linode detail tab with the modal open and they then close it,
+    // change the URL to reflect just the tab they are on.
+    if (
+      isQueryParameter('?resize=true') ||
+      isQueryParameter('?rescue=true') ||
+      isQueryParameter('?rebuild=true') ||
+      isQueryParameter('?migrate=true')
+    ) {
+      history.replace(
+        `/linodes/${match?.params.linodeId}/${match?.params?.subpath}`
+      );
+    }
+
     setPowerDialog(powerDialog => ({ ...powerDialog, open: false }));
     setDeleteDialog(deleteDialog => ({ ...deleteDialog, open: false }));
     setResizeDialog(resizeDialog => ({ ...resizeDialog, open: false }));

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
@@ -69,8 +69,8 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
 
   // Related to the above, you should also be able to navigate directly to a Linode
   // detail tab and have the correct modal open based on the query parameter, if provided.
-  // see uses of parseQueryParams(location.search)
   const location = useLocation();
+  const queryParams = parseQueryParams(location.search);
 
   const matchedLinodeId = Number(match?.params?.linodeId ?? 0);
 
@@ -91,22 +91,22 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
   });
 
   const [resizeDialog, setResizeDialog] = React.useState<DialogProps>({
-    open: isSubpath('resize') || parseQueryParams(location.search).resize,
+    open: isSubpath('resize') || queryParams.resize,
     linodeID: matchedLinodeId
   });
 
   const [migrateDialog, setMigrateDialog] = React.useState<DialogProps>({
-    open: isSubpath('migrate') || parseQueryParams(location.search).migrate,
+    open: isSubpath('migrate') || queryParams.migrate,
     linodeID: matchedLinodeId
   });
 
   const [rescueDialog, setRescueDialog] = React.useState<DialogProps>({
-    open: isSubpath('rescue') || parseQueryParams(location.search).rescue,
+    open: isSubpath('rescue') || queryParams.rescue,
     linodeID: matchedLinodeId
   });
 
   const [rebuildDialog, setRebuildDialog] = React.useState<DialogProps>({
-    open: isSubpath('rebuild') || parseQueryParams(location.search).rebuild,
+    open: isSubpath('rebuild') || queryParams.rebuild,
     linodeID: matchedLinodeId
   });
 
@@ -158,7 +158,7 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
           open: true,
           linodeID
         }));
-        history.replace({ search: '?migrate=true' });
+        history.replace({ search: 'migrate=true' });
         break;
       case 'resize':
         setResizeDialog(resizeDialog => ({
@@ -166,7 +166,7 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
           open: true,
           linodeID
         }));
-        history.replace({ search: '?resize=true' });
+        history.replace({ search: 'resize=true' });
         break;
       case 'rescue':
         setRescueDialog(rescueDialog => ({
@@ -174,7 +174,7 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
           open: true,
           linodeID
         }));
-        history.replace({ search: '?rescue=true' });
+        history.replace({ search: 'rescue=true' });
         break;
       case 'rebuild':
         setRebuildDialog(rebuildDialog => ({
@@ -182,7 +182,7 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
           open: true,
           linodeID
         }));
-        history.replace({ search: '?rebuild=true' });
+        history.replace({ search: 'rebuild=true' });
         break;
       case 'enable_backups':
         setBackupsDialog(backupsDialog => ({
@@ -209,10 +209,10 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
     // If the user is on a Linode detail tab with the modal open and they then close it,
     // change the URL to reflect just the tab they are on.
     if (
-      parseQueryParams(location.search).resize ||
-      parseQueryParams(location.search).rescue ||
-      parseQueryParams(location.search).rebuild ||
-      parseQueryParams(location.search).migrate
+      queryParams.resize ||
+      queryParams.rescue ||
+      queryParams.rebuild ||
+      queryParams.migrate
     ) {
       history.replace({ search: undefined });
     }

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
@@ -29,6 +29,7 @@ import HostMaintenance from './HostMaintenance';
 import MutationNotification from './MutationNotification';
 import Notifications from './Notifications';
 import LinodeDetailsBreadcrumb from './LinodeDetailsBreadcrumb';
+import { parseQueryParams } from 'src/utilities/queryParams';
 
 interface Props {
   numVolumes: number;
@@ -68,9 +69,8 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
 
   // Related to the above, you should also be able to navigate directly to a Linode
   // detail tab and have the correct modal open based on the query parameter, if provided.
+  // see uses of parseQueryParams(location.search)
   const location = useLocation();
-  const isQueryParameter = (queryParam: string) =>
-    location.search === queryParam;
 
   const matchedLinodeId = Number(match?.params?.linodeId ?? 0);
 
@@ -91,22 +91,22 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
   });
 
   const [resizeDialog, setResizeDialog] = React.useState<DialogProps>({
-    open: isSubpath('resize') || isQueryParameter('?resize=true'),
+    open: isSubpath('resize') || parseQueryParams(location.search).resize,
     linodeID: matchedLinodeId
   });
 
   const [migrateDialog, setMigrateDialog] = React.useState<DialogProps>({
-    open: isSubpath('migrate') || isQueryParameter('?migrate=true'),
+    open: isSubpath('migrate') || parseQueryParams(location.search).migrate,
     linodeID: matchedLinodeId
   });
 
   const [rescueDialog, setRescueDialog] = React.useState<DialogProps>({
-    open: isSubpath('rescue') || isQueryParameter('?rescue=true'),
+    open: isSubpath('rescue') || parseQueryParams(location.search).rescue,
     linodeID: matchedLinodeId
   });
 
   const [rebuildDialog, setRebuildDialog] = React.useState<DialogProps>({
-    open: isSubpath('rebuild') || isQueryParameter('?rebuild=true'),
+    open: isSubpath('rebuild') || parseQueryParams(location.search).rebuild,
     linodeID: matchedLinodeId
   });
 
@@ -158,7 +158,7 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
           open: true,
           linodeID
         }));
-        history.push(`?migrate=true`);
+        history.replace({ search: '?migrate=true' });
         break;
       case 'resize':
         setResizeDialog(resizeDialog => ({
@@ -166,7 +166,7 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
           open: true,
           linodeID
         }));
-        history.push(`?resize=true`);
+        history.replace({ search: '?resize=true' });
         break;
       case 'rescue':
         setRescueDialog(rescueDialog => ({
@@ -174,7 +174,7 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
           open: true,
           linodeID
         }));
-        history.push(`?rescue=true`);
+        history.replace({ search: '?rescue=true' });
         break;
       case 'rebuild':
         setRebuildDialog(rebuildDialog => ({
@@ -182,7 +182,7 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
           open: true,
           linodeID
         }));
-        history.push(`?rebuild=true`);
+        history.replace({ search: '?rebuild=true' });
         break;
       case 'enable_backups':
         setBackupsDialog(backupsDialog => ({
@@ -209,14 +209,12 @@ const LinodeDetailHeader: React.FC<CombinedProps> = props => {
     // If the user is on a Linode detail tab with the modal open and they then close it,
     // change the URL to reflect just the tab they are on.
     if (
-      isQueryParameter('?resize=true') ||
-      isQueryParameter('?rescue=true') ||
-      isQueryParameter('?rebuild=true') ||
-      isQueryParameter('?migrate=true')
+      parseQueryParams(location.search).resize ||
+      parseQueryParams(location.search).rescue ||
+      parseQueryParams(location.search).rebuild ||
+      parseQueryParams(location.search).migrate
     ) {
-      history.replace(
-        `/linodes/${match?.params.linodeId}/${match?.params?.subpath}`
-      );
+      history.replace({ search: undefined });
     }
 
     setPowerDialog(powerDialog => ({ ...powerDialog, open: false }));


### PR DESCRIPTION
## Description
Update the URL appropriately when opening, closing, and navigating to Linode Resize, Rebuild, Rescue, & Migrate modals.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers
The following scenarios should work:
1. Navigating to, for example, `/linodes/:id/resize` should still work as it did before.
2. From any tab in Linode details, clicking Resize/Rebuild/Rescue/Migrate should add said action to the URL as a query param (i.e. if you click Resize, "?resize=true" should be appended)
3. Navigating directly to a Linode details tab with a modal indicated to be open (e.g., `/linodes/:id/storage?rebuild=true`) should take you to the appropriate tab with the appropriate modal open.
4. Closing the modal should return you to the appropriate tab and update the URL accordingly.
