### PR TITLE
Hotfix: Make sure inline action isn't disabled

### DIFF
--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
@@ -200,7 +200,7 @@ export const LinodeActionMenu: React.FC<CombinedProps> = props => {
           className: classes.link,
           disabled:
             linodeStatus !== 'running' ||
-            !hasMadeConfigsRequest ||
+            (!hasMadeConfigsRequest && matchesSmDown) ||
             readOnly ||
             Boolean(configsError?.[0]?.reason),
           tooltip: readOnly


### PR DESCRIPTION
## Description

Merging inline and normal actions led to the Reboot action breaking, since (for good reasons) we don't request a Linode's configs until someone opens the menu for that Linode.

I'd like to remove this whole configs check from the action menu. I've never been a fan, and there's a useful error if you try to reboot a Linode without configs from the API. Conversation for another day.