### PR TITLE
POC: Make visual indicator for "Skip to Main Content" link

### DIFF
--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -186,12 +186,8 @@ export class App extends React.Component<CombinedProps, State> {
 
     return (
       <React.Fragment>
-        {/** Accessibility helpers */}
-        {/* TODO these should become visible on focus as per: https://www.w3.org/TR/WCAG20-TECHS/G1 */}
-        <a href="#main-navigation" className="visually-hidden">
-          Skip to main navigation
-        </a>
-        <a href="#main-content" className="visually-hidden">
+        {/** Accessibility helper */}
+        <a href="#main-content" className="skip-link">
           Skip to main content
         </a>
         <div hidden>

--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -131,6 +131,23 @@ const useStyles = makeStyles((theme: Theme) => ({
       width: '50%',
       margin: '0 auto'
     }
+  },
+  skipLink: {
+    display: 'flex',
+    justifyContent: 'center',
+    background: '#17cf73',
+    color: 'white',
+    fontSize: '0.75rem',
+    letterSpacing: '1.5px',
+    padding: theme.spacing(),
+    position: 'absolute',
+    top: -40,
+    textTransform: 'uppercase',
+    width: 190,
+    zIndex: 9999,
+    '&:focus': {
+      top: 0
+    }
   }
 }));
 
@@ -287,6 +304,9 @@ const MainContent: React.FC<CombinedProps> = props => {
         [classes.hidden]: props.appIsLoading
       })}
     >
+      <a href="#main-content" className={classes.skipLink}>
+        Skip to main content
+      </a>
       <PreferenceToggle<boolean>
         preferenceKey="desktop_sidebar_open"
         preferenceOptions={[true, false]}
@@ -336,6 +356,7 @@ const MainContent: React.FC<CombinedProps> = props => {
                       className={classes.cmrWrapper}
                       id="main-content"
                       role="main"
+                      tabIndex={-1}
                     >
                       <Grid container spacing={0} className={classes.grid}>
                         <Grid item className={`${classes.switchWrapper} p0`}>

--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -336,7 +336,6 @@ const MainContent: React.FC<CombinedProps> = props => {
                       className={classes.cmrWrapper}
                       id="main-content"
                       role="main"
-                      tabIndex={-1}
                     >
                       <Grid container spacing={0} className={classes.grid}>
                         <Grid item className={`${classes.switchWrapper} p0`}>

--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -135,14 +135,13 @@ const useStyles = makeStyles((theme: Theme) => ({
   skipLink: {
     display: 'flex',
     justifyContent: 'center',
-    background: '#17cf73',
+    background: theme.palette.primary.main,
     color: 'white',
-    fontSize: '0.75rem',
-    letterSpacing: '1.5px',
+    fontFamily: theme.font.bold,
+    fontSize: '0.875rem',
     padding: theme.spacing(),
     position: 'absolute',
     top: -40,
-    textTransform: 'uppercase',
     width: 190,
     zIndex: 9999,
     '&:focus': {

--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -131,22 +131,6 @@ const useStyles = makeStyles((theme: Theme) => ({
       width: '50%',
       margin: '0 auto'
     }
-  },
-  skipLink: {
-    display: 'flex',
-    justifyContent: 'center',
-    background: theme.palette.primary.main,
-    color: 'white',
-    fontFamily: theme.font.bold,
-    fontSize: '0.875rem',
-    padding: theme.spacing(),
-    position: 'absolute',
-    top: -40,
-    width: 190,
-    zIndex: 9999,
-    '&:focus': {
-      top: 0
-    }
   }
 }));
 
@@ -303,9 +287,6 @@ const MainContent: React.FC<CombinedProps> = props => {
         [classes.hidden]: props.appIsLoading
       })}
     >
-      <a href="#main-content" className={classes.skipLink}>
-        Skip to main content
-      </a>
       <PreferenceToggle<boolean>
         preferenceKey="desktop_sidebar_open"
         preferenceOptions={[true, false]}

--- a/packages/manager/src/index.css
+++ b/packages/manager/src/index.css
@@ -376,3 +376,21 @@ button::-moz-focus-inner {
 .overflow-hidden {
   overflow: hidden !important;
 }
+
+.skip-link {
+  display: flex;
+  justify-content: center;
+  background: #3683dc;
+  color: white;
+  font-size: 14px;
+  font-weight: bold;
+  padding: 8px;
+  position: absolute;
+  top: -40px;
+  width: 190px;
+  z-index: 9999;
+}
+
+.skip-link:focus {
+  top: 0;
+}


### PR DESCRIPTION
## Description

~~Since our navigation is pretty lengthy, I created a hidden "Skip to Main Content" link that is only visible when the user starts to tab through the website. This way users navigating with the keyboard can bypass tabbing through the sidebar and the top nav when they reload the page~~

We already have one so I added some styles that would show up on focus instead

Here's a link for more info: [https://webaim.org/techniques/skipnav/](https://webaim.org/techniques/skipnav/)

## Note to Reviewers

After clicking on the skip link, it should take you to the first element in the main content which is usually the breadcrumb which doesn't have a focus state but you should be able to traverse to the documentation and the create button pretty quickly 
