### PR TITLE
M3-4780 Change: Sort Firewall rule ports

### DIFF
--- a/packages/api-v4/src/firewalls/firewalls.schema.ts
+++ b/packages/api-v4/src/firewalls/firewalls.schema.ts
@@ -44,7 +44,7 @@ export const FirewallRuleTypeSchema = object().shape({
     then: string()
       .required('Ports are required for TCP and UDP protocols.')
       .matches(
-        /^([0-9\-]+,?)+$/,
+        /^([0-9\-]+,?\s?)+$/,
         'Ports must be an integer, range of integers, or a comma-separated list of integers.'
       ),
     // Workaround to get the test to fail if ports is defined when protocol === ICMP

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
@@ -571,7 +571,7 @@ export const validateForm = (protocol?: string, ports?: string) => {
     return errors;
   }
 
-  if (ports && !ports.match(/^([0-9\-]+,?)+$/)) {
+  if (ports && !ports.match(/^([0-9\-]+,?\s?)+$/)) {
     errors.ports =
       'Ports must be an integer, range of integers, or a comma-separated list of integers.';
   }

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
@@ -573,7 +573,7 @@ export const validateForm = (protocol?: string, ports?: string) => {
 
   if (ports && !ports.match(/^([0-9\-]+,?)+$/)) {
     errors.ports =
-      'Ports be an integer, range of integers, or a comma-separated list of integers.';
+      'Ports must be an integer, range of integers, or a comma-separated list of integers.';
   }
 
   return errors;

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.test.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.test.tsx
@@ -29,6 +29,10 @@ describe('Firewall rule table tests', () => {
       expect(sortPortString('443, 22, 80-81')).toMatch('22, 80-81, 443');
     });
 
+    it('should handle whitespace variations', () => {
+      expect(sortPortString('443,22,80-81')).toMatch('22, 80-81, 443');
+    });
+
     it('should return the string unaltered with bad input', () => {
       expect(sortPortString('')).toBe('');
       expect(sortPortString('33, XX-gibberish')).toMatch('33, XX-gibberish');

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.test.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.test.tsx
@@ -1,20 +1,37 @@
 import { ExtendedFirewallRule } from './firewallRuleEditor';
-import { firewallRuleToRowData } from './FirewallRuleTable';
+import { firewallRuleToRowData, sortPortString } from './FirewallRuleTable';
 
-describe('firewallRuleToRowData', () => {
-  it('transforms a FirewallRuleType to the appropriate row', () => {
-    const rule: ExtendedFirewallRule = {
-      ports: '22',
-      protocol: 'TCP',
-      addresses: { ipv4: ['0.0.0.0/0'], ipv6: ['::/0'] },
-      status: 'NOT_MODIFIED'
-    };
-    expect(firewallRuleToRowData([rule])[0]).toHaveProperty('type', 'SSH');
-    expect(firewallRuleToRowData([rule])[0]).toHaveProperty('protocol', 'TCP');
-    expect(firewallRuleToRowData([rule])[0]).toHaveProperty('ports', '22');
-    expect(firewallRuleToRowData([rule])[0]).toHaveProperty(
-      'addresses',
-      'All IPv4, All IPv6'
-    );
+describe('Firewall rule table tests', () => {
+  describe('firewallRuleToRowData', () => {
+    it('transforms a FirewallRuleType to the appropriate row', () => {
+      const rule: ExtendedFirewallRule = {
+        ports: '22',
+        protocol: 'TCP',
+        addresses: { ipv4: ['0.0.0.0/0'], ipv6: ['::/0'] },
+        status: 'NOT_MODIFIED'
+      };
+      expect(firewallRuleToRowData([rule])[0]).toHaveProperty('type', 'SSH');
+      expect(firewallRuleToRowData([rule])[0]).toHaveProperty(
+        'protocol',
+        'TCP'
+      );
+      expect(firewallRuleToRowData([rule])[0]).toHaveProperty('ports', '22');
+      expect(firewallRuleToRowData([rule])[0]).toHaveProperty(
+        'addresses',
+        'All IPv4, All IPv6'
+      );
+    });
+  });
+
+  describe('sortPortString utility', () => {
+    it('should sort ports numerically', () => {
+      expect(sortPortString('80, 22')).toMatch('22, 80');
+      expect(sortPortString('443, 22, 80-81')).toMatch('22, 80-81, 443');
+    });
+
+    it('should return the string unaltered with bad input', () => {
+      expect(sortPortString('')).toBe('');
+      expect(sortPortString('33, XX-gibberish')).toMatch('33, XX-gibberish');
+    });
   });
 });

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -343,3 +343,38 @@ export const firewallRuleToRowData = (
     };
   });
 };
+
+/**
+ * Sorts ports string returned by the API into something more intuitive for users.
+ * Examples:
+ * "80, 22" --> "22, 80"
+ * "443, 22, 80-81" --> "22, 80-81, 443"
+ */
+export const sortPortString = (portString: string) => {
+  try {
+    const ports = portString.split(', ');
+    return ports.sort(sortString).join(', ');
+  } catch {
+    // API responses should always work with this logic,
+    // but in case we get bad input, return the unsorted/unaltered string.
+    return portString;
+  }
+};
+
+// Custom sort helper for working with port strings
+const sortString = (_a: string, _b: string) => {
+  const a = Number(stripHyphen(_a));
+  const b = Number(stripHyphen(_b));
+  if (a > b) {
+    return 1;
+  }
+  if (a < b) {
+    return -1;
+  }
+  return 0;
+};
+
+// If a port range is included (80-1000) return the first element of the range
+const stripHyphen = (str: string) => {
+  return str.match(/-/) ? str.split('-')[0] : str;
+};

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -337,6 +337,7 @@ export const firewallRuleToRowData = (
 
     return {
       ...thisRule,
+      ports: sortPortString(thisRule.ports),
       type: generateRuleLabel(ruleType),
       addresses: generateAddressesLabel(thisRule.addresses),
       id: idx

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -356,7 +356,7 @@ export const sortPortString = (portString: string) => {
     const ports = portString.split(',');
     return ports
       .sort(sortString)
-      .map(i => i.trim())
+      .map(port => port.trim())
       .join(', ');
   } catch {
     // API responses should always work with this logic,

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -352,8 +352,11 @@ export const firewallRuleToRowData = (
  */
 export const sortPortString = (portString: string) => {
   try {
-    const ports = portString.split(', ');
-    return ports.sort(sortString).join(', ');
+    const ports = portString.split(',');
+    return ports
+      .sort(sortString)
+      .map(i => i.trim())
+      .join(', ');
   } catch {
     // API responses should always work with this logic,
     // but in case we get bad input, return the unsorted/unaltered string.


### PR DESCRIPTION
## Description

Sort ports more intuitively in the Firewall rules table. See comments for examples, or check the ticket (where I took the examples from).

## Note to Reviewers

I'll rebase to fix the diff once #7315  is merged; if you look at the last 3 commits in the meantime you'll see the real changes here.