### PR TITLE
M3-4787 Add: modal for upgrading LKE minor version

### DIFF
--- a/packages/api-v4/src/kubernetes/kubernetes.ts
+++ b/packages/api-v4/src/kubernetes/kubernetes.ts
@@ -97,9 +97,11 @@ export const getKubeConfig = (clusterId: number) =>
  *
  */
 
-export const getKubernetesVersions = () =>
+export const getKubernetesVersions = (params?: any, filters?: any) =>
   Request<Page<KubernetesVersion>>(
     setMethod('GET'),
+    setXFilter(filters),
+    setParams(params),
     setURL(`${API_ROOT}/lke/versions`)
   );
 

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -32,6 +32,7 @@ import { getAllWithArguments } from 'src/utilities/getAll';
 import { ExtendedCluster, PoolNodeWithPrice } from '.././types';
 import KubeSummaryPanel from './KubeSummaryPanel';
 import NodePoolsDisplay from './NodePoolsDisplay';
+import UpgradeKubernetesVersionBanner from './UpgradeKubernetesVersionBanner';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -299,6 +300,9 @@ export const KubernetesClusterDetail: React.FunctionComponent<CombinedProps> = p
   return (
     <React.Fragment>
       <DocumentTitleSegment segment={`Kubernetes Cluster ${cluster.label}`} />
+      <Grid item>
+        <UpgradeKubernetesVersionBanner currentVersion={cluster.k8s_version} />
+      </Grid>
       <Grid
         container
         className={classes.root}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -301,7 +301,10 @@ export const KubernetesClusterDetail: React.FunctionComponent<CombinedProps> = p
     <React.Fragment>
       <DocumentTitleSegment segment={`Kubernetes Cluster ${cluster.label}`} />
       <Grid item>
-        <UpgradeKubernetesVersionBanner currentVersion={cluster.k8s_version} />
+        <UpgradeKubernetesVersionBanner
+          clusterID={cluster.id}
+          currentVersion={cluster.k8s_version}
+        />
       </Grid>
       <Grid
         container

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
@@ -48,7 +48,7 @@ const NodePool: React.FC<Props> = props => {
             buttonType="secondary"
             onClick={() => openRecycleAllNodesDialog(poolId)}
           >
-            Recycle Nodes
+            Recycle Pool
           </Button>
           <Button
             buttonType="secondary"

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
@@ -48,7 +48,7 @@ const NodePool: React.FC<Props> = props => {
             buttonType="secondary"
             onClick={() => openRecycleAllNodesDialog(poolId)}
           >
-            Recycle Pool
+            Recycle Pool Nodes
           </Button>
           <Button
             buttonType="secondary"

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -254,7 +254,7 @@ export const NodePoolsDisplay: React.FC<Props> = props => {
             className={`${classes.button} ${classes.mobileSpacing}`}
             onClick={() => recycleAllClusterNodesDialog.openDialog(undefined)}
           >
-            Recycle All Nodes
+            Recycle Cluster
           </Button>
           <Button
             buttonType="primary"

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -254,7 +254,7 @@ export const NodePoolsDisplay: React.FC<Props> = props => {
             className={`${classes.button} ${classes.mobileSpacing}`}
             onClick={() => recycleAllClusterNodesDialog.openDialog(undefined)}
           >
-            Recycle Cluster
+            Recycle All Nodes
           </Button>
           <Button
             buttonType="primary"

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/RecycleAllPoolNodesDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/RecycleAllPoolNodesDialog.tsx
@@ -36,7 +36,7 @@ const renderActions = (
         data-qa-confirm
         data-testid={'dialog-confirm'}
       >
-        Recycle all Nodes
+        Recycle Pool
       </Button>
     </ActionsPanel>
   );
@@ -48,16 +48,16 @@ const RecycleAllPoolNodesDialog: React.FC<Props> = props => {
   return (
     <ConfirmationDialog
       open={open}
-      title="Recycle all nodes?"
+      title="Recycle node pool?"
       onClose={onClose}
       actions={() => renderActions(loading, onClose, onSubmit)}
     >
       {error && <Notice error text={error} />}
       <Typography>
-        Are you sure you want to recycle the nodes in this pool? All nodes will
-        be deleted and new nodes will be created to replace them. Any local
-        storage (such as &apos;hostPath&apos; volumes) will be erased. This may
-        take several minutes, as nodes will be replaced on a rolling basis.
+        Are you sure you want to recycle this pool? All nodes will be deleted
+        and new nodes will be created to replace them. Any local storage (such
+        as &apos;hostPath&apos; volumes) will be erased. This may take several
+        minutes, as nodes will be replaced on a rolling basis.
       </Typography>
     </ConfirmationDialog>
   );

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/RecycleAllPoolNodesDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/RecycleAllPoolNodesDialog.tsx
@@ -36,7 +36,7 @@ const renderActions = (
         data-qa-confirm
         data-testid={'dialog-confirm'}
       >
-        Recycle Pool
+        Recycle Pool Nodes
       </Button>
     </ActionsPanel>
   );
@@ -54,10 +54,10 @@ const RecycleAllPoolNodesDialog: React.FC<Props> = props => {
     >
       {error && <Notice error text={error} />}
       <Typography>
-        Are you sure you want to recycle this pool? All nodes will be deleted
-        and new nodes will be created to replace them. Any local storage (such
-        as &apos;hostPath&apos; volumes) will be erased. This may take several
-        minutes, as nodes will be replaced on a rolling basis.
+        Are you sure you want to recycle the nodes in this pool? All nodes will
+        be deleted and new nodes will be created to replace them. Any local
+        storage (such as &apos;hostPath&apos; volumes) will be erased. This may
+        take several minutes, as nodes will be replaced on a rolling basis.
       </Typography>
     </ConfirmationDialog>
   );

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/RecycleAllClusterNodesDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/RecycleAllClusterNodesDialog.tsx
@@ -36,7 +36,7 @@ const renderActions = (
         data-qa-confirm
         data-testid={'dialog-confirm'}
       >
-        Recycle all Nodes
+        Recycle Cluster
       </Button>
     </ActionsPanel>
   );
@@ -54,10 +54,10 @@ const RecycleAllClusterNodesDialog: React.FC<Props> = props => {
     >
       {error && <Notice error text={error} />}
       <Typography>
-        Are you sure you want to recycle the nodes in this cluster? All nodes
-        will be deleted and new nodes will be created to replace them. Any local
-        storage (such as &apos;hostPath&apos; volumes) will be erased. This may
-        take several minutes, as nodes will be replaced on a rolling basis.
+        Are you sure you want to recycle this cluster? All nodes will be deleted
+        and new nodes will be created to replace them. Any local storage (such
+        as &apos;hostPath&apos; volumes) will be erased. This may take several
+        minutes, as nodes will be replaced on a rolling basis.
       </Typography>
     </ConfirmationDialog>
   );

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/RecycleAllClusterNodesDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/RecycleAllClusterNodesDialog.tsx
@@ -36,7 +36,7 @@ const renderActions = (
         data-qa-confirm
         data-testid={'dialog-confirm'}
       >
-        Recycle Cluster
+        Recycle All Nodes
       </Button>
     </ActionsPanel>
   );

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeKubernetesVersionBanner.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeKubernetesVersionBanner.tsx
@@ -221,7 +221,7 @@ export const RecycleDialog: React.FC<DialogProps> = React.memo(props => {
       }
     >
       Kubernetes version has been updated successfully. For the changes to take
-      effect, you must recycle all nodes in your cluster.
+      full effect you must recycle the nodes in your cluster.
     </Dialog>
   );
 });

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeKubernetesVersionBanner.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeKubernetesVersionBanner.tsx
@@ -67,7 +67,7 @@ export const UpgradeKubernetesVersionBanner: React.FC<Props> = props => {
 
   const onSubmitRecycleDialog = () =>
     recycleClusterNodes(clusterID).then(_ =>
-      enqueueSnackbar('Cluster recycle started successfully.', {
+      enqueueSnackbar('Recycle started successfully.', {
         variant: 'success'
       })
     );
@@ -106,6 +106,7 @@ export const UpgradeKubernetesVersionBanner: React.FC<Props> = props => {
       <UpgradeDialog
         currentVersion={currentVersion}
         nextVersion={nextVersion ?? ''}
+        error={confirmUpgradeDialog.dialog.error}
         isOpen={confirmUpgradeDialog.dialog.isOpen}
         isLoading={confirmUpgradeDialog.dialog.isLoading}
         onClose={confirmUpgradeDialog.closeDialog}
@@ -118,6 +119,7 @@ export const UpgradeKubernetesVersionBanner: React.FC<Props> = props => {
       <RecycleDialog
         isOpen={recycleNodesDialog.dialog.isOpen}
         isLoading={recycleNodesDialog.dialog.isLoading}
+        error={recycleNodesDialog.dialog.error}
         onClose={recycleNodesDialog.closeDialog}
         onSubmit={() => recycleNodesDialog.submitDialog(undefined)}
       >
@@ -134,6 +136,7 @@ export const UpgradeKubernetesVersionBanner: React.FC<Props> = props => {
 interface DialogProps {
   isOpen: boolean;
   isLoading: boolean;
+  error?: string;
   onClose: () => void;
   onSubmit: () => void;
 }
@@ -149,6 +152,7 @@ export const UpgradeDialog: React.FC<UpgradeDialogProps> = React.memo(props => {
   const {
     currentVersion,
     nextVersion,
+    error,
     isOpen,
     isLoading,
     onClose,
@@ -158,6 +162,7 @@ export const UpgradeDialog: React.FC<UpgradeDialogProps> = React.memo(props => {
   return (
     <Dialog
       title={`Step 1: Upgrade to Kubernetes ${nextVersion}`}
+      error={error}
       open={isOpen}
       onClose={onClose}
       actions={
@@ -187,10 +192,11 @@ export const UpgradeDialog: React.FC<UpgradeDialogProps> = React.memo(props => {
 
 // Recycle Dialog (Step 2)
 export const RecycleDialog: React.FC<DialogProps> = React.memo(props => {
-  const { isOpen, isLoading, onClose, onSubmit } = props;
+  const { error, isOpen, isLoading, onClose, onSubmit } = props;
   return (
     <Dialog
       title={`Step 2: Recycle All Cluster Nodes`}
+      error={error}
       open={isOpen}
       onClose={onClose}
       actions={

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeKubernetesVersionBanner.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeKubernetesVersionBanner.tsx
@@ -57,20 +57,23 @@ export const UpgradeKubernetesVersionBanner: React.FC<Props> = props => {
 
   const { updateKubernetesCluster } = useKubernetesClusters();
 
-  const onSubmitUpgradeDialog = (nextVersion: string) => {
-    return updateKubernetesCluster(clusterID, {
+  const onSubmitUpgradeDialog = (nextVersion: string) =>
+    updateKubernetesCluster(clusterID, {
       k8s_version: nextVersion
-    }).then(_ => {
-      recycleNodesDialog.openDialog(undefined);
-    });
-  };
+    })
+      .then(_ => {
+        recycleNodesDialog.openDialog(undefined);
+      })
+      .catch(_ => null); // Errors handled through useDialog
 
   const onSubmitRecycleDialog = () =>
-    recycleClusterNodes(clusterID).then(_ =>
-      enqueueSnackbar('Recycle started successfully.', {
-        variant: 'success'
-      })
-    );
+    recycleClusterNodes(clusterID)
+      .then(_ =>
+        enqueueSnackbar('Recycle started successfully.', {
+          variant: 'success'
+        })
+      )
+      .catch(_ => null); // Errors handled through useDialog
 
   const confirmUpgradeDialog = useDialog(() =>
     onSubmitUpgradeDialog(nextVersion ?? '')

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeKubernetesVersionBanner.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeKubernetesVersionBanner.tsx
@@ -122,10 +122,10 @@ export const UpgradeKubernetesVersionBanner: React.FC<Props> = props => {
         onSubmit={() => recycleNodesDialog.submitDialog(undefined)}
       >
         Kubernetes version has been updated successfully. For the changes to
-        take effect, you must recycle your cluster. All nodes will be deleted
-        and new nodes will be created to replace them. Any local storage (such
-        as &apos;hostPath&apos; volumes) will be erased. This may take several
-        minutes, as nodes will be replaced on a rolling basis.
+        take effect, you must recycle all nodes in your cluster. All nodes will
+        be deleted and new nodes will be created to replace them. Any local
+        storage (such as &apos;hostPath&apos; volumes) will be erased. This may
+        take several minutes, as nodes will be replaced on a rolling basis.
       </RecycleDialog>
     </>
   );
@@ -179,7 +179,8 @@ export const UpgradeDialog: React.FC<UpgradeDialogProps> = React.memo(props => {
     >
       Upgrade this cluster&apos;s Kubernetes version from{' '}
       <strong>{currentVersion}</strong> to <strong>{nextVersion}</strong>? Once
-      the upgrade is complete you will need to recycle your cluster.
+      the upgrade is complete you will need to recycle all nodes in your
+      cluster.
     </Dialog>
   );
 });
@@ -204,13 +205,13 @@ export const RecycleDialog: React.FC<DialogProps> = React.memo(props => {
             loading={isLoading}
             data-qa-confirm
           >
-            Recycle Cluster
+            Recycle All Nodes
           </Button>
         </ActionsPanel>
       }
     >
       Kubernetes version has been updated successfully. For the changes to take
-      effect, you must recycle your cluster.
+      effect, you must recycle all nodes in your cluster.
     </Dialog>
   );
 });

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeKubernetesVersionBanner.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeKubernetesVersionBanner.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+
+import Button from 'src/components/Button';
+import Paper from 'src/components/core/Paper';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+import Grid from 'src/components/Grid';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    borderLeft: `solid 6px ${theme.color.green}`,
+    padding: theme.spacing(1.5)
+  }
+}));
+
+interface Props {
+  currentVersion: string;
+}
+
+export type CombinedProps = Props;
+
+export const UpgradeKubernetesVersionBanner: React.FC<Props> = props => {
+  const { currentVersion } = props;
+  const classes = useStyles();
+  return (
+    <Paper className={classes.root}>
+      <Grid
+        container
+        direction="row"
+        alignItems="center"
+        justify="space-between"
+      >
+        <Grid item>
+          <Typography>
+            A new version of Kubernetes is available. {currentVersion}
+          </Typography>
+        </Grid>
+        <Grid item>
+          <Button onClick={() => null} buttonType="primary">
+            Upgrade Version
+          </Button>
+        </Grid>
+      </Grid>
+    </Paper>
+  );
+};
+
+export default React.memo(UpgradeKubernetesVersionBanner);

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeKubernetesVersionBanner.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeKubernetesVersionBanner.tsx
@@ -60,20 +60,16 @@ export const UpgradeKubernetesVersionBanner: React.FC<Props> = props => {
   const onSubmitUpgradeDialog = (nextVersion: string) =>
     updateKubernetesCluster(clusterID, {
       k8s_version: nextVersion
-    })
-      .then(_ => {
-        recycleNodesDialog.openDialog(undefined);
-      })
-      .catch(_ => null); // Errors handled through useDialog
+    }).then(_ => {
+      recycleNodesDialog.openDialog(undefined);
+    });
 
   const onSubmitRecycleDialog = () =>
-    recycleClusterNodes(clusterID)
-      .then(_ =>
-        enqueueSnackbar('Recycle started successfully.', {
-          variant: 'success'
-        })
-      )
-      .catch(_ => null); // Errors handled through useDialog
+    recycleClusterNodes(clusterID).then(_ =>
+      enqueueSnackbar('Recycle started successfully.', {
+        variant: 'success'
+      })
+    );
 
   const confirmUpgradeDialog = useDialog(() =>
     onSubmitUpgradeDialog(nextVersion ?? '')

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeKubernetesVersionBanner.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeKubernetesVersionBanner.tsx
@@ -8,8 +8,12 @@ import Grid from 'src/components/Grid';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
+    fontSize: '1rem',
     borderLeft: `solid 6px ${theme.color.green}`,
-    padding: theme.spacing(1.5)
+    padding: theme.spacing(1)
+  },
+  upgradeMessage: {
+    marginLeft: theme.spacing()
   }
 }));
 
@@ -31,7 +35,7 @@ export const UpgradeKubernetesVersionBanner: React.FC<Props> = props => {
         justify="space-between"
       >
         <Grid item>
-          <Typography>
+          <Typography className={classes.upgradeMessage}>
             A new version of Kubernetes is available. {currentVersion}
           </Typography>
         </Grid>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeKubernetesVersionBanner.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeKubernetesVersionBanner.tsx
@@ -122,7 +122,10 @@ export const UpgradeKubernetesVersionBanner: React.FC<Props> = props => {
         onSubmit={() => recycleNodesDialog.submitDialog(undefined)}
       >
         Kubernetes version has been updated successfully. For the changes to
-        take effect, you must recycle your cluster.
+        take effect, you must recycle your cluster. All nodes will be deleted
+        and new nodes will be created to replace them. Any local storage (such
+        as &apos;hostPath&apos; volumes) will be erased. This may take several
+        minutes, as nodes will be replaced on a rolling basis.
       </RecycleDialog>
     </>
   );
@@ -142,7 +145,7 @@ interface UpgradeDialogProps extends DialogProps {
 
 // Upgrade Confirmation Dialog (Step 1)
 
-export const UpgradeDialog: React.FC<UpgradeDialogProps> = props => {
+export const UpgradeDialog: React.FC<UpgradeDialogProps> = React.memo(props => {
   const {
     currentVersion,
     nextVersion,
@@ -179,10 +182,10 @@ export const UpgradeDialog: React.FC<UpgradeDialogProps> = props => {
       the upgrade is complete you will need to recycle your cluster.
     </Dialog>
   );
-};
+});
 
 // Recycle Dialog (Step 2)
-export const RecycleDialog: React.FC<DialogProps> = props => {
+export const RecycleDialog: React.FC<DialogProps> = React.memo(props => {
   const { isOpen, isLoading, onClose, onSubmit } = props;
   return (
     <Dialog
@@ -210,6 +213,6 @@ export const RecycleDialog: React.FC<DialogProps> = props => {
       effect, you must recycle your cluster.
     </Dialog>
   );
-};
+});
 
 export default React.memo(UpgradeKubernetesVersionBanner);

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeKubernetesVersionBanner.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeKubernetesVersionBanner.tsx
@@ -89,7 +89,7 @@ export const UpgradeKubernetesVersionBanner: React.FC<Props> = props => {
           >
             <Grid item>
               <Typography className={classes.upgradeMessage}>
-                A new version of Kubernetes is available.
+                A new version of Kubernetes is available ({nextVersion}).
               </Typography>
             </Grid>
             <Grid item>
@@ -114,7 +114,8 @@ export const UpgradeKubernetesVersionBanner: React.FC<Props> = props => {
       >
         Upgrade this cluster&apos;s Kubernetes version from{' '}
         <strong>{currentVersion}</strong> to <strong>{nextVersion}</strong>?
-        Once the upgrade is complete you will need to recycle your cluster.
+        Once the upgrade is complete you will need to recycle all nodes in your
+        cluster.
       </UpgradeDialog>
       <RecycleDialog
         isOpen={recycleNodesDialog.dialog.isOpen}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeKubernetesVersionBanner.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeKubernetesVersionBanner.tsx
@@ -1,16 +1,21 @@
+import { KubernetesVersion } from '@linode/api-v4/lib/kubernetes/types';
 import * as React from 'react';
-
+import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
+import Dialog from 'src/components/ConfirmationDialog';
 import Grid from 'src/components/Grid';
+import useKubernetesClusters from 'src/hooks/useKubernetesClusters';
+import { useKubernetesVersionQuery } from 'src/queries/kubernetesVersion';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
     fontSize: '1rem',
     borderLeft: `solid 6px ${theme.color.green}`,
-    padding: theme.spacing(1)
+    padding: theme.spacing(1),
+    marginBottom: theme.spacing()
   },
   upgradeMessage: {
     marginLeft: theme.spacing()
@@ -18,34 +23,93 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 interface Props {
+  clusterID: number;
   currentVersion: string;
 }
 
 export type CombinedProps = Props;
 
+export const getNextVersion = (
+  currentVersion: string,
+  versions: KubernetesVersion[]
+) => {
+  const versionStrings = versions.map(v => v.id).sort();
+  const currentIdx = versionStrings.findIndex(
+    thisVersion => currentVersion === thisVersion
+  );
+  if (currentIdx < 0 || currentIdx === versions.length - 1) {
+    return null;
+  }
+  return versionStrings[currentIdx + 1];
+};
+
 export const UpgradeKubernetesVersionBanner: React.FC<Props> = props => {
-  const { currentVersion } = props;
+  const { clusterID, currentVersion } = props;
   const classes = useStyles();
+  const { data: versions } = useKubernetesVersionQuery();
+  const nextVersion = getNextVersion(currentVersion, versions ?? []);
+
+  const [confirmDialogOpen, setConfirmDialogOpen] = React.useState(false);
+  const onClose = () => setConfirmDialogOpen(false);
+  const { updateKubernetesCluster } = useKubernetesClusters();
+
+  const onSubmit = (nextVersion: string) => {
+    updateKubernetesCluster(clusterID, { k8s_version: nextVersion });
+  };
+
+  if (!nextVersion) {
+    return null;
+  }
+
   return (
-    <Paper className={classes.root}>
-      <Grid
-        container
-        direction="row"
-        alignItems="center"
-        justify="space-between"
+    <>
+      <Paper className={classes.root}>
+        <Grid
+          container
+          direction="row"
+          alignItems="center"
+          justify="space-between"
+        >
+          <Grid item>
+            <Typography className={classes.upgradeMessage}>
+              A new version of Kubernetes is available.
+            </Typography>
+          </Grid>
+          <Grid item>
+            <Button
+              onClick={() => setConfirmDialogOpen(true)}
+              buttonType="primary"
+            >
+              Upgrade Version
+            </Button>
+          </Grid>
+        </Grid>
+      </Paper>
+      <Dialog
+        title={`Upgrade to Kubernetes ${nextVersion}?`}
+        open={confirmDialogOpen}
+        onClose={() => setConfirmDialogOpen(false)}
+        actions={
+          <ActionsPanel style={{ padding: 0 }}>
+            <Button buttonType="cancel" onClick={onClose} data-qa-cancel>
+              Cancel
+            </Button>
+            <Button
+              buttonType="primary"
+              destructive
+              onClick={() => onSubmit(nextVersion)}
+              loading={false}
+              data-qa-confirm
+            >
+              Upgrade
+            </Button>
+          </ActionsPanel>
+        }
       >
-        <Grid item>
-          <Typography className={classes.upgradeMessage}>
-            A new version of Kubernetes is available. {currentVersion}
-          </Typography>
-        </Grid>
-        <Grid item>
-          <Button onClick={() => null} buttonType="primary">
-            Upgrade Version
-          </Button>
-        </Grid>
-      </Grid>
-    </Paper>
+        Upgrade Kubernetes from {currentVersion} to {nextVersion}? Once the
+        upgrade is complete you will need to recycle the nodes in your cluster.
+      </Dialog>
+    </>
   );
 };
 

--- a/packages/manager/src/hooks/useKubernetesClusters.ts
+++ b/packages/manager/src/hooks/useKubernetesClusters.ts
@@ -2,15 +2,22 @@ import { KubernetesCluster } from '@linode/api-v4/lib/kubernetes/types';
 import { useDispatch, useSelector } from 'react-redux';
 import { ApplicationState } from 'src/store';
 import { State } from 'src/store/kubernetes/kubernetes.reducer';
-import { requestKubernetesClusters as _request } from 'src/store/kubernetes/kubernetes.requests';
+import {
+  requestKubernetesClusters as _request,
+  updateCluster as _update
+} from 'src/store/kubernetes/kubernetes.requests';
 import { Dispatch } from './types';
 
 export interface KubernetesProps {
   kubernetesClusters: State;
   requestKubernetesClusters: () => Promise<KubernetesCluster[]>;
+  updateKubernetesCluster: (
+    clusterID: number,
+    updatedCluster: Partial<KubernetesCluster>
+  ) => Promise<KubernetesCluster>;
 }
 
-export const useKubernetesClusters = () => {
+export const useKubernetesClusters = (): KubernetesProps => {
   const dispatch: Dispatch = useDispatch();
   const kubernetesClusters = useSelector(
     (state: ApplicationState) => state.__resources.kubernetes
@@ -18,7 +25,16 @@ export const useKubernetesClusters = () => {
   const requestKubernetesClusters = () =>
     dispatch(_request()).then(response => response.data);
 
-  return { kubernetesClusters, requestKubernetesClusters };
+  const updateKubernetesCluster = (
+    clusterID: number,
+    updatedCluster: Partial<KubernetesCluster>
+  ) => dispatch(_update({ clusterID, ...updatedCluster }));
+
+  return {
+    kubernetesClusters,
+    requestKubernetesClusters,
+    updateKubernetesCluster
+  };
 };
 
 export default useKubernetesClusters;

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -170,6 +170,12 @@ export const handlers = [
     const cluster = kubernetesAPIResponse.build({ id });
     return res(ctx.json(cluster));
   }),
+  rest.put('*/lke/clusters/:clusterId', async (req, res, ctx) => {
+    const id = Number(req.params.clusterId);
+    const k8s_version = req.params.k8s_version;
+    const cluster = kubernetesAPIResponse.build({ id, k8s_version });
+    return res(ctx.json(cluster));
+  }),
   rest.get('*/lke/clusters/:clusterId/pools', async (req, res, ctx) => {
     const pools = nodePoolFactory.buildList(10);
     nodePoolFactory.resetSequenceNumber();
@@ -178,6 +184,9 @@ export const handlers = [
   rest.get('*/lke/clusters/*/api-endpoints', async (req, res, ctx) => {
     const endpoints = kubeEndpointFactory.buildList(2);
     return res(ctx.json(makeResourcePage(endpoints)));
+  }),
+  rest.get('*/lke/clusters/*/recycle', async (req, res, ctx) => {
+    return res(ctx.json({}));
   }),
   rest.get('*/firewalls/', (req, res, ctx) => {
     const firewalls = firewallFactory.buildList(0);

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -1,7 +1,7 @@
 import { rest, RequestHandler } from 'msw';
 
 import {
-  abuseTicketNotificationFactory,
+  // abuseTicketNotificationFactory,
   accountFactory,
   appTokenFactory,
   creditPaymentResponseFactory,
@@ -162,12 +162,12 @@ export const handlers = [
     return res(ctx.json(linode));
   }),
   rest.get('*/lke/clusters', async (req, res, ctx) => {
-    const clusters = kubernetesAPIResponse.buildList(0);
+    const clusters = kubernetesAPIResponse.buildList(10);
     return res(ctx.json(makeResourcePage(clusters)));
   }),
   rest.get('*/lke/clusters/:clusterId', async (req, res, ctx) => {
     const id = Number(req.params.clusterId);
-    const cluster = kubernetesAPIResponse.build({ id });
+    const cluster = kubernetesAPIResponse.build({ id, k8s_version: '1.16' });
     return res(ctx.json(cluster));
   }),
   rest.put('*/lke/clusters/:clusterId', async (req, res, ctx) => {
@@ -378,13 +378,13 @@ export const handlers = [
     //   until: null,
     //   body: null
     // });
-    const abuseTicket = abuseTicketNotificationFactory.build();
+    // const abuseTicket = abuseTicketNotificationFactory.build();
 
     return res(
       ctx.json(
         makeResourcePage([
-          ...notificationFactory.buildList(1),
-          abuseTicket
+          ...notificationFactory.buildList(1)
+          // abuseTicket
           // emailBounce
         ])
       )

--- a/packages/manager/src/queries/kubernetesVersion.ts
+++ b/packages/manager/src/queries/kubernetesVersion.ts
@@ -10,7 +10,7 @@ const _getVersions = () => {
   return getKubernetesVersions().then(response => response.data);
 };
 
-export const useManagedSSHKey = () =>
+export const useKubernetesVersionQuery = () =>
   useQuery<KubernetesVersion[], APIError[]>(
     'k8s_versions',
     _getVersions,

--- a/packages/manager/src/queries/kubernetesVersion.ts
+++ b/packages/manager/src/queries/kubernetesVersion.ts
@@ -7,7 +7,10 @@ import { useQuery } from 'react-query';
 import { queryPresets } from './base';
 
 const _getVersions = () => {
-  return getKubernetesVersions().then(response => response.data);
+  return getKubernetesVersions(
+    {},
+    { '+order_by': 'id', '+order': 'desc' }
+  ).then(response => response.data);
 };
 
 export const useKubernetesVersionQuery = () =>

--- a/packages/manager/src/queries/kubernetesVersion.ts
+++ b/packages/manager/src/queries/kubernetesVersion.ts
@@ -1,0 +1,18 @@
+import {
+  getKubernetesVersions,
+  KubernetesVersion
+} from '@linode/api-v4/lib/kubernetes';
+import { APIError } from '@linode/api-v4/lib/types';
+import { useQuery } from 'react-query';
+import { queryPresets } from './base';
+
+const _getVersions = () => {
+  return getKubernetesVersions().then(response => response.data);
+};
+
+export const useManagedSSHKey = () =>
+  useQuery<KubernetesVersion[], APIError[]>(
+    'k8s_versions',
+    _getVersions,
+    queryPresets.oneTimeFetch
+  );


### PR DESCRIPTION
## Description

Add modal for bumping LKE version. Only one version bump is supported per PUT (1.16 -> 1.17 but not 1.16 -> 1.18). Copy and some UX details are still under discussion.

## Note to Reviewers

- To test, create an LKE cluster with a version lower than the current (1.18). On the cluster detail page there should be a modal prompting you to upgrade.
- I also updated the mocks so if you turn those on the flow should work.
- Does the transition between 2 modals bother anyone else? Looking for a way around it

Still to come: Banner on LKE landing page and "upgrade" badge in individual cluster rows.