### PR TITLE
M3-4771 Fix wrapping in UserMenu causing disappearing Log Out button

### DIFF
--- a/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
+++ b/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
@@ -181,7 +181,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   profileWrapper: {
     marginBottom: theme.spacing(2),
-    maxHeight: 200,
     width: '100%',
     '& > div': {
       whiteSpace: 'normal'
@@ -291,7 +290,7 @@ export const UserMenu: React.FC<{}> = () => {
 
   const renderLink = (menuLink: MenuLink) =>
     menuLink.hide ? null : (
-      <Grid item xs={6} key={menuLink.display}>
+      <Grid item xs={12} key={menuLink.display}>
         <MenuLink
           as={Link}
           to={menuLink.href}
@@ -343,13 +342,27 @@ export const UserMenu: React.FC<{}> = () => {
               <strong>{userName}</strong>
             </div>
             <div className={classes.menuHeader}>My Profile</div>
-            <Grid
-              container
-              wrap="wrap"
-              direction="column"
-              className={classes.profileWrapper}
-            >
-              {profileLinks.map(renderLink)}
+            <Grid container>
+              <Grid
+                container
+                item
+                xs={6}
+                wrap="nowrap"
+                direction="column"
+                className={classes.profileWrapper}
+              >
+                {profileLinks.slice(0, 4).map(renderLink)}
+              </Grid>
+              <Grid
+                container
+                item
+                xs={6}
+                wrap="nowrap"
+                direction="column"
+                className={classes.profileWrapper}
+              >
+                {profileLinks.slice(4).map(renderLink)}
+              </Grid>
             </Grid>
             {_hasAccountAccess ? (
               <>


### PR DESCRIPTION
## Description

This fixes a bug where the "Log Out", "My Settings", and "Referrals" buttons are apparently missing from the User Menu. 

<img width="342" alt="Screen Shot 2021-01-22 at 5 33 14 PM" src="https://user-images.githubusercontent.com/16911484/105555789-1c27e500-5cd8-11eb-8eab-f1622676e66a.png">

This happens on Chrome (and other browsers) when there is an increased font size. To reproduce, change your font size to "Large" at `chrome://settings/appearance`.

**To fix this**, I broke up the links into two actual Grid columns rather than relying on max-height + CSS wrapping.
