### PR TITLE
M3 4781 firewall rule clone

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleActionMenu.test.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleActionMenu.test.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import FirewallRuleActionMenu, { Props } from './FirewallRuleActionMenu';
+
+import { includesActions, renderWithTheme } from 'src/utilities/testHelpers';
+
+jest.mock('src/components/ActionMenu/ActionMenu');
+
+const props: Props = {
+  idx: 1,
+  triggerCloneFirewallRule: jest.fn(),
+  triggerDeleteFirewallRule: jest.fn(),
+  triggerOpenRuleDrawerForEditing: jest.fn()
+};
+
+describe('Firewall rule action menu', () => {
+  it('should include the correct actions', () => {
+    const { queryByText } = renderWithTheme(
+      <FirewallRuleActionMenu {...props} />
+    );
+    includesActions(['Edit', 'Clone', 'Delete'], queryByText);
+  });
+});

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleActionMenu.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleActionMenu.tsx
@@ -6,7 +6,7 @@ import ActionMenu, {
 import { Theme, useTheme, useMediaQuery } from 'src/components/core/styles';
 import InlineMenuAction from 'src/components/InlineMenuAction';
 
-interface Props extends Partial<ActionMenuProps> {
+export interface Props extends Partial<ActionMenuProps> {
   idx: number;
   triggerCloneFirewallRule: (idx: number) => void;
   triggerDeleteFirewallRule: (idx: number) => void;

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleActionMenu.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleActionMenu.tsx
@@ -8,6 +8,7 @@ import InlineMenuAction from 'src/components/InlineMenuAction';
 
 interface Props extends Partial<ActionMenuProps> {
   idx: number;
+  triggerCloneFirewallRule: (idx: number) => void;
   triggerDeleteFirewallRule: (idx: number) => void;
   triggerOpenRuleDrawerForEditing: (idx: number) => void;
 }
@@ -20,6 +21,7 @@ const FirewallRuleActionMenu: React.FC<CombinedProps> = props => {
 
   const {
     idx,
+    triggerCloneFirewallRule,
     triggerDeleteFirewallRule,
     triggerOpenRuleDrawerForEditing,
     ...actionMenuProps
@@ -30,6 +32,12 @@ const FirewallRuleActionMenu: React.FC<CombinedProps> = props => {
       title: 'Edit',
       onClick: () => {
         triggerOpenRuleDrawerForEditing(idx);
+      }
+    },
+    {
+      title: 'Clone',
+      onClick: () => {
+        triggerCloneFirewallRule(idx);
       }
     },
     {

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -77,13 +77,17 @@ interface RuleRow {
 // =============================================================================
 // <FirewallRuleTable />
 // =============================================================================
-interface Props {
-  category: Category;
-  openRuleDrawer: (category: Category, mode: Mode) => void;
-  rulesWithStatus: ExtendedFirewallRule[];
+
+interface RowActionHandlers {
+  triggerCloneFirewallRule: (idx: number) => void;
   triggerDeleteFirewallRule: (idx: number) => void;
   triggerOpenRuleDrawerForEditing: (idx: number) => void;
   triggerUndo: (idx: number) => void;
+}
+interface Props extends RowActionHandlers {
+  category: Category;
+  openRuleDrawer: (category: Category, mode: Mode) => void;
+  rulesWithStatus: ExtendedFirewallRule[];
 }
 
 type CombinedProps = Props;
@@ -93,6 +97,7 @@ const FirewallRuleTable: React.FC<CombinedProps> = props => {
     category,
     openRuleDrawer,
     rulesWithStatus,
+    triggerCloneFirewallRule,
     triggerDeleteFirewallRule,
     triggerOpenRuleDrawerForEditing,
     triggerUndo
@@ -191,6 +196,7 @@ const FirewallRuleTable: React.FC<CombinedProps> = props => {
                     <FirewallRuleTableRow
                       key={thisRuleRow.id}
                       {...thisRuleRow}
+                      triggerCloneFirewallRule={triggerCloneFirewallRule}
                       triggerDeleteFirewallRule={triggerDeleteFirewallRule}
                       triggerOpenRuleDrawerForEditing={
                         triggerOpenRuleDrawerForEditing
@@ -213,11 +219,7 @@ export default React.memo(FirewallRuleTable);
 // =============================================================================
 // <FirewallRuleTableRow />
 // =============================================================================
-interface FirewallRuleTableRowProps extends RuleRow {
-  triggerDeleteFirewallRule: (idx: number) => void;
-  triggerOpenRuleDrawerForEditing: (idx: number) => void;
-  triggerUndo: (idx: number) => void;
-}
+type FirewallRuleTableRowProps = RuleRow & RowActionHandlers;
 
 const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
   props => {
@@ -230,6 +232,7 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
       ports,
       addresses,
       status,
+      triggerCloneFirewallRule,
       triggerDeleteFirewallRule,
       triggerOpenRuleDrawerForEditing,
       triggerUndo,
@@ -238,6 +241,7 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
 
     const actionMenuProps = {
       idx: id,
+      triggerCloneFirewallRule,
       triggerDeleteFirewallRule,
       triggerOpenRuleDrawerForEditing
     };

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRulesLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRulesLanding.tsx
@@ -117,6 +117,11 @@ const FirewallRulesLanding: React.FC<CombinedProps> = props => {
     dispatch({ type: 'NEW_RULE', rule });
   };
 
+  const handleCloneRule = (category: Category, idx: number) => {
+    const dispatch = dispatchFromCategory(category);
+    dispatch({ type: 'CLONE_RULE', idx });
+  };
+
   const handleEditRule = (
     category: Category,
     rule: Partial<FirewallRuleType>
@@ -279,6 +284,9 @@ const FirewallRulesLanding: React.FC<CombinedProps> = props => {
       <div className={classes.table}>
         <FirewallRuleTable
           category="inbound"
+          triggerCloneFirewallRule={(idx: number) =>
+            handleCloneRule('inbound', idx)
+          }
           rulesWithStatus={inboundRules}
           openRuleDrawer={openRuleDrawer}
           triggerOpenRuleDrawerForEditing={(idx: number) =>
@@ -291,6 +299,9 @@ const FirewallRulesLanding: React.FC<CombinedProps> = props => {
       <div className={classes.table}>
         <FirewallRuleTable
           category="outbound"
+          triggerCloneFirewallRule={(idx: number) =>
+            handleCloneRule('outbound', idx)
+          }
           rulesWithStatus={outboundRules}
           openRuleDrawer={openRuleDrawer}
           triggerOpenRuleDrawerForEditing={(idx: number) =>

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/firewallRuleEditor.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/firewallRuleEditor.ts
@@ -55,6 +55,10 @@ export type RuleEditorAction =
       modifiedRule: Partial<FirewallRuleType>;
     }
   | {
+      type: 'CLONE_RULE';
+      idx: number;
+    }
+  | {
       type: 'SET_ERROR';
       idx: number;
       error: FirewallRuleError;
@@ -111,6 +115,15 @@ const ruleEditorReducer = (
         ...action.modifiedRule,
         status: 'MODIFIED'
       });
+      return;
+
+    case 'CLONE_RULE':
+      const ruleToClone = last(draft[action.idx]);
+      if (!ruleToClone) {
+        return;
+      }
+      const { addresses, ports, protocol } = ruleToClone;
+      draft.push([{ addresses, ports, protocol, status: 'NEW' }]);
       return;
 
     case 'SET_ERROR':


### PR DESCRIPTION
## Description

Add "Clone" to the Firewall rule action menu; directly clones a rule and adds it to the queued changes.

Holding off on the open-the-drawer piece, still not sure how to handle that part but this works and we might as well get it in and get some feedback on it.