### PR TITLE
M3-4795 Change: don't show "Linode Expert" for Linode accounts

### DIFF
--- a/packages/manager/src/features/Support/ExpandableTicketPanel.test.tsx
+++ b/packages/manager/src/features/Support/ExpandableTicketPanel.test.tsx
@@ -1,5 +1,10 @@
+import { screen } from '@testing-library/react';
 import { DateTime } from 'luxon';
+import * as React from 'react';
 import { ISO_DATETIME_NO_TZ_FORMAT } from 'src/constants';
+import { supportReplyFactory } from 'src/factories/support';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+import ExpandableTicketPanel, { Props } from './ExpandableTicketPanel';
 import { shouldRenderHively } from './Hively';
 
 const recent = DateTime.utc()
@@ -10,28 +15,76 @@ const old = DateTime.utc()
   .toFormat(ISO_DATETIME_NO_TZ_FORMAT);
 const user = 'Linode';
 
-describe('shouldRenderHively function', () => {
-  it('should return true if an improperly formatted date is passed', () => {
-    expect(shouldRenderHively(true, 'blah')).toBeTruthy();
+const reply = supportReplyFactory.build();
+
+const props: Props = {
+  reply: { ...reply, gravatarUrl: '' },
+  isCurrentUser: false
+};
+
+describe('Expandable ticket panel', () => {
+  describe('Panel component', () => {
+    it('should display "Linode Expert" if the ticket or reply has from_linode', () => {
+      renderWithTheme(<ExpandableTicketPanel {...props} />);
+      expect(screen.getByText('Linode Expert')).toBeInTheDocument();
+    });
+
+    it('should not display "Linode Expert" if the reply is from the Linode account', () => {
+      const replyFromLinode = {
+        ...supportReplyFactory.build({
+          created_by: 'Linode',
+          from_linode: true
+        }),
+        gravatarUrl: ''
+      };
+      renderWithTheme(
+        <ExpandableTicketPanel {...props} reply={replyFromLinode} />
+      );
+      expect(screen.queryByText('Linode Expert')).toBeNull();
+    });
+
+    it('should not display "Linode Expert" if the reply is from the Linode Trust & Safety account', () => {
+      const replyFromLinode = {
+        ...supportReplyFactory.build({
+          created_by: 'Linode Trust & Safety',
+          from_linode: true
+        }),
+        gravatarUrl: ''
+      };
+      renderWithTheme(
+        <ExpandableTicketPanel {...props} reply={replyFromLinode} />
+      );
+      expect(screen.queryByText('Linode Expert')).toBeNull();
+    });
   });
-  it('should return true if the date is now', () => {
-    expect(
-      shouldRenderHively(
-        true,
-        DateTime.utc().toFormat(ISO_DATETIME_NO_TZ_FORMAT)
-      )
-    ).toBeTruthy();
-  });
-  it('should return true if the date is within the past 7 days', () => {
-    expect(shouldRenderHively(true, recent)).toBeTruthy();
-  });
-  it('should return false for dates older than 7 days', () => {
-    expect(shouldRenderHively(true, old)).toBeFalsy();
-  });
-  it('should return false if the fromLinode parameter is false', () => {
-    expect(shouldRenderHively(false, recent)).toBeFalsy();
-  });
-  it('should return false if the user is Linode', () => {
-    expect(shouldRenderHively(false, recent, user)).toBeFalsy();
+  describe('shouldRenderHively function', () => {
+    it('should return true if an improperly formatted date is passed', () => {
+      expect(shouldRenderHively(true, 'blah')).toBeTruthy();
+    });
+    it('should return true if the date is now', () => {
+      expect(
+        shouldRenderHively(
+          true,
+          DateTime.utc().toFormat(ISO_DATETIME_NO_TZ_FORMAT)
+        )
+      ).toBeTruthy();
+    });
+    it('should return true if the date is within the past 7 days', () => {
+      expect(shouldRenderHively(true, recent)).toBeTruthy();
+    });
+    it('should return false for dates older than 7 days', () => {
+      expect(shouldRenderHively(true, old)).toBeFalsy();
+    });
+    it('should return false if the fromLinode parameter is false', () => {
+      expect(shouldRenderHively(false, recent)).toBeFalsy();
+    });
+    it('should return false if the user is Linode', () => {
+      expect(shouldRenderHively(false, recent, user)).toBeFalsy();
+    });
+    it('should return false if the user is Linode Trust & Safety', () => {
+      expect(
+        shouldRenderHively(false, recent, 'Linode Trust & Safety')
+      ).toBeFalsy();
+    });
   });
 });

--- a/packages/manager/src/features/Support/ExpandableTicketPanel.tsx
+++ b/packages/manager/src/features/Support/ExpandableTicketPanel.tsx
@@ -88,7 +88,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   }
 }));
 
-interface Props {
+export interface Props {
   reply?: ExtendedReply;
   ticket?: ExtendedTicket;
   open?: boolean;

--- a/packages/manager/src/features/Support/ExpandableTicketPanel.tsx
+++ b/packages/manager/src/features/Support/ExpandableTicketPanel.tsx
@@ -10,6 +10,7 @@ import useFlags from 'src/hooks/useFlags';
 import { ExtendedReply, ExtendedTicket } from './types';
 import { Hively, shouldRenderHively } from './Hively';
 import TicketDetailBody from './TicketDetailText';
+import { OFFICIAL_USERNAMES } from './ticketUtils';
 
 const useStyles = makeStyles((theme: Theme) => ({
   '@keyframes fadeIn': {
@@ -197,7 +198,8 @@ export const ExpandableTicketPanel: React.FC<CombinedProps> = props => {
                   <Typography className={classes.userName} component="span">
                     {data.username}
                   </Typography>
-                  {data.from_linode && (
+                  {data.from_linode &&
+                  !OFFICIAL_USERNAMES.includes(data.username) ? (
                     <Typography
                       component="span"
                       variant="body1"
@@ -205,7 +207,7 @@ export const ExpandableTicketPanel: React.FC<CombinedProps> = props => {
                     >
                       <em>Linode Expert</em>
                     </Typography>
-                  )}
+                  ) : null}
                   <Typography variant="body1" component="span">
                     commented <DateTimeDisplay value={data.date} />
                   </Typography>

--- a/packages/manager/src/features/Support/Hively.tsx
+++ b/packages/manager/src/features/Support/Hively.tsx
@@ -43,7 +43,7 @@ export const shouldRenderHively = (
 ) => {
   /* Render Hively only for replies marked as from_linode,
    * and are on tickets less than 7 days old,
-   * and when the user is not "Linode" or "Linode Trust and Safety"
+   * and when the user is not "Linode" or "Linode Trust & Safety"
    * Defaults to showing Hively if there are any errors parsing dates
    * or the date is invalid.
    */

--- a/packages/manager/src/features/Support/Hively.tsx
+++ b/packages/manager/src/features/Support/Hively.tsx
@@ -48,7 +48,7 @@ export const shouldRenderHively = (
    * or the date is invalid.
    */
   try {
-    if (!username || OFFICIAL_USERNAMES.includes(username)) {
+    if (username && OFFICIAL_USERNAMES.includes(username)) {
       return false;
     }
     const lastUpdated = parseAPIDate(updated);

--- a/packages/manager/src/features/Support/Hively.tsx
+++ b/packages/manager/src/features/Support/Hively.tsx
@@ -4,6 +4,7 @@ import { parseAPIDate } from 'src/utilities/date';
 import Divider from 'src/components/core/Divider';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
+import { OFFICIAL_USERNAMES } from './ticketUtils';
 
 const useStyles = makeStyles((theme: Theme) => ({
   hivelyContainer: {
@@ -42,12 +43,12 @@ export const shouldRenderHively = (
 ) => {
   /* Render Hively only for replies marked as from_linode,
    * and are on tickets less than 7 days old,
-   * and when the user is not "Linode"
+   * and when the user is not "Linode" or "Linode Trust and Safety"
    * Defaults to showing Hively if there are any errors parsing dates
    * or the date is invalid.
    */
   try {
-    if (username === 'Linode') {
+    if (!username || OFFICIAL_USERNAMES.includes(username)) {
       return false;
     }
     const lastUpdated = parseAPIDate(updated);

--- a/packages/manager/src/features/Support/ticketUtils.ts
+++ b/packages/manager/src/features/Support/ticketUtils.ts
@@ -1,3 +1,5 @@
+export const OFFICIAL_USERNAMES = ['Linode', 'Linode Trust and Safety'];
+
 export const reshapeFiles = (files: FileList) => {
   const reshapedFiles = [];
 

--- a/packages/manager/src/features/Support/ticketUtils.ts
+++ b/packages/manager/src/features/Support/ticketUtils.ts
@@ -1,4 +1,4 @@
-export const OFFICIAL_USERNAMES = ['Linode', 'Linode Trust and Safety'];
+export const OFFICIAL_USERNAMES = ['Linode', 'Linode Trust & Safety'];
 
 export const reshapeFiles = (files: FileList) => {
   const reshapedFiles = [];


### PR DESCRIPTION
## Description

Hide "Linode Expert" text for Linode and Linode Trust & Safety accounts. Also added Trust & Safety to the list of names to not show Hively (the rating system icons).

Test account 4 has a closed ticket with a reply from T&S.
