### PR TITLE
M3-4800: Fix scheduled migration banner font color on dark mode

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/MigrationNotification.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/MigrationNotification.tsx
@@ -1,34 +1,16 @@
 import { NotificationType } from '@linode/api-v4/lib/account';
 import { scheduleOrQueueMigration } from '@linode/api-v4/lib/linodes';
-import { withSnackbar, WithSnackbarProps } from 'notistack';
+import { useSnackbar } from 'notistack';
 import * as React from 'react';
-import { compose } from 'recompose';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles
-} from 'src/components/core/styles';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Notice from 'src/components/Notice';
 
-type ClassNames = 'copy' | 'migrationLink';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    copy: {
-      color: theme.palette.text.primary,
-      fontSize: '.875rem'
-    },
-    migrationLink: {
-      color: theme.cmrTextColors.linkActiveLight,
-      cursor: 'pointer',
-      display: 'inline',
-      '&:hover': {
-        textDecoration: 'underline'
-      }
-    }
-  });
+const useStyles = makeStyles((theme: Theme) => ({
+  migrationLink: {
+    ...theme.applyLinkStyles
+  }
+}));
 
 interface Props {
   linodeID: number;
@@ -37,14 +19,13 @@ interface Props {
   notificationMessage: string;
 }
 
-type CombinedProps = Props & WithStyles<ClassNames> & WithSnackbarProps;
+const MigrationNotification: React.FC<Props> = props => {
+  const classes = useStyles();
+  const { enqueueSnackbar } = useSnackbar();
 
-const MigrationNotification: React.FC<CombinedProps> = props => {
   const {
     linodeID,
     requestNotifications,
-    enqueueSnackbar,
-    classes,
     notificationMessage,
     notificationType
   } = props;
@@ -74,22 +55,18 @@ const MigrationNotification: React.FC<CombinedProps> = props => {
   };
 
   return (
-    <Notice important warning className={classes.copy}>
-      {notificationMessage}
-      {notificationType === 'migration_scheduled'
-        ? ' To enter the migration queue right now, please '
-        : ' To schedule your migration, please '}
-      <Typography className={classes.migrationLink} onClick={migrate}>
-        click here.
+    <Notice important warning>
+      <Typography>
+        {notificationMessage}
+        {notificationType === 'migration_scheduled'
+          ? ' To enter the migration queue right now, please '
+          : ' To schedule your migration, please '}
+        <button className={classes.migrationLink} onClick={migrate}>
+          click here.
+        </button>
       </Typography>
     </Notice>
   );
 };
 
-const styled = withStyles(styles);
-
-export default compose<CombinedProps, Props>(
-  withSnackbar,
-  React.memo,
-  styled
-)(MigrationNotification);
+export default MigrationNotification;

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/MigrationNotification.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/MigrationNotification.tsx
@@ -69,4 +69,4 @@ const MigrationNotification: React.FC<Props> = props => {
   );
 };
 
-export default MigrationNotification;
+export default React.memo(MigrationNotification);

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/MigrationNotification.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/MigrationNotification.tsx
@@ -12,12 +12,16 @@ import {
 import Typography from 'src/components/core/Typography';
 import Notice from 'src/components/Notice';
 
-type ClassNames = 'migrationLink';
+type ClassNames = 'copy' | 'migrationLink';
 
 const styles = (theme: Theme) =>
   createStyles({
+    copy: {
+      color: theme.palette.text.primary,
+      fontSize: '.875rem'
+    },
     migrationLink: {
-      color: theme.palette.primary.main,
+      color: theme.cmrTextColors.linkActiveLight,
       cursor: 'pointer',
       display: 'inline',
       '&:hover': {
@@ -70,7 +74,7 @@ const MigrationNotification: React.FC<CombinedProps> = props => {
   };
 
   return (
-    <Notice important warning>
+    <Notice important warning className={classes.copy}>
       {notificationMessage}
       {notificationType === 'migration_scheduled'
         ? ' To enter the migration queue right now, please '

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -380,12 +380,18 @@ export const handlers = [
     // });
     // const abuseTicket = abuseTicketNotificationFactory.build();
 
+    const migrationTicket = notificationFactory.build({
+      type: 'migration_pending',
+      entity: { id: 0, type: 'linode' }
+    });
+
     return res(
       ctx.json(
         makeResourcePage([
-          ...notificationFactory.buildList(1)
+          ...notificationFactory.buildList(1),
           // abuseTicket
           // emailBounce
+          migrationTicket
         ])
       )
     );


### PR DESCRIPTION
This is what it looked like before:
<img width="1297" alt="Screen Shot 2021-01-26 at 12 04 11 PM" src="https://user-images.githubusercontent.com/7692354/105878064-9ef9ba00-5fce-11eb-9b77-f4620efbc263.png">

[http://localhost:3000/linodes/0](http://localhost:3000/linodes/0) has a mock migration banner for ease of testing