### PR TITLE
M3-4879 Fix: "Compatible Images" field on StackScript detail

### DIFF
--- a/packages/manager/src/components/StackScript/StackScript.test.tsx
+++ b/packages/manager/src/components/StackScript/StackScript.test.tsx
@@ -1,49 +1,16 @@
-import { shallow } from 'enzyme';
+import { screen } from '@testing-library/react';
 import * as React from 'react';
-
+import { stackScriptFactory } from 'src/factories/stackscripts';
+import { renderWithTheme } from 'src/utilities/testHelpers';
 import { SStackScript } from './StackScript';
 
 describe('StackScript', () => {
-  it('should render script code', () => {
-    const component = shallow(
-      <SStackScript
-        imagesData={{}}
-        imagesLoading={false}
-        data={{
-          id: 1,
-          label: 'MySQL',
-          images: [],
-          user_defined_fields: [],
-          is_public: true,
-          user_gravatar_id: 'ead4da00f4fe6a4bd0b4f11a510c031d',
-          username: 'Linode',
-          deployments_total: 2,
-          deployments_active: 1,
-          description: 'Some test script for fun',
-          script: 'sudo rm -rf /etc',
-          created: '2010-12-31T23:59:58',
-          updated: '2010-12-31T23:59:59',
-          rev_note: 'Initial import.',
-          ordinal: 1, // default value
-          logo_url: '' // default value
-        }}
-        classes={{
-          root: '',
-          deployments: '',
-          author: '',
-          description: '',
-          scriptHeading: '',
-          descriptionText: '',
-          deploymentSection: '',
-          idSection: '',
-          copyIcon: '',
-          dateTimeDisplay: '',
-          compatibleImages: '',
-          divider: ''
-        }}
-      />
-    );
+  it('should render the StackScript label, id, and username', () => {
+    const stackScript = stackScriptFactory.build();
+    renderWithTheme(<SStackScript data={stackScript} />);
 
-    expect(component.find('WithStyles(ScriptCode)')).toHaveLength(1);
+    expect(screen.getByText(stackScript.label)).toBeInTheDocument();
+    expect(screen.getByText(stackScript.username)).toBeInTheDocument();
+    expect(screen.getByText(String(stackScript.id))).toBeInTheDocument();
   });
 });

--- a/packages/manager/src/components/StackScript/StackScript.tsx
+++ b/packages/manager/src/components/StackScript/StackScript.tsx
@@ -1,232 +1,187 @@
-import { Image } from '@linode/api-v4/lib/images';
 import { StackScript } from '@linode/api-v4/lib/stackscripts';
 import { stringify } from 'qs';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { compose } from 'recompose';
 import CopyTooltip from 'src/components/CopyTooltip';
 import Chip from 'src/components/core/Chip';
 import Divider from 'src/components/core/Divider';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles
-} from 'src/components/core/styles';
+import { Theme, makeStyles } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import DateTimeDisplay from 'src/components/DateTimeDisplay';
 import H1Header from 'src/components/H1Header';
 import ScriptCode from 'src/components/ScriptCode';
-import withImages from 'src/containers/withImages.container';
-import { filterImagesByType } from 'src/store/image/image.helpers';
+import { useImages } from 'src/hooks/useImages';
+import { useReduxLoad } from 'src/hooks/useReduxLoad';
 
-type CSSClasses =
-  | 'root'
-  | 'deployments'
-  | 'author'
-  | 'description'
-  | 'scriptHeading'
-  | 'descriptionText'
-  | 'deploymentSection'
-  | 'idSection'
-  | 'copyIcon'
-  | 'dateTimeDisplay'
-  | 'compatibleImages'
-  | 'divider';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {
-      backgroundColor: theme.color.white,
-      '.detailsWrapper &': {
-        padding: theme.spacing(4)
-      }
-    },
-    deployments: {
-      marginTop: theme.spacing(1)
-    },
-    author: {
-      marginTop: theme.spacing(2),
-      marginBottom: theme.spacing(2)
-    },
-    description: {
-      whiteSpace: 'pre-wrap'
-    },
-    scriptHeading: {
-      marginBottom: theme.spacing(1),
-      fontSize: '1rem'
-    },
-    descriptionText: {
-      marginBottom: theme.spacing(2)
-    },
-    deploymentSection: {
-      marginTop: theme.spacing(1),
-      fontSize: '1rem'
-    },
-    idSection: {
-      marginTop: theme.spacing(1),
-      fontSize: '1rem'
-    },
-    copyIcon: {
-      color: theme.palette.primary.main,
-      position: 'relative',
-      display: 'inline-block',
-      transition: theme.transitions.create(['color']),
-      '& svg': {
-        width: '1em',
-        height: '1em'
-      }
-    },
-    dateTimeDisplay: {
-      display: 'inline-block',
-      fontSize: '1rem'
-    },
-    compatibleImages: {
-      display: 'block',
-      marginTop: theme.spacing(1)
-    },
-    divider: {
-      marginTop: theme.spacing(2),
-      marginBottom: theme.spacing(2)
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    backgroundColor: theme.color.white,
+    '.detailsWrapper &': {
+      padding: theme.spacing(4)
     }
-  });
+  },
+  deployments: {
+    marginTop: theme.spacing(1)
+  },
+  author: {
+    marginTop: theme.spacing(2),
+    marginBottom: theme.spacing(2)
+  },
+  description: {
+    whiteSpace: 'pre-wrap'
+  },
+  scriptHeading: {
+    marginBottom: theme.spacing(1),
+    fontSize: '1rem'
+  },
+  descriptionText: {
+    marginBottom: theme.spacing(2)
+  },
+  deploymentSection: {
+    marginTop: theme.spacing(1),
+    fontSize: '1rem'
+  },
+  idSection: {
+    marginTop: theme.spacing(1),
+    fontSize: '1rem'
+  },
+  copyIcon: {
+    color: theme.palette.primary.main,
+    position: 'relative',
+    display: 'inline-block',
+    transition: theme.transitions.create(['color']),
+    '& svg': {
+      width: '1em',
+      height: '1em'
+    }
+  },
+  dateTimeDisplay: {
+    display: 'inline-block',
+    fontSize: '1rem'
+  },
+  compatibleImages: {
+    display: 'block',
+    marginTop: theme.spacing(1)
+  },
+  divider: {
+    marginTop: theme.spacing(2),
+    marginBottom: theme.spacing(2)
+  }
+}));
 
 export interface Props {
   data: StackScript;
 }
 
-export interface State {
-  imagesList: Image[];
-}
+export const SStackScript: React.FC<Props> = props => {
+  const {
+    data: {
+      username,
+      deployments_total,
+      deployments_active,
+      description,
+      id: stackscriptId,
+      script,
+      label,
+      updated,
+      images
+    }
+  } = props;
 
-type CombinedProps = Props & WithImagesProps & WithStyles<CSSClasses>;
+  const classes = useStyles();
+  const { images: imagesData } = useImages('public');
+  useReduxLoad(['images']);
 
-/* tslint:disable-next-line */
-export class SStackScript extends React.Component<CombinedProps> {
-  render() {
-    const {
-      classes,
-      data: {
-        username,
-        deployments_total,
-        deployments_active,
-        description,
-        id: stackscriptId,
-        script,
-        label,
-        updated,
-        images
-      },
-      imagesData
-    } = this.props;
+  const compatibleImages = React.useMemo(() => {
+    const imageChips = images.reduce((acc: any[], image: string) => {
+      const imageObj = imagesData.itemsById[image];
 
-    const compatibleImages =
-      images.reduce((acc: any[], image: string) => {
-        const imageObj = imagesData[image];
+      if (imageObj) {
+        acc.push(
+          <Chip
+            key={imageObj.id}
+            label={imageObj.label}
+            component="span"
+            clickable={false}
+          />
+        );
+      }
 
-        if (imageObj) {
-          acc.push(
-            <Chip
-              key={imageObj.id}
-              label={imageObj.label}
-              component="span"
-              clickable={false}
-            />
-          );
-        }
+      return acc;
+    }, []);
+    return imageChips.length > 0 ? imageChips : <>No compatible images found</>;
+  }, [images, imagesData]);
 
-        return acc;
-      }, []) || 'No compatible images found';
+  const queryString = stringify({
+    type: 'community',
+    query: `username:${username}`
+  });
 
-    const queryString = stringify({
-      type: 'community',
-      query: `username:${username}`
-    });
-
-    return (
-      <div className={classes.root}>
-        <H1Header title={label} data-qa-stack-title={label} />
-        <Typography
-          variant="h2"
-          className={classes.author}
-          data-qa-stack-author={username}
-        >
-          by&nbsp;
-          <Link
-            to={`/stackscripts?${queryString}`}
-            data-qa-community-stack-link
-          >
-            {username}
-          </Link>
+  return (
+    <div className={classes.root}>
+      <H1Header title={label} data-qa-stack-title={label} />
+      <Typography
+        variant="h2"
+        className={classes.author}
+        data-qa-stack-author={username}
+      >
+        by&nbsp;
+        <Link to={`/stackscripts?${queryString}`} data-qa-community-stack-link>
+          {username}
+        </Link>
+      </Typography>
+      <div data-qa-stack-deployments className={classes.deployments}>
+        <Typography className={classes.deploymentSection}>
+          <strong>{deployments_total}</strong> deployments
         </Typography>
-        <div data-qa-stack-deployments className={classes.deployments}>
-          <Typography className={classes.deploymentSection}>
-            <strong>{deployments_total}</strong> deployments
-          </Typography>
-          <Typography className={classes.deploymentSection}>
-            <strong>{deployments_active}</strong> still active
-          </Typography>
-          <Typography className={classes.deploymentSection}>
-            <strong>Last revision: </strong>
-            <DateTimeDisplay
-              value={updated}
-              className={classes.dateTimeDisplay}
-            />
-          </Typography>
-          <Typography className={classes.idSection}>
-            <strong>StackScript ID: </strong>
-            {stackscriptId}
-            <CopyTooltip
-              text={stackscriptId.toString()}
-              className={classes.copyIcon}
-            />
-          </Typography>
-          <Divider className={classes.divider} />
-        </div>
-        {description && (
-          <div className={classes.description}>
-            <Typography
-              className={classes.descriptionText}
-              data-qa-stack-description
-            >
-              {description}
-            </Typography>
-            <Divider className={classes.divider} />
-          </div>
-        )}
-        <div>
-          <Typography
-            data-qa-compatible-distro
-            className={classes.deploymentSection}
-            style={{ marginTop: 0 }}
-          >
-            <strong>Compatible with:</strong>
-            <span className={classes.compatibleImages}>{compatibleImages}</span>
-          </Typography>
-          <Divider className={classes.divider} />
-        </div>
-        <Typography className={classes.scriptHeading}>
-          <strong>Script:</strong>
+        <Typography className={classes.deploymentSection}>
+          <strong>{deployments_active}</strong> still active
         </Typography>
-        <ScriptCode script={script} />
+        <Typography className={classes.deploymentSection}>
+          <strong>Last revision: </strong>
+          <DateTimeDisplay
+            value={updated}
+            className={classes.dateTimeDisplay}
+          />
+        </Typography>
+        <Typography className={classes.idSection}>
+          <strong>StackScript ID: </strong>
+          {stackscriptId}
+          <CopyTooltip
+            text={stackscriptId.toString()}
+            className={classes.copyIcon}
+          />
+        </Typography>
+        <Divider className={classes.divider} />
       </div>
-    );
-  }
-}
+      {description && (
+        <div className={classes.description}>
+          <Typography
+            className={classes.descriptionText}
+            data-qa-stack-description
+          >
+            {description}
+          </Typography>
+          <Divider className={classes.divider} />
+        </div>
+      )}
+      <div>
+        <Typography
+          data-qa-compatible-distro
+          className={classes.deploymentSection}
+          style={{ marginTop: 0 }}
+        >
+          <strong>Compatible with:</strong>
+          <span className={classes.compatibleImages}>{compatibleImages}</span>
+        </Typography>
+        <Divider className={classes.divider} />
+      </div>
+      <Typography className={classes.scriptHeading}>
+        <strong>Script:</strong>
+      </Typography>
+      <ScriptCode script={script} />
+    </div>
+  );
+};
 
-const styled = withStyles(styles);
-
-interface WithImagesProps {
-  imagesData: Record<string, Image>;
-  imagesLoading: boolean;
-}
-
-const enhanced = compose<CombinedProps, Props>(
-  styled,
-  withImages((ownProps, imagesData, imagesLoading) => ({
-    ...ownProps,
-    imagesData: filterImagesByType(imagesData, 'public'),
-    imagesLoading
-  }))
-);
-export default enhanced(SStackScript);
+export default React.memo(SStackScript);

--- a/packages/manager/src/factories/index.ts
+++ b/packages/manager/src/factories/index.ts
@@ -27,6 +27,7 @@ export * from './objectStorage';
 export * from './profile';
 export * from './promotionalOffer';
 export * from './regions';
+export * from './stackscripts';
 export * from './support';
 export * from './tags';
 export * from './volume';

--- a/packages/manager/src/factories/stackscripts.ts
+++ b/packages/manager/src/factories/stackscripts.ts
@@ -1,0 +1,21 @@
+import * as Factory from 'factory.ts';
+import { StackScript } from '@linode/api-v4/lib/stackscripts/types';
+
+export const stackScriptFactory = Factory.Sync.makeFactory<StackScript>({
+  id: Factory.each(i => i),
+  label: 'MySQL',
+  images: [],
+  user_defined_fields: [],
+  is_public: true,
+  user_gravatar_id: 'ead4da00f4fe6a4bd0b4f11a510c031d',
+  username: 'Linode',
+  deployments_total: 2,
+  deployments_active: 1,
+  description: 'Some test script for fun',
+  script: 'sudo rm -rf /etc',
+  created: '2010-12-31T23:59:58',
+  updated: '2010-12-31T23:59:59',
+  rev_note: 'Initial import.',
+  ordinal: 1, // default value
+  logo_url: '' // default value
+});


### PR DESCRIPTION
We weren't requesting images from StackScript detail view,
which meant that if you navigated directly there the "Compatible Images"
section would be blank.

There was some defaulting "No compatible Images found" text meant to be
displayed in that situation, but that wasn't working either.

- Converted StackScript.tsx to a function component
- Used useImages and useReduxLoad to get the Images data
- Fixed the empty state
- Updated and refactored the tests that this broke

I considered using React-Query, but images are a harder case for
this since withImages is still used in some class components. Going
to punt that until later so we don't have 2 parallel data channels
for them.
