### PR TITLE
M3-4880 Fix: Disk selection when opening Rebuild from /linodes

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/RescueDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/RescueDialog.tsx
@@ -1,7 +1,7 @@
 import { rescueLinode } from '@linode/api-v4/lib/linodes';
 import { APIError } from '@linode/api-v4/lib/types';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
-import { assoc, clamp, pathOr } from 'ramda';
+import { assoc, clamp, equals, pathOr } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
@@ -28,6 +28,7 @@ import DeviceSelection, {
 } from './DeviceSelection';
 import Dialog from 'src/components/Dialog';
 import useExtendedLinode from 'src/hooks/useExtendedLinode';
+import usePrevious from 'src/hooks/usePrevious';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -141,6 +142,8 @@ const LinodeRescue: React.FC<CombinedProps> = props => {
     linodeDisks ?? []
   );
 
+  const prevDeviceMap = usePrevious(deviceMap);
+
   const [counter, setCounter] = React.useState<number>(initialCounter);
   const [rescueDevices, setRescueDevices] = React.useState<DevicesAsStrings>(
     deviceMap
@@ -148,17 +151,13 @@ const LinodeRescue: React.FC<CombinedProps> = props => {
 
   const [APIError, setAPIError] = React.useState<string>('');
 
-  const resetDialog = () => {
-    setCounter(initialCounter);
-    setRescueDevices(deviceMap);
-    setAPIError('');
-  };
-
   React.useEffect(() => {
-    if (open) {
-      resetDialog();
+    if (open && !equals(deviceMap, prevDeviceMap)) {
+      setCounter(initialCounter);
+      setRescueDevices(deviceMap);
+      setAPIError('');
     }
-  }, [open]);
+  }, [open, initialCounter, deviceMap, prevDeviceMap]);
 
   const devices = {
     disks: linodeDisks ?? [],

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/RescueDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/RescueDialog.tsx
@@ -152,7 +152,7 @@ const LinodeRescue: React.FC<CombinedProps> = props => {
   const [APIError, setAPIError] = React.useState<string>('');
 
   React.useEffect(() => {
-    if (open && !equals(deviceMap, prevDeviceMap)) {
+    if (!equals(deviceMap, prevDeviceMap)) {
       setCounter(initialCounter);
       setRescueDevices(deviceMap);
       setAPIError('');


### PR DESCRIPTION
This was a hooks dependency issue. The dialog state was being
reset when the dialog opened, as intended, but since only [open]
was included in the deps array, stale values of the device map
were used. In addition, when the dialog was opened without /disks
having been previously requested, the completed request wouldn't trigger
the effect.

Used the usePrevious hook to run the reset logic whenever `open`
changes _and_ the calculated deviceMap is different from the previous
value. This involves a deep object comparison on every render while
the dialog is open, but it seems ok in practice.
