### PR TITLE
M3-4845: Reduce size of Docs text link and icon

### DIFF
--- a/packages/manager/src/assets/icons/docs.svg
+++ b/packages/manager/src/assets/icons/docs.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
+<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 20 20">
     <g fill="none" fill-rule="evenodd" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.25">
         <path d="M1.974 19.375c-.727 0-1.316-.56-1.316-1.25V1.875c0-.69.589-1.25 1.316-1.25h13.158c.343 0 .672.127.918.355l2.632 2.402c.254.236.397.558.397.895v15.098H1.974zM4.605 6.875L15.132 6.875M4.605 10.625L9.868 10.625M4.605 14.375L12.105 14.5"/>
     </g>

--- a/packages/manager/src/components/CMR_DocumentationButton/DocumentationButton.tsx
+++ b/packages/manager/src/components/CMR_DocumentationButton/DocumentationButton.tsx
@@ -7,7 +7,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   root: {
     alignItems: 'center',
     fontFamily: theme.font.normal,
-    fontSize: 14,
+    fontSize: '.875rem',
     lineHeight: 'normal',
     margin: 0,
     minWidth: 'auto',

--- a/packages/manager/src/components/CMR_DocumentationButton/DocumentationButton.tsx
+++ b/packages/manager/src/components/CMR_DocumentationButton/DocumentationButton.tsx
@@ -7,6 +7,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   root: {
     alignItems: 'center',
     fontFamily: theme.font.normal,
+    fontSize: 14,
     lineHeight: 'normal',
     margin: 0,
     minWidth: 'auto',


### PR DESCRIPTION
## Description
Set the Docs icon to 18px and the text to 14px

Before:
<img width="1141" alt="Screen Shot 2021-01-27 at 4 59 14 PM" src="https://user-images.githubusercontent.com/32860776/106059651-055f0500-60c1-11eb-8f04-714b794d84bf.png">

After:
<img width="1141" alt="Screen Shot 2021-01-27 at 4 59 21 PM" src="https://user-images.githubusercontent.com/32860776/106059666-0859f580-60c1-11eb-8df4-b2750d273f0b.png">

## Type of Change
- Non breaking change ('update', 'change')
