### PR TITLE
M3-4833: Change table header font color

### DIFF
--- a/packages/manager/src/components/Table/Table_CMR.tsx
+++ b/packages/manager/src/components/Table/Table_CMR.tsx
@@ -30,7 +30,7 @@ const styles = (theme: Theme) =>
           borderLeft: `1px solid ${theme.cmrBorderColors.borderTable}`,
           fontFamily: theme.font.bold,
           fontSize: '0.875em !important',
-          color: theme.palette.text.primary,
+          color: theme.cmrTextColors.tableHeader,
           padding: '10px 15px',
           '&:first-of-type': {
             borderLeft: 'none'

--- a/packages/manager/src/components/TableSortCell/TableSortCell_CMR.tsx
+++ b/packages/manager/src/components/TableSortCell/TableSortCell_CMR.tsx
@@ -14,10 +14,10 @@ const useStyles = makeStyles((theme: Theme) => ({
       width: 20
     },
     '&:hover': {
-      backgroundColor: '#3683dc',
+      backgroundColor: theme.palette.primary.main,
       cursor: 'pointer',
       '& span': {
-        color: '#ffffff'
+        color: '#ffffff !important'
       },
       '& .MuiTableSortLabel-icon': {
         color: '#ffffff !important'
@@ -28,7 +28,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     }
   },
   label: {
-    color: theme.palette.text.primary,
+    color: theme.cmrTextColors.tableHeader,
     fontSize: '.875rem',
     minHeight: 20,
     transition: 'none'

--- a/packages/manager/src/features/Profile/APITokens/APITokenTable.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokenTable.tsx
@@ -74,6 +74,7 @@ const styles = (theme: Theme) =>
       }
     },
     labelCell: {
+      ...theme.applyTableHeaderStyles,
       width: '40%',
       [theme.breakpoints.down('md')]: {
         width: '25%'

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs_CMR.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs_CMR.tsx
@@ -1,3 +1,4 @@
+import { Account } from '@linode/api-v4/lib/account';
 import {
   Config,
   Disk,
@@ -20,7 +21,6 @@ import AddNewLink from 'src/components/AddNewLink/AddNewLink_CMR';
 import Button from 'src/components/Button';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
 import RootRef from 'src/components/core/RootRef';
-import { getAllVlans } from 'src/store/vlans/vlans.requests';
 import {
   createStyles,
   Theme,
@@ -40,21 +40,21 @@ import Table from 'src/components/Table/Table_CMR';
 import TableCell from 'src/components/TableCell/TableCell_CMR.tsx';
 import TableContentWrapper from 'src/components/TableContentWrapper';
 import TableSortCell from 'src/components/TableSortCell/TableSortCell_CMR';
+import withFeatureFlags, {
+  FeatureFlagConsumerProps
+} from 'src/containers/withFeatureFlagConsumer.container.ts';
 import { resetEventsPolling } from 'src/eventsPolling';
 import {
   DeleteLinodeConfig,
   withLinodeDetailContext
 } from 'src/features/linodes/LinodesDetail/linodeDetailContext';
 import { MapState } from 'src/store/types';
+import { getAllVlans } from 'src/store/vlans/vlans.requests';
+import { isFeatureEnabled } from 'src/utilities/accountCapabilities';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { getAll, GetAllData } from 'src/utilities/getAll';
 import LinodeConfigDrawer from '../LinodeSettings/LinodeConfigDrawer_CMR';
 import ConfigRow from './ConfigRow_CMR';
-import withFeatureFlags, {
-  FeatureFlagConsumerProps
-} from 'src/containers/withFeatureFlagConsumer.container.ts';
-import { isFeatureEnabled } from 'src/utilities/accountCapabilities';
-import { Account } from '@linode/api-v4/lib/account';
 
 type ClassNames =
   | 'root'
@@ -99,9 +99,11 @@ const styles = (theme: Theme) =>
       fontWeight: 'bold'
     },
     labelColumn: {
+      ...theme.applyTableHeaderStyles,
       width: '18%'
     },
     vmColumn: {
+      ...theme.applyTableHeaderStyles,
       width: '10%'
     },
     kernelColumn: {

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.styles.ts
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.styles.ts
@@ -31,8 +31,8 @@ const styles = (theme: Theme) =>
       flexDirection: 'row-reverse'
     },
     CSVlink: {
+      color: theme.cmrTextColors.tableHeader,
       fontSize: '.9rem',
-      color: theme.palette.text.primary,
       '&:hover': {
         textDecoration: 'underline'
       }

--- a/packages/manager/src/features/linodes/LinodesLanding/SortableTableHead.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/SortableTableHead.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
+import GridView from 'src/assets/icons/grid-view.svg';
+import Hidden from 'src/components/core/Hidden';
+import IconButton from 'src/components/core/IconButton';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import TableHead from 'src/components/core/TableHead';
+import Tooltip from 'src/components/core/Tooltip';
+import { GroupByTagToggle } from 'src/components/EntityTable/EntityTableHeader';
 import { OrderByProps } from 'src/components/OrderBy';
 import TableCell from 'src/components/TableCell/TableCell_CMR';
 import TableRow from 'src/components/TableRow/TableRow_CMR';
 import TableSortCell from 'src/components/TableSortCell/TableSortCell_CMR';
-import Hidden from 'src/components/core/Hidden';
-import IconButton from 'src/components/core/IconButton';
-import Tooltip from 'src/components/core/Tooltip';
-import GridView from 'src/assets/icons/grid-view.svg';
-import { makeStyles, Theme } from 'src/components/core/styles';
-import { GroupByTagToggle } from 'src/components/EntityTable/EntityTableHeader';
 
 const useStyles = makeStyles((theme: Theme) => ({
   controlHeader: {
@@ -27,12 +27,14 @@ const useStyles = makeStyles((theme: Theme) => ({
   // There's nothing very scientific about the widths across the breakpoints
   // here, just a lot of trial and error based on maximum expected column sizes.
   labelCell: {
+    ...theme.applyTableHeaderStyles,
     width: '24%',
     [theme.breakpoints.down('md')]: {
       width: '20%'
     }
   },
   statusCell: {
+    ...theme.applyTableHeaderStyles,
     width: '20%',
     [theme.breakpoints.only('md')]: {
       width: '27%'
@@ -42,24 +44,28 @@ const useStyles = makeStyles((theme: Theme) => ({
     }
   },
   planCell: {
+    ...theme.applyTableHeaderStyles,
     width: '14%',
     [theme.breakpoints.only('sm')]: {
       width: '15%'
     }
   },
   ipAddressCell: {
+    ...theme.applyTableHeaderStyles,
     width: '14%',
     [theme.breakpoints.only('sm')]: {
       width: '22%'
     }
   },
   regionCell: {
+    ...theme.applyTableHeaderStyles,
     width: '14%',
     [theme.breakpoints.down('xs')]: {
       width: '18%'
     }
   },
   lastBackupCell: {
+    ...theme.applyTableHeaderStyles,
     width: '14%',
     [theme.breakpoints.down('xs')]: {
       width: '18%'

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -54,6 +54,7 @@ declare module '@material-ui/core/styles/createMuiTheme' {
     addCircleHoverEffect?: any;
     applyLinkStyles?: any;
     applyStatusPillStyles?: any;
+    applyTableHeaderStyles?: any;
 
     notificationList: any;
     status: any;
@@ -94,6 +95,7 @@ const cmrBGColors = {
 const cmrTextColors = {
   linkActiveLight: '#2575d0',
   headlineStatic: '#32363c',
+  tableHeader: '#888F91',
   tableStatic: '#606469',
   textAccessTable: '#606469'
 };
@@ -187,6 +189,16 @@ const genericStatusPillStyle = {
     width: 16,
     minWidth: 16,
     marginRight: 8
+  }
+};
+
+const genericTableHeaderStyle = {
+  '&:hover': {
+    backgroundColor: primaryColors.main,
+    cursor: 'pointer',
+    '& span': {
+      color: '#fff !important'
+    }
   }
 };
 
@@ -408,6 +420,9 @@ const themeDefaults: ThemeDefaults = ({ spacingOverride: spacingUnit }) => {
     },
     applyStatusPillStyles: {
       ...genericStatusPillStyle
+    },
+    applyTableHeaderStyles: {
+      ...genericTableHeaderStyle
     },
     notificationList: {
       padding: '16px 32px 16px 23px',
@@ -1431,17 +1446,14 @@ const themeDefaults: ThemeDefaults = ({ spacingOverride: spacingUnit }) => {
           fontSize: '.9rem',
           lineHeight: '1.1rem',
           transition: 'color 225ms ease-in-out',
+          '&.MuiTableSortLabel-active': {
+            color: cmrTextColors.tableHeader
+          },
           '&:hover': {
             color: primaryColors.main
           },
           '&:focus': {
             outline: '1px dotted #999'
-          }
-        },
-        active: {
-          color: primaryColors.main,
-          '&:hover': {
-            color: primaryColors.main
           }
         },
         icon: {

--- a/packages/manager/src/themes.ts
+++ b/packages/manager/src/themes.ts
@@ -30,6 +30,7 @@ const cmrBGColors = {
 const cmrTextColors = {
   linkActiveLight: '#74aae6',
   headlineStatic: '#e6e6e6',
+  tableHeader: '#888F91',
   tableStatic: '#e6e6e6',
   textAccessTable: '#acb0b4'
 };


### PR DESCRIPTION
The new grey color has been applied to table headers and the "Download CSV" link on the Linode Landing page

This PR also includes a fix make sure all table headers have a blue background and white text on hover which was previously missing on the Linode Landing page and a few other tables