### PR TITLE
Firewalls: update submission of IP addresses

### DIFF
--- a/packages/api-v4/src/firewalls/types.ts
+++ b/packages/api-v4/src/firewalls/types.ts
@@ -21,7 +21,7 @@ export interface FirewallRules {
 
 export interface FirewallRuleType {
   protocol: FirewallRuleProtocol;
-  ports: string;
+  ports?: string;
   addresses?: null | {
     ipv4?: null | string[];
     ipv6?: null | string[];

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.test.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.test.tsx
@@ -53,18 +53,15 @@ describe('utilities', () => {
         allIPs
       );
       expect(formValueToIPs('allIPv4', [''].map(stringToExtendedIP))).toEqual({
-        ipv4: ['0.0.0.0/0'],
-        ipv6: []
+        ipv4: ['0.0.0.0/0']
       });
       expect(formValueToIPs('allIPv6', [''].map(stringToExtendedIP))).toEqual({
-        ipv4: [],
         ipv6: ['::/0']
       });
       expect(
         formValueToIPs('ip/netmask', ['1.1.1.1'].map(stringToExtendedIP))
       ).toEqual({
-        ipv4: ['1.1.1.1'],
-        ipv6: []
+        ipv4: ['1.1.1.1']
       });
     });
   });
@@ -165,8 +162,7 @@ describe('utilities', () => {
     });
     it('accepts ranges', () => {
       expect(classifyIPs(['1.1.0.0/16'].map(stringToExtendedIP))).toEqual({
-        ipv4: ['1.1.0.0/16'],
-        ipv6: []
+        ipv4: ['1.1.0.0/16']
       });
     });
   });

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
@@ -342,6 +342,7 @@ const FirewallRuleForm: React.FC<FirewallRuleFormProps> = React.memo(props => {
         value={addressesValue}
         onChange={handleAddressesChange}
         onBlur={handleBlur}
+        isClearable={false}
       />
       {/* Show this field only if "IP / Netmask has been selected." */}
       {values.addresses === 'ip/netmask' && (

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -337,7 +337,7 @@ export const firewallRuleToRowData = (
 
     return {
       ...thisRule,
-      ports: sortPortString(thisRule.ports),
+      ports: sortPortString(thisRule.ports || ''),
       type: generateRuleLabel(ruleType),
       addresses: generateAddressesLabel(thisRule.addresses),
       id: idx

--- a/packages/manager/src/features/Firewalls/shared.ts
+++ b/packages/manager/src/features/Firewalls/shared.ts
@@ -62,7 +62,7 @@ export const protocolOptions: Item<FirewallRuleProtocol>[] = [
 ];
 
 export const addressOptions = [
-  { label: 'All', value: 'all' },
+  { label: 'All IPv4, All IPv6', value: 'all' },
   { label: 'All IPv4', value: 'allIPv4' },
   { label: 'All IPv6', value: 'allIPv6' },
   { label: 'IP / Netmask', value: 'ip/netmask' }


### PR DESCRIPTION
A change made in the API means that an empty address list is not accepted. Therefore if there are no ipv6 addresses for example, we don't include the ipv6 field at all.

I also made `ports` optional since that was changed in the API as well.

**To test,** use the dev API and check FW rule submission/editing thoroughly. 