### PR TITLE
M3-4835: New Accordion expand/collapse icons

### DIFF
--- a/packages/manager/src/assets/icons/minus-square.svg
+++ b/packages/manager/src/assets/icons/minus-square.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="20" height="20" viewBox="0 0 22 22" fill="none" stroke="currentColor" stroke-width="1" stroke-linecap="butt" stroke-linejoin="butt">
-  <rect x="2" y="2" width="16" height="16" rx="0" ry="0" class="border"></rect>
-  <line x1="8" y1="12" x2="16" y2="12" transform="translate(-2, -2)"></line>
-</svg>

--- a/packages/manager/src/assets/icons/plus-square.svg
+++ b/packages/manager/src/assets/icons/plus-square.svg
@@ -1,5 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="20" height="20" viewBox="0 0 22 22" fill="none" stroke="currentColor" stroke-width="1" stroke-linecap="butt" stroke-linejoin="butt">
-  <rect x="2" y="2" width="16" height="16" rx="0" ry="0" class="border"></rect>
-  <line x1="12" y1="8" x2="12" y2="16" transform="translate(-2, -2)"></line>
-  <line x1="8" y1="12" x2="16" y2="12" transform="translate(-2, -2)"></line>
-</svg>

--- a/packages/manager/src/components/Accordion/Accordion.tsx
+++ b/packages/manager/src/components/Accordion/Accordion.tsx
@@ -1,6 +1,5 @@
+import KeyboardArrowDown from '@material-ui/icons/KeyboardArrowDown';
 import * as React from 'react';
-import Minus from 'src/assets/icons/minus-square.svg';
-import Plus from 'src/assets/icons/plus-square.svg';
 import Accordion, { AccordionProps } from 'src/components/core/Accordion';
 import AccordionDetails, {
   AccordionDetailsProps
@@ -118,7 +117,7 @@ class AAccordion extends React.Component<CombinedProps> {
       <Accordion {...accordionProps} className={classes.root} data-qa-panel>
         <AccordionSummary
           onClick={this.handleClick}
-          expandIcon={this.state.open ? <Minus /> : <Plus />}
+          expandIcon={<KeyboardArrowDown />}
           {...summaryProps}
           data-qa-panel-summary={this.props.heading}
         >

--- a/packages/manager/src/components/AddNewLink/AddNewLink.tsx
+++ b/packages/manager/src/components/AddNewLink/AddNewLink.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
-
-import PlusSquare from 'src/assets/icons/plus-square.svg';
 import Tooltip, { TooltipProps } from 'src/components/core/Tooltip';
-import IconTextLink from 'src/components/IconTextLink';
+import Button from '../Button';
 
 export interface Props extends Omit<TooltipProps, 'children' | 'title'> {
   label: string;
@@ -30,7 +28,6 @@ const AddNewLink: React.FC<CombinedProps> = props => {
   } = props;
 
   const baseProps = {
-    SideIcon: PlusSquare,
     onClick,
     title: label,
     text: label,
@@ -50,16 +47,18 @@ const AddNewLink: React.FC<CombinedProps> = props => {
         title={disabledReason}
       >
         <div>
-          {/* 
+          {/*
             wrapping in div because the child of tooltip needs to be able to hold a ref 
           */}
-          <IconTextLink {...baseProps}>{display || label}</IconTextLink>
+          <Button buttonType="secondary" {...baseProps}>
+            {display || label}
+          </Button>
         </div>
       </Tooltip>
     );
   }
 
-  return <IconTextLink {...baseProps}>{display || label}</IconTextLink>;
+  return <Button {...baseProps}>{display || label}</Button>;
 };
 
 export default AddNewLink;

--- a/packages/manager/src/features/Support/TicketDetailText.tsx
+++ b/packages/manager/src/features/Support/TicketDetailText.tsx
@@ -1,70 +1,48 @@
+import KeyboardArrowDown from '@material-ui/icons/KeyboardArrowDown';
 import * as React from 'react';
-import { compose } from 'recompose';
-import Collapse from 'src/assets/icons/minus-square.svg';
-import Expand from 'src/assets/icons/plus-square.svg';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles
-} from 'src/components/core/styles';
-import Typography from 'src/components/core/Typography';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Grid from 'src/components/Grid';
 import HighlightedMarkdown from 'src/components/HighlightedMarkdown';
 import IconButton from 'src/components/IconButton';
-
 import truncateText from 'src/utilities/truncateText';
 
-type ClassNames = 'root' | 'expButton' | 'toggle' | 'buttonText';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {
-      marginTop: theme.spacing(1),
-      padding: `${theme.spacing(2)}px ${theme.spacing(1)}px`,
-      position: 'relative',
-      '& pre': {
-        backgroundColor: theme.bg.tableHeader
-      }
-    },
-    expButton: {
-      position: 'absolute',
-      top: -43,
-      right: 0,
-      left: 'auto',
-      '& svg': {
-        stroke: theme.color.grey1
-      },
-      '& .border': {
-        stroke: theme.color.grey1,
-        fill: theme.color.white
-      }
-    },
-    toggle: {
-      height: 24,
-      width: 24
-    },
-    buttonText: {
-      position: 'relative',
-      top: -1,
-      marginRight: 4,
-      color: theme.palette.primary.main,
-      [theme.breakpoints.down('sm')]: {
-        visibility: 'hidden'
-      }
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    marginTop: theme.spacing(1),
+    padding: `${theme.spacing(2)}px ${theme.spacing(1)}px`,
+    position: 'relative',
+    '& pre': {
+      backgroundColor: theme.bg.tableHeader
     }
-  });
+  },
+  expButton: {
+    position: 'absolute',
+    top: -43,
+    right: 0,
+    left: 'auto',
+    '& svg': {
+      stroke: theme.cmrTextColors.tableHeader
+    }
+  },
+  toggle: {
+    height: 22,
+    width: 22
+  },
+  expand: {
+    transform: 'rotate(180deg)'
+  }
+}));
 
 interface Props {
   text: string;
   open?: boolean;
 }
 
-type CombinedProps = Props & WithStyles<ClassNames>;
+const TicketDetailText: React.FC<Props> = props => {
+  const classes = useStyles();
 
-const TicketDetailText: React.FC<CombinedProps> = props => {
   const [panelOpen, togglePanel] = React.useState<boolean>(props.open || true);
-  const { text, classes } = props;
+  const { text } = props;
 
   const truncatedText = truncateText(text, 175);
   const ticketReplyBody = panelOpen ? text : truncatedText;
@@ -81,19 +59,11 @@ const TicketDetailText: React.FC<CombinedProps> = props => {
           onClick={() => togglePanel(!panelOpen)}
         >
           {panelOpen ? (
-            <>
-              <Typography component="span" className={classes.buttonText}>
-                Collapse
-              </Typography>
-              <Collapse className={classes.toggle} />
-            </>
+            <KeyboardArrowDown className={classes.toggle} />
           ) : (
-            <>
-              <Typography component="span" className={classes.buttonText}>
-                Expand
-              </Typography>
-              <Expand className={classes.toggle} />
-            </>
+            <KeyboardArrowDown
+              className={`${classes.toggle} ${classes.expand}`}
+            />
           )}
         </IconButton>
       )}
@@ -101,9 +71,4 @@ const TicketDetailText: React.FC<CombinedProps> = props => {
   );
 };
 
-const styled = withStyles(styles, { withTheme: true });
-
-export default compose<CombinedProps, Props>(
-  React.memo,
-  styled
-)(TicketDetailText);
+export default React.memo(TicketDetailText);

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -775,25 +775,16 @@ const themeDefaults: ThemeDefaults = ({ spacingOverride: spacingUnit }) => {
       },
       MuiAccordionSummary: {
         root: {
-          '&$focused': {
-            backgroundColor: '#fbfbfb'
-          },
-          padding: `0 ${spacingUnit * 2 + 2}px`,
-          backgroundColor: '#fbfbfb',
           justifyContent: 'flex-start',
+          backgroundColor: '#fbfbfb',
           minHeight: spacingUnit * 6,
+          padding: `0 ${spacingUnit * 2 + 2}px`,
           '& h3': {
             transition: 'color 400ms cubic-bezier(0.4, 0, 0.2, 1) 0ms'
           },
           '&:hover': {
             '& h3': {
               color: primaryColors.light
-            },
-            '& $expandIcon': {
-              '& svg': {
-                fill: primaryColors.light,
-                stroke: 'white'
-              }
             }
           },
           '&:focus': {
@@ -803,6 +794,9 @@ const themeDefaults: ThemeDefaults = ({ spacingOverride: spacingUnit }) => {
           '&$expanded': {
             minHeight: spacingUnit * 6,
             margin: 0
+          },
+          '&$focused': {
+            backgroundColor: '#fbfbfb'
           }
         },
         content: {
@@ -813,31 +807,20 @@ const themeDefaults: ThemeDefaults = ({ spacingOverride: spacingUnit }) => {
             margin: `${spacingUnit + spacingUnit / 2}px 0`
           }
         },
-        expanded: {},
         expandIcon: {
           display: 'flex',
-          order: 1,
-          top: 0,
-          right: 0,
-          transform: 'none',
-          color: primaryColors.main,
-          position: 'relative',
           marginLeft: -spacingUnit * 2,
           '& svg': {
-            fill: '#fff',
-            transition: `${'stroke 400ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, '}
-            ${'fill 400ms cubic-bezier(0.4, 0, 0.2, 1) 0ms'}`,
+            fill: cmrTextColors.tableHeader,
+            height: 22,
             width: 22,
-            height: 22
-          },
-          '& .border': {
-            stroke: `${primaryColors.light} !important`
+            transition: `${'stroke 400ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, '}
+            ${'fill 400ms cubic-bezier(0.4, 0, 0.2, 1) 0ms'}`
           },
           '&$expanded': {
-            transform: 'none'
+            transform: 'rotate(180deg)'
           }
-        },
-        focused: {}
+        }
       },
       MuiFormControl: {
         root: {

--- a/packages/manager/src/themes.ts
+++ b/packages/manager/src/themes.ts
@@ -398,31 +398,16 @@ const darkThemeOptions = {
     },
     MuiAccordionSummary: {
       root: {
-        '&$focused': {
-          backgroundColor: '#111111'
-        },
         backgroundColor: '#32363c',
         '&:hover': {
           '& h3': {
             color: primaryColors.light
-          },
-          '& $expandIcon': {
-            '& svg': {
-              fill: primaryColors.light
-            }
           }
-        }
-      },
-      expandIcon: {
-        color: primaryColors.main,
-        '& svg': {
-          fill: 'transparent'
         },
-        '& .border': {
-          stroke: `${primaryColors.light} !important`
+        '&$focused': {
+          backgroundColor: '#111111'
         }
-      },
-      focused: {}
+      }
     },
     MuiFormControl: {
       root: {


### PR DESCRIPTION
Swap the previous expand/collapse icons used in the `Accordion` component and the same icons used in `/support/tickets`