### PR TITLE
M3-4854: Fix StackScripts search

### DIFF
--- a/packages/manager/src/components/StackScript/StackScript.tsx
+++ b/packages/manager/src/components/StackScript/StackScript.tsx
@@ -112,10 +112,7 @@ export const SStackScript: React.FC<Props> = props => {
     return imageChips.length > 0 ? imageChips : <>No compatible images found</>;
   }, [images, imagesData]);
 
-  const queryString = stringify({
-    type: 'community',
-    query: `username:${username}`
-  });
+  const queryString = stringify({ query: `username:${username}` });
 
   return (
     <div className={classes.root}>
@@ -126,7 +123,10 @@ export const SStackScript: React.FC<Props> = props => {
         data-qa-stack-author={username}
       >
         by&nbsp;
-        <Link to={`/stackscripts/${queryString}`} data-qa-community-stack-link>
+        <Link
+          to={`/stackscripts/community?${queryString}`}
+          data-qa-community-stack-link
+        >
           {username}
         </Link>
       </Typography>

--- a/packages/manager/src/components/StackScript/StackScript.tsx
+++ b/packages/manager/src/components/StackScript/StackScript.tsx
@@ -5,12 +5,13 @@ import { Link } from 'react-router-dom';
 import CopyTooltip from 'src/components/CopyTooltip';
 import Chip from 'src/components/core/Chip';
 import Divider from 'src/components/core/Divider';
-import { Theme, makeStyles } from 'src/components/core/styles';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import DateTimeDisplay from 'src/components/DateTimeDisplay';
 import H1Header from 'src/components/H1Header';
 import ScriptCode from 'src/components/ScriptCode';
 import { useImages } from 'src/hooks/useImages';
+import useProfile from 'src/hooks/useProfile';
 import { useReduxLoad } from 'src/hooks/useReduxLoad';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -90,6 +91,7 @@ export const SStackScript: React.FC<Props> = props => {
 
   const classes = useStyles();
   const { images: imagesData } = useImages('public');
+  const { profile } = useProfile();
   useReduxLoad(['images']);
 
   const compatibleImages = React.useMemo(() => {
@@ -113,6 +115,10 @@ export const SStackScript: React.FC<Props> = props => {
   }, [images, imagesData]);
 
   const queryString = stringify({ query: `username:${username}` });
+  const link =
+    profile.data?.username === username
+      ? '/stackscripts/account'
+      : `/stackscripts/community?${queryString}`;
 
   return (
     <div className={classes.root}>
@@ -123,10 +129,7 @@ export const SStackScript: React.FC<Props> = props => {
         data-qa-stack-author={username}
       >
         by&nbsp;
-        <Link
-          to={`/stackscripts/community?${queryString}`}
-          data-qa-community-stack-link
-        >
+        <Link to={link} data-qa-community-stack-link>
           {username}
         </Link>
       </Typography>

--- a/packages/manager/src/components/StackScript/StackScript.tsx
+++ b/packages/manager/src/components/StackScript/StackScript.tsx
@@ -126,7 +126,7 @@ export const SStackScript: React.FC<Props> = props => {
         data-qa-stack-author={username}
       >
         by&nbsp;
-        <Link to={`/stackscripts?${queryString}`} data-qa-community-stack-link>
+        <Link to={`/stackscripts/${queryString}`} data-qa-community-stack-link>
           {username}
         </Link>
       </Typography>

--- a/packages/manager/src/features/StackScripts/Partials/StackScriptTableHead_CMR.tsx
+++ b/packages/manager/src/features/StackScripts/Partials/StackScriptTableHead_CMR.tsx
@@ -80,7 +80,11 @@ const useStyles = makeStyles((theme: Theme) => ({
     height: 48
   },
   tableHead: {
-    top: 104
+    color: theme.cmrTextColors.tableHeader,
+    top: 104,
+    '& span': {
+      color: theme.cmrTextColors.tableHeader
+    }
   }
 }));
 

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -332,7 +332,7 @@ const withStackScriptBase = (options: WithStackScriptBaseOptions) => (
 
       // Update the Query String as the user types.
       if (useQueryString) {
-        updateQueryString(category, lowerCaseValue, history);
+        updateQueryString(lowerCaseValue, history);
       }
 
       let filter: any;
@@ -659,11 +659,10 @@ export default withStackScriptBase;
 
 // Update the query string with a `type=` and `query=`.
 const updateQueryString = (
-  type: string,
   query: string,
   history: RouteComponentProps<{}>['history']
 ) => {
-  const queryString = stringify({ type, query });
+  const queryString = stringify({ query });
 
   // Use `replace` instead of `push` so that each keystroke is not a separate
   // browser history item.

--- a/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptRow.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptRow.tsx
@@ -58,7 +58,7 @@ export const StackScriptRow: React.FC<CombinedProps> = props => {
   const renderLabel = () => {
     return (
       <React.Fragment>
-        <Link to={`/stackscripts/${stackScriptID}`}>
+        <Link className={classes.link} to={`/stackscripts/${stackScriptID}`}>
           <Typography variant="h3" className={classes.libTitle}>
             {stackScriptUsername && (
               <span

--- a/packages/manager/src/features/StackScripts/StackScriptRowHelpers.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptRowHelpers.tsx
@@ -5,6 +5,7 @@ import { createStyles, Theme } from 'src/components/core/styles';
 import ShowMore from 'src/components/ShowMore';
 
 export type ClassNames =
+  | 'link'
   | 'libRadio'
   | 'libRadioLabel'
   | 'libTitle'
@@ -17,6 +18,9 @@ export type ClassNames =
 
 export const styles = (theme: Theme) =>
   createStyles({
+    link: {
+      color: theme.cmrTextColors.tableStatic
+    },
     libRadio: {
       display: 'flex',
       flexWrap: 'wrap',


### PR DESCRIPTION
Removing the type from `querySearch` fixes the search redirecting to /accounts

**Update:**
- If the username matches the one in the profile, the username link from the StackScripts Detail page redirects to `/accounts`
- If not, it'll redirect to `/community/?query=username[insert username]` instead
- Change the table headers to the new gray color
- Made the link underline color match the text instead of blue