### PR TITLE
M3-4857: Update flag art

### DIFF
--- a/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionSelect.tsx
+++ b/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionSelect.tsx
@@ -69,7 +69,7 @@ export const flags = {
   uk: () => <UK width="32" height="24" viewBox="0 0 640 480" />,
   eu: () => <UK width="32" height="24" viewBox="0 0 640 480" />,
   de: () => <DE width="32" height="24" viewBox="0 0 640 480" />,
-  ca: () => <CA id="canada" width="32" height="24" viewBox="0 0 640 480" />,
+  ca: () => <CA width="32" height="24" viewBox="0 0 640 480" />,
   in: () => <IN width="32" height="24" viewBox="0 0 640 480" />
 };
 
@@ -84,7 +84,7 @@ const useStyles = makeStyles((theme: Theme) => ({
         clipPath: 'none !important' as 'none'
       }
     },
-    '& #singapore, #japan, #canada': {
+    '& #singapore, #japan': {
       border: `1px solid ${theme.color.border3}`
     }
   }

--- a/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionSelect.tsx
+++ b/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionSelect.tsx
@@ -1,3 +1,4 @@
+import { Region } from '@linode/api-v4/lib/regions';
 import AU from 'flag-icon-css/flags/4x3/au.svg';
 import CA from 'flag-icon-css/flags/4x3/ca.svg';
 import DE from 'flag-icon-css/flags/4x3/de.svg';
@@ -6,11 +7,10 @@ import IN from 'flag-icon-css/flags/4x3/in.svg';
 import JP from 'flag-icon-css/flags/4x3/jp.svg';
 import SG from 'flag-icon-css/flags/4x3/sg.svg';
 import US from 'flag-icon-css/flags/4x3/us.svg';
-import { Region } from '@linode/api-v4/lib/regions';
 import { groupBy } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
-import { makeStyles } from 'src/components/core/styles';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import SingleValue from 'src/components/EnhancedSelect/components/SingleValue';
 import Select, {
@@ -18,7 +18,6 @@ import Select, {
   GroupType
 } from 'src/components/EnhancedSelect/Select';
 import Link from 'src/components/Link';
-
 import RegionOption, { RegionItem } from './RegionOption';
 
 /**
@@ -55,11 +54,12 @@ interface Props extends Omit<BaseSelectProps, 'onChange'> {
 }
 
 export const flags = {
-  au: () => <AU width="32" height="24" viewBox="0 0 720 480" />,
-  us: () => <US width="32" height="24" viewBox="0 0 720 480" />,
-  sg: () => <SG width="32" height="24" viewBox="0 0 640 480" />,
+  au: () => <AU width="32" height="24" viewBox="0 0 640 480" />,
+  us: () => <US width="32" height="24" viewBox="0 0 640 480" />,
+  sg: () => <SG id="singapore" width="32" height="24" viewBox="0 0 640 480" />,
   jp: () => (
     <JP
+      id="japan"
       width="32"
       height="24"
       viewBox="0 0 640 480"
@@ -68,21 +68,24 @@ export const flags = {
   ),
   uk: () => <UK width="32" height="24" viewBox="0 0 640 480" />,
   eu: () => <UK width="32" height="24" viewBox="0 0 640 480" />,
-  de: () => <DE width="32" height="24" viewBox="0 0 720 480" />,
-  ca: () => <CA width="32" height="24" viewBox="0 0 640 480" />,
+  de: () => <DE width="32" height="24" viewBox="0 0 640 480" />,
+  ca: () => <CA id="canada" width="32" height="24" viewBox="0 0 640 480" />,
   in: () => <IN width="32" height="24" viewBox="0 0 640 480" />
 };
 
 export const selectStyles = {
   menuList: (base: any) => ({ ...base, maxHeight: `40vh !important` })
 };
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((theme: Theme) => ({
   root: {
     '& svg': {
       '& g': {
         // Super hacky fix for Firefox rendering of some flag icons that had a clip-path property.
         clipPath: 'none !important' as 'none'
       }
+    },
+    '& #singapore, #japan, #canada': {
+      border: `1px solid ${theme.color.border3}`
     }
   }
 }));


### PR DESCRIPTION
Fixing the flags that appear shorter than the rest and adding a light gray border to flags with a lot of whitespace (ie. Japan and Singapore)

<img width="1276" alt="Screen Shot 2021-01-22 at 9 04 17 AM" src="https://user-images.githubusercontent.com/7692354/106499905-30fe3880-648f-11eb-8db6-0783d9784777.png">