### PR TITLE
M3-4883 'bug' - Update TransferDisplay.tsx

### DIFF
--- a/packages/manager/src/features/linodes/LinodesLanding/TransferDisplay.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/TransferDisplay.tsx
@@ -137,6 +137,7 @@ export const TransferDisplay: React.FC<{}> = _ => {
 export const getDaysRemaining = () =>
   Math.floor(
     DateTime.local()
+      .setZone('America/New_York')
       .endOf('month')
       .diffNow('days')
       .toObject().days ?? 0


### PR DESCRIPTION
Cloud Manager shows transfer allotment based on the customer's TZ. This can cause confusion as Linode resets Transfer based on EST. This locks the Monthly Network Transfer Pool reset timeline to match EST.
M3-4883