### PR TITLE
POC: Move save changes button to bottom of rules table

### DIFF
--- a/packages/manager/src/components/Prompt/Prompt.tsx
+++ b/packages/manager/src/components/Prompt/Prompt.tsx
@@ -82,6 +82,11 @@ const Prompt: React.FC<CombinedProps> = props => {
   };
 
   const handleNavigation = (location: Location) => {
+    if (location.pathname === history.location.pathname) {
+      // Sorting order changes affect the search portion of the URL.
+      // The path is the same though, so the user isn't actually navigating away.
+      return true;
+    }
     // If this user hasn't yet confirmed navigation, present a confirmation modal.
     if (!confirmedNav.current) {
       setIsModalOpen(true);

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRulesLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRulesLanding.tsx
@@ -8,7 +8,6 @@ import Button from 'src/components/Button';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
-import FixedToolBar from 'src/components/FixedToolbar/FixedToolbar';
 import Notice from 'src/components/Notice';
 import Prompt from 'src/components/Prompt';
 import withFirewalls, {
@@ -39,7 +38,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginBottom: theme.spacing(4)
   },
   actions: {
-    alignSelf: 'flex-end'
+    float: 'right'
   },
   mobileSpacing: {
     [theme.breakpoints.down('sm')]: {
@@ -319,25 +318,23 @@ const FirewallRulesLanding: React.FC<CombinedProps> = props => {
         onSubmit={ruleDrawer.mode === 'create' ? handleAddRule : handleEditRule}
         ruleToModify={ruleToModify}
       />
-      {hasUnsavedChanges && (
-        <FixedToolBar>
-          <ActionsPanel className={classes.actions}>
-            <Button
-              buttonType="cancel"
-              onClick={() => setDiscardChangesModalOpen(true)}
-            >
-              Discard Changes
-            </Button>
-            <Button
-              buttonType="primary"
-              onClick={applyChanges}
-              loading={submitting}
-            >
-              Apply Changes
-            </Button>
-          </ActionsPanel>
-        </FixedToolBar>
-      )}
+      <ActionsPanel className={classes.actions}>
+        <Button
+          buttonType="cancel"
+          disabled={!hasUnsavedChanges}
+          onClick={() => setDiscardChangesModalOpen(true)}
+        >
+          Discard Changes
+        </Button>
+        <Button
+          buttonType="primary"
+          onClick={applyChanges}
+          loading={submitting}
+          disabled={!hasUnsavedChanges}
+        >
+          Save Changes
+        </Button>
+      </ActionsPanel>
       <DiscardChangesDialog
         isOpen={discardChangesModalOpen}
         handleClose={() => setDiscardChangesModalOpen(false)}


### PR DESCRIPTION
## Description

Move the "Save Changes" button for Firewall rules to somewhere where it's easier to see. Also displayed it at all times, disabled until there are changes to save or discard. The idea is to make it clearer to users that they need to make and then save changes.

Edit: based on Matthew's feedback, also fixed a bug where clicking the sort headers with unsaved changes triggered the "Are you sure?" confirmation modal.