### PR TITLE
Make FW Rule "Description" field non-sortable

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -150,14 +150,7 @@ const FirewallRuleTable: React.FC<CombinedProps> = props => {
                     Label
                   </TableSortCell>
                   <Hidden mdDown>
-                    <TableSortCell
-                      active={orderBy === 'type'}
-                      label="description"
-                      direction={order}
-                      handleClick={handleOrderChange}
-                    >
-                      Description
-                    </TableSortCell>
+                    <TableCell>Description</TableCell>
                   </Hidden>
                   <Hidden xsDown>
                     <TableSortCell


### PR DESCRIPTION
Sorting by this field isn't very useful.