### PR TITLE
M3-4893: Make use of variant to reduce padding around secondary button types

### DIFF
--- a/packages/manager/src/components/Button/Button.tsx
+++ b/packages/manager/src/components/Button/Button.tsx
@@ -3,22 +3,8 @@ import { always, cond, propEq } from 'ramda';
 import * as React from 'react';
 import Reload from 'src/assets/icons/reload.svg';
 import Button, { ButtonProps } from 'src/components/core/Button';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles
-} from 'src/components/core/styles';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import HelpIcon from 'src/components/HelpIcon';
-
-type ClassNames =
-  | 'root'
-  | 'loading'
-  | 'loadingText'
-  // | 'destructive'
-  | 'compact'
-  | 'superCompact'
-  | 'reg';
 
 export interface Props extends ButtonProps {
   loading?: boolean;
@@ -32,96 +18,46 @@ export interface Props extends ButtonProps {
   loadingText?: string;
 }
 
-const styles = (theme: Theme) =>
-  createStyles({
-    '@keyframes rotate': {
-      from: {
-        transform: 'rotate(0deg)'
-      },
-      to: {
-        transform: 'rotate(360deg)'
-      }
+const useStyles = makeStyles((theme: Theme) => ({
+  '@keyframes rotate': {
+    from: {
+      transform: 'rotate(0deg)'
     },
-    root: {
-      minWidth: '105px',
-      transition: 'none'
-      // '&.cancel': {
-      //   border: `1px solid transparent`,
-      //   transition: theme.transitions.create(['color', 'border-color']),
-      //   '&:hover, &:focus': {
-      //     color: theme.palette.primary.light,
-      //     borderColor: theme.palette.primary.light
-      //   }
-      // },
-      // '&.remove': {
-      //   fontSize: '.9rem',
-      //   border: 0,
-      //   color: '#C44742',
-      //   padding: `${theme.spacing(2) + 2}px  ${theme.spacing(2) +
-      //     2}px ${theme.spacing(3) + 2}px ${theme.spacing(2) + 2}px`,
-      //   transition: theme.transitions.create(['color', 'border-color']),
-      //   '&:hover, &:focus': {
-      //     color: '#DF6560'
-      //   }
-      // }
-    },
-    loading: {
-      '& svg': {
-        margin: '0 auto',
-        width: `${theme.spacing(1) + 8}px !important`,
-        height: `${theme.spacing(1) + 8}px !important`,
-        animation: '$rotate 2s linear infinite'
-      }
-    },
-    loadingText: {
-      marginRight: 8
-    },
-    // destructive: {
-    //   borderColor: '#C44742',
-    //   color: '#C44742',
-    //   background: theme.color.white,
-    //   '&.primary:not(.disabled)': {
-    //     backgroundColor: '#C44742',
-    //     color: '#fff',
-    //     '&:hover, &:focus': {
-    //       backgroundColor: '#DF6560',
-    //       color: '#fff'
-    //     }
-    //   },
-    //   '&:hover, &:focus': {
-    //     background: theme.color.white,
-    //     color: '#DF6560',
-    //     borderColor: '#DF6560'
-    //   },
-    //   '&:active': {
-    //     color: '#963530',
-    //     borderColor: '#963530'
-    //   },
-    //   '&$loading': {
-    //     color: '#C44742 !important',
-    //     '&.primary': {
-    //       background: 'rgba(0, 0, 0, 0.12) !important'
-    //     }
-    //   }
-    // },
-    compact: {
-      paddingLeft: theme.spacing(2) - 2,
-      paddingRight: theme.spacing(2) - 2,
-      minWidth: '75px'
-    },
-    superCompact: {
-      paddingLeft: 0,
-      paddingRight: 0,
-      paddingTop: theme.spacing(1),
-      paddingBottom: theme.spacing(1)
-    },
-    reg: {
-      display: 'flex',
-      alignItems: 'center'
+    to: {
+      transform: 'rotate(360deg)'
     }
-  });
+  },
+  root: {
+    minWidth: '105px',
+    transition: 'none'
+  },
+  loading: {
+    '& svg': {
+      margin: '0 auto',
+      width: `${theme.spacing(1) + 8}px !important`,
+      height: `${theme.spacing(1) + 8}px !important`,
+      animation: '$rotate 2s linear infinite'
+    }
+  },
+  loadingText: {
+    marginRight: 8
+  },
+  compact: {
+    paddingLeft: theme.spacing(2) - 2,
+    paddingRight: theme.spacing(2) - 2,
+    minWidth: '75px'
+  },
+  superCompact: {
+    paddingLeft: 0,
+    paddingRight: 0
+  },
+  reg: {
+    display: 'flex',
+    alignItems: 'center'
+  }
+}));
 
-type CombinedProps = Props & WithStyles<ClassNames>;
+type CombinedProps = Props;
 
 const getVariant = cond([
   [propEq('buttonType', 'primary'), always('contained')],
@@ -143,11 +79,11 @@ const getColor = cond([
 // Add invariant warning if loading destructive cancel
 // Add invariant warning if destructive cancel
 
-const wrappedButton: React.FC<CombinedProps> = props => {
+const WrappedButton: React.FC<CombinedProps> = props => {
+  const classes = useStyles();
+
   const {
-    classes,
     loading,
-    destructive,
     deleteText,
     tooltipText,
     loadingText,
@@ -171,7 +107,6 @@ const wrappedButton: React.FC<CombinedProps> = props => {
             [classes.root]: true,
             [classes.loading]: loading,
             loading,
-            // [classes.destructive]: destructive,
             [classes.compact]: compact,
             [classes.superCompact]: superCompact,
             disabled: props.disabled
@@ -210,6 +145,4 @@ const wrappedButton: React.FC<CombinedProps> = props => {
   );
 };
 
-const styled = withStyles(styles);
-
-export default styled(wrappedButton);
+export default WrappedButton;

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -125,6 +125,7 @@ const FirewallRuleTable: React.FC<CombinedProps> = props => {
           buttonType="secondary"
           className={classes.button}
           onClick={openDrawerForCreating}
+          superCompact
         >
           Add an {capitalize(category)} Rule
         </Button>

--- a/packages/manager/src/features/Profile/SSHKeys/SSHKeyCreationDrawer.test.tsx
+++ b/packages/manager/src/features/Profile/SSHKeys/SSHKeyCreationDrawer.test.tsx
@@ -7,8 +7,8 @@ jest.mock('@linode/api-v4/lib/profile');
 const o = {
   labelField: `WithStyles(LinodeTextField)[data-qa-label-field=true]`,
   keyField: `WithStyles(LinodeTextField)[data-qa-ssh-key-field]`,
-  submitButton: `WithStyles(wrappedButton)[data-qa-submit]`,
-  cancelButton: `WithStyles(wrappedButton)[data-qa-cancel]`
+  submitButton: `WrappedButton[data-qa-submit]`,
+  cancelButton: `WrappedButton[data-qa-cancel]`
 };
 
 describe('SSHKeyCreationDrawer', () => {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.test.tsx
@@ -75,8 +75,8 @@ describe('Linode Power Control Dialogs', () => {
     // Set status to a transition status such as "cloning."
     renderedComponent.setProps({ status: 'cloning' });
 
-    expect(
-      renderedComponent.find('WithStyles(wrappedButton)').prop('disabled')
-    ).toEqual(true);
+    expect(renderedComponent.find('WrappedButton').prop('disabled')).toEqual(
+      true
+    );
   });
 });


### PR DESCRIPTION
The button variant, `superCompact`, wasn't being used so I adjusted the styling a bit and applied it to the links on the Firewalls Detail page