### PR TITLE
M3-4907: Enable Backups drawer rearrangement & tweaks

### DIFF
--- a/packages/manager/src/features/Backups/BackupDrawer.tsx
+++ b/packages/manager/src/features/Backups/BackupDrawer.tsx
@@ -159,15 +159,6 @@ export class BackupDrawer extends React.Component<CombinedProps, {}> {
               </Notice>
             </Grid>
           )}
-          <Grid item>
-            <BackupsTable linodes={linodesWithoutBackups} loading={loading} />
-          </Grid>
-          <Grid item>
-            <DisplayPrice
-              price={getTotalPrice(linodesWithoutBackups)}
-              interval="mo"
-            />
-          </Grid>
           {/* Don't show this if the setting is already active. */}
           {!accountBackups && (
             <Grid item>
@@ -179,7 +170,13 @@ export class BackupDrawer extends React.Component<CombinedProps, {}> {
             </Grid>
           )}
           <Grid item>
-            <ActionsPanel style={{ marginTop: 16 }}>
+            <DisplayPrice
+              price={getTotalPrice(linodesWithoutBackups)}
+              interval="mo"
+            />
+          </Grid>
+          <Grid item>
+            <ActionsPanel style={{ padding: 0, margin: 0 }}>
               <Button
                 onClick={this.handleSubmit}
                 loading={loading || enabling || enrolling}
@@ -199,6 +196,9 @@ export class BackupDrawer extends React.Component<CombinedProps, {}> {
                 Cancel
               </Button>
             </ActionsPanel>
+          </Grid>
+          <Grid item>
+            <BackupsTable linodes={linodesWithoutBackups} loading={loading} />
           </Grid>
         </Grid>
       </Drawer>

--- a/packages/manager/src/features/Backups/BackupsCTA.tsx
+++ b/packages/manager/src/features/Backups/BackupsCTA.tsx
@@ -72,7 +72,7 @@ const BackupsCTA: React.FC<CombinedProps> = props => {
           <React.Fragment />
         ) : (
           <Paper className={classes.root}>
-            <Typography style={{ fontSize: '1rem' }}>
+            <Typography style={{ fontSize: '1rem', marginLeft: '0.5rem' }}>
               <button
                 className={classes.enableText}
                 onClick={openBackupsDrawer}

--- a/packages/manager/src/features/Backups/BackupsTable.tsx
+++ b/packages/manager/src/features/Backups/BackupsTable.tsx
@@ -41,7 +41,7 @@ export const BackupsTable: React.FC<CombinedProps> = props => {
   const { classes, linodes, loading } = props;
 
   return (
-    <Table tableClass={classes.root} border spacingTop={16}>
+    <Table tableClass={classes.root} border>
       <TableHead>
         <TableRow>
           <TableCell data-qa-table-header="Label">Label</TableCell>

--- a/packages/manager/src/store/backupDrawer/index.ts
+++ b/packages/manager/src/store/backupDrawer/index.ts
@@ -120,7 +120,7 @@ const reducer: Reducer<State> = (
         enableErrors: [],
         autoEnrollError: undefined,
         updatedCount: 0,
-        autoEnroll: false
+        autoEnroll: true
       };
 
     case CLOSE:


### PR DESCRIPTION
## Description
Move Auto Enroll, the action panel, and the price above the list of linodes; default Auto Enroll toggle to enabled. Indent Backups CTA banner text.

## Type of Change
- Non breaking change ('update', 'change')

## To-Do:
- [x] Indentation
- [x] Default Auto Enroll toggle to enabled