### PR TITLE
M3-4886: Remove text underline on selected tab

### DIFF
--- a/packages/manager/src/components/TabLinkList/TabLinkList.tsx
+++ b/packages/manager/src/components/TabLinkList/TabLinkList.tsx
@@ -37,7 +37,7 @@ const useStyles = makeStyles((theme: Theme) => ({
       boxShadow: `inset 0 -1px 0 ${theme.cmrBorderColors.borderTabs}`,
       marginBottom: theme.spacing(),
       [theme.breakpoints.down('md')]: {
-        overflowX: 'scroll',
+        overflowX: 'auto',
         padding: 1
       }
     }

--- a/packages/manager/src/components/TabLinkList/TabLinkList.tsx
+++ b/packages/manager/src/components/TabLinkList/TabLinkList.tsx
@@ -19,6 +19,7 @@ const useStyles = makeStyles((theme: Theme) => ({
       minHeight: theme.spacing(5),
       minWidth: 50,
       padding: '6px 16px',
+      textDecoration: 'none',
       '&:hover': {
         color: theme.color.blue
       }

--- a/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
+++ b/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
@@ -61,7 +61,7 @@ const useStyles = makeStyles((theme: Theme) => ({
       marginTop: 22,
       marginBottom: theme.spacing(3),
       [theme.breakpoints.down('md')]: {
-        overflowX: 'scroll',
+        overflowX: 'auto',
         padding: 1
       }
     }

--- a/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
+++ b/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
@@ -43,6 +43,7 @@ const useStyles = makeStyles((theme: Theme) => ({
       minHeight: theme.spacing(5),
       minWidth: 50,
       padding: '6px 16px',
+      textDecoration: 'none',
       '&:hover': {
         color: theme.color.blue
       }

--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketsLanding.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketsLanding.tsx
@@ -81,7 +81,7 @@ const styles = (theme: Theme) =>
         boxShadow: `inset 0 -1px 0 ${theme.color.border2}`,
         marginBottom: theme.spacing(),
         [theme.breakpoints.down('md')]: {
-          overflowX: 'scroll',
+          overflowX: 'auto',
           padding: 1
         }
       }

--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketsLanding.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketsLanding.tsx
@@ -64,6 +64,7 @@ const styles = (theme: Theme) =>
         minHeight: theme.spacing(5),
         minWidth: 50,
         padding: '6px 16px',
+        textDecoration: 'none',
         '&:hover': {
           color: theme.color.blue
         }


### PR DESCRIPTION
Also includes a fix for scroll bars appearing below 1280px when the setting for scrollbars is set to always show even though there's no overflow (M3-4752, see ticket for more info)