### PR TITLE
M3-4895 Add: Entity transfer controls

### DIFF
--- a/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/ConfirmTransferDialog.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/ConfirmTransferDialog.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import Dialog from 'src/components/Dialog';
+
+// import { makeStyles, Theme } from 'src/components/core/styles';
+
+// const useStyles = makeStyles((theme: Theme) => ({}));
+
+interface Props {
+  onClose: () => void;
+  open: boolean;
+  token?: string;
+}
+
+export type CombinedProps = Props;
+
+export const ConfirmTransferDialog: React.FC<Props> = props => {
+  const { onClose, open, token } = props;
+  return (
+    <Dialog onClose={onClose} title="Confirm Transfer" open={open}>
+      You entered token: {token}
+    </Dialog>
+  );
+};
+
+export default React.memo(ConfirmTransferDialog);

--- a/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/EntityTransfersLanding.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/EntityTransfersLanding.tsx
@@ -1,12 +1,25 @@
 import * as React from 'react';
 import Breadcrumb from 'src/components/Breadcrumb';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import ConfirmTransferDialog from './ConfirmTransferDialog';
+import TransferControls from './TransferControls';
 
 export const EntityTransfersLanding: React.FC<{}> = _ => {
+  const [confirmDialogOpen, setConfirmDialogOpen] = React.useState(false);
+  const [token, setToken] = React.useState('');
   return (
     <>
       <DocumentTitleSegment segment="Transfers" />
       <Breadcrumb pathname={location.pathname} labelTitle="Transfers" />
+      <TransferControls
+        openConfirmTransferDialog={() => setConfirmDialogOpen(true)}
+        onTokenInput={setToken}
+      />
+      <ConfirmTransferDialog
+        open={confirmDialogOpen}
+        token={token}
+        onClose={() => setConfirmDialogOpen(false)}
+      />
     </>
   );
 };

--- a/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/TransferControls.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/TransferControls.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import { useHistory } from 'react-router-dom';
+import Button from 'src/components/Button';
+import TextField from 'src/components/TextField';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    display: 'flex',
+    flexFlow: 'row wrap',
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  receiveTransfer: {
+    display: 'flex',
+    flexFlow: 'row nowrap',
+    alignItems: 'center',
+    marginRight: theme.spacing(3)
+  },
+  label: {
+    marginRight: theme.spacing()
+  }
+}));
+
+interface Props {
+  onTokenInput: (token: string) => void;
+  openConfirmTransferDialog: () => void;
+}
+
+export type CombinedProps = Props;
+
+export const TransferControls: React.FC<Props> = props => {
+  const { openConfirmTransferDialog, onTokenInput } = props;
+  const classes = useStyles();
+  const { push } = useHistory();
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onTokenInput(e.target.value);
+  };
+
+  const handleCreateTransfer = () => push('/account/entity-transfers/create');
+  return (
+    <div className={classes.root}>
+      <div className={classes.receiveTransfer}>
+        <Typography className={classes.label}>
+          <strong>Receive a Transfer</strong>
+        </Typography>
+        <TextField
+          hideLabel
+          label="Receive a Transfer"
+          placeholder="Enter a token"
+          onChange={handleInputChange}
+        />
+        <Button buttonType="secondary" onClick={openConfirmTransferDialog}>
+          Review Details
+        </Button>
+      </div>
+      <Button buttonType="primary" onClick={handleCreateTransfer}>
+        Make a Transfer
+      </Button>
+    </div>
+  );
+};
+
+export default React.memo(TransferControls);


### PR DESCRIPTION
## Description

Designs aren't final and everything is stubbed. I want to have a skeleton for these elements asap so we can work in parallel (and also so there's a link in the UI to the /create-transfer page).