### PR TITLE
Add: Account transfer methods for JS client and mock service worker

### DIFF
--- a/packages/api-v4/src/entity-transfers/index.ts
+++ b/packages/api-v4/src/entity-transfers/index.ts
@@ -1,0 +1,5 @@
+export * from './types';
+
+export * from './transfers';
+
+export * from './transfers.schema';

--- a/packages/api-v4/src/entity-transfers/transfers.schema.ts
+++ b/packages/api-v4/src/entity-transfers/transfers.schema.ts
@@ -1,0 +1,7 @@
+import { array, number, object } from 'yup';
+
+export const CreateTransferSchema = object({
+  entities: object({
+    linodes: array().of(number())
+  })
+});

--- a/packages/api-v4/src/entity-transfers/transfers.ts
+++ b/packages/api-v4/src/entity-transfers/transfers.ts
@@ -1,0 +1,76 @@
+import { BETA_API_ROOT } from '../constants';
+import Request, {
+  setData,
+  setMethod,
+  setParams,
+  setURL,
+  setXFilter
+} from '../request';
+import { ResourcePage as Page } from '../types';
+import { CreateTransferSchema } from './transfers.schema';
+import { CreateTransferPayload, EntityTransfer } from './types';
+
+// SELF SERVE ENTITY TRANSFERS
+
+/**
+ * getEntityTransfers
+ *
+ * Returns a paginated list of all Entity Transfers which this customer has created or accepted.
+ */
+export const getEntityTransfers = (params?: any, filters?: any) =>
+  Request<Page<EntityTransfer>>(
+    setMethod('GET'),
+    setParams(params),
+    setXFilter(filters),
+    setURL(`${BETA_API_ROOT}/account/entity-transfers`)
+  );
+
+/**
+ * getEntityTransfer
+ *
+ * Get a single Entity Transfer by its token (uuid). A Pending transfer
+ * can be retrieved by any unrestricted user.
+ *
+ */
+export const getEntityTransfer = (token: string) =>
+  Request<EntityTransfer>(
+    setMethod('GET'),
+    setURL(`${BETA_API_ROOT}/account/entity-transfers/${token}`)
+  );
+
+/**
+ * createEntityTransfer
+ *
+ *  Creates a pending Entity Transfer for one or more entities on
+ *  the sender's account. Only unrestricted users can create a transfer.
+ */
+export const createEntityTransfer = (data: CreateTransferPayload) =>
+  Request<EntityTransfer>(
+    setMethod('POST'),
+    setData(data, CreateTransferSchema),
+    setURL(`${BETA_API_ROOT}/account/entity-transfers`)
+  );
+
+/**
+ * acceptEntityTransfer
+ *
+ * Accepts a transfer that has been created by a user on a different account.
+ */
+export const acceptEntityTransfer = (token: string) =>
+  Request<{}>(
+    setMethod('POST'),
+    setURL(`${BETA_API_ROOT}/account/entity-transfers/${token}/accept`)
+  );
+
+/**
+ * cancelTransfer
+ *
+ * Cancels a pending transfer. Only unrestricted users on the account
+ * that created the transfer are able to cancel it.
+ *
+ */
+export const cancelTransfer = (token: string) =>
+  Request<{}>(
+    setMethod('DELETE'),
+    setURL(`${BETA_API_ROOT}/account/entity-transfers/${token}`)
+  );

--- a/packages/api-v4/src/entity-transfers/types.ts
+++ b/packages/api-v4/src/entity-transfers/types.ts
@@ -1,0 +1,25 @@
+export type EntityTransferStatus =
+  | 'pending'
+  | 'accepted'
+  | 'cancelled'
+  | 'completed'
+  | 'failed'
+  | 'stale';
+
+// @todo merge this with the types made for M3-4900
+export interface TransferEntities {
+  linodes: number[];
+}
+
+export interface EntityTransfer {
+  token: string;
+  status: EntityTransferStatus;
+  created: string;
+  updated: string;
+  is_sender: boolean;
+  expiry: string;
+  entities: TransferEntities;
+}
+export interface CreateTransferPayload {
+  entities: TransferEntities;
+}

--- a/packages/manager/src/factories/entityTransfers.ts
+++ b/packages/manager/src/factories/entityTransfers.ts
@@ -1,0 +1,25 @@
+import * as Factory from 'factory.ts';
+import {
+  EntityTransfer,
+  TransferEntities
+} from '@linode/api-v4/lib/entity-transfers/types';
+import { v4 } from 'uuid';
+import { DateTime } from 'luxon';
+
+export const transferEntitiesFactory = Factory.Sync.makeFactory<
+  TransferEntities
+>({
+  linodes: [0, 1, 2, 3]
+});
+
+export const entityTransferFactory = Factory.Sync.makeFactory<EntityTransfer>({
+  token: v4(),
+  is_sender: true,
+  entities: transferEntitiesFactory.build(),
+  expiry: DateTime.local()
+    .plus({ days: 1 })
+    .toISO(),
+  created: DateTime.local().toISO(),
+  updated: DateTime.local().toISO(),
+  status: 'pending'
+});

--- a/packages/manager/src/factories/index.ts
+++ b/packages/manager/src/factories/index.ts
@@ -5,6 +5,7 @@ export * from './config';
 export * from './databases';
 export * from './disk';
 export * from './domain';
+export * from './entityTransfers';
 export * from './events';
 export * from './firewalls';
 export * from './images';

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -9,6 +9,7 @@ import {
   domainFactory,
   domainRecordFactory,
   imageFactory,
+  entityTransferFactory,
   firewallFactory,
   firewallDeviceFactory,
   kubernetesAPIResponse,
@@ -59,6 +60,33 @@ export const makeResourcePage = (
   results: override.results ?? e.length,
   data: e
 });
+
+const entityTransfers = [
+  rest.get('*/account/entity-transfers', (req, res, ctx) => {
+    const transfers = entityTransferFactory.buildList(10);
+    return res(ctx.json(makeResourcePage(transfers)));
+  }),
+  rest.get('*/account/entity-transfers/:transferId', (req, res, ctx) => {
+    const transfer = entityTransferFactory.build();
+    return res(ctx.json(transfer));
+  }),
+  rest.post('*/account/entity-transfers', (req, res, ctx) => {
+    const payload = req.body as any;
+    const newTransfer = entityTransferFactory.build({
+      entities: payload.entities
+    });
+    return res(ctx.json(newTransfer));
+  }),
+  rest.post(
+    '*/account/entity-transfers/:transferId/accept',
+    (req, res, ctx) => {
+      return res(ctx.json({}));
+    }
+  ),
+  rest.delete('*/account/entity-transfers/:transferId', (req, res, ctx) => {
+    return res(ctx.json({}));
+  })
+];
 
 export const handlers = [
   rest.get('*/profile', (req, res, ctx) => {
@@ -430,7 +458,8 @@ export const handlers = [
     const unknown = databaseFactory.build({ status: 'unknown' });
     const databases = [online, initializing, error, unknown];
     return res(ctx.json(makeResourcePage(databases)));
-  })
+  }),
+  ...entityTransfers
 ];
 
 // Generator functions for dynamic handlers, in use by mock data dev tools.


### PR DESCRIPTION
## Description

New methods for the account transfer feature, based on a spec doc from the API. Also includes mocks. These methods may not be complete/final, but they should be enough for us to work with.