### PR TITLE
M3-4898 Receive Transfer Confirmation

### DIFF
--- a/packages/manager/src/components/Dialog/Dialog.tsx
+++ b/packages/manager/src/components/Dialog/Dialog.tsx
@@ -10,6 +10,7 @@ import Grid from 'src/components/Grid';
 import { convertForAria } from 'src/components/TabLink/TabLink';
 
 export interface DialogProps extends _DialogProps {
+  className?: string;
   title: string;
   fullHeight?: boolean;
   titleBottomBorder?: boolean;
@@ -84,7 +85,14 @@ const useStyles = makeStyles((theme: Theme) =>
 );
 
 const Dialog: React.FC<DialogProps> = props => {
-  const { title, fullHeight, titleBottomBorder, children, ...rest } = props;
+  const {
+    className,
+    title,
+    fullHeight,
+    titleBottomBorder,
+    children,
+    ...rest
+  } = props;
 
   const classes = useStyles();
 
@@ -131,7 +139,9 @@ const Dialog: React.FC<DialogProps> = props => {
         </div>
         {titleBottomBorder && <hr className={classes.titleBottomBorder} />}
         <Grid container>
-          <div className={classes.dialogContent}>{children}</div>
+          <div className={className ? className : classes.dialogContent}>
+            {children}
+          </div>
         </Grid>
       </Grid>
     </MUIDialog>

--- a/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/ConfirmTransferDialog.test.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/ConfirmTransferDialog.test.tsx
@@ -1,0 +1,18 @@
+import { screen } from '@testing-library/react';
+import * as React from 'react';
+import { DateTime } from 'luxon';
+import { getTimeRemaining } from './ConfirmTransferDialog';
+
+describe('Accept Entity Transfer confirmation dialog', () => {
+  describe('getTimeRemaining helper function', () => {
+    it('should return a large time in hours remaining', () => {
+      expect(
+        getTimeRemaining(
+          DateTime.local()
+            .plus({ hours: 23 })
+            .toISO()
+        )
+      ).toMatch(/in 23 hours/);
+    });
+  });
+});

--- a/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/ConfirmTransferDialog.test.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/ConfirmTransferDialog.test.tsx
@@ -14,5 +14,15 @@ describe('Accept Entity Transfer confirmation dialog', () => {
         )
       ).toMatch(/in 23 hours/);
     });
+
+    it('should return smaller time in minutes remaining', () => {
+      expect(
+        getTimeRemaining(
+          DateTime.local()
+            .plus({ minutes: 8 })
+            .toISO()
+        )
+      ).toMatch(/in 8 minutes/);
+    });
   });
 });

--- a/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/ConfirmTransferDialog.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/ConfirmTransferDialog.tsx
@@ -35,15 +35,16 @@ const useStyles = makeStyles((theme: Theme) => ({
     fontSize: '1rem'
   },
   entityTypeDisplay: {
-    marginTop: theme.spacing(),
     marginBottom: theme.spacing()
   },
   summary: {
-    fontSize: '1rem'
+    fontSize: '1rem',
+    marginBottom: 4
   },
   list: {
     listStyleType: 'none',
-    paddingLeft: theme.spacing(2)
+    paddingLeft: 0,
+    margin: 0
   }
 }));
 
@@ -210,7 +211,7 @@ export const DialogContent: React.FC<ContentProps> = React.memo(props => {
         <ul className={classes.list}>
           {Object.keys(entities).map(thisEntityType => {
             // According to spec, all entity names are plural and lowercase
-            // (NB: This will cause problems for NodeBalancers if/when they are added to the payload)
+            // (NB: This may cause problems for NodeBalancers if/when they are added to the payload)
             const entityName = capitalize(thisEntityType).slice(0, -1);
             return (
               <li key={thisEntityType}>

--- a/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/ConfirmTransferDialog.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/ConfirmTransferDialog.tsx
@@ -19,6 +19,7 @@ import ErrorState from 'src/components/ErrorState';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import Notice from 'src/components/Notice';
 import { useSnackbar } from 'notistack';
+import { DateTime } from 'luxon';
 
 const useStyles = makeStyles((theme: Theme) => ({
   dialogContent: {
@@ -158,6 +159,8 @@ export const DialogContent: React.FC<ContentProps> = React.memo(props => {
     );
   }
 
+  const timeRemaining = getTimeRemaining(expiry);
+
   return (
     <>
       {// There could be multiple errors here that are relevant.
@@ -192,10 +195,8 @@ export const DialogContent: React.FC<ContentProps> = React.memo(props => {
           );
         })}
       </div>
-      {expiry ? (
-        <Typography className={classes.expiry}>
-          This token expires on {formatDate(expiry)}
-        </Typography>
+      {timeRemaining ? (
+        <Typography className={classes.expiry}>{timeRemaining}</Typography>
       ) : null}
       <div>
         <CheckBox
@@ -222,5 +223,31 @@ export const DialogContent: React.FC<ContentProps> = React.memo(props => {
     </>
   );
 });
+
+export const getTimeRemaining = (time?: string) => {
+  if (!time) {
+    return;
+  }
+
+  const _date = DateTime.fromISO(time);
+  const hours = Math.floor(_date.diffNow('hours').toObject().hours ?? 0);
+
+  if (hours < 1) {
+    const minutes = Math.floor(
+      _date.diffNow('minutes').toObject().minutes ?? 0
+    );
+    return `This token will expire in ${pluralize(
+      'minute',
+      'minutes',
+      minutes
+    )} (${formatDate(time)}).`;
+  } else {
+    return `This token will expire in ${pluralize(
+      'hour',
+      'hours',
+      hours
+    )} (${formatDate(time)}).`;
+  }
+};
 
 export default React.memo(ConfirmTransferDialog);

--- a/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/ConfirmTransferDialog.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/ConfirmTransferDialog.tsx
@@ -48,13 +48,11 @@ const useStyles = makeStyles((theme: Theme) => ({
   }
 }));
 
-interface Props {
+export interface Props {
   onClose: () => void;
   open: boolean;
   token?: string;
 }
-
-export type CombinedProps = Props;
 
 export const ConfirmTransferDialog: React.FC<Props> = props => {
   const { onClose, open, token } = props;

--- a/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/ConfirmTransferDialog.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/ConfirmTransferDialog.tsx
@@ -229,25 +229,19 @@ export const getTimeRemaining = (time?: string) => {
     return;
   }
 
-  const _date = DateTime.fromISO(time);
-  const hours = Math.floor(_date.diffNow('hours').toObject().hours ?? 0);
+  const minutesRemaining = Math.floor(
+    DateTime.fromISO(time)
+      .diffNow('minutes')
+      .toObject().minutes ?? 0
+  );
 
-  if (hours < 1) {
-    const minutes = Math.floor(
-      _date.diffNow('minutes').toObject().minutes ?? 0
-    );
-    return `This token will expire in ${pluralize(
-      'minute',
-      'minutes',
-      minutes
-    )} (${formatDate(time)}).`;
-  } else {
-    return `This token will expire in ${pluralize(
-      'hour',
-      'hours',
-      hours
-    )} (${formatDate(time)}).`;
-  }
+  const unit = minutesRemaining > 60 ? 'hour' : 'minute';
+
+  return `This token will expire in ${pluralize(
+    unit,
+    unit + 's',
+    unit === 'minute' ? minutesRemaining : Math.round(minutesRemaining / 60)
+  )} (${formatDate(time)}).`;
 };
 
 export default React.memo(ConfirmTransferDialog);

--- a/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/ConfirmTransferDialog.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/ConfirmTransferDialog.tsx
@@ -1,9 +1,46 @@
+import { APIError } from '@linode/api-v4/lib/types';
+import {
+  acceptEntityTransfer,
+  TransferEntities
+} from '@linode/api-v4/lib/entity-transfers';
 import * as React from 'react';
 import Dialog from 'src/components/Dialog';
+import { useTransferQuery } from 'src/queries/transfers';
+import CircleProgress from 'src/components/CircleProgress';
+import Typography from 'src/components/core/Typography';
+import { capitalize } from 'src/utilities/capitalize';
+import { pluralize } from 'src/utilities/pluralize';
+import { formatDate } from 'src/utilities/formatDate';
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import CheckBox from 'src/components/CheckBox';
+import ErrorState from 'src/components/ErrorState';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import Notice from 'src/components/Notice';
+import { useSnackbar } from 'notistack';
 
-// import { makeStyles, Theme } from 'src/components/core/styles';
-
-// const useStyles = makeStyles((theme: Theme) => ({}));
+const useStyles = makeStyles((theme: Theme) => ({
+  dialogContent: {
+    padding: theme.spacing(2),
+    width: '100%'
+  },
+  transferSummary: {
+    marginBottom: theme.spacing()
+  },
+  actions: {
+    display: 'flex',
+    justifyContent: 'flex-end'
+  },
+  expiry: {
+    marginTop: theme.spacing(2),
+    marginBottom: theme.spacing(2)
+  },
+  entityTypeDisplay: {
+    marginTop: theme.spacing(),
+    marginBottom: theme.spacing()
+  }
+}));
 
 interface Props {
   onClose: () => void;
@@ -15,11 +52,175 @@ export type CombinedProps = Props;
 
 export const ConfirmTransferDialog: React.FC<Props> = props => {
   const { onClose, open, token } = props;
+  const classes = useStyles();
+  const { enqueueSnackbar } = useSnackbar();
+  const { data, isLoading, isError, error } = useTransferQuery(
+    token ?? '',
+    open
+  );
+
+  const [submitting, setSubmitting] = React.useState(false);
+  const [submissionErrors, setSubmissionErrors] = React.useState<
+    APIError[] | null
+  >(null);
+
+  React.useEffect(() => {
+    if (open) {
+      setSubmissionErrors(null);
+      setSubmitting(false);
+    }
+  }, [open]);
+
+  const handleAcceptTransfer = () => {
+    // This should never happen.
+    if (!token) {
+      return;
+    }
+    setSubmissionErrors(null);
+    setSubmitting(true);
+    acceptEntityTransfer(token)
+      .then(() => {
+        setSubmitting(false);
+        enqueueSnackbar('Transfer accepted successfully.', {
+          variant: 'success'
+        });
+        onClose();
+      })
+      .catch(e => {
+        setSubmissionErrors(
+          getAPIErrorOrDefault(e, 'An unexpected error occurred.')
+        );
+        setSubmitting(false);
+      });
+  };
+
   return (
-    <Dialog onClose={onClose} title="Confirm Transfer" open={open}>
-      You entered token: {token}
+    <Dialog
+      onClose={onClose}
+      title="Receive a Transfer"
+      open={open}
+      className={classes.dialogContent}
+    >
+      <DialogContent
+        isLoading={isLoading}
+        isError={isError}
+        errors={error}
+        entities={data?.entities ?? { linodes: [] }}
+        expiry={data?.expiry}
+        isSubmitting={submitting}
+        submissionErrors={submissionErrors}
+        onClose={onClose}
+        onSubmit={handleAcceptTransfer}
+      />
     </Dialog>
   );
 };
+
+interface ContentProps {
+  isLoading: boolean;
+  isError: boolean;
+  errors: APIError[] | null;
+  entities: TransferEntities;
+  expiry?: string;
+  isSubmitting: boolean;
+  submissionErrors: APIError[] | null;
+  onClose: () => void;
+  onSubmit: () => void;
+}
+
+export const DialogContent: React.FC<ContentProps> = React.memo(props => {
+  const {
+    entities,
+    errors,
+    expiry,
+    isError,
+    isLoading,
+    isSubmitting,
+    submissionErrors,
+    onClose,
+    onSubmit
+  } = props;
+  const classes = useStyles();
+  const [hasConfirmed, setHasConfirmed] = React.useState(false);
+
+  if (isLoading) {
+    return <CircleProgress />;
+  }
+
+  if (isError) {
+    return (
+      <ErrorState
+        errorText={
+          getAPIErrorOrDefault(errors ?? [], 'Unable to load this transfer.')[0]
+            .reason
+        }
+      />
+    );
+  }
+
+  return (
+    <>
+      {// There could be multiple errors here that are relevant.
+      submissionErrors
+        ? submissionErrors.map((thisError, idx) => (
+            <Notice
+              key={`form-submit-error-${idx}`}
+              error
+              text={thisError.reason}
+            />
+          ))
+        : null}
+      <div className={classes.transferSummary}>
+        <Typography>This transfer contains:</Typography>
+        {Object.keys(entities).map(thisEntityType => {
+          // According to spec, all entity names are plural and lowercase
+          // (NB: This will cause problems for NodeBalancers if/when they are added to the payload)
+          const entityName = capitalize(thisEntityType).slice(0, -1);
+          return (
+            <Typography
+              key={thisEntityType}
+              className={classes.entityTypeDisplay}
+            >
+              <strong>
+                {pluralize(
+                  entityName,
+                  entityName + 's',
+                  entities[thisEntityType].length
+                )}
+              </strong>
+            </Typography>
+          );
+        })}
+      </div>
+      {expiry ? (
+        <Typography className={classes.expiry}>
+          This token expires on {formatDate(expiry)}
+        </Typography>
+      ) : null}
+      <div>
+        <CheckBox
+          checked={hasConfirmed}
+          onChange={() => setHasConfirmed(confirmed => !confirmed)}
+          text="I understand that I am responsible for any and all fees ipsum dolor sit amet"
+        />
+      </div>
+
+      <ActionsPanel className={classes.actions}>
+        <Button onClick={onClose} buttonType="cancel">
+          Cancel
+        </Button>
+        <Button
+          disabled={!hasConfirmed}
+          onClick={onSubmit}
+          loading={isSubmitting}
+          destructive
+          buttonType="primary"
+        >
+          Accept Transfer
+        </Button>
+      </ActionsPanel>
+    </>
+  );
+});
 
 export default React.memo(ConfirmTransferDialog);

--- a/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/ConfirmTransferDialog.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/ConfirmTransferDialog.tsx
@@ -31,11 +31,19 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   expiry: {
     marginTop: theme.spacing(2),
-    marginBottom: theme.spacing(2)
+    marginBottom: theme.spacing(2),
+    fontSize: '1rem'
   },
   entityTypeDisplay: {
     marginTop: theme.spacing(),
     marginBottom: theme.spacing()
+  },
+  summary: {
+    fontSize: '1rem'
+  },
+  list: {
+    listStyleType: 'none',
+    paddingLeft: theme.spacing(2)
   }
 }));
 
@@ -66,6 +74,7 @@ export const ConfirmTransferDialog: React.FC<Props> = props => {
     if (open) {
       setSubmissionErrors(null);
       setSubmitting(false);
+      setHasConfirmed(false);
     }
   }, [open]);
 
@@ -195,26 +204,29 @@ export const DialogContent: React.FC<ContentProps> = React.memo(props => {
           ))
         : null}
       <div className={classes.transferSummary}>
-        <Typography>This transfer contains:</Typography>
-        {Object.keys(entities).map(thisEntityType => {
-          // According to spec, all entity names are plural and lowercase
-          // (NB: This will cause problems for NodeBalancers if/when they are added to the payload)
-          const entityName = capitalize(thisEntityType).slice(0, -1);
-          return (
-            <Typography
-              key={thisEntityType}
-              className={classes.entityTypeDisplay}
-            >
-              <strong>
-                {pluralize(
-                  entityName,
-                  entityName + 's',
-                  entities[thisEntityType].length
-                )}
-              </strong>
-            </Typography>
-          );
-        })}
+        <Typography className={classes.summary}>
+          This transfer contains:
+        </Typography>
+        <ul className={classes.list}>
+          {Object.keys(entities).map(thisEntityType => {
+            // According to spec, all entity names are plural and lowercase
+            // (NB: This will cause problems for NodeBalancers if/when they are added to the payload)
+            const entityName = capitalize(thisEntityType).slice(0, -1);
+            return (
+              <li key={thisEntityType}>
+                <Typography className={classes.entityTypeDisplay}>
+                  <strong>
+                    {pluralize(
+                      entityName,
+                      entityName + 's',
+                      entities[thisEntityType].length
+                    )}
+                  </strong>
+                </Typography>
+              </li>
+            );
+          })}
+        </ul>
       </div>
       {timeRemaining ? (
         <Typography className={classes.expiry}>{timeRemaining}</Typography>

--- a/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/EntityTransfersLanding.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/EntityTransfersLanding.tsx
@@ -8,8 +8,6 @@ export const EntityTransfersLanding: React.FC<{}> = _ => {
   const [token, setToken] = React.useState('');
 
   const handleCloseDialog = () => {
-    // I'm not sure this is the best place to do this; open to suggestions.
-    setToken('');
     setConfirmDialogOpen(false);
   };
 

--- a/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/EntityTransfersLanding.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/EntityTransfersLanding.tsx
@@ -9,6 +9,8 @@ export const EntityTransfersLanding: React.FC<{}> = _ => {
 
   const handleCloseDialog = () => {
     setConfirmDialogOpen(false);
+    // I don't love the UX here but it seems better than leaving a token in the input
+    setTimeout(() => setToken(''), 150);
   };
 
   return (

--- a/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/EntityTransfersLanding.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/EntityTransfersLanding.tsx
@@ -6,6 +6,13 @@ import TransferControls from './TransferControls';
 export const EntityTransfersLanding: React.FC<{}> = _ => {
   const [confirmDialogOpen, setConfirmDialogOpen] = React.useState(false);
   const [token, setToken] = React.useState('');
+
+  const handleCloseDialog = () => {
+    // I'm not sure this is the best place to do this; open to suggestions.
+    setToken('');
+    setConfirmDialogOpen(false);
+  };
+
   return (
     <>
       <DocumentTitleSegment segment="Transfers" />
@@ -17,7 +24,7 @@ export const EntityTransfersLanding: React.FC<{}> = _ => {
       <ConfirmTransferDialog
         open={confirmDialogOpen}
         token={token}
-        onClose={() => setConfirmDialogOpen(false)}
+        onClose={handleCloseDialog}
       />
     </>
   );

--- a/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/TransferControls.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/TransferControls.tsx
@@ -69,6 +69,7 @@ export const TransferControls: React.FC<Props> = props => {
         <TextField
           className={classes.transferInput}
           hideLabel
+          value={token}
           label="Receive a Transfer"
           placeholder="Enter a token"
           onChange={handleInputChange}

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -68,7 +68,7 @@ const entityTransfers = [
   }),
   rest.get('*/account/entity-transfers/:transferId', (req, res, ctx) => {
     const transfer = entityTransferFactory.build();
-    return res(ctx.delay(5000), ctx.json(transfer));
+    return res(ctx.json(transfer));
   }),
   rest.post('*/account/entity-transfers', (req, res, ctx) => {
     const payload = req.body as any;

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -68,7 +68,7 @@ const entityTransfers = [
   }),
   rest.get('*/account/entity-transfers/:transferId', (req, res, ctx) => {
     const transfer = entityTransferFactory.build();
-    return res(ctx.json(transfer));
+    return res(ctx.delay(5000), ctx.json(transfer));
   }),
   rest.post('*/account/entity-transfers', (req, res, ctx) => {
     const payload = req.body as any;

--- a/packages/manager/src/queries/transfers.ts
+++ b/packages/manager/src/queries/transfers.ts
@@ -1,0 +1,17 @@
+import {
+  EntityTransfer,
+  getEntityTransfer
+} from '@linode/api-v4/lib/entity-transfers';
+import { APIError } from '@linode/api-v4/lib/types';
+import { useQuery } from 'react-query';
+import { queryPresets } from './base';
+
+const queryKey = 'entity-transfers';
+
+export const useTransferQuery = (token: string, enabled: boolean = true) => {
+  return useQuery<EntityTransfer, APIError[]>(
+    [queryKey, token],
+    () => getEntityTransfer(token),
+    { ...queryPresets.shortLived, enabled }
+  );
+};


### PR DESCRIPTION
## Description

- Add an override for the styling in src/components/Dialog
- Fill in the Accept a Transfer dialog
- It'll work with any random token with the mocks.

![Screen Shot 2021-02-12 at 1 31 05 PM](https://user-images.githubusercontent.com/1624067/107814478-f96d7700-6d3f-11eb-9a26-f51f34e1323f.png)


## Todo

- [x] Refactor and clean up the time remaining calculation
- [ ] I'd like to do some validation on the token before opening the modal (need API input)
- [x] Tests