### PR TITLE
Rename function component in LinodeVolumes.tsx

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeVolumes.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeVolumes.tsx
@@ -133,7 +133,7 @@ const volumeHeaders = [
   }
 ];
 
-export const LinodeStorage: React.FC<CombinedProps> = props => {
+export const LinodeVolumes: React.FC<CombinedProps> = props => {
   const {
     volumesLoading,
     volumesLastUpdated,
@@ -418,4 +418,4 @@ export default compose<CombinedProps, {}>(
     ...ownProps,
     eventsData: eventsData.filter(filterVolumeEvents)
   }))
-)(LinodeStorage);
+)(LinodeVolumes);


### PR DESCRIPTION
## Description
The function component in `LinodeVolumes.tsx` is better-named "LinodeVolumes" than "LinodeStorage," the latter of which refers to the component that contains `LinodeVolumes.tsx`.

## Type of Change
- Non breaking change ('update', 'change')
