### PR TITLE
Change: Move token management to TransferControls

### DIFF
--- a/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/EntityTransfersLanding.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/EntityTransfersLanding.tsx
@@ -1,19 +1,16 @@
 import { EntityTransfer } from '@linode/api-v4/lib/entity-transfers';
-import { useHistory, useLocation } from 'react-router-dom';
 import { partition } from 'ramda';
 import * as React from 'react';
+import { useHistory, useLocation } from 'react-router-dom';
 import CircleProgress from 'src/components/CircleProgress';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import ErrorState from 'src/components/ErrorState';
 import { useEntityTransfersQuery } from 'src/queries/entityTransfers';
 import TransfersTable from '../TransfersTable';
-import ConfirmTransferDialog from './ConfirmTransferDialog';
 import CreateTransferSuccessDialog from './CreateTransferSuccessDialog';
 import TransferControls from './TransferControls';
 
 export const EntityTransfersLanding: React.FC<{}> = _ => {
-  const [confirmDialogOpen, setConfirmDialogOpen] = React.useState(false);
-  const [token, setToken] = React.useState('');
   const [successDialogOpen, setSuccessDialogOpen] = React.useState(true);
   const [transfer, setTransfer] = React.useState<EntityTransfer | undefined>(
     undefined
@@ -21,12 +18,6 @@ export const EntityTransfersLanding: React.FC<{}> = _ => {
 
   const location = useLocation();
   const history = useHistory();
-
-  const handleCloseDialog = () => {
-    setConfirmDialogOpen(false);
-    // I don't love the UX here but it seems better than leaving a token in the input
-    setTimeout(() => setToken(''), 150);
-  };
 
   const handleCloseSuccessDialog = () => {
     setSuccessDialogOpen(false);
@@ -66,16 +57,7 @@ export const EntityTransfersLanding: React.FC<{}> = _ => {
   return (
     <>
       <DocumentTitleSegment segment="Transfers" />
-      <TransferControls
-        token={token}
-        openConfirmTransferDialog={() => setConfirmDialogOpen(true)}
-        onTokenInput={setToken}
-      />
-      <ConfirmTransferDialog
-        open={confirmDialogOpen}
-        token={token}
-        onClose={handleCloseDialog}
-      />
+      <TransferControls />
       <CreateTransferSuccessDialog
         isOpen={successDialogOpen}
         transfer={transfer}

--- a/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/TransferControls.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/TransferControls.tsx
@@ -6,6 +6,7 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import HelpIcon from 'src/components/HelpIcon';
 import TextField from 'src/components/TextField';
+import ConfirmTransferDialog from './ConfirmTransferDialog';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -40,54 +41,61 @@ const useStyles = makeStyles((theme: Theme) => ({
   }
 }));
 
-interface Props {
-  token: string;
-  onTokenInput: (token: string) => void;
-  openConfirmTransferDialog: () => void;
-}
+export const TransferControls: React.FC<{}> = _ => {
+  const [token, setToken] = React.useState('');
+  const [confirmDialogOpen, setConfirmDialogOpen] = React.useState(false);
 
-export type CombinedProps = Props;
-
-export const TransferControls: React.FC<Props> = props => {
-  const { openConfirmTransferDialog, onTokenInput, token } = props;
   const classes = useStyles();
   const { push } = useHistory();
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    onTokenInput(e.target.value);
+    setToken(e.target.value);
+  };
+
+  const handleCloseDialog = () => {
+    setConfirmDialogOpen(false);
+    // I don't love the UX here but it seems better than leaving a token in the input
+    setTimeout(() => setToken(''), 150);
   };
 
   const handleCreateTransfer = () => push('/account/entity-transfers/create');
   return (
-    <div className={classes.root}>
-      <div className={classes.receiveTransfer}>
-        <Hidden mdDown>
-          <Typography className={classes.label}>
-            <strong>Receive a Transfer</strong>
-          </Typography>
-        </Hidden>
-        <TextField
-          className={classes.transferInput}
-          hideLabel
-          value={token}
-          label="Receive a Transfer"
-          placeholder="Enter a token"
-          onChange={handleInputChange}
-        />
-        <Button
-          className={classes.reviewDetails}
-          buttonType="primary"
-          disabled={token === ''}
-          onClick={openConfirmTransferDialog}
-        >
-          Review Details
+    <>
+      <div className={classes.root}>
+        <div className={classes.receiveTransfer}>
+          <Hidden mdDown>
+            <Typography className={classes.label}>
+              <strong>Receive a Transfer</strong>
+            </Typography>
+          </Hidden>
+          <TextField
+            className={classes.transferInput}
+            hideLabel
+            value={token}
+            label="Receive a Transfer"
+            placeholder="Enter a token"
+            onChange={handleInputChange}
+          />
+          <Button
+            className={classes.reviewDetails}
+            buttonType="primary"
+            disabled={token === ''}
+            onClick={() => setConfirmDialogOpen(true)}
+          >
+            Review Details
+          </Button>
+          <HelpIcon className={classes.helpIcon} text="Text TBD" />
+        </div>
+        <Button buttonType="primary" onClick={handleCreateTransfer}>
+          Make a Transfer
         </Button>
-        <HelpIcon className={classes.helpIcon} text="Text TBD" />
       </div>
-      <Button buttonType="primary" onClick={handleCreateTransfer}>
-        Make a Transfer
-      </Button>
-    </div>
+      <ConfirmTransferDialog
+        open={confirmDialogOpen}
+        token={token}
+        onClose={handleCloseDialog}
+      />
+    </>
   );
 };
 


### PR DESCRIPTION
The confirm transfer dialog was originally put on the Transfers landing page
but it turns out we don't need that state there. Moving the dialog and its state
management inside TransferControls makes it easier to memoize things and should
prevent some renders.
