### PR TITLE
Fix: Make event progress bars always full-width

### DIFF
--- a/packages/manager/src/features/NotificationCenter/NotificationData/RenderProgressEvent.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/RenderProgressEvent.tsx
@@ -18,7 +18,8 @@ import useEventInfo from './useEventInfo';
 const useStyles = makeStyles((theme: Theme) => ({
   action: {
     display: 'flex',
-    flexFlow: 'row nowrap'
+    flexFlow: 'row nowrap',
+    width: '100%'
   },
   bar: {
     marginTop: theme.spacing()


### PR DESCRIPTION
## Description

This was bugging me.