### PR TITLE
Resolve validateDOMNesting(...) console error on Transfers landing

### DIFF
--- a/packages/manager/src/features/EntityTransfers/TransfersTable.tsx
+++ b/packages/manager/src/features/EntityTransfers/TransfersTable.tsx
@@ -164,7 +164,8 @@ export const TransfersTable: React.FC<CombinedProps> = props => {
                   <TableCell key="transfer-token-table-header-expiry">
                     Expiry
                   </TableCell>
-                  <TableCell /> {/*  Empty column header for action column */}
+                  {/*  Empty column header for action column */}
+                  <TableCell />
                 </>
               ) : transferTypeIsSent ? (
                 <>


### PR DESCRIPTION
## Description
Moved code comment to its own line to resolve the `validateDOMNesting(...)` console error re: whitespace appearing as a child of `<tr>`

## Type of Change
- Bug fix ('fix', 'repair', 'bug')
