### PR TITLE
Cancel Transfer modal follow-up

### DIFF
--- a/packages/manager/src/features/EntityTransfers/EntityTransfersCreate/EntityTransfersCreate.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersCreate/EntityTransfersCreate.tsx
@@ -6,7 +6,7 @@ import Breadcrumb from 'src/components/Breadcrumb';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
 import { queryClient } from 'src/queries/base';
-import { useCreateTransfer } from 'src/queries/entityTransfers';
+import { queryKey, useCreateTransfer } from 'src/queries/entityTransfers';
 import TransferCheckoutBar from './TransferCheckoutBar';
 import TransferHeader from './TransferHeader';
 import LinodeTransferTable from './LinodeTransferTable';
@@ -54,7 +54,7 @@ export const EntityTransfersCreate: React.FC<{}> = _ => {
   const handleCreateTransfer = (payload: CreateTransferPayload) => {
     createTransfer(payload, {
       onSuccess: transfer => {
-        queryClient.invalidateQueries('entity-transfers');
+        queryClient.invalidateQueries(queryKey);
         push({ pathname: '/account/entity-transfers', state: { transfer } });
       }
     });

--- a/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/ConfirmTransferCancelDialog.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/ConfirmTransferCancelDialog.tsx
@@ -9,6 +9,7 @@ import { makeStyles } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Notice from 'src/components/Notice';
 import { queryClient } from 'src/queries/base';
+import { queryKey } from 'src/queries/entityTransfers';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
 const useStyles = makeStyles(() => ({
@@ -53,7 +54,7 @@ export const ConfirmTransferCancelDialog: React.FC<Props> = props => {
     cancelTransfer(token)
       .then(() => {
         // Refresh the query for Entity Transfers.
-        queryClient.invalidateQueries('entity-transfers');
+        queryClient.invalidateQueries(queryKey);
 
         onClose();
         setSubmitting(false);

--- a/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/ConfirmTransferCancelDialog.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/ConfirmTransferCancelDialog.tsx
@@ -94,11 +94,11 @@ export const ConfirmTransferCancelDialog: React.FC<Props> = props => {
     >
       {// There could be multiple errors here that are relevant.
       submissionErrors
-        ? submissionErrors.map((error, idx) => (
+        ? submissionErrors.map((thisError, idx) => (
             <Notice
               key={`form-submit-error-${idx}`}
               error
-              text={error.reason}
+              text={thisError.reason}
             />
           ))
         : null}

--- a/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/EntityTransfersLanding.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/EntityTransfersLanding.tsx
@@ -33,7 +33,6 @@ export const EntityTransfersLanding: React.FC<{}> = _ => {
   }, [location]);
 
   const { data, isLoading, error: transfersError } = useEntityTransfersQuery();
-
   const allEntityTransfers = Object.values(data ?? {});
 
   let [sentTransfers, receivedTransfers] = partition(

--- a/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/EntityTransfersLanding.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/EntityTransfersLanding.tsx
@@ -33,6 +33,7 @@ export const EntityTransfersLanding: React.FC<{}> = _ => {
   }, [location]);
 
   const { data, isLoading, error: transfersError } = useEntityTransfersQuery();
+
   const allEntityTransfers = Object.values(data ?? {});
 
   let [sentTransfers, receivedTransfers] = partition(

--- a/packages/manager/src/features/EntityTransfers/TransfersTable.tsx
+++ b/packages/manager/src/features/EntityTransfers/TransfersTable.tsx
@@ -16,6 +16,7 @@ import capitalize from 'src/utilities/capitalize';
 import { pluralize } from 'src/utilities/pluralize';
 import ConfirmTransferCancelDialog from './EntityTransfersLanding/ConfirmTransferCancelDialog';
 import ActionMenu from './TransfersPendingActionMenu';
+import { isEmpty } from 'ramda';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -76,7 +77,13 @@ export const TransfersTable: React.FC<CombinedProps> = props => {
 
   const renderTransferRow = (transfer: EntityTransfer, idx: number) => {
     const entitiesBeingTransferred = transfer.entities;
-    const entitiesAndTheirCounts = Object.entries(entitiesBeingTransferred);
+    const entitiesAndTheirCounts = Object.entries(
+      entitiesBeingTransferred ?? {}
+    );
+
+    if (isEmpty(entitiesAndTheirCounts)) {
+      return null;
+    }
 
     return (
       <TableRow key={`transfer-${idx}`}>

--- a/packages/manager/src/queries/entityTransfers.ts
+++ b/packages/manager/src/queries/entityTransfers.ts
@@ -10,7 +10,7 @@ import { useMutation, useQuery } from 'react-query';
 import { getAll } from 'src/utilities/getAll';
 import { creationHandlers, listToItemsByID, queryPresets } from './base';
 
-const queryKey = 'entity-transfers';
+export const queryKey = 'entity-transfers';
 
 const getAllEntityTransfersRequest = () =>
   getAll<EntityTransfer>((passedParams, passedFilter) =>

--- a/packages/manager/src/queries/entityTransfers.ts
+++ b/packages/manager/src/queries/entityTransfers.ts
@@ -3,12 +3,18 @@ import {
   CreateTransferPayload,
   EntityTransfer,
   getEntityTransfer,
-  getEntityTransfers
+  getEntityTransfers,
+  cancelTransfer
 } from '@linode/api-v4/lib/entity-transfers';
 import { APIError } from '@linode/api-v4/lib/types';
 import { useMutation, useQuery } from 'react-query';
 import { getAll } from 'src/utilities/getAll';
-import { creationHandlers, listToItemsByID, queryPresets } from './base';
+import {
+  creationHandlers,
+  mutationHandlers,
+  listToItemsByID,
+  queryPresets
+} from './base';
 
 const queryKey = 'entity-transfers';
 
@@ -40,4 +46,10 @@ export const useCreateTransfer = () => {
     },
     creationHandlers(queryKey, 'token')
   );
+};
+
+export const useCancelTransfer = () => {
+  return useMutation<{}, APIError[], string>(token => {
+    return cancelTransfer(token);
+  }, mutationHandlers(queryKey, 'token'));
 };

--- a/packages/manager/src/queries/entityTransfers.ts
+++ b/packages/manager/src/queries/entityTransfers.ts
@@ -3,18 +3,12 @@ import {
   CreateTransferPayload,
   EntityTransfer,
   getEntityTransfer,
-  getEntityTransfers,
-  cancelTransfer
+  getEntityTransfers
 } from '@linode/api-v4/lib/entity-transfers';
 import { APIError } from '@linode/api-v4/lib/types';
 import { useMutation, useQuery } from 'react-query';
 import { getAll } from 'src/utilities/getAll';
-import {
-  creationHandlers,
-  mutationHandlers,
-  listToItemsByID,
-  queryPresets
-} from './base';
+import { creationHandlers, listToItemsByID, queryPresets } from './base';
 
 const queryKey = 'entity-transfers';
 
@@ -46,10 +40,4 @@ export const useCreateTransfer = () => {
     },
     creationHandlers(queryKey, 'token')
   );
-};
-
-export const useCancelTransfer = () => {
-  return useMutation<{}, APIError[], string>(token => {
-    return cancelTransfer(token);
-  }, mutationHandlers(queryKey, 'token'));
 };


### PR DESCRIPTION
## Description
Ensure that the Transfers Pending & Transfers Sent tables update appropriately after a transfer is canceled; this is done by refreshing the `entity-transfers` query.

## Type of Change
- Non breaking change ('update', 'change')
