### PR TITLE
Prevent users from loading the receive transfer dialog for transfers on their own account

### DIFF
--- a/packages/manager/src/components/ErrorState/ErrorState.tsx
+++ b/packages/manager/src/components/ErrorState/ErrorState.tsx
@@ -56,7 +56,7 @@ const ErrorState = (props: Props & WithStyles<CSSClasses>) => {
       justify="center"
       alignItems="center"
     >
-      <Grid item>
+      <Grid item data-testid="error-state">
         <div className={props.classes.iconContainer}>
           {CustomIcon ? (
             <CustomIcon

--- a/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/ConfirmTransferDialog.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/ConfirmTransferDialog.tsx
@@ -69,6 +69,18 @@ export const ConfirmTransferDialog: React.FC<Props> = props => {
     APIError[] | null
   >(null);
 
+  const isOwnAccount = Boolean(data?.is_sender);
+
+  // If a user is trying to load their own account
+  const errors = isOwnAccount
+    ? [
+        {
+          reason:
+            'You cannot initiate a transfer to another user on your account.'
+        }
+      ]
+    : error;
+
   React.useEffect(() => {
     if (open) {
       setSubmissionErrors(null);
@@ -125,8 +137,8 @@ export const ConfirmTransferDialog: React.FC<Props> = props => {
     >
       <DialogContent
         isLoading={isLoading}
-        isError={isError}
-        errors={error}
+        isError={isError || isOwnAccount}
+        errors={errors}
         entities={data?.entities ?? { linodes: [] }}
         expiry={data?.expiry}
         hasConfirmed={hasConfirmed}
@@ -251,6 +263,12 @@ export const getTimeRemaining = (time?: string) => {
       .diffNow('minutes')
       .toObject().minutes ?? 0
   );
+
+  if (minutesRemaining < 1) {
+    // This should never happen; expired tokens have a status of STALE and can't be
+    // retrieved by users on another account.
+    return 'This token has expired.';
+  }
 
   const unit = minutesRemaining > 60 ? 'hour' : 'minute';
 


### PR DESCRIPTION
It's possible to open the "receive transfer" with a transfer you or another user on your account created. You get an error if you submit the form, but it's a weird UX (including the display of -111354 minutes if you use an expired token). I think the best thing to do is show an error up front in these cases.