### PR TITLE
M3-4943 Change: Selecting a Linode auto-selects the region when creating a Volume

### DIFF
--- a/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionSelect.tsx
+++ b/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionSelect.tsx
@@ -9,7 +9,6 @@ import SG from 'flag-icon-css/flags/4x3/sg.svg';
 import US from 'flag-icon-css/flags/4x3/us.svg';
 import { groupBy } from 'ramda';
 import * as React from 'react';
-import { compose } from 'recompose';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import SingleValue from 'src/components/EnhancedSelect/components/SingleValue';
@@ -51,6 +50,7 @@ interface Props extends Omit<BaseSelectProps, 'onChange'> {
   selectedID: string | null;
   label?: string;
   helperText?: string;
+  isClearable?: boolean;
 }
 
 export const flags = {
@@ -169,6 +169,7 @@ const SelectRegionPanel: React.FC<Props> = props => {
     label,
     disabled,
     handleSelection,
+    isClearable,
     helperText,
     regions,
     selectedID,
@@ -177,13 +178,17 @@ const SelectRegionPanel: React.FC<Props> = props => {
   } = props;
 
   const onChange = React.useCallback(
-    (selection: RegionItem) => {
+    (selection: RegionItem | null) => {
+      if (selection === null) {
+        handleSelection('');
+        return;
+      }
       if (selection.disabledMessage) {
         // React Select's disabled state should prevent anything
         // from firing, this is basic paranoia.
         return;
       }
-      handleSelection(selection.value);
+      handleSelection(selection?.value);
     },
     [handleSelection]
   );
@@ -195,7 +200,7 @@ const SelectRegionPanel: React.FC<Props> = props => {
   return (
     <div className={classes.root}>
       <Select
-        isClearable={false}
+        isClearable={Boolean(isClearable)} // Defaults to false if the prop isn't provided
         value={getSelectedRegionById(selectedID || '', options)}
         label={label ?? 'Region'}
         disabled={disabled}
@@ -216,4 +221,4 @@ const SelectRegionPanel: React.FC<Props> = props => {
   );
 };
 
-export default compose<Props, Props>(React.memo)(SelectRegionPanel);
+export default React.memo(SelectRegionPanel);

--- a/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
@@ -257,6 +257,7 @@ const CreateVolumeForm: React.FC<CombinedProps> = props => {
                     disabled={disabled}
                   />
                   <RegionSelect
+                    isClearable
                     errorText={touched.region ? errors.region : undefined}
                     regions={props.regions
                       .filter(eachRegion =>
@@ -271,7 +272,10 @@ const CreateVolumeForm: React.FC<CombinedProps> = props => {
                     name="region"
                     onBlur={handleBlur}
                     selectedID={values.region}
-                    handleSelection={value => setFieldValue('region', value)}
+                    handleSelection={value => {
+                      setFieldValue('region', value);
+                      setFieldValue('linode_id', initialValueDefaultId);
+                    }}
                     disabled={disabled}
                     styles={{
                       /** altering styles for mobile-view */

--- a/packages/manager/src/features/linodes/LinodeSelect/LinodeSelect.tsx
+++ b/packages/manager/src/features/linodes/LinodeSelect/LinodeSelect.tsx
@@ -42,6 +42,9 @@ interface Props {
   noMarginTop?: boolean;
   value?: Item<any> | null;
   inputId?: string;
+  // Formik stuff to be passed down to the inner Select
+  onBlur?: (e: any) => void;
+  name?: string;
 }
 
 type CombinedProps = Props & WithLinodesProps;
@@ -64,7 +67,8 @@ const LinodeSelect: React.FC<CombinedProps> = props => {
     labelOverride,
     filterCondition,
     value,
-    inputId
+    inputId,
+    ...rest
   } = props;
 
   const { _loading } = useReduxLoad(['linodes']);
@@ -118,6 +122,7 @@ const LinodeSelect: React.FC<CombinedProps> = props => {
       isClearable={false}
       textFieldProps={props.textFieldProps}
       noOptionsMessage={() => props.noOptionsMessage || noOptionsMessage}
+      {...rest}
     />
   );
 };


### PR DESCRIPTION
## Description

Instead of adding plumbing to work with the /Volumes/LinodeSelect component that's only really used here, I used src/features/linodes/LinodeSelect instead and adjusted things to make it work out.