### PR TITLE
Update types and factories to reflect new Firewall rule policy types

### DIFF
--- a/packages/api-v4/src/firewalls/firewalls.schema.ts
+++ b/packages/api-v4/src/firewalls/firewalls.schema.ts
@@ -41,6 +41,9 @@ export const validateFirewallPorts = string().matches(
 
 const validFirewallRuleProtocol = ['ALL', 'TCP', 'UDP', 'ICMP'];
 export const FirewallRuleTypeSchema = object().shape({
+  action: mixed()
+    .oneOf(['ACCEPT', 'DROP'])
+    .required('Action is required'),
   protocol: mixed()
     .oneOf(validFirewallRuleProtocol)
     .required('Protocol is required.'),
@@ -69,7 +72,13 @@ export const FirewallRuleTypeSchema = object().shape({
 
 export const FirewallRuleSchema = object().shape({
   inbound: array(FirewallRuleTypeSchema).nullable(true),
-  outbound: array(FirewallRuleTypeSchema).nullable(true)
+  outbound: array(FirewallRuleTypeSchema).nullable(true),
+  inbound_policy: mixed()
+    .oneOf(['ACCEPT', 'DROP'])
+    .required('Inbound policy is required.'),
+  outbound_policy: mixed()
+    .oneOf(['ACCEPT', 'DROP'])
+    .required('Outbound policy is required.')
 });
 
 export const CreateFirewallSchema = object().shape({

--- a/packages/api-v4/src/firewalls/types.ts
+++ b/packages/api-v4/src/firewalls/types.ts
@@ -4,6 +4,8 @@ export type FirewallRuleProtocol = 'ALL' | 'TCP' | 'UDP' | 'ICMP';
 
 export type FirewallDeviceEntityType = 'linode' | 'nodebalancer';
 
+export type FirewallPolicyType = 'ACCEPT' | 'DROP';
+
 export interface Firewall {
   id: number;
   status: FirewallStatus;
@@ -17,6 +19,8 @@ export interface Firewall {
 export interface FirewallRules {
   inbound?: FirewallRuleType[] | null;
   outbound?: FirewallRuleType[] | null;
+  inbound_policy: FirewallPolicyType;
+  outbound_policy: FirewallPolicyType;
 }
 
 export interface FirewallRuleType {
@@ -24,6 +28,7 @@ export interface FirewallRuleType {
   description?: string;
   protocol: FirewallRuleProtocol;
   ports?: string;
+  action: FirewallPolicyType;
   addresses?: null | {
     ipv4?: null | string[];
     ipv6?: null | string[];

--- a/packages/manager/src/__data__/firewalls.ts
+++ b/packages/manager/src/__data__/firewalls.ts
@@ -8,11 +8,14 @@ export const firewall: Firewall = {
   updated_dt: '2019-09-11T19:44:38.526Z',
   tags: [],
   rules: {
+    inbound_policy: 'DROP',
+    outbound_policy: 'DROP',
     inbound: [
       {
         protocol: 'ALL',
-        ports: '443'
-      }
+        ports: '443',
+        action: 'ACCEPT',
+      },
     ],
     outbound: [
       {
@@ -20,11 +23,12 @@ export const firewall: Firewall = {
         ports: '22',
         addresses: {
           ipv4: ['12.12.12.12'],
-          ipv6: ['192.168.12.12']
-        }
-      }
-    ]
-  }
+          ipv6: ['192.168.12.12'],
+        },
+        action: 'ACCEPT',
+      },
+    ],
+  },
 };
 
 export const firewall2: Firewall = {
@@ -35,18 +39,22 @@ export const firewall2: Firewall = {
   updated_dt: '2019-12-11T19:44:38.526Z',
   tags: [],
   rules: {
+    inbound_policy: 'DROP',
+    outbound_policy: 'DROP',
     inbound: [],
     outbound: [
       {
         protocol: 'ALL',
-        ports: '443'
+        ports: '443',
+        action: 'ACCEPT',
       },
       {
         protocol: 'ALL',
-        ports: '80'
-      }
-    ]
-  }
+        ports: '80',
+        action: 'ACCEPT',
+      },
+    ],
+  },
 };
 
 export const firewalls = [firewall, firewall2];

--- a/packages/manager/src/factories/firewalls.ts
+++ b/packages/manager/src/factories/firewalls.ts
@@ -4,41 +4,44 @@ import {
   FirewallDevice,
   FirewallDeviceEntityType,
   FirewallRules,
-  FirewallRuleType
+  FirewallRuleType,
 } from '@linode/api-v4/lib/firewalls/types';
 
 export const firewallRuleFactory = Factory.Sync.makeFactory<FirewallRuleType>({
   ports: '22',
   protocol: 'TCP',
+  action: 'DROP',
   addresses: {
     ipv4: ['0.0.0.0/0'],
-    ipv6: ['::/0']
-  }
+    ipv6: ['::/0'],
+  },
 });
 
 export const firewallRulesFactory = Factory.Sync.makeFactory<FirewallRules>({
   inbound: firewallRuleFactory.buildList(1),
-  outbound: firewallRuleFactory.buildList(1)
+  outbound: firewallRuleFactory.buildList(1),
+  outbound_policy: 'ACCEPT',
+  inbound_policy: 'DROP',
 });
 
 export const firewallFactory = Factory.Sync.makeFactory<Firewall>({
-  id: Factory.each(id => id),
-  label: Factory.each(id => `mock-firewall-${id}`),
+  id: Factory.each((id) => id),
+  label: Factory.each((id) => `mock-firewall-${id}`),
   rules: firewallRulesFactory.build(),
   created_dt: '2020-01-01 00:00:00',
   updated_dt: '2020-01-01 00:00:00',
   tags: [],
-  status: 'enabled'
+  status: 'enabled',
 });
 
 export const firewallDeviceFactory = Factory.Sync.makeFactory<FirewallDevice>({
-  id: Factory.each(i => i),
+  id: Factory.each((i) => i),
   created: '2020-01-01',
   updated: '2020-01-01',
   entity: {
     type: 'linode' as FirewallDeviceEntityType,
     label: 'entity',
     id: 10,
-    url: '/linodes/1'
-  }
+    url: '/linodes/1',
+  },
 });

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.test.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.test.tsx
@@ -14,7 +14,7 @@ import RuleDrawer, {
   portStringToItems,
   IP_ERROR_MESSAGE,
   validateForm,
-  validateIPs
+  validateIPs,
 } from './FirewallRuleDrawer';
 import { ExtendedFirewallRule } from './firewallRuleEditor';
 import { FirewallRuleError, PORT_PRESETS } from './shared';
@@ -31,7 +31,7 @@ const props: CombinedProps = {
   mode: 'create',
   isOpen: true,
   onClose: mockOnClose,
-  onSubmit: mockOnSubmit
+  onSubmit: mockOnSubmit,
 };
 
 describe('AddRuleDrawer', () => {
@@ -57,15 +57,15 @@ describe('utilities', () => {
         allIPs
       );
       expect(formValueToIPs('allIPv4', [''].map(stringToExtendedIP))).toEqual({
-        ipv4: ['0.0.0.0/0']
+        ipv4: ['0.0.0.0/0'],
       });
       expect(formValueToIPs('allIPv6', [''].map(stringToExtendedIP))).toEqual({
-        ipv6: ['::/0']
+        ipv6: ['::/0'],
       });
       expect(
         formValueToIPs('ip/netmask', ['1.1.1.1'].map(stringToExtendedIP))
       ).toEqual({
-        ipv4: ['1.1.1.1']
+        ipv4: ['1.1.1.1'],
       });
     });
   });
@@ -76,7 +76,7 @@ describe('utilities', () => {
         validateIPs(['1.1.1.1', 'invalid-IP'].map(stringToExtendedIP))
       ).toEqual([
         { address: '1.1.1.1' },
-        { address: 'invalid-IP', error: IP_ERROR_MESSAGE }
+        { address: 'invalid-IP', error: IP_ERROR_MESSAGE },
       ]);
     });
   });
@@ -105,15 +105,16 @@ describe('utilities', () => {
       ports: '80',
       protocol: 'TCP',
       status: 'NEW',
+      action: 'ACCEPT',
       addresses: {
         ipv4: ['1.2.3.4'],
-        ipv6: ['::0']
-      }
+        ipv6: ['::0'],
+      },
     };
     it('parses the IPs when no errors', () => {
       expect(getInitialIPs(ruleToModify)).toEqual([
         { address: '1.2.3.4' },
-        { address: '::0' }
+        { address: '::0' },
       ]);
     });
     it('parses the IPs with no errors', () => {
@@ -123,12 +124,12 @@ describe('utilities', () => {
           formField: 'addresses',
           idx: 1,
           reason: 'Invalid IP',
-          ip: { idx: 0, type: 'ipv4' }
-        }
+          ip: { idx: 0, type: 'ipv4' },
+        },
       ];
       expect(getInitialIPs({ ...ruleToModify, errors })).toEqual([
         { address: '1.2.3.4', error: IP_ERROR_MESSAGE },
-        { address: '::0' }
+        { address: '::0' },
       ]);
     });
     it('offsets error indices correctly', () => {
@@ -136,7 +137,7 @@ describe('utilities', () => {
         ...ruleToModify,
         addresses: {
           ipv4: ['1.2.3.4'],
-          ipv6: ['INVALID_IP']
+          ipv6: ['INVALID_IP'],
         },
         errors: [
           {
@@ -144,13 +145,13 @@ describe('utilities', () => {
             formField: 'addresses',
             idx: 1,
             reason: 'Invalid IP',
-            ip: { idx: 0, type: 'ipv6' }
-          }
-        ]
+            ip: { idx: 0, type: 'ipv6' },
+          },
+        ],
       });
       expect(result).toEqual([
         { address: '1.2.3.4' },
-        { address: 'INVALID_IP', error: IP_ERROR_MESSAGE }
+        { address: 'INVALID_IP', error: IP_ERROR_MESSAGE },
       ]);
     });
   });
@@ -159,12 +160,12 @@ describe('utilities', () => {
     it('classifies v4 and v6', () => {
       expect(classifyIPs(['1.1.1.1', '0::0'].map(stringToExtendedIP))).toEqual({
         ipv4: ['1.1.1.1'],
-        ipv6: ['0::0']
+        ipv6: ['0::0'],
       });
     });
     it('accepts ranges', () => {
       expect(classifyIPs(['1.1.0.0/16'].map(stringToExtendedIP))).toEqual({
-        ipv4: ['1.1.0.0/16']
+        ipv4: ['1.1.0.0/16'],
       });
     });
   });
@@ -176,7 +177,7 @@ describe('utilities', () => {
       protocol: 'TCP',
       type: '',
       label: '',
-      description: ''
+      description: '',
     };
 
     it('correctly matches values to their representative type', () => {
@@ -240,7 +241,7 @@ describe('utilities', () => {
       expect(items).toEqual([
         PORT_PRESETS['443'],
         PORT_PRESETS['22'],
-        PORT_PRESETS['CUSTOM']
+        PORT_PRESETS['CUSTOM'],
       ]);
       expect(portString).toEqual('1111-2222');
     });

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
@@ -2,7 +2,7 @@ import { Formik, FormikProps } from 'formik';
 import { parse as parseIP, parseCIDR } from 'ipaddr.js';
 import {
   FirewallRuleProtocol,
-  FirewallRuleType
+  FirewallRuleType,
 } from '@linode/api-v4/lib/firewalls';
 import { uniq } from 'ramda';
 import * as React from 'react';
@@ -27,7 +27,7 @@ import {
   firewallOptionItemsShort,
   portPresets,
   predefinedFirewallFromRule,
-  protocolOptions
+  protocolOptions,
 } from 'src/features/Firewalls/shared';
 import capitalize from 'src/utilities/capitalize';
 import { ExtendedIP, stringToExtendedIP } from 'src/utilities/ipUtils';
@@ -37,7 +37,7 @@ import {
   FirewallRuleError,
   PORT_PRESETS,
   PORT_PRESETS_ITEMS,
-  sortString
+  sortString,
 } from './shared';
 
 export type Mode = 'create' | 'edit';
@@ -68,7 +68,7 @@ interface Form {
 
 export type CombinedProps = Props;
 
-const FirewallRuleDrawer: React.FC<CombinedProps> = props => {
+const FirewallRuleDrawer: React.FC<CombinedProps> = (props) => {
   const { isOpen, onClose, category, mode, ruleToModify } = props;
 
   // Custom IPs are tracked separately from the form. The <MultipleIPs />
@@ -105,12 +105,12 @@ const FirewallRuleDrawer: React.FC<CombinedProps> = props => {
     protocol,
     label,
     description,
-    addresses
+    addresses,
   }: Form) => {
     // The validated IPs may have errors, so set them to state so we see the errors.
     const validatedIPs = validateIPs(ips, {
       // eslint-disable-next-line sonarjs/no-duplicate-string
-      allowEmptyAddress: addresses !== 'ip/netmask'
+      allowEmptyAddress: addresses !== 'ip/netmask',
     });
     setIPs(validatedIPs);
 
@@ -121,7 +121,7 @@ const FirewallRuleDrawer: React.FC<CombinedProps> = props => {
       // This is a bit of a trick. If this function DOES NOT return an empty object, Formik will call
       // `onSubmit()`. If there are IP errors, we add them to the return object so Formik knows there
       // is an issue with the form.
-      ...validatedIPs.filter(thisIP => Boolean(thisIP.error))
+      ...validatedIPs.filter((thisIP) => Boolean(thisIP.error)),
     };
   };
 
@@ -133,7 +133,8 @@ const FirewallRuleDrawer: React.FC<CombinedProps> = props => {
     const payload: FirewallRuleType = {
       ports,
       protocol,
-      addresses
+      addresses,
+      action: 'ACCEPT',
     };
 
     if (values.label) {
@@ -157,7 +158,7 @@ const FirewallRuleDrawer: React.FC<CombinedProps> = props => {
         onSubmit={onSubmit}
         validate={onValidate}
       >
-        {formikProps => {
+        {(formikProps) => {
           return (
             <FirewallRuleForm
               category={category}
@@ -188,8 +189,8 @@ export default React.memo(FirewallRuleDrawer);
 // =============================================================================
 const useStyles = makeStyles((theme: Theme) => ({
   ipSelect: {
-    marginTop: theme.spacing(2)
-  }
+    marginTop: theme.spacing(2),
+  },
 }));
 
 interface FirewallRuleFormProps extends FormikProps<Form> {
@@ -203,287 +204,289 @@ interface FirewallRuleFormProps extends FormikProps<Form> {
   ruleErrors?: FirewallRuleError[];
 }
 
-const FirewallRuleForm: React.FC<FirewallRuleFormProps> = React.memo(props => {
-  const classes = useStyles();
+const FirewallRuleForm: React.FC<FirewallRuleFormProps> = React.memo(
+  (props) => {
+    const classes = useStyles();
 
-  // This will be set to `true` once a form field has been touched. This is used to disable the
-  // "Submit" button unless there have been changes to the form.
-  const [formTouched, setFormTouched] = React.useState<boolean>(false);
+    // This will be set to `true` once a form field has been touched. This is used to disable the
+    // "Submit" button unless there have been changes to the form.
+    const [formTouched, setFormTouched] = React.useState<boolean>(false);
 
-  const {
-    values,
-    errors,
-    status,
-    handleChange,
-    handleBlur,
-    handleSubmit,
-    setFieldValue,
-    addressesLabel,
-    ips,
-    setIPs,
-    presetPorts,
-    setPresetPorts,
-    mode,
-    ruleErrors,
-    setFieldError,
-    touched,
-    category
-  } = props;
+    const {
+      values,
+      errors,
+      status,
+      handleChange,
+      handleBlur,
+      handleSubmit,
+      setFieldValue,
+      addressesLabel,
+      ips,
+      setIPs,
+      presetPorts,
+      setPresetPorts,
+      mode,
+      ruleErrors,
+      setFieldError,
+      touched,
+      category,
+    } = props;
 
-  const hasCustomInput = presetPorts.some(
-    thisPort => thisPort.value === PORT_PRESETS['CUSTOM'].value
-  );
-
-  const hasSelectedAllPorts = presetPorts.some(
-    thisPort => thisPort.value === PORT_PRESETS['ALL'].value
-  );
-
-  // If ALL is selected, don't show additional options
-  // (because they won't do anything)
-  const portOptions = hasSelectedAllPorts
-    ? PORT_PRESETS_ITEMS.filter(
-        thisItem => thisItem.value === PORT_PRESETS['ALL'].value
-      )
-    : PORT_PRESETS_ITEMS;
-
-  // This is an edge case; if there's an error for the Ports field
-  // but CUSTOM isn't selected, the error won't be visible to the user.
-  const generalPortError = !hasCustomInput && errors.ports;
-
-  // Set form field errors for each error we have (except "addresses" errors, which are handled
-  // by IP Error state).
-  React.useEffect(() => {
-    // eslint-disable-next-line no-unused-expressions
-    ruleErrors?.forEach(thisError => {
-      if (thisError.formField !== 'addresses') {
-        setFieldError(thisError.formField, thisError.reason);
-      }
-    });
-  }, [ruleErrors, setFieldError]);
-
-  // These handlers are all memoized because the form was laggy when I tried them inline.
-  const handleTypeChange = React.useCallback(
-    (item: Item | null) => {
-      const selectedType = item?.value;
-      setFieldValue('type', selectedType);
-
-      if (!selectedType) {
-        return;
-      }
-
-      if (!formTouched) {
-        setFormTouched(true);
-      }
-
-      if (!touched.label) {
-        setFieldValue('label', `allow-${category}-${item?.label}`);
-      }
-
-      // Pre-populate other form values if selecting a pre-defined type.
-      if (selectedType !== 'custom') {
-        // All predefined FW types use the TCP protocol.
-        setFieldValue('protocol', 'TCP');
-        // All predefined FW types use all IPv4 and IPv6.
-        setFieldValue('addresses', 'all');
-        // Use the port for the selected type.
-        setPresetPorts([PORT_PRESETS[portPresets[selectedType]]]);
-      }
-    },
-    [formTouched, setFieldValue, touched, category, setPresetPorts]
-  );
-
-  const handleTextFieldChange = React.useCallback(
-    (e: React.ChangeEvent) => {
-      if (!formTouched) {
-        setFormTouched(true);
-      }
-      handleChange(e);
-    },
-    [formTouched, handleChange]
-  );
-
-  const handleProtocolChange = React.useCallback(
-    (item: Item | null) => {
-      if (!formTouched) {
-        setFormTouched(true);
-      }
-
-      setFieldValue('protocol', item?.value);
-      if (item?.value === 'ICMP') {
-        // Submitting the form with ICMP and defined ports causes an error
-        setFieldValue('ports', '');
-        setPresetPorts([]);
-      }
-    },
-    [formTouched, setFieldValue, setPresetPorts]
-  );
-
-  const handleAddressesChange = React.useCallback(
-    (item: Item | null) => {
-      if (!formTouched) {
-        setFormTouched(true);
-      }
-
-      setFieldValue('addresses', item?.value);
-      // Reset custom IPs
-      setIPs([{ address: '' }]);
-    },
-    [formTouched, setFieldValue, setFormTouched, setIPs]
-  );
-
-  const handleIPChange = React.useCallback(
-    (_ips: ExtendedIP[]) => {
-      if (!formTouched) {
-        setFormTouched(true);
-      }
-      setIPs(_ips);
-    },
-    [formTouched, setIPs]
-  );
-
-  const handlePortPresetChange = React.useCallback(
-    (items: Item<string>[]) => {
-      if (!formTouched) {
-        setFormTouched(true);
-      }
-      // If the user is selecting "ALL", it doesn't make sense
-      // to show additional selections.
-      if (
-        items.some(thisItem => thisItem.value === PORT_PRESETS['ALL'].value)
-      ) {
-        setPresetPorts([PORT_PRESETS['ALL']]);
-        setFieldValue('ports', '');
-        return;
-      }
-      setPresetPorts(items);
-      if (!items.some(thisItem => thisItem.value === 'CUSTOM')) {
-        setFieldValue('ports', '');
-      }
-    },
-    [setPresetPorts, formTouched, setFieldValue]
-  );
-
-  const addressesValue = React.useMemo(() => {
-    return (
-      addressOptions.find(
-        thisOption => thisOption.value === values.addresses
-      ) || null
+    const hasCustomInput = presetPorts.some(
+      (thisPort) => thisPort.value === PORT_PRESETS['CUSTOM'].value
     );
-  }, [values]);
 
-  return (
-    <form onSubmit={handleSubmit}>
-      {status && (
-        <Notice key={status} text={status.generalError} error data-qa-error />
-      )}
-      <Select
-        label="Preset"
-        name="type"
-        placeholder="Select a rule preset..."
-        aria-label="Preset for firewall rule"
-        options={firewallOptionItemsShort}
-        onChange={handleTypeChange}
-        isClearable={false}
-        onBlur={handleBlur}
-      />
-      <TextField
-        label="Label"
-        name="label"
-        placeholder="Enter a label..."
-        aria-label="Label for firewall rule"
-        value={values.label}
-        errorText={errors.label}
-        onChange={handleTextFieldChange}
-        onBlur={handleBlur}
-      />
-      <TextField
-        label="Description"
-        name="description"
-        placeholder="Enter a description..."
-        aria-label="Description for firewall rule"
-        value={values.description}
-        errorText={errors.description}
-        onChange={handleTextFieldChange}
-        onBlur={handleBlur}
-      />
-      <Select
-        label="Protocol"
-        name="protocol"
-        placeholder="Select a protocol..."
-        aria-label="Select rule protocol."
-        value={
-          values.protocol
-            ? { label: values.protocol, value: values.protocol }
-            : undefined
+    const hasSelectedAllPorts = presetPorts.some(
+      (thisPort) => thisPort.value === PORT_PRESETS['ALL'].value
+    );
+
+    // If ALL is selected, don't show additional options
+    // (because they won't do anything)
+    const portOptions = hasSelectedAllPorts
+      ? PORT_PRESETS_ITEMS.filter(
+          (thisItem) => thisItem.value === PORT_PRESETS['ALL'].value
+        )
+      : PORT_PRESETS_ITEMS;
+
+    // This is an edge case; if there's an error for the Ports field
+    // but CUSTOM isn't selected, the error won't be visible to the user.
+    const generalPortError = !hasCustomInput && errors.ports;
+
+    // Set form field errors for each error we have (except "addresses" errors, which are handled
+    // by IP Error state).
+    React.useEffect(() => {
+      // eslint-disable-next-line no-unused-expressions
+      ruleErrors?.forEach((thisError) => {
+        if (thisError.formField !== 'addresses') {
+          setFieldError(thisError.formField, thisError.reason);
         }
-        errorText={errors.protocol}
-        options={protocolOptions}
-        onChange={handleProtocolChange}
-        onBlur={handleBlur}
-        isClearable={false}
-      />
-      <Select
-        isMulti
-        label="Ports"
-        errorText={generalPortError}
-        value={presetPorts}
-        options={portOptions}
-        onChange={handlePortPresetChange}
-        disabled={values.protocol === 'ICMP'}
-        textFieldProps={{
-          helperText:
-            values.protocol === 'ICMP'
-              ? 'Ports are not allowed for ICMP protocols.'
-              : undefined
-        }}
-      />
-      {hasCustomInput ? (
+      });
+    }, [ruleErrors, setFieldError]);
+
+    // These handlers are all memoized because the form was laggy when I tried them inline.
+    const handleTypeChange = React.useCallback(
+      (item: Item | null) => {
+        const selectedType = item?.value;
+        setFieldValue('type', selectedType);
+
+        if (!selectedType) {
+          return;
+        }
+
+        if (!formTouched) {
+          setFormTouched(true);
+        }
+
+        if (!touched.label) {
+          setFieldValue('label', `allow-${category}-${item?.label}`);
+        }
+
+        // Pre-populate other form values if selecting a pre-defined type.
+        if (selectedType !== 'custom') {
+          // All predefined FW types use the TCP protocol.
+          setFieldValue('protocol', 'TCP');
+          // All predefined FW types use all IPv4 and IPv6.
+          setFieldValue('addresses', 'all');
+          // Use the port for the selected type.
+          setPresetPorts([PORT_PRESETS[portPresets[selectedType]]]);
+        }
+      },
+      [formTouched, setFieldValue, touched, category, setPresetPorts]
+    );
+
+    const handleTextFieldChange = React.useCallback(
+      (e: React.ChangeEvent) => {
+        if (!formTouched) {
+          setFormTouched(true);
+        }
+        handleChange(e);
+      },
+      [formTouched, handleChange]
+    );
+
+    const handleProtocolChange = React.useCallback(
+      (item: Item | null) => {
+        if (!formTouched) {
+          setFormTouched(true);
+        }
+
+        setFieldValue('protocol', item?.value);
+        if (item?.value === 'ICMP') {
+          // Submitting the form with ICMP and defined ports causes an error
+          setFieldValue('ports', '');
+          setPresetPorts([]);
+        }
+      },
+      [formTouched, setFieldValue, setPresetPorts]
+    );
+
+    const handleAddressesChange = React.useCallback(
+      (item: Item | null) => {
+        if (!formTouched) {
+          setFormTouched(true);
+        }
+
+        setFieldValue('addresses', item?.value);
+        // Reset custom IPs
+        setIPs([{ address: '' }]);
+      },
+      [formTouched, setFieldValue, setFormTouched, setIPs]
+    );
+
+    const handleIPChange = React.useCallback(
+      (_ips: ExtendedIP[]) => {
+        if (!formTouched) {
+          setFormTouched(true);
+        }
+        setIPs(_ips);
+      },
+      [formTouched, setIPs]
+    );
+
+    const handlePortPresetChange = React.useCallback(
+      (items: Item<string>[]) => {
+        if (!formTouched) {
+          setFormTouched(true);
+        }
+        // If the user is selecting "ALL", it doesn't make sense
+        // to show additional selections.
+        if (
+          items.some((thisItem) => thisItem.value === PORT_PRESETS['ALL'].value)
+        ) {
+          setPresetPorts([PORT_PRESETS['ALL']]);
+          setFieldValue('ports', '');
+          return;
+        }
+        setPresetPorts(items);
+        if (!items.some((thisItem) => thisItem.value === 'CUSTOM')) {
+          setFieldValue('ports', '');
+        }
+      },
+      [setPresetPorts, formTouched, setFieldValue]
+    );
+
+    const addressesValue = React.useMemo(() => {
+      return (
+        addressOptions.find(
+          (thisOption) => thisOption.value === values.addresses
+        ) || null
+      );
+    }, [values]);
+
+    return (
+      <form onSubmit={handleSubmit}>
+        {status && (
+          <Notice key={status} text={status.generalError} error data-qa-error />
+        )}
+        <Select
+          label="Preset"
+          name="type"
+          placeholder="Select a rule preset..."
+          aria-label="Preset for firewall rule"
+          options={firewallOptionItemsShort}
+          onChange={handleTypeChange}
+          isClearable={false}
+          onBlur={handleBlur}
+        />
         <TextField
-          label="Custom Port Range"
-          name="ports"
-          placeholder="Enter a custom port range..."
-          aria-label="Custom port range for firewall rule"
-          value={values.ports}
-          errorText={errors.ports}
+          label="Label"
+          name="label"
+          placeholder="Enter a label..."
+          aria-label="Label for firewall rule"
+          value={values.label}
+          errorText={errors.label}
           onChange={handleTextFieldChange}
           onBlur={handleBlur}
         />
-      ) : null}
-      <Select
-        label={`${capitalize(addressesLabel)}s`}
-        name="addresses"
-        placeholder={`Select ${addressesLabel}s...`}
-        aria-label={`Select rule ${addressesLabel}s.`}
-        options={addressOptions}
-        value={addressesValue}
-        onChange={handleAddressesChange}
-        onBlur={handleBlur}
-        isClearable={false}
-      />
-      {/* Show this field only if "IP / Netmask has been selected." */}
-      {values.addresses === 'ip/netmask' && (
-        <MultipleIPInput
-          title="IP / Netmask"
-          aria-label="IP / Netmask for Firewall rule"
-          className={classes.ipSelect}
-          ips={ips}
-          onChange={handleIPChange}
-          inputProps={{ autoFocus: true }}
+        <TextField
+          label="Description"
+          name="description"
+          placeholder="Enter a description..."
+          aria-label="Description for firewall rule"
+          value={values.description}
+          errorText={errors.description}
+          onChange={handleTextFieldChange}
+          onBlur={handleBlur}
         />
-      )}
-      <ActionsPanel>
-        <Button
-          buttonType="primary"
-          onClick={() => handleSubmit()}
-          disabled={!formTouched}
-          data-qa-submit
-        >
-          {mode === 'create' ? 'Add Rule' : 'Add Changes'}
-        </Button>
-      </ActionsPanel>
-    </form>
-  );
-});
+        <Select
+          label="Protocol"
+          name="protocol"
+          placeholder="Select a protocol..."
+          aria-label="Select rule protocol."
+          value={
+            values.protocol
+              ? { label: values.protocol, value: values.protocol }
+              : undefined
+          }
+          errorText={errors.protocol}
+          options={protocolOptions}
+          onChange={handleProtocolChange}
+          onBlur={handleBlur}
+          isClearable={false}
+        />
+        <Select
+          isMulti
+          label="Ports"
+          errorText={generalPortError}
+          value={presetPorts}
+          options={portOptions}
+          onChange={handlePortPresetChange}
+          disabled={values.protocol === 'ICMP'}
+          textFieldProps={{
+            helperText:
+              values.protocol === 'ICMP'
+                ? 'Ports are not allowed for ICMP protocols.'
+                : undefined,
+          }}
+        />
+        {hasCustomInput ? (
+          <TextField
+            label="Custom Port Range"
+            name="ports"
+            placeholder="Enter a custom port range..."
+            aria-label="Custom port range for firewall rule"
+            value={values.ports}
+            errorText={errors.ports}
+            onChange={handleTextFieldChange}
+            onBlur={handleBlur}
+          />
+        ) : null}
+        <Select
+          label={`${capitalize(addressesLabel)}s`}
+          name="addresses"
+          placeholder={`Select ${addressesLabel}s...`}
+          aria-label={`Select rule ${addressesLabel}s.`}
+          options={addressOptions}
+          value={addressesValue}
+          onChange={handleAddressesChange}
+          onBlur={handleBlur}
+          isClearable={false}
+        />
+        {/* Show this field only if "IP / Netmask has been selected." */}
+        {values.addresses === 'ip/netmask' && (
+          <MultipleIPInput
+            title="IP / Netmask"
+            aria-label="IP / Netmask for Firewall rule"
+            className={classes.ipSelect}
+            ips={ips}
+            onChange={handleIPChange}
+            inputProps={{ autoFocus: true }}
+          />
+        )}
+        <ActionsPanel>
+          <Button
+            buttonType="primary"
+            onClick={() => handleSubmit()}
+            disabled={!formTouched}
+            data-qa-submit
+          >
+            {mode === 'create' ? 'Add Rule' : 'Add Changes'}
+          </Button>
+        </ActionsPanel>
+      </form>
+    );
+  }
+);
 
 // =============================================================================
 // Utilities
@@ -508,7 +511,8 @@ export const deriveTypeFromValuesAndIPs = (values: Form, ips: ExtendedIP[]) => {
   const predefinedFirewall = predefinedFirewallFromRule({
     ports: values.ports,
     protocol,
-    addresses: formValueToIPs(values.addresses, ips)
+    addresses: formValueToIPs(values.addresses, ips),
+    action: 'ACCEPT',
   });
 
   if (predefinedFirewall) {
@@ -603,7 +607,7 @@ const initialValues: Form = {
   addresses: '',
   protocol: '',
   label: '',
-  description: ''
+  description: '',
 };
 
 const getInitialFormValues = (ruleToModify?: ExtendedFirewallRule): Form => {
@@ -617,7 +621,7 @@ const getInitialFormValues = (ruleToModify?: ExtendedFirewallRule): Form => {
     addresses: getInitialAddressFormValue(ruleToModify.addresses),
     type: predefinedFirewallFromRule(ruleToModify) || '',
     label: ruleToModify?.label || '',
-    description: ruleToModify?.description || ''
+    description: ruleToModify?.description || '',
   };
 };
 
@@ -652,7 +656,7 @@ export const getInitialIPs = (
   const ips: ExtendedIP[] = [...extendedIPv4, ...extendedIPv6];
 
   // eslint-disable-next-line no-unused-expressions
-  ruleToModify.errors?.forEach(thisError => {
+  ruleToModify.errors?.forEach((thisError) => {
     const { formField, ip } = thisError;
 
     if (formField !== 'addresses' || !ip) {
@@ -700,14 +704,14 @@ export const itemsToPortString = (
 ): string | undefined => {
   // If a user has selected ALL, just return that; anything else in the string
   // will be redundant.
-  if (items.findIndex(thisItem => thisItem.value === 'ALL') > -1) {
+  if (items.findIndex((thisItem) => thisItem.value === 'ALL') > -1) {
     return '1-65535';
   }
   // Take the values, excluding "CUSTOM" since that just indicates there was custom user input.
-  const presets = items.map(i => i.value).filter(i => i !== 'CUSTOM');
+  const presets = items.map((i) => i.value).filter((i) => i !== 'CUSTOM');
   const customArray = (portInput ?? '')
     .split(',')
-    .map(port => port.trim())
+    .map((port) => port.trim())
     .filter(Boolean);
   return uniq([...presets, ...customArray])
     .sort(sortString)
@@ -732,11 +736,11 @@ export const portStringToItems = (
     return [[PORT_PRESETS['ALL']], ''];
   }
 
-  const ports = portString.split(',').map(p => p.trim());
+  const ports = portString.split(',').map((p) => p.trim());
   const items: Item<string>[] = [];
   const customInput: string[] = [];
 
-  ports.forEach(thisPort => {
+  ports.forEach((thisPort) => {
     const preset = PORT_PRESETS[thisPort];
     if (preset) {
       items.push(preset);

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.test.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.test.tsx
@@ -8,7 +8,8 @@ describe('Firewall rule table tests', () => {
         ports: '22',
         protocol: 'TCP',
         addresses: { ipv4: ['0.0.0.0/0'], ipv6: ['::/0'] },
-        status: 'NOT_MODIFIED'
+        action: 'ACCEPT',
+        status: 'NOT_MODIFIED',
       };
       expect(firewallRuleToRowData([rule])[0]).toHaveProperty('type', 'SSH');
       expect(firewallRuleToRowData([rule])[0]).toHaveProperty(

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRulesLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRulesLanding.tsx
@@ -1,4 +1,8 @@
-import { FirewallRules, FirewallRuleType } from '@linode/api-v4/lib/firewalls';
+import {
+  FirewallRules,
+  FirewallRuleType,
+  FirewallPolicyType,
+} from '@linode/api-v4/lib/firewalls';
 import { APIError } from '@linode/api-v4/lib/types';
 import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
@@ -11,7 +15,7 @@ import Typography from 'src/components/core/Typography';
 import Notice from 'src/components/Notice';
 import Prompt from 'src/components/Prompt';
 import withFirewalls, {
-  DispatchProps
+  DispatchProps,
 } from 'src/containers/firewalls.container';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import FirewallRuleDrawer, { Mode } from './FirewallRuleDrawer';
@@ -21,7 +25,7 @@ import curriedFirewallRuleEditorReducer, {
   hasModified as _hasModified,
   initRuleEditorState,
   prepareRules,
-  stripExtendedFields
+  stripExtendedFields,
 } from './firewallRuleEditor';
 import FirewallRuleTable from './FirewallRuleTable';
 import { Category, parseFirewallRuleError } from './shared';
@@ -31,21 +35,21 @@ const useStyles = makeStyles((theme: Theme) => ({
   copy: {
     fontSize: '0.875rem',
     lineHeight: 1.5,
-    paddingBottom: theme.spacing(1)
+    paddingBottom: theme.spacing(1),
   },
   table: {
     marginTop: theme.spacing(2),
-    marginBottom: theme.spacing(4)
+    marginBottom: theme.spacing(4),
   },
   actions: {
-    float: 'right'
+    float: 'right',
   },
   mobileSpacing: {
     [theme.breakpoints.down('sm')]: {
       marginLeft: theme.spacing(),
-      marginRight: theme.spacing()
-    }
-  }
+      marginRight: theme.spacing(),
+    },
+  },
 }));
 
 interface Props {
@@ -62,7 +66,7 @@ interface Drawer {
 
 type CombinedProps = Props & DispatchProps & RouteComponentProps;
 
-const FirewallRulesLanding: React.FC<CombinedProps> = props => {
+const FirewallRulesLanding: React.FC<CombinedProps> = (props) => {
   const classes = useStyles();
   const { firewallID, rules } = props;
 
@@ -72,23 +76,24 @@ const FirewallRulesLanding: React.FC<CombinedProps> = props => {
   const [ruleDrawer, setRuleDrawer] = React.useState<Drawer>({
     mode: 'create',
     category: 'inbound',
-    isOpen: false
+    isOpen: false,
   });
   const [submitting, setSubmitting] = React.useState<boolean>(false);
   // @todo fine-grained error handling.
   const [generalErrors, setGeneralErrors] = React.useState<
     APIError[] | undefined
   >();
-  const [discardChangesModalOpen, setDiscardChangesModalOpen] = React.useState<
-    boolean
-  >(false);
+  const [
+    discardChangesModalOpen,
+    setDiscardChangesModalOpen,
+  ] = React.useState<boolean>(false);
 
   const openRuleDrawer = (category: Category, mode: Mode, idx?: number) =>
     setRuleDrawer({
       mode,
       ruleIdx: idx,
       category,
-      isOpen: true
+      isOpen: true,
     });
 
   const closeRuleDrawer = () => setRuleDrawer({ ...ruleDrawer, isOpen: false });
@@ -134,7 +139,7 @@ const FirewallRulesLanding: React.FC<CombinedProps> = props => {
     dispatch({
       type: 'MODIFY_RULE',
       modifiedRule: rule,
-      idx: ruleDrawer.ruleIdx
+      idx: ruleDrawer.ruleIdx,
     });
   };
 
@@ -157,22 +162,24 @@ const FirewallRulesLanding: React.FC<CombinedProps> = props => {
     // because we may need to reference extended fields like "index" for error handling.
     const preparedRules = {
       inbound: prepareRules(inboundState),
-      outbound: prepareRules(outboundState)
+      outbound: prepareRules(outboundState),
     };
 
     const finalRules = {
       inbound: preparedRules.inbound.map(stripExtendedFields),
-      outbound: preparedRules.outbound.map(stripExtendedFields)
+      outbound: preparedRules.outbound.map(stripExtendedFields),
+      inbound_policy: 'DROP' as FirewallPolicyType, // @todo fix these defaults
+      outbound_policy: 'ACCEPT' as FirewallPolicyType, // @todo fix these defaults
     };
 
     updateFirewallRules(firewallID, finalRules)
-      .then(_rules => {
+      .then((_rules) => {
         setSubmitting(false);
         // Reset editor state.
         inboundDispatch({ type: 'RESET', rules: _rules.inbound ?? [] });
         outboundDispatch({ type: 'RESET', rules: _rules.outbound ?? [] });
       })
-      .catch(err => {
+      .catch((err) => {
         setSubmitting(false);
 
         const _err = getAPIErrorOrDefault(err);
@@ -183,9 +190,9 @@ const FirewallRulesLanding: React.FC<CombinedProps> = props => {
           // If we are unable to parse this error as a FirewallRuleError,
           // consider it a general error.
           if (parsedError === null) {
-            setGeneralErrors(prevGeneralErrors => [
+            setGeneralErrors((prevGeneralErrors) => [
               ...(prevGeneralErrors ?? []),
-              thisError
+              thisError,
             ]);
           } else {
             const { idx, category } = parsedError;
@@ -208,7 +215,7 @@ const FirewallRulesLanding: React.FC<CombinedProps> = props => {
             dispatch({
               type: 'SET_ERROR',
               idx: originalIndex,
-              error: parsedError
+              error: parsedError,
             });
           }
         }
@@ -221,10 +228,10 @@ const FirewallRulesLanding: React.FC<CombinedProps> = props => {
   );
 
   const inboundRules = React.useMemo(() => editorStateToRules(inboundState), [
-    inboundState
+    inboundState,
   ]);
   const outboundRules = React.useMemo(() => editorStateToRules(outboundState), [
-    outboundState
+    outboundState,
   ]);
 
   // This is for the Rule Drawer. If there is a rule to modify,
@@ -291,8 +298,8 @@ const FirewallRulesLanding: React.FC<CombinedProps> = props => {
           triggerOpenRuleDrawerForEditing={(idx: number) =>
             openRuleDrawer('inbound', 'edit', idx)
           }
-          triggerDeleteFirewallRule={idx => handleDeleteRule('inbound', idx)}
-          triggerUndo={idx => handleUndo('inbound', idx)}
+          triggerDeleteFirewallRule={(idx) => handleDeleteRule('inbound', idx)}
+          triggerUndo={(idx) => handleUndo('inbound', idx)}
         />
       </div>
       <div className={classes.table}>
@@ -306,8 +313,8 @@ const FirewallRulesLanding: React.FC<CombinedProps> = props => {
           triggerOpenRuleDrawerForEditing={(idx: number) =>
             openRuleDrawer('outbound', 'edit', idx)
           }
-          triggerDeleteFirewallRule={idx => handleDeleteRule('outbound', idx)}
-          triggerUndo={idx => handleUndo('outbound', idx)}
+          triggerDeleteFirewallRule={(idx) => handleDeleteRule('outbound', idx)}
+          triggerUndo={(idx) => handleUndo('outbound', idx)}
         />
       </div>
       <FirewallRuleDrawer
@@ -361,7 +368,7 @@ interface DiscardChangesDialogProps {
 }
 
 export const DiscardChangesDialog: React.FC<DiscardChangesDialogProps> = React.memo(
-  props => {
+  (props) => {
     const { isOpen, handleClose, handleDiscard } = props;
 
     const actions = React.useCallback(

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/firewallRuleEditor.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/firewallRuleEditor.ts
@@ -96,7 +96,7 @@ const ruleEditorReducer = (
 
       draft[action.idx].push({
         ...lastRevision,
-        status: 'PENDING_DELETION'
+        status: 'PENDING_DELETION',
       });
       return;
 
@@ -121,7 +121,7 @@ const ruleEditorReducer = (
       draft[action.idx].push({
         ...lastRevision,
         ...action.modifiedRule,
-        status: 'MODIFIED'
+        status: 'MODIFIED',
       });
       return;
 
@@ -130,8 +130,10 @@ const ruleEditorReducer = (
       if (!ruleToClone) {
         return;
       }
-      const { addresses, ports, protocol } = ruleToClone;
-      draft.push([{ addresses, ports, protocol, status: 'NEW' }]);
+      const { addresses, ports, protocol, action: _action } = ruleToClone;
+      draft.push([
+        { action: _action, addresses, ports, protocol, status: 'NEW' },
+      ]);
       return;
 
     case 'SET_ERROR':
@@ -163,7 +165,7 @@ const ruleEditorReducer = (
 
     case 'DISCARD_CHANGES':
       const original: RuleEditorState = [];
-      draft.forEach(revisionList => {
+      draft.forEach((revisionList) => {
         const head = revisionList[0];
         if (head.status === 'NOT_MODIFIED') {
           original.push([head]);
@@ -179,12 +181,12 @@ const ruleEditorReducer = (
 export const initRuleEditorState = (
   rules: FirewallRuleType[]
 ): RuleEditorState =>
-  rules.map(thisRule => [{ ...thisRule, status: 'NOT_MODIFIED' }]) ?? [];
+  rules.map((thisRule) => [{ ...thisRule, status: 'NOT_MODIFIED' }]) ?? [];
 
 export const editorStateToRules = (
   state: RuleEditorState
 ): ExtendedFirewallRule[] =>
-  state.map(revisionList => revisionList[revisionList.length - 1]);
+  state.map((revisionList) => revisionList[revisionList.length - 1]);
 
 // Remove fields we use internally.
 export const stripExtendedFields = (
@@ -194,7 +196,7 @@ export const stripExtendedFields = (
 // The API will return an error if a `ports` attribute is present on a payload for an ICMP rule,
 // so we do a bit of trickery here and delete it if necessary.
 export const removeICMPPort = (rules: ExtendedFirewallRule[]) =>
-  rules.map(thisRule => {
+  rules.map((thisRule) => {
     if (thisRule.protocol === 'ICMP' && thisRule.ports === '') {
       delete thisRule.ports;
     }
@@ -202,7 +204,7 @@ export const removeICMPPort = (rules: ExtendedFirewallRule[]) =>
   });
 
 export const filterRulesPendingDeletion = (rules: ExtendedFirewallRule[]) =>
-  rules.filter(thisRule => thisRule.status !== 'PENDING_DELETION');
+  rules.filter((thisRule) => thisRule.status !== 'PENDING_DELETION');
 
 export const appendIndex = (rules: ExtendedFirewallRule[]) =>
   rules.map((thisRule, index) => ({ ...thisRule, index }));
@@ -216,7 +218,7 @@ export const prepareRules = compose(
 
 export const hasModified = (editorState: RuleEditorState) => {
   const rules = editorStateToRules(editorState);
-  return rules.find(thisRule => thisRule.status !== 'NOT_MODIFIED');
+  return rules.find((thisRule) => thisRule.status !== 'NOT_MODIFIED');
 };
 
 export default produce(ruleEditorReducer);

--- a/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.test.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.test.tsx
@@ -9,7 +9,7 @@ const props: CombinedProps = {
   onClose: jest.fn(),
   onSubmit: jest.fn().mockResolvedValue({}),
   title: 'Add a Firewall',
-  open: true
+  open: true,
 };
 
 describe('Add Firewall Drawer', () => {
@@ -35,15 +35,17 @@ describe('Add Firewall Drawer', () => {
     await waitFor(() =>
       expect(props.onSubmit).toHaveBeenCalledWith({
         devices: {
-          linodes: []
+          linodes: [],
         },
         label: undefined,
         rules: {
+          inbound_policy: 'DROP',
+          outbound_policy: 'ACCEPT',
           inbound: [
             ...predefinedFirewalls.ssh.inbound,
-            ...predefinedFirewalls.dns.inbound
-          ]
-        }
+            ...predefinedFirewalls.dns.inbound,
+          ],
+        },
       })
     );
   });

--- a/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.tsx
@@ -2,7 +2,7 @@ import { Formik, FormikBag } from 'formik';
 import {
   CreateFirewallPayload,
   CreateFirewallSchema,
-  Firewall
+  Firewall,
 } from '@linode/api-v4/lib/firewalls';
 import { Capabilities } from '@linode/api-v4/lib/regions/types';
 import * as React from 'react';
@@ -19,7 +19,7 @@ import { useRegionsQuery } from 'src/queries/regions';
 import arrayToList from 'src/utilities/arrayToCommaSeparatedList';
 import {
   handleFieldErrors,
-  handleGeneralErrors
+  handleGeneralErrors,
 } from 'src/utilities/formikErrorUtils';
 import { predefinedFirewalls } from '../shared';
 
@@ -35,17 +35,19 @@ export type CombinedProps = Props;
 const initialValues: CreateFirewallPayload = {
   label: '',
   rules: {
+    inbound_policy: 'DROP',
+    outbound_policy: 'ACCEPT',
     inbound: [
       ...predefinedFirewalls.ssh.inbound,
-      ...predefinedFirewalls.dns.inbound
-    ]
+      ...predefinedFirewalls.dns.inbound,
+    ],
   },
   devices: {
-    linodes: []
-  }
+    linodes: [],
+  },
 };
 
-const AddFirewallDrawer: React.FC<CombinedProps> = props => {
+const AddFirewallDrawer: React.FC<CombinedProps> = (props) => {
   const { onClose, onSubmit, ...restOfDrawerProps } = props;
 
   /**
@@ -57,10 +59,10 @@ const AddFirewallDrawer: React.FC<CombinedProps> = props => {
   const regions = useRegionsQuery().data ?? [];
 
   const regionsWithFirewalls = regions
-    .filter(thisRegion =>
+    .filter((thisRegion) =>
       thisRegion.capabilities.includes('Cloud Firewall' as Capabilities)
     )
-    .map(thisRegion => thisRegion.id);
+    .map((thisRegion) => thisRegion.id);
 
   const submitForm = (
     values: CreateFirewallPayload,
@@ -94,7 +96,7 @@ const AddFirewallDrawer: React.FC<CombinedProps> = props => {
         setSubmitting(false);
         onClose();
       })
-      .catch(err => {
+      .catch((err) => {
         const mapErrorToStatus = (generalError: string) =>
           setStatus({ generalError });
 
@@ -121,7 +123,7 @@ const AddFirewallDrawer: React.FC<CombinedProps> = props => {
           handleBlur,
           handleSubmit,
           isSubmitting,
-          setFieldValue
+          setFieldValue,
         }) => {
           const generalError =
             status?.generalError ||
@@ -160,7 +162,7 @@ const AddFirewallDrawer: React.FC<CombinedProps> = props => {
                 errorText={errors.label}
                 onBlur={handleBlur}
                 inputProps={{
-                  autoFocus: true
+                  autoFocus: true,
                 }}
               />
               <LinodeMultiSelect
@@ -170,7 +172,7 @@ const AddFirewallDrawer: React.FC<CombinedProps> = props => {
                 helperText={`Assign one or more Linodes to this firewall. You can add
                  Linodes later if you want to customize your rules first. Only Linodes in
                  regions that support Firewalls (${arrayToList(
-                   regionsWithFirewalls.map(thisId => dcDisplayNames[thisId])
+                   regionsWithFirewalls.map((thisId) => dcDisplayNames[thisId])
                  )}) will be displayed as options.`}
                 errorText={errors['devices.linodes']}
                 handleChange={(selected: number[]) =>

--- a/packages/manager/src/features/Firewalls/shared.test.ts
+++ b/packages/manager/src/features/Firewalls/shared.test.ts
@@ -3,24 +3,25 @@ import {
   allIPv4,
   allIPv6,
   generateAddressesLabel,
-  predefinedFirewallFromRule
+  predefinedFirewallFromRule,
 } from './shared';
 
 const addresses = {
   ipv4: [allIPv4],
-  ipv6: [allIPv6]
+  ipv6: [allIPv6],
 };
 
 const limitedAddresses = {
   ipv4: ['1.1.1.1'],
-  ipv6: ['::']
+  ipv6: ['::'],
 };
 
 describe('predefinedFirewallFromRule', () => {
   const rule: FirewallRuleType = {
     ports: '',
     protocol: 'TCP',
-    addresses
+    addresses,
+    action: 'ACCEPT',
   };
 
   it('handles SSH', () => {
@@ -50,7 +51,8 @@ describe('predefinedFirewallFromRule', () => {
         // Test another port
         ports: '22-24',
         protocol: 'TCP',
-        addresses
+        addresses,
+        action: 'ACCEPT',
       })
     ).toBeUndefined();
 
@@ -59,7 +61,8 @@ describe('predefinedFirewallFromRule', () => {
         ports: '22',
         // Test another protocol
         protocol: 'UDP',
-        addresses
+        addresses,
+        action: 'ACCEPT',
       })
     ).toBeUndefined();
 
@@ -68,7 +71,8 @@ describe('predefinedFirewallFromRule', () => {
         ports: '22',
         protocol: 'TCP',
         // Test other addresses
-        addresses: limitedAddresses
+        addresses: limitedAddresses,
+        action: 'ACCEPT',
       })
     ).toBeUndefined();
   });
@@ -85,7 +89,7 @@ describe('generateAddressLabel', () => {
   it("doesn't include other IPv4 addresses if ALL are also specified", () => {
     const result = generateAddressesLabel({
       ...addresses,
-      ipv4: [allIPv4, '1.1.1.1']
+      ipv4: [allIPv4, '1.1.1.1'],
     });
     expect(result.includes('All IPv4')).toBe(true);
     expect(result.includes('1.1.1.1')).toBe(false);
@@ -98,7 +102,7 @@ describe('generateAddressLabel', () => {
   it("doesn't include other IPv6 addresses if ALL are also specified", () => {
     const result = generateAddressesLabel({
       ...addresses,
-      ipv6: [allIPv6, '::1']
+      ipv6: [allIPv6, '::1'],
     });
     expect(result.includes('All IPv6')).toBe(true);
     expect(result.includes('::1')).toBe(false);
@@ -119,7 +123,7 @@ describe('generateAddressLabel', () => {
   it('truncates large lists', () => {
     expect(
       generateAddressesLabel({
-        ipv4: ['1.1.1.1', '2.2.2.2', '3.3.3.3', '4.4.4.4', '5.5.5.5']
+        ipv4: ['1.1.1.1', '2.2.2.2', '3.3.3.3', '4.4.4.4', '5.5.5.5'],
       })
     ).toBe('1.1.1.1, 2.2.2.2, 3.3.3.3, plus 2 more');
   });
@@ -128,7 +132,7 @@ describe('generateAddressLabel', () => {
     expect(
       generateAddressesLabel({
         ipv4: ['1.1.1.1', '2.2.2.2', '3.3.3.3', '4.4.4.4', '5.5.5.5'],
-        ipv6: ['::/0']
+        ipv6: ['::/0'],
       })
     ).toBe('All IPv6, 1.1.1.1, 2.2.2.2, plus 3 more');
   });

--- a/packages/manager/src/features/Firewalls/shared.ts
+++ b/packages/manager/src/features/Firewalls/shared.ts
@@ -1,6 +1,6 @@
 import {
   FirewallRuleProtocol,
-  FirewallRuleType
+  FirewallRuleType,
 } from '@linode/api-v4/lib/firewalls/types';
 import { Item } from 'src/components/EnhancedSelect/Select';
 import { truncateAndJoinList } from 'src/utilities/stringUtils';
@@ -11,61 +11,61 @@ export type FirewallPreset = 'ssh' | 'http' | 'https' | 'mysql' | 'dns';
 export const firewallOptionItemsLong = [
   {
     label: 'SSH (TCP 22 - All IPv4, All IPv6)',
-    value: 'ssh'
+    value: 'ssh',
   },
   {
     label: 'HTTP (TCP 80 - All IPv4, All IPv6)',
-    value: 'http'
+    value: 'http',
   },
   {
     label: 'HTTPS (TCP 443 - All IPv4, All IPv6)',
-    value: 'https'
+    value: 'https',
   },
   {
     label: 'MySQL (TCP 3306 - All IPv4, All IPv6)',
-    value: 'mysql'
+    value: 'mysql',
   },
   {
     label: 'DNS (TCP 53 - All IPv4, All IPv6)',
-    value: 'dns'
-  }
+    value: 'dns',
+  },
 ];
 
 // Predefined Firewall options for Select components (short-form).
 export const firewallOptionItemsShort = [
   {
     label: 'SSH',
-    value: 'ssh'
+    value: 'ssh',
   },
   {
     label: 'HTTP',
-    value: 'http'
+    value: 'http',
   },
   {
     label: 'HTTPS',
-    value: 'https'
+    value: 'https',
   },
   {
     label: 'MySQL',
-    value: 'mysql'
+    value: 'mysql',
   },
   {
     label: 'DNS',
-    value: 'dns'
-  }
+    value: 'dns',
+  },
 ];
 
 export const protocolOptions: Item<FirewallRuleProtocol>[] = [
   { label: 'TCP', value: 'TCP' },
   { label: 'ICMP', value: 'ICMP' },
-  { label: 'UDP', value: 'UDP' }
+  { label: 'UDP', value: 'UDP' },
 ];
 
 export const addressOptions = [
   { label: 'All IPv4, All IPv6', value: 'all' },
   { label: 'All IPv4', value: 'allIPv4' },
   { label: 'All IPv6', value: 'allIPv6' },
-  { label: 'IP / Netmask', value: 'ip/netmask' }
+  { label: 'IP / Netmask', value: 'ip/netmask' },
 ];
 
 export const portPresets: Record<FirewallPreset, string> = {
@@ -73,7 +73,7 @@ export const portPresets: Record<FirewallPreset, string> = {
   http: '80',
   https: '443',
   mysql: '3306',
-  dns: '53'
+  dns: '53',
 };
 
 export const allIPv4 = '0.0.0.0/0';
@@ -81,7 +81,7 @@ export const allIPv6 = '::/0';
 
 export const allIPs = {
   ipv4: [allIPv4],
-  ipv6: [allIPv6]
+  ipv6: [allIPv6],
 };
 
 export interface PredefinedFirewall {
@@ -96,9 +96,10 @@ export const predefinedFirewalls: Record<FirewallPreset, PredefinedFirewall> = {
       {
         ports: portPresets.ssh,
         protocol: 'TCP',
-        addresses: allIPs
-      }
-    ]
+        addresses: allIPs,
+        action: 'ACCEPT',
+      },
+    ],
   },
   http: {
     label: 'HTTP',
@@ -106,9 +107,10 @@ export const predefinedFirewalls: Record<FirewallPreset, PredefinedFirewall> = {
       {
         ports: portPresets.http,
         protocol: 'TCP',
-        addresses: allIPs
-      }
-    ]
+        addresses: allIPs,
+        action: 'ACCEPT',
+      },
+    ],
   },
   https: {
     label: 'HTTPS',
@@ -116,9 +118,10 @@ export const predefinedFirewalls: Record<FirewallPreset, PredefinedFirewall> = {
       {
         ports: portPresets.https,
         protocol: 'TCP',
-        addresses: allIPs
-      }
-    ]
+        addresses: allIPs,
+        action: 'ACCEPT',
+      },
+    ],
   },
   mysql: {
     label: 'MySQL',
@@ -126,9 +129,10 @@ export const predefinedFirewalls: Record<FirewallPreset, PredefinedFirewall> = {
       {
         ports: portPresets.mysql,
         protocol: 'TCP',
-        addresses: allIPs
-      }
-    ]
+        addresses: allIPs,
+        action: 'ACCEPT',
+      },
+    ],
   },
   dns: {
     label: 'DNS',
@@ -136,10 +140,11 @@ export const predefinedFirewalls: Record<FirewallPreset, PredefinedFirewall> = {
       {
         ports: portPresets.dns,
         protocol: 'TCP',
-        addresses: allIPs
-      }
-    ]
-  }
+        addresses: allIPs,
+        action: 'ACCEPT',
+      },
+    ],
+  },
 };
 
 export const predefinedFirewallFromRule = (
@@ -205,13 +210,13 @@ export const generateAddressesLabel = (
 
   // Now we can look at the rest of the rules:
   if (!allowedAllIPv4) {
-    addresses?.ipv4?.forEach(thisIP => {
+    addresses?.ipv4?.forEach((thisIP) => {
       strBuilder.push(thisIP);
     });
   }
 
   if (!allowedAllIPv6) {
-    addresses?.ipv6?.forEach(thisIP => {
+    addresses?.ipv6?.forEach((thisIP) => {
       strBuilder.push(thisIP);
     });
   }


### PR DESCRIPTION
## Description

Includes the updated types and factories for the updated Firewall rule policy switches. These types will break things against any environment except devenv, but you can check them against the spec docs. Reach out if you're feeling suicidal and would like a link to the PR to pull if you want to actually run the in-review backend code.

All UI changes to work with these new types will come in a future PR.

Most of the diff is linter/prettier. api-v4/src/firewalls has most of the actual changes. Most of our rule presets have also been adjusted, we can adjust or remove the defaults when the UI is complete.