### PR TITLE
Fix: Account balance display

### DIFF
--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
@@ -1,5 +1,4 @@
 import { ActivePromotion } from '@linode/api-v4/lib/account/types';
-import { DateTime } from 'luxon';
 import * as React from 'react';
 import { useHistory, useRouteMatch } from 'react-router-dom';
 import CreditCard from 'src/assets/icons/credit-card.svg';
@@ -22,44 +21,44 @@ const useStyles = makeStyles((theme: Theme) => ({
     padding: theme.spacing(3) + 1,
     border: `solid 1px ${theme.cmrBorderColors.borderBillingSummary}`,
     borderRadius: 8,
-    backgroundColor: theme.cmrBGColors.bgBillingSummary
+    backgroundColor: theme.cmrBGColors.bgBillingSummary,
   },
   header: {
-    marginBottom: theme.spacing(2) - 1
+    marginBottom: theme.spacing(2) - 1,
   },
   unpaidBalance: {
     marginBottom: theme.spacing(1) + 2,
     fontSize: 32,
-    color: '#cf1e1e'
+    color: '#cf1e1e',
   },
   gridItem: {
     padding: `0 0 ${theme.spacing(3) + 1}px`,
     [theme.breakpoints.up('md')]: {
-      padding: `0 ${theme.spacing(4) - 2}px`
+      padding: `0 ${theme.spacing(4) - 2}px`,
     },
     '&:first-of-type': {
       [theme.breakpoints.up('md')]: {
         paddingLeft: 0,
         display: 'flex',
         flexDirection: 'column',
-        justifyContent: 'space-between'
-      }
+        justifyContent: 'space-between',
+      },
     },
     '&:nth-of-type(2)': {
       [theme.breakpoints.up('md')]: {
-        borderLeft: `1px solid ${theme.cmrBorderColors.borderBillingSummary}`
-      }
+        borderLeft: `1px solid ${theme.cmrBorderColors.borderBillingSummary}`,
+      },
     },
     '&:last-of-type': {
       paddingBottom: 0,
       [theme.breakpoints.up('md')]: {
-        paddingRight: 0
-      }
-    }
+        paddingRight: 0,
+      },
+    },
   },
   balanceOuter: {
     paddingTop: theme.spacing(1) - 3,
-    borderTop: `1px dashed ${theme.cmrBorderColors.borderBalance}`
+    borderTop: `1px dashed ${theme.cmrBorderColors.borderBalance}`,
   },
   label: {
     margin: `${theme.spacing(1) - 3}px 0`,
@@ -67,66 +66,66 @@ const useStyles = makeStyles((theme: Theme) => ({
     color: theme.color.headline,
     fontSize: '1rem',
     letterSpacing: 0.07,
-    lineHeight: 1.25
+    lineHeight: 1.25,
   },
   field: {
     margin: `${theme.spacing(1) - 3}px 0`,
     color: `${theme.color.headline}`,
     fontSize: '1rem',
-    lineHeight: 1.13
+    lineHeight: 1.13,
   },
   caption: {
     marginTop: theme.spacing(1) + 2,
-    textAlign: 'right'
+    textAlign: 'right',
   },
   text: {
     lineHeight: 1.43,
     letterSpacing: 0.1,
-    color: theme.color.billingText
+    color: theme.color.billingText,
   },
   iconButtonOuter: {
     display: 'flex',
     justifyContent: 'space-between',
     '& button, & a': {
-      justifyContent: 'flex-start'
+      justifyContent: 'flex-start',
     },
     [theme.breakpoints.down('md')]: {
-      justifyContent: 'flex-start'
+      justifyContent: 'flex-start',
     },
     [theme.breakpoints.only('xs')]: {
-      flexDirection: 'column'
+      flexDirection: 'column',
     },
     [theme.breakpoints.only('md')]: {
-      flexDirection: 'column'
-    }
+      flexDirection: 'column',
+    },
   },
   invoiceButton: {
     [theme.breakpoints.only('sm')]: {
-      paddingLeft: 32
+      paddingLeft: 32,
     },
     '& button': {
-      paddingLeft: '0'
-    }
+      paddingLeft: '0',
+    },
   },
   iconButton: {
     paddingLeft: 0,
     [theme.breakpoints.up('md')]: {
-      paddingBottom: 0
+      paddingBottom: 0,
     },
     '&:hover': {
       textDecoration: 'none',
       '& svg': {
-        color: `${theme.palette.primary.main} !important`
-      }
+        color: `${theme.palette.primary.main} !important`,
+      },
     },
     '&:focus': {
-      textDecoration: 'none'
-    }
+      textDecoration: 'none',
+    },
   },
   infoIcon: {
     padding: `0px ${theme.spacing(1) + 2}px`,
-    top: -2
-  }
+    top: -2,
+  },
 }));
 
 interface Props {
@@ -136,7 +135,7 @@ interface Props {
   mostRecentInvoiceId?: number;
 }
 
-export const BillingSummary: React.FC<Props> = props => {
+export const BillingSummary: React.FC<Props> = (props) => {
   const { promotion, balanceUninvoiced, balance, mostRecentInvoiceId } = props;
 
   // On-the-fly route matching so this component can open the drawer itself.
@@ -175,14 +174,14 @@ export const BillingSummary: React.FC<Props> = props => {
   const nextCycleEstimatedBalance = getNextCycleEstimatedBalance({
     balance,
     balanceUninvoiced,
-    promoThisMonthCreditRemaining
+    promoThisMonthCreditRemaining,
   });
 
   const shouldDisplayPromotion =
     Boolean(promotion) && promoThisMonthCreditRemaining !== undefined;
 
   const determinePaymentDisplay = (pastDueAmount: number) => {
-    if (pastDueAmount > 0 && dayOfMonth >= 3) {
+    if (pastDueAmount > 0) {
       return (
         <div>
           <Typography className={classes.header} variant="h2">
@@ -351,7 +350,5 @@ export const BillingSummary: React.FC<Props> = props => {
     </>
   );
 };
-
-const dayOfMonth = DateTime.local().day;
 
 export default React.memo(BillingSummary);

--- a/packages/manager/src/features/NotificationCenter/NotificationData/RenderNotification.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/RenderNotification.tsx
@@ -16,41 +16,41 @@ import { checkIfMaintenanceNotification } from './notificationUtils';
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
     paddingTop: 2,
-    paddingBottom: 2
+    paddingBottom: 2,
   },
   divider: {
-    marginTop: theme.spacing()
+    marginTop: theme.spacing(),
   },
   criticalIcon: {
-    fill: theme.color.red
+    fill: theme.color.red,
   },
   majorIcon: {
-    fill: theme.palette.status.warningDark
+    fill: theme.palette.status.warningDark,
   },
   itemsWithoutIcon: {
-    marginLeft: '1.25rem'
+    marginLeft: '1.25rem',
   },
   severeAlert: {
-    color: theme.color.red
+    color: theme.color.red,
   },
   redLink: {
     '&:hover': {
-      textDecoration: `${theme.color.red} underline`
-    }
+      textDecoration: `${theme.color.red} underline`,
+    },
   },
   greyLink: {
     '&:hover': {
-      textDecoration: `${theme.palette.text.primary} underline`
-    }
+      textDecoration: `${theme.palette.text.primary} underline`,
+    },
   },
   notificationIcon: {
     lineHeight: '1rem',
     display: 'flex',
     '& svg': {
       height: '1.25rem',
-      width: '1.25rem'
-    }
-  }
+      width: '1.25rem',
+    },
+  },
 }));
 
 interface Props {
@@ -60,13 +60,15 @@ interface Props {
 
 export type CombinedProps = Props;
 
-export const RenderNotification: React.FC<Props> = props => {
+export const RenderNotification: React.FC<Props> = (props) => {
   const { notification, onClose } = props;
   const classes = useStyles();
 
   const isMaintenanceNotification = checkIfMaintenanceNotification(
     notification.type
   );
+
+  const severity = notification.severity;
 
   const linkTarget =
     // payment_due notifications do not have an entity property, so in that case, link directly to /account/billing
@@ -77,10 +79,8 @@ export const RenderNotification: React.FC<Props> = props => {
   const message = (
     <Typography
       className={classNames({
-        [classes.severeAlert]:
-          notification.severity === 'critical' &&
-          notification.type === 'payment_due',
-        [classes.itemsWithoutIcon]: notification.severity === 'minor'
+        [classes.severeAlert]: severity === 'critical',
+        [classes.itemsWithoutIcon]: notification.severity === 'minor',
       })}
       dangerouslySetInnerHTML={{ __html: sanitizeHTML(notification.message) }}
     />
@@ -96,10 +96,10 @@ export const RenderNotification: React.FC<Props> = props => {
       >
         <Grid item>
           <div className={classes.notificationIcon}>
-            {notification.severity === 'critical' ? (
+            {severity === 'critical' ? (
               <ErrorIcon className={classes.criticalIcon} />
             ) : null}
-            {notification.severity === 'major' ? (
+            {severity === 'major' ? (
               <WarningIcon className={classes.majorIcon} />
             ) : null}
           </div>
@@ -116,8 +116,8 @@ export const RenderNotification: React.FC<Props> = props => {
             <Link
               to={linkTarget}
               className={classNames({
-                [classes.redLink]: notification.type === 'payment_due',
-                [classes.greyLink]: notification.type !== 'payment_due'
+                [classes.redLink]: severity === 'critical',
+                [classes.greyLink]: severity !== 'critical',
               })}
               onClick={onClose}
             >
@@ -178,7 +178,7 @@ const linkifiedOutageMessage = (notification: Notification) => {
         'Could not find the DC name for the outage notification',
         {
           rawRegion: notification.entity.id,
-          convertedRegion
+          convertedRegion,
         }
       );
     }

--- a/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
@@ -15,7 +15,7 @@ export const useFormattedNotifications = () => {
 
   const dayOfMonth = DateTime.local().day;
 
-  // Filter out the late payment notification from the API (since we are using a custom one), and any bounced email notifications and abuse tickets because users are alerted to those by global notification banners already.
+  // Filter out any bounced email notifications and abuse tickets because users are alerted to those by global notification banners already.
   const combinedNotifications = [...notifications].filter(
     (notification) =>
       !['billing_email_bounce', 'user_email_bounce', 'ticket_abuse'].includes(

--- a/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
@@ -2,7 +2,6 @@ import { Notification, NotificationSeverity } from '@linode/api-v4/lib/account';
 import { DateTime } from 'luxon';
 import { path } from 'ramda';
 import * as React from 'react';
-import useAccount from 'src/hooks/useAccount';
 import useNotifications from 'src/hooks/useNotifications';
 import { notificationContext } from '../NotificationContext';
 import { NotificationItem } from '../NotificationSection';
@@ -13,49 +12,42 @@ export const useFormattedNotifications = () => {
   const context = React.useContext(notificationContext);
 
   const notifications = useNotifications();
-  const { account } = useAccount();
 
-  const balance = account?.data?.balance ?? 0;
   const dayOfMonth = DateTime.local().day;
 
   // Filter out the late payment notification from the API (since we are using a custom one), and any bounced email notifications and abuse tickets because users are alerted to those by global notification banners already.
   const combinedNotifications = [...notifications].filter(
-    notification =>
-      ![
-        'payment_due',
-        'billing_email_bounce',
-        'user_email_bounce',
-        'ticket_abuse'
-      ].includes(notification.type)
+    (notification) =>
+      !['billing_email_bounce', 'user_email_bounce', 'ticket_abuse'].includes(
+        notification.type
+      )
   );
 
-  if (balance > 0 && dayOfMonth >= 3) {
-    combinedNotifications.unshift({
-      entity: null,
-      label: '',
-      message: `You have a past due balance of $${balance}. Please make a payment immediately to avoid service disruption.`,
-      type: 'payment_due',
-      severity: 'critical',
-      when: null,
-      until: null,
-      body: null
-    });
-  }
-
-  return combinedNotifications.map((notification, idx) =>
-    formatNotificationForDisplay(
-      interceptNotification(notification),
-      idx,
-      context.closeDrawer
-    )
-  );
+  return combinedNotifications
+    .filter((thisNotification) => {
+      /**
+       * Don't show balance overdue notifications at the beginning of the month
+       * to avoid causing anxiety if an automatic payment takes time to process.
+       * This is a temporary hack; customers can have their payment grace period extended
+       * to more than 3 days, and using this method also means that if you're more than
+       * a month overdue the notification will disappear for three days.
+       */
+      return !(thisNotification.type === 'payment_due' && dayOfMonth <= 3);
+    })
+    .map((notification, idx) =>
+      formatNotificationForDisplay(
+        interceptNotification(notification),
+        idx,
+        context.closeDrawer
+      )
+    );
 };
 
 const interceptNotification = (notification: Notification): Notification => {
   if (notification.type === 'ticket_abuse') {
     return {
       ...notification,
-      message: notification.message.replace('!', '.')
+      message: notification.message.replace('!', '.'),
     };
   }
 
@@ -80,7 +72,7 @@ const interceptNotification = (notification: Notification): Notification => {
               linodeAttachedToNotification
             )
           : notification.body
-        : notification.message
+        : notification.message,
     };
   }
 
@@ -94,13 +86,13 @@ const formatNotificationForDisplay = (
 ): NotificationItem => ({
   id: `notification-${idx}`,
   body: <RenderNotification notification={notification} onClose={onClose} />,
-  countInTotal: true
+  countInTotal: true,
 });
 
 // For communicative purposes in the UI, in some cases we want to adjust the severity of certain notifications compared to what the API returns. If it is a maintenance notification of any sort, we display them as major instead of critical. Otherwise, we return the existing severity.
 export const adjustSeverity = ({
   severity,
-  type
+  type,
 }: Notification): NotificationSeverity => {
   if (checkIfMaintenanceNotification(type)) {
     return 'major';

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -41,7 +41,7 @@ import {
   tagFactory,
   nodeBalancerConfigFactory,
   nodeBalancerConfigNodeFactory,
-  VLANFactory
+  VLANFactory,
 } from 'src/factories';
 
 import cachedRegions from 'src/cachedData/regions.json';
@@ -52,27 +52,27 @@ export const makeResourcePage = (
   e: any[],
   override: { page: number; pages: number; results?: number } = {
     page: 1,
-    pages: 1
+    pages: 1,
   }
 ) => ({
   page: override.page ?? 1,
   pages: override.pages ?? 1,
   results: override.results ?? e.length,
-  data: e
+  data: e,
 });
 
 const entityTransfers = [
   rest.get('*/account/entity-transfers', (req, res, ctx) => {
     const transfers1 = entityTransferFactory.buildList(10);
     const transfers2 = entityTransferFactory.buildList(10, {
-      token: 'TEST123'
+      token: 'TEST123',
     });
     const transfers3 = entityTransferFactory.buildList(10, {
-      token: '987TEST'
+      token: '987TEST',
     });
     const transfer4 = entityTransferFactory.build({
       is_sender: true,
-      status: 'pending'
+      status: 'pending',
     });
 
     const combinedTransfers = transfers1.concat(
@@ -89,7 +89,7 @@ const entityTransfers = [
   rest.post('*/account/entity-transfers', (req, res, ctx) => {
     const payload = req.body as any;
     const newTransfer = entityTransferFactory.build({
-      entities: payload.entities
+      entities: payload.entities,
     });
     return res(ctx.json(newTransfer));
   }),
@@ -101,7 +101,7 @@ const entityTransfers = [
   ),
   rest.delete('*/account/entity-transfers/:transferId', (req, res, ctx) => {
     return res(ctx.json({}));
-  })
+  }),
 ];
 
 export const handlers = [
@@ -131,14 +131,14 @@ export const handlers = [
   rest.get('*/linode/instances', async (req, res, ctx) => {
     const onlineLinodes = linodeFactory.buildList(17, {
       backups: { enabled: false },
-      ipv4: ['000.000.000.000']
+      ipv4: ['000.000.000.000'],
     });
     const offlineLinodes = linodeFactory.buildList(1, { status: 'offline' });
     const busyLinodes = linodeFactory.buildList(5, { status: 'migrating' });
     const eventLinode = linodeFactory.build({
       id: 999,
       status: 'rebooting',
-      label: 'eventful'
+      label: 'eventful',
     });
     const multipleIPLinode = linodeFactory.build({
       label: 'multiple-ips',
@@ -148,9 +148,9 @@ export const handlers = [
         '192.168.0.2',
         '192.168.0.3',
         '192.168.0.4',
-        '192.168.0.5'
+        '192.168.0.5',
       ],
-      tags: ['test1', 'test2', 'test3']
+      tags: ['test1', 'test2', 'test3'],
     });
     const linodes = [
       ...onlineLinodes,
@@ -159,16 +159,16 @@ export const handlers = [
       linodeFactory.build({
         label: 'shadow-plan',
         type: 'g5-standard-20-s1',
-        backups: { enabled: false }
+        backups: { enabled: false },
       }),
       linodeFactory.build({
         label: 'shadow-plan-with-tags',
         type: 'g5-standard-20-s1',
         backups: { enabled: false },
-        tags: ['test1', 'test2', 'test3']
+        tags: ['test1', 'test2', 'test3'],
       }),
       eventLinode,
-      multipleIPLinode
+      multipleIPLinode,
     ];
     return res(ctx.json(makeResourcePage(linodes)));
   }),
@@ -201,7 +201,7 @@ export const handlers = [
       label: payload?.label ?? 'new-linode',
       type: payload?.type ?? 'g6-standard-1',
       image: payload?.image ?? 'linode/debian-10',
-      region: payload?.region ?? 'us-east'
+      region: payload?.region ?? 'us-east',
     });
     return res(ctx.json(linode));
   }),
@@ -242,14 +242,14 @@ export const handlers = [
   }),
   rest.put('*/firewalls/:firewallId', (req, res, ctx) => {
     const firewall = firewallFactory.build({
-      status: req.body?.['status'] ?? 'disabled'
+      status: req.body?.['status'] ?? 'disabled',
     });
     return res(ctx.json(firewall));
   }),
   rest.post('*/firewalls', (req, res, ctx) => {
     const payload = req.body as any;
     const newFirewall = firewallFactory.build({
-      label: payload.label ?? 'mock-firewall'
+      label: payload.label ?? 'mock-firewall',
     });
     return res(ctx.json(newFirewall));
   }),
@@ -259,13 +259,13 @@ export const handlers = [
   }),
   rest.get('*/nodebalancers/:nodeBalancerID', (req, res, ctx) => {
     const nodeBalancer = nodeBalancerFactory.build({
-      id: req.params.nodeBalancerID
+      id: req.params.nodeBalancerID,
     });
     return res(ctx.json(nodeBalancer));
   }),
   rest.get('*/nodebalancers/:nodeBalancerID/configs', (req, res, ctx) => {
     const configs = nodeBalancerConfigFactory.buildList(2, {
-      nodebalancer_id: req.params.nodeBalancerID
+      nodebalancer_id: req.params.nodeBalancerID,
     });
     return res(ctx.json(makeResourcePage(configs)));
   }),
@@ -273,7 +273,7 @@ export const handlers = [
     '*/nodebalancers/:nodeBalancerID/configs/:configID/nodes',
     (req, res, ctx) => {
       const configs = nodeBalancerConfigNodeFactory.buildList(2, {
-        nodebalancer_id: req.params.nodeBalancerID
+        nodebalancer_id: req.params.nodeBalancerID,
       });
       return res(ctx.json(makeResourcePage(configs)));
     }
@@ -322,7 +322,7 @@ export const handlers = [
   rest.get('*/account', (req, res, ctx) => {
     const account = accountFactory.build({
       balance: 50,
-      active_since: '2019-11-05'
+      active_since: '2019-11-05',
     });
     return res(ctx.json(account));
   }),
@@ -343,7 +343,7 @@ export const handlers = [
       percent_complete: 15,
       entity: { type: 'linode', id: 999, label: 'linode-1' },
       message:
-        'Rebooting this thing and showing an extremely long event message for no discernible reason other than the fairly obvious reason that we want to do some testing of whether or not these messages wrap.'
+        'Rebooting this thing and showing an extremely long event message for no discernible reason other than the fairly obvious reason that we want to do some testing of whether or not these messages wrap.',
     });
     const diskResize = eventFactory.build({
       action: 'disk_resize',
@@ -351,13 +351,13 @@ export const handlers = [
       secondary_entity: {
         type: 'disk',
         id: 1,
-        label: 'my-disk'
-      }
+        label: 'my-disk',
+      },
     });
     const oldEvents = eventFactory.buildList(20, {
       action: 'account_update',
       seen: true,
-      percent_complete: 100
+      percent_complete: 100,
     });
     return res.once(
       ctx.json(makeResourcePage([...events, diskResize, ...oldEvents]))
@@ -441,7 +441,7 @@ export const handlers = [
       label: "We've updated our policies.",
       severity: 'minor',
       until: null,
-      body: null
+      body: null,
     };
 
     const outageNotification = {
@@ -450,7 +450,7 @@ export const handlers = [
         type: 'region',
         label: null,
         id: 'us-east',
-        url: '/regions/us-east'
+        url: '/regions/us-east',
       },
       when: null,
       message:
@@ -458,7 +458,7 @@ export const handlers = [
       label: 'There is an issue affecting service in this facility',
       severity: 'major',
       until: null,
-      body: null
+      body: null,
     };
 
     const emailBounce = notificationFactory.build({
@@ -469,20 +469,26 @@ export const handlers = [
       label: 'We are unable to send emails to your billing email address!',
       severity: 'major',
       until: null,
-      body: null
+      body: null,
     });
     const abuseTicket = abuseTicketNotificationFactory.build();
 
     const migrationTicket = notificationFactory.build({
       type: 'migration_pending',
       entity: { id: 0, type: 'linode', label: 'linode-0' },
-      severity: 'critical'
+      severity: 'critical',
     });
 
     const minorSeverityTicket = notificationFactory.build({
       type: 'notice',
       message: 'Testing for minor notification',
-      severity: 'minor'
+      severity: 'minor',
+    });
+
+    const balanceNotification = notificationFactory.build({
+      type: 'payment_due',
+      message: 'You have an overdue balance!',
+      severity: 'major',
     });
 
     return res(
@@ -495,7 +501,8 @@ export const handlers = [
           minorSeverityTicket,
           abuseTicket,
           emailBounce,
-          migrationTicket
+          migrationTicket,
+          balanceNotification,
         ])
       )
     );
@@ -514,7 +521,7 @@ export const handlers = [
     const databases = [online, initializing, error, unknown];
     return res(ctx.json(makeResourcePage(databases)));
   }),
-  ...entityTransfers
+  ...entityTransfers,
 ];
 
 // Generator functions for dynamic handlers, in use by mock data dev tools.
@@ -522,24 +529,24 @@ export const mockDataHandlers: Record<
   keyof MockData,
   (count: number) => RequestHandler
 > = {
-  linode: count =>
+  linode: (count) =>
     rest.get('*/linode/instances', async (req, res, ctx) => {
       const linodes = linodeFactory.buildList(count);
       return res(ctx.json(makeResourcePage(linodes)));
     }),
-  nodeBalancer: count =>
+  nodeBalancer: (count) =>
     rest.get('*/nodebalancers', (req, res, ctx) => {
       const nodeBalancers = nodeBalancerFactory.buildList(count);
       return res(ctx.json(makeResourcePage(nodeBalancers)));
     }),
-  domain: count =>
+  domain: (count) =>
     rest.get('*/domains', (req, res, ctx) => {
       const domains = domainFactory.buildList(count);
       return res(ctx.json(makeResourcePage(domains)));
     }),
-  volume: count =>
+  volume: (count) =>
     rest.get('*/volumes', (req, res, ctx) => {
       const volumes = volumeFactory.buildList(count);
       return res(ctx.json(makeResourcePage(volumes)));
-    })
+    }),
 };


### PR DESCRIPTION
Recent changes to how we display past due balances lead to confusion
for some customers. Specifically, a balance due was being hidden
during the first 3 calendar days of the month. This is a problem because:

- Some customers have a custom grace period much longer than 3 days
- Customers with old balances were seeing them disappear

Solution (for now!):

- No longer hide the balance due during the first 3 days of the month
  This is a temporary fix, the balance will still be displayed in red
  and as "Past Due." Customers with longstanding balances were seeing
  this disappear at the beginning of the month.
- Use the notification past_due instead of hiding it and faking a similar one.
  For now, we'll still hide this for the first three days of the month as a
  stopgap.
- Use the natural severity (Major) of this notification rather than making
  it artificially Critical

### Note to Reviewers

Sorry about the commas. Test with the mocks, and reach out for login info for accounts that are currently affected by this.