### PR TITLE
M3-4938: Add network interface information to Configurations table

### DIFF
--- a/packages/manager/src/factories/linodeConfigInterfaceFactory.ts
+++ b/packages/manager/src/factories/linodeConfigInterfaceFactory.ts
@@ -3,7 +3,7 @@ import { InterfaceBody } from '@linode/api-v4/lib/linodes/types';
 
 export const LinodeConfigInterfaceFactory = Factory.Sync.makeFactory<InterfaceBody>(
   {
-    label: `interface-${Factory.each((i) => i)}`,
+    label: Factory.each((i) => `interface-${i}`),
     purpose: 'vlan',
     ipam_address: '10.0.0.1/24',
   }

--- a/packages/manager/src/factories/linodeConfigs.ts
+++ b/packages/manager/src/factories/linodeConfigs.ts
@@ -1,6 +1,12 @@
-import { Config } from '@linode/api-v4/lib/linodes/types';
 import * as Factory from 'factory.ts';
-import { LinodeConfigInterfaceFactory } from 'src/factories/linodeConfigInterfaceFactory';
+import { Config, LinodeInterface } from '@linode/api-v4/lib/linodes/types';
+
+// @TODO: Remove this custom interface once the VLAN API changes are rolled out.
+interface LinodeInterfaceTemp extends LinodeInterface {
+  label: string;
+  ipam_address: string | null;
+  purpose: 'public' | 'vlan' | 'internal' | 'multivlan';
+}
 
 const generateRandomId = () => Math.floor(Math.random() * 10000);
 

--- a/packages/manager/src/factories/linodeConfigs.ts
+++ b/packages/manager/src/factories/linodeConfigs.ts
@@ -1,5 +1,6 @@
 import * as Factory from 'factory.ts';
 import { Config } from '@linode/api-v4/lib/linodes/types';
+import { LinodeConfigInterfaceFactory } from 'src/factories/linodeConfigInterfaceFactory';
 
 const generateRandomId = () => Math.floor(Math.random() * 10000);
 

--- a/packages/manager/src/factories/linodeConfigs.ts
+++ b/packages/manager/src/factories/linodeConfigs.ts
@@ -1,12 +1,5 @@
 import * as Factory from 'factory.ts';
-import { Config, LinodeInterface } from '@linode/api-v4/lib/linodes/types';
-
-// @TODO: Remove this custom interface once the VLAN API changes are rolled out.
-interface LinodeInterfaceTemp extends LinodeInterface {
-  label: string;
-  ipam_address: string | null;
-  purpose: 'public' | 'vlan' | 'internal' | 'multivlan';
-}
+import { Config } from '@linode/api-v4/lib/linodes/types';
 
 const generateRandomId = () => Math.floor(Math.random() * 10000);
 

--- a/packages/manager/src/factories/linodeConfigs.ts
+++ b/packages/manager/src/factories/linodeConfigs.ts
@@ -4,6 +4,14 @@ import { LinodeConfigInterfaceFactory } from 'src/factories/linodeConfigInterfac
 
 const generateRandomId = () => Math.floor(Math.random() * 10000);
 
+const publicInterface = LinodeConfigInterfaceFactory.build({
+  purpose: 'public',
+  ipam_address: null,
+});
+const [vlanInterface1, vlanInterface2] = LinodeConfigInterfaceFactory.buildList(
+  2
+);
+
 export const linodeConfigFactory = Factory.Sync.makeFactory<Config>({
   created: '2018-06-26T16:04:28',
   memory_limit: 0,
@@ -43,10 +51,9 @@ export const linodeConfigFactory = Factory.Sync.makeFactory<Config>({
   },
   kernel: 'linode/grub2',
   interfaces: [
-    LinodeConfigInterfaceFactory.build(),
-    LinodeConfigInterfaceFactory.build({
-      purpose: 'public',
-      ipam_address: null,
-    }),
+    // The order of this array is significant. Index 0 (eth0) should be public.
+    publicInterface,
+    vlanInterface1,
+    vlanInterface2,
   ],
 });

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/ConfigRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/ConfigRow.tsx
@@ -4,7 +4,6 @@ import { Volume } from '@linode/api-v4/lib/volumes';
 import { isEmpty } from 'ramda';
 import * as React from 'react';
 import { makeStyles } from 'src/components/core/styles';
-import { Link } from 'src/components/Link';
 import TableCell from 'src/components/TableCell/TableCell_CMR';
 import TableRow from 'src/components/TableRow/TableRow_CMR';
 import { privateIPRegex } from 'src/utilities/ipUtils';
@@ -41,7 +40,6 @@ interface Props {
   linodeInterfaces: LinodeInterface[];
   linodeIPs: string[];
   vlans: Record<string, VLAN>;
-  vlansEnabled: boolean;
 }
 
 interface Handlers {
@@ -66,7 +64,6 @@ export const ConfigRow: React.FC<CombinedProps> = (props) => {
     readOnly,
     linodeInterfaces,
     vlans,
-    vlansEnabled,
   } = props;
 
   const classes = useStyles();
@@ -157,11 +154,9 @@ export const ConfigRow: React.FC<CombinedProps> = (props) => {
       </TableCell>
       <TableCell>{linodeKernel}</TableCell>
       <TableCell>{deviceLabels}</TableCell>
-      {vlansEnabled ? (
-        <TableCell>
-          {!isEmpty(config.interfaces) ? InterfaceList : defaultInterfaceLabel}
-        </TableCell>
-      ) : null}
+      <TableCell>
+        {!isEmpty(config.interfaces) ? InterfaceList : defaultInterfaceLabel}
+      </TableCell>
       <TableCell className={classes.actionInner}>
         <LinodeConfigActionMenu
           config={config}
@@ -196,5 +191,9 @@ export const getInterfaceLabel = (
     return linodeInterface.description;
   }
 
-  return <Link to={`/vlans/${vlan.id}`}>{vlan.label}</Link>;
+  const hasIPAM = isEmpty(linodeInterface.ipam_address);
+
+  return `VLAN: ${vlan.label} ${
+    hasIPAM ? `(${linodeInterface.ipam_address})` : null
+  }`;
 };

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/ConfigRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/ConfigRow.tsx
@@ -1,5 +1,4 @@
 import { Config, Disk, InterfaceBody } from '@linode/api-v4/lib/linodes';
-import { VLAN } from '@linode/api-v4/lib/vlans';
 import { Volume } from '@linode/api-v4/lib/volumes';
 import { isEmpty } from 'ramda';
 import * as React from 'react';
@@ -38,7 +37,6 @@ interface Props {
   linodeVolumes: Volume[];
   linodeKernel: string;
   linodeIPs: string[];
-  vlans: Record<string, VLAN>;
 }
 
 interface Handlers {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/ConfigRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/ConfigRow.tsx
@@ -172,7 +172,7 @@ export const getInterfaceLabel = (
 
   const interfaceLabel = configInterface.label;
   const ipamAddress = configInterface.ipam_address;
-  const hasIPAM = !isEmpty(ipamAddress);
+  const hasIPAM = Boolean(ipamAddress);
 
   return `VLAN: ${interfaceLabel} ${hasIPAM ? `(${ipamAddress})` : ''}`;
 };

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/ConfigRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/ConfigRow.tsx
@@ -107,8 +107,9 @@ export const ConfigRow: React.FC<CombinedProps> = (props) => {
   const InterfaceList = (
     <ul className={classes.interfaceList}>
       {config.interfaces.map((interfaceEntry, idx) => {
-        // Establish interface name (eth0, eth1, eth2)
-        const interfaceName = 'eth';
+        // The order of the config.interfaces array as returned by the API is significant.
+        // Index 0 is eth0, index 1 is eth1, index 2 is eth2.
+        const interfaceName = `eth${idx}`;
 
         return (
           <li

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs.tsx
@@ -49,7 +49,6 @@ import {
 } from 'src/features/linodes/LinodesDetail/linodeDetailContext';
 import { MapState } from 'src/store/types';
 import { getAllVlans } from 'src/store/vlans/vlans.requests';
-import { isFeatureEnabled } from 'src/utilities/accountCapabilities';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { getAll, GetAllData } from 'src/utilities/getAll';
 import LinodeConfigDrawer from '../LinodeSettings/LinodeConfigDialog';
@@ -206,20 +205,9 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
     }
   };
 
-  vlansEnabled = () => {
-    return isFeatureEnabled(
-      'Vlans',
-      Boolean(this.props.flags.vlans),
-      this.props.accountData?.capabilities ?? []
-    );
-  };
-
   componentDidMount() {
     this.requestKernels(this.props.linodeHypervisor);
-
-    if (this.vlansEnabled()) {
-      this.maybeRequestVlans();
-    }
+    this.maybeRequestVlans();
   }
 
   configsPanel = React.createRef();
@@ -527,13 +515,11 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
                         >
                           Disks
                         </TableCell>
-                        {this.vlansEnabled() ? (
-                          <TableCell
-                            className={`${classes.tableCell} ${classes.interfacesColumn}`}
-                          >
-                            Network Interfaces
-                          </TableCell>
-                        ) : null}
+                        <TableCell
+                          className={`${classes.tableCell} ${classes.interfacesColumn}`}
+                        >
+                          Network Interfaces
+                        </TableCell>
                         <TableCell className={classes.actionsColumn} />
                       </TableRow>
                     </TableHead>
@@ -574,7 +560,6 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
                               linodeInterfaces={this.state.interfaces}
                               linodeVolumes={this.props.linodeVolumes}
                               vlans={this.props.vlansData}
-                              vlansEnabled={this.vlansEnabled()}
                             />
                           );
                         })}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs.tsx
@@ -4,7 +4,6 @@ import {
   Disk,
   getLinodeKernels,
   Kernel,
-  LinodeInterface,
   linodeReboot,
 } from '@linode/api-v4/lib/linodes';
 import { APIError } from '@linode/api-v4/lib/types';
@@ -129,9 +128,6 @@ interface State {
   kernels: Kernel[];
   kernelError: APIError[] | null;
   kernelsLoading: boolean;
-  interfaces: LinodeInterface[];
-  interfacesLoading: boolean;
-  interfacesError: APIError[] | null;
 }
 
 interface ConfigDrawerState {
@@ -176,9 +172,6 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
     kernels: [],
     kernelError: null,
     kernelsLoading: false,
-    interfaces: [],
-    interfacesLoading: false,
-    interfacesError: null,
   };
 
   requestKernels = (linodeHypervisor: 'kvm' | 'xen') => {
@@ -528,16 +521,12 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
                         loading={
                           (configsLoading && configsLastUpdated === 0) ||
                           this.state.kernelsLoading ||
-                          this.state.interfacesLoading ||
                           this.props.vlansLoading
                         }
                         lastUpdated={configsLastUpdated}
                         length={paginatedData.length}
                         error={
-                          configsError ??
-                          this.state.interfacesError ??
-                          this.props.vlansError ??
-                          undefined
+                          configsError ?? this.props.vlansError ?? undefined
                         }
                       >
                         {paginatedData.map((thisConfig) => {
@@ -557,7 +546,6 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
                               onEdit={this.openForEditing}
                               onDelete={this.confirmDelete}
                               readOnly={readOnly}
-                              linodeInterfaces={this.state.interfaces}
                               linodeVolumes={this.props.linodeVolumes}
                               vlans={this.props.vlansData}
                             />


### PR DESCRIPTION
## Description
Removes some old VLANs logic from the previous feature iteration; adds Config interfaces mocks; tweaks Network Interfaces column to show VLAN info if the interface is connected to a VLAN.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers
Please use the Mock Service Worker as the mocks are updated with the new data shape for Linode Config interfaces
