### PR TITLE
Allow saving reordered FW rules

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.test.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.test.tsx
@@ -106,6 +106,7 @@ describe('utilities', () => {
       protocol: 'TCP',
       status: 'NEW',
       action: 'ACCEPT',
+      originalIndex: 0,
       addresses: {
         ipv4: ['1.2.3.4'],
         ipv6: ['::0'],

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.test.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.test.tsx
@@ -10,6 +10,7 @@ describe('Firewall rule table tests', () => {
         addresses: { ipv4: ['0.0.0.0/0'], ipv6: ['::/0'] },
         action: 'ACCEPT',
         status: 'NOT_MODIFIED',
+        originalIndex: 0,
       };
       expect(firewallRuleToRowData([rule])[0]).toHaveProperty('type', 'SSH');
       expect(firewallRuleToRowData([rule])[0]).toHaveProperty(

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -90,6 +90,7 @@ interface RuleRow {
   id: number;
   status: RuleStatus;
   errors?: FirewallRuleError[];
+  originalIndex: number;
 }
 
 // =============================================================================
@@ -253,6 +254,7 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
       errors,
       innerRef,
       isDragging,
+      originalIndex,
       ...rest
     } = props;
 
@@ -266,7 +268,12 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
     return (
       <TableRow
         key={id}
-        highlight={status === 'MODIFIED' || status === 'NEW'}
+        highlight={
+          // Highlight the row if it's been modified or reordered. ID is the
+          // current index, if if it doesn't match the original index we know
+          // that the rule has been moved.
+          status === 'MODIFIED' || status === 'NEW' || originalIndex !== id
+        }
         disabled={status === 'PENDING_DELETION'}
         domRef={innerRef}
         className={isDragging ? classes.dragging : ''}

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -270,7 +270,7 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
         key={id}
         highlight={
           // Highlight the row if it's been modified or reordered. ID is the
-          // current index, if if it doesn't match the original index we know
+          // current index, so if it doesn't match the original index we know
           // that the rule has been moved.
           status === 'MODIFIED' || status === 'NEW' || originalIndex !== id
         }

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/firewallRuleEditor.test.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/firewallRuleEditor.test.ts
@@ -14,10 +14,10 @@ describe('Rule Editor', () => {
 
   describe('initRuleEditorState', () => {
     it('initializes a list of revisions for each rule', () => {
-      baseState.revisionLists.forEach((thisRevisionList, i) => {
+      baseState.forEach((revisionList, i) => {
         // The first element in each revisionList should be equal to the
         // original rule, plus a status of "NOT_MODIFIED".
-        expect(thisRevisionList[0]).toEqual({
+        expect(revisionList[0]).toEqual({
           ...rules[i],
           originalIndex: i,
           status: 'NOT_MODIFIED',
@@ -31,8 +31,8 @@ describe('Rule Editor', () => {
           type: 'NEW_RULE',
           rule: firewallRuleFactory.build(),
         });
-        expect(newState.revisionLists).toHaveLength(INITIAL_RULE_LENGTH + 1);
-        const lastRevisionList = last(newState.revisionLists);
+        expect(newState).toHaveLength(INITIAL_RULE_LENGTH + 1);
+        const lastRevisionList = last(newState);
         const lastRevision = last(lastRevisionList!);
         expect(lastRevision).toHaveProperty('status', 'NEW');
       });
@@ -45,7 +45,7 @@ describe('Rule Editor', () => {
           idx: idxToDelete,
         });
 
-        const revisionList = newState.revisionLists[idxToDelete];
+        const revisionList = newState[idxToDelete];
 
         expect(last(revisionList)).toHaveProperty('status', 'PENDING_DELETION');
       });
@@ -61,7 +61,7 @@ describe('Rule Editor', () => {
           },
         });
 
-        const revisionList = newState.revisionLists[idxToModify];
+        const revisionList = newState[idxToModify];
 
         expect(revisionList).toHaveLength(2);
         expect(last(revisionList)).toHaveProperty('status', 'MODIFIED');
@@ -82,11 +82,8 @@ describe('Rule Editor', () => {
           idx,
         });
 
-        expect(newState.revisionLists[idx]).toHaveLength(1);
-        expect(last(newState.revisionLists[idx])).toHaveProperty(
-          'status',
-          'NOT_MODIFIED'
-        );
+        expect(newState[idx]).toHaveLength(1);
+        expect(last(newState[idx])).toHaveProperty('status', 'NOT_MODIFIED');
       });
 
       it('discards all changes', () => {
@@ -106,13 +103,9 @@ describe('Rule Editor', () => {
         const finalState = reducer(newState, {
           type: 'DISCARD_CHANGES',
         });
-        expect(finalState.revisionLists).toHaveLength(
-          baseState.revisionLists.length
-        );
-        expect(finalState.revisionLists[0]).toHaveLength(1);
-        expect(finalState.revisionLists[0][0]).toEqual(
-          baseState.revisionLists[0][0]
-        );
+        expect(finalState).toHaveLength(baseState.length);
+        expect(finalState[0]).toHaveLength(1);
+        expect(finalState[0][0]).toEqual(baseState[0][0]);
       });
 
       it('resets the reducer state', () => {
@@ -133,8 +126,8 @@ describe('Rule Editor', () => {
           type: 'RESET',
           rules,
         });
-        finalState.revisionLists.forEach((thisRevisionList) => {
-          expect(thisRevisionList).toHaveLength(1);
+        finalState.forEach((revisionList) => {
+          expect(revisionList).toHaveLength(1);
         });
       });
 
@@ -144,8 +137,8 @@ describe('Rule Editor', () => {
           startIdx: 1,
           endIdx: 0,
         });
-        expect(newState.revisionLists[0][0]).toHaveProperty('originalIndex', 1);
-        expect(newState.revisionLists[1][0]).toHaveProperty('originalIndex', 0);
+        expect(newState[0][0]).toHaveProperty('originalIndex', 1);
+        expect(newState[1][0]).toHaveProperty('originalIndex', 0);
       });
     });
   });
@@ -161,11 +154,11 @@ describe('Rule Editor', () => {
       // Next, undo the addition.
       newState = reducer(newState, {
         type: 'UNDO',
-        idx: newState.revisionLists.length - 1,
+        idx: newState.length - 1,
       });
 
       const rulesWithoutStatus = editorStateToRules(newState);
-      expect(rulesWithoutStatus.length).toBe(baseState.revisionLists.length);
+      expect(rulesWithoutStatus.length).toBe(baseState.length);
       rulesWithoutStatus.forEach((thisRule) => {
         expect(thisRule).toBeDefined();
       });

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/firewallRuleEditor.test.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/firewallRuleEditor.test.ts
@@ -14,11 +14,12 @@ describe('Rule Editor', () => {
 
   describe('initRuleEditorState', () => {
     it('initializes a list of revisions for each rule', () => {
-      baseState.forEach((revisionList, i) => {
+      baseState.revisionLists.forEach((thisRevisionList, i) => {
         // The first element in each revisionList should be equal to the
         // original rule, plus a status of "NOT_MODIFIED".
-        expect(revisionList[0]).toEqual({
+        expect(thisRevisionList[0]).toEqual({
           ...rules[i],
+          originalIndex: i,
           status: 'NOT_MODIFIED',
         });
       });
@@ -30,8 +31,8 @@ describe('Rule Editor', () => {
           type: 'NEW_RULE',
           rule: firewallRuleFactory.build(),
         });
-        expect(newState).toHaveLength(INITIAL_RULE_LENGTH + 1);
-        const lastRevisionList = last(newState);
+        expect(newState.revisionLists).toHaveLength(INITIAL_RULE_LENGTH + 1);
+        const lastRevisionList = last(newState.revisionLists);
         const lastRevision = last(lastRevisionList!);
         expect(lastRevision).toHaveProperty('status', 'NEW');
       });
@@ -44,7 +45,7 @@ describe('Rule Editor', () => {
           idx: idxToDelete,
         });
 
-        const revisionList = newState[idxToDelete];
+        const revisionList = newState.revisionLists[idxToDelete];
 
         expect(last(revisionList)).toHaveProperty('status', 'PENDING_DELETION');
       });
@@ -60,7 +61,7 @@ describe('Rule Editor', () => {
           },
         });
 
-        const revisionList = newState[idxToModify];
+        const revisionList = newState.revisionLists[idxToModify];
 
         expect(revisionList).toHaveLength(2);
         expect(last(revisionList)).toHaveProperty('status', 'MODIFIED');
@@ -81,8 +82,11 @@ describe('Rule Editor', () => {
           idx,
         });
 
-        expect(newState[idx]).toHaveLength(1);
-        expect(last(newState[idx])).toHaveProperty('status', 'NOT_MODIFIED');
+        expect(newState.revisionLists[idx]).toHaveLength(1);
+        expect(last(newState.revisionLists[idx])).toHaveProperty(
+          'status',
+          'NOT_MODIFIED'
+        );
       });
 
       it('discards all changes', () => {
@@ -102,9 +106,13 @@ describe('Rule Editor', () => {
         const finalState = reducer(newState, {
           type: 'DISCARD_CHANGES',
         });
-        expect(finalState).toHaveLength(baseState.length);
-        expect(finalState[0]).toHaveLength(1);
-        expect(finalState[0][0]).toEqual(baseState[0][0]);
+        expect(finalState.revisionLists).toHaveLength(
+          baseState.revisionLists.length
+        );
+        expect(finalState.revisionLists[0]).toHaveLength(1);
+        expect(finalState.revisionLists[0][0]).toEqual(
+          baseState.revisionLists[0][0]
+        );
       });
 
       it('resets the reducer state', () => {
@@ -125,9 +133,19 @@ describe('Rule Editor', () => {
           type: 'RESET',
           rules,
         });
-        finalState.forEach((revisionList) => {
-          expect(revisionList).toHaveLength(1);
+        finalState.revisionLists.forEach((thisRevisionList) => {
+          expect(thisRevisionList).toHaveLength(1);
         });
+      });
+
+      it('reorders the revision lists', () => {
+        const newState = reducer(baseState, {
+          type: 'REORDER',
+          startIdx: 1,
+          endIdx: 0,
+        });
+        expect(newState.revisionLists[0][0]).toHaveProperty('originalIndex', 1);
+        expect(newState.revisionLists[1][0]).toHaveProperty('originalIndex', 0);
       });
     });
   });
@@ -143,11 +161,11 @@ describe('Rule Editor', () => {
       // Next, undo the addition.
       newState = reducer(newState, {
         type: 'UNDO',
-        idx: newState.length - 1,
+        idx: newState.revisionLists.length - 1,
       });
 
       const rulesWithoutStatus = editorStateToRules(newState);
-      expect(rulesWithoutStatus.length).toBe(baseState.length);
+      expect(rulesWithoutStatus.length).toBe(baseState.revisionLists.length);
       rulesWithoutStatus.forEach((thisRule) => {
         expect(thisRule).toBeDefined();
       });

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/firewallRuleEditor.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/firewallRuleEditor.ts
@@ -17,6 +17,9 @@
 //
 // To "undo" an action, we pop() the revisionList.
 //
+// The original index of each rule is captured and stored with each rule. This
+// way we can "Discard Changes" even after the ruleset has be reordered.
+//
 // The ruleEditorReducer is meant to manage state for one type of rule. In other
 // words, one instance of the reducer manages "inbound" rules, and another
 // instance manages "outbound" rules.
@@ -36,9 +39,13 @@ export interface ExtendedFirewallRule extends FirewallRuleType {
   status: RuleStatus;
   index?: number;
   errors?: FirewallRuleError[];
+  originalIndex: number;
 }
 
-export type RuleEditorState = ExtendedFirewallRule[][];
+export interface RuleEditorState {
+  revisionLists: ExtendedFirewallRule[][];
+  hasModifiedOrder: boolean;
+}
 
 export type RuleEditorAction =
   | {
@@ -86,11 +93,17 @@ const ruleEditorReducer = (
 ) => {
   switch (action.type) {
     case 'NEW_RULE':
-      draft.push([{ ...action.rule, status: 'NEW' }]);
+      draft.revisionLists.push([
+        {
+          ...action.rule,
+          originalIndex: draft.revisionLists.length,
+          status: 'NEW',
+        },
+      ]);
       return;
 
     case 'DELETE_RULE':
-      let lastRevision = last(draft[action.idx]);
+      let lastRevision = last(draft.revisionLists[action.idx]);
 
       if (!lastRevision) {
         return;
@@ -99,14 +112,14 @@ const ruleEditorReducer = (
       // Seems pointless to show errors on rules pending deletion.
       delete lastRevision.errors;
 
-      draft[action.idx].push({
+      draft.revisionLists[action.idx].push({
         ...lastRevision,
         status: 'PENDING_DELETION',
       });
       return;
 
     case 'MODIFY_RULE':
-      lastRevision = last(draft[action.idx]);
+      lastRevision = last(draft.revisionLists[action.idx]);
 
       if (!lastRevision) {
         return;
@@ -123,7 +136,7 @@ const ruleEditorReducer = (
         delete lastRevision.description;
       }
 
-      draft[action.idx].push({
+      draft.revisionLists[action.idx].push({
         ...lastRevision,
         ...action.modifiedRule,
         status: 'MODIFIED',
@@ -131,18 +144,25 @@ const ruleEditorReducer = (
       return;
 
     case 'CLONE_RULE':
-      const ruleToClone = last(draft[action.idx]);
+      const ruleToClone = last(draft.revisionLists[action.idx]);
       if (!ruleToClone) {
         return;
       }
       const { addresses, ports, protocol, action: _action } = ruleToClone;
-      draft.push([
-        { action: _action, addresses, ports, protocol, status: 'NEW' },
+      draft.revisionLists.push([
+        {
+          action: _action,
+          addresses,
+          ports,
+          protocol,
+          originalIndex: draft.revisionLists.length,
+          status: 'NEW',
+        },
       ]);
       return;
 
     case 'SET_ERROR':
-      lastRevision = last(draft[action.idx]);
+      lastRevision = last(draft.revisionLists[action.idx]);
 
       if (!lastRevision) {
         return;
@@ -156,57 +176,66 @@ const ruleEditorReducer = (
       return;
 
     case 'UNDO':
-      lastRevision = last(draft[action.idx]);
+      lastRevision = last(draft.revisionLists[action.idx]);
 
-      draft[action.idx].pop();
+      draft.revisionLists[action.idx].pop();
 
       // If there's nothing left on the stack, we need to actually remove this revisionList.
       // This will only happen if a user performing UNDO on a NEW rule.
-      if (draft[action.idx].length === 0) {
-        draft.splice(action.idx, 1);
+      if (draft.revisionLists[action.idx].length === 0) {
+        draft.revisionLists.splice(action.idx, 1);
       }
 
       return;
 
     case 'DISCARD_CHANGES':
-      const original: RuleEditorState = [];
-      draft.forEach((revisionList) => {
-        const head = revisionList[0];
+      const original: RuleEditorState['revisionLists'] = [];
+      draft.revisionLists.forEach((thisRevisionList) => {
+        const head = thisRevisionList[0];
         if (head.status === 'NOT_MODIFIED') {
-          original.push([head]);
+          original[head.originalIndex] = [head];
         }
       });
-      return original;
+      return { revisionLists: original, hasModifiedOrder: false };
 
     case 'RESET':
       return initRuleEditorState(action.rules);
 
     case 'REORDER':
-      const [removed] = draft.splice(action.startIdx, 1);
-      draft.splice(action.endIdx, 0, removed);
-
+      const [removed] = draft.revisionLists.splice(action.startIdx, 1);
+      draft.revisionLists.splice(action.endIdx, 0, removed);
+      draft.hasModifiedOrder = true;
       return;
   }
 };
 
 export const initRuleEditorState = (
   rules: FirewallRuleType[]
-): RuleEditorState =>
-  rules.map((thisRule) => [{ ...thisRule, status: 'NOT_MODIFIED' }]) ?? [];
+): RuleEditorState => ({
+  revisionLists:
+    rules.map((thisRule, index) => [
+      { ...thisRule, originalIndex: index, status: 'NOT_MODIFIED' },
+    ]) ?? [],
+  hasModifiedOrder: false,
+});
 
 export const editorStateToRules = (
   state: RuleEditorState
 ): ExtendedFirewallRule[] =>
-  state.map((revisionList) => revisionList[revisionList.length - 1]);
+  state.revisionLists.map(
+    (thisRevisionList) => thisRevisionList[thisRevisionList.length - 1]
+  );
 
 // Remove fields we use internally.
 export const stripExtendedFields = (
   rule: ExtendedFirewallRule
-): FirewallRuleType => omit(['errors', 'status', 'index'], rule);
+): FirewallRuleType => omit(['errors', 'status', 'originalIndex'], rule);
 
 // The API will return an error if a `ports` attribute is present on a payload for an ICMP rule,
 // so we do a bit of trickery here and delete it if necessary.
-export const removeICMPPort = (rules: ExtendedFirewallRule[]) =>
+export const removeICMPPort = (
+  rules: ExtendedFirewallRule[]
+): ExtendedFirewallRule[] =>
   rules.map((thisRule) => {
     if (thisRule.protocol === 'ICMP' && thisRule.ports === '') {
       delete thisRule.ports;
@@ -214,22 +243,23 @@ export const removeICMPPort = (rules: ExtendedFirewallRule[]) =>
     return thisRule;
   });
 
-export const filterRulesPendingDeletion = (rules: ExtendedFirewallRule[]) =>
+export const filterRulesPendingDeletion = (
+  rules: ExtendedFirewallRule[]
+): ExtendedFirewallRule[] =>
   rules.filter((thisRule) => thisRule.status !== 'PENDING_DELETION');
-
-export const appendIndex = (rules: ExtendedFirewallRule[]) =>
-  rules.map((thisRule, index) => ({ ...thisRule, index }));
 
 export const prepareRules = compose(
   removeICMPPort,
   filterRulesPendingDeletion,
-  appendIndex,
   editorStateToRules
 );
 
-export const hasModified = (editorState: RuleEditorState) => {
+export const hasModified = (editorState: RuleEditorState): boolean => {
+  if (editorState.hasModifiedOrder) {
+    return true;
+  }
   const rules = editorStateToRules(editorState);
-  return rules.find((thisRule) => thisRule.status !== 'NOT_MODIFIED');
+  return rules.some((thisRule) => thisRule.status !== 'NOT_MODIFIED');
 };
 
 export default produce(ruleEditorReducer);


### PR DESCRIPTION
## Description

This PR allows saving of FW rules that have been reordered. 

I went back and forth with how to represent these modifications in our data structure. The challenge is that:

- Each rule is represented as list of "revisions"!
- These lists of revisions are themselves stored in an array. The order of the array corresponds to the order of rules.
- So, there's no good way to indicate that the order has been modified without pushing a new revision to each rule stack.

~I opted to change the reducer state to~:

```ts
export interface RuleEditorState {
  revisionLists: ExtendedFirewallRule[][]; // <-- existing reducer state
  hasModifiedOrder: boolean;
}
```

~When the order is modified, **no new revisions are pushed to the rule stacks.** Instead, `revisionLists` is reordered and we set `hasModifiedOrder` to `true`.~

**EDIT: ** this was changed to @Jskobos's much better idea.

We also capture the original index of each rule when the state is initialized so that we can "Discard Changes" and return to the original order.

## Note to Reviewers

You'll likely run into API issues trying to save rules; one way to solve is to drop some code into the JS client to delete the new keys the API isn't expecting (inbound_policy, outbound_policy, and on rules: action).

Please beat this up. Add rules, delete them, modify them, reorder them, etc. etc. 
