### PR TITLE
Add: Policy toggles to Firewall rule tables

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -80,9 +80,11 @@ const useStyles = makeStyles((theme: Theme) => ({
   dragging: {
     display: 'table',
   },
+  policyText: {
+    textAlign: 'right',
+  },
   policySelect: {
     paddingLeft: 4,
-    zIndex: 1000,
   },
 }));
 
@@ -367,7 +369,10 @@ export const PolicyRow: React.FC<PolicyRowProps> = React.memo((props) => {
   const classes = useStyles();
   return (
     <TableRow>
-      <TableCell colSpan={5}>Some helper text here</TableCell>
+      <TableCell colSpan={5} className={classes.policyText}>
+        Default {category} policy (applied to any traffic that does not match
+        any specific rule):
+      </TableCell>
       <TableCell colSpan={1} className={classes.policySelect}>
         <Select
           label={`${category} policy`}

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -1,3 +1,4 @@
+import { FirewallPolicyType } from '@linode/api-v4/lib/firewalls/types';
 import classnames from 'classnames';
 import { prop, uniqBy } from 'ramda';
 import * as React from 'react';
@@ -8,6 +9,7 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
 import Typography from 'src/components/core/Typography';
+import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import Table from 'src/components/Table/Table_CMR';
 import TableCell from 'src/components/TableCell/TableCell_CMR';
 import TableRow from 'src/components/TableRow';
@@ -78,6 +80,10 @@ const useStyles = makeStyles((theme: Theme) => ({
   dragging: {
     display: 'table',
   },
+  policySelect: {
+    paddingLeft: 4,
+    zIndex: 1000,
+  },
 }));
 
 interface RuleRow {
@@ -106,6 +112,11 @@ interface RowActionHandlers {
 }
 interface Props extends RowActionHandlers {
   category: Category;
+  policy: FirewallPolicyType;
+  handlePolicyChange: (
+    category: Category,
+    newPolicy: FirewallPolicyType
+  ) => void;
   openRuleDrawer: (category: Category, mode: Mode) => void;
   rulesWithStatus: ExtendedFirewallRule[];
 }
@@ -116,6 +127,8 @@ const FirewallRuleTable: React.FC<CombinedProps> = (props) => {
   const {
     category,
     openRuleDrawer,
+    policy,
+    handlePolicyChange,
     rulesWithStatus,
     triggerCloneFirewallRule,
     triggerDeleteFirewallRule,
@@ -142,6 +155,10 @@ const FirewallRuleTable: React.FC<CombinedProps> = (props) => {
     if (result.destination) {
       triggerReorder(result.source.index, result.destination?.index);
     }
+  };
+
+  const onPolicyChange = (newPolicy: FirewallPolicyType) => {
+    handlePolicyChange(category, newPolicy);
   };
 
   return (
@@ -220,6 +237,11 @@ const FirewallRuleTable: React.FC<CombinedProps> = (props) => {
             )}
           </Droppable>
         </DragDropContext>
+        <PolicyRow
+          category={category}
+          policy={policy}
+          handlePolicyChange={onPolicyChange}
+        />
       </Table>
     </>
   );
@@ -328,6 +350,43 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
     );
   }
 );
+
+interface PolicyRowProps {
+  category: Category;
+  policy: FirewallPolicyType;
+  handlePolicyChange: (newPolicy: FirewallPolicyType) => void;
+}
+
+const policyOptions: Item<FirewallPolicyType>[] = [
+  { label: 'Accept', value: 'ACCEPT' },
+  { label: 'Drop', value: 'DROP' },
+];
+
+export const PolicyRow: React.FC<PolicyRowProps> = React.memo((props) => {
+  const { category, policy, handlePolicyChange } = props;
+  const classes = useStyles();
+  return (
+    <TableRow>
+      <TableCell colSpan={5}>Some helper text here</TableCell>
+      <TableCell colSpan={1} className={classes.policySelect}>
+        <Select
+          label={`${category} policy`}
+          menuPlacement="top"
+          hideLabel
+          isClearable={false}
+          value={policyOptions.find(
+            (thisOption) => thisOption.value === policy
+          )}
+          options={policyOptions}
+          onChange={(selected: Item<FirewallPolicyType>) =>
+            handlePolicyChange(selected.value)
+          }
+        />
+      </TableCell>
+      <TableCell /> {/* Leave empty space to match action cell */}
+    </TableRow>
+  );
+});
 
 interface ConditionalErrorProps {
   formField: string;

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -155,8 +155,7 @@ const FirewallRuleTable: React.FC<CombinedProps> = (props) => {
     openRuleDrawer(category, 'create');
   }, [openRuleDrawer, category]);
 
-  const zeroOutboundRulesMessage =
-    'No outbound rules have been added. When no outbound rules are present, all outbound traffic is allowed.';
+  const zeroOutboundRulesMessage = 'No outbound rules have been added.';
 
   const onDragEnd = (result: DropResult) => {
     if (result.destination) {

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -5,7 +5,12 @@ import * as React from 'react';
 import Undo from 'src/assets/icons/undo.svg';
 import Button from 'src/components/Button';
 import Hidden from 'src/components/core/Hidden';
-import { makeStyles, Theme } from 'src/components/core/styles';
+import {
+  makeStyles,
+  Theme,
+  useMediaQuery,
+  useTheme,
+} from 'src/components/core/styles';
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
 import Typography from 'src/components/core/Typography';
@@ -186,8 +191,8 @@ const FirewallRuleTable: React.FC<CombinedProps> = (props) => {
             <Hidden xsDown>
               <TableCell>Protocol</TableCell>
               <TableCell>Port Range</TableCell>
+              <TableCell>{capitalize(addressColumnLabel)}</TableCell>
             </Hidden>
-            <TableCell>{capitalize(addressColumnLabel)}</TableCell>
             <TableCell>Action</TableCell>
             <TableCell className={classes.actionHeader} />
           </TableRow>
@@ -321,11 +326,15 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
             {ports === '1-65535' ? 'All Ports' : ports}
             <ConditionalError errors={errors} formField="ports" />
           </TableCell>
+          <TableCell style={{ width: '15%' }}>
+            {addresses}{' '}
+            <ConditionalError errors={errors} formField="addresses" />
+          </TableCell>
         </Hidden>
-        <TableCell style={{ width: '15%' }}>
-          {addresses} <ConditionalError errors={errors} formField="addresses" />
+
+        <TableCell style={{ width: '5%' }}>
+          {capitalize(action?.toLocaleLowerCase() ?? '')}
         </TableCell>
-        <TableCell>{capitalize(action?.toLocaleLowerCase() ?? '')}</TableCell>
         <TableCell className={classes.actionCell}>
           {status !== 'NOT_MODIFIED' ? (
             <div className={classes.undoButtonContainer}>
@@ -367,11 +376,23 @@ const policyOptions: Item<FirewallPolicyType>[] = [
 export const PolicyRow: React.FC<PolicyRowProps> = React.memo((props) => {
   const { category, policy, handlePolicyChange } = props;
   const classes = useStyles();
+
+  // Calculate how many cells the text should span so that the Select lines up
+  // with the Action column
+  const theme: Theme = useTheme();
+  const xsDown = useMediaQuery(theme.breakpoints.down('xs'));
+  const mdDown = useMediaQuery(theme.breakpoints.down('md'));
+  const colSpan = xsDown ? 1 : mdDown ? 4 : 5;
+
+  const helperText = mdDown
+    ? `${capitalize(category)} policy:`
+    : `Default ${category} policy (applied to any traffic that does not match
+    any rules):`;
+
   return (
     <TableRow>
-      <TableCell colSpan={5} className={classes.policyText}>
-        Default {category} policy (applied to any traffic that does not match
-        any specific rule):
+      <TableCell colSpan={colSpan} className={classes.policyText}>
+        {helperText}
       </TableCell>
       <TableCell colSpan={1} className={classes.policySelect}>
         <Select

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -12,6 +12,7 @@ import {
   useTheme,
 } from 'src/components/core/styles';
 import TableBody from 'src/components/core/TableBody';
+import TableFooter from 'src/components/core/TableFooter';
 import TableHead from 'src/components/core/TableHead';
 import Typography from 'src/components/core/Typography';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
@@ -89,7 +90,13 @@ const useStyles = makeStyles((theme: Theme) => ({
     textAlign: 'right',
   },
   policySelect: {
-    paddingLeft: 4,
+    paddingLeft: 3,
+  },
+  policySelectInner: {
+    width: 90,
+  },
+  policyRow: {
+    marginTop: '10px !important',
   },
 }));
 
@@ -244,11 +251,13 @@ const FirewallRuleTable: React.FC<CombinedProps> = (props) => {
             )}
           </Droppable>
         </DragDropContext>
-        <PolicyRow
-          category={category}
-          policy={policy}
-          handlePolicyChange={onPolicyChange}
-        />
+        <TableFooter>
+          <PolicyRow
+            category={category}
+            policy={policy}
+            handlePolicyChange={onPolicyChange}
+          />
+        </TableFooter>
       </Table>
     </>
   );
@@ -390,18 +399,23 @@ export const PolicyRow: React.FC<PolicyRowProps> = React.memo((props) => {
   const mdDown = useMediaQuery(theme.breakpoints.down('md'));
   const colSpan = xsDown ? 1 : mdDown ? 4 : 5;
 
-  const helperText = mdDown
-    ? `${capitalize(category)} policy:`
-    : `Default ${category} policy (applied to any traffic that does not match
-    any rules):`;
+  const helperText = mdDown ? (
+    <strong>{capitalize(category)} policy:</strong>
+  ) : (
+    <span>
+      <strong>Default {category} policy.</strong> This policy applies to any
+      traffic not covered by the inbound rules listed above.
+    </span>
+  );
 
   return (
-    <TableRow>
+    <TableRow className={classes.policyRow}>
       <TableCell colSpan={colSpan} className={classes.policyText}>
         {helperText}
       </TableCell>
       <TableCell colSpan={1} className={classes.policySelect}>
         <Select
+          className={classes.policySelectInner}
           label={`${category} policy`}
           menuPlacement="top"
           hideLabel
@@ -415,7 +429,7 @@ export const PolicyRow: React.FC<PolicyRowProps> = React.memo((props) => {
           }
         />
       </TableCell>
-      <TableCell /> {/* Leave empty space to match action cell */}
+      <TableCell />
     </TableRow>
   );
 });

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -89,7 +89,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   footer: {
     '&:before': {
       display: 'block',
-      content: '',
+      content: '""',
       height: theme.spacing(),
     },
   },
@@ -97,7 +97,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     textAlign: 'right',
   },
   policySelect: {
-    paddingLeft: 3,
+    paddingLeft: 4,
   },
   policySelectInner: {
     width: 90,
@@ -411,7 +411,7 @@ export const PolicyRow: React.FC<PolicyRowProps> = React.memo((props) => {
   ) : (
     <span>
       <strong>Default {category} policy.</strong> This policy applies to any
-      traffic not covered by the inbound rules listed above.
+      traffic not covered by the {category} rules listed above.
     </span>
   );
 

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -86,6 +86,13 @@ const useStyles = makeStyles((theme: Theme) => ({
   dragging: {
     display: 'table',
   },
+  footer: {
+    '&:before': {
+      display: 'block',
+      content: '',
+      height: theme.spacing(),
+    },
+  },
   policyText: {
     textAlign: 'right',
   },
@@ -251,7 +258,7 @@ const FirewallRuleTable: React.FC<CombinedProps> = (props) => {
             )}
           </Droppable>
         </DragDropContext>
-        <TableFooter>
+        <TableFooter className={classes.footer}>
           <PolicyRow
             category={category}
             policy={policy}

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRulesLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRulesLanding.tsx
@@ -71,6 +71,23 @@ const FirewallRulesLanding: React.FC<CombinedProps> = (props) => {
   const { firewallID, rules } = props;
 
   /**
+   * inbound and outbound policy aren't part of any particular rule
+   * so they are managed separately rather than through the reducer.
+   */
+
+  const [policy, setPolicy] = React.useState({
+    inbound: rules.inbound_policy,
+    outbound: rules.outbound_policy,
+  });
+
+  const handlePolicyChange = (
+    category: Category,
+    newPolicy: FirewallPolicyType
+  ) => {
+    setPolicy((oldPolicy) => ({ ...oldPolicy, [category]: newPolicy }));
+  };
+
+  /**
    * Component state and handlers
    */
   const [ruleDrawer, setRuleDrawer] = React.useState<Drawer>({
@@ -177,8 +194,8 @@ const FirewallRulesLanding: React.FC<CombinedProps> = (props) => {
     const finalRules = {
       inbound: preparedRules.inbound.map(stripExtendedFields),
       outbound: preparedRules.outbound.map(stripExtendedFields),
-      inbound_policy: 'DROP' as FirewallPolicyType, // @todo fix these defaults
-      outbound_policy: 'ACCEPT' as FirewallPolicyType, // @todo fix these defaults
+      inbound_policy: policy.inbound,
+      outbound_policy: policy.outbound,
     };
 
     updateFirewallRules(firewallID, finalRules)
@@ -299,6 +316,8 @@ const FirewallRulesLanding: React.FC<CombinedProps> = (props) => {
       <div className={classes.table}>
         <FirewallRuleTable
           category="inbound"
+          policy={policy.inbound}
+          handlePolicyChange={handlePolicyChange}
           triggerCloneFirewallRule={(idx: number) =>
             handleCloneRule('inbound', idx)
           }
@@ -317,6 +336,8 @@ const FirewallRulesLanding: React.FC<CombinedProps> = (props) => {
       <div className={classes.table}>
         <FirewallRuleTable
           category="outbound"
+          policy={policy.outbound}
+          handlePolicyChange={handlePolicyChange}
           triggerCloneFirewallRule={(idx: number) =>
             handleCloneRule('outbound', idx)
           }

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRulesLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRulesLanding.tsx
@@ -309,15 +309,6 @@ const FirewallRulesLanding: React.FC<CombinedProps> = (props) => {
         }}
       </Prompt>
 
-      <Typography
-        variant="body1"
-        className={`${classes.copy} ${classes.mobileSpacing}`}
-      >
-        Firewall rules act as an allowlist, permitting only network traffic that
-        matches the rules&apos; parameters to pass through. If there are no
-        outbound rules set, all outbound traffic will be permitted.
-      </Typography>
-
       {generalErrors?.length === 1 && (
         <Notice spacingTop={8} error text={generalErrors[0].reason} />
       )}

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRulesLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRulesLanding.tsx
@@ -87,6 +87,10 @@ const FirewallRulesLanding: React.FC<CombinedProps> = (props) => {
     setPolicy((oldPolicy) => ({ ...oldPolicy, [category]: newPolicy }));
   };
 
+  const _hasModifiedPolicy = () =>
+    policy.inbound !== rules.inbound_policy ||
+    policy.outbound !== rules.outbound_policy;
+
   /**
    * Component state and handlers
    */
@@ -249,8 +253,13 @@ const FirewallRulesLanding: React.FC<CombinedProps> = (props) => {
   };
 
   const hasUnsavedChanges = React.useMemo(
-    () => Boolean(_hasModified(inboundState) || _hasModified(outboundState)),
-    [inboundState, outboundState]
+    () =>
+      Boolean(
+        _hasModified(inboundState) ||
+          _hasModified(outboundState) ||
+          _hasModifiedPolicy()
+      ),
+    [inboundState, outboundState, policy, rules]
   );
 
   const inboundRules = React.useMemo(() => editorStateToRules(inboundState), [
@@ -384,6 +393,10 @@ const FirewallRulesLanding: React.FC<CombinedProps> = (props) => {
         handleDiscard={() => {
           setDiscardChangesModalOpen(false);
           setGeneralErrors(undefined);
+          setPolicy({
+            inbound: rules.inbound_policy,
+            outbound: rules.outbound_policy,
+          });
           inboundDispatch({ type: 'DISCARD_CHANGES' });
           outboundDispatch({ type: 'DISCARD_CHANGES' });
         }}


### PR DESCRIPTION
## Description

You should be able to test this using dev services. There are some edge cases to work out in a future PR (specifically, we're defaulting outbound_policy to ACCEPT for new firewalls, but then if someone adds an outbound rule set to ACCEPT we might want to auto-toggle outbound_policy to DROP.