### PR TITLE
Fix search/pagination bug in LinodeTransferTable

### DIFF
--- a/packages/manager/src/features/EntityTransfers/EntityTransfersCreate/LinodeTransferTable.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersCreate/LinodeTransferTable.tsx
@@ -52,6 +52,8 @@ export const LinodeTransferTable: React.FC<Props> = (props) => {
 
   const handleSearch = (searchText: string) => {
     setSearchText(searchText);
+    // If you're on page 2+, need to go back to page 1 to see the actual results
+    pagination.handlePageChange(1);
   };
 
   const theme = useTheme<Theme>();


### PR DESCRIPTION
## Description

This came up in demo today. Have more than 1 page of Linodes, go to page 2+, search for a Linode label that matches something you know is on page 1. Search will come up empty now, on this branch should contain the thing.