### PR TITLE
Fix: Cloning a FW rule should also clone the label and description

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/firewallRuleEditor.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/firewallRuleEditor.ts
@@ -145,9 +145,18 @@ const ruleEditorReducer = (
       if (!ruleToClone) {
         return;
       }
-      const { addresses, ports, protocol, action: _action } = ruleToClone;
+      const {
+        addresses,
+        description,
+        label,
+        ports,
+        protocol,
+        action: _action,
+      } = ruleToClone;
       draft.push([
         {
+          label,
+          description,
           action: _action,
           addresses,
           ports,


### PR DESCRIPTION
## Description

