### PR TITLE
M3-4977: Created, descending order for Transfers tables

### DIFF
--- a/packages/manager/src/queries/entityTransfers.ts
+++ b/packages/manager/src/queries/entityTransfers.ts
@@ -16,12 +16,21 @@ interface EntityTransfersData {
   entityTransfers: Record<string, EntityTransfer>;
 }
 
+const sortFilter = { '+order_by': 'created', '+order': 'desc' };
+
 export const TRANSFER_FILTERS = {
   received: {
+    ...sortFilter,
     '+and': [{ is_sender: false }, { status: { '+neq': 'pending' } }],
   },
-  pending: { status: 'pending' },
-  sent: { '+and': [{ is_sender: true }, { status: { '+neq': 'pending' } }] },
+  pending: {
+    ...sortFilter,
+    status: 'pending',
+  },
+  sent: {
+    ...sortFilter,
+    '+and': [{ is_sender: true }, { status: { '+neq': 'pending' } }],
+  },
 };
 
 const getAllEntityTransfersRequest = (


### PR DESCRIPTION
## Description
As discussed in the demo, the Transfers tables should now be sorted in descending order by the Created date/time.

## Type of Change
- Non breaking change ('update', 'change')