### PR TITLE
Display some text on empty state in transfer checkout bar

### DIFF
--- a/packages/manager/src/features/EntityTransfers/EntityTransfersCreate/EntityTransfersCreate.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersCreate/EntityTransfersCreate.tsx
@@ -156,4 +156,4 @@ export const EntityTransfersCreate: React.FC<{}> = (_) => {
   );
 };
 
-export default React.memo(EntityTransfersCreate);
+export default EntityTransfersCreate;

--- a/packages/manager/src/features/EntityTransfers/EntityTransfersCreate/EntityTransfersCreate.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersCreate/EntityTransfersCreate.tsx
@@ -156,4 +156,4 @@ export const EntityTransfersCreate: React.FC<{}> = (_) => {
   );
 };
 
-export default EntityTransfersCreate;
+export default React.memo(EntityTransfersCreate);

--- a/packages/manager/src/features/EntityTransfers/EntityTransfersCreate/TransferCheckoutBar.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersCreate/TransferCheckoutBar.tsx
@@ -126,7 +126,9 @@ export const TransferCheckoutBar: React.FC<Props> = (props) => {
           {pluralize('Linode', 'Linodes', totalSelectedLinodes)} to be
           transferred
         </Typography>
-      ) : null}
+      ) : (
+        <Typography>No Linodes selected</Typography>
+      )}
       <Button
         buttonType="primary"
         disabled={totalSelectedLinodes === 0}


### PR DESCRIPTION
## Description

Step 1 of making the empty state of the make transfers page less weird, particularly when using Dark theme