### PR TITLE
M3-4976: Add CopyTooltip next to Transfer tokens in tables

### DIFF
--- a/packages/manager/src/features/EntityTransfers/RenderTransferRow.tsx
+++ b/packages/manager/src/features/EntityTransfers/RenderTransferRow.tsx
@@ -11,6 +11,13 @@ import { pluralize } from 'src/utilities/pluralize';
 import ActionMenu from './TransfersPendingActionMenu';
 
 const useStyles = makeStyles((theme: Theme) => ({
+  row: {
+    '&:hover': {
+      '& [data-qa-copy-token]': {
+        opacity: 1,
+      },
+    },
+  },
   cellContents: {
     paddingLeft: '1rem',
   },
@@ -22,9 +29,13 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   tokenAndCopyIcon: {
     display: 'flex',
+    '& [data-qa-copy-token]': {
+      opacity: 0,
+    },
   },
   icon: {
     marginLeft: theme.spacing(1),
+    marginTop: 2,
     '& svg': {
       width: 12,
       height: 12,
@@ -94,14 +105,6 @@ export const RenderTransferRow: React.FC<CombinedProps> = (props) => {
     handleTokenClick,
   } = props;
 
-  const [showCopyOnHover, setShowCopyOnHover] = React.useState<boolean>(false);
-  const handleRowOnMouseEnter = () => {
-    setShowCopyOnHover(true);
-  };
-  const handleRowOnMouseLeave = () => {
-    setShowCopyOnHover(false);
-  };
-
   const classes = useStyles();
 
   const entitiesAndTheirCounts = Object.entries(entities);
@@ -111,10 +114,7 @@ export const RenderTransferRow: React.FC<CombinedProps> = (props) => {
   const transferTypeIsSent = transferType === 'sent';
 
   return (
-    <TableRow
-      onMouseEnter={handleRowOnMouseEnter}
-      onMouseLeave={handleRowOnMouseLeave}
-    >
+    <TableRow className={classes.row}>
       <TableCell
         className={`${classes.cellContents} ${classes.tokenCell}`}
         noWrap
@@ -126,10 +126,9 @@ export const RenderTransferRow: React.FC<CombinedProps> = (props) => {
           >
             {token}
           </button>
-          <CopyTooltip
-            text={token}
-            className={`${classes.icon} ${showCopyOnHover ? '' : classes.hide}`}
-          />
+          <div data-qa-copy-token>
+            <CopyTooltip text={token} className={`${classes.icon}`} />
+          </div>
         </div>
       </TableCell>
       <Hidden smDown={transferTypeIsPending || transferTypeIsSent}>

--- a/packages/manager/src/features/EntityTransfers/RenderTransferRow.tsx
+++ b/packages/manager/src/features/EntityTransfers/RenderTransferRow.tsx
@@ -41,11 +41,6 @@ const useStyles = makeStyles((theme: Theme) => ({
       height: 12,
     },
   },
-  hide: {
-    [theme.breakpoints.up('md')]: {
-      opacity: 0,
-    },
-  },
   createdCell: {
     width: '20%',
     [theme.breakpoints.down('xs')]: {

--- a/packages/manager/src/features/EntityTransfers/RenderTransferRow.tsx
+++ b/packages/manager/src/features/EntityTransfers/RenderTransferRow.tsx
@@ -8,6 +8,7 @@ import TableCell from 'src/components/TableCell';
 import capitalize from 'src/utilities/capitalize';
 import { pluralize } from 'src/utilities/pluralize';
 import ActionMenu from './TransfersPendingActionMenu';
+import CopyTooltip from 'src/components/CopyTooltip';
 
 const useStyles = makeStyles((theme: Theme) => ({
   cellContents: {
@@ -17,6 +18,25 @@ const useStyles = makeStyles((theme: Theme) => ({
     width: '40%',
     [theme.breakpoints.down('sm')]: {
       width: '50%',
+    },
+  },
+  tokenAndCopyIcon: {
+    display: 'flex',
+  },
+  icon: {
+    marginLeft: theme.spacing(1),
+    '& svg': {
+      width: 12,
+      height: 12,
+    },
+  },
+  hide: {
+    [theme.breakpoints.up('md')]: {
+      opacity: 0,
+    },
+    transition: theme.transitions.create(['opacity']),
+    '&:focus': {
+      opacity: 1,
     },
   },
   createdCell: {
@@ -92,12 +112,18 @@ export const RenderTransferRow: React.FC<CombinedProps> = (props) => {
         className={`${classes.cellContents} ${classes.tokenCell}`}
         noWrap
       >
-        <button
-          className={classes.link}
-          onClick={() => handleTokenClick(token, entities)}
-        >
-          {token}
-        </button>
+        <div className={classes.tokenAndCopyIcon}>
+          <button
+            className={classes.link}
+            onClick={() => handleTokenClick(token, entities)}
+          >
+            {token}
+          </button>
+          <CopyTooltip
+            text={token}
+            className={`${classes.icon} ${classes.hide}`}
+          />
+        </div>
       </TableCell>
       <Hidden smDown={transferTypeIsPending || transferTypeIsSent}>
         <TableCell

--- a/packages/manager/src/features/EntityTransfers/RenderTransferRow.tsx
+++ b/packages/manager/src/features/EntityTransfers/RenderTransferRow.tsx
@@ -1,5 +1,6 @@
 import { TransferEntities } from '@linode/api-v4/lib/entity-transfers';
 import * as React from 'react';
+import CopyTooltip from 'src/components/CopyTooltip';
 import Hidden from 'src/components/core/Hidden';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import TableRow from 'src/components/core/TableRow';
@@ -8,7 +9,6 @@ import TableCell from 'src/components/TableCell';
 import capitalize from 'src/utilities/capitalize';
 import { pluralize } from 'src/utilities/pluralize';
 import ActionMenu from './TransfersPendingActionMenu';
-import CopyTooltip from 'src/components/CopyTooltip';
 
 const useStyles = makeStyles((theme: Theme) => ({
   cellContents: {
@@ -33,10 +33,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   hide: {
     [theme.breakpoints.up('md')]: {
       opacity: 0,
-    },
-    transition: theme.transitions.create(['opacity']),
-    '&:focus': {
-      opacity: 1,
     },
   },
   createdCell: {
@@ -98,6 +94,14 @@ export const RenderTransferRow: React.FC<CombinedProps> = (props) => {
     handleTokenClick,
   } = props;
 
+  const [showCopyOnHover, setShowCopyOnHover] = React.useState<boolean>(false);
+  const handleRowOnMouseEnter = () => {
+    setShowCopyOnHover(true);
+  };
+  const handleRowOnMouseLeave = () => {
+    setShowCopyOnHover(false);
+  };
+
   const classes = useStyles();
 
   const entitiesAndTheirCounts = Object.entries(entities);
@@ -107,7 +111,10 @@ export const RenderTransferRow: React.FC<CombinedProps> = (props) => {
   const transferTypeIsSent = transferType === 'sent';
 
   return (
-    <TableRow>
+    <TableRow
+      onMouseEnter={handleRowOnMouseEnter}
+      onMouseLeave={handleRowOnMouseLeave}
+    >
       <TableCell
         className={`${classes.cellContents} ${classes.tokenCell}`}
         noWrap
@@ -121,7 +128,7 @@ export const RenderTransferRow: React.FC<CombinedProps> = (props) => {
           </button>
           <CopyTooltip
             text={token}
-            className={`${classes.icon} ${classes.hide}`}
+            className={`${classes.icon} ${showCopyOnHover ? '' : classes.hide}`}
           />
         </div>
       </TableCell>


### PR DESCRIPTION
## Description
This PR adds copy icons (only visible on row hover) to the right of Transfer tokens in the Transfers tables.

## Type of Change
- Non breaking change ('update', 'change')