### PR TITLE
Add: dismissible notifications hook and logic

### DIFF
--- a/packages/manager/src/components/AbuseTicketBanner/AbuseTicketBanner.tsx
+++ b/packages/manager/src/components/AbuseTicketBanner/AbuseTicketBanner.tsx
@@ -4,6 +4,7 @@ import { Link, useLocation } from 'react-router-dom';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
+import useDismissibleNotifications from 'src/hooks/useDismissibleNotifications';
 import getAbuseTicket from 'src/store/selectors/getAbuseTicket';
 import { ApplicationState } from 'src/store';
 
@@ -12,6 +13,11 @@ export const AbuseTicketBanner: React.FC<{}> = (_) => {
     getAbuseTicket(state.__resources)
   );
   const location = useLocation();
+
+  const {
+    dismissNotifications,
+    hasDismissedNotifications,
+  } = useDismissibleNotifications();
 
   if (!abuseTickets || abuseTickets.length === 0) {
     return null;
@@ -27,6 +33,14 @@ export const AbuseTicketBanner: React.FC<{}> = (_) => {
     </>
   );
 
+  const onDismiss = () => {
+    dismissNotifications(abuseTickets);
+  };
+
+  if (hasDismissedNotifications(abuseTickets)) {
+    return null;
+  }
+
   /**
    * The ticket list page doesn't indicate which tickets are abuse tickets
    * so for now, the link can just take the user to the first ticket.
@@ -36,7 +50,7 @@ export const AbuseTicketBanner: React.FC<{}> = (_) => {
 
   return (
     <Grid item xs={12}>
-      <Notice important error dismissible={false}>
+      <Notice important error dismissible onClose={onDismiss}>
         <Typography>
           {message}
           {/** Don't link to /support/tickets if we're already on the landing page. */}

--- a/packages/manager/src/features/NotificationCenter/NotificationData/RenderNotification.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/RenderNotification.tsx
@@ -1,4 +1,4 @@
-import { Notification } from '@linode/api-v4/lib/account';
+import { Notification, NotificationType } from '@linode/api-v4/lib/account';
 import ErrorIcon from '@material-ui/icons/Error';
 import WarningIcon from '@material-ui/icons/Warning';
 import * as classNames from 'classnames';
@@ -70,11 +70,11 @@ export const RenderNotification: React.FC<Props> = (props) => {
 
   const severity = notification.severity;
 
-  const linkTarget =
-    // payment_due notifications do not have an entity property, so in that case, link directly to /account/billing
-    notification?.type === 'payment_due'
-      ? '/account/billing'
-      : getEntityLinks(notification?.entity?.type, notification?.entity?.id);
+  const linkTarget = getEntityLinks(
+    notification?.type,
+    notification?.entity?.type,
+    notification?.entity?.id
+  );
 
   const message = (
     <Typography
@@ -133,14 +133,22 @@ export const RenderNotification: React.FC<Props> = (props) => {
   );
 };
 
-const getEntityLinks = (type?: string, id?: number) => {
-  if (!type) {
-    return;
-  } else if (type === 'linode') {
-    return `/linodes/${id}`;
-  } else {
-    return;
+const getEntityLinks = (
+  notificationType?: NotificationType,
+  entityType?: string,
+  id?: number
+) => {
+  // Handle specific notification types ()
+  switch (notificationType) {
+    case 'ticket_abuse':
+      return `/support/tickets/${id}`;
+    case 'payment_due':
+      return '/account/billing';
+    default:
+      break;
   }
+  // The only entity.type we currently expect and can handle for is "linode."
+  return entityType === 'linode' ? `/linodes/${id}` : null;
 };
 
 const linkifiedMaintenanceMessage = (

--- a/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
@@ -9,7 +9,7 @@ import { NotificationItem } from '../NotificationSection';
 import { checkIfMaintenanceNotification } from './notificationUtils';
 import RenderNotification from './RenderNotification';
 
-export const useFormattedNotifications = () => {
+export const useFormattedNotifications = (): NotificationItem[] => {
   const context = React.useContext(notificationContext);
   const {
     dismissNotifications,

--- a/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
@@ -11,11 +11,19 @@ import RenderNotification from './RenderNotification';
 
 export const useFormattedNotifications = () => {
   const context = React.useContext(notificationContext);
-  const { hasDismissedNotifications } = useDismissibleNotifications();
+  const {
+    dismissNotifications,
+    hasDismissedNotifications,
+  } = useDismissibleNotifications();
 
   const notifications = useNotifications();
 
   const dayOfMonth = DateTime.local().day;
+
+  const handleClose = () => {
+    dismissNotifications(notifications);
+    context.closeDrawer();
+  };
 
   return notifications
     .filter((thisNotification) => {
@@ -32,7 +40,7 @@ export const useFormattedNotifications = () => {
       formatNotificationForDisplay(
         interceptNotification(notification),
         idx,
-        context.closeDrawer,
+        handleClose,
         !hasDismissedNotifications([notification])
       )
     );

--- a/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
@@ -33,8 +33,7 @@ export const useFormattedNotifications = () => {
         interceptNotification(notification),
         idx,
         context.closeDrawer,
-        (_notification: Notification) =>
-          !hasDismissedNotifications([_notification])
+        !hasDismissedNotifications([notification])
       )
     );
 };
@@ -79,11 +78,11 @@ const formatNotificationForDisplay = (
   notification: Notification,
   idx: number,
   onClose: () => void,
-  shouldIncludeInCount: (notification: Notification) => boolean = (_) => true
+  shouldIncludeInCount: boolean = true
 ): NotificationItem => ({
   id: `notification-${idx}`,
   body: <RenderNotification notification={notification} onClose={onClose} />,
-  countInTotal: shouldIncludeInCount(notification),
+  countInTotal: shouldIncludeInCount,
 });
 
 // For communicative purposes in the UI, in some cases we want to adjust the severity of certain notifications compared to what the API returns. If it is a maintenance notification of any sort, we display them as major instead of critical. Otherwise, we return the existing severity.

--- a/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
@@ -1,6 +1,6 @@
 import { Notification, NotificationSeverity } from '@linode/api-v4/lib/account';
 import { DateTime } from 'luxon';
-import { path } from 'ramda';
+import { partition, path } from 'ramda';
 import * as React from 'react';
 import useNotifications from 'src/hooks/useNotifications';
 import { notificationContext } from '../NotificationContext';
@@ -15,15 +15,15 @@ export const useFormattedNotifications = () => {
 
   const dayOfMonth = DateTime.local().day;
 
-  // Filter out any bounced email notifications and abuse tickets because users are alerted to those by global notification banners already.
-  const combinedNotifications = [...notifications].filter(
-    (notification) =>
-      !['billing_email_bounce', 'user_email_bounce', 'ticket_abuse'].includes(
-        notification.type
-      )
+  const [abuseNotifications, otherNotifications] = partition<Notification>(
+    (thisNotification) => thisNotification.type === 'ticket_abuse',
+    notifications
   );
 
-  return combinedNotifications
+  if (abuseNotifications.length > 0) {
+  }
+
+  return [...otherNotifications]
     .filter((thisNotification) => {
       /**
        * Don't show balance overdue notifications at the beginning of the month
@@ -86,7 +86,7 @@ const formatNotificationForDisplay = (
 ): NotificationItem => ({
   id: `notification-${idx}`,
   body: <RenderNotification notification={notification} onClose={onClose} />,
-  countInTotal: true,
+  countInTotal: !['ticket_abuse'].includes(notification.type),
 });
 
 // For communicative purposes in the UI, in some cases we want to adjust the severity of certain notifications compared to what the API returns. If it is a maintenance notification of any sort, we display them as major instead of critical. Otherwise, we return the existing severity.

--- a/packages/manager/src/features/NotificationCenter/NotificationDrawer.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationDrawer.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { useDispatch } from 'react-redux';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Drawer from 'src/components/Drawer';
+import useDismissibleNotifications from 'src/hooks/useDismissibleNotifications';
+import useNotifications from 'src/hooks/useNotifications';
 import usePrevious from 'src/hooks/usePrevious';
 import { markAllSeen } from 'src/store/events/event.request';
 import { ThunkDispatch } from 'src/store/types';
@@ -42,6 +44,8 @@ interface Props {
 export const NotificationDrawer: React.FC<Props> = (props) => {
   const { data, open, onClose } = props;
   const classes = useStyles();
+  const { dismissNotifications } = useDismissibleNotifications();
+  const notifications = useNotifications();
   const dispatch = useDispatch<ThunkDispatch>();
   const { eventNotifications, formattedNotifications } = data;
 
@@ -51,8 +55,9 @@ export const NotificationDrawer: React.FC<Props> = (props) => {
     if (wasOpen && !open) {
       // User has closed the drawer.
       dispatch(markAllSeen());
+      dismissNotifications(notifications);
     }
-  }, [dispatch, open, wasOpen]);
+  }, [dismissNotifications, notifications, dispatch, open, wasOpen]);
 
   return (
     <Drawer open={open} onClose={onClose} title="" className={classes.root}>

--- a/packages/manager/src/hooks/useDismissibleNotifications.ts
+++ b/packages/manager/src/hooks/useDismissibleNotifications.ts
@@ -31,7 +31,7 @@ export const useDismissibleNotifications = (): DismissibleNotificationsHook => {
     if (dismissed) {
       return true;
     }
-    return _notifications.some((thisNotification) => {
+    return _notifications.every((thisNotification) => {
       const hashKey = getHashKey(thisNotification);
       return Boolean(dismissedNotifications[hashKey]);
     });
@@ -70,8 +70,9 @@ const updateDismissedNotifications = (
   });
   return Object.values(notifications).reduce((acc, thisNotification) => {
     const isStale =
-      DateTime.fromISO(thisNotification.created).diffNow('days').days > 60;
-    return isStale ? { ...acc, [thisNotification.id]: thisNotification } : acc;
+      DateTime.fromISO(thisNotification.created).diffNow('days').toObject()
+        .days ?? 0 > 60;
+    return isStale ? acc : { ...acc, [thisNotification.id]: thisNotification };
   }, newNotifications);
 };
 

--- a/packages/manager/src/hooks/useDismissibleNotifications.ts
+++ b/packages/manager/src/hooks/useDismissibleNotifications.ts
@@ -1,0 +1,38 @@
+import { Notification } from '@linode/api-v4/lib/account/types';
+import * as md5 from 'md5';
+import { useState } from 'react';
+import { usePreferences } from 'src/hooks/usePreferences';
+
+export const useDismissibleNotifications = () => {
+  const { preferences, updatePreferences } = usePreferences();
+  const [dismissed, setDismissed] = useState(false);
+
+  const dismissedNotifications = preferences?.dismissed_notifications ?? [];
+
+  const dismissNotifications = (_notifications: Notification[]) => {
+    const hashKey = getHashKey(_notifications);
+    setDismissed(true);
+    updatePreferences({
+      dismissed_notifications: [...dismissedNotifications, hashKey],
+    });
+  };
+
+  const hasDismissedNotifications = (_notifications: Notification[]) => {
+    if (dismissed) {
+      return true;
+    }
+    const hashKey = getHashKey(_notifications);
+    return dismissedNotifications.includes(hashKey);
+  };
+
+  return {
+    dismissNotifications,
+    hasDismissedNotifications,
+    dismissedNotifications,
+  };
+};
+
+const getHashKey = (notifications: Notification[]) =>
+  md5(JSON.stringify(notifications));
+
+export default useDismissibleNotifications;

--- a/packages/manager/src/hooks/useDismissibleNotifications.ts
+++ b/packages/manager/src/hooks/useDismissibleNotifications.ts
@@ -1,19 +1,29 @@
 import { Notification } from '@linode/api-v4/lib/account/types';
+import { DateTime } from 'luxon';
 import * as md5 from 'md5';
 import { useState } from 'react';
 import { usePreferences } from 'src/hooks/usePreferences';
+import { DismissedNotification } from 'src/store/preferences/preferences.actions';
 
-export const useDismissibleNotifications = () => {
+export interface DismissibleNotificationsHook {
+  dismissedNotifications: Record<string, DismissedNotification>;
+  hasDismissedNotifications: (notifications: Notification[]) => boolean;
+  dismissNotifications: (notifications: Notification[]) => void;
+}
+
+export const useDismissibleNotifications = (): DismissibleNotificationsHook => {
   const { preferences, updatePreferences } = usePreferences();
   const [dismissed, setDismissed] = useState(false);
 
-  const dismissedNotifications = preferences?.dismissed_notifications ?? [];
+  const dismissedNotifications = preferences?.dismissed_notifications ?? {};
 
   const dismissNotifications = (_notifications: Notification[]) => {
-    const hashKey = getHashKey(_notifications);
     setDismissed(true);
     updatePreferences({
-      dismissed_notifications: [...dismissedNotifications, hashKey],
+      dismissed_notifications: updateDismissedNotifications(
+        dismissedNotifications,
+        _notifications
+      ),
     });
   };
 
@@ -21,8 +31,10 @@ export const useDismissibleNotifications = () => {
     if (dismissed) {
       return true;
     }
-    const hashKey = getHashKey(_notifications);
-    return dismissedNotifications.includes(hashKey);
+    return _notifications.some((thisNotification) => {
+      const hashKey = getHashKey(thisNotification);
+      return Boolean(dismissedNotifications[hashKey]);
+    });
   };
 
   return {
@@ -32,7 +44,35 @@ export const useDismissibleNotifications = () => {
   };
 };
 
-const getHashKey = (notifications: Notification[]) =>
-  md5(JSON.stringify(notifications));
+const getHashKey = (notification: Notification) =>
+  md5(JSON.stringify(notification));
+
+/**
+ * Does two things:
+ *  1. Adds the new notifications to the list of things that
+ *     have been dismissed (or overrides it if the hashkey is
+ *     already present)
+ *  2. Removes any notifications older than 2 months (60 days).
+ *     We do this to prevent user preferences from turning into
+ *     an ever-expanding blob of old notification hashes.
+ */
+const updateDismissedNotifications = (
+  notifications: Record<string, DismissedNotification>,
+  notificationsToDismiss: Notification[]
+) => {
+  const newNotifications = {};
+  notificationsToDismiss.forEach((thisNotification) => {
+    const hashKey = getHashKey(thisNotification);
+    notifications[hashKey] = {
+      id: hashKey,
+      created: DateTime.utc().toLocaleString(),
+    };
+  });
+  return Object.values(notifications).reduce((acc, thisNotification) => {
+    const isStale =
+      DateTime.fromISO(thisNotification.created).diffNow('days').days > 60;
+    return isStale ? { ...acc, [thisNotification.id]: thisNotification } : acc;
+  }, newNotifications);
+};
 
 export default useDismissibleNotifications;

--- a/packages/manager/src/hooks/useDismissibleNotifications.ts
+++ b/packages/manager/src/hooks/useDismissibleNotifications.ts
@@ -63,7 +63,7 @@ const updateDismissedNotifications = (
   const newNotifications = {};
   notificationsToDismiss.forEach((thisNotification) => {
     const hashKey = getHashKey(thisNotification);
-    notifications[hashKey] = {
+    newNotifications[hashKey] = {
       id: hashKey,
       created: DateTime.utc().toLocaleString(),
     };

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -118,7 +118,14 @@ export const handlers = [
     return res(ctx.json(makeResourcePage(tokens)));
   }),
   rest.get('*/regions', async (req, res, ctx) => {
-    return res(ctx.json(cachedRegions));
+    return res(
+      ctx.json(
+        cachedRegions.data.map((thisRegion) => ({
+          ...thisRegion,
+          status: 'outage',
+        }))
+      )
+    );
   }),
   rest.get('*/linode/types', async (req, res, ctx) => {
     return res(ctx.json(cachedTypes));
@@ -477,6 +484,7 @@ export const handlers = [
       until: null,
       body: null,
     });
+
     const abuseTicket = abuseTicketNotificationFactory.build();
 
     const migrationTicket = notificationFactory.build({

--- a/packages/manager/src/store/preferences/preferences.actions.ts
+++ b/packages/manager/src/store/preferences/preferences.actions.ts
@@ -11,6 +11,11 @@ export interface OrderSet {
   orderBy: string;
 }
 
+export interface DismissedNotification {
+  id: string;
+  created: string;
+}
+
 export interface UserPreferences {
   longviewTimeRange?: string;
   gst_banner_dismissed?: boolean;
@@ -26,7 +31,7 @@ export interface UserPreferences {
   linode_news_banner_dismissed?: boolean;
   firewall_beta_notification?: boolean;
   backups_cta_dismissed?: boolean;
-  dismissed_notifications?: string[];
+  dismissed_notifications?: Record<string, DismissedNotification>;
 }
 
 export const handleGetPreferences = actionCreator.async<

--- a/packages/manager/src/store/preferences/preferences.actions.ts
+++ b/packages/manager/src/store/preferences/preferences.actions.ts
@@ -26,6 +26,7 @@ export interface UserPreferences {
   linode_news_banner_dismissed?: boolean;
   firewall_beta_notification?: boolean;
   backups_cta_dismissed?: boolean;
+  dismissed_notifications?: string[];
 }
 
 export const handleGetPreferences = actionCreator.async<


### PR DESCRIPTION
## Description

Opening this for review, still things to address in future PRs but I want to get feedback on the approach, which is:
- Store a set of `Record<hash, { created: string, key: hash }>` in user preferences
- Add a dismissible notification hook that exposes a few things:
     - hasDismissedNotifications: given a list of Notification[] (or anything really) will check the hashes of those things against
       the hashes in userPreferences and return `false` if _any_ item in the list doesn't have a matching hash.
     - dismissNotification: given a list of Notification[] (or anything again), hashes and timestamps them, and updates user preferences. Because the full payload must be included when updating preferences, I use this opportunity to filter out any items with a `created` date older than 60 days (to prevent the endless bloating of the preferences object).
- In AbuseTicketBanner:
    - Add a `dismissible` prop to the Notice
    - On dismiss, do the usual thing (optimistically hide the banner and update user preferences, in this case using the useDismissibleNotifications hook)
    - Don't show the banner in the first place if `hasDismissedNotifications` is true (if all of the current abuse ticket notifications have been dismissed).
- In the notification drawer:
   - Only include non-dismissed notifications in the badge count (note: this raises a performance issue I haven't worked out yet, see below).
   - Dismiss all notifications on drawer close (has the same effect as marking events as seen, except that in this case it's a client-side hack)
 
## Remaining Issues
- For interlocking hooks reasons, and because the notification drawer is essentially always mounted, the `hasDismissedNotifications` method is run A LOT, N times on basically any interaction where N is the number of notifications on the account.
- Talked with Matthew and we decided to add some extra toggles to profile/settings to, in this case, have a "never show this banner again no matter how many abuse tickets get opened". Did this because, with the current approach, the banner will return as soon as a new ticket is opened on the account, which for large accounts is frequent.
- Plenty of other things need to be dismissed using this approach. I think that the useDismissibleNotifications hook will work fine for these, you can pass anything serializable to the dismissNotifications handler and all ought to be well. I hope.

## To Test

Development test account 4 has 5 open abuse tickets on it. You can generate these too on your own account if you'd like, reach out for help. You can use the preference editor at http://localhost:3000/profile/settings?preferenceEditor=true to clear out the `dismissed_notifications` object and reset the dismissed state. It's slow but you can go through the process as many times as you need.