### PR TITLE
Fix collision on FW -> Linodes

### DIFF
--- a/packages/manager/src/components/AddNewLink/AddNewLink_CMR.tsx
+++ b/packages/manager/src/components/AddNewLink/AddNewLink_CMR.tsx
@@ -30,6 +30,7 @@ const AddNewLink: React.FC<CombinedProps> = (props) => {
     label,
     left,
     onClick,
+    className,
     ...remainingPropsAsTooltipProps
   } = props;
 
@@ -39,6 +40,7 @@ const AddNewLink: React.FC<CombinedProps> = (props) => {
     onClick,
     text: label,
     title: label,
+    className,
   };
 
   if (!!disabled && !!disabledReason) {

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallLinodesLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallLinodesLanding.tsx
@@ -25,7 +25,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     fontSize: '16px',
   },
   link: {
-    margin: '8px 8px 8px 0px',
+    margin: '8px 8px 8px auto !important',
   },
   cmrSpacing: {
     [theme.breakpoints.down('md')]: {
@@ -134,21 +134,23 @@ const FirewallLinodesLanding: React.FC<CombinedProps> = (props) => {
 
   return (
     <>
-      <Typography
-        className={classnames({
-          [classes.message]: true,
-          [classes.cmrSpacing]: flags.cmr,
-        })}
-      >
-        The following Linodes have been assigned to this Firewall. A Linode can
-        only be assigned to a single Firewall.
-      </Typography>
       <Box
         display="flex"
         flexDirection="row"
-        alignItems="flex-end"
-        justifyContent="flex-end"
+        alignItems="center"
+        justifyContent="space-between"
+        flexWrap="wrap"
+        marginTop="10px"
       >
+        <Typography
+          className={classnames({
+            [classes.message]: true,
+            [classes.cmrSpacing]: flags.cmr,
+          })}
+        >
+          The following Linodes have been assigned to this Firewall. A Linode
+          can only be assigned to a single Firewall.
+        </Typography>
         <Link
           onClick={() => setDeviceDrawerOpen(true)}
           label="Add Linodes to Firewall"

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallLinodesLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallLinodesLanding.tsx
@@ -25,7 +25,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     fontSize: '16px',
   },
   link: {
-    margin: '8px 8px 8px auto !important',
+    margin: '8px 8px 8px auto',
   },
   cmrSpacing: {
     [theme.breakpoints.down('md')]: {

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallLinodesLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallLinodesLanding.tsx
@@ -1,10 +1,8 @@
 import { APIError } from '@linode/api-v4/lib/types';
 import Promise from 'bluebird';
-import classnames from 'classnames';
 import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
-import AddNewLink from 'src/components/AddNewLink';
 import AddNewLink_CMR from 'src/components/AddNewLink/AddNewLink_CMR';
 import Box from 'src/components/core/Box';
 import { makeStyles, Theme } from 'src/components/core/styles';
@@ -14,7 +12,6 @@ import withLinodes, {
 } from 'src/containers/withLinodes.container';
 import { useDialog } from 'src/hooks/useDialog';
 import useFirewallDevices from 'src/hooks/useFirewallDevices';
-import useFlags from 'src/hooks/useFlags';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import AddDeviceDrawer from './AddDeviceDrawer';
 import FirewallDevicesTable from './FirewallDevicesTable';
@@ -23,14 +20,15 @@ import RemoveDeviceDialog from './RemoveDeviceDialog';
 const useStyles = makeStyles((theme: Theme) => ({
   message: {
     fontSize: '16px',
-  },
-  link: {
-    margin: '8px 8px 8px auto',
-  },
-  cmrSpacing: {
     [theme.breakpoints.down('md')]: {
       marginLeft: theme.spacing(),
       marginRight: theme.spacing(),
+    },
+  },
+  link: {
+    margin: '8px 8px 8px auto',
+    [theme.breakpoints.up('md')]: {
+      marginRight: 0,
     },
   },
 }));
@@ -66,10 +64,6 @@ const FirewallLinodesLanding: React.FC<CombinedProps> = (props) => {
     handleError,
     submitDialog,
   } = useDialog<number>(removeDevice);
-
-  const flags = useFlags();
-
-  const Link = flags.cmr ? AddNewLink_CMR : AddNewLink;
 
   const _openDialog = React.useCallback(openDialog, [dialog, openDialog]);
   const _closeDialog = React.useCallback(closeDialog, [dialog, closeDialog]);
@@ -142,19 +136,14 @@ const FirewallLinodesLanding: React.FC<CombinedProps> = (props) => {
         flexWrap="wrap"
         marginTop="10px"
       >
-        <Typography
-          className={classnames({
-            [classes.message]: true,
-            [classes.cmrSpacing]: flags.cmr,
-          })}
-        >
+        <Typography className={classes.message}>
           The following Linodes have been assigned to this Firewall. A Linode
           can only be assigned to a single Firewall.
         </Typography>
-        <Link
+        <AddNewLink_CMR
           onClick={() => setDeviceDrawerOpen(true)}
           label="Add Linodes to Firewall"
-          className={flags.cmr && classes.link}
+          className={classes.link}
         />
       </Box>
       <FirewallDevicesTable


### PR DESCRIPTION
Fix this collision:

![image (2)](https://user-images.githubusercontent.com/16911484/110573690-b4afe280-8129-11eb-9c07-44c42e87a733.png)

In doing so, I restored the passing down of classNames to the Button in AddNewLink_CMR. This reverses a change made here: https://github.com/linode/manager/pull/7270/files#diff-14508ed4b0441d547fadf5aa1f4c123ee37bb0abc5e2a5b97029bf80c6d73405L30.
