### PR TITLE
M3-4966: Remove "Status" column from Community StackScripts landing page

### DIFF
--- a/packages/api-v4/src/stackscripts/types.ts
+++ b/packages/api-v4/src/stackscripts/types.ts
@@ -1,7 +1,3 @@
-/* eslint-disable no-unused-vars */
-import { Grant } from '@linode/api-v4/lib/account';
-import { ResourcePage } from '@linode/api-v4/lib/types';
-
 export interface StackScriptPayload {
   script: string;
   label: string;
@@ -38,10 +34,3 @@ export interface UserDefinedField {
   manyof?: string;
   default?: string;
 }
-
-export type StackScriptsRequest = (
-  username: string,
-  params?: unknown,
-  filter?: unknown,
-  stackScriptGrants?: Grant[]
-) => Promise<ResourcePage<StackScript>>;

--- a/packages/api-v4/src/stackscripts/types.ts
+++ b/packages/api-v4/src/stackscripts/types.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars */
-import { Grant } from '../account';
-import { ResourcePage } from '../types';
+import { Grant } from '@linode/api-v4/lib/account';
+import { ResourcePage } from '@linode/api-v4/lib/types';
 
 export interface StackScriptPayload {
   script: string;

--- a/packages/api-v4/src/stackscripts/types.ts
+++ b/packages/api-v4/src/stackscripts/types.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars */
-import { Grant } from '@linode/api-v4/lib/account';
-import { ResourcePage } from '@linode/api-v4/lib/types';
+import { Grant } from '../account';
+import { ResourcePage } from '../types';
 
 export interface StackScriptPayload {
   script: string;

--- a/packages/api-v4/src/stackscripts/types.ts
+++ b/packages/api-v4/src/stackscripts/types.ts
@@ -1,3 +1,7 @@
+/* eslint-disable no-unused-vars */
+import { Grant } from '@linode/api-v4/lib/account';
+import { ResourcePage } from '@linode/api-v4/lib/types';
+
 export interface StackScriptPayload {
   script: string;
   label: string;
@@ -34,3 +38,10 @@ export interface UserDefinedField {
   manyof?: string;
   default?: string;
 }
+
+export type StackScriptsRequest = (
+  username: string,
+  params?: unknown,
+  filter?: unknown,
+  stackScriptGrants?: Grant[]
+) => Promise<ResourcePage<StackScript>>;

--- a/packages/manager/src/components/StackScript/StackScript.tsx
+++ b/packages/manager/src/components/StackScript/StackScript.tsx
@@ -21,7 +21,7 @@ import { useAccountUsers } from 'src/queries/accountUsers';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
-    backgroundColor: theme.color.white,
+    backgroundColor: theme.cmrBGColors,
     '.detailsWrapper &': {
       padding: theme.spacing(4),
     },

--- a/packages/manager/src/components/StackScript/StackScript.tsx
+++ b/packages/manager/src/components/StackScript/StackScript.tsx
@@ -21,7 +21,7 @@ import { useAccountUsers } from 'src/queries/accountUsers';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
-    backgroundColor: theme.cmrBGColors,
+    backgroundColor: theme.color.white,
     '.detailsWrapper &': {
       padding: theme.spacing(4),
     },

--- a/packages/manager/src/features/StackScripts/Partials/StackScriptTableHead_CMR.tsx
+++ b/packages/manager/src/features/StackScripts/Partials/StackScriptTableHead_CMR.tsx
@@ -93,6 +93,7 @@ type SortOrder = 'asc' | 'desc';
 type CurrentFilter = 'label' | 'deploys' | 'revision';
 
 interface Props {
+  category?: string;
   isSelecting?: boolean;
   handleClickTableHeader?: (value: string) => void;
   sortOrder?: SortOrder;
@@ -108,6 +109,7 @@ export const StackScriptTableHead: React.FC<CombinedProps> = (props) => {
     isSelecting,
     handleClickTableHeader,
     sortOrder,
+    category,
   } = props;
 
   const Cell: React.ComponentType<any> =
@@ -122,6 +124,8 @@ export const StackScriptTableHead: React.FC<CombinedProps> = (props) => {
           handleClick: handleClickTableHeader,
         }
       : {};
+
+  const communityStackScripts = category === 'community';
 
   return (
     <TableHead className={classes.root}>
@@ -176,7 +180,7 @@ export const StackScriptTableHead: React.FC<CombinedProps> = (props) => {
             </TableCell>
           </Hidden>
         )}
-        {!isSelecting && (
+        {!isSelecting && !communityStackScripts ? (
           <Hidden mdDown>
             <TableCell
               className={`${classes.tableHead} ${classes.status} ${classes.noHover}`}
@@ -185,7 +189,7 @@ export const StackScriptTableHead: React.FC<CombinedProps> = (props) => {
               Status
             </TableCell>
           </Hidden>
-        )}
+        ) : null}
         {!isSelecting && (
           <TableCell
             className={`${classes.tableHead} ${classes.actionMenu} ${classes.noHover}`}

--- a/packages/manager/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanelContent.tsx
+++ b/packages/manager/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanelContent.tsx
@@ -1,12 +1,11 @@
-import { Grant } from '@linode/api-v4/lib/account';
 import { Image } from '@linode/api-v4/lib/images';
 import { StackScript, UserDefinedField } from '@linode/api-v4/lib/stackscripts';
-import { ResourcePage } from '@linode/api-v4/lib/types';
 import * as React from 'react';
 import { compose } from 'recompose';
 import StackScriptBase, {
   StateProps,
 } from '../StackScriptBase/StackScriptBase';
+import { StackScriptsRequest } from '../types';
 import SelectStackScriptsSection from './SelectStackScriptsSection';
 
 interface Props {
@@ -20,12 +19,7 @@ interface Props {
   resetStackScriptSelection: () => void;
   publicImages: Record<string, Image>;
   currentUser: string;
-  request: (
-    username: string,
-    params?: any,
-    filter?: any,
-    stackScriptGrants?: Grant[]
-  ) => Promise<ResourcePage<StackScript>>;
+  request: StackScriptsRequest;
   category: string;
   disabled?: boolean;
   isOnCreate?: boolean;

--- a/packages/manager/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanelContent.tsx
+++ b/packages/manager/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanelContent.tsx
@@ -1,9 +1,7 @@
+import { Grant } from '@linode/api-v4/lib/account';
 import { Image } from '@linode/api-v4/lib/images';
-import {
-  StackScript,
-  UserDefinedField,
-  StackScriptsRequest,
-} from '@linode/api-v4/lib/stackscripts';
+import { StackScript, UserDefinedField } from '@linode/api-v4/lib/stackscripts';
+import { ResourcePage } from '@linode/api-v4/lib/types';
 import * as React from 'react';
 import { compose } from 'recompose';
 import StackScriptBase, {
@@ -22,7 +20,12 @@ interface Props {
   resetStackScriptSelection: () => void;
   publicImages: Record<string, Image>;
   currentUser: string;
-  request: StackScriptsRequest;
+  request: (
+    username: string,
+    params?: any,
+    filter?: any,
+    stackScriptGrants?: Grant[]
+  ) => Promise<ResourcePage<StackScript>>;
   category: string;
   disabled?: boolean;
   isOnCreate?: boolean;

--- a/packages/manager/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanelContent.tsx
+++ b/packages/manager/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanelContent.tsx
@@ -1,7 +1,9 @@
-import { Grant } from '@linode/api-v4/lib/account';
 import { Image } from '@linode/api-v4/lib/images';
-import { StackScript, UserDefinedField } from '@linode/api-v4/lib/stackscripts';
-import { ResourcePage } from '@linode/api-v4/lib/types';
+import {
+  StackScript,
+  UserDefinedField,
+  StackScriptsRequest,
+} from '@linode/api-v4/lib/stackscripts';
 import * as React from 'react';
 import { compose } from 'recompose';
 import StackScriptBase, {
@@ -20,12 +22,7 @@ interface Props {
   resetStackScriptSelection: () => void;
   publicImages: Record<string, Image>;
   currentUser: string;
-  request: (
-    username: string,
-    params?: any,
-    filter?: any,
-    stackScriptGrants?: Grant[]
-  ) => Promise<ResourcePage<StackScript>>;
+  request: StackScriptsRequest;
   category: string;
   disabled?: boolean;
   isOnCreate?: boolean;

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -35,6 +35,7 @@ import {
   generateCatchAllFilter,
   generateSpecificFilter,
 } from '../stackScriptUtils';
+import { StackScriptsRequest } from '../types';
 import withStyles, { StyleProps } from './StackScriptBase.styles';
 
 type CurrentFilter = 'label' | 'deploys' | 'revision';
@@ -79,12 +80,7 @@ type CombinedProps = StyleProps &
     publicImages: Record<string, Image>;
     currentUser: string;
     category: string;
-    request: (
-      user: string,
-      pageArgs: { page: number; page_size: number },
-      filter: any,
-      grants?: Grant[]
-    ) => Promise<ResourcePage<StackScript>>;
+    request: StackScriptsRequest;
   };
 
 interface HelperFunctions {

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -1,6 +1,9 @@
 import { Grant } from '@linode/api-v4/lib/account';
 import { Image } from '@linode/api-v4/lib/images';
-import { StackScript } from '@linode/api-v4/lib/stackscripts';
+import {
+  StackScript,
+  StackScriptsRequest,
+} from '@linode/api-v4/lib/stackscripts';
 import { APIError, ResourcePage } from '@linode/api-v4/lib/types';
 import classnames from 'classnames';
 import { stringify } from 'qs';
@@ -79,12 +82,7 @@ type CombinedProps = StyleProps &
     publicImages: Record<string, Image>;
     currentUser: string;
     category: string;
-    request: (
-      user: string,
-      pageArgs: { page: number; page_size: number },
-      filter: any,
-      grants?: Grant[]
-    ) => Promise<ResourcePage<StackScript>>;
+    request: StackScriptsRequest;
   };
 
 interface HelperFunctions {

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -1,9 +1,6 @@
 import { Grant } from '@linode/api-v4/lib/account';
 import { Image } from '@linode/api-v4/lib/images';
-import {
-  StackScript,
-  StackScriptsRequest,
-} from '@linode/api-v4/lib/stackscripts';
+import { StackScript } from '@linode/api-v4/lib/stackscripts';
 import { APIError, ResourcePage } from '@linode/api-v4/lib/types';
 import classnames from 'classnames';
 import { stringify } from 'qs';
@@ -82,7 +79,12 @@ type CombinedProps = StyleProps &
     publicImages: Record<string, Image>;
     currentUser: string;
     category: string;
-    request: StackScriptsRequest;
+    request: (
+      user: string,
+      pageArgs: { page: number; page_size: number },
+      filter: any,
+      grants?: Grant[]
+    ) => Promise<ResourcePage<StackScript>>;
   };
 
 interface HelperFunctions {

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -79,7 +79,12 @@ type CombinedProps = StyleProps &
     publicImages: Record<string, Image>;
     currentUser: string;
     category: string;
-    request: Function;
+    request: (
+      user: string,
+      pageArgs: { page: number; page_size: number },
+      filter: any,
+      grants?: Grant[]
+    ) => Promise<ResourcePage<StackScript>>;
   };
 
 interface HelperFunctions {
@@ -577,6 +582,7 @@ const withStackScriptBase = (options: WithStackScriptBaseOptions) => (
                   sortOrder={sortOrder}
                   currentFilterType={currentFilterType}
                   isSelecting={isSelecting}
+                  category={this.props.category}
                 />
                 <Component
                   {...this.props}

--- a/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptPanelContent.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptPanelContent.tsx
@@ -1,9 +1,10 @@
 import { Image } from '@linode/api-v4/lib/images';
 import {
   deleteStackScript,
+  StackScript,
   updateStackScript,
-  StackScriptsRequest,
 } from '@linode/api-v4/lib/stackscripts';
+import { ResourcePage } from '@linode/api-v4/lib/types';
 import * as React from 'react';
 import { compose } from 'recompose';
 import ActionsPanel from 'src/components/ActionsPanel';
@@ -31,7 +32,11 @@ interface Props {
   category: string;
   currentUser: string;
   publicImages: Record<string, Image>;
-  request: StackScriptsRequest;
+  request: (
+    username: string,
+    params?: any,
+    filter?: any
+  ) => Promise<ResourcePage<StackScript>>;
 }
 
 type CombinedProps = Props & StateProps;

--- a/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptPanelContent.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptPanelContent.tsx
@@ -1,10 +1,8 @@
 import { Image } from '@linode/api-v4/lib/images';
 import {
   deleteStackScript,
-  StackScript,
   updateStackScript,
 } from '@linode/api-v4/lib/stackscripts';
-import { ResourcePage } from '@linode/api-v4/lib/types';
 import * as React from 'react';
 import { compose } from 'recompose';
 import ActionsPanel from 'src/components/ActionsPanel';
@@ -15,6 +13,7 @@ import StackScriptBase, {
   StateProps,
 } from '../StackScriptBase/StackScriptBase';
 import StackScriptsSection from './StackScriptsSection';
+import { StackScriptsRequest } from 'src/features/StackScripts/types';
 
 interface DialogVariantProps {
   open: boolean;
@@ -32,11 +31,7 @@ interface Props {
   category: string;
   currentUser: string;
   publicImages: Record<string, Image>;
-  request: (
-    username: string,
-    params?: any,
-    filter?: any
-  ) => Promise<ResourcePage<StackScript>>;
+  request: StackScriptsRequest;
 }
 
 type CombinedProps = Props & StateProps;

--- a/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptPanelContent.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptPanelContent.tsx
@@ -1,10 +1,9 @@
 import { Image } from '@linode/api-v4/lib/images';
 import {
   deleteStackScript,
-  StackScript,
   updateStackScript,
+  StackScriptsRequest,
 } from '@linode/api-v4/lib/stackscripts';
-import { ResourcePage } from '@linode/api-v4/lib/types';
 import * as React from 'react';
 import { compose } from 'recompose';
 import ActionsPanel from 'src/components/ActionsPanel';
@@ -32,11 +31,7 @@ interface Props {
   category: string;
   currentUser: string;
   publicImages: Record<string, Image>;
-  request: (
-    username: string,
-    params?: any,
-    filter?: any
-  ) => Promise<ResourcePage<StackScript>>;
+  request: StackScriptsRequest;
 }
 
 type CombinedProps = Props & StateProps;

--- a/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptRow.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptRow.tsx
@@ -55,6 +55,8 @@ export const StackScriptRow: React.FC<CombinedProps> = (props) => {
     canAddLinodes,
   } = props;
 
+  const communityStackScript = category === 'community';
+
   const renderLabel = () => {
     return (
       <React.Fragment>
@@ -93,11 +95,13 @@ export const StackScriptRow: React.FC<CombinedProps> = (props) => {
           {displayTagsAndShowMore(images)}
         </TableCell>
       </Hidden>
-      <Hidden mdDown>
-        <TableCell data-qa-stackscript-status>
-          {isPublic ? 'Public' : 'Private'}
-        </TableCell>
-      </Hidden>
+      {communityStackScript ? null : ( // We hide the "Status" column in the "Community StackScripts" tab of the StackScripts landing page since all of those are public.
+        <Hidden mdDown>
+          <TableCell data-qa-stackscript-status>
+            {isPublic ? 'Public' : 'Private'}
+          </TableCell>
+        </Hidden>
+      )}
       <TableCell>
         <StackScriptsActionMenu
           stackScriptID={stackScriptID}

--- a/packages/manager/src/features/StackScripts/stackScriptUtils.ts
+++ b/packages/manager/src/features/StackScripts/stackScriptUtils.ts
@@ -5,6 +5,7 @@ import {
   StackScript,
 } from '@linode/api-v4/lib/stackscripts';
 import { ResourcePage } from '@linode/api-v4/lib/types';
+import { StackScriptsRequest } from './types';
 
 export type StackScriptCategory = 'account' | 'community';
 
@@ -90,7 +91,7 @@ const oneClickFilter = [
 export const getOneClickApps = (params?: any) =>
   getStackScripts(params, oneClickFilter);
 
-export const getStackScriptsByUser = (
+export const getStackScriptsByUser: StackScriptsRequest = (
   username: string,
   params?: any,
   filter?: any
@@ -100,7 +101,7 @@ export const getStackScriptsByUser = (
     username,
   });
 
-export const getMineAndAccountStackScripts = (
+export const getMineAndAccountStackScripts: StackScriptsRequest = (
   currentUser: string,
   params?: any,
   filter?: any,
@@ -165,7 +166,7 @@ export const getMineAndAccountStackScripts = (
  * Gets all StackScripts that don't belong to user "Linode"
  * and do not belong to any users on the current account
  */
-export const getCommunityStackscripts = (
+export const getCommunityStackscripts: StackScriptsRequest = (
   currentUser: string,
   params?: any,
   filter?: any,

--- a/packages/manager/src/features/StackScripts/types.ts
+++ b/packages/manager/src/features/StackScripts/types.ts
@@ -1,0 +1,10 @@
+import { Grant } from '@linode/api-v4/lib/account';
+import { ResourcePage } from '@linode/api-v4/lib/types';
+import { StackScript } from '@linode/api-v4/lib/stackscripts';
+
+export type StackScriptsRequest = (
+  username: string,
+  params?: unknown,
+  filter?: unknown,
+  stackScriptGrants?: Grant[]
+) => Promise<ResourcePage<StackScript>>;

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -1,8 +1,7 @@
+import { Grant } from '@linode/api-v4/lib/account';
 import { Image } from '@linode/api-v4/lib/images';
-import {
-  UserDefinedField,
-  StackScriptsRequest,
-} from '@linode/api-v4/lib/stackscripts';
+import { StackScript, UserDefinedField } from '@linode/api-v4/lib/stackscripts';
+import { ResourcePage } from '@linode/api-v4/lib/types';
 import { assocPath } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
@@ -52,7 +51,12 @@ const styles = (theme: Theme) =>
   });
 
 interface Props {
-  request: StackScriptsRequest;
+  request: (
+    username: string,
+    params?: any,
+    filter?: any,
+    stackScriptGrants?: Grant[]
+  ) => Promise<ResourcePage<StackScript>>;
   header: string;
   category: 'community' | 'account';
 }

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -1,7 +1,5 @@
-import { Grant } from '@linode/api-v4/lib/account';
 import { Image } from '@linode/api-v4/lib/images';
-import { StackScript, UserDefinedField } from '@linode/api-v4/lib/stackscripts';
-import { ResourcePage } from '@linode/api-v4/lib/types';
+import { UserDefinedField } from '@linode/api-v4/lib/stackscripts';
 import { assocPath } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
@@ -22,6 +20,7 @@ import withFeatureFlags, {
 import SelectStackScriptPanel from 'src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel';
 import SelectStackScriptPanel_CMR from 'src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel_CMR';
 import StackScriptDrawer from 'src/features/StackScripts/StackScriptDrawer';
+import { StackScriptsRequest } from 'src/features/StackScripts/types';
 import UserDefinedFieldsPanel from 'src/features/StackScripts/UserDefinedFieldsPanel';
 import { filterImagesByType } from 'src/store/image/image.helpers';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
@@ -51,12 +50,7 @@ const styles = (theme: Theme) =>
   });
 
 interface Props {
-  request: (
-    username: string,
-    params?: any,
-    filter?: any,
-    stackScriptGrants?: Grant[]
-  ) => Promise<ResourcePage<StackScript>>;
+  request: StackScriptsRequest;
   header: string;
   category: 'community' | 'account';
 }

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -1,7 +1,8 @@
-import { Grant } from '@linode/api-v4/lib/account';
 import { Image } from '@linode/api-v4/lib/images';
-import { StackScript, UserDefinedField } from '@linode/api-v4/lib/stackscripts';
-import { ResourcePage } from '@linode/api-v4/lib/types';
+import {
+  UserDefinedField,
+  StackScriptsRequest,
+} from '@linode/api-v4/lib/stackscripts';
 import { assocPath } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
@@ -51,12 +52,7 @@ const styles = (theme: Theme) =>
   });
 
 interface Props {
-  request: (
-    username: string,
-    params?: any,
-    filter?: any,
-    stackScriptGrants?: Grant[]
-  ) => Promise<ResourcePage<StackScript>>;
+  request: StackScriptsRequest;
   header: string;
   category: 'community' | 'account';
 }


### PR DESCRIPTION
## Description
Since Community StackScripts are all public, this removes the "Status" column from the table on the Community StackScripts tab on the StackScripts landing page.

Areas elsewhere in the app where StackScripts appear (Create flow; Rebuild, etc. from Community StackScript; etc.) should be unaffected.

## Type of Change
- Non breaking change ('update', 'change')

