### PR TITLE
M3-4939: Configurations table revamp

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/ConfigRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/ConfigRow.tsx
@@ -149,13 +149,9 @@ export const ConfigRow: React.FC<CombinedProps> = (props) => {
       key={config.id}
       data-qa-config={config.label}
     >
-      <TableCell>{config.label}</TableCell>
       <TableCell>
-        {config.virt_mode === 'fullvirt'
-          ? 'Full virtualization'
-          : 'Paravirtualization'}
+        {config.label} – {linodeKernel}
       </TableCell>
-      <TableCell>{linodeKernel}</TableCell>
       <TableCell>{deviceLabels}</TableCell>
       {vlansEnabled ? (
         <TableCell>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs.tsx
@@ -94,20 +94,13 @@ const styles = (theme: Theme) =>
     },
     labelColumn: {
       ...theme.applyTableHeaderStyles,
-      width: '18%',
-    },
-    vmColumn: {
-      ...theme.applyTableHeaderStyles,
-      width: '10%',
-    },
-    kernelColumn: {
-      width: '23%',
+      width: '35%',
     },
     interfacesColumn: {
-      width: '20%',
+      width: '30%',
     },
     deviceColumn: {
-      width: '20%',
+      width: '25%',
     },
     actionsColumn: {
       width: '10%',
@@ -504,24 +497,8 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
                           data-qa-config-label-header
                           className={classes.labelColumn}
                         >
-                          <strong>Label</strong>
+                          <strong>Config</strong>
                         </TableSortCell>
-                        <TableSortCell
-                          active={orderBy === 'virt_mode'}
-                          label={'virt_mode'}
-                          direction={order}
-                          handleClick={handleOrderChange}
-                          data-qa-virt-mode-header
-                          className={classes.vmColumn}
-                        >
-                          <strong>VM Mode</strong>
-                        </TableSortCell>
-                        <TableCell
-                          className={`${classes.tableCell} ${classes.kernelColumn}`}
-                        >
-                          Kernel
-                        </TableCell>
-
                         <TableCell
                           className={`${classes.tableCell} ${classes.deviceColumn}`}
                         >


### PR DESCRIPTION
## Description
- Remove `VM Mode` and `Kernel` columns from Configurations table
- Rename `Label` column to `Config` and add kernel after the label
- Adjustments to column widths since there are fewer columns now

## Type of Change
- Non breaking change ('update', 'change')
