### PR TITLE
Change: Don't mark notifications read when closing drawer

### DIFF
--- a/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
@@ -2,7 +2,6 @@ import { Notification, NotificationSeverity } from '@linode/api-v4/lib/account';
 import { DateTime } from 'luxon';
 import { path } from 'ramda';
 import * as React from 'react';
-import useDismissibleNotifications from 'src/hooks/useDismissibleNotifications';
 import useNotifications from 'src/hooks/useNotifications';
 import { notificationContext } from '../NotificationContext';
 import { NotificationItem } from '../NotificationSection';
@@ -11,17 +10,12 @@ import RenderNotification from './RenderNotification';
 
 export const useFormattedNotifications = (): NotificationItem[] => {
   const context = React.useContext(notificationContext);
-  const {
-    dismissNotifications,
-    hasDismissedNotifications,
-  } = useDismissibleNotifications();
 
   const notifications = useNotifications();
 
   const dayOfMonth = DateTime.local().day;
 
   const handleClose = () => {
-    dismissNotifications(notifications);
     context.closeDrawer();
   };
 
@@ -40,8 +34,7 @@ export const useFormattedNotifications = (): NotificationItem[] => {
       formatNotificationForDisplay(
         interceptNotification(notification),
         idx,
-        handleClose,
-        !hasDismissedNotifications([notification])
+        handleClose
       )
     );
 };

--- a/packages/manager/src/features/NotificationCenter/NotificationDrawer.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationDrawer.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { useDispatch } from 'react-redux';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Drawer from 'src/components/Drawer';
-import useDismissibleNotifications from 'src/hooks/useDismissibleNotifications';
 import useNotifications from 'src/hooks/useNotifications';
 import usePrevious from 'src/hooks/usePrevious';
 import { markAllSeen } from 'src/store/events/event.request';
@@ -44,7 +43,6 @@ interface Props {
 export const NotificationDrawer: React.FC<Props> = (props) => {
   const { data, open, onClose } = props;
   const classes = useStyles();
-  const { dismissNotifications } = useDismissibleNotifications();
   const notifications = useNotifications();
   const dispatch = useDispatch<ThunkDispatch>();
   const { eventNotifications, formattedNotifications } = data;
@@ -55,9 +53,8 @@ export const NotificationDrawer: React.FC<Props> = (props) => {
     if (wasOpen && !open) {
       // User has closed the drawer.
       dispatch(markAllSeen());
-      dismissNotifications(notifications);
     }
-  }, [dismissNotifications, notifications, dispatch, open, wasOpen]);
+  }, [notifications, dispatch, open, wasOpen]);
 
   return (
     <Drawer open={open} onClose={onClose} title="" className={classes.root}>


### PR DESCRIPTION
## Description

For consideration by stakeholders, may or may not end up merging this. The badge count always reflects the current number of notifications, regardless of whether they've been dismissed. Closing the notification drawer no longer marks notifications as read.