### PR TITLE
Banner feedback

### DIFF
--- a/packages/manager/src/components/AbuseTicketBanner/AbuseTicketBanner.test.tsx
+++ b/packages/manager/src/components/AbuseTicketBanner/AbuseTicketBanner.test.tsx
@@ -21,6 +21,8 @@ const makeMockStore = (notifications: Notification[]) => {
   };
 };
 
+const TICKET_TESTID = 'abuse-ticket-link';
+
 describe('Abuse ticket banner', () => {
   it('should render a banner for an abuse ticket', () => {
     const { queryAllByText } = render(
@@ -40,21 +42,32 @@ describe('Abuse ticket banner', () => {
     expect(queryAllByText(/2 open abuse tickets/)).toHaveLength(1);
   });
 
-  it('should link to the ticket', () => {
+  it('should link to the ticket if there is a single abuse ticket', () => {
     const mockAbuseTicket = abuseTicketNotificationFactory.build();
     const { getByTestId } = render(
       wrapWithTheme(<AbuseTicketBanner />, {
         customStore: makeMockStore([mockAbuseTicket]),
       })
     );
-    const link = getByTestId('abuse-ticket-link');
+    const link = getByTestId(TICKET_TESTID);
     expect(link).toHaveAttribute('href', mockAbuseTicket.entity!.url);
+  });
+
+  it('should link to the ticket list view if there are multiple tickets', () => {
+    const mockAbuseTicket = abuseTicketNotificationFactory.buildList(2);
+    const { getByTestId } = render(
+      wrapWithTheme(<AbuseTicketBanner />, {
+        customStore: makeMockStore(mockAbuseTicket),
+      })
+    );
+    const link = getByTestId(TICKET_TESTID);
+    expect(link).toHaveAttribute('href', '/support/tickets');
   });
 
   it('should return null if there are no abuse tickets', () => {
     const { queryByTestId } = render(wrapWithTheme(<AbuseTicketBanner />));
 
-    expect(queryByTestId('abuse-ticket-link')).toBeNull();
+    expect(queryByTestId(TICKET_TESTID)).toBeNull();
   });
 
   describe('integration tests', () => {

--- a/packages/manager/src/components/AbuseTicketBanner/AbuseTicketBanner.tsx
+++ b/packages/manager/src/components/AbuseTicketBanner/AbuseTicketBanner.tsx
@@ -41,7 +41,7 @@ export const AbuseTicketBanner: React.FC<{}> = (_) => {
     return null;
   }
 
-  const href = '/support/tickets';
+  const href = multiple ? '/support/tickets' : abuseTickets[0].entity.url;
   const isViewingTicket = location.pathname.match(href);
 
   return (

--- a/packages/manager/src/components/AbuseTicketBanner/AbuseTicketBanner.tsx
+++ b/packages/manager/src/components/AbuseTicketBanner/AbuseTicketBanner.tsx
@@ -41,11 +41,7 @@ export const AbuseTicketBanner: React.FC<{}> = (_) => {
     return null;
   }
 
-  /**
-   * The ticket list page doesn't indicate which tickets are abuse tickets
-   * so for now, the link can just take the user to the first ticket.
-   */
-  const href = abuseTickets[0].entity!.url;
+  const href = '/support/tickets';
   const isViewingTicket = location.pathname.match(href);
 
   return (

--- a/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
@@ -21,7 +21,7 @@ export const useFormattedNotifications = (): NotificationItem[] => {
   const dayOfMonth = DateTime.local().day;
 
   const handleClose = () => {
-    dismissNotifications(notifications);
+    dismissNotifications(notifications, 'notificationDrawer');
     context.closeDrawer();
   };
 
@@ -41,7 +41,7 @@ export const useFormattedNotifications = (): NotificationItem[] => {
         interceptNotification(notification),
         idx,
         handleClose,
-        !hasDismissedNotifications([notification])
+        !hasDismissedNotifications([notification], 'notificationDrawer')
       )
     );
 };

--- a/packages/manager/src/features/NotificationCenter/NotificationDrawer.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationDrawer.tsx
@@ -55,7 +55,7 @@ export const NotificationDrawer: React.FC<Props> = (props) => {
     if (wasOpen && !open) {
       // User has closed the drawer.
       dispatch(markAllSeen());
-      dismissNotifications(notifications);
+      dismissNotifications(notifications, 'notificationDrawer');
     }
   }, [dismissNotifications, notifications, dispatch, open, wasOpen]);
 

--- a/packages/manager/src/hooks/useDismissibleNotifications.ts
+++ b/packages/manager/src/hooks/useDismissibleNotifications.ts
@@ -1,14 +1,29 @@
-import { Notification } from '@linode/api-v4/lib/account/types';
 import { DateTime } from 'luxon';
 import * as md5 from 'md5';
 import { useState } from 'react';
 import { usePreferences } from 'src/hooks/usePreferences';
 import { DismissedNotification } from 'src/store/preferences/preferences.actions';
 
+/**
+ * Handlers for dismissing notifications and checking if a notification has been dismissed.
+ *
+ * Notifications don't exist as entities in our API, so this is a workaround using the user
+ * preferences endpoint.
+ *
+ * Any unique value can be used as a key, which will be passed through JSON.stringify and md5
+ * to generate a unique hash for the notification. In the case of actual Notifications, we use
+ * the full notification object, which is usually (but not guaranteed to be in all cases) unique.
+ *
+ * The optional prefix prop allows you to specify a random string to be used as a prefix when generating
+ * the hash. The purpose of this is to dismiss the same notification in different contexts independently.
+ */
 export interface DismissibleNotificationsHook {
   dismissedNotifications: Record<string, DismissedNotification>;
-  hasDismissedNotifications: (notifications: Notification[]) => boolean;
-  dismissNotifications: (notifications: Notification[]) => void;
+  hasDismissedNotifications: (
+    notifications: unknown[],
+    prefix?: string
+  ) => boolean;
+  dismissNotifications: (notifications: unknown[], prefix?: string) => void;
 }
 
 export const useDismissibleNotifications = (): DismissibleNotificationsHook => {
@@ -17,22 +32,26 @@ export const useDismissibleNotifications = (): DismissibleNotificationsHook => {
 
   const dismissedNotifications = preferences?.dismissed_notifications ?? {};
 
-  const dismissNotifications = (_notifications: Notification[]) => {
+  const dismissNotifications = (_notifications: unknown[], prefix?: string) => {
     setDismissed(true);
     updatePreferences({
       dismissed_notifications: updateDismissedNotifications(
         dismissedNotifications,
-        _notifications
+        _notifications,
+        prefix
       ),
     });
   };
 
-  const hasDismissedNotifications = (_notifications: Notification[]) => {
+  const hasDismissedNotifications = (
+    _notifications: unknown[],
+    prefix?: string
+  ) => {
     if (dismissed) {
       return true;
     }
     return _notifications.every((thisNotification) => {
-      const hashKey = getHashKey(thisNotification);
+      const hashKey = getHashKey(thisNotification, prefix);
       return Boolean(dismissedNotifications[hashKey]);
     });
   };
@@ -44,8 +63,8 @@ export const useDismissibleNotifications = (): DismissibleNotificationsHook => {
   };
 };
 
-const getHashKey = (notification: Notification) =>
-  md5(JSON.stringify(notification));
+const getHashKey = (notification: unknown, prefix: string = '') =>
+  md5(prefix + JSON.stringify(notification));
 
 /**
  * Does two things:
@@ -58,11 +77,12 @@ const getHashKey = (notification: Notification) =>
  */
 const updateDismissedNotifications = (
   notifications: Record<string, DismissedNotification>,
-  notificationsToDismiss: Notification[]
+  notificationsToDismiss: unknown[],
+  prefix?: string
 ) => {
   const newNotifications = {};
   notificationsToDismiss.forEach((thisNotification) => {
-    const hashKey = getHashKey(thisNotification);
+    const hashKey = getHashKey(thisNotification, prefix);
     newNotifications[hashKey] = {
       id: hashKey,
       created: DateTime.utc().toLocaleString(),


### PR DESCRIPTION
## Description

Some changes to the banner pattern after previewing it to Chris:

- The toggles in /profile/preferences won't be implemented
- Clicking the link in the abuse ticket banner takes you to the tickets landing page
- Dismissing notifications via the drawer is handled separately from the banner, so if you dismiss the banner the badge count is unchanged, and if you close the drawer the badge count is cleared but the banner still appears. If the user clears it both ways, we're fine with having no visual indication that abuse tickets are still open.
