### PR TITLE
M3-4941: Attach a VLAN section in Linode Create flow

### DIFF
--- a/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
@@ -8,10 +8,7 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Currency from 'src/components/Currency';
 import Grid from 'src/components/Grid';
-import useAccount from 'src/hooks/useAccount';
-import useFlags from 'src/hooks/useFlags';
-import SelectVLAN from './SelectVLAN';
-import { isFeatureEnabled } from 'src/utilities/accountCapabilities';
+import AttachVLAN from './AttachVLAN';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -88,32 +85,9 @@ interface Props {
 
 type CombinedProps = Props;
 const AddonsPanel: React.FC<CombinedProps> = (props) => {
-  const {
-    accountBackups,
-    changeBackups,
-    changePrivateIP,
-    changeSelectedVLAN,
-    vlanError,
-    disabled,
-  } = props;
-
-  const flags = useFlags();
-  const { account } = useAccount();
-
-  const handleVlanChange = React.useCallback(
-    (vlans: number[]) => {
-      changeSelectedVLAN(vlans);
-    },
-    [changeSelectedVLAN]
-  );
+  const { accountBackups, changeBackups, changePrivateIP, disabled } = props;
 
   const classes = useStyles();
-
-  const showVlans = isFeatureEnabled(
-    'Vlans',
-    Boolean(flags.vlans),
-    account?.data?.capabilities ?? []
-  );
 
   const renderBackupsPrice = () => {
     const { backupsMonthly } = props;
@@ -131,6 +105,7 @@ const AddonsPanel: React.FC<CombinedProps> = (props) => {
   return (
     <Paper className={classes.root} data-qa-add-ons>
       <div className={classes.inner}>
+        <AttachVLAN />
         <Typography variant="h2" className={classes.title}>
           Optional Add-ons
         </Typography>
@@ -199,21 +174,6 @@ const AddonsPanel: React.FC<CombinedProps> = (props) => {
             </React.Fragment>
           )
         }
-        {flags.cmr && showVlans ? (
-          <Grid container className={classes.lastItem}>
-            <Grid item xs={12}>
-              <Divider className={classes.divider} />
-            </Grid>
-            <div className={classes.vlanSelect}>
-              <SelectVLAN
-                selectedRegionID={props.selectedRegionID}
-                selectedVlanIDs={props.selectedVlanIDs}
-                handleSelectVLAN={handleVlanChange}
-                error={vlanError}
-              />
-            </div>
-          </Grid>
-        ) : null}
       </div>
     </Paper>
   );

--- a/packages/manager/src/features/linodes/LinodesCreate/AttachVLAN.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/AttachVLAN.tsx
@@ -1,0 +1,142 @@
+import { Interface } from '@linode/api-v4/lib/linodes';
+import { APIError } from '@linode/api-v4/lib/types';
+import { useFormik } from 'formik';
+import * as React from 'react';
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+import Grid from 'src/components/Grid';
+import {
+  handleFieldErrors,
+  handleGeneralErrors,
+} from 'src/utilities/formikErrorUtils';
+import InterfaceSelect from '../LinodesDetail/LinodeSettings/InterfaceSelect';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    paddingBottom: theme.spacing(3),
+  },
+  title: {
+    marginBottom: theme.spacing(2),
+  },
+  actions: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+  },
+}));
+
+interface Props {}
+
+type CombinedProps = Props;
+
+const defaultInterface = {
+  purpose: 'vlan',
+  label: '',
+  ipam_address: '',
+};
+
+interface EditableFields {
+  label: string;
+  ipam_address?: string;
+}
+
+const AttachVLAN: React.FC<CombinedProps> = (props) => {
+  const classes = useStyles();
+
+  const { values, setFieldValue, ...formik } = useFormik({
+    initialValues: defaultInterface,
+    validateOnChange: true,
+    validateOnMount: true,
+    onSubmit: (values) => onSubmit(values),
+  });
+
+  const handleInterfaceChange = React.useCallback(
+    (slot: number, updatedInterface: Interface) => {
+      setFieldValue(`interfaces[${slot}]`, updatedInterface);
+    },
+    [setFieldValue]
+  );
+
+  const onSubmit = (values: EditableFields) => {
+    // const { linodeConfigId, createLinodeConfig, updateLinodeConfig } = props;
+
+    formik.setSubmitting(true);
+
+    // const configData = convertStateToData(values);
+    const data = values;
+
+    alert(JSON.stringify(values));
+
+    const handleSuccess = () => {
+      formik.setSubmitting(false);
+      console.log('VLAN attached successfully');
+    };
+
+    const handleError = (error: APIError[]) => {
+      const mapErrorToStatus = (generalError: string) =>
+        formik.setStatus({ generalError });
+      formik.setSubmitting(false);
+      handleFieldErrors(formik.setErrors, error);
+      handleGeneralErrors(
+        mapErrorToStatus,
+        error,
+        'An unexpected error occurred.'
+      );
+      // scrollErrorIntoView('linode-config-dialog');
+    };
+
+    /** Creating */
+    // return createLinodeConfig(configData)
+    //   .then(handleSuccess)
+    //   .catch(handleError);
+  };
+
+  return (
+    <div className={classes.root}>
+      <Typography variant="h2" className={classes.title}>
+        Attach a VLAN
+      </Typography>
+      <Grid container>
+        <Grid item xs={12}>
+          <Typography variant="body1">
+            Helper text about VLANs.... eth0 is attached to the public Internet.
+            eth1 will be automatically assigned to it and editing can happen
+            from the Configurations tab
+          </Typography>
+          <InterfaceSelect
+            slotNumber={1}
+            readOnly={false}
+            error={formik.errors[`interfaces[1]`]}
+            label={values.label}
+            purpose="vlan"
+            ipamAddress={values.ipam_address}
+            handleChange={(newInterface: Interface) =>
+              handleInterfaceChange(1, newInterface)
+            }
+            fromAddonsPanel
+          />
+        </Grid>
+      </Grid>
+      <ActionsPanel className={classes.actions}>
+        <Button
+          disabled={formik.isSubmitting}
+          onClick={() => console.log('Cancel Attach VLAN')}
+          loading={formik.isSubmitting}
+          buttonType="cancel"
+        >
+          Cancel
+        </Button>
+        <Button
+          onClick={formik.submitForm}
+          loading={formik.isSubmitting}
+          buttonType="primary"
+        >
+          Attach VLAN
+        </Button>
+      </ActionsPanel>
+    </div>
+  );
+};
+
+export default React.memo(AttachVLAN);

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/ConfigRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/ConfigRow.tsx
@@ -1,4 +1,4 @@
-import { Config, Disk, InterfaceBody } from '@linode/api-v4/lib/linodes';
+import { Config, Disk, Interface } from '@linode/api-v4/lib/linodes';
 import { Volume } from '@linode/api-v4/lib/volumes';
 import { isEmpty } from 'ramda';
 import * as React from 'react';
@@ -159,7 +159,7 @@ export const ConfigRow: React.FC<CombinedProps> = (props) => {
 export default React.memo(ConfigRow);
 
 export const getInterfaceLabel = (
-  configInterface: InterfaceBody,
+  configInterface: Interface,
   hasPrivateIP: boolean
 ): string => {
   if (configInterface.purpose === 'public') {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
@@ -13,6 +13,7 @@ export interface Props {
   readOnly: boolean;
   error?: string;
   handleChange: (updatedInterface: ExtendedInterface) => void;
+  fromAddonsPanel?: boolean;
 }
 
 // To allow for empty slots, which the API doesn't account for
@@ -30,6 +31,7 @@ export const InterfaceSelect: React.FC<Props> = (props) => {
     label,
     ipamAddress,
     handleChange,
+    fromAddonsPanel,
   } = props;
 
   const purposeOptions: Item<ExtendedPurpose>[] = [
@@ -67,23 +69,25 @@ export const InterfaceSelect: React.FC<Props> = (props) => {
 
   return (
     <Grid container>
-      <Grid item xs={6}>
-        <Select
-          options={purposeOptions}
-          label={`eth${slotNumber}`}
-          defaultValue={purposeOptions.find(
-            (thisOption) => thisOption.value === purpose
-          )}
-          onChange={handlePurposeChange}
-          onCreate
-          disabled={readOnly}
-          isClearable={false}
-        />
-      </Grid>
+      {fromAddonsPanel ? null : (
+        <Grid item xs={6}>
+          <Select
+            options={purposeOptions}
+            label={`eth${slotNumber}`}
+            defaultValue={purposeOptions.find(
+              (thisOption) => thisOption.value === purpose
+            )}
+            onChange={handlePurposeChange}
+            onCreate
+            disabled={readOnly}
+            isClearable={false}
+          />
+        </Grid>
+      )}
       {purpose === 'vlan' ? (
         <Grid item xs={6}>
-          <Grid container direction="column">
-            <Grid item>
+          <Grid container direction={fromAddonsPanel ? 'row' : 'column'}>
+            <Grid item xs={fromAddonsPanel ? 6 : undefined}>
               <Select
                 errorText={error}
                 options={vlanOptions}
@@ -99,9 +103,9 @@ export const InterfaceSelect: React.FC<Props> = (props) => {
                 isClearable={false}
               />
             </Grid>
-            <Grid item>
+            <Grid item xs={fromAddonsPanel ? 6 : undefined}>
               <TextField
-                label="IPAM Address (optional)"
+                label="IPAM Address (Optional)"
                 value={ipamAddress}
                 onChange={handleAddressChange}
               />

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -301,7 +301,7 @@ export const handlers = [
     return res(ctx.json(makeResourcePage(volumes)));
   }),
   rest.get('*/vlans', (req, res, ctx) => {
-    const vlans = VLANFactory.buildList(0);
+    const vlans = VLANFactory.buildList(2);
     return res(ctx.json(makeResourcePage(vlans)));
   }),
   rest.get('*/profile/preferences', (req, res, ctx) => {


### PR DESCRIPTION
## Description
Create new `AttachVLAN` component that uses `InterfaceSelect.tsx` and appears above the Add-ons in the Linode Create flow

## Type of Change
- Non breaking change ('update', 'change')

## To-Do:
- [ ] Include VLAN data w/ Linode creation payload (as opposed to the "Attach VLAN" button in the designs)
- [ ] Helper text
