### PR TITLE
Pass default values to formik.resetForm

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -151,7 +151,7 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
   const classes = useStyles();
   const [counter, setCounter] = React.useState(1);
 
-  const { values, ...formik } = useFormik({
+  const { values, resetForm, ...formik } = useFormik({
     initialValues: defaultFieldsValues,
     validateOnChange: true,
     validateOnMount: true,
@@ -244,7 +244,7 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
         const devices = createStringsFromDevices(config.devices);
         const initialCounter = Object.keys(devices).length;
         setCounter(initialCounter);
-        formik.resetForm({
+        resetForm({
           values: {
             useCustomRoot: isUsingCustomRoot(config.root_device),
             label: config.label,
@@ -262,10 +262,10 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
         });
       } else {
         // Create mode; make sure loading/error states are cleared.
-        formik.resetForm();
+        resetForm({ values: defaultFieldsValues });
       }
     }
-  }, [open, config]);
+  }, [open, config, resetForm]);
 
   const isLoading = props.kernelsLoading;
 


### PR DESCRIPTION
## Description

Apparently calling `formik.resetForm()` does not, in fact, reset the form.

To test:

1. create a config
2. edit it and change some things
3. go to create a new config
4. the inputs from editing are still there