### PR TITLE
M3-4971: Prevent wrapping of Linode Detail graph legends

### DIFF
--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -320,7 +320,7 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
                 const { data: metricsData, format } = legendRows[idx];
                 return (
                   <TableRow key={idx}>
-                    <TableCell className={classes.legend}>
+                    <TableCell className={classes.legend} noWrap>
                       <Button
                         onClick={() => handleLegendClick(idx)}
                         data-qa-legend-title

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -71,7 +71,7 @@ const styles = (theme: Theme) =>
     graphGrids: {
       flexWrap: 'nowrap',
       margin: 0,
-      [theme.breakpoints.down('sm')]: {
+      [theme.breakpoints.down('md')]: {
         flexWrap: 'wrap',
       },
     },

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph.tsx
@@ -38,7 +38,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   graphGrids: {
     flexWrap: 'nowrap',
     paddingLeft: '8px',
-    [theme.breakpoints.down('sm')]: {
+    [theme.breakpoints.down('md')]: {
       flexWrap: 'wrap',
     },
   },


### PR DESCRIPTION
## Description
Aiming to prevent the wrapping of Linode Detail graph legends. This approach adds the `noWrap` prop to the `<TableCell />` the legend keys are rendered in, which seems to fix the issue while not causing any adverse effects where the `LineGraph` component is used elsewhere (Longview, etc.)

Before (this can currently be seen as you shrink to around the tablet view, let's say ~1080px width):
<img width="436" alt="Screen Shot 2021-03-17 at 2 09 10 PM" src="https://user-images.githubusercontent.com/32860776/111523730-02cc7380-8732-11eb-9283-b98afa101dad.png">

After:
<img width="436" alt="Screen Shot 2021-03-17 at 2 09 28 PM" src="https://user-images.githubusercontent.com/32860776/111523750-07912780-8732-11eb-8d75-39760c0e36e1.png">

## Type of Change
- Non breaking change ('update', 'change')
