### PR TITLE
M3-4948 Fix: Don't clear support modal contents from local storage on close

### DIFF
--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
@@ -305,7 +305,7 @@ export const SupportTicketDrawer: React.FC<CombinedProps> = (props) => {
 
   const onCancel = () => {
     props.onClose();
-    resetDrawer(true);
+    window.setTimeout(() => resetDrawer(true), 500);
   };
 
   const updateFiles = (newFiles: FileAttachment[]) => {
@@ -398,19 +398,17 @@ export const SupportTicketDrawer: React.FC<CombinedProps> = (props) => {
       .then((response) => {
         setErrors(undefined);
         setSubmitting(false);
-        resetDrawer(true);
+        window.setTimeout(() => resetDrawer(true), 500);
         return response;
       })
       .then((response) => {
-        attachFiles(response!.id).then(
-          ({ success, errors: _errors }: Accumulator) => {
-            if (!props.keepOpenOnSuccess) {
-              close();
-            }
-            /* Errors will be an array of errors, or empty if all attachments succeeded. */
-            onSuccess(response!.id, _errors);
+        attachFiles(response!.id).then(({ errors: _errors }: Accumulator) => {
+          if (!props.keepOpenOnSuccess) {
+            close();
           }
-        );
+          /* Errors will be an array of errors, or empty if all attachments succeeded. */
+          onSuccess(response!.id, _errors);
+        });
       })
       .catch((errResponse) => {
         /* This block will only handle errors in creating the actual ticket; attachment

--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
@@ -398,7 +398,7 @@ export const SupportTicketDrawer: React.FC<CombinedProps> = (props) => {
       .then((response) => {
         setErrors(undefined);
         setSubmitting(false);
-        resetTicket();
+        resetDrawer(true);
         return response;
       })
       .then((response) => {

--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
@@ -301,6 +301,10 @@ export const SupportTicketDrawer: React.FC<CombinedProps> = (props) => {
 
   const close = () => {
     props.onClose();
+  };
+
+  const onCancel = () => {
+    props.onClose();
     resetDrawer(true);
   };
 
@@ -551,7 +555,7 @@ export const SupportTicketDrawer: React.FC<CombinedProps> = (props) => {
               Open Ticket
             </Button>
             <Button
-              onClick={close}
+              onClick={onCancel}
               buttonType="secondary"
               className="cancel"
               data-qa-cancel


### PR DESCRIPTION
Use a separate onCancel handler for the support ticket modal's Cancel
button. If the user closes the modal by clicking outside it, hitting the X button,
or pressing ESC (most of these can be done accidentally), close the drawer but
don't clear the values from local storage. In this way, if the user opens the drawer
their contents are still present.

If the user explicitly hits the "Cancel" button, though, take this opportunity to
clear the contents. Contents will also clear when a ticket has been created successfully.

We can also consider disabling backdrop and escape click handlers for the support dialog (or any dialog, if accidental closures become annoying), it would be easy to do.