### PR TITLE
Demo feedback

### DIFF
--- a/packages/manager/src/components/AbuseTicketBanner/AbuseTicketBanner.tsx
+++ b/packages/manager/src/components/AbuseTicketBanner/AbuseTicketBanner.tsx
@@ -46,7 +46,7 @@ export const AbuseTicketBanner: React.FC<{}> = (_) => {
 
   return (
     <Grid item xs={12}>
-      <Notice important error dismissible onClose={onDismiss}>
+      <Notice important warning dismissible onClose={onDismiss}>
         <Typography>
           {message}
           {/** Don't link to /support/tickets if we're already on the landing page. */}

--- a/packages/manager/src/features/GlobalNotifications/EmailBounce.tsx
+++ b/packages/manager/src/features/GlobalNotifications/EmailBounce.tsx
@@ -143,7 +143,7 @@ const EmailBounceNotification: React.FC<CombinedProps> = React.memo((props) => {
   }
 
   return (
-    <Notice important error spacing={2}>
+    <Notice important warning spacing={2}>
       <Grid container alignItems="center">
         <Grid item xs={12} md={6} lg={8}>
           {text}

--- a/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
@@ -50,7 +50,9 @@ const interceptNotification = (notification: Notification): Notification => {
   if (notification.type === 'ticket_abuse') {
     return {
       ...notification,
-      message: notification.message.replace('!', '.'),
+      message: `${notification.message.replace('!', '')} (${
+        notification?.entity?.label
+      }): #${notification?.entity?.id}`,
     };
   }
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/MigrationNotification.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/MigrationNotification.tsx
@@ -9,6 +9,7 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Notice from 'src/components/Notice';
 import { useDialog } from 'src/hooks/useDialog';
+import { capitalize } from 'src/utilities/capitalize';
 
 const useStyles = makeStyles((theme: Theme) => ({
   migrationLink: {
@@ -90,13 +91,14 @@ const MigrationNotification: React.FC<Props> = (props) => {
       <Notice important warning>
         <Typography>
           {notificationMessage}
-          {` To ${migrationActionDescription}, please `}
+          {` `}
           <button
             className={classes.migrationLink}
             onClick={() => openDialog(linodeID)}
           >
-            click here.
+            {capitalize(migrationActionDescription)}
           </button>
+          .
         </Typography>
       </Notice>
       <ConfirmationDialog

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/MigrationNotification.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/MigrationNotification.tsx
@@ -82,7 +82,7 @@ const MigrationNotification: React.FC<Props> = (props) => {
 
   const migrationActionDescription =
     notificationType === 'migration_scheduled'
-      ? 'enter the migration queue right now'
+      ? 'enter the migration queue now'
       : 'schedule your migration';
 
   return (


### PR DESCRIPTION
## Description

Assorted items from demo prep this morning:

- M3-5017: Show IDs (and entity labels as a POC) for abuse ticket notifications in the drawer
- M3-5018: Remove "right" from "right now" in the migration banner/confirmation modal
- M3-????: Make the abuse ticket banner a warning not an error