### PR TITLE
Change: Make LKE upgrade banner dismissible

### DIFF
--- a/packages/manager/src/components/DismissibleBanner/DismissibleBanner.tsx
+++ b/packages/manager/src/components/DismissibleBanner/DismissibleBanner.tsx
@@ -2,8 +2,7 @@ import Close from '@material-ui/icons/Close';
 import * as React from 'react';
 import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
-import Typography from 'src/components/core/Typography';
-import usePreferences from 'src/hooks/usePreferences';
+import useDismissibleNotifications from 'src/hooks/useDismissibleNotifications';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -26,29 +25,29 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 interface Props {
   preferenceKey: string;
-  message: string;
+  children: JSX.Element;
   className?: string;
 }
 
 export const DismissibleBanner: React.FC<Props> = (props) => {
-  const { className, message, preferenceKey } = props;
-  const { preferences, updatePreferences } = usePreferences();
+  const { className, preferenceKey } = props;
+  const {
+    dismissNotifications,
+    hasDismissedNotifications,
+  } = useDismissibleNotifications();
   const classes = useStyles();
 
-  const [hidden, setHidden] = React.useState(false);
-
-  if (hidden || preferences?.[preferenceKey]) {
+  if (hasDismissedNotifications([preferenceKey])) {
     return null;
   }
 
   const handleDismiss = () => {
-    setHidden(true);
-    updatePreferences({ [preferenceKey]: true });
+    dismissNotifications([preferenceKey]);
   };
 
   return (
     <Paper className={`${classes.root} ${className || ''}`}>
-      <Typography className={classes.text}>{message}</Typography>
+      {props.children}
       <button
         aria-label={`Dismiss ${preferenceKey} banner`}
         className={classes.button}

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallBanner.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallBanner.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import Typography from 'src/components/core/Typography';
 import DismissibleBanner from 'src/components/DismissibleBanner';
 import { dcDisplayNames } from 'src/constants';
 import { useRegionsQuery } from 'src/queries/regions';
@@ -15,11 +16,12 @@ export const FirewallBanner: React.FC<{}> = (_) => {
   );
 
   return (
-    <DismissibleBanner
-      preferenceKey="firewall-beta-notification"
-      message={`Cloud Firewalls are currently in beta. Firewalls can
-        only be used with Linodes in ${regionDisplayList}.`}
-    />
+    <DismissibleBanner preferenceKey="firewall-beta-notification">
+      <Typography>
+        Cloud Firewalls are currently in beta. Firewalls can only be used with
+        Linodes in {regionDisplayList}.
+      </Typography>
+    </DismissibleBanner>
   );
 };
 

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeKubernetesVersionBanner.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeKubernetesVersionBanner.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import Button from 'src/components/Button';
-import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
+import DismissibleBanner from 'src/components/DismissibleBanner';
 import Grid from 'src/components/Grid';
 import { useKubernetesVersionQuery } from 'src/queries/kubernetesVersion';
 import { getNextVersion } from '../kubeUtils';
@@ -17,6 +17,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   upgradeMessage: {
     marginLeft: theme.spacing(),
+  },
+  upgradeButton: {
+    marginRight: theme.spacing(),
   },
 }));
 
@@ -39,7 +42,10 @@ export const UpgradeKubernetesVersionBanner: React.FC<Props> = (props) => {
   return (
     <>
       {nextVersion ? (
-        <Paper className={classes.root}>
+        <DismissibleBanner
+          className={classes.root}
+          preferenceKey={`${clusterID}-${currentVersion}`}
+        >
           <Grid
             container
             direction="row"
@@ -51,13 +57,13 @@ export const UpgradeKubernetesVersionBanner: React.FC<Props> = (props) => {
                 A new version of Kubernetes is available ({nextVersion}).
               </Typography>
             </Grid>
-            <Grid item>
+            <Grid item className={classes.upgradeButton}>
               <Button onClick={() => setDialogOpen(true)} buttonType="primary">
                 Upgrade Version
               </Button>
             </Grid>
           </Grid>
-        </Paper>
+        </DismissibleBanner>
       ) : null}
       <UpgradeVersionModal
         clusterID={clusterID}


### PR DESCRIPTION
## Description

Newest installment in "all banners should be dismissible: a continuing saga." LKE version upgrade banners are now dismissible, using the hooks from useDismissibleBanners. Once dismissed, they won't reappear until a new version of LKE is available.