### PR TITLE
VLAN assorted fixes

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
@@ -20,6 +20,7 @@ export interface Props {
   label: string;
   ipamAddress: string | null;
   readOnly: boolean;
+  region?: string;
   labelError?: string;
   ipamError?: string;
   handleChange: (updatedInterface: ExtendedInterface) => void;
@@ -42,6 +43,7 @@ export const InterfaceSelect: React.FC<Props> = (props) => {
     ipamAddress,
     ipamError,
     labelError,
+    region,
     handleChange,
   } = props;
 
@@ -64,10 +66,15 @@ export const InterfaceSelect: React.FC<Props> = (props) => {
 
   const { data: vlans, isLoading } = useVlansQuery();
   const vlanOptions =
-    vlans?.map((thisVlan) => ({
-      label: thisVlan.label,
-      value: thisVlan.label,
-    })) ?? [];
+    vlans
+      ?.filter((thisVlan) => {
+        // If a region is provided, only show VLANs in the target region as options
+        return region ? thisVlan.region === region : true;
+      })
+      .map((thisVlan) => ({
+        label: thisVlan.label,
+        value: thisVlan.label,
+      })) ?? [];
 
   const handlePurposeChange = (selected: Item<InterfacePurpose>) =>
     handleChange({ purpose: selected.value, label, ipam_address: ipamAddress });

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.test.tsx
@@ -1,0 +1,17 @@
+import { padList } from './LinodeConfigDialog';
+
+describe('LinodeConfigDialog', () => {
+  describe('padInterface helper method', () => {
+    it('should return a list of the correct length unchanged', () => {
+      expect(padList([1, 2, 3], 0, 3)).toEqual([1, 2, 3]);
+    });
+
+    it('should add the padder until the specified length is reached', () => {
+      expect(padList([1], 0, 5)).toEqual([1, 0, 0, 0, 0]);
+    });
+
+    it('should return a list longer than the limit unchanged', () => {
+      expect(padList([1, 2, 3, 4, 5], 0, 2)).toEqual([1, 2, 3, 4, 5]);
+    });
+  });
+});

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -121,11 +121,12 @@ const defaultInterface = {
  * interfaces will be removed from the payload before submission,
  * they are only used as placeholders presented to the user as empty selects.
  */
-const padInterfaceList = (
-  interfaces: ExtendedInterface[],
-  size: number = 3
-) => {
-  return [...interfaces, ...repeat(defaultInterface, size - interfaces.length)];
+export const padList = <T,>(list: T[], filler: T, size: number = 3): T[] => {
+  return [...list, ...repeat(filler, Math.max(0, size - list.length))];
+};
+
+const padInterfaceList = (interfaces: ExtendedInterface[]) => {
+  return padList<ExtendedInterface>(interfaces, defaultInterface, 3);
 };
 
 const defaultInterfaceList = padInterfaceList([


### PR DESCRIPTION
## Description

- Make interfaceSelect filterable by region (since vlans are region-limited)
- Make sure when loading a config for editing in the drawer that there are
enough empty interfaces (purpose === 'none') added to it to match the UI pattern.

