### PR TITLE
Patch/hide configs

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/ConfigRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/ConfigRow.tsx
@@ -101,7 +101,7 @@ export const ConfigRow: React.FC<CombinedProps> = (props) => {
 
   const InterfaceList = (
     <ul className={classes.interfaceList}>
-      {config.interfaces.map((interfaceEntry, idx) => {
+      {(config?.interfaces ?? []).map((interfaceEntry, idx) => {
         // The order of the config.interfaces array as returned by the API is significant.
         // Index 0 is eth0, index 1 is eth1, index 2 is eth2.
         const interfaceName = `eth${idx}`;

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/ConfigRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/ConfigRow.tsx
@@ -61,6 +61,7 @@ export const ConfigRow: React.FC<CombinedProps> = (props) => {
   } = props;
 
   const classes = useStyles();
+  const interfaces = config?.interfaces ?? [];
   const validDevices = React.useMemo(
     () =>
       Object.keys(config.devices)
@@ -101,7 +102,7 @@ export const ConfigRow: React.FC<CombinedProps> = (props) => {
 
   const InterfaceList = (
     <ul className={classes.interfaceList}>
-      {(config?.interfaces ?? []).map((interfaceEntry, idx) => {
+      {interfaces.map((interfaceEntry, idx) => {
         // The order of the config.interfaces array as returned by the API is significant.
         // Index 0 is eth0, index 1 is eth1, index 2 is eth2.
         const interfaceName = `eth${idx}`;
@@ -134,7 +135,7 @@ export const ConfigRow: React.FC<CombinedProps> = (props) => {
       </TableCell>
       <TableCell>{deviceLabels}</TableCell>
       <TableCell>
-        {!isEmpty(config.interfaces) ? InterfaceList : defaultInterfaceLabel}
+        {!isEmpty(interfaces) ? InterfaceList : defaultInterfaceLabel}
       </TableCell>
       <TableCell className={classes.actionInner}>
         <LinodeConfigActionMenu

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -166,7 +166,7 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
   const { account } = useAccount();
   const [deviceCounter, setDeviceCounter] = React.useState(1);
   const [useCustomRoot, setUseCustomRoot] = React.useState(
-    pathsOptions.some((thisOption) => thisOption.value === config?.root_device)
+    !pathsOptions.some((thisOption) => thisOption.value === config?.root_device)
   );
 
   const showVlans = isFeatureEnabled(
@@ -322,9 +322,16 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
     [setFieldValue]
   );
 
-  const handleToggleCustomRoot = React.useCallback(() => {
-    setUseCustomRoot((currentValue) => !currentValue);
-  }, [setUseCustomRoot]);
+  const handleToggleCustomRoot = React.useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setUseCustomRoot(e.target.checked);
+      if (!e.target.checked) {
+        // Toggling from custom to standard; reset any custom input
+        setFieldValue('root_device', pathsOptions[0].value);
+      }
+    },
+    [setUseCustomRoot, setFieldValue]
+  );
 
   const handleRootDeviceChange = React.useCallback(
     (selected: Item<string>) => {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -166,7 +166,7 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
   const { account } = useAccount();
   const [deviceCounter, setDeviceCounter] = React.useState(1);
   const [useCustomRoot, setUseCustomRoot] = React.useState(
-    !pathsOptions.some((thisOption) => thisOption.value === config?.root_device)
+    pathsOptions.some((thisOption) => thisOption.value === config?.root_device)
   );
 
   const showVlans = isFeatureEnabled(

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -165,6 +165,9 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
   const flags = useFlags();
   const { account } = useAccount();
   const [deviceCounter, setDeviceCounter] = React.useState(1);
+  const [useCustomRoot, setUseCustomRoot] = React.useState(
+    pathsOptions.some((thisOption) => thisOption.value === config?.root_device)
+  );
 
   const showVlans = isFeatureEnabled(
     'Vlans',
@@ -315,6 +318,17 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
   const handleInterfaceChange = React.useCallback(
     (slot: number, updatedInterface: Interface) => {
       setFieldValue(`interfaces[${slot}]`, updatedInterface);
+    },
+    [setFieldValue]
+  );
+
+  const handleToggleCustomRoot = React.useCallback(() => {
+    setUseCustomRoot((currentValue) => !currentValue);
+  }, [setUseCustomRoot]);
+
+  const handleRootDeviceChange = React.useCallback(
+    (selected: Item<string>) => {
+      setFieldValue('root_device', selected.value);
     },
     [setFieldValue]
   );
@@ -569,20 +583,20 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
                   name="useCustomRoot"
                   control={
                     <Toggle
-                      checked={values.useCustomRoot}
-                      onChange={formik.handleChange}
+                      checked={useCustomRoot}
+                      onChange={handleToggleCustomRoot}
                       disabled={readOnly}
                     />
                   }
                 />
-                {!values.useCustomRoot ? (
+                {!useCustomRoot ? (
                   <Select
                     options={pathsOptions}
                     label="Root Device"
-                    defaultValue={pathsOptions.find(
+                    value={pathsOptions.find(
                       (device) => device.value === values.root_device
                     )}
-                    onChange={formik.handleChange}
+                    onChange={handleRootDeviceChange}
                     name="root_device"
                     id="root_device"
                     errorText={formik.errors.root_device}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -164,9 +164,7 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
   const flags = useFlags();
   const { account } = useAccount();
   const [deviceCounter, setDeviceCounter] = React.useState(1);
-  const [useCustomRoot, setUseCustomRoot] = React.useState(
-    pathsOptions.some((thisOption) => thisOption.value === config?.root_device)
-  );
+  const [useCustomRoot, setUseCustomRoot] = React.useState(false);
 
   // Making this an && instead of the usual hasFeatureEnabled, which is || based.
   // Doing this so that we can toggle our flag without enabling vlans for all customers.
@@ -261,6 +259,11 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
         const devices = createStringsFromDevices(config.devices);
         const initialCounter = Object.keys(devices).length;
         setDeviceCounter(initialCounter);
+        setUseCustomRoot(
+          !pathsOptions.some(
+            (thisOption) => thisOption.value === config?.root_device
+          )
+        );
         resetForm({
           values: {
             useCustomRoot: isUsingCustomRoot(config.root_device),
@@ -281,6 +284,7 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
       } else {
         // Create mode; make sure loading/error states are cleared.
         resetForm({ values: defaultFieldsValues });
+        setUseCustomRoot(false);
       }
     }
   }, [open, config, resetForm]);

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -34,7 +34,6 @@ import DeviceSelection, {
 import useAccount from 'src/hooks/useAccount';
 import useFlags from 'src/hooks/useFlags';
 import { ApplicationState } from 'src/store';
-import { isFeatureEnabled } from 'src/utilities/accountCapabilities';
 import createDevicesFromStrings, {
   DevicesAsStrings,
 } from 'src/utilities/createDevicesFromStrings';
@@ -169,11 +168,10 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
     pathsOptions.some((thisOption) => thisOption.value === config?.root_device)
   );
 
-  const showVlans = isFeatureEnabled(
-    'Vlans',
-    Boolean(flags.vlans),
-    account?.data?.capabilities ?? []
-  );
+  // Making this an && instead of the usual hasFeatureEnabled, which is || based.
+  // Doing this so that we can toggle our flag without enabling vlans for all customers.
+  const capabilities = account?.data?.capabilities ?? [];
+  const showVlans = capabilities.includes('Vlans') && flags.vlans;
 
   const { values, resetForm, setFieldValue, ...formik } = useFormik({
     initialValues: defaultFieldsValues,

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -275,7 +275,7 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
             virt_mode: config.virt_mode,
             helpers: config.helpers,
             root_device: config.root_device,
-            interfaces: config.interfaces ?? [],
+            interfaces: config.interfaces ?? defaultInterfaces,
             setMemoryLimit:
               config.memory_limit !== 0 ? 'set_limit' : 'no_limit',
           },

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -275,7 +275,7 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
             virt_mode: config.virt_mode,
             helpers: config.helpers,
             root_device: config.root_device,
-            interfaces: config.interfaces,
+            interfaces: config.interfaces ?? [],
             setMemoryLimit:
               config.memory_limit !== 0 ? 'set_limit' : 'no_limit',
           },

--- a/packages/manager/src/queries/vlans.ts
+++ b/packages/manager/src/queries/vlans.ts
@@ -1,14 +1,19 @@
 import { getVlans, VLAN } from '@linode/api-v4/lib/vlans';
 import { APIError } from '@linode/api-v4/lib/types';
 import { useQuery } from 'react-query';
+import useFlags from 'src/hooks/useFlags';
 import { queryPresets } from './base';
 
 export const _getVlans = (): Promise<VLAN[]> =>
   getVlans().then(({ data }) => data);
 
-export const useVlansQuery = () =>
-  useQuery<VLAN[], APIError[]>('vlans', _getVlans, {
+export const useVlansQuery = () => {
+  // Using the flag directly so we can control this independently from account.capabilities
+  const flags = useFlags();
+  return useQuery<VLAN[], APIError[]>('vlans', _getVlans, {
     ...queryPresets.longLived,
+    enabled: flags.vlans,
   });
+};
 
 export default useVlansQuery;


### PR DESCRIPTION
## Description

Hide the interfaces section of the config modal if vlans tag isn't active
Fix some root device stuff that I broke when I refactored a month ago