### PR TITLE
M3-4955: Bare Metal feature flag

### DIFF
--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -10,6 +10,7 @@ import Grid from 'src/components/core/Grid';
 const options: { label: string; flag: keyof Flags }[] = [
   { label: 'CMR', flag: 'cmr' },
   { label: 'Databases', flag: 'databases' },
+  { label: 'Bare Metal', flag: 'bareMetal' },
 ];
 
 const FeatureFlagTool: React.FC<{}> = () => {

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -30,6 +30,7 @@ export interface Flags {
   databases: boolean;
   firewallBetaNotification: boolean;
   entityTransfers: boolean;
+  bareMetal: boolean;
 }
 
 type PromotionalOfferFeature =

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
@@ -30,6 +30,7 @@ import MutationNotification from './MutationNotification';
 import Notifications from './Notifications';
 import LinodeDetailsBreadcrumb from './LinodeDetailsBreadcrumb';
 import { parseQueryParams } from 'src/utilities/queryParams';
+import useFlags from 'src/hooks/useFlags';
 
 interface Props {
   numVolumes: number;
@@ -66,6 +67,11 @@ const LinodeDetailHeader: React.FC<CombinedProps> = (props) => {
   // is first rendered.
   const location = useLocation();
   const queryParams = parseQueryParams(location.search);
+  const flags = useFlags();
+
+  if (flags.bareMetal) {
+    console.log('Bare Metal flag is on');
+  }
 
   const match = useRouteMatch<{ linodeId: string; subpath: string }>({
     path: '/linodes/:linodeId/:subpath?',

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
@@ -30,7 +30,6 @@ import MutationNotification from './MutationNotification';
 import Notifications from './Notifications';
 import LinodeDetailsBreadcrumb from './LinodeDetailsBreadcrumb';
 import { parseQueryParams } from 'src/utilities/queryParams';
-import useFlags from 'src/hooks/useFlags';
 
 interface Props {
   numVolumes: number;
@@ -67,11 +66,6 @@ const LinodeDetailHeader: React.FC<CombinedProps> = (props) => {
   // is first rendered.
   const location = useLocation();
   const queryParams = parseQueryParams(location.search);
-  const flags = useFlags();
-
-  if (flags.bareMetal) {
-    console.log('Bare Metal flag is on');
-  }
 
   const match = useRouteMatch<{ linodeId: string; subpath: string }>({
     path: '/linodes/:linodeId/:subpath?',


### PR DESCRIPTION
## Description
This PR:
1. Picks up the Bare Metal flag from LD,
2. Adds an option in our Dev Tool for easily toggling the flag on and off locally,
3. Adds some temporary & basic code in `LinodeDetailHeader.tsx` to allow for easy confirmation of whether the flag is on or off (will be removed before merging)

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers
To test easily, have your console open while visiting a Linode's Detail page. When the flag is on you should see a statement logged to the console. You can turn the flag on and off locally using the "Bare Metal" option under "Feature Flags" in our Dev Tool.
