### PR TITLE
Change: Make Domain banner dismissible

### DIFF
--- a/packages/manager/src/features/Domains/DomainBanner.tsx
+++ b/packages/manager/src/features/Domains/DomainBanner.tsx
@@ -1,5 +1,6 @@
 import { DateTime } from 'luxon';
 import * as React from 'react';
+import Typography from 'src/components/core/Typography';
 import Link from 'src/components/Link';
 import Notice from 'src/components/Notice';
 import { makeStyles, Theme } from 'src/components/core/styles';
@@ -47,12 +48,14 @@ export const DomainBanner: React.FC<Props> = (props) => {
       dismissible
       onClose={handleClose}
     >
-      <div className={classes.banner}>
-        <strong>Your DNS zones are not being served.</strong>
-      </div>
-      Your domains will not be served by Linode&#39;s nameservers unless you
-      have at least one active Linode on your account.
-      <Link to="/linodes/create"> You can create one here.</Link>
+      <Typography>
+        <div className={classes.banner}>
+          <strong>Your DNS zones are not being served.</strong>
+        </div>
+        Your domains will not be served by Linode&#39;s nameservers unless you
+        have at least one active Linode on your account.{` `}
+        <Link to="/linodes/create">You can create one here.</Link>
+      </Typography>
     </Notice>
   );
 };

--- a/packages/manager/src/features/Domains/DomainBanner.tsx
+++ b/packages/manager/src/features/Domains/DomainBanner.tsx
@@ -21,6 +21,8 @@ interface Props {
   hidden: boolean;
 }
 
+const KEY = 'domain-banner';
+
 export const DomainBanner: React.FC<Props> = (props) => {
   const { hidden } = props;
   const classes = useStyles();
@@ -31,12 +33,13 @@ export const DomainBanner: React.FC<Props> = (props) => {
   } = useDismissibleNotifications();
 
   const handleClose = () => {
-    dismissNotifications(['domain-banner'], {
+    dismissNotifications([KEY], {
       expiry: DateTime.utc().plus({ days: 30 }).toISO(),
+      label: KEY,
     });
   };
 
-  if (hidden || hasDismissedNotifications(['domain-banner'])) {
+  if (hidden || hasDismissedNotifications([KEY])) {
     return null;
   }
 

--- a/packages/manager/src/features/Domains/DomainBanner.tsx
+++ b/packages/manager/src/features/Domains/DomainBanner.tsx
@@ -20,8 +20,6 @@ interface Props {
   hidden: boolean;
 }
 
-export type CombinedProps = Props;
-
 export const DomainBanner: React.FC<Props> = (props) => {
   const { hidden } = props;
   const classes = useStyles();
@@ -47,7 +45,7 @@ export const DomainBanner: React.FC<Props> = (props) => {
       important
       className={classes.dnsWarning}
       dismissible
-      onClick={handleClose}
+      onClose={handleClose}
     >
       <div className={classes.banner}>
         <strong>Your DNS zones are not being served.</strong>

--- a/packages/manager/src/features/Domains/DomainBanner.tsx
+++ b/packages/manager/src/features/Domains/DomainBanner.tsx
@@ -1,0 +1,62 @@
+import { DateTime } from 'luxon';
+import * as React from 'react';
+import Link from 'src/components/Link';
+import Notice from 'src/components/Notice';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import useDismissibleNotifications from 'src/hooks/useDismissibleNotifications';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  banner: {
+    marginBottom: theme.spacing(),
+  },
+  dnsWarning: {
+    '& h3:first-child': {
+      marginBottom: theme.spacing(1),
+    },
+  },
+}));
+
+interface Props {
+  hidden: boolean;
+}
+
+export type CombinedProps = Props;
+
+export const DomainBanner: React.FC<Props> = (props) => {
+  const { hidden } = props;
+  const classes = useStyles();
+
+  const {
+    dismissNotifications,
+    hasDismissedNotifications,
+  } = useDismissibleNotifications();
+
+  const handleClose = () => {
+    dismissNotifications(['domain-banner'], {
+      expiry: DateTime.utc().plus({ days: 30 }).toISO(),
+    });
+  };
+
+  if (hidden || hasDismissedNotifications(['domain-banner'])) {
+    return null;
+  }
+
+  return (
+    <Notice
+      warning
+      important
+      className={classes.dnsWarning}
+      dismissible
+      onClick={handleClose}
+    >
+      <div className={classes.banner}>
+        <strong>Your DNS zones are not being served.</strong>
+      </div>
+      Your domains will not be served by Linode&#39;s nameservers unless you
+      have at least one active Linode on your account.
+      <Link to="/linodes/create"> You can create one here.</Link>
+    </Notice>
+  );
+};
+
+export default React.memo(DomainBanner);

--- a/packages/manager/src/features/Domains/DomainsLanding.test.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.test.tsx
@@ -38,7 +38,6 @@ const props: CombinedProps = {
   closeSnackbar: jest.fn(),
   classes: {
     domain: '',
-    dnsWarning: '',
     root: '',
     titleWrapper: '',
     tagWrapper: '',
@@ -46,7 +45,6 @@ const props: CombinedProps = {
     title: '',
     breadcrumbs: '',
     importButton: '',
-    banner: '',
   },
   domainsByID: {},
   upsertMultipleDomains: jest.fn(),

--- a/packages/manager/src/features/Domains/DomainsLanding.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.tsx
@@ -42,6 +42,7 @@ import {
 import { upsertMultipleDomains } from 'src/store/domains/domains.actions';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { sendGroupByTagEnabledEvent } from 'src/utilities/ga';
+import DomainBanner from './DomainBanner';
 import DisableDomainDialog from './DisableDomainDialog';
 import { Handlers as DomainHandlers } from './DomainActionMenu';
 import DomainRow from './DomainTableRow';
@@ -55,11 +56,9 @@ type ClassNames =
   | 'title'
   | 'breadcrumbs'
   | 'domain'
-  | 'dnsWarning'
   | 'tagWrapper'
   | 'tagGroup'
-  | 'importButton'
-  | 'banner';
+  | 'importButton';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -83,11 +82,6 @@ const styles = (theme: Theme) =>
     domain: {
       width: '60%',
     },
-    dnsWarning: {
-      '& h3:first-child': {
-        marginBottom: theme.spacing(1),
-      },
-    },
     tagWrapper: {
       marginTop: theme.spacing(1) / 2,
       '& [class*="MuiChip"]': {
@@ -101,9 +95,6 @@ const styles = (theme: Theme) =>
     importButton: {
       marginLeft: -theme.spacing(),
       whiteSpace: 'nowrap',
-    },
-    banner: {
-      marginBottom: theme.spacing(),
     },
   });
 
@@ -408,16 +399,7 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
     return (
       <React.Fragment>
         <DocumentTitleSegment segment="Domains" />
-        {shouldShowBanner && (
-          <Notice warning important className={classes.dnsWarning}>
-            <div className={classes.banner}>
-              <strong>Your DNS zones are not being served.</strong>
-            </div>
-            Your domains will not be served by Linode&#39;s nameservers unless
-            you have at least one active Linode on your account.
-            <Link to="/linodes/create"> You can create one here.</Link>
-          </Notice>
-        )}
+        <DomainBanner hidden={!shouldShowBanner} />
         {this.props.location.state?.recordError && (
           <Notice error text={this.props.location.state.recordError} />
         )}

--- a/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
@@ -21,7 +21,7 @@ export const useFormattedNotifications = (): NotificationItem[] => {
   const dayOfMonth = DateTime.local().day;
 
   const handleClose = () => {
-    dismissNotifications(notifications, 'notificationDrawer');
+    dismissNotifications(notifications, { prefix: 'notificationDrawer' });
     context.closeDrawer();
   };
 

--- a/packages/manager/src/features/NotificationCenter/NotificationDrawer.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationDrawer.tsx
@@ -55,7 +55,7 @@ export const NotificationDrawer: React.FC<Props> = (props) => {
     if (wasOpen && !open) {
       // User has closed the drawer.
       dispatch(markAllSeen());
-      dismissNotifications(notifications, 'notificationDrawer');
+      dismissNotifications(notifications, { prefix: 'notificationDrawer' });
     }
   }, [dismissNotifications, notifications, dispatch, open, wasOpen]);
 

--- a/packages/manager/src/hooks/useDismissibleNotifications.test.ts
+++ b/packages/manager/src/hooks/useDismissibleNotifications.test.ts
@@ -53,18 +53,18 @@ describe('Dismissible notifications', () => {
     const dismissedNotifications = {
       normal: {
         created: DateTime.utc().plus({ minutes: 5 }).toISO(),
-        id: 'xxxx',
+        id: 'normal',
       },
       stale: {
         created: DateTime.utc()
           .minus({ days: STALE_DAYS + 1 })
           .toISO(),
-        id: 'xxxx',
+        id: 'stale',
       },
       expired: {
         created: DateTime.utc().plus({ minutes: 5 }).toISO(),
         expiry: DateTime.utc().minus({ minutes: 5 }).toISO(),
-        id: 'xxxx',
+        id: 'expired',
       },
     };
     it('should include existing dismissed notifications', () => {

--- a/packages/manager/src/hooks/useDismissibleNotifications.test.ts
+++ b/packages/manager/src/hooks/useDismissibleNotifications.test.ts
@@ -1,0 +1,88 @@
+import { DateTime } from 'luxon';
+import {
+  isExpired,
+  isStale,
+  STALE_DAYS,
+  updateDismissedNotifications,
+} from './useDismissibleNotifications';
+
+describe('Dismissible notifications', () => {
+  describe('isStale handlers', () => {
+    it('Should return true if the notification was created more than 60 days ago', () => {
+      expect(
+        isStale(
+          DateTime.utc()
+            .minus({ days: STALE_DAYS + 1 })
+            .toISO()
+        )
+      ).toBe(true);
+    });
+
+    it('Should return false if the notification was created fewer than 60 days ago', () => {
+      expect(
+        isStale(
+          DateTime.utc()
+            .minus({ days: STALE_DAYS - 1 })
+            .toISO()
+        )
+      ).toBe(false);
+    });
+
+    it('Should return false if the timestamp is not provided', () => {
+      expect(isStale()).toBe(false);
+    });
+  });
+
+  describe('isExpired helper', () => {
+    it('should return true if the expiry is in the past', () => {
+      expect(isExpired(DateTime.utc().minus({ seconds: 30 }).toISO())).toBe(
+        true
+      );
+    });
+
+    it('should return false if the expiry is in the future or is undefined', () => {
+      expect(isExpired(DateTime.utc().plus({ minutes: 30 }).toISO())).toBe(
+        false
+      );
+
+      expect(isExpired()).toBe(false);
+    });
+  });
+
+  describe('updateDismissedNotifications', () => {
+    const dismissedNotifications = {
+      normal: {
+        created: DateTime.utc().plus({ minutes: 5 }).toISO(),
+        id: 'xxxx',
+      },
+      stale: {
+        created: DateTime.utc()
+          .minus({ days: STALE_DAYS + 1 })
+          .toISO(),
+        id: 'xxxx',
+      },
+      expired: {
+        created: DateTime.utc().plus({ minutes: 5 }).toISO(),
+        expiry: DateTime.utc().minus({ minutes: 5 }).toISO(),
+        id: 'xxxx',
+      },
+    };
+    it('should include existing dismissed notifications', () => {
+      expect(
+        updateDismissedNotifications(dismissedNotifications, [], {})
+      ).toHaveProperty('normal');
+    });
+
+    it('should not include notifications created more than 60 days ago', () => {
+      expect(
+        updateDismissedNotifications(dismissedNotifications, [], {})
+      ).not.toHaveProperty('stale');
+    });
+
+    it('should not include notifications past their specified expiry', () => {
+      expect(
+        updateDismissedNotifications(dismissedNotifications, [], {})
+      ).not.toHaveProperty('expired');
+    });
+  });
+});

--- a/packages/manager/src/hooks/useDismissibleNotifications.ts
+++ b/packages/manager/src/hooks/useDismissibleNotifications.ts
@@ -21,6 +21,8 @@ import { DismissedNotification } from 'src/store/preferences/preferences.actions
  *    dismissNotifications is called. However, if expiry is specified, a notification that has been dismissed
  *    and is now past the expiry date will a) no longer be considered dismissed; and b) will be cleaned up
  *    on the next preferences() call as if stale (as described above).
+ * - label: an optional label that doesn't affect anything but makes it easier to find notifications inside
+ *    the preferences object.
  */
 
 export const STALE_DAYS = 60;
@@ -28,6 +30,7 @@ export const STALE_DAYS = 60;
 export interface DismissibleNotificationOptions {
   prefix?: string;
   expiry?: string;
+  label?: string;
 }
 export interface DismissibleNotificationsHook {
   dismissedNotifications: Record<string, DismissedNotification>;
@@ -106,8 +109,9 @@ export const updateDismissedNotifications = (
     const hashKey = getHashKey(thisNotification, options.prefix);
     newNotifications[hashKey] = {
       id: hashKey,
-      created: DateTime.utc().toLocaleString(),
+      created: DateTime.utc().toISO(),
       expiry: options.expiry,
+      label: options.label || options.prefix || undefined,
     };
   });
   return Object.values(notifications).reduce((acc, thisNotification) => {

--- a/packages/manager/src/hooks/useDismissibleNotifications.ts
+++ b/packages/manager/src/hooks/useDismissibleNotifications.ts
@@ -14,8 +14,13 @@ import { DismissedNotification } from 'src/store/preferences/preferences.actions
  * to generate a unique hash for the notification. In the case of actual Notifications, we use
  * the full notification object, which is usually (but not guaranteed to be in all cases) unique.
  *
- * The optional prefix prop allows you to specify a random string to be used as a prefix when generating
- * the hash. The purpose of this is to dismiss the same notification in different contexts independently.
+ * The options object allows you to specify the following options:
+ * - prefix: a string prefix to use when generating the hash.
+ *    The purpose of this is to dismiss the same notification in different contexts independently.
+ * - expiry: all dismissed notifications are stale after 60 days, and will be cleaned up the next time
+ *    dismissNotifications is called. However, if expiry is specified, a notification that has been dismissed
+ *    and is now past the expiry date will a) no longer be considered dismissed; and b) will be cleaned up
+ *    on the next preferences() call as if stale (as described above).
  */
 
 export interface DismissibleNotificationOptions {

--- a/packages/manager/src/hooks/useDismissibleNotifications.ts
+++ b/packages/manager/src/hooks/useDismissibleNotifications.ts
@@ -66,7 +66,7 @@ export const useDismissibleNotifications = (): DismissibleNotificationsHook => {
       // if the notification is present in our preferences, and
       // is not expired, it is considered dismissed.
       const dismissedNotification = dismissedNotifications[hashKey];
-      return dismissedNotification && isExpired(dismissedNotification.expiry);
+      return dismissedNotification && !isExpired(dismissedNotification.expiry);
     });
   };
 

--- a/packages/manager/src/hooks/useDismissibleNotifications.ts
+++ b/packages/manager/src/hooks/useDismissibleNotifications.ts
@@ -23,6 +23,8 @@ import { DismissedNotification } from 'src/store/preferences/preferences.actions
  *    on the next preferences() call as if stale (as described above).
  */
 
+export const STALE_DAYS = 60;
+
 export interface DismissibleNotificationOptions {
   prefix?: string;
   expiry?: string;
@@ -94,7 +96,7 @@ const getHashKey = (notification: unknown, prefix: string = '') =>
  *     We do this to prevent user preferences from turning into
  *     an ever-expanding blob of old notification hashes.
  */
-const updateDismissedNotifications = (
+export const updateDismissedNotifications = (
   notifications: Record<string, DismissedNotification>,
   notificationsToDismiss: unknown[],
   options: DismissibleNotificationOptions
@@ -117,14 +119,17 @@ const updateDismissedNotifications = (
   }, newNotifications);
 };
 
-const isStale = (timestamp?: string) => {
+export const isStale = (timestamp?: string) => {
   if (!timestamp) {
     return false;
   }
-  return DateTime.fromISO(timestamp).diffNow('days').toObject().days ?? 0 > 60;
+  return (
+    Math.abs(DateTime.fromISO(timestamp).diffNow('days').toObject().days ?? 0) >
+    STALE_DAYS
+  );
 };
 
-const isExpired = (timestamp?: string) => {
+export const isExpired = (timestamp?: string) => {
   if (!timestamp) {
     return false;
   }

--- a/packages/manager/src/store/preferences/preferences.actions.ts
+++ b/packages/manager/src/store/preferences/preferences.actions.ts
@@ -14,6 +14,7 @@ export interface OrderSet {
 export interface DismissedNotification {
   id: string;
   created: string;
+  expiry?: string;
 }
 
 export interface UserPreferences {

--- a/packages/manager/src/store/preferences/preferences.actions.ts
+++ b/packages/manager/src/store/preferences/preferences.actions.ts
@@ -15,6 +15,7 @@ export interface DismissedNotification {
   id: string;
   created: string;
   expiry?: string;
+  label?: string;
 }
 
 export interface UserPreferences {


### PR DESCRIPTION
## Description

Make the "Your domains aren't being served" banner disappear. This involved adding an optional `expiry` field to our mini-database and refactoring a bunch of stuff around it. The idea is:

- If a notification is dismissed normally, it is considered "stale" after 60 days. The next time a user dismisses anything, the stale stuff will be removed from the mini-database (this is clean-up to avoid bloat inside user preferences)
- If a notification is dismissed with a specified expiry date, it is not considered "dismissed" if the expiry has passed (so regardless of cleanup, an expired dismissal will reappear in the UI; in this case, the Domain banner will reappear after 30 days). Dismissals past their expiry are also considered "stale" and will be cleaned up as described above.

## Note to Reviewers

To test:
1. Have an account with > 1 Domain and 0 Linodes (mocks won't quite work with user preferences, so that's out)
2. Go to /domains; you should see a banner
3. Dismiss it; make sure it stays dismissed when you reload the page
4. Use the super-secret user preferences editor to find the domain banner in the dismissedNotifications section (it'll be the one with an `expiry` key) and set the expiry to the past.
5. The banner should reappear. 