### PR TITLE
Marketplace update: Openlitespeed document link

### DIFF
--- a/packages/manager/src/features/OneClickApps/FakeSpec.ts
+++ b/packages/manager/src/features/OneClickApps/FakeSpec.ts
@@ -578,7 +578,7 @@ export const oneClickApps: OCA[] = [
       {
         title: 'Deploy OpenLiteSpeed WordPress with Marketplace Apps',
         href:
-          'https://linode.com/docs/guides/deploy-openlitespeedwordpress-with-marketplace-apps',
+          'https://www.linode.com/docs/guides/deploy-openlitespeed-with-marketplace-apps/',
       },
     ],
     related_info: [


### PR DESCRIPTION
## Description

Current URL is 404'ing simply updating the URL for the Openlitespeed Linode doc. Can be merged at any time.

## Type of Change
- Non breaking change ('update')

