### PR TITLE
M3-5007: Copy tooltip confirmation capitalization

### DIFF
--- a/packages/manager/src/components/CopyTooltip/CopyTooltip.tsx
+++ b/packages/manager/src/components/CopyTooltip/CopyTooltip.tsx
@@ -120,7 +120,7 @@ class CopyTooltip extends React.Component<CombinedProps, State> {
       >
         {copied && (
           <span className={classes.copied} data-qa-copied>
-            copied
+            Copied!
           </span>
         )}
         <FileCopy />

--- a/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/CreateTransferSuccessDialog.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/CreateTransferSuccessDialog.tsx
@@ -116,7 +116,7 @@ export const CreateTransferSuccessDialog: React.FC<Props> = (props) => {
           fullWidth
           aria-disabled
         />
-        <ToolTip open={tooltipOpen[0]} title="copied!">
+        <ToolTip open={tooltipOpen[0]} title="Copied!">
           <div className={classes.copyButton}>
             <Button
               buttonType="secondary"
@@ -142,7 +142,7 @@ export const CreateTransferSuccessDialog: React.FC<Props> = (props) => {
           aria-disabled
           multiline
         />
-        <ToolTip open={tooltipOpen[1]} title="copied!">
+        <ToolTip open={tooltipOpen[1]} title="Copied!">
           <div className={classes.copyButton}>
             <Button
               buttonType="primary"

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketBreadcrumb.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketBreadcrumb.tsx
@@ -110,7 +110,7 @@ const BucketBreadcrumb: React.FC<CombinedProps> = (props) => {
     <div className={classes.root}>
       {copied && (
         <span className={classes.copied} data-qa-copied>
-          Path copied
+          Copied!
         </span>
       )}
       <FileCopy


### PR DESCRIPTION
## Description
Successful copying of text using tooltips throughout the app should show "Copied!" 

Specific locations in app include:
- IP Address in Linodes Landing table
- IP Addresses & Access in Linode Detail header
- Tokens in Service Transfers tables
- OBJ Bucket breadcrumb
- OBJ Bucket Details drawer

I believe all instances in the app should be consistent now, but if you are aware of others, please let me know.

## Type of Change
- Non breaking change ('update', 'change')
