### PR TITLE
Patch/hide interfaces in bad regions

### DIFF
--- a/packages/api-v4/src/linodes/types.ts
+++ b/packages/api-v4/src/linodes/types.ts
@@ -353,13 +353,3 @@ export interface LinodeDiskCreationData {
   stackscript_id?: number;
   stackscript_data?: any;
 }
-
-export interface LinodeInterface {
-  id: number;
-  type: unknown;
-  description: string;
-  linode_id: number;
-  vlan_id: number;
-  mac_address: string;
-  ip_address: string;
-}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
@@ -131,9 +131,9 @@ export const InterfaceSelect: React.FC<Props> = (props) => {
             direction={fromAddonsPanel ? 'row' : 'column'}
             className={fromAddonsPanel ? classes.vlanGrid : ''}
           >
-            <Grid item xs={fromAddonsPanel ? 6 : undefined}>
+            <Grid item xs={fromAddonsPanel ? 6 : 12}>
               <Select
-                className={classes.vlanLabelField}
+                className={fromAddonsPanel ? classes.vlanLabelField : ''}
                 errorText={labelError}
                 options={vlanOptions}
                 isLoading={isLoading}
@@ -149,7 +149,7 @@ export const InterfaceSelect: React.FC<Props> = (props) => {
             </Grid>
             <Grid
               item
-              xs={fromAddonsPanel ? 6 : undefined}
+              xs={fromAddonsPanel ? 6 : 12}
               className={fromAddonsPanel ? '' : 'py0'}
               style={fromAddonsPanel ? {} : { marginTop: -8, marginBottom: 8 }}
             >

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -1,4 +1,10 @@
-import { Config, Disk, Interface, Kernel } from '@linode/api-v4/lib/linodes';
+import {
+  Config,
+  Disk,
+  Interface,
+  Kernel,
+  LinodeConfigCreationData,
+} from '@linode/api-v4/lib/linodes';
 import { APIError } from '@linode/api-v4/lib/types';
 import { Volume } from '@linode/api-v4/lib/volumes';
 import { useFormik } from 'formik';
@@ -247,7 +253,11 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
 
     formik.setSubmitting(true);
 
-    const configData = convertStateToData(values);
+    const configData = convertStateToData(values) as LinodeConfigCreationData;
+
+    if (!regionHasVLANS) {
+      delete configData.interfaces;
+    }
 
     const handleSuccess = () => {
       formik.setSubmitting(false);

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -33,6 +33,7 @@ import DeviceSelection, {
 } from 'src/features/linodes/LinodesDetail/LinodeRescue/DeviceSelection';
 import useAccount from 'src/hooks/useAccount';
 import useFlags from 'src/hooks/useFlags';
+import { useRegionsQuery } from 'src/queries/regions';
 import { ApplicationState } from 'src/store';
 import createDevicesFromStrings, {
   DevicesAsStrings,
@@ -185,6 +186,7 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
 
   const classes = useStyles();
   const flags = useFlags();
+  const regions = useRegionsQuery().data ?? [];
   const { account } = useAccount();
   const [deviceCounter, setDeviceCounter] = React.useState(1);
   const [useCustomRoot, setUseCustomRoot] = React.useState(false);
@@ -192,7 +194,13 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
   // Making this an && instead of the usual hasFeatureEnabled, which is || based.
   // Doing this so that we can toggle our flag without enabling vlans for all customers.
   const capabilities = account?.data?.capabilities ?? [];
-  const showVlans = capabilities.includes('Vlans') && flags.vlans;
+  const regionHasVLANS = regions.some(
+    (thisRegion) =>
+      thisRegion.id === linodeRegion &&
+      thisRegion.capabilities.includes('Vlans')
+  );
+  const showVlans =
+    capabilities.includes('Vlans') && flags.vlans && regionHasVLANS;
 
   const { values, resetForm, setFieldValue, ...formik } = useFormik({
     initialValues: defaultFieldsValues,


### PR DESCRIPTION
## Description

- Hide the interfaces section in the config modal if the Linode's region doesn't support vlans
- Remove interfaces from the payload in this case ^^^
- Conditionally add wrapper style for vlan input (only apply in create flow)