### PR TITLE
Changes for VLAN attachment in Linode Create flow

### DIFF
--- a/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
@@ -100,6 +100,7 @@ const AddonsPanel: React.FC<CombinedProps> = (props) => {
     ipamAddress,
     ipamError,
     handleVLANChange,
+    selectedRegionID,
   } = props;
 
   const classes = useStyles();
@@ -135,6 +136,7 @@ const AddonsPanel: React.FC<CombinedProps> = (props) => {
             ipamError={ipamError}
             readOnly={disabled}
             handleVLANChange={handleVLANChange}
+            region={selectedRegionID}
           />
         ) : null}
         <Typography variant="h2" className={classes.title}>

--- a/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
@@ -11,6 +11,8 @@ import Currency from 'src/components/Currency';
 import Grid from 'src/components/Grid';
 import useAccount from 'src/hooks/useAccount';
 import useFlags from 'src/hooks/useFlags';
+import { useRegionsQuery } from 'src/queries/regions';
+import { doesRegionSupportVLANs } from 'src/utilities/doesRegionSupportVLANs';
 import AttachVLAN from './AttachVLAN';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -107,10 +109,15 @@ const AddonsPanel: React.FC<CombinedProps> = (props) => {
   const flags = useFlags();
   const { account } = useAccount();
 
+  const regions = useRegionsQuery().data ?? [];
+  const selectedRegion = selectedRegionID || '';
+
   // Making this an && instead of the usual hasFeatureEnabled, which is || based.
   // Doing this so that we can toggle our flag without enabling vlans for all customers.
   const capabilities = account?.data?.capabilities ?? [];
   const showVlans = capabilities.includes('Vlans') && flags.vlans;
+
+  const regionSupportsVLANs = doesRegionSupportVLANs(selectedRegion, regions);
 
   const renderBackupsPrice = () => {
     const { backupsMonthly } = props;
@@ -128,7 +135,7 @@ const AddonsPanel: React.FC<CombinedProps> = (props) => {
   return (
     <Paper className={classes.root} data-qa-add-ons>
       <div className={classes.inner}>
-        {showVlans ? (
+        {showVlans && regionSupportsVLANs ? (
           <AttachVLAN
             vlanLabel={vlanLabel}
             labelError={labelError}

--- a/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
@@ -11,7 +11,6 @@ import Currency from 'src/components/Currency';
 import Grid from 'src/components/Grid';
 import useAccount from 'src/hooks/useAccount';
 import useFlags from 'src/hooks/useFlags';
-import { isFeatureEnabled } from 'src/utilities/accountCapabilities';
 import AttachVLAN from './AttachVLAN';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -107,11 +106,10 @@ const AddonsPanel: React.FC<CombinedProps> = (props) => {
   const flags = useFlags();
   const { account } = useAccount();
 
-  const showVlans = isFeatureEnabled(
-    'Vlans',
-    Boolean(flags.vlans),
-    account?.data?.capabilities ?? []
-  );
+  // Making this an && instead of the usual hasFeatureEnabled, which is || based.
+  // Doing this so that we can toggle our flag without enabling vlans for all customers.
+  const capabilities = account?.data?.capabilities ?? [];
+  const showVlans = capabilities.includes('Vlans') && flags.vlans;
 
   const renderBackupsPrice = () => {
     const { backupsMonthly } = props;

--- a/packages/manager/src/features/linodes/LinodesCreate/AttachVLAN.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/AttachVLAN.tsx
@@ -24,6 +24,7 @@ interface Props {
   ipamAddress: string;
   ipamError?: string;
   readOnly?: boolean;
+  region?: string;
   handleVLANChange: (updatedInterface: Interface) => void;
 }
 
@@ -39,6 +40,7 @@ const AttachVLAN: React.FC<CombinedProps> = (props) => {
     ipamAddress,
     ipamError,
     readOnly,
+    region,
   } = props;
 
   return (
@@ -65,6 +67,7 @@ const AttachVLAN: React.FC<CombinedProps> = (props) => {
             handleChange={(newInterface: Interface) =>
               handleVLANChange(newInterface)
             }
+            region={region}
             fromAddonsPanel
           />
         </Grid>

--- a/packages/manager/src/utilities/doesRegionSupportVLANs.ts
+++ b/packages/manager/src/utilities/doesRegionSupportVLANs.ts
@@ -1,0 +1,14 @@
+import { Region } from '@linode/api-v4/lib/regions';
+
+export const doesRegionSupportVLANs = (
+  region: string,
+  regionsData: Region[]
+) => {
+  const regionMetaData = regionsData.find((thisRegion) => {
+    return thisRegion.id === region;
+  });
+  if (!regionMetaData) {
+    return false;
+  }
+  return regionMetaData.capabilities.includes('Vlans');
+};


### PR DESCRIPTION
## Description
Changes:
1. Revised `showVlans` logic to match what's in the Config modal
2. Pass selected region from AddonsPanel --> AttachVLAN --> InterfaceSelect so only VLANs for the given region populate the dropdown
3. New utility file for checking if a region supports VLANs
4. Only show "Attach a VLAN" section in Create flow if the selected region supports VLANs
5. Only include `interfaces` in the Create Linode payload if the selected region supports VLANs

## Type of Change
- Non breaking change ('update', 'change')
