### PR TITLE
M3-5025: Properly handle migration_pending notifications & refactor rendering logic

### DIFF
--- a/packages/manager/src/features/NotificationCenter/NotificationData/RenderNotification.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/RenderNotification.tsx
@@ -1,4 +1,4 @@
-import { Notification, NotificationType } from '@linode/api-v4/lib/account';
+import { NotificationType } from '@linode/api-v4/lib/account';
 import ErrorIcon from '@material-ui/icons/Error';
 import WarningIcon from '@material-ui/icons/Warning';
 import * as classNames from 'classnames';
@@ -8,10 +8,8 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 import { Link } from 'src/components/Link';
-import { dcDisplayNames } from 'src/constants';
-import { reportException } from 'src/exceptionReporting';
 import { sanitizeHTML } from 'src/utilities/sanitize-html';
-import { checkIfMaintenanceNotification } from './notificationUtils';
+import { ExtendedNotification } from './useFormattedNotifications';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -54,7 +52,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 interface Props {
-  notification: Notification;
+  notification: ExtendedNotification;
   onClose: () => void;
 }
 
@@ -63,10 +61,6 @@ export type CombinedProps = Props;
 export const RenderNotification: React.FC<Props> = (props) => {
   const { notification, onClose } = props;
   const classes = useStyles();
-
-  const isMaintenanceNotification = checkIfMaintenanceNotification(
-    notification.type
-  );
 
   const severity = notification.severity;
 
@@ -106,12 +100,9 @@ export const RenderNotification: React.FC<Props> = (props) => {
         </Grid>
 
         <Grid item>
-          {isMaintenanceNotification ? (
-            linkifiedMaintenanceMessage(notification, onClose)
-          ) : notification.type === 'outage' ? (
-            linkifiedOutageMessage(notification)
-          ) : notification.type === 'ticket_important' ? (
-            linkifiedImportantTicketMessage(notification, onClose)
+          {/* If JSX has already been put together from interceptions in useFormattedNotifications.tsx, use that */}
+          {notification.jsx ? (
+            notification.jsx
           ) : linkTarget ? (
             <Link
               to={linkTarget}
@@ -149,84 +140,6 @@ const getEntityLinks = (
   }
   // The only entity.type we currently expect and can handle for is "linode."
   return entityType === 'linode' ? `/linodes/${id}` : null;
-};
-
-const linkifiedMaintenanceMessage = (
-  notification: Notification,
-  onClose: () => void
-) => {
-  return (
-    <Typography>
-      <Link to={`/linodes/${notification?.entity?.id ?? ''}`} onClick={onClose}>
-        {notification?.entity?.label ?? 'One of your Linodes'}
-      </Link>{' '}
-      resides on a host that is pending critical maintenance. You should have
-      received a{' '}
-      <Link to={'/support/tickets?type=open'} onClick={onClose}>
-        support ticket
-      </Link>{' '}
-      that details how you will be affected. Please see the aforementioned
-      ticket and{' '}
-      <Link to={'https://status.linode.com/'}>status.linode.com</Link> for more
-      details.
-    </Typography>
-  );
-};
-
-const linkifiedOutageMessage = (notification: Notification) => {
-  /** this is an outage to one of the datacenters */
-  if (
-    notification.type === 'outage' &&
-    notification.entity?.type === 'region'
-  ) {
-    const convertedRegion = dcDisplayNames[notification.entity.id];
-
-    if (!convertedRegion) {
-      reportException(
-        'Could not find the DC name for the outage notification',
-        {
-          rawRegion: notification.entity.id,
-          convertedRegion,
-        }
-      );
-    }
-
-    return (
-      <Typography>
-        We are aware of an issue affecting service in{' '}
-        {convertedRegion || 'one of our facilities'}. If you are experiencing
-        service issues in this facility, there is no need to open a support
-        ticket at this time. Please monitor our status blog at{' '}
-        <Link to={'https://status.linode.com/'}>https://status.linode.com</Link>{' '}
-        for further information. Thank you for your patience and understanding.
-      </Typography>
-    );
-  }
-
-  return notification.message;
-};
-
-const linkifiedImportantTicketMessage = (
-  notification: Notification,
-  onClose: () => void
-) => {
-  // Failsafe
-  if (!notification.entity?.id) {
-    return notification.message;
-  }
-
-  return (
-    <Typography>
-      You have an{' '}
-      <Link
-        to={`/support/tickets/${notification.entity?.id}`}
-        onClick={onClose}
-      >
-        important ticket
-      </Link>{' '}
-      open!
-    </Typography>
-  );
 };
 
 export default React.memo(RenderNotification);

--- a/packages/manager/src/features/NotificationCenter/NotificationData/notificationUtils.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/notificationUtils.tsx
@@ -3,7 +3,6 @@ import { NotificationType } from '@linode/api-v4/lib/account';
 export const maintenanceNotificationTypes = [
   'maintenance',
   'maintenance_scheduled',
-  'migration_pending',
 ];
 
 export const checkIfMaintenanceNotification = (type: NotificationType) => {

--- a/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.test.ts
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.test.ts
@@ -11,12 +11,12 @@ const migrationScheduled = notificationFactory.build({
 const migrationPending = notificationFactory.build({
   type: 'migration_pending',
   entity: { id: 1, type: 'linode', label: 'linode-1' },
-  severity: 'critical',
+  severity: 'major',
 });
 
 const maintenanceNotice = notificationFactory.build();
 const maintenanceWithLowSeverity = notificationFactory.build({
-  type: 'migration_pending',
+  type: 'maintenance',
   entity: { id: 4, type: 'linode', label: 'linode-4' },
   severity: 'minor',
 });
@@ -35,15 +35,18 @@ const emailBounce = notificationFactory.build({
 describe('Notification Severity', () => {
   describe('adjustSeverity helper', () => {
     it("should return 'major' severity for all maintenance types", () => {
-      expect(adjustSeverity(migrationScheduled)).toMatch('major');
-      expect(adjustSeverity(migrationPending)).toMatch('major');
-      expect(adjustSeverity(migrationPending)).toMatch('major');
       expect(adjustSeverity(maintenanceNotice)).toMatch('major');
       expect(adjustSeverity(maintenanceWithLowSeverity)).toMatch('major');
     });
 
     it('should return severity as returned by the API with no modification for non-maintenance types', () => {
       expect(adjustSeverity(emailBounce)).toMatch(emailBounce.severity);
+      expect(adjustSeverity(migrationScheduled)).toMatch(
+        migrationScheduled.severity
+      );
+      expect(adjustSeverity(migrationPending)).toMatch(
+        migrationPending.severity
+      );
     });
   });
 });

--- a/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
@@ -2,12 +2,20 @@ import { Notification, NotificationSeverity } from '@linode/api-v4/lib/account';
 import { DateTime } from 'luxon';
 import { path } from 'ramda';
 import * as React from 'react';
+import Typography from 'src/components/core/Typography';
+import { Link } from 'src/components/Link';
+import { dcDisplayNames } from 'src/constants';
+import { reportException } from 'src/exceptionReporting';
 import useDismissibleNotifications from 'src/hooks/useDismissibleNotifications';
 import useNotifications from 'src/hooks/useNotifications';
 import { notificationContext } from '../NotificationContext';
 import { NotificationItem } from '../NotificationSection';
 import { checkIfMaintenanceNotification } from './notificationUtils';
 import RenderNotification from './RenderNotification';
+
+export interface ExtendedNotification extends Notification {
+  jsx?: JSX.Element;
+}
 
 export const useFormattedNotifications = (): NotificationItem[] => {
   const context = React.useContext(notificationContext);
@@ -38,7 +46,7 @@ export const useFormattedNotifications = (): NotificationItem[] => {
     })
     .map((notification, idx) =>
       formatNotificationForDisplay(
-        interceptNotification(notification),
+        interceptNotification(notification, handleClose),
         idx,
         handleClose,
         !hasDismissedNotifications([notification], 'notificationDrawer')
@@ -46,7 +54,20 @@ export const useFormattedNotifications = (): NotificationItem[] => {
     );
 };
 
-const interceptNotification = (notification: Notification): Notification => {
+/**
+ * This function intercepts the notification for further processing and formatting. Depending on the notification type,
+ * the contents of notification.message get changed, or JSX is generated and added to the notification object, etc.
+ *
+ * Specific types of notifications that are altered here: ticket_abuse, ticket_important, maintenance, maintenance_scheduled,
+ * migration_pending, outage
+ * @param notification
+ * @param onClose
+ */
+const interceptNotification = (
+  notification: Notification,
+  onClose: () => void
+): ExtendedNotification => {
+  // Ticket interceptions
   if (notification.type === 'ticket_abuse') {
     return {
       ...notification,
@@ -56,7 +77,31 @@ const interceptNotification = (notification: Notification): Notification => {
     };
   }
 
-  /** there is maintenance on this Linode */
+  if (notification.type === 'ticket_important') {
+    if (!notification.entity?.id) {
+      return notification;
+    }
+
+    const jsx = (
+      <Typography>
+        You have an{' '}
+        <Link
+          to={`/support/tickets/${notification.entity?.id}`}
+          onClick={onClose}
+        >
+          important ticket
+        </Link>{' '}
+        open!
+      </Typography>
+    );
+
+    return {
+      ...notification,
+      jsx,
+    };
+  }
+
+  /** Linode Maintenance interception */
   if (
     checkIfMaintenanceNotification(notification.type) &&
     notification.entity?.type === 'linode'
@@ -66,6 +111,27 @@ const interceptNotification = (notification: Notification): Notification => {
       ['label'],
       notification.entity
     );
+
+    const jsx = (
+      <Typography>
+        <Link
+          to={`/linodes/${notification?.entity?.id ?? ''}`}
+          onClick={onClose}
+        >
+          {notification?.entity?.label ?? 'One of your Linodes'}
+        </Link>{' '}
+        resides on a host that is pending critical maintenance. You should have
+        received a{' '}
+        <Link to={'/support/tickets?type=open'} onClick={onClose}>
+          support ticket
+        </Link>{' '}
+        that details how you will be affected. Please see the aforementioned
+        ticket and{' '}
+        <Link to={'https://status.linode.com/'}>status.linode.com</Link> for
+        more details.
+      </Typography>
+    );
+
     return {
       ...notification,
       label: `Maintenance Scheduled`,
@@ -78,9 +144,73 @@ const interceptNotification = (notification: Notification): Notification => {
             )
           : notification.body
         : notification.message,
+      jsx,
     };
   }
 
+  // Migration interception
+  if (notification.type === 'migration_pending') {
+    const jsx = (
+      <Typography>
+        You have a migration pending!{' '}
+        <Link to={`/linodes/${notification.entity?.id}`} onClick={onClose}>
+          {notification.entity?.label}
+        </Link>{' '}
+        must be offline before starting the migration.
+      </Typography>
+    );
+
+    return {
+      ...notification,
+      jsx,
+    };
+  }
+
+  // Outage interception
+  if (notification.type === 'outage') {
+    /** this is an outage to one of the datacenters */
+    if (
+      notification.type === 'outage' &&
+      notification.entity?.type === 'region'
+    ) {
+      const convertedRegion = dcDisplayNames[notification.entity.id];
+
+      if (!convertedRegion) {
+        reportException(
+          'Could not find the DC name for the outage notification',
+          {
+            rawRegion: notification.entity.id,
+            convertedRegion,
+          }
+        );
+      }
+
+      const jsx = (
+        <Typography>
+          We are aware of an issue affecting service in{' '}
+          {convertedRegion || 'one of our facilities'}. If you are experiencing
+          service issues in this facility, there is no need to open a support
+          ticket at this time. Please monitor our status blog at{' '}
+          <Link to={'https://status.linode.com/'}>
+            https://status.linode.com
+          </Link>{' '}
+          for further information. Thank you for your patience and
+          understanding.
+        </Typography>
+      );
+
+      return {
+        ...notification,
+        jsx,
+      };
+    }
+
+    return notification;
+  }
+
+  /* If the notification is not of any of the types above, return the notification object without modification. In this case, logic in <RenderNotification />
+  will either linkify notifcation.message or render it plainly.
+  */
   return notification;
 };
 

--- a/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
@@ -148,7 +148,25 @@ const interceptNotification = (
     };
   }
 
-  // Migration interception
+  // Migration interceptions
+  if (notification.type === 'migration_scheduled') {
+    const jsx = (
+      <Typography>
+        You have a scheduled migration pending!{' '}
+        <Link to={`/linodes/${notification.entity?.id}`} onClick={onClose}>
+          {notification.entity?.label}
+        </Link>{' '}
+        will be automatically shut down, migrated, and returned to its last
+        state.
+      </Typography>
+    );
+
+    return {
+      ...notification,
+      jsx,
+    };
+  }
+
   if (notification.type === 'migration_pending') {
     const jsx = (
       <Typography>

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -1,7 +1,7 @@
 import { rest, RequestHandler } from 'msw';
 
 import {
-  // abuseTicketNotificationFactory,
+  abuseTicketNotificationFactory,
   accountFactory,
   appTokenFactory,
   creditPaymentResponseFactory,
@@ -500,18 +500,27 @@ export const handlers = [
     //   body: null,
     // });
 
-    // const abuseTicket = abuseTicketNotificationFactory.build();
+    const abuseTicket = abuseTicketNotificationFactory.build();
 
-    const migrationTicket = notificationFactory.build({
+    const migrationNotification = notificationFactory.build({
       type: 'migration_pending',
+      label: 'You have a migration pending!',
+      message:
+        'You have a migration pending! Your Linode must be offline before starting the migration.',
       entity: { id: 0, type: 'linode', label: 'linode-0' },
-      severity: 'critical',
+      severity: 'major',
     });
 
-    const minorSeverityTicket = notificationFactory.build({
+    const minorSeverityNotification = notificationFactory.build({
       type: 'notice',
       message: 'Testing for minor notification',
       severity: 'minor',
+    });
+
+    const criticalSeverityNotification = notificationFactory.build({
+      type: 'notice',
+      message: 'Testing for critical notification',
+      severity: 'critical',
     });
 
     const balanceNotification = notificationFactory.build({
@@ -527,10 +536,11 @@ export const handlers = [
           ...notificationFactory.buildList(1),
           generalGlobalNotice,
           outageNotification,
-          minorSeverityTicket,
-          // abuseTicket,
+          minorSeverityNotification,
+          criticalSeverityNotification,
+          abuseTicket,
           // emailBounce,
-          migrationTicket,
+          migrationNotification,
           balanceNotification,
         ])
       )


### PR DESCRIPTION
## Description
`migration_pending` notifications were previously being treated incorrectly as Linode maintenance. This PR fixes that.

I also took this opportunity to refactor `RenderNotification.tsx` and `useFormattedNotifications.tsx` so that notifications aren't intercepted at two levels, per https://github.com/linode/manager/pull/7390#discussion_r575285171. Intercepting logic has been consolidated in `useFormattedNotifications.tsx`.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')
- Non breaking change ('update', 'change')

## Note to Reviewers
Mocks can be turned on for testing; I made a couple of additions and changes to the mocked notifications
