### PR TITLE
Fix: Invalidate VLAN query when creating/editing a new config

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -39,6 +39,7 @@ import DeviceSelection, {
 } from 'src/features/linodes/LinodesDetail/LinodeRescue/DeviceSelection';
 import useAccount from 'src/hooks/useAccount';
 import useFlags from 'src/hooks/useFlags';
+import { queryClient } from 'src/queries/base';
 import { useRegionsQuery } from 'src/queries/regions';
 import { ApplicationState } from 'src/store';
 import createDevicesFromStrings, {
@@ -261,6 +262,7 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
 
     const handleSuccess = () => {
       formik.setSubmitting(false);
+      queryClient.invalidateQueries('vlans');
       onClose();
     };
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -262,7 +262,14 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
 
     const handleSuccess = () => {
       formik.setSubmitting(false);
-      queryClient.invalidateQueries('vlans');
+      // If there's any chance a VLAN changed here, make sure our query data is up to date
+      if (
+        configData.interfaces?.some(
+          (thisInterface) => thisInterface.purpose === 'vlan'
+        )
+      ) {
+        queryClient.invalidateQueries('vlans');
+      }
       onClose();
     };
 


### PR DESCRIPTION
Update the list of VLANs in local state when creating or editing a config.

To test:

- Create or edit a config, adding a new vlan as you do so (in eth1 or wherever)
- Open the config dialog again, and check the vlans dropdown; the VLAN you just created should be listed.

You still have to pin yourself to a host that supports VLANs then create a Linode in the host's region. test account 4 has this set up already.