### PR TITLE
Allow creating a Linode without an image

### DIFF
--- a/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
@@ -84,6 +84,7 @@ interface Props {
   ipamAddress: string;
   handleVLANChange: (updatedInterface: Interface) => void;
   disabled?: boolean;
+  vlanDisabledReason?: string;
   hidePrivateIP?: boolean;
   labelError?: string;
   ipamError?: string;
@@ -97,6 +98,7 @@ const AddonsPanel: React.FC<CombinedProps> = (props) => {
     changeBackups,
     changePrivateIP,
     disabled,
+    vlanDisabledReason,
     vlanLabel,
     labelError,
     ipamAddress,
@@ -141,7 +143,8 @@ const AddonsPanel: React.FC<CombinedProps> = (props) => {
             labelError={labelError}
             ipamAddress={ipamAddress}
             ipamError={ipamError}
-            readOnly={disabled}
+            readOnly={disabled || Boolean(vlanDisabledReason)}
+            helperText={vlanDisabledReason}
             handleVLANChange={handleVLANChange}
             region={selectedRegionID}
           />

--- a/packages/manager/src/features/linodes/LinodesCreate/AttachVLAN.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/AttachVLAN.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
+import HelpIcon from 'src/components/HelpIcon';
 import InterfaceSelect from '../LinodesDetail/LinodeSettings/InterfaceSelect';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -11,6 +12,8 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   title: {
     marginBottom: theme.spacing(2),
+    display: 'flex',
+    alignItems: 'center',
   },
   actions: {
     display: 'flex',
@@ -25,6 +28,7 @@ interface Props {
   ipamError?: string;
   readOnly?: boolean;
   region?: string;
+  helperText?: string;
   handleVLANChange: (updatedInterface: Interface) => void;
 }
 
@@ -35,6 +39,7 @@ const AttachVLAN: React.FC<CombinedProps> = (props) => {
 
   const {
     handleVLANChange,
+    helperText,
     vlanLabel,
     labelError,
     ipamAddress,
@@ -46,7 +51,7 @@ const AttachVLAN: React.FC<CombinedProps> = (props) => {
   return (
     <div className={classes.root}>
       <Typography variant="h2" className={classes.title}>
-        Attach a VLAN
+        Attach a VLAN {helperText ? <HelpIcon text={helperText} /> : null}
       </Typography>
       <Grid container>
         <Grid item xs={12}>

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -326,8 +326,9 @@ export class LinodeCreate extends React.PureComponent<
       stackscript_data: this.props.selectedUDFs,
     };
 
-    if (regionSupportsVLANs) {
-      // Only submit interfaces in the payload if the region supports VLANs.
+    if (regionSupportsVLANs && this.props.selectedImageID) {
+      // Only submit interfaces in the payload if the region supports VLANs
+      // and an image has been selected
       payload['interfaces'] = interfaces;
     }
 
@@ -626,6 +627,11 @@ export class LinodeCreate extends React.PureComponent<
             changeBackups={this.props.toggleBackupsEnabled}
             changePrivateIP={this.props.togglePrivateIPEnabled}
             disabled={userCannotCreateLinode}
+            vlanDisabledReason={
+              !this.props.selectedImageID
+                ? 'You must select an image to attach a VLAN'
+                : undefined
+            }
             hidePrivateIP={this.props.createType === 'fromLinode'}
             vlanLabel={this.props.vlanLabel || ''}
             ipamAddress={this.props.ipamAddress || ''}

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -295,7 +295,7 @@ export class LinodeCreate extends React.PureComponent<
       this.props.regionsData
     );
 
-    const interfaces = [defaultPublicInterface]; // the purpose of defaultPublicInterface is to make sure the eth0 slot is not occupied by a VLAN.
+    const interfaces = [defaultPublicInterface];
     if (Boolean(this.props.vlanLabel)) {
       interfaces.push({
         purpose: 'vlan',

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -245,11 +245,16 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
     this.setState(defaultState);
   };
 
-  setImageID = (id: string) => {
-    /** allows for de-selecting an image */
-    if (id === this.state.selectedImageID) {
-      return this.setState({ selectedImageID: undefined });
+  setImageID = (id: string | undefined) => {
+    if (typeof id === 'undefined') {
+      /** In this case we also clear any VLAN input, since VLANs are incompatible with empty Linodes */
+      return this.setState({
+        selectedImageID: undefined,
+        attachedVLANLabel: '',
+        vlanIPAMAddress: '',
+      });
     }
+
     return this.setState({ selectedImageID: id });
   };
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
@@ -143,7 +143,10 @@ export const InterfaceSelect: React.FC<Props> = (props) => {
                 placeholder="Create or select a VLAN"
                 variant="creatable"
                 createOptionPosition="first"
-                value={vlanOptions.find((thisVlan) => thisVlan.value === label)}
+                value={
+                  vlanOptions.find((thisVlan) => thisVlan.value === label) ??
+                  null
+                }
                 onChange={handleLabelChange}
                 isClearable
                 disabled={readOnly}


### PR DESCRIPTION
When creating a Linode without an image, interfaces are not allowed.
Remove interfaces from the payload in this case to avoid an error
from the API. Disable the VLAN select and show helper text to explain
what needs to be done.

