### PR TITLE
M3-4961 Change: Separate password change flow for bare metal Linodes

### DIFF
--- a/packages/api-v4/src/linodes/linodes.ts
+++ b/packages/api-v4/src/linodes/linodes.ts
@@ -128,7 +128,7 @@ export const deleteLinode = (linodeId: number) =>
  * through the API.
  */
 
-export const resetLinodePassword = (linodeId: number, root_pass: string) =>
+export const changeLinodePassword = (linodeId: number, root_pass: string) =>
   Request<{}>(
     setURL(`${API_ROOT}/linode/instances/${linodeId}/password`),
     setData({ root_pass }),

--- a/packages/api-v4/src/linodes/linodes.ts
+++ b/packages/api-v4/src/linodes/linodes.ts
@@ -121,7 +121,7 @@ export const deleteLinode = (linodeId: number) =>
 /**
  * resetLinodePassword
  *
- * This method is distinct from resetLinodeDiskPassword,
+ * This method is distinct from changeLinodeDiskPassword,
  * in that it resets the root password on the Linode itself
  * rather than on a specific disk. This situation only applies
  * to bare metal instances, which don't have disks that are managed
@@ -132,5 +132,5 @@ export const changeLinodePassword = (linodeId: number, root_pass: string) =>
   Request<{}>(
     setURL(`${API_ROOT}/linode/instances/${linodeId}/password`),
     setData({ root_pass }),
-    setMethod('DELETE')
+    setMethod('POST')
   );

--- a/packages/api-v4/src/linodes/linodes.ts
+++ b/packages/api-v4/src/linodes/linodes.ts
@@ -4,7 +4,7 @@ import Request, {
   setMethod,
   setParams,
   setURL,
-  setXFilter
+  setXFilter,
 } from '../request';
 import { DeepPartial, ResourcePage as Page } from '../types';
 import { Volume } from '../volumes/types';
@@ -115,5 +115,22 @@ export const updateLinode = (linodeId: number, values: DeepPartial<Linode>) =>
 export const deleteLinode = (linodeId: number) =>
   Request<{}>(
     setURL(`${API_ROOT}/linode/instances/${linodeId}`),
+    setMethod('DELETE')
+  );
+
+/**
+ * resetLinodePassword
+ *
+ * This method is distinct from resetLinodeDiskPassword,
+ * in that it resets the root password on the Linode itself
+ * rather than on a specific disk. This situation only applies
+ * to bare metal instances, which don't have disks that are managed
+ * through the API.
+ */
+
+export const resetLinodePassword = (linodeId: number, root_pass: string) =>
+  Request<{}>(
+    setURL(`${API_ROOT}/linode/instances/${linodeId}/password`),
+    setData({ root_pass }),
     setMethod('DELETE')
   );

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettings.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettings.tsx
@@ -60,7 +60,7 @@ const LinodeSettings: React.FC<CombinedProps> = (props) => {
             </Typography>
             <LinodeSettingsLabelPanel />
             <LinodeSettingsPasswordPanel
-              linodeLabel={linode.label}
+              isBareMetalInstance={isBareMetalInstance}
               linodeId={linode.id}
               linodeStatus={linode.status}
             />

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
@@ -1,6 +1,7 @@
 import { GrantLevel } from '@linode/api-v4/lib/account';
 import {
   changeLinodeDiskPassword,
+  changeLinodePassword,
   Disk,
   getLinodeDisks,
 } from '@linode/api-v4/lib/linodes';
@@ -97,6 +98,9 @@ class LinodeSettingsPasswordPanel extends React.Component<
     };
 
     if (isBareMetalInstance) {
+      changeLinodePassword(linodeId, value)
+        .then(handleSuccess)
+        .catch(handleError);
     } else {
       changeLinodeDiskPassword(linodeId, diskId!, value)
         .then(handleSuccess)

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
@@ -187,7 +187,7 @@ class LinodeSettingsPasswordPanel extends React.Component<
   };
 
   handlePanelChange = (e: React.ChangeEvent<{}>, open: boolean) => {
-    if (open) {
+    if (open && !this.props.isBareMetalInstance) {
       this.searchDisks();
     }
   };


### PR DESCRIPTION
## Description

Bare metal Linodes don't have disks that are managed through the API, so they have to use a new endpoint (linode/instances/:id/password) to reset their root password. In planning I recommended using a separate component for this to avoid a bunch of prop-driven stuff, but it turns out there's a lot of shared logic between the two flows that would be repeated and I couldn't think of a great way around it. So I kept the existing stuff in place and a) hid the disks dropdown then b) used a different method on submit.