### PR TITLE
M3-4956 bare metal create

### DIFF
--- a/packages/api-v4/src/regions/types.ts
+++ b/packages/api-v4/src/regions/types.ts
@@ -6,7 +6,8 @@ export type Capabilities =
   | 'Kubernetes'
   | 'GPU Linodes'
   | 'Cloud Firewall'
-  | 'Vlans';
+  | 'Vlans'
+  | 'Bare Metal'; // This hasn't actually been added to the API yet
 
 export interface DNSResolvers {
   ipv4: string; // Comma-separated IP addresses

--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -33,11 +33,6 @@ export const LAUNCH_DARKLY_API_KEY =
   process.env.REACT_APP_LAUNCH_DARKLY_ID || '';
 export const LINODE_STATUS_PAGE_ID = process.env.REACT_APP_STATUS_PAGE_ID || '';
 
-/** If it's hitting the prod API */
-export const isProdAPI = RegExp(
-  /api.linode.com\/v4|cloud.linode.com\/api\/v4/
-).test(API_ROOT);
-
 // Maximum page size allowed by the API. Used in the `getAll()` helper function
 // to request as many items at once as possible.
 export const API_MAX_PAGE_SIZE =

--- a/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
@@ -84,7 +84,8 @@ interface Props {
   ipamAddress: string;
   handleVLANChange: (updatedInterface: Interface) => void;
   disabled?: boolean;
-  vlanDisabledReason?: string;
+  selectedImageID?: string;
+  selectedTypeID?: string;
   hidePrivateIP?: boolean;
   labelError?: string;
   ipamError?: string;
@@ -98,13 +99,14 @@ const AddonsPanel: React.FC<CombinedProps> = (props) => {
     changeBackups,
     changePrivateIP,
     disabled,
-    vlanDisabledReason,
     vlanLabel,
     labelError,
     ipamAddress,
     ipamError,
     handleVLANChange,
     selectedRegionID,
+    selectedImageID,
+    selectedTypeID,
   } = props;
 
   const classes = useStyles();
@@ -120,6 +122,11 @@ const AddonsPanel: React.FC<CombinedProps> = (props) => {
   const showVlans = capabilities.includes('Vlans') && flags.vlans;
 
   const regionSupportsVLANs = doesRegionSupportVLANs(selectedRegion, regions);
+
+  const vlanDisabledReason = getVlanDisabledReason(
+    selectedTypeID,
+    selectedImageID
+  );
 
   const renderBackupsPrice = () => {
     const { backupsMonthly } = props;
@@ -220,6 +227,18 @@ const AddonsPanel: React.FC<CombinedProps> = (props) => {
       </div>
     </Paper>
   );
+};
+
+const getVlanDisabledReason = (
+  selectedType?: string,
+  selectedImage?: string
+) => {
+  if (selectedType && /metal/.test(selectedType)) {
+    return 'VLANs cannot be used with Bare Metal Linodes.';
+  } else if (!selectedImage) {
+    return 'You must select an Image to attach a VLAN.';
+  }
+  return undefined;
 };
 
 export default React.memo(AddonsPanel);

--- a/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
@@ -9,12 +9,12 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Currency from 'src/components/Currency';
 import Grid from 'src/components/Grid';
+import HelpIcon from 'src/components/HelpIcon';
 import useAccount from 'src/hooks/useAccount';
 import useFlags from 'src/hooks/useFlags';
 import { useRegionsQuery } from 'src/queries/regions';
 import { doesRegionSupportVLANs } from 'src/utilities/doesRegionSupportVLANs';
 import AttachVLAN from './AttachVLAN';
-import HelpIcon from 'src/components/HelpIcon';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -627,11 +627,8 @@ export class LinodeCreate extends React.PureComponent<
             changeBackups={this.props.toggleBackupsEnabled}
             changePrivateIP={this.props.togglePrivateIPEnabled}
             disabled={userCannotCreateLinode}
-            vlanDisabledReason={
-              !this.props.selectedImageID
-                ? 'You must select an image to attach a VLAN'
-                : undefined
-            }
+            selectedImageID={this.props.selectedImageID}
+            selectedTypeID={this.props.selectedTypeID}
             hidePrivateIP={this.props.createType === 'fromLinode'}
             vlanLabel={this.props.vlanLabel || ''}
             ipamAddress={this.props.ipamAddress || ''}

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -53,6 +53,7 @@ import FromImageContent from './TabbedContent/FromImageContent';
 import FromLinodeContent from './TabbedContent/FromLinodeContent';
 import FromStackScriptContent from './TabbedContent/FromStackScriptContent';
 import { renderBackupsDisplaySection } from './TabbedContent/utils';
+import { v4 } from 'uuid';
 import {
   AllFormStateAndHandlers,
   AppsData,
@@ -176,6 +177,7 @@ type CombinedProps = Props &
 interface State {
   selectedTab: number;
   stackScriptSelectedTab: number;
+  planKey: string;
 }
 
 interface CreateTab extends Tab {
@@ -217,6 +219,7 @@ export class LinodeCreate extends React.PureComponent<
       selectedTab: preSelectedTab !== -1 ? preSelectedTab : 0,
       stackScriptSelectedTab:
         preSelectedTab === 2 && location.search.search('Account') > -1 ? 1 : 0,
+      planKey: v4(),
     };
   }
 
@@ -233,9 +236,22 @@ export class LinodeCreate extends React.PureComponent<
     /** set the tab in redux state */
     this.props.setTab(this.tabs[index].type);
 
+    /** Reset the plan panel since types may have shifted */
+
     this.setState({
       selectedTab: index,
+      planKey: v4(),
     });
+  };
+
+  filterTypes = () => {
+    const { createType, typesData } = this.props;
+    const { selectedTab } = this.state;
+    const currentTypes = filterCurrentTypes(typesData ?? []);
+
+    return ['fromImage', 'fromBackup'].includes(createType) && selectedTab !== 0
+      ? currentTypes.filter((t) => t.class !== 'metal')
+      : currentTypes;
   };
 
   tabs: CreateTab[] = [
@@ -562,14 +578,16 @@ export class LinodeCreate extends React.PureComponent<
             />
           )}
           <SelectPlanPanel
+            key={this.state.planKey}
             data-qa-select-plan
             error={hasErrorFor.type}
-            types={filterCurrentTypes(typesData)!}
+            types={this.filterTypes()}
             onSelect={this.props.updateTypeID}
             selectedID={this.props.selectedTypeID}
             updateFor={[
               this.props.selectedTypeID,
               this.props.disabledClasses,
+              this.props.createType,
               errors,
             ]}
             disabled={userCannotCreateLinode}

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -267,7 +267,22 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
     this.setState({ selectedRegionID: id, disabledClasses });
   };
 
-  setTypeID = (id: string) => this.setState({ selectedTypeID: id });
+  setTypeID = (id: string) => {
+    if (/metal/.test(id)) {
+      // VLANs and backups don't work with bare metal;
+      // reset those values.
+      this.setState({
+        selectedTypeID: id,
+        vlanIPAMAddress: '',
+        attachedVLANLabel: '',
+        backupsEnabled: false,
+      });
+    } else {
+      this.setState({
+        selectedTypeID: id,
+      });
+    }
+  };
 
   setLinodeID = (id: number, diskSize?: number) => {
     if (id !== this.state.selectedLinodeID) {

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -92,6 +92,7 @@ const styles = (theme: Theme) =>
       paddingRight: theme.spacing(),
     },
     gpuGuideLink: {
+      fontSize: '0.9em',
       '& a': {
         color: theme.cmrTextColors.linkActiveLight,
       },
@@ -425,20 +426,26 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
     }
 
     if (!isEmpty(metal)) {
-      // const programInfo = this.getDisabledClass('metal') ? (
-      //   <>
-      //     Bare Metal instances are not available in the selected region.
-      //     Currently these plans are only available in{' '}
-      //     {this.getRegionsWithCapability('Bare Metal')}.
-      //   </>
-      // ) : (
-      //   <Typography className={classes.gpuGuideLink}>Bare Metal Linodes have limited avail...etc</Typography>
-      // );
+      const programInfo = this.getDisabledClass('metal') ? (
+        // Until BM-426 is merged, we aren't filtering for regions in getDisabledClass
+        // so this branch will never run.
+        <Typography>
+          Bare Metal instances are not available in the selected region.
+          Currently these plans are only available in{' '}
+          {this.getRegionsWithCapability('Bare Metal')}.
+        </Typography>
+      ) : (
+        <Typography className={classes.gpuGuideLink}>
+          Bare Metal Linodes have limited availability and may not be available
+          at the time of your request. Some additional verification may be
+          required to access these services.
+        </Typography>
+      );
       tabs.push({
         render: () => {
           return (
             <>
-              {/* <Notice warning>{programInfo}</Notice> */}
+              <Notice warning>{programInfo}</Notice>
               <Typography data-qa-gpu className={classes.copy}>
                 Bare Metal Linodes give you full, dedicated access to a single
                 physical machine. Some services, including backups, VLANs, and

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -1,4 +1,5 @@
 import { LinodeTypeClass } from '@linode/api-v4/lib/linodes';
+import { Capabilities } from '@linode/api-v4/lib/regions/types';
 import * as classnames from 'classnames';
 import { LDClient } from 'launchdarkly-js-client-sdk';
 import { isEmpty, pathOr } from 'ramda';
@@ -131,6 +132,9 @@ const getDedicated = (types: ExtendedType[]) =>
 const getGPU = (types: ExtendedType[]) =>
   types.filter((t) => /gpu/.test(t.class));
 
+const getMetal = (types: ExtendedType[]) =>
+  types.filter((t) => t.class === 'metal');
+
 type CombinedProps = Props & WithStyles<ClassNames> & RegionsProps;
 
 export class SelectPlanPanel extends React.Component<CombinedProps> {
@@ -141,12 +145,12 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
     return disabledClasses.includes(thisClass);
   };
 
-  getRegionsWithGPU = () => {
+  getRegionsWithCapability = (capability: Capabilities) => {
     const regions = this.props.regionsData ?? [];
-    const withGPU = regions
-      .filter((thisRegion) => thisRegion.capabilities.includes('GPU Linodes'))
+    const withCapability = regions
+      .filter((thisRegion) => thisRegion.capabilities.includes(capability))
       .map((thisRegion) => dcDisplayNames[thisRegion.id]);
-    return arrayToList(withGPU);
+    return arrayToList(withCapability);
   };
 
   renderSelection = (type: ExtendedType, idx: number) => {
@@ -330,6 +334,7 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
     const highmem = getHighMem(types);
     const dedicated = getDedicated(types);
     const gpu = getGPU(types);
+    const metal = getMetal(types);
 
     const tabOrder: LinodeTypeClass[] = [];
 
@@ -394,7 +399,8 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
       const programInfo = this.getDisabledClass('gpu') ? (
         <>
           GPU instances are not available in the selected region. Currently
-          these plans are only available in {this.getRegionsWithGPU()}.
+          these plans are only available in{' '}
+          {this.getRegionsWithCapability('GPU Linodes')}.
         </>
       ) : (
         <div className={classes.gpuGuideLink}>{gpuPlanText()}</div>
@@ -416,6 +422,35 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
         title: 'GPU',
       });
       tabOrder.push('gpu');
+    }
+
+    if (!isEmpty(metal)) {
+      // const programInfo = this.getDisabledClass('metal') ? (
+      //   <>
+      //     Bare Metal instances are not available in the selected region.
+      //     Currently these plans are only available in{' '}
+      //     {this.getRegionsWithCapability('Bare Metal')}.
+      //   </>
+      // ) : (
+      //   <Typography className={classes.gpuGuideLink}>Bare Metal Linodes have limited avail...etc</Typography>
+      // );
+      tabs.push({
+        render: () => {
+          return (
+            <>
+              {/* <Notice warning>{programInfo}</Notice> */}
+              <Typography data-qa-gpu className={classes.copy}>
+                Bare Metal Linodes give you full, dedicated access to a single
+                physical machine. Some services, including backups, VLANs, and
+                disk management, are not available with these plans.
+              </Typography>
+              {this.renderPlanContainer(metal)}
+            </>
+          );
+        },
+        title: 'Bare Metal',
+      });
+      tabOrder.push('metal');
     }
 
     return [tabs, tabOrder];

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
@@ -86,6 +86,8 @@ export const InterfaceSelect: React.FC<Props> = (props) => {
     fromAddonsPanel,
   } = props;
 
+  const [newVlan, setNewVlan] = React.useState('');
+
   const purposeOptions: Item<ExtendedPurpose>[] = [
     slotNumber === 0
       ? {
@@ -115,6 +117,10 @@ export const InterfaceSelect: React.FC<Props> = (props) => {
         value: thisVlan.label,
       })) ?? [];
 
+  if (Boolean(newVlan)) {
+    vlanOptions.push({ label: newVlan, value: newVlan });
+  }
+
   const handlePurposeChange = (selected: Item<InterfacePurpose>) =>
     handleChange({ purpose: selected.value, label, ipam_address: ipamAddress });
 
@@ -127,6 +133,15 @@ export const InterfaceSelect: React.FC<Props> = (props) => {
       ipam_address: ipamAddress,
       label: selected?.value ?? '',
     });
+
+  const handleCreateOption = (_newVlan: string) => {
+    setNewVlan(_newVlan);
+    handleChange({
+      purpose,
+      ipam_address: ipamAddress,
+      label: _newVlan,
+    });
+  };
 
   return (
     <Grid container>
@@ -171,6 +186,7 @@ export const InterfaceSelect: React.FC<Props> = (props) => {
                   null
                 }
                 onChange={handleLabelChange}
+                createNew={handleCreateOption}
                 isClearable
                 disabled={readOnly}
                 noOptionsMessage={() =>

--- a/packages/manager/src/store/linodeType/linodeType.requests.ts
+++ b/packages/manager/src/store/linodeType/linodeType.requests.ts
@@ -6,9 +6,9 @@ import {
 } from '@linode/api-v4/lib/linodes';
 import cachedTypes from 'src/cachedData/types.json';
 import cachedDeprecatedTypes from 'src/cachedData/typesLegacy.json';
-import { isProdAPI } from 'src/constants';
 import { ThunkActionCreator } from 'src/store/types';
 import { getAll } from 'src/utilities/getAll';
+import { isProdAPI } from 'src/utilities/isProdApi';
 import { createRequestThunk } from '../store.helpers.tmp';
 import {
   getLinodeTypeActions,
@@ -24,7 +24,7 @@ export const requestTypes: RequestTypesThunk = () => (dispatch) => {
    * NOTE: We don't rely on cached data in non-production environments,
    * since it may not match dev/staging API data.
    */
-  if (isProdAPI && cachedTypes.data && cachedDeprecatedTypes.data) {
+  if (isProdAPI() && cachedTypes.data && cachedDeprecatedTypes.data) {
     // AC: need to cast as the Class string cannot be assigned to a type enum in TS 3.9
     const allCachedTypes: LinodeType[] = [
       ...cachedTypes.data,

--- a/packages/manager/src/store/regions/regions.reducer.ts
+++ b/packages/manager/src/store/regions/regions.reducer.ts
@@ -1,9 +1,9 @@
-import produce from 'immer';
 import { Capabilities, Region, RegionStatus } from '@linode/api-v4/lib/regions';
+import produce from 'immer';
 import { Reducer } from 'redux';
 import regions from 'src/cachedData/regions.json';
-import { isProdAPI } from 'src/constants';
 import { EntityState } from 'src/store/types';
+import { isProdAPI } from 'src/utilities/isProdApi';
 import { isType } from 'typescript-fsa';
 import { regionsRequestActions } from './regions.actions';
 
@@ -18,8 +18,8 @@ export type State = EntityState<Region>;
  * use that as our default.
  */
 export const defaultState: State = {
-  results: isProdAPI ? regions?.data?.map((r) => r.id) ?? [] : [],
-  entities: isProdAPI ? (regions?.data as Region[]) ?? [] : [],
+  results: isProdAPI() ? regions?.data?.map((r) => r.id) ?? [] : [],
+  entities: isProdAPI() ? (regions?.data as Region[]) ?? [] : [],
   loading: true,
   lastUpdated: 0,
   error: undefined,

--- a/packages/manager/src/utilities/isProdApi.ts
+++ b/packages/manager/src/utilities/isProdApi.ts
@@ -1,0 +1,17 @@
+import { API_ROOT } from 'src/constants';
+import { devToolsEnabled } from 'src/dev-tools/load';
+import { storage } from 'src/utilities/storage';
+
+/** If it's hitting the prod API */
+export const isProdAPI = () => {
+  const regExp = RegExp(/api.linode.com\/v4|cloud.linode.com\/api\/v4/);
+
+  // If the user has dev tools enabled, we need to check the API root from the environment switcher
+  if (devToolsEnabled()) {
+    const localStorageEnv = storage.devToolsEnv.get();
+    return regExp.test(localStorageEnv?.apiRoot ?? '');
+  } else {
+    // Otherwise test the API_ROOT from src/constants
+    return regExp.test(API_ROOT);
+  }
+};


### PR DESCRIPTION
## Description

Add a tab for metal plans on the Linode create flow. This was the easy part. In order to make the flow work out, I also had to:

- Update our isProdAPI logic
- Disable VLANs if a metal type is selected
- Filter out metal types (so the tab doesn't appear) when creating from a private image or backup

See commit messages for more details. There's a new open ticket for adding metal to region.capabilities, but until that's done we can't do our usual filtering (using the GPU pattern).