### PR TITLE
Change: Public interface can appear in any slot

### DIFF
--- a/packages/api-v4/src/linodes/linodes.schema.ts
+++ b/packages/api-v4/src/linodes/linodes.schema.ts
@@ -18,31 +18,41 @@ const validateIP = (ipAddress: string) => {
 
 const stackscript_data = array().of(object()).nullable(true);
 
-export const linodeInterfaceSchema = array().of(
-  object({
-    purpose: mixed().oneOf(
-      [null, 'public', 'vlan'],
-      'Purpose must be null, public, or vlan.'
-    ),
-    label: string().when('purpose', {
-      is: (value) => value === 'vlan',
-      then: string()
-        .required('Label is required.')
-        .min(1, 'Label must be between 1 and 64 characters.')
-        .max(64, 'Label must be between 1 and 64 characters.')
-        .matches(
-          /[a-z0-9-]+/,
-          'Interface labels cannot contain special characters.'
-        ),
-      otherwise: string().notRequired(),
-    }),
-    ipam_address: string().test({
-      name: 'validateIPAM',
-      message: 'Must be a valid IPv4 range',
-      test: validateIP,
-    }),
-  })
-);
+export const linodeInterfaceSchema = array()
+  .of(
+    object({
+      purpose: mixed().oneOf(
+        [null, 'public', 'vlan'],
+        'Purpose must be null, public, or vlan.'
+      ),
+      label: string().when('purpose', {
+        is: (value) => value === 'vlan',
+        then: string()
+          .required('Label is required.')
+          .min(1, 'Label must be between 1 and 64 characters.')
+          .max(64, 'Label must be between 1 and 64 characters.')
+          .matches(
+            /[a-z0-9-]+/,
+            'Interface labels cannot contain special characters.'
+          ),
+        otherwise: string().notRequired(),
+      }),
+      ipam_address: string().test({
+        name: 'validateIPAM',
+        message: 'Must be a valid IPv4 range',
+        test: validateIP,
+      }),
+    })
+  )
+  .test(
+    'unique-public-interface',
+    'Only one public interface per config is allowed.',
+    (list: any[]) => {
+      return (
+        list.filter((thisSlot) => thisSlot.purpose === 'public').length <= 1
+      );
+    }
+  );
 
 // const rootPasswordValidation = string().test(
 //   'is-strong-password',

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
@@ -89,12 +89,10 @@ export const InterfaceSelect: React.FC<Props> = (props) => {
   const [newVlan, setNewVlan] = React.useState('');
 
   const purposeOptions: Item<ExtendedPurpose>[] = [
-    slotNumber === 0
-      ? {
-          label: 'Public Internet',
-          value: 'public',
-        }
-      : null,
+    {
+      label: 'Public Internet',
+      value: 'public',
+    },
     {
       label: 'VLAN',
       value: 'vlan',
@@ -103,7 +101,7 @@ export const InterfaceSelect: React.FC<Props> = (props) => {
       label: 'None',
       value: 'none',
     },
-  ].filter(Boolean) as Item<ExtendedPurpose>[];
+  ];
 
   const { data: vlans, isLoading } = useVlansQuery();
   const vlanOptions =

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -733,6 +733,9 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
                     }
                   />
                 </Box>
+                {formik.errors.interfaces ? (
+                  <Notice error text={formik.errors.interfaces as string} />
+                ) : null}
                 <Typography>
                   VLAN is currently in beta and is subject to the terms of the{' '}
                   <ExternalLink

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -8,7 +8,7 @@ import {
 import { APIError } from '@linode/api-v4/lib/types';
 import { Volume } from '@linode/api-v4/lib/volumes';
 import { useFormik } from 'formik';
-import { pathOr, repeat } from 'ramda';
+import { equals, pathOr, repeat } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'recompose';
@@ -198,11 +198,14 @@ const interfacesToPayload = (interfaces?: ExtendedInterface[]) => {
   if (!interfaces || interfaces.length === 0) {
     return [];
   }
-  return interfaces.some((thisInterface) => thisInterface.purpose === 'vlan')
-    ? (interfaces.filter(
+  return equals(interfaces, defaultInterfaceList)
+    ? // In this case, where eth0 is set to public interface
+      // and no other interfaces are specified, the API prefers
+      // to receive an empty array.
+      []
+    : (interfaces.filter(
         (thisInterface) => thisInterface.purpose !== 'none'
-      ) as Interface[])
-    : [];
+      ) as Interface[]);
 };
 
 const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {


### PR DESCRIPTION
## Description

We heard from the VLAN team that the spec has changed a bit and public interfaces can be placed anywhere, not just on eth0. Since the API supports this we should too, though it's a rare use case.

We still don't have a validation schema attached to this dialog, and I've had trouble getting one to behave properly because of all the surgery we do on the interfaces payload. The schema is being run on submit, which I think is fine for now. We might want to open a separate ticket for including "live" validation on this form.

The API validates to make sure only a single public interface is included, regardless of position. I added validation for that too, though there's one discrepancy: the API returns this error without a field, so it appears as the general error at the top of the form. The schema returns it as `field: interfaces`, which I've rendered in the interfaces section. The API is probably wrong here, but the result is a situation where the same error could theoretically appear in different places depending on how the form is validated.