### PR TITLE
For Release: Schema and typing revisions to allow interface.label to be null

### DIFF
--- a/packages/api-v4/src/linodes/linodes.schema.ts
+++ b/packages/api-v4/src/linodes/linodes.schema.ts
@@ -2,18 +2,14 @@ import { array, boolean, mixed, number, object, string } from 'yup';
 import { parseCIDR } from 'ipaddr.js';
 
 const validateIP = (ipAddress: string | null) => {
-  if (ipAddress === '') {
-    // ipam_address is technically required, but empty strings are valid
+  if (!ipAddress) {
     return true;
   }
 
-  if (ipAddress !== null) {
-    // We accept IP ranges (i.e., CIDR notation).
-    try {
-      parseCIDR(ipAddress);
-    } catch (err) {
-      return false;
-    }
+  try {
+    parseCIDR(ipAddress);
+  } catch (err) {
+    return false;
   }
 
   return true;
@@ -41,7 +37,7 @@ export const linodeInterfaceSchema = array().of(
         otherwise: string().notRequired(),
       })
       .nullable(true),
-    ipam_address: string().nullable().test({
+    ipam_address: string().test({
       name: 'validateIPAM',
       message: 'Must be a valid IPv4 range',
       test: validateIP,

--- a/packages/api-v4/src/linodes/linodes.schema.ts
+++ b/packages/api-v4/src/linodes/linodes.schema.ts
@@ -6,6 +6,7 @@ const validateIP = (ipAddress: string | null) => {
     return true;
   }
 
+  // We accept IP ranges (i.e., CIDR notation).
   try {
     parseCIDR(ipAddress);
   } catch (err) {

--- a/packages/api-v4/src/linodes/types.ts
+++ b/packages/api-v4/src/linodes/types.ts
@@ -149,7 +149,7 @@ export type LinodeStatus =
 export type InterfacePurpose = 'public' | 'vlan';
 
 export interface Interface {
-  label: string;
+  label: string | null;
   purpose: InterfacePurpose;
   ipam_address: string | null;
 }

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -136,7 +136,7 @@ interface Props {
   resetCreationState: () => void;
   setBackupID: (id: number) => void;
   showGeneralError?: boolean;
-  vlanLabel: string;
+  vlanLabel: string | null;
   ipamAddress: string | null;
   handleVLANChange: (updatedInterface: Interface) => void;
 }

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -97,7 +97,7 @@ interface State {
   appInstancesLoading: boolean;
   appInstancesError?: string;
   disabledClasses?: LinodeTypeClass[];
-  attachedVLANLabel: string;
+  attachedVLANLabel: string | null;
   vlanIPAMAddress: string | null;
 }
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/ConfigRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/ConfigRow.tsx
@@ -109,7 +109,7 @@ export const ConfigRow: React.FC<CombinedProps> = (props) => {
 
         return (
           <li
-            key={interfaceEntry.purpose + idx}
+            key={interfaceEntry.label ?? 'public' + idx}
             className={classes.interfaceListItem}
           >
             {interfaceName} – {getInterfaceLabel(interfaceEntry)}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/ConfigRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/ConfigRow.tsx
@@ -109,7 +109,7 @@ export const ConfigRow: React.FC<CombinedProps> = (props) => {
 
         return (
           <li
-            key={interfaceEntry.label + idx}
+            key={interfaceEntry.purpose + idx}
             className={classes.interfaceListItem}
           >
             {interfaceName} – {getInterfaceLabel(interfaceEntry)}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
@@ -54,7 +54,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 export interface Props {
   slotNumber: number;
   purpose: ExtendedPurpose;
-  label: string;
+  label: string | null;
   ipamAddress: string | null;
   readOnly: boolean;
   region?: string;


### PR DESCRIPTION
## Description
There was a bug where you could not successfully edit a configuration that had a VLAN interface. That was due to some incorrect validation. This PR revises the schema and allows `null` to be a valid type for `interface.label` in several places.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers
Please ensure that Linode configurations with and without VLANs can be edited and created as expected, and that Linodes can be created with or without VLANs.
