### PR TITLE
M3-5040 Add: Delete cluster button/modal in LKE detail view

### DIFF
--- a/packages/manager/src/components/Tag/Tag_CMR.tsx
+++ b/packages/manager/src/components/Tag/Tag_CMR.tsx
@@ -10,6 +10,7 @@ import {
   withStyles,
   WithStyles,
 } from 'src/components/core/styles';
+import { truncateEnd } from 'src/utilities/truncate';
 
 type Variants =
   | 'white'
@@ -157,6 +158,7 @@ export interface Props extends ChipProps {
   asSuggestion?: boolean;
   closeMenu?: any;
   component?: string;
+  maxLength?: number;
 }
 
 type CombinedProps = Props & RouteComponentProps<{}> & WithStyles<CSSClasses>;
@@ -181,18 +183,24 @@ class Tag extends React.Component<CombinedProps, {}> {
       colorVariant,
       classes,
       className,
+      label,
       history,
       location,
       staticContext,
       match, // Don't pass route props to the Chip component
       asSuggestion,
       closeMenu,
+      maxLength,
       ...chipProps
     } = this.props;
+
+    // If maxWidth is set, truncate display to that length.
+    const _label = maxLength ? truncateEnd(label, maxLength) : label;
 
     return (
       <Chip
         {...chipProps}
+        label={_label}
         className={classNames({
           ...(className && { [className]: true }),
           [classes[colorVariant!]]: true,

--- a/packages/manager/src/components/Tag/Tag_CMR.tsx
+++ b/packages/manager/src/components/Tag/Tag_CMR.tsx
@@ -26,7 +26,9 @@ type CSSClasses = 'label' | 'root' | 'deleteButton' | Variants;
 
 const styles = (theme: Theme) =>
   createStyles({
-    label: {},
+    label: {
+      maxWidth: 350,
+    },
     root: {
       height: 30,
       paddingLeft: 0,
@@ -53,9 +55,6 @@ const styles = (theme: Theme) =>
         borderTopRightRadius: 0,
         borderBottomRightRadius: 0,
         borderRight: `1px solid ${theme.color.tagBorder}`,
-      },
-      '&:last-child': {
-        marginRight: 8,
       },
     },
     deleteButton: {

--- a/packages/manager/src/components/TagsPanel/TagsPanelRedesigned.tsx
+++ b/packages/manager/src/components/TagsPanel/TagsPanelRedesigned.tsx
@@ -54,15 +54,15 @@ const styles = (theme: Theme) =>
     },
     addButtonWrapper: {
       display: 'flex',
-      justifyContent: 'flex-end',
+      justifyContent: 'flex-start',
       width: '100%',
     },
     hasError: {
       marginTop: 0,
     },
     errorNotice: {
-      borderLeft: `5px solid ${theme.palette.status.errorDark}`,
       animation: '$fadeIn 225ms linear forwards',
+      borderLeft: `5px solid ${theme.palette.status.errorDark}`,
       '& .noticeText': {
         ...theme.typography.body1,
         fontFamily: '"LatoWeb", sans-serif',
@@ -75,13 +75,13 @@ const styles = (theme: Theme) =>
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',
-      borderRadius: 3,
       backgroundColor: theme.color.tagButton,
       border: 'none',
+      borderRadius: 3,
       color: theme.cmrTextColors.linkActiveLight,
       cursor: 'pointer',
       fontFamily: theme.font.normal,
-      fontSize: 14,
+      fontSize: '0.875rem',
       fontWeight: 'bold',
       padding: '7px 10px',
       whiteSpace: 'nowrap',
@@ -97,39 +97,40 @@ const styles = (theme: Theme) =>
       position: 'relative',
     },
     selectTag: {
+      animation: '$fadeIn .3s ease-in-out forwards',
+      marginTop: -3.5,
       minWidth: 275,
+      position: 'relative',
       textAlign: 'left',
       width: '100%',
-      position: 'relative',
       zIndex: 3,
-      animation: '$fadeIn .3s ease-in-out forwards',
       '& .error-for-scroll > div': {
         flexDirection: 'row',
         flexWrap: 'wrap-reverse',
       },
       '& .input': {
         '& p': {
-          fontSize: '.9rem',
           color: theme.color.grey1,
           borderLeft: 'none',
+          fontSize: '.9rem',
         },
       },
       '& .react-select__input': {
-        fontSize: '.9rem',
-        color: theme.palette.text.primary,
         backgroundColor: 'transparent',
+        color: theme.palette.text.primary,
+        fontSize: '.9rem',
       },
       '& .react-select__value-container': {
         padding: '6px',
       },
     },
     progress: {
-      position: 'absolute',
-      height: '100%',
-      width: '100%',
       display: 'flex',
       justifyContent: 'center',
       alignItems: 'center',
+      position: 'absolute',
+      height: '100%',
+      width: '100%',
       zIndex: 2,
     },
     loading: {
@@ -375,11 +376,6 @@ class TagsPanelRedesigned extends React.Component<CombinedProps, State> {
               [classes.addButtonWrapper]: true,
               [classes.hasError]: tagError,
             })}
-            style={
-              this.props.align === 'left'
-                ? { justifyContent: 'flex-start' }
-                : { justifyContent: 'flex-end' }
-            }
           >
             <button
               className={classes.addTagButton}
@@ -398,26 +394,23 @@ class TagsPanelRedesigned extends React.Component<CombinedProps, State> {
               <CircleProgress mini />
             </div>
           )}
-          <div
-            className={classNames({
-              [classes.loading]: loading,
-            })}
-          >
-            {tags.map((thisTag) => {
-              return (
-                <Tag
-                  key={`tag-item-${thisTag}`}
-                  className={classes.tag}
-                  colorVariant="lightBlue"
-                  label={thisTag}
-                  maxLength={30}
-                  onDelete={
-                    disabled ? undefined : () => this.handleDeleteTag(thisTag)
-                  }
-                />
-              );
-            })}
-          </div>
+          {tags.map((thisTag) => {
+            return (
+              <Tag
+                key={`tag-item-${thisTag}`}
+                className={classNames({
+                  [classes.tag]: true,
+                  [classes.loading]: loading,
+                })}
+                colorVariant="lightBlue"
+                label={thisTag}
+                maxLength={30}
+                onDelete={
+                  disabled ? undefined : () => this.handleDeleteTag(thisTag)
+                }
+              />
+            );
+          })}
           {tagError && (
             <Typography className={classes.errorNotice}>{tagError}</Typography>
           )}

--- a/packages/manager/src/components/TagsPanel/TagsPanelRedesigned.tsx
+++ b/packages/manager/src/components/TagsPanel/TagsPanelRedesigned.tsx
@@ -49,15 +49,14 @@ const styles = (theme: Theme) =>
         opacity: 1,
       },
     },
-    root: {},
     tag: {
       marginTop: theme.spacing(1) / 2,
-      marginRight: 0,
+      marginRight: 4,
     },
     addButtonWrapper: {
-      width: '100%',
       display: 'flex',
       justifyContent: 'flex-end',
+      width: '100%',
     },
     hasError: {
       marginTop: 0,
@@ -69,9 +68,9 @@ const styles = (theme: Theme) =>
         ...theme.typography.body1,
         fontFamily: '"LatoWeb", sans-serif',
       },
-      textAlign: 'left',
-      paddingLeft: 10,
       marginTop: 20,
+      paddingLeft: 10,
+      textAlign: 'left',
     },
     addTagButton: {
       display: 'flex',
@@ -353,11 +352,7 @@ class TagsPanelRedesigned extends React.Component<CombinedProps, State> {
     } = this.state;
 
     return (
-      <div
-        className={classNames({
-          [classes.root]: true,
-        })}
-      >
+      <>
         {isCreatingTag ? (
           <Select
             onChange={this.handleCreateTag}
@@ -398,11 +393,7 @@ class TagsPanelRedesigned extends React.Component<CombinedProps, State> {
           </div>
         )}
 
-        <div
-          className={classNames({
-            [classes.tagsPanelItemWrapper]: true,
-          })}
-        >
+        <div className={classes.tagsPanelItemWrapper}>
           {loading && (
             <div className={classes.progress}>
               <CircleProgress mini />
@@ -417,17 +408,12 @@ class TagsPanelRedesigned extends React.Component<CombinedProps, State> {
               return (
                 <Tag
                   key={`tag-item-${thisTag}`}
+                  className={classes.tag}
                   colorVariant="lightBlue"
                   label={truncateEnd(thisTag, 30)}
-                  style={
-                    this.props.align === 'left'
-                      ? { marginRight: '4px' }
-                      : { marginLeft: '4px' }
-                  }
                   onDelete={
                     disabled ? undefined : () => this.handleDeleteTag(thisTag)
                   }
-                  className={classes.tag}
                 />
               );
             })}
@@ -436,7 +422,7 @@ class TagsPanelRedesigned extends React.Component<CombinedProps, State> {
             <Typography className={classes.errorNotice}>{tagError}</Typography>
           )}
         </div>
-      </div>
+      </>
     );
   }
 }

--- a/packages/manager/src/components/TagsPanel/TagsPanelRedesigned.tsx
+++ b/packages/manager/src/components/TagsPanel/TagsPanelRedesigned.tsx
@@ -52,12 +52,7 @@ const styles = (theme: Theme) =>
     root: {},
     tag: {
       marginTop: theme.spacing(1) / 2,
-      marginLeft: theme.spacing(1),
       marginRight: 0,
-      [theme.breakpoints.down('xs')]: {
-        marginLeft: theme.spacing(2),
-      },
-      fontWeight: 600,
     },
     addButtonWrapper: {
       width: '100%',
@@ -167,6 +162,7 @@ interface State {
 }
 
 export interface Props {
+  align?: 'left' | 'right';
   tags: string[];
   updateTags: (tags: string[]) => Promise<any>;
   disabled?: boolean;
@@ -385,6 +381,11 @@ class TagsPanelRedesigned extends React.Component<CombinedProps, State> {
               [classes.addButtonWrapper]: true,
               [classes.hasError]: tagError,
             })}
+            style={
+              this.props.align === 'left'
+                ? { justifyContent: 'flex-start' }
+                : { justifyContent: 'flex-end' }
+            }
           >
             <button
               className={classes.addTagButton}
@@ -418,6 +419,11 @@ class TagsPanelRedesigned extends React.Component<CombinedProps, State> {
                   key={`tag-item-${thisTag}`}
                   colorVariant="lightBlue"
                   label={truncateEnd(thisTag, 30)}
+                  style={
+                    this.props.align === 'left'
+                      ? { marginRight: '4px' }
+                      : { marginLeft: '4px' }
+                  }
                   onDelete={
                     disabled ? undefined : () => this.handleDeleteTag(thisTag)
                   }

--- a/packages/manager/src/components/TagsPanel/TagsPanelRedesigned.tsx
+++ b/packages/manager/src/components/TagsPanel/TagsPanelRedesigned.tsx
@@ -25,6 +25,7 @@ import Typography from 'src/components/core/Typography';
 import Select from 'src/components/EnhancedSelect/Select';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import Tag from 'src/components/Tag/Tag_CMR';
+import { truncateEnd } from 'src/utilities/truncate';
 
 type ClassNames =
   | 'root'
@@ -51,15 +52,15 @@ const styles = (theme: Theme) =>
     root: {},
     tag: {
       marginTop: theme.spacing(1) / 2,
-      marginRight: theme.spacing(1),
+      marginLeft: theme.spacing(1),
+      marginRight: 0,
       [theme.breakpoints.down('xs')]: {
-        marginRight: theme.spacing(2),
+        marginLeft: theme.spacing(2),
       },
       fontWeight: 600,
     },
     addButtonWrapper: {
       width: '100%',
-      marginBottom: theme.spacing(2) + 1,
       display: 'flex',
       justifyContent: 'flex-end',
     },
@@ -99,7 +100,7 @@ const styles = (theme: Theme) =>
       },
     },
     tagsPanelItemWrapper: {
-      marginBottom: theme.spacing(2),
+      marginBottom: theme.spacing(),
       position: 'relative',
     },
     selectTag: {
@@ -373,6 +374,10 @@ class TagsPanelRedesigned extends React.Component<CombinedProps, State> {
             value={tagInputValue}
             createOptionPosition="first"
             className={classes.selectTag}
+            escapeClearsValue
+            blurInputOnSelect
+            // eslint-disable-next-line
+            autoFocus
           />
         ) : (
           <div
@@ -412,7 +417,7 @@ class TagsPanelRedesigned extends React.Component<CombinedProps, State> {
                 <Tag
                   key={`tag-item-${thisTag}`}
                   colorVariant="lightBlue"
-                  label={thisTag}
+                  label={truncateEnd(thisTag, 30)}
                   onDelete={
                     disabled ? undefined : () => this.handleDeleteTag(thisTag)
                   }

--- a/packages/manager/src/components/TagsPanel/TagsPanelRedesigned.tsx
+++ b/packages/manager/src/components/TagsPanel/TagsPanelRedesigned.tsx
@@ -7,7 +7,7 @@
  * "./TagsPanel.tsx" should be replaced with the contents of this file, and this
  * file should be deleted.
  */
-import AddCircle from '@material-ui/icons/AddCircle';
+import Plus from 'src/assets/icons/plusSign.svg';
 import * as classNames from 'classnames';
 import { getTags } from '@linode/api-v4/lib/tags';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
@@ -23,19 +23,16 @@ import {
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Select from 'src/components/EnhancedSelect/Select';
-import IconTextLink from 'src/components/IconTextLink';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
-import TagsPanelItem from './TagsPanelItem';
+import Tag from 'src/components/Tag/Tag_CMR';
 
 type ClassNames =
   | 'root'
   | 'tag'
   | 'addButtonWrapper'
-  | 'addButtonCircleIcon'
-  | 'addButtonText'
   | 'hasError'
   | 'errorNotice'
-  | 'addButton'
+  | 'addTagButton'
   | 'tagsPanelItemWrapper'
   | 'selectTag'
   | 'progress'
@@ -63,6 +60,8 @@ const styles = (theme: Theme) =>
     addButtonWrapper: {
       width: '100%',
       marginBottom: theme.spacing(2) + 1,
+      display: 'flex',
+      justifyContent: 'flex-end',
     },
     hasError: {
       marginTop: 0,
@@ -78,26 +77,26 @@ const styles = (theme: Theme) =>
       paddingLeft: 10,
       marginTop: 20,
     },
-    addButton: {
-      padding: 0,
-      marginRight: 2,
-      position: 'relative',
-      top: 2,
-      display: 'inline-block',
+    addTagButton: {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderRadius: 3,
+      backgroundColor: theme.color.tagButton,
+      border: 'none',
+      color: theme.cmrTextColors.linkActiveLight,
+      cursor: 'pointer',
+      fontFamily: theme.font.normal,
+      fontSize: 14,
+      fontWeight: 'bold',
+      padding: '7px 10px',
+      whiteSpace: 'nowrap',
       '& svg': {
-        marginRight: theme.spacing(1),
+        color: theme.color.tagIcon,
+        marginLeft: 10,
+        height: 10,
+        width: 10,
       },
-      '&:hover p': {
-        color: theme.palette.primary.main,
-      },
-    },
-    addButtonCircleIcon: {
-      width: 16,
-      height: 16,
-    },
-    addButtonText: {
-      color: theme.palette.primary.main,
-      fontWeight: 700,
     },
     tagsPanelItemWrapper: {
       marginBottom: theme.spacing(2),
@@ -194,18 +193,18 @@ class TagsPanelRedesigned extends React.Component<CombinedProps, State> {
          * tags that are already applied because there cannot
          * be duplicates.
          */
-        const filteredTags = response.data.filter((eachTag: Tag) => {
+        const filteredTags = response.data.filter((thisTag: Tag) => {
           return !tags.some((alreadyAppliedTag: string) => {
-            return alreadyAppliedTag === eachTag.label;
+            return alreadyAppliedTag === thisTag.label;
           });
         });
         /*
          * reshaping them for the purposes of being passed to the Select component
          */
-        const reshapedTags = filteredTags.map((eachTag: Tag) => {
+        const reshapedTags = filteredTags.map((thisTag: Tag) => {
           return {
-            label: eachTag.label,
-            value: eachTag.label,
+            label: thisTag.label,
+            value: thisTag.label,
           };
         });
         this.setState({ tagsToSuggest: reshapedTags });
@@ -238,9 +237,10 @@ class TagsPanelRedesigned extends React.Component<CombinedProps, State> {
          * with the deleted tag filtered out). It's important to note that the Tag is *not*
          * being deleted here - it's just being removed from the list
          */
-        const tagsWithoutDeletedTag = tags.filter((eachTag: string) => {
-          return this.state.listDeletingTags.indexOf(eachTag) === -1;
+        const tagsWithoutDeletedTag = tags.filter((thisTag: string) => {
+          return this.state.listDeletingTags.indexOf(thisTag) === -1;
         });
+
         updateTags(tagsWithoutDeletedTag)
           .then(() => {
             /*
@@ -256,13 +256,13 @@ class TagsPanelRedesigned extends React.Component<CombinedProps, State> {
                 ...cloneTagSuggestions,
               ],
               listDeletingTags: this.state.listDeletingTags.filter(
-                (eachTag) => eachTag !== label
+                (thisTag) => thisTag !== label
               ),
               loading: false,
               tagError: '',
             });
           })
-          .catch((e) => {
+          .catch((_) => {
             this.props.enqueueSnackbar(`Could not delete Tag: ${label}`, {
               variant: 'error',
             });
@@ -271,7 +271,7 @@ class TagsPanelRedesigned extends React.Component<CombinedProps, State> {
              */
             this.setState({
               listDeletingTags: this.state.listDeletingTags.filter(
-                (eachTag) => eachTag !== label
+                (thisTag) => thisTag !== label
               ),
               loading: false,
             });
@@ -326,8 +326,8 @@ class TagsPanelRedesigned extends React.Component<CombinedProps, State> {
            * since we can't attach this tag anymore
            */
           const cloneTagSuggestions = clone(tagsToSuggest) || [];
-          const filteredTags = cloneTagSuggestions.filter((eachTag: Item) => {
-            return eachTag.label !== value.label;
+          const filteredTags = cloneTagSuggestions.filter((thisTag: Item) => {
+            return thisTag.label !== value.label;
           });
           this.setState({
             tagsToSuggest: filteredTags,
@@ -349,7 +349,6 @@ class TagsPanelRedesigned extends React.Component<CombinedProps, State> {
 
     const {
       isCreatingTag,
-      listDeletingTags,
       tagsToSuggest,
       tagInputValue,
       tagError,
@@ -373,10 +372,7 @@ class TagsPanelRedesigned extends React.Component<CombinedProps, State> {
             hideLabel
             value={tagInputValue}
             createOptionPosition="first"
-            autoFocus
             className={classes.selectTag}
-            blurInputOnSelect={false}
-            menuIsOpen={!loading && !tagError}
           />
         ) : (
           <div
@@ -385,13 +381,14 @@ class TagsPanelRedesigned extends React.Component<CombinedProps, State> {
               [classes.hasError]: tagError,
             })}
           >
-            <IconTextLink
-              text="Add a tag"
-              SideIcon={AddCircle}
+            <button
+              className={classes.addTagButton}
               title="Add a tag"
               onClick={this.toggleTagInput}
-              className={classes.addButton}
-            />
+            >
+              Add a tag
+              <Plus />
+            </button>
           </div>
         )}
 
@@ -410,21 +407,16 @@ class TagsPanelRedesigned extends React.Component<CombinedProps, State> {
               [classes.loading]: loading,
             })}
           >
-            {tags.map((eachTag) => {
+            {tags.map((thisTag) => {
               return (
-                <TagsPanelItem
-                  key={eachTag}
-                  label={eachTag}
-                  tagLabel={eachTag}
-                  onDelete={disabled ? undefined : this.handleDeleteTag}
+                <Tag
+                  key={`tag-item-${thisTag}`}
+                  colorVariant="lightBlue"
+                  label={thisTag}
+                  onDelete={
+                    disabled ? undefined : () => this.handleDeleteTag(thisTag)
+                  }
                   className={classes.tag}
-                  loading={listDeletingTags.some((inProgressTag) => {
-                    /*
-                     * The tag is getting deleted if it appears in the state
-                     * which holds the list of tags queued for deletion
-                     */
-                    return eachTag === inProgressTag;
-                  })}
                 />
               );
             })}

--- a/packages/manager/src/components/TagsPanel/TagsPanelRedesigned.tsx
+++ b/packages/manager/src/components/TagsPanel/TagsPanelRedesigned.tsx
@@ -25,7 +25,6 @@ import Typography from 'src/components/core/Typography';
 import Select from 'src/components/EnhancedSelect/Select';
 import Tag from 'src/components/Tag/Tag_CMR';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
-import { truncateEnd } from 'src/utilities/truncate';
 
 type ClassNames =
   | 'root'
@@ -410,7 +409,8 @@ class TagsPanelRedesigned extends React.Component<CombinedProps, State> {
                   key={`tag-item-${thisTag}`}
                   className={classes.tag}
                   colorVariant="lightBlue"
-                  label={truncateEnd(thisTag, 30)}
+                  label={thisTag}
+                  maxLength={30}
                   onDelete={
                     disabled ? undefined : () => this.handleDeleteTag(thisTag)
                   }

--- a/packages/manager/src/components/TagsPanel/TagsPanelRedesigned.tsx
+++ b/packages/manager/src/components/TagsPanel/TagsPanelRedesigned.tsx
@@ -7,13 +7,13 @@
  * "./TagsPanel.tsx" should be replaced with the contents of this file, and this
  * file should be deleted.
  */
-import Plus from 'src/assets/icons/plusSign.svg';
-import * as classNames from 'classnames';
 import { getTags } from '@linode/api-v4/lib/tags';
+import * as classNames from 'classnames';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import { clone } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
+import Plus from 'src/assets/icons/plusSign.svg';
 import CircleProgress from 'src/components/CircleProgress';
 import {
   createStyles,
@@ -23,8 +23,8 @@ import {
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Select from 'src/components/EnhancedSelect/Select';
-import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import Tag from 'src/components/Tag/Tag_CMR';
+import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import { truncateEnd } from 'src/utilities/truncate';
 
 type ClassNames =

--- a/packages/manager/src/features/Domains/DomainRecords.tsx
+++ b/packages/manager/src/features/Domains/DomainRecords.tsx
@@ -45,7 +45,7 @@ import TableCell from 'src/components/TableCell';
 import TableRowEmptyState from 'src/components/TableRowEmptyState';
 import withFeatureFlags, {
   FeatureFlagConsumerProps,
-} from 'src/containers/withFeatureFlagConsumer.container.ts';
+} from 'src/containers/withFeatureFlagConsumer.container';
 import {
   getAPIErrorOrDefault,
   getErrorStringOrDefault,

--- a/packages/manager/src/features/Domains/DomainRecordsWrapper.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordsWrapper.tsx
@@ -6,12 +6,10 @@ import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme, withStyles } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
-import TagsPanel from 'src/components/TagsPanel';
 import TagsPanelRedesigned from 'src/components/TagsPanel/TagsPanelRedesigned';
 import summaryPanelStyles, {
   StyleProps,
 } from 'src/containers/SummaryPanels.styles';
-import useFlags from 'src/hooks/useFlags';
 import DeleteDomain from './DeleteDomain';
 import DomainRecords from './DomainRecords';
 
@@ -44,9 +42,7 @@ const useStyles = makeStyles((theme: Theme) => ({
       marginLeft: theme.spacing(),
     },
   },
-  tagPanel: {
-    maxWidth: 500,
-  },
+  tagPanel: {},
 }));
 
 interface Props {
@@ -62,7 +58,6 @@ const DomainRecordsWrapper: React.FC<CombinedProps> = (props) => {
   const { domain, records, updateRecords, handleUpdateTags, classes } = props;
   const hookClasses = useStyles();
   const history = useHistory();
-  const flags = useFlags();
 
   return (
     <Grid container className={hookClasses.root}>
@@ -84,21 +79,14 @@ const DomainRecordsWrapper: React.FC<CombinedProps> = (props) => {
             Tags
           </Typography>
           <div className={hookClasses.tagPanel}>
-            {flags.cmr ? (
-              <TagsPanelRedesigned
-                tags={domain.tags}
-                updateTags={handleUpdateTags}
-              />
-            ) : (
-              <TagsPanel tags={domain.tags} updateTags={handleUpdateTags} />
-            )}
+            <TagsPanelRedesigned
+              align="left"
+              tags={domain.tags}
+              updateTags={handleUpdateTags}
+            />
           </div>
         </Paper>
-        <div
-          className={`${hookClasses.tagPanel} ${
-            flags.cmr && hookClasses.cmrSpacing
-          }`}
-        >
+        <div className={`${hookClasses.tagPanel} ${hookClasses.cmrSpacing}`}>
           <DeleteDomain
             domainId={domain.id}
             domainLabel={domain.domain}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
@@ -15,6 +15,7 @@ import MapPin from 'src/assets/icons/map-pin-icon.svg';
 import MiniKube from 'src/assets/icons/mini-kube.svg';
 import PriceIcon from 'src/assets/icons/price-icon.svg';
 import RamIcon from 'src/assets/icons/ram-sticks.svg';
+import Button from 'src/components/Button';
 import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
@@ -136,10 +137,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
   },
   deleteButton: {
-    ...theme.applyLinkStyles,
-    marginBottom: theme.spacing(),
     position: 'absolute',
-    top: 4,
     right: theme.spacing(),
   },
 }));
@@ -432,28 +430,21 @@ export const KubeSummaryPanel: React.FunctionComponent<Props> = (props) => {
           {setKubeconfigDisplay()}
 
           <Grid item className={classes.tags} xs={12} lg={4}>
-            {/* <Grid
-              container
-              direction="column"
-              alignItems="flex-end"
-              className={classes.tagsSection}
-            >
-              <Grid item className={classes.tags}> */}
             <TagsPanel
               align="right"
               tags={cluster.tags}
               updateTags={handleUpdateTags}
             />
-            {/* </Grid>
-            </Grid> */}
           </Grid>
 
-          <button
+          <Button
+            buttonType="secondary"
             className={classes.deleteButton}
             onClick={() => openDialog(cluster.id)}
+            superCompact
           >
             Delete Cluster
-          </button>
+          </Button>
         </Grid>
       </Paper>
 

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
@@ -15,7 +15,7 @@ import MiniKube from 'src/assets/icons/mini-kube.svg';
 import PriceIcon from 'src/assets/icons/price-icon.svg';
 import RamIcon from 'src/assets/icons/ram-sticks.svg';
 import Paper from 'src/components/core/Paper';
-import { Theme, makeStyles } from 'src/components/core/styles';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 import TagsPanel from 'src/components/TagsPanel/TagsPanelRedesigned';

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
@@ -40,6 +40,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     }px ${theme.spacing(3)}px`,
   },
   mainGridContainer: {
+    position: 'relative',
     [theme.breakpoints.up('lg')]: {
       justifyContent: 'space-between',
     },
@@ -98,27 +99,34 @@ const useStyles = makeStyles((theme: Theme) => ({
     minWidth: 115,
   },
   tags: {
-    [theme.breakpoints.up(1400)]: {
-      flexBasis: '100%',
-      flexGrow: 0,
-      maxWidth: '100%',
+    '&.MuiGrid-item': {
+      paddingBottom: 0,
     },
-    [theme.breakpoints.down(1400)]: {
-      marginLeft: theme.spacing(),
-      '& > div': {
-        flexDirection: 'row-reverse',
-        '& > button': {
-          marginRight: 4,
-        },
-        '& > div': {
-          justifyContent: 'flex-start !important',
-        },
+    [theme.breakpoints.up('lg')]: {
+      marginTop: theme.spacing(2),
+      '& .MuiChip-root': {
+        marginRight: 0,
+        marginLeft: 4,
+      },
+    },
+    [theme.breakpoints.down('md')]: {
+      width: '100%',
+      // Add a Tag button
+      '& > div:first-child': {
+        justifyContent: 'flex-start !important',
+      },
+      // Tags Panel wrapper
+      '& > div:last-child': {
+        marginBottom: 2,
       },
     },
   },
   deleteButton: {
     ...theme.applyLinkStyles,
     marginBottom: theme.spacing(),
+    position: 'absolute',
+    top: 4,
+    right: theme.spacing(),
   },
 }));
 
@@ -406,21 +414,13 @@ export const KubeSummaryPanel: React.FunctionComponent<Props> = (props) => {
 
           {setKubeconfigDisplay()}
 
-          <Grid item xs={12} lg={4}>
+          <Grid item xs={12} lg={4} style={{ marginTop: 8 }}>
             <Grid
               container
               direction="column"
               alignItems="flex-end"
               className={classes.tagsSection}
             >
-              <Grid item>
-                <button
-                  className={classes.deleteButton}
-                  onClick={() => openDialog(cluster.id)}
-                >
-                  Delete Cluster
-                </button>
-              </Grid>
               <Grid item className={classes.tags}>
                 <TagsPanel
                   align="right"
@@ -430,6 +430,13 @@ export const KubeSummaryPanel: React.FunctionComponent<Props> = (props) => {
               </Grid>
             </Grid>
           </Grid>
+
+          <button
+            className={classes.deleteButton}
+            onClick={() => openDialog(cluster.id)}
+          >
+            Delete Cluster
+          </button>
         </Grid>
       </Paper>
 

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
@@ -19,7 +19,7 @@ import Paper from 'src/components/core/Paper';
 import { Theme, makeStyles } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
-import TagCell, { TagDrawer } from 'src/components/TagCell';
+import TagsPanel from 'src/components/TagsPanel/TagsPanelRedesigned';
 import { dcDisplayNames } from 'src/constants';
 import { reportException } from 'src/exceptionReporting';
 import { ExtendedCluster } from 'src/features/Kubernetes/types';
@@ -162,7 +162,6 @@ export const KubeSummaryPanel: React.FunctionComponent<Props> = (props) => {
   const [drawerOpen, setDrawerOpen] = React.useState<boolean>(false);
   const [drawerError, setDrawerError] = React.useState<string | null>(null);
   const [drawerLoading, setDrawerLoading] = React.useState<boolean>(false);
-  const [tagDrawerOpen, setTagDrawerOpen] = React.useState(false);
   const region = dcDisplayNames[cluster.region] || 'Unknown region';
 
   // Deletion handlers
@@ -177,15 +176,6 @@ export const KubeSummaryPanel: React.FunctionComponent<Props> = (props) => {
   const { dialog, closeDialog, openDialog, submitDialog } = useDialog(
     _deleteCluster
   );
-
-  const addTag = (tag: string) => {
-    return handleUpdateTags([...cluster.tags, tag]);
-  };
-
-  const deleteTag = (tag: string) => {
-    const newTags = cluster.tags.filter((thisTag) => thisTag !== tag);
-    return handleUpdateTags(newTags);
-  };
 
   const [kubeConfig, setKubeConfig] = React.useState<string>('');
 
@@ -432,13 +422,7 @@ export const KubeSummaryPanel: React.FunctionComponent<Props> = (props) => {
                 </Button>
               </Grid>
               <Grid item className={classes.tags}>
-                <TagCell
-                  tags={cluster.tags}
-                  width={500}
-                  addTag={addTag}
-                  deleteTag={deleteTag}
-                  listAllTags={() => setTagDrawerOpen(true)}
-                />
+                <TagsPanel tags={cluster.tags} updateTags={handleUpdateTags} />
               </Grid>
             </Grid>
           </Grid>
@@ -461,14 +445,6 @@ export const KubeSummaryPanel: React.FunctionComponent<Props> = (props) => {
         clusterPools={cluster.node_pools}
         onClose={closeDialog}
         onDelete={() => submitDialog(cluster.id)}
-      />
-      <TagDrawer
-        entityLabel={cluster.label}
-        open={tagDrawerOpen}
-        tags={cluster.tags}
-        addTag={addTag}
-        deleteTag={deleteTag}
-        onClose={() => setTagDrawerOpen(false)}
       />
     </React.Fragment>
   );

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
@@ -422,7 +422,11 @@ export const KubeSummaryPanel: React.FunctionComponent<Props> = (props) => {
                 </button>
               </Grid>
               <Grid item className={classes.tags}>
-                <TagsPanel tags={cluster.tags} updateTags={handleUpdateTags} />
+                <TagsPanel
+                  align="right"
+                  tags={cluster.tags}
+                  updateTags={handleUpdateTags}
+                />
               </Grid>
             </Grid>
           </Grid>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
@@ -14,7 +14,6 @@ import MapPin from 'src/assets/icons/map-pin-icon.svg';
 import MiniKube from 'src/assets/icons/mini-kube.svg';
 import PriceIcon from 'src/assets/icons/price-icon.svg';
 import RamIcon from 'src/assets/icons/ram-sticks.svg';
-import Button from 'src/components/Button';
 import Paper from 'src/components/core/Paper';
 import { Theme, makeStyles } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
@@ -84,6 +83,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   tagsSection: {
     display: 'flex',
+    height: '100%',
     [theme.breakpoints.up('lg')]: {
       justifyContent: 'flex-end',
       textAlign: 'right',
@@ -117,7 +117,8 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
   },
   deleteButton: {
-    paddingRight: 0,
+    ...theme.applyLinkStyles,
+    marginBottom: theme.spacing(),
   },
 }));
 
@@ -412,14 +413,13 @@ export const KubeSummaryPanel: React.FunctionComponent<Props> = (props) => {
               alignItems="flex-end"
               className={classes.tagsSection}
             >
-              <Grid item className={classes.deleteButton}>
-                <Button
-                  superCompact
-                  buttonType="secondary"
+              <Grid item>
+                <button
+                  className={classes.deleteButton}
                   onClick={() => openDialog(cluster.id)}
                 >
                   Delete Cluster
-                </Button>
+                </button>
               </Grid>
               <Grid item className={classes.tags}>
                 <TagsPanel tags={cluster.tags} updateTags={handleUpdateTags} />

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
@@ -6,6 +6,7 @@ import { APIError } from '@linode/api-v4/lib/types';
 import { useSnackbar } from 'notistack';
 import * as React from 'react';
 import { useDispatch } from 'react-redux';
+import { useHistory } from 'react-router-dom';
 import DetailsIcon from 'src/assets/icons/code-file.svg';
 import CPUIcon from 'src/assets/icons/cpu-icon.svg';
 import DiskIcon from 'src/assets/icons/disk.svg';
@@ -167,6 +168,7 @@ export const KubeSummaryPanel: React.FunctionComponent<Props> = (props) => {
     handleUpdateTags,
   } = props;
   const classes = useStyles();
+  const { push } = useHistory();
   const { enqueueSnackbar } = useSnackbar();
   const [drawerOpen, setDrawerOpen] = React.useState<boolean>(false);
   const [drawerError, setDrawerError] = React.useState<string | null>(null);
@@ -180,7 +182,9 @@ export const KubeSummaryPanel: React.FunctionComponent<Props> = (props) => {
   // since we're going to switch to queries for all of these soon.
   const dispatch: ThunkDispatch = useDispatch();
   const _deleteCluster = () =>
-    dispatch(deleteCluster({ clusterID: cluster.id }));
+    dispatch(deleteCluster({ clusterID: cluster.id })).then(() =>
+      push('/kubernetes/clusters')
+    );
 
   const { dialog, closeDialog, openDialog, submitDialog } = useDialog(
     _deleteCluster

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
@@ -53,35 +53,35 @@ const useStyles = makeStyles((theme: Theme) => ({
     paddingBottom: theme.spacing(1),
   },
   label: {
-    marginBottom: `${theme.spacing(1) - 3}px`,
     fontWeight: 'bold',
+    marginBottom: `${theme.spacing(1) - 3}px`,
   },
   column: {},
   iconsSharedStyling: {
-    width: 24,
     height: 24,
+    width: 24,
     objectFit: 'contain',
   },
   kubeconfigSection: {
     marginTop: `${theme.spacing() + 2}px`,
   },
   kubeconfigElements: {
-    color: theme.palette.primary.main,
     display: 'flex',
     alignItems: 'center',
+    color: theme.palette.primary.main,
   },
   kubeconfigFileText: {
-    cursor: 'pointer',
     color: theme.cmrTextColors.linkActiveLight,
+    cursor: 'pointer',
     marginRight: theme.spacing(1),
   },
   kubeconfigIcons: {
     color: theme.cmrTextColors.linkActiveLight,
     cursor: 'pointer',
-    width: 16,
     height: 16,
-    objectFit: 'contain',
+    width: 16,
     margin: `0 ${theme.spacing(1)}px`,
+    objectFit: 'contain',
   },
   tagsSection: {
     display: 'flex',
@@ -92,34 +92,47 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
   },
   iconSharedOuter: {
-    textAlign: 'center',
     flexBasis: '28%',
+    textAlign: 'center',
   },
   iconTextOuter: {
     flexBasis: '72%',
     minWidth: 115,
   },
   tags: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignSelf: 'stretch',
+    alignItems: 'flex-end',
+    justifyContent: 'flex-end',
     '&.MuiGrid-item': {
       paddingBottom: 0,
     },
+    // Tags Panel wrapper
+    '& > div:last-child': {
+      marginTop: 2,
+      marginBottom: 0,
+      width: '100%',
+    },
     [theme.breakpoints.up('lg')]: {
-      marginTop: theme.spacing(2),
       '& .MuiChip-root': {
         marginRight: 0,
         marginLeft: 4,
       },
-    },
-    [theme.breakpoints.down('md')]: {
-      width: '100%',
       // Add a Tag button
       '& > div:first-child': {
-        justifyContent: 'flex-start !important',
+        justifyContent: 'flex-end',
+        marginTop: theme.spacing(5),
       },
       // Tags Panel wrapper
       '& > div:last-child': {
-        marginBottom: 2,
+        display: 'flex',
+        flexWrap: 'wrap',
+        justifyContent: 'flex-end',
       },
+    },
+    [theme.breakpoints.down('md')]: {
+      width: '100%',
     },
   },
   deleteButton: {
@@ -418,21 +431,21 @@ export const KubeSummaryPanel: React.FunctionComponent<Props> = (props) => {
 
           {setKubeconfigDisplay()}
 
-          <Grid item xs={12} lg={4} style={{ marginTop: 8 }}>
-            <Grid
+          <Grid item className={classes.tags} xs={12} lg={4}>
+            {/* <Grid
               container
               direction="column"
               alignItems="flex-end"
               className={classes.tagsSection}
             >
-              <Grid item className={classes.tags}>
-                <TagsPanel
-                  align="right"
-                  tags={cluster.tags}
-                  updateTags={handleUpdateTags}
-                />
-              </Grid>
-            </Grid>
+              <Grid item className={classes.tags}> */}
+            <TagsPanel
+              align="right"
+              tags={cluster.tags}
+              updateTags={handleUpdateTags}
+            />
+            {/* </Grid>
+            </Grid> */}
           </Grid>
 
           <button

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesDialog.tsx
@@ -38,7 +38,6 @@ const renderActions = (
       <Button
         buttonType="primary"
         disabled={disabled}
-        destructive
         loading={loading}
         onClick={onDelete}
         data-qa-confirm


### PR DESCRIPTION
## Description

Currently it's only possible to delete a cluster from the action menu on the cluster list view. This adds a button to do the same thing from a cluster's detail view.

Also included in the ticket is restyling the tags section of the summary panel to match what's used in Linode detail view. This is tricky since it's the same component used in DomainRecordWrapper. I don't love what I did here, I tried to match the appearance and behavior of the TagCell component, which we can't use here because it requires a fixed width to do its fade-out magic. Discussed this with Matthew and decided on this approach for now.