### PR TITLE
M3-4970: Linode Details graphs UI refinements

### DIFF
--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -140,14 +140,23 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
       scales: {
         yAxes: [
           {
+            // Defines a fixed width for the Y-axis labels
+            afterFit(axes) {
+              axes.width = 32;
+            },
             gridLines: {
               borderDash: [3, 6],
+              drawTicks: false,
               zeroLineWidth: 1,
               zeroLineBorderDashOffset: 2,
             },
             ticks: {
-              suggestedMax: _suggestedMax ?? undefined,
               beginAtZero: true,
+              fontSize: 12,
+              fontStyle: 'normal',
+              maxTicksLimit: 8,
+              padding: 10,
+              suggestedMax: _suggestedMax ?? undefined,
               callback(value: number, _index: number) {
                 return humanizeLargeData(value);
               },
@@ -176,6 +185,10 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
               date: {
                 zone: timezone,
               },
+            },
+            ticks: {
+              fontSize: 12,
+              fontStyle: 'normal',
             },
             // This cast is because the type definition does not include adapters
           } as ChartXAxe,

--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -1,22 +1,20 @@
-import { curry } from 'ramda';
-import * as React from 'react';
 import {
+  Chart,
+  ChartData,
   ChartDataSets,
   ChartOptions,
-  Chart,
-  ChartXAxe,
   ChartTooltipItem,
-  ChartData,
+  ChartXAxe,
 } from 'chart.js';
 import 'chartjs-adapter-luxon';
-
-import LineChartIcon from 'src/assets/icons/line-chart.svg';
+import { curry } from 'ramda';
+import * as React from 'react';
 import Button from 'src/components/Button';
 import {
   makeStyles,
   Theme,
-  useTheme,
   useMediaQuery,
+  useTheme,
 } from 'src/components/core/styles';
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
@@ -28,6 +26,7 @@ import { setUpCharts } from 'src/utilities/charts';
 import roundTo from 'src/utilities/roundTo';
 import { Metrics } from 'src/utilities/statMetrics';
 import MetricDisplayStyles from './NewMetricDisplay.styles';
+
 setUpCharts();
 
 export interface DataSet {
@@ -80,14 +79,14 @@ const humanizeLargeData = (value: number) => {
 };
 
 const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
+  const classes = useStyles();
+  const theme = useTheme<Theme>();
+  const matchesSmDown = useMediaQuery(theme.breakpoints.down(960));
+
   const inputEl: React.RefObject<any> = React.useRef(null);
   const chartInstance: React.MutableRefObject<any> = React.useRef(null);
   const [legendRendered, setLegendRendered] = React.useState(false);
   const [hiddenDatasets, setHiddenDatasets] = React.useState<number[]>([]);
-
-  const classes = useStyles();
-  const theme = useTheme<Theme>();
-  const matchesSmDown = useMediaQuery(theme.breakpoints.down(960));
 
   const {
     chartHeight,
@@ -102,6 +101,7 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
     nativeLegend,
     unit,
   } = props;
+
   const finalRowHeaders = rowHeaders ? rowHeaders : ['Max', 'Avg', 'Last'];
   // is undefined on linode/summary
   const plugins = [
@@ -187,7 +187,7 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
         bodyFontColor: '#32363C',
         displayColors: false,
         titleFontColor: '#606469',
-        xPadding: 16,
+        xPadding: 8,
         yPadding: 10,
         borderWidth: 0.5,
         borderColor: '#999',
@@ -288,16 +288,7 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
                 ))
               ) : (
                 <TableRow>
-                  <TableCell className={classes.tableHeadInner}>
-                    <Typography
-                      variant="body1"
-                      component="span"
-                      className={classes.text}
-                    >
-                      Toggle Graphs
-                    </Typography>
-                    <LineChartIcon className={classes.chartIcon} />
-                  </TableCell>
+                  <TableCell style={{ height: 26 }} />
                   {finalRowHeaders.map((section, i) => (
                     <TableCell
                       key={i}

--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -262,14 +262,14 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
   });
   return (
     <div className={classes.wrapper}>
-      <div style={{ width: '100%' }}>
+      <div>
         <canvas height={chartHeight || 300} ref={inputEl} />
       </div>
       {legendRendered && legendRows && (
         <div className={classes.container}>
           <Table aria-label="Stats and metrics" className={classes.root}>
             <TableHead className={classes.tableHead}>
-              {/* Remove "Toggle Graph" label and repeat legend for each data set for mobile */}
+              {/* Repeat legend for each data set for mobile */}
               {matchesSmDown ? (
                 data.map((section) => (
                   <TableRow key={section.label}>

--- a/packages/manager/src/components/LineGraph/NewMetricDisplay.styles.ts
+++ b/packages/manager/src/components/LineGraph/NewMetricDisplay.styles.ts
@@ -42,10 +42,15 @@ const newMetricDisplayStyles = (theme: Theme) =>
     },
     root: {
       maxWidth: 600,
+      width: '85%',
       '& *': {
         height: 'auto',
         border: 'none',
         backgroundColor: 'transparent',
+        tableLayout: 'fixed',
+      },
+      '& th, td': {
+        padding: `${theme.spacing(0.5)}px !important`,
       },
       '& td:first-child': {
         backgroundColor: 'transparent !important',
@@ -60,6 +65,9 @@ const newMetricDisplayStyles = (theme: Theme) =>
         '& th, & td': {
           padding: '4px !important',
         },
+      },
+      [theme.breakpoints.down('md')]: {
+        width: '100%',
       },
       [theme.breakpoints.down('sm')]: {
         maxWidth: '100%',
@@ -103,8 +111,12 @@ const newMetricDisplayStyles = (theme: Theme) =>
       },
     },
     tableHeadInner: {
+      width: '23%',
       '& p': {
         color: theme.cmrTextColors.tableHeader,
+      },
+      [theme.breakpoints.down('md')]: {
+        width: '20%',
       },
     },
     toggleButton: {

--- a/packages/manager/src/components/LineGraph/NewMetricDisplay.styles.ts
+++ b/packages/manager/src/components/LineGraph/NewMetricDisplay.styles.ts
@@ -32,14 +32,13 @@ const newMetricDisplayStyles = (theme: Theme) =>
       },
     },
     container: {
-      margin: `${theme.spacing(2)}px ${theme.spacing(1)}px ${theme.spacing(
-        1
-      )}px`,
-      padding: 10,
+      borderTop: `1px solid ${theme.color.border3}`,
       color: '#777',
-      backgroundColor: theme.bg.offWhiteDT,
-      border: `1px solid ${theme.color.border3}`,
-      fontSize: 14,
+      fontSize: '0.875rem',
+      marginTop: theme.spacing(0.5),
+      marginLeft: theme.spacing(4),
+      marginRight: theme.spacing(),
+      paddingTop: theme.spacing(0.5),
     },
     root: {
       maxWidth: 600,
@@ -104,16 +103,24 @@ const newMetricDisplayStyles = (theme: Theme) =>
       },
     },
     tableHeadInner: {
-      paddingBottom: 4,
+      '& p': {
+        color: theme.cmrTextColors.tableHeader,
+      },
     },
     toggleButton: {
-      padding: 0,
-      margin: 0,
       justifyContent: 'flex-start',
+      color: theme.color.headline,
       fontFamily: theme.font.normal,
-      fontSize: 14,
+      fontSize: '0.75rem',
+      margin: 0,
+      marginLeft: -2,
+      padding: 0,
       '&:focus': {
         outline: `1px dotted #ccc`,
+      },
+      '&:hover': {
+        backgroundColor: 'transparent',
+        color: theme.color.headline,
       },
     },
     legend: {
@@ -130,6 +137,7 @@ const newMetricDisplayStyles = (theme: Theme) =>
     },
     text: {
       color: theme.color.black,
+      fontSize: '0.75rem',
     },
     simpleLegendRoot: {
       maxWidth: 'initial',

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.test.tsx
@@ -20,8 +20,8 @@ describe('LinodeSummary', () => {
         chart: '',
         graphControls: '',
         graphGrids: '',
+        grid: '',
         chartSelect: '',
-        headerOuter: '',
         labelRangeSelect: '',
       }}
       theme={light()}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -56,6 +56,7 @@ type ClassNames =
 const styles = (theme: Theme) =>
   createStyles({
     root: {
+      paddingBottom: theme.spacing(3),
       width: '100%',
     },
     chart: {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -68,13 +68,15 @@ const styles = (theme: Theme) =>
     graphControls: {
       display: 'flex',
       alignItems: 'center',
+      justifyContent: 'space-between',
       marginTop: theme.spacing(0.5),
       paddingLeft: theme.spacing(),
+      paddingRight: theme.spacing(),
     },
     graphGrids: {
       flexWrap: 'nowrap',
       margin: 0,
-      [theme.breakpoints.down('md')]: {
+      [theme.breakpoints.down(1100)]: {
         flexWrap: 'wrap',
       },
     },
@@ -86,11 +88,15 @@ const styles = (theme: Theme) =>
       '&.MuiGrid-item': {
         padding: theme.spacing(2),
       },
-      [theme.breakpoints.down('md')]: {
+      '& h2': {
+        fontSize: '1rem',
+      },
+      [theme.breakpoints.down(1100)]: {
         marginBottom: theme.spacing(2),
       },
     },
     labelRangeSelect: {
+      fontSize: '1rem',
       paddingRight: theme.spacing(2),
     },
   });

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -50,7 +50,7 @@ type ClassNames =
   | 'chartSelect'
   | 'graphControls'
   | 'graphGrids'
-  | 'headerOuter'
+  | 'grid'
   | 'labelRangeSelect';
 
 const styles = (theme: Theme) =>
@@ -59,9 +59,7 @@ const styles = (theme: Theme) =>
       width: '100%',
     },
     chart: {
-      position: 'relative',
-      paddingTop: theme.spacing(2),
-      paddingLeft: theme.spacing(3),
+      paddingTop: theme.spacing(),
     },
     chartSelect: {
       maxWidth: 150,
@@ -79,14 +77,20 @@ const styles = (theme: Theme) =>
         flexWrap: 'wrap',
       },
     },
-    headerOuter: {
-      [theme.breakpoints.up('md')]: {
-        display: 'flex',
-        justifyContent: 'space-between',
+    grid: {
+      backgroundColor: theme.bg.offWhiteDT,
+      border: 'solid 1px #eeeeee',
+      marginLeft: theme.spacing(),
+      marginRight: theme.spacing(),
+      '&.MuiGrid-item': {
+        padding: theme.spacing(2),
+      },
+      [theme.breakpoints.down('md')]: {
+        marginBottom: theme.spacing(2),
       },
     },
     labelRangeSelect: {
-      paddingRight: '1em',
+      paddingRight: theme.spacing(2),
     },
   });
 
@@ -118,7 +122,7 @@ type CombinedProps = Props &
   WithImages &
   WithStyles<ClassNames>;
 
-const chartHeight = 240;
+const chartHeight = 160;
 
 const statsFetchInterval = 30000;
 
@@ -380,7 +384,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
           <Grid item xs={12}>
             <div className={classes.graphControls}>
               <Typography variant="h2" className={classes.labelRangeSelect}>
-                Resource Allocation
+                Metrics Dashboard
               </Typography>
               <Select
                 options={this.rangeSelectOptions}
@@ -399,14 +403,14 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
           </Grid>
           {!isBareMetalInstance ? (
             <Grid container item xs={12} className={classes.graphGrids}>
-              <Grid item xs={12}>
+              <Grid item className={classes.grid} xs={12}>
                 <StatsPanel
                   title="CPU (%)"
                   renderBody={this.renderCPUChart}
                   {...chartProps}
                 />
               </Grid>
-              <Grid item xs={12}>
+              <Grid item className={classes.grid} xs={12}>
                 <StatsPanel
                   title="Disk IO (blocks/s)"
                   renderBody={this.renderDiskIOChart}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph.tsx
@@ -34,8 +34,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     flexWrap: 'nowrap',
     margin: 0,
     padding: theme.spacing(),
-    [theme.breakpoints.down('md')]: {
+    [theme.breakpoints.down(1100)]: {
       flexWrap: 'wrap',
+      marginTop: -theme.spacing(2),
     },
   },
   grid: {
@@ -46,17 +47,15 @@ const useStyles = makeStyles((theme: Theme) => ({
     '&.MuiGrid-item': {
       padding: theme.spacing(2),
     },
-    [theme.breakpoints.down('md')]: {
+    '& h2': {
+      fontSize: '1rem',
+    },
+    [theme.breakpoints.down(1100)]: {
       marginBottom: theme.spacing(2),
     },
   },
   chart: {
     paddingTop: theme.spacing(),
-  },
-  ipv4: {
-    '& .chartjs-render-monitor': {
-      paddingLeft: theme.spacing(),
-    },
   },
 }));
 
@@ -162,7 +161,7 @@ export const NetworkGraph: React.FC<CombinedProps> = (props) => {
 
   return (
     <Grid container className={classes.graphGrids}>
-      <Grid item className={`${classes.grid} ${classes.ipv4}`} xs={12}>
+      <Grid item className={classes.grid} xs={12}>
         <StatsPanel
           title={`Network — IPv4 (${v4Unit}/s)`}
           renderBody={() => (

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph.tsx
@@ -53,6 +53,11 @@ const useStyles = makeStyles((theme: Theme) => ({
   chart: {
     paddingTop: theme.spacing(),
   },
+  ipv4: {
+    '& .chartjs-render-monitor': {
+      paddingLeft: theme.spacing(),
+    },
+  },
 }));
 
 interface Props extends ChartProps {
@@ -157,7 +162,7 @@ export const NetworkGraph: React.FC<CombinedProps> = (props) => {
 
   return (
     <Grid container className={classes.graphGrids}>
-      <Grid item className={classes.grid} xs={12}>
+      <Grid item className={`${classes.grid} ${classes.ipv4}`} xs={12}>
         <StatsPanel
           title={`Network — IPv4 (${v4Unit}/s)`}
           renderBody={() => (

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraph.tsx
@@ -38,10 +38,20 @@ const useStyles = makeStyles((theme: Theme) => ({
       flexWrap: 'wrap',
     },
   },
+  grid: {
+    backgroundColor: theme.bg.offWhiteDT,
+    border: 'solid 1px #eeeeee',
+    marginLeft: theme.spacing(),
+    marginRight: theme.spacing(),
+    '&.MuiGrid-item': {
+      padding: theme.spacing(2),
+    },
+    [theme.breakpoints.down('md')]: {
+      marginBottom: theme.spacing(2),
+    },
+  },
   chart: {
-    position: 'relative',
-    paddingTop: theme.spacing(2),
-    paddingLeft: theme.spacing(3),
+    paddingTop: theme.spacing(),
   },
 }));
 
@@ -147,7 +157,7 @@ export const NetworkGraph: React.FC<CombinedProps> = (props) => {
 
   return (
     <Grid container className={classes.graphGrids}>
-      <Grid item xs={12}>
+      <Grid item className={classes.grid} xs={12}>
         <StatsPanel
           title={`Network — IPv4 (${v4Unit}/s)`}
           renderBody={() => (
@@ -162,7 +172,7 @@ export const NetworkGraph: React.FC<CombinedProps> = (props) => {
           {...rest}
         />
       </Grid>
-      <Grid item xs={12}>
+      <Grid item className={classes.grid} xs={12}>
         <StatsPanel
           title={`Network — IPv6 (${v6Unit}/s)`}
           renderBody={() => (
@@ -240,25 +250,25 @@ const Graph: React.FC<GraphProps> = (props) => {
             borderColor: 'transparent',
             backgroundColor: theme.graphs.network.inbound,
             data: convertedPublicIn,
-            label: 'Public Inbound',
+            label: 'Public In',
           },
           {
             borderColor: 'transparent',
             backgroundColor: theme.graphs.network.outbound,
             data: convertedPublicOut,
-            label: 'Public Outbound',
+            label: 'Public Out',
           },
           {
             borderColor: 'transparent',
             backgroundColor: theme.graphs.purple,
             data: convertedPrivateIn,
-            label: 'Private Inbound',
+            label: 'Private In',
           },
           {
             borderColor: 'transparent',
             backgroundColor: theme.graphs.yellow,
             data: convertedPrivateOut,
-            label: 'Private Outbound',
+            label: 'Private Out',
           },
         ]}
         legendRows={[

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/StatsPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/StatsPanel.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import CircleProgress from 'src/components/CircleProgress';
-import Paper from 'src/components/core/Paper';
 import { makeStyles } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import ErrorState from 'src/components/ErrorState';
@@ -10,9 +9,9 @@ const useStyles = makeStyles(() => ({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    width: '100%',
     padding: 16,
     paddingTop: 0,
+    width: '100%',
   },
   spinner: {
     display: 'flex',
@@ -46,7 +45,7 @@ export const StatsPanel: React.FC<CombinedProps> = (props) => {
   } = props;
 
   return (
-    <Paper>
+    <>
       <Typography variant="h2" data-qa-stats-title>
         {title}
       </Typography>
@@ -66,7 +65,7 @@ export const StatsPanel: React.FC<CombinedProps> = (props) => {
       ) : (
         renderBody()
       )}
-    </Paper>
+    </>
   );
 };
 

--- a/packages/manager/src/themes.ts
+++ b/packages/manager/src/themes.ts
@@ -197,6 +197,26 @@ const darkThemeOptions = {
   cmrBorderColors,
   cmrTextColors,
   cmrIconColors,
+  graphs: {
+    network: {
+      outbound: `rgb(49, 206, 62)`,
+      inbound: `rgb(16, 162, 29)`,
+    },
+    cpu: {
+      system: `rgb(2, 118, 253)`,
+      user: `rgb(81, 166, 245)`,
+      wait: `rgb(145, 199, 237)`,
+      percent: `rgb(54, 131, 220)`,
+    },
+    diskIO: {
+      read: `rgb(255, 196, 105)`,
+      write: `rgb(255, 179, 77)`,
+      swap: `rgb(238, 44, 44)`,
+    },
+    purple: `rgb(217, 176, 217)`,
+    red: `rgb(255, 99, 60)`,
+    yellow: `rgb(255, 220, 125)`,
+  },
   animateCircleIcon: {
     ...iconCircleAnimation,
   },


### PR DESCRIPTION
Changes include:
- New title
- Gray background
- Remove "Toggle Graphs" label and icon (aka the caterpillar)
- Abbreviate legend labels and decrease font size
- Decrease graph height

Also updated the dark mode colors used in the graphs that previously blended in due to the transparency

The legend converts to a smaller view too quickly imo and the dark mode colors (border vs background color) aren't ideal but everything is legible so I'll have a separate PR address these two issues

Before:
<img width="1256" alt="Screen Shot 2021-04-06 at 4 13 07 PM" src="https://user-images.githubusercontent.com/7692354/113772654-fadd6f00-96f2-11eb-9402-296931d0aa50.png">

After:
<img width="781" alt="Screen Shot 2021-04-09 at 5 14 16 PM" src="https://user-images.githubusercontent.com/7692354/114241376-0c26b580-9957-11eb-9d3f-3f80509ac4bd.png">
