### PR TITLE
M3-5044: Machine Images feature flag

### DIFF
--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -37,7 +37,8 @@ export type AccountCapability =
   | 'Object Storage'
   | 'Kubernetes'
   | 'Cloud Firewall'
-  | 'Vlans';
+  | 'Vlans'
+  | 'Machine Images';
 
 export interface AccountSettings {
   managed: boolean;

--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -199,16 +199,6 @@ const MainContent: React.FC<CombinedProps> = (props) => {
     account.data?.capabilities ?? []
   );
 
-  const machineImagesEnabled = isFeatureEnabled(
-    'Machine Images',
-    Boolean(flags.machineImages),
-    account.data?.capabilities ?? []
-  );
-
-  if (machineImagesEnabled) {
-    console.log('Machine Images enabled');
-  }
-
   const defaultRoot = _isManagedAccount ? '/managed' : '/linodes';
 
   const shouldDisplayMainContentBanner =

--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -199,6 +199,16 @@ const MainContent: React.FC<CombinedProps> = (props) => {
     account.data?.capabilities ?? []
   );
 
+  const machineImagesEnabled = isFeatureEnabled(
+    'Machine Images',
+    Boolean(flags.machineImages),
+    account.data?.capabilities ?? []
+  );
+
+  if (machineImagesEnabled) {
+    console.log('Machine Images enabled');
+  }
+
   const defaultRoot = _isManagedAccount ? '/managed' : '/linodes';
 
   const shouldDisplayMainContentBanner =

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -11,6 +11,7 @@ const options: { label: string; flag: keyof Flags }[] = [
   { label: 'CMR', flag: 'cmr' },
   { label: 'Databases', flag: 'databases' },
   { label: 'Bare Metal', flag: 'bareMetal' },
+  { label: 'Machine Images', flag: 'machineImages' },
 ];
 
 const FeatureFlagTool: React.FC<{}> = () => {

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -31,6 +31,7 @@ export interface Flags {
   firewallBetaNotification: boolean;
   entityTransfers: boolean;
   bareMetal: boolean;
+  machineImages: boolean;
 }
 
 type PromotionalOfferFeature =


### PR DESCRIPTION
## Description
This PR:

1. Picks up the Machine Images flag from LD,
2. Adds an option in our Dev Tool for easily toggling the flag on and off locally,
3. Adds some temporary & basic code in MainContent.tsx to allow for easy confirmation of whether the flag is on or off (will be removed before merging),
4. Adds `Machine Images` to the `AccountCapability` type as confirmed w/ API team

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers
To test easily, have your console open while navigating through the app. When the flag is on you should see `Machine Images enabled.` logged to the console. You can turn the flag on and off locally using the "Machine Images" option under "Feature Flags" in our Dev Tool.
