### PR TITLE
Assorted VLAN feedback

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
@@ -153,7 +153,7 @@ export const InterfaceSelect: React.FC<Props> = (props) => {
         <Grid item xs={12} sm={6}>
           <Select
             options={
-              // Do not display "None" as an option for eth0, since
+              // Do not display "None" as an option for eth0 (must be either Public Internet or a VLAN).
               slotNumber > 0
                 ? purposeOptions
                 : purposeOptions.filter(

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
@@ -182,7 +182,7 @@ export const InterfaceSelect: React.FC<Props> = (props) => {
                 className={fromAddonsPanel ? classes.vlanLabelField : ''}
                 errorText={labelError}
                 options={vlanOptions}
-                label="Label"
+                label="VLAN"
                 placeholder="Create or select a VLAN"
                 variant="creatable"
                 createOptionPosition="first"

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
@@ -152,7 +152,14 @@ export const InterfaceSelect: React.FC<Props> = (props) => {
       {fromAddonsPanel ? null : (
         <Grid item xs={12} sm={6}>
           <Select
-            options={purposeOptions}
+            options={
+              // Do not display "None" as an option for eth0, since
+              slotNumber > 0
+                ? purposeOptions
+                : purposeOptions.filter(
+                    (thisPurposeOption) => thisPurposeOption.value !== 'none'
+                  )
+            }
             label={`eth${slotNumber}`}
             value={purposeOptions.find(
               (thisOption) => thisOption.value === purpose

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -783,7 +783,7 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
                 ]}
                 fullWidth
               >
-                <FormGroup>
+                <FormGroup style={{ alignItems: 'flex-start' }}>
                   <FormControlLabel
                     label="Enable distro helper"
                     name="helpers.distro"

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -879,7 +879,7 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
                   disabled={readOnly}
                   loading={formik.isSubmitting}
                 >
-                  {linodeConfigId ? 'Edit' : 'Add'} Configuration
+                  {linodeConfigId ? 'Save' : 'Add'} Configuration
                 </Button>
                 <Button
                   buttonType="secondary"

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -879,7 +879,7 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
                   disabled={readOnly}
                   loading={formik.isSubmitting}
                 >
-                  {linodeConfigId ? 'Save' : 'Add'} Configuration
+                  {linodeConfigId ? 'Save Changes' : 'Add Configuration'}
                 </Button>
                 <Button
                   buttonType="secondary"

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -84,6 +84,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   tooltip: {
     maxWidth: 350,
   },
+  formGroup: {
+    alignItems: 'flex-start',
+  },
 }));
 
 interface Helpers {
@@ -496,6 +499,7 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
                   VM Mode
                 </FormLabel>
                 <RadioGroup
+                  className={classes.formGroup}
                   aria-label="virt_mode"
                   name="virt_mode"
                   value={values.virt_mode}
@@ -560,6 +564,7 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
                   Run Level
                 </FormLabel>
                 <RadioGroup
+                  className={classes.formGroup}
                   aria-label="run_level"
                   name="run_level"
                   value={values.run_level}
@@ -606,6 +611,7 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
                   Memory Limit
                 </FormLabel>
                 <RadioGroup
+                  className={classes.formGroup}
                   aria-label="memory_limit"
                   name="setMemoryLimit"
                   value={values.setMemoryLimit}
@@ -664,7 +670,7 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
                 Add a Device
               </Button>
 
-              <FormControl fullWidth>
+              <FormControl className={classes.formGroup} fullWidth>
                 <FormControlLabel
                   label="Use Custom Root"
                   name="useCustomRoot"
@@ -783,7 +789,7 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
                 ]}
                 fullWidth
               >
-                <FormGroup style={{ alignItems: 'flex-start' }}>
+                <FormGroup className={classes.formGroup}>
                   <FormControlLabel
                     label="Enable distro helper"
                     name="helpers.distro"


### PR DESCRIPTION
## Description

M3-5049: In Config Dialog, save button should be labeled "Save Changes"
M3-5051: In the Config Dialog, the targets for toggles are too wide
M3-5052: In the Linode Create flow and Config Dialog, change VLAN "Label" field to "VLAN"
M3-5055: Remove (or disable) "None" as an option for eth0 network interface

One thing I haven't addressed in M3-5052 is that the error message for this field will still say e.g. "Label is required". I didn't want to make this change in the API wrapper / validation layer since this is Cloud-specific. Still thinking about how to best do this.

