### PR TITLE
M3-5056 Display all interfaces all the time

### DIFF
--- a/packages/api-v4/src/linodes/linodes.schema.ts
+++ b/packages/api-v4/src/linodes/linodes.schema.ts
@@ -29,12 +29,12 @@ export const linodeInterfaceSchema = array()
         .when('purpose', {
           is: (value) => value === 'vlan',
           then: string()
-            .required('Label is required.')
-            .min(1, 'Label must be between 1 and 64 characters.')
-            .max(64, 'Label must be between 1 and 64 characters.')
+            .required('VLAN label is required.')
+            .min(1, 'VLAN label must be between 1 and 64 characters.')
+            .max(64, 'VLAN label must be between 1 and 64 characters.')
             .matches(
               /[a-z0-9-]+/,
-              'Interface labels cannot contain special characters.'
+              'VLAN labels cannot contain special characters.'
             ),
           otherwise: string().notRequired(),
         })

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -278,6 +278,9 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
     };
   };
 
+  // This validation runs BEFORE Yup schema validation. This validation logic
+  // is specific to Cloud Manager, which is why it is run separately (not in the
+  // shared Validation package).
   const onValidate = (values: EditableFields) => {
     const errors: any = {};
     const { interfaces } = values;
@@ -288,7 +291,16 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
     if (eth1?.purpose === 'none' && eth2.purpose !== 'none') {
       errors.interfaces =
         'You cannot assign an interface to eth2 without an interface assigned to eth1.';
+      return errors;
     }
+
+    // The API field is called "label" and thus the Validation package error
+    // message is "Label is required." Our field in Cloud is called "VLAN".
+    interfaces.forEach((thisInterface, idx) => {
+      if (thisInterface.purpose === 'vlan' && !thisInterface.label) {
+        errors[`interfaces[${idx}].label`] = 'VLAN is required.';
+      }
+    });
 
     return errors;
   };

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -240,8 +240,9 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
 
   const { values, resetForm, setFieldValue, ...formik } = useFormik({
     initialValues: defaultFieldsValues,
-    validateOnChange: true,
-    validateOnMount: true,
+    validateOnChange: false,
+    validateOnMount: false,
+    validate: (values) => onValidate(values),
     onSubmit: (values) => onSubmit(values),
   });
 
@@ -275,6 +276,21 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
       helpers,
       root_device,
     };
+  };
+
+  const onValidate = (values: EditableFields) => {
+    const errors: any = {};
+    const { interfaces } = values;
+
+    const eth1 = interfaces[1];
+    const eth2 = interfaces[2];
+
+    if (eth1?.purpose === 'none' && eth2.purpose !== 'none') {
+      errors.interfaces =
+        'You cannot assign an interface to eth2 without an interface on eth1.';
+    }
+
+    return errors;
   };
 
   const onSubmit = (values: EditableFields) => {
@@ -745,10 +761,8 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
                   />
                   .
                 </Typography>
-                {values.interfaces.map((thisInterface, idx, arr) =>
-                  // Magic so that we show interfaces that have been filled plus one more
-                  arr[idx - 1]?.purpose !== 'none' ||
-                  thisInterface.purpose !== 'none' ? (
+                {values.interfaces.map((thisInterface, idx) => {
+                  return (
                     <InterfaceSelect
                       key={`eth${idx}-interface`}
                       slotNumber={idx}
@@ -765,8 +779,8 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
                         handleInterfaceChange(idx, newInterface)
                       }
                     />
-                  ) : null
-                )}
+                  );
+                })}
               </Grid>
             ) : null}
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -287,7 +287,7 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
 
     if (eth1?.purpose === 'none' && eth2.purpose !== 'none') {
       errors.interfaces =
-        'You cannot assign an interface to eth2 without an interface on eth1.';
+        'You cannot assign an interface to eth2 without an interface assigned to eth1.';
     }
 
     return errors;


### PR DESCRIPTION
## Description

We received internal feedback that the "disappearing" interfaces were confusing. This makes it so that all interfaces are shown all the time. Validation runs before form submission, potentially resulting in this error message (word-smithing welcome):

<img width="930" alt="Screen Shot 2021-04-08 at 4 59 42 PM" src="https://user-images.githubusercontent.com/16911484/114097674-5db73d80-988e-11eb-94b5-43aef7ad9669.png">

I also updated the error message displayed when a user doesn't select or enter a VLAN name, as mentioned in https://github.com/linode/manager/pull/7570. I made the change here since there was already an `onValidate()` function in these changes.

