### PR TITLE
Fix for linodeInterfaceSchema test

### DIFF
--- a/packages/api-v4/src/linodes/linodes.schema.ts
+++ b/packages/api-v4/src/linodes/linodes.schema.ts
@@ -50,6 +50,10 @@ export const linodeInterfaceSchema = array()
     'unique-public-interface',
     'Only one public interface per config is allowed.',
     (list: any[]) => {
+      if (!list) {
+        return true;
+      }
+
       return (
         list.filter((thisSlot) => thisSlot.purpose === 'public').length <= 1
       );


### PR DESCRIPTION
## Description
Seems that the Linode Create flow was broken on `develop` because the linodeInterfaceSchema test was failing when there were no interfaces. This change addresses that case 

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers
Please confirm that Linode creation and editing and Linode Configuration creation and editing with and without VLANs function as intended
