### PR TITLE
Ensure VLANs are fresh when opening the config drawer

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -42,6 +42,7 @@ import DeviceSelection, {
 import useAccount from 'src/hooks/useAccount';
 import useFlags from 'src/hooks/useFlags';
 import { queryClient } from 'src/queries/base';
+import { queryKey as vlansQueryKey } from 'src/queries/vlans';
 import { useRegionsQuery } from 'src/queries/regions';
 import { ApplicationState } from 'src/store';
 import createDevicesFromStrings, {
@@ -329,6 +330,9 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
 
   React.useEffect(() => {
     if (open) {
+      // Ensure VLANs are fresh.
+      queryClient.invalidateQueries(vlansQueryKey);
+
       /**
        * If config is defined, we're editing. Set the state
        * to the values of the config.

--- a/packages/manager/src/queries/vlans.ts
+++ b/packages/manager/src/queries/vlans.ts
@@ -4,13 +4,15 @@ import { useQuery } from 'react-query';
 import useFlags from 'src/hooks/useFlags';
 import { queryPresets } from './base';
 
+export const queryKey = 'vlans';
+
 export const _getVlans = (): Promise<VLAN[]> =>
   getVlans().then(({ data }) => data);
 
 export const useVlansQuery = () => {
   // Using the flag directly so we can control this independently from account.capabilities
   const flags = useFlags();
-  return useQuery<VLAN[], APIError[]>('vlans', _getVlans, {
+  return useQuery<VLAN[], APIError[]>(queryKey, _getVlans, {
     ...queryPresets.longLived,
     enabled: flags.vlans,
   });


### PR DESCRIPTION
## Description

This fixes the following bug:

- Create a new Linode with a **new** VLAN attached.
- Navigate to the new Linode's Configs tab.
- Click "Edit" on the configuration.
- **Observe:** the VLAN is not present under the "Network Interfaces" section.


