### PR TITLE
M3-5043 Change: ImagesLanding split into 2 tables

### DIFF
--- a/packages/api-v4/src/images/types.ts
+++ b/packages/api-v4/src/images/types.ts
@@ -1,3 +1,9 @@
+export type ImageStatus =
+  | 'available'
+  | 'creating'
+  | 'deleted'
+  | 'pending_upload';
+
 export interface Image {
   id: string;
   label: string;
@@ -11,6 +17,7 @@ export interface Image {
   vendor: string | null;
   deprecated: boolean;
   expiry: null | string;
+  status: ImageStatus;
 }
 
 export interface CreateImagePayload {

--- a/packages/manager/src/components/ActionMenu_CMR/ActionMenu_CMR.tsx
+++ b/packages/manager/src/components/ActionMenu_CMR/ActionMenu_CMR.tsx
@@ -62,7 +62,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     '&[data-reach-menu-items]': {
       padding: 0,
       minWidth: 200,
-      width: 'fit-content',
       background: '#3683dc',
       border: 'none',
       fontSize: 14,

--- a/packages/manager/src/components/ActionMenu_CMR/ActionMenu_CMR.tsx
+++ b/packages/manager/src/components/ActionMenu_CMR/ActionMenu_CMR.tsx
@@ -61,7 +61,8 @@ const useStyles = makeStyles((theme: Theme) => ({
   itemsOuter: {
     '&[data-reach-menu-items]': {
       padding: 0,
-      width: 200,
+      minWidth: 200,
+      width: 'fit-content',
       background: '#3683dc',
       border: 'none',
       fontSize: 14,

--- a/packages/manager/src/components/EntityTable/APIPaginatedTable.tsx
+++ b/packages/manager/src/components/EntityTable/APIPaginatedTable.tsx
@@ -30,6 +30,7 @@ export const APIPaginatedTable: React.FC<CombinedProps> = (props) => {
     headers,
     initialOrder,
     RowComponent,
+    emptyMessage,
   } = props;
 
   const _data = data ?? [];
@@ -62,6 +63,7 @@ export const APIPaginatedTable: React.FC<CombinedProps> = (props) => {
               loading={loading}
               error={error}
               lastUpdated={100}
+              emptyMessage={emptyMessage}
             >
               {normalizedData.map((thisEntity) => (
                 <RowComponent

--- a/packages/manager/src/components/EntityTable/EntityTable_CMR.tsx
+++ b/packages/manager/src/components/EntityTable/EntityTable_CMR.tsx
@@ -29,6 +29,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 interface Props {
   entity: string;
   headers: HeaderCell[];
+  emptyMessage?: string;
   toggleGroupByTag?: () => boolean;
   isGroupedByTag?: boolean;
   row: EntityTableRow<any>;
@@ -43,6 +44,7 @@ export type CombinedProps = Props & PageyIntegrationProps;
 export const LandingTable: React.FC<CombinedProps> = (props) => {
   const {
     entity,
+    emptyMessage,
     headers,
     row,
     initialOrder,
@@ -63,6 +65,7 @@ export const LandingTable: React.FC<CombinedProps> = (props) => {
     handlers: row.handlers,
     toggleGroupByTag,
     isGroupedByTag,
+    emptyMessage,
   };
 
   if (row.request) {

--- a/packages/manager/src/components/EntityTable/GroupedEntitiesByTag_CMR.tsx
+++ b/packages/manager/src/components/EntityTable/GroupedEntitiesByTag_CMR.tsx
@@ -141,7 +141,7 @@ export const GroupedEntitiesByTag: React.FC<CombinedProps> = (props) => {
                                   handleSizeChange={handlePageSizeChange}
                                   pageSize={pageSize}
                                   page={page}
-                                  eventCategory={'domains landing'}
+                                  eventCategory={'Entity table'}
                                   showAll
                                 />
                               </TableCell>

--- a/packages/manager/src/components/EntityTable/ListEntities_CMR.tsx
+++ b/packages/manager/src/components/EntityTable/ListEntities_CMR.tsx
@@ -24,6 +24,7 @@ export const ListEntities: React.FC<CombinedProps> = (props) => {
     RowComponent,
     toggleGroupByTag,
     isGroupedByTag,
+    emptyMessage,
   } = props;
 
   return (
@@ -57,6 +58,7 @@ export const ListEntities: React.FC<CombinedProps> = (props) => {
 
                   <TableBody>
                     <TableContentWrapper
+                      emptyMessage={emptyMessage}
                       length={paginatedAndOrderedData.length}
                       loading={loading}
                       error={error}

--- a/packages/manager/src/components/EntityTable/types.ts
+++ b/packages/manager/src/components/EntityTable/types.ts
@@ -5,6 +5,7 @@ import { Linode } from '@linode/api-v4/lib/linodes/types';
 import { Volume } from '@linode/api-v4/lib/volumes/types';
 import { APIError } from '@linode/api-v4/lib/types';
 import { OrderByProps } from 'src/components/OrderBy';
+// eslint-disable-next-line
 export type Handlers = Record<string, Function>;
 export type Entity = Linode | Domain | Firewall | Image | Volume; // @todo add more here
 
@@ -34,6 +35,7 @@ export interface ListProps extends BaseProps {
   };
   toggleGroupByTag?: () => boolean;
   isGroupedByTag?: boolean;
+  emptyMessage?: string;
 }
 
 export interface EntityTableRow<T> extends BaseProps {

--- a/packages/manager/src/factories/images.ts
+++ b/packages/manager/src/factories/images.ts
@@ -14,4 +14,5 @@ export const imageFactory = Factory.Sync.makeFactory<Image>({
   type: 'image',
   vendor: null,
   expiry: null,
+  status: 'available',
 });

--- a/packages/manager/src/features/Images/ImageRow.tsx
+++ b/packages/manager/src/features/Images/ImageRow.tsx
@@ -11,23 +11,6 @@ import { formatDate } from 'src/utilities/formatDate';
 import ActionMenu, { Handlers } from './ImagesActionMenu';
 
 const useStyles = makeStyles((theme: Theme) => ({
-  label: {
-    width: '30%',
-    [theme.breakpoints.down('sm')]: {
-      width: '45%',
-    },
-    [theme.breakpoints.down('xs')]: {
-      width: '65%',
-    },
-  },
-  size: {
-    [theme.breakpoints.down('sm')]: {
-      width: '15%',
-    },
-    [theme.breakpoints.down('xs')]: {
-      width: '20%',
-    },
-  },
   loadingStatus: {
     marginBottom: theme.spacing() / 2,
   },
@@ -54,12 +37,13 @@ const ImageRow: React.FC<CombinedProps> = (props) => {
     id,
     label,
     size,
+    status,
     ...rest
   } = props;
 
   return isImageUpdating(event) ? (
     <TableRow key={id} data-qa-image-cell={id}>
-      <TableCell className={classes.label} data-qa-image-label>
+      <TableCell data-qa-image-label>
         <ProgressDisplay
           className={classes.loadingStatus}
           text="Creating"
@@ -73,20 +57,25 @@ const ImageRow: React.FC<CombinedProps> = (props) => {
     </TableRow>
   ) : (
     <TableRow key={id} data-qa-image-cell={id}>
-      <TableCell className={classes.label} data-qa-image-label>
-        {label}
-      </TableCell>
+      <TableCell data-qa-image-label>{label}</TableCell>
       <Hidden xsDown>
+        {status ? <TableCell>{status.replace('_', ' ')}</TableCell> : null}
         <TableCell data-qa-image-date>{formatDate(created)}</TableCell>
-        <TableCell data-qa-image-date>
-          {expiry ? formatDate(expiry) : 'Never'}
-        </TableCell>
       </Hidden>
-      <TableCell className={classes.size} data-qa-image-size>
-        {size} MB
-      </TableCell>
+      <TableCell data-qa-image-size>{size} MB</TableCell>
+      <Hidden xsDown>
+        {expiry ? (
+          <TableCell data-qa-image-date>{formatDate(expiry)}</TableCell>
+        ) : null}
+      </Hidden>
       <TableCell className={classes.actionMenu}>
-        <ActionMenu id={id} label={label} description={description} {...rest} />
+        <ActionMenu
+          id={id}
+          label={label}
+          description={description}
+          status={status}
+          {...rest}
+        />
       </TableCell>
     </TableRow>
   );

--- a/packages/manager/src/features/Images/ImageRow.tsx
+++ b/packages/manager/src/features/Images/ImageRow.tsx
@@ -7,6 +7,7 @@ import Typography from 'src/components/core/Typography';
 import LinearProgress from 'src/components/LinearProgress';
 import TableCell from 'src/components/TableCell/TableCell_CMR';
 import TableRow from 'src/components/TableRow/TableRow_CMR';
+import { capitalizeAllWords } from 'src/utilities/capitalize';
 import { formatDate } from 'src/utilities/formatDate';
 import ActionMenu, { Handlers } from './ImagesActionMenu';
 
@@ -59,7 +60,9 @@ const ImageRow: React.FC<CombinedProps> = (props) => {
     <TableRow key={id} data-qa-image-cell={id}>
       <TableCell data-qa-image-label>{label}</TableCell>
       <Hidden xsDown>
-        {status ? <TableCell>{status.replace('_', ' ')}</TableCell> : null}
+        {status ? (
+          <TableCell>{capitalizeAllWords(status.replace('_', ' '))}</TableCell>
+        ) : null}
         <TableCell data-qa-image-date>{formatDate(created)}</TableCell>
       </Hidden>
       <TableCell data-qa-image-size>{size} MB</TableCell>

--- a/packages/manager/src/features/Images/ImagesActionMenu.tsx
+++ b/packages/manager/src/features/Images/ImagesActionMenu.tsx
@@ -84,7 +84,13 @@ export const ImagesActionMenu: React.FC<CombinedProps> = (props) => {
           },
         ];
 
-  const splitActionsArrayIndex = matchesSmDown ? 0 : 2;
+  /**
+   * Moving all actions to the dropdown menu to prevent visual mismatches
+   * between different Image types/statuses.
+   *
+   * Leaving the logic in place in case until the decision has been officially OK'd.
+   */
+  const splitActionsArrayIndex = 0;
   const [inlineActions, menuActions] = splitAt(splitActionsArrayIndex, actions);
 
   return (

--- a/packages/manager/src/features/Images/ImagesActionMenu.tsx
+++ b/packages/manager/src/features/Images/ImagesActionMenu.tsx
@@ -66,7 +66,7 @@ export const ImagesActionMenu: React.FC<CombinedProps> = (props) => {
             title: 'Deploy New Linode',
             disabled: isDisabled,
             tooltip: isDisabled
-              ? 'Image is not yet available for deployment'
+              ? 'Image is not yet available for use.'
               : undefined,
             onClick: () => {
               onDeploy(id);
@@ -76,7 +76,7 @@ export const ImagesActionMenu: React.FC<CombinedProps> = (props) => {
             title: 'Restore to Existing Linode',
             disabled: isDisabled,
             tooltip: isDisabled
-              ? 'Image is not yet available for use'
+              ? 'Image is not yet available for use.'
               : undefined,
             onClick: () => {
               onRestore(id);

--- a/packages/manager/src/features/Images/ImagesActionMenu.tsx
+++ b/packages/manager/src/features/Images/ImagesActionMenu.tsx
@@ -42,8 +42,10 @@ export const ImagesActionMenu: React.FC<CombinedProps> = (props) => {
     onDelete,
   } = props;
 
-  const actions: Action[] =
-    status === 'pending_upload'
+  const actions: Action[] = React.useMemo(() => {
+    // @todo remove first half of this conditional when Machine Images is GA
+    const isDisabled = status && status !== 'available';
+    return status === 'pending_upload'
       ? [
           // Cancelling a pending upload is functionally equivalent to deleting it
           {
@@ -62,16 +64,20 @@ export const ImagesActionMenu: React.FC<CombinedProps> = (props) => {
           },
           {
             title: 'Deploy New Linode',
-            // @todo remove first half of this conditional when the feature is GA
-
-            disabled: status && status !== 'available',
+            disabled: isDisabled,
+            tooltip: isDisabled
+              ? 'Image is not yet available for deployment'
+              : undefined,
             onClick: () => {
               onDeploy(id);
             },
           },
           {
             title: 'Restore to Existing Linode',
-            disabled: status && status !== 'available',
+            disabled: isDisabled,
+            tooltip: isDisabled
+              ? 'Image is not yet available for use'
+              : undefined,
             onClick: () => {
               onRestore(id);
             },
@@ -83,6 +89,7 @@ export const ImagesActionMenu: React.FC<CombinedProps> = (props) => {
             },
           },
         ];
+  }, [status, description, id, label, onDelete, onRestore, onDeploy, onEdit]);
 
   /**
    * Moving all actions to the dropdown menu to prevent visual mismatches

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -145,9 +145,30 @@ export const handlers = [
     return res(ctx.json(cachedTypes));
   }),
   rest.get('*/images', async (req, res, ctx) => {
-    const privateImages = imageFactory.buildList(0);
+    const privateImages = imageFactory.buildList(5, {
+      status: 'available',
+      type: 'manual',
+    });
+    const creatingImages = imageFactory.buildList(2, {
+      type: 'manual',
+      status: 'creating',
+    });
+    const pendingImages = imageFactory.buildList(5, {
+      status: 'pending_upload',
+      type: 'manual',
+    });
+    const automaticImages = imageFactory.buildList(5, {
+      type: 'automatic',
+      expiry: '2021-05-01',
+    });
     const publicImages = imageFactory.buildList(0, { is_public: true });
-    const images = [...privateImages, ...publicImages];
+    const images = [
+      ...automaticImages,
+      ...privateImages,
+      ...publicImages,
+      ...pendingImages,
+      ...creatingImages,
+    ];
     return res(ctx.json(makeResourcePage(images)));
   }),
   rest.get('*/linode/instances', async (req, res, ctx) => {


### PR DESCRIPTION
## Description

- Using client-side sorting (for now, until the API work is complete), split
Images into 2 tables, one for manual (normal images) and one for automatic (created
by Linode when a Linode is deleted).
- Manual images no longer have an Expiry column, since they never expire
- Add a Status column, present only when the machineImages flag is active
- When image.status is pending, only one action is possible ("Cancel", which
just deletes the image)
- When image.status is not "available", disable "deploy" actions

## Note to Reviewers

I used our normal flagging logic to keep with convention and because it's in the ticket's AC, but I think I might feel a bit safer if we showed the Status column if the API returns a "status" field on the Image. It amounts to the same thing but we'd be tying the display to exactly what we're concerned with.

To test, try the following combos:

1. Feature flag is on (you can use devtools for this) && customer tag is present on the account; use dev/alpha API
2. Flag is off, and customer tag is not present (normal customers)
3. For the handling of `pending_upload` and `creating` statuses, use the provided mocks.