### PR TITLE
M3-5038: NodeBalancer IP Addresses' copy tooltips appear on row hover

### DIFF
--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancerTableRow.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancerTableRow.tsx
@@ -85,7 +85,7 @@ const NodeBalancerTableRow: React.FC<CombinedProps> = (props) => {
     <TableRow
       key={id}
       data-qa-nodebalancer-cell={label}
-      className={`${classes.row} fade-in-table`} //"fade-in-table"
+      className={`${classes.row} fade-in-table`}
       ariaLabel={label}
     >
       <TableCell data-qa-nodebalancer-label>

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancerTableRow.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancerTableRow.tsx
@@ -37,6 +37,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   ipsWrapper: {
     display: 'inline-flex',
     flexDirection: 'column',
+    '& [data-qa-copy-ip]': {
+      opacity: 0,
+    },
   },
   actionCell: {
     // @todo: remove action cell duplication (this is from DomainTableRow_CMR)
@@ -49,6 +52,13 @@ const useStyles = makeStyles((theme: Theme) => ({
       We can remove once we make the full switch to CMR styling
       */
     paddingRight: '0 !important',
+  },
+  row: {
+    '&:hover': {
+      '& [data-qa-copy-ip]': {
+        opacity: 1,
+      },
+    },
   },
 }));
 
@@ -75,7 +85,7 @@ const NodeBalancerTableRow: React.FC<CombinedProps> = (props) => {
     <TableRow
       key={id}
       data-qa-nodebalancer-cell={label}
-      className="fade-in-table"
+      className={`${classes.row} fade-in-table`} //"fade-in-table"
       ariaLabel={label}
     >
       <TableCell data-qa-nodebalancer-label>


### PR DESCRIPTION
## Description
Instead of being visible all the time, the copy tooltips for NodeBalancer IP Addresses on the NodeBalancer landing page now appear on row hover.

## Type of Change
- Non breaking change ('update', 'change')
