### PR TITLE
M3-5066: Removed the Typography containing incorrect helper text

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.tsx
@@ -8,7 +8,6 @@ import { Capabilities } from '@linode/api-v4/lib/regions/types';
 import * as React from 'react';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
-import Typography from 'src/components/core/Typography';
 import Drawer, { DrawerProps } from 'src/components/Drawer';
 import LinodeMultiSelect from 'src/components/LinodeMultiSelect';
 import Notice from 'src/components/Notice';
@@ -142,11 +141,6 @@ const AddFirewallDrawer: React.FC<CombinedProps> = (props) => {
                   data-qa-error
                 />
               )}
-              <Typography>
-                Firewalls are created with default rules to allow inbound SSH
-                (port 22) and DNS (port 53) traffic. You can edit these rules or
-                add additional rules once the Firewall has been created.
-              </Typography>
               <TextField
                 aria-label="Label for your new Firewall"
                 label="Label"


### PR DESCRIPTION
## Description

In v1.36.0 the default behavior when creating a new firewall was changed to no longer create default SSH and DNS rules. There was still a message on the drawer for creating a firewall that said it created these rules which it did not. The message has been removed from the drawer to reflect the default behavior. The documentation about the removal of this behavior can be found [here](https://github.com/linode/manager/releases/tag/linode-manager%401.36.0).

## Type of Change

- Non breaking change ('update', 'change')

