### PR TITLE
M3-4951 change: remove overriding font style for receive transfer modal

### DIFF
--- a/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/ConfirmTransferDialog.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/ConfirmTransferDialog.tsx
@@ -39,13 +39,11 @@ const useStyles = makeStyles((theme: Theme) => ({
   expiry: {
     marginTop: theme.spacing(2),
     marginBottom: theme.spacing(2),
-    fontSize: '1rem',
   },
   entityTypeDisplay: {
     marginBottom: theme.spacing(),
   },
   summary: {
-    fontSize: '1rem',
     marginBottom: 4,
   },
   list: {


### PR DESCRIPTION
## Description

Removes the overriding font styles for the receive service transfer modal, using Typography's body font-style of 0.875rem(14px) instead.

Before:
<img width="463" alt="before" src="https://user-images.githubusercontent.com/14323019/114769292-086ca780-9d38-11eb-96fc-0a4e783b89de.png">

After:
<img width="467" alt="after" src="https://user-images.githubusercontent.com/14323019/114769320-115d7900-9d38-11eb-9a5e-6332a42e0c44.png">


## Type of Change
- Non breaking change ('update', 'change')
