### PR TITLE
Feedback: Machine Images table row updates

### DIFF
--- a/packages/manager/src/features/Images/ImageRow.tsx
+++ b/packages/manager/src/features/Images/ImageRow.tsx
@@ -47,7 +47,7 @@ const ImageRow: React.FC<CombinedProps> = (props) => {
         <TableCell data-qa-image-date>{formatDate(created)}</TableCell>
       </Hidden>
       <TableCell data-qa-image-size>
-        {isImageUpdating(event) ? 'N/A' : `${size} MB`}
+        {isImageUpdating(event) ? 'Pending' : `${size} MB`}
       </TableCell>
       <Hidden xsDown>
         {expiry ? (

--- a/packages/manager/src/features/Images/ImageRow.tsx
+++ b/packages/manager/src/features/Images/ImageRow.tsx
@@ -2,19 +2,14 @@ import { Event } from '@linode/api-v4/lib/account';
 import { Image } from '@linode/api-v4/lib/images';
 import * as React from 'react';
 import Hidden from 'src/components/core/Hidden';
-import { makeStyles, Theme } from 'src/components/core/styles';
-import Typography from 'src/components/core/Typography';
-import LinearProgress from 'src/components/LinearProgress';
+import { makeStyles } from 'src/components/core/styles';
 import TableCell from 'src/components/TableCell/TableCell_CMR';
 import TableRow from 'src/components/TableRow/TableRow_CMR';
 import { capitalizeAllWords } from 'src/utilities/capitalize';
 import { formatDate } from 'src/utilities/formatDate';
 import ActionMenu, { Handlers } from './ImagesActionMenu';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  loadingStatus: {
-    marginBottom: theme.spacing() / 2,
-  },
+const useStyles = makeStyles(() => ({
   actionMenu: {
     display: 'flex',
     justifyContent: 'flex-end',
@@ -42,21 +37,7 @@ const ImageRow: React.FC<CombinedProps> = (props) => {
     ...rest
   } = props;
 
-  return isImageUpdating(event) ? (
-    <TableRow key={id} data-qa-image-cell={id}>
-      <TableCell data-qa-image-label>
-        <ProgressDisplay
-          className={classes.loadingStatus}
-          text="Creating"
-          progress={progressFromEvent(event)}
-        />
-        {label}
-      </TableCell>
-      <TableCell colSpan={4}>
-        <LinearProgress value={progressFromEvent(event)} />
-      </TableCell>
-    </TableRow>
-  ) : (
+  return (
     <TableRow key={id} data-qa-image-cell={id}>
       <TableCell data-qa-image-label>{label}</TableCell>
       <Hidden xsDown>
@@ -65,7 +46,9 @@ const ImageRow: React.FC<CombinedProps> = (props) => {
         ) : null}
         <TableCell data-qa-image-date>{formatDate(created)}</TableCell>
       </Hidden>
-      <TableCell data-qa-image-size>{size} MB</TableCell>
+      <TableCell data-qa-image-size>
+        {isImageUpdating(event) ? 'N/A' : `${size} MB`}
+      </TableCell>
       <Hidden xsDown>
         {expiry ? (
           <TableCell data-qa-image-date>{formatDate(expiry)}</TableCell>
@@ -91,27 +74,6 @@ export const isImageUpdating = (e?: Event) => {
   }
   return (
     e?.action === 'disk_imagize' && ['scheduled', 'started'].includes(e.status)
-  );
-};
-
-const progressFromEvent = (e?: Event) => {
-  return e?.status === 'started' && e?.percent_complete
-    ? e.percent_complete
-    : undefined;
-};
-
-const ProgressDisplay: React.FC<{
-  className: string;
-  progress: undefined | number;
-  text: string;
-}> = (props) => {
-  const { progress, text, className } = props;
-  const displayProgress = progress ? `${progress}%` : `scheduled`;
-
-  return (
-    <Typography variant="body1" className={className}>
-      {text}: {displayProgress}
-    </Typography>
   );
 };
 

--- a/packages/manager/src/features/Images/ImageRow.tsx
+++ b/packages/manager/src/features/Images/ImageRow.tsx
@@ -3,6 +3,7 @@ import { Image } from '@linode/api-v4/lib/images';
 import * as React from 'react';
 import Hidden from 'src/components/core/Hidden';
 import { makeStyles } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
 import TableCell from 'src/components/TableCell/TableCell_CMR';
 import TableRow from 'src/components/TableRow/TableRow_CMR';
 import { capitalizeAllWords } from 'src/utilities/capitalize';
@@ -42,12 +43,23 @@ const ImageRow: React.FC<CombinedProps> = (props) => {
       <TableCell data-qa-image-label>{label}</TableCell>
       <Hidden xsDown>
         {status ? (
-          <TableCell>{capitalizeAllWords(status.replace('_', ' '))}</TableCell>
+          <TableCell>
+            {status === 'creating' ? (
+              <ProgressDisplay
+                text="Creating"
+                progress={progressFromEvent(event)}
+              />
+            ) : (
+              capitalizeAllWords(status.replace('_', ' '))
+            )}
+          </TableCell>
         ) : null}
         <TableCell data-qa-image-date>{formatDate(created)}</TableCell>
       </Hidden>
       <TableCell data-qa-image-size>
-        {isImageUpdating(event) ? 'Pending' : `${size} MB`}
+        {status === 'pending_upload' || isImageUpdating(event)
+          ? 'Pending'
+          : `${size} MB`}
       </TableCell>
       <Hidden xsDown>
         {expiry ? (
@@ -74,6 +86,26 @@ export const isImageUpdating = (e?: Event) => {
   }
   return (
     e?.action === 'disk_imagize' && ['scheduled', 'started'].includes(e.status)
+  );
+};
+
+const progressFromEvent = (e?: Event) => {
+  return e?.status === 'started' && e?.percent_complete
+    ? e.percent_complete
+    : undefined;
+};
+
+const ProgressDisplay: React.FC<{
+  progress: undefined | number;
+  text: string;
+}> = (props) => {
+  const { progress, text } = props;
+  const displayProgress = progress ? `${progress}%` : `scheduled`;
+
+  return (
+    <Typography variant="body1">
+      {text}: {displayProgress}
+    </Typography>
   );
 };
 

--- a/packages/manager/src/features/Images/ImagesActionMenu.tsx
+++ b/packages/manager/src/features/Images/ImagesActionMenu.tsx
@@ -49,7 +49,7 @@ export const ImagesActionMenu: React.FC<CombinedProps> = (props) => {
       ? [
           // Cancelling a pending upload is functionally equivalent to deleting it
           {
-            title: 'Cancel',
+            title: 'Cancel Upload',
             onClick: () => {
               onDelete(label, id, status);
             },
@@ -97,7 +97,8 @@ export const ImagesActionMenu: React.FC<CombinedProps> = (props) => {
    *
    * Leaving the logic in place in case until the decision has been officially OK'd.
    */
-  const splitActionsArrayIndex = 0;
+  const splitActionsArrayIndex =
+    !matchesSmDown && status === 'pending_upload' ? 1 : 0;
   const [inlineActions, menuActions] = splitAt(splitActionsArrayIndex, actions);
 
   return (


### PR DESCRIPTION
- Always expose actions for pending Images
- Update "Cancel" to "Cancel Upload"
- Remove progress bar for pending images and have the corresponding size be "N/A"