### PR TITLE
Tighten Create flow radio buttons and update hover states for docs and secondary buttons

### DIFF
--- a/packages/manager/src/components/Button/Button.tsx
+++ b/packages/manager/src/components/Button/Button.tsx
@@ -56,6 +56,11 @@ const useStyles = makeStyles((theme: Theme) => ({
     border: `1px solid ${theme.palette.primary.main}`,
     borderRadius: 1,
     minHeight: 34,
+    '&:hover, &:focus': {
+      backgroundColor: `${theme.cmrBGColors.bgSecondaryButton} !important`,
+      border: `1px solid ${theme.cmrBorderColors.borderSecondaryButton}`,
+      color: theme.cmrTextColors.secondaryButton,
+    },
   },
   reg: {
     display: 'flex',

--- a/packages/manager/src/components/Button/button.stories.tsx
+++ b/packages/manager/src/components/Button/button.stories.tsx
@@ -21,6 +21,10 @@ storiesOf('Button', module)
         Secondary
       </Button>
       <Divider />
+      <Button buttonType="secondary" outline data-qa-button="secondary">
+        Secondary with Outline
+      </Button>
+      <Divider />
       <Button buttonType="cancel" data-qa-button="cancel">
         Cancel
       </Button>

--- a/packages/manager/src/components/DocumentationButton/DocumentationButton.tsx
+++ b/packages/manager/src/components/DocumentationButton/DocumentationButton.tsx
@@ -18,10 +18,8 @@ const useStyles = makeStyles((theme: Theme) => ({
       marginRight: theme.spacing(),
     },
     '&:hover': {
+      color: theme.cmrTextColors.linkActiveLight,
       textDecoration: 'underline',
-      '& svg': {
-        color: theme.palette.primary.light,
-      },
     },
   },
 }));

--- a/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
+++ b/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
@@ -649,7 +649,7 @@ const useAccessTableStyles = makeStyles((theme: Theme) => ({
   copyCell: {
     width: 36,
     height: 33,
-    backgroundColor: `${theme.cmrBGColors.bgSecondaryButton} !important`,
+    backgroundColor: `${theme.cmrBGColors.bgCopyButton} !important`,
     padding: '0px !important',
     '& svg': {
       width: 16,

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -89,7 +89,7 @@ const styles = (theme: Theme) =>
     radioCell: {
       height: theme.spacing(6),
       width: '5%',
-      paddingRight: theme.spacing(),
+      paddingRight: 0,
     },
     gpuGuideLink: {
       fontSize: '0.9em',

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -572,7 +572,8 @@ const themeDefaults: ThemeDefaults = () => {
           backgroundColor: 'transparent',
           color: cmrTextColors.linkActiveLight,
           '&:hover, &:focus': {
-            backgroundColor: 'transparent !important',
+            backgroundColor: '#f5f8ff',
+            border: '1px solid #d7dfed',
             color: cmrTextColors.linkActiveLight,
           },
           '&:active': {

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -85,7 +85,8 @@ const cmrBGColors = {
   bgPaper: '#ffffff',
   bgPrimaryButton: '#3683dc',
   // notification center, add a tag, breadcrumb
-  bgSecondaryButton: '#e5f1ff',
+  bgSecondaryButton: '#f5f8ff',
+  bgCopyButton: '#e5f1ff',
   bgTableHeader: '#f9fafa',
   bgBillingSummary: '#f5f9ff',
   bgAccessRow: '#fafafa',
@@ -98,6 +99,7 @@ const cmrTextColors = {
   tableHeader: '#888F91',
   tableStatic: '#606469',
   textAccessTable: '#606469',
+  secondaryButton: '2575d0',
 };
 
 const cmrBorderColors = {
@@ -106,6 +108,7 @@ const cmrBorderColors = {
   borderBillingSummary: '#cce2ff',
   borderBalance: '#c2daff',
   borderTable: '#f4f5f6',
+  borderSecondaryButton: '#d7dfed',
 };
 
 const cmrIconColors = {
@@ -572,8 +575,7 @@ const themeDefaults: ThemeDefaults = () => {
           backgroundColor: 'transparent',
           color: cmrTextColors.linkActiveLight,
           '&:hover, &:focus': {
-            backgroundColor: '#f5f8ff',
-            border: '1px solid #d7dfed',
+            backgroundColor: 'transparent !important',
             color: cmrTextColors.linkActiveLight,
           },
           '&:active': {

--- a/packages/manager/src/themes.ts
+++ b/packages/manager/src/themes.ts
@@ -321,9 +321,9 @@ const darkThemeOptions = {
       containedSecondary: {
         color: cmrTextColors.linkActiveLight,
         '&:hover, &:focus': {
-          backgroundColor: '#f5f8ff',
-          border: '1px solid #d7dfed',
-          color: cmrTextColors.linkActiveLight,
+          backgroundColor: 'transparent',
+          border: '1px solid #fff',
+          color: '#fff',
         },
         '&:active': {
           color: primaryColors.dark,

--- a/packages/manager/src/themes.ts
+++ b/packages/manager/src/themes.ts
@@ -16,7 +16,8 @@ const cmrBGColors = {
   bgPaper: '#2e3238',
   bgPrimaryButton: '#3683dc',
   // notification center, add a tag, breadcrumb
-  bgSecondaryButton: '#364863',
+  bgSecondaryButton: 'transparent',
+  bgCopyButton: '#364863',
   bgTableHeader: '#33373e',
   bgBillingSummary: '#2d3d53',
   bgAccessRow: '#454b54',
@@ -29,6 +30,7 @@ const cmrTextColors = {
   tableHeader: '#888F91',
   tableStatic: '#e6e6e6',
   textAccessTable: '#acb0b4',
+  secondaryButton: '#fff',
 };
 
 const cmrBorderColors = {
@@ -37,6 +39,7 @@ const cmrBorderColors = {
   borderBillingSummary: '#243142',
   borderBalance: '#4d79b2',
   borderTable: '#3a3f46',
+  borderSecondaryButton: '#fff',
 };
 
 const cmrIconColors = {
@@ -321,9 +324,7 @@ const darkThemeOptions = {
       containedSecondary: {
         color: cmrTextColors.linkActiveLight,
         '&:hover, &:focus': {
-          backgroundColor: 'transparent',
-          border: '1px solid #fff',
-          color: '#fff',
+          color: cmrTextColors.linkActiveLight,
         },
         '&:active': {
           color: primaryColors.dark,

--- a/packages/manager/src/themes.ts
+++ b/packages/manager/src/themes.ts
@@ -321,6 +321,8 @@ const darkThemeOptions = {
       containedSecondary: {
         color: cmrTextColors.linkActiveLight,
         '&:hover, &:focus': {
+          backgroundColor: '#f5f8ff',
+          border: '1px solid #d7dfed',
           color: cmrTextColors.linkActiveLight,
         },
         '&:active': {


### PR DESCRIPTION
## Description
This PR includes several small UI updates:
- M3-4916: Tighten spacing between the radio button and Linode Plan name in the `SelectPlanPanel`
  - **How to test:** Navigate to the Linode Create page and check the Linode Plan section
- M3-5011: Remove hover state color change for Docs link
  - **How to test:** Navigate to any landing page and locate the Docs link on the upper right
- M3-5022: Add hover state for secondary buttons with outlines
  - **How to test:** Run `yarn storybook` and navigate to the Button story (or check the NodeBalancers Configs tab)