### PR TITLE
M3-4225: Fix Typing of renderUnitPrice and Test

### DIFF
--- a/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
+++ b/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
@@ -11,6 +11,7 @@ import TableCell from 'src/components/TableCell';
 import TableRowEmptyState from 'src/components/TableRowEmptyState';
 import TableRowError from 'src/components/TableRowError';
 import TableRowLoading from 'src/components/TableRowLoading';
+import { renderUnitPrice } from 'src/features/Billing/billingUtils.ts';
 
 import Paginate from 'src/components/Paginate';
 import PaginationFooter from 'src/components/PaginationFooter';
@@ -49,8 +50,6 @@ const InvoiceTable: React.FC<Props> = (props) => {
 
 const renderDate = (v: null | string) =>
   v ? <DateTimeDisplay value={v} data-qa-invoice-date /> : null;
-
-const renderUnitPrice = (v: null | number) => (v ? `$${v}` : null);
 
 const renderQuantity = (v: null | number) => (v ? v : null);
 

--- a/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
+++ b/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
@@ -11,7 +11,7 @@ import TableCell from 'src/components/TableCell';
 import TableRowEmptyState from 'src/components/TableRowEmptyState';
 import TableRowError from 'src/components/TableRowError';
 import TableRowLoading from 'src/components/TableRowLoading';
-import { renderUnitPrice } from 'src/features/Billing/billingUtils.ts';
+import { renderUnitPrice } from 'src/features/Billing/billingUtils';
 
 import Paginate from 'src/components/Paginate';
 import PaginationFooter from 'src/components/PaginationFooter';

--- a/packages/manager/src/features/Billing/billingUtils.test.ts
+++ b/packages/manager/src/features/Billing/billingUtils.test.ts
@@ -1,4 +1,4 @@
-import { cleanCVV } from './billingUtils';
+import { cleanCVV, renderUnitPrice } from './billingUtils';
 
 describe('Billing helper methods', () => {
   describe('cleanCVV function', () => {
@@ -13,6 +13,19 @@ describe('Billing helper methods', () => {
 
     it('should strip out non-numeric input', () => {
       expect(cleanCVV('abc1')).toBe('1');
+    });
+  });
+
+  describe('renderUnitPrice function', () => {
+    it('should return null if the value can not be parsed into a Number', () => {
+      expect(renderUnitPrice('three')).toBeNull();
+      expect(renderUnitPrice('None')).toBe(null);
+      expect(renderUnitPrice(null)).toBe(null);
+    });
+
+    it('should return the formated value if the value can be parsed into a Number', () => {
+      expect(renderUnitPrice('0')).toBe('$0');
+      expect(renderUnitPrice('0.015')).toBe('$0.015');
     });
   });
 });

--- a/packages/manager/src/features/Billing/billingUtils.test.ts
+++ b/packages/manager/src/features/Billing/billingUtils.test.ts
@@ -19,11 +19,11 @@ describe('Billing helper methods', () => {
   describe('renderUnitPrice function', () => {
     it('should return null if the value can not be parsed into a Number', () => {
       expect(renderUnitPrice('three')).toBeNull();
-      expect(renderUnitPrice('None')).toBe(null);
-      expect(renderUnitPrice(null)).toBe(null);
+      expect(renderUnitPrice('None')).toBeNull();
+      expect(renderUnitPrice(null)).toBeNull();
     });
 
-    it('should return the formated value if the value can be parsed into a Number', () => {
+    it('should return the formatted value if the value can be parsed into a Number', () => {
       expect(renderUnitPrice('0')).toBe('$0');
       expect(renderUnitPrice('0.015')).toBe('$0.015');
     });

--- a/packages/manager/src/features/Billing/billingUtils.ts
+++ b/packages/manager/src/features/Billing/billingUtils.ts
@@ -19,3 +19,8 @@ export const getTaxID = (
     Date.parse(invoiceItemDate) > Date.parse(taxDate);
   return taxStartedBeforeThisInvoiceItem ? taxID : undefined;
 };
+
+export const renderUnitPrice = (v: null | string) => {
+  const parsedValue = parseFloat(`${v}`);
+  return Number.isNaN(parsedValue) ? null : `$${parsedValue}`;
+};


### PR DESCRIPTION
## Description

This PR corrects an incorrect argument type declaration for a function called `renderUnitPrice`. Previously the function took a type of `null | number` but in practice was being given a `null | string`. The function was extracted from the `InvoiceTable` react component and moved into the `billingUtils.ts` file. Tests were added to verify that strings that parse into valid numbers return a formatted string for the unit price. Tests were also added that if a string that cannot be parsed into a Number or null are passed tot he function then the function returns null. 

## How to test

To run the unit tests associated with this PR run `yarn test ./packages/manager/src/features/Billing/billingUtils.test.ts` from the project root directory.
