### PR TITLE
light/dark mode shortcut changed to Ctrl+Shift+D

### DIFF
--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -84,7 +84,7 @@ export class App extends React.Component<CombinedProps, State> {
      */
     // eslint-disable-next-line
     document.addEventListener('keydown', (event: KeyboardEvent) => {
-      if (event.ctrlKey && event.shiftKey && event.key === 'D') {
+      if (event.ctrlKey && event.shiftKey && event.key === 'L') {
         this.props.toggleTheme();
       }
 


### PR DESCRIPTION
## Description

This PR changes the keyboard shortcut for toggling light and dark mode for the manager from `Ctrl+Shift+D` to `Ctrl+Shift+L`. This was done to avoid conflicts with existing keyboard shortcuts built into browsers.

## How to test

Press `Ctrl+Shift+L` the manager should switch from light to dark mode or vice versa. It should also not pop up any dialogs from the browser.
