### PR TITLE
M3-5077: Rename Image deployment actions

### DIFF
--- a/packages/manager/src/features/Images/ImagesActionMenu.tsx
+++ b/packages/manager/src/features/Images/ImagesActionMenu.tsx
@@ -63,7 +63,7 @@ export const ImagesActionMenu: React.FC<CombinedProps> = (props) => {
             },
           },
           {
-            title: 'Deploy New Linode',
+            title: 'Deploy to New Linode',
             disabled: isDisabled,
             tooltip: isDisabled
               ? 'Image is not yet available for use.'
@@ -73,7 +73,7 @@ export const ImagesActionMenu: React.FC<CombinedProps> = (props) => {
             },
           },
           {
-            title: 'Restore to Existing Linode',
+            title: 'Deploy to Existing Linode',
             disabled: isDisabled,
             tooltip: isDisabled
               ? 'Image is not yet available for use.'


### PR DESCRIPTION
## Description
Per demo feedback, rename:

- "Restore to Existing Linode" to "Deploy to Existing Linode"
- "Deploy New Linode" to "Deploy to New Linode"
