### PR TITLE
Fix: VLAN label validation

### DIFF
--- a/packages/api-v4/src/linodes/linodes.schema.ts
+++ b/packages/api-v4/src/linodes/linodes.schema.ts
@@ -33,8 +33,8 @@ export const linodeInterfaceSchema = array()
             .min(1, 'VLAN label must be between 1 and 64 characters.')
             .max(64, 'VLAN label must be between 1 and 64 characters.')
             .matches(
-              /[a-z0-9-]+/,
-              'VLAN labels cannot contain special characters.'
+              /[a-zA-Z0-9-]+/,
+              'Must include only ASCII letters, numbers, and dashes'
             ),
           otherwise: string().notRequired(),
         })

--- a/packages/validation/src/linodes.schema.ts
+++ b/packages/validation/src/linodes.schema.ts
@@ -33,8 +33,8 @@ export const linodeInterfaceSchema = array()
             .min(1, 'VLAN label must be between 1 and 64 characters.')
             .max(64, 'VLAN label must be between 1 and 64 characters.')
             .matches(
-              /[a-z0-9-]+/,
-              'VLAN labels cannot contain special characters.'
+              /[a-zA-Z0-9-]+/,
+              'Must include only ASCII letters, numbers, and dashes'
             ),
           otherwise: string().notRequired(),
         })


### PR DESCRIPTION
## Description

Update VLAN validation to match API

## How to test

Create a VLAN containing capital letters in the label. This can be done from linodes/:id/configs or linodes/create. On develop, it won't get through our client validation (check the network tab to see that no request is being made).
