### PR TITLE
Add beta notice for image uploads

### DIFF
--- a/packages/manager/src/features/Images/ImageUpload.tsx
+++ b/packages/manager/src/features/Images/ImageUpload.tsx
@@ -8,18 +8,20 @@ import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import RegionSelect from 'src/components/EnhancedSelect/variants/RegionSelect';
+import ExternalLink from 'src/components/ExternalLink';
+import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
 import { Dispatch } from 'src/hooks/types';
 import { useRegionsQuery } from 'src/queries/regions';
 import { uploadImage } from 'src/store/image/image.requests';
 import { getErrorMap } from 'src/utilities/errorUtils';
-import Notice from 'src/components/Notice';
 
 const useStyles = makeStyles((theme: Theme) => ({
   container: {
     minWidth: '100%',
     padding: theme.spacing(3),
-    paddingBottom: theme.spacing(4),
+    paddingTop: theme.spacing(),
+    paddingBottom: theme.spacing(),
     '& .MuiFormHelperText-root': {
       marginBottom: theme.spacing(2),
     },
@@ -116,7 +118,18 @@ export const ImageUpload: React.FC<Props> = (props) => {
           other regions.
         </Typography>
 
-        <ActionsPanel style={{ marginTop: 16 }}>
+        <Typography style={{ marginTop: 16 }}>
+          <strong>Note:</strong> Image Uploads are currently in beta and are
+          subject to the terms of the{' '}
+          <ExternalLink
+            text="Early Adopter Testing Agreement"
+            link="https://www.linode.com/legal-eatp/"
+            hideIcon
+          />
+          .
+        </Typography>
+
+        <ActionsPanel>
           <Button
             onClick={handleSubmit}
             disabled={region === '' || !canCreateImage}

--- a/packages/manager/src/features/Images/ImageUpload.tsx
+++ b/packages/manager/src/features/Images/ImageUpload.tsx
@@ -4,6 +4,7 @@ import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
+import Chip from 'src/components/core/Chip';
 import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
@@ -28,6 +29,14 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   helperText: {
     marginTop: theme.spacing(2),
+  },
+  chip: {
+    fontSize: '0.625rem',
+    height: 15,
+    marginBottom: 4,
+    lineHeight: '1px',
+    letterSpacing: '.25px',
+    textTransform: 'uppercase',
   },
 }));
 export interface Props {
@@ -84,6 +93,16 @@ export const ImageUpload: React.FC<Props> = (props) => {
 
   return (
     <Paper className={classes.container}>
+      <Typography style={{ marginTop: 16 }}>
+        <Chip className={classes.chip} label="beta" component="span" />
+        Image Uploads is currently in beta and is subject to the terms of the{' '}
+        <ExternalLink
+          text="Early Adopter Testing Agreement"
+          link="https://www.linode.com/legal-eatp/"
+          hideIcon
+        />
+        .
+      </Typography>
       {errorMap.none ? <Notice error text={errorMap.none} /> : null}
       <div style={{ width: '100%' }}>
         <TextField
@@ -118,18 +137,7 @@ export const ImageUpload: React.FC<Props> = (props) => {
           other regions.
         </Typography>
 
-        <Typography style={{ marginTop: 16 }}>
-          <strong>Note:</strong> Image Uploads are currently in beta and are
-          subject to the terms of the{' '}
-          <ExternalLink
-            text="Early Adopter Testing Agreement"
-            link="https://www.linode.com/legal-eatp/"
-            hideIcon
-          />
-          .
-        </Typography>
-
-        <ActionsPanel>
+        <ActionsPanel style={{ marginTop: 16 }}>
           <Button
             onClick={handleSubmit}
             disabled={region === '' || !canCreateImage}

--- a/packages/manager/src/features/Images/ImageUpload.tsx
+++ b/packages/manager/src/features/Images/ImageUpload.tsx
@@ -9,7 +9,7 @@ import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import RegionSelect from 'src/components/EnhancedSelect/variants/RegionSelect';
-import ExternalLink from 'src/components/ExternalLink';
+import Link from 'src/components/Link';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
 import { Dispatch } from 'src/hooks/types';
@@ -96,11 +96,9 @@ export const ImageUpload: React.FC<Props> = (props) => {
       <Typography style={{ marginTop: 16 }}>
         <Chip className={classes.chip} label="beta" component="span" />
         Image Uploads is currently in beta and is subject to the terms of the{' '}
-        <ExternalLink
-          text="Early Adopter Testing Agreement"
-          link="https://www.linode.com/legal-eatp/"
-          hideIcon
-        />
+        <Link to="https://www.linode.com/legal-eatp/">
+          Early Adopter Testing Agreement
+        </Link>
         .
       </Typography>
       {errorMap.none ? <Notice error text={errorMap.none} /> : null}

--- a/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
@@ -319,7 +319,10 @@ class CreateImageTab extends React.Component<CombinedProps, State> {
           />
         </>
 
-        <ActionsPanel updateFor={[requirementsMet, classes, submitting]}>
+        <ActionsPanel
+          style={{ marginTop: 16 }}
+          updateFor={[requirementsMet, classes, submitting]}
+        >
           <Button
             onClick={this.onSubmit}
             disabled={requirementsMet || !canCreateImage}

--- a/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
@@ -39,7 +39,8 @@ const styles = (theme: Theme) =>
     },
     container: {
       padding: theme.spacing(3),
-      paddingBottom: theme.spacing(4),
+      paddingTop: theme.spacing(),
+      paddingBottom: theme.spacing(),
       '& .MuiFormHelperText-root': {
         marginBottom: theme.spacing(2),
       },
@@ -318,10 +319,7 @@ class CreateImageTab extends React.Component<CombinedProps, State> {
           />
         </>
 
-        <ActionsPanel
-          style={{ marginTop: 16 }}
-          updateFor={[requirementsMet, classes, submitting]}
-        >
+        <ActionsPanel updateFor={[requirementsMet, classes, submitting]}>
           <Button
             onClick={this.onSubmit}
             disabled={requirementsMet || !canCreateImage}


### PR DESCRIPTION
## Description

This PR adds a beta notice to the Upload Image tab, and updates the container padding on both image creation tabs:

![Screen Shot 2021-04-20 at 5 30 46 PM](https://user-images.githubusercontent.com/16911484/115466730-79133880-a1fe-11eb-93d1-682b731f4252.png)


## How to test

Visit localhost:3000/images/create. View both tabs to check the container spacing. Look near the "Generate URL" button to see the beta notice.

I'm open to wordsmithing here. I couldn't exactly figure out what to call this feature... we don't say "Machine Images" anywhere else on this page. The grammar might be a bit weird too... "Image Uploads **are** currently in beta...". Would love to hear your thoughts.
