### PR TITLE
Fix: image_upload events

### DIFF
--- a/packages/manager/src/events.ts
+++ b/packages/manager/src/events.ts
@@ -77,7 +77,7 @@ export const startEventsInterval = () =>
           setRequestDeadline(now + 500);
         } else {
           const timeout = INTERVAL * pollIteration;
-          /** Update the dealing */
+          /** Update the deadline */
           setRequestDeadline(now + timeout);
           /* Update the iteration to a maximum of 16. */
           const newIteration = Math.min(pollIteration * 2, 16);

--- a/packages/manager/src/features/NotificationCenter/NotificationData/RenderEvent.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/RenderEvent.tsx
@@ -7,6 +7,7 @@ import Typography from 'src/components/core/Typography';
 import EntityIcon, { Variant } from 'src/components/EntityIcon';
 import Grid from 'src/components/Grid';
 import { Link } from 'src/components/Link';
+import { LONG_PENDING_EVENTS } from 'src/store/events/event.helpers';
 import formatDate from 'src/utilities/formatDate';
 import useEventInfo from './useEventInfo';
 
@@ -61,7 +62,7 @@ export const RenderEvent: React.FC<Props> = (props) => {
       })}
     >
       {message}
-      {event.duration
+      {event.duration && !LONG_PENDING_EVENTS.includes(event.action)
         ? event.status === 'failed'
           ? ` (Failed after ${duration})`
           : ` (Completed in ${duration})`

--- a/packages/manager/src/store/events/event.helpers.test.ts
+++ b/packages/manager/src/store/events/event.helpers.test.ts
@@ -1,5 +1,6 @@
 import { Event } from '@linode/api-v4/lib/account';
 import { DateTime } from 'luxon';
+import { eventFactory } from 'src/factories/events';
 import {
   addToEvents,
   findInEvents,
@@ -65,13 +66,13 @@ describe('event.helpers', () => {
 
   describe('isInProgressEvent', () => {
     it('should return true', () => {
-      const event = { percent_complete: 60 };
+      const event = eventFactory.build({ percent_complete: 60 });
       const result = isInProgressEvent(event);
       expect(result).toBeTruthy();
     });
 
     it('should return false', () => {
-      const event = { percent_complete: 100 };
+      const event = eventFactory.build({ percent_complete: 100 });
       const result = isInProgressEvent(event);
       expect(result).toBeFalsy();
     });
@@ -330,43 +331,19 @@ describe('event.helpers', () => {
 
     it('should do nothing if there are no in-progress events', () => {
       const inProgressEvents = { '999': 23 };
-      const events = [
-        {
-          id: 1,
-          percent_complete: 100,
-        },
-        {
-          id: 2,
-          percent_complete: 100,
-        },
-        {
-          id: 3,
-          percent_complete: 100,
-        },
-      ];
+      const events = eventFactory.buildList(3, { percent_complete: 100 });
       const result = updateInProgressEvents(inProgressEvents, events);
       expect(result).toEqual({ '999': 23 });
     });
 
     it('should add in-progress events to the Map', () => {
       const inProgressEvents = {};
-      const events = [
-        {
-          id: 1,
-          percent_complete: 100,
-        },
-        {
-          id: 2,
-          percent_complete: 60,
-        },
-        {
-          id: 3,
-          percent_complete: 100,
-        },
-      ];
+      const events = eventFactory.buildList(3, { percent_complete: 100 });
+      // Mark one event as in progress
+      events[1].percent_complete = 60;
       const result = updateInProgressEvents(inProgressEvents, events);
 
-      expect(result).toEqual({ '2': 60 });
+      expect(result).toEqual({ [events[1].id]: 60 });
     });
   });
 });

--- a/packages/manager/src/store/events/event.helpers.ts
+++ b/packages/manager/src/store/events/event.helpers.ts
@@ -18,7 +18,7 @@ import { EntityEvent, ExtendedEvent } from './event.types';
  * for that period, would be pointless. We treat these events differently
  * when determining whether they are in progress.
  */
-const LONG_PENDING_EVENTS = ['image_upload'];
+export const LONG_PENDING_EVENTS = ['image_upload'];
 
 /** We use the epoch on our initial request to get all of the users events. */
 export const epoch = new Date(`1970-01-01T00:00:00.000`).getTime();

--- a/packages/manager/src/store/events/event.helpers.ts
+++ b/packages/manager/src/store/events/event.helpers.ts
@@ -10,6 +10,16 @@ import updateRight from 'src/utilities/updateRight';
 
 import { EntityEvent, ExtendedEvent } from './event.types';
 
+/**
+ * Some events can be in a pending state, with a percent_complete
+ * of 0 and a status of "scheduled", for hours or days. We don't want
+ * to treat these as in-progress events in Cloud, since displaying an empty
+ * progress bar for 24 hours, or polling /events at our maximum frequency
+ * for that period, would be pointless. We treat these events differently
+ * when determining whether they are in progress.
+ */
+const LONG_PENDING_EVENTS = ['image_upload'];
+
 /** We use the epoch on our initial request to get all of the users events. */
 export const epoch = new Date(`1970-01-01T00:00:00.000`).getTime();
 
@@ -148,10 +158,16 @@ export const addToEvents = (prevArr: Event[], arr: Event[]) =>
       : [el, ...updatedArray];
   }, prevArr);
 
-export const isInProgressEvent = ({
-  percent_complete,
-}: Pick<Event, 'percent_complete'>) =>
-  percent_complete !== null && percent_complete < 100;
+export const isInProgressEvent = (event: Event) => {
+  const { percent_complete } = event;
+  if (percent_complete === null) {
+    return false;
+  } else if (LONG_PENDING_EVENTS.includes(event.action)) {
+    return percent_complete > 0 && percent_complete < 100;
+  } else {
+    return percent_complete !== null && percent_complete < 100;
+  }
+};
 
 export const isLongRunningProgressEventAction = (eventAction: EventAction) => {
   const longRunningProgressEventActions: EventAction[] = [
@@ -181,7 +197,7 @@ export const isEntityEvent = (e: Event): e is EntityEvent => Boolean(e.entity);
  */
 export const updateInProgressEvents = (
   inProgressEvents: Record<number, number>,
-  event: Pick<Event, 'percent_complete' | 'id'>[]
+  event: Event[]
 ) => {
   return event.reduce((result, e) => {
     const key = String(e.id);


### PR DESCRIPTION
## Description

Adjust our handling of the image_upload event.

In general, if an event has a percent_complete from 0-99 we consider it "in progress." This means that we show a progress bar for it in the notifications drawer, may display related entities differently throughout the app, and (most importantly) we don't throttle our polling interval if there are any in progress events still running. In practice this means we'll request events every 1.5 seconds, instead of ramping down to every 16 seconds.

The image_upload event, generated when you POST to image/uploads, is different, in that it can stay in percent_complete: 0 for up to 24 hours (until the user actually uploads an image to the provided URL). There may be some other long-running events we can consider that would fall into a similarly long pending state, but for now we need to treat this one event differently so that we're not spamming the API with /account/events calls.

Question: we might want to hide the duration for these events, since it's still weird ("completed in 16 hours"). I did this for the drawer, but we could consider doing the same thing for the events landing page.

## How to test

1. Create an Image using the /images/create/upload flow
2. On develop you should see progress for this event in the Notification drawer, here it should be rendered without the bar:

Develop:
![Screen Shot 2021-04-21 at 1 28 49 PM](https://user-images.githubusercontent.com/1624067/115596003-9b13c600-a2a5-11eb-8a47-badc8ba4ac28.png)

This branch:
![Screen Shot 2021-04-21 at 1 37 39 PM](https://user-images.githubusercontent.com/1624067/115597057-cfd44d00-a2a6-11eb-9467-cd1b4410de8c.png)


3. Open dev tools to the Network tab and filter on "events". On develop, you should see a call to this endpoint every ~2 seconds, here it should throttle down to once every 16 seconds (unless something else is happening on your account).

4. Run the tests:

`yarn test event.handlers`