### PR TITLE
M3-5086: Filter out creating and pending images from ImageSelect

### DIFF
--- a/packages/manager/src/components/ImageSelect/ImageSelect.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.tsx
@@ -96,7 +96,7 @@ export const imagesToGroupedItems = (images: Image[]) => {
               const isDeprecated = thisImage.deprecated;
               const fullLabel =
                 thisImage.label + (isDeprecated ? ' (Deprecated)' : '');
-              const _option = {
+              return {
                 created: thisImage.created,
                 label: fullLabel,
                 value: thisImage.id,
@@ -104,7 +104,6 @@ export const imagesToGroupedItems = (images: Image[]) => {
                   ? `fl-${distroIcons[thisImage.vendor]}`
                   : `fl-tux`,
               };
-              return _option;
             })
             .sort(sortByImageVersion),
         });
@@ -135,15 +134,12 @@ export const ImageSelect: React.FC<Props> = (props) => {
         .reason
     : undefined;
 
-  const imageIsReady = (image: Image) =>
-    !['creating', 'pending_upload'].includes(image.status);
-
   const filteredImages = images.filter((thisImage) => {
     switch (variant) {
       case 'public':
-        return thisImage.is_public && imageIsReady(thisImage);
+        return thisImage.is_public && thisImage.status === 'available';
       case 'private':
-        return !thisImage.is_public && imageIsReady(thisImage);
+        return !thisImage.is_public && thisImage.status === 'available';
       case 'all':
       default:
         return true;
@@ -161,37 +157,35 @@ export const ImageSelect: React.FC<Props> = (props) => {
   };
 
   return (
-    <>
-      <Paper className={classes.root} data-qa-select-image-panel>
-        <Typography variant="h2" data-qa-tp={title}>
-          {title}
-        </Typography>
-        <Grid container direction="row" wrap="nowrap" spacing={4}>
-          <Grid container item direction="column">
-            <Grid container item direction="row">
-              <Grid item xs={12}>
-                <Select
-                  disabled={disabled}
-                  label="Images"
-                  isLoading={_loading}
-                  placeholder="Choose an image"
-                  options={options}
-                  onChange={onChange}
-                  value={getSelectedOptionFromGroupedOptions(
-                    selectedImageID || '',
-                    options
-                  )}
-                  errorText={error || imageError}
-                  components={{ Option: ImageOption, SingleValue }}
-                  {...reactSelectProps}
-                  className={classNames}
-                />
-              </Grid>
+    <Paper className={classes.root} data-qa-select-image-panel>
+      <Typography variant="h2" data-qa-tp={title}>
+        {title}
+      </Typography>
+      <Grid container direction="row" wrap="nowrap" spacing={4}>
+        <Grid container item direction="column">
+          <Grid container item direction="row">
+            <Grid item xs={12}>
+              <Select
+                disabled={disabled}
+                label="Images"
+                isLoading={_loading}
+                placeholder="Choose an image"
+                options={options}
+                onChange={onChange}
+                value={getSelectedOptionFromGroupedOptions(
+                  selectedImageID || '',
+                  options
+                )}
+                errorText={error || imageError}
+                components={{ Option: ImageOption, SingleValue }}
+                {...reactSelectProps}
+                className={classNames}
+              />
             </Grid>
           </Grid>
         </Grid>
-      </Paper>
-    </>
+      </Grid>
+    </Paper>
   );
 };
 

--- a/packages/manager/src/components/ImageSelect/ImageSelect.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.tsx
@@ -135,12 +135,15 @@ export const ImageSelect: React.FC<Props> = (props) => {
         .reason
     : undefined;
 
+  const imageIsReady = (image: Image) =>
+    !['creating', 'pending_upload'].includes(image.status);
+
   const filteredImages = images.filter((thisImage) => {
     switch (variant) {
       case 'public':
-        return thisImage.is_public;
+        return thisImage.is_public && imageIsReady(thisImage);
       case 'private':
-        return !thisImage.is_public;
+        return !thisImage.is_public && imageIsReady(thisImage);
       case 'all':
       default:
         return true;


### PR DESCRIPTION
## Description
Filters out images with the status of `creating` or `pending_upload` in the ImageSelect component.

## How to test
1. Create a manual image for a Linode in `Images`
2. While the image status is creating or pending upload, go to `Linodes` and click on `Create Linode`
3. In the `Images` tab within Create Linode, click on the `Choose an image` dropdown
4. The image we just created should not display
5. Go back to image status and wait for the status to be `Ready`
6. Check the dropdown again and the new image should now display
