### PR TITLE
small fix for stackscripts e2e

### DIFF
--- a/packages/manager/cypress/integration/stackscripts/stackscripts.spec.ts
+++ b/packages/manager/cypress/integration/stackscripts/stackscripts.spec.ts
@@ -33,10 +33,18 @@ describe('stackscripts', () => {
     getClick('[data-qa-stackscript-script="true"]').type('#!/bin/bash');
     getClick('[data-qa-save="true"]');
     fbtVisible(ssLabel);
-    getVisible(`[data-qa-table-row="${ssLabel}"]`).within(() => {
-      getClick(`[aria-label="Action menu for StackScript ${ssLabel}"]`);
-    });
-    fbtClick('Deploy New Linode');
+    getVisible(`[data-qa-table-row="${ssLabel}"]`);
+    cy.get(`[aria-label="Action menu for StackScript ${ssLabel}"]`)
+      .invoke('attr', 'aria-controls')
+      .then(($id) => {
+        if ($id) {
+          getClick(`[aria-label="Action menu for StackScript ${ssLabel}"]`);
+        }
+        getClick(
+          `[id="option-1--${$id}"][data-qa-action-menu-item="Deploy New Linode"]`
+        );
+      });
+
     createLinode();
     cy.wait('@createLinode', { timeout: 300000 }).then((linode) => {
       cy.visit(`/linodes/${linode.response?.body.id}/storage`);

--- a/packages/manager/cypress/integration/stackscripts/stackscripts.spec.ts
+++ b/packages/manager/cypress/integration/stackscripts/stackscripts.spec.ts
@@ -34,8 +34,9 @@ describe('stackscripts', () => {
     getClick('[data-qa-save="true"]');
     fbtVisible(ssLabel);
     getVisible(`[data-qa-table-row="${ssLabel}"]`).within(() => {
-      fbtClick('Deploy New Linode');
+      getClick(`[aria-label="Action menu for StackScript ${ssLabel}"]`);
     });
+    fbtClick('Deploy New Linode');
     createLinode();
     cy.wait('@createLinode', { timeout: 300000 }).then((linode) => {
       cy.visit(`/linodes/${linode.response?.body.id}/storage`);


### PR DESCRIPTION
## Description
This change was needed because of some recent ui changes to this page

**What does this PR do?**
just a small stackscripts e2e test update

## How to test
- `yarn up` in one terminal
- `yarn cy:e2e -s ./cypress/integration/stackscripts/stackscripts.spec.ts` in another
- Result should be `✔  All specs passed!`

## Make sure your .env contains:
```
REACT_APP_LOGIN_ROOT
REACT_APP_API_ROOT
REACT_APP_APP_ROOT
REACT_APP_LAUNCH_DARKLY_ID
REACT_APP_CLIENT_ID
MANAGER_OAUTH
```
