### PR TITLE
change status from disk imagize to capturing image

### DIFF
--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
@@ -305,7 +305,7 @@ RenderFlag.displayName = `RenderFlag`;
 export const ProgressDisplay: React.FC<{
   className?: string;
   progress: null | number;
-  text: string;
+  text: string | undefined;
 }> = (props) => {
   const { progress, text, className } = props;
   const displayProgress = progress ? `${progress}%` : `scheduled`;

--- a/packages/manager/src/features/linodes/transitions.test.ts
+++ b/packages/manager/src/features/linodes/transitions.test.ts
@@ -1,25 +1,17 @@
 import { transitionText } from './transitions';
+import { eventFactory } from 'src/factories/events';
 
 describe('transitionText helper', () => {
   it('should remove "linode" from the event and capitalize it', () => {
-    expect(
-      transitionText('loading', 123, {
-        id: 123,
-        action: 'linode_snapshot',
-        secondary_entity: null,
-        created: '2012-12-12',
-        entity: null,
-        percent_complete: null,
-        rate: null,
-        read: true,
-        seen: true,
-        status: 'started',
-        time_remaining: null,
-        username: 'linode',
-        duration: 0,
-        message: null,
-      })
-    ).toEqual('Snapshot');
+    const mockEvent = eventFactory.build({
+      action: 'linode_snapshot',
+      percent_complete: null,
+      read: true,
+      seen: true,
+    });
+    expect(transitionText('loading', mockEvent.id, mockEvent)).toEqual(
+      'Snapshot'
+    );
   });
 
   it('should use status if an event is missing and capitalize it', () => {
@@ -27,49 +19,29 @@ describe('transitionText helper', () => {
   });
 
   it('should use status if an event is not a transition event and capitalize it', () => {
-    expect(
-      transitionText('optimus', 123, {
-        id: 123,
-        action: 'linode_addip',
-        secondary_entity: null,
-        created: '2012-12-12',
-        entity: null,
-        percent_complete: null,
-        rate: null,
-        read: true,
-        seen: true,
-        status: 'started',
-        time_remaining: null,
-        username: 'linode',
-        duration: 0,
-        message: null,
-      })
-    ).toEqual('Optimus');
+    const mockEvent = eventFactory.build({
+      action: 'linode_addip',
+      percent_complete: null,
+      read: true,
+      seen: true,
+    });
+    expect(transitionText('optimus', mockEvent.id, mockEvent)).toEqual(
+      'Optimus'
+    );
   });
 
-  it('should use present tense if an event is a transition event and capitalize it', () => {
-    expect(
-      transitionText('running', 123, {
-        id: 123,
-        action: 'disk_imagize',
-        secondary_entity: {
-          id: 12345,
-          label: 'Alpine 3.13 Disk',
-          type: 'image',
-          url: '/v4/images/private/12345',
-        },
-        created: '2020-12-12',
-        entity: null,
-        percent_complete: 34,
-        rate: null,
-        read: false,
-        seen: false,
-        status: 'started',
-        time_remaining: null,
-        username: 'linode',
-        duration: 12,
-        message: null,
-      })
-    ).toEqual('Capturing Image');
+  it('should use present continuous tense if an event is a transition event and capitalize it', () => {
+    const mockEvent = eventFactory.build({
+      action: 'disk_imagize',
+      secondary_entity: {
+        id: 12345,
+        label: 'Alpine 3.13 Disk',
+        type: 'image',
+        url: '/v4/images/private/12345',
+      },
+    });
+    expect(transitionText('running', mockEvent.id, mockEvent)).toEqual(
+      'Capturing Image'
+    );
   });
 });

--- a/packages/manager/src/features/linodes/transitions.test.ts
+++ b/packages/manager/src/features/linodes/transitions.test.ts
@@ -2,44 +2,19 @@ import { transitionText } from './transitions';
 import { eventFactory } from 'src/factories/events';
 
 describe('transitionText helper', () => {
-  it('should remove "linode" from the event and capitalize it', () => {
-    const mockEvent = eventFactory.build({
-      action: 'linode_snapshot',
-      percent_complete: null,
-      read: true,
-      seen: true,
-    });
-    expect(transitionText('loading', mockEvent.id, mockEvent)).toEqual(
-      'Snapshot'
-    );
-  });
-
   it('should use status if an event is missing and capitalize it', () => {
     expect(transitionText('loading', 0)).toEqual('Loading');
   });
 
   it('should use status if an event is not a transition event and capitalize it', () => {
-    const mockEvent = eventFactory.build({
-      action: 'linode_addip',
-      percent_complete: null,
-      read: true,
-      seen: true,
-    });
+    const mockEvent = eventFactory.build({ action: 'linode_addip' });
     expect(transitionText('optimus', mockEvent.id, mockEvent)).toEqual(
       'Optimus'
     );
   });
 
   it('should use present continuous tense if an event is a transition event and capitalize it', () => {
-    const mockEvent = eventFactory.build({
-      action: 'disk_imagize',
-      secondary_entity: {
-        id: 12345,
-        label: 'Alpine 3.13 Disk',
-        type: 'image',
-        url: '/v4/images/private/12345',
-      },
-    });
+    const mockEvent = eventFactory.build({ action: 'disk_imagize' });
     expect(transitionText('running', mockEvent.id, mockEvent)).toEqual(
       'Capturing Image'
     );

--- a/packages/manager/src/features/linodes/transitions.test.ts
+++ b/packages/manager/src/features/linodes/transitions.test.ts
@@ -46,4 +46,30 @@ describe('transitionText helper', () => {
       })
     ).toEqual('Optimus');
   });
+
+  it('should use present tense if an event is a transition event and capitalize it', () => {
+    expect(
+      transitionText('running', 123, {
+        id: 123,
+        action: 'disk_imagize',
+        secondary_entity: {
+          id: 12345,
+          label: 'Alpine 3.13 Disk',
+          type: 'image',
+          url: '/v4/images/private/12345',
+        },
+        created: '2020-12-12',
+        entity: null,
+        percent_complete: 34,
+        rate: null,
+        read: false,
+        seen: false,
+        status: 'started',
+        time_remaining: null,
+        username: 'linode',
+        duration: 12,
+        message: null,
+      })
+    ).toEqual('Capturing Image');
+  });
 });

--- a/packages/manager/src/features/linodes/transitions.ts
+++ b/packages/manager/src/features/linodes/transitions.ts
@@ -28,9 +28,9 @@ const transitionActionMap: Partial<Record<EventAction, string>> = {
   linode_mutate: 'Upgrading',
   linode_clone: 'Cloning',
   linode_migrate_datacenter: 'Migrating',
-  disk_resize: 'Resizing',
+  disk_resize: 'Disk Resizing',
   disk_imagize: 'Capturing Image',
-  disk_duplicate: 'Duplicating',
+  disk_duplicate: 'Disk Duplicating',
 };
 
 export const linodeInTransition = (
@@ -68,39 +68,6 @@ export const transitionText = (
   }
 
   return capitalizeAllWords(status.replace('_', ' '));
-};
-
-// There are two possibilities here:
-//
-// 1. "Cloning from <linode_label>"
-// 2. "Cloning to <linode_label>"
-//
-// This function builds this message based on the event, its primary and
-// secondary entities, and the Linode ID.
-export const buildLinodeCloneTransitionText = (
-  event: Event,
-  linodeId: number,
-  cmr?: boolean
-) => {
-  let text = 'Cloning';
-
-  if (cmr !== true) {
-    if (isPrimaryEntity(event, linodeId)) {
-      const secondaryEntityLabel = event?.secondary_entity?.label;
-      if (secondaryEntityLabel) {
-        text += ` to: ${secondaryEntityLabel}`;
-      }
-    }
-
-    if (isSecondaryEntity(event, linodeId)) {
-      const primaryEntityLabel = event?.entity?.label;
-      if (primaryEntityLabel) {
-        text += ` from: ${primaryEntityLabel}`;
-      }
-    }
-  }
-
-  return text;
 };
 
 // Given a list of Events, returns a set of all Linode IDs that are involved in an in-progress event.

--- a/packages/manager/src/features/linodes/transitions.ts
+++ b/packages/manager/src/features/linodes/transitions.ts
@@ -33,6 +33,12 @@ export const transitionAction = [
   'linode_migrate_datacenter',
 ];
 
+const transitionActionMap = {
+  linode_mutate: 'Upgrading',
+  linode_migrate_datacenter: 'Migrating',
+  disk_imagize: 'Capturing Image',
+};
+
 export const linodeInTransition = (
   status: string,
   recentEvent?: Event
@@ -54,14 +60,6 @@ export const transitionText = (
   linodeId: number,
   recentEvent?: Event
 ): string => {
-  // `linode_mutate` is a special case, because we want to display
-  // "Upgrading" instead of "Mutate".
-
-  // @todo @tdt: use a map instead (event_type to display name)
-  if (recentEvent?.action === 'linode_mutate') {
-    return 'Upgrading';
-  }
-
   if (recentEvent?.action === 'linode_clone') {
     if (isPrimaryEntity(recentEvent, linodeId)) {
       return 'Cloning';
@@ -71,17 +69,16 @@ export const transitionText = (
     }
   }
 
-  if (recentEvent?.action === 'linode_migrate_datacenter') {
-    return 'Migrating';
+  if (recentEvent && transitionActionMap[recentEvent.action]) {
+    return transitionActionMap[recentEvent.action];
   }
 
-  let event;
-  if (recentEvent && transitionAction.includes(recentEvent.action)) {
-    event = recentEvent.action.replace('linode_', '').replace('_', ' ');
-  } else {
-    event = status.replace('_', ' ');
+  if (recentEvent && transitionAction.includes(recentEvent?.action)) {
+    const event = recentEvent?.action.replace('linode_', '').replace('_', ' ');
+    return capitalizeAllWords(event);
   }
-  return capitalizeAllWords(event);
+
+  return capitalizeAllWords(status.replace('_', ' '));
 };
 
 // There are two possibilities here:

--- a/packages/manager/src/features/linodes/transitions.ts
+++ b/packages/manager/src/features/linodes/transitions.ts
@@ -22,21 +22,15 @@ export const transitionStatus = [
   'edit_mode',
 ];
 
-export const transitionAction = [
-  'linode_snapshot',
-  'disk_resize',
-  'backups_restore',
-  'disk_imagize',
-  'disk_duplicate',
-  'linode_mutate',
-  'linode_clone',
-  'linode_migrate_datacenter',
-];
-
-const transitionActionMap = {
+const transitionActionMap: Partial<Record<EventAction, string>> = {
+  backups_restore: 'Backups Restore',
+  linode_snapshot: 'Snapshot',
   linode_mutate: 'Upgrading',
+  linode_clone: 'Cloning',
   linode_migrate_datacenter: 'Migrating',
+  disk_resize: 'Resizing',
   disk_imagize: 'Capturing Image',
+  disk_duplicate: 'Duplicating',
 };
 
 export const linodeInTransition = (
@@ -49,7 +43,7 @@ export const linodeInTransition = (
 
   return (
     recentEvent !== undefined &&
-    transitionAction.includes(recentEvent.action || '') &&
+    transitionActionMap.hasOwnProperty(recentEvent.action) &&
     recentEvent.percent_complete !== null &&
     recentEvent.percent_complete < 100
   );
@@ -59,7 +53,7 @@ export const transitionText = (
   status: string,
   linodeId: number,
   recentEvent?: Event
-): string => {
+): string | undefined => {
   if (recentEvent?.action === 'linode_clone') {
     if (isPrimaryEntity(recentEvent, linodeId)) {
       return 'Cloning';
@@ -71,11 +65,6 @@ export const transitionText = (
 
   if (recentEvent && transitionActionMap[recentEvent.action]) {
     return transitionActionMap[recentEvent.action];
-  }
-
-  if (recentEvent && transitionAction.includes(recentEvent?.action)) {
-    const event = recentEvent?.action.replace('linode_', '').replace('_', ' ');
-    return capitalizeAllWords(event);
   }
 
   return capitalizeAllWords(status.replace('_', ' '));


### PR DESCRIPTION
## Description
Changes status transition text from `Disk Imagize` to `Capturing Image`
## How to test
1. Go to `Images` and create/capture an image.
2. The status in `Images` should be `Creating`
3. Go to `Linodes`, the linode status you captured the image from should be `Capturing image`
