### PR TITLE
M3-5057: TextField error message positioning and width

### DIFF
--- a/packages/manager/src/components/Breadcrumb/FinalCrumb.tsx
+++ b/packages/manager/src/components/Breadcrumb/FinalCrumb.tsx
@@ -48,6 +48,7 @@ const FinalCrumb: React.FC<CombinedProps> = (props) => {
         labelLink={labelOptions && labelOptions.linkTo}
         data-qa-editable-text
         className={classes.editableContainer}
+        inBreadcrumb
       />
     );
   }

--- a/packages/manager/src/components/EditableText/EditableText.tsx
+++ b/packages/manager/src/components/EditableText/EditableText.tsx
@@ -79,6 +79,16 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginRight: 6,
     minWidth: 'auto',
     padding: 0,
+    [theme.breakpoints.down('sm')]: {
+      marginLeft: 4,
+      marginRight: 4,
+    },
+    '&:first-of-type': {
+      marginLeft: 20,
+      [theme.breakpoints.down('sm')]: {
+        marginLeft: 12,
+      },
+    },
   },
   icon: {
     color: theme.palette.text.primary,
@@ -95,9 +105,6 @@ const useStyles = makeStyles((theme: Theme) => ({
         opacity: 1,
       },
     },
-  },
-  saveIcon: {
-    marginLeft: theme.spacing(),
   },
   headline: {
     ...theme.typography.h1,
@@ -116,6 +123,7 @@ interface Props {
   errorText?: string;
   labelLink?: string;
   className?: string;
+  inBreadcrumb?: boolean;
 }
 
 type PassThroughProps = Props & TextFieldProps;
@@ -134,6 +142,7 @@ const EditableText: React.FC<FinalProps> = (props) => {
     onCancel,
     text: propText,
     className,
+    inBreadcrumb,
     ...rest
   } = props;
 
@@ -234,13 +243,14 @@ const EditableText: React.FC<FinalProps> = (props) => {
           }}
           // eslint-disable-next-line
           autoFocus={true}
+          inBreadcrumb={inBreadcrumb}
         />
         <Button
           className={classes.button}
           onClick={finishEditing}
           data-qa-save-edit
         >
-          <Check className={`${classes.icon} ${classes.saveIcon}`} />
+          <Check className={classes.icon} />
         </Button>
         <Button
           className={classes.button}

--- a/packages/manager/src/components/EnhancedNumberInput/EnhancedNumberInput.test.tsx
+++ b/packages/manager/src/components/EnhancedNumberInput/EnhancedNumberInput.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
 import { wrapWithTheme } from 'src/utilities/testHelpers';
@@ -27,7 +28,7 @@ describe('EnhancedNumberInput', () => {
 
     const addButton = getByTestId('increment-button');
 
-    fireEvent.click(addButton);
+    userEvent.click(addButton);
     expect(setValue).toHaveBeenCalledWith(2);
   });
 
@@ -38,7 +39,7 @@ describe('EnhancedNumberInput', () => {
 
     const subtractButton = getByTestId('decrement-button');
 
-    fireEvent.click(subtractButton);
+    userEvent.click(subtractButton);
     expect(setValue).toHaveBeenCalledWith(0);
   });
 
@@ -48,7 +49,7 @@ describe('EnhancedNumberInput', () => {
     );
 
     const input = getByTestId('textfield-input');
-    fireEvent.change(input, { target: { value: '100' } });
+    userEvent.type(input, '100');
     expect(setValue).toHaveBeenCalledWith(100);
   });
 
@@ -58,7 +59,7 @@ describe('EnhancedNumberInput', () => {
     );
 
     const input = getByTestId('textfield-input');
-    fireEvent.change(input, { target: { value: 'prestidigitation' } });
+    userEvent.type(input, 'prestidigitation');
     expect(setValue).toHaveBeenCalledWith(0);
   });
 

--- a/packages/manager/src/components/EnhancedNumberInput/EnhancedNumberInput.tsx
+++ b/packages/manager/src/components/EnhancedNumberInput/EnhancedNumberInput.tsx
@@ -95,6 +95,9 @@ export const EnhancedNumberInput: React.FC<FinalProps> = (props) => {
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const parsedValue = +e.target.value;
+    if (isNaN(parsedValue)) {
+      setValue(0);
+    }
     if (parsedValue >= min && parsedValue <= max) {
       setValue(+e.target.value);
     }

--- a/packages/manager/src/components/TextField.tsx
+++ b/packages/manager/src/components/TextField.tsx
@@ -19,9 +19,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   noTransform: {
     transform: 'none',
   },
-  root: {
-    marginTop: 0,
-  },
   helpWrapperContainer: {
     display: 'flex',
     width: '100%',
@@ -71,22 +68,27 @@ const useStyles = makeStyles((theme: Theme) => ({
     color: theme.color.red,
     height: 34,
     top: -2,
-    left: 280,
-    width: 200,
+    left: 285,
+    width: 'max-content',
+  },
+  // Adjusts position of errorText when textfield is in breadcrumb
+  errorTextBreadcrumb: {
+    [theme.breakpoints.down('md')]: {
+      maxWidth: 300,
+    },
     [theme.breakpoints.down('sm')]: {
-      left: 260,
+      left: 248,
+      maxWidth: 200,
     },
     [theme.breakpoints.down('xs')]: {
       top: 26,
-      left: 5,
-      width: 400,
+      left: 6,
+      maxWidth: 300,
     },
   },
   errorTextLong: {
-    width: '100%',
-    [theme.breakpoints.down(480)]: {
+    [theme.breakpoints.down('xs')]: {
       top: 36,
-      width: 240,
     },
   },
   absolute: {
@@ -94,7 +96,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   editable: {
     wordBreak: 'keep-all',
-    paddingLeft: 1,
   },
   helperTextTop: {
     marginBottom: theme.spacing(),
@@ -118,7 +119,7 @@ interface BaseProps {
   // Currently only used for LKE node pool inputs
   tiny?: boolean;
   /**
-   * number amounts allowed in textfield
+   * Number amounts allowed in textfield
    * "type" prop must also be set to "number"
    */
   min?: number;
@@ -129,6 +130,7 @@ interface BaseProps {
   hideLabel?: boolean;
   hasAbsoluteError?: boolean;
   inputId?: string;
+  inBreadcrumb?: boolean;
 }
 
 interface TextFieldPropsOverrides extends TextFieldProps {
@@ -145,32 +147,33 @@ export const LinodeTextField: React.FC<CombinedProps> = (props) => {
 
   const {
     errorText,
-    editable,
     errorGroup,
     affirmative,
-    onChange,
+    helperText,
+    helperTextPosition,
     tooltipText,
     className,
     expand,
     small,
+    editable,
     tiny,
-    inputProps,
-    helperText,
-    helperTextPosition,
-    InputProps,
-    InputLabelProps,
-    SelectProps,
-    dataAttrs,
+    onChange,
     error,
-    hideLabel,
-    noMarginTop,
     label,
-    loading,
-    hasAbsoluteError,
-    inputId,
     type,
     min,
     max,
+    dataAttrs,
+    noMarginTop,
+    loading,
+    hideLabel,
+    hasAbsoluteError,
+    inputId,
+    inBreadcrumb,
+    inputProps,
+    InputProps,
+    InputLabelProps,
+    SelectProps,
     ...textFieldProps
   } = props;
 
@@ -246,6 +249,7 @@ export const LinodeTextField: React.FC<CombinedProps> = (props) => {
   const maybeRequiredLabel = !!props.required ? `${label} (required)` : label;
   const validInputId =
     inputId || (props.label ? convertToKebabCase(`${props.label}`) : undefined);
+
   return (
     <div
       className={classNames({
@@ -257,8 +261,8 @@ export const LinodeTextField: React.FC<CombinedProps> = (props) => {
         <InputLabel
           data-qa-textfield-label={label}
           className={classNames({
-            [classes.wrapper]: noMarginTop ? false : true,
             [classes.noTransform]: true,
+            [classes.wrapper]: noMarginTop ? false : true,
             'visually-hidden': hideLabel,
           })}
           htmlFor={validInputId}
@@ -345,9 +349,9 @@ export const LinodeTextField: React.FC<CombinedProps> = (props) => {
           }}
           className={classNames(
             {
+              [classes.noMarginTop]: true,
               [classes.helpWrapperTextField]: Boolean(tooltipText),
               [classes.small]: small,
-              [classes.root]: true,
             },
             className
           )}
@@ -362,7 +366,8 @@ export const LinodeTextField: React.FC<CombinedProps> = (props) => {
         <FormHelperText
           className={classNames({
             [classes.errorText]: true,
-            [classes.errorTextLong]: errorText.length > 60,
+            [classes.errorTextBreadcrumb]: inBreadcrumb,
+            [classes.errorTextLong]: inBreadcrumb && errorText.length > 45,
             [classes.editable]: editable,
             [classes.absolute]: editable || hasAbsoluteError,
           })}

--- a/packages/manager/src/components/TextField.tsx
+++ b/packages/manager/src/components/TextField.tsx
@@ -160,7 +160,6 @@ export const LinodeTextField: React.FC<CombinedProps> = (props) => {
     onChange,
     error,
     label,
-    type,
     min,
     max,
     dataAttrs,
@@ -189,7 +188,7 @@ export const LinodeTextField: React.FC<CombinedProps> = (props) => {
        */
       const cleanedValue =
         minAndMaxExist &&
-        numberTypes.some((eachType) => eachType === type) &&
+        numberTypes.some((eachType) => eachType === props.type) &&
         e.target.value !== ''
           ? clamp(min, max, +e.target.value)
           : e.target.value;
@@ -225,7 +224,7 @@ export const LinodeTextField: React.FC<CombinedProps> = (props) => {
         }
       }
     },
-    [max, min, onChange, type]
+    [max, min, onChange, props.type]
   );
 
   let errorScrollClassName = '';

--- a/packages/manager/src/components/TextField.tsx
+++ b/packages/manager/src/components/TextField.tsx
@@ -7,128 +7,103 @@ import CircleProgress from 'src/components/CircleProgress';
 import FormHelperText from 'src/components/core/FormHelperText';
 import InputAdornment from 'src/components/core/InputAdornment';
 import InputLabel from 'src/components/core/InputLabel';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles,
-  WithTheme,
-} from 'src/components/core/styles';
+import { makeStyles, Theme, WithTheme } from 'src/components/core/styles';
 import TextField, { TextFieldProps } from 'src/components/core/TextField';
 import HelpIcon from 'src/components/HelpIcon';
 import { convertToKebabCase } from 'src/utilities/convertToKebobCase';
 
-type ClassNames =
-  | 'root'
-  | 'helpWrapperContainer'
-  | 'helpWrapper'
-  | 'helpWrapperTextField'
-  | 'expand'
-  | 'errorText'
-  | 'errorTextLong'
-  | 'editable'
-  | 'helperTextTop'
-  | 'small'
-  | 'noTransform'
-  | 'selectSmall'
-  | 'wrapper'
-  | 'tiny'
-  | 'absolute'
-  | 'helpIcon';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    wrapper: {
-      marginTop: theme.spacing(2),
-    },
-    noTransform: {
-      transform: 'none',
-    },
-    root: {
-      marginTop: 0,
-    },
-    helpWrapperContainer: {
-      display: 'flex',
+const useStyles = makeStyles((theme: Theme) => ({
+  wrapper: {
+    marginTop: theme.spacing(2),
+  },
+  noTransform: {
+    transform: 'none',
+  },
+  root: {
+    marginTop: 0,
+  },
+  helpWrapperContainer: {
+    display: 'flex',
+    width: '100%',
+  },
+  helpWrapper: {
+    display: 'flex',
+    alignItems: 'flex-end',
+    flexWrap: 'wrap',
+  },
+  helpWrapperTextField: {
+    width: 415,
+    [theme.breakpoints.down('xs')]: {
       width: '100%',
     },
-    helpWrapper: {
-      display: 'flex',
-      alignItems: 'flex-end',
-      flexWrap: 'wrap',
-    },
-    helpWrapperTextField: {
-      width: 415,
-      [theme.breakpoints.down('xs')]: {
-        width: '100%',
-      },
-    },
-    helpIcon: {
-      padding: '0px 0px 0px 8px',
-      color: theme.cmrTextColors.tableHeader,
-    },
-    expand: {
-      maxWidth: '100%',
-    },
-    small: {
+  },
+  helpIcon: {
+    padding: '0px 0px 0px 8px',
+    color: theme.cmrTextColors.tableHeader,
+  },
+  expand: {
+    maxWidth: '100%',
+  },
+  small: {
+    minHeight: 32,
+    marginTop: 0,
+    '& input': {
       minHeight: 32,
+      padding: theme.spacing(1),
+    },
+  },
+  selectSmall: {
+    padding: '8px 32px 0 8px',
+    minHeight: 32,
+    minWidth: 132,
+    '& svg': {
       marginTop: 0,
-      '& input': {
-        minHeight: 32,
-        padding: theme.spacing(1),
-      },
+      width: 24,
+      height: 24,
     },
-    selectSmall: {
-      padding: '8px 32px 0 8px',
-      minHeight: 32,
-      minWidth: 132,
-      '& svg': {
-        marginTop: 0,
-        width: 24,
-        height: 24,
-      },
+  },
+  tiny: {
+    width: '3.6em',
+  },
+  errorText: {
+    display: 'flex',
+    alignItems: 'center',
+    color: theme.color.red,
+    height: 34,
+    top: -2,
+    left: 280,
+    width: 200,
+    [theme.breakpoints.down('sm')]: {
+      left: 260,
     },
-    tiny: {
-      width: '3.6em',
+    [theme.breakpoints.down('xs')]: {
+      top: 26,
+      left: 5,
+      width: 400,
     },
-    errorText: {
-      display: 'flex',
-      alignItems: 'center',
-      color: theme.color.red,
-      height: 34,
-      top: -2,
-      left: 280,
-      width: 200,
-      [theme.breakpoints.down('sm')]: {
-        left: 260,
-      },
-      [theme.breakpoints.down('xs')]: {
-        top: 26,
-        left: 5,
-        width: 400,
-      },
+  },
+  errorTextLong: {
+    width: '100%',
+    [theme.breakpoints.down(480)]: {
+      top: 36,
+      width: 240,
     },
-    errorTextLong: {
-      width: '100%',
-      [theme.breakpoints.down(480)]: {
-        top: 36,
-        width: 240,
-      },
-    },
-    absolute: {
-      position: 'absolute',
-    },
-    editable: {
-      wordBreak: 'keep-all',
-      paddingLeft: 1,
-    },
-    helperTextTop: {
-      marginBottom: theme.spacing(),
-      marginTop: theme.spacing(),
-    },
-    noMarginTop: {
-      marginTop: 0,
-    },
-  });
+  },
+  absolute: {
+    position: 'absolute',
+  },
+  editable: {
+    wordBreak: 'keep-all',
+    paddingLeft: 1,
+  },
+  helperTextTop: {
+    marginBottom: theme.spacing(),
+    marginTop: theme.spacing(),
+  },
+  noMarginTop: {
+    marginTop: 0,
+  },
+}));
 
 interface BaseProps {
   errorText?: string;
@@ -163,32 +138,59 @@ interface TextFieldPropsOverrides extends TextFieldProps {
 
 export type Props = BaseProps & TextFieldProps & TextFieldPropsOverrides;
 
-type CombinedProps = Props & WithTheme & WithStyles<ClassNames>;
+type CombinedProps = Props & WithTheme;
 
-interface State {
-  value: string | number;
-}
+export const LinodeTextField: React.FC<CombinedProps> = (props) => {
+  const classes = useStyles();
 
-class LinodeTextField extends React.PureComponent<CombinedProps> {
-  state: State = {
-    /** initialize the state with our passed value if we have one */
-    value:
-      typeof this.props.value === 'string' ||
-      typeof this.props.value === 'number'
-        ? this.props.value
-        : '',
-  };
+  const {
+    errorText,
+    editable,
+    errorGroup,
+    affirmative,
+    onChange,
+    tooltipText,
+    className,
+    expand,
+    small,
+    tiny,
+    inputProps,
+    helperText,
+    helperTextPosition,
+    InputProps,
+    InputLabelProps,
+    SelectProps,
+    dataAttrs,
+    error,
+    hideLabel,
+    noMarginTop,
+    label,
+    loading,
+    hasAbsoluteError,
+    inputId,
+    type,
+    min,
+    max,
+    ...textFieldProps
+  } = props;
 
-  handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { type, min, max, onChange } = this.props;
+  /** Initialize the state with our passed value if we have one */
+  const [currentValue, setCurrentValue] = React.useState<
+    string | number | undefined
+  >(
+    typeof props.value === 'string' || typeof props.value === 'number'
+      ? props.value
+      : ''
+  );
 
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const numberTypes = ['tel', 'number'];
 
     /** because !!0 is falsy :( */
     const minAndMaxExist = typeof min === 'number' && typeof max === 'number';
 
     /**
-     * if we've provided a mix and max value, make sure the user
+     * If we've provided a mix and max value, make sure the user
      * input doesn't go outside of those bounds ONLY if the input
      * type matches a number type
      */
@@ -199,16 +201,14 @@ class LinodeTextField extends React.PureComponent<CombinedProps> {
         ? clamp(min, max, +e.target.value)
         : e.target.value;
 
-    this.setState({
-      value: cleanedValue,
-    });
+    setCurrentValue(cleanedValue);
 
     /**
-     * invoke the onChange prop if one is provided with the cleaned value.
+     * Invoke the onChange prop if one is provided with the cleaned value.
      */
     if (onChange) {
       /**
-       * create clone of event node only if our cleanedValue
+       * Create clone of event node only if our cleanedValue
        * is different from the e.target.value
        *
        * This solves for a specific scenario where the e.target on
@@ -235,195 +235,153 @@ class LinodeTextField extends React.PureComponent<CombinedProps> {
     }
   };
 
-  render() {
-    const {
-      errorText,
-      editable,
-      errorGroup,
-      affirmative,
-      classes,
-      fullWidth,
-      onChange,
-      children,
-      tooltipText,
-      theme,
-      className,
-      expand,
-      small,
-      tiny,
-      inputProps,
-      helperText,
-      helperTextPosition,
-      InputProps,
-      InputLabelProps,
-      SelectProps,
-      value,
-      dataAttrs,
-      error,
-      hideLabel,
-      noMarginTop,
-      label,
-      loading,
-      hasAbsoluteError,
-      inputId,
-      ...textFieldProps
-    } = this.props;
+  let errorScrollClassName = '';
 
-    let errorScrollClassName = '';
+  if (errorText) {
+    errorScrollClassName = errorGroup
+      ? `error-for-scroll-${errorGroup}`
+      : `error-for-scroll`;
+  }
 
-    if (errorText) {
-      errorScrollClassName = errorGroup
-        ? `error-for-scroll-${errorGroup}`
-        : `error-for-scroll`;
-    }
-
-    const maybeRequiredLabel = !!this.props.required
-      ? `${label} (required)`
-      : label;
-    const validInputId =
-      inputId ||
-      (this.props.label
-        ? convertToKebabCase(`${this.props.label}`)
-        : undefined);
-    return (
+  const maybeRequiredLabel = !!props.required ? `${label} (required)` : label;
+  const validInputId =
+    inputId || (props.label ? convertToKebabCase(`${props.label}`) : undefined);
+  return (
+    <div
+      className={classNames({
+        [classes.helpWrapper]: Boolean(tooltipText),
+        [errorScrollClassName]: !!errorText,
+      })}
+    >
+      {maybeRequiredLabel && (
+        <InputLabel
+          data-qa-textfield-label={label}
+          className={classNames({
+            [classes.wrapper]: noMarginTop ? false : true,
+            [classes.noTransform]: true,
+            'visually-hidden': hideLabel,
+          })}
+          htmlFor={validInputId}
+        >
+          {maybeRequiredLabel}
+        </InputLabel>
+      )}
+      {helperText && helperTextPosition === 'top' && (
+        <FormHelperText
+          data-qa-textfield-helper-text
+          className={classes.helperTextTop}
+        >
+          {helperText}
+        </FormHelperText>
+      )}
       <div
         className={classNames({
-          [classes.helpWrapper]: Boolean(tooltipText),
-          [errorScrollClassName]: !!errorText,
+          [classes.helpWrapperContainer]: Boolean(tooltipText),
         })}
       >
-        {maybeRequiredLabel && (
-          <InputLabel
-            data-qa-textfield-label={label}
-            className={classNames({
-              [classes.wrapper]: noMarginTop ? false : true,
-              [classes.noTransform]: true,
-              'visually-hidden': hideLabel,
-            })}
-            htmlFor={validInputId}
-          >
-            {maybeRequiredLabel}
-          </InputLabel>
-        )}
-        {helperText && helperTextPosition === 'top' && (
-          <FormHelperText
-            data-qa-textfield-helper-text
-            className={classes.helperTextTop}
-          >
-            {helperText}
-          </FormHelperText>
-        )}
-        <div
-          className={classNames({
-            [classes.helpWrapperContainer]: Boolean(tooltipText),
-          })}
-        >
-          <TextField
-            {...textFieldProps}
-            {...dataAttrs}
-            error={!!error || !!errorText}
-            /**
-             * set _helperText_ and _label_ to no value because we want to
-             * have the ability to put the helper text under the label at the top
-             */
-            label={''}
-            helperText={''}
-            fullWidth
-            /*
+        <TextField
+          {...textFieldProps}
+          {...dataAttrs}
+          error={!!error || !!errorText}
+          /**
+           * set _helperText_ and _label_ to no value because we want to
+           * have the ability to put the helper text under the label at the top
+           */
+          label={''}
+          helperText={''}
+          fullWidth
+          /*
             let us explicitly pass an empty string to the input
 
             see UserDefinedFieldsPanel.tsx for a verbose explanation why.
           */
-            value={value}
-            onChange={this.handleChange}
-            InputLabelProps={{
-              ...InputLabelProps,
-              required: false,
-              shrink: true,
-            }}
-            inputProps={{
-              'data-testid': 'textfield-input',
-              id: validInputId,
-              ...inputProps,
-            }}
-            InputProps={{
-              disableUnderline: true,
-              endAdornment: loading && (
-                <InputAdornment position="end">
-                  <CircleProgress mini />
-                </InputAdornment>
-              ),
-              className: classNames(
-                'input',
-                {
-                  [classes.expand]: expand,
-                  [classes.small]: small,
-                  [classes.tiny]: tiny,
-                  affirmative: !!affirmative,
-                },
-                className
-              ),
-              ...InputProps,
-            }}
-            SelectProps={{
-              disableUnderline: true,
-              IconComponent: KeyboardArrowDown,
-              MenuProps: {
-                getContentAnchorEl: undefined,
-                anchorOrigin: { vertical: 'bottom', horizontal: 'left' },
-                transformOrigin: { vertical: 'top', horizontal: 'left' },
-                MenuListProps: { className: 'selectMenuList' },
-                PaperProps: { className: 'selectMenuDropdown' },
-              },
-              inputProps: {
-                className: classNames({
-                  [classes.selectSmall]: small,
-                }),
-              },
-              ...SelectProps,
-            }}
-            className={classNames(
+          value={currentValue}
+          onChange={handleChange}
+          InputLabelProps={{
+            ...InputLabelProps,
+            required: false,
+            shrink: true,
+          }}
+          inputProps={{
+            'data-testid': 'textfield-input',
+            id: validInputId,
+            ...inputProps,
+          }}
+          InputProps={{
+            disableUnderline: true,
+            endAdornment: loading && (
+              <InputAdornment position="end">
+                <CircleProgress mini />
+              </InputAdornment>
+            ),
+            className: classNames(
+              'input',
               {
-                [classes.helpWrapperTextField]: Boolean(tooltipText),
+                [classes.expand]: expand,
                 [classes.small]: small,
-                [classes.root]: true,
+                [classes.tiny]: tiny,
+                affirmative: !!affirmative,
               },
               className
-            )}
-          >
-            {this.props.children}
-          </TextField>
-          {tooltipText && (
-            <HelpIcon className={classes.helpIcon} text={tooltipText} />
+            ),
+            ...InputProps,
+          }}
+          SelectProps={{
+            disableUnderline: true,
+            IconComponent: KeyboardArrowDown,
+            MenuProps: {
+              getContentAnchorEl: undefined,
+              anchorOrigin: { vertical: 'bottom', horizontal: 'left' },
+              transformOrigin: { vertical: 'top', horizontal: 'left' },
+              MenuListProps: { className: 'selectMenuList' },
+              PaperProps: { className: 'selectMenuDropdown' },
+            },
+            inputProps: {
+              className: classNames({
+                [classes.selectSmall]: small,
+              }),
+            },
+            ...SelectProps,
+          }}
+          className={classNames(
+            {
+              [classes.helpWrapperTextField]: Boolean(tooltipText),
+              [classes.small]: small,
+              [classes.root]: true,
+            },
+            className
           )}
-        </div>
-        {errorText && (
-          <FormHelperText
-            className={classNames({
-              [classes.errorText]: true,
-              [classes.errorTextLong]: errorText.length > 60,
-              [classes.editable]: editable,
-              [classes.absolute]: editable || hasAbsoluteError,
-            })}
-            data-qa-textfield-error-text={this.props.label}
-            role="alert"
-          >
-            {errorText}
+        >
+          {props.children}
+        </TextField>
+        {tooltipText && (
+          <HelpIcon className={classes.helpIcon} text={tooltipText} />
+        )}
+      </div>
+      {errorText && (
+        <FormHelperText
+          className={classNames({
+            [classes.errorText]: true,
+            [classes.errorTextLong]: errorText.length > 60,
+            [classes.editable]: editable,
+            [classes.absolute]: editable || hasAbsoluteError,
+          })}
+          data-qa-textfield-error-text={props.label}
+          role="alert"
+        >
+          {errorText}
+        </FormHelperText>
+      )}
+      {helperText &&
+        (helperTextPosition === 'bottom' || !helperTextPosition) && (
+          <FormHelperText data-qa-textfield-helper-text>
+            {helperText}
           </FormHelperText>
         )}
-        {helperText &&
-          (helperTextPosition === 'bottom' || !helperTextPosition) && (
-            <FormHelperText data-qa-textfield-helper-text>
-              {helperText}
-            </FormHelperText>
-          )}
-      </div>
-    );
-  }
-}
+    </div>
+  );
+};
 
-const styled = withStyles(styles, { withTheme: true });
-
-export default compose<CombinedProps, Props>(styled)(
+export default compose<CombinedProps, Props>()(
   LinodeTextField
 ) as React.ComponentType<Props>;

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -664,7 +664,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                   small
                   disabled={disabled}
                   noMarginTop
-                  InputProps={{ id: `port-${configIdx}` }}
+                  inputId={`port-${configIdx}`}
                 />
                 <FormHelperText>Listen on this port</FormHelperText>
               </Grid>

--- a/packages/manager/src/features/StackScripts/StackScriptsDetail.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptsDetail.tsx
@@ -34,6 +34,12 @@ type CombinedProps = RouteProps & SetDocsProps;
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
     margin: 0,
+    // Display label errorText below to save space
+    '& .MuiFormHelperText-root': {
+      top: 26,
+      left: 6,
+      maxWidth: 'max-content',
+    },
     [theme.breakpoints.down('sm')]: {
       paddingRight: theme.spacing(),
     },
@@ -74,6 +80,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     fontFamily: theme.font.normal,
     fontSize: 20,
     marginRight: 2,
+  },
+  error: {
+    paddingTop: 20,
   },
 }));
 
@@ -212,7 +221,12 @@ export const StackScriptsDetail: React.FC<CombinedProps> = (props) => {
           </Button>
         </Grid>
       </Grid>
-      <div className="detailsWrapper">
+      <div
+        className={classnames({
+          detailsWrapper: true,
+          [classes.error]: Boolean(labelError),
+        })}
+      >
         <_StackScript data={stackScript} />
       </div>
     </>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailsBreadcrumb.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailsBreadcrumb.tsx
@@ -34,17 +34,17 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
     // The docs button will wrap when the label is editing mode so do not add
     // padding when it wraps
-    [theme.breakpoints.down(395)]: {
+    [theme.breakpoints.down(396)]: {
       paddingBottom: 0,
     },
   },
   errorLong: {
-    [theme.breakpoints.down(480)]: {
+    [theme.breakpoints.down('xs')]: {
       paddingBottom: 40,
     },
     // The docs button will wrap when the label is editing mode so do not add
     // padding when it wraps
-    [theme.breakpoints.down(395)]: {
+    [theme.breakpoints.down(396)]: {
       paddingBottom: 0,
     },
   },
@@ -102,7 +102,7 @@ const LinodeControls: React.FC<CombinedProps> = (props) => {
       className={classnames({
         [classes.root]: true,
         [classes.error]: Boolean(editableLabelError),
-        [classes.errorLong]: Boolean(editableLabelError.length > 60),
+        [classes.errorLong]: editableLabelError.length > 45,
         m0: true,
       })}
       container


### PR DESCRIPTION
## Description

This PR refactors `TextField` into a FC and adds a conditional prop that adjusts the position and width of an editable `TextField` when it's part of a breadcrumb. This will prevent the error message from wrapping to a newline when there's space in a form.

ie.
<img width="478" alt="Screen Shot 2021-04-09 at 2 33 21 PM" src="https://user-images.githubusercontent.com/7692354/116149447-27f8be00-a6b0-11eb-9de3-749946c97229.png">


The original ask for this ticket was to look into replacing `position: absolute` and the fixed width with `display: flex`. I ended up cleaning up the responsiveness and tightening the whitespace instead because there was no clean way to move the error message after the save/cancel buttons since the error message is rendered as part of `TextField`.

## How to test

Please check the error message for `TextField` components throughout the app at different viewports. You can find an editable breadcrumb on most of the product detail pages. 