### PR TITLE
For release: Remove beta notices and link for VLANs since they're leaving beta

### DIFF
--- a/packages/manager/src/features/linodes/LinodesCreate/AttachVLAN.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/AttachVLAN.tsx
@@ -1,7 +1,6 @@
 import { Interface } from '@linode/api-v4/lib/linodes';
 import * as React from 'react';
 import Box from 'src/components/core/Box';
-import Chip from 'src/components/core/Chip';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import ExternalLink from 'src/components/ExternalLink';
@@ -73,7 +72,6 @@ const AttachVLAN: React.FC<CombinedProps> = (props) => {
         <Typography variant="h2" className={classes.title}>
           Attach a VLAN {helperText ? <HelpIcon text={helperText} /> : null}
         </Typography>
-        <Chip className={classes.chip} label="beta" component="span" />
       </Box>
       <Grid container>
         <Grid item xs={12}>
@@ -86,15 +84,6 @@ const AttachVLAN: React.FC<CombinedProps> = (props) => {
             <ExternalLink
               text="Configuration Profile"
               link="https://linode.com/docs/guides/disk-images-and-configuration-profiles/"
-              hideIcon
-            />
-            .
-          </Typography>
-          <Typography style={{ marginTop: 16 }}>
-            VLAN is currently in beta and is subject to the terms of the{' '}
-            <ExternalLink
-              text="Early Adopter Testing Agreement"
-              link="https://www.linode.com/legal-eatp/"
               hideIcon
             />
             .

--- a/packages/manager/src/features/linodes/LinodesCreate/AttachVLAN.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/AttachVLAN.tsx
@@ -1,6 +1,5 @@
 import { Interface } from '@linode/api-v4/lib/linodes';
 import * as React from 'react';
-import Box from 'src/components/core/Box';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import ExternalLink from 'src/components/ExternalLink';
@@ -68,11 +67,9 @@ const AttachVLAN: React.FC<CombinedProps> = (props) => {
 
   return (
     <div className={classes.root}>
-      <Box display="flex" alignItems="center">
-        <Typography variant="h2" className={classes.title}>
-          Attach a VLAN {helperText ? <HelpIcon text={helperText} /> : null}
-        </Typography>
-      </Box>
+      <Typography variant="h2" className={classes.title}>
+        Attach a VLAN {helperText ? <HelpIcon text={helperText} /> : null}
+      </Typography>
       <Grid container>
         <Grid item xs={12}>
           <Typography variant="body1">

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -774,15 +774,6 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
                 {formik.errors.interfaces ? (
                   <Notice error text={formik.errors.interfaces as string} />
                 ) : null}
-                <Typography>
-                  VLAN is currently in beta and is subject to the terms of the{' '}
-                  <ExternalLink
-                    text="Early Adopter Testing Agreement"
-                    link="https://www.linode.com/legal-eatp/"
-                    hideIcon
-                  />
-                  .
-                </Typography>
                 {values.interfaces.map((thisInterface, idx) => {
                   return (
                     <InterfaceSelect


### PR DESCRIPTION
## Description

Remove the beta notice and legal text from the VLAN section of the Linode create flow and config modal. This will be released on 4/28 when the feature goes into GA.

## How to test

Everything should work as before; the beta chip and info should not be displayed.
