### PR TITLE
M3-4841 consistent storage units render

### DIFF
--- a/packages/manager/src/features/Images/ImagesDrawer.tsx
+++ b/packages/manager/src/features/Images/ImagesDrawer.tsx
@@ -389,7 +389,7 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
               data-qa-disk-select
             />
             <Typography className={classes.helperText} variant="body1">
-              Linode Images are limited to {IMAGE_DEFAULT_LIMIT}MB of data per
+              Linode Images are limited to {IMAGE_DEFAULT_LIMIT} MB of data per
               disk by default. Please ensure that your disk content does not
               exceed this size limit, or open a Support ticket to request a
               higher limit. Additionally, Linode Images cannot be created if you

--- a/packages/manager/src/features/Kubernetes/ClusterList/ClusterRow.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/ClusterRow.tsx
@@ -128,7 +128,7 @@ export const ClusterRow: React.FunctionComponent<CombinedProps> = (props) => {
       </TableCell>
       <Hidden xsDown>
         <TableCell data-qa-cluster-memory>
-          {`${cluster.totalMemory / 1024}GB`}
+          {`${cluster.totalMemory / 1024} GB`}
         </TableCell>
       </Hidden>
       <Hidden xsDown>

--- a/packages/manager/src/features/Kubernetes/kubeUtils.ts
+++ b/packages/manager/src/features/Kubernetes/kubeUtils.ts
@@ -110,7 +110,7 @@ export const getDescriptionForCluster = (cluster: ExtendedCluster) => {
     'CPU core',
     'CPU cores',
     cluster.totalCPU
-  )}, ${cluster.totalMemory / 1024}GB RAM`;
+  )}, ${cluster.totalMemory / 1024} GB RAM`;
 };
 
 export const getNextVersion = (

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -205,7 +205,7 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
             <TableCell className={classes.radioCell}>
               {!isSamePlan && (
                 <FormControlLabel
-                  label={type.heading.replace('GB', ' GB')}
+                  label={type.heading}
                   aria-label={type.heading}
                   className={'label-visually-hidden'}
                   control={

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -205,7 +205,7 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
             <TableCell className={classes.radioCell}>
               {!isSamePlan && (
                 <FormControlLabel
-                  label={type.heading}
+                  label={type.heading.replace('GB', ' GB')}
                   aria-label={type.heading}
                   className={'label-visually-hidden'}
                   control={

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskSpace.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskSpace.tsx
@@ -88,7 +88,7 @@ export class LinodeDiskSpace extends React.PureComponent<CombinedProps> {
         </Grid>
         <Typography className={classes.text}>
           <strong data-qa-disk-used-percentage>{formattedPercentage}%</strong>{' '}
-          of your {totalDiskSpace}MB is allocated towards
+          of your {totalDiskSpace} MB is allocated towards
           <strong> {disks.length}</strong> disk{' '}
           {disks.length === 1 ? 'image' : 'images'}.
         </Typography>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/BackupTableRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/BackupTableRow.tsx
@@ -47,12 +47,12 @@ const BackupTableRow: React.FC<Props> = (props) => {
       <TableCell parentColumn="Disks" data-qa-backup-disks>
         {backup.disks.map((disk, idx) => (
           <div key={idx}>
-            {disk.label} ({disk.filesystem}) - {disk.size}MB
+            {disk.label} ({disk.filesystem}) - {disk.size} MB
           </div>
         ))}
       </TableCell>
       <TableCell parentColumn="Space Required" data-qa-space-required>
-        {backup.disks.reduce((acc, disk) => acc + disk.size, 0)}MB
+        {backup.disks.reduce((acc, disk) => acc + disk.size, 0)} MB
       </TableCell>
       <TableCell>
         <LinodeBackupActionMenu

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
@@ -211,7 +211,9 @@ export const LinodeRow: React.FC<CombinedProps> = (props) => {
 
       <Hidden xsDown>
         <TableCell className={classes.planCell} data-qa-ips>
-          <div className={classes.planCell}>{type?.label ?? 'Unknown'}</div>
+          <div className={classes.planCell}>
+            {(type?.label ?? 'Unknown').replace('GB', ' GB')}
+          </div>
         </TableCell>
         <TableCell className={classes.ipCell} data-qa-ips>
           <div className={classes.ipCellWrapper}>

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
@@ -211,7 +211,7 @@ export const LinodeRow: React.FC<CombinedProps> = (props) => {
 
       <Hidden xsDown>
         <TableCell className={classes.planCell} data-qa-ips>
-          <div className={classes.planCell}>{label}</div>
+          <div className={classes.planCell}>{type?.label}</div>
         </TableCell>
         <TableCell className={classes.ipCell} data-qa-ips>
           <div className={classes.ipCellWrapper}>

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
@@ -211,9 +211,7 @@ export const LinodeRow: React.FC<CombinedProps> = (props) => {
 
       <Hidden xsDown>
         <TableCell className={classes.planCell} data-qa-ips>
-          <div className={classes.planCell}>
-            {(type?.label ?? 'Unknown').replace('GB', ' GB')}
-          </div>
+          <div className={classes.planCell}>{label}</div>
         </TableCell>
         <TableCell className={classes.ipCell} data-qa-ips>
           <div className={classes.ipCellWrapper}>

--- a/packages/manager/src/features/linodes/presentation.test.tsx
+++ b/packages/manager/src/features/linodes/presentation.test.tsx
@@ -4,17 +4,17 @@ describe('Linode presentation helpers', () => {
   describe('type label details', () => {
     it('should return a string with memory, disk, and cpu details', () => {
       const typedLabel = typeLabelDetails(2048, 2048, 1);
-      expect(typedLabel).toBe('1 CPU, 2GB Storage, 2GB RAM');
+      expect(typedLabel).toBe('1 CPU, 2 GB Storage, 2 GB RAM');
     });
 
-    it('should return storage in GB', () => {
+    it('should return storage in  GB', () => {
       const typedLabel = typeLabelDetails(1024, 2048, 1);
-      expect(typedLabel.includes('2GB Storage'));
+      expect(typedLabel.includes('2 GB Storage'));
     });
 
-    it('should return memory in GB', () => {
+    it('should return memory in  GB', () => {
       const typedLabel = typeLabelDetails(1024, 2048, 1);
-      expect(typedLabel.includes('1GB Ram'));
+      expect(typedLabel.includes('1 GB Ram'));
     });
 
     it('should return number of CPUs', () => {
@@ -31,19 +31,19 @@ describe('Linode presentation helpers', () => {
   describe('Display for Kube pool nodes', () => {
     it('should return a string with heading, size, and CPUs', () => {
       expect(displayTypeForKubePoolNode('standard', 4096, 2)).toEqual(
-        'Standard 4GB, 2 CPUs'
+        'Standard 4 GB, 2 CPUs'
       );
     });
 
     it('should pluralize CPUs correctly', () => {
       expect(displayTypeForKubePoolNode('standard', 2048, 1)).toEqual(
-        'Standard 2GB, 1 CPU'
+        'Standard 2 GB, 1 CPU'
       );
     });
 
     it('should format highmem instances', () => {
       expect(displayTypeForKubePoolNode('highmem', 2048, 1)).toEqual(
-        'High Memory 2GB, 1 CPU'
+        'High Memory 2 GB, 1 CPU'
       );
     });
   });

--- a/packages/manager/src/features/linodes/presentation.ts
+++ b/packages/manager/src/features/linodes/presentation.ts
@@ -20,7 +20,7 @@ export const typeLabelDetails = (
 ) => {
   const memG = memory / 1024;
   const diskG = disk / 1024;
-  return `${cpus} CPU, ${diskG}GB Storage, ${memG}GB RAM`;
+  return `${cpus} CPU, ${diskG} GB Storage, ${memG} GB RAM`;
 };
 
 export const displayType = (
@@ -46,7 +46,7 @@ export const displayClass = (category: string) => {
 
 export const displaySize = (memory: number) => {
   const memG = memory / 1024;
-  return `${memG}GB`;
+  return `${memG} GB`;
 };
 
 export const displayTypeForKubePoolNode = (

--- a/packages/manager/src/store/linodeType/linodeType.reducer.ts
+++ b/packages/manager/src/store/linodeType/linodeType.reducer.ts
@@ -94,9 +94,11 @@ export const extendType = (type: LinodeType): ExtendedType => {
     disk,
     price: { monthly, hourly },
   } = type;
+  const formattedLabel = label.replace('GB', ' GB');
   return {
     ...type,
-    heading: label.replace('GB', ' GB'),
+    label: formattedLabel,
+    heading: formattedLabel,
     subHeadings: [
       `$${monthly}/mo ($${hourly}/hr)`,
       typeLabelDetails(memory, disk, vcpus),

--- a/packages/manager/src/store/linodeType/linodeType.reducer.ts
+++ b/packages/manager/src/store/linodeType/linodeType.reducer.ts
@@ -7,6 +7,7 @@ import {
   getLinodeTypeActions,
 } from './linodeType.actions';
 import { typeLabelDetails } from 'src/features/linodes/presentation';
+import { formatStorageUnits } from 'src/utilities/formatStorageUnits';
 
 export interface ExtendedType extends LinodeType {
   heading: string;
@@ -94,7 +95,7 @@ export const extendType = (type: LinodeType): ExtendedType => {
     disk,
     price: { monthly, hourly },
   } = type;
-  const formattedLabel = label.replace('GB', ' GB');
+  const formattedLabel = formatStorageUnits(label);
   return {
     ...type,
     label: formattedLabel,

--- a/packages/manager/src/store/linodeType/linodeType.reducer.ts
+++ b/packages/manager/src/store/linodeType/linodeType.reducer.ts
@@ -96,7 +96,7 @@ export const extendType = (type: LinodeType): ExtendedType => {
   } = type;
   return {
     ...type,
-    heading: label,
+    heading: label.replace('GB', ' GB'),
     subHeadings: [
       `$${monthly}/mo ($${hourly}/hr)`,
       typeLabelDetails(memory, disk, vcpus),

--- a/packages/manager/src/utilities/formatStorageUnits.test.ts
+++ b/packages/manager/src/utilities/formatStorageUnits.test.ts
@@ -1,0 +1,32 @@
+import { formatStorageUnits } from './formatStorageUnits';
+
+describe('formatStorageUnits', () => {
+  it('returns "unknown" when formatting a string that does not contain a storage unit', () => {
+    expect(formatStorageUnits('Linode High Memory')).toBe('unknown');
+    expect(formatStorageUnits('Linode GB')).toBe('unknown');
+    expect(formatStorageUnits('')).toBe('unknown');
+    expect(formatStorageUnits(null)).toBe('unknown');
+  });
+
+  it('returns a string that contains the storage units and measurement seperated by a single space character', () => {
+    expect(formatStorageUnits('Nanode 1GB')).toBe('Nanode 1 GB');
+    expect(formatStorageUnits('Linode 4GB')).toBe('Linode 4 GB');
+    expect(formatStorageUnits('10kB')).toBe('10 kB');
+    expect(formatStorageUnits('10MB')).toBe('10 MB');
+    expect(formatStorageUnits('10GB')).toBe('10 GB');
+    expect(formatStorageUnits('10TB')).toBe('10 TB');
+    expect(formatStorageUnits('10PB')).toBe('10 PB');
+    expect(formatStorageUnits('10EB')).toBe('10 EB');
+    expect(formatStorageUnits('10ZB')).toBe('10 ZB');
+    expect(formatStorageUnits('10YB')).toBe('10 YB');
+
+    expect(formatStorageUnits('10kiB')).toBe('10 kiB');
+    expect(formatStorageUnits('10MiB')).toBe('10 MiB');
+    expect(formatStorageUnits('10GiB')).toBe('10 GiB');
+    expect(formatStorageUnits('10TiB')).toBe('10 TiB');
+    expect(formatStorageUnits('10PiB')).toBe('10 PiB');
+    expect(formatStorageUnits('10EiB')).toBe('10 EiB');
+    expect(formatStorageUnits('10ZiB')).toBe('10 ZiB');
+    expect(formatStorageUnits('10YiB')).toBe('10 YiB');
+  });
+});

--- a/packages/manager/src/utilities/formatStorageUnits.test.ts
+++ b/packages/manager/src/utilities/formatStorageUnits.test.ts
@@ -1,14 +1,13 @@
 import { formatStorageUnits } from './formatStorageUnits';
 
 describe('formatStorageUnits', () => {
-  it('returns "unknown" when formatting a string that does not contain a storage unit', () => {
-    expect(formatStorageUnits('Linode High Memory')).toBe('unknown');
-    expect(formatStorageUnits('Linode GB')).toBe('unknown');
-    expect(formatStorageUnits('')).toBe('unknown');
-    expect(formatStorageUnits(null)).toBe('unknown');
+  it('returns the original string when the string does not contain a storage unit', () => {
+    expect(formatStorageUnits('Linode High Memory')).toBe('Linode High Memory');
+    expect(formatStorageUnits('Linode GB')).toBe('Linode GB');
+    expect(formatStorageUnits('')).toBe('');
   });
 
-  it('returns a string that contains the storage units and measurement seperated by a single space character', () => {
+  it('returns a string that contains the storage units and measurement separated by a single space character', () => {
     expect(formatStorageUnits('Nanode 1GB')).toBe('Nanode 1 GB');
     expect(formatStorageUnits('Linode 4GB')).toBe('Linode 4 GB');
     expect(formatStorageUnits('10kB')).toBe('10 kB');

--- a/packages/manager/src/utilities/formatStorageUnits.ts
+++ b/packages/manager/src/utilities/formatStorageUnits.ts
@@ -1,0 +1,14 @@
+const storageRegex = /([0-9])([kMGTPEZY]?i?[B])/;
+
+function replaceFunc(match: string, p1: string, p2: string) {
+  if (match.length === 0) return 'unknown';
+  return `${p1} ${p2}`;
+}
+
+function formatStorageUnits(unformattedString: string | null) {
+  const cleanedUnformattedString = unformattedString ?? 'unknown';
+  if (!cleanedUnformattedString.match(storageRegex)) return 'unknown';
+  return cleanedUnformattedString.replace(storageRegex, replaceFunc);
+}
+
+export { formatStorageUnits };

--- a/packages/manager/src/utilities/formatStorageUnits.ts
+++ b/packages/manager/src/utilities/formatStorageUnits.ts
@@ -1,13 +1,14 @@
 const storageRegex = /([0-9])([kMGTPEZY]?i?[B])/;
 
 function replaceFunc(match: string, p1: string, p2: string) {
-  if (match.length === 0) return 'unknown';
   return `${p1} ${p2}`;
 }
 
-function formatStorageUnits(unformattedString: string | null) {
-  const cleanedUnformattedString = unformattedString ?? 'unknown';
-  if (!cleanedUnformattedString.match(storageRegex)) return 'unknown';
+function formatStorageUnits(unformattedString: string) {
+  const cleanedUnformattedString = `${unformattedString}`;
+  if (!cleanedUnformattedString.match(storageRegex)) {
+    return unformattedString;
+  }
   return cleanedUnformattedString.replace(storageRegex, replaceFunc);
 }
 

--- a/packages/manager/src/utilities/formatStorageUnits.ts
+++ b/packages/manager/src/utilities/formatStorageUnits.ts
@@ -5,11 +5,10 @@ function replaceFunc(match: string, p1: string, p2: string) {
 }
 
 function formatStorageUnits(unformattedString: string) {
-  const cleanedUnformattedString = `${unformattedString}`;
-  if (!cleanedUnformattedString.match(storageRegex)) {
+  if (!unformattedString.match(storageRegex)) {
     return unformattedString;
   }
-  return cleanedUnformattedString.replace(storageRegex, replaceFunc);
+  return unformattedString.replace(storageRegex, replaceFunc);
 }
 
 export { formatStorageUnits };


### PR DESCRIPTION
## Description

This PR updates formatting for storage units across the cloud manager application. There are a few places where storage sizes are listed that needed to updated in place but for the Linode plans there is an update to the reducer that should be reflected in all places where the name of the Linode plan are visible.

## How to test

Check to see if there are any places in the app where there is not a space before the storage unit

