### PR TITLE
M3-4957: "Last Backup" cell for Bare Metal instances

### DIFF
--- a/packages/manager/src/components/BackupStatus/BackupStatus.tsx
+++ b/packages/manager/src/components/BackupStatus/BackupStatus.tsx
@@ -14,7 +14,8 @@ import HelpIcon from 'src/components/HelpIcon';
 
 type ClassNames =
   | 'icon'
-  | 'noBackupText'
+  | 'backupScheduledOrNever'
+  | 'backupNotApplicable'
   | 'root'
   | 'wrapper'
   | 'helpIcon'
@@ -28,8 +29,11 @@ const styles = (theme: Theme) =>
       fontSize: 18,
       fill: theme.color.grey1,
     },
-    noBackupText: {
+    backupScheduledOrNever: {
       marginRight: theme.spacing(1),
+    },
+    backupNotApplicable: {
+      marginRight: theme.spacing(2.2),
     },
     root: {},
     wrapper: {
@@ -43,6 +47,11 @@ const styles = (theme: Theme) =>
         backgroundColor: 'transparent',
       },
       padding: 0,
+      '& svg': {
+        fontSize: 0,
+        height: 20,
+        width: 20,
+      },
     },
     withHelpIcon: {
       display: 'flex',
@@ -99,7 +108,10 @@ const BackupStatus: React.FC<CombinedProps> = (props) => {
             to={`/linodes/${linodeId}/backup`}
             className={classes.backupLink}
           >
-            <Typography variant="body1" className={classes.noBackupText}>
+            <Typography
+              variant="body1"
+              className={classes.backupScheduledOrNever}
+            >
               Scheduled
             </Typography>
           </Link>
@@ -111,7 +123,7 @@ const BackupStatus: React.FC<CombinedProps> = (props) => {
   if (isBareMetalInstance) {
     return (
       <div className={classes.withHelpIcon}>
-        <Typography variant="body1" className={classes.noBackupText}>
+        <Typography variant="body1" className={classes.backupNotApplicable}>
           N/A
         </Typography>
         <HelpIcon
@@ -130,7 +142,10 @@ const BackupStatus: React.FC<CombinedProps> = (props) => {
           to={`/linodes/${linodeId}/backup`}
           className={classes.backupLink}
         >
-          <Typography variant="body1" className={classes.noBackupText}>
+          <Typography
+            variant="body1"
+            className={classes.backupScheduledOrNever}
+          >
             Never
           </Typography>
           <Backup className={`${classes.icon} backupIcon`} />

--- a/packages/manager/src/components/BackupStatus/BackupStatus.tsx
+++ b/packages/manager/src/components/BackupStatus/BackupStatus.tsx
@@ -10,12 +10,15 @@ import {
 import Tooltip from 'src/components/core/Tooltip';
 import Typography from 'src/components/core/Typography';
 import DateTimeDisplay from 'src/components/DateTimeDisplay';
+import HelpIcon from 'src/components/HelpIcon';
 
 type ClassNames =
   | 'icon'
   | 'noBackupText'
   | 'root'
   | 'wrapper'
+  | 'helpIcon'
+  | 'withHelpIcon'
   | 'backupLink'
   | 'backupText';
 
@@ -32,6 +35,18 @@ const styles = (theme: Theme) =>
     wrapper: {
       display: 'flex',
       alignContent: 'center',
+    },
+    helpIcon: {
+      color: theme.color.grey1,
+      '& :hover': {
+        color: '#4d99f1',
+        backgroundColor: 'transparent',
+      },
+      padding: 0,
+    },
+    withHelpIcon: {
+      display: 'flex',
+      alignItems: 'center',
     },
     backupLink: {
       display: 'flex',
@@ -50,12 +65,22 @@ interface Props {
   mostRecentBackup: string | null;
   linodeId: number;
   backupsEnabled: boolean;
+  isBareMetalInstance?: boolean;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 const BackupStatus: React.FC<CombinedProps> = (props) => {
-  const { classes, mostRecentBackup, linodeId, backupsEnabled } = props;
+  const {
+    classes,
+    mostRecentBackup,
+    linodeId,
+    backupsEnabled,
+    isBareMetalInstance,
+  } = props;
+
+  const backupsUnavailableMessage =
+    'Backups are unavailable for Bare Metal instances.';
 
   if (mostRecentBackup) {
     return (
@@ -79,6 +104,20 @@ const BackupStatus: React.FC<CombinedProps> = (props) => {
             </Typography>
           </Link>
         </Tooltip>
+      </div>
+    );
+  }
+
+  if (isBareMetalInstance) {
+    return (
+      <div className={classes.withHelpIcon}>
+        <Typography variant="body1" className={classes.noBackupText}>
+          N/A
+        </Typography>
+        <HelpIcon
+          text={backupsUnavailableMessage}
+          className={classes.helpIcon}
+        />
       </div>
     );
   }

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
@@ -109,6 +109,8 @@ export const LinodeRow: React.FC<CombinedProps> = (props) => {
     mutationAvailable,
   } = props;
 
+  const isBareMetalInstance = type?.class === 'metal';
+
   const loading = linodeInTransition(status, recentEvent);
   const parsedMaintenanceStartTime = parseMaintenanceStartTime(
     maintenanceStartTime
@@ -229,6 +231,7 @@ export const LinodeRow: React.FC<CombinedProps> = (props) => {
           linodeId={id}
           backupsEnabled={backups.enabled || false}
           mostRecentBackup={mostRecentBackup || ''}
+          isBareMetalInstance={isBareMetalInstance}
         />
       </Hidden>
 

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowBackupCell.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowBackupCell.tsx
@@ -16,6 +16,7 @@ interface Props {
   linodeId: number;
   mostRecentBackup: string | null;
   backupsEnabled: boolean;
+  isBareMetalInstance: boolean;
 }
 
 type CombinedProps = Props;
@@ -23,7 +24,12 @@ type CombinedProps = Props;
 const LinodeRowBackupCell: React.FC<CombinedProps> = (props) => {
   const classes = useStyles();
 
-  const { linodeId, backupsEnabled, mostRecentBackup } = props;
+  const {
+    linodeId,
+    backupsEnabled,
+    mostRecentBackup,
+    isBareMetalInstance,
+  } = props;
 
   return (
     <TableCell className={classes.root}>
@@ -31,6 +37,7 @@ const LinodeRowBackupCell: React.FC<CombinedProps> = (props) => {
         linodeId={linodeId}
         backupsEnabled={backupsEnabled}
         mostRecentBackup={mostRecentBackup}
+        isBareMetalInstance={isBareMetalInstance}
       />
     </TableCell>
   );


### PR DESCRIPTION
## Description
Backups are unavailable for Bare Metal instances. This PR adds "N/A" with a tooltip explaining this to the "Last Backup" cell for Bare Metal instances in the Linodes landing table.
