### PR TITLE
Image fixes

### DIFF
--- a/packages/manager/src/features/Images/ImageUploadSuccessDialog.tsx
+++ b/packages/manager/src/features/Images/ImageUploadSuccessDialog.tsx
@@ -73,7 +73,7 @@ export const ImageUploadSuccessDialog: React.FC<Props> = (props) => {
     );
   };
 
-  const curlExample = `curl -v -X PUT \\\n-H "Content-Type: application/octet-stream" \\\n--data-binary @path/to/image \\\n"${url}"`;
+  const curlExample = `curl -v -X PUT \\\n-H "Content-Type: application/octet-stream" \\\n--upload-file example.img.gz \\\n"${url}" \\\n--progress-bar \\\n--output /dev/null`;
 
   return (
     /** Disabling the normal ESC/click away to close, because once the modal goes away the URL is lost */
@@ -91,11 +91,11 @@ export const ImageUploadSuccessDialog: React.FC<Props> = (props) => {
             <strong>It won&apos;t be shown again.</strong>
           </Typography>
           <Typography>
-            See{' '}
-            <Link to="https://linode.com/docs">
-              Deploy an Image to a Linode
+            See our{' '}
+            <Link to="https://www.linode.com/docs/products/tools/images/guides/upload-an-image/">
+              Upload an Image
             </Link>{' '}
-            for more information on uploading an image to Linode.
+            guide for more information.
           </Typography>
         </div>
 

--- a/packages/manager/src/features/Images/ImageUploadSuccessDialog.tsx
+++ b/packages/manager/src/features/Images/ImageUploadSuccessDialog.tsx
@@ -73,7 +73,7 @@ export const ImageUploadSuccessDialog: React.FC<Props> = (props) => {
     );
   };
 
-  const curlExample = `curl -v -X PUT \\\n-H "Content-Type: application/octet-stream" \\\n--upload-file example.img.gz \\\n"${url}" \\\n--progress-bar \\\n--output /dev/null`;
+  const curlExample = `curl -v -X PUT \\\n-H "Content-Type: application/octet-stream" \\\n--upload-file "example.img.gz" \\\n"${url}" \\\n--progress-bar \\\n--output /dev/null`;
 
   return (
     /** Disabling the normal ESC/click away to close, because once the modal goes away the URL is lost */

--- a/packages/manager/src/features/Images/ImagesLanding.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding.tsx
@@ -264,6 +264,14 @@ export const ImagesLanding: React.FC<CombinedProps> = (props) => {
       });
   };
 
+  const onCreateButtonClick = () => {
+    if (account.data?.capabilities.includes('Machine Images')) {
+      return props.history.push('/images/create');
+    }
+
+    return openForCreate();
+  };
+
   const openForCreate = () => {
     setDrawer({
       open: true,
@@ -437,7 +445,7 @@ export const ImagesLanding: React.FC<CombinedProps> = (props) => {
           isEntity
           buttonProps={[
             {
-              onClick: openForCreate,
+              onClick: onCreateButtonClick,
               children: 'Create Image',
             },
           ]}
@@ -473,14 +481,6 @@ export const ImagesLanding: React.FC<CombinedProps> = (props) => {
   if (!imagesData || imagesData.length === 0) {
     return renderEmpty();
   }
-
-  const onCreateButtonClick = () => {
-    if (account.data?.capabilities.includes('Machine Images')) {
-      return props.history.push('/images/create');
-    }
-
-    return openForCreate();
-  };
 
   return (
     <React.Fragment>


### PR DESCRIPTION
## Description

- Fix: "Create Image" button from Images Placeholder incorrectly opened the drawer instead of the Create page.
- Fix: Replace placeholder docs link and update text
- Change: In the sample curl command: 
  - use `--upload-file` instead of `--data-binary`.
  - use an example filename instead of a path (to match our doc and curl man page)
  -  add progress bar 

## How to test

Have no images, go to /images and click "Create". Create an image for upload and observe the modal.
