### PR TITLE
M3-5041: Make icon more vibrant on hover

### DIFF
--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.styles.ts
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.styles.ts
@@ -60,6 +60,9 @@ const useStyles = makeStyles((theme: Theme) => ({
       '& $linkItem': {
         color: 'white',
       },
+      '& .icon': {
+        opacity: 1,
+      },
       '& svg': {
         color: theme.color.greenCyan,
         fill: theme.color.greenCyan,

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -310,7 +310,7 @@ const themeDefaults: ThemeDefaults = () => {
       black: '#222',
       blue: primaryColors.main,
       offBlack: primaryColors.offBlack,
-      greenCyan: '#6FEC86',
+      greenCyan: '#17cf73',
       boxShadow: '#ddd',
       boxShadowDark: '#aaa',
       focusBorder: '#999',


### PR DESCRIPTION
## Description

Update the green icon color and remove the opacity on hover to make the icon look more vibrant

| Before: | After: |
| :--- | :--- |
| <img width="199" alt="Screen Shot 2021-04-28 at 3 05 22 PM" src="https://user-images.githubusercontent.com/7692354/116458925-2efc0980-a833-11eb-8df5-ab0b5e7dc857.png"> | <img width="198" alt="Screen Shot 2021-04-28 at 3 04 30 PM" src="https://user-images.githubusercontent.com/7692354/116458926-2f94a000-a833-11eb-8e37-5679accb389f.png"> |

## How to test

Hover over the rows in the `PrimaryNav`
