### PR TITLE
M3-5058: Show promo service type in billing summary

### DIFF
--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -56,7 +56,7 @@ export interface ActivePromotion {
   this_month_credit_remaining: string;
   credit_monthly_cap: string;
   image_url: string;
-  service_type: string;
+  service_type: PromotionServiceType;
 }
 
 export type PromotionServiceType =

--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -56,7 +56,23 @@ export interface ActivePromotion {
   this_month_credit_remaining: string;
   credit_monthly_cap: string;
   image_url: string;
+  service_type: string;
 }
+
+export type PromotionServiceType =
+  | 'all'
+  | 'backup'
+  | 'blockstorage'
+  | 'db_mysql'
+  | 'ip_v4'
+  | 'linode'
+  | 'linode_disk'
+  | 'linode_memory'
+  | 'longview'
+  | 'managed'
+  | 'nodebalancer'
+  | 'objectstorage'
+  | 'transfer_tx';
 
 interface CreditCard {
   expiry: string | null;

--- a/packages/manager/src/__data__/account.ts
+++ b/packages/manager/src/__data__/account.ts
@@ -13,6 +13,7 @@ export const activePromotions: ActivePromotion[] = [
     summary: '$50 off each month for 5 months',
     credit_monthly_cap: '50',
     image_url: 'https://my-image.com/image',
+    service_type: 'linode',
   },
 ];
 

--- a/packages/manager/src/factories/account.ts
+++ b/packages/manager/src/factories/account.ts
@@ -13,6 +13,7 @@ export const promoFactory = Factory.Sync.makeFactory<ActivePromotion>({
   credit_monthly_cap: '20.00',
   credit_remaining: '20.00',
   this_month_credit_remaining: '20.00',
+  service_type: 'all',
 });
 
 export const accountFactory = Factory.Sync.makeFactory<Account>({
@@ -51,6 +52,7 @@ export const accountFactory = Factory.Sync.makeFactory<Account>({
       credit_monthly_cap: '20.00',
       credit_remaining: '20.00',
       this_month_credit_remaining: '20.00',
+      service_type: 'all',
     },
     {
       image_url: '',
@@ -61,6 +63,7 @@ export const accountFactory = Factory.Sync.makeFactory<Account>({
       credit_monthly_cap: '20.00',
       credit_remaining: '20.00',
       this_month_credit_remaining: '20.00',
+      service_type: 'all',
     },
   ],
   euuid: '278EC57D-7424-4B3A-B35C3CE395787567',

--- a/packages/manager/src/factories/account.ts
+++ b/packages/manager/src/factories/account.ts
@@ -54,17 +54,6 @@ export const accountFactory = Factory.Sync.makeFactory<Account>({
       this_month_credit_remaining: '20.00',
       service_type: 'all',
     },
-    {
-      image_url: '',
-      summary: 'BAD_PROMO',
-      description:
-        'This promotion is invalid since it has an expiration of null',
-      expire_dt: null,
-      credit_monthly_cap: '20.00',
-      credit_remaining: '20.00',
-      this_month_credit_remaining: '20.00',
-      service_type: 'all',
-    },
   ],
   euuid: '278EC57D-7424-4B3A-B35C3CE395787567',
 });

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.test.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.test.tsx
@@ -67,6 +67,22 @@ describe('BillingSummary', () => {
     getByTextWithMarkup('Monthly cap: $20.00');
   });
 
+  it('displays promo service type unless the service type is all', () => {
+    const promotions = [
+      promoFactory.build(),
+      promoFactory.build({ summary: 'MY_PROMO_CODE', service_type: 'linode' }),
+    ];
+    renderWithTheme(
+      <BillingSummary
+        balance={0}
+        balanceUninvoiced={5}
+        promotions={promotions}
+      />
+    );
+    expect(screen.queryByText('Applies to: All')).not.toBeInTheDocument();
+    expect(screen.getByText('Applies to: Linodes'));
+  });
+
   it('displays accrued charges', () => {
     renderWithTheme(<BillingSummary balance={0} balanceUninvoiced={5} />);
     within(screen.getByTestId('accrued-charges-value')).getByText('$5.00');

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
@@ -69,11 +69,11 @@ const serviceTypeMap: Partial<Record<PromotionServiceType, string>> = {
   linode: 'Linodes',
   linode_disk: 'Storage',
   linode_memory: 'Memory',
-  longview: 'Longviews',
+  longview: 'Longview',
   managed: 'Managed',
   nodebalancer: 'NodeBalancers',
   objectstorage: 'Object Storage',
-  transfer_tx: 'Service Transfers',
+  transfer_tx: 'Transfer Overages',
 };
 
 // =============================================================================
@@ -285,7 +285,7 @@ export const PromoDisplay: React.FC<PromoDisplayProps> = React.memo((props) => {
           Expires: <DateTimeDisplay value={expire_dt} displayTime={false} />
         </Typography>
       ) : null}
-      {service_type !== 'all' ? (
+      {service_type !== 'all' && serviceTypeMap[service_type] ? (
         <Typography>Applies to: {serviceTypeMap[service_type]}</Typography>
       ) : null}
       {parsedCreditMonthlyCap > 0 ? (

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
@@ -1,4 +1,7 @@
-import { ActivePromotion } from '@linode/api-v4/lib/account/types';
+import {
+  ActivePromotion,
+  PromotionServiceType,
+} from '@linode/api-v4/lib/account/types';
 import { GridSize } from '@material-ui/core/Grid';
 import { Breakpoint } from '@material-ui/core/styles/createBreakpoints';
 import * as classnames from 'classnames';
@@ -56,6 +59,22 @@ const useStyles = makeStyles((theme: Theme) => ({
     color: theme.palette.text.primary,
   },
 }));
+
+const serviceTypeMap: Partial<Record<PromotionServiceType, string>> = {
+  all: 'All',
+  backup: 'Backups',
+  blockstorage: 'Volumes',
+  db_mysql: 'DBaaS',
+  ip_v4: 'IPv4',
+  linode: 'Linodes',
+  linode_disk: 'Storage',
+  linode_memory: 'Memory',
+  longview: 'Longviews',
+  managed: 'Managed',
+  nodebalancer: 'NodeBalancers',
+  objectstorage: 'Object Storage',
+  transfer_tx: 'Service Transfers',
+};
 
 // =============================================================================
 // <BillingSummary />
@@ -227,6 +246,7 @@ export const PromoDisplay: React.FC<PromoDisplayProps> = React.memo((props) => {
     credit_remaining,
     expire_dt,
     credit_monthly_cap,
+    service_type,
   } = props;
 
   const parsedCreditRemaining = Number.parseFloat(credit_remaining);
@@ -260,11 +280,13 @@ export const PromoDisplay: React.FC<PromoDisplayProps> = React.memo((props) => {
           </Typography>
         ) : null}
       </Box>
-      {/* @todo: Add support for service_type ("Applies to: Linodes"). */}
       {expire_dt ? (
         <Typography>
           Expires: <DateTimeDisplay value={expire_dt} displayTime={false} />
         </Typography>
+      ) : null}
+      {service_type !== 'all' ? (
+        <Typography>Applies to: {serviceTypeMap[service_type]}</Typography>
       ) : null}
       {parsedCreditMonthlyCap > 0 ? (
         <Typography>


### PR DESCRIPTION
## Description
Displays `Applies to: <service_type>` in the promo billing summary if the service type is not "all".

## How to test

1. You will need to update your `.env` file to use dev services
2. Login to a dev test account that has a specific service type promo applied to it. The 4th dev test account currently has the service type `linodes` applied.
3. Click on `Accounts`
4. You should see a promotions box, under the `expires` line, there should be another line that says `Applies to: <service_type`
