### PR TITLE
M3-5013: Change OBJ drag and drop instructional text color

### DIFF
--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/ObjectUploader.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/ObjectUploader.tsx
@@ -98,7 +98,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
   },
   copy: {
-    color: theme.palette.primary.main,
+    color: theme.palette.text.primary,
     margin: '0 auto',
   },
   uploadButton: {


### PR DESCRIPTION
## Description
Change the color of the instructional text in the Object Storage drag and drop area to `theme.palette.text.primary` (gray in light mode, white in dark mode).
