### PR TITLE
Apply adjusted brightness for PrimaryNav icon to active state

### DIFF
--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.styles.ts
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.styles.ts
@@ -98,10 +98,12 @@ const useStyles = makeStyles((theme: Theme) => ({
   active: {
     backgroundImage: 'linear-gradient(98deg, #38584B 1%, #3A5049 166%)',
     textDecoration: 'none',
+    '& .icon': {
+      opacity: 1,
+    },
     '& svg': {
       color: theme.color.greenCyan,
     },
-    '&:hover': {},
   },
   divider: {
     backgroundColor: 'rgba(0, 0, 0, 0.12)',


### PR DESCRIPTION
## Description

Forgot to apply the changes from [https://github.com/linode/manager/pull/7619](https://github.com/linode/manager/pull/7619) to the active state
