### PR TITLE
M3-5070: SideMenu scrollbar overlap

### DIFF
--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.styles.ts
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.styles.ts
@@ -30,7 +30,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
   },
   logoCollapsed: {
-    background: theme.cmrBGColors.bgPrimaryNav,
+    background: theme.bg.primaryNavPaper,
     height: 48,
     width: 100,
     position: 'absolute',

--- a/packages/manager/src/components/SideMenu.tsx
+++ b/packages/manager/src/components/SideMenu.tsx
@@ -1,55 +1,43 @@
 import * as React from 'react';
-import { compose } from 'recompose';
 import Drawer from 'src/components/core/Drawer';
 import Hidden from 'src/components/core/Hidden';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles,
-} from 'src/components/core/styles';
-import withFeatureFlagConsumer, {
-  FeatureFlagConsumerProps,
-} from 'src/containers/withFeatureFlagConsumer.container';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import PrimaryNav from './PrimaryNav/PrimaryNav';
 
-type ClassNames =
-  | 'menuPaper'
-  | 'menuDocked'
-  | 'desktopMenu'
-  | 'collapsedDesktopMenu';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    menuPaper: {
-      height: '100%',
+const useStyles = makeStyles((theme: Theme) => ({
+  menuPaper: {
+    backgroundColor: theme.bg.primaryNavPaper,
+    borderRight: 'none',
+    boxShadow: 'none',
+    height: '100%',
+    width: 190,
+    left: 'inherit',
+    overflowX: 'hidden',
+    transition: 'width linear .1s',
+  },
+  menuDocked: {
+    height: '100%',
+  },
+  desktopMenu: {
+    transform: 'none',
+  },
+  collapsedDesktopMenu: {
+    width: 52,
+    '&:hover': {
+      overflowY: 'scroll',
       width: 190,
-      backgroundColor: theme.bg.primaryNavPaper,
-      borderRight: 'none',
-      left: 'inherit',
-      boxShadow: 'none',
-      transition: 'width linear .1s',
-      overflowX: 'hidden',
-    },
-    menuDocked: {
-      height: '100%',
-    },
-    desktopMenu: {
-      transform: 'none',
-    },
-    collapsedDesktopMenu: {
-      width: 52,
-      '&:hover': {
-        width: 190,
-        '& .primaryNavLink': {
-          opacity: 1,
-        },
-        '& .logoCollapsed': {
-          opacity: 0,
-        },
+      '& .primaryNavLink': {
+        opacity: 1,
+      },
+      '& .logoCollapsed': {
+        opacity: 0,
       },
     },
-  });
+    [theme.breakpoints.up('sm')]: {
+      overflowY: 'hidden',
+    },
+  },
+}));
 
 interface Props {
   open: boolean;
@@ -57,52 +45,46 @@ interface Props {
   closeMenu: () => void;
 }
 
-type CombinedProps = Props & WithStyles<ClassNames> & FeatureFlagConsumerProps;
+type CombinedProps = Props;
 
-class SideMenu extends React.Component<CombinedProps> {
-  render() {
-    const { classes, open, desktopOpen, closeMenu } = this.props;
+export const SideMenu: React.FC<CombinedProps> = (props) => {
+  const classes = useStyles();
+  const { open, desktopOpen, closeMenu } = props;
 
-    return (
-      <React.Fragment>
-        <Hidden mdUp>
-          <Drawer
-            variant="temporary"
-            open={open}
-            classes={{
-              paper: classes.menuPaper,
-            }}
-            onClose={closeMenu}
-            ModalProps={{
-              keepMounted: true, // Better open performance on mobile.
-            }}
-          >
-            <PrimaryNav closeMenu={closeMenu} isCollapsed={false} />
-          </Drawer>
-        </Hidden>
-        <Hidden smDown implementation="css">
-          <Drawer
-            variant="permanent"
-            open
-            classes={{
-              paper: `${classes.menuPaper} ${
-                desktopOpen && classes.collapsedDesktopMenu
-              }`,
-              docked: classes.menuDocked,
-            }}
-            className={classes.desktopMenu}
-          >
-            <PrimaryNav closeMenu={closeMenu} isCollapsed={desktopOpen} />
-          </Drawer>
-        </Hidden>
-      </React.Fragment>
-    );
-  }
-}
+  return (
+    <>
+      <Hidden mdUp>
+        <Drawer
+          classes={{
+            paper: classes.menuPaper,
+          }}
+          ModalProps={{
+            keepMounted: true, // Better open performance on mobile.
+          }}
+          onClose={closeMenu}
+          open={open}
+          variant="temporary"
+        >
+          <PrimaryNav closeMenu={closeMenu} isCollapsed={false} />
+        </Drawer>
+      </Hidden>
+      <Hidden smDown implementation="css">
+        <Drawer
+          classes={{
+            paper: `${classes.menuPaper} ${
+              desktopOpen && classes.collapsedDesktopMenu
+            }`,
+            docked: classes.menuDocked,
+          }}
+          className={classes.desktopMenu}
+          open
+          variant="permanent"
+        >
+          <PrimaryNav closeMenu={closeMenu} isCollapsed={desktopOpen} />
+        </Drawer>
+      </Hidden>
+    </>
+  );
+};
 
-const enhanced = compose<CombinedProps, Props>(
-  withStyles(styles),
-  withFeatureFlagConsumer
-);
-
-export default enhanced(SideMenu);
+export default SideMenu;

--- a/packages/manager/src/components/SideMenu.tsx
+++ b/packages/manager/src/components/SideMenu.tsx
@@ -24,7 +24,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   collapsedDesktopMenu: {
     width: 52,
     '&:hover': {
-      overflowY: 'scroll',
+      overflowY: 'auto',
       width: 190,
       '& .primaryNavLink': {
         opacity: 1,


### PR DESCRIPTION
## Description

Refactors the SideMenu component and prevents the scrollbar from overlapping it when the height of the viewport is decreased. 

Since the menu is only in the collapsed view when the width is > 600px, I set the vertical overflow to hidden in order to hide the scrollbar but the scroll is restored on hover. 

## How to test

Set your MacOS preferences to always show the scrollbar and decrease the height of the viewport. The scrollbar should no longer be visible on the collapsed view of the SideMenu until you hover which also expands the menu.
