### PR TITLE
M3-4862: Styling for EventsLanding table column headers

### DIFF
--- a/packages/manager/src/features/Events/EventsLanding.tsx
+++ b/packages/manager/src/features/Events/EventsLanding.tsx
@@ -41,6 +41,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     minWidth: 200,
     paddingLeft: 10,
   },
+  columnHeader: {
+    fontWeight: 700,
+  },
 }));
 
 interface Props {
@@ -269,12 +272,22 @@ export const EventsLanding: React.FC<CombinedProps> = (props) => {
               {!entityId && <TableCell style={{ padding: 0, width: '1%' }} />}
               <TableCell
                 data-qa-events-subject-header
-                className={classes.labelCell}
+                className={`${classes.labelCell} ${classes.columnHeader}`}
               >
                 Event
               </TableCell>
-              <TableCell data-qa-events-duration-header>Duration</TableCell>
-              <TableCell data-qa-events-time-header>When</TableCell>
+              <TableCell
+                className={classes.columnHeader}
+                data-qa-events-duration-header
+              >
+                Duration
+              </TableCell>
+              <TableCell
+                className={classes.columnHeader}
+                data-qa-events-time-header
+              >
+                When
+              </TableCell>
             </TableRow>
           </TableHead>
           <TableBody>

--- a/packages/manager/src/features/Events/EventsLanding.tsx
+++ b/packages/manager/src/features/Events/EventsLanding.tsx
@@ -43,7 +43,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   columnHeader: {
     fontFamily: theme.font.bold,
-    fontSize: 14,
+    fontSize: '0.875rem',
     color: theme.cmrTextColors.tableHeader,
   },
 }));

--- a/packages/manager/src/features/Events/EventsLanding.tsx
+++ b/packages/manager/src/features/Events/EventsLanding.tsx
@@ -42,7 +42,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     paddingLeft: 10,
   },
   columnHeader: {
-    fontWeight: 700,
+    fontFamily: theme.font.bold,
+    fontSize: 14,
+    color: theme.cmrTextColors.tableHeader,
   },
 }));
 


### PR DESCRIPTION
## Description
Make the column headers of the Events landing table (found under "Activity Feed" and the /events page) bold, size 14, and color `#888F91`
