### PR TITLE
M3-5127: Feature flag for Google Pay

### DIFF
--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -12,7 +12,7 @@ const options: { label: string; flag: keyof Flags }[] = [
   { label: 'Databases', flag: 'databases' },
   { label: 'Bare Metal', flag: 'bareMetal' },
   { label: 'Machine Images', flag: 'machineImages' },
-  { label: 'Google Pay', flag: 'googlePay' },
+  { label: 'Additional Payment Methods', flag: 'additionalPaymentMethods' },
 ];
 
 const FeatureFlagTool: React.FC<{}> = () => {

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -12,6 +12,7 @@ const options: { label: string; flag: keyof Flags }[] = [
   { label: 'Databases', flag: 'databases' },
   { label: 'Bare Metal', flag: 'bareMetal' },
   { label: 'Machine Images', flag: 'machineImages' },
+  { label: 'Google Pay', flag: 'googlePay' },
 ];
 
 const FeatureFlagTool: React.FC<{}> = () => {

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -34,6 +34,7 @@ export interface Flags {
   bareMetal: boolean;
   tpaProviders: Provider[];
   machineImages: boolean;
+  googlePay: boolean;
 }
 
 type PromotionalOfferFeature =

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -34,7 +34,7 @@ export interface Flags {
   bareMetal: boolean;
   tpaProviders: Provider[];
   machineImages: boolean;
-  googlePay: boolean;
+  additionalPaymentMethods: AdditionalPaymentMethod[];
 }
 
 type PromotionalOfferFeature =
@@ -84,3 +84,5 @@ export interface Provider {
   icon: any;
   href: string;
 }
+
+export type AdditionalPaymentMethod = 'google_pay';

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.tsx
@@ -8,6 +8,7 @@ import Grid from 'src/components/Grid';
 import styled from 'src/containers/SummaryPanels.styles';
 import CreditCard from './CreditCard';
 import UpdateCreditCardDrawer from './UpdateCreditCardDrawer';
+import useFlags from 'src/hooks/useFlags';
 
 const useStyles = makeStyles((theme: Theme) => ({
   ...styled(theme),
@@ -62,6 +63,9 @@ const PaymentInformation: React.FC<CombinedProps> = (props) => {
   const handleOpenDrawer = () => {
     setDrawerOpen(true);
   };
+
+  const flags = useFlags();
+  console.log(flags.additionalPaymentMethods);
 
   return (
     <Grid className={classes.root} item xs={12} md={6}>

--- a/packages/manager/src/features/Billing/billingUtils.ts
+++ b/packages/manager/src/features/Billing/billingUtils.ts
@@ -24,3 +24,5 @@ export const renderUnitPrice = (v: null | string) => {
   const parsedValue = parseFloat(`${v}`);
   return Number.isNaN(parsedValue) ? null : `$${parsedValue}`;
 };
+
+export type AcceptedPaymentMethods = 'credit_card' | 'google_pay' | 'paypal';

--- a/packages/manager/src/features/Billing/billingUtils.ts
+++ b/packages/manager/src/features/Billing/billingUtils.ts
@@ -24,5 +24,3 @@ export const renderUnitPrice = (v: null | string) => {
   const parsedValue = parseFloat(`${v}`);
   return Number.isNaN(parsedValue) ? null : `$${parsedValue}`;
 };
-
-export type AcceptedPaymentMethods = 'credit_card' | 'google_pay' | 'paypal';


### PR DESCRIPTION
## Description
This PR:

1. Picks up the "Additional Payment Methods" flag from LD,
2. Adds an option in our Dev Tool for easily toggling the flag on and off locally,
3. Adds some temporary & basic code in PaymentInformation.tsx to allow for easy confirmation of whether the flag is on or off (will be removed before merging),
4. Adds a type `AdditionalPaymentMethod` in featureFlags.ts
