### PR TITLE
Remove beta notices for Firewalls 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2021-05-12] - v1.40.1
+
+### Changed
+- Remove Beta notifications and text for Cloud Firewalls as part of GA release
+
 ## [2021-05-05] - v1.40.0
 
 ### Added:

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.40.0",
+  "version": "1.40.1",
   "private": true,
   "engines": {
     "node": ">= 14.15.4"

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -151,7 +151,6 @@ export const PrimaryNav: React.FC<Props> = (props) => {
           display: 'Firewalls',
           href: '/firewalls',
           icon: <Firewall />,
-          isBeta: true,
         },
         {
           display: 'StackScripts',

--- a/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.tsx
@@ -55,6 +55,9 @@ const AddFirewallDrawer: React.FC<CombinedProps> = (props) => {
     )
     .map((thisRegion) => thisRegion.id);
 
+  const allRegionsHaveFirewalls =
+    regionsWithFirewalls.length === regions.length;
+
   const submitForm = (
     values: CreateFirewallPayload,
     { setSubmitting, setErrors, setStatus }: FormikProps
@@ -96,6 +99,16 @@ const AddFirewallDrawer: React.FC<CombinedProps> = (props) => {
         handleGeneralErrors(mapErrorToStatus, err, 'Error creating Firewall.');
       });
   };
+
+  let firewallHelperText = `Assign one or more Linodes to this firewall. You can add
+  Linodes later if you want to customize your rules first.`;
+
+  if (!allRegionsHaveFirewalls) {
+    firewallHelperText += ` Only Linodes in regions that support Firewalls (${arrayToList(
+      regionsWithFirewalls.map((thisId) => dcDisplayNames[thisId]),
+      ';'
+    )}) will be displayed as options.`;
+  }
 
   return (
     <Drawer {...restOfDrawerProps} onClose={onClose}>
@@ -155,11 +168,7 @@ const AddFirewallDrawer: React.FC<CombinedProps> = (props) => {
                 showAllOption
                 disabled={_isRestrictedUser}
                 allowedRegions={regionsWithFirewalls}
-                helperText={`Assign one or more Linodes to this firewall. You can add
-                 Linodes later if you want to customize your rules first. Only Linodes in
-                 regions that support Firewalls (${arrayToList(
-                   regionsWithFirewalls.map((thisId) => dcDisplayNames[thisId])
-                 )}) will be displayed as options.`}
+                helperText={firewallHelperText}
                 errorText={errors['devices.linodes']}
                 handleChange={(selected: number[]) =>
                   setFieldValue('devices.linodes', selected)

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallLanding.tsx
@@ -8,7 +8,6 @@ import { compose } from 'recompose';
 import CircleProgress from 'src/components/CircleProgress';
 import EntityTable from 'src/components/EntityTable/EntityTable_CMR';
 import LandingHeader from 'src/components/LandingHeader';
-import useFlags from 'src/hooks/useFlags';
 import {
   useCreateFirewall,
   useDeleteFirewall,
@@ -17,7 +16,6 @@ import {
 } from 'src/queries/firewalls';
 import AddFirewallDrawer from './AddFirewallDrawer';
 import { ActionHandlers as FirewallHandlers } from './FirewallActionMenu';
-import FirewallBanner from './FirewallBanner';
 import FirewallDialog, { Mode } from './FirewallDialog';
 import FirewallEmptyState from './FirewallEmptyState';
 import FirewallRow from './FirewallRow';
@@ -26,7 +24,6 @@ type CombinedProps = RouteComponentProps<{}>;
 
 const FirewallLanding: React.FC<CombinedProps> = () => {
   const { data, isLoading, error, dataUpdatedAt } = useFirewallQuery();
-  const { firewallBetaNotification } = useFlags();
 
   // @TODO: Refactor so these are combined?
   const { mutateAsync: updateFirewall } = useMutateFirewall();
@@ -175,7 +172,6 @@ const FirewallLanding: React.FC<CombinedProps> = () => {
 
   return (
     <React.Fragment>
-      {firewallBetaNotification ? <FirewallBanner /> : null}
       <LandingHeader
         title="Firewalls"
         entity="Firewall"


### PR DESCRIPTION
## Description

- Remove all Beta notices and chips for Firewalls
- Hide regions list when all regions are supported

## How to test

Visit all Firewalls pages and make sure no Beta stuff is visible. You can mock or otherwise adjust your data so that all regions include "Cloud Firewall" in their `capabilities` array; when this is true, the list of available regions shouldn't be displayed.