### PR TITLE
Fix: IP sharing for large accounts

### DIFF
--- a/packages/manager/src/components/EnhancedSelect/Select.styles.ts
+++ b/packages/manager/src/components/EnhancedSelect/Select.styles.ts
@@ -402,7 +402,7 @@ export const reactSelectStyles = (theme: Theme) => ({
     ...base,
     padding: theme.spacing(1) / 2,
     backgroundColor: theme.bg.white,
-    height: '101%',
+    minHeight: '101%',
     overflow: 'auto',
     maxHeight: 285,
     '&::-webkit-scrollbar': {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/IPSharing.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/IPSharing.tsx
@@ -8,7 +8,7 @@ import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import CircleProgress from 'src/components/CircleProgress';
 import Divider from 'src/components/core/Divider';
-import { Theme, makeStyles } from 'src/components/core/styles';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Dialog from 'src/components/Dialog';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
@@ -16,7 +16,8 @@ import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
 import RenderGuard, { RenderGuardProps } from 'src/components/RenderGuard';
 import TextField from 'src/components/TextField';
-import { useLinodesQuery } from 'src/queries/linodes';
+import { API_MAX_PAGE_SIZE } from 'src/constants';
+import { useAllLinodesQuery } from 'src/queries/linodes';
 import { getAPIErrorOrDefault, getErrorMap } from 'src/utilities/errorUtils';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -107,9 +108,11 @@ const IPSharingPanel: React.FC<CombinedProps> = (props) => {
     linodeSharedIPs,
   } = props;
 
-  const { data, isLoading } = useLinodesQuery(
-    {},
-    { region: linodeRegion },
+  const { data, isLoading } = useAllLinodesQuery(
+    { page_size: API_MAX_PAGE_SIZE },
+    {
+      region: linodeRegion,
+    },
     open // Only run the query if the modal is open
   );
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/IPSharing.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/IPSharing.tsx
@@ -16,6 +16,7 @@ import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
 import RenderGuard, { RenderGuardProps } from 'src/components/RenderGuard';
 import TextField from 'src/components/TextField';
+import { API_MAX_PAGE_SIZE } from 'src/constants';
 import { useAllLinodesQuery } from 'src/queries/linodes';
 import { getAPIErrorOrDefault, getErrorMap } from 'src/utilities/errorUtils';
 
@@ -108,7 +109,7 @@ const IPSharingPanel: React.FC<CombinedProps> = (props) => {
   } = props;
 
   const { data, isLoading } = useAllLinodesQuery(
-    {},
+    { page_size: API_MAX_PAGE_SIZE },
     {
       region: linodeRegion,
     },

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/IPSharing.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/IPSharing.tsx
@@ -16,7 +16,6 @@ import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
 import RenderGuard, { RenderGuardProps } from 'src/components/RenderGuard';
 import TextField from 'src/components/TextField';
-import { API_MAX_PAGE_SIZE } from 'src/constants';
 import { useAllLinodesQuery } from 'src/queries/linodes';
 import { getAPIErrorOrDefault, getErrorMap } from 'src/utilities/errorUtils';
 
@@ -109,7 +108,7 @@ const IPSharingPanel: React.FC<CombinedProps> = (props) => {
   } = props;
 
   const { data, isLoading } = useAllLinodesQuery(
-    { page_size: API_MAX_PAGE_SIZE },
+    {},
     {
       region: linodeRegion,
     },

--- a/packages/manager/src/queries/linodes.ts
+++ b/packages/manager/src/queries/linodes.ts
@@ -1,6 +1,7 @@
 import { Linode, getLinodes } from '@linode/api-v4/lib/linodes';
 import { APIError } from '@linode/api-v4/lib/types';
 import { useQuery } from 'react-query';
+import { getAll } from 'src/utilities/getAll';
 import { listToItemsByID, queryPresets } from './base';
 
 const getLinodesRequest = (passedParams: any = {}, passedFilter: any = {}) =>
@@ -24,6 +25,29 @@ export const useLinodesQuery = (
   return useQuery<LinodeData, APIError[]>(
     [queryKey, params, filter],
     () => getLinodesRequest(params, filter),
+    { ...queryPresets.longLived, enabled }
+  );
+};
+
+/** Use with care; originally added to request all Linodes in a given region for IP sharing and transfer */
+export const queryKeyAll = 'linodes-all';
+
+const getAllLinodesRequest = (passedParams: any = {}, passedFilter: any = {}) =>
+  getAll<Linode>(() => getLinodes(passedParams, passedFilter))().then(
+    (data) => ({
+      linodes: listToItemsByID(data.data),
+      results: data.results,
+    })
+  );
+
+export const useAllLinodesQuery = (
+  params: any = {},
+  filter: any = {},
+  enabled: boolean = true
+) => {
+  return useQuery<LinodeData, APIError[]>(
+    [queryKeyAll, params, filter],
+    () => getAllLinodesRequest(params, filter),
     { ...queryPresets.longLived, enabled }
   );
 };


### PR DESCRIPTION
## Description

Fixes issues sharing IPs on a huge account, screen shots shared privately to avoid exposing customer details.

- Set the page_size to the API max in the linodeQuery used in IPSharing.tsx
(a single request of page_size: 100 isn't enough to return every option
in a datacenter for large customers, which resulted in strange behavior.

- Added a useAllLinodesQuery so that we can request all Linodes in e.g. a
single region. This is so that if a user with more than 500 Linodes in a single
region tries to use IP sharing, all options will be available. (There are a handful
of customers that meet these criteria). The search solution that we use for IP transfer
doesn't work here without a lot of overhead/mess, because the list of Linodes is
used for multiple purposes and filtering it on search text throws off a lot of the other
logic.

- Adjusted the styles used when overflowPortal is set on a Select (this is
done when the Select is inside a modal to prevent the overflow from being
hidden). For some reason I haven't worked out yet, large modals resulted
in a menuList component that was much too small.


Notes:

- I'm not thrilled to be bringing getAll() back into play, but it seemed less messy than the alternative. For >99% of users, it'll be a single API request when the modal opens, as it is currently in production.
- I'm opening a separate ticket to deal with the overflowPortal issues, which include some other style stuff and the fact that menuPlacement is broken for these, even when set explicitly.

## How to test

It's pretty hard to mock this particular case. Reach out for customer login info for the account that reported this.
