### PR TITLE
E2E Update: resize-linode and lke tests

### DIFF
--- a/packages/manager/cypress/integration/linodes/resize-linode.spec.ts
+++ b/packages/manager/cypress/integration/linodes/resize-linode.spec.ts
@@ -8,7 +8,7 @@ describe('resize linode', () => {
         'linodeResize'
       );
       cy.visitWithLogin(`/linodes/${linode.id}?resize=true`);
-      containsVisible('Linode 2GB');
+      containsVisible('Linode 2 GB');
       getClick('[id="g6-standard-4"]');
       cy.get('[data-testid="textfield-input"]').type(linode.label);
       cy.get('[data-qa-resize="true"]').click();

--- a/packages/manager/cypress/integration/lke/smoke-lke-create.spec.ts
+++ b/packages/manager/cypress/integration/lke/smoke-lke-create.spec.ts
@@ -49,13 +49,13 @@ describe('LKE Create Cluster', () => {
     cy.get('[id="kubernetes-version"]').type('{enter}');
 
     const kNb2Gb = 2;
-    addNodes('Linode 2GB', kNb2Gb);
+    addNodes('Linode 2 GB', kNb2Gb);
 
     // wait for change to reflect on Checkout bar
 
-    fbtVisible('Linode 2GB Plan');
+    fbtVisible('Linode 2 GB Plan');
     cy.get('[data-testid="kube-checkout-bar"]').within((_bar) => {
-      fbtVisible('Linode 2GB Plan');
+      fbtVisible('Linode 2 GB Plan');
       getVisible('[data-testid="remove-pool-button"]');
       cy.get('[data-qa-notice="true"]').within((_notice) => {
         fbtVisible(


### PR DESCRIPTION
## Description
This change was needed because of some recent ui changes to these pages

**What does this PR do?**
just a small stackscripts e2e test update

## How to test
- `yarn up` 
-  For First Test: `yarn cy:e2e -s ./cypress/integration/linodes/resize-linode.spec.ts`
- For Second Test: `yarn cy:e2e -s ./cypress/integration/lke/smoke-lke-create.spec.ts`
- Result should be "✔  All specs passed!"

## Make sure your .env contains:
```
REACT_APP_LOGIN_ROOT
REACT_APP_API_ROOT
REACT_APP_APP_ROOT
REACT_APP_LAUNCH_DARKLY_ID
REACT_APP_CLIENT_ID
MANAGER_OAUTH
```
