### PR TITLE
Add method and schema for adding promo codes to an existing account

### DIFF
--- a/packages/api-v4/src/account/index.ts
+++ b/packages/api-v4/src/account/index.ts
@@ -10,4 +10,6 @@ export * from './users';
 
 export * from './oauth';
 
+export * from './promos';
+
 export * from './types';

--- a/packages/api-v4/src/account/promos.ts
+++ b/packages/api-v4/src/account/promos.ts
@@ -1,0 +1,23 @@
+import { PromoCodeSchema } from '@linode/validation/lib/account.schema';
+import { API_ROOT } from '../constants';
+import Request, { setData, setMethod, setURL } from '../request';
+import { ActivePromotion } from './types';
+
+/**
+ * addPromotion
+ *
+ * Add an expiring credit (promotion) to an existing account.
+ * This is only possible if:
+ * - The user is unrestricted
+ * - The account is fewer than 90 days old
+ * - No promotions are currently active on the account
+ * - The code is a valid expiring credit (it has not expired and has a
+ *   credit_months field, after which it will expire)
+ *
+ */
+export const addPromotion = (code: string) =>
+  Request<ActivePromotion>(
+    setURL(`${API_ROOT}/account/promo-codes`),
+    setMethod('POST'),
+    setData({ promo_code: code }, PromoCodeSchema)
+  );

--- a/packages/api-v4/src/account/promos.ts
+++ b/packages/api-v4/src/account/promos.ts
@@ -11,9 +11,7 @@ import { ActivePromotion } from './types';
  * - The user is unrestricted
  * - The account is fewer than 90 days old
  * - No promotions are currently active on the account
- * - The code is a valid expiring credit (it has not expired and has a
- *   credit_months field, after which it will expire)
- *
+ * - The code is a valid expiring credit (it has not expired, but will at some point)
  */
 export const addPromotion = (code: string) =>
   Request<ActivePromotion>(

--- a/packages/validation/src/account.schema.ts
+++ b/packages/validation/src/account.schema.ts
@@ -113,3 +113,10 @@ export const UpdateAccountSettingsSchema = object({
   backups_enabled: boolean(),
   managed: boolean(),
 });
+
+export const PromoCodeSchema = object({
+  promo_code: string()
+    .required('Promo code is required.')
+    .min(1, 'Promo code must be between 1 and 32 characters.')
+    .max(32, 'Promo code must be between 1 and 32 characters.'),
+});


### PR DESCRIPTION
## Description

*** Not ready for merge! ***

Putting this up because I won't be around by the time the API is ready for this. Once the PR (3583) has been merged, please double check that the signature and validation are still accurate. This method can then be used on the /account/billing page to add expiring credits to an account.