### PR TITLE
M3-5130 added link to documentation on rescue modal

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/BareMetalRescue.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/BareMetalRescue.tsx
@@ -6,7 +6,8 @@ import Button from 'src/components/Button';
 import { rescueMetalLinode } from '@linode/api-v4/lib/linodes/actions';
 import { resetEventsPolling } from 'src/eventsPolling';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
-import { RESCUE_HELPER_TEXT } from './shared';
+import RescueDescription from './RescueDescription';
+
 interface Props {
   linodeID: number;
   linodeLabel: string;
@@ -66,7 +67,7 @@ export const BareMetalRescue: React.FC<Props> = (props) => {
       actions={actions}
       error={error}
     >
-      {RESCUE_HELPER_TEXT}
+      <RescueDescription />
     </ConfirmationDialog>
   );
 };

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/RescueDescription.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/RescueDescription.tsx
@@ -1,19 +1,20 @@
 import * as React from 'react';
 import ExternalLink from 'src/components/ExternalLink';
+import Typography from 'src/components/core/Typography';
 
 const RESCUE_HELPER_TEXT = `If you suspect that your primary filesystem is corrupt, use the Linode
 Manager to boot your Linode into Rescue Mode. This is a safe environment
 for performing many system recovery and disk management tasks.`;
 
 const RescueDescription = () => (
-  <>
+  <Typography>
     {RESCUE_HELPER_TEXT}{' '}
     <ExternalLink
       fixedIcon
       text="Learn more."
       link="https://www.linode.com/docs/guides/rescue-and-rebuild/"
     />
-  </>
+  </Typography>
 );
 
 export default RescueDescription;

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/RescueDescription.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/RescueDescription.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import ExternalLink from 'src/components/ExternalLink';
+
+const RESCUE_HELPER_TEXT = `If you suspect that your primary filesystem is corrupt, use the Linode
+Manager to boot your Linode into Rescue Mode. This is a safe environment
+for performing many system recovery and disk management tasks.`;
+
+const RescueDescription = () => (
+  <>
+    {RESCUE_HELPER_TEXT}{' '}
+    <ExternalLink
+      fixedIcon
+      text="Learn more."
+      link="https://www.linode.com/docs/guides/rescue-and-rebuild/"
+    />
+  </>
+);
+
+export default RescueDescription;

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/RescueDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/RescueDialog.tsx
@@ -29,6 +29,7 @@ import Dialog from 'src/components/Dialog';
 import useExtendedLinode from 'src/hooks/useExtendedLinode';
 import usePrevious from 'src/hooks/usePrevious';
 import { RESCUE_HELPER_TEXT } from './shared';
+import ExternalLink from 'src/components/ExternalLink';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -216,7 +217,14 @@ const LinodeRescue: React.FC<CombinedProps> = (props) => {
         <div>
           <Paper className={classes.root}>
             {unauthorized && <LinodePermissionsError />}
-            <Typography>{RESCUE_HELPER_TEXT}</Typography>
+            <Typography>
+              {RESCUE_HELPER_TEXT}{' '}
+              <ExternalLink
+                fixedIcon
+                text="Learn more."
+                link="https://www.linode.com/docs/guides/rescue-and-rebuild/"
+              />
+            </Typography>
             <DeviceSelection
               slots={['sda', 'sdb', 'sdc', 'sdd', 'sde', 'sdf', 'sdg']}
               devices={devices}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/RescueDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/RescueDialog.tsx
@@ -10,7 +10,6 @@ import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
-import Typography from 'src/components/core/Typography';
 import Notice from 'src/components/Notice';
 import ErrorState from 'src/components/ErrorState';
 import SectionErrorBoundary from 'src/components/SectionErrorBoundary';
@@ -216,9 +215,7 @@ const LinodeRescue: React.FC<CombinedProps> = (props) => {
         <div>
           <Paper className={classes.root}>
             {unauthorized && <LinodePermissionsError />}
-            <Typography>
-              <RescueDescription />
-            </Typography>
+            <RescueDescription />
             <DeviceSelection
               slots={['sda', 'sdb', 'sdc', 'sdd', 'sde', 'sdf', 'sdg']}
               devices={devices}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/RescueDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/RescueDialog.tsx
@@ -28,8 +28,7 @@ import DeviceSelection, {
 import Dialog from 'src/components/Dialog';
 import useExtendedLinode from 'src/hooks/useExtendedLinode';
 import usePrevious from 'src/hooks/usePrevious';
-import { RESCUE_HELPER_TEXT } from './shared';
-import ExternalLink from 'src/components/ExternalLink';
+import RescueDescription from './RescueDescription';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -218,12 +217,7 @@ const LinodeRescue: React.FC<CombinedProps> = (props) => {
           <Paper className={classes.root}>
             {unauthorized && <LinodePermissionsError />}
             <Typography>
-              {RESCUE_HELPER_TEXT}{' '}
-              <ExternalLink
-                fixedIcon
-                text="Learn more."
-                link="https://www.linode.com/docs/guides/rescue-and-rebuild/"
-              />
+              <RescueDescription />
             </Typography>
             <DeviceSelection
               slots={['sda', 'sdb', 'sdc', 'sdd', 'sde', 'sdf', 'sdg']}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/shared.ts
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/shared.ts
@@ -1,3 +1,0 @@
-export const RESCUE_HELPER_TEXT = `If you suspect that your primary filesystem is corrupt, use the Linode
-Manager to boot your Linode into Rescue Mode. This is a safe environment
-for performing many system recovery and disk management tasks.`;


### PR DESCRIPTION
## Description

Added a link to Linode's ['Rescue and Rebuild' documentation](https://www.linode.com/docs/guides/rescue-and-rebuild/) on the Rescue Dialog. 

I modeled this off of the Resize Dialog in `LinodeResize.tsx`.

## How to test

Open the **rescue** modal for any Linode and verify there is a 'Learn more.' link that brings you to the documentation linked above.  