### PR TITLE
M3-4799 create cluster button flickering fix

### DIFF
--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
@@ -5,7 +5,6 @@ import { isEmpty, pathOr } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
 import Button from 'src/components/Button';
-import FormControlLabel from 'src/components/core/FormControlLabel';
 import Hidden from 'src/components/core/Hidden';
 import {
   createStyles,

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
@@ -246,7 +246,7 @@ export class SelectPlanPanel extends React.Component<
               aria-label="List of Linode Plans"
             >
               {tableHeader}
-              <TableBody role="radiogroup">
+              <TableBody role="grid">
                 {plans.map(this.renderSelection)}
               </TableBody>
             </Table>

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
@@ -19,7 +19,6 @@ import Typography from 'src/components/core/Typography';
 import EnhancedNumberInput from 'src/components/EnhancedNumberInput';
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
-import Radio from 'src/components/Radio';
 import RenderGuard, { RenderGuardProps } from 'src/components/RenderGuard';
 import SelectionCard from 'src/components/SelectionCard';
 import TabbedPanel from 'src/components/TabbedPanel';
@@ -153,21 +152,6 @@ export class SelectPlanPanel extends React.Component<
               [classes.disabledRow]: disabled,
             })}
           >
-            <TableCell className={'visually-hidden'}>
-              <FormControlLabel
-                label={type.heading}
-                aria-label={type.heading}
-                className={'label-visually-hidden'}
-                control={
-                  <Radio
-                    checked={type.id === String(selectedID)}
-                    onChange={this.onSelect(type.id)}
-                    disabled={disabled}
-                    id={type.id}
-                  />
-                }
-              />
-            </TableCell>
             <TableCell data-qa-plan-name>
               <div className={classes.headingCellContainer}>
                 {type.heading}{' '}
@@ -238,7 +222,6 @@ export class SelectPlanPanel extends React.Component<
     const tableHeader = (
       <TableHead>
         <TableRow>
-          <TableCell className={'visually-hidden'} />
           <TableCell data-qa-plan-header>Plan</TableCell>
           <TableCell data-qa-monthly-header>Monthly</TableCell>
           <TableCell data-qa-hourly-header>Hourly</TableCell>


### PR DESCRIPTION
## Description

This PR fixes the rendering issues on the Kubernetes create cluster screen for chromium based browsers. This is accomplished by removing an unused radio button that was `visually-hidden` which interacted strangely with the `EnhancedNumberInput` component.

## How to test

Open the manager in a chromium based browser and navigate to the create Kubernetes cluster screen. Shrink the browser window height enough so that the linode plan quantity selection table is just out of view. Refresh the page. Scroll down to the plan quantity selection table. All the quantity selectors should be visible and hovering over any of the fields or buttons should not cause any other field/button to disappear.