### PR TITLE
M3-5129:  Added connect with LISH copy to rescue modal for Bare Metal instances

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/BareMetalRescue.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/BareMetalRescue.tsx
@@ -67,7 +67,7 @@ export const BareMetalRescue: React.FC<Props> = (props) => {
       actions={actions}
       error={error}
     >
-      <RescueDescription />
+      <RescueDescription linodeId={linodeID} />
     </ConfirmationDialog>
   );
 };

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/RescueDescription.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/RescueDescription.tsx
@@ -35,7 +35,7 @@ const RescueDescription: React.FC<Props> = (props) => {
         {rescueDescription.text}{' '}
         <Link to={rescueDescription.link}>Learn more.</Link>
       </Typography>
-      {linodeId && (
+      {linodeId ? (
         <Typography className={classes.copy}>
           {`When your Linode has successfully rebooted into Rescue Mode, use the `}
           <button
@@ -49,7 +49,7 @@ const RescueDescription: React.FC<Props> = (props) => {
             Learn more.
           </Link>
         </Typography>
-      )}
+      ) : null}
     </React.Fragment>
   );
 };

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/RescueDescription.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/RescueDescription.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import ExternalLink from 'src/components/ExternalLink';
 import Typography from 'src/components/core/Typography';
 import { lishLaunch } from 'src/features/Lish/lishUtils';
 import { makeStyles, Theme } from 'src/components/core/styles';
+import Link from 'src/components/Link';
 
 const rescueDescription = {
   text: `If you suspect that your primary filesystem is corrupt, use the Linode Manager to boot your Linode into Rescue Mode. This is a safe environment for performing many system recovery and disk management tasks.`,
@@ -10,7 +10,7 @@ const rescueDescription = {
 };
 
 interface Props {
-  linodeId: number;
+  linodeId?: number;
 }
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -20,35 +20,36 @@ const useStyles = makeStyles((theme: Theme) => ({
   lishLink: theme.applyLinkStyles,
 }));
 
-const RescueDescription = (props: Props) => {
+const RescueDescription: React.FC<Props> = (props) => {
   const { linodeId } = props;
   const classes = useStyles();
 
+  /**
+   * Pass the prop 'linodeId' when you want to include a note about
+   * connection with LISH upon reboot into Rescue Mode. This is
+   * intended for the Bare Metal dialog.
+   */
   return (
     <React.Fragment>
       <Typography>
         {rescueDescription.text}{' '}
-        <ExternalLink
-          fixedIcon
-          text="Learn more."
-          link={rescueDescription.link}
-        />
+        <Link to={rescueDescription.link}>Learn more.</Link>
       </Typography>
-      <Typography className={classes.copy}>
-        {`When your Linode has successfully rebooted into Rescue Mode, use the `}
-        <button
-          className={classes.lishLink}
-          onClick={() => lishLaunch(linodeId)}
-        >
-          LISH Console
-        </button>
-        {` to access it. `}
-        <ExternalLink
-          fixedIcon
-          text="Learn more."
-          link="https://www.linode.com/docs/guides/rescue-and-rebuild/#connecting-to-a-linode-running-in-rescue-mode"
-        />
-      </Typography>
+      {linodeId && (
+        <Typography className={classes.copy}>
+          {`When your Linode has successfully rebooted into Rescue Mode, use the `}
+          <button
+            className={classes.lishLink}
+            onClick={() => lishLaunch(linodeId)}
+          >
+            LISH Console
+          </button>
+          {` to access it. `}
+          <Link to="https://www.linode.com/docs/guides/rescue-and-rebuild/#connecting-to-a-linode-running-in-rescue-mode">
+            Learn more.
+          </Link>
+        </Typography>
+      )}
     </React.Fragment>
   );
 };

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/RescueDescription.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/RescueDescription.tsx
@@ -1,20 +1,56 @@
 import * as React from 'react';
 import ExternalLink from 'src/components/ExternalLink';
 import Typography from 'src/components/core/Typography';
+import { lishLaunch } from 'src/features/Lish/lishUtils';
+import { makeStyles, Theme } from 'src/components/core/styles';
 
-const RESCUE_HELPER_TEXT = `If you suspect that your primary filesystem is corrupt, use the Linode
-Manager to boot your Linode into Rescue Mode. This is a safe environment
-for performing many system recovery and disk management tasks.`;
+const rescueDescription = {
+  text: `If you suspect that your primary filesystem is corrupt, use the Linode Manager to boot your Linode into Rescue Mode. This is a safe environment for performing many system recovery and disk management tasks.`,
+  link: 'https://www.linode.com/docs/guides/rescue-and-rebuild/',
+};
 
-const RescueDescription = () => (
-  <Typography>
-    {RESCUE_HELPER_TEXT}{' '}
-    <ExternalLink
-      fixedIcon
-      text="Learn more."
-      link="https://www.linode.com/docs/guides/rescue-and-rebuild/"
-    />
-  </Typography>
-);
+interface Props {
+  linodeId: number;
+}
+
+const useStyles = makeStyles((theme: Theme) => ({
+  copy: {
+    marginTop: theme.spacing(1),
+  },
+  lishLink: theme.applyLinkStyles,
+}));
+
+const RescueDescription = (props: Props) => {
+  const { linodeId } = props;
+  const classes = useStyles();
+
+  return (
+    <React.Fragment>
+      <Typography>
+        {rescueDescription.text}{' '}
+        <ExternalLink
+          fixedIcon
+          text="Learn more."
+          link={rescueDescription.link}
+        />
+      </Typography>
+      <Typography className={classes.copy}>
+        {`When your Linode has successfully rebooted into Rescue Mode, use the `}
+        <button
+          className={classes.lishLink}
+          onClick={() => lishLaunch(linodeId)}
+        >
+          LISH Console
+        </button>
+        {` to access it. `}
+        <ExternalLink
+          fixedIcon
+          text="Learn more."
+          link="https://www.linode.com/docs/guides/rescue-and-rebuild/#connecting-to-a-linode-running-in-rescue-mode"
+        />
+      </Typography>
+    </React.Fragment>
+  );
+};
 
 export default RescueDescription;

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/RescueDescription.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/RescueDescription.tsx
@@ -44,10 +44,7 @@ const RescueDescription: React.FC<Props> = (props) => {
           >
             LISH Console
           </button>
-          {` to access it. `}
-          <Link to="https://www.linode.com/docs/guides/rescue-and-rebuild/#connecting-to-a-linode-running-in-rescue-mode">
-            Learn more.
-          </Link>
+          {` to access it.`}
         </Typography>
       ) : null}
     </React.Fragment>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/RescueDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/RescueDialog.tsx
@@ -215,7 +215,7 @@ const LinodeRescue: React.FC<CombinedProps> = (props) => {
         <div>
           <Paper className={classes.root}>
             {unauthorized && <LinodePermissionsError />}
-            <RescueDescription linodeId={linodeId} />
+            <RescueDescription />
             <DeviceSelection
               slots={['sda', 'sdb', 'sdc', 'sdd', 'sde', 'sdf', 'sdg']}
               devices={devices}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/RescueDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/RescueDialog.tsx
@@ -215,7 +215,7 @@ const LinodeRescue: React.FC<CombinedProps> = (props) => {
         <div>
           <Paper className={classes.root}>
             {unauthorized && <LinodePermissionsError />}
-            <RescueDescription />
+            <RescueDescription linodeId={linodeId} />
             <DeviceSelection
               slots={['sda', 'sdb', 'sdc', 'sdd', 'sde', 'sdf', 'sdg']}
               devices={devices}


### PR DESCRIPTION
## Description

Adds copy to the Rescue Dialog for Bare Metal instances informing the user that they should use the LISH console to connect to their Linode upon rescue. Also includes a link that directly opens LISH for them. 

![screenshot](https://wsend.net/6fa53e3cef6b5faa4fd47533ec938f38/Screen%20Shot%202021-05-17%20at%205.10.49%20PM.png)

## How to test

**What are the steps to reproduce the issue or verify the changes?**

Open the Rescue Dialog on a Bare Metal Linode and ensure copy and links are good. 