### PR TITLE
M3-3830 default nodebalancers sort to ascending order

### DIFF
--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.tsx
@@ -263,7 +263,7 @@ export class NodeBalancersLanding extends React.Component<
                   toggleGroupByTag={toggleNodeBalancerGroupByTag}
                   row={nodeBalancerRow}
                   headers={headers}
-                  initialOrder={{ order: 'desc', orderBy: 'label' }}
+                  initialOrder={{ order: 'asc', orderBy: 'label' }}
                 />
               </>
             );


### PR DESCRIPTION
## Description

Changes the default sort order to **ascending** on the Kubernetes landing page. This change was made to be consistent with other landing pages such as Firewall, Domains, etc...

## How to test

Ensure the Kubernetes landing page is sorted in **ascending order** by the label by default. Consider cleaning sorting preferences in `/profile/settings?preferenceEditor=true` to thoroughly test. 