### PR TITLE
M3-4744 Filter Linodes (and NodeBalacers) by IP

### DIFF
--- a/packages/manager/src/features/Search/useAPISearch.tsx
+++ b/packages/manager/src/features/Search/useAPISearch.tsx
@@ -72,9 +72,13 @@ const generateFilter = (
       {
         tags: { '+contains': text },
       },
-      {
-        ipv4: isLinode ? { '+contains': text } : undefined,
-      },
+      ...(isLinode
+        ? [
+            {
+              ipv4: { '+contains': text },
+            },
+          ]
+        : []),
     ],
   };
 };

--- a/packages/manager/src/features/Search/useAPISearch.tsx
+++ b/packages/manager/src/features/Search/useAPISearch.tsx
@@ -59,7 +59,11 @@ export const useAPISearch = (): Search => {
   return { searchAPI };
 };
 
-const generateFilter = (text: string, labelFieldName: string = 'label') => {
+const generateFilter = (
+  text: string,
+  labelFieldName: string = 'label',
+  isLinode?: boolean
+) => {
   return {
     '+or': [
       {
@@ -67,6 +71,9 @@ const generateFilter = (text: string, labelFieldName: string = 'label') => {
       },
       {
         tags: { '+contains': text },
+      },
+      {
+        ipv4: isLinode ? { '+contains': text } : undefined,
       },
     ],
   };
@@ -84,7 +91,10 @@ const requestEntities = (
     getDomains(params, generateFilter(searchText, 'domain')).then((results) =>
       results.data.map(domainToSearchableItem)
     ),
-    getLinodes(params, generateFilter(searchText)).then((results) =>
+    getLinodes(
+      params,
+      generateFilter(searchText, 'label', true)
+    ).then((results) =>
       results.data.map((thisResult) => formatLinode(thisResult, types, images))
     ),
     getImages(

--- a/packages/manager/src/features/Search/useAPISearch.tsx
+++ b/packages/manager/src/features/Search/useAPISearch.tsx
@@ -62,7 +62,7 @@ export const useAPISearch = (): Search => {
 const generateFilter = (
   text: string,
   labelFieldName: string = 'label',
-  isLinode?: boolean
+  filterByIp?: boolean
 ) => {
   return {
     '+or': [
@@ -72,7 +72,7 @@ const generateFilter = (
       {
         tags: { '+contains': text },
       },
-      ...(isLinode
+      ...(filterByIp
         ? [
             {
               ipv4: { '+contains': text },
@@ -112,9 +112,10 @@ const requestEntities = (
     getVolumes(params, generateFilter(searchText)).then((results) =>
       results.data.map(volumeToSearchableItem)
     ),
-    getNodeBalancers(params, generateFilter(searchText)).then((results) =>
-      results.data.map(nodeBalToSearchableItem)
-    ),
+    getNodeBalancers(
+      params,
+      generateFilter(searchText, 'label', true)
+    ).then((results) => results.data.map(nodeBalToSearchableItem)),
     // Restricted users always get a 403 when requesting clusters
     !isRestricted
       ? getKubernetesClusters().then((results) =>

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -17,7 +17,7 @@ import useAPISearch from 'src/features/Search/useAPISearch';
 import useAccountManagement from 'src/hooks/useAccountManagement';
 import { ReduxEntity, useReduxLoad } from 'src/hooks/useReduxLoad';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
-import { sendSearchBarUsedEvent } from 'src/utilities/ga.ts';
+import { sendSearchBarUsedEvent } from 'src/utilities/ga';
 import { debounce } from 'throttle-debounce';
 import styled, { StyleProps } from './SearchBar.styles';
 import SearchSuggestion from './SearchSuggestion';

--- a/packages/manager/src/store/selectors/getSearchEntities.ts
+++ b/packages/manager/src/store/selectors/getSearchEntities.ts
@@ -129,6 +129,7 @@ export const nodeBalToSearchableItem = (
     path: `/nodebalancers/${nodebal.id}`,
     created: nodebal.created,
     ips: getNodebalIps(nodebal),
+    region: nodebal.region,
   },
 });
 


### PR DESCRIPTION
## Description

When a user has a large linode account with many Linodes, allow search to use the API to filter by IPv4 address. 

## How to test

- Login to the cloud manager
- Have at least 1 Linode
- Enter an IP address of a linode into the search box
- Verify search finds Linodes by IP address while also ensuring you can still search on other properties 

Cloud Manager is aware of whether or not a user has a _large_ Linode account. If an account is large, search will happen at an API level. _Small_  Linode accounts use client side searching therefore can already can search by IP.

To simulate testing on a large paginated amount of Linodes, you can temporarily set `_isLargeAccount` to true here https://github.com/linode/manager/blob/d4578ff3a8b54e84c658ebea50a47c13abb0eee7/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx#L86
