### PR TITLE
hotfix: Fallback to Tux icon for unknown distro icons

### DIFF
--- a/packages/manager/src/components/ImageSelect/ImageSelect.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.tsx
@@ -101,7 +101,8 @@ export const imagesToGroupedItems = (images: Image[]) => {
                 label: fullLabel,
                 value: thisImage.id,
                 className: thisImage.vendor
-                  ? `fl-${distroIcons[thisImage.vendor]}`
+                  ? // Use Tux as a fallback.
+                    `fl-${distroIcons[thisImage.vendor] ?? 'tux'}`
                   : `fl-tux`,
               };
             })

--- a/packages/manager/src/utilities/images.ts
+++ b/packages/manager/src/utilities/images.ts
@@ -14,19 +14,6 @@ import {
   startsWith,
 } from 'ramda';
 
-export const distroIcons = {
-  Alpine: 'alpine',
-  Arch: 'archlinux',
-  CentOS: 'centos',
-  CoreOS: 'coreos',
-  Debian: 'debian',
-  Fedora: 'fedora',
-  Gentoo: 'gentoo',
-  openSUSE: 'opensuse',
-  Slackware: 'slackware',
-  Ubuntu: 'ubuntu',
-};
-
 export const sortCreatedDESC = compose<any, any, any>(
   reverse,
   sortBy(


### PR DESCRIPTION
## Description

**What does this PR do?**

If there is an unknown icon, fallback to the Tux icon (instead of not displaying an icon at all).

<img width="508" alt="Screen Shot 2021-05-18 at 3 12 49 PM" src="https://user-images.githubusercontent.com/16911484/118709849-84508880-b7eb-11eb-9089-c38e3a67846a.png">


## How to test

**What are the steps to reproduce the issue or verify the changes?**

To test, log in to one of the prod test accounts and create a Linode. You should see AlmaLinux as an option with the Tux icon. On develop, there will be no icon.
