### PR TITLE
M3-5113: Fix viewing Object Storage contents

### DIFF
--- a/packages/manager/src/factories/objectStorage.ts
+++ b/packages/manager/src/factories/objectStorage.ts
@@ -39,3 +39,14 @@ export const objectStorageObjectFactory = Factory.Sync.makeFactory<ObjectStorage
     name: Factory.each((id) => `example-${id}`),
   }
 );
+
+export const makeObjectsPage = (
+  e: ObjectStorageObject[],
+  override: { is_truncated: boolean; next_marker: string | null }
+) => ({
+  data: e,
+  is_truncated: override.is_truncated || false,
+  next_marker: override.next_marker || null,
+});
+
+export const staticObjects = objectStorageObjectFactory.buildList(250);

--- a/packages/manager/src/factories/objectStorage.ts
+++ b/packages/manager/src/factories/objectStorage.ts
@@ -2,6 +2,7 @@ import * as Factory from 'factory.ts';
 import {
   ObjectStorageBucket,
   ObjectStorageCluster,
+  ObjectStorageObject,
 } from '@linode/api-v4/lib/object-storage/types';
 
 export const objectStorageBucketFactory = Factory.Sync.makeFactory<ObjectStorageBucket>(
@@ -26,5 +27,15 @@ export const objectStorageClusterFactory = Factory.Sync.makeFactory<ObjectStorag
       (id) => `website-cluster-${id}.linodeobjects.com`
     ),
     status: 'available',
+  }
+);
+
+export const objectStorageObjectFactory = Factory.Sync.makeFactory<ObjectStorageObject>(
+  {
+    size: 1024,
+    owner: 'bfc70ab2-e3d4-42a4-ad55-83921822270c',
+    etag: '9f254c71e28e033bf9e0e5262e3e72ab',
+    last_modified: '2019-01-01T01:23:45',
+    name: Factory.each((id) => `example-${id}`),
   }
 );

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -154,8 +154,9 @@ export class BucketDetail extends React.Component<CombinedProps, State> {
         // For some reason, the API might return only return a small number of items even though we asked for a page size of 100.
         // To ensure the user will be able to view all of their objects:
         // If the response from the API is truncated but it did not fulfil our requested page size, load more data
-        if (response.is_truncated && this.state.data.length < page_size)
+        if (response.is_truncated && extendedData.length < page_size) {
           this.getNextPage();
+        }
       })
       .catch((err) => {
         this.setState({
@@ -220,6 +221,10 @@ export class BucketDetail extends React.Component<CombinedProps, State> {
           allObjectsFetched,
           nextMarker: response.next_marker,
         });
+
+        if (response.is_truncated && extendedData.length < page_size) {
+          this.getNextPage();
+        }
       })
       .catch((err) => {
         this.setState({

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -461,8 +461,7 @@ export class BucketDetail extends React.Component<CombinedProps, State> {
                 {!loading &&
                   !allObjectsFetched &&
                   !generalError &&
-                  !nextPageError &&
-                  data.length >= 100 && (
+                  !nextPageError && (
                     <Waypoint onEnter={this.getNextPage}>
                       <div />
                     </Waypoint>

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -151,8 +151,9 @@ export class BucketDetail extends React.Component<CombinedProps, State> {
           nextMarker: response.next_marker,
         });
 
-        // For some reason, the API might return only return a small number of items even though we asked for a page size of 100. To ensure the user will be able to view all of their objects:
-        // If the response from the API is truncated but it did not fulfil our requested page size, load more
+        // For some reason, the API might return only return a small number of items even though we asked for a page size of 100.
+        // To ensure the user will be able to view all of their objects:
+        // If the response from the API is truncated but it did not fulfil our requested page size, load more data
         if (response.is_truncated && this.state.data.length < page_size)
           this.getNextPage();
       })

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -150,13 +150,6 @@ export class BucketDetail extends React.Component<CombinedProps, State> {
           allObjectsFetched,
           nextMarker: response.next_marker,
         });
-
-        // For some reason, the API might return only return a small number of items even though we asked for a page size of 100.
-        // To ensure the user will be able to view all of their objects:
-        // If the response from the API is truncated but it did not fulfil our requested page size, load more data
-        if (response.is_truncated && extendedData.length < page_size) {
-          this.getNextPage();
-        }
       })
       .catch((err) => {
         this.setState({
@@ -221,10 +214,6 @@ export class BucketDetail extends React.Component<CombinedProps, State> {
           allObjectsFetched,
           nextMarker: response.next_marker,
         });
-
-        if (response.is_truncated && extendedData.length < page_size) {
-          this.getNextPage();
-        }
       })
       .catch((err) => {
         this.setState({

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -150,6 +150,11 @@ export class BucketDetail extends React.Component<CombinedProps, State> {
           allObjectsFetched,
           nextMarker: response.next_marker,
         });
+
+        // For some reason, the API might return only return a small number of items even though we asked for a page size of 100. To ensure the user will be able to view all of their objects:
+        // If the response from the API is truncated but it did not fulfil our requested page size, load more
+        if (response.is_truncated && this.state.data.length < page_size)
+          this.getNextPage();
       })
       .catch((err) => {
         this.setState({

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -46,14 +46,14 @@ import {
   nodeBalancerConfigNodeFactory,
   VLANFactory,
   promoFactory,
-  objectStorageObjectFactory,
+  staticObjects,
+  makeObjectsPage,
 } from 'src/factories';
 
 import cachedRegions from 'src/cachedData/regions.json';
 import { MockData } from 'src/dev-tools/mockDataController';
 import cachedTypes from 'src/cachedData/types.json';
 import { accountMaintenanceFactory } from 'src/factories/accountMaintenance';
-import { ObjectStorageObject } from '@linode/api-v4/lib/object-storage';
 
 export const makeResourcePage = (
   e: any[],
@@ -67,17 +67,6 @@ export const makeResourcePage = (
   results: override.results ?? e.length,
   data: e,
 });
-
-const makeObjectsPage = (
-  e: ObjectStorageObject[],
-  override: { is_truncated: boolean; next_marker: string | null }
-) => ({
-  data: e,
-  is_truncated: override.is_truncated || false,
-  next_marker: override.next_marker || null,
-});
-
-const staticObjects = objectStorageObjectFactory.buildList(250);
 
 const statusPage = [
   rest.get('*statuspage.io/api/v2/incidents*', (req, res, ctx) => {


### PR DESCRIPTION
## Description

Addresses potential issue with loading paginated data from the API  when loading objects in an object storage bucket.

Some users experience incomplete results when loading their objects.  It appears that the API sometimes does not respect the page number query parameter resulting in a response that tells the client: "here are a few items (less than the quested page number), but there are still more to load." When the API does that, it also returns a nextMarker that does not make sense. This may be an issue with the API or Object Storage. 

This PR fixes this edge case by removing the check `results >= 100` so our infinite scroll waypoint renders depending on `allObjectsFetched` which is going to be accurate. The actual bug fix is in `BucketDetail.tsx`.

This PR also enables the MSW to mock objects in a bucket. This can be factored out of the PR if needed.   

## How to test

Go to an object storage bucket and make sure infinite scroll (pagination) works as expected. Test on large accounts. 

Also ensure the mock service worker still works as expected and see if it correctly mocks objects in object storage. 
