### PR TITLE
Remove checkout bar from Linode Create

### DIFF
--- a/packages/manager/cypress/integration/linodes/clone-linode.spec.ts
+++ b/packages/manager/cypress/integration/linodes/clone-linode.spec.ts
@@ -1,13 +1,9 @@
-import {
-  createLinode,
-  deleteLinodeById,
-  deleteLinodeByLabel,
-} from '../../support/api/linodes';
+import { createLinode } from '../../support/api/linodes';
 import {
   containsClick,
   containsVisible,
+  fbtClick,
   getClick,
-  getVisible,
 } from '../../support/helpers';
 import { assertToast } from '../../support/ui/events';
 
@@ -27,19 +23,13 @@ describe('clone linode', () => {
         containsClick('Clone');
         containsClick('Select a Region');
         containsClick('Newark, NJ');
-        getVisible('[data-qa-details]').within(() => {
-          containsVisible(linode.label);
-        });
         getClick('[id="g6-nanode-1"]');
-        getClick('[data-qa-deploy-linode="true"]');
+        fbtClick('Create Linode');
         cy.wait('@cloneLinode').then((xhr) => {
           const newLinodeLabel = xhr.response?.body?.label;
-          const newLinodeId = xhr.response?.body?.id;
           assert.equal(xhr.response?.statusCode, 200);
           assertToast(`Your Linode ${newLinodeLabel} is being created.`);
           containsVisible(newLinodeLabel);
-          deleteLinodeById(linode.id);
-          deleteLinodeById(newLinodeId);
         });
       }
     });

--- a/packages/manager/cypress/integration/linodes/smoke-create-linode.spec.ts
+++ b/packages/manager/cypress/integration/linodes/smoke-create-linode.spec.ts
@@ -7,6 +7,7 @@ import { assertToast } from '../../support/ui/events';
 import {
   containsClick,
   containsVisible,
+  fbtClick,
   getClick,
 } from '../../support/helpers';
 import { selectRegionString } from '../../support/ui/constants';
@@ -14,7 +15,6 @@ import { selectRegionString } from '../../support/ui/constants';
 describe('create linode', () => {
   beforeEach(() => {
     cy.visitWithLogin('/linodes/create');
-    cy.get('[data-qa-deploy-linode]');
   });
   it('creates a nanode', () => {
     const rootpass = strings.randomPass();
@@ -26,7 +26,7 @@ describe('create linode', () => {
     getClick('[id="g6-nanode-1"]');
     getClick('#linode-label').clear().type(linodeLabel);
     cy.get('#root-password').type(rootpass);
-    getClick('[data-qa-deploy-linode]');
+    fbtClick('Create Linode');
     cy.wait('@linodeCreated').its('response.statusCode').should('eq', 200);
     assertToast(`Your Linode ${linodeLabel} is being created.`);
     containsVisible('PROVISIONING');

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -61,7 +61,6 @@ import { validatePassword } from 'src/utilities/validatePassword';
 import LinodeCreate from './LinodeCreate';
 import {
   HandleSubmit,
-  Info,
   ReduxStateProps,
   ReduxStatePropsAndSSHKeys,
   TypeInfo,
@@ -601,46 +600,6 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
     );
   };
 
-  getRegionInfo = (): Info | undefined => {
-    const { selectedRegionID } = this.state;
-
-    if (!selectedRegionID) {
-      return;
-    }
-
-    const selectedRegion = this.props.regionsData.find(
-      (region) => region.id === selectedRegionID
-    );
-
-    return (
-      selectedRegion && {
-        title: selectedRegion.country.toUpperCase(),
-        details: selectedRegion.display,
-      }
-    );
-  };
-
-  getImageInfo = (): Info | undefined => {
-    const { selectedImageID } = this.state;
-
-    if (!selectedImageID) {
-      return;
-    }
-
-    /**
-     * safe to ignore possibility of "undefined"
-     * null checking happens in CALinodeCreate
-     */
-    const selectedImage = this.props.imagesData![selectedImageID];
-
-    return (
-      selectedImage && {
-        title: `${selectedImage.vendor || selectedImage.label}`,
-        details: `${selectedImage.vendor ? selectedImage.label : ''}`,
-      }
-    );
-  };
-
   render() {
     const {
       enqueueSnackbar,
@@ -681,9 +640,6 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
             />
           </Grid>
           <LinodeCreate
-            regionDisplayInfo={this.getRegionInfo()}
-            imageDisplayInfo={this.getImageInfo()}
-            typeDisplayInfo={this.getTypeInfo()}
             backupsMonthlyPrice={this.getBackupsMonthlyPrice()}
             updateRegionID={this.setRegionID}
             updateImageID={this.setImageID}

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -283,7 +283,7 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
           {plans.map(this.renderSelection)}
         </Hidden>
         <Hidden mdDown={isCreate} smDown={!isCreate}>
-          <Grid item xs={12} lg={11}>
+          <Grid item xs={12}>
             <Table border spacingBottom={16} aria-label="List of Linode Plans">
               <TableHead>
                 <TableRow>

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -164,7 +164,7 @@ class FromAppsContent extends React.PureComponent<CombinedProps, State> {
 
     return (
       <React.Fragment>
-        <Grid item className={`${classes.main} mlMain py0`}>
+        <Grid item className={`${classes.main} py0`}>
           <SelectAppPanel
             appInstances={appInstances}
             appInstancesError={appInstancesError}

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
@@ -181,7 +181,7 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
     );
 
     return (
-      <Grid item className={`${classes.main} mlMain py0`}>
+      <Grid item className={`${classes.main} py0`}>
         {!userHasBackups ? (
           <Paper>
             <Placeholder

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -48,7 +48,7 @@ export const FromImageContent: React.FC<CombinedProps> = (props) => {
 
   if (variant === 'private' && Object.keys(privateImages).length === 0) {
     return (
-      <Grid item className={`${classes.main} mlMain py0`}>
+      <Grid item className={`${classes.main} py0`}>
         <Paper>
           <Placeholder title="My Images" icon={ImageIcon} isEntity>
             <Typography variant="subtitle1">
@@ -63,7 +63,7 @@ export const FromImageContent: React.FC<CombinedProps> = (props) => {
   }
 
   return (
-    <Grid item className={`${classes.main} mlMain py0`}>
+    <Grid item className={`${classes.main} py0`}>
       <ImageSelect
         title={imagePanelTitle || 'Choose an Image'}
         images={Object.keys(imagesData).map((eachKey) => imagesData[eachKey])}

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
@@ -61,7 +61,7 @@ export const FromLinodeContent: React.FC<CombinedProps> = (props) => {
     // eslint-disable-next-line
     <React.Fragment>
       {linodesData && linodesData.length === 0 ? (
-        <Grid item className={`${classes.main} mlMain py0`}>
+        <Grid item className={`${classes.main} py0`}>
           <Paper>
             <Placeholder
               data-qa-placeholder
@@ -76,7 +76,7 @@ export const FromLinodeContent: React.FC<CombinedProps> = (props) => {
           </Paper>
         </Grid>
       ) : (
-        <Grid item className={`${classes.main} mlMain py0`}>
+        <Grid item className={`${classes.main} py0`}>
           <SelectLinodePanel
             data-qa-linode-panel
             error={hasErrorFor('linode_id')}

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -140,11 +140,7 @@ export class FromStackScriptContent extends React.PureComponent<CombinedProps> {
 
     return (
       <React.Fragment>
-        <Grid
-          data-qa-panel={header}
-          item
-          className={`${classes.main} mlMain py0`}
-        >
+        <Grid data-qa-panel={header} item className={`${classes.main} py0`}>
           <SelectStackScriptPanel
             data-qa-select-stackscript
             error={hasErrorFor('stackscript_id')}


### PR DESCRIPTION
## Description

This removes the checkout bar from the Linode Create bar.

It does not remove the checkout bar from anything else (Volumes, NodeBalancers, Kubernetes).

## How to test

Check all pathways of Linode Creation.
