### PR TITLE
Remove focus styles for mouse users

### DIFF
--- a/packages/manager/src/index.css
+++ b/packages/manager/src/index.css
@@ -394,3 +394,10 @@ button::-moz-focus-inner {
 .skip-link:focus {
   top: 0;
 }
+
+/* Removes focus styles for mouse users
+https://blog.chromium.org/2020/09/giving-users-and-developers-more.html
+*/
+:focus:not(:focus-visible) {
+  outline: none;
+}

--- a/packages/manager/src/index.css
+++ b/packages/manager/src/index.css
@@ -395,8 +395,9 @@ button::-moz-focus-inner {
   top: 0;
 }
 
-/* Removes focus styles for mouse users
-https://blog.chromium.org/2020/09/giving-users-and-developers-more.html
+/*
+Removes focus styles for mouse users.
+See: https://blog.chromium.org/2020/09/giving-users-and-developers-more.html
 */
 :focus:not(:focus-visible) {
   outline: none;


### PR DESCRIPTION
## Description

This removes focus styles for focusable elements when the element is clicked on with the mouse.

**Example:** Linode Create -> "Choose a Distribution" Paper

In production, clicking this panel will activate the browser's focus styles around the Paper (e.g. dashed border). This is because tabbed panels have a `tabindex`, making it focusable. This is good for accessibility, but it is not necessary when the element is selected with a mouse.

This uses the new `:focus-visible` pseudo-class , which selects for the same heuristics the browser uses to display the default focus indicator. This can be combined with `:focus:not` to select elements which are focusable _but that the browser has determined should not have a focus indicator._ 

```
:focus:not(:focus-visible) {
  outline: none;
}
```

More reading: 
- https://blog.chromium.org/2020/09/giving-users-and-developers-more.html
- https://css-tricks.com/the-focus-visible-trick/

## How to test

Please navigate around the app with the keyboard and mouse. We should not lose any accessibility when navigating with the keyboard; i.e. focus indicators should still be visible. Note: this pseudo-class isn't available in Safari.
