### PR TITLE
M3-5162: changed warning message to include new language

### DIFF
--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.test.tsx
@@ -27,7 +27,7 @@ describe('KubeCheckoutBar', () => {
 
   it('should not show a warning if all pools have 3 nodes or more', () => {
     const { queryAllByText } = renderComponent(props);
-    expect(queryAllByText(/at least 3 nodes/i)).toHaveLength(0);
+    expect(queryAllByText(/minimum of 3 nodes/i)).toHaveLength(0);
   });
 
   it('should show a warning if any pool has fewer than 3 nodes', () => {
@@ -36,7 +36,7 @@ describe('KubeCheckoutBar', () => {
       ...props,
       pools: poolsWithSmallNode,
     });
-    getByText(/at least 3 nodes/i);
+    getByText(/minimum of 3 nodes/i);
   });
 
   it('should display the total price of the cluster', () => {

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/ResizeNodePoolDrawer/ResizeNodePoolDrawer.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/ResizeNodePoolDrawer/ResizeNodePoolDrawer.test.tsx
@@ -44,7 +44,7 @@ describe('ResizeNodePoolDrawer', () => {
     const { getByText } = renderWithTheme(
       <ResizeNodePoolDrawer {...props} nodePool={smallPool} />
     );
-    expect(getByText(/we recommend at least 3 nodes/i));
+    expect(getByText(/minimum of 3 nodes/i));
   });
 
   it('should display a warning if the user tries to resize to a smaller node count', () => {

--- a/packages/manager/src/features/Kubernetes/kubeUtils.ts
+++ b/packages/manager/src/features/Kubernetes/kubeUtils.ts
@@ -6,7 +6,7 @@ import { LinodeType } from '@linode/api-v4/lib/linodes';
 import { pluralize } from 'src/utilities/pluralize';
 import { ExtendedCluster, ExtendedPoolNode, PoolNodeWithPrice } from './types';
 
-export const nodeWarning = `We recommend at least 3 nodes in each pool. Fewer nodes may affect availability.`;
+export const nodeWarning = `We recommend a minimum of 3 node in each NodePool to avoid downtime during upgrades and maintenance.`;
 
 export const getMonthlyPrice = (
   type: string,

--- a/packages/manager/src/features/Kubernetes/kubeUtils.ts
+++ b/packages/manager/src/features/Kubernetes/kubeUtils.ts
@@ -6,7 +6,7 @@ import { LinodeType } from '@linode/api-v4/lib/linodes';
 import { pluralize } from 'src/utilities/pluralize';
 import { ExtendedCluster, ExtendedPoolNode, PoolNodeWithPrice } from './types';
 
-export const nodeWarning = `We recommend a minimum of 3 node in each NodePool to avoid downtime during upgrades and maintenance.`;
+export const nodeWarning = `We recommend a minimum of 3 nodes in each NodePool to avoid downtime during upgrades and maintenance.`;
 
 export const getMonthlyPrice = (
   type: string,

--- a/packages/manager/src/features/Kubernetes/kubeUtils.ts
+++ b/packages/manager/src/features/Kubernetes/kubeUtils.ts
@@ -6,7 +6,7 @@ import { LinodeType } from '@linode/api-v4/lib/linodes';
 import { pluralize } from 'src/utilities/pluralize';
 import { ExtendedCluster, ExtendedPoolNode, PoolNodeWithPrice } from './types';
 
-export const nodeWarning = `We recommend a minimum of 3 nodes in each NodePool to avoid downtime during upgrades and maintenance.`;
+export const nodeWarning = `We recommend a minimum of 3 nodes in each Node Pool to avoid downtime during upgrades and maintenance.`;
 
 export const getMonthlyPrice = (
   type: string,


### PR DESCRIPTION
## Description

Changes the language in the warning recommending users use at least 3 nodes for their LKE cluster. 

## How to test

Prepare to buy a Kubernetes Cluster with less than 3 nodes and ensure the warning says `We recommend a minimum of 3 node in each NodePool to avoid downtime during upgrades and maintenance.` 
