### PR TITLE
E2E Update: small changes to work with credit card drawer

### DIFF
--- a/packages/manager/cypress/integration/account/smoke-billing-contact.spec.ts
+++ b/packages/manager/cypress/integration/account/smoke-billing-contact.spec.ts
@@ -134,7 +134,7 @@ describe('Billing Contact', () => {
       .click()
       .clear()
       .type(newAccountData['tax_id']);
-    fbtClick('Save').then(() => {
+    getClick('[data-qa-save-contact-info="true"]').then(() => {
       cy.wait('@createAccount').then((xhr) => {
         expect(xhr.request.body).to.eql(newAccountData);
       });

--- a/packages/manager/cypress/integration/notificationsAndEvents/notifications.spec.ts
+++ b/packages/manager/cypress/integration/notificationsAndEvents/notifications.spec.ts
@@ -10,7 +10,6 @@ const notifications: Notification[] = [
   notificationFactory.build({ type: 'migration_pending', severity: 'major' }),
   notificationFactory.build({ type: 'reboot_scheduled', severity: 'minor' }),
   notificationFactory.build({ type: 'outage', severity: 'critical' }),
-  notificationFactory.build({ type: 'payment_due', severity: 'major' }),
   notificationFactory.build({ type: 'ticket_important', severity: 'minor' }),
   notificationFactory.build({ type: 'ticket_abuse', severity: 'critical' }),
   notificationFactory.build({ type: 'notice', severity: 'major' }),


### PR DESCRIPTION
## Description
This change was needed because of some recent ui changes to this page

**What does this PR do?**
just a small stackscripts e2e test update

## How to test
- `yarn up` in one terminal
- `yarn cy:e2e -s ./cypress/integration/account/smoke-billing-contact.spec.ts` in another
Also:
-  `yarn cy:e2e -s ./cypress/integration/notificationsAndEvents/notifications.spec.ts`
- Result should be "✔  All specs passed!"

## Make sure your .env contains:
```
REACT_APP_LOGIN_ROOT
REACT_APP_API_ROOT
REACT_APP_APP_ROOT
REACT_APP_LAUNCH_DARKLY_ID
REACT_APP_CLIENT_ID
MANAGER_OAUTH
```