### PR TITLE
M3-5150: updated event text for domain record creation and update

### DIFF
--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -156,12 +156,10 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
     notification: (e) => `Domain ${e.entity!.label} has been deleted.`,
   },
   domain_record_create: {
-    notification: (e) =>
-      `A domain record has been created for ${e.entity!.label}`,
+    notification: (e) => `${e.message} added to ${e.entity!.label}`,
   },
   domain_record_update: {
-    notification: (e) =>
-      `A domain record has been updated for ${e.entity!.label}`,
+    notification: (e) => `${e.message} updated for ${e.entity!.label}`,
   },
   domain_record_delete: {
     notification: (e) =>
@@ -692,12 +690,6 @@ export default (e: Event): string => {
     eventMessageCreators
   );
 
-  if (e.message) {
-    // If the API has specified a message for this event, rely on that instead of
-    // our custom logic.
-    return formatEventWithAPIMessage(e);
-  }
-
   /** we couldn't find the event in our list above */
   if (!fn) {
     /** log unknown events to the console */
@@ -710,7 +702,9 @@ export default (e: Event): string => {
     }
 
     /** finally return some default fallback text */
-    return `${e.action}${e.entity ? ` on ${e.entity.label}` : ''}`;
+    return e.message
+      ? formatEventWithAPIMessage(e)
+      : `${e.action}${e.entity ? ` on ${e.entity.label}` : ''}`;
   }
 
   let message = '';


### PR DESCRIPTION
## Description

Updates the logic for displaying an event when the API sends us an optional message. This change allows us to use the API's message in our own message we generate. 

Domain record creation and update event messages now use our own message combined with what the API gives as a message. 

## How to test

View your events in the drawer or on the Events landing page and verify that the message for domain record creation and updates are more descriptive and grammatically correct. 