### PR TITLE
M3-5208: Fix Domains table header for large accounts

### DIFF
--- a/packages/manager/src/components/EntityTable/APIPaginatedTable.tsx
+++ b/packages/manager/src/components/EntityTable/APIPaginatedTable.tsx
@@ -9,9 +9,14 @@ import TableContentWrapper from 'src/components/TableContentWrapper';
 import EntityTableHeader from './EntityTableHeader';
 import { Entity, ListProps, PageyIntegrationProps } from './types';
 
+interface Props {
+  isLargeAccount?: boolean;
+}
+
 export type CombinedProps = ListProps &
   PaginationProps<Entity> &
-  PageyIntegrationProps;
+  PageyIntegrationProps &
+  Props;
 
 export const APIPaginatedTable: React.FC<CombinedProps> = (props) => {
   const {
@@ -33,6 +38,7 @@ export const APIPaginatedTable: React.FC<CombinedProps> = (props) => {
     emptyMessage,
     toggleGroupByTag,
     isGroupedByTag,
+    isLargeAccount,
   } = props;
 
   const _data = data ?? [];
@@ -60,6 +66,7 @@ export const APIPaginatedTable: React.FC<CombinedProps> = (props) => {
             handleOrderChange={props.handleOrderChange}
             toggleGroupByTag={toggleGroupByTag}
             isGroupedByTag={isGroupedByTag}
+            isLargeAccount={isLargeAccount}
           />
           <TableBody>
             <TableContentWrapper

--- a/packages/manager/src/components/EntityTable/APIPaginatedTable.tsx
+++ b/packages/manager/src/components/EntityTable/APIPaginatedTable.tsx
@@ -31,6 +31,8 @@ export const APIPaginatedTable: React.FC<CombinedProps> = (props) => {
     initialOrder,
     RowComponent,
     emptyMessage,
+    toggleGroupByTag,
+    isGroupedByTag,
   } = props;
 
   const _data = data ?? [];
@@ -56,6 +58,8 @@ export const APIPaginatedTable: React.FC<CombinedProps> = (props) => {
             order={props.order}
             orderBy={props.orderBy ?? 'asc'}
             handleOrderChange={props.handleOrderChange}
+            toggleGroupByTag={toggleGroupByTag}
+            isGroupedByTag={isGroupedByTag}
           />
           <TableBody>
             <TableContentWrapper

--- a/packages/manager/src/components/EntityTable/APIPaginatedTable.tsx
+++ b/packages/manager/src/components/EntityTable/APIPaginatedTable.tsx
@@ -4,7 +4,7 @@ import Paper from 'src/components/core/Paper';
 import TableBody from 'src/components/core/TableBody';
 import Pagey, { PaginationProps } from 'src/components/Pagey';
 import PaginationFooter from 'src/components/PaginationFooter';
-import Table from 'src/components/Table';
+import Table from 'src/components/Table/Table_CMR';
 import TableContentWrapper from 'src/components/TableContentWrapper';
 import EntityTableHeader from './EntityTableHeader';
 import { Entity, ListProps, PageyIntegrationProps } from './types';

--- a/packages/manager/src/components/EntityTable/EntityTableHeader.tsx
+++ b/packages/manager/src/components/EntityTable/EntityTableHeader.tsx
@@ -190,6 +190,8 @@ export const GroupByTagToggle: React.FC<GroupByTagToggleProps> = React.memo(
             onClick={toggleGroupByTag}
             disableRipple
             className={classes.toggleButton}
+            // Group by Tag is only available when you have less than 500 Domains
+            // See https://github.com/linode/manager/pull/6653 for more details
             disabled={isLargeAccount}
           >
             <GroupByTag />

--- a/packages/manager/src/components/EntityTable/EntityTableHeader.tsx
+++ b/packages/manager/src/components/EntityTable/EntityTableHeader.tsx
@@ -14,25 +14,14 @@ import { HeaderCell } from './types';
 const useStyles = makeStyles((theme: Theme) => ({
   hiddenHeaderCell: theme.visually.hidden,
   sortCell: {
-    fontFamily: theme.font.bold,
-    padding: '10px 15px',
     '& .MuiTableSortLabel-active:hover': {
       color: theme.palette.primary.main,
     },
   },
-  thead: {
-    '& p': {
-      fontFamily: theme.font.bold,
-      fontWeight: 500,
-    },
-  },
-  '& .MuiTableCell-head': {
-    borderBottom: 0,
-  },
   groupByTagCell: {
-    textAlign: 'right',
     backgroundColor: theme.cmrBGColors.bgTableHeader,
     paddingRight: `0px !important`,
+    textAlign: 'right',
   },
 }));
 
@@ -83,7 +72,6 @@ export const EntityTableHeader: React.FC<Props> = (props) => {
     return (
       <TableCell
         data-testid={`${thisCell.label}-header-cell`}
-        className={classes.thead}
         style={{ width: `${thisCell.widthPercent}%` }}
       >
         <span

--- a/packages/manager/src/components/EntityTable/EntityTableHeader.tsx
+++ b/packages/manager/src/components/EntityTable/EntityTableHeader.tsx
@@ -13,11 +13,6 @@ import { HeaderCell } from './types';
 
 const useStyles = makeStyles((theme: Theme) => ({
   hiddenHeaderCell: theme.visually.hidden,
-  sortCell: {
-    '& .MuiTableSortLabel-active:hover': {
-      color: theme.palette.primary.main,
-    },
-  },
   groupByTagCell: {
     backgroundColor: theme.cmrBGColors.bgTableHeader,
     paddingRight: `0px !important`,
@@ -60,7 +55,6 @@ export const EntityTableHeader: React.FC<Props> = (props) => {
         label={thisCell.dataColumn}
         direction={order}
         handleClick={handleOrderChange}
-        className={classes.sortCell}
         style={{ width: `${thisCell.widthPercent}%` }}
         data-testid={`${thisCell.label}-header-cell`}
       >

--- a/packages/manager/src/components/EntityTable/EntityTableHeader.tsx
+++ b/packages/manager/src/components/EntityTable/EntityTableHeader.tsx
@@ -8,18 +8,16 @@ import TableRow from 'src/components/core/TableRow';
 import Tooltip from 'src/components/core/Tooltip';
 import { OrderByProps } from 'src/components/OrderBy';
 import TableCell from 'src/components/TableCell';
-import TableSortCell from 'src/components/TableSortCell';
-import TableSortCell_CMR from 'src/components/TableSortCell/TableSortCell_CMR';
-import useFlags from 'src/hooks/useFlags';
+import TableSortCell from 'src/components/TableSortCell/TableSortCell_CMR';
 import { HeaderCell } from './types';
 
 const useStyles = makeStyles((theme: Theme) => ({
   hiddenHeaderCell: theme.visually.hidden,
-  root: {
-    '& td': {
-      borderTop: 0,
-      paddingLeft: '15px',
-      paddingRight: '15px',
+  sortCell: {
+    fontFamily: theme.font.bold,
+    padding: '10px 15px',
+    '& .MuiTableSortLabel-active:hover': {
+      color: theme.palette.primary.main,
     },
   },
   thead: {
@@ -62,23 +60,21 @@ export const EntityTableHeader: React.FC<Props> = (props) => {
     isGroupedByTag,
   } = props;
   const classes = useStyles();
-  const flags = useFlags();
 
-  const SortCell = flags.cmr ? TableSortCell_CMR : TableSortCell;
-
-  const _SortCell: React.FC<SortCellProps> = (props) => {
+  const SortCell: React.FC<SortCellProps> = (props) => {
     const { orderBy, order, thisCell, handleOrderChange } = props;
     return (
-      <SortCell
+      <TableSortCell
         active={orderBy === thisCell.dataColumn}
         label={thisCell.dataColumn}
         direction={order}
         handleClick={handleOrderChange}
+        className={classes.sortCell}
         style={{ width: `${thisCell.widthPercent}%` }}
         data-testid={`${thisCell.label}-header-cell`}
       >
         {thisCell.label}
-      </SortCell>
+      </TableSortCell>
     );
   };
 
@@ -108,7 +104,7 @@ export const EntityTableHeader: React.FC<Props> = (props) => {
           thisCell.sortable ? (
             thisCell.hideOnTablet ? (
               <Hidden smDown key={thisCell.dataColumn}>
-                <_SortCell
+                <SortCell
                   thisCell={thisCell}
                   order={order}
                   orderBy={orderBy}
@@ -117,7 +113,7 @@ export const EntityTableHeader: React.FC<Props> = (props) => {
               </Hidden>
             ) : thisCell.hideOnMobile ? (
               <Hidden xsDown key={thisCell.dataColumn}>
-                <_SortCell
+                <SortCell
                   thisCell={thisCell}
                   order={order}
                   orderBy={orderBy}
@@ -125,7 +121,7 @@ export const EntityTableHeader: React.FC<Props> = (props) => {
                 />
               </Hidden>
             ) : (
-              <_SortCell
+              <SortCell
                 thisCell={thisCell}
                 key={thisCell.dataColumn}
                 order={order}

--- a/packages/manager/src/components/EntityTable/EntityTableHeader.tsx
+++ b/packages/manager/src/components/EntityTable/EntityTableHeader.tsx
@@ -29,6 +29,7 @@ interface Props extends Omit<OrderByProps, 'data'> {
   headers: HeaderCell[];
   toggleGroupByTag?: () => boolean;
   isGroupedByTag?: boolean;
+  isLargeAccount?: boolean;
 }
 
 interface SortCellProps extends Omit<Props, 'headers'> {
@@ -47,6 +48,7 @@ export const EntityTableHeader: React.FC<Props> = (props) => {
     orderBy,
     toggleGroupByTag,
     isGroupedByTag,
+    isLargeAccount,
   } = props;
   const classes = useStyles();
 
@@ -136,6 +138,7 @@ export const EntityTableHeader: React.FC<Props> = (props) => {
         {toggleGroupByTag && typeof isGroupedByTag !== 'undefined' ? (
           <TableCell className={classes.groupByTagCell}>
             <GroupByTagToggle
+              isLargeAccount={isLargeAccount}
               toggleGroupByTag={toggleGroupByTag}
               isGroupedByTag={isGroupedByTag}
             />
@@ -154,6 +157,7 @@ export default React.memo(EntityTableHeader);
 interface GroupByTagToggleProps {
   toggleGroupByTag: () => boolean;
   isGroupedByTag: boolean;
+  isLargeAccount?: boolean;
 }
 
 const useGroupByTagToggleStyles = makeStyles(() => ({
@@ -163,6 +167,9 @@ const useGroupByTagToggleStyles = makeStyles(() => ({
     '&:focus': {
       outline: '1px dotted #999',
     },
+    '&.Mui-disabled': {
+      display: 'none',
+    },
   },
 }));
 
@@ -170,7 +177,7 @@ export const GroupByTagToggle: React.FC<GroupByTagToggleProps> = React.memo(
   (props) => {
     const classes = useGroupByTagToggleStyles();
 
-    const { toggleGroupByTag, isGroupedByTag } = props;
+    const { toggleGroupByTag, isGroupedByTag, isLargeAccount } = props;
 
     return (
       <>
@@ -189,6 +196,7 @@ export const GroupByTagToggle: React.FC<GroupByTagToggleProps> = React.memo(
             onClick={toggleGroupByTag}
             disableRipple
             className={classes.toggleButton}
+            disabled={isLargeAccount}
           >
             <GroupByTag />
           </IconButton>

--- a/packages/manager/src/components/EntityTable/EntityTable_CMR.tsx
+++ b/packages/manager/src/components/EntityTable/EntityTable_CMR.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
-import { makeStyles, Theme } from 'src/components/core/styles';
+import { makeStyles } from 'src/components/core/styles';
 import { OrderByProps } from 'src/components/OrderBy';
 import APIPaginatedTable from './APIPaginatedTable';
 import GroupedEntitiesByTag from './GroupedEntitiesByTag_CMR';
 import ListEntities from './ListEntities_CMR';
 import type { EntityTableRow, PageyIntegrationProps } from './types';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  hiddenHeaderCell: theme.visually.hidden,
+const useStyles = makeStyles(() => ({
   root: {
     '& td': {
       borderTop: 0,
@@ -15,28 +14,20 @@ const useStyles = makeStyles((theme: Theme) => ({
       paddingRight: '15px',
     },
   },
-  '& .MuiTableCell-head': {
-    borderBottom: 0,
-  },
-  thead: {
-    '& p': {
-      fontFamily: theme.font.bold,
-      fontWeight: 500,
-    },
-  },
 }));
 
 interface Props {
   entity: string;
   headers: HeaderCell[];
-  emptyMessage?: string;
-  toggleGroupByTag?: () => boolean;
-  isGroupedByTag?: boolean;
   row: EntityTableRow<any>;
+  emptyMessage?: string;
   initialOrder?: {
     order: OrderByProps['order'];
     orderBy: OrderByProps['orderBy'];
   };
+  toggleGroupByTag?: () => boolean;
+  isGroupedByTag?: boolean;
+  isLargeAccount?: boolean;
 }
 
 export type CombinedProps = Props & PageyIntegrationProps;
@@ -44,12 +35,13 @@ export type CombinedProps = Props & PageyIntegrationProps;
 export const LandingTable: React.FC<CombinedProps> = (props) => {
   const {
     entity,
-    emptyMessage,
     headers,
     row,
+    emptyMessage,
     initialOrder,
     toggleGroupByTag,
     isGroupedByTag,
+    isLargeAccount,
   } = props;
   const classes = useStyles();
   const tableProps = {
@@ -58,14 +50,15 @@ export const LandingTable: React.FC<CombinedProps> = (props) => {
     error: row.error,
     loading: row.loading,
     lastUpdated: row.lastUpdated,
-    RowComponent: row.Component,
-    headers,
-    initialOrder,
     entity,
+    headers,
+    RowComponent: row.Component,
     handlers: row.handlers,
+    emptyMessage,
+    initialOrder,
     toggleGroupByTag,
     isGroupedByTag,
-    emptyMessage,
+    isLargeAccount,
   };
 
   if (row.request) {

--- a/packages/manager/src/features/Domains/DomainTableRow.tsx
+++ b/packages/manager/src/features/Domains/DomainTableRow.tsx
@@ -11,35 +11,8 @@ import ActionMenu, { Handlers } from './DomainActionMenu';
 import { getDomainDisplayType } from './domainUtils';
 
 const useStyles = makeStyles((theme: Theme) => ({
-  link: {
-    display: 'block',
-    lineHeight: '1.125rem',
-    color: theme.cmrTextColors.linkActiveLight,
-    '&:hover, &:focus': {
-      color: theme.palette.primary.main,
-      textDecoration: 'underline',
-    },
-  },
   button: {
     ...theme.applyLinkStyles,
-    display: 'block',
-    color: theme.cmrTextColors.linkActiveLight,
-    lineHeight: '1.125rem',
-    '&:hover, &:focus': {
-      color: theme.palette.primary.main,
-      textDecoration: 'underline',
-    },
-  },
-  domain: {
-    width: '60%',
-  },
-  domainRow: {
-    backgroundColor: theme.bg.white,
-  },
-  domainCellContainer: {
-    [theme.breakpoints.down('sm')]: {
-      textAlign: 'left',
-    },
   },
   labelStatusWrapper: {
     display: 'flex',
@@ -84,13 +57,13 @@ const DomainTableRow: React.FC<CombinedProps> = (props) => {
     <TableRow
       key={id}
       data-qa-domain-cell={domain}
-      className={`${classes.domainRow} ${'fade-in-table'}`}
+      className="fade-in-table"
       ariaLabel={`Domain ${domain}`}
     >
       <TableCell data-qa-domain-label>
         <div className={classes.labelStatusWrapper}>
           {type !== 'slave' ? (
-            <Link to={`/domains/${id}`} tabIndex={0} className={classes.link}>
+            <Link to={`/domains/${id}`} tabIndex={0}>
               {domain}
             </Link>
           ) : (

--- a/packages/manager/src/features/Domains/DomainsLanding.test.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.test.tsx
@@ -37,13 +37,7 @@ const props: CombinedProps = {
   enqueueSnackbar: jest.fn(),
   closeSnackbar: jest.fn(),
   classes: {
-    domain: '',
     root: '',
-    titleWrapper: '',
-    tagWrapper: '',
-    tagGroup: '',
-    title: '',
-    breadcrumbs: '',
     importButton: '',
   },
   domainsByID: {},

--- a/packages/manager/src/features/Domains/DomainsLanding.test.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.test.tsx
@@ -36,10 +36,6 @@ const props: CombinedProps = {
   openForEditing: jest.fn(),
   enqueueSnackbar: jest.fn(),
   closeSnackbar: jest.fn(),
-  classes: {
-    root: '',
-    importButton: '',
-  },
   domainsByID: {},
   upsertMultipleDomains: jest.fn(),
   ...reactRouterProps,

--- a/packages/manager/src/features/Domains/DomainsLanding.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.tsx
@@ -126,16 +126,16 @@ export const DomainsLanding: React.FC<CombinedProps> = (props) => {
   const {
     domainForEditing,
     domainsLastUpdated,
-    isLargeAccount,
-    openForEditing,
     getAllDomains,
-    deleteDomain,
-    domainsError,
+    openForEditing,
     domainsData,
     domainsLoading,
+    domainsError,
+    deleteDomain,
     howManyLinodesOnAccount,
-    isRestrictedUser,
     linodesLoading,
+    isRestrictedUser,
+    isLargeAccount,
   } = props;
 
   const [selectedDomainLabel, setSelectedDomainLabel] = React.useState<string>(

--- a/packages/manager/src/features/Domains/DomainsLanding.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.tsx
@@ -8,7 +8,12 @@ import { compose } from 'recompose';
 import DomainIcon from 'src/assets/icons/entityIcons/domain.svg';
 import Button from 'src/components/Button';
 import CircleProgress from 'src/components/CircleProgress';
-import { makeStyles, Theme } from 'src/components/core/styles';
+import {
+  makeStyles,
+  Theme,
+  useMediaQuery,
+  useTheme,
+} from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import DeletionDialog from 'src/components/DeletionDialog';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
@@ -77,37 +82,46 @@ export type CombinedProps = DispatchProps &
   StateProps &
   WithSnackbarProps;
 
-const headers: HeaderCell[] = [
-  {
-    label: 'Domain',
-    dataColumn: 'domain',
-    sortable: true,
-    widthPercent: 25,
-  },
-  {
-    label: 'Status',
-    dataColumn: 'status',
-    sortable: true,
-    widthPercent: 10,
-  },
-  {
-    label: 'Type',
-    dataColumn: 'type',
-    sortable: true,
-    widthPercent: 10,
-    hideOnMobile: true,
-  },
-  {
-    label: 'Last Modified',
-    dataColumn: 'updated',
-    sortable: true,
-    widthPercent: 20,
-    hideOnMobile: true,
-  },
-];
+const getHeaders = (
+  matchesXsDown: boolean,
+  matchesSmDown: boolean,
+  matchesMdDown: boolean
+): HeaderCell[] =>
+  [
+    {
+      label: 'Domain',
+      dataColumn: 'domain',
+      sortable: true,
+      widthPercent: matchesXsDown ? 50 : matchesSmDown ? 35 : 30,
+    },
+    {
+      label: 'Status',
+      dataColumn: 'status',
+      sortable: true,
+      widthPercent: matchesXsDown ? 25 : 12,
+    },
+    {
+      label: 'Type',
+      dataColumn: 'type',
+      sortable: true,
+      widthPercent: 12,
+      hideOnMobile: true,
+    },
+    {
+      label: 'Last Modified',
+      dataColumn: 'updated',
+      sortable: true,
+      widthPercent: matchesSmDown ? 25 : matchesMdDown ? 20 : 15,
+      hideOnMobile: true,
+    },
+  ].filter(Boolean) as HeaderCell[];
 
 export const DomainsLanding: React.FC<CombinedProps> = (props) => {
   const classes = useStyles();
+  const theme = useTheme<Theme>();
+  const matchesXsDown = useMediaQuery(theme.breakpoints.down('xs'));
+  const matchesSmDown = useMediaQuery(theme.breakpoints.down('sm'));
+  const matchesMdDown = useMediaQuery(theme.breakpoints.down('md'));
 
   const {
     domainForEditing,
@@ -364,7 +378,11 @@ export const DomainsLanding: React.FC<CombinedProps> = (props) => {
               />
               <EntityTable
                 entity="domain"
-                headers={headers}
+                headers={getHeaders(
+                  matchesXsDown,
+                  matchesSmDown,
+                  matchesMdDown
+                )}
                 row={domainRow}
                 initialOrder={initialOrder}
                 toggleGroupByTag={toggleGroupDomains}

--- a/packages/manager/src/features/Domains/DomainsLanding.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.tsx
@@ -404,11 +404,12 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
                 />
                 <EntityTable_CMR
                   entity="domain"
+                  headers={headers}
+                  row={domainRow}
+                  initialOrder={initialOrder}
                   toggleGroupByTag={toggleGroupDomains}
                   isGroupedByTag={domainsAreGrouped}
-                  row={domainRow}
-                  headers={headers}
-                  initialOrder={initialOrder}
+                  isLargeAccount={isLargeAccount}
                   normalizeData={(pageyData: Domain[]) => {
                     // Use Redux copies of each Domain, since Redux is more up-to-date.
                     return getReduxCopyOfDomains(

--- a/packages/manager/src/features/Domains/DomainsLanding.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.tsx
@@ -50,15 +50,7 @@ import DomainZoneImportDrawer from './DomainZoneImportDrawer';
 
 const DOMAIN_CREATE_ROUTE = '/domains/create';
 
-type ClassNames =
-  | 'root'
-  | 'titleWrapper'
-  | 'title'
-  | 'breadcrumbs'
-  | 'domain'
-  | 'tagWrapper'
-  | 'tagGroup'
-  | 'importButton';
+type ClassNames = 'root' | 'importButton';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -69,28 +61,6 @@ const styles = (theme: Theme) =>
           paddingBottom: theme.spacing(2),
         },
       },
-    },
-    titleWrapper: {
-      flex: 1,
-    },
-    title: {
-      marginBottom: theme.spacing(1) + theme.spacing(1) / 2,
-    },
-    breadcrumbs: {
-      marginBottom: theme.spacing(1),
-    },
-    domain: {
-      width: '60%',
-    },
-    tagWrapper: {
-      marginTop: theme.spacing(1) / 2,
-      '& [class*="MuiChip"]': {
-        cursor: 'pointer',
-      },
-    },
-    tagGroup: {
-      flexDirection: 'row-reverse',
-      marginBottom: theme.spacing(2) - 8,
     },
     importButton: {
       marginLeft: -theme.spacing(),


### PR DESCRIPTION
## Description

Tables using the `APIPaginatedTable` component did not have the right styling and are missing the last column in the header since the props weren't being passed down.

## How to test

Login to `prod-test-001` and go to `/domains`
