### PR TITLE
M3-5203: Remove "beta" tag from Machine Images

### DIFF
--- a/packages/manager/src/features/Images/ImageUpload.tsx
+++ b/packages/manager/src/features/Images/ImageUpload.tsx
@@ -4,12 +4,10 @@ import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
-import Chip from 'src/components/core/Chip';
 import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import RegionSelect from 'src/components/EnhancedSelect/variants/RegionSelect';
-import Link from 'src/components/Link';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
 import { Dispatch } from 'src/hooks/types';
@@ -20,7 +18,6 @@ import { getErrorMap } from 'src/utilities/errorUtils';
 const useStyles = makeStyles((theme: Theme) => ({
   container: {
     minWidth: '100%',
-    padding: theme.spacing(3),
     paddingTop: theme.spacing(),
     paddingBottom: theme.spacing(),
     '& .MuiFormHelperText-root': {
@@ -29,14 +26,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   helperText: {
     marginTop: theme.spacing(2),
-  },
-  chip: {
-    fontSize: '0.625rem',
-    height: 15,
-    marginBottom: 4,
-    lineHeight: '1px',
-    letterSpacing: '.25px',
-    textTransform: 'uppercase',
   },
 }));
 export interface Props {
@@ -93,15 +82,11 @@ export const ImageUpload: React.FC<Props> = (props) => {
 
   return (
     <Paper className={classes.container}>
-      <Typography style={{ marginTop: 16 }}>
-        <Chip className={classes.chip} label="beta" component="span" />
-        Image Uploads is currently in beta and is subject to the terms of the{' '}
-        <Link to="https://www.linode.com/legal-eatp/">
-          Early Adopter Testing Agreement
-        </Link>
-        .
-      </Typography>
-      {errorMap.none ? <Notice error text={errorMap.none} /> : null}
+      {errorMap.none ? (
+        <div style={{ marginTop: 16 }}>
+          <Notice error text={errorMap.none} />
+        </div>
+      ) : null}
       <div style={{ width: '100%' }}>
         <TextField
           label="Label (required)"


### PR DESCRIPTION
## Description

Remove beta chip, text and link from Machine Images after confirming that Machine Images is in GA

## How to test

1. Go to `/images`
2. Click on the "Create Image" button
3. Click on the "Upload Image" tab
4. The beta tag should no longer be above the label textfield
