### PR TITLE
M3-5230: Added new payment endpoints and validation

### DIFF
--- a/packages/api-v4/src/account/payments.ts
+++ b/packages/api-v4/src/account/payments.ts
@@ -181,9 +181,14 @@ export const getClientToken = () => {
  * Adds a new payment method to a user's account via a nonce.
  *
  * @param data { object }
- * @param data.nonce { string } the nonce for the payment method to be added
+ * @param data.type { string } 'credit_card' or 'payment_method_nonce'
  * @param data.is_default { boolean } whether of not this payment method should
- * become a user's default method of payment
+ * @param data.data { object } this will be data containting a nonce or credit card info
+ * @param data.data.nonce { string } the nonce for the payment method to be added
+ * @param data.data.card_number { string } a credit card number
+ * @param data.data.expiry_year { number } credit card's expiry year
+ * @param data.data.expiry_month { number } credit card's expiry month
+ * @param data.data.cvv { string } credit card's cvv
  *
  */
 export const addPaymentMethod = (data: PaymentMethodData) => {

--- a/packages/api-v4/src/account/payments.ts
+++ b/packages/api-v4/src/account/payments.ts
@@ -5,7 +5,7 @@ import {
   StagePaypalPaymentSchema,
   PaymentMethodSchema,
 } from '@linode/validation/lib/account.schema';
-import { API_ROOT } from '../constants';
+import { API_ROOT, BETA_API_ROOT } from '../constants';
 import Request, {
   setData,
   setMethod,
@@ -155,7 +155,7 @@ export const saveCreditCard = (data: SaveCreditCardData) => {
  */
 export const getPaymentMethods = (params?: any) => {
   return Request<ResourcePage<PaymentMethod>>(
-    setURL(`${API_ROOT}/account/payment-methods`),
+    setURL(`${BETA_API_ROOT}/account/payment-methods`),
     setMethod('GET'),
     setParams(params)
   );

--- a/packages/api-v4/src/account/payments.ts
+++ b/packages/api-v4/src/account/payments.ts
@@ -5,7 +5,7 @@ import {
   StagePaypalPaymentSchema,
   PaymentMethodSchema,
 } from '@linode/validation/lib/account.schema';
-import { API_ROOT, BETA_API_ROOT } from '../constants';
+import { API_ROOT } from '../constants';
 import Request, {
   setData,
   setMethod,
@@ -155,7 +155,7 @@ export const saveCreditCard = (data: SaveCreditCardData) => {
  */
 export const getPaymentMethods = (params?: any) => {
   return Request<ResourcePage<PaymentMethod>>(
-    setURL(`${BETA_API_ROOT}/account/payment-methods`),
+    setURL(`${API_ROOT}/account/payment-methods`),
     setMethod('GET'),
     setParams(params)
   );

--- a/packages/api-v4/src/account/payments.ts
+++ b/packages/api-v4/src/account/payments.ts
@@ -3,6 +3,7 @@ import {
   ExecutePaypalPaymentSchema,
   PaymentSchema,
   StagePaypalPaymentSchema,
+  PaymentMethodSchema,
 } from '@linode/validation/lib/account.schema';
 import { API_ROOT } from '../constants';
 import Request, {
@@ -14,12 +15,16 @@ import Request, {
 } from '../request';
 import { ResourcePage } from '../types';
 import {
+  ClientToken,
   ExecutePayload,
   Payment,
+  PaymentMethod,
   PaymentResponse,
   Paypal,
   PaypalResponse,
   SaveCreditCardData,
+  PaymentMethodData,
+  MakePaymentData,
 } from './types';
 
 /**
@@ -41,15 +46,17 @@ export const getPayments = (params?: any, filter?: any) =>
  * makePayment
  *
  * Make a payment using the currently active credit card on your
- * account.
+ * account, a nonce, or by another payment method on your account
+ * (by providing its id).
  *
  * @param data { object }
  * @param data.usd { string } the dollar amount of the payment
  * @param data.cvv { string } the 3-digit code on the back of the
- * credit card.
+ * @param data.nonce { string } the payment nonce to make a one time payment
+ * @param data.payment_method_id { number } the payment nonce to make a one time payment
  *
  */
-export const makePayment = (data: { usd: string; cvv?: string }) => {
+export const makePayment = (data: MakePaymentData) => {
   /**
    * in the context of APIv4, CVV is optional - in other words, it's totally
    * valid to submit a payment without a CVV
@@ -136,5 +143,53 @@ export const saveCreditCard = (data: SaveCreditCardData) => {
     setURL(`${API_ROOT}/account/credit-card`),
     setMethod('POST'),
     setData(data, CreditCardSchema)
+  );
+};
+
+/**
+ * getPaymentMethods
+ *
+ * Gets a paginatated list of all the payment methods avalible
+ * on a user's account
+ *
+ */
+export const getPaymentMethods = (params?: any) => {
+  return Request<ResourcePage<PaymentMethod>>(
+    setURL(`${API_ROOT}/account/payment-methods`),
+    setMethod('GET'),
+    setParams(params)
+  );
+};
+
+/**
+ * getClientToken
+ *
+ * Gets a unique token that is used to interact with the
+ * Braintree front-end SDK
+ *
+ */
+export const getClientToken = () => {
+  return Request<ClientToken>(
+    setURL(`${API_ROOT}/account/client-token`),
+    setMethod('GET')
+  );
+};
+
+/**
+ * addPaymentMethod
+ *
+ * Adds a new payment method to a user's account via a nonce.
+ *
+ * @param data { object }
+ * @param data.nonce { string } the nonce for the payment method to be added
+ * @param data.is_default { boolean } whether of not this payment method should
+ * become a user's default method of payment
+ *
+ */
+export const addPaymentMethod = (data: PaymentMethodData) => {
+  return Request<{}>(
+    setURL(`${API_ROOT}/account/payment-methods`),
+    setMethod('POST'),
+    setData(data, PaymentMethodSchema)
   );
 };

--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -376,7 +376,7 @@ export interface AccountMaintenance {
 
 export interface PaymentMethod {
   method: string;
-  is_default: number; // bruh
+  is_default: boolean;
   created: string;
   data: {
     card_type: string;

--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -390,6 +390,8 @@ export interface ClientToken {
 }
 
 export interface PaymentMethodData {
+  type: 'credit_card' | 'payment_method_nonce';
+  data: SaveCreditCardData | { nonce: string };
   nonce: string;
   is_default: boolean;
 }

--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -375,7 +375,7 @@ export interface AccountMaintenance {
 }
 
 export interface PaymentMethod {
-  method: string;
+  type: string;
   is_default: boolean;
   created: string;
   data: {

--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -373,3 +373,30 @@ export interface AccountMaintenance {
     url: string;
   };
 }
+
+export interface PaymentMethod {
+  method: string;
+  is_default: number; // bruh
+  created: string;
+  data: {
+    card_type: string;
+    last_four: string;
+    expiry: string;
+  };
+}
+
+export interface ClientToken {
+  client_token: string;
+}
+
+export interface PaymentMethodData {
+  nonce: string;
+  is_default: boolean;
+}
+
+export interface MakePaymentData {
+  usd: string;
+  cvv?: string;
+  nonce?: string;
+  payment_method_id?: number;
+}

--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -392,7 +392,6 @@ export interface ClientToken {
 export interface PaymentMethodData {
   type: 'credit_card' | 'payment_method_nonce';
   data: SaveCreditCardData | { nonce: string };
-  nonce: string;
   is_default: boolean;
 }
 

--- a/packages/validation/src/account.schema.ts
+++ b/packages/validation/src/account.schema.ts
@@ -69,7 +69,17 @@ export const CreditCardSchema = object({
 });
 
 export const PaymentMethodSchema = object({
-  nonce: string().required('Payment nonce is required.'),
+  type: mixed().oneOf(
+    ['credit_card', 'payment_method_nonce'],
+    'Type must be credit_card or payment_method_nonce.'
+  ),
+  data: object().when('type', {
+    is: (value) => value === 'credit_card',
+    then: CreditCardSchema,
+    otherwise: object({
+      nonce: string().required('Payment nonce is required.'),
+    }),
+  }),
   is_default: boolean().required(
     'You must indicate if this should be your default method of payment.'
   ),

--- a/packages/validation/src/account.schema.ts
+++ b/packages/validation/src/account.schema.ts
@@ -68,6 +68,13 @@ export const CreditCardSchema = object({
     .max(4, 'CVV code must be between 3 and 4 characters.'),
 });
 
+export const PaymentMethodSchema = object({
+  nonce: string().required('Payment nonce is required.'),
+  is_default: boolean().required(
+    'You must indicate if this should be your default method of payment.'
+  ),
+});
+
 export const CreateUserSchema = object({
   username: string()
     .required('Username is required.')


### PR DESCRIPTION
## Description

Adds new payment endpoints with respective validation.

Updates

- `POST` `https://api.linode.com/v4/account/payments`

Adds

- `GET` `https://api.linode.com/v4/account/payment-methods`
- `POST` `https://api.linode.com/v4/account/payment-methods`
  - Add validation with `PaymentMethodSchema`
- `GET` `https://api.linode.com/v4/account/client-token`

## How to test

Test payment endpoints in`@linode/api-v4` and `@linode/validation`.