### PR TITLE
E2E Update: Firewall

### DIFF
--- a/packages/manager/cypress/integration/firewall/migrate-linode-with-firewall.spec.ts
+++ b/packages/manager/cypress/integration/firewall/migrate-linode-with-firewall.spec.ts
@@ -230,7 +230,7 @@ describe('Migrate Linode With Firewall', () => {
         containsVisible(`Migrate Linode ${linode.label}`);
         getClick('[data-qa-checked="false"]');
         fbtClick(selectRegionString);
-        fbtClick('Dallas, TX');
+        fbtClick('Newark, NJ');
         validateBlockedMigration();
 
         if (!cy.findByText('Linode busy.').should('not.exist')) {


### PR DESCRIPTION
## Description
firewalls have been added to dallas. this is a negative test so needed to change region to non firewall

**What does this PR do?**
just a small firewall e2e test update

## How to test
- `yarn up` in one terminal
- `yarn cy:e2e -s ./cypress/integration/firewall/migrate-linode-with-firewall.spec.ts` in another
- Result should be "✔  All specs passed!"

## Make sure your .env contains:
```
REACT_APP_LOGIN_ROOT
REACT_APP_API_ROOT
REACT_APP_APP_ROOT
REACT_APP_LAUNCH_DARKLY_ID
REACT_APP_CLIENT_ID
MANAGER_OAUTH
```