### PR TITLE
Hotfix: Referral Banner

### DIFF
--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -37,7 +37,7 @@ export interface Flags {
   additionalPaymentMethods: AdditionalPaymentMethod[];
   imagesPricingBanner: ImagesPricingBanner;
   imagesPricingCopy: ImagesPricingCopy;
-  referralChangeBanner: boolean;
+  referralBannerText: ReferralBannerText;
 }
 
 type PromotionalOfferFeature =
@@ -101,4 +101,12 @@ export interface ImagesPricingBanner {
 export interface ImagesPricingCopy {
   captureImage: string;
   uploadImage: string;
+}
+
+interface ReferralBannerText {
+  text: string;
+  link?: {
+    text: string;
+    url: string;
+  };
 }

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -37,6 +37,7 @@ export interface Flags {
   additionalPaymentMethods: AdditionalPaymentMethod[];
   imagesPricingBanner: ImagesPricingBanner;
   imagesPricingCopy: ImagesPricingCopy;
+  referralChangeBanner: boolean;
 }
 
 type PromotionalOfferFeature =

--- a/packages/manager/src/features/Profile/Referrals/Referrals.tsx
+++ b/packages/manager/src/features/Profile/Referrals/Referrals.tsx
@@ -58,16 +58,14 @@ class Referrals extends React.Component<CombinedProps, {}> {
             <Typography variant="h2" data-qa-title>
               Referrals
             </Typography>
-            {flags.referralChangeBanner ? (
+            {flags.referralBannerText?.text ? (
               <Notice warning spacingTop={16} spacingBottom={16}>
-                We’re updating our customer referral program on July 1, 2021.
-                Afterwards, referred customers will receive a $100, 60-day
-                credit. Once that referral bills $25 of services, you will
-                receive a $25 non-expiring credit. Learn more about eligibility{' '}
-                <Link to="https://www.linode.com/promotional-policy/">
-                  here
-                </Link>
-                .
+                {flags.referralBannerText.text}{' '}
+                {flags.referralBannerText.link ? (
+                  <Link to={flags.referralBannerText?.link?.url}>
+                    {flags.referralBannerText.link?.text}
+                  </Link>
+                ) : null}
               </Notice>
             ) : null}
           </Grid>

--- a/packages/manager/src/features/Profile/Referrals/Referrals.tsx
+++ b/packages/manager/src/features/Profile/Referrals/Referrals.tsx
@@ -13,6 +13,11 @@ import {
 import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
+import Link from 'src/components/Link';
+import Notice from 'src/components/Notice';
+import withFeatureFlags, {
+  FeatureFlagConsumerProps,
+} from 'src/containers/withFeatureFlagConsumer.container';
 import { MapState } from 'src/store/types';
 
 type ClassNames = 'results' | 'copyField';
@@ -27,7 +32,9 @@ const styles = (theme: Theme) =>
     },
   });
 
-type CombinedProps = StateProps & WithStyles<ClassNames>;
+type CombinedProps = StateProps &
+  WithStyles<ClassNames> &
+  FeatureFlagConsumerProps;
 
 class Referrals extends React.Component<CombinedProps, {}> {
   render() {
@@ -40,6 +47,7 @@ class Referrals extends React.Component<CombinedProps, {}> {
       completed,
       pending,
       credit,
+      flags,
     } = this.props;
 
     return (
@@ -50,6 +58,18 @@ class Referrals extends React.Component<CombinedProps, {}> {
             <Typography variant="h2" data-qa-title>
               Referrals
             </Typography>
+            {flags.referralChangeBanner ? (
+              <Notice warning spacingTop={16} spacingBottom={16}>
+                We’re updating our customer referral program on July 1, 2021.
+                Afterwards, referred customers will receive a $100, 60-day
+                credit. Once that referral bills $25 of services, you will
+                receive a $25 non-expiring credit. Learn more about eligibility{' '}
+                <Link to="https://www.linode.com/promotional-policy/">
+                  here
+                </Link>
+                .
+              </Notice>
+            ) : null}
           </Grid>
           <Grid item xs={12}>
             <Typography>
@@ -119,6 +139,10 @@ const mapStateToProps: MapState<StateProps, {}> = (state) => {
 
 const connected = connect(mapStateToProps);
 
-const enhanced = compose<CombinedProps, {}>(styled, connected);
+const enhanced = compose<CombinedProps, {}>(
+  styled,
+  connected,
+  withFeatureFlags
+);
 
 export default enhanced(Referrals);


### PR DESCRIPTION
## Description

**What does this PR do?**

Adds a Notice component to the referrals page. The presence of this Notice, along with the content, is sources from Launch Darkly.

<img width="1305" alt="Screen Shot 2021-06-17 at 3 18 31 PM" src="https://user-images.githubusercontent.com/16911484/122459763-4deb6200-cf7f-11eb-8ed1-cf39e0944711.png">

## How to test

**What are the steps to reproduce the issue or verify the changes?**

Go to profile/referrals. Test with and without the flag (in the test environment).

**How do I run relevant unit tests?**
N/A.

