### PR TITLE
M3-5133: Fix bug that prevented /dev/sdh Block Device from showing up 

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -414,6 +414,8 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
     volumes: props.volumes,
   };
 
+  const deviceSlots = ['sda', 'sdb', 'sdc', 'sdd', 'sde', 'sdf', 'sdg', 'sdh'];
+
   /**
    * Form change handlers
    * (where formik.handleChange is insufficient)
@@ -683,7 +685,7 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
               <Typography variant="h3">Block Device Assignment</Typography>
               <DeviceSelection
                 counter={deviceCounter}
-                slots={['sda', 'sdb', 'sdc', 'sdd', 'sde', 'sdf', 'sdg', 'sdh']}
+                slots={deviceSlots}
                 devices={availableDevices}
                 onChange={handleDevicesChanges}
                 getSelected={(slot) => pathOr('', [slot], values.devices)}
@@ -694,7 +696,7 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
                 buttonType="secondary"
                 superCompact
                 onClick={() => setDeviceCounter((counter) => counter + 1)}
-                disabled={readOnly || deviceCounter >= 7}
+                disabled={readOnly || deviceCounter >= deviceSlots.length - 1}
               >
                 Add a Device
               </Button>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -694,7 +694,7 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
                 buttonType="secondary"
                 superCompact
                 onClick={() => setDeviceCounter((counter) => counter + 1)}
-                disabled={readOnly || deviceCounter >= 6}
+                disabled={readOnly || deviceCounter >= 7}
               >
                 Add a Device
               </Button>


### PR DESCRIPTION
## Description
When editing a Linode's default config or adding a new one, clicking the "Add a Device" button should be possible until you reach `/dev/sdh`. Users were being blocked from getting there because the condition disabling the button was set 1 lower than it should've been. 

## How to test
Edit default configs and add new ones from a Linode's "Configurations" tab. Confirm that clicking the "Add a Device" button until it is disabled takes you up to `/dev/sdh`. Save Changes/Add Configuration and confirm that the proper disks/volumes are tied to the Block Devices you assigned them to.
