### PR TITLE
Add analytics for Image Uploads

### DIFF
--- a/packages/manager/src/components/CopyTooltip/CopyTooltip.tsx
+++ b/packages/manager/src/components/CopyTooltip/CopyTooltip.tsx
@@ -16,6 +16,7 @@ interface Props {
   standAlone?: boolean;
   ariaLabel?: string;
   displayText?: string;
+  onClickCallback?: () => void;
 }
 
 interface State {
@@ -100,6 +101,9 @@ class CopyTooltip extends React.Component<CombinedProps, State> {
     });
     window.setTimeout(() => this.setState({ copied: false }), 1500);
     copy(this.props.text);
+    if (this.props.onClickCallback) {
+      this.props.onClickCallback();
+    }
   };
 
   render() {

--- a/packages/manager/src/components/FileUploader/FileUploader.tsx
+++ b/packages/manager/src/components/FileUploader/FileUploader.tsx
@@ -19,7 +19,6 @@ import {
   MAX_PARALLEL_UPLOADS,
   pathOrFileName,
 } from 'src/features/ObjectStorage/ObjectUploader/reducer';
-import { Dispatch } from 'src/hooks/types';
 import { useCurrentToken } from 'src/hooks/useAuthentication';
 import { redirectToLogin } from 'src/session';
 import { uploadImage } from 'src/store/image/image.requests';
@@ -262,7 +261,6 @@ const FileUploader: React.FC<CombinedProps> = (props) => {
 
         dispatchAction(setPendingUpload(false));
 
-        // @analytics
         recordImageAnalytics('success', file);
 
         // EDGE CASE:

--- a/packages/manager/src/components/LinodeCLIModal/LinodeCLIModal.tsx
+++ b/packages/manager/src/components/LinodeCLIModal/LinodeCLIModal.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { makeStyles, Theme } from 'src/components/core/styles';
-import Typography from 'src/components/core/Typography';
 import Dialog from 'src/components/Dialog';
 import CopyTooltip from '../CopyTooltip';
+import { sendCLIClickEvent } from 'src/utilities/ga';
 
 const useStyles = makeStyles((theme: Theme) => ({
   dialog: {
@@ -58,12 +58,13 @@ interface Props {
   isOpen: boolean;
   onClose: () => void;
   command: string;
+  analyticsKey?: string;
 }
 
 export type CombinedProps = Props;
 
 export const ImageUploadSuccessDialog: React.FC<Props> = (props) => {
-  const { isOpen, onClose, command } = props;
+  const { isOpen, onClose, command, analyticsKey } = props;
   const classes = useStyles();
 
   return (
@@ -75,10 +76,16 @@ export const ImageUploadSuccessDialog: React.FC<Props> = (props) => {
       className={classes.dialog}
     >
       <div className={classes.commandAndCopy}>
-        <Typography className={classes.commandDisplay}>
+        <div className={classes.commandDisplay}>
           <div className={classes.cliText}>{command}</div>{' '}
-          <CopyTooltip text={command} className={classes.copyIcon} />
-        </Typography>
+          <CopyTooltip
+            text={command}
+            className={classes.copyIcon}
+            onClickCallback={
+              analyticsKey ? () => sendCLIClickEvent(analyticsKey) : undefined
+            }
+          />
+        </div>
       </div>
     </Dialog>
   );

--- a/packages/manager/src/features/Images/ImageUpload.tsx
+++ b/packages/manager/src/features/Images/ImageUpload.tsx
@@ -223,6 +223,7 @@ export const ImageUpload: React.FC<Props> = (props) => {
         isOpen={linodeCLIModalOpen}
         onClose={() => setLinodeCLIModalOpen(false)}
         command={linodeCLICommand}
+        analyticsKey="Image Upload"
       />
     </>
   );

--- a/packages/manager/src/utilities/ga.ts
+++ b/packages/manager/src/utilities/ga.ts
@@ -375,3 +375,18 @@ export const sendHelpButtonClickEvent = (buttonLabel: string) => {
     action: buttonLabel,
   });
 };
+
+export const sendCLIClickEvent = (action: string) => {
+  sendEvent({
+    category: 'Linode CLI Prompt',
+    action,
+  });
+};
+
+export const sendImageUploadEvent = (action: string, imageSize: string) => {
+  sendEvent({
+    category: 'Image Upload',
+    action,
+    label: imageSize,
+  });
+};


### PR DESCRIPTION
## Description

**What does this PR do?**

Add analytic events:

- When a user begins an image upload
- When an image upload is successful
- When an image upload fails
- When a user clicks "Copy" on the Image Upload CLI modal

The first three event types capture the file size. 

For the CLI Modal, I call the function on the generic LinodeCLIModal component if an `analyticsKey` prop is passed in (since we'll likely want to capture these events for future CLI modals.

## How to test

- Run the app with GA enabled
- Open the dev tools console
- Upload and image and notice the events being sent
- Open the CLI modal and click "Copy"; notice the event that is sent.

Also, I fixed an invalid DOM nesting console error in the LinodeCLIModal component.

