### PR TITLE
Fix console warning for Divider custom props

### DIFF
--- a/packages/manager/src/components/core/Divider.tsx
+++ b/packages/manager/src/components/core/Divider.tsx
@@ -27,7 +27,7 @@ interface Props extends _DividerProps {
 
 const _Divider: React.FC<Props> = (props) => {
   const classes = useStyles();
-  const { light, spacingTop, spacingBottom } = props;
+  const { light, spacingTop, spacingBottom, ...rest } = props;
 
   return (
     <Divider
@@ -36,7 +36,7 @@ const _Divider: React.FC<Props> = (props) => {
         [classes.light]: light,
       })}
       style={{ marginTop: spacingTop, marginBottom: spacingBottom }}
-      {...props}
+      {...rest}
     />
   );
 };


### PR DESCRIPTION
## Description

Fixes the `unknown-prop` warning that shows up in the console as a result of the custom props (`spacingTop`, `spacingBottom`) that I made for Divider. More information on that [here](https://reactjs.org/warnings/unknown-prop.html).

Passing the remaining properties as `...rest` should prevent the DOM from complaining

## How to test

Check the console to make sure that there's no longer an error
