### PR TITLE
M3-5179: Use React Query for account users endpoint

### DIFF
--- a/packages/manager/src/features/Users/UsersLanding.tsx
+++ b/packages/manager/src/features/Users/UsersLanding.tsx
@@ -1,11 +1,6 @@
-import { map as mapPromise } from 'bluebird';
-import { deleteUser, getUsers, User } from '@linode/api-v4/lib/account';
-import { APIError } from '@linode/api-v4/lib/types';
-import * as memoize from 'memoizee';
-import { withSnackbar, WithSnackbarProps } from 'notistack';
+import { deleteUser, User } from '@linode/api-v4/lib/account';
+import { useSnackbar } from 'notistack';
 import * as React from 'react';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
-import { compose } from 'recompose';
 import UserIcon from 'src/assets/icons/user.svg';
 import AddNewLink from 'src/components/AddNewLink';
 import {
@@ -20,7 +15,6 @@ import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
-import Pagey, { PaginationProps } from 'src/components/Pagey';
 import PaginationFooter from 'src/components/PaginationFooter';
 import Table from 'src/components/Table/Table_CMR';
 import TableCell from 'src/components/TableCell/TableCell_CMR';
@@ -28,7 +22,8 @@ import TableRow from 'src/components/TableRow/TableRow_CMR';
 import TableRowEmptyState from 'src/components/TableRowEmptyState/TableRowEmptyState_CMR';
 import TableRowError from 'src/components/TableRowError/TableRowError_CMR';
 import TableRowLoading from 'src/components/TableRowLoading/TableRowLoading_CMR';
-import { getGravatarUrl } from 'src/utilities/gravatar';
+import usePagination from 'src/hooks/usePagination';
+import { useAccountUsers } from 'src/queries/accountUsers';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import CreateUserDrawer from './CreateUserDrawer';
 import UserDeleteConfirmationDialog from './UserDeleteConfirmationDialog';
@@ -102,21 +97,16 @@ interface Props {
   isRestrictedUser: boolean;
 }
 
-type CombinedProps = WithSnackbarProps &
-  Props &
-  PaginationProps<User> &
-  RouteComponentProps<{}>;
-
-const UsersLanding: React.FC<CombinedProps> = (props) => {
-  const {
-    request,
-    onDelete,
-    enqueueSnackbar,
-    data: users,
-    error,
-    loading,
-  } = props;
-
+const UsersLanding: React.FC<Props> = (props) => {
+  const pagination = usePagination(1);
+  const { data: users, isLoading, error, refetch } = useAccountUsers(
+    {
+      page: pagination.page,
+      page_size: pagination.pageSize,
+    },
+    true
+  );
+  const { enqueueSnackbar } = useSnackbar();
   const [createDrawerOpen, setCreateDrawerOpen] = React.useState<boolean>(
     false
   );
@@ -138,12 +128,8 @@ const UsersLanding: React.FC<CombinedProps> = (props) => {
   const theme = useTheme<Theme>();
   const matchesSmDown = useMediaQuery(theme.breakpoints.down('sm'));
 
-  React.useEffect(() => {
-    request();
-  }, [request]);
-
   const addUser = () => {
-    request();
+    refetch();
   };
 
   const openForCreate = () => {
@@ -161,7 +147,8 @@ const UsersLanding: React.FC<CombinedProps> = (props) => {
 
     deleteUser(username)
       .then(() => {
-        onDelete();
+        // What is this and what magical prop did it come from
+        // onDelete();
         enqueueSnackbar(`User ${username} has been deleted successfully.`, {
           variant: 'success',
         });
@@ -224,12 +211,8 @@ const UsersLanding: React.FC<CombinedProps> = (props) => {
     );
   };
 
-  const renderTableContent = (
-    loading: boolean,
-    error?: APIError[],
-    data?: User[]
-  ) => {
-    if (loading) {
+  const renderTableContent = () => {
+    if (isLoading) {
       return <TableRowLoading colSpan={4} oneLine hasEntityIcon />;
     }
 
@@ -237,11 +220,11 @@ const UsersLanding: React.FC<CombinedProps> = (props) => {
       return <TableRowError colSpan={4} message={error[0].reason} />;
     }
 
-    if (!data || data.length === 0) {
+    if (!users || users.results === 0) {
       return <TableRowEmptyState colSpan={4} />;
     }
 
-    return data.map((user) => renderUserRow(user));
+    return users.data.map((user) => renderUserRow(user));
   };
 
   return (
@@ -293,16 +276,15 @@ const UsersLanding: React.FC<CombinedProps> = (props) => {
               <TableCell />
             </TableRow>
           </TableHead>
-          <TableBody>{renderTableContent(loading, error, users)}</TableBody>
+          <TableBody>{renderTableContent()}</TableBody>
         </Table>
       </div>
-
       <PaginationFooter
-        count={props.count}
-        page={props.page}
-        pageSize={props.pageSize}
-        handlePageChange={props.handlePageChange}
-        handleSizeChange={props.handlePageSizeChange}
+        count={users?.results || 0}
+        page={pagination.page}
+        pageSize={pagination.pageSize}
+        handlePageChange={pagination.handlePageChange}
+        handleSizeChange={pagination.handlePageSizeChange}
         eventCategory="users landing"
       />
       <CreateUserDrawer
@@ -320,21 +302,4 @@ const UsersLanding: React.FC<CombinedProps> = (props) => {
   );
 };
 
-const memoizedGetGravatarURL = memoize(getGravatarUrl);
-
-const paginated = Pagey((ownProps, params, filters) =>
-  getUsers(params, filters).then(({ data, page, pages, results }) =>
-    mapPromise(data, (user) =>
-      memoizedGetGravatarURL(user.email).then((gravatarUrl: string) => ({
-        ...user,
-        gravatarUrl,
-      }))
-    ).then((updatedUsers) => ({ page, pages, results, data: updatedUsers }))
-  )
-);
-
-export default compose<CombinedProps, Props>(
-  withRouter,
-  paginated,
-  withSnackbar
-)(UsersLanding);
+export default UsersLanding;

--- a/packages/manager/src/features/Users/UsersLanding.tsx
+++ b/packages/manager/src/features/Users/UsersLanding.tsx
@@ -147,8 +147,7 @@ const UsersLanding: React.FC<Props> = (props) => {
 
     deleteUser(username)
       .then(() => {
-        // What is this and what magical prop did it come from
-        // onDelete();
+        refetch();
         enqueueSnackbar(`User ${username} has been deleted successfully.`, {
           variant: 'success',
         });

--- a/packages/manager/src/queries/accountUsers.ts
+++ b/packages/manager/src/queries/accountUsers.ts
@@ -3,10 +3,25 @@ import { ResourcePage } from '@linode/api-v4/lib/types';
 import { APIError } from '@linode/api-v4/lib/types';
 import { useQuery } from 'react-query';
 import { queryPresets } from './base';
+import { map as mapPromise } from 'bluebird';
+import * as memoize from 'memoizee';
+import { getGravatarUrl } from 'src/utilities/gravatar';
 
-export const useAccountUsers = () =>
+export const useAccountUsers = (params: any, withGravatar: boolean = false) =>
   useQuery<ResourcePage<User>, APIError[]>(
-    'account-users',
-    getUsers,
+    ['account-users', params.page, params.page_size],
+    withGravatar ? () => getUsersWithGravatar(params) : () => getUsers(params),
     queryPresets.oneTimeFetch
+  );
+
+const memoizedGetGravatarURL = memoize(getGravatarUrl);
+
+const getUsersWithGravatar = (params?: any, filters?: any) =>
+  getUsers(params, filters).then(({ data, page, pages, results }) =>
+    mapPromise(data, (user) =>
+      memoizedGetGravatarURL(user.email).then((gravatarUrl: string) => ({
+        ...user,
+        gravatarUrl,
+      }))
+    ).then((updatedUsers) => ({ page, pages, results, data: updatedUsers }))
   );


### PR DESCRIPTION
## Description

- Uses React Query to populate and paginate `/account/users`.
- The pagination logic and the entire `UsersLanding.tsx` was refactored.
 
## How to test

Ensure `/account/users` in Cloud Manager still functions as expected. Try to test cases where the table would need to paginate (more than 25 users) even though this is rare. 
