### PR TITLE
M3-5256: Match Image Upload file types more broadly

### DIFF
--- a/packages/manager/src/components/FileUploader/FileUploader.tsx
+++ b/packages/manager/src/components/FileUploader/FileUploader.tsx
@@ -185,7 +185,7 @@ const FileUploader: React.FC<CombinedProps> = (props) => {
 
   // This function will be called when the user drops non-.gz files, more than one file at a time, or files that are over the max size.
   const onDropRejected = (files: FileRejection[]) => {
-    const wrongFileType = files[0].file.type !== 'application/x-gzip';
+    const wrongFileType = !files[0].file.type.match(/gzip/gi);
     const fileTypeErrorMessage =
       'Only raw disk images (.img) compressed using gzip (.gz) can be uploaded.';
 


### PR DESCRIPTION
## Description

**What does this PR do?**
Currently we are determining if an image is the correct file type by making sure the mime-type is "application/x-gzip". This PR makes this check more broad so that "application/gzip" (which is valid) also passes the test.

## How to test

**What are the steps to reproduce the issue or verify the changes?**
Image uploads should continue to work as before. I was unable to reproduce the original bug report, and am unclear about the mechanics of the mime-type here. Even if a file as a mime-type of `application/gzip` on my computer, when I drag it to the upload area the browser reads it as `application/x-gzip`. **So this is more of a theoretical fix that shouldn't break anything.**
