### PR TITLE
Updates Package.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,10 @@ jobs:
       - run: yarn --frozen-lockfile
       - run: yarn workspace @linode/validation run build
       - uses: actions/upload-artifact@v2
-        with:
           name: packages-validation-lib
-          path: packages/validation/lib
+          path: |
+            packages/validation/index.js
+            packages/validation/lib
 
   publish-validation:
     runs-on: ubuntu-latest
@@ -31,7 +32,7 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: packages-validation-lib
-          path: packages/validation/lib
+          path: packages/validation
       - uses: JS-DevTools/npm-publish@v1
         id: npm-publish
         with:
@@ -66,7 +67,7 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: packages-validation-lib
-          path: packages/validation/lib
+          path: packages/validation
       - run: yarn workspace @linode/api-v4 run test
 
   build-sdk:
@@ -86,14 +87,17 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: packages-validation-lib
-          path: packages/validation/lib
+          path: packages/validation
       - run: yarn --frozen-lockfile
       - run: yarn workspace @linode/api-v4 run build
       - run: yarn workspace @linode/api-v4 run build:node
       - uses: actions/upload-artifact@v2
         with:
           name: packages-api-v4-lib
-          path: packages/api-v4/lib
+          path: |
+            packages/api-v4/index.js
+            packages/api-v4/index.node.js
+            packages/api-v4/lib
 
   test-manager:
     runs-on: ubuntu-latest
@@ -112,11 +116,11 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: packages-validation-lib
-          path: packages/validation/lib
+          path: packages/validation
       - uses: actions/download-artifact@v2
         with:
           name: packages-api-v4-lib
-          path: packages/api-v4/lib
+          path: packages/api-v4
       - run: yarn --frozen-lockfile
       - run: yarn workspace linode-manager run test
 
@@ -139,11 +143,11 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: packages-validation-lib
-          path: packages/validation/lib
+          path: packages/validation
       - uses: actions/download-artifact@v2
         with:
           name: packages-api-v4-lib
-          path: packages/api-v4/lib
+          path: packages/api-v4
       - run: yarn --frozen-lockfile
       - run: yarn workspace linode-manager run build
       - uses: actions/upload-artifact@v2
@@ -164,7 +168,7 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: packages-api-v4-lib
-          path: packages/api-v4/lib
+          path: packages/api-v4
       - uses: JS-DevTools/npm-publish@v1
         id: npm-publish
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       - run: yarn --frozen-lockfile
       - run: yarn workspace @linode/validation run build
       - uses: actions/upload-artifact@v2
+        with:
           name: packages-validation-lib
           path: |
             packages/validation/index.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
           path: packages/validation/lib
       - run: yarn --frozen-lockfile
       - run: yarn workspace @linode/api-v4 run build
+      - run: yarn workspace @linode/api-v4 run build:node
       - uses: actions/upload-artifact@v2
         with:
           name: packages-api-v4-lib

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist
 build
 lib
 **/api-v4/index.js
+**/api-v4/index.node.js
 **/api-v4/index.d.ts
 **/validation/index.js
 **/validation/index.d.ts

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+# Intentionally blank. @linode/api-v4 and @linode/validation packages observe the
+# _files_ key in their _package.json_ files

--- a/packages/api-v4/package.json
+++ b/packages/api-v4/package.json
@@ -17,7 +17,8 @@
   "author": "Linode",
   "license": "Apache-2.0",
   "private": false,
-  "main": "./index.js",
+  "main": "./index.node.js",
+  "browser": "./index.js",
   "types": "./lib/index.d.ts",
   "unpkg": "./index.js",
   "dependencies": {

--- a/packages/api-v4/package.json
+++ b/packages/api-v4/package.json
@@ -31,6 +31,7 @@
   "scripts": {
     "start": "concurrently \"tsc -w\" \"babel src --watch --out-dir lib --extensions '.ts,.tsx'\" -n 'tsc,babel' -k",
     "build": "tsc && babel src --out-dir lib --extensions '.ts,.tsx' && webpack",
+    "build:node": "yarn build --config webpack.node.config.js",
     "test": "jest --config jestconfig.json",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",
     "lint": "yarn run eslint . --quiet --ext .js,.ts,.tsx",
@@ -39,6 +40,7 @@
   },
   "files": [
     "index.js",
+    "index.node.js",
     "index.d.ts",
     "lib/*",
     "package.json",

--- a/packages/api-v4/package.json
+++ b/packages/api-v4/package.json
@@ -18,7 +18,7 @@
   "license": "Apache-2.0",
   "private": false,
   "main": "./index.js",
-  "types": "./index.d.ts",
+  "types": "./lib/index.d.ts",
   "unpkg": "./index.js",
   "dependencies": {
     "@linode/validation": "0.4.0",

--- a/packages/api-v4/package.json
+++ b/packages/api-v4/package.json
@@ -17,8 +17,8 @@
   "author": "Linode",
   "license": "Apache-2.0",
   "private": false,
-  "main": "./lib/index.js",
-  "types": "./lib/index.d.ts",
+  "main": "./index.js",
+  "types": "./index.d.ts",
   "unpkg": "./index.js",
   "dependencies": {
     "@linode/validation": "0.4.0",

--- a/packages/api-v4/webpack.node.config.js
+++ b/packages/api-v4/webpack.node.config.js
@@ -2,18 +2,15 @@ const path = require('path');
 const NpmDtsPlugin = require('npm-dts-webpack-plugin');
 
 module.exports = {
-  mode: 'development',
+  mode: 'production',
   entry: './lib/index.js',
+  target: 'node',
   output: {
-    filename: 'index.js',
+    filename: './index.node.js',
     path: path.resolve(__dirname),
     library: '@linode/api-v4',
     libraryTarget: 'umd',
   },
-  devServer: {
-    contentBase: './lib',
-  },
-  devtool: 'inline-source-map',
   plugins: [
     new NpmDtsPlugin({
       logLevel: 'warn',

--- a/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
@@ -1,5 +1,4 @@
-import { updateAccountInfo } from '@linode/api-v4';
-import { Account } from '@linode/api-v4/lib/account';
+import { Account, updateAccountInfo } from '@linode/api-v4/lib/account';
 import { APIError } from '@linode/api-v4/lib/types';
 import countryData from 'country-region-data';
 import { defaultTo, lensPath, pick, set } from 'ramda';

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.tsx
@@ -1,4 +1,4 @@
-import { deletePaymentMethod, PaymentMethod } from '@linode/api-v4';
+import { deletePaymentMethod, PaymentMethod } from '@linode/api-v4/lib/account';
 import { APIError } from '@linode/api-v4/lib/types';
 import * as React from 'react';
 import { useHistory, useRouteMatch } from 'react-router-dom';

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -2,8 +2,15 @@
   "name": "@linode/validation",
   "version": "0.4.0",
   "description": "Yup validation schemas for use with the Linode APIv4",
-  "main": "./lib/index.js",
-  "types": "./lib/index.d.ts",
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "files": [
+    "index.js",
+    "index.d.ts",
+    "lib/*",
+    "package.json",
+    "README.md"
+  ],
   "scripts": {
     "build": "tsc && babel src --out-dir lib --extensions '.ts,.tsx' && webpack",
     "test": "jest --config jestconfig.json",

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -3,7 +3,7 @@
   "version": "0.4.0",
   "description": "Yup validation schemas for use with the Linode APIv4",
   "main": "./index.js",
-  "types": "./index.d.ts",
+  "types": "./lib/index.d.ts",
   "files": [
     "index.js",
     "index.d.ts",


### PR DESCRIPTION
## Description

1. Adds `files` key to validation package (which determines what gets published to NPM)

2. Changes `main` key in `package.json` (which dictates where things are imported from).
    * As of right now `import { blah } from '@linode/api-v4'` by default imports things from `lib/index.js` which is unminified code, unlike `./index.js` which is minified.
    * In other words, importing from `./index.js` is impossible right now
    * Didn't update `types` key because it's fine as is
  
## How to test

1. Run all projects locally
2. Make changes to `api-v4`
3. Ensure manager still hot reloads with changes

-------

1. Also ensure imports from `@linode/api-v4/lib/whatever` still works

-------

1. Run `cd ./packages/validation && npm publish --dry-run` to see what files are getting published to NPM. Comparing this branch to dev, you'll see all the `src` code along with other unnecessary files are getting published under the `validation` package and now it should just be the relevant ones

Before:

![Screen Shot 2021-06-24 at 12 36 31 PM](https://user-images.githubusercontent.com/7387001/123300716-d79fb000-d4e8-11eb-88cb-27da9f7c1eed.png)

## Possible Issues

When I installed the SDK, I noticed `./index.js` and `./index.d.ts` weren't actually published to NPM. Obviously not sure if that was a cause from a bad publish or it's a genuine issue that needs to be fixed prior to merging this PR

![Screen Shot 2021-06-24 at 12 31 16 PM](https://user-images.githubusercontent.com/7387001/123300015-18e39000-d4e8-11eb-93f2-ad315f0fd35f.png)
