### PR TITLE
M3-5268: Fix Object Storage table

### DIFF
--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTable.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTable.tsx
@@ -87,7 +87,7 @@ export const BucketTable: React.FC<CombinedProps> = (props) => {
                 >
                   Size
                 </TableSortCell>
-                <Hidden smDown>
+                <Hidden xsDown>
                   <TableSortCell
                     active={orderBy === 'objects'}
                     label="objects"

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.tsx
@@ -86,28 +86,30 @@ export const BucketTableRow: React.FC<CombinedProps> = (props) => {
           </Grid>
         </Grid>
       </TableCell>
-      <TableCell parentColumn="Region">
-        <Typography variant="body1" data-qa-region>
-          {formatObjectStorageCluster(cluster) || cluster}
-        </Typography>
-      </TableCell>
-      <TableCell parentColumn="Created">
-        <DateTimeDisplay value={created} data-qa-created />
-      </TableCell>
+      <Hidden xsDown>
+        <TableCell parentColumn="Region">
+          <Typography variant="body1" data-qa-region>
+            {formatObjectStorageCluster(cluster) || cluster}
+          </Typography>
+        </TableCell>
+      </Hidden>
+      <Hidden smDown>
+        <TableCell parentColumn="Created">
+          <DateTimeDisplay value={created} data-qa-created />
+        </TableCell>
+      </Hidden>
       <TableCell parentColumn="Size">
         <Typography variant="body1" data-qa-size>
           {readableBytes(size).formatted}
         </Typography>
       </TableCell>
-
-      <Hidden smDown>
+      <Hidden xsDown>
         <TableCell>
           <Typography variant="body1" data-qa-size>
             {objects}
           </Typography>
         </TableCell>
       </Hidden>
-
       <TableCell className={classes.actionCell}>
         <BucketActionMenu
           onRemove={onRemove}


### PR DESCRIPTION
## Description

Fixes table columns on smaller screen sizes in the Object Storage Buckets table. 

The issue is shown in this screenshot:
<img width="712" alt="Screen Shot 2021-06-28 at 2 30 32 PM" src="https://user-images.githubusercontent.com/6440455/123688288-d25f9f80-d81f-11eb-8876-6a76b9e889bc.png">

The fix changes what columns appear and fix the visual bug:
<img width="712" alt="Screen Shot 2021-06-28 at 2 48 47 PM" src="https://user-images.githubusercontent.com/6440455/123688417-f4592200-d81f-11eb-8a7b-86645da0aa79.png">



## How to test

Go to `/object-storage/buckets` and ensure columns collapse correctly as you shrink the viewport.  