### PR TITLE
ref: add test assertion to confirm linodes start running after provisioning

### DIFF
--- a/packages/manager/cypress/integration/linodes/smoke-create-linode.spec.ts
+++ b/packages/manager/cypress/integration/linodes/smoke-create-linode.spec.ts
@@ -16,6 +16,11 @@ describe('create linode', () => {
     cy.visitWithLogin('/linodes/create');
     cy.get('[data-qa-deploy-linode]');
   });
+
+  afterEach(() => {
+    deleteAllTestLinodes();
+  });
+
   it('creates a nanode', () => {
     const rootpass = strings.randomPass();
     const linodeLabel = makeLinodeLabel();
@@ -30,6 +35,6 @@ describe('create linode', () => {
     cy.wait('@linodeCreated').its('response.statusCode').should('eq', 200);
     assertToast(`Your Linode ${linodeLabel} is being created.`);
     containsVisible('PROVISIONING');
-    deleteAllTestLinodes();
+    cy.contains('RUNNING', { timeout: 180000 }).should('be.visible');
   });
 });


### PR DESCRIPTION
## Description

**What does this PR do?**

Added an assertion to confirm linodes achieve a "running" state after provisioning.. this should always happen

Also, refactored cleanup to get executed in a hook, not in the test. All lifecycle events should happen in these hooks, because they will get executed regardless of the test passing/failure.

## How to test

1. `yarn up`
2. `yarn cy:debug`
3. Run the test via cypress's UI
4. It should pass.

**What are the steps to reproduce the issue or verify the changes?**

**How do I run relevant unit tests?**
