### PR TITLE
M3-5261: Successful payment UI updates

### DIFF
--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -1,15 +1,19 @@
+import * as React from 'react';
 import {
   getInvoiceItems,
-  getInvoices,
-  getPayments,
   Invoice,
   InvoiceItem,
   Payment,
 } from '@linode/api-v4/lib/account';
 import { APIError } from '@linode/api-v4/lib/types';
 import { DateTime } from 'luxon';
+import { ISO_DATETIME_NO_TZ_FORMAT } from 'src/constants';
 import { parseAPIDate } from 'src/utilities/date';
-import * as React from 'react';
+import { isAfter } from 'src/utilities/date';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import formatDate from 'src/utilities/formatDate';
+import { getAllWithArguments } from 'src/utilities/getAll';
+import { getTaxID } from '../../billingUtils';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
@@ -25,20 +29,18 @@ import Table from 'src/components/Table/Table_CMR';
 import TableCell from 'src/components/TableCell/TableCell_CMR';
 import TableContentWrapper from 'src/components/TableContentWrapper/TableContentWrapper_CMR';
 import TableRow from 'src/components/TableRow/TableRow_CMR';
+import InlineMenuAction from 'src/components/InlineMenuAction';
 import {
   printInvoice,
   printPayment,
 } from 'src/features/Billing/PdfGenerator/PdfGenerator';
 import { useAccount } from 'src/hooks/useAccount';
-import useFlags from 'src/hooks/useFlags';
-import { ISO_DATETIME_NO_TZ_FORMAT } from 'src/constants';
 import { useSet } from 'src/hooks/useSet';
-import { isAfter } from 'src/utilities/date';
-import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
-import formatDate from 'src/utilities/formatDate';
-import { getAll, getAllWithArguments } from 'src/utilities/getAll';
-import { getTaxID } from '../../billingUtils';
-import InlineMenuAction from 'src/components/InlineMenuAction';
+import useFlags from 'src/hooks/useFlags';
+import {
+  useAllAccountInvoices,
+  useAllAccountPayments,
+} from 'src/queries/accountBilling';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -173,10 +175,8 @@ export const BillingActivityPanel: React.FC<Props> = (props) => {
   const flags = useFlags();
   const { account } = useAccount();
 
-  const [loading, setLoading] = React.useState<boolean>(false);
+  const [loading, setLoading] = React.useState<boolean>(true);
   const [error, setError] = React.useState<APIError[] | undefined>();
-  const [invoices, setInvoices] = React.useState<Invoice[]>([]);
-  const [payments, setPayments] = React.useState<Payment[]>([]);
 
   const pdfErrors = useSet();
   const pdfLoading = useSet();
@@ -191,42 +191,43 @@ export const BillingActivityPanel: React.FC<Props> = (props) => {
     setSelectedTransactionDate,
   ] = React.useState<DateRange>(defaultDateRange);
 
-  const requestAllInvoicesAndPayments = React.useCallback(
-    (endDate?: string) => {
-      const filter = makeFilter(endDate);
-
-      setLoading(true);
-      setError(undefined);
-
-      Promise.all([getAllInvoices({}, filter), getAllPayments({}, filter)])
-        .then(([invoices, payments]) => {
-          setLoading(false);
-          setInvoices(invoices.data);
-          setPayments(payments.data);
-        })
-        .catch((_error) => {
-          setError(
-            getAPIErrorOrDefault(
-              _error,
-              'There was an error retrieving your billing activity.'
-            )
-          );
-          setLoading(false);
-        });
-    },
-    []
+  const {
+    data: payments,
+    isLoading: accountPaymentsLoading,
+    error: accountPaymentsError,
+  } = useAllAccountPayments(
+    {},
+    makeFilter(getCutoffFromDateRange(selectedTransactionDate))
   );
 
-  // Request all invoices and payments when component mounts.
+  const {
+    data: invoices,
+    isLoading: accountInvoicesLoading,
+    error: accountInvoicesError,
+  } = useAllAccountInvoices(
+    {},
+    makeFilter(getCutoffFromDateRange(selectedTransactionDate))
+  );
+
   React.useEffect(() => {
-    const defaultDateCutoff = getCutoffFromDateRange(defaultDateRange);
-    requestAllInvoicesAndPayments(defaultDateCutoff);
-    // eslint-disable-next-line
-  }, []);
+    setLoading(accountPaymentsLoading || accountInvoicesLoading);
+  }, [accountPaymentsLoading, accountInvoicesLoading]);
+
+  React.useEffect(() => {
+    if (accountPaymentsError || accountInvoicesError) {
+      setLoading(false);
+      setError(
+        getAPIErrorOrDefault(
+          (accountPaymentsError || accountInvoicesError) as APIError[],
+          'There was an error retrieving your billing activity.'
+        )
+      );
+    }
+  }, [accountInvoicesError, accountPaymentsError]);
 
   const downloadInvoicePDF = React.useCallback(
     (invoiceId: number) => {
-      const invoice = invoices.find(
+      const invoice = invoices?.find(
         (thisInvoice) => thisInvoice.id === invoiceId
       );
 
@@ -267,7 +268,7 @@ export const BillingActivityPanel: React.FC<Props> = (props) => {
 
   const downloadPaymentPDF = React.useCallback(
     (paymentId: number) => {
-      const payment = payments.find(
+      const payment = payments?.find(
         (thisPayment) => thisPayment.id === paymentId
       );
 
@@ -305,39 +306,21 @@ export const BillingActivityPanel: React.FC<Props> = (props) => {
     },
     [pdfErrors, pdfLoading]
   );
+
   const handleTransactionDateChange = React.useCallback(
     (item: Item<DateRange>) => {
       setSelectedTransactionDate(item.value);
       pdfErrors.clear();
       pdfLoading.clear();
-
-      const earliestInvoiceDate =
-        invoices[invoices.length - 1]?.date ||
-        DateTime.utc().toFormat(ISO_DATETIME_NO_TZ_FORMAT);
-      const earliestPaymentDate =
-        payments[payments.length - 1]?.date ||
-        DateTime.utc().toFormat(ISO_DATETIME_NO_TZ_FORMAT);
-      const dateCutoff = getCutoffFromDateRange(item.value);
-
-      // If the data we already have falls within the selected date range,
-      // no need to request more data.
-      if (
-        isAfter(dateCutoff, earliestInvoiceDate) &&
-        isAfter(dateCutoff, earliestPaymentDate)
-      ) {
-        return;
-      }
-
-      requestAllInvoicesAndPayments(dateCutoff);
     },
-    [requestAllInvoicesAndPayments, invoices, payments, pdfErrors, pdfLoading]
+    [pdfErrors, pdfLoading]
   );
 
   // Combine Invoices and Payments
   const combinedData = React.useMemo(
     () => [
-      ...invoices.map(invoiceToActivityFeedItem),
-      ...payments.map(paymentToActivityFeedItem),
+      ...(invoices?.map(invoiceToActivityFeedItem) ?? []),
+      ...(payments?.map(paymentToActivityFeedItem) ?? []),
     ],
     [invoices, payments]
   );
@@ -570,8 +553,6 @@ export const ActivityFeedItem: React.FC<ActivityFeedItemProps> = React.memo(
 // =============================================================================
 // Utilities
 // =============================================================================
-const getAllInvoices = getAll<Invoice>(getInvoices);
-const getAllPayments = getAll<Payment>(getPayments);
 const getAllInvoiceItems = getAllWithArguments<InvoiceItem>(getInvoiceItems);
 
 export const invoiceToActivityFeedItem = (

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -216,12 +216,9 @@ export const BillingActivityPanel: React.FC<Props> = (props) => {
   React.useEffect(() => {
     if (accountPaymentsError || accountInvoicesError) {
       setLoading(false);
-      setError(
-        getAPIErrorOrDefault(
-          (accountPaymentsError || accountInvoicesError) as APIError[],
-          'There was an error retrieving your billing activity.'
-        )
-      );
+      setError([
+        { reason: 'There was an error retrieving your billing activity.' },
+      ]);
     }
   }, [accountInvoicesError, accountPaymentsError]);
 

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCardPayment.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCardPayment.tsx
@@ -1,17 +1,19 @@
 import * as React from 'react';
 import { makePayment, CardType } from '@linode/api-v4/lib/account';
+import isCreditCardExpired from 'src/utilities/isCreditCardExpired';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import { cleanCVV } from 'src/features/Billing/billingUtils';
 import Button from 'src/components/Button';
 import { makeStyles } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 import TextField from 'src/components/TextField';
-import { cleanCVV } from 'src/features/Billing/billingUtils';
 import CreditCardDialog from './PaymentBits/CreditCardDialog';
-import isCreditCardExpired from 'src/utilities/isCreditCardExpired';
-import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { SetSuccess } from './types';
 import CreditCard from './CreditCard';
 import useFlags from 'src/hooks/useFlags';
+import { queryClient } from 'src/queries/base';
+import { queryKey } from 'src/queries/accountBilling';
 
 // @TODO: remove unused code and feature flag logic once google pay is released
 const useStyles = makeStyles(() => ({
@@ -98,10 +100,11 @@ export const CreditCardPayment: React.FC<Props> = (props) => {
         setSubmitting(false);
         setDialogOpen(false);
         setSuccess(
-          `Payment for $${usd} submitted successfully`,
+          `Payment for $${usd} successfully submitted`,
           true,
           response.warnings
         );
+        queryClient.invalidateQueries(`${queryKey}-payments`);
       })
       .catch((errorResponse) => {
         setSubmitting(false);

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/GooglePayButton.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/GooglePayButton.tsx
@@ -96,8 +96,8 @@ export const GooglePayButton: React.FC<Props> = (props) => {
       (message: string, variant: VariantType) => {
         if (variant === 'error') {
           setError(message);
-        } else {
-          setSuccess(message);
+        } else if (variant === 'success') {
+          setSuccess(message, true);
           queryClient.invalidateQueries(`${queryKey}-payments`);
         }
       }

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/GooglePayButton.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/GooglePayButton.tsx
@@ -4,6 +4,8 @@ import { VariantType } from 'notistack';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import { useScript } from 'src/hooks/useScript';
 import { useClientToken } from 'src/queries/accountPayment';
+import { queryClient } from 'src/queries/base';
+import { queryKey } from 'src/queries/accountBilling';
 import { SetSuccess } from './types';
 import {
   initGooglePaymentInstance,
@@ -91,8 +93,14 @@ export const GooglePayButton: React.FC<Props> = (props) => {
     gPay(
       'one-time-payment',
       transactionInfo,
-      (message: string, variant: VariantType) =>
-        variant === 'error' ? setError(message) : setSuccess(message)
+      (message: string, variant: VariantType) => {
+        if (variant === 'error') {
+          setError(message);
+        } else {
+          setSuccess(message);
+          queryClient.invalidateQueries(`${queryKey}-payments`);
+        }
+      }
     );
   };
 

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
@@ -4,6 +4,8 @@ import * as classnames from 'classnames';
 import * as React from 'react';
 import makeAsyncScriptLoader from 'react-async-script';
 import { compose } from 'recompose';
+import { v4 } from 'uuid';
+import { useSnackbar } from 'notistack';
 import Divider from 'src/components/core/Divider';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
@@ -18,7 +20,6 @@ import AccountContainer, {
   DispatchProps as AccountDispatchProps,
 } from 'src/containers/account.container';
 import useFlags from 'src/hooks/useFlags';
-import { v4 } from 'uuid';
 import CreditCardPayment from './CreditCardPayment';
 import PayPal, { paypalScriptSrc } from './Paypal';
 import { SetSuccess } from './types';
@@ -81,6 +82,7 @@ export const PaymentDrawer: React.FC<CombinedProps> = (props) => {
     open,
     onClose,
   } = props;
+  const { enqueueSnackbar } = useSnackbar();
   const classes = useStyles();
   const flags = useFlags();
 
@@ -111,6 +113,14 @@ export const PaymentDrawer: React.FC<CombinedProps> = (props) => {
     }
   }, [open]);
 
+  React.useEffect(() => {
+    if (successMessage) {
+      enqueueSnackbar(successMessage, {
+        variant: 'success',
+      });
+    }
+  }, [successMessage, enqueueSnackbar]);
+
   const handleUSDChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setUSD(e.target.value || '');
   };
@@ -132,6 +142,7 @@ export const PaymentDrawer: React.FC<CombinedProps> = (props) => {
       setCreditCardKey(v4());
       setPayPalKey(v4());
       props.requestAccount();
+      onClose();
     }
     if (warnings && warnings.length > 0) {
       setWarning(warnings[0]);
@@ -156,7 +167,6 @@ export const PaymentDrawer: React.FC<CombinedProps> = (props) => {
     <Drawer title="Make a Payment" open={open} onClose={onClose}>
       <Grid container>
         <Grid item xs={12}>
-          {successMessage && <Notice success text={successMessage ?? ''} />}
           {errorMessage && <Notice error text={errorMessage ?? ''} />}
           {warning ? <Warning warning={warning} /> : null}
           {balance !== false && (

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/Paypal.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/Paypal.tsx
@@ -38,6 +38,8 @@ import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import PaypalDialog from './PaymentBits/PaypalDialog';
 import { SetSuccess } from './types';
 import useFlags from 'src/hooks/useFlags';
+import { queryClient } from 'src/queries/base';
+import { queryKey } from 'src/queries/accountBilling';
 
 // @TODO: remove unused code and feature flag logic once google pay is released
 const useStyles = makeStyles((theme: Theme) => ({
@@ -175,6 +177,7 @@ export const PayPalDisplay: React.FC<CombinedProps> = (props) => {
           true,
           response.warnings
         );
+        queryClient.invalidateQueries(`${queryKey}-payments`);
       })
       .catch((_) => {
         setExecuting(false);

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.tsx
@@ -135,9 +135,8 @@ const PaymentInformation: React.FC<Props> = (props) => {
           <Box display="flex" alignItems="center" mt={3}>
             <GooglePay width={16} height={16} />
             <Typography className={classes.googlePayNotice}>
-              Google Pay is now available for recurring payments.
+              Google Pay is now available for recurring payments.{' '}
               <Link to="#" onClick={openAddDrawer}>
-                {' '}
                 Add Google Pay
               </Link>
             </Typography>

--- a/packages/manager/src/queries/accountBilling.ts
+++ b/packages/manager/src/queries/accountBilling.ts
@@ -15,8 +15,8 @@ const getAllAccountInvoices = async (
   passedParams: any = {},
   passedFilter: any = {}
 ) => {
-  const res = await getAll<Invoice>(() =>
-    getInvoices(passedParams, passedFilter)
+  const res = await getAll<Invoice>((params, filter) =>
+    getInvoices({ ...params, ...passedParams }, { ...filter, ...passedFilter })
   )();
   return res.data;
 };
@@ -25,8 +25,8 @@ const getAllAccountPayments = async (
   passedParams: any = {},
   passedFilter: any = {}
 ) => {
-  const res = await getAll<Payment>(() =>
-    getPayments(passedParams, passedFilter)
+  const res = await getAll<Payment>((params, filter) =>
+    getPayments({ ...params, ...passedParams }, { ...filter, ...passedFilter })
   )();
   return res.data;
 };

--- a/packages/manager/src/queries/accountBilling.ts
+++ b/packages/manager/src/queries/accountBilling.ts
@@ -1,0 +1,54 @@
+import {
+  Invoice,
+  Payment,
+  getInvoices,
+  getPayments,
+} from '@linode/api-v4/lib/account';
+import { APIError } from '@linode/api-v4/lib/types';
+import { useQuery } from 'react-query';
+import { getAll } from 'src/utilities/getAll';
+import { queryPresets } from './base';
+
+export const queryKey = 'account-billing';
+
+const getAllAccountInvoices = async (
+  passedParams: any = {},
+  passedFilter: any = {}
+) => {
+  const res = await getAll<Invoice>(() =>
+    getInvoices(passedParams, passedFilter)
+  )();
+  return res.data;
+};
+
+const getAllAccountPayments = async (
+  passedParams: any = {},
+  passedFilter: any = {}
+) => {
+  const res = await getAll<Payment>(() =>
+    getPayments(passedParams, passedFilter)
+  )();
+  return res.data;
+};
+
+export const useAllAccountInvoices = (params: any = {}, filter: any = {}) => {
+  return useQuery<Invoice[], APIError[]>(
+    [`${queryKey}-invoices`, params, filter],
+    () => getAllAccountInvoices(params, filter),
+    {
+      ...queryPresets.oneTimeFetch,
+      keepPreviousData: true,
+    }
+  );
+};
+
+export const useAllAccountPayments = (params: any = {}, filter: any = {}) => {
+  return useQuery<Payment[], APIError[]>(
+    [`${queryKey}-payments`, params, filter],
+    () => getAllAccountPayments(params, filter),
+    {
+      ...queryPresets.oneTimeFetch,
+      keepPreviousData: true,
+    }
+  );
+};


### PR DESCRIPTION
## Description

- Populate billing & payment history table using React Query
- Update the table by invalidating the query after a payment is made and also update account balance
- Close payment drawer and display success toast after successful payment

## How to test
Go to Account and make a payment. After a payment is successfully submitted, the following should update without a page refresh:
- The billing & payment table with the new payment
- The account balance in the Account Balance paper and also in the Make a Payment drawer
- The payment drawer should close and there should be a success toast displayed
