### PR TITLE
M3-5263: Integrate Algolia Search Results in the Cloud Manager search bar 

### DIFF
--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -363,10 +363,15 @@ export const createFinalOptions = (
 
   // LESS THAN 20 RESULTS:
   if (results.length <= 20) {
-    const algoliaResultsIncluded = [
-      ...results,
-      Object.values(formattedAlgoliaResults as {}),
-    ];
+    const algoliaResultsIterator = Object.values(
+      formattedAlgoliaResults as {}
+    ).values();
+    const algoliaResultsIncluded = [...results];
+
+    for (const result of algoliaResultsIterator) {
+      algoliaResultsIncluded.push(result as any);
+    }
+
     console.log(algoliaResultsIncluded);
     return [redirectOption, ...results];
   }


### PR DESCRIPTION
## Description
Verify that Algolia search results can be integrated into the top menu search bar (using both client-side and API search) and print results to console.

## How to test
With your console open, type a fragment of one of the entity labels on your account into the top menu search bar. For example, if you have a series of Linodes with the word "test" in them, type in "test." If there are 20 or fewer results for that search term, results should be logged to the console including any matches from the Algolia search. You can tell which ones are Algolia because they will have a nested `source` property equal to either "Linode Documentation" or "Linode Community Site".
