### PR TITLE
M3 5205 retry image upload

### DIFF
--- a/packages/manager/src/features/Images/ImageRow.tsx
+++ b/packages/manager/src/features/Images/ImageRow.tsx
@@ -53,7 +53,7 @@ const ImageRow: React.FC<CombinedProps> = (props) => {
       case 'available':
         return 'Ready';
       case 'pending_upload':
-        return isFailed ? 'Failed' : 'Pending Upload';
+        return isFailed ? 'Failed' : 'Processing';
       default:
         return capitalizeAllWords(status.replace('_', ' '));
     }

--- a/packages/manager/src/features/Images/ImageRow.tsx
+++ b/packages/manager/src/features/Images/ImageRow.tsx
@@ -35,8 +35,11 @@ const ImageRow: React.FC<CombinedProps> = (props) => {
     label,
     size,
     status,
+    onRetry,
     ...rest
   } = props;
+
+  const isFailed = status === 'pending_upload' && event?.status === 'failed';
 
   const getStatusForImage = (status: string) => {
     switch (status) {
@@ -50,7 +53,7 @@ const ImageRow: React.FC<CombinedProps> = (props) => {
       case 'available':
         return 'Ready';
       case 'pending_upload':
-        return event?.status === 'failed' ? 'Failed' : 'Pending Upload';
+        return isFailed ? 'Failed' : 'Pending Upload';
       default:
         return capitalizeAllWords(status.replace('_', ' '));
     }
@@ -63,7 +66,7 @@ const ImageRow: React.FC<CombinedProps> = (props) => {
   ) => {
     if (status === 'available' || eventStatus === 'finished') {
       return `${size} MB`;
-    } else if (status === 'pending_upload' && eventStatus === 'failed') {
+    } else if (isFailed) {
       return 'N/A';
     } else {
       return 'Pending';
@@ -94,7 +97,16 @@ const ImageRow: React.FC<CombinedProps> = (props) => {
             status={status}
             {...rest}
           />
-        ) : null}
+        ) : (
+          <ActionMenu
+            id={id}
+            label={label}
+            description={description}
+            status={status}
+            event={event}
+            onRetry={onRetry}
+          />
+        )}
       </TableCell>
     </TableRow>
   );

--- a/packages/manager/src/features/Images/ImageRow.tsx
+++ b/packages/manager/src/features/Images/ImageRow.tsx
@@ -36,6 +36,7 @@ const ImageRow: React.FC<CombinedProps> = (props) => {
     size,
     status,
     onRetry,
+    onCancelFailed,
     ...rest
   } = props;
 
@@ -105,6 +106,7 @@ const ImageRow: React.FC<CombinedProps> = (props) => {
             status={status}
             event={event}
             onRetry={onRetry}
+            onCancelFailed={onCancelFailed}
           />
         )}
       </TableCell>

--- a/packages/manager/src/features/Images/ImagesActionMenu.tsx
+++ b/packages/manager/src/features/Images/ImagesActionMenu.tsx
@@ -36,22 +36,23 @@ export const ImagesActionMenu: React.FC<CombinedProps> = (props) => {
     id,
     label,
     status,
+    event,
     onRestore,
     onDeploy,
     onEdit,
     onDelete,
+    onRetry,
   } = props;
 
   const actions: Action[] = React.useMemo(() => {
-    // @todo remove first half of this conditional when Machine Images is GA
     const isDisabled = status && status !== 'available';
-    return status === 'pending_upload'
+    const isFailed = event?.status === 'failed';
+    return isFailed
       ? [
-          // Cancelling a pending upload is functionally equivalent to deleting it
           {
-            title: 'Cancel Upload',
+            title: 'Retry',
             onClick: () => {
-              onDelete(label, id, status);
+              onRetry(id, label, description);
             },
           },
         ]
@@ -89,7 +90,17 @@ export const ImagesActionMenu: React.FC<CombinedProps> = (props) => {
             },
           },
         ];
-  }, [status, description, id, label, onDelete, onRestore, onDeploy, onEdit]);
+  }, [
+    status,
+    description,
+    id,
+    label,
+    onDelete,
+    onRestore,
+    onDeploy,
+    onEdit,
+    onRetry,
+  ]);
 
   /**
    * Moving all actions to the dropdown menu to prevent visual mismatches

--- a/packages/manager/src/features/Images/ImagesActionMenu.tsx
+++ b/packages/manager/src/features/Images/ImagesActionMenu.tsx
@@ -49,6 +49,7 @@ export const ImagesActionMenu: React.FC<CombinedProps> = (props) => {
 
   const actions: Action[] = React.useMemo(() => {
     const isDisabled = status && status !== 'available';
+    const isAvailable = !isDisabled;
     const isFailed = event?.status === 'failed';
     return isFailed
       ? [
@@ -97,7 +98,7 @@ export const ImagesActionMenu: React.FC<CombinedProps> = (props) => {
             },
           },
           {
-            title: 'Delete',
+            title: isAvailable ? 'Delete' : 'Cancel Upload',
             onClick: () => {
               onDelete(label, id, status);
             },

--- a/packages/manager/src/features/Images/ImagesActionMenu.tsx
+++ b/packages/manager/src/features/Images/ImagesActionMenu.tsx
@@ -14,6 +14,8 @@ export interface Handlers {
   onDeploy: (imageID: string) => void;
   onEdit: (label: string, description: string, imageID: string) => void;
   onDelete: (label: string, imageID: string, status?: ImageStatus) => void;
+  onRetry: (imageID: string, label: string, description: string) => void;
+  onCancelFailed: (imageID: string) => void;
   [index: string]: any;
 }
 
@@ -42,6 +44,7 @@ export const ImagesActionMenu: React.FC<CombinedProps> = (props) => {
     onEdit,
     onDelete,
     onRetry,
+    onCancelFailed,
   } = props;
 
   const actions: Action[] = React.useMemo(() => {
@@ -53,6 +56,12 @@ export const ImagesActionMenu: React.FC<CombinedProps> = (props) => {
             title: 'Retry',
             onClick: () => {
               onRetry(id, label, description);
+            },
+          },
+          {
+            title: 'Cancel',
+            onClick: () => {
+              onCancelFailed(id);
             },
           },
         ]
@@ -104,6 +113,8 @@ export const ImagesActionMenu: React.FC<CombinedProps> = (props) => {
     onDeploy,
     onEdit,
     onRetry,
+    onCancelFailed,
+    event,
   ]);
 
   /**
@@ -126,6 +137,7 @@ export const ImagesActionMenu: React.FC<CombinedProps> = (props) => {
               actionText={action.title}
               onClick={action.onClick}
               disabled={action.disabled}
+              tooltip={action.tooltip}
             />
           );
         })}

--- a/packages/manager/src/features/Images/ImagesActionMenu.tsx
+++ b/packages/manager/src/features/Images/ImagesActionMenu.tsx
@@ -59,6 +59,10 @@ export const ImagesActionMenu: React.FC<CombinedProps> = (props) => {
       : [
           {
             title: 'Edit',
+            disabled: isDisabled,
+            tooltip: isDisabled
+              ? 'Image is not yet available for use.'
+              : undefined,
             onClick: () => {
               onEdit(label, description ?? ' ', id);
             },

--- a/packages/manager/src/features/Images/ImagesCreate/ImageCreate.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/ImageCreate.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { RouteComponentProps, withRouter, useHistory } from 'react-router-dom';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import NavTabs, { NavTab } from 'src/components/NavTabs/NavTabs';
 import SuspenseLoader from 'src/components/SuspenseLoader';
@@ -10,8 +10,14 @@ const CreateImageTab = React.lazy(() => import('./CreateImageTab'));
 const ImageUpload = React.lazy(() => import('../ImageUpload'));
 
 export const ImageCreate: React.FC<CombinedProps> = (props) => {
-  const [label, setLabel] = React.useState<string>('');
-  const [description, setDescription] = React.useState<string>('');
+  const { location } = useHistory();
+
+  const [label, setLabel] = React.useState<string>(
+    location?.state ? location.state.imageLabel : ''
+  );
+  const [description, setDescription] = React.useState<string>(
+    location?.state ? location.state.imageDescription : ''
+  );
 
   const handleSetLabel = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;

--- a/packages/manager/src/features/Images/ImagesLanding.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding.tsx
@@ -4,7 +4,7 @@ import produce from 'immer';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import { partition } from 'ramda';
 import * as React from 'react';
-import { connect, MapDispatchToProps } from 'react-redux';
+import { connect, MapDispatchToProps, useDispatch } from 'react-redux';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
 import { AnyAction } from 'redux';
@@ -28,7 +28,7 @@ import { Order } from 'src/components/Pagey';
 import Placeholder from 'src/components/Placeholder';
 import useReduxLoad from 'src/hooks/useReduxLoad';
 import { ApplicationState } from 'src/store';
-import { DeleteImagePayload } from 'src/store/image/image.actions';
+import { DeleteImagePayload, removeImage } from 'src/store/image/image.actions';
 import {
   deleteImage as _deleteImage,
   requestImages as _requestImages,
@@ -178,6 +178,8 @@ export const ImagesLanding: React.FC<CombinedProps> = (props) => {
     defaultDialogState
   );
 
+  const dispatch = useDispatch();
+
   const dialogAction = dialog.status === 'pending_upload' ? 'cancel' : 'delete';
   const dialogMessage =
     dialogAction === 'cancel'
@@ -244,6 +246,18 @@ export const ImagesLanding: React.FC<CombinedProps> = (props) => {
 
   const onCreateButtonClick = () => {
     props.history.push('/images/create');
+  };
+
+  const onRetryClick = (
+    imageId: string,
+    imageLabel: string,
+    imageDescription: string
+  ) => {
+    dispatch(removeImage(imageId));
+    props.history.push('/images/create/upload', {
+      imageLabel,
+      imageDescription,
+    });
   };
 
   const openForEdit = (label: string, description: string, imageID: string) => {
@@ -357,6 +371,7 @@ export const ImagesLanding: React.FC<CombinedProps> = (props) => {
     onDeploy: deployNewLinode,
     onEdit: openForEdit,
     onDelete: openDialog,
+    onRetry: onRetryClick,
   };
 
   // @todo remove this check after Machine Images is in GA

--- a/packages/manager/src/features/Images/ImagesLanding.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding.tsx
@@ -260,6 +260,10 @@ export const ImagesLanding: React.FC<CombinedProps> = (props) => {
     });
   };
 
+  const onCancelFailedClick = (imageId: string) => {
+    dispatch(removeImage(imageId));
+  };
+
   const openForEdit = (label: string, description: string, imageID: string) => {
     setDrawer({
       open: true,
@@ -372,6 +376,7 @@ export const ImagesLanding: React.FC<CombinedProps> = (props) => {
     onEdit: openForEdit,
     onDelete: openDialog,
     onRetry: onRetryClick,
+    onCancelFailed: onCancelFailedClick,
   };
 
   // @todo remove this check after Machine Images is in GA


### PR DESCRIPTION
## Description

Allows users to retry a failed Image upload. If during the processing of an image on the server side an error is encountered then the Image in the ImagesLanding table will change it's status to 'failed' and two options will be available to the user via the ImageActionMenu on the right side of the row. First will be Remove which will remove the Image entry from the table. The Image will already have been removed on the server side since the Image processing failed. The other option will be to Retry the Image upload. This will bring the user back to the Image upload form where the Label and Description will be pre-filled based on the failed Image they are retrying. 

## How to test

Attempt to upload an image known to cause an error during processing. Wait for the processing to fail. Check that the image has two actions that can be taken upon it. Remove and Retry should both work as described above. 