### PR TITLE
Use new status page url for system status

### DIFF
--- a/packages/manager/.env.example
+++ b/packages/manager/.env.example
@@ -31,8 +31,8 @@ REACT_APP_APP_ROOT='http://localhost:3000'
 # Max page size requested of the Linode API:
 # REACT_APP_API_MAX_PAGE_SIZE=
 
-# The Statuspage ID for displaying incidents and maintenance:
-# REACT_APP_STATUS_PAGE_ID=
+# The Statuspage URL for displaying incidents and maintenance:
+# REACT_APP_STATUS_PAGE_URL=
 
 # The PayPal environment to use ("production" or "sandbox"):
 # REACT_APP_PAYPAL_ENV=

--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -31,7 +31,8 @@ export const ALGOLIA_SEARCH_KEY =
   process.env.REACT_APP_ALGOLIA_SEARCH_KEY || '';
 export const LAUNCH_DARKLY_API_KEY =
   process.env.REACT_APP_LAUNCH_DARKLY_ID || '';
-export const LINODE_STATUS_PAGE_ID = process.env.REACT_APP_STATUS_PAGE_ID || '';
+export const LINODE_STATUS_PAGE_URL =
+  process.env.REACT_APP_STATUS_PAGE_URL || 'https://status.linode.com/api/v2';
 
 // Maximum page size allowed by the API. Used in the `getAll()` helper function
 // to request as many items at once as possible.

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -69,11 +69,11 @@ export const makeResourcePage = (
 });
 
 const statusPage = [
-  rest.get('*statuspage.io/api/v2/incidents*', (req, res, ctx) => {
+  rest.get('*/api/v2/incidents*', (req, res, ctx) => {
     const response = incidentResponseFactory.build();
     return res(ctx.json(response));
   }),
-  rest.get('*statuspage.io/api/v2/scheduled_maintenances*', (req, res, ctx) => {
+  rest.get('*/api/v2/scheduled_maintenances*', (req, res, ctx) => {
     const response = maintenanceResponseFactory.build();
     return res(ctx.json(response));
   }),

--- a/packages/manager/src/queries/statusPage/statusPage.ts
+++ b/packages/manager/src/queries/statusPage/statusPage.ts
@@ -2,22 +2,22 @@ import Axios from 'axios';
 import { APIError } from '@linode/api-v4/lib/types';
 import { IncidentResponse, MaintenanceResponse } from './types';
 import { useQuery } from 'react-query';
-import { LINODE_STATUS_PAGE_ID } from 'src/constants';
+import { LINODE_STATUS_PAGE_URL } from 'src/constants';
 import { reportException } from 'src/exceptionReporting';
 import { queryPresets } from '../base';
 
-const BASE_URL = `https://${LINODE_STATUS_PAGE_ID}.statuspage.io/api/v2`;
-
 /**
  * Documentation for the Linode-specific statuspage API can be found at:
- * https://8dn0wstr1chc.statuspage.io/api/v2/
+ * https://status.linode.com/api/v2/
  */
 
 /**
  * Return a list of incidents with a status of "unresolved."
  */
 const getIncidents = () => {
-  return Axios.get<IncidentResponse>(`${BASE_URL}/incidents/unresolved.json`)
+  return Axios.get<IncidentResponse>(
+    `${LINODE_STATUS_PAGE_URL}/incidents/unresolved.json`
+  )
     .then((response) => response.data)
     .catch((error) => {
       // Don't show any errors sent from the statuspage API to users, but report them to Sentry
@@ -32,7 +32,7 @@ const getIncidents = () => {
  */
 const getAllMaintenance = () => {
   return Axios.get<MaintenanceResponse>(
-    `${BASE_URL}/scheduled-maintenances.json`
+    `${LINODE_STATUS_PAGE_URL}/scheduled-maintenances.json`
   )
     .then((response) => response.data)
     .catch((error) => {


### PR DESCRIPTION
## Description

Uses new env variable `LINODE_STATUS_PAGE_URL` instead of  `LINODE_STATUS_PAGE_ID` to populate system status. This also improves defaults because you no longer need an env variable for the fetch to work. 

## How to test

Ensure Manager can still fetch for system status.