### PR TITLE
M3-5285: Update the Edit Credit Card drawer to use new API endpoint

### DIFF
--- a/packages/api-v4/src/account/payments.ts
+++ b/packages/api-v4/src/account/payments.ts
@@ -136,7 +136,7 @@ export const executePaypalPayment = (data: ExecutePayload) =>
  * Add or update credit card information to your account. Only one
  * card is allowed per account, so this method will overwrite any
  * existing information.
- *
+ * @deprecated Use POST /account/payment-methods
  */
 export const saveCreditCard = (data: SaveCreditCardData) => {
   return Request<{}>(

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCard.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCard.tsx
@@ -42,8 +42,8 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 const iconMap = {
   Visa: VisaIcon,
-  Mastercard: MastercardIcon,
-  Amex: AmexIcon,
+  MasterCard: MastercardIcon,
+  'American Express': AmexIcon,
   Discover: DiscoverIcon,
   JCB: JCBIcon,
 };

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/UpdateCreditCardDrawer/UpdateCreditCardDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/UpdateCreditCardDrawer/UpdateCreditCardDrawer.tsx
@@ -125,8 +125,8 @@ export const UpdateCreditCardDrawer: React.FC<CombinedProps> = (props) => {
         cvv,
       },
     })
-      .then(async () => {
-        await queryClient.refetchQueries(['account-payment-methods-all']);
+      .then(() => {
+        queryClient.invalidateQueries('account-payment-methods-all');
         enqueueSnackbar('Successfully updated your credit card.', {
           variant: 'success',
         });

--- a/packages/manager/src/queries/accountPayment.ts
+++ b/packages/manager/src/queries/accountPayment.ts
@@ -7,12 +7,12 @@ import { getClientToken, ClientToken } from '@linode/api-v4/lib/account';
 
 const queryKey = 'account-payment-methods';
 
-export const usePaymentMethodsQuery = (params?: any) => {
+export const usePaymentMethodsQuery = (params: any = {}, filter: any = {}) => {
   return useQuery<ResourcePage<PaymentMethod>, APIError[]>(
-    [queryKey, params?.page, params?.page_size],
+    [queryKey, params, filter],
     () => getPaymentMethods(params),
     {
-      ...queryPresets.longLived,
+      ...queryPresets.oneTimeFetch,
     }
   );
 };
@@ -22,7 +22,7 @@ export const useAllPaymentMethodsQuery = () => {
     [queryKey + '-all'],
     getAllPaymentMethodsRequest,
     {
-      ...queryPresets.longLived,
+      ...queryPresets.oneTimeFetch,
     }
   );
 };


### PR DESCRIPTION
## Description

- Use `POST /account/payment-methods` since `POST /account/credit-card` is deprecated.
- Refetch payment methods after the edit occurs
- Adds a success toast 
- Updated the credit card icon map to correctly map based on the API's card types

## How to test

- Point Cloud Manager to dev environment 
- Try editing your credit card by using the `Edit` button on your credit card's action menu. 
  - You can find a list of test credit cards [here](https://developer.paypal.com/braintree/docs/guides/credit-cards/testing-go-live/php)
- Ensure you credit card gets updated, you see a success toast, and your payment methods show the new card. 
