### PR TITLE
M3-5281: Add loading spinner while GPay loads

### DIFF
--- a/packages/manager/src/components/HelpIcon/HelpIcon.tsx
+++ b/packages/manager/src/components/HelpIcon/HelpIcon.tsx
@@ -1,5 +1,6 @@
-import HelpOutline from '@material-ui/icons/HelpOutline';
 import * as React from 'react';
+import HelpOutline from '@material-ui/icons/HelpOutline';
+import ErrorOutline from '@material-ui/icons/ErrorOutline';
 import IconButton from 'src/components/core/IconButton';
 import Tooltip, { TooltipProps } from 'src/components/core/Tooltip';
 
@@ -8,6 +9,8 @@ interface Props
   text: string | JSX.Element;
   className?: string;
   interactive?: boolean;
+  isError?: boolean;
+  size?: number;
   classes?: any;
   leaveDelay?: boolean;
   tooltipPosition?:
@@ -33,6 +36,8 @@ const HelpIcon: React.FC<CombinedProps> = (props) => {
     className,
     tooltipPosition,
     interactive,
+    isError,
+    size = 24,
     leaveDelay,
     classes,
   } = props;
@@ -49,7 +54,15 @@ const HelpIcon: React.FC<CombinedProps> = (props) => {
       classes={classes}
     >
       <IconButton className={className} data-qa-help-button>
-        <HelpOutline />
+        {isError ? (
+          <ErrorOutline
+            style={{
+              fontSize: size,
+            }}
+          />
+        ) : (
+          <HelpOutline />
+        )}
       </IconButton>
     </Tooltip>
   );

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/GooglePayButton.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/GooglePayButton.tsx
@@ -16,6 +16,7 @@ import Notice from 'src/components/Notice';
 import Button from 'src/components/Button';
 import Tooltip from 'src/components/core/Tooltip';
 import CircleProgress from 'src/components/CircleProgress';
+import Grid from 'src/components/Grid';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -45,6 +46,9 @@ const useStyles = makeStyles((theme: Theme) => ({
       marginLeft: 0,
       width: '101.5%',
     },
+  },
+  loading: {
+    padding: 4,
   },
   disabled: {
     opacity: 0.3,
@@ -123,7 +127,16 @@ export const GooglePayButton: React.FC<Props> = (props) => {
   }
 
   if (isLoading) {
-    return <CircleProgress mini />;
+    return (
+      <Grid
+        container
+        className={classes.loading}
+        justify="center"
+        alignContent="center"
+      >
+        <CircleProgress mini />
+      </Grid>
+    );
   }
 
   return (

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
@@ -89,10 +89,6 @@ export const PaymentDrawer: React.FC<CombinedProps> = (props) => {
   const showGooglePay = flags.additionalPaymentMethods?.includes('google_pay');
 
   const [usd, setUSD] = React.useState<string>(getMinimumPayment(balance));
-  const [successMessage, setSuccessMessage] = React.useState<string | null>(
-    null
-  );
-  const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
   const [warning, setWarning] = React.useState<APIWarning | null>(null);
 
   const [creditCardKey, setCreditCardKey] = React.useState<string>(v4());
@@ -108,18 +104,9 @@ export const PaymentDrawer: React.FC<CombinedProps> = (props) => {
 
   React.useEffect(() => {
     if (open) {
-      setSuccessMessage(null);
       setWarning(null);
     }
   }, [open]);
-
-  React.useEffect(() => {
-    if (successMessage) {
-      enqueueSnackbar(successMessage, {
-        variant: 'success',
-      });
-    }
-  }, [successMessage, enqueueSnackbar]);
 
   const handleUSDChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setUSD(e.target.value || '');
@@ -135,8 +122,10 @@ export const PaymentDrawer: React.FC<CombinedProps> = (props) => {
     paymentWasMade = false,
     warnings = undefined
   ) => {
-    setSuccessMessage(message);
     if (paymentWasMade) {
+      enqueueSnackbar(message, {
+        variant: 'success',
+      });
       // Reset everything
       setUSD('0.00');
       setCreditCardKey(v4());
@@ -147,6 +136,12 @@ export const PaymentDrawer: React.FC<CombinedProps> = (props) => {
     if (warnings && warnings.length > 0) {
       setWarning(warnings[0]);
     }
+  };
+
+  const setError = (message: string) => {
+    enqueueSnackbar(message, {
+      variant: 'error',
+    });
   };
 
   const minimumPayment = getMinimumPayment(balance || 0);
@@ -167,7 +162,6 @@ export const PaymentDrawer: React.FC<CombinedProps> = (props) => {
     <Drawer title="Make a Payment" open={open} onClose={onClose}>
       <Grid container>
         <Grid item xs={12}>
-          {errorMessage && <Notice error text={errorMessage ?? ''} />}
           {warning ? <Warning warning={warning} /> : null}
           {balance !== false && (
             <Grid item>
@@ -233,7 +227,7 @@ export const PaymentDrawer: React.FC<CombinedProps> = (props) => {
                     }}
                     balance={balance}
                     setSuccess={setSuccess}
-                    setError={setErrorMessage}
+                    setError={setError}
                   />
                 </Grid>
               </Grid>

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/AddPaymentMethodDrawer/AddPaymentMethodDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/AddPaymentMethodDrawer/AddPaymentMethodDrawer.tsx
@@ -39,7 +39,14 @@ export const AddPaymentMethodDrawer: React.FC<Props> = (props) => {
             You&apos;ll be taken to Google Pay to complete sign up.
           </Typography>
         </Grid>
-        <Grid item xs={4} md={3}>
+        <Grid
+          container
+          item
+          xs={4}
+          md={3}
+          justify="center"
+          alignContent="center"
+        >
           <GooglePayChip makeToast={makeToast} onClose={onClose} />
         </Grid>
       </Grid>

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/AddPaymentMethodDrawer/AddPaymentMethodDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/AddPaymentMethodDrawer/AddPaymentMethodDrawer.tsx
@@ -24,21 +24,15 @@ export const AddPaymentMethodDrawer: React.FC<Props> = (props) => {
   return (
     <Drawer title="Add a Payment Method" open={open} onClose={onClose}>
       <Divider />
-      <Grid container spacing={1} className={classes.root}>
-        <Grid item xs={12} sm container alignItems="center">
-          <Grid item xs container direction="column" spacing={1}>
-            <Grid item xs>
-              <Typography variant="h3">Google Pay</Typography>
-            </Grid>
-            <Grid item xs>
-              <Typography>
-                You&apos;ll be taken to Google Pay to complete sign up.
-              </Typography>
-            </Grid>
-          </Grid>
-          <Grid item>
-            <GooglePayChip onAdd={onClose} />
-          </Grid>
+      <Grid className={classes.root} container>
+        <Grid item direction="column" xs={8} md={9}>
+          <Typography variant="h3">Google Pay</Typography>
+          <Typography>
+            You&apos;ll be taken to Google Pay to complete sign up.
+          </Typography>
+        </Grid>
+        <Grid item xs={4} md={3}>
+          <GooglePayChip onClose={onClose} />
         </Grid>
       </Grid>
     </Drawer>

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/AddPaymentMethodDrawer/AddPaymentMethodDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/AddPaymentMethodDrawer/AddPaymentMethodDrawer.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useSnackbar, VariantType } from 'notistack';
 import Divider from 'src/components/core/Divider';
 import { makeStyles } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
@@ -20,6 +21,13 @@ const useStyles = makeStyles(() => ({
 export const AddPaymentMethodDrawer: React.FC<Props> = (props) => {
   const { onClose, open } = props;
   const classes = useStyles();
+  const { enqueueSnackbar } = useSnackbar();
+
+  const makeToast = (message: string, variant: VariantType) => {
+    enqueueSnackbar(message, {
+      variant,
+    });
+  };
 
   return (
     <Drawer title="Add a Payment Method" open={open} onClose={onClose}>
@@ -32,7 +40,7 @@ export const AddPaymentMethodDrawer: React.FC<Props> = (props) => {
           </Typography>
         </Grid>
         <Grid item xs={4} md={3}>
-          <GooglePayChip onClose={onClose} />
+          <GooglePayChip makeToast={makeToast} onClose={onClose} />
         </Grid>
       </Grid>
     </Drawer>

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/GooglePayChip.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/GooglePayChip.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useSnackbar, VariantType } from 'notistack';
+import { VariantType } from 'notistack';
 import GooglePayIcon from 'src/assets/icons/payment/googlePay.svg';
 import { useScript } from 'src/hooks/useScript';
 import { useClientToken } from 'src/queries/accountPayment';
@@ -30,12 +30,12 @@ const useStyles = makeStyles(() => ({
 }));
 
 interface Props {
+  makeToast: (message: string, variant: VariantType) => void;
   onClose: () => void;
 }
 
 export const GooglePayChip: React.FC<Props> = (props) => {
-  const { onClose } = props;
-  const { enqueueSnackbar } = useSnackbar();
+  const { makeToast, onClose } = props;
   const classes = useStyles();
   const status = useScript('https://pay.google.com/gp/p/js/pay.js');
   const { data, isLoading, error: clientTokenError } = useClientToken();
@@ -57,18 +57,8 @@ export const GooglePayChip: React.FC<Props> = (props) => {
     init();
   }, [status, data]);
 
-  if (status === 'error' || clientTokenError) {
-    return <Notice error text="Error loading Google Pay." />;
-  }
-
-  if (initializationError) {
-    return <Notice error text="Error initializing Google Pay." />;
-  }
-
   const handleMessage = (message: string, variant: VariantType) => {
-    enqueueSnackbar(message, {
-      variant,
-    });
+    makeToast(message, variant);
     if (variant === 'success') {
       onClose();
     }
@@ -85,6 +75,14 @@ export const GooglePayChip: React.FC<Props> = (props) => {
       handleMessage
     );
   };
+
+  if (status === 'error' || clientTokenError) {
+    return <Notice error text="Error loading Google Pay." />;
+  }
+
+  if (initializationError) {
+    return <Notice error text="Error initializing Google Pay." />;
+  }
 
   if (isLoading) {
     return <CircleProgress mini />;

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/GooglePayChip.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/GooglePayChip.tsx
@@ -3,18 +3,19 @@ import { VariantType } from 'notistack';
 import GooglePayIcon from 'src/assets/icons/payment/googlePay.svg';
 import { useScript } from 'src/hooks/useScript';
 import { useClientToken } from 'src/queries/accountPayment';
-import { makeStyles } from 'src/components/core/styles';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import {
   initGooglePaymentInstance,
   gPay,
 } from 'src/features/Billing/Providers/GooglePay';
-import Notice from 'src/components/Notice';
 import CircleProgress from 'src/components/CircleProgress';
+import HelpIcon from 'src/components/HelpIcon';
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((theme: Theme) => ({
   button: {
     border: 0,
     padding: 0,
+    marginTop: 10,
     backgroundColor: 'transparent',
     cursor: 'pointer',
     '&:hover': {
@@ -25,6 +26,13 @@ const useStyles = makeStyles(() => ({
     opacity: 0.3,
     '&:hover': {
       opacity: 0.3,
+    },
+  },
+  errorIcon: {
+    color: theme.color.red,
+    '&:hover': {
+      color: theme.color.red,
+      opacity: 0.7,
     },
   },
 }));
@@ -76,12 +84,17 @@ export const GooglePayChip: React.FC<Props> = (props) => {
     );
   };
 
-  if (status === 'error' || clientTokenError) {
-    return <Notice error text="Error loading Google Pay." />;
-  }
-
-  if (initializationError) {
-    return <Notice error text="Error initializing Google Pay." />;
+  if (status === 'error' || clientTokenError || initializationError) {
+    return (
+      <HelpIcon
+        className={classes.errorIcon}
+        isError={true}
+        size={35}
+        text={`Error ${
+          initializationError ? 'initializing' : 'loading'
+        } Google Pay.`}
+      />
+    );
   }
 
   if (isLoading) {

--- a/packages/manager/src/features/Billing/Providers/GooglePay.ts
+++ b/packages/manager/src/features/Billing/Providers/GooglePay.ts
@@ -37,8 +37,7 @@ export const gPay = async (
   transactionInfo: Omit<google.payments.api.TransactionInfo, 'totalPrice'> & {
     totalPrice?: string;
   },
-  setMessage: (message: string, variant: VariantType) => void,
-  onSuccess?: () => void
+  setMessage: (message: string, variant: VariantType) => void
 ) => {
   if (!googlePaymentInstance) {
     return setMessage('Unable to open Google Pay.', 'error');
@@ -94,9 +93,6 @@ export const gPay = async (
         data: { nonce: 'fake-android-pay-nonce' },
         is_default: true,
       });
-      if (onSuccess) {
-        onSuccess();
-      }
       await queryClient.fetchQuery(
         'account-payment-methods',
         getAllPaymentMethodsRequest


### PR DESCRIPTION
## Description
- Adds loading spinner to the GPay Chip & Button components while Google Pay is still loading
- If there is an error loading or initializing Google Pay, the spinner is replaced by an error message
- Error messages while making a payment in the Make a Payment drawer are now toasts to match the Add Payment Method drawer
- Minor refactoring

## How to test
In `account/billing` on dev:
- Refresh the page and click on `Add Payment Method`. In the drawer, you should briefly see a loading spinner before it's replaced by the Google Pay Chip
- Refresh the page again and this time click on `Make a Payment`. In that drawer, you should briefly see a loading spinner near the bottom before it's replaced by the Google Pay Button
- Adding Gpay as a Payment Method & making a payment should still work as before
- Switch to Prod and repeat the above. Both spinners should be replaced by an error message
