### PR TITLE
M3-4721: Changes to how account balances are communicated in app

### DIFF
--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.test.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.test.tsx
@@ -24,9 +24,9 @@ describe('BillingSummary', () => {
     within(screen.getByTestId(accountBalanceValue)).getByText('$10.00');
   });
 
-  it('displays an overdue payment notice when there is a positive balance', () => {
+  it('displays the balance when there is a positive balance that is not yet past due', () => {
     renderWithTheme(<BillingSummary balance={10} balanceUninvoiced={5} />);
-    within(screen.getByTestId(accountBalanceText)).getByText(/payment due/gi);
+    within(screen.getByTestId(accountBalanceText)).getByText(/Balance/gi);
     within(screen.getByTestId(accountBalanceValue)).getByText('$10.00');
   });
 

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
@@ -87,12 +87,10 @@ export const BillingSummary: React.FC<BillingSummaryProps> = (props) => {
   const notifications = useNotifications();
 
   // If a user has a payment_due notification with a severity of critical, it indicates that they are outside of any grace period they may have and payment is due immediately.
-  const isBalanceOutsideGracePeriod = Boolean(
-    notifications.find(
-      (notification) =>
-        notification.type === 'payment_due' &&
-        notification.severity === 'critical'
-    )
+  const isBalanceOutsideGracePeriod = notifications.some(
+    (notification) =>
+      notification.type === 'payment_due' &&
+      notification.severity === 'critical'
   );
 
   const { promotions, balanceUninvoiced, balance } = props;

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
@@ -150,34 +150,17 @@ export const BillingSummary: React.FC<BillingSummaryProps> = (props) => {
     promotions && promotions.length > 0 ? { xs: 12, md: 4 } : { xs: 12, sm: 6 };
 
   const generateBalanceJSX = (balance: number, pastDueBalance: boolean) => {
-    if (pastDueBalance) {
-      return (
-        <Typography style={{ marginTop: 16 }}>
-          <button
-            className={classes.makeAPaymentButton}
-            onClick={() => replace(routeForMakePayment)}
-          >
-            Make a payment immediately
-          </button>{' '}
-          to avoid service disruption.
-        </Typography>
-      );
-    }
-
-    if (balance > 0) {
-      return (
-        <Typography style={{ marginTop: 16 }}>
-          <button
-            className={classes.makeAPaymentButton}
-            onClick={() => replace(routeForMakePayment)}
-          >
-            Make a payment.
-          </button>
-        </Typography>
-      );
-    }
-
-    return null;
+    return balance > 0 ? (
+      <Typography style={{ marginTop: 16 }}>
+        <button
+          className={classes.makeAPaymentButton}
+          onClick={() => replace(routeForMakePayment)}
+        >
+          {pastDueBalance ? 'Make a payment immediately' : 'Make a payment.'}
+        </button>
+        {pastDueBalance ? `${' '} to avoid service disruption.` : null}
+      </Typography>
+    ) : null;
   };
 
   return (

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
@@ -102,9 +102,8 @@ export const BillingSummary: React.FC<BillingSummaryProps> = (props) => {
   //
 
   // On-the-fly route matching so this component can open the drawer itself.
-  const makePaymentRouteMatch = Boolean(
-    useRouteMatch('/account/billing/make-payment')
-  );
+  const routeForMakePayment = '/account/billing/make-payment';
+  const makePaymentRouteMatch = Boolean(useRouteMatch(routeForMakePayment));
 
   const { replace } = useHistory();
 
@@ -158,7 +157,7 @@ export const BillingSummary: React.FC<BillingSummaryProps> = (props) => {
         <Typography style={{ marginTop: 16 }}>
           <button
             className={classes.makeAPaymentButton}
-            onClick={() => replace('/account/billing/make-payment')}
+            onClick={() => replace(routeForMakePayment)}
           >
             Make a payment immediately
           </button>{' '}
@@ -172,7 +171,7 @@ export const BillingSummary: React.FC<BillingSummaryProps> = (props) => {
         <Typography style={{ marginTop: 16 }}>
           <button
             className={classes.makeAPaymentButton}
-            onClick={() => replace('/account/billing/make-payment')}
+            onClick={() => replace(routeForMakePayment)}
           >
             Make a payment.
           </button>

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
@@ -152,6 +152,37 @@ export const BillingSummary: React.FC<BillingSummaryProps> = (props) => {
   const gridDimensions: Partial<Record<Breakpoint, GridSize>> =
     promotions && promotions.length > 0 ? { xs: 12, md: 4 } : { xs: 12, sm: 6 };
 
+  const generateBalanceJSX = (balance: number, pastDueBalance: boolean) => {
+    if (pastDueBalance) {
+      return (
+        <Typography style={{ marginTop: 16 }}>
+          <button
+            className={classes.makeAPaymentButton}
+            onClick={() => replace('/account/billing/make-payment')}
+          >
+            Make a payment immediately
+          </button>{' '}
+          to avoid service disruption.
+        </Typography>
+      );
+    }
+
+    if (balance > 0) {
+      return (
+        <Typography style={{ marginTop: 16 }}>
+          <button
+            className={classes.makeAPaymentButton}
+            onClick={() => replace('/account/billing/make-payment')}
+          >
+            Make a payment.
+          </button>
+        </Typography>
+      );
+    }
+
+    return null;
+  };
+
   return (
     <>
       <Grid container spacing={2} className={classes.root}>
@@ -180,17 +211,7 @@ export const BillingSummary: React.FC<BillingSummaryProps> = (props) => {
                 />
               </Typography>
             </Box>
-            {balance > 0 ? (
-              <Typography style={{ marginTop: 16 }}>
-                <button
-                  className={classes.makeAPaymentButton}
-                  onClick={() => replace('/account/billing/make-payment')}
-                >
-                  Make a payment immediately
-                </button>{' '}
-                to avoid service disruption.
-              </Typography>
-            ) : null}
+            {generateBalanceJSX(balance, pastDueBalance)}
           </Paper>
         </Grid>
         {promotions && promotions?.length > 0 ? (

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
@@ -149,8 +149,8 @@ export const BillingSummary: React.FC<BillingSummaryProps> = (props) => {
   const gridDimensions: Partial<Record<Breakpoint, GridSize>> =
     promotions && promotions.length > 0 ? { xs: 12, md: 4 } : { xs: 12, sm: 6 };
 
-  const generateBalanceJSX = (balance: number, pastDueBalance: boolean) => {
-    return balance > 0 ? (
+  const balanceJSX =
+    balance > 0 ? (
       <Typography style={{ marginTop: 16 }}>
         <button
           className={classes.makeAPaymentButton}
@@ -158,10 +158,9 @@ export const BillingSummary: React.FC<BillingSummaryProps> = (props) => {
         >
           {pastDueBalance ? 'Make a payment immediately' : 'Make a payment.'}
         </button>
-        {pastDueBalance ? `${' '} to avoid service disruption.` : null}
+        {pastDueBalance ? `${' '}to avoid service disruption.` : null}
       </Typography>
     ) : null;
-  };
 
   return (
     <>
@@ -191,7 +190,7 @@ export const BillingSummary: React.FC<BillingSummaryProps> = (props) => {
                 />
               </Typography>
             </Box>
-            {generateBalanceJSX(balance, pastDueBalance)}
+            {balanceJSX}
           </Paper>
         </Grid>
         {promotions && promotions?.length > 0 ? (

--- a/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
@@ -227,6 +227,14 @@ const interceptNotification = (
     return notification;
   }
 
+  if (
+    notification.type === 'payment_due' &&
+    notification.severity !== 'critical'
+  ) {
+    // A critical severity indicates the user's balance is past due; temper the messaging a bit outside of that case by replacing the exclamation point.
+    notification.message = notification.message.replace('!', '.');
+  }
+
   /* If the notification is not of any of the types above, return the notification object without modification. In this case, logic in <RenderNotification />
   will either linkify notifcation.message or render it plainly.
   */


### PR DESCRIPTION
## Description
For `payment_due` notifications where a user is outside of their grace period, the API will now be returning a severity of `critical` instead of `major`. We will key off of `critical` to govern the intensity of our messaging regarding account balance, on /account/billing and in the notification drawer.

## How to Test
Check two accounts: one with a past due balance, and one with an outstanding balance that is not yet past due (reach out for a couple of accounts that meet this condition already).

The account with a past due balance should have an Account Balance panel and a drawer notification that look as follows:

<img width="625" alt="Screen Shot 2021-07-08 at 12 18 38 PM" src="https://user-images.githubusercontent.com/32860776/124957134-c07fb880-dfe6-11eb-9beb-af38a351680a.png">

<img width="596" alt="Screen Shot 2021-07-08 at 12 18 53 PM" src="https://user-images.githubusercontent.com/32860776/124957140-c2497c00-dfe6-11eb-8029-489d713eb5b1.png">

The account with an outstanding balance that is not yet past due should have an Account Balance panel and a drawer notification that look as follows:

<img width="617" alt="Screen Shot 2021-07-08 at 12 20 20 PM" src="https://user-images.githubusercontent.com/32860776/124957342-f886fb80-dfe6-11eb-9efc-039034c74602.png">

<img width="606" alt="Screen Shot 2021-07-08 at 12 20 35 PM" src="https://user-images.githubusercontent.com/32860776/124957295-edcc6680-dfe6-11eb-8ca3-cdbe4798845b.png">

Other balance cases (no balance or a credit) should be unchanged from their current handling.