### PR TITLE
M3-5257: Updated font-logos and added Rocky Linux icon

### DIFF
--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -44,7 +44,7 @@
     "css-animation-sync": "^0.2.0",
     "cypress": "6.4.0",
     "flag-icon-css": "^3.3.0",
-    "font-logos": "^0.17.0",
+    "font-logos": "^0.18.0",
     "formik": "~2.1.3",
     "he": "^1.2.0",
     "highlight.js": "~10.4.1",

--- a/packages/manager/src/components/ImageSelect/icons.ts
+++ b/packages/manager/src/components/ImageSelect/icons.ts
@@ -8,6 +8,7 @@ export const distroIcons = {
   Fedora: 'fedora',
   Gentoo: 'gentoo',
   openSUSE: 'opensuse',
+  Rocky: 'rocky-linux',
   Slackware: 'slackware',
   Ubuntu: 'ubuntu',
 };


### PR DESCRIPTION
## Description

- Updates [font-logos](https://github.com/lukas-w/font-logos/releases/tag/v0.18) to `v0.18`
- Adds Rocky Linux icon to distro icon map

![Screen Shot 2021-07-07 at 5 22 58 PM](https://user-images.githubusercontent.com/6440455/124830520-ffaafc80-df47-11eb-9af3-391b132c855b.png)


## How to test

- Restart your local dev environment so dependencies get updated
- Go to `Create a Linode`, select the `Image` dropdown and make sure `Rocky Linux 8` appears with its icon. You should **not** see the default Linux penguin. 
