### PR TITLE
M3-5163: Fix Nodebalancer Table console error children with the same key

### DIFF
--- a/packages/manager/src/components/CheckoutBar/DisplaySectionList.tsx
+++ b/packages/manager/src/components/CheckoutBar/DisplaySectionList.tsx
@@ -14,14 +14,14 @@ export const DisplaySectionList: React.FC<Props> = ({ displaySections }) => {
     // eslint-disable-next-line react/jsx-no-useless-fragment
     <>
       {displaySections.map(({ title, details }, idx) => (
-        <>
+        <React.Fragment key={`fragment-${title}-${idx}`}>
           {idx !== 0 && <Divider light spacingTop={0} spacingBottom={0} />}
           <DisplaySection
             key={`${title}-${idx}`}
             title={title}
             details={details}
           />
-        </>
+        </React.Fragment>
       ))}
     </>
   );

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancerTableRow.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancerTableRow.tsx
@@ -113,7 +113,7 @@ const NodeBalancerTableRow: React.FC<CombinedProps> = (props) => {
         <TableCell data-qa-ports>
           {configs.length === 0 && 'None'}
           {configs.map(({ port, id: configId }, i) => (
-            <React.Fragment key={id}>
+            <React.Fragment key={configId}>
               <Link
                 to={`/nodebalancers/${id}/configurations/${configId}`}
                 className={classes.portLink}


### PR DESCRIPTION
## Description

- Fixes a console error telling us we need to have children with difficulty keys. 
- Fixed by using the Nodebalacer's config id when rendering the configs instead of duplicating the Nodebalancer's id. 

## How to test

- Make sure you have at least one Nodebalancer and that Nodebalancer has more than one config on it.
- Go to `/nodebalancers`
- Check your console for errors regarding duplicate keys.