### PR TITLE
M3-5280: Expand all Linode Settings accordions by default

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsAlertsPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsAlertsPanel.tsx
@@ -290,6 +290,7 @@ class LinodeSettingsAlertsPanel extends React.Component<CombinedProps, State> {
         heading="Notification Thresholds"
         success={this.state.success}
         actions={this.renderExpansionActions}
+        defaultExpanded
       >
         {generalError && <Notice error>{generalError}</Notice>}
         {alertSections.map((p, idx) => (

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsDeletePanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsDeletePanel.tsx
@@ -69,7 +69,7 @@ class LinodeSettingsDeletePanel extends React.Component<CombinedProps, State> {
 
     return (
       <React.Fragment>
-        <Accordion heading="Delete Linode">
+        <Accordion heading="Delete Linode" defaultExpanded>
           <Button
             buttonType="primary"
             destructive

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsLabelPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsLabelPanel.tsx
@@ -84,6 +84,7 @@ class LinodeSettingsLabelPanel extends React.Component<CombinedProps, State> {
       <Accordion
         heading="Linode Label"
         success={this.state.success}
+        defaultExpanded
         actions={() => (
           <ActionsPanel>
             <Button

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
@@ -59,6 +59,10 @@ class LinodeSettingsPasswordPanel extends React.Component<
     disks: [],
   };
 
+  componentDidMount() {
+    this.searchDisks();
+  }
+
   handleSubmit = () => {
     const { diskId, value } = this.state;
     const { linodeId, isBareMetalInstance } = this.props;
@@ -223,6 +227,7 @@ class LinodeSettingsPasswordPanel extends React.Component<
         success={this.state.success}
         actions={this.renderExpansionActions}
         onChange={this.handlePanelChange}
+        defaultExpanded
       >
         <form>
           {generalError && <Notice text={generalError} error />}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeWatchdogPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeWatchdogPanel.tsx
@@ -97,7 +97,11 @@ class LinodeWatchdogPanel extends React.Component<CombinedProps, State> {
     const disabled = permissions === 'read_only';
 
     return (
-      <Accordion heading="Shutdown Watchdog" data-qa-watchdog-panel>
+      <Accordion
+        heading="Shutdown Watchdog"
+        data-qa-watchdog-panel
+        defaultExpanded
+      >
         <Grid
           container
           alignItems="center"


### PR DESCRIPTION
## Description

- Expands all Linode Settings accordions by default
- Forces fetch for disks when password section is mounted

## How to test

- Visit `/linodes/{id}/settings`
- Make sure all accordions are expanded by default and all forms function as expected