### PR TITLE
payments in payment activiy table are never negative

### DIFF
--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.test.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.test.tsx
@@ -144,13 +144,13 @@ describe('paymentToActivityFeedItem', () => {
     expect(paymentToActivityFeedItem(payment).label).toBe('Refund');
   });
 
-  it('sets total as -usd', () => {
+  it('sets total as absolute value of usd', () => {
     const paymentNegative = paymentFactory.build({ usd: -1 });
     const paymentZero = paymentFactory.build({ usd: 0 });
     const paymentPositive = paymentFactory.build({ usd: 1 });
     expect(paymentToActivityFeedItem(paymentNegative).total).toBe(1);
     expect(paymentToActivityFeedItem(paymentZero).total).toBe(0);
-    expect(paymentToActivityFeedItem(paymentPositive).total).toBe(-1);
+    expect(paymentToActivityFeedItem(paymentPositive).total).toBe(1);
   });
 
   describe('getCutoffFromDateRange', () => {

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -586,9 +586,6 @@ export const paymentToActivityFeedItem = (
   // Refunds are issued as negative payments.
   const label = usd < 0 ? 'Refund' : `Payment #${payment.id}`;
 
-  // Note: this is confusing.
-  // We flip the polarity here, since we display a positive payment as e.g. "-($5.00)"
-  // and a negative payment (i.e. refund) as e.g. "$5.00"
   const total = Math.abs(usd);
 
   return {

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -589,7 +589,7 @@ export const paymentToActivityFeedItem = (
   // Note: this is confusing.
   // We flip the polarity here, since we display a positive payment as e.g. "-($5.00)"
   // and a negative payment (i.e. refund) as e.g. "$5.00"
-  const total = usd <= 0 ? Math.abs(usd) : -usd;
+  const total = Math.abs(usd);
 
   return {
     label,


### PR DESCRIPTION
## Description

Payments listed in the Billing & Payment History table will no longer show payments as a negative number in parentheses. The number of a credit or debt will be shown as the absolute value of the credit or debt. Instead relying on other information to show a credit as opposed to a debt.  

## How to test

Load an account with debts and credits to verify the parenthesis should not be shown. 
run: `yarn workspace linode-manager run test BillingActivityPanel`
