### PR TITLE
Deep link Add Payment Method Drawer

### DIFF
--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.tsx
@@ -1,6 +1,7 @@
 import { PaymentMethod } from '@linode/api-v4';
 import { APIError } from '@linode/api-v4/lib/types';
 import * as React from 'react';
+import { useHistory, useRouteMatch } from 'react-router-dom';
 import GooglePay from 'src/assets/icons/providers/google-logo.svg';
 import Button from 'src/components/Button';
 import Box from 'src/components/core/Box';
@@ -63,26 +64,36 @@ const PaymentInformation: React.FC<Props> = (props) => {
 
   const classes = useStyles();
   const flags = useFlags();
+  const { replace } = useHistory();
 
-  const isGooglePayEnabled = flags.additionalPaymentMethods?.includes(
-    'google_pay'
+  const addPaymentMethodRouteMatch = Boolean(
+    useRouteMatch('/account/billing/add-payment-method')
   );
 
-  const openAddDrawer = () => {
-    setAddDrawerOpen(true);
-  };
+  const openAddDrawer = React.useCallback(() => setAddDrawerOpen(true), []);
+
+  const closeAddDrawer = React.useCallback(() => {
+    setAddDrawerOpen(false);
+    replace('/account/billing');
+  }, [replace]);
 
   const openEditDrawer = () => {
     setEditDrawerOpen(true);
   };
 
-  const closeAddDrawer = () => {
-    setAddDrawerOpen(false);
-  };
-
   const closeEditDrawer = () => {
     setEditDrawerOpen(false);
   };
+
+  React.useEffect(() => {
+    if (addPaymentMethodRouteMatch) {
+      openAddDrawer();
+    }
+  }, [addPaymentMethodRouteMatch, openAddDrawer]);
+
+  const isGooglePayEnabled = flags.additionalPaymentMethods?.includes(
+    'google_pay'
+  );
 
   return (
     <Grid className={classes.root} item xs={12} md={6}>
@@ -96,7 +107,10 @@ const PaymentInformation: React.FC<Props> = (props) => {
           </Typography>
 
           {isGooglePayEnabled ? (
-            <Button className={classes.edit} onClick={openAddDrawer}>
+            <Button
+              className={classes.edit}
+              onClick={() => replace('/account/billing/add-payment-method')}
+            >
               Add Payment Method
             </Button>
           ) : null}
@@ -135,7 +149,10 @@ const PaymentInformation: React.FC<Props> = (props) => {
             <GooglePay width={16} height={16} />
             <Typography className={classes.googlePayNotice}>
               Google Pay is now available for recurring payments.{' '}
-              <Link to="#" onClick={openAddDrawer}>
+              <Link
+                to="#"
+                onClick={() => replace('/account/billing/add-payment-method')}
+              >
                 Add Google Pay
               </Link>
             </Typography>

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.tsx
@@ -66,9 +66,9 @@ const PaymentInformation: React.FC<Props> = (props) => {
   const flags = useFlags();
   const { replace } = useHistory();
 
-  const addPaymentMethodRouteMatch = Boolean(
-    useRouteMatch('/account/billing/add-payment-method')
-  );
+  const drawerLink = '/account/billing/add-payment-method';
+
+  const addPaymentMethodRouteMatch = Boolean(useRouteMatch(drawerLink));
 
   const openAddDrawer = React.useCallback(() => setAddDrawerOpen(true), []);
 
@@ -109,7 +109,7 @@ const PaymentInformation: React.FC<Props> = (props) => {
           {isGooglePayEnabled ? (
             <Button
               className={classes.edit}
-              onClick={() => replace('/account/billing/add-payment-method')}
+              onClick={() => replace(drawerLink)}
             >
               Add Payment Method
             </Button>
@@ -149,10 +149,7 @@ const PaymentInformation: React.FC<Props> = (props) => {
             <GooglePay width={16} height={16} />
             <Typography className={classes.googlePayNotice}>
               Google Pay is now available for recurring payments.{' '}
-              <Link
-                to="#"
-                onClick={() => replace('/account/billing/add-payment-method')}
-              >
+              <Link to="#" onClick={() => replace(drawerLink)}>
                 Add Google Pay
               </Link>
             </Typography>


### PR DESCRIPTION
## Description

Adds a deep link to the `Add a Payment Method` drawer at `/account/billing/add-payment-method`.  This works the same way `/account/billing/make-payment` works. This is very beneficial because support can link customers directly to the open drawer. 

## How to test

- Make sure going to `/account/billing/add-payment-method` opens the drawer.
- Make sure the drawer still functions as expected
