### PR TITLE
M3-5298: Change Default Payment Method

### DIFF
--- a/packages/api-v4/src/account/payments.ts
+++ b/packages/api-v4/src/account/payments.ts
@@ -198,3 +198,11 @@ export const addPaymentMethod = (data: PaymentMethodData) => {
     setData(data, PaymentMethodSchema)
   );
 };
+
+export const editPaymentMethod = (id: number, data: any) => {
+  return Request<{}>(
+    setURL(`${API_ROOT}/account/payment-methods/${id}`),
+    setMethod('PUT'),
+    setData(data)
+  );
+};

--- a/packages/api-v4/src/account/payments.ts
+++ b/packages/api-v4/src/account/payments.ts
@@ -205,7 +205,7 @@ export const addPaymentMethod = (data: PaymentMethodData) => {
  */
 export const makeDefaultPaymentMethod = (id: number) => {
   return Request<{}>(
-    setURL(`${API_ROOT}/account/payment-methods/${id}/default`),
+    setURL(`${API_ROOT}/account/payment-methods/${id}/make-default`),
     setMethod('POST')
   );
 };

--- a/packages/api-v4/src/account/payments.ts
+++ b/packages/api-v4/src/account/payments.ts
@@ -162,6 +162,22 @@ export const getPaymentMethods = (params?: any) => {
 };
 
 /**
+ * getPaymentMethod
+ *
+ * Gets information about a specific payment method on
+ * your account.
+ *
+ * @param id {number} the id of the payment method
+ *
+ */
+export const getPaymentMethod = (id: number) => {
+  return Request<PaymentMethod>(
+    setURL(`${API_ROOT}/account/payment-method/${id}`),
+    setMethod('GET')
+  );
+};
+
+/**
  * getClientToken
  *
  * Gets a unique token that is used to interact with the
@@ -200,7 +216,10 @@ export const addPaymentMethod = (data: PaymentMethodData) => {
 };
 
 /**
+ * makeDefaultPaymentMethod
+ *
  * Action endpoint to change your default payment method
+ *
  * @param id {number} id of the payment method
  */
 export const makeDefaultPaymentMethod = (id: number) => {

--- a/packages/api-v4/src/account/payments.ts
+++ b/packages/api-v4/src/account/payments.ts
@@ -199,10 +199,13 @@ export const addPaymentMethod = (data: PaymentMethodData) => {
   );
 };
 
-export const editPaymentMethod = (id: number, data: any) => {
+/**
+ * Action endpoint to change your default payment method
+ * @param id {number} id of the payment method
+ */
+export const makeDefaultPaymentMethod = (id: number) => {
   return Request<{}>(
-    setURL(`${API_ROOT}/account/payment-methods/${id}`),
-    setMethod('PUT'),
-    setData(data)
+    setURL(`${API_ROOT}/account/payment-methods/${id}/default`),
+    setMethod('POST')
   );
 };

--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -387,6 +387,7 @@ export interface AccountMaintenance {
 }
 
 export interface PaymentMethod {
+  id: number;
   type: PaymentType;
   is_default: boolean;
   created: string;

--- a/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.stories.tsx
+++ b/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.stories.tsx
@@ -11,6 +11,7 @@ const card = (type: CardType) => {
     <>
       <PaymentMethodRow
         paymentMethod={{
+          id: 0,
           type: 'credit_card',
           is_default: true,
           created: '2021-06-01T20:14:49',
@@ -23,6 +24,7 @@ const card = (type: CardType) => {
       />
       <PaymentMethodRow
         paymentMethod={{
+          id: 0,
           type: 'credit_card',
           is_default: false,
           created: '2021-06-01T20:14:49',
@@ -54,6 +56,7 @@ export const GooglePay = () => (
   <>
     <PaymentMethodRow
       paymentMethod={{
+        id: 0,
         data: {
           card_type: 'Discover',
           expiry: '12/2022',
@@ -66,6 +69,7 @@ export const GooglePay = () => (
     />
     <PaymentMethodRow
       paymentMethod={{
+        id: 0,
         data: {
           card_type: 'Discover',
           expiry: '12/2022',
@@ -83,6 +87,7 @@ export const PayPal = () => (
   <>
     <PaymentMethodRow
       paymentMethod={{
+        id: 0,
         data: {
           card_type: 'Discover',
           expiry: '12/2022',
@@ -95,6 +100,7 @@ export const PayPal = () => (
     />
     <PaymentMethodRow
       paymentMethod={{
+        id: 0,
         data: {
           card_type: 'Discover',
           expiry: '12/2022',

--- a/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.tsx
+++ b/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.tsx
@@ -14,6 +14,7 @@ import ActionMenu, { Action } from 'src/components/ActionMenu';
 import { makeDefaultPaymentMethod } from '@linode/api-v4/lib';
 import { useSnackbar } from 'notistack';
 import { queryClient } from 'src/queries/base';
+import { queryKey } from 'src/queries/accountPayment';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -50,26 +51,10 @@ const PaymentMethodRow: React.FC<Props> = (props) => {
   const makeDefault = async (id: number) => {
     try {
       await makeDefaultPaymentMethod(id);
-
-      queryClient.setQueryData(
-        'account-payment-methods-all',
-        (oldData: PaymentMethod[]) => {
-          const otherPaymentMethods = oldData
-            .filter((method: PaymentMethod) => method.id !== paymentMethod.id)
-            .map((method) => (method.is_default = false));
-
-          return [
-            ...otherPaymentMethods,
-            {
-              ...paymentMethod,
-              is_default: true,
-            },
-          ];
-        }
-      );
+      queryClient.invalidateQueries(`${queryKey}-all`);
     } catch (errors) {
       enqueueSnackbar(
-        errors[0].reason || `Unable to change your default payment method.`,
+        errors[0]?.reason || `Unable to change your default payment method.`,
         { variant: 'error' }
       );
     }

--- a/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.tsx
+++ b/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.tsx
@@ -69,8 +69,7 @@ const PaymentMethodRow: React.FC<Props> = (props) => {
       );
     } catch (errors) {
       enqueueSnackbar(
-        errors[0].reason ||
-          `Unable to make your ${paymentMethod.type} default.`,
+        errors[0].reason || `Unable to change your default payment method.`,
         { variant: 'error' }
       );
     }

--- a/packages/manager/src/factories/accountPayment.ts
+++ b/packages/manager/src/factories/accountPayment.ts
@@ -2,6 +2,7 @@ import * as Factory from 'factory.ts';
 import { PaymentMethod } from '@linode/api-v4';
 
 export const paymentMethodFactory = Factory.Sync.makeFactory<PaymentMethod>({
+  id: 0,
   data: {
     expiry: '12/2022',
     last_four: '1881',

--- a/packages/manager/src/factories/accountPayment.ts
+++ b/packages/manager/src/factories/accountPayment.ts
@@ -2,7 +2,7 @@ import * as Factory from 'factory.ts';
 import { PaymentMethod } from '@linode/api-v4';
 
 export const paymentMethodFactory = Factory.Sync.makeFactory<PaymentMethod>({
-  id: 0,
+  id: Factory.each((id: number) => id),
   data: {
     expiry: '12/2022',
     last_four: '1881',


### PR DESCRIPTION
## Description

- [x] Adds support for `POST  /account/payment-methods/:id/make-default`
- [x] Adds the `id` field to the `PaymentMethod` type
- [x] Adds `GET /account/payment-methods/:id`
- [x] Ability to change default payment method

## How to test

- Click `Make Default` in a payment method's action menu and make sure it becomes your default payment method
