### PR TITLE
M3-5247: Remove "Other Entities" from Monthly Network Transfer section of Network tab

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkTransfer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkTransfer.tsx
@@ -126,15 +126,11 @@ const TransferContent: React.FC<ContentProps> = (props) => {
   const classes = useStyles();
 
   /**
-   * In this component we display four pieces of information:
+   * In this component we display three pieces of information:
    *
    * 1. Account-level transfer quota for this month
    * 2. The amount of transfer THIS Linode has used this month
-   * 3. The amount of transfer OTHER things on your account have used this month
-   * 4. The remaining transfer on your account this month
-   *
-   * The value for #3 comes from subtracting the transfer THIS Linode has used from the TOTAL
-   * transfer used on the account.
+   * 3. The remaining transfer on your account this month
    */
 
   const linodeUsagePercent = calculatePercentageWithCeiling(
@@ -147,7 +143,6 @@ const TransferContent: React.FC<ContentProps> = (props) => {
     accountQuotaInGB
   );
 
-  const otherEntitiesUsedInGB = Math.max(totalUsedInGB - linodeUsedInGB, 0);
   const remainingInGB = Math.max(accountQuotaInGB - totalUsedInGB, 0);
 
   if (error) {
@@ -185,11 +180,6 @@ const TransferContent: React.FC<ContentProps> = (props) => {
       <Typography className={`${classes.legendItem} ${classes.darkGreen}`}>
         {linodeLabel} ({linodeUsedInGB} GB)
       </Typography>
-      {otherEntitiesUsedInGB > 0 && (
-        <Typography className={`${classes.legendItem} ${classes.lightGreen}`}>
-          Other entities ({otherEntitiesUsedInGB} GB)
-        </Typography>
-      )}
       <Typography className={`${classes.legendItem} ${classes.grey}`}>
         Remaining ({remainingInGB} GB)
       </Typography>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkTransfer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkTransfer.tsx
@@ -39,11 +39,6 @@ const useStyles = makeStyles((theme: Theme) => ({
       backgroundColor: '#5ad865',
     },
   },
-  lightGreen: {
-    '&:before': {
-      backgroundColor: '#99ec79',
-    },
-  },
   grey: {
     '&:before': {
       backgroundColor: theme.color.grey2,


### PR DESCRIPTION
## Description
The "Other Entities" data point has been a recurring source of confusion and opaque fluctuations. This PR removes it since Monthly Network Transfer Pool was added back to the Linodes landing page a while ago.

## How to test
Checking the "Network" tab of a Linode detail page, "Other Entities" should no longer be listed in the "Monthly Network Transfer" section. Confirm that no other data or graphs are thrown off by this removal.
