### PR TITLE
Show card info for GPay in Payment Methods paper

### DIFF
--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -390,11 +390,7 @@ export interface PaymentMethod {
   type: PaymentType;
   is_default: boolean;
   created: string;
-  data: {
-    card_type: CardType;
-    last_four: string;
-    expiry: string;
-  };
+  data: CreditCard;
 }
 
 export interface ClientToken {

--- a/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.stories.tsx
+++ b/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.stories.tsx
@@ -6,16 +6,16 @@ export default {
   title: 'Payment Method Row',
 };
 
-const render = (paymentMethod: PaymentType, type: CardType) => {
+const render = (paymentMethodType: PaymentType, cardType: CardType) => {
   return (
     <>
       <PaymentMethodRow
         paymentMethod={{
-          type: paymentMethod,
+          type: paymentMethodType,
           is_default: true,
           created: '2021-06-01T20:14:49',
           data: {
-            card_type: type,
+            card_type: cardType,
             last_four: '1234',
             expiry: '10/2025',
           },
@@ -23,11 +23,11 @@ const render = (paymentMethod: PaymentType, type: CardType) => {
       />
       <PaymentMethodRow
         paymentMethod={{
-          type: paymentMethod,
+          type: paymentMethodType,
           is_default: false,
           created: '2021-06-01T20:14:49',
           data: {
-            card_type: type,
+            card_type: cardType,
             last_four: '1234',
             expiry: '10/2025',
           },

--- a/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.stories.tsx
+++ b/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.stories.tsx
@@ -1,17 +1,17 @@
 import * as React from 'react';
 import PaymentMethodRow from './PaymentMethodRow';
-import { CardType } from '@linode/api-v4/lib/account/types';
+import { PaymentType, CardType } from '@linode/api-v4/lib/account/types';
 
 export default {
   title: 'Payment Method Row',
 };
 
-const card = (type: CardType) => {
+const render = (paymentMethod: PaymentType, type: CardType) => {
   return (
     <>
       <PaymentMethodRow
         paymentMethod={{
-          type: 'credit_card',
+          type: paymentMethod,
           is_default: true,
           created: '2021-06-01T20:14:49',
           data: {
@@ -23,7 +23,7 @@ const card = (type: CardType) => {
       />
       <PaymentMethodRow
         paymentMethod={{
-          type: 'credit_card',
+          type: paymentMethod,
           is_default: false,
           created: '2021-06-01T20:14:49',
           data: {
@@ -37,73 +37,19 @@ const card = (type: CardType) => {
   );
 };
 
-export const Visa = () => card('Visa');
+export const Visa = () => render('credit_card', 'Visa');
 
-export const Mastercard = () => card('MasterCard');
+export const Mastercard = () => render('credit_card', 'MasterCard');
 
-export const Amex = () => card('American Express');
+export const Amex = () => render('credit_card', 'American Express');
 
-export const Discover = () => card('Discover');
+export const Discover = () => render('credit_card', 'Discover');
 
-export const JCB = () => card('JCB');
+export const JCB = () => render('credit_card', 'JCB');
 
 // @ts-expect-error This is just an example
-export const Other = () => card('Other');
+export const Other = () => render('credit_card', 'Other');
 
-export const GooglePay = () => (
-  <>
-    <PaymentMethodRow
-      paymentMethod={{
-        data: {
-          card_type: 'Discover',
-          expiry: '12/2022',
-          last_four: '1111',
-        },
-        is_default: true,
-        created: '2021-06-01T20:14:49',
-        type: 'google_pay',
-      }}
-    />
-    <PaymentMethodRow
-      paymentMethod={{
-        data: {
-          card_type: 'Discover',
-          expiry: '12/2022',
-          last_four: '1111',
-        },
-        is_default: false,
-        created: '2021-06-01T20:14:49',
-        type: 'google_pay',
-      }}
-    />
-  </>
-);
+export const GooglePay = () => render('google_pay', 'Discover');
 
-export const PayPal = () => (
-  <>
-    <PaymentMethodRow
-      paymentMethod={{
-        data: {
-          card_type: 'Discover',
-          expiry: '12/2022',
-          last_four: '1111',
-        },
-        is_default: true,
-        created: '2021-06-01T20:14:49',
-        type: 'paypal',
-      }}
-    />
-    <PaymentMethodRow
-      paymentMethod={{
-        data: {
-          card_type: 'Discover',
-          expiry: '12/2022',
-          last_four: '1111',
-        },
-        is_default: false,
-        created: '2021-06-01T20:14:49',
-        type: 'paypal',
-      }}
-    />
-  </>
-);
+export const PayPal = () => render('paypal', 'MasterCard');

--- a/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.tsx
+++ b/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.tsx
@@ -75,7 +75,7 @@ const PaymentMethodRow: React.FC<CombinedProps> = (props) => {
             />
           )}
         </Grid>
-        <Grid item className={classes.item}>
+        <Grid item className={classes.item} style={{ paddingRight: 0 }}>
           {is_default && (
             <Chip className={classes.chip} label="DEFAULT" component="span" />
           )}

--- a/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.tsx
+++ b/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.tsx
@@ -9,7 +9,7 @@ import Paper from 'src/components/core/Paper';
 import Grid from 'src/components/Grid';
 import Chip from 'src/components/core/Chip';
 import CreditCard from 'src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCard';
-import ThirdPartyPayment, { thirdPartyPaymentMap } from './ThirdPartyPayment';
+import ThirdPartyPayment from './ThirdPartyPayment';
 import ActionMenu, { Action } from 'src/components/ActionMenu';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -41,7 +41,7 @@ type CombinedProps = Props;
 
 const PaymentMethodRow: React.FC<CombinedProps> = (props) => {
   const { paymentMethod, onEdit } = props;
-  const { data, type, is_default } = paymentMethod;
+  const { data: creditCard, type, is_default } = paymentMethod;
   const classes = useStyles();
   const history = useHistory();
 
@@ -67,14 +67,11 @@ const PaymentMethodRow: React.FC<CombinedProps> = (props) => {
       <Grid container className={classes.container}>
         <Grid item className={classes.item}>
           {paymentMethod.type === 'credit_card' ? (
-            <CreditCard
-              type={data?.card_type}
-              lastFour={data?.last_four}
-              expiry={data?.expiry}
-            />
+            <CreditCard creditCard={creditCard} />
           ) : (
             <ThirdPartyPayment
               thirdPartyPayment={type as ThirdPartyPaymentTypes}
+              creditCard={creditCard}
             />
           )}
         </Grid>
@@ -86,11 +83,7 @@ const PaymentMethodRow: React.FC<CombinedProps> = (props) => {
         <Grid item className={classes.actions}>
           <ActionMenu
             actionsList={actions}
-            ariaLabel={`Action menu for ${
-              type === 'credit_card'
-                ? `card ending in ${data?.last_four}`
-                : thirdPartyPaymentMap[type]?.label
-            }`}
+            ariaLabel={`Action menu for card ending in ${creditCard?.last_four}`}
           />
         </Grid>
       </Grid>

--- a/packages/manager/src/components/PaymentMethodRow/ThirdPartyPayment.tsx
+++ b/packages/manager/src/components/PaymentMethodRow/ThirdPartyPayment.tsx
@@ -4,7 +4,11 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import GooglePayIcon from 'src/assets/icons/payment/googlePay.svg';
 import PayPalIcon from 'src/assets/icons/payment/payPal.svg';
-import { ThirdPartyPayment as ThirdPartyPaymentType } from '@linode/api-v4/lib/account/types';
+import {
+  CreditCard as CreditCardType,
+  ThirdPartyPayment as ThirdPartyPaymentType,
+} from '@linode/api-v4/lib/account/types';
+import CreditCard from 'src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCard';
 
 const useStyles = makeStyles((theme: Theme) => ({
   icon: {
@@ -14,6 +18,10 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   paymentText: {
     fontWeight: 'bold',
+    display: 'flex',
+  },
+  paymentLabel: {
+    marginRight: 8,
   },
   payPal: {
     border: `1px solid ${theme.color.grey2}`,
@@ -35,6 +43,7 @@ export const thirdPartyPaymentMap = {
 
 interface Props {
   thirdPartyPayment: ThirdPartyPaymentType;
+  creditCard: CreditCardType;
 }
 
 const getIcon = (paymentMethod: ThirdPartyPaymentType) => {
@@ -44,7 +53,7 @@ const getIcon = (paymentMethod: ThirdPartyPaymentType) => {
 export type CombinedProps = Props;
 
 export const TPP: React.FC<CombinedProps> = (props) => {
-  const { thirdPartyPayment } = props;
+  const { thirdPartyPayment, creditCard } = props;
 
   const classes = useStyles();
 
@@ -60,7 +69,10 @@ export const TPP: React.FC<CombinedProps> = (props) => {
         />
       </span>
       <Typography className={classes.paymentText}>
-        &nbsp;{thirdPartyPaymentMap[thirdPartyPayment].label}
+        <span className={classes.paymentLabel}>
+          &nbsp;{thirdPartyPaymentMap[thirdPartyPayment].label}
+        </span>
+        <CreditCard creditCard={creditCard} showIcon={false} />
       </Typography>
     </>
   );

--- a/packages/manager/src/components/PaymentMethodRow/ThirdPartyPayment.tsx
+++ b/packages/manager/src/components/PaymentMethodRow/ThirdPartyPayment.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
 import { makeStyles, Theme } from 'src/components/core/styles';
-import Typography from 'src/components/core/Typography';
 import GooglePayIcon from 'src/assets/icons/payment/googlePay.svg';
 import PayPalIcon from 'src/assets/icons/payment/payPal.svg';
 import {
@@ -57,7 +56,7 @@ export const TPP: React.FC<CombinedProps> = (props) => {
 
   const classes = useStyles();
 
-  const Icon = thirdPartyPayment && getIcon(thirdPartyPayment);
+  const Icon = getIcon(thirdPartyPayment);
 
   return (
     <>
@@ -69,9 +68,6 @@ export const TPP: React.FC<CombinedProps> = (props) => {
         />
       </span>
       <div className={classes.paymentContainer}>
-        <Typography className={classes.paymentLabel}>
-          &nbsp;{thirdPartyPaymentMap[thirdPartyPayment].label}
-        </Typography>
         <CreditCard creditCard={creditCard} showIcon={false} />
       </div>
     </>

--- a/packages/manager/src/components/PaymentMethodRow/ThirdPartyPayment.tsx
+++ b/packages/manager/src/components/PaymentMethodRow/ThirdPartyPayment.tsx
@@ -16,11 +16,11 @@ const useStyles = makeStyles((theme: Theme) => ({
     justifyContent: 'center',
     width: 45,
   },
-  paymentText: {
-    fontWeight: 'bold',
+  paymentContainer: {
     display: 'flex',
   },
   paymentLabel: {
+    fontWeight: 'bold',
     marginRight: 8,
   },
   payPal: {
@@ -68,12 +68,12 @@ export const TPP: React.FC<CombinedProps> = (props) => {
           })}
         />
       </span>
-      <Typography className={classes.paymentText}>
-        <span className={classes.paymentLabel}>
+      <div className={classes.paymentContainer}>
+        <Typography className={classes.paymentLabel}>
           &nbsp;{thirdPartyPaymentMap[thirdPartyPayment].label}
-        </span>
+        </Typography>
         <CreditCard creditCard={creditCard} showIcon={false} />
-      </Typography>
+      </div>
     </>
   );
 };

--- a/packages/manager/src/components/PaymentMethodRow/ThirdPartyPayment.tsx
+++ b/packages/manager/src/components/PaymentMethodRow/ThirdPartyPayment.tsx
@@ -27,6 +27,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   paymentMethodLabel: {
     fontWeight: 'bold',
     marginRight: 8,
+    marginLeft: 3,
   },
   payPal: {
     border: `1px solid ${theme.color.grey2}`,
@@ -78,7 +79,7 @@ export const TPP: React.FC<CombinedProps> = (props) => {
       <div className={classes.paymentTextContainer}>
         {!matchesSmDown ? (
           <Typography className={classes.paymentMethodLabel}>
-            &nbsp;{thirdPartyPaymentMap[thirdPartyPayment].label}
+            {thirdPartyPaymentMap[thirdPartyPayment].label}
           </Typography>
         ) : null}
         <CreditCard creditCard={creditCard} showIcon={false} />

--- a/packages/manager/src/components/PaymentMethodRow/ThirdPartyPayment.tsx
+++ b/packages/manager/src/components/PaymentMethodRow/ThirdPartyPayment.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
 import * as classNames from 'classnames';
-import { makeStyles, Theme } from 'src/components/core/styles';
+import {
+  makeStyles,
+  Theme,
+  useMediaQuery,
+  useTheme,
+} from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
 import GooglePayIcon from 'src/assets/icons/payment/googlePay.svg';
 import PayPalIcon from 'src/assets/icons/payment/payPal.svg';
 import {
@@ -15,10 +21,10 @@ const useStyles = makeStyles((theme: Theme) => ({
     justifyContent: 'center',
     width: 45,
   },
-  paymentContainer: {
+  paymentTextContainer: {
     display: 'flex',
   },
-  paymentLabel: {
+  paymentMethodLabel: {
     fontWeight: 'bold',
     marginRight: 8,
   },
@@ -55,6 +61,8 @@ export const TPP: React.FC<CombinedProps> = (props) => {
   const { thirdPartyPayment, creditCard } = props;
 
   const classes = useStyles();
+  const theme = useTheme<Theme>();
+  const matchesSmDown = useMediaQuery(theme.breakpoints.down('sm'));
 
   const Icon = getIcon(thirdPartyPayment);
 
@@ -67,7 +75,12 @@ export const TPP: React.FC<CombinedProps> = (props) => {
           })}
         />
       </span>
-      <div className={classes.paymentContainer}>
+      <div className={classes.paymentTextContainer}>
+        {!matchesSmDown ? (
+          <Typography className={classes.paymentMethodLabel}>
+            &nbsp;{thirdPartyPaymentMap[thirdPartyPayment].label}
+          </Typography>
+        ) : null}
         <CreditCard creditCard={creditCard} showIcon={false} />
       </div>
     </>

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCard.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCard.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as classnames from 'classnames';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import { CardType } from '@linode/api-v4/lib/account/types';
 import Typography from 'src/components/core/Typography';
@@ -76,15 +75,9 @@ export const CreditCard: React.FC<CombinedProps> = (props) => {
           <Icon />
         </span>
       ) : null}
-      <div
-        className={classnames({
-          [classes.card]: true,
-        })}
-      >
+      <div className={classes.card}>
         <Typography className={classes.cardInfo} data-qa-contact-cc>
-          {lastFour
-            ? `${type || 'Card ending in'} ****${lastFour}`
-            : 'No credit card on file.'}
+          {`${type || 'Card ending in'} ****${lastFour}`}
         </Typography>
         <Typography data-qa-contact-cc-exp-date>
           {expiry && isCreditCardExpired(expiry) ? (

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCard.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCard.tsx
@@ -10,6 +10,7 @@ import AmexIcon from 'src/assets/icons/payment/amex.svg';
 import DiscoverIcon from 'src/assets/icons/payment/discover.svg';
 import JCBIcon from 'src/assets/icons/payment/jcb.svg';
 import GenericCardIcon from 'src/assets/icons/credit-card.svg';
+import { CreditCard as CreditCardType } from '@linode/api-v4/lib/account/types';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -49,9 +50,8 @@ const iconMap = {
 };
 
 interface Props {
-  type?: CardType | null;
-  lastFour?: string | null;
-  expiry?: string | null;
+  creditCard: CreditCardType;
+  showIcon?: boolean;
 }
 
 const getIcon = (type: CardType) => {
@@ -61,16 +61,21 @@ const getIcon = (type: CardType) => {
 export type CombinedProps = Props;
 
 export const CreditCard: React.FC<CombinedProps> = (props) => {
-  const { type, lastFour, expiry } = props;
+  const {
+    creditCard: { card_type: type = undefined, last_four: lastFour, expiry },
+    showIcon = true,
+  } = props;
 
   const classes = useStyles();
   const Icon = type ? getIcon(type) : GenericCardIcon;
 
   return (
     <div className={classes.root}>
-      <span className={classes.icon}>
-        <Icon />
-      </span>
+      {showIcon ? (
+        <span className={classes.icon}>
+          <Icon />
+        </span>
+      ) : null}
       <div
         className={classnames({
           [classes.card]: true,

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCardPayment.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCardPayment.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
-import { makePayment, CardType } from '@linode/api-v4/lib/account';
+import {
+  makePayment,
+  CreditCard as CreditCardType,
+} from '@linode/api-v4/lib/account';
 import isCreditCardExpired, { formatExpiry } from 'src/utilities/creditCard';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { cleanCVV } from 'src/features/Billing/billingUtils';
@@ -51,9 +54,7 @@ const useStyles = makeStyles(() => ({
 }));
 
 export interface Props {
-  type?: CardType | null;
-  lastFour: string;
-  expiry: string;
+  creditCard: CreditCardType;
   usd: string;
   minimumPayment: string;
   setSuccess: SetSuccess;
@@ -61,15 +62,7 @@ export interface Props {
 }
 
 export const CreditCardPayment: React.FC<Props> = (props) => {
-  const {
-    type,
-    expiry,
-    lastFour,
-    minimumPayment,
-    usd,
-    setSuccess,
-    disabled,
-  } = props;
+  const { creditCard, minimumPayment, usd, setSuccess, disabled } = props;
   const [cvv, setCVV] = React.useState<string>('');
   const [dialogOpen, setDialogOpen] = React.useState<boolean>(false);
   const [submitting, setSubmitting] = React.useState<boolean>(false);
@@ -79,7 +72,8 @@ export const CreditCardPayment: React.FC<Props> = (props) => {
   const flags = useFlags();
 
   const showGooglePay = flags.additionalPaymentMethods?.includes('google_pay');
-  const isCardExpired = (expiry && isCreditCardExpired(expiry)) || false;
+  const isCardExpired =
+    (creditCard.expiry && isCreditCardExpired(creditCard.expiry)) || false;
   const paymentTooLow = +usd < +minimumPayment;
 
   const handleCVVChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -137,9 +131,9 @@ export const CreditCardPayment: React.FC<Props> = (props) => {
         {showGooglePay ? (
           <>
             <Grid item className={classes.cardSectionNew}>
-              <CreditCard type={type} expiry={expiry} lastFour={lastFour} />
+              <CreditCard creditCard={creditCard} />
             </Grid>
-            {lastFour ? (
+            {creditCard.last_four ? (
               <Grid item className={classes.input}>
                 <Grid item>
                   <TextField
@@ -171,17 +165,17 @@ export const CreditCardPayment: React.FC<Props> = (props) => {
               </Grid>
             ) : null}
           </>
-        ) : lastFour ? (
+        ) : creditCard.last_four ? (
           <>
             <Grid item>
               <Grid container direction="row" wrap="nowrap" alignItems="center">
                 <Grid item className={classes.cardSection}>
                   <Typography className={classes.cardText}>
-                    Card ending in {lastFour}
+                    Card ending in {creditCard.last_four}
                   </Typography>
-                  {Boolean(expiry) && (
+                  {Boolean(creditCard.expiry) && (
                     <Typography className={classes.cardText}>
-                      Expires {formatExpiry(expiry)}
+                      Expires {formatExpiry(creditCard.expiry ?? '')}
                     </Typography>
                   )}
                 </Grid>
@@ -204,7 +198,7 @@ export const CreditCardPayment: React.FC<Props> = (props) => {
               <Button
                 buttonType="primary"
                 onClick={handleOpenDialog}
-                disabled={!lastFour || paymentTooLow}
+                disabled={!creditCard.last_four || paymentTooLow}
                 tooltipText={
                   paymentTooLow
                     ? `Payment amount must be at least ${minimumPayment}.`
@@ -215,11 +209,7 @@ export const CreditCardPayment: React.FC<Props> = (props) => {
               </Button>
             </Grid>
           </>
-        ) : (
-          <Grid item>
-            <Typography>No credit card on file.</Typography>
-          </Grid>
-        )}
+        ) : null}
       </Grid>
       <CreditCardDialog
         error={errorMessage}

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCardPayment.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCardPayment.tsx
@@ -73,7 +73,7 @@ export const CreditCardPayment: React.FC<Props> = (props) => {
 
   const showGooglePay = flags.additionalPaymentMethods?.includes('google_pay');
   const isCardExpired =
-    (creditCard.expiry && isCreditCardExpired(creditCard.expiry)) || false;
+    creditCard.expiry && isCreditCardExpired(creditCard.expiry);
   const paymentTooLow = +usd < +minimumPayment;
 
   const handleCVVChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
@@ -199,16 +199,20 @@ export const PaymentDrawer: React.FC<CombinedProps> = (props) => {
             />
           </Grid>
           <Divider spacingTop={32} spacingBottom={16} />
-          <CreditCardPayment
-            key={creditCardKey}
-            type={creditCard?.card_type}
-            lastFour={creditCard?.last_four ?? ''}
-            expiry={creditCard?.expiry ?? ''}
-            disabled={isProcessing}
-            usd={usd}
-            minimumPayment={minimumPayment}
-            setSuccess={setSuccess}
-          />
+          {creditCard ? (
+            <CreditCardPayment
+              key={creditCardKey}
+              creditCard={creditCard}
+              disabled={isProcessing}
+              usd={usd}
+              minimumPayment={minimumPayment}
+              setSuccess={setSuccess}
+            />
+          ) : (
+            <Grid item>
+              <Typography>No credit card on file.</Typography>
+            </Grid>
+          )}
           <Divider spacingTop={32} spacingBottom={16} />
           {showGooglePay ? (
             <>


### PR DESCRIPTION
## Description
- Show card info in the Payment Method Row for Google Pay
    - Show Google Pay text on desktop, hide for mobile
- Refactor to use CreditCard type

![image](https://user-images.githubusercontent.com/14323019/125969410-032b8f04-cb38-42d1-b6ef-7791bb7e77b3.png)
![image](https://user-images.githubusercontent.com/14323019/125969468-d7e8d886-fd40-4a64-9ef7-db8afd4d857b.png)

## How to test
In `account/billing`, ensure that Google Pay is added as a Payment Method. The Payment Methods paper should now display the card information.
