### PR TITLE
M3-5314: Fix Kubernetes Create Active State and Refactor

### DIFF
--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -179,6 +179,7 @@ export const PrimaryNav: React.FC<Props> = (props) => {
         {
           display: 'Kubernetes',
           href: '/kubernetes/clusters',
+          activeLinks: ['/kubernetes/create'],
           icon: <Kubernetes />,
         },
         {

--- a/packages/manager/src/features/Kubernetes/index.tsx
+++ b/packages/manager/src/features/Kubernetes/index.tsx
@@ -1,47 +1,38 @@
 import * as React from 'react';
-import {
-  Redirect,
-  Route,
-  RouteComponentProps,
-  Switch,
-  withRouter,
-} from 'react-router-dom';
+import { Redirect, Route, Switch } from 'react-router-dom';
+import SuspenseLoader from 'src/components/SuspenseLoader';
 
 const KubernetesLanding = React.lazy(() => import('./KubernetesLanding'));
-
 const ClusterCreate = React.lazy(() => import('./CreateCluster'));
-
 const ClusterDetail = React.lazy(() => import('./KubernetesClusterDetail'));
 
-type Props = RouteComponentProps<{}>;
-
-class Kubernetes extends React.Component<Props> {
-  render() {
-    const {
-      match: { path },
-    } = this.props;
-
-    return (
+const Kubernetes: React.FC = () => {
+  return (
+    <React.Suspense fallback={<SuspenseLoader />}>
       <Switch>
-        <Route component={ClusterCreate} exact path={`${path}/create`} />
+        <Route component={ClusterCreate} path={`/kubernetes/create`} />
         <Route
           component={ClusterDetail}
           exact
-          path={`${path}/clusters/:clusterID/summary`}
+          path={`/kubernetes/clusters/:clusterID/summary`}
         />
         <Route
-          path={`${path}/clusters/:clusterID`}
+          path={`/kubernetes/clusters/:clusterID`}
           render={(props) => (
             <Redirect
-              to={`${path}/clusters/${props.match.params.clusterID}/summary`}
+              to={`/kubernetes/clusters/${props.match.params.clusterID}/summary`}
             />
           )}
         />
-        <Route component={KubernetesLanding} exact path={`${path}/clusters`} />
+        <Route
+          component={KubernetesLanding}
+          exact
+          path={`/kubernetes/clusters`}
+        />
         <Redirect to={'/kubernetes/clusters'} />
       </Switch>
-    );
-  }
-}
+    </React.Suspense>
+  );
+};
 
-export default withRouter(Kubernetes);
+export default Kubernetes;

--- a/packages/manager/src/features/linodes/index.tsx
+++ b/packages/manager/src/features/linodes/index.tsx
@@ -7,10 +7,10 @@ import { useAllAccountMaintenanceQuery } from 'src/queries/accountMaintenance';
 import { addMaintenanceToLinodes } from 'src/store/linodes/linodes.helpers';
 
 const LinodesLanding = React.lazy(() => import('./LinodesLanding'));
+const LinodesDetail = React.lazy(() => import('./LinodesDetail'));
 const LinodesCreate = React.lazy(
   () => import('./LinodesCreate/LinodeCreateContainer')
 );
-const LinodesDetail = React.lazy(() => import('./LinodesDetail'));
 
 const LinodesRoutes: React.FC = () => {
   return (


### PR DESCRIPTION
## Description

- Make Kubernetes router a functional component
- Clean up Linodes router
- Fixed `/kubernetes/create` not showing as active in the main navigation

## How to test

- Test all `/kubernetes` routing
- Make sure `Kubernetes` in the navigation shows as active when at `/kubernetes/create`
