### PR TITLE
Clean up Linode Settings

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/AlertSection.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/AlertSection.tsx
@@ -3,74 +3,69 @@ import { compose } from 'recompose';
 import Divider from 'src/components/core/Divider';
 import FormControlLabel from 'src/components/core/FormControlLabel';
 import InputAdornment from 'src/components/core/InputAdornment';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles,
-} from 'src/components/core/styles';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 import RenderGuard from 'src/components/RenderGuard';
 import TextField from 'src/components/TextField';
 import Toggle from 'src/components/Toggle';
 
-type ClassNames = 'root' | 'switch' | 'copy' | 'usage' | 'usageWrapper';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    '@keyframes fadeIn': {
-      from: {
-        opacity: 0,
-      },
-      to: {
-        opacity: 1,
-      },
+const useStyles = makeStyles((theme: Theme) => ({
+  '@keyframes fadeIn': {
+    from: {
+      opacity: 0,
     },
-    root: {
-      position: 'relative',
-      padding: `${theme.spacing(2)}px 0`,
-      '&:last-of-type + hr': {
-        display: 'none',
+    to: {
+      opacity: 1,
+    },
+  },
+  root: {
+    marginBottom: theme.spacing(2),
+    paddingTop: theme.spacing(0.5),
+    '&:last-of-type': {
+      marginBottom: 0,
+    },
+    '&:last-of-type + hr': {
+      display: 'none',
+    },
+  },
+  switch: {
+    display: 'flex',
+    marginLeft: -12,
+    width: 240,
+    '& .toggleLabel': {
+      display: 'flex',
+      flexDirection: 'row',
+      '& > span:first-child': {
+        marginTop: -6,
       },
-      '& .toggleLabel > span:last-child': {
-        position: 'absolute',
-        left: `calc(58px + ${theme.spacing(2)}px)`,
-        top: theme.spacing(3) + 16,
+      '& > span:last-child': {
         ...theme.typography.h3,
-        [theme.breakpoints.up('md')]: {
-          top: theme.spacing(3) + 8,
-          left: `calc(58px + ${theme.spacing(4)}px)`,
-        },
       },
     },
-    switch: {
-      width: 50,
-      padding: '2px 0 !important',
+  },
+  copy: {
+    marginTop: 40,
+    marginLeft: -160,
+    width: 600,
+    [theme.breakpoints.down('sm')]: {
+      marginTop: -28,
+      marginLeft: 70,
+      width: '100%',
     },
-    copy: {
-      [theme.breakpoints.down('sm')]: {
-        flexBasis: '100%',
-      },
-      [theme.breakpoints.up('md')]: {
-        margin: `24px ${theme.spacing(3) + 8}px 0`,
-      },
-      [theme.breakpoints.up('lg')]: {
-        width: 600,
-      },
+  },
+  usageWrapper: {
+    [theme.breakpoints.down('sm')]: {
+      marginLeft: 70,
+      width: '100%',
     },
-    usageWrapper: {
-      [theme.breakpoints.down('md')]: {
-        width: '100%',
-        marginTop: theme.spacing(2),
-      },
-    },
-    usage: {
-      animation: '$fadeIn .3s ease-in-out forwards',
-      marginTop: 0,
-      maxWidth: 150,
-    },
-  });
+  },
+  usage: {
+    animation: '$fadeIn .3s ease-in-out forwards',
+    marginTop: 0,
+    maxWidth: 150,
+  },
+}));
 
 interface Props {
   title: string;
@@ -87,65 +82,71 @@ interface Props {
   readOnly?: boolean;
 }
 
-type CombinedProps = Props & WithStyles<ClassNames>;
+type CombinedProps = Props;
 
-class AlertSection extends React.Component<CombinedProps> {
-  render() {
-    const { classes, readOnly } = this.props;
+export const AlertSection: React.FC<CombinedProps> = (props) => {
+  const classes = useStyles();
+  const {
+    title,
+    textTitle,
+    copy,
+    state,
+    value,
+    onStateChange,
+    onValueChange,
+    error,
+    endAdornment,
+    readOnly,
+  } = props;
 
-    return (
-      <React.Fragment>
-        <Grid
-          container
-          alignItems="flex-start"
-          className={classes.root}
-          data-qa-alerts-panel
-        >
-          <Grid item className={classes.switch}>
-            <FormControlLabel
-              className="toggleLabel"
-              control={
-                <Toggle
-                  checked={this.props.state}
-                  onChange={this.props.onStateChange}
-                  disabled={readOnly}
-                />
-              }
-              label={this.props.title}
-              data-qa-alert={this.props.title}
-            />
-          </Grid>
-          <Grid item className={classes.copy}>
-            <Typography>{this.props.copy}</Typography>
-          </Grid>
-          <Grid item className={`${classes.usageWrapper} py0`}>
-            <TextField
-              label={this.props.textTitle}
-              type="number"
-              value={this.props.value}
-              min={0}
-              max={Infinity}
-              disabled={!this.props.state || readOnly}
-              InputProps={{
-                endAdornment: (
-                  <InputAdornment position="end">
-                    {this.props.endAdornment}
-                  </InputAdornment>
-                ),
-              }}
-              error={Boolean(this.props.error)}
-              errorText={this.props.error}
-              onChange={this.props.onValueChange}
-              className={classes.usage}
-            />
-          </Grid>
+  return (
+    <>
+      <Grid
+        container
+        alignItems="flex-start"
+        className={classes.root}
+        data-qa-alerts-panel
+      >
+        <Grid item className={classes.switch}>
+          <FormControlLabel
+            className="toggleLabel"
+            control={
+              <Toggle
+                checked={state}
+                disabled={readOnly}
+                onChange={onStateChange}
+              />
+            }
+            label={title}
+            data-qa-alert={title}
+          />
         </Grid>
-        <Divider />
-      </React.Fragment>
-    );
-  }
-}
+        <Grid item className={classes.copy}>
+          <Typography>{copy}</Typography>
+        </Grid>
+        <Grid item className={`${classes.usageWrapper} py0`}>
+          <TextField
+            className={classes.usage}
+            disabled={!state || readOnly}
+            error={Boolean(error)}
+            errorText={error}
+            label={textTitle}
+            min={0}
+            max={Infinity}
+            onChange={onValueChange}
+            type="number"
+            value={value}
+            InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">{endAdornment}</InputAdornment>
+              ),
+            }}
+          />
+        </Grid>
+      </Grid>
+      <Divider />
+    </>
+  );
+};
 
-const styled = withStyles(styles);
-
-export default compose<CombinedProps, any>(RenderGuard, styled)(AlertSection);
+export default compose<CombinedProps, any>(RenderGuard)(AlertSection);

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsDeletePanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsDeletePanel.tsx
@@ -3,11 +3,11 @@ import { lensPath, set } from 'ramda';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
+import Accordion from 'src/components/Accordion';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
 import Typography from 'src/components/core/Typography';
-import Accordion from 'src/components/Accordion';
 import PanelErrorBoundary from 'src/components/PanelErrorBoundary';
 import { resetEventsPolling } from 'src/eventsPolling';
 import { withLinodeDetailContext } from 'src/features/linodes/LinodesDetail/linodeDetailContext';
@@ -22,104 +22,88 @@ interface Props {
   linodeLabel: string;
 }
 
-interface State {
-  open: boolean;
-  errors?: APIError[];
-}
-
 type CombinedProps = Props &
   ContextProps &
   LinodeActionsProps &
   RouteComponentProps<{}>;
 
-class LinodeSettingsDeletePanel extends React.Component<CombinedProps, State> {
-  state: State = {
-    open: false,
-  };
+export const LinodeSettingsDeletePanel: React.FC<CombinedProps> = (props) => {
+  const {
+    linodeId,
+    linodeLabel,
+    linodeActions: { deleteLinode },
+    readOnly,
+  } = props;
 
-  deleteLinode = () => {
-    const {
-      linodeActions: { deleteLinode },
-    } = this.props;
-    this.setState(set(lensPath(['submitting']), true));
+  const [open, setOpen] = React.useState<boolean>(false);
+  const [submitting, setSubmitting] = React.useState<boolean>(false);
+  const [errors, setErrors] = React.useState<APIError[] | undefined>(undefined);
 
-    deleteLinode({ linodeId: this.props.linodeId })
-      .then((response) => {
+  const _deleteLinode = () => {
+    setSubmitting(true);
+
+    deleteLinode({ linodeId })
+      .then(() => {
         resetEventsPolling();
-        this.props.history.push('/linodes');
+        props.history.push('/linodes');
       })
       .catch((error: APIError[]) => {
-        this.setState(set(lensPath(['errors']), error), () => {
-          scrollErrorIntoView();
-        });
+        setErrors(set(lensPath(['errors']), error));
+        scrollErrorIntoView();
       });
   };
 
-  openDeleteDialog = () => {
-    this.setState({ open: true });
-  };
-
-  closeDeleteDialog = () => {
-    this.setState({ open: false });
-  };
-
-  render() {
-    const { readOnly } = this.props;
-    const { errors } = this.state;
-
-    return (
-      <React.Fragment>
-        <Accordion heading="Delete Linode" defaultExpanded>
-          <Button
-            buttonType="primary"
-            destructive
-            style={{ marginBottom: 8 }}
-            onClick={this.openDeleteDialog}
-            data-qa-delete-linode
-            disabled={readOnly}
-          >
-            Delete
-          </Button>
-          <Typography variant="body1">
-            Deleting a Linode will result in permanent data loss.
-          </Typography>
-        </Accordion>
-        <ConfirmationDialog
-          title={`Delete ${this.props.linodeLabel}?`}
-          actions={this.renderConfirmationActions}
-          open={this.state.open}
-          onClose={this.closeDeleteDialog}
-          error={errors ? errors[0].reason : undefined}
-        >
-          <Typography>
-            Are you sure you want to delete this Linode? This will result in
-            permanent data loss.
-          </Typography>
-        </ConfirmationDialog>
-      </React.Fragment>
-    );
-  }
-
-  renderConfirmationActions = () => (
-    <ActionsPanel style={{ padding: 0 }}>
+  const renderConfirmationActions = () => (
+    <ActionsPanel>
       <Button
         buttonType="cancel"
-        onClick={this.closeDeleteDialog}
+        onClick={() => setOpen(false)}
         data-qa-cancel-delete
       >
         Cancel
       </Button>
       <Button
         buttonType="primary"
-        destructive
-        onClick={this.deleteLinode}
+        loading={submitting}
+        onClick={_deleteLinode}
         data-qa-confirm-delete
       >
         Delete
       </Button>
     </ActionsPanel>
   );
-}
+
+  return (
+    <React.Fragment>
+      <Accordion heading="Delete Linode" defaultExpanded>
+        <Button
+          buttonType="primary"
+          disabled={readOnly}
+          onClick={() => setOpen(true)}
+          style={{ marginBottom: 8 }}
+          data-qa-delete-linode
+        >
+          Delete
+        </Button>
+        <Typography variant="body1">
+          Deleting a Linode will result in permanent data loss.
+        </Typography>
+      </Accordion>
+      <ConfirmationDialog
+        title={`Delete ${linodeLabel}?`}
+        actions={renderConfirmationActions}
+        open={open}
+        onClose={() => setOpen(false)}
+        error={errors ? errors[0].reason : undefined}
+      >
+        <Typography>
+          Are you sure you want to delete this Linode? This will result in
+          permanent data loss.
+        </Typography>
+      </ConfirmationDialog>
+    </React.Fragment>
+  );
+};
 
 const errorBoundary = PanelErrorBoundary({ heading: 'Delete Linode' });
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeWatchdogPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeWatchdogPanel.tsx
@@ -109,21 +109,6 @@ export const LinodeWatchdogPanel: React.FC<CombinedProps> = (props) => {
   );
 };
 
-// const L = {
-//   currentStatus: lensPath(['currentStatus']),
-//   error: lensPath(['errors']),
-//   submitting: lensPath(['submitting']),
-//   success: lensPath(['success']),
-// };
-
-// const setCurrentStatus = (v: boolean) => set(L.currentStatus, v);
-
-// const setSubmitting = (v: boolean) => set(L.submitting, v);
-
-// const setSuccess = (v: string) => set(L.success, v);
-
-// const setErrors = (v: string) => set(L.error, v);
-
 const errorBoundary = PanelErrorBoundary({ heading: 'Delete Linode' });
 
 interface ContextProps {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeWatchdogPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeWatchdogPanel.tsx
@@ -1,5 +1,4 @@
 import { GrantLevel } from '@linode/api-v4/lib/account';
-import { compose, lensPath, set } from 'ramda';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose as recompose } from 'recompose';
@@ -21,127 +20,109 @@ interface Props {
   currentStatus: boolean;
 }
 
-interface State {
-  linodeId: number;
-  currentStatus: boolean;
-  submitting: boolean;
-  success?: string;
-  errors?: string;
-}
-
 type CombinedProps = Props &
   ContextProps &
   LinodeActionsProps &
   RouteComponentProps<{}>;
 
-class LinodeWatchdogPanel extends React.Component<CombinedProps, State> {
-  state: State = {
-    currentStatus: this.props.currentStatus,
-    linodeId: this.props.linodeId,
-    submitting: false,
-  };
+export const LinodeWatchdogPanel: React.FC<CombinedProps> = (props) => {
+  const {
+    linodeId,
+    linodeActions: { updateLinode },
+    permissions,
+  } = props;
 
-  toggleWatchdog = (e: React.ChangeEvent<HTMLElement>, value: boolean) => {
-    const {
-      linodeActions: { updateLinode },
-    } = this.props;
-    this.setState({
-      submitting: true,
-      errors: undefined,
-      success: undefined,
-    });
+  const disabled = permissions === 'read_only';
 
-    updateLinode({ linodeId: this.props.linodeId, watchdog_enabled: value })
+  const [currentStatus, setCurrentStatus] = React.useState<boolean>(
+    props.currentStatus
+  );
+  const [submitting, setSubmitting] = React.useState<boolean>(false);
+  const [success, setSuccess] = React.useState<string | undefined>(undefined);
+  const [errors, setErrors] = React.useState<string | undefined>(undefined);
+
+  const toggleWatchdog = (
+    e: React.ChangeEvent<HTMLElement>,
+    value: boolean
+  ) => {
+    setSubmitting(true);
+    setSuccess(undefined);
+    setErrors(undefined);
+
+    updateLinode({ linodeId, watchdog_enabled: value })
       .then((response) => {
-        this.setState(
-          compose(
-            setSubmitting(false),
-            setSuccess(
-              `Watchdog successfully ${value ? 'enabled' : 'disabled.'}`
-            ),
-            setCurrentStatus(response.watchdog_enabled) as any
-          )
-        );
+        setSubmitting(false);
+        setSuccess(`Watchdog successfully ${value ? 'enabled' : 'disabled.'}`);
+        setCurrentStatus(response.watchdog_enabled);
       })
       .catch(() => {
-        this.setState(
-          compose(
-            setSubmitting(false),
-            setErrors(`Unable to ${!value ? 'disable' : 'enable'} Watchdog.`)
-          )
-        );
+        setSubmitting(false);
+        setErrors(`Unable to ${!value ? 'disable' : 'enable'} Watchdog.`);
       });
   };
 
-  render() {
-    const { currentStatus, submitting, success, errors } = this.state;
-    const { permissions } = this.props;
-
-    const disabled = permissions === 'read_only';
-
-    return (
-      <Accordion
-        heading="Shutdown Watchdog"
-        data-qa-watchdog-panel
-        defaultExpanded
-      >
-        <Grid container alignItems="center">
-          {(success || errors) && (
-            <Grid item xs={12}>
-              <Notice
-                success={Boolean(success)}
-                error={Boolean(errors)}
-                text={success || errors}
-              />
-            </Grid>
-          )}
-          <Grid item xs={12} md={2}>
-            <FormControlLabel
-              control={
-                <Toggle
-                  onChange={this.toggleWatchdog}
-                  checked={currentStatus}
-                  data-qa-watchdog-toggle={currentStatus}
-                />
-              }
-              label={currentStatus ? 'Enabled' : 'Disabled'}
-              aria-label={
-                currentStatus
-                  ? 'Shutdown Watchdog is enabled'
-                  : 'Shutdown Watchdog is disabled'
-              }
-              disabled={submitting || disabled}
+  return (
+    <Accordion
+      heading="Shutdown Watchdog"
+      defaultExpanded
+      data-qa-watchdog-panel
+    >
+      <Grid container alignItems="center">
+        {(success || errors) && (
+          <Grid item xs={12}>
+            <Notice
+              success={Boolean(success)}
+              error={Boolean(errors)}
+              text={success || errors}
             />
           </Grid>
-          <Grid item xs={12} md={10} lg={8} xl={6}>
-            <Typography data-qa-watchdog-desc>
-              Shutdown Watchdog, also known as Lassie, is a Linode Manager
-              feature capable of automatically rebooting your Linode if it
-              powers off unexpectedly. Lassie is not technically an availability
-              monitoring tool, but it can help get your Linode back online fast
-              if it’s accidentally powered off.
-            </Typography>
-          </Grid>
+        )}
+        <Grid item xs={12} md={2}>
+          <FormControlLabel
+            control={
+              <Toggle
+                onChange={toggleWatchdog}
+                checked={currentStatus}
+                data-qa-watchdog-toggle={currentStatus}
+              />
+            }
+            label={currentStatus ? 'Enabled' : 'Disabled'}
+            aria-label={
+              currentStatus
+                ? 'Shutdown Watchdog is enabled'
+                : 'Shutdown Watchdog is disabled'
+            }
+            disabled={submitting || disabled}
+          />
         </Grid>
-      </Accordion>
-    );
-  }
-}
-
-const L = {
-  currentStatus: lensPath(['currentStatus']),
-  error: lensPath(['errors']),
-  submitting: lensPath(['submitting']),
-  success: lensPath(['success']),
+        <Grid item xs={12} md={10} lg={8} xl={6}>
+          <Typography data-qa-watchdog-desc>
+            Shutdown Watchdog, also known as Lassie, is a Linode Manager feature
+            capable of automatically rebooting your Linode if it powers off
+            unexpectedly. Lassie is not technically an availability monitoring
+            tool, but it can help get your Linode back online fast if it’s
+            accidentally powered off.
+          </Typography>
+        </Grid>
+      </Grid>
+    </Accordion>
+  );
 };
 
-const setCurrentStatus = (v: boolean) => set(L.currentStatus, v);
+// const L = {
+//   currentStatus: lensPath(['currentStatus']),
+//   error: lensPath(['errors']),
+//   submitting: lensPath(['submitting']),
+//   success: lensPath(['success']),
+// };
 
-const setErrors = (v: string) => set(L.error, v);
+// const setCurrentStatus = (v: boolean) => set(L.currentStatus, v);
 
-const setSubmitting = (v: boolean) => set(L.submitting, v);
+// const setSubmitting = (v: boolean) => set(L.submitting, v);
 
-const setSuccess = (v: string) => set(L.success, v);
+// const setSuccess = (v: string) => set(L.success, v);
+
+// const setErrors = (v: string) => set(L.error, v);
 
 const errorBoundary = PanelErrorBoundary({ heading: 'Delete Linode' });
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeWatchdogPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeWatchdogPanel.tsx
@@ -3,15 +3,9 @@ import { compose, lensPath, set } from 'ramda';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose as recompose } from 'recompose';
-import FormControlLabel from 'src/components/core/FormControlLabel';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles,
-} from 'src/components/core/styles';
-import Typography from 'src/components/core/Typography';
 import Accordion from 'src/components/Accordion';
+import FormControlLabel from 'src/components/core/FormControlLabel';
+import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
 import PanelErrorBoundary from 'src/components/PanelErrorBoundary';
@@ -21,16 +15,6 @@ import {
   LinodeActionsProps,
   withLinodeActions,
 } from 'src/store/linodes/linode.containers';
-
-type ClassNames = 'root' | 'shutDownWatchdog';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {},
-    shutDownWatchdog: {
-      margin: `${theme.spacing(2)}px 0`,
-    },
-  });
 
 interface Props {
   linodeId: number;
@@ -48,8 +32,7 @@ interface State {
 type CombinedProps = Props &
   ContextProps &
   LinodeActionsProps &
-  RouteComponentProps<{}> &
-  WithStyles<ClassNames>;
+  RouteComponentProps<{}>;
 
 class LinodeWatchdogPanel extends React.Component<CombinedProps, State> {
   state: State = {
@@ -92,7 +75,7 @@ class LinodeWatchdogPanel extends React.Component<CombinedProps, State> {
 
   render() {
     const { currentStatus, submitting, success, errors } = this.state;
-    const { classes, permissions } = this.props;
+    const { permissions } = this.props;
 
     const disabled = permissions === 'read_only';
 
@@ -102,11 +85,7 @@ class LinodeWatchdogPanel extends React.Component<CombinedProps, State> {
         data-qa-watchdog-panel
         defaultExpanded
       >
-        <Grid
-          container
-          alignItems="center"
-          className={classes.shutDownWatchdog}
-        >
+        <Grid container alignItems="center">
           {(success || errors) && (
             <Grid item xs={12}>
               <Notice
@@ -164,8 +143,6 @@ const setSubmitting = (v: boolean) => set(L.submitting, v);
 
 const setSuccess = (v: string) => set(L.success, v);
 
-const styled = withStyles(styles);
-
 const errorBoundary = PanelErrorBoundary({ heading: 'Delete Linode' });
 
 interface ContextProps {
@@ -179,7 +156,6 @@ const linodeContext = withLinodeDetailContext<ContextProps>(({ linode }) => ({
 export default recompose<CombinedProps, Props>(
   errorBoundary,
   withRouter,
-  styled,
   withLinodeActions,
   linodeContext
 )(LinodeWatchdogPanel) as React.ComponentType<Props>;

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -861,7 +861,7 @@ const themeDefaults: ThemeDefaults = () => {
         root: {
           color: '#555',
           fontFamily: primaryFonts.bold,
-          fontSize: '.9rem',
+          fontSize: '.875rem',
           marginBottom: 8,
           '&$focused': {
             color: '#555',


### PR DESCRIPTION
## Description

Since the Linode settings are now expanded by default, I tightened up the spacing in the Notification Thresholds and Shutdown Watchdog panels.

Also refactored and cleaned up the code for those, the Linode Label, and Delete Linode panels. While I was in there, I also adjusted the Linode Label primary action to be disabled unless a change is detected. 

## How to test

Go to `/linodes/[insert_id]/settings` and make sure all the functionality hasn't changed.

- If you're testing the Shutdown Watchdog panel, check the API responses for `/linode/instances` to confirm that the change is reflected.
