### PR TITLE
fix for cypress bug with workaround for now

### DIFF
--- a/packages/manager/cypress/integration/helpAndSupport/open-support-ticket.spec.ts
+++ b/packages/manager/cypress/integration/helpAndSupport/open-support-ticket.spec.ts
@@ -61,9 +61,9 @@ describe('help & support', () => {
       }).as('getReplies');
 
       containsClick('Open New Ticket');
-      getClick('[placeholder="Enter a title for your ticket."]').type(
-        ticketLabel
-      );
+      cy.get('input[placeholder="Enter a title for your ticket."]')
+        .click({ scrollBehavior: false })
+        .type(ticketLabel);
       getVisible('[data-qa-enhanced-select="General/Account/Billing"]');
       getClick('[data-qa-ticket-description="true"]').type(ticketDescription);
       cy.get('[id="attach-file"]').attachFile(image);


### PR DESCRIPTION
## Description
This ended up being caused by a weird cypress scrolling bug that specifically effects elements in fixed containers such as modals: https://github.com/cypress-io/cypress/issues/4233. I added a workaround ({ scrollBehavior: false }) for now. 

**What does this PR do?**
a small support-ticket e2e test fix

## How to test
- `yarn up` in one terminal
- `yarn cy:e2e -s ./cypress/integration/helpAndSupport/open-support-ticket.spec.ts` in another
- Result should be "✔  All specs passed!"

## Make sure your .env contains:
```
REACT_APP_LOGIN_ROOT
REACT_APP_API_ROOT
REACT_APP_APP_ROOT
REACT_APP_LAUNCH_DARKLY_ID
REACT_APP_CLIENT_ID
MANAGER_OAUTH
```