### PR TITLE
M3-5329: Refresh Users Table on Permission Change

### DIFF
--- a/packages/manager/src/features/Users/UserPermissions.tsx
+++ b/packages/manager/src/features/Users/UserPermissions.tsx
@@ -35,6 +35,7 @@ import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import Toggle from 'src/components/Toggle';
+import { queryClient } from 'src/queries/base';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
@@ -385,8 +386,10 @@ class UserPermissions extends React.Component<CombinedProps, State> {
           });
         })
         .then(() => {
-          /* unconditionally sets this.state.loadingGrants to false */
+          // unconditionally sets this.state.loadingGrants to false
           this.getUserGrants();
+          // refresh the data on /account/users so it is accurate
+          queryClient.invalidateQueries('account-users');
         })
         .catch((errResponse) => {
           this.setState({


### PR DESCRIPTION
## Description

Minor change that improves user experience. If a user grants full permissions to another user on their account, we need to refetch the users list so it us up to date. 

## How to test

- Go to `/account/users`
- Find a user that is not you and click `User Permissions`
- Toggle `Full Account Access` and make sure changes are reflected when you navigate back to `/account/users`
