### PR TITLE
M3-5326: "Add an SSH Key" button

### DIFF
--- a/packages/manager/cypress/support/ui/constants.ts
+++ b/packages/manager/cypress/support/ui/constants.ts
@@ -142,7 +142,7 @@ export const pages = [
   {
     name: 'Profile/SSH Keys',
     url: `${routes.profile}/keys`,
-    assertIsLoaded: () => cy.findByText('Add a SSH Key').should('be.visible'),
+    assertIsLoaded: () => cy.findByText('Add an SSH Key').should('be.visible'),
     goWithUI: [
       {
         name: 'Tab',

--- a/packages/manager/e2e/pageobjects/profile/ssh-keys.page.js
+++ b/packages/manager/e2e/pageobjects/profile/ssh-keys.page.js
@@ -5,7 +5,7 @@ import Page from '../page';
 
 export class SshKeys extends Page {
   get addKeyButton() {
-    return this.addIcon('Add a SSH Key');
+    return this.addIcon('Add an SSH Key');
   }
 
   get drawerKeyLabel() {

--- a/packages/manager/src/features/Profile/SSHKeys/SSHKeys.tsx
+++ b/packages/manager/src/features/Profile/SSHKeys/SSHKeys.tsx
@@ -133,7 +133,7 @@ export class SSHKeys extends React.Component<CombinedProps, State> {
           </Grid>
           <Grid className={classes.addNewWrapper} item>
             <AddNewLink
-              label="Add a SSH Key"
+              label="Add an SSH Key"
               onClick={this.openCreationDrawer}
             />
           </Grid>


### PR DESCRIPTION
## Description
The primary button at `/profile/keys` says "Add a SSH Key," while in the Linode Create flow we say "Add an SSH Key." The latter is more grammatically correct, so this PR brings the former into agreement with it and updates a couple of other files accordingly.
