### PR TITLE
[For Demo] Remove parenthetical GB limit from Monthly Transfer Limit

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkTransfer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkTransfer.tsx
@@ -80,7 +80,6 @@ export const NetworkTransfer: React.FC<Props> = (props) => {
     <div>
       <Typography className={classes.header}>
         <strong>Monthly Network Transfer</strong>{' '}
-        {accountQuotaInGB > 0 && <>({accountQuotaInGB} GB limit)</>}
       </Typography>
       <TransferContent
         linodeUsedInGB={linodeUsedInGB}


### PR DESCRIPTION
## Description
Follow-up to https://github.com/linode/manager/pull/7766. 

As discussed in demo prep, to decrease discrepancies, remove the parenthetical GB limit after "Monthly Transfer Limit" on the Linode Network tab.

