### PR TITLE
[Demo feedback] M3-5332: Billing UI changes

### DIFF
--- a/packages/manager/src/components/LandingHeader/LandingHeader.tsx
+++ b/packages/manager/src/components/LandingHeader/LandingHeader.tsx
@@ -25,6 +25,7 @@ export interface Props extends Omit<HeaderProps, 'actions'> {
   breadcrumbProps?: BreadcrumbProps;
 }
 
+export const defaultCreateButtonWidth = 152;
 /**
  * This component is essentially a variant of the more abstract EntityHeader
  * component, included as its own component because it will be used in
@@ -44,8 +45,6 @@ export const LandingHeader: React.FC<Props> = (props) => {
     loading,
     breadcrumbProps,
   } = props;
-
-  const defaultCreateButtonWidth = 152;
 
   const actions = React.useMemo(
     () => (

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
@@ -190,8 +190,9 @@ export const BillingSummary: React.FC<BillingSummaryProps> = (props) => {
     balance > 0 ? (
       <div className={classes.balanceBlurbAndButton}>
         <Typography className={classes.blurb}>
-          {pastDueBalance ? 'Make a payment immediately' : 'Make a payment.'}
-          {pastDueBalance ? `${' '}to avoid service disruption.` : null}
+          {pastDueBalance
+            ? 'Make a payment immediately to avoid service disruption.'
+            : null}
         </Typography>
         {makePaymentButton}
       </div>

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
@@ -1,13 +1,14 @@
+import { PaymentMethod } from '@linode/api-v4';
 import {
   ActivePromotion,
   PromotionServiceType,
 } from '@linode/api-v4/lib/account/types';
-import { PaymentMethod } from '@linode/api-v4';
 import { GridSize } from '@material-ui/core/Grid';
 import { Breakpoint } from '@material-ui/core/styles/createBreakpoints';
 import * as classnames from 'classnames';
 import * as React from 'react';
 import { useHistory, useRouteMatch } from 'react-router-dom';
+import Button from 'src/components/Button';
 import Box from 'src/components/core/Box';
 import Divider from 'src/components/core/Divider';
 import Grid from 'src/components/core/Grid';
@@ -17,6 +18,7 @@ import Typography from 'src/components/core/Typography';
 import Currency from 'src/components/Currency';
 import DateTimeDisplay from 'src/components/DateTimeDisplay';
 import HelpIcon from 'src/components/HelpIcon';
+import { defaultCreateButtonWidth } from 'src/components/LandingHeader/LandingHeader';
 import useNotifications from 'src/hooks/useNotifications';
 import PaymentDrawer from './PaymentDrawer';
 
@@ -29,6 +31,11 @@ const useStyles = makeStyles((theme: Theme) => ({
   paper: {
     padding: `15px 20px`,
     height: '100%',
+  },
+  button: {
+    padding: 0,
+    margin: '1rem 0 0 0',
+    width: defaultCreateButtonWidth,
   },
   helpIcon: {
     padding: `0px 8px`,
@@ -151,17 +158,34 @@ export const BillingSummary: React.FC<BillingSummaryProps> = (props) => {
   const gridDimensions: Partial<Record<Breakpoint, GridSize>> =
     promotions && promotions.length > 0 ? { xs: 12, md: 4 } : { xs: 12, sm: 6 };
 
+  const openMakePaymentDrawer = () => {
+    replace(routeForMakePayment);
+  };
+
+  const makePaymentButton = (
+    <Button
+      buttonType="primary"
+      className={classes.button}
+      onClick={openMakePaymentDrawer}
+    >
+      Make a Payment
+    </Button>
+  );
+
   const balanceJSX =
     balance > 0 ? (
-      <Typography style={{ marginTop: 16 }}>
-        <button
-          className={classes.makeAPaymentButton}
-          onClick={() => replace(routeForMakePayment)}
-        >
-          {pastDueBalance ? 'Make a payment immediately' : 'Make a payment.'}
-        </button>
-        {pastDueBalance ? `${' '}to avoid service disruption.` : null}
-      </Typography>
+      <>
+        {makePaymentButton}
+        <Typography style={{ marginTop: 16 }}>
+          <button
+            className={classes.makeAPaymentButton}
+            onClick={openMakePaymentDrawer}
+          >
+            {pastDueBalance ? 'Make a payment immediately' : 'Make a payment.'}
+          </button>
+          {pastDueBalance ? `${' '}to avoid service disruption.` : null}
+        </Typography>
+      </>
     ) : null;
 
   return (

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
@@ -18,7 +18,6 @@ import Typography from 'src/components/core/Typography';
 import Currency from 'src/components/Currency';
 import DateTimeDisplay from 'src/components/DateTimeDisplay';
 import HelpIcon from 'src/components/HelpIcon';
-import { defaultCreateButtonWidth } from 'src/components/LandingHeader/LandingHeader';
 import useNotifications from 'src/hooks/useNotifications';
 import PaymentDrawer from './PaymentDrawer';
 
@@ -32,10 +31,25 @@ const useStyles = makeStyles((theme: Theme) => ({
     padding: `15px 20px`,
     height: '100%',
   },
+  balanceBlurbAndButton: {
+    display: 'flex',
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'space-between',
+    [theme.breakpoints.down('md')]: {
+      flexDirection: 'column',
+    },
+  },
+  blurb: {
+    marginTop: 16,
+  },
   button: {
     padding: 0,
     margin: '1rem 0 0 0',
-    width: defaultCreateButtonWidth,
+    whiteSpace: 'nowrap',
+    [theme.breakpoints.down('md')]: {
+      alignSelf: 'flex-end',
+    },
   },
   helpIcon: {
     padding: `0px 8px`,
@@ -164,7 +178,7 @@ export const BillingSummary: React.FC<BillingSummaryProps> = (props) => {
 
   const makePaymentButton = (
     <Button
-      buttonType="primary"
+      buttonType="secondary"
       className={classes.button}
       onClick={openMakePaymentDrawer}
     >
@@ -174,18 +188,13 @@ export const BillingSummary: React.FC<BillingSummaryProps> = (props) => {
 
   const balanceJSX =
     balance > 0 ? (
-      <>
-        {makePaymentButton}
-        <Typography style={{ marginTop: 16 }}>
-          <button
-            className={classes.makeAPaymentButton}
-            onClick={openMakePaymentDrawer}
-          >
-            {pastDueBalance ? 'Make a payment immediately' : 'Make a payment.'}
-          </button>
+      <div className={classes.balanceBlurbAndButton}>
+        <Typography className={classes.blurb}>
+          {pastDueBalance ? 'Make a payment immediately' : 'Make a payment.'}
           {pastDueBalance ? `${' '}to avoid service disruption.` : null}
         </Typography>
-      </>
+        {makePaymentButton}
+      </div>
     ) : null;
 
   return (

--- a/packages/manager/src/features/NotificationCenter/NotificationData/RenderNotification.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/RenderNotification.tsx
@@ -138,7 +138,7 @@ const getEntityLinks = (
     case 'ticket_abuse':
       return `/support/tickets/${id}`;
     case 'payment_due':
-      return '/account/billing';
+      return '/account/billing/make-payment';
     default:
       break;
   }

--- a/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
@@ -227,12 +227,16 @@ const interceptNotification = (
     return notification;
   }
 
-  if (
-    notification.type === 'payment_due' &&
-    notification.severity !== 'critical'
-  ) {
-    // A critical severity indicates the user's balance is past due; temper the messaging a bit outside of that case by replacing the exclamation point.
-    notification.message = notification.message.replace('!', '.');
+  if (notification.type === 'payment_due') {
+    if (notification.severity !== 'critical') {
+      // A critical severity indicates the user's balance is past due; temper the messaging a bit outside of that case by replacing the exclamation point.
+      notification.message = notification.message.replace('!', '.');
+    }
+
+    return {
+      ...notification,
+      message: `${notification.message} ${' '} Click to make a payment now.`,
+    };
   }
 
   /* If the notification is not of any of the types above, return the notification object without modification. In this case, logic in <RenderNotification />


### PR DESCRIPTION
## Description
- [x] Add "Make a Payment" button to the Billing Summary
<img width="613" alt="Screen Shot 2021-07-23 at 4 54 47 PM" src="https://user-images.githubusercontent.com/32860776/126840571-851354fa-25c6-4e79-9893-6b6a403ef5cf.png">
<hr>

- [x] Add an instructional, second sentence to notification in the drawer indicating to users what happens when the notification is clicked
<img width="613" alt="Screen Shot 2021-07-23 at 4 55 00 PM" src="https://user-images.githubusercontent.com/32860776/126840597-4f5b2dea-6c20-453f-a9ae-b777f5ec73c8.png">


Open to suggested revisions for the language of that second sentence.

