### PR TITLE
Minor UI fixes

### DIFF
--- a/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
+++ b/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
@@ -38,6 +38,13 @@ const useStyles = makeStyles((theme: Theme) => ({
       minWidth: 50,
       padding: '6px 16px',
       textDecoration: 'none',
+      '&:focus': {
+        backgroundColor: theme.cmrBGColors.bgTableHeader,
+      },
+      '&:hover': {
+        backgroundColor: theme.cmrBGColors.bgTableHeader,
+        color: theme.color.blue,
+      },
     },
     '&[data-reach-tab][data-selected]': {
       borderBottom: `3px solid ${theme.cmrTextColors.linkActiveLight}`,

--- a/packages/manager/src/features/StackScripts/Partials/StackScriptTableHead.tsx
+++ b/packages/manager/src/features/StackScripts/Partials/StackScriptTableHead.tsx
@@ -14,7 +14,6 @@ const useStyles = makeStyles((theme: Theme) => ({
       borderTop: `2px solid ${theme.cmrBorderColors.borderTable}`,
       borderBottom: `2px solid ${theme.cmrBorderColors.borderTable}`,
       fontFamily: theme.font.bold,
-      height: 40,
       padding: '10px 15px',
       '&:first-of-type': {
         borderLeft: 'none',
@@ -26,9 +25,6 @@ const useStyles = makeStyles((theme: Theme) => ({
         ...theme.applyTableHeaderStyles,
       },
     },
-  },
-  tr: {
-    height: 44,
   },
   tableHead: {
     color: theme.cmrTextColors.tableHeader,
@@ -142,7 +138,7 @@ export const StackScriptTableHead: React.FC<CombinedProps> = (props) => {
 
   return (
     <TableHead className={classes.root}>
-      <TableRow className={classes.tr}>
+      <TableRow>
         {/* The column width jumps in the Linode Create flow when the user
             clicks on the table header. This is currently also happening in
             production and might be related to the difference in width between

--- a/packages/manager/src/features/StackScripts/StackScriptRowHelpers.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptRowHelpers.tsx
@@ -19,7 +19,7 @@ export type ClassNames =
 export const styles = (theme: Theme) =>
   createStyles({
     row: {
-      height: 44,
+      height: 46,
     },
     link: {
       color: theme.cmrTextColors.tableStatic,


### PR DESCRIPTION
## Description

Adding a hover state for the `SelectPlanPanel` inside of the Linode Create flow and the StackScript table row heights

## How to test

- Go to `/linodes/create` and hover over the tabs under "Linode Plans".
  - The background color should change on hover

- Go to `/stackscripts` and `/linodes/create?type=StackScripts`
  - The table header row height should now be 46px which matches the other table headers