### PR TITLE
Improve Drawer Headers

### DIFF
--- a/packages/manager/src/components/Drawer/Drawer.tsx
+++ b/packages/manager/src/components/Drawer/Drawer.tsx
@@ -49,6 +49,7 @@ const styles = (theme: Theme) =>
     },
     drawerHeader: {
       marginBottom: theme.spacing(2),
+      flexWrap: 'nowrap',
     },
     drawerContent: {},
     button: {


### PR DESCRIPTION
## Description

- Disables wrapping in the Drawer header flexbox

Before this PR:
![before](https://user-images.githubusercontent.com/6440455/127029164-3022e774-3ad8-4505-935e-51ce7c9deb9c.png)

After this PR:
![after](https://user-images.githubusercontent.com/6440455/127029180-0cdb5b8e-63f9-4175-80cf-be809a43a77d.png)

## How to test

- Open drawers in Cloud Manager on many screen sizes and make sure header appears as expected