### PR TITLE
M3-5277: My Profile / Account dropdown changes

### DIFF
--- a/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
+++ b/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
@@ -128,9 +128,6 @@ const useStyles = makeStyles((theme: Theme) => ({
         paddingLeft: theme.spacing(),
       },
     },
-    '&:hover, &:focus': {
-      backgroundColor: theme.cmrBGColors.bgApp,
-    },
   },
   gravatar: {
     height: 30,
@@ -199,16 +196,17 @@ const useStyles = makeStyles((theme: Theme) => ({
       alignItems: 'center',
       color: theme.cmrTextColors.linkActiveLight,
       cursor: 'pointer',
-      fontSize: '1rem',
+      fontSize: '0.875rem',
       padding: '8px 24px',
       '&:focus, &:hover': {
-        backgroundColor: theme.cmrBGColors.bgApp,
-        color: theme.palette.primary.main,
+        backgroundColor: 'transparent',
+        color: theme.cmrTextColors.linkActiveLight,
       },
-    },
-    '&[data-reach-menu-item][data-selected]': {
-      backgroundColor: theme.cmrBGColors.bgApp,
-      color: theme.cmrTextColors.linkActiveLight,
+      '&[data-reach-menu-item][data-selected]:not(:hover)': {
+        backgroundColor: 'transparent',
+        color: theme.cmrTextColors.linkActiveLight,
+        outline: 'dotted 1px #c1c1c0',
+      },
     },
   },
   userName: {


### PR DESCRIPTION
## Description

Remove the hover state for the button in the top nav and adjust the link styles once the menu is expanded.

## How to test

- The background for My Profile / Account in the top nav should no longer change.
- The links inside the menu should be 14px and no longer have a hover state as well unless the user is navigating through it via a keyboard.
