### PR TITLE
E2E Billing Test Update

### DIFF
--- a/packages/manager/cypress/integration/account/billing-contact.spec.ts
+++ b/packages/manager/cypress/integration/account/billing-contact.spec.ts
@@ -58,7 +58,9 @@ const checkAccountContactDisplay = (data) => {
   cy.contains(data['address_2']);
   cy.findByText(data['state'], { exact: false });
   cy.findByText(data['zip'], { exact: false });
-  cy.findByText(data['email']);
+  cy.get('[data-qa-contact-email="true"]').within(() => {
+    cy.findByText(data['email']);
+  });
   cy.findByText(data['phone']);
 };
 


### PR DESCRIPTION
## Description
fix for billing contact which was failing because of the email address also appearing in the banner saying the sending the email failed

**What does this PR do?**
just a small billing-contact e2e test update

## How to test
- `yarn up` in one terminal
- `yarn cy:e2e -s ./cypress/integration/account/billing-contact.spec.ts` in another
- Result should be "✔  All specs passed!"

## Make sure your .env contains:
```
REACT_APP_LOGIN_ROOT
REACT_APP_API_ROOT
REACT_APP_APP_ROOT
REACT_APP_LAUNCH_DARKLY_ID
REACT_APP_CLIENT_ID
MANAGER_OAUTH
```