### PR TITLE
M3-5332: Refine handling of payment_due notifications in Notifications drawer

### DIFF
--- a/packages/manager/src/features/NotificationCenter/NotificationData/RenderNotification.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/RenderNotification.tsx
@@ -11,7 +11,7 @@ import { Link } from 'src/components/Link';
 import { sanitizeHTML } from 'src/utilities/sanitize-html';
 import { ExtendedNotification } from './useFormattedNotifications';
 
-const useStyles = makeStyles((theme: Theme) => ({
+export const useStyles = makeStyles((theme: Theme) => ({
   root: {
     paddingTop: 2,
     paddingBottom: 2,
@@ -29,11 +29,13 @@ const useStyles = makeStyles((theme: Theme) => ({
     color: theme.color.red,
   },
   redLink: {
+    color: theme.color.red,
     '&:hover': {
       textDecoration: `${theme.color.red} underline`,
     },
   },
   greyLink: {
+    color: theme.palette.text.primary,
     '&:hover': {
       textDecoration: `${theme.palette.text.primary} underline`,
     },
@@ -134,14 +136,10 @@ const getEntityLinks = (
   id?: number
 ) => {
   // Handle specific notification types ()
-  switch (notificationType) {
-    case 'ticket_abuse':
-      return `/support/tickets/${id}`;
-    case 'payment_due':
-      return '/account/billing';
-    default:
-      break;
+  if (notificationType === 'ticket_abuse') {
+    return `/support/tickets/${id}`;
   }
+
   // The only entity.type we currently expect and can handle for is "linode."
   return entityType === 'linode' ? `/linodes/${id}` : null;
 };

--- a/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
@@ -6,13 +6,14 @@ import Typography from 'src/components/core/Typography';
 import { Link } from 'src/components/Link';
 import { dcDisplayNames } from 'src/constants';
 import { reportException } from 'src/exceptionReporting';
+import { useStyles } from 'src/features/NotificationCenter/NotificationData/RenderNotification';
 import useDismissibleNotifications from 'src/hooks/useDismissibleNotifications';
 import useNotifications from 'src/hooks/useNotifications';
+import { formatDate } from 'src/utilities/formatDate';
 import { notificationContext } from '../NotificationContext';
 import { NotificationItem } from '../NotificationSection';
 import { checkIfMaintenanceNotification } from './notificationUtils';
 import RenderNotification from './RenderNotification';
-import { formatDate } from 'src/utilities/formatDate';
 
 export interface ExtendedNotification extends Notification {
   jsx?: JSX.Element;
@@ -26,6 +27,7 @@ export const useFormattedNotifications = (): NotificationItem[] => {
   } = useDismissibleNotifications();
 
   const notifications = useNotifications();
+  const classes = useStyles();
 
   const dayOfMonth = DateTime.local().day;
 
@@ -47,7 +49,7 @@ export const useFormattedNotifications = (): NotificationItem[] => {
     })
     .map((notification, idx) =>
       formatNotificationForDisplay(
-        interceptNotification(notification, handleClose),
+        interceptNotification(notification, handleClose, classes),
         idx,
         handleClose,
         !hasDismissedNotifications([notification], 'notificationDrawer')
@@ -66,7 +68,8 @@ export const useFormattedNotifications = (): NotificationItem[] => {
  */
 const interceptNotification = (
   notification: Notification,
-  onClose: () => void
+  onClose: () => void,
+  classes: any
 ): ExtendedNotification => {
   // Ticket interceptions
   if (notification.type === 'ticket_abuse') {
@@ -227,12 +230,33 @@ const interceptNotification = (
     return notification;
   }
 
-  if (
-    notification.type === 'payment_due' &&
-    notification.severity !== 'critical'
-  ) {
-    // A critical severity indicates the user's balance is past due; temper the messaging a bit outside of that case by replacing the exclamation point.
-    notification.message = notification.message.replace('!', '.');
+  if (notification.type === 'payment_due') {
+    const criticalSeverity = notification.severity === 'critical';
+
+    if (!criticalSeverity) {
+      // A critical severity indicates the user's balance is past due; temper the messaging a bit outside of that case by replacing the exclamation point.
+      notification.message = notification.message.replace('!', '.');
+    }
+
+    const jsx = (
+      <Typography>
+        <Link
+          to={'/account/billing'}
+          onClick={onClose}
+          className={criticalSeverity ? classes.redLink : classes.greyLink}
+        >
+          {notification.message}
+        </Link>{' '}
+        <Link to={'/account/billing/make-payment'} onClick={onClose}>
+          Make a payment now.
+        </Link>
+      </Typography>
+    );
+
+    return {
+      ...notification,
+      jsx,
+    };
   }
 
   /* If the notification is not of any of the types above, return the notification object without modification. In this case, logic in <RenderNotification />

--- a/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
@@ -241,13 +241,13 @@ const interceptNotification = (
     const jsx = (
       <Typography>
         <Link
-          to={'/account/billing'}
+          to="/account/billing"
           onClick={onClose}
           className={criticalSeverity ? classes.redLink : classes.greyLink}
         >
           {notification.message}
         </Link>{' '}
-        <Link to={'/account/billing/make-payment'} onClick={onClose}>
+        <Link to="/account/billing/make-payment" onClick={onClose}>
           Make a payment now.
         </Link>
       </Typography>


### PR DESCRIPTION
## Description
Add a call to action sentence to the `payment_due` notification in the Notifications drawer.

Outstanding balance that isn't past due:
<img width="582" alt="Screen Shot 2021-07-27 at 1 54 50 PM" src="https://user-images.githubusercontent.com/32860776/127203829-aecf5da9-e472-4d3c-bd17-eb779c3fd44f.png">

Outstanding balance that is past due:
<img width="582" alt="Screen Shot 2021-07-27 at 1 55 04 PM" src="https://user-images.githubusercontent.com/32860776/127203848-9e97c144-7a2a-4647-a746-3601a60cfbea.png">

In each case, the first sentence links to `/account/billing` and the second links to `/account/billing/make-payment`. Upon arriving at each destination, the notification drawer closes.

## How to test
Check the Notifications drawer for an account with an outstanding balance that isn't past due and for one that is. Ensure no other notifications have been adversely impacted.

## Note to Reviewers
I have some reservations about the red and blue text in a single notification for the past due outstanding balance notification.

~~This PR is an alternative path from https://github.com/linode/manager/pull/7790 pending managerial and executive clarification and confirmation. If https://github.com/linode/manager/pull/7790 is the direction we take, I will close this PR and merge these changes into that one; otherwise, I will close the former and we will proceed with this one.~~ https://github.com/linode/manager/pull/7790 was closed in favor of this one.
