### PR TITLE
Handle API warning message when making a payment

### DIFF
--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/GooglePayButton.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/GooglePayButton.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { APIWarning } from '@linode/api-v4/lib/types';
 import classNames from 'classnames';
 import { VariantType } from 'notistack';
 import { makeStyles, Theme } from 'src/components/core/styles';
@@ -114,11 +115,15 @@ export const GooglePayButton: React.FC<Props> = (props) => {
     init();
   }, [status, data]);
 
-  const handleMessage = (message: string, variant: VariantType) => {
+  const handleMessage = (
+    message: string,
+    variant: VariantType,
+    warning?: APIWarning[]
+  ) => {
     if (variant === 'error') {
       setError(message);
     } else if (variant === 'success') {
-      setSuccess(message, true);
+      setSuccess(message, true, warning);
     }
   };
 

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
@@ -133,7 +133,7 @@ export const PaymentDrawer: React.FC<Props> = (props) => {
     paymentWasMade = false,
     warnings = undefined
   ) => {
-    if (paymentWasMade) {
+    if (paymentWasMade && !warnings) {
       enqueueSnackbar(message, {
         variant: 'success',
       });
@@ -277,7 +277,7 @@ const Warning: React.FC<WarningProps> = (props) => {
   /** The most common API warning includes "please open a Support ticket",
    * which we'd like to be a link.
    */
-  const ticketLink = warning.detail.match(/open a support ticket\./i) ? (
+  const ticketLink = warning.detail?.match(/open a support ticket\./i) ? (
     <>
       {warning.detail.replace(/open a support ticket\./i, '')}
       <SupportLink
@@ -287,7 +287,7 @@ const Warning: React.FC<WarningProps> = (props) => {
       .
     </>
   ) : (
-    warning.detail
+    warning.detail ?? ''
   );
   const message = (
     <>


### PR DESCRIPTION
## Description
Some API warning messages do not have a `detail` field, which was causing the app to crash when trying to make a credit card payment. This fixes that and also adds warning handling for Google Pay payments

## How to test
See slack
