### PR TITLE
Fix GPay mark regression in Add Payment Method drawer

### DIFF
--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/AddPaymentMethodDrawer/AddPaymentMethodDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/AddPaymentMethodDrawer/AddPaymentMethodDrawer.tsx
@@ -26,11 +26,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   root: {
     marginTop: 4,
   },
-  gpay: {
-    '& button': {
-      marginRight: -theme.spacing(2),
-    },
-  },
   progress: {
     marginBottom: 18,
     width: '100%',
@@ -108,7 +103,6 @@ export const AddPaymentMethodDrawer: React.FC<Props> = (props) => {
             <Grid
               container
               item
-              className={classes.gpay}
               xs={4}
               md={3}
               justify="flex-end"

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/GooglePayChip.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/GooglePayChip.tsx
@@ -18,6 +18,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     border: 0,
     padding: 0,
     marginTop: 10,
+    marginRight: -8,
     backgroundColor: 'transparent',
     cursor: 'pointer',
     '&:hover': {
@@ -32,6 +33,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
   },
   errorIcon: {
+    marginRight: -16,
     color: theme.color.red,
     '&:hover': {
       color: theme.color.red,
@@ -123,7 +125,7 @@ export const GooglePayChip: React.FC<Props> = (props) => {
       onClick={handlePay}
       disabled={disabledDueToProcessing}
     >
-      <GooglePayIcon height="48px" />
+      <GooglePayIcon height="26px" />
     </button>
   );
 };


### PR DESCRIPTION
## Description
Fixes the GPay mark being too big in the Add Payment Method drawer 

## How to test
Go to `account/billing/add-payment-method` and the icon shouldn't be huge anymore