### PR TITLE
M3-5349  E2E update test to reflect copy update

### DIFF
--- a/packages/manager/cypress/integration/objectStorage/access-keys.spec.ts
+++ b/packages/manager/cypress/integration/objectStorage/access-keys.spec.ts
@@ -1,9 +1,5 @@
 import { makeTestLabel } from '../../support/api/common';
-import {
-  createBucket,
-  deleteAllTestAccessKeys,
-  deleteBucketByLabel,
-} from '../../support/api/objectStorage';
+import { createBucket } from '../../support/api/objectStorage';
 import {
   containsVisible,
   fbtClick,
@@ -33,9 +29,9 @@ describe('access keys', () => {
       fbtClick('Submit');
       cy.wait('@createAccessKey');
       fbtVisible(
-        'Your keys have been generated. For security purposes, we can only display your Secret Key once, after which it can’t be recovered.'
+        "For security purposes, we can only display your secret key once, after which it can't be recovered. Be sure to keep it in a safe place."
       );
-      getClick('[data-qa-close-dialog="true"]');
+      getClick('[data-qa-close-drawer="true"]');
       fbtVisible(accessKeyLabel);
     });
   });


### PR DESCRIPTION
## Description
This change was needed because of some recent copy changes to this page

**What does this PR do?**
just a small access-keys e2e test update

## How to test
- `yarn up` in one terminal
- `yarn cy:e2e -s ./cypress/integration/objectStorage/access-keys.spec.ts` in another
- Result should be "✔  All specs passed!"

## Make sure your the mock service worker is off and your .env contains:
```
REACT_APP_LOGIN_ROOT
REACT_APP_API_ROOT
REACT_APP_APP_ROOT
REACT_APP_LAUNCH_DARKLY_ID
REACT_APP_CLIENT_ID
MANAGER_OAUTH
```