### PR TITLE
M3-5350 E2E firewall test update

### DIFF
--- a/packages/manager/cypress/integration/firewall/migrate-linode-with-firewall.spec.ts
+++ b/packages/manager/cypress/integration/firewall/migrate-linode-with-firewall.spec.ts
@@ -137,7 +137,7 @@ describe('Migrate Linode With Firewall', () => {
     }).as('getLinodes');
 
     // modify incoming response
-    cy.intercept(`*/linode/instances/${fakeLinodeId}/migrate`, (req) => {
+    cy.intercept('GET', `*/linode/instances/${fakeLinodeId}/migrate`, (req) => {
       req.reply((res) => {
         res.send(fakeLinodeData);
       });


### PR DESCRIPTION
## Description
This change was needed because of some recent ui changes to this page

**What does this PR do?**
just a small firewall e2e test update. The intercepts were getting mixed up and not stubbing the post correctly. 

## How to test
- `yarn up` in one terminal
- `yarn cy:e2e -s ./cypress/integration/firewall/migrate-linode-with-firewall.spec.ts` in another
- Result should be "✔  All specs passed!"

## Make sure your .env contains:
```
REACT_APP_LOGIN_ROOT
REACT_APP_API_ROOT
REACT_APP_APP_ROOT
REACT_APP_LAUNCH_DARKLY_ID
REACT_APP_CLIENT_ID
MANAGER_OAUTH
```