### PR TITLE
Improve Table Loading and Table Error Styles

### DIFF
--- a/packages/manager/src/components/ErrorState/ErrorState.tsx
+++ b/packages/manager/src/components/ErrorState/ErrorState.tsx
@@ -24,6 +24,7 @@ type CSSClasses = 'root' | 'iconContainer' | 'icon' | 'compact' | 'cozy';
 const styles = (theme: Theme) =>
   createStyles({
     root: {
+      width: '100%',
       padding: theme.spacing(10),
     },
     compact: {

--- a/packages/manager/src/components/Skeleton/Skeleton.tsx
+++ b/packages/manager/src/components/Skeleton/Skeleton.tsx
@@ -7,8 +7,8 @@ import Grid from 'src/components/Grid';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
+    width: '100%',
     marginTop: theme.spacing(1),
-    marginBottom: 10,
   },
   oneLine: {
     marginBottom: 0,
@@ -109,39 +109,37 @@ const _Skeleton: React.FC<combinedProps> = (props) => {
     );
   }
 
-  return (
-    <>
-      {table ? (
-        <>
-          <Grid
-            container
-            className={classNames({
-              [classes.root]: true,
-              [classes.oneLine]: oneLine,
-              [classes.hasEntityIcon]: hasEntityIcon,
-            })}
-            data-testid={'tableSkeleton'}
-            aria-label="Table Content Loading"
-            tabIndex={0}
-          >
-            {hasEntityIcon && (
-              <Grid item className={classes.skeletonIconContainer}>
-                <Skeleton variant="circle" className={classes.skeletonIcon} />
-              </Grid>
-            )}
-            {columns}
+  if (table) {
+    return (
+      <Grid
+        container
+        className={classNames({
+          [classes.root]: true,
+          [classes.oneLine]: oneLine,
+          [classes.hasEntityIcon]: hasEntityIcon,
+        })}
+        data-testid="tableSkeleton"
+        aria-label="Table Content Loading"
+        tabIndex={0}
+      >
+        {hasEntityIcon && (
+          <Grid item className={classes.skeletonIconContainer}>
+            <Skeleton variant="circle" className={classes.skeletonIcon} />
           </Grid>
-        </>
-      ) : (
-        <Skeleton
-          {...props}
-          className={classes.root}
-          data-testid={'basicSkeleton'}
-          aria-label="Table Content Loading"
-          tabIndex={0}
-        />
-      )}
-    </>
+        )}
+        {columns}
+      </Grid>
+    );
+  }
+
+  return (
+    <Skeleton
+      {...props}
+      className={classes.root}
+      data-testid="basicSkeleton"
+      aria-label="Table Content Loading"
+      tabIndex={0}
+    />
   );
 };
 


### PR DESCRIPTION
## Description

- Fixes x-overflow for Table related components by manually setting width to `100%` for the necessary Gird containers

Before:
<img width="1547" alt="Screen Shot 2021-07-30 at 9 51 45 AM" src="https://user-images.githubusercontent.com/6440455/127663429-45f905f6-5b91-404a-bd6c-4f3ef8f56236.png">

After:
<img width="1547" alt="Screen Shot 2021-07-30 at 9 37 38 AM" src="https://user-images.githubusercontent.com/6440455/127663357-0ad331a1-4b99-40d1-9651-569534afca28.png">


## How to test

- Make sure things that use `Skeleton.tsx` still display as expected
- Make sure Loading state and error states of Tables look ok and have no x-overflow
