### PR TITLE
M3-4411  E2E test for create bucket flow

### DIFF
--- a/packages/manager/cypress/integration/objectStorage/buckets.spec.ts
+++ b/packages/manager/cypress/integration/objectStorage/buckets.spec.ts
@@ -1,0 +1,38 @@
+import { createMockBucket } from 'cypress/support/api/objectStorage';
+import {
+  fbtClick,
+  fbtVisible,
+  getClick,
+  getVisible,
+} from 'cypress/support/helpers';
+
+const bucketLabel = createMockBucket().data[0].label;
+const bucketCluster = createMockBucket().data[0].cluster;
+const hostname = `${bucketLabel}.${bucketCluster}.linodeobjets.com`;
+const mockBucket = createMockBucket({ hostname });
+const regionSelect = 'Frankfurt, DE';
+
+describe('create bucket flow, mocked data', () => {
+  it('creates bucket', () => {
+    cy.intercept('*/object-storage/buckets*', (req) => {
+      req.reply(mockBucket);
+    }).as('mockBucket');
+    cy.intercept('GET', `*/object-storage/buckets/${bucketCluster}*`, (req) => {
+      req.reply(mockBucket);
+    }).as('getBuckets');
+
+    cy.visitWithLogin('/object-storage/buckets');
+    fbtClick('Create Bucket');
+    getClick('[data-qa-cluster-label="true"]').type(bucketLabel);
+    getClick('[data-qa-enhanced-select="Select a Region"]');
+    fbtClick(regionSelect);
+    getVisible('[data-qa-submit="true"]').within(() => {
+      fbtClick('Create Bucket');
+    });
+    cy.wait('@mockBucket');
+    cy.wait('@getBuckets');
+    fbtVisible(bucketLabel);
+    fbtVisible(hostname);
+    fbtVisible(regionSelect);
+  });
+});

--- a/packages/manager/cypress/support/api/objectStorage.ts
+++ b/packages/manager/cypress/support/api/objectStorage.ts
@@ -1,9 +1,21 @@
+import { imageFactory, objectStorageBucketFactory } from '@src/factories';
+import { makeResourcePage } from '@src/mocks/serverHandlers';
 import { apiCheckErrors, deleteById, getAll, isTestEntity } from './common';
 const oauthtoken = Cypress.env('MANAGER_OAUTH');
 const apiroot = Cypress.env('REACT_APP_API_ROOT') + '/';
 
 export const getAccessKeys = () => getAll('object-storage/keys');
 export const getBuckets = () => getAll('object-storage/buckets');
+
+export const createMockBucket = (
+  data?,
+  cluster = 'eu-central-1',
+  label = 'cy-test-bucket'
+) => {
+  return makeResourcePage(
+    objectStorageBucketFactory.buildList(1, { cluster, label, ...data })
+  );
+};
 
 const makeBucketCreateReq = (
   label: string,


### PR DESCRIPTION
## Description
Create Bucket Flow Test

**What does this PR do?**
Goes through flow of creating a bucket, mocked data

## How to test
- `yarn up` in one terminal
- `yarn cy:e2e -s ./cypress/integration/objectStorage/buckets.spec.ts` in another
- Result should be "✔  All specs passed!"

## Make sure your .env contains:
```
REACT_APP_LOGIN_ROOT
REACT_APP_API_ROOT
REACT_APP_APP_ROOT
REACT_APP_LAUNCH_DARKLY_ID
REACT_APP_CLIENT_ID
MANAGER_OAUTH
```