### PR TITLE
M3-5331: Remove redundant headers

### DIFF
--- a/packages/manager/src/features/Profile/LishSettings/LishSettings.tsx
+++ b/packages/manager/src/features/Profile/LishSettings/LishSettings.tsx
@@ -28,35 +28,19 @@ import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 
 type ClassNames =
-  | 'root'
-  | 'title'
   | 'intro'
   | 'modeControl'
   | 'sshWrap'
   | 'keyTextarea'
-  | 'image'
-  | 'addNew'
-  | 'remove'
-  | 'button';
+  | 'addNew';
 
 const styles = (theme: Theme) =>
   createStyles({
-    root: {
-      padding: theme.spacing(3),
-      paddingBottom: theme.spacing(3),
-    },
-    title: {
-      marginBottom: theme.spacing(2),
-    },
     intro: {
       marginBottom: theme.spacing(2),
     },
     modeControl: {
       display: 'flex',
-    },
-    image: {
-      display: 'flex',
-      flexWrap: 'wrap',
     },
     addNew: {
       ...theme.applyLinkStyles,
@@ -69,13 +53,6 @@ const styles = (theme: Theme) =>
       [theme.breakpoints.up('md')]: {
         minWidth: 415,
       },
-    },
-    remove: {
-      ...theme.applyLinkStyles,
-    },
-    button: {
-      margin: 0,
-      padding: 0,
     },
   });
 
@@ -154,21 +131,20 @@ class LishSettings extends React.Component<CombinedProps, State> {
     });
 
     return (
-      <React.Fragment>
+      <>
         <DocumentTitleSegment segment="LISH Console Settings" />
-        <Paper className={classes.root}>
-          <Typography variant="h2" className={classes.title} data-qa-title>
-            LISH Console Settings
-          </Typography>
-          {success && <Notice success text={success} />}
-          {authorizedKeysError && <Notice error text={authorizedKeysError} />}
-          {generalError && <Notice error text={generalError} />}
+        <Paper>
+          {success ? <Notice success text={success} /> : null}
+          {authorizedKeysError ? (
+            <Notice error text={authorizedKeysError} />
+          ) : null}
+          {generalError ? <Notice error text={generalError} /> : null}
           <Typography className={classes.intro}>
             This controls what authentication methods are allowed to connect to
             the Lish console servers.
           </Typography>
           {loading ? null : (
-            <React.Fragment>
+            <>
               <FormControl className={classes.modeControl}>
                 <Select
                   textFieldProps={{
@@ -199,47 +175,48 @@ class LishSettings extends React.Component<CombinedProps, State> {
                     className={classes.keyTextarea}
                     data-qa-public-key
                   />
-                  {((idx === 0 && typeof authorizedKeys[0] !== 'undefined') ||
-                    idx > 0) && (
-                    <button
+                  {(idx === 0 && typeof authorizedKeys[0] !== 'undefined') ||
+                  idx > 0 ? (
+                    <Button
+                      buttonType="secondary"
+                      compact
                       onClick={this.onPublicKeyRemove(idx)}
-                      className={classes.remove}
                       data-qa-remove
                     >
                       Remove
-                    </button>
-                  )}
+                    </Button>
+                  ) : null}
                 </div>
               ))}
               <Typography style={{ paddingTop: 2 }}>
                 Place your SSH public keys here for use with Lish console
                 access.
               </Typography>
-              <button
+              <Button
+                buttonType="secondary"
+                compact
                 onClick={this.addSSHPublicKeyField}
-                className={classes.addNew}
               >
                 Add SSH Public Key
-              </button>
-            </React.Fragment>
+              </Button>
+            </>
           )}
           <ActionsPanel>
             <Button
-              className={classes.button}
               buttonType="primary"
-              onClick={this.onSubmit}
-              loading={this.state.submitting}
               disabled={
                 this.state.lishAuthMethod === this.props.lishAuthMethod &&
                 equals(this.state.authorizedKeys, this.props.authorizedKeys)
               }
+              loading={this.state.submitting}
+              onClick={this.onSubmit}
               data-qa-save
             >
               Save
             </Button>
           </ActionsPanel>
         </Paper>
-      </React.Fragment>
+      </>
     );
   }
 

--- a/packages/manager/src/features/Profile/OAuthClients/OAuthClients.test.tsx
+++ b/packages/manager/src/features/Profile/OAuthClients/OAuthClients.test.tsx
@@ -1,11 +1,8 @@
-import { shallow, ShallowWrapper } from 'enzyme';
 import { OAuthClient } from '@linode/api-v4/lib/account';
+import { shallow, ShallowWrapper } from 'enzyme';
 import * as React from 'react';
-
-import { pageyProps } from 'src/__data__/pageyProps';
-
 import { clearDocs, setDocs } from 'src/store/documentation';
-
+import { pageyProps } from 'src/__data__/pageyProps';
 import { OAuthClients } from './OAuthClients';
 
 describe('OAuth Clients', () => {
@@ -40,7 +37,7 @@ describe('OAuth Clients', () => {
   beforeEach(() => {
     wrapper = shallow(
       <OAuthClients
-        classes={{ root: '', headline: '', addNewWrapper: '', actionCell: '' }}
+        classes={{ root: '', addNewWrapper: '', actionCell: '' }}
         {...pageyProps}
         data={mockData}
         setDocs={setDocs}

--- a/packages/manager/src/features/Profile/OAuthClients/OAuthClients.tsx
+++ b/packages/manager/src/features/Profile/OAuthClients/OAuthClients.tsx
@@ -19,7 +19,6 @@ import {
 } from 'src/components/core/styles';
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
-import Typography from 'src/components/core/Typography';
 import setDocs, { SetDocsProps } from 'src/components/DocsSidebar/setDocs';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
@@ -39,20 +38,20 @@ import Modals from './Modals';
 import ActionMenu from './OAuthClientActionMenu';
 import OAuthFormDrawer from './OAuthFormDrawer';
 
-type ClassNames = 'root' | 'headline' | 'addNewWrapper' | 'actionCell';
+type ClassNames = 'root' | 'addNewWrapper' | 'actionCell';
 
 const styles = (theme: Theme) =>
   createStyles({
     root: {
-      backgroundColor: theme.color.white,
       width: '100%',
-    },
-    headline: {
-      marginLeft: 15,
     },
     addNewWrapper: {
       '&.MuiGrid-item': {
-        padding: 5,
+        paddingTop: 0,
+        paddingRight: 0,
+      },
+      [theme.breakpoints.down('sm')]: {
+        marginRight: theme.spacing(),
       },
     },
     actionCell: {
@@ -373,21 +372,12 @@ export class OAuthClients extends React.Component<CombinedProps, State> {
           className={`${classes.root} m0`}
           container
           alignItems="center"
-          justify="space-between"
+          justify="flex-end"
         >
-          <Grid className="p0" item>
-            <Typography
-              className={classes.headline}
-              variant="h3"
-              data-qa-table={classes.headline}
-            >
-              OAuth Apps
-            </Typography>
-          </Grid>
           <Grid className={classes.addNewWrapper} item>
             <AddNewLink
-              onClick={() => this.openDrawer()(false)}
               label="Add an OAuth App"
+              onClick={() => this.openDrawer()(false)}
               data-qa-oauth-create
             />
           </Grid>

--- a/packages/manager/src/features/Profile/SSHKeys/SSHKeys.test.tsx
+++ b/packages/manager/src/features/Profile/SSHKeys/SSHKeys.test.tsx
@@ -1,8 +1,8 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
+import { pageyProps } from 'src/__data__/pageyProps';
 import { SSHKeys } from './SSHKeys';
 
-import { pageyProps } from 'src/__data__/pageyProps';
 /**
  * Displays a table
  * Table has 4 columns
@@ -15,9 +15,7 @@ describe('SSHKeys', () => {
       <SSHKeys
         {...pageyProps}
         classes={{
-          root: '',
           sshKeysHeader: '',
-          headline: '',
           addNewWrapper: '',
           createdCell: '',
           actionCell: '',
@@ -59,9 +57,7 @@ describe('SSHKeys', () => {
       <SSHKeys
         {...pageyProps}
         classes={{
-          root: '',
           sshKeysHeader: '',
-          headline: '',
           addNewWrapper: '',
           createdCell: '',
           actionCell: '',
@@ -80,9 +76,7 @@ describe('SSHKeys', () => {
       <SSHKeys
         {...pageyProps}
         classes={{
-          root: '',
           sshKeysHeader: '',
-          headline: '',
           addNewWrapper: '',
           createdCell: '',
           actionCell: '',
@@ -101,9 +95,7 @@ describe('SSHKeys', () => {
       <SSHKeys
         {...pageyProps}
         classes={{
-          root: '',
           sshKeysHeader: '',
-          headline: '',
           addNewWrapper: '',
           createdCell: '',
           actionCell: '',

--- a/packages/manager/src/features/Profile/SSHKeys/SSHKeys.tsx
+++ b/packages/manager/src/features/Profile/SSHKeys/SSHKeys.tsx
@@ -43,6 +43,7 @@ const styles = (theme: Theme) =>
     },
     addNewWrapper: {
       '&.MuiGrid-item': {
+        paddingTop: 0,
         paddingRight: 0,
       },
       [theme.breakpoints.down('sm')]: {

--- a/packages/manager/src/features/Profile/SSHKeys/SSHKeys.tsx
+++ b/packages/manager/src/features/Profile/SSHKeys/SSHKeys.tsx
@@ -30,31 +30,23 @@ import fingerprint from 'src/utilities/ssh-fingerprint';
 import SSHKeyCreationDrawer from './SSHKeyCreationDrawer';
 
 type ClassNames =
-  | 'root'
   | 'sshKeysHeader'
-  | 'headline'
   | 'addNewWrapper'
   | 'createdCell'
   | 'actionCell';
 
 const styles = (theme: Theme) =>
   createStyles({
-    root: {
-      backgroundColor: theme.color.white,
-    },
     sshKeysHeader: {
       margin: 0,
       width: '100%',
     },
-    headline: {
-      marginTop: 8,
-      marginBottom: 8,
-      marginLeft: 15,
-      lineHeight: '1.5rem',
-    },
     addNewWrapper: {
       '&.MuiGrid-item': {
-        padding: 5,
+        paddingRight: 0,
+      },
+      [theme.breakpoints.down('sm')]: {
+        marginRight: theme.spacing(),
       },
     },
     createdCell: {
@@ -118,19 +110,14 @@ export class SSHKeys extends React.Component<CombinedProps, State> {
     const { classes } = this.props;
 
     return (
-      <div className={classes.root}>
+      <>
         <DocumentTitleSegment segment="SSH Keys" />
         <Grid
-          className={classes.sshKeysHeader}
           container
           alignItems="flex-end"
-          justify="space-between"
+          justify="flex-end"
+          className={classes.sshKeysHeader}
         >
-          <Grid className="p0" item>
-            <Typography variant="h3" className={classes.headline}>
-              SSH Keys
-            </Typography>
-          </Grid>
           <Grid className={classes.addNewWrapper} item>
             <AddNewLink
               label="Add an SSH Key"
@@ -171,7 +158,7 @@ export class SSHKeys extends React.Component<CombinedProps, State> {
           onSuccess={this.handleSuccessfulCreation}
           onCancel={this.closeCreationDrawer}
         />
-      </div>
+      </>
     );
   }
 

--- a/packages/manager/src/features/Users/UsersLanding.tsx
+++ b/packages/manager/src/features/Users/UsersLanding.tsx
@@ -11,28 +11,24 @@ import {
 } from 'src/components/core/styles';
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
-import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
 import PaginationFooter from 'src/components/PaginationFooter';
-import usePagination from 'src/hooks/usePagination';
-import { useAccountUsers } from 'src/queries/accountUsers';
 import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import TableRowEmptyState from 'src/components/TableRowEmptyState';
 import TableRowError from 'src/components/TableRowError';
 import TableRowLoading from 'src/components/TableRowLoading';
+import usePagination from 'src/hooks/usePagination';
+import { useAccountUsers } from 'src/queries/accountUsers';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import CreateUserDrawer from './CreateUserDrawer';
 import UserDeleteConfirmationDialog from './UserDeleteConfirmationDialog';
 import ActionMenu from './UsersActionMenu';
 
 const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    backgroundColor: theme.color.white,
-  },
   userLandingHeader: {
     margin: 0,
     width: '100%',
@@ -46,10 +42,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   addNewWrapper: {
     [theme.breakpoints.down('xs')]: {
       marginLeft: -(theme.spacing(1) + theme.spacing(1) / 2),
-      padding: 5,
     },
     '&.MuiGrid-item': {
-      padding: 5,
+      paddingRight: 0,
     },
   },
   '@keyframes fadeIn': {
@@ -234,45 +229,38 @@ const UsersLanding: React.FC<Props> = (props) => {
           text={`Error when deleting user, please try again later`}
         />
       )}
-      <div className={classes.root}>
-        <Grid
-          container
-          justify="space-between"
-          alignItems="flex-end"
-          className={classes.userLandingHeader}
-        >
-          <Grid item className="p0">
-            <Typography variant="h3" data-qa-title className={classes.headline}>
-              Users
-            </Typography>
-          </Grid>
-          <Grid item className={classes.addNewWrapper}>
-            <AddNewLink
-              disabled={props.isRestrictedUser}
-              disabledReason={
-                props.isRestrictedUser
-                  ? 'You cannot create other users as a restricted user.'
-                  : undefined
-              }
-              onClick={openForCreate}
-              label="Add a User"
-            />
-          </Grid>
+      <Grid
+        container
+        alignItems="flex-end"
+        justify="flex-end"
+        className={classes.userLandingHeader}
+      >
+        <Grid item className={classes.addNewWrapper}>
+          <AddNewLink
+            disabled={props.isRestrictedUser}
+            disabledReason={
+              props.isRestrictedUser
+                ? 'You cannot create other users as a restricted user.'
+                : undefined
+            }
+            onClick={openForCreate}
+            label="Add a User"
+          />
         </Grid>
-        <Table aria-label="List of Users">
-          <TableHead>
-            <TableRow>
-              <TableCell data-qa-username-column>Username</TableCell>
-              {!matchesSmDown && (
-                <TableCell data-qa-email-column>Email Address</TableCell>
-              )}
-              <TableCell data-qa-restriction-column>Account Access</TableCell>
-              <TableCell />
-            </TableRow>
-          </TableHead>
-          <TableBody>{renderTableContent()}</TableBody>
-        </Table>
-      </div>
+      </Grid>
+      <Table aria-label="List of Users">
+        <TableHead>
+          <TableRow>
+            <TableCell data-qa-username-column>Username</TableCell>
+            {!matchesSmDown && (
+              <TableCell data-qa-email-column>Email Address</TableCell>
+            )}
+            <TableCell data-qa-restriction-column>Account Access</TableCell>
+            <TableCell />
+          </TableRow>
+        </TableHead>
+        <TableBody>{renderTableContent()}</TableBody>
+      </Table>
       <PaginationFooter
         count={users?.results || 0}
         page={pagination.page}

--- a/packages/manager/src/features/Users/UsersLanding.tsx
+++ b/packages/manager/src/features/Users/UsersLanding.tsx
@@ -40,11 +40,11 @@ const useStyles = makeStyles((theme: Theme) => ({
     lineHeight: '1.5rem',
   },
   addNewWrapper: {
-    [theme.breakpoints.down('xs')]: {
-      marginLeft: -(theme.spacing(1) + theme.spacing(1) / 2),
-    },
     '&.MuiGrid-item': {
       paddingRight: 0,
+    },
+    [theme.breakpoints.down('sm')]: {
+      marginRight: theme.spacing(),
     },
   },
   '@keyframes fadeIn': {

--- a/packages/manager/src/features/Users/UsersLanding.tsx
+++ b/packages/manager/src/features/Users/UsersLanding.tsx
@@ -41,6 +41,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   addNewWrapper: {
     '&.MuiGrid-item': {
+      paddingTop: 0,
       paddingRight: 0,
     },
     [theme.breakpoints.down('sm')]: {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeActivity/LinodeActivity.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeActivity/LinodeActivity.test.tsx
@@ -3,9 +3,7 @@ import * as React from 'react';
 import { LinodeActivity } from './LinodeActivity';
 
 describe('LinodeActivity', () => {
-  const wrapper = shallow(
-    <LinodeActivity classes={{ root: '', title: '' }} linodeID={123} />
-  );
+  const wrapper = shallow(<LinodeActivity linodeID={123} />);
 
   it('should return an EventsLanding component', () => {
     expect(wrapper.find('[data-qa-events-landing-for-linode]')).toHaveLength(1);

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeActivity/LinodeActivity.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeActivity/LinodeActivity.tsx
@@ -1,53 +1,24 @@
 import * as React from 'react';
 import { compose } from 'recompose';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles,
-} from 'src/components/core/styles';
-import Typography from 'src/components/core/Typography';
 import EventsLanding from 'src/features/Events/EventsLanding';
 import { getEventsForEntity } from 'src/utilities/getEventsForEntity';
 import { withLinodeDetailContext } from '../linodeDetailContext';
 
-type ClassNames = 'root' | 'title';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {},
-    title: {
-      marginBottom: theme.spacing(2),
-      [theme.breakpoints.down('md')]: {
-        marginLeft: theme.spacing(1),
-      },
-    },
-  });
-
-type CombinedProps = WithStyles<ClassNames> & StateProps;
+type CombinedProps = StateProps;
 
 export const LinodeActivity: React.FC<CombinedProps> = (props) => {
-  const { classes, linodeID } = props;
+  const { linodeID } = props;
 
   return (
-    <div>
-      <Typography
-        variant="h2"
-        className={classes.title}
-        data-qa-settings-header
-      >
-        Activity Feed
-      </Typography>
-      <EventsLanding
-        entityId={linodeID}
-        getEventsRequest={(params: any = {}) =>
-          getEventsForEntity(params, 'linode', props.linodeID)
-        }
-        errorMessage="There was an error retrieving activity for this Linode."
-        emptyMessage="No recent activity for this Linode."
-        data-qa-events-landing-for-linode
-      />
-    </div>
+    <EventsLanding
+      entityId={linodeID}
+      getEventsRequest={(params: any = {}) =>
+        getEventsForEntity(params, 'linode', props.linodeID)
+      }
+      errorMessage="There was an error retrieving activity for this Linode."
+      emptyMessage="No recent activity for this Linode."
+      data-qa-events-landing-for-linode
+    />
   );
 };
 
@@ -58,8 +29,6 @@ const linodeContext = withLinodeDetailContext(({ linode }) => ({
   linodeID: linode.id,
 }));
 
-const styled = withStyles(styles);
-
-const enhanced = compose<CombinedProps, {}>(linodeContext, styled);
+const enhanced = compose<CombinedProps, {}>(linodeContext);
 
 export default enhanced(LinodeActivity);

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs.tsx
@@ -15,7 +15,6 @@ import ActionsPanel from 'src/components/ActionsPanel';
 import AddNewLink from 'src/components/AddNewLink';
 import Button from 'src/components/Button';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
-import RootRef from 'src/components/core/RootRef';
 import {
   createStyles,
   Theme,
@@ -179,18 +178,13 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
     const { classes, readOnly } = this.props;
 
     return (
-      <React.Fragment>
+      <>
         <Grid
           container
           alignItems="flex-end"
-          justify="space-between"
+          justify="flex-end"
           className={classes.root}
         >
-          <RootRef rootRef={this.configsPanel}>
-            <Grid item className="p0">
-              <Typography variant="h3" />
-            </Grid>
-          </RootRef>
           <Grid item className={classes.addNewWrapper}>
             <AddNewLink
               onClick={this.openConfigDrawerForCreation}
@@ -235,7 +229,7 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
             ?&quot;
           </Typography>
         </ConfirmationDialog>
-      </React.Fragment>
+      </>
     );
   }
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs.tsx
@@ -64,6 +64,7 @@ const styles = (theme: Theme) =>
     },
     addNewWrapper: {
       '&.MuiGrid-item': {
+        paddingTop: 0,
         paddingRight: 0,
       },
       [theme.breakpoints.down('sm')]: {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs.tsx
@@ -29,7 +29,6 @@ import Grid from 'src/components/Grid';
 import OrderBy from 'src/components/OrderBy';
 import Paginate from 'src/components/Paginate';
 import PaginationFooter from 'src/components/PaginationFooter';
-import PanelErrorBoundary from 'src/components/PanelErrorBoundary';
 import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
 import TableContentWrapper from 'src/components/TableContentWrapper';
@@ -51,7 +50,6 @@ import ConfigRow from './ConfigRow';
 
 type ClassNames =
   | 'root'
-  | 'headline'
   | 'addNewWrapper'
   | 'tableCell'
   | 'labelColumn'
@@ -62,22 +60,16 @@ type ClassNames =
 const styles = (theme: Theme) =>
   createStyles({
     root: {
-      backgroundColor: theme.color.white,
       margin: 0,
       width: '100%',
     },
-    headline: {
-      marginTop: 8,
-      marginBottom: 8,
-      marginLeft: 15,
-      lineHeight: '1.5rem',
-    },
     addNewWrapper: {
-      [theme.breakpoints.down('xs')]: {
-        marginLeft: -(theme.spacing(1) + theme.spacing(1) / 2),
-        marginTop: -theme.spacing(1),
+      '&.MuiGrid-item': {
+        paddingRight: 0,
       },
-      padding: '5px !important',
+      [theme.breakpoints.down('sm')]: {
+        marginRight: theme.spacing(),
+      },
     },
     tableCell: {
       borderRight: `1px solid ${theme.palette.divider}`,
@@ -190,15 +182,13 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
       <React.Fragment>
         <Grid
           container
-          justify="space-between"
           alignItems="flex-end"
+          justify="space-between"
           className={classes.root}
         >
           <RootRef rootRef={this.configsPanel}>
             <Grid item className="p0">
-              <Typography variant="h3" className={classes.headline}>
-                Configurations
-              </Typography>
+              <Typography variant="h3" />
             </Grid>
           </RootRef>
           <Grid item className={classes.addNewWrapper}>
@@ -529,10 +519,6 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
 
 const styled = withStyles(styles);
 
-const errorBoundary = PanelErrorBoundary({
-  heading: 'Advanced Configurations',
-});
-
 interface LinodeContext {
   linodeHypervisor: 'kvm' | 'xen';
   linodeId: number;
@@ -592,7 +578,6 @@ const enhanced = compose<CombinedProps, {}>(
   withFeatureFlags,
   connected,
   styled,
-  errorBoundary,
   withSnackbar
 );
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -69,7 +69,6 @@ import RestoreToLinodeDrawer from './RestoreToLinodeDrawer';
 
 type ClassNames =
   | 'paper'
-  | 'title'
   | 'subTitle'
   | 'snapshotNameField'
   | 'snapshotFormControl'
@@ -83,13 +82,6 @@ const styles = (theme: Theme) =>
   createStyles({
     paper: {
       marginBottom: theme.spacing(3),
-    },
-    title: {
-      marginTop: theme.spacing(1),
-      marginBottom: theme.spacing(2),
-      [theme.breakpoints.down('md')]: {
-        marginLeft: theme.spacing(1),
-      },
     },
     subTitle: {
       marginBottom: theme.spacing(1),
@@ -717,15 +709,6 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
     return (
       <React.Fragment>
         {disabled && <LinodePermissionsError />}
-        <Typography
-          aria-level={2}
-          role="heading"
-          variant="h2"
-          className={classes.title}
-          data-qa-title
-        >
-          Backups
-        </Typography>
         {backups.length ? (
           <this.Table backups={backups} />
         ) : (

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettings.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettings.tsx
@@ -1,11 +1,4 @@
 import * as React from 'react';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles,
-} from 'src/components/core/styles';
-import Typography from 'src/components/core/Typography';
 import { LinodeDetailContextConsumer } from '../linodeDetailContext';
 import LinodePermissionsError from '../LinodePermissionsError';
 import LinodeSettingsAlertsPanel from './LinodeSettingsAlertsPanel';
@@ -14,27 +7,14 @@ import LinodeSettingsLabelPanel from './LinodeSettingsLabelPanel';
 import LinodeSettingsPasswordPanel from './LinodeSettingsPasswordPanel';
 import LinodeWatchdogPanel from './LinodeWatchdogPanel';
 
-type ClassNames = 'root' | 'title';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {},
-    title: {
-      marginBottom: theme.spacing(2),
-      [theme.breakpoints.down('md')]: {
-        marginLeft: theme.spacing(1),
-      },
-    },
-  });
-
 interface Props {
   isBareMetalInstance: boolean;
 }
 
-type CombinedProps = Props & WithStyles<ClassNames>;
+type CombinedProps = Props;
 
 const LinodeSettings: React.FC<CombinedProps> = (props) => {
-  const { classes, isBareMetalInstance } = props;
+  const { isBareMetalInstance } = props;
 
   return (
     <LinodeDetailContextConsumer>
@@ -49,15 +29,8 @@ const LinodeSettings: React.FC<CombinedProps> = (props) => {
           ) : null;
 
         return (
-          <div>
+          <>
             {permissionsError}
-            <Typography
-              variant="h2"
-              className={classes.title}
-              data-qa-settings-header
-            >
-              Settings
-            </Typography>
             <LinodeSettingsLabelPanel />
             <LinodeSettingsPasswordPanel
               isBareMetalInstance={isBareMetalInstance}
@@ -78,13 +51,11 @@ const LinodeSettings: React.FC<CombinedProps> = (props) => {
               linodeId={linode.id}
               linodeLabel={linode.label}
             />
-          </div>
+          </>
         );
       }}
     </LinodeDetailContextConsumer>
   );
 };
 
-const styled = withStyles(styles);
-
-export default styled(LinodeSettings);
+export default LinodeSettings;


### PR DESCRIPTION
## Description

Remove redundant headers from the Linode Detail tab pages and the settings related pages.

After removing the headers, there are several pages (ie. `/account/users`, `/profile/keys`, and `/linodes/id/configurations`) that are left with only a button in the header region. We decided to generally leave the buttons as they are except we removed the white background and aligned the button to the right. 

## How to test

Check the page headers and make sure the ones remaining add some context or information rather than repeating the tab label. 
