### PR TITLE
M3-5346: GooglePay display in Safari

### DIFF
--- a/packages/manager/src/components/PaymentMethodRow/ThirdPartyPayment.tsx
+++ b/packages/manager/src/components/PaymentMethodRow/ThirdPartyPayment.tsx
@@ -1,5 +1,11 @@
-import * as React from 'react';
+import {
+  CreditCard as CreditCardType,
+  ThirdPartyPayment as ThirdPartyPaymentType,
+} from '@linode/api-v4/lib/account/types';
 import * as classNames from 'classnames';
+import * as React from 'react';
+import GooglePayIcon from 'src/assets/icons/payment/googlePay.svg';
+import PayPalIcon from 'src/assets/icons/payment/payPal.svg';
 import {
   makeStyles,
   Theme,
@@ -7,29 +13,31 @@ import {
   useTheme,
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
-import GooglePayIcon from 'src/assets/icons/payment/googlePay.svg';
-import PayPalIcon from 'src/assets/icons/payment/payPal.svg';
-import {
-  CreditCard as CreditCardType,
-  ThirdPartyPayment as ThirdPartyPaymentType,
-} from '@linode/api-v4/lib/account/types';
+import Grid from 'src/components/Grid';
 import CreditCard from 'src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCard';
 
 const useStyles = makeStyles((theme: Theme) => ({
   icon: {
     display: 'flex',
+    // Safari's default setting for `alignItems` is `stretch` so defining it as
+    // `flex-start` fixes the issue
+    // https://stackoverflow.com/questions/57516373/image-stretching-in-flexbox-in-safari
+    alignItems: 'flex-start',
     justifyContent: 'center',
-    paddingRight: 4,
-    paddingLeft: theme.spacing(),
+    paddingLeft: 6,
+    paddingRight: 6,
     width: 45,
+    '& svg': {
+      // Safari needs the height/width defined in order to render the image
+      width: 33,
+    },
   },
   paymentTextContainer: {
     display: 'flex',
   },
   paymentMethodLabel: {
-    fontWeight: 'bold',
-    marginRight: 8,
-    marginLeft: 3,
+    fontFamily: theme.font.bold,
+    marginRight: theme.spacing(),
   },
   payPal: {
     border: `1px solid ${theme.color.grey2}`,
@@ -71,21 +79,21 @@ export const TPP: React.FC<CombinedProps> = (props) => {
 
   return (
     <>
-      <span className={classes.icon}>
+      <Grid item className={classes.icon}>
         <Icon
           className={classNames({
             [classes.payPal]: thirdPartyPayment === 'paypal',
           })}
         />
-      </span>
-      <div className={classes.paymentTextContainer}>
+      </Grid>
+      <Grid item className={classes.paymentTextContainer}>
         {!matchesSmDown ? (
           <Typography className={classes.paymentMethodLabel}>
             {thirdPartyPaymentMap[thirdPartyPayment].label}
           </Typography>
         ) : null}
         <CreditCard creditCard={creditCard} showIcon={false} />
-      </div>
+      </Grid>
     </>
   );
 };

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCard.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCard.tsx
@@ -1,15 +1,17 @@
+import {
+  CardType,
+  CreditCard as CreditCardType,
+} from '@linode/api-v4/lib/account/types';
 import * as React from 'react';
-import { makeStyles, Theme } from 'src/components/core/styles';
-import { CardType } from '@linode/api-v4/lib/account/types';
-import Typography from 'src/components/core/Typography';
-import isCreditCardExpired, { formatExpiry } from 'src/utilities/creditCard';
-import VisaIcon from 'src/assets/icons/payment/visa.svg';
-import MastercardIcon from 'src/assets/icons/payment/mastercard.svg';
+import GenericCardIcon from 'src/assets/icons/credit-card.svg';
 import AmexIcon from 'src/assets/icons/payment/amex.svg';
 import DiscoverIcon from 'src/assets/icons/payment/discover.svg';
 import JCBIcon from 'src/assets/icons/payment/jcb.svg';
-import GenericCardIcon from 'src/assets/icons/credit-card.svg';
-import { CreditCard as CreditCardType } from '@linode/api-v4/lib/account/types';
+import MastercardIcon from 'src/assets/icons/payment/mastercard.svg';
+import VisaIcon from 'src/assets/icons/payment/visa.svg';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+import isCreditCardExpired, { formatExpiry } from 'src/utilities/creditCard';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -18,13 +20,12 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   card: {
     display: 'flex',
-    marginLeft: 2,
     [theme.breakpoints.down('xs')]: {
-      display: 'grid',
+      flexDirection: 'column',
     },
   },
   cardInfo: {
-    fontWeight: 'bold',
+    fontFamily: theme.font.bold,
     marginRight: 10,
     [theme.breakpoints.down('xs')]: {
       marginRight: 0,


### PR DESCRIPTION
## Description

Fixes the vertical stretching and missing icon occurring in Payment Methods for GooglePay in Safari and iOS Chrome.

<img width="635" alt="Screen Shot 2021-08-02 at 4 49 03 PM" src="https://user-images.githubusercontent.com/7692354/127888869-acd06be6-7e27-44a6-bf8f-9b618592bc39.png">

Turns out Safari's default setting for `alignItems` is `stretch` so defining it as `flex-start` fixes the issue. A similar thing is happening to the GooglePay icon where Safari needs the height or width of the svg in order to render it.

## How to test

Go to `accounts/billing` on different browsers and check the display for different resolutions.
