### PR TITLE
M3-5164: Fix delay in graph reporting when navigating to Linodes from search

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -196,6 +196,18 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
     this.statsInterval = window.setInterval(this.getStats, statsFetchInterval);
   }
 
+  componentDidUpdate(prevProps: CombinedProps) {
+    /*
+    If the user navigates to a different Linode via the search bar,
+    this component wouldn't unmount. Stats wouldn't be fetched immediately,
+    leading to a period of up to 30 seconds where the previous Linode's chart
+    data would show.
+    */
+    if (prevProps.linodeId !== this.props.linodeId) {
+      this.getStats();
+    }
+  }
+
   componentWillUnmount() {
     this.mounted = false;
     window.clearInterval(this.statsInterval as number);


### PR DESCRIPTION
## Description
From the Analytics tab in a Linode's Detail view, navigating to another Linode via the search bar results in a charts data update delay of up to 30 seconds in which the previous Linode's chart data is still shown.

From what I can tell, this happens because the `<LinodeSummary />` component doesn't unmount in that process, so `getStats()` doesn't get called before the interval is up.

This PR checks in `componentDidUpdate()` whether the `linodeId` prop has changed (which it does when you switch Linodes) and if it has, `getStats()` gets called, pulling in the correct chart data.

## How to test
On the Analytics tab in a Linode's Detail view, use the search bar to navigate to another Linode. The chart data and all other data shown should be for the Linode you just navigated to, not the previous one.
