### PR TITLE
Fix: unable to add tags to Volumes during creation.

### DIFF
--- a/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
@@ -40,6 +40,7 @@ import { sendCreateVolumeEvent } from 'src/utilities/ga';
 import { getEntityByIDFromStore } from 'src/utilities/getEntityByIDFromStore';
 import isNilOrEmpty from 'src/utilities/isNilOrEmpty';
 import maybeCastToNumber from 'src/utilities/maybeCastToNumber';
+import { array, object, string } from 'yup';
 import ConfigSelect, {
   initialValueDefaultId,
 } from '../VolumeDrawer/ConfigSelect';
@@ -85,6 +86,18 @@ interface Props {
   ) => void;
 }
 
+// The original schema expects tags to be an array of strings, but Formik treats
+// tags as _Tag[], so we extend the schema to transform tags before validation.
+const extendedCreateVolumeSchema = CreateVolumeSchema.concat(
+  object({
+    tags: array()
+      .transform((tagItems: _Tag[]) =>
+        tagItems.map((thisTagItem) => thisTagItem.value)
+      )
+      .of(string()),
+  })
+);
+
 type CombinedProps = Props & VolumesRequests & StateProps;
 
 const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
@@ -110,7 +123,7 @@ const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
   return (
     <Formik
       initialValues={initialValues}
-      validationSchema={CreateVolumeSchema}
+      validationSchema={extendedCreateVolumeSchema}
       onSubmit={(
         values,
         { resetForm, setSubmitting, setStatus, setErrors }


### PR DESCRIPTION
## Description

This fixes a bug in develop where creating a new volume with a tag results in a field error: "Unable to tag Volume." 

This appears to have been introduced in the recent [Yup upgrade](https://github.com/linode/manager/pull/7787). I don't exactly know why, though. We've always been validating tags in the CreateVolumeSchema as `array().of(string())`, but we've been sending an array of `_Tag`, which are objects. Maybe yup wasn't validating properly beforehand. In any case, we should dig more into this issue because it may also be present elsewhere.

To fix this, I extended the schema in CreateVolumeForm.

## How to test

**What are the steps to reproduce the issue or verify the changes?**

Create a Volume from the Create Volume page with a tag. Check that other validation still works as expected.
