### PR TITLE
Do not display the Google Pay notice when loading payment methods

### DIFF
--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.tsx
@@ -98,6 +98,7 @@ const PaymentInformation: React.FC<Props> = (props) => {
       ));
 
   const showGooglePayAvailableNotice =
+    !loading &&
     isGooglePayEnabled &&
     !paymentMethods?.some(
       (paymetMethod: PaymentMethod) => paymetMethod.type === 'google_pay'


### PR DESCRIPTION
## Description

- Does not render the Google Pay notice when loading payment methods
  - This makes the initial page load look better. Users that have Google Pay added would briefly see the Google Pay notice as their payment methods were loading, and then see the notice quickly disappear. This PR makes sure the payment methods are loaded before showing the Google Pay notice

**Before:**

https://user-images.githubusercontent.com/6440455/128217545-0923aa78-746c-4e74-8d5a-787582a75dd3.mov


**After:**

https://user-images.githubusercontent.com/6440455/128217536-812ca04f-23ad-4e57-a2c8-23ee75050cdf.mov



## How to test

- Go to `/account/billing` and make sure
  - Payment methods show up
  - The Google Pay notice shows up on an account without Google Pay added
  - The loading state for the payment methods section looks good
