### PR TITLE
M3-5347: Handle errors thrown when payment popup is closed or timesout

### DIFF
--- a/packages/manager/src/features/Billing/Providers/GooglePay.ts
+++ b/packages/manager/src/features/Billing/Providers/GooglePay.ts
@@ -152,9 +152,6 @@ export const gPay = async (
     setProcessing(false);
   } catch (error) {
     setProcessing(false);
-    if (error.message && (error.message as string).includes('User closed')) {
-      return;
-    }
 
     if (error.statusCode === 'CANCELED') {
       return;

--- a/packages/manager/src/features/Billing/Providers/GooglePay.ts
+++ b/packages/manager/src/features/Billing/Providers/GooglePay.ts
@@ -156,6 +156,10 @@ export const gPay = async (
       return;
     }
 
+    if (error.statusCode === 'CANCELED') {
+      return;
+    }
+
     const errorMsg = isOneTimePayment
       ? 'Unable to complete Google Pay payment'
       : 'Unable to add payment method';


### PR DESCRIPTION
## Description

This PR adds better error handling with respect to GooglePay errors. In particular on non-chrome browsers if a user closed the GooglePay pop-up window without authorizing a payment an error is thrown that was then logged into Sentry and caused a Toast notification to pop up that informed the user "Unable to add payment method". A similar error ocurred if the GooglePay pop-up was left up for more than 5 minutes. This should be handled in the same way. 

## How to test

Attempt to add a new payment method using GooglePay on a non-chrome browser. Close the pop-up window without authorizing payment. This should silently fail without informing the user. There should be no Toast notification or error logged to sentry. The same should be true if the pop-up is left open for more than 5 minutes.
