### PR TITLE
M3 5339: Improve firewall error message for unsupported hosts

### DIFF
--- a/packages/manager/src/components/Notice/Notice.tsx
+++ b/packages/manager/src/components/Notice/Notice.tsx
@@ -14,7 +14,7 @@ import {
 import Typography, { TypographyProps } from 'src/components/core/Typography';
 import Grid, { GridProps } from 'src/components/Grid';
 
-const useStyles = makeStyles((theme: Theme) => ({
+export const useStyles = makeStyles((theme: Theme) => ({
   '@keyframes fadeIn': {
     from: {
       opacity: 0,

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddDeviceDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddDeviceDrawer.tsx
@@ -1,18 +1,18 @@
 import { Capabilities } from '@linode/api-v4/lib/regions/types';
 import { APIError } from '@linode/api-v4/lib/types';
 import * as React from 'react';
+import v4 from 'uuid';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import Drawer from 'src/components/Drawer';
 import Link from 'src/components/Link';
 import LinodeMultiSelect from 'src/components/LinodeMultiSelect';
 import Notice from 'src/components/Notice';
+import { useStyles } from 'src/components/Notice/Notice';
 import { dcDisplayNames } from 'src/constants';
 import { useRegionsQuery } from 'src/queries/regions';
 import arrayToList from 'src/utilities/arrayToDelimiterSeparatedList';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
-import v4 from 'uuid';
-
 interface Props {
   open: boolean;
   error?: APIError[];
@@ -34,6 +34,7 @@ export const AddDeviceDrawer: React.FC<Props> = (props) => {
     addDevice,
   } = props;
 
+  const classes = useStyles();
   const regions = useRegionsQuery().data ?? [];
 
   const regionsWithFirewalls = regions
@@ -77,7 +78,7 @@ export const AddDeviceDrawer: React.FC<Props> = (props) => {
       const labelIndex = errorMsg.indexOf(label);
       errorMsg = errorMsg.replace(/\(id ([^()]*)\)/i, '');
       return (
-        <Notice error>
+        <Notice error className={classes.noticeText}>
           {errorMsg.substring(0, labelIndex)}
           <Link to={`/linodes/${id}`}>{label}</Link>
           {errorMsg.substring(labelIndex + label.length)}

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddDeviceDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddDeviceDrawer.tsx
@@ -79,7 +79,7 @@ export const AddDeviceDrawer: React.FC<Props> = (props) => {
       const labelIndex = errorMsg.indexOf(label);
       errorMsg = errorMsg.replace(/\(id ([^()]*)\)/i, '');
       return (
-        <>
+        <Notice error>
           {errorMsg.substring(0, labelIndex)}
           <Link to={`/linodes/${id}`}>{label}</Link>
           {errorMsg.substring(labelIndex + label.length)}
@@ -92,7 +92,7 @@ export const AddDeviceDrawer: React.FC<Props> = (props) => {
               .
             </>
           ) : null}
-        </>
+        </Notice>
       );
     } else {
       return <Notice error text={errorMessage} />;

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddDeviceDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddDeviceDrawer.tsx
@@ -7,7 +7,6 @@ import Drawer from 'src/components/Drawer';
 import Link from 'src/components/Link';
 import LinodeMultiSelect from 'src/components/LinodeMultiSelect';
 import Notice from 'src/components/Notice';
-import SupportLink from 'src/components/SupportLink';
 import { dcDisplayNames } from 'src/constants';
 import { useRegionsQuery } from 'src/queries/regions';
 import arrayToList from 'src/utilities/arrayToDelimiterSeparatedList';
@@ -70,9 +69,8 @@ export const AddDeviceDrawer: React.FC<Props> = (props) => {
   const errorNotice = (errorMsg: string) => {
     // match something like: Linode <linode_label> (ID <linode_id>)
     const linode = /linode (.+?) \(id ([^()]*)\)/i.exec(errorMsg);
-    const openTicket = errorMsg.match(/open a support ticket\./i);
-    if (openTicket) {
-      errorMsg = errorMsg.replace(/open a support ticket\./i, '');
+    if (errorMsg.match(/ or open a support ticket/i)) {
+      errorMsg = errorMsg.replace(/ or open a support ticket/i, '');
     }
     if (linode) {
       const [, label, id] = linode;
@@ -83,15 +81,6 @@ export const AddDeviceDrawer: React.FC<Props> = (props) => {
           {errorMsg.substring(0, labelIndex)}
           <Link to={`/linodes/${id}`}>{label}</Link>
           {errorMsg.substring(labelIndex + label.length)}
-          {openTicket ? (
-            <>
-              <SupportLink
-                text="open a Support ticket"
-                title={`Re: ${errorMessage}`}
-              />
-              .
-            </>
-          ) : null}
         </Notice>
       );
     } else {

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddDeviceDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddDeviceDrawer.tsx
@@ -7,6 +7,7 @@ import Drawer from 'src/components/Drawer';
 import Link from 'src/components/Link';
 import LinodeMultiSelect from 'src/components/LinodeMultiSelect';
 import Notice from 'src/components/Notice';
+import SupportLink from 'src/components/SupportLink';
 import { dcDisplayNames } from 'src/constants';
 import { useRegionsQuery } from 'src/queries/regions';
 import arrayToList from 'src/utilities/arrayToDelimiterSeparatedList';
@@ -69,6 +70,10 @@ export const AddDeviceDrawer: React.FC<Props> = (props) => {
   const errorNotice = (errorMsg: string) => {
     // match something like: Linode <linode_label> (ID <linode_id>)
     const linode = /linode (.+?) \(id ([^()]*)\)/i.exec(errorMsg);
+    const openTicket = errorMsg.match(/open a support ticket\./i);
+    if (openTicket) {
+      errorMsg = errorMsg.replace(/open a support ticket\./i, '');
+    }
     if (linode) {
       const [, label, id] = linode;
       const labelIndex = errorMsg.indexOf(label);
@@ -78,6 +83,15 @@ export const AddDeviceDrawer: React.FC<Props> = (props) => {
           {errorMsg.substring(0, labelIndex)}
           <Link to={`/linodes/${id}`}>{label}</Link>
           {errorMsg.substring(labelIndex + label.length)}
+          {openTicket ? (
+            <>
+              <SupportLink
+                text="open a Support ticket"
+                title={`Re: ${errorMessage}`}
+              />
+              .
+            </>
+          ) : null}
         </>
       );
     } else {

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallLinodesLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallLinodesLanding.tsx
@@ -161,11 +161,11 @@ const FirewallLinodesLanding: React.FC<CombinedProps> = (props) => {
       <AddDeviceDrawer
         open={addDeviceDrawerOpen}
         error={addDeviceError}
-        onClose={handleClose}
-        addDevice={handleAddDevice}
         isSubmitting={deviceSubmitting}
         currentDevices={deviceList.map((thisDevice) => thisDevice.entity.id)}
         firewallLabel={firewallLabel}
+        onClose={handleClose}
+        addDevice={handleAddDevice}
       />
       <RemoveDeviceDialog
         open={dialog.isOpen}


### PR DESCRIPTION
## Description
Improve firewall error message when trying to add a firewall to a Linode on an unsupported host

- Remove the Id
- Make the Linode label a link to that Linode's detail page
- Remove unnecessary `open a Support ticket` text
    - Users can initiate inter-DC migration on their own. And in the event that this was a migration unrelated to one they queued up, there should already be a ticket open for it

Before:

![image](https://user-images.githubusercontent.com/14323019/128260731-a7f95c14-c058-4619-a946-d6e373e97d24.png)

After:

![image](https://user-images.githubusercontent.com/14323019/128386057-a02cd3a8-628c-4cf0-9ca2-76864ff6d6df.png)

## How to test
Try to add a firewall to a Linode that is on an unsupported host (reach out for exact steps)
