### PR TITLE
UI fixes for /account/billing

### DIFF
--- a/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/ContactInformation.tsx
@@ -45,6 +45,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     fontSize: '.875rem',
     fontWeight: 700,
     marginBottom: theme.spacing(2),
+    minHeight: 0,
     minWidth: 'auto',
     padding: 0,
     '&:hover, &:focus': {

--- a/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/ContactInformation.tsx
@@ -39,13 +39,12 @@ const useStyles = makeStyles((theme: Theme) => ({
       alignSelf: 'end',
     },
   },
-  editBtn: {
-    fontFamily: theme.font.normal,
+  edit: {
     color: theme.cmrTextColors.linkActiveLight,
+    fontFamily: theme.font.normal,
     fontSize: '.875rem',
     fontWeight: 700,
-    marginBottom: theme.spacing(2),
-    minHeight: 0,
+    minHeight: 'unset',
     minWidth: 'auto',
     padding: 0,
     '&:hover, &:focus': {
@@ -124,9 +123,8 @@ const ContactInformation: React.FC<CombinedProps> = (props) => {
               Billing Contact
             </Typography>
           </Grid>
-
           <Grid item>
-            <Button className={classes.editBtn} onClick={handleEditDrawerOpen}>
+            <Button className={classes.edit} onClick={handleEditDrawerOpen}>
               Edit
             </Button>
           </Grid>

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.tsx
@@ -4,15 +4,15 @@ import * as React from 'react';
 import { useHistory, useRouteMatch } from 'react-router-dom';
 import GooglePayIcon from 'src/assets/icons/payment/googlePay.svg';
 import Button from 'src/components/Button';
+import CircleProgress from 'src/components/CircleProgress';
 import Box from 'src/components/core/Box';
 import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
+import DismissibleBanner from 'src/components/DismissibleBanner';
 import Grid from 'src/components/Grid';
 import Link from 'src/components/Link';
 import PaymentMethodRow from 'src/components/PaymentMethodRow';
-import DismissibleBanner from 'src/components/DismissibleBanner';
-import CircleProgress from 'src/components/CircleProgress';
 import styled from 'src/containers/SummaryPanels.styles';
 import useFlags from 'src/hooks/useFlags';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
@@ -40,10 +40,15 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginBottom: theme.spacing(3),
   },
   googlePayNoticeContainer: {
+    fontSize: '0.875rem',
     marginTop: theme.spacing(2),
     padding: `8px 0px`,
     '& button': {
       marginLeft: theme.spacing(),
+    },
+    '& p': {
+      fontSize: '0.875rem',
+      marginLeft: 0,
     },
   },
   googlePayIcon: {

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.tsx
@@ -21,9 +21,6 @@ import UpdateCreditCardDrawer from './UpdateCreditCardDrawer';
 
 const useStyles = makeStyles((theme: Theme) => ({
   ...styled(theme),
-  root: {
-    display: 'flex',
-  },
   summarySectionHeight: {
     flex: '0 1 auto',
     width: '100%',
@@ -33,8 +30,14 @@ const useStyles = makeStyles((theme: Theme) => ({
     justifyContent: 'center',
   },
   container: {
-    display: 'flex',
-    justifyContent: 'space-between',
+    flex: 1,
+    maxWidth: '100%',
+    position: 'relative',
+    '&.mlMain': {
+      [theme.breakpoints.up('lg')]: {
+        maxWidth: '78.8%',
+      },
+    },
   },
   billingGroup: {
     marginBottom: theme.spacing(3),
@@ -47,6 +50,7 @@ const useStyles = makeStyles((theme: Theme) => ({
       marginLeft: theme.spacing(),
     },
     '& p': {
+      // Overwrites the default styling from the banner
       fontSize: '0.875rem',
       marginLeft: 0,
     },
@@ -61,8 +65,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     fontFamily: theme.font.normal,
     fontSize: '.875rem',
     fontWeight: 700,
-    marginBottom: theme.spacing(2),
-    minHeight: 0,
+    minHeight: 'unset',
     minWidth: 'auto',
     padding: 0,
     '&:hover, &:focus': {
@@ -131,24 +134,25 @@ const PaymentInformation: React.FC<Props> = (props) => {
   }, [addPaymentMethodRouteMatch, openAddDrawer]);
 
   return (
-    <Grid className={classes.root} item xs={12} md={6}>
-      <Paper
-        className={`${classes.summarySection} ${classes.summarySectionHeight}`}
-        data-qa-billing-summary
-      >
-        <div className={classes.container}>
-          <Typography variant="h3" className={classes.title}>
-            Payment Methods
-          </Typography>
+    <Grid item xs={12} md={6}>
+      <Paper className={classes.summarySection} data-qa-billing-summary>
+        <Grid container spacing={2}>
+          <Grid item className={classes.container}>
+            <Typography variant="h3" className={classes.title}>
+              Payment Methods
+            </Typography>
+          </Grid>
           {showAddPaymentMethodButton ? (
-            <Button
-              className={classes.edit}
-              onClick={() => replace(drawerLink)}
-            >
-              Add Payment Method
-            </Button>
+            <Grid item>
+              <Button
+                className={classes.edit}
+                onClick={() => replace(drawerLink)}
+              >
+                Add Payment Method
+              </Button>
+            </Grid>
           ) : null}
-        </div>
+        </Grid>
         {loading ? (
           <Grid className={classes.loading}>
             <CircleProgress mini />

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.tsx
@@ -57,6 +57,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     fontSize: '.875rem',
     fontWeight: 700,
     marginBottom: theme.spacing(2),
+    minHeight: 0,
     minWidth: 'auto',
     padding: 0,
     '&:hover, &:focus': {


### PR DESCRIPTION
## Description

Fixes the placement of the "Edit" button on "Billing Contact" and the "Add Payment Method" button on "Payment Methods" and a regression for the add GooglePay banner.

<img width="575" alt="Screen Shot 2021-08-05 at 6 49 53 PM" src="https://user-images.githubusercontent.com/7692354/128397346-b4131bce-0287-4911-a196-11fbb73fd396.png">


## How to test

Go to `/account/billing` and checking the "Billing Contact" and "Payment Method" panels.
