### PR TITLE
M3-5372: Add edit credit card notice to Add Payment Method drawer

### DIFF
--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/AddPaymentMethodDrawer/AddPaymentMethodDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/AddPaymentMethodDrawer/AddPaymentMethodDrawer.tsx
@@ -11,11 +11,13 @@ import GooglePayChip from '../GooglePayChip';
 import AddCreditCardForm from './AddCreditCardForm';
 import HelpIcon from 'src/components/HelpIcon';
 import useFlags from 'src/hooks/useFlags';
+import Paper from 'src/components/core/Paper';
 
 interface Props {
   open: boolean;
   onClose: () => void;
   paymentMethods: PaymentMethod[] | undefined;
+  openEditCreditCardDrawer: () => void;
 }
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -39,10 +41,21 @@ const useStyles = makeStyles((theme: Theme) => ({
       width: 20,
     },
   },
+  notice: {
+    borderLeft: `solid 6px ${theme.color.green}`,
+    marginBottom: theme.spacing(2),
+    padding: '8px 16px',
+    '& p': {
+      fontSize: '0.95em',
+    },
+  },
+  link: {
+    ...theme.applyLinkStyles,
+  },
 }));
 
 export const AddPaymentMethodDrawer: React.FC<Props> = (props) => {
-  const { onClose, open, paymentMethods } = props;
+  const { onClose, open, paymentMethods, openEditCreditCardDrawer } = props;
   const classes = useStyles();
   const flags = useFlags();
   const { enqueueSnackbar } = useSnackbar();
@@ -75,6 +88,18 @@ export const AddPaymentMethodDrawer: React.FC<Props> = (props) => {
   return (
     <Drawer title="Add Payment Method" open={open} onClose={onClose}>
       {isProcessing ? <LinearProgress className={classes.progress} /> : null}
+      <Paper className={classes.notice}>
+        <Typography>
+          The option to add additonal credit cards is coming soon.
+        </Typography>
+        <Typography>
+          To edit your current credit card,{' '}
+          <button className={classes.link} onClick={openEditCreditCardDrawer}>
+            click here
+          </button>
+          .
+        </Typography>
+      </Paper>
       {isGooglePayEnabled ? (
         <React.Fragment>
           <Divider />

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/AddPaymentMethodDrawer/AddPaymentMethodDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/AddPaymentMethodDrawer/AddPaymentMethodDrawer.tsx
@@ -73,9 +73,10 @@ export const AddPaymentMethodDrawer: React.FC<Props> = (props) => {
     });
   };
 
-  const numberOfCreditCards = paymentMethods?.filter(
-    (method: PaymentMethod) => method.type === 'credit_card'
-  ).length;
+  const numberOfCreditCards =
+    paymentMethods?.filter(
+      (method: PaymentMethod) => method.type === 'credit_card'
+    ).length || 0;
 
   const isGPayAlreadyAdded = paymentMethods?.some(
     (method: PaymentMethod) => method.type === 'google_pay'
@@ -88,18 +89,20 @@ export const AddPaymentMethodDrawer: React.FC<Props> = (props) => {
   return (
     <Drawer title="Add Payment Method" open={open} onClose={onClose}>
       {isProcessing ? <LinearProgress className={classes.progress} /> : null}
-      <Paper className={classes.notice}>
-        <Typography>
-          The option to add additonal credit cards is coming soon.
-        </Typography>
-        <Typography>
-          To edit your current credit card,{' '}
-          <button className={classes.link} onClick={openEditCreditCardDrawer}>
-            click here
-          </button>
-          .
-        </Typography>
-      </Paper>
+      {numberOfCreditCards > 0 ? (
+        <Paper className={classes.notice}>
+          <Typography>
+            The option to add additonal credit cards is coming soon.
+          </Typography>
+          <Typography>
+            To edit your current credit card,{' '}
+            <button className={classes.link} onClick={openEditCreditCardDrawer}>
+              click here
+            </button>
+            .
+          </Typography>
+        </Paper>
+      ) : null}
       {isGooglePayEnabled ? (
         <React.Fragment>
           <Divider />

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.tsx
@@ -197,6 +197,7 @@ const PaymentInformation: React.FC<Props> = (props) => {
           open={addDrawerOpen}
           onClose={closeAddDrawer}
           paymentMethods={paymentMethods}
+          openEditCreditCardDrawer={openEditDrawer}
         />
       </Paper>
     </Grid>


### PR DESCRIPTION
## Description

- [x] Adds notice about editing credit card on file
- [x] Only show notice if:
  - User has a credit card on file


![Screen Shot 2021-08-05 at 5 42 59 PM](https://user-images.githubusercontent.com/6440455/128425112-6bcf4b9a-794b-4589-9f9e-2a95e6e4d10e.png)


## How to test

- Go to /account/billing/add-payment-method
  - Test on an account with a credit card on file
  - Test on account with only Google Pay added
  - Test on account with no payment methods on file
