### PR TITLE
M3-5385: Handling for entity_transfer_accept_recipient events

### DIFF
--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -171,6 +171,9 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
   entity_transfer_accept: {
     notification: (_) => `A service transfer has been accepted.`,
   },
+  entity_transfer_accept_recipient: {
+    notification: (_) => `You have accepted a service transfer.`,
+  },
   entity_transfer_cancel: {
     notification: (_) => `A service transfer has been cancelled.`,
   },

--- a/packages/manager/src/features/Events/Event.helpers.ts
+++ b/packages/manager/src/features/Events/Event.helpers.ts
@@ -81,6 +81,7 @@ export const maybeRemoveTrailingPeriod = (string: string) => {
 
 const ACTIONS_WITHOUT_USERNAMES = [
   'entity_transfer_accept',
+  'entity_transfer_accept_recipient',
   'entity_transfer_cancel',
   'entity_transfer_create',
   'entity_transfer_fail',

--- a/packages/manager/src/utilities/getEventsActionLink.ts
+++ b/packages/manager/src/utilities/getEventsActionLink.ts
@@ -84,7 +84,7 @@ export default (
       return `/domains/${id}`;
 
     case 'entity_transfer':
-      return `/account/entity-transfers`;
+      return `/account/service-transfers`;
 
     case 'volume':
       return `/volumes`;

--- a/packages/manager/src/utilities/getEventsActionLinkStrings.ts
+++ b/packages/manager/src/utilities/getEventsActionLinkStrings.ts
@@ -72,7 +72,7 @@ export default (
       return `/domains/${id}`;
 
     case 'entity_transfer':
-      return `/account/entity-transfers`;
+      return `/account/service-transfers`;
 
     case 'volume':
       return `/volumes`;


### PR DESCRIPTION
## Description
Add handling for new `entity_transfer_accept_recipient` event; fix link strings for Service Transfer events so that clicking on those notifications brings you to the "Service Transfers" tab. 

## How to test
Initiate and complete a service transfer; for `entity_transfer_accept_recipient` events, the recipient account should see a notification in the drawer that reads, "You have accepted a service transfer," and the account that sent the transfer should just have one that says, corresponding to the `entity_transfer_accept` event, "A service transfer has been accepted." Clicking both should bring you to the "Service Transfers" tab (`/account/service-transfers`).
