### PR TITLE
Add display location for us-southeast-1 OBJ cluster

### DIFF
--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -202,6 +202,7 @@ export const objectStorageClusterDisplay: Record<
   'us-east-1': 'Newark, NJ',
   'eu-central-1': 'Frankfurt, DE',
   'ap-south-1': 'Singapore, SG',
+  'us-southeast-1': 'Atlanta, GA',
 };
 
 export type ContinentKey = 'NA' | 'EU' | 'AS';


### PR DESCRIPTION
## Description

Adds the correct display location for the OBJ cluster at us-southeast-1.
