### PR TITLE
M3-5381: Fix disabled action buttons in dark mode

### DIFF
--- a/packages/manager/src/components/FileUploader/FileUploader.tsx
+++ b/packages/manager/src/components/FileUploader/FileUploader.tsx
@@ -61,7 +61,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     // When the dropzone is disabled
     borderColor: '#888',
     '& $uploadButton': {
-      backgroundColor: theme.color.grey6,
       '&:hover': {
         cursor: 'default',
       },

--- a/packages/manager/src/components/InlineMenuAction/InlineMenuAction.tsx
+++ b/packages/manager/src/components/InlineMenuAction/InlineMenuAction.tsx
@@ -18,6 +18,8 @@ const useStyles = makeStyles((theme: Theme) => ({
       textDecoration: 'none',
     },
     '&[disabled]': {
+      // Override disabled background color defined for dark mode
+      backgroundColor: 'transparent',
       color: '#cdd0d5',
       cursor: 'default',
       '&:hover': {

--- a/packages/manager/src/components/PaymentMethodRow/DeletePaymentMethodDialog.tsx
+++ b/packages/manager/src/components/PaymentMethodRow/DeletePaymentMethodDialog.tsx
@@ -37,12 +37,11 @@ export const DeletePaymentMethodDialog: React.FC<Props> = (props) => {
 
   const actions = (
     <ActionsPanel style={{ padding: 0 }}>
-      <Button buttonType="cancel" onClick={onClose} data-qa-cancel>
+      <Button buttonType="secondary" onClick={onClose} data-qa-cancel>
         Cancel
       </Button>
       <Button
         buttonType="primary"
-        destructive
         onClick={onDelete}
         loading={loading}
         data-qa-confirm


### PR DESCRIPTION
## Description

This fixes the background color for disabled buttons and the Upload Image button in dark mode.

Example:
<img width="1181" alt="Screen Shot 2021-08-06 at 4 14 30 PM" src="https://user-images.githubusercontent.com/7692354/128900208-67dae4ff-9665-4afc-a75f-56710102da3d.png">

<img width="372" alt="Screen Shot 2021-08-09 at 4 53 33 PM" src="https://user-images.githubusercontent.com/7692354/128900281-feb388c3-672b-4ca1-bfd9-8fffbb936d6c.png">

## How to test
- Turn dark mode on
- Go to `/linodes` on a restricted account (or turn off one or more Linodes on any account)
- The background of the disabled inline actions should be the same color as the table background
- Go to `/images/create/upload` 
- The "Browse File" font and background color should be different
