### PR TITLE
E2E Buckets test fix

### DIFF
--- a/packages/manager/cypress/integration/objectStorage/buckets.spec.ts
+++ b/packages/manager/cypress/integration/objectStorage/buckets.spec.ts
@@ -14,12 +14,9 @@ const regionSelect = 'Frankfurt, DE';
 
 describe('create bucket flow, mocked data', () => {
   it('creates bucket', () => {
-    cy.intercept('*/object-storage/buckets*', (req) => {
+    cy.intercept('POST', '*/object-storage/buckets*', (req) => {
       req.reply(mockBucket);
     }).as('mockBucket');
-    cy.intercept('GET', `*/object-storage/buckets/${bucketCluster}*`, (req) => {
-      req.reply(mockBucket);
-    }).as('getBuckets');
 
     cy.visitWithLogin('/object-storage/buckets');
     fbtClick('Create Bucket');
@@ -30,6 +27,10 @@ describe('create bucket flow, mocked data', () => {
       fbtClick('Create Bucket');
     });
     cy.wait('@mockBucket');
+    cy.intercept('GET', `*/object-storage/buckets/${bucketCluster}*`, (req) => {
+      req.reply(mockBucket);
+    }).as('getBuckets');
+    cy.reload();
     cy.wait('@getBuckets');
     cy.get('[data-qa-bucket-cell="cy-test-bucket"]').within(() => {
       fbtVisible(bucketLabel);


### PR DESCRIPTION
## Description
this test had some issues when running in ci. this will hopefully fix that

**What does this PR do?**
just a small stackscripts e2e test update

## How to test
- `yarn up` in one terminal
- `yarn cy:e2e -s ./cypress/integration/objectStorage/buckets.spec.ts` in another
- Result should be "✔  All specs passed!"

## Make sure your .env contains:
```
REACT_APP_LOGIN_ROOT
REACT_APP_API_ROOT
REACT_APP_APP_ROOT
REACT_APP_LAUNCH_DARKLY_ID
REACT_APP_CLIENT_ID
MANAGER_OAUTH
```