### PR TITLE
M3-5313: Fix @linode/api-v4 import issue

### DIFF
--- a/packages/api-v4/src/support/types.ts
+++ b/packages/api-v4/src/support/types.ts
@@ -1,4 +1,5 @@
-import { Entity } from 'src/account/types';
+import { Entity } from '../account/types';
+
 export interface SupportTicket {
   opened: string;
   id: number;


### PR DESCRIPTION
## Description

- Fixes #7686 by using a relative path to import

## How to test

- Pull this PR 
- Build @linode/api-v4 with `yarn build:sdk`
- Start a new Typescript project
  -  `mkdir ts-test`
  - `npm init`
  - `npm install typescript --save-dev`
  - `npm i @linode/api-v4`
  - Use this `tsconfig.json` and `index.ts`
 
```{
"compilerOptions": {
  "target": "es5",
  "module": "commonjs",
  "strict": true
  }
}
```

```
import { getLinodeTypes } from '@linode/api-v4'

getLinodeTypes().then(types => {
  console.log(types)
})
```
- Delete all files in the new project in `node_modules/@linode/api-v4`
- Manually copy the @linode/api-v4 files into a new Typescript project's `node_modules/@linode/api-v4`
- Run the Typescript compiler and make sure we don't see any import errors (as seen in #7686)