### PR TITLE
M3-5173: Remove now-unneeded fakeAtlanta logic

### DIFF
--- a/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionSelect.tsx
+++ b/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionSelect.tsx
@@ -10,34 +10,12 @@ import US from 'flag-icon-css/flags/4x3/us.svg';
 import { groupBy } from 'ramda';
 import * as React from 'react';
 import { makeStyles, Theme } from 'src/components/core/styles';
-import Typography from 'src/components/core/Typography';
 import SingleValue from 'src/components/EnhancedSelect/components/SingleValue';
 import Select, {
   BaseSelectProps,
   GroupType,
 } from 'src/components/EnhancedSelect/Select';
-import Link from 'src/components/Link';
 import RegionOption, { RegionItem } from './RegionOption';
-
-/**
- * We are deprecating the Atlanta region. The API doesn't support this
- * in its region.status, and it's unclear how situation-specific this
- * will end up being (e.g., will the linked blog post name Atlanta specifically)?
- *
- * For these reasons, we're doing a hard-coded, manual solution rather than try
- * to come up with something more abstract/general.
- */
-const atlantaDisabledMessage = (
-  <Typography>
-    The Atlanta datacenter is currently sold out as we prepare for a move to an
-    upgraded facility. Please see{' '}
-    <Link to="https://www.linode.com/blog/linode/atlanta-data-center-update/">
-      this blog post
-    </Link>
-    {` `}
-    for more information.
-  </Typography>
-);
 
 export interface ExtendedRegion extends Region {
   display: string;
@@ -122,9 +100,6 @@ export const getRegionOptions = (regions: ExtendedRegion[]) => {
               flag:
                 flags[thisRegion.country.toLocaleLowerCase()] ?? (() => null),
               country: thisRegion.country,
-              disabledMessage: thisRegion.disabled
-                ? atlantaDisabledMessage
-                : undefined,
             }))
 
             .sort(sortRegions),

--- a/packages/manager/src/store/regions/regions.reducer.ts
+++ b/packages/manager/src/store/regions/regions.reducer.ts
@@ -1,4 +1,4 @@
-import { Capabilities, Region, RegionStatus } from '@linode/api-v4/lib/regions';
+import { Region } from '@linode/api-v4/lib/regions';
 import produce from 'immer';
 import { Reducer } from 'redux';
 import regions from 'src/cachedData/regions.json';
@@ -26,25 +26,6 @@ export const defaultState: State = {
 };
 
 /**
- * For display purposes only, a disabled
- * version of the us-southeast region that
- * is otherwise not returned by the API.
- */
-const fakeAtlanta = {
-  id: 'us-southeast',
-  country: 'us',
-  capabilities: ['Linodes', 'NodeBalancers'] as Capabilities[],
-  status: 'ok' as RegionStatus,
-  resolvers: {
-    ipv4:
-      '173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5',
-    ipv6: '',
-  },
-  disabled: true,
-  display: 'Atlanta, GA',
-};
-
-/**
  * Reducer
  */
 const reducer: Reducer<State> = (state = defaultState, action) => {
@@ -57,18 +38,7 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
       const { result } = action.payload;
       draft.loading = false;
       draft.lastUpdated = Date.now();
-      /**
-       * If the API response includes us-southeast (Atlanta),
-       * they can access the datacenter normally and there's nothing for us to do.
-       * If it doesn't come back, we want to show a disabled Atlanta option in the select
-       * with messaging and a link to the relevant blog post, so that users aren't
-       * confused by the sudden, temporary disappearance of a region.
-       */
-      draft.entities = result.some(
-        (thisRegion) => thisRegion.id === 'us-southeast'
-      )
-        ? result
-        : [...result, fakeAtlanta];
+      draft.entities = result;
       draft.results = result.map((r) => r.id);
     }
 


### PR DESCRIPTION
## Description
Now that the new Atlanta facility is up and running, the `fakeAtlanta` logic that was added last year to show the region as disabled in situations where the API didn't return Atlanta can be removed.

## How to test
Ensure all Create and edit flows function as normal and there are no regressions in Region dropdowns.
