### PR TITLE
E2E removing after hook to avoid conflicts in ci runs

### DIFF
--- a/packages/manager/cypress/integration/account/change-username.spec.ts
+++ b/packages/manager/cypress/integration/account/change-username.spec.ts
@@ -13,7 +13,7 @@ describe('username', () => {
       fbtVisible('Username');
       fbtVisible('Email');
       fbtVisible('Delete User');
-      getVisible('[id="username"]').clear().type(testText);
+      cy.get('[id="username"]').clear().type(testText);
       getVisible('[id="username"]').should('have.value', testText);
     });
   });

--- a/packages/manager/cypress/support/index.js
+++ b/packages/manager/cypress/support/index.js
@@ -26,7 +26,3 @@ import './commands';
 before(() => {
   deleteAllTestData();
 });
-
-after(() => {
-  deleteAllTestData();
-});


### PR DESCRIPTION
There is not too much to test with this. This change is primarily for the benefit of ci runs. I made a small change to the username test but it's minimal. This should help to avoid some api conflicts when trying to delete right after a test runs. Now we will only do cleanup before each test block so things should go a bit more smoothly. 