### PR TITLE
Update firewalls text

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddDeviceDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddDeviceDrawer.tsx
@@ -1,6 +1,7 @@
 import { APIError } from '@linode/api-v4/lib/types';
 import * as React from 'react';
 import v4 from 'uuid';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import Drawer from 'src/components/Drawer';
@@ -8,7 +9,7 @@ import Link from 'src/components/Link';
 import LinodeMultiSelect from 'src/components/LinodeMultiSelect';
 import Notice from 'src/components/Notice';
 import { useStyles } from 'src/components/Notice/Notice';
-import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import SupportLink from 'src/components/SupportLink';
 interface Props {
   open: boolean;
   error?: APIError[];
@@ -59,8 +60,9 @@ export const AddDeviceDrawer: React.FC<Props> = (props) => {
   const errorNotice = (errorMsg: string) => {
     // match something like: Linode <linode_label> (ID <linode_id>)
     const linode = /linode (.+?) \(id ([^()]*)\)/i.exec(errorMsg);
-    if (errorMsg.match(/ or open a support ticket/i)) {
-      errorMsg = errorMsg.replace(/ or open a support ticket/i, '');
+    const openTicket = errorMsg.match(/open a support ticket/i);
+    if (openTicket) {
+      errorMsg = errorMsg.replace(/open a support ticket/i, '');
     }
     if (linode) {
       const [, label, id] = linode;
@@ -71,6 +73,7 @@ export const AddDeviceDrawer: React.FC<Props> = (props) => {
           {errorMsg.substring(0, labelIndex)}
           <Link to={`/linodes/${id}`}>{label}</Link>
           {errorMsg.substring(labelIndex + label.length)}
+          {openTicket ? <SupportLink text="open a Support ticket" /> : null}
         </Notice>
       );
     } else {

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddDeviceDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddDeviceDrawer.tsx
@@ -60,9 +60,9 @@ export const AddDeviceDrawer: React.FC<Props> = (props) => {
   const errorNotice = (errorMsg: string) => {
     // match something like: Linode <linode_label> (ID <linode_id>)
     const linode = /linode (.+?) \(id ([^()]*)\)/i.exec(errorMsg);
-    const openTicket = errorMsg.match(/open a support ticket/i);
+    const openTicket = errorMsg.match(/open a support ticket\./i);
     if (openTicket) {
-      errorMsg = errorMsg.replace(/open a support ticket/i, '');
+      errorMsg = errorMsg.replace(/open a support ticket\./i, '');
     }
     if (linode) {
       const [, label, id] = linode;
@@ -73,7 +73,11 @@ export const AddDeviceDrawer: React.FC<Props> = (props) => {
           {errorMsg.substring(0, labelIndex)}
           <Link to={`/linodes/${id}`}>{label}</Link>
           {errorMsg.substring(labelIndex + label.length)}
-          {openTicket ? <SupportLink text="open a Support ticket" /> : null}
+          {openTicket ? (
+            <>
+              <SupportLink text="open a Support ticket" />.
+            </>
+          ) : null}
         </Notice>
       );
     } else {

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddDeviceDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddDeviceDrawer.tsx
@@ -1,4 +1,3 @@
-import { Capabilities } from '@linode/api-v4/lib/regions/types';
 import { APIError } from '@linode/api-v4/lib/types';
 import * as React from 'react';
 import v4 from 'uuid';
@@ -9,9 +8,6 @@ import Link from 'src/components/Link';
 import LinodeMultiSelect from 'src/components/LinodeMultiSelect';
 import Notice from 'src/components/Notice';
 import { useStyles } from 'src/components/Notice/Notice';
-import { dcDisplayNames } from 'src/constants';
-import { useRegionsQuery } from 'src/queries/regions';
-import arrayToList from 'src/utilities/arrayToDelimiterSeparatedList';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 interface Props {
   open: boolean;
@@ -35,13 +31,6 @@ export const AddDeviceDrawer: React.FC<Props> = (props) => {
   } = props;
 
   const classes = useStyles();
-  const regions = useRegionsQuery().data ?? [];
-
-  const regionsWithFirewalls = regions
-    .filter((thisRegion) =>
-      thisRegion.capabilities.includes('Cloud Firewall' as Capabilities)
-    )
-    .map((thisRegion) => thisRegion.id);
 
   const [selectedLinodes, setSelectedLinodes] = React.useState<number[]>([]);
 
@@ -104,12 +93,8 @@ export const AddDeviceDrawer: React.FC<Props> = (props) => {
         {errorMessage ? errorNotice(errorMessage) : null}
         <LinodeMultiSelect
           key={key}
-          allowedRegions={regionsWithFirewalls}
           handleChange={(selected) => setSelectedLinodes(selected)}
-          helperText={`You can assign one or more Linodes to this Firewall. Only Linodes
-          in regions that currently support Firewalls (${arrayToList(
-            regionsWithFirewalls.map((thisId) => dcDisplayNames[thisId])
-          )}) will be displayed as options. Each Linode can only be assigned to a single Firewall.`}
+          helperText={`You can assign one or more Linodes to this Firewall. Each Linode can only be assigned to a single Firewall.`}
           filteredLinodes={currentDevices}
         />
         <ActionsPanel>

--- a/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.tsx
@@ -1,5 +1,4 @@
 import { CreateFirewallPayload, Firewall } from '@linode/api-v4/lib/firewalls';
-import { Capabilities } from '@linode/api-v4/lib/regions/types';
 import { CreateFirewallSchema } from '@linode/validation/lib/firewalls.schema';
 import { Formik, FormikBag } from 'formik';
 import * as React from 'react';
@@ -9,10 +8,7 @@ import Drawer, { DrawerProps } from 'src/components/Drawer';
 import LinodeMultiSelect from 'src/components/LinodeMultiSelect';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
-import { dcDisplayNames } from 'src/constants';
 import { useAccountManagement } from 'src/hooks/useAccountManagement';
-import { useRegionsQuery } from 'src/queries/regions';
-import arrayToList from 'src/utilities/arrayToDelimiterSeparatedList';
 import {
   handleFieldErrors,
   handleGeneralErrors,
@@ -46,17 +42,6 @@ const AddFirewallDrawer: React.FC<CombinedProps> = (props) => {
    * grant here too, but it doesn't exist yet.
    */
   const { _isRestrictedUser } = useAccountManagement();
-
-  const regions = useRegionsQuery().data ?? [];
-
-  const regionsWithFirewalls = regions
-    .filter((thisRegion) =>
-      thisRegion.capabilities.includes('Cloud Firewall' as Capabilities)
-    )
-    .map((thisRegion) => thisRegion.id);
-
-  const allRegionsHaveFirewalls =
-    regionsWithFirewalls.length === regions.length;
 
   const submitForm = (
     values: CreateFirewallPayload,
@@ -100,15 +85,8 @@ const AddFirewallDrawer: React.FC<CombinedProps> = (props) => {
       });
   };
 
-  let firewallHelperText = `Assign one or more Linodes to this firewall. You can add
+  const firewallHelperText = `Assign one or more Linodes to this firewall. You can add
   Linodes later if you want to customize your rules first.`;
-
-  if (!allRegionsHaveFirewalls) {
-    firewallHelperText += ` Only Linodes in regions that support Firewalls (${arrayToList(
-      regionsWithFirewalls.map((thisId) => dcDisplayNames[thisId]),
-      ';'
-    )}) will be displayed as options.`;
-  }
 
   return (
     <Drawer {...restOfDrawerProps} onClose={onClose}>
@@ -167,7 +145,6 @@ const AddFirewallDrawer: React.FC<CombinedProps> = (props) => {
               <LinodeMultiSelect
                 showAllOption
                 disabled={_isRestrictedUser}
-                allowedRegions={regionsWithFirewalls}
                 helperText={firewallHelperText}
                 errorText={errors['devices.linodes']}
                 handleChange={(selected: number[]) =>


### PR DESCRIPTION
## Description
Remove DC verbiage from Firewalls and add back link to open a support ticket in `AddDeviceDrawer.tsx`

## How to test
Check the verbiage in `firewalls/create` and `firewalls/<firewall_id>/linodes`. The Linode select dropdown should also not be filtering regions anymore
