### PR TITLE
M3-5274 & M3-5275: Updated Button Placement and Styles

### DIFF
--- a/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
+++ b/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
@@ -23,6 +23,9 @@ const styles = (theme: Theme) =>
         marginRight: theme.spacing(),
         marginLeft: 0,
       },
+      '& > :only-child': {
+        marginRight: 0,
+      },
     },
   });
 

--- a/packages/manager/src/components/Drawer/Drawer.tsx
+++ b/packages/manager/src/components/Drawer/Drawer.tsx
@@ -35,7 +35,9 @@ const styles = (theme: Theme) =>
         padding: theme.spacing(4),
       },
       '& .actionPanel': {
-        marginTop: theme.spacing(2),
+        display: 'flex',
+        justifyContent: 'flex-end',
+        marginTop: theme.spacing(),
       },
       '& .selectionCard': {
         maxWidth: '100%',

--- a/packages/manager/src/features/Account/CloseAccountSetting.tsx
+++ b/packages/manager/src/features/Account/CloseAccountSetting.tsx
@@ -12,7 +12,7 @@ const CloseAccountSetting: React.FC<{}> = () => {
       <Accordion heading="Close Account" defaultExpanded={true}>
         <Grid container direction="column">
           <Grid item>
-            <Button buttonType="primary" onClick={() => setDialogOpen(true)}>
+            <Button buttonType="outlined" onClick={() => setDialogOpen(true)}>
               Close Account
             </Button>
           </Grid>

--- a/packages/manager/src/features/Account/EnableObjectStorage.tsx
+++ b/packages/manager/src/features/Account/EnableObjectStorage.tsx
@@ -44,7 +44,7 @@ export const ObjectStorageContent: React.FC<ContentProps> = (props) => {
           </Typography>
         </Grid>
         <Grid item>
-          <Button buttonType="primary" onClick={openConfirmationModal}>
+          <Button buttonType="outlined" onClick={openConfirmationModal}>
             Cancel Object Storage
           </Button>
         </Grid>

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -204,11 +204,10 @@ const FirewallRuleTable: React.FC<CombinedProps> = (props) => {
       <div className={classes.header}>
         <Typography variant="h2">{`${capitalize(category)} Rules`}</Typography>
         <Button
-          buttonType="secondary"
+          buttonType="primary"
           onClick={openDrawerForCreating}
           className={classes.button}
           disabled={disabled}
-          compact
         >
           Add an {capitalize(category)} Rule
         </Button>

--- a/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.tsx
@@ -157,6 +157,14 @@ const AddFirewallDrawer: React.FC<CombinedProps> = (props) => {
               />
               <ActionsPanel>
                 <Button
+                  buttonType="secondary"
+                  onClick={onClose}
+                  disabled={_isRestrictedUser}
+                  data-qa-cancel
+                >
+                  Cancel
+                </Button>
+                <Button
                   buttonType="primary"
                   onClick={() => handleSubmit()}
                   disabled={userCannotAddFirewall}
@@ -165,9 +173,6 @@ const AddFirewallDrawer: React.FC<CombinedProps> = (props) => {
                   data-testid="create-firewall-submit"
                 >
                   Create Firewall
-                </Button>
-                <Button buttonType="secondary" onClick={onClose} data-qa-cancel>
-                  Cancel
                 </Button>
               </ActionsPanel>
             </form>

--- a/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.tsx
@@ -156,12 +156,7 @@ const AddFirewallDrawer: React.FC<CombinedProps> = (props) => {
                 onBlur={handleBlur}
               />
               <ActionsPanel>
-                <Button
-                  buttonType="secondary"
-                  onClick={onClose}
-                  disabled={_isRestrictedUser}
-                  data-qa-cancel
-                >
+                <Button buttonType="secondary" onClick={onClose} data-qa-cancel>
                   Cancel
                 </Button>
                 <Button

--- a/packages/manager/src/features/Managed/Credentials/AddCredentialDrawer.tsx
+++ b/packages/manager/src/features/Managed/Credentials/AddCredentialDrawer.tsx
@@ -96,20 +96,20 @@ const CredentialDrawer: React.FC<CombinedProps> = (props) => {
               </React.Suspense>
               <ActionsPanel>
                 <Button
-                  buttonType="primary"
-                  onClick={() => handleSubmit()}
-                  loading={isSubmitting}
-                  data-qa-submit
-                >
-                  Add Credential
-                </Button>
-                <Button
                   onClick={onClose}
                   data-qa-cancel
                   buttonType="secondary"
                   className="cancel"
                 >
                   Cancel
+                </Button>
+                <Button
+                  buttonType="primary"
+                  onClick={() => handleSubmit()}
+                  loading={isSubmitting}
+                  data-qa-submit
+                >
+                  Add Credential
                 </Button>
               </ActionsPanel>
             </form>

--- a/packages/manager/src/features/Managed/MonitorDrawer.tsx
+++ b/packages/manager/src/features/Managed/MonitorDrawer.tsx
@@ -282,20 +282,20 @@ const MonitorDrawer: React.FC<CombinedProps> = (props) => {
               />
               <ActionsPanel>
                 <Button
-                  buttonType="primary"
-                  onClick={() => handleSubmit()}
-                  loading={isSubmitting}
-                  data-qa-submit
-                >
-                  {mode === 'create' ? 'Add Monitor' : 'Save Changes'}
-                </Button>
-                <Button
                   onClick={onClose}
                   data-qa-cancel
                   buttonType="secondary"
                   className="cancel"
                 >
                   Cancel
+                </Button>
+                <Button
+                  buttonType="primary"
+                  onClick={() => handleSubmit()}
+                  loading={isSubmitting}
+                  data-qa-submit
+                >
+                  {mode === 'create' ? 'Add Monitor' : 'Save Changes'}
                 </Button>
               </ActionsPanel>
             </form>

--- a/packages/manager/src/features/Profile/APITokens/APITokenDrawer.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokenDrawer.tsx
@@ -424,16 +424,16 @@ export class APITokenDrawer extends React.Component<CombinedProps, State> {
           <FormHelperText error>{errorMap.scopes}</FormHelperText>
         )}
         <ActionsPanel>
-          {mode === 'view' && (
-            <Button
-              buttonType="primary"
-              onClick={closeDrawer}
-              data-qa-close-drawer
-            >
-              Done
-            </Button>
-          )}
           {(mode === 'create' || mode === 'edit') && [
+            <Button
+              buttonType="secondary"
+              className="cancel"
+              key="cancel"
+              onClick={closeDrawer}
+              data-qa-cancel
+            >
+              Cancel
+            </Button>,
             <Button
               key="create"
               buttonType="primary"
@@ -452,15 +452,6 @@ export class APITokenDrawer extends React.Component<CombinedProps, State> {
               data-qa-submit
             >
               {(mode as string) === 'create' ? 'Create Token' : 'Save Token'}
-            </Button>,
-            <Button
-              buttonType="secondary"
-              className="cancel"
-              key="cancel"
-              onClick={closeDrawer}
-              data-qa-cancel
-            >
-              Cancel
             </Button>,
           ]}
         </ActionsPanel>

--- a/packages/manager/src/features/Profile/APITokens/APITokenDrawer.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokenDrawer.tsx
@@ -427,7 +427,6 @@ export class APITokenDrawer extends React.Component<CombinedProps, State> {
           {(mode === 'create' || mode === 'edit') && [
             <Button
               buttonType="secondary"
-              className="cancel"
               key="cancel"
               onClick={closeDrawer}
               data-qa-cancel

--- a/packages/manager/src/features/Profile/LishSettings/LishSettings.tsx
+++ b/packages/manager/src/features/Profile/LishSettings/LishSettings.tsx
@@ -36,6 +36,9 @@ const useStyles = makeStyles((theme: Theme) => ({
       minWidth: 415,
     },
   },
+  sshKeyButton: {
+    marginTop: theme.spacing(),
+  },
 }));
 
 const LishSettings: React.FC = () => {
@@ -187,7 +190,8 @@ const LishSettings: React.FC = () => {
                 {(idx === 0 && typeof authorizedKeys[0] !== 'undefined') ||
                 idx > 0 ? (
                   <Button
-                    buttonType="secondary"
+                    buttonType="outlined"
+                    className={classes.sshKeyButton}
                     compact
                     onClick={onPublicKeyRemove(idx)}
                     data-qa-remove
@@ -202,7 +206,8 @@ const LishSettings: React.FC = () => {
             </Typography>
             <Button
               onClick={addSSHPublicKeyField}
-              buttonType="secondary"
+              className={classes.sshKeyButton}
+              buttonType="outlined"
               compact
             >
               Add SSH Public Key

--- a/packages/manager/src/features/Profile/OAuthClients/OAuthFormDrawer.tsx
+++ b/packages/manager/src/features/Profile/OAuthClients/OAuthFormDrawer.tsx
@@ -83,20 +83,20 @@ const OAuthCreationDrawer: React.FC<CombinedProps> = (props) => {
       </FormControl>
       <ActionsPanel>
         <Button
-          buttonType="primary"
-          onClick={onSubmit}
-          loading={loading}
-          data-qa-submit
-        >
-          Submit
-        </Button>
-        <Button
           onClick={onClose}
           data-qa-cancel
           buttonType="secondary"
           className="cancel"
         >
           Cancel
+        </Button>
+        <Button
+          buttonType="primary"
+          onClick={onSubmit}
+          loading={loading}
+          data-qa-submit
+        >
+          Submit
         </Button>
       </ActionsPanel>
     </Drawer>

--- a/packages/manager/src/features/Profile/OAuthClients/OAuthFormDrawer.tsx
+++ b/packages/manager/src/features/Profile/OAuthClients/OAuthFormDrawer.tsx
@@ -96,7 +96,7 @@ const OAuthCreationDrawer: React.FC<CombinedProps> = (props) => {
           loading={loading}
           data-qa-submit
         >
-          Submit
+          {edit ? 'Save Changes' : 'Create'}
         </Button>
       </ActionsPanel>
     </Drawer>

--- a/packages/manager/src/features/Profile/SSHKeys/SSHKeyCreationDrawer.tsx
+++ b/packages/manager/src/features/Profile/SSHKeys/SSHKeyCreationDrawer.tsx
@@ -85,19 +85,19 @@ export class SSHKeyCreationDrawer extends React.PureComponent<
 
         <ActionsPanel>
           <Button
+            buttonType="secondary"
+            onClick={this.props.onCancel}
+            data-qa-cancel
+          >
+            Cancel
+          </Button>
+          <Button
             buttonType="primary"
             onClick={this.onSubmit}
             loading={this.state.submitting}
             data-qa-submit
           >
             Add Key
-          </Button>
-          <Button
-            buttonType="secondary"
-            onClick={this.props.onCancel}
-            data-qa-cancel
-          >
-            Cancel
           </Button>
         </ActionsPanel>
       </Drawer>

--- a/packages/manager/src/features/StackScripts/StackScriptForm/StackScriptForm.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptForm/StackScriptForm.tsx
@@ -53,6 +53,10 @@ const useStyles = makeStyles((theme: Theme) => ({
   revisionTextarea: {
     maxWidth: '100%',
   },
+  actions: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+  },
 }));
 
 interface TextFieldHandler {
@@ -201,16 +205,7 @@ export const StackScriptForm: React.FC<CombinedProps> = (props) => {
         disabled={disabled}
         data-qa-stackscript-revision
       />
-      <ActionsPanel style={{ paddingBottom: 0 }}>
-        <Button
-          onClick={onSubmit}
-          buttonType="primary"
-          loading={isSubmitting}
-          disabled={disabled || disableSubmit}
-          data-qa-save
-        >
-          {mode === 'edit' ? 'Save Changes' : 'Create StackScript'}
-        </Button>
+      <ActionsPanel style={{ paddingBottom: 0 }} className={classes.actions}>
         <Button
           onClick={onCancel}
           buttonType="secondary"
@@ -219,6 +214,15 @@ export const StackScriptForm: React.FC<CombinedProps> = (props) => {
           data-qa-cancel
         >
           Reset
+        </Button>
+        <Button
+          onClick={onSubmit}
+          buttonType="primary"
+          loading={isSubmitting}
+          disabled={disabled || disableSubmit}
+          data-qa-save
+        >
+          {mode === 'edit' ? 'Save Changes' : 'Create StackScript'}
         </Button>
       </ActionsPanel>
     </Paper>

--- a/packages/manager/src/features/StackScripts/StackScriptForm/StackScriptForm.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptForm/StackScriptForm.tsx
@@ -56,6 +56,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   actions: {
     display: 'flex',
     justifyContent: 'flex-end',
+    paddingBottom: 0,
   },
 }));
 
@@ -205,7 +206,7 @@ export const StackScriptForm: React.FC<CombinedProps> = (props) => {
         disabled={disabled}
         data-qa-stackscript-revision
       />
-      <ActionsPanel style={{ paddingBottom: 0 }} className={classes.actions}>
+      <ActionsPanel className={classes.actions}>
         <Button
           onClick={onCancel}
           buttonType="secondary"

--- a/packages/manager/src/features/Users/CreateUserDrawer.tsx
+++ b/packages/manager/src/features/Users/CreateUserDrawer.tsx
@@ -149,16 +149,16 @@ class CreateUserDrawer extends React.Component<CombinedProps, State> {
           />
         </div>
         <ActionsPanel>
+          <Button buttonType="secondary" onClick={onClose} data-qa-cancel>
+            Cancel
+          </Button>
           <Button
             buttonType="primary"
             onClick={this.onSubmit}
             loading={submitting}
             data-qa-submit
           >
-            Submit
-          </Button>
-          <Button buttonType="secondary" onClick={onClose} data-qa-cancel>
-            Cancel
+            Add User
           </Button>
         </ActionsPanel>
       </Drawer>

--- a/packages/manager/src/features/Users/UserProfile.tsx
+++ b/packages/manager/src/features/Users/UserProfile.tsx
@@ -219,8 +219,8 @@ const UserProfile: React.FC<Props> = (props) => {
         )}
         <Button
           disabled={profile?.username === username}
+          buttonType="outlined"
           className={classes.topMargin}
-          buttonType="primary"
           onClick={onDelete}
           data-qa-confirm-delete
         >

--- a/packages/manager/src/features/Volumes/VolumeAttachmentDrawer.tsx
+++ b/packages/manager/src/features/Volumes/VolumeAttachmentDrawer.tsx
@@ -233,8 +233,14 @@ class VolumeAttachmentDrawer extends React.Component<CombinedProps, State> {
             )}
           </FormControl>
         )}
-
         <ActionsPanel>
+          <Button
+            buttonType="secondary"
+            onClick={this.handleClose}
+            data-qa-cancel
+          >
+            Cancel
+          </Button>
           <Button
             buttonType="primary"
             onClick={this.attachToLinode}
@@ -242,13 +248,6 @@ class VolumeAttachmentDrawer extends React.Component<CombinedProps, State> {
             data-qa-submit
           >
             Save
-          </Button>
-          <Button
-            buttonType="secondary"
-            onClick={this.handleClose}
-            data-qa-cancel
-          >
-            Cancel
           </Button>
         </ActionsPanel>
       </Drawer>

--- a/packages/manager/src/features/Volumes/VolumeDrawer/VolumeConfigForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/VolumeConfigForm.tsx
@@ -1,6 +1,4 @@
 import * as React from 'react';
-import ActionsPanel from 'src/components/ActionsPanel';
-import Button from 'src/components/Button';
 import CopyableTextField from 'src/components/CopyableTextField';
 import {
   createStyles,
@@ -34,7 +32,7 @@ interface Props {
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 const VolumeConfigDrawer: React.FC<CombinedProps> = (props) => {
-  const { classes, message, onClose } = props;
+  const { classes, message } = props;
 
   return (
     <React.Fragment>
@@ -94,11 +92,6 @@ const VolumeConfigDrawer: React.FC<CombinedProps> = (props) => {
           hideLabel
         />
       </div>
-      <ActionsPanel>
-        <Button onClick={onClose} buttonType="primary">
-          Close
-        </Button>
-      </ActionsPanel>
     </React.Fragment>
   );
 };

--- a/packages/manager/src/features/Volumes/VolumeDrawer/VolumesActionsPanel.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/VolumesActionsPanel.tsx
@@ -21,6 +21,11 @@ const VolumesActionsPanel: React.FC<CombinedProps> = ({
 }) => {
   return (
     <ActionsPanel style={{ marginTop: 16 }}>
+      {onCancel && (
+        <Button buttonType="secondary" onClick={onCancel} data-qa-cancel>
+          Cancel
+        </Button>
+      )}
       {onSubmit && (
         <Button
           buttonType="primary"
@@ -30,11 +35,6 @@ const VolumesActionsPanel: React.FC<CombinedProps> = ({
           data-qa-submit
         >
           {submitText ?? 'Submit'}
-        </Button>
-      )}
-      {onCancel && (
-        <Button buttonType="secondary" onClick={onCancel} data-qa-cancel>
-          Cancel
         </Button>
       )}
     </ActionsPanel>


### PR DESCRIPTION
## Notice

This PR will right align all Action Buttons in drawers, but I did not update the order in some drawers. @tiffwong will have a PR that fixes other drawers button placement. 

## Description

- [x] My Profile → SSH Keys → Add SSH Key
  - Switch order of buttons and right align
- [x] My Profile → LISH Console Settings
  - Make ‘Add SSH Public Key’ Secondary button style
- [x] My Profile → API Tokens → Add Personal Access Token
  - Switch order of buttons and right align
- [x] My Profile → API Tokens → View Scopes drawer
  - Remove ‘Done’ button
- [x] My Profile → API Tokens → Edit Personal Access Token drawer
  - Switch order of buttons and right align
- [x] My Profile → OAuth Apps → Create OAuth App, Edit OAuth App
  - Switch order of buttons and right align
- [x] Managed → Monitors → Add Monitor drawer
  - Switch order of buttons and right align
- [x] Managed → Credentials → Add Credential drawer
  - Switch order of buttons and right align
- [x] Managed → SSH Access → Edit SSH Access drawer
  - [x] Fix button right padding since there is only one child
- [x] Managed → Contacts → Add Contact drawer
  - Right align button
- [x] Volumes → Edit Volume Drawer
  - Switch order of buttons and right align
- [x] Volumes landing → Resize, Clone, Attach
  - Switch order of buttons and right align
- [x] Volumes → Configuration drawer
  - Remove close button
- [x] Firewalls detail → Add Rule, Edit Rule, Create Firewall
  - Switch order of buttons and right align
- [x] Firewalls detail → Add Inbound Rule, Add Outbound Rule buttons
  - Should be Primary Buttons
- [x] StackScripts → Edit
  - Switch order of buttons and right align
- [x] Users & Grants → Add a User
  - Switch order of buttons and right align
- [x] Account → Settings → Object Storage, Close Account
  - Make both buttons Secondary with Outline
- [x] Account → User Profile
  - Change ‘Delete’ to Secondary with Outline

## How to test

- Test all affected components, all drawers, and all Dialogs