### PR TITLE
[for release] Fix: unable to add Firewall rules that use ICMP protocol

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/firewallRuleEditor.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/firewallRuleEditor.ts
@@ -224,11 +224,15 @@ export const initRuleEditorState = (
   );
 };
 
-export const editorStateToRules = (
-  state: RuleEditorState
-): ExtendedFirewallRule[] =>
+export const editorStateToRules = (state: RuleEditorState) => {
   // Cast the results of the Immer state to a mutable data structure.
-  castDraft(state.map((revisionList) => revisionList[revisionList.length - 1]));
+  return castDraft(
+    state.map((revisionList) =>
+      // Make a mutable copy of the object since Immer state objects are frozen.
+      Object.assign({}, revisionList[revisionList.length - 1])
+    )
+  );
+};
 
 // Remove fields we use internally.
 export const stripExtendedFields = (


### PR DESCRIPTION
## Description

This fixes a bug in production that my [dependency update PR](https://github.com/linode/manager/pull/7787) introduced.

That PR included an upgrade of Immer to v8.0.4. One thing I missed is that Immer introduced a breaking change in v8.0.0 that made state tree freezing (via `Object.freeze()`) the default behavior. This means that any state modified with `produce` is frozen, and attempting to modify properties results in a runtime error (e.g. `Cannot delete property 'ports' of #<Object>`). 

This is a sane default, but we were modifying part of the state tree intentionally in order to prepare the rule state to send to the API. That probably wasn't a good idea anyway, so what I've done here is _copied the object_ first, so modifications can be made without error.

See: 
- https://immerjs.github.io/immer/freezing/
- https://github.com/immerjs/immer/releases/tag/v8.0.0

## How to test

- test that adding/modifying/deleting a rule that uses the ICMP protocol works
- test that adding/modifying/deleting other types of rules works

I'm not sure why the unit tests for this didn't fail... still looking into that.
