### PR TITLE
M3-5360: Fix Root Device bugs in LinodeConfigDialog.tsx

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -723,6 +723,7 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
                 deviceCounter,
                 values.devices,
                 values.root_device,
+                useCustomRoot,
                 values.useCustomRoot,
                 formik.errors.devices,
               ]}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -722,6 +722,7 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
               updateFor={[
                 deviceCounter,
                 values.devices,
+                values.root_device,
                 values.useCustomRoot,
                 formik.errors.devices,
               ]}


### PR DESCRIPTION
## Description
Unfortunately some of the changes made in https://github.com/linode/manager/pull/7718 opened the door to a couple of bugs in the LinodeConfigDialog, namely a non-functional "Use Custom Root" button and Root Device dropdown.

This PR fixes that by adding the relevant variables to `updateFor` for the `<Grid />` that contains these fields.

## How to test
Ensure that adding and editing Linode Configurations work as expected.

To see the intended functionality prior to these bugs being introduced in late July, you can checkout a release from June by running `git checkout f5c6168bbce32a0a42a1d3de20ccb307e976f003` (Cloud v1.43.1) to compare.
