### PR TITLE
M3-5391: Fixed Object Storage warning message styles in dark mode

### DIFF
--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
@@ -367,19 +367,21 @@ const Banner: React.FC<BannerProps> = React.memo(({ regionsAffected }) => {
 
   return (
     <Notice warning important>
-      There was an error loading buckets in{' '}
-      {moreThanOneRegionAffected
-        ? 'the following regions:'
-        : `${regionsAffected[0]}.`}
-      <ul>
-        {moreThanOneRegionAffected &&
-          regionsAffected.map((thisRegion) => (
-            <li key={thisRegion}>{thisRegion}</li>
-          ))}
-      </ul>
-      If you have buckets in{' '}
-      {moreThanOneRegionAffected ? 'these regions' : regionsAffected[0]}, you
-      may not see them listed below.
+      <Typography component="div" style={{ fontSize: '1rem' }}>
+        There was an error loading buckets in{' '}
+        {moreThanOneRegionAffected
+          ? 'the following regions:'
+          : `${regionsAffected[0]}.`}
+        <ul>
+          {moreThanOneRegionAffected &&
+            regionsAffected.map((thisRegion) => (
+              <li key={thisRegion}>{thisRegion}</li>
+            ))}
+        </ul>
+        If you have buckets in{' '}
+        {moreThanOneRegionAffected ? 'these regions' : regionsAffected[0]}, you
+        may not see them listed below.
+      </Typography>
     </Notice>
   );
 });


### PR DESCRIPTION
## Description

- Fixes dark mode text color for Object Storage warning banners
 
```tsx
<Typography component="div" style={{ fontSize: '1rem' }}>
```
I used `component="div"` because `<ul>`'s can't appear as children of a `<p>` but I want the children to inherit the Typography styles. 

Before
![Screen Shot 2021-08-11 at 5 06 20 PM](https://user-images.githubusercontent.com/6440455/129105552-02f85fed-5590-471e-a5dd-46808501ae8f.png)

After
![Screen Shot 2021-08-11 at 5 26 01 PM](https://user-images.githubusercontent.com/6440455/129105587-850db896-b08b-4701-bec6-b92ceb94440c.png)

## How to test

- Manually mock a warning to show a banner
- Ensure styles look good in dark mode and light mode
