### PR TITLE
M3-5392: Fix primary button loading state in dark mode

### DIFF
--- a/packages/manager/src/themes.ts
+++ b/packages/manager/src/themes.ts
@@ -308,17 +308,11 @@ const darkThemeOptions = {
         },
         '&$disabled': {
           backgroundColor: '#454b54',
-          color: '#5c6470',
         },
         '&.loading': {
           color: primaryColors.text,
         },
       },
-      // text: {
-      //   '&:hover': {
-      //     backgroundColor: 'transparent'
-      //   }
-      // },
       containedPrimary: {
         '&:hover, &:focus': {
           backgroundColor: '#226dc3',
@@ -328,7 +322,6 @@ const darkThemeOptions = {
         },
         '&$disabled': {
           backgroundColor: '#454b54',
-          color: '#5c6470',
         },
       },
       outlined: {

--- a/packages/manager/src/themes.ts
+++ b/packages/manager/src/themes.ts
@@ -308,6 +308,7 @@ const darkThemeOptions = {
         },
         '&$disabled': {
           backgroundColor: '#454b54',
+          color: '#5c6470',
         },
         '&.loading': {
           color: primaryColors.text,
@@ -322,6 +323,10 @@ const darkThemeOptions = {
         },
         '&$disabled': {
           backgroundColor: '#454b54',
+          color: '#5c6470',
+        },
+        '&.loading': {
+          color: primaryColors.text,
         },
       },
       outlined: {


### PR DESCRIPTION
## Description

- Fixes the loading spinner not showing up in primary buttons

Before
<img width="283" alt="Screen Shot 2021-08-12 at 11 29 11 AM" src="https://user-images.githubusercontent.com/6440455/129224565-6efc8cc7-e71c-482b-a7be-3d7a314c1154.png">

After
<img width="283" alt="Screen Shot 2021-08-12 at 11 29 35 AM" src="https://user-images.githubusercontent.com/6440455/129224578-0f82cde1-bf39-48d6-aa88-7929cfa7d5df.png">

## How to test

- Check the styles of all buttons
- Make sure you can see the loading spinner in dark and light mode
- Make sure text inside buttons is still the correct color and not affected by this change