### PR TITLE
E2E Volumes Test Update

### DIFF
--- a/packages/manager/cypress/integration/volumes/smoke-create-volumes.spec.ts
+++ b/packages/manager/cypress/integration/volumes/smoke-create-volumes.spec.ts
@@ -59,7 +59,7 @@ const createBasicVolume = (linodeLabel?: string) => {
 const validateBasicVolume = (volLabel: string, volId: string) => {
   containsVisible('Volume Configuration');
   cy.findByDisplayValue(`mkdir "/mnt/${volLabel}"`);
-  containsClick('Close');
+  getClick('[data-qa-close-drawer="true"]');
   // assertToast(`Volume ${volLabel} successfully created.`);
   fbtVisible(volLabel);
   cy.get(`[data-qa-volume-cell="${volId}"]`).within(() => {


### PR DESCRIPTION
## Description
This change was needed because of some recent ui changes to this page

**What does this PR do?**
small update for volumes drawer change

## How to test
- `yarn up` in one terminal
- `yarn cy:e2e -s ./cypress/integration/volumes/smoke-create-volumes.spec.ts` in another
- Result should be "✔  All specs passed!"

## Make sure your .env contains:
```
REACT_APP_LOGIN_ROOT
REACT_APP_API_ROOT
REACT_APP_APP_ROOT
REACT_APP_LAUNCH_DARKLY_ID
REACT_APP_CLIENT_ID
MANAGER_OAUTH
```