### PR TITLE
M3-5394: Fix Kubernetes Debian images showing up in the Rebuild Dialog

### DIFF
--- a/packages/manager/src/components/ImageSelect/ImageSelect.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.tsx
@@ -143,6 +143,8 @@ export const ImageSelect: React.FC<Props> = (props) => {
       case 'private':
         return !thisImage.is_public && thisImage.status === 'available';
       case 'all':
+        // Even if all images are requested, we don't want to expose the Kubernetes images
+        return !thisImage.label.match(/kube/i);
       default:
         return true;
     }

--- a/packages/manager/src/components/ImageSelect/ImageSelect.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.tsx
@@ -143,10 +143,7 @@ export const ImageSelect: React.FC<Props> = (props) => {
       case 'private':
         return !thisImage.is_public && thisImage.status === 'available';
       case 'all':
-        /*
-         * Even if all images are requested, we don't want to expose the Kubernetes images
-         * We keep images that don't have kube in the name that are created by Linode
-         */
+        // We don't show images with 'kube' in the label that are created by Linode
         return !(
           thisImage.label.match(/kube/i) && thisImage.created_by === 'linode'
         );

--- a/packages/manager/src/components/ImageSelect/ImageSelect.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.tsx
@@ -143,8 +143,13 @@ export const ImageSelect: React.FC<Props> = (props) => {
       case 'private':
         return !thisImage.is_public && thisImage.status === 'available';
       case 'all':
-        // Even if all images are requested, we don't want to expose the Kubernetes images
-        return !thisImage.label.match(/kube/i);
+        /*
+         * Even if all images are requested, we don't want to expose the Kubernetes images
+         * We keep images that don't have kube in the name that are created by Linode
+         */
+        return !(
+          thisImage.label.match(/kube/i) && thisImage.created_by === 'linode'
+        );
       default:
         return true;
     }

--- a/packages/manager/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
@@ -441,7 +441,9 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
     const hasUnsavedChanges = this.hasUnsavedChanges();
 
     const availableImages = Object.values(imagesData).filter(
-      (thisImage) => !this.state.images.includes(thisImage.id)
+      (thisImage) =>
+        !this.state.images.includes(thisImage.id) &&
+        !thisImage.label.match(/kube/i)
     );
 
     const stackScriptGrants = getGrants(grants.data, 'stackscript');


### PR DESCRIPTION
## Description

- Fixes Kubernetes Debian images showing up in the Rebuild Dialog
- Caused by #7800 
- Fixed by filtering out Kube images when ImageSelection variant is `all`

Please check my filtering logic. I want to make sure Linode's Kubernetes images get filtered out but I want to make sure that if a user has a script with Kube in the name, it still gets shown.

## How to test

- Check all Image selections in Cloud Manager
- Specifically Check the Linode Rebuild from Image Dialog 
