### PR TITLE
M3-5395: Fix users unable to set a label and description when capturing an Image

### DIFF
--- a/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
@@ -124,7 +124,6 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
     setSubmitting(true);
 
     const safeDescription = description ?? '';
-
     createImage({
       diskID: Number(selectedDisk),
       label,
@@ -253,7 +252,7 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
 
       <ActionsPanel
         style={{ marginTop: 16 }}
-        updateFor={[requirementsMet, classes, submitting]}
+        updateFor={[label, description, requirementsMet, classes, submitting]}
       >
         <Button
           onClick={onSubmit}


### PR DESCRIPTION
## Description

- Fixed a random but somewhat important bug I found where on `/images/create/disk`, the **label** and **description** fields were not getting passed to the API and not being used. This made creating an Image from a disk really confusing. 

## How to test

- Test creating an Image from a disk and also test uploading an Image.
- Make sure label and description get passed to the API in the dev tools network tab (previously it those values were not being sent)
