### PR TITLE
M3-5368: Fix support ticket input with different font sizes

### DIFF
--- a/packages/manager/src/features/Support/SupportTicketDetail/TabbedReply/TicketReply.tsx
+++ b/packages/manager/src/features/Support/SupportTicketDetail/TabbedReply/TicketReply.tsx
@@ -11,7 +11,6 @@ type ClassNames = 'replyField';
 const styles = () =>
   createStyles({
     replyField: {
-      height: 320,
       marginTop: 0,
       '& > div': {
         maxWidth: '100% !important',

--- a/packages/manager/src/features/Support/SupportTicketDetail/TabbedReply/TicketReply.tsx
+++ b/packages/manager/src/features/Support/SupportTicketDetail/TabbedReply/TicketReply.tsx
@@ -35,7 +35,7 @@ class TicketReply extends React.Component<CombinedProps> {
       <TextField
         className={classes.replyField}
         multiline
-        rows={15}
+        rows={12}
         value={value}
         placeholder={placeholder || 'Enter your reply'}
         data-qa-ticket-description


### PR DESCRIPTION
## Description

- FIxes weird text overflow issues in the Create Ticket dialog Text Field or Ticket Reply Text Field when user changes their browsers font size (chrome://settings/?search=Font)
- This issues was happening because the TextField component takes `rows` as a prop which dictates the size, but we also had a height css property on it, these were most likely conflicting.
- This fix is to remove the static CSS heigh we assigned and rely on the `rows` prop for size

Before
![Screen Shot 2021-08-17 at 10 42 37 AM](https://user-images.githubusercontent.com/6440455/129747391-5ec35183-68db-4e96-a720-100ebff93f2f.png)

After
![Screen Shot 2021-08-17 at 10 43 07 AM](https://user-images.githubusercontent.com/6440455/129747406-035f93d3-89d8-48a4-8fba-70bac3368c05.png)

## How to test

- Go to Chrome's settings and change the browser's font size to **large** or anything bigger
- Test the **Open a Support Ticket** dialog
- Make sure the reply Text Field for a ticket thread still looks right
- Make sure the size of ticket related dialogs look correct, because this PR changes the size a bit
