### PR TITLE
M3-5358: Allow more room for image names

### DIFF
--- a/packages/manager/src/features/Images/ImagesLanding.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding.tsx
@@ -56,9 +56,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-/**
- * @todo remove conditional cell sizes when we're no longer relying on a flag here.
- */
 const getHeaders = (
   tableType: 'automatic' | 'manual',
   flagEnabled: boolean = true
@@ -68,7 +65,7 @@ const getHeaders = (
       label: 'Image',
       dataColumn: 'label',
       sortable: true,
-      widthPercent: flagEnabled ? 30 : 35,
+      widthPercent: 30,
     },
     flagEnabled
       ? {
@@ -83,21 +80,21 @@ const getHeaders = (
       label: 'Created',
       dataColumn: 'created',
       sortable: false,
-      widthPercent: flagEnabled ? 15 : 20,
+      widthPercent: 20,
       hideOnMobile: true,
     },
     {
       label: 'Size',
       dataColumn: 'size',
       sortable: true,
-      widthPercent: flagEnabled ? 15 : 20,
+      widthPercent: 15,
     },
     tableType === 'automatic'
       ? {
           label: 'Expires',
           dataColumn: 'expires',
           sortable: false,
-          widthPercent: 15,
+          widthPercent: 20,
           hideOnMobile: true,
         }
       : null,
@@ -106,7 +103,7 @@ const getHeaders = (
       visuallyHidden: true,
       dataColumn: '',
       sortable: false,
-      widthPercent: 35,
+      widthPercent: 15,
     },
   ].filter(Boolean) as HeaderCell[];
 

--- a/packages/manager/src/features/Images/ImagesLanding.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding.tsx
@@ -68,7 +68,7 @@ const getHeaders = (
       label: 'Image',
       dataColumn: 'label',
       sortable: true,
-      widthPercent: flagEnabled ? 20 : 25,
+      widthPercent: flagEnabled ? 30 : 35,
     },
     flagEnabled
       ? {

--- a/packages/manager/src/features/Images/ImagesLanding.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding.tsx
@@ -56,10 +56,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-const getHeaders = (
-  tableType: 'automatic' | 'manual',
-  flagEnabled: boolean = true
-): HeaderCell[] =>
+const getHeaders = (tableType: 'automatic' | 'manual'): HeaderCell[] =>
   [
     {
       label: 'Image',
@@ -67,15 +64,13 @@ const getHeaders = (
       sortable: true,
       widthPercent: 30,
     },
-    flagEnabled
-      ? {
-          label: 'Status',
-          dataColumn: 'status',
-          sortable: true,
-          widthPercent: 15,
-          hideOnMobile: true,
-        }
-      : null,
+    {
+      label: 'Status',
+      dataColumn: 'status',
+      sortable: true,
+      widthPercent: 15,
+      hideOnMobile: true,
+    },
     {
       label: 'Created',
       dataColumn: 'created',
@@ -385,8 +380,8 @@ export const ImagesLanding: React.FC<CombinedProps> = (props) => {
     thisImage.hasOwnProperty('status')
   );
 
-  const manualHeaders = getHeaders('manual', machineImagesEnabled);
-  const automaticHeaders = getHeaders('automatic', machineImagesEnabled);
+  const manualHeaders = getHeaders('manual');
+  const automaticHeaders = getHeaders('automatic');
 
   const initialOrder = {
     order: 'asc' as Order,


### PR DESCRIPTION
## Description

This PR increases the width of the linode image name width

## How to test

Clone branch and view images under /images

N/A No relevant unit tests - small styling change only

## Notes

ImagesLanding.tsx: "widthPercent" before only added up to 100 in the case of tableType=='automatic' and flagEnabled==true headers being passed in. 

This PR has the side effect of making the width percents not add up to 100 in this case but the way components/EntityTable/EntityTableHeaders.tsx presents the width to the TableCell doesn't seem to have a 100% sum requirement. Perhaps it's OK to ignore this since we do in most other instances, and making the ratios change to sum to 100% is kinda unwieldily? 