### PR TITLE
M3-5375: Handle API maintenance mode

### DIFF
--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -39,6 +39,7 @@ import usePreferences from 'src/hooks/usePreferences';
 import { isFeatureEnabled } from 'src/utilities/accountCapabilities';
 import { FlagSet } from './featureFlags';
 import { UserPreferences } from './store/preferences/preferences.actions';
+import { MaintenanceScreen } from 'src/components/MaintenanceScreen';
 
 const useStyles = makeStyles((theme: Theme) => ({
   appFrame: {
@@ -254,6 +255,11 @@ const MainContent: React.FC<CombinedProps> = (props) => {
         </div>
       </div>
     );
+  }
+
+  // If the API is in maintenance mode, return a Maintenance screen
+  if (props.globalErrors.api_maintenance_mode) {
+    return <MaintenanceScreen />;
   }
 
   /**

--- a/packages/manager/src/components/MaintenanceScreen.tsx
+++ b/packages/manager/src/components/MaintenanceScreen.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react';
+import Link from 'src/components/Link';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+import Box from 'src/components/core/Box';
+import Logo from 'src/assets/logo/logo-text.svg';
+import ErrorState from 'src/components/ErrorState';
+import BuildIcon from '@material-ui/icons/Build';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  bgStyling: {
+    backgroundColor: theme.bg.main,
+    minHeight: '100vh',
+  },
+  maintenanceWrapper: {
+    padding: theme.spacing(4),
+    [theme.breakpoints.up('xl')]: {
+      width: '50%',
+      margin: '0 auto',
+    },
+  },
+  logo: {
+    '& > g': {
+      fill: theme.color.black,
+    },
+  },
+  errorHeading: {
+    marginBottom: theme.spacing(2),
+  },
+  subheading: {
+    margin: '0 auto',
+    maxWidth: '75%',
+  },
+}));
+
+export const MaintenanceScreen: React.FC<{}> = () => {
+  const classes = useStyles();
+
+  const maintenanceCopy = (
+    <Typography variant="h2" className={classes.errorHeading}>
+      We are currently undergoing scheduled maintenance.
+    </Typography>
+  );
+
+  const statusPageCopy = (
+    <Typography className={classes.subheading}>
+      To stay updated on the status of the Linode Cloud Manager and API, you may
+      visit{' '}
+      <Link to="https://status.linode.com/">https://status.linode.com</Link>.
+    </Typography>
+  );
+
+  return (
+    <div className={classes.bgStyling}>
+      <div className={classes.maintenanceWrapper}>
+        <Box
+          style={{
+            display: 'flex',
+          }}
+        >
+          <Logo width={150} height={87} className={classes.logo} />
+        </Box>
+
+        <ErrorState
+          CustomIcon={BuildIcon}
+          CustomIconStyles={{
+            color: 'black',
+          }}
+          errorText={
+            <>
+              {maintenanceCopy}
+              {statusPageCopy}
+            </>
+          }
+        />
+      </div>
+    </div>
+  );
+};

--- a/packages/manager/src/request.tsx
+++ b/packages/manager/src/request.tsx
@@ -38,11 +38,7 @@ export const handleError = (error: AxiosError) => {
     { reason: DEFAULT_ERROR_MESSAGE },
   ];
 
-  const apiInMaintenanceMode =
-    !!error.config?.headers['x-maintenance-mode'] ||
-    errors.some((err) => {
-      return Boolean(err.reason.match(/maintenance mode/i));
-    });
+  const apiInMaintenanceMode = !!error.response?.headers['x-maintenance-mode'];
 
   if (apiInMaintenanceMode) {
     store.dispatch(
@@ -132,9 +128,9 @@ baseRequest.interceptors.request.use((config) => {
 });
 
 /*
-Interceptor that initiates re-authentication if:
-  * The response is HTTP 401 "Unauthorized"
-  * The API is in Maintenance mode
+Interceptor that:
+  * initiates re-authentication if the response is HTTP 401 "Unauthorized"
+  * displays a Maintenance view if the API is in Maintenance mode
 Also rejects non-error responses if the API is in Maintenance mode
 */
 baseRequest.interceptors.response.use(handleSuccess, handleError);

--- a/packages/manager/src/store/globalErrors/types.ts
+++ b/packages/manager/src/store/globalErrors/types.ts
@@ -1,5 +1,6 @@
 interface S {
   account_unactivated: boolean;
+  api_maintenance_mode: boolean;
 }
 
 export type State = Partial<S>;


### PR DESCRIPTION
## Description
If the API is in maintenance mode, users would not be able to do anything in Cloud because successful API requests wouldn't be possible.

To avoid that, this PR creates a maintenance view that will display if the API is in maintenance mode:

<img width="1194" alt="Screen Shot 2021-08-19 at 4 32 47 PM" src="https://user-images.githubusercontent.com/32860776/130140175-a20c3b1d-0620-4e55-b349-76fcdf53a35a.png">

## How to test
To just test the view itself, you can make the condition on line 261 of `MainContext.tsx` true.

To test the logic for the response headers & errors, you'll need to use devenv. Please reach out if you need details on putting the API into maintenance mode in that environment.
