### PR TITLE
E2E Gpay Test Fix

### DIFF
--- a/packages/manager/cypress/integration/account/google-pay.spec.ts
+++ b/packages/manager/cypress/integration/account/google-pay.spec.ts
@@ -15,7 +15,11 @@ const getPaymentMethodDataWithGpay = {
       type: 'credit_card',
       is_default: true,
       created: '2021-07-27T14:37:43',
-      data: { card_type: 'AMEX', last_four: '2222', expiry: '07/2025' },
+      data: {
+        card_type: 'American Express',
+        last_four: '2222',
+        expiry: '07/2025',
+      },
     },
     {
       id: 434357,
@@ -56,7 +60,11 @@ const getPaymentMethodDataWithGpayExpired = {
       type: 'credit_card',
       is_default: true,
       created: '2021-07-27T14:37:43',
-      data: { card_type: 'AMEX', last_four: '2222', expiry: '07/2025' },
+      data: {
+        card_type: 'American Express',
+        last_four: '2222',
+        expiry: '07/2025',
+      },
     },
     {
       id: 434357,


### PR DESCRIPTION
## Description
needed to change amex to american express

**What does this PR do?**
small gpay e2e test update

## How to test
- `yarn up` in one terminal
- `yarn cy:e2e -s ./cypress/integration/account/google-pay.spec.ts` in another
- Result should be "✔  All specs passed!"

## Make sure your .env contains:
```
REACT_APP_LOGIN_ROOT
REACT_APP_API_ROOT
REACT_APP_APP_ROOT
REACT_APP_LAUNCH_DARKLY_ID
REACT_APP_CLIENT_ID
MANAGER_OAUTH
```