### PR TITLE
Add additional client-side Firewall rule label validation

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.test.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.test.tsx
@@ -96,8 +96,54 @@ describe('utilities', () => {
       );
       expect(validateForm('TCP', 'invalid-port')).toHaveProperty('ports');
     });
+    it('validates label', () => {
+      const expectedResults = [
+        {
+          value: 'test',
+          result: {},
+        },
+        {
+          value: 'accept-inbound-HTTP',
+          result: {},
+        },
+        {
+          value: '',
+          result: {
+            label: 'Label is required.',
+          },
+        },
+        {
+          value: 'ab',
+          result: {
+            label: 'Label must be 3-32 characters.',
+          },
+        },
+        {
+          value: 'qwertyuiopasdfghjklzxcvbnm1234567890',
+          result: {
+            label: 'Label must be 3-32 characters.',
+          },
+        },
+        {
+          value: ' test',
+          result: {
+            label: 'Label must begin with a letter.',
+          },
+        },
+        {
+          value: 'test ',
+          result: {
+            label:
+              'Label must include only ASCII letters, numbers, underscores, periods, and dashes.',
+          },
+        },
+      ];
+      expectedResults.forEach(({ value, result }) => {
+        expect(validateForm('TCP', '80', value)).toEqual(result);
+      });
+    });
     it('accepts a valid form', () => {
-      expect(validateForm('TCP', '22')).toEqual({});
+      expect(validateForm('TCP', '22', 'accept-inbound-HTTP')).toEqual({});
     });
   });
 

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.test.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.test.tsx
@@ -137,6 +137,13 @@ describe('utilities', () => {
               'Label must include only ASCII letters, numbers, underscores, periods, and dashes.',
           },
         },
+        {
+          value: 'b&a$e#c@!%^*()+=[]{}?/,<>~',
+          result: {
+            label:
+              'Label must include only ASCII letters, numbers, underscores, periods, and dashes.',
+          },
+        },
       ];
       expectedResults.forEach(({ value, result }) => {
         expect(validateForm('TCP', '80', value)).toEqual(result);

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
@@ -827,6 +827,21 @@ export const validateForm = (
 ) => {
   const errors: Partial<Form> = {};
 
+  if (!label) {
+    errors.label = 'Label is required.';
+  } else if (label.length < 3 || label.length > 32) {
+    errors.label = 'Label must be 3-32 characters.';
+  } else if (/^[^a-z]/i.test(label)) {
+    errors.label = 'Label must begin with a letter.';
+  } else if (/[^0-9a-z._-]+/i.test(label)) {
+    errors.label =
+      'Label must include only ASCII letters, numbers, underscores, periods, and dashes.';
+  }
+
+  if (description && description.length > 100) {
+    errors.description = 'Description must be 1-100 characters.';
+  }
+
   if (!protocol) {
     // eslint-disable-next-line
     errors.protocol = 'Protocol is required.';
@@ -834,20 +849,9 @@ export const validateForm = (
 
   if (protocol === 'ICMP' && ports) {
     errors.ports = 'Ports are not allowed for ICMP protocols.';
-    return errors;
-  }
-
-  if (ports && !ports.match(/^([0-9\-]+,?\s?)+$/)) {
+  } else if (ports && !ports.match(/^([0-9\-]+,?\s?)+$/)) {
     errors.ports =
       'Ports must be an integer, range of integers, or a comma-separated list of integers.';
-  }
-
-  if (description && description.length > 100) {
-    errors.description = 'Description must be 1-100 characters.';
-  }
-
-  if (label && (label.length < 3 || label.length > 32)) {
-    errors.label = 'Label must be 3-32 characters.';
   }
 
   return errors;


### PR DESCRIPTION
## Description
Re issue https://github.com/linode/manager/issues/7750: Adds additional client-side Firewall rule label validation to match the API

I looked into validating using `FirewallRuleTypeSchema` but the current structure of the code made it difficult and it was a bit out of scope, so I just added onto the `validateForm` function

- Label is required
    - There is inconsistency between actual API behavior and the docs. The [docs](https://www.linode.com/docs/api/networking/#firewall-create__request-body-schema) says label is required, however you can create a Firewall rule without a label. ARB-2686 has been created to address this
- Label must begin with a letter
- Label must only include ASCII letters, numbers, underscores, periods, and dashes

## How to test

**What are the steps to reproduce the issue or verify the changes?**

- Go to `/firewalls/<firewall_id>`
- In the Rules tab, edit an existing rule or add a new inbound/outbound rule
- In the add/edit form, edit the label with valid/invalid text, then click the blue Add button
    - If the text is invalid, there should be a red error message under the label input and the drawer should not close
    - If the text is valid, the drawer should close and the Rule Table should be updated with the new rule

**How do I run relevant unit tests?**
`yarn test FirewallRuleDrawer`
