### PR TITLE
M3-5278: Update buttons for Domains

### DIFF
--- a/packages/manager/src/features/Domains/DeleteDomain.tsx
+++ b/packages/manager/src/features/Domains/DeleteDomain.tsx
@@ -2,7 +2,7 @@ import { withSnackbar, WithSnackbarProps } from 'notistack';
 import * as React from 'react';
 import { compose } from 'recompose';
 import Button from 'src/components/Button';
-import { makeStyles } from 'src/components/core/styles';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import DeletionDialog from 'src/components/DeletionDialog';
 import { useDialog } from 'src/hooks/useDialog';
 import {
@@ -18,9 +18,12 @@ interface Props {
   onSuccess?: () => void;
 }
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((theme: Theme) => ({
   button: {
     float: 'right',
+    [theme.breakpoints.down('md')]: {
+      marginRight: theme.spacing(),
+    },
   },
 }));
 

--- a/packages/manager/src/features/Domains/DomainDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainDrawer.tsx
@@ -15,7 +15,6 @@ import { compose } from 'recompose';
 import { bindActionCreators, Dispatch } from 'redux';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
-import Divider from 'src/components/core/Divider';
 import FormControlLabel from 'src/components/core/FormControlLabel';
 import RadioGroup from 'src/components/core/RadioGroup';
 import Drawer from 'src/components/Drawer';
@@ -47,7 +46,6 @@ import {
   stringToExtendedIP,
 } from 'src/utilities/ipUtils';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
-import DeleteDomain from './DeleteDomain';
 import { getInitialIPs, transferHelperText as helperText } from './domainUtils';
 
 type DefaultRecordsType = 'none' | 'linode' | 'nodebalancer';
@@ -349,16 +347,6 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
             {mode === EDITING ? 'Save Changes' : 'Create Domain'}
           </Button>
         </ActionsPanel>
-        {mode === EDITING && this.props.id && this.props.domain && (
-          <>
-            <Divider spacingTop={28} spacingBottom={22} />
-            <DeleteDomain
-              domainId={this.props.id}
-              domainLabel={this.props.domain}
-              onSuccess={this.closeDrawer}
-            />
-          </>
-        )}
       </Drawer>
     );
   }

--- a/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
@@ -815,15 +815,14 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
         {fields.map((field: any, idx: number) => field(idx))}
 
         <ActionsPanel>
-          <Button {...buttonProps} data-qa-record-save />
           <Button
             buttonType="secondary"
-            className="cancel"
             onClick={this.onClose}
             data-qa-record-cancel
           >
             Cancel
           </Button>
+          <Button {...buttonProps} data-qa-record-save />
         </ActionsPanel>
       </Drawer>
     );

--- a/packages/manager/src/features/Domains/DomainRecords.tsx
+++ b/packages/manager/src/features/Domains/DomainRecords.tsx
@@ -60,8 +60,16 @@ const styles = (theme: Theme) =>
   createStyles({
     root: {
       margin: 0,
+      marginTop: theme.spacing(2),
+      width: '100%',
       '& .MuiGrid-item': {
         paddingLeft: 0,
+        paddingRight: 0,
+      },
+      '& .domain-btn': {
+        [theme.breakpoints.down('md')]: {
+          marginRight: theme.spacing(),
+        },
       },
       [theme.breakpoints.down('sm')]: {
         marginLeft: theme.spacing(),
@@ -136,7 +144,7 @@ interface IType {
 }
 
 const createLink = (title: string, handler: () => void) => (
-  <Button buttonType="secondary" onClick={handler}>
+  <Button buttonType="primary" className="domain-btn" onClick={handler}>
     {title}
   </Button>
 );

--- a/packages/manager/src/features/Domains/DomainRecords.tsx
+++ b/packages/manager/src/features/Domains/DomainRecords.tsx
@@ -381,7 +381,7 @@ class DomainRecords extends React.Component<CombinedProps, State> {
             ),
         },
       ],
-      link: () => createLink('Add a NS Record', this.openForCreateNSRecord),
+      link: () => createLink('Add an NS Record', this.openForCreateNSRecord),
     },
 
     /** MX Record */
@@ -592,7 +592,7 @@ class DomainRecords extends React.Component<CombinedProps, State> {
           ),
         },
       ],
-      link: () => createLink('Add a SRV Record', this.openForCreateSRVRecord),
+      link: () => createLink('Add an SRV Record', this.openForCreateSRVRecord),
     },
 
     /** CAA Record */


### PR DESCRIPTION
## Description

Make add buttons on the Domain Detail page primary and remove "Delete Domain" from the edit drawer

## How to test

- Go to `/domains`
- Click on "Edit" and the "Delete Domain" button should no longer show up in the drawer
- Click on the label for any primary domain
- The add buttons on the right of each table should now be in the primary style
