### PR TITLE
Make Payment Drawer UI fixes

### DIFF
--- a/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.tsx
+++ b/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.tsx
@@ -65,7 +65,7 @@ const PaymentMethodRow: React.FC<Props> = (props) => {
       onClick: () => {
         history.push({
           pathname: '/account/billing/make-payment/',
-          state: { id: paymentMethod.id },
+          state: { paymentMethod },
         });
       },
     },

--- a/packages/manager/src/components/SelectionCard/CardBase.tsx
+++ b/packages/manager/src/components/SelectionCard/CardBase.tsx
@@ -106,7 +106,7 @@ const CardBase: React.FC<CombinedProps> = (props) => {
           return (
             <div
               key={idx}
-              className={classes.subheading}
+              className={`${classes.subheading} cardBaseSubHeading`}
               data-qa-select-card-subheading={subheading}
             >
               {subheading}

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
@@ -123,21 +123,21 @@ export const BillingSummary: React.FC<BillingSummaryProps> = (props) => {
     false
   );
 
-  const [selectedPaymentMethodId, setSelectedPaymentMethodId] = React.useState<
-    number | undefined
+  const [selectedPaymentMethod, setSelectedPaymentMethod] = React.useState<
+    PaymentMethod | undefined
   >(undefined);
 
   const openPaymentDrawer = React.useCallback(
-    (selectedPaymentMethodId: number | undefined) => {
+    (selectedPaymentMethod: PaymentMethod) => {
       setPaymentDrawerOpen(true);
-      setSelectedPaymentMethodId(selectedPaymentMethodId);
+      setSelectedPaymentMethod(selectedPaymentMethod);
     },
     []
   );
 
   const closePaymentDrawer = React.useCallback(() => {
     setPaymentDrawerOpen(false);
-    setSelectedPaymentMethodId(undefined);
+    setSelectedPaymentMethod(undefined);
     replace('/account/billing');
   }, [replace]);
 
@@ -149,12 +149,12 @@ export const BillingSummary: React.FC<BillingSummaryProps> = (props) => {
       return;
     }
 
-    const paymentMethodId =
-      location?.state?.id ??
-      paymentMethods?.find((paymentMethod) => paymentMethod.is_default)?.id ??
+    const selectedPaymentMethod =
+      location?.state?.paymentMethod ??
+      paymentMethods?.find((payment) => payment.is_default) ??
       undefined;
 
-    openPaymentDrawer(paymentMethodId);
+    openPaymentDrawer(selectedPaymentMethod);
   }, [
     paymentMethods,
     openPaymentDrawer,
@@ -289,7 +289,7 @@ export const BillingSummary: React.FC<BillingSummaryProps> = (props) => {
       </Grid>
       <PaymentDrawer
         paymentMethods={paymentMethods}
-        selectedPaymentMethodId={selectedPaymentMethodId}
+        selectedPaymentMethod={selectedPaymentMethod}
         open={paymentDrawerOpen}
         onClose={closePaymentDrawer}
       />

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
@@ -62,7 +62,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   button: {
     alignSelf: 'flex-end',
     marginLeft: 'auto',
-    marginTop: theme.spacing(2),
   },
   cvvField: {
     width: 100,
@@ -434,7 +433,7 @@ export const PaymentDrawer: React.FC<Props> = (props) => {
               </Grid>
               {hasPaymentMethods ? (
                 <Grid item className={classes.input}>
-                  <Grid item className={classes.button}>
+                  <Grid className={classes.button}>
                     {paymentTooLow || selectedCardExpired ? (
                       <HelpIcon
                         className={classes.helpIcon}
@@ -495,7 +494,7 @@ export const PaymentDrawer: React.FC<Props> = (props) => {
                 </Grid>
               </Grid>
               <Grid item className={classes.input}>
-                <Grid item className={classes.button}>
+                <Grid className={classes.button}>
                   {paymentTooLow || selectedCardExpired ? (
                     <HelpIcon
                       className={classes.helpIcon}

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
@@ -153,14 +153,15 @@ export const PaymentDrawer: React.FC<Props> = (props) => {
     (paymentMethod) => paymentMethod.type === 'credit_card'
   )[0];
 
-  const [usd, setUSD] = React.useState<string>(
-    getMinimumPayment(account?.balance || 0)
-  );
-
   const isCardExpired = Boolean(
     creditCard?.data.expiry && isCreditCardExpired(creditCard?.data.expiry)
   );
 
+  const hasPaymentMethods = paymentMethods && paymentMethods.length > 0;
+
+  const [usd, setUSD] = React.useState<string>(
+    getMinimumPayment(account?.balance || 0)
+  );
   const [cvv, setCVV] = React.useState<string>('');
   const [paymentMethodId, setPaymentMethodId] = React.useState<number>(-1);
   const [dialogOpen, setDialogOpen] = React.useState<boolean>(false);
@@ -346,7 +347,7 @@ export const PaymentDrawer: React.FC<Props> = (props) => {
                 </Typography>
               </Grid>
               <Grid item>
-                {paymentMethods && paymentMethods?.length > 0 ? (
+                {hasPaymentMethods ? (
                   paymentMethods?.map((paymentMethod: PaymentMethod) => {
                     const heading = `${
                       paymentMethod.type !== 'credit_card'
@@ -435,22 +436,24 @@ export const PaymentDrawer: React.FC<Props> = (props) => {
               <Typography>No credit card on file.</Typography>
             </Grid>
           )}
-          <Grid item className={classes.input}>
-            <Grid item className={classes.button}>
-              <Button
-                buttonType="primary"
-                onClick={handleOpenDialog}
-                disabled={paymentTooLow || isCardExpired}
-                tooltipText={
-                  paymentTooLow
-                    ? `Payment amount must be at least ${minimumPayment}.`
-                    : undefined
-                }
-              >
-                Pay Now
-              </Button>
+          {hasPaymentMethods ? (
+            <Grid item className={classes.input}>
+              <Grid item className={classes.button}>
+                <Button
+                  buttonType="primary"
+                  onClick={handleOpenDialog}
+                  disabled={paymentTooLow || isCardExpired}
+                  tooltipText={
+                    paymentTooLow
+                      ? `Payment amount must be at least ${minimumPayment}.`
+                      : undefined
+                  }
+                >
+                  Pay Now
+                </Button>
+              </Grid>
             </Grid>
-          </Grid>
+          ) : null}
           <CreditCardDialog
             error={errorMessage}
             isMakingPayment={submitting}


### PR DESCRIPTION
## Description
- Hide the `Pay Now` button if there are no payment methods on file
- Fix displaying of expired cards
- Show tooltip if a card is expired and display the tooltip on the left side instead of the right

## How to test
- On an account with no payment methods, the `Pay Now` button should not display in the make payment drawer
- If a payment method is expired:
    - The text in the SelectionCard should be red and read `expired`
    - The `Pay Now` button should be disabled and a tooltip should appear on the left side of the button
