### PR TITLE
M3-5418 Swap shared and dedicated cpu tabs

### DIFF
--- a/packages/manager/cypress/integration/linodes/clone-linode.spec.ts
+++ b/packages/manager/cypress/integration/linodes/clone-linode.spec.ts
@@ -6,6 +6,7 @@ import {
 import {
   containsClick,
   containsVisible,
+  fbtClick,
   getClick,
   getVisible,
 } from '../../support/helpers';
@@ -30,6 +31,7 @@ describe('clone linode', () => {
         getVisible('[data-qa-details]').within(() => {
           containsVisible(linode.label);
         });
+        fbtClick('Shared CPU');
         getClick('[id="g6-nanode-1"]');
         getClick('[data-qa-deploy-linode="true"]');
         cy.wait('@cloneLinode').then((xhr) => {

--- a/packages/manager/cypress/integration/linodes/create-linode.spec.ts
+++ b/packages/manager/cypress/integration/linodes/create-linode.spec.ts
@@ -4,6 +4,7 @@ import { assertToast } from '../../support/ui/events';
 import {
   containsClick,
   containsVisible,
+  fbtClick,
   fbtVisible,
   getClick,
 } from '../../support/helpers';
@@ -19,6 +20,7 @@ describe('create linode', () => {
     cy.intercept('POST', '*/linode/instances').as('linodeCreated');
     cy.get('[data-qa-header="Create"]').should('have.text', 'Create');
     containsClick(selectRegionString).type('new {enter}');
+    fbtClick('Shared CPU');
     getClick('[id="g6-nanode-1"]');
     getClick('#linode-label').clear().type(linodeLabel);
     cy.get('#root-password').type(rootpass);

--- a/packages/manager/cypress/integration/linodes/resize-linode.spec.ts
+++ b/packages/manager/cypress/integration/linodes/resize-linode.spec.ts
@@ -1,4 +1,4 @@
-import { createLinode, deleteLinodeById } from '../../support/api/linodes';
+import { createLinode } from '../../support/api/linodes';
 import { containsVisible, fbtVisible, getClick } from '../../support/helpers';
 
 describe('resize linode', () => {
@@ -8,6 +8,7 @@ describe('resize linode', () => {
         'linodeResize'
       );
       cy.visitWithLogin(`/linodes/${linode.id}?resize=true`);
+      cy.findByText('Shared CPU').click({ scrollBehavior: false });
       containsVisible('Linode 2 GB');
       getClick('[id="g6-standard-4"]');
       cy.get('[data-testid="textfield-input"]').type(linode.label);

--- a/packages/manager/cypress/integration/lke/smoke-lke-create.spec.ts
+++ b/packages/manager/cypress/integration/lke/smoke-lke-create.spec.ts
@@ -48,7 +48,7 @@ describe('LKE Create Cluster', () => {
       .type(makeTestLabel());
     containsClick(selectRegionString).type('Newar{enter}');
     cy.get('[id="kubernetes-version"]').type('{enter}');
-
+    fbtClick('Shared CPU');
     addNodes('Linode 2 GB');
 
     // wait for change to reflect on Checkout bar

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -353,7 +353,7 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
         render: () => {
           return (
             <>
-              <Typography data-qa-dedicated className={classes.copy}>
+              <Typography data-qa-standard className={classes.copy}>
                 Dedicated CPU instances are good for full-duty workloads where
                 consistent performance is important.
               </Typography>
@@ -371,7 +371,7 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
         render: () => {
           return (
             <>
-              <Typography data-qa-standard className={classes.copy}>
+              <Typography data-qa-shared className={classes.copy}>
                 Shared CPU instances are good for medium-duty workloads and are
                 a good mix of performance, resources, and price.
               </Typography>

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -348,24 +348,6 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
 
     const shared = [...nanodes, ...standards];
 
-    if (!isEmpty(shared)) {
-      tabs.push({
-        render: () => {
-          return (
-            <>
-              <Typography data-qa-standard className={classes.copy}>
-                Shared CPU instances are good for medium-duty workloads and are
-                a good mix of performance, resources, and price.
-              </Typography>
-              {this.renderPlanContainer(shared)}
-            </>
-          );
-        },
-        title: 'Shared CPU',
-      });
-      tabOrder.push('standard');
-    }
-
     if (!isEmpty(dedicated)) {
       tabs.push({
         render: () => {
@@ -382,6 +364,24 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
         title: 'Dedicated CPU',
       });
       tabOrder.push('dedicated');
+    }
+
+    if (!isEmpty(shared)) {
+      tabs.push({
+        render: () => {
+          return (
+            <>
+              <Typography data-qa-standard className={classes.copy}>
+                Shared CPU instances are good for medium-duty workloads and are
+                a good mix of performance, resources, and price.
+              </Typography>
+              {this.renderPlanContainer(shared)}
+            </>
+          );
+        },
+        title: 'Shared CPU',
+      });
+      tabOrder.push('standard');
     }
 
     if (!isEmpty(highmem)) {

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -363,7 +363,7 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
         },
         title: 'Dedicated CPU',
       });
-      tabOrder.push('standard');
+      tabOrder.push('dedicated');
     }
 
     if (!isEmpty(shared)) {
@@ -381,7 +381,7 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
         },
         title: 'Shared CPU',
       });
-      tabOrder.push('shared');
+      tabOrder.push('standard');
     }
 
     if (!isEmpty(highmem)) {

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -363,7 +363,7 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
         },
         title: 'Dedicated CPU',
       });
-      tabOrder.push('dedicated');
+      tabOrder.push('standard');
     }
 
     if (!isEmpty(shared)) {
@@ -381,7 +381,7 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
         },
         title: 'Shared CPU',
       });
-      tabOrder.push('standard');
+      tabOrder.push('shared');
     }
 
     if (!isEmpty(highmem)) {

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -353,7 +353,7 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
         render: () => {
           return (
             <>
-              <Typography data-qa-standard className={classes.copy}>
+              <Typography data-qa-dedicated className={classes.copy}>
                 Dedicated CPU instances are good for full-duty workloads where
                 consistent performance is important.
               </Typography>
@@ -371,7 +371,7 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
         render: () => {
           return (
             <>
-              <Typography data-qa-shared className={classes.copy}>
+              <Typography data-qa-standard className={classes.copy}>
                 Shared CPU instances are good for medium-duty workloads and are
                 a good mix of performance, resources, and price.
               </Typography>

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
@@ -307,7 +307,7 @@ export class SelectPlanPanel extends React.Component<
         },
         title: 'Dedicated CPU',
       });
-      tabOrder.push('standard');
+      tabOrder.push('dedicated');
     }
 
     if (!isEmpty(shared)) {
@@ -325,7 +325,7 @@ export class SelectPlanPanel extends React.Component<
         },
         title: 'Shared CPU',
       });
-      tabOrder.push('shared');
+      tabOrder.push('standard');
     }
 
     if (!isEmpty(highmem)) {

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
@@ -307,7 +307,7 @@ export class SelectPlanPanel extends React.Component<
         },
         title: 'Dedicated CPU',
       });
-      tabOrder.push('dedicated');
+      tabOrder.push('standard');
     }
 
     if (!isEmpty(shared)) {
@@ -325,7 +325,7 @@ export class SelectPlanPanel extends React.Component<
         },
         title: 'Shared CPU',
       });
-      tabOrder.push('standard');
+      tabOrder.push('shared');
     }
 
     if (!isEmpty(highmem)) {

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
@@ -290,24 +290,6 @@ export class SelectPlanPanel extends React.Component<
 
     const shared = [...nanodes, ...standards];
 
-    if (!isEmpty(shared)) {
-      tabs.push({
-        render: () => {
-          return (
-            <>
-              <Typography data-qa-standard className={classes.copy}>
-                Shared CPU instances are good for medium-duty workloads and are
-                a good mix of performance, resources, and price.
-              </Typography>
-              {this.renderPlanContainer(shared)}
-            </>
-          );
-        },
-        title: 'Shared CPU',
-      });
-      tabOrder.push('standard');
-    }
-
     if (!isEmpty(dedicated)) {
       tabs.push({
         render: () => {
@@ -326,6 +308,24 @@ export class SelectPlanPanel extends React.Component<
         title: 'Dedicated CPU',
       });
       tabOrder.push('dedicated');
+    }
+
+    if (!isEmpty(shared)) {
+      tabs.push({
+        render: () => {
+          return (
+            <>
+              <Typography data-qa-standard className={classes.copy}>
+                Shared CPU instances are good for medium-duty workloads and are
+                a good mix of performance, resources, and price.
+              </Typography>
+              {this.renderPlanContainer(shared)}
+            </>
+          );
+        },
+        title: 'Shared CPU',
+      });
+      tabOrder.push('standard');
     }
 
     if (!isEmpty(highmem)) {

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
@@ -296,7 +296,7 @@ export class SelectPlanPanel extends React.Component<
           return (
             <>
               {isOnCreate && (
-                <Typography data-qa-dedicated className={classes.copy}>
+                <Typography data-qa-standard className={classes.copy}>
                   Dedicated CPU instances are good for full-duty workloads where
                   consistent performance is important.
                 </Typography>
@@ -315,7 +315,7 @@ export class SelectPlanPanel extends React.Component<
         render: () => {
           return (
             <>
-              <Typography data-qa-standard className={classes.copy}>
+              <Typography data-qa-shared className={classes.copy}>
                 Shared CPU instances are good for medium-duty workloads and are
                 a good mix of performance, resources, and price.
               </Typography>

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
@@ -296,7 +296,7 @@ export class SelectPlanPanel extends React.Component<
           return (
             <>
               {isOnCreate && (
-                <Typography data-qa-standard className={classes.copy}>
+                <Typography data-qa-dedicated className={classes.copy}>
                   Dedicated CPU instances are good for full-duty workloads where
                   consistent performance is important.
                 </Typography>
@@ -315,7 +315,7 @@ export class SelectPlanPanel extends React.Component<
         render: () => {
           return (
             <>
-              <Typography data-qa-shared className={classes.copy}>
+              <Typography data-qa-standard className={classes.copy}>
                 Shared CPU instances are good for medium-duty workloads and are
                 a good mix of performance, resources, and price.
               </Typography>


### PR DESCRIPTION
Swaps the order of the “Shared CPU” and “Dedicated CPU” tabs. I was initially going to make dedicated the standard, but api still has shared as standard. 

When you go to Create Linode, Resize Linode, Clone Linode, or Create LKE Cluster “Dedicated CPU” should be the first tab, selected by default. Test creating, resizing, cloning, creating LKE cluster flows as well just to be safe.

I will be adding some test updates to this pr as well. 