### PR TITLE
E2E Domain Records Test Update

### DIFF
--- a/packages/manager/cypress/integration/domains/smoke-create-domain-records.spec.ts
+++ b/packages/manager/cypress/integration/domains/smoke-create-domain-records.spec.ts
@@ -59,7 +59,7 @@ const createRecords = () => [
     ],
   },
   {
-    name: 'Add a SRV Record',
+    name: 'Add an SRV Record',
     tableAriaLabel: 'List of Domains SRV Record',
     fields: [
       {


### PR DESCRIPTION
## Description
This change was needed because of some recent ui changes to this page

**What does this PR do?**
A small domain records e2e test update

## How to test
- `yarn up` in one terminal
- `yarn cy:e2e -s ./cypress/integration/domians/smoke-create-domain-records.spec.ts` in another
- Result should be "✔  All specs passed!"

## Make sure your .env contains:
```
REACT_APP_LOGIN_ROOT
REACT_APP_API_ROOT
REACT_APP_APP_ROOT
REACT_APP_LAUNCH_DARKLY_ID
REACT_APP_CLIENT_ID
MANAGER_OAUTH
```