### PR TITLE
M3-5408: Add EU Contract Component to creation flows

### DIFF
--- a/packages/manager/src/components/CheckoutBar/CheckoutBar.tsx
+++ b/packages/manager/src/components/CheckoutBar/CheckoutBar.tsx
@@ -14,6 +14,7 @@ interface Props {
   submitText?: string;
   children?: JSX.Element;
   footer?: JSX.Element;
+  agreement?: JSX.Element;
 }
 
 type CombinedProps = Props;
@@ -30,6 +31,7 @@ const CheckoutBar: React.FC<CombinedProps> = (props) => {
     priceHelperText,
     submitText,
     footer,
+    agreement,
   } = props;
 
   const price = calculatedPrice ?? 0;
@@ -52,7 +54,7 @@ const CheckoutBar: React.FC<CombinedProps> = (props) => {
           )}
         </div>
       }
-
+      {agreement ? agreement : null}
       <div className={classes.checkoutSection}>
         <Button
           buttonType="primary"

--- a/packages/manager/src/features/Account/Agreements/EUAgreementCheckbox.tsx
+++ b/packages/manager/src/features/Account/Agreements/EUAgreementCheckbox.tsx
@@ -5,6 +5,8 @@ import Typography from 'src/components/core/Typography';
 import Link from 'src/components/Link';
 
 interface Props {
+  className?: string;
+  centerCheckbox?: boolean;
   checked: boolean;
   onChange: (
     event: React.ChangeEvent<HTMLInputElement>,
@@ -13,10 +15,15 @@ interface Props {
 }
 
 const EUAgreementCheckbox: React.FC<Props> = (props) => {
-  const { checked, onChange } = props;
+  const { checked, onChange, className, centerCheckbox } = props;
 
   return (
-    <Box display="flex" flexDirection="row" alignItems="flex-start">
+    <Box
+      display="flex"
+      flexDirection="row"
+      alignItems={centerCheckbox ? 'center' : 'flex-start'}
+      className={className}
+    >
       <CheckBox
         checked={checked}
         onChange={onChange}

--- a/packages/manager/src/features/Images/ImageUpload.tsx
+++ b/packages/manager/src/features/Images/ImageUpload.tsx
@@ -23,7 +23,9 @@ import { redirectToLogin } from 'src/session';
 import { ApplicationState } from 'src/store';
 import { setPendingUpload } from 'src/store/pendingUpload';
 import { getErrorMap } from 'src/utilities/errorUtils';
+import { isEURegion } from 'src/utilities/formatRegion';
 import { wrapInQuotes } from 'src/utilities/stringUtils';
+import EUAgreementCheckbox from '../Account/Agreements/EUAgreementCheckbox';
 import ImagesPricingCopy from './ImagesCreate/ImagesPricingCopy';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -45,6 +47,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   cliModalButton: {
     ...theme.applyLinkStyles,
     fontWeight: 700,
+  },
+  agreement: {
+    marginTop: theme.spacing(),
   },
 }));
 export interface Props {
@@ -189,6 +194,15 @@ export const ImageUpload: React.FC<Props> = (props) => {
             selectedID={region}
             disabled={!canCreateImage}
           />
+
+          {isEURegion(region) ? (
+            <EUAgreementCheckbox
+              checked={false}
+              onChange={() => null}
+              centerCheckbox
+              className={classes.agreement}
+            />
+          ) : null}
 
           <Typography className={classes.helperText}>
             For fastest initial upload, select the region that is geographically

--- a/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
@@ -1,4 +1,4 @@
-import { Disk, getLinodeDisks } from '@linode/api-v4/lib/linodes';
+import { Disk, getLinodeDisks, Linode } from '@linode/api-v4/lib/linodes';
 import { APIError } from '@linode/api-v4/lib/types';
 import { makeStyles } from '@material-ui/styles';
 import { useSnackbar } from 'notistack';
@@ -6,7 +6,6 @@ import { equals } from 'ramda';
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 import { compose } from 'recompose';
-import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import Paper from 'src/components/core/Paper';
 import { Theme } from 'src/components/core/styles';
@@ -23,6 +22,9 @@ import ImagesPricingCopy from './ImagesPricingCopy';
 import withImages, {
   ImagesDispatch,
 } from 'src/containers/withImages.container';
+import Box from 'src/components/core/Box';
+import EUAgreementCheckbox from 'src/features/Account/Agreements/EUAgreementCheckbox';
+import { isEURegion } from 'src/utilities/formatRegion';
 
 const useStyles = makeStyles((theme: Theme) => ({
   helperText: {
@@ -35,6 +37,16 @@ const useStyles = makeStyles((theme: Theme) => ({
     '& .MuiFormHelperText-root': {
       marginBottom: theme.spacing(2),
     },
+  },
+  agreement: {
+    maxWidth: '80%',
+    [theme.breakpoints.down('sm')]: {
+      maxWidth: 'unset',
+    },
+  },
+  buttonGroup: {
+    marginTop: theme.spacing(3),
+    marginBottom: theme.spacing(2),
   },
 }));
 
@@ -61,7 +73,7 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
   const { data: profile } = useProfile();
   const { data: grants } = useGrants();
 
-  const [selectedLinode, setSelectedLinode] = React.useState<number>(0);
+  const [selectedLinode, setSelectedLinode] = React.useState<Linode>();
   const [selectedDisk, setSelectedDisk] = React.useState<string | null>('');
   const [disks, setDisks] = React.useState<Disk[]>([]);
   const [notice, setNotice] = React.useState<string | undefined>();
@@ -100,16 +112,15 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
       });
   };
 
-  const changeSelectedLinode = (linodeId: number | null) => {
-    const linodeID = linodeId ?? 0;
-    fetchLinodeDisksOnLinodeChange(linodeID);
-    setSelectedLinode(linodeID);
+  const changeSelectedLinode = (linode: Linode) => {
+    fetchLinodeDisksOnLinodeChange(linode.id);
+    setSelectedLinode(linode);
   };
 
-  const handleLinodeChange = (linodeID: number) => {
+  const handleLinodeChange = (linode: Linode) => {
     // Clear any errors
     setErrors(undefined);
-    changeSelectedLinode(linodeID);
+    changeSelectedLinode(linode);
   };
 
   const handleDiskChange = (diskID: string | null) => {
@@ -192,10 +203,10 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
       {notice ? <Notice success text={notice} data-qa-notice /> : null}
       <ImagesPricingCopy type="captureImage" />
       <LinodeSelect
-        selectedLinode={selectedLinode}
+        selectedLinode={selectedLinode?.id || null}
         linodeError={linodeError}
         disabled={!canCreateImage}
-        handleChange={(linode) => handleLinodeChange(linode.id)}
+        handleChange={(linode) => handleLinodeChange(linode)}
         filterCondition={(linode) =>
           availableLinodesToImagize
             ? availableLinodesToImagize.includes(linode.id)
@@ -210,50 +221,56 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
         ]}
       />
 
-      <>
-        <DiskSelect
-          selectedDisk={selectedDisk}
-          disks={disks}
-          diskError={diskError}
-          handleChange={handleDiskChange}
-          updateFor={[disks, selectedDisk, diskError, classes]}
-          disabled={!canCreateImage}
-          data-qa-disk-select
-        />
-        <Typography className={classes.helperText} variant="body1">
-          Linode Images cannot be created if you are using raw disks or disks
-          that have been formatted using custom filesystems.
-        </Typography>
-      </>
-
-      <>
-        <TextField
-          label="Label"
-          value={label}
-          onChange={changeLabel}
-          error={Boolean(labelError)}
-          errorText={labelError}
-          disabled={!canCreateImage}
-          data-qa-image-label
-        />
-
-        <TextField
-          label="Description"
-          multiline
-          rows={4}
-          value={description}
-          onChange={changeDescription}
-          error={Boolean(descriptionError)}
-          errorText={descriptionError}
-          disabled={!canCreateImage}
-          data-qa-image-description
-        />
-      </>
-
-      <ActionsPanel
-        style={{ marginTop: 16 }}
-        updateFor={[label, description, requirementsMet, classes, submitting]}
+      <DiskSelect
+        selectedDisk={selectedDisk}
+        disks={disks}
+        diskError={diskError}
+        handleChange={handleDiskChange}
+        updateFor={[disks, selectedDisk, diskError, classes]}
+        disabled={!canCreateImage}
+        data-qa-disk-select
+      />
+      <Typography className={classes.helperText} variant="body1">
+        Linode Images cannot be created if you are using raw disks or disks that
+        have been formatted using custom filesystems.
+      </Typography>
+      <TextField
+        label="Label"
+        value={label}
+        onChange={changeLabel}
+        error={Boolean(labelError)}
+        errorText={labelError}
+        disabled={!canCreateImage}
+        data-qa-image-label
+      />
+      <TextField
+        label="Description"
+        multiline
+        rows={4}
+        value={description}
+        onChange={changeDescription}
+        error={Boolean(descriptionError)}
+        errorText={descriptionError}
+        disabled={!canCreateImage}
+        data-qa-image-description
+      />
+      <Box
+        display="flex"
+        justifyContent={
+          isEURegion(selectedLinode?.region) ? 'space-between' : 'flex-end'
+        }
+        alignItems="center"
+        flexWrap="wrap"
+        className={classes.buttonGroup}
       >
+        {isEURegion(selectedLinode?.region) ? (
+          <EUAgreementCheckbox
+            checked={false}
+            onChange={() => null}
+            className={classes.agreement}
+            centerCheckbox
+          />
+        ) : null}
         <Button
           onClick={onSubmit}
           disabled={requirementsMet || !canCreateImage}
@@ -263,7 +280,7 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
         >
           Create Image
         </Button>
-      </ActionsPanel>
+      </Box>
     </Paper>
   );
 };

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -340,7 +340,9 @@ export const CreateCluster: React.FC<CombinedProps> = (props) => {
           updatePool={updatePool}
           removePool={removePool}
           typesData={typesData || []}
+          region={selectedRegion}
           updateFor={[
+            selectedRegion,
             nodePools,
             submitting,
             typesData,

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.test.tsx
@@ -15,6 +15,7 @@ const props: Props = {
   removePool: jest.fn(),
   createCluster: jest.fn(),
   typesData: types as ExtendedType[],
+  region: undefined,
 };
 
 const renderComponent = (_props: Props) =>

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
@@ -2,7 +2,9 @@ import * as React from 'react';
 import CheckoutBar from 'src/components/CheckoutBar';
 import Notice from 'src/components/Notice';
 import renderGuard from 'src/components/RenderGuard';
+import EUAgreementCheckbox from 'src/features/Account/Agreements/EUAgreementCheckbox';
 import { ExtendedType } from 'src/store/linodeType/linodeType.reducer';
+import { isEURegion } from 'src/utilities/formatRegion';
 import { getTotalClusterPrice, nodeWarning } from '../kubeUtils';
 import { PoolNodeWithPrice } from '../types';
 import NodePoolSummary from './NodePoolSummary';
@@ -14,6 +16,7 @@ export interface Props {
   createCluster: () => void;
   updatePool: (poolIdx: number, updatedPool: PoolNodeWithPrice) => void;
   removePool: (poolIdx: number) => void;
+  region: string | undefined;
 }
 
 export const KubeCheckoutBar: React.FC<Props> = (props) => {
@@ -24,6 +27,7 @@ export const KubeCheckoutBar: React.FC<Props> = (props) => {
     removePool,
     typesData,
     updatePool,
+    region,
   } = props;
 
   // Show a warning if any of the pools have fewer than 3 nodes
@@ -38,6 +42,11 @@ export const KubeCheckoutBar: React.FC<Props> = (props) => {
       disabled={pools.length < 1}
       onDeploy={createCluster}
       submitText={'Create Cluster'}
+      agreement={
+        isEURegion(region) ? (
+          <EUAgreementCheckbox checked={false} onChange={() => null} />
+        ) : undefined
+      }
     >
       <>
         {pools.map((thisPool, idx) => (

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -44,9 +44,11 @@ import {
   WithNodeBalancerActions,
 } from 'src/store/nodeBalancer/nodeBalancer.containers';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import { isEURegion } from 'src/utilities/formatRegion';
 import { sendCreateNodeBalancerEvent } from 'src/utilities/ga';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
+import EUAgreementCheckbox from '../Account/Agreements/EUAgreementCheckbox';
 import NodeBalancerConfigPanel from './NodeBalancerConfigPanel';
 import {
   createNewNodeBalancerConfig,
@@ -705,6 +707,11 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
               calculatedPrice={10}
               disabled={this.state.submitting || this.disabled}
               submitText="Create NodeBalancer"
+              agreement={
+                isEURegion(nodeBalancerFields.region) ? (
+                  <EUAgreementCheckbox checked={false} onChange={() => null} />
+                ) : undefined
+              }
             >
               <DisplaySectionList displaySections={displaySections} />
             </CheckoutBar>

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.test.tsx
@@ -14,7 +14,6 @@ describe('CreateBucketForm', () => {
       getBucket={jest.fn()}
       bucketsData={[]}
       bucketsLoading={false}
-      classes={{ root: '', textWrapper: '' }}
       isRestrictedUser={false}
     />
   );

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.tsx
@@ -3,12 +3,7 @@ import { ObjectStorageBucket } from '@linode/api-v4/lib/object-storage';
 import { CreateBucketSchema } from '@linode/validation/lib/buckets.schema';
 import * as React from 'react';
 import Form from 'src/components/core/Form';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles,
-} from 'src/components/core/styles';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
 import bucketContainer, {
@@ -29,15 +24,18 @@ import { confirmObjectStorage } from '../utilities';
 import ClusterSelect from './ClusterSelect';
 import { useAccountSettings } from 'src/queries/accountSettings';
 import { compose } from 'recompose';
+import { isEURegion } from 'src/utilities/formatRegion';
+import EUAgreementCheckbox from 'src/features/Account/Agreements/EUAgreementCheckbox';
 
-type ClassNames = 'root' | 'textWrapper';
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {},
-    textWrapper: {
-      marginBottom: theme.spacing(1) + 2,
-    },
-  });
+const useStyles = makeStyles((theme: Theme) => ({
+  textWrapper: {
+    marginBottom: theme.spacing(1) + 2,
+  },
+  agreement: {
+    marginTop: theme.spacing(3),
+    marginButton: theme.spacing(3),
+  },
+}));
 
 interface Props {
   isRestrictedUser: boolean;
@@ -45,10 +43,7 @@ interface Props {
   onSuccess: (bucketLabel: string) => void;
 }
 
-type CombinedProps = Props &
-  BucketContainerProps &
-  BucketsRequests &
-  WithStyles<ClassNames>;
+type CombinedProps = Props & BucketContainerProps & BucketsRequests;
 
 export const CreateBucketForm: React.FC<CombinedProps> = (props) => {
   const {
@@ -58,6 +53,8 @@ export const CreateBucketForm: React.FC<CombinedProps> = (props) => {
     createBucket,
     bucketsData,
   } = props;
+
+  const classes = useStyles();
 
   const [dialogOpen, setDialogOpen] = React.useState<boolean>(false);
 
@@ -189,6 +186,14 @@ export const CreateBucketForm: React.FC<CombinedProps> = (props) => {
                 disabled={isRestrictedUser}
               />
 
+              {isEURegion(values.cluster) ? (
+                <EUAgreementCheckbox
+                  className={classes.agreement}
+                  checked={false}
+                  onChange={() => null}
+                />
+              ) : null}
+
               <BucketsActionPanel
                 data-qa-bucket-actions-panel
                 isSubmitting={isSubmitting}
@@ -222,10 +227,7 @@ const initialValues: FormState = {
   cluster: '',
 };
 
-const styled = withStyles(styles);
-
 const enhanced = compose<CombinedProps, Props>(
-  styled,
   bucketRequestsContainer,
   bucketContainer
 );

--- a/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
@@ -44,6 +44,8 @@ import SizeField from '../VolumeDrawer/SizeField';
 import { useGrants, useProfile } from 'src/queries/profile';
 import useFlags from 'src/hooks/useFlags';
 import LinodeSelect from 'src/features/linodes/LinodeSelect';
+import { isEURegion } from 'src/utilities/formatRegion';
+import EUAgreementCheckbox from 'src/features/Account/Agreements/EUAgreementCheckbox';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -56,10 +58,19 @@ const useStyles = makeStyles((theme: Theme) => ({
   notice: {
     borderColor: theme.color.green,
   },
-  button: {
+  buttonGroup: {
     marginTop: theme.spacing(3),
+  },
+  agreement: {
+    maxWidth: '80%',
     [theme.breakpoints.down('sm')]: {
-      marginRight: theme.spacing(),
+      maxWidth: 'unset',
+    },
+  },
+  button: {
+    maxHeight: 34,
+    [theme.breakpoints.down('sm')]: {
+      marginTop: theme.spacing(2),
     },
   },
 }));
@@ -315,22 +326,35 @@ const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
                     }
                     value={values.tags}
                   />
-                </Paper>
-                <Box
-                  display="flex"
-                  justifyContent="flex-end"
-                  className={classes.button}
-                >
-                  <Button
-                    buttonType="primary"
-                    disabled={disabled}
-                    loading={isSubmitting}
-                    onClick={() => handleSubmit()}
-                    data-qa-deploy-linode
+                  <Box
+                    display="flex"
+                    justifyContent={
+                      isEURegion(values.region) ? 'space-between' : 'flex-end'
+                    }
+                    alignItems="center"
+                    flexWrap="wrap"
+                    className={classes.buttonGroup}
                   >
-                    Create Volume
-                  </Button>
-                </Box>
+                    {isEURegion(values.region) ? (
+                      <EUAgreementCheckbox
+                        checked={false}
+                        onChange={() => null}
+                        className={classes.agreement}
+                        centerCheckbox
+                      />
+                    ) : null}
+                    <Button
+                      buttonType="primary"
+                      disabled={disabled}
+                      loading={isSubmitting}
+                      onClick={() => handleSubmit()}
+                      data-qa-deploy-linode
+                      className={classes.button}
+                    >
+                      Create Volume
+                    </Button>
+                  </Box>
+                </Paper>
               </Grid>
             </Grid>
           </Form>

--- a/packages/manager/src/features/linodes/CloneLanding/Details.tsx
+++ b/packages/manager/src/features/linodes/CloneLanding/Details.tsx
@@ -9,7 +9,9 @@ import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Notice from 'src/components/Notice';
+import EUAgreementCheckbox from 'src/features/Account/Agreements/EUAgreementCheckbox';
 import { formatRegion } from 'src/utilities';
+import { isEURegion } from 'src/utilities/formatRegion';
 import LinodeSelect from '../LinodeSelect';
 import {
   EstimatedCloneTimeMode,
@@ -67,6 +69,9 @@ const useStyles = makeStyles((theme: Theme) => ({
       textDecoration: 'underline',
       color: theme.color.red,
     },
+  },
+  agreement: {
+    marginTop: theme.spacing(2),
   },
 }));
 
@@ -289,6 +294,14 @@ export const Configs: React.FC<Props> = (props) => {
           </a>
         </Typography>
       )}
+
+      {isEURegion(selectedLinodeRegion) ? (
+        <EUAgreementCheckbox
+          className={classes.agreement}
+          checked={false}
+          onChange={() => null}
+        />
+      ) : null}
 
       <Button
         className={classes.submitButton}

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -68,6 +68,8 @@ import {
   WithTypesProps,
   WithTypesRegionsAndImages,
 } from './types';
+import EUAgreementCheckbox from 'src/features/Account/Agreements/EUAgreementCheckbox';
+import { isEURegion } from 'src/utilities/formatRegion';
 
 type ClassNames = 'root' | 'form' | 'stackScriptWrapper' | 'imageSelect';
 
@@ -672,6 +674,11 @@ export class LinodeCreate extends React.PureComponent<
               <SMTPRestrictionText>
                 {({ text }) => <div style={{ marginTop: 16 }}>{text}</div>}
               </SMTPRestrictionText>
+            }
+            agreement={
+              isEURegion(this.props.selectedRegionID) ? (
+                <EUAgreementCheckbox checked={false} onChange={() => null} />
+              ) : undefined
             }
           >
             <DisplaySectionList displaySections={displaySections} />

--- a/packages/manager/src/features/linodes/MigrateLanding/MigrateLinode.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/MigrateLinode.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import { connect, MapStateToProps } from 'react-redux';
 import { compose } from 'recompose';
 import Button from 'src/components/Button';
+import Box from 'src/components/core/Box';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Dialog from 'src/components/Dialog';
@@ -13,6 +14,7 @@ import HelpIcon from 'src/components/HelpIcon';
 import Notice from 'src/components/Notice';
 import { MBpsInterDC } from 'src/constants';
 import { resetEventsPolling } from 'src/eventsPolling';
+import EUAgreementCheckbox from 'src/features/Account/Agreements/EUAgreementCheckbox';
 import { addUsedDiskSpace } from 'src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskSpace';
 import { displayType } from 'src/features/linodes/presentation';
 import useExtendedLinode from 'src/hooks/useExtendedLinode';
@@ -21,6 +23,7 @@ import { useTypes } from 'src/hooks/useTypes';
 import { useRegionsQuery } from 'src/queries/regions';
 import { ApplicationState } from 'src/store';
 import { formatDate } from 'src/utilities/formatDate';
+import { isEURegion } from 'src/utilities/formatRegion';
 import { sendMigrationInitiatedEvent } from 'src/utilities/ga';
 import getLinodeDescription from 'src/utilities/getLinodeDescription';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
@@ -39,6 +42,23 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   vlanHelperText: {
     marginTop: theme.spacing() / 2,
+  },
+  buttonGroup: {
+    marginTop: theme.spacing(3),
+    [theme.breakpoints.down('sm')]: {
+      flexWrap: 'wrap',
+    },
+  },
+  agreement: {
+    maxWidth: '70%',
+    [theme.breakpoints.down('sm')]: {
+      maxWidth: 'unset',
+    },
+  },
+  button: {
+    [theme.breakpoints.down('sm')]: {
+      marginTop: theme.spacing(2),
+    },
   },
 }));
 
@@ -193,17 +213,33 @@ const MigrateLanding: React.FC<CombinedProps> = (props) => {
         handleSelectRegion={handleSelectRegion}
         selectedRegion={selectedRegion}
       />
-      <div className={classes.actionWrapper}>
+      <Box
+        display="flex"
+        justifyContent={
+          isEURegion(selectedRegion) ? 'space-between' : 'flex-end'
+        }
+        alignItems="center"
+        className={classes.buttonGroup}
+      >
+        {isEURegion(selectedRegion) ? (
+          <EUAgreementCheckbox
+            checked={false}
+            onChange={() => null}
+            className={classes.agreement}
+            centerCheckbox
+          />
+        ) : null}
         <Button
           buttonType="primary"
           disabled={!!disabledText || !hasConfirmed}
           loading={isLoading}
           onClick={handleMigrate}
+          className={classes.button}
         >
           Enter Migration Queue
         </Button>
         {!!disabledText && <HelpIcon text={disabledText} />}
-      </div>
+      </Box>
     </Dialog>
   );
 };

--- a/packages/manager/src/utilities/formatRegion.ts
+++ b/packages/manager/src/utilities/formatRegion.ts
@@ -49,3 +49,6 @@ export const getHumanReadableCountry = (regionSlug: string) => {
 
 export const formatObjectStorageCluster = (clusterId: string) =>
   objectStorageClusterDisplay[clusterId] || '';
+
+export const isEURegion = (region: string | null | undefined) =>
+  region?.match('^eu');


### PR DESCRIPTION
## Description

- Adds the `<EUAgreementCheckbox />` component to the following creation flows
  - Linode Create
  - LKE Cluster Create
  - NodeBalancer Create
  - Volume Create
  - OBJ Bucket Create
  - Image Create
  - Linode Migrate
  - Linode Disk/Config Clone
- The  `<EUAgreementCheckbox />` component should only be rendered when a user chooses an EU region as the targeted region. 
- Adds `isEURegion(region: string): boolean` function to help conditionally render component

## How to test

- For now, just check for styling and rendering when choosing an EU region, functionality is to come
