### PR TITLE
updates for tab change that I forgot in previous pr

### DIFF
--- a/packages/manager/cypress/integration/images/create-linode-from-image.spec.ts
+++ b/packages/manager/cypress/integration/images/create-linode-from-image.spec.ts
@@ -50,6 +50,7 @@ const createLinodeWithImageMock = () => {
     containsClick('Select a Region');
   });
   containsClick(regionSelect);
+  fbtClick('Shared CPU');
   getClick('[id="g6-nanode-1"][type="radio"]');
   cy.get('[id="root-password"]').type(rootpass);
   getClick('[data-qa-deploy-linode="true"]');

--- a/packages/manager/cypress/integration/stackscripts/stackscripts.spec.ts
+++ b/packages/manager/cypress/integration/stackscripts/stackscripts.spec.ts
@@ -11,6 +11,7 @@ const createLinode = () => {
   const password = strings.randomPass();
   fbtClick('Select a Region');
   fbtClick('Newark, NJ');
+  fbtClick('Shared CPU');
   getClick('[id="g6-nanode-1"]');
   getClick('[id="root-password"]').type(password);
   getClick('[data-qa-deploy-linode]');


### PR DESCRIPTION
## Description
This change is needed because of the tab swap pr

**What does this PR do?**
small stackscripts and create-linode-from-image e2e test updates

## How to test
- `yarn up` in one terminal
- `yarn cy:e2e -s ./cypress/integration/stackscripts/stackscripts.spec.ts` in another
-  Then `yarn cy:e2e -s ./cypress/integration/images/create-linode-from-image.spec.ts` in another
- Result should be "✔  All specs passed!"

## Make sure your .env contains:
```
REACT_APP_LOGIN_ROOT
REACT_APP_API_ROOT
REACT_APP_APP_ROOT
REACT_APP_LAUNCH_DARKLY_ID
REACT_APP_CLIENT_ID
MANAGER_OAUTH
```