### PR TITLE
M3-5427: Vertically center icons and texts in dropdown

### DIFF
--- a/packages/manager/src/components/EnhancedSelect/Select.styles.ts
+++ b/packages/manager/src/components/EnhancedSelect/Select.styles.ts
@@ -111,6 +111,9 @@ export const styles = (theme: Theme) =>
         cursor: 'pointer',
         padding: '10px',
         fontSize: '0.9rem',
+        '& svg': {
+          marginTop: 2,
+        },
       },
       '& .react-select__option--is-focused': {
         backgroundColor: theme.palette.primary.main,

--- a/packages/manager/src/components/EnhancedSelect/Select.styles.ts
+++ b/packages/manager/src/components/EnhancedSelect/Select.styles.ts
@@ -129,7 +129,6 @@ export const styles = (theme: Theme) =>
       '& .react-select__single-value': {
         color: theme.palette.text.primary,
         overflow: 'hidden',
-        paddingBottom: 1,
       },
       '& .react-select__indicator-separator': {
         display: 'none',
@@ -458,7 +457,6 @@ export const reactSelectStyles = (theme: Theme) => ({
     ...base,
     color: theme.palette.text.primary,
     overflow: 'hidden',
-    paddingBottom: 1,
   }),
   indicatorSeparator: (base: any) => ({
     ...base,

--- a/packages/manager/src/components/EnhancedSelect/components/SingleValue.tsx
+++ b/packages/manager/src/components/EnhancedSelect/components/SingleValue.tsx
@@ -11,7 +11,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   icon: {
     fontSize: '1.8em',
-    marginTop: 2,
+    height: 24,
     marginLeft: 6,
     marginRight: theme.spacing(),
     position: 'absolute',

--- a/packages/manager/src/components/EnhancedSelect/components/SingleValue.tsx
+++ b/packages/manager/src/components/EnhancedSelect/components/SingleValue.tsx
@@ -10,9 +10,10 @@ const useStyles = makeStyles((theme: Theme) => ({
     paddingLeft: `45px !important`,
   },
   icon: {
-    marginLeft: theme.spacing(1) - 2,
-    marginRight: theme.spacing(1),
     fontSize: '1.8em',
+    marginTop: 2,
+    marginLeft: 6,
+    marginRight: theme.spacing(),
     position: 'absolute',
   },
 }));

--- a/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionSelect.tsx
+++ b/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionSelect.tsx
@@ -57,7 +57,6 @@ export const selectStyles = {
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
     '& svg': {
-      // marginTop: 2,
       '& g': {
         // Super hacky fix for Firefox rendering of some flag icons that had a clip-path property.
         clipPath: 'none !important' as 'none',

--- a/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionSelect.tsx
+++ b/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionSelect.tsx
@@ -57,6 +57,7 @@ export const selectStyles = {
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
     '& svg': {
+      // marginTop: 2,
       '& g': {
         // Super hacky fix for Firefox rendering of some flag icons that had a clip-path property.
         clipPath: 'none !important' as 'none',

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -81,7 +81,6 @@ const useStyles = makeStyles((theme: Theme) => ({
       fontWeight: 500,
       lineHeight: '1.43rem',
       margin: 0,
-      marginBottom: 4,
       maxWidth: '100%',
     },
     '& .MuiInput-root': {


### PR DESCRIPTION
## Description

Remove spacing related styles that were throwing off the vertical alignment

## How to test

Check dropdown components throughout the app
