### PR TITLE
M3-5428: Refactor getIcon() to prevent crashing bug on /account page

### DIFF
--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCard.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCard.tsx
@@ -55,7 +55,11 @@ interface Props {
 }
 
 export const getIcon = (type: CardType | undefined) => {
-  return !type ? GenericCardIcon : iconMap[type];
+  if (!type || !iconMap[type]) {
+    return GenericCardIcon;
+  }
+
+  return iconMap[type];
 };
 
 export type CombinedProps = Props;


### PR DESCRIPTION
## Description
Credit card types not accounted for in the `iconMap` were causing a crashing bug on the `/account` page; this PR refactors `getIcon()` to return the generic icon if the `type` is undefined _or_ not found in the `iconMap`.

## How to test
Reach out for the specific account to test this on
