### PR TITLE
M3-5317: Preserve Ticket Reply in LocalStorage

### DIFF
--- a/packages/manager/src/store/authentication/authentication.helpers.ts
+++ b/packages/manager/src/store/authentication/authentication.helpers.ts
@@ -2,6 +2,7 @@ import {
   authentication,
   stackScriptInProgress,
   supportText,
+  ticketReply,
 } from 'src/utilities/storage';
 
 export const clearLocalStorage = () => {
@@ -16,6 +17,7 @@ export const clearUserInput = () => {
   // Support ticket title/description.
 
   supportText.set({ title: '', description: '' });
+  ticketReply.set({ ticketId: -1, text: ''});
   stackScriptInProgress.set({
     id: '',
     label: '',

--- a/packages/manager/src/utilities/storage.ts
+++ b/packages/manager/src/utilities/storage.ts
@@ -47,6 +47,7 @@ const NONCE = 'authentication/nonce';
 const SCOPES = 'authentication/scopes';
 const EXPIRE = 'authentication/expire';
 const SUPPORT = 'support';
+const TICKET = 'ticket';
 const STACKSCRIPT = 'stackscript';
 const DEV_TOOLS_ENV = 'devTools/env';
 
@@ -60,6 +61,11 @@ interface AuthGetAndSet {
 interface SupportText {
   title: string;
   description: string;
+}
+
+interface TicketReply {
+  text: string;
+  ticketId: number;
 }
 
 interface StackScriptData extends StackScriptPayload {
@@ -95,6 +101,10 @@ export interface Storage {
   supportText: {
     get: () => SupportText;
     set: (v: SupportText) => void;
+  };
+  ticketReply: {
+    get: () => TicketReply;
+    set: (v: TicketReply) => void;
   };
   stackScriptInProgress: {
     get: () => StackScriptData;
@@ -152,6 +162,10 @@ export const storage: Storage = {
     get: () => getStorage(SUPPORT, { title: '', description: '' }),
     set: (v) => setStorage(SUPPORT, JSON.stringify(v)),
   },
+  ticketReply: {
+    get: () => getStorage(TICKET, { text: '' }),
+    set: (v) => setStorage(TICKET, JSON.stringify(v)),
+  },
   stackScriptInProgress: {
     get: () =>
       getStorage(STACKSCRIPT, {
@@ -177,6 +191,7 @@ export const {
   BackupsCtaDismissed,
   stackScriptInProgress,
   supportText,
+  ticketReply,
 } = storage;
 
 // Only return these if the dev tools are enabled and we're in development mode.


### PR DESCRIPTION
## Description

When a user starts to write a reply to a support ticket the ticket ID and the user's response is stored in LocalStorage. This mimics the behavior of opening a support ticket. Unlike opening a support ticket a user may have multiple ticket replies to edit. When a user opens a ticket the application checks to see if `LocalStorage` has an entry in the `ticketReply` entry that has a `ticketId` that matches the support ticket the user is replying to. If the `ticketId` matches then it will prefill the reply text box with what is stored in `LocalStorage`. If the `ticketId` does not match what the user types will overwrite what is currently stored in `LocalStorage`.

## How to test

There are 4 key functionalities to test

- Navigate to a support ticket and start to type a reply then leaving before submitting. Navigate to that same support ticket the text box should be prefilled with the text that was written before you navigated away.
- Navigate to a support ticket and start to type a reply then leaving before submitting. Navigate to a different support ticket. The text box should not be prefilled with any text from the previous support ticket.
- Navigate to a support ticket and start to type a reply then without submitting the reply allow the session to expire. Start a new session and navigate to the same support ticket. The text box should be prefilled with the same text that was there before the session expired.
- Navigate to a support ticket and start to type a reply. Then without submitting the reply manually log out. Log back in and navigate to the same support ticket. The text box should not contain any of the text that was previously there before you logged out.
