### PR TITLE
M3-5429: Add feature flag for post-9/1 Images pricing copy & update "Upload Image" tab

### DIFF
--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -37,6 +37,7 @@ export interface Flags {
   imagesPricingCopy: ImagesPricingCopy;
   referralBannerText: ReferralBannerText;
   blockStorageAvailability: boolean;
+  imagesPriceInfo: boolean;
 }
 
 type PromotionalOfferFeature =

--- a/packages/manager/src/features/Images/ImageUpload.tsx
+++ b/packages/manager/src/features/Images/ImageUpload.tsx
@@ -25,6 +25,7 @@ import { setPendingUpload } from 'src/store/pendingUpload';
 import { getErrorMap } from 'src/utilities/errorUtils';
 import { wrapInQuotes } from 'src/utilities/stringUtils';
 import ImagesPricingCopy from './ImagesCreate/ImagesPricingCopy';
+import { useFlags } from 'src/hooks/useFlags';
 
 const useStyles = makeStyles((theme: Theme) => ({
   container: {
@@ -56,10 +57,13 @@ export interface Props {
 
 export const ImageUpload: React.FC<Props> = (props) => {
   const { label, description, changeLabel, changeDescription } = props;
+
   const { data: profile } = useProfile();
   const { data: grants } = useGrants();
   const classes = useStyles();
   const { push } = useHistory();
+  const flags = useFlags();
+
   const [region, setRegion] = React.useState<string>('');
   const dispatch: Dispatch = useDispatch();
   const regions = useRegionsQuery().data ?? [];
@@ -196,6 +200,14 @@ export const ImageUpload: React.FC<Props> = (props) => {
             to other regions. Image files must be raw disk images (.img)
             compressed using gzip (.gz). The maximum file size is 5 GB
             (compressed).
+            {flags.imagesPriceInfo ? (
+              <>
+                <br />
+                <br />
+                Custom Images are billed at $0.10/GB per month based on the
+                uncompressed image size.
+              </>
+            ) : null}
           </Typography>
 
           <FileUploader

--- a/packages/manager/src/hooks/useFlags.ts
+++ b/packages/manager/src/hooks/useFlags.ts
@@ -30,6 +30,11 @@ export const useFlags = () => {
     // !!! Override the CMR flag so that it's officially "released" !!!!
     // @todo: clean up all conditional logic based on this flag.
     cmr: true,
+    // imagesPricingCopy: {
+    //   captureImage: '',
+    //   uploadImage: '',
+    // },
+    // imagesPriceInfo: false,
     ...mockFlags,
   };
 };

--- a/packages/manager/src/hooks/useFlags.ts
+++ b/packages/manager/src/hooks/useFlags.ts
@@ -30,11 +30,6 @@ export const useFlags = () => {
     // !!! Override the CMR flag so that it's officially "released" !!!!
     // @todo: clean up all conditional logic based on this flag.
     cmr: true,
-    // imagesPricingCopy: {
-    //   captureImage: '',
-    //   uploadImage: '',
-    // },
-    // imagesPriceInfo: false,
     ...mockFlags,
   };
 };


### PR DESCRIPTION
## Description
Starting on Sep. 1, 2021, Custom Images will be billed at $0.10/GB per month.

The current copy we have at the top of the "Capture Image" and "Upload Image" tabs will need to be replaced on 9/1 with permanent pricing copy.

This PR adds a feature flag for that permanent copy and updates the "Upload Image" tab.

## How to test
I added temporary, commented-out code in `useFlags.ts` for both flags related to Images pricing copy (`imagesPricingCopy` is for the temporary copy currently in prod, `imagesPriceInfo` is the new one for the permanent copy) so you can locally override the flag values from LD.

To test what the state should be before 9/1, uncomment only the line for `imagesPriceInfo`.

To test what the state should be on 9/1 and after, uncomment only the lines for `imagesPricingCopy`.
