### PR TITLE
Feature flag image price estimation

### DIFF
--- a/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
@@ -212,8 +212,8 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
         handleChange={(linode) => handleLinodeChange(linode.id)}
         filterCondition={(linode) =>
           availableLinodesToImagize
-          ? availableLinodesToImagize.includes(linode.id)
-          : true
+            ? availableLinodesToImagize.includes(linode.id)
+            : true
         }
         updateFor={[
           selectedLinode,
@@ -234,11 +234,14 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
           disabled={!canCreateImage}
           data-qa-disk-select
         />
-        { isImagePricingEnabled &&
+        {isImagePricingEnabled ? (
           <Typography className={classes.helperText} variant="body1">
-            { `Estimated: ${calculateCostFromUnitPrice(0.1, selectedDiskSizeInGB)}/month` }
+            {`Estimated: ${calculateCostFromUnitPrice(
+              0.1,
+              selectedDiskSizeInGB
+            )}/month`}
           </Typography>
-        }
+        ) : undefined}
         <Typography className={classes.helperText} variant="body1">
           Linode Images cannot be created if you are using raw disks or disks
           that have been formatted using custom filesystems.

--- a/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
@@ -165,7 +165,7 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
   const requirementsMet = checkRequirements();
 
   const flags = useFlags();
-  const isImagePricingEnabled = !Boolean(flags.imagesPricingInfo);
+  const isImagePricingEnabled = Boolean(flags.imagesPriceInfo);
   const selectedDiskData: Disk | undefined = disks.find(
     (d) => `${d.id}` === selectedDisk
   );

--- a/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
@@ -241,7 +241,7 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
               selectedDiskSizeInGB
             )}/month`}
           </Typography>
-        ) : undefined}
+        ) : null}
         <Typography className={classes.helperText} variant="body1">
           Linode Images cannot be created if you are using raw disks or disks
           that have been formatted using custom filesystems.

--- a/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
@@ -18,13 +18,14 @@ import DiskSelect from 'src/features/linodes/DiskSelect';
 import LinodeSelect from 'src/features/linodes/LinodeSelect';
 import { useGrants, useProfile } from 'src/queries/profile';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
-// import calculateCostFromUnitPrice from 'src/utilities/calculateCostFromUnitPrice';
-// import { convertStorageUnit } from 'src/utilities/unitConversions';
+import calculateCostFromUnitPrice from 'src/utilities/calculateCostFromUnitPrice';
+import { convertStorageUnit } from 'src/utilities/unitConversions';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 import ImagesPricingCopy from './ImagesPricingCopy';
 import withImages, {
   ImagesDispatch,
 } from 'src/containers/withImages.container';
+import useFlags from 'src/hooks/useFlags';
 
 const useStyles = makeStyles((theme: Theme) => ({
   helperText: {
@@ -162,15 +163,17 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
   };
 
   const requirementsMet = checkRequirements();
-  // TODO: uncomment for billing on 9/1
-  /* const selectedDiskData: Disk | undefined = disks.find(
-   *   (d) => `${d.id}` === selectedDisk
-   * );
-   * const selectedDiskSizeInGB = convertStorageUnit(
-   *   'MB',
-   *   selectedDiskData?.size,
-   *   'GB'
-   * ); */
+
+  const flags = useFlags();
+  const isImagePricingEnabled = !Boolean(flags.imagesPricingInfo);
+  const selectedDiskData: Disk | undefined = disks.find(
+    (d) => `${d.id}` === selectedDisk
+  );
+  const selectedDiskSizeInGB = convertStorageUnit(
+    'MB',
+    selectedDiskData?.size,
+    'GB'
+  );
 
   const hasErrorFor = getAPIErrorFor(
     {
@@ -209,8 +212,8 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
         handleChange={(linode) => handleLinodeChange(linode.id)}
         filterCondition={(linode) =>
           availableLinodesToImagize
-            ? availableLinodesToImagize.includes(linode.id)
-            : true
+          ? availableLinodesToImagize.includes(linode.id)
+          : true
         }
         updateFor={[
           selectedLinode,
@@ -231,6 +234,11 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
           disabled={!canCreateImage}
           data-qa-disk-select
         />
+        { isImagePricingEnabled &&
+          <Typography className={classes.helperText} variant="body1">
+            { `Estimated: ${calculateCostFromUnitPrice(0.1, selectedDiskSizeInGB)}/month` }
+          </Typography>
+        }
         <Typography className={classes.helperText} variant="body1">
           Linode Images cannot be created if you are using raw disks or disks
           that have been formatted using custom filesystems.

--- a/packages/manager/src/features/Users/UserPermissions.tsx
+++ b/packages/manager/src/features/Users/UserPermissions.tsx
@@ -422,7 +422,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
         "Can modify this account's Longview subscription ($)",
       add_domains: 'Can add Domains using the DNS Manager',
       add_stackscripts: 'Can create StackScripts under this account',
-      add_images: 'Can create frozen Images under this account',
+      add_images: 'Can create frozen Images under this account ($)',
       add_volumes: 'Can add Block Storage Volumes to this account ($)',
       add_firewalls: 'Can add Firewalls to this account',
       cancel_account: 'Can cancel the entire account',


### PR DESCRIPTION
## Description

Un-comment the image price estimation and put it behind the `imagesPriceInfo` feature flag.

## How to test

If the `imagesPriceInfo` flag is overridden then the price estimator for copying a disk image should be shown on the `ImageCreateTab` component.

