### PR TITLE
M3-5436: Fix action buttons being disabled upon Firewall creation for restricted users

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.tsx
@@ -16,7 +16,7 @@ import {
 
 export interface Props extends Omit<DrawerProps, 'onClose' | 'onSubmit'> {
   onClose: () => void;
-  onSubmit: (payload: CreateFirewallPayload) => Promise<void | Firewall>;
+  onSubmit: (payload: CreateFirewallPayload) => Promise<Firewall>;
 }
 
 export type FormikProps = FormikBag<CombinedProps, CreateFirewallPayload>;

--- a/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.tsx
@@ -16,7 +16,7 @@ import {
 
 export interface Props extends Omit<DrawerProps, 'onClose' | 'onSubmit'> {
   onClose: () => void;
-  onSubmit: (payload: CreateFirewallPayload) => Promise<Firewall>;
+  onSubmit: (payload: CreateFirewallPayload) => Promise<void | Firewall>;
 }
 
 export type FormikProps = FormikBag<CombinedProps, CreateFirewallPayload>;

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallLanding.tsx
@@ -61,11 +61,12 @@ const FirewallLanding: React.FC<CombinedProps> = () => {
 
   const createFirewall = (
     payload: CreateFirewallPayload
-  ): Promise<void | Firewall> => {
-    return _createFirewall(payload).then(() => {
+  ): Promise<Firewall> => {
+    return _createFirewall(payload).then((firewall) => {
       if (profile?.restricted) {
         queryClient.invalidateQueries(`${queryKey}-grants`);
       }
+      return firewall;
     });
   };
 


### PR DESCRIPTION
## Description
When a restricted user creates a Firewall, they are given read/write access to the newly created Firewall. This fixes the Firewall action buttons displaying as disabled after creation even though the user has r/w access. Current prod behavior is that the user needs to refresh the page for the buttons to display as non-disabled.

Note: There is a known issue where users can assign a read-only Linode while creating a Firewall. M3-5435 and ARB-2692 have been created to address that

## How to test
On a restricted user with permissions to add Firewalls:

1. Go to `/firewalls` and click on `Create Firewall`
2. Give the Firewall a unique label and click `Create Firewall`
3. The action buttons for the newly created Firewall should not be disabled
