### PR TITLE
M3-5402: Functionality for EU Contract on NodeBalancer Create

### DIFF
--- a/packages/manager/src/factories/accountAgreements.ts
+++ b/packages/manager/src/factories/accountAgreements.ts
@@ -1,0 +1,7 @@
+import * as Factory from 'factory.ts';
+import { Agreements } from '@linode/api-v4/lib/account';
+
+export const accountAgreementsFactory = Factory.Sync.makeFactory<Agreements>({
+  eu_model: false,
+  privacy_policy: true,
+});

--- a/packages/manager/src/features/Account/Agreements/EUAgreementCheckbox.tsx
+++ b/packages/manager/src/features/Account/Agreements/EUAgreementCheckbox.tsx
@@ -1,14 +1,11 @@
 import * as React from 'react';
 import CheckBox from 'src/components/CheckBox';
 import Box from 'src/components/core/Box';
-import Tooltip from 'src/components/core/Tooltip';
 import Typography from 'src/components/core/Typography';
 import Link from 'src/components/Link';
 
 interface Props {
   className?: string;
-  disabled?: boolean;
-  tooltip?: string;
   centerCheckbox?: boolean;
   checked: boolean;
   onChange: (
@@ -18,14 +15,7 @@ interface Props {
 }
 
 const EUAgreementCheckbox: React.FC<Props> = (props) => {
-  const {
-    checked,
-    onChange,
-    className,
-    centerCheckbox,
-    tooltip,
-    disabled,
-  } = props;
+  const { checked, onChange, className, centerCheckbox } = props;
 
   const checkboxStyle = centerCheckbox
     ? { marginLeft: -8 }
@@ -38,25 +28,7 @@ const EUAgreementCheckbox: React.FC<Props> = (props) => {
       alignItems={centerCheckbox ? 'center' : 'flex-start'}
       className={className}
     >
-      {disabled && tooltip ? (
-        <Tooltip title={tooltip}>
-          <div>
-            <CheckBox
-              checked={checked}
-              onChange={onChange}
-              disabled={disabled}
-              style={checkboxStyle}
-            />
-          </div>
-        </Tooltip>
-      ) : (
-        <CheckBox
-          checked={checked}
-          onChange={onChange}
-          disabled={disabled}
-          style={checkboxStyle}
-        />
-      )}
+      <CheckBox checked={checked} onChange={onChange} style={checkboxStyle} />
       <Typography>
         I have read and agree to the{' '}
         <Link to="https://www.linode.com/legal-privacy/">

--- a/packages/manager/src/features/Account/Agreements/EUAgreementCheckbox.tsx
+++ b/packages/manager/src/features/Account/Agreements/EUAgreementCheckbox.tsx
@@ -1,11 +1,14 @@
 import * as React from 'react';
 import CheckBox from 'src/components/CheckBox';
 import Box from 'src/components/core/Box';
+import Tooltip from 'src/components/core/Tooltip';
 import Typography from 'src/components/core/Typography';
 import Link from 'src/components/Link';
 
 interface Props {
   className?: string;
+  disabled?: boolean;
+  tooltip?: string;
   centerCheckbox?: boolean;
   checked: boolean;
   onChange: (
@@ -15,7 +18,14 @@ interface Props {
 }
 
 const EUAgreementCheckbox: React.FC<Props> = (props) => {
-  const { checked, onChange, className, centerCheckbox } = props;
+  const {
+    checked,
+    onChange,
+    className,
+    centerCheckbox,
+    tooltip,
+    disabled,
+  } = props;
 
   const checkboxStyle = centerCheckbox
     ? { marginLeft: -8 }
@@ -28,7 +38,25 @@ const EUAgreementCheckbox: React.FC<Props> = (props) => {
       alignItems={centerCheckbox ? 'center' : 'flex-start'}
       className={className}
     >
-      <CheckBox checked={checked} onChange={onChange} style={checkboxStyle} />
+      {disabled && tooltip ? (
+        <Tooltip title={tooltip}>
+          <div>
+            <CheckBox
+              checked={checked}
+              onChange={onChange}
+              disabled={disabled}
+              style={checkboxStyle}
+            />
+          </div>
+        </Tooltip>
+      ) : (
+        <CheckBox
+          checked={checked}
+          onChange={onChange}
+          disabled={disabled}
+          style={checkboxStyle}
+        />
+      )}
       <Typography>
         I have read and agree to the{' '}
         <Link to="https://www.linode.com/legal-privacy/">

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -305,7 +305,7 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
     });
   };
 
-  createNodeBalancer = async () => {
+  createNodeBalancer = () => {
     const {
       nodeBalancerActions: { createNodeBalancer },
     } = this.props;

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -62,7 +62,6 @@ import {
 } from './utils';
 import { queryClient, simpleMutationHandlers } from 'src/queries/base';
 import { queryKey } from 'src/queries/accountAgreements';
-import { withSnackbar, WithSnackbarProps } from 'notistack';
 
 type ClassNames = 'title' | 'sidebar';
 
@@ -89,8 +88,7 @@ type CombinedProps = WithNodeBalancerActions &
   WithRegions &
   RouteComponentProps<{}> &
   WithStyles<ClassNames> &
-  AgreementsProps &
-  WithSnackbarProps;
+  AgreementsProps;
 
 interface NodeBalancerFieldsState {
   label?: string;
@@ -853,6 +851,5 @@ export default recompose<CombinedProps, {}>(
   styled,
   withRouter,
   withProfile,
-  withAgreements,
-  withSnackbar
+  withAgreements
 )(NodeBalancerCreate);

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -307,7 +307,6 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
 
   createNodeBalancer = async () => {
     const {
-      enqueueSnackbar,
       nodeBalancerActions: { createNodeBalancer },
     } = this.props;
     const { nodeBalancerFields, signedAgreement } = this.state;
@@ -324,23 +323,6 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
     /* Clear config errors */
     this.setState({ submitting: true, errors: undefined });
 
-    if (signedAgreement) {
-      try {
-        await queryClient.executeMutation({
-          variables: { eu_model: true, privacy_policy: true },
-          mutationFn: signAgreement,
-          mutationKey: queryKey,
-          ...simpleMutationHandlers(queryKey),
-        });
-      } catch (error) {
-        this.setState({ submitting: false });
-        enqueueSnackbar('There was an error creating your NodeBalancer.', {
-          variant: 'error',
-        });
-        return;
-      }
-    }
-
     createNodeBalancer(nodeBalancerRequestData)
       .then((nodeBalancer) => {
         this.props.history.push(`/nodebalancers/${nodeBalancer.id}/summary`);
@@ -348,6 +330,14 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
         sendCreateNodeBalancerEvent(
           `${nodeBalancer.label}: ${nodeBalancer.region}`
         );
+        if (signedAgreement) {
+          queryClient.executeMutation({
+            variables: { eu_model: true, privacy_policy: true },
+            mutationFn: signAgreement,
+            mutationKey: queryKey,
+            ...simpleMutationHandlers(queryKey),
+          });
+        }
       })
       .catch((errorResponse) => {
         const errors = getAPIErrorOrDefault(errorResponse);

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -735,9 +735,7 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
               disabled={
                 this.state.submitting ||
                 this.disabled ||
-                (showAgreement &&
-                  !this.state.agree &&
-                  !profile.data?.restricted)
+                (showAgreement && !this.state.agree)
               }
               submitText="Create NodeBalancer"
               agreement={

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -105,6 +105,14 @@ const entityTransfers = [
     const transfer = entityTransferFactory.build();
     return res(ctx.json(transfer));
   }),
+  rest.get('*/account/agreements', (req, res, ctx) =>
+    res(
+      ctx.json({
+        eu_model: false,
+        privacy_policy: true,
+      })
+    )
+  ),
   rest.post('*/account/entity-transfers', (req, res, ctx) => {
     const payload = req.body as any;
     const newTransfer = entityTransferFactory.build({
@@ -125,7 +133,7 @@ const entityTransfers = [
 
 export const handlers = [
   rest.get('*/profile', (req, res, ctx) => {
-    const profile = profileFactory.build();
+    const profile = profileFactory.build({ restricted: false });
     return res(ctx.json(profile));
   }),
   rest.put('*/profile', (req, res, ctx) => {

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -55,6 +55,7 @@ import {
 import cachedRegions from 'src/cachedData/regions.json';
 import { MockData } from 'src/dev-tools/mockDataController';
 import { grantsFactory } from 'src/factories/grants';
+import { accountAgreementsFactory } from 'src/factories/accountAgreements';
 
 export const makeResourcePage = (
   e: any[],
@@ -106,12 +107,7 @@ const entityTransfers = [
     return res(ctx.json(transfer));
   }),
   rest.get('*/account/agreements', (req, res, ctx) =>
-    res(
-      ctx.json({
-        eu_model: false,
-        privacy_policy: true,
-      })
-    )
+    res(ctx.json(accountAgreementsFactory.build()))
   ),
   rest.post('*/account/entity-transfers', (req, res, ctx) => {
     const payload = req.body as any;

--- a/packages/manager/src/queries/accountAgreements.ts
+++ b/packages/manager/src/queries/accountAgreements.ts
@@ -1,7 +1,11 @@
-import { Agreements, getAccountAgreements } from '@linode/api-v4/lib/account';
+import {
+  Agreements,
+  getAccountAgreements,
+  signAgreement,
+} from '@linode/api-v4/lib/account';
 import { APIError } from '@linode/api-v4/lib/types';
-import { useQuery } from 'react-query';
-import { queryPresets } from './base';
+import { useMutation, useQuery } from 'react-query';
+import { queryClient, queryPresets } from './base';
 
 export const queryKey = 'account-agreements';
 
@@ -11,3 +15,28 @@ export const useAccountAgreements = () =>
     getAccountAgreements,
     queryPresets.oneTimeFetch
   );
+
+export const useMutateAccountAgreements = () => {
+  return useMutation<{}, APIError[], Partial<Agreements>>(
+    (data) => signAgreement(data),
+    {
+      onSuccess: updateAccountAgreementsData,
+    }
+  );
+};
+
+/**
+ * To be used as an onSuccess function for a React Query
+ * Mutation to update the React Query Cache
+ * @param newData data returned by the API - in this case the API always returns {}
+ * @param variables varibles passed to the mutation to be sent to the API
+ */
+export const updateAccountAgreementsData = (
+  newData: {},
+  variables: Partial<Agreements>
+): void => {
+  queryClient.setQueryData(queryKey, (oldData: Agreements) => ({
+    ...oldData,
+    ...variables,
+  }));
+};

--- a/packages/manager/src/queries/accountAgreements.ts
+++ b/packages/manager/src/queries/accountAgreements.ts
@@ -5,7 +5,7 @@ import {
 } from '@linode/api-v4/lib/account';
 import { APIError } from '@linode/api-v4/lib/types';
 import { useMutation, useQuery } from 'react-query';
-import { queryClient, queryPresets } from './base';
+import { queryPresets, simpleMutationHandlers } from './base';
 
 export const queryKey = 'account-agreements';
 
@@ -19,24 +19,6 @@ export const useAccountAgreements = () =>
 export const useMutateAccountAgreements = () => {
   return useMutation<{}, APIError[], Partial<Agreements>>(
     (data) => signAgreement(data),
-    {
-      onSuccess: updateAccountAgreementsData,
-    }
+    simpleMutationHandlers<Agreements, Partial<Agreements>>(queryKey)
   );
-};
-
-/**
- * To be used as an onSuccess function for a React Query
- * Mutation to update the React Query Cache
- * @param newData data returned by the API - in this case the API always returns {}
- * @param variables varibles passed to the mutation to be sent to the API
- */
-export const updateAccountAgreementsData = (
-  newData: {},
-  variables: Partial<Agreements>
-): void => {
-  queryClient.setQueryData(queryKey, (oldData: Agreements) => ({
-    ...oldData,
-    ...variables,
-  }));
 };

--- a/packages/manager/src/queries/base.ts
+++ b/packages/manager/src/queries/base.ts
@@ -1,5 +1,6 @@
 import { APIError } from '@linode/api-v4/lib/types';
 import { QueryClient, UseMutationOptions, UseQueryOptions } from 'react-query';
+import { isEmpty } from '@linode/api-v4/lib/request';
 
 // =============================================================================
 // Config
@@ -68,6 +69,19 @@ export const mutationHandlers = <T, V, E = APIError[]>(
       queryClient.setQueryData<ItemsByID<T>>(queryKey, (oldData) => ({
         ...oldData,
         [variables[indexer]]: updatedEntity,
+      }));
+    },
+  };
+};
+
+export const simpleMutationHandlers = <T, V, E = APIError[]>(
+  queryKey: string
+): UseMutationOptions<T, E, V, () => void> => {
+  return {
+    onSuccess: (updatedEntity, variables: V) => {
+      queryClient.setQueryData<T>(queryKey, (oldData: T) => ({
+        ...oldData,
+        ...(isEmpty(updatedEntity) ? variables : updatedEntity),
       }));
     },
   };


### PR DESCRIPTION
## Preview

![Screen Shot 2021-08-31 at 12 32 27 AM](https://user-images.githubusercontent.com/6440455/131442254-910606c1-76c4-4152-9b27-3dac58980555.png)

## Description

- Functionality for EU Contract on NodeBalancer Create
  - The component should only be visible if the user has not signed the EU MC contract and is not a restricted user (restricted users have no access to view agreements)
  - The "Create NodeBalancer" button should be disabled unless the the EU MC confirmation is checked.
  - After the EU MC confirmation has been checked, when the user clicks "Create NodeBalancer", a POST to /account/agreements signing the eu model contract should be made. 

### TODO
  - [x] Agreements Factory
  - [x] Mutate React Query Cache when agreement is signed

## How to test

- Go to `/nodebalancers/create`
- Try to create a Nodebalancer in a non-EU region
  - You should not see an Agreement Checkbox and you should be able to create a Nodebalancer as per usual
- Try to create a Nodebalancer in an EU region
  - You should see an Agreement Checkbox
    - If you don't it's probably because it is already signed on your account (API returns `{ eu_model: false, privacy_policy: true }`). If this is the case, you can turn on the MSW to simulate the agreement not being signed
  - Try creating a Nodebalancer in an EU region as a restricted user
    - You should be able to create as normal but you should not see the agreement checkbox. Restricted users will not have to agree to this agreement

- MSW code for mocking an API error when signing (put in serverHandlers.ts)
```ts
  rest.post('*/account/agreements', (req, res, ctx) => {
    return res(ctx.status(500), ctx.json({ reason: 'Unknown error' }));
  }),
```