### PR TITLE
M3-5400: EU contract functionality for Linode create

### DIFF
--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -69,7 +69,6 @@ import {
   WithTypesRegionsAndImages,
 } from './types';
 import EUAgreementCheckbox from 'src/features/Account/Agreements/EUAgreementCheckbox';
-import { isEURegion } from 'src/utilities/formatRegion';
 
 type ClassNames = 'root' | 'form' | 'stackScriptWrapper' | 'imageSelect';
 
@@ -140,6 +139,9 @@ interface Props {
   vlanLabel: string | null;
   ipamAddress: string | null;
   handleVLANChange: (updatedInterface: Interface) => void;
+  showAgreement: boolean;
+  handleAgreementChange: () => void;
+  signedAgreement: boolean;
 }
 
 const errorMap = [
@@ -361,6 +363,7 @@ export class LinodeCreate extends React.PureComponent<
 
     const {
       classes,
+      formIsSubmitting,
       linodesData,
       linodesLoading,
       linodesError,
@@ -389,6 +392,9 @@ export class LinodeCreate extends React.PureComponent<
       userCannotCreateLinode,
       accountBackupsEnabled,
       showGeneralError,
+      showAgreement,
+      handleAgreementChange,
+      signedAgreement,
       ...rest
     } = this.props;
 
@@ -666,8 +672,12 @@ export class LinodeCreate extends React.PureComponent<
             data-qa-checkout-bar
             heading="Linode Summary"
             calculatedPrice={calculatedPrice}
-            isMakingRequest={this.props.formIsSubmitting}
-            disabled={this.props.formIsSubmitting || userCannotCreateLinode}
+            isMakingRequest={formIsSubmitting}
+            disabled={
+              formIsSubmitting ||
+              userCannotCreateLinode ||
+              (showAgreement && !signedAgreement)
+            }
             onDeploy={this.createLinode}
             submitText="Create Linode"
             footer={
@@ -676,8 +686,11 @@ export class LinodeCreate extends React.PureComponent<
               </SMTPRestrictionText>
             }
             agreement={
-              isEURegion(this.props.selectedRegionID) ? (
-                <EUAgreementCheckbox checked={false} onChange={() => null} />
+              showAgreement ? (
+                <EUAgreementCheckbox
+                  checked={signedAgreement}
+                  onChange={handleAgreementChange}
+                />
               ) : undefined
             }
           >

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -476,6 +476,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
       try {
         await signAgreement({
           eu_model: true,
+          privacy_policy: true,
         });
         queryClient.invalidateQueries(queryKey);
         this.setState({

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -47,8 +47,6 @@ import {
   getOneClickApps,
 } from 'src/features/StackScripts/stackScriptUtils';
 import { accountBackupsEnabled } from 'src/queries/accountSettings';
-import { queryClient } from 'src/queries/base';
-import { queryKey } from 'src/queries/accountAgreements';
 import { CreateTypes } from 'src/store/linodeCreate/linodeCreate.actions';
 import {
   LinodeActionsProps,
@@ -477,29 +475,6 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
 
     this.setState({ formIsSubmitting: true, errors: [] });
 
-    if (signedAgreement) {
-      try {
-        await signAgreement({
-          eu_model: true,
-          privacy_policy: true,
-        });
-        queryClient.invalidateQueries(queryKey);
-        this.setState({
-          formIsSubmitting: false,
-          showAgreement: false,
-        });
-      } catch (err) {
-        return this.setState({
-          formIsSubmitting: false,
-          errors: [
-            {
-              reason: 'Unable to create Linode.',
-            },
-          ],
-        });
-      }
-    }
-
     const payload = { ..._payload };
 
     /**
@@ -607,6 +582,14 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
     return request()
       .then((response: Linode) => {
         this.setState({ formIsSubmitting: false });
+
+        if (signedAgreement) {
+          // @TODO Use React Query Mutation
+          signAgreement({
+            eu_model: true,
+            privacy_policy: true,
+          });
+        }
 
         /** if cloning a Linode, upsert Linode in redux */
         if (createType === 'fromLinode') {

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -72,6 +72,8 @@ import {
 } from './types';
 import { getRegionIDFromLinodeID } from './utilities';
 import { isEURegion } from 'src/utilities/formatRegion';
+import { queryClient, simpleMutationHandlers } from 'src/queries/base';
+import { queryKey } from 'src/queries/accountAgreements';
 
 const DEFAULT_IMAGE = 'linode/debian10';
 
@@ -578,10 +580,11 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
         this.setState({ formIsSubmitting: false });
 
         if (signedAgreement) {
-          // @TODO Use React Query Mutation
-          signAgreement({
-            eu_model: true,
-            privacy_policy: true,
+          queryClient.executeMutation({
+            variables: { eu_model: true, privacy_policy: true },
+            mutationFn: signAgreement,
+            mutationKey: queryKey,
+            ...simpleMutationHandlers(queryKey),
           });
         }
 

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -472,9 +472,6 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
   submitForm: HandleSubmit = async (_payload, linodeID?: number) => {
     const { createType } = this.props;
     const { signedAgreement } = this.state;
-
-    this.setState({ formIsSubmitting: true, errors: [] });
-
     const payload = { ..._payload };
 
     /**
@@ -494,7 +491,6 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
       if (passwordError) {
         this.setState(
           {
-            formIsSubmitting: false,
             errors: [
               {
                 field: 'root_pass',
@@ -518,7 +514,6 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
     if (createType === 'fromLinode' && !linodeID) {
       return this.setState(
         () => ({
-          formIsSubmitting: false,
           errors: [
             {
               reason: 'You must select a Linode to clone from',
@@ -534,7 +529,6 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
       /* a backup selection is also required */
       this.setState(
         {
-          formIsSubmitting: false,
           errors: [{ field: 'backup_id', reason: 'You must select a Backup.' }],
         },
         () => {
@@ -547,7 +541,6 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
     if (createType === 'fromStackScript' && !this.state.selectedStackScriptID) {
       return this.setState(
         () => ({
-          formIsSubmitting: false,
           errors: [
             {
               reason: 'You must select a StackScript.',
@@ -562,7 +555,6 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
     if (createType === 'fromApp' && !this.state.selectedStackScriptID) {
       return this.setState(
         () => ({
-          formIsSubmitting: false,
           errors: [
             {
               reason: 'You must select a Marketplace App.',
@@ -578,6 +570,8 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
       createType === 'fromLinode'
         ? () => cloneLinode(linodeID!, payload)
         : () => this.props.linodeActions.createLinode(payload);
+
+    this.setState({ formIsSubmitting: true });
 
     return request()
       .then((response: Linode) => {

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -469,7 +469,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
     return getLabel(arg1, arg2, arg3);
   };
 
-  submitForm: HandleSubmit = async (_payload, linodeID?: number) => {
+  submitForm: HandleSubmit = (_payload, linodeID?: number) => {
     const { createType } = this.props;
     const { signedAgreement } = this.state;
     const payload = { ..._payload };


### PR DESCRIPTION
## Description
Add functionality for the EU Contract on Linode Create.

- The component should only be visible if the user has not signed the EU MC contract and is not a restricted user (restricted users have no access to view agreements)
- The "Create Linode" button should be disabled unless the the EU MC confirmation is checked.
- After the EU MC confirmation has been checked, when the user clicks "Create Linode", a POST to /account/agreements signing the eu model contract should be made. 

TODO:
- [x] Mutate React Query Cache when agreement is signed (wait for [7900](https://github.com/linode/manager/pull/7900) to get merged)

## How to test
On an account that hasn't signed the eu agreement:
- Go to `/linodes/create`
- Select a non-EU region:
    - You should not see the EU agreement checkbox in the checkout bar
- Select an EU region:
   - You should see the EU agreement checkbox and the `Create Linode` button should be disabled until it is checked
- Check the checkbox and click `Create Linode`
   - You should see a POST request made to `/account/agreements`
   - If there was an error POSTing to the agreements endpoint, you should see an error toast
   - If there was an error POSTing to `/linode/instances` after a successful POST to agreements (e.g. on dev bc there is no availability in the EU region), the EU checkbox should no longer display

Restricted users should not be able to see the EU agreement checkbox regardless of whether the parent account has signed or not signed the agreement and should be able to create a Linode as normal.
