### PR TITLE
E2E Update Create Domain Test

### DIFF
--- a/packages/manager/cypress/integration/domains/smoke-create-domain.spec.ts
+++ b/packages/manager/cypress/integration/domains/smoke-create-domain.spec.ts
@@ -1,5 +1,10 @@
 import { makeDomainLabel } from '../../support/api/domains';
-import { fbtClick, fbtVisible, getClick } from '../../support/helpers';
+import {
+  fbtClick,
+  fbtVisible,
+  getClick,
+  getVisible,
+} from '../../support/helpers';
 
 describe('Create a Domain', () => {
   it('Creates first Domain', () => {
@@ -20,8 +25,10 @@ describe('Create a Domain', () => {
     cy.wait('@getDomains');
     fbtClick('Create Domain');
     const label = makeDomainLabel();
-    fbtVisible('Domain (required)').type(label);
-    fbtVisible('SOA Email Address (required)').type('devs@linode.com');
+    getVisible('[id="domain"][data-testid="textfield-input"]').type(label);
+    getVisible('[id="soa-email-address"][data-testid="textfield-input"]').type(
+      'devs@linode.com'
+    );
     getClick('[data-testid="create-domain-submit"]');
     cy.wait('@createDomain');
     cy.get('[data-qa-header]').should('contain', label);


### PR DESCRIPTION
## Description
This change was needed because of some recent ui changes to this page

**What does this PR do?**
updating create domain test after input attributes were changed

## How to test
- `yarn up` in one terminal
- `yarn cy:e2e -s ./cypress/integration/domains/smoke-create-domain.spec.ts` in another
- Result should be "✔  All specs passed!"

## Make sure your .env contains:
```
REACT_APP_LOGIN_ROOT
REACT_APP_API_ROOT
REACT_APP_APP_ROOT
REACT_APP_LAUNCH_DARKLY_ID
REACT_APP_CLIENT_ID
MANAGER_OAUTH
```