### PR TITLE
Fix Linode Maintenance Query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Changed:
 - Labels’ “(required)” substring adjusted to normal weight
 
+### Fixed:
+- Populating all Linode maintenance events
+
 ## [2021-08-26] - v1.47.1
 
 ### Added:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Labels’ “(required)” substring adjusted to normal weight
 
 ### Fixed:
-- Populating all Linode maintenance events
+- Not all Linode maintenance events being populated
 
 ## [2021-08-26] - v1.47.1
 

--- a/packages/manager/src/features/Account/Maintenance/MaintenanceTableRow.tsx
+++ b/packages/manager/src/features/Account/Maintenance/MaintenanceTableRow.tsx
@@ -9,10 +9,15 @@ import TableRow from 'src/components/TableRow';
 import capitalize from 'src/utilities/capitalize';
 import { parseAPIDate } from 'src/utilities/date';
 import formatDate from 'src/utilities/formatDate';
+import HighlightedMarkdown from 'src/components/HighlightedMarkdown';
 
 const useStyles = makeStyles(() => ({
   capitalize: {
     textTransform: 'capitalize',
+  },
+  padding: {
+    padding: 8,
+    paddingLeft: 0,
   },
 }));
 
@@ -50,7 +55,9 @@ const MaintenanceTableRow: React.FC<AccountMaintenance> = (props) => {
         </TableCell>
       </Hidden>
       <Hidden mdDown>
-        <TableCell>{reason}</TableCell>
+        <TableCell className={classes.padding}>
+          <HighlightedMarkdown textOrMarkdown={reason} />
+        </TableCell>
       </Hidden>
     </TableRow>
   );

--- a/packages/manager/src/features/Account/Maintenance/MaintenanceTableRow.tsx
+++ b/packages/manager/src/features/Account/Maintenance/MaintenanceTableRow.tsx
@@ -17,7 +17,6 @@ const useStyles = makeStyles(() => ({
   },
   padding: {
     padding: 8,
-    paddingLeft: 0,
   },
 }));
 

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -438,7 +438,7 @@ export const handlers = [
         entity: { label: 'very-long-name-for-a-linode-for-testing' },
         when: new Date(Date.now() + 5000).toISOString(),
       }),
-      ...accountMaintenanceFactory.buildList(27, { status: 'pending' }),
+      ...accountMaintenanceFactory.buildList(5, { status: 'pending' }),
       ...accountMaintenanceFactory.buildList(3, { status: 'started' }),
     ];
 

--- a/packages/manager/src/queries/accountMaintenance.ts
+++ b/packages/manager/src/queries/accountMaintenance.ts
@@ -21,7 +21,7 @@ const getAllAccountMaintenance = (
 export const useAllAccountMaintenanceQuery = (
   params: any = {},
   filter: any = {},
-  enabled: boolean = false
+  enabled: boolean = true
 ) => {
   return useQuery<AccountMaintenance[], APIError[]>(
     queryKey,


### PR DESCRIPTION
## Description

- Enables the getAllAccountMaintenace query by default
- Adds padding to the `Reason` column in the Maintenance Table (`/account/maintenance`)
- Parses any possible markdown returned in the reason field for the Maintenance Table (`/account/maintenance`)

## How to test

- Make sure all maintenance events are populated on the Linodes landing page
- Make sure `/account/maintenance` still works as expected (still is API paginated and sorted)
- Make sure a notice banner appears for a Linode having maintenance on the Linode Detail Page