### PR TITLE
M3-5404: Functionality for EU Contract on Bucket Create

### DIFF
--- a/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.tsx
@@ -220,7 +220,12 @@ export const CreateBucketForm: React.FC<CombinedProps> = (props) => {
                   resetForm();
                   onClose();
                 }}
-                disabled={isRestrictedUser}
+                disabled={
+                  isRestrictedUser ||
+                  !values.label ||
+                  !values.cluster ||
+                  (showAgreement && !signedAgreement)
+                }
                 submitText="Create Bucket"
               />
             </Form>

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.tsx
@@ -164,7 +164,7 @@ export const CreateBucketForm: React.FC<CombinedProps> = (props) => {
 
         const showAgreement = Boolean(
           !profile?.restricted &&
-            !agreements?.eu_model &&
+            agreements?.eu_model === false &&
             isEURegion(values.cluster)
         );
 

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.tsx
@@ -26,6 +26,11 @@ import { useAccountSettings } from 'src/queries/accountSettings';
 import { compose } from 'recompose';
 import { isEURegion } from 'src/utilities/formatRegion';
 import EUAgreementCheckbox from 'src/features/Account/Agreements/EUAgreementCheckbox';
+import {
+  useAccountAgreements,
+  useMutateAccountAgreements,
+} from 'src/queries/accountAgreements';
+import { useProfile } from 'src/queries/profile';
 
 const useStyles = makeStyles((theme: Theme) => ({
   textWrapper: {
@@ -54,14 +59,17 @@ export const CreateBucketForm: React.FC<CombinedProps> = (props) => {
     bucketsData,
   } = props;
 
-  const classes = useStyles();
-
-  const [dialogOpen, setDialogOpen] = React.useState<boolean>(false);
-
   const {
     data: accountSettings,
     refetch: requestAccountSettings,
   } = useAccountSettings();
+
+  const classes = useStyles();
+  const [dialogOpen, setDialogOpen] = React.useState<boolean>(false);
+  const [signedAgreement, setSignedAgreement] = React.useState<boolean>(false);
+  const { data: agreements } = useAccountAgreements();
+  const { mutate: signAgreement } = useMutateAccountAgreements();
+  const { data: profile } = useProfile();
 
   return (
     <Formik
@@ -94,6 +102,10 @@ export const CreateBucketForm: React.FC<CombinedProps> = (props) => {
             resetForm({ values: initialValues });
             setSubmitting(false);
             onSuccess(bucketLabel);
+
+            if (signedAgreement) {
+              signAgreement({ eu_model: true, privacy_policy: true });
+            }
 
             // If our Redux Store says that the user doesn't have OBJ enabled,
             // it probably means they have just enabled it with the creation
@@ -150,6 +162,12 @@ export const CreateBucketForm: React.FC<CombinedProps> = (props) => {
           values,
         } = formikProps;
 
+        const showAgreement = Boolean(
+          !profile?.restricted &&
+            !agreements?.eu_model &&
+            isEURegion(values.cluster)
+        );
+
         return (
           <>
             <Form>
@@ -186,11 +204,11 @@ export const CreateBucketForm: React.FC<CombinedProps> = (props) => {
                 disabled={isRestrictedUser}
               />
 
-              {isEURegion(values.cluster) ? (
+              {showAgreement ? (
                 <EUAgreementCheckbox
                   className={classes.agreement}
-                  checked={false}
-                  onChange={() => null}
+                  checked={signedAgreement}
+                  onChange={(e) => setSignedAgreement(e.target.checked)}
                 />
               ) : null}
 


### PR DESCRIPTION
## Preview

![Screen Shot 2021-09-02 at 12 58 49 PM](https://user-images.githubusercontent.com/6440455/131886050-f51d7548-07b2-4cd6-aff7-c0e1bea36168.png)


## Description

- Functionality for EU Contract on Object Storage - Bucket Create
  - The component should only be visible if the user has not signed the EU MC contract and is not a restricted user (restricted users have no access to view agreements)
  - The "Create Bucket" button should be disabled unless the the EU MC confirmation is checked.
  - After the EU MC confirmation has been checked, when the user clicks "Create Bucket", a POST to /account/agreements signing the eu model contract should be made. 

## How to test

- Go to `/object-storage/buckets/create`
- Try to create a Bucket in a non-EU region
  - You should not see an Agreement Checkbox and you should be able to create a Bucket as per usual
- Try to create a Bucket in an EU region
  - You should see an Agreement Checkbox
    - If you don't it's probably because it is already signed on your account (API returns `{ eu_model: false, privacy_policy: true }`). If this is the case, you can turn on the MSW to simulate the agreement not being signed
  - Try creating a Bucket in an EU region as a restricted user
    - You should be able to create as normal but you should not see the agreement checkbox. Restricted users will not have to agree to this agreement