### PR TITLE
M3-5405: Functionality for EU Contract on Image Create

### DIFF
--- a/packages/manager/src/components/FileUploader/FileUploader.tsx
+++ b/packages/manager/src/components/FileUploader/FileUploader.tsx
@@ -122,6 +122,7 @@ interface Props {
   setErrors: React.Dispatch<React.SetStateAction<APIError[] | undefined>>;
   // Send a function for cancelling the upload back to the parent.
   setCancelFn: React.Dispatch<React.SetStateAction<(() => void) | null>>;
+  onSuccess?: () => void;
 }
 
 type CombinedProps = Props & WithSnackbarProps;
@@ -134,6 +135,7 @@ const FileUploader: React.FC<CombinedProps> = (props) => {
     dropzoneDisabled,
     apiError,
     setErrors,
+    onSuccess,
   } = props;
 
   const [uploadToURL, setUploadToURL] = React.useState<string>('');
@@ -243,6 +245,10 @@ const FileUploader: React.FC<CombinedProps> = (props) => {
       const onUploadProgress = onUploadProgressFactory(dispatch, path);
 
       const handleSuccess = () => {
+        if (onSuccess) {
+          onSuccess();
+        }
+
         dispatch({
           type: 'UPDATE_FILES',
           filesToUpdate: [path],

--- a/packages/manager/src/components/FileUploader/FileUploader.tsx
+++ b/packages/manager/src/components/FileUploader/FileUploader.tsx
@@ -403,10 +403,9 @@ const FileUploader: React.FC<CombinedProps> = (props) => {
 
   const UploadZoneActive = state.files.length !== 0;
 
-  const placeholder =
-    !label || !region
-      ? 'To upload an image, complete the required fields.'
-      : 'You can browse your device to upload an image file or drop it here.';
+  const placeholder = dropzoneDisabled
+    ? 'To upload an image, complete the required fields.'
+    : 'You can browse your device to upload an image file or drop it here.';
 
   return (
     <div

--- a/packages/manager/src/features/Images/ImageUpload.tsx
+++ b/packages/manager/src/features/Images/ImageUpload.tsx
@@ -84,7 +84,7 @@ export const ImageUpload: React.FC<Props> = (props) => {
   );
 
   const showAgreement = Boolean(
-    !profile?.restricted && !agreements?.eu_model && isEURegion(region)
+    !profile?.restricted && agreements?.eu_model === false && isEURegion(region)
   );
 
   //  This holds a "cancel function" from the Axios instance that handles image

--- a/packages/manager/src/features/Images/ImageUpload.tsx
+++ b/packages/manager/src/features/Images/ImageUpload.tsx
@@ -69,7 +69,7 @@ export const ImageUpload: React.FC<Props> = (props) => {
   const { data: profile } = useProfile();
   const { data: grants } = useGrants();
   const { data: agreements } = useAccountAgreements();
-  const { mutate: signAgreement } = useMutateAccountAgreements();
+  const { mutateAsync: signAgreement } = useMutateAccountAgreements();
 
   const classes = useStyles();
   const regions = useRegionsQuery().data ?? [];

--- a/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
@@ -25,12 +25,6 @@ import withImages, {
   ImagesDispatch,
 } from 'src/containers/withImages.container';
 import Box from 'src/components/core/Box';
-import EUAgreementCheckbox from 'src/features/Account/Agreements/EUAgreementCheckbox';
-import { isEURegion } from 'src/utilities/formatRegion';
-import {
-  useAccountAgreements,
-  useMutateAccountAgreements,
-} from 'src/queries/accountAgreements';
 
 const useStyles = makeStyles((theme: Theme) => ({
   helperText: {
@@ -42,13 +36,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     paddingBottom: theme.spacing(),
     '& .MuiFormHelperText-root': {
       marginBottom: theme.spacing(2),
-    },
-  },
-  agreement: {
-    maxWidth: '70%',
-    [theme.breakpoints.down('xs')]: {
-      maxWidth: 'unset',
-      marginBottom: theme.spacing(1),
     },
   },
   buttonGroup: {
@@ -82,8 +69,6 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
 
   const { data: profile } = useProfile();
   const { data: grants } = useGrants();
-  const { data: agreements } = useAccountAgreements();
-  const { mutate: signAgreement } = useMutateAccountAgreements();
 
   const [selectedLinode, setSelectedLinode] = React.useState<Linode>();
   const [selectedDisk, setSelectedDisk] = React.useState<string | null>('');
@@ -91,7 +76,6 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
   const [notice, setNotice] = React.useState<string | undefined>();
   const [errors, setErrors] = React.useState<APIError[] | undefined>();
   const [submitting, setSubmitting] = React.useState<boolean>(false);
-  const [signedAgreement, setSignedAgreement] = React.useState<boolean>(false);
 
   const canCreateImage =
     Boolean(!profile?.restricted) || Boolean(grants?.global?.add_images);
@@ -101,12 +85,6 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
         .filter((thisGrant) => thisGrant.permissions === 'read_write')
         .map((thisGrant) => thisGrant.id) ?? []
     : null;
-
-  const showAgreement = Boolean(
-    !profile?.restricted &&
-      agreements?.eu_model === false &&
-      isEURegion(selectedLinode?.region)
-  );
 
   const fetchLinodeDisksOnLinodeChange = (selectedLinode: number) => {
     setSelectedDisk('');
@@ -163,10 +141,6 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
         resetEventsPolling();
 
         setSubmitting(false);
-
-        if (signedAgreement) {
-          signAgreement({ eu_model: true, privacy_policy: true });
-        }
 
         enqueueSnackbar('Image scheduled for creation.', {
           variant: 'info',
@@ -288,26 +262,14 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
       />
       <Box
         display="flex"
-        justifyContent={showAgreement ? 'space-between' : 'flex-end'}
+        justifyContent="flex-end"
         alignItems="center"
         flexWrap="wrap"
         className={classes.buttonGroup}
       >
-        {showAgreement ? (
-          <EUAgreementCheckbox
-            checked={signedAgreement}
-            onChange={(e) => setSignedAgreement(e.target.checked)}
-            className={classes.agreement}
-            centerCheckbox
-          />
-        ) : null}
         <Button
           onClick={onSubmit}
-          disabled={
-            requirementsMet ||
-            !canCreateImage ||
-            (showAgreement && !signedAgreement)
-          }
+          disabled={requirementsMet || !canCreateImage}
           loading={submitting}
           buttonType="primary"
           data-qa-submit

--- a/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
@@ -104,7 +104,7 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
 
   const showAgreement = Boolean(
     !profile?.restricted &&
-      !agreements?.eu_model &&
+      agreements?.eu_model === false &&
       isEURegion(selectedLinode?.region)
   );
 

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -219,6 +219,10 @@ export const handlers = [
         backups: { enabled: false },
         tags: ['test1', 'test2', 'test3'],
       }),
+      linodeFactory.build({
+        label: 'eu-linode',
+        region: 'eu-west',
+      }),
       eventLinode,
       multipleIPLinode,
     ];


### PR DESCRIPTION
## Preview

![Screen Shot 2021-09-02 at 12 57 00 PM](https://user-images.githubusercontent.com/6440455/131885759-6a050642-e970-4784-b0dc-e817231c7209.png)

## Description

- Functionality for EU Contract on Image Create
  - The component should only be visible if
    - An EU region is selected
    - The user has not signed the EU MC contract
    - The user is not a restricted user (restricted users have no access to view agreements)
  - The "Create Image" button should be disabled unless the the EU MC confirmation is checked.
    - The dropzone and `Browse Files` button should be disabled if the checkbox is not checked 
  - After the EU MC confirmation has been checked, when the user clicks "Create Image", a POST to /account/agreements signing the eu model contract should be made. 

## How to test

- Go to `/images/create/disk` and `/images/create/upload`
- Try to create a Bucket in a non-EU region
  - You should not see an Agreement Checkbox and you should be able to create a Bucket as per usual
- Try to create a Image in an EU region
  - You should see an Agreement Checkbox
    - If you don't it's probably because it is already signed on your account (API returns `{ eu_model: false, privacy_policy: true }`). If this is the case, you can turn on the MSW to simulate the agreement not being signed
  - Try creating a Image in an EU region as a restricted user
    - You should be able to create as normal but you should not see the agreement checkbox. Restricted users will not have to agree to this agreement