### PR TITLE
M3-5403: Functionality for EU Contract on Volumes Create

### DIFF
--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -299,6 +299,9 @@ export const handlers = [
     });
     return res(ctx.json(firewall));
   }),
+  // rest.post('*/account/agreements', (req, res, ctx) => {
+  //   return res(ctx.status(500), ctx.json({ reason: 'Unknown error' }));
+  // }),
   rest.post('*/firewalls', (req, res, ctx) => {
     const payload = req.body as any;
     const newFirewall = firewallFactory.build({
@@ -391,6 +394,10 @@ export const handlers = [
   rest.get('*/volumes', (req, res, ctx) => {
     const volumes = volumeFactory.buildList(0);
     return res(ctx.json(makeResourcePage(volumes)));
+  }),
+  rest.post('*/volumes', (req, res, ctx) => {
+    const volume = volumeFactory.build();
+    return res(ctx.json(volume));
   }),
   rest.get('*/vlans', (req, res, ctx) => {
     const vlans = VLANFactory.buildList(2);

--- a/packages/manager/src/queries/accountAgreements.ts
+++ b/packages/manager/src/queries/accountAgreements.ts
@@ -5,6 +5,7 @@ import {
 } from '@linode/api-v4/lib/account';
 import { APIError } from '@linode/api-v4/lib/types';
 import { useMutation, useQuery } from 'react-query';
+import { reportException } from 'src/exceptionReporting';
 import { queryPresets, simpleMutationHandlers } from './base';
 
 export const queryKey = 'account-agreements';
@@ -21,4 +22,16 @@ export const useMutateAccountAgreements = () => {
     (data) => signAgreement(data),
     simpleMutationHandlers<Agreements, Partial<Agreements>>(queryKey)
   );
+};
+
+export const reportAgreementSigningError = (err: any) => {
+  let customErrorMessage =
+    'Excepted to sign the EU agreement, but the request resulted in an error';
+  const apiErrorMessage = err?.[0]?.reason;
+
+  if (apiErrorMessage) {
+    customErrorMessage += `: ${apiErrorMessage}`;
+  }
+
+  reportException(customErrorMessage);
 };


### PR DESCRIPTION
## Description

**What does this PR do?**

Adds functionality for the GDPR agreement on the Volumes Create page.

## How to test

Things to test:
- Create a Volume normally without having signing the agreement
- Create a Volume singing the agreement
- Create a Volume singing the agreement with either request failing
- Other things

Use the MSW to mock an account needing to sign the agreement. Uncomment the /agreements POST in serverHandlers to simulate a failure.

