### PR TITLE
M3-5443: Update Linode logo used in MaintenanceScreen.tsx

### DIFF
--- a/packages/manager/src/components/MaintenanceScreen.tsx
+++ b/packages/manager/src/components/MaintenanceScreen.tsx
@@ -3,7 +3,7 @@ import Link from 'src/components/Link';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Box from 'src/components/core/Box';
-import Logo from 'src/assets/logo/logo-text.svg';
+import Logo from 'src/assets/logo/logo.svg';
 import ErrorState from 'src/components/ErrorState';
 import BuildIcon from '@material-ui/icons/Build';
 
@@ -58,7 +58,7 @@ export const MaintenanceScreen: React.FC<{}> = () => {
             display: 'flex',
           }}
         >
-          <Logo width={150} height={87} className={classes.logo} />
+          <Logo width={115} height={43} className={classes.logo} />
         </Box>
 
         <ErrorState


### PR DESCRIPTION
## Description
Update Linode logo used in MaintenanceScreen.tsx.

Before:
<img width="575" alt="Screen Shot 2021-09-02 at 12 31 57 PM" src="https://user-images.githubusercontent.com/32860776/131882364-a48e598e-f94c-44f9-808a-15895c3dee7a.png">

After:
<img width="1181" alt="Screen Shot 2021-09-02 at 12 03 19 PM" src="https://user-images.githubusercontent.com/32860776/131881834-bf913e8f-170e-47e7-9c7c-4edbcd4e188b.png">

## How to Test
Change the condition to `true`:

https://github.com/linode/manager/blob/f434767652640b634717d519cf6459b65482337c/packages/manager/src/MainContent.tsx#L261-L263
