### PR TITLE
M3-5431 EU Model Contract agreement banner + notification 

### DIFF
--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -13,6 +13,7 @@ import {
 } from 'src/components/core/styles';
 import Grid from 'src/components/Grid';
 import MainContentBanner from 'src/components/MainContentBanner';
+import { MaintenanceScreen } from 'src/components/MaintenanceScreen';
 import NotFound from 'src/components/NotFound';
 import PreferenceToggle, { ToggleProps } from 'src/components/PreferenceToggle';
 import SideMenu from 'src/components/SideMenu';
@@ -37,9 +38,9 @@ import useAccountManagement from 'src/hooks/useAccountManagement';
 import useFlags from 'src/hooks/useFlags';
 import usePreferences from 'src/hooks/usePreferences';
 import { isFeatureEnabled } from 'src/utilities/accountCapabilities';
+import { complianceUpdateContext } from './context/complianceUpdateContext';
 import { FlagSet } from './featureFlags';
 import { UserPreferences } from './store/preferences/preferences.actions';
-import { MaintenanceScreen } from 'src/components/MaintenanceScreen';
 
 const useStyles = makeStyles((theme: Theme) => ({
   appFrame: {
@@ -183,6 +184,9 @@ const MainContent: React.FC<CombinedProps> = (props) => {
   const DbaasContextProvider = dbaasContext.Provider;
   const dbaasContextValue = useDialogContext();
 
+  const ComplianceUpdateProvider = complianceUpdateContext.Provider;
+  const complianceUpdateContextValue = useDialogContext();
+
   const [menuIsOpen, toggleMenu] = React.useState<boolean>(false);
   const { account, profile, _isManagedAccount } = useAccountManagement();
 
@@ -284,24 +288,25 @@ const MainContent: React.FC<CombinedProps> = (props) => {
           togglePreference: desktopMenuToggle,
         }: ToggleProps<boolean>) => (
           <DbaasContextProvider value={dbaasContextValue}>
-            <NotificationProvider value={contextValue}>
-              <>
-                {shouldDisplayMainContentBanner && (
-                  <MainContentBanner
-                    bannerText={flags.mainContentBanner?.text ?? ''}
-                    url={flags.mainContentBanner?.link?.url ?? ''}
-                    linkText={flags.mainContentBanner?.link?.text ?? ''}
-                    bannerKey={flags.mainContentBanner?.key ?? ''}
-                    onClose={() => setBannerDismissed(true)}
+            <ComplianceUpdateProvider value={complianceUpdateContextValue}>
+              <NotificationProvider value={contextValue}>
+                <>
+                  {shouldDisplayMainContentBanner && (
+                    <MainContentBanner
+                      bannerText={flags.mainContentBanner?.text ?? ''}
+                      url={flags.mainContentBanner?.link?.url ?? ''}
+                      linkText={flags.mainContentBanner?.link?.text ?? ''}
+                      bannerKey={flags.mainContentBanner?.key ?? ''}
+                      onClose={() => setBannerDismissed(true)}
+                    />
+                  )}
+                  <SideMenu
+                    open={menuIsOpen}
+                    desktopOpen={desktopMenuIsOpen || false}
+                    closeMenu={() => toggleMenu(false)}
                   />
-                )}
-                <SideMenu
-                  open={menuIsOpen}
-                  desktopOpen={desktopMenuIsOpen || false}
-                  closeMenu={() => toggleMenu(false)}
-                />
-                <div
-                  className={`
+                  <div
+                    className={`
                       ${classes.content}
                       ${
                         desktopMenuIsOpen ||
@@ -310,82 +315,95 @@ const MainContent: React.FC<CombinedProps> = (props) => {
                           : ''
                       }
                     `}
-                >
-                  <TopMenu
-                    isSideMenuOpen={!desktopMenuIsOpen}
-                    openSideMenu={() => toggleMenu(true)}
-                    desktopMenuToggle={desktopMenuToggle}
-                    isLoggedInAsCustomer={props.isLoggedInAsCustomer}
-                    username={username}
-                  />
-                  <main
-                    className={classes.cmrWrapper}
-                    id="main-content"
-                    role="main"
                   >
-                    <Grid container spacing={0} className={classes.grid}>
-                      <Grid item className={`${classes.switchWrapper} p0`}>
-                        <GlobalNotifications />
-                        <React.Suspense fallback={<SuspenseLoader />}>
-                          <Switch>
-                            <Route path="/linodes" component={LinodesRoutes} />
-                            <Route path="/volumes" component={Volumes} />
-                            <Redirect path="/volumes*" to="/volumes" />
-                            <Route
-                              path="/nodebalancers"
-                              component={NodeBalancers}
-                            />
-                            <Route path="/domains" component={Domains} />
-                            <Route path="/managed" component={Managed} />
-                            <Route path="/longview" component={Longview} />
-                            <Route path="/images" component={Images} />
-                            <Route
-                              path="/stackscripts"
-                              component={StackScripts}
-                            />
-                            <Route
-                              path="/object-storage"
-                              component={ObjectStorage}
-                            />
-                            <Route path="/kubernetes" component={Kubernetes} />
-                            <Route path="/account" component={Account} />
+                    <TopMenu
+                      isSideMenuOpen={!desktopMenuIsOpen}
+                      openSideMenu={() => toggleMenu(true)}
+                      desktopMenuToggle={desktopMenuToggle}
+                      isLoggedInAsCustomer={props.isLoggedInAsCustomer}
+                      username={username}
+                    />
+                    <main
+                      className={classes.cmrWrapper}
+                      id="main-content"
+                      role="main"
+                    >
+                      <Grid container spacing={0} className={classes.grid}>
+                        <Grid item className={`${classes.switchWrapper} p0`}>
+                          <GlobalNotifications />
+                          <React.Suspense fallback={<SuspenseLoader />}>
+                            <Switch>
+                              <Route
+                                path="/linodes"
+                                component={LinodesRoutes}
+                              />
+                              <Route path="/volumes" component={Volumes} />
+                              <Redirect path="/volumes*" to="/volumes" />
+                              <Route
+                                path="/nodebalancers"
+                                component={NodeBalancers}
+                              />
+                              <Route path="/domains" component={Domains} />
+                              <Route path="/managed" component={Managed} />
+                              <Route path="/longview" component={Longview} />
+                              <Route path="/images" component={Images} />
+                              <Route
+                                path="/stackscripts"
+                                component={StackScripts}
+                              />
+                              <Route
+                                path="/object-storage"
+                                component={ObjectStorage}
+                              />
+                              <Route
+                                path="/kubernetes"
+                                component={Kubernetes}
+                              />
+                              <Route path="/account" component={Account} />
 
-                            <Route
-                              path="/profile"
-                              render={(routeProps) => (
-                                <Profile
-                                  {...routeProps}
-                                  toggleTheme={props.toggleTheme}
+                              <Route
+                                path="/profile"
+                                render={(routeProps) => (
+                                  <Profile
+                                    {...routeProps}
+                                    toggleTheme={props.toggleTheme}
+                                  />
+                                )}
+                              />
+                              <Route path="/support" component={Help} />
+                              <Route path="/search" component={SearchLanding} />
+                              <Route path="/events" component={EventsLanding} />
+                              {showFirewalls && (
+                                <Route
+                                  path="/firewalls"
+                                  component={Firewalls}
                                 />
                               )}
-                            />
-                            <Route path="/support" component={Help} />
-                            <Route path="/search" component={SearchLanding} />
-                            <Route path="/events" component={EventsLanding} />
-                            {showFirewalls && (
-                              <Route path="/firewalls" component={Firewalls} />
-                            )}
-                            {flags.databases && (
-                              <Route path="/databases" component={Databases} />
-                            )}
-                            <Redirect exact from="/" to={defaultRoot} />
-                            {/** We don't want to break any bookmarks. This can probably be removed eventually. */}
-                            <Redirect from="/dashboard" to={defaultRoot} />
-                            <Route component={NotFound} />
-                          </Switch>
-                        </React.Suspense>
+                              {flags.databases && (
+                                <Route
+                                  path="/databases"
+                                  component={Databases}
+                                />
+                              )}
+                              <Redirect exact from="/" to={defaultRoot} />
+                              {/** We don't want to break any bookmarks. This can probably be removed eventually. */}
+                              <Redirect from="/dashboard" to={defaultRoot} />
+                              <Route component={NotFound} />
+                            </Switch>
+                          </React.Suspense>
+                        </Grid>
                       </Grid>
-                    </Grid>
-                  </main>
-                </div>
-              </>
-            </NotificationProvider>
-            <Footer desktopMenuIsOpen={desktopMenuIsOpen} />
-            <ToastNotifications />
-            <DomainDrawer />
-            <VolumeDrawer />
-            <BackupDrawer />
-            <CreateDatabaseDialog />
+                    </main>
+                  </div>
+                </>
+              </NotificationProvider>
+              <Footer desktopMenuIsOpen={desktopMenuIsOpen} />
+              <ToastNotifications />
+              <DomainDrawer />
+              <VolumeDrawer />
+              <BackupDrawer />
+              <CreateDatabaseDialog />
+            </ComplianceUpdateProvider>
           </DbaasContextProvider>
         )}
       </PreferenceToggle>

--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -291,7 +291,7 @@ const MainContent: React.FC<CombinedProps> = (props) => {
             <ComplianceUpdateProvider value={complianceUpdateContextValue}>
               <NotificationProvider value={contextValue}>
                 <>
-                  {shouldDisplayMainContentBanner && (
+                  {shouldDisplayMainContentBanner ? (
                     <MainContentBanner
                       bannerText={flags.mainContentBanner?.text ?? ''}
                       url={flags.mainContentBanner?.link?.url ?? ''}
@@ -299,7 +299,7 @@ const MainContent: React.FC<CombinedProps> = (props) => {
                       bannerKey={flags.mainContentBanner?.key ?? ''}
                       onClose={() => setBannerDismissed(true)}
                     />
-                  )}
+                  ) : null}
                   <SideMenu
                     open={menuIsOpen}
                     desktopOpen={desktopMenuIsOpen || false}
@@ -379,12 +379,12 @@ const MainContent: React.FC<CombinedProps> = (props) => {
                                   component={Firewalls}
                                 />
                               )}
-                              {flags.databases && (
+                              {flags.databases ? (
                                 <Route
                                   path="/databases"
                                   component={Databases}
                                 />
-                              )}
+                              ) : null}
                               <Redirect exact from="/" to={defaultRoot} />
                               {/** We don't want to break any bookmarks. This can probably be removed eventually. */}
                               <Redirect from="/dashboard" to={defaultRoot} />

--- a/packages/manager/src/components/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/packages/manager/src/components/ConfirmationDialog/ConfirmationDialog.tsx
@@ -27,7 +27,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-interface Props extends DialogProps {
+export interface Props extends DialogProps {
   actions?: ((props: any) => JSX.Element) | JSX.Element;
   error?: string | JSX.Element;
   onClose: () => void;

--- a/packages/manager/src/components/ConfirmationDialog/index.ts
+++ b/packages/manager/src/components/ConfirmationDialog/index.ts
@@ -1,2 +1,7 @@
-import ConfirmationDialog from './ConfirmationDialog';
+import ConfirmationDialog, {
+  Props as _ConfirmationDialogProps,
+} from './ConfirmationDialog';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ConfirmationDialogProps extends _ConfirmationDialogProps {}
 export default ConfirmationDialog;

--- a/packages/manager/src/components/DismissibleBanner/DismissibleBanner.tsx
+++ b/packages/manager/src/components/DismissibleBanner/DismissibleBanner.tsx
@@ -39,19 +39,15 @@ interface Props {
 
 export const DismissibleBanner: React.FC<Props> = (props) => {
   const { className, preferenceKey, productInformationIndicator } = props;
-  const {
-    dismissNotifications,
-    hasDismissedNotifications,
-  } = useDismissibleNotifications();
   const classes = useStyles();
 
-  if (hasDismissedNotifications([preferenceKey])) {
+  const { hasDismissedBanner, handleDismiss } = useDismissibleBanner(
+    preferenceKey
+  );
+
+  if (hasDismissedBanner) {
     return null;
   }
-
-  const handleDismiss = () => {
-    dismissNotifications([preferenceKey]);
-  };
 
   return (
     <Paper
@@ -76,3 +72,20 @@ export const DismissibleBanner: React.FC<Props> = (props) => {
 };
 
 export default DismissibleBanner;
+
+// Hook that contains the nuts-and-bolts of the DismissibleBanner component.
+// Extracted out as its own hook so other components can use it.
+export const useDismissibleBanner = (preferenceKey: string) => {
+  const {
+    dismissNotifications,
+    hasDismissedNotifications,
+  } = useDismissibleNotifications();
+
+  const hasDismissedBanner = hasDismissedNotifications([preferenceKey]);
+
+  const handleDismiss = () => {
+    dismissNotifications([preferenceKey]);
+  };
+
+  return { hasDismissedBanner, handleDismiss };
+};

--- a/packages/manager/src/components/SupportLink/SupportLink.tsx
+++ b/packages/manager/src/components/SupportLink/SupportLink.tsx
@@ -1,16 +1,17 @@
 import * as React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, LinkProps } from 'react-router-dom';
 
 interface Props {
   title?: string;
   description?: string;
   text: string;
+  onClick?: LinkProps['onClick'];
 }
 
 type CombinedProps = Props;
 
 const SupportLink: React.FunctionComponent<CombinedProps> = (props) => {
-  const { description, text, title } = props;
+  const { description, text, title, onClick } = props;
   return (
     <Link
       to={{
@@ -21,6 +22,7 @@ const SupportLink: React.FunctionComponent<CombinedProps> = (props) => {
           description,
         },
       }}
+      onClick={onClick}
     >
       {text}
     </Link>

--- a/packages/manager/src/context/complianceUpdateContext.ts
+++ b/packages/manager/src/context/complianceUpdateContext.ts
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import { defaultContext, DialogContextProps } from './useDialogContext';
+
+export const complianceUpdateContext = React.createContext<DialogContextProps>(
+  defaultContext
+);

--- a/packages/manager/src/factories/notification.ts
+++ b/packages/manager/src/factories/notification.ts
@@ -34,3 +34,14 @@ export const abuseTicketNotificationFactory = notificationFactory.extend({
   until: null,
   body: null,
 });
+
+export const gdprComplianceNotification = notificationFactory.extend({
+  type: 'notice',
+  entity: null,
+  when: null,
+  label: 'EU Contract Compliance Update',
+  severity: 'major',
+  until: null,
+  message:
+    'Please review the compliance update for guidance regarding the EU Standard Contractual Clauses and its application to user deployments in Linode’s London and Frankfurt data centers.',
+});

--- a/packages/manager/src/factories/notification.ts
+++ b/packages/manager/src/factories/notification.ts
@@ -39,9 +39,10 @@ export const gdprComplianceNotification = notificationFactory.extend({
   type: 'notice',
   entity: null,
   when: null,
-  label: 'EU Contract Compliance Update',
+  label: "We've updated our policies",
   severity: 'major',
   until: null,
+  // safe
   message:
-    'Please review the compliance update for guidance regarding the EU Standard Contractual Clauses and its application to user deployments in Linode’s London and Frankfurt data centers.',
+    "We've updated our policies. See <a href='https://www.linode.com/eu-model/'>https://www.linode.com/eu-model/</a> for more information.",
 });

--- a/packages/manager/src/features/Account/Agreements/EUAgreementCheckbox.tsx
+++ b/packages/manager/src/features/Account/Agreements/EUAgreementCheckbox.tsx
@@ -29,7 +29,7 @@ const EUAgreementCheckbox: React.FC<Props> = (props) => {
       className={className}
     >
       <CheckBox checked={checked} onChange={onChange} style={checkboxStyle} />
-      <Typography>
+      <Typography style={{ marginLeft: 4 }}>
         I have read and agree to the{' '}
         <Link to="https://www.linode.com/legal-privacy/">
           Linode Privacy Policy

--- a/packages/manager/src/features/GlobalNotifications/ComplianceBanner.tsx
+++ b/packages/manager/src/features/GlobalNotifications/ComplianceBanner.tsx
@@ -34,8 +34,9 @@ const ComplianceBanner: React.FC<{}> = () => {
       >
         <Typography>
           Please review the compliance update for guidance regarding the EU
-          Standard Contractual Clauses and its application to user deployments
-          in Linode’s London and Frankfurt data centers.
+          Standard Contractual Clauses and its application to users located in
+          Europe as well as deployments in Linode’s London and Frankfurt data
+          centers
         </Typography>
         <Button
           buttonType="primary"

--- a/packages/manager/src/features/GlobalNotifications/ComplianceBanner.tsx
+++ b/packages/manager/src/features/GlobalNotifications/ComplianceBanner.tsx
@@ -13,7 +13,7 @@ const ComplianceBanner: React.FC<{}> = () => {
 
   const hasComplianceNotification =
     notifications.filter((thisNotification) => {
-      return thisNotification.message.match(/compliance update/gi);
+      return thisNotification.message.match(/eu-model/gi);
     }).length > 0;
 
   const { hasDismissedBanner, handleDismiss } = useDismissibleBanner(

--- a/packages/manager/src/features/GlobalNotifications/ComplianceBanner.tsx
+++ b/packages/manager/src/features/GlobalNotifications/ComplianceBanner.tsx
@@ -1,46 +1,51 @@
 import * as React from 'react';
-
-import DismissibleBanner from 'src/components/DismissibleBanner';
-import Grid from 'src/components/core/Grid';
-import Typography from 'src/components/core/Typography';
 import Button from 'src/components/Button';
-import ComplianceUpdateModal from './ComplianceUpdateModal';
+import Box from 'src/components/core/Box';
+import Typography from 'src/components/core/Typography';
+import { useDismissibleBanner } from 'src/components/DismissibleBanner/DismissibleBanner';
+import Notice from 'src/components/Notice';
+import { complianceUpdateContext } from 'src/context/complianceUpdateContext';
+import useNotifications from 'src/hooks/useNotifications';
 
 const ComplianceBanner: React.FC<{}> = () => {
-  const [dialogOpen, setDialogOpen] = React.useState(false);
+  const context = React.useContext(complianceUpdateContext);
+  const notifications = useNotifications();
+
+  const hasComplianceNotification =
+    notifications.filter((thisNotification) => {
+      return thisNotification.message.match(/compliance update/gi);
+    }).length > 0;
+
+  const { hasDismissedBanner, handleDismiss } = useDismissibleBanner(
+    'gdpr-compliance'
+  );
+
+  if (!hasComplianceNotification || hasDismissedBanner) {
+    return null;
+  }
 
   return (
-    <>
-      <DismissibleBanner preferenceKey="gdpr-compliance">
-        <Grid
-          container
-          direction="row"
-          alignItems="center"
-          justify="space-between"
+    <Notice important warning dismissible onClose={handleDismiss}>
+      <Box
+        display="flex"
+        flexDirection="row"
+        alignItems="center"
+        justifyContent="space-between"
+      >
+        <Typography>
+          Please review the compliance update for guidance regarding the EU
+          Standard Contractual Clauses and its application to user deployments
+          in Linode’s London and Frankfurt data centers.
+        </Typography>
+        <Button
+          buttonType="primary"
+          style={{ marginLeft: 12, minWidth: 150 }}
+          onClick={() => context.open()}
         >
-          <Grid item xs={9}>
-            <Typography>
-              Please review the compliance update for guidance regarding the EU
-              Standard Contractual Clauses and its application to user
-              deployments in Linode’s London and Frankfurt data centers.
-            </Typography>
-          </Grid>
-          <Grid
-            item
-            xs={3}
-            style={{ display: 'flex', justifyContent: 'flex-end' }}
-          >
-            <Button buttonType="primary" onClick={() => setDialogOpen(true)}>
-              Review Update
-            </Button>
-          </Grid>
-        </Grid>
-      </DismissibleBanner>
-      <ComplianceUpdateModal
-        open={dialogOpen}
-        onClose={() => setDialogOpen(false)}
-      />
-    </>
+          Review Update
+        </Button>
+      </Box>
+    </Notice>
   );
 };
 

--- a/packages/manager/src/features/GlobalNotifications/ComplianceBanner.tsx
+++ b/packages/manager/src/features/GlobalNotifications/ComplianceBanner.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+
+import DismissibleBanner from 'src/components/DismissibleBanner';
+import Grid from 'src/components/core/Grid';
+import Typography from 'src/components/core/Typography';
+import Button from 'src/components/Button';
+import ComplianceUpdateModal from './ComplianceUpdateModal';
+
+const ComplianceBanner: React.FC<{}> = () => {
+  const [dialogOpen, setDialogOpen] = React.useState(false);
+
+  return (
+    <>
+      <DismissibleBanner preferenceKey="gdpr-compliance">
+        <Grid
+          container
+          direction="row"
+          alignItems="center"
+          justify="space-between"
+        >
+          <Grid item xs={9}>
+            <Typography>
+              Please review the compliance update for guidance regarding the EU
+              Standard Contractual Clauses and its application to user
+              deployments in Linode’s London and Frankfurt data centers.
+            </Typography>
+          </Grid>
+          <Grid
+            item
+            xs={3}
+            style={{ display: 'flex', justifyContent: 'flex-end' }}
+          >
+            <Button buttonType="primary" onClick={() => setDialogOpen(true)}>
+              Review Update
+            </Button>
+          </Grid>
+        </Grid>
+      </DismissibleBanner>
+      <ComplianceUpdateModal
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+      />
+    </>
+  );
+};
+
+export default ComplianceBanner;

--- a/packages/manager/src/features/GlobalNotifications/ComplianceBanner.tsx
+++ b/packages/manager/src/features/GlobalNotifications/ComplianceBanner.tsx
@@ -6,15 +6,15 @@ import { useDismissibleBanner } from 'src/components/DismissibleBanner/Dismissib
 import Notice from 'src/components/Notice';
 import { complianceUpdateContext } from 'src/context/complianceUpdateContext';
 import useNotifications from 'src/hooks/useNotifications';
+import { isEUModelContractNotification } from '../NotificationCenter/NotificationData/useFormattedNotifications';
 
 const ComplianceBanner: React.FC<{}> = () => {
   const context = React.useContext(complianceUpdateContext);
   const notifications = useNotifications();
 
-  const hasComplianceNotification =
-    notifications.filter((thisNotification) => {
-      return thisNotification.message.match(/eu-model/gi);
-    }).length > 0;
+  const hasComplianceNotification = notifications.some((thisNotification) =>
+    isEUModelContractNotification(thisNotification)
+  );
 
   const { hasDismissedBanner, handleDismiss } = useDismissibleBanner(
     'gdpr-compliance'

--- a/packages/manager/src/features/GlobalNotifications/ComplianceUpdateModal.tsx
+++ b/packages/manager/src/features/GlobalNotifications/ComplianceUpdateModal.tsx
@@ -71,9 +71,9 @@ const ComplianceUpdateModal: React.FC<{}> = () => {
       error={error}
     >
       <Typography>
-        Recent legal changes now require all users with deployments in Linode’s
-        London or Frankfurt data centers to be covered under the EU Standard
-        Contractual Clauses.
+        Recent legal changes now require users located in Europe, or with
+        deployments in Linode’s London or Frankfurt data centers, to be covered
+        under the revised EU Standard Contractual Clauses.
       </Typography>
       <Typography style={{ marginTop: 16 }}>
         After your review, please click the box below if the agreement is

--- a/packages/manager/src/features/GlobalNotifications/ComplianceUpdateModal.tsx
+++ b/packages/manager/src/features/GlobalNotifications/ComplianceUpdateModal.tsx
@@ -2,9 +2,7 @@ import * as React from 'react';
 import { useDispatch } from 'react-redux';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
-import ConfirmationDialog, {
-  ConfirmationDialogProps,
-} from 'src/components/ConfirmationDialog';
+import ConfirmationDialog from 'src/components/ConfirmationDialog';
 import Typography from 'src/components/core/Typography';
 import SupportLink from 'src/components/SupportLink';
 import { Dispatch } from 'src/hooks/types';
@@ -12,24 +10,25 @@ import { useMutateAccountAgreements } from 'src/queries/accountAgreements';
 import { requestNotifications } from 'src/store/notification/notification.requests';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import EUAgreementCheckbox from '../Account/Agreements/EUAgreementCheckbox';
+import { complianceUpdateContext } from 'src/context/complianceUpdateContext';
 
-type Props = Omit<ConfirmationDialogProps, 'title'>;
-
-const ComplianceUpdateModal: React.FC<Props> = (props) => {
+const ComplianceUpdateModal: React.FC<{}> = () => {
   const [error, setError] = React.useState('');
   const [checked, setChecked] = React.useState(false);
   const dispatch: Dispatch = useDispatch();
+
+  const complianceModelContext = React.useContext(complianceUpdateContext);
 
   const {
     mutateAsync: updateAccountAgreements,
     isLoading,
   } = useMutateAccountAgreements();
 
-  const handleClick = () => {
+  const handleAgree = () => {
     setError('');
     updateAccountAgreements({ eu_model: true, privacy_policy: true })
       .then(() => {
-        props.onClose();
+        complianceModelContext.close();
         // Re-request notifications so the GDPR notification goes away.
         dispatch(requestNotifications());
       })
@@ -44,7 +43,8 @@ const ComplianceUpdateModal: React.FC<Props> = (props) => {
 
   return (
     <ConfirmationDialog
-      {...props}
+      open={complianceModelContext.isOpen}
+      onClose={complianceModelContext.close}
       title="Compliance Update"
       actions={() => (
         <ActionsPanel>
@@ -52,7 +52,7 @@ const ComplianceUpdateModal: React.FC<Props> = (props) => {
             buttonType="secondary"
             onClick={() => {
               setChecked(false);
-              props.onClose();
+              complianceModelContext.close();
             }}
             data-qa-cancel
           >
@@ -60,7 +60,7 @@ const ComplianceUpdateModal: React.FC<Props> = (props) => {
           </Button>
           <Button
             buttonType="primary"
-            onClick={handleClick}
+            onClick={handleAgree}
             loading={isLoading}
             disabled={!checked}
           >
@@ -79,10 +79,10 @@ const ComplianceUpdateModal: React.FC<Props> = (props) => {
         After your review, please click the box below if the agreement is
         acceptable, or{' '}
         <SupportLink
-          text="contact us"
+          text="open a Support Ticket"
           onClick={() => {
             setChecked(false);
-            props.onClose();
+            complianceModelContext.close();
           }}
           title="Updates to the new EU Model Contact"
         />{' '}

--- a/packages/manager/src/features/GlobalNotifications/ComplianceUpdateModal.tsx
+++ b/packages/manager/src/features/GlobalNotifications/ComplianceUpdateModal.tsx
@@ -63,7 +63,7 @@ const ComplianceUpdateModal: React.FC<Props> = (props) => {
             loading={isLoading}
             disabled={!checked}
           >
-            Return to Cloud Manager
+            Agree
           </Button>
         </ActionsPanel>
       )}

--- a/packages/manager/src/features/GlobalNotifications/ComplianceUpdateModal.tsx
+++ b/packages/manager/src/features/GlobalNotifications/ComplianceUpdateModal.tsx
@@ -26,7 +26,7 @@ const ComplianceUpdateModal: React.FC<Props> = (props) => {
 
   const handleClick = () => {
     setError('');
-    updateAccountAgreements({ eu_model: true })
+    updateAccountAgreements({ eu_model: true, privacy_policy: true })
       .then(() => {
         props.onClose();
         // Re-request notifications so the GDPR notification goes away.

--- a/packages/manager/src/features/GlobalNotifications/ComplianceUpdateModal.tsx
+++ b/packages/manager/src/features/GlobalNotifications/ComplianceUpdateModal.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
+import { useDispatch } from 'react-redux';
 import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
 import ConfirmationDialog, {
   ConfirmationDialogProps,
 } from 'src/components/ConfirmationDialog';
-import Button from 'src/components/Button';
-
-import { useMutateAccountAgreements } from 'src/queries/accountAgreements';
-import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import Typography from 'src/components/core/Typography';
+import { Dispatch } from 'src/hooks/types';
+import { useMutateAccountAgreements } from 'src/queries/accountAgreements';
+import { requestNotifications } from 'src/store/notification/notification.requests';
+import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import EUAgreementCheckbox from '../Account/Agreements/EUAgreementCheckbox';
 
 type Props = Omit<ConfirmationDialogProps, 'title'>;
@@ -15,6 +17,7 @@ type Props = Omit<ConfirmationDialogProps, 'title'>;
 const ComplianceUpdateModal: React.FC<Props> = (props) => {
   const [error, setError] = React.useState('');
   const [checked, setChecked] = React.useState(false);
+  const dispatch: Dispatch = useDispatch();
 
   const {
     mutateAsync: updateAccountAgreements,
@@ -26,6 +29,8 @@ const ComplianceUpdateModal: React.FC<Props> = (props) => {
     updateAccountAgreements({ eu_model: true })
       .then(() => {
         props.onClose();
+        // Re-request notifications so the GDPR notification goes away.
+        dispatch(requestNotifications());
       })
       .catch((err) => {
         const errorMessage = getErrorStringOrDefault(

--- a/packages/manager/src/features/GlobalNotifications/ComplianceUpdateModal.tsx
+++ b/packages/manager/src/features/GlobalNotifications/ComplianceUpdateModal.tsx
@@ -6,6 +6,7 @@ import ConfirmationDialog, {
   ConfirmationDialogProps,
 } from 'src/components/ConfirmationDialog';
 import Typography from 'src/components/core/Typography';
+import SupportLink from 'src/components/SupportLink';
 import { Dispatch } from 'src/hooks/types';
 import { useMutateAccountAgreements } from 'src/queries/accountAgreements';
 import { requestNotifications } from 'src/store/notification/notification.requests';
@@ -76,8 +77,16 @@ const ComplianceUpdateModal: React.FC<Props> = (props) => {
       </Typography>
       <Typography style={{ marginTop: 16 }}>
         After your review, please click the box below if the agreement is
-        acceptable, or contact us at support@linode.com if you have any
-        questions.
+        acceptable, or{' '}
+        <SupportLink
+          text="contact us"
+          onClick={() => {
+            setChecked(false);
+            props.onClose();
+          }}
+          title="Updates to the new EU Model Contact"
+        />{' '}
+        if you have any questions.
       </Typography>
       <div style={{ marginTop: 24 }}>
         <EUAgreementCheckbox

--- a/packages/manager/src/features/GlobalNotifications/ComplianceUpdateModal.tsx
+++ b/packages/manager/src/features/GlobalNotifications/ComplianceUpdateModal.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+import ActionsPanel from 'src/components/ActionsPanel';
+import ConfirmationDialog, {
+  ConfirmationDialogProps,
+} from 'src/components/ConfirmationDialog';
+import Button from 'src/components/Button';
+
+import { useMutateAccountAgreements } from 'src/queries/accountAgreements';
+import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
+import Typography from 'src/components/core/Typography';
+import EUAgreementCheckbox from '../Account/Agreements/EUAgreementCheckbox';
+
+type Props = Omit<ConfirmationDialogProps, 'title'>;
+
+const ComplianceUpdateModal: React.FC<Props> = (props) => {
+  const [error, setError] = React.useState('');
+  const [checked, setChecked] = React.useState(false);
+
+  const {
+    mutateAsync: updateAccountAgreements,
+    isLoading,
+  } = useMutateAccountAgreements();
+
+  const handleClick = () => {
+    setError('');
+    updateAccountAgreements({ eu_model: true })
+      .then(() => {
+        props.onClose();
+      })
+      .catch((err) => {
+        const errorMessage = getErrorStringOrDefault(
+          err,
+          'There was an error updating your account. If this issue persists please contact Customer Support.'
+        );
+        setError(errorMessage);
+      });
+  };
+
+  return (
+    <ConfirmationDialog
+      {...props}
+      title="Compliance Update"
+      actions={() => (
+        <ActionsPanel>
+          <Button
+            buttonType="secondary"
+            onClick={() => {
+              setChecked(false);
+              props.onClose();
+            }}
+            data-qa-cancel
+          >
+            Close
+          </Button>
+          <Button
+            buttonType="primary"
+            onClick={handleClick}
+            loading={isLoading}
+            disabled={!checked}
+          >
+            Return to Cloud Manager
+          </Button>
+        </ActionsPanel>
+      )}
+      error={error}
+    >
+      <Typography>
+        Recent legal changes now require all users with deployments in Linode’s
+        London or Frankfurt data centers to be covered under the EU Standard
+        Contractual Clauses.
+      </Typography>
+      <Typography style={{ marginTop: 16 }}>
+        After your review, please click the box below if the agreement is
+        acceptable, or contact us at support@linode.com if you have any
+        questions.
+      </Typography>
+      <div style={{ marginTop: 24 }}>
+        <EUAgreementCheckbox
+          checked={checked}
+          onChange={(e) => setChecked(e.target.checked)}
+        />
+      </div>
+    </ConfirmationDialog>
+  );
+};
+
+export default ComplianceUpdateModal;

--- a/packages/manager/src/features/GlobalNotifications/GlobalNotifications.tsx
+++ b/packages/manager/src/features/GlobalNotifications/GlobalNotifications.tsx
@@ -3,6 +3,7 @@ import AbuseTicketBanner from 'src/components/AbuseTicketBanner';
 import { useRegionsQuery } from 'src/queries/regions';
 import RegionStatusBanner from './RegionStatusBanner';
 import { EmailBounceNotificationSection } from './EmailBounce';
+import ComplianceBanner from './ComplianceBanner';
 
 const GlobalNotifications: React.FC<{}> = () => {
   const regions = useRegionsQuery().data ?? [];
@@ -12,6 +13,7 @@ const GlobalNotifications: React.FC<{}> = () => {
       <EmailBounceNotificationSection />
       <RegionStatusBanner regions={regions} />
       <AbuseTicketBanner />
+      <ComplianceBanner />
     </>
   );
 };

--- a/packages/manager/src/features/GlobalNotifications/GlobalNotifications.tsx
+++ b/packages/manager/src/features/GlobalNotifications/GlobalNotifications.tsx
@@ -4,9 +4,12 @@ import { useRegionsQuery } from 'src/queries/regions';
 import RegionStatusBanner from './RegionStatusBanner';
 import { EmailBounceNotificationSection } from './EmailBounce';
 import ComplianceBanner from './ComplianceBanner';
+import ComplianceUpdateModal from './ComplianceUpdateModal';
+import { complianceUpdateContext } from 'src/context/complianceUpdateContext';
 
 const GlobalNotifications: React.FC<{}> = () => {
   const regions = useRegionsQuery().data ?? [];
+  const complianceModelContext = React.useContext(complianceUpdateContext);
 
   return (
     <>
@@ -14,6 +17,10 @@ const GlobalNotifications: React.FC<{}> = () => {
       <RegionStatusBanner regions={regions} />
       <AbuseTicketBanner />
       <ComplianceBanner />
+      <ComplianceUpdateModal
+        open={complianceModelContext.isOpen}
+        onClose={complianceModelContext.close}
+      />
     </>
   );
 };

--- a/packages/manager/src/features/GlobalNotifications/GlobalNotifications.tsx
+++ b/packages/manager/src/features/GlobalNotifications/GlobalNotifications.tsx
@@ -5,11 +5,9 @@ import RegionStatusBanner from './RegionStatusBanner';
 import { EmailBounceNotificationSection } from './EmailBounce';
 import ComplianceBanner from './ComplianceBanner';
 import ComplianceUpdateModal from './ComplianceUpdateModal';
-import { complianceUpdateContext } from 'src/context/complianceUpdateContext';
 
 const GlobalNotifications: React.FC<{}> = () => {
   const regions = useRegionsQuery().data ?? [];
-  const complianceModelContext = React.useContext(complianceUpdateContext);
 
   return (
     <>
@@ -17,10 +15,7 @@ const GlobalNotifications: React.FC<{}> = () => {
       <RegionStatusBanner regions={regions} />
       <AbuseTicketBanner />
       <ComplianceBanner />
-      <ComplianceUpdateModal
-        open={complianceModelContext.isOpen}
-        onClose={complianceModelContext.close}
-      />
+      <ComplianceUpdateModal />
     </>
   );
 };

--- a/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.test.ts
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.test.ts
@@ -1,5 +1,8 @@
-import { adjustSeverity } from './useFormattedNotifications';
-import { notificationFactory } from 'src/factories';
+import { gdprComplianceNotification, notificationFactory } from 'src/factories';
+import {
+  adjustSeverity,
+  isEUModelContractNotification,
+} from './useFormattedNotifications';
 
 // Migration types are considered as types of maintenance notifications.
 const migrationScheduled = notificationFactory.build({
@@ -48,5 +51,15 @@ describe('Notification Severity', () => {
         migrationPending.severity
       );
     });
+  });
+});
+
+describe('EU Model Contract Notification', () => {
+  it('returns `true` only if the Notification is regarding the EU Model Contract', () => {
+    const gdprNotification = gdprComplianceNotification.build();
+    const otherNotification = notificationFactory.build();
+
+    expect(isEUModelContractNotification(gdprNotification)).toBe(true);
+    expect(isEUModelContractNotification(otherNotification)).toBe(false);
   });
 });

--- a/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
@@ -330,7 +330,7 @@ const ComplianceNotification: React.FC<{}> = () => {
 };
 
 export const isEUModelContractNotification = (notification: Notification) => {
-  return Boolean(
-    notification.type === 'notice' && notification.message.match(/eu-model/gi)
+  return (
+    notification.type === 'notice' && /eu-model/gi.test(notification.message)
   );
 };

--- a/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
@@ -2,9 +2,12 @@ import { Notification, NotificationSeverity } from '@linode/api-v4/lib/account';
 import { DateTime } from 'luxon';
 import { path } from 'ramda';
 import * as React from 'react';
+import Button from 'src/components/Button';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import { Link } from 'src/components/Link';
 import { dcDisplayNames } from 'src/constants';
+import { complianceUpdateContext } from 'src/context/complianceUpdateContext';
 import { reportException } from 'src/exceptionReporting';
 import { useStyles } from 'src/features/NotificationCenter/NotificationData/RenderNotification';
 import useDismissibleNotifications from 'src/hooks/useDismissibleNotifications';
@@ -259,8 +262,21 @@ const interceptNotification = (
     };
   }
 
+  if (
+    notification.type === 'notice' &&
+    notification.message.match(/compliance update/gi)
+  ) {
+    // This needs to be its own component so it can use hooks.
+    const jsx = <ComplianceNotification />;
+
+    return {
+      ...notification,
+      jsx,
+    };
+  }
+
   /* If the notification is not of any of the types above, return the notification object without modification. In this case, logic in <RenderNotification />
-  will either linkify notifcation.message or render it plainly.
+  will either linkify notification.message or render it plainly.
   */
   return notification;
 };
@@ -289,3 +305,29 @@ export const adjustSeverity = ({
 };
 
 export default useFormattedNotifications;
+
+const useComplianceNotificationStyles = makeStyles((theme: Theme) => ({
+  reviewUpdateButton: {
+    ...theme.applyLinkStyles,
+    minHeight: 0,
+  },
+}));
+
+const ComplianceNotification: React.FC<{}> = () => {
+  const classes = useComplianceNotificationStyles();
+  const complianceModelContext = React.useContext(complianceUpdateContext);
+
+  return (
+    <Typography>
+      Please review the compliance update for guidance regarding the EU Standard
+      Contractual Clauses and its application to user deployments in Linode’s
+      London and Frankfurt data centers.{' '}
+      <Button
+        className={classes.reviewUpdateButton}
+        onClick={() => complianceModelContext.open()}
+      >
+        Review compliance update.
+      </Button>
+    </Typography>
+  );
+};

--- a/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
@@ -262,10 +262,7 @@ const interceptNotification = (
     };
   }
 
-  if (
-    notification.type === 'notice' &&
-    notification.message.match(/eu-model/gi)
-  ) {
+  if (isEUModelContractNotification(notification)) {
     // This needs to be its own component so it can use hooks.
     const jsx = <ComplianceNotification />;
 
@@ -329,5 +326,11 @@ const ComplianceNotification: React.FC<{}> = () => {
         Review compliance update.
       </Button>
     </Typography>
+  );
+};
+
+export const isEUModelContractNotification = (notification: Notification) => {
+  return Boolean(
+    notification.type === 'notice' && notification.message.match(/eu-model/gi)
   );
 };

--- a/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
@@ -264,7 +264,7 @@ const interceptNotification = (
 
   if (
     notification.type === 'notice' &&
-    notification.message.match(/compliance update/gi)
+    notification.message.match(/eu-model/gi)
   ) {
     // This needs to be its own component so it can use hooks.
     const jsx = <ComplianceNotification />;

--- a/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
@@ -317,8 +317,8 @@ const ComplianceNotification: React.FC<{}> = () => {
   return (
     <Typography>
       Please review the compliance update for guidance regarding the EU Standard
-      Contractual Clauses and its application to user deployments in Linode’s
-      London and Frankfurt data centers.{' '}
+      Contractual Clauses and its application to users located in Europe as well
+      as deployments in Linode’s London and Frankfurt data centers
       <Button
         className={classes.reviewUpdateButton}
         onClick={() => complianceModelContext.open()}

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -674,16 +674,16 @@ export const handlers = [
       ctx.json(
         makeResourcePage([
           // pastDueBalance,
-          ...notificationFactory.buildList(1),
+          // ...notificationFactory.buildList(1),
           gdprNotification,
-          generalGlobalNotice,
-          outageNotification,
-          minorSeverityNotification,
-          criticalSeverityNotification,
-          abuseTicket,
+          // generalGlobalNotice,
+          // outageNotification,
+          // minorSeverityNotification,
+          // criticalSeverityNotification,
+          // abuseTicket,
           // emailBounce,
-          migrationNotification,
-          balanceNotification,
+          // migrationNotification,
+          // balanceNotification,
         ])
       )
     );

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -1,7 +1,7 @@
 import { rest, RequestHandler } from 'msw';
 
 import {
-  abuseTicketNotificationFactory,
+  // abuseTicketNotificationFactory,
   accountFactory,
   appTokenFactory,
   creditPaymentResponseFactory,
@@ -31,7 +31,7 @@ import {
   maintenanceResponseFactory,
   monitorFactory,
   nodeBalancerFactory,
-  notificationFactory,
+  // notificationFactory,
   objectStorageBucketFactory,
   objectStorageClusterFactory,
   profileFactory,
@@ -600,35 +600,35 @@ export const handlers = [
 
     const gdprNotification = gdprComplianceNotification.build();
 
-    const generalGlobalNotice = {
-      type: 'notice',
-      entity: null,
-      when: null,
-      // eslint-disable-next-line xss/no-mixed-html
-      message:
-        "We've updated our policies. See <a href='https://cloud.linode.com/support'>this page</a> for more information.",
-      label: "We've updated our policies.",
-      severity: 'minor',
-      until: null,
-      body: null,
-    };
+    // const generalGlobalNotice = {
+    //   type: 'notice',
+    //   entity: null,
+    //   when: null,
+    //   // eslint-disable-next-line xss/no-mixed-html
+    //   message:
+    //     "We've updated our policies. See <a href='https://cloud.linode.com/support'>this page</a> for more information.",
+    //   label: "We've updated our policies.",
+    //   severity: 'minor',
+    //   until: null,
+    //   body: null,
+    // };
 
-    const outageNotification = {
-      type: 'outage',
-      entity: {
-        type: 'region',
-        label: null,
-        id: 'us-east',
-        url: '/regions/us-east',
-      },
-      when: null,
-      message:
-        'We are aware of an issue affecting service in this facility. If you are experiencing service issues in this facility, there is no need to open a support ticket at this time. Please monitor our status blog at https://status.linode.com for further information.  Thank you for your patience and understanding.',
-      label: 'There is an issue affecting service in this facility',
-      severity: 'major',
-      until: null,
-      body: null,
-    };
+    // const outageNotification = {
+    //   type: 'outage',
+    //   entity: {
+    //     type: 'region',
+    //     label: null,
+    //     id: 'us-east',
+    //     url: '/regions/us-east',
+    //   },
+    //   when: null,
+    //   message:
+    //     'We are aware of an issue affecting service in this facility. If you are experiencing service issues in this facility, there is no need to open a support ticket at this time. Please monitor our status blog at https://status.linode.com for further information.  Thank you for your patience and understanding.',
+    //   label: 'There is an issue affecting service in this facility',
+    //   severity: 'major',
+    //   until: null,
+    //   body: null,
+    // };
 
     // const emailBounce = notificationFactory.build({
     //   type: 'billing_email_bounce',
@@ -641,34 +641,34 @@ export const handlers = [
     //   body: null,
     // });
 
-    const abuseTicket = abuseTicketNotificationFactory.build();
+    // const abuseTicket = abuseTicketNotificationFactory.build();
 
-    const migrationNotification = notificationFactory.build({
-      type: 'migration_pending',
-      label: 'You have a migration pending!',
-      message:
-        'You have a migration pending! Your Linode must be offline before starting the migration.',
-      entity: { id: 0, type: 'linode', label: 'linode-0' },
-      severity: 'major',
-    });
+    // const migrationNotification = notificationFactory.build({
+    //   type: 'migration_pending',
+    //   label: 'You have a migration pending!',
+    //   message:
+    //     'You have a migration pending! Your Linode must be offline before starting the migration.',
+    //   entity: { id: 0, type: 'linode', label: 'linode-0' },
+    //   severity: 'major',
+    // });
 
-    const minorSeverityNotification = notificationFactory.build({
-      type: 'notice',
-      message: 'Testing for minor notification',
-      severity: 'minor',
-    });
+    // const minorSeverityNotification = notificationFactory.build({
+    //   type: 'notice',
+    //   message: 'Testing for minor notification',
+    //   severity: 'minor',
+    // });
 
-    const criticalSeverityNotification = notificationFactory.build({
-      type: 'notice',
-      message: 'Testing for critical notification',
-      severity: 'critical',
-    });
+    // const criticalSeverityNotification = notificationFactory.build({
+    //   type: 'notice',
+    //   message: 'Testing for critical notification',
+    //   severity: 'critical',
+    // });
 
-    const balanceNotification = notificationFactory.build({
-      type: 'payment_due',
-      message: 'You have an overdue balance!',
-      severity: 'major',
-    });
+    // const balanceNotification = notificationFactory.build({
+    //   type: 'payment_due',
+    //   message: 'You have an overdue balance!',
+    //   severity: 'major',
+    // });
 
     return res(
       ctx.json(

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -50,6 +50,7 @@ import {
   makeObjectsPage,
   paymentMethodFactory,
   accountMaintenanceFactory,
+  gdprComplianceNotification,
 } from 'src/factories';
 
 import cachedRegions from 'src/cachedData/regions.json';
@@ -597,6 +598,8 @@ export const handlers = [
     //   body: null
     // });
 
+    const gdprNotification = gdprComplianceNotification.build();
+
     const generalGlobalNotice = {
       type: 'notice',
       entity: null,
@@ -672,6 +675,7 @@ export const handlers = [
         makeResourcePage([
           // pastDueBalance,
           ...notificationFactory.buildList(1),
+          gdprNotification,
           generalGlobalNotice,
           outageNotification,
           minorSeverityNotification,


### PR DESCRIPTION
## Description

This adds two things:
1.  Banner indicating the user must accept the EU Model Contract agreement
2. Handling for the EU Model Contract agreement notification

The new modal component sits in the GlobalNotifications wrapper component, and context is used in order to control the component from across the app. This pattern is debatable and honestly I didn’t think about it as much as I would like since we’re moving quickly. If you have other suggestions I’d love to consider them.

I also did a slight refactor of the DismissibleBanner component to be able to use the functionality from another component.

**TODO**: ~Listen for the correct API notification (I just mocked it in for now)~


## How to test

I included a mock notification in serverHandlers so if you use the MSW you should see the banner/notification.

To test dismissibility you'll need to turn the MSW off and remove `!hasComplianceNotification` from L23 of ComplianceBanner.tsx.

To test end-to-end you'll need to use devenv... (haven't done this myself yet).
