### PR TITLE
M3-5231: Reduce bottom padding for grouped display tags

### DIFF
--- a/packages/manager/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
@@ -34,7 +34,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     height: 'auto',
     '& td': {
       // This is maintaining the spacing between groups because of how tables handle margin/padding. Adjust with care!
-      padding: `${theme.spacing(2) + 4}px 0 ${theme.spacing(1) + 2}px`,
+      padding: `${theme.spacing(2) + 4}px 0 ${theme.spacing(0) + 2}px`,
       borderBottom: 'none',
       borderTop: 'none',
     },


### PR DESCRIPTION
## Description

This PR reduces the padding between grouped display tags. Matthew and I settled on simply reducing the padding after taking a look at other stylistic changes. Note: MUI themes specify a spacing value of 8 * n (where n is the index)

Verified with Matthew 2px is what is wanted here

## How to test

Create a few Linodes, tag them in the details view, return to the Linodes screen, and group by tag