### PR TITLE
M3-5444: Add optional prop to Textfield and cleanup optional fields

### DIFF
--- a/packages/manager/src/components/TextField.tsx
+++ b/packages/manager/src/components/TextField.tsx
@@ -34,7 +34,7 @@ type ClassNames =
   | 'tiny'
   | 'absolute'
   | 'helpIcon'
-  | 'required';
+  | 'label';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -112,7 +112,7 @@ const styles = (theme: Theme) =>
     noMarginTop: {
       marginTop: 0,
     },
-    required: {
+    label: {
       fontFamily: theme.font.normal,
     },
   });
@@ -141,6 +141,7 @@ interface BaseProps {
   hideLabel?: boolean;
   hasAbsoluteError?: boolean;
   inputId?: string;
+  optional?: boolean;
 }
 
 interface TextFieldPropsOverrides extends TextFieldProps {
@@ -253,6 +254,7 @@ class LinodeTextField extends React.PureComponent<CombinedProps> {
       loading,
       hasAbsoluteError,
       inputId,
+      optional,
       ...textFieldProps
     } = this.props;
 
@@ -288,7 +290,9 @@ class LinodeTextField extends React.PureComponent<CombinedProps> {
         >
           {label}
           {this.props.required ? (
-            <span className={classes.required}> (required)</span>
+            <span className={classes.label}> (required)</span>
+          ) : this.props.optional ? (
+            <span className={classes.label}> (optional)</span>
           ) : null}
         </InputLabel>
 

--- a/packages/manager/src/features/Account/CloseAccountDialog.tsx
+++ b/packages/manager/src/features/Account/CloseAccountDialog.tsx
@@ -3,10 +3,10 @@ import { APIError } from '@linode/api-v4/lib/types';
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 import { compose } from 'recompose';
-import { makeStyles, Theme } from 'src/components/core/styles';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import Dialog from 'src/components/ConfirmationDialog';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import TextField from 'src/components/TextField';
 import { useProfile } from 'src/queries/profile';
@@ -126,19 +126,20 @@ const CloseAccountDialog: React.FC<CombinedProps> = (props) => {
         inputRef={inputRef}
       />
       <Typography className={classes.dontgo}>
-        We'd hate to see you go. Please let us know what we could be doing
+        We&apos;d hate to see you go. Please let us know what we could be doing
         better in the comments section below. After your account is closed,
-        you'll be directed to a quick survey so we can better gauge your
+        you&apos;ll be directed to a quick survey so we can better gauge your
         feedback.
       </Typography>
       <TextField
+        label="Comments"
         multiline
+        onChange={(e) => setComments(e.target.value)}
+        optional
+        placeholder="Provide Feedback"
+        rows={2}
         value={comments}
         aria-label="Optional comments field"
-        rows={2}
-        label="Comments (optional)"
-        placeholder="Provide Feedback"
-        onChange={(e) => setComments(e.target.value)}
       />
     </Dialog>
   );

--- a/packages/manager/src/features/Account/CloseAccountDialog.tsx
+++ b/packages/manager/src/features/Account/CloseAccountDialog.tsx
@@ -126,9 +126,9 @@ const CloseAccountDialog: React.FC<CombinedProps> = (props) => {
         inputRef={inputRef}
       />
       <Typography className={classes.dontgo}>
-        We&apos;d hate to see you go. Please let us know what we could be doing
+        We’d hate to see you go. Please let us know what we could be doing
         better in the comments section below. After your account is closed,
-        you&apos;ll be directed to a quick survey so we can better gauge your
+        you’ll be directed to a quick survey so we can better gauge your
         feedback.
       </Typography>
       <TextField

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
@@ -2,41 +2,41 @@ import { PaymentMethod } from '@linode/api-v4';
 import { makePayment } from '@linode/api-v4/lib/account';
 import { APIWarning } from '@linode/api-v4/lib/types';
 import * as classnames from 'classnames';
+import { useSnackbar } from 'notistack';
 import * as React from 'react';
 import makeAsyncScriptLoader from 'react-async-script';
-import { v4 } from 'uuid';
-import { useSnackbar } from 'notistack';
-import { cleanCVV } from 'src/features/Billing/billingUtils';
-import { getIcon as getCreditCardIcon } from 'src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCard';
+import Button from 'src/components/Button';
+import Chip from 'src/components/core/Chip';
 import Divider from 'src/components/core/Divider';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
-import Button from 'src/components/Button';
-import Chip from 'src/components/core/Chip';
 import Currency from 'src/components/Currency';
 import Drawer from 'src/components/Drawer';
 import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
 import HelpIcon from 'src/components/HelpIcon';
+import LinearProgress from 'src/components/LinearProgress';
 import Notice from 'src/components/Notice';
 import {
-  thirdPartyPaymentMap,
   getIcon as getTPPIcon,
+  thirdPartyPaymentMap,
 } from 'src/components/PaymentMethodRow/ThirdPartyPayment';
 import SelectionCard from 'src/components/SelectionCard';
 import SupportLink from 'src/components/SupportLink';
 import TextField from 'src/components/TextField';
-import LinearProgress from 'src/components/LinearProgress';
+import { getIcon as getCreditCardIcon } from 'src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCard';
+import { cleanCVV } from 'src/features/Billing/billingUtils';
 import useFlags from 'src/hooks/useFlags';
 import { useAccount } from 'src/queries/account';
 import { queryKey } from 'src/queries/accountBilling';
 import { queryClient } from 'src/queries/base';
 import isCreditCardExpired, { formatExpiry } from 'src/utilities/creditCard';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
-import { SetSuccess } from './types';
+import { v4 } from 'uuid';
 import GooglePayButton from './GooglePayButton';
 import CreditCardDialog from './PaymentBits/CreditCardDialog';
 import PayPal, { paypalScriptSrc } from './Paypal';
+import { SetSuccess } from './types';
 
 // @TODO: remove unused code and feature flag logic once google pay is released
 const useStyles = makeStyles((theme: Theme) => ({
@@ -480,15 +480,16 @@ export const PaymentDrawer: React.FC<Props> = (props) => {
                   </Grid>
                   <Grid item className={classes.cvvFieldWrapper}>
                     <TextField
-                      label="CVV (optional)"
-                      small
-                      onChange={handleCVVChange}
-                      value={cvv}
-                      type="text"
-                      inputProps={{ id: 'paymentCVV' }}
                       className={classes.cvvField}
                       hasAbsoluteError
+                      inputProps={{ id: 'paymentCVV' }}
+                      label="Security Code"
+                      onChange={handleCVVChange}
                       noMarginTop
+                      optional
+                      small
+                      type="text"
+                      value={cvv}
                     />
                   </Grid>
                 </Grid>

--- a/packages/manager/src/features/Managed/Contacts/ContactsDrawer.tsx
+++ b/packages/manager/src/features/Managed/Contacts/ContactsDrawer.tsx
@@ -131,30 +131,32 @@ const ContactsDrawer: React.FC<CombinedProps> = (props) => {
 
               <form onSubmit={handleSubmit}>
                 <TextField
-                  name="name"
                   label="Name"
-                  value={values.name}
+                  name="name"
                   error={!!errors.name}
                   errorText={errors.name}
-                  onChange={handleChange}
                   onBlur={handleBlur}
+                  onChange={handleChange}
+                  required
+                  value={values.name}
                 />
 
                 <TextField
-                  name="email"
                   label="E-mail"
-                  value={values.email}
+                  name="email"
                   error={!!errors.email}
                   errorText={errors.email}
-                  onChange={handleChange}
                   onBlur={handleBlur}
+                  onChange={handleChange}
+                  required
+                  value={values.email}
                 />
 
                 <Grid container>
                   <Grid item xs={12} md={6}>
                     <TextField
                       name="phone.primary"
-                      label="Primary Phone (optional)"
+                      label="Primary Phone"
                       value={pathOr('', ['phone', 'primary'], values)}
                       error={!!primaryPhoneError}
                       errorText={primaryPhoneError}
@@ -165,7 +167,7 @@ const ContactsDrawer: React.FC<CombinedProps> = (props) => {
                   <Grid item xs={12} md={6}>
                     <TextField
                       name="phone.secondary"
-                      label="Secondary Phone (optional)"
+                      label="Secondary Phone"
                       value={pathOr('', ['phone', 'secondary'], values)}
                       error={!!secondaryPhoneError}
                       errorText={secondaryPhoneError}
@@ -177,7 +179,7 @@ const ContactsDrawer: React.FC<CombinedProps> = (props) => {
 
                 {/* @todo: This <Select /> should be clearable eventually, but isn't currently allowed by the API. */}
                 <Select
-                  label="Group (optional)"
+                  label="Group"
                   placeholder="Create or Select a Group"
                   variant="creatable"
                   isClearable={false}
@@ -202,8 +204,8 @@ const ContactsDrawer: React.FC<CombinedProps> = (props) => {
                 <ActionsPanel>
                   <Button
                     buttonType="primary"
-                    onClick={() => handleSubmit()}
                     loading={isSubmitting}
+                    onClick={() => handleSubmit()}
                   >
                     {isEditing ? 'Save Changes' : 'Add Contact'}
                   </Button>

--- a/packages/manager/src/features/Managed/Credentials/AddCredentialDrawer.tsx
+++ b/packages/manager/src/features/Managed/Credentials/AddCredentialDrawer.tsx
@@ -62,7 +62,6 @@ const CredentialDrawer: React.FC<CombinedProps> = (props) => {
                 errorText={errors.label}
                 onBlur={handleBlur}
                 onChange={handleChange}
-                required
                 value={values.label}
                 data-qa-add-label
               />
@@ -74,6 +73,7 @@ const CredentialDrawer: React.FC<CombinedProps> = (props) => {
                 errorText={errors.username}
                 onBlur={handleBlur}
                 onChange={handleChange}
+                optional
                 value={values.username}
                 data-qa-add-username
               />
@@ -88,7 +88,6 @@ const CredentialDrawer: React.FC<CombinedProps> = (props) => {
                   hideValidation
                   onBlur={handleBlur}
                   onChange={handleChange}
-                  required
                   type="password"
                   value={values.password}
                   data-qa-add-password

--- a/packages/manager/src/features/Managed/Credentials/AddCredentialDrawer.tsx
+++ b/packages/manager/src/features/Managed/Credentials/AddCredentialDrawer.tsx
@@ -1,16 +1,15 @@
-import { Formik } from 'formik';
 import { CredentialPayload } from '@linode/api-v4/lib/managed';
+import { Formik } from 'formik';
 import * as React from 'react';
-
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import Drawer from 'src/components/Drawer';
 import Notice from 'src/components/Notice';
-const PasswordInput = React.lazy(() => import('src/components/PasswordInput'));
 import SuspenseLoader from 'src/components/SuspenseLoader';
 import TextField from 'src/components/TextField';
-
 import { creationSchema } from './credential.schema';
+
+const PasswordInput = React.lazy(() => import('src/components/PasswordInput'));
 
 export interface Props {
   open: boolean;
@@ -57,56 +56,52 @@ const CredentialDrawer: React.FC<CombinedProps> = (props) => {
 
             <form onSubmit={handleSubmit}>
               <TextField
+                label="Label"
                 name="label"
-                label="Credential Label"
-                data-qa-add-label
-                value={values.label}
                 error={!!errors.label}
                 errorText={errors.label}
-                onChange={handleChange}
                 onBlur={handleBlur}
+                onChange={handleChange}
+                required
+                value={values.label}
+                data-qa-add-label
               />
 
               <TextField
+                label="Username"
                 name="username"
-                label="Username (optional)"
-                data-qa-add-username
-                value={values.username}
                 error={!!errors.username}
                 errorText={errors.username}
-                onChange={handleChange}
                 onBlur={handleBlur}
+                onChange={handleChange}
+                value={values.username}
+                data-qa-add-username
               />
 
               <React.Suspense fallback={<SuspenseLoader />}>
                 <PasswordInput
+                  label="Password"
                   name="password"
-                  label="Password / Passphrase"
-                  type="password"
-                  data-qa-add-password
-                  value={values.password}
                   error={!!errors.password}
                   errorText={errors.password}
-                  onChange={handleChange}
-                  onBlur={handleBlur}
                   // This credential could be anything so might be counterproductive to validate strength
                   hideValidation
+                  onBlur={handleBlur}
+                  onChange={handleChange}
                   required
+                  type="password"
+                  value={values.password}
+                  data-qa-add-password
                 />
               </React.Suspense>
               <ActionsPanel>
-                <Button
-                  onClick={onClose}
-                  data-qa-cancel
-                  buttonType="secondary"
-                  className="cancel"
-                >
+                <Button buttonType="secondary" onClick={onClose} data-qa-cancel>
                   Cancel
                 </Button>
                 <Button
                   buttonType="primary"
-                  onClick={() => handleSubmit()}
                   loading={isSubmitting}
+                  onClick={() => handleSubmit()}
                   data-qa-submit
                 >
                   Add Credential

--- a/packages/manager/src/features/Managed/Credentials/UpdateCredentialDrawer.tsx
+++ b/packages/manager/src/features/Managed/Credentials/UpdateCredentialDrawer.tsx
@@ -140,6 +140,7 @@ const CredentialDrawer: React.FC<CombinedProps> = (props) => {
                 errorText={errors.username}
                 onBlur={handleBlur}
                 onChange={handleChange}
+                optional
                 value={values.username}
                 data-qa-add-username
               />

--- a/packages/manager/src/features/Managed/Credentials/UpdateCredentialDrawer.tsx
+++ b/packages/manager/src/features/Managed/Credentials/UpdateCredentialDrawer.tsx
@@ -1,15 +1,15 @@
-import { Formik } from 'formik';
 import { CredentialPayload } from '@linode/api-v4/lib/managed';
+import { Formik } from 'formik';
 import * as React from 'react';
-
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import Drawer from 'src/components/Drawer';
 import Notice from 'src/components/Notice';
-const PasswordInput = React.lazy(() => import('src/components/PasswordInput'));
 import SuspenseLoader from 'src/components/SuspenseLoader';
 import TextField from 'src/components/TextField';
 import { updateLabelSchema, updatePasswordSchema } from './credential.schema';
+
+const PasswordInput = React.lazy(() => import('src/components/PasswordInput'));
 
 export interface Props {
   label: string;
@@ -68,21 +68,21 @@ const CredentialDrawer: React.FC<CombinedProps> = (props) => {
 
             <form onSubmit={handleSubmit}>
               <TextField
+                label="Label"
                 name="label"
-                label="Credential Label"
-                data-qa-add-label
-                value={values.label}
                 error={!!errors.label}
                 errorText={errors.label}
-                onChange={handleChange}
                 onBlur={handleBlur}
+                onChange={handleChange}
+                value={values.label}
+                data-qa-add-label
               />
 
               <ActionsPanel>
                 <Button
                   buttonType="primary"
-                  onClick={() => handleSubmit()}
                   loading={isSubmitting}
+                  onClick={() => handleSubmit()}
                   data-qa-submit
                 >
                   Update label
@@ -134,29 +134,29 @@ const CredentialDrawer: React.FC<CombinedProps> = (props) => {
 
             <form onSubmit={handleSubmit}>
               <TextField
+                label="Username"
                 name="username"
-                label="Username (optional)"
-                data-qa-add-username
-                value={values.username}
                 error={!!errors.username}
                 errorText={errors.username}
-                onChange={handleChange}
                 onBlur={handleBlur}
+                onChange={handleChange}
+                value={values.username}
+                data-qa-add-username
               />
 
               <React.Suspense fallback={<SuspenseLoader />}>
                 <PasswordInput
+                  label="Password"
                   name="password"
-                  label="Password / Passphrase"
-                  type="password"
-                  data-qa-add-password
-                  value={values.password}
                   error={!!errors.password}
                   errorText={errors.password}
-                  onChange={handleChange}
-                  onBlur={handleBlur}
                   // This credential could be anything so might be counterproductive to validate strength
                   hideValidation
+                  onBlur={handleBlur}
+                  onChange={handleChange}
+                  type="password"
+                  value={values.password}
+                  data-qa-add-password
                 />
               </React.Suspense>
               <ActionsPanel>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/InterfaceSelect.tsx
@@ -218,15 +218,16 @@ export const InterfaceSelect: React.FC<Props> = (props) => {
               <div className={fromAddonsPanel ? classes.ipamAddressLabel : ''}>
                 <TextField
                   inputId={`ipam-input-${slotNumber}`}
-                  label="IPAM Address (Optional)"
-                  placeholder="192.0.2.0/24"
-                  value={ipamAddress}
+                  label="IPAM Address"
+                  disabled={readOnly}
                   errorText={ipamError}
                   onChange={handleAddressChange}
-                  disabled={readOnly}
+                  optional
+                  placeholder="192.0.2.0/24"
                   tooltipText={
                     'IPAM address must use IP/netmask format, e.g. 192.0.2.0/24.'
                   }
+                  value={ipamAddress}
                 />
               </div>
             </Grid>


### PR DESCRIPTION
## Description

Add an optional label to `Textfields` to be used when the majority of fields are required and make the styling match the required styling (ie. lowercase in parenthesis and normal weight). Also renamed some of the fields on `AddCredentialDrawer` and `UpdateCredentialDrawer`.

## How to test

Go to the following components and test to make sure the functionality has not changed:
- Go to `/managed`, click on the "Credentials" tab, and click "Add Credential"
- Go to `/managed`, click on the "Credentials" tab, and click "Edit" on any existing credential
- Go to `/managed`, click on the "Contacts" tab, and click "Add Contact"
- Go to any Linode Details page, click on the "Configurations" tab, click "Add Configuration", and select "VLAN" for any Network Interfaces dropdown
- Go to `/billing` and check the Payment Drawer
- Go to `/account/settings` and click "Close Account"
