### PR TITLE
E2E machine images test fix for ci

### DIFF
--- a/packages/manager/cypress/integration/images/machine-image-upload.spec.ts
+++ b/packages/manager/cypress/integration/images/machine-image-upload.spec.ts
@@ -102,9 +102,6 @@ describe('machine image', () => {
       eventIntercept(imageId, status);
       cy.wait('@getImage');
       cy.wait('@getEvent');
-      assertToast(
-        `Image ${imageLabel} uploaded successfully. It is being processed and will be available shortly.`
-      );
       assertToast(`Image ${imageLabel} is now available.`, 2);
       cy.get(`[data-qa-image-cell="${imageId}"]`).within(() => {
         fbtVisible(imageLabel);

--- a/packages/manager/cypress/integration/images/machine-image-upload.spec.ts
+++ b/packages/manager/cypress/integration/images/machine-image-upload.spec.ts
@@ -49,9 +49,6 @@ const imageIntercept = (id: number, status: ImageStatus) => {
 
 const assertFailed = (imageId: number, message: string) => {
   assertToast(
-    `Image ${imageLabel} uploaded successfully. It is being processed and will be available shortly.`
-  );
-  assertToast(
     `There was a problem processing image ${imageLabel}: ${message}`,
     2
   );
@@ -100,6 +97,9 @@ describe('machine image', () => {
       const imageId = xhr.response?.body.image.id;
       imageIntercept(imageId, 'available');
       eventIntercept(imageId, status);
+      assertToast(
+        `Image ${imageLabel} uploaded successfully. It is being processed and will be available shortly.`
+      );
       cy.wait('@getImage');
       cy.wait('@getEvent');
       assertToast(`Image ${imageLabel} is now available.`, 2);


### PR DESCRIPTION
## Description
since ci runs tend to load slower/differently than they do locally sometimes, I needed to make a couple changes to make sure these pass in ci

## How to test
- `yarn up` in one terminal
- `yarn cy:e2e -s ./cypress/integration/images/machine-image-upload.spec.ts` in another
- Result should be "✔  All specs passed!"

## Make sure your .env contains:
```
REACT_APP_LOGIN_ROOT
REACT_APP_API_ROOT
REACT_APP_APP_ROOT
REACT_APP_LAUNCH_DARKLY_ID
REACT_APP_CLIENT_ID
MANAGER_OAUTH
```