### PR TITLE
Friendly Validation Error Message W/ Nodebalancer

### DIFF
--- a/packages/validation/src/nodebalancers.schema.ts
+++ b/packages/validation/src/nodebalancers.schema.ts
@@ -39,7 +39,7 @@ export const createNodeBalancerConfigSchema = object({
   check_attempts: number(),
   check_body: string().when('check', {
     is: 'http_body',
-    then: string().required(),
+    then: string().required('An HTTP Body RegEx is required'),
   }),
   check_interval: number().typeError('Check interval must be a number.'),
   check_passive: boolean(),
@@ -47,11 +47,11 @@ export const createNodeBalancerConfigSchema = object({
     .matches(/\/.*/)
     .when('check', {
       is: 'http',
-      then: string().required(),
+      then: string().required('An HTTP Path is required'),
     })
     .when('check', {
       is: 'http_body',
-      then: string().required(),
+      then: string().required('An HTTP Path is required'),
     }),
   proxy_protocol: string().oneOf(['none', 'v1', 'v2']),
   check_timeout: number().typeError('Timeout must be a number.').integer(),
@@ -83,7 +83,7 @@ export const UpdateNodeBalancerConfigSchema = object({
   check_attempts: number(),
   check_body: string().when('check', {
     is: 'http_body',
-    then: string().required(),
+    then: string().required('An HTTP Body RegEx is required'),
   }),
   check_interval: number().typeError('Check interval must be a number.'),
   check_passive: boolean(),
@@ -91,11 +91,11 @@ export const UpdateNodeBalancerConfigSchema = object({
     .matches(/\/.*/)
     .when('check', {
       is: 'http',
-      then: string().required(),
+      then: string().required('An HTTP Path is required'),
     })
     .when('check', {
       is: 'http_body',
-      then: string().required(),
+      then: string().required('An HTTP Path is required'),
     }),
   proxy_protocol: string().oneOf(['none', 'v1', 'v2']),
   check_timeout: number().typeError('Timeout must be a number.').integer(),


### PR DESCRIPTION
- update createNodeBalancerConfigSchema object with friendly validation
  error message surrounding HTTP Path and or HTTP Body RegEx
- update UpdateNodeBalancerConfigSchema object with friendly validation
  error message surrounding HTTP Path and or HTTP Body RegEx

Resolves: fix/nodebalancer-validation-errors-msg

## Description

**_First let me give huge kudos!_**  Getting this project up and running was a breeze and super phenomenal!  I also really enjoyed scratching a bit of my old-skool JavaScript dev itch, so much has changed with the introduction of typescript, react, plus just in general a ton of other really neat things!  I also dig how the OAuth Apps pattern works with the .env file, like really, this was a blast to get running from fork-to-local-dev, it's so rare to have that - **PROPS**!

**Currently in Prod, when there is a given error surrounding a missing field validation on the HTTP Path and/or HTTP Body Regular Expression the validation message error is echoed as:**
```
# For HTTP Path
configs[0].check_path is a required field
# For HTTP Body
configs[0].check_body is a required field
```

**This PR Allows for a more friendly way to echo errors back out surrounding Active Health Checks on Nodebalancer either via creation or updating a given Nodebalancer.  This removes the given configs[0] based array/list lookup at first index check_path or check_body reference that currently is echoed out in prod as validation error message.  The text replacement exists as:**

```
# For HTTP Path
An HTTP Path is required
# For HTTP Body
An HTTP Body RegEx is required
```

## How to test

**Visually audit via attached pictures or feel free to spin up branch, this is a text change, no function impact**

<img width="1282" alt="fix_http_status_based" src="https://user-images.githubusercontent.com/5370752/132263193-71b8070c-c7d0-4468-bfe8-210147918bd3.png">
<img width="1282" alt="fix_http_body_based" src="https://user-images.githubusercontent.com/5370752/132263195-3c8512cd-ebdc-4dfc-af75-cdc797905df2.png">
<img width="1282" alt="prod_http_body_based" src="https://user-images.githubusercontent.com/5370752/132263196-3335030b-321c-4689-ba30-e11ec380bb2f.png">
<img width="1282" alt="prod_http_status_based" src="https://user-images.githubusercontent.com/5370752/132263198-aac47ff2-fb77-404e-8bff-0b81c1d7f20e.png">

