### PR TITLE
M3-5445: Change font size for Credentials and Contacts copy

### DIFF
--- a/packages/manager/src/features/Managed/Contacts/Contacts.tsx
+++ b/packages/manager/src/features/Managed/Contacts/Contacts.tsx
@@ -28,6 +28,7 @@ import ContactTableContact from './ContactsTableContent';
 
 const useStyles = makeStyles((theme: Theme) => ({
   copy: {
+    fontSize: '0.875rem',
     marginBottom: theme.spacing(2),
     [theme.breakpoints.down('md')]: {
       marginLeft: theme.spacing(),
@@ -127,7 +128,7 @@ const Contacts: React.FC<CombinedProps> = (props) => {
   return (
     <>
       <DocumentTitleSegment segment="Contacts" />
-      <Typography className={classes.copy} variant="subtitle1">
+      <Typography className={classes.copy}>
         You can assign contact groups to monitors so we know who to talk to in
         the event of a support issue. Create contacts and assign them to a
         group, then assign the group to the appropriate monitor(s).

--- a/packages/manager/src/features/Managed/Credentials/CredentialList.tsx
+++ b/packages/manager/src/features/Managed/Credentials/CredentialList.tsx
@@ -37,6 +37,7 @@ import UpdateCredentialDrawer from './UpdateCredentialDrawer';
 
 const useStyles = makeStyles((theme: Theme) => ({
   copy: {
+    fontSize: '0.875rem',
     marginBottom: theme.spacing(2),
     [theme.breakpoints.down('md')]: {
       marginLeft: theme.spacing(),
@@ -214,9 +215,9 @@ export const CredentialList: React.FC<CombinedProps> = (props) => {
   };
 
   return (
-    <div>
+    <>
       <DocumentTitleSegment segment="Credentials" />
-      <Typography variant="subtitle1" className={classes.copy}>
+      <Typography className={classes.copy}>
         Please share any credentials our support team may need when responding
         to a service issue.
         <br /> Credentials are stored encrypted and all decryption attempts are
@@ -318,7 +319,7 @@ export const CredentialList: React.FC<CombinedProps> = (props) => {
         onSubmitLabel={handleUpdateLabel}
         onSubmitPassword={handleUpdatePassword}
       />
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## Description

Change the font size of the copy to 14px and removed the `subtitle1` variant since it was applying additional styles that we don't need

## How to test

Go to `/managed` and click on the "Credentials" and "Contacts" tab to see the copy