### PR TITLE
GDPR Clean Up and Error Handling

### DIFF
--- a/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -61,7 +61,10 @@ import {
   transformConfigsForRequest,
 } from './utils';
 import { queryClient, simpleMutationHandlers } from 'src/queries/base';
-import { queryKey } from 'src/queries/accountAgreements';
+import {
+  queryKey,
+  reportAgreementSigningError,
+} from 'src/queries/accountAgreements';
 
 type ClassNames = 'title' | 'sidebar';
 
@@ -333,6 +336,7 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
             variables: { eu_model: true, privacy_policy: true },
             mutationFn: signAgreement,
             mutationKey: queryKey,
+            onError: reportAgreementSigningError,
             ...simpleMutationHandlers(queryKey),
           });
         }

--- a/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
@@ -169,9 +169,10 @@ const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
         })
           .then(({ filesystem_path, label: volumeLabel }) => {
             if (hasSignedAgreement) {
-              updateAccountAgreements({ eu_model: true }).catch((err) => {
-                reportAgreementSigningError(err);
-              });
+              updateAccountAgreements({
+                eu_model: true,
+                privacy_policy: true,
+              }).catch(reportAgreementSigningError);
             }
 
             resetForm({ values: initialValues });

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -73,7 +73,10 @@ import {
 import { getRegionIDFromLinodeID } from './utilities';
 import { isEURegion } from 'src/utilities/formatRegion';
 import { queryClient, simpleMutationHandlers } from 'src/queries/base';
-import { queryKey } from 'src/queries/accountAgreements';
+import {
+  queryKey,
+  reportAgreementSigningError,
+} from 'src/queries/accountAgreements';
 
 const DEFAULT_IMAGE = 'linode/debian10';
 
@@ -584,6 +587,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
             variables: { eu_model: true, privacy_policy: true },
             mutationFn: signAgreement,
             mutationKey: queryKey,
+            onError: reportAgreementSigningError,
             ...simpleMutationHandlers(queryKey),
           });
         }

--- a/packages/manager/src/queries/accountAgreements.ts
+++ b/packages/manager/src/queries/accountAgreements.ts
@@ -26,7 +26,7 @@ export const useMutateAccountAgreements = () => {
 
 export const reportAgreementSigningError = (err: any) => {
   let customErrorMessage =
-    'Excepted to sign the EU agreement, but the request resulted in an error';
+    'Expected to sign the EU agreement, but the request resulted in an error';
   const apiErrorMessage = err?.[0]?.reason;
 
   if (apiErrorMessage) {


### PR DESCRIPTION
## Description

- Updates state variable names to be consistent across files
- Adds error handling to all React Query Mutations we added

## Questions

- Should we be calling the API with `{ eu_model: true, privacy_policy: true }`or`{ eu_model: true }`?
  - My thought is `{ eu_model: true, privacy_policy: true }` since the agreement actual copy mentions and links the privacy policy.


## How to test

- Ensure all agreement functionality still works
  - Linode Create
  - Linode Migrate
  - Image Upload
  - Bucket Create
  - Volume Create 
  - Nodebalancer Create
  - ~Kubernetes Create~ (still in progress #7928)