### PR TITLE
M30-5401: EU Contract Cluster Create

### DIFF
--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -28,6 +28,7 @@ import { getMonthlyPrice } from '.././kubeUtils';
 import { PoolNodeWithPrice } from '.././types';
 import KubeCheckoutBar from '../KubeCheckoutBar';
 import NodePoolPanel from './NodePoolPanel';
+import { signAgreement } from '@linode/api-v4/lib/account';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -138,6 +139,7 @@ export const CreateCluster: React.FC<CombinedProps> = (props) => {
   const [version, setVersion] = React.useState<Item<string> | undefined>();
   const [errors, setErrors] = React.useState<APIError[] | undefined>();
   const [submitting, setSubmitting] = React.useState<boolean>(false);
+  const [hasAgreed, setAgreed] = React.useState<boolean>(false);
   const {
     data: versionData,
     isError: versionLoadError,
@@ -179,11 +181,18 @@ export const CreateCluster: React.FC<CombinedProps> = (props) => {
 
     createKubernetesCluster(payload)
       .then((cluster) => push(`/kubernetes/clusters/${cluster.id}`))
+      .then(() => {
+        signAgreement({ eu_model: hasAgreed });
+      })
       .catch((err) => {
         setErrors(getAPIErrorOrDefault(err, 'Error creating your cluster'));
         setSubmitting(false);
         scrollErrorIntoView();
       });
+  };
+
+  const toggleHasAgreed = () => {
+    setAgreed(!hasAgreed);
   };
 
   const addPool = (pool: PoolNodeWithPrice) => {
@@ -351,6 +360,8 @@ export const CreateCluster: React.FC<CombinedProps> = (props) => {
             createCluster,
             classes,
           ]}
+          hasAgreed={hasAgreed}
+          toggleHasAgreed={toggleHasAgreed}
         />
       </Grid>
     </Grid>

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -200,9 +200,7 @@ export const CreateCluster: React.FC<CombinedProps> = (props) => {
       });
   };
 
-  const toggleHasAgreed = () => {
-    setAgreed(!hasAgreed);
-  };
+  const toggleHasAgreed = () => setAgreed((prevHasAgreed) => !prevHasAgreed);
 
   const addPool = (pool: PoolNodeWithPrice) => {
     setNodePools([...nodePools, pool]);

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.test.tsx
@@ -16,6 +16,8 @@ const props: Props = {
   createCluster: jest.fn(),
   typesData: types as ExtendedType[],
   region: undefined,
+  hasAgreed: false,
+  toggleHasAgreed: jest.fn(),
 };
 
 const renderComponent = (_props: Props) =>

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
@@ -8,6 +8,8 @@ import { isEURegion } from 'src/utilities/formatRegion';
 import { getTotalClusterPrice, nodeWarning } from '../kubeUtils';
 import { PoolNodeWithPrice } from '../types';
 import NodePoolSummary from './NodePoolSummary';
+import useAccountManagement from 'src/hooks/useAccountManagement';
+// import { signAgreement } from '';
 
 export interface Props {
   pools: PoolNodeWithPrice[];
@@ -17,6 +19,12 @@ export interface Props {
   updatePool: (poolIdx: number, updatedPool: PoolNodeWithPrice) => void;
   removePool: (poolIdx: number) => void;
   region: string | undefined;
+}
+
+type SetAgreed = (hasAgreed: boolean) => void;
+
+const toggleAgreed = (hasAgreed: boolean, setAgreed: SetAgreed) => {
+  setAgreed(!hasAgreed);
 }
 
 export const KubeCheckoutBar: React.FC<Props> = (props) => {
@@ -33,6 +41,10 @@ export const KubeCheckoutBar: React.FC<Props> = (props) => {
   // Show a warning if any of the pools have fewer than 3 nodes
   const showWarning = pools.some((thisPool) => thisPool.count < 3);
 
+  const { _isRestrictedUser: isRestrictedUser } = useAccountManagement();
+
+  const [hasAgreed, setAgreed] = React.useState(false);
+
   return (
     <CheckoutBar
       data-qa-checkout-bar
@@ -43,8 +55,8 @@ export const KubeCheckoutBar: React.FC<Props> = (props) => {
       onDeploy={createCluster}
       submitText={'Create Cluster'}
       agreement={
-        isEURegion(region) ? (
-          <EUAgreementCheckbox checked={false} onChange={() => null} />
+        isEURegion(region) && !isRestrictedUser ? (
+          <EUAgreementCheckbox checked={hasAgreed} onChange={() => {toggleAgreed(hasAgreed, setAgreed)}} />
         ) : undefined
       }
     >

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
@@ -8,7 +8,8 @@ import { isEURegion } from 'src/utilities/formatRegion';
 import { getTotalClusterPrice, nodeWarning } from '../kubeUtils';
 import { PoolNodeWithPrice } from '../types';
 import NodePoolSummary from './NodePoolSummary';
-import { useAccountManagement } from 'src/hooks/useAccountManagement';
+import { useProfile } from 'src/queries/profile';
+import { useAccountAgreements } from 'src/queries/accountAgreements';
 
 export interface Props {
   pools: PoolNodeWithPrice[];
@@ -38,7 +39,9 @@ export const KubeCheckoutBar: React.FC<Props> = (props) => {
   // Show a warning if any of the pools have fewer than 3 nodes
   const showWarning = pools.some((thisPool) => thisPool.count < 3);
 
-  const { _isRestrictedUser: isRestrictedUser } = useAccountManagement();
+  const { profile } = useProfile();
+  const { agreements } = useAccountAgreements();
+  const showGDPRCheckbox = isEURegion(region) && !profile?.restricted && !agreements?.eu_model;
 
   return (
     <CheckoutBar
@@ -50,7 +53,7 @@ export const KubeCheckoutBar: React.FC<Props> = (props) => {
       onDeploy={createCluster}
       submitText={'Create Cluster'}
       agreement={
-        isEURegion(region) && !isRestrictedUser ? (
+        showGDPRCheckbox ? (
           <EUAgreementCheckbox checked={hasAgreed} onChange={toggleHasAgreed} />
         ) : undefined
       }

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
@@ -42,7 +42,14 @@ export const KubeCheckoutBar: React.FC<Props> = (props) => {
   const { data: profile } = useProfile();
   const { data: agreements } = useAccountAgreements();
   const showGDPRCheckbox =
-    isEURegion(region) && !profile?.restricted && !agreements?.eu_model;
+    isEURegion(region) &&
+    !profile?.restricted &&
+    agreements?.eu_model === false;
+
+  const needsAPool = pools.length < 1;
+  const disableCheckout = Boolean(
+    needsAPool || (!hasAgreed && showGDPRCheckbox)
+  );
 
   return (
     <CheckoutBar
@@ -50,7 +57,7 @@ export const KubeCheckoutBar: React.FC<Props> = (props) => {
       heading="Cluster Summary"
       calculatedPrice={getTotalClusterPrice(pools)}
       isMakingRequest={submitting}
-      disabled={pools.length < 1 || !hasAgreed}
+      disabled={disableCheckout}
       onDeploy={createCluster}
       submitText={'Create Cluster'}
       agreement={

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
@@ -39,9 +39,10 @@ export const KubeCheckoutBar: React.FC<Props> = (props) => {
   // Show a warning if any of the pools have fewer than 3 nodes
   const showWarning = pools.some((thisPool) => thisPool.count < 3);
 
-  const { profile } = useProfile();
-  const { agreements } = useAccountAgreements();
-  const showGDPRCheckbox = isEURegion(region) && !profile?.restricted && !agreements?.eu_model;
+  const { data: profile } = useProfile();
+  const { data: agreements } = useAccountAgreements();
+  const showGDPRCheckbox =
+    isEURegion(region) && !profile?.restricted && !agreements?.eu_model;
 
   return (
     <CheckoutBar

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
@@ -8,8 +8,7 @@ import { isEURegion } from 'src/utilities/formatRegion';
 import { getTotalClusterPrice, nodeWarning } from '../kubeUtils';
 import { PoolNodeWithPrice } from '../types';
 import NodePoolSummary from './NodePoolSummary';
-import useAccountManagement from 'src/hooks/useAccountManagement';
-// import { signAgreement } from '';
+import { useAccountManagement } from 'src/hooks/useAccountManagement';
 
 export interface Props {
   pools: PoolNodeWithPrice[];
@@ -19,12 +18,8 @@ export interface Props {
   updatePool: (poolIdx: number, updatedPool: PoolNodeWithPrice) => void;
   removePool: (poolIdx: number) => void;
   region: string | undefined;
-}
-
-type SetAgreed = (hasAgreed: boolean) => void;
-
-const toggleAgreed = (hasAgreed: boolean, setAgreed: SetAgreed) => {
-  setAgreed(!hasAgreed);
+  hasAgreed: boolean;
+  toggleHasAgreed: () => void;
 }
 
 export const KubeCheckoutBar: React.FC<Props> = (props) => {
@@ -36,6 +31,8 @@ export const KubeCheckoutBar: React.FC<Props> = (props) => {
     typesData,
     updatePool,
     region,
+    hasAgreed,
+    toggleHasAgreed,
   } = props;
 
   // Show a warning if any of the pools have fewer than 3 nodes
@@ -43,20 +40,18 @@ export const KubeCheckoutBar: React.FC<Props> = (props) => {
 
   const { _isRestrictedUser: isRestrictedUser } = useAccountManagement();
 
-  const [hasAgreed, setAgreed] = React.useState(false);
-
   return (
     <CheckoutBar
       data-qa-checkout-bar
       heading="Cluster Summary"
       calculatedPrice={getTotalClusterPrice(pools)}
       isMakingRequest={submitting}
-      disabled={pools.length < 1}
+      disabled={pools.length < 1 || !hasAgreed}
       onDeploy={createCluster}
       submitText={'Create Cluster'}
       agreement={
         isEURegion(region) && !isRestrictedUser ? (
-          <EUAgreementCheckbox checked={hasAgreed} onChange={() => {toggleAgreed(hasAgreed, setAgreed)}} />
+          <EUAgreementCheckbox checked={hasAgreed} onChange={toggleHasAgreed} />
         ) : undefined
       }
     >


### PR DESCRIPTION
## Description

Add's the ability to sign the EU contract agreement for the Create Kubernetes Cluster page.

## How to test

If a user who has not accepted the GDPR agreement tries to create a cluster in an EU region then:

- In the checkout bar there should be a check-box component that allows the customer to agree to the terms.
- When the check-box is not checked then the checkout button should be disabled.
- When the check-box is checked then the checkout button should be enabled.
- If the user has agreed to the GDPR agreement then the checkbox should not be visible.
- If the user selects a region that is not in the EU then the checkbox should not be visible.
