### PR TITLE
Undo label required for Firewall rules

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.test.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.test.tsx
@@ -107,12 +107,6 @@ describe('utilities', () => {
           result: {},
         },
         {
-          value: '',
-          result: {
-            label: 'Label is required.',
-          },
-        },
-        {
           value: 'ab',
           result: {
             label: 'Label must be 3-32 characters.',
@@ -150,7 +144,7 @@ describe('utilities', () => {
       });
     });
     it('accepts a valid form', () => {
-      expect(validateForm('TCP', '22', 'accept-inbound-HTTP')).toEqual({});
+      expect(validateForm('TCP', '22')).toEqual({});
     });
   });
 

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
@@ -827,15 +827,15 @@ export const validateForm = (
 ) => {
   const errors: Partial<Form> = {};
 
-  if (!label) {
-    errors.label = 'Label is required.';
-  } else if (label.length < 3 || label.length > 32) {
-    errors.label = 'Label must be 3-32 characters.';
-  } else if (/^[^a-z]/i.test(label)) {
-    errors.label = 'Label must begin with a letter.';
-  } else if (/[^0-9a-z._-]+/i.test(label)) {
-    errors.label =
-      'Label must include only ASCII letters, numbers, underscores, periods, and dashes.';
+  if (label) {
+    if (label.length < 3 || label.length > 32) {
+      errors.label = 'Label must be 3-32 characters.';
+    } else if (/^[^a-z]/i.test(label)) {
+      errors.label = 'Label must begin with a letter.';
+    } else if (/[^0-9a-z._-]+/i.test(label)) {
+      errors.label =
+        'Label must include only ASCII letters, numbers, underscores, periods, and dashes.';
+    }
   }
 
   if (description && description.length > 100) {


### PR DESCRIPTION
## Description
According to API, the docs are wrong about label being a required field for Firewall rules. This undos that bit from my previous Firewalls PR https://github.com/linode/manager/pull/7874

## How to test

**What are the steps to reproduce the issue or verify the changes?**
- Go to `/firewalls/<firewall_id>`
- In the Rules tab, edit an existing rule or add a new inbound/outbound rule
    - You should be able to edit/add a new rule with a blank label field

**How do I run relevant unit tests?**
`yarn test FirewallRuleDrawer`