### PR TITLE
M3-5437: Fix validation saying "expiring too far in the future" when entering credit card expiration date

### DIFF
--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/AddPaymentMethodDrawer/AddCreditCardForm.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/AddPaymentMethodDrawer/AddCreditCardForm.tsx
@@ -10,11 +10,11 @@ import { useSnackbar } from 'notistack';
 import Notice from 'src/components/Notice';
 import { queryClient } from 'src/queries/base';
 import { CreditCardSchema } from '@linode/validation';
-import { take } from 'ramda';
 import { handleAPIErrors } from 'src/utilities/formikErrorUtils';
 import CheckBox from 'src/components/CheckBox';
 import NumberFormat, { NumberFormatProps } from 'react-number-format';
 import { InputBaseComponentProps } from '@material-ui/core/InputBase/InputBase';
+import { parseExpiryYear } from 'src/utilities/creditCard';
 
 const useStyles = makeStyles((theme: Theme) => ({
   error: {
@@ -150,12 +150,7 @@ const AddCreditCardForm: React.FC<Props> = (props) => {
             onChange={(e) => {
               const value: string[] = e.target.value.split('/');
               setFieldValue('expiry_month', value[0]);
-              setFieldValue(
-                'expiry_year',
-                value[1]
-                  ? take(2, String(new Date().getFullYear())) + value[1]
-                  : undefined
-              );
+              setFieldValue('expiry_year', parseExpiryYear(value[1]));
             }}
             label="Expiration Date"
             placeholder="MM/YY"

--- a/packages/manager/src/utilities/creditCard.test.ts
+++ b/packages/manager/src/utilities/creditCard.test.ts
@@ -151,7 +151,7 @@ describe('credit card expiry date parsing and validation', () => {
         expiry: '05/999',
         cvv: '123',
       },
-      result: 'Must be 2 for 4 digits.',
+      result: 'Expiration year must be 2 for 4 digits.',
     },
     {
       data: {
@@ -159,7 +159,7 @@ describe('credit card expiry date parsing and validation', () => {
         expiry: '05/99999',
         cvv: '123',
       },
-      result: 'Must be 2 for 4 digits.',
+      result: 'Expiration year must be 2 for 4 digits.',
     },
   ].forEach(({ data, result }) => {
     describe(`Expiry year of ${data.expiry}`, () => {

--- a/packages/manager/src/utilities/creditCard.test.ts
+++ b/packages/manager/src/utilities/creditCard.test.ts
@@ -1,5 +1,10 @@
 import { DateTime } from 'luxon';
-import { formatExpiry, hasExpirationPassedFor } from './creditCard';
+import { take } from 'ramda';
+import {
+  formatExpiry,
+  hasExpirationPassedFor,
+  parseExpiryYear,
+} from './creditCard';
 
 describe('isCreditCardExpired', () => {
   describe('give today is 01/01/2019', () => {
@@ -52,6 +57,25 @@ describe('formatExpiry', () => {
     describe(`Expiry date of ${expiry}`, () => {
       it(`should return ${result}`, () => {
         expect(formatExpiry(expiry)).toBe(result);
+      });
+    });
+  });
+});
+
+describe('parseExpiryYear', () => {
+  const currentYearFirstTwoDigits = take(2, String(new Date().getFullYear()));
+
+  [
+    [undefined, undefined],
+    ['2024', '2024'],
+    ['24', `${currentYearFirstTwoDigits}24`],
+    ['2', `${currentYearFirstTwoDigits}2`],
+    ['196', '196'],
+    ['9879', '9879'],
+  ].forEach(([expiry, result]) => {
+    describe(`Expiry year of ${expiry}`, () => {
+      it(`should return ${result}`, () => {
+        expect(parseExpiryYear(expiry)).toBe(result);
       });
     });
   });

--- a/packages/manager/src/utilities/creditCard.test.ts
+++ b/packages/manager/src/utilities/creditCard.test.ts
@@ -104,6 +104,10 @@ describe('credit card expiry date parsing and validation', () => {
     {
       data: {
         card_number: '1111111111111111',
+        // Credit Card expiry years can't be more than 20 years in the future.
+        // We also use currentYear to make sure this test does not fail in many
+        // years down the road.
+        // Using takeLast to similate a user entering the year in a 2 digit format.
         expiry: `09/${takeLast(2, String(currentYear + 21))}`,
         cvv: '123',
       },

--- a/packages/manager/src/utilities/creditCard.test.ts
+++ b/packages/manager/src/utilities/creditCard.test.ts
@@ -141,6 +141,22 @@ describe('credit card expiry date parsing and validation', () => {
       },
       result: 'Expiration month must be a number from 1 to 12.',
     },
+    {
+      data: {
+        card_number: '1111111111111111',
+        expiry: '05/999',
+        cvv: '123',
+      },
+      result: 'Must be 2 for 4 digits.',
+    },
+    {
+      data: {
+        card_number: '1111111111111111',
+        expiry: '05/99999',
+        cvv: '123',
+      },
+      result: 'Must be 2 for 4 digits.',
+    },
   ].forEach(({ data, result }) => {
     describe(`Expiry year of ${data.expiry}`, () => {
       const message =

--- a/packages/manager/src/utilities/creditCard.test.ts
+++ b/packages/manager/src/utilities/creditCard.test.ts
@@ -107,7 +107,7 @@ describe('credit card expiry date parsing and validation', () => {
         // Credit Card expiry years can't be more than 20 years in the future.
         // We also use currentYear to make sure this test does not fail in many
         // years down the road.
-        // Using takeLast to similate a user entering the year in a 2 digit format.
+        // Using takeLast to simulate a user entering the year in a 2 digit format.
         expiry: `09/${takeLast(2, String(currentYear + 21))}`,
         cvv: '123',
       },

--- a/packages/manager/src/utilities/creditCard.ts
+++ b/packages/manager/src/utilities/creditCard.ts
@@ -1,5 +1,5 @@
 import { DateTime } from 'luxon';
-import { takeLast } from 'ramda';
+import { take, takeLast } from 'ramda';
 /**
  * Expiration is the beginning of the day of the first day of the month.
  * Expiration: yyyy-MM-01 00:00:00
@@ -33,6 +33,20 @@ export const formatExpiry = (expiry: string): string => {
   return expiryData[1].length > 2
     ? `${expiryData[0]}/${takeLast(2, expiryData[1])}`
     : expiry;
+};
+
+export const parseExpiryYear = (
+  expiryYear: string | undefined
+): string | undefined => {
+  if (!expiryYear) {
+    return undefined;
+  }
+
+  if (expiryYear.length > 2) {
+    return expiryYear;
+  }
+
+  return take(2, String(new Date().getFullYear())) + expiryYear;
 };
 
 export default hasExpirationPassedFor();

--- a/packages/validation/src/account.schema.ts
+++ b/packages/validation/src/account.schema.ts
@@ -55,6 +55,9 @@ export const CreditCardSchema = object({
     .min(13, 'Credit card number must be between 13 and 23 characters.')
     .max(23, 'Credit card number must be between 13 and 23 characters.'),
   expiry_year: number()
+    .test('length', 'Must be 2 for 4 digits.', (value) =>
+      [2, 4].includes(String(value).length)
+    )
     .required('Expiration year is required.')
     .typeError('Expiration year must be a number.')
     .min(new Date().getFullYear(), 'Expiration year must not be in the past.')

--- a/packages/validation/src/account.schema.ts
+++ b/packages/validation/src/account.schema.ts
@@ -55,7 +55,7 @@ export const CreditCardSchema = object({
     .min(13, 'Credit card number must be between 13 and 23 characters.')
     .max(23, 'Credit card number must be between 13 and 23 characters.'),
   expiry_year: number()
-    .test('length', 'Must be 2 for 4 digits.', (value) =>
+    .test('length', 'Expiration year must be 2 for 4 digits.', (value) =>
       [2, 4].includes(String(value).length)
     )
     .required('Expiration year is required.')


### PR DESCRIPTION
## Description

- Allows user to enter a **two digit** or **four digit** expiry date
- Users were getting `Expiry too far in the future.` when entering a four digit year (MM/YYYY).
- Added `parseExpiryYear = (expiryYear: string | undefined): string | undefined` function to parse user input (year only)
  - Added some unit tests for this

## How to test

- Test the validation for the Credit Card form in the **Add a Payment Method** Drawer
  - Test the **Expiry** field specifically
  - Test with a 4 digit expiry year
  - Test with a 2 digit expiry year
- `yarn test creditCard`