### PR TITLE
M3-5442: Linode Details: remove /128 prefix length from IPv6 address

### DIFF
--- a/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
+++ b/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
@@ -117,9 +117,7 @@ const LinodeEntityDetail: React.FC<CombinedProps> = (props) => {
     progress = getProgressOrDefault(recentEvent);
     transitionText = _transitionText(linode.status, linode.id, recentEvent);
   }
-  const trimmedIPv6 = linode.ipv6
-    ? linode.ipv6.replace('/128', '')
-    : linode.ipv6;
+  const trimmedIPv6 = linode.ipv6?.replace('/128', '') || null;
 
   return (
     <EntityDetail

--- a/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
+++ b/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
@@ -117,6 +117,9 @@ const LinodeEntityDetail: React.FC<CombinedProps> = (props) => {
     progress = getProgressOrDefault(recentEvent);
     transitionText = _transitionText(linode.status, linode.id, recentEvent);
   }
+  const trimmedIPv6 = linode.ipv6
+    ? linode.ipv6.replace('/128', '')
+    : linode.ipv6;
 
   return (
     <EntityDetail
@@ -149,7 +152,7 @@ const LinodeEntityDetail: React.FC<CombinedProps> = (props) => {
           gbStorage={linode.specs.disk / 1024}
           region={linode.region}
           ipv4={linode.ipv4}
-          ipv6={linode.ipv6}
+          ipv6={trimmedIPv6}
           linodeId={linode.id}
           username={username ? username : 'none'}
         />


### PR DESCRIPTION
## Description

Removes the prefix length for IPv6 on the Linode Details Page

## How to test

Navigate to a Linode that has an IPv6 address. In the details header the IPv6 address should not include the length prefix `/128`
