### PR TITLE
M3-5458: Adjustments for API Scheduled Maintenance feature flag and banner

### DIFF
--- a/packages/manager/src/factories/statusPage.ts
+++ b/packages/manager/src/factories/statusPage.ts
@@ -97,14 +97,28 @@ export const maintenanceResponseFactory = Factory.Sync.makeFactory<MaintenanceRe
     scheduled_maintenances: [
       maintenanceFactory.build({
         id: 'test001',
-        name: 'Linode Database Infrastructure Maintenance',
+        name:
+          'Cloud Manager and API Downtime on September 23, 2021 for 3-hour window',
         incident_updates: [
           incidentUpdateFactory.build({
+            // eslint-disable-next-line xss/no-mixed-html
             body:
-              'A maintenance window has been scheduled for upgrades to the Linode database infrastructure on September 19th 2021, from 7PM until 10PM EDT (23:00 to 02:00 UTC). During this time, running Linodes will not be impacted but customers will not be able to perform tasks in the Cloud Manager or Linode API.',
+              'The Linode Cloud Manager, API, and CLI will be offline for internal upgrades and maintenance on Thursday, September 23rd, 2021, from 7PM until 10PM EDT (23:00 to 02:00 UTC). During this window, running Linodes and related services will <b>not</b> be disrupted, but account management access and support tickets will be unavailable.',
           }),
         ],
       }),
+      // maintenanceFactory.build({
+      //   id: 'test002',
+      //   name:
+      //     'Cloud Manager and API Downtime on December 23, 2021 for 5-hour window',
+      //   incident_updates: [
+      //     incidentUpdateFactory.build({
+      //       // eslint-disable-next-line xss/no-mixed-html
+      //       body:
+      //         'The Linode Cloud Manager, API, and CLI will be offline for internal upgrades and maintenance on December 23rd, 2021, from 6PM until 11PM EDT. During this window, running Linodes and related services will <b>not</b> be disrupted, but account management access and support tickets will be unavailable.',
+      //     }),
+      //   ],
+      // }),
     ],
   }
 );

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -38,7 +38,7 @@ export interface Flags {
   referralBannerText: ReferralBannerText;
   blockStorageAvailability: boolean;
   imagesPriceInfo: boolean;
-  apiMaintenance: string[];
+  apiMaintenance: APIMaintenance;
 }
 
 type PromotionalOfferFeature =
@@ -110,4 +110,10 @@ interface ReferralBannerText {
     text: string;
     url: string;
   };
+}
+
+export interface APIMaintenance {
+  id: string;
+  title?: string;
+  body?: string;
 }

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -112,8 +112,11 @@ interface ReferralBannerText {
   };
 }
 
-export interface APIMaintenance {
+export interface SuppliedMaintenanceData {
   id: string;
   title?: string;
   body?: string;
+}
+export interface APIMaintenance {
+  maintenances: SuppliedMaintenanceData[];
 }

--- a/packages/manager/src/features/GlobalNotifications/APIMaintenanceBanner.tsx
+++ b/packages/manager/src/features/GlobalNotifications/APIMaintenanceBanner.tsx
@@ -65,19 +65,19 @@ export const APIMaintenanceBanner: React.FC<Props> = (props) => {
     );
 
     const bannerTitle =
-      correspondingSuppliedMaintenance?.title !== undefined &&
-      correspondingSuppliedMaintenance?.title !== ''
-        ? correspondingSuppliedMaintenance.title
-        : scheduledAPIMaintenance.name;
+      correspondingSuppliedMaintenance?.title || scheduledAPIMaintenance.name;
 
     const bannerBody =
-      correspondingSuppliedMaintenance?.body !== undefined &&
-      correspondingSuppliedMaintenance?.body !== ''
-        ? correspondingSuppliedMaintenance?.body
-        : mostRecentUpdate.body;
+      correspondingSuppliedMaintenance?.body || mostRecentUpdate.body;
 
     return (
-      <Notice important warning dismissible onClose={onDismiss}>
+      <Notice
+        important
+        warning
+        dismissible
+        onClose={onDismiss}
+        key={scheduledAPIMaintenance.id}
+      >
         <Typography data-testid="scheduled-maintenance-banner">
           <Link to={scheduledAPIMaintenance.shortlink}>
             <strong data-testid="scheduled-maintenance-status">

--- a/packages/manager/src/features/GlobalNotifications/GlobalNotifications.tsx
+++ b/packages/manager/src/features/GlobalNotifications/GlobalNotifications.tsx
@@ -9,7 +9,7 @@ import { isEmpty } from 'ramda';
 
 const GlobalNotifications: React.FC<{}> = () => {
   const flags = useFlags();
-  const suppliedMaintenance = flags.apiMaintenance; // The data (ID, and sometimes the title and body) we supply regarding a maintenance event in LD.
+  const suppliedMaintenances = flags.apiMaintenance?.maintenances; // The data (ID, and sometimes the title and body) we supply regarding maintenance events in LD.
 
   const regions = useRegionsQuery().data ?? [];
 
@@ -18,8 +18,8 @@ const GlobalNotifications: React.FC<{}> = () => {
       <EmailBounceNotificationSection />
       <RegionStatusBanner regions={regions} />
       <AbuseTicketBanner />
-      {!isEmpty(suppliedMaintenance) ? (
-        <APIMaintenanceBanner apiMaintenanceEvent={suppliedMaintenance} />
+      {!isEmpty(suppliedMaintenances) ? (
+        <APIMaintenanceBanner suppliedMaintenances={suppliedMaintenances} />
       ) : null}
     </>
   );

--- a/packages/manager/src/features/GlobalNotifications/GlobalNotifications.tsx
+++ b/packages/manager/src/features/GlobalNotifications/GlobalNotifications.tsx
@@ -5,10 +5,11 @@ import { useRegionsQuery } from 'src/queries/regions';
 import { APIMaintenanceBanner } from './APIMaintenanceBanner';
 import { EmailBounceNotificationSection } from './EmailBounce';
 import RegionStatusBanner from './RegionStatusBanner';
+import { isEmpty } from 'ramda';
 
 const GlobalNotifications: React.FC<{}> = () => {
   const flags = useFlags();
-  const apiMaintenanceIds = flags.apiMaintenance ?? [];
+  const suppliedMaintenance = flags.apiMaintenance; // The data (ID, and sometimes the title and body) we supply regarding a maintenance event in LD.
 
   const regions = useRegionsQuery().data ?? [];
 
@@ -17,8 +18,8 @@ const GlobalNotifications: React.FC<{}> = () => {
       <EmailBounceNotificationSection />
       <RegionStatusBanner regions={regions} />
       <AbuseTicketBanner />
-      {apiMaintenanceIds.length > 0 ? (
-        <APIMaintenanceBanner apiMaintenanceIds={apiMaintenanceIds} />
+      {!isEmpty(suppliedMaintenance) ? (
+        <APIMaintenanceBanner apiMaintenanceEvent={suppliedMaintenance} />
       ) : null}
     </>
   );


### PR DESCRIPTION
## Description
The feature flag for API Maintenance events needed to be adjusted to give us more control over the title and body of the banner due to length and specificity concerns of the Statuspage data within the context of Cloud.

This PR accounts for that adjustment and does some other minor cleanup to the banner.

<img width="1121" alt="Screen Shot 2021-09-09 at 11 30 37 AM" src="https://user-images.githubusercontent.com/32860776/132716169-fdd56dec-ab7a-4bf5-9c6c-598e25db1800.png">

## How to test
Pointing to prod, you should see a global banner that corresponds to [this upcoming maintenance](https://status.linode.com/incidents/khfqpfsfdh0g). Persisted dismissibility should still work across pages within the app and across different sessions.

You can uncomment the mocked data and turn on the MSW to confirm multiple maintenances are handled again.