### PR TITLE
M3-5448: Global changes to help icon

### DIFF
--- a/packages/manager/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/manager/src/components/ActionMenu/ActionMenu.tsx
@@ -96,7 +96,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     color: '#fff',
     '& :hover': {
       color: '#4d99f1',
-      backgroundColor: 'transparent',
     },
     padding: '0 0 0 8px',
     '& svg': {

--- a/packages/manager/src/components/BackupStatus/BackupStatus.tsx
+++ b/packages/manager/src/components/BackupStatus/BackupStatus.tsx
@@ -14,10 +14,10 @@ const useStyles = makeStyles((theme: Theme) => ({
     fill: theme.color.grey1,
   },
   backupScheduledOrNever: {
-    marginRight: theme.spacing(1),
+    marginRight: theme.spacing(),
   },
   backupNotApplicable: {
-    marginRight: theme.spacing(2.2),
+    marginRight: theme.spacing(),
   },
   root: {},
   wrapper: {
@@ -28,13 +28,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     maxWidth: 275,
   },
   helpIcon: {
-    color: theme.color.grey1,
     padding: 0,
-    '& svg': {
-      fontSize: 0,
-      height: 20,
-      width: 20,
-    },
   },
   withHelpIcon: {
     display: 'flex',

--- a/packages/manager/src/components/BackupStatus/BackupStatus.tsx
+++ b/packages/manager/src/components/BackupStatus/BackupStatus.tsx
@@ -19,7 +19,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   backupNotApplicable: {
     marginRight: theme.spacing(),
   },
-  root: {},
   wrapper: {
     display: 'flex',
     alignContent: 'center',

--- a/packages/manager/src/components/Button/Button.tsx
+++ b/packages/manager/src/components/Button/Button.tsx
@@ -40,6 +40,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     display: 'flex',
     alignItems: 'center',
   },
+  helpIcon: {
+    marginLeft: -theme.spacing(),
+  },
 }));
 
 type CombinedProps = Props;
@@ -96,7 +99,9 @@ export const Button: React.FC<CombinedProps> = (props) => {
           {loading ? <Reload /> : props.children}
         </span>
       </_Button>
-      {tooltipText && <HelpIcon text={tooltipText} />}
+      {tooltipText && (
+        <HelpIcon className={classes.helpIcon} text={tooltipText} />
+      )}
     </React.Fragment>
   );
 };

--- a/packages/manager/src/components/HelpIcon/HelpIcon.tsx
+++ b/packages/manager/src/components/HelpIcon/HelpIcon.tsx
@@ -53,7 +53,7 @@ const HelpIcon: React.FC<CombinedProps> = (props) => {
     tooltipPosition,
     interactive,
     isError,
-    size = 20,
+    size = 24,
     leaveDelay,
     classes,
   } = props;

--- a/packages/manager/src/components/HelpIcon/HelpIcon.tsx
+++ b/packages/manager/src/components/HelpIcon/HelpIcon.tsx
@@ -1,8 +1,22 @@
-import * as React from 'react';
-import HelpOutline from '@material-ui/icons/HelpOutline';
 import ErrorOutline from '@material-ui/icons/ErrorOutline';
+import HelpOutline from '@material-ui/icons/HelpOutline';
+import * as React from 'react';
 import IconButton from 'src/components/core/IconButton';
+import { makeStyles } from 'src/components/core/styles';
 import Tooltip, { TooltipProps } from 'src/components/core/Tooltip';
+
+const useStyles = makeStyles(() => ({
+  root: {
+    color: '#888f91',
+    '&:hover': {
+      color: '#3683dc',
+    },
+    '& svg': {
+      height: 20,
+      width: 20,
+    },
+  },
+}));
 
 interface Props
   extends Omit<TooltipProps, 'leaveDelay' | 'title' | 'children'> {
@@ -31,13 +45,15 @@ interface Props
 type CombinedProps = Props;
 
 const HelpIcon: React.FC<CombinedProps> = (props) => {
+  const styles = useStyles();
+
   const {
     text,
     className,
     tooltipPosition,
     interactive,
     isError,
-    size = 24,
+    size = 20,
     leaveDelay,
     classes,
   } = props;
@@ -53,7 +69,7 @@ const HelpIcon: React.FC<CombinedProps> = (props) => {
       placement={tooltipPosition ? tooltipPosition : 'bottom'}
       classes={classes}
     >
-      <IconButton className={className} data-qa-help-button>
+      <IconButton className={`${className} ${styles.root}`} data-qa-help-button>
         {isError ? (
           <ErrorOutline
             style={{

--- a/packages/manager/src/components/MultipleIPInput/MultipleIPInput.tsx
+++ b/packages/manager/src/components/MultipleIPInput/MultipleIPInput.tsx
@@ -49,9 +49,11 @@ const useStyles = makeStyles((theme: Theme) => ({
     display: 'flex',
     flexDirection: 'row',
   },
-  infoIcon: {
-    marginTop: '-1.05rem',
-    color: '#888F91',
+  helpIcon: {
+    marginTop: -11,
+  },
+  required: {
+    fontFamily: theme.font.normal,
   },
 }));
 
@@ -66,6 +68,7 @@ export interface Props {
   onBlur?: (ips: ExtendedIP[]) => void;
   inputProps?: InputBaseProps;
   className?: string;
+  required?: boolean;
 }
 
 export const MultipleIPInput: React.FC<Props> = (props) => {
@@ -78,6 +81,7 @@ export const MultipleIPInput: React.FC<Props> = (props) => {
     helperText,
     tooltip,
     placeholder,
+    required,
   } = props;
   const classes = useStyles();
 
@@ -129,13 +133,18 @@ export const MultipleIPInput: React.FC<Props> = (props) => {
         <div className={classes.ipNetmaskTooltipSection}>
           <InputLabel>{title}</InputLabel>
           <HelpIcon
-            className={classes.infoIcon}
+            className={classes.helpIcon}
             text={tooltip}
             tooltipPosition="right"
           />
         </div>
       ) : (
-        <InputLabel>{title}</InputLabel>
+        <InputLabel>
+          {title}
+          {required ? (
+            <span className={classes.required}> (required)</span>
+          ) : null}
+        </InputLabel>
       )}
       {helperText && (
         <Typography className={classes.helperText}>{helperText}</Typography>

--- a/packages/manager/src/components/MultipleIPInput/MultipleIPInput.tsx
+++ b/packages/manager/src/components/MultipleIPInput/MultipleIPInput.tsx
@@ -50,7 +50,8 @@ const useStyles = makeStyles((theme: Theme) => ({
     flexDirection: 'row',
   },
   helpIcon: {
-    marginTop: -11,
+    marginTop: -15,
+    marginLeft: -4,
   },
   required: {
     fontFamily: theme.font.normal,

--- a/packages/manager/src/components/TextField.tsx
+++ b/packages/manager/src/components/TextField.tsx
@@ -64,7 +64,6 @@ const styles = (theme: Theme) =>
     },
     helpIcon: {
       padding: '0px 0px 0px 8px',
-      color: theme.cmrTextColors.tableHeader,
     },
     expand: {
       maxWidth: '100%',

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
@@ -1,13 +1,13 @@
+import { PaymentMethod } from '@linode/api-v4';
 import {
   ActivePromotion,
   PromotionServiceType,
 } from '@linode/api-v4/lib/account/types';
-import { PaymentMethod } from '@linode/api-v4';
 import { GridSize } from '@material-ui/core/Grid';
 import { Breakpoint } from '@material-ui/core/styles/createBreakpoints';
 import * as classnames from 'classnames';
 import * as React from 'react';
-import { useHistory, useRouteMatch, useLocation } from 'react-router-dom';
+import { useHistory, useLocation, useRouteMatch } from 'react-router-dom';
 import Box from 'src/components/core/Box';
 import Divider from 'src/components/core/Divider';
 import Grid from 'src/components/core/Grid';
@@ -17,11 +17,11 @@ import Typography from 'src/components/core/Typography';
 import Currency from 'src/components/Currency';
 import DateTimeDisplay from 'src/components/DateTimeDisplay';
 import HelpIcon from 'src/components/HelpIcon';
+import useAccountManagement from 'src/hooks/useAccountManagement';
 import useNotifications from 'src/hooks/useNotifications';
+import { isWithinDays } from 'src/utilities/date';
 import PaymentDrawer from './PaymentDrawer';
 import PromoDialog from './PromoDialog';
-import useAccountManagement from 'src/hooks/useAccountManagement';
-import { isWithinDays } from 'src/utilities/date';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -35,11 +35,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   helpIcon: {
     padding: `0px 8px`,
-    color: '#888f91',
-    '& svg': {
-      height: 20,
-      width: 20,
-    },
   },
   noBalanceOrNotDue: {
     color: theme.palette.text.primary,

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
@@ -116,11 +116,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   helpIcon: {
     padding: `0px 8px`,
-    color: '#888f91',
-    '& svg': {
-      height: 20,
-      width: 20,
-    },
   },
 }));
 

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/GooglePayChip.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/GooglePayChip.tsx
@@ -33,14 +33,14 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   errorIcon: {
     color: theme.color.red,
-    marginRight: -18,
+    marginRight: -20,
     '&:hover': {
       color: theme.color.red,
       opacity: 0.7,
     },
     '& svg': {
-      height: theme.spacing(3),
-      width: theme.spacing(3),
+      height: 28,
+      width: 28,
     },
   },
 }));

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/GooglePayChip.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/GooglePayChip.tsx
@@ -32,11 +32,15 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
   },
   errorIcon: {
-    marginRight: -16,
     color: theme.color.red,
+    marginRight: -18,
     '&:hover': {
       color: theme.color.red,
       opacity: 0.7,
+    },
+    '& svg': {
+      height: theme.spacing(3),
+      width: theme.spacing(3),
     },
   },
 }));

--- a/packages/manager/src/features/Domains/CreateDomain/CreateDomain.tsx
+++ b/packages/manager/src/features/Domains/CreateDomain/CreateDomain.tsx
@@ -471,15 +471,16 @@ export const CreateDomain: React.FC<CombinedProps> = (props) => {
             )}
             {isCreatingSecondaryDomain && (
               <MultipleIPInput
-                title="Primary Nameserver IP Address (required)"
+                title="Primary Nameserver IP Address"
                 className={classes.ip}
-                ips={values.master_ips.map(stringToExtendedIP)}
-                onChange={updatePrimaryIPAddress}
                 error={
                   formik.touched.master_ips
                     ? (primaryIPsError as string | undefined)
                     : undefined
                 }
+                ips={values.master_ips.map(stringToExtendedIP)}
+                onChange={updatePrimaryIPAddress}
+                required
               />
             )}
             {isCreatingPrimaryDomain && (

--- a/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/TransferControls.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersLanding/TransferControls.tsx
@@ -4,10 +4,10 @@ import Button from 'src/components/Button';
 import Hidden from 'src/components/core/Hidden';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
+import Grid from 'src/components/Grid';
 import HelpIcon from 'src/components/HelpIcon';
 import TextField from 'src/components/TextField';
 import ConfirmTransferDialog from './ConfirmTransferDialog';
-import Grid from 'src/components/Grid';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -67,9 +67,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     [theme.breakpoints.down('xs')]: {
       width: '100%',
     },
-  },
-  helpIcon: {
-    color: theme.color.grey1,
   },
   makeTransfer: {
     [theme.breakpoints.up('md')]: {
@@ -164,10 +161,7 @@ export const TransferControls: React.FC<{}> = (_) => {
               Review Details
             </Button>
             <Hidden smDown>
-              <HelpIcon
-                className={classes.helpIcon}
-                text="Enter a service transfer token to review the details and accept the transfer."
-              />
+              <HelpIcon text="Enter a service transfer token to review the details and accept the transfer." />
             </Hidden>
           </Grid>
         </Grid>

--- a/packages/manager/src/features/Images/ImageSelect.tsx
+++ b/packages/manager/src/features/Images/ImageSelect.tsx
@@ -17,7 +17,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   icon: {
     marginTop: 30,
     marginLeft: -20,
-    color: theme.cmrTextColors.tableHeader,
   },
   selectContainer: {
     width: 415 + theme.spacing(2),

--- a/packages/manager/src/features/linodes/LinodesCreate/AttachVLAN.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/AttachVLAN.tsx
@@ -20,6 +20,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     display: 'flex',
     alignItems: 'center',
     marginBottom: theme.spacing(2),
+    '& button': {
+      paddingLeft: theme.spacing(),
+    },
   },
   paragraphBreak: {
     marginTop: theme.spacing(2),

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -58,7 +58,7 @@ type ClassNames =
 const styles = (theme: Theme) =>
   createStyles({
     toolTip: {
-      paddingTop: theme.spacing(1),
+      marginLeft: -2,
     },
     title: {
       marginBottom: theme.spacing(2),

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -78,7 +78,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
   },
   helpIcon: {
-    color: theme.cmrTextColors.tableHeader,
     paddingTop: 0,
     paddingBottom: 0,
   },


### PR DESCRIPTION
## Description

Make help icons consistent throughout the app and remove styles that are no longer needed. 

Help icons should generally be:
- Gray (#888f91) by default and blue (#3683dc) on hover
- 20x20px

**Note:** Found a "(required)" regression in `MultipleIPInput` so added a required prop there to make it consistent.

## How to test

Check the help icons throughout the app.
