### PR TITLE
[For Release] Reduce number of requests associated w/ API Maintenance Banner

### DIFF
--- a/packages/manager/src/features/GlobalNotifications/APIMaintenanceBanner.tsx
+++ b/packages/manager/src/features/GlobalNotifications/APIMaintenanceBanner.tsx
@@ -4,6 +4,7 @@ import Link from 'src/components/Link';
 import Notice from 'src/components/Notice';
 import { SuppliedMaintenanceData } from 'src/featureFlags';
 import useDismissibleNotifications from 'src/hooks/useDismissibleNotifications';
+import { queryPresets } from 'src/queries/base';
 import { Maintenance, useMaintenanceQuery } from 'src/queries/statusPage';
 import { sanitizeHTML } from 'src/utilities/sanitize-html';
 
@@ -19,7 +20,9 @@ export const APIMaintenanceBanner: React.FC<Props> = (props) => {
     hasDismissedNotifications,
   } = useDismissibleNotifications();
 
-  const { data: maintenancesData } = useMaintenanceQuery();
+  const { data: maintenancesData } = useMaintenanceQuery({
+    ...queryPresets.oneTimeFetch,
+  });
   const maintenances = maintenancesData?.scheduled_maintenances ?? [];
 
   if (hasDismissedNotifications(suppliedMaintenances ?? [])) {

--- a/packages/manager/src/features/GlobalNotifications/APIMaintenanceBanner.tsx
+++ b/packages/manager/src/features/GlobalNotifications/APIMaintenanceBanner.tsx
@@ -22,6 +22,10 @@ export const APIMaintenanceBanner: React.FC<Props> = (props) => {
   const { data: maintenancesData } = useMaintenanceQuery();
   const maintenances = maintenancesData?.scheduled_maintenances ?? [];
 
+  if (hasDismissedNotifications(suppliedMaintenances ?? [])) {
+    return null;
+  }
+
   if (
     !maintenances ||
     maintenances.length === 0 ||
@@ -46,12 +50,8 @@ export const APIMaintenanceBanner: React.FC<Props> = (props) => {
     return null;
   }
 
-  if (hasDismissedNotifications(scheduledAPIMaintenances)) {
-    return null;
-  }
-
   const onDismiss = () => {
-    dismissNotifications(scheduledAPIMaintenances);
+    dismissNotifications(suppliedMaintenances);
   };
 
   const renderBanner = (scheduledAPIMaintenance: Maintenance) => {

--- a/packages/manager/src/features/GlobalNotifications/GlobalNotifications.tsx
+++ b/packages/manager/src/features/GlobalNotifications/GlobalNotifications.tsx
@@ -14,9 +14,14 @@ const GlobalNotifications: React.FC<{}> = () => {
 
   const { hasDismissedNotifications } = useDismissibleNotifications();
 
+  const _hasDismissedNotifications = React.useCallback(
+    hasDismissedNotifications,
+    []
+  );
+
   const hasDismissedMaintenances = React.useMemo(
-    () => hasDismissedNotifications(suppliedMaintenances ?? []),
-    [hasDismissedNotifications, suppliedMaintenances]
+    () => _hasDismissedNotifications(suppliedMaintenances ?? []),
+    [_hasDismissedNotifications, suppliedMaintenances]
   );
 
   const regions = useRegionsQuery().data ?? [];

--- a/packages/manager/src/features/GlobalNotifications/GlobalNotifications.tsx
+++ b/packages/manager/src/features/GlobalNotifications/GlobalNotifications.tsx
@@ -6,10 +6,18 @@ import { APIMaintenanceBanner } from './APIMaintenanceBanner';
 import { EmailBounceNotificationSection } from './EmailBounce';
 import RegionStatusBanner from './RegionStatusBanner';
 import { isEmpty } from 'ramda';
+import useDismissibleNotifications from 'src/hooks/useDismissibleNotifications';
 
 const GlobalNotifications: React.FC<{}> = () => {
   const flags = useFlags();
   const suppliedMaintenances = flags.apiMaintenance?.maintenances; // The data (ID, and sometimes the title and body) we supply regarding maintenance events in LD.
+
+  const { hasDismissedNotifications } = useDismissibleNotifications();
+
+  const hasDismissedMaintenances = React.useMemo(
+    () => hasDismissedNotifications(suppliedMaintenances ?? []),
+    [hasDismissedNotifications, suppliedMaintenances]
+  );
 
   const regions = useRegionsQuery().data ?? [];
 
@@ -18,7 +26,7 @@ const GlobalNotifications: React.FC<{}> = () => {
       <EmailBounceNotificationSection />
       <RegionStatusBanner regions={regions} />
       <AbuseTicketBanner />
-      {!isEmpty(suppliedMaintenances) ? (
+      {!isEmpty(suppliedMaintenances) && !hasDismissedMaintenances ? (
         <APIMaintenanceBanner suppliedMaintenances={suppliedMaintenances} />
       ) : null}
     </>

--- a/packages/manager/src/queries/statusPage/statusPage.ts
+++ b/packages/manager/src/queries/statusPage/statusPage.ts
@@ -1,7 +1,7 @@
 import Axios from 'axios';
 import { APIError } from '@linode/api-v4/lib/types';
 import { IncidentResponse, MaintenanceResponse } from './types';
-import { useQuery } from 'react-query';
+import { useQuery, UseQueryOptions } from 'react-query';
 import { LINODE_STATUS_PAGE_URL } from 'src/constants';
 import { reportException } from 'src/exceptionReporting';
 import { queryPresets } from '../base';
@@ -55,10 +55,10 @@ export const useIncidentQuery = () => {
   );
 };
 
-export const useMaintenanceQuery = () => {
+export const useMaintenanceQuery = (options?: UseQueryOptions<any>) => {
   return useQuery<MaintenanceResponse, APIError[]>(
     maintenanceKey,
     getAllMaintenance,
-    queryPresets.shortLived
+    { ...queryPresets.shortLived, ...(options ?? {}) }
   );
 };


### PR DESCRIPTION
## Description
Adjust dismissal logic to key off of `suppliedMaintenances` instead to allow a check to be done in `GlobalNotifications.tsx`

## How to Test
On `staging` right now, you will see a request to `scheduled-maintenances.json` on every window focus, even when you've dismissed the API Maintenance notification.

On this branch, you should see a single request to `scheduled-maintenances.json` when Cloud first loads, and no new requests to it on subsequent window focuses. If you dismiss the banner, that request should not be made on subsequent Cloud reloads.