### PR TITLE
Disable Glish on Bare Metal Machines

### DIFF
--- a/packages/manager/src/features/Lish/Lish.tsx
+++ b/packages/manager/src/features/Lish/Lish.tsx
@@ -254,7 +254,7 @@ class Lish extends React.Component<CombinedProps, State> {
                 />
               </SafeTabPanel>
             )}
-            {linode && token && isBareMetal && (
+            {linode && token && !isBareMetal && (
               <SafeTabPanel index={1} data-qa-tab="Glish">
                 <Glish
                   token={token}

--- a/packages/manager/src/features/Lish/Lish.tsx
+++ b/packages/manager/src/features/Lish/Lish.tsx
@@ -107,6 +107,7 @@ class Lish extends React.Component<CombinedProps, State> {
         if (!this.mounted) {
           return;
         }
+
         this.setState({
           linode,
           loading: false,
@@ -196,10 +197,6 @@ class Lish extends React.Component<CombinedProps, State> {
       title: 'Weblish',
       routeName: `${this.props.match.url}/weblish`,
     },
-    {
-      title: 'Glish',
-      routeName: `${this.props.match.url}/glish`,
-    },
   ];
 
   matches = (p: string) =>
@@ -208,6 +205,22 @@ class Lish extends React.Component<CombinedProps, State> {
   render() {
     const { classes } = this.props;
     const { authenticated, loading, linode, token } = this.state;
+
+    const isBareMetal = linode && linode.type && linode.type.includes('metal');
+
+    if (!isBareMetal) {
+      this.tabs = [
+        /* NB: These must correspond to the routes inside the Switch */
+        {
+          title: 'Weblish',
+          routeName: `${this.props.match.url}/weblish`,
+        },
+        {
+          title: 'Glish',
+          routeName: `${this.props.match.url}/glish`,
+        },
+      ];
+    }
 
     const navToURL = (index: number) => {
       this.props.history.push(this.tabs[index].routeName);
@@ -241,7 +254,7 @@ class Lish extends React.Component<CombinedProps, State> {
                 />
               </SafeTabPanel>
             )}
-            {linode && token && (
+            {linode && token && isBareMetal && (
               <SafeTabPanel index={1} data-qa-tab="Glish">
                 <Glish
                   token={token}

--- a/packages/manager/src/features/Lish/Lish.tsx
+++ b/packages/manager/src/features/Lish/Lish.tsx
@@ -19,6 +19,7 @@ import TabLinkList from 'src/components/TabLinkList';
 import Typography from 'src/components/core/Typography';
 import ErrorState from 'src/components/ErrorState';
 import NotFound from 'src/components/NotFound';
+import { Tab } from 'src/components/TabLinkList/TabLinkList';
 import Glish from './Glish';
 import Weblish from './Weblish';
 
@@ -191,14 +192,6 @@ class Lish extends React.Component<CombinedProps, State> {
       });
   };
 
-  tabs = [
-    /* NB: These must correspond to the routes inside the Switch */
-    {
-      title: 'Weblish',
-      routeName: `${this.props.match.url}/weblish`,
-    },
-  ];
-
   matches = (p: string) =>
     Boolean(matchPath(p, { path: this.props.location.pathname }));
 
@@ -208,22 +201,22 @@ class Lish extends React.Component<CombinedProps, State> {
 
     const isBareMetal = linode && linode.type && linode.type.includes('metal');
 
-    if (!isBareMetal) {
-      this.tabs = [
-        /* NB: These must correspond to the routes inside the Switch */
-        {
-          title: 'Weblish',
-          routeName: `${this.props.match.url}/weblish`,
-        },
-        {
-          title: 'Glish',
-          routeName: `${this.props.match.url}/glish`,
-        },
-      ];
-    }
+    const tabs = [
+      /* NB: These must correspond to the routes inside the Switch */
+      {
+        title: 'Weblish',
+        routeName: `${this.props.match.url}/weblish`,
+      },
+      !isBareMetal
+        ? {
+            title: 'Glish',
+            routeName: `${this.props.match.url}/glish`,
+          }
+        : null,
+    ].filter(Boolean) as Tab[];
 
     const navToURL = (index: number) => {
-      this.props.history.push(this.tabs[index].routeName);
+      this.props.history.push(tabs[index].routeName);
     };
 
     // If the window.close() logic above fails, we render an error state as a fallback
@@ -243,7 +236,7 @@ class Lish extends React.Component<CombinedProps, State> {
     return (
       <React.Fragment>
         <Tabs className={classes.tabs} onChange={navToURL}>
-          <TabLinkList className={classes.lish} tabs={this.tabs} />
+          <TabLinkList className={classes.lish} tabs={tabs} />
           <TabPanels>
             {linode && token && (
               <SafeTabPanel index={0} data-qa-tab="Weblish">

--- a/packages/manager/src/features/Lish/Lish.tsx
+++ b/packages/manager/src/features/Lish/Lish.tsx
@@ -239,6 +239,7 @@ class Lish extends React.Component<CombinedProps, State> {
     }
 
     // Only show 404 component if we are missing _both_ linode and token
+    // eslint-disable-next-line react/jsx-no-useless-fragment
     if (!loading && !linode && !token) {
       return <NotFound className={classes.notFound} />;
     }

--- a/packages/manager/src/features/Lish/Lish.tsx
+++ b/packages/manager/src/features/Lish/Lish.tsx
@@ -233,12 +233,22 @@ class Lish extends React.Component<CombinedProps, State> {
       );
     }
 
+    // if we're loading show circular spinner
+    if (loading) {
+      return <CircleProgress noInner className={classes.progress} />;
+    }
+
+    // Only show 404 component if we are missing _both_ linode and token
+    if (!loading && !linode && !token) {
+      return <NotFound className={classes.notFound} />;
+    }
+
     return (
       <React.Fragment>
-        <Tabs className={classes.tabs} onChange={navToURL}>
-          <TabLinkList className={classes.lish} tabs={tabs} />
-          <TabPanels>
-            {linode && token && (
+        {linode && token && (
+          <Tabs className={classes.tabs} onChange={navToURL}>
+            <TabLinkList className={classes.lish} tabs={tabs} />
+            <TabPanels>
               <SafeTabPanel index={0} data-qa-tab="Weblish">
                 <Weblish
                   token={token}
@@ -246,22 +256,17 @@ class Lish extends React.Component<CombinedProps, State> {
                   refreshToken={this.refreshToken}
                 />
               </SafeTabPanel>
-            )}
-            {linode && token && !isBareMetal && (
-              <SafeTabPanel index={1} data-qa-tab="Glish">
-                <Glish
-                  token={token}
-                  linode={linode}
-                  refreshToken={this.refreshToken}
-                />
-              </SafeTabPanel>
-            )}
-          </TabPanels>
-        </Tabs>
-        {loading && <CircleProgress noInner className={classes.progress} />}
-        {/* Only show 404 component if we are missing _both_ linode and token */}
-        {!loading && !linode && !token && (
-          <NotFound className={classes.notFound} />
+              {!isBareMetal && (
+                <SafeTabPanel index={1} data-qa-tab="Glish">
+                  <Glish
+                    token={token}
+                    linode={linode}
+                    refreshToken={this.refreshToken}
+                  />
+                </SafeTabPanel>
+              )}
+            </TabPanels>
+          </Tabs>
         )}
       </React.Fragment>
     );

--- a/packages/manager/src/features/Lish/Lish.tsx
+++ b/packages/manager/src/features/Lish/Lish.tsx
@@ -41,7 +41,7 @@ const styles = (theme: Theme) =>
       '& [role="tab"]': {
         backgroundColor: theme.bg.offWhite,
         color: theme.color.tableHeaderText,
-        flexBasis: '50%',
+        flex: 'auto',
         margin: 0,
         maxWidth: 'none !important',
         '&[aria-selected="true"]': {

--- a/packages/manager/src/features/Lish/Lish.tsx
+++ b/packages/manager/src/features/Lish/Lish.tsx
@@ -239,12 +239,12 @@ class Lish extends React.Component<CombinedProps, State> {
     }
 
     // Only show 404 component if we are missing _both_ linode and token
-    // eslint-disable-next-line react/jsx-no-useless-fragment
     if (!loading && !linode && !token) {
       return <NotFound className={classes.notFound} />;
     }
 
     return (
+      // eslint-disable-next-line react/jsx-no-useless-fragment
       <React.Fragment>
         {linode && token && (
           <Tabs className={classes.tabs} onChange={navToURL}>

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -178,7 +178,6 @@ export const handlers = [
   rest.get('*/linode/instances', async (req, res, ctx) => {
     const onlineLinodes = linodeFactory.buildList(17, {
       backups: { enabled: false },
-      type: 'g6-metal-alpha-1',
       ipv4: ['000.000.000.000'],
     });
     const offlineLinodes = linodeFactory.buildList(1, { status: 'offline' });
@@ -207,6 +206,11 @@ export const handlers = [
       linodeFactory.build({
         label: 'shadow-plan',
         type: 'g5-standard-20-s1',
+        backups: { enabled: false },
+      }),
+      linodeFactory.build({
+        label: 'bare-metal',
+        type: 'g1-metal-c2',
         backups: { enabled: false },
       }),
       linodeFactory.build({


### PR DESCRIPTION
## Description

This disables glish for bare metal machines by checking if the current Linode is bare metal

## How to test

First you must authorize yourself for bare metal then create a bare metal linode and a non bare metal linode. Verify that the bare metal one has no glish and the non bare metal one does

Note: Not important but I went down a bunch of dead ends trying to use src/hooks/useExtendedLinode but because Lish is not a FC that didn't work. Then I thought about passing in the data from store.getState() in src/index.tsx because I misguidedly thought that perhaps Lish being a separate popup couldn't access the store and needed it passed in without realizing api calls work. TLDR - read documentation 🙃