### PR TITLE
M3-5341: Reduce bottom padding for Linodes grouped by tag

### DIFF
--- a/packages/manager/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
@@ -34,7 +34,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     height: 'auto',
     '& td': {
       // This is maintaining the spacing between groups because of how tables handle margin/padding. Adjust with care!
-      padding: `${theme.spacing(2) + 4}px 0 ${theme.spacing(1) + 2}px`,
+      padding: `${theme.spacing(2) + 4}px 0 2px`,
       borderBottom: 'none',
       borderTop: 'none',
     },
@@ -42,7 +42,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   groupContainer: {
     [theme.breakpoints.up('md')]: {
       '& $tagHeaderRow > td': {
-        padding: '10px 0',
+        padding: '10px 0 2px',
         borderTop: 'none',
       },
     },


### PR DESCRIPTION
## Description

Reduces the bottom padding of tag headers to make dark more more readable. I accidentally deleted the last [PR](https://github.com/linode/manager/pull/7919) 🙃

## How to test

Create a few Linodes, tag them in the details view, return to the Linodes screen, and group by tag and verify they have a smaller padding than before. Make sure to check various screen sizes
