### PR TITLE
E2e multiple test updates

### DIFF
--- a/packages/manager/cypress/integration/images/create-linode-from-image.spec.ts
+++ b/packages/manager/cypress/integration/images/create-linode-from-image.spec.ts
@@ -1,5 +1,5 @@
 import { createMockImage } from 'cypress/support/api/images';
-import { createMockLinode } from 'cypress/support/api/linodes';
+import { createMockLinodeList } from 'cypress/support/api/linodes';
 import {
   containsClick,
   fbtClick,
@@ -16,12 +16,14 @@ const region = 'us-west';
 const regionSelect = 'Fremont, CA';
 const imageId = mockImage.id;
 const type = 'g6-nanode-1';
-const mockLinode = createMockLinode({
+const mockLinodeList = createMockLinodeList({
   id: linodeId,
   label: `${imageLabel}-${region}`,
   region,
   type,
 });
+
+const mockLinode = mockLinodeList.data[0];
 
 const createLinodeWithImageMock = () => {
   cy.intercept('*/images*', (req) => {

--- a/packages/manager/cypress/integration/linodes/rescue-linode.spec.ts
+++ b/packages/manager/cypress/integration/linodes/rescue-linode.spec.ts
@@ -47,6 +47,7 @@ describe('rescue linode', () => {
         .its('response.statusCode')
         .should('eq', 400);
       fbtVisible('Linode busy.');
+      // another possible bug
     });
   });
 });

--- a/packages/manager/cypress/integration/linodes/rescue-linode.spec.ts
+++ b/packages/manager/cypress/integration/linodes/rescue-linode.spec.ts
@@ -47,7 +47,6 @@ describe('rescue linode', () => {
         .its('response.statusCode')
         .should('eq', 400);
       fbtVisible('Linode busy.');
-      // another possible bug
     });
   });
 });

--- a/packages/manager/cypress/integration/linodes/smoke-linode-landing-table.spec.ts
+++ b/packages/manager/cypress/integration/linodes/smoke-linode-landing-table.spec.ts
@@ -230,13 +230,33 @@ describe('linode landing checks', () => {
 });
 
 describe('linode landing actions', () => {
-  it('deleting multiple linodes with action menu', () => {
+  it.only('deleting multiple linodes with action menu', () => {
+    const mockAccountSettings = accountSettingsFactory.build({
+      managed: false,
+    });
+
+    cy.intercept('GET', '*/account/settings', (req) => {
+      req.reply(mockAccountSettings);
+    }).as('getAccountSettings');
+
+    interceptOnce('GET', '*/profile/preferences*', {
+      linodes_view_style: 'list',
+      linodes_group_by_tag: false,
+      volumes_group_by_tag: false,
+      desktop_sidebar_open: false,
+      sortKeys: {
+        'linodes-landing': { order: 'asc', orderBy: 'label' },
+        volume: { order: 'asc', orderBy: 'label' },
+      },
+    }).as('getProfilePreferences');
     cy.intercept('DELETE', '*/linode/instances/*').as('deleteLinode');
     createLinode().then((linodeA) => {
       createLinode().then((linodeB) => {
         cy.visitWithLogin('/linodes');
+        cy.wait('@getAccountSettings');
+        cy.wait('@getProfilePreferences');
         getVisible('[data-qa-header="Linodes"]');
-        if (!cy.get('[data-qa-sort-label="asc"')) {
+        if (!cy.get('[data-qa-sort-label="asc"]')) {
           getClick('[aria-label="Sort by label"]');
         }
         deleteLinodeFromActionMenu(linodeA.label);

--- a/packages/manager/cypress/integration/volumes/smoke-create-volumes.spec.ts
+++ b/packages/manager/cypress/integration/volumes/smoke-create-volumes.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import { clickVolumeActionMenu } from '../../support/api/volumes';
 import { assertToast } from '../../support/ui/events';
-import { createMockLinode } from '../../support/api/linodes';
+import { createMockLinodeList } from '../../support/api/linodes';
 import { selectRegionString } from '../../support/ui/constants';
 import {
   containsVisible,
@@ -35,7 +35,7 @@ const validateBasicVolume = (
 const tagList = makeResourcePage(tagFactory.buildList(5));
 const tag = tagList.data[getRandomNumber(0, 4)];
 const tagLabel = tag.label;
-const linodeList = createMockLinode(3, { region: 'us-southeast' });
+const linodeList = createMockLinodeList({ region: 'us-southeast' }, 3);
 const linode = linodeList.data[1];
 const linodeLabel = linode.label;
 const linodeId = linode.id;

--- a/packages/manager/cypress/support/api/linodes.ts
+++ b/packages/manager/cypress/support/api/linodes.ts
@@ -18,7 +18,7 @@ const testLinodeTag = testTag;
 export const makeRandomId = () => Math.floor(Math.random() * 99999999);
 export const makeLinodeLabel = makeTestLabel;
 
-export const createMockLinode = (listNumber: number = 1, data?: {}) => {
+export const createMockLinodeList = (data?: {}, listNumber: number = 1) => {
   return makeResourcePage(
     linodeFactory.buildList(listNumber, {
       ...data,

--- a/packages/manager/cypress/tsconfig.json
+++ b/packages/manager/cypress/tsconfig.json
@@ -13,5 +13,5 @@
     },
     "types": ["cypress", "cypress-file-upload", "@testing-library/cypress", "cypress-real-events"]
   },
-  "include": ["../cypress/**/*.ts", "**/*.*"]
+  "include": ["../cypress/**/*.ts"]
 }


### PR DESCRIPTION
## Description
Multiple test updates and changes for image, linode-landing, and volumes tests as well as a change to the create mock linode helper.

## How to test
- `yarn up` in one terminal
- `yarn cy:e2e -s ./cypress/integration/images/machine-image-upload.spec.ts` in another
- Result should be "✔  All specs passed!"

---------------------------------------------

- `yarn up` in one terminal
- `yarn cy:e2e -s ./cypress/integration/volumes/smoke-create-volumes.spec.ts` in another
- Result should be "✔  All specs passed!"

---------------------------------------------

- `yarn up` in one terminal
- `yarn cy:e2e -s ./cypress/integration/linodes/smoke-linode-landing-table.spec.ts` in another
- Result should be "✔  All specs passed!"

## Make sure your .env contains:
```
REACT_APP_LOGIN_ROOT
REACT_APP_API_ROOT
REACT_APP_APP_ROOT
REACT_APP_LAUNCH_DARKLY_ID
REACT_APP_CLIENT_ID
MANAGER_OAUTH
```