### PR TITLE
Upgrade Axios again to fix app crashing bug

### DIFF
--- a/packages/api-v4/package.json
+++ b/packages/api-v4/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@linode/validation": "0.4.0",
     "@types/yup": "^0.29.13",
-    "axios": "~0.21.2",
+    "axios": "~0.21.4",
     "ipaddr.js": "^2.0.0",
     "querystring": "^0.2.0",
     "yup": "^0.32.9"

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -32,7 +32,7 @@
     "@types/react-beautiful-dnd": "^13.0.0",
     "@types/react-router-hash-link": "^1.2.1",
     "algoliasearch": "^3.30.0",
-    "axios": "~0.21.2",
+    "axios": "~0.21.4",
     "axios-mock-adapter": "^1.15.0",
     "bluebird": "^3.5.1",
     "braintree-web": "^3.76.4",


### PR DESCRIPTION
## Description

There was a bug introduced in axios v0.21.2 that handled interceptors incorrectly. 

We upgraded to 0.21.2 here: https://github.com/linode/manager/pull/7937

The result was that the app would crash when the API returned an error, since we rely on an interceptor to transform Axios errors into `APIError[]`. 

See the axios changelog: https://github.com/axios/axios/blob/master/CHANGELOG.md


## How to test
Generally test that things are working throughout the app (happy paths and error paths).


