### PR TITLE
M3-5452: Add support for Autoscaling Node Pools

### DIFF
--- a/packages/api-v4/src/kubernetes/nodePools.ts
+++ b/packages/api-v4/src/kubernetes/nodePools.ts
@@ -8,7 +8,11 @@ import Request, {
   setXFilter,
 } from '../request';
 import { ResourcePage as Page } from '../types';
-import { KubeNodePoolResponse, PoolNodeRequest } from './types';
+import {
+  KubeNodePoolResponse,
+  PoolNodeRequest,
+  AutoscaleNodePoolRequest,
+} from './types';
 
 /**
  * getNodePools
@@ -93,4 +97,17 @@ export const recycleNode = (clusterID: number, nodeID: string) =>
   Request<{}>(
     setMethod('POST'),
     setURL(`${API_ROOT}/lke/clusters/${clusterID}/nodes/${nodeID}/recycle`)
+  );
+
+export const autoscaleNodePool = ({
+  clusterID,
+  nodePoolID,
+  autoscaler,
+}: AutoscaleNodePoolRequest) =>
+  Request<{}>(
+    setMethod('PUT'),
+    setURL(`${API_ROOT}/lke/clusters/${clusterID}/pools/${nodePoolID}`),
+    setData({
+      autoscaler,
+    })
   );

--- a/packages/api-v4/src/kubernetes/types.ts
+++ b/packages/api-v4/src/kubernetes/types.ts
@@ -27,6 +27,18 @@ export interface PoolNodeRequest {
   count: number;
 }
 
+export interface AutoscaleNodePool {
+  enabled: boolean;
+  min: number;
+  max: number;
+}
+
+export interface AutoscaleNodePoolRequest {
+  clusterID: number;
+  nodePoolID: number;
+  autoscaler: AutoscaleNodePool;
+}
+
 export interface KubeConfigResponse {
   kubeconfig: string;
 }

--- a/packages/api-v4/src/kubernetes/types.ts
+++ b/packages/api-v4/src/kubernetes/types.ts
@@ -14,6 +14,7 @@ export interface KubeNodePoolResponse {
   id: number;
   nodes: PoolNodeResponse[];
   type: string;
+  autoscaler: AutoscaleNodePool;
 }
 
 export interface PoolNodeResponse {

--- a/packages/manager/src/__data__/nodePools.ts
+++ b/packages/manager/src/__data__/nodePools.ts
@@ -13,6 +13,11 @@ export const pool1: ExtendedNodePool = {
     },
   ],
   clusterID: 10,
+  autoscaler: {
+    enabled: false,
+    min: 1,
+    max: 1,
+  },
 };
 
 export const pool2: ExtendedNodePool = {
@@ -32,6 +37,11 @@ export const pool2: ExtendedNodePool = {
     },
   ],
   clusterID: 10,
+  autoscaler: {
+    enabled: false,
+    min: 1,
+    max: 1,
+  },
 };
 
 export const pool3: ExtendedNodePool = {
@@ -46,6 +56,11 @@ export const pool3: ExtendedNodePool = {
     },
   ],
   clusterID: 10,
+  autoscaler: {
+    enabled: false,
+    min: 1,
+    max: 1,
+  },
 };
 
 export const extendedPools = [pool1, pool2, pool3];

--- a/packages/manager/src/factories/kubernetesCluster.ts
+++ b/packages/manager/src/factories/kubernetesCluster.ts
@@ -23,6 +23,11 @@ export const nodePoolAPIFactory = Factory.Sync.makeFactory<KubeNodePoolResponse>
     count: 3,
     type: 'g6-standard-1',
     nodes: kubeLinodeFactory.buildList(3),
+    autoscaler: {
+      enabled: false,
+      min: 1,
+      max: 1,
+    },
   }
 );
 
@@ -31,6 +36,11 @@ export const _nodePoolFactory = Factory.Sync.makeFactory<PoolNodeWithPrice>({
   count: 3,
   type: 'g6-standard-1',
   totalMonthlyPrice: 1000,
+  autoscaler: {
+    enabled: false,
+    min: 1,
+    max: 1,
+  },
 });
 
 export const nodePoolFactory = _nodePoolFactory.withDerivation1(

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -40,6 +40,7 @@ export interface Flags {
   imagesPriceInfo: boolean;
   productInformationBanners: ProductInformationBannerFlag[];
   apiMaintenance: APIMaintenance;
+  autoscaler: boolean;
 }
 
 type PromotionalOfferFeature =

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -294,6 +294,7 @@ export const KubernetesClusterDetail: React.FunctionComponent<CombinedProps> = (
       </Grid>
       <Grid item xs={12}>
         <NodePoolsDisplay
+          clusterID={cluster.id}
           clusterLabel={cluster.label}
           pools={cluster.node_pools}
           types={props.typesData || []}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -324,6 +324,9 @@ export const KubernetesClusterDetail: React.FunctionComponent<CombinedProps> = (
           }
           recycleNode={handleRecycleNode}
           recycleAllClusterNodes={handleRecycleAllClusterNodes}
+          getNodePools={() =>
+            props.requestNodePools(+props.match.params.clusterID)
+          }
         />
       </Grid>
     </>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AutoscalePoolDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AutoscalePoolDialog.tsx
@@ -3,16 +3,17 @@ import { AutoscaleNodePoolSchema } from '@linode/validation/lib/kubernetes.schem
 import { useFormik } from 'formik';
 import * as React from 'react';
 import * as classNames from 'classnames';
+import FormControlLabel from 'src/components/core/FormControlLabel';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
-import FormControlLabel from 'src/components/core/FormControlLabel';
-import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
+import Link from 'src/components/Link';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
 import Toggle from 'src/components/Toggle';
-import { makeStyles, Theme } from 'src/components/core/styles';
 
 interface Props {
   poolID: number;
@@ -173,9 +174,12 @@ const AutoscalePoolDialog: React.FC<Props> = (props) => {
         </Notice>
       ) : null}
       <Typography>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis augue
-        arcu, semper id diam vitae, ultrices aliquet est. Morbi mauris risus,
-        mattis non sodales at, ultrices et quam.
+        Set minimum and maximum node pool constraints for LKE to resize your
+        cluster based on demand and control cluster resource costs. Autoscaler
+        maximum limit is 100.{' '}
+        <Link to={'https://www.linode.com/docs/products/compute/kubernetes/'}>
+          Learn More.
+        </Link>
       </Typography>
       <FormControlLabel
         label="Autoscaler"

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AutoscalePoolDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AutoscalePoolDialog.tsx
@@ -72,8 +72,13 @@ const AutoscalePoolDialog: React.FC<Props> = (props) => {
   const autoscaler = getAutoscaler();
   const classes = useStyles();
 
-  const submitForm = (values: AutoscaleNodePool) => {
+  const submitForm = () => {
     onSubmit(values, setSubmitting);
+  };
+
+  const handleClose = () => {
+    onClose();
+    setWarningMessage('');
   };
 
   const handleWarning = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -102,20 +107,20 @@ const AutoscalePoolDialog: React.FC<Props> = (props) => {
     },
     enableReinitialize: true,
     validationSchema: AutoscaleNodePoolSchema,
-    onSubmit: (values) => submitForm(values),
+    onSubmit: submitForm,
   });
 
   return (
     <ConfirmationDialog
       open={open}
       title="Autoscale Pool"
-      onClose={onClose}
+      onClose={handleClose}
       actions={() => (
         <form onSubmit={handleSubmit}>
           <ActionsPanel style={{ padding: 0 }}>
             <Button
               buttonType="secondary"
-              onClick={onClose}
+              onClick={handleClose}
               data-qa-cancel
               data-testid="dialog-cancel"
             >
@@ -147,7 +152,7 @@ const AutoscalePoolDialog: React.FC<Props> = (props) => {
               buttonType="secondary"
               compact
               onClick={() => {
-                onClose();
+                handleClose();
                 handleOpenResizeDrawer(poolID);
               }}
             >

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AutoscalePoolDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AutoscalePoolDialog.tsx
@@ -35,6 +35,11 @@ const useStyles = makeStyles((theme: Theme) => ({
       padding: `${theme.spacing(2)}px 0`,
     },
   },
+  inputContainer: {
+    '& label': {
+      marginTop: 13,
+    }
+  },
   disabled: {
     opacity: 0.5,
   },
@@ -124,8 +129,9 @@ const AutoscalePoolDialog: React.FC<Props> = (props) => {
             disabled={isSubmitting}
           />
         }
+        style={{ marginTop: 12 }}
       />
-      <Grid container>
+      <Grid container className={classes.inputContainer}>
         <Grid item xs={3}>
           <TextField
             name="min"

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AutoscalePoolDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AutoscalePoolDialog.tsx
@@ -175,9 +175,9 @@ const AutoscalePoolDialog: React.FC<Props> = (props) => {
       ) : null}
       <Typography>
         Set minimum and maximum node pool constraints for LKE to resize your
-        cluster based on demand and control cluster resource costs. Autoscaler
-        maximum limit is 100.{' '}
-        <Link to={'https://www.linode.com/docs/products/compute/kubernetes/'}>
+        cluster automatically based on resource demand and overall usage.
+        Maximum limit is 100 nodes.{' '}
+        <Link to="https://www.linode.com/docs/products/compute/kubernetes/guides/enable-cluster-autoscaling">
           Learn More.
         </Link>
       </Typography>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AutoscalePoolDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AutoscalePoolDialog.tsx
@@ -41,7 +41,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   inputContainer: {
     '& label': {
       marginTop: 13,
-    }
+    },
   },
   disabled: {
     opacity: 0.5,
@@ -50,8 +50,11 @@ const useStyles = makeStyles((theme: Theme) => ({
     color: theme.color.red,
   },
   resize: {
-    display: 'flex',
-    alignItems: 'baseline',
+    marginTop: -4,
+    marginLeft: -2,
+    marginRight: 2,
+    minHeight: 0,
+    padding: 0,
   },
   notice: {
     fontFamily: theme.font.bold,
@@ -156,9 +159,10 @@ const AutoscalePoolDialog: React.FC<Props> = (props) => {
       {warningMessage ? (
         <Notice warning className={classes.notice}>
           {warningMessage}
-          <div className={classes.resize}>
+          <div>
             <Button
               buttonType="secondary"
+              className={classes.resize}
               compact
               onClick={() => {
                 handleClose();

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AutoscalePoolDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AutoscalePoolDialog.tsx
@@ -93,7 +93,7 @@ const AutoscalePoolDialog: React.FC<Props> = (props) => {
   };
 
   const handleWarning = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (autoscaler && +e.target.value < autoscaler.max) {
+    if (autoscaler && autoscaler.max > 1 && +e.target.value < autoscaler.max) {
       return setWarningMessage(
         'The Node Pool will only be scaled down if there are unneeded nodes.'
       );
@@ -104,12 +104,9 @@ const AutoscalePoolDialog: React.FC<Props> = (props) => {
   const {
     values,
     errors,
-    touched,
     isSubmitting,
     handleChange,
-    handleSubmit,
     handleReset,
-    setFieldTouched,
     setSubmitting,
   } = useFormik({
     initialValues: {
@@ -128,31 +125,31 @@ const AutoscalePoolDialog: React.FC<Props> = (props) => {
       title="Autoscale Pool"
       onClose={handleClose}
       actions={() => (
-        <form onSubmit={handleSubmit}>
-          <ActionsPanel style={{ padding: 0 }}>
-            <Button
-              buttonType="secondary"
-              onClick={handleClose}
-              data-qa-cancel
-              data-testid="dialog-cancel"
-            >
-              Cancel
-            </Button>
-            <Button
-              buttonType="primary"
-              type="submit"
-              loading={loading || isSubmitting}
-              disabled={
-                !(touched.enabled || touched.min || touched.max) ||
-                Object.keys(errors).length !== 0
-              }
-              data-qa-confirm
-              data-testid="dialog-confirm"
-            >
-              Save Changes
-            </Button>
-          </ActionsPanel>
-        </form>
+        <ActionsPanel style={{ padding: 0 }}>
+          <Button
+            buttonType="secondary"
+            onClick={handleClose}
+            data-qa-cancel
+            data-testid="dialog-cancel"
+          >
+            Cancel
+          </Button>
+          <Button
+            buttonType="primary"
+            onClick={submitForm}
+            loading={loading || isSubmitting}
+            disabled={
+              (values.enabled === autoscaler?.enabled &&
+                values.min === autoscaler?.min &&
+                values.max === autoscaler?.max) ||
+              Object.keys(errors).length !== 0
+            }
+            data-qa-confirm
+            data-testid="dialog-confirm"
+          >
+            Save Changes
+          </Button>
+        </ActionsPanel>
       )}
     >
       {error ? <Notice error text={error} /> : null}
@@ -186,10 +183,7 @@ const AutoscalePoolDialog: React.FC<Props> = (props) => {
           <Toggle
             name="enabled"
             checked={values.enabled}
-            onChange={(e) => {
-              setFieldTouched('enabled', true);
-              handleChange(e);
-            }}
+            onChange={handleChange}
             disabled={isSubmitting}
           />
         }
@@ -202,12 +196,9 @@ const AutoscalePoolDialog: React.FC<Props> = (props) => {
             label="Min"
             type="number"
             value={values.min}
-            onChange={(e) => {
-              setFieldTouched('min', true);
-              handleChange(e);
-            }}
+            onChange={handleChange}
             disabled={!values.enabled || isSubmitting}
-            error={touched.min && Boolean(errors.min)}
+            error={Boolean(errors.min)}
             className={classes.input}
           />
         </Grid>
@@ -227,29 +218,22 @@ const AutoscalePoolDialog: React.FC<Props> = (props) => {
             type="number"
             value={values.max}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-              setFieldTouched('max', true);
               handleChange(e);
               handleWarning(e);
             }}
             disabled={!values.enabled || isSubmitting}
-            error={touched.max && Boolean(errors.max)}
+            error={Boolean(errors.max)}
             className={classes.input}
           />
         </Grid>
-        {(touched.min && errors.min) || (touched.max && errors.max) ? (
-          <Grid item xs={12} style={{ padding: '0 8px' }}>
-            {errors.min ? (
-              <Typography className={classes.errorText}>
-                {errors.min}
-              </Typography>
-            ) : null}
-            {errors.max ? (
-              <Typography className={classes.errorText}>
-                {errors.max}
-              </Typography>
-            ) : null}
-          </Grid>
-        ) : null}
+        <Grid item xs={12} style={{ padding: '0 8px' }}>
+          {errors.min ? (
+            <Typography className={classes.errorText}>{errors.min}</Typography>
+          ) : null}
+          {errors.max ? (
+            <Typography className={classes.errorText}>{errors.max}</Typography>
+          ) : null}
+        </Grid>
       </Grid>
     </ConfirmationDialog>
   );

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AutoscalePoolDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AutoscalePoolDialog.tsx
@@ -1,0 +1,185 @@
+import { AutoscaleNodePool } from '@linode/api-v4/lib/kubernetes';
+import { AutoscaleNodePoolSchema } from '@linode/validation/lib/kubernetes.schema';
+import { useFormik } from 'formik';
+import * as React from 'react';
+import * as classNames from 'classnames';
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
+import ConfirmationDialog from 'src/components/ConfirmationDialog';
+import FormControlLabel from 'src/components/core/FormControlLabel';
+import Typography from 'src/components/core/Typography';
+import Grid from 'src/components/Grid';
+import Notice from 'src/components/Notice';
+import TextField from 'src/components/TextField';
+import Toggle from 'src/components/Toggle';
+import { makeStyles, Theme } from 'src/components/core/styles';
+
+interface Props {
+  open: boolean;
+  loading: boolean;
+  error?: string;
+  getAutoscaler: () => AutoscaleNodePool | undefined;
+  onClose: () => void;
+  onSubmit: (
+    values: AutoscaleNodePool,
+    setSubmitting: (isSubmitting: boolean) => void
+  ) => void;
+}
+
+const useStyles = makeStyles((theme: Theme) => ({
+  slash: {
+    alignSelf: 'end',
+    padding: '0px !important',
+    '& p': {
+      fontSize: '1rem',
+      padding: `${theme.spacing(2)}px 0`,
+    },
+  },
+  disabled: {
+    opacity: 0.5,
+  },
+  errorText: {
+    color: theme.color.red,
+  },
+}));
+
+const AutoscalePoolDialog: React.FC<Props> = (props) => {
+  const { error, loading, open, getAutoscaler, onClose, onSubmit } = props;
+  const autoscaler = getAutoscaler();
+  const classes = useStyles();
+
+  const submitForm = (values: AutoscaleNodePool) => {
+    onSubmit(values, setSubmitting);
+  };
+
+  const {
+    values,
+    errors,
+    touched,
+    isSubmitting,
+    handleChange,
+    handleSubmit,
+    setFieldTouched,
+    setSubmitting,
+  } = useFormik({
+    initialValues: {
+      enabled: autoscaler?.enabled ?? false,
+      min: autoscaler?.min ?? 1,
+      max: autoscaler?.max ?? 1,
+    },
+    enableReinitialize: true,
+    validationSchema: AutoscaleNodePoolSchema,
+    onSubmit: (values) => submitForm(values),
+  });
+
+  return (
+    <ConfirmationDialog
+      open={open}
+      title="Autoscale Pool"
+      onClose={onClose}
+      actions={() => (
+        <form onSubmit={handleSubmit}>
+          <ActionsPanel style={{ padding: 0 }}>
+            <Button
+              buttonType="secondary"
+              onClick={onClose}
+              data-qa-cancel
+              data-testid="dialog-cancel"
+            >
+              Cancel
+            </Button>
+            <Button
+              buttonType="primary"
+              type="submit"
+              loading={loading || isSubmitting}
+              disabled={
+                !(touched.enabled || touched.min || touched.max) ||
+                Object.keys(errors).length !== 0
+              }
+              data-qa-confirm
+              data-testid="dialog-confirm"
+            >
+              Save Changes
+            </Button>
+          </ActionsPanel>
+        </form>
+      )}
+    >
+      {error ? <Notice error text={error} /> : null}
+      <Typography>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis augue
+        arcu, semper id diam vitae, ultrices aliquet est. Morbi mauris risus,
+        mattis non sodales at, ultrices et quam.
+      </Typography>
+      <FormControlLabel
+        label="Autoscaler"
+        control={
+          <Toggle
+            name="enabled"
+            checked={values.enabled}
+            onChange={(e) => {
+              setFieldTouched('enabled', true);
+              handleChange(e);
+            }}
+            disabled={isSubmitting}
+          />
+        }
+      />
+      <Grid container>
+        <Grid item xs={3}>
+          <TextField
+            name="min"
+            label="Min"
+            type="number"
+            value={values.min}
+            onChange={(e) => {
+              setFieldTouched('min', true);
+              handleChange(e);
+            }}
+            disabled={!values.enabled || isSubmitting}
+            error={touched.min && Boolean(errors.min)}
+          />
+        </Grid>
+        <Grid
+          item
+          className={classNames({
+            [classes.slash]: true,
+            [classes.disabled]: !values.enabled,
+          })}
+        >
+          <Typography>/</Typography>
+        </Grid>
+        <Grid item xs={3}>
+          <TextField
+            name="max"
+            label="Max"
+            type="number"
+            value={values.max}
+            onChange={(e) => {
+              setFieldTouched('max', true);
+              handleChange(e);
+            }}
+            disabled={!values.enabled || isSubmitting}
+            error={touched.max && Boolean(errors.max)}
+          />
+        </Grid>
+        {(touched.min && errors.min) || (touched.max && errors.max) ? (
+          <Grid item xs={12} style={{ padding: '0 8px' }}>
+            {errors.min ? (
+              <Typography className={classes.errorText}>
+                {errors.min}
+              </Typography>
+            ) : null}
+            {errors.max ? (
+              <Typography className={classes.errorText}>
+                {errors.max}
+              </Typography>
+            ) : null}
+          </Grid>
+        ) : null}
+      </Grid>
+    </ConfirmationDialog>
+  );
+};
+
+export default React.memo(AutoscalePoolDialog);

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AutoscalePoolDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AutoscalePoolDialog.tsx
@@ -24,7 +24,8 @@ interface Props {
   onClose: () => void;
   onSubmit: (
     values: AutoscaleNodePool,
-    setSubmitting: (isSubmitting: boolean) => void
+    setSubmitting: (isSubmitting: boolean) => void,
+    setWarningMessage: (warning: string) => void
   ) => void;
 }
 
@@ -55,6 +56,12 @@ const useStyles = makeStyles((theme: Theme) => ({
   notice: {
     fontFamily: theme.font.bold,
   },
+  input: {
+    minWidth: 'auto',
+    '& input': {
+      width: 70,
+    },
+  },
 }));
 
 const AutoscalePoolDialog: React.FC<Props> = (props) => {
@@ -73,12 +80,13 @@ const AutoscalePoolDialog: React.FC<Props> = (props) => {
   const classes = useStyles();
 
   const submitForm = () => {
-    onSubmit(values, setSubmitting);
+    onSubmit(values, setSubmitting, setWarningMessage);
   };
 
   const handleClose = () => {
     onClose();
     setWarningMessage('');
+    handleReset(values);
   };
 
   const handleWarning = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -97,6 +105,7 @@ const AutoscalePoolDialog: React.FC<Props> = (props) => {
     isSubmitting,
     handleChange,
     handleSubmit,
+    handleReset,
     setFieldTouched,
     setSubmitting,
   } = useFormik({
@@ -158,7 +167,7 @@ const AutoscalePoolDialog: React.FC<Props> = (props) => {
             >
               Resize
             </Button>
-            to immediately scale your node pool up or down.
+            to immediately scale your Node Pool up or down.
           </div>
         </Notice>
       ) : null}
@@ -183,7 +192,7 @@ const AutoscalePoolDialog: React.FC<Props> = (props) => {
         style={{ marginTop: 12 }}
       />
       <Grid container className={classes.inputContainer}>
-        <Grid item xs={3}>
+        <Grid item>
           <TextField
             name="min"
             label="Min"
@@ -195,6 +204,7 @@ const AutoscalePoolDialog: React.FC<Props> = (props) => {
             }}
             disabled={!values.enabled || isSubmitting}
             error={touched.min && Boolean(errors.min)}
+            className={classes.input}
           />
         </Grid>
         <Grid
@@ -206,7 +216,7 @@ const AutoscalePoolDialog: React.FC<Props> = (props) => {
         >
           <Typography>/</Typography>
         </Grid>
-        <Grid item xs={3}>
+        <Grid item>
           <TextField
             name="max"
             label="Max"
@@ -219,6 +229,7 @@ const AutoscalePoolDialog: React.FC<Props> = (props) => {
             }}
             disabled={!values.enabled || isSubmitting}
             error={touched.max && Boolean(errors.max)}
+            className={classes.input}
           />
         </Grid>
         {(touched.min && errors.min) || (touched.max && errors.max) ? (

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
@@ -7,6 +7,7 @@ import Button from 'src/components/Button';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 import NodeTable from './NodeTable';
+import useFlags from 'src/hooks/useFlags';
 
 interface Props {
   poolId: number;
@@ -33,6 +34,8 @@ const NodePool: React.FC<Props> = (props) => {
     poolId,
   } = props;
 
+  const flags = useFlags();
+
   return (
     <>
       <Grid
@@ -45,18 +48,20 @@ const NodePool: React.FC<Props> = (props) => {
           <Typography variant="h2">{typeLabel}</Typography>
         </Grid>
         <Grid item style={{ display: 'flex' }}>
-          <div style={{ display: 'flex' }}>
-            <Button
-              style={{ paddingRight: 10 }}
-              buttonType="secondary"
-              onClick={() => openAutoscalePoolDialog(poolId)}
-            >
-              Autoscale Pool
-            </Button>
-            <Typography style={{ alignSelf: 'center', paddingRight: 16 }}>
-              {`(Min ${autoscaler.min} / Max ${autoscaler.max})`}
-            </Typography>
-          </div>
+          {flags.autoscaler ? (
+            <div style={{ display: 'flex' }}>
+              <Button
+                style={{ paddingRight: 10 }}
+                buttonType="secondary"
+                onClick={() => openAutoscalePoolDialog(poolId)}
+              >
+                Autoscale Pool
+              </Button>
+              <Typography style={{ alignSelf: 'center', paddingRight: 16 }}>
+                {`(Min ${autoscaler.min} / Max ${autoscaler.max})`}
+              </Typography>
+            </div>
+          ) : null}
           <Button
             buttonType="secondary"
             onClick={() => handleClickResize(poolId)}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
@@ -1,4 +1,7 @@
-import { PoolNodeResponse } from '@linode/api-v4/lib/kubernetes';
+import {
+  AutoscaleNodePool,
+  PoolNodeResponse,
+} from '@linode/api-v4/lib/kubernetes';
 import * as React from 'react';
 import Button from 'src/components/Button';
 import Typography from 'src/components/core/Typography';
@@ -9,15 +12,19 @@ interface Props {
   poolId: number;
   typeLabel: string;
   nodes: PoolNodeResponse[];
+  autoscaler: AutoscaleNodePool;
+  handleClickResize: (poolId: number) => void;
+  openAutoscalePoolDialog: (poolId: number) => void;
   openDeletePoolDialog: (poolId: number) => void;
   openRecycleAllNodesDialog: (poolId: number) => void;
   openRecycleNodeDialog: (nodeID: string, linodeLabel: string) => void;
-  handleClickResize: (poolId: number) => void;
 }
 
 const NodePool: React.FC<Props> = (props) => {
   const {
+    autoscaler,
     handleClickResize,
+    openAutoscalePoolDialog,
     openDeletePoolDialog,
     openRecycleAllNodesDialog,
     openRecycleNodeDialog,
@@ -37,7 +44,19 @@ const NodePool: React.FC<Props> = (props) => {
         <Grid item>
           <Typography variant="h2">{typeLabel}</Typography>
         </Grid>
-        <Grid item>
+        <Grid item style={{ display: 'flex' }}>
+          <div style={{ display: 'flex' }}>
+            <Button
+              style={{ paddingRight: 10 }}
+              buttonType="secondary"
+              onClick={() => openAutoscalePoolDialog(poolId)}
+            >
+              Autoscale Pool
+            </Button>
+            <Typography style={{ alignSelf: 'center', paddingRight: 16 }}>
+              {`(Min ${autoscaler.min} / Max ${autoscaler.max})`}
+            </Typography>
+          </div>
           <Button
             buttonType="secondary"
             onClick={() => handleClickResize(poolId)}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
@@ -3,6 +3,7 @@ import {
   PoolNodeResponse,
 } from '@linode/api-v4/lib/kubernetes';
 import * as React from 'react';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Button from 'src/components/Button';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
@@ -21,6 +22,23 @@ interface Props {
   openRecycleNodeDialog: (nodeID: string, linodeLabel: string) => void;
 }
 
+const useStyles = makeStyles((theme: Theme) => ({
+  slash: {
+    alignSelf: 'end',
+    padding: '0px !important',
+    '& p': {
+      fontSize: '1rem',
+      padding: `${theme.spacing(2)}px 0`,
+    },
+  },
+  container: {
+    display: 'flex',
+  },
+  button: {
+    paddingRight: 8,
+  },
+}));
+
 const NodePool: React.FC<Props> = (props) => {
   const {
     autoscaler,
@@ -34,6 +52,7 @@ const NodePool: React.FC<Props> = (props) => {
     poolId,
   } = props;
 
+  const classes = useStyles();
   const flags = useFlags();
 
   return (
@@ -47,19 +66,21 @@ const NodePool: React.FC<Props> = (props) => {
         <Grid item>
           <Typography variant="h2">{typeLabel}</Typography>
         </Grid>
-        <Grid item style={{ display: 'flex' }}>
+        <Grid item className={classes.container}>
           {flags.autoscaler ? (
-            <div style={{ display: 'flex' }}>
+            <div className={classes.container}>
               <Button
-                style={{ paddingRight: 10 }}
+                className={`${autoscaler.enabled ? classes.button : ''}`}
                 buttonType="secondary"
                 onClick={() => openAutoscalePoolDialog(poolId)}
               >
                 Autoscale Pool
               </Button>
-              <Typography style={{ alignSelf: 'center', paddingRight: 16 }}>
-                {`(Min ${autoscaler.min} / Max ${autoscaler.max})`}
-              </Typography>
+              {autoscaler.enabled ? (
+                <Typography style={{ alignSelf: 'center', paddingRight: 16 }}>
+                  {`(Min ${autoscaler.min} / Max ${autoscaler.max})`}
+                </Typography>
+              ) : null}
             </div>
           ) : null}
           <Button

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
@@ -37,6 +37,10 @@ const useStyles = makeStyles((theme: Theme) => ({
   button: {
     paddingRight: 8,
   },
+  text: {
+    alignSelf: 'center',
+    paddingRight: 16,
+  },
 }));
 
 const NodePool: React.FC<Props> = (props) => {
@@ -77,7 +81,7 @@ const NodePool: React.FC<Props> = (props) => {
                 Autoscale Pool
               </Button>
               {autoscaler.enabled ? (
-                <Typography style={{ alignSelf: 'center', paddingRight: 16 }}>
+                <Typography className={classes.text}>
                   {`(Min ${autoscaler.min} / Max ${autoscaler.max})`}
                 </Typography>
               ) : null}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.test.tsx
@@ -16,6 +16,7 @@ const props: Props = {
   recycleAllPoolNodes: jest.fn(),
   recycleAllClusterNodes: jest.fn(),
   recycleNode: jest.fn(),
+  getNodePools: jest.fn(),
   clusterID: 123,
   clusterLabel: 'a cluster',
 };

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.test.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.test.tsx
@@ -16,6 +16,7 @@ const props: Props = {
   recycleAllPoolNodes: jest.fn(),
   recycleAllClusterNodes: jest.fn(),
   recycleNode: jest.fn(),
+  clusterID: 123,
   clusterLabel: 'a cluster',
 };
 

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -80,6 +80,7 @@ export interface Props {
   recycleAllClusterNodes: () => Promise<{}>;
   recycleAllPoolNodes: (poolID: number) => Promise<{}>;
   recycleNode: (nodeID: string) => Promise<{}>;
+  getNodePools: () => Promise<any>;
 }
 
 export const NodePoolsDisplay: React.FC<Props> = (props) => {
@@ -94,6 +95,7 @@ export const NodePoolsDisplay: React.FC<Props> = (props) => {
     recycleAllClusterNodes,
     recycleAllPoolNodes,
     recycleNode,
+    getNodePools,
   } = props;
 
   const classes = useStyles();
@@ -215,6 +217,7 @@ export const NodePoolsDisplay: React.FC<Props> = (props) => {
           `Autoscaling updated for Node Pool ${dialog.entityID}.`,
           { variant: 'success' }
         );
+        getNodePools();
       })
       .catch((err) => {
         handleError(

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -380,6 +380,7 @@ export const NodePoolsDisplay: React.FC<Props> = (props) => {
             />
             <AutoscalePoolDialog
               getAutoscaler={getAutoscaler}
+              handleOpenResizeDrawer={handleOpenResizeDrawer}
               onSubmit={(
                 values: AutoscaleNodePoolValues,
                 setSubmitting: (isSubmitting: boolean) => void
@@ -388,6 +389,7 @@ export const NodePoolsDisplay: React.FC<Props> = (props) => {
               open={autoscalePoolDialog.dialog.isOpen}
               error={autoscalePoolDialog.dialog.error}
               loading={autoscalePoolDialog.dialog.isLoading}
+              poolID={autoscalePoolDialog.dialog.entityID}
             />
             <RecycleAllPoolNodesDialog
               open={recycleAllPoolNodesDialog.dialog.isOpen}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -201,7 +201,8 @@ export const NodePoolsDisplay: React.FC<Props> = (props) => {
 
   const handleAutoscalePool = (
     values: AutoscaleNodePoolValues,
-    setSubmitting: (isSubmitting: boolean) => void
+    setSubmitting: (isSubmitting: boolean) => void,
+    setWarningMessage: (warning: string) => void
   ) => {
     const { dialog, submitDialog, handleError } = autoscalePoolDialog;
     if (!dialog.entityID) {
@@ -223,7 +224,10 @@ export const NodePoolsDisplay: React.FC<Props> = (props) => {
           )[0].reason
         );
       })
-      .finally(() => setSubmitting(false));
+      .finally(() => {
+        setSubmitting(false);
+        setWarningMessage('');
+      });
   };
 
   const handleRecycleAllPoolNodes = () => {
@@ -383,8 +387,11 @@ export const NodePoolsDisplay: React.FC<Props> = (props) => {
               handleOpenResizeDrawer={handleOpenResizeDrawer}
               onSubmit={(
                 values: AutoscaleNodePoolValues,
-                setSubmitting: (isSubmitting: boolean) => void
-              ) => handleAutoscalePool(values, setSubmitting)}
+                setSubmitting: (isSubmitting: boolean) => void,
+                setWarningMessage: (warning: string) => void
+              ) =>
+                handleAutoscalePool(values, setSubmitting, setWarningMessage)
+              }
               onClose={autoscalePoolDialog.closeDialog}
               open={autoscalePoolDialog.dialog.isOpen}
               error={autoscalePoolDialog.dialog.error}

--- a/packages/manager/src/features/Kubernetes/kubeUtils.test.ts
+++ b/packages/manager/src/features/Kubernetes/kubeUtils.test.ts
@@ -14,6 +14,11 @@ const mockNodePool = {
   type: extendedTypes[0].id,
   count: 4,
   totalMonthlyPrice: 10,
+  autoscaler: {
+    enabled: false,
+    min: 1,
+    max: 1,
+  },
 };
 
 const badNodePool = {
@@ -23,6 +28,11 @@ const badNodePool = {
   type: 'not-a-real-type',
   count: 1,
   totalMonthlyPrice: 0,
+  autoscaler: {
+    enabled: false,
+    min: 1,
+    max: 1,
+  },
 };
 
 describe('helper functions', () => {

--- a/packages/manager/src/features/Kubernetes/types.ts
+++ b/packages/manager/src/features/Kubernetes/types.ts
@@ -1,6 +1,7 @@
 import {
   KubernetesCluster,
   PoolNodeResponse,
+  AutoscaleNodePool,
 } from '@linode/api-v4/lib/kubernetes';
 import { APIError } from '@linode/api-v4/lib/types';
 
@@ -17,6 +18,7 @@ export interface ExtendedPoolNode {
   type: string;
   clusterID?: number;
   nodes?: PoolNodeResponse[];
+  autoscaler: AutoscaleNodePool;
 }
 export interface ExtendedCluster extends KubernetesCluster {
   node_pools: PoolNodeWithPrice[];

--- a/packages/validation/src/kubernetes.schema.ts
+++ b/packages/validation/src/kubernetes.schema.ts
@@ -1,4 +1,4 @@
-import { array, number, object, string, boolean, ref } from 'yup';
+import { array, number, object, string, boolean } from 'yup';
 
 export const nodePoolSchema = object().shape({
   type: string(),
@@ -9,10 +9,22 @@ export const AutoscaleNodePoolSchema = object({
   enabled: boolean(),
   min: number().when('enabled', {
     is: true,
-    then: number()
-      .min(1, 'Minimum must be between 1 and 99 nodes.')
-      .max(99, 'Minimum must be between 1 and 99 nodes.')
-      .lessThan(ref('max'), 'Minimum cannot be greater than Maximum.'),
+    then: number().test(
+      'min',
+      'Minimum must be between 1 and 99 nodes and cannot be greater than Maximum.',
+      function (min) {
+        if (!min) {
+          return false;
+        }
+        if (min < 1 || min > 99) {
+          return false;
+        }
+        if (min > this.parent['max']) {
+          return false;
+        }
+        return true;
+      }
+    ),
   }),
   max: number().when('enabled', {
     is: true,

--- a/packages/validation/src/kubernetes.schema.ts
+++ b/packages/validation/src/kubernetes.schema.ts
@@ -1,8 +1,25 @@
-import { array, number, object, string } from 'yup';
+import { array, number, object, string, boolean, ref } from 'yup';
 
 export const nodePoolSchema = object().shape({
   type: string(),
   count: number(),
+});
+
+export const AutoscaleNodePoolSchema = object({
+  enabled: boolean(),
+  min: number().when('enabled', {
+    is: true,
+    then: number()
+      .min(1, 'Minimum must be between 1 and 99 nodes.')
+      .max(99, 'Minimum must be between 1 and 99 nodes.')
+      .lessThan(ref('max'), 'Minimum cannot be greater than Maximum.'),
+  }),
+  max: number().when('enabled', {
+    is: true,
+    then: number()
+      .min(1, 'Maximum must be between 1 and 100 nodes.')
+      .max(100, 'Maximum must be between 1 and 100 nodes.'),
+  }),
 });
 
 export const clusterLabelSchema = string()

--- a/packages/validation/src/kubernetes.schema.ts
+++ b/packages/validation/src/kubernetes.schema.ts
@@ -9,26 +9,29 @@ export const AutoscaleNodePoolSchema = object({
   enabled: boolean(),
   min: number().when('enabled', {
     is: true,
-    then: number().test(
-      'min',
-      'Minimum must be between 1 and 99 nodes and cannot be greater than Maximum.',
-      function (min) {
-        if (!min) {
-          return false;
+    then: number()
+      .required()
+      .test(
+        'min',
+        'Minimum must be between 1 and 99 nodes and cannot be greater than Maximum.',
+        function (min) {
+          if (!min) {
+            return false;
+          }
+          if (min < 1 || min > 99) {
+            return false;
+          }
+          if (min > this.parent['max']) {
+            return false;
+          }
+          return true;
         }
-        if (min < 1 || min > 99) {
-          return false;
-        }
-        if (min > this.parent['max']) {
-          return false;
-        }
-        return true;
-      }
-    ),
+      ),
   }),
   max: number().when('enabled', {
     is: true,
     then: number()
+      .required()
       .min(1, 'Maximum must be between 1 and 100 nodes.')
       .max(100, 'Maximum must be between 1 and 100 nodes.'),
   }),


### PR DESCRIPTION
## Description
Adds support for Autoscaling a Node Pool on a Kubernetes Cluster's summary page

## How to test
Go to `kubernetes/clusters/<cluser_id>/summary`, ensure the `autoscaler` feature flag is on

- You should see an `Autoscale Pool` button before the Resize Pool button
    - If the Autoscaler is on, you should see min/max values next to the autoscale pool button
    - If the Autoscaler is off, you should not see min/max values next to the autoscale pool button
- Clicking on Autoscale Pool should display a dialog
- The Save Changes button should be disabled until there has been a change in the form and there are no errors
- If Autoscaler is off, the Min/Max input fields should be disabled
- If the Minimum value is not between 1-99 or greater than the Maximum value, there should be an error displayed under the input field
- If the Maximum value is not between 1-100, there should be an error displayed under the input field
- If the Maximum value is less than the current Max, then a warning notice should display
    - Clicking on `resize` in the warning should close the modal and open the resize drawer for that pool
- Clicking Save Changes should make a request to `lke/clusters/<cluster_id>/pools/<pool_id>`
    - Any API errors should be displayed as a Notice error in the dialog
    - A successful request should close the dialog, pop a success toast and update the Min/Max values next to the Autoscale Pool button (might take a few seconds to update)