### PR TITLE
E2e run workflow on staging and PRs with e2e label

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,12 +8,16 @@ env:
 on:
   schedule:
     - cron: "0 13 * * 1-5"
+  pull_request_target:
+    types: [labeled]
   push:
     branches:
       - develop
+      - staging
 
 jobs:
   run-cypress-e2e:
+    if: contains(github.event.pull_request.labels.*.name, 'e2e')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -21,6 +25,8 @@ jobs:
         user: ["USER_1", "USER_2", "USER_3", "USER_4"]
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-node@v1
         with:
           node-version: "14.17.4"


### PR DESCRIPTION
This PR changes the UI automation workflow to run on pushes to staging, as well as PR's when the `e2e` label is added. For now, all tests will run. Soon I will create more workflows for running only select tests based on what is changed in the PR. 