### PR TITLE
M3-5481: Remove "File System Path" column from Volumes landing table

### DIFF
--- a/packages/manager/src/features/Volumes/VolumeTableRow.tsx
+++ b/packages/manager/src/features/Volumes/VolumeTableRow.tsx
@@ -2,6 +2,7 @@ import { Event } from '@linode/api-v4/lib/account';
 import * as React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { compose } from 'recompose';
+import Hidden from 'src/components/core/Hidden';
 import { makeStyles } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
@@ -98,12 +99,19 @@ export const VolumeTableRow: React.FC<CombinedProps> = (props) => {
           </Grid>
         </Grid>
       </TableCell>
-      {region && (
+      {region ? (
         <TableCell data-qa-volume-region noWrap>
           {formattedRegion}
         </TableCell>
-      )}
+      ) : null}
       <TableCell data-qa-volume-size>{size} GB</TableCell>
+      {!isVolumesLanding ? (
+        <Hidden xsDown>
+          <TableCell className={classes.volumePath} data-qa-fs-path>
+            {filesystemPath}
+          </TableCell>
+        </Hidden>
+      ) : null}
       {isVolumesLanding && (
         <TableCell data-qa-volume-cell-attachment={linodeLabel}>
           {linodeId ? (

--- a/packages/manager/src/features/Volumes/VolumeTableRow.tsx
+++ b/packages/manager/src/features/Volumes/VolumeTableRow.tsx
@@ -2,7 +2,6 @@ import { Event } from '@linode/api-v4/lib/account';
 import * as React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { compose } from 'recompose';
-import Hidden from 'src/components/core/Hidden';
 import { makeStyles } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
@@ -99,13 +98,12 @@ export const VolumeTableRow: React.FC<CombinedProps> = (props) => {
           </Grid>
         </Grid>
       </TableCell>
-      {region && <TableCell data-qa-volume-region>{formattedRegion}</TableCell>}
-      <TableCell data-qa-volume-size>{size} GB</TableCell>
-      <Hidden xsDown>
-        <TableCell className={classes.volumePath} data-qa-fs-path>
-          {filesystemPath}
+      {region && (
+        <TableCell data-qa-volume-region noWrap>
+          {formattedRegion}
         </TableCell>
-      </Hidden>
+      )}
+      <TableCell data-qa-volume-size>{size} GB</TableCell>
       {isVolumesLanding && (
         <TableCell data-qa-volume-cell-attachment={linodeLabel}>
           {linodeId ? (

--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -107,13 +107,13 @@ const volumeHeaders = [
     label: 'Label',
     dataColumn: 'label',
     sortable: true,
-    widthPercent: 25,
+    widthPercent: 40,
   },
   {
     label: 'Region',
     dataColumn: 'region',
     sortable: true,
-    widthPercent: 15,
+    widthPercent: 10,
   },
   {
     label: 'Size',
@@ -122,17 +122,10 @@ const volumeHeaders = [
     widthPercent: 5,
   },
   {
-    label: 'File System Path',
-    dataColumn: 'File System Path',
-    sortable: false,
-    widthPercent: 25,
-    hideOnMobile: true,
-  },
-  {
     label: 'Attached To',
     dataColumn: 'Attached To',
     sortable: false,
-    widthPercent: 20,
+    widthPercent: 25,
   },
 ];
 

--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -113,7 +113,7 @@ const volumeHeaders = [
     label: 'Region',
     dataColumn: 'region',
     sortable: true,
-    widthPercent: 10,
+    widthPercent: 15,
   },
   {
     label: 'Size',


### PR DESCRIPTION
## Description
Removes the "File System Path" column from the Volumes landing table

## How to test
Check the Volumes landing table and ensure the "File System Path" column has been removed and that the table looks good across viewport sizes.

Also check the Volumes table on the Linode Detail --> Storage tab to make sure it has not been impacted.
