### PR TITLE
M3-5424: Improve experience when attaching a VLAN when creating a Linode from a Backup or Clone

### DIFF
--- a/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
@@ -97,8 +97,10 @@ const AddonsPanel: React.FC<CombinedProps> = (props) => {
   // Doing this so that we can toggle our flag without enabling vlans for all customers.
   const capabilities = account?.capabilities ?? [];
 
-  // The VLAN section is shown when, a user has the capability, the flag is on, and
-  // the user is not creating by cloning (cloning copys the network interfaces)
+  // The VLAN section is shown when:
+  // - the user has the capability
+  // - the flag is on
+  // - the user is not creating by cloning (cloning copies the network interfaces)
   const showVlans =
     capabilities.includes('Vlans') &&
     flags.vlans &&
@@ -224,7 +226,7 @@ const getVlanDisabledReason = (
   if (isBareMetal) {
     return 'VLANs cannot be used with Bare Metal Linodes.';
   } else if (createType === 'fromBackup') {
-    return 'You cannot attach a VLAN when restoring from a backup.';
+    return 'You cannot attach a VLAN when deploying to a new Linode from a backup.';
   } else if (!selectedImage) {
     return 'You must select an Image to attach a VLAN.';
   }

--- a/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
@@ -96,7 +96,13 @@ const AddonsPanel: React.FC<CombinedProps> = (props) => {
   // Making this an && instead of the usual hasFeatureEnabled, which is || based.
   // Doing this so that we can toggle our flag without enabling vlans for all customers.
   const capabilities = account?.capabilities ?? [];
-  const showVlans = capabilities.includes('Vlans') && flags.vlans;
+
+  // The VLAN section is shown when, a user has the capability, the flag is on, and
+  // the user is not creating by cloning (cloning copys the network interfaces)
+  const showVlans =
+    capabilities.includes('Vlans') &&
+    flags.vlans &&
+    createType !== 'fromLinode';
 
   const isBareMetal = /metal/.test(selectedTypeID ?? '');
 
@@ -217,10 +223,9 @@ const getVlanDisabledReason = (
 ) => {
   if (isBareMetal) {
     return 'VLANs cannot be used with Bare Metal Linodes.';
-  } else if (
-    !selectedImage &&
-    !['fromLinode', 'fromBackup'].includes(createType)
-  ) {
+  } else if (createType === 'fromBackup') {
+    return 'You cannot attach a VLAN when restoring from a backup.';
+  } else if (!selectedImage) {
     return 'You must select an Image to attach a VLAN.';
   }
   return undefined;

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -658,13 +658,13 @@ export class LinodeCreate extends React.PureComponent<
             disabled={userCannotCreateLinode}
             selectedImageID={this.props.selectedImageID}
             selectedTypeID={this.props.selectedTypeID}
-            hidePrivateIP={this.props.createType === 'fromLinode'}
             vlanLabel={this.props.vlanLabel || ''}
             ipamAddress={this.props.ipamAddress || ''}
             handleVLANChange={this.props.handleVLANChange}
             selectedRegionID={this.props.selectedRegionID}
             labelError={hasErrorFor['interfaces[1].label']}
             ipamError={hasErrorFor['interfaces[1].ipam_address']}
+            createType={this.props.createType}
           />
         </Grid>
         <Grid item className="mlSidebar">


### PR DESCRIPTION
## Description

### The Bug
- The VLAN option was disabled in the Linode Create flow when restoring from a backup or cloning 

### The Fix (not really a fix)
- Hides the VLANS section when cloning a Linode because cloning will copy the network interfaces
- Updates disabled tooltip copy for creating a Linode from a backup. (You cannot attach a VLAN when creating from a backup shown in the screenshot)

<img width="1600" alt="Screen Shot 2021-09-20 at 12 42 05 PM" src="https://user-images.githubusercontent.com/6440455/134067106-dae44337-f703-4e66-a21e-8676bd378534.png">

## How to test

- Test all Linode Create Flows (from Image, from Backup, from Cloning, etc...)
