### PR TITLE
M3-5482: Add NVMe chip for NVMe volumes

### DIFF
--- a/packages/api-v4/src/volumes/types.ts
+++ b/packages/api-v4/src/volumes/types.ts
@@ -9,6 +9,7 @@ export interface Volume {
   updated: string;
   filesystem_path: string;
   tags: string[];
+  hardware_type: string;
 }
 
 export type VolumeStatus =

--- a/packages/api-v4/src/volumes/types.ts
+++ b/packages/api-v4/src/volumes/types.ts
@@ -9,7 +9,7 @@ export interface Volume {
   updated: string;
   filesystem_path: string;
   tags: string[];
-  hardware_type: string;
+  hardware_type: VolumeHardwareType;
 }
 
 export type VolumeStatus =
@@ -19,6 +19,8 @@ export type VolumeStatus =
   | 'deleting'
   | 'deleted'
   | 'contact_support';
+
+type VolumeHardwareType = 'hdd' | 'nvme';
 
 export interface VolumeRequestPayload {
   label: string;

--- a/packages/manager/src/__data__/volumes.ts
+++ b/packages/manager/src/__data__/volumes.ts
@@ -12,6 +12,7 @@ export const volumes: Volume[] = [
     status: 'active',
     tags: ['tag1', 'tag2'],
     updated: '2018-06-06T13:16:02',
+    hardware_type: 'hdd',
   },
   {
     created: '2018-06-06T13:16:54',
@@ -24,6 +25,7 @@ export const volumes: Volume[] = [
     status: 'active',
     tags: ['tag1'],
     updated: '2018-06-06T13:16:54',
+    hardware_type: 'hdd',
   },
   {
     created: '2018-06-27T12:38:51',
@@ -36,6 +38,7 @@ export const volumes: Volume[] = [
     status: 'active',
     tags: ['tag1', 'tag2', 'tag3', 'tag4'],
     updated: '2018-06-27T12:38:51',
+    hardware_type: 'nvme',
   },
   {
     created: '2018-06-27T12:39:30',
@@ -49,5 +52,6 @@ export const volumes: Volume[] = [
     status: 'active',
     tags: ['tag1', 'tag2', 'tag3'],
     updated: '2018-06-27T12:39:30',
+    hardware_type: 'hdd',
   },
 ];

--- a/packages/manager/src/factories/volume.ts
+++ b/packages/manager/src/factories/volume.ts
@@ -12,4 +12,5 @@ export const volumeFactory = Factory.Sync.makeFactory<Volume>({
   updated: '2019-01-01',
   filesystem_path: '/mnt',
   linode_id: null,
+  hardware_type: 'hdd',
 });

--- a/packages/manager/src/features/Volumes/RenderVolumeData.tsx
+++ b/packages/manager/src/features/Volumes/RenderVolumeData.tsx
@@ -65,6 +65,7 @@ const RenderData: React.FC<
           created={volume.created}
           updated={volume.updated}
           filesystem_path={volume.filesystem_path}
+          hardware_type={volume.hardware_type}
           linode_id={volume.linode_id}
           isVolumesLanding={isVolumesLanding}
           isUpdating={isVolumeUpdating(volume.recentEvent)}

--- a/packages/manager/src/features/Volumes/VolumeTableRow.test.tsx
+++ b/packages/manager/src/features/Volumes/VolumeTableRow.test.tsx
@@ -27,6 +27,7 @@ const props: CombinedProps = {
   created: '',
   updated: '',
   filesystem_path: '',
+  hardware_type: 'hdd',
   linode_id: 0,
   isUpdating: false,
   isVolumesLanding: true,

--- a/packages/manager/src/features/Volumes/VolumeTableRow.tsx
+++ b/packages/manager/src/features/Volumes/VolumeTableRow.tsx
@@ -2,8 +2,9 @@ import { Event } from '@linode/api-v4/lib/account';
 import * as React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { compose } from 'recompose';
+import Chip from 'src/components/core/Chip';
 import Hidden from 'src/components/core/Hidden';
-import { makeStyles } from 'src/components/core/styles';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 import LinearProgress from 'src/components/LinearProgress';
@@ -13,7 +14,7 @@ import { formatRegion } from 'src/utilities';
 import { ExtendedVolume } from './types';
 import VolumesActionMenu, { ActionHandlers } from './VolumesActionMenu';
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((theme: Theme) => ({
   volumePath: {
     width: '35%',
     wordBreak: 'break-all',
@@ -28,6 +29,18 @@ const useStyles = makeStyles(() => ({
       We can remove once we make the full switch to CMR styling
       */
     paddingRight: '0 !important',
+  },
+  chip: {
+    fontSize: '0.65rem',
+    minHeight: theme.spacing(2),
+    paddingLeft: theme.spacing(0.5),
+    paddingRight: theme.spacing(0.5),
+    marginTop: 0,
+    marginBottom: 0,
+    marginLeft: theme.spacing(2),
+    borderRadius: '1px',
+    backgroundColor: 'transparent',
+    border: '1px solid #02B159',
   },
 }));
 
@@ -62,6 +75,7 @@ export const VolumeTableRow: React.FC<CombinedProps> = (props) => {
     size,
     recentEvent,
     region,
+    hardware_type: hardwareType,
     filesystem_path: filesystemPath,
     linodeLabel,
     linode_id: linodeId,
@@ -72,6 +86,8 @@ export const VolumeTableRow: React.FC<CombinedProps> = (props) => {
   const isVolumesLanding = Boolean(location.pathname.match(/volumes/));
 
   const formattedRegion = formatRegion(region);
+
+  const isNVMe = hardwareType === 'nvme';
 
   return isUpdating ? (
     <TableRow
@@ -93,10 +109,32 @@ export const VolumeTableRow: React.FC<CombinedProps> = (props) => {
   ) : (
     <TableRow key={`volume-row-${id}`} data-qa-volume-cell={id}>
       <TableCell data-qa-volume-cell-label={label}>
-        <Grid container wrap="nowrap" alignItems="center">
-          <Grid item>
-            <div>{label}</div>
-          </Grid>
+        <Grid
+          container
+          wrap="nowrap"
+          justify="space-between"
+          alignItems="flex-end"
+        >
+          {isVolumesLanding ? (
+            <>
+              <Grid item>
+                <div>{label}</div>
+              </Grid>
+              <Grid item>
+                {isNVMe ? (
+                  <Chip
+                    className={classes.chip}
+                    label="NVMe"
+                    data-testid="nvme-chip"
+                  />
+                ) : null}
+              </Grid>
+            </>
+          ) : (
+            <Grid item>
+              <div>{label}</div>
+            </Grid>
+          )}
         </Grid>
       </TableCell>
       {region ? (

--- a/packages/manager/src/features/Volumes/VolumeTableRow.tsx
+++ b/packages/manager/src/features/Volumes/VolumeTableRow.tsx
@@ -30,6 +30,9 @@ const useStyles = makeStyles((theme: Theme) => ({
       */
     paddingRight: '0 !important',
   },
+  chipWrapper: {
+    alignSelf: 'center',
+  },
   chip: {
     fontSize: '0.65rem',
     minHeight: theme.spacing(2),
@@ -120,15 +123,15 @@ export const VolumeTableRow: React.FC<CombinedProps> = (props) => {
               <Grid item>
                 <div>{label}</div>
               </Grid>
-              <Grid item>
-                {isNVMe ? (
+              {isNVMe ? (
+                <Grid item className={classes.chipWrapper}>
                   <Chip
                     className={classes.chip}
                     label="NVMe"
                     data-testid="nvme-chip"
                   />
-                ) : null}
-              </Grid>
+                </Grid>
+              ) : null}
             </>
           ) : (
             <Grid item>

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -401,7 +401,14 @@ export const handlers = [
     return res(ctx.json(record));
   }),
   rest.get('*/volumes', (req, res, ctx) => {
-    const volumes = volumeFactory.buildList(0);
+    const hddVolumes = volumeFactory.buildList(2, {
+      region: 'us-southeast',
+    });
+    const nvmeVolumes = volumeFactory.buildList(2, {
+      hardware_type: 'nvme',
+    });
+
+    const volumes = [...hddVolumes, ...nvmeVolumes];
     return res(ctx.json(makeResourcePage(volumes)));
   }),
   rest.post('*/volumes', (req, res, ctx) => {


### PR DESCRIPTION
## Description
- Add `hardware_type` to `Volume` interface
- Update mocks, fix TS errors
- Display an NVMe chip on the Volumes landing page to the right of the labels of volumes that have a `hardware_type` of `nvme`

<img width="1151" alt="Screen Shot 2021-09-22 at 4 40 50 PM" src="https://user-images.githubusercontent.com/32860776/134419184-e0c4e094-949a-4b09-8758-cba03fd62319.png">

## How to test
I updated the mocks, so you can turn on the MSW and see two mocked volumes with the NVMe chip. 
