### PR TITLE
M3-5322: Fix formatting of long strings in Domains TXT Record

### DIFF
--- a/packages/manager/src/features/Domains/DomainRecords.tsx
+++ b/packages/manager/src/features/Domains/DomainRecords.tsx
@@ -51,6 +51,7 @@ import {
 } from 'src/utilities/errorUtils';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import { storage } from 'src/utilities/storage';
+import { truncateEnd } from 'src/utilities/truncate';
 import ActionMenu from './DomainRecordActionMenu';
 import Drawer from './DomainRecordDrawer';
 
@@ -78,9 +79,7 @@ const styles = (theme: Theme) =>
     },
     cells: {
       whiteSpace: 'nowrap',
-      [theme.breakpoints.up('md')]: {
-        maxWidth: 300,
-      },
+      width: 'auto',
       '& .data': {
         maxWidth: 300,
         overflow: 'hidden',
@@ -513,7 +512,7 @@ class DomainRecords extends React.Component<CombinedProps, State> {
         { title: 'Hostname', render: (r: DomainRecord) => r.name },
         {
           title: 'Value',
-          render: (r: DomainRecord) => r.target,
+          render: (r: DomainRecord) => truncateEnd(r.target, 100),
         },
         { title: 'TTL', render: getTTL },
         {


### PR DESCRIPTION
## Description
Truncate TXT Record value and fix overflowing bug

Before:

![image](https://user-images.githubusercontent.com/14323019/134422995-fdd24fdd-d5f8-428b-a5f7-53947c8b82b4.png)

After:

![image](https://user-images.githubusercontent.com/14323019/134423011-994b3b9b-1d98-4522-82de-2d83981edd77.png)


## How to test
- Go to `domains/<domain_id>`
- Add/Edit a TXT Record value to be at least 439 characters
- The value should be truncated with an ellipsis and should not overflow into the next cell
