### PR TITLE
M3-5485: Upgrade volumes banner on Linode details

### DIFF
--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -201,7 +201,9 @@ export type NotificationType =
   | 'ticket_abuse'
   | 'notice'
   | 'promotion'
-  | 'user_email_bounce';
+  | 'user_email_bounce'
+  | 'volume_migration_scheduled'
+  | 'volume_migration_imminent';
 
 export type NotificationSeverity = 'minor' | 'major' | 'critical';
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
@@ -266,9 +266,6 @@ const LinodeDetailHeader: React.FC<CombinedProps> = (props) => {
     return <CircleProgress />;
   }
 
-  const getVolumesByLinode = (linodeId: number) =>
-    getVolumesForLinode(volumes.itemsById, linodeId).length;
-
   const volumesForLinode = getVolumesForLinode(volumes.itemsById, linode.id);
   const numAttachedVolumes = volumesForLinode.length;
 
@@ -403,7 +400,7 @@ const LinodeDetailHeader: React.FC<CombinedProps> = (props) => {
         variant="details"
         id={linode.id}
         linode={linode}
-        numVolumes={getVolumesByLinode(linode.id)}
+        numVolumes={numAttachedVolumes}
         username={profile?.username}
         linodeConfigs={linodeConfigs}
         backups={linode.backups}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
@@ -18,6 +18,7 @@ import { DialogType } from 'src/features/linodes/types';
 import { notificationContext as _notificationContext } from 'src/features/NotificationCenter/NotificationContext';
 import useFlags from 'src/hooks/useFlags';
 import useLinodeActions from 'src/hooks/useLinodeActions';
+import useNotifications from 'src/hooks/useNotifications';
 import useReduxLoad from 'src/hooks/useReduxLoad';
 import useVolumes from 'src/hooks/useVolumes';
 import { getVolumesForLinode } from 'src/store/volume/volume.selector';
@@ -83,6 +84,16 @@ const LinodeDetailHeader: React.FC<CombinedProps> = (props) => {
   });
 
   const matchedLinodeId = Number(match?.params?.linodeId ?? 0);
+
+  const notifications = useNotifications();
+
+  const showUpgradeVolumesBanner = notifications.some(
+    (notification) =>
+      notification?.entity?.id === matchedLinodeId &&
+      ['volume_migration_scheduled', 'volume_migration_imminent'].includes(
+        notification.type
+      )
+  );
 
   const notificationContext = React.useContext(_notificationContext);
 
@@ -346,6 +357,39 @@ const LinodeDetailHeader: React.FC<CombinedProps> = (props) => {
                 }
               >
                 {volumesBannerAction} a Volume
+              </Button>
+            </Grid>
+          </Grid>
+        </DismissibleBanner>
+      ) : null}
+      {showUpgradeVolumesBanner ? (
+        <DismissibleBanner
+          preferenceKey="upgradable-volumes-attached"
+          productInformationIndicator
+        >
+          <Grid
+            container
+            direction="row"
+            alignItems="center"
+            justify="space-between"
+          >
+            <Grid item>
+              <Typography>
+                Volume(s) attached to this Linode are eligible for a{' '}
+                <b>free upgrade</b> to high performance{' '}
+                <Link to="https://www.linode.com/products/block-storage/">
+                  NVMe Block Storage
+                </Link>
+                .
+              </Typography>
+              <Typography>
+                Upgrade this Linode to get up to 10x faster performance on the
+                attached Volume(s).
+              </Typography>
+            </Grid>
+            <Grid item>
+              <Button buttonType="primary" onClick={() => null}>
+                Upgrade Volume
               </Button>
             </Grid>
           </Grid>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
@@ -286,7 +286,7 @@ const LinodeDetailHeader: React.FC<CombinedProps> = (props) => {
       ['volume_migration_scheduled', 'volume_migration_imminent'].includes(
         notification.type
       ) &&
-      getVolumesForLinode(volumes.itemsById, linode.id).find(
+      getVolumesForLinode(volumes.itemsById, linode.id).some(
         (volume: Volume) => volume.id === notification?.entity?.id
       )
   );
@@ -392,7 +392,7 @@ const LinodeDetailHeader: React.FC<CombinedProps> = (props) => {
             </Grid>
             <Grid item>
               <Button buttonType="primary" onClick={() => null}>
-                Upgrade Volume
+                Upgrade Volume(s)
               </Button>
             </Grid>
           </Grid>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
@@ -1,3 +1,4 @@
+import { NotificationType } from '@linode/api-v4/lib/account';
 import { Config, Disk, LinodeStatus } from '@linode/api-v4/lib/linodes';
 import { Volume } from '@linode/api-v4/lib/volumes';
 import * as React from 'react';
@@ -283,9 +284,8 @@ const LinodeDetailHeader: React.FC<CombinedProps> = (props) => {
 
   const showUpgradeVolumesBanner = notifications.some(
     (notification) =>
-      ['volume_migration_scheduled', 'volume_migration_imminent'].includes(
-        notification.type
-      ) &&
+      notification.type ===
+        ('volume_migration_scheduled' as NotificationType) &&
       getVolumesForLinode(volumes.itemsById, linode.id).some(
         (volume: Volume) => volume.id === notification?.entity?.id
       )

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
@@ -1,4 +1,5 @@
 import { Config, Disk, LinodeStatus } from '@linode/api-v4/lib/linodes';
+import { Volume } from '@linode/api-v4/lib/volumes';
 import * as React from 'react';
 import { useDispatch } from 'react-redux';
 import { useHistory, useLocation, useRouteMatch } from 'react-router-dom';
@@ -86,14 +87,6 @@ const LinodeDetailHeader: React.FC<CombinedProps> = (props) => {
   const matchedLinodeId = Number(match?.params?.linodeId ?? 0);
 
   const notifications = useNotifications();
-
-  const showUpgradeVolumesBanner = notifications.some(
-    (notification) =>
-      notification?.entity?.id === matchedLinodeId &&
-      ['volume_migration_scheduled', 'volume_migration_imminent'].includes(
-        notification.type
-      )
-  );
 
   const notificationContext = React.useContext(_notificationContext);
 
@@ -287,6 +280,16 @@ const LinodeDetailHeader: React.FC<CombinedProps> = (props) => {
     flags.blockStorageAvailability &&
     linode.region === region &&
     numAttachedVolumes === 0;
+
+  const showUpgradeVolumesBanner = notifications.some(
+    (notification) =>
+      ['volume_migration_scheduled', 'volume_migration_imminent'].includes(
+        notification.type
+      ) &&
+      getVolumesForLinode(volumes.itemsById, linode.id).find(
+        (volume: Volume) => volume.id === notification?.entity?.id
+      )
+  );
 
   // Check to make sure:
   //    1. there are no Volumes currently attached

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
@@ -269,7 +269,8 @@ const LinodeDetailHeader: React.FC<CombinedProps> = (props) => {
   const getVolumesByLinode = (linodeId: number) =>
     getVolumesForLinode(volumes.itemsById, linodeId).length;
 
-  const numAttachedVolumes = getVolumesByLinode(linode.id);
+  const volumesForLinode = getVolumesForLinode(volumes.itemsById, linode.id);
+  const numAttachedVolumes = volumesForLinode.length;
 
   const handleDeleteLinode = (linodeId: number) => {
     history.push('/linodes');
@@ -282,14 +283,14 @@ const LinodeDetailHeader: React.FC<CombinedProps> = (props) => {
     linode.region === region &&
     numAttachedVolumes === 0;
 
-  const showUpgradeVolumesBanner = notifications.some(
+  const numUpgradeableVolumes = notifications.filter(
     (notification) =>
       notification.type ===
         ('volume_migration_scheduled' as NotificationType) &&
-      getVolumesForLinode(volumes.itemsById, linode.id).some(
+      volumesForLinode.some(
         (volume: Volume) => volume.id === notification?.entity?.id
       )
-  );
+  ).length;
 
   // Check to make sure:
   //    1. there are no Volumes currently attached
@@ -365,7 +366,7 @@ const LinodeDetailHeader: React.FC<CombinedProps> = (props) => {
           </Grid>
         </DismissibleBanner>
       ) : null}
-      {showUpgradeVolumesBanner ? (
+      {numUpgradeableVolumes > 0 ? (
         <DismissibleBanner
           preferenceKey="upgradable-volumes-attached"
           productInformationIndicator
@@ -378,21 +379,20 @@ const LinodeDetailHeader: React.FC<CombinedProps> = (props) => {
           >
             <Grid item>
               <Typography>
-                Volume(s) attached to this Linode are eligible for a{' '}
-                <b>free upgrade</b> to high performance{' '}
-                <Link to="https://www.linode.com/products/block-storage/">
-                  NVMe Block Storage
+                {numUpgradeableVolumes === 1
+                  ? 'A Volume attached to this Linode is '
+                  : 'Volumes attached to this Linode are '}
+                eligible for a <b>free upgrade</b> to high performance NVMe
+                Block Storage.{' '}
+                <Link to="https://www.linode.com/blog/cloud-storage/nvme-block-storage-now-available/">
+                  Learn More
                 </Link>
                 .
-              </Typography>
-              <Typography>
-                Upgrade this Linode to get up to 10x faster performance on the
-                attached Volume(s).
               </Typography>
             </Grid>
             <Grid item>
               <Button buttonType="primary" onClick={() => null}>
-                Upgrade Volume(s)
+                Upgrade {numUpgradeableVolumes > 1 ? 'Volumes' : 'Volume'}
               </Button>
             </Grid>
           </Grid>

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -31,7 +31,7 @@ import {
   maintenanceResponseFactory,
   monitorFactory,
   nodeBalancerFactory,
-  // notificationFactory,
+  notificationFactory,
   objectStorageBucketFactory,
   objectStorageClusterFactory,
   profileFactory,
@@ -50,7 +50,7 @@ import {
   makeObjectsPage,
   paymentMethodFactory,
   accountMaintenanceFactory,
-  gdprComplianceNotification,
+  // gdprComplianceNotification,
 } from 'src/factories';
 
 import cachedRegions from 'src/cachedData/regions.json';
@@ -613,7 +613,7 @@ export const handlers = [
     //   body: null
     // });
 
-    const gdprNotification = gdprComplianceNotification.build();
+    // const gdprNotification = gdprComplianceNotification.build();
 
     // const generalGlobalNotice = {
     //   type: 'notice',
@@ -685,12 +685,30 @@ export const handlers = [
     //   severity: 'major',
     // });
 
+    const blockStorageMigrationNotification = notificationFactory.build({
+      type: 'volume_migration_scheduled',
+      entity: {
+        type: 'volume',
+        label: 'volume-0',
+        id: 0,
+        url: '/volumes/0',
+      },
+      when: '2021-09-30T04:00:00',
+      message:
+        'The Linode that the volume is attached to will shut down in order to complete the upgrade and reboot once it is complete. Any other volumes attached to the same Linode will also be upgraded.',
+      label: 'You have a scheduled Block Storage volume upgrade pending!',
+      severity: 'major',
+      until: '2021-10-16T04:00:00',
+      body: 'Your volumes in us-southeast will be upgraded to NVMe.',
+    });
+
     return res(
       ctx.json(
         makeResourcePage([
           // pastDueBalance,
           // ...notificationFactory.buildList(1),
-          gdprNotification,
+          // gdprNotification,
+          blockStorageMigrationNotification,
           // generalGlobalNotice,
           // outageNotification,
           // minorSeverityNotification,


### PR DESCRIPTION
## Description
Display upgrade volumes banner on a Linode's details page if upgradeable volumes are attached

## How to test
Set `numUpgradeableVolumes` to 1 or 1+, turn on the MSW, and go to a Linode's details page:

![image](https://user-images.githubusercontent.com/14323019/135325207-6955e894-36bf-49bd-85a6-c818a6f9a89d.png)

![image](https://user-images.githubusercontent.com/14323019/135325261-b278057d-6e78-44d9-8de1-8d65bc216945.png)
