### PR TITLE
M3-5488: Add Notification in drawer when a user has Volumes scheduled for migration

### DIFF
--- a/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
@@ -1,4 +1,8 @@
-import { Notification, NotificationSeverity } from '@linode/api-v4/lib/account';
+import {
+  Notification,
+  NotificationSeverity,
+  NotificationType,
+} from '@linode/api-v4/lib/account';
 import { DateTime } from 'luxon';
 import { path } from 'ramda';
 import * as React from 'react';
@@ -30,6 +34,12 @@ export const useFormattedNotifications = (): NotificationItem[] => {
   } = useDismissibleNotifications();
 
   const notifications = useNotifications();
+
+  const volumeMigrationScheduledIsPresent = notifications.some(
+    (notification) =>
+      notification.type === ('volume_migration_scheduled' as NotificationType)
+  );
+
   const classes = useStyles();
 
   const dayOfMonth = DateTime.local().day;
@@ -39,25 +49,44 @@ export const useFormattedNotifications = (): NotificationItem[] => {
     context.closeDrawer();
   };
 
-  return notifications
-    .filter((thisNotification) => {
-      /**
-       * Don't show balance overdue notifications at the beginning of the month
-       * to avoid causing anxiety if an automatic payment takes time to process.
-       * This is a temporary hack; customers can have their payment grace period extended
-       * to more than 3 days, and using this method also means that if you're more than
-       * a month overdue the notification will disappear for three days.
-       */
-      return !(thisNotification.type === 'payment_due' && dayOfMonth <= 3);
-    })
-    .map((notification, idx) =>
-      formatNotificationForDisplay(
-        interceptNotification(notification, handleClose, classes),
-        idx,
-        handleClose,
-        !hasDismissedNotifications([notification], 'notificationDrawer')
-      )
+  const filteredNotifications = notifications.filter((thisNotification) => {
+    /**
+     * Don't show balance overdue notifications at the beginning of the month
+     * to avoid causing anxiety if an automatic payment takes time to process.
+     * This is a temporary hack; customers can have their payment grace period extended
+     * to more than 3 days, and using this method also means that if you're more than
+     * a month overdue the notification will disappear for three days.
+     *
+     * Also filter out volume_migration_scheduled notifications, since those will be condensed into a single customized one.
+     */
+    return (
+      !(thisNotification.type === 'payment_due' && dayOfMonth <= 3) &&
+      thisNotification.type !== 'volume_migration_scheduled'
     );
+  });
+
+  if (volumeMigrationScheduledIsPresent) {
+    filteredNotifications.push({
+      type: 'volume_migration_scheduled' as NotificationType,
+      entity: null,
+      when: null,
+      message:
+        'You have pending volume migrations. Check the maintenance page for more details.',
+      label: 'You have a scheduled Block Storage volume upgrade pending!',
+      severity: 'major',
+      until: null,
+      body: null,
+    });
+  }
+
+  return filteredNotifications.map((notification, idx) =>
+    formatNotificationForDisplay(
+      interceptNotification(notification, handleClose, classes),
+      idx,
+      handleClose,
+      !hasDismissedNotifications([notification], 'notificationDrawer')
+    )
+  );
 };
 
 /**
@@ -333,4 +362,8 @@ export const isEUModelContractNotification = (notification: Notification) => {
   return (
     notification.type === 'notice' && /eu-model/gi.test(notification.message)
   );
+};
+
+export const condensedVolumeMigrationScheduledNotification = () => {
+  return {};
 };

--- a/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
@@ -363,7 +363,3 @@ export const isEUModelContractNotification = (notification: Notification) => {
     notification.type === 'notice' && /eu-model/gi.test(notification.message)
   );
 };
-
-export const condensedVolumeMigrationScheduledNotification = () => {
-  return {};
-};

--- a/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
@@ -301,6 +301,27 @@ const interceptNotification = (
     };
   }
 
+  if (notification.type === 'volume_migration_scheduled') {
+    const jsx = (
+      <Typography>
+        You have volumes scheduled to be upgraded to NVMe. Please refer to the{' '}
+        <Link to={'/account/maintenance/'} onClick={onClose}>
+          Maintenance page
+        </Link>{' '}
+        for more details on their upgrade status. You have the option of{' '}
+        <Link to={'/volumes'} onClick={onClose}>
+          upgrading attached volumes
+        </Link>{' '}
+        sooner than their default scheduled date.
+      </Typography>
+    );
+
+    return {
+      ...notification,
+      jsx,
+    };
+  }
+
   /* If the notification is not of any of the types above, return the notification object without modification. In this case, logic in <RenderNotification />
   will either linkify notification.message or render it plainly.
   */

--- a/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
@@ -304,14 +304,14 @@ const interceptNotification = (
   if (notification.type === 'volume_migration_scheduled') {
     const jsx = (
       <Typography>
-        Some of your Volumes are scheduled for a free upgrade to NVMe Block
+        Attached Volumes are eligible for a free upgrade to NVMe-based Block
         Storage. Visit the{' '}
         <Link to={'/account/maintenance/'} onClick={onClose}>
           Maintenance page
         </Link>{' '}
-        to view upcoming scheduled upgrades or{' '}
+        to view scheduled upgrades or visit the{' '}
         <Link to={'/volumes'} onClick={onClose}>
-          view all Volumes
+          Volumes page
         </Link>{' '}
         to begin self-service upgrades if available.
       </Typography>

--- a/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
@@ -304,15 +304,16 @@ const interceptNotification = (
   if (notification.type === 'volume_migration_scheduled') {
     const jsx = (
       <Typography>
-        You have volumes scheduled to be upgraded to NVMe. Please refer to the{' '}
+        Some of your Volumes are scheduled for a free upgrade to NVMe Block
+        Storage. Visit the{' '}
         <Link to={'/account/maintenance/'} onClick={onClose}>
           Maintenance page
         </Link>{' '}
-        for more details on their upgrade status. You have the option of{' '}
+        to view upcoming scheduled upgrades or{' '}
         <Link to={'/volumes'} onClick={onClose}>
-          upgrading attached volumes
+          view all Volumes
         </Link>{' '}
-        sooner than their default scheduled date.
+        to begin self-service upgrades if available.
       </Typography>
     );
 

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -57,6 +57,7 @@ import cachedRegions from 'src/cachedData/regions.json';
 import { MockData } from 'src/dev-tools/mockDataController';
 import { grantsFactory } from 'src/factories/grants';
 import { accountAgreementsFactory } from 'src/factories/accountAgreements';
+import { NotificationType } from '@linode/api-v4';
 
 export const makeResourcePage = (
   e: any[],
@@ -693,12 +694,29 @@ export const handlers = [
     // });
 
     const blockStorageMigrationNotification = notificationFactory.build({
-      type: 'volume_migration_scheduled',
+      type: 'volume_migration_scheduled' as NotificationType,
       entity: {
         type: 'volume',
         label: 'volume-0',
         id: 0,
         url: '/volumes/0',
+      },
+      when: '2021-09-30T04:00:00',
+      message:
+        'The Linode that the volume is attached to will shut down in order to complete the upgrade and reboot once it is complete. Any other volumes attached to the same Linode will also be upgraded.',
+      label: 'You have a scheduled Block Storage volume upgrade pending!',
+      severity: 'major',
+      until: '2021-10-16T04:00:00',
+      body: 'Your volumes in us-southeast will be upgraded to NVMe.',
+    });
+
+    const blockStorageMigrationNotification2 = notificationFactory.build({
+      type: 'volume_migration_scheduled' as NotificationType,
+      entity: {
+        type: 'volume1',
+        label: 'volume-1',
+        id: 1,
+        url: '/volumes/1',
       },
       when: '2021-09-30T04:00:00',
       message:
@@ -715,7 +733,6 @@ export const handlers = [
           // pastDueBalance,
           // ...notificationFactory.buildList(1),
           // gdprNotification,
-          blockStorageMigrationNotification,
           // generalGlobalNotice,
           // outageNotification,
           // minorSeverityNotification,
@@ -724,6 +741,8 @@ export const handlers = [
           // emailBounce,
           // migrationNotification,
           // balanceNotification,
+          blockStorageMigrationNotification,
+          blockStorageMigrationNotification2,
         ])
       )
     );


### PR DESCRIPTION
## Description
If a user has any notifications for volumes scheduled for migration (`volume_migration_scheduled`), display one notification in the drawer regarding volumes scheduled for migration (thus, if there were multiple volumes scheduled for migration, their individual notifications would be filtered out in favor of our customized, condensed one to prevent potential flooding of the Notifications drawer).

<img width="595" alt="Screen Shot 2021-09-30 at 3 32 40 PM" src="https://user-images.githubusercontent.com/32860776/135518976-b0718f32-d759-4314-9d0e-b1f9e9564f0f.png">

## How to Test
Turn on the MSW --> check the Notifications drawer --> you should observe a single condensed notification regarding volumes eligible for upgrade to NVMe ("condensed" because every attached volume scheduled for upgrade has a notification come through for it, simulated here by there being 2 in the mocks, but we want only a single representative one in the Notification drawer so as to not clutter it)

## To-Do:
- [x] Use final copy & structure the JSX for the notification
