### PR TITLE
Autoscaler UI fixes

### DIFF
--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AutoscalePoolDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/AutoscalePoolDialog.tsx
@@ -51,14 +51,16 @@ const useStyles = makeStyles((theme: Theme) => ({
     color: theme.color.red,
   },
   resize: {
-    marginTop: -4,
-    marginLeft: -2,
-    marginRight: 2,
+    fontSize: 'inherit',
+    marginTop: -3.2,
+    marginLeft: -4,
+    marginRight: 0,
     minHeight: 0,
     padding: 0,
   },
   notice: {
     fontFamily: theme.font.bold,
+    fontSize: 15,
   },
   input: {
     minWidth: 'auto',


### PR DESCRIPTION
## Description
- Fix alignment of the resize button
- Smaller warning notice text

![image](https://user-images.githubusercontent.com/14323019/135886908-f9c4e865-1bd4-4093-910a-321291369089.png)


## How to test
- Go to `kubernetes/clusters/<cluster_id>/summary`
- Click on Autoscale Pool and set the max lower than the current max, you should see the warning notice
