### PR TITLE
M3-5489: Handle language for Volume migration events

### DIFF
--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -663,6 +663,15 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
     finished: (e) => `Volume ${e.entity!.label} has been detached.`,
     notification: (e) => `Volume ${e.entity!.label} has been detached.`,
   },
+  volume_migrate: {
+    started: (e) => `Volume ${e.entity!.label} is being upgraded to NVMe.`,
+    failed: (e) => `Volume ${e.entity!.label} failed to upgrade to NVMe.`,
+    finished: (e) => `Volume ${e.entity!.label} has been upgraded to NVMe.`,
+  },
+  volume_migrate_scheduled: {
+    scheduled: (e) =>
+      `Volume ${e.entity!.label} has been scheduled for an upgrade to NVMe.`,
+  },
   volume_resize: {
     notification: (e) => `Volume ${e.entity!.label} has been resized.`,
   },

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -558,7 +558,21 @@ export const handlers = [
     const volumeMigrationScheduled = eventFactory.build({
       entity: { type: 'volume', id: 0, label: 'volume-0' },
       action: 'volume_migrate_scheduled' as EventAction,
-      message: 'Volume 0 has been scheduled for upgrade to NVMe.',
+      message: 'Volume 0 has been scheduled for an upgrade to NVMe.',
+      percent_complete: 100,
+    });
+    const volumeMigrating = eventFactory.build({
+      entity: { type: 'volume', id: 0, label: 'volume-0' },
+      action: 'volume_migrate',
+      status: 'started',
+      message: 'Volume 0 is being upgraded to NVMe.',
+      percent_complete: 65,
+    });
+    const volumeMigrationFinished = eventFactory.build({
+      entity: { type: 'volume', id: 0, label: 'volume-0' },
+      action: 'volume_migrate',
+      status: 'finished',
+      message: 'Volume 0 has finished upgrading to NVMe.',
       percent_complete: 100,
     });
     const oldEvents = eventFactory.buildList(20, {
@@ -571,8 +585,11 @@ export const handlers = [
         makeResourcePage([
           ...events,
           diskResize,
-          volumeMigrationScheduled,
           ...oldEvents,
+          ...oldEvents,
+          volumeMigrationScheduled,
+          volumeMigrating,
+          volumeMigrationFinished,
         ])
       )
     );


### PR DESCRIPTION
## Description
Display friendly messages and progress indicators for volume migration event types.

## How to test
Turn on the MSW and open the notifications drawer

![image](https://user-images.githubusercontent.com/14323019/136042657-69464cc9-6ebe-49a9-afe9-671847110300.png)
