### PR TITLE
[DNM] M3-5461: Add strong warning when removing Object Storage service

### DIFF
--- a/packages/manager/src/features/Account/EnableObjectStorage.tsx
+++ b/packages/manager/src/features/Account/EnableObjectStorage.tsx
@@ -99,7 +99,6 @@ export const EnableObjectStorage: React.FC<CombinedProps> = (props) => {
     setError(e[0].reason);
     setLoading(false);
   };
-  ``;
 
   const handleSubmit = () => {
     setLoading(true);

--- a/packages/manager/src/features/Account/EnableObjectStorage.tsx
+++ b/packages/manager/src/features/Account/EnableObjectStorage.tsx
@@ -18,11 +18,11 @@ import { useProfile } from 'src/queries/profile';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
-    marginBottom: `16px !important`,
+    marginBottom: '16px !important',
     '& p': {
-      lineHeight: `unset`,
-      fontFamily: `LatoWeb`,
-      fontSize: `smaller`,
+      lineHeight: 'unset',
+      fontFamily: theme.font.normal,
+      fontSize: '0.0875rem',
     },
   },
 }));

--- a/packages/manager/src/features/Account/EnableObjectStorage.tsx
+++ b/packages/manager/src/features/Account/EnableObjectStorage.tsx
@@ -50,16 +50,8 @@ export const ObjectStorageContent: React.FC<ContentProps> = (props) => {
       <Grid container direction="column">
         <Grid item>
           <Typography variant="body1">
-            Object Storage is enabled on your account. To cancel Object Storage,
-            all buckets must be removed from the account. For more information
-            on how to delete large amounts of objects within a bucket, consult
-            our guide on{' '}
-            <ExternalLink
-              fixedIcon
-              text="lifecycle policies."
-              link="https://www.linode.com/docs/platform/object-storage/lifecycle-policies/"
-            />{' '}
-            Upon cancellation, all Object Storage Access Keys will be revoked.
+            Object Storage is enabled on your account. Upon cancellation, all
+            Object Storage Access Keys will be revoked.
           </Typography>
         </Grid>
         <Grid item>

--- a/packages/manager/src/features/Account/EnableObjectStorage.tsx
+++ b/packages/manager/src/features/Account/EnableObjectStorage.tsx
@@ -3,20 +3,43 @@ import { cancelObjectStorage } from '@linode/api-v4/lib/object-storage';
 import { APIError } from '@linode/api-v4/lib/types';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
+import {
+  createStyles,
+  Theme,
+  withStyles,
+  WithStyles,
+} from 'src/components/core/styles';
 import Accordion from 'src/components/Accordion';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
 import Typography from 'src/components/core/Typography';
+import TextField from 'src/components/TextField';
+import Notice from 'src/components/Notice';
 import ExternalLink from 'src/components/ExternalLink';
 import Grid from 'src/components/Grid';
 import { updateAccountSettingsData } from 'src/queries/accountSettings';
+import { useProfile } from 'src/queries/profile';
+
+type ClassNames = 'root';
+
+const styles = (theme: Theme) =>
+  createStyles({
+    root: {
+      marginBottom: `16px !important`,
+      '& p': {
+        lineHeight: `unset`,
+        fontFamily: `LatoWeb`,
+        fontSize: `smaller`,
+      },
+    },
+  });
 
 interface Props {
   object_storage: AccountSettings['object_storage'];
 }
 
-type CombinedProps = Props;
+type CombinedProps = Props & WithStyles<ClassNames>;
 
 interface ContentProps {
   object_storage: AccountSettings['object_storage'];
@@ -72,7 +95,11 @@ export const EnableObjectStorage: React.FC<CombinedProps> = (props) => {
   const { object_storage } = props;
   const [isOpen, setOpen] = React.useState<boolean>(false);
   const [error, setError] = React.useState<string | undefined>();
+  const [usernameInput, setUsername] = React.useState<string>('');
+
   const [isLoading, setLoading] = React.useState<boolean>(false);
+
+  const { data: profile } = useProfile();
 
   const handleClose = () => {
     setOpen(false);
@@ -83,6 +110,7 @@ export const EnableObjectStorage: React.FC<CombinedProps> = (props) => {
     setError(e[0].reason);
     setLoading(false);
   };
+  ``;
 
   const handleSubmit = () => {
     setLoading(true);
@@ -101,7 +129,12 @@ export const EnableObjectStorage: React.FC<CombinedProps> = (props) => {
         Close
       </Button>
 
-      <Button buttonType="primary" onClick={handleSubmit} loading={isLoading}>
+      <Button
+        disabled={profile?.username !== usernameInput}
+        buttonType="primary"
+        onClick={handleSubmit}
+        loading={isLoading}
+      >
         Cancel Object Storage
       </Button>
     </ActionsPanel>
@@ -122,13 +155,25 @@ export const EnableObjectStorage: React.FC<CombinedProps> = (props) => {
         title="Cancel Object Storage"
         actions={actions}
       >
-        <Typography variant="subtitle1">
-          Canceling Object Storage will permanently delete all buckets and their
-          objects. Object Storage Access Keys will be revoked.
+        <Notice
+          warning
+          className={props.classes.root}
+          text="Canceling Object Storage will permanently delete all buckets and their objects. Object Storage Access Keys will be revoked."
+        />
+        <Typography variant="body1">
+          To confirm cancellation, type your username in the field below.
         </Typography>
+        <TextField
+          label="Username"
+          value={usernameInput}
+          onChange={(e) => setUsername(e.target.value)}
+          aria-label="username field"
+        />
       </ConfirmationDialog>
     </>
   );
 };
 
-export default React.memo(EnableObjectStorage);
+const styled = withStyles(styles);
+
+export default React.memo(styled(EnableObjectStorage));

--- a/packages/manager/src/features/Account/EnableObjectStorage.tsx
+++ b/packages/manager/src/features/Account/EnableObjectStorage.tsx
@@ -22,7 +22,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     '& p': {
       lineHeight: 'unset',
       fontFamily: theme.font.normal,
-      fontSize: '0.0875rem',
+      fontSize: '0.875rem',
     },
   },
 }));

--- a/packages/manager/src/features/Account/EnableObjectStorage.tsx
+++ b/packages/manager/src/features/Account/EnableObjectStorage.tsx
@@ -154,7 +154,8 @@ export const EnableObjectStorage: React.FC<CombinedProps> = (props) => {
           text="Canceling Object Storage will permanently delete all buckets and their objects. Object Storage Access Keys will be revoked."
         />
         <Typography variant="body1">
-          To confirm cancellation, type your username in the field below.
+          To confirm cancellation, type your username,{' '}
+          <strong>{profile?.username}</strong>, in the field below.
         </Typography>
         <TextField
           label="Username"

--- a/packages/manager/src/features/Account/EnableObjectStorage.tsx
+++ b/packages/manager/src/features/Account/EnableObjectStorage.tsx
@@ -98,11 +98,11 @@ export const EnableObjectStorage: React.FC<CombinedProps> = (props) => {
   const actions = () => (
     <ActionsPanel>
       <Button buttonType="secondary" onClick={handleClose}>
-        Cancel
+        Close
       </Button>
 
       <Button buttonType="primary" onClick={handleSubmit} loading={isLoading}>
-        Confirm cancellation
+        Cancel Object Storage
       </Button>
     </ActionsPanel>
   );
@@ -119,11 +119,12 @@ export const EnableObjectStorage: React.FC<CombinedProps> = (props) => {
         open={isOpen}
         error={error}
         onClose={() => handleClose()}
-        title="Just to confirm..."
+        title="Cancel Object Storage"
         actions={actions}
       >
         <Typography variant="subtitle1">
-          Are you sure you want to cancel Object Storage?
+          Canceling Object Storage will permanently delete all buckets and their
+          objects. Object Storage Access Keys will be revoked.
         </Typography>
       </ConfirmationDialog>
     </>

--- a/packages/manager/src/features/Account/EnableObjectStorage.tsx
+++ b/packages/manager/src/features/Account/EnableObjectStorage.tsx
@@ -3,12 +3,7 @@ import { cancelObjectStorage } from '@linode/api-v4/lib/object-storage';
 import { APIError } from '@linode/api-v4/lib/types';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles,
-} from 'src/components/core/styles';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Accordion from 'src/components/Accordion';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
@@ -21,25 +16,22 @@ import Grid from 'src/components/Grid';
 import { updateAccountSettingsData } from 'src/queries/accountSettings';
 import { useProfile } from 'src/queries/profile';
 
-type ClassNames = 'root';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {
-      marginBottom: `16px !important`,
-      '& p': {
-        lineHeight: `unset`,
-        fontFamily: `LatoWeb`,
-        fontSize: `smaller`,
-      },
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    marginBottom: `16px !important`,
+    '& p': {
+      lineHeight: `unset`,
+      fontFamily: `LatoWeb`,
+      fontSize: `smaller`,
     },
-  });
+  },
+}));
 
 interface Props {
   object_storage: AccountSettings['object_storage'];
 }
 
-type CombinedProps = Props & WithStyles<ClassNames>;
+type CombinedProps = Props;
 
 interface ContentProps {
   object_storage: AccountSettings['object_storage'];
@@ -93,6 +85,7 @@ export const ObjectStorageContent: React.FC<ContentProps> = (props) => {
 
 export const EnableObjectStorage: React.FC<CombinedProps> = (props) => {
   const { object_storage } = props;
+  const classes = useStyles();
   const [isOpen, setOpen] = React.useState<boolean>(false);
   const [error, setError] = React.useState<string | undefined>();
   const [usernameInput, setUsername] = React.useState<string>('');
@@ -157,7 +150,7 @@ export const EnableObjectStorage: React.FC<CombinedProps> = (props) => {
       >
         <Notice
           warning
-          className={props.classes.root}
+          className={classes.root}
           text="Canceling Object Storage will permanently delete all buckets and their objects. Object Storage Access Keys will be revoked."
         />
         <Typography variant="body1">
@@ -174,6 +167,4 @@ export const EnableObjectStorage: React.FC<CombinedProps> = (props) => {
   );
 };
 
-const styled = withStyles(styles);
-
-export default React.memo(styled(EnableObjectStorage));
+export default React.memo(EnableObjectStorage);

--- a/packages/manager/src/features/Account/EnableObjectStorage.tsx
+++ b/packages/manager/src/features/Account/EnableObjectStorage.tsx
@@ -25,6 +25,10 @@ const useStyles = makeStyles((theme: Theme) => ({
       fontSize: '0.875rem',
     },
   },
+  input: {
+    maxWidth: 'unset',
+    width: '100%',
+  },
 }));
 
 interface Props {
@@ -159,6 +163,7 @@ export const EnableObjectStorage: React.FC<CombinedProps> = (props) => {
         </Typography>
         <TextField
           label="Username"
+          className={classes.input}
           value={usernameInput}
           onChange={(e) => setUsername(e.target.value)}
           aria-label="username field"


### PR DESCRIPTION
## Description

Adds copy and type to confirm of service deletion

## How to test

Add Object Storage. Then go into /account/settings and Cancel Object Storage. Verify the modal has new copy and type to confirm working. Note: depends on ARB-2708 to merge
