### PR TITLE
[DNM] M3-5460: Remove copy warning about deleting non empty buckets

### DIFF
--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
@@ -160,7 +160,7 @@ export const BucketLanding: React.FC<CombinedProps> = (props) => {
   const deleteBucketConfirmationMessage = bucketToRemove ? (
     <React.Fragment>
       <Typography>
-        Deleting a bucket is permanent and can&apos;t be undone.
+        Deleting a bucket is permanent and can&rsquo;t be undone.
       </Typography>
       {/* If the user is attempting to delete their last Bucket, remind them
       that they will still be billed unless they cancel Object Storage in


### PR DESCRIPTION
## Description

Removes warning for deleting non empty Object Storage buckets

## How to test

Create Object Storage bucket, fill with some files, then delete. Verify there is no warning about deleting a non empty bucket. Note: until ARB-2708 is merged this should still yield an API error mentioning a non empty bucket.