### PR TITLE
Ability to add PayPal as a recurring payment method

### DIFF
--- a/packages/api-v4/src/account/payments.ts
+++ b/packages/api-v4/src/account/payments.ts
@@ -23,8 +23,8 @@ import {
   Paypal,
   PaypalResponse,
   SaveCreditCardData,
-  PaymentMethodData,
   MakePaymentData,
+  PaymentMethodPayload,
 } from './types';
 
 /**
@@ -207,7 +207,7 @@ export const getClientToken = () => {
  * @param data.data.cvv { string } credit card's cvv
  *
  */
-export const addPaymentMethod = (data: PaymentMethodData) => {
+export const addPaymentMethod = (data: PaymentMethodPayload) => {
   return Request<{}>(
     setURL(`${API_ROOT}/account/payment-methods`),
     setMethod('POST'),

--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -14,7 +14,7 @@ export interface Account {
   email: string;
   first_name: string;
   tax_id: string;
-  credit_card: CreditCard;
+  credit_card: CreditCardData;
   state: string;
   zip: string;
   address_1: string;
@@ -84,12 +84,6 @@ export type CardType =
   | 'JCB';
 
 export type PaymentType = 'credit_card' | ThirdPartyPayment;
-
-export interface CreditCard {
-  expiry: string | null;
-  last_four: string | null;
-  card_type?: CardType;
-}
 
 export interface Invoice {
   id: number;
@@ -395,19 +389,48 @@ export interface AccountMaintenance {
   };
 }
 
-export interface PaymentMethod {
-  id: number;
-  type: PaymentType;
-  is_default: boolean;
-  created: string;
-  data: CreditCard;
+export interface PayPalData {
+  paypal_id: string;
+  email: string;
 }
+
+export interface CreditCardData {
+  expiry: string | null;
+  last_four: string | null;
+  card_type?: CardType;
+}
+
+// Google Pay data extends CreditCardData, but use type alias to avoid empty interface
+export type GooglePayData = CreditCardData;
+
+export type PaymentMethod =
+  | {
+      id: number;
+      type: 'credit_card';
+      is_default: boolean;
+      created: string;
+      data: CreditCardData;
+    }
+  | {
+      id: number;
+      type: 'google_pay';
+      is_default: boolean;
+      created: string;
+      data: GooglePayData;
+    }
+  | {
+      id: number;
+      type: 'paypal';
+      is_default: boolean;
+      created: string;
+      data: PayPalData;
+    };
 
 export interface ClientToken {
   client_token: string;
 }
 
-export interface PaymentMethodData {
+export interface PaymentMethodPayload {
   type: 'credit_card' | 'payment_method_nonce';
   data: SaveCreditCardData | { nonce: string };
   is_default: boolean;

--- a/packages/manager/src/components/PaymentMethodRow/DeletePaymentMethodDialog.tsx
+++ b/packages/manager/src/components/PaymentMethodRow/DeletePaymentMethodDialog.tsx
@@ -2,10 +2,7 @@ import * as React from 'react';
 import ActionsPanel from '../ActionsPanel';
 import Button from '../Button';
 import Dialog from 'src/components/ConfirmationDialog';
-import {
-  PaymentMethod,
-  ThirdPartyPayment as ThirdPartyPaymentTypes,
-} from '@linode/api-v4/lib/account/types';
+import { PaymentMethod } from '@linode/api-v4/lib/account/types';
 import CreditCard from 'src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCard';
 import ThirdPartyPayment from './ThirdPartyPayment';
 import Grid from '../Grid';
@@ -64,10 +61,7 @@ export const DeletePaymentMethodDialog: React.FC<Props> = (props) => {
           {paymentMethod && paymentMethod.type === 'credit_card' ? (
             <CreditCard creditCard={paymentMethod.data} />
           ) : paymentMethod ? (
-            <ThirdPartyPayment
-              thirdPartyPayment={paymentMethod.type as ThirdPartyPaymentTypes}
-              creditCard={paymentMethod.data}
-            />
+            <ThirdPartyPayment paymentMethod={paymentMethod} />
           ) : null}
         </Grid>
       </Grid>

--- a/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.stories.tsx
+++ b/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import PaymentMethodRow from './PaymentMethodRow';
-import { PaymentType, CardType } from '@linode/api-v4/lib/account/types';
+import { paymentMethodFactory } from 'src/factories';
+import { PaymentMethod } from '@linode/api-v4';
 
 export default {
   title: 'Components/Payment Method Row',
@@ -10,54 +11,16 @@ const onDelete = () => {
   // ...
 };
 
-const render = (paymentMethodType: PaymentType, cardType: CardType) => {
-  return (
-    <>
-      <PaymentMethodRow
-        onDelete={onDelete}
-        paymentMethod={{
-          type: paymentMethodType,
-          id: 0,
-          is_default: true,
-          created: '2021-06-01T20:14:49',
-          data: {
-            card_type: cardType,
-            last_four: '1234',
-            expiry: '10/2025',
-          },
-        }}
-      />
-      <PaymentMethodRow
-        onDelete={onDelete}
-        paymentMethod={{
-          type: paymentMethodType,
-          id: 1,
-          is_default: false,
-          created: '2021-06-01T20:14:49',
-          data: {
-            card_type: cardType,
-            last_four: '1234',
-            expiry: '10/2025',
-          },
-        }}
-      />
-    </>
+const render = (paymentMethod: PaymentMethod) => (
+  <PaymentMethodRow onDelete={onDelete} paymentMethod={paymentMethod} />
+);
+
+export const Visa = () =>
+  render(
+    paymentMethodFactory.build({
+      type: 'credit_card',
+      data: {
+        card_type: 'Visa',
+      },
+    })
   );
-};
-
-export const Visa = () => render('credit_card', 'Visa');
-
-export const Mastercard = () => render('credit_card', 'MasterCard');
-
-export const Amex = () => render('credit_card', 'American Express');
-
-export const Discover = () => render('credit_card', 'Discover');
-
-export const JCB = () => render('credit_card', 'JCB');
-
-// @ts-expect-error This is just an example
-export const Other = () => render('credit_card', 'Other');
-
-export const GooglePay = () => render('google_pay', 'Discover');
-
-export const PayPal = () => render('paypal', 'MasterCard');

--- a/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.tsx
+++ b/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 import {
+  CreditCardData,
   PaymentMethod,
-  ThirdPartyPayment as ThirdPartyPaymentTypes,
+  PayPalData,
 } from '@linode/api-v4/lib/account/types';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Paper from 'src/components/core/Paper';
@@ -43,7 +44,7 @@ interface Props {
 
 const PaymentMethodRow: React.FC<Props> = (props) => {
   const { paymentMethod, onDelete } = props;
-  const { data: creditCard, type, is_default } = paymentMethod;
+  const { data: paymentMethodData, type, is_default } = paymentMethod;
   const classes = useStyles();
   const history = useHistory();
   const { enqueueSnackbar } = useSnackbar();
@@ -96,12 +97,9 @@ const PaymentMethodRow: React.FC<Props> = (props) => {
       <Grid container className={classes.container}>
         <Grid item className={classes.item}>
           {paymentMethod.type === 'credit_card' ? (
-            <CreditCard creditCard={creditCard} />
+            <CreditCard creditCard={paymentMethod.data} />
           ) : (
-            <ThirdPartyPayment
-              thirdPartyPayment={type as ThirdPartyPaymentTypes}
-              creditCard={creditCard}
-            />
+            <ThirdPartyPayment paymentMethod={paymentMethod} />
           )}
         </Grid>
         <Grid item className={classes.item} style={{ paddingRight: 0 }}>
@@ -112,7 +110,15 @@ const PaymentMethodRow: React.FC<Props> = (props) => {
         <Grid item className={classes.actions}>
           <ActionMenu
             actionsList={actions}
-            ariaLabel={`Action menu for card ending in ${creditCard?.last_four}`}
+            ariaLabel={
+              type === 'paypal'
+                ? `Action menu for Paypal ${
+                    (paymentMethodData as PayPalData).email
+                  }`
+                : `Action menu for card ending in ${
+                    (paymentMethodData as CreditCardData)?.last_four
+                  }`
+            }
           />
         </Grid>
       </Grid>

--- a/packages/manager/src/components/PaymentMethodRow/ThirdPartyPayment.tsx
+++ b/packages/manager/src/components/PaymentMethodRow/ThirdPartyPayment.tsx
@@ -1,7 +1,4 @@
-import {
-  CreditCard as CreditCardType,
-  ThirdPartyPayment as ThirdPartyPaymentType,
-} from '@linode/api-v4/lib/account/types';
+import { PaymentMethod, ThirdPartyPayment } from '@linode/api-v4/lib/account';
 import * as classNames from 'classnames';
 import * as React from 'react';
 import GooglePayIcon from 'src/assets/icons/payment/googlePay.svg';
@@ -54,41 +51,52 @@ export const thirdPartyPaymentMap = {
 };
 
 interface Props {
-  thirdPartyPayment: ThirdPartyPaymentType;
-  creditCard: CreditCardType;
+  paymentMethod: PaymentMethod;
 }
 
-export const getIcon = (paymentMethod: ThirdPartyPaymentType) => {
+export const renderThirdPartyPaymentBody = (paymentMethod: PaymentMethod) => {
+  // eslint-disable-next-line sonarjs/no-small-switch
+  switch (paymentMethod.type) {
+    case 'paypal':
+      return (
+        <Typography>
+          <span>{paymentMethod.data.email}</span>
+        </Typography>
+      );
+    default:
+      return <CreditCard creditCard={paymentMethod.data} showIcon={false} />;
+  }
+};
+
+export const getIcon = (paymentMethod: ThirdPartyPayment) => {
   return thirdPartyPaymentMap[paymentMethod].icon;
 };
 
-export type CombinedProps = Props;
-
-export const TPP: React.FC<CombinedProps> = (props) => {
-  const { thirdPartyPayment, creditCard } = props;
+export const TPP: React.FC<Props> = (props) => {
+  const { paymentMethod } = props;
 
   const classes = useStyles();
   const theme = useTheme<Theme>();
   const matchesSmDown = useMediaQuery(theme.breakpoints.down('sm'));
 
-  const Icon = getIcon(thirdPartyPayment);
+  const Icon = getIcon(paymentMethod.type as ThirdPartyPayment);
 
   return (
     <>
       <Grid item className={classes.icon}>
         <Icon
           className={classNames({
-            [classes.payPal]: thirdPartyPayment === 'paypal',
+            [classes.payPal]: paymentMethod.type === 'paypal',
           })}
         />
       </Grid>
       <Grid item className={classes.paymentTextContainer}>
         {!matchesSmDown ? (
           <Typography className={classes.paymentMethodLabel}>
-            {thirdPartyPaymentMap[thirdPartyPayment].label}
+            {thirdPartyPaymentMap[paymentMethod.type].label}
           </Typography>
         ) : null}
-        <CreditCard creditCard={creditCard} showIcon={false} />
+        {renderThirdPartyPaymentBody(paymentMethod)}
       </Grid>
     </>
   );

--- a/packages/manager/src/factories/accountPayment.ts
+++ b/packages/manager/src/factories/accountPayment.ts
@@ -4,7 +4,7 @@ import { pickRandom } from 'src/utilities/random';
 
 export const paymentMethodFactory = Factory.Sync.makeFactory<PaymentMethod>({
   id: Factory.each((id) => id),
-  data: Factory.each(() => ({
+  data: {
     expiry: '12/2022',
     last_four: '1881',
     card_type: pickRandom([
@@ -14,10 +14,8 @@ export const paymentMethodFactory = Factory.Sync.makeFactory<PaymentMethod>({
       'American Express',
       'JCB',
     ]),
-  })),
+  },
   created: '2021-05-21T14:27:51',
-  type: Factory.each(() =>
-    pickRandom(['credit_card', 'credit_card', 'google_pay'])
-  ),
+  type: 'credit_card',
   is_default: false,
 });

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCard.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCard.tsx
@@ -1,7 +1,4 @@
-import {
-  CardType,
-  CreditCard as CreditCardType,
-} from '@linode/api-v4/lib/account/types';
+import { CardType, CreditCardData } from '@linode/api-v4/lib/account/types';
 import * as React from 'react';
 import GenericCardIcon from 'src/assets/icons/credit-card.svg';
 import AmexIcon from 'src/assets/icons/payment/amex.svg';
@@ -50,7 +47,7 @@ const iconMap = {
 };
 
 interface Props {
-  creditCard: CreditCardType;
+  creditCard: CreditCardData;
   showIcon?: boolean;
 }
 

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/AddPaymentMethodDrawer/AddPaymentMethodDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/AddPaymentMethodDrawer/AddPaymentMethodDrawer.tsx
@@ -12,6 +12,7 @@ import AddCreditCardForm from './AddCreditCardForm';
 import useFlags from 'src/hooks/useFlags';
 import Notice from 'src/components/Notice';
 import { MAXIMUM_PAYMENT_METHODS } from 'src/constants';
+import { PayPalChip } from '../PayPalChip';
 
 interface Props {
   open: boolean;
@@ -119,6 +120,31 @@ export const AddPaymentMethodDrawer: React.FC<Props> = (props) => {
           </Grid>
         </>
       ) : null}
+      <>
+        <Divider />
+        <Grid className={classes.root} container>
+          <Grid item xs={8} md={9}>
+            <Typography variant="h3">PayPal</Typography>
+            <Typography>
+              You’ll be taken to PayPal to complete sign up.
+            </Typography>
+          </Grid>
+          <Grid
+            container
+            item
+            xs={4}
+            md={3}
+            justify="flex-end"
+            alignContent="center"
+          >
+            <PayPalChip
+              onClose={onClose}
+              setProcessing={setIsProcessing}
+              disabled={disabled}
+            />
+          </Grid>
+        </Grid>
+      </>
       <>
         <Divider spacingBottom={16} spacingTop={16} />
         <Typography variant="h3">Credit Card</Typography>

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/GooglePayChip.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/GooglePayChip.tsx
@@ -13,7 +13,7 @@ import HelpIcon from 'src/components/HelpIcon';
 import classNames from 'classnames';
 import { reportException } from 'src/exceptionReporting';
 
-const useStyles = makeStyles((theme: Theme) => ({
+export const useStyles = makeStyles((theme: Theme) => ({
   button: {
     border: 0,
     padding: 0,
@@ -26,6 +26,8 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   disabled: {
     cursor: 'default',
+    // Allows us to disable the pointer even the button PayPal creates
+    pointerEvents: 'none',
     opacity: 0.3,
     '&:hover': {
       opacity: 0.3,

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PayPalChip.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PayPalChip.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import classNames from 'classnames';
+import braintree from 'braintree-web';
+import HelpIcon from 'src/components/HelpIcon';
+import CircleProgress from 'src/components/CircleProgress';
+import { useClientToken } from 'src/queries/accountPayment';
+import { useStyles } from './GooglePayChip';
+import { useSnackbar } from 'notistack';
+import { reportException } from 'src/exceptionReporting';
+import { onSuccess } from '../../Providers/PayPal';
+
+interface Props {
+  setProcessing: (processing: boolean) => void;
+  onClose: () => void;
+  disabled: boolean;
+}
+
+export const PayPalChip: React.FC<Props> = (props) => {
+  const classes = useStyles();
+  const { onClose, disabled, setProcessing } = props;
+  const { enqueueSnackbar } = useSnackbar();
+  const [hasPaypalError, setHasPayPalError] = React.useState<boolean>(false);
+
+  const {
+    data,
+    isLoading: isClientTokenLoading,
+    error: hasClientTokenError,
+  } = useClientToken();
+
+  React.useEffect(() => {
+    const init = async () => {
+      if (data) {
+        try {
+          const clientInstance = await braintree.client.create({
+            authorization: data.client_token,
+          });
+
+          const paypalCheckoutInstance = await braintree.paypalCheckout.create({
+            client: clientInstance,
+          });
+
+          paypalCheckoutInstance.loadPayPalSDK(
+            {
+              vault: true,
+              // @ts-expect-error Needed but types are wrong
+              commit: false,
+            },
+            () => {
+              // @ts-expect-error Needed but types are wrong
+              paypal
+                // @ts-expect-error Needed but types are wrong
+                .Buttons({
+                  style: {
+                    height: 25,
+                    // color: 'white',
+                  },
+                  fundingSource: 'paypal',
+                  createBillingAgreement() {
+                    return paypalCheckoutInstance.createPayment({
+                      // @ts-expect-error Needed but types are wrong
+                      flow: 'vault',
+                      vault: true,
+                      // @ts-expect-error Needed but types are wrong
+                      intent: 'tokenize',
+                      commit: false,
+                      enableShippingAddress: false,
+                    });
+                  },
+                  onApprove(data: any) {
+                    return paypalCheckoutInstance.tokenizePayment(
+                      data,
+                      (err, payload) =>
+                        onSuccess(
+                          err,
+                          payload,
+                          enqueueSnackbar,
+                          onClose,
+                          setProcessing
+                        )
+                    );
+                  },
+                  onError(error: any) {
+                    reportException(error, {
+                      message: 'Paypal threw an error.',
+                    });
+                    // We probably don't want to expose the actual error to the user.
+                    enqueueSnackbar(`Error ${error}`, {
+                      variant: 'error',
+                    });
+                  },
+                })
+                .render('#paypal-button-add-as-payment-method')
+                .then(() => {
+                  // PayPal button is ready to use
+                  // setIsPayPalLoading(false);
+                });
+            }
+          );
+        } catch (error) {
+          setHasPayPalError(true);
+        }
+      }
+    };
+    init();
+  }, [data]);
+
+  if (hasClientTokenError || hasPaypalError) {
+    return (
+      <HelpIcon
+        className={classes.errorIcon}
+        text="Error loading Paypal"
+        size={35}
+        isError
+      />
+    );
+  }
+
+  if (isClientTokenLoading) {
+    return <CircleProgress mini />;
+  }
+
+  return (
+    <div
+      style={{ marginRight: -8 }}
+      className={classNames({
+        [classes.disabled]: disabled,
+      })}
+    >
+      <div id="paypal-button-add-as-payment-method"></div>
+    </div>
+  );
+};

--- a/packages/manager/src/features/Billing/Providers/PayPal.ts
+++ b/packages/manager/src/features/Billing/Providers/PayPal.ts
@@ -1,0 +1,35 @@
+import { addPaymentMethod, PaymentMethod } from '@linode/api-v4/lib/account';
+import { queryClient } from 'src/queries/base';
+import { queryKey as accountPaymentKey } from 'src/queries/accountPayment';
+
+export const onSuccess = async (
+  error: any,
+  payload: any,
+  enqueueSnackbar: any,
+  onClose: () => void,
+  setProcessing: (processing: boolean) => void
+) => {
+  setProcessing(true);
+  // Next line is temporary for testing
+  payload.nonce = 'fake-paypal-billing-agreement-nonce';
+
+  const { nonce } = payload;
+
+  const paymentMethods = queryClient.getQueryData<PaymentMethod[]>(
+    `${accountPaymentKey}-all`
+  );
+
+  await addPaymentMethod({
+    type: 'payment_method_nonce',
+    data: { nonce },
+    // Make PayPal default if they have no payment methods upon add
+    is_default: paymentMethods?.length === 0,
+  });
+  queryClient.invalidateQueries(`${accountPaymentKey}-all`);
+
+  enqueueSnackbar('Successfully added PayPal', {
+    variant: 'success',
+  });
+  onClose();
+  setProcessing(false);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3412,6 +3412,15 @@
     "@babel/runtime" "^7.7.2"
     regenerator-runtime "^0.13.3"
 
+"@linode/validation@0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@linode/validation/-/validation-0.5.0.tgz#cf7e0482d813422ebc0a39fb247f84eae03cacbc"
+  integrity sha512-0lZp0fSFv4xrB49Ns0VlSUnHiijekm88fgzZm99UUtoD4blqRcG/5iDEcRZ6EW9CqwJHT5IAd1sWcHOGFdKCJA==
+  dependencies:
+    "@types/yup" "^0.29.13"
+    ipaddr.js "^2.0.0"
+    yup "^0.32.9"
+
 "@material-ui/core@^4.11.0":
   version "4.11.0"
   resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.11.0.tgz#b69b26e4553c9e53f2bfaf1053e216a0af9be15a"


### PR DESCRIPTION
## Preview
<img width="1788" alt="Screen Shot 2021-10-10 at 11 06 59 PM" src="https://user-images.githubusercontent.com/6440455/136728181-2d3226cd-5bad-4c80-9543-71d6d6560946.png">

## Description

- Ability to add PayPal as a payment method in your Linode Wallet
- This PR uses Braintree + Paypal. It does **not** use the `react-paypal-js` package. 
- Putting this up as a draft just to we have something to look at and refer to. This is not in final form.

## How to test

- Pull this PR
- Point Cloud Manager at your local dev environment (make sure your local env is up to date with latest) 
