### PR TITLE
M3-5509: Fix vertical alignment for Linode status column 

### DIFF
--- a/packages/manager/src/components/StatusIcon/StatusIcon.tsx
+++ b/packages/manager/src/components/StatusIcon/StatusIcon.tsx
@@ -1,42 +1,8 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
-
 import { makeStyles, Theme } from 'src/components/core/styles';
 
 const useStyles = makeStyles((theme: Theme) => ({
-  statusCell: {
-    whiteSpace: 'nowrap',
-    width: '17%',
-    [theme.breakpoints.down('sm')]: {
-      width: '100%',
-    },
-  },
-  statusCellMaintenance: {
-    [theme.breakpoints.up('md')]: {
-      width: '20%',
-    },
-    '& .data': {
-      display: 'flex',
-      alignItems: 'center',
-      lineHeight: 1.2,
-      marginRight: -12,
-      [theme.breakpoints.down('sm')]: {
-        minWidth: 200,
-        justifyContent: 'flex-end',
-      },
-      [theme.breakpoints.up('md')]: {
-        minWidth: 200,
-      },
-    },
-    '& button': {
-      padding: '0 6px',
-      position: 'relative',
-      top: 1,
-      [theme.breakpoints.up('md')]: {
-        padding: 6,
-      },
-    },
-  },
   statusIcon: {
     display: 'inline-block',
     borderRadius: '50%',
@@ -44,13 +10,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     width: '16px',
     marginRight: theme.spacing(),
     position: 'relative',
-    top: 2,
   },
   statusIconRunning: {
     backgroundColor: theme.cmrIconColors.iGreen,
-  },
-  statusIconOther: {
-    backgroundColor: theme.cmrIconColors.iOrange,
   },
   statusIconOffline: {
     backgroundColor: theme.cmrIconColors.iGrey,
@@ -58,9 +20,8 @@ const useStyles = makeStyles((theme: Theme) => ({
   statusIconError: {
     backgroundColor: theme.color.red,
   },
-  statusHelpIcon: {
-    position: 'relative',
-    top: -2,
+  statusIconOther: {
+    backgroundColor: theme.cmrIconColors.iOrange,
   },
 }));
 

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.style.ts
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.style.ts
@@ -12,9 +12,9 @@ type ClassNames =
   | 'actionCell'
   | 'actionInner'
   | 'bodyRow'
+  | 'status'
   | 'statusCell'
   | 'statusCellMaintenance'
-  | 'statusHelpIcon'
   | 'statusLink'
   | 'ipCell'
   | 'ipCellWrapper'
@@ -64,6 +64,10 @@ const styles = (theme: Theme) =>
       whiteSpace: 'nowrap',
       width: '17%',
     },
+    status: {
+      display: 'flex',
+      alignItems: 'center',
+    },
     statusCellMaintenance: {
       [theme.breakpoints.up('md')]: {
         width: '20%',
@@ -81,12 +85,7 @@ const styles = (theme: Theme) =>
         color: theme.cmrTextColors.linkActiveLight,
         padding: '0 6px',
         position: 'relative',
-        top: 1,
       },
-    },
-    statusHelpIcon: {
-      position: 'relative',
-      top: -2,
     },
     statusLink: {
       backgroundColor: 'transparent',

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
@@ -175,7 +175,7 @@ export const LinodeRow: React.FC<CombinedProps> = (props) => {
       >
         {!maintenanceStartTime ? (
           loading ? (
-            <>
+            <div className={classes.status}>
               <StatusIcon status={iconStatus} />
               <button
                 className={classes.statusLink}
@@ -187,21 +187,20 @@ export const LinodeRow: React.FC<CombinedProps> = (props) => {
                   text={transitionText(status, id, recentEvent)}
                 />
               </button>
-            </>
+            </div>
           ) : (
-            <>
+            <div className={classes.status}>
               <StatusIcon status={iconStatus} />
               {displayStatus.includes('_')
                 ? capitalizeAllWords(displayStatus.replace('_', ' '))
                 : capitalize(displayStatus)}
-            </>
+            </div>
           )
         ) : (
           <div className={classes.maintenanceOuter}>
             <strong>Maintenance Scheduled</strong>
             <HelpIcon
               text={<MaintenanceText />}
-              className={classes.statusHelpIcon}
               tooltipPosition="top"
               interactive
               classes={{ tooltip: classes.maintenanceTooltip }}


### PR DESCRIPTION
## Description

Vertically center the status content in the Linode Landing table and cleaned up some unused classes.

## How to test

Go to `/linodes` and turn on MSW in order to see a variety of statuses.
