### PR TITLE
workflow fixes for not running on push to pr and running with any label

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,7 +9,7 @@ on:
   schedule:
     - cron: "0 13 * * 1-5"
   pull_request_target:
-    types: [labeled]
+    types: [labeled, synchronize]
   push:
     branches:
       - develop
@@ -17,7 +17,7 @@ on:
 
 jobs:
   run-cypress-e2e:
-    if: contains(github.event.pull_request.labels.*.name, 'e2e') || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/staging'
+    if: (github.event == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'e2e')) || (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/staging')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -25,8 +25,6 @@ jobs:
         user: ["USER_1", "USER_2", "USER_3", "USER_4"]
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-node@v1
         with:
           node-version: "14.17.4"


### PR DESCRIPTION
## Description
Currently, any label on a PR will trigger a workflow if the base repository is develop or staging (which is most of them). Additionally, the tests are not re-run when a change is pushed to a PR that already has a label. 

This PR changes the logic a bit with conditional grouping. In theory, this should make it so that it will either look for develop/staging as base, or an e2e label on the PR. It should also now re-run tests when new changes are pushed to a PR. This will need to be merged in order to know if it fully works. I needed to take out the ref pointing to the pull request head, since this is not always running agains a PR. If this doesn't work correctly, we may need to split this into two workflows. 

## How to test
Check logic/Actions syntax. As I mentioned, the best way to know is merging it. 

I will be quick to fix it if it doesn't work once merged. There should not be any security risks introduced here. The main risk is that the workflow could break, which is not a huge deal temporarily. 
