### PR TITLE
M3-5474: Fix timezone issue with NodeBalancer graphs

### DIFF
--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
@@ -4,7 +4,6 @@ import {
 } from '@linode/api-v4/lib/nodebalancers';
 import { pathOr } from 'ramda';
 import * as React from 'react';
-import { connect } from 'react-redux';
 import { compose } from 'recompose';
 import CircleProgress from 'src/components/CircleProgress';
 import Paper from 'src/components/core/Paper';
@@ -21,9 +20,10 @@ import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
 import LineGraph from 'src/components/LineGraph';
 import MetricsDisplay from 'src/components/LineGraph/MetricsDisplay';
+import withProfile, { ProfileProps } from 'src/components/withProfile';
 import { formatBitsPerSecond } from 'src/features/Longview/shared/utilities';
 import { ExtendedNodeBalancer } from 'src/features/NodeBalancers/types';
-import { ApplicationState } from 'src/store';
+import getUserTimezone from 'src/utilities/getUserTimezone';
 import { initAll } from 'src/utilities/initAll';
 import { formatNumber, getMetrics } from 'src/utilities/statMetrics';
 
@@ -84,7 +84,11 @@ interface State {
   statsError?: string;
 }
 
-type CombinedProps = Props & WithTheme & StateProps & WithStyles<ClassNames>;
+type CombinedProps = Props &
+  WithTheme &
+  ProfileProps &
+  StateProps &
+  WithStyles<ClassNames>;
 
 const statsFetchInterval = 30000;
 
@@ -192,9 +196,11 @@ class TablesPanel extends React.Component<CombinedProps, State> {
     statsError: string | undefined,
     loadingStats: boolean
   ) => {
-    const { classes, timezone, theme } = this.props;
+    const { classes, theme, profile } = this.props;
     const { stats } = this.state;
     const data = pathOr([[]], ['data', 'connections'], stats);
+
+    const timezone = getUserTimezone(profile.data);
 
     if (loadingStats) {
       return loading();
@@ -334,16 +340,8 @@ interface StateProps {
   timezone: string;
 }
 
-const withTimezone = connect((state: ApplicationState, ownProps) => ({
-  timezone: pathOr(
-    'UTC',
-    ['__resources', 'profile', 'data', 'timezone'],
-    state
-  ),
-}));
-
 const styled = withStyles(styles);
 
-const enhanced = compose<CombinedProps, Props>(withTheme, withTimezone, styled);
+const enhanced = compose<CombinedProps, Props>(withTheme, withProfile, styled);
 
 export default enhanced(TablesPanel);


### PR DESCRIPTION
## Description
This situation slipped through the cracks when we moved `profile` data from Redux to React Query with https://github.com/linode/manager/pull/7778.

Essentially, the old code here was setting the timezone to UTC if `__resources' --> 'profile' --> 'data' --> 'timezone'` was not populated in Redux. Of course, since this was removed from Redux, it was never finding the data and always setting to UTC, causing discrepancies for accounts set up to display times besides UTC.

This PR pulls in the `profile` data, makes use of `getUserTimezone()`, and cleans up some now-unused code.

## How to test
Details on this specific case in M3-5474 and the ticket linked therein. Can test locally as that user, first on the `develop` branch to see the bug, and then on this branch to see that it is now fixed. Please reach out if you have any questions.