### PR TITLE
Fix IP / Netmask display issue in Firewalls Edit Rules Drawer

### DIFF
--- a/packages/manager/src/components/PasswordInput/HideShowText.tsx
+++ b/packages/manager/src/components/PasswordInput/HideShowText.tsx
@@ -12,6 +12,7 @@ type Props = TextFieldProps & {
   required?: boolean;
   tooltipText?: string;
   label: string;
+  value: string | undefined;
 };
 
 class HideShowText extends React.Component<Props, State> {
@@ -25,7 +26,7 @@ class HideShowText extends React.Component<Props, State> {
 
   render() {
     const { hidden } = this.state;
-    const { label } = this.props;
+    const { label, value } = this.props;
 
     return (
       <TextField
@@ -33,6 +34,7 @@ class HideShowText extends React.Component<Props, State> {
         dataAttrs={{
           'data-qa-hide': hidden,
         }}
+        value={value}
         label={label}
         type={hidden ? 'password' : 'text'}
         InputProps={{

--- a/packages/manager/src/components/PasswordInput/PasswordInput.tsx
+++ b/packages/manager/src/components/PasswordInput/PasswordInput.tsx
@@ -8,7 +8,7 @@ import StrengthIndicator from '../PasswordInput/StrengthIndicator';
 import HideShowText from './HideShowText';
 
 type Props = TextFieldProps & {
-  value?: string;
+  value?: string | undefined;
   required?: boolean;
   disabledReason?: string;
   hideStrengthLabel?: boolean;

--- a/packages/manager/src/components/TextField.tsx
+++ b/packages/manager/src/components/TextField.tsx
@@ -89,7 +89,10 @@ interface BaseProps {
   optional?: boolean;
   required?: boolean;
   tooltipText?: string;
+  value?: Value;
 }
+
+type Value = string | number | undefined | null;
 
 interface TextFieldPropsOverrides extends TextFieldProps {
   // We override this prop to make it required
@@ -137,12 +140,10 @@ export const LinodeTextField: React.FC<CombinedProps> = (props) => {
     ...textFieldProps
   } = props;
 
-  const [_value, setValue] = React.useState<string | number>('');
+  const [_value, setValue] = React.useState<Value>(value);
 
   React.useEffect(() => {
-    if (typeof value === 'string' || typeof value === 'number') {
-      setValue(value);
-    }
+    setValue(value);
   }, [value]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## Description
Fixes issue where not all the IP Addresses were showing in the IP / Netmask section of the Firewalls Edit Rules Drawer. This was bc the `value` state in `TextField.tsx` was being initialized to `''` instead of `value`

![image](https://user-images.githubusercontent.com/14323019/138319257-31e0c3e0-95a8-4917-8685-fbb3c9c69c90.png)

![image](https://user-images.githubusercontent.com/14323019/138319272-d5c15e2c-f6c5-4189-b76e-34dda9ae00e9.png)

## How to test
Edit a Firewall Rule that has multiple IP addresses in the `IP / Netmask` section. All the IP addresses should now display.

![image](https://user-images.githubusercontent.com/14323019/138319286-a0ab3dff-72b0-4225-b1fb-60db12747b71.png)
