### PR TITLE
M3-5529: Update "Add an IP Address" drawer and provide for ability to add IPv6 ranges in it

### DIFF
--- a/packages/api-v4/src/networking/networking.ts
+++ b/packages/api-v4/src/networking/networking.ts
@@ -14,6 +14,7 @@ import Request, {
 } from '../request';
 import { ResourcePage as Page } from '../types';
 import {
+  CreateIPv6RangePayload,
   IPAddress,
   IPAssignmentPayload,
   IPRange,
@@ -142,3 +143,16 @@ export const getIPv6Ranges = (params?: any) =>
     setMethod('GET'),
     setParams(params)
   );
+
+/**
+ * Allows self-serving range creation by the customer
+ *
+ */
+
+export const createIPv6Range = (payload: CreateIPv6RangePayload) => {
+  return Request<{}>(
+    setURL(`${API_ROOT}/networking/ipv6/ranges`),
+    setMethod('POST'),
+    setData(payload)
+  );
+};

--- a/packages/api-v4/src/networking/types.ts
+++ b/packages/api-v4/src/networking/types.ts
@@ -44,3 +44,11 @@ export interface IPAssignmentPayload {
   region: string;
   assignments: IPAssignment[];
 }
+
+export type IPv6Prefix = 56 | 64;
+
+export interface CreateIPv6RangePayload {
+  linode_id?: number;
+  route_target?: string;
+  prefix_length: IPv6Prefix;
+}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/AddIPDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/AddIPDrawer.tsx
@@ -1,13 +1,18 @@
 import { allocateIPAddress } from '@linode/api-v4/lib/linodes';
+import { createIPv6Range, IPv6Prefix } from '@linode/api-v4/lib/networking';
+import { APIError } from '@linode/api-v4/lib/types';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
+import FormControlLabel from 'src/components/core/FormControlLabel';
+import Radio from 'src/components/core/Radio';
+import RadioGroup from 'src/components/core/RadioGroup';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Tooltip from 'src/components/core/Tooltip';
 import Typography from 'src/components/core/Typography';
 import Drawer from 'src/components/Drawer';
-import EnhancedSelect, { Item } from 'src/components/EnhancedSelect/Select';
+import { Item } from 'src/components/EnhancedSelect/Select';
 import Notice from 'src/components/Notice';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 
@@ -18,6 +23,12 @@ const useStyles = makeStyles((theme: Theme) => ({
   ipv6: {
     marginTop: theme.spacing(4),
   },
+  ipSubheader: {
+    marginTop: '1rem',
+  },
+  radioButtons: {
+    marginTop: '0 !important',
+  },
 }));
 
 type IPType = 'v4Public' | 'v4Private';
@@ -25,6 +36,11 @@ type IPType = 'v4Public' | 'v4Private';
 const ipOptions: Item<IPType>[] = [
   { value: 'v4Public', label: 'IPv4 – Public' },
   { value: 'v4Private', label: 'IPv4 – Private' },
+];
+
+const prefixOptions = [
+  { value: '64', label: '/64' },
+  { value: '56', label: '/56' },
 ];
 
 // @todo: Pre-fill support tickets.
@@ -67,9 +83,15 @@ type CombinedProps = Props;
 const AddIPDrawer: React.FC<CombinedProps> = (props) => {
   const classes = useStyles();
 
-  const [selected, setSelected] = React.useState<IPType | null>(null);
+  const [selectedIPv4, setSelectedIPv4] = React.useState<IPType | null>(null);
+  const [errorMessageIPv4, setErrorMessageIPv4] = React.useState('');
+
+  const [
+    selectedIPv6Prefix,
+    setSelectedIPv6Prefix,
+  ] = React.useState<IPv6Prefix | null>(null);
   const [submitting, setSubmitting] = React.useState(false);
-  const [errorMessage, setErrorMessage] = React.useState('');
+  const [errorMessageIPv6, setErrorMessageIPv6] = React.useState('');
 
   const {
     open,
@@ -82,18 +104,34 @@ const AddIPDrawer: React.FC<CombinedProps> = (props) => {
 
   React.useEffect(() => {
     if (open) {
-      setSelected(null);
-      setErrorMessage('');
+      setSelectedIPv4(null);
+      setSelectedIPv6Prefix(null);
+      setErrorMessageIPv4('');
+      setErrorMessageIPv6('');
     }
   }, [open]);
 
-  const handleAllocate = () => {
+  const handleIPv4Change = (
+    e: React.ChangeEvent<HTMLInputElement>,
+    value: 'v4Public' | 'v4Private'
+  ) => {
+    setSelectedIPv4(value);
+  };
+
+  const handleIPv6Change = (
+    e: React.ChangeEvent<HTMLInputElement>,
+    value: any
+  ) => {
+    setSelectedIPv6Prefix(value);
+  };
+
+  const handleAllocateIPv4 = () => {
     setSubmitting(true);
 
     // Only IPv4 addresses can currently be allocated.
     allocateIPAddress(linodeID, {
       type: 'ipv4',
-      public: selected === 'v4Public',
+      public: selectedIPv4 === 'v4Public',
     })
       .then((_) => {
         setSubmitting(false);
@@ -102,18 +140,51 @@ const AddIPDrawer: React.FC<CombinedProps> = (props) => {
       })
       .catch((errResponse) => {
         setSubmitting(false);
-        setErrorMessage(getErrorStringOrDefault(errResponse));
+        setErrorMessageIPv4(getErrorStringOrDefault(errResponse));
       });
   };
 
-  const disabled =
-    (selected === 'v4Private' && hasPrivateIPAddress) || !selected || readOnly;
+  const handleCreateIPv6Range = () => {
+    setSubmitting(true);
+
+    createIPv6Range({
+      linode_id: linodeID,
+      prefix_length: Number(selectedIPv6Prefix) as IPv6Prefix,
+    })
+      .then((_: any) => {
+        setSubmitting(false);
+        onSuccess();
+        onClose();
+      })
+      .catch((errResponse: APIError[]) => {
+        setSubmitting(false);
+        setErrorMessageIPv6(getErrorStringOrDefault(errResponse));
+      });
+  };
+
+  const disabledIPv4 =
+    (selectedIPv4 === 'v4Private' && hasPrivateIPAddress) ||
+    !selectedIPv4 ||
+    readOnly;
 
   const AllocateButton = (
     <Button
       buttonType="primary"
-      onClick={handleAllocate}
-      disabled={disabled}
+      onClick={handleAllocateIPv4}
+      disabled={disabledIPv4}
+      style={{ marginBottom: 8 }}
+      loading={submitting}
+    >
+      Allocate
+    </Button>
+  );
+
+  const disabledIPv6 = !selectedIPv6Prefix || readOnly;
+  const AllocateButton2 = (
+    <Button
+      buttonType="primary"
+      onClick={handleCreateIPv6Range}
+      disabled={disabledIPv6}
       style={{ marginBottom: 8 }}
       loading={submitting}
     >
@@ -122,29 +193,43 @@ const AddIPDrawer: React.FC<CombinedProps> = (props) => {
   );
 
   const _tooltipCopy =
-    disabled && selected
+    disabledIPv4 && selectedIPv4
       ? readOnly
         ? 'You do not have permission to modify this Linode.'
-        : tooltipCopy[selected]
+        : tooltipCopy[selectedIPv4]
       : null;
 
   return (
     <Drawer open={open} onClose={onClose} title="Add an IP Address">
       <React.Fragment>
         <Typography variant="h2">IPv4</Typography>
-        {errorMessage && <Notice error text={errorMessage} spacingTop={8} />}
-        <EnhancedSelect
-          name={'IPv4 type'}
-          label="IPv4 type"
-          placeholder="Select an IPv4 type"
-          value={ipOptions.find((thisOption) => thisOption.value === selected)}
-          options={ipOptions}
-          onChange={(_selected: Item<IPType>) => setSelected(_selected.value)}
-          isClearable={false}
-        />
-        {selected && (
+        {errorMessageIPv4 && (
+          <Notice error text={errorMessageIPv4} spacingTop={8} />
+        )}
+        <Typography variant="h3" className={classes.ipSubheader}>
+          Select IPv4 type
+        </Typography>
+        <RadioGroup
+          aria-label="ip-option"
+          name="Select IPv4 type"
+          value={selectedIPv4}
+          onChange={handleIPv4Change}
+          className={classes.radioButtons}
+          data-qa-ip-options-radio-group
+        >
+          {ipOptions.map((option, idx) => (
+            <FormControlLabel
+              key={idx}
+              value={option.value}
+              label={option.label}
+              control={<Radio />}
+              data-qa-radio={option.label}
+            />
+          ))}
+        </RadioGroup>
+        {selectedIPv4 && (
           <Typography variant="body1" className={classes.copy}>
-            {explainerCopy[selected]}
+            {explainerCopy[selectedIPv4]}
           </Typography>
         )}
         <ActionsPanel>
@@ -162,13 +247,40 @@ const AddIPDrawer: React.FC<CombinedProps> = (props) => {
         <Typography variant="h2" className={classes.ipv6}>
           IPv6
         </Typography>
+        {errorMessageIPv6 && (
+          <Notice error text={errorMessageIPv6} spacingTop={8} />
+        )}
+        <Typography variant="h3" className={classes.ipSubheader}>
+          Select prefix
+        </Typography>
+        <RadioGroup
+          aria-label="prefix-option"
+          name="Select prefix"
+          value={selectedIPv6Prefix}
+          onChange={handleIPv6Change}
+          className={classes.radioButtons}
+          data-qa-ip-options-radio-group
+        >
+          {prefixOptions.map((option, idx) => (
+            <FormControlLabel
+              key={idx}
+              value={option.value}
+              label={option.label}
+              control={<Radio />}
+              data-qa-radio={option.label}
+            />
+          ))}
+        </RadioGroup>
         <Typography>
           IPv6 addresses are allocated as ranges, which you can choose to
-          distribute and further route yourself. These ranges can only be
-          allocated by our support team. Please open a{' '}
-          <Link to="/support/tickets">Support Ticket</Link> and request an IPv6
-          range for this Linode.
+          distribute and further route yourself.
         </Typography>
+        <ActionsPanel>
+          <Button buttonType="secondary" onClick={onClose} data-qa-cancel>
+            Close
+          </Button>
+          {AllocateButton2}
+        </ActionsPanel>
       </React.Fragment>
     </Drawer>
   );

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/AddIPDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/AddIPDrawer.tsx
@@ -100,13 +100,15 @@ const AddIPDrawer: React.FC<CombinedProps> = (props) => {
   const classes = useStyles();
 
   const [selectedIPv4, setSelectedIPv4] = React.useState<IPType | null>(null);
+  const [submittingIPv4, setSubmittingIPv4] = React.useState(false);
   const [errorMessageIPv4, setErrorMessageIPv4] = React.useState('');
 
   const [
     selectedIPv6Prefix,
     setSelectedIPv6Prefix,
   ] = React.useState<IPv6Prefix | null>(null);
-  const [submitting, setSubmitting] = React.useState(false);
+
+  const [submittingIPv6, setSubmittingIPv6] = React.useState(false);
   const [errorMessageIPv6, setErrorMessageIPv6] = React.useState('');
 
   const {
@@ -142,7 +144,7 @@ const AddIPDrawer: React.FC<CombinedProps> = (props) => {
   };
 
   const handleAllocateIPv4 = () => {
-    setSubmitting(true);
+    setSubmittingIPv4(true);
 
     // Only IPv4 addresses can currently be allocated.
     allocateIPAddress(linodeID, {
@@ -150,30 +152,30 @@ const AddIPDrawer: React.FC<CombinedProps> = (props) => {
       public: selectedIPv4 === 'v4Public',
     })
       .then((_) => {
-        setSubmitting(false);
+        setSubmittingIPv4(false);
         onSuccess();
         onClose();
       })
       .catch((errResponse) => {
-        setSubmitting(false);
+        setSubmittingIPv4(false);
         setErrorMessageIPv4(getErrorStringOrDefault(errResponse));
       });
   };
 
   const handleCreateIPv6Range = () => {
-    setSubmitting(true);
+    setSubmittingIPv6(true);
 
     createIPv6Range({
       linode_id: linodeID,
       prefix_length: Number(selectedIPv6Prefix) as IPv6Prefix,
     })
       .then((_: any) => {
-        setSubmitting(false);
+        setSubmittingIPv6(false);
         onSuccess();
         onClose();
       })
       .catch((errResponse: APIError[]) => {
-        setSubmitting(false);
+        setSubmittingIPv6(false);
         setErrorMessageIPv6(getErrorStringOrDefault(errResponse));
       });
   };
@@ -197,6 +199,7 @@ const AddIPDrawer: React.FC<CombinedProps> = (props) => {
 
     const onClick = IPv4 ? handleAllocateIPv4 : handleCreateIPv6Range;
     const disabled = IPv4 ? disabledIPv4 : disabledIPv6;
+    const submitting = IPv4 ? submittingIPv4 : submittingIPv6;
 
     return (
       <Button

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/AddIPDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/AddIPDrawer.tsx
@@ -145,6 +145,7 @@ const AddIPDrawer: React.FC<CombinedProps> = (props) => {
 
   const handleAllocateIPv4 = () => {
     setSubmittingIPv4(true);
+    setErrorMessageIPv4('');
 
     // Only IPv4 addresses can currently be allocated.
     allocateIPAddress(linodeID, {
@@ -164,6 +165,7 @@ const AddIPDrawer: React.FC<CombinedProps> = (props) => {
 
   const handleCreateIPv6Range = () => {
     setSubmittingIPv6(true);
+    setErrorMessageIPv6('');
 
     createIPv6Range({
       linode_id: linodeID,

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/AddIPDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/AddIPDrawer.tsx
@@ -167,30 +167,7 @@ const AddIPDrawer: React.FC<CombinedProps> = (props) => {
     !selectedIPv4 ||
     readOnly;
 
-  const AllocateButton = (
-    <Button
-      buttonType="primary"
-      onClick={handleAllocateIPv4}
-      disabled={disabledIPv4}
-      style={{ marginBottom: 8 }}
-      loading={submitting}
-    >
-      Allocate
-    </Button>
-  );
-
   const disabledIPv6 = !selectedIPv6Prefix || readOnly;
-  const AllocateButton2 = (
-    <Button
-      buttonType="primary"
-      onClick={handleCreateIPv6Range}
-      disabled={disabledIPv6}
-      style={{ marginBottom: 8 }}
-      loading={submitting}
-    >
-      Allocate
-    </Button>
-  );
 
   const _tooltipCopy =
     disabledIPv4 && selectedIPv4
@@ -198,6 +175,25 @@ const AddIPDrawer: React.FC<CombinedProps> = (props) => {
         ? 'You do not have permission to modify this Linode.'
         : tooltipCopy[selectedIPv4]
       : null;
+
+  const buttonJSX = (type: 'IPv4' | 'IPv6') => {
+    const IPv4 = type === 'IPv4';
+
+    const onClick = IPv4 ? handleAllocateIPv4 : handleCreateIPv6Range;
+    const disabled = IPv4 ? disabledIPv4 : disabledIPv6;
+
+    return (
+      <Button
+        buttonType="primary"
+        onClick={onClick}
+        disabled={disabled}
+        style={{ marginBottom: 8 }}
+        loading={submitting}
+      >
+        Allocate
+      </Button>
+    );
+  };
 
   return (
     <Drawer open={open} onClose={onClose} title="Add an IP Address">
@@ -238,10 +234,10 @@ const AddIPDrawer: React.FC<CombinedProps> = (props) => {
           </Button>
           {_tooltipCopy ? (
             <Tooltip title={_tooltipCopy}>
-              <div style={{ display: 'inline' }}>{AllocateButton}</div>
+              <div style={{ display: 'inline' }}>{buttonJSX('IPv4')}</div>
             </Tooltip>
           ) : (
-            AllocateButton
+            buttonJSX('IPv4')
           )}
         </ActionsPanel>
         <Typography variant="h2" className={classes.ipv6}>
@@ -279,7 +275,7 @@ const AddIPDrawer: React.FC<CombinedProps> = (props) => {
           <Button buttonType="secondary" onClick={onClose} data-qa-cancel>
             Close
           </Button>
-          {AllocateButton2}
+          {buttonJSX('IPv6')}
         </ActionsPanel>
       </React.Fragment>
     </Drawer>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/AddIPDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/AddIPDrawer.tsx
@@ -13,6 +13,7 @@ import Tooltip from 'src/components/core/Tooltip';
 import Typography from 'src/components/core/Typography';
 import Drawer from 'src/components/Drawer';
 import { Item } from 'src/components/EnhancedSelect/Select';
+import ExternalLink from 'src/components/Link';
 import Notice from 'src/components/Notice';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 
@@ -34,8 +35,8 @@ const useStyles = makeStyles((theme: Theme) => ({
 type IPType = 'v4Public' | 'v4Private';
 
 const ipOptions: Item<IPType>[] = [
-  { value: 'v4Public', label: 'IPv4 – Public' },
-  { value: 'v4Private', label: 'IPv4 – Private' },
+  { value: 'v4Public', label: 'Public' },
+  { value: 'v4Private', label: 'Private' },
 ];
 
 const prefixOptions = [
@@ -60,6 +61,21 @@ const explainerCopy: Record<IPType, JSX.Element> = {
       private IP addresses in the same data center does not incur transfer quota
       usage. To ensure that the private IP is properly configured once added,
       it&apos;s best to reboot your Linode.
+    </>
+  ),
+};
+
+const IPv6ExplanatoryCopy = {
+  56: (
+    <>
+      These larger ranges are typically only required by specialized systems or
+      networking applications.
+    </>
+  ),
+  64: (
+    <>
+      This is the most common range provided to our customers and sufficient for
+      most applications that require additional IPv6 addresses.
     </>
   ),
 };
@@ -203,7 +219,7 @@ const AddIPDrawer: React.FC<CombinedProps> = (props) => {
           <Notice error text={errorMessageIPv4} spacingTop={8} />
         )}
         <Typography variant="h3" className={classes.ipSubheader}>
-          Select IPv4 type
+          Select type
         </Typography>
         <RadioGroup
           aria-label="ip-option"
@@ -266,8 +282,17 @@ const AddIPDrawer: React.FC<CombinedProps> = (props) => {
         </RadioGroup>
         <Typography>
           IPv6 addresses are allocated as ranges, which you can choose to
-          distribute and further route yourself.
+          distribute and further route yourself.{' '}
+          <ExternalLink to="https://www.linode.com/docs/guides/an-overview-of-ipv6-on-linode/">
+            Learn more
+          </ExternalLink>
+          .
         </Typography>
+        {selectedIPv6Prefix && (
+          <Typography variant="body1" className={classes.copy}>
+            {IPv6ExplanatoryCopy[selectedIPv6Prefix]}
+          </Typography>
+        )}
         <ActionsPanel>{buttonJSX('IPv6')}</ActionsPanel>
       </React.Fragment>
     </Drawer>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/AddIPDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/AddIPDrawer.tsx
@@ -229,9 +229,6 @@ const AddIPDrawer: React.FC<CombinedProps> = (props) => {
           </Typography>
         )}
         <ActionsPanel>
-          <Button buttonType="secondary" onClick={onClose} data-qa-cancel>
-            Close
-          </Button>
           {_tooltipCopy ? (
             <Tooltip title={_tooltipCopy}>
               <div style={{ display: 'inline' }}>{buttonJSX('IPv4')}</div>
@@ -271,12 +268,7 @@ const AddIPDrawer: React.FC<CombinedProps> = (props) => {
           IPv6 addresses are allocated as ranges, which you can choose to
           distribute and further route yourself.
         </Typography>
-        <ActionsPanel>
-          <Button buttonType="secondary" onClick={onClose} data-qa-cancel>
-            Close
-          </Button>
-          {buttonJSX('IPv6')}
-        </ActionsPanel>
+        <ActionsPanel>{buttonJSX('IPv6')}</ActionsPanel>
       </React.Fragment>
     </Drawer>
   );

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/AddIPDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/AddIPDrawer.tsx
@@ -68,13 +68,13 @@ const explainerCopy: Record<IPType, JSX.Element> = {
 const IPv6ExplanatoryCopy = {
   56: (
     <>
-      These larger ranges are typically only required by specialized systems or
+      /56 ranges are typically only required by specialized systems or
       networking applications.
     </>
   ),
   64: (
     <>
-      This is the most common range provided to our customers and sufficient for
+      /64 is the most common range provided to our customers and sufficient for
       most applications that require additional IPv6 addresses.
     </>
   ),
@@ -280,6 +280,11 @@ const AddIPDrawer: React.FC<CombinedProps> = (props) => {
             />
           ))}
         </RadioGroup>
+        {selectedIPv6Prefix && (
+          <Typography variant="body1" style={{ marginBottom: '1rem' }}>
+            {IPv6ExplanatoryCopy[selectedIPv6Prefix]}
+          </Typography>
+        )}
         <Typography>
           IPv6 addresses are allocated as ranges, which you can choose to
           distribute and further route yourself.{' '}
@@ -288,11 +293,6 @@ const AddIPDrawer: React.FC<CombinedProps> = (props) => {
           </ExternalLink>
           .
         </Typography>
-        {selectedIPv6Prefix && (
-          <Typography variant="body1" className={classes.copy}>
-            {IPv6ExplanatoryCopy[selectedIPv6Prefix]}
-          </Typography>
-        )}
         <ActionsPanel>{buttonJSX('IPv6')}</ActionsPanel>
       </React.Fragment>
     </Drawer>

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -706,6 +706,10 @@ export const handlers = [
   rest.post('*/networking/vlans', (req, res, ctx) => {
     return res(ctx.json({}));
   }),
+  rest.post('*/networking/ipv6/ranges', (req, res, ctx) => {
+    const range = req.body?.['prefix_length'];
+    return res(ctx.json({ range, route_target: '2001:DB8::0000' }));
+  }),
   rest.post('*/account/payments', (req, res, ctx) => {
     return res(ctx.json(creditPaymentResponseFactory.build()));
   }),


### PR DESCRIPTION
## Description
Updates the types and requests to support the new IPv6 functionality, updates the mocks accordingly, and makes a few changes in the "Add an IP Address" drawer:

- Changes IPv4 dropdown to radio buttons
- Adds IPv6 radio buttons

## To-Do
- [x] Clean up & refactor `<AddIPDrawer />`
- [x] Final description copy

## How to test
From the "Network" tab of a Linode Detail page, click "Add an IP Address" and confirm that no functionality has been lost for allocating IPv4 addresses and that you can now allocate IPv6 addresses successfully.


