### PR TITLE
M3-5553: Revisions to Account Maintenance Page for Volumes

### DIFF
--- a/packages/manager/src/components/PaginationFooter/PaginationFooter.tsx
+++ b/packages/manager/src/components/PaginationFooter/PaginationFooter.tsx
@@ -49,7 +49,6 @@ export interface PaginationProps {
   eventCategory: string;
   showAll?: boolean;
   fixedSize?: boolean;
-  forceShow?: boolean;
 }
 
 interface Props extends PaginationProps {
@@ -83,11 +82,9 @@ class PaginationFooter extends React.PureComponent<CombinedProps> {
       padded,
       eventCategory,
       showAll,
-      children,
-      forceShow,
     } = this.props;
 
-    if (!forceShow && count <= MIN_PAGE_SIZE && !fixedSize) {
+    if (count <= MIN_PAGE_SIZE && !fixedSize) {
       return null;
     }
 
@@ -126,7 +123,6 @@ class PaginationFooter extends React.PureComponent<CombinedProps> {
             />
           )}
         </Grid>
-        {children ? <Grid item>{children}</Grid> : null}
         {!fixedSize ? (
           <Grid item className={`${classes.select} p0`}>
             <Select

--- a/packages/manager/src/features/Account/Maintenance/MaintenanceLanding.tsx
+++ b/packages/manager/src/features/Account/Maintenance/MaintenanceLanding.tsx
@@ -17,6 +17,17 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 const MaintenanceLanding: React.FC = () => {
   const classes = useStyles();
+  const [accordians, setAccordians] = React.useState([
+    { expanded: true },
+    { expanded: true },
+  ]);
+
+  const setExpanded = (idx: number) => {
+    setAccordians((old) => {
+      old[idx].expanded = !old[idx].expanded;
+      return [...old];
+    });
+  };
 
   const supportedMaintenanceEntities: MaintenanceEntities[] = [
     'Linode',
@@ -27,8 +38,16 @@ const MaintenanceLanding: React.FC = () => {
     <React.Fragment>
       <DocumentTitleSegment segment="Maintenance" />
       <div className={classes.noTablePadding}>
-        {supportedMaintenanceEntities.map((type) => (
-          <MaintenanceTable key={type} type={type} />
+        {supportedMaintenanceEntities.map((type, idx) => (
+          <MaintenanceTable
+            key={type}
+            type={type}
+            expanded={accordians[idx].expanded}
+            toggleExpanded={() => setExpanded(idx)}
+            addTopMargin={
+              accordians[idx - 1]?.expanded && !accordians[idx].expanded
+            }
+          />
         ))}
       </div>
     </React.Fragment>

--- a/packages/manager/src/features/Account/Maintenance/MaintenanceTable.test.tsx
+++ b/packages/manager/src/features/Account/Maintenance/MaintenanceTable.test.tsx
@@ -63,7 +63,14 @@ describe('Maintenance Table', () => {
         return res(ctx.json(makeResourcePage(accountMaintenance)));
       })
     );
-    renderWithTheme(<MaintenanceTable type="Linode" />);
+    renderWithTheme(
+      <MaintenanceTable
+        type="Linode"
+        expanded={true}
+        toggleExpanded={() => null}
+        addTopMargin={false}
+      />
+    );
 
     // Loading state should render
     expect(screen.getByTestId(loadingTestId)).toBeInTheDocument();
@@ -80,7 +87,14 @@ describe('Maintenance Table', () => {
   });
 
   it('should render the CSV download button if there are items', async () => {
-    renderWithTheme(<MaintenanceTable type="Linode" />);
+    renderWithTheme(
+      <MaintenanceTable
+        type="Linode"
+        expanded={true}
+        toggleExpanded={() => null}
+        addTopMargin={false}
+      />
+    );
 
     screen.getByText('Download CSV');
   });
@@ -92,7 +106,15 @@ describe('Maintenance Table', () => {
       })
     );
 
-    renderWithTheme(<MaintenanceTable type="Linode" />, { queryClient });
+    renderWithTheme(
+      <MaintenanceTable
+        type="Linode"
+        expanded={true}
+        toggleExpanded={() => null}
+        addTopMargin={false}
+      />,
+      { queryClient }
+    );
 
     expect(await screen.findByTestId('table-row-empty')).toBeInTheDocument();
 

--- a/packages/manager/src/features/Account/Maintenance/MaintenanceTable.tsx
+++ b/packages/manager/src/features/Account/Maintenance/MaintenanceTable.tsx
@@ -45,6 +45,11 @@ const headersForCSVDownload = [
 ];
 
 const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    '&.MuiAccordion-root.Mui-expanded': {
+      marginBottom: theme.spacing(),
+    },
+  },
   csvLink: {
     [theme.breakpoints.down('sm')]: {
       marginRight: theme.spacing(),
@@ -156,6 +161,7 @@ const MaintenanceTable: React.FC<Props> = (props) => {
   return (
     <>
       <Accordion
+        className={classes.root}
         heading={`${type}s`}
         expanded={expanded}
         onChange={() => setExpanded((previous) => !previous)}
@@ -173,6 +179,17 @@ const MaintenanceTable: React.FC<Props> = (props) => {
               >
                 Date
               </TableSortCell>
+              <Hidden smDown>
+                <TableSortCell
+                  active={orderBy === 'when'}
+                  direction={order}
+                  label="when"
+                  handleClick={handleOrderChange}
+                  className={classes.cell}
+                >
+                  When
+                </TableSortCell>
+              </Hidden>
               <Hidden xsDown>
                 <TableSortCell
                   active={orderBy === 'type'}
@@ -193,17 +210,6 @@ const MaintenanceTable: React.FC<Props> = (props) => {
               >
                 Status
               </TableSortCell>
-              <Hidden smDown>
-                <TableSortCell
-                  active={orderBy === 'when'}
-                  direction={order}
-                  label="when"
-                  handleClick={handleOrderChange}
-                  className={classes.cell}
-                >
-                  When
-                </TableSortCell>
-              </Hidden>
               <Hidden mdDown>
                 <TableCell style={{ width: '40%' }}>Reason</TableCell>
               </Hidden>

--- a/packages/manager/src/features/Account/Maintenance/MaintenanceTable.tsx
+++ b/packages/manager/src/features/Account/Maintenance/MaintenanceTable.tsx
@@ -24,6 +24,7 @@ import {
   useAllAccountMaintenanceQuery,
 } from 'src/queries/accountMaintenance';
 import Accordion from 'src/components/Accordion';
+import Box from 'src/components/core/Box';
 
 export type MaintenanceEntities = 'Linode' | 'Volume';
 
@@ -44,7 +45,7 @@ const headersForCSVDownload = [
 ];
 
 const useStyles = makeStyles((theme: Theme) => ({
-  CSVlink: {
+  csvLink: {
     [theme.breakpoints.down('sm')]: {
       marginRight: theme.spacing(),
     },
@@ -67,6 +68,7 @@ const MaintenanceTable: React.FC<Props> = (props) => {
   const csvRef = React.useRef<any>();
   const classes = useStyles();
   const pagination = usePagination(1, `${preferenceKey}-${type.toLowerCase()}`);
+  const [expanded, setExpanded] = React.useState(true);
 
   const { order, orderBy, handleOrderChange } = useOrder(
     {
@@ -152,41 +154,16 @@ const MaintenanceTable: React.FC<Props> = (props) => {
   };
 
   return (
-    <Accordion heading={`${type}s`} defaultExpanded>
-      <Table>
-        <TableHead>
-          <TableRow>
-            <TableCell className={classes.cell}>Label</TableCell>
-            <TableSortCell
-              active={orderBy === 'when'}
-              direction={order}
-              label="when"
-              handleClick={handleOrderChange}
-              className={classes.cell}
-            >
-              Date
-            </TableSortCell>
-            <Hidden xsDown>
-              <TableSortCell
-                active={orderBy === 'type'}
-                direction={order}
-                label="type"
-                handleClick={handleOrderChange}
-                className={classes.cell}
-              >
-                Type
-              </TableSortCell>
-            </Hidden>
-            <TableSortCell
-              active={orderBy === 'status'}
-              direction={order}
-              label="status"
-              handleClick={handleOrderChange}
-              className={classes.cell}
-            >
-              Status
-            </TableSortCell>
-            <Hidden smDown>
+    <>
+      <Accordion
+        heading={`${type}s`}
+        expanded={expanded}
+        onChange={() => setExpanded((previous) => !previous)}
+      >
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell className={classes.cell}>Label</TableCell>
               <TableSortCell
                 active={orderBy === 'when'}
                 direction={order}
@@ -194,48 +171,81 @@ const MaintenanceTable: React.FC<Props> = (props) => {
                 handleClick={handleOrderChange}
                 className={classes.cell}
               >
-                When
+                Date
               </TableSortCell>
-            </Hidden>
-            <Hidden mdDown>
-              <TableCell style={{ width: '40%' }}>Reason</TableCell>
-            </Hidden>
-          </TableRow>
-        </TableHead>
-        <TableBody>{renderTableContent()}</TableBody>
-      </Table>
-      <PaginationFooter
-        count={data?.results || 0}
-        handlePageChange={pagination.handlePageChange}
-        handleSizeChange={pagination.handlePageSizeChange}
-        page={pagination.page}
-        pageSize={pagination.pageSize}
-        eventCategory={`${type} Maintenance Table`}
-        forceShow={data && data.results > 0}
-      >
-        {/*
-          We are using a hidden CSVLink and an <a> to allow us to lazy load the
-          entire maintenance list for the CSV download. The <a> is what shows up
-          to the user and the onClick fetches the full user data and then
-          uses a ref to 'click' the real CSVLink.
-          This adds some complexity but gives us the benefit of lazy loading a potentially
-          large set of maintenance events on mount for the CSV download.
-        */}
-        <CSVLink
-          ref={csvRef}
-          headers={headersForCSVDownload}
-          filename={`maintenance-${Date.now()}.csv`}
-          data={cleanCSVData(csv || [])}
+              <Hidden xsDown>
+                <TableSortCell
+                  active={orderBy === 'type'}
+                  direction={order}
+                  label="type"
+                  handleClick={handleOrderChange}
+                  className={classes.cell}
+                >
+                  Type
+                </TableSortCell>
+              </Hidden>
+              <TableSortCell
+                active={orderBy === 'status'}
+                direction={order}
+                label="status"
+                handleClick={handleOrderChange}
+                className={classes.cell}
+              >
+                Status
+              </TableSortCell>
+              <Hidden smDown>
+                <TableSortCell
+                  active={orderBy === 'when'}
+                  direction={order}
+                  label="when"
+                  handleClick={handleOrderChange}
+                  className={classes.cell}
+                >
+                  When
+                </TableSortCell>
+              </Hidden>
+              <Hidden mdDown>
+                <TableCell style={{ width: '40%' }}>Reason</TableCell>
+              </Hidden>
+            </TableRow>
+          </TableHead>
+          <TableBody>{renderTableContent()}</TableBody>
+        </Table>
+        <PaginationFooter
+          count={data?.results || 0}
+          handlePageChange={pagination.handlePageChange}
+          handleSizeChange={pagination.handlePageSizeChange}
+          page={pagination.page}
+          pageSize={pagination.pageSize}
+          eventCategory={`${type} Maintenance Table`}
         />
-        <a
-          className={`${classes.CSVlink} ${classes.CSVlink}`}
-          onClick={downloadCSV}
-          aria-hidden="true"
-        >
-          Download CSV
-        </a>
-      </PaginationFooter>
-    </Accordion>
+      </Accordion>
+      {expanded ? (
+        <Box display="flex" justifyContent="flex-end">
+          {/*
+            We are using a hidden CSVLink and an <a> to allow us to lazy load the
+            entire maintenance list for the CSV download. The <a> is what shows up
+            to the user and the onClick fetches the full user data and then
+            uses a ref to 'click' the real CSVLink.
+            This adds some complexity but gives us the benefit of lazy loading a potentially
+            large set of maintenance events on mount for the CSV download.
+          */}
+          <CSVLink
+            ref={csvRef}
+            headers={headersForCSVDownload}
+            filename={`maintenance-${Date.now()}.csv`}
+            data={cleanCSVData(csv || [])}
+          />
+          <a
+            className={classes.csvLink}
+            onClick={downloadCSV}
+            aria-hidden="true"
+          >
+            Download CSV
+          </a>
+        </Box>
+      ) : null}
+    </>
   );
 };
 

--- a/packages/manager/src/features/Account/Maintenance/MaintenanceTable.tsx
+++ b/packages/manager/src/features/Account/Maintenance/MaintenanceTable.tsx
@@ -25,12 +25,9 @@ import {
 } from 'src/queries/accountMaintenance';
 import Accordion from 'src/components/Accordion';
 import Box from 'src/components/core/Box';
+import classNames from 'classnames';
 
 export type MaintenanceEntities = 'Linode' | 'Volume';
-
-interface Props {
-  type: MaintenanceEntities;
-}
 
 const preferenceKey = 'account-maintenance';
 
@@ -48,6 +45,11 @@ const useStyles = makeStyles((theme: Theme) => ({
   root: {
     '&.MuiAccordion-root.Mui-expanded': {
       marginBottom: theme.spacing(),
+    },
+  },
+  topMargin: {
+    '&.MuiAccordion-root': {
+      marginTop: theme.spacing(2),
     },
   },
   csvLink: {
@@ -68,12 +70,18 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
+interface Props {
+  type: MaintenanceEntities;
+  expanded: boolean;
+  toggleExpanded: () => void;
+  addTopMargin: boolean;
+}
+
 const MaintenanceTable: React.FC<Props> = (props) => {
-  const { type } = props;
+  const { type, expanded, toggleExpanded, addTopMargin } = props;
   const csvRef = React.useRef<any>();
   const classes = useStyles();
   const pagination = usePagination(1, `${preferenceKey}-${type.toLowerCase()}`);
-  const [expanded, setExpanded] = React.useState(true);
 
   const { order, orderBy, handleOrderChange } = useOrder(
     {
@@ -161,10 +169,13 @@ const MaintenanceTable: React.FC<Props> = (props) => {
   return (
     <>
       <Accordion
-        className={classes.root}
+        className={classNames({
+          [classes.root]: true,
+          [classes.topMargin]: addTopMargin,
+        })}
         heading={`${type}s`}
         expanded={expanded}
-        onChange={() => setExpanded((previous) => !previous)}
+        onChange={() => toggleExpanded()}
       >
         <Table>
           <TableHead>

--- a/packages/manager/src/features/Account/Maintenance/MaintenanceTableRow.tsx
+++ b/packages/manager/src/features/Account/Maintenance/MaintenanceTableRow.tsx
@@ -39,9 +39,12 @@ const MaintenanceTableRow: React.FC<AccountMaintenance> = (props) => {
           {entity.label}
         </Link>
       </TableCell>
-      <TableCell noWrap>
-        <div>{formatDate(when)}</div>
-      </TableCell>
+      <TableCell noWrap>{formatDate(when)}</TableCell>
+      <Hidden smDown>
+        <TableCell data-testid="relative-date">
+          {parseAPIDate(when).toRelative()}
+        </TableCell>
+      </Hidden>
       <Hidden xsDown>
         <TableCell className={classes.capitalize} noWrap>
           {type.replace('_', ' ')}
@@ -54,15 +57,12 @@ const MaintenanceTableRow: React.FC<AccountMaintenance> = (props) => {
             // @ts-expect-error api will change pending -> scheduled
             status === 'pending' || status === 'scheduled'
               ? 'Scheduled'
+              : status === 'started'
+              ? 'In Progress'
               : capitalize(status)
-          }{' '}
+          }
         </div>
       </TableCell>
-      <Hidden smDown>
-        <TableCell data-testid="relative-date">
-          {parseAPIDate(when).toRelative()}
-        </TableCell>
-      </Hidden>
       <Hidden mdDown>
         <TableCell>
           <HighlightedMarkdown textOrMarkdown={reason} />

--- a/packages/manager/src/features/Account/Maintenance/MaintenanceTableRow.tsx
+++ b/packages/manager/src/features/Account/Maintenance/MaintenanceTableRow.tsx
@@ -15,6 +15,10 @@ const useStyles = makeStyles(() => ({
   capitalize: {
     textTransform: 'capitalize',
   },
+  status: {
+    display: 'flex',
+    alignItems: 'center',
+  },
 }));
 
 const MaintenanceTableRow: React.FC<AccountMaintenance> = (props) => {
@@ -44,13 +48,15 @@ const MaintenanceTableRow: React.FC<AccountMaintenance> = (props) => {
         </TableCell>
       </Hidden>
       <TableCell>
-        <StatusIcon status={status == 'started' ? 'other' : 'inactive'} />
-        {
-          // @ts-expect-error api will change pending -> scheduled
-          status === 'pending' || status === 'scheduled'
-            ? 'Scheduled'
-            : capitalize(status)
-        }{' '}
+        <div className={classes.status}>
+          <StatusIcon status={status == 'started' ? 'other' : 'inactive'} />
+          {
+            // @ts-expect-error api will change pending -> scheduled
+            status === 'pending' || status === 'scheduled'
+              ? 'Scheduled'
+              : capitalize(status)
+          }{' '}
+        </div>
       </TableCell>
       <Hidden smDown>
         <TableCell data-testid="relative-date">


### PR DESCRIPTION
## Description

![Screen Shot 2021-10-28 at 2 18 26 PM](https://user-images.githubusercontent.com/6440455/139312740-524421ad-eafc-4c5f-a21a-0309e40cacb4.png)

- Ensure the Status indicator and text are properly aligned vertically
  - Same issue as #7983
- Hide Pagination controls if there are not >25 results
- Move the `Download CSV` link outside of the table to the bottom right below it
  - Still hides link when accordion is collapsed 

## How to test

- Go to `/account/maintenance` in Cloud Manager
- Test the three changes listed above
- Double check functionality of tables and accordians
