### PR TITLE
M3-5515: Fix button placement and improved spacing in Add Node Pool Drawer

### DIFF
--- a/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
+++ b/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
@@ -44,8 +44,8 @@ const ActionPanel: React.FC<CombinedProps> = (props) => {
       data-qa-buttons
       className={classNames({
         [classes.root]: true,
-        ...(className && { [className]: true }),
         actionPanel: true,
+        ...(className && { [className]: true }),
       })}
       style={style}
     >

--- a/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
+++ b/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
@@ -44,8 +44,8 @@ const ActionPanel: React.FC<CombinedProps> = (props) => {
       data-qa-buttons
       className={classNames({
         [classes.root]: true,
-        actionPanel: true,
         ...(className && { [className]: true }),
+        actionPanel: true,
       })}
       style={style}
     >

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/AddNodePoolDrawer/AddNodePoolDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/AddNodePoolDrawer/AddNodePoolDrawer.tsx
@@ -54,9 +54,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     '& span': {
       fontWeight: 'bold',
     },
-    [theme.breakpoints.up('md')]: {
-      marginTop: 0,
-    },
   },
   boxOuter: {
     width: '100%',

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/AddNodePoolDrawer/AddNodePoolDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/AddNodePoolDrawer/AddNodePoolDrawer.tsx
@@ -41,6 +41,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
   },
   button: {
+    paddingTop: 0,
     marginTop: '0 !important',
   },
   priceDisplay: {
@@ -49,15 +50,16 @@ const useStyles = makeStyles((theme: Theme) => ({
     fontSize: '1rem',
     lineHeight: '1.25rem',
     marginTop: theme.spacing(2),
+    marginBottom: theme.spacing(2),
     '& span': {
       fontWeight: 'bold',
     },
     [theme.breakpoints.up('md')]: {
-      marginLeft: theme.spacing(2),
       marginTop: 0,
     },
   },
   boxOuter: {
+    width: '100%',
     [theme.breakpoints.down('sm')]: {
       alignItems: 'flex-start',
       flexDirection: 'column',
@@ -171,23 +173,22 @@ export const AddNodePoolDrawer: React.FC<CombinedProps> = (props) => {
           resetValues={resetDrawer}
         />
         {currentCount > 0 && currentCount < 3 && (
-          <Notice important warning text={nodeWarning} spacingTop={8} />
+          <Notice
+            important
+            warning
+            text={nodeWarning}
+            spacingTop={8}
+            spacingBottom={16}
+          />
         )}
         <ActionsPanel className={classes.button}>
           <Box
             display="flex"
             flexDirection="row"
             alignItems="center"
+            justifyContent={currentCount > 0 ? 'space-between' : 'flex-end'}
             className={classes.boxOuter}
           >
-            <Button
-              buttonType="primary"
-              onClick={() => handleAdd()}
-              disabled={currentCount === 0}
-              loading={isSubmitting}
-            >
-              Add pool
-            </Button>
             {currentCount > 0 && (
               <Typography className={classes.priceDisplay}>
                 This pool will add{' '}
@@ -199,6 +200,14 @@ export const AddNodePoolDrawer: React.FC<CombinedProps> = (props) => {
                 to this cluster.
               </Typography>
             )}
+            <Button
+              buttonType="primary"
+              onClick={() => handleAdd()}
+              disabled={currentCount === 0}
+              loading={isSubmitting}
+            >
+              Add pool
+            </Button>
           </Box>
         </ActionsPanel>
       </form>


### PR DESCRIPTION
## Description

![Screen Shot 2021-10-28 at 10 45 44 PM](https://user-images.githubusercontent.com/6440455/139365250-62e19992-755f-4a8d-b06a-2c2509d2f6ee.png)

- Right aligns the `Add Pool` button in the `Add Node Pool` drawer for a Kubernetes Cluster

## How to test

- Go to any Kubernetes Cluster
- Click `Add Pool`
- Try many different Node Pool configurations and screen sizes and ensure the `Add Pool` button placement is good
