### PR TITLE
M3-5556: Refresh Redux upon volume_migrate starting & finishing

### DIFF
--- a/packages/manager/src/store/volume/volume.events.ts
+++ b/packages/manager/src/store/volume/volume.events.ts
@@ -5,7 +5,7 @@ import { deleteVolumeActions } from './volume.actions';
 import { getAllVolumes, getOneVolume } from './volume.requests';
 
 const volumeEventsHandler: EventHandler = (event, dispatch) => {
-  const { action, entity, status } = event;
+  const { action, entity, status, percent_complete } = event;
   const { id } = entity;
 
   switch (action) {
@@ -23,7 +23,7 @@ const volumeEventsHandler: EventHandler = (event, dispatch) => {
       return handleVolumeDelete(dispatch, status, id);
 
     case 'volume_migrate':
-      return handleVolumeMigrate(dispatch, status);
+      return handleVolumeMigrate(dispatch, status, percent_complete);
 
     default:
       return;
@@ -84,11 +84,17 @@ const handleVolumeDelete = (
   }
 };
 
-const handleVolumeMigrate = (dispatch: Dispatch<any>, status: EventStatus) => {
+const handleVolumeMigrate = (
+  dispatch: Dispatch<any>,
+  status: EventStatus,
+  percent_complete: number | null
+) => {
   switch (status) {
     case 'started':
     case 'finished':
-      dispatch(getAllVolumes({ setLoading: false }));
+      if (percent_complete === 100) {
+        dispatch(getAllVolumes({ setLoading: false }));
+      }
     case 'failed':
     case 'notification':
     case 'scheduled':

--- a/packages/manager/src/store/volume/volume.events.ts
+++ b/packages/manager/src/store/volume/volume.events.ts
@@ -22,6 +22,9 @@ const volumeEventsHandler: EventHandler = (event, dispatch) => {
     case 'volume_delete':
       return handleVolumeDelete(dispatch, status, id);
 
+    case 'volume_migrate':
+      return handleVolumeMigrate(dispatch, status);
+
     default:
       return;
   }
@@ -78,6 +81,20 @@ const handleVolumeDelete = (
         result: {},
       });
       return dispatch(action);
+  }
+};
+
+const handleVolumeMigrate = (dispatch: Dispatch<any>, status: EventStatus) => {
+  switch (status) {
+    case 'started':
+    case 'finished':
+      dispatch(getAllVolumes({ setLoading: false }));
+    case 'failed':
+    case 'notification':
+    case 'scheduled':
+
+    default:
+      return;
   }
 };
 


### PR DESCRIPTION
## Description
Handles for the `volume_migrate` event type in `volume.events.ts`. Grab all volumes after `volume_migrate` starts and finishes.

## How to test
Once the volume migration is completed, you should see the chip next to the volume label on the Volumes landing page change from "Upgrade to NVMe" to "NVMe" without having to refresh the page.

When https://github.com/linode/manager/pull/8002 is merged, after pushing a volume into the queue, you should see the chip change from "Upgrade to NVMe" to "Upgrade Pending," and then from "Upgrade Pending" to "NVMe" once the volume migration is completed.


