### PR TITLE
M3-5559: Button alignment in the Enable All Backups drawer

### DIFF
--- a/packages/manager/src/features/Backups/BackupDrawer.tsx
+++ b/packages/manager/src/features/Backups/BackupDrawer.tsx
@@ -179,15 +179,6 @@ export class BackupDrawer extends React.Component<CombinedProps, {}> {
           <Grid item>
             <ActionsPanel style={{ padding: 0, margin: 0 }}>
               <Button
-                onClick={this.handleSubmit}
-                loading={loading || enabling || enrolling}
-                buttonType="primary"
-                data-qa-submit
-                data-testid={'submit'}
-              >
-                Confirm
-              </Button>
-              <Button
                 onClick={close}
                 buttonType="secondary"
                 className="cancel"
@@ -195,6 +186,15 @@ export class BackupDrawer extends React.Component<CombinedProps, {}> {
                 data-testid={'cancel'}
               >
                 Cancel
+              </Button>
+              <Button
+                onClick={this.handleSubmit}
+                loading={loading || enabling || enrolling}
+                buttonType="primary"
+                data-qa-submit
+                data-testid={'submit'}
+              >
+                Confirm
               </Button>
             </ActionsPanel>
           </Grid>


### PR DESCRIPTION
## Description

- Fixes button order in the **_Enable All Backups_** drawer

### Before

![Screen Shot 2021-11-01 at 6 51 47 PM](https://user-images.githubusercontent.com/6440455/139753809-fd53a8a7-0f85-4757-bcd0-eadb91a273d3.png)

### After

![Screen Shot 2021-11-01 at 7 10 38 PM](https://user-images.githubusercontent.com/6440455/139753871-7af4576c-a23d-4ea8-896c-d6c731b18bc5.png)

## How to test

- Go to `/account/settings` on a non-managed account
- Click `enable now` to open the **_Enable All Backups_** drawer
- Make sure buttons are right aligned and the primary action button is on the right side 
