### PR TITLE
Fixed general console errors due to Material UI deprecation warnings

### DIFF
--- a/packages/manager/src/components/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/packages/manager/src/components/ConfirmationDialog/ConfirmationDialog.tsx
@@ -39,13 +39,17 @@ type CombinedProps = Props;
 const ConfirmationDialog: React.FC<CombinedProps> = (props) => {
   const classes = useStyles();
 
-  const { title, children, actions, error, ...dialogProps } = props;
+  const { title, children, actions, error, onClose, ...dialogProps } = props;
 
   return (
     <Dialog
       {...dialogProps}
+      onClose={(_, reason) => {
+        if (reason !== 'backdropClick') {
+          onClose();
+        }
+      }}
       className={classes.root}
-      disableBackdropClick={true}
       PaperProps={{ role: undefined }}
       role="dialog"
     >

--- a/packages/manager/src/components/Drawer/Drawer.tsx
+++ b/packages/manager/src/components/Drawer/Drawer.tsx
@@ -73,18 +73,22 @@ const styles = (theme: Theme) =>
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 const DDrawer: React.FC<CombinedProps> = (props) => {
-  const { title, classes, children, wide, ...rest } = props;
+  const { title, classes, children, wide, onClose, ...rest } = props;
 
   const titleID = convertForAria(title);
 
   return (
     <Drawer
       anchor="right"
+      onClose={(event, reason) => {
+        if (onClose && reason !== 'backdropClick') {
+          onClose(event, reason);
+        }
+      }}
       {...rest}
       classes={{ paper: `${classes.paper} ${wide ? classes.wide : ''}` }}
       ModalProps={{
         BackdropProps: { className: classes.backDrop },
-        disableBackdropClick: true,
       }}
       data-qa-drawer
       data-testid="drawer"

--- a/packages/manager/src/components/InformationDialog/InformationDialog.tsx
+++ b/packages/manager/src/components/InformationDialog/InformationDialog.tsx
@@ -9,11 +9,15 @@ interface Props extends DialogProps {
 }
 
 export const InformationDialog: React.FC<Props> = (props) => {
-  const { title, children, ...dialogProps } = props;
+  const { title, children, onClose, ...dialogProps } = props;
   return (
     <Dialog
       {...dialogProps}
-      disableBackdropClick={true}
+      onClose={(_, reason) => {
+        if (reason !== 'backdropClick') {
+          onClose();
+        }
+      }}
       PaperProps={{ role: undefined }}
       role="dialog"
     >

--- a/packages/manager/src/components/core/RootRef.ts
+++ b/packages/manager/src/components/core/RootRef.ts
@@ -1,8 +1,0 @@
-import RootRef, {
-  RootRefProps as _RootRefProps,
-} from '@material-ui/core/RootRef';
-
-/* tslint:disable-next-line:no-empty-interface */
-export interface RootRefProps extends _RootRefProps {}
-
-export default RootRef;

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
@@ -470,9 +470,14 @@ export const KubeSummaryPanel: React.FunctionComponent<Props> = (props) => {
             </Grid>
           </Grid>
 
-          <Grid item container direction="row" lg={9} justify="space-between">
+          <Grid
+            item
+            container
+            direction="row"
+            lg={9}
+            justifyContent="space-between"
+          >
             {setKubeconfigDisplay()}
-
             <Grid
               item
               container

--- a/packages/manager/src/features/Managed/Contacts/Contacts.tsx
+++ b/packages/manager/src/features/Managed/Contacts/Contacts.tsx
@@ -120,7 +120,7 @@ const Contacts: React.FC<CombinedProps> = (props) => {
   const contactDrawer = useOpenClose();
 
   // Ref for handling "scrollTo" on Paginated component.
-  const contactsTableRef = React.createRef<any>();
+  const contactsTableRef = React.createRef<HTMLDivElement>();
 
   const groups = generateGroupsFromContacts(contacts);
 

--- a/packages/manager/src/features/Managed/Contacts/Contacts.tsx
+++ b/packages/manager/src/features/Managed/Contacts/Contacts.tsx
@@ -4,7 +4,6 @@ import { withSnackbar, WithSnackbarProps } from 'notistack';
 import * as React from 'react';
 import AddNewLink from 'src/components/AddNewLink';
 import Hidden from 'src/components/core/Hidden';
-import RootRef from 'src/components/core/RootRef';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
@@ -121,7 +120,7 @@ const Contacts: React.FC<CombinedProps> = (props) => {
   const contactDrawer = useOpenClose();
 
   // Ref for handling "scrollTo" on Paginated component.
-  const contactsTableRef = React.createRef();
+  const contactsTableRef = React.createRef<any>();
 
   const groups = generateGroupsFromContacts(contacts);
 
@@ -133,24 +132,23 @@ const Contacts: React.FC<CombinedProps> = (props) => {
         the event of a support issue. Create contacts and assign them to a
         group, then assign the group to the appropriate monitor(s).
       </Typography>
-      <RootRef rootRef={contactsTableRef}>
-        <Grid
-          className={classes.header}
-          container
-          alignItems="center"
-          justifyContent="flex-end"
-        >
-          <Grid item className={classes.addNewWrapper}>
-            <AddNewLink
-              onClick={() => {
-                setContactDrawerMode('create');
-                contactDrawer.open();
-              }}
-              label="Add Contact"
-            />
-          </Grid>
+      <Grid
+        ref={contactsTableRef}
+        className={classes.header}
+        container
+        alignItems="center"
+        justifyContent="flex-end"
+      >
+        <Grid item className={classes.addNewWrapper}>
+          <AddNewLink
+            onClick={() => {
+              setContactDrawerMode('create');
+              contactDrawer.open();
+            }}
+            label="Add Contact"
+          />
         </Grid>
-      </RootRef>
+      </Grid>
       <OrderBy data={contacts} orderBy="name" order="asc">
         {({ data: orderedData, handleOrderChange, order, orderBy }) => {
           return (

--- a/packages/manager/src/features/Profile/SecretTokenDialog/SecretTokenDialog.tsx
+++ b/packages/manager/src/features/Profile/SecretTokenDialog/SecretTokenDialog.tsx
@@ -35,9 +35,12 @@ export const SecretTokenDialog: React.FC<CombinedProps> = (props) => {
     <Dialog
       title={title}
       open={open}
-      onClose={onClose}
+      onClose={(_, reason) => {
+        if (reason !== 'backdropClick') {
+          onClose();
+        }
+      }}
       disableEscapeKeyDown
-      disableBackdropClick
       maxWidth="sm"
     >
       <Notice

--- a/packages/manager/src/features/TheApplicationIsOnFire.tsx
+++ b/packages/manager/src/features/TheApplicationIsOnFire.tsx
@@ -13,12 +13,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 const TheApplicationIsOnFire: React.FC<{}> = (props) => {
   return (
-    <Dialog
-      open
-      disableBackdropClick={true}
-      PaperProps={{ role: undefined }}
-      role="dialog"
-    >
+    <Dialog open PaperProps={{ role: undefined }} role="dialog">
       <DialogTitle title="Oh snap!" />
       <DialogContent>
         <Typography variant="subtitle1" style={{ marginBottom: 16 }}>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks.tsx
@@ -8,7 +8,6 @@ import AddNewLink from 'src/components/AddNewLink';
 import Button from 'src/components/Button';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
 import Hidden from 'src/components/core/Hidden';
-import RootRef from 'src/components/core/RootRef';
 import {
   createStyles,
   Theme,
@@ -166,13 +165,11 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
           alignItems="flex-end"
           justifyContent="space-between"
         >
-          <RootRef rootRef={this.disksHeader}>
-            <Grid item className="p0">
-              <Typography variant="h3" className={classes.headline}>
-                Disks
-              </Typography>
-            </Grid>
-          </RootRef>
+          <Grid item ref={this.disksHeader} className="p0">
+            <Typography variant="h3" className={classes.headline}>
+              Disks
+            </Typography>
+          </Grid>
           <Grid item className={classes.addNewWrapper}>
             <AddNewLink
               onClick={this.openDrawerForCreation}


### PR DESCRIPTION
## Description

Keeping the developer console clean is crucial to debugging and developing Cloud Manager. Putting this PR up in hopes to make the dev console cleaner so it can help us be more productive using it. 

- We were seeing a lot of deprecation errors in the console due to Material UI depreciating the `disableBackdropClick` prop. 
  - This PR implements a fix that is recommended by MUI to fix this deprecation warning.
- Replaced `justify` with `justifyContent` because `justify` prop is deprecated by MUI.
- Replace `RootRef`s with regular `refs` because MUI should now forward that properly and `RootRef`s have also been deprecated.

### Before
![Screen Shot 2021-11-01 at 9 23 09 PM](https://user-images.githubusercontent.com/6440455/139771719-2193c2e5-1714-489e-bf9d-edc9352787df.png)

### After
![Screen Shot 2021-11-01 at 9 23 27 PM](https://user-images.githubusercontent.com/6440455/139771731-32f0317d-045b-4690-80a4-5a6be94a5ef8.png)

## How to test

- Make sure all Modals, Dialogs, and Drawers are only dismissable by the `esc` key or the close buttons.
- Ensure no Modals, Dialogs, or Drawers close by clicking out of them on the "backdrop"
- Check for general regressions