### PR TITLE
M3-5524 & M3-5523: Contextual help with Google Analytics on Docs Links

### DIFF
--- a/packages/manager/src/components/DocsLink/DocsLink.tsx
+++ b/packages/manager/src/components/DocsLink/DocsLink.tsx
@@ -27,6 +27,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 interface Props {
   href: string;
   label?: string;
+  analyticsLabel?: string;
 }
 
 type CombinedProps = Props;
@@ -34,7 +35,7 @@ type CombinedProps = Props;
 export const DocsLink: React.FC<CombinedProps> = (props) => {
   const classes = useStyles();
 
-  const { href, label } = props;
+  const { href, label, analyticsLabel } = props;
 
   return (
     <IconTextLink
@@ -43,7 +44,7 @@ export const DocsLink: React.FC<CombinedProps> = (props) => {
       text={label ?? 'Docs'}
       title={label ?? 'Docs'}
       onClick={() => {
-        sendHelpButtonClickEvent(href);
+        sendHelpButtonClickEvent(href, analyticsLabel);
         window.open(href, '_blank', 'noopener');
       }}
       aria-describedby="external-site"

--- a/packages/manager/src/components/EntityHeader/EntityHeader.tsx
+++ b/packages/manager/src/components/EntityHeader/EntityHeader.tsx
@@ -147,7 +147,13 @@ export const EntityHeader: React.FC<HeaderProps> = (props) => {
             sm={8}
           >
             {props.children}
-            {docsLink ? <DocsLink href={docsLink} label={docsLabel} /> : null}
+            {docsLink ? (
+              <DocsLink
+                href={docsLink}
+                label={docsLabel}
+                analyticsLabel={`${title} Landing`}
+              />
+            ) : null}
             <div className={classes.actions}>{actions}</div>
           </Grid>
         </Grid>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailsBreadcrumb.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailsBreadcrumb.tsx
@@ -103,7 +103,10 @@ const LinodeControls: React.FC<CombinedProps> = (props) => {
         />
       </Grid>
       <Grid item className="px0" style={{ marginTop: 4 }}>
-        <DocsLink href="https://www.linode.com/docs/platform/billing-and-support/linode-beginners-guide/" />
+        <DocsLink
+          href="https://www.linode.com/docs/platform/billing-and-support/linode-beginners-guide/"
+          analyticsLabel="Linode Detail"
+        />
       </Grid>
     </Grid>
   );

--- a/packages/manager/src/utilities/ga.ts
+++ b/packages/manager/src/utilities/ga.ts
@@ -369,10 +369,11 @@ export const sendEntityTransferCopyDraftEmailEvent = (): void => {
   });
 };
 
-export const sendHelpButtonClickEvent = (buttonLabel: string) => {
+export const sendHelpButtonClickEvent = (url: string, from?: string) => {
   sendEvent({
     category: 'Help Button',
-    action: buttonLabel,
+    action: url,
+    label: from,
   });
 };
 


### PR DESCRIPTION
## Description

- Adds a label to the existing Google Analytics event which allows us to specify where the link click was initiated. 
- The goal was to see how often the Docs link was clicked on Linode Detail and Linode Landing. In a way, this was already recorded (we recorded how often the [destination link](https://www.linode.com/docs/platform/billing-and-Support/linode-Beginners-Guide/
) was visited) (the links on Linode Landing and Linode Detail are the same link), but we didn't know where the click was initiated. 

## How to test

Currently unsure if I can test this in a dev environment. 