### PR TITLE
M3-5468: Fix Linode Networking Graph Overlapping with DNS Resolvers

### DIFF
--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -58,6 +58,10 @@ type CombinedProps = Props;
 
 const useStyles = makeStyles((theme: Theme) => ({
   ...MetricDisplayStyles(theme),
+  canvasContainer: {
+    position: 'relative',
+    width: '80%',
+  },
 }));
 
 const lineOptions: ChartDataSets = {
@@ -275,7 +279,7 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
   });
   return (
     <div className={classes.wrapper}>
-      <div>
+      <div className={classes.canvasContainer}>
         <canvas height={chartHeight || 300} ref={inputEl} />
       </div>
       {legendRendered && legendRows && (


### PR DESCRIPTION
## Description

Prevents the Linode Networking graph from flowing outside of it's container and into the DNS Resolvers table. This was an issue where since the graph is rendered using a Canvas element it cannot be sized dynamically easily. The docs for chartjs specify that in order to dynamically resize the chart specifying a relative position and a relative width on the graph would be necessary. https://www.chartjs.org/docs/latest/configuration/responsive.html#important-note

## How to test

1. Open a Linode details page.
2. Ensure your browser window is relatively wide.
2. Switch to the Networking tab.
3. Slowly shrink the horizontal size of your browser window.
4. Observe if at any point the DNS Resolvers table overlays the Networking graph.