### PR TITLE
M3-5560: Add Delete Button to NodeBalancer Detail in Settings

### DIFF
--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
@@ -1,6 +1,7 @@
 import {
   getNodeBalancer,
   getNodeBalancerConfigs,
+  NodeBalancer,
 } from '@linode/api-v4/lib/nodebalancers';
 import { APIError } from '@linode/api-v4/lib/types';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
@@ -80,6 +81,7 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
   state: State = {
     nodeBalancer: undefined,
     ApiError: undefined,
+    labelInput: undefined,
   };
 
   pollInterval: number;
@@ -348,6 +350,18 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
                   nodeBalancerClientConnThrottle={
                     nodeBalancer.client_conn_throttle
                   }
+                  updateNodeBalancerStore={(data: NodeBalancer) => {
+                    if (this.state.nodeBalancer) {
+                      this.setState({
+                        nodeBalancer: {
+                          ...this.state.nodeBalancer,
+                          label: data.label,
+                          client_conn_throttle: data.client_conn_throttle,
+                        },
+                        labelInput: data.label,
+                      });
+                    }
+                  }}
                 />
               </SafeTabPanel>
             </TabPanels>

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
@@ -251,6 +251,19 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
     },
   ];
 
+  updateNodeBalancerState = (data: NodeBalancer) => {
+    if (this.state.nodeBalancer) {
+      this.setState({
+        nodeBalancer: {
+          ...this.state.nodeBalancer,
+          label: data.label,
+          client_conn_throttle: data.client_conn_throttle,
+        },
+        labelInput: data.label,
+      });
+    }
+  };
+
   render() {
     const matches = (pathName: string) =>
       Boolean(matchPath(this.props.location.pathname, { path: pathName }));
@@ -350,18 +363,7 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
                   nodeBalancerClientConnThrottle={
                     nodeBalancer.client_conn_throttle
                   }
-                  updateNodeBalancerStore={(data: NodeBalancer) => {
-                    if (this.state.nodeBalancer) {
-                      this.setState({
-                        nodeBalancer: {
-                          ...this.state.nodeBalancer,
-                          label: data.label,
-                          client_conn_throttle: data.client_conn_throttle,
-                        },
-                        labelInput: data.label,
-                      });
-                    }
-                  }}
+                  updateNodeBalancerDetailState={this.updateNodeBalancerState}
                 />
               </SafeTabPanel>
             </TabPanels>

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSettings/NodeBalancerSettings.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSettings/NodeBalancerSettings.tsx
@@ -8,7 +8,6 @@ import InputAdornment from 'src/components/core/InputAdornment';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
-import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
 import defaultNumeric from 'src/utilities/defaultNumeric';
 import {
@@ -34,7 +33,7 @@ interface Props {
   nodeBalancerId: number;
   nodeBalancerLabel: string;
   nodeBalancerClientConnThrottle: number;
-  updateNodeBalancerStore: (data: NodeBalancer) => void;
+  updateNodeBalancerDetailState: (data: NodeBalancer) => void;
 }
 
 type CombinedProps = Props & WithNodeBalancerActions;
@@ -47,7 +46,7 @@ export const NodeBalancerSettings: React.FC<CombinedProps> = (props) => {
     nodeBalancerId,
     nodeBalancerLabel,
     nodeBalancerActions: { updateNodeBalancer, deleteNodeBalancer },
-    updateNodeBalancerStore,
+    updateNodeBalancerDetailState,
   } = props;
 
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = React.useState<boolean>(
@@ -92,7 +91,7 @@ export const NodeBalancerSettings: React.FC<CombinedProps> = (props) => {
     updateNodeBalancer({ nodeBalancerId, label })
       .then((data) => {
         setIsLabelSaving(false);
-        updateNodeBalancerStore(data);
+        updateNodeBalancerDetailState(data);
       })
       .catch((error) => {
         setIsLabelSaving(false);
@@ -115,7 +114,7 @@ export const NodeBalancerSettings: React.FC<CombinedProps> = (props) => {
     })
       .then((data) => {
         setIsConnectionThrottleSaving(false);
-        updateNodeBalancerStore(data);
+        updateNodeBalancerDetailState(data);
       })
       .catch((error) => {
         setIsConnectionThrottleSaving(false);
@@ -146,7 +145,6 @@ export const NodeBalancerSettings: React.FC<CombinedProps> = (props) => {
     <div>
       <DocumentTitleSegment segment={`${nodeBalancerLabel} - Settings`} />
       <Accordion heading="NodeBalancer Label" defaultExpanded>
-        {labelError ? <Notice error text={labelError} /> : null}
         <TextField
           label="Label"
           placeholder="Enter a label between 3 and 32 characters"
@@ -159,6 +157,7 @@ export const NodeBalancerSettings: React.FC<CombinedProps> = (props) => {
           buttonType="primary"
           className={classes.spacing}
           loading={isLabelSaving}
+          disabled={label === nodeBalancerLabel}
           onClick={onSaveUsername}
           data-qa-label-save
         >
@@ -166,9 +165,6 @@ export const NodeBalancerSettings: React.FC<CombinedProps> = (props) => {
         </Button>
       </Accordion>
       <Accordion heading="Client Connection Throttle" defaultExpanded>
-        {connectionThrottleError ? (
-          <Notice error text={connectionThrottleError} />
-        ) : null}
         <TextField
           InputProps={{
             endAdornment: (
@@ -194,6 +190,7 @@ export const NodeBalancerSettings: React.FC<CombinedProps> = (props) => {
           buttonType="primary"
           className={classes.spacing}
           loading={isConnectionThrottleSaving}
+          disabled={connectionThrottle === props.nodeBalancerClientConnThrottle}
           onClick={onSaveConnectionThrottle}
           data-qa-label-save
         >
@@ -207,7 +204,9 @@ export const NodeBalancerSettings: React.FC<CombinedProps> = (props) => {
         >
           Delete
         </Button>
-        <Typography className={classes.spacing}>Delete NodeBalancer</Typography>
+        <Typography className={classes.spacing}>
+          Deleting a NodeBalancer will remove associated configurations.
+        </Typography>
       </Accordion>
       <DeletionDialog
         typeToConfirm

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSettings/NodeBalancerSettings.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSettings/NodeBalancerSettings.tsx
@@ -248,7 +248,7 @@ export const NodeBalancerSettings: React.FC<CombinedProps> = (props) => {
         <Typography variant="body1">
           Traffic will no longer be routed through this NodeBalancer. Please
           check your DNS settings and either provide the IP address of another
-          active NodeBalancer, or route traffic directly to you Linode.
+          active NodeBalancer, or route traffic directly to your Linode.
         </Typography>
       </ConfirmationDialog>
     </div>

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSettings/NodeBalancerSettings.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSettings/NodeBalancerSettings.tsx
@@ -1,32 +1,32 @@
-import { APIError } from '@linode/api-v4/lib/types';
 import { clamp, compose, defaultTo } from 'ramda';
 import * as React from 'react';
 import { compose as composeC } from 'recompose';
-import ActionsPanel from 'src/components/ActionsPanel';
+import Accordion from 'src/components/Accordion';
 import Button from 'src/components/Button';
 import FormHelperText from 'src/components/core/FormHelperText';
 import InputAdornment from 'src/components/core/InputAdornment';
-import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
-import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
+import defaultNumeric from 'src/utilities/defaultNumeric';
+import {
+  getAPIErrorOrDefault,
+  getErrorStringOrDefault,
+} from 'src/utilities/errorUtils';
 import {
   withNodeBalancerActions,
   WithNodeBalancerActions,
 } from 'src/store/nodeBalancer/nodeBalancer.containers';
-import defaultNumeric from 'src/utilities/defaultNumeric';
-import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
-import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
-import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
+import { NodeBalancer } from '@linode/api-v4/lib/nodebalancers';
+import { APIError } from '@linode/api-v4/lib/types';
+import DeletionDialog from 'src/components/DeletionDialog';
+import { useHistory } from 'react-router-dom';
 
 const useStyles = makeStyles((theme: Theme) => ({
-  inner: {
-    paddingBottom: theme.spacing(2),
-    '& label': {
-      marginTop: 4,
-    },
+  spacing: {
+    marginTop: theme.spacing(),
   },
 }));
 
@@ -34,121 +34,198 @@ interface Props {
   nodeBalancerId: number;
   nodeBalancerLabel: string;
   nodeBalancerClientConnThrottle: number;
-}
-
-interface FieldsState {
-  client_conn_throttle?: number;
-  label?: string;
+  updateNodeBalancerStore: (data: NodeBalancer) => void;
 }
 
 type CombinedProps = Props & WithNodeBalancerActions;
 
-const errorResources = {
-  client_conn_throttle: 'client connection throttle',
-  label: 'label',
-};
-
 export const NodeBalancerSettings: React.FC<CombinedProps> = (props) => {
   const classes = useStyles();
+  const history = useHistory();
 
   const {
     nodeBalancerId,
     nodeBalancerLabel,
-    nodeBalancerActions: { updateNodeBalancer },
+    nodeBalancerActions: { updateNodeBalancer, deleteNodeBalancer },
+    updateNodeBalancerStore,
   } = props;
 
-  const defaultFieldsStates = {
-    client_conn_throttle: props.nodeBalancerClientConnThrottle,
-    label: props.nodeBalancerLabel,
-  };
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = React.useState<boolean>(
+    false
+  );
+  const [isDeleting, setIsDeleting] = React.useState<boolean>(false);
+  const [deleteError, setDeleteError] = React.useState<APIError[] | undefined>(
+    undefined
+  );
 
-  const [fields, setFields] = React.useState<FieldsState>(defaultFieldsStates);
-  const [isSubmitting, setIsSubmitting] = React.useState<boolean>(false);
-  const [success, setSuccess] = React.useState<string | undefined>(undefined);
-  const [errors, setErrors] = React.useState<APIError[] | undefined>(undefined);
+  const [label, setLabel] = React.useState<string>(props.nodeBalancerLabel);
+  const [isLabelSaving, setIsLabelSaving] = React.useState<boolean>(false);
+  const [labelError, setLabelError] = React.useState<string | undefined>(
+    undefined
+  );
 
-  const hasErrorFor = getAPIErrorFor(errorResources, errors);
-  const generalError = hasErrorFor('none');
+  const [connectionThrottle, setConnectionThrottle] = React.useState<number>(
+    props.nodeBalancerClientConnThrottle
+  );
+  const [
+    isConnectionThrottleSaving,
+    setIsConnectionThrottleSaving,
+  ] = React.useState<boolean>(false);
+  const [connectionThrottleError, setConnectionThrottleError] = React.useState<
+    string | undefined
+  >(undefined);
 
-  const handleLabelInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setFields({ ...fields, label: e.target.value });
-  };
+  React.useEffect(() => {
+    if (label !== props.nodeBalancerLabel) {
+      setLabel(props.nodeBalancerLabel);
+    }
+    if (connectionThrottle !== props.nodeBalancerClientConnThrottle) {
+      setConnectionThrottle(props.nodeBalancerClientConnThrottle);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props]);
 
-  const handleThrottleInputChange = (
-    e: React.ChangeEvent<HTMLInputElement>
-  ) => {
-    setFields({
-      ...fields,
-      client_conn_throttle: controlClientConnectionThrottle(e.target.value),
-    });
-  };
+  const onSaveUsername = () => {
+    setIsLabelSaving(true);
+    setLabelError(undefined);
 
-  const onSubmitUpdateNodeBalancer = () => {
-    setIsSubmitting(true);
-    setSuccess(undefined);
-    setErrors(undefined);
-
-    updateNodeBalancer({ nodeBalancerId, ...fields })
-      .then(() => {
-        setIsSubmitting(false);
-        setSuccess('NodeBalancer settings updated successfully');
+    updateNodeBalancer({ nodeBalancerId, label })
+      .then((data) => {
+        setIsLabelSaving(false);
+        updateNodeBalancerStore(data);
       })
       .catch((error) => {
-        setIsSubmitting(false);
-        setErrors(getAPIErrorOrDefault(error));
-        scrollErrorIntoView();
+        setIsLabelSaving(false);
+        setLabelError(
+          getAPIErrorOrDefault(
+            error,
+            "Unable to update your NodeBalancer's label."
+          )[0].reason
+        );
+      });
+  };
+
+  const onSaveConnectionThrottle = () => {
+    setIsConnectionThrottleSaving(true);
+    setConnectionThrottleError(undefined);
+
+    updateNodeBalancer({
+      nodeBalancerId,
+      client_conn_throttle: connectionThrottle,
+    })
+      .then((data) => {
+        setIsConnectionThrottleSaving(false);
+        updateNodeBalancerStore(data);
+      })
+      .catch((error) => {
+        setIsConnectionThrottleSaving(false);
+        setLabelError(
+          getAPIErrorOrDefault(
+            error,
+            "Unable to update your NodeBalancer's client connection throttle."
+          )[0].reason
+        );
+      });
+  };
+
+  const handleDelete = () => {
+    setIsDeleting(true);
+    setDeleteError(undefined);
+
+    deleteNodeBalancer({ nodeBalancerId })
+      .then(() => {
+        history.replace('/nodebalancers');
+      })
+      .catch((errors: APIError[]) => {
+        setDeleteError(errors);
+        setIsDeleting(false);
       });
   };
 
   return (
     <div>
       <DocumentTitleSegment segment={`${nodeBalancerLabel} - Settings`} />
-      <Paper>
-        <Grid item xs={12}>
-          {generalError ? <Notice error text={generalError} /> : null}
-          {success ? <Notice success text={success} /> : null}
-        </Grid>
-        <div className={classes.inner}>
-          <TextField
-            label="Label"
-            placeholder="Enter a label between 3 and 32 characters"
-            errorText={hasErrorFor('label')}
-            onChange={handleLabelInputChange}
-            value={fields.label}
-            data-qa-label-panel
-          />
-          <FormHelperText>Rename your NodeBalancer</FormHelperText>
-        </div>
-        <div className={classes.inner}>
-          <TextField
-            InputProps={{
-              endAdornment: (
-                <InputAdornment position="end">/ second</InputAdornment>
-              ),
-            }}
-            label="Client Connection Throttle"
-            errorText={hasErrorFor('client_conn_throttle')}
-            onChange={handleThrottleInputChange}
-            placeholder="0"
-            value={defaultTo(0, fields.client_conn_throttle)}
-            data-qa-connection-throttle
-          />
-          <FormHelperText>
-            To help mitigate abuse, throttle connections from a single client IP
-            to this number per second. 0 to disable.
-          </FormHelperText>
-        </div>
-        <ActionsPanel className="p0">
-          <Button
-            buttonType="primary"
-            disabled={isSubmitting}
-            onClick={onSubmitUpdateNodeBalancer}
-            data-qa-label-save
-          >
-            Save Changes
-          </Button>
-        </ActionsPanel>
-      </Paper>
+      <Accordion heading="NodeBalancer Label" defaultExpanded>
+        {labelError ? <Notice error text={labelError} /> : null}
+        <TextField
+          label="Label"
+          placeholder="Enter a label between 3 and 32 characters"
+          errorText={labelError}
+          onChange={(e) => setLabel(e.target.value)}
+          value={label}
+          data-qa-label-panel
+        />
+        <Button
+          buttonType="primary"
+          className={classes.spacing}
+          loading={isLabelSaving}
+          onClick={onSaveUsername}
+          data-qa-label-save
+        >
+          Save
+        </Button>
+      </Accordion>
+      <Accordion heading="Client Connection Throttle" defaultExpanded>
+        {connectionThrottleError ? (
+          <Notice error text={connectionThrottleError} />
+        ) : null}
+        <TextField
+          InputProps={{
+            endAdornment: (
+              <InputAdornment position="end">/ second</InputAdornment>
+            ),
+          }}
+          label="Connection Throttle"
+          errorText={connectionThrottleError}
+          onChange={(e) =>
+            setConnectionThrottle(
+              controlClientConnectionThrottle(e.target.value)
+            )
+          }
+          placeholder="0"
+          value={defaultTo(0, connectionThrottle)}
+          data-qa-connection-throttle
+        />
+        <FormHelperText>
+          To help mitigate abuse, throttle connections from a single client IP
+          to this number per second. 0 to disable.
+        </FormHelperText>
+        <Button
+          buttonType="primary"
+          className={classes.spacing}
+          loading={isConnectionThrottleSaving}
+          onClick={onSaveConnectionThrottle}
+          data-qa-label-save
+        >
+          Save
+        </Button>
+      </Accordion>
+      <Accordion heading="Delete NodeBalancer" defaultExpanded>
+        <Button
+          buttonType="primary"
+          onClick={() => setIsDeleteDialogOpen(true)}
+        >
+          Delete
+        </Button>
+        <Typography className={classes.spacing}>Delete NodeBalancer</Typography>
+      </Accordion>
+      <DeletionDialog
+        typeToConfirm
+        entity="NodeBalancer"
+        open={isDeleteDialogOpen}
+        label={nodeBalancerLabel}
+        loading={isDeleting}
+        error={
+          deleteError && deleteError.length > 0
+            ? getErrorStringOrDefault(
+                deleteError,
+                'Unable to delete this NodeBalancer.'
+              )
+            : undefined
+        }
+        onClose={() => setIsDeleteDialogOpen(false)}
+        onDelete={handleDelete}
+      />
     </div>
   );
 };

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSettings/NodeBalancerSettings.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSettings/NodeBalancerSettings.tsx
@@ -20,12 +20,20 @@ import {
 } from 'src/store/nodeBalancer/nodeBalancer.containers';
 import { NodeBalancer } from '@linode/api-v4/lib/nodebalancers';
 import { APIError } from '@linode/api-v4/lib/types';
-import DeletionDialog from 'src/components/DeletionDialog';
 import { useHistory } from 'react-router-dom';
+import ConfirmationDialog from 'src/components/ConfirmationDialog';
+import ActionsPanel from 'src/components/ActionsPanel';
+import Notice from 'src/components/Notice';
 
 const useStyles = makeStyles((theme: Theme) => ({
   spacing: {
     marginTop: theme.spacing(),
+  },
+  notice: {
+    '& p': {
+      fontFamily: theme.font.normal,
+      fontSize: '0.875rem',
+    },
   },
 }));
 
@@ -142,6 +150,20 @@ export const NodeBalancerSettings: React.FC<CombinedProps> = (props) => {
       });
   };
 
+  const actions = (
+    <ActionsPanel>
+      <Button
+        buttonType="secondary"
+        onClick={() => setIsDeleteDialogOpen(false)}
+      >
+        Cancel
+      </Button>
+      <Button buttonType="primary" onClick={handleDelete} loading={isDeleting}>
+        Delete NodeBalancer
+      </Button>
+    </ActionsPanel>
+  );
+
   return (
     <div>
       <DocumentTitleSegment segment={`${nodeBalancerLabel} - Settings`} />
@@ -205,16 +227,10 @@ export const NodeBalancerSettings: React.FC<CombinedProps> = (props) => {
         >
           Delete
         </Button>
-        <Typography className={classes.spacing}>
-          Deleting a NodeBalancer will remove associated configurations.
-        </Typography>
       </Accordion>
-      <DeletionDialog
-        typeToConfirm
-        entity="NodeBalancer"
+      <ConfirmationDialog
+        title={`Delete NodeBalancer ${label}?`}
         open={isDeleteDialogOpen}
-        label={nodeBalancerLabel}
-        loading={isDeleting}
         error={
           deleteError && deleteError.length > 0
             ? getErrorStringOrDefault(
@@ -224,8 +240,17 @@ export const NodeBalancerSettings: React.FC<CombinedProps> = (props) => {
             : undefined
         }
         onClose={() => setIsDeleteDialogOpen(false)}
-        onDelete={handleDelete}
-      />
+        actions={actions}
+      >
+        <Notice warning className={classes.notice}>
+          Deleting this NodeBalancer is permanent and can’t be undone.
+        </Notice>
+        <Typography variant="body1">
+          Traffic will no longer be routed through this NodeBalancer. Please
+          check your DNS settings and either provide the IP address of another
+          active NodeBalancer, or route traffic directly to you Linode.
+        </Typography>
+      </ConfirmationDialog>
     </div>
   );
 };

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSettings/NodeBalancerSettings.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSettings/NodeBalancerSettings.tsx
@@ -45,6 +45,7 @@ export const NodeBalancerSettings: React.FC<CombinedProps> = (props) => {
   const {
     nodeBalancerId,
     nodeBalancerLabel,
+    nodeBalancerClientConnThrottle,
     nodeBalancerActions: { updateNodeBalancer, deleteNodeBalancer },
     updateNodeBalancerDetailState,
   } = props;
@@ -64,7 +65,7 @@ export const NodeBalancerSettings: React.FC<CombinedProps> = (props) => {
   );
 
   const [connectionThrottle, setConnectionThrottle] = React.useState<number>(
-    props.nodeBalancerClientConnThrottle
+    nodeBalancerClientConnThrottle
   );
   const [
     isConnectionThrottleSaving,
@@ -84,7 +85,7 @@ export const NodeBalancerSettings: React.FC<CombinedProps> = (props) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props]);
 
-  const onSaveUsername = () => {
+  const onSaveLabel = () => {
     setIsLabelSaving(true);
     setLabelError(undefined);
 
@@ -158,7 +159,7 @@ export const NodeBalancerSettings: React.FC<CombinedProps> = (props) => {
           className={classes.spacing}
           loading={isLabelSaving}
           disabled={label === nodeBalancerLabel}
-          onClick={onSaveUsername}
+          onClick={onSaveLabel}
           data-qa-label-save
         >
           Save


### PR DESCRIPTION
## Preview

![Screen Shot 2021-11-04 at 1 21 02 PM](https://user-images.githubusercontent.com/6440455/140388339-07223e78-f09d-477a-88a9-7b55300d69dd.png)

## Description

- Made NodeBalancer settings look more like Linode settings
- Adds the ability to delete a NodeBalancer from `/nodebalancers/{id}/settings`
  - Previously, this was only possible from the NodeBalancer Landing Table
- Also fixes a bug where the Breadcrumb label would not update when the label was changed on the settings tab
 
## How to test

- Try deleting a NodeBalancer from `/nodebalancers/{id}/settings`
- Ensure no other functionality was broken as a result of this work
