### PR TITLE
M3-5537: Table row height too high in Safari

### DIFF
--- a/packages/manager/src/components/InlineMenuAction/InlineMenuAction.tsx
+++ b/packages/manager/src/components/InlineMenuAction/InlineMenuAction.tsx
@@ -79,16 +79,14 @@ const InlineMenuAction: React.FC<CombinedProps> = (props) => {
         enterDelay={500}
         leaveDelay={0}
       >
-        <div>
-          <Button
-            className={`${className} ${classes.btnRoot}`}
-            onClick={onClick}
-            disabled={disabled}
-            loading={loading}
-          >
-            {actionText}
-          </Button>
-        </div>
+        <Button
+          className={`${className} ${classes.btnRoot}`}
+          onClick={onClick}
+          disabled={disabled}
+          loading={loading}
+        >
+          {actionText}
+        </Button>
       </Tooltip>
     );
   }


### PR DESCRIPTION
## Description

The inline menu actions on the LinodeLanding page were too short. Removing this unnecessary div allows the button to fill the height of the row.

## How to test

1. Open manager in Safari.
2. Navigate to the LinodesLanding page.
3. Ensure the `Power Off`, `Reboot`, and kabob menu should fill the row vertically when hovered over.
4. Repeat steps 1 through 3 in Chrome and Firefox.
