### PR TITLE
M3-5563: Update location of HA Cluster guide link

### DIFF
--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/HACheckbox.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/HACheckbox.tsx
@@ -11,7 +11,7 @@ export const HACopy = () => (
   <Typography>
     A high availability (HA) control plane is replicated on multiple master
     nodes to provide 99.99% uptime, and is recommended for production workloads.{' '}
-    <Link to="https://www.linode.com/docs/guides/kubernetes/">
+    <Link to="https://www.linode.com/docs/guides/enable-lke-high-availability/">
       Learn more about the HA control plane
     </Link>
     .

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
@@ -154,6 +154,13 @@ const useStyles = makeStyles((theme: Theme) => ({
     paddingLeft: theme.spacing(0.5),
     paddingRight: theme.spacing(0.5),
   },
+  actionRow: {
+    flexDirection: 'column',
+    [theme.breakpoints.down('md')]: {
+      justifyContent: 'flex-end',
+      flexDirection: 'row',
+    },
+  },
 }));
 
 interface Props {
@@ -482,13 +489,11 @@ export const KubeSummaryPanel: React.FunctionComponent<Props> = (props) => {
               direction="row"
               xs={12}
               lg={7}
-              className="foobar"
               justifyContent="flex-end"
             >
               <Grid
                 item
                 container
-                direction="column"
                 lg={12}
                 alignContent="flex-end"
                 style={matches ? { margin: 1 } : undefined}
@@ -497,7 +502,7 @@ export const KubeSummaryPanel: React.FunctionComponent<Props> = (props) => {
                   item
                   container
                   direction={matches ? 'row-reverse' : 'row'}
-                  justifyContent="flex-end"
+                  justifyContent={matches ? 'flex-start' : 'flex-end'}
                 >
                   {isClusterHighlyAvailable ? (
                     <Grid item>


### PR DESCRIPTION
## Description

Changes the location the link in the `HAClusterCheckbox` points to for information of HA Clusters in the guides.

## How to test

The link in the checkout summary that points to the HA Clusters guide should bring the user to the HA Cluster guide.

