### PR TITLE
Update speed test link to avoid redirect

### DIFF
--- a/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
+++ b/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
@@ -67,7 +67,7 @@ const SelectRegionPanel: React.FC<Props & WithStyles<ClassNames>> = (props) => {
             target="_blank"
             aria-describedby="external-site"
             rel="noopener noreferrer"
-            href="https://www.linode.com/speedtest"
+            href="https://www.linode.com/speed-test/"
           >
             Use our speedtest page
           </a>

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -113,7 +113,7 @@ const regionHelperText = (
       target="_blank"
       aria-describedby="external-site"
       rel="noopener noreferrer"
-      href="https://www.linode.com/speedtest"
+      href="https://www.linode.com/speed-test/"
       style={{ fontWeight: 600 }}
     >
       our speedtest page


### PR DESCRIPTION
## Description

**What does this PR do?**

This changes `linode.com/speedtest` to `linode.com/speed-test` to avoid an unnecessary redirect.
