### PR TITLE
M3-5565: Fix button order in the Add Linode to Firewall drawer

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddDeviceDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddDeviceDrawer.tsx
@@ -105,6 +105,9 @@ export const AddDeviceDrawer: React.FC<Props> = (props) => {
           filteredLinodes={currentDevices}
         />
         <ActionsPanel>
+          <Button buttonType="secondary" onClick={onClose} data-qa-cancel>
+            Cancel
+          </Button>
           <Button
             buttonType="primary"
             onClick={handleSubmit}
@@ -113,9 +116,6 @@ export const AddDeviceDrawer: React.FC<Props> = (props) => {
             data-qa-submit
           >
             Add
-          </Button>
-          <Button buttonType="secondary" onClick={onClose} data-qa-cancel>
-            Cancel
           </Button>
         </ActionsPanel>
       </form>

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallLinodesLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallLinodesLanding.tsx
@@ -34,7 +34,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     '&.MuiGrid-item': {
       paddingTop: 0,
     },
-    [theme.breakpoints.down('md')]: {
+    [theme.breakpoints.only('sm')]: {
       marginRight: theme.spacing(),
     },
   },

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallLinodesLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallLinodesLanding.tsx
@@ -160,7 +160,7 @@ const FirewallLinodesLanding: React.FC<CombinedProps> = (props) => {
         </Grid>
         <Grid item className={classes.actions}>
           <Button
-            buttonType="secondary"
+            buttonType="primary"
             disabled={disabled}
             onClick={() => setDeviceDrawerOpen(true)}
             compact


### PR DESCRIPTION
## Description

- Switched the order of buttons in the Add Linode to Firewall drawer so the primary button is on the right side
- Also made the action button on `/firewalls/{id}/linodes` `primary` instead of `secondary`

### Before
<img width="1078" alt="Screen Shot 2021-11-05 at 12 32 41 PM" src="https://user-images.githubusercontent.com/6440455/140546331-9e7cba87-ec54-49d0-b03d-c6c9d1248cd0.png">


<img width="1078" alt="Screen Shot 2021-11-05 at 12 39 08 PM" src="https://user-images.githubusercontent.com/6440455/140546520-cf1d02ac-247d-4083-b313-0fe9be9ea3ce.png">

### After
<img width="1078" alt="Screen Shot 2021-11-05 at 12 31 11 PM" src="https://user-images.githubusercontent.com/6440455/140546347-5953ad41-f83f-4373-8def-d75c2095b36f.png">

<img width="1078" alt="Screen Shot 2021-11-05 at 12 39 01 PM" src="https://user-images.githubusercontent.com/6440455/140546549-18155142-1e59-4680-8ff1-69329590fcee.png">

## How to test

- Go to `/firewalls/{id}/linodes`
  - Check button style
  - Open the drawer and check button order
