### PR TITLE
M3-5575: Updates to Payment Method Logic and UI

### DIFF
--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/AddPaymentMethodDrawer/AddCreditCardForm.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/AddPaymentMethodDrawer/AddCreditCardForm.tsx
@@ -11,7 +11,6 @@ import Notice from 'src/components/Notice';
 import { queryClient } from 'src/queries/base';
 import { CreditCardSchema } from '@linode/validation';
 import { handleAPIErrors } from 'src/utilities/formikErrorUtils';
-import CheckBox from 'src/components/CheckBox';
 import NumberFormat, { NumberFormatProps } from 'react-number-format';
 import { InputBaseComponentProps } from '@material-ui/core/InputBase/InputBase';
 import { parseExpiryYear } from 'src/utilities/creditCard';
@@ -28,7 +27,6 @@ const useStyles = makeStyles((theme: Theme) => ({
 interface Props {
   onClose: () => void;
   disabled: boolean;
-  hasNoPaymentMethods: boolean;
 }
 
 interface Values {
@@ -36,7 +34,6 @@ interface Values {
   expiry_month: string;
   expiry_year: string;
   cvv: string;
-  is_default: boolean;
   address: string;
   address2: string;
   city: string;
@@ -46,13 +43,13 @@ interface Values {
 }
 
 const AddCreditCardForm: React.FC<Props> = (props) => {
-  const { onClose, disabled, hasNoPaymentMethods } = props;
+  const { onClose, disabled } = props;
   const [error, setError] = React.useState<string>();
   const classes = useStyles();
   const { enqueueSnackbar } = useSnackbar();
 
   const addCreditCard = async (
-    { card_number, cvv, expiry_month, expiry_year, is_default }: Values,
+    { card_number, cvv, expiry_month, expiry_year }: Values,
     {
       setSubmitting,
       setFieldError,
@@ -67,7 +64,7 @@ const AddCreditCardForm: React.FC<Props> = (props) => {
     try {
       await addPaymentMethod({
         type: 'credit_card',
-        is_default,
+        is_default: true,
         data: {
           card_number,
           cvv,
@@ -108,7 +105,6 @@ const AddCreditCardForm: React.FC<Props> = (props) => {
       expiry_month: '',
       expiry_year: '',
       cvv: '',
-      is_default: true,
       address: '',
       address2: '',
       city: '',
@@ -122,6 +118,13 @@ const AddCreditCardForm: React.FC<Props> = (props) => {
 
   const disableInput = isSubmitting || disabled;
 
+  const disableAddButton =
+    disabled ||
+    !values.card_number ||
+    !values.expiry_month ||
+    !values.expiry_year ||
+    !values.cvv;
+
   return (
     <form onSubmit={handleSubmit}>
       {error && (
@@ -129,7 +132,7 @@ const AddCreditCardForm: React.FC<Props> = (props) => {
           <Notice error text={error} />
         </Grid>
       )}
-      <Grid container spacing={0}>
+      <Grid container spacing={1}>
         <Grid item xs={12}>
           <TextField
             name="card_number"
@@ -245,23 +248,21 @@ const AddCreditCardForm: React.FC<Props> = (props) => {
             errorText={errors.country}
             />
             */}
-          <CheckBox
-            text="Make Default"
-            checked={values.is_default}
-            onChange={() => setFieldValue('is_default', !values.is_default)}
-            disabled={disableInput || hasNoPaymentMethods}
-          />
         </Grid>
       </Grid>
       <ActionsPanel style={{ marginTop: 0 }}>
-        <Button onClick={onClose} buttonType="secondary" disabled={disabled}>
+        <Button
+          onClick={onClose}
+          buttonType="secondary"
+          disabled={disableInput}
+        >
           Cancel
         </Button>
         <Button
           type="submit"
           buttonType="primary"
           loading={isSubmitting}
-          disabled={disabled}
+          disabled={disableAddButton}
         >
           Add Credit Card
         </Button>

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/AddPaymentMethodDrawer/AddPaymentMethodDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/AddPaymentMethodDrawer/AddPaymentMethodDrawer.tsx
@@ -28,6 +28,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   root: {
     marginTop: 4,
+    marginBottom: 4,
   },
   progress: {
     marginBottom: 18,
@@ -153,13 +154,9 @@ export const AddPaymentMethodDrawer: React.FC<Props> = (props) => {
         </>
       ) : null}
       <>
-        <Divider spacingBottom={16} spacingTop={16} />
+        <Divider spacingBottom={16} />
         <Typography variant="h3">Credit Card</Typography>
-        <AddCreditCardForm
-          hasNoPaymentMethods={paymentMethods?.length === 0}
-          disabled={disabled}
-          onClose={onClose}
-        />
+        <AddCreditCardForm disabled={disabled} onClose={onClose} />
       </>
     </Drawer>
   );

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PayPalChip.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PayPalChip.tsx
@@ -9,7 +9,6 @@ import { addPaymentMethod } from '@linode/api-v4/lib/account/payments';
 import { useSnackbar } from 'notistack';
 import { APIError } from '@linode/api-v4/lib/types';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
-import { PaymentMethod } from '@linode/api-v4';
 import classNames from 'classnames';
 import { reportException } from 'src/exceptionReporting';
 import {
@@ -103,14 +102,10 @@ export const PayPalChip: React.FC<Props> = (props) => {
   };
 
   const onNonce = (nonce: string) => {
-    const paymentMethods = queryClient.getQueryData<PaymentMethod[]>(
-      `${accountPaymentKey}-all`
-    );
-
     addPaymentMethod({
       type: 'payment_method_nonce',
       data: { nonce },
-      is_default: paymentMethods?.length === 0,
+      is_default: true,
     })
       .then(() => {
         queryClient.invalidateQueries(`${accountPaymentKey}-all`);

--- a/packages/manager/src/features/Billing/Providers/GooglePay.ts
+++ b/packages/manager/src/features/Billing/Providers/GooglePay.ts
@@ -9,7 +9,6 @@ import { queryClient } from 'src/queries/base';
 import { queryKey as accountPaymentKey } from 'src/queries/accountPayment';
 import { queryKey as accountBillingKey } from 'src/queries/accountBilling';
 import { GPAY_CLIENT_ENV, GPAY_MERCHANT_ID } from 'src/constants';
-import { PaymentMethod } from '@linode/api-v4/lib/account';
 import { reportException } from 'src/exceptionReporting';
 
 const merchantInfo: google.payments.api.MerchantInfo = {
@@ -121,15 +120,10 @@ export const gPay = async (
         response.warnings
       );
     } else {
-      const paymentMethods = queryClient.getQueryData<PaymentMethod[]>(
-        `${accountPaymentKey}-all`
-      );
-
       await addPaymentMethod({
         type: 'payment_method_nonce',
         data: { nonce },
-        // Make Google Pay default if they have no payment methods upon add
-        is_default: paymentMethods?.length === 0,
+        is_default: true,
       });
       queryClient.invalidateQueries(`${accountPaymentKey}-all`);
       setMessage('Successfully added Google Pay', 'success');


### PR DESCRIPTION
## Description
![Screen Shot 2021-11-09 at 1 08 28 PM](https://user-images.githubusercontent.com/6440455/140980153-e6087ad8-d264-4241-b27e-36264698f2a8.png)

- Disabled the `Add Credit Card` button until the user enters all required credit card data
- Any new payment method becomes the default payment method (Users can change default payment method on the Billing page)
- In the Add Payment Method Drawer, the check box to make a credit card default is removed
- A new payment method is added to the bottom of the list of payment methods upon add
- Improves spacing in the Add Payment Method Drawer

## How to test

- Go to `/account/billing/add-payment-method`
- Ensure all items listed above are true