### PR TITLE
M3-5530: Add IPv6 ranges to IP Transfer modal

### DIFF
--- a/packages/api-v4/src/networking/networking.ts
+++ b/packages/api-v4/src/networking/networking.ts
@@ -83,8 +83,8 @@ export const allocateIp = (payload: any) =>
 
 /**
  * Assign multiple IPs to multiple Linodes in one Region. This allows swapping,
- * shuffling, or otherwise reorganizing IPv4 Addresses to your Linodes. When the
- * assignment is finished, all Linodes must end up with at least one public
+ * shuffling, or otherwise reorganizing IPv4 Addresses/IPv6 Ranges to your Linodes.
+ * When the assignment is finished, all Linodes must end up with at least one public
  * IPv4 and no more than one private IPv4.
  *
  * @param payload { Object }
@@ -95,7 +95,7 @@ export const allocateIp = (payload: any) =>
  */
 export const assignAddresses = (payload: IPAssignmentPayload) =>
   Request<{}>(
-    setURL(`${API_ROOT}/networking/ipv4/assign`),
+    setURL(`${API_ROOT}/networking/ips/assign`),
     setMethod('POST'),
     setData(payload, assignAddressesSchema)
   );

--- a/packages/manager/src/factories/linodes.ts
+++ b/packages/manager/src/factories/linodes.ts
@@ -100,7 +100,14 @@ export const linodeIPFactory = Factory.Sync.makeFactory<LinodeIPsResponse>({
       region: 'us-southeast',
       public: false,
     },
-    global: [],
+    global: [
+      {
+        prefix: 64,
+        range: '2600:3c02:e000:0201::',
+        region: 'us-southeast',
+        route_target: '2600:3c02::f03c:92ff:fe9d:0f25',
+      },
+    ],
   },
 });
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/IPTransfer.test.ts
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/IPTransfer.test.ts
@@ -1,6 +1,6 @@
-import { getLinodeIpv6Ranges } from './IPTransfer';
+import { getLinodeIPv6Ranges } from './IPTransfer';
 
-describe('getLinodeIpv6Ranges', () => {
+describe('getLinodeIPv6Ranges', () => {
   const ipv6Ranges = [
     {
       range: '2fff:db08:e003:1::',
@@ -24,15 +24,15 @@ describe('getLinodeIpv6Ranges', () => {
 
   it('returns an array of ranges', () => {
     expect(
-      getLinodeIpv6Ranges(ipv6Ranges, '2600:3c03::f03c:92ff:fe8d:5c0d/128')
+      getLinodeIPv6Ranges(ipv6Ranges, '2600:3c03::f03c:92ff:fe8d:5c0d/128')
     ).toEqual(['2fff:db08:e003:2::/64', '2fff:db08:e003:3::/56']);
   });
 
   it('returns an empty array if at least one argument is undefined or null', () => {
     expect(
-      getLinodeIpv6Ranges(undefined, '2600:3c03::f03c:92ff:fe8d:5b1b/128')
+      getLinodeIPv6Ranges(undefined, '2600:3c03::f03c:92ff:fe8d:5b1b/128')
     ).toEqual([]);
-    expect(getLinodeIpv6Ranges(ipv6Ranges, null)).toEqual([]);
-    expect(getLinodeIpv6Ranges(undefined, null)).toEqual([]);
+    expect(getLinodeIPv6Ranges(ipv6Ranges, null)).toEqual([]);
+    expect(getLinodeIPv6Ranges(undefined, null)).toEqual([]);
   });
 });

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/IPTransfer.test.ts
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/IPTransfer.test.ts
@@ -1,0 +1,38 @@
+import { getLinodeIpv6Ranges } from './IPTransfer';
+
+describe('getLinodeIpv6Ranges', () => {
+  const ipv6Ranges = [
+    {
+      range: '2fff:db08:e003:1::',
+      prefix: 64,
+      region: 'us-east',
+      route_target: '2600:3c03::f03c:92ff:fe8d:5c0c',
+    },
+    {
+      range: '2fff:db08:e003:2::',
+      prefix: 64,
+      region: 'us-east',
+      route_target: '2600:3c03::f03c:92ff:fe8d:5c0d',
+    },
+    {
+      range: '2fff:db08:e003:3::',
+      prefix: 56,
+      region: 'us-east',
+      route_target: '2600:3c03::f03c:92ff:fe8d:5c0d',
+    },
+  ];
+
+  it('returns an array of ranges', () => {
+    expect(
+      getLinodeIpv6Ranges(ipv6Ranges, '2600:3c03::f03c:92ff:fe8d:5c0d/128')
+    ).toEqual(['2fff:db08:e003:2::/64', '2fff:db08:e003:3::/56']);
+  });
+
+  it('returns an empty array if at least one argument is undefined or null', () => {
+    expect(
+      getLinodeIpv6Ranges(undefined, '2600:3c03::f03c:92ff:fe8d:5b1b/128')
+    ).toEqual([]);
+    expect(getLinodeIpv6Ranges(ipv6Ranges, null)).toEqual([]);
+    expect(getLinodeIpv6Ranges(undefined, null)).toEqual([]);
+  });
+});

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/IPTransfer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/IPTransfer.tsx
@@ -160,7 +160,11 @@ const LinodeNetworkingIPTransferPanel: React.FC<CombinedProps> = (props) => {
     open // only run the query if the modal is open
   );
 
-  const { data: ipv6RangesData } = useIpv6RangesQuery();
+  const {
+    data: ipv6RangesData,
+    isLoading: ipv6RangesLoading,
+    error: ipv6RangesError,
+  } = useIpv6RangesQuery();
 
   const linodes = Object.values(data?.linodes ?? []).filter(
     (l) => l.id !== linodeID
@@ -338,7 +342,7 @@ const LinodeNetworkingIPTransferPanel: React.FC<CombinedProps> = (props) => {
           label="Select Linode"
           hideLabel
           onInputChange={handleInputChange}
-          isLoading={isLoading}
+          isLoading={isLoading || ipv6RangesLoading}
           errorText={linodesError?.[0].reason}
           overflowPortal
         />
@@ -486,7 +490,10 @@ const LinodeNetworkingIPTransferPanel: React.FC<CombinedProps> = (props) => {
         </Typography>
       </Grid>
       <Grid item xs={12}>
-        {isLoading && searchText === '' ? (
+        {!isLoading && !ipv6RangesLoading && ipv6RangesError ? (
+          <Notice error text={'There was an error loading IPv6 Ranges'} />
+        ) : null}
+        {(isLoading || ipv6RangesLoading) && searchText === '' ? (
           <div className={classes.loading}>
             <CircleProgress mini />
           </div>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/IPTransfer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/IPTransfer.tsx
@@ -24,7 +24,7 @@ import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
 import usePrevious from 'src/hooks/usePrevious';
-import { queryKey } from 'src/queries/networking';
+import { ipv6RangeQueryKey } from 'src/queries/networking';
 import { queryClient } from 'src/queries/base';
 import { useLinodesQuery } from 'src/queries/linodes';
 import { useIpv6RangesQuery } from 'src/queries/networking';
@@ -121,7 +121,7 @@ const defaultState = (
   sourceIPsLinodeID,
 });
 
-export const getLinodeIpv6Ranges = (
+export const getLinodeIPv6Ranges = (
   ipv6RangesData: IPRange[] | undefined,
   ipv6: string | null
 ) => {
@@ -219,11 +219,11 @@ const LinodeNetworkingIPTransferPanel: React.FC<CombinedProps> = (props) => {
         compose(
           setSelectedIP(ip, firstLinode.ipv4[0]),
           updateSelectedLinodesIPs(ip, () => {
-            const linodeIpv6Ranges = getLinodeIpv6Ranges(
+            const linodeIPv6Ranges = getLinodeIPv6Ranges(
               ipv6RangesData?.data,
               firstLinode.ipv6
             );
-            return [...firstLinode.ipv4, ...linodeIpv6Ranges];
+            return [...firstLinode.ipv4, ...linodeIPv6Ranges];
           })
         )
       )
@@ -247,11 +247,11 @@ const LinodeNetworkingIPTransferPanel: React.FC<CombinedProps> = (props) => {
           updateSelectedLinodesIPs(ip, () => {
             const linode = linodes.find((l) => l.id === Number(e.value));
             if (linode) {
-              const linodeIpv6Ranges = getLinodeIpv6Ranges(
+              const linodeIPv6Ranges = getLinodeIPv6Ranges(
                 ipv6RangesData?.data,
                 linode?.ipv6
               );
-              return [...linode.ipv4, ...linodeIpv6Ranges];
+              return [...linode.ipv4, ...linodeIPv6Ranges];
             }
             return [];
           }),
@@ -438,7 +438,8 @@ const LinodeNetworkingIPTransferPanel: React.FC<CombinedProps> = (props) => {
             setSubmitting(false);
             setError(undefined);
             setSuccessMessage('IP transferred successfully.');
-            queryClient.invalidateQueries(queryKey);
+            // get updated route_target for ipv6 ranges
+            queryClient.invalidateQueries(ipv6RangeQueryKey);
           })
           .catch((err) => {
             setError(

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/IPTransfer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/IPTransfer.tsx
@@ -128,6 +128,7 @@ const LinodeNetworkingIPTransferPanel: React.FC<CombinedProps> = (props) => {
     readOnly,
   } = props;
   const classes = useStyles();
+  console.log(ipAddresses, props)
   const [ips, setIPs] = React.useState<IPRowState>(
     props.ipAddresses.reduce(
       (acc, ip) => ({
@@ -224,6 +225,7 @@ const LinodeNetworkingIPTransferPanel: React.FC<CombinedProps> = (props) => {
           /** We need to find the selected Linode's IPs and return the first. */
           updateSelectedIP(ip, () => {
             const linode = linodes.find((l) => l.id === Number(e.value));
+            console.log(linode)
             if (linode) {
               return linode.ipv4[0];
             }
@@ -325,6 +327,7 @@ const LinodeNetworkingIPTransferPanel: React.FC<CombinedProps> = (props) => {
   };
 
   const ipSelect = ({ sourceIP, selectedIP, selectedLinodesIPs }: Swap) => {
+    console.log(selectedLinodesIPs)
     const IPList = selectedLinodesIPs.map((ip) => {
       return { label: ip, value: ip };
     });

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
@@ -457,6 +457,11 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
     const sharedIPs = uniq<string>(
       pathOr([], ['ipv4', 'shared'], linodeIPs).map((i: IPAddress) => i.address)
     );
+    const globalIPs = uniq<string>(
+      pathOr([], ['ipv6', 'global'], linodeIPs).map(
+        (i: IPRange) => `${i.range}/${i.prefix}`
+      )
+    );
 
     return (
       <div>
@@ -527,7 +532,7 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
           linodeID={linodeID}
           linodeRegion={linodeRegion}
           refreshIPs={this.refreshIPs}
-          ipAddresses={[...publicIPs, ...privateIPs]}
+          ipAddresses={[...publicIPs, ...privateIPs, ...globalIPs]}
           readOnly={readOnly}
         />
 

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -706,6 +706,9 @@ export const handlers = [
   rest.post('*/networking/vlans', (req, res, ctx) => {
     return res(ctx.json({}));
   }),
+  rest.post('*/networking/ips/assign', (req, res, ctx) => {
+    return res(ctx.json({}));
+  }),
   rest.post('*/account/payments', (req, res, ctx) => {
     return res(ctx.json(creditPaymentResponseFactory.build()));
   }),

--- a/packages/manager/src/queries/networking.ts
+++ b/packages/manager/src/queries/networking.ts
@@ -3,11 +3,11 @@ import { APIError, ResourcePage } from '@linode/api-v4/lib/types';
 import { useQuery } from 'react-query';
 import { queryPresets } from './base';
 
-export const queryKey = 'networking-ipv6-ranges';
+export const ipv6RangeQueryKey = 'networking-ipv6-ranges';
 
 export const useIpv6RangesQuery = () => {
   return useQuery<ResourcePage<IPRange>, APIError[]>(
-    [queryKey],
+    [ipv6RangeQueryKey],
     () => getIPv6Ranges(),
     {
       ...queryPresets.oneTimeFetch,

--- a/packages/manager/src/queries/networking.ts
+++ b/packages/manager/src/queries/networking.ts
@@ -1,0 +1,16 @@
+import { getIPv6Ranges, IPRange } from '@linode/api-v4/lib/networking';
+import { APIError, ResourcePage } from '@linode/api-v4/lib/types';
+import { useQuery } from 'react-query';
+import { queryPresets } from './base';
+
+export const queryKey = 'networking-ipv6-ranges';
+
+export const useIpv6RangesQuery = () => {
+  return useQuery<ResourcePage<IPRange>, APIError[]>(
+    [queryKey],
+    () => getIPv6Ranges(),
+    {
+      ...queryPresets.oneTimeFetch,
+    }
+  );
+};


### PR DESCRIPTION
## Description
Add functionality to move/swap IPv6 Ranges in the IP Transfer Modal

## How to test
- On the dev env, go to `linodes/<linode_id>/networking`
    - Pick a Linode that already has an IPv6 Range, or add an IPv6 Range to a Linode (reach out for more details)
    - Pick a second Linode that has more than one public IPv4 address, or add an additional IPv4 address to a Linode (reach out for more details)
- Click on the `IP Transfer` button to open up the transfer modal
- You should see the IPv6 Range as a row in the modal and should be able to move or swap it to another Linode
    - To swap it with an IPv4 address, the Linode you're swapping with must have at least one public IP after assignment.
    - To swap it with another IPv6 range, your account needs to be able to have more than 1 max allowed IPv6 range, otherwise you'll get an error. This error is expected for now
- IPv4 moving/swapping should work as normal