### PR TITLE
M3-5576: Fix row height and extra spacing around ActionMenu in Safari

### DIFF
--- a/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.tsx
+++ b/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.tsx
@@ -23,6 +23,9 @@ export const useStyles = makeStyles((theme: Theme) => ({
   },
   actions: {
     marginLeft: 'auto',
+    '& button': {
+      margin: 0,
+    },
   },
   item: {
     display: 'flex',

--- a/packages/manager/src/components/TableCell/TableCell.tsx
+++ b/packages/manager/src/components/TableCell/TableCell.tsx
@@ -39,6 +39,17 @@ const useStyles = makeStyles((theme: Theme) => ({
   compact: {
     padding: 6,
   },
+  actionCell: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    height: 40,
+    padding: 0,
+    // Prevents Safari from adding margins to the ActionMenu button
+    '& > button': {
+      margin: 0,
+    },
+  },
 }));
 
 export interface Props extends TableCellProps {
@@ -51,6 +62,7 @@ export interface Props extends TableCellProps {
    */
   parentColumn?: string;
   compact?: boolean;
+  actionCell?: boolean;
 }
 
 type CombinedProps = Props;
@@ -58,7 +70,15 @@ type CombinedProps = Props;
 export const WrappedTableCell: React.FC<CombinedProps> = (props) => {
   const classes = useStyles();
 
-  const { className, parentColumn, noWrap, sortable, compact, ...rest } = props;
+  const {
+    className,
+    parentColumn,
+    noWrap,
+    sortable,
+    compact,
+    actionCell,
+    ...rest
+  } = props;
 
   return (
     <TableCell
@@ -67,6 +87,7 @@ export const WrappedTableCell: React.FC<CombinedProps> = (props) => {
         [classes.noWrap]: noWrap,
         [classes.sortable]: sortable,
         [classes.compact]: compact,
+        [classes.actionCell]: actionCell,
         // hide the cell at small breakpoints if it's empty with no parent column
         emptyCell: !parentColumn && !props.children,
       })}

--- a/packages/manager/src/features/Domains/DomainTableRow.tsx
+++ b/packages/manager/src/features/Domains/DomainTableRow.tsx
@@ -23,17 +23,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   statusCell: {
     whiteSpace: 'nowrap',
   },
-  actionCell: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'flex-end',
-    padding: 0,
-    /*
-    Explicitly stating this as the theme file is automatically adding padding to the last cell
-    We can remove once we make the full switch to CMR styling
-    */
-    paddingRight: '0 !important',
-  },
 }));
 
 type CombinedProps = Domain & Handlers;
@@ -86,8 +75,7 @@ const DomainTableRow: React.FC<CombinedProps> = (props) => {
           <DateTimeDisplay value={updated} />
         </TableCell>
       </Hidden>
-
-      <TableCell className={classes.actionCell}>
+      <TableCell actionCell>
         <ActionMenu
           domain={domain}
           onDisableOrEnable={onDisableOrEnable}

--- a/packages/manager/src/features/EntityTransfers/RenderTransferRow.tsx
+++ b/packages/manager/src/features/EntityTransfers/RenderTransferRow.tsx
@@ -62,10 +62,6 @@ const useStyles = makeStyles((theme: Theme) => ({
       width: '25%',
     },
   },
-  actionCell: {
-    padding: 0,
-    paddingRight: '0 !important',
-  },
   link: {
     ...theme.applyLinkStyles,
     fontSize: '0.875rem',
@@ -159,7 +155,7 @@ export const RenderTransferRow: React.FC<CombinedProps> = (props) => {
           >
             <DateTimeDisplay value={expiry ?? ''} />
           </TableCell>
-          <TableCell className={classes.actionCell}>
+          <TableCell actionCell>
             <ActionMenu
               onCancelClick={() =>
                 handleCancelPendingTransferClick(token, entities)

--- a/packages/manager/src/features/EntityTransfers/TransfersTable.tsx
+++ b/packages/manager/src/features/EntityTransfers/TransfersTable.tsx
@@ -35,10 +35,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   cellContents: {
     paddingLeft: '1rem',
   },
-  actionCell: {
-    padding: 0,
-    paddingRight: '0 !important',
-  },
   link: {
     ...theme.applyLinkStyles,
     fontSize: '0.875rem',

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallDeviceRow.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/FirewallDeviceRow.tsx
@@ -1,21 +1,10 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { makeStyles } from 'src/components/core/styles';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import ActionMenu, { Props as ActionProps } from './FirewallDeviceActionMenu';
 
-const useStyles = makeStyles(() => ({
-  actionCell: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'flex-end',
-    padding: 0,
-  },
-}));
-
 export const FirewallDeviceRow: React.FC<ActionProps> = (props) => {
-  const classes = useStyles();
   const { deviceLabel, deviceID, deviceEntityID } = props;
 
   return (
@@ -28,7 +17,7 @@ export const FirewallDeviceRow: React.FC<ActionProps> = (props) => {
           {deviceLabel}
         </Link>
       </TableCell>
-      <TableCell className={classes.actionCell}>
+      <TableCell actionCell>
         <ActionMenu {...props} />
       </TableCell>
     </TableRow>

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -79,12 +79,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     paddingLeft: 6,
     whiteSpace: 'nowrap',
   },
-  actionCell: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'flex-end',
-    padding: 0,
-  },
   table: {
     backgroundColor: theme.color.border3,
   },
@@ -384,7 +378,7 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
         </Hidden>
 
         <TableCell>{capitalize(action?.toLocaleLowerCase() ?? '')}</TableCell>
-        <TableCell className={classes.actionCell}>
+        <TableCell actionCell>
           {status !== 'NOT_MODIFIED' ? (
             <div className={classes.undoButtonContainer}>
               <button

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallRow.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallRow.tsx
@@ -29,14 +29,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     alignItems: 'center',
     whiteSpace: 'nowrap',
   },
-  actionCell: {
-    display: 'flex',
-    justifyContent: 'flex-end',
-    padding: 0,
-    '&.MuiTableCell-root': {
-      paddingRight: 0,
-    },
-  },
 }));
 
 export type CombinedProps = Firewall & ActionHandlers;
@@ -91,7 +83,7 @@ export const FirewallRow: React.FC<CombinedProps> = (props) => {
           {getLinodesCellString(devices, loading, error.read)}
         </TableCell>
       </Hidden>
-      <TableCell className={classes.actionCell}>
+      <TableCell actionCell>
         <ActionMenu
           firewallID={id}
           firewallLabel={label}

--- a/packages/manager/src/features/Images/ImageRow.tsx
+++ b/packages/manager/src/features/Images/ImageRow.tsx
@@ -2,20 +2,12 @@ import { Event } from '@linode/api-v4/lib/account';
 import { Image } from '@linode/api-v4/lib/images';
 import * as React from 'react';
 import Hidden from 'src/components/core/Hidden';
-import { makeStyles } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import { capitalizeAllWords } from 'src/utilities/capitalize';
 import { formatDate } from 'src/utilities/formatDate';
 import ActionMenu, { Handlers } from './ImagesActionMenu';
-
-const useStyles = makeStyles(() => ({
-  actionMenu: {
-    display: 'flex',
-    justifyContent: 'flex-end',
-  },
-}));
 
 export interface ImageWithEvent extends Image {
   event?: Event;
@@ -24,8 +16,6 @@ export interface ImageWithEvent extends Image {
 type CombinedProps = Handlers & ImageWithEvent;
 
 const ImageRow: React.FC<CombinedProps> = (props) => {
-  const classes = useStyles();
-
   const {
     created,
     description,
@@ -89,7 +79,7 @@ const ImageRow: React.FC<CombinedProps> = (props) => {
           <TableCell data-qa-image-date>{formatDate(expiry)}</TableCell>
         ) : null}
       </Hidden>
-      <TableCell className={classes.actionMenu}>
+      <TableCell actionCell>
         {event?.status !== 'failed' ? (
           <ActionMenu
             id={id}

--- a/packages/manager/src/features/Kubernetes/ClusterList/ClusterRow.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/ClusterRow.tsx
@@ -32,17 +32,6 @@ const useStyles = makeStyles((theme: Theme) => ({
       display: 'none',
     },
   },
-  actionCell: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'flex-end',
-    padding: 0,
-    /*
-      Explicitly stating this as the theme file is automatically adding padding to the last cell
-      We can remove once we make the full switch to CMR styling
-      */
-    paddingRight: '0 !important',
-  },
   chip: {
     fontSize: '0.65rem',
     textTransform: 'uppercase',
@@ -135,7 +124,7 @@ export const ClusterRow: React.FunctionComponent<CombinedProps> = (props) => {
           {`${cluster.totalCPU} ${cluster.totalCPU === 1 ? 'CPU' : 'CPUs'}`}
         </TableCell>
       </Hidden>
-      <TableCell className={classes.actionCell}>
+      <TableCell actionCell>
         <ActionMenu
           clusterId={cluster.id}
           clusterLabel={cluster.label}

--- a/packages/manager/src/features/Managed/Contacts/ContactsRow.tsx
+++ b/packages/manager/src/features/Managed/Contacts/ContactsRow.tsx
@@ -1,19 +1,9 @@
 import { ManagedContact } from '@linode/api-v4/lib/managed';
 import * as React from 'react';
 import Hidden from 'src/components/core/Hidden';
-import { makeStyles } from 'src/components/core/styles';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import ActionMenu from './ContactsActionMenu';
-
-const useStyles = makeStyles(() => ({
-  actionCell: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'flex-end',
-    padding: 0,
-  },
-}));
 
 interface Props {
   contact: ManagedContact;
@@ -23,8 +13,6 @@ interface Props {
 }
 
 export const ContactsRow: React.FunctionComponent<Props> = (props) => {
-  const classes = useStyles();
-
   const { contact, updateOrAdd, openDrawer, openDialog } = props;
 
   return (
@@ -38,7 +26,7 @@ export const ContactsRow: React.FunctionComponent<Props> = (props) => {
         <TableCell>{contact.phone.primary}</TableCell>
         <TableCell>{contact.phone.secondary}</TableCell>
       </Hidden>
-      <TableCell className={classes.actionCell}>
+      <TableCell actionCell>
         <ActionMenu
           contactId={contact.id}
           updateOrAdd={updateOrAdd}

--- a/packages/manager/src/features/Managed/Credentials/CredentialList.tsx
+++ b/packages/manager/src/features/Managed/Credentials/CredentialList.tsx
@@ -57,11 +57,6 @@ const useStyles = makeStyles((theme: Theme) => ({
       marginRight: theme.spacing(),
     },
   },
-  actionCell: {
-    '&.emptyCell': {
-      fontSize: '0.875em !important',
-    },
-  },
 }));
 
 interface Props {
@@ -272,7 +267,7 @@ export const CredentialList: React.FC<CombinedProps> = (props) => {
                       >
                         Last Decrypted
                       </TableSortCell>
-                      <TableCell className={classes.actionCell} />
+                      <TableCell />
                     </TableRow>
                   </TableHead>
                   <TableBody>

--- a/packages/manager/src/features/Managed/Monitors/MonitorRow.tsx
+++ b/packages/manager/src/features/Managed/Monitors/MonitorRow.tsx
@@ -35,12 +35,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   errorStatus: {
     color: theme.color.red,
   },
-  actionCell: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'flex-end',
-    padding: 0,
-  },
 }));
 
 interface Props {
@@ -119,7 +113,7 @@ export const MonitorRow: React.FunctionComponent<CombinedProps> = (props) => {
       <TableCell data-qa-monitor-resource>
         <Typography>{monitor.address}</Typography>
       </TableCell>
-      <TableCell className={classes.actionCell}>
+      <TableCell actionCell>
         <ActionMenu
           status={monitor.status}
           monitorID={monitor.id}

--- a/packages/manager/src/features/Managed/SSHAccess/SSHAccessRow.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/SSHAccessRow.tsx
@@ -1,19 +1,9 @@
 import { ManagedLinodeSetting } from '@linode/api-v4/lib/managed';
 import * as React from 'react';
 import Hidden from 'src/components/core/Hidden';
-import { makeStyles } from 'src/components/core/styles';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import ActionMenu from './SSHAccessActionMenu';
-
-const useStyles = makeStyles(() => ({
-  actionCell: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'flex-end',
-    padding: 0,
-  },
-}));
 
 interface Props {
   linodeSetting: ManagedLinodeSetting;
@@ -22,8 +12,6 @@ interface Props {
 }
 
 export const SSHAccessRow: React.FunctionComponent<Props> = (props) => {
-  const classes = useStyles();
-
   const { linodeSetting, updateOne, openDrawer } = props;
 
   const isAccessEnabled = linodeSetting.ssh.access;
@@ -46,7 +34,7 @@ export const SSHAccessRow: React.FunctionComponent<Props> = (props) => {
         </TableCell>
         <TableCell data-qa-managed-port>{linodeSetting.ssh.port}</TableCell>
       </Hidden>
-      <TableCell className={classes.actionCell}>
+      <TableCell actionCell>
         <ActionMenu
           linodeId={linodeSetting.id}
           isEnabled={isAccessEnabled}

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancerTableRow.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancerTableRow.tsx
@@ -41,18 +41,6 @@ const useStyles = makeStyles((theme: Theme) => ({
       opacity: 0,
     },
   },
-  actionCell: {
-    // @todo: remove action cell duplication (this is from DomainTableRow)
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'flex-end',
-    padding: 0,
-    /*
-      Explicitly stating this as the theme file is automatically adding padding to the last cell
-      We can remove once we make the full switch to CMR styling
-      */
-    paddingRight: '0 !important',
-  },
   row: {
     '&:hover': {
       '& [data-qa-copy-ip]': {
@@ -137,7 +125,7 @@ const NodeBalancerTableRow: React.FC<CombinedProps> = (props) => {
         </TableCell>
       </Hidden>
 
-      <TableCell className={classes.actionCell}>
+      <TableCell actionCell>
         <NodeBalancerActionMenu
           nodeBalancerId={id}
           toggleDialog={toggleDialog}

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableRow.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableRow.tsx
@@ -22,12 +22,6 @@ const useStyles = makeStyles((theme: Theme) => ({
       fill: theme.bg.lightBlue,
     },
   },
-  actionCell: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'flex-end',
-    padding: 0,
-  },
   objectNameButton: {
     ...theme.applyLinkStyles,
     color: theme.cmrTextColors.linkActiveLight,
@@ -93,7 +87,7 @@ const ObjectTableRow: React.FC<Props> = (props) => {
           <DateTimeDisplay value={objectLastModified} />
         </TableCell>
       </Hidden>
-      <TableCell className={classes.actionCell}>
+      <TableCell actionCell>
         <ObjectActionMenu
           handleClickDownload={handleClickDownload}
           handleClickDelete={handleClickDelete}

--- a/packages/manager/src/features/Profile/APITokens/APITokenTable.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokenTable.tsx
@@ -1,3 +1,4 @@
+import { Account } from '@linode/api-v4/lib';
 import {
   createPersonalAccessToken,
   deleteAppToken,
@@ -7,12 +8,10 @@ import {
   Token,
   updatePersonalAccessToken,
 } from '@linode/api-v4/lib/profile';
-import { Account } from '@linode/api-v4/lib';
 import { APIError } from '@linode/api-v4/lib/types';
 import { DateTime } from 'luxon';
 import * as React from 'react';
 import { compose } from 'recompose';
-import SecretTokenDialog from 'src/features/Profile/SecretTokenDialog';
 import ActionsPanel from 'src/components/ActionsPanel';
 import AddNewLink from 'src/components/AddNewLink';
 import Button from 'src/components/Button';
@@ -37,6 +36,7 @@ import TableRowEmptyState from 'src/components/TableRowEmptyState';
 import TableRowError from 'src/components/TableRowError';
 import TableRowLoading from 'src/components/TableRowLoading';
 import TableSortCell from 'src/components/TableSortCell';
+import SecretTokenDialog from 'src/features/Profile/SecretTokenDialog';
 import { queryClient } from 'src/queries/base';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import isPast from 'src/utilities/isPast';
@@ -50,9 +50,7 @@ type ClassNames =
   | 'headline'
   | 'tokens'
   | 'addNewWrapper'
-  | 'addNewLink'
-  | 'labelCell'
-  | 'actionMenu';
+  | 'labelCell';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -77,10 +75,6 @@ const styles = (theme: Theme) =>
       [theme.breakpoints.down('md')]: {
         width: '25%',
       },
-    },
-    actionMenu: {
-      display: 'flex',
-      justifyContent: 'flex-end',
     },
   });
 
@@ -478,7 +472,7 @@ export class APITokenTable extends React.Component<CombinedProps, State> {
   }
 
   renderRows(tokens: Token[]) {
-    const { classes, title, type } = this.props;
+    const { title, type } = this.props;
 
     return tokens.map((token: Token) => (
       <TableRow
@@ -515,7 +509,7 @@ export class APITokenTable extends React.Component<CombinedProps, State> {
             }
           </Typography>
         </TableCell>
-        <TableCell className={classes.actionMenu}>
+        <TableCell actionCell>
           <APITokenMenu
             token={token}
             type={type}

--- a/packages/manager/src/features/Profile/APITokens/APITokens.test.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokens.test.tsx
@@ -26,9 +26,7 @@ describe('APITokens', () => {
           headline: '',
           tokens: '',
           addNewWrapper: '',
-          addNewLink: '',
           labelCell: '',
-          actionMenu: '',
         }}
         title="Personal Access Tokens"
         type="Personal Access Token"

--- a/packages/manager/src/features/Profile/OAuthClients/OAuthClients.test.tsx
+++ b/packages/manager/src/features/Profile/OAuthClients/OAuthClients.test.tsx
@@ -37,7 +37,7 @@ describe('OAuth Clients', () => {
   beforeEach(() => {
     wrapper = shallow(
       <OAuthClients
-        classes={{ root: '', addNewWrapper: '', actionCell: '' }}
+        classes={{ root: '', addNewWrapper: '' }}
         {...pageyProps}
         data={mockData}
         setDocs={setDocs}

--- a/packages/manager/src/features/Profile/OAuthClients/OAuthClients.tsx
+++ b/packages/manager/src/features/Profile/OAuthClients/OAuthClients.tsx
@@ -38,7 +38,7 @@ import Modals from './Modals';
 import ActionMenu from './OAuthClientActionMenu';
 import OAuthFormDrawer from './OAuthFormDrawer';
 
-type ClassNames = 'root' | 'addNewWrapper' | 'actionCell';
+type ClassNames = 'root' | 'addNewWrapper';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -53,10 +53,6 @@ const styles = (theme: Theme) =>
       [theme.breakpoints.down('sm')]: {
         marginRight: theme.spacing(),
       },
-    },
-    actionCell: {
-      display: 'flex',
-      justifyContent: 'flex-end',
     },
   });
 
@@ -319,8 +315,6 @@ export class OAuthClients extends React.Component<CombinedProps, State> {
   };
 
   renderRows = (data: OAuthClient[]) => {
-    const { classes } = this.props;
-
     return data.map(({ id, label, redirect_uri, public: isPublic }) => (
       <TableRow ariaLabel={label} key={id} data-qa-table-row={label}>
         <TableCell data-qa-oauth-label>{label}</TableCell>
@@ -333,7 +327,7 @@ export class OAuthClients extends React.Component<CombinedProps, State> {
         <Hidden xsDown>
           <TableCell data-qa-oauth-callback>{redirect_uri}</TableCell>
         </Hidden>
-        <TableCell className={classes.actionCell}>
+        <TableCell actionCell>
           <ActionMenu
             openSecretModal={this.openSecretModal}
             openDeleteModal={this.openDeleteModal}

--- a/packages/manager/src/features/Profile/SSHKeys/SSHKeys.test.tsx
+++ b/packages/manager/src/features/Profile/SSHKeys/SSHKeys.test.tsx
@@ -18,7 +18,6 @@ describe('SSHKeys', () => {
           sshKeysHeader: '',
           addNewWrapper: '',
           createdCell: '',
-          actionCell: '',
         }}
         data={[
           { id: 1, label: '', ssh_key: '', created: '', fingerprint: '' },
@@ -60,7 +59,6 @@ describe('SSHKeys', () => {
           sshKeysHeader: '',
           addNewWrapper: '',
           createdCell: '',
-          actionCell: '',
         }}
         data={undefined}
         loading={true}
@@ -79,7 +77,6 @@ describe('SSHKeys', () => {
           sshKeysHeader: '',
           addNewWrapper: '',
           createdCell: '',
-          actionCell: '',
         }}
         data={undefined}
         error={[{ reason: 'error here' }]}
@@ -98,7 +95,6 @@ describe('SSHKeys', () => {
           sshKeysHeader: '',
           addNewWrapper: '',
           createdCell: '',
-          actionCell: '',
         }}
         data={undefined}
         timezone={'GMT'}

--- a/packages/manager/src/features/Profile/SSHKeys/SSHKeys.tsx
+++ b/packages/manager/src/features/Profile/SSHKeys/SSHKeys.tsx
@@ -29,11 +29,7 @@ import { parseAPIDate } from 'src/utilities/date';
 import fingerprint from 'src/utilities/ssh-fingerprint';
 import SSHKeyCreationDrawer from './SSHKeyCreationDrawer';
 
-type ClassNames =
-  | 'sshKeysHeader'
-  | 'addNewWrapper'
-  | 'createdCell'
-  | 'actionCell';
+type ClassNames = 'sshKeysHeader' | 'addNewWrapper' | 'createdCell';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -52,9 +48,6 @@ const styles = (theme: Theme) =>
     },
     createdCell: {
       width: '16%',
-    },
-    actionCell: {
-      textAlign: 'right',
     },
   });
 
@@ -214,7 +207,7 @@ export class SSHKeys extends React.Component<CombinedProps, State> {
             {key.created}
           </TableCell>
         </Hidden>
-        <TableCell className={classes.actionCell}>
+        <TableCell actionCell>
           <SSHKeyActionMenu
             id={key.id}
             label={key.label}

--- a/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptActionMenu.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptActionMenu.tsx
@@ -3,23 +3,10 @@ import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
 import ActionMenu, { Action } from 'src/components/ActionMenu';
 import Hidden from 'src/components/core/Hidden';
-import {
-  makeStyles,
-  Theme,
-  useMediaQuery,
-  useTheme,
-} from 'src/components/core/styles';
+import { Theme, useMediaQuery, useTheme } from 'src/components/core/styles';
 import InlineMenuAction from 'src/components/InlineMenuAction';
 import { useProfile } from 'src/queries/profile';
 import { getStackScriptUrl, StackScriptCategory } from '../stackScriptUtils';
-
-const useStyles = makeStyles(() => ({
-  stackScriptActionsWrapper: {
-    display: 'flex',
-    justifyContent: 'flex-end',
-    alignItems: 'center',
-  },
-}));
 
 interface Props {
   stackScriptID: number;
@@ -41,7 +28,6 @@ interface Props {
 type CombinedProps = Props & RouteComponentProps<{}>;
 
 const StackScriptActionMenu: React.FC<CombinedProps> = (props) => {
-  const classes = useStyles();
   const theme = useTheme<Theme>();
   const matchesSmDown = useMediaQuery(theme.breakpoints.down('sm'));
   const { data: profile } = useProfile();
@@ -118,7 +104,8 @@ const StackScriptActionMenu: React.FC<CombinedProps> = (props) => {
   ].filter(Boolean) as Action[];
 
   return (
-    <div className={classes.stackScriptActionsWrapper}>
+    // eslint-disable-next-line react/jsx-no-useless-fragment
+    <>
       {category === 'account' || matchesSmDown ? (
         <ActionMenu
           actionsList={actions}
@@ -138,7 +125,7 @@ const StackScriptActionMenu: React.FC<CombinedProps> = (props) => {
           })}
         </Hidden>
       )}
-    </div>
+    </>
   );
 };
 

--- a/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptRow.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptRow.tsx
@@ -106,7 +106,7 @@ export const StackScriptRow: React.FC<CombinedProps> = (props) => {
           </TableCell>
         </Hidden>
       )}
-      <TableCell>
+      <TableCell actionCell>
         <StackScriptsActionMenu
           stackScriptID={stackScriptID}
           stackScriptUsername={stackScriptUsername}

--- a/packages/manager/src/features/Users/UsersLanding.tsx
+++ b/packages/manager/src/features/Users/UsersLanding.tsx
@@ -76,17 +76,6 @@ const useStyles = makeStyles((theme: Theme) => ({
       height: 40,
     },
   },
-  actionCell: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'flex-end',
-    padding: 0,
-    /*
-      Explicitly stating this as the theme file is automatically adding padding to the last cell
-      We can remove once we make the full switch to CMR styling
-      */
-    paddingRight: '0 !important',
-  },
 }));
 
 interface Props {
@@ -194,7 +183,7 @@ const UsersLanding: React.FC<Props> = (props) => {
         <TableCell data-qa-user-restriction>
           {user.restricted ? 'Limited' : 'Full'}
         </TableCell>
-        <TableCell className={classes.actionCell}>
+        <TableCell actionCell>
           <ActionMenu username={user.username} onDelete={onUsernameDelete} />
         </TableCell>
       </TableRow>

--- a/packages/manager/src/features/Volumes/VolumeTableRow.tsx
+++ b/packages/manager/src/features/Volumes/VolumeTableRow.tsx
@@ -25,17 +25,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     width: '35%',
     wordBreak: 'break-all',
   },
-  actionCell: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'flex-end',
-    padding: 0,
-    /*
-      Explicitly stating this as the theme file is automatically adding padding to the last cell
-      We can remove once we make the full switch to CMR styling
-      */
-    paddingRight: '0 !important',
-  },
   chipWrapper: {
     alignSelf: 'center',
   },
@@ -226,35 +215,33 @@ export const VolumeTableRow: React.FC<CombinedProps> = (props) => {
           )}
         </TableCell>
       )}
-      <TableCell>
-        <div className={classes.actionCell}>
-          <VolumesActionMenu
-            onShowConfig={openForConfig}
-            filesystemPath={filesystemPath}
-            linodeLabel={linodeLabel || ''}
-            regionID={region}
-            volumeId={id}
-            volumeTags={tags}
-            size={size}
-            label={label}
-            onEdit={openForEdit}
-            onResize={openForResize}
-            onClone={openForClone}
-            volumeLabel={label}
-            /**
-             * This is a safer check than linode_id (see logic in addAttachedLinodeInfoToVolume() from VolumesLanding)
-             * as it actually checks to see if the Linode exists before adding linodeLabel and linodeStatus.
-             * This avoids a bug (M3-2534) where a Volume attached to a just-deleted Linode
-             * could sometimes get tagged as "attached" here.
-             */
-            attached={Boolean(linodeLabel)}
-            isVolumesLanding={isVolumesLanding} // Passing this down to govern logic re: showing Attach or Detach in action menu.
-            onAttach={handleAttach}
-            onDetach={handleDetach}
-            poweredOff={linodeStatus === 'offline'}
-            onDelete={handleDelete}
-          />
-        </div>
+      <TableCell actionCell>
+        <VolumesActionMenu
+          onShowConfig={openForConfig}
+          filesystemPath={filesystemPath}
+          linodeLabel={linodeLabel || ''}
+          regionID={region}
+          volumeId={id}
+          volumeTags={tags}
+          size={size}
+          label={label}
+          onEdit={openForEdit}
+          onResize={openForResize}
+          onClone={openForClone}
+          volumeLabel={label}
+          /**
+           * This is a safer check than linode_id (see logic in addAttachedLinodeInfoToVolume() from VolumesLanding)
+           * as it actually checks to see if the Linode exists before adding linodeLabel and linodeStatus.
+           * This avoids a bug (M3-2534) where a Volume attached to a just-deleted Linode
+           * could sometimes get tagged as "attached" here.
+           */
+          attached={Boolean(linodeLabel)}
+          isVolumesLanding={isVolumesLanding} // Passing this down to govern logic re: showing Attach or Detach in action menu.
+          onAttach={handleAttach}
+          onDetach={handleDetach}
+          poweredOff={linodeStatus === 'offline'}
+          onDelete={handleDelete}
+        />
       </TableCell>
     </TableRow>
   );

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/BackupTableRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/BackupTableRow.tsx
@@ -1,7 +1,6 @@
 import { LinodeBackup } from '@linode/api-v4/lib/linodes';
 import { Duration } from 'luxon';
 import * as React from 'react';
-import { makeStyles } from 'src/components/core/styles';
 import DateTimeDisplay from 'src/components/DateTimeDisplay';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
@@ -9,16 +8,6 @@ import { parseAPIDate } from 'src/utilities/date';
 import { formatDuration } from 'src/utilities/formatDuration';
 import LinodeBackupActionMenu from './LinodeBackupActionMenu';
 
-const useStyles = makeStyles(() => ({
-  actionCell: {
-    display: 'flex',
-    justifyContent: 'flex-end',
-    padding: 0,
-    '&.MuiTableCell-root': {
-      paddingRight: 0,
-    },
-  },
-}));
 interface Props {
   backup: LinodeBackup;
   disabled: boolean;
@@ -32,7 +21,6 @@ const typeMap = {
 };
 
 const BackupTableRow: React.FC<Props> = (props) => {
-  const classes = useStyles();
   const { backup, disabled, handleRestore } = props;
 
   const onDeploy = () => {
@@ -69,7 +57,7 @@ const BackupTableRow: React.FC<Props> = (props) => {
       <TableCell parentColumn="Space Required" data-qa-space-required>
         {backup.disks.reduce((acc, disk) => acc + disk.size, 0)} MB
       </TableCell>
-      <TableCell className={classes.actionCell}>
+      <TableCell actionCell>
         <LinodeBackupActionMenu
           backup={backup}
           disabled={disabled}

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.style.ts
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.style.ts
@@ -9,8 +9,6 @@ import {
 export type StyleProps = WithStyles<ClassNames> & WithTheme;
 
 type ClassNames =
-  | 'actionCell'
-  | 'actionInner'
   | 'bodyRow'
   | 'status'
   | 'statusCell'
@@ -28,27 +26,6 @@ type ClassNames =
 
 const styles = (theme: Theme) =>
   createStyles({
-    actionCell: {
-      paddingTop: 0,
-      paddingBottom: 0,
-      paddingLeft: 0,
-      width: '22%',
-      textAlign: 'right',
-      '&:last-child': {
-        paddingRight: 0,
-      },
-      [theme.breakpoints.down('sm')]: {
-        width: '5%',
-      },
-    },
-    actionInner: {
-      display: 'flex',
-      justifyContent: 'flex-end',
-      marginRight: 1,
-      '& a': {
-        lineHeight: '1rem',
-      },
-    },
     bodyRow: {
       height: 'auto',
       '&:hover': {

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
@@ -233,25 +233,23 @@ export const LinodeRow: React.FC<CombinedProps> = (props) => {
         />
       </Hidden>
 
-      <TableCell className={classes.actionCell} data-qa-notifications>
-        <div className={classes.actionInner}>
-          <RenderFlag
-            mutationAvailable={mutationAvailable}
-            linodeNotifications={linodeNotifications}
-            classes={classes}
-          />
-          <LinodeActionMenu
-            linodeId={id}
-            linodeLabel={label}
-            linodeRegion={region}
-            linodeType={type}
-            linodeStatus={status}
-            linodeBackups={backups}
-            openDialog={openDialog}
-            openPowerActionDialog={openPowerActionDialog}
-            inTableContext
-          />
-        </div>
+      <TableCell actionCell data-qa-notifications>
+        <RenderFlag
+          mutationAvailable={mutationAvailable}
+          linodeNotifications={linodeNotifications}
+          classes={classes}
+        />
+        <LinodeActionMenu
+          linodeId={id}
+          linodeLabel={label}
+          linodeRegion={region}
+          linodeType={type}
+          linodeStatus={status}
+          linodeBackups={backups}
+          openDialog={openDialog}
+          openPowerActionDialog={openPowerActionDialog}
+          inTableContext
+        />
       </TableCell>
     </TableRow>
   );

--- a/packages/manager/src/features/linodes/LinodesLanding/SortableTableHead.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/SortableTableHead.tsx
@@ -71,15 +71,6 @@ const useStyles = makeStyles((theme: Theme) => ({
       width: '18%',
     },
   },
-  actionCell: {
-    width: '16%',
-    [theme.breakpoints.only('md')]: {
-      width: '10%',
-    },
-    [theme.breakpoints.down('sm')]: {
-      width: '12%',
-    },
-  },
 }));
 
 interface Props {
@@ -190,7 +181,7 @@ const SortableTableHead: React.FC<CombinedProps> = (props) => {
             </Hidden>
           </>
         )}
-        <TableCell className={classes.actionCell}>
+        <TableCell>
           <div className={classes.controlHeader}>
             <div id="displayViewDescription" className="visually-hidden">
               Currently in {linodeViewPreference} view

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -1268,17 +1268,9 @@ const themeDefaults: ThemeDefaults = () => {
       },
       MuiTableCell: {
         root: {
-          padding: 10,
           borderTop: `1px solid ${primaryColors.divider}`,
           borderBottom: `1px solid ${primaryColors.divider}`,
-          '&:last-child': {
-            paddingRight: 10,
-          },
-          '& .action-menu': {
-            [breakpoints.down('sm')]: {
-              width: '100%',
-            },
-          },
+          padding: 10,
         },
         head: {
           fontSize: '.9rem',


### PR DESCRIPTION
## Description

The `InlineMenuAction` and `ActionMenu` components weren't fully extending to the entire row height in Safari for certain entities (ie. Volumes and Images). This seems to be related to having an extra `div` inside the `TableCell` and applying the styling on that `div`. 

In order to make things more consistent and prevent having to copy and paste the styles for each `ActionMenu`, I created a `TableCell` variant that cleans up the code.

## How to test

Check the `ActionMenu`'s throughout the app on Chrome **and** Safari.