### PR TITLE
M3-5535: Handle IPv6 events language

### DIFF
--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -302,6 +302,12 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
   ipaddress_update: {
     notification: (e) => `An IP address has been updated on your account.`,
   },
+  ipv6pool_add: {
+    notification: (e) => 'An IPv6 range has been added on your account.',
+  },
+  ipv6pool_delete: {
+    notification: (e) => 'An IPv6 range has been deleted on your account.',
+  },
   lish_boot: {
     scheduled: (e) =>
       `Linode ${

--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -303,10 +303,10 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
     notification: (e) => `An IP address has been updated on your account.`,
   },
   ipv6pool_add: {
-    notification: (e) => 'An IPv6 range has been added on your account.',
+    notification: () => 'An IPv6 range has been added.',
   },
   ipv6pool_delete: {
-    notification: (e) => 'An IPv6 range has been deleted on your account.',
+    notification: () => 'An IPv6 range has been deleted.',
   },
   lish_boot: {
     scheduled: (e) =>


### PR DESCRIPTION
## Description
Before:
<img width="573" alt="Screen Shot 2021-11-12 at 2 03 17 PM" src="https://user-images.githubusercontent.com/32860776/141521223-f8d4dc48-2f47-4533-8c6e-5de204e3efba.png">

After:
<img width="573" alt="Screen Shot 2021-11-12 at 1 54 31 PM" src="https://user-images.githubusercontent.com/32860776/141521200-bf477101-7735-40c8-9ac1-7844b8c2c8d0.png">

Open to changing the language, perhaps removing the "on your account" phrase.

## How to test
- Add an IPv6 range
- Delete it
- Check the Notifications drawer
