### PR TITLE
M3-4983: Transferred column on NodeBalancer page not showing the correct amount

### DIFF
--- a/packages/manager/src/utilities/unitConversions.test.ts
+++ b/packages/manager/src/utilities/unitConversions.test.ts
@@ -3,6 +3,7 @@ import {
   readableBytes,
   ReadableBytesOptions,
   convertStorageUnit,
+  convertMegabytesTo,
 } from './unitConversions';
 
 describe('conversion helper functions', () => {
@@ -304,6 +305,35 @@ describe('conversion helper functions', () => {
 
     it('should convert gigabytes to bytes', () => {
       expect(convertStorageUnit('TB', 5, 'B')).toBe(5 * Math.pow(base, 4));
+    });
+  });
+
+  describe('convertMegabytesTo', () => {
+    const oneByteInMegabytes = Number.parseFloat('9.5367431640625e-7');
+    const oneKilobyteInMegabytes = 0.0009765625;
+    const oneGigabyteInMegabytes = 1024;
+    const rationalGigabyteQuantity = 1377.28;
+    const rationalKilobyteQuantity = 0.0013134765625;
+
+    it('should convert megabytes to bytes', () => {
+      expect(convertMegabytesTo(oneByteInMegabytes)).toBe('1 bytes');
+    });
+
+    it('should convert megabytes to kilobytes', () => {
+      expect(convertMegabytesTo(oneKilobyteInMegabytes)).toBe('1.00 KB');
+    });
+
+    it('should convert megabytes to gigabytes', () => {
+      expect(convertMegabytesTo(oneGigabyteInMegabytes)).toBe('1.00 GB');
+    });
+
+    it('should only return whole numbers when the removeDecimals argument is passed when the result is measured in gigabytes', () => {
+      expect(convertMegabytesTo(oneGigabyteInMegabytes, true)).toBe('1 GB');
+    });
+
+    it('should return two decimals of precision for quantities between whole numbers', () => {
+      expect(convertMegabytesTo(rationalKilobyteQuantity)).toBe('1.34 KB');
+      expect(convertMegabytesTo(rationalGigabyteQuantity)).toBe('1.34 GB');
     });
   });
 });

--- a/packages/manager/src/utilities/unitConversions.ts
+++ b/packages/manager/src/utilities/unitConversions.ts
@@ -8,20 +8,16 @@ export const convertMegabytesTo = (data: number, removeDecimals?: boolean) => {
   if (totalToBytes >= gb) {
     // convert bytes to GB
     return removeDecimals
-      ? `${Math.max(Math.ceil(totalToBytes / gb))} GB`
-      : `${Math.max(Math.ceil(totalToBytes / gb)).toFixed(2)} GB`;
+      ? `${Math.max(totalToBytes / gb)} GB`
+      : `${Math.max(totalToBytes / gb).toFixed(2)} GB`;
   }
   if (totalToBytes >= mb) {
     // convert bytes to MB
-    return `${Math.max(Math.ceil((totalToBytes / mb) * 100) / 100).toFixed(
-      2
-    )} MB`;
+    return `${Math.max(((totalToBytes / mb) * 100) / 100).toFixed(2)} MB`;
   }
   if (totalToBytes >= kb) {
     // convert bytes to KB
-    return `${Math.max(Math.ceil((totalToBytes / kb) * 100) / 100).toFixed(
-      2
-    )} KB`;
+    return `${Math.max(((totalToBytes / kb) * 100) / 100).toFixed(2)} KB`;
   }
   return `${totalToBytes} bytes`;
 };

--- a/packages/manager/src/utilities/unitConversions.ts
+++ b/packages/manager/src/utilities/unitConversions.ts
@@ -8,16 +8,16 @@ export const convertMegabytesTo = (data: number, removeDecimals?: boolean) => {
   if (totalToBytes >= gb) {
     // convert bytes to GB
     return removeDecimals
-      ? `${Math.max(totalToBytes / gb)} GB`
-      : `${Math.max(totalToBytes / gb).toFixed(2)} GB`;
+      ? `${totalToBytes / gb} GB`
+      : `${(totalToBytes / gb).toFixed(2)} GB`;
   }
   if (totalToBytes >= mb) {
     // convert bytes to MB
-    return `${Math.max(((totalToBytes / mb) * 100) / 100).toFixed(2)} MB`;
+    return `${(((totalToBytes / mb) * 100) / 100).toFixed(2)} MB`;
   }
   if (totalToBytes >= kb) {
     // convert bytes to KB
-    return `${Math.max(((totalToBytes / kb) * 100) / 100).toFixed(2)} KB`;
+    return `${(((totalToBytes / kb) * 100) / 100).toFixed(2)} KB`;
   }
   return `${totalToBytes} bytes`;
 };


### PR DESCRIPTION
## Description

Removes use of `Math.ceiling` from `convertMegabytesTo` function. This use of `Math.ceiling` causing only increases in the magnitude on the order of the nearest whole storage unit to be shown to the user. Adds tests for `convertMegabytesTo` function.

## How to test

Ensure that when a Node Balancer has transferred a quantity of bytes that should be represented with a string containing a number with two decimal places of precision that the representation is as accurate as possible. For example if a Node Balancer has transfered `1.432342 GB` of data then that should be represented as `1.43 GB` and not as `1.00 GB` or `2.00 GB`.

**How do I run relevant unit tests?**

yarn test packages/manager/src/utilities/unitConversions.test.ts
