### PR TITLE
M3-5567: Add warning when booting into Rescue Mode that Cloud Firewall will not be enabled

### DIFF
--- a/packages/api-v4/src/linodes/linodes.ts
+++ b/packages/api-v4/src/linodes/linodes.ts
@@ -3,6 +3,7 @@ import {
   UpdateLinodeSchema,
 } from '@linode/validation/lib/linodes.schema';
 import { API_ROOT } from 'src/constants';
+import { Firewall } from '../firewalls/types';
 import Request, {
   setData,
   setMethod,
@@ -136,4 +137,16 @@ export const changeLinodePassword = (linodeId: number, root_pass: string) =>
     setURL(`${API_ROOT}/linode/instances/${linodeId}/password`),
     setData({ root_pass }),
     setMethod('POST')
+  );
+
+/**
+ * getLinodeFirewalls
+ *
+ * View Firewall information for Firewalls associated with this Linode
+ */
+
+export const getLinodeFirewalls = (linodeId: number) =>
+  Request<Page<Firewall>>(
+    setURL(`${API_ROOT}/linode/instances/${linodeId}/firewalls`),
+    setMethod('GET')
   );

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/BareMetalRescue.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/BareMetalRescue.tsx
@@ -67,7 +67,7 @@ export const BareMetalRescue: React.FC<Props> = (props) => {
       actions={actions}
       error={error}
     >
-      <RescueDescription linodeId={linodeID} />
+      <RescueDescription linodeId={linodeID} isBareMetal />
     </ConfirmationDialog>
   );
 };

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/RescueDescription.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/RescueDescription.tsx
@@ -7,6 +7,8 @@ import Link from 'src/components/Link';
 const rescueDescription = {
   text: `If you suspect that your primary filesystem is corrupt, use the Linode Manager to boot your Linode into Rescue Mode. This is a safe environment for performing many system recovery and disk management tasks.`,
   link: 'https://www.linode.com/docs/guides/rescue-and-rebuild/',
+  firewallWarning:
+    'Cloud Firewall rules are not enabled when booting into Rescue Mode.',
 };
 
 interface Props {
@@ -34,6 +36,9 @@ const RescueDescription: React.FC<Props> = (props) => {
       <Typography>
         {rescueDescription.text}{' '}
         <Link to={rescueDescription.link}>Learn more.</Link>
+      </Typography>
+      <Typography className={classes.copy}>
+        {rescueDescription.firewallWarning}
       </Typography>
       {linodeId ? (
         <Typography className={classes.copy}>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/RescueDescription.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/RescueDescription.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
-import Typography from 'src/components/core/Typography';
-import { lishLaunch } from 'src/features/Lish/lishUtils';
 import { makeStyles, Theme } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
 import Link from 'src/components/Link';
+import Notice from 'src/components/Notice';
+import { lishLaunch } from 'src/features/Lish/lishUtils';
+import { useLinodeFirewalls } from 'src/queries/linodeFirewalls';
 
 const rescueDescription = {
   text: `If you suspect that your primary filesystem is corrupt, use the Linode Manager to boot your Linode into Rescue Mode. This is a safe environment for performing many system recovery and disk management tasks.`,
@@ -12,35 +14,43 @@ const rescueDescription = {
 };
 
 interface Props {
-  linodeId?: number;
+  linodeId: number;
+  isBareMetal?: boolean;
 }
 
 const useStyles = makeStyles((theme: Theme) => ({
   copy: {
     marginTop: theme.spacing(1),
   },
+  notice: {
+    marginTop: theme.spacing(2),
+  },
   lishLink: theme.applyLinkStyles,
 }));
 
 const RescueDescription: React.FC<Props> = (props) => {
-  const { linodeId } = props;
+  const { linodeId, isBareMetal } = props;
   const classes = useStyles();
 
-  /**
-   * Pass the prop 'linodeId' when you want to include a note about
-   * connection with LISH upon reboot into Rescue Mode. This is
-   * intended for the Bare Metal dialog.
-   */
+  const { data: linodeFirewallsData } = useLinodeFirewalls(linodeId);
+  const firewallsLinodeAssignedTo = linodeFirewallsData?.data ?? [];
+  const displayFirewallWarning = firewallsLinodeAssignedTo.length > 0;
+
   return (
     <React.Fragment>
+      {displayFirewallWarning ? (
+        <Notice
+          warning
+          text={rescueDescription.firewallWarning}
+          spacingTop={0}
+          spacingBottom={16}
+        />
+      ) : null}
       <Typography>
         {rescueDescription.text}{' '}
         <Link to={rescueDescription.link}>Learn more.</Link>
       </Typography>
-      <Typography className={classes.copy}>
-        {rescueDescription.firewallWarning}
-      </Typography>
-      {linodeId ? (
+      {linodeId && isBareMetal ? (
         <Typography className={classes.copy}>
           {`When your Linode has successfully rebooted into Rescue Mode, use the `}
           <button

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/RescueDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/RescueDialog.tsx
@@ -215,7 +215,7 @@ const LinodeRescue: React.FC<CombinedProps> = (props) => {
         <div>
           <Paper className={classes.root}>
             {unauthorized && <LinodePermissionsError />}
-            <RescueDescription />
+            <RescueDescription linodeId={linodeId} />
             <DeviceSelection
               slots={['sda', 'sdb', 'sdc', 'sdd', 'sde', 'sdf', 'sdg']}
               devices={devices}

--- a/packages/manager/src/queries/linodeFirewalls.ts
+++ b/packages/manager/src/queries/linodeFirewalls.ts
@@ -1,0 +1,14 @@
+import { getLinodeFirewalls } from '@linode/api-v4/lib/linodes';
+import { Firewall } from '@linode/api-v4/lib/firewalls/types';
+import { APIError, ResourcePage } from '@linode/api-v4/lib/types';
+import { useQuery } from 'react-query';
+import { queryPresets } from './base';
+
+const queryKey = 'queryLinodeFirewalls';
+
+export const useLinodeFirewalls = (linodeID: number) =>
+  useQuery<ResourcePage<Firewall>, APIError[]>(
+    [queryKey, linodeID],
+    () => getLinodeFirewalls(linodeID),
+    queryPresets.oneTimeFetch
+  );


### PR DESCRIPTION
## Description
Linodes booted into Rescue Mode no longer have firewall rules enabled.

This PR adds a warning notice in the Rescue dialog that says, `Cloud Firewall rules are not enabled when booting into Rescue Mode.` if the Linode is assigned to a firewall.

To facilitate this, a new method `getLinodeFirewalls` has been added to the JS Client, along with a new RQ query `useLinodeFirewalls`.

## How to Test
There are 3 cases. Only case #1 should display the notice; the other two cases should look the same as they do in prod.

1. A Linode assigned to a firewall
<img width="906" alt="Screen Shot 2021-11-22 at 2 21 41 PM" src="https://user-images.githubusercontent.com/32860776/142922443-7063772c-0510-4c08-8ad3-14ab550751a2.png">

2. A Linode not assigned to a firewall
<img width="906" alt="Screen Shot 2021-11-22 at 2 21 20 PM" src="https://user-images.githubusercontent.com/32860776/142922384-cc65b20a-4e98-4e91-bbf9-0d72db9f3e47.png">

3. A Bare Metal instance (this PR modifies the logic for `BareMetalRescue.tsx` and `RescueDescription.tsx`)
<img width="612" alt="Screen Shot 2021-11-22 at 2 21 00 PM" src="https://user-images.githubusercontent.com/32860776/142922359-a3fc99b0-606c-46c9-95d8-9733b0b92b17.png">

Please also check React Query to confirm that the data is being stored and handled as expected.