### PR TITLE
M3-5059: Persisting when editing stackscripts on separate computers

### DIFF
--- a/packages/manager/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
@@ -75,6 +75,7 @@ interface State {
   dialogOpen: boolean;
   apiResponse?: StackScript;
   isLoadingStackScript: boolean;
+  updated: string;
 }
 
 interface Props {
@@ -105,6 +106,7 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
     isSubmitting: false,
     dialogOpen: false,
     isLoadingStackScript: false,
+    updated: '',
   };
 
   static docs = [StackScripts];
@@ -127,7 +129,14 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
       this.setState({ isLoadingStackScript: true });
       getStackScript(+stackScriptID)
         .then((response) => {
-          if (response.id === valuesFromStorage.id) {
+          const responseUpdated = Date.parse(response.updated);
+          const localUpdated = Date.parse(valuesFromStorage.updated);
+          const stackScriptHasBeenUpdatedElsewhere =
+            responseUpdated > localUpdated;
+          if (
+            response.id === valuesFromStorage.id &&
+            !stackScriptHasBeenUpdatedElsewhere
+          ) {
             this.setState({
               label: valuesFromStorage.label ?? '',
               description: valuesFromStorage.description ?? '',
@@ -146,6 +155,7 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
               script: response.script,
               apiResponse: response, // Saved for use when resetting the form
               isLoadingStackScript: false,
+              updated: response.updated,
             });
           }
         })
@@ -179,6 +189,7 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
       script,
       images,
       revisionNote: rev_note,
+      updated,
     } = this.state;
     const {
       mode,
@@ -200,6 +211,7 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
         script,
         images,
         rev_note,
+        updated,
       });
     }
   };

--- a/packages/manager/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
@@ -41,7 +41,7 @@ import ScriptForm from 'src/features/StackScripts/StackScriptForm';
 import { filterImagesByType } from 'src/store/image/image.helpers';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
-import { sessionStorage as storage } from 'src/utilities/sessionStorage';
+import { storage } from 'src/utilities/storage';
 import { debounce } from 'throttle-debounce';
 import { queryClient } from 'src/queries/base';
 import { queryKey } from 'src/queries/profile';

--- a/packages/manager/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
@@ -41,7 +41,7 @@ import ScriptForm from 'src/features/StackScripts/StackScriptForm';
 import { filterImagesByType } from 'src/store/image/image.helpers';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
-import { storage } from 'src/utilities/storage';
+import { sessionStorage as storage } from 'src/utilities/sessionStorage';
 import { debounce } from 'throttle-debounce';
 import { queryClient } from 'src/queries/base';
 import { queryKey } from 'src/queries/profile';

--- a/packages/manager/src/store/authentication/authentication.helpers.ts
+++ b/packages/manager/src/store/authentication/authentication.helpers.ts
@@ -25,5 +25,6 @@ export const clearUserInput = () => {
     rev_note: '',
     description: '',
     images: [],
+    updated: '',
   });
 };

--- a/packages/manager/src/utilities/storage.ts
+++ b/packages/manager/src/utilities/storage.ts
@@ -70,9 +70,6 @@ interface TicketReply {
 
 interface StackScriptData extends StackScriptPayload {
   id: number | string;
-}
-
-interface StackScriptDataWithUpdated extends StackScriptData {
   updated: string;
 }
 
@@ -111,8 +108,8 @@ export interface Storage {
     set: (v: TicketReply) => void;
   };
   stackScriptInProgress: {
-    get: () => StackScriptDataWithUpdated;
-    set: (s: StackScriptDataWithUpdated) => void;
+    get: () => StackScriptData;
+    set: (s: StackScriptData) => void;
   };
   devToolsEnv: {
     get: () => DevToolsEnv | null;

--- a/packages/manager/src/utilities/storage.ts
+++ b/packages/manager/src/utilities/storage.ts
@@ -72,6 +72,10 @@ interface StackScriptData extends StackScriptPayload {
   id: number | string;
 }
 
+interface StackScriptDataWithUpdated extends StackScriptData {
+  updated: string;
+}
+
 export interface DevToolsEnv {
   apiRoot: string;
   loginRoot: string;
@@ -107,8 +111,8 @@ export interface Storage {
     set: (v: TicketReply) => void;
   };
   stackScriptInProgress: {
-    get: () => StackScriptData;
-    set: (s: StackScriptData) => void;
+    get: () => StackScriptDataWithUpdated;
+    set: (s: StackScriptDataWithUpdated) => void;
   };
   devToolsEnv: {
     get: () => DevToolsEnv | null;


### PR DESCRIPTION
## Description

When a StackScript is edited without being saved the data stored in local storage now includes the `updated` field. Before the data from local storage is loaded its `updated` is compared to the `updated` field from the response. If response has been updated since the edits in the local storage then the local storage data is not loaded.

## How to test

1. Open a StackScript in two different browsers.
2. In browser A edit the StackScript without saving the changes.
3. In browser A navigate away from the StackScript.
4. In browser B edit the StackScript in a different way and save the changes.
5. In browser A navigate to the same StackScript.
6. In browser A click the `edit` button for the StackScript.
7. The prefilled text in the StackScript should reflect the changes from browser B. 
