### PR TITLE
M3-5516: Add url page number handling for linodes

### DIFF
--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -63,6 +63,7 @@
     "patch-package": "^6.1.0",
     "qrcode.react": "^0.8.0",
     "qs": "^6.6.0",
+    "query-string": "^7.0.1",
     "ramda": "~0.25.0",
     "react": "^17.0.2",
     "react-async-script": "^1.2.0",

--- a/packages/manager/src/components/Paginate.ts
+++ b/packages/manager/src/components/Paginate.ts
@@ -43,6 +43,7 @@ interface Props {
   scrollToRef?: React.RefObject<any>;
   pageSizeSetter?: (v: number) => void;
   shouldScroll?: boolean;
+  updateUrl?: (page: number) => void;
 }
 
 export default class Paginate extends React.Component<Props, State> {
@@ -55,6 +56,9 @@ export default class Paginate extends React.Component<Props, State> {
     if (this.props.shouldScroll ?? true) {
       const { scrollToRef } = this.props;
       scrollTo(scrollToRef);
+    }
+    if (this.props.updateUrl) {
+      this.props.updateUrl(page);
     }
     this.setState({ page });
   };

--- a/packages/manager/src/components/PaginationControls/PaginationControls.stories.tsx
+++ b/packages/manager/src/components/PaginationControls/PaginationControls.stories.tsx
@@ -1,31 +1,18 @@
-// import { storiesOf } from '@storybook/react';
-// import * as React from 'react';
-// import PaginationControls from './PaginationControls';
+import * as React from 'react';
+import PaginationControls from './PaginationControls';
 
-// class Example extends React.Component<{}, { currentPage: number }> {
-//   constructor(props: { range: number }) {
-//     super(props);
-//     this.state = { currentPage: 1 };
-//   }
+export default {
+  title: 'Components/PaginationControl',
+};
 
-//   handleClick = (page: number) => {
-//     this.setState({ currentPage: page });
-//   };
-
-//   render() {
-//     return (
-//       <PaginationControls
-//         count={250}
-//         page={this.state.currentPage}
-//         onClickHandler={this.handleClick}
-//         pageSize={25}
-//       />
-//     );
-//   }
-// }
-
-// export default Example;
-
-// storiesOf('Pagination Controls', module).add('Interactive example', () => (
-//   <Example />
-// ));
+export const PaginationControl = () => {
+  const [page, setPage] = React.useState<number>(1);
+  return (
+    <PaginationControls
+      count={250}
+      page={page}
+      onClickHandler={(pageNum: number) => setPage(pageNum)}
+      pageSize={25}
+    />
+  );
+};

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -131,7 +131,7 @@ export const PrimaryNav: React.FC<Props> = (props) => {
       [
         {
           display: 'Linodes',
-          href: '/linodes',
+          href: '/linodes?page=1',
           activeLinks: ['/linodes', '/linodes/create'],
           icon: <Linode />,
         },

--- a/packages/manager/src/features/linodes/LinodesLanding/DisplayLinodes.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/DisplayLinodes.tsx
@@ -16,6 +16,8 @@ import IconButton from 'src/components/core/IconButton';
 import Tooltip from 'src/components/core/Tooltip';
 import GroupByTag from 'src/assets/icons/group-by-tag.svg';
 import TableView from 'src/assets/icons/table-view.svg';
+import queryString from 'query-string';
+import { useLocation } from 'react-router-dom';
 
 const useStyles = makeStyles((theme: Theme) => ({
   controlHeader: {
@@ -53,6 +55,7 @@ interface Props {
   toggleGroupLinodes: () => boolean;
   linodeViewPreference: 'grid' | 'list';
   linodesAreGrouped: boolean;
+  updateUrl: (page: number) => void;
 }
 
 type CombinedProps = Props & OrderByProps;
@@ -70,10 +73,13 @@ const DisplayLinodes: React.FC<CombinedProps> = (props) => {
     toggleGroupLinodes,
     linodeViewPreference,
     linodesAreGrouped,
+    updateUrl,
     ...rest
   } = props;
 
   const { infinitePageSize, setInfinitePageSize } = useInfinitePageSize();
+  const { search } = useLocation();
+  const queryParams = queryString.parse(search);
 
   const numberOfLinodesWithMaintenance = data.reduce((acc, thisLinode) => {
     if (thisLinode.maintenance) {
@@ -85,6 +91,7 @@ const DisplayLinodes: React.FC<CombinedProps> = (props) => {
   return (
     <Paginate
       data={data}
+      page={Number(queryParams.page)}
       // If there are more Linodes with maintenance than the current page size, show the minimum
       // page size needed to show ALL Linodes with maintenance.
       pageSize={
@@ -93,6 +100,7 @@ const DisplayLinodes: React.FC<CombinedProps> = (props) => {
           : infinitePageSize
       }
       pageSizeSetter={setInfinitePageSize}
+      updateUrl={updateUrl}
     >
       {({
         data: paginatedData,
@@ -182,7 +190,7 @@ const DisplayLinodes: React.FC<CombinedProps> = (props) => {
                   handlePageChange={handlePageChange}
                   handleSizeChange={handlePageSizeChange}
                   pageSize={pageSize}
-                  page={page}
+                  page={Number(queryParams.page) || page}
                   eventCategory={'linodes landing'}
                   showAll
                 />

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -120,6 +120,10 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
     history.push(`?${updatedParams}`);
   };
 
+  updateUrl = (page: number) => {
+    this.props.history.push(`?page=${page}`);
+  };
+
   /**
    * when you change the linode view, send an event to google analytics, debounced.
    */
@@ -424,6 +428,7 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
                                     display={linodeViewPreference}
                                     toggleLinodeView={toggleLinodeView}
                                     toggleGroupLinodes={toggleGroupLinodes}
+                                    updateUrl={this.updateUrl}
                                     linodesAreGrouped={false}
                                     linodeViewPreference={linodeViewPreference}
                                     component={

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -182,7 +182,7 @@ export const handlers = [
     return res(ctx.json(makeResourcePage(images)));
   }),
   rest.get('*/linode/instances', async (req, res, ctx) => {
-    const onlineLinodes = linodeFactory.buildList(3, {
+    const onlineLinodes = linodeFactory.buildList(60, {
       backups: { enabled: false },
       ipv4: ['000.000.000.000'],
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -8849,6 +8849,11 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+filter-obj@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-1.1.0.tgz#9b311112bc6c6127a16e016c6c5d7f19e0805c5b"
+  integrity sha1-mzERErxsYSehbgFsbF1/GeCAXFs=
+
 finalhandler@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.2.tgz#b7e7d000ffd11938d0fdb053506f6ebabe9f587d"
@@ -14395,6 +14400,16 @@ query-string@^4.1.0:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
+query-string@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.0.1.tgz#45bd149cf586aaa582dffc7ec7a8ad97dd02f75d"
+  integrity sha512-uIw3iRvHnk9to1blJCG3BTc+Ro56CBowJXKmNNAm3RulvPBzWLRqKSiiDk+IplJhsydwtuNMHi8UGQFcCLVfkA==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    filter-obj "^1.1.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 querystring-es3@^0.2.0, querystring-es3@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -16338,6 +16353,11 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-argv@0.3.1, string-argv@^0.3.0:
   version "0.3.1"


### PR DESCRIPTION
## Description
- You can now load a specific page in `/linodes` through the url with a page query parameter (e.g. `/linodes?page=2`).
- Clicking on a page number in `/linodes` adds a page query param to the url.
- Added back `PaginationControl` to storybook

## How to test
1. Turn on the MSW and go to `/linodes`
2. Click on the page 2 button in the table, the url should update with the page number
3. Click on a Linode to go to the Linode's details page
4. Click the browser's back button, you should be redirected to the previous page you were on (in this case, page 2)
5. Update the url to `linodes?page=3`, the third page should load
6. Run storybook (`yarn storybook`), you should see `PaginationControl` under components

