### PR TITLE
M3-5492 & M3-5547: Axis label UI refinements

### DIFF
--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -146,7 +146,7 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
           {
             // Defines a fixed width for the Y-axis labels
             afterFit(axes) {
-              axes.width = 32;
+              axes.width = 35;
             },
             gridLines: {
               borderDash: [3, 6],
@@ -156,6 +156,7 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
             },
             ticks: {
               beginAtZero: true,
+              fontColor: theme.cmrTextColors.tableHeader,
               fontSize: 12,
               fontStyle: 'normal',
               maxTicksLimit: 8,
@@ -191,6 +192,7 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
               },
             },
             ticks: {
+              fontColor: theme.cmrTextColors.tableHeader,
               fontSize: 12,
               fontStyle: 'normal',
             },

--- a/packages/manager/src/components/LineGraph/NewMetricDisplay.styles.ts
+++ b/packages/manager/src/components/LineGraph/NewMetricDisplay.styles.ts
@@ -32,7 +32,7 @@ const newMetricDisplayStyles = (theme: Theme) =>
       },
     },
     container: {
-      borderTop: `1px solid ${theme.color.border3}`,
+      borderTop: `1px solid ${theme.cmrBorderColors.divider}`,
       color: '#777',
       fontSize: '0.875rem',
       marginTop: theme.spacing(0.5),


### PR DESCRIPTION
## Description

This PR makes the line graph's axis label color match the one used for table headers and prevents the y-axis labels from being cutoff if there are more than 3 digits.

## How to test

1. Go to any Linode Detail view
2. Go to the "Analytics" tab if it's not on there already
3. Scroll down and inspect the font color
4. The "Disk IO" graph will usually have 3 digits in the y-axis but in case there isn't, make a new Linode
