### PR TITLE
M3-5549: Backup Auto Enrollment – Remove redundant head

### DIFF
--- a/packages/manager/src/components/Notice/Notice.tsx
+++ b/packages/manager/src/components/Notice/Notice.tsx
@@ -128,7 +128,7 @@ interface Props extends GridProps {
   flag?: boolean;
   notificationList?: boolean;
   spacingTop?: 0 | 8 | 16 | 24;
-  spacingBottom?: 0 | 8 | 16 | 24;
+  spacingBottom?: 0 | 8 | 16 | 20 | 24;
   breakWords?: boolean;
   onClick?: (e: React.MouseEvent<HTMLElement>) => void;
   // Dismissible Props

--- a/packages/manager/src/features/Account/AutoBackups.tsx
+++ b/packages/manager/src/features/Account/AutoBackups.tsx
@@ -11,8 +11,7 @@ import Typography from 'src/components/core/Typography';
 import Accordion from 'src/components/Accordion';
 import Grid from 'src/components/Grid';
 import Toggle from 'src/components/Toggle';
-
-import HelpIcon from 'src/components/HelpIcon';
+import Notice from 'src/components/Notice';
 
 type ClassNames = 'root' | 'footnote' | 'link' | 'icon' | 'toolTip';
 
@@ -25,14 +24,6 @@ const styles = (theme: Theme) =>
     },
     link: {
       ...theme.applyLinkStyles,
-    },
-    icon: {
-      display: 'inline-block',
-      fontSize: '0.8em',
-      marginLeft: theme.spacing(1) / 3,
-    },
-    toolTip: {
-      paddingTop: theme.spacing(1),
     },
   });
 
@@ -60,16 +51,12 @@ const AutoBackups: React.FC<CombinedProps> = (props) => {
     <Accordion heading="Backup Auto Enrollment" defaultExpanded={true}>
       <Grid container direction="column" className={classes.root}>
         <Grid item>
-          <Typography variant="h2">
-            Back Up All New Linodes
-            {!!isManagedCustomer && (
-              <HelpIcon
-                className={classes.toolTip}
-                text={`You're a Managed customer, which means your Linodes are already automatically
-              backed up - no need to toggle this setting.`}
-              />
-            )}
-          </Typography>
+          {!!isManagedCustomer ? (
+            <Notice success>
+              You're a Managed customer, which means your Linodes are already
+              automatically backed up - no need to toggle this setting.
+            </Notice>
+          ) : null}
         </Grid>
         <Grid item>
           <Typography variant="body1">

--- a/packages/manager/src/features/Account/AutoBackups.tsx
+++ b/packages/manager/src/features/Account/AutoBackups.tsx
@@ -62,8 +62,6 @@ const AutoBackups: React.FC<CombinedProps> = (props) => {
               automatically backed up - no need to toggle this setting.
             </Notice>
           ) : null}
-        </Grid>
-        <Grid item>
           <Typography variant="body1">
             This controls whether Linode Backups are enabled, by default, for
             all Linodes when they are initially created. For each Linode with

--- a/packages/manager/src/features/Account/AutoBackups.tsx
+++ b/packages/manager/src/features/Account/AutoBackups.tsx
@@ -1,36 +1,26 @@
 import OpenInNew from '@material-ui/icons/OpenInNew';
 import * as React from 'react';
 import FormControlLabel from 'src/components/core/FormControlLabel';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles,
-} from 'src/components/core/styles';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Accordion from 'src/components/Accordion';
 import Grid from 'src/components/Grid';
 import Toggle from 'src/components/Toggle';
 import Notice from 'src/components/Notice';
+import Button from 'src/components/Button';
 
-type ClassNames = 'root' | 'footnote' | 'link' | 'icon' | 'toolTip';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {},
-    footnote: {
-      fontSize: 14,
-      cursor: 'pointer',
-    },
-    link: {
-      ...theme.applyLinkStyles,
-    },
-    icon: {
-      display: 'inline-block',
-      fontSize: '0.8em',
-      marginLeft: theme.spacing(1) / 3,
-    },
-  });
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {},
+  footnote: {
+    fontSize: 14,
+    cursor: 'pointer',
+  },
+  icon: {
+    display: 'inline-block',
+    fontSize: '0.8em',
+    marginLeft: theme.spacing(1) / 3,
+  },
+}));
 
 interface Props {
   backups_enabled: boolean;
@@ -40,17 +30,16 @@ interface Props {
   isManagedCustomer: boolean;
 }
 
-type CombinedProps = Props & WithStyles<ClassNames>;
-
-const AutoBackups: React.FC<CombinedProps> = (props) => {
+const AutoBackups: React.FC<Props> = (props) => {
   const {
     backups_enabled,
-    classes,
     hasLinodesWithoutBackups,
     onChange,
     openBackupsDrawer,
     isManagedCustomer,
   } = props;
+
+  const classes = useStyles();
 
   return (
     <Accordion heading="Backup Auto Enrollment" defaultExpanded={true}>
@@ -66,7 +55,7 @@ const AutoBackups: React.FC<CombinedProps> = (props) => {
             This controls whether Linode Backups are enabled, by default, for
             all Linodes when they are initially created. For each Linode with
             Backups enabled, your account will be billed the additional hourly
-            rate noted on the
+            rate noted on the &nbsp;
             <a
               data-qa-backups-price
               href="https://linode.com/backups"
@@ -74,7 +63,7 @@ const AutoBackups: React.FC<CombinedProps> = (props) => {
               aria-describedby="external-site"
               rel="noopener noreferrer"
             >
-              {` Backups pricing page`}
+              {`Backups pricing page`}
               <OpenInNew className={classes.icon} />
             </a>
             .
@@ -104,14 +93,15 @@ const AutoBackups: React.FC<CombinedProps> = (props) => {
           <Grid item>
             <Typography variant="body1" className={classes.footnote}>
               {`For existing Linodes without backups, `}
-              <button
+              <Button
+                compact
+                buttonType="secondary"
                 data-qa-backup-existing
-                className={classes.link}
                 onClick={openBackupsDrawer}
                 title="enable now"
               >
                 enable now
-              </button>
+              </Button>
               .
             </Typography>
           </Grid>
@@ -121,6 +111,4 @@ const AutoBackups: React.FC<CombinedProps> = (props) => {
   );
 };
 
-const styled = withStyles(styles);
-
-export default styled(AutoBackups);
+export default AutoBackups;

--- a/packages/manager/src/features/Account/AutoBackups.tsx
+++ b/packages/manager/src/features/Account/AutoBackups.tsx
@@ -25,6 +25,11 @@ const styles = (theme: Theme) =>
     link: {
       ...theme.applyLinkStyles,
     },
+    icon: {
+      display: 'inline-block',
+      fontSize: '0.8em',
+      marginLeft: theme.spacing(1) / 3,
+    },
   });
 
 interface Props {

--- a/packages/manager/src/features/Account/AutoBackups.tsx
+++ b/packages/manager/src/features/Account/AutoBackups.tsx
@@ -1,16 +1,15 @@
 import OpenInNew from '@material-ui/icons/OpenInNew';
 import * as React from 'react';
+import Accordion from 'src/components/Accordion';
+import Button from 'src/components/Button';
 import FormControlLabel from 'src/components/core/FormControlLabel';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
-import Accordion from 'src/components/Accordion';
 import Grid from 'src/components/Grid';
-import Toggle from 'src/components/Toggle';
 import Notice from 'src/components/Notice';
-import Button from 'src/components/Button';
+import Toggle from 'src/components/Toggle';
 
 const useStyles = makeStyles((theme: Theme) => ({
-  root: {},
   footnote: {
     fontSize: 14,
     cursor: 'pointer',
@@ -43,19 +42,19 @@ const AutoBackups: React.FC<Props> = (props) => {
 
   return (
     <Accordion heading="Backup Auto Enrollment" defaultExpanded={true}>
-      <Grid container direction="column" className={classes.root}>
+      <Grid container direction="column">
         <Grid item>
           {!!isManagedCustomer ? (
-            <Notice success>
-              You're a Managed customer, which means your Linodes are already
-              automatically backed up - no need to toggle this setting.
+            <Notice success spacingBottom={20}>
+              You&rsquo;re a Managed customer, which means your Linodes are
+              already automatically backed up - no need to toggle this setting.
             </Notice>
           ) : null}
           <Typography variant="body1">
             This controls whether Linode Backups are enabled, by default, for
             all Linodes when they are initially created. For each Linode with
             Backups enabled, your account will be billed the additional hourly
-            rate noted on the &nbsp;
+            rate noted on the&nbsp;
             <a
               data-qa-backups-price
               href="https://linode.com/backups"
@@ -63,7 +62,7 @@ const AutoBackups: React.FC<Props> = (props) => {
               aria-describedby="external-site"
               rel="noopener noreferrer"
             >
-              {`Backups pricing page`}
+              Backups pricing page
               <OpenInNew className={classes.icon} />
             </a>
             .
@@ -72,7 +71,6 @@ const AutoBackups: React.FC<Props> = (props) => {
         <Grid item container direction="row" alignItems="center">
           <Grid item>
             <FormControlLabel
-              // className="toggleLabel"
               control={
                 <Toggle
                   onChange={onChange}
@@ -92,7 +90,7 @@ const AutoBackups: React.FC<Props> = (props) => {
         {!isManagedCustomer && !backups_enabled && hasLinodesWithoutBackups && (
           <Grid item>
             <Typography variant="body1" className={classes.footnote}>
-              {`For existing Linodes without backups, `}
+              For existing Linodes without backups,&nbsp;
               <Button
                 compact
                 buttonType="secondary"


### PR DESCRIPTION
## Description

Removes the redundant header on the account settings backup auto enrollment section. There was also a tooltip that would show up to inform managed users that they are already auto enrolled in backups. I removed the tooltip and replaced it with a success notice.

## How to test

1. Open the Account Settings page as managed user.
2. There should be no redundant header in the back up auto enrollment section.
3. There should be a success notice informing you that you are already enrolled in auto backups.
4. Open the Account Settings page as an unmanaged user.
5. There should be no redundant header in the back up auto enrollment section.
