### PR TITLE
M3-5551: Refactor logic for displaying NVMe-related chips

### DIFF
--- a/packages/manager/src/features/Volumes/VolumeTableRow.tsx
+++ b/packages/manager/src/features/Volumes/VolumeTableRow.tsx
@@ -1,7 +1,7 @@
 import {
   Event,
-  EventAction,
-  NotificationType,
+  // EventAction,
+  // NotificationType,
 } from '@linode/api-v4/lib/account';
 import * as React from 'react';
 import { Link, useHistory, useLocation } from 'react-router-dom';
@@ -14,11 +14,11 @@ import Grid from 'src/components/Grid';
 import LinearProgress from 'src/components/LinearProgress';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
-import useNotifications from 'src/hooks/useNotifications';
+// import useNotifications from 'src/hooks/useNotifications';
 import { formatRegion } from 'src/utilities';
 import { ExtendedVolume } from './types';
 import VolumesActionMenu, { ActionHandlers } from './VolumesActionMenu';
-import useEvents from 'src/hooks/useEvents';
+// import useEvents from 'src/hooks/useEvents';
 
 const useStyles = makeStyles((theme: Theme) => ({
   volumePath: {
@@ -90,37 +90,44 @@ export const VolumeTableRow: React.FC<CombinedProps> = (props) => {
     linodeLabel,
     linode_id: linodeId,
     linodeStatus,
+    eligibleForUpgradeToNVMe,
+    nvmeUpgradeScheduledByUserImminent,
+    nvmeUpgradeScheduledByUserInProgress,
   } = props;
 
-  const { events } = useEvents();
+  // const { events } = useEvents();
   const history = useHistory();
   const location = useLocation();
-  const notifications = useNotifications();
+  // const notifications = useNotifications();
   const isVolumesLanding = Boolean(location.pathname.match(/volumes/));
 
   const formattedRegion = formatRegion(region);
 
   const isNVMe = hardwareType === 'nvme';
 
-  const eligibleForUpgradeToNVMe = notifications.some(
-    (notification) =>
-      notification.type ===
-        ('volume_migration_scheduled' as NotificationType) &&
-      notification.entity?.id === id
+  console.log(
+    `Eligible: ${eligibleForUpgradeToNVMe}, Scheduled Imminent: ${nvmeUpgradeScheduledByUserImminent}, Scheduled In Progress: ${nvmeUpgradeScheduledByUserInProgress}`
   );
 
-  const nvmeUpgradeScheduledByUserImminent = notifications.some(
-    (notification) =>
-      notification.type === ('volume_migration_imminent' as NotificationType) &&
-      notification.entity?.id === id
-  );
+  // const eligibleForUpgradeToNVMe = notifications.some(
+  //   (notification) =>
+  //     notification.type ===
+  //       ('volume_migration_scheduled' as NotificationType) &&
+  //     notification.entity?.id === id
+  // );
 
-  const nvmeUpgradeScheduledByUserInProgress = events.some(
-    (event) =>
-      event.action === ('volume_migrate' as EventAction) &&
-      event.entity?.id === id &&
-      event.status === 'started'
-  );
+  // const nvmeUpgradeScheduledByUserImminent = notifications.some(
+  //   (notification) =>
+  //     notification.type === ('volume_migration_imminent' as NotificationType) &&
+  //     notification.entity?.id === id
+  // );
+
+  // const nvmeUpgradeScheduledByUserInProgress = events.some(
+  //   (event) =>
+  //     event.action === ('volume_migrate' as EventAction) &&
+  //     event.entity?.id === id &&
+  //     event.status === 'started'
+  // );
 
   return isUpdating ? (
     <TableRow

--- a/packages/manager/src/features/Volumes/VolumeTableRow.tsx
+++ b/packages/manager/src/features/Volumes/VolumeTableRow.tsx
@@ -1,8 +1,4 @@
-import {
-  Event,
-  // EventAction,
-  // NotificationType,
-} from '@linode/api-v4/lib/account';
+import { Event } from '@linode/api-v4/lib/account';
 import * as React from 'react';
 import { Link, useHistory, useLocation } from 'react-router-dom';
 import { compose } from 'recompose';
@@ -14,11 +10,9 @@ import Grid from 'src/components/Grid';
 import LinearProgress from 'src/components/LinearProgress';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
-// import useNotifications from 'src/hooks/useNotifications';
 import { formatRegion } from 'src/utilities';
 import { ExtendedVolume } from './types';
 import VolumesActionMenu, { ActionHandlers } from './VolumesActionMenu';
-// import useEvents from 'src/hooks/useEvents';
 
 const useStyles = makeStyles((theme: Theme) => ({
   volumePath: {
@@ -95,39 +89,13 @@ export const VolumeTableRow: React.FC<CombinedProps> = (props) => {
     nvmeUpgradeScheduledByUserInProgress,
   } = props;
 
-  // const { events } = useEvents();
   const history = useHistory();
   const location = useLocation();
-  // const notifications = useNotifications();
   const isVolumesLanding = Boolean(location.pathname.match(/volumes/));
 
   const formattedRegion = formatRegion(region);
 
   const isNVMe = hardwareType === 'nvme';
-
-  console.log(
-    `Eligible: ${eligibleForUpgradeToNVMe}, Scheduled Imminent: ${nvmeUpgradeScheduledByUserImminent}, Scheduled In Progress: ${nvmeUpgradeScheduledByUserInProgress}`
-  );
-
-  // const eligibleForUpgradeToNVMe = notifications.some(
-  //   (notification) =>
-  //     notification.type ===
-  //       ('volume_migration_scheduled' as NotificationType) &&
-  //     notification.entity?.id === id
-  // );
-
-  // const nvmeUpgradeScheduledByUserImminent = notifications.some(
-  //   (notification) =>
-  //     notification.type === ('volume_migration_imminent' as NotificationType) &&
-  //     notification.entity?.id === id
-  // );
-
-  // const nvmeUpgradeScheduledByUserInProgress = events.some(
-  //   (event) =>
-  //     event.action === ('volume_migrate' as EventAction) &&
-  //     event.entity?.id === id &&
-  //     event.status === 'started'
-  // );
 
   return isUpdating ? (
     <TableRow

--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -470,7 +470,7 @@ const filterVolumeEvents = (event: Event): boolean => {
   );
 };
 
-const includeNVMeBooleans = (
+const addNVMeBooleansToVolume = (
   volumes: Volume[],
   notifications: Notification[],
   events: Event[]
@@ -529,7 +529,7 @@ export default compose<CombinedProps, Props>(
       volumesResults,
       volumesError
     ) => {
-      const volumesWithNVMeBooleans = includeNVMeBooleans(
+      const volumesWithNVMeBooleans = addNVMeBooleansToVolume(
         volumesData,
         ownProps.notifications,
         ownProps.eventsData

--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -1,9 +1,4 @@
-import {
-  Event,
-  EventAction,
-  Notification,
-  NotificationType,
-} from '@linode/api-v4/lib/account';
+import { Event, Notification } from '@linode/api-v4/lib/account';
 import { Config, Linode } from '@linode/api-v4/lib/linodes';
 import { Volume } from '@linode/api-v4/lib/volumes';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
@@ -475,26 +470,24 @@ const addNVMeBooleansToVolume = (
   notifications: Notification[],
   events: Event[]
 ) => {
-  return volumes.reduce((acc: any, eachVolume) => {
+  return volumes.reduce((acc: ExtendedVolume[], eachVolume) => {
     const { id } = eachVolume;
 
     const eligibleForUpgradeToNVMe = notifications.some(
       (notification) =>
-        notification.type ===
-          ('volume_migration_scheduled' as NotificationType) &&
+        notification.type === 'volume_migration_scheduled' &&
         notification.entity?.id === id
     );
 
     const nvmeUpgradeScheduledByUserImminent = notifications.some(
       (notification) =>
-        notification.type ===
-          ('volume_migration_imminent' as NotificationType) &&
+        notification.type === 'volume_migration_imminent' &&
         notification.entity?.id === id
     );
 
     const nvmeUpgradeScheduledByUserInProgress = events.some(
       (event) =>
-        event.action === ('volume_migrate' as EventAction) &&
+        event.action === 'volume_migrate' &&
         event.entity?.id === id &&
         event.status === 'started'
     );

--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -1,4 +1,8 @@
-import { Event } from '@linode/api-v4/lib/account';
+import {
+  Event,
+  EventAction,
+  NotificationType,
+} from '@linode/api-v4/lib/account';
 import { Config, Linode } from '@linode/api-v4/lib/linodes';
 import { Volume } from '@linode/api-v4/lib/volumes';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
@@ -33,6 +37,9 @@ import withLinodes, {
 import { resetEventsPolling } from 'src/eventsPolling';
 import useFlags from 'src/hooks/useFlags';
 import useReduxLoad from 'src/hooks/useReduxLoad';
+import withNotifications, {
+  WithNotifications,
+} from 'src/store/notification/notification.containers';
 import {
   LinodeOptions,
   openForClone,
@@ -100,7 +107,8 @@ type CombinedProps = Props &
   DispatchProps &
   RouteProps &
   WithSnackbarProps &
-  WithMappedVolumesProps;
+  WithMappedVolumesProps &
+  WithNotifications;
 
 const volumeHeaders = [
   {
@@ -461,6 +469,48 @@ const filterVolumeEvents = (event: Event): boolean => {
   );
 };
 
+const includeNVMeBooleans = (
+  volumes: Volume[],
+  notifications: Notification[],
+  events: Event[]
+) => {
+  return volumes.reduce((acc: any, eachVolume) => {
+    const { id } = eachVolume;
+
+    // fix notification.type typing
+    const eligibleForUpgradeToNVMe = notifications.some(
+      (notification) =>
+        notification.type ===
+          ('volume_migration_scheduled' as NotificationType) &&
+        notification.entity?.id === id
+    );
+
+    const nvmeUpgradeScheduledByUserImminent = notifications.some(
+      (notification) =>
+        notification.type ===
+          ('volume_migration_imminent' as NotificationType) &&
+        notification.entity?.id === id
+    );
+
+    const nvmeUpgradeScheduledByUserInProgress = events.some(
+      (event) =>
+        event.action === ('volume_migrate' as EventAction) &&
+        event.entity?.id === id &&
+        event.status === 'started'
+    );
+
+    return [
+      ...acc,
+      {
+        ...eachVolume,
+        eligibleForUpgradeToNVMe,
+        nvmeUpgradeScheduledByUserImminent,
+        nvmeUpgradeScheduledByUserInProgress,
+      },
+    ];
+  }, []);
+};
+
 export default compose<CombinedProps, Props>(
   connected,
   withVolumesRequests,
@@ -468,6 +518,7 @@ export default compose<CombinedProps, Props>(
     ...ownProps,
     eventsData: eventsData.filter(filterVolumeEvents),
   })),
+  withNotifications(),
   withLinodes(),
   withVolumes(
     (
@@ -478,16 +529,26 @@ export default compose<CombinedProps, Props>(
       volumesResults,
       volumesError
     ) => {
-      const mappedVolumesDataWithLinodes = volumesData.map((volume) => {
-        const volumeWithLinodeData = addAttachedLinodeInfoToVolume(
-          volume,
-          ownProps.linodesData
-        );
-        return addRecentEventToVolume(
-          volumeWithLinodeData,
-          ownProps.eventsData
-        );
-      });
+      const volumesWithNVMeBooleans = includeNVMeBooleans(
+        volumesData,
+        ownProps.notifications,
+        ownProps.eventsData
+      ); // fix ownProps.notifications
+
+      // console.log(volumesWithNVMeBooleans);
+
+      const mappedVolumesDataWithLinodes = volumesWithNVMeBooleans.map(
+        (volume: ExtendedVolume) => {
+          const volumeWithLinodeData = addAttachedLinodeInfoToVolume(
+            volume,
+            ownProps.linodesData
+          );
+          return addRecentEventToVolume(
+            volumeWithLinodeData,
+            ownProps.eventsData
+          );
+        }
+      );
       return {
         ...ownProps,
         volumesData,

--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -1,6 +1,7 @@
 import {
   Event,
   EventAction,
+  Notification,
   NotificationType,
 } from '@linode/api-v4/lib/account';
 import { Config, Linode } from '@linode/api-v4/lib/linodes';
@@ -477,7 +478,6 @@ const includeNVMeBooleans = (
   return volumes.reduce((acc: any, eachVolume) => {
     const { id } = eachVolume;
 
-    // fix notification.type typing
     const eligibleForUpgradeToNVMe = notifications.some(
       (notification) =>
         notification.type ===
@@ -533,9 +533,7 @@ export default compose<CombinedProps, Props>(
         volumesData,
         ownProps.notifications,
         ownProps.eventsData
-      ); // fix ownProps.notifications
-
-      // console.log(volumesWithNVMeBooleans);
+      );
 
       const mappedVolumesDataWithLinodes = volumesWithNVMeBooleans.map(
         (volume: ExtendedVolume) => {

--- a/packages/manager/src/features/Volumes/types.ts
+++ b/packages/manager/src/features/Volumes/types.ts
@@ -5,4 +5,7 @@ export interface ExtendedVolume extends Volume {
   recentEvent?: Event;
   linodeLabel?: string;
   linodeStatus?: string;
+  eligibleForUpgradeToNVMe?: boolean;
+  nvmeUpgradeScheduledByUserImminent?: boolean;
+  nvmeUpgradeScheduledByUserInProgress?: boolean;
 }


### PR DESCRIPTION
## Description
In `VolumeTableRow.tsx`, the approach of using `notifications.some()` comes with some performance drawbacks since the array is looped through for every row, on every render.

This PR lifts that logic to `VolumesLanding.tsx` and uses a `.reduce()` to add booleans on the volume objects.

## To Do:
- [x] Testing for edge cases and ensuring there have been no regressions
- [x] Cleanup (removing comments, fixing types, etc.)

## How to test
Create a few HDD volumes (attached and unattached) and have them go through the full NVMe migration flow. The chips should show up just as they have been with no regressions. 