### PR TITLE
M3-5522: Object Storage Landing contextual help

### DIFF
--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
@@ -28,6 +28,7 @@ import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import {
   sendDeleteBucketEvent,
   sendDeleteBucketFailedEvent,
+  sendObjectStorageDocsEvent,
 } from 'src/utilities/ga';
 import { readableBytes } from 'src/utilities/unitConversions';
 import CancelNotice from '../CancelNotice';
@@ -318,6 +319,7 @@ const RenderEmpty: React.FC<{
         <Typography variant="subtitle1">Need help getting started?</Typography>
         <Typography variant="subtitle1">
           <a
+            onClick={() => sendObjectStorageDocsEvent('Empty state')}
             href="https://linode.com/docs/platform/object-storage"
             target="_blank"
             aria-describedby="external-site"

--- a/packages/manager/src/utilities/ga.ts
+++ b/packages/manager/src/utilities/ga.ts
@@ -370,6 +370,10 @@ export const sendEntityTransferCopyDraftEmailEvent = (): void => {
 };
 
 export const sendHelpButtonClickEvent = (url: string, from?: string) => {
+  if (from === 'Object Storage Landing') {
+    sendObjectStorageDocsEvent('Docs');
+  }
+
   sendEvent({
     category: 'Help Button',
     action: url,
@@ -395,6 +399,13 @@ export const sendImageUploadEvent = (action: string, imageSize: string) => {
 export const sendLinodeCreateDocsEvent = (action: string) => {
   sendEvent({
     category: 'Linode Create Contextual Help',
+    action,
+  });
+};
+
+export const sendObjectStorageDocsEvent = (action: string) => {
+  sendEvent({
+    category: 'Object Storage Landing Contextual Help',
     action,
   });
 };


### PR DESCRIPTION
## Description

- Logs an event when the user clicks
  - The `Docs` button in the Object Storage Landing header
  - The `Learn more about storage options...` docs link in the Object Storage empty state

![ObjectStorage_EmptyLanding_ContextualHelp](https://user-images.githubusercontent.com/6440455/143909083-dacfdfe8-f8e3-4cc8-9081-16ec639c3dde.jpg)

## How to test

Click one of the buttons described above and check the console to make sure Google Analytics logs the event. (You may not see this is the console if you have an ad blocker or use [Pi-hole](https://pi-hole.net). Google Analytics may be blocked preventing this from loading)

<img width="826" alt="Screen Shot 2021-11-29 at 11 52 35 AM" src="https://user-images.githubusercontent.com/6440455/143909521-42978776-fac8-4c8f-97ff-9434934a9067.png">

