### PR TITLE
M3-5631: Add beta badge to HA Upgrade and HA Checkbox

### DIFF
--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -181,7 +181,6 @@ export const PrimaryNav: React.FC<Props> = (props) => {
           href: '/kubernetes/clusters',
           activeLinks: ['/kubernetes/create'],
           icon: <Kubernetes />,
-          isBeta: true,
         },
         {
           hide: !showDatabases,

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -181,6 +181,7 @@ export const PrimaryNav: React.FC<Props> = (props) => {
           href: '/kubernetes/clusters',
           activeLinks: ['/kubernetes/create'],
           icon: <Kubernetes />,
+          isBeta: true,
         },
         {
           hide: !showDatabases,

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/HACheckbox.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/HACheckbox.tsx
@@ -36,6 +36,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   chip: {
     fontWeight: theme.typography.fontWeightRegular,
     margin: 0,
+    marginTop: -1,
   },
 }));
 

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/HACheckbox.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/HACheckbox.tsx
@@ -35,6 +35,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   chip: {
     fontWeight: theme.typography.fontWeightRegular,
+    margin: 0,
   },
 }));
 

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/HACheckbox.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/HACheckbox.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import CheckBox from 'src/components/CheckBox';
 import Box from 'src/components/core/Box';
+import Chip from 'src/components/core/Chip';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import DisplayPrice from 'src/components/DisplayPrice';
@@ -61,7 +62,7 @@ const HACheckbox: React.FC<Props> = (props) => {
         />
         <Box>
           <Typography className={classes.heading}>
-            Enable HA Control Plane
+            Enable HA Control Plane <Chip label="BETA" />
           </Typography>
           <HACopy />
         </Box>

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/HACheckbox.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/HACheckbox.tsx
@@ -33,6 +33,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   price: {
     marginTop: theme.spacing(),
   },
+  chip: {
+    fontWeight: theme.typography.fontWeightRegular,
+  },
 }));
 
 export interface Props {
@@ -62,7 +65,8 @@ const HACheckbox: React.FC<Props> = (props) => {
         />
         <Box>
           <Typography className={classes.heading}>
-            Enable HA Control Plane <Chip label="BETA" />
+            Enable HA Control Plane{' '}
+            <Chip className={classes.chip} label="BETA" />
           </Typography>
           <HACopy />
         </Box>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeClusterDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeClusterDialog.tsx
@@ -9,6 +9,7 @@ import useKubernetesClusters from 'src/hooks/useKubernetesClusters';
 import { HIGH_AVAILABILITY_PRICE } from 'src/constants';
 import { HACopy } from '../KubeCheckoutBar/HACheckbox';
 import { useSnackbar } from 'notistack';
+import Chip from 'src/components/core/Chip';
 
 interface Props {
   open: boolean;
@@ -95,6 +96,7 @@ const UpgradeClusterDialog: React.FC<Props> = (props) => {
         onChange={toggleChecked}
         text="Enable HA Control Plane"
       />
+      <Chip label="BETA" />
     </ConfirmationDialog>
   );
 };

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeClusterDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeClusterDialog.tsx
@@ -10,6 +10,7 @@ import { HIGH_AVAILABILITY_PRICE } from 'src/constants';
 import { HACopy } from '../KubeCheckoutBar/HACheckbox';
 import { useSnackbar } from 'notistack';
 import Chip from 'src/components/core/Chip';
+import { makeStyles } from 'src/components/core/styles';
 
 interface Props {
   open: boolean;
@@ -45,6 +46,14 @@ const renderActions = (
   );
 };
 
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    '& label': {
+      backgroundColor: 'red',
+    }
+  }
+}));
+
 const UpgradeClusterDialog: React.FC<Props> = (props) => {
   const { open, onClose, clusterID } = props;
   const { enqueueSnackbar } = useSnackbar();
@@ -54,6 +63,7 @@ const UpgradeClusterDialog: React.FC<Props> = (props) => {
   const { updateKubernetesCluster } = useKubernetesClusters();
   const [error, setError] = React.useState<string | undefined>();
   const [submitting, setSubmitting] = React.useState(false);
+  const classes = useStyles();
 
   const onUpgrade = () => {
     setSubmitting(true);
@@ -95,6 +105,7 @@ const UpgradeClusterDialog: React.FC<Props> = (props) => {
         checked={checked}
         onChange={toggleChecked}
         text="Enable HA Control Plane"
+        className={classes.root}
       />
       <Chip label="BETA" />
     </ConfirmationDialog>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeClusterDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeClusterDialog.tsx
@@ -10,7 +10,6 @@ import { HIGH_AVAILABILITY_PRICE } from 'src/constants';
 import { HACopy } from '../KubeCheckoutBar/HACheckbox';
 import { useSnackbar } from 'notistack';
 import Chip from 'src/components/core/Chip';
-import { makeStyles } from 'src/components/core/styles';
 
 interface Props {
   open: boolean;

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeClusterDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeClusterDialog.tsx
@@ -72,12 +72,6 @@ const UpgradeClusterDialog: React.FC<Props> = (props) => {
       });
   };
 
-  const checkboxText = (
-    <>
-      Enable HA Control Plane <Chip style={{marginLeft: 4}} label="BETA" />
-    </>
-  )
-
   return (
     <ConfirmationDialog
       open={open}
@@ -100,8 +94,9 @@ const UpgradeClusterDialog: React.FC<Props> = (props) => {
       <CheckBox
         checked={checked}
         onChange={toggleChecked}
-        text={checkboxText}
+        text="Enable HA Control Plane"
       />
+      <Chip style={{ marginLeft: -8 }} label="BETA" />
     </ConfirmationDialog>
   );
 };

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeClusterDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeClusterDialog.tsx
@@ -46,14 +46,6 @@ const renderActions = (
   );
 };
 
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    '& label': {
-      backgroundColor: 'red',
-    }
-  }
-}));
-
 const UpgradeClusterDialog: React.FC<Props> = (props) => {
   const { open, onClose, clusterID } = props;
   const { enqueueSnackbar } = useSnackbar();
@@ -63,7 +55,6 @@ const UpgradeClusterDialog: React.FC<Props> = (props) => {
   const { updateKubernetesCluster } = useKubernetesClusters();
   const [error, setError] = React.useState<string | undefined>();
   const [submitting, setSubmitting] = React.useState(false);
-  const classes = useStyles();
 
   const onUpgrade = () => {
     setSubmitting(true);
@@ -81,6 +72,12 @@ const UpgradeClusterDialog: React.FC<Props> = (props) => {
         setError(e[0].reason);
       });
   };
+
+  const checkboxText = (
+    <>
+      Enable HA Control Plane <Chip style={{marginLeft: 4}} label="BETA" />
+    </>
+  )
 
   return (
     <ConfirmationDialog
@@ -104,10 +101,8 @@ const UpgradeClusterDialog: React.FC<Props> = (props) => {
       <CheckBox
         checked={checked}
         onChange={toggleChecked}
-        text="Enable HA Control Plane"
-        className={classes.root}
+        text={checkboxText}
       />
-      <Chip label="BETA" />
     </ConfirmationDialog>
   );
 };


### PR DESCRIPTION
## Description

Add a beta badge for the HA Upgrade dialog and to the HA Checkbox in the Kubernetes Checkout Bar.

## How to test

1. Navigate to Kubernetes page.
2. Open Kubernetes creation.
3. Ensure that next to the `Enable HA Cluster Plane` label there is a `BETA` badge.
4. Navigate back to Kubernetes Landing page.
5. Open an existing non-HA enabled Cluster.
6. Click the `Upgrade to HA` button.
7. Ensure that next to the `Enable HA Cluster Plane` label there is a `BETA` badge.
