### PR TITLE
Override Domain type display in search results

### DIFF
--- a/packages/manager/src/store/selectors/getSearchEntities.ts
+++ b/packages/manager/src/store/selectors/getSearchEntities.ts
@@ -108,7 +108,7 @@ export const domainToSearchableItem = (domain: Domain): SearchableItem => ({
   entityType: 'domain',
   data: {
     tags: domain.tags,
-    description: domain.type,
+    description: domain.type === 'master' ? 'primary' : 'secondary',
     status: domain.status,
     icon: 'domain',
     path: `/domains/${domain.id}`,


### PR DESCRIPTION
## Description

I noticed we were displaying the raw `domain.type` in search results (in the search bar and on the search landing page). This PR overrides that to ensure we display `"primary" | "secondary"` instead of `"master" | "slave"` which is a change we’ve made everywhere else in the app.

## How to test

Have a primary and a secondary Domain on your account and search for them in the search bar. Production will display the type as being either 'master' or 'slave', while in this PR they should be displayed as 'primary' or 'secondary'.
