### PR TITLE
M3-5600: Chips in Storybook

### DIFF
--- a/packages/manager/src/components/Chip.stories.mdx
+++ b/packages/manager/src/components/Chip.stories.mdx
@@ -34,6 +34,7 @@ Actionable Chips indicate a state and allow users to take action.
   </Story>
 </Canvas>
 
+
 ## Outlined
 
 Static Chips are an indication of status and are intended to be informational.
@@ -45,8 +46,17 @@ No action is required or enabled.
 
 **Visual style:** outline.
 
+
 <Canvas>
-  <Story name="Outline">
+  <Story name="Outlined">
+    <Chip label="Chip" variant="outlined" />
+  </Story>
+</Canvas>
+
+## Custom
+
+<Canvas>
+  <Story name="Custom">
     {() => {
       const classes = useStyles();
       return (

--- a/packages/manager/src/components/Chip.stories.mdx
+++ b/packages/manager/src/components/Chip.stories.mdx
@@ -1,6 +1,117 @@
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
 import Chip from '/src/components/core/Chip';
+import { useStyles } from '/src/features/Volumes/VolumeTableRow';
 
 <Meta title="UI Elements/Chips" component={Chip} />
 
+export const Template = (args) => {
+   return (
+     <Chip {...args} />
+   );
+ };
+
 # Chips
+
+<Canvas>
+  <Story name="Chip">
+    <Chip label="Chip" />
+  </Story>
+</Canvas>
+
+## Clickable
+
+Actionable Chips indicate a state and allow users to take action.
+
+
+**Example:** An ‘Upgrade’ chip on a Kubernetes cluster shows the software is not current and allows a user to upgrade to a new version.
+
+
+**Visual style:** solid color background.
+
+<Canvas>
+  <Story name="Clickable">
+    <Chip label="Upgrade" clickable />
+  </Story>
+</Canvas>
+
+## Outlined
+
+Static Chips are an indication of status and are intended to be informational.
+No action is required or enabled.
+
+
+**Example:** ‘NVMe’ chip on a volume.
+
+
+**Visual style:** outline.
+
+<Canvas>
+  <Story name="Outline">
+    {() => {
+      const classes = useStyles();
+      return (
+        <Chip
+          className={`${classes.chip} ${classes.nvmeChip}`}
+          style={{ marginLeft: 0 }}
+          label="NVMe"
+          data-testid="nvme-chip"
+        />
+      )
+    }}
+  </Story>
+</Canvas>
+
+## Component API
+
+<Canvas>
+  <Story
+    name="Component API"
+    args={{
+      label: "Chip",
+      clickable: false,
+      disabled: false,
+      onClick: () => alert("Clicked!"),
+      variant: "default",
+      color: "default",
+      size: "medium",
+    }}
+    argTypes={{
+      label: {
+        description: "The content of the label.",
+      },
+      clickable: {
+        description: 'If `true`, the chip will appear clickable, and will raise when pressed, even if the onClick prop is not defined. If false, the chip will not be clickable, even if onClick prop is defined. This can be used, for example, along with the component prop to indicate an anchor Chip is clickable.  ',
+      },
+      disabled: {
+        description: "If `true`, the chip should be displayed in a disabled state.",
+      },
+      onClick: {
+        description: "Function called when the object is clicked.",
+      },
+      color: {
+        description: 'Color of the Chip `"default" | "primary" | "secondary"`',
+        options: ['default', 'primary', 'secondary'],
+        control: { type: 'radio' }
+      },
+      variant: {
+        description: 'Variant of the Chip `"default" | "outlined"`',
+        options: ['default', 'outlined'],
+        control: { type: 'radio' }
+      },
+      size: {
+        description: 'Size of the Chip `"small" | "medium"`',
+        options: ['small', 'medium'],
+        control: { type: 'radio' }
+      },
+      component: {
+        description: "The component used for the root node. Either a string to use a HTML element or a component.",
+      },
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+<ArgsTable
+  story="Component API"
+/>

--- a/packages/manager/src/components/Chip.stories.mdx
+++ b/packages/manager/src/components/Chip.stories.mdx
@@ -78,30 +78,65 @@ No action is required or enabled.
     argTypes={{
       label: {
         description: "The content of the label.",
+        table: {
+          defaultValue: {
+            summary: 'undefined',
+          },
+        },
       },
       clickable: {
         description: 'If `true`, the chip will appear clickable, and will raise when pressed, even if the onClick prop is not defined. If false, the chip will not be clickable, even if onClick prop is defined. This can be used, for example, along with the component prop to indicate an anchor Chip is clickable.  ',
+        table: {
+          defaultValue: {
+            summary: 'false',
+          },
+        },
       },
       disabled: {
         description: "If `true`, the chip should be displayed in a disabled state.",
+        table: {
+          defaultValue: {
+            summary: 'false',
+          },
+        },
       },
       onClick: {
         description: "Function called when the object is clicked.",
+        table: {
+          defaultValue: {
+            summary: 'undefined',
+          },
+        },
       },
       color: {
         description: 'Color of the Chip `"default" | "primary" | "secondary"`',
         options: ['default', 'primary', 'secondary'],
-        control: { type: 'radio' }
+        control: { type: 'radio' },
+        table: {
+          defaultValue: {
+            summary: 'default',
+          },
+        },
       },
       variant: {
         description: 'Variant of the Chip `"default" | "outlined"`',
         options: ['default', 'outlined'],
-        control: { type: 'radio' }
+        control: { type: 'radio' },
+        table: {
+          defaultValue: {
+            summary: 'default',
+          },
+        },
       },
       size: {
         description: 'Size of the Chip `"small" | "medium"`',
         options: ['small', 'medium'],
-        control: { type: 'radio' }
+        control: { type: 'radio' },
+        table: {
+          defaultValue: {
+            summary: 'medium',
+          },
+        },
       },
       component: {
         description: "The component used for the root node. Either a string to use a HTML element or a component.",

--- a/packages/manager/src/components/StackScript/StackScript.tsx
+++ b/packages/manager/src/components/StackScript/StackScript.tsx
@@ -111,12 +111,7 @@ export const SStackScript: React.FC<CombinedProps> = (props) => {
 
       if (imageObj) {
         acc.push(
-          <Chip
-            key={imageObj.id}
-            label={imageObj.label}
-            component="span"
-            clickable={false}
-          />
+          <Chip key={imageObj.id} label={imageObj.label} component="span" />
         );
       }
 

--- a/packages/manager/src/features/Volumes/VolumeTableRow.tsx
+++ b/packages/manager/src/features/Volumes/VolumeTableRow.tsx
@@ -14,7 +14,7 @@ import { formatRegion } from 'src/utilities';
 import { ExtendedVolume } from './types';
 import VolumesActionMenu, { ActionHandlers } from './VolumesActionMenu';
 
-const useStyles = makeStyles((theme: Theme) => ({
+export const useStyles = makeStyles((theme: Theme) => ({
   volumePath: {
     width: '35%',
     wordBreak: 'break-all',


### PR DESCRIPTION
## Description

- Adds `<Chip />` in Storybook with `mdx`
- Minor clean up in `StackScript.tsx`

## 🔎 Preview 
[https://m3-5600-storybook-for-chips.manager-ec2.pages.dev](https://m3-5600-storybook-for-chips.manager-ec2.pages.dev/?path=/docs/ui-elements-chips--chip#chips)

## How to test

- Checkout this PR
- `yarn storybook`
- Test the `Chips` Story in Storybook