### PR TITLE
M3-5636: Updates Object Storage cancellation copy

### DIFF
--- a/packages/manager/src/features/Account/EnableObjectStorage.tsx
+++ b/packages/manager/src/features/Account/EnableObjectStorage.tsx
@@ -31,16 +31,9 @@ export const ObjectStorageContent: React.FC<ContentProps> = (props) => {
       <Grid container direction="column">
         <Grid item>
           <Typography variant="body1">
-            Object Storage is enabled on your account. To cancel Object Storage,
-            all buckets must be removed from the account. For more information
-            on how to delete large amounts of objects within a bucket, consult
-            our guide on{' '}
-            <ExternalLink
-              fixedIcon
-              text="lifecycle policies."
-              link="https://www.linode.com/docs/platform/object-storage/lifecycle-policies/"
-            />{' '}
-            Upon cancellation, all Object Storage Access Keys will be revoked.
+            Object Storage is enabled on your account. Upon cancellation, all
+            Object Storage Access Keys will be revoked, all buckets will be
+            removed, and their objects deleted.
           </Typography>
         </Grid>
         <Grid item>

--- a/packages/manager/src/features/Account/EnableObjectStorage.tsx
+++ b/packages/manager/src/features/Account/EnableObjectStorage.tsx
@@ -31,7 +31,7 @@ export const ObjectStorageContent: React.FC<ContentProps> = (props) => {
       <Grid container direction="column">
         <Grid item>
           <Typography variant="body1">
-            Object Storage is enabled on your account. Upon cancellation, all
+            Object Storage is enabled on your account. Upon cancelation, all
             Object Storage Access Keys will be revoked, all buckets will be
             removed, and their objects deleted.
           </Typography>


### PR DESCRIPTION
## Description

Removes instructions for clearing out and removing buckets from Object Storage cancellation copy, as this now happens automatically on the backend.

## How to test

Run through Object Storage cancellation flow and verify copy is updated to not mention clearing out and removing buckets
