### PR TITLE
DBAAS1-77: Add Database to the Create button

### DIFF
--- a/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.test.tsx
+++ b/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.test.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import LinodeThemeWrapper from 'src/LinodeThemeWrapper';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+import { fireEvent } from '@testing-library/react';
+
+import AddNewMenu from './AddNewMenu';
+
+describe('AddNewMenu', () => {
+  it('should render without error', () => {
+    renderWithTheme(
+      <LinodeThemeWrapper theme="light">
+        <AddNewMenu />
+      </LinodeThemeWrapper>
+    );
+  });
+
+  it('should have an entry for database', () => {
+    const { getByText } = renderWithTheme(
+      <LinodeThemeWrapper theme="light">
+        <AddNewMenu />
+      </LinodeThemeWrapper>,
+      { flags: { databases: true } }
+    );
+    const createButton = getByText('Create');
+    fireEvent.click(createButton);
+    expect(getByText('Database')).not.toBe(undefined);
+  });
+});

--- a/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -193,17 +193,6 @@ class AddNewMenu extends React.Component<CombinedProps> {
                       ItemIcon={VolumeIcon}
                     />
                   </MenuLink>
-                  <MenuLink
-                    as={Link}
-                    to="/nodebalancers/create"
-                    className={classes.menuItemLink}
-                  >
-                    <AddNewMenuItem
-                      title="NodeBalancer"
-                      body="Ensure your services are highly available"
-                      ItemIcon={NodebalancerIcon}
-                    />
-                  </MenuLink>
                   {flags.databases ? (
                     <MenuLink
                       as={Link}
@@ -218,6 +207,17 @@ class AddNewMenu extends React.Component<CombinedProps> {
                       />
                     </MenuLink>
                   ) : null}
+                  <MenuLink
+                    as={Link}
+                    to="/nodebalancers/create"
+                    className={classes.menuItemLink}
+                  >
+                    <AddNewMenuItem
+                      title="NodeBalancer"
+                      body="Ensure your services are highly available"
+                      ItemIcon={NodebalancerIcon}
+                    />
+                  </MenuLink>
                   {showFirewalls ? (
                     <MenuLink
                       as={Link}

--- a/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -19,6 +19,7 @@ import LinodeIcon from 'src/assets/icons/entityIcons/linode.svg';
 import NodebalancerIcon from 'src/assets/icons/entityIcons/nodebalancer.svg';
 import OneClickIcon from 'src/assets/icons/entityIcons/oneclick.svg';
 import VolumeIcon from 'src/assets/icons/entityIcons/volume.svg';
+import DatabaseIcon from 'src/assets/icons/entityIcons/database.svg';
 import {
   createStyles,
   Theme,
@@ -261,6 +262,20 @@ class AddNewMenu extends React.Component<CombinedProps> {
                       attr={{ 'data-qa-one-click-add-new': true }}
                     />
                   </MenuLink>
+                  {flags.databases ? (
+                    <MenuLink
+                      as={Link}
+                      to="/databases/create"
+                      className={classes.menuItemLink}
+                    >
+                      <AddNewMenuItem
+                        title="Database"
+                        body="High-performance database clusters"
+                        ItemIcon={DatabaseIcon}
+                        attr={{ 'data-qa-database-add-new': true }}
+                      />
+                    </MenuLink>
+                  ) : null}
                 </MenuItems>
               </MenuPopover>
             </Menu>

--- a/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -204,6 +204,20 @@ class AddNewMenu extends React.Component<CombinedProps> {
                       ItemIcon={NodebalancerIcon}
                     />
                   </MenuLink>
+                  {flags.databases ? (
+                    <MenuLink
+                      as={Link}
+                      to="/databases/create"
+                      className={classes.menuItemLink}
+                    >
+                      <AddNewMenuItem
+                        title="Database"
+                        body="High-performance database clusters"
+                        ItemIcon={DatabaseIcon}
+                        attr={{ 'data-qa-database-add-new': true }}
+                      />
+                    </MenuLink>
+                  ) : null}
                   {showFirewalls ? (
                     <MenuLink
                       as={Link}
@@ -262,20 +276,6 @@ class AddNewMenu extends React.Component<CombinedProps> {
                       attr={{ 'data-qa-one-click-add-new': true }}
                     />
                   </MenuLink>
-                  {flags.databases ? (
-                    <MenuLink
-                      as={Link}
-                      to="/databases/create"
-                      className={classes.menuItemLink}
-                    >
-                      <AddNewMenuItem
-                        title="Database"
-                        body="High-performance database clusters"
-                        ItemIcon={DatabaseIcon}
-                        attr={{ 'data-qa-database-add-new': true }}
-                      />
-                    </MenuLink>
-                  ) : null}
                 </MenuItems>
               </MenuPopover>
             </Menu>


### PR DESCRIPTION
-------

## Description

Adds a menu item to the Create button menu that directs the user to the database create page.
This feature is feature flagged behind the `databases` flag.

## How to test

1. Open cloud to any page.
2. Click the Create button in the top nav.
3. A new menu item should be there for Database.
   - The new menu item should have a title of Database.
   - The new menu item should have a summary of:
     `High-performance database clusters`
   - The new menu item should have the Database icon.
4. Click the new menu item.
5. Ensure the page you are directed to is the Database create page.

**How do I run relevant unit tests?**