### PR TITLE
M3-5632: Fixed Customer Unable to Edit Cloud Firewall Rules

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/firewallRuleEditor.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/firewallRuleEditor.ts
@@ -251,7 +251,7 @@ export const removeICMPPort = (
     return thisRule;
   });
 
-const removeEmptyAdderessArrays = (rules: ExtendedFirewallRule[]) => {
+const removeEmptyAddressArrays = (rules: ExtendedFirewallRule[]) => {
   return rules.map((rule) => {
     const keepIPv4 = rule.addresses?.ipv4 && rule.addresses.ipv4.length > 0;
     const keepIPv6 = rule.addresses?.ipv6 && rule.addresses.ipv6.length > 0;
@@ -272,7 +272,7 @@ export const filterRulesPendingDeletion = (
   rules.filter((thisRule) => thisRule.status !== 'PENDING_DELETION');
 
 export const prepareRules = compose(
-  removeEmptyAdderessArrays,
+  removeEmptyAddressArrays,
   removeICMPPort,
   filterRulesPendingDeletion,
   editorStateToRules

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/firewallRuleEditor.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/firewallRuleEditor.ts
@@ -251,12 +251,28 @@ export const removeICMPPort = (
     return thisRule;
   });
 
+const removeEmptyAdderessArrays = (rules: ExtendedFirewallRule[]) => {
+  return rules.map((rule) => {
+    const keepIPv4 = rule.addresses?.ipv4 && rule.addresses.ipv4.length > 0;
+    const keepIPv6 = rule.addresses?.ipv6 && rule.addresses.ipv6.length > 0;
+
+    return {
+      ...rule,
+      addresses: {
+        ipv4: keepIPv4 ? rule.addresses?.ipv4 : undefined,
+        ipv6: keepIPv6 ? rule.addresses?.ipv6 : undefined,
+      },
+    };
+  });
+};
+
 export const filterRulesPendingDeletion = (
   rules: ExtendedFirewallRule[]
 ): ExtendedFirewallRule[] =>
   rules.filter((thisRule) => thisRule.status !== 'PENDING_DELETION');
 
 export const prepareRules = compose(
+  removeEmptyAdderessArrays,
   removeICMPPort,
   filterRulesPendingDeletion,
   editorStateToRules


### PR DESCRIPTION
## 🐛 Bug Description

This PR fixes some customers unable to edit Firewall rules

### What would happen
- User was able to click `Save Changes` but no change occurred when editing a firewall rule.
- An API validation error occurred but was not surfaced to the frontend (only viewable in devtools)

### The cause
- This was caused by what we suppose to be a very old firewall rule that had **many** rules with an empty IPv6 array that the API no longer accepts when you make a PUT

### The Fix
- Ensure we don't pass any empty IPv4 or IPv6 arrays in the PUT request

##  🧪 How to test

- I was unable to reproduce on my personal account. Refer to the internal ticket to see which Firewall and Account had this issue
- Test editing a firewall rule in various ways
- Test creating a firewall rule