### PR TITLE
Update URL after redirecting from a URL that doesn't exist

### DIFF
--- a/packages/manager/src/features/Databases/DatabaseDetail/index.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/index.tsx
@@ -34,7 +34,14 @@ export const DatabaseDetail: React.FC = () => {
     const tabChoice = tabs.findIndex((tab) =>
       Boolean(matchPath(tab.routeName, { path: location.pathname }))
     );
-    return tabChoice < 0 ? 0 : tabChoice;
+
+    // Redirect to the landing page if the path does not exist
+    if (tabChoice < 0) {
+      history.push('/databases');
+      return 0;
+    } else {
+      return tabChoice;
+    }
   };
 
   const handleTabChange = (index: number) => {

--- a/packages/manager/src/features/Databases/DatabaseDetail/index.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/index.tsx
@@ -37,7 +37,7 @@ export const DatabaseDetail: React.FC = () => {
 
     // Redirect to the landing page if the path does not exist
     if (tabChoice < 0) {
-      history.push('/databases');
+      history.push(`/databases/${databaseId}`);
       return 0;
     } else {
       return tabChoice;

--- a/packages/manager/src/features/Databases/DatabaseDetail/index.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/index.tsx
@@ -38,10 +38,9 @@ export const DatabaseDetail: React.FC = () => {
     // Redirect to the landing page if the path does not exist
     if (tabChoice < 0) {
       history.push(`/databases/${databaseId}`);
-      return 0;
-    } else {
-      return tabChoice;
     }
+
+    return tabChoice;
   };
 
   const handleTabChange = (index: number) => {


### PR DESCRIPTION
## Description

If a user tries to navigate to a URL that doesn't exist which uses the `SafeTabPanel`, the expected behavior is to redirect them to the content on the default tab. This fixes the issue of the URL not being updated when this happens for DBaaS.

Will release another PR that fixes this for other pages.

## How to test

- Go to `/databases/[id]`
- Navigate to a different tab
- Change the URL to something else (ie. `/databases/[id]/test`)
  - The URL should now be updated to `/databases/[id]`
