### PR TITLE
M3-5638: Fix Editing a Secondary Domain Freezing Cloud Manager

### DIFF
--- a/packages/manager/src/features/Domains/DomainZoneImportDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainZoneImportDrawer.tsx
@@ -61,16 +61,16 @@ class DomainZoneImportDrawer extends React.Component<CombinedProps, State> {
           errorText={remoteNameserverError}
         />
         <ActionsPanel>
+          <Button buttonType="secondary" onClick={this.onClose}>
+            Cancel
+          </Button>
           <Button
             buttonType="primary"
             onClick={this.onSubmit}
             disabled={!requirementsMet}
             loading={submitting}
           >
-            Save
-          </Button>
-          <Button buttonType="secondary" onClick={this.onClose}>
-            Cancel
+            Import
           </Button>
         </ActionsPanel>
       </Drawer>

--- a/packages/manager/src/features/Domains/DomainsLanding.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.tsx
@@ -178,16 +178,6 @@ export const DomainsLanding: React.FC<CombinedProps> = (props) => {
     openForEditing,
   ]);
 
-  React.useEffect(() => {
-    // Open the "Edit Domain" drawer if so specified by this component's props.
-    if (domainForEditing) {
-      props.openForEditing(
-        domainForEditing.domainLabel,
-        domainForEditing.domainId
-      );
-    }
-  }, [domainForEditing, props]);
-
   const navigateToCreate = () => {
     props.history.push(DOMAIN_CREATE_ROUTE);
   };


### PR DESCRIPTION
## 🐛 Bug Description

When searching for a secondary domain and clicking on it, Cloud Manager would freeze and call the useEffect many many times in an infinite loop

https://user-images.githubusercontent.com/6440455/146985697-0613b6f5-00fc-47b3-be43-66832c9801ff.mov

The fix was removing a redundant `useEffect` that called same function as the other `useEffect`

I also fixed the button order in the `Import a Zone` drawer

## How to test

- Test editing a primary and secondary domain
- Test editing from search and from the landing table
- Make sure that what happens in the video above does not happen anymore