### PR TITLE
M3-5641 & 5642: Update URL for invalid paths and cleanup routing

### DIFF
--- a/packages/manager/src/features/Account/AccountLanding.tsx
+++ b/packages/manager/src/features/Account/AccountLanding.tsx
@@ -58,12 +58,22 @@ const AccountLanding: React.FC<Props> = (props) => {
     },
   ].filter(Boolean) as Tab[];
 
-  const matches = (p: string) => {
-    return Boolean(matchPath(p, { path: location.pathname }));
+  const getDefaultTabIndex = () => {
+    const tabChoice = tabs.findIndex((tab) =>
+      Boolean(matchPath(tab.routeName, { path: location.pathname }))
+    );
+
+    // Redirect to the landing page if the path does not exist
+    if (tabChoice < 0) {
+      history.push(`${props.match.url}/billing`);
+      return 0;
+    } else {
+      return tabChoice;
+    }
   };
 
-  const navToURL = (index: number) => {
-    props.history.push(tabs[index].routeName);
+  const handleTabChange = (index: number) => {
+    history.push(tabs[index].routeName);
   };
 
   let idx = 0;
@@ -87,18 +97,12 @@ const AccountLanding: React.FC<Props> = (props) => {
   }
 
   return (
-    <React.Fragment>
+    <>
       <DocumentTitleSegment segment="Account Settings" />
       <TaxBanner location={location} marginBottom={24} />
       <LandingHeader {...landingHeaderProps} data-qa-profile-header />
 
-      <Tabs
-        index={Math.max(
-          tabs.findIndex((tab) => matches(tab.routeName)),
-          0
-        )}
-        onChange={navToURL}
-      >
+      <Tabs index={getDefaultTabIndex()} onChange={handleTabChange}>
         <TabLinkList tabs={tabs} />
 
         <React.Suspense fallback={<SuspenseLoader />}>
@@ -123,7 +127,7 @@ const AccountLanding: React.FC<Props> = (props) => {
           </TabPanels>
         </React.Suspense>
       </Tabs>
-    </React.Fragment>
+    </>
   );
 };
 

--- a/packages/manager/src/features/Account/index.tsx
+++ b/packages/manager/src/features/Account/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Redirect, Route, RouteComponentProps, Switch } from 'react-router-dom';
+import { Redirect, Route, Switch, useRouteMatch } from 'react-router-dom';
 import SuspenseLoader from 'src/components/SuspenseLoader';
 
 const AccountLanding = React.lazy(
@@ -13,32 +13,26 @@ const EntityTransfersCreate = React.lazy(
 );
 const UserDetail = React.lazy(() => import('src/features/Users/UserDetail'));
 
-type Props = RouteComponentProps<{}>;
+const Account: React.FC = () => {
+  const { path } = useRouteMatch();
 
-class Account extends React.Component<Props> {
-  render() {
-    const {
-      match: { path },
-    } = this.props;
+  return (
+    <React.Suspense fallback={<SuspenseLoader />}>
+      <Switch>
+        <Route component={UserDetail} path={`${path}/users/:username`} />
+        <Route
+          component={InvoiceDetail}
+          path={`${path}/billing/invoices/:invoiceId`}
+        />
+        <Route
+          component={EntityTransfersCreate}
+          path={`${path}/service-transfers/create`}
+        />
+        <Redirect from={path} to={`${path}/billing`} exact />
+        <Route component={AccountLanding} path={path} />
+      </Switch>
+    </React.Suspense>
+  );
+};
 
-    return (
-      <React.Suspense fallback={<SuspenseLoader />}>
-        <Switch>
-          <Route path={`${path}/users/:username`} component={UserDetail} />
-          <Route
-            exact
-            path={`${path}/billing/invoices/:invoiceId`}
-            component={InvoiceDetail}
-          />
-          <Route
-            path={`${path}/service-transfers/create`}
-            component={EntityTransfersCreate}
-          />
-          <Redirect exact from="/account" to="/account/billing" />
-          <Route path={`${path}`} component={AccountLanding} />
-        </Switch>
-      </React.Suspense>
-    );
-  }
-}
 export default Account;

--- a/packages/manager/src/features/Domains/DomainDetail/index.tsx
+++ b/packages/manager/src/features/Domains/DomainDetail/index.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { RouteComponentProps } from 'react-router-dom';
+import { RouteComponentProps, useHistory } from 'react-router-dom';
 import CircleProgress from 'src/components/CircleProgress';
 import NotFound from 'src/components/NotFound';
 import { useAPIRequest } from 'src/hooks/useAPIRequest';
 import useDomains from 'src/hooks/useDomains';
+
 const DomainsLanding = React.lazy(() => import('../DomainsLanding'));
 const DomainDetail = React.lazy(() => import('./DomainDetail'));
 
@@ -15,6 +16,7 @@ export const DomainDetailRouting: React.FC<
   const domainId = Number(props.match.params.domainId);
   const { domains, requestDomain } = useDomains();
   const request = useAPIRequest(() => requestDomain(domainId), undefined);
+  const history = useHistory();
 
   // The Domain from the store that matches this ID.
   const foundDomain = Object.values(domains.itemsById).find(
@@ -26,9 +28,13 @@ export const DomainDetailRouting: React.FC<
     if (!request.loading && request.lastUpdated > 0) {
       return <NotFound />;
     }
-    // If not, we don't know if the Domain exists yet so we have to stall
+    // If not, we don't know if the Domain exists yet so we have to stall.
+    setTimeout(() => {
+      history.push('/domains');
+    }, 5000);
     return <CircleProgress />;
   }
+
   // Primary Domains have a Detail page.
   if (foundDomain.type === 'master') {
     return <DomainDetail {...props} />;

--- a/packages/manager/src/features/Domains/index.tsx
+++ b/packages/manager/src/features/Domains/index.tsx
@@ -18,19 +18,9 @@ const DomainsRoutes: React.FC = () => {
   return (
     <React.Suspense fallback={<SuspenseLoader />}>
       <Switch>
-        <Route component={DomainCreate} path={`${path}/create`} exact />
-        <Route
-          component={DomainDetail}
-          path={`${path}/:domainId/records`}
-          exact
-          strict
-        />
-        <Route
-          component={DomainDetail}
-          path={`${path}/:domainId`}
-          exact
-          strict
-        />
+        <Route component={DomainCreate} path={`${path}/create`} />
+        <Route component={DomainDetail} path={`${path}/:domainId/records`} />
+        <Route component={DomainDetail} path={`${path}/:domainId`} />
         <Route component={DomainsLanding} path={path} exact strict />
         <Redirect to={path} />
       </Switch>

--- a/packages/manager/src/features/Domains/index.tsx
+++ b/packages/manager/src/features/Domains/index.tsx
@@ -2,48 +2,40 @@ import * as React from 'react';
 import {
   Redirect,
   Route,
-  RouteComponentProps,
   Switch,
+  useRouteMatch,
   withRouter,
 } from 'react-router-dom';
-import { compose } from 'recompose';
-
 import SuspenseLoader from 'src/components/SuspenseLoader';
 
-const DomainCreate = React.lazy(() => import('./CreateDomain'));
 const DomainsLanding = React.lazy(() => import('./DomainsLanding'));
 const DomainDetail = React.lazy(() => import('./DomainDetail'));
+const DomainCreate = React.lazy(() => import('./CreateDomain'));
 
-type CombinedProps = RouteComponentProps<{ domainId?: string }>;
-
-const DomainsRoutes: React.FC<CombinedProps> = (props) => {
-  const {
-    match: { path },
-  } = props;
+const DomainsRoutes: React.FC = () => {
+  const { path } = useRouteMatch();
 
   return (
     <React.Suspense fallback={<SuspenseLoader />}>
       <Switch>
-        <Route component={DomainCreate} exact path={`${path}/create`} />
+        <Route component={DomainCreate} path={`${path}/create`} exact />
         <Route
+          component={DomainDetail}
           path={`${path}/:domainId/records`}
           exact
           strict
-          component={DomainDetail}
         />
         <Route
+          component={DomainDetail}
           path={`${path}/:domainId`}
           exact
           strict
-          component={DomainDetail}
         />
         <Route component={DomainsLanding} path={path} exact strict />
-        <Redirect to={`${path}`} />
+        <Redirect to={path} />
       </Switch>
     </React.Suspense>
   );
 };
 
-const enhanced = compose<CombinedProps, {}>(withRouter);
-
-export default enhanced(DomainsRoutes);
+export default withRouter(DomainsRoutes);

--- a/packages/manager/src/features/Domains/index.tsx
+++ b/packages/manager/src/features/Domains/index.tsx
@@ -18,9 +18,19 @@ const DomainsRoutes: React.FC = () => {
   return (
     <React.Suspense fallback={<SuspenseLoader />}>
       <Switch>
-        <Route component={DomainCreate} path={`${path}/create`} />
-        <Route component={DomainDetail} path={`${path}/:domainId/records`} />
-        <Route component={DomainDetail} path={`${path}/:domainId`} />
+        <Route component={DomainCreate} path={`${path}/create`} exact strict />
+        <Route
+          component={DomainDetail}
+          path={`${path}/:domainId/records`}
+          exact
+          strict
+        />
+        <Route
+          component={DomainDetail}
+          path={`${path}/:domainId`}
+          exact
+          strict
+        />
         <Route component={DomainsLanding} path={path} exact strict />
         <Redirect to={path} />
       </Switch>

--- a/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { matchPath, RouteComponentProps, useHistory } from 'react-router-dom';
+import { matchPath, RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
 import Breadcrumb from 'src/components/Breadcrumb';
 import CircleProgress from 'src/components/CircleProgress';
@@ -16,8 +16,8 @@ import TabLinkList from 'src/components/TabLinkList';
 import withFirewalls, {
   Props as WithFirewallsProps,
 } from 'src/containers/firewalls.container';
-import { useProfile, useGrants } from 'src/queries/profile';
 import { useFirewallQuery, useMutateFirewall } from 'src/queries/firewalls';
+import { useGrants, useProfile } from 'src/queries/profile';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 
 const FirewallRulesLanding = React.lazy(
@@ -40,7 +40,6 @@ export const FirewallDetail: React.FC<CombinedProps> = (props) => {
   const classes = useStyles();
   const { data: profile } = useProfile();
   const { data: grants } = useGrants();
-  const history = useHistory();
 
   // Source the Firewall's ID from the /:id path param.
   const thisFirewallId = props.match.params.id;
@@ -69,7 +68,7 @@ export const FirewallDetail: React.FC<CombinedProps> = (props) => {
 
     // Redirect to the landing page if the path does not exist
     if (tabChoice < 0) {
-      history.push(`${URL}`);
+      props.history.push(`${URL}`);
       return 0;
     } else {
       return tabChoice;
@@ -77,7 +76,7 @@ export const FirewallDetail: React.FC<CombinedProps> = (props) => {
   };
 
   const handleTabChange = (index: number) => {
-    history.push(tabs[index].routeName);
+    props.history.push(tabs[index].routeName);
   };
 
   const { data } = useFirewallQuery();

--- a/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { matchPath, RouteComponentProps } from 'react-router-dom';
+import { matchPath, RouteComponentProps, useHistory } from 'react-router-dom';
 import { compose } from 'recompose';
 import Breadcrumb from 'src/components/Breadcrumb';
 import CircleProgress from 'src/components/CircleProgress';
@@ -40,6 +40,7 @@ export const FirewallDetail: React.FC<CombinedProps> = (props) => {
   const classes = useStyles();
   const { data: profile } = useProfile();
   const { data: grants } = useGrants();
+  const history = useHistory();
 
   // Source the Firewall's ID from the /:id path param.
   const thisFirewallId = props.match.params.id;
@@ -61,12 +62,22 @@ export const FirewallDetail: React.FC<CombinedProps> = (props) => {
     },
   ];
 
-  const matches = (p: string) => {
-    return Boolean(matchPath(p, { path: props.location.pathname }));
+  const getDefaultTabIndex = () => {
+    const tabChoice = tabs.findIndex((tab) =>
+      Boolean(matchPath(tab.routeName, { path: location.pathname }))
+    );
+
+    // Redirect to the landing page if the path does not exist
+    if (tabChoice < 0) {
+      history.push(`${URL}`);
+      return 0;
+    } else {
+      return tabChoice;
+    }
   };
 
-  const navToURL = (index: number) => {
-    props.history.push(tabs[index].routeName);
+  const handleTabChange = (index: number) => {
+    history.push(tabs[index].routeName);
   };
 
   const { data } = useFirewallQuery();
@@ -133,15 +144,8 @@ export const FirewallDetail: React.FC<CombinedProps> = (props) => {
           <DocsLink href="https://linode.com/docs/platform/cloud-firewall/getting-started-with-cloud-firewall/" />
         </Grid>
       </Grid>
-      <Tabs
-        index={Math.max(
-          tabs.findIndex((tab) => matches(tab.routeName)),
-          0
-        )}
-        onChange={navToURL}
-      >
+      <Tabs index={getDefaultTabIndex()} onChange={handleTabChange}>
         <TabLinkList tabs={tabs} />
-
         <TabPanels>
           <SafeTabPanel index={0}>
             <FirewallRulesLanding

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallLanding.tsx
@@ -7,16 +7,17 @@ import {
 } from 'react-router-dom';
 import { compose } from 'recompose';
 import CircleProgress from 'src/components/CircleProgress';
+import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import EntityTable from 'src/components/EntityTable';
 import LandingHeader from 'src/components/LandingHeader';
+import { queryClient } from 'src/queries/base';
 import {
   useCreateFirewall,
   useDeleteFirewall,
   useFirewallQuery,
   useMutateFirewall,
 } from 'src/queries/firewalls';
-import { queryClient } from 'src/queries/base';
-import { useProfile, queryKey } from 'src/queries/profile';
+import { queryKey, useProfile } from 'src/queries/profile';
 import AddFirewallDrawer from './AddFirewallDrawer';
 import { ActionHandlers as FirewallHandlers } from './FirewallActionMenu';
 import FirewallDialog, { Mode } from './FirewallDialog';
@@ -189,7 +190,8 @@ const FirewallLanding: React.FC<CombinedProps> = () => {
   };
 
   return (
-    <React.Fragment>
+    <>
+      <DocumentTitleSegment segment="Firewalls" />
       <LandingHeader
         title="Firewalls"
         entity="Firewall"
@@ -219,7 +221,7 @@ const FirewallLanding: React.FC<CombinedProps> = () => {
         selectedFirewallLabel={selectedFirewallLabel}
         closeDialog={() => toggleModal(false)}
       />
-    </React.Fragment>
+    </>
   );
 };
 

--- a/packages/manager/src/features/Firewalls/index.tsx
+++ b/packages/manager/src/features/Firewalls/index.tsx
@@ -1,34 +1,22 @@
 import * as React from 'react';
-import { Route, RouteComponentProps, Switch } from 'react-router-dom';
-import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import { Route, Switch, useRouteMatch } from 'react-router-dom';
 import SuspenseLoader from 'src/components/SuspenseLoader';
 import useReduxLoad from 'src/hooks/useReduxLoad';
 
 const FirewallLanding = React.lazy(() => import('./FirewallLanding'));
-
 const FirewallDetail = React.lazy(() => import('./FirewallDetail'));
 
-type Props = RouteComponentProps<{}>;
-
-type CombinedProps = Props;
-
-const Firewall: React.FC<CombinedProps> = (props) => {
-  const {
-    match: { path },
-  } = props;
-
+const Firewall: React.FC = () => {
+  const { path } = useRouteMatch();
   useReduxLoad(['firewalls']);
 
   return (
     <React.Suspense fallback={<SuspenseLoader />}>
-      <React.Fragment>
-        <DocumentTitleSegment segment="Firewalls" />
-        <Switch>
-          <Route exact path={`${path}(/create)?`} component={FirewallLanding} />
-          <Route path={`${path}/:id`} component={FirewallDetail} />
-          <Route component={FirewallLanding} />
-        </Switch>
-      </React.Fragment>
+      <Switch>
+        <Route component={FirewallLanding} path={`${path}/create`} />
+        <Route component={FirewallDetail} path={`${path}/:id`} />
+        <Route component={FirewallLanding} exact strict />
+      </Switch>
     </React.Suspense>
   );
 };

--- a/packages/manager/src/features/Help/index.tsx
+++ b/packages/manager/src/features/Help/index.tsx
@@ -1,43 +1,35 @@
 import * as React from 'react';
-import { Redirect, Route, Switch } from 'react-router-dom';
+import { Redirect, Route, Switch, useRouteMatch } from 'react-router-dom';
 import StatusBanners from './StatusBanners';
 
 const HelpLanding = React.lazy(() => import('./HelpLanding'));
-
 const SupportSearchLanding = React.lazy(
   () => import('src/features/Help/SupportSearchLanding')
-);
-
-const SupportTickets = React.lazy(
-  () => import('src/features/Support/SupportTickets')
 );
 const SupportTicketDetail = React.lazy(
   () => import('src/features/Support/SupportTicketDetail')
 );
+const SupportTickets = React.lazy(
+  () => import('src/features/Support/SupportTickets')
+);
 
-const HelpAndSupport: React.FC<{}> = (_) => {
+const HelpAndSupport: React.FC = () => {
+  const { path } = useRouteMatch();
+
   return (
     <>
       <StatusBanners />
       <Switch>
         <Route
-          exact
-          strict
-          path="/support/tickets"
-          component={SupportTickets}
-        />
-        <Route
-          path="/support/tickets/:ticketId"
           component={SupportTicketDetail}
-          exact
-          strict
+          path={`${path}/tickets/:ticketId`}
         />
-        <Route path="/support/search/" component={SupportSearchLanding} />
-
-        <Route path="/support">
+        <Route component={SupportTickets} path={`${path}/tickets`} />
+        <Route component={SupportSearchLanding} path={`${path}/search`} />
+        <Route path={path} exact strict>
           <HelpLanding />
         </Route>
-        <Redirect to={'/support'} />
+        <Redirect to={path} />
       </Switch>
     </>
   );

--- a/packages/manager/src/features/Help/index.tsx
+++ b/packages/manager/src/features/Help/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Redirect, Route, Switch, useRouteMatch } from 'react-router-dom';
+import { Route, Switch, useRouteMatch } from 'react-router-dom';
 import StatusBanners from './StatusBanners';
 
 const HelpLanding = React.lazy(() => import('./HelpLanding'));
@@ -23,13 +23,24 @@ const HelpAndSupport: React.FC = () => {
         <Route
           component={SupportTicketDetail}
           path={`${path}/tickets/:ticketId`}
+          exact
+          strict
         />
-        <Route component={SupportTickets} path={`${path}/tickets`} />
-        <Route component={SupportSearchLanding} path={`${path}/search`} />
+        <Route
+          component={SupportTickets}
+          path={`${path}/tickets`}
+          exact
+          strict
+        />
+        <Route
+          component={SupportSearchLanding}
+          path={`${path}/search`}
+          exact
+          strict
+        />
         <Route path={path} exact strict>
           <HelpLanding />
         </Route>
-        <Redirect to={path} />
       </Switch>
     </>
   );

--- a/packages/manager/src/features/Images/index.tsx
+++ b/packages/manager/src/features/Images/index.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import {
   Redirect,
   Route,
-  RouteComponentProps,
   Switch,
+  useRouteMatch,
   withRouter,
 } from 'react-router-dom';
 import SuspenseLoader from 'src/components/SuspenseLoader';
@@ -16,15 +16,10 @@ const ImageCreate = React.lazy(
   () => import('./ImagesCreate/ImageCreateContainer')
 );
 
-type Props = RouteComponentProps<{}>;
-
-export const ImagesRoutes: React.FC<Props> = (props) => {
-  const {
-    match: { path },
-  } = props;
-
+export const ImagesRoutes: React.FC = () => {
   const flags = useFlags();
   const { account } = useAccountManagement();
+  const { path } = useRouteMatch();
 
   const machineImagesEnabled = isFeatureEnabled(
     'Machine Images',
@@ -35,11 +30,11 @@ export const ImagesRoutes: React.FC<Props> = (props) => {
   return (
     <React.Suspense fallback={<SuspenseLoader />}>
       <Switch>
-        <Route component={ImagesLanding} path={path} exact />
         {machineImagesEnabled ? (
           <Route component={ImageCreate} path={`${path}/create`} />
         ) : null}
-        <Redirect to="/images" />
+        <Route component={ImagesLanding} path={path} exact strict />
+        <Redirect to={path} />
       </Switch>
     </React.Suspense>
   );

--- a/packages/manager/src/features/Kubernetes/index.tsx
+++ b/packages/manager/src/features/Kubernetes/index.tsx
@@ -1,35 +1,42 @@
 import * as React from 'react';
-import { Redirect, Route, Switch } from 'react-router-dom';
+import {
+  Redirect,
+  Route,
+  Switch,
+  useParams,
+  useRouteMatch,
+} from 'react-router-dom';
 import SuspenseLoader from 'src/components/SuspenseLoader';
 
 const KubernetesLanding = React.lazy(() => import('./KubernetesLanding'));
-const ClusterCreate = React.lazy(() => import('./CreateCluster'));
 const ClusterDetail = React.lazy(() => import('./KubernetesClusterDetail'));
+const ClusterCreate = React.lazy(() => import('./CreateCluster'));
 
 const Kubernetes: React.FC = () => {
+  const { path } = useRouteMatch();
+  const { clusterID } = useParams<{ clusterID: string }>();
+
   return (
     <React.Suspense fallback={<SuspenseLoader />}>
       <Switch>
-        <Route component={ClusterCreate} path={`/kubernetes/create`} />
+        <Route component={ClusterCreate} path={`${path}/create`} />
         <Route
           component={ClusterDetail}
-          exact
-          path={`/kubernetes/clusters/:clusterID/summary`}
+          path={`${path}/clusters/:clusterID/summary`}
         />
         <Route
-          path={`/kubernetes/clusters/:clusterID`}
-          render={(props) => (
-            <Redirect
-              to={`/kubernetes/clusters/${props.match.params.clusterID}/summary`}
-            />
+          path={`${path}/clusters/:clusterID`}
+          render={() => (
+            <Redirect to={`${path}/clusters/${clusterID}/summary`} />
           )}
         />
         <Route
           component={KubernetesLanding}
+          path={`${path}/clusters`}
           exact
-          path={`/kubernetes/clusters`}
+          strict
         />
-        <Redirect to={'/kubernetes/clusters'} />
+        <Redirect to={`${path}/clusters`} />
       </Switch>
     </React.Suspense>
   );

--- a/packages/manager/src/features/Kubernetes/index.tsx
+++ b/packages/manager/src/features/Kubernetes/index.tsx
@@ -1,11 +1,5 @@
 import * as React from 'react';
-import {
-  Redirect,
-  Route,
-  Switch,
-  useParams,
-  useRouteMatch,
-} from 'react-router-dom';
+import { Redirect, Route, Switch, useRouteMatch } from 'react-router-dom';
 import SuspenseLoader from 'src/components/SuspenseLoader';
 
 const KubernetesLanding = React.lazy(() => import('./KubernetesLanding'));
@@ -14,21 +8,20 @@ const ClusterCreate = React.lazy(() => import('./CreateCluster'));
 
 const Kubernetes: React.FC = () => {
   const { path } = useRouteMatch();
-  const { clusterID } = useParams<{ clusterID: string }>();
 
   return (
     <React.Suspense fallback={<SuspenseLoader />}>
       <Switch>
-        <Route component={ClusterCreate} path={`${path}/create`} />
-        <Route
-          component={ClusterDetail}
-          path={`${path}/clusters/:clusterID/summary`}
+        <Route component={ClusterCreate} path={`${path}/create`} exact strict />
+        <Redirect
+          from={`${path}/clusters/:clusterID/summary`}
+          to={`${path}/clusters/:clusterID`}
         />
         <Route
+          component={ClusterDetail}
           path={`${path}/clusters/:clusterID`}
-          render={() => (
-            <Redirect to={`${path}/clusters/${clusterID}/summary`} />
-          )}
+          exact
+          strict
         />
         <Route
           component={KubernetesLanding}

--- a/packages/manager/src/features/Lish/Lish.tsx
+++ b/packages/manager/src/features/Lish/Lish.tsx
@@ -215,7 +215,21 @@ class Lish extends React.Component<CombinedProps, State> {
         : null,
     ].filter(Boolean) as Tab[];
 
-    const navToURL = (index: number) => {
+    const getDefaultTabIndex = () => {
+      const tabChoice = tabs.findIndex((tab) =>
+        Boolean(matchPath(tab.routeName, { path: location.pathname }))
+      );
+
+      // Redirect to the landing page if the path does not exist
+      if (tabChoice < 0) {
+        this.props.history.push(`${this.props.match.url}`);
+        return 0;
+      } else {
+        return tabChoice;
+      }
+    };
+
+    const handleTabChange = (index: number) => {
       this.props.history.push(tabs[index].routeName);
     };
 
@@ -247,7 +261,11 @@ class Lish extends React.Component<CombinedProps, State> {
       // eslint-disable-next-line react/jsx-no-useless-fragment
       <React.Fragment>
         {linode && token && (
-          <Tabs className={classes.tabs} onChange={navToURL}>
+          <Tabs
+            className={classes.tabs}
+            index={getDefaultTabIndex()}
+            onChange={handleTabChange}
+          >
             <TabLinkList className={classes.lish} tabs={tabs} />
             <TabPanels>
               <SafeTabPanel index={0} data-qa-tab="Weblish">

--- a/packages/manager/src/features/Longview/LongviewDetail/LongviewDetail.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/LongviewDetail.tsx
@@ -1,7 +1,7 @@
 import { LongviewClient } from '@linode/api-v4/lib/longview';
 import { pathOr } from 'ramda';
 import * as React from 'react';
-import { matchPath, RouteComponentProps, useHistory } from 'react-router-dom';
+import { matchPath, RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
 import Breadcrumb from 'src/components/Breadcrumb';
 import CircleProgress from 'src/components/CircleProgress';
@@ -78,7 +78,6 @@ export const LongviewDetail: React.FC<CombinedProps> = (props) => {
   const timezone = profile?.timezone || 'US/Eastern';
 
   const classes = useStyles();
-  const history = useHistory();
 
   React.useEffect(() => {
     /** request clients if they haven't already been requested */
@@ -170,7 +169,7 @@ export const LongviewDetail: React.FC<CombinedProps> = (props) => {
 
     // Redirect to the landing page if the path does not exist
     if (tabChoice < 0) {
-      history.push(`${props.match.url}`);
+      props.history.push(`${props.match.url}`);
       return 0;
     } else {
       return tabChoice;
@@ -178,7 +177,7 @@ export const LongviewDetail: React.FC<CombinedProps> = (props) => {
   };
 
   const handleTabChange = (index: number) => {
-    history.push(tabs[index].routeName);
+    props.history.push(tabs[index].routeName);
   };
 
   // Filtering out conditional tabs if they don't exist on client

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewLanding.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewLanding.tsx
@@ -9,7 +9,7 @@ import {
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import { isEmpty } from 'ramda';
 import * as React from 'react';
-import { matchPath, RouteComponentProps } from 'react-router-dom';
+import { matchPath, RouteComponentProps, useHistory } from 'react-router-dom';
 import { compose } from 'recompose';
 import TabPanels from 'src/components/core/ReachTabPanels';
 import Tabs from 'src/components/core/ReachTabs';
@@ -44,6 +44,7 @@ export const LongviewLanding: React.FunctionComponent<CombinedProps> = (
     () => getLongviewSubscriptions().then((response) => response.data),
     []
   );
+  const history = useHistory();
 
   const { createLongviewClient } = props;
 
@@ -67,12 +68,22 @@ export const LongviewLanding: React.FunctionComponent<CombinedProps> = (
     },
   ];
 
-  const matches = (p: string) => {
-    return Boolean(matchPath(p, { path: props.location.pathname }));
+  const getDefaultTabIndex = () => {
+    const tabChoice = tabs.findIndex((tab) =>
+      Boolean(matchPath(tab.routeName, { path: location.pathname }))
+    );
+
+    // Redirect to the landing page if the path does not exist
+    if (tabChoice < 0) {
+      history.push(`${props.match.url}`);
+      return 0;
+    } else {
+      return tabChoice;
+    }
   };
 
-  const navToURL = (index: number) => {
-    props.history.push(tabs[index].routeName);
+  const handleTabChange = (index: number) => {
+    history.push(tabs[index].routeName);
   };
 
   const handleAddClient = () => {
@@ -133,15 +144,11 @@ export const LongviewLanding: React.FunctionComponent<CombinedProps> = (
         removeCrumbX={1}
       />
       <Tabs
-        index={Math.max(
-          tabs.findIndex((tab) => matches(tab.routeName)),
-          0
-        )}
-        onChange={navToURL}
+        index={getDefaultTabIndex()}
+        onChange={handleTabChange}
         style={{ marginTop: 0 }}
       >
         <TabLinkList tabs={tabs} />
-
         <React.Suspense fallback={<SuspenseLoader />}>
           <TabPanels>
             <SafeTabPanel index={0}>

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewLanding.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewLanding.tsx
@@ -13,6 +13,7 @@ import { matchPath, RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
 import TabPanels from 'src/components/core/ReachTabPanels';
 import Tabs from 'src/components/core/ReachTabs';
+import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import LandingHeader from 'src/components/LandingHeader';
 import SafeTabPanel from 'src/components/SafeTabPanel';
 import SuspenseLoader from 'src/components/SuspenseLoader';
@@ -121,6 +122,7 @@ export const LongviewLanding: React.FunctionComponent<CombinedProps> = (
 
   return (
     <>
+      <DocumentTitleSegment segment="Longview" />
       <LandingHeader
         title="Longview"
         entity="Client"

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewLanding.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewLanding.tsx
@@ -9,7 +9,7 @@ import {
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import { isEmpty } from 'ramda';
 import * as React from 'react';
-import { matchPath, RouteComponentProps, useHistory } from 'react-router-dom';
+import { matchPath, RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
 import TabPanels from 'src/components/core/ReachTabPanels';
 import Tabs from 'src/components/core/ReachTabs';
@@ -44,7 +44,6 @@ export const LongviewLanding: React.FunctionComponent<CombinedProps> = (
     () => getLongviewSubscriptions().then((response) => response.data),
     []
   );
-  const history = useHistory();
 
   const { createLongviewClient } = props;
 
@@ -75,7 +74,7 @@ export const LongviewLanding: React.FunctionComponent<CombinedProps> = (
 
     // Redirect to the landing page if the path does not exist
     if (tabChoice < 0) {
-      history.push(`${props.match.url}`);
+      props.history.push(`${props.match.url}`);
       return 0;
     } else {
       return tabChoice;
@@ -83,7 +82,7 @@ export const LongviewLanding: React.FunctionComponent<CombinedProps> = (
   };
 
   const handleTabChange = (index: number) => {
-    history.push(tabs[index].routeName);
+    props.history.push(tabs[index].routeName);
   };
 
   const handleAddClient = () => {

--- a/packages/manager/src/features/Longview/index.tsx
+++ b/packages/manager/src/features/Longview/index.tsx
@@ -1,28 +1,20 @@
 import * as React from 'react';
-import { Route, RouteComponentProps, Switch } from 'react-router-dom';
-import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import { Route, Switch, useRouteMatch } from 'react-router-dom';
 import SuspenseLoader from 'src/components/SuspenseLoader';
 
 const LongviewLanding = React.lazy(() => import('./LongviewLanding'));
 const LongviewDetail = React.lazy(() => import('./LongviewDetail'));
 
-type Props = RouteComponentProps<{}>;
-
-const Longview: React.FC<Props> = (props) => {
-  const {
-    match: { path },
-  } = props;
+const Longview: React.FC = () => {
+  const { path } = useRouteMatch();
 
   return (
-    <React.Fragment>
-      <DocumentTitleSegment segment="Longview" />
-      <React.Suspense fallback={<SuspenseLoader />}>
-        <Switch>
-          <Route component={LongviewDetail} path={`${path}/clients/:id`} />
-          <Route component={LongviewLanding} />
-        </Switch>
-      </React.Suspense>
-    </React.Fragment>
+    <React.Suspense fallback={<SuspenseLoader />}>
+      <Switch>
+        <Route component={LongviewDetail} path={`${path}/clients/:id`} />
+        <Route component={LongviewLanding} />
+      </Switch>
+    </React.Suspense>
   );
 };
 

--- a/packages/manager/src/features/Managed/index.tsx
+++ b/packages/manager/src/features/Managed/index.tsx
@@ -8,7 +8,7 @@ const Managed: React.FC = () => {
   return (
     <React.Suspense fallback={<SuspenseLoader />}>
       <Switch>
-        <Route component={ManagedLanding} exact strict />
+        <Route component={ManagedLanding} />
       </Switch>
     </React.Suspense>
   );

--- a/packages/manager/src/features/Managed/index.tsx
+++ b/packages/manager/src/features/Managed/index.tsx
@@ -1,30 +1,17 @@
 import * as React from 'react';
-import {
-  Route,
-  RouteComponentProps,
-  Switch,
-  withRouter,
-} from 'react-router-dom';
+import { Route, Switch, withRouter } from 'react-router-dom';
 import SuspenseLoader from 'src/components/SuspenseLoader';
 
 const ManagedLanding = React.lazy(() => import('./ManagedLanding'));
 
-type Props = RouteComponentProps<{}>;
-
-class Managed extends React.Component<Props> {
-  render() {
-    const {
-      match: { path },
-    } = this.props;
-
-    return (
-      <React.Suspense fallback={<SuspenseLoader />}>
-        <Switch>
-          <Route component={ManagedLanding} path={path} />
-        </Switch>
-      </React.Suspense>
-    );
-  }
-}
+const Managed: React.FC = () => {
+  return (
+    <React.Suspense fallback={<SuspenseLoader />}>
+      <Switch>
+        <Route component={ManagedLanding} exact strict />
+      </Switch>
+    </React.Suspense>
+  );
+};
 
 export default withRouter(Managed);

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -1,3 +1,4 @@
+import { Agreements, signAgreement } from '@linode/api-v4/lib/account';
 import { APIError } from '@linode/api-v4/lib/types';
 import {
   append,
@@ -40,6 +41,11 @@ import { dcDisplayCountry } from 'src/constants';
 import withRegions from 'src/containers/regions.container';
 import { hasGrant } from 'src/features/Profile/permissionsHelpers';
 import {
+  queryKey,
+  reportAgreementSigningError,
+} from 'src/queries/accountAgreements';
+import { queryClient, simpleMutationHandlers } from 'src/queries/base';
+import {
   withNodeBalancerActions,
   WithNodeBalancerActions,
 } from 'src/store/nodeBalancer/nodeBalancer.containers';
@@ -48,7 +54,6 @@ import { isEURegion } from 'src/utilities/formatRegion';
 import { sendCreateNodeBalancerEvent } from 'src/utilities/ga';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
-import { Agreements, signAgreement } from '@linode/api-v4/lib/account';
 import EUAgreementCheckbox from '../Account/Agreements/EUAgreementCheckbox';
 import withAgreements, {
   AgreementsProps,
@@ -60,11 +65,6 @@ import {
   NodeBalancerConfigFieldsWithStatus,
   transformConfigsForRequest,
 } from './utils';
-import { queryClient, simpleMutationHandlers } from 'src/queries/base';
-import {
-  queryKey,
-  reportAgreementSigningError,
-} from 'src/queries/accountAgreements';
 
 type ClassNames = 'title' | 'sidebar';
 
@@ -530,9 +530,9 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
       <React.Fragment>
         <DocumentTitleSegment segment="Create a NodeBalancer" />
         <Grid container className="m0">
-          <Grid item className={`mlMain p0`}>
+          <Grid item className="mlMain p0">
             <Breadcrumb
-              pathname="/NodeBalancers/Create"
+              pathname="/nodebalancers/create"
               data-qa-create-nodebalancer-header
             />
             {generalError && !this.disabled && (

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
@@ -19,8 +19,8 @@ import {
   withStyles,
   WithStyles,
 } from 'src/components/core/styles';
-import setDocs from 'src/components/DocsSidebar/setDocs';
 import DocsLink from 'src/components/DocsLink';
+import setDocs from 'src/components/DocsSidebar/setDocs';
 import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
@@ -251,6 +251,24 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
     },
   ];
 
+  getDefaultTabIndex = () => {
+    const tabChoice = this.tabs.findIndex((tab) =>
+      Boolean(matchPath(tab.routeName, { path: location.pathname }))
+    );
+
+    // Redirect to the landing page if the path does not exist
+    if (tabChoice < 0) {
+      this.props.history.push(`${this.props.match.url}`);
+      return 0;
+    } else {
+      return tabChoice;
+    }
+  };
+
+  handleTabChange = (index: number) => {
+    this.props.history.push(this.tabs[index].routeName);
+  };
+
   updateNodeBalancerState = (data: NodeBalancer) => {
     if (this.state.nodeBalancer) {
       this.setState({
@@ -265,8 +283,6 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
   };
 
   render() {
-    const matches = (pathName: string) =>
-      Boolean(matchPath(this.props.location.pathname, { path: pathName }));
     const { classes, error, loading } = this.props;
     const { nodeBalancer } = this.state;
 
@@ -299,10 +315,6 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
       updateTags: this.updateTags,
     };
 
-    const navToURL = (index: number) => {
-      this.props.history.push(this.tabs[index].routeName);
-    };
-
     return (
       <NodeBalancerProvider value={p}>
         <React.Fragment>
@@ -329,14 +341,10 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
           </Grid>
           {errorMap.none && <Notice error text={errorMap.none} />}
           <Tabs
-            index={Math.max(
-              this.tabs.findIndex((tab) => matches(tab.routeName)),
-              0
-            )}
-            onChange={navToURL}
+            index={this.getDefaultTabIndex()}
+            onChange={this.handleTabChange}
           >
             <TabLinkList tabs={this.tabs} />
-
             <TabPanels>
               <SafeTabPanel index={0}>
                 <NodeBalancerSummary
@@ -348,14 +356,12 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
                   )}
                 />
               </SafeTabPanel>
-
               <SafeTabPanel index={1}>
                 <NodeBalancerConfigurations
                   nodeBalancerLabel={nodeBalancer.label}
                   nodeBalancerRegion={nodeBalancer.region}
                 />
               </SafeTabPanel>
-
               <SafeTabPanel index={2}>
                 <NodeBalancerSettings
                   nodeBalancerId={nodeBalancer.id}

--- a/packages/manager/src/features/NodeBalancers/NodeBalancers.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancers.tsx
@@ -1,37 +1,33 @@
 import * as React from 'react';
 import {
+  Redirect,
   Route,
-  RouteComponentProps,
   Switch,
+  useRouteMatch,
   withRouter,
 } from 'react-router-dom';
 import SuspenseLoader from 'src/components/SuspenseLoader';
 
-const NodeBalancerDetail = React.lazy(() => import('./NodeBalancerDetail'));
 const NodeBalancersLanding = React.lazy(() => import('./NodeBalancersLanding'));
+const NodeBalancerDetail = React.lazy(() => import('./NodeBalancerDetail'));
 const NodeBalancerCreate = React.lazy(() => import('./NodeBalancerCreate'));
 
-type Props = RouteComponentProps<{}>;
+export const NodeBalancers: React.FC = () => {
+  const { path } = useRouteMatch();
 
-class NodeBalancers extends React.Component<Props> {
-  render() {
-    const {
-      match: { path },
-    } = this.props;
-
-    return (
-      <React.Suspense fallback={<SuspenseLoader />}>
-        <Switch>
-          <Route component={NodeBalancersLanding} path={path} exact />
-          <Route component={NodeBalancerCreate} path={`${path}/create`} exact />
-          <Route
-            component={NodeBalancerDetail}
-            path={`${path}/:nodeBalancerId`}
-          />
-        </Switch>
-      </React.Suspense>
-    );
-  }
-}
+  return (
+    <React.Suspense fallback={<SuspenseLoader />}>
+      <Switch>
+        <Route component={NodeBalancerCreate} path={`${path}/create`} />
+        <Route
+          component={NodeBalancerDetail}
+          path={`${path}/:nodeBalancerId`}
+        />
+        <Route component={NodeBalancersLanding} path={path} exact strict />
+        <Redirect to={path} />
+      </Switch>
+    </React.Suspense>
+  );
+};
 
 export default withRouter(NodeBalancers);

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/index.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/index.tsx
@@ -1,6 +1,6 @@
 import { ObjectStorageClusterID } from '@linode/api-v4/lib/object-storage';
 import * as React from 'react';
-import { matchPath, RouteComponentProps, useHistory } from 'react-router-dom';
+import { matchPath, RouteComponentProps } from 'react-router-dom';
 import Breadcrumb from 'src/components/Breadcrumb';
 import Box from 'src/components/core/Box';
 import TabPanels from 'src/components/core/ReachTabPanels';
@@ -35,7 +35,6 @@ type CombinedProps = RouteComponentProps<MatchProps>;
 
 export const BucketDetailLanding: React.FC<CombinedProps> = (props) => {
   const classes = useStyles();
-  const history = useHistory();
 
   const { bucketName, clusterId } = props.match.params;
 
@@ -61,7 +60,7 @@ export const BucketDetailLanding: React.FC<CombinedProps> = (props) => {
 
     // Redirect to the landing page if the path does not exist
     if (tabChoice < 0) {
-      history.push(`${props.match.url}`);
+      props.history.push(`${props.match.url}`);
       return 0;
     } else {
       return tabChoice;

--- a/packages/manager/src/features/ObjectStorage/ObjectStorageLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectStorageLanding.tsx
@@ -4,7 +4,6 @@ import { useDispatch } from 'react-redux';
 import {
   matchPath,
   RouteComponentProps,
-  useHistory,
   useRouteMatch,
 } from 'react-router-dom';
 import { compose } from 'recompose';
@@ -58,7 +57,6 @@ export const ObjectStorageLanding: React.FC<CombinedProps> = (props) => {
 
   const dispatch = useDispatch<Dispatch>();
   const flags = useFlags();
-  const history = useHistory();
 
   // @todo: dispatch bucket drawer open action
 
@@ -102,7 +100,7 @@ export const ObjectStorageLanding: React.FC<CombinedProps> = (props) => {
 
     // Redirect to the landing page if the path does not exist
     if (tabChoice < 0) {
-      history.push(`${props.match.url}`);
+      props.history.push(`${props.match.url}`);
       return 0;
     } else {
       return tabChoice;
@@ -110,7 +108,7 @@ export const ObjectStorageLanding: React.FC<CombinedProps> = (props) => {
   };
 
   const handleTabChange = (index: number) => {
-    history.push(tabs[index].routeName);
+    props.history.push(tabs[index].routeName);
   };
 
   const openDrawer = (mode: MODE) => {

--- a/packages/manager/src/features/ObjectStorage/ObjectStorageLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectStorageLanding.tsx
@@ -4,6 +4,7 @@ import { useDispatch } from 'react-redux';
 import {
   matchPath,
   RouteComponentProps,
+  useHistory,
   useRouteMatch,
 } from 'react-router-dom';
 import { compose } from 'recompose';
@@ -56,6 +57,8 @@ export const ObjectStorageLanding: React.FC<CombinedProps> = (props) => {
   useReduxLoad(['clusters']);
 
   const dispatch = useDispatch<Dispatch>();
+  const flags = useFlags();
+  const history = useHistory();
 
   // @todo: dispatch bucket drawer open action
 
@@ -91,6 +94,24 @@ export const ObjectStorageLanding: React.FC<CombinedProps> = (props) => {
       routeName: `${props.match.url}/access-keys`,
     },
   ];
+
+  const getDefaultTabIndex = () => {
+    const tabChoice = tabs.findIndex((tab) =>
+      Boolean(matchPath(tab.routeName, { path: location.pathname }))
+    );
+
+    // Redirect to the landing page if the path does not exist
+    if (tabChoice < 0) {
+      history.push(`${props.match.url}`);
+      return 0;
+    } else {
+      return tabChoice;
+    }
+  };
+
+  const handleTabChange = (index: number) => {
+    history.push(tabs[index].routeName);
+  };
 
   const openDrawer = (mode: MODE) => {
     setMode(mode);
@@ -133,17 +154,6 @@ export const ObjectStorageLanding: React.FC<CombinedProps> = (props) => {
   React.useEffect(() => {
     setRoute(props.location.pathname.replace('/object-storage/', ''));
   }, [route, props.location.pathname]);
-
-  const matches = (p: string) => {
-    return Boolean(matchPath(p, { path: props.location.pathname }));
-  };
-
-  const navToURL = (index: number) => {
-    setRoute(props.location.pathname.replace('/object-storage/', ''));
-    props.history.push(tabs[index].routeName);
-  };
-
-  const flags = useFlags();
 
   const objPromotionalOffers = (
     flags.promotionalOffers ?? []
@@ -195,15 +205,8 @@ export const ObjectStorageLanding: React.FC<CombinedProps> = (props) => {
         removeCrumbX={1}
         breadcrumbProps={{ pathname: '/object-storage' }}
       />
-      <Tabs
-        index={Math.max(
-          tabs.findIndex((tab) => matches(tab.routeName)),
-          0
-        )}
-        onChange={navToURL}
-      >
+      <Tabs index={getDefaultTabIndex()} onChange={handleTabChange}>
         <TabLinkList tabs={tabs} />
-
         {objPromotionalOffers.map((promotionalOffer) => (
           <PromotionalOfferCard
             key={promotionalOffer.name}

--- a/packages/manager/src/features/ObjectStorage/index.tsx
+++ b/packages/manager/src/features/ObjectStorage/index.tsx
@@ -1,23 +1,22 @@
 import * as React from 'react';
-import { Route, RouteComponentProps, Switch } from 'react-router-dom';
+import { Redirect, Route, Switch, useRouteMatch } from 'react-router-dom';
 import SuspenseLoader from 'src/components/SuspenseLoader';
 
 const ObjectStorageLanding = React.lazy(() => import('./ObjectStorageLanding'));
 const BucketDetail = React.lazy(() => import('./BucketDetail'));
 
-type CombinedProps = RouteComponentProps;
-
-export const ObjectStorage: React.FC<CombinedProps> = (props) => {
-  const path = props.match.path;
+export const ObjectStorage: React.FC = () => {
+  const { path } = useRouteMatch();
 
   return (
     <React.Suspense fallback={<SuspenseLoader />}>
       <Switch>
         <Route
-          path={`${path}/buckets/:clusterId/:bucketName`}
           component={BucketDetail}
+          path={`${path}/buckets/:clusterId/:bucketName`}
         />
-        <Route component={ObjectStorageLanding} path={path} />
+        <Route component={ObjectStorageLanding} path={path} exact strict />
+        <Redirect to={path} />
       </Switch>
     </React.Suspense>
   );

--- a/packages/manager/src/features/OneClickApps/AppDetailDrawer.tsx
+++ b/packages/manager/src/features/OneClickApps/AppDetailDrawer.tsx
@@ -61,7 +61,7 @@ const styles = (theme: Theme) =>
   });
 
 interface Props {
-  stackscriptID: string;
+  stackscriptId: string;
   open: boolean;
   onClose: () => void;
 }
@@ -71,7 +71,7 @@ type CombinedProps = Props & WithStyles<ClassNames>;
 export const AppDetailDrawer: React.FunctionComponent<CombinedProps> = (
   props
 ) => {
-  const { classes, stackscriptID, open, onClose } = props;
+  const { classes, stackscriptId, open, onClose } = props;
   const app = oneClickApps.find((eachApp) => {
     const cleanedAppName = eachApp.name.replace(
       /[-\/\\^$*+?.()|[\]{}]/g,
@@ -79,7 +79,7 @@ export const AppDetailDrawer: React.FunctionComponent<CombinedProps> = (
     );
     const strippedAppName = cleanedAppName.replace('&reg;', '');
     const regex = new RegExp(strippedAppName);
-    return Boolean(stackscriptID.match(regex));
+    return Boolean(stackscriptId.match(regex));
   }); // This is horrible
   if (!app) {
     return null;

--- a/packages/manager/src/features/StackScripts/StackScripts.tsx
+++ b/packages/manager/src/features/StackScripts/StackScripts.tsx
@@ -63,8 +63,8 @@ export const StackScripts: React.FC = () => {
           exact
           strict
         />
-        <Redirect to={path} />
       </Switch>
+      <Redirect to={path} />
     </React.Suspense>
   );
 };

--- a/packages/manager/src/features/StackScripts/StackScripts.tsx
+++ b/packages/manager/src/features/StackScripts/StackScripts.tsx
@@ -1,33 +1,31 @@
 import * as React from 'react';
 import {
-  Redirect,
   Route,
-  RouteComponentProps,
   Switch,
+  useHistory,
+  useLocation,
+  useRouteMatch,
   withRouter,
 } from 'react-router-dom';
 import SuspenseLoader from 'src/components/SuspenseLoader';
-import { parseQueryParams } from 'src/utilities/queryParams';
+import { getParamsFromUrl } from 'src/utilities/queryParams';
 
-const StackScriptsDetail = React.lazy(() => import('./StackScriptsDetail'));
 const StackScriptsLanding = React.lazy(() => import('./StackScriptsLanding'));
+const StackScriptsDetail = React.lazy(() => import('./StackScriptsDetail'));
 const StackScriptCreate = React.lazy(() => import('./StackScriptCreate'));
 
-type Props = RouteComponentProps<{}>;
-
-export const StackScripts: React.FC<Props> = (props) => {
-  const {
-    match: { path },
-    location: { search },
-  } = props;
+export const StackScripts: React.FC = () => {
+  const location = useLocation();
+  const history = useHistory();
+  const { path } = useRouteMatch();
 
   // Redirects to prevent breaking old stackscripts?type=whatever bookmarks
-  const searchParams = parseQueryParams(search);
+  const searchParams = getParamsFromUrl(location.search);
   if (searchParams.type === 'community') {
-    props.history.replace('stackscripts/community');
+    history.replace('stackscripts/community');
   }
   if (searchParams.type === 'account') {
-    props.history.replace('stackscripts/account');
+    history.replace('stackscripts/account');
   }
 
   return (
@@ -35,23 +33,16 @@ export const StackScripts: React.FC<Props> = (props) => {
       <Switch>
         <Route component={StackScriptsLanding} path={`${path}/account`} />
         <Route component={StackScriptsLanding} path={`${path}/community`} />
-        <Route component={StackScriptsLanding} path={path} exact />
+        <Route component={StackScriptsLanding} path={path} exact strict />
         <Route
           render={() => <StackScriptCreate mode="create" />}
           path={`${path}/create`}
-          exact
         />
         <Route
           render={() => <StackScriptCreate mode="edit" />}
-          path={`${path}/:stackScriptID/edit`}
-          exact
+          path={`${path}/:stackScriptId/edit`}
         />
-        <Route
-          component={StackScriptsDetail}
-          path={`${path}/:stackScriptId`}
-          exact
-        />
-        <Redirect to={`${path}`} />
+        <Route component={StackScriptsDetail} path={`${path}/:stackScriptId`} />
       </Switch>
     </React.Suspense>
   );

--- a/packages/manager/src/features/StackScripts/StackScripts.tsx
+++ b/packages/manager/src/features/StackScripts/StackScripts.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  Redirect,
   Route,
   Switch,
   useHistory,
@@ -31,18 +32,38 @@ export const StackScripts: React.FC = () => {
   return (
     <React.Suspense fallback={<SuspenseLoader />}>
       <Switch>
-        <Route component={StackScriptsLanding} path={`${path}/account`} />
-        <Route component={StackScriptsLanding} path={`${path}/community`} />
+        <Route
+          component={StackScriptsLanding}
+          path={`${path}/account`}
+          exact
+          strict
+        />
+        <Route
+          component={StackScriptsLanding}
+          path={`${path}/community`}
+          exact
+          strict
+        />
         <Route component={StackScriptsLanding} path={path} exact strict />
         <Route
           render={() => <StackScriptCreate mode="create" />}
           path={`${path}/create`}
+          exact
+          strict
         />
         <Route
           render={() => <StackScriptCreate mode="edit" />}
           path={`${path}/:stackScriptId/edit`}
+          exact
+          strict
         />
-        <Route component={StackScriptsDetail} path={`${path}/:stackScriptId`} />
+        <Route
+          component={StackScriptsDetail}
+          path={`${path}/:stackScriptId`}
+          exact
+          strict
+        />
+        <Redirect to={path} />
       </Switch>
     </React.Suspense>
   );

--- a/packages/manager/src/features/Users/UserDetail.tsx
+++ b/packages/manager/src/features/Users/UserDetail.tsx
@@ -68,6 +68,24 @@ const UserDetail: React.FC = () => {
     },
   ];
 
+  const getDefaultTabIndex = () => {
+    const tabChoice = tabs.findIndex((tab) =>
+      Boolean(matchPath(tab.routeName, { path: location.pathname }))
+    );
+
+    // Redirect to the landing page if the path does not exist
+    if (tabChoice < 0) {
+      history.push(`/account/users/${usernameParam}/profile`);
+      return 0;
+    } else {
+      return tabChoice;
+    }
+  };
+
+  const handleTabChange = (index: number) => {
+    history.push(tabs[index].routeName);
+  };
+
   React.useEffect(() => {
     getUser(usernameParam)
       .then((user) => {
@@ -92,6 +110,7 @@ const UserDetail: React.FC = () => {
         state: {},
       });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const clearNewUser = () => {
@@ -178,19 +197,6 @@ const UserDetail: React.FC = () => {
       });
   };
 
-  const matches = (p: string) => {
-    return Boolean(matchPath(p, { path: location.pathname }));
-  };
-
-  const clampTabChoice = () => {
-    const tabChoice = tabs.findIndex((tab) => matches(tab.routeName));
-    return tabChoice < 0 ? 0 : tabChoice;
-  };
-
-  const navToURL = (index: number) => {
-    history.push(tabs[index].routeName);
-  };
-
   if (error) {
     return (
       <React.Fragment>
@@ -226,7 +232,7 @@ const UserDetail: React.FC = () => {
         ]}
         removeCrumbX={4}
       />
-      <Tabs defaultIndex={clampTabChoice()} onChange={navToURL}>
+      <Tabs defaultIndex={getDefaultTabIndex()} onChange={handleTabChange}>
         <TabLinkList tabs={tabs} />
 
         {createdUsername && (

--- a/packages/manager/src/features/Volumes/Volumes.tsx
+++ b/packages/manager/src/features/Volumes/Volumes.tsx
@@ -15,7 +15,7 @@ const Volumes: React.FC = () => {
 
   return (
     <Switch>
-      <Route component={VolumeCreate} path={`${path}/create`} />
+      <Route component={VolumeCreate} path={`${path}/create`} exact strict />
       <Route
         render={(routeProps) => (
           <VolumesLanding isVolumesLanding removeBreadCrumb {...routeProps} />

--- a/packages/manager/src/features/Volumes/Volumes.tsx
+++ b/packages/manager/src/features/Volumes/Volumes.tsx
@@ -2,23 +2,20 @@ import * as React from 'react';
 import {
   Redirect,
   Route,
-  RouteComponentProps,
   Switch,
+  useRouteMatch,
   withRouter,
 } from 'react-router-dom';
 
 const VolumesLanding = React.lazy(() => import('./VolumesLanding'));
 const VolumeCreate = React.lazy(() => import('./VolumeCreate/VolumeCreate'));
 
-type Props = RouteComponentProps<{}>;
-
-const Volumes: React.FC<Props> = (props) => {
-  const {
-    match: { path },
-  } = props;
+const Volumes: React.FC = () => {
+  const { path } = useRouteMatch();
 
   return (
     <Switch>
+      <Route component={VolumeCreate} path={`${path}/create`} />
       <Route
         render={(routeProps) => (
           <VolumesLanding isVolumesLanding removeBreadCrumb {...routeProps} />
@@ -27,7 +24,6 @@ const Volumes: React.FC<Props> = (props) => {
         exact
         strict
       />
-      <Route component={VolumeCreate} path={`${path}/create`} exact strict />
       <Redirect to={path} />
     </Switch>
   );

--- a/packages/manager/src/features/linodes/CloneLanding/CloneLanding.tsx
+++ b/packages/manager/src/features/linodes/CloneLanding/CloneLanding.tsx
@@ -117,13 +117,22 @@ export const CloneLanding: React.FC<CombinedProps> = (props) => {
     },
   ];
 
-  // Helper function for the <Tabs /> component
-  const matches = (p: string) => {
-    return Boolean(matchPath(p, { path: props.location.pathname }));
+  const getDefaultTabIndex = () => {
+    const tabChoice = tabs.findIndex((tab) =>
+      Boolean(matchPath(tab.routeName, { path: location.pathname }))
+    );
+
+    // Redirect to the landing page if the path does not exist
+    if (tabChoice < 0) {
+      history.push(`${props.match.url}`);
+      return 0;
+    } else {
+      return tabChoice;
+    }
   };
 
-  const navToURL = (index: number) => {
-    props.history.push(tabs[index].routeName);
+  const handleTabChange = (index: number) => {
+    history.push(tabs[index].routeName);
   };
 
   /**
@@ -152,10 +161,12 @@ export const CloneLanding: React.FC<CombinedProps> = (props) => {
     });
     // We can't use `configs` and `disks` as deps, since they are arrays.
     // Instead we use a serialized representation of their IDs.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [stringifiedConfigIds, stringifiedDiskIds]);
 
   // A config and/or disk can be selected via query param. Memoized
   // so it can be used as a dep in the useEffects that consume it.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const queryParams = React.useMemo(() => getParamsFromUrl(location.search), [
     location.search,
   ]);
@@ -312,13 +323,7 @@ export const CloneLanding: React.FC<CombinedProps> = (props) => {
               Clone
             </Typography>
 
-            <Tabs
-              index={Math.max(
-                tabs.findIndex((tab) => matches(tab.routeName)),
-                0
-              )}
-              onChange={navToURL}
-            >
+            <Tabs index={getDefaultTabIndex()} onChange={handleTabChange}>
               <TabLinkList tabs={tabs} />
               <TabPanels>
                 <SafeTabPanel index={0}>
@@ -331,7 +336,6 @@ export const CloneLanding: React.FC<CombinedProps> = (props) => {
                     />
                   </div>
                 </SafeTabPanel>
-
                 <SafeTabPanel index={1}>
                   <div className={classes.outerContainer}>
                     <Typography>

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -221,7 +221,7 @@ class FromAppsContent extends React.PureComponent<CombinedProps, State> {
 
         <AppDetailDrawer
           open={this.state.detailDrawerOpen}
-          stackscriptID={this.state.selectedScriptForDrawer}
+          stackscriptId={this.state.selectedScriptForDrawer}
           onClose={this.closeDrawer}
         />
       </React.Fragment>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetail.container.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetail.container.tsx
@@ -76,7 +76,7 @@ export const LinodesDetailContainer: React.FC<Props> = (props) => {
     return <CircleProgress />;
   }
 
-  return <LinodesDetail linodeId={linodeId} />;
+  return <LinodesDetail />;
 };
 
 export default React.memo(LinodesDetailContainer);

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetail.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetail.tsx
@@ -3,8 +3,9 @@ import { useDispatch } from 'react-redux';
 import {
   Redirect,
   Route,
-  RouteComponentProps,
   Switch,
+  useParams,
+  useRouteMatch,
   withRouter,
 } from 'react-router-dom';
 import { compose } from 'recompose';
@@ -24,17 +25,9 @@ const LinodesDetailNavigation = React.lazy(
 );
 const CloneLanding = React.lazy(() => import('../CloneLanding'));
 
-interface Props {
-  linodeId: string;
-}
-
-type CombinedProps = Props & RouteComponentProps<{ linodeId: string }>;
-
-const LinodeDetail: React.FC<CombinedProps> = (props) => {
-  const {
-    linodeId,
-    match: { path, url },
-  } = props;
+const LinodeDetail: React.FC = () => {
+  const { linodeId } = useParams<{ linodeId: string }>();
+  const { path, url } = useRouteMatch();
 
   const dispatch = useDispatch();
   const linode = useExtendedLinode(+linodeId);
@@ -59,7 +52,7 @@ const LinodeDetail: React.FC<CombinedProps> = (props) => {
 
           <Route
             render={() => (
-              <React.Fragment>
+              <>
                 <LinodesDetailHeader />
                 <LinodesDetailNavigation />
                 <Switch>
@@ -78,7 +71,7 @@ const LinodeDetail: React.FC<CombinedProps> = (props) => {
                     to={`${url}?upgrade=true`}
                   />
                 </Switch>
-              </React.Fragment>
+              </>
             )}
           />
         </Switch>
@@ -87,9 +80,6 @@ const LinodeDetail: React.FC<CombinedProps> = (props) => {
   );
 };
 
-const enhanced = compose<CombinedProps, Props>(
-  withRouter,
-  LinodeDetailErrorBoundary
-);
+const enhanced = compose(withRouter, LinodeDetailErrorBoundary);
 
 export default enhanced(LinodeDetail);

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation.tsx
@@ -74,18 +74,21 @@ const LinodesDetailNavigation: React.FC<CombinedProps> = (props) => {
     },
   ].filter((thisTab) => !thisTab.hidden);
 
-  const matches = (p: string) => {
-    return Boolean(matchPath(p, { path: location.pathname }));
-  };
-
-  const getIndex = () => {
-    return Math.max(
-      tabs.findIndex((tab) => matches(tab.routeName)),
-      0
+  const getDefaultTabIndex = () => {
+    const tabChoice = tabs.findIndex((tab) =>
+      Boolean(matchPath(tab.routeName, { path: location.pathname }))
     );
+
+    // Redirect to the landing page if the path does not exist
+    if (tabChoice < 0) {
+      props.history.push(`${url}`);
+      return 0;
+    } else {
+      return tabChoice;
+    }
   };
 
-  const navToURL = (index: number) => {
+  const handleTabChange = (index: number) => {
     props.history.push(tabs[index].routeName);
   };
 
@@ -94,10 +97,12 @@ const LinodesDetailNavigation: React.FC<CombinedProps> = (props) => {
   return (
     <>
       <DocumentTitleSegment
-        segment={`${linodeLabel} - ${tabs[getIndex()]?.title ?? 'Detail View'}`}
+        segment={`${linodeLabel} - ${
+          tabs[getDefaultTabIndex()]?.title ?? 'Detail View'
+        }`}
       />
       <div style={{ marginTop: 8 }}>
-        <Tabs index={getIndex()} onChange={navToURL}>
+        <Tabs index={getDefaultTabIndex()} onChange={handleTabChange}>
           <TabLinkList tabs={tabs} />
 
           <React.Suspense fallback={<SuspenseLoader />}>
@@ -105,7 +110,6 @@ const LinodesDetailNavigation: React.FC<CombinedProps> = (props) => {
               <SafeTabPanel index={idx++}>
                 <LinodeSummary isBareMetalInstance={isBareMetalInstance} />
               </SafeTabPanel>
-
               <SafeTabPanel index={idx++}>
                 <LinodeNetworking />
               </SafeTabPanel>
@@ -118,7 +122,6 @@ const LinodesDetailNavigation: React.FC<CombinedProps> = (props) => {
                   <SafeTabPanel index={idx++}>
                     <LinodeConfigurations />
                   </SafeTabPanel>
-
                   <SafeTabPanel index={idx++}>
                     <LinodeBackup />
                   </SafeTabPanel>
@@ -128,7 +131,6 @@ const LinodesDetailNavigation: React.FC<CombinedProps> = (props) => {
               <SafeTabPanel index={idx++}>
                 <LinodeActivity />
               </SafeTabPanel>
-
               <SafeTabPanel index={idx++}>
                 <LinodeSettings isBareMetalInstance={isBareMetalInstance} />
               </SafeTabPanel>

--- a/packages/manager/src/features/linodes/index.tsx
+++ b/packages/manager/src/features/linodes/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Redirect, Route, Switch } from 'react-router-dom';
+import { Redirect, Route, Switch, useRouteMatch } from 'react-router-dom';
 import SuspenseLoader from 'src/components/SuspenseLoader';
 import useLinodes from 'src/hooks/useLinodes';
 import { useTypes } from 'src/hooks/useTypes';
@@ -13,13 +13,15 @@ const LinodesCreate = React.lazy(
 );
 
 const LinodesRoutes: React.FC = () => {
+  const { path } = useRouteMatch();
+
   return (
     <React.Suspense fallback={<SuspenseLoader />}>
       <Switch>
-        <Route component={LinodesCreate} path="/linodes/create" />
-        <Route component={LinodesDetail} path="/linodes/:linodeId" />
-        <Route component={LinodesLandingWrapper} path="/linodes" exact strict />
-        <Redirect to="/linodes" />
+        <Route component={LinodesCreate} path={`${path}/create`} />
+        <Route component={LinodesDetail} path={`${path}/:linodeId`} />
+        <Route component={LinodesLandingWrapper} path={path} exact strict />
+        <Redirect to={path} />
       </Switch>
     </React.Suspense>
   );

--- a/packages/manager/src/features/linodes/index.tsx
+++ b/packages/manager/src/features/linodes/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Redirect, Route, Switch, useRouteMatch } from 'react-router-dom';
+import { Route, Switch, useRouteMatch } from 'react-router-dom';
 import SuspenseLoader from 'src/components/SuspenseLoader';
 import useLinodes from 'src/hooks/useLinodes';
 import { useTypes } from 'src/hooks/useTypes';
@@ -21,7 +21,6 @@ const LinodesRoutes: React.FC = () => {
         <Route component={LinodesCreate} path={`${path}/create`} exact strict />
         <Route component={LinodesDetail} path={`${path}/:linodeId`} />
         <Route component={LinodesLandingWrapper} path={path} exact strict />
-        <Redirect to={path} />
       </Switch>
     </React.Suspense>
   );

--- a/packages/manager/src/features/linodes/index.tsx
+++ b/packages/manager/src/features/linodes/index.tsx
@@ -18,7 +18,7 @@ const LinodesRoutes: React.FC = () => {
   return (
     <React.Suspense fallback={<SuspenseLoader />}>
       <Switch>
-        <Route component={LinodesCreate} path={`${path}/create`} />
+        <Route component={LinodesCreate} path={`${path}/create`} exact strict />
         <Route component={LinodesDetail} path={`${path}/:linodeId`} />
         <Route component={LinodesLandingWrapper} path={path} exact strict />
         <Redirect to={path} />


### PR DESCRIPTION
## Description

**M3-5641:**

Previously, the page would redirect to the first tab if the URL was invalid but the URL was not updated. This PR fixes that and also updates the tab-related functions to be consistent.

**M3-5642:**

Cleans up the routing so that it'll redirect to the landing pages and replace `RouteComponentProps` with `useRouteMatch` hook.

## How to test

Make sure none of the links have regressed and try breaking the URL from different pages.
