### PR TITLE
M3-5645: State/Province dropdown

### DIFF
--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -9,8 +9,7 @@ import Grid from 'src/components/core/Grid';
 
 const options: { label: string; flag: keyof Flags }[] = [
   { label: 'Databases', flag: 'databases' },
-  { label: 'Bare Metal', flag: 'bareMetal' },
-  { label: 'Machine Images', flag: 'machineImages' },
+  { label: 'Avalara', flag: 'avalara' },
 ];
 
 const FeatureFlagTool: React.FC<{}> = () => {

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -9,7 +9,7 @@ import Grid from 'src/components/core/Grid';
 
 const options: { label: string; flag: keyof Flags }[] = [
   { label: 'Databases', flag: 'databases' },
-  { label: 'Avalara', flag: 'avalara' },
+  { label: 'Region Dropdown', flag: 'regionDropdown' },
 ];
 
 const FeatureFlagTool: React.FC<{}> = () => {

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -43,6 +43,7 @@ export interface Flags {
   lkeHighAvailability: boolean;
   autoscaler: boolean;
   kubernetesDashboardAvailability: boolean;
+  avalara: boolean;
 }
 
 type PromotionalOfferFeature =

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -43,7 +43,7 @@ export interface Flags {
   lkeHighAvailability: boolean;
   autoscaler: boolean;
   kubernetesDashboardAvailability: boolean;
-  avalara: boolean;
+  regionDropdown: boolean;
 }
 
 type PromotionalOfferFeature =

--- a/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
@@ -399,20 +399,12 @@ class UpdateContactInformationForm extends React.Component<
                 options={regionResults}
                 placeholder="Select region"
                 required
-                // value={
-                //   regionResults.find(({ value }) =>
-                //     fields.state
-                //       ? value === fields.state
-                //       : value === account.state
-                //   ) || account.state
-                // }
                 value={
-                  fields.state
-                    ? {
-                        label: fields.state,
-                        value: fields.state,
-                      }
-                    : ''
+                  regionResults.find(({ value }) =>
+                    fields.state
+                      ? value === fields.state
+                      : value === account.state
+                  ) ?? ''
                 }
                 textFieldProps={{
                   dataAttrs: {
@@ -573,7 +565,7 @@ class UpdateContactInformationForm extends React.Component<
   updateState = (selectedRegion: Item) => {
     this.composeState([set(L.fields.state, selectedRegion.value)]);
 
-    if (selectedRegion.value === undefined) {
+    if (selectedRegion.value === undefined || selectedRegion.value === '') {
       this.setState({ isValid: false });
     } else {
       this.setState({ isValid: true });
@@ -581,13 +573,15 @@ class UpdateContactInformationForm extends React.Component<
   };
 
   updateCountry = (selectedCountry: Item) => {
+    this.composeState([set(L.fields.country, selectedCountry.value)]);
+
     this.setState({
       fields: {
         ...this.state.fields,
         state: undefined,
       },
+      isValid: false,
     });
-    this.composeState([set(L.fields.country, selectedCountry.value)]);
   };
 
   updateTaxID = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
@@ -201,10 +201,35 @@ class UpdateContactInformationForm extends React.Component<
     );
 
     const regionResults = countryRegions.map((region) => {
+      if (region.name === 'Virgin Islands') {
+        return {
+          value: region.shortCode,
+          label: 'Virgin Islands, U.S.',
+        };
+      }
+
       return {
         value: region.shortCode,
         label: region.name,
       };
+    });
+
+    const excludedUSRegions = [
+      'Micronesia',
+      'Marshall Islands',
+      'Palau',
+      'Armed Forces Americas',
+      'Armed Forces Europe, Canada, Africa and Middle East',
+      'Armed Forces Pacific',
+    ];
+
+    const filteredRegionResults = regionResults.filter(
+      (region) => !excludedUSRegions.includes(region.label)
+    );
+
+    filteredRegionResults.push({
+      value: 'UM',
+      label: 'United States Minor Outlying Islands',
     });
 
     return (
@@ -394,11 +419,11 @@ class UpdateContactInformationForm extends React.Component<
               errorText={errorMap.state}
               isClearable={false}
               onChange={this.updateState}
-              options={regionResults}
+              options={filteredRegionResults}
               placeholder="Select region"
               required
               value={
-                regionResults.find(({ value }) =>
+                filteredRegionResults.find(({ value }) =>
                   fields.state
                     ? value === fields.state
                     : value === account.state

--- a/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
@@ -201,7 +201,7 @@ class UpdateContactInformationForm extends React.Component<
     );
 
     const regionResults = countryRegions.map((region) => {
-      if (region.name === 'Virgin Islands') {
+      if (fields.country === 'US' && region.name === 'Virgin Islands') {
         return {
           value: region.shortCode,
           label: 'Virgin Islands, U.S.',
@@ -223,14 +223,20 @@ class UpdateContactInformationForm extends React.Component<
       'Armed Forces Pacific',
     ];
 
-    const filteredRegionResults = regionResults.filter(
-      (region) => !excludedUSRegions.includes(region.label)
-    );
+    let filteredRegionResults;
 
-    filteredRegionResults.push({
-      value: 'UM',
-      label: 'United States Minor Outlying Islands',
-    });
+    if (fields.country === 'US') {
+      filteredRegionResults = regionResults.filter(
+        (region) => !excludedUSRegions.includes(region.label)
+      );
+
+      filteredRegionResults.push({
+        value: 'UM',
+        label: 'United States Minor Outlying Islands',
+      });
+    } else {
+      filteredRegionResults = regionResults;
+    }
 
     return (
       <Grid

--- a/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
@@ -27,12 +27,15 @@ import { getErrorMap } from 'src/utilities/errorUtils';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import { Country } from './types';
 
-type ClassNames = 'mainFormContainer' | 'actions' | 'removeTopMargin';
+type ClassNames = 'mainFormContainer' | 'actions';
 
 const styles = () =>
   createStyles({
     mainFormContainer: {
       maxWidth: 860,
+      '& .MuiGrid-item:not(:first-child) label': {
+        marginTop: 0,
+      },
     },
     actions: {
       display: 'flex',
@@ -40,11 +43,6 @@ const styles = () =>
       paddingBottom: 0,
       '& button': {
         marginBottom: 0,
-      },
-    },
-    removeTopMargin: {
-      '& label': {
-        marginTop: 0,
       },
     },
   });
@@ -245,7 +243,6 @@ class UpdateContactInformationForm extends React.Component<
         </Grid>
 
         <Grid
-          className={classes.removeTopMargin}
           item
           xs={12}
           sm={6}
@@ -266,7 +263,6 @@ class UpdateContactInformationForm extends React.Component<
         </Grid>
 
         <Grid
-          className={classes.removeTopMargin}
           item
           xs={12}
           sm={6}
@@ -308,7 +304,6 @@ class UpdateContactInformationForm extends React.Component<
         </Grid>
 
         <Grid
-          className={classes.removeTopMargin}
           item
           xs={12}
           updateFor={[
@@ -328,7 +323,6 @@ class UpdateContactInformationForm extends React.Component<
         </Grid>
 
         <Grid
-          className={classes.removeTopMargin}
           item
           xs={12}
           updateFor={[
@@ -348,7 +342,6 @@ class UpdateContactInformationForm extends React.Component<
         </Grid>
 
         <Grid
-          className={classes.removeTopMargin}
           item
           xs={12}
           sm={6}
@@ -381,7 +374,6 @@ class UpdateContactInformationForm extends React.Component<
         </Grid>
 
         <Grid
-          className={classes.removeTopMargin}
           item
           xs={12}
           sm={6}
@@ -395,7 +387,7 @@ class UpdateContactInformationForm extends React.Component<
             classes,
           ]}
         >
-          {flags.avalara &&
+          {flags.regionDropdown &&
           (fields.country === 'US' || fields.country == 'CA') ? (
             <EnhancedSelect
               label={`${fields.country === 'US' ? 'State' : 'Province'}`}
@@ -439,7 +431,6 @@ class UpdateContactInformationForm extends React.Component<
         </Grid>
 
         <Grid
-          className={classes.removeTopMargin}
           item
           xs={12}
           sm={6}
@@ -454,7 +445,7 @@ class UpdateContactInformationForm extends React.Component<
           />
         </Grid>
 
-        <Grid className={classes.removeTopMargin} item xs={12} sm={6}>
+        <Grid item xs={12} sm={6}>
           <TextField
             label="Postal Code"
             errorText={errorMap.zip}
@@ -480,7 +471,6 @@ class UpdateContactInformationForm extends React.Component<
         </Grid>
 
         <Grid
-          className={classes.removeTopMargin}
           item
           xs={12}
           updateFor={[account.tax_id, fields.tax_id, errorMap.tax_id, classes]}
@@ -511,7 +501,7 @@ class UpdateContactInformationForm extends React.Component<
         </Button>
         <Button
           buttonType="primary"
-          disabled={flags.avalara && !this.state.isValid}
+          disabled={flags.regionDropdown && !this.state.isValid}
           onClick={this.submitForm}
           loading={this.state.submitting}
           data-qa-save-contact-info
@@ -542,7 +532,7 @@ class UpdateContactInformationForm extends React.Component<
 
   updateEmail = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { flags } = this.props;
-    if (flags.avalara && e.target.value === '') {
+    if (flags.regionDropdown && e.target.value === '') {
       this.setState({ isValid: false });
     } else {
       this.setState({ isValid: true });
@@ -565,7 +555,7 @@ class UpdateContactInformationForm extends React.Component<
   updateState = (selectedRegion: Item) => {
     const { flags } = this.props;
     if (
-      flags.avalara &&
+      flags.regionDropdown &&
       (selectedRegion.value === undefined || selectedRegion.value === '')
     ) {
       this.setState({ isValid: false });
@@ -585,7 +575,7 @@ class UpdateContactInformationForm extends React.Component<
       },
     });
 
-    if (flags.avalara) {
+    if (flags.regionDropdown) {
       this.setState({
         isValid: false,
       });

--- a/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
@@ -85,6 +85,15 @@ const L = {
   },
 };
 
+const excludedUSRegions = [
+  'Micronesia',
+  'Marshall Islands',
+  'Palau',
+  'Armed Forces Americas',
+  'Armed Forces Europe, Canada, Africa and Middle East',
+  'Armed Forces Pacific',
+];
+
 class UpdateContactInformationForm extends React.Component<
   CombinedProps,
   State
@@ -213,15 +222,6 @@ class UpdateContactInformationForm extends React.Component<
         label: region.name,
       };
     });
-
-    const excludedUSRegions = [
-      'Micronesia',
-      'Marshall Islands',
-      'Palau',
-      'Armed Forces Americas',
-      'Armed Forces Europe, Canada, Africa and Middle East',
-      'Armed Forces Pacific',
-    ];
 
     let filteredRegionResults;
 
@@ -390,7 +390,7 @@ class UpdateContactInformationForm extends React.Component<
             onChange={this.updateCountry}
             options={countryResults}
             placeholder="Select a Country"
-            required
+            required={flags.regionDropdown}
             value={countryResults.find(({ value }) =>
               fields.country
                 ? value === fields.country
@@ -427,7 +427,7 @@ class UpdateContactInformationForm extends React.Component<
               onChange={this.updateState}
               options={filteredRegionResults}
               placeholder="Select region"
-              required
+              required={flags.regionDropdown}
               value={
                 filteredRegionResults.find(({ value }) =>
                   fields.state
@@ -452,7 +452,7 @@ class UpdateContactInformationForm extends React.Component<
                 })
               }
               placeholder="Enter region"
-              required
+              required={flags.regionDropdown}
               value={fields.state || ''}
               dataAttrs={{
                 'data-qa-contact-province': true,

--- a/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
@@ -66,18 +66,18 @@ const field = (path: string[]) => lensPath(['fields', ...path]);
 
 const L = {
   fields: {
-    address_1: field(['address_1']),
-    address_2: field(['address_2']),
-    city: field(['city']),
-    company: field(['company']),
     email: field(['email']),
     first_name: field(['first_name']),
     last_name: field(['last_name']),
-    phone: field(['phone']),
-    tax_id: field(['tax_id']),
-    zip: field(['zip']),
+    company: field(['company']),
+    address_1: field(['address_1']),
+    address_2: field(['address_2']),
     country: field(['country']),
     state: field(['state']),
+    city: field(['city']),
+    zip: field(['zip']),
+    phone: field(['phone']),
+    tax_id: field(['tax_id']),
   },
 };
 
@@ -104,16 +104,16 @@ class UpdateContactInformationForm extends React.Component<
     // display in the form.
     const editableContactInformationFields = pick(
       [
+        'email',
         'first_name',
         'last_name',
         'company',
         'address_1',
         'address_2',
-        'city',
-        'state',
-        'zip',
         'country',
-        'email',
+        'state',
+        'city',
+        'zip',
         'phone',
         'tax_id',
       ],
@@ -204,296 +204,289 @@ class UpdateContactInformationForm extends React.Component<
     });
 
     return (
-      <form>
+      <Grid
+        container
+        className={classes.mainFormContainer}
+        data-qa-update-contact
+      >
+        {generalError && (
+          <Grid item xs={12}>
+            <Notice error text={generalError} />
+          </Grid>
+        )}
+        {success && (
+          <Grid item xs={12}>
+            <Notice success text={success} />
+          </Grid>
+        )}
+
         <Grid
-          container
-          className={classes.mainFormContainer}
-          data-qa-update-contact
+          item
+          xs={12}
+          updateFor={[account.email, fields.email, errorMap.email, classes]}
         >
-          {generalError && (
-            <Grid item xs={12}>
-              <Notice error text={generalError} />
-            </Grid>
-          )}
-          {success && (
-            <Grid item xs={12}>
-              <Notice success text={success} />
-            </Grid>
-          )}
+          <TextField
+            label="Email"
+            errorText={errorMap.email}
+            helperTextPosition="top"
+            inputRef={this.emailRef}
+            onChange={this.updateEmail}
+            required
+            type="email"
+            value={defaultTo(account.email, fields.email)}
+            data-qa-contact-email
+          />
+        </Grid>
 
-          <Grid
-            item
-            xs={12}
-            updateFor={[account.email, fields.email, errorMap.email, classes]}
-          >
+        <Grid
+          className={classes.removeTopMargin}
+          item
+          xs={12}
+          sm={6}
+          updateFor={[
+            account.first_name,
+            fields.first_name,
+            errorMap.first_name,
+            classes,
+          ]}
+        >
+          <TextField
+            label="First Name"
+            errorText={errorMap.first_name}
+            onChange={this.updateFirstName}
+            value={defaultTo(account.first_name, fields.first_name)}
+            data-qa-contact-first-name
+          />
+        </Grid>
+
+        <Grid
+          className={classes.removeTopMargin}
+          item
+          xs={12}
+          sm={6}
+          updateFor={[
+            account.last_name,
+            fields.last_name,
+            errorMap.last_name,
+            classes,
+          ]}
+        >
+          <TextField
+            label="Last Name"
+            errorText={errorMap.last_name}
+            onChange={this.updateLastName}
+            value={defaultTo(account.last_name, fields.last_name)}
+            data-qa-contact-last-name
+          />
+        </Grid>
+
+        <Grid
+          item
+          xs={12}
+          updateFor={[
+            account.company,
+            fields.company,
+            errorMap.company,
+            classes,
+          ]}
+        >
+          <Grid item xs={12}>
             <TextField
-              label="Email"
-              errorText={errorMap.email}
-              helperTextPosition="top"
-              inputRef={this.emailRef}
-              onChange={this.updateEmail}
-              required
-              type="email"
-              value={defaultTo(account.email, fields.email)}
-              data-qa-contact-email
-            />
-          </Grid>
-
-          <Grid
-            className={classes.removeTopMargin}
-            item
-            xs={12}
-            sm={6}
-            updateFor={[
-              account.first_name,
-              fields.first_name,
-              errorMap.first_name,
-              classes,
-            ]}
-          >
-            <TextField
-              label="First Name"
-              errorText={errorMap.first_name}
-              onChange={this.updateFirstName}
-              value={defaultTo(account.first_name, fields.first_name)}
-              data-qa-contact-first-name
-            />
-          </Grid>
-
-          <Grid
-            className={classes.removeTopMargin}
-            item
-            xs={12}
-            sm={6}
-            updateFor={[
-              account.last_name,
-              fields.last_name,
-              errorMap.last_name,
-              classes,
-            ]}
-          >
-            <TextField
-              label="Last Name"
-              errorText={errorMap.last_name}
-              onChange={this.updateLastName}
-              value={defaultTo(account.last_name, fields.last_name)}
-              data-qa-contact-last-name
-            />
-          </Grid>
-
-          <Grid
-            item
-            xs={12}
-            updateFor={[
-              account.company,
-              fields.company,
-              errorMap.company,
-              classes,
-            ]}
-          >
-            <Grid item xs={12}>
-              <TextField
-                label="Company Name"
-                errorText={errorMap.company}
-                onChange={this.updateCompany}
-                value={defaultTo(account.company, fields.company)}
-                data-qa-company
-              />
-            </Grid>
-          </Grid>
-
-          <Grid
-            className={classes.removeTopMargin}
-            item
-            xs={12}
-            updateFor={[
-              account.address_1,
-              fields.address_1,
-              errorMap.address_1,
-              classes,
-            ]}
-          >
-            <TextField
-              label="Address"
-              errorText={errorMap.address_1}
-              onChange={this.updateAddress1}
-              value={defaultTo(account.address_1, fields.address_1)}
-              data-qa-contact-address-1
-            />
-          </Grid>
-
-          <Grid
-            className={classes.removeTopMargin}
-            item
-            xs={12}
-            updateFor={[
-              account.address_2,
-              fields.address_2,
-              errorMap.address_2,
-              classes,
-            ]}
-          >
-            <TextField
-              label="Address 2"
-              errorText={errorMap.address_2}
-              onChange={this.updateAddress2}
-              value={defaultTo(account.address_2, fields.address_2)}
-              data-qa-contact-address-2
-            />
-          </Grid>
-
-          <Grid
-            className={classes.removeTopMargin}
-            item
-            xs={12}
-            sm={6}
-            updateFor={[
-              account.country,
-              fields.country,
-              errorMap.country,
-              classes,
-            ]}
-          >
-            <EnhancedSelect
-              label="Country"
-              errorText={errorMap.country}
-              isClearable={false}
-              onChange={this.updateCountry}
-              options={countryResults}
-              placeholder="Select a Country"
-              required
-              value={countryResults.find(({ value }) =>
-                fields.country
-                  ? value === fields.country
-                  : value === account.country
-              )}
-              textFieldProps={{
-                dataAttrs: {
-                  'data-qa-contact-country': true,
-                },
-              }}
-            />
-          </Grid>
-
-          <Grid
-            className={classes.removeTopMargin}
-            item
-            xs={12}
-            sm={6}
-            updateFor={[
-              fields.state,
-              fields.zip,
-              fields.country,
-              errorMap.state,
-              errorMap.zip,
-              errorMap.country,
-              classes,
-            ]}
-          >
-            {fields.country === 'US' || fields.country == 'CA' ? (
-              <EnhancedSelect
-                label={`${fields.country === 'US' ? 'State' : 'Province'}`}
-                errorText={errorMap.state}
-                isClearable={false}
-                onChange={this.updateState}
-                options={regionResults}
-                placeholder="Select region"
-                required
-                value={
-                  regionResults.find(({ value }) =>
-                    fields.state
-                      ? value === fields.state
-                      : value === account.state
-                  ) ?? ''
-                }
-                textFieldProps={{
-                  dataAttrs: {
-                    'data-qa-contact-province': true,
-                  },
-                }}
-              />
-            ) : (
-              <TextField
-                label="State / Province"
-                errorText={errorMap.state}
-                onChange={(e) =>
-                  this.updateState({
-                    label: e.target.value,
-                    value: e.target.value,
-                  })
-                }
-                placeholder="Enter region"
-                required
-                value={fields.state || ''}
-                dataAttrs={{
-                  'data-qa-contact-province': true,
-                }}
-              />
-            )}
-          </Grid>
-
-          <Grid
-            className={classes.removeTopMargin}
-            item
-            xs={12}
-            sm={6}
-            updateFor={[account.city, fields.city, errorMap.city, classes]}
-          >
-            <TextField
-              label="City"
-              errorText={errorMap.city}
-              onChange={this.updateCity}
-              value={defaultTo(account.city, fields.city)}
-              data-qa-contact-city
-            />
-          </Grid>
-
-          <Grid className={classes.removeTopMargin} item xs={12} sm={6}>
-            <TextField
-              label="Postal Code"
-              errorText={errorMap.zip}
-              onChange={this.updateZip}
-              value={defaultTo(account.zip, fields.zip)}
-              data-qa-contact-post-code
-            />
-          </Grid>
-
-          <Grid
-            item
-            xs={12}
-            updateFor={[account.phone, fields.phone, errorMap.phone, classes]}
-          >
-            <TextField
-              label="Phone"
-              type="tel"
-              errorText={errorMap.phone}
-              onChange={this.updatePhone}
-              value={defaultTo(account.phone, fields.phone)}
-              data-qa-contact-phone
-            />
-          </Grid>
-
-          <Grid
-            className={classes.removeTopMargin}
-            item
-            xs={12}
-            updateFor={[
-              account.tax_id,
-              fields.tax_id,
-              errorMap.tax_id,
-              classes,
-            ]}
-          >
-            <TextField
-              label="Tax ID"
-              errorText={errorMap.tax_id}
-              onChange={this.updateTaxID}
-              value={defaultTo(account.tax_id, fields.tax_id)}
-              data-qa-contact-tax-id
+              label="Company Name"
+              errorText={errorMap.company}
+              onChange={this.updateCompany}
+              value={defaultTo(account.company, fields.company)}
+              data-qa-company
             />
           </Grid>
         </Grid>
-      </form>
+
+        <Grid
+          className={classes.removeTopMargin}
+          item
+          xs={12}
+          updateFor={[
+            account.address_1,
+            fields.address_1,
+            errorMap.address_1,
+            classes,
+          ]}
+        >
+          <TextField
+            label="Address"
+            errorText={errorMap.address_1}
+            onChange={this.updateAddress1}
+            value={defaultTo(account.address_1, fields.address_1)}
+            data-qa-contact-address-1
+          />
+        </Grid>
+
+        <Grid
+          className={classes.removeTopMargin}
+          item
+          xs={12}
+          updateFor={[
+            account.address_2,
+            fields.address_2,
+            errorMap.address_2,
+            classes,
+          ]}
+        >
+          <TextField
+            label="Address 2"
+            errorText={errorMap.address_2}
+            onChange={this.updateAddress2}
+            value={defaultTo(account.address_2, fields.address_2)}
+            data-qa-contact-address-2
+          />
+        </Grid>
+
+        <Grid
+          className={classes.removeTopMargin}
+          item
+          xs={12}
+          sm={6}
+          updateFor={[
+            account.country,
+            fields.country,
+            errorMap.country,
+            classes,
+          ]}
+        >
+          <EnhancedSelect
+            label="Country"
+            errorText={errorMap.country}
+            isClearable={false}
+            onChange={this.updateCountry}
+            options={countryResults}
+            placeholder="Select a Country"
+            required
+            value={countryResults.find(({ value }) =>
+              fields.country
+                ? value === fields.country
+                : value === account.country
+            )}
+            textFieldProps={{
+              dataAttrs: {
+                'data-qa-contact-country': true,
+              },
+            }}
+          />
+        </Grid>
+
+        <Grid
+          className={classes.removeTopMargin}
+          item
+          xs={12}
+          sm={6}
+          updateFor={[
+            fields.state,
+            fields.zip,
+            fields.country,
+            errorMap.state,
+            errorMap.zip,
+            errorMap.country,
+            classes,
+          ]}
+        >
+          {fields.country === 'US' || fields.country == 'CA' ? (
+            <EnhancedSelect
+              label={`${fields.country === 'US' ? 'State' : 'Province'}`}
+              errorText={errorMap.state}
+              isClearable={false}
+              onChange={this.updateState}
+              options={regionResults}
+              placeholder="Select region"
+              required
+              value={
+                regionResults.find(({ value }) =>
+                  fields.state
+                    ? value === fields.state
+                    : value === account.state
+                ) ?? ''
+              }
+              textFieldProps={{
+                dataAttrs: {
+                  'data-qa-contact-province': true,
+                },
+              }}
+            />
+          ) : (
+            <TextField
+              label="State / Province"
+              errorText={errorMap.state}
+              onChange={(e) =>
+                this.updateState({
+                  label: e.target.value,
+                  value: e.target.value,
+                })
+              }
+              placeholder="Enter region"
+              required
+              value={fields.state || ''}
+              dataAttrs={{
+                'data-qa-contact-province': true,
+              }}
+            />
+          )}
+        </Grid>
+
+        <Grid
+          className={classes.removeTopMargin}
+          item
+          xs={12}
+          sm={6}
+          updateFor={[account.city, fields.city, errorMap.city, classes]}
+        >
+          <TextField
+            label="City"
+            errorText={errorMap.city}
+            onChange={this.updateCity}
+            value={defaultTo(account.city, fields.city)}
+            data-qa-contact-city
+          />
+        </Grid>
+
+        <Grid className={classes.removeTopMargin} item xs={12} sm={6}>
+          <TextField
+            label="Postal Code"
+            errorText={errorMap.zip}
+            onChange={this.updateZip}
+            value={defaultTo(account.zip, fields.zip)}
+            data-qa-contact-post-code
+          />
+        </Grid>
+
+        <Grid
+          item
+          xs={12}
+          updateFor={[account.phone, fields.phone, errorMap.phone, classes]}
+        >
+          <TextField
+            label="Phone"
+            type="tel"
+            errorText={errorMap.phone}
+            onChange={this.updatePhone}
+            value={defaultTo(account.phone, fields.phone)}
+            data-qa-contact-phone
+          />
+        </Grid>
+
+        <Grid
+          className={classes.removeTopMargin}
+          item
+          xs={12}
+          updateFor={[account.tax_id, fields.tax_id, errorMap.tax_id, classes]}
+        >
+          <TextField
+            label="Tax ID"
+            errorText={errorMap.tax_id}
+            onChange={this.updateTaxID}
+            value={defaultTo(account.tax_id, fields.tax_id)}
+            data-qa-contact-tax-id
+          />
+        </Grid>
+      </Grid>
     );
   };
 
@@ -541,13 +534,12 @@ class UpdateContactInformationForm extends React.Component<
   };
 
   updateEmail = (e: React.ChangeEvent<HTMLInputElement>) => {
-    this.composeState([set(L.fields.email, e.target.value)]);
-
     if (e.target.value === '') {
       this.setState({ isValid: false });
     } else {
       this.setState({ isValid: true });
     }
+    this.composeState([set(L.fields.email, e.target.value)]);
   };
 
   updateFirstName = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -563,18 +555,15 @@ class UpdateContactInformationForm extends React.Component<
   };
 
   updateState = (selectedRegion: Item) => {
-    this.composeState([set(L.fields.state, selectedRegion.value)]);
-
     if (selectedRegion.value === undefined || selectedRegion.value === '') {
       this.setState({ isValid: false });
     } else {
       this.setState({ isValid: true });
     }
+    this.composeState([set(L.fields.state, selectedRegion.value)]);
   };
 
   updateCountry = (selectedCountry: Item) => {
-    this.composeState([set(L.fields.country, selectedCountry.value)]);
-
     this.setState({
       fields: {
         ...this.state.fields,
@@ -582,6 +571,7 @@ class UpdateContactInformationForm extends React.Component<
       },
       isValid: false,
     });
+    this.composeState([set(L.fields.country, selectedCountry.value)]);
   };
 
   updateTaxID = (e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## Description

This PR will make the state/province a dropdown field if the US or Canada is selected as the country. If the previous input does not match any of the options, keep that field as is until the user goes to modify their state/province. Additionally, the country and state/province fields are now required and the form layout has been changed to better match the sign up form. 

**Remaining tasks:**
- [x] Display `Virgin Islands` as `Virgin Islands, U.S.`
- [x] Remove `Micronesia`, `Marshall Islands`, `Palau`, `Armed Forces Americas`, `Armed Forces Europe, Canada, Africa and Middle East`, and `Armed Forces Pacific` from the US states dropdown
- [x] Add `United States Minor Outlying Islands` (short code is `UM`)

## How to test

Switch between countries as you input valid and invalid values for the US/Canada and other countries.