### PR TITLE
M3-5651: Enable Mock Data in PR Builds

### DIFF
--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -3,8 +3,11 @@ import { ObjectStorageClusterID } from '@linode/api-v4/lib/object-storage';
 
 const PRODUCTION = 'production';
 
-/** native to webpack build */
+// native to webpack build
 export const isProductionBuild = process.env.NODE_ENV === PRODUCTION;
+
+// allow us to explicity enable dev tools
+export const ENABLE_DEV_TOOLS = Boolean(process.env.REACT_APP_ENABLE_DEV_TOOLS);
 
 /** required for the app to function */
 export const APP_ROOT =

--- a/packages/manager/src/dev-tools/dev-tools.tsx
+++ b/packages/manager/src/dev-tools/dev-tools.tsx
@@ -7,7 +7,7 @@ import EnvironmentToggleTool from './EnvironmentToggleTool';
 import store from 'src/store';
 import { Provider } from 'react-redux';
 import MockDataTool from './MockDataTool';
-import { isProductionBuild } from 'src/constants';
+import { ENABLE_DEV_TOOLS, isProductionBuild } from 'src/constants';
 import Grid from 'src/components/core/Grid';
 
 function install() {
@@ -26,11 +26,11 @@ function install() {
               <EnvironmentToggleTool />
             </Grid>
           )}
-          {!isProductionBuild && (
+          {!isProductionBuild || ENABLE_DEV_TOOLS ? (
             <Grid item xs={4} sm={5} md={3}>
               <MockDataTool />
             </Grid>
-          )}
+          ) : null}
         </Grid>
       </div>
     );

--- a/packages/manager/src/dev-tools/load.ts
+++ b/packages/manager/src/dev-tools/load.ts
@@ -1,5 +1,7 @@
 // Thanks to https://kentcdodds.com/blog/make-your-own-dev-tools
 
+import { ENABLE_DEV_TOOLS } from 'src/constants';
+
 function loadDevTools(callback: () => any) {
   // we want it enabled by default everywhere but production and we also want
   // to support the dev tools in production (to make us more productive triaging production issues).
@@ -28,7 +30,8 @@ export const devToolsEnabled = () => {
     window.localStorage.getItem('dev-tools') === 'false';
   const explicitlyEnabled =
     window.location.search.includes('dev-tools=true') ||
-    window.localStorage.getItem('dev-tools') === 'true';
+    window.localStorage.getItem('dev-tools') === 'true' ||
+    ENABLE_DEV_TOOLS;
 
   return (
     !explicitlyDisabled &&

--- a/packages/manager/src/mocks/testBrowser.ts
+++ b/packages/manager/src/mocks/testBrowser.ts
@@ -1,6 +1,6 @@
 import { setupWorker } from 'msw';
 import { SetupWorkerApi } from 'msw/lib/types/setupWorker/setupWorker';
-import { isProductionBuild } from 'src/constants';
+import { ENABLE_DEV_TOOLS, isProductionBuild } from 'src/constants';
 import { MockData, mockDataController } from 'src/dev-tools/mockDataController';
 import store, { ApplicationState } from 'src/store';
 import { requestDomains } from 'src/store/domains/domains.requests';
@@ -11,7 +11,7 @@ import { handlers, mockDataHandlers } from './serverHandlers';
 
 let worker: SetupWorkerApi;
 
-if (!isProductionBuild) {
+if (!isProductionBuild || ENABLE_DEV_TOOLS) {
   worker = setupWorker(...handlers);
 
   // Subscribe to changes from the mockDataController, which is updated by local dev tools.


### PR DESCRIPTION
## Description

Allows us to specify an environment variable that will explicitly enable the MSW in the dev tools. 

Specifying `REACT_APP_ENABLE_DEV_TOOLS` will explicitly enable the data mocking tools in the dev tools and show the dev tools in PR builds unless explicitly disabled. 

## How to test

For now, we can't test this because the internal ticket is not yet merged. 

If you **really** want to test this, you should run your own production build with `yarn build` with the normal Cloud Manager secrets and `REACT_APP_ENABLE_DEV_TOOLS=true`. Host this on your own web server and see if mock data tools are showing up and working.

I did the steps above and confirmed that with `REACT_APP_ENABLE_DEV_TOOLS=true`, we should have mock data when that env variable is specified. Please review this PR for nomenclature and do your best to assess functionality. 
