### PR TITLE
M3-5647: Fix Icon Alignment for Kubernetes Nodes

### DIFF
--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
@@ -237,7 +237,7 @@ export const NodeRow: React.FC<NodeRowProps> = React.memo((props) => {
             Error retrieving status
           </Typography>
         ) : (
-          <Grid container alignItems="center">
+          <Grid container alignItems="center" wrap="nowrap">
             <StatusIcon status={iconStatus} />
             {displayStatus}
           </Grid>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodeTable.tsx
@@ -44,9 +44,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   error: {
     color: theme.color.red,
   },
-  statusIconAndText: {
-    whiteSpace: 'nowrap',
-  },
 }));
 
 // =============================================================================
@@ -241,10 +238,8 @@ export const NodeRow: React.FC<NodeRowProps> = React.memo((props) => {
           </Typography>
         ) : (
           <Grid container alignItems="center">
-            <Grid item className={classes.statusIconAndText}>
-              <StatusIcon status={iconStatus} />
-              {displayStatus}
-            </Grid>
+            <StatusIcon status={iconStatus} />
+            {displayStatus}
           </Grid>
         )}
       </TableCell>


### PR DESCRIPTION
## Description

Fixes an unaligned status icon in the Kubernetes Node Table. This recession was caused by linode#7763. An extra wrapping Grid caused the centering to not happen. I was able to remove the extra styles and wrapping Grid. 

I removed the `whiteSpace: 'nowrap'` because in my testing, it had no effect on the UI. 


Before
<img width="156" alt="Screen Shot 2022-01-11 at 11 34 23 AM" src="https://user-images.githubusercontent.com/6440455/148983235-9986144a-b469-4b43-af61-7ab5d3769868.png">


After
<img width="156" alt="Screen Shot 2022-01-11 at 11 34 38 AM" src="https://user-images.githubusercontent.com/6440455/148983257-a482c25e-f2fe-45f1-ab0c-044089ff6a83.png">


## How to test

- Navigate to any `/kubernetes/clusters/{id}/summary`
- Check the status icon of a node at all viewport sizes
- Compare this PR build to https://cloud.linode.com
