### PR TITLE
Update Cypress Test for Editing Account Information

### DIFF
--- a/packages/manager/cypress/integration/account/billing-contact.spec.ts
+++ b/packages/manager/cypress/integration/account/billing-contact.spec.ts
@@ -126,7 +126,7 @@ describe('Billing Contact', () => {
       .clear()
       .type(newAccountData['phone']);
     getClick('[data-qa-contact-country]').type('France{enter}');
-    cy.findByTestId('[data-qa-contact-state-province]')
+    getClick('[data-qa-contact-state-province]')
       .should('be.visible')
       .click()
       .clear()

--- a/packages/manager/cypress/integration/account/billing-contact.spec.ts
+++ b/packages/manager/cypress/integration/account/billing-contact.spec.ts
@@ -126,7 +126,7 @@ describe('Billing Contact', () => {
       .clear()
       .type(newAccountData['phone']);
     getClick('[data-qa-contact-country]').type('France{enter}');
-    cy.findByLabelText('State / Province')
+    cy.findByTestId('[data-qa-contact-state-province]')
       .should('be.visible')
       .click()
       .clear()

--- a/packages/manager/cypress/integration/account/billing-contact.spec.ts
+++ b/packages/manager/cypress/integration/account/billing-contact.spec.ts
@@ -43,7 +43,7 @@ const newAccountData = {
   city: 'New Philadelphia',
   country: 'FR',
   phone: '6104444444',
-  state: 'New Pennsylvania',
+  state: 'Pennsylvania',
   tax_id: '9234567890',
   zip: '19108',
 };
@@ -125,12 +125,11 @@ describe('Billing Contact', () => {
       .click()
       .clear()
       .type(newAccountData['phone']);
-    getClick('[data-qa-contact-country]').type('France{enter}');
+    getClick('[data-qa-contact-country]').type('United States{enter}');
     getClick('[data-qa-contact-state-province]')
       .should('be.visible')
       .click()
-      .clear()
-      .type(newAccountData['state']);
+      .type(`${newAccountData['state']}{enter}`);
     cy.findByLabelText('Tax ID')
       .should('be.visible')
       .click()

--- a/packages/manager/cypress/integration/account/billing-contact.spec.ts
+++ b/packages/manager/cypress/integration/account/billing-contact.spec.ts
@@ -115,7 +115,7 @@ describe('Billing Contact', () => {
       .click()
       .clear()
       .type(newAccountData['city']);
-    cy.findByLabelText('Zip / Postal Code')
+    cy.findByLabelText('Postal Code')
       .should('be.visible')
       .click()
       .clear()

--- a/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
@@ -426,7 +426,9 @@ class UpdateContactInformationForm extends React.Component<
               isClearable={false}
               onChange={this.updateState}
               options={filteredRegionResults}
-              placeholder="Select region"
+              placeholder={`Select ${
+                fields.country === 'US' ? 'state' : 'region'
+              }`}
               required={flags.regionDropdown}
               value={
                 filteredRegionResults.find(({ value }) =>
@@ -437,7 +439,7 @@ class UpdateContactInformationForm extends React.Component<
               }
               textFieldProps={{
                 dataAttrs: {
-                  'data-qa-contact-province': true,
+                  'data-qa-contact-state-province': true,
                 },
               }}
             />
@@ -455,7 +457,7 @@ class UpdateContactInformationForm extends React.Component<
               required={flags.regionDropdown}
               value={fields.state || ''}
               dataAttrs={{
-                'data-qa-contact-province': true,
+                'data-qa-contact-state-province': true,
               }}
             />
           )}

--- a/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
@@ -437,11 +437,7 @@ class UpdateContactInformationForm extends React.Component<
                     : value === account.state
                 ) ?? ''
               }
-              textFieldProps={{
-                dataAttrs: {
-                  'data-qa-contact-state-province': true,
-                },
-              }}
+              data-qa-contact-state-province
             />
           ) : (
             <TextField
@@ -456,9 +452,7 @@ class UpdateContactInformationForm extends React.Component<
               placeholder="Enter region"
               required={flags.regionDropdown}
               value={fields.state || ''}
-              dataAttrs={{
-                'data-qa-contact-state-province': true,
-              }}
+              data-qa-contact-state-province
             />
           )}
         </Grid>

--- a/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
@@ -437,7 +437,9 @@ class UpdateContactInformationForm extends React.Component<
                     : value === account.state
                 ) ?? ''
               }
-              data-qa-contact-state-province
+              textFieldProps={{
+                'data-qa-contact-state-province': true,
+              }}
             />
           ) : (
             <TextField


### PR DESCRIPTION
## Description

- Updates a Cypress test to match a change made by #8111 
- This test is kind of weird right now because it runs the same test but Cloud Manager has two different region / country selections right now that are toggled with a feature flag. I updated the test so it should pass if the flag is both on or off.

## How to test

- Is the change from `ZIP / Postal Code` to `Postal Code` desired? (I have no problem with it, just asking the question to be 100% sure)
- If the e2e GitHub Actions passed ✅, we should be good!
- If you want to run the test locally, run `yarn cy:debug` and run the test from Cypress's GUI