### PR TITLE
DBaaS Fixes and Updates

### DIFF
--- a/packages/api-v4/src/databases/types.ts
+++ b/packages/api-v4/src/databases/types.ts
@@ -97,7 +97,6 @@ export interface Database {
   region: string;
   status: DatabaseStatus;
   type: string;
-  version: string;
   failover_count: FailoverCount;
   engine: Engine;
   encrypted: boolean;

--- a/packages/api-v4/src/databases/types.ts
+++ b/packages/api-v4/src/databases/types.ts
@@ -97,6 +97,7 @@ export interface Database {
   region: string;
   status: DatabaseStatus;
   type: string;
+  version: string;
   failover_count: FailoverCount;
   engine: Engine;
   encrypted: boolean;

--- a/packages/manager/src/factories/databases.ts
+++ b/packages/manager/src/factories/databases.ts
@@ -71,7 +71,7 @@ export const databaseFactory = Factory.Sync.makeFactory<Database>({
   label: Factory.each((i) => `database-${i}`),
   region: 'us-east',
   status: pickRandom(possibleStatuses),
-  type: databaseTypeFactory.build().id,
+  type: 'g6-standard-0',
   version: '5.8.13',
   failover_count: 2,
   engine: 'mysql',

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.test.tsx
@@ -18,12 +18,16 @@ afterEach(() => {
 
 describe('Database Create', () => {
   it('should render loading state', () => {
-    const { getByTestId } = renderWithTheme(<DatabaseCreate />);
+    const { getByTestId } = renderWithTheme(<DatabaseCreate />, {
+      queryClient,
+    });
     expect(getByTestId(loadingTestId)).toBeInTheDocument();
   });
 
   it('should render inputs', async () => {
-    const { getAllByText, getByTestId } = renderWithTheme(<DatabaseCreate />);
+    const { getAllByText, getByTestId } = renderWithTheme(<DatabaseCreate />, {
+      queryClient,
+    });
     await waitForElementToBeRemoved(getByTestId(loadingTestId));
 
     getAllByText('Cluster Label');


### PR DESCRIPTION
## Description

- Adds `version` to the `Database` type
- Uses the same `queryClient` for all `DatabaseCreate` unit tests
- Makes the Database factory use the same type for every database (fixes the no cluster config issue)

## How to test

- Make sure the type change I made is accurate
- make sure unit tests pass
- Make sure the change to the database factory type makes logical sense and fixes the empty cluster config
