### PR TITLE
M3-5668: DBaaS Landing Page Refinements

### DIFF
--- a/packages/api-v4/src/databases/types.ts
+++ b/packages/api-v4/src/databases/types.ts
@@ -28,11 +28,14 @@ export interface DatabaseVersion {
 }
 
 export type DatabaseStatus =
-  | 'creating'
-  | 'running'
+  | 'provisioning'
+  | 'active'
+  | 'suspending'
+  | 'suspended'
+  | 'resuming'
+  | 'restoring'
   | 'failed'
-  | 'degraded'
-  | 'updating';
+  | 'degraded';
 
 export type DatabaseBackupType = 'snapshot' | 'auto';
 

--- a/packages/manager/src/components/TableSortCell/TableSortCell.tsx
+++ b/packages/manager/src/components/TableSortCell/TableSortCell.tsx
@@ -35,6 +35,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   initialIcon: {
     margin: 0,
     marginLeft: 4,
+    marginRight: 4,
   },
   noWrap: {
     whiteSpace: 'nowrap',

--- a/packages/manager/src/factories/databases.ts
+++ b/packages/manager/src/factories/databases.ts
@@ -11,12 +11,12 @@ import {
   ReplicationType,
 } from '@linode/api-v4/lib/databases/types';
 
+// These are not all of the possible statuses, but these are some common ones.
 const possibleStatuses: DatabaseStatus[] = [
-  'creating',
-  'running',
+  'provisioning',
+  'active',
   'failed',
   'degraded',
-  'updating',
 ];
 
 const possibleReplicationTypes: ReplicationType[] = [

--- a/packages/manager/src/factories/databases.ts
+++ b/packages/manager/src/factories/databases.ts
@@ -57,7 +57,7 @@ export const databaseInstanceFactory = Factory.Sync.makeFactory<DatabaseInstance
     engine: 'mysql',
     type: databaseTypeFactory.build().id,
     region: 'us-east',
-    version: 'mysql/5.8.13',
+    version: '5.8.13',
     status: Factory.each(() => pickRandom(possibleStatuses)),
     failover_count: Factory.each(() => pickRandom([0, 2])),
     updated: '2021-12-16T17:15:12',

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.test.tsx
@@ -58,7 +58,7 @@ describe('Database Table', () => {
     server.use(
       rest.get('*/databases/instances', (req, res, ctx) => {
         const databases = databaseInstanceFactory.buildList(1, {
-          status: 'running',
+          status: 'active',
         });
         return res(ctx.json(makeResourcePage(databases)));
       })
@@ -84,7 +84,7 @@ describe('Database Table', () => {
     getAllByText('Created');
 
     // Check to see if the mocked API data rendered in the table
-    queryAllByText('Running');
+    queryAllByText('Active');
   });
 
   it('should render database landing with empty state', async () => {

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
@@ -67,8 +67,9 @@ const DatabaseLanding: React.FC = () => {
   return (
     <React.Fragment>
       <LandingHeader
-        title="Databases"
-        entity="Database"
+        title="Database Clusters"
+        createButtonText="Create Database Cluster"
+        createButtonWidth={205}
         docsLink="https://linode.com/docs"
         onAddNew={() => history.push('/databases/create')}
       />

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseRow.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseRow.tsx
@@ -19,11 +19,14 @@ import {
 } from '@linode/api-v4/lib/databases/types';
 
 export const databaseStatusMap: Record<DatabaseStatus, Status> = {
-  creating: 'other',
-  running: 'active',
+  provisioning: 'other',
+  active: 'active',
+  suspending: 'other',
+  suspended: 'error',
+  resuming: 'other',
+  restoring: 'other',
   failed: 'error',
   degraded: 'inactive',
-  updating: 'other',
 };
 
 export const databaseEngineMap: Record<Engine, string> = {

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseRow.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseRow.tsx
@@ -43,10 +43,6 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-export const getDatabaseVersionNumber = (
-  version: DatabaseInstance['version']
-) => version.split('/')[1];
-
 interface Props {
   database: DatabaseInstance;
 }
@@ -92,9 +88,7 @@ export const DatabaseRow: React.FC<Props> = ({ database }) => {
       <Hidden xsDown>
         <TableCell>{configuration}</TableCell>
       </Hidden>
-      <TableCell>
-        {`${databaseEngineMap[engine]} v${getDatabaseVersionNumber(version)}`}
-      </TableCell>
+      <TableCell>{`${databaseEngineMap[engine]} v${version}`}</TableCell>
       <Hidden smDown>
         <TableCell>{dcDisplayNames[region] || 'Unknown Region'}</TableCell>
       </Hidden>


### PR DESCRIPTION
## Description

- Changes the title `Databases` ➡️ `Database Clusters`
- Updates the create button `Create Database` ➡️ `Create Database Cluster`
- Fixes the table shifting when changing the `order by` column
  - Fixed this by making the inactive sorter icon have the same margin as the active sorter icon
- Change how the version is determined in the table row
- Updates the possible Database statuses and the respective status icons

## How to test

- Verify all of the changes described above are accurate
- You should be able to use the internal PR build to test all of this
- Test with the MSW and optionally the alpha environment 
