### PR TITLE
M3-5671: Tweaks to Access Controls

### DIFF
--- a/packages/manager/src/components/MultipleIPInput/MultipleIPInput.tsx
+++ b/packages/manager/src/components/MultipleIPInput/MultipleIPInput.tsx
@@ -70,6 +70,7 @@ export interface Props {
   inputProps?: InputBaseProps;
   className?: string;
   required?: boolean;
+  forDatabaseAccessControls?: boolean;
 }
 
 export const MultipleIPInput: React.FC<Props> = (props) => {
@@ -83,6 +84,7 @@ export const MultipleIPInput: React.FC<Props> = (props) => {
     tooltip,
     placeholder,
     required,
+    forDatabaseAccessControls,
   } = props;
   const classes = useStyles();
 
@@ -179,16 +181,16 @@ export const MultipleIPInput: React.FC<Props> = (props) => {
               hideLabel
             />
           </Grid>
-          {/** Don't show the button for the first input since it won't do anything */}
+          {/** Don't show the button for the first input since it won't do anything, unless this component is used in DBaaS */}
           <Grid item xs={1}>
-            {idx > 0 && (
+            {idx > 0 || forDatabaseAccessControls ? (
               <Button
                 className={classes.button}
                 onClick={() => removeInput(idx)}
               >
                 <Close data-testid={`delete-ip-${idx}`} />
               </Button>
-            )}
+            ) : null}
           </Grid>
         </Grid>
       ))}

--- a/packages/manager/src/features/Databases/DatabaseDetail/AccessControls.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/AccessControls.tsx
@@ -52,7 +52,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   table: {
     width: '50%',
-    border: `solid 1px ${theme.cmrBorderColors.divider}`,
+    border: `solid 1px ${theme.cmrBorderColors.borderTable}`,
     '&:last-child': {
       borderBottom: 'none',
     },
@@ -64,7 +64,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-between',
-    borderBottom: `solid 1px ${theme.cmrBorderColors.divider}`,
+    borderBottom: `solid 1px ${theme.cmrBorderColors.borderTable}`,
   },
   removeButton: {
     float: 'right',

--- a/packages/manager/src/features/Databases/DatabaseDetail/AccessControls.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/AccessControls.tsx
@@ -44,7 +44,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
   },
   addAccessControlBtn: {
-    minWidth: 180,
+    minWidth: 214,
     [theme.breakpoints.down('sm')]: {
       alignSelf: 'flex-start',
       marginBottom: '1rem',
@@ -187,10 +187,9 @@ export const AccessControls: React.FC<Props> = (props) => {
           </div>
           <div className={classes.sectionText}>
             <Typography>
-              Add the IP addresses or IP range(s) for other instances or users
-              that should have the authorization to view this cluster&apos;s
-              database. By default, all public and private connections are
-              denied.{' '}
+              Add the IP addresses for other instances or users that should have
+              the authorization to view this cluster&apos;s database. By
+              default, all public and private connections are denied.{' '}
               <ExternalLink to="https://www.linode.com/docs/products/database">
                 Learn more.
               </ExternalLink>
@@ -198,7 +197,7 @@ export const AccessControls: React.FC<Props> = (props) => {
           </div>
         </div>
         <AddNewLink
-          label="Add Access Control"
+          label="Manage Access Controls"
           onClick={() => setAddAccessControlDrawerOpen(true)}
           className={classes.addAccessControlBtn}
         />
@@ -214,8 +213,7 @@ export const AccessControls: React.FC<Props> = (props) => {
         <Typography data-testid="ip-removal-confirmation-warning">
           IP {accessControlToBeRemoved} will lose all access to the data on this
           database cluster. This action cannot be undone, but you can re-enable
-          access by clicking Add Access Control and adding the same IP address
-          or IP range.
+          access by clicking Add Access Control and adding the same IP address.
         </Typography>
       </ConfirmationDialog>
       <AddAccessControlDrawer

--- a/packages/manager/src/features/Databases/DatabaseDetail/AccessControls.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/AccessControls.tsx
@@ -213,7 +213,8 @@ export const AccessControls: React.FC<Props> = (props) => {
         <Typography data-testid="ip-removal-confirmation-warning">
           IP {accessControlToBeRemoved} will lose all access to the data on this
           database cluster. This action cannot be undone, but you can re-enable
-          access by clicking Add Access Control and adding the same IP address.
+          access by clicking Manage Access Controls and adding the same IP
+          address.
         </Typography>
       </ConfirmationDialog>
       <AddAccessControlDrawer

--- a/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.test.tsx
@@ -20,7 +20,7 @@ describe('Add Access Controls drawer', () => {
   const { getByText, getByTestId } = renderWithTheme(
     <AccessControls database={database} />
   );
-  const button = getByText('Add Access Control');
+  const button = getByText('Manage Access Controls');
 
   fireEvent.click(button);
 
@@ -58,7 +58,7 @@ describe('Add Access Controls drawer', () => {
       />
     );
 
-    const addInboundSourcesButton = getByText('Add Inbound Sources').closest(
+    const addInboundSourcesButton = getByText('Update Inbound Sources').closest(
       'button'
     );
 

--- a/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
@@ -1,5 +1,4 @@
 import { useFormik } from 'formik';
-import { parse as parseIP, parseCIDR } from 'ipaddr.js';
 import * as React from 'react';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
@@ -10,7 +9,11 @@ import ExternalLink from 'src/components/Link';
 import MultipleIPInput from 'src/components/MultipleIPInput/MultipleIPInput';
 import Notice from 'src/components/Notice';
 import { handleAPIErrors } from 'src/utilities/formikErrorUtils';
-import { ExtendedIP, extendedIPToString } from 'src/utilities/ipUtils';
+import {
+  ExtendedIP,
+  extendedIPToString,
+  validateIPs,
+} from 'src/utilities/ipUtils';
 
 const useStyles = makeStyles((theme: Theme) => ({
   instructions: {
@@ -80,6 +83,7 @@ const AddAccessControlDrawer: React.FC<CombinedProps> = (props) => {
   const onValidate = ({ _allowList }: Values) => {
     const validatedIPs = validateIPs(_allowList, {
       allowEmptyAddress: false,
+      errorMessage: 'Must be a valid IPv4 address.',
     });
 
     setValues({ _allowList: validatedIPs });
@@ -165,33 +169,6 @@ const AddAccessControlDrawer: React.FC<CombinedProps> = (props) => {
       </React.Fragment>
     </Drawer>
   );
-};
-
-// Adds an `error` message to each invalid IP in the list.
-export const validateIPs = (
-  ips: ExtendedIP[],
-  options?: { allowEmptyAddress: boolean }
-): ExtendedIP[] => {
-  return ips.map(({ address }) => {
-    if (!options?.allowEmptyAddress && !address) {
-      return { address, error: 'Please enter an IP address.' };
-    }
-    // We accept plain IPs as well as ranges (i.e. CIDR notation). Ipaddr.js has separate parsing
-    // methods for each, so we check for a netmask to decide the method to use.
-    const [, mask] = address.split('/');
-    try {
-      if (mask) {
-        parseCIDR(address);
-      } else {
-        parseIP(address);
-      }
-    } catch (err) {
-      if (address) {
-        return { address, error: 'Must be a valid IPv4 address.' };
-      }
-    }
-    return { address };
-  });
 };
 
 export default AddAccessControlDrawer;

--- a/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
@@ -139,6 +139,7 @@ const AddAccessControlDrawer: React.FC<CombinedProps> = (props) => {
             onChange={handleIPChange}
             inputProps={{ autoFocus: true }}
             placeholder="Add IP address"
+            forDatabaseAccessControls
           />
           <ActionsPanel>
             <Button

--- a/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
@@ -1,4 +1,3 @@
-import { IP_ERROR_MESSAGE } from '@linode/validation/lib/firewalls.schema';
 import { useFormik } from 'formik';
 import { parse as parseIP, parseCIDR } from 'ipaddr.js';
 import * as React from 'react';
@@ -121,7 +120,7 @@ const AddAccessControlDrawer: React.FC<CombinedProps> = (props) => {
   );
 
   return (
-    <Drawer open={open} onClose={onClose} title="Add Access Controls">
+    <Drawer open={open} onClose={onClose} title="Manage Access Controls">
       <React.Fragment>
         {error ? <Notice error text={error} /> : null}
         <Typography variant="body1" className={classes.instructions}>
@@ -139,7 +138,7 @@ const AddAccessControlDrawer: React.FC<CombinedProps> = (props) => {
             ips={values._allowList}
             onChange={handleIPChange}
             inputProps={{ autoFocus: true }}
-            placeholder="Add IP address or range"
+            placeholder="Add IP address"
           />
           <ActionsPanel>
             <Button
@@ -158,7 +157,7 @@ const AddAccessControlDrawer: React.FC<CombinedProps> = (props) => {
               style={{ marginBottom: 8 }}
               loading={isSubmitting}
             >
-              Add Inbound Sources
+              Update Inbound Sources
             </Button>
           </ActionsPanel>
         </form>
@@ -187,7 +186,7 @@ export const validateIPs = (
       }
     } catch (err) {
       if (address) {
-        return { address, error: IP_ERROR_MESSAGE };
+        return { address, error: 'Must be a valid IPv4 address.' };
       }
     }
     return { address };


### PR DESCRIPTION
## Description
- [x] "Add Access Controls" button & drawer title --> "Manage Access Controls"
- [x] "Add Inbound Sources" button in drawer --> "Update Inbound Sources"
- [x] Remove references to "IP ranges" in copy & error messages
- [x] Allow for removal of first IP input

## Note to Reviewers
Without the mocks on, if you try removing the last IP that is allow listed on a cluster, an error message will be returned. It gets surfaced in the confirmation modal but not in the drawer. The API is working on some changes that will render this a non-issue, feel free to reach out for further details.