### PR TITLE
M3 5665 - Create page refinement

### DIFF
--- a/packages/api-v4/src/databases/types.ts
+++ b/packages/api-v4/src/databases/types.ts
@@ -1,6 +1,6 @@
 import { BaseType } from '../linodes/types';
 
-export type DatabaseTypeClass = 'standard' | 'dedicated';
+export type DatabaseTypeClass = 'standard' | 'dedicated' | 'nanode';
 
 interface DatabasePriceObject {
   monthly: number;

--- a/packages/manager/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/manager/src/components/Breadcrumb/Breadcrumb.tsx
@@ -25,6 +25,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     [theme.breakpoints.only('sm')]: {
       marginLeft: theme.spacing(),
     },
+    [theme.breakpoints.only('xs')]: {
+      marginLeft: theme.spacing(),
+    },
   },
   preContainer: {
     display: 'flex',

--- a/packages/manager/src/components/TextField.tsx
+++ b/packages/manager/src/components/TextField.tsx
@@ -89,6 +89,7 @@ interface BaseProps {
   optional?: boolean;
   required?: boolean;
   tooltipText?: string | JSX.Element;
+  tooltipClasses?: string;
   tooltipOnMouseEnter?: React.MouseEventHandler<HTMLDivElement> | undefined;
   value?: Value;
 }
@@ -136,6 +137,7 @@ export const LinodeTextField: React.FC<CombinedProps> = (props) => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     theme,
     tooltipText,
+    tooltipClasses,
     tooltipOnMouseEnter,
     type,
     value,
@@ -318,6 +320,7 @@ export const LinodeTextField: React.FC<CombinedProps> = (props) => {
         {tooltipText && (
           <HelpIcon
             className={classes.helpIcon}
+            classes={{ popper: tooltipClasses }}
             text={tooltipText}
             onMouseEnter={tooltipOnMouseEnter}
           />

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.test.tsx
@@ -43,21 +43,15 @@ describe('Database Create', () => {
     const standardTypes = [
       databaseTypeFactory.build({
         id: 'g6-standard-0',
-        label: `Linode 1 GB`,
-        class: 'standard',
+        label: `Nanode 1 GB`,
+        class: 'nanode',
         memory: 1024,
       }),
       ...databaseTypeFactory.buildList(7, { class: 'standard' }),
     ];
-    const dedicatedTypes = [
-      databaseTypeFactory.build({
-        id: 'g6-dedicated-0',
-        label: `Dedicated 1 GB`,
-        class: 'dedicated',
-        memory: 1024,
-      }),
-      ...databaseTypeFactory.buildList(7, { class: 'dedicated' }),
-    ];
+    const dedicatedTypes = databaseTypeFactory.buildList(7, {
+      class: 'dedicated',
+    });
     server.use(
       rest.get('*/databases/types', (req, res, ctx) => {
         return res(
@@ -76,9 +70,9 @@ describe('Database Create', () => {
     expect(nodeRadioBtns).toHaveTextContent('$0/month $0/hr');
 
     // update node pricing if a plan is selected
-    const radioBtn = getAllByText('Linode 1 GB')[0];
+    const radioBtn = getAllByText('Nanode 1 GB')[0];
     fireEvent.click(radioBtn);
-    expect(nodeRadioBtns).toHaveTextContent('$60/month $0.4/hr');
+    expect(nodeRadioBtns).toHaveTextContent('$60/month $0.40/hr');
     expect(nodeRadioBtns).toHaveTextContent('$140.00/month $1.00/hr');
 
     // 3 Node options are disabled for 1 GB plans

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -73,7 +73,8 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
   },
   nodeHelpIcon: {
-    padding: 0,
+    padding: '0px 0px 0px 2px',
+    marginTop: '-2px',
   },
   createText: {
     [theme.breakpoints.down('xs')]: {
@@ -310,7 +311,14 @@ const DatabaseCreate: React.FC<{}> = () => {
       value: 0,
       label: (
         <Typography>
-          1 Node
+          1 Node {` `}
+          {is1GbPlan ? (
+            <HelpIcon
+              className={classes.nodeHelpIcon}
+              text="1 GB Linodes are only available for single-node database deployments."
+              tooltipPosition="right"
+            />
+          ) : null}
           <br />
           {`$${type?.price.monthly || 0}/month $${type?.price.hourly || 0}/hr`}
         </Typography>
@@ -455,13 +463,6 @@ const DatabaseCreate: React.FC<{}> = () => {
         <Grid item>
           <Typography variant="h2" style={{ marginBottom: 4 }}>
             Set Number of Nodes{' '}
-            {is1GbPlan ? (
-              <HelpIcon
-                className={classes.nodeHelpIcon}
-                text="1 GB Linodes are only available for single-node database deployments."
-                tooltipPosition="right"
-              />
-            ) : null}
           </Typography>
           <Typography>
             We recommend 3 nodes in a database cluster to avoid downtime during

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -322,7 +322,7 @@ const DatabaseCreate: React.FC<{}> = () => {
           <br />
           <Typography style={{ fontSize: '12px' }}>
             {`$${type?.price.monthly || 0}/month $${
-              type?.price.hourly || 0
+              type?.price.hourly.toFixed(2) || 0.0
             }/hr`}
           </Typography>
         </Typography>
@@ -333,12 +333,11 @@ const DatabaseCreate: React.FC<{}> = () => {
       value: 2,
       label: (
         <Typography>
-          3 Nodes - High Availability{' '}
-          {type?.memory !== 1024 ? '(recommended)' : ''}
+          3 Nodes - High Availability {!is1GbPlan && '(recommended)'}
           <br />
           <Typography style={{ fontSize: '12px' }}>
             {`$${multiNodePricing.monthly || 0}/month $${
-              multiNodePricing.hourly || 0
+              parseFloat(multiNodePricing.hourly).toFixed(2) || 0.0
             }/hr`}
           </Typography>
         </Typography>

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -508,8 +508,8 @@ const DatabaseCreate: React.FC<{}> = () => {
         <Grid item>
           <Typography variant="h2">Add Access Controls</Typography>
           <Typography>
-            Add the IP addresses or IP range(s) for other instances or users
-            that should have the authorization to view this cluster’s database.
+            Add the IP addresses for other instances or users that should have
+            the authorization to view this cluster’s database.
           </Typography>
           <Typography>
             By default, all public and private connections are denied.{' '}
@@ -523,6 +523,7 @@ const DatabaseCreate: React.FC<{}> = () => {
               placeholder="Add IP Address or range"
               ips={values.allow_list}
               onChange={(address) => setFieldValue('allow_list', address)}
+              required
             />
           </Grid>
         </Grid>

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -452,7 +452,7 @@ const DatabaseCreate: React.FC<{}> = () => {
         </Grid>
         <Divider spacingTop={26} spacingBottom={12} />
         <Grid item>
-          <Typography variant="h2">
+          <Typography variant="h2" style={{ marginBottom: 4 }}>
             Set Number of Nodes{' '}
             {is1GbPlan ? (
               <HelpIcon
@@ -498,7 +498,9 @@ const DatabaseCreate: React.FC<{}> = () => {
         </Grid>
         <Divider spacingTop={26} spacingBottom={12} />
         <Grid item>
-          <Typography variant="h2">Add Access Controls</Typography>
+          <Typography variant="h2" style={{ marginBottom: 4 }}>
+            Add Access Controls
+          </Typography>
           <Typography>
             Add the IP addresses for other instances or users that should have
             the authorization to view this cluster’s database.

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -303,7 +303,7 @@ const DatabaseCreate: React.FC<{}> = () => {
     </div>
   );
 
-  const is1GbPlan = type?.memory === 1024;
+  const is1GbPlan = type?.class.includes('nanode');
 
   const nodeOptions = [
     {

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -244,6 +244,7 @@ const DatabaseCreate: React.FC<{}> = () => {
     const createPayload: CreateDatabasePayload = {
       ...values,
       allow_list: values.allow_list.map((ip) => ip.address),
+      ssl_connection: true,
     };
 
     try {

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -90,6 +90,13 @@ const useStyles = makeStyles((theme: Theme) => ({
     letterSpacing: '.25px',
     textTransform: 'uppercase',
   },
+  tooltip: {
+    '& .MuiTooltip-tooltip': {
+      [theme.breakpoints.up('md')]: {
+        minWidth: 350,
+      },
+    },
+  },
 }));
 
 const engineIcons = {
@@ -403,6 +410,7 @@ const DatabaseCreate: React.FC<{}> = () => {
             errorText={errors.label}
             label="Cluster Label"
             tooltipText={labelToolTip}
+            tooltipClasses={classes.tooltip}
             onChange={(e) => setFieldValue('label', e.target.value)}
             value={values.label}
           />

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -320,7 +320,11 @@ const DatabaseCreate: React.FC<{}> = () => {
             />
           ) : null}
           <br />
-          {`$${type?.price.monthly || 0}/month $${type?.price.hourly || 0}/hr`}
+          <Typography style={{ fontSize: '12px' }}>
+            {`$${type?.price.monthly || 0}/month $${
+              type?.price.hourly || 0
+            }/hr`}
+          </Typography>
         </Typography>
       ),
       disabled: is1GbPlan,
@@ -332,9 +336,11 @@ const DatabaseCreate: React.FC<{}> = () => {
           3 Nodes - High Availability{' '}
           {type?.memory !== 1024 ? '(recommended)' : ''}
           <br />
-          {`$${multiNodePricing.monthly || 0}/month $${
-            multiNodePricing.hourly || 0
-          }/hr`}
+          <Typography style={{ fontSize: '12px' }}>
+            {`$${multiNodePricing.monthly || 0}/month $${
+              multiNodePricing.hourly || 0
+            }/hr`}
+          </Typography>
         </Typography>
       ),
       disabled: is1GbPlan,

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -302,14 +302,6 @@ const DatabaseCreate: React.FC<{}> = () => {
     </div>
   );
 
-  const disableCreateButton =
-    !values.label ||
-    !values.engine ||
-    !values.region ||
-    !values.type ||
-    values.failover_count < 0 ||
-    values.allow_list.some((item) => item.address === '');
-
   const is1GbPlan = type?.memory === 1024;
 
   const nodeOptions = [
@@ -529,12 +521,7 @@ const DatabaseCreate: React.FC<{}> = () => {
         </Grid>
       </Paper>
       <Grid className={classes.btnCtn}>
-        <Button
-          type="submit"
-          buttonType="primary"
-          disabled={disableCreateButton}
-          loading={isSubmitting}
-        >
+        <Button type="submit" buttonType="primary" loading={isSubmitting}>
           Create Database Cluster
         </Button>
       </Grid>

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -140,21 +140,15 @@ const databases = [
     const standardTypes = [
       databaseTypeFactory.build({
         id: 'g6-standard-0',
-        label: `Linode 1 GB`,
-        class: 'standard',
+        label: `Nanode 1 GB`,
+        class: 'nanode',
         memory: 1024,
       }),
       ...databaseTypeFactory.buildList(7, { class: 'standard' }),
     ];
-    const dedicatedTypes = [
-      databaseTypeFactory.build({
-        id: 'g6-dedicated-0',
-        label: `Linode 1 GB`,
-        class: 'dedicated',
-        memory: 1024,
-      }),
-      ...databaseTypeFactory.buildList(7, { class: 'dedicated' }),
-    ];
+    const dedicatedTypes = databaseTypeFactory.buildList(7, {
+      class: 'dedicated',
+    });
     return res(
       ctx.json(makeResourcePage([...standardTypes, ...dedicatedTypes]))
     );

--- a/packages/manager/src/queries/databases.ts
+++ b/packages/manager/src/queries/databases.ts
@@ -69,7 +69,7 @@ export const useDatabaseMutation = (engine: Engine, id: number) =>
 
 export const useCreateDatabaseMutation = () =>
   useMutation<Database, APIError[], CreateDatabasePayload>(
-    (data) => createDatabase(data.engine, data),
+    (data) => createDatabase(data.engine?.split('/')[0] as Engine, data),
     {
       onSuccess: (data) => {
         // Invalidate useDatabasesQuery to show include the new database.

--- a/packages/manager/src/utilities/formatStorageUnits.ts
+++ b/packages/manager/src/utilities/formatStorageUnits.ts
@@ -1,13 +1,19 @@
 const storageRegex = /([0-9])([kMGTPEZY]?i?[B])/;
+const labelPrefixRegex = /^(DBaaS).+- /;
 
 function replaceFunc(match: string, p1: string, p2: string) {
   return `${p1} ${p2}`;
 }
 
 function formatStorageUnits(unformattedString: string) {
+  if (unformattedString.match(labelPrefixRegex)) {
+    unformattedString = unformattedString.replace(labelPrefixRegex, '');
+  }
+
   if (!unformattedString.match(storageRegex)) {
     return unformattedString;
   }
+
   return unformattedString.replace(storageRegex, replaceFunc);
 }
 

--- a/packages/validation/src/databases.schema.ts
+++ b/packages/validation/src/databases.schema.ts
@@ -11,7 +11,9 @@ export const createDatabaseSchema = object({
   engine: string().required('Database Engine is required'),
   region: string().required('Region is required'),
   type: string().required('Type is required'),
-  failover_count: number().oneOf([0, 2]).required('Nodes are required'),
+  failover_count: number()
+    .oneOf([0, 2], 'Nodes are required')
+    .required('Nodes are required'),
   replication_type: string()
     .oneOf(['none', 'semi-synch', 'asynch'])
     .required('Replication Type is required'),


### PR DESCRIPTION
## Description

Addresses Create Database feedback

## Done:
1. At mobile screen size breadcrumb needs left margin
4. Add space between top of helper text and baseline of headers Number of Nodes and Access Controls to 12 px (currently 8 px)
5. Move tooltip about limits of selecting Linode 1 GB plan to inline with the text block
6. Reduce size of pricing text to 12 px (currently 14 px)
7. Add (required) to field label
8. Button to be active by default
9. Remove references to IP Ranges from "Add Access Control" copy
10. Enable SSL mode by default
11. Add nanode to DatabaseTypeClass type
12. Update is1GbPlan variable logic so that selecting the 1 GB nanode plan disables the 3 Node option (logic is currently based on memory but we're getting null back from the api rn)
15. remove 'DBAAS MYSQL - ' from plan labels
16. Make shape of tooltip more horizontal (need to double check with Matthew about break points)


## TODO:
1. Reduce spacing between radio button and plan name to 26 px to match Linode plan table (_This seems to get a little messy because of how SelectPlanPanel dynamically expands to fit available width_)
2. [**Not required**] Change the hover state engine icon color to white. It currently does not change on hover and remains gray (see the gray dolphin in the attached screenshot)