### PR TITLE
M3-5630: Update NVMe Block Storage copy

### DIFF
--- a/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
@@ -275,7 +275,7 @@ const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
                   <Typography variant="body1" data-qa-volume-size-help>
                     A single Volume can range from 10 to {MAX_VOLUME_SIZE} GB in
                     size and costs <strong>$0.10/GB per month</strong>. Up to
-                    volumes can be attached to a single Linode.
+                    eight volumes can be attached to a single Linode.
                   </Typography>
                   <Typography
                     variant="body1"

--- a/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
@@ -64,7 +64,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   notice: {
     borderColor: theme.color.green,
-    fontWeight: 'bold',
     fontSize: 15,
     lineHeight: '18px',
   },
@@ -264,16 +263,18 @@ const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
                       dismissible
                       onClose={handleDismiss}
                     >
-                      We’re working quickly to expand global availability of our
-                      high-performance NVMe block storage.{' '}
-                      <Link to="https://www.linode.com/blog/cloud-storage/nvme-block-storage-global-rollout/">
-                        Check NVMe rollout status on our blog.
-                      </Link>
+                      <strong>
+                        We’re working quickly to expand global availability of
+                        our high-performance NVMe block storage.{' '}
+                        <Link to="https://www.linode.com/blog/cloud-storage/nvme-block-storage-global-rollout/">
+                          Check NVMe rollout status on our blog.
+                        </Link>
+                      </strong>
                     </Notice>
                   ) : null}
                   <Typography variant="body1" data-qa-volume-size-help>
                     A single Volume can range from 10 to {MAX_VOLUME_SIZE} GB in
-                    size and costs <b>$0.10/GB per month</b>. Up to eight
+                    size and costs <strong>$0.10/GB per month</strong>. Up to
                     volumes can be attached to a single Linode.
                   </Typography>
                   <Typography

--- a/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
@@ -17,6 +17,7 @@ import Typography from 'src/components/core/Typography';
 import { useDismissibleBanner } from 'src/components/DismissibleBanner/DismissibleBanner';
 import RegionSelect from 'src/components/EnhancedSelect/variants/RegionSelect';
 import Grid from 'src/components/Grid';
+import Link from 'src/components/Link';
 import Notice from 'src/components/Notice';
 import TagsInput, { Tag as _Tag } from 'src/components/TagsInput';
 import { dcDisplayNames, MAX_VOLUME_SIZE } from 'src/constants';
@@ -63,6 +64,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   notice: {
     borderColor: theme.color.green,
+    fontWeight: 'bold',
+    fontSize: 15,
+    lineHeight: '18px',
   },
   buttonGroup: {
     marginTop: theme.spacing(3),
@@ -260,8 +264,11 @@ const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
                       dismissible
                       onClose={handleDismiss}
                     >
-                      High-performance NVMe block storage is currently available
-                      in Atlanta, GA and Newark, NJ.
+                      We’re working quickly to expand global availability of our
+                      high-performance NVMe block storage.{' '}
+                      <Link to="https://www.linode.com/blog/cloud-storage/nvme-block-storage-global-rollout/">
+                        Check NVMe rollout status on our blog.
+                      </Link>
                     </Notice>
                   ) : null}
                   <Typography variant="body1" data-qa-volume-size-help>


### PR DESCRIPTION
## Description
Updates the NVMe Block Storage banner copy in the Volume Create form and adds link to rollout status blog

## How to test
Go to `volumes/create` and check the banner/link
