### PR TITLE
Reset root password heading cleanup

### DIFF
--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettings.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettings.test.tsx
@@ -19,7 +19,7 @@ describe('DatabaseSettings Component', () => {
     expect(paper).not.toBeNull();
     const headings = getAllByRole('heading');
     expect(headings[0].textContent).toBe('Access Controls');
-    expect(headings[1].textContent).toBe('Root Password Reset');
+    expect(headings[1].textContent).toBe('Reset Root Password');
     expect(headings[2].textContent).toBe('Delete Cluster');
   });
 });

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettings.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettings.tsx
@@ -53,7 +53,7 @@ export const DatabaseSettings: React.FC<Props> = (props) => {
           buttonText="Reset Root Password"
           descriptiveText={resetRootPasswordCopy}
           onClick={onResetRootPassword}
-          sectionTitle="Root Password Reset"
+          sectionTitle="Reset Root Password"
         />
         <Divider spacingTop={22} spacingBottom={22} />
         <DatabaseSettingsMenuItem


### PR DESCRIPTION
## Description

Changes the title of the Root Password Reset section of `DatabaseSettings` component to Reset Root Password. This better informs the user what the section is for and what action will happen when the button is clicked.

## How to test

1. Navigate to a database summary
2. Click on the Settings tag
3. Ensure the title and button text for the Reset Root Password section match

