### PR TITLE
hotfix: Region dropdown not showing previous value

### DIFF
--- a/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
@@ -426,9 +426,10 @@ class UpdateContactInformationForm extends React.Component<
               isClearable={false}
               onChange={this.updateState}
               options={filteredRegionResults}
-              placeholder={`Select ${
-                fields.country === 'US' ? 'state' : 'region'
-              }`}
+              placeholder={
+                account.state ||
+                `Select ${fields.country === 'US' ? 'state' : 'province'}`
+              }
               required={flags.regionDropdown}
               value={
                 filteredRegionResults.find(({ value }) =>


### PR DESCRIPTION
## Description

If the user previously had a region that is in options provided, display the region as the placeholder until they try to modify in which case the user will have to choose one of the provided options in the dropdown.

## How to test

1. Make sure the flag is turned off
2. Set the country as the "United States"
3. Type in a random word as the state in the input field
4. Turn the flag on
5. The state input field should now be a dropdown with the previous input displayed as the placeholder
