### PR TITLE
hotfix: Region dropdown not showing previous value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,28 +4,39 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [{2022-01-24] - v1.58.1
+
+### Fixed:
+
+- Display previous region as placeholder
+
 ## [2022-01-24] - v1.58.0
 
 ### Added:
+
 - Marketplace January 2022 Release
 
 ### Changed:
+
 - Upgrade to High Availability Dialog Copy
 - Marketplace document link updates and cleanup
 - State/Province field in Billing Contact Info drawer becomes a dropdown if country is US or Canada
 
 ### Fixed:
+
 - Icon Alignment for Kubernetes Nodes
 
 ## [2022-01-10] - v1.57.0
 
 ### Changed:
+
 - Marketplace: Utunnel app name update
 - Override Domain type display in search results
 - Backup Auto Enrollment – Remove redundant head
 - Removed copy re: OBJ buckets needing to be empty prior to removal
 
 ### Fixed:
+
 - Customer unable to edit Cloud Firewall Rules
 - Editing a Secondary Domain that caused freeze and crash
 - Support ticket entity param bug for LKE clusters

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.58.0",
+  "version": "1.58.1",
   "private": true,
   "engines": {
     "node": ">= 14.17.4"

--- a/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
@@ -426,9 +426,10 @@ class UpdateContactInformationForm extends React.Component<
               isClearable={false}
               onChange={this.updateState}
               options={filteredRegionResults}
-              placeholder={`Select ${
-                fields.country === 'US' ? 'state' : 'region'
-              }`}
+              placeholder={
+                account.state ||
+                `Select ${fields.country === 'US' ? 'state' : 'province'}`
+              }
               required={flags.regionDropdown}
               value={
                 filteredRegionResults.find(({ value }) =>


### PR DESCRIPTION
## Description

If the user previously had a region that is in options provided, display the region as the placeholder until they try to modify in which case the user will have to choose one of the provided options in the dropdown.

## How to test

1. Make sure the flag is turned off
2. Set the country as the "United States"
3. Type in a random word as the state in the input field
4. Turn the flag on
5. The state input field should now be a dropdown with the previous input displayed as the placeholder
