### PR TITLE
Revise parameter type for getDatabaseType() method

### DIFF
--- a/packages/api-v4/src/databases/databases.ts
+++ b/packages/api-v4/src/databases/databases.ts
@@ -59,7 +59,7 @@ export const getDatabaseTypes = (params?: any, filters?: any) =>
  * Return information for a single database type
  *
  */
-export const getDatabaseType = (typeSlug: number) =>
+export const getDatabaseType = (typeSlug: string) =>
   Request<DatabaseType>(
     setURL(`${API_ROOT}/databases/types/${typeSlug}`),
     setMethod('GET')


### PR DESCRIPTION
## Description
Adjust the type of `typeSlug` that is passed to the `getDatabaseType` method to a string so it is correct.
