### PR TITLE
M3-5676: Database Backups Refinements

### DIFF
--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackupTableRow.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackupTableRow.tsx
@@ -4,6 +4,7 @@ import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import DatabaseBackupActionMenu from './DatabaseBackupActionMenu';
 import formatDate from 'src/utilities/formatDate';
+import { parseAPIDate } from 'src/utilities/date';
 
 interface Props {
   backup: DatabaseBackup;
@@ -16,6 +17,7 @@ const BackupTableRow: React.FC<Props> = ({ backup, onRestore }) => {
   return (
     <TableRow key={id}>
       <TableCell>{formatDate(created)}</TableCell>
+      <TableCell>{parseAPIDate(created).toRelative()}</TableCell>
       <TableCell>
         <DatabaseBackupActionMenu backup={backup} onRestore={onRestore} />
       </TableCell>

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
@@ -68,17 +68,17 @@ export const DatabaseBackups: React.FC = () => {
 
   const renderTableBody = () => {
     if (databaseError) {
-      return <TableRowError message={databaseError[0].reason} colSpan={2} />;
+      return <TableRowError message={databaseError[0].reason} colSpan={3} />;
     }
     if (backupsError) {
-      return <TableRowError message={backupsError[0].reason} colSpan={2} />;
+      return <TableRowError message={backupsError[0].reason} colSpan={3} />;
     }
     if (isDatabaseLoading || isBackupsLoading) {
-      return <TableRowLoading oneLine numberOfColumns={2} colSpan={2} />;
+      return <TableRowLoading oneLine numberOfColumns={3} colSpan={3} />;
     }
     if (backups?.results === 0) {
       return (
-        <TableRowEmptyState message="No backups to display." colSpan={2} />
+        <TableRowEmptyState message="No backups to display." colSpan={3} />
       );
     }
     if (backups) {

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
@@ -10,6 +10,7 @@ import TableSortCell from 'src/components/TableSortCell';
 import DatabaseBackupTableRow from './DatabaseBackupTableRow';
 import TableRowError from 'src/components/TableRowError';
 import TableRowEmptyState from 'src/components/TableRowEmptyState';
+import Skeleton from 'src/components/core/Skeleton';
 import { useOrder } from 'src/hooks/useOrder';
 import { useParams } from 'react-router-dom';
 import { RestoreFromBackupDialog } from './RestoreFromBackupDialog';
@@ -18,7 +19,6 @@ import {
   useDatabaseBackupsQuery,
   useDatabaseQuery,
 } from 'src/queries/databases';
-import Skeleton from 'src/components/core/Skeleton';
 
 export const DatabaseBackups: React.FC = () => {
   const { databaseId, engine } = useParams<{
@@ -75,7 +75,7 @@ export const DatabaseBackups: React.FC = () => {
     }
     if (isDatabaseLoading || isBackupsLoading) {
       return (
-        <TableRow key={id}>
+        <TableRow>
           <TableCell>
             <Skeleton />
           </TableCell>
@@ -83,7 +83,7 @@ export const DatabaseBackups: React.FC = () => {
             <Skeleton />
           </TableCell>
           <TableCell>
-            <Skeleton style={{ width: '92%' }} />
+            <Skeleton style={{ maxWidth: '85%' }} />
           </TableCell>
         </TableRow>
       );

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
@@ -8,7 +8,6 @@ import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import TableSortCell from 'src/components/TableSortCell';
 import DatabaseBackupTableRow from './DatabaseBackupTableRow';
-import TableRowLoading from 'src/components/TableRowLoading';
 import TableRowError from 'src/components/TableRowError';
 import TableRowEmptyState from 'src/components/TableRowEmptyState';
 import { useOrder } from 'src/hooks/useOrder';
@@ -19,6 +18,7 @@ import {
   useDatabaseBackupsQuery,
   useDatabaseQuery,
 } from 'src/queries/databases';
+import Skeleton from 'src/components/core/Skeleton';
 
 export const DatabaseBackups: React.FC = () => {
   const { databaseId, engine } = useParams<{
@@ -74,7 +74,19 @@ export const DatabaseBackups: React.FC = () => {
       return <TableRowError message={backupsError[0].reason} colSpan={3} />;
     }
     if (isDatabaseLoading || isBackupsLoading) {
-      return <TableRowLoading oneLine numberOfColumns={3} colSpan={3} />;
+      return (
+        <TableRow key={id}>
+          <TableCell>
+            <Skeleton />
+          </TableCell>
+          <TableCell>
+            <Skeleton />
+          </TableCell>
+          <TableCell>
+            <Skeleton style={{ width: '92%' }} />
+          </TableCell>
+        </TableRow>
+      );
     }
     if (backups?.results === 0) {
       return (
@@ -105,11 +117,12 @@ export const DatabaseBackups: React.FC = () => {
               direction={order}
               label="created"
               handleClick={handleOrderChange}
+              style={{ width: 155 }}
             >
               Date Created
             </TableSortCell>
             <TableCell></TableCell>
-            <TableCell></TableCell>
+            <TableCell style={{ width: 100 }}></TableCell>
           </TableRow>
         </TableHead>
         <TableBody>{renderTableBody()}</TableBody>

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
@@ -109,6 +109,7 @@ export const DatabaseBackups: React.FC = () => {
               Date Created
             </TableSortCell>
             <TableCell></TableCell>
+            <TableCell></TableCell>
           </TableRow>
         </TableHead>
         <TableBody>{renderTableBody()}</TableBody>
@@ -116,8 +117,8 @@ export const DatabaseBackups: React.FC = () => {
       <Paper style={{ marginTop: 16 }}>
         <Typography variant="h3">Backup Schedule</Typography>
         <Typography style={{ lineHeight: '20px', marginTop: 4 }}>
-          A backup of this database is created every 24 hours at 0:00 UTC on a 7
-          day cycle.
+          A backup of this database is created every 24 hours at 0:00 UTC and
+          each backup is retained for 7 days.
         </Typography>
       </Paper>
       {database && backupToRestore ? (

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
@@ -75,7 +75,7 @@ export const DatabaseBackups: React.FC = () => {
     }
     if (isDatabaseLoading || isBackupsLoading) {
       return (
-        <TableRow>
+        <TableRow data-testid="table-row-loading">
           <TableCell>
             <Skeleton />
           </TableCell>

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/RestoreFromBackupDialog.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/RestoreFromBackupDialog.tsx
@@ -11,6 +11,7 @@ import formatDate from 'src/utilities/formatDate';
 import { useRestoreFromBackupMutation } from 'src/queries/databases';
 import { useSnackbar } from 'notistack';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import { useHistory } from 'react-router-dom';
 
 interface Props extends Omit<DialogProps, 'title'> {
   open: boolean;
@@ -22,6 +23,7 @@ interface Props extends Omit<DialogProps, 'title'> {
 export const RestoreFromBackupDialog: React.FC<Props> = (props) => {
   const { database, backup, onClose, open, ...rest } = props;
 
+  const history = useHistory();
   const { enqueueSnackbar } = useSnackbar();
 
   const [confirmationText, setConfirmationText] = React.useState('');
@@ -34,7 +36,8 @@ export const RestoreFromBackupDialog: React.FC<Props> = (props) => {
 
   const handleRestoreDatabase = () => {
     restore().then(() => {
-      enqueueSnackbar('Your database has been scheduled to be restored.', {
+      history.push('summary');
+      enqueueSnackbar('Your database is being restored.', {
         variant: 'success',
       });
       onClose();

--- a/packages/manager/src/features/Databases/DatabaseDetail/index.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/index.tsx
@@ -63,7 +63,7 @@ export const DatabaseDetail: React.FC = () => {
     },
   ];
 
-  const getDefaultTabIndex = () => {
+  const getTabIndex = () => {
     const tabChoice = tabs.findIndex((tab) =>
       Boolean(matchPath(tab.routeName, { path: location.pathname }))
     );
@@ -97,7 +97,7 @@ export const DatabaseDetail: React.FC = () => {
         ]}
         labelOptions={{ noCap: true }}
       />
-      <Tabs defaultIndex={getDefaultTabIndex()} onChange={handleTabChange}>
+      <Tabs index={getTabIndex()} onChange={handleTabChange}>
         <TabLinkList tabs={tabs} />
         <TabPanels>
           <SafeTabPanel index={0}>


### PR DESCRIPTION
## Description

- Added **relative date** column to the backups table
- Updated **copy** to explain that **backups are retained for 7 days**
- When user successfully initializes a restore, we toast a success message, and redirect them to the summary page
  - The user will see the status `Restoring` immediately they start a restore successfully. This may not be immediately updating until #8131 is merged. 
 
## How to test

- Try restoring a database form a backup. Ensure the flow as described above is accurate
- Check copy change for spelling and grammar
- Check that the relative date in the table works and looks good
