### PR TITLE
DBaaS1-205: Replace instances of 'semi-synch' with 'semi_synch'

### DIFF
--- a/packages/api-v4/src/databases/types.ts
+++ b/packages/api-v4/src/databases/types.ts
@@ -80,7 +80,7 @@ export interface DatabaseInstance {
 export type FailoverCount = 0 | 2;
 type ReadonlyCount = 0 | 2;
 
-export type ReplicationType = 'none' | 'semi-synch' | 'asynch';
+export type ReplicationType = 'none' | 'semi_synch' | 'asynch';
 
 export interface CreateDatabasePayload {
   label: string;

--- a/packages/manager/src/factories/databases.ts
+++ b/packages/manager/src/factories/databases.ts
@@ -21,7 +21,7 @@ const possibleStatuses: DatabaseStatus[] = [
 
 const possibleReplicationTypes: ReplicationType[] = [
   'none',
-  'semi-synch',
+  'semi_synch',
   'asynch',
 ];
 

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -373,7 +373,7 @@ const DatabaseCreate: React.FC<{}> = () => {
       ).toFixed(2),
     });
     setFieldValue('failover_count', is1GbPlan ? 0 : 2);
-    setFieldValue('replication_type', is1GbPlan ? 'none' : 'semi-synch');
+    setFieldValue('replication_type', is1GbPlan ? 'none' : 'semi_synch');
   }, [dbtypes, is1GbPlan, setFieldValue, values.type]);
 
   if (regionsLoading || !regionsData || versionsLoading || typesLoading) {
@@ -487,7 +487,7 @@ const DatabaseCreate: React.FC<{}> = () => {
               setFieldValue('failover_count', +e.target.value);
               setFieldValue(
                 'replication_type',
-                +e.target.value === 0 ? 'none' : 'semi-synch'
+                +e.target.value === 0 ? 'none' : 'semi_synch'
               );
             }}
             data-testid="database-nodes"

--- a/packages/validation/src/databases.schema.ts
+++ b/packages/validation/src/databases.schema.ts
@@ -15,7 +15,7 @@ export const createDatabaseSchema = object({
     .oneOf([0, 2], 'Nodes are required')
     .required('Nodes are required'),
   replication_type: string()
-    .oneOf(['none', 'semi-synch', 'asynch'])
+    .oneOf(['none', 'semi_synch', 'asynch'])
     .required('Replication Type is required'),
 });
 


### PR DESCRIPTION
## Description
Replace instances of `semi-synch` with `semi_synch` per imminent API hotfix.

## How to test
Once the hotfix has been merged, ensure that everything in the DBaaS flow still functions properly.
