### PR TITLE
M3-5683: Add Secondary Host and Tooltip

### DIFF
--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
@@ -11,6 +11,8 @@ import { useDatabaseCredentialsQuery } from 'src/queries/databases';
 import { downloadFile } from 'src/utilities/downloadFile';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import { useSnackbar } from 'notistack';
+import Box from 'src/components/core/Box';
+import HelpIcon from 'src/components/HelpIcon';
 
 const useStyles = makeStyles((theme: Theme) => ({
   header: {
@@ -69,11 +71,18 @@ const useStyles = makeStyles((theme: Theme) => ({
     color: theme.color.red,
     marginLeft: theme.spacing(2),
   },
+  helpIcon: {
+    padding: 0,
+    marginLeft: theme.spacing(),
+  },
 }));
 
 interface Props {
   database: Database;
 }
+
+const privateHostCopy =
+  'A private network host and a private IP can only be used to access a database cluster from Linodes in the same data center and will not incur transfer costs.';
 
 export const DatabaseSummaryConnectionDetails: React.FC<Props> = (props) => {
   const { database } = props;
@@ -189,6 +198,14 @@ export const DatabaseSummaryConnectionDetails: React.FC<Props> = (props) => {
         <Typography>
           <span>host</span> = {database.hosts?.primary}
         </Typography>
+        {database.hosts.secondary ? (
+          <Box display="flex" flexDirection="row" alignItems="center">
+            <Typography>
+              <span>private network host</span> = {database.hosts.secondary}
+            </Typography>
+            <HelpIcon className={classes.helpIcon} text={privateHostCopy} />
+          </Box>
+        ) : null}
         <Typography>
           <span>port</span> = {database.port}
         </Typography>


### PR DESCRIPTION
## Preview 
<img width="610" alt="Screen Shot 2022-01-26 at 12 55 37 PM" src="https://user-images.githubusercontent.com/6440455/151219363-9bd15d46-cabc-4796-9be0-45356952cc02.png">


## Description

- Displays a databases's secondary host if available from the API
- A tooltip is included to give the user context about what the secondary host is to be used for

## How to test

- Test with the MSW enabled (the API is not returning secondary hosts yet)
- Go to `/databases/mysql/0` and ensure you see `private network host` with a `HelpIcon` in the `Connection Details`