### PR TITLE
M3-5675: Post-demo Refinements to Access Controls

### DIFF
--- a/packages/manager/src/features/Databases/DatabaseDetail/AccessControls.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/AccessControls.tsx
@@ -90,6 +90,9 @@ export const AccessControls: React.FC<Props> = (props) => {
 
   const [isDialogOpen, setDialogOpen] = React.useState<boolean>(false);
   const [error, setError] = React.useState<string | undefined>();
+  const [ipRemovalLoading, setIPRemovalLoading] = React.useState<boolean>(
+    false
+  );
   const [
     accessControlToBeRemoved,
     setAccessControlToBeRemoved,
@@ -125,15 +128,19 @@ export const AccessControls: React.FC<Props> = (props) => {
   };
 
   const handleRemoveIPAddress = () => {
+    setIPRemovalLoading(true);
+
     updateDatabase({
       allow_list: allowList.filter(
         (ipAddress) => ipAddress !== accessControlToBeRemoved
       ),
     })
       .then(() => {
+        setIPRemovalLoading(false);
         handleDialogClose();
       })
       .catch((e: APIError[]) => {
+        setIPRemovalLoading(false);
         setError(e[0].reason);
       });
   };
@@ -172,7 +179,11 @@ export const AccessControls: React.FC<Props> = (props) => {
         Cancel
       </Button>
 
-      <Button buttonType="primary" onClick={handleRemoveIPAddress}>
+      <Button
+        buttonType="primary"
+        onClick={handleRemoveIPAddress}
+        loading={ipRemovalLoading}
+      >
         Remove IP Address
       </Button>
     </ActionsPanel>

--- a/packages/manager/src/features/Databases/DatabaseDetail/AccessControls.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/AccessControls.tsx
@@ -90,9 +90,7 @@ export const AccessControls: React.FC<Props> = (props) => {
 
   const [isDialogOpen, setDialogOpen] = React.useState<boolean>(false);
   const [error, setError] = React.useState<string | undefined>();
-  const [ipRemovalLoading, setIPRemovalLoading] = React.useState<boolean>(
-    false
-  );
+
   const [
     accessControlToBeRemoved,
     setAccessControlToBeRemoved,
@@ -105,7 +103,10 @@ export const AccessControls: React.FC<Props> = (props) => {
 
   const [extendedIPs, setExtendedIPs] = React.useState<ExtendedIP[]>([]);
 
-  const { mutateAsync: updateDatabase } = useDatabaseMutation(engine, id);
+  const {
+    mutateAsync: updateDatabase,
+    isLoading: databaseUpdating,
+  } = useDatabaseMutation(engine, id);
 
   React.useEffect(() => {
     if (allowList.length > 0) {
@@ -128,19 +129,15 @@ export const AccessControls: React.FC<Props> = (props) => {
   };
 
   const handleRemoveIPAddress = () => {
-    setIPRemovalLoading(true);
-
     updateDatabase({
       allow_list: allowList.filter(
         (ipAddress) => ipAddress !== accessControlToBeRemoved
       ),
     })
       .then(() => {
-        setIPRemovalLoading(false);
         handleDialogClose();
       })
       .catch((e: APIError[]) => {
-        setIPRemovalLoading(false);
         setError(e[0].reason);
       });
   };
@@ -182,7 +179,7 @@ export const AccessControls: React.FC<Props> = (props) => {
       <Button
         buttonType="primary"
         onClick={handleRemoveIPAddress}
-        loading={ipRemovalLoading}
+        loading={databaseUpdating}
       >
         Remove IP Address
       </Button>
@@ -201,7 +198,7 @@ export const AccessControls: React.FC<Props> = (props) => {
               Add the IP addresses for other instances or users that should have
               the authorization to view this cluster&apos;s database. By
               default, all public and private connections are denied.{' '}
-              <ExternalLink to="https://www.linode.com/docs/products/databases/managed-databases/">
+              <ExternalLink to="https://www.linode.com/docs/products/databases/managed-databases/guides/manage-access-controls/">
                 Learn more.
               </ExternalLink>
             </Typography>

--- a/packages/manager/src/features/Databases/DatabaseDetail/AccessControls.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/AccessControls.tsx
@@ -201,7 +201,7 @@ export const AccessControls: React.FC<Props> = (props) => {
               Add the IP addresses for other instances or users that should have
               the authorization to view this cluster&apos;s database. By
               default, all public and private connections are denied.{' '}
-              <ExternalLink to="https://www.linode.com/docs/products/database">
+              <ExternalLink to="https://www.linode.com/docs/products/databases/managed-databases/">
                 Learn more.
               </ExternalLink>
             </Typography>

--- a/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.test.tsx
@@ -58,16 +58,16 @@ describe('Add Access Controls drawer', () => {
       />
     );
 
-    const addInboundSourcesButton = getByText('Update Inbound Sources').closest(
+    const addAccessControlsButton = getByText('Update Access Controls').closest(
       'button'
     );
 
     // Before making a change to the IP addresses, the "Add Inbound Sources" button should be disabled.
-    expect(addInboundSourcesButton).toBeDisabled();
+    expect(addAccessControlsButton).toBeDisabled();
 
     const addAnIPButton = getByText('Add an IP');
     fireEvent.click(addAnIPButton);
 
-    expect(addInboundSourcesButton).toBeEnabled();
+    expect(addAccessControlsButton).toBeEnabled();
   });
 });

--- a/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.test.tsx
@@ -30,12 +30,13 @@ describe('Add Access Controls drawer', () => {
   });
 
   it('Should open with a full list of current inbound sources that are allow listed', async () => {
+    const IPv4ListWithMasks = IPv4List.map((ip) => `${ip}/32`);
     const { getAllByTestId } = renderWithTheme(
       <AddAccessControlDrawer
         open={true}
         onClose={() => null}
         updateDatabase={() => null}
-        allowList={IPv4List.map(stringToExtendedIP)}
+        allowList={IPv4ListWithMasks.map(stringToExtendedIP)}
       />
     );
 
@@ -43,9 +44,9 @@ describe('Add Access Controls drawer', () => {
       IPv4List.length
     );
 
-    await screen.findByDisplayValue(IPv4List[0]);
-    await screen.findByDisplayValue(IPv4List[1]);
-    await screen.findByDisplayValue(IPv4List[2]);
+    await screen.findByDisplayValue(IPv4ListWithMasks[0]);
+    await screen.findByDisplayValue(IPv4ListWithMasks[1]);
+    await screen.findByDisplayValue(IPv4ListWithMasks[2]);
   });
 
   it('Should have a disabled Add Inbound Sources button until an inbound source field is touched', () => {

--- a/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
@@ -1,3 +1,4 @@
+import { APIError } from '@linode/api-v4/lib/types';
 import { useFormik } from 'formik';
 import * as React from 'react';
 import ActionsPanel from 'src/components/ActionsPanel';
@@ -8,10 +9,12 @@ import Drawer from 'src/components/Drawer';
 import ExternalLink from 'src/components/Link';
 import MultipleIPInput from 'src/components/MultipleIPInput/MultipleIPInput';
 import Notice from 'src/components/Notice';
+import { enforceIPMasks } from 'src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer';
 import { handleAPIErrors } from 'src/utilities/formikErrorUtils';
 import {
   ExtendedIP,
   extendedIPToString,
+  ipFieldPlaceholder,
   validateIPs,
 } from 'src/utilities/ipUtils';
 
@@ -43,18 +46,19 @@ const AddAccessControlDrawer: React.FC<CombinedProps> = (props) => {
   const classes = useStyles();
 
   const [error, setError] = React.useState<string | undefined>('');
+  const [allowListErrors, setAllowListErrors] = React.useState<APIError[]>();
 
   // This will be set to `true` once a form field has been touched. This is used to disable the
-  // "Allow Inbound Sources" button unless there have been changes to the form.
+  // "Update Access Controls" button unless there have been changes to the form.
   const [formTouched, setFormTouched] = React.useState<boolean>(false);
 
-  React.useEffect(() => {
-    if (open) {
-      setError('');
-    }
-  }, [open]);
+  const handleIPBlur = (_ips: ExtendedIP[]) => {
+    const _ipsWithMasks = enforceIPMasks(_ips);
 
-  const handleAllowInboundSourcesClick = (
+    setValues({ _allowList: _ipsWithMasks });
+  };
+
+  const handleUpdateAccessControlsClick = (
     { _allowList }: Values,
     {
       setSubmitting,
@@ -75,6 +79,14 @@ const AddAccessControlDrawer: React.FC<CombinedProps> = (props) => {
         onClose();
       })
       .catch((errors: any) => {
+        // Surface allow_list errors -- for example, "Invalid IPv4 address(es): ..."
+        const allowListErrors = errors.filter(
+          (error: APIError) => error.field === 'allow_list'
+        );
+        if (allowListErrors) {
+          setAllowListErrors(allowListErrors);
+        }
+
         handleAPIErrors(errors, setFieldError, setError);
         setSubmitting(false);
       });
@@ -101,12 +113,18 @@ const AddAccessControlDrawer: React.FC<CombinedProps> = (props) => {
     };
   };
 
-  const { values, isSubmitting, handleSubmit, setValues } = useFormik({
+  const {
+    values,
+    isSubmitting,
+    handleSubmit,
+    setValues,
+    resetForm,
+  } = useFormik({
     initialValues: {
       _allowList: allowList,
     },
     enableReinitialize: true,
-    onSubmit: handleAllowInboundSourcesClick,
+    onSubmit: handleUpdateAccessControlsClick,
     validateOnChange: false,
     validateOnBlur: false,
     validate: (values: Values) => onValidate(values),
@@ -123,10 +141,27 @@ const AddAccessControlDrawer: React.FC<CombinedProps> = (props) => {
     [formTouched, setValues]
   );
 
+  React.useEffect(() => {
+    if (open) {
+      setError('');
+      setAllowListErrors([]);
+      resetForm();
+    }
+  }, [open, resetForm]);
+
   return (
     <Drawer open={open} onClose={onClose} title="Manage Access Controls">
       <React.Fragment>
         {error ? <Notice error text={error} /> : null}
+        {allowListErrors
+          ? allowListErrors.map((allowListError) => (
+              <Notice
+                error
+                text={allowListError.reason}
+                key={allowListError.reason}
+              />
+            ))
+          : null}
         <Typography variant="body1" className={classes.instructions}>
           Add or remove IPv4 addresses and ranges that should be authorized to
           view your cluster&apos;s database.{' '}
@@ -141,8 +176,9 @@ const AddAccessControlDrawer: React.FC<CombinedProps> = (props) => {
             className={classes.ipSelect}
             ips={values._allowList}
             onChange={handleIPChange}
+            onBlur={handleIPBlur}
             inputProps={{ autoFocus: true }}
-            placeholder="Add IP address"
+            placeholder={ipFieldPlaceholder}
             forDatabaseAccessControls
           />
           <ActionsPanel>

--- a/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
@@ -128,16 +128,16 @@ const AddAccessControlDrawer: React.FC<CombinedProps> = (props) => {
       <React.Fragment>
         {error ? <Notice error text={error} /> : null}
         <Typography variant="body1" className={classes.instructions}>
-          To restrict connections to trusted sources, add at least one inbound
-          source below.{' '}
+          Add or remove IPv4 addresses and ranges that should be authorized to
+          view your cluster&apos;s database.{' '}
           <ExternalLink to="https://www.linode.com/docs/products/database">
             Learn more about securing your cluster.
           </ExternalLink>
         </Typography>
         <form onSubmit={handleSubmit}>
           <MultipleIPInput
-            title="Inbound Sources"
-            aria-label="Inbound Sources"
+            title="Allowed IP Address(es) or Range(s)"
+            aria-label="Allowed IP Addresses or Ranges"
             className={classes.ipSelect}
             ips={values._allowList}
             onChange={handleIPChange}
@@ -162,7 +162,7 @@ const AddAccessControlDrawer: React.FC<CombinedProps> = (props) => {
               style={{ marginBottom: 8 }}
               loading={isSubmitting}
             >
-              Update Inbound Sources
+              Update Access Controls
             </Button>
           </ActionsPanel>
         </form>

--- a/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
@@ -165,7 +165,7 @@ const AddAccessControlDrawer: React.FC<CombinedProps> = (props) => {
         <Typography variant="body1" className={classes.instructions}>
           Add or remove IPv4 addresses and ranges that should be authorized to
           view your cluster&apos;s database.{' '}
-          <ExternalLink to="https://www.linode.com/docs/products/databases/managed-databases/">
+          <ExternalLink to="https://www.linode.com/docs/products/databases/managed-databases/guides/manage-access-controls/">
             Learn more about securing your cluster.
           </ExternalLink>
         </Typography>

--- a/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
@@ -165,7 +165,7 @@ const AddAccessControlDrawer: React.FC<CombinedProps> = (props) => {
         <Typography variant="body1" className={classes.instructions}>
           Add or remove IPv4 addresses and ranges that should be authorized to
           view your cluster&apos;s database.{' '}
-          <ExternalLink to="https://www.linode.com/docs/products/database">
+          <ExternalLink to="https://www.linode.com/docs/products/databases/managed-databases/">
             Learn more about securing your cluster.
           </ExternalLink>
         </Typography>

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseEmptyState.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseEmptyState.tsx
@@ -39,7 +39,7 @@ const DatabaseEmptyState: React.FC = () => {
           Fully managed and highly scalable database clusters. Choose your
           Linode plan, select a database engine, and deploy in minutes.
         </div>
-        <Link to="https://www.linode.com/docs/products/database">
+        <Link to="https://www.linode.com/docs/products/databases/managed-databases/">
           Need help getting started? Browse database guides.
         </Link>
       </Typography>


### PR DESCRIPTION
## Description
- [x] Revisions to copy and drawer & button names
- [x] Accept and enforce CIDR notation in drawer (same convention as Firewalls)
- [x] Loading state on "Remove IP Address" in Remove IP confirmation modal

## How to test
- When you go to remove an IP address, confirm there is a button loading state, and that errors display as expected
- Check that copy matches what is specified in ticket
- Confirm that CIDR notation (`/32`) is accepted and enforced on IPs in the drawer
