### PR TITLE
M3-5679: Querify database credentials reset

### DIFF
--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsResetPasswordDialog.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsResetPasswordDialog.tsx
@@ -3,7 +3,8 @@ import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
 import Typography from 'src/components/core/Typography';
-import { Engine, resetDatabaseCredentials } from '@linode/api-v4/lib/databases';
+import { Engine } from '@linode/api-v4/lib/databases';
+import { useDatabaseCredentialsMutation } from 'src/queries/databases';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
 interface Props {
@@ -45,23 +46,23 @@ const renderActions = (
 export const DatabaseSettingsResetPasswordDialog: React.FC<Props> = (props) => {
   const { open, onClose, databaseEngine, databaseID } = props;
 
-  const [isLoading, setIsLoading] = React.useState(false);
-  const [error, setError] = React.useState('');
+  const [error, setError] = React.useState<string | undefined>();
+
+  const { mutateAsync, isLoading } = useDatabaseCredentialsMutation(
+    databaseEngine,
+    databaseID
+  );
 
   const onResetRootPassword = async () => {
-    setIsLoading(true);
     try {
-      await resetDatabaseCredentials(databaseEngine, databaseID);
-      setIsLoading(false);
+      await mutateAsync();
       onClose();
-    } catch (e) {
-      setIsLoading(false);
-      setError(
-        getAPIErrorOrDefault(
-          e,
-          'There was an error resetting the root password'
-        )[0].reason
-      );
+    } catch (_error) {
+      const reason = getAPIErrorOrDefault(
+        _error,
+        'There was an error resetting the root password'
+      )[0].reason;
+      setError(reason);
     }
   };
 

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsResetPasswordDialog.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsResetPasswordDialog.tsx
@@ -5,7 +5,7 @@ import ConfirmationDialog from 'src/components/ConfirmationDialog';
 import Typography from 'src/components/core/Typography';
 import { Engine } from '@linode/api-v4/lib/databases';
 import { useDatabaseCredentialsMutation } from 'src/queries/databases';
-import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import Notice from 'src/components/Notice';
 
 interface Props {
   open: boolean;
@@ -46,24 +46,14 @@ const renderActions = (
 export const DatabaseSettingsResetPasswordDialog: React.FC<Props> = (props) => {
   const { open, onClose, databaseEngine, databaseID } = props;
 
-  const [error, setError] = React.useState<string | undefined>();
-
-  const { mutateAsync, isLoading } = useDatabaseCredentialsMutation(
+  const { mutateAsync, isLoading, error } = useDatabaseCredentialsMutation(
     databaseEngine,
     databaseID
   );
 
   const onResetRootPassword = async () => {
-    try {
-      await mutateAsync();
-      onClose();
-    } catch (_error) {
-      const reason = getAPIErrorOrDefault(
-        _error,
-        'There was an error resetting the root password'
-      )[0].reason;
-      setError(reason);
-    }
+    await mutateAsync();
+    onClose();
   };
 
   return (
@@ -72,8 +62,8 @@ export const DatabaseSettingsResetPasswordDialog: React.FC<Props> = (props) => {
       title="Reset Root Password"
       onClose={onClose}
       actions={renderActions(onClose, onResetRootPassword, isLoading)}
-      error={error}
     >
+      {error ? <Notice error>{error[0].reason}</Notice> : undefined}
       <Typography>
         After resetting your Root Password, you can view your new password on
         the Database Cluster Summary page.

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
@@ -104,17 +104,20 @@ export const DatabaseSummaryConnectionDetails: React.FC<Props> = (props) => {
     isLoading: credentialsLoading,
     error: credentialsError,
     refetch: getDatabaseCredentials,
+    isRefetching,
   } = useDatabaseCredentialsQuery(database.engine, database.id);
 
+  const passwordIsReady = credentials && !isRefetching && !credentialsLoading;
+
   const password =
-    showCredentials && credentials ? credentials?.password : '••••••••';
+    showCredentials && passwordIsReady ? credentials?.password : '••••••••';
 
   const handleShowPasswordClick = () => {
     setShowPassword((showCredentials) => !showCredentials);
   };
 
   React.useEffect(() => {
-    if (showCredentials && !credentials) {
+    if (showCredentials) {
       getDatabaseCredentials();
     }
   }, [credentials, getDatabaseCredentials, showCredentials]);
@@ -180,7 +183,7 @@ export const DatabaseSummaryConnectionDetails: React.FC<Props> = (props) => {
               <span>password</span> = {password}
             </Typography>
           </div>
-          {credentialsLoading ? (
+          {credentialsLoading || isRefetching ? (
             <div className={classes.progressCtn}>
               <CircleProgress mini tag />
             </div>

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
@@ -106,7 +106,8 @@ export const DatabaseSummaryConnectionDetails: React.FC<Props> = (props) => {
     refetch: getDatabaseCredentials,
   } = useDatabaseCredentialsQuery(database.engine, database.id);
 
-  const password = showCredentials ? credentials?.password : '••••••••';
+  const password =
+    showCredentials && credentials ? credentials?.password : '••••••••';
 
   const handleShowPasswordClick = () => {
     setShowPassword((showCredentials) => !showCredentials);

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
@@ -104,20 +104,16 @@ export const DatabaseSummaryConnectionDetails: React.FC<Props> = (props) => {
     isLoading: credentialsLoading,
     error: credentialsError,
     refetch: getDatabaseCredentials,
-    isRefetching,
   } = useDatabaseCredentialsQuery(database.engine, database.id);
 
-  const passwordIsReady = credentials && !isRefetching && !credentialsLoading;
-
-  const password =
-    showCredentials && passwordIsReady ? credentials?.password : '••••••••';
+  const password = showCredentials ? credentials?.password : '••••••••';
 
   const handleShowPasswordClick = () => {
     setShowPassword((showCredentials) => !showCredentials);
   };
 
   React.useEffect(() => {
-    if (showCredentials) {
+    if (showCredentials && !credentials) {
       getDatabaseCredentials();
     }
   }, [credentials, getDatabaseCredentials, showCredentials]);
@@ -183,7 +179,7 @@ export const DatabaseSummaryConnectionDetails: React.FC<Props> = (props) => {
               <span>password</span> = {password}
             </Typography>
           </div>
-          {credentialsLoading || isRefetching ? (
+          {credentialsLoading ? (
             <div className={classes.progressCtn}>
               <CircleProgress mini tag />
             </div>

--- a/packages/manager/src/queries/databases.ts
+++ b/packages/manager/src/queries/databases.ts
@@ -9,6 +9,7 @@ import {
   getEngineDatabase,
   restoreWithBackup,
   updateDatabase,
+  resetDatabaseCredentials,
 } from '@linode/api-v4/lib/databases';
 import {
   CreateDatabasePayload,
@@ -142,6 +143,13 @@ export const useDatabaseCredentialsQuery = (
     () => getDatabaseCredentials(engine, id),
     { ...queryPresets.oneTimeFetch, enabled }
   );
+
+export const useDatabaseCredentialsMutation = (engine: Engine, id: number) =>
+  useMutation<{}, APIError[]>(() => resetDatabaseCredentials(engine, id), {
+    onSuccess: () => {
+      queryClient.invalidateQueries(`${queryKey}-credentials`);
+    },
+  });
 
 export const useRestoreFromBackupMutation = (
   engine: Engine,

--- a/packages/manager/src/queries/databases.ts
+++ b/packages/manager/src/queries/databases.ts
@@ -147,7 +147,8 @@ export const useDatabaseCredentialsQuery = (
 export const useDatabaseCredentialsMutation = (engine: Engine, id: number) =>
   useMutation<{}, APIError[]>(() => resetDatabaseCredentials(engine, id), {
     onSuccess: () => {
-      queryClient.invalidateQueries(`${queryKey}-credentials`);
+      queryClient.invalidateQueries([`${queryKey}-credentials`, id]);
+      queryClient.removeQueries([`${queryKey}-credentials`, id]);
     },
   });
 


### PR DESCRIPTION
## Description

Creates a query for resetting a database's credentials. The query invalidates and removes the cached response from the get credentials query.

## How to test

1. Navigate to a database cluster's details page
2. Click the show button for the root database password
3. Take note of the current root database password
4. Navigate to the settings tab
5. Click the Reset Root Password button
6. Click the confirm button in the confirmation modal
7. Navigate back to the summary tab
8. Click the show button for the root database password
9. Ensure that the new root password is different from the one from step 3.

