### PR TITLE
M3-5662 Remove check for E2E label when running tests against PRs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -23,14 +23,14 @@ If the continuous integration workflow was triggered via a push to the `master` 
 ## End-to-End Tests
 Automatic end-to-end testing of Linode Cloud Manager via [Cypress](https://www.cypress.io/) is handled by the `Run Tests On PR` and `Run Tests On Push/Schedule` workflows. These two workflows are very similar, and differ primarily in how they are triggered.
 
-End-to-end tests are run automatically for the `develop` branch each weekday at 8:00 AM ET, and are triggered any time code is pushed to the `develop`, `staging`, and `master` branches. However, tests are only performed for pull requests if the PR includes the `e2e` label.
+End-to-end tests are run automatically for the `develop` branch each weekday at 8:00 AM ET, and are triggered any time code is pushed to the `develop`, `staging`, and `master` branches. Tests also run for pull requests authored by Cloud Manager team members.
 
 Cypress tests are parallelized across four containers, and tests are automatically distributed among containers for optimal performance. To avoid race conditions, each test container is authenticated with its own test user account.
 
 ### Triggers
 * Scheduled, 1:00 PM UTC (8:00 AM ET) every Monday through Friday for `develop` branch
 * Upon push to `develop`, `staging`, and `master` branches
-* Upon creation or update to any pull request with `e2e` label
+* Upon creation or update to any pull request authored by a Cloud Manager team member
 
 ### Secrets
 | Name                       | Description                               |

--- a/.github/workflows/e2e_pr.yml
+++ b/.github/workflows/e2e_pr.yml
@@ -8,11 +8,10 @@ env:
   CLIENT_ID: ${{ secrets.REACT_APP_CLIENT_ID }}
 on:
   pull_request_target:
-    types: [labeled, synchronize]
+    types: [synchronize]
 
 jobs:
   run-cypress-e2e-pr:
-    if: contains(github.event.pull_request.labels.*.name, 'e2e')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/e2e_pr.yml
+++ b/.github/workflows/e2e_pr.yml
@@ -8,7 +8,6 @@ env:
   CLIENT_ID: ${{ secrets.REACT_APP_CLIENT_ID }}
 on:
   pull_request_target:
-    types: [synchronize]
 
 jobs:
   run-cypress-e2e-pr:


### PR DESCRIPTION
## Description

**What does this PR do?**
Removes the check for the `e2e` label on PRs before running the Cypress end-to-end tests. Workflows already require approval to run for PRs authored by outside contributors, so the thought is that the check for the `e2e` label isn't really necessary from a security perspective.

## How to test

**What are the steps to reproduce the issue or verify the changes?**

We're limited in our ability to test this before merging. If the code is merged, I'll open two PRs -- one with this account, and one with my personal account -- to make sure that:

* PRs opened by team members have their E2E tests run automatically
* PRs opened by outside contributors require approval before their E2E tests run

I'll revert these changes if we do not observe the above behavior.

## Other notes/thoughts
* :white_check_mark: This change has been cleared by the security team
* :question: Would there be any value in checking for a `skip-e2e` or similar label for PRs where tests aren't necessary? (documentation and changelog updates, etc.)
