### PR TITLE
M3-5694: Changes to types, schema, and Database components to reflect cluster_size

### DIFF
--- a/packages/api-v4/src/databases/types.ts
+++ b/packages/api-v4/src/databases/types.ts
@@ -7,15 +7,15 @@ interface DatabasePriceObject {
   hourly: number;
 }
 
+interface DatabaseClusterSizeObject {
+  quantity: number;
+  price: DatabasePriceObject;
+}
+
 export interface DatabaseType extends BaseType {
   class: DatabaseTypeClass;
   deprecated: boolean;
-  price: DatabasePriceObject;
-  addons: {
-    failover: {
-      price: DatabasePriceObject;
-    };
-  };
+  cluster_size: DatabaseClusterSizeObject[];
 }
 
 export type Engine = 'mysql' | 'postgresql' | 'mongodb' | 'redis';
@@ -70,14 +70,14 @@ export interface DatabaseInstance {
   region: string;
   version: string;
   status: DatabaseStatus;
-  failover_count: number;
+  cluster_size: ClusterSize;
   updated: string;
   created: string;
   instance_uri: string;
   hosts: DatabaseHosts;
 }
 
-export type FailoverCount = 0 | 2;
+export type ClusterSize = 1 | 3;
 type ReadonlyCount = 0 | 2;
 
 export type ReplicationType = 'none' | 'semi_synch' | 'asynch';
@@ -86,7 +86,7 @@ export interface CreateDatabasePayload {
   label: string;
   region: string;
   type: string;
-  failover_count?: FailoverCount;
+  cluster_size?: ClusterSize;
   engine?: Engine;
   encrypted?: boolean;
   ssl_connection?: boolean;
@@ -108,7 +108,7 @@ export interface Database {
   version: string;
   region: string;
   status: DatabaseStatus;
-  failover_count: FailoverCount;
+  cluster_size: ClusterSize;
   readonly_count?: ReadonlyCount;
   engine: Engine;
   encrypted: boolean;

--- a/packages/api-v4/src/databases/types.ts
+++ b/packages/api-v4/src/databases/types.ts
@@ -2,7 +2,7 @@ import { BaseType } from '../linodes/types';
 
 export type DatabaseTypeClass = 'standard' | 'dedicated' | 'nanode';
 
-interface DatabasePriceObject {
+export interface DatabasePriceObject {
   monthly: number;
   hourly: number;
 }

--- a/packages/manager/src/factories/databases.ts
+++ b/packages/manager/src/factories/databases.ts
@@ -31,23 +31,27 @@ export const databaseTypeFactory = Factory.Sync.makeFactory<DatabaseType>({
   id: Factory.each((i) => `g6-standard-${i}`),
   label: Factory.each((i) => `Linode ${i} GB`),
   class: 'standard',
-  price: {
-    hourly: 0.4,
-    monthly: 60,
-  },
+  cluster_size: [
+    {
+      quantity: 1,
+      price: {
+        hourly: 0.4,
+        monthly: 60,
+      },
+    },
+    {
+      quantity: 3,
+      price: {
+        hourly: 0.3,
+        monthly: 90,
+      },
+    },
+  ],
   memory: 2048,
   transfer: 30,
   disk: 20480,
   vcpus: 2,
   deprecated: false,
-  addons: {
-    failover: {
-      price: {
-        monthly: 80,
-        hourly: 0.6,
-      },
-    },
-  },
 });
 
 export const databaseInstanceFactory = Factory.Sync.makeFactory<DatabaseInstance>(
@@ -59,7 +63,7 @@ export const databaseInstanceFactory = Factory.Sync.makeFactory<DatabaseInstance
     region: 'us-east',
     version: '5.8.13',
     status: Factory.each(() => pickRandom(possibleStatuses)),
-    failover_count: Factory.each(() => pickRandom([0, 2])),
+    cluster_size: Factory.each(() => pickRandom([1, 3])),
     hosts: {
       primary: 'db-mysql-primary-0.b.linodeb.net',
       secondary: 'db-mysql-secondary-0.b.linodeb.net',
@@ -77,7 +81,7 @@ export const databaseFactory = Factory.Sync.makeFactory<Database>({
   status: pickRandom(possibleStatuses),
   type: 'g6-standard-0',
   version: '5.8.13',
-  failover_count: 2,
+  cluster_size: Factory.each(() => pickRandom([1, 3])),
   engine: 'mysql',
   encrypted: false,
   ipv4_public: pickRandom(IPv4List),

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.test.tsx
@@ -75,10 +75,7 @@ describe('Database Create', () => {
     // update node pricing if a plan is selected
     const radioBtn = getAllByText('Nanode 1 GB')[0];
     fireEvent.click(radioBtn);
-    expect(nodeRadioBtns).toHaveTextContent('$60/month $0.40/hr');
-    expect(nodeRadioBtns).toHaveTextContent('$140.00/month $1.00/hr');
-
-    // 3 Node options are disabled for 1 GB plans
-    expect(nodeRadioBtns.querySelector('input[type=radio]')).toBeDisabled();
+    expect(nodeRadioBtns).toHaveTextContent('$60/month $0.4/hr');
+    expect(nodeRadioBtns).toHaveTextContent('$90/month $0.3/hr');
   });
 });

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -356,9 +356,12 @@ const DatabaseCreate: React.FC<{}> = () => {
         ?.price,
       multi: type.cluster_size.find((cluster) => cluster.quantity === 3)?.price,
     });
-    setFieldValue('cluster_size', 3);
+    setFieldValue(
+      'cluster_size',
+      values.cluster_size < 1 ? 3 : values.cluster_size
+    );
     setFieldValue('replication_type', 'semi_synch');
-  }, [dbtypes, setFieldValue, values.type]);
+  }, [dbtypes, setFieldValue, values.cluster_size, values.type]);
 
   if (regionsLoading || !regionsData || versionsLoading || typesLoading) {
     return <CircleProgress />;

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -21,7 +21,6 @@ import Chip from 'src/components/core/Chip';
 import Divider from 'src/components/core/Divider';
 import FormControl from 'src/components/core/FormControl';
 import FormControlLabel from 'src/components/core/FormControlLabel';
-import FormHelperText from 'src/components/core/FormHelperText';
 import Paper from 'src/components/core/Paper';
 import RadioGroup from 'src/components/core/RadioGroup';
 import { makeStyles, Theme } from 'src/components/core/styles';
@@ -467,12 +466,11 @@ const DatabaseCreate: React.FC<{}> = () => {
           <Typography variant="h2" style={{ marginBottom: 4 }}>
             Set Number of Nodes{' '}
           </Typography>
-          <Typography>
+          <Typography style={{ marginBottom: 8 }}>
             We recommend 3 nodes in a database cluster to avoid downtime during
             upgrades and maintenance.
           </Typography>
           <FormControl
-            error={Boolean(errors.cluster_size)}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
               setFieldValue('cluster_size', +e.target.value);
               setFieldValue(
@@ -482,7 +480,13 @@ const DatabaseCreate: React.FC<{}> = () => {
             }}
             data-testid="database-nodes"
           >
-            <RadioGroup style={{ marginBottom: 0 }} value={values.cluster_size}>
+            {errors.cluster_size ? (
+              <Notice error text={errors.cluster_size} />
+            ) : null}
+            <RadioGroup
+              style={{ marginTop: 0, marginBottom: 0 }}
+              value={values.cluster_size}
+            >
               {nodeOptions.map((nodeOption) => (
                 <FormControlLabel
                   key={nodeOption.value}
@@ -494,7 +498,6 @@ const DatabaseCreate: React.FC<{}> = () => {
                 />
               ))}
             </RadioGroup>
-            <FormHelperText>{errors.cluster_size}</FormHelperText>
           </FormControl>
         </Grid>
         <Divider spacingTop={26} spacingBottom={12} />

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -1,30 +1,32 @@
 import {
+  ClusterSize,
   CreateDatabasePayload,
   DatabaseType,
   DatabaseVersion,
   Engine,
-  FailoverCount,
   ReplicationType,
 } from '@linode/api-v4/lib/databases/types';
+import { APIError } from '@linode/api-v4/lib/types';
 import { createDatabaseSchema } from '@linode/validation/lib/databases.schema';
 import { useFormik } from 'formik';
 import { groupBy } from 'ramda';
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 import MySQLIcon from 'src/assets/icons/mysql.svg';
-import { makeStyles, Theme } from 'src/components/core/styles';
+import BreadCrumb from 'src/components/Breadcrumb';
+import Button from 'src/components/Button';
+import CircleProgress from 'src/components/CircleProgress';
+import Chip from 'src/components/core/Chip';
 import Divider from 'src/components/core/Divider';
 import FormControl from 'src/components/core/FormControl';
 import FormControlLabel from 'src/components/core/FormControlLabel';
 import FormHelperText from 'src/components/core/FormHelperText';
 import Paper from 'src/components/core/Paper';
 import RadioGroup from 'src/components/core/RadioGroup';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
-import BreadCrumb from 'src/components/Breadcrumb';
-import Button from 'src/components/Button';
-import CircleProgress from 'src/components/CircleProgress';
-import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import SingleValue from 'src/components/EnhancedSelect/components/SingleValue';
+import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import RegionSelect from 'src/components/EnhancedSelect/variants/RegionSelect';
 import RegionOption from 'src/components/EnhancedSelect/variants/RegionSelect/RegionOption';
 import ErrorState from 'src/components/ErrorState';
@@ -39,18 +41,16 @@ import { databaseEngineMap } from 'src/features/Databases/DatabaseLanding/Databa
 import SelectPlanPanel from 'src/features/linodes/LinodesCreate/SelectPlanPanel';
 import { typeLabelDetails } from 'src/features/linodes/presentation';
 import {
-  useDatabaseVersionsQuery,
-  useDatabaseTypesQuery,
   useCreateDatabaseMutation,
+  useDatabaseTypesQuery,
+  useDatabaseVersionsQuery,
 } from 'src/queries/databases';
 import { useRegionsQuery } from 'src/queries/regions';
 import { formatStorageUnits } from 'src/utilities/formatStorageUnits';
-import getSelectedOptionFromGroupedOptions from 'src/utilities/getSelectedOptionFromGroupedOptions';
 import { handleAPIErrors } from 'src/utilities/formikErrorUtils';
+import getSelectedOptionFromGroupedOptions from 'src/utilities/getSelectedOptionFromGroupedOptions';
 import { validateIPs } from 'src/utilities/ipUtils';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
-import Chip from 'src/components/core/Chip';
-import { APIError } from '@linode/api-v4/lib/types';
 
 const useStyles = makeStyles((theme: Theme) => ({
   formControlLabel: {
@@ -284,7 +284,7 @@ const DatabaseCreate: React.FC<{}> = () => {
       engine: '' as Engine,
       region: '',
       type: '',
-      failover_count: -1 as FailoverCount,
+      failover_count: -1 as ClusterSize,
       replication_type: 'none' as ReplicationType,
       allow_list: [
         {

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -2,6 +2,7 @@ import {
   ClusterSize,
   CreateDatabasePayload,
   DatabaseType,
+  DatabasePriceObject,
   DatabaseVersion,
   Engine,
   ReplicationType,
@@ -151,6 +152,11 @@ export interface ExtendedDatabaseType extends DatabaseType {
   subHeadings: [string, string];
 }
 
+interface NodePricing {
+  single: DatabasePriceObject | undefined;
+  multi: DatabasePriceObject | undefined;
+}
+
 const DatabaseCreate: React.FC<{}> = () => {
   const classes = useStyles();
   const history = useHistory();
@@ -175,7 +181,7 @@ const DatabaseCreate: React.FC<{}> = () => {
 
   const { mutateAsync: createDatabase } = useCreateDatabaseMutation();
 
-  const [type, setType] = React.useState<DatabaseType>();
+  const [nodePricing, setNodePricing] = React.useState<NodePricing>();
   const [createError, setCreateError] = React.useState<string>();
   const [ipErrorsFromAPI, setIPErrorsFromAPI] = React.useState<APIError[]>();
 
@@ -309,8 +315,8 @@ const DatabaseCreate: React.FC<{}> = () => {
           1 Node {` `}
           <br />
           <span style={{ fontSize: '12px' }}>
-            {`$${type?.cluster_size[0].price.monthly || 0}/month $${
-              type?.cluster_size[0].price.hourly || 0
+            {`$${nodePricing?.single?.monthly || 0}/month $${
+              nodePricing?.single?.hourly || 0
             }/hr`}
           </span>
         </Typography>
@@ -323,8 +329,8 @@ const DatabaseCreate: React.FC<{}> = () => {
           3 Nodes - High Availability (recommended)
           <br />
           <span style={{ fontSize: '12px' }}>
-            {`$${type?.cluster_size[2].price.monthly || 0}/month $${
-              type?.cluster_size[2].price.hourly || 0
+            {`$${nodePricing?.multi?.monthly || 0}/month $${
+              nodePricing?.multi?.hourly || 0
             }/hr`}
           </span>
         </Typography>
@@ -342,7 +348,11 @@ const DatabaseCreate: React.FC<{}> = () => {
       return;
     }
 
-    setType(type);
+    setNodePricing({
+      single: type.cluster_size.find((cluster) => cluster.quantity === 1)
+        ?.price,
+      multi: type.cluster_size.find((cluster) => cluster.quantity === 3)?.price,
+    });
     setFieldValue('cluster_size', 3);
     setFieldValue('replication_type', 'semi_synch');
   }, [dbtypes, setFieldValue, values.type]);

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -360,7 +360,10 @@ const DatabaseCreate: React.FC<{}> = () => {
       'cluster_size',
       values.cluster_size < 1 ? 3 : values.cluster_size
     );
-    setFieldValue('replication_type', 'semi_synch');
+    setFieldValue(
+      'replication_type',
+      values.cluster_size === 1 ? 'none' : 'semi_synch'
+    );
   }, [dbtypes, setFieldValue, values.cluster_size, values.type]);
 
   if (regionsLoading || !regionsData || versionsLoading || typesLoading) {

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -199,13 +199,16 @@ const DatabaseCreate: React.FC<{}> = () => {
     return dbtypes.map((type) => {
       const { label, memory, vcpus, disk, cluster_size } = type;
       const formattedLabel = formatStorageUnits(label);
+      const singleNodePricing = cluster_size.find(
+        (cluster) => cluster.quantity === 1
+      )?.price;
       return {
         ...type,
-        price: cluster_size[0].price,
+        price: singleNodePricing,
         label: formattedLabel,
         heading: formattedLabel,
         subHeadings: [
-          `$${cluster_size[0].price.monthly}/mo ($${cluster_size[0].price.hourly}/hr)`,
+          `$${singleNodePricing?.monthly}/mo ($${singleNodePricing?.hourly}/hr)`,
           typeLabelDetails(memory, disk, vcpus),
         ] as [string, string],
       };

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryClusterConfiguration.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryClusterConfiguration.tsx
@@ -53,9 +53,9 @@ export const DatabaseSummaryClusterConfiguration: React.FC<Props> = (props) => {
   }
 
   const configuration =
-    database.failover_count === 0
+    database.cluster_size === 1
       ? 'Primary'
-      : `Primary +${database.failover_count} replicas`;
+      : `Primary +${database.cluster_size - 1} replicas`;
 
   return (
     <>

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseRow.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseRow.tsx
@@ -61,15 +61,15 @@ export const DatabaseRow: React.FC<Props> = ({ database }) => {
     status,
     region,
     version,
-    failover_count,
+    cluster_size,
   } = database;
 
   const configuration =
-    failover_count === 0 ? (
+    cluster_size === 1 ? (
       'Primary'
     ) : (
       <>
-        {`Primary +${failover_count}`}
+        {`Primary +${cluster_size - 1}`}
         <Chip
           className={`${chipClasses.chip} ${chipClasses.nvmeChip}`}
           label="HA"

--- a/packages/validation/src/databases.schema.ts
+++ b/packages/validation/src/databases.schema.ts
@@ -11,8 +11,8 @@ export const createDatabaseSchema = object({
   engine: string().required('Database Engine is required'),
   region: string().required('Region is required'),
   type: string().required('Type is required'),
-  failover_count: number()
-    .oneOf([0, 2], 'Nodes are required')
+  cluster_size: number()
+    .oneOf([1, 3], 'Nodes are required')
     .required('Nodes are required'),
   replication_type: string()
     .oneOf(['none', 'semi_synch', 'asynch'])


### PR DESCRIPTION
## Description
The API has revised the shapes of some data points:

1. The database types will no longer have `addons` or `price` properties; they are being replaced by `cluster_size` which is an array here consisting of a `quantity` property and a `price` property.
2. `failover_count` is being replaced by `cluster_size` (different from the above), which is a number (either 1 or 3) here. 

## To-Do:
- [x] Update the logic in the Create flow to reflect these changes

## How to test
`yarn test DatabaseCreate`

- Test things mentioned in the description
- The database create page should no longer crash
- All the pricing comes from the API now, check that the prices displayed match the API and check the POST request
    - 3 Node option for Nanodes are no longer disabled