### PR TITLE
M3-5674: Fix 'X' misalignment when MultipleIPInput has a field error

### DIFF
--- a/packages/manager/src/components/MultipleIPInput/MultipleIPInput.tsx
+++ b/packages/manager/src/components/MultipleIPInput/MultipleIPInput.tsx
@@ -30,9 +30,10 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginTop: theme.spacing(),
   },
   button: {
+    marginTop: 4,
+    marginLeft: -theme.spacing(),
     minWidth: 'auto',
     minHeight: 'auto',
-    marginLeft: -theme.spacing(),
     padding: 0,
     '& > span': {
       padding: 2,
@@ -158,7 +159,6 @@ export const MultipleIPInput: React.FC<Props> = (props) => {
           container
           key={`domain-transfer-ip-${idx}`}
           direction="row"
-          alignItems="center"
           justifyContent="center"
           data-testid="domain-transfer-input"
         >


### PR DESCRIPTION
## Description

**Before**
<img width="439" alt="Screen Shot 2022-01-31 at 12 02 56 PM" src="https://user-images.githubusercontent.com/7692354/151838934-0f9b9fc7-0562-4383-ab83-4f83f5b82d85.png">

**After**
<img width="435" alt="Screen Shot 2022-01-31 at 12 02 28 PM" src="https://user-images.githubusercontent.com/7692354/151838861-49f37127-88ea-4876-a490-5a5532be02c2.png">

## How to test

- Go to any component that uses `MultipleIPInput` (ie. Firewall Add Rule drawer or the "Add Access Controls" at the bottom of the Create Database flow)
- Click "Add an IP"
- Click the associate action button
- An error should show up below the input field and the 'X' should not be misaligned
