### PR TITLE
Display country in the Billing Contact panel

### DIFF
--- a/packages/manager/src/features/Billing/BillingDetail.test.tsx
+++ b/packages/manager/src/features/Billing/BillingDetail.test.tsx
@@ -1,4 +1,3 @@
-import { waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { paymentMethodFactory } from 'src/factories';
 import { invoiceFactory, paymentFactory } from 'src/factories/billing';
@@ -32,7 +31,7 @@ jest.mock('@linode/api-v4/lib/account', () => {
 
 describe('Account Landing', () => {
   it('should render', async () => {
-    const { getByTestId } = renderWithTheme(
+    const { findByTestId } = renderWithTheme(
       <BillingDetail
         history={history}
         location={mockLocation}
@@ -41,7 +40,7 @@ describe('Account Landing', () => {
         clearDocs={jest.fn()}
       />
     );
-    await waitFor(() => getByTestId('billing-detail'));
+    await findByTestId('billing-detail');
     // Todo: add some get-by-texts once the correct text is available
   });
 });

--- a/packages/manager/src/features/Billing/BillingDetail.tsx
+++ b/packages/manager/src/features/Billing/BillingDetail.tsx
@@ -82,13 +82,14 @@ export const BillingDetail: React.FC<CombinedProps> = (props) => {
                 lastName={account.last_name}
                 address1={account.address_1}
                 address2={account.address_2}
-                email={account.email}
-                phone={account.phone}
                 city={account.city}
                 state={account.state}
                 zip={account.zip}
-                history={props.history}
+                country={account.country}
+                email={account.email}
+                phone={account.phone}
                 taxId={account.tax_id}
+                history={props.history}
               />
               <PaymentInformation
                 loading={paymentMethodsLoading}

--- a/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/ContactInformation.tsx
@@ -200,7 +200,9 @@ const ContactInformation: React.FC<CombinedProps> = (props) => {
                 {city}
                 {city && state && ','} {state} {zip}
               </Typography>
-              <Typography className={classes.section}>{countryName}</Typography>
+              <Typography className={classes.section}>
+                {countryName?.countryName}
+              </Typography>
             </Grid>
           )}
 

--- a/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/ContactInformation.tsx
@@ -14,7 +14,6 @@ import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 import styled from 'src/containers/SummaryPanels.styles';
 import BillingContactDrawer from './EditBillingContactDrawer';
-import { Country } from './UpdateContactInformationForm/types';
 
 const useStyles = makeStyles((theme: Theme) => ({
   ...styled(theme),
@@ -130,13 +129,10 @@ const ContactInformation: React.FC<CombinedProps> = (props) => {
     }
   }, [editContactDrawerOpen, history.location.state]);
 
-  const countryName = countryData.map((_country: Country) => {
-    if (country === _country.countryShortCode) {
-      return _country.countryName;
-    }
-
-    return null;
-  });
+  // Finding the country from the countryData JSON
+  const countryName = countryData?.find(
+    (_country) => _country.countryShortCode === country ?? null
+  );
 
   return (
     <Grid item xs={12} md={6}>

--- a/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/ContactInformation.tsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames';
+import countryData from 'country-region-data';
 import * as React from 'react';
 import {
   RouteComponentProps,
@@ -13,11 +14,15 @@ import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 import styled from 'src/containers/SummaryPanels.styles';
 import BillingContactDrawer from './EditBillingContactDrawer';
+import { Country } from './UpdateContactInformationForm/types';
 
 const useStyles = makeStyles((theme: Theme) => ({
   ...styled(theme),
   wordWrap: {
     wordBreak: 'break-all',
+  },
+  bold: {
+    fontFamily: theme.font.bold,
   },
   switchWrapper: {
     flex: 1,
@@ -32,13 +37,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   switchWrapperFlex: {
     display: 'flex',
     flexDirection: 'column',
-    alignContent: 'flex-start',
-    '& > div:nth-last-child(2)': {
-      flexGrow: 1,
-    },
-    '& > div:last-child': {
-      alignSelf: 'end',
-    },
   },
   edit: {
     color: theme.cmrTextColors.linkActiveLight,
@@ -58,13 +56,14 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 interface Props extends Pick<RouteComponentProps, 'history'> {
   company: string;
-  lastName: string;
   firstName: string;
-  zip: string;
-  state: string;
-  city: string;
-  address2: string;
+  lastName: string;
   address1: string;
+  address2: string;
+  city: string;
+  state: string;
+  zip: string;
+  country: string;
   email: string;
   phone: string;
   taxId: string;
@@ -74,14 +73,15 @@ type CombinedProps = Props;
 
 const ContactInformation: React.FC<CombinedProps> = (props) => {
   const {
-    city,
-    state,
+    company,
     firstName,
     lastName,
-    zip,
-    company,
     address1,
     address2,
+    city,
+    state,
+    zip,
+    country,
     email,
     phone,
     taxId,
@@ -130,6 +130,14 @@ const ContactInformation: React.FC<CombinedProps> = (props) => {
     }
   }, [editContactDrawerOpen, history.location.state]);
 
+  const countryName = countryData.map((_country: Country) => {
+    if (country === _country.countryShortCode) {
+      return _country.countryName;
+    }
+
+    return null;
+  });
+
   return (
     <Grid item xs={12} md={6}>
       <Paper className={classes.summarySection} data-qa-contact-summary>
@@ -160,43 +168,43 @@ const ContactInformation: React.FC<CombinedProps> = (props) => {
             address2 ||
             city ||
             state ||
-            zip) && (
+            zip ||
+            country) && (
             <Grid item className={classes.switchWrapper}>
               {(firstName || lastName) && (
-                <div className={classes.section} data-qa-contact-name>
-                  <div
-                    className={classes.wordWrap}
-                  >{`${firstName} ${lastName}`}</div>
-                </div>
+                <Typography
+                  className={`${classes.section} ${classes.wordWrap}`}
+                  data-qa-contact-name
+                >
+                  {firstName} {lastName}
+                </Typography>
               )}
-
               {company && (
-                <div className={classes.section} data-qa-company>
-                  <div className={classes.wordWrap}>{company}</div>
-                </div>
+                <Typography
+                  className={`${classes.section} ${classes.wordWrap}`}
+                  data-qa-company
+                >
+                  {company}
+                </Typography>
               )}
-
-              {(address1 || address2 || city || state || zip) && (
-                <div>
-                  <div className={classes.section} data-qa-contact-address>
-                    <div>
-                      <span>{address1}</span>
-                    </div>
-                  </div>
-
-                  <div className={classes.section}>
-                    <div>
-                      <div>{address2}</div>
-                    </div>
-                  </div>
-                </div>
+              {(address1 || address2 || city || state || zip || country) && (
+                <>
+                  <Typography
+                    className={classes.section}
+                    data-qa-contact-address
+                  >
+                    {address1}
+                  </Typography>
+                  <Typography className={classes.section}>
+                    {address2}
+                  </Typography>
+                </>
               )}
-
-              <div className={classes.section}>
-                <div>
-                  <div>{`${city}${city && state && ','} ${state} ${zip}`}</div>
-                </div>
-              </div>
+              <Typography className={classes.section}>
+                {city}
+                {city && state && ','} {state} {zip}
+              </Typography>
+              <Typography className={classes.section}>{countryName}</Typography>
             </Grid>
           )}
 
@@ -208,18 +216,24 @@ const ContactInformation: React.FC<CombinedProps> = (props) => {
                 taxId !== undefined && taxId !== null && taxId !== '',
             })}
           >
-            <div className={classes.section} data-qa-contact-email>
-              <div className={classes.wordWrap}>{email}</div>
-            </div>
-
+            <Typography
+              className={`${classes.section} ${classes.wordWrap}`}
+              data-qa-contact-email
+            >
+              {email}
+            </Typography>
             {phone && (
-              <div className={classes.section} data-qa-contact-phone>
+              <Typography className={classes.section} data-qa-contact-phone>
                 {phone}
-              </div>
+              </Typography>
             )}
-
             {taxId && (
-              <div className={classes.section}>{'Tax ID ' + taxId}</div>
+              <Typography
+                className={classes.section}
+                style={{ marginTop: 'auto' }}
+              >
+                <span className={classes.bold}>Tax ID</span> {taxId}
+              </Typography>
             )}
           </Grid>
         </Grid>

--- a/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/ContactInformation.tsx
@@ -131,8 +131,8 @@ const ContactInformation: React.FC<CombinedProps> = (props) => {
 
   // Finding the country from the countryData JSON
   const countryName = countryData?.find(
-    (_country) => _country.countryShortCode === country ?? null
-  );
+    (_country) => _country.countryShortCode === country
+  )?.countryName;
 
   return (
     <Grid item xs={12} md={6}>
@@ -200,9 +200,7 @@ const ContactInformation: React.FC<CombinedProps> = (props) => {
                 {city}
                 {city && state && ','} {state} {zip}
               </Typography>
-              <Typography className={classes.section}>
-                {countryName?.countryName}
-              </Typography>
+              <Typography className={classes.section}>{countryName}</Typography>
             </Grid>
           )}
 

--- a/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/ContactInformation.tsx
@@ -20,9 +20,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   wordWrap: {
     wordBreak: 'break-all',
   },
-  bold: {
-    fontFamily: theme.font.bold,
-  },
   switchWrapper: {
     flex: 1,
     maxWidth: '100%',
@@ -228,7 +225,7 @@ const ContactInformation: React.FC<CombinedProps> = (props) => {
                 className={classes.section}
                 style={{ marginTop: 'auto' }}
               >
-                <span className={classes.bold}>Tax ID</span> {taxId}
+                <strong>Tax ID</strong> {taxId}
               </Typography>
             )}
           </Grid>


### PR DESCRIPTION
## Description

Add the users's country to the panel and fix the alignment for Tax ID (M3-5640).

**Before**
<img width="641" alt="Screen Shot 2022-01-31 at 5 20 36 PM" src="https://user-images.githubusercontent.com/7692354/151882693-15d711c9-5948-412b-86a8-cdf62acf2b82.png">

**After**
<img width="627" alt="Screen Shot 2022-01-31 at 5 20 15 PM" src="https://user-images.githubusercontent.com/7692354/151882646-44f22471-9918-410d-a247-1b3f4a054195.png">

## How to test

Go to `/account/billing`
