### PR TITLE
Update SSLFields type and Download CA Certficate button

### DIFF
--- a/packages/api-v4/src/databases/types.ts
+++ b/packages/api-v4/src/databases/types.ts
@@ -57,8 +57,7 @@ interface DatabaseHosts {
 }
 
 export interface SSLFields {
-  public_key: string;
-  certificate: string;
+  ca_certificate: string;
 }
 
 // DatabaseInstance is the interface for the shape of data returned by the /databases/instances endpoint.

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
@@ -124,11 +124,8 @@ export const DatabaseSummaryConnectionDetails: React.FC<Props> = (props) => {
       .then((response: SSLFields) => {
         // Convert to utf-8 from base64
         try {
-          const decodedFile = window.atob(response.certificate);
-          downloadFile(
-            `${response.public_key}-ca-certificate.crt`,
-            decodedFile
-          );
+          const decodedFile = window.atob(response.ca_certificate);
+          downloadFile(`${database.label}-ca-certificate.crt`, decodedFile);
         } catch (e) {
           enqueueSnackbar('Error parsing your CA Certificate file', {
             variant: 'error',


### PR DESCRIPTION
## Description
The `GET /databases/mysql/instances/{id}/ssl` endpoint now just returns `ca_certificate`

## How to test
Go to the summary tab of a database cluster and try to download the CA certificate, you should no longer see an error toast
