### PR TITLE
Observe account.capabilities to enable DBaaS

### DIFF
--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -39,7 +39,8 @@ export type AccountCapability =
   | 'Cloud Firewall'
   | 'Vlans'
   | 'Machine Images'
-  | 'LKE HA Control Planes';
+  | 'LKE HA Control Planes'
+  | 'Managed Databases';
 
 export interface AccountSettings {
   managed: boolean;

--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -196,6 +196,12 @@ const MainContent: React.FC<CombinedProps> = (props) => {
     account?.capabilities ?? []
   );
 
+  const showDatabases = isFeatureEnabled(
+    'Managed Databases',
+    Boolean(flags.databases),
+    account?.capabilities ?? []
+  );
+
   const defaultRoot = _isManagedAccount ? '/managed' : '/linodes';
 
   const shouldDisplayMainContentBanner =
@@ -358,7 +364,7 @@ const MainContent: React.FC<CombinedProps> = (props) => {
                             {showFirewalls && (
                               <Route path="/firewalls" component={Firewalls} />
                             )}
-                            {flags.databases ? (
+                            {showDatabases ? (
                               <Route path="/databases" component={Databases} />
                             ) : null}
                             <Redirect exact from="/" to={defaultRoot} />

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -96,8 +96,11 @@ export const PrimaryNav: React.FC<Props> = (props) => {
     account?.capabilities ?? []
   );
 
-  // No account capability returned yet.
-  const showDatabases = flags.databases;
+  const showDatabases = isFeatureEnabled(
+    'Managed Databases',
+    Boolean(flags.databases),
+    account?.capabilities ?? []
+  );
 
   const clustersLoadedOrLoadingOrHasError =
     objectStorageClusters.lastUpdated > 0 ||

--- a/packages/manager/src/features/Databases/DatabaseDetail/index.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/index.tsx
@@ -6,7 +6,6 @@ import Tabs from 'src/components/core/ReachTabs';
 import ErrorState from 'src/components/ErrorState';
 import SafeTabPanel from 'src/components/SafeTabPanel';
 import TabLinkList from 'src/components/TabLinkList';
-import useFlags from 'src/hooks/useFlags';
 import { matchPath, useHistory, useParams } from 'react-router-dom';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { useDatabaseQuery, useDatabaseTypesQuery } from 'src/queries/databases';
@@ -18,7 +17,6 @@ const DatabaseBackups = React.lazy(() => import('./DatabaseBackups'));
 const DatabaseSettings = React.lazy(() => import('./DatabaseSettings'));
 
 export const DatabaseDetail: React.FC = () => {
-  const flags = useFlags();
   const history = useHistory();
 
   const { databaseId, engine } = useParams<{
@@ -45,7 +43,7 @@ export const DatabaseDetail: React.FC = () => {
     return <CircleProgress />;
   }
 
-  if (!database || !flags.databases) {
+  if (!database) {
     return null;
   }
 

--- a/packages/manager/src/features/Databases/index.tsx
+++ b/packages/manager/src/features/Databases/index.tsx
@@ -2,7 +2,9 @@ import * as React from 'react';
 import { Route, Switch } from 'react-router-dom';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import SuspenseLoader from 'src/components/SuspenseLoader';
+import useAccountManagement from 'src/hooks/useAccountManagement';
 import useFlags from 'src/hooks/useFlags';
+import { isFeatureEnabled } from 'src/utilities/accountCapabilities';
 
 const DatabaseLanding = React.lazy(() => import('./DatabaseLanding'));
 const DatabaseDetail = React.lazy(() => import('./DatabaseDetail'));
@@ -10,8 +12,16 @@ const DatabaseCreate = React.lazy(() => import('./DatabaseCreate'));
 
 const Database: React.FC = () => {
   // @TODO: Remove when Database goes to GA
+  const { account } = useAccountManagement();
   const flags = useFlags();
-  if (!flags.databases) {
+
+  const showDatabases = isFeatureEnabled(
+    'Managed Databases',
+    Boolean(flags.databases),
+    account?.capabilities ?? []
+  );
+
+  if (!showDatabases) {
     return null;
   }
 

--- a/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -157,6 +157,12 @@ class AddNewMenu extends React.Component<CombinedProps> {
       account?.capabilities ?? []
     );
 
+    const showDatabases = isFeatureEnabled(
+      'Managed Databases',
+      Boolean(flags.databases),
+      account?.capabilities ?? []
+    );
+
     return (
       <dbaasContext.Consumer>
         {(dbaas) => (
@@ -193,7 +199,7 @@ class AddNewMenu extends React.Component<CombinedProps> {
                       ItemIcon={VolumeIcon}
                     />
                   </MenuLink>
-                  {flags.databases ? (
+                  {showDatabases ? (
                     <MenuLink
                       as={Link}
                       to="/databases/create"


### PR DESCRIPTION
## Description

**What does this PR do?**
This PR changes the `flags.databases` checks to make use of the `isFeatureEnabled` function, taking into account the user's capabilities. **When we go to beta the LD flag should be off.** (Otherwise DBaaS would be shown to everyone, not just beta participants).

## How to test

**What are the steps to reproduce the issue or verify the changes?**
To test, check all combos and make sure that DBaaS works (or doesn't work) correctly:

- LD flag on, account capability off **(DBaaS should work)**
- LD flag on, account capability on **(DBaaS should work)**
- LD flag off, account capability off **(DBaaS should NOT work)**
- LD flag off, account capability on **(DBaaS should work – this is the situation for beta)**



**How do I run relevant unit tests?**
