### PR TITLE
M3-5701: Disable show button if database cluster is provisioning

### DIFF
--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
@@ -144,8 +144,13 @@ export const DatabaseSummaryConnectionDetails: React.FC<Props> = (props) => {
   };
 
   const ssl = database.ssl_connection ? 'ENABLED' : 'DISABLED';
-  const disableShowBtn = database.status === 'provisioning';
+  const disableShowBtn = ['provisioning', 'failed'].includes(database.status);
+  const disableToolTipText =
+    database.status === 'provisioning'
+      ? 'Your Database Cluster is currently provisioning.'
+      : 'You cannot view your root password when your Database Cluster has failed.';
   // const connectionDetailsCopy = `username = ${credentials?.username}\npassword = ${credentials?.password}\nhost = ${database.host}\nport = ${database.port}\ssl = ${ssl}`;
+
   const credentialsBtn = (handleClick: () => void, btnText: string) => {
     return (
       <Button
@@ -189,10 +194,7 @@ export const DatabaseSummaryConnectionDetails: React.FC<Props> = (props) => {
             )
           )}
           {disableShowBtn ? (
-            <HelpIcon
-              className={classes.helpIcon}
-              text={'Your database cluster is currently provisioning.'}
-            />
+            <HelpIcon className={classes.helpIcon} text={disableToolTipText} />
           ) : null}
         </Box>
         <Typography>

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
@@ -148,7 +148,7 @@ export const DatabaseSummaryConnectionDetails: React.FC<Props> = (props) => {
   const disableToolTipText =
     database.status === 'provisioning'
       ? 'Your Database Cluster is currently provisioning.'
-      : 'You cannot view your root password when your Database Cluster has failed.';
+      : 'Your root password is unavailable when your Database Cluster has failed.';
   // const connectionDetailsCopy = `username = ${credentials?.username}\npassword = ${credentials?.password}\nhost = ${database.host}\nport = ${database.port}\ssl = ${ssl}`;
 
   const credentialsBtn = (handleClick: () => void, btnText: string) => {

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
@@ -14,6 +14,7 @@ import { downloadFile } from 'src/utilities/downloadFile';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import Box from 'src/components/core/Box';
 import HelpIcon from 'src/components/HelpIcon';
+import Button from 'src/components/Button';
 
 const useStyles = makeStyles((theme: Theme) => ({
   header: {
@@ -62,8 +63,11 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   showBtn: {
     color: theme.color.blue,
-    cursor: 'pointer',
     marginLeft: theme.spacing(2),
+    fontSize: '0.875rem',
+    minHeight: 'auto',
+    minWidth: 'auto',
+    padding: 0,
   },
   progressCtn: {
     marginLeft: 22,
@@ -72,9 +76,6 @@ const useStyles = makeStyles((theme: Theme) => ({
       stroke: theme.color.blue,
     },
     alignSelf: 'flex-end',
-  },
-  credentialsCtn: {
-    display: 'flex',
   },
   error: {
     color: theme.color.red,
@@ -107,7 +108,7 @@ export const DatabaseSummaryConnectionDetails: React.FC<Props> = (props) => {
   } = useDatabaseCredentialsQuery(database.engine, database.id);
 
   const password =
-    showCredentials && credentials ? credentials?.password : '••••••••';
+    showCredentials && credentials ? credentials?.password : '••••••••••';
 
   const handleShowPasswordClick = () => {
     setShowPassword((showCredentials) => !showCredentials);
@@ -143,22 +144,17 @@ export const DatabaseSummaryConnectionDetails: React.FC<Props> = (props) => {
   };
 
   const ssl = database.ssl_connection ? 'ENABLED' : 'DISABLED';
+  const disableShowBtn = database.status === 'provisioning';
   // const connectionDetailsCopy = `username = ${credentials?.username}\npassword = ${credentials?.password}\nhost = ${database.host}\nport = ${database.port}\ssl = ${ssl}`;
   const credentialsBtn = (handleClick: () => void, btnText: string) => {
     return (
-      <span
+      <Button
         onClick={handleClick}
         className={classes.showBtn}
-        role="button"
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') {
-            handleClick();
-          }
-        }}
-        tabIndex={0}
+        disabled={disableShowBtn}
       >
         {btnText}
-      </span>
+      </Button>
     );
   };
 
@@ -168,37 +164,37 @@ export const DatabaseSummaryConnectionDetails: React.FC<Props> = (props) => {
         Connection Details
       </Typography>
       <Grid className={classes.connectionDetailsCtn}>
-        <div className={classes.credentialsCtn}>
-          <div>
-            <Typography>
-              <span>username</span> = {DB_ROOT_USERNAME}
-            </Typography>
-            <Typography>
-              <span>password</span> = {password}
-            </Typography>
-          </div>
+        <Typography>
+          <span>username</span> = {DB_ROOT_USERNAME}
+        </Typography>
+        <Box display="flex">
+          <Typography>
+            <span>password</span> = {password}
+          </Typography>
           {credentialsLoading ? (
             <div className={classes.progressCtn}>
               <CircleProgress mini tag />
             </div>
+          ) : credentialsError ? (
+            <>
+              <span className={classes.error}>
+                Error retrieving credentials.
+              </span>
+              {credentialsBtn(() => getDatabaseCredentials(), 'Retry')}
+            </>
           ) : (
-            <Typography style={{ alignSelf: 'flex-end' }}>
-              {credentialsError ? (
-                <>
-                  <span className={classes.error}>
-                    Error retrieving credentials.
-                  </span>
-                  {credentialsBtn(() => getDatabaseCredentials(), 'Retry')}
-                </>
-              ) : (
-                credentialsBtn(
-                  handleShowPasswordClick,
-                  showCredentials && credentials ? 'Hide' : 'Show'
-                )
-              )}
-            </Typography>
+            credentialsBtn(
+              handleShowPasswordClick,
+              showCredentials && credentials ? 'Hide' : 'Show'
+            )
           )}
-        </div>
+          {disableShowBtn ? (
+            <HelpIcon
+              className={classes.helpIcon}
+              text={'Your database cluster is currently provisioning.'}
+            />
+          ) : null}
+        </Box>
         <Typography>
           <span>host</span> = {database.hosts?.primary}
         </Typography>

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -165,6 +165,7 @@ const databases = [
       label: `database-${req.params.id}`,
       engine: req.params.engine,
       ssl_connection: true,
+      status: 'provisioning',
     });
     return res(ctx.json(database));
   }),

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -165,7 +165,6 @@ const databases = [
       label: `database-${req.params.id}`,
       engine: req.params.engine,
       ssl_connection: true,
-      status: 'provisioning',
     });
     return res(ctx.json(database));
   }),


### PR DESCRIPTION
## Description
Disables the show button in a database cluster's connection details if the database is still provisioning since it will just result in an error

## How to test
Go to the summary tab of a database cluster. To see the disabled button state, turn on the MSW