### PR TITLE
Un-exclude certain regions for US in the billing region dropdown

### DIFF
--- a/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
@@ -85,14 +85,7 @@ const L = {
   },
 };
 
-const excludedUSRegions = [
-  'Micronesia',
-  'Marshall Islands',
-  'Palau',
-  'Armed Forces Americas',
-  'Armed Forces Europe, Canada, Africa and Middle East',
-  'Armed Forces Pacific',
-];
+const excludedUSRegions = ['Micronesia', 'Marshall Islands', 'Palau'];
 
 class UpdateContactInformationForm extends React.Component<
   CombinedProps,


### PR DESCRIPTION
## Description

Got an update to include the Armed Forces regions (which was previously hidden).

## How to test

- Go to `/account/billing/edit` and make sure that the country is set to "United States"
- If you click on the "State" dropdown, the Armed Forces regions should now show up at the very end of the list
