### PR TITLE
Add copy tooltip to password and hosts in Database Connection Details

### DIFF
--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
@@ -6,7 +6,7 @@ import DownloadIcon from 'src/assets/icons/lke-download.svg';
 import CircleProgress from 'src/components/CircleProgress';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
-// import CopyTooltip from 'src/components/CopyTooltip';
+import CopyTooltip from 'src/components/CopyTooltip';
 import Grid from 'src/components/Grid';
 import { DB_ROOT_USERNAME } from 'src/constants';
 import { useDatabaseCredentialsQuery } from 'src/queries/databases';
@@ -27,6 +27,14 @@ const useStyles = makeStyles((theme: Theme) => ({
       width: `16px !important`,
     },
     marginRight: 12,
+  },
+  inlineCopyToolTip: {
+    '& svg': {
+      height: `16px`,
+      width: `16px`,
+    },
+    padding: `0 0 0 4px`,
+    marginLeft: 4,
   },
   actionBtnsCtn: {
     display: 'flex',
@@ -63,7 +71,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   showBtn: {
     color: theme.color.blue,
-    marginLeft: theme.spacing(2),
+    marginLeft: theme.spacing(),
     fontSize: '0.875rem',
     minHeight: 'auto',
     minWidth: 'auto',
@@ -196,15 +204,33 @@ export const DatabaseSummaryConnectionDetails: React.FC<Props> = (props) => {
           {disableShowBtn ? (
             <HelpIcon className={classes.helpIcon} text={disableToolTipText} />
           ) : null}
+          {showCredentials && credentials ? (
+            <CopyTooltip
+              className={classes.inlineCopyToolTip}
+              text={password}
+            />
+          ) : null}
         </Box>
-        <Typography>
-          <span>host</span> = {database.hosts?.primary}
-        </Typography>
+        <Box display="flex">
+          <Typography>
+            <span>host</span> = {database.hosts?.primary}
+          </Typography>
+          {database.hosts?.primary ? (
+            <CopyTooltip
+              className={classes.inlineCopyToolTip}
+              text={database.hosts?.primary}
+            />
+          ) : null}
+        </Box>
         {database.hosts.secondary ? (
           <Box display="flex" flexDirection="row" alignItems="center">
             <Typography>
               <span>private network host</span> = {database.hosts.secondary}
             </Typography>
+            <CopyTooltip
+              className={classes.inlineCopyToolTip}
+              text={database.hosts.secondary}
+            />
             <HelpIcon className={classes.helpIcon} text={privateHostCopy} />
           </Box>
         ) : null}


### PR DESCRIPTION
## Description
Adds a copy tooltip to the password (after user clicks show), host, and private host fields

## How to test
Check the summary page of a Database Cluster
