### PR TITLE
DBaaS UI fixes

### DIFF
--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -1,8 +1,8 @@
 import {
   ClusterSize,
   CreateDatabasePayload,
-  DatabaseType,
   DatabasePriceObject,
+  DatabaseType,
   DatabaseVersion,
   Engine,
   ReplicationType,
@@ -48,10 +48,13 @@ import {
 import { useRegionsQuery } from 'src/queries/regions';
 import { formatStorageUnits } from 'src/utilities/formatStorageUnits';
 import { handleAPIErrors } from 'src/utilities/formikErrorUtils';
-import { validateIPs, ExtendedIP } from 'src/utilities/ipUtils';
-import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
-import { ipFieldPlaceholder } from 'src/utilities/ipUtils';
 import getSelectedOptionFromGroupedOptions from 'src/utilities/getSelectedOptionFromGroupedOptions';
+import {
+  ExtendedIP,
+  ipFieldPlaceholder,
+  validateIPs,
+} from 'src/utilities/ipUtils';
+import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 
 const useStyles = makeStyles((theme: Theme) => ({
   formControlLabel: {
@@ -494,7 +497,7 @@ const DatabaseCreate: React.FC<{}> = () => {
             Set Number of Nodes{' '}
           </Typography>
           <Typography style={{ marginBottom: 8 }}>
-            We recommend 3 nodes in a database cluster to avoid downtime during
+            We recommend 3 nodes in a Database Cluster to avoid downtime during
             upgrades and maintenance.
           </Typography>
           <FormControl
@@ -529,7 +532,7 @@ const DatabaseCreate: React.FC<{}> = () => {
           <Grid item xs={12} md={8}>
             <Notice success className={classes.notice}>
               <strong>
-                Notice: There is no charge for database clusters during beta.
+                Notice: There is no charge for Database Clusters during beta.
               </strong>{' '}
               You will be notified before the beta period ends and database
               clusters are subject to charges.{' '}

--- a/packages/manager/src/features/Databases/DatabaseDetail/AccessControls.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/AccessControls.tsx
@@ -53,11 +53,13 @@ const useStyles = makeStyles((theme: Theme) => ({
   table: {
     width: '50%',
     border: `solid 1px ${theme.cmrBorderColors.borderTable}`,
-    '&:last-child': {
-      borderBottom: 'none',
-    },
     [theme.breakpoints.down('xs')]: {
       width: '100%',
+    },
+  },
+  row: {
+    '&:last-of-type td': {
+      borderBottom: 'none',
     },
   },
   cell: {
@@ -151,7 +153,7 @@ export const AccessControls: React.FC<Props> = (props) => {
       <Table className={classes.table}>
         <TableBody>
           {accessControlsList.map((accessControl) => (
-            <TableRow key={`${accessControl}-row`}>
+            <TableRow key={`${accessControl}-row`} className={classes.row}>
               <TableCell
                 key={`${accessControl}-tablecell`}
                 className={classes.cell}
@@ -220,7 +222,7 @@ export const AccessControls: React.FC<Props> = (props) => {
         {error ? <Notice error text={error} /> : null}
         <Typography data-testid="ip-removal-confirmation-warning">
           IP {accessControlToBeRemoved} will lose all access to the data on this
-          database cluster. This action cannot be undone, but you can re-enable
+          Database Cluster. This action cannot be undone, but you can re-enable
           access by clicking Manage Access Controls and adding the same IP
           address.
         </Typography>

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/RestoreFromBackupDialog.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/RestoreFromBackupDialog.tsx
@@ -1,4 +1,7 @@
+import { Database, DatabaseBackup } from '@linode/api-v4/lib/databases';
+import { useSnackbar } from 'notistack';
 import * as React from 'react';
+import { useHistory } from 'react-router-dom';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
@@ -6,12 +9,9 @@ import Typography from 'src/components/core/Typography';
 import { DialogProps } from 'src/components/Dialog';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
-import { Database, DatabaseBackup } from '@linode/api-v4/lib/databases';
-import formatDate from 'src/utilities/formatDate';
 import { useRestoreFromBackupMutation } from 'src/queries/databases';
-import { useSnackbar } from 'notistack';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
-import { useHistory } from 'react-router-dom';
+import formatDate from 'src/utilities/formatDate';
 
 interface Props extends Omit<DialogProps, 'title'> {
   open: boolean;
@@ -88,7 +88,7 @@ export const RestoreFromBackupDialog: React.FC<Props> = (props) => {
         text="Restoring from a backup will erase all existing data on this cluster."
       />
       <Typography>
-        To confirm restoration, type the name of the database cluster (
+        To confirm restoration, type the name of the Database Cluster (
         <strong>{database.label}</strong>) in the field below.
       </Typography>
       <TextField

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettings.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettings.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react';
-import Paper from 'src/components/core/Paper';
-import Divider from 'src/components/core/Divider';
 import { Database } from '@linode/api-v4/lib/databases/types';
-import DatabaseSettingsMenuItem from './DatabaseSettingsMenuItem';
-import DatabaseSettingsDeleteClusterDialog from './DatabaseSettingsDeleteClusterDialog';
-import DatabaseSettingsResetPasswordDialog from './DatabaseSettingsResetPasswordDialog';
-import AccessControls from '../AccessControls';
+import * as React from 'react';
+import Divider from 'src/components/core/Divider';
+import Paper from 'src/components/core/Paper';
 import { useProfile } from 'src/queries/profile';
+import AccessControls from '../AccessControls';
+import DatabaseSettingsDeleteClusterDialog from './DatabaseSettingsDeleteClusterDialog';
+import DatabaseSettingsMenuItem from './DatabaseSettingsMenuItem';
+import DatabaseSettingsResetPasswordDialog from './DatabaseSettingsResetPasswordDialog';
 
 interface Props {
   database: Database;
@@ -17,10 +17,10 @@ export const DatabaseSettings: React.FC<Props> = (props) => {
   const { data: profile } = useProfile();
 
   const resetRootPasswordCopy =
-    'Resetting your root password will automatically generate a new password. You can view the updated password on your Database Cluster Summary page. ';
+    'Resetting your root password will automatically generate a new password. You can view the updated password on your Database Cluster summary page. ';
 
   const deleteClusterCopy =
-    'Deleting a database cluster is permanent and cannot be undone.';
+    'Deleting a Database Cluster is permanent and cannot be undone.';
 
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = React.useState(false);
   const [

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsDeleteClusterDialog.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsDeleteClusterDialog.tsx
@@ -1,15 +1,15 @@
-import * as React from 'react';
-import ConfirmationDialog from 'src/components/ConfirmationDialog';
 import { Engine } from '@linode/api-v4/lib/databases';
-import { useDeleteDatabaseMutation } from 'src/queries/databases';
-import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { useSnackbar } from 'notistack';
-import Notice from 'src/components/Notice';
-import Typography from 'src/components/core/Typography';
-import TextField from 'src/components/TextField';
+import * as React from 'react';
+import { useHistory } from 'react-router-dom';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
-import { useHistory } from 'react-router-dom';
+import ConfirmationDialog from 'src/components/ConfirmationDialog';
+import Typography from 'src/components/core/Typography';
+import Notice from 'src/components/Notice';
+import TextField from 'src/components/TextField';
+import { useDeleteDatabaseMutation } from 'src/queries/databases';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
 interface Props {
   open: boolean;
@@ -54,7 +54,7 @@ export const DatabaseSettingsDeleteClusterDialog: React.FC<Props> = (props) => {
     databaseEngine,
     databaseID
   );
-  const defaultError = 'There was an error deleting this database cluster';
+  const defaultError = 'There was an error deleting this Database Cluster.';
   const [error, setError] = React.useState('');
   const [confirmText, setConfirmText] = React.useState('');
   const [isLoading, setIsLoading] = React.useState(false);
@@ -66,7 +66,7 @@ export const DatabaseSettingsDeleteClusterDialog: React.FC<Props> = (props) => {
     deleteDatabase()
       .then(() => {
         setIsLoading(false);
-        enqueueSnackbar('Database Cluster deleted successfully', {
+        enqueueSnackbar('Database Cluster deleted successfully.', {
           variant: 'success',
         });
         onClose();
@@ -94,7 +94,7 @@ export const DatabaseSettingsDeleteClusterDialog: React.FC<Props> = (props) => {
         </Typography>
       </Notice>
       <Typography style={{ marginTop: '10px' }}>
-        To confirm deletion, type the name of the database cluster (
+        To confirm deletion, type the name of the Database Cluster (
         <b>{databaseLabel}</b>) in the field below:
       </Typography>
       <TextField

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsMenuItem.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsMenuItem.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import Typography from 'src/components/core/Typography';
 import Button from 'src/components/Button';
 import { makeStyles, Theme } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
 
 interface Props {
   buttonText: string;
@@ -21,6 +21,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
   },
   sectionTitleAndText: {
+    width: '100%',
     [theme.breakpoints.down('sm')]: {
       width: '100%',
     },
@@ -30,7 +31,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   sectionText: {
     width: '65%',
-    marginRight: 0,
     [theme.breakpoints.down('sm')]: {
       marginBottom: '1rem',
     },
@@ -60,12 +60,12 @@ export const DatabaseSettingsMenuItem: React.FC<Props> = (props) => {
   return (
     <div className={classes.topSection}>
       <div className={classes.sectionTitleAndText}>
-        <div className={classes.sectionTitle}>
-          <Typography variant="h3">{sectionTitle}</Typography>
-        </div>
-        <div className={classes.sectionText}>
-          <Typography>{descriptiveText}</Typography>
-        </div>
+        <Typography variant="h3" className={classes.sectionTitle}>
+          {sectionTitle}
+        </Typography>
+        <Typography className={classes.sectionText}>
+          {descriptiveText}
+        </Typography>
       </div>
       <Button
         className={classes.sectionButton}

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsResetPasswordDialog.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsResetPasswordDialog.tsx
@@ -1,9 +1,9 @@
+import { Engine, resetDatabaseCredentials } from '@linode/api-v4/lib/databases';
 import * as React from 'react';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
 import Typography from 'src/components/core/Typography';
-import { Engine, resetDatabaseCredentials } from '@linode/api-v4/lib/databases';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
 interface Props {
@@ -36,7 +36,7 @@ const renderActions = (
         data-testid="dialog-confrim"
         loading={loading}
       >
-        Reset Password
+        Reset Root Password
       </Button>
     </ActionsPanel>
   );
@@ -74,8 +74,8 @@ export const DatabaseSettingsResetPasswordDialog: React.FC<Props> = (props) => {
       error={error}
     >
       <Typography>
-        After resetting your Root Password, you can view your new password on
-        the Database Cluster Summary page.
+        After resetting your root password, you can view your new password on
+        the Database Cluster summary page.
       </Typography>
     </ConfirmationDialog>
   );

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
@@ -4,16 +4,16 @@ import { useSnackbar } from 'notistack';
 import * as React from 'react';
 import DownloadIcon from 'src/assets/icons/lke-download.svg';
 import CircleProgress from 'src/components/CircleProgress';
+import Box from 'src/components/core/Box';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 // import CopyTooltip from 'src/components/CopyTooltip';
 import Grid from 'src/components/Grid';
+import HelpIcon from 'src/components/HelpIcon';
 import { DB_ROOT_USERNAME } from 'src/constants';
 import { useDatabaseCredentialsQuery } from 'src/queries/databases';
 import { downloadFile } from 'src/utilities/downloadFile';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
-import Box from 'src/components/core/Box';
-import HelpIcon from 'src/components/HelpIcon';
 
 const useStyles = makeStyles((theme: Theme) => ({
   header: {
@@ -91,7 +91,7 @@ interface Props {
 }
 
 const privateHostCopy =
-  'A private network host and a private IP can only be used to access a database cluster from Linodes in the same data center and will not incur transfer costs.';
+  'A private network host and a private IP can only be used to access a Database Cluster from Linodes in the same data center and will not incur transfer costs.';
 
 export const DatabaseSummaryConnectionDetails: React.FC<Props> = (props) => {
   const { database } = props;

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseEmptyState.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseEmptyState.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
+import { useHistory } from 'react-router-dom';
+import DatabaseIcon from 'src/assets/icons/entityIcons/database.svg';
+import { makeStyles } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Link from 'src/components/Link';
 import Placeholder from 'src/components/Placeholder';
-import DatabaseIcon from 'src/assets/icons/entityIcons/database.svg';
-import { useHistory } from 'react-router-dom';
-import { makeStyles } from 'src/components/core/styles';
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -36,7 +36,7 @@ const DatabaseEmptyState: React.FC = () => {
     >
       <Typography variant="subtitle1">
         <div className={classes.entityDescription}>
-          Fully managed and highly scalable database clusters. Choose your
+          Fully managed and highly scalable Database Clusters. Choose your
           Linode plan, select a database engine, and deploy in minutes.
         </div>
         <Link to="https://www.linode.com/docs/products/databases/managed-databases/">

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.test.tsx
@@ -1,18 +1,18 @@
-import * as React from 'react';
-import formatDate from 'src/utilities/formatDate';
-import DatabaseRow from './DatabaseRow';
-import DatabaseLanding from './DatabaseLanding';
 import { waitForElementToBeRemoved } from '@testing-library/react';
-import { databaseInstanceFactory } from 'src/factories';
-import { rest, server } from 'src/mocks/testServer';
-import { makeResourcePage } from 'src/mocks/serverHandlers';
-import { QueryClient } from 'react-query';
 import { DateTime } from 'luxon';
+import * as React from 'react';
+import { QueryClient } from 'react-query';
+import { databaseInstanceFactory } from 'src/factories';
+import { makeResourcePage } from 'src/mocks/serverHandlers';
+import { rest, server } from 'src/mocks/testServer';
+import formatDate from 'src/utilities/formatDate';
 import {
   mockMatchMedia,
   renderWithTheme,
   wrapWithTableBody,
 } from 'src/utilities/testHelpers';
+import DatabaseLanding from './DatabaseLanding';
+import DatabaseRow from './DatabaseRow';
 
 const queryClient = new QueryClient();
 
@@ -102,7 +102,7 @@ describe('Database Table', () => {
 
     expect(
       getByText(
-        'Fully managed and highly scalable database clusters. Choose your Linode plan, select a database engine, and deploy in minutes.'
+        'Fully managed and highly scalable Database Clusters. Choose your Linode plan, select a database engine, and deploy in minutes.'
       )
     ).toBeInTheDocument();
   });

--- a/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -201,7 +201,7 @@ class AddNewMenu extends React.Component<CombinedProps> {
                     >
                       <AddNewMenuItem
                         title="Database"
-                        body="High-performance managed database clusters"
+                        body="High-performance managed Database Clusters"
                         ItemIcon={DatabaseIcon}
                         attr={{ 'data-qa-database-add-new': true }}
                       />


### PR DESCRIPTION
## Description

- Standardizes the capitalization for "Database Cluster"
- Fixes the double border on the last row of IP addresses for Access Controls
- Removes the line break from the Delete Cluster copy
- Add "Root" to the primary action for the Reset Root Password modal

## How to test

- Check all the copy references to "Database Cluster" and check for capitalization
- Check the other changes on the Settings tab
