### PR TITLE
DBaaS menu location and access controls copy changes

### DIFF
--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -146,13 +146,6 @@ export const PrimaryNav: React.FC<Props> = (props) => {
           icon: <NodeBalancer />,
         },
         {
-          hide: !showDatabases,
-          display: 'Databases',
-          href: '/databases',
-          icon: <Database />,
-          isBeta: true,
-        },
-        {
           hide: !showFirewalls,
           display: 'Firewalls',
           href: '/firewalls',
@@ -181,6 +174,13 @@ export const PrimaryNav: React.FC<Props> = (props) => {
           prefetchRequestFn: requestDomains,
           prefetchRequestCondition:
             !domains.loading && domains.lastUpdated === 0 && !_isLargeAccount,
+        },
+        {
+          hide: !showDatabases,
+          display: 'Databases',
+          href: '/databases',
+          icon: <Database />,
+          isBeta: true,
         },
         {
           display: 'Kubernetes',

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -543,14 +543,17 @@ const DatabaseCreate: React.FC<{}> = () => {
             Add Access Controls
           </Typography>
           <Typography>
-            Add at least one IPv4 address or range that should be authorized to
-            view this cluster’s database.
+            Add any IPv4 address or range that should be authorized to access
+            this cluster.
           </Typography>
           <Typography>
             By default, all public and private connections are denied.{' '}
             <Link to="https://www.linode.com/docs/products/databases/managed-databases/guides/manage-access-controls/">
               Learn more.
             </Link>
+          </Typography>
+          <Typography style={{ marginTop: 16 }}>
+            You can add or modify access controls after your Database is active.{' '}
           </Typography>
           <Grid style={{ marginTop: 24, maxWidth: 450 }}>
             {ipErrorsFromAPI

--- a/packages/manager/src/features/Databases/DatabaseDetail/AccessControls.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/AccessControls.tsx
@@ -1,6 +1,7 @@
 import { Database } from '@linode/api-v4/lib/databases';
 import { APIError } from '@linode/api-v4/lib/types';
 import * as React from 'react';
+import { useLocation } from 'react-router-dom';
 import ActionsPanel from 'src/components/ActionsPanel';
 import AddNewLink from 'src/components/AddNewLink';
 import Button from 'src/components/Button';
@@ -9,7 +10,7 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 import TableBody from 'src/components/core/TableBody';
 import Typography from 'src/components/core/Typography';
 import InlineMenuAction from 'src/components/InlineMenuAction';
-import ExternalLink from 'src/components/Link';
+import { Link } from 'src/components/Link';
 import Notice from 'src/components/Notice';
 import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
@@ -87,6 +88,7 @@ export const AccessControls: React.FC<Props> = (props) => {
   } = props;
 
   const classes = useStyles();
+  const location = useLocation();
 
   const [isDialogOpen, setDialogOpen] = React.useState<boolean>(false);
   const [error, setError] = React.useState<string | undefined>();
@@ -117,6 +119,35 @@ export const AccessControls: React.FC<Props> = (props) => {
       setExtendedIPs([]);
     }
   }, [allowList]);
+
+  const getCopy = (url: string) => {
+    if (url.includes('/settings')) {
+      // Copy for `/settings`
+      return (
+        <Typography>
+          Add or remove IPv4 addresses or ranges that should be authorized to
+          access your cluster.
+        </Typography>
+      );
+    } else {
+      // Copy for `/summary`
+      return (
+        <>
+          <Typography>
+            Add IPv4 addresses or ranges that should be authorized to access
+            this cluster. All other public and private connections are denied.{' '}
+            <Link to="https://www.linode.com/docs/products/databases/managed-databases/guides/manage-access-controls/">
+              Learn more.
+            </Link>
+          </Typography>
+          <Typography style={{ marginTop: 12 }}>
+            You can add or modify access controls after your database cluster is
+            active.
+          </Typography>
+        </>
+      );
+    }
+  };
 
   const handleClickRemove = (accessControl: string) => {
     setError(undefined);
@@ -195,12 +226,10 @@ export const AccessControls: React.FC<Props> = (props) => {
           </div>
           <div className={classes.sectionText}>
             <Typography>
-              Add the IP addresses for other instances or users that should have
-              the authorization to view this cluster&apos;s database. By
-              default, all public and private connections are denied.{' '}
-              <ExternalLink to="https://www.linode.com/docs/products/databases/managed-databases/guides/manage-access-controls/">
+              {getCopy(location.pathname)}
+              {/* <ExternalLink to="https://www.linode.com/docs/products/databases/managed-databases/guides/manage-access-controls/">
                 Learn more.
-              </ExternalLink>
+              </ExternalLink> */}
             </Typography>
           </div>
         </div>

--- a/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
@@ -6,7 +6,6 @@ import Button from 'src/components/Button';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Drawer from 'src/components/Drawer';
-import ExternalLink from 'src/components/Link';
 import MultipleIPInput from 'src/components/MultipleIPInput/MultipleIPInput';
 import Notice from 'src/components/Notice';
 import { enforceIPMasks } from 'src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer';
@@ -163,11 +162,8 @@ const AddAccessControlDrawer: React.FC<CombinedProps> = (props) => {
             ))
           : null}
         <Typography variant="body1" className={classes.instructions}>
-          Add or remove IPv4 addresses and ranges that should be authorized to
-          view your cluster&apos;s database.{' '}
-          <ExternalLink to="https://www.linode.com/docs/products/databases/managed-databases/guides/manage-access-controls/">
-            Learn more about securing your cluster.
-          </ExternalLink>
+          Add, edit, or remove IPv4 addresses and ranges that should be
+          authorized to access your cluster.
         </Typography>
         <form onSubmit={handleSubmit}>
           <MultipleIPInput

--- a/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -193,20 +193,6 @@ class AddNewMenu extends React.Component<CombinedProps> {
                       ItemIcon={VolumeIcon}
                     />
                   </MenuLink>
-                  {flags.databases ? (
-                    <MenuLink
-                      as={Link}
-                      to="/databases/create"
-                      className={classes.menuItemLink}
-                    >
-                      <AddNewMenuItem
-                        title="Database"
-                        body="High-performance managed database clusters"
-                        ItemIcon={DatabaseIcon}
-                        attr={{ 'data-qa-database-add-new': true }}
-                      />
-                    </MenuLink>
-                  ) : null}
                   <MenuLink
                     as={Link}
                     to="/nodebalancers/create"
@@ -242,6 +228,20 @@ class AddNewMenu extends React.Component<CombinedProps> {
                       ItemIcon={DomainIcon}
                     />
                   </MenuLink>
+                  {flags.databases ? (
+                    <MenuLink
+                      as={Link}
+                      to="/databases/create"
+                      className={classes.menuItemLink}
+                    >
+                      <AddNewMenuItem
+                        title="Database"
+                        body="High-performance managed database clusters"
+                        ItemIcon={DatabaseIcon}
+                        attr={{ 'data-qa-database-add-new': true }}
+                      />
+                    </MenuLink>
+                  ) : null}
                   <MenuLink
                     as={Link}
                     to="/kubernetes/create"


### PR DESCRIPTION
## Description

- **M3- 5711:** Change location of Databases in Primary Nav and Create menu to after Domains
- **M3-5710:** Make access controls optional and add conditional text

## How to test

- Check the Database location in the primary nav and the create button
- Check the copy on the Create Database page, `/summary` tab, `/settings` tab, and the Manage Access Controls drawer
