### PR TITLE
Fix StackScript Broken Cypress Test

### DIFF
--- a/packages/manager/cypress/integration/stackscripts/stackscripts.spec.ts
+++ b/packages/manager/cypress/integration/stackscripts/stackscripts.spec.ts
@@ -19,7 +19,7 @@ const createLinode = () => {
 
 describe('stackscripts', () => {
   it('create stackscript, use it to deploy linode', () => {
-    const disk = 'Alpine 3.10';
+    const disk = 'Alpine 3.15';
     cy.intercept('POST', `*/linode/instances`).as('createLinode');
     const ssLabel = makeTestLabel();
     cy.visitWithLogin('/stackscripts');


### PR DESCRIPTION
## Description

**What does this PR do?**
This fixes the failing StackScript Cypress test. The test was failing because it attempts to use a target image (Alpine 3.10) which no longer exists. I just updated to Alpine 3.15, which appears to be the newest version available, and I'm now seeing the test succeed.

## How to test

**What are the steps to reproduce the issue or verify the changes?**
You can reproduce the issue by checking out `develop` and running `yarn up` followed by `yarn cy:debug`. Once the Cypress window opens, select `stackscripts.spec.ts` -- you should observe a failure when it attempts to select Alpine 3.10 as the target image for the Stack Script.

Check out this PR and run the same steps to observe that the test no longer fails.
