### PR TITLE
M3-4635: Disable "Make a Payment" button if restricted user has read_only access

### DIFF
--- a/packages/manager/src/components/LandingHeader/LandingHeader.tsx
+++ b/packages/manager/src/components/LandingHeader/LandingHeader.tsx
@@ -23,6 +23,7 @@ export interface Props extends Omit<HeaderProps, 'actions'> {
   createButtonText?: string;
   loading?: boolean;
   breadcrumbProps?: BreadcrumbProps;
+  disabledCreateButton?: boolean;
 }
 
 /**
@@ -43,6 +44,7 @@ export const LandingHeader: React.FC<Props> = (props) => {
     createButtonText,
     loading,
     breadcrumbProps,
+    disabledCreateButton,
   } = props;
 
   const defaultCreateButtonWidth = 152;
@@ -59,6 +61,7 @@ export const LandingHeader: React.FC<Props> = (props) => {
             loading={loading}
             onClick={onAddNew}
             style={{ width: createButtonWidth ?? defaultCreateButtonWidth }}
+            disabled={disabledCreateButton}
           >
             {createButtonText ?? `Create ${entity}`}
           </Button>
@@ -73,6 +76,7 @@ export const LandingHeader: React.FC<Props> = (props) => {
       createButtonWidth,
       createButtonText,
       entity,
+      disabledCreateButton,
     ]
   );
 

--- a/packages/manager/src/features/Account/AccountLanding.tsx
+++ b/packages/manager/src/features/Account/AccountLanding.tsx
@@ -11,7 +11,7 @@ import SuspenseLoader from 'src/components/SuspenseLoader';
 import TabLinkList from 'src/components/TabLinkList';
 import TaxBanner from 'src/components/TaxBanner';
 import useFlags from 'src/hooks/useFlags';
-import { useProfile } from 'src/queries/profile';
+import { getGrantData, useProfile } from 'src/queries/profile';
 
 const Billing = React.lazy(() => import('src/features/Billing'));
 const EntityTransfersLanding = React.lazy(
@@ -28,6 +28,10 @@ const AccountLanding: React.FC = () => {
   const history = useHistory();
   const location = useLocation();
   const { data: profile } = useProfile();
+
+  const grantData = getGrantData();
+  const accountAccessGrant = grantData?.global?.account_access;
+  const readOnlyAccountAccess = accountAccessGrant === 'read_only';
 
   const tabs = [
     {
@@ -99,6 +103,7 @@ const AccountLanding: React.FC = () => {
     landingHeaderProps.createButtonText = 'Make a Payment';
     landingHeaderProps.onAddNew = () =>
       history.replace('/account/billing/make-payment');
+    landingHeaderProps.disabledCreateButton = readOnlyAccountAccess;
   }
 
   return (

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
@@ -22,6 +22,7 @@ import useNotifications from 'src/hooks/useNotifications';
 import { isWithinDays } from 'src/utilities/date';
 import PaymentDrawer from './PaymentDrawer';
 import PromoDialog from './PromoDialog';
+import { getGrantData } from 'src/queries/profile';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -93,6 +94,10 @@ export const BillingSummary: React.FC<BillingSummaryProps> = (props) => {
   const [isPromoDialogOpen, setIsPromoDialogOpen] = React.useState<boolean>(
     false
   );
+
+  const grantData = getGrantData();
+  const accountAccessGrant = grantData?.global?.account_access;
+  const readOnlyAccountAccess = accountAccessGrant === 'read_only';
 
   // If a user has a payment_due notification with a severity of critical, it indicates that they are outside of any grace period they may have and payment is due immediately.
   const isBalanceOutsideGracePeriod = notifications.some(
@@ -228,7 +233,7 @@ export const BillingSummary: React.FC<BillingSummaryProps> = (props) => {
                 />
               </Typography>
             </Box>
-            {balanceJSX}
+            {!readOnlyAccountAccess ? balanceJSX : null}
             {showAddPromoLink ? (
               <Typography className={classes.promo}>
                 <button


### PR DESCRIPTION
## Description
If a user has `read_only` access for the `account_access` grant, the "Make a Payment" button on the /account/billing page should be disabled.

Additionally, if an account has a balance, there's a link in the "Account Balance" section that says `Make a payment.` below "Balance". Clicking it would open the same payment drawer as clicking the "Make a Payment" button does. I went ahead and made the display of that link conditional on whether the user has `read_only` access or not.

## How to test
On a single account, look at the `/account/billing` page as an unrestricted user and as a restricted user. 

The unrestricted user should see an enabled "Make a Payment" button and the `Make a payment.` text in the "Account Balance" section.

The restricted user should see a disabled "Make a Payment" button and no `Make a payment.` link in the "Account Balance" section.