### PR TITLE
Exclude Storybook stories from Jest code coverage report

### DIFF
--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -249,7 +249,8 @@
       "<rootDir>/src"
     ],
     "collectCoverageFrom": [
-      "src/**/*.{js,jsx,ts,tsx}"
+      "src/**/*.{js,jsx,ts,tsx}",
+      "!src/**/*.stories.{js,jsx,ts,tsx}"
     ],
     "setupFiles": [
       "<rootDir>/config/polyfills.js"


### PR DESCRIPTION
## Description

**What does this PR do?**
Trying to stick to the Storybook theme this sprint 😄 

This tweak prevents Storybook stories from being included in Jest's code coverage report. At the moment, stories ending in `.tsx` appear in the code coverage report. Since stories have no code coverage, they make it appear at a glance that our components have less coverage than they actually do.

## How to test

**What are the steps to reproduce the issue or verify the changes?**

From the root of the repository:

```bash
yarn test --coverage
```
Once tests finish running, navigate to `packages/manager/coverage/lcov-report/` and open `index.html` in your browser. Observe that stories ending in `.stories.tsx` are included in the code coverage report (or, if you've checked out this PR, are excluded).

The `Accordion` component is a good one to check since it's towards the top of the list.
