### PR TITLE
Proof of Concept for useImperativeHandle hook

### DIFF
--- a/packages/manager/src/components/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/packages/manager/src/components/ConfirmationDialog/ConfirmationDialog.tsx
@@ -36,17 +36,26 @@ export interface Props extends DialogProps {
 
 type CombinedProps = Props;
 
-const ConfirmationDialog: React.FC<CombinedProps> = (props) => {
+const ConfirmationDialog: React.FC<CombinedProps> = (props, ref) => {
+  const [dialogOpen, setDialogOpen] = React.useState<boolean>(false);
   const classes = useStyles();
 
   const { title, children, actions, error, onClose, ...dialogProps } = props;
 
+  React.useImperativeHandle(ref, () => ({
+    openDialog: () => setDialogOpen(true),
+    closeDialog: () => setDialogOpen(false),
+  }));
+
+  console.log('Dialog rendered');
+
   return (
     <Dialog
       {...dialogProps}
+      open={dialogOpen}
       onClose={(_, reason) => {
         if (reason !== 'backdropClick') {
-          onClose();
+          setDialogOpen(false);
         }
       }}
       className={classes.root}
@@ -71,4 +80,4 @@ const ConfirmationDialog: React.FC<CombinedProps> = (props) => {
   );
 };
 
-export default ConfirmationDialog;
+export default React.forwardRef(ConfirmationDialog);

--- a/packages/manager/src/features/Databases/DatabaseDetail/AccessControls.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/AccessControls.tsx
@@ -89,6 +89,16 @@ export const AccessControls: React.FC<Props> = (props) => {
 
   const classes = useStyles();
 
+  const ipRemovalDialogRef = React.useRef();
+
+  const handleOpenIPRemovalDialog = () => {
+    ipRemovalDialogRef.current.openDialog();
+  };
+
+  const handleCloseIPRemovalDialog = () => {
+    ipRemovalDialogRef.current.closeDialog();
+  };
+
   const [isDialogOpen, setDialogOpen] = React.useState<boolean>(false);
   const [error, setError] = React.useState<string | undefined>();
 
@@ -121,8 +131,9 @@ export const AccessControls: React.FC<Props> = (props) => {
 
   const handleClickRemove = (accessControl: string) => {
     setError(undefined);
-    setDialogOpen(true);
-    setAccessControlToBeRemoved(accessControl);
+    // setDialogOpen(true);
+    // setAccessControlToBeRemoved(accessControl);
+    handleOpenIPRemovalDialog();
   };
 
   const handleDialogClose = () => {
@@ -143,6 +154,8 @@ export const AccessControls: React.FC<Props> = (props) => {
       });
   };
 
+  console.log('AccessControls.tsx rendered');
+
   const ipTable = (accessControlsList: string[]) => {
     if (accessControlsList.length === 0) {
       return null;
@@ -161,7 +174,7 @@ export const AccessControls: React.FC<Props> = (props) => {
                 <InlineMenuAction
                   actionText="Remove"
                   className={classes.removeButton}
-                  onClick={() => handleClickRemove(accessControl)}
+                  onClick={handleOpenIPRemovalDialog}
                 />
               </TableCell>
             </TableRow>
@@ -173,7 +186,7 @@ export const AccessControls: React.FC<Props> = (props) => {
 
   const actionsPanel = (
     <ActionsPanel>
-      <Button buttonType="secondary" onClick={handleDialogClose}>
+      <Button buttonType="secondary" onClick={handleCloseIPRemovalDialog}>
         Cancel
       </Button>
 
@@ -205,6 +218,7 @@ export const AccessControls: React.FC<Props> = (props) => {
       {ipTable(allowList)}
       <ConfirmationDialog
         open={isDialogOpen}
+        ref={ipRemovalDialogRef}
         onClose={handleDialogClose}
         title={`Remove IP Address ${accessControlToBeRemoved}`}
         actions={actionsPanel}


### PR DESCRIPTION
## Description
(note: I will close this PR early next week. It isn't meant to be merged; rather, it is strictly a Proof of Concept. As such, there are still TypeScript errors, etc.)

A proof of concept to apply the `useImperativeHandle` [hook](https://reactjs.org/docs/hooks-reference.html#useimperativehandle) to a modal use case in Cloud. 

The hook allows a function that is defined in a child component to be called in the parent component.

The example use case here is Database Access Controls and the modal that appears when removing an IP address.

## How to test
I left the `console.log()` statements in for the effects of this to easily be seen. Outside of this branch, if you add these same `console.log()` statements, you'd see that both `AccessControls.tsx` and `ConfirmationDialog.tsx` render each time the modal is opened and closed. On this branch, only the latter will render & re-render.
