### PR TITLE
M3-4768: Add toasts when making a StackScript public

### DIFF
--- a/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptPanelContent.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptPanelContent.tsx
@@ -3,6 +3,7 @@ import {
   deleteStackScript,
   updateStackScript,
 } from '@linode/api-v4/lib/stackscripts';
+import { useSnackbar } from 'notistack';
 import * as React from 'react';
 import { compose } from 'recompose';
 import ActionsPanel from 'src/components/ActionsPanel';
@@ -56,6 +57,8 @@ export const StackScriptPanelContent: React.FC<CombinedProps> = (props) => {
   const [dialog, setDialogState] = React.useState<DialogState>(
     defaultDialogState
   );
+
+  const { enqueueSnackbar } = useSnackbar();
 
   React.useEffect(() => {
     setMounted(true);
@@ -144,12 +147,20 @@ export const StackScriptPanelContent: React.FC<CombinedProps> = (props) => {
           return;
         }
         handleCloseDialog();
+        enqueueSnackbar(
+          `${dialog.stackScriptLabel} successfully published to the public library.`,
+          { variant: 'success' }
+        );
         props.getDataAtPage(1, currentFilter, true);
       })
       .catch((_) => {
         if (!mounted) {
           return;
         }
+        enqueueSnackbar(
+          `There was an error publishing ${dialog.stackScriptLabel} to the public library.`,
+          { variant: 'error' }
+        );
         handleCloseDialog();
       });
   };


### PR DESCRIPTION
## Description
Adds success & error toasts when making a StackScript public.

## How to test
Pointing at the dev environment, make a StackScript. Then from the "Account StackScripts" tab, choose "Make StackScript Public" from the StackScript's action menu. It should go through successfully and you should see a success toast. To test the error toast, block requests to `*stackscripts*` and then try to make a StackScript public. You should see an error toast.
