### PR TITLE
TypeScript Docgen for Storybook

### DIFF
--- a/packages/manager/.storybook/main.js
+++ b/packages/manager/.storybook/main.js
@@ -10,6 +10,15 @@ module.exports = {
     '@storybook/addon-controls',
     '@storybook/addon-viewport',
   ],
+  typescript: {
+    reactDocgen: 'react-docgen-typescript',
+    reactDocgenTypescriptOptions: {
+      compilerOptions: {
+        allowSyntheticDefaultImports: false,
+        esModuleInterop: false,
+      },
+    },
+  },
   webpackFinal: (config) => {
     /**
      * Added logic to find svg config included with Storybook and tell it to excude all svgs.

--- a/packages/manager/src/GoTo.tsx
+++ b/packages/manager/src/GoTo.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import EnhancedSelect, { Item } from 'src/components/EnhancedSelect/Select';
-import MUIDialog from 'src/components/core/Dialog';
+import Dialog from '@material-ui/core/Dialog';
 import { useHistory } from 'react-router-dom';
 import useFlags from './hooks/useFlags';
 import { isFeatureEnabled } from './utilities/accountCapabilities';
@@ -168,7 +168,7 @@ const GoTo: React.FC<CombinedProps> = (props) => {
   ]);
 
   return (
-    <MUIDialog
+    <Dialog
       classes={dialogClasses}
       title="Go To..."
       open={props.open}
@@ -195,7 +195,7 @@ const GoTo: React.FC<CombinedProps> = (props) => {
           menuIsOpen={true}
         />
       </div>
-    </MUIDialog>
+    </Dialog>
   );
 };
 

--- a/packages/manager/src/components/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/packages/manager/src/components/ConfirmationDialog/ConfirmationDialog.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Dialog, { DialogProps } from 'src/components/core/Dialog';
+import Dialog, { DialogProps } from '@material-ui/core/Dialog';
 import DialogActions from 'src/components/core/DialogActions';
 import DialogContent from 'src/components/core/DialogContent';
 import DialogContentText from 'src/components/core/DialogContentText';

--- a/packages/manager/src/components/Dialog/Dialog.stories.mdx
+++ b/packages/manager/src/components/Dialog/Dialog.stories.mdx
@@ -8,6 +8,7 @@ import { Canvas, Meta, Story, ArgsTable } from '@storybook/addon-docs';
 
 <Meta
   title="Components/Dialogs"
+  component={Dialog}
 />
 
 export const DeletionTemplate = (args) => (

--- a/packages/manager/src/components/Dialog/Dialog.tsx
+++ b/packages/manager/src/components/Dialog/Dialog.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import Close from '@material-ui/icons/Close';
 import Button from 'src/components/Button';
-import MUIDialog, {
+import {
+  default as _Dialog,
   DialogProps as _DialogProps,
-} from 'src/components/core/Dialog';
+} from '@material-ui/core/Dialog';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
@@ -89,7 +90,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-const Dialog: React.FC<DialogProps> = (props) => {
+export const Dialog: React.FC<DialogProps> = (props) => {
   const {
     className,
     title,
@@ -105,7 +106,7 @@ const Dialog: React.FC<DialogProps> = (props) => {
   const titleID = convertForAria(title);
 
   return (
-    <MUIDialog
+    <_Dialog
       title={title}
       maxWidth={props.maxWidth ?? 'md'}
       {...rest}
@@ -151,7 +152,7 @@ const Dialog: React.FC<DialogProps> = (props) => {
           </div>
         </Grid>
       </Grid>
-    </MUIDialog>
+    </_Dialog>
   );
 };
 

--- a/packages/manager/src/components/TransferDisplay/TransferDisplay.tsx
+++ b/packages/manager/src/components/TransferDisplay/TransferDisplay.tsx
@@ -3,7 +3,7 @@ import OpenInNew from '@material-ui/icons/OpenInNew';
 import { DateTime } from 'luxon';
 import * as React from 'react';
 import BarPercent from 'src/components/BarPercent';
-import Dialog from 'src/components/core/Dialog';
+import Dialog from '@material-ui/core/Dialog';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';

--- a/packages/manager/src/components/core/Dialog.ts
+++ b/packages/manager/src/components/core/Dialog.ts
@@ -1,6 +1,0 @@
-import Dialog, { DialogProps as _DialogProps } from '@material-ui/core/Dialog';
-
-/* tslint:disable-next-line:no-empty-interface */
-export interface DialogProps extends _DialogProps {}
-
-export default Dialog;

--- a/packages/manager/src/components/core/Paper.tsx
+++ b/packages/manager/src/components/core/Paper.tsx
@@ -23,7 +23,7 @@ export interface PaperProps extends _PaperProps {
 
 type CombinedProps = PaperProps;
 
-const Paper: React.FC<CombinedProps> = (props) => {
+export const Paper: React.FC<CombinedProps> = (props) => {
   const { error, className, ...rest } = props;
   const classes = useStyles();
 

--- a/packages/manager/src/features/TheApplicationIsOnFire.tsx
+++ b/packages/manager/src/features/TheApplicationIsOnFire.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Dialog from 'src/components/core/Dialog';
+import Dialog from '@material-ui/core/Dialog';
 import DialogContent from 'src/components/core/DialogContent';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';


### PR DESCRIPTION
## Description

- Allows Storybook to better infer args from Typescript types
- The diff shows some changes that should be made for this concept to work better for a component (Dialog in this case)

```ts
<Meta title="Components/Paper" component={Paper} />
```

## How to test

- Go look at some stories!
  - Paper
  - Dialog

https://user-images.githubusercontent.com/6440455/154551144-88201c3c-c971-4911-b08f-06efbf0b3fd6.mov


