### PR TITLE
M3-5583: Fixed Linode Configurations Table Misalignment

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/ConfigRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/ConfigRow.tsx
@@ -24,9 +24,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   interfaceListItem: {
     paddingBottom: 4,
   },
-  alignTop: {
-    verticalAlign: 'top',
-  },
 }));
 
 interface Props {
@@ -121,15 +118,8 @@ export const ConfigRow: React.FC<CombinedProps> = (props) => {
 
   const defaultInterfaceLabel = 'eth0 – Public Internet';
 
-  // This should determine alignment based on device count associated w/ a config
-  const hasManyConfigs = validDevices.length > 3;
-
   return (
-    <TableRow
-      className={hasManyConfigs ? classes.alignTop : undefined}
-      key={config.id}
-      data-qa-config={config.label}
-    >
+    <TableRow key={config.id} data-qa-config={config.label}>
       <TableCell>
         {config.label} – {linodeKernel}
       </TableCell>


### PR DESCRIPTION
## Description

- Fixes alignment issues in the Linode Configurations table

### Before
![Screen Shot 2022-02-22 at 4 56 04 PM](https://user-images.githubusercontent.com/6440455/155226329-6ebce853-1a95-40ad-8921-c82c0c609651.png)


### After
![Screen Shot 2022-02-22 at 4 56 18 PM](https://user-images.githubusercontent.com/6440455/155226314-916baf02-fe64-4b73-8531-e99e930b3859.png)


## How to test

- Create a Linode and attach two volumes to it
- Visit `http://localhost:3000/linodes/{id}/configurations`
- Create many different types of configurations and ensure content remains vertically centered in each row