### PR TITLE
M3-5467: Add Transfer and Network in/out to Linode Plans Tables

### DIFF
--- a/packages/manager/src/__data__/ExtendedType.ts
+++ b/packages/manager/src/__data__/ExtendedType.ts
@@ -5,7 +5,7 @@ const extendTypes = () => {
     return {
       ...type,
       heading: 'test',
-      subHeadings: ['test', 'test'] as [string, string],
+      subHeadings: ['test', 'test', 'test'] as [string, string, string],
       isDeprecated: false,
     };
   });

--- a/packages/manager/src/components/SelectionCard/SelectionCard.stories.mdx
+++ b/packages/manager/src/components/SelectionCard/SelectionCard.stories.mdx
@@ -48,7 +48,7 @@ Tables used for selecting an item become cards at a breakpoint (e.g., plans on t
       renderIcon: iconOptions.Photo,
       renderVariant: variantOptions.None,
       heading: 'Photos',
-      subheadings: ['Use a photo', 'Select up to 3'],
+      subheadings: ['Use a photo', 'Select up to 3', 'test'],
       checked: false,
       disabled: false,
       tooltip: '',

--- a/packages/manager/src/components/TableCell/TableCell.tsx
+++ b/packages/manager/src/components/TableCell/TableCell.tsx
@@ -21,6 +21,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   noWrap: {
     whiteSpace: 'nowrap',
   },
+  center: {
+    textAlign: 'center',
+  },
   sortable: {
     color: theme.color.headline,
     fontWeight: 'normal',
@@ -63,6 +66,7 @@ export interface Props extends TableCellProps {
   parentColumn?: string;
   compact?: boolean;
   actionCell?: boolean;
+  center?: boolean;
 }
 
 type CombinedProps = Props;
@@ -77,6 +81,7 @@ export const WrappedTableCell: React.FC<CombinedProps> = (props) => {
     sortable,
     compact,
     actionCell,
+    center,
     ...rest
   } = props;
 
@@ -88,6 +93,7 @@ export const WrappedTableCell: React.FC<CombinedProps> = (props) => {
         [classes.sortable]: sortable,
         [classes.compact]: compact,
         [classes.actionCell]: actionCell,
+        [classes.center]: center,
         // hide the cell at small breakpoints if it's empty with no parent column
         emptyCell: !parentColumn && !props.children,
       })}

--- a/packages/manager/src/components/TableCell/TableCell.tsx
+++ b/packages/manager/src/components/TableCell/TableCell.tsx
@@ -23,6 +23,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   center: {
     textAlign: 'center',
+    '&:last-child': {
+      paddingRight: '15px',
+    },
   },
   sortable: {
     color: theme.color.headline,

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -604,6 +604,7 @@ export class LinodeCreate extends React.PureComponent<
             disabled={userCannotCreateLinode}
             disabledClasses={this.props.disabledClasses}
             isCreate
+            showTransfer
           />
           <LabelAndTagsPanel
             data-qa-label-and-tags-panel

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -125,6 +125,7 @@ interface Props {
   ldClient?: LDClient;
   isCreate?: boolean;
   className?: string;
+  showTransfer?: boolean;
 }
 
 const getNanodes = (types: ExtendedTypes) =>
@@ -170,6 +171,7 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
       disabled,
       classes,
       isCreate,
+      showTransfer,
     } = this.props;
     const selectedDiskSize = this.props.selectedDiskSize
       ? this.props.selectedDiskSize
@@ -179,6 +181,8 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
     const isSamePlan = type.heading === currentPlanHeading;
     const isGPU = type.class === 'gpu';
     const isDisabledClass = this.getDisabledClass(type.class);
+    const shouldShowTransfer = showTransfer && type.transfer;
+    const shouldShowNetwork = showTransfer && type.network_out;
 
     if (planTooSmall) {
       tooltip = `This plan is too small for the selected image.`;
@@ -255,13 +259,25 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
                 `$` + type.price.hourly
               )}
             </TableCell>
-            <TableCell data-qa-ram>
+            <TableCell center data-qa-ram>
               {convertMegabytesTo(type.memory, true)}
             </TableCell>
-            <TableCell data-qa-cpu>{type.vcpus}</TableCell>
-            <TableCell data-qa-storage>
+            <TableCell center data-qa-cpu>
+              {type.vcpus}
+            </TableCell>
+            <TableCell center data-qa-storage>
               {convertMegabytesTo(type.disk, true)}
             </TableCell>
+            {shouldShowTransfer ? (
+              <TableCell center data-qa-transfer>
+                {type.transfer / 1000} TB
+              </TableCell>
+            ) : null}
+            {shouldShowNetwork ? (
+              <TableCell center noWrap data-qa-network>
+                40 Gbps / {type.network_out / 1000} Gbps
+              </TableCell>
+            ) : null}
           </TableRow>
         </Hidden>
 
@@ -282,7 +298,12 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
   };
 
   renderPlanContainer = (plans: ExtendedTypes) => {
-    const { classes, isCreate, header } = this.props;
+    const { classes, isCreate, header, showTransfer } = this.props;
+
+    const shouldShowTransfer = showTransfer && plans[0].transfer;
+
+    // @ts-expect-error Database does not have
+    const shouldShowNetwork = showTransfer && plans[0].network_out;
 
     return (
       <Grid container>
@@ -314,18 +335,46 @@ export class SelectPlanPanel extends React.Component<CombinedProps> {
                   >
                     Hourly
                   </TableCell>
-                  <TableCell className={classes.headerCell} data-qa-ram-header>
+                  <TableCell
+                    className={classes.headerCell}
+                    data-qa-ram-header
+                    center
+                  >
                     RAM
                   </TableCell>
-                  <TableCell className={classes.headerCell} data-qa-cpu-header>
+                  <TableCell
+                    className={classes.headerCell}
+                    data-qa-cpu-header
+                    center
+                  >
                     CPUs
                   </TableCell>
                   <TableCell
                     className={classes.headerCell}
                     data-qa-storage-header
+                    center
                   >
                     Storage
                   </TableCell>
+                  {shouldShowTransfer ? (
+                    <TableCell
+                      className={classes.headerCell}
+                      data-qa-transfer-header
+                      center
+                    >
+                      Transfer
+                    </TableCell>
+                  ) : null}
+                  {shouldShowNetwork ? (
+                    <TableCell
+                      className={classes.headerCell}
+                      data-qa-network-header
+                      noWrap
+                      center
+                    >
+                      Network (In / Out)
+                    </TableCell>
+                  ) : null}
                 </TableRow>
               </TableHead>
               <TableBody role="radiogroup">

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
@@ -30,7 +30,7 @@ import { gpuPlanText } from './utilities';
 
 export interface ExtendedType extends LinodeType {
   heading: string;
-  subHeadings: [string, string];
+  subHeadings: [string, string, string];
 }
 
 type ClassNames =

--- a/packages/manager/src/features/linodes/presentation.ts
+++ b/packages/manager/src/features/linodes/presentation.ts
@@ -23,6 +23,15 @@ export const typeLabelDetails = (
   return `${cpus} CPU, ${diskG} GB Storage, ${memG} GB RAM`;
 };
 
+export const networkAndTransferDetails = (
+  transfer: number,
+  networkOut: number
+) => {
+  const transferTb = transfer / 1000;
+  const networkOutTb = networkOut / 1000;
+  return `Transfer ${transferTb} TB, Network In / Out 40 Gbps / ${networkOutTb} Gbps`;
+};
+
 export const displayType = (
   linodeTypeId: null | string,
   types: Pick<LinodeType, 'id' | 'label'>[]

--- a/packages/manager/src/store/linodeType/linodeType.reducer.ts
+++ b/packages/manager/src/store/linodeType/linodeType.reducer.ts
@@ -6,12 +6,15 @@ import {
   getLinodeTypesActions,
   getLinodeTypeActions,
 } from './linodeType.actions';
-import { typeLabelDetails } from 'src/features/linodes/presentation';
+import {
+  networkAndTransferDetails,
+  typeLabelDetails,
+} from 'src/features/linodes/presentation';
 import { formatStorageUnits } from 'src/utilities/formatStorageUnits';
 
 export interface ExtendedType extends LinodeType {
   heading: string;
-  subHeadings: [string, string];
+  subHeadings: [string, string, string];
   isDeprecated: boolean;
   isShadowPlan?: boolean;
 }
@@ -93,6 +96,8 @@ export const extendType = (type: LinodeType): ExtendedType => {
     memory,
     vcpus,
     disk,
+    network_out,
+    transfer,
     price: { monthly, hourly },
   } = type;
   const formattedLabel = formatStorageUnits(label);
@@ -103,7 +108,8 @@ export const extendType = (type: LinodeType): ExtendedType => {
     subHeadings: [
       `$${monthly}/mo ($${hourly}/hr)`,
       typeLabelDetails(memory, disk, vcpus),
-    ] as [string, string],
+      networkAndTransferDetails(transfer, network_out),
+    ],
     isDeprecated: type.successor !== null,
   };
 };


### PR DESCRIPTION
## Description

- Adds Transfer and Network in/out to the Plans table on the Linode Create flow

## How to test

- ⚠️ Work in progress
