### PR TITLE
Fixed Support Ticket Entity Selection Extra Character

### DIFF
--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
@@ -553,7 +553,7 @@ export const SupportTicketDrawer: React.FC<CombinedProps> = (props) => {
                   />
                   {!areEntitiesLoading && entityOptions.length === 0 ? (
                     <FormHelperText>
-                      You don&apos;t have any ${entityIdToNameMap[entityType]}s
+                      You don&apos;t have any {entityIdToNameMap[entityType]}s
                       on your account.
                     </FormHelperText>
                   ) : null}


### PR DESCRIPTION
## Description

- Removes the `$` shown in the screenshot
- I let this slip through the cracks when I did some refactoring and added Firewall and Database support to the support ticket form
  - #8122

![Screen Shot 2022-02-28 at 12 24 10 PM](https://user-images.githubusercontent.com/6440455/156029998-8cf5737a-69ad-4871-a2c5-b1525176a972.png)


## How to test

- Go to `/support/tickets`
- Click the `Open New Ticket` button
- Select an entity that you have none of on your account
- Ensure the empty message does not include a `$`
  - Text should read `You don't have any Domains on your account.`, not `You don't have any $Domains on your account.` 
