### PR TITLE
M3-5750: Update README.md with new logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-  <img src="https://www.linode.com/media/images/logos/diagonal/light/linode-logo_diagonal_light_medium.png" width="200" />
+  <img src="https://user-images.githubusercontent.com/32860776/156064400-4eb7e3ef-aa93-4b75-9962-07f6090de2ed.png" width="200" />
   <br />
   Linode Cloud Manager
 </h1>


### PR DESCRIPTION
## Description
If you go to our [main repo page](https://github.com/linode/manager), the logo currently doesn't render (plus, the image that's supposed to render is the old logo):

<img width="906" alt="Screen Shot 2022-02-28 at 4 53 52 PM" src="https://user-images.githubusercontent.com/32860776/156065072-38fcc737-ecea-4063-84df-646a6c84d664.png">

This PR updates the logo and fixes things so that the logo renders 🎉 :

<img width="906" alt="Screen Shot 2022-02-28 at 4 56 23 PM" src="https://user-images.githubusercontent.com/32860776/156065187-484528db-8f9f-41f7-bce5-bd11e3859969.png">

## How to Test
To verify this is now displaying as intended, you can check [the branch](https://github.com/linode/manager/tree/DevDW-update-readme-new-logo).