### PR TITLE
Prevent preferences call from storybook

### DIFF
--- a/packages/manager/src/LinodeThemeWrapper.tsx
+++ b/packages/manager/src/LinodeThemeWrapper.tsx
@@ -18,7 +18,7 @@ interface Props {
    * this is mostly so the unit tests work
    */
   theme?: ThemeChoice;
-  fromPreferences?: boolean;
+  shouldGetPreferences?: boolean;
 }
 
 const themes = { light, dark };
@@ -41,7 +41,7 @@ const setActiveHighlightTheme = (value: ThemeChoice) => {
 };
 
 const LinodeThemeWrapper: React.FC<CombinedProps> = (props) => {
-  const { children, fromPreferences = true } = props;
+  const { children, shouldGetPreferences = true } = props;
   const toggleTheme = (value: ThemeChoice) => {
     setTimeout(() => {
       document.body.classList.remove('no-transition');
@@ -50,7 +50,7 @@ const LinodeThemeWrapper: React.FC<CombinedProps> = (props) => {
   };
 
   React.useEffect(() => {
-    if (fromPreferences) {
+    if (shouldGetPreferences) {
       /** request the user preferences on app load */
       props
         .getUserPreferences()

--- a/packages/manager/src/LinodeThemeWrapper.tsx
+++ b/packages/manager/src/LinodeThemeWrapper.tsx
@@ -18,6 +18,7 @@ interface Props {
    * this is mostly so the unit tests work
    */
   theme?: ThemeChoice;
+  fromPreferences?: boolean;
 }
 
 const themes = { light, dark };
@@ -40,6 +41,7 @@ const setActiveHighlightTheme = (value: ThemeChoice) => {
 };
 
 const LinodeThemeWrapper: React.FC<CombinedProps> = (props) => {
+  const { children, fromPreferences = true } = props;
   const toggleTheme = (value: ThemeChoice) => {
     setTimeout(() => {
       document.body.classList.remove('no-transition');
@@ -48,24 +50,24 @@ const LinodeThemeWrapper: React.FC<CombinedProps> = (props) => {
   };
 
   React.useEffect(() => {
-    /** request the user preferences on app load */
-    props
-      .getUserPreferences()
-      .then((response) => {
-        // Without the timeout a race condition sometimes runs the theme
-        // highlight checker before the stylesheets have fully loaded.
-        window.setTimeout(
-          () => setActiveHighlightTheme(response?.theme ?? 'light'),
-          1000
+    if (fromPreferences) {
+      /** request the user preferences on app load */
+      props
+        .getUserPreferences()
+        .then((response) => {
+          // Without the timeout a race condition sometimes runs the theme
+          // highlight checker before the stylesheets have fully loaded.
+          window.setTimeout(
+            () => setActiveHighlightTheme(response?.theme ?? 'light'),
+            1000
+          );
+        })
+        .catch(
+          () =>
+            /** swallow the error. PreferenceToggle.tsx handles failures gracefully */ null
         );
-      })
-      .catch(
-        () =>
-          /** swallow the error. PreferenceToggle.tsx handles failures gracefully */ null
-      );
+    }
   }, []);
-
-  const { children } = props;
 
   return (
     <PreferenceToggle<'light' | 'dark'>

--- a/packages/manager/src/utilities/testHelpers.tsx
+++ b/packages/manager/src/utilities/testHelpers.tsx
@@ -49,7 +49,7 @@ export const wrapWithTheme = (ui: any, options: Options = {}) => {
   return (
     <Provider store={storeToPass}>
       <QueryClientProvider client={passedQueryClient || queryClient}>
-        <LinodeThemeWrapper theme="dark" fromPreferences={false}>
+        <LinodeThemeWrapper theme="dark" shouldGetPreferences={false}>
           <LDProvider value={{ flags: options.flags ?? {} }}>
             <SnackbarProvider>
               <MemoryRouter {...options.MemoryRouter}>{ui}</MemoryRouter>

--- a/packages/manager/src/utilities/testHelpers.tsx
+++ b/packages/manager/src/utilities/testHelpers.tsx
@@ -49,7 +49,7 @@ export const wrapWithTheme = (ui: any, options: Options = {}) => {
   return (
     <Provider store={storeToPass}>
       <QueryClientProvider client={passedQueryClient || queryClient}>
-        <LinodeThemeWrapper theme="dark">
+        <LinodeThemeWrapper theme="dark" fromPreferences={false}>
           <LDProvider value={{ flags: options.flags ?? {} }}>
             <SnackbarProvider>
               <MemoryRouter {...options.MemoryRouter}>{ui}</MemoryRouter>


### PR DESCRIPTION
## Description

Prevents storybook from making a call to the preferences endpoint.

## How to test

Run `yarn storybook`
Once it is available to view in your browser open the network tab in dev tools and make sure there are no calls to the preferences endpoint while browsing components.
