### PR TITLE
Fixed Highlight.js Theme Issues caused by Webpack 5

### DIFF
--- a/packages/manager/src/LinodeThemeWrapper.tsx
+++ b/packages/manager/src/LinodeThemeWrapper.tsx
@@ -6,6 +6,7 @@ import withPreferences, {
   PreferencesActionsProps,
 } from 'src/containers/preferences.container';
 import { dark, light } from 'src/themes';
+import { isProductionBuild } from './constants';
 
 export type ThemeChoice = 'light' | 'dark';
 
@@ -40,16 +41,26 @@ const setActiveHighlightTheme = (value: ThemeChoice) => {
     // Get the inner content of style tag as a text string
     const content: string = thisLink?.textContent ?? '';
 
+    const isHighlightJS = content.match('.hljs');
+
+    const darkColor = isProductionBuild
+      ? 'background:#2b2b2b;'
+      : 'background: #2b2b2b;';
+
+    const lightColor = isProductionBuild
+      ? 'background:#fefefe;'
+      : 'background: #fefefe;';
+
     // If the CSS string contains .hljs and background: #2b2b2b; we can safely assume
     // we are currently using a11y-dark.css
-    if (content.match('.hljs') && content.match('background: #2b2b2b;')) {
+    if (isHighlightJS && content.match(darkColor)) {
       // If we are in dark mode, disable the dark mode css if the new theme is light
       thisLink.disabled = value === 'light';
     }
 
     // If the CSS string contains .hljs and background: #fefefe; we can safely assume
     // we are currently using a11y-light.css
-    if (content.match('.hljs') && content.match('background: #fefefe;')) {
+    if (isHighlightJS && content.match(lightColor)) {
       // If we are in light mode, disable the light mode css if the new theme is dark
       thisLink.disabled = value === 'dark';
     }

--- a/packages/manager/src/LinodeThemeWrapper.tsx
+++ b/packages/manager/src/LinodeThemeWrapper.tsx
@@ -31,12 +31,28 @@ const setActiveHighlightTheme = (value: ThemeChoice) => {
    * the app theme. This looks horrible but it is the recommended approach:
    * https://github.com/highlightjs/highlight.js/blob/master/demo/demo.js
    */
-  const inactiveTheme = value === 'dark' ? 'a11y-light' : 'a11y-dark';
+
+  // Get all the <style>...</style> tags currently rendered.
+  // We do this because Webpack writes our CSS into these html tags.
   const links = document.querySelectorAll('style');
+
   links.forEach((thisLink: any) => {
-    const content = thisLink?.textContent ?? '';
-    // We're matching a comment in the style tag's text contents :groan:
-    thisLink.disabled = content.match(inactiveTheme);
+    // Get the inner content of style tag as a text string
+    const content: string = thisLink?.textContent ?? '';
+
+    // If the CSS string contains .hljs and background: #2b2b2b; we can safely assume
+    // we are currently using a11y-dark.css
+    if (content.match('.hljs') && content.match('background: #2b2b2b;')) {
+      // If we are in dark mode, disable the dark mode css if the new theme is light
+      thisLink.disabled = value === 'light';
+    }
+
+    // If the CSS string contains .hljs and background: #fefefe; we can safely assume
+    // we are currently using a11y-light.css
+    if (content.match('.hljs') && content.match('background: #fefefe;')) {
+      // If we are in light mode, disable the light mode css if the new theme is dark
+      thisLink.disabled = value === 'dark';
+    }
   });
 };
 


### PR DESCRIPTION
## Description

![Screen Shot 2022-03-03 at 12 57 53 AM](https://user-images.githubusercontent.com/6440455/156505325-8eb00645-abb7-4955-a579-0aa329141fd1.png)

- Highlight.js's theme was stuck in dark mode
  - This resulted in the `View Kubeconfig` drawer displaying the yaml in the wrong theme
- Bug was caused by #8040

## The Fix

- Check against the actual CSS values instead of an inline comment to disable each Highlight.js theme
  - We use to check for a comment in the CSS, but now that we use esbuild, comments are removed and we can't change that

## Evidence

### Before Webpack 5
![Screen Shot 2022-03-02 at 11 43 04 PM](https://user-images.githubusercontent.com/6440455/156505502-ba04f517-cef7-48e1-b531-6e94a1649ab3.png)

### After Webpack 5
![Screen Shot 2022-03-02 at 11 46 03 PM](https://user-images.githubusercontent.com/6440455/156505496-1b7cece3-3b53-485c-bc2a-4f4d9550aa0f.png)

## How to test

- Go to (or create) a Kubernetes Cluster
- View the Kube Config
- Ensure the yaml's theme matches and respects Cloud Manager's theme (Toggle themes with `control` `shift` `d`)
  - A slight delay in the yaml's theme is expected 
