### PR TITLE
M3-5490: Fix Linode Detail action colors in dark mode

### DIFF
--- a/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
+++ b/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
@@ -270,6 +270,7 @@ const useHeaderStyles = makeStyles((theme: Theme) => ({
   },
   actionItem: {
     borderRadius: 0,
+    color: theme.textColors.linkActiveLight,
     fontFamily: theme.font.normal,
     fontSize: '0.875rem',
     height: theme.spacing(5),


### PR DESCRIPTION
## Description

This PR makes the color of the "Power Off/On", "Reboot", and "Launch LISH Console" consistent with the ActionMenu in dark mode. 
<img width="394" alt="Screen Shot 2022-03-03 at 12 08 12 PM" src="https://user-images.githubusercontent.com/7692354/156615044-08a03f87-49ce-4a4d-9ae1-c070aea60d13.png">

## How to test

Go to any Linode Details page in dark mode
