### PR TITLE
Fix Storybook for Safari and Fix Favicon

### DIFF
--- a/packages/manager/.storybook/main.js
+++ b/packages/manager/.storybook/main.js
@@ -13,6 +13,7 @@ module.exports = {
     '@storybook/addon-controls',
     '@storybook/addon-viewport',
   ],
+  staticDirs: ['../public'],
   webpackFinal: (config) => {
     /**
      * Added logic to find svg config included with Storybook and tell it to excude all svgs.

--- a/packages/manager/.storybook/preview.tsx
+++ b/packages/manager/.storybook/preview.tsx
@@ -56,13 +56,3 @@ export const parameters = {
     viewports: MINIMAL_VIEWPORTS,
   },
 };
-
-// Use the Mock Service Worker to mock API requests.
-if (typeof global.process === 'undefined') {
-  try {
-    const { worker } = require('../src/mocks/testBrowser');
-    worker.start();
-  } catch (e) {
-    console.warn('Unable to start the MSW', e);
-  }
-}

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -106,7 +106,7 @@
     "precommit": "lint-staged && yarn typecheck",
     "test": "jest --color",
     "test:debug": "node --inspect-brk scripts/test.js --runInBand",
-    "storybook": "yarn run start-storybook -p 6006 --ci -s ./public",
+    "storybook": "yarn run start-storybook -p 6006 --ci",
     "storybook-static": "build-storybook -c .storybook -o .out",
     "storybook:e2e": "yarn run wait-on http://localhost:6006 && yarn run wdio ./e2e/config/wdio.storybook.conf.js",
     "build-storybook": "build-storybook",


### PR DESCRIPTION
## Description

- Removes the attempt to import the service worker at all. This was breaking production storybook for Safari
- Fixes favicon

## How to test

- This will work because I did a production build with Cloudflare Pages and it works now
  - https://b50bbf70.manager-ec2.pages.dev