### PR TITLE
M3-5644: Fix mismatching Marketplace drawers

### DIFF
--- a/packages/manager/src/features/OneClickApps/AppDetailDrawer.tsx
+++ b/packages/manager/src/features/OneClickApps/AppDetailDrawer.tsx
@@ -61,7 +61,7 @@ const styles = (theme: Theme) =>
   });
 
 interface Props {
-  stackscriptID: string;
+  stackScriptLabel: string;
   open: boolean;
   onClose: () => void;
 }
@@ -71,15 +71,14 @@ type CombinedProps = Props & WithStyles<ClassNames>;
 export const AppDetailDrawer: React.FunctionComponent<CombinedProps> = (
   props
 ) => {
-  const { classes, stackscriptID, open, onClose } = props;
-  const app = oneClickApps.find((eachApp) => {
-    const cleanedAppName = eachApp.name.replace(
-      /[-\/\\^$*+?.()|[\]{}]/g,
-      '\\$&'
-    );
-    const strippedAppName = cleanedAppName.replace('&reg;', '');
-    const regex = new RegExp(strippedAppName);
-    return Boolean(stackscriptID.match(regex));
+  const { classes, stackScriptLabel, open, onClose } = props;
+
+  const app = oneClickApps.find((app) => {
+    const cleanedStackScriptLabel = stackScriptLabel
+      .replace(/[^\w\s\/$*+-?.:()]/gi, '')
+      .trim();
+    const cleanedAppName = app.name.replace('&reg;', '');
+    return cleanedStackScriptLabel === cleanedAppName;
   }); // This is horrible
   if (!app) {
     return null;

--- a/packages/manager/src/features/OneClickApps/AppDetailDrawer.tsx
+++ b/packages/manager/src/features/OneClickApps/AppDetailDrawer.tsx
@@ -4,12 +4,7 @@ import Info from 'src/assets/icons/info.svg';
 import Link from 'src/assets/icons/moreInfo.svg';
 import Divider from 'src/components/core/Divider';
 import Grid from 'src/components/core/Grid';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles,
-} from 'src/components/core/styles';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Drawer from 'src/components/Drawer';
 import { APP_ROOT } from 'src/constants';
@@ -18,47 +13,36 @@ import { oneClickApps } from './FakeSpec';
 import LinkSection from './LinkSection';
 import TipSection from './TipSection';
 
-type ClassNames =
-  | 'logo'
-  | 'appName'
-  | 'summary'
-  | 'description'
-  | 'image'
-  | 'wrapLogo'
-  | 'wrapAppName';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    logo: {
-      marginRight: theme.spacing(1),
-    },
-    appName: {
-      fontSize: '2.0rem',
-      fontFamily: theme.font.normal,
-      color: theme.color.grey4,
-      lineHeight: '2.5rem',
-    },
-    summary: {
-      marginTop: theme.spacing(2),
-      marginBottom: theme.spacing(2),
-      textAlign: 'center',
-    },
-    description: {
-      lineHeight: 1.5,
-    },
-
-    image: {
-      maxWidth: 50,
-    },
-    wrapLogo: {
-      alignSelf: 'flex-start',
-      marginLeft: -theme.spacing(3),
-    },
-    wrapAppName: {
-      maxWidth: 'fit-content',
-      minWidth: 170,
-    },
-  });
+const useStyles = makeStyles((theme: Theme) => ({
+  logo: {
+    marginRight: theme.spacing(1),
+  },
+  appName: {
+    fontSize: '2.0rem',
+    fontFamily: theme.font.normal,
+    color: theme.color.grey4,
+    lineHeight: '2.5rem',
+  },
+  summary: {
+    marginTop: theme.spacing(2),
+    marginBottom: theme.spacing(2),
+    textAlign: 'center',
+  },
+  description: {
+    lineHeight: 1.5,
+  },
+  image: {
+    maxWidth: 50,
+  },
+  wrapLogo: {
+    alignSelf: 'flex-start',
+    marginLeft: -theme.spacing(3),
+  },
+  wrapAppName: {
+    maxWidth: 'fit-content',
+    minWidth: 170,
+  },
+}));
 
 interface Props {
   stackScriptLabel: string;
@@ -66,12 +50,9 @@ interface Props {
   onClose: () => void;
 }
 
-type CombinedProps = Props & WithStyles<ClassNames>;
-
-export const AppDetailDrawer: React.FunctionComponent<CombinedProps> = (
-  props
-) => {
-  const { classes, stackScriptLabel, open, onClose } = props;
+export const AppDetailDrawer: React.FunctionComponent<Props> = (props) => {
+  const { stackScriptLabel, open, onClose } = props;
+  const classes = useStyles();
 
   const app = oneClickApps.find((app) => {
     const cleanedStackScriptLabel = stackScriptLabel
@@ -155,6 +136,4 @@ export const AppDetailDrawer: React.FunctionComponent<CombinedProps> = (
   );
 };
 
-const styled = withStyles(styles);
-
-export default styled(AppDetailDrawer);
+export default AppDetailDrawer;

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -221,7 +221,7 @@ class FromAppsContent extends React.PureComponent<CombinedProps, State> {
 
         <AppDetailDrawer
           open={this.state.detailDrawerOpen}
-          stackscriptID={this.state.selectedScriptForDrawer}
+          stackScriptLabel={this.state.selectedScriptForDrawer}
           onClose={this.closeDrawer}
         />
       </React.Fragment>


### PR DESCRIPTION
## Description
Fix LiteSpeed cPanel drawer opening the cPanel drawer & OpenLiteSpeed Django drawer opening the Django drawer instead of the LiteSpeed versions.

This was due to the `cPanel` and `Django` apps being matched first and returning true before we get to their LiteSpeed versions. So, I updated the find function to find exact matches instead.

## How to test
Go to Marketplace and check that:
- LiteSpeed cPanel opens the LiteSpeed cPanel drawer
- OpenLiteSpeed Django opens the OpenLiteSpeed Django drawer
- Apps with special characters still open their drawers (Minecraft: Java Edition, MySQL/MariaDB, Percona (PPM), Rocket.Chat, WireGuard®)
