### PR TITLE
Disable Cypress recording for PR end-to-end tests

### DIFF
--- a/.github/workflows/e2e_pr.yml
+++ b/.github/workflows/e2e_pr.yml
@@ -58,5 +58,5 @@ jobs:
           install: false
           browser: chrome
           headless: true
-          record: true
+          record: false
           parallel: true


### PR DESCRIPTION
## Description

**What does this PR do?**
This disables the recording of Cypress runs for end-to-end tests run on PRs. End-to-end tests that run upon pushing to `develop`, `staging`, and `master`, as well as scheduled tests that run each morning, will continue to be recorded.

We're approaching our monthly limit for test recordings on Cypress.io and thought this would be a workable compromise. If anybody relies on the Cypress.io test recordings for PRs, please let me know!