### PR TITLE
Fix hover state for Linode Detail header copy icon on Safari

### DIFF
--- a/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
+++ b/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
@@ -633,37 +633,40 @@ const useAccessTableStyles = makeStyles((theme: Theme) => ({
       width: 170,
     },
     '& td': {
-      backgroundColor: theme.bg.bgAccessRow,
       border: 'none',
       borderBottom: `1px solid ${theme.bg.bgPaper}`,
       fontSize: '0.875rem',
       lineHeight: 1,
-      padding: theme.spacing(),
       whiteSpace: 'nowrap',
     },
   },
   code: {
+    backgroundColor: theme.bg.bgAccessRow,
     color: theme.textColors.tableStatic,
     fontFamily: '"UbuntuMono", monospace, sans-serif',
+    padding: theme.spacing(),
     position: 'relative',
     '& div': {
       fontSize: 15,
     },
   },
   copyCell: {
-    width: 36,
+    backgroundColor: theme.bg.lightBlue2,
     height: 33,
-    backgroundColor: `${theme.bg.lightBlue2} !important`,
-    padding: '0px !important',
+    width: 36,
+    padding: 0,
     '& svg': {
-      width: 16,
       height: 16,
+      width: 16,
       '& path': {
         fill: theme.textColors.linkActiveLight,
       },
     },
-    '&:last-child': {
-      paddingRight: theme.spacing(),
+    '&:hover': {
+      backgroundColor: '#3683dc',
+      '& svg path': {
+        fill: '#fff',
+      },
     },
   },
   copyButton: {
@@ -674,10 +677,7 @@ const useAccessTableStyles = makeStyles((theme: Theme) => ({
     height: '100%',
     width: '100%',
     '&:hover': {
-      backgroundColor: '#3683dc',
-      '& svg path': {
-        fill: '#fff',
-      },
+      backgroundColor: 'transparent',
     },
   },
   gradient: {


### PR DESCRIPTION
## Description

Fixes the background not covering the copy cell during hover **on Safari**. This PR also cleans up the CSS by removing usages of `!important` which were related to the issue

## How to test

Check out the copy icon on the Linode Detail header on Chrome and Safari (and Firefox if you prefer)
