### PR TITLE
[Hotfix] Add EAP SLA dismissible banners to Database Create & empty state Landing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2022-03-08] - v1.61.1
+
+### Added:
+
+- Early Adopter Program SLA banners to Database Create and empty state Database landing pages for beta
+
 ## [2022-03-07] - v1.61.0
 
 ### Added:

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.61.0",
+  "version": "1.61.1",
   "private": true,
   "engines": {
     "node": ">= 14.17.4"

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -55,6 +55,7 @@ import {
   validateIPs,
 } from 'src/utilities/ipUtils';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
+import DismissibleBanner from 'src/components/DismissibleBanner';
 
 const useStyles = makeStyles((theme: Theme) => ({
   formControlLabel: {
@@ -416,6 +417,20 @@ const DatabaseCreate: React.FC<{}> = () => {
 
   return (
     <form onSubmit={handleSubmit}>
+      <DismissibleBanner
+        preferenceKey="dbaas-open-beta-notice"
+        productInformationIndicator
+      >
+        <Typography>
+          Managed Database for MySQL is available in a free, open beta period.
+          This is a beta environment and should not be used to support
+          production workloads. Review the{' '}
+          <Link to="https://www.linode.com/legal-eatp">
+            Early Adopter Program SLA
+          </Link>
+          .
+        </Typography>
+      </DismissibleBanner>
       <BreadCrumb
         labelTitle="Create"
         pathname={location.pathname}

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseEmptyState.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseEmptyState.tsx
@@ -3,6 +3,7 @@ import { useHistory } from 'react-router-dom';
 import DatabaseIcon from 'src/assets/icons/entityIcons/database.svg';
 import { makeStyles } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
+import DismissibleBanner from 'src/components/DismissibleBanner';
 import Link from 'src/components/Link';
 import Placeholder from 'src/components/Placeholder';
 
@@ -22,28 +23,44 @@ const DatabaseEmptyState: React.FC = () => {
   const history = useHistory();
 
   return (
-    <Placeholder
-      title="Databases"
-      className={classes.root}
-      icon={DatabaseIcon}
-      isEntity
-      buttonProps={[
-        {
-          onClick: () => history.push('/databases/create'),
-          children: 'Create Database Cluster',
-        },
-      ]}
-    >
-      <Typography variant="subtitle1">
-        <div className={classes.entityDescription}>
-          Fully managed and highly scalable Database Clusters. Choose your
-          Linode plan, select a database engine, and deploy in minutes.
-        </div>
-        <Link to="https://www.linode.com/docs/products/databases/managed-databases/">
-          Need help getting started? Browse database guides.
-        </Link>
-      </Typography>
-    </Placeholder>
+    <>
+      <DismissibleBanner
+        preferenceKey="dbaas-open-beta-notice"
+        productInformationIndicator
+      >
+        <Typography>
+          Managed Database for MySQL is available in a free, open beta period.
+          This is a beta environment and should not be used to support
+          production workloads. Review the{' '}
+          <Link to="https://www.linode.com/legal-eatp">
+            Early Adopter Program SLA
+          </Link>
+          .
+        </Typography>
+      </DismissibleBanner>
+      <Placeholder
+        title="Databases"
+        className={classes.root}
+        icon={DatabaseIcon}
+        isEntity
+        buttonProps={[
+          {
+            onClick: () => history.push('/databases/create'),
+            children: 'Create Database Cluster',
+          },
+        ]}
+      >
+        <Typography variant="subtitle1">
+          <div className={classes.entityDescription}>
+            Fully managed and highly scalable Database Clusters. Choose your
+            Linode plan, select a database engine, and deploy in minutes.
+          </div>
+          <Link to="https://www.linode.com/docs/products/databases/managed-databases/">
+            Need help getting started? Browse database guides.
+          </Link>
+        </Typography>
+      </Placeholder>
+    </>
   );
 };
 


### PR DESCRIPTION
## Description
Adds dismissible banners containing copy on the Early Adopter Program SLA to the Database Create & empty state Landing page for beta.

## How to test
Check both the Database Create page and the empty state Database Landing page to confirm the banners display. When either is dismissed, the other should no longer be seen. The banner should not be visible on the landing page in the non-empty state.
