### PR TITLE
Patch: restricted users without billing access cannot use the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - Early Adopter Program SLA banners to Database Create and empty state Database landing pages for beta
 
+### Fixed:
+
+- Fixed issue where limited users without billing access could not use the app
+
 ## [2022-03-07] - v1.61.0
 
 ### Added:
@@ -20,7 +24,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Changed:
 
 - Drupal Marketplace app logo
-- Feedback link 
+- Feedback link
 - Improve styling consistency for backup auto enrollment
 - Replaced copy icon and added copy tooltip on hover
 
@@ -40,7 +44,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Linode Details action link colors in dark mode
 - Linode Details Configurations table alignment
 
-
 ## [2022-02-25] - v1.60.1
 
 ### Added:
@@ -50,14 +53,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [2022-02-21] - v1.60.0
 
 ### Added:
+
 - Copy IP address tooltip in the Linode Networking tab
 - February 2022 Marketplace release
 
 ### Changed:
+
 - Update Storybook components
 - Glish URL root from “alpha” to “dev”
 
 ### Fixed:
+
 - Prevent previous saved support text from loading into a ticket reply
 
 ## [2022-02-14] - v1.59.1

--- a/packages/manager/src/IdentifyUser.tsx
+++ b/packages/manager/src/IdentifyUser.tsx
@@ -87,7 +87,7 @@ export const IdentifyUser: React.FC<{}> = () => {
           .catch(() => setFeatureFlagsLoaded());
       }
     }
-  }, [client, userID, username, account]);
+  }, [client, userID, username, account, accountError]);
 
   return null;
 };

--- a/packages/manager/src/queries/account.ts
+++ b/packages/manager/src/queries/account.ts
@@ -10,11 +10,10 @@ import { mutationHandlers, queryPresets } from './base';
 export const queryKey = 'account';
 
 export const useAccount = () =>
-  useQuery<Account, APIError[]>(
-    queryKey,
-    getAccountInfo,
-    queryPresets.oneTimeFetch
-  );
+  useQuery<Account, APIError[]>(queryKey, getAccountInfo, {
+    ...queryPresets.oneTimeFetch,
+    retry: false,
+  });
 
 export const useMutateAccount = () => {
   return useMutation<Account, APIError[], Partial<Account>>((data) => {

--- a/packages/manager/src/queries/account.ts
+++ b/packages/manager/src/queries/account.ts
@@ -12,7 +12,7 @@ export const queryKey = 'account';
 export const useAccount = () =>
   useQuery<Account, APIError[]>(queryKey, getAccountInfo, {
     ...queryPresets.oneTimeFetch,
-    retry: false,
+    ...queryPresets.noRetry,
   });
 
 export const useMutateAccount = () => {

--- a/packages/manager/src/queries/accountAgreements.ts
+++ b/packages/manager/src/queries/accountAgreements.ts
@@ -11,11 +11,10 @@ import { queryPresets, simpleMutationHandlers } from './base';
 export const queryKey = 'account-agreements';
 
 export const useAccountAgreements = () =>
-  useQuery<Agreements, APIError[]>(
-    queryKey,
-    getAccountAgreements,
-    queryPresets.oneTimeFetch
-  );
+  useQuery<Agreements, APIError[]>(queryKey, getAccountAgreements, {
+    ...queryPresets.oneTimeFetch,
+    ...queryPresets.noRetry,
+  });
 
 export const useMutateAccountAgreements = () => {
   return useMutation<{}, APIError[], Partial<Agreements>>(

--- a/packages/manager/src/queries/accountSettings.ts
+++ b/packages/manager/src/queries/accountSettings.ts
@@ -10,11 +10,10 @@ import { queryClient, queryPresets } from './base';
 export const queryKey = 'account-settings';
 
 export const useAccountSettings = () =>
-  useQuery<AccountSettings, APIError[]>(
-    queryKey,
-    getAccountSettings,
-    queryPresets.oneTimeFetch
-  );
+  useQuery<AccountSettings, APIError[]>(queryKey, getAccountSettings, {
+    ...queryPresets.oneTimeFetch,
+    ...queryPresets.noRetry,
+  });
 
 export const useMutateAccountSettings = () => {
   return useMutation<AccountSettings, APIError[], Partial<AccountSettings>>(

--- a/packages/manager/src/queries/base.ts
+++ b/packages/manager/src/queries/base.ts
@@ -5,7 +5,7 @@ import { isEmpty } from '@linode/api-v4/lib/request';
 // =============================================================================
 // Config
 // =============================================================================
-type QueryConfigTypes = 'shortLived' | 'longLived' | 'oneTimeFetch';
+type QueryConfigTypes = 'shortLived' | 'longLived' | 'oneTimeFetch' | 'noRetry';
 
 export const queryPresets: Record<QueryConfigTypes, UseQueryOptions<any>> = {
   shortLived: {
@@ -23,6 +23,9 @@ export const queryPresets: Record<QueryConfigTypes, UseQueryOptions<any>> = {
   oneTimeFetch: {
     staleTime: Infinity,
     cacheTime: Infinity,
+  },
+  noRetry: {
+    retry: false,
   },
 };
 


### PR DESCRIPTION
## Description

**What does this PR do?**
This adds `accountError` to the dependency array of the effect that "identifies" a user with LD and sets feature flags to "loaded" (thus letting users past the splash screen).

This caused an issue in production where restricted users without billing access (i.e. access to `/account`) could not load the app.

It seems to have been introduced in the Webpack 5 PR, but it is entirely unclear why to me why that is the case. In fact, it's unclear to me why this _ever_ worked (without `accountError` in the dependency array.)

I also changed "retry: false" on the account query so the page would load faster for restricted users. This _may_ have other effects that we should look into.

## How to test

**What are the steps to reproduce the issue or verify the changes?**

Run the app as a full user and as a restricted user.

**How do I run relevant unit tests?**
