### PR TITLE
Disable Cypress parallelization on PRs while recording is disabled

### DIFF
--- a/.github/workflows/e2e_pr.yml
+++ b/.github/workflows/e2e_pr.yml
@@ -15,7 +15,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        user: ["USER_1", "USER_2", "USER_3", "USER_4"]
+        # user: ["USER_1", "USER_2", "USER_3", "USER_4"]
+        user: ["USER_1"]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/e2e_pr.yml
+++ b/.github/workflows/e2e_pr.yml
@@ -59,4 +59,4 @@ jobs:
           browser: chrome
           headless: true
           record: false
-          parallel: true
+          parallel: false


### PR DESCRIPTION
## Description

**What does this PR do?**
This disables Cypress parallelization for PR E2E tests. This is a temporary measure while Cypress recording is disabled as parallelization is only supported while recording is enabled. In our current state we're getting test failures ([example](https://github.com/linode/manager/runs/5486158088?check_suite_focus=true)).

This will slow down Cypress tests on PRs. Hopefully we'll upgrade our Cypress account soon so that we can reverse this and related changes.

See also PR #8259 

