### PR TITLE
M3-5604: Clean up payment method code

### DIFF
--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PayPalButton.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PayPalButton.tsx
@@ -183,7 +183,10 @@ export const PayPalButton: React.FC<Props> = (props) => {
     }
   };
 
-  const onError = (error: Record<string, unknown>) => {
+  const onError = (error: any) => {
+    if (error?.message?.includes('popup close')) {
+      return;
+    }
     reportException(
       'An error occurred when trying to make a one-time PayPal payment.',
       { error }

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentMethodCard.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentMethodCard.tsx
@@ -1,0 +1,137 @@
+import { PaymentMethod, PaymentType } from '@linode/api-v4';
+import classNames from 'classnames';
+import * as React from 'react';
+import Chip from 'src/components/core/Chip';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import Grid from 'src/components/Grid';
+import {
+  getIcon as getTPPIcon,
+  thirdPartyPaymentMap,
+} from 'src/components/PaymentMethodRow/ThirdPartyPayment';
+import SelectionCard from 'src/components/SelectionCard';
+import { getIcon as getCreditCardIcon } from 'src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCard';
+import isCreditCardExpired, { formatExpiry } from 'src/utilities/creditCard';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  paymentMethod: {
+    marginBottom: theme.spacing(),
+  },
+  selectionCard: {
+    minWidth: '100%',
+    padding: 0,
+    marginBottom: theme.spacing(),
+    '& .cardBaseGrid': {
+      flexWrap: 'nowrap',
+    },
+    '& .cardBaseIcon': {
+      width: 45,
+      padding: 0,
+      justifyContent: 'center',
+    },
+    '& .cardBaseHeadings': {
+      flex: 'inherit',
+    },
+  },
+  expired: {
+    '& .cardBaseSubHeading': {
+      color: theme.color.red,
+    },
+  },
+  chip: {
+    '& span': {
+      color: 'inherit !important',
+      fontSize: '0.625rem',
+    },
+  },
+}));
+
+interface Props {
+  paymentMethod: PaymentMethod;
+  paymentMethodId: number;
+  handlePaymentMethodChange: (id: number, cardExpired: boolean) => void;
+}
+
+const getIsCardExpired = (paymentMethod: PaymentMethod) => {
+  if (paymentMethod.type === 'paypal') {
+    return false;
+  }
+  return Boolean(
+    paymentMethod.data.expiry && isCreditCardExpired(paymentMethod.data.expiry)
+  );
+};
+
+const getIcon = (paymentMethod: PaymentMethod) => {
+  // eslint-disable-next-line sonarjs/no-small-switch
+  switch (paymentMethod.type) {
+    case 'credit_card':
+      return getCreditCardIcon(paymentMethod.data.card_type);
+    default:
+      return getTPPIcon(paymentMethod.type);
+  }
+};
+
+const getHeading = (paymentMethod: PaymentMethod, type: PaymentType) => {
+  switch (paymentMethod.type) {
+    case 'paypal':
+      return thirdPartyPaymentMap[type].label;
+    case 'google_pay':
+      return `${thirdPartyPaymentMap[type].label} ${paymentMethod.data.card_type} ****${paymentMethod.data.last_four}`;
+    default:
+      return `${paymentMethod.data.card_type} ****${paymentMethod.data.last_four}`;
+  }
+};
+
+const getSubHeading = (paymentMethod: PaymentMethod, isExpired: boolean) => {
+  // eslint-disable-next-line sonarjs/no-small-switch
+  switch (paymentMethod.type) {
+    case 'paypal':
+      return paymentMethod.data.email;
+    default:
+      return `${isExpired ? 'Expired' : 'Expires'} ${formatExpiry(
+        paymentMethod.data.expiry ?? ''
+      )}`;
+  }
+};
+
+export const PaymentMethodCard: React.FC<Props> = (props) => {
+  const { paymentMethod, paymentMethodId, handlePaymentMethodChange } = props;
+  const { id, type, is_default } = paymentMethod;
+
+  const classes = useStyles();
+
+  const heading = getHeading(paymentMethod, type);
+  const cardIsExpired = getIsCardExpired(paymentMethod);
+  const subHeading = getSubHeading(paymentMethod, cardIsExpired);
+
+  const renderIcon = () => {
+    const Icon = getIcon(paymentMethod);
+    return <Icon />;
+  };
+
+  const renderVariant = () => {
+    return is_default ? (
+      <Grid item className={classes.chip} xs={3} md={2}>
+        <Chip label="DEFAULT" component="span" />
+      </Grid>
+    ) : null;
+  };
+
+  return (
+    <Grid className={classes.paymentMethod}>
+      <SelectionCard
+        className={classNames({
+          [classes.selectionCard]: true,
+          [classes.expired]: cardIsExpired,
+        })}
+        checked={id === paymentMethodId}
+        onClick={() => handlePaymentMethodChange(id, cardIsExpired)}
+        renderIcon={renderIcon}
+        renderVariant={renderVariant}
+        heading={heading}
+        subheadings={[subHeading]}
+      />
+    </Grid>
+  );
+};
+
+export default PaymentMethodCard;

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PayPalChip.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PayPalChip.tsx
@@ -138,7 +138,10 @@ export const PayPalChip: React.FC<Props> = (props) => {
       });
   };
 
-  const onError = (error: unknown) => {
+  const onError = (error: any) => {
+    if (error?.message?.includes('popup close')) {
+      return;
+    }
     reportException(
       'A PayPal error occurred preventing a user from adding PayPal as a payment method.',
       { error }


### PR DESCRIPTION
## Description
- Added PaymentMethodCard component for displaying payment method cards
- Don't report popup closed errors to Sentry
    - There's no exact way to reproduce this. The one time I did get this error, the payment went through anyway. I was also unable to find more info on this specific error so I think we can go ahead and filter these out
- Removed unused classes

## How to test
Go to `/account/billing/make-payment` and ensure the payment methods still display correctly