### PR TITLE
M3-5743: Editable DBaaS cluster labels

### DIFF
--- a/packages/manager/src/features/Databases/DatabaseDetail/index.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/index.tsx
@@ -1,22 +1,35 @@
+import { Engine } from '@linode/api-v4/lib/databases/types';
+import { APIError } from '@linode/api-v4/lib/types';
 import * as React from 'react';
+import { matchPath, useHistory, useParams } from 'react-router-dom';
 import Breadcrumb from 'src/components/Breadcrumb';
 import CircleProgress from 'src/components/CircleProgress';
 import TabPanels from 'src/components/core/ReachTabPanels';
 import Tabs from 'src/components/core/ReachTabs';
+import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import ErrorState from 'src/components/ErrorState';
 import SafeTabPanel from 'src/components/SafeTabPanel';
 import TabLinkList from 'src/components/TabLinkList';
-import { matchPath, useHistory, useParams } from 'react-router-dom';
-import { DocumentTitleSegment } from 'src/components/DocumentTitle';
-import { useDatabaseQuery, useDatabaseTypesQuery } from 'src/queries/databases';
+import withEditableLabelState, {
+  EditableLabelProps,
+} from 'src/features/linodes/LinodesDetail/LinodesDetailHeader/editableLabelState';
+import {
+  useDatabaseMutation,
+  useDatabaseQuery,
+  useDatabaseTypesQuery,
+} from 'src/queries/databases';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
-import { Engine } from '@linode/api-v4/lib/databases/types';
 
 const DatabaseSummary = React.lazy(() => import('./DatabaseSummary'));
 const DatabaseBackups = React.lazy(() => import('./DatabaseBackups'));
 const DatabaseSettings = React.lazy(() => import('./DatabaseSettings'));
 
-export const DatabaseDetail: React.FC = () => {
+export const DatabaseDetail: React.FC<EditableLabelProps> = (props) => {
+  const {
+    resetEditableLabel,
+    setEditableLabelError,
+    editableLabelError,
+  } = props;
   const history = useHistory();
 
   const { databaseId, engine } = useParams<{
@@ -28,6 +41,8 @@ export const DatabaseDetail: React.FC = () => {
 
   const { data: database, isLoading, error } = useDatabaseQuery(engine, id);
   const { isLoading: isTypesLoading } = useDatabaseTypesQuery();
+
+  const { mutateAsync: updateDatabase } = useDatabaseMutation(engine, id);
 
   if (error) {
     return (
@@ -81,6 +96,24 @@ export const DatabaseDetail: React.FC = () => {
     history.push(tabs[index].routeName);
   };
 
+  const handleSubmitLabelChange = (newLabel: string) => {
+    return updateDatabase({ allow_list: database.allow_list, label: newLabel })
+      .then(() => {
+        resetEditableLabel();
+      })
+      .catch((err) => {
+        const errors: APIError[] = getAPIErrorOrDefault(
+          err,
+          'An error occurred while updating label',
+          'label'
+        );
+
+        const errorStrings: string[] = errors.map((e) => e.reason);
+        setEditableLabelError(errorStrings[0]);
+        return Promise.reject(errorStrings[0]);
+      });
+  };
+
   return (
     <>
       <DocumentTitleSegment segment={database.label} />
@@ -95,6 +128,12 @@ export const DatabaseDetail: React.FC = () => {
           },
         ]}
         labelOptions={{ noCap: true }}
+        onEditHandlers={{
+          editableTextTitle: database.label,
+          onEdit: handleSubmitLabelChange,
+          onCancel: resetEditableLabel,
+          errorText: editableLabelError,
+        }}
       />
       <Tabs index={getTabIndex()} onChange={handleTabChange}>
         <TabLinkList tabs={tabs} />
@@ -114,4 +153,4 @@ export const DatabaseDetail: React.FC = () => {
   );
 };
 
-export default DatabaseDetail;
+export default withEditableLabelState(DatabaseDetail);

--- a/packages/manager/src/features/Databases/DatabaseDetail/index.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/index.tsx
@@ -97,6 +97,7 @@ export const DatabaseDetail: React.FC<EditableLabelProps> = (props) => {
   };
 
   const handleSubmitLabelChange = (newLabel: string) => {
+    // @TODO Update this to only send the label when the API supports it
     return updateDatabase({ allow_list: database.allow_list, label: newLabel })
       .then(() => {
         resetEditableLabel();


### PR DESCRIPTION
## Description
Similar to Linodes, LKE, etc., the labels of DBaaS clusters are now editable from the breadcrumb on the Database Detail page.

## How to test
Please test the success flow and also the error flow by blocking requests to `/database` before attempting to submit the label change.
