### PR TITLE
Re-enable Cypress recording

### DIFF
--- a/.github/workflows/e2e_pr.yml
+++ b/.github/workflows/e2e_pr.yml
@@ -58,5 +58,5 @@ jobs:
           install: false
           browser: chrome
           headless: true
-          record: false
+          record: true
           parallel: true


### PR DESCRIPTION
## Description

**What does this PR do?**
This will re-enable Cypress test recording so that test results are once again published to Cypress Dashboard. This will also resolve the consistent failures we've been seeing for PR E2E tests over the past few days.

This can be merged any time on or after March 14th.
