### PR TITLE
M3-5514: Dynamically-shown warning for raw disks in Capture Image tab

### DIFF
--- a/packages/manager/src/components/Notice/Notice.tsx
+++ b/packages/manager/src/components/Notice/Notice.tsx
@@ -128,7 +128,7 @@ interface Props extends GridProps {
   flag?: boolean;
   notificationList?: boolean;
   spacingTop?: 0 | 8 | 16 | 24;
-  spacingBottom?: 0 | 8 | 16 | 20 | 24;
+  spacingBottom?: 0 | 8 | 16 | 20 | 24 | 32;
   breakWords?: boolean;
   onClick?: (e: React.MouseEvent<HTMLElement>) => void;
   // Dismissible Props

--- a/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
@@ -44,6 +44,12 @@ const useStyles = makeStyles((theme: Theme) => ({
       justifyContent: 'flex-end',
     },
   },
+  rawDiskWarning: {
+    marginTop: '1rem !important',
+    marginBottom: '1rem !important',
+    width: '100%',
+    maxWidth: '425px',
+  },
 }));
 
 export interface Props {
@@ -177,6 +183,15 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
     'GB'
   );
 
+  const isRawDisk = selectedDiskData?.filesystem === 'raw';
+  const rawDiskWarning = (
+    <Notice
+      className={classes.rawDiskWarning}
+      warning
+      text={rawDiskWarningText}
+    />
+  );
+
   const hasErrorFor = getAPIErrorFor(
     {
       linode_id: 'Linode',
@@ -235,16 +250,16 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
           disabled={!canCreateImage}
           data-qa-disk-select
         />
-        <Typography className={classes.helperText} variant="body1">
-          {`Estimated: ${calculateCostFromUnitPrice(
-            0.1,
-            selectedDiskSizeInGB
-          )}/month`}
-        </Typography>
-        <Typography className={classes.helperText} variant="body1">
-          Linode Images cannot be created if you are using raw disks or disks
-          that have been formatted using custom filesystems.
-        </Typography>
+        {isRawDisk ? (
+          rawDiskWarning
+        ) : (
+          <Typography className={classes.helperText} variant="body1">
+            {`Estimated: ${calculateCostFromUnitPrice(
+              0.1,
+              selectedDiskSizeInGB
+            )}/month`}
+          </Typography>
+        )}
       </>
 
       <>
@@ -294,3 +309,6 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
 export default compose<Props & ImagesDispatch, Props>(withImages())(
   CreateImageTab
 );
+
+const rawDiskWarningText =
+  'Using a raw disk may fail, as Linode Images cannot be created from disks formatted with custom filesystems.';

--- a/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
@@ -46,9 +46,13 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   rawDiskWarning: {
     marginTop: '1rem !important',
-    marginBottom: '1rem !important',
+    marginBottom: '2rem !important',
     width: '100%',
     maxWidth: '425px',
+  },
+  diskAndPrice: {
+    display: 'flex',
+    alignItems: 'flex-end',
   },
 }));
 
@@ -240,7 +244,7 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
         ]}
       />
 
-      <>
+      <div className={classes.diskAndPrice}>
         <DiskSelect
           selectedDisk={selectedDisk}
           disks={disks}
@@ -250,18 +254,16 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
           disabled={!canCreateImage}
           data-qa-disk-select
         />
-        {isRawDisk ? (
-          rawDiskWarning
-        ) : (
+        {selectedDiskData?.size ? (
           <Typography className={classes.helperText} variant="body1">
             {`Estimated: ${calculateCostFromUnitPrice(
               0.1,
               selectedDiskSizeInGB
             )}/month`}
           </Typography>
-        )}
-      </>
-
+        ) : null}
+      </div>
+      {isRawDisk ? rawDiskWarning : null}
       <>
         <TextField
           label="Label"

--- a/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
@@ -26,9 +26,6 @@ import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 import { convertStorageUnit } from 'src/utilities/unitConversions';
 
 const useStyles = makeStyles((theme: Theme) => ({
-  helperText: {
-    paddingTop: theme.spacing(1) / 2,
-  },
   container: {
     padding: theme.spacing(3),
     paddingTop: theme.spacing(2),
@@ -45,14 +42,17 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
   },
   rawDiskWarning: {
-    marginTop: '1rem !important',
-    marginBottom: '2rem !important',
+    maxWidth: 600,
     width: '100%',
-    maxWidth: '425px',
   },
   diskAndPrice: {
-    display: 'flex',
-    alignItems: 'flex-end',
+    '& > div': {
+      width: 415,
+    },
+  },
+  helperText: {
+    marginBottom: theme.spacing(),
+    marginLeft: theme.spacing(1.5),
   },
 }));
 
@@ -191,6 +191,8 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
   const rawDiskWarning = (
     <Notice
       className={classes.rawDiskWarning}
+      spacingTop={16}
+      spacingBottom={32}
       warning
       text={rawDiskWarningText}
     />
@@ -244,7 +246,11 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
         ]}
       />
 
-      <div className={classes.diskAndPrice}>
+      <Box
+        display="flex"
+        alignItems="flex-end"
+        className={classes.diskAndPrice}
+      >
         <DiskSelect
           selectedDisk={selectedDisk}
           disks={disks}
@@ -256,13 +262,11 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
         />
         {selectedDiskData?.size ? (
           <Typography className={classes.helperText} variant="body1">
-            {`Estimated: ${calculateCostFromUnitPrice(
-              0.1,
-              selectedDiskSizeInGB
-            )}/month`}
+            Estimated: {calculateCostFromUnitPrice(0.1, selectedDiskSizeInGB)}
+            /month
           </Typography>
         ) : null}
-      </div>
+      </Box>
       {isRawDisk ? rawDiskWarning : null}
       <>
         <TextField

--- a/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
@@ -53,6 +53,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   helperText: {
     marginBottom: theme.spacing(),
     marginLeft: theme.spacing(1.5),
+    whiteSpace: 'nowrap',
   },
 }));
 


### PR DESCRIPTION
## Description
Replace the static `Linode Images cannot be created if you are using raw disks or disks that have been formatted using custom filesystems.` text on the Capture Image tab in the Image Create flow with a warning notice that displays only if the chosen disk is a raw disk. If the warning notice is being displayed, the estimated price also does not display.

## How to test
From the "Capture Image" tab in the Image Create flow, choose a Linode that you have a raw disk added to. Then select that raw disk. The warning notice should display. If you choose a different, non-raw disk, or choose a different Linode, the warning should disappear.
