### PR TITLE
M3-5727: Remove manage SSH keys link

### DIFF
--- a/packages/manager/src/components/AccessPanel/UserSSHKeyPanel.tsx
+++ b/packages/manager/src/components/AccessPanel/UserSSHKeyPanel.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Link } from 'react-router-dom';
 import Button from 'src/components/Button';
 import CheckBox from 'src/components/CheckBox';
 import { makeStyles, Theme } from 'src/components/core/styles';
@@ -97,10 +96,7 @@ const UserSSHKeyPanel: React.FC<CombinedProps> = (props) => {
       </Typography>
       {success && (
         <Notice success data-testid="ssh-success-message">
-          <Typography>
-            SSH key added successfully.{' '}
-            <Link to="/profile/keys">Click here</Link> to manage your keys.
-          </Typography>
+          <Typography>SSH key added successfully.</Typography>
         </Notice>
       )}
       <Table spacingBottom={16}>


### PR DESCRIPTION
## Description
Removes the manage SSH keys link from the `UserSSHKeyPanel` success notice

<img width="259" alt="image" src="https://user-images.githubusercontent.com/14323019/158877930-b397fa56-a173-44c3-bbc6-c109b8082d12.png">

## How to test
Create an SSH key (e.g. in the Linode Create flow) and the link should no longer display in the success notice
