### PR TITLE
StackScript Fixes

### DIFF
--- a/packages/manager/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/packages/manager/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -25,7 +25,6 @@ import Table from 'src/components/Table';
 import withProfile, { ProfileProps } from 'src/components/withProfile';
 import { formatDate } from 'src/utilities/formatDate';
 import { getParamFromUrl } from 'src/utilities/queryParams';
-import stripImageName from 'src/utilities/stripImageName';
 import { truncate } from 'src/utilities/truncate';
 import StackScriptTableHead from '../Partials/StackScriptTableHead';
 import SelectStackScriptPanelContent from './SelectStackScriptPanelContent';
@@ -178,7 +177,6 @@ class SelectStackScriptPanel extends React.Component<CombinedProps, State> {
                   stackScriptUsername={stackScript.username}
                   disabledCheckedSelect
                   description={truncate(stackScript.description, 100)}
-                  images={stripImageName(stackScript.images)}
                   deploymentsActive={stackScript.deployments_active}
                   updated={formatDate(stackScript.updated, {
                     displayTime: false,

--- a/packages/manager/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptsSection.tsx
+++ b/packages/manager/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptsSection.tsx
@@ -7,7 +7,6 @@ import TableBody from 'src/components/core/TableBody';
 import TableCell from 'src/components/core/TableCell';
 import TableRow from 'src/components/TableRow';
 import { formatDate } from 'src/utilities/formatDate';
-import stripImageName from 'src/utilities/stripImageName';
 import { truncate } from 'src/utilities/truncate';
 import StackScriptSelectionRow from './StackScriptSelectionRow';
 
@@ -40,7 +39,6 @@ export const SelectStackScriptsSection: React.FC<CombinedProps> = (props) => {
       label={s.label}
       stackScriptUsername={s.username}
       description={truncate(s.description, 100)}
-      images={stripImageName(s.images)}
       deploymentsActive={s.deployments_active}
       updated={formatDate(s.updated, { displayTime: false })}
       onSelect={() => onSelect(s)}

--- a/packages/manager/src/features/StackScripts/SelectStackScriptPanel/StackScriptSelectionRow.tsx
+++ b/packages/manager/src/features/StackScripts/SelectStackScriptPanel/StackScriptSelectionRow.tsx
@@ -15,7 +15,6 @@ import { ClassNames, styles } from '../StackScriptRowHelpers';
 export interface Props {
   label: string;
   description: string;
-  images: string[];
   deploymentsActive: number;
   updated: string;
   disabledCheckedSelect?: boolean;

--- a/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptRow.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptRow.tsx
@@ -106,7 +106,7 @@ export const StackScriptRow: React.FC<CombinedProps> = (props) => {
           </TableCell>
         </Hidden>
       )}
-      <TableCell actionCell>
+      <TableCell actionCell className={classes.row}>
         <StackScriptsActionMenu
           stackScriptID={stackScriptID}
           stackScriptUsername={stackScriptUsername}

--- a/packages/manager/src/features/StackScripts/StackScriptRowHelpers.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptRowHelpers.tsx
@@ -20,6 +20,9 @@ export const styles = (theme: Theme) =>
   createStyles({
     row: {
       height: 46,
+      '& > button': {
+        height: 46,
+      },
     },
     link: {
       color: theme.textColors.tableStatic,

--- a/packages/manager/src/features/StackScripts/StackScriptRowHelpers.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptRowHelpers.tsx
@@ -55,6 +55,7 @@ export const styles = (theme: Theme) =>
       },
     },
     selectionGrid: {
+      width: '100%',
       flexWrap: 'nowrap',
       alignItems: 'center',
       justifyContent: 'space-between',

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -220,7 +220,7 @@ export class LinodeCreate extends React.PureComponent<
     this.state = {
       selectedTab: preSelectedTab !== -1 ? preSelectedTab : 0,
       stackScriptSelectedTab:
-        preSelectedTab === 2 && location.search.search('Account') > -1 ? 1 : 0,
+        preSelectedTab === 2 && location.search.search('Account') > -1 ? 0 : 1,
       planKey: v4(),
     };
   }

--- a/packages/manager/src/store/image/image.helpers.ts
+++ b/packages/manager/src/store/image/image.helpers.ts
@@ -19,16 +19,14 @@ export const filterImagesByType = (
   }, {});
 };
 
+export const isLinodeKubeImage = (image: Image) =>
+  image.label.match(/kube/i) && image.created_by === 'linode';
+
 export const filterOutKubeImages = (
   images: Record<string, Image>
 ): Record<string, Image> => {
   return Object.keys(images).reduce((acc, eachKey) => {
-    if (
-      !(
-        images[eachKey].label.match(/kube/i) &&
-        images[eachKey].created_by === 'linode'
-      )
-    ) {
+    if (!isLinodeKubeImage(images[eachKey])) {
       acc[eachKey] = images[eachKey];
     }
 

--- a/packages/manager/src/store/linodeCreate/linodeCreate.reducer.ts
+++ b/packages/manager/src/store/linodeCreate/linodeCreate.reducer.ts
@@ -28,7 +28,10 @@ export const getInitialType = (): CreateTypes => {
        * we have a subtype in the query string so now we need to deduce what
        * endpoint we should be POSTing to based on what is in the query params
        */
-      if (normalizedSubtype.includes('community' || 'account')) {
+      if (
+        normalizedSubtype.includes('community') ||
+        normalizedSubtype.includes('account')
+      ) {
         return 'fromStackScript';
       } else if (normalizedSubtype.includes('clone')) {
         return 'fromLinode';


### PR DESCRIPTION
## Description

- Fixes backwards "Account" and "Community" stackscript routing on Linode Create
- Fixes surfacing LKE stackscripts that should not be shown on Linode Create Stackscript tab (shown in screenshots)
- Fixes tons of docs from rendering in the summary section on the Linode Create page when deploying from a StackScript (reported by @HanaXu)
- Cleaned up some unused props
- Fixed unnecessary x-overflow shown in the first screenshot below eb508e9
- Fixed broken action menu height on StackScripts landing (seen in before after screenshots) 6fb1360

### Before
<img width="1206" alt="Screen Shot 2022-03-17 at 8 16 16 PM" src="https://user-images.githubusercontent.com/6440455/158914532-6a18c6f6-45cc-4b31-81c7-d7a0ee34dca5.png">

<img width="1273" alt="Screen Shot 2022-03-18 at 11 35 03 AM" src="https://user-images.githubusercontent.com/6440455/159033945-f68e28a7-54d8-4b7c-ade4-9a247db25b4a.png">


### After
<img width="1206" alt="Screen Shot 2022-03-17 at 8 15 57 PM" src="https://user-images.githubusercontent.com/6440455/158914565-63b8c443-1469-4ec5-a769-d5b7d1151405.png">

<img width="1273" alt="Screen Shot 2022-03-18 at 11 33 36 AM" src="https://user-images.githubusercontent.com/6440455/159033953-a10b95c0-a0f8-4780-ac14-55f2376d895f.png">

## How to test

- Test Linode Create StackScript tab routing
- Test Deploying a Linode from a StackScript
  - Make sure there are not a ton of docs in the Checkout Summary panel at the bottom of the create page
- Test Deploying a Linode from a StackScript when you have a LKE Cluster
  - Make sure the LKE service account Stackscripts are not surfaced