### PR TITLE
M3-5762: Resolve "try to delete in use disk" E2E test flakiness

### DIFF
--- a/packages/manager/cypress/integration/linodes/linode-storage.spec.ts
+++ b/packages/manager/cypress/integration/linodes/linode-storage.spec.ts
@@ -61,18 +61,11 @@ describe('linode storage tab', () => {
       cy.intercept('DELETE', `*/linode/instances/${linode.id}/disks/*`).as(
         'deleteDisk'
       );
-      /* Waiting is necessary because visiting the Linode landing page too
-       * quickly causes the disk not to appear in the `Storage` tab, presumably
-       * because it has not been created yet. This can be improved by waiting
-       * only until an API response confirms that the disk has been created,
-       * or by changing the `Storage` tab to update its contents automatically
-       * without requiring a refresh. In the meantime, this hack should help
-       * reduce flakiness for this test.
-       */
-      // @TODO Remove/improve use of `cy.wait()`. See M3-5762.
-      // eslint-disable-next-line cypress/no-unnecessary-waiting
-      cy.wait(5);
-      cy.visitWithLogin(`/linodes/${linode.id}/storage`);
+      cy.visitWithLogin(`/linodes/${linode.id}`);
+      containsVisible('RUNNING');
+      cy.get('[role="tablist"]').within(() => {
+        fbtClick('Storage');
+      });
       fbtVisible(diskName);
       cy.get('button[title="Add a Disk"]').should('be.disabled');
       cy.get(`[data-qa-disk="${diskName}"]`).within(() => {

--- a/packages/manager/cypress/integration/linodes/linode-storage.spec.ts
+++ b/packages/manager/cypress/integration/linodes/linode-storage.spec.ts
@@ -61,11 +61,16 @@ describe('linode storage tab', () => {
       cy.intercept('DELETE', `*/linode/instances/${linode.id}/disks/*`).as(
         'deleteDisk'
       );
-      cy.visitWithLogin(`/linodes/${linode.id}`);
-      containsVisible('RUNNING');
-      cy.get('[role="tablist"]').within(() => {
-        fbtClick('Storage');
-      });
+      // Wait for Linode to boot before navigating to `Storage` details page.
+      // @TODO Remove this step upon resolution of M3-5762.
+      cy.visitWithLogin(`/linodes`);
+      cy.findByText(linode.label)
+        .should('be.visible')
+        .closest('tr')
+        .within(() => {
+          cy.findByText('Running');
+        });
+      cy.visitWithLogin(`linodes/${linode.id}/storage`);
       fbtVisible(diskName);
       cy.get('button[title="Add a Disk"]').should('be.disabled');
       cy.get(`[data-qa-disk="${diskName}"]`).within(() => {

--- a/packages/manager/cypress/integration/linodes/linode-storage.spec.ts
+++ b/packages/manager/cypress/integration/linodes/linode-storage.spec.ts
@@ -61,6 +61,17 @@ describe('linode storage tab', () => {
       cy.intercept('DELETE', `*/linode/instances/${linode.id}/disks/*`).as(
         'deleteDisk'
       );
+      /* Waiting is necessary because visiting the Linode landing page too
+       * quickly causes the disk not to appear in the `Storage` tab, presumably
+       * because it has not been created yet. This can be improved by waiting
+       * only until an API response confirms that the disk has been created,
+       * or by changing the `Storage` tab to update its contents automatically
+       * without requiring a refresh. In the meantime, this hack should help
+       * reduce flakiness for this test.
+       */
+      // @TODO Remove/improve use of `cy.wait()`. See M3-5762.
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(5);
       cy.visitWithLogin(`/linodes/${linode.id}/storage`);
       fbtVisible(diskName);
       cy.get('button[title="Add a Disk"]').should('be.disabled');

--- a/packages/manager/cypress/integration/linodes/linode-storage.spec.ts
+++ b/packages/manager/cypress/integration/linodes/linode-storage.spec.ts
@@ -61,15 +61,11 @@ describe('linode storage tab', () => {
       cy.intercept('DELETE', `*/linode/instances/${linode.id}/disks/*`).as(
         'deleteDisk'
       );
-      // Wait for Linode to boot before navigating to `Storage` details page.
+      // Wait for Linode to boot before navigating to `Storage` details tab.
+      // Navigate via `cy.visitWithLogin` to invoke a page refresh.
       // @TODO Remove this step upon resolution of M3-5762.
-      cy.visitWithLogin(`/linodes`);
-      cy.findByText(linode.label)
-        .should('be.visible')
-        .closest('tr')
-        .within(() => {
-          cy.findByText('Running');
-        });
+      cy.visitWithLogin(`/linodes/${linode.id}`);
+      containsVisible('RUNNING');
       cy.visitWithLogin(`linodes/${linode.id}/storage`);
       fbtVisible(diskName);
       cy.get('button[title="Add a Disk"]').should('be.disabled');


### PR DESCRIPTION
## Description

**What does this PR do?**
This reduces or eliminates the test flakiness found in the `try to delete in use disk` test within `linode-storage.spec.ts`.

This test is flaky because navigating to the Linode details page "Storage" tab too quickly after creating a Linode can cause the Linode's disk not to appear (presumably because it has not been created yet), and the disk will not appear until the page is refreshed.

These changes sidestep the issue by waiting for the Linode to boot before navigating to the "Storage" tab. See M3-5762 for more information.

## How to test

**What are the steps to reproduce the issue or verify the changes?**
```bash
yarn cy:run -s "**/*/linode-storage.spec.ts"
```
Confirm that tests succeed.

Unfortunately, reproducing the issue is difficult and it only occurs once in a while, so it may take some time to confirm that the flakiness is truly resolved.
