### PR TITLE
Kubernetes Dashboard url fix

### DIFF
--- a/packages/api-v4/src/kubernetes/types.ts
+++ b/packages/api-v4/src/kubernetes/types.ts
@@ -54,7 +54,7 @@ export interface KubernetesEndpointResponse {
 }
 
 export interface KubernetesDashboardResponse {
-  endpoint: string;
+  url: string;
 }
 
 export interface ControlPlaneOptions {

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
@@ -520,7 +520,7 @@ export const KubeSummaryPanel: React.FunctionComponent<Props> = (props) => {
                       buttonType="secondary"
                       disabled={Boolean(dashboardError)}
                       onClick={() => {
-                        window.open(dashboard?.endpoint, '_blank');
+                        window.open(dashboard?.url, '_blank');
                       }}
                     >
                       Kubernetes Dashboard


### PR DESCRIPTION
## Description

Changes the `KubernetesDashboardResponse` to reflect the response returned by the API. In particular changed the `endpoint` property to `url`

## How to test

1. Login dev
2. Navigate to the Kubernetes landing page
3. Create a cluster if there are none
4. Navigate to a cluster details page
5. Ensure that the `Kubernetes Dashboard` is visible and works.
