### PR TITLE
M3-4926: Default values creating access token

### DIFF
--- a/packages/manager/src/features/Profile/APITokens/APITokenDrawer.test.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokenDrawer.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, within } from '@testing-library/react';
+import { fireEvent, within, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { APITokenDrawer } from './APITokenDrawer';
 
@@ -59,5 +59,16 @@ describe('API Token Drawer', () => {
     const submit = getByText('Create Token');
     fireEvent.click(submit);
     expect(props.onCreate).toHaveBeenCalledWith('*');
+  });
+  it.only('Should default to read/write for all scopes', async () => {
+    const { findByLabelText } = renderWithTheme(<APITokenDrawer {...props} />);
+    const selectAllReadWriteRadioButton = await findByLabelText(
+      'Select read/write for all'
+    );
+    await waitFor(() => expect(selectAllReadWriteRadioButton).toBeChecked());
+  });
+  it('Should default to never for expiration', () => {
+    // const { getByLabelText } = renderWithTheme(<APITokenDrawer {...props} />);
+    // const experationSelection = getByLabelText('Expiry');
   });
 });

--- a/packages/manager/src/features/Profile/APITokens/APITokenDrawer.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokenDrawer.tsx
@@ -30,6 +30,7 @@ import {
   Permission,
   permTuplesToScopeString,
   scopeStringToPermTuples,
+  allScopesAreTheSame,
 } from './utils';
 
 type Expiry = [string, string];
@@ -147,9 +148,10 @@ export class APITokenDrawer extends React.Component<CombinedProps, State> {
   state = {
     scopes: scopeStringToPermTuples(this.props.scopes || '', this.props.perms),
     expiryTups: genExpiryTups(),
-    selectAllSelectedScope: null,
+    selectAllSelectedScope: allScopesAreTheSame(
+      scopeStringToPermTuples(this.props.scopes || '', this.props.perms)
+    ),
   };
-
   /* NB: Upon updating React, port this to getDerivedStateFromProps */
   UNSAFE_componentWillReceiveProps(nextProps: CombinedProps) {
     if (
@@ -238,7 +240,7 @@ export class APITokenDrawer extends React.Component<CombinedProps, State> {
                 className={classes.noneCell}
               >
                 <Radio
-                  name="Select All"
+                  name="Select Al"
                   checked={
                     selectAllSelectedScope === 0 && this.allScopesIdentical()
                   }
@@ -411,6 +413,7 @@ export class APITokenDrawer extends React.Component<CombinedProps, State> {
               onChange={this.handleExpiryChange}
               name="expiry"
               id="expiry"
+              labelId="expiry"
               label="Expiry"
               isClearable={false}
             />

--- a/packages/manager/src/features/Profile/APITokens/APITokenTable.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokenTable.tsx
@@ -131,8 +131,8 @@ export class APITokenTable extends React.Component<CombinedProps, State> {
       errors: undefined,
       id: undefined,
       values: {
-        scopes: undefined,
-        expiry: genExpiryTups()[0][1],
+        scopes: '*',
+        expiry: genExpiryTups()[3][1],
         label: '',
       },
     },
@@ -166,8 +166,8 @@ export class APITokenTable extends React.Component<CombinedProps, State> {
         id: undefined,
         values: {
           label: '',
-          expiry: genExpiryTups()[0][1],
-          scopes: undefined,
+          expiry: genExpiryTups()[3][1],
+          scopes: '*',
         },
       },
     });

--- a/packages/manager/src/features/Profile/APITokens/utils.test.ts
+++ b/packages/manager/src/features/Profile/APITokens/utils.test.ts
@@ -1,4 +1,9 @@
-import { basePerms, scopeStringToPermTuples } from './utils';
+import {
+  basePerms,
+  scopeStringToPermTuples,
+  allScopesAreTheSame,
+  Permission,
+} from './utils';
 
 describe('APIToken utils', () => {
   describe('scopeStringToPermTuples', () => {
@@ -191,6 +196,77 @@ describe('APIToken utils', () => {
 
       it('should return the higher value for account.', () => {
         expect(result).toEqual(expected);
+      });
+    });
+
+    describe('allScopesAreTheSame', () => {
+      it('should return 0 if all scopes are 0', () => {
+        const scopes: Permission[] = [
+          ['account', 0],
+          ['domains', 0],
+          ['events', 0],
+          ['images', 0],
+          ['ips', 0],
+          ['linodes', 0],
+          ['longview', 0],
+          ['nodebalancers', 0],
+          ['object_storage', 0],
+          // ['lke', 0],
+          ['stackscripts', 0],
+          ['volumes', 0],
+        ];
+        expect(allScopesAreTheSame(scopes)).toBe(0);
+      });
+      it('should return 1 if all scopes are 1', () => {
+        const scopes: Permission[] = [
+          ['account', 1],
+          ['domains', 1],
+          ['events', 1],
+          ['images', 1],
+          ['ips', 1],
+          ['linodes', 1],
+          ['longview', 1],
+          ['nodebalancers', 1],
+          ['object_storage', 1],
+          // ['lke', 1],
+          ['stackscripts', 1],
+          ['volumes', 1],
+        ];
+        expect(allScopesAreTheSame(scopes)).toBe(1);
+      });
+      it('should return 2 if all scopes are 2', () => {
+        const scopes: Permission[] = [
+          ['account', 2],
+          ['domains', 2],
+          ['events', 2],
+          ['images', 2],
+          ['ips', 2],
+          ['linodes', 2],
+          ['longview', 2],
+          ['nodebalancers', 2],
+          ['object_storage', 2],
+          // ['lke', 2],
+          ['stackscripts', 2],
+          ['volumes', 2],
+        ];
+        expect(allScopesAreTheSame(scopes)).toBe(2);
+      });
+      it('should return null if all scopes are different', () => {
+        const scopes: Permission[] = [
+          ['account', 1],
+          ['domains', 2],
+          ['events', 0],
+          ['images', 2],
+          ['ips', 2],
+          ['linodes', 1],
+          ['longview', 2],
+          ['nodebalancers', 0],
+          ['object_storage', 2],
+          // ['lke', 2],
+          ['stackscripts', 2],
+          ['volumes', 2],
+        ];
+        expect(allScopesAreTheSame(scopes)).toBe(null);
       });
     });
   });

--- a/packages/manager/src/features/Profile/APITokens/utils.ts
+++ b/packages/manager/src/features/Profile/APITokens/utils.ts
@@ -160,3 +160,19 @@ export const permTuplesToScopeString = (
   }, []);
   return joinedTups.join(' ');
 };
+
+export const allScopesAreTheSame = (scopes: Permission[]) => {
+  const result = scopes.reduce((acc, scope) => {
+    if (acc === null) {
+      return null;
+    } else if (acc === scope[1] || acc === undefined) {
+      return scope[1];
+    } else {
+      return null;
+    }
+  }, undefined);
+  if (result === undefined) {
+    return null;
+  }
+  return result;
+};


### PR DESCRIPTION
## Description

- [ ] Change default values to `Read/Write` for all
- [ ] When creating a new token the `Select All` radio button for `Read/Write` should be selected

## How to test

1. Login to cloud
2. Navigate to `/profile/tokens`
3. Click the `Create a Personal Access Token` button
4. Ensure that all the radio buttons in the `Read/Write` column are selected including the on in the `Select All` row

**How do I run relevant unit tests?**
 `yarn test APITokens`