### PR TITLE
M3-5587: Swap button order in Restore from Backup drawer

### DIFF
--- a/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
+++ b/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
@@ -37,7 +37,7 @@ interface Props {
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 const ActionPanel: React.FC<CombinedProps> = (props) => {
-  const { classes, className, style } = props;
+  const { classes, className, style, children } = props;
 
   return (
     <div
@@ -49,7 +49,11 @@ const ActionPanel: React.FC<CombinedProps> = (props) => {
       })}
       style={style}
     >
-      {props.children}
+      {children instanceof Array
+        ? [...children].sort((child) =>
+            child.props.buttonType === 'primary' ? 1 : -1
+          )
+        : children}
     </div>
   );
 };

--- a/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
+++ b/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
@@ -49,10 +49,10 @@ const ActionPanel: React.FC<CombinedProps> = (props) => {
       })}
       style={style}
     >
-      {children instanceof Array
+      {Array.isArray(children)
         ? [...children].sort((child) =>
             child?.props?.buttonType === 'primary' ? 1 : -1
-          )
+          ) // enforce that the primary button will always be to the right
         : children}
     </div>
   );

--- a/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
+++ b/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
@@ -51,7 +51,7 @@ const ActionPanel: React.FC<CombinedProps> = (props) => {
     >
       {children instanceof Array
         ? [...children].sort((child) =>
-            child.props.buttonType === 'primary' ? 1 : -1
+            child?.props?.buttonType === 'primary' ? 1 : -1
           )
         : children}
     </div>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/RestoreToLinodeDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/RestoreToLinodeDrawer.tsx
@@ -173,19 +173,19 @@ export const RestoreToLinodeDrawer: React.FC<CombinedProps> = (props) => {
       )}
       <ActionsPanel>
         <Button
+          buttonType="secondary"
+          onClick={handleCloseDrawer}
+          data-qa-restore-cancel
+        >
+          Cancel
+        </Button>
+        <Button
           buttonType="primary"
           onClick={restoreToLinode}
           data-qa-restore-submit
           disabled={readOnly}
         >
           Restore
-        </Button>
-        <Button
-          buttonType="secondary"
-          onClick={handleCloseDrawer}
-          data-qa-restore-cancel
-        >
-          Cancel
         </Button>
       </ActionsPanel>
     </Drawer>


### PR DESCRIPTION
## Description
- Aligns the primary button to the right and secondary to the left in the Restore from Backup drawer
- Add logic to automatically display primary buttons to the right (can be updated in the future if we wanted to swap orders again)

## How to test
- Go to a Linode's details page, click the backups tab, and click `Restore to Existing Linode` to open the drawer
- Ensure that the new logic hasn't negatively affected other places where ActionsPanel is used