### PR TITLE
M3-5719: Fixed StackScripts with deprecated Images not showing

### DIFF
--- a/packages/manager/src/components/StackScript/StackScript.test.tsx
+++ b/packages/manager/src/components/StackScript/StackScript.test.tsx
@@ -2,12 +2,12 @@ import { screen } from '@testing-library/react';
 import * as React from 'react';
 import { stackScriptFactory } from 'src/factories/stackscripts';
 import { renderWithTheme } from 'src/utilities/testHelpers';
-import { SStackScript } from './StackScript';
+import { StackScript } from './StackScript';
 
 describe('StackScript', () => {
   it('should render the StackScript label, id, and username', () => {
     const stackScript = stackScriptFactory.build();
-    renderWithTheme(<SStackScript data={stackScript} userCanModify />);
+    renderWithTheme(<StackScript data={stackScript} userCanModify />);
 
     expect(screen.getByText(stackScript.label)).toBeInTheDocument();
     expect(screen.getByText(stackScript.username)).toBeInTheDocument();

--- a/packages/manager/src/components/StackScript/StackScript.tsx
+++ b/packages/manager/src/components/StackScript/StackScript.tsx
@@ -15,6 +15,8 @@ import ScriptCode from 'src/components/ScriptCode';
 import { useImages } from 'src/hooks/useImages';
 import { useAccountManagement } from 'src/hooks/useAccountManagement';
 import { useReduxLoad } from 'src/hooks/useReduxLoad';
+import HelpIcon from '../HelpIcon';
+import Box from '../core/Box';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -40,9 +42,8 @@ const useStyles = makeStyles((theme: Theme) => ({
   description: {
     whiteSpace: 'pre-wrap',
   },
-  scriptHeading: {
+  heading: {
     marginBottom: theme.spacing(1),
-    fontSize: '1rem',
   },
   descriptionText: {
     marginBottom: theme.spacing(2),
@@ -73,11 +74,20 @@ const useStyles = makeStyles((theme: Theme) => ({
     display: 'block',
     marginTop: theme.spacing(1),
   },
+  helpIcon: {
+    padding: 0,
+    marginLeft: theme.spacing(),
+  },
 }));
 
 export interface Props {
   data: StackScript;
   userCanModify: boolean;
+}
+
+interface StackScriptImages {
+  available: JSX.Element[];
+  deprecated: JSX.Element[];
 }
 
 type CombinedProps = Props;
@@ -106,18 +116,57 @@ export const SStackScript: React.FC<CombinedProps> = (props) => {
   useReduxLoad(['images']);
 
   const compatibleImages = React.useMemo(() => {
-    const imageChips = images.reduce((acc: any[], image: string) => {
-      const imageObj = imagesData.itemsById[image];
+    const imageChips = images.reduce(
+      (acc: StackScriptImages, image: string) => {
+        const imageObj = imagesData.itemsById[image];
 
-      if (imageObj) {
-        acc.push(
-          <Chip key={imageObj.id} label={imageObj.label} component="span" />
-        );
-      }
+        if (imageObj) {
+          acc.available.push(
+            <Chip key={imageObj.id} label={imageObj.label} component="span" />
+          );
+        } else {
+          acc.deprecated.push(
+            <Chip key={image} label={image} component="span" />
+          );
+        }
 
-      return acc;
-    }, []);
-    return imageChips.length > 0 ? imageChips : <>No compatible images found</>;
+        return acc;
+      },
+      { available: [], deprecated: [] }
+    );
+
+    if (images.length === 0) {
+      return <>No compatible images found</>;
+    }
+
+    return (
+      <>
+        {imageChips.available.length > 0 ? (
+          imageChips.available
+        ) : (
+          <Typography variant="body1">No compatible images found</Typography>
+        )}
+        {imageChips.deprecated.length > 0 ? (
+          <Grid spacing={4}>
+            <Divider spacingTop={16} spacingBottom={16} />
+            <Box
+              display="flex"
+              flexDirection="row"
+              alignItems="center"
+              className={classes.heading}
+            >
+              <Typography variant="h3">Deprecated Images</Typography>
+              <HelpIcon
+                text="You must update your StackScript to use a compatible Image to deploy it"
+                tooltipPosition="bottom"
+                className={classes.helpIcon}
+              />
+            </Box>
+            {imageChips.deprecated}
+          </Grid>
+        ) : null}
+      </>
+    );
   }, [images, imagesData]);
 
   const queryString = stringify({ query: `username:${username}` });
@@ -183,6 +232,9 @@ export const SStackScript: React.FC<CombinedProps> = (props) => {
       </div>
       {description && (
         <div className={classes.description}>
+          <Typography variant="h3" className={classes.heading}>
+            Description
+          </Typography>
           <Typography
             className={classes.descriptionText}
             data-qa-stack-description
@@ -198,13 +250,13 @@ export const SStackScript: React.FC<CombinedProps> = (props) => {
           className={classes.deploymentSection}
           style={{ marginTop: 0 }}
         >
-          <strong>Compatible with:</strong>
+          <Typography variant="h3">Compatible Images</Typography>
           <span className={classes.compatibleImages}>{compatibleImages}</span>
         </Typography>
         <Divider spacingTop={16} spacingBottom={16} />
       </div>
-      <Typography className={classes.scriptHeading}>
-        <strong>Script:</strong>
+      <Typography variant="h3" className={classes.heading}>
+        Script
       </Typography>
       <ScriptCode script={script} />
     </div>

--- a/packages/manager/src/components/StackScript/StackScript.tsx
+++ b/packages/manager/src/components/StackScript/StackScript.tsx
@@ -1,4 +1,4 @@
-import { StackScript } from '@linode/api-v4/lib/stackscripts';
+import { StackScript as StackScriptType } from '@linode/api-v4/lib/stackscripts';
 import { stringify } from 'qs';
 import * as React from 'react';
 import { Link, useHistory } from 'react-router-dom';
@@ -60,7 +60,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     color: theme.palette.primary.main,
     position: 'relative',
     display: 'inline-block',
-    transition: theme.transitions.create(['color']),
     '& svg': {
       width: '1em',
       height: '1em',
@@ -81,7 +80,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 export interface Props {
-  data: StackScript;
+  data: StackScriptType;
   userCanModify: boolean;
 }
 
@@ -90,9 +89,7 @@ interface StackScriptImages {
   deprecated: JSX.Element[];
 }
 
-type CombinedProps = Props;
-
-export const SStackScript: React.FC<CombinedProps> = (props) => {
+export const StackScript: React.FC<Props> = (props) => {
   const {
     data: {
       username,
@@ -115,59 +112,24 @@ export const SStackScript: React.FC<CombinedProps> = (props) => {
   const { images: imagesData } = useImages('public');
   useReduxLoad(['images']);
 
-  const compatibleImages = React.useMemo(() => {
-    const imageChips = images.reduce(
-      (acc: StackScriptImages, image: string) => {
-        const imageObj = imagesData.itemsById[image];
+  const imageChips = images.reduce(
+    (acc: StackScriptImages, image: string) => {
+      const imageObj = imagesData.itemsById[image];
 
-        if (imageObj) {
-          acc.available.push(
-            <Chip key={imageObj.id} label={imageObj.label} component="span" />
-          );
-        } else {
-          acc.deprecated.push(
-            <Chip key={image} label={image} component="span" />
-          );
-        }
+      if (imageObj) {
+        acc.available.push(
+          <Chip key={imageObj.id} label={imageObj.label} component="span" />
+        );
+      } else {
+        acc.deprecated.push(
+          <Chip key={image} label={image} component="span" />
+        );
+      }
 
-        return acc;
-      },
-      { available: [], deprecated: [] }
-    );
-
-    if (images.length === 0) {
-      return <>No compatible images found</>;
-    }
-
-    return (
-      <>
-        {imageChips.available.length > 0 ? (
-          imageChips.available
-        ) : (
-          <Typography variant="body1">No compatible images found</Typography>
-        )}
-        {imageChips.deprecated.length > 0 ? (
-          <Grid spacing={4}>
-            <Divider spacingTop={16} spacingBottom={16} />
-            <Box
-              display="flex"
-              flexDirection="row"
-              alignItems="center"
-              className={classes.heading}
-            >
-              <Typography variant="h3">Deprecated Images</Typography>
-              <HelpIcon
-                text="You must update your StackScript to use a compatible Image to deploy it"
-                tooltipPosition="bottom"
-                className={classes.helpIcon}
-              />
-            </Box>
-            {imageChips.deprecated}
-          </Grid>
-        ) : null}
-      </>
-    );
-  }, [images, imagesData]);
+      return acc;
+    },
+    { available: [], deprecated: [] }
+  );
 
   const queryString = stringify({ query: `username:${username}` });
   const link =
@@ -245,14 +207,39 @@ export const SStackScript: React.FC<CombinedProps> = (props) => {
         </div>
       )}
       <div>
-        <Typography
+        <div
           data-qa-compatible-distro
           className={classes.deploymentSection}
           style={{ marginTop: 0 }}
         >
-          <Typography variant="h3">Compatible Images</Typography>
-          <span className={classes.compatibleImages}>{compatibleImages}</span>
-        </Typography>
+          <Typography variant="h3" className={classes.heading}>
+            Compatible Images
+          </Typography>
+          {imageChips.available.length > 0 ? (
+            imageChips.available
+          ) : (
+            <Typography variant="body1">No compatible images found</Typography>
+          )}
+          {imageChips.deprecated.length > 0 ? (
+            <>
+              <Divider spacingTop={16} spacingBottom={16} />
+              <Box
+                display="flex"
+                flexDirection="row"
+                alignItems="center"
+                className={classes.heading}
+              >
+                <Typography variant="h3">Deprecated Images</Typography>
+                <HelpIcon
+                  text="You must update your StackScript to use a compatible Image to deploy it"
+                  tooltipPosition="bottom"
+                  className={classes.helpIcon}
+                />
+              </Box>
+              {imageChips.deprecated}
+            </>
+          ) : null}
+        </div>
         <Divider spacingTop={16} spacingBottom={16} />
       </div>
       <Typography variant="h3" className={classes.heading}>
@@ -263,4 +250,4 @@ export const SStackScript: React.FC<CombinedProps> = (props) => {
   );
 };
 
-export default React.memo(SStackScript);
+export default React.memo(StackScript);

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -229,11 +229,8 @@ const withStackScriptBase = (options: WithStackScriptBaseOptions) => (
       );
     };
 
-    usesKubeImage = (stackScriptImages: string[]) => {
-      return stackScriptImages.some((imageId) => {
-        return isLinodeKubeImageId(imageId);
-      });
-    };
+    usesKubeImage = (stackScriptImages: string[]) =>
+      stackScriptImages.some((imageId) => isLinodeKubeImageId(imageId));
 
     generateFilterInfo = (value: CurrentFilter): FilterInfo => {
       switch (value) {

--- a/packages/manager/src/features/StackScripts/StackScriptsLanding.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptsLanding.tsx
@@ -10,10 +10,7 @@ import withImagesContainer, {
   WithImages,
 } from 'src/containers/withImages.container';
 import { useReduxLoad } from 'src/hooks/useReduxLoad';
-import {
-  filterImagesByType,
-  filterOutKubeImages,
-} from 'src/store/image/image.helpers';
+import { filterImagesByType } from 'src/store/image/image.helpers';
 import StackScriptPanel from './StackScriptPanel';
 
 type CombinedProps = WithImages & RouteComponentProps<{}, any, any>;
@@ -61,7 +58,7 @@ export const StackScriptsLanding: React.FC<CombinedProps> = (props) => {
 export default compose<CombinedProps, {}>(
   withImagesContainer((ownProps, imagesData, imagesLoading, imagesError) => ({
     ...ownProps,
-    imagesData: filterOutKubeImages(filterImagesByType(imagesData, 'public')),
+    imagesData: filterImagesByType(imagesData, 'public'),
     imagesLoading,
     imagesError,
   }))

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -220,7 +220,9 @@ export class LinodeCreate extends React.PureComponent<
     this.state = {
       selectedTab: preSelectedTab !== -1 ? preSelectedTab : 0,
       stackScriptSelectedTab:
-        preSelectedTab === 2 && location.search.search('Account') > -1 ? 0 : 1,
+        preSelectedTab === 2 && location.search.search('Community') > -1
+          ? 1
+          : 0,
       planKey: v4(),
     };
   }

--- a/packages/manager/src/store/image/image.helpers.test.ts
+++ b/packages/manager/src/store/image/image.helpers.test.ts
@@ -1,0 +1,13 @@
+import { isLinodeKubeImageId } from './image.helpers';
+
+describe('isLinodeKubeImageId', () => {
+  it('should be false if the image id does not start with linode/', () => {
+    expect(isLinodeKubeImageId('private/15943292')).toBe(false);
+  });
+  it('should be false if the image is a regular non-kube image', () => {
+    expect(isLinodeKubeImageId('linode/alpine3.15')).toBe(false);
+  });
+  it('should be true if the image is a linode kube image', () => {
+    expect(isLinodeKubeImageId('linode/debian11-kube-v1.23.4')).toBe(true);
+  });
+});

--- a/packages/manager/src/store/image/image.helpers.ts
+++ b/packages/manager/src/store/image/image.helpers.ts
@@ -23,18 +23,3 @@ export const filterImagesByType = (
 export const isLinodeKubeImageId = (id: string) => {
   return id.startsWith('linode/') && Boolean(id.match(/kube/i));
 };
-
-export const isLinodeKubeImage = (image: Image) =>
-  image.label.match(/kube/i) && image.created_by === 'linode';
-
-export const filterOutKubeImages = (
-  images: Record<string, Image>
-): Record<string, Image> => {
-  return Object.keys(images).reduce((acc, eachKey) => {
-    if (!isLinodeKubeImage(images[eachKey])) {
-      acc[eachKey] = images[eachKey];
-    }
-
-    return acc;
-  }, {});
-};

--- a/packages/manager/src/store/image/image.helpers.ts
+++ b/packages/manager/src/store/image/image.helpers.ts
@@ -19,6 +19,11 @@ export const filterImagesByType = (
   }, {});
 };
 
+// Image IDs are in the form linode/debian11
+export const isLinodeKubeImageId = (id: string) => {
+  return id.startsWith('linode/') && Boolean(id.match(/kube/i));
+};
+
 export const isLinodeKubeImage = (image: Image) =>
   image.label.match(/kube/i) && image.created_by === 'linode';
 

--- a/packages/manager/src/store/image/image.helpers.ts
+++ b/packages/manager/src/store/image/image.helpers.ts
@@ -19,7 +19,16 @@ export const filterImagesByType = (
   }, {});
 };
 
-// Image IDs are in the form linode/debian11
+/**
+ * isLinodeKubeImageId helps us determined if an Image is an
+ * LKE (Linode Kubernetes Engine) image. In Cloud Manager, we hide
+ * these images from the user.
+ *
+ * Image IDs are in the form linode/debian11 or private/15943292
+ *
+ * @param {string} id the image's id (unlike most entities, image ids are string)
+ * @returns {boolean} true if the image a LKE image
+ */
 export const isLinodeKubeImageId = (id: string) => {
-  return id.startsWith('linode/') && Boolean(id.match(/kube/i));
+  return id.startsWith('linode/') && /kube/i.test(id);
 };

--- a/packages/manager/src/store/image/image.helpers.ts
+++ b/packages/manager/src/store/image/image.helpers.ts
@@ -29,6 +29,6 @@ export const filterImagesByType = (
  * @param {string} id the image's id (unlike most entities, image ids are string)
  * @returns {boolean} true if the image a LKE image
  */
-export const isLinodeKubeImageId = (id: string) => {
+export const isLinodeKubeImageId = (id: string): boolean => {
   return id.startsWith('linode/') && /kube/i.test(id);
 };

--- a/packages/manager/src/store/image/image.helpers.ts
+++ b/packages/manager/src/store/image/image.helpers.ts
@@ -20,14 +20,14 @@ export const filterImagesByType = (
 };
 
 /**
- * isLinodeKubeImageId helps us determined if an Image is an
+ * isLinodeKubeImageId helps us determine if an Image is an
  * LKE (Linode Kubernetes Engine) image. In Cloud Manager, we hide
  * these images from the user.
  *
  * Image IDs are in the form linode/debian11 or private/15943292
  *
  * @param {string} id the image's id (unlike most entities, image ids are string)
- * @returns {boolean} true if the image a LKE image
+ * @returns {boolean} true if the image is an LKE image
  */
 export const isLinodeKubeImageId = (id: string): boolean => {
   return id.startsWith('linode/') && /kube/i.test(id);


### PR DESCRIPTION
## Description

- Shows StackScripts that use deprecated Images
  - Previously we just filtered out StackScripts that used deprecated images and user's StackScripts would not be viewable at all in Cloud Manager
- Adds a new "Deprecated Images" section to the StackScript details page containing any deprecated images the StackScript uses (show in screenshot)
 
![Screen Shot 2022-03-25 at 11 04 53 AM](https://user-images.githubusercontent.com/6440455/160146915-d2fda44c-49c5-4afa-926d-940de64f2d2f.jpg)

## How to test

- Test viewing account StackScripts
  - Ensure Linode Kubernetes StackScripts do not display when you have LKE clusters deployed
-  Refer to internal ticket
