### PR TITLE
Initial commit

### DIFF
--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.test.tsx
@@ -1,16 +1,16 @@
-import * as React from 'react';
 import { screen } from '@testing-library/react';
-import { extendedTypes } from 'src/__data__/ExtendedType';
-import { regionFactory } from 'src/factories/regions';
+import * as React from 'react';
 import { linodeBackupsFactory } from 'src/factories/linodes';
+import { regionFactory } from 'src/factories/regions';
 import { includesActions, renderWithTheme } from 'src/utilities/testHelpers';
+import { extendedTypes } from 'src/__data__/ExtendedType';
 import LinodeActionMenu, {
   buildQueryStringForLinodeClone,
   Props,
 } from './LinodeActionMenu';
 
 const props: Props = {
-  inTableContext: true,
+  inListView: true,
   linodeId: 1,
   linodeRegion: 'us-east',
   linodeBackups: linodeBackupsFactory.build(),
@@ -54,7 +54,7 @@ describe('LinodeActionMenu', () => {
         <LinodeActionMenu
           {...props}
           linodeStatus="offline"
-          inTableContext={false}
+          inListView={false}
         />
       );
       expect(

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.style.ts
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.style.ts
@@ -28,6 +28,7 @@ const styles = (theme: Theme) =>
     bodyRow: {
       height: 'auto',
       '&:hover': {
+        backgroundColor: theme.bg.lightBlue1,
         '& [data-qa-copy-ip]': {
           opacity: 1,
         },
@@ -84,11 +85,17 @@ const styles = (theme: Theme) =>
         paddingTop: 0,
         paddingBottom: 0,
       },
+      '& button:hover': {
+        backgroundColor: 'transparent',
+      },
       '& [data-qa-copy-ip]': {
         opacity: 0,
       },
       '& svg': {
         marginTop: 2,
+        '&:hover': {
+          color: theme.palette.primary.main,
+        },
       },
     },
     regionCell: {

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
@@ -249,7 +249,7 @@ export const LinodeRow: React.FC<CombinedProps> = (props) => {
           linodeBackups={backups}
           openDialog={openDialog}
           openPowerActionDialog={openPowerActionDialog}
-          inTableContext
+          inListView
         />
       </TableCell>
     </TableRow>


### PR DESCRIPTION
## Description

Scrolling occurs on the Linodes Landing table when there are legacy/long plan names or maintenance scheduled. This PR mitigates the scrolling by moving the inline actions inside the `ActionMenu`. 

In order to prevent confusion regarding which Linode the actions are being applied to, a hover state has been added to the row. I also updated the hover state for the IP address copy icon to be consistent with other clickable icons.

## How to test

Go to `/linodes` and check for scrolling at different viewports with different plan names and statuses.
