### PR TITLE
M3-5338: Notification Drawer refinements

### DIFF
--- a/packages/manager/src/components/Drawer/Drawer.tsx
+++ b/packages/manager/src/components/Drawer/Drawer.tsx
@@ -9,7 +9,6 @@ import { convertForAria } from 'src/components/TabLink/TabLink';
 
 export interface Props extends DrawerProps {
   title: string;
-  isNotificationDrawer?: boolean;
   wide?: boolean;
 }
 
@@ -54,9 +53,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   backDrop: {
     backgroundColor: theme.color.drawerBackdrop,
   },
-  visuallyHideBackdrop: {
-    backgroundColor: 'rgba(255, 255, 255, 0)',
-  },
 }));
 
 type CombinedProps = Props;
@@ -64,14 +60,7 @@ type CombinedProps = Props;
 const DDrawer: React.FC<CombinedProps> = (props) => {
   const classes = useStyles();
 
-  const {
-    title,
-    children,
-    isNotificationDrawer,
-    onClose,
-    wide,
-    ...rest
-  } = props;
+  const { title, children, onClose, wide, ...rest } = props;
 
   const titleID = convertForAria(title);
 
@@ -80,19 +69,14 @@ const DDrawer: React.FC<CombinedProps> = (props) => {
       anchor="right"
       classes={{ paper: `${classes.paper} ${wide ? classes.wide : ''}` }}
       onClose={(event, reason) => {
-        if (
-          (onClose && reason !== 'backdropClick') ||
-          (onClose && isNotificationDrawer)
-        ) {
+        if (onClose && reason !== 'backdropClick') {
           onClose(event, reason);
         }
       }}
       {...rest}
       ModalProps={{
         BackdropProps: {
-          className: isNotificationDrawer
-            ? classes.visuallyHideBackdrop
-            : classes.backDrop,
+          className: classes.backDrop,
         },
       }}
       aria-labelledby={titleID}
@@ -107,31 +91,27 @@ const DDrawer: React.FC<CombinedProps> = (props) => {
         justifyContent="space-between"
         updateFor={[title, classes]}
       >
-        {!isNotificationDrawer ? (
-          <>
-            <Grid item>
-              <Typography
-                id={titleID}
-                variant="h2"
-                data-qa-drawer-title={title}
-                data-testid="drawer-title"
-              >
-                {title}
-              </Typography>
-            </Grid>
-            <Grid item>
-              <Button
-                className={classes.button}
-                buttonType="secondary"
-                onClick={props.onClose as (e: any) => void}
-                aria-label="Close drawer"
-                data-qa-close-drawer
-              >
-                <Close />
-              </Button>
-            </Grid>
-          </>
-        ) : null}
+        <Grid item>
+          <Typography
+            id={titleID}
+            variant="h2"
+            data-qa-drawer-title={title}
+            data-testid="drawer-title"
+          >
+            {title}
+          </Typography>
+        </Grid>
+        <Grid item>
+          <Button
+            className={classes.button}
+            buttonType="secondary"
+            onClick={props.onClose as (e: any) => void}
+            aria-label="Close drawer"
+            data-qa-close-drawer
+          >
+            <Close />
+          </Button>
+        </Grid>
       </Grid>
       {children}
     </Drawer>

--- a/packages/manager/src/components/Drawer/Drawer.tsx
+++ b/packages/manager/src/components/Drawer/Drawer.tsx
@@ -77,7 +77,7 @@ const DDrawer: React.FC<CombinedProps> = (props) => {
 
   return (
     <Drawer
-      anchor={isNotificationDrawer ? 'top' : 'right'}
+      anchor="right"
       classes={{ paper: `${classes.paper} ${wide ? classes.wide : ''}` }}
       onClose={(event, reason) => {
         if (

--- a/packages/manager/src/components/Drawer/Drawer.tsx
+++ b/packages/manager/src/components/Drawer/Drawer.tsx
@@ -2,133 +2,140 @@ import Close from '@material-ui/icons/Close';
 import * as React from 'react';
 import Button from 'src/components/Button';
 import Drawer, { DrawerProps } from 'src/components/core/Drawer';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles,
-} from 'src/components/core/styles';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 import { convertForAria } from 'src/components/TabLink/TabLink';
 
 export interface Props extends DrawerProps {
   title: string;
+  isNotificationDrawer?: boolean;
   wide?: boolean;
 }
 
-type ClassNames =
-  | 'paper'
-  | 'button'
-  | 'drawerHeader'
-  | 'drawerContent'
-  | 'backDrop'
-  | 'wide';
+const useStyles = makeStyles((theme: Theme) => ({
+  paper: {
+    width: 300,
+    padding: theme.spacing(2),
+    [theme.breakpoints.up('sm')]: {
+      width: 480,
+      padding: theme.spacing(4),
+    },
+    '& .actionPanel': {
+      display: 'flex',
+      justifyContent: 'flex-end',
+      marginTop: theme.spacing(),
+    },
+    '& .selectionCard': {
+      maxWidth: '100%',
+      flexBasis: '100%',
+    },
+  },
+  wide: {
+    [theme.breakpoints.up('sm')]: {
+      width: 700,
+    },
+  },
+  drawerHeader: {
+    marginBottom: theme.spacing(2),
+  },
+  button: {
+    minWidth: 'auto',
+    minHeight: 'auto',
+    padding: 0,
+    '& > span': {
+      padding: 2,
+    },
+    '& :hover, & :focus': {
+      color: 'white',
+      backgroundColor: theme.palette.primary.main,
+    },
+  },
+  backDrop: {
+    backgroundColor: theme.color.drawerBackdrop,
+  },
+  visuallyHideBackdrop: {
+    backgroundColor: 'rgba(255, 255, 255, 0)',
+  },
+}));
 
-const styles = (theme: Theme) =>
-  createStyles({
-    paper: {
-      width: 300,
-      padding: theme.spacing(2),
-      [theme.breakpoints.up('sm')]: {
-        width: 480,
-        padding: theme.spacing(4),
-      },
-      '& .actionPanel': {
-        display: 'flex',
-        justifyContent: 'flex-end',
-        marginTop: theme.spacing(),
-      },
-      '& .selectionCard': {
-        maxWidth: '100%',
-        flexBasis: '100%',
-      },
-    },
-    wide: {
-      [theme.breakpoints.up('sm')]: {
-        width: 700,
-      },
-    },
-    drawerHeader: {
-      marginBottom: theme.spacing(2),
-    },
-    drawerContent: {},
-    button: {
-      minWidth: 'auto',
-      minHeight: 'auto',
-      padding: 0,
-      '& > span': {
-        padding: 2,
-      },
-      '& :hover, & :focus': {
-        color: 'white',
-        backgroundColor: theme.palette.primary.main,
-      },
-    },
-    backDrop: {
-      backgroundColor: theme.color.drawerBackdrop,
-    },
-  });
-
-type CombinedProps = Props & WithStyles<ClassNames>;
+type CombinedProps = Props;
 
 const DDrawer: React.FC<CombinedProps> = (props) => {
-  const { title, classes, children, wide, onClose, ...rest } = props;
+  const classes = useStyles();
+
+  const {
+    title,
+    children,
+    isNotificationDrawer,
+    onClose,
+    wide,
+    ...rest
+  } = props;
 
   const titleID = convertForAria(title);
 
   return (
     <Drawer
-      anchor="right"
+      anchor={isNotificationDrawer ? 'top' : 'right'}
+      classes={{ paper: `${classes.paper} ${wide ? classes.wide : ''}` }}
       onClose={(event, reason) => {
-        if (onClose && reason !== 'backdropClick') {
+        if (
+          (onClose && reason !== 'backdropClick') ||
+          (onClose && isNotificationDrawer)
+        ) {
           onClose(event, reason);
         }
       }}
       {...rest}
-      classes={{ paper: `${classes.paper} ${wide ? classes.wide : ''}` }}
       ModalProps={{
-        BackdropProps: { className: classes.backDrop },
+        BackdropProps: {
+          className: isNotificationDrawer
+            ? classes.visuallyHideBackdrop
+            : classes.backDrop,
+        },
       }}
+      aria-labelledby={titleID}
       data-qa-drawer
       data-testid="drawer"
       role="dialog"
-      aria-labelledby={titleID}
     >
       <Grid
-        container
-        justifyContent="space-between"
-        alignItems="center"
         className={classes.drawerHeader}
+        container
+        alignItems="center"
+        justifyContent="space-between"
         updateFor={[title, classes]}
       >
-        <Grid item>
-          <Typography
-            variant="h2"
-            id={titleID}
-            data-qa-drawer-title={title}
-            data-testid="drawer-title"
-          >
-            {title}
-          </Typography>
-        </Grid>
-        <Grid item>
-          <Button
-            buttonType="secondary"
-            onClick={props.onClose as (e: any) => void}
-            className={classes.button}
-            data-qa-close-drawer
-            aria-label="Close drawer"
-          >
-            <Close />
-          </Button>
-        </Grid>
+        {!isNotificationDrawer ? (
+          <>
+            <Grid item>
+              <Typography
+                id={titleID}
+                variant="h2"
+                data-qa-drawer-title={title}
+                data-testid="drawer-title"
+              >
+                {title}
+              </Typography>
+            </Grid>
+            <Grid item>
+              <Button
+                className={classes.button}
+                buttonType="secondary"
+                onClick={props.onClose as (e: any) => void}
+                aria-label="Close drawer"
+                data-qa-close-drawer
+              >
+                <Close />
+              </Button>
+            </Grid>
+          </>
+        ) : null}
       </Grid>
-      <div className={classes.drawerContent}>{children}</div>
+      {children}
     </Drawer>
   );
 };
 
-const styled = withStyles(styles);
-
-export default styled(DDrawer);
+export default DDrawer;

--- a/packages/manager/src/components/ExtendedAccordion/ExtendedAccordion.tsx
+++ b/packages/manager/src/components/ExtendedAccordion/ExtendedAccordion.tsx
@@ -7,6 +7,7 @@ interface Props extends Omit<AccordionProps, 'children'> {
   height?: number;
   renderMainContent: () => JSX.Element;
   headingNumberCount?: number;
+  defaultExpanded?: boolean;
 }
 
 /*
@@ -56,6 +57,7 @@ const ExtendedAccordion: React.FC<Props> = (props) => {
     onChange,
     renderMainContent,
     headingNumberCount,
+    defaultExpanded,
   } = props;
 
   return (
@@ -63,6 +65,7 @@ const ExtendedAccordion: React.FC<Props> = (props) => {
       heading={heading}
       onChange={onChange}
       headingNumberCount={headingNumberCount}
+      defaultExpanded={defaultExpanded}
     >
       {renderContent(error, Boolean(loading), height || 300, renderMainContent)}
     </Accordion>

--- a/packages/manager/src/components/NotificationDrawer/NotificationDrawer.tsx
+++ b/packages/manager/src/components/NotificationDrawer/NotificationDrawer.tsx
@@ -15,6 +15,8 @@ const useStyles = makeStyles((theme: Theme) => ({
   root: {
     '& .MuiDrawer-paper': {
       boxShadow: '0 2px 3px 3px rgba(0, 0, 0, 0.1)',
+      // Overrides the default drawer height
+      height: 'auto',
       maxHeight: 'calc(100% - 50px)',
       overflowX: 'hidden',
       // Prevents the width from changing if the scrollbar is visible
@@ -23,8 +25,6 @@ const useStyles = makeStyles((theme: Theme) => ({
       paddingTop: theme.spacing(),
       paddingBottom: 0,
       top: 50,
-      // Prevents the drawer from being aligned on the left since the it is anchored to the top
-      left: 'auto',
       // Overrides the built-in animation so it matches the UserMenu
       transition: 'none !important',
       [theme.breakpoints.up('md')]: {

--- a/packages/manager/src/components/NotificationDrawer/NotificationDrawer.tsx
+++ b/packages/manager/src/components/NotificationDrawer/NotificationDrawer.tsx
@@ -15,8 +15,12 @@ const useStyles = makeStyles((theme: Theme) => ({
   root: {
     '& .MuiDrawer-paper': {
       boxShadow: '0 2px 3px 3px rgba(0, 0, 0, 0.1)',
+      maxHeight: 'calc(100% - 50px)',
       overflowX: 'hidden',
+      // Prevents the width from changing if the scrollbar is visible
+      overflowY: 'scroll',
       padding: 20,
+      paddingTop: theme.spacing(),
       paddingBottom: 0,
       top: 50,
       // Prevents the drawer from being aligned on the left since the it is anchored to the top
@@ -31,13 +35,8 @@ const useStyles = makeStyles((theme: Theme) => ({
       [theme.breakpoints.down('sm')]: {
         height: '100%',
       },
-    },
-  },
-  notificationSectionContainer: {
-    '& > div': {
-      marginTop: theme.spacing(3),
-      [theme.breakpoints.down('sm')]: {
-        marginBottom: theme.spacing(3),
+      [theme.breakpoints.down('xs')]: {
+        width: '100%',
       },
     },
   },
@@ -76,13 +75,11 @@ export const NotificationDrawer: React.FC<Props> = (props) => {
       title="Notification Drawer"
       isNotificationDrawer
     >
-      <div className={classes.notificationSectionContainer}>
-        <Notifications
-          notificationsList={formattedNotifications}
-          onClose={onClose}
-        />
-        <Events events={eventNotifications} onClose={onClose} />
-      </div>
+      <Notifications
+        notificationsList={formattedNotifications}
+        onClose={onClose}
+      />
+      <Events events={eventNotifications} onClose={onClose} />
     </Drawer>
   );
 };

--- a/packages/manager/src/components/NotificationDrawer/NotificationDrawer.tsx
+++ b/packages/manager/src/components/NotificationDrawer/NotificationDrawer.tsx
@@ -1,58 +1,35 @@
 import * as React from 'react';
 import { useDispatch } from 'react-redux';
 import { makeStyles, Theme } from 'src/components/core/styles';
-import Drawer from 'src/components/Drawer';
+import Events from 'src/features/NotificationCenter/Events';
+import { NotificationData } from 'src/features/NotificationCenter/NotificationData/useNotificationData';
+import Notifications from 'src/features/NotificationCenter/Notifications';
 import useDismissibleNotifications from 'src/hooks/useDismissibleNotifications';
 import useNotifications from 'src/hooks/useNotifications';
 import usePrevious from 'src/hooks/usePrevious';
 import { markAllSeen } from 'src/store/events/event.request';
 import { ThunkDispatch } from 'src/store/types';
-import { NotificationData } from 'src/features/NotificationCenter/NotificationData/useNotificationData';
-import Events from 'src/features/NotificationCenter/Events';
-import Notifications from 'src/features/NotificationCenter/Notifications';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
-    '& .MuiDrawer-paper': {
-      boxShadow: '0 2px 3px 3px rgba(0, 0, 0, 0.1)',
-      // Overrides the default drawer height
-      height: 'auto',
-      maxHeight: 'calc(100% - 50px)',
-      overflowX: 'hidden',
-      // Prevents the width from changing if the scrollbar is visible
-      overflowY: 'scroll',
-      padding: 20,
-      paddingTop: theme.spacing(),
-      paddingBottom: 0,
-      top: 50,
-      // Overrides the built-in animation so it matches the UserMenu
-      transition: 'none !important',
-      [theme.breakpoints.up('md')]: {
-        maxHeight: 'calc(100% - 150px)',
-        width: 430,
-      },
-
-      [theme.breakpoints.down('sm')]: {
-        height: '100%',
-      },
-      [theme.breakpoints.down('xs')]: {
-        width: '100%',
-      },
-    },
+    padding: 20,
+    paddingTop: theme.spacing(2),
+    paddingBottom: 0,
   },
 }));
 
 export interface Props {
   data: NotificationData;
   open: boolean;
-  onClose: () => void;
 }
 
 export const NotificationDrawer: React.FC<Props> = (props) => {
-  const classes = useStyles();
+  const {
+    data: { eventNotifications, formattedNotifications },
+    open,
+  } = props;
 
-  const { data, open, onClose } = props;
-  const { eventNotifications, formattedNotifications } = data;
+  const classes = useStyles();
   const { dismissNotifications } = useDismissibleNotifications();
   const notifications = useNotifications();
   const dispatch = useDispatch<ThunkDispatch>();
@@ -68,19 +45,10 @@ export const NotificationDrawer: React.FC<Props> = (props) => {
   }, [dismissNotifications, notifications, dispatch, open, wasOpen]);
 
   return (
-    <Drawer
-      className={classes.root}
-      open={open}
-      onClose={onClose}
-      title="Notification Drawer"
-      isNotificationDrawer
-    >
-      <Notifications
-        notificationsList={formattedNotifications}
-        onClose={onClose}
-      />
-      <Events events={eventNotifications} onClose={onClose} />
-    </Drawer>
+    <div className={classes.root}>
+      <Notifications notificationsList={formattedNotifications} />
+      <Events events={eventNotifications} />
+    </div>
   );
 };
 

--- a/packages/manager/src/components/NotificationDrawer/NotificationDrawer.tsx
+++ b/packages/manager/src/components/NotificationDrawer/NotificationDrawer.tsx
@@ -14,24 +14,32 @@ import Notifications from 'src/features/NotificationCenter/Notifications';
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
     '& .MuiDrawer-paper': {
-      [theme.breakpoints.up('md')]: {
-        width: 620,
-      },
+      boxShadow: '0 2px 3px 3px rgba(0, 0, 0, 0.1)',
       overflowX: 'hidden',
+      padding: 20,
+      paddingBottom: 0,
+      top: 50,
+      // Prevents the drawer from being aligned on the left since the it is anchored to the top
+      left: 'auto',
+      // Overrides the built-in animation so it matches the UserMenu
+      transition: 'none !important',
+      [theme.breakpoints.up('md')]: {
+        maxHeight: 'calc(100% - 150px)',
+        width: 430,
+      },
+
+      [theme.breakpoints.down('sm')]: {
+        height: '100%',
+      },
     },
   },
   notificationSectionContainer: {
     '& > div': {
       marginTop: theme.spacing(3),
-      marginBottom: theme.spacing(3),
+      [theme.breakpoints.down('sm')]: {
+        marginBottom: theme.spacing(3),
+      },
     },
-  },
-  actionHeader: {
-    display: 'flex',
-    paddingBottom: theme.spacing(),
-    justifyContent: 'flex-end',
-    borderBottom: `solid 1px ${theme.palette.divider}`,
-    marginBottom: theme.spacing(3),
   },
 }));
 
@@ -42,12 +50,13 @@ export interface Props {
 }
 
 export const NotificationDrawer: React.FC<Props> = (props) => {
-  const { data, open, onClose } = props;
   const classes = useStyles();
+
+  const { data, open, onClose } = props;
+  const { eventNotifications, formattedNotifications } = data;
   const { dismissNotifications } = useDismissibleNotifications();
   const notifications = useNotifications();
   const dispatch = useDispatch<ThunkDispatch>();
-  const { eventNotifications, formattedNotifications } = data;
 
   const wasOpen = usePrevious(open);
 
@@ -60,7 +69,13 @@ export const NotificationDrawer: React.FC<Props> = (props) => {
   }, [dismissNotifications, notifications, dispatch, open, wasOpen]);
 
   return (
-    <Drawer open={open} onClose={onClose} title="" className={classes.root}>
+    <Drawer
+      className={classes.root}
+      open={open}
+      onClose={onClose}
+      title="Notification Drawer"
+      isNotificationDrawer
+    >
       <div className={classes.notificationSectionContainer}>
         <Notifications
           notificationsList={formattedNotifications}

--- a/packages/manager/src/components/NotificationDrawer/index.ts
+++ b/packages/manager/src/components/NotificationDrawer/index.ts
@@ -1,6 +1,0 @@
-import NotificationDrawer, {
-  Props as _NotificationDrawerProps,
-} from './NotificationDrawer';
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface NotificationDrawerProps extends _NotificationDrawerProps {}
-export default NotificationDrawer;

--- a/packages/manager/src/components/NotificationMenu/.NotificationMenu.stories.mdx
+++ b/packages/manager/src/components/NotificationMenu/.NotificationMenu.stories.mdx
@@ -3,14 +3,14 @@ import Typography from 'src/components/core/Typography';
 import ActionsPanel from '../ActionsPanel';
 import TextField from '../TextField';
 import { Canvas, Meta, Story } from '@storybook/addon-docs';
-import { NotificationDrawer } from './NotificationDrawer';
+import { NotificationMenu } from './NotificationMenu';
 import useNotificationData from 'src/features/NotificationCenter/NotificationData/useNotificationData';
 import { eventFactory, notificationFactory } from 'src/factories';
 
 export const mockEvents = eventFactory.buildList(1);
 export const mockNotifications = notificationFactory.buildList(1);
 
-<Meta title="Components/Drawer/Notification Drawer" component={NotificationDrawer} />
+<Meta title="Components/Drawer/Notification Drawer" component={NotificationMenu} />
 
 # Notification Drawer
 
@@ -41,7 +41,7 @@ export const Template = (args, context) => {
       <Button buttonType="primary" onClick={() => context.setOpen(true)}>
         Click to open Drawer
       </Button>
-      <NotificationDrawer
+      <NotificationMenu
         open={context.open}
         onClose={() => context.setOpen(false)}
         data={notificationData}

--- a/packages/manager/src/components/NotificationMenu/.NotificationMenu.stories.mdx
+++ b/packages/manager/src/components/NotificationMenu/.NotificationMenu.stories.mdx
@@ -10,13 +10,13 @@ import { eventFactory, notificationFactory } from 'src/factories';
 export const mockEvents = eventFactory.buildList(1);
 export const mockNotifications = notificationFactory.buildList(1);
 
-<Meta title="Components/Drawer/Notification Drawer" component={NotificationMenu} />
+<Meta title="Components/Notifications/Notification Menu" component={NotificationMenu} />
 
-# Notification Drawer
+# Notification Menu
 
 #### Overview
 
-There are two sections in the Notifications drawer:
+There are two sections in the Notifications menu:
 
 - **Notifications** are informational messages and are usually not tied directly to user input or activity in the system. They inform the user of a change in the system state or of an event that may be of interest.
 - **Events** present the status of actions taken by the user.
@@ -34,16 +34,14 @@ There are two sections in the Notifications drawer:
 - Passive: Reports system occurrences. Does not require users to take action.
 
 export const Template = (args, context) => {
-  const close = () => context.setOpen(false);
   const notificationData = useNotificationData(mockEvents, mockNotifications);
   return (
     <>
       <Button buttonType="primary" onClick={() => context.setOpen(true)}>
-        Click to open Drawer
+        Click to open menu
       </Button>
       <NotificationMenu
         open={context.open}
-        onClose={() => context.setOpen(false)}
         data={notificationData}
       />
     </>
@@ -52,7 +50,7 @@ export const Template = (args, context) => {
 
 <Canvas>
   <Story
-    name="Notification Drawer"
+    name="Notification Menu"
     decorators={[
       (Story) => {
         const [open, setOpen] = React.useState(false);

--- a/packages/manager/src/components/NotificationMenu/NotificationMenu.tsx
+++ b/packages/manager/src/components/NotificationMenu/NotificationMenu.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { useDispatch } from 'react-redux';
+import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Events from 'src/features/NotificationCenter/Events';
 import { NotificationData } from 'src/features/NotificationCenter/NotificationData/useNotificationData';
@@ -45,10 +46,10 @@ export const NotificationMenu: React.FC<Props> = (props) => {
   }, [dismissNotifications, notifications, dispatch, open, wasOpen]);
 
   return (
-    <div className={classes.root}>
+    <Paper className={classes.root}>
       <Notifications notificationsList={formattedNotifications} />
       <Events events={eventNotifications} />
-    </div>
+    </Paper>
   );
 };
 

--- a/packages/manager/src/components/NotificationMenu/NotificationMenu.tsx
+++ b/packages/manager/src/components/NotificationMenu/NotificationMenu.tsx
@@ -23,7 +23,7 @@ export interface Props {
   open: boolean;
 }
 
-export const NotificationDrawer: React.FC<Props> = (props) => {
+export const NotificationMenu: React.FC<Props> = (props) => {
   const {
     data: { eventNotifications, formattedNotifications },
     open,
@@ -38,9 +38,9 @@ export const NotificationDrawer: React.FC<Props> = (props) => {
 
   React.useEffect(() => {
     if (wasOpen && !open) {
-      // User has closed the drawer.
+      // User has closed the menu.
       dispatch(markAllSeen());
-      dismissNotifications(notifications, { prefix: 'notificationDrawer' });
+      dismissNotifications(notifications, { prefix: 'notificationMenu' });
     }
   }, [dismissNotifications, notifications, dispatch, open, wasOpen]);
 
@@ -52,4 +52,4 @@ export const NotificationDrawer: React.FC<Props> = (props) => {
   );
 };
 
-export default React.memo(NotificationDrawer);
+export default React.memo(NotificationMenu);

--- a/packages/manager/src/components/NotificationMenu/index.ts
+++ b/packages/manager/src/components/NotificationMenu/index.ts
@@ -1,0 +1,6 @@
+import NotificationMenu, {
+  Props as _NotificationMenuProps,
+} from './NotificationMenu';
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface NotificationMenuProps extends _NotificationMenuProps {}
+export default NotificationMenu;

--- a/packages/manager/src/components/Table/Table.stories.mdx
+++ b/packages/manager/src/components/Table/Table.stories.mdx
@@ -128,7 +128,7 @@ export const PaginatedExample = () => {
                           vcpus={linode.specs.vcpus}
                           openDialog={() => null}
                           openPowerActionDialog={() => null}
-                          openNotificationDrawer={() => null}
+                          openNotificationMenu={() => null}
                         ></LinodeRow>
                       ))}
                     </TableBody>

--- a/packages/manager/src/features/NotificationCenter/Events.tsx
+++ b/packages/manager/src/features/NotificationCenter/Events.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import NotificationSection, { NotificationItem } from './NotificationSection';
 
-const NUM_EVENTS_DISPLAY = 20; // @todo adjust this number when the drawer is complete
+const NUM_EVENTS_DISPLAY = 20;
 
 interface Props {
   events: NotificationItem[];
@@ -15,8 +15,8 @@ export const Events: React.FC<Props> = (props) => {
     <NotificationSection
       content={events.slice(0, NUM_EVENTS_DISPLAY)}
       header="Events"
-      showMoreTarget={'/events'}
-      showMoreText={'View all events'}
+      showMoreTarget="/events"
+      showMoreText="View all events"
       emptyMessage="No events to display."
       onClose={onClose}
       count={NUM_EVENTS_DISPLAY}

--- a/packages/manager/src/features/NotificationCenter/Events.tsx
+++ b/packages/manager/src/features/NotificationCenter/Events.tsx
@@ -17,7 +17,7 @@ export const Events: React.FC<Props> = (props) => {
       header="Events"
       showMoreTarget="/events"
       showMoreText="View all events"
-      emptyMessage="No events to display."
+      emptyMessage="No recent events to display."
       onClose={onClose}
       count={NUM_EVENTS_DISPLAY}
     />

--- a/packages/manager/src/features/NotificationCenter/Events.tsx
+++ b/packages/manager/src/features/NotificationCenter/Events.tsx
@@ -5,11 +5,10 @@ const NUM_EVENTS_DISPLAY = 20;
 
 interface Props {
   events: NotificationItem[];
-  onClose?: () => void;
 }
 
 export const Events: React.FC<Props> = (props) => {
-  const { events, onClose } = props;
+  const { events } = props;
 
   return (
     <NotificationSection
@@ -18,7 +17,6 @@ export const Events: React.FC<Props> = (props) => {
       showMoreTarget="/events"
       showMoreText="View all events"
       emptyMessage="No recent events to display."
-      onClose={onClose}
       count={NUM_EVENTS_DISPLAY}
     />
   );

--- a/packages/manager/src/features/NotificationCenter/NotificationContext.ts
+++ b/packages/manager/src/features/NotificationCenter/NotificationContext.ts
@@ -1,17 +1,17 @@
 import { createContext, useCallback, useState } from 'react';
 
 export interface NotificationContextProps {
-  drawerOpen: boolean;
-  openDrawer: () => void;
-  closeDrawer: () => void;
-  toggleDrawer: () => void;
+  menuOpen: boolean;
+  openMenu: () => void;
+  closeMenu: () => void;
+  toggleMenu: () => void;
 }
 
 const defaultContext = {
-  drawerOpen: false,
-  openDrawer: () => null,
-  closeDrawer: () => null,
-  toggleDrawer: () => null,
+  menuOpen: false,
+  openMenu: () => null,
+  closeMenu: () => null,
+  toggleMenu: () => null,
 };
 
 export const notificationContext = createContext<NotificationContextProps>(
@@ -19,19 +19,19 @@ export const notificationContext = createContext<NotificationContextProps>(
 );
 
 export const useNotificationContext = (): NotificationContextProps => {
-  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
 
-  const openDrawer = useCallback(() => setDrawerOpen(true), []);
-  const closeDrawer = useCallback(() => setDrawerOpen(false), []);
-  const toggleDrawer = useCallback(
-    () => setDrawerOpen((drawerOpen) => !drawerOpen),
+  const openMenu = useCallback(() => setMenuOpen(true), []);
+  const closeMenu = useCallback(() => setMenuOpen(false), []);
+  const toggleMenu = useCallback(
+    () => setMenuOpen((menuOpen) => !menuOpen),
     []
   );
 
   return {
-    drawerOpen,
-    openDrawer,
-    closeDrawer,
-    toggleDrawer,
+    menuOpen,
+    openMenu,
+    closeMenu,
+    toggleMenu,
   };
 };

--- a/packages/manager/src/features/NotificationCenter/NotificationContext.ts
+++ b/packages/manager/src/features/NotificationCenter/NotificationContext.ts
@@ -1,37 +1,97 @@
-import { createContext, useCallback, useState } from 'react';
+/* eslint-disable no-unused-expressions */
+import { createContext, useCallback, useEffect, useState } from 'react';
 
 export interface NotificationContextProps {
   menuOpen: boolean;
   openMenu: () => void;
   closeMenu: () => void;
-  toggleMenu: () => void;
 }
 
 const defaultContext = {
   menuOpen: false,
   openMenu: () => null,
   closeMenu: () => null,
-  toggleMenu: () => null,
 };
 
 export const notificationContext = createContext<NotificationContextProps>(
   defaultContext
 );
 
+export const menuId = 'notification-events-menu';
+const menuButtonId = 'menu-button--notification-events-menu';
+
+const hasParentElementById = (
+  element: HTMLElement | null,
+  id: string
+): boolean => {
+  if (!element) {
+    return false;
+  }
+  if (element.id === id) {
+    return true;
+  } else {
+    return hasParentElementById(element.parentElement, id);
+  }
+};
+
 export const useNotificationContext = (): NotificationContextProps => {
   const [menuOpen, setMenuOpen] = useState(false);
 
-  const openMenu = useCallback(() => setMenuOpen(true), []);
-  const closeMenu = useCallback(() => setMenuOpen(false), []);
-  const toggleMenu = useCallback(
-    () => setMenuOpen((menuOpen) => !menuOpen),
-    []
+  const openMenu = useCallback(() => {
+    document.getElementById(menuId)?.parentElement?.removeAttribute('hidden');
+    document
+      .getElementById(menuButtonId)
+      ?.setAttribute('aria-expanded', 'true');
+    setMenuOpen(true);
+  }, []);
+
+  const closeMenu = useCallback(() => {
+    document.getElementById(menuId)?.parentElement?.setAttribute('hidden', '');
+    document.getElementById(menuButtonId)?.removeAttribute('aria-expanded');
+    setMenuOpen(false);
+  }, []);
+
+  const handleAnyClick = useCallback(
+    (e: any) => {
+      const clickWasFromInsideMenu = hasParentElementById(
+        e.target.parentElement,
+        menuId
+      );
+      // Ignore clicks from inside the menu unless it's a link
+      if (clickWasFromInsideMenu && e.target.tagName.toLowerCase() !== 'a') {
+        return;
+      }
+      /**
+       * If the user clicks the bell icon while the menu is open,
+       * prevent the bell click event from being called
+       * otherwise the menu will immediately re-open
+       */
+      if (
+        e.target.nearestViewportElement instanceof SVGElement ||
+        e.target.id === menuButtonId
+      ) {
+        e.stopImmediatePropagation();
+      }
+      closeMenu();
+    },
+    [closeMenu]
   );
+
+  useEffect(() => {
+    if (menuOpen) {
+      // eslint-disable-next-line
+      document.addEventListener('click', handleAnyClick, true);
+
+      // clean up the event when the component is re-rendered
+      return () => document.removeEventListener('click', handleAnyClick, true);
+    } else {
+      return () => null;
+    }
+  }, [handleAnyClick, menuOpen]);
 
   return {
     menuOpen,
     openMenu,
     closeMenu,
-    toggleMenu,
   };
 };

--- a/packages/manager/src/features/NotificationCenter/NotificationContext.ts
+++ b/packages/manager/src/features/NotificationCenter/NotificationContext.ts
@@ -4,12 +4,14 @@ export interface NotificationContextProps {
   drawerOpen: boolean;
   openDrawer: () => void;
   closeDrawer: () => void;
+  toggleDrawer: () => void;
 }
 
 const defaultContext = {
   drawerOpen: false,
   openDrawer: () => null,
   closeDrawer: () => null,
+  toggleDrawer: () => null,
 };
 
 export const notificationContext = createContext<NotificationContextProps>(
@@ -21,10 +23,15 @@ export const useNotificationContext = (): NotificationContextProps => {
 
   const openDrawer = useCallback(() => setDrawerOpen(true), []);
   const closeDrawer = useCallback(() => setDrawerOpen(false), []);
+  const toggleDrawer = useCallback(
+    () => setDrawerOpen((drawerOpen) => !drawerOpen),
+    []
+  );
 
   return {
     drawerOpen,
     openDrawer,
     closeDrawer,
+    toggleDrawer,
   };
 };

--- a/packages/manager/src/features/NotificationCenter/NotificationData/RenderEvent.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/RenderEvent.tsx
@@ -10,10 +10,10 @@ import GravatarIcon from 'src/features/Profile/DisplaySettings/GravatarIcon';
 import { parseAPIDate } from 'src/utilities/date';
 import useEventInfo from './useEventInfo';
 
-const useStyles = makeStyles((theme: Theme) => ({
+export const useStyles = makeStyles((theme: Theme) => ({
   root: {
-    paddingTop: theme.spacing(2),
-    paddingBottom: theme.spacing(2),
+    paddingTop: 12,
+    paddingBottom: 12,
     width: '100%',
   },
   icon: {

--- a/packages/manager/src/features/NotificationCenter/NotificationData/RenderEvent.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/RenderEvent.tsx
@@ -1,37 +1,47 @@
 import { Event } from '@linode/api-v4/lib/account/types';
 import classNames from 'classnames';
 import * as React from 'react';
+import Box from 'src/components/core/Box';
 import Divider from 'src/components/core/Divider';
-import { makeStyles } from 'src/components/core/styles';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
-import EntityIcon, { Variant } from 'src/components/EntityIcon';
-import Grid from 'src/components/Grid';
 import { Link } from 'src/components/Link';
-import { isLongPendingEvent } from 'src/store/events/event.helpers';
-import formatDate from 'src/utilities/formatDate';
+import GravatarIcon from 'src/features/Profile/DisplaySettings/GravatarIcon';
+import { parseAPIDate } from 'src/utilities/date';
 import useEventInfo from './useEventInfo';
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((theme: Theme) => ({
   root: {
-    paddingTop: 2,
-    paddingBottom: 2,
+    paddingTop: theme.spacing(2),
+    paddingBottom: theme.spacing(2),
+    width: '100%',
   },
   icon: {
-    '& svg': {
-      height: 20,
-      width: 20,
+    height: 40,
+    minWidth: 40,
+    marginRight: 20,
+  },
+  event: {
+    color: '#888f91',
+    '&:hover': {
+      backgroundColor: '#f4f5f6',
+      cursor: 'pointer',
+      marginLeft: -20,
+      marginRight: -20,
+      paddingLeft: 20,
+      paddingRight: 20,
+      width: 'calc(100% + 40px)',
+      '& a': {
+        textDecoration: 'none',
+      },
     },
   },
   eventMessage: {
-    '&:hover': {
-      textDecoration: 'underline',
-    },
-  },
-  timeStamp: {
-    textAlign: 'right',
+    marginTop: 2,
   },
   unseenEvent: {
-    fontWeight: 'bold',
+    color: '#32363c',
+    textDecoration: 'none',
   },
 }));
 
@@ -40,13 +50,12 @@ interface Props {
   onClose: () => void;
 }
 
-export type CombinedProps = Props;
-
 export const RenderEvent: React.FC<Props> = (props) => {
-  const { event, onClose } = props;
   const classes = useStyles();
 
-  const { message, duration, type, status, linkTarget } = useEventInfo(event);
+  const { event, onClose } = props;
+  const { message, linkTarget } = useEventInfo(event);
+
   if (message === null) {
     return null;
   }
@@ -55,55 +64,38 @@ export const RenderEvent: React.FC<Props> = (props) => {
     <Typography
       className={classNames({
         [classes.unseenEvent]: !event.seen,
-        [classes.eventMessage]: !!linkTarget,
       })}
     >
       {message}
-      {event.duration && !isLongPendingEvent(event)
-        ? event.status === 'failed'
-          ? ` (Failed after ${duration})`
-          : ` (Completed in ${duration})`
-        : null}
     </Typography>
   );
 
   return (
     <>
-      <Grid
-        container
-        className={classes.root}
-        justifyContent="space-between"
+      <Box
+        className={classNames({
+          [classes.root]: true,
+          [classes.event]: !!linkTarget,
+        })}
+        display="flex"
         data-test-id={event.action}
       >
-        <Grid item xs={8}>
-          <Grid container wrap="nowrap">
-            <Grid item>
-              <EntityIcon
-                className={classes.icon}
-                variant={type as Variant}
-                status={status}
-                size={25}
-              />
-            </Grid>
-            <Grid item>
-              {linkTarget ? (
-                <Link to={linkTarget} onClick={onClose}>
-                  {eventMessage}
-                </Link>
-              ) : (
-                eventMessage
-              )}
-            </Grid>
-          </Grid>
-        </Grid>
-        <Grid item xs={4} className={classes.timeStamp}>
+        <GravatarIcon username={event.username} className={classes.icon} />
+        <div className={classes.eventMessage}>
+          {linkTarget ? (
+            <Link to={linkTarget} onClick={onClose}>
+              {eventMessage}
+            </Link>
+          ) : (
+            eventMessage
+          )}
           <Typography
             className={classNames({ [classes.unseenEvent]: !event.seen })}
           >
-            {formatDate(event.created)}
+            {parseAPIDate(event.created).toRelative()}
           </Typography>
-        </Grid>
-      </Grid>
+        </div>
+      </Box>
       <Divider />
     </>
   );

--- a/packages/manager/src/features/NotificationCenter/NotificationData/RenderEvent.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/RenderEvent.tsx
@@ -26,6 +26,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     '&:hover': {
       backgroundColor: theme.bg.app,
       cursor: 'pointer',
+      // Extends the hover state to the edges of the drawer
       marginLeft: -20,
       marginRight: -20,
       paddingLeft: 20,

--- a/packages/manager/src/features/NotificationCenter/NotificationData/RenderEvent.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/RenderEvent.tsx
@@ -22,9 +22,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginRight: 20,
   },
   event: {
-    color: '#888f91',
+    color: theme.textColors.tableHeader,
     '&:hover': {
-      backgroundColor: '#f4f5f6',
+      backgroundColor: theme.bg.app,
       cursor: 'pointer',
       marginLeft: -20,
       marginRight: -20,
@@ -40,7 +40,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginTop: 2,
   },
   unseenEvent: {
-    color: '#32363c',
+    color: theme.textColors.headlineStatic,
     textDecoration: 'none',
   },
 }));

--- a/packages/manager/src/features/NotificationCenter/NotificationData/RenderNotification.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/RenderNotification.tsx
@@ -13,8 +13,7 @@ import { ExtendedNotification } from './useFormattedNotifications';
 
 export const useStyles = makeStyles((theme: Theme) => ({
   root: {
-    paddingTop: 2,
-    paddingBottom: 2,
+    marginTop: -2,
   },
   criticalIcon: {
     fill: theme.color.red,
@@ -34,15 +33,9 @@ export const useStyles = makeStyles((theme: Theme) => ({
       textDecoration: `${theme.color.red} underline`,
     },
   },
-  greyLink: {
-    color: theme.palette.text.primary,
-    '&:hover': {
-      textDecoration: `${theme.palette.text.primary} underline`,
-    },
-  },
   notificationIcon: {
-    lineHeight: '1rem',
     display: 'flex',
+    lineHeight: '1rem',
     '& svg': {
       height: '1.25rem',
       width: '1.25rem',
@@ -72,8 +65,8 @@ export const RenderNotification: React.FC<Props> = (props) => {
   const message = (
     <Typography
       className={classNames({
-        [classes.severeAlert]: severity === 'critical',
         [classes.itemsWithoutIcon]: notification.severity === 'minor',
+        [classes.severeAlert]: severity === 'critical',
       })}
       dangerouslySetInnerHTML={{ __html: sanitizeHTML(notification.message) }}
     />
@@ -82,11 +75,11 @@ export const RenderNotification: React.FC<Props> = (props) => {
   return (
     <>
       <Grid
-        container
         className={classes.root}
-        data-test-id={notification.type}
+        container
+        alignItems="flex-start"
         wrap="nowrap"
-        alignItems="center"
+        data-test-id={notification.type}
       >
         <Grid item>
           <div className={classes.notificationIcon}>
@@ -104,18 +97,16 @@ export const RenderNotification: React.FC<Props> = (props) => {
             ) : null}
           </div>
         </Grid>
-
         <Grid item>
           {/* If JSX has already been put together from interceptions in useFormattedNotifications.tsx, use that */}
           {notification.jsx ? (
             notification.jsx
           ) : linkTarget ? (
             <Link
-              to={linkTarget}
               className={classNames({
                 [classes.redLink]: severity === 'critical',
-                [classes.greyLink]: severity !== 'critical',
               })}
+              to={linkTarget}
               onClick={onClose}
             >
               {message}
@@ -135,12 +126,12 @@ const getEntityLinks = (
   entityType?: string,
   id?: number
 ) => {
-  // Handle specific notification types ()
+  // Handle specific notification types
   if (notificationType === 'ticket_abuse') {
     return `/support/tickets/${id}`;
   }
 
-  // The only entity.type we currently expect and can handle for is "linode."
+  // The only entity.type we currently expect and can handle for is "linode"
   return entityType === 'linode' ? `/linodes/${id}` : null;
 };
 

--- a/packages/manager/src/features/NotificationCenter/NotificationData/RenderNotification.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/RenderNotification.tsx
@@ -28,7 +28,7 @@ export const useStyles = makeStyles((theme: Theme) => ({
     color: theme.color.red,
   },
   redLink: {
-    color: theme.color.red,
+    color: `${theme.color.red} !important`,
     '&:hover': {
       textDecoration: `${theme.color.red} underline`,
     },

--- a/packages/manager/src/features/NotificationCenter/NotificationData/RenderProgressEvent.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/RenderProgressEvent.tsx
@@ -24,9 +24,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     width: '100%',
   },
   event: {
-    color: '#32363c',
+    color: theme.textColors.headlineStatic,
     '&:hover': {
-      backgroundColor: '#f4f5f6',
+      backgroundColor: theme.bg.app,
       cursor: 'pointer',
       marginLeft: -20,
       marginRight: -20,

--- a/packages/manager/src/features/NotificationCenter/NotificationData/RenderProgressEvent.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/RenderProgressEvent.tsx
@@ -28,6 +28,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     '&:hover': {
       backgroundColor: theme.bg.app,
       cursor: 'pointer',
+      // Extends the hover state to the edges of the drawer
       marginLeft: -20,
       marginRight: -20,
       paddingLeft: 20,

--- a/packages/manager/src/features/NotificationCenter/NotificationData/RenderProgressEvent.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/RenderProgressEvent.tsx
@@ -1,7 +1,10 @@
 import { Event } from '@linode/api-v4/lib/account/types';
+import classNames from 'classnames';
 import { Duration } from 'luxon';
 import * as React from 'react';
 import BarPercent from 'src/components/BarPercent';
+import Box from 'src/components/core/Box';
+import Divider from 'src/components/core/Divider';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import { Link } from 'src/components/Link';
@@ -9,39 +12,42 @@ import {
   eventLabelGenerator,
   eventMessageGenerator,
 } from 'src/eventMessageGenerator_CMR';
+import GravatarIcon from 'src/features/Profile/DisplaySettings/GravatarIcon';
 import useLinodes from 'src/hooks/useLinodes';
 import { useTypes } from 'src/hooks/useTypes';
-import EntityIcon, { Variant } from 'src/components/EntityIcon';
-import Divider from 'src/components/core/Divider';
 import useEventInfo from './useEventInfo';
 
 const useStyles = makeStyles((theme: Theme) => ({
-  action: {
-    display: 'flex',
-    flexFlow: 'row nowrap',
+  root: {
+    paddingTop: theme.spacing(2),
+    paddingBottom: theme.spacing(2),
     width: '100%',
+  },
+  event: {
+    color: '#32363c',
+    '&:hover': {
+      backgroundColor: '#f4f5f6',
+      cursor: 'pointer',
+      marginLeft: -20,
+      marginRight: -20,
+      paddingLeft: 20,
+      paddingRight: 20,
+      width: 'calc(100% + 40px)',
+      '& a': {
+        textDecoration: 'none',
+      },
+    },
   },
   bar: {
     marginTop: theme.spacing(),
   },
   icon: {
-    marginRight: theme.spacing(2),
-    '& svg': {
-      height: 20,
-      width: 20,
-    },
+    height: 40,
+    minWidth: 40,
+    marginRight: 20,
   },
-  message: {
-    width: '100%',
-  },
-  link: {
-    color: theme.palette.text.primary,
-    fontWeight: 'bold',
-    textDecoration: 'none',
-    '&:hover': {
-      textDecoration: 'underline',
-      textDecorationColor: 'inherit',
-    },
+  eventMessage: {
+    marginTop: 2,
   },
 }));
 
@@ -60,7 +66,7 @@ export const RenderProgressEvent: React.FC<Props> = (props) => {
   const { types } = useTypes();
   const _linodes = Object.values(linodes.itemsById);
   const _types = types.entities;
-  const { linkTarget, status, type } = useEventInfo(event);
+  const { linkTarget } = useEventInfo(event);
   const message = eventMessageGenerator(event, _linodes, _types);
 
   if (message === null) {
@@ -74,32 +80,33 @@ export const RenderProgressEvent: React.FC<Props> = (props) => {
     : null;
 
   const eventMessage = (
-    <>
+    <Typography>
       {event.action !== 'volume_migrate' ? eventLabelGenerator(event) : ''}
       {` `}
       {message}
       {formattedTimeRemaining}
-    </>
+    </Typography>
   );
 
   return (
     <>
-      <div className={classes.action}>
-        <EntityIcon
-          className={classes.icon}
-          variant={type as Variant}
-          status={status}
-        />
-        <div className={classes.message} data-test-id={event.action}>
-          <Typography>
-            {linkTarget ? (
-              <Link className={classes.link} to={linkTarget} onClick={onClose}>
-                {eventMessage}
-              </Link>
-            ) : (
-              <strong>{eventMessage}</strong>
-            )}
-          </Typography>
+      <Box
+        className={classNames({
+          [classes.root]: true,
+          [classes.event]: !!linkTarget,
+        })}
+        display="flex"
+        data-test-id={event.action}
+      >
+        <GravatarIcon username={event.username} className={classes.icon} />
+        <div className={classes.eventMessage} data-test-id={event.action}>
+          {linkTarget ? (
+            <Link to={linkTarget} onClick={onClose}>
+              {eventMessage}
+            </Link>
+          ) : (
+            eventMessage
+          )}
           <BarPercent
             className={classes.bar}
             max={100}
@@ -108,7 +115,7 @@ export const RenderProgressEvent: React.FC<Props> = (props) => {
             narrow
           />
         </div>
-      </div>
+      </Box>
       <Divider className={classes.bar} />
     </>
   );

--- a/packages/manager/src/features/NotificationCenter/NotificationData/RenderProgressEvent.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/RenderProgressEvent.tsx
@@ -15,40 +15,12 @@ import {
 import GravatarIcon from 'src/features/Profile/DisplaySettings/GravatarIcon';
 import useLinodes from 'src/hooks/useLinodes';
 import { useTypes } from 'src/hooks/useTypes';
+import { useStyles as useEventStyles } from './RenderEvent';
 import useEventInfo from './useEventInfo';
 
 const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    paddingTop: theme.spacing(2),
-    paddingBottom: theme.spacing(2),
-    width: '100%',
-  },
-  event: {
-    color: theme.textColors.headlineStatic,
-    '&:hover': {
-      backgroundColor: theme.bg.app,
-      cursor: 'pointer',
-      // Extends the hover state to the edges of the drawer
-      marginLeft: -20,
-      marginRight: -20,
-      paddingLeft: 20,
-      paddingRight: 20,
-      width: 'calc(100% + 40px)',
-      '& a': {
-        textDecoration: 'none',
-      },
-    },
-  },
   bar: {
     marginTop: theme.spacing(),
-  },
-  icon: {
-    height: 40,
-    minWidth: 40,
-    marginRight: 20,
-  },
-  eventMessage: {
-    marginTop: 2,
   },
 }));
 
@@ -61,6 +33,7 @@ export type CombinedProps = Props;
 
 export const RenderProgressEvent: React.FC<Props> = (props) => {
   const { event, onClose } = props;
+  const eventClasses = useEventStyles();
   const classes = useStyles();
 
   const { linodes } = useLinodes();
@@ -93,14 +66,14 @@ export const RenderProgressEvent: React.FC<Props> = (props) => {
     <>
       <Box
         className={classNames({
-          [classes.root]: true,
-          [classes.event]: !!linkTarget,
+          [eventClasses.root]: true,
+          [eventClasses.event]: !!linkTarget,
         })}
         display="flex"
         data-test-id={event.action}
       >
-        <GravatarIcon username={event.username} className={classes.icon} />
-        <div className={classes.eventMessage} data-test-id={event.action}>
+        <GravatarIcon username={event.username} className={eventClasses.icon} />
+        <div className={eventClasses.eventMessage} data-test-id={event.action}>
           {linkTarget ? (
             <Link to={linkTarget} onClick={onClose}>
               {eventMessage}

--- a/packages/manager/src/features/NotificationCenter/NotificationData/useEventNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useEventNotifications.tsx
@@ -4,10 +4,10 @@ import * as React from 'react';
 import useEvents from 'src/hooks/useEvents';
 import { isInProgressEvent } from 'src/store/events/event.helpers';
 import { ExtendedEvent } from 'src/store/events/event.types';
+import { notificationContext as _notificationContext } from '../NotificationContext';
 import { NotificationItem } from '../NotificationSection';
 import RenderEvent from './RenderEvent';
 import RenderProgressEvent from './RenderProgressEvent';
-import { notificationContext } from '../NotificationContext';
 
 const unwantedEvents: EventAction[] = [
   'account_update',
@@ -20,7 +20,7 @@ const unwantedEvents: EventAction[] = [
 
 export const useEventNotifications = (givenEvents?: ExtendedEvent[]) => {
   const events = givenEvents ?? useEvents().events;
-  const context = React.useContext(notificationContext);
+  const notificationContext = React.useContext(_notificationContext);
 
   const _events = events.filter(
     (thisEvent) => !unwantedEvents.includes(thisEvent.action)
@@ -30,10 +30,10 @@ export const useEventNotifications = (givenEvents?: ExtendedEvent[]) => {
 
   const allEvents = [
     ...inProgress.map((thisEvent) =>
-      formatProgressEventForDisplay(thisEvent, context.closeDrawer)
+      formatProgressEventForDisplay(thisEvent, notificationContext.closeMenu)
     ),
     ...completed.map((thisEvent) =>
-      formatEventForDisplay(thisEvent, context.closeDrawer)
+      formatEventForDisplay(thisEvent, notificationContext.closeMenu)
     ),
   ];
 

--- a/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useFormattedNotifications.tsx
@@ -17,7 +17,7 @@ import { useStyles } from 'src/features/NotificationCenter/NotificationData/Rend
 import useDismissibleNotifications from 'src/hooks/useDismissibleNotifications';
 import useNotifications from 'src/hooks/useNotifications';
 import { formatDate } from 'src/utilities/formatDate';
-import { notificationContext } from '../NotificationContext';
+import { notificationContext as _notificationContext } from '../NotificationContext';
 import { NotificationItem } from '../NotificationSection';
 import { checkIfMaintenanceNotification } from './notificationUtils';
 import RenderNotification from './RenderNotification';
@@ -29,7 +29,7 @@ export interface ExtendedNotification extends Notification {
 export const useFormattedNotifications = (
   givenNotifications?: Notification[]
 ): NotificationItem[] => {
-  const context = React.useContext(notificationContext);
+  const notificationContext = React.useContext(_notificationContext);
   const {
     dismissNotifications,
     hasDismissedNotifications,
@@ -47,8 +47,8 @@ export const useFormattedNotifications = (
   const dayOfMonth = DateTime.local().day;
 
   const handleClose = () => {
-    dismissNotifications(notifications, { prefix: 'notificationDrawer' });
-    context.closeDrawer();
+    dismissNotifications(notifications, { prefix: 'notificationMenu' });
+    notificationContext.closeMenu();
   };
 
   const filteredNotifications = notifications.filter((thisNotification) => {
@@ -88,7 +88,7 @@ export const useFormattedNotifications = (
       interceptNotification(notification, handleClose, classes),
       idx,
       handleClose,
-      !hasDismissedNotifications([notification], 'notificationDrawer')
+      !hasDismissedNotifications([notification], 'notificationMenu')
     )
   );
 };

--- a/packages/manager/src/features/NotificationCenter/NotificationSection.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationSection.tsx
@@ -59,6 +59,10 @@ const useStyles = makeStyles((theme: Theme) => ({
   inverted: {
     transform: 'rotate(180deg)',
   },
+  emptyMessage: {
+    marginTop: theme.spacing(),
+    marginBottom: theme.spacing(2.5),
+  },
 }));
 
 export interface NotificationItem {
@@ -174,16 +178,16 @@ export const NotificationSection: React.FC<Props> = (props) => {
 // =============================================================================
 interface BodyProps {
   header: string;
-  loading: boolean;
   content: NotificationItem[];
   count: number;
   emptyMessage?: string;
+  loading: boolean;
 }
 
 const ContentBody: React.FC<BodyProps> = React.memo((props) => {
   const classes = useStyles();
 
-  const { content, count, loading } = props;
+  const { header, content, count, emptyMessage, loading } = props;
 
   const [showAll, setShowAll] = React.useState(false);
 
@@ -227,6 +231,12 @@ const ContentBody: React.FC<BodyProps> = React.memo((props) => {
         </Box>
       ) : null}
     </>
+  ) : header === 'Events' ? (
+    <Typography className={classes.emptyMessage} variant="body1">
+      {emptyMessage
+        ? emptyMessage
+        : `You have no ${header.toLocaleLowerCase()}.`}
+    </Typography>
   ) : null;
 });
 

--- a/packages/manager/src/features/NotificationCenter/NotificationSection.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationSection.tsx
@@ -1,13 +1,15 @@
 import KeyboardArrowDown from '@material-ui/icons/KeyboardArrowDown';
+import { MenuLink } from '@reach/menu-button';
 import classNames from 'classnames';
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 import CircleProgress from 'src/components/CircleProgress';
 import Box from 'src/components/core/Box';
 import Hidden from 'src/components/core/Hidden';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import ExtendedAccordion from 'src/components/ExtendedAccordion';
-import { Link } from 'src/components/Link';
+import { menuLinkStyle } from 'src/features/TopMenu/UserMenu/UserMenu';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -63,6 +65,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   emptyMessage: {
     marginTop: theme.spacing(),
     marginBottom: theme.spacing(2.5),
+  },
+  menuItemLink: {
+    ...menuLinkStyle(theme.textColors.linkActiveLight),
   },
 }));
 
@@ -130,13 +135,16 @@ export const NotificationSection: React.FC<Props> = (props) => {
                 <div className={classes.header}>
                   <Typography variant="h3">{header}</Typography>
                   {showMoreTarget && (
-                    <Typography variant="body1">
-                      <strong>
-                        <Link to={showMoreTarget}>
-                          {showMoreText ?? 'View history'}
-                        </Link>
-                      </strong>
-                    </Typography>
+                    <strong>
+                      <MenuLink
+                        as={Link}
+                        to={showMoreTarget}
+                        className={classes.menuItemLink}
+                        style={{ padding: 0 }}
+                      >
+                        {showMoreText ?? 'View history'}
+                      </MenuLink>
+                    </strong>
                   )}
                 </div>
                 <ContentBody

--- a/packages/manager/src/features/NotificationCenter/NotificationSection.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationSection.tsx
@@ -23,6 +23,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     display: 'flex',
     justifyContent: 'space-between',
     borderBottom: `solid 1px ${theme.borderColors.borderTypography}`,
+    marginBottom: 6,
   },
   content: {
     width: '100%',

--- a/packages/manager/src/features/NotificationCenter/NotificationSection.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationSection.tsx
@@ -16,6 +16,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     alignItems: 'flex-start',
     justifyContent: 'flex-start',
   },
+  notificationSpacing: {
+    marginBottom: theme.spacing(2),
+  },
   header: {
     display: 'flex',
     justifyContent: 'space-between',
@@ -66,7 +69,7 @@ export interface NotificationItem {
 
 interface Props {
   header: string;
-  count?: number; // @todo do we even need the expansion behavior anymore?
+  count?: number;
   showMoreText?: string;
   showMoreTarget?: string;
   content: NotificationItem[];
@@ -78,6 +81,8 @@ interface Props {
 export type CombinedProps = Props;
 
 export const NotificationSection: React.FC<Props> = (props) => {
+  const classes = useStyles();
+
   const {
     content,
     count,
@@ -89,9 +94,8 @@ export const NotificationSection: React.FC<Props> = (props) => {
     onClose,
   } = props;
 
-  const _loading = Boolean(loading); // false if not provided
   const _count = count ?? 5;
-  const classes = useStyles();
+  const _loading = Boolean(loading); // false if not provided
 
   const innerContent = () => {
     return (
@@ -105,48 +109,62 @@ export const NotificationSection: React.FC<Props> = (props) => {
     );
   };
 
-  return (
-    <>
-      <Hidden smDown>
-        <div className={classes.root}>
-          <div className={classes.content}>
-            <div className={classes.header}>
-              <Typography variant="h3">{header}</Typography>
-              {showMoreTarget && (
-                <Typography variant="body1">
-                  <strong>
-                    <Link
-                      to={showMoreTarget}
-                      onClick={() => {
-                        if (onClose) {
-                          onClose();
-                        }
-                      }}
-                    >
-                      {showMoreText ?? 'View history'}
-                    </Link>
-                  </strong>
-                </Typography>
-              )}
-            </div>
-            <ContentBody
-              loading={_loading}
-              count={_count}
-              content={content}
-              header={header}
-              emptyMessage={emptyMessage}
-            />
-          </div>
-        </div>
-      </Hidden>
+  const isActualNotificationContainer = header === 'Notifications';
 
-      <Hidden mdUp>
-        <ExtendedAccordion
-          heading={header}
-          headingNumberCount={content.length > 0 ? content.length : undefined}
-          renderMainContent={innerContent}
-        />
-      </Hidden>
+  return (
+    // eslint-disable-next-line react/jsx-no-useless-fragment
+    <>
+      {isActualNotificationContainer && content.length === 0 ? null : (
+        <>
+          <Hidden smDown>
+            <div
+              className={classNames({
+                [classes.root]: true,
+                [classes.notificationSpacing]: isActualNotificationContainer,
+              })}
+            >
+              <div className={classes.content}>
+                <div className={classes.header}>
+                  <Typography variant="h3">{header}</Typography>
+                  {showMoreTarget && (
+                    <Typography variant="body1">
+                      <strong>
+                        <Link
+                          to={showMoreTarget}
+                          onClick={() => {
+                            if (onClose) {
+                              onClose();
+                            }
+                          }}
+                        >
+                          {showMoreText ?? 'View history'}
+                        </Link>
+                      </strong>
+                    </Typography>
+                  )}
+                </div>
+                <ContentBody
+                  loading={_loading}
+                  count={_count}
+                  content={content}
+                  header={header}
+                  emptyMessage={emptyMessage}
+                />
+              </div>
+            </div>
+          </Hidden>
+
+          <Hidden mdUp>
+            <ExtendedAccordion
+              heading={header}
+              headingNumberCount={
+                content.length > 0 ? content.length : undefined
+              }
+              renderMainContent={innerContent}
+            />
+          </Hidden>
+        </>
+      )}
     </>
   );
 };
@@ -165,7 +183,7 @@ interface BodyProps {
 const ContentBody: React.FC<BodyProps> = React.memo((props) => {
   const classes = useStyles();
 
-  const { content, count, emptyMessage, header, loading } = props;
+  const { content, count, loading } = props;
 
   const [showAll, setShowAll] = React.useState(false);
 
@@ -209,13 +227,7 @@ const ContentBody: React.FC<BodyProps> = React.memo((props) => {
         </Box>
       ) : null}
     </>
-  ) : (
-    <Typography className={classes.notificationItem}>
-      {emptyMessage
-        ? emptyMessage
-        : `You have no ${header.toLocaleLowerCase()}.`}
-    </Typography>
-  );
+  ) : null;
 });
 
 export default React.memo(NotificationSection);

--- a/packages/manager/src/features/NotificationCenter/NotificationSection.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationSection.tsx
@@ -79,7 +79,6 @@ interface Props {
   content: NotificationItem[];
   loading?: boolean;
   emptyMessage?: string;
-  onClose?: () => void;
 }
 
 export type CombinedProps = Props;
@@ -95,7 +94,6 @@ export const NotificationSection: React.FC<Props> = (props) => {
     loading,
     showMoreText,
     showMoreTarget,
-    onClose,
   } = props;
 
   const _count = count ?? 5;
@@ -133,14 +131,7 @@ export const NotificationSection: React.FC<Props> = (props) => {
                   {showMoreTarget && (
                     <Typography variant="body1">
                       <strong>
-                        <Link
-                          to={showMoreTarget}
-                          onClick={() => {
-                            if (onClose) {
-                              onClose();
-                            }
-                          }}
-                        >
+                        <Link to={showMoreTarget}>
                           {showMoreText ?? 'View history'}
                         </Link>
                       </strong>
@@ -165,6 +156,7 @@ export const NotificationSection: React.FC<Props> = (props) => {
                 content.length > 0 ? content.length : undefined
               }
               renderMainContent={innerContent}
+              defaultExpanded={true}
             />
           </Hidden>
         </>

--- a/packages/manager/src/features/NotificationCenter/NotificationSection.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationSection.tsx
@@ -213,7 +213,7 @@ const ContentBody: React.FC<BodyProps> = React.memo((props) => {
             aria-label={`Display all ${content.length} items`}
             data-test-id="showMoreButton"
           >
-            {showAll ? 'Close' : `${content.length - count} more`}
+            {showAll ? 'Collapse' : `${content.length - count} more`}
             <KeyboardArrowDown
               className={classNames({
                 [classes.caret]: true,

--- a/packages/manager/src/features/NotificationCenter/NotificationSection.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationSection.tsx
@@ -119,7 +119,7 @@ export const NotificationSection: React.FC<Props> = (props) => {
     <>
       {isActualNotificationContainer && content.length === 0 ? null : (
         <>
-          <Hidden smDown>
+          <Hidden xsDown>
             <div
               className={classNames({
                 [classes.root]: true,
@@ -150,7 +150,7 @@ export const NotificationSection: React.FC<Props> = (props) => {
             </div>
           </Hidden>
 
-          <Hidden mdUp>
+          <Hidden smUp>
             <ExtendedAccordion
               heading={header}
               headingNumberCount={

--- a/packages/manager/src/features/NotificationCenter/NotificationSection.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationSection.tsx
@@ -1,25 +1,25 @@
+import KeyboardArrowDown from '@material-ui/icons/KeyboardArrowDown';
 import classNames from 'classnames';
 import * as React from 'react';
-import KeyboardArrowDown from '@material-ui/icons/KeyboardArrowDown';
 import CircleProgress from 'src/components/CircleProgress';
+import Box from 'src/components/core/Box';
+import Hidden from 'src/components/core/Hidden';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
-import { Link } from 'src/components/Link';
-import Hidden from 'src/components/core/Hidden';
 import ExtendedAccordion from 'src/components/ExtendedAccordion';
+import { Link } from 'src/components/Link';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
-    marginBottom: theme.spacing(),
     display: 'flex',
-    flexFlow: 'row nowrap',
+    flexWrap: 'nowrap',
     alignItems: 'flex-start',
     justifyContent: 'flex-start',
   },
   header: {
-    borderBottom: `solid 1px ${theme.borderColors.borderTypography}`,
     display: 'flex',
     justifyContent: 'space-between',
+    borderBottom: `solid 1px ${theme.borderColors.borderTypography}`,
   },
   content: {
     width: '100%',
@@ -28,20 +28,15 @@ const useStyles = makeStyles((theme: Theme) => ({
     display: 'flex',
     justifyContent: 'center',
   },
-  icon: {
-    marginRight: theme.spacing(),
-    '& svg': {
-      color: theme.color.grey1,
-      stroke: theme.color.grey1,
-    },
-  },
   notificationItem: {
-    paddingTop: '10px',
-    width: '100%',
-    lineHeight: 1.43,
-    fontSize: '14px',
     display: 'flex',
     justifyContent: 'space-between',
+    fontSize: '0.875rem',
+    width: '100%',
+    '& p': {
+      color: '#32363c',
+      lineHeight: '1.25rem',
+    },
   },
   showMore: {
     ...theme.applyLinkStyles,
@@ -56,6 +51,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   caret: {
     color: theme.palette.primary.main,
+    marginRight: -4,
   },
   inverted: {
     transform: 'rotate(180deg)',
@@ -167,8 +163,10 @@ interface BodyProps {
 }
 
 const ContentBody: React.FC<BodyProps> = React.memo((props) => {
-  const { content, count, emptyMessage, header, loading } = props;
   const classes = useStyles();
+
+  const { content, count, emptyMessage, header, loading } = props;
+
   const [showAll, setShowAll] = React.useState(false);
 
   if (loading) {
@@ -193,20 +191,22 @@ const ContentBody: React.FC<BodyProps> = React.memo((props) => {
         </div>
       ))}
       {content.length > count ? (
-        <button
-          className={classes.showMore}
-          onClick={() => setShowAll(!showAll)}
-          aria-label={`Display all ${content.length} items`}
-          data-test-id="showMoreButton"
-        >
-          {showAll ? 'Close' : `${content.length - count} more`}
-          <KeyboardArrowDown
-            className={classNames({
-              [classes.caret]: true,
-              [classes.inverted]: showAll,
-            })}
-          />
-        </button>
+        <Box display="flex" justifyContent="flex-end">
+          <button
+            className={classes.showMore}
+            onClick={() => setShowAll(!showAll)}
+            aria-label={`Display all ${content.length} items`}
+            data-test-id="showMoreButton"
+          >
+            {showAll ? 'Close' : `${content.length - count} more`}
+            <KeyboardArrowDown
+              className={classNames({
+                [classes.caret]: true,
+                [classes.inverted]: showAll,
+              })}
+            />
+          </button>
+        </Box>
       ) : null}
     </>
   ) : (

--- a/packages/manager/src/features/NotificationCenter/NotificationSection.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationSection.tsx
@@ -34,7 +34,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     fontSize: '0.875rem',
     width: '100%',
     '& p': {
-      color: '#32363c',
+      color: theme.textColors.headlineStatic,
       lineHeight: '1.25rem',
     },
   },

--- a/packages/manager/src/features/NotificationCenter/Notifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/Notifications.tsx
@@ -3,18 +3,16 @@ import NotificationSection, { NotificationItem } from './NotificationSection';
 
 interface Props {
   notificationsList: NotificationItem[];
-  onClose?: () => void;
 }
 
 export const Notifications: React.FC<Props> = (props) => {
-  const { notificationsList, onClose } = props;
+  const { notificationsList } = props;
 
   return (
     <NotificationSection
       content={notificationsList}
       header="Notifications"
       emptyMessage="No notifications to display."
-      onClose={onClose}
     />
   );
 };

--- a/packages/manager/src/features/NotificationCenter/index.tsx
+++ b/packages/manager/src/features/NotificationCenter/index.tsx
@@ -1,2 +1,2 @@
 export { default as Events } from './Events';
-export { default as NotificationDrawer } from 'src/components/NotificationDrawer';
+export { default as NotificationMenu } from 'src/components/NotificationMenu';

--- a/packages/manager/src/features/TopMenu/NotificationButton.tsx
+++ b/packages/manager/src/features/TopMenu/NotificationButton.tsx
@@ -52,6 +52,17 @@ const useMenuStyles = makeStyles((theme: Theme) => ({
 const menuId = 'notification-events-menu';
 const menuButtonId = 'menu-button--notification-events-menu';
 
+const hasParentElementById = (element: HTMLElement | null, id: string): any => {
+  if (!element) {
+    return false;
+  }
+  if (element.id === id) {
+    return true;
+  } else {
+    return hasParentElementById(element.parentElement, id);
+  }
+};
+
 export const NotificationButton: React.FC<{}> = (_) => {
   const iconClasses = useStyles();
   const classes = useMenuStyles();
@@ -73,14 +84,14 @@ export const NotificationButton: React.FC<{}> = (_) => {
 
   const handleAnyClick = React.useCallback(
     (e: any) => {
-      const clickWasFromInsideMenu =
-        e.target?.parentElement.textContent.indexOf('EventsView all events') >
-        -1;
+      const clickWasFromInsideMenu = hasParentElementById(
+        e.target.parentElement,
+        menuId
+      );
       // Ignore clicks from inside the menu unless it's a link
       if (clickWasFromInsideMenu && e.target.tagName.toLowerCase() !== 'a') {
         return;
       }
-
       /**
        * If the user clicks the bell icon while the menu is open,
        * prevent the bell click event from being called

--- a/packages/manager/src/features/TopMenu/NotificationButton.tsx
+++ b/packages/manager/src/features/TopMenu/NotificationButton.tsx
@@ -50,6 +50,7 @@ const useMenuStyles = makeStyles((theme: Theme) => ({
 }));
 
 const menuId = 'notification-events-menu';
+const menuButtonId = 'menu-button--notification-events-menu';
 
 export const NotificationButton: React.FC<{}> = (_) => {
   const iconClasses = useStyles();
@@ -72,8 +73,11 @@ export const NotificationButton: React.FC<{}> = (_) => {
 
   const handleAnyClick = React.useCallback(
     (e: any) => {
-      // Ignore clicks from inside the menu
-      if (e?.path.some((element: any) => element.id === menuId)) {
+      // Ignore clicks from inside the menu unless it's a link
+      if (
+        e.path?.some((element: any) => element.id === menuId) &&
+        e.target.tagName.toLowerCase() !== 'a'
+      ) {
         return;
       }
 
@@ -81,7 +85,9 @@ export const NotificationButton: React.FC<{}> = (_) => {
        * Prevent the notification bell click event from being called
        * otherwise the menu will immediately re-open
        */
-      e.stopImmediatePropagation();
+      if (e.path?.some((element: any) => element.id === menuButtonId)) {
+        e.stopImmediatePropagation();
+      }
       notificationContext.closeMenu();
     },
     [notificationContext]

--- a/packages/manager/src/features/TopMenu/NotificationButton.tsx
+++ b/packages/manager/src/features/TopMenu/NotificationButton.tsx
@@ -25,8 +25,10 @@ export const NotificationButton: React.FC<{}> = (_) => {
     <>
       <button
         aria-label="Notifications"
-        className={classes.icon}
-        onMouseDown={notificationContext.openDrawer}
+        className={`${classes.icon} ${
+          notificationContext.drawerOpen ? classes.hover : ''
+        }`}
+        onClick={notificationContext.openDrawer}
       >
         <TopMenuIcon title="Notifications">
           <Bell />

--- a/packages/manager/src/features/TopMenu/NotificationButton.tsx
+++ b/packages/manager/src/features/TopMenu/NotificationButton.tsx
@@ -4,7 +4,7 @@ import Bell from 'src/assets/icons/notification.svg';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import { NotificationMenu } from 'src/features/NotificationCenter';
 import useNotificationData from 'src/features/NotificationCenter/NotificationData/useNotificationData';
-import { notificationContext as _notificationContext } from '../NotificationCenter/NotificationContext';
+import { menuId } from '../NotificationCenter/NotificationContext';
 import { useStyles } from './iconStyles';
 import TopMenuIcon from './TopMenuIcon';
 
@@ -49,25 +49,10 @@ const useMenuStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-const menuId = 'notification-events-menu';
-const menuButtonId = 'menu-button--notification-events-menu';
-
-const hasParentElementById = (element: HTMLElement | null, id: string): any => {
-  if (!element) {
-    return false;
-  }
-  if (element.id === id) {
-    return true;
-  } else {
-    return hasParentElementById(element.parentElement, id);
-  }
-};
-
 export const NotificationButton: React.FC<{}> = (_) => {
   const iconClasses = useStyles();
   const classes = useMenuStyles();
 
-  const notificationContext = React.useContext(_notificationContext);
   const notificationData = useNotificationData();
 
   const numNotifications =
@@ -78,78 +63,29 @@ export const NotificationButton: React.FC<{}> = (_) => {
       (thisEvent) => thisEvent.countInTotal
     ).length;
 
-  const handleNotificationButtonClick = () => {
-    notificationContext.toggleMenu();
-  };
-
-  const handleAnyClick = React.useCallback(
-    (e: any) => {
-      const clickWasFromInsideMenu = hasParentElementById(
-        e.target.parentElement,
-        menuId
-      );
-      // Ignore clicks from inside the menu unless it's a link
-      if (clickWasFromInsideMenu && e.target.tagName.toLowerCase() !== 'a') {
-        return;
-      }
-      /**
-       * If the user clicks the bell icon while the menu is open,
-       * prevent the bell click event from being called
-       * otherwise the menu will immediately re-open
-       */
-      if (
-        e.target.nearestViewportElement instanceof SVGElement ||
-        e.target.id === menuButtonId
-      ) {
-        e.stopImmediatePropagation();
-      }
-      notificationContext.closeMenu();
-    },
-    [notificationContext]
-  );
-
-  React.useEffect(() => {
-    if (notificationContext.menuOpen) {
-      // eslint-disable-next-line
-      document.addEventListener('click', handleAnyClick, true);
-
-      // clean up the event when the component is re-rendered
-      return () => document.removeEventListener('click', handleAnyClick, true);
-    } else {
-      return () => null;
-    }
-  }, [handleAnyClick, notificationContext.menuOpen]);
-
   return (
     <Menu id={menuId}>
-      <TopMenuIcon title="Notifications">
-        <MenuButton
-          className={`${iconClasses.icon} ${classes.menuButton}`}
-          onClick={handleNotificationButtonClick}
-          onKeyDown={(e: React.KeyboardEvent) => {
-            if (e.key === 'Escape') {
-              notificationContext.closeMenu();
-            }
-          }}
-          aria-expanded={notificationContext.menuOpen}
-        >
-          <Bell />
-          {numNotifications > 0 ? (
-            <span className={iconClasses.badge}>{numNotifications}</span>
-          ) : null}
-        </MenuButton>
-      </TopMenuIcon>
-      <MenuPopover
-        className={classes.menuPopover}
-        hidden={!notificationContext.menuOpen}
-      >
-        <MenuItems className={classes.menuItem}>
-          <NotificationMenu
-            open={notificationContext.menuOpen}
-            data={notificationData}
-          />
-        </MenuItems>
-      </MenuPopover>
+      {({ isExpanded }) => (
+        <>
+          <TopMenuIcon title="Notifications">
+            <MenuButton
+              className={`${iconClasses.icon} ${classes.menuButton} ${
+                isExpanded ? iconClasses.hover : ''
+              }`}
+            >
+              <Bell />
+              {numNotifications > 0 ? (
+                <span className={iconClasses.badge}>{numNotifications}</span>
+              ) : null}
+            </MenuButton>
+          </TopMenuIcon>
+          <MenuPopover className={classes.menuPopover}>
+            <MenuItems className={classes.menuItem}>
+              <NotificationMenu open={isExpanded} data={notificationData} />
+            </MenuItems>
+          </MenuPopover>
+        </>
+      )}
     </Menu>
   );
 };

--- a/packages/manager/src/features/TopMenu/NotificationButton.tsx
+++ b/packages/manager/src/features/TopMenu/NotificationButton.tsx
@@ -73,11 +73,11 @@ export const NotificationButton: React.FC<{}> = (_) => {
 
   const handleAnyClick = React.useCallback(
     (e: any) => {
+      const clickWasFromInsideMenu =
+        e.target?.parentElement.textContent.indexOf('EventsView all events') >
+        -1;
       // Ignore clicks from inside the menu unless it's a link
-      if (
-        e.path?.some((element: any) => element.id === menuId) &&
-        e.target.tagName.toLowerCase() !== 'a'
-      ) {
+      if (clickWasFromInsideMenu && e.target.tagName.toLowerCase() !== 'a') {
         return;
       }
 
@@ -86,7 +86,7 @@ export const NotificationButton: React.FC<{}> = (_) => {
        * prevent the bell click event from being called
        * otherwise the menu will immediately re-open
        */
-      if (e.path?.some((element: any) => element.id === menuButtonId)) {
+      if (e.target.nearestViewportElement?.parentElement.id === menuButtonId) {
         e.stopImmediatePropagation();
       }
       notificationContext.closeMenu();

--- a/packages/manager/src/features/TopMenu/NotificationButton.tsx
+++ b/packages/manager/src/features/TopMenu/NotificationButton.tsx
@@ -82,7 +82,8 @@ export const NotificationButton: React.FC<{}> = (_) => {
       }
 
       /**
-       * Prevent the notification bell click event from being called
+       * If the user clicks the bell icon while the menu is open,
+       * prevent the bell click event from being called
        * otherwise the menu will immediately re-open
        */
       if (e.path?.some((element: any) => element.id === menuButtonId)) {

--- a/packages/manager/src/features/TopMenu/NotificationButton.tsx
+++ b/packages/manager/src/features/TopMenu/NotificationButton.tsx
@@ -2,7 +2,7 @@ import { Menu, MenuButton, MenuItems, MenuPopover } from '@reach/menu-button';
 import * as React from 'react';
 import Bell from 'src/assets/icons/notification.svg';
 import { makeStyles, Theme } from 'src/components/core/styles';
-import { NotificationDrawer } from 'src/features/NotificationCenter';
+import { NotificationMenu } from 'src/features/NotificationCenter';
 import useNotificationData from 'src/features/NotificationCenter/NotificationData/useNotificationData';
 import { notificationContext as _notificationContext } from '../NotificationCenter/NotificationContext';
 import { useStyles } from './iconStyles';
@@ -34,7 +34,7 @@ const useMenuStyles = makeStyles((theme: Theme) => ({
         width: '100%',
       },
       height: 'auto',
-      maxHeight: 'calc(100% - 50px)',
+      maxHeight: 'calc(90% - 50px)',
       overflowX: 'hidden',
       overflowY: 'auto',
     },
@@ -67,14 +67,12 @@ export const NotificationButton: React.FC<{}> = (_) => {
     ).length;
 
   const handleNotificationButtonClick = () => {
-    notificationContext.toggleDrawer();
+    notificationContext.toggleMenu();
   };
 
   const handleAnyClick = React.useCallback(
     (e: any) => {
-      /**
-       * Ignore clicks from inside the menu
-       */
+      // Ignore clicks from inside the menu
       if (e?.path.some((element: any) => element.id === menuId)) {
         return;
       }
@@ -84,13 +82,13 @@ export const NotificationButton: React.FC<{}> = (_) => {
        * otherwise the menu will immediately re-open
        */
       e.stopImmediatePropagation();
-      notificationContext.closeDrawer();
+      notificationContext.closeMenu();
     },
     [notificationContext]
   );
 
   React.useEffect(() => {
-    if (notificationContext.drawerOpen) {
+    if (notificationContext.menuOpen) {
       // eslint-disable-next-line
       document.addEventListener('click', handleAnyClick, true);
 
@@ -99,7 +97,7 @@ export const NotificationButton: React.FC<{}> = (_) => {
     } else {
       return () => null;
     }
-  }, [handleAnyClick, notificationContext.drawerOpen]);
+  }, [handleAnyClick, notificationContext.menuOpen]);
 
   return (
     <Menu id={menuId}>
@@ -109,10 +107,10 @@ export const NotificationButton: React.FC<{}> = (_) => {
           onClick={handleNotificationButtonClick}
           onKeyDown={(e: React.KeyboardEvent) => {
             if (e.key === 'Escape') {
-              notificationContext.closeDrawer();
+              notificationContext.closeMenu();
             }
           }}
-          aria-expanded={notificationContext.drawerOpen}
+          aria-expanded={notificationContext.menuOpen}
         >
           <Bell />
           {numNotifications > 0 ? (
@@ -122,11 +120,11 @@ export const NotificationButton: React.FC<{}> = (_) => {
       </TopMenuIcon>
       <MenuPopover
         className={classes.menuPopover}
-        hidden={!notificationContext.drawerOpen}
+        hidden={!notificationContext.menuOpen}
       >
         <MenuItems className={classes.menuItem}>
-          <NotificationDrawer
-            open={notificationContext.drawerOpen}
+          <NotificationMenu
+            open={notificationContext.menuOpen}
             data={notificationData}
           />
         </MenuItems>

--- a/packages/manager/src/features/TopMenu/NotificationButton.tsx
+++ b/packages/manager/src/features/TopMenu/NotificationButton.tsx
@@ -86,7 +86,10 @@ export const NotificationButton: React.FC<{}> = (_) => {
        * prevent the bell click event from being called
        * otherwise the menu will immediately re-open
        */
-      if (e.target.nearestViewportElement?.parentElement.id === menuButtonId) {
+      if (
+        e.target.nearestViewportElement instanceof SVGElement ||
+        e.target.id === menuButtonId
+      ) {
         e.stopImmediatePropagation();
       }
       notificationContext.closeMenu();

--- a/packages/manager/src/features/TopMenu/NotificationButton.tsx
+++ b/packages/manager/src/features/TopMenu/NotificationButton.tsx
@@ -26,7 +26,7 @@ export const NotificationButton: React.FC<{}> = (_) => {
       <button
         aria-label="Notifications"
         className={classes.icon}
-        onClick={notificationContext.openDrawer}
+        onMouseDown={notificationContext.openDrawer}
       >
         <TopMenuIcon title="Notifications">
           <Bell />

--- a/packages/manager/src/features/TopMenu/NotificationButton.tsx
+++ b/packages/manager/src/features/TopMenu/NotificationButton.tsx
@@ -1,16 +1,61 @@
+import { Menu, MenuButton, MenuItems, MenuPopover } from '@reach/menu-button';
 import * as React from 'react';
 import Bell from 'src/assets/icons/notification.svg';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import { NotificationDrawer } from 'src/features/NotificationCenter';
 import useNotificationData from 'src/features/NotificationCenter/NotificationData/useNotificationData';
 import { notificationContext as _notificationContext } from '../NotificationCenter/NotificationContext';
 import { useStyles } from './iconStyles';
 import TopMenuIcon from './TopMenuIcon';
 
+const useMenuStyles = makeStyles((theme: Theme) => ({
+  menuButton: {
+    '&[data-reach-menu-button]': {
+      margin: 0,
+    },
+    '& svg': {
+      marginTop: 1,
+    },
+    '& span': {
+      top: -1,
+    },
+  },
+  menuPopover: {
+    '&[data-reach-menu], &[data-reach-menu-popover]': {
+      boxShadow: '0 2px 3px 3px rgba(0, 0, 0, 0.1)',
+      position: 'absolute',
+      zIndex: 3000,
+      width: 430,
+      top: '50px !important',
+      left: 'auto !important',
+      right: 8,
+      [theme.breakpoints.down('xs')]: {
+        right: 0,
+        width: '100%',
+      },
+      height: 'auto',
+      maxHeight: 'calc(100% - 50px)',
+      overflowX: 'hidden',
+      overflowY: 'auto',
+    },
+  },
+  menuItem: {
+    boxShadow: '0 2px 3px 3px rgba(0, 0, 0, 0.1)',
+    '&[data-reach-menu-items]': {
+      whiteSpace: 'initial',
+      border: 'none',
+      padding: 0,
+    },
+  },
+}));
+
+const menuId = 'notification-events-menu';
+
 export const NotificationButton: React.FC<{}> = (_) => {
+  const iconClasses = useStyles();
+  const classes = useMenuStyles();
+
   const notificationContext = React.useContext(_notificationContext);
-
-  const classes = useStyles();
-
   const notificationData = useNotificationData();
 
   const numNotifications =
@@ -21,28 +66,72 @@ export const NotificationButton: React.FC<{}> = (_) => {
       (thisEvent) => thisEvent.countInTotal
     ).length;
 
+  const handleNotificationButtonClick = () => {
+    notificationContext.toggleDrawer();
+  };
+
+  const handleAnyClick = React.useCallback(
+    (e: any) => {
+      /**
+       * Ignore clicks from inside the menu
+       */
+      if (e?.path.some((element: any) => element.id === menuId)) {
+        return;
+      }
+
+      /**
+       * Prevent the notification bell click event from being called
+       * otherwise the menu will immediately re-open
+       */
+      e.stopImmediatePropagation();
+      notificationContext.closeDrawer();
+    },
+    [notificationContext]
+  );
+
+  React.useEffect(() => {
+    if (notificationContext.drawerOpen) {
+      // eslint-disable-next-line
+      document.addEventListener('click', handleAnyClick, true);
+
+      // clean up the event when the component is re-rendered
+      return () => document.removeEventListener('click', handleAnyClick, true);
+    } else {
+      return () => null;
+    }
+  }, [handleAnyClick, notificationContext.drawerOpen]);
+
   return (
-    <>
-      <button
-        aria-label="Notifications"
-        className={`${classes.icon} ${
-          notificationContext.drawerOpen ? classes.hover : ''
-        }`}
-        onClick={notificationContext.openDrawer}
-      >
-        <TopMenuIcon title="Notifications">
+    <Menu id={menuId}>
+      <TopMenuIcon title="Notifications">
+        <MenuButton
+          className={`${iconClasses.icon} ${classes.menuButton}`}
+          onClick={handleNotificationButtonClick}
+          onKeyDown={(e: React.KeyboardEvent) => {
+            if (e.key === 'Escape') {
+              notificationContext.closeDrawer();
+            }
+          }}
+          aria-expanded={notificationContext.drawerOpen}
+        >
           <Bell />
-        </TopMenuIcon>
-        {numNotifications > 0 ? (
-          <span className={classes.badge}>{numNotifications}</span>
-        ) : null}
-      </button>
-      <NotificationDrawer
-        open={notificationContext.drawerOpen}
-        onClose={notificationContext.closeDrawer}
-        data={notificationData}
-      />
-    </>
+          {numNotifications > 0 ? (
+            <span className={iconClasses.badge}>{numNotifications}</span>
+          ) : null}
+        </MenuButton>
+      </TopMenuIcon>
+      <MenuPopover
+        className={classes.menuPopover}
+        hidden={!notificationContext.drawerOpen}
+      >
+        <MenuItems className={classes.menuItem}>
+          <NotificationDrawer
+            open={notificationContext.drawerOpen}
+            data={notificationData}
+          />
+        </MenuItems>
+      </MenuPopover>
+    </Menu>
   );
 };
 

--- a/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
+++ b/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
@@ -24,6 +24,27 @@ interface MenuLink {
   hide?: boolean;
 }
 
+export const menuLinkStyle = (linkColor: string) => ({
+  lineHeight: 1,
+  '&[data-reach-menu-item]': {
+    display: 'flex',
+    alignItems: 'center',
+    color: linkColor,
+    cursor: 'pointer',
+    fontSize: '0.875rem',
+    padding: '8px 24px',
+    '&:focus, &:hover': {
+      backgroundColor: 'transparent',
+      color: linkColor,
+    },
+    '&[data-reach-menu-item][data-selected]:not(:hover)': {
+      backgroundColor: 'transparent',
+      color: linkColor,
+      outline: 'dotted 1px #c1c1c0',
+    },
+  },
+});
+
 const useStyles = makeStyles((theme: Theme) => ({
   menu: {
     transform: `translateY(${theme.spacing(1)}px)`,
@@ -190,26 +211,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     whiteSpace: 'normal',
     width: '100%',
   },
-  menuItemLink: {
-    lineHeight: 1,
-    '&[data-reach-menu-item]': {
-      display: 'flex',
-      alignItems: 'center',
-      color: theme.textColors.linkActiveLight,
-      cursor: 'pointer',
-      fontSize: '0.875rem',
-      padding: '8px 24px',
-      '&:focus, &:hover': {
-        backgroundColor: 'transparent',
-        color: theme.textColors.linkActiveLight,
-      },
-      '&[data-reach-menu-item][data-selected]:not(:hover)': {
-        backgroundColor: 'transparent',
-        color: theme.textColors.linkActiveLight,
-        outline: 'dotted 1px #c1c1c0',
-      },
-    },
-  },
+  menuItemLink: menuLinkStyle(theme.textColors.linkActiveLight),
   userName: {
     color: theme.textColors.headlineStatic,
     fontSize: '1.1rem',

--- a/packages/manager/src/features/TopMenu/iconStyles.ts
+++ b/packages/manager/src/features/TopMenu/iconStyles.ts
@@ -33,9 +33,6 @@ export const useStyles = makeStyles((theme: Theme) => ({
       marginTop: 4,
     },
   },
-  hover: {
-    color: '#606469',
-  },
   badge: {
     display: 'flex',
     position: 'absolute',

--- a/packages/manager/src/features/TopMenu/iconStyles.ts
+++ b/packages/manager/src/features/TopMenu/iconStyles.ts
@@ -33,6 +33,9 @@ export const useStyles = makeStyles((theme: Theme) => ({
       marginTop: 4,
     },
   },
+  hover: {
+    color: '#606469',
+  },
   badge: {
     display: 'flex',
     position: 'absolute',

--- a/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
+++ b/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
@@ -70,7 +70,7 @@ interface LinodeEntityDetailProps {
   linodeConfigs: Config[];
   numVolumes: number;
   openTagDrawer: (tags: string[]) => void;
-  openNotificationDrawer?: () => void;
+  openNotificationMenu?: () => void;
   isDetailLanding?: boolean;
 }
 
@@ -88,7 +88,7 @@ const LinodeEntityDetail: React.FC<CombinedProps> = (props) => {
     numVolumes,
     isDetailLanding,
     openTagDrawer,
-    openNotificationDrawer,
+    openNotificationMenu,
     recentEvent,
   } = props;
 
@@ -136,7 +136,7 @@ const LinodeEntityDetail: React.FC<CombinedProps> = (props) => {
           isDetailLanding={isDetailLanding}
           type={linodeType}
           image={linode.image ?? 'Unknown Image'}
-          openNotificationDrawer={openNotificationDrawer || (() => null)}
+          openNotificationMenu={openNotificationMenu || (() => null)}
           progress={progress}
           transitionText={transitionText}
         />
@@ -200,7 +200,7 @@ export interface HeaderProps {
   image: string;
   linodeConfigs: Config[];
   isDetailLanding?: boolean;
-  openNotificationDrawer: () => void;
+  openNotificationMenu: () => void;
   progress?: number;
   transitionText?: string;
 }
@@ -313,7 +313,7 @@ const Header: React.FC<HeaderProps> = (props) => {
     isDetailLanding,
     progress,
     transitionText,
-    openNotificationDrawer,
+    openNotificationMenu,
   } = props;
 
   const isDetails = variant === 'details';
@@ -384,7 +384,7 @@ const Header: React.FC<HeaderProps> = (props) => {
               >
                 <button
                   className={classes.statusLink}
-                  onClick={openNotificationDrawer}
+                  onClick={openNotificationMenu}
                 >
                   <ProgressDisplay
                     progress={progress ?? 0}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
@@ -462,7 +462,7 @@ const LinodeDetailHeader: React.FC<CombinedProps> = (props) => {
         openTagDrawer={openTagDrawer}
         openDialog={openDialog}
         openPowerActionDialog={openPowerActionDialog}
-        openNotificationDrawer={notificationContext.openDrawer}
+        openNotificationMenu={notificationContext.openMenu}
       />
       <PowerDialogOrDrawer
         isOpen={powerDialog.open}

--- a/packages/manager/src/features/linodes/LinodesLanding/CardView.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/CardView.tsx
@@ -145,7 +145,7 @@ const CardView: React.FC<CombinedProps> = (props) => {
                 openTagDrawer={openTagDrawer}
                 openDialog={openDialog}
                 openPowerActionDialog={openPowerActionDialog}
-                openNotificationDrawer={notificationContext.openDrawer}
+                openNotificationMenu={notificationContext.openMenu}
               />
             </Grid>
           </React.Fragment>

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
@@ -71,7 +71,7 @@ interface Props {
     linodeLabel: string,
     linodeConfigs: Config[]
   ) => void;
-  openNotificationDrawer: () => void;
+  openNotificationMenu: () => void;
 }
 
 export type CombinedProps = Props &
@@ -104,7 +104,7 @@ export const LinodeRow: React.FC<CombinedProps> = (props) => {
     linodeNotifications,
     openDialog,
     openPowerActionDialog,
-    openNotificationDrawer,
+    openNotificationMenu,
     recentEvent,
     mutationAvailable,
   } = props;
@@ -180,7 +180,7 @@ export const LinodeRow: React.FC<CombinedProps> = (props) => {
               <StatusIcon status={iconStatus} />
               <button
                 className={classes.statusLink}
-                onClick={() => openNotificationDrawer()}
+                onClick={() => openNotificationMenu()}
               >
                 <ProgressDisplay
                   className={classes.progressDisplay}

--- a/packages/manager/src/features/linodes/LinodesLanding/ListView.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/ListView.tsx
@@ -111,7 +111,7 @@ export const ListView: React.FC<CombinedProps> = (props) => {
           key={`linode-row-${idx}`}
           openTagDrawer={openTagDrawer}
           openDialog={openDialog}
-          openNotificationDrawer={notificationContext.openDrawer}
+          openNotificationMenu={notificationContext.openMenu}
           openPowerActionDialog={openPowerActionDialog}
         />
       ))}

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -1,9 +1,9 @@
-// import { EventAction, NotificationType } from '@linode/api-v4';
+import { EventAction } from '@linode/api-v4';
 import { RequestHandler, rest } from 'msw';
 import cachedRegions from 'src/cachedData/regions.json';
 import { MockData } from 'src/dev-tools/mockDataController';
 import {
-  // abuseTicketNotificationFactory,
+  abuseTicketNotificationFactory,
   accountFactory,
   accountMaintenanceFactory,
   accountTransferFactory,
@@ -43,7 +43,7 @@ import {
   nodeBalancerConfigNodeFactory,
   nodeBalancerFactory,
   nodePoolFactory,
-  // notificationFactory,
+  notificationFactory,
   objectStorageBucketFactory,
   objectStorageClusterFactory,
   paymentMethodFactory,
@@ -697,34 +697,34 @@ export const handlers = [
     );
   }),
   rest.get('*/events', (req, res, ctx) => {
-    // const events = eventFactory.buildList(1, {
-    //   action: 'lke_node_create',
-    //   percent_complete: 15,
-    //   entity: { type: 'linode', id: 999, label: 'linode-1' },
-    //   message:
-    //     'Rebooting this thing and showing an extremely long event message for no discernible reason other than the fairly obvious reason that we want to do some testing of whether or not these messages wrap.',
-    // });
-    // const volumeMigrationScheduled = eventFactory.build({
-    //   entity: { type: 'volume', id: 6, label: 'bravoExample' },
-    //   action: 'volume_migrate_scheduled' as EventAction,
-    //   status: 'scheduled',
-    //   message: 'Volume bravoExample has been scheduled for an upgrade to NVMe.',
-    //   percent_complete: 100,
-    // });
-    // const volumeMigrating = eventFactory.build({
-    //   entity: { type: 'volume', id: 2, label: 'example-upgrading' },
-    //   action: 'volume_migrate' as EventAction,
-    //   status: 'started',
-    //   message: 'Volume example-upgrading is being upgraded to NVMe.',
-    //   percent_complete: 65,
-    // });
-    // const volumeMigrationFinished = eventFactory.build({
-    //   entity: { type: 'volume', id: 6, label: 'alphaExample' },
-    //   action: 'volume_migrate',
-    //   status: 'finished',
-    //   message: 'Volume alphaExample has finished upgrading to NVMe.',
-    //   percent_complete: 100,
-    // });
+    const events = eventFactory.buildList(1, {
+      action: 'lke_node_create',
+      percent_complete: 15,
+      entity: { type: 'linode', id: 999, label: 'linode-1' },
+      message:
+        'Rebooting this thing and showing an extremely long event message for no discernible reason other than the fairly obvious reason that we want to do some testing of whether or not these messages wrap.',
+    });
+    const volumeMigrationScheduled = eventFactory.build({
+      entity: { type: 'volume', id: 6, label: 'bravoExample' },
+      action: 'volume_migrate_scheduled' as EventAction,
+      status: 'scheduled',
+      message: 'Volume bravoExample has been scheduled for an upgrade to NVMe.',
+      percent_complete: 100,
+    });
+    const volumeMigrating = eventFactory.build({
+      entity: { type: 'volume', id: 2, label: 'example-upgrading' },
+      action: 'volume_migrate' as EventAction,
+      status: 'started',
+      message: 'Volume example-upgrading is being upgraded to NVMe.',
+      percent_complete: 65,
+    });
+    const volumeMigrationFinished = eventFactory.build({
+      entity: { type: 'volume', id: 6, label: 'alphaExample' },
+      action: 'volume_migrate',
+      status: 'finished',
+      message: 'Volume alphaExample has finished upgrading to NVMe.',
+      percent_complete: 100,
+    });
     const oldEvents = eventFactory.buildList(20, {
       action: 'account_update',
       seen: true,
@@ -733,11 +733,11 @@ export const handlers = [
     return res.once(
       ctx.json(
         makeResourcePage([
-          // ...events,
+          ...events,
           ...oldEvents,
-          // volumeMigrationScheduled,
-          // volumeMigrating,
-          // volumeMigrationFinished,
+          volumeMigrationScheduled,
+          volumeMigrating,
+          volumeMigrationFinished,
         ])
       )
     );
@@ -811,149 +811,149 @@ export const handlers = [
   rest.get('*stackscripts/', (req, res, ctx) => {
     return res(ctx.json(makeResourcePage(stackScriptFactory.buildList(1))));
   }),
-  // rest.get('*/notifications', (req, res, ctx) => {
-  // pastDueBalance included here merely for ease of testing for Notifications section in the Notifications drawer.
-  // const pastDueBalance = notificationFactory.build({
-  //   entity: null,
-  //   label: 'past due',
-  //   message: `You have a past due balance of $58.50. Please make a payment immediately to avoid service disruption.`,
-  //   type: 'payment_due',
-  //   severity: 'critical',
-  //   when: null,
-  //   until: null,
-  //   body: null,
-  // });
+  rest.get('*/notifications', (req, res, ctx) => {
+    // pastDueBalance included here merely for ease of testing for Notifications section in the Notifications drawer.
+    const pastDueBalance = notificationFactory.build({
+      entity: null,
+      label: 'past due',
+      message: `You have a past due balance of $58.50. Please make a payment immediately to avoid service disruption.`,
+      type: 'payment_due',
+      severity: 'critical',
+      when: null,
+      until: null,
+      body: null,
+    });
 
-  // const gdprNotification = gdprComplianceNotification.build();
+    // const gdprNotification = gdprComplianceNotification.build();
 
-  // const generalGlobalNotice = {
-  //   type: 'notice',
-  //   entity: null,
-  //   when: null,
-  //   // eslint-disable-next-line xss/no-mixed-html
-  //   message:
-  //     "We've updated our policies. See <a href='https://cloud.linode.com/support'>this page</a> for more information.",
-  //   label: "We've updated our policies.",
-  //   severity: 'minor',
-  //   until: null,
-  //   body: null,
-  // };
+    const generalGlobalNotice = {
+      type: 'notice',
+      entity: null,
+      when: null,
+      // eslint-disable-next-line xss/no-mixed-html
+      message:
+        "We've updated our policies. See <a href='https://cloud.linode.com/support'>this page</a> for more information.",
+      label: "We've updated our policies.",
+      severity: 'minor',
+      until: null,
+      body: null,
+    };
 
-  // const outageNotification = {
-  //   type: 'outage',
-  //   entity: {
-  //     type: 'region',
-  //     label: null,
-  //     id: 'us-east',
-  //     url: '/regions/us-east',
-  //   },
-  //   when: null,
-  //   message:
-  //     'We are aware of an issue affecting service in this facility. If you are experiencing service issues in this facility, there is no need to open a support ticket at this time. Please monitor our status blog at https://status.linode.com for further information.  Thank you for your patience and understanding.',
-  //   label: 'There is an issue affecting service in this facility',
-  //   severity: 'major',
-  //   until: null,
-  //   body: null,
-  // };
+    const outageNotification = {
+      type: 'outage',
+      entity: {
+        type: 'region',
+        label: null,
+        id: 'us-east',
+        url: '/regions/us-east',
+      },
+      when: null,
+      message:
+        'We are aware of an issue affecting service in this facility. If you are experiencing service issues in this facility, there is no need to open a support ticket at this time. Please monitor our status blog at https://status.linode.com for further information.  Thank you for your patience and understanding.',
+      label: 'There is an issue affecting service in this facility',
+      severity: 'major',
+      until: null,
+      body: null,
+    };
 
-  // const emailBounce = notificationFactory.build({
-  //   type: 'billing_email_bounce',
-  //   entity: null,
-  //   when: null,
-  //   message: 'We are unable to send emails to your billing email address!',
-  //   label: 'We are unable to send emails to your billing email address!',
-  //   severity: 'major',
-  //   until: null,
-  //   body: null,
-  // });
+    const emailBounce = notificationFactory.build({
+      type: 'billing_email_bounce',
+      entity: null,
+      when: null,
+      message: 'We are unable to send emails to your billing email address!',
+      label: 'We are unable to send emails to your billing email address!',
+      severity: 'major',
+      until: null,
+      body: null,
+    });
 
-  // const abuseTicket = abuseTicketNotificationFactory.build();
+    const abuseTicket = abuseTicketNotificationFactory.build();
 
-  // const migrationNotification = notificationFactory.build({
-  //   type: 'migration_pending',
-  //   label: 'You have a migration pending!',
-  //   message:
-  //     'You have a migration pending! Your Linode must be offline before starting the migration.',
-  //   entity: { id: 0, type: 'linode', label: 'linode-0' },
-  //   severity: 'major',
-  // });
+    const migrationNotification = notificationFactory.build({
+      type: 'migration_pending',
+      label: 'You have a migration pending!',
+      message:
+        'You have a migration pending! Your Linode must be offline before starting the migration.',
+      entity: { id: 0, type: 'linode', label: 'linode-0' },
+      severity: 'major',
+    });
 
-  // const minorSeverityNotification = notificationFactory.build({
-  //   type: 'notice',
-  //   message: 'Testing for minor notification',
-  //   severity: 'minor',
-  // });
+    const minorSeverityNotification = notificationFactory.build({
+      type: 'notice',
+      message: 'Testing for minor notification',
+      severity: 'minor',
+    });
 
-  // const criticalSeverityNotification = notificationFactory.build({
-  //   type: 'notice',
-  //   message: 'Testing for critical notification',
-  //   severity: 'critical',
-  // });
+    const criticalSeverityNotification = notificationFactory.build({
+      type: 'notice',
+      message: 'Testing for critical notification',
+      severity: 'critical',
+    });
 
-  // const balanceNotification = notificationFactory.build({
-  //   type: 'payment_due',
-  //   message: 'You have an overdue balance!',
-  //   severity: 'major',
-  // });
+    const balanceNotification = notificationFactory.build({
+      type: 'payment_due',
+      message: 'You have an overdue balance!',
+      severity: 'major',
+    });
 
-  // const blockStorageMigrationScheduledNotification = notificationFactory.build(
-  //   {
-  //     type: 'volume_migration_scheduled' as NotificationType,
-  //     entity: {
-  //       type: 'volume',
-  //       label: 'eligibleNow',
-  //       id: 20,
-  //       url: '/volumes/20',
-  //     },
-  //     when: '2021-09-30T04:00:00',
-  //     message:
-  //       'The Linode that the volume is attached to will shut down in order to complete the upgrade and reboot once it is complete. Any other volumes attached to the same Linode will also be upgraded.',
-  //     label: 'You have a scheduled Block Storage volume upgrade pending!',
-  //     severity: 'critical',
-  //     until: '2021-10-16T04:00:00',
-  //     body: 'Your volumes in us-east will be upgraded to NVMe.',
-  //   }
-  // );
+    // const blockStorageMigrationScheduledNotification = notificationFactory.build(
+    //   {
+    //     type: 'volume_migration_scheduled' as NotificationType,
+    //     entity: {
+    //       type: 'volume',
+    //       label: 'eligibleNow',
+    //       id: 20,
+    //       url: '/volumes/20',
+    //     },
+    //     when: '2021-09-30T04:00:00',
+    //     message:
+    //       'The Linode that the volume is attached to will shut down in order to complete the upgrade and reboot once it is complete. Any other volumes attached to the same Linode will also be upgraded.',
+    //     label: 'You have a scheduled Block Storage volume upgrade pending!',
+    //     severity: 'critical',
+    //     until: '2021-10-16T04:00:00',
+    //     body: 'Your volumes in us-east will be upgraded to NVMe.',
+    //   }
+    // );
 
-  // const blockStorageMigrationImminentNotification = notificationFactory.build(
-  //   {
-  //     type: 'volume_migration_imminent' as NotificationType,
-  //     entity: {
-  //       type: 'volume',
-  //       label: 'example-upgrading',
-  //       id: 2,
-  //       url: '/volumes/2',
-  //     },
-  //     when: '2021-09-30T04:00:00',
-  //     message:
-  //       'The Linode that the volume is attached to will shut down in order to complete the upgrade and reboot once it is complete. Any other volumes attached to the same Linode will also be upgraded.',
-  //     label: 'You have a scheduled Block Storage volume upgrade pending!',
-  //     severity: 'major',
-  //     until: '2021-10-16T04:00:00',
-  //     body: 'Your volumes in us-east will be upgraded to NVMe.',
-  //   }
-  // );
+    // const blockStorageMigrationImminentNotification = notificationFactory.build(
+    //   {
+    //     type: 'volume_migration_imminent' as NotificationType,
+    //     entity: {
+    //       type: 'volume',
+    //       label: 'example-upgrading',
+    //       id: 2,
+    //       url: '/volumes/2',
+    //     },
+    //     when: '2021-09-30T04:00:00',
+    //     message:
+    //       'The Linode that the volume is attached to will shut down in order to complete the upgrade and reboot once it is complete. Any other volumes attached to the same Linode will also be upgraded.',
+    //     label: 'You have a scheduled Block Storage volume upgrade pending!',
+    //     severity: 'major',
+    //     until: '2021-10-16T04:00:00',
+    //     body: 'Your volumes in us-east will be upgraded to NVMe.',
+    //   }
+    // );
 
-  // return res(
-  //   ctx.json(
-  //     makeResourcePage([
-  // pastDueBalance,
-  // ...notificationFactory.buildList(1),
-  // gdprNotification,
-  // generalGlobalNotice,
-  // outageNotification,
-  // minorSeverityNotification,
-  // criticalSeverityNotification,
-  // abuseTicket,
-  // emailBounce,
-  // migrationNotification,
-  // balanceNotification,
-  //         blockStorageMigrationScheduledNotification,
-  //         blockStorageMigrationImminentNotification,
-  //       ])
-  //     )
-  //   );
-  // }),
+    return res(
+      ctx.json(
+        makeResourcePage([
+          pastDueBalance,
+          ...notificationFactory.buildList(1),
+          // gdprNotification,
+          generalGlobalNotice,
+          outageNotification,
+          minorSeverityNotification,
+          criticalSeverityNotification,
+          abuseTicket,
+          emailBounce,
+          migrationNotification,
+          balanceNotification,
+          // blockStorageMigrationScheduledNotification,
+          // blockStorageMigrationImminentNotification,
+        ])
+      )
+    );
+  }),
   rest.post('*/networking/vlans', (req, res, ctx) => {
     return res(ctx.json({}));
   }),

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -1,4 +1,4 @@
-import { EventAction, NotificationType } from '@linode/api-v4';
+// import { EventAction, NotificationType } from '@linode/api-v4';
 import { RequestHandler, rest } from 'msw';
 import cachedRegions from 'src/cachedData/regions.json';
 import { MockData } from 'src/dev-tools/mockDataController';
@@ -43,7 +43,7 @@ import {
   nodeBalancerConfigNodeFactory,
   nodeBalancerFactory,
   nodePoolFactory,
-  notificationFactory,
+  // notificationFactory,
   objectStorageBucketFactory,
   objectStorageClusterFactory,
   paymentMethodFactory,
@@ -704,34 +704,27 @@ export const handlers = [
     //   message:
     //     'Rebooting this thing and showing an extremely long event message for no discernible reason other than the fairly obvious reason that we want to do some testing of whether or not these messages wrap.',
     // });
-    const events = eventFactory.buildList(10, {
-      action: 'lke_node_create',
-      percent_complete: 15,
-      entity: { type: 'linode', id: 999, label: 'linode-1' },
-      message:
-        'Rebooting this thing and showing an extremely long event message for no discernible reason other than the fairly obvious reason that we want to do some testing of whether or not these messages wrap.',
-    });
-    const volumeMigrationScheduled = eventFactory.build({
-      entity: { type: 'volume', id: 6, label: 'bravoExample' },
-      action: 'volume_migrate_scheduled' as EventAction,
-      status: 'scheduled',
-      message: 'Volume bravoExample has been scheduled for an upgrade to NVMe.',
-      percent_complete: 100,
-    });
-    const volumeMigrating = eventFactory.build({
-      entity: { type: 'volume', id: 2, label: 'example-upgrading' },
-      action: 'volume_migrate' as EventAction,
-      status: 'started',
-      message: 'Volume example-upgrading is being upgraded to NVMe.',
-      percent_complete: 65,
-    });
-    const volumeMigrationFinished = eventFactory.build({
-      entity: { type: 'volume', id: 6, label: 'alphaExample' },
-      action: 'volume_migrate',
-      status: 'finished',
-      message: 'Volume alphaExample has finished upgrading to NVMe.',
-      percent_complete: 100,
-    });
+    // const volumeMigrationScheduled = eventFactory.build({
+    //   entity: { type: 'volume', id: 6, label: 'bravoExample' },
+    //   action: 'volume_migrate_scheduled' as EventAction,
+    //   status: 'scheduled',
+    //   message: 'Volume bravoExample has been scheduled for an upgrade to NVMe.',
+    //   percent_complete: 100,
+    // });
+    // const volumeMigrating = eventFactory.build({
+    //   entity: { type: 'volume', id: 2, label: 'example-upgrading' },
+    //   action: 'volume_migrate' as EventAction,
+    //   status: 'started',
+    //   message: 'Volume example-upgrading is being upgraded to NVMe.',
+    //   percent_complete: 65,
+    // });
+    // const volumeMigrationFinished = eventFactory.build({
+    //   entity: { type: 'volume', id: 6, label: 'alphaExample' },
+    //   action: 'volume_migrate',
+    //   status: 'finished',
+    //   message: 'Volume alphaExample has finished upgrading to NVMe.',
+    //   percent_complete: 100,
+    // });
     const oldEvents = eventFactory.buildList(20, {
       action: 'account_update',
       seen: true,
@@ -740,12 +733,11 @@ export const handlers = [
     return res.once(
       ctx.json(
         makeResourcePage([
-          ...events,
+          // ...events,
           ...oldEvents,
-          ...oldEvents,
-          volumeMigrationScheduled,
-          volumeMigrating,
-          volumeMigrationFinished,
+          // volumeMigrationScheduled,
+          // volumeMigrating,
+          // volumeMigrationFinished,
         ])
       )
     );
@@ -819,149 +811,149 @@ export const handlers = [
   rest.get('*stackscripts/', (req, res, ctx) => {
     return res(ctx.json(makeResourcePage(stackScriptFactory.buildList(1))));
   }),
-  rest.get('*/notifications', (req, res, ctx) => {
-    // pastDueBalance included here merely for ease of testing for Notifications section in the Notifications drawer.
-    const pastDueBalance = notificationFactory.build({
-      entity: null,
-      label: 'past due',
-      message: `You have a past due balance of $58.50. Please make a payment immediately to avoid service disruption.`,
-      type: 'payment_due',
-      severity: 'critical',
-      when: null,
-      until: null,
-      body: null,
-    });
+  // rest.get('*/notifications', (req, res, ctx) => {
+  // pastDueBalance included here merely for ease of testing for Notifications section in the Notifications drawer.
+  // const pastDueBalance = notificationFactory.build({
+  //   entity: null,
+  //   label: 'past due',
+  //   message: `You have a past due balance of $58.50. Please make a payment immediately to avoid service disruption.`,
+  //   type: 'payment_due',
+  //   severity: 'critical',
+  //   when: null,
+  //   until: null,
+  //   body: null,
+  // });
 
-    // const gdprNotification = gdprComplianceNotification.build();
+  // const gdprNotification = gdprComplianceNotification.build();
 
-    const generalGlobalNotice = {
-      type: 'notice',
-      entity: null,
-      when: null,
-      // eslint-disable-next-line xss/no-mixed-html
-      message:
-        "We've updated our policies. See <a href='https://cloud.linode.com/support'>this page</a> for more information.",
-      label: "We've updated our policies.",
-      severity: 'minor',
-      until: null,
-      body: null,
-    };
+  // const generalGlobalNotice = {
+  //   type: 'notice',
+  //   entity: null,
+  //   when: null,
+  //   // eslint-disable-next-line xss/no-mixed-html
+  //   message:
+  //     "We've updated our policies. See <a href='https://cloud.linode.com/support'>this page</a> for more information.",
+  //   label: "We've updated our policies.",
+  //   severity: 'minor',
+  //   until: null,
+  //   body: null,
+  // };
 
-    const outageNotification = {
-      type: 'outage',
-      entity: {
-        type: 'region',
-        label: null,
-        id: 'us-east',
-        url: '/regions/us-east',
-      },
-      when: null,
-      message:
-        'We are aware of an issue affecting service in this facility. If you are experiencing service issues in this facility, there is no need to open a support ticket at this time. Please monitor our status blog at https://status.linode.com for further information.  Thank you for your patience and understanding.',
-      label: 'There is an issue affecting service in this facility',
-      severity: 'major',
-      until: null,
-      body: null,
-    };
+  // const outageNotification = {
+  //   type: 'outage',
+  //   entity: {
+  //     type: 'region',
+  //     label: null,
+  //     id: 'us-east',
+  //     url: '/regions/us-east',
+  //   },
+  //   when: null,
+  //   message:
+  //     'We are aware of an issue affecting service in this facility. If you are experiencing service issues in this facility, there is no need to open a support ticket at this time. Please monitor our status blog at https://status.linode.com for further information.  Thank you for your patience and understanding.',
+  //   label: 'There is an issue affecting service in this facility',
+  //   severity: 'major',
+  //   until: null,
+  //   body: null,
+  // };
 
-    const emailBounce = notificationFactory.build({
-      type: 'billing_email_bounce',
-      entity: null,
-      when: null,
-      message: 'We are unable to send emails to your billing email address!',
-      label: 'We are unable to send emails to your billing email address!',
-      severity: 'major',
-      until: null,
-      body: null,
-    });
+  // const emailBounce = notificationFactory.build({
+  //   type: 'billing_email_bounce',
+  //   entity: null,
+  //   when: null,
+  //   message: 'We are unable to send emails to your billing email address!',
+  //   label: 'We are unable to send emails to your billing email address!',
+  //   severity: 'major',
+  //   until: null,
+  //   body: null,
+  // });
 
-    // const abuseTicket = abuseTicketNotificationFactory.build();
+  // const abuseTicket = abuseTicketNotificationFactory.build();
 
-    const migrationNotification = notificationFactory.build({
-      type: 'migration_pending',
-      label: 'You have a migration pending!',
-      message:
-        'You have a migration pending! Your Linode must be offline before starting the migration.',
-      entity: { id: 0, type: 'linode', label: 'linode-0' },
-      severity: 'major',
-    });
+  // const migrationNotification = notificationFactory.build({
+  //   type: 'migration_pending',
+  //   label: 'You have a migration pending!',
+  //   message:
+  //     'You have a migration pending! Your Linode must be offline before starting the migration.',
+  //   entity: { id: 0, type: 'linode', label: 'linode-0' },
+  //   severity: 'major',
+  // });
 
-    const minorSeverityNotification = notificationFactory.build({
-      type: 'notice',
-      message: 'Testing for minor notification',
-      severity: 'minor',
-    });
+  // const minorSeverityNotification = notificationFactory.build({
+  //   type: 'notice',
+  //   message: 'Testing for minor notification',
+  //   severity: 'minor',
+  // });
 
-    const criticalSeverityNotification = notificationFactory.build({
-      type: 'notice',
-      message: 'Testing for critical notification',
-      severity: 'critical',
-    });
+  // const criticalSeverityNotification = notificationFactory.build({
+  //   type: 'notice',
+  //   message: 'Testing for critical notification',
+  //   severity: 'critical',
+  // });
 
-    const balanceNotification = notificationFactory.build({
-      type: 'payment_due',
-      message: 'You have an overdue balance!',
-      severity: 'major',
-    });
+  // const balanceNotification = notificationFactory.build({
+  //   type: 'payment_due',
+  //   message: 'You have an overdue balance!',
+  //   severity: 'major',
+  // });
 
-    const blockStorageMigrationScheduledNotification = notificationFactory.build(
-      {
-        type: 'volume_migration_scheduled' as NotificationType,
-        entity: {
-          type: 'volume',
-          label: 'eligibleNow',
-          id: 20,
-          url: '/volumes/20',
-        },
-        when: '2021-09-30T04:00:00',
-        message:
-          'The Linode that the volume is attached to will shut down in order to complete the upgrade and reboot once it is complete. Any other volumes attached to the same Linode will also be upgraded.',
-        label: 'You have a scheduled Block Storage volume upgrade pending!',
-        severity: 'critical',
-        until: '2021-10-16T04:00:00',
-        body: 'Your volumes in us-east will be upgraded to NVMe.',
-      }
-    );
+  // const blockStorageMigrationScheduledNotification = notificationFactory.build(
+  //   {
+  //     type: 'volume_migration_scheduled' as NotificationType,
+  //     entity: {
+  //       type: 'volume',
+  //       label: 'eligibleNow',
+  //       id: 20,
+  //       url: '/volumes/20',
+  //     },
+  //     when: '2021-09-30T04:00:00',
+  //     message:
+  //       'The Linode that the volume is attached to will shut down in order to complete the upgrade and reboot once it is complete. Any other volumes attached to the same Linode will also be upgraded.',
+  //     label: 'You have a scheduled Block Storage volume upgrade pending!',
+  //     severity: 'critical',
+  //     until: '2021-10-16T04:00:00',
+  //     body: 'Your volumes in us-east will be upgraded to NVMe.',
+  //   }
+  // );
 
-    const blockStorageMigrationImminentNotification = notificationFactory.build(
-      {
-        type: 'volume_migration_imminent' as NotificationType,
-        entity: {
-          type: 'volume',
-          label: 'example-upgrading',
-          id: 2,
-          url: '/volumes/2',
-        },
-        when: '2021-09-30T04:00:00',
-        message:
-          'The Linode that the volume is attached to will shut down in order to complete the upgrade and reboot once it is complete. Any other volumes attached to the same Linode will also be upgraded.',
-        label: 'You have a scheduled Block Storage volume upgrade pending!',
-        severity: 'major',
-        until: '2021-10-16T04:00:00',
-        body: 'Your volumes in us-east will be upgraded to NVMe.',
-      }
-    );
+  // const blockStorageMigrationImminentNotification = notificationFactory.build(
+  //   {
+  //     type: 'volume_migration_imminent' as NotificationType,
+  //     entity: {
+  //       type: 'volume',
+  //       label: 'example-upgrading',
+  //       id: 2,
+  //       url: '/volumes/2',
+  //     },
+  //     when: '2021-09-30T04:00:00',
+  //     message:
+  //       'The Linode that the volume is attached to will shut down in order to complete the upgrade and reboot once it is complete. Any other volumes attached to the same Linode will also be upgraded.',
+  //     label: 'You have a scheduled Block Storage volume upgrade pending!',
+  //     severity: 'major',
+  //     until: '2021-10-16T04:00:00',
+  //     body: 'Your volumes in us-east will be upgraded to NVMe.',
+  //   }
+  // );
 
-    return res(
-      ctx.json(
-        makeResourcePage([
-          pastDueBalance,
-          ...notificationFactory.buildList(1),
-          // gdprNotification,
-          generalGlobalNotice,
-          outageNotification,
-          minorSeverityNotification,
-          criticalSeverityNotification,
-          // abuseTicket,
-          emailBounce,
-          migrationNotification,
-          balanceNotification,
-          blockStorageMigrationScheduledNotification,
-          blockStorageMigrationImminentNotification,
-        ])
-      )
-    );
-  }),
+  // return res(
+  //   ctx.json(
+  //     makeResourcePage([
+  // pastDueBalance,
+  // ...notificationFactory.buildList(1),
+  // gdprNotification,
+  // generalGlobalNotice,
+  // outageNotification,
+  // minorSeverityNotification,
+  // criticalSeverityNotification,
+  // abuseTicket,
+  // emailBounce,
+  // migrationNotification,
+  // balanceNotification,
+  //         blockStorageMigrationScheduledNotification,
+  //         blockStorageMigrationImminentNotification,
+  //       ])
+  //     )
+  //   );
+  // }),
   rest.post('*/networking/vlans', (req, res, ctx) => {
     return res(ctx.json({}));
   }),

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -704,6 +704,13 @@ export const handlers = [
     //   message:
     //     'Rebooting this thing and showing an extremely long event message for no discernible reason other than the fairly obvious reason that we want to do some testing of whether or not these messages wrap.',
     // });
+    const events = eventFactory.buildList(10, {
+      action: 'lke_node_create',
+      percent_complete: 15,
+      entity: { type: 'linode', id: 999, label: 'linode-1' },
+      message:
+        'Rebooting this thing and showing an extremely long event message for no discernible reason other than the fairly obvious reason that we want to do some testing of whether or not these messages wrap.',
+    });
     const volumeMigrationScheduled = eventFactory.build({
       entity: { type: 'volume', id: 6, label: 'bravoExample' },
       action: 'volume_migrate_scheduled' as EventAction,
@@ -733,7 +740,7 @@ export const handlers = [
     return res.once(
       ctx.json(
         makeResourcePage([
-          // ...events,
+          ...events,
           ...oldEvents,
           ...oldEvents,
           volumeMigrationScheduled,
@@ -814,88 +821,88 @@ export const handlers = [
   }),
   rest.get('*/notifications', (req, res, ctx) => {
     // pastDueBalance included here merely for ease of testing for Notifications section in the Notifications drawer.
-    // const pastDueBalance = notificationFactory.build({
-    //   entity: null,
-    //   label: 'past due',
-    //   message: `You have a past due balance of $58.50. Please make a payment immediately to avoid service disruption.`,
-    //   type: 'payment_due',
-    //   severity: 'critical',
-    //   when: null,
-    //   until: null,
-    //   body: null
-    // });
+    const pastDueBalance = notificationFactory.build({
+      entity: null,
+      label: 'past due',
+      message: `You have a past due balance of $58.50. Please make a payment immediately to avoid service disruption.`,
+      type: 'payment_due',
+      severity: 'critical',
+      when: null,
+      until: null,
+      body: null,
+    });
 
     // const gdprNotification = gdprComplianceNotification.build();
 
-    // const generalGlobalNotice = {
-    //   type: 'notice',
-    //   entity: null,
-    //   when: null,
-    //   // eslint-disable-next-line xss/no-mixed-html
-    //   message:
-    //     "We've updated our policies. See <a href='https://cloud.linode.com/support'>this page</a> for more information.",
-    //   label: "We've updated our policies.",
-    //   severity: 'minor',
-    //   until: null,
-    //   body: null,
-    // };
+    const generalGlobalNotice = {
+      type: 'notice',
+      entity: null,
+      when: null,
+      // eslint-disable-next-line xss/no-mixed-html
+      message:
+        "We've updated our policies. See <a href='https://cloud.linode.com/support'>this page</a> for more information.",
+      label: "We've updated our policies.",
+      severity: 'minor',
+      until: null,
+      body: null,
+    };
 
-    // const outageNotification = {
-    //   type: 'outage',
-    //   entity: {
-    //     type: 'region',
-    //     label: null,
-    //     id: 'us-east',
-    //     url: '/regions/us-east',
-    //   },
-    //   when: null,
-    //   message:
-    //     'We are aware of an issue affecting service in this facility. If you are experiencing service issues in this facility, there is no need to open a support ticket at this time. Please monitor our status blog at https://status.linode.com for further information.  Thank you for your patience and understanding.',
-    //   label: 'There is an issue affecting service in this facility',
-    //   severity: 'major',
-    //   until: null,
-    //   body: null,
-    // };
+    const outageNotification = {
+      type: 'outage',
+      entity: {
+        type: 'region',
+        label: null,
+        id: 'us-east',
+        url: '/regions/us-east',
+      },
+      when: null,
+      message:
+        'We are aware of an issue affecting service in this facility. If you are experiencing service issues in this facility, there is no need to open a support ticket at this time. Please monitor our status blog at https://status.linode.com for further information.  Thank you for your patience and understanding.',
+      label: 'There is an issue affecting service in this facility',
+      severity: 'major',
+      until: null,
+      body: null,
+    };
 
-    // const emailBounce = notificationFactory.build({
-    //   type: 'billing_email_bounce',
-    //   entity: null,
-    //   when: null,
-    //   message: 'We are unable to send emails to your billing email address!',
-    //   label: 'We are unable to send emails to your billing email address!',
-    //   severity: 'major',
-    //   until: null,
-    //   body: null,
-    // });
+    const emailBounce = notificationFactory.build({
+      type: 'billing_email_bounce',
+      entity: null,
+      when: null,
+      message: 'We are unable to send emails to your billing email address!',
+      label: 'We are unable to send emails to your billing email address!',
+      severity: 'major',
+      until: null,
+      body: null,
+    });
 
     // const abuseTicket = abuseTicketNotificationFactory.build();
 
-    // const migrationNotification = notificationFactory.build({
-    //   type: 'migration_pending',
-    //   label: 'You have a migration pending!',
-    //   message:
-    //     'You have a migration pending! Your Linode must be offline before starting the migration.',
-    //   entity: { id: 0, type: 'linode', label: 'linode-0' },
-    //   severity: 'major',
-    // });
+    const migrationNotification = notificationFactory.build({
+      type: 'migration_pending',
+      label: 'You have a migration pending!',
+      message:
+        'You have a migration pending! Your Linode must be offline before starting the migration.',
+      entity: { id: 0, type: 'linode', label: 'linode-0' },
+      severity: 'major',
+    });
 
-    // const minorSeverityNotification = notificationFactory.build({
-    //   type: 'notice',
-    //   message: 'Testing for minor notification',
-    //   severity: 'minor',
-    // });
+    const minorSeverityNotification = notificationFactory.build({
+      type: 'notice',
+      message: 'Testing for minor notification',
+      severity: 'minor',
+    });
 
-    // const criticalSeverityNotification = notificationFactory.build({
-    //   type: 'notice',
-    //   message: 'Testing for critical notification',
-    //   severity: 'critical',
-    // });
+    const criticalSeverityNotification = notificationFactory.build({
+      type: 'notice',
+      message: 'Testing for critical notification',
+      severity: 'critical',
+    });
 
-    // const balanceNotification = notificationFactory.build({
-    //   type: 'payment_due',
-    //   message: 'You have an overdue balance!',
-    //   severity: 'major',
-    // });
+    const balanceNotification = notificationFactory.build({
+      type: 'payment_due',
+      message: 'You have an overdue balance!',
+      severity: 'major',
+    });
 
     const blockStorageMigrationScheduledNotification = notificationFactory.build(
       {
@@ -938,17 +945,17 @@ export const handlers = [
     return res(
       ctx.json(
         makeResourcePage([
-          // pastDueBalance,
-          // ...notificationFactory.buildList(1),
+          pastDueBalance,
+          ...notificationFactory.buildList(1),
           // gdprNotification,
-          // generalGlobalNotice,
-          // outageNotification,
-          // minorSeverityNotification,
-          // criticalSeverityNotification,
+          generalGlobalNotice,
+          outageNotification,
+          minorSeverityNotification,
+          criticalSeverityNotification,
           // abuseTicket,
-          // emailBounce,
-          // migrationNotification,
-          // balanceNotification,
+          emailBounce,
+          migrationNotification,
+          balanceNotification,
           blockStorageMigrationScheduledNotification,
           blockStorageMigrationImminentNotification,
         ])


### PR DESCRIPTION
## Description

This PR updates the UI for the notification drawer and it's empty state. The notification drawer is less of a drawer and is more consistent with the user menu. 

**Todo:**
- [x] Refactor `NotificationDrawer` to implement a Menu component (such as from the Reach package) instead of adding conditional logic inside of our `Drawer` component
- [x] Update namings from drawer to menu

**Tasks that will be addressed in a future PR:**
- [ ] Bold the username, action and entity name in the event messages inside the notification drawer

## How to test

Check the notification events view:
- Notifications but a few events (< 5 events)
- Notifications but a lot of events (turn on mocks)
- No notifications and no events (comment out code inside of `serverHandlers.ts`)

Test menu opening/closing:
- Opening the menu via another action other than the bell icon (such as clicking on a Linode's status when it is booting)
- Toggling the menu by double clicking the bell icon
- Clicking inside the menu should not close the menu
    - Unless you clicked a link inside the menu (such as `View all events`), then the menu should close

Other:
- Browsers such as Firefox and Safari
- Mobile view