### PR TITLE
M3-5733: Support Ticket Refinements

### DIFF
--- a/packages/manager/src/components/TabLinkList/TabLinkList.tsx
+++ b/packages/manager/src/components/TabLinkList/TabLinkList.tsx
@@ -2,53 +2,6 @@ import { Link } from '@reach/router';
 import * as React from 'react';
 import Tab from 'src/components/core/ReachTab';
 import TabList from 'src/components/core/ReachTabList';
-import { makeStyles, Theme } from 'src/components/core/styles';
-
-const useStyles = makeStyles((theme: Theme) => ({
-  tab: {
-    '&[data-reach-tab]': {
-      display: 'inline-flex',
-      flexShrink: 0,
-      alignItems: 'center',
-      borderBottom: '2px solid transparent',
-      color: theme.textColors.linkActiveLight,
-      fontSize: '0.9rem',
-      lineHeight: 1.3,
-      marginTop: theme.spacing(0.5),
-      maxWidth: 264,
-      minHeight: theme.spacing(5),
-      minWidth: 50,
-      padding: '6px 16px',
-      textDecoration: 'none',
-      '&:focus': {
-        backgroundColor: theme.color.grey7,
-      },
-      '&:hover': {
-        backgroundColor: theme.color.grey7,
-        color: theme.palette.primary.main,
-      },
-    },
-    '&[data-reach-tab][data-selected]': {
-      borderBottom: `3px solid ${theme.textColors.linkActiveLight}`,
-      color: theme.textColors.headlineStatic,
-      fontFamily: theme.font.bold,
-    },
-  },
-  tabList: {
-    color: theme.color.tableHeaderText,
-    '&[data-reach-tab-list]': {
-      background: 'none !important',
-      boxShadow: `inset 0 -1px 0 ${
-        theme.name === 'lightTheme' ? '#e3e5e8' : '#2e3238'
-      }`,
-      marginBottom: theme.spacing(),
-      [theme.breakpoints.down('md')]: {
-        overflowX: 'auto',
-        padding: 1,
-      },
-    },
-  },
-}));
 
 export interface Tab {
   title: string;
@@ -61,23 +14,17 @@ interface Props {
   noLink?: boolean; // @todo: remove this prop if we use NavTab widely.
 }
 
-type CombinedProps = Props;
-
-export const TabLinkList: React.FC<CombinedProps> = (props) => {
-  const classes = useStyles();
-  const { tabs } = props;
-
+export const TabLinkList: React.FC<Props> = ({ tabs, noLink }) => {
   return (
-    <TabList className={classes.tabList}>
+    <TabList>
       {tabs.map((tab, _index) => {
         // @todo: remove this if we use NavTab widely.
-        const extraTemporaryProps: any = props.noLink
+        const extraTemporaryProps: any = noLink
           ? {}
           : { as: Link, to: tab.routeName };
 
         return (
           <Tab
-            className={classes.tab}
             key={`tab-${_index}`}
             // @todo: remove this if we use NavTab widely.
             {...extraTemporaryProps}

--- a/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
+++ b/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
@@ -118,9 +118,11 @@ export const TabbedPanel: React.FC<CombinedProps> = (props) => {
         )}
 
         <Tabs className={classes.tabsWrapper} onChange={handleTabChange}>
-          <TabList>
+          <TabList className={classes.tabList}>
             {tabs.map((tab, idx) => (
-              <Tab key={`tabs-${tab.title}-${idx}`}>{tab.title}</Tab>
+              <Tab className={classes.tab} key={`tabs-${tab.title}-${idx}`}>
+                {tab.title}
+              </Tab>
             ))}
           </TabList>
 

--- a/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
+++ b/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
@@ -25,43 +25,19 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   tab: {
     '&[data-reach-tab]': {
-      display: 'inline-flex',
-      flexShrink: 0,
-      alignItems: 'center',
-      borderBottom: '2px solid transparent',
-      color: theme.textColors.linkActiveLight,
-      fontSize: '0.9rem',
-      lineHeight: 1.3,
-      marginTop: theme.spacing(0.5),
-      maxWidth: 264,
-      minHeight: theme.spacing(5),
-      minWidth: 50,
-      padding: '6px 16px',
-      textDecoration: 'none',
       '&:focus': {
         backgroundColor: theme.bg.tableHeader,
       },
       '&:hover': {
         backgroundColor: theme.bg.tableHeader,
-        color: theme.palette.primary.main,
       },
-    },
-    '&[data-reach-tab][data-selected]': {
-      borderBottom: `3px solid ${theme.textColors.linkActiveLight}`,
-      color: theme.textColors.headlineStatic,
-      fontFamily: theme.font.bold,
     },
   },
   tabList: {
     '&[data-reach-tab-list]': {
-      background: 'none !important',
       boxShadow: `inset 0 -1px 0 ${theme.borderColors.divider}`,
       marginTop: 22,
       marginBottom: theme.spacing(3),
-      [theme.breakpoints.down('md')]: {
-        overflowX: 'auto',
-        padding: 1,
-      },
     },
   },
 }));

--- a/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
+++ b/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
@@ -118,11 +118,9 @@ export const TabbedPanel: React.FC<CombinedProps> = (props) => {
         )}
 
         <Tabs className={classes.tabsWrapper} onChange={handleTabChange}>
-          <TabList className={classes.tabList}>
+          <TabList>
             {tabs.map((tab, idx) => (
-              <Tab className={classes.tab} key={`tabs-${tab.title}-${idx}`}>
-                {tab.title}
-              </Tab>
+              <Tab key={`tabs-${tab.title}-${idx}`}>{tab.title}</Tab>
             ))}
           </TabList>
 

--- a/packages/manager/src/components/core/ReachTab.ts
+++ b/packages/manager/src/components/core/ReachTab.ts
@@ -1,3 +1,0 @@
-import { Tab } from '@reach/tabs';
-
-export default Tab;

--- a/packages/manager/src/components/core/ReachTab.tsx
+++ b/packages/manager/src/components/core/ReachTab.tsx
@@ -34,9 +34,8 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-const Tab: React.FC<TabProps> = (props) => {
+const Tab: React.FC<TabProps> = ({ children, ...rest }) => {
   const classes = useStyles();
-  const { children, ...rest } = props;
 
   return (
     <ReachTab className={classes.tab} {...rest}>

--- a/packages/manager/src/components/core/ReachTab.tsx
+++ b/packages/manager/src/components/core/ReachTab.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { Tab as ReachTab, TabProps } from '@reach/tabs';
+import { makeStyles, Theme } from './styles';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  tab: {
+    '&[data-reach-tab]': {
+      display: 'inline-flex',
+      flexShrink: 0,
+      alignItems: 'center',
+      borderBottom: '2px solid transparent',
+      color: theme.textColors.linkActiveLight,
+      fontSize: '0.9rem',
+      lineHeight: 1.3,
+      marginTop: theme.spacing(0.5),
+      maxWidth: 264,
+      minHeight: theme.spacing(5),
+      minWidth: 50,
+      padding: '6px 16px',
+      textDecoration: 'none',
+      '&:focus': {
+        backgroundColor: theme.color.grey7,
+      },
+      '&:hover': {
+        backgroundColor: theme.color.grey7,
+        color: theme.palette.primary.main,
+      },
+    },
+    '&[data-reach-tab][data-selected]': {
+      borderBottom: `3px solid ${theme.textColors.linkActiveLight}`,
+      color: theme.textColors.headlineStatic,
+      fontFamily: theme.font.bold,
+    },
+  },
+}));
+
+const Tab: React.FC<TabProps> = (props) => {
+  const classes = useStyles();
+  const { children, ...rest } = props;
+
+  return (
+    <ReachTab className={classes.tab} {...rest}>
+      {children}
+    </ReachTab>
+  );
+};
+
+export default Tab;

--- a/packages/manager/src/components/core/ReachTab.tsx
+++ b/packages/manager/src/components/core/ReachTab.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Tab as ReachTab, TabProps } from '@reach/tabs';
 import { makeStyles, Theme } from './styles';
+import classNames from 'classnames';
 
 const useStyles = makeStyles((theme: Theme) => ({
   tab: {
@@ -34,11 +35,15 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-const Tab: React.FC<TabProps> = ({ children, ...rest }) => {
+const Tab: React.FC<TabProps & { className?: string }> = ({
+  children,
+  className,
+  ...rest
+}) => {
   const classes = useStyles();
 
   return (
-    <ReachTab className={classes.tab} {...rest}>
+    <ReachTab className={classNames(classes.tab, className)} {...rest}>
       {children}
     </ReachTab>
   );

--- a/packages/manager/src/components/core/ReachTabList.ts
+++ b/packages/manager/src/components/core/ReachTabList.ts
@@ -1,3 +1,0 @@
-import { TabList } from '@reach/tabs';
-
-export default TabList;

--- a/packages/manager/src/components/core/ReachTabList.tsx
+++ b/packages/manager/src/components/core/ReachTabList.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { TabList as ReachTabList, TabListProps } from '@reach/tabs';
+import { makeStyles, Theme } from './styles';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  tabList: {
+    color: theme.color.tableHeaderText,
+    '&[data-reach-tab-list]': {
+      background: 'none !important',
+      boxShadow: `inset 0 -1px 0 ${
+        theme.name === 'lightTheme' ? '#e3e5e8' : '#2e3238'
+      }`,
+      marginBottom: theme.spacing(),
+      [theme.breakpoints.down('md')]: {
+        overflowX: 'auto',
+        padding: 1,
+      },
+    },
+  },
+}));
+
+const TabList: React.FC<TabListProps> = (props) => {
+  const classes = useStyles();
+  const { children, ...rest } = props;
+
+  return (
+    <ReachTabList className={classes.tabList} {...rest}>
+      {children}
+    </ReachTabList>
+  );
+};
+
+export default TabList;

--- a/packages/manager/src/components/core/ReachTabList.tsx
+++ b/packages/manager/src/components/core/ReachTabList.tsx
@@ -19,9 +19,8 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-const TabList: React.FC<TabListProps> = (props) => {
+const TabList: React.FC<TabListProps> = ({ children, ...rest }) => {
   const classes = useStyles();
-  const { children, ...rest } = props;
 
   return (
     <ReachTabList className={classes.tabList} {...rest}>

--- a/packages/manager/src/components/core/ReachTabList.tsx
+++ b/packages/manager/src/components/core/ReachTabList.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { TabList as ReachTabList, TabListProps } from '@reach/tabs';
 import { makeStyles, Theme } from './styles';
+import classNames from 'classnames';
 
 const useStyles = makeStyles((theme: Theme) => ({
   tabList: {
@@ -19,11 +20,15 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-const TabList: React.FC<TabListProps> = ({ children, ...rest }) => {
+const TabList: React.FC<TabListProps & { className?: string }> = ({
+  children,
+  className,
+  ...rest
+}) => {
   const classes = useStyles();
 
   return (
-    <ReachTabList className={classes.tabList} {...rest}>
+    <ReachTabList className={classNames(classes.tabList, className)} {...rest}>
       {children}
     </ReachTabList>
   );

--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketsLanding.test.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketsLanding.test.tsx
@@ -15,9 +15,6 @@ describe('Support Tickets Landing', () => {
       classes={{
         title: '',
         openTicketButton: '',
-        tabsWrapper: '',
-        tabList: '',
-        tab: '',
       }}
       {...reactRouterProps}
     />

--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketsLanding.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketsLanding.tsx
@@ -27,12 +27,7 @@ import { AttachmentError } from '../SupportTicketDetail/SupportTicketDetail';
 import SupportTicketDrawer from './SupportTicketDrawer';
 import TicketList from './TicketList';
 
-type ClassNames =
-  | 'title'
-  | 'openTicketButton'
-  | 'tabsWrapper'
-  | 'tab'
-  | 'tabList';
+type ClassNames = 'title' | 'openTicketButton';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -45,45 +40,6 @@ const styles = (theme: Theme) =>
       minWidth: 150,
       [theme.breakpoints.down('sm')]: {
         marginRight: theme.spacing(),
-      },
-    },
-    tabsWrapper: {
-      position: 'relative',
-    },
-    tab: {
-      '&[data-reach-tab]': {
-        display: 'inline-flex',
-        flexShrink: 0,
-        alignItems: 'center',
-        borderBottom: '2px solid transparent',
-        color: theme.textColors.linkActiveLight,
-        fontSize: '0.9rem',
-        lineHeight: 1.3,
-        marginTop: theme.spacing(0.5),
-        maxWidth: 264,
-        minHeight: theme.spacing(5),
-        minWidth: 50,
-        padding: '6px 16px',
-        textDecoration: 'none',
-        '&:hover': {
-          color: theme.palette.primary.main,
-        },
-      },
-      '&[data-reach-tab][data-selected]': {
-        borderBottom: `3px solid ${theme.palette.primary.main}`,
-        color: theme.color.headline,
-        fontFamily: theme.font.bold,
-      },
-    },
-    tabList: {
-      '&[data-reach-tab-list]': {
-        background: 'none !important',
-        boxShadow: `inset 0 -1px 0 ${theme.color.border2}`,
-        marginBottom: theme.spacing(),
-        [theme.breakpoints.down('md')]: {
-          overflowX: 'auto',
-          padding: 1,
-        },
       },
     },
   });
@@ -251,14 +207,10 @@ export class SupportTicketsLanding extends React.PureComponent<
           )}
         </Grid>
         {notice && <Notice success text={notice} />}
-        <Tabs defaultIndex={value} className={classes.tabsWrapper}>
-          <TabList className={classes.tabList}>
-            <Tab data-qa-tab="Open Tickets" key={0} className={classes.tab}>
-              Open Tickets
-            </Tab>
-            <Tab data-qa-tab="Closed Tickets" key={1} className={classes.tab}>
-              Closed Tickets
-            </Tab>
+        <Tabs defaultIndex={value}>
+          <TabList>
+            <Tab data-qa-tab="Open Tickets">Open Tickets</Tab>
+            <Tab data-qa-tab="Closed Tickets">Closed Tickets</Tab>
           </TabList>
           <TabPanels>
             <TabPanel>

--- a/packages/manager/src/features/Support/SupportTickets/TicketRow.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/TicketRow.tsx
@@ -1,35 +1,23 @@
-import { SupportTicket } from '@linode/api-v4/lib/support';
 import * as React from 'react';
-import { Link } from 'react-router-dom';
 import Hidden from 'src/components/core/Hidden';
-import {
-  createStyles,
-  withStyles,
-  WithStyles,
-} from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import DateTimeDisplay from 'src/components/DateTimeDisplay';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
+import { SupportTicket } from '@linode/api-v4/lib/support';
+import { Link } from 'react-router-dom';
+import { makeStyles } from 'src/components/core/styles';
 import { getLinkTargets } from 'src/utilities/getEventsActionLink';
+
+const useStyles = makeStyles(() => ({
+  regarding: {
+    lineHeight: 1.1,
+  },
+}));
 
 interface Props {
   ticket: SupportTicket;
 }
-
-type ClassNames = 'summary' | 'regarding';
-
-const styles = () =>
-  createStyles({
-    summary: {
-      lineHeight: 1.1,
-    },
-    regarding: {
-      lineHeight: 1.1,
-    },
-  });
-
-type CombinedProps = Props & WithStyles<ClassNames>;
 
 const renderEntityLink = (ticket: SupportTicket) => {
   const target = getLinkTargets(ticket.entity);
@@ -49,8 +37,10 @@ const renderEntityLink = (ticket: SupportTicket) => {
   null;
 };
 
-const TicketRow: React.FC<CombinedProps> = (props) => {
-  const { ticket, classes } = props;
+const TicketRow: React.FC<Props> = (props) => {
+  const classes = useStyles();
+  const { ticket } = props;
+
   return (
     <TableRow
       data-qa-support-ticket={ticket.id}
@@ -59,16 +49,11 @@ const TicketRow: React.FC<CombinedProps> = (props) => {
       ariaLabel={`Ticket subject ${ticket.summary}`}
     >
       <TableCell data-qa-support-subject>
-        <Link to={`/support/tickets/${ticket.id}`}>
-          <Typography variant="h3" className={classes.summary}>
-            {ticket.summary}
-          </Typography>
-        </Link>
+        <Link to={`/support/tickets/${ticket.id}`}>{ticket.summary}</Link>
       </TableCell>
       <Hidden smDown>
         <TableCell data-qa-support-id>{ticket.id}</TableCell>
       </Hidden>
-
       <TableCell data-qa-support-entity className={classes.regarding}>
         {renderEntityLink(ticket)}
       </TableCell>
@@ -87,6 +72,4 @@ const TicketRow: React.FC<CombinedProps> = (props) => {
   );
 };
 
-const styled = withStyles(styles);
-
-export default styled(TicketRow);
+export default TicketRow;

--- a/packages/manager/src/features/Support/SupportTickets/TicketRow.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/TicketRow.tsx
@@ -37,9 +37,8 @@ const renderEntityLink = (ticket: SupportTicket) => {
   null;
 };
 
-const TicketRow: React.FC<Props> = (props) => {
+const TicketRow: React.FC<Props> = ({ ticket }) => {
   const classes = useStyles();
-  const { ticket } = props;
 
   return (
     <TableRow


### PR DESCRIPTION
## Description

- Update support ticket table links to match our newest pattern for links in tables
- The old tab styles were driving me nuts so...
  - Wrap Reach Tabs and TabList so we can apply our styles to them before we import them in other components

### Before

![Screen Shot 2022-04-04 at 2 30 36 PM](https://user-images.githubusercontent.com/6440455/161610107-09bff66e-1600-4b42-8b10-b76825b5665f.jpg)

### After

![Screen Shot 2022-04-04 at 2 30 28 PM](https://user-images.githubusercontent.com/6440455/161610132-487ad877-e507-42d3-b72d-1e6879af4e44.jpg)

## How to test

- Go to `/support/tickets` and check Tab styles and link styles in the table
- Please check **all Tabs** in Cloud Manager because of the minor refactor
