### PR TITLE
GitHub Actions Tweak

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,11 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: "14.17.4"
+      - uses: actions/cache@v2
+        with:
+          path: |
+            **/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn --frozen-lockfile
       - run: yarn workspace @linode/validation run build
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
## Description

- Adds `node_modules` cache to the `build-validation` stage of our Github Actions CI so that `yarn install` does not have to download packages every time that stage runs
- I'm unsure of why we didn't already have cache on this one stage. Maybe it was overlooked, but maybe there is good reason?
- This should speed up `ci` by about 1-3 minutes

Looks like this was removed in #7475. Does anyone know why? 

## How to test

- Merge and see if it works
