### PR TITLE
M3-5574: Update Chip variants

### DIFF
--- a/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.tsx
+++ b/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.tsx
@@ -28,9 +28,6 @@ export const useStyles = makeStyles((theme: Theme) => ({
     display: 'flex',
     alignItems: 'center',
   },
-  chip: {
-    fontSize: '0.625rem',
-  },
   container: {
     flexWrap: 'nowrap',
   },
@@ -113,9 +110,7 @@ const PaymentMethodRow: React.FC<Props> = (props) => {
           )}
         </Grid>
         <Grid item className={classes.item} style={{ paddingRight: 0 }}>
-          {is_default && (
-            <Chip className={classes.chip} label="DEFAULT" component="span" />
-          )}
+          {is_default && <Chip label="DEFAULT" component="span" />}
         </Grid>
         <Grid item className={classes.actions}>
           <ActionMenu

--- a/packages/manager/src/components/Tag/Tag.tsx
+++ b/packages/manager/src/components/Tag/Tag.tsx
@@ -137,8 +137,7 @@ export const Tag: React.FC<CombinedProps> = (props) => {
     <Chip
       {...chipProps}
       label={_label}
-      className={classNames({
-        ...(className && { [className]: true }),
+      className={classNames(className, {
         [classes[colorVariant!]]: true,
         [classes.root]: true,
       })}

--- a/packages/manager/src/components/core/Chip.ts
+++ b/packages/manager/src/components/core/Chip.ts
@@ -1,6 +1,0 @@
-import Chip, { ChipProps as _ChipProps } from '@material-ui/core/Chip';
-
-/* tslint:disable-next-line:no-empty-interface */
-export interface ChipProps extends _ChipProps {}
-
-export default Chip;

--- a/packages/manager/src/components/core/Chip.tsx
+++ b/packages/manager/src/components/core/Chip.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import classNames from 'classnames';
+import { makeStyles, Theme } from './styles';
+import {
+  default as _Chip,
+  ChipProps as _ChipProps,
+} from '@material-ui/core/Chip';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    fontSize: '0.65rem',
+  },
+  clickable: {
+    backgroundColor: theme.name === 'lightTheme' ? '#e5f1ff' : '#415d81',
+    '&:hover': {
+      backgroundColor: theme.name === 'lightTheme' ? '#cce2ff' : '#374863',
+    },
+  },
+  outlined: {
+    borderRadius: 1,
+    backgroundColor: 'transparent',
+  },
+  ['outline-gray']: {
+    border: '1px solid #ccc',
+  },
+  ['outline-green']: {
+    border: '1px solid #02B159',
+  },
+}));
+
+export interface ChipProps extends Omit<_ChipProps, 'variant'> {
+  variant?: 'clickable' | _ChipProps['variant'];
+  outlineColor?: 'green' | 'gray';
+  component?: string;
+}
+
+const Chip: React.FC<ChipProps> = ({
+  variant,
+  outlineColor = 'gray',
+  className,
+  ...props
+}) => {
+  const classes = useStyles();
+
+  return (
+    <_Chip
+      className={classNames(className, classes.root, {
+        [classes.clickable]: variant === 'clickable',
+        [classes.outlined]: variant === 'outlined',
+        [classes[`outline-${outlineColor}`]]: variant === 'outlined',
+      })}
+      {...props}
+    />
+  );
+};
+
+export default Chip;

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentMethodCard.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentMethodCard.tsx
@@ -37,12 +37,6 @@ const useStyles = makeStyles((theme: Theme) => ({
       color: theme.color.red,
     },
   },
-  chip: {
-    '& span': {
-      color: 'inherit !important',
-      fontSize: '0.625rem',
-    },
-  },
 }));
 
 interface Props {
@@ -110,7 +104,7 @@ export const PaymentMethodCard: React.FC<Props> = (props) => {
 
   const renderVariant = () => {
     return is_default ? (
-      <Grid item className={classes.chip} xs={3} md={2}>
+      <Grid item xs={3} md={2}>
         <Chip label="DEFAULT" component="span" />
       </Grid>
     ) : null;

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseRow.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseRow.tsx
@@ -59,7 +59,9 @@ export const DatabaseRow: React.FC<Props> = ({ database }) => {
       <>
         {`Primary +${cluster_size - 1}`}
         <Chip
-          className={`${chipClasses.chip} ${chipClasses.nvmeChip}`}
+          variant="outlined"
+          outlineColor="green"
+          className={chipClasses.chip}
           label="HA"
         />
       </>

--- a/packages/manager/src/features/Kubernetes/ClusterList/ClusterRow.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/ClusterRow.tsx
@@ -97,6 +97,7 @@ export const ClusterRow: React.FunctionComponent<CombinedProps> = (props) => {
             {cluster.k8s_version}
             {hasUpgrade ? (
               <Chip
+                variant="clickable"
                 className={classes.chip}
                 onClick={openUpgradeDialog}
                 label="UPGRADE"

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
@@ -147,13 +147,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   buttons: {
     marginRight: theme.spacing(),
   },
-  chip: {
-    backgroundColor: theme.color.tagButton,
-    borderRadius: 1,
-    fontSize: 10,
-    paddingLeft: theme.spacing(0.5),
-    paddingRight: theme.spacing(0.5),
-  },
   actionRow: {
     flexDirection: 'column',
     [theme.breakpoints.down('md')]: {
@@ -511,7 +504,7 @@ export const KubeSummaryPanel: React.FunctionComponent<Props> = (props) => {
                 >
                   {isClusterHighlyAvailable ? (
                     <Grid item>
-                      <Chip className={classes.chip} label="HA CLUSTER" />
+                      <Chip label="HA CLUSTER" />
                     </Grid>
                   ) : null}
                   {isKubeDashboardFeatureEnabled ? (

--- a/packages/manager/src/features/Volumes/VolumeTableRow.tsx
+++ b/packages/manager/src/features/Volumes/VolumeTableRow.tsx
@@ -23,28 +23,12 @@ export const useStyles = makeStyles((theme: Theme) => ({
     alignSelf: 'center',
   },
   chip: {
-    borderRadius: 1,
-    fontSize: '0.65rem',
     marginTop: 0,
     marginBottom: 0,
     marginLeft: theme.spacing(2),
     minHeight: theme.spacing(2),
     paddingLeft: theme.spacing(0.5),
     paddingRight: theme.spacing(0.5),
-  },
-  forceUpgradeChip: {
-    backgroundColor: theme.name === 'lightTheme' ? '#e5f1ff' : '#415d81',
-    '&:hover': {
-      backgroundColor: theme.name === 'lightTheme' ? '#cce2ff' : '#374863',
-    },
-  },
-  upgradePendingChip: {
-    backgroundColor: 'transparent',
-    border: '1px solid #ccc',
-  },
-  nvmeChip: {
-    backgroundColor: 'transparent',
-    border: '1px solid #02B159',
   },
 }));
 
@@ -131,7 +115,9 @@ export const VolumeTableRow: React.FC<CombinedProps> = (props) => {
               {isNVMe ? (
                 <Grid item className={classes.chipWrapper}>
                   <Chip
-                    className={`${classes.chip} ${classes.nvmeChip}`}
+                    variant="outlined"
+                    outlineColor="green"
+                    className={classes.chip}
                     label="NVMe"
                     data-testid="nvme-chip"
                   />
@@ -141,7 +127,8 @@ export const VolumeTableRow: React.FC<CombinedProps> = (props) => {
                 !nvmeUpgradeScheduledByUserImminent ? (
                 <Grid item className={classes.chipWrapper}>
                   <Chip
-                    className={`${classes.chip} ${classes.forceUpgradeChip}`}
+                    variant="clickable"
+                    className={classes.chip}
                     label="UPGRADE TO NVMe"
                     onClick={() => history.push(`/linodes/${linodeId}/upgrade`)}
                     data-testid="upgrade-chip"
@@ -152,7 +139,9 @@ export const VolumeTableRow: React.FC<CombinedProps> = (props) => {
                   nvmeUpgradeScheduledByUserInProgress) ? (
                 <Grid item className={classes.chipWrapper}>
                   <Chip
-                    className={`${classes.chip} ${classes.upgradePendingChip}`}
+                    variant="outlined"
+                    outlineColor="gray"
+                    className={classes.chip}
                     label="UPGRADE PENDING"
                     data-testid="upgrading-chip"
                   />


### PR DESCRIPTION
## Description

- Wraps the Material UI Chip component
  - adds `outlined` and `clickable` variant 
- Makes `Upgrade to NVMe` chip the same as the Kubernetes `Upgrade` chip

## How to test

- Check the Chip component in Storybook
- Check all Chip styles in Cloud Manager
  - Use the MSW to help with this
