### PR TITLE
Fix Cypress Machine Image Upload Tests

### DIFF
--- a/packages/manager/cypress/integration/images/machine-image-upload.spec.ts
+++ b/packages/manager/cypress/integration/images/machine-image-upload.spec.ts
@@ -15,11 +15,12 @@ import { randomLabel } from 'support/util/random';
 
 const eventIntercept = (
   label: string,
-  id: number,
+  id: string,
   status: RecPartial<EventStatus>,
   message?: string,
   created?: string
 ) => {
+  const numericId = numericImageIdFromString(id);
   interceptOnce(
     'GET',
     '*/account/events*',
@@ -29,9 +30,9 @@ const eventIntercept = (
         action: 'image_upload',
         entity: {
           label: label,
-          id,
+          id: numericId,
           type: 'image',
-          url: `/v4/images/private/${id}`,
+          url: `/v4/images/private/${numericId}`,
         },
         status,
         secondary_entity: null,

--- a/packages/manager/cypress/integration/images/machine-image-upload.spec.ts
+++ b/packages/manager/cypress/integration/images/machine-image-upload.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 /* eslint-disable sonarjs/no-identical-functions */
-import { createMockImage, deleteAllTestImages } from '../../support/api/images';
+import { createMockImage } from '../../support/api/images';
 import { fbtClick, fbtVisible, getClick } from '../../support/helpers';
 import 'cypress-file-upload';
 import { assertToast } from 'cypress/support/ui/events';
@@ -11,10 +11,10 @@ import { interceptOnce } from 'cypress/support/ui/common';
 import { RecPartial } from 'factory.ts';
 import { EventStatus } from '../../../../api-v4/lib/account/types';
 import { ImageStatus } from '../../../../api-v4/lib/images/types';
-
-const imageLabel = 'cy-test-image';
+import { randomLabel } from 'support/util/random';
 
 const eventIntercept = (
+  label: string,
   id: number,
   status: RecPartial<EventStatus>,
   message?: string,
@@ -28,7 +28,7 @@ const eventIntercept = (
         created: created ? created : DateTime.local().toISO(),
         action: 'image_upload',
         entity: {
-          label: imageLabel,
+          label: label,
           id,
           type: 'image',
           url: `/v4/images/private/${id}`,
@@ -41,37 +41,34 @@ const eventIntercept = (
   ).as('getEvent');
 };
 
-const imageIntercept = (id: number, status: ImageStatus) => {
+const imageIntercept = (label: string, id: number, status: ImageStatus) => {
   cy.intercept('GET', `*/images*`, (req) => {
-    req.reply(createMockImage({ label: imageLabel, id, status }));
+    req.reply(createMockImage({ label, id, status }));
   }).as('getImage');
 };
 
-const assertFailed = (imageId: number, message: string) => {
-  assertToast(
-    `There was a problem processing image ${imageLabel}: ${message}`,
-    2
-  );
+const assertFailed = (label: string, imageId: number, message: string) => {
+  assertToast(`There was a problem processing image ${label}: ${message}`, 2);
   cy.get(`[data-qa-image-cell="${imageId}"]`).within(() => {
-    fbtVisible(imageLabel);
+    fbtVisible(label);
     fbtVisible('Failed');
     fbtVisible('N/A');
   });
 };
 
-const assertProcessing = (imageId: number) => {
+const assertProcessing = (label: string, imageId: number) => {
   cy.get(`[data-qa-image-cell="${imageId}"]`).within(() => {
-    fbtVisible(imageLabel);
+    fbtVisible(label);
     fbtVisible('Processing');
     fbtVisible('Pending');
   });
 };
 
-const uploadImage = () => {
+const uploadImage = (label: string) => {
   const regionSelect = 'Fremont, CA';
   const upload = 'testImage.gz';
   cy.visitWithLogin('/images/create/upload');
-  getClick('[id="label"][data-testid="textfield-input"]').type(imageLabel);
+  getClick('[id="label"][data-testid="textfield-input"]').type(label);
   getClick('[id="description"]').type('This is a machine image upload test');
   fbtClick('Select a Region');
   fbtClick(regionSelect);
@@ -86,67 +83,67 @@ const uploadImage = () => {
 };
 
 describe('machine image', () => {
-  beforeEach(() => {
-    deleteAllTestImages();
-  });
-
   it('uploads machine image, mock finished event', () => {
+    const label = randomLabel();
     const status = 'finished';
-    uploadImage();
+    uploadImage(label);
     cy.wait('@imageUpload').then((xhr) => {
       const imageId = xhr.response?.body.image.id;
-      imageIntercept(imageId, 'available');
-      eventIntercept(imageId, status);
+      imageIntercept(label, imageId, 'available');
+      eventIntercept(label, imageId, status);
       assertToast(
-        `Image ${imageLabel} uploaded successfully. It is being processed and will be available shortly.`
+        `Image ${label} uploaded successfully. It is being processed and will be available shortly.`
       );
       cy.wait('@getImage');
       cy.wait('@getEvent');
-      assertToast(`Image ${imageLabel} is now available.`, 2);
+      assertToast(`Image ${label} is now available.`, 2);
       cy.get(`[data-qa-image-cell="${imageId}"]`).within(() => {
-        fbtVisible(imageLabel);
+        fbtVisible(label);
         fbtVisible('Ready');
       });
     });
   });
 
   it('uploads machine image, mock upload canceled failed event', () => {
+    const label = randomLabel();
     const status = 'failed';
     const message = 'Upload canceled';
-    uploadImage();
+    uploadImage(label);
     cy.wait('@imageUpload').then((xhr) => {
       const imageId = xhr.response?.body.image.id;
-      assertProcessing(imageId);
-      eventIntercept(imageId, status, message);
+      assertProcessing(label, imageId);
+      eventIntercept(label, imageId, status, message);
       cy.wait('@getEvent');
-      assertFailed(imageId, message);
+      assertFailed(label, imageId, message);
     });
   });
 
   it('uploads machine image, mock failed to decompress failed event', () => {
+    const label = randomLabel();
     const status = 'failed';
     const message = 'Failed to decompress image';
-    uploadImage();
+    uploadImage(label);
     cy.wait('@imageUpload').then((xhr) => {
       const imageId = xhr.response?.body.image.id;
-      assertProcessing(imageId);
-      eventIntercept(imageId, status, message);
+      assertProcessing(label, imageId);
+      eventIntercept(label, imageId, status, message);
       cy.wait('@getEvent');
-      assertFailed(imageId, message);
+      assertFailed(label, imageId, message);
     });
   });
 
   it('uploads machine image, mock expired upload event', () => {
+    const label = randomLabel();
     const status = 'failed';
     const message = 'Upload window expired';
     const expiredDate = DateTime.local().minus({ days: 1 }).toISO();
-    uploadImage();
+    uploadImage(label);
     cy.wait('@imageUpload').then((xhr) => {
       const imageId = xhr.response?.body.image.id;
-      assertProcessing(imageId);
-      eventIntercept(imageId, status, message, expiredDate);
+      assertProcessing(label, imageId);
+      eventIntercept(label, imageId, status, message, expiredDate);
       cy.wait('@getEvent');
-      assertFailed(imageId, message);
+      assertFailed(label, imageId, message);
     });
   });
 });

--- a/packages/manager/cypress/integration/images/machine-image-upload.spec.ts
+++ b/packages/manager/cypress/integration/images/machine-image-upload.spec.ts
@@ -26,6 +26,18 @@ const numericImageIdFromString = (imageIdString: string): number => {
   const substring = imageIdString.split('/')[1];
   return parseInt(substring, 10);
 };
+
+/**
+ * Intercepts the response from the next events poll request.
+ *
+ * Responds with an `image_upload` event associated with an image.
+ *
+ * @param label - Label of image that is associated with the event.
+ * @param id - ID of image that is associated with the event. Expected to be prefixed with a string (e.g. 'private/12345').
+ * @param status - Event status.
+ * @param message - Optional event message.
+ * @param created - Optional event created data. If omitted, the current time is used.
+ */
 const eventIntercept = (
   label: string,
   id: string,
@@ -55,6 +67,15 @@ const eventIntercept = (
   ).as('getEvent');
 };
 
+/**
+ * Intercepts the response for an image GET request.
+ *
+ * Responds with an image with the given label, ID, and status.
+ *
+ * @param label - Response image label.
+ * @param id - Response image ID. Expected to be prefixed with a string (e.g. 'private/12345').
+ * @param status - Image status.
+ */
 const imageIntercept = (label: string, id: string, status: ImageStatus) => {
   cy.intercept('GET', `*/images/${id}*`, (req) => {
     req.reply(
@@ -67,23 +88,43 @@ const imageIntercept = (label: string, id: string, status: ImageStatus) => {
   }).as('getImage');
 };
 
-const assertFailed = (label: string, imageId: number, message: string) => {
-  assertToast(`There was a problem processing image ${label}: ${message}`, 2);
-  cy.get(`[data-qa-image-cell="${imageId}"]`).within(() => {
+/**
+ * Asserts that provisioning an image fails.
+ *
+ * @param label - Label for image that is expected to fail.
+ * @param id - ID for image that is expected to fail. Expected to be prefixed with a string (e.g. 'private/12345').
+ * @param message - Expected failure message.
+ */
+const assertFailed = (label: string, id: string, message: string) => {
+  assertToast(`There was a problem processing image ${label}: ${message}`);
+  cy.get(`[data-qa-image-cell="${id}"]`).within(() => {
     fbtVisible(label);
     fbtVisible('Failed');
     fbtVisible('N/A');
   });
 };
 
-const assertProcessing = (label: string, imageId: number) => {
-  cy.get(`[data-qa-image-cell="${imageId}"]`).within(() => {
+/**
+ * Asserts that an image is in the process of being provisioned.
+ *
+ * @param label - Label for image that is expected to be processing.
+ * @param id - ID for image that is expected to be processing. Expected to be prefixed with a string (e.g. 'private/12345').
+ */
+const assertProcessing = (label: string, id: string) => {
+  cy.get(`[data-qa-image-cell="${id}"]`).within(() => {
     fbtVisible(label);
     fbtVisible('Processing');
     fbtVisible('Pending');
   });
 };
 
+/**
+ * Uploads an image and intercepts the request response.
+ *
+ * The image is uploaded to a random region.
+ *
+ * @param label - Label to apply to uploaded image.
+ */
 const uploadImage = (label: string) => {
   const regionSelect = randomItem(regionsFriendly);
   const upload = 'testImage.gz';
@@ -92,7 +133,8 @@ const uploadImage = (label: string) => {
   getClick('[id="description"]').type('This is a machine image upload test');
   fbtClick('Select a Region');
   fbtClick(regionSelect);
-  cy.fixture(upload).then((fileContent) => {
+  // Pass `null` to `cy.fixture()` to ensure file is encoded as a Cypress buffer object.
+  cy.fixture(upload, null).then((fileContent) => {
     cy.get('input[accept="application/x-gzip"]').attachFile({
       fileContent,
       fileName: 'testImage',
@@ -103,20 +145,20 @@ const uploadImage = (label: string) => {
 };
 
 describe('machine image', () => {
-  it('uploads machine image, mock finished event', () => {
+  /*
+   * - Uploads machine image.
+   * - Confirms that image uploads successfully.
+   * - Confirms that machine image is listed in landing page as expected.
+   * - Confirms that notifications appear that describe the image's success status.
+   */
+  it.skip('uploads machine image, end-to-end', () => {
+    // @TODO Unskip 'uploads machine image, end-to-end' when we have a better path forward for segmenting slower tests.
+    // See also: M3-5723 "Investigate creating a second 'tier' of Cypress tests".
     const label = randomLabel();
-    const status = 'finished';
     uploadImage(label);
     cy.wait('@imageUpload').then((xhr) => {
       const imageId = xhr.response?.body.image.id;
-      imageIntercept(label, imageId, 'available');
-      eventIntercept(label, imageId, status);
-      assertToast(
-        `Image ${label} uploaded successfully. It is being processed and will be available shortly.`
-      );
-      cy.wait('@getImage');
-      cy.wait('@getEvent');
-      assertToast(`Image ${label} is now available.`, 2);
+      assertToast(`Image ${label} is now available.`);
       cy.get(`[data-qa-image-cell="${imageId}"]`).within(() => {
         fbtVisible(label);
         fbtVisible('Ready');
@@ -124,6 +166,39 @@ describe('machine image', () => {
     });
   });
 
+  /*
+   * - Uploads machine image.
+   * - Mocks events and image requests to simulate successful upload.
+   * - Confirms that machine image is listed in landing page as expected.
+   * - Confirms that notifications appear that describe the image's success status.
+   */
+  it('uploads machine image, mock finish event', () => {
+    const label = randomLabel();
+    const status = 'finished';
+    uploadImage(label);
+    cy.wait('@imageUpload').then((xhr) => {
+      const imageId = xhr.response?.body.image.id;
+      assertProcessing(label, imageId);
+      imageIntercept(label, imageId, 'available');
+      eventIntercept(label, imageId, status);
+      assertToast(
+        `Image ${label} uploaded successfully. It is being processed and will be available shortly.`
+      );
+      cy.wait('@getImage');
+      assertToast(`Image ${label} is now available.`);
+      cy.get(`[data-qa-image-cell="${imageId}"]`).within(() => {
+        fbtVisible(label);
+        fbtVisible('Ready');
+      });
+    });
+  });
+
+  /*
+   * - Uploads machine image.
+   * - Mocks events to simulate cancelled upload.
+   * - Confirms that machine image is listed in landing page as expected.
+   * - Confirms that notifications appear that describe the image's failed status.
+   */
   it('uploads machine image, mock upload canceled failed event', () => {
     const label = randomLabel();
     const status = 'failed';
@@ -138,6 +213,12 @@ describe('machine image', () => {
     });
   });
 
+  /*
+   * - Uploads machine image.
+   * - Mocks events to simulate decompression failure.
+   * - Confirms that machine image is listed in landing page as expected.
+   * - Confirms that notifications appear that describe the image's failed status.
+   */
   it('uploads machine image, mock failed to decompress failed event', () => {
     const label = randomLabel();
     const status = 'failed';
@@ -152,6 +233,12 @@ describe('machine image', () => {
     });
   });
 
+  /*
+   * - Uploads machine image.
+   * - Mocks events to simulate upload expiration failure.
+   * - Confirms that machine image is listed in landing page as expected.
+   * - Confirms that notifications appear that describe the image's failed status.
+   */
   it('uploads machine image, mock expired upload event', () => {
     const label = randomLabel();
     const status = 'failed';

--- a/packages/manager/cypress/integration/images/machine-image-upload.spec.ts
+++ b/packages/manager/cypress/integration/images/machine-image-upload.spec.ts
@@ -11,7 +11,7 @@ import { interceptOnce } from 'cypress/support/ui/common';
 import { RecPartial } from 'factory.ts';
 import { EventStatus } from '../../../../api-v4/lib/account/types';
 import { ImageStatus } from '../../../../api-v4/lib/images/types';
-import { randomLabel } from 'support/util/random';
+import { randomLabel, randomItem } from 'support/util/random';
 
 const eventIntercept = (
   label: string,
@@ -66,7 +66,7 @@ const assertProcessing = (label: string, imageId: number) => {
 };
 
 const uploadImage = (label: string) => {
-  const regionSelect = 'Fremont, CA';
+  const regionSelect = randomItem(regionsFriendly);
   const upload = 'testImage.gz';
   cy.visitWithLogin('/images/create/upload');
   getClick('[id="label"][data-testid="textfield-input"]').type(label);

--- a/packages/manager/cypress/integration/images/machine-image-upload.spec.ts
+++ b/packages/manager/cypress/integration/images/machine-image-upload.spec.ts
@@ -1,15 +1,14 @@
-/* eslint-disable sonarjs/no-duplicate-string */
-/* eslint-disable sonarjs/no-identical-functions */
-import { fbtClick, fbtVisible, getClick } from '../../support/helpers';
-import 'cypress-file-upload';
-import { assertToast } from 'cypress/support/ui/events';
-import { DateTime } from 'luxon';
+import { EventStatus } from '@linode/api-v4/lib/account/types';
+import { ImageStatus } from '@linode/api-v4/lib/images/types';
 import { eventFactory, imageFactory } from '@src/factories';
 import { makeResourcePage } from '@src/mocks/serverHandlers';
-import { interceptOnce } from 'cypress/support/ui/common';
+import 'cypress-file-upload';
 import { RecPartial } from 'factory.ts';
-import { EventStatus } from '../../../../api-v4/lib/account/types';
-import { ImageStatus } from '../../../../api-v4/lib/images/types';
+import { DateTime } from 'luxon';
+import { regionsFriendly } from 'support/constants/regions';
+import { fbtClick, fbtVisible, getClick } from 'support/helpers';
+import { interceptOnce } from 'support/ui/common';
+import { assertToast } from 'support/ui/events';
 import { randomLabel, randomItem } from 'support/util/random';
 
 /**

--- a/packages/manager/cypress/integration/images/machine-image-upload.spec.ts
+++ b/packages/manager/cypress/integration/images/machine-image-upload.spec.ts
@@ -1,11 +1,10 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 /* eslint-disable sonarjs/no-identical-functions */
-import { createMockImage } from '../../support/api/images';
 import { fbtClick, fbtVisible, getClick } from '../../support/helpers';
 import 'cypress-file-upload';
 import { assertToast } from 'cypress/support/ui/events';
 import { DateTime } from 'luxon';
-import { eventFactory } from '@src/factories';
+import { eventFactory, imageFactory } from '@src/factories';
 import { makeResourcePage } from '@src/mocks/serverHandlers';
 import { interceptOnce } from 'cypress/support/ui/common';
 import { RecPartial } from 'factory.ts';
@@ -42,9 +41,15 @@ const eventIntercept = (
   ).as('getEvent');
 };
 
-const imageIntercept = (label: string, id: number, status: ImageStatus) => {
-  cy.intercept('GET', `*/images*`, (req) => {
-    req.reply(createMockImage({ label, id, status }));
+const imageIntercept = (label: string, id: string, status: ImageStatus) => {
+  cy.intercept('GET', `*/images/${id}*`, (req) => {
+    req.reply(
+      imageFactory.build({
+        label,
+        id,
+        status,
+      })
+    );
   }).as('getImage');
 };
 

--- a/packages/manager/cypress/integration/images/machine-image-upload.spec.ts
+++ b/packages/manager/cypress/integration/images/machine-image-upload.spec.ts
@@ -12,6 +12,20 @@ import { EventStatus } from '../../../../api-v4/lib/account/types';
 import { ImageStatus } from '../../../../api-v4/lib/images/types';
 import { randomLabel, randomItem } from 'support/util/random';
 
+/**
+ * Returns a numeric image ID from a string-based image ID.
+ *
+ * @param imageIdString - Image ID string to convert to number.
+ *
+ * @example
+ * numericImageIdFromString('private/1111111'); // Returns 1111111.
+ *
+ * @returns Numeric image ID.
+ */
+const numericImageIdFromString = (imageIdString: string): number => {
+  const substring = imageIdString.split('/')[1];
+  return parseInt(substring, 10);
+};
 const eventIntercept = (
   label: string,
   id: string,

--- a/packages/manager/cypress/integration/volumes/create-volume.smoke.spec.ts
+++ b/packages/manager/cypress/integration/volumes/create-volume.smoke.spec.ts
@@ -147,6 +147,6 @@ describe('volumes', () => {
     cy.contains(`Detach Volume ${attachedVolumeLabel}?`);
     getClick('[data-qa-confirm="true"]');
     cy.wait('@volumeDetached').its('response.statusCode').should('eq', 200);
-    assertToast('Volume detachment started', 2);
+    assertToast('Volume detachment started');
   });
 });

--- a/packages/manager/cypress/support/ui/events.ts
+++ b/packages/manager/cypress/support/ui/events.ts
@@ -1,12 +1,8 @@
-// asserts text in popup toast notifications
-export const assertToast = (message: string, elementNumber: number = 1) => {
-  cy.get('[data-qa-toast]')
-    .then((elements) => {
-      if (elementNumber > 1) {
-        return elements[elementNumber - 1];
-      }
-    })
-    .within((_element) =>
-      cy.findByText(message, { exact: false }).should('be.visible')
-    );
+/**
+ * Asserts that a toast notification with the given message is visible.
+ *
+ * @param message - Message that should be displayed on toast notification.
+ */
+export const assertToast = (message: string) => {
+  cy.contains('[data-qa-toast]', message).should('be.visible');
 };


### PR DESCRIPTION
## Description

**What does this PR do?**
This fixes a couple issues with the Machine Image Upload tests that I noticed while investigating our recent failures (the cause of which was actually unrelated to our code or tests).

Specifically:
- Use random labels for uploaded images, remove `beforeEach()` hook which deletes existing test images
- Use random region for uploaded images
- Fix encoding issue with uploaded image which resulted in decompression error
- Fix mismatch with image IDs (_private/12345_ vs _12345_) used in mocked events

On my machine, I'm seeing average speed improvements of 122 seconds to run all the tests in `machine-image-upload.spec.ts`. This should also resolve the flakiness we occasionally see with these tests.

## How to test

**What are the steps to reproduce the issue or verify the changes?**
To run the image upload tests:
```
yarn cy:run -s './packages/manager/cypress/integration/images/machine-image-upload.spec.ts'
```

To run all tests:
```
yarn cy:run
```
Or observe the test results on this PR.