### PR TITLE
M3-5776: Cloud Manager doesn't give feedback when resizing a Node Pool over the 100 node limit

### DIFF
--- a/packages/manager/src/components/EnhancedNumberInput/EnhancedNumberInput.tsx
+++ b/packages/manager/src/components/EnhancedNumberInput/EnhancedNumberInput.tsx
@@ -141,9 +141,9 @@ export const EnhancedNumberInput: React.FC<Props> = (props) => {
           className: classNames({
             [classes.input]: true,
           }),
-          min,
-          max,
         }}
+        min={min}
+        max={max}
         disabled={disabled}
         data-testid={'quantity-input'}
       />


### PR DESCRIPTION
## Description

Fixes a bug with the `EnhancedNumberInput` that would allow numbers above the max to be input. This bug in conjunction with how the component updated its value resulted in truncated large values being submitted. Now when the user tries to input a number larger than the max the component will set the value to the max.

## How to test

1. Navigate to the Kubernetes cluster create page
2. Click a node pool quantity to begin to edit it
3. Type in a number larger than the max (100)
4. Ensure that the value shown in the input does not exceed the max (100)
5. Ensure that when adding that pool to the checkout bar that the value is the max (100)
