### PR TITLE
replaced the word in with empty string

### DIFF
--- a/packages/manager/src/features/linodes/MigrateLanding/CautionNotice.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/CautionNotice.tsx
@@ -108,7 +108,8 @@ const CautionNotice: React.FC<CombinedProps> = (props) => {
           When this migration begins, we estimate it will take approximately{' '}
           {DateTime.local()
             .plus({ minutes: props.migrationTimeInMins })
-            .toRelative()}{' '}
+            .toRelative()
+            ?.replace('in', '')}{' '}
           to complete.
         </li>
       </ul>


### PR DESCRIPTION
## Description

Fixes a typo caused by the luxor package.

## How to test

1. Navigate to the Linode landing page
2. Click the action menu
3. Click the migrate button
4. Ensure that the final line in the warning notice has proper grammar. 
