### PR TITLE
Show /116s in networking panel

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
@@ -929,7 +929,7 @@ export const ipResponseToDisplayRows = (
     ipDisplay.push(ipToDisplay(ipv6?.link_local, 'Link Local'));
   }
 
-  // IPv6 pools (116s)
+  // IPv6 pools (/116s) and routed ranges to display in the networking table
   ipDisplay.push(
     ...[
       ...(ipv6

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
@@ -955,6 +955,21 @@ export const ipResponseToDisplayRows = (
   if (routedRanges) {
     ipDisplay.push(
       ...routedRanges.map((range) => {
+        /* If you want to surface rdns info in the future you have two options:
+          1. Use the info we already have:
+            We get info on our routed ranges from /networking/ipv6/ranges and /networking/ipv6/ranges/<id>, because the API
+            only surfaces is_bgp in /networking/ipv6/ranges/<id> we need to use both, this should change in the API
+            Similarly, the API only surfaces rdns info in /networking/ips/<ip>. To correlate a range and
+            it's rdns info, you'll need to make an extra request to /netowrking/ips/<ip> or loop through the
+            result of the request to /networking/ips and find the range info you want
+
+          - OR -
+
+          2. Ask for API change
+            API could include RDNS info in /networking/ipv6/ranges and /networking/ipv6/ranges/<id> and 
+            while you're at it please ask them to add in is_bgp to /networking/ipv6/ranges as it would save a bunch of 
+            extra requests on Linodes with many ranges
+        */
         return {
           type: 'IPv6 – Range' as IPDisplay['type'],
           address: `${range.range}/${range.prefix}`,

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
@@ -937,11 +937,9 @@ export const ipResponseToDisplayRows = (
           return ip.prefix === 116 ? ip : null;
         })
         .map((thisIP) => {
-          const address = thisIP.range + ` / ${thisIP.prefix}`;
-
           return {
             type: 'IPv6 – Range' as IPDisplay['type'],
-            address,
+            address: `${thisIP.range}/${thisIP.prefix}`,
             gateway: '',
             subnetMask: '',
             rdns: '',

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
@@ -929,7 +929,29 @@ export const ipResponseToDisplayRows = (
     ipDisplay.push(ipToDisplay(ipv6?.link_local, 'Link Local'));
   }
 
-  // Routed ranges are a special case.
+  // IPv6 pools (116s)
+  if (ipv6?.global) {
+    ipDisplay.push(
+      ...ipv6.global
+        .filter((ip) => {
+          return ip.prefix === 116 ? ip : null;
+        })
+        .map((thisIP) => {
+          const address = thisIP.range + ` / ${thisIP.prefix}`;
+
+          return {
+            type: 'IPv6 – Range' as IPDisplay['type'],
+            address,
+            gateway: '',
+            subnetMask: '',
+            rdns: '',
+            _range: thisIP,
+          };
+        })
+    );
+  }
+
+  // Routed ranges
   if (routedRanges) {
     ipDisplay.push(
       ...routedRanges.map((range) => {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
@@ -930,55 +930,40 @@ export const ipResponseToDisplayRows = (
   }
 
   // IPv6 pools (116s)
-  if (ipv6?.global) {
-    ipDisplay.push(
-      ...ipv6.global
-        .filter((ip) => {
-          return ip.prefix === 116 ? ip : null;
-        })
-        .map((thisIP) => {
-          return {
-            type: 'IPv6 – Range' as IPDisplay['type'],
-            address: `${thisIP.range}/${thisIP.prefix}`,
-            gateway: '',
-            subnetMask: '',
-            rdns: '',
-            _range: thisIP,
-          };
-        })
-    );
-  }
+  ipDisplay.push(
+    ...[
+      ...(ipv6?.global
+        ? ipv6?.global.filter((ip) => {
+            return ip.prefix === 116 ? ip : null;
+          })
+        : []),
+      ...routedRanges,
+    ].map((thisIP) => {
+      /* If you want to surface rdns info in the future you have two options:
+        1. Use the info we already have:
+          We get info on our routed ranges from /networking/ipv6/ranges and /networking/ipv6/ranges/<id>, because the API
+          only surfaces is_bgp in /networking/ipv6/ranges/<id> we need to use both, this should change in the API
+          Similarly, the API only surfaces rdns info in /networking/ips/<ip>. To correlate a range and
+          it's rdns info, you'll need to make an extra request to /netowrking/ips/<ip> or loop through the
+          result of the request to /networking/ips and find the range info you want
 
-  // Routed ranges
-  if (routedRanges) {
-    ipDisplay.push(
-      ...routedRanges.map((range) => {
-        /* If you want to surface rdns info in the future you have two options:
-          1. Use the info we already have:
-            We get info on our routed ranges from /networking/ipv6/ranges and /networking/ipv6/ranges/<id>, because the API
-            only surfaces is_bgp in /networking/ipv6/ranges/<id> we need to use both, this should change in the API
-            Similarly, the API only surfaces rdns info in /networking/ips/<ip>. To correlate a range and
-            it's rdns info, you'll need to make an extra request to /netowrking/ips/<ip> or loop through the
-            result of the request to /networking/ips and find the range info you want
+        - OR -
 
-          - OR -
-
-          2. API change
-            API could include RDNS info in /networking/ipv6/ranges and /networking/ipv6/ranges/<id> and 
-            while you're at it please ask them to add in is_bgp to /networking/ipv6/ranges as it would save a bunch of 
-            extra requests on Linodes with many ranges
-        */
-        return {
-          type: 'IPv6 – Range' as IPDisplay['type'],
-          address: `${range.range}/${range.prefix}`,
-          gateway: '',
-          subnetMask: '',
-          rdns: '',
-          _range: range,
-        };
-      })
-    );
-  }
+        2. API change
+          API could include RDNS info in /networking/ipv6/ranges and /networking/ipv6/ranges/<id> and
+          while you're at it please ask them to add in is_bgp to /networking/ipv6/ranges as it would save a bunch of
+          extra requests on Linodes with many ranges
+      */
+      return {
+        type: 'IPv6 – Range' as IPDisplay['type'],
+        address: `${thisIP.range}/${thisIP.prefix}`,
+        gateway: '',
+        subnetMask: '',
+        rdns: '',
+        _range: thisIP,
+      };
+    })
+  );
 
   return ipDisplay;
 };

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
@@ -932,8 +932,8 @@ export const ipResponseToDisplayRows = (
   // IPv6 pools (116s)
   ipDisplay.push(
     ...[
-      ...(ipv6?.global
-        ? ipv6?.global.filter((ip) => {
+      ...(ipv6
+        ? ipv6.global.filter((ip) => {
             return ip.prefix === 116 ? ip : null;
           })
         : []),

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
@@ -933,9 +933,7 @@ export const ipResponseToDisplayRows = (
   ipDisplay.push(
     ...[
       ...(ipv6
-        ? ipv6.global.filter((ip) => {
-            return ip.prefix === 116 ? ip : null;
-          })
+        ? ipv6.global.filter((ip) => (ip.prefix === 116 ? ip : null))
         : []),
       ...routedRanges,
     ].map((thisIP) => {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
@@ -965,7 +965,7 @@ export const ipResponseToDisplayRows = (
 
           - OR -
 
-          2. Ask for API change
+          2. API change
             API could include RDNS info in /networking/ipv6/ranges and /networking/ipv6/ranges/<id> and 
             while you're at it please ask them to add in is_bgp to /networking/ipv6/ranges as it would save a bunch of 
             extra requests on Linodes with many ranges


### PR DESCRIPTION
## Description

Adds back in /116 ranges to a Linode's networking panel. These were accidentally removed when support for routed and shared /64s and /56s was added. This happened because we get our /64 and /56 info from /networking/ipv6/ranges which doesn't surface /116 information

Also adds comment about adding in RDNS info in the future

## Testing

See internal message "Testing https://github.com/linode/manager/pull/8327"