### PR TITLE
M3-5581: Change object name text to regular weight

### DIFF
--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableRow.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableRow.tsx
@@ -74,7 +74,7 @@ const ObjectTableRow: React.FC<Props> = (props) => {
                   className={classes.objectNameButton}
                   onClick={handleClickDetails}
                 >
-                  <strong>{displayName}</strong>
+                  {displayName}
                 </button>
               </Typography>
             </Box>


### PR DESCRIPTION
## Description

Removes the `strong` tag wrapping the object name in the `ObjectTableRow` component.

## How to test

1. Navigate to an bucket with objects in it
2. Ensure the object names in the table are not bold
