### PR TITLE
Max node pool copy update

### DIFF
--- a/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
@@ -97,7 +97,7 @@ const Panel: React.FunctionComponent<CombinedProps> = (props) => {
           onSelect={(newType: string) => setSelectedType(newType)}
           error={apiError}
           header="Add Node Pools"
-          copy="Add groups of Linodes to your cluster with a chosen size."
+          copy="Add groups of Linodes to your cluster. You can have a maximum of 100 Linodes per node pool."
           updatePlanCount={updatePlanCount}
           submitForm={submitForm}
           isOnCreate={isOnCreate}


### PR DESCRIPTION
## Description

Changed the copy to reflect the max number of nodes per node pool

## How to test

1. Navigate to the Kubernetes cluster create page
2. Ensure that the copy is correct for the `Add Node Pools` section
