### PR TITLE
Fix Events Table Loading State

### DIFF
--- a/packages/manager/src/features/Events/EventsLanding.tsx
+++ b/packages/manager/src/features/Events/EventsLanding.tsx
@@ -343,9 +343,9 @@ export const renderTableBody = (
   if (loading) {
     return (
       <TableRowLoading
-        columns={entityId ? 3 : 4}
+        columns={4}
         rows={5}
-        responsive={{ 0: { xsDown: true }, 2: { mdDown: true } }}
+        responsive={{ 0: { xsDown: true }, 3: { smDown: true } }}
       />
     );
   } else if (error) {


### PR DESCRIPTION
## Description

- Fixes the broken table loading state shown in the video below
- Fixes responsiveness of that same loading state
- This bug was introduced because we did not spend time testing #8289 and #8305 together

### Before
https://user-images.githubusercontent.com/6440455/163873798-e5d39963-5f3d-4f7b-a8a7-7d51b6a993a3.mov


### After
![Screen Shot 2022-04-18 at 4 36 36 PM](https://user-images.githubusercontent.com/6440455/163873921-8f3b54a0-1053-4f63-9b94-b503cd9960fe.jpg)


## How to test

- View the Activity Feed `/linodes/{id}/activity` of any Linode and check the loading state for any UI weirdness
- Check the loading state at all screen sizes for issues
