### PR TITLE
Fix broken notifications e2e tests

### DIFF
--- a/packages/manager/src/features/TopMenu/NotificationButton.tsx
+++ b/packages/manager/src/features/TopMenu/NotificationButton.tsx
@@ -69,6 +69,7 @@ export const NotificationButton: React.FC<{}> = (_) => {
         <>
           <TopMenuIcon title="Notifications">
             <MenuButton
+              aria-label="Notifications"
               className={`${iconClasses.icon} ${classes.menuButton} ${
                 isExpanded ? iconClasses.hover : ''
               }`}


### PR DESCRIPTION
## Description
Fix broken e2e notification tests caused by https://github.com/linode/manager/pull/8305

## How to test
```
yarn cy:run -s './cypress/integration/notificationsAndEvents/events.spec.ts'
```

```
yarn cy:run -s './cypress/integration/notificationsAndEvents/notifications.spec.ts'
```
