### PR TITLE
M3-5774: Type to confirm add hyphens

### DIFF
--- a/packages/manager/src/components/Dialog/Dialog.stories.mdx
+++ b/packages/manager/src/components/Dialog/Dialog.stories.mdx
@@ -189,7 +189,7 @@ A Confirmation Dialog is used for confirming a simple task.
 A Deletion Dialog is used for deleting entities such as Linodes, NodeBalancers, Volumes, or other entities. 
 
 Require `typeToConfirm` when an action would have a significant negative impact if done in error, consider requiring the user to enter a unique identifier such as entity label before activating the action button. 
-If a user has opted out of type to confirm this will be ignored
+If a user has opted out of type-to-confirm this will be ignored
 
 <Canvas>
   <Story

--- a/packages/manager/src/components/TypeToConfirm/TypeToConfirm.tsx
+++ b/packages/manager/src/components/TypeToConfirm/TypeToConfirm.tsx
@@ -65,7 +65,7 @@ const TypeToConfirm: React.FC<Props> = (props) => {
                       onChange={toggleTypeToConfirm}
                       checked={!istypeToConfirm}
                       inputProps={{
-                        'aria-label': `Disable type to confirm`,
+                        'aria-label': `Disable type-to-confirm`,
                       }}
                     />
                   }
@@ -95,7 +95,7 @@ const TypeToConfirm: React.FC<Props> = (props) => {
   } else {
     return (
       <Typography className={classes.description}>
-        To enable type to confirm, go to{' '}
+        To enable type-to-confirm, go to{' '}
         <Link to="/profile/settings">My Settings</Link>.
       </Typography>
     );

--- a/packages/manager/src/components/TypeToConfirm/TypeToConfirm.tsx
+++ b/packages/manager/src/components/TypeToConfirm/TypeToConfirm.tsx
@@ -69,7 +69,7 @@ const TypeToConfirm: React.FC<Props> = (props) => {
                       }}
                     />
                   }
-                  label="Disable type to confirm"
+                  label="Disable type-to-confirm"
                 />
               </Grid>
             </Grid>

--- a/packages/manager/src/features/Profile/Settings/Settings.tsx
+++ b/packages/manager/src/features/Profile/Settings/Settings.tsx
@@ -133,7 +133,7 @@ const ProfileSettings: React.FC<Props & { theme: Theme }> = (props) => {
                         checked={istypeToConfirm}
                       />
                     }
-                    label={`Type to confirm is${
+                    label={`Type-to-confirm is${
                       istypeToConfirm ? ' enabled' : ' disabled'
                     }`}
                   />

--- a/packages/manager/src/features/Profile/Settings/Settings.tsx
+++ b/packages/manager/src/features/Profile/Settings/Settings.tsx
@@ -108,10 +108,10 @@ const ProfileSettings: React.FC<Props & { theme: Theme }> = (props) => {
       </Paper>
       <Paper className={classes.root}>
         <Typography variant="h2" className={classes.title}>
-          Type to Confirm
+          Type-to-Confirm
         </Typography>
         <Typography variant="body1">
-          For some products and services, the type to confirm setting requires
+          For some products and services, the type-to-confirm setting requires
           entering the label before deletion.
         </Typography>
         <PreferenceToggle<boolean>


### PR DESCRIPTION
## Description

Changes all occurrences of the phrase `type to confirm` to `type-to-confirm`

## How to test

Ensure the phrase `type to confirm` is always formatted as `type-to-confirm`