### PR TITLE
Fix remaining test failures related to notification changes

### DIFF
--- a/packages/manager/cypress/integration/linodes/linode-storage.spec.ts
+++ b/packages/manager/cypress/integration/linodes/linode-storage.spec.ts
@@ -95,7 +95,9 @@ describe('linode storage tab', () => {
       deleteDisk(diskName);
       cy.wait('@deleteDisk').its('response.statusCode').should('eq', 200);
       cy.get('button[title="Add a Disk"]').should('be.enabled');
-      cy.contains(diskName).should('not.exist');
+      cy.findByLabelText('List of Disks').within(() => {
+        cy.contains(diskName).should('not.exist');
+      });
     });
   });
 

--- a/packages/manager/cypress/integration/linodes/resize-linode.spec.ts
+++ b/packages/manager/cypress/integration/linodes/resize-linode.spec.ts
@@ -14,9 +14,9 @@ describe('resize linode', () => {
       cy.get('[data-testid="textfield-input"]').type(linode.label);
       cy.get('[data-qa-resize="true"]').click();
       cy.wait('@linodeResize');
-      fbtVisible(
+      cy.contains(
         'Your Linode will soon be automatically powered off, migrated, and restored to its previous state (booted or powered off).'
-      );
+      ).should('be.visible');
     });
   });
 });


### PR DESCRIPTION
## Description

(See also: #8305, #8335 )

Fixes the remaining test failures from #8305.

The crux of these failures is that the new notification menu is always present in the DOM, whether or not it is open (it's simply hidden when closed). This differs from the older implementation, where no notification content existed in the DOM when the notifications drawer was not open. This change caused some tests to fail because the tests assumed that the notice text would only exist once in the DOM, and it now exists twice (visible in a banner, invisible in notifications menu).

## To Test
```bash
yarn cy:run -s "cypress/integration/linodes/linode-storage.spec.ts","cypress/integration/linodes/resize-linode.spec.ts"
```