### PR TITLE
M3-5748: Use private user attributes for LaunchDarkly fields

### DIFF
--- a/packages/manager/src/IdentifyUser.tsx
+++ b/packages/manager/src/IdentifyUser.tsx
@@ -77,6 +77,7 @@ export const IdentifyUser: React.FC<{}> = () => {
             custom: {
               taxID: _taxID,
             },
+            privateAttributeNames: ['country', 'taxID'],
           })
           .then(() => setFeatureFlagsLoaded())
           /**

--- a/packages/manager/src/containers/withFeatureFlagProvider.container.ts
+++ b/packages/manager/src/containers/withFeatureFlagProvider.container.ts
@@ -21,6 +21,7 @@ const featureFlagProvider = LAUNCH_DARKLY_API_KEY
       user: {
         key: 'anonymous',
         anonymous: true,
+        privateAttributeNames: ['country', 'taxID'],
       },
     })
   : (component: React.ComponentType) => component;


### PR DESCRIPTION
## Description

Makes use of the private user attributes feature of Launch Darkly to limit the collection of PII. In particular the items of `country` and `taxID`. 

## How to test

Instructions listed in ticket
