### PR TITLE
M3-5773: Adjust spacing on DBaaS Settings page

### DIFF
--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettings.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettings.tsx
@@ -64,7 +64,7 @@ export const DatabaseSettings: React.FC<Props> = (props) => {
           onClick={onResetRootPassword}
           sectionTitle="Reset Root Password"
         />
-        <Divider spacingTop={22} spacingBottom={22} />
+        <Divider spacingTop={28} spacingBottom={22} />
         <DatabaseSettingsMenuItem
           sectionTitle="Delete Cluster"
           descriptiveText={deleteClusterCopy}
@@ -72,7 +72,7 @@ export const DatabaseSettings: React.FC<Props> = (props) => {
           disabled={Boolean(profile?.restricted)}
           onClick={onDeleteCluster}
         />
-        <Divider spacingTop={22} spacingBottom={22} />
+        <Divider spacingTop={28} spacingBottom={22} />
         <MaintenanceWindow database={database} timezone={profile?.timezone} />
       </Paper>
       <DatabaseSettingsDeleteClusterDialog


### PR DESCRIPTION
## Description
Set the `spacingTop` to `28` and `spacingBottom` to `22`.

Per the ticket comments, I took a look at modifying `Divider.tsx` to make these the default values if those props weren't passed to the component, but many files would need to be updated to maintain the integrity of spacing in other instances outside of this page.

## How to test
Take a look at the spacing on the Settings tab of a Database Detail page.
