### PR TITLE
Fix failing firewall E2E test

### DIFF
--- a/packages/manager/cypress/integration/firewalls/migrate-linode-with-firewall.spec.ts
+++ b/packages/manager/cypress/integration/firewalls/migrate-linode-with-firewall.spec.ts
@@ -192,16 +192,16 @@ describe('Migrate Linode With Firewall', () => {
         fbtClick('Create Firewall');
       });
 
-      cy.get('[data-testid="textfield-input"]').type(firewallLabel);
-      getVisible(
-        '[data-qa-enhanced-select="Select a Linode or type to search..."]'
-      );
+      cy.get('[data-testid="textfield-input"]')
+        .should('be.visible')
+        .type(firewallLabel);
 
-      getClick(
-        '[data-qa-enhanced-select="Select a Linode or type to search..."]'
-      );
+      cy.get('[data-qa-enhanced-select="Select a Linode or type to search..."]')
+        .should('be.visible')
+        .click();
 
-      fbtClick(linode.label);
+      cy.findByText(linode.label).should('be.visible').click();
+
       getClick('[data-qa-submit="true"]');
       cy.wait('@createFirewall');
       cy.visit(`/linodes/${linode.id}`);
@@ -247,11 +247,16 @@ describe('Migrate Linode With Firewall', () => {
         });
         fbtClick('Create Firewall');
       });
-      cy.get('[data-testid="textfield-input"]').type(firewallLabel);
-      getClick(
-        '[data-qa-enhanced-select="Select a Linode or type to search..."]'
-      );
-      containsClick(linodeLabel);
+      cy.get('[data-testid="textfield-input"]')
+        .should('be.visible')
+        .type(firewallLabel);
+
+      cy.get('[data-qa-enhanced-select="Select a Linode or type to search..."]')
+        .should('be.visible')
+        .click();
+
+      cy.findByText(linodeLabel).should('be.visible').click();
+
       getClick('[data-qa-submit="true"]');
       cy.wait('@createFirewall').its('response.statusCode').should('eq', 200);
       fbtVisible(linodeLabel);


### PR DESCRIPTION
## Description

**What does this PR do?**
Fixes the failing Cypress test related to firewalls. The tests were failing to select options within an enhanced select; I think Cypress was finding the option elements in the DOM and attempting to interact with them before they were actually visible on-screen.

## How to test

**What are the steps to reproduce the issue or verify the changes?**
```bash
yarn cy:run -s "cypress/integration/firewalls/migrate-linode-with-firewall.spec.ts"
```

To reproduce the issue, run the above command against `develop` and observe failures (the test doesn't fail every time, but does seem to fail most of the time). To test the fix, run the same command against this PR and confirm that the tests succeed.