### PR TITLE
Curly the quotes

### DIFF
--- a/packages/manager/src/components/DeletionDialog/DeletionDialog.tsx
+++ b/packages/manager/src/components/DeletionDialog/DeletionDialog.tsx
@@ -90,7 +90,7 @@ const DeletionDialog: React.FC<CombinedProps> = (props) => {
       <Notice warning>
         <Typography style={{ fontSize: '0.875rem' }}>
           <strong>Warning:</strong> Deleting this {entity} is permanent and
-          can&apos;t be undone.
+          can&rsquo;t be undone.
         </Typography>
       </Notice>
       <TypeToConfirm

--- a/packages/manager/src/components/DismissibleBanner/DismissibleBanner.stories.mdx
+++ b/packages/manager/src/components/DismissibleBanner/DismissibleBanner.stories.mdx
@@ -16,7 +16,7 @@ Banners appear between the top nav and page content and are a visual interruptio
 
 ### Design
 
-- Banners are dismissible using an &apos;X&apos; icon.
+- Banners are dismissible using an &rsquo;X&rsquo; icon.
 - Consider adding a link to a doc or a guide for users to learn more.
 - Banners should be considered as one part of a larger communications plan; messaging should be developed with the marketing team.
 

--- a/packages/manager/src/components/IPSelect/IPSelect.tsx
+++ b/packages/manager/src/components/IPSelect/IPSelect.tsx
@@ -57,7 +57,7 @@ const IPSelect: React.FC<CombinedProps> = (props) => {
     errorText = props.errorText;
   } else if (linodesError) {
     errorText =
-      'There was an error retrieving this Linode&rsquo;s IP addresses.';
+      'There was an error retrieving this Linode\u{2019}s IP addresses.';
   }
 
   return (

--- a/packages/manager/src/components/IPSelect/IPSelect.tsx
+++ b/packages/manager/src/components/IPSelect/IPSelect.tsx
@@ -56,7 +56,8 @@ const IPSelect: React.FC<CombinedProps> = (props) => {
   if (props.errorText) {
     errorText = props.errorText;
   } else if (linodesError) {
-    errorText = "There was an error retrieving this Linode's IP addresses.";
+    errorText =
+      'There was an error retrieving this Linode&rsquo;s IP addresses.';
   }
 
   return (

--- a/packages/manager/src/components/MaintenanceBanner/MaintenanceBanner.tsx
+++ b/packages/manager/src/components/MaintenanceBanner/MaintenanceBanner.tsx
@@ -124,7 +124,7 @@ const generateIntroText = (
     if (maintenanceInProgress) {
       return (
         <React.Fragment>
-          This Linode&apos;s physical host is currently undergoing maintenance.{' '}
+          This Linode&rsquo;s physical host is currently undergoing maintenance.{' '}
           {maintenanceActionTextMap[type]} Please refer to
           <Link to="/support/tickets"> your Support tickets </Link> for more
           information.
@@ -142,7 +142,7 @@ const generateIntroText = (
 
       return (
         <React.Fragment>
-          This Linode&apos;s physical host will be undergoing maintenance at{' '}
+          This Linode&rsquo;s physical host will be undergoing maintenance at{' '}
           {rawDate}
           {'. '}
           {maintenanceActionTextMap[type]}
@@ -164,7 +164,7 @@ const generateIntroText = (
   /** We are on the Dashboard or Linode Landing page. */
   return (
     <React.Fragment>
-      Maintenance is required for one or more of your Linodes&apos; physical
+      Maintenance is required for one or more of your Linodes&rsquo; physical
       hosts. Your maintenance times will be listed under the &quot;Status&quot;
       column
       {!location.pathname.includes('/linodes') && (

--- a/packages/manager/src/components/Notice/Notice.stories.mdx
+++ b/packages/manager/src/components/Notice/Notice.stories.mdx
@@ -12,7 +12,7 @@ import Notice from './Notice';
 - Appear within the page or modal
 - Might be triggered by user action
 - Typically used to alert the user to a new service, limited availability, or a potential consequence of the action being taken
-- Considering making the notice dismissible if it&apos;s not critical information
+- Considering making the notice dismissible if it&rsquo;s not critical information
 
 Types of Notices:
 

--- a/packages/manager/src/components/TransferDisplay/TransferDisplay.tsx
+++ b/packages/manager/src/components/TransferDisplay/TransferDisplay.tsx
@@ -202,7 +202,7 @@ export const TransferDialog: React.FC<DialogProps> = React.memo((props) => {
         </strong>
       </Typography>
       <Typography className={classes.proratedNotice}>
-        Your account&apos;s network transfer pool adds up all the included
+        Your account&rsquo;s network transfer pool adds up all the included
         transfer associated with the active Linode services on your account, and
         is prorated based on service creation and deletion dates.
       </Typography>

--- a/packages/manager/src/features/Account/AutoBackups.tsx
+++ b/packages/manager/src/features/Account/AutoBackups.tsx
@@ -85,7 +85,7 @@ const AutoBackups: React.FC<Props> = (props) => {
               label={
                 backups_enabled || isManagedCustomer
                   ? 'Enabled (Auto enroll all new Linodes in Backups)'
-                  : "Disabled (Don't enroll new Linodes in Backups automatically)"
+                  : 'Disabled (Don\u{2019}t enroll new Linodes in Backups automatically)'
               }
             />
           </Grid>

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/AddPaymentMethodDrawer/AddPaymentMethodDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/AddPaymentMethodDrawer/AddPaymentMethodDrawer.tsx
@@ -113,7 +113,7 @@ export const AddPaymentMethodDrawer: React.FC<Props> = (props) => {
           <Grid item xs={8} md={9}>
             <Typography variant="h3">Google Pay</Typography>
             <Typography>
-              You&apos;ll be taken to Google Pay to complete sign up.
+              You&rsquo;ll be taken to Google Pay to complete sign up.
             </Typography>
           </Grid>
           <Grid
@@ -140,7 +140,7 @@ export const AddPaymentMethodDrawer: React.FC<Props> = (props) => {
           <Grid item xs={8} md={9}>
             <Typography variant="h3">PayPal</Typography>
             <Typography>
-              You&apos;ll be taken to PayPal to complete sign up.
+              You&rsquo;ll be taken to PayPal to complete sign up.
             </Typography>
           </Grid>
           <Grid

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PayPalChip.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PayPalChip.tsx
@@ -133,7 +133,8 @@ export const PayPalChip: React.FC<Props> = (props) => {
         enqueueSnackbar(error, { variant: 'error' });
 
         reportException(error, {
-          message: "Failed to add PayPal as a payment method with Linode's API",
+          message:
+            'Failed to add PayPal as a payment method with Linode&rsquo;s API',
         });
       });
   };

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PayPalChip.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PayPalChip.tsx
@@ -134,7 +134,7 @@ export const PayPalChip: React.FC<Props> = (props) => {
 
         reportException(error, {
           message:
-            'Failed to add PayPal as a payment method with Linode&rsquo;s API',
+            'Failed to add PayPal as a payment method with Linode\u{2019}s API',
         });
       });
   };

--- a/packages/manager/src/features/CancelLanding/CancelLanding.tsx
+++ b/packages/manager/src/features/CancelLanding/CancelLanding.tsx
@@ -54,7 +54,7 @@ export const CancelLanding: React.FC<{}> = () => {
   return (
     <div className={classes.root} data-testid="body">
       <Logo className={classes.logo} />
-      <H1Header title="It's been our pleasure to serve you." />
+      <H1Header title="It&rsquo;s been our pleasure to serve you." />
       <Typography>
         Your account is closed. We hope you'll consider Linode for your future
         cloud hosting needs.

--- a/packages/manager/src/features/CancelLanding/CancelLanding.tsx
+++ b/packages/manager/src/features/CancelLanding/CancelLanding.tsx
@@ -54,7 +54,7 @@ export const CancelLanding: React.FC<{}> = () => {
   return (
     <div className={classes.root} data-testid="body">
       <Logo className={classes.logo} />
-      <H1Header title="It&rsquo;s been our pleasure to serve you." />
+      <H1Header title="It\u{2019}s been our pleasure to serve you." />
       <Typography>
         Your account is closed. We hope you'll consider Linode for your future
         cloud hosting needs.

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/MaintenanceWindow.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/MaintenanceWindow.tsx
@@ -189,8 +189,8 @@ export const MaintenanceWindow: React.FC<Props> = (props) => {
           ) : null}
           <Typography className={classes.sectionText}>
             OS and DB engine updates will be performed on the schedule below.
-            Select the frequency, day, and time you&apos;d prefer maintenance to
-            occur.{' '}
+            Select the frequency, day, and time you&rsquo;d prefer maintenance
+            to occur.{' '}
             {database.cluster_size !== 3
               ? 'For non-HA plans, expect downtime during this window.'
               : null}

--- a/packages/manager/src/features/Domains/DomainBanner.tsx
+++ b/packages/manager/src/features/Domains/DomainBanner.tsx
@@ -55,7 +55,7 @@ export const DomainBanner: React.FC<Props> = (props) => {
         <div className={classes.banner}>
           <strong>Your DNS zones are not being served.</strong>
         </div>
-        Your domains will not be served by Linode&#39;s nameservers unless you
+        Your domains will not be served by Linode&rsquo;s nameservers unless you
         have at least one active Linode on your account.{` `}
         <Link to="/linodes/create">You can create one here.</Link>
       </Typography>

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
@@ -533,7 +533,8 @@ const FirewallRuleForm: React.FC<FirewallRuleFormProps> = React.memo(
             />
             <FormControlLabel value="DROP" label="Drop" control={<Radio />} />
             <Typography style={{ paddingTop: 4 }}>
-              This will take precedence over the Firewall's {category} policy.
+              This will take precedence over the Firewall&rsquo;s {category}{' '}
+              policy.
             </Typography>
           </RadioGroup>
         </div>

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
@@ -183,7 +183,7 @@ const FirewallRuleDrawer: React.FC<CombinedProps> = (props) => {
         }}
       </Formik>
       <Typography variant="body1">
-        Rule changes don&apos;t take effect immediately. You can add or delete
+        Rule changes don&rsquo;t take effect immediately. You can add or delete
         rules before saving all your changes to this Firewall.
       </Typography>
     </Drawer>

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRulesLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRulesLanding.tsx
@@ -301,9 +301,9 @@ const FirewallRulesLanding: React.FC<CombinedProps> = (props) => {
               )}
             >
               <Typography variant="subtitle1">
-                The changes you made to this Firewall haven&apos;t been applied.
-                If you navigate away from this page, your changes will be
-                discarded.
+                The changes you made to this Firewall haven&rsquo;t been
+                applied. If you navigate away from this page, your changes will
+                be discarded.
               </Typography>
             </ConfirmationDialog>
           );

--- a/packages/manager/src/features/GlobalNotifications/EmailBounce.tsx
+++ b/packages/manager/src/features/GlobalNotifications/EmailBounce.tsx
@@ -139,8 +139,8 @@ const EmailBounceNotification: React.FC<CombinedProps> = React.memo((props) => {
 
   const confirmationText = matchesSmDown
     ? 'Confirm'
-    : 'Yes it&rsquo;s correct.';
-  const updateText = matchesSmDown ? 'Update' : 'No, let&rsquo;s update it.';
+    : 'Yes it\u{2019}s correct.';
+  const updateText = matchesSmDown ? 'Update' : 'No, let\u{2019}s update it.';
 
   if (dismissed) {
     return null;

--- a/packages/manager/src/features/GlobalNotifications/EmailBounce.tsx
+++ b/packages/manager/src/features/GlobalNotifications/EmailBounce.tsx
@@ -137,8 +137,10 @@ const EmailBounceNotification: React.FC<CombinedProps> = React.memo((props) => {
   const theme = useTheme<Theme>();
   const matchesSmDown = useMediaQuery(theme.breakpoints.down('sm'));
 
-  const confirmationText = matchesSmDown ? 'Confirm' : "Yes it's correct.";
-  const updateText = matchesSmDown ? 'Update' : "No, let's update it.";
+  const confirmationText = matchesSmDown
+    ? 'Confirm'
+    : 'Yes it&rsquo;s correct.';
+  const updateText = matchesSmDown ? 'Update' : 'No, let&rsquo;s update it.';
 
   if (dismissed) {
     return null;

--- a/packages/manager/src/features/GlobalNotifications/EmailBounce.tsx
+++ b/packages/manager/src/features/GlobalNotifications/EmailBounce.tsx
@@ -51,7 +51,7 @@ export const EmailBounceNotificationSection: React.FC<{}> = React.memo(() => {
         <EmailBounceNotification
           text={
             <Typography data-testid="billing_email_bounce">
-              An email to your account&apos;s email address couldn&apos;t be
+              An email to your account&rsquo;s email address couldn&rsquo;t be
               delivered. Is <strong>{accountEmailRef.current}</strong> the
               correct address?
             </Typography>
@@ -69,7 +69,7 @@ export const EmailBounceNotificationSection: React.FC<{}> = React.memo(() => {
         <EmailBounceNotification
           text={
             <Typography data-testid="user_email_bounce">
-              An email to your user profile&apos;s email address couldn&apos;t
+              An email to your user profile&rsquo;s email address couldn&rsquo;t
               be delivered. Is <strong>{profileEmailRef.current}</strong> the
               correct address?
             </Typography>

--- a/packages/manager/src/features/Help/SupportSearchLanding/HelpResources.tsx
+++ b/packages/manager/src/features/Help/SupportSearchLanding/HelpResources.tsx
@@ -130,7 +130,7 @@ export class OtherWays extends React.Component<CombinedProps, State> {
         <Grid container className={classes.wrapper}>
           <Grid item xs={12}>
             <Typography variant="h2" className={classes.heading}>
-              Didn&apos;t find what you need? Get help.
+              Didn&rsquo;t find what you need? Get help.
             </Typography>
           </Grid>
           <Grid item xs={12} md={4}>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
@@ -591,7 +591,7 @@ export const KubeSummaryPanel: React.FunctionComponent<Props> = (props) => {
             : undefined
         }
       >
-        This will delete and regenerate the cluster&apos;s Kubeconfig file. You
+        This will delete and regenerate the cluster&rsquo;s Kubeconfig file. You
         will no longer be able to access this cluster via your previous
         Kubeconfig file. This action cannot be undone.
       </ConfirmationDialog>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesDialog.tsx
@@ -95,7 +95,7 @@ export const KubernetesDialog: React.FC<CombinedProps> = (props) => {
             {linodeCount === 1 ? `1 Linode ` : `${linodeCount} Linodes `}
           </strong>
           that will be deleted along with the cluster. Deleting a cluster is
-          permanent and can&apos;t be undone.
+          permanent and can&rsquo;t be undone.
         </Typography>
       </Notice>
       <TypeToConfirm

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/RecycleAllPoolNodesDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/RecycleAllPoolNodesDialog.tsx
@@ -55,8 +55,8 @@ const RecycleAllPoolNodesDialog: React.FC<Props> = (props) => {
       <Typography>
         Are you sure you want to recycle the nodes in this pool? All nodes will
         be deleted and new nodes will be created to replace them. Any local
-        storage (such as &apos;hostPath&apos; volumes) will be erased. This may
-        take several minutes, as nodes will be replaced on a rolling basis.
+        storage (such as &rsquo;hostPath&rsquo; volumes) will be erased. This
+        may take several minutes, as nodes will be replaced on a rolling basis.
       </Typography>
     </ConfirmationDialog>
   );

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/RecycleAllClusterNodesDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/RecycleAllClusterNodesDialog.tsx
@@ -55,7 +55,7 @@ const RecycleAllClusterNodesDialog: React.FC<Props> = (props) => {
       <Typography>
         Are you sure you want to recycle this cluster? All nodes will be deleted
         and new nodes will be created to replace them. Any local storage (such
-        as &apos;hostPath&apos; volumes) will be erased. This may take several
+        as &rsquo;hostPath&rsquo; volumes) will be erased. This may take several
         minutes, as nodes will be replaced on a rolling basis.
       </Typography>
     </ConfirmationDialog>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeClusterDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeClusterDialog.tsx
@@ -110,7 +110,7 @@ const UpgradeClusterDialog: React.FC<Props> = (props) => {
             them.
           </li>
           <li>
-            Any local storage (such as &apos;hostPath&apos; volumes) will be
+            Any local storage (such as &rsquo;hostPath&rsquo; volumes) will be
             erased.
           </li>
           <li>

--- a/packages/manager/src/features/Kubernetes/UpgradeVersionModal.tsx
+++ b/packages/manager/src/features/Kubernetes/UpgradeVersionModal.tsx
@@ -128,7 +128,7 @@ export const UpgradeDialog: React.FC<DialogProps> = (props) => {
         </>
       ) : (
         <>
-          Upgrade {clusterLabel}&apos;s Kubernetes version from{' '}
+          Upgrade {clusterLabel}&rsquo;s Kubernetes version from{' '}
           <strong>{currentVersion}</strong> to <strong>{nextVersion}</strong>?
           Once the upgrade is complete you will need to recycle all nodes in
           your cluster.

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -775,7 +775,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
             />
             <FormHelperText>
               Roundrobin. Least connections assigns connections to the backend
-              with the least connections. Source uses the client&#39;s IPv4
+              with the least connections. Source uses the client&rsquo;s IPv4
               address
             </FormHelperText>
           </Grid>

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSettings/NodeBalancerSettings.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSettings/NodeBalancerSettings.tsx
@@ -107,7 +107,7 @@ export const NodeBalancerSettings: React.FC<CombinedProps> = (props) => {
         setLabelError(
           getAPIErrorOrDefault(
             error,
-            "Unable to update your NodeBalancer's label."
+            'Unable to update your NodeBalancer&rsquo;s label.'
           )[0].reason
         );
       });
@@ -130,7 +130,7 @@ export const NodeBalancerSettings: React.FC<CombinedProps> = (props) => {
         setLabelError(
           getAPIErrorOrDefault(
             error,
-            "Unable to update your NodeBalancer's client connection throttle."
+            'Unable to update your NodeBalancer&rsquo;s client connection throttle.'
           )[0].reason
         );
       });

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSettings/NodeBalancerSettings.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSettings/NodeBalancerSettings.tsx
@@ -107,7 +107,7 @@ export const NodeBalancerSettings: React.FC<CombinedProps> = (props) => {
         setLabelError(
           getAPIErrorOrDefault(
             error,
-            'Unable to update your NodeBalancer&rsquo;s label.'
+            'Unable to update your NodeBalancer\u{2019}s label.'
           )[0].reason
         );
       });
@@ -130,7 +130,7 @@ export const NodeBalancerSettings: React.FC<CombinedProps> = (props) => {
         setLabelError(
           getAPIErrorOrDefault(
             error,
-            'Unable to update your NodeBalancer&rsquo;s client connection throttle.'
+            'Unable to update your NodeBalancer\u{2019}s client connection throttle.'
           )[0].reason
         );
       });

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
@@ -258,7 +258,7 @@ export const BucketLanding: React.FC<CombinedProps> = (props) => {
         <Notice warning>
           <Typography style={{ fontSize: '0.875rem' }}>
             <strong>Warning:</strong> Deleting a bucket is permanent and
-            can&apos;t be undone.
+            can&rsquo;t be undone.
           </Typography>
         </Notice>
         <Typography className={classes.copy}>

--- a/packages/manager/src/features/Profile/Referrals/Referrals.tsx
+++ b/packages/manager/src/features/Profile/Referrals/Referrals.tsx
@@ -130,13 +130,13 @@ export const Referrals: React.FC<{}> = () => {
         <Grid item>
           <Typography variant="body1" style={{ marginBottom: 12 }}>
             When you refer friends or colleagues to Linode using your referral
-            link, they&apos;ll receive a $100, 60-day credit once a valid
+            link, they&rsquo;ll receive a $100, 60-day credit once a valid
             payment method is added to their new account.
           </Typography>
           <Typography variant="body1">
             When the referred customer spends $25 on Linode services, and has
             remained an active customer in good standing for 90 days,
-            you&apos;ll receive a $25 non-expiring account credit. There are no
+            you&rsquo;ll receive a $25 non-expiring account credit. There are no
             limits to the number of people you can refer.{' '}
             <Link to="https://www.linode.com/promotional-policy/">
               Read more about our promotions policy

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -478,7 +478,7 @@ const withStackScriptBase = (options: WithStackScriptBaseOptions) => (
                   title="StackScripts"
                   className={classes.stackscriptPlaceholder}
                 >
-                  You don&apos;t have any StackScripts to select from.
+                  You don&rsquo;t have any StackScripts to select from.
                 </Placeholder>
               ) : (
                 <Placeholder

--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
@@ -553,7 +553,7 @@ export const SupportTicketDrawer: React.FC<CombinedProps> = (props) => {
                   />
                   {!areEntitiesLoading && entityOptions.length === 0 ? (
                     <FormHelperText>
-                      You don&apos;t have any {entityIdToNameMap[entityType]}s
+                      You don&rsquo;t have any {entityIdToNameMap[entityType]}s
                       on your account.
                     </FormHelperText>
                   ) : null}

--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
@@ -504,7 +504,7 @@ export const SupportTicketDrawer: React.FC<CombinedProps> = (props) => {
           {generalError && <Notice error text={generalError} data-qa-notice />}
 
           <Typography data-qa-support-ticket-helper-text>
-            {`We love our customers, and we're here to help if you need us.
+            {`We love our customers, and we\u{2019}re here to help if you need us.
           Please keep in mind that not all topics are within the scope of our support.
           For overall system status, please see `}
             <a

--- a/packages/manager/src/features/Users/UserPermissions.tsx
+++ b/packages/manager/src/features/Users/UserPermissions.tsx
@@ -419,7 +419,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
       add_nodebalancers: 'Can add NodeBalancers to this account ($)',
       add_longview: 'Can add Longview clients to this account',
       longview_subscription:
-        "Can modify this account's Longview subscription ($)",
+        'Can modify this account&rsquo;s Longview subscription ($)',
       add_domains: 'Can add Domains using the DNS Manager',
       add_stackscripts: 'Can create StackScripts under this account',
       add_images: 'Can create frozen Images under this account ($)',

--- a/packages/manager/src/features/Users/UserPermissions.tsx
+++ b/packages/manager/src/features/Users/UserPermissions.tsx
@@ -419,7 +419,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
       add_nodebalancers: 'Can add NodeBalancers to this account ($)',
       add_longview: 'Can add Longview clients to this account',
       longview_subscription:
-        'Can modify this account&rsquo;s Longview subscription ($)',
+        'Can modify this account\u{2019}s Longview subscription ($)',
       add_domains: 'Can add Domains using the DNS Manager',
       add_stackscripts: 'Can create StackScripts under this account',
       add_images: 'Can create frozen Images under this account ($)',

--- a/packages/manager/src/features/Users/UserProfile.tsx
+++ b/packages/manager/src/features/Users/UserProfile.tsx
@@ -154,7 +154,7 @@ const UserProfile: React.FC<Props> = (props) => {
             onChange={changeEmail}
             tooltipText={
               profile?.username !== originalUsername
-                ? "You can't change another user&rsquo;s email address"
+                ? "You can't change another user\u{2019}s email address"
                 : ''
             }
             errorText={hasProfileErrorFor('email')}

--- a/packages/manager/src/features/Users/UserProfile.tsx
+++ b/packages/manager/src/features/Users/UserProfile.tsx
@@ -154,7 +154,7 @@ const UserProfile: React.FC<Props> = (props) => {
             onChange={changeEmail}
             tooltipText={
               profile?.username !== originalUsername
-                ? "You can't change another user's email address"
+                ? "You can't change another user&rsquo;s email address"
                 : ''
             }
             errorText={hasProfileErrorFor('email')}

--- a/packages/manager/src/features/Users/UsersLanding.tsx
+++ b/packages/manager/src/features/Users/UsersLanding.tsx
@@ -166,7 +166,7 @@ const UsersLanding: React.FC<Props> = (props) => {
                 <UserIcon className={classes.avatar} />
               ) : (
                 <img
-                  alt={`user ${user.username}'s avatar`}
+                  alt={`user ${user.username}&rsquo;s avatar`}
                   src={user.gravatarUrl}
                   className={classes.avatar}
                 />

--- a/packages/manager/src/features/Users/UsersLanding.tsx
+++ b/packages/manager/src/features/Users/UsersLanding.tsx
@@ -166,7 +166,7 @@ const UsersLanding: React.FC<Props> = (props) => {
                 <UserIcon className={classes.avatar} />
               ) : (
                 <img
-                  alt={`user ${user.username}&rsquo;s avatar`}
+                  alt={`user ${user.username}\u{2019}s avatar`}
                   src={user.gravatarUrl}
                   className={classes.avatar}
                 />

--- a/packages/manager/src/features/Volumes/VolumeAttachmentDrawer.tsx
+++ b/packages/manager/src/features/Volumes/VolumeAttachmentDrawer.tsx
@@ -206,7 +206,7 @@ class VolumeAttachmentDrawer extends React.Component<CombinedProps, State> {
         />
         {!(linodeError || linodesError) && (
           <FormHelperText>
-            Only Linodes in this Volume&#39;s region are displayed.
+            Only Linodes in this Volume&rsquo;s region are displayed.
           </FormHelperText>
         )}
 

--- a/packages/manager/src/features/Volumes/VolumeDrawer/VolumeConfigForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/VolumeConfigForm.tsx
@@ -40,8 +40,8 @@ const VolumeConfigDrawer: React.FC<CombinedProps> = (props) => {
 
       <div className={classes.copySection}>
         <Typography variant="body1" data-qa-config-help-msg>
-          To get started with a new volume, you'll want to create a filesystem
-          on it:
+          To get started with a new volume, you&rsquo;ll want to create a
+          filesystem on it:
         </Typography>
         <CopyableTextField
           className={classes.copyField}
@@ -81,8 +81,8 @@ const VolumeConfigDrawer: React.FC<CombinedProps> = (props) => {
       <div className={classes.copySection}>
         <Typography variant="body1" data-qa-config-help-msg>
           If you want the volume to automatically mount every time your Linode
-          boots, you'll want to add a line like the following to your /etc/fstab
-          file:
+          boots, you&rsquo;ll want to add a line like the following to your
+          /etc/fstab file:
         </Typography>
         <CopyableTextField
           className={classes.copyField}

--- a/packages/manager/src/features/Volumes/VolumeDrawer/VolumeSelect.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/VolumeSelect.tsx
@@ -180,7 +180,7 @@ class VolumeSelect extends React.Component<CombinedProps, State> {
         />
         {!error && (
           <FormHelperText data-qa-volume-region>
-            Only volumes in this Linode's region are displayed.
+            Only volumes in this Linode&rsquo;s region are displayed.
           </FormHelperText>
         )}
       </FormControl>

--- a/packages/manager/src/features/linodes/LinodesCreate/AttachVLAN.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/AttachVLAN.tsx
@@ -92,7 +92,7 @@ const AttachVLAN: React.FC<CombinedProps> = (props) => {
             between Linodes. A VLAN created or attached in this section will be
             assigned to the eth1 interface, with eth0 being used for connections
             to the public internet. VLAN configurations can be further edited in
-            the Linode&apos;s{' '}
+            the Linode&rsquo;s{' '}
             <ExternalLink
               text="Configuration Profile"
               link="https://linode.com/docs/guides/disk-images-and-configuration-profiles/"

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -52,9 +52,9 @@ export const FromImageContent: React.FC<CombinedProps> = (props) => {
         <Paper>
           <Placeholder title="My Images" icon={ImageIcon} isEntity>
             <Typography variant="subtitle1">
-              You don&#39;t have any private Images. Visit the{' '}
+              You don&rsquo;t have any private Images. Visit the{' '}
               <Link to="/images">Images section</Link> to create an Image from
-              one of your Linode&#39;s disks.
+              one of your Linode&rsquo;s disks.
             </Typography>
           </Placeholder>
         </Paper>

--- a/packages/manager/src/features/linodes/LinodesDetail/HostMaintenanceError.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/HostMaintenanceError.tsx
@@ -4,7 +4,7 @@ import Notice from 'src/components/Notice';
 const HostMaintenanceError = () => (
   <Notice
     warning
-    text="This action is unavailable while your Linode&rsquo;s host is undergoing maintenance."
+    text="This action is unavailable while your Linode\u{2019}s host is undergoing maintenance."
   />
 );
 

--- a/packages/manager/src/features/linodes/LinodesDetail/HostMaintenanceError.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/HostMaintenanceError.tsx
@@ -4,7 +4,7 @@ import Notice from 'src/components/Notice';
 const HostMaintenanceError = () => (
   <Notice
     warning
-    text="This action is unavailable while your Linode's host is undergoing maintenance."
+    text="This action is unavailable while your Linode&rsquo;s host is undergoing maintenance."
   />
 );
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskSpace.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskSpace.tsx
@@ -93,7 +93,7 @@ export class LinodeDiskSpace extends React.PureComponent<CombinedProps> {
           {disks.length === 1 ? 'image' : 'images'}.
         </Typography>
         <Typography className={classes.text}>
-          <strong>Note: </strong> This section represents your plan&#39;s
+          <strong>Note: </strong> This section represents your plan&rsquo;s
           available storage that has been allocated to your disks. Install{' '}
           <Link to="/longview">Longview</Link> or run:
         </Typography>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackupActionMenu.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackupActionMenu.tsx
@@ -17,7 +17,7 @@ export const LinodeBackupActionMenu: React.FC<CombinedProps> = (props) => {
   const disabledProps = {
     disabled,
     tooltip: disabled
-      ? "You don't have permission to deploy from this Linode&rsquo;s backups"
+      ? "You don't have permission to deploy from this Linode\u{2019}s backups"
       : undefined,
   };
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackupActionMenu.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackupActionMenu.tsx
@@ -17,7 +17,7 @@ export const LinodeBackupActionMenu: React.FC<CombinedProps> = (props) => {
   const disabledProps = {
     disabled,
     tooltip: disabled
-      ? "You don't have permission to deploy from this Linode's backups"
+      ? "You don't have permission to deploy from this Linode&rsquo;s backups"
       : undefined,
   };
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/AddIPDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/AddIPDrawer.tsx
@@ -60,7 +60,7 @@ const explainerCopy: Record<IPType, JSX.Element> = {
       Add a private IP address to your Linode. Data sent explicitly to and from
       private IP addresses in the same data center does not incur transfer quota
       usage. To ensure that the private IP is properly configured once added,
-      it&apos;s best to reboot your Linode.
+      it&rsquo;s best to reboot your Linode.
     </>
   ),
 };

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/CreateIPv4Drawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/CreateIPv4Drawer.tsx
@@ -64,7 +64,7 @@ class CreateIPv4Drawer extends React.Component<CombinedProps, State> {
     const privateCopy = `Add a private IP address to your Linode. Data sent
       explicitly to and from private IP addresses in the same data center does
       not incur transfer quota usage. To ensure that the private IP is properly
-      configured once added, it&rsquo;s best to reboot your Linode.`;
+      configured once added, it\u{2019}s best to reboot your Linode.`;
     return this.state.forPublic ? publicCopy : privateCopy;
   }
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/CreateIPv4Drawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/CreateIPv4Drawer.tsx
@@ -64,7 +64,7 @@ class CreateIPv4Drawer extends React.Component<CombinedProps, State> {
     const privateCopy = `Add a private IP address to your Linode. Data sent
       explicitly to and from private IP addresses in the same data center does
       not incur transfer quota usage. To ensure that the private IP is properly
-      configured once added, it's best to reboot your Linode.`;
+      configured once added, it&rsquo;s best to reboot your Linode.`;
     return this.state.forPublic ? publicCopy : privateCopy;
   }
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/IPSharing.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/IPSharing.tsx
@@ -341,7 +341,7 @@ const IPSharingPanel: React.FC<CombinedProps> = (props) => {
               </Grid>
               {noChoices ? (
                 <Typography className={classes.noIPsMessage}>
-                  You have no other Linodes in this Linode&apos;s datacenter
+                  You have no other Linodes in this Linode&rsquo;s datacenter
                   with which to share IPs.
                 </Typography>
               ) : (

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/IPTransfer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/IPTransfer.tsx
@@ -492,7 +492,7 @@ const LinodeNetworkingIPTransferPanel: React.FC<CombinedProps> = (props) => {
         <Typography className={classes.networkActionText}>
           If you have two Linodes in the same data center, you can use the IP
           transfer feature to switch their IP addresses. This could be useful in
-          several situations. For example, if you&#39;ve built a new server to
+          several situations. For example, if you&rsquo;ve built a new server to
           replace an old one, you could swap IP addresses instead of updating
           the DNS records.
         </Typography>
@@ -521,7 +521,7 @@ const LinodeNetworkingIPTransferPanel: React.FC<CombinedProps> = (props) => {
             </Grid>
             {linodes.length === 0 && searchText === '' ? (
               <Typography className={classes.emptyStateText}>
-                You have no other linodes in this Linode&#39;s datacenter with
+                You have no other linodes in this Linode&rsquo;s datacenter with
                 which to transfer IPs.
               </Typography>
             ) : (

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuildDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuildDialog.tsx
@@ -97,7 +97,7 @@ const LinodeRebuildDialog: React.FC<CombinedProps> = (props) => {
         {hostMaintenance && <HostMaintenanceError />}
         {rebuildError && <Notice error>{rebuildError}</Notice>}
         <Typography data-qa-rebuild-desc className={classes.helperText}>
-          If you can&#39;t rescue an existing disk, it&#39;s time to rebuild
+          If you can&rsquo;t rescue an existing disk, it&rsquo;s time to rebuild
           your Linode. There are a couple of different ways you can do this:
           either restore from a backup or start over with a fresh Linux
           distribution.&nbsp;

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -316,7 +316,7 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
         {disksError && (
           <Notice
             error
-            text="There was an error loading your Linode&rsquo;s Disks."
+            text="There was an error loading your Linode\u{2019}s Disks."
           />
         )}
         {submissionError && <Notice error>{submissionError}</Notice>}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -321,9 +321,10 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
         )}
         {submissionError && <Notice error>{submissionError}</Notice>}
         <Typography data-qa-description>
-          If you&apos;re expecting a temporary burst of traffic to your website,
-          or if you&apos;re not using your Linode as much as you thought, you
-          can temporarily or permanently resize your Linode to a different plan.{' '}
+          If you&rsquo;re expecting a temporary burst of traffic to your
+          website, or if you&rsquo;re not using your Linode as much as you
+          thought, you can temporarily or permanently resize your Linode to a
+          different plan.{' '}
           <ExternalLink
             fixedIcon
             text="Learn more."
@@ -379,7 +380,7 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
               ) : (
                 'your disk'
               )}{' '}
-              to be automatically scaled with this Linode&apos;s new size? We
+              to be automatically scaled with this Linode&rsquo;s new size? We
               recommend you keep this option enabled when available. Automatic
               resizing is only available when moving to a larger plan, and when
               you have a single ext disk (or one ext and one swap disk) on your

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -316,7 +316,7 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
         {disksError && (
           <Notice
             error
-            text="There was an error loading your Linode's Disks."
+            text="There was an error loading your Linode&rsquo;s Disks."
           />
         )}
         {submissionError && <Notice error>{submissionError}</Notice>}
@@ -348,7 +348,7 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
           {disksError ? (
             <HelpIcon
               className={classes.toolTip}
-              text={`There was an error loading your Linode's disks.`}
+              text={`There was an error loading your Linode&rsquo; disks.`}
             />
           ) : isSmaller ? (
             <HelpIcon

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -583,7 +583,7 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
                   <FormHelperText id="virtModeCaption">
                     Controls if devices inside your virtual machine are
                     paravirtualized or fully virtualized. Paravirt is what you
-                    want, unless you&apos;re doing weird things.
+                    want, unless you&rsquo;re doing weird things.
                   </FormHelperText>
                 </RadioGroup>
               </FormControl>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/UpgradeVolumesDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/UpgradeVolumesDialog.tsx
@@ -47,7 +47,7 @@ export const UpgradeVolumesDialog: React.FC<Props> = (props) => {
   const onSubmit = () => {
     migrateVolumes(upgradeableVolumeIds).then(() => {
       enqueueSnackbar(
-        `Successfully added ${linode.label}&rsquo;s volumes to the migration queue.`,
+        `Successfully added ${linode.label}\u{2019}s volumes to the migration queue.`,
         { variant: 'success' }
       );
       // Re-request notifications so the Upgrade Volume banner on the Linode Detail page disappears.

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/UpgradeVolumesDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/UpgradeVolumesDialog.tsx
@@ -47,7 +47,7 @@ export const UpgradeVolumesDialog: React.FC<Props> = (props) => {
   const onSubmit = () => {
     migrateVolumes(upgradeableVolumeIds).then(() => {
       enqueueSnackbar(
-        `Successfully added ${linode.label}'s volumes to the migration queue.`,
+        `Successfully added ${linode.label}&rsquo;s volumes to the migration queue.`,
         { variant: 'success' }
       );
       // Re-request notifications so the Upgrade Volume banner on the Linode Detail page disappears.

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
@@ -119,7 +119,7 @@ export const LinodeRow: React.FC<CombinedProps> = (props) => {
   const MaintenanceText = () => {
     return (
       <>
-        This Linode&apos;s maintenance window opens at{' '}
+        This Linode&rsquo;s maintenance window opens at{' '}
         {parsedMaintenanceStartTime}. For more information, see your{' '}
         <Link className={classes.statusLink} to="/support/tickets?type=open">
           open support tickets.

--- a/packages/manager/src/features/linodes/MigrateLanding/CautionNotice.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/CautionNotice.tsx
@@ -64,7 +64,7 @@ const CautionNotice: React.FC<CombinedProps> = (props) => {
       </Typography>
       <ul>
         <li>
-          You&apos;ll be assigned new IPv4 and IPv6 addresses, which will be
+          You&rsquo;ll be assigned new IPv4 and IPv6 addresses, which will be
           accessible once your migration is complete.
         </li>
         <li>
@@ -90,7 +90,7 @@ const CautionNotice: React.FC<CombinedProps> = (props) => {
         )}
         <li>Your Linode will be powered off.</li>
         <li>
-          Block Storage can&apos;t be migrated to other regions.{' '}
+          Block Storage can&rsquo;t be migrated to other regions.{' '}
           {amountOfAttachedVolumes > 0 && (
             <React.Fragment>
               The following

--- a/packages/validation/README.md
+++ b/packages/validation/README.md
@@ -6,7 +6,7 @@ This library consists of [Yup](https://github.com/jquense/yup) schemas correspon
 [Linode API](https://www.linode.com/docs/api/), intended to be used for client-side validation.
 They closely (though not exactly) match the validation that is run by the API back-end when a
 request is received. They can be used to validate API request payloads manually or to validate forms (for example through
-Formik&apos;s `validationSchema`). They also work well with the [@linode/api-v4](https://npmjs.com/@linode/api-v4) package.
+Formik&rsquo;s `validationSchema`). They also work well with the [@linode/api-v4](https://npmjs.com/@linode/api-v4) package.
 
 ### Manual Validation
 
@@ -42,7 +42,7 @@ especially before @linode/api-v4 was published as a separate package. However, a
 this setup caused a few problems:
 
 1. Coupling the request handlers and validation schemas meant that it wasn't possible to turn client-side validation off, which isn't a good fit for a public package.
-2. The validation doesn't match the API&apos;s exactly. There are some things, such as uniqueness, that are
+2. The validation doesn't match the API&rsquo;s exactly. There are some things, such as uniqueness, that are
    difficult to validate on the client. There are some additional cases where the validation is too complex, and
    we made a decision to fall back on the backend validation. This was acceptable when the schemas were only used internally by the Cloud
    Manager, but can lead to confusion for external users (in fact it's unlikely that most external users were even aware that validation


### PR DESCRIPTION
## Description

Replaces all the straight apostrophes with the curly apostrophe. HTML strings use the `&rsquo;` escape sequence and javascript uses the `\u{2019}` escape sequence.

## How to test

Ensure that all the replaced apostrophes render correctly 
