### PR TITLE
feature flagged the beta chips for DBaaS

### DIFF
--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -179,7 +179,7 @@ export const PrimaryNav: React.FC<Props> = (props) => {
           display: 'Databases',
           href: '/databases',
           icon: <Database />,
-          isBeta: true,
+          isBeta: flags.databaseBeta,
         },
         {
           display: 'Kubernetes',
@@ -230,6 +230,7 @@ export const PrimaryNav: React.FC<Props> = (props) => {
       domains.lastUpdated,
       _isLargeAccount,
       allowObjPrefetch,
+      flags.databaseBeta,
     ]
   );
 

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -445,9 +445,9 @@ const DatabaseCreate: React.FC<{}> = () => {
           },
         ]}
         labelOptions={{
-          suffixComponent: (
+          suffixComponent: flags.databaseBeta ? (
             <Chip className={classes.chip} label="beta" component="span" />
-          ),
+          ) : undefined,
         }}
       />
       <Paper>


### PR DESCRIPTION
## Description

Controls the beta chips for DBaaS using the `databaseBeta` feature flag

## How to test

1. Disable database beta in the dev tools
3. Ensure that the beta chip for databases in the primary nav does not render
3. Navigate to Database Create
4. Ensure that the beta chip in the breadcrumb at the top of the page does not render