### PR TITLE
M3-5790: Login & Authentication Scaffolding for Security Questions and Phone Verification

### DIFF
--- a/packages/manager/src/components/ErrorState/ErrorState.tsx
+++ b/packages/manager/src/components/ErrorState/ErrorState.tsx
@@ -1,15 +1,9 @@
+import * as React from 'react';
 import ErrorOutline from '@material-ui/icons/ErrorOutline';
 import classNames from 'classnames';
-import * as React from 'react';
-import {
-  createStyles,
-  SvgIconProps,
-  Theme,
-  withStyles,
-  WithStyles,
-} from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
+import { makeStyles, SvgIconProps, Theme } from 'src/components/core/styles';
 
 interface Props {
   errorText: string | JSX.Element;
@@ -19,54 +13,51 @@ interface Props {
   CustomIconStyles?: React.CSSProperties;
 }
 
-type CSSClasses = 'root' | 'iconContainer' | 'icon' | 'compact' | 'cozy';
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    width: '100%',
+    padding: theme.spacing(10),
+  },
+  compact: {
+    padding: theme.spacing(5),
+  },
+  cozy: {
+    padding: theme.spacing(1),
+  },
+  iconContainer: {
+    textAlign: 'center',
+  },
+  icon: {
+    marginBottom: theme.spacing(2),
+    color: theme.color.red,
+    width: 50,
+    height: 50,
+  },
+}));
 
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {
-      width: '100%',
-      padding: theme.spacing(10),
-    },
-    compact: {
-      padding: theme.spacing(5),
-    },
-    cozy: {
-      padding: theme.spacing(1),
-    },
-    iconContainer: {
-      textAlign: 'center',
-    },
-    icon: {
-      marginBottom: theme.spacing(2),
-      color: theme.color.red,
-      width: 50,
-      height: 50,
-    },
-  });
-
-const ErrorState = (props: Props & WithStyles<CSSClasses>) => {
+const ErrorState = (props: Props) => {
   const { CustomIcon } = props;
+  const classes = useStyles();
   return (
     <Grid
       container
-      className={classNames({
-        [props.classes.root]: true,
-        [props.classes.compact]: props.compact,
-        [props.classes.cozy]: !!props.cozy,
+      className={classNames(classes.root, {
+        [classes.compact]: props.compact,
+        [classes.cozy]: !!props.cozy,
       })}
       justifyContent="center"
       alignItems="center"
     >
       <Grid item data-testid="error-state">
-        <div className={props.classes.iconContainer}>
+        <div className={classes.iconContainer}>
           {CustomIcon ? (
             <CustomIcon
-              className={props.classes.icon}
+              className={classes.icon}
               data-qa-error-icon
               style={props.CustomIconStyles}
             />
           ) : (
-            <ErrorOutline className={props.classes.icon} data-qa-error-icon />
+            <ErrorOutline className={classes.icon} data-qa-error-icon />
           )}
         </div>
         {typeof props.errorText === 'string' ? (
@@ -85,6 +76,4 @@ const ErrorState = (props: Props & WithStyles<CSSClasses>) => {
   );
 };
 
-const styled = withStyles(styles);
-
-export default styled(ErrorState);
+export default ErrorState;

--- a/packages/manager/src/features/Profile/AuthenticationSettings/AuthenticationSettings.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/AuthenticationSettings.tsx
@@ -1,12 +1,10 @@
 import * as React from 'react';
-import { compose } from 'recompose';
+import Divider from 'src/components/core/Divider';
 import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
-import setDocs from 'src/components/DocsSidebar/setDocs';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Notice from 'src/components/Notice';
-import { AccountsAndPasswords, SecurityControls } from 'src/documentation';
 import { useMutateProfile, useProfile } from 'src/queries/profile';
 import ResetPassword from './ResetPassword';
 import SecuritySettings from './SecuritySettings';
@@ -25,7 +23,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-export const AuthenticationSettings: React.FC<{}> = () => {
+export const AuthenticationSettings: React.FC = () => {
   const classes = useStyles();
   const { data: profile, isLoading: profileLoading } = useProfile();
   const {
@@ -40,55 +38,65 @@ export const AuthenticationSettings: React.FC<{}> = () => {
 
   const [success, setSuccess] = React.useState<string | undefined>(undefined);
 
-  const thirdPartyEnabled = authType !== 'password';
-
   const clearState = () => {
     setSuccess(undefined);
   };
+
   const onAllowlistingDisable = () => {
     setSuccess('IP allowlisting disabled. This feature cannot be re-enabled.');
   };
 
   return (
     <div data-testid="authSettings">
-      <DocumentTitleSegment segment={`Login & Authentication`} />
-      {/* Remove when logic above is cleared */}
+      <DocumentTitleSegment segment="Login & Authentication" />
       {success && <Notice success text={success} />}
       {!profileLoading && (
         <>
           <TPAProviders authType={authType} />
-
-          {!thirdPartyEnabled && (
-            <Paper className={classes.root}>
-              <Typography className={classes.linode} variant="h3">
-                Linode Authentication
-              </Typography>
-              <ResetPassword username={username} />
-              <TwoFactor
-                twoFactor={twoFactor}
-                username={username}
-                clearState={clearState}
+          <Paper className={classes.root}>
+            <Typography className={classes.linode} variant="h3">
+              Security Settings
+            </Typography>
+            <Divider spacingTop={24} spacingBottom={16} />
+            <ResetPassword username={username} />
+            <Divider spacingTop={22} spacingBottom={16} />
+            <TwoFactor
+              twoFactor={twoFactor}
+              username={username}
+              clearState={clearState}
+            />
+            <Divider spacingTop={22} spacingBottom={16} />
+            <Typography variant="h3">Security Questions</Typography>
+            <Typography
+              variant="body1"
+              style={{ marginTop: 8, marginBottom: 8 }}
+            >
+              This is a placeholder for the Security Questions component.
+            </Typography>
+            <Divider spacingTop={22} spacingBottom={16} />
+            <Typography variant="h3">Phone Verification</Typography>
+            <Typography
+              variant="body1"
+              style={{ marginTop: 8, marginBottom: 8 }}
+            >
+              This is a placeholder for the Phone Verification component.
+            </Typography>
+            <Divider spacingTop={22} spacingBottom={16} />
+            <TrustedDevices />
+            {ipAllowlisting && (
+              <SecuritySettings
+                updateProfile={updateProfile}
+                onSuccess={onAllowlistingDisable}
+                updateProfileError={profileUpdateError || undefined}
+                ipAllowlistingEnabled={ipAllowlisting}
+                data-qa-allowlisting-form
               />
-              <TrustedDevices />
-              {ipAllowlisting && (
-                <SecuritySettings
-                  updateProfile={updateProfile}
-                  onSuccess={onAllowlistingDisable}
-                  updateProfileError={profileUpdateError || undefined}
-                  ipAllowlistingEnabled={ipAllowlisting}
-                  data-qa-allowlisting-form
-                />
-              )}
-            </Paper>
-          )}
+            )}
+          </Paper>
         </>
       )}
     </div>
   );
 };
 
-const docs = [AccountsAndPasswords, SecurityControls];
-
-const enhanced = compose(setDocs(docs));
-
-export default enhanced(AuthenticationSettings);
+export default AuthenticationSettings;

--- a/packages/manager/src/features/Profile/AuthenticationSettings/AuthenticationSettings.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/AuthenticationSettings.tsx
@@ -44,7 +44,7 @@ export const AuthenticationSettings: React.FC = () => {
   const twoFactor = Boolean(profile?.two_factor_auth);
   const username = profile?.username;
 
-  const thirdPartyEnabled = authType !== 'password';
+  const isThirdPartyAuthEnabled = authType !== 'password';
 
   const [success, setSuccess] = React.useState<string | undefined>(undefined);
 
@@ -74,7 +74,7 @@ export const AuthenticationSettings: React.FC = () => {
           Security Settings
         </Typography>
         <Divider spacingTop={24} spacingBottom={16} />
-        {!thirdPartyEnabled ? (
+        {!isThirdPartyAuthEnabled ? (
           <>
             <ResetPassword username={username} />
             <Divider spacingTop={22} spacingBottom={16} />
@@ -95,7 +95,7 @@ export const AuthenticationSettings: React.FC = () => {
         <Typography variant="body1" style={{ marginTop: 8, marginBottom: 8 }}>
           This is a placeholder for the Phone Verification component.
         </Typography>
-        {!thirdPartyEnabled ? (
+        {!isThirdPartyAuthEnabled ? (
           <>
             <Divider spacingTop={22} spacingBottom={16} />
             <TrustedDevices />

--- a/packages/manager/src/features/Profile/AuthenticationSettings/TPAProviders.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/TPAProviders.tsx
@@ -7,6 +7,7 @@ import GoogleIcon from 'src/assets/icons/providers/google-logo.svg';
 import LinodeLogo from 'src/assets/logo/logo-footer.svg';
 import Button from 'src/components/Button';
 import Box from 'src/components/core/Box';
+import Divider from 'src/components/core/Divider';
 import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
@@ -183,45 +184,44 @@ export const TPAProviders: React.FC<CombinedProps> = (props) => {
             );
           })}
         </Grid>
+        {isThirdPartyAuthEnabled && (
+          <>
+            <Divider spacingTop={24} spacingBottom={16} />
+            <Typography variant="h3">
+              {currentProvider.displayName} Authentication
+            </Typography>
+            <Notice
+              className={classes.notice}
+              spacingTop={16}
+              spacingBottom={16}
+              warning
+            >
+              Your login credentials are currently managed via{' '}
+              {currentProvider.displayName}.
+            </Notice>
+            <Typography variant="body1" className={classes.copy}>
+              If you need to reset your password or set up Two-Factor
+              Authentication (TFA), please visit the{' '}
+              <ExternalLink
+                hideIcon
+                link={currentProvider.href}
+                text={`${currentProvider.displayName}` + ` website`}
+              />
+              .
+            </Typography>
+            <Typography
+              variant="body1"
+              className={classes.copy}
+              style={{ marginBottom: 8 }}
+            >
+              To disable {currentProvider.displayName} authentication and log in
+              using your Linode credentials, click the Linode button above.
+              We&rsquo;ll send you an e-mail with instructions on how to reset
+              your password.
+            </Typography>
+          </>
+        )}
       </Paper>
-
-      {isThirdPartyAuthEnabled && (
-        <Paper className={classes.root}>
-          <Typography variant="h3">
-            {currentProvider.displayName} Authentication
-          </Typography>
-          <Notice
-            className={classes.notice}
-            spacingTop={16}
-            spacingBottom={16}
-            warning
-          >
-            Your login credentials are currently managed via{' '}
-            {currentProvider.displayName}.
-          </Notice>
-          <Typography variant="body1" className={classes.copy}>
-            If you need to reset your password or set up Two-Factor
-            Authentication (TFA), please visit the{' '}
-            <ExternalLink
-              hideIcon
-              link={currentProvider.href}
-              text={`${currentProvider.displayName}` + ` website`}
-            />
-            .
-          </Typography>
-          <Typography
-            variant="body1"
-            className={classes.copy}
-            style={{ marginBottom: 8 }}
-          >
-            To disable {currentProvider.displayName} authentication and log in
-            using your Linode credentials, click the Linode button above.
-            We&rsquo;ll send you an e-mail with instructions on how to reset
-            your password.
-          </Typography>
-        </Paper>
-      )}
-
       <TPADialog
         currentProvider={currentProvider}
         newProvider={newProvider}

--- a/packages/manager/src/features/Profile/AuthenticationSettings/TPAProviders.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/TPAProviders.tsx
@@ -184,7 +184,7 @@ export const TPAProviders: React.FC<CombinedProps> = (props) => {
             );
           })}
         </Grid>
-        {isThirdPartyAuthEnabled && (
+        {isThirdPartyAuthEnabled ? (
           <>
             <Divider spacingTop={24} spacingBottom={16} />
             <Typography variant="h3">
@@ -220,7 +220,7 @@ export const TPAProviders: React.FC<CombinedProps> = (props) => {
               your password.
             </Typography>
           </>
-        )}
+        ) : null}
       </Paper>
       <TPADialog
         currentProvider={currentProvider}

--- a/packages/manager/src/features/Profile/AuthenticationSettings/TwoFactor/TwoFactor.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/TwoFactor/TwoFactor.tsx
@@ -18,9 +18,6 @@ import EnableTwoFactorForm from './EnableTwoFactorForm';
 import ScratchDialog from './ScratchCodeDialog';
 
 const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    marginBottom: theme.spacing(4),
-  },
   container: {
     display: 'flex',
     flexFlow: 'row nowrap',
@@ -168,11 +165,7 @@ export const TwoFactor: React.FC<Props> = (props) => {
         <ToggleState>
           {({ open: scratchDialogOpen, toggle: toggleScratchDialog }) => (
             <React.Fragment>
-              <div
-                className={`${classes.root} ${
-                  disabled ? classes.disabled : ''
-                }`}
-              >
+              <div className={disabled ? classes.disabled : undefined}>
                 {success && <Notice success text={success} />}
                 {generalError && <Notice error text={generalError} />}
                 <Typography variant="h3" data-qa-title>


### PR DESCRIPTION
## Description

- Changes `Linode Authentication` to `Security Settings`
- Adds placeholders for `Phone Verification` and `Security Questions`
- Moves all 3rd party login information to a single `Login Method` paper
- Adds dividers as shown in mock up (in internal ticket)

## How to test

- Check UI compared to the mockup 
