### PR TITLE
Resolve "Generation of index.d.ts has failed!" error by adding TypeScript type assertion

### DIFF
--- a/packages/api-v4/src/request.ts
+++ b/packages/api-v4/src/request.ts
@@ -94,7 +94,7 @@ export const setData = (
     return (object: any) => ({
       ...object,
       data: updatedData,
-      validationErrors: convertYupToLinodeErrors(error),
+      validationErrors: convertYupToLinodeErrors(error as ValidationError),
     });
   }
 };


### PR DESCRIPTION
## Description

**What does this PR do?**
This fixes a TypeScript error in the APIv4 package that results in the following error being shown when running `yarn up`:
![Screen Shot 2022-04-26 at 3 06 55 PM](https://user-images.githubusercontent.com/97627410/165377916-f1cea056-ae6e-43d3-9d18-2f6e1ba182d5.jpg)

Navigating to `packages/api-v4` and running `tsc` directly yields this specific error:

![Screen Shot 2022-04-26 at 3 13 12 PM](https://user-images.githubusercontent.com/97627410/165378151-779c6e82-bc5b-4930-a1eb-3258c8aad626.jpg)

Adding a type assertion seems to resolve the error both when running `yarn up` and when running `tsc` in the API v4 package directory. I'm not sure if this is the safest solution so I'm open to alternative ideas.

I don't believe this error has any practical impact on the APIv4 build; it seems that the API code is transpiled as expected. I'm not sure if we need to investigate why the Webpack build succeeds when there is a type error, however.

## How to test

**What are the steps to reproduce the issue or verify the changes?**
1. Run `yarn up`, observe console output
2. You should see the API v4 package compile successfully (you'll see the normal Webpack build output)
3. A few seconds later, this error will appear in the console output (presumably when the TypeScript type checking finishes)

After applying these changes, you should be able to run `yarn up` without seeing the error after compiling API v4. You should also be able to navigate to `packages/api-v4`, run `tsc` and not see any TypeScript errors.

**How do I run relevant unit tests?**
To run unit tests:
```
yarn test
```

To run Cypress tests:
```
yarn up
yarn cy:run
```