### PR TITLE
M3-5578: Button text not vertically centered in Firefox

### DIFF
--- a/packages/manager/src/components/Button/Button.tsx
+++ b/packages/manager/src/components/Button/Button.tsx
@@ -40,6 +40,12 @@ const useStyles = makeStyles((theme: Theme) => ({
     display: 'flex',
     alignItems: 'center',
   },
+  '@supports (-moz-appearance: none)': {
+    /* Fix text alignment for Firefox */
+    reg: {
+      marginTop: 2,
+    },
+  },
   helpIcon: {
     marginLeft: -theme.spacing(),
   },

--- a/packages/manager/src/components/DocsLink/DocsLink.tsx
+++ b/packages/manager/src/components/DocsLink/DocsLink.tsx
@@ -22,6 +22,14 @@ const useStyles = makeStyles((theme: Theme) => ({
       textDecoration: 'underline',
     },
   },
+  '@supports (-moz-appearance: none)': {
+    /* Fix text alignment for Firefox */
+    root: {
+      '& span': {
+        top: 1,
+      },
+    },
+  },
 }));
 
 interface Props {


### PR DESCRIPTION
## Description

This PR fixes the vertical alignment for button text on Firefox by adding slight margin for Firefox only. 

## How to test

Check buttons throughout the app and the docs link as well.
