### PR TITLE
M3-5801: Fix events sometimes disappearing from the notification menu

### DIFF
--- a/packages/manager/src/features/NotificationCenter/NotificationData/useEventNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useEventNotifications.tsx
@@ -20,7 +20,6 @@ const unwantedEvents: EventAction[] = [
 
 export const useEventNotifications = (givenEvents?: ExtendedEvent[]) => {
   const events = givenEvents ?? useEvents().events;
-  console.log(events)
   const notificationContext = React.useContext(_notificationContext);
 
   const _events = events.filter(

--- a/packages/manager/src/features/NotificationCenter/NotificationData/useEventNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useEventNotifications.tsx
@@ -20,6 +20,7 @@ const unwantedEvents: EventAction[] = [
 
 export const useEventNotifications = (givenEvents?: ExtendedEvent[]) => {
   const events = givenEvents ?? useEvents().events;
+  console.log(events)
   const notificationContext = React.useContext(_notificationContext);
 
   const _events = events.filter(

--- a/packages/manager/src/hooks/useDismissibleNotifications.ts
+++ b/packages/manager/src/hooks/useDismissibleNotifications.ts
@@ -55,13 +55,15 @@ export const useDismissibleNotifications = (): DismissibleNotificationsHook => {
     options: DismissibleNotificationOptions = {}
   ) => {
     setDismissed(true);
-    updatePreferences({
-      dismissed_notifications: updateDismissedNotifications(
-        dismissedNotifications,
-        _notifications,
-        options
-      ),
-    });
+    if (_notifications.length > 0) {
+      updatePreferences({
+        dismissed_notifications: updateDismissedNotifications(
+          dismissedNotifications,
+          _notifications,
+          options
+        ),
+      });
+    }
   };
 
   const hasDismissedNotifications = (


### PR DESCRIPTION
## Description
There was an existing bug in production that caused events to sometimes disappear from the notification menu upon opening/closing the menu and then refreshing the page.

This was because every time the menu was closed, we were calling `dismissNotifications`, which calls `updatePreferences`, which creates a `profile_update` event, even if there were no notifications. The issue with this is that we store a certain amount of most recent events in the redux store, and then from those events, we filter out `profile_update` events. So eventually, after opening/closing the menu enough times, actual events would get pushed out and only `profile_update` events would be in the store.

This fix makes sure that preferences are only updated when there are actually notifications.

Before:

https://user-images.githubusercontent.com/14323019/165631261-80030245-1526-4154-97e1-ab3921b570f6.mov

After:

https://user-images.githubusercontent.com/14323019/165631250-74c57a55-1e57-4d1b-a761-cc00d0be47bc.mov


## How to test
- Comment the conditional if out
- In the console pick an event to observe that's not a `profile_update` event. Make note of its position in the array. 
- Open/close the notification menu a few times, refresh, and then observe how new `profile_update` events were added correlating to how many times you open/closed the menu and how all the event positions got pushed down
- Uncomment the conditional if, repeat the steps above, notice how no more new `profile_update` events are created
