### PR TITLE
M3-5808: Adjustments to Database Create flow and types due to API changes

### DIFF
--- a/packages/api-v4/src/databases/types.ts
+++ b/packages/api-v4/src/databases/types.ts
@@ -12,10 +12,13 @@ interface DatabaseClusterSizeObject {
   price: DatabasePriceObject;
 }
 
-export interface DatabaseType extends BaseType {
+interface Engines {
+  [engineType: string]: DatabaseClusterSizeObject[];
+}
+export interface DatabaseType extends Omit<BaseType, 'transfer'> {
   class: DatabaseTypeClass;
-  deprecated: boolean;
-  cluster_size: DatabaseClusterSizeObject[];
+  engines: Engines;
+  transfer?: number;
 }
 
 export type Engine = 'mysql' | 'postgresql' | 'mongodb' | 'redis';

--- a/packages/api-v4/src/databases/types.ts
+++ b/packages/api-v4/src/databases/types.ts
@@ -7,18 +7,15 @@ export interface DatabasePriceObject {
   hourly: number;
 }
 
-interface DatabaseClusterSizeObject {
+export interface DatabaseClusterSizeObject {
   quantity: number;
   price: DatabasePriceObject;
 }
 
-interface Engines {
-  [engineType: string]: DatabaseClusterSizeObject[];
-}
-export interface DatabaseType extends Omit<BaseType, 'transfer'> {
+type Engines = Partial<Record<Engine, DatabaseClusterSizeObject[]>>;
+export interface DatabaseType extends BaseType {
   class: DatabaseTypeClass;
   engines: Engines;
-  transfer?: number;
 }
 
 export type Engine = 'mysql' | 'postgresql' | 'mongodb' | 'redis';

--- a/packages/api-v4/src/databases/types.ts
+++ b/packages/api-v4/src/databases/types.ts
@@ -12,7 +12,7 @@ export interface DatabaseClusterSizeObject {
   price: DatabasePriceObject;
 }
 
-type Engines = Partial<Record<Engine, DatabaseClusterSizeObject[]>>;
+type Engines = Record<Engine, DatabaseClusterSizeObject[]>;
 export interface DatabaseType extends BaseType {
   class: DatabaseTypeClass;
   engines: Engines;

--- a/packages/api-v4/src/linodes/types.ts
+++ b/packages/api-v4/src/linodes/types.ts
@@ -273,10 +273,10 @@ export interface BaseType {
   label: string;
   disk: number;
   memory: number;
-  transfer: number;
   vcpus: number;
 }
 export interface LinodeType extends BaseType {
+  transfer: number;
   class: LinodeTypeClass;
   successor: string | null;
   network_out: number;

--- a/packages/manager/src/factories/databases.ts
+++ b/packages/manager/src/factories/databases.ts
@@ -1,15 +1,15 @@
-import * as Factory from 'factory.ts';
-import { pickRandom, randomDate } from 'src/utilities/random';
-import { v4 } from 'uuid';
 import {
   Database,
   DatabaseBackup,
+  DatabaseEngine,
   DatabaseInstance,
   DatabaseStatus,
   DatabaseType,
-  DatabaseEngine,
   ReplicationType,
 } from '@linode/api-v4/lib/databases/types';
+import * as Factory from 'factory.ts';
+import { pickRandom, randomDate } from 'src/utilities/random';
+import { v4 } from 'uuid';
 
 // These are not all of the possible statuses, but these are some common ones.
 const possibleStatuses: DatabaseStatus[] = [
@@ -31,27 +31,80 @@ export const databaseTypeFactory = Factory.Sync.makeFactory<DatabaseType>({
   id: Factory.each((i) => `g6-standard-${i}`),
   label: Factory.each((i) => `Linode ${i} GB`),
   class: 'standard',
-  cluster_size: [
-    {
-      quantity: 1,
-      price: {
-        hourly: 0.4,
-        monthly: 60,
+  engines: {
+    mysql: [
+      {
+        quantity: 1,
+        price: {
+          hourly: 0.09,
+          monthly: 60,
+        },
       },
-    },
-    {
-      quantity: 3,
-      price: {
-        hourly: 0.3,
-        monthly: 90,
+      {
+        quantity: 2,
+        price: {
+          hourly: 0.15,
+          monthly: 100,
+        },
       },
-    },
-  ],
+      {
+        quantity: 3,
+        price: {
+          hourly: 0.21,
+          monthly: 140,
+        },
+      },
+    ],
+    postgresql: [
+      {
+        quantity: 1,
+        price: {
+          hourly: 0.05,
+          monthly: 70,
+        },
+      },
+      {
+        quantity: 2,
+        price: {
+          hourly: 0.12,
+          monthly: 116,
+        },
+      },
+      {
+        quantity: 3,
+        price: {
+          hourly: 0.25,
+          monthly: 180,
+        },
+      },
+    ],
+    mongodb: [
+      {
+        quantity: 1,
+        price: {
+          hourly: 0.03,
+          monthly: 50,
+        },
+      },
+      {
+        quantity: 2,
+        price: {
+          hourly: 0.08,
+          monthly: 88,
+        },
+      },
+      {
+        quantity: 3,
+        price: {
+          hourly: 0.22,
+          monthly: 116,
+        },
+      },
+    ],
+  },
   memory: 2048,
-  transfer: 30,
   disk: 20480,
   vcpus: 2,
-  deprecated: false,
 });
 
 export const databaseInstanceFactory = Factory.Sync.makeFactory<DatabaseInstance>(
@@ -118,7 +171,7 @@ export const databaseBackupFactory = Factory.Sync.makeFactory<DatabaseBackup>({
 });
 
 export const databaseEngineFactory = Factory.Sync.makeFactory<DatabaseEngine>({
-  id: Factory.each((i) => `mysql/${i}`),
+  id: Factory.each((i) => `test/${i}`),
   engine: 'mysql',
   version: Factory.each((i) => `${i}`),
   deprecated: false,

--- a/packages/manager/src/factories/databases.ts
+++ b/packages/manager/src/factories/databases.ts
@@ -101,6 +101,29 @@ export const databaseTypeFactory = Factory.Sync.makeFactory<DatabaseType>({
         },
       },
     ],
+    redis: [
+      {
+        quantity: 1,
+        price: {
+          hourly: 0.08,
+          monthly: 180,
+        },
+      },
+      {
+        quantity: 2,
+        price: {
+          hourly: 0.16,
+          monthly: 360,
+        },
+      },
+      {
+        quantity: 3,
+        price: {
+          hourly: 0.32,
+          monthly: 540,
+        },
+      },
+    ],
   },
   memory: 2048,
   disk: 20480,

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.test.tsx
@@ -75,7 +75,7 @@ describe('Database Create', () => {
     // update node pricing if a plan is selected
     const radioBtn = getAllByText('Nanode 1 GB')[0];
     fireEvent.click(radioBtn);
-    expect(nodeRadioBtns).toHaveTextContent('$60/month $0.4/hr');
-    expect(nodeRadioBtns).toHaveTextContent('$90/month $0.3/hr');
+    expect(nodeRadioBtns).toHaveTextContent('$60/month $0.09/hr');
+    expect(nodeRadioBtns).toHaveTextContent('$140/month $0.21/hr');
   });
 });

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -5,6 +5,7 @@ import {
   DatabasePriceObject,
   DatabaseType,
   Engine,
+  DatabaseClusterSizeObject,
   ReplicationType,
 } from '@linode/api-v4/lib/databases/types';
 import { APIError } from '@linode/api-v4/lib/types';
@@ -208,9 +209,7 @@ const DatabaseCreate: React.FC<{}> = () => {
 
   const { mutateAsync: createDatabase } = useCreateDatabaseMutation();
 
-  const [selectedEngine, setSelectedEngine] = React.useState<
-    Engine | undefined
-  >();
+  const [selectedEngine, setSelectedEngine] = React.useState<Engine>('mysql');
   const [nodePricing, setNodePricing] = React.useState<NodePricing>();
   const [createError, setCreateError] = React.useState<string>();
   const [ipErrorsFromAPI, setIPErrorsFromAPI] = React.useState<APIError[]>();
@@ -311,7 +310,7 @@ const DatabaseCreate: React.FC<{}> = () => {
   } = useFormik({
     initialValues: {
       label: '',
-      engine: '' as Engine,
+      engine: 'mysql' as Engine,
       region: '',
       type: '',
       cluster_size: -1 as ClusterSize,
@@ -388,13 +387,15 @@ const DatabaseCreate: React.FC<{}> = () => {
       return;
     }
 
-    const engineType = values.engine.split('/')[0] || 'mysql'; // If an engine has not yet been selected, default to 'mysql' to prevent crashes from setNodePricing().
+    const engineType = values.engine.split('/')[0];
 
     setNodePricing({
-      single: type.engines[engineType].find((cluster) => cluster.quantity === 1)
-        ?.price,
-      multi: type.engines[engineType].find((cluster) => cluster.quantity === 3)
-        ?.price,
+      single: type.engines[engineType].find(
+        (cluster: DatabaseClusterSizeObject) => cluster.quantity === 1
+      )?.price,
+      multi: type.engines[engineType].find(
+        (cluster: DatabaseClusterSizeObject) => cluster.quantity === 3
+      )?.price,
     });
     setFieldValue(
       'cluster_size',
@@ -508,7 +509,7 @@ const DatabaseCreate: React.FC<{}> = () => {
             header="Choose a Plan"
             className={classes.selectPlanPanel}
             isCreate
-            selectedEngine={selectedEngine ?? 'mysql'} // `selectedEngine` is undefined upon page load, so pass 'mysql' as a default to prevent SelectPlanPanel.tsx crashes.
+            selectedEngine={selectedEngine}
           />
         </Grid>
         <Divider spacingTop={26} spacingBottom={12} />

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -175,8 +175,7 @@ const getEngineOptions = (engines: DatabaseEngine[]) => {
 };
 
 export interface ExtendedDatabaseType extends DatabaseType {
-  heading?: string;
-  subHeadings?: [string, string];
+  heading: string;
 }
 
 interface NodePricing {
@@ -505,7 +504,7 @@ const DatabaseCreate: React.FC<{}> = () => {
               setFieldValue('type', selected);
             }}
             selectedID={values.type}
-            updateFor={[values.type, errors]}
+            updateFor={[values.type, selectedEngine, errors]}
             header="Choose a Plan"
             className={classes.selectPlanPanel}
             isCreate

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -194,7 +194,7 @@ export const SelectPlanPanel: React.FC<CombinedProps> = (props) => {
     const databasePrices = selectedEngine
       ? ((type as unknown) as ExtendedDatabaseType).engines[
           selectedEngine
-        ].find((cluster: any) => cluster.quantity === 1)
+        ]?.find((cluster: any) => cluster.quantity === 1)
       : undefined;
 
     const databaseSubheadings = [
@@ -317,10 +317,11 @@ export const SelectPlanPanel: React.FC<CombinedProps> = (props) => {
   };
 
   const renderPlanContainer = (plans: ExtendedTypes) => {
-    // Show the Transfer column if, for any plan, the api returned data
+    // Show the Transfer column if, for any plan, the api returned data and we're not in the Database Create flow
     const shouldShowTransfer =
       showTransfer &&
-      plans.some((plan: ExtendedType | ExtendedDatabaseType) => plan.transfer);
+      !selectedEngine &&
+      plans.some((plan: ExtendedType) => plan.transfer);
 
     // Show the Network throughput column if, for any plan, the api returned data (currently Bare Metal does not)
     const shouldShowNetwork =

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -167,7 +167,7 @@ export const SelectPlanPanel: React.FC<CombinedProps> = (props) => {
     return arrayToList(withCapability);
   };
 
-  const renderSelection = (type: any, idx: number) => {
+  const renderSelection = (type: ExtendedType, idx: number) => {
     const selectedDiskSize = props.selectedDiskSize
       ? props.selectedDiskSize
       : 0;
@@ -192,9 +192,9 @@ export const SelectPlanPanel: React.FC<CombinedProps> = (props) => {
 
     // If `selectedEngine` is present, it indicates that <SelectPlanPanel /> is being called from <DatabaseCreate />.
     const databasePrices = selectedEngine
-      ? type.engines[selectedEngine].find(
-          (cluster: any) => cluster.quantity === 1
-        )
+      ? ((type as unknown) as ExtendedDatabaseType).engines[
+          selectedEngine
+        ].find((cluster: any) => cluster.quantity === 1)
       : undefined;
 
     const databaseSubheadings = [
@@ -258,13 +258,20 @@ export const SelectPlanPanel: React.FC<CombinedProps> = (props) => {
             </TableCell>
             <TableCell data-qa-monthly>
               {' '}
-              ${type.price?.monthly ?? databasePrices.price.monthly}
+              $
+              {!selectedEngine
+                ? type.price?.monthly
+                : databasePrices?.price.monthly ?? 0}
             </TableCell>
             <TableCell data-qa-hourly>
               {isGPU ? (
                 <Currency quantity={type.price.hourly ?? 0} />
               ) : (
-                `$${type.price?.hourly ?? databasePrices.price.hourly}`
+                `$${
+                  !selectedEngine
+                    ? type.price?.hourly
+                    : databasePrices?.price.hourly ?? 0
+                }`
               )}
             </TableCell>
             <TableCell center noWrap data-qa-ram>
@@ -299,7 +306,7 @@ export const SelectPlanPanel: React.FC<CombinedProps> = (props) => {
             onClick={onSelect(type.id)}
             heading={type.heading}
             subheadings={
-              selectedEngine ? databaseSubheadings : type.subHeadings
+              !selectedEngine ? type.subHeadings : databaseSubheadings
             }
             disabled={planTooSmall || isSamePlan || disabled || isDisabledClass}
             tooltip={tooltip}

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -155,8 +155,17 @@ const databases = [
   }),
 
   rest.get('*/databases/engines', (req, res, ctx) => {
-    const engine = databaseEngineFactory.buildList(3);
-    return res(ctx.json(makeResourcePage(engine)));
+    const engine1 = databaseEngineFactory.buildList(3);
+    const engine2 = databaseEngineFactory.buildList(3, {
+      engine: 'postgresql',
+    });
+    const engine3 = databaseEngineFactory.buildList(3, {
+      engine: 'mongodb',
+    });
+
+    const combinedList = [...engine1, ...engine2, ...engine3];
+
+    return res(ctx.json(makeResourcePage(combinedList)));
   }),
 
   rest.get('*/databases/:engine/instances/:id', (req, res, ctx) => {


### PR DESCRIPTION
## Description
Adjustments to the Database Create flow, Database types, and mocks to reflect forthcoming API changes.

## To-Do:
- [x] Fix various TypeScript types
- [x] Fix issue where changing the DB Engine doesn't update the plan table pricing
- [x] Fix `DatabaseCreate.test.tsx`
- [x] Cleanup (rename some variables, etc.)

## How to test
Go through the Database and Linode Create flows on dev or staging. Ensure that nothing is broken and things behave as you would expect them to.

Please note that the app will crash on dev currently if you choose a MongoDB or PostgreSQL database engine while a plan is selected. This is because the rows have not been populated on dev with data for those engines. Neither DB engine will appear outside of dev presently.
