### PR TITLE
Update Wazuh link

### DIFF
--- a/packages/manager/src/features/OneClickApps/FakeSpec.ts
+++ b/packages/manager/src/features/OneClickApps/FakeSpec.ts
@@ -1574,7 +1574,7 @@ export const oneClickApps: OCA[] = [
     related_guides: [
       {
         title: 'Deploying Wazuh through the Linode Marketplace',
-        href: 'https://www.linode.com/docs/guides/webuzo-marketplace-app/',
+        href: 'https://www.linode.com/docs/products/tools/marketplace/guides/wazuh/',
       },
     ],
     related_info: [


### PR DESCRIPTION
## Description
Currently, the link for the Wazuh Marketplace app guide is actually pointing to the Webuzo guide.

**What does this PR do?**
Fix the link. 