### PR TITLE
M3-5805: Remove NVMe Banners

### DIFF
--- a/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
@@ -12,10 +12,8 @@ import Form from 'src/components/core/Form';
 import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
-import { useDismissibleBanner } from 'src/components/DismissibleBanner/DismissibleBanner';
 import RegionSelect from 'src/components/EnhancedSelect/variants/RegionSelect';
 import HelpIcon from 'src/components/HelpIcon';
-import Link from 'src/components/Link';
 import Notice from 'src/components/Notice';
 import { dcDisplayNames, MAX_VOLUME_SIZE } from 'src/constants';
 import withVolumesRequests, {
@@ -24,7 +22,6 @@ import withVolumesRequests, {
 import EUAgreementCheckbox from 'src/features/Account/Agreements/EUAgreementCheckbox';
 import LinodeSelect from 'src/features/linodes/LinodeSelect';
 import { hasGrant } from 'src/features/Profile/permissionsHelpers';
-import useFlags from 'src/hooks/useFlags';
 import {
   reportAgreementSigningError,
   useAccountAgreements,
@@ -123,7 +120,6 @@ type CombinedProps = Props & VolumesRequests & StateProps;
 
 const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
   const classes = useStyles();
-  const flags = useFlags();
   const { onSuccess, createVolume, origin, history, regions } = props;
 
   const { data: profile } = useProfile();
@@ -150,10 +146,6 @@ const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
 
   const doesNotHavePermission =
     profile?.restricted && !hasGrant('add_volumes', grants);
-
-  const { hasDismissedBanner, handleDismiss } = useDismissibleBanner(
-    'block-storage-available'
-  );
 
   const renderSelectTooltip = (tooltipText: string) => {
     return (
@@ -287,22 +279,6 @@ const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
             ) : null}
             <Box display="flex" flexDirection="column">
               <Paper>
-                {flags.blockStorageAvailability && !hasDismissedBanner ? (
-                  <Notice
-                    success
-                    className={classes.notice}
-                    dismissible
-                    onClose={handleDismiss}
-                  >
-                    <strong>
-                      We&rsquo;re working quickly to expand global availability
-                      of our high-performance NVMe block storage.{' '}
-                      <Link to="https://www.linode.com/blog/cloud-storage/nvme-block-storage-global-rollout/">
-                        Check NVMe rollout status on our blog.
-                      </Link>
-                    </strong>
-                  </Notice>
-                ) : null}
                 <Typography
                   className={classes.copy}
                   variant="body1"

--- a/packages/manager/src/features/Volumes/VolumeTableRow.tsx
+++ b/packages/manager/src/features/Volumes/VolumeTableRow.tsx
@@ -97,7 +97,7 @@ export const VolumeTableRow: React.FC<CombinedProps> = (props) => {
           container
           wrap="nowrap"
           justifyContent="space-between"
-          alignItems="flex-end"
+          alignItems="center"
         >
           {isVolumesLanding ? (
             <>

--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -10,7 +10,6 @@ import { bindActionCreators, Dispatch } from 'redux';
 import VolumeIcon from 'src/assets/icons/entityIcons/volume.svg';
 import { makeStyles } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
-import DismissibleBanner from 'src/components/DismissibleBanner';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import EntityTable from 'src/components/EntityTable';
 import LandingHeader from 'src/components/LandingHeader';
@@ -31,7 +30,6 @@ import withLinodes, {
   Props as WithLinodesProps,
 } from 'src/containers/withLinodes.container';
 import { resetEventsPolling } from 'src/eventsPolling';
-import useFlags from 'src/hooks/useFlags';
 import useReduxLoad from 'src/hooks/useReduxLoad';
 import withNotifications, {
   WithNotifications,
@@ -143,7 +141,6 @@ export const useStyles = makeStyles(() => ({
 
 export const VolumesLanding: React.FC<CombinedProps> = (props) => {
   const classes = useStyles();
-  const flags = useFlags();
 
   const {
     volumesLoading,
@@ -284,23 +281,6 @@ export const VolumesLanding: React.FC<CombinedProps> = (props) => {
       });
   };
 
-  const Banner = () => {
-    return flags.blockStorageAvailability ? (
-      <DismissibleBanner
-        preferenceKey="block-storage-available"
-        productInformationIndicator
-      >
-        <Typography>
-          Take advantage of high-performance{' '}
-          <Link to="https://www.linode.com/products/block-storage/">
-            NVMe Block Storage
-          </Link>
-          .
-        </Typography>
-      </DismissibleBanner>
-    ) : null;
-  };
-
   if (_loading) {
     return <Loading />;
   }
@@ -313,7 +293,6 @@ export const VolumesLanding: React.FC<CombinedProps> = (props) => {
     return (
       <>
         <DocumentTitleSegment segment="Volumes" />
-        <Banner />
         <Placeholder
           title="Volumes"
           className={classes.empty}
@@ -372,7 +351,6 @@ export const VolumesLanding: React.FC<CombinedProps> = (props) => {
         }: ToggleProps<boolean>) => {
           return (
             <>
-              <Banner />
               <LandingHeader
                 title="Volumes"
                 entity="Volume"

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
@@ -1,7 +1,6 @@
 import { Config, Disk, LinodeStatus } from '@linode/api-v4/lib/linodes';
 import { Volume } from '@linode/api-v4/lib/volumes';
 import * as React from 'react';
-import { useDispatch } from 'react-redux';
 import { useHistory, useLocation, useRouteMatch } from 'react-router-dom';
 import { compose } from 'recompose';
 import Button from 'src/components/Button';
@@ -17,14 +16,12 @@ import PowerDialogOrDrawer, {
 } from 'src/features/linodes/PowerActionsDialogOrDrawer';
 import { DialogType } from 'src/features/linodes/types';
 import { notificationContext as _notificationContext } from 'src/features/NotificationCenter/NotificationContext';
-import useFlags from 'src/hooks/useFlags';
 import useLinodeActions from 'src/hooks/useLinodeActions';
 import useNotifications from 'src/hooks/useNotifications';
 import useReduxLoad from 'src/hooks/useReduxLoad';
 import useVolumes from 'src/hooks/useVolumes';
 import { useProfile } from 'src/queries/profile';
 import { getVolumesForLinode } from 'src/store/volume/volume.selector';
-import { openForAttaching, openForCreating } from 'src/store/volumeForm';
 import { parseQueryParams } from 'src/utilities/queryParams';
 import DeleteDialog from '../../LinodesLanding/DeleteDialog';
 import MigrateLinode from '../../MigrateLanding/MigrateLinode';
@@ -70,9 +67,6 @@ interface DialogProps {
 type CombinedProps = Props & LinodeDetailContext & LinodeContext;
 
 const LinodeDetailHeader: React.FC<CombinedProps> = (props) => {
-  const flags = useFlags();
-  const dispatch = useDispatch();
-
   // Several routes that used to have dedicated pages (e.g. /resize, /rescue)
   // now show their content in modals instead. The logic below facilitates handling
   // modal-related query params (and the older /:subpath routes before the redirect
@@ -145,9 +139,6 @@ const LinodeDetailHeader: React.FC<CombinedProps> = (props) => {
 
   const { updateLinode, deleteLinode } = useLinodeActions();
   const history = useHistory();
-
-  const isAtlanta = linode.region === 'us-southeast';
-  const isNewark = linode.region === 'us-east';
 
   const openPowerActionDialog = (
     bootAction: BootAction,
@@ -297,9 +288,6 @@ const LinodeDetailHeader: React.FC<CombinedProps> = (props) => {
     return deleteLinode(linodeId);
   };
 
-  const showVolumesBanner =
-    flags.blockStorageAvailability && numAttachedVolumes === 0;
-
   const upgradeableVolumeIds = notifications
     .filter(
       (notification) =>
@@ -312,102 +300,6 @@ const LinodeDetailHeader: React.FC<CombinedProps> = (props) => {
     .map((notification) => notification.entity!.id);
 
   const numUpgradeableVolumes = upgradeableVolumeIds.length;
-
-  // Check to make sure:
-  //    1. there are no Volumes currently attached
-  //    2. the Volume is unattached
-  //    3. the Volume is in the right region
-  const allUnattachedAtlantaVolumes = Object.values(volumes.itemsById).filter(
-    (thisVolume) =>
-      thisVolume.linode_id === null && thisVolume.region === 'us-southeast'
-  );
-
-  const allUnattachedNewarkVolumes = Object.values(volumes.itemsById).filter(
-    (thisVolume) =>
-      thisVolume.linode_id === null && thisVolume.region === 'us-east'
-  );
-
-  const isCreateMode = isAtlanta
-    ? numAttachedVolumes === 0 && allUnattachedAtlantaVolumes.length === 0
-    : isNewark
-    ? numAttachedVolumes === 0 && allUnattachedNewarkVolumes.length === 0
-    : false;
-
-  const volumesBannerAction = isCreateMode ? 'Create' : 'Attach';
-
-  const NVMeBanner = () => {
-    if (showVolumesBanner && (isAtlanta || isNewark)) {
-      return (
-        <DismissibleBanner
-          preferenceKey={`block-storage-available-${
-            isAtlanta ? 'atlanta' : 'newark'
-          }`}
-          productInformationIndicator
-        >
-          <Grid
-            container
-            direction="row"
-            alignItems="center"
-            justifyContent="space-between"
-          >
-            <Grid item>
-              {isAtlanta ? (
-                <Typography>
-                  Atlanta is the first data center with our new high-performance{' '}
-                  <Link to="https://www.linode.com/products/block-storage/">
-                    NVMe Block Storage
-                  </Link>
-                  .
-                </Typography>
-              ) : (
-                <Typography>
-                  High-performance{' '}
-                  <Link to="https://www.linode.com/products/block-storage/">
-                    NVMe Block Storage
-                  </Link>{' '}
-                  is now available in Newark, NJ.
-                </Typography>
-              )}
-            </Grid>
-            <Grid item>
-              <Button
-                buttonType="primary"
-                onClick={
-                  isCreateMode ? openCreateVolumeDrawer : openAttachVolumeDrawer
-                }
-              >
-                {volumesBannerAction} a Volume
-              </Button>
-            </Grid>
-          </Grid>
-        </DismissibleBanner>
-      );
-    } else {
-      return null;
-    }
-  };
-
-  const openCreateVolumeDrawer = (e: any) => {
-    e.preventDefault();
-
-    if (linode.id && linode.label && linode.region) {
-      dispatch(
-        openForCreating('Created from Linode Details', {
-          linodeId: linode.id,
-          linodeLabel: linode.label,
-          linodeRegion: linode.region,
-        })
-      );
-    }
-  };
-
-  const openAttachVolumeDrawer = (e: any) => {
-    e.preventDefault();
-
-    if (linode.id && linode.label && linode.region) {
-      dispatch(openForAttaching(linode.id, linode.region, linode.label));
-    }
-  };
 
   return (
     <>
@@ -449,7 +341,6 @@ const LinodeDetailHeader: React.FC<CombinedProps> = (props) => {
           </Grid>
         </DismissibleBanner>
       ) : null}
-      <NVMeBanner />
       <LinodeDetailsBreadcrumb />
       <LinodeEntityDetail
         variant="details"


### PR DESCRIPTION
## Description

- Remove NVMe Banners
- Fixes alignment in Volume Row

### Removed Banners
![Screen Shot 2022-05-11 at 12 09 29 PM](https://user-images.githubusercontent.com/6440455/167898958-bae10fb2-c7b3-4fda-a55c-eda5ec638ea5.jpg)
![Screen Shot 2022-05-11 at 12 07 38 PM](https://user-images.githubusercontent.com/6440455/167899243-896bdafb-7a29-4398-8a0b-bb07c0b7df29.jpg)
![Screen Shot 2022-05-11 at 12 07 25 PM](https://user-images.githubusercontent.com/6440455/167899315-e72aba82-4125-493a-b9c9-2c6b6276eacb.jpg)

### Fixed Volume Row
![Screen Shot 2022-05-11 at 12 08 22 PM](https://user-images.githubusercontent.com/6440455/167899032-728503e9-adbf-4a91-a37f-43760fbb0c94.jpg)
![Screen Shot 2022-05-11 at 12 08 38 PM](https://user-images.githubusercontent.com/6440455/167899043-17e9734b-a796-4190-bab0-af9ec9e36712.jpg)


## How to test

- Check alignment in volume tables
- Ensure volume banners have been removed properly and no critical functionality was accidentally lost
