### PR TITLE
M3-5827: Hotfix for MongoDB username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2022-05-16] - v1.66.1
+### Changed:
+- Display 'admin' as username for MongoDB database clusters
+
 ## [2022-05-16] - v1.66.0
 
 ### Added:

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.66.0",
+  "version": "1.66.1",
   "private": true,
   "engines": {
     "node": ">= 14.17.4"

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
@@ -179,7 +179,8 @@ export const DatabaseSummaryConnectionDetails: React.FC<Props> = (props) => {
       </Typography>
       <Grid className={classes.connectionDetailsCtn}>
         <Typography>
-          <span>username</span> = {DB_ROOT_USERNAME}
+          <span>username</span> ={' '}
+          {database.engine === 'mongodb' ? 'admin' : DB_ROOT_USERNAME}
         </Typography>
         <Box display="flex">
           <Typography>


### PR DESCRIPTION
## Description
Display `admin` as the username for MongoDB clusters.

## How to test
MySQL and PostgreSQL database clusters should have `linroot` as the username, and MongoDB clusters should have `admin` as the username in Connection Details.
