### PR TITLE
M3-5827: Display correct engine-based usernames in Connection Details section 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2022-05-16] - v1.66.2
+### Changed:
+- Display linroot as the username for MongoDB and MySQL clusters, and linpostgres as the username for PostgreSQL clusters
+
 ## [2022-05-16] - v1.66.1
 ### Changed:
 - Display 'admin' as username for MongoDB database clusters

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.66.1",
+  "version": "1.66.2",
   "private": true,
   "engines": {
     "node": ">= 14.17.4"

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
@@ -180,7 +180,7 @@ export const DatabaseSummaryConnectionDetails: React.FC<Props> = (props) => {
       <Grid className={classes.connectionDetailsCtn}>
         <Typography>
           <span>username</span> ={' '}
-          {database.engine === 'mongodb' ? 'admin' : DB_ROOT_USERNAME}
+          {database.engine === 'postgresql' ? 'linpostgres' : DB_ROOT_USERNAME}
         </Typography>
         <Box display="flex">
           <Typography>


### PR DESCRIPTION
## Description
Display `linpostgres` for PostgreSQL database usernames and `linroot` for MySQL and MongoDB database usernames.