### PR TITLE
M3-5828: Fix creation of 3 node MySQL clusters

### DIFF
--- a/packages/api-v4/package.json
+++ b/packages/api-v4/package.json
@@ -21,7 +21,7 @@
   "types": "./lib/index.d.ts",
   "unpkg": "./index.js",
   "dependencies": {
-    "@linode/validation": "0.11.0",
+    "@linode/validation": "0.11.1",
     "@types/yup": "^0.29.13",
     "axios": "~0.21.4",
     "ipaddr.js": "^2.0.0",

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@linode/api-v4": "^0.71.0",
-    "@linode/validation": "0.11.0",
+    "@linode/validation": "0.11.1",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.56",

--- a/packages/validation/CHANGELOG.md
+++ b/packages/validation/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2022-05-16] - v0.11.1
+
+### Fixed
+- createDatabaseSchema MySQL validation to accept semi_synch
+
 ## [2022-05-16] - v0.11.0
 
 ### Changed

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linode/validation",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Yup validation schemas for use with the Linode APIv4",
   "main": "./index.js",
   "types": "./lib/index.d.ts",

--- a/packages/validation/src/databases.schema.ts
+++ b/packages/validation/src/databases.schema.ts
@@ -19,7 +19,7 @@ export const createDatabaseSchema = object({
     then: string()
       .when('engine', {
         is: (engine: string) => Boolean(engine.match(/mysql/)),
-        then: string().oneOf(['none', 'semi-synch', 'asynch']),
+        then: string().oneOf(['none', 'semi_synch', 'asynch']),
       })
       .when('engine', {
         is: (engine: string) => Boolean(engine.match(/postgres/)),


### PR DESCRIPTION
## Description

- Fixes typo in `@linode/validation` package allowing users to create 3 node MySQL clusters. 

## How to test

- Try to create a 3 node MySQL cluster
- Try testing many other configurations of Databases in Cloud Manager