### PR TITLE
M3-5829: Fix Linode Configs Cancel Button

### DIFF
--- a/packages/manager/src/components/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/packages/manager/src/components/ConfirmationDialog/ConfirmationDialog.tsx
@@ -34,19 +34,17 @@ export interface Props extends DialogProps {
   title: string;
 }
 
-type CombinedProps = Props;
-
-const ConfirmationDialog: React.FC<CombinedProps> = (props) => {
+const ConfirmationDialog: React.FC<Props> = (props) => {
   const classes = useStyles();
 
-  const { title, children, actions, error, onClose, ...dialogProps } = props;
+  const { title, children, actions, error, ...dialogProps } = props;
 
   return (
     <Dialog
       {...dialogProps}
       onClose={(_, reason) => {
         if (reason !== 'backdropClick') {
-          onClose();
+          dialogProps.onClose();
         }
       }}
       className={classes.root}


### PR DESCRIPTION
## 🪲 The Bug

- Caused 6 months ago
- Caused when updating code to fix a Material UI deprecation regarding `backdropClick`
- The `onClose` function was not getting passed to our function that generates the modal action buttons

## 📝 Description

- Fixes a flaw in the `ConfirmationDialog.tsx` component by passing `onClose` down to the actions

## 🧪 How to test

- Test action buttons and cancel buttons in Linode dialogs
  - Specifically test the Linode configs deletion dialog


![Screen Shot 2022-05-17 at 10 04 38 AM](https://user-images.githubusercontent.com/6440455/168829995-a0836aca-2be0-4128-b8ff-be59583d8f70.jpg)

