### PR TITLE
SD-168: Mask admin usernames in the Cloud Manager

### DIFF
--- a/packages/api-v4/src/support/types.ts
+++ b/packages/api-v4/src/support/types.ts
@@ -23,6 +23,7 @@ export interface SupportReply {
   description: string;
   id: number;
   from_linode: boolean;
+  friendly_name: string;
 }
 
 export interface ReplyRequest {

--- a/packages/manager/src/factories/support.ts
+++ b/packages/manager/src/factories/support.ts
@@ -24,4 +24,5 @@ export const supportReplyFactory = Factory.Sync.makeFactory<SupportReply>({
   created: '2019-04-02T12:37:47',
   gravatar_id: 'xxxxx',
   from_linode: true,
+  friendly_name: 'Lucy',
 });

--- a/packages/manager/src/features/Support/ExpandableTicketPanel.tsx
+++ b/packages/manager/src/features/Support/ExpandableTicketPanel.tsx
@@ -100,6 +100,7 @@ interface Data {
   date: string;
   description: string;
   username: string;
+  friendly_name: string;
   from_linode: boolean;
   ticket_id: string;
   reply_id: string;
@@ -134,6 +135,7 @@ export const ExpandableTicketPanel: React.FC<CombinedProps> = (props) => {
         description: ticket.description,
         username: ticket.opened_by,
         from_linode: false,
+        friendly_name: ticket.opened_by,
         updated: ticket.updated,
       });
     } else if (reply) {
@@ -146,6 +148,7 @@ export const ExpandableTicketPanel: React.FC<CombinedProps> = (props) => {
         description: reply.description,
         username: reply.created_by,
         from_linode: reply.from_linode,
+        friendly_name: reply.friendly_name,
         updated: ticketUpdated!,
       });
     }
@@ -186,7 +189,7 @@ export const ExpandableTicketPanel: React.FC<CombinedProps> = (props) => {
               <Grid container className={classes.header}>
                 <Grid item className={classes.headerInner}>
                   <Typography className={classes.userName} component="span">
-                    {data.username}
+                    {data.friendly_name}
                   </Typography>
                   {data.from_linode &&
                   !OFFICIAL_USERNAMES.includes(data.username) ? (


### PR DESCRIPTION
## Description

This adds the `friendly_name` property to the `SupportReply` interface. This will be displayed on ticket replies by Linode support instead of showing their current handle. 

*This is contingent on changes to the API.*

The proposed API changes will always return a `friendly_name`; it defaults to the `created_by` value.

## How to test

I've already added the `friendly_name` property to the `supportReplyFactory` for mock data; you can see it populating with the name "Lucy" for any replies created by `support-staff`.
