### PR TITLE
Fix volumes e2e tests after removing NVMe banners

### DIFF
--- a/packages/manager/cypress/integration/volumes/create-volume.smoke.spec.ts
+++ b/packages/manager/cypress/integration/volumes/create-volume.smoke.spec.ts
@@ -90,7 +90,7 @@ describe('volumes', () => {
     getVisible('[data-qa-action-menu-item="Delete"]');
   });
 
-  it('creates volume from linode with block storage support (Atlanta)', () => {
+  it('creates volume from linode details', () => {
     interceptOnce('GET', '*/volumes*', volumeList).as('getVolumes');
     cy.intercept('POST', `*/volumes`, (req) => {
       req.reply(attachedVolume);
@@ -107,12 +107,8 @@ describe('volumes', () => {
     fbtClick(linodeLabel);
     cy.wait('@getVolumes');
     cy.wait('@getLinodeDetail');
-    getVisible(
-      '[href="https://www.linode.com/products/block-storage/"]'
-    ).within(() => {
-      fbtVisible('NVMe Block Storage');
-    });
-    fbtClick('Create a Volume');
+    fbtClick('Storage');
+    fbtClick('Create Volume');
     getClick('[value="creating_for_linode"]');
     getVisible(`[data-qa-drawer-title="Create Volume for ${linodeLabel}"]`);
     getClick('[data-qa-volume-label="true"]').type('cy-test-volume');


### PR DESCRIPTION
## Description

- Updates e2e tests for volumes to not use the NVMe banner we removed in #8371 

## How to test

- `yarn cy:run -s "./cypress/integration/volumes/create-volume.smoke.spec.ts"`
