### PR TITLE
Allow more sorting options for Databases 

### DIFF
--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
@@ -93,7 +93,14 @@ const DatabaseLanding: React.FC = () => {
               Status
             </TableSortCell>
             <Hidden xsDown>
-              <TableCell>Configuration</TableCell>
+              <TableSortCell
+                active={orderBy === 'cluster_size'}
+                direction={order}
+                label="cluster_size"
+                handleClick={handleOrderChange}
+              >
+                Configuration
+              </TableSortCell>
             </Hidden>
             <TableCell>Engine</TableCell>
             <Hidden smDown>

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
@@ -84,7 +84,14 @@ const DatabaseLanding: React.FC = () => {
             >
               Cluster Label
             </TableSortCell>
-            <TableCell>Status</TableCell>
+            <TableSortCell
+              active={orderBy === 'status'}
+              direction={order}
+              label="status"
+              handleClick={handleOrderChange}
+            >
+              Status
+            </TableSortCell>
             <Hidden xsDown>
               <TableCell>Configuration</TableCell>
             </Hidden>


### PR DESCRIPTION
## 📝 Description

- Allows users to sort their Databases by `Configuration` and `Status` in addition to the existing `Label` and `Created`
- We can add this because the API supports it and this table is fully paginated and sorted by the API

## 🔍 Preview 

https://user-images.githubusercontent.com/6440455/169611034-49d0f160-fc86-4fb4-9f9c-337275b9b4ae.mov

## How to test

- Ensure you have a few databases of different types to test with
- Go to `http://localhost:3000/databases`
- Test all sortable columns
  - Test table responsiveness
  - Ensure query params get set properly when a column is changed
