### PR TITLE
M3-5817: Add support for scoping Database and Firewall permissions

### DIFF
--- a/packages/manager/src/features/Profile/APITokens/utils.test.ts
+++ b/packages/manager/src/features/Profile/APITokens/utils.test.ts
@@ -11,8 +11,10 @@ describe('APIToken utils', () => {
       const result = scopeStringToPermTuples('*', basePerms);
       const expected = [
         ['account', 2],
+        ['databases', 2],
         ['domains', 2],
         ['events', 2],
+        ['firewall', 2],
         ['images', 2],
         ['ips', 2],
         ['linodes', 2],
@@ -32,8 +34,10 @@ describe('APIToken utils', () => {
       const result = scopeStringToPermTuples('', basePerms);
       const expected = [
         ['account', 0],
+        ['databases', 0],
         ['domains', 0],
         ['events', 0],
+        ['firewall', 0],
         ['images', 0],
         ['ips', 0],
         ['linodes', 0],
@@ -54,8 +58,10 @@ describe('APIToken utils', () => {
       const result = scopeStringToPermTuples('account:none', basePerms);
       const expected = [
         ['account', 0],
+        ['databases', 0],
         ['domains', 0],
         ['events', 0],
+        ['firewall', 0],
         ['images', 0],
         ['ips', 0],
         ['linodes', 0],
@@ -76,8 +82,10 @@ describe('APIToken utils', () => {
       const result = scopeStringToPermTuples('account:read_only', basePerms);
       const expected = [
         ['account', 1],
+        ['databases', 0],
         ['domains', 0],
         ['events', 0],
+        ['firewall', 0],
         ['images', 0],
         ['ips', 0],
         ['linodes', 0],
@@ -98,8 +106,10 @@ describe('APIToken utils', () => {
       const result = scopeStringToPermTuples('account:read_write', basePerms);
       const expected = [
         ['account', 2],
+        ['databases', 0],
         ['domains', 0],
         ['events', 0],
+        ['firewall', 0],
         ['images', 0],
         ['ips', 0],
         ['linodes', 0],
@@ -123,8 +133,10 @@ describe('APIToken utils', () => {
       );
       const expected = [
         ['account', 0],
+        ['databases', 0],
         ['domains', 1],
         ['events', 0],
+        ['firewall', 0],
         ['images', 0],
         ['ips', 0],
         ['linodes', 0],
@@ -152,8 +164,10 @@ describe('APIToken utils', () => {
       );
       const expected = [
         ['account', 2],
+        ['databases', 0],
         ['domains', 0],
         ['events', 0],
+        ['firewall', 0],
         ['images', 0],
         ['ips', 0],
         ['linodes', 0],
@@ -181,8 +195,10 @@ describe('APIToken utils', () => {
       );
       const expected = [
         ['account', 1],
+        ['databases', 0],
         ['domains', 0],
         ['events', 0],
+        ['firewall', 0],
         ['images', 0],
         ['ips', 0],
         ['linodes', 0],
@@ -203,8 +219,10 @@ describe('APIToken utils', () => {
       it('should return 0 if all scopes are 0', () => {
         const scopes: Permission[] = [
           ['account', 0],
+          ['databases', 0],
           ['domains', 0],
           ['events', 0],
+          ['firewall', 0],
           ['images', 0],
           ['ips', 0],
           ['linodes', 0],
@@ -220,8 +238,10 @@ describe('APIToken utils', () => {
       it('should return 1 if all scopes are 1', () => {
         const scopes: Permission[] = [
           ['account', 1],
+          ['databases', 1],
           ['domains', 1],
           ['events', 1],
+          ['firewall', 1],
           ['images', 1],
           ['ips', 1],
           ['linodes', 1],
@@ -237,8 +257,10 @@ describe('APIToken utils', () => {
       it('should return 2 if all scopes are 2', () => {
         const scopes: Permission[] = [
           ['account', 2],
+          ['databases', 2],
           ['domains', 2],
           ['events', 2],
+          ['firewall', 2],
           ['images', 2],
           ['ips', 2],
           ['linodes', 2],
@@ -254,8 +276,10 @@ describe('APIToken utils', () => {
       it('should return null if all scopes are different', () => {
         const scopes: Permission[] = [
           ['account', 1],
+          ['databases', 0],
           ['domains', 2],
           ['events', 0],
+          ['firewall', 0],
           ['images', 2],
           ['ips', 2],
           ['linodes', 1],

--- a/packages/manager/src/features/Profile/APITokens/utils.ts
+++ b/packages/manager/src/features/Profile/APITokens/utils.ts
@@ -13,6 +13,7 @@ export const basePerms = [
   'object_storage',
   'stackscripts',
   'volumes',
+  'databases',
 ];
 
 export const basePermNameMap: Record<string, string> = {
@@ -28,6 +29,7 @@ export const basePermNameMap: Record<string, string> = {
   object_storage: 'Object Storage',
   stackscripts: 'StackScripts',
   volumes: 'Volumes',
+  databases: 'Databases',
 };
 
 export const inverseLevelMap = ['none', 'read_only', 'read_write'];

--- a/packages/manager/src/features/Profile/APITokens/utils.ts
+++ b/packages/manager/src/features/Profile/APITokens/utils.ts
@@ -2,8 +2,10 @@ export type Permission = [string, number];
 
 export const basePerms = [
   'account',
+  'databases',
   'domains',
   'events',
+  'firewall',
   'images',
   'ips',
   'linodes',
@@ -13,14 +15,14 @@ export const basePerms = [
   'object_storage',
   'stackscripts',
   'volumes',
-  'firewall',
-  'databases',
 ];
 
 export const basePermNameMap: Record<string, string> = {
   account: 'Account',
+  databases: 'Databases',
   domains: 'Domains',
   events: 'Events',
+  firewall: 'Firewall',
   images: 'Images',
   ips: 'IPs',
   linodes: 'Linodes',
@@ -30,8 +32,6 @@ export const basePermNameMap: Record<string, string> = {
   object_storage: 'Object Storage',
   stackscripts: 'StackScripts',
   volumes: 'Volumes',
-  firewall: 'Firewall',
-  databases: 'Databases',
 };
 
 export const inverseLevelMap = ['none', 'read_only', 'read_write'];

--- a/packages/manager/src/features/Profile/APITokens/utils.ts
+++ b/packages/manager/src/features/Profile/APITokens/utils.ts
@@ -13,6 +13,7 @@ export const basePerms = [
   'object_storage',
   'stackscripts',
   'volumes',
+  'firewall',
   'databases',
 ];
 
@@ -29,6 +30,7 @@ export const basePermNameMap: Record<string, string> = {
   object_storage: 'Object Storage',
   stackscripts: 'StackScripts',
   volumes: 'Volumes',
+  firewall: 'Firewall',
   databases: 'Databases',
 };
 

--- a/packages/manager/src/features/Profile/APITokens/utils.ts
+++ b/packages/manager/src/features/Profile/APITokens/utils.ts
@@ -22,7 +22,7 @@ export const basePermNameMap: Record<string, string> = {
   databases: 'Databases',
   domains: 'Domains',
   events: 'Events',
-  firewall: 'Firewall',
+  firewall: 'Firewalls',
   images: 'Images',
   ips: 'IPs',
   linodes: 'Linodes',


### PR DESCRIPTION
## Description
Adds Databases to the `Personal Access Token` drawer, which lets the user set smaller scopes such as read_only.

I also went ahead and added Firewall to the drawer since it's a simple change and we'll need to add support for that later anyway.

![image](https://user-images.githubusercontent.com/14323019/170341135-6abfc93c-2e48-4f76-b554-0e0af3eeb8ac.png)

## How to test
- Go to `/profile/tokens` and click on `Create a Personal Access Token`
- You should see `Databases` and `Firewall` in the access table
- Create a token and then click on `View Scopes` for the token you just created. You should see a checkmark for the values you selected when creating the token.
- Make an API request with the token and ensure that the permissions are working as expected
