### PR TITLE
M3-5812: Tweak Connection Details for Mongo clusters

### DIFF
--- a/packages/api-v4/src/databases/types.ts
+++ b/packages/api-v4/src/databases/types.ts
@@ -153,6 +153,8 @@ type MongoCompressionType = 'none' | 'snappy' | 'zlib';
 export interface MongoDatabase extends BaseDatabase {
   storage_engine: MongoStorageEngine;
   compression_type: MongoCompressionType;
+  replica_set: string | null;
+  peers: string[];
 }
 
 export type ComprehensiveReplicationType = MySQLReplicationType &


### PR DESCRIPTION
## Description
- Change `host` field to `hostname` across engine types (note: single-node Mongo clusters will have `hostname` and multi-node clusters will have `hostnames`)
- Add `replica set` field for Mongo clusters
- The `ssl` field for Mongo clusters will have `TRUE` or `FALSE` (compared to `ENABLED` or `DISABLED` for other engine types)
- When a DB is provisioning, have placeholders for the appropriate fields until provisioning is complete.

![Screen Shot 2022-05-25 at 4 51 53 PM](https://user-images.githubusercontent.com/32860776/170370226-cddd304c-e03a-4222-8f56-4d4805e0a79f.jpg)

![Screen Shot 2022-05-25 at 4 41 56 PM](https://user-images.githubusercontent.com/32860776/170370189-d2447d6d-f712-4b26-b704-3d0badbde03e.jpg)

## How to test
Review your existing clusters to make sure no inadvertent changes have happened to the Connection Details. Then create a new single-node Mongo cluster and a new multi-node Mongo clusters. Observe the provisional state of the data and that it updates when provisioning completes.
