### PR TITLE
Indicate that MongoDB and PostgreSQL are in beta.

### DIFF
--- a/packages/manager/src/components/EnhancedSelect/components/SingleValue.tsx
+++ b/packages/manager/src/components/EnhancedSelect/components/SingleValue.tsx
@@ -8,6 +8,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     flexFlow: 'row nowrap',
     alignItems: 'center',
     paddingLeft: `45px !important`,
+    height: '100%',
   },
   icon: {
     fontSize: '1.8em',

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -32,6 +32,7 @@ export interface Flags {
   regionDropdown: boolean;
   taxCollectionBanner: TaxCollectionBanner;
   databaseBeta: boolean;
+  databaseEngineBetas: string[];
 }
 
 type PromotionalOfferFeature =

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -496,7 +496,7 @@ const DatabaseCreate: React.FC<{}> = () => {
           {isSelectedEngineInBeta ? (
             <Typography style={{ marginTop: 8 }}>
               {databaseEngineMap[engineType]} managed databases are currently in
-              beta and after subject to the terms of the{' '}
+              beta and are subject to the terms of the{' '}
               <ExternalLink
                 text="Early Adopter Testing Agreement"
                 link="https://www.linode.com/legal-eatp/"

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -28,7 +28,6 @@ import Paper from 'src/components/core/Paper';
 import RadioGroup from 'src/components/core/RadioGroup';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
-import DismissibleBanner from 'src/components/DismissibleBanner';
 import SingleValue from 'src/components/EnhancedSelect/components/SingleValue';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import RegionSelect from 'src/components/EnhancedSelect/variants/RegionSelect';
@@ -60,6 +59,10 @@ import {
   validateIPs,
 } from 'src/utilities/ipUtils';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
+import { components } from 'react-select';
+import Box from 'src/components/core/Box';
+import ExternalLink from 'src/components/ExternalLink';
+import { GroupHeadingProps } from 'react-select/src/components/Group';
 
 const useStyles = makeStyles((theme: Theme) => ({
   formControlLabel: {
@@ -428,24 +431,14 @@ const DatabaseCreate: React.FC<{}> = () => {
     return <ErrorState errorText="An unexpected error occurred." />;
   }
 
+  const engineType = values.engine.split('/')[0];
+
+  const isSelectedEngineInBeta = (flags.databaseEngineBetas ?? []).includes(
+    databaseEngineMap[engineType]
+  );
+
   return (
     <form onSubmit={handleSubmit}>
-      {flags.databaseBeta ? (
-        <DismissibleBanner
-          preferenceKey="dbaas-open-beta-notice"
-          productInformationIndicator
-        >
-          <Typography>
-            Managed Database for MySQL is available in a free, open beta period
-            until May 2nd, 2022. This is a beta environment and should not be
-            used to support production workloads. Review the{' '}
-            <Link to="https://www.linode.com/legal-eatp">
-              Early Adopter Program SLA
-            </Link>
-            .
-          </Typography>
-        </DismissibleBanner>
-      ) : null}
       <BreadCrumb
         labelTitle="Create"
         pathname={location.pathname}
@@ -486,7 +479,11 @@ const DatabaseCreate: React.FC<{}> = () => {
             )}
             errorText={errors.engine}
             options={engineOptions}
-            components={{ Option: RegionOption, SingleValue }}
+            components={{
+              Option: RegionOption,
+              SingleValue,
+              GroupHeading: DatabaseBetaGroupHeading,
+            }}
             placeholder={'Select a Database Engine'}
             onChange={(selected: Item<string>) => {
               setFieldValue('engine', selected.value);
@@ -496,6 +493,18 @@ const DatabaseCreate: React.FC<{}> = () => {
             }}
             isClearable={false}
           />
+          {isSelectedEngineInBeta ? (
+            <Typography style={{ marginTop: 8 }}>
+              {databaseEngineMap[engineType]} managed databases are currently in
+              beta and after subject to the terms of the{' '}
+              <ExternalLink
+                text="Early Adopter Testing Agreement"
+                link="https://www.linode.com/legal-eatp/"
+                hideIcon
+              />
+              .
+            </Typography>
+          ) : null}
         </Grid>
         <Grid item>
           <RegionSelect
@@ -679,3 +688,36 @@ const determineCompressionType = (engine: string) => {
 };
 
 export default DatabaseCreate;
+
+// Add's a "BETA" chip to DB Engine Groups in beta.
+export const DatabaseBetaGroupHeading: React.FC<
+  GroupHeadingProps<{}, false>
+> = (props) => {
+  const flags = useFlags();
+
+  const { databaseEngineBetas } = flags;
+
+  const isBeta =
+    typeof props.children === 'string' &&
+    (databaseEngineBetas ?? []).includes(props.children);
+
+  return (
+    <Box display="flex">
+      <components.GroupHeading {...props} />
+      {isBeta ? (
+        <Chip
+          style={{
+            backgroundColor: '#E9E9E9',
+            fontSize: '0.625rem',
+            height: 16,
+            marginTop: 2,
+            letterSpacing: '.25px',
+            textTransform: 'uppercase',
+          }}
+          label="beta"
+          component="span"
+        />
+      ) : null}
+    </Box>
+  );
+};

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -689,7 +689,7 @@ const determineCompressionType = (engine: string) => {
 
 export default DatabaseCreate;
 
-// Add's a "BETA" chip to DB Engine Groups in beta.
+// Adds a "BETA" chip to DB Engine Groups in beta.
 export const DatabaseBetaGroupHeading: React.FC<
   GroupHeadingProps<{}, false>
 > = (props) => {


### PR DESCRIPTION
## Description

This adds a “BETA” chip to the DB engine selection on Databases Create.

Whether or not a DB engine is controlled by LaunchDarkly. There’s a new “Database Engine Betas” flag, which is an array of engines that are considered to be in Beta. The values are the display names (e.g. “MongoDB” and “PostgreSQL”).

![Screen Shot 2022-05-27 at 4 02 08 PM](https://user-images.githubusercontent.com/16911484/170781975-9f51b6ea-d9dd-4075-a687-a9e3411b1053.jpg)

New copy has been added under the Engine Selection component if a beta engine is selected:

![Screen Shot 2022-05-27 at 4 02 13 PM](https://user-images.githubusercontent.com/16911484/170781953-d4ec9cc7-512c-4938-9abd-d28e9881e802.jpg)

## How to test

Try different values for databaseEngineBetas (you can override the flags in `useFlags.ts`). Make sure everything works as expected.

**ALSO:** to address Matthew's comment below, I added some height to the SingleValue component, used by Region Select and Image Select. Please check for regressions here as well. 