### PR TITLE
Remove notification menu content from DOM when not expanded

### DIFF
--- a/packages/manager/src/components/NotificationMenu/NotificationMenu.tsx
+++ b/packages/manager/src/components/NotificationMenu/NotificationMenu.tsx
@@ -41,7 +41,7 @@ export const NotificationMenu: React.FC<Props> = (props) => {
         dismissNotifications(notifications, { prefix: 'notificationMenu' });
       }
     };
-  }, [open]);
+  }, [dismissNotifications, notifications, dispatch, open]);
 
   return (
     <Paper className={classes.root}>

--- a/packages/manager/src/components/NotificationMenu/NotificationMenu.tsx
+++ b/packages/manager/src/components/NotificationMenu/NotificationMenu.tsx
@@ -7,7 +7,6 @@ import { NotificationData } from 'src/features/NotificationCenter/NotificationDa
 import Notifications from 'src/features/NotificationCenter/Notifications';
 import useDismissibleNotifications from 'src/hooks/useDismissibleNotifications';
 import useNotifications from 'src/hooks/useNotifications';
-import usePrevious from 'src/hooks/usePrevious';
 import { markAllSeen } from 'src/store/events/event.request';
 import { ThunkDispatch } from 'src/store/types';
 
@@ -35,15 +34,14 @@ export const NotificationMenu: React.FC<Props> = (props) => {
   const notifications = useNotifications();
   const dispatch = useDispatch<ThunkDispatch>();
 
-  const wasOpen = usePrevious(open);
-
   React.useEffect(() => {
-    if (wasOpen && !open) {
-      // User has closed the menu.
-      dispatch(markAllSeen());
-      dismissNotifications(notifications, { prefix: 'notificationMenu' });
-    }
-  }, [dismissNotifications, notifications, dispatch, open, wasOpen]);
+    return () => {
+      if (open) {
+        dispatch(markAllSeen());
+        dismissNotifications(notifications, { prefix: 'notificationMenu' });
+      }
+    };
+  }, [open]);
 
   return (
     <Paper className={classes.root}>

--- a/packages/manager/src/features/TopMenu/NotificationButton.tsx
+++ b/packages/manager/src/features/TopMenu/NotificationButton.tsx
@@ -82,7 +82,9 @@ export const NotificationButton: React.FC<{}> = (_) => {
           </TopMenuIcon>
           <MenuPopover className={classes.menuPopover}>
             <MenuItems className={classes.menuItem}>
-              <NotificationMenu open={isExpanded} data={notificationData} />
+              {isExpanded && (
+                <NotificationMenu open={isExpanded} data={notificationData} />
+              )}
             </MenuItems>
           </MenuPopover>
         </>


### PR DESCRIPTION
## Description

**What does this PR do?**
Since revamping the notification menu (#8305), the notification menu content has been present in the DOM even when hidden.

This PR changes the behavior of the `NotificationButton` component so that the notification menu content is not present in the DOM when the menu is not open.

**Why?**
A few tests are failing or are flaky because `cy.findByText(...)` and similar calls are now selecting elements within the notification menu instead of the elements that were intended. We can (and do) fix these on a case-by-case basis, but it's becoming a game of whack-a-mole as changes to the notification menu and event language continue to cause previously stable tests to break.

## How to test

**What are the steps to reproduce the issue or verify the changes?**
To reproduce:
1. Checkout develop, run `yarn up`
2. `yarn cy:run`
3. Observe failing/flaky tests

To verify changes:
1. Checkout this branch, run `yarn up`
2. `yarn cy:run`
3. Observe fewer (no?) failing/flaky tests
  (ℹ️ In my case all tests pass, but I did encounter a few flaky tests (e.g. `resizes a linode`) that could fail on subsequent runs)
4. Confirm that notification menu UX is the same as before
