### PR TITLE
Fix height of "SingleValue" component

### DIFF
--- a/packages/manager/src/components/EnhancedSelect/components/SingleValue.tsx
+++ b/packages/manager/src/components/EnhancedSelect/components/SingleValue.tsx
@@ -8,6 +8,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     flexFlow: 'row nowrap',
     alignItems: 'center',
     paddingLeft: `45px !important`,
+    height: '100%',
   },
   icon: {
     fontSize: '1.8em',


### PR DESCRIPTION
## Description

A fix for this was included in a reverted PR, but is still something that we need throughout the app.

This is to fix the bottom of the “g” character being cut off in Postgres/Mongo clusters in the Engine selection component.

