### PR TITLE
Database Create Remove Duplicate State

### DIFF
--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -213,7 +213,6 @@ const DatabaseCreate: React.FC<{}> = () => {
 
   const { mutateAsync: createDatabase } = useCreateDatabaseMutation();
 
-  const [selectedEngine, setSelectedEngine] = React.useState<Engine>('mysql');
   const [nodePricing, setNodePricing] = React.useState<NodePricing>();
   const [createError, setCreateError] = React.useState<string>();
   const [ipErrorsFromAPI, setIPErrorsFromAPI] = React.useState<APIError[]>();
@@ -335,6 +334,8 @@ const DatabaseCreate: React.FC<{}> = () => {
     validate: handleIPValidation,
     onSubmit: submitForm,
   });
+
+  const selectedEngine = (values.engine.split('/')?.[0] as Engine) ?? 'mysql';
 
   React.useEffect(() => {
     if (errors || createError) {
@@ -490,9 +491,6 @@ const DatabaseCreate: React.FC<{}> = () => {
             placeholder={'Select a Database Engine'}
             onChange={(selected: Item<string>) => {
               setFieldValue('engine', selected.value);
-
-              const selection = selected.value.split('/')[0];
-              setSelectedEngine(selection as Engine);
             }}
             isClearable={false}
           />

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -335,7 +335,7 @@ const DatabaseCreate: React.FC<{}> = () => {
     onSubmit: submitForm,
   });
 
-  const selectedEngine = (values.engine.split('/')?.[0] as Engine) ?? 'mysql';
+  const selectedEngine = values.engine.split('/')[0] as Engine;
 
   React.useEffect(() => {
     if (errors || createError) {


### PR DESCRIPTION
## Description

- We stored the Engine state in two places on the Database Create page
  - This PR removes one state and pulls the database's engine from Formik's state
 
## How to test

- Test the Database Creation flow for different engines
- Run Database Create Cypress tests
