### PR TITLE
Add ability to group StackScript UDFs with custom labels

### DIFF
--- a/packages/api-v4/src/stackscripts/types.ts
+++ b/packages/api-v4/src/stackscripts/types.ts
@@ -34,4 +34,5 @@ export interface UserDefinedField {
   oneof?: string;
   manyof?: string;
   default?: string;
+  header?: string;
 }

--- a/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
+++ b/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
@@ -68,6 +68,14 @@ const renderField = (
   // if the 'default' key is returned from the API, the field is optional
   const isOptional = field.hasOwnProperty('default');
 
+  if (isHeader(field)) {
+    return (
+      <Grid item xs={12} lg={5} key={field.name}>
+        <Typography variant="h2">{field.label}</Typography>
+      </Grid>
+    );
+  }
+
   if (isMultiSelect(field)) {
     return (
       <Grid item xs={12} lg={5} key={field.name}>
@@ -234,6 +242,10 @@ const isOneSelect = (udf: UserDefinedField) => {
 
 const isMultiSelect = (udf: UserDefinedField) => {
   return !!udf.manyof; // if we have a manyof prop, it's a checkbox
+};
+
+const isHeader = (udf: UserDefinedField) => {
+  return udf.header?.toLowerCase() === 'yes';
 };
 
 /**

--- a/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
+++ b/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
@@ -70,7 +70,7 @@ const renderField = (
 
   if (isHeader(field)) {
     return (
-      <Grid item xs={12} lg={5} key={field.name}>
+      <Grid item xs={12} lg={5} key={field.name} style={{ marginTop: 24 }}>
         <Typography variant="h2">{field.label}</Typography>
       </Grid>
     );


### PR DESCRIPTION
## Description
Add the ability to group StackScript user defined fields with custom labels (this will mainly be used to group Marketplace App setup inputs)

![image](https://user-images.githubusercontent.com/115299789/200419854-1c76e198-077e-4b45-bbb1-ba71c63d7ecd.png)

## How to test
1. Create/edit a StackScript to include a UDF field with the Header set to "Yes"
2. Go to `/linodes/create?type=StackScripts` and select that StackScript
3. Confirm that the header you defined displays under Advanced Options

Example StackScript:
```
#!/bin/bash
#<UDF name="header_test" label="Test Group Header" default="Yes" header="Yes">
#<UDF name="disable_root" label="Choose the addons you'd like to add to this instance?" manyOf="Redis,Memcached, JetBackups, Desktop Environment,Cockpit,None," default="None" >
#<UDF name="disable_rot" label="Would you like Redis installed?" oneOf="Yes,No" default="No" >
#<UDF name="disable_roo" label="Which Stack would you like to utilize?" oneOf="LAMP,LEMP,OpenLightSpeed" default="LAMP">
#<UDF name="disabe_rot" label="Which Database would you like to use?" oneOf="MySQL5.7,MySQL8.0,MariaDB10.5,MariaDB10.6" default="MySQL8.0" >
#<UDF name="header_test2" label="Another Test Group Header" default="Yes" header="Yes">
#<UDF name="diabe_rot" label="Which version of PHP ?" oneOf="7.3,7.4,8.0,8.1" default="7.4" >
#<UDF name="diae_rot" label="Would you like to deploy Wordpress via Docker?" oneOf="Yes,No" default="No" >
#<UDF name="dirgbe_rot" label="Would you like to add JetBackups to your installation?" oneOf="Yes,No" default="No" >
#<UDF name="diae_rorgregt" label="Select Addons" manyOf="Yes,No" default="Yes" >
```
