### PR TITLE
Fix Flaky Cypress Firewall Tests

### DIFF
--- a/packages/manager/cypress/integration/firewalls/migrate-linode-with-firewall.spec.ts
+++ b/packages/manager/cypress/integration/firewalls/migrate-linode-with-firewall.spec.ts
@@ -157,7 +157,7 @@ describe('Migrate Linode With Firewall', () => {
   });
 
   // create linode w/ firewall region then add firewall to it then attempt to migrate linode to non firewall region, should fail
-  it('migrates linode with firewall - real data, ', () => {
+  it('migrates linode with firewall - real data', () => {
     const validateMigration = () => {
       getVisible('[type="button"]').within(() => {
         containsClick('Enter Migration Queue');
@@ -198,9 +198,10 @@ describe('Migrate Linode With Firewall', () => {
 
       cy.get('[data-qa-enhanced-select="Select a Linode or type to search..."]')
         .should('be.visible')
-        .click();
+        .click()
+        .type(`${linode.label}{enter}`);
 
-      cy.findByText(linode.label).should('be.visible').click();
+      cy.findByText(linode.label).should('be.visible');
 
       getClick('[data-qa-submit="true"]');
       cy.wait('@createFirewall');
@@ -232,12 +233,12 @@ describe('Migrate Linode With Firewall', () => {
     });
   });
 
-  it('adds linode to firewall - real data, ', () => {
+  it('adds linode to firewall - real data', () => {
     const firewallLabel = `cy-test-firewall-${randomString(5)}`;
-    // intercept create firewall request
+    // intercept firewall requests
     cy.intercept('POST', '*/networking/firewalls').as('createFirewall');
-    // modify incoming response
     cy.intercept('*/networking/firewalls*').as('getFirewall');
+
     cy.visitWithLogin('/firewalls');
     createLinode().then((linode) => {
       const linodeLabel = linode.label;
@@ -247,15 +248,17 @@ describe('Migrate Linode With Firewall', () => {
         });
         fbtClick('Create Firewall');
       });
+
       cy.get('[data-testid="textfield-input"]')
         .should('be.visible')
         .type(firewallLabel);
 
       cy.get('[data-qa-enhanced-select="Select a Linode or type to search..."]')
         .should('be.visible')
-        .click();
+        .click()
+        .type(`${linodeLabel}{enter}`);
 
-      cy.findByText(linodeLabel).should('be.visible').click();
+      cy.findByText(linodeLabel).should('be.visible');
 
       getClick('[data-qa-submit="true"]');
       cy.wait('@createFirewall').its('response.statusCode').should('eq', 200);


### PR DESCRIPTION
## Description

**What does this PR do?**
Fixes the `migrates linode with firewall - real data` and `adds linode to firewall - real data` Cypress tests, which have been flaky.

The tests fail often because some of our test accounts have so many resources that the label for the desired Linode is not immediately visible in the drop-down when creating a firewall, causing a `should('be.visible')` assertion to fail. This PR changes the test behavior so that the Linode label is typed into the field instead.

## How to test

**What are the steps to reproduce the issue or verify the changes?**
**Note:** this issue can only be reproduced if you have enough Linodes on your test account.

To reproduce, check out `develop`, do `yarn up`, and run:
```
yarn cy:run -s "cypress/integration/firewalls/migrate-linode-with-firewall.spec.ts"
```

To verify changes, check out this branch instead of `develop` and follow the rest of the instructions above.

## See also
PR #8343, which attempted to address this same issue.
