### PR TITLE
Create MongoDB and PostgreSQL databases during test

### DIFF
--- a/packages/manager/cypress/integration/databases/create-database.spec.ts
+++ b/packages/manager/cypress/integration/databases/create-database.spec.ts
@@ -39,6 +39,26 @@ const databaseConfigurations: databaseClusterConfiguration[] = [
     engine: 'MySQL',
     version: '5.7.30',
   },
+  {
+    label: randomLabel(),
+    linodeType: 'g6-dedicated-16',
+    clusterSize: 1,
+    dbType: 'mongodb',
+    regionTypeahead: 'Atlanta',
+    region: 'us-southeast',
+    engine: 'MongoDB',
+    version: '4.4.10',
+  },
+  {
+    label: randomLabel(),
+    linodeType: 'g6-nanode-1',
+    clusterSize: 3,
+    dbType: 'postgresql',
+    regionTypeahead: 'Newark',
+    region: 'us-east',
+    engine: 'PostgreSQL',
+    version: '13.2',
+  },
 ];
 
 describe('create a database cluster, mocked data', () => {
@@ -53,6 +73,7 @@ describe('create a database cluster, mocked data', () => {
           version: configuration.version,
           status: 'provisioning',
           cluster_size: configuration.clusterSize,
+          engine: configuration.dbType,
           hosts: {
             primary: undefined,
             secondary: undefined,
@@ -72,9 +93,11 @@ describe('create a database cluster, mocked data', () => {
           secondary_entity: undefined,
         });
 
-        cy.intercept('POST', '*/databases/mysql/instances', databaseMock).as(
-          'createDatabase'
-        );
+        cy.intercept(
+          'POST',
+          `*/databases/${configuration.dbType}/instances`,
+          databaseMock
+        ).as('createDatabase');
 
         cy.intercept(
           'GET',


### PR DESCRIPTION
## Description

**What does this PR do?**
Adds tests to create MongoDB and PostgreSQL DBs using mocked data

## How to test

**What are the steps to reproduce the issue or verify the changes?**

Check out this branch, run `yarn up`, and then run:
```
yarn cy:run -s "cypress/integration/databases/create-database.spec.ts"
```

Confirm that two new tests run and succeed:

* `creates a g6-dedicated-16 MongoDB v4.4.10 1-node cluster at us-southeast`
* `creates a g6-nanode-1 PostgreSQL v13.2 3-node cluster at us-east`