### PR TITLE
M3-5835: Allow users to migrate unattached volumes

### DIFF
--- a/packages/manager/src/features/Volumes/UpgradeVolumeDialog.tsx
+++ b/packages/manager/src/features/Volumes/UpgradeVolumeDialog.tsx
@@ -28,7 +28,7 @@ export const VolumeUpgradeCopy = (props: CopyProps) => {
     <Typography>
       {prefix} will be upgraded to high-performance NVMe Block Storage. This is
       a free upgrade and will not incur any additional service charges. Check
-      Check upgrade eligibility or current status of Volumes on the{' '}
+      upgrade eligibility or current status of Volumes on the{' '}
       <Link to="/account/maintenance">Maintenance Page</Link>.
     </Typography>
   );

--- a/packages/manager/src/features/Volumes/UpgradeVolumeDialog.tsx
+++ b/packages/manager/src/features/Volumes/UpgradeVolumeDialog.tsx
@@ -8,6 +8,32 @@ import { useVolumesMigrateMutation } from 'src/queries/volumesMigrations';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { useSnackbar } from 'notistack';
 
+interface CopyProps {
+  label: string;
+  type: 'volume' | 'linode';
+  isManyVolumes?: boolean;
+}
+
+export const VolumeUpgradeCopy = (props: CopyProps) => {
+  const { label, type, isManyVolumes } = props;
+
+  const prefix =
+    type === 'linode'
+      ? isManyVolumes
+        ? `Volumes attached to ${label}`
+        : `A Volume attached to Linode ${label}`
+      : `Volume ${label}`;
+
+  return (
+    <Typography>
+      {prefix} will be upgraded to high-performance NVMe Block Storage. This is
+      a free upgrade and will not incur any additional service charges. Check
+      Check upgrade eligibility or current status of Volumes on the{' '}
+      <Link to="/account/maintenance">Maintenance Page</Link>.
+    </Typography>
+  );
+};
+
 interface Props {
   open: boolean;
   onClose: () => void;
@@ -57,12 +83,7 @@ export const UpgradeVolumeDialog: React.FC<Props> = (props) => {
           : undefined
       }
     >
-      <Typography>
-        Volume {label} will be upgraded to high-performance NVMe Block Storage.
-        This is a free upgrade and will not incur any additional service
-        charges. Check upgrade eligibility or current status of Volumes on the{' '}
-        <Link to="/account/maintenance">Maintenance Page</Link>.
-      </Typography>
+      <VolumeUpgradeCopy type="volume" label={label} />
     </Dialog>
   );
 };

--- a/packages/manager/src/features/Volumes/UpgradeVolumeDialog.tsx
+++ b/packages/manager/src/features/Volumes/UpgradeVolumeDialog.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
+import Dialog from 'src/components/ConfirmationDialog';
+import Typography from 'src/components/core/Typography';
+import Link from 'src/components/Link';
+import { useVolumesMigrateMutation } from 'src/queries/volumesMigrations';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import { useSnackbar } from 'notistack';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  id: number;
+  label: string;
+}
+
+export const UpgradeVolumeDialog: React.FC<Props> = (props) => {
+  const { open, onClose, id, label } = props;
+  const { enqueueSnackbar } = useSnackbar();
+
+  const {
+    mutateAsync: migrateVolumes,
+    isLoading,
+    error,
+  } = useVolumesMigrateMutation();
+
+  const onSubmit = () => {
+    migrateVolumes([id]).then(() => {
+      enqueueSnackbar(`Successfully added ${label} to the migration queue.`, {
+        variant: 'success',
+      });
+      onClose();
+    });
+  };
+
+  const actions = (
+    <ActionsPanel>
+      <Button buttonType="secondary" onClick={onClose}>
+        Cancel
+      </Button>
+      <Button buttonType="primary" onClick={onSubmit} loading={isLoading}>
+        Enter Upgrade Queue
+      </Button>
+    </ActionsPanel>
+  );
+
+  return (
+    <Dialog
+      title={`Upgrade Volume ${label}`}
+      open={open}
+      onClose={onClose}
+      actions={actions}
+      error={
+        error
+          ? getAPIErrorOrDefault(error, 'Unable to migrate volume.')[0].reason
+          : undefined
+      }
+    >
+      <Typography>
+        Volume {label} will be upgraded to high-performance NVMe Block Storage.
+        This is a free upgrade and will not incur any additional service
+        charges. Check upgrade eligibility or current status of Volumes on the{' '}
+        <Link to="/account/maintenance">Maintenance Page</Link>.
+      </Typography>
+    </Dialog>
+  );
+};

--- a/packages/manager/src/features/Volumes/VolumeTableRow.tsx
+++ b/packages/manager/src/features/Volumes/VolumeTableRow.tsx
@@ -49,6 +49,7 @@ export const VolumeTableRow: React.FC<CombinedProps> = (props) => {
     handleAttach,
     handleDelete,
     handleDetach,
+    handleUpgrade,
     id,
     label,
     tags,
@@ -114,13 +115,16 @@ export const VolumeTableRow: React.FC<CombinedProps> = (props) => {
                     size="small"
                   />
                 </Grid>
-              ) : linodeId &&
-                eligibleForUpgradeToNVMe &&
+              ) : eligibleForUpgradeToNVMe &&
                 !nvmeUpgradeScheduledByUserImminent ? (
                 <Grid item className={classes.chipWrapper}>
                   <Chip
                     label="UPGRADE TO NVMe"
-                    onClick={() => history.push(`/linodes/${linodeId}/upgrade`)}
+                    onClick={
+                      linodeId
+                        ? () => history.push(`/linodes/${linodeId}/upgrade`)
+                        : () => handleUpgrade?.(id, label)
+                    }
                     data-testid="upgrade-chip"
                     size="small"
                     clickable

--- a/packages/manager/src/features/Volumes/VolumeTableRow.tsx
+++ b/packages/manager/src/features/Volumes/VolumeTableRow.tsx
@@ -130,9 +130,8 @@ export const VolumeTableRow: React.FC<CombinedProps> = (props) => {
                     clickable
                   />
                 </Grid>
-              ) : linodeId &&
-                (nvmeUpgradeScheduledByUserImminent ||
-                  nvmeUpgradeScheduledByUserInProgress) ? (
+              ) : nvmeUpgradeScheduledByUserImminent ||
+                nvmeUpgradeScheduledByUserInProgress ? (
                 <Grid item className={classes.chipWrapper}>
                   <Chip
                     variant="outlined"

--- a/packages/manager/src/features/Volumes/VolumesActionMenu.tsx
+++ b/packages/manager/src/features/Volumes/VolumesActionMenu.tsx
@@ -24,6 +24,7 @@ export interface ActionHandlers {
     regionID: string
   ) => void;
   handleAttach: (volumeId: number, label: string, linodeRegion: string) => void;
+  handleUpgrade?: (volumeId: number, label: string) => void;
   handleDetach: (
     volumeId: number,
     volumeLabel: string,

--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -46,6 +46,7 @@ import {
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import DestructiveVolumeDialog from './DestructiveVolumeDialog';
 import { ExtendedVolume } from './types';
+import { UpgradeVolumeDialog } from './UpgradeVolumeDialog';
 import VolumeAttachmentDrawer from './VolumeAttachmentDrawer';
 import { ActionHandlers as VolumeHandlers } from './VolumesActionMenu';
 import VolumeTableRow from './VolumeTableRow';
@@ -153,6 +154,12 @@ export const VolumesLanding: React.FC<CombinedProps> = (props) => {
     openForResize,
   } = props;
 
+  const [upgradeVolumeDialog, setUpgradeVolumeDialog] = React.useState({
+    open: false,
+    volumeId: 0,
+    volumeLabel: '',
+  });
+
   const [attachmentDrawer, setAttachmentDrawer] = React.useState({
     open: false,
     volumeId: 0,
@@ -185,6 +192,10 @@ export const VolumesLanding: React.FC<CombinedProps> = (props) => {
       ...attachmentDrawer,
       open: false,
     }));
+  };
+
+  const handleUpgrade = (volumeId: number, label: string) => {
+    setUpgradeVolumeDialog({ open: true, volumeId, volumeLabel: label });
   };
 
   const handleAttach = (volumeId: number, label: string, regionID: string) => {
@@ -230,6 +241,13 @@ export const VolumesLanding: React.FC<CombinedProps> = (props) => {
   const closeDestructiveDialog = () => {
     setDestructiveDialog((destructiveDialog) => ({
       ...destructiveDialog,
+      open: false,
+    }));
+  };
+
+  const closeUpgradeVolumeDialog = () => {
+    setUpgradeVolumeDialog((value) => ({
+      ...value,
       open: false,
     }));
   };
@@ -326,6 +344,7 @@ export const VolumesLanding: React.FC<CombinedProps> = (props) => {
     handleAttach,
     handleDetach,
     handleDelete,
+    handleUpgrade,
   };
 
   const volumeRow = {
@@ -364,6 +383,12 @@ export const VolumesLanding: React.FC<CombinedProps> = (props) => {
                 toggleGroupByTag={toggleGroupVolumes}
                 row={volumeRow}
                 initialOrder={{ order: 'asc', orderBy: 'label' }}
+              />
+              <UpgradeVolumeDialog
+                open={upgradeVolumeDialog.open}
+                id={upgradeVolumeDialog.volumeId}
+                label={upgradeVolumeDialog.volumeLabel}
+                onClose={closeUpgradeVolumeDialog}
               />
               <VolumeAttachmentDrawer
                 open={attachmentDrawer.open}

--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -246,8 +246,8 @@ export const VolumesLanding: React.FC<CombinedProps> = (props) => {
   };
 
   const closeUpgradeVolumeDialog = () => {
-    setUpgradeVolumeDialog((value) => ({
-      ...value,
+    setUpgradeVolumeDialog((values) => ({
+      ...values,
       open: false,
     }));
   };

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/UpgradeVolumesDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/UpgradeVolumesDialog.tsx
@@ -1,13 +1,13 @@
-import { useSnackbar } from 'notistack';
 import * as React from 'react';
-import { useDispatch } from 'react-redux';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import Dialog from 'src/components/ConfirmationDialog';
 import Paper from 'src/components/core/Paper';
-import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
-import Link from 'src/components/Link';
+import { useDispatch } from 'react-redux';
+import { useSnackbar } from 'notistack';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import { VolumeUpgradeCopy } from 'src/features/Volumes/UpgradeVolumeDialog';
 import { Dispatch } from 'src/hooks/types';
 import { useVolumesMigrateMutation } from 'src/queries/volumesMigrations';
 import { requestNotifications } from 'src/store/notification/notification.requests';
@@ -80,13 +80,11 @@ export const UpgradeVolumesDialog: React.FC<Props> = (props) => {
       }
     >
       <Typography>
-        {numUpgradeableVolumes === 1
-          ? 'A Volume attached to Linode '
-          : 'Volumes attached to '}
-        {linode.label} will be upgraded to high-performance NVMe Block Storage.
-        This is a free upgrade and will not incur any additional service
-        charges. Check upgrade eligibility or current status of Volumes on the{' '}
-        <Link to="/account/maintenance">Maintenance Page</Link>.
+        <VolumeUpgradeCopy
+          type="linode"
+          label={linode.label}
+          isManyVolumes={numUpgradeableVolumes > 1}
+        />
         <Paper className={classes.notice}>
           As part of the upgrade process, this Linode may be rebooted and will
           be returned to its last known state prior to the upgrade.

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -1,4 +1,4 @@
-import { EventAction } from '@linode/api-v4';
+import { EventAction, NotificationType } from '@linode/api-v4';
 import { RequestHandler, rest } from 'msw';
 import cachedRegions from 'src/cachedData/regions.json';
 import { MockData } from 'src/dev-tools/mockDataController';
@@ -578,21 +578,36 @@ export const handlers = [
     );
   }),
   rest.get('*/volumes', (req, res, ctx) => {
+    const hddVolumeUnattached = volumeFactory.build({
+      id: 30,
+      label: 'hdd-unattached',
+    });
     const hddVolumeAttached = volumeFactory.build({
       id: 20,
       linode_id: 20,
-      label: 'eligibleNow',
+      label: 'eligible-now-for-nvme',
     });
     const hddVolumeAttached2 = volumeFactory.build({
       id: 2,
       linode_id: 2,
       label: 'example-upgrading',
     });
-    const nvmeVolumes = volumeFactory.buildList(2, {
+    const nvmeVolumeUpgrading = volumeFactory.build({
+      id: 2,
+      hardware_type: 'nvme',
+    });
+    const newNVMeVolume = volumeFactory.build({
+      id: 1,
       hardware_type: 'nvme',
     });
 
-    const volumes = [...nvmeVolumes, hddVolumeAttached, hddVolumeAttached2];
+    const volumes = [
+      newNVMeVolume,
+      nvmeVolumeUpgrading,
+      hddVolumeAttached,
+      hddVolumeAttached2,
+      hddVolumeUnattached,
+    ];
     return res(ctx.json(makeResourcePage(volumes)));
   }),
   rest.post('*/volumes', (req, res, ctx) => {
@@ -923,43 +938,62 @@ export const handlers = [
       severity: 'major',
     });
 
-    // const blockStorageMigrationScheduledNotification = notificationFactory.build(
-    //   {
-    //     type: 'volume_migration_scheduled' as NotificationType,
-    //     entity: {
-    //       type: 'volume',
-    //       label: 'eligibleNow',
-    //       id: 20,
-    //       url: '/volumes/20',
-    //     },
-    //     when: '2021-09-30T04:00:00',
-    //     message:
-    //       'The Linode that the volume is attached to will shut down in order to complete the upgrade and reboot once it is complete. Any other volumes attached to the same Linode will also be upgraded.',
-    //     label: 'You have a scheduled Block Storage volume upgrade pending!',
-    //     severity: 'critical',
-    //     until: '2021-10-16T04:00:00',
-    //     body: 'Your volumes in us-east will be upgraded to NVMe.',
-    //   }
-    // );
+    const blockStorageMigrationScheduledNotification = notificationFactory.build(
+      {
+        type: 'volume_migration_scheduled' as NotificationType,
+        entity: {
+          type: 'volume',
+          label: 'eligibleNow',
+          id: 20,
+          url: '/volumes/20',
+        },
+        when: '2021-09-30T04:00:00',
+        message:
+          'The Linode that the volume is attached to will shut down in order to complete the upgrade and reboot once it is complete. Any other volumes attached to the same Linode will also be upgraded.',
+        label: 'You have a scheduled Block Storage volume upgrade pending!',
+        severity: 'critical',
+        until: '2021-10-16T04:00:00',
+        body: 'Your volumes in us-east will be upgraded to NVMe.',
+      }
+    );
 
-    // const blockStorageMigrationImminentNotification = notificationFactory.build(
-    //   {
-    //     type: 'volume_migration_imminent' as NotificationType,
-    //     entity: {
-    //       type: 'volume',
-    //       label: 'example-upgrading',
-    //       id: 2,
-    //       url: '/volumes/2',
-    //     },
-    //     when: '2021-09-30T04:00:00',
-    //     message:
-    //       'The Linode that the volume is attached to will shut down in order to complete the upgrade and reboot once it is complete. Any other volumes attached to the same Linode will also be upgraded.',
-    //     label: 'You have a scheduled Block Storage volume upgrade pending!',
-    //     severity: 'major',
-    //     until: '2021-10-16T04:00:00',
-    //     body: 'Your volumes in us-east will be upgraded to NVMe.',
-    //   }
-    // );
+    const blockStorageMigrationScheduledNotificationUnattached = notificationFactory.build(
+      {
+        type: 'volume_migration_scheduled' as NotificationType,
+        entity: {
+          type: 'volume',
+          label: 'hdd-unattached',
+          id: 30,
+          url: '/volumes/30',
+        },
+        when: '2021-09-30T04:00:00',
+        message:
+          'This unattached volume is scheduled to be migrated to NVMe I think.',
+        label: 'You have a scheduled Block Storage volume upgrade pending!',
+        severity: 'critical',
+        until: '2021-10-16T04:00:00',
+        body: 'Your volume will be upgraded to NVMe.',
+      }
+    );
+
+    const blockStorageMigrationImminentNotification = notificationFactory.build(
+      {
+        type: 'volume_migration_imminent' as NotificationType,
+        entity: {
+          type: 'volume',
+          label: 'example-upgrading',
+          id: 2,
+          url: '/volumes/2',
+        },
+        when: '2021-09-30T04:00:00',
+        message:
+          'The Linode that the volume is attached to will shut down in order to complete the upgrade and reboot once it is complete. Any other volumes attached to the same Linode will also be upgraded.',
+        label: 'You have a scheduled Block Storage volume upgrade pending!',
+        severity: 'major',
+        until: '2021-10-16T04:00:00',
+        body: 'Your volumes in us-east will be upgraded to NVMe.',
+      }
+    );
 
     return res(
       ctx.json(
@@ -975,8 +1009,9 @@ export const handlers = [
           emailBounce,
           migrationNotification,
           balanceNotification,
-          // blockStorageMigrationScheduledNotification,
-          // blockStorageMigrationImminentNotification,
+          blockStorageMigrationScheduledNotification,
+          blockStorageMigrationImminentNotification,
+          blockStorageMigrationScheduledNotificationUnattached,
         ])
       )
     );


### PR DESCRIPTION
## Description 📝

- Allows unattached volumes to be migrated to NVMe instantly by the user
- Refer to internal ticket on what problem this is trying to solve
- This flow is different that an attached volume because it does not associate the action with an entire linode

## Preview 🔍

https://user-images.githubusercontent.com/6440455/172462431-d20492c9-00d7-4f64-b27a-300d32341382.mov


## How to test 🧪

- Turn on MSW, try upgrade flow for the volume called `hdd-unattached`
