### PR TITLE
M3-5826: Display tax lines on invoices

### DIFF
--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -87,6 +87,11 @@ export type CardType =
 
 export type PaymentType = 'credit_card' | ThirdPartyPayment;
 
+export interface TaxSummary {
+  tax: number;
+  name: string;
+}
+
 export interface Invoice {
   id: number;
   date: string;
@@ -94,6 +99,7 @@ export interface Invoice {
   total: number;
   tax: number;
   subtotal: number;
+  tax_summary: TaxSummary[];
 }
 
 export interface InvoiceItem {

--- a/packages/manager/src/factories/billing.ts
+++ b/packages/manager/src/factories/billing.ts
@@ -37,9 +37,19 @@ export const invoiceFactory = Factory.Sync.makeFactory<Invoice>({
     return invoiceDate.toISOString();
   }),
   id: Factory.each((i) => i),
-  subtotal: 5,
-  tax: 1,
-  total: 6,
+  subtotal: 50,
+  tax: 5,
+  tax_summary: [
+    {
+      tax: 3,
+      name: 'PA STATE TAX',
+    },
+    {
+      tax: 2,
+      name: 'PA COUNTY TAX',
+    },
+  ],
+  total: 55,
   label: Factory.each((i) => `Invoice #${i}`),
 });
 

--- a/packages/manager/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
+++ b/packages/manager/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
@@ -199,8 +199,18 @@ export const InvoiceDetail: React.FC<CombinedProps> = (props) => {
                     quantity={invoice.subtotal}
                   />
                 </Typography>
+                {invoice.tax_summary.map((summary) => {
+                  return (
+                    <Typography key={summary.name} variant="h2">
+                      {summary.name === 'Standard'
+                        ? 'Standard Tax'
+                        : summary.name}{' '}
+                      <Currency quantity={summary.tax} />
+                    </Typography>
+                  );
+                })}
                 <Typography variant="h2">
-                  Tax: <Currency quantity={invoice.tax} />
+                  Tax Subtotal: <Currency quantity={invoice.tax} />
                 </Typography>
                 <Typography variant="h2">
                   Total:{' '}

--- a/packages/manager/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
+++ b/packages/manager/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
@@ -203,8 +203,8 @@ export const InvoiceDetail: React.FC<CombinedProps> = (props) => {
                   return (
                     <Typography key={summary.name} variant="h2">
                       {summary.name === 'Standard'
-                        ? 'Standard Tax'
-                        : summary.name}{' '}
+                        ? 'Standard Tax: '
+                        : `${summary.name}: `}
                       <Currency quantity={summary.tax} />
                     </Typography>
                   );


### PR DESCRIPTION
## Description
If we have `tax_summary` data, display associated taxes on their own lines on invoices otherwise just display the tax subtotal

Standard tax
![image](https://user-images.githubusercontent.com/14323019/172924439-1f4abd30-2af5-494e-bcd1-ba6870ed4498.png)

More specific taxes (turn on MSW)
![image](https://user-images.githubusercontent.com/14323019/172924347-745ac871-3c86-4c34-b286-dc33338c9016.png)

Empty `tax_summary` array
![image](https://user-images.githubusercontent.com/14323019/172925422-4847e308-4fd5-4350-9b8b-1473ad0d0230.png)


## How to test
- Click on an invoice and look at the invoice details
- Download an invoice and check the PDF
