### PR TITLE
M3-5770: Cypress Integration Tests for SMS Opt-Out

### DIFF
--- a/packages/api-v4/src/account/account.ts
+++ b/packages/api-v4/src/account/account.ts
@@ -111,3 +111,16 @@ export const signAgreement = (data: Partial<Agreements>) => {
     setData(data)
   );
 };
+
+/**
+ * smsOptOut
+ *
+ * Opts user out of SMS messaging
+ */
+export const smsOptOut = () => {
+  return Request<{}>(
+    setURL(`${API_ROOT}/account/phone-number/opt-out`),
+    setMethod('POST'),
+    setData({ opt_out: true })
+  );
+};

--- a/packages/api-v4/src/account/account.ts
+++ b/packages/api-v4/src/account/account.ts
@@ -111,16 +111,3 @@ export const signAgreement = (data: Partial<Agreements>) => {
     setData(data)
   );
 };
-
-/**
- * smsOptOut
- *
- * Opts user out of SMS messaging
- */
-export const smsOptOut = () => {
-  return Request<{}>(
-    setURL(`${API_ROOT}/account/phone-number/opt-out`),
-    setMethod('POST'),
-    setData({ opt_out: true })
-  );
-};

--- a/packages/api-v4/src/profile/profile.ts
+++ b/packages/api-v4/src/profile/profile.ts
@@ -182,3 +182,16 @@ export const updateSecurityQuestions = (payload: SecurityQuestions) => {
     })
   );
 };
+
+/**
+ * smsOptOut
+ *
+ * Opts user out of SMS messaging
+ */
+export const smsOptOut = () => {
+  return Request<{}>(
+    setURL(`${API_ROOT}/profile/phone-number/opt-out`),
+    setMethod('POST'),
+    setData({ opt_out: true })
+  );
+};

--- a/packages/api-v4/src/profile/types.ts
+++ b/packages/api-v4/src/profile/types.ts
@@ -21,7 +21,7 @@ export interface Profile {
   authorized_keys: string[];
   two_factor_auth: boolean;
   restricted: boolean;
-  phone_number?: string;
+  phone_number?: string | null;
 }
 
 export interface TokenRequest {

--- a/packages/manager/cypress/integration/account/sms-verification.spec.ts
+++ b/packages/manager/cypress/integration/account/sms-verification.spec.ts
@@ -27,7 +27,7 @@ describe('SMS phone verification', () => {
     const userProfile = profileFactory.build({
       uid: randomNumber(1000, 9999),
       username: randomLabel(),
-      phone_number: userPhoneNumber,
+      verified_phone_number: userPhoneNumber,
     });
 
     const expectedOptInMessage =

--- a/packages/manager/cypress/integration/account/sms-verification.spec.ts
+++ b/packages/manager/cypress/integration/account/sms-verification.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * @file Integration tests for SMS phone verification.
+ */
+
+import { profileFactory } from 'src/factories/profile';
+import {
+  randomLabel,
+  randomNumber,
+  randomPhoneNumber,
+} from 'support/util/random';
+import {
+  mockGetProfile,
+  mockSmsVerificationOptOut,
+} from 'support/intercepts/profile';
+import { ui } from 'support/ui';
+import { assertToast } from 'support/ui/events';
+
+describe('SMS phone verification', () => {
+  /*
+   * - Validates SMS phone verification opt-out flow using mocked data.
+   * - Confirms that user is shown message telling them they are opted in.
+   * - Confirms that user can opt out by clicking 'Opt Out'
+   * - Confirms that user is then shown message telling them they are opted out.
+   */
+  it('can opt out of SMS phone verification', () => {
+    const userPhoneNumber = randomPhoneNumber();
+    const userProfile = profileFactory.build({
+      uid: randomNumber(1000, 9999),
+      username: randomLabel(),
+      phone_number: userPhoneNumber,
+    });
+
+    const expectedOptInMessage =
+      'You have opted in to SMS messaging for phone verification';
+    const expectedOptOutMessage =
+      'You are opted out of SMS messaging for phone verification';
+
+    mockGetProfile(userProfile).as('getProfile');
+    mockSmsVerificationOptOut().as('smsOptOut');
+
+    cy.visitWithLogin('/profile/auth');
+    cy.wait('@getProfile');
+
+    cy.findByText(expectedOptInMessage).should('be.visible');
+
+    ui.button
+      .findByTitle('Opt Out')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    ui.dialog
+      .findByTitle('Opt out of SMS messaging for phone verification')
+      .should('be.visible')
+      .within(() => {
+        cy.findByText(userPhoneNumber, { exact: false }).should('be.visible');
+
+        ui.buttonGroup
+          .findButtonByTitle('Opt Out')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    cy.wait('@smsOptOut');
+    cy.findByText(expectedOptOutMessage).should('be.visible');
+
+    assertToast('Successfully opted out of SMS messaging');
+  });
+});

--- a/packages/manager/cypress/support/intercepts/profile.ts
+++ b/packages/manager/cypress/support/intercepts/profile.ts
@@ -1,0 +1,25 @@
+/**
+ * @file Cypress intercepts and mocks for Cloud Manager profile requests.
+ */
+
+import { Profile } from '@linode/api-v4/lib/profile/types';
+
+/**
+ * Intercepts GET request to fetch profile and mocks response.
+ *
+ * @param profile - Profile with which to respond.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetProfile = (profile: Profile): Cypress.Chainable<null> => {
+  return cy.intercept('GET', '*/profile', profile);
+};
+
+/**
+ * Intercepts POST request to opt out of SMS verification and mocks response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockSmsVerificationOptOut = (): Cypress.Chainable<null> => {
+  return cy.intercept('POST', '*/account/phone-number/opt-out', {});
+};

--- a/packages/manager/cypress/support/intercepts/profile.ts
+++ b/packages/manager/cypress/support/intercepts/profile.ts
@@ -21,5 +21,5 @@ export const mockGetProfile = (profile: Profile): Cypress.Chainable<null> => {
  * @returns Cypress chainable.
  */
 export const mockSmsVerificationOptOut = (): Cypress.Chainable<null> => {
-  return cy.intercept('POST', '*/account/phone-number/opt-out', {});
+  return cy.intercept('POST', '*/profile/phone-number/opt-out', {});
 };

--- a/packages/manager/cypress/support/intercepts/profile.ts
+++ b/packages/manager/cypress/support/intercepts/profile.ts
@@ -21,5 +21,5 @@ export const mockGetProfile = (profile: Profile): Cypress.Chainable<null> => {
  * @returns Cypress chainable.
  */
 export const mockSmsVerificationOptOut = (): Cypress.Chainable<null> => {
-  return cy.intercept('POST', '*/profile/phone-number/opt-out', {});
+  return cy.intercept('DELETE', '*/profile/phone-number/opt-out', {});
 };

--- a/packages/manager/cypress/support/ui/buttons.ts
+++ b/packages/manager/cypress/support/ui/buttons.ts
@@ -1,4 +1,39 @@
 /**
+ * Button UI element.
+ */
+export const button = {
+  /**
+   * Finds a button by its title.
+   *
+   * Most buttons in Cloud Manager have a child `<span />` element containing
+   * the title text. Hence, the `<button />` element itself must be selected
+   * by traversing the DOM.
+   *
+   * @param buttonTitle - Title of button to find.
+   *
+   * @returns Cypress chainable.
+   */
+  findByTitle: (buttonTitle: string): Cypress.Chainable => {
+    return cy.findByText(buttonTitle).closest('button');
+  },
+
+  /**
+   * Finds a button by the value of a given attribute.
+   *
+   * @param attributeName - Attribute to compare against.
+   * @param attributeValue - Expected value for attribute.
+   *
+   * @returns Cypress chainable.
+   */
+  findByAttribute: (
+    attributeName: string,
+    attributeValue: string
+  ): Cypress.Chainable => {
+    return cy.get(`button[${attributeName}="${attributeValue}"`);
+  },
+};
+
+/**
  * Button group UI element.
  *
  * Generally used to contain buttons in drawers and dialogs.

--- a/packages/manager/cypress/support/util/random.ts
+++ b/packages/manager/cypress/support/util/random.ts
@@ -153,3 +153,27 @@ export const randomIp = () => {
   const randomOctet = () => randomNumber(0, 254);
   return `${randomOctet()}.${randomOctet()}.${randomOctet()}.${randomOctet()}`;
 };
+
+/**
+ * Returns a random phone number.
+ *
+ * The three digits following the area code will always be '555'.
+ *
+ * @param randomCountryCode - Whether country code should be random. If not, '1' is used.
+ *
+ * @example
+ * randomPhoneNumber(); // Example output: `+19965551794`.
+ * randomPhoneNumber(false); // Equivalent to above.
+ * randomPhoneNumber(true); // Example output: `+2642285555485`.
+ *
+ * @returns Random phone number.
+ */
+export const randomPhoneNumber = (
+  randomCountryCode: boolean = false
+): string => {
+  const countryCode = randomCountryCode ? randomNumber(1, 999) : 1;
+  return `+${countryCode}${randomNumber(100, 999)}555${randomNumber(
+    1000,
+    9999
+  )}`;
+};

--- a/packages/manager/src/components/Notice/Notice.tsx
+++ b/packages/manager/src/components/Notice/Notice.tsx
@@ -137,8 +137,8 @@ interface Props extends GridProps {
   className?: string;
   flag?: boolean;
   notificationList?: boolean;
-  spacingTop?: 0 | 8 | 16 | 24;
-  spacingBottom?: 0 | 8 | 16 | 20 | 24 | 32;
+  spacingTop?: 0 | 8 | 12 | 16 | 24;
+  spacingBottom?: 0 | 8 | 12 | 16 | 20 | 24 | 32;
   breakWords?: boolean;
   onClick?: (e: React.MouseEvent<HTMLElement>) => void;
   // Dismissible Props

--- a/packages/manager/src/features/Profile/AuthenticationSettings/AuthenticationSettings.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/AuthenticationSettings.tsx
@@ -10,6 +10,7 @@ import Notice from 'src/components/Notice';
 import { useMutateProfile, useProfile } from 'src/queries/profile';
 import ResetPassword from './ResetPassword';
 import SecuritySettings from './SecuritySettings';
+import { SMSMessageing } from './SMSMessaging';
 import TPAProviders from './TPAProviders';
 import TrustedDevices from './TrustedDevices';
 import TwoFactor from './TwoFactor';
@@ -95,6 +96,9 @@ export const AuthenticationSettings: React.FC = () => {
         <Typography variant="body1" style={{ marginTop: 8, marginBottom: 8 }}>
           This is a placeholder for the Phone Verification component.
         </Typography>
+        <Divider spacingTop={22} spacingBottom={16} />
+        <Typography variant="h3">SMS Messaging</Typography>
+        <SMSMessageing />
         {!isThirdPartyAuthEnabled ? (
           <>
             <Divider spacingTop={22} spacingBottom={16} />

--- a/packages/manager/src/features/Profile/AuthenticationSettings/SMSMessaging.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/SMSMessaging.tsx
@@ -6,8 +6,9 @@ import Notice from 'src/components/Notice';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
 import ActionsPanel from 'src/components/ActionsPanel';
 import { makeStyles, Theme } from 'src/components/core/styles';
-import { useMutateProfile, useProfile } from 'src/queries/profile';
+import { useProfile } from 'src/queries/profile';
 import { useSnackbar } from 'notistack';
+import { useSMSOptOutMutation } from 'src/queries/account';
 
 const useStyles = makeStyles((theme: Theme) => ({
   notice: {
@@ -30,7 +31,7 @@ export const SMSMessageing = () => {
 
   const { enqueueSnackbar } = useSnackbar();
   const { data: profile } = useProfile();
-  const { mutateAsync: updateProfile, isLoading, error } = useMutateProfile();
+  const { mutateAsync: optOut, error, isLoading } = useSMSOptOutMutation();
 
   const hasVerifiedPhoneNumber = Boolean(profile?.phone_number);
 
@@ -45,7 +46,7 @@ export const SMSMessageing = () => {
   };
 
   const onOptOut = () => {
-    updateProfile({ phone_number: null }).then(() => {
+    optOut().then(() => {
       onClose();
       enqueueSnackbar('Successfully opted out of SMS messaging', {
         variant: 'success',

--- a/packages/manager/src/features/Profile/AuthenticationSettings/SMSMessaging.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/SMSMessaging.tsx
@@ -107,7 +107,7 @@ export const SMSMessageing = () => {
       >
         <Typography>
           Opting out of SMS messaging will reduce security and limit the ways
-          you can securly access your account.{' '}
+          you can securely access your account.{' '}
           <a href="https://www.linode.com/docs/guides/linode-manager-security-controls/">
             Learn more about security options.
           </a>

--- a/packages/manager/src/features/Profile/AuthenticationSettings/SMSMessaging.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/SMSMessaging.tsx
@@ -8,7 +8,7 @@ import ActionsPanel from 'src/components/ActionsPanel';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import { useProfile } from 'src/queries/profile';
 import { useSnackbar } from 'notistack';
-import { useSMSOptOutMutation } from 'src/queries/account';
+import { useSMSOptOutMutation } from 'src/queries/profile';
 
 const useStyles = makeStyles((theme: Theme) => ({
   notice: {

--- a/packages/manager/src/features/Profile/AuthenticationSettings/SMSMessaging.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/SMSMessaging.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import Button from 'src/components/Button';
+import Box from 'src/components/core/Box';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+import Notice from 'src/components/Notice';
+import { useProfile } from 'src/queries/profile';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  notice: {
+    fontSize: '0.875rem !important',
+    fontFamily: theme.font.bold,
+  },
+}));
+
+export const SMSMessageing = () => {
+  const classes = useStyles();
+  const { data: profile } = useProfile();
+
+  const hasVerifiedPhoneNumber = Boolean(profile?.phone_number);
+
+  return (
+    <Box>
+      <Notice
+        spacingTop={12}
+        spacingBottom={16}
+        success={hasVerifiedPhoneNumber}
+        warning={!hasVerifiedPhoneNumber}
+      >
+        <Typography className={classes.notice}>
+          {hasVerifiedPhoneNumber
+            ? 'You have opted in to SMS messaging for phone verification'
+            : 'You are opted out of SMS messaging for phone verification'}
+        </Typography>
+      </Notice>
+      <Typography>
+        An authentication code is sent via SMS as part of the verification
+        process. Messages are not sent for any other reason. SMS authentication
+        by verified phone number provides an important degree of account
+        security. You may opt out at any time and your verified phone number
+        will be deleted.
+      </Typography>
+      {hasVerifiedPhoneNumber ? (
+        <Box display="flex" justifyContent="flex-end">
+          <Button buttonType="primary">Opt Out</Button>
+        </Box>
+      ) : null}
+    </Box>
+  );
+};

--- a/packages/manager/src/features/Profile/AuthenticationSettings/SMSMessaging.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/SMSMessaging.tsx
@@ -27,9 +27,12 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 export const SMSMessageing = () => {
   const classes = useStyles();
+
   const { enqueueSnackbar } = useSnackbar();
   const { data: profile } = useProfile();
   const { mutateAsync: updateProfile, isLoading, error } = useMutateProfile();
+
+  const hasVerifiedPhoneNumber = Boolean(profile?.phone_number);
 
   const [open, setOpen] = React.useState(false);
 
@@ -49,8 +52,6 @@ export const SMSMessageing = () => {
       });
     });
   };
-
-  const hasVerifiedPhoneNumber = Boolean(profile?.phone_number);
 
   return (
     <>
@@ -105,8 +106,10 @@ export const SMSMessageing = () => {
       >
         <Typography>
           Opting out of SMS messaging will reduce security and limit the ways
-          you can securly access your account. Learn more about security
-          options.
+          you can securly access your account.{' '}
+          <a href="https://www.linode.com/docs/guides/linode-manager-security-controls/">
+            Learn more about security options.
+          </a>
         </Typography>
         <Notice
           spacingTop={16}

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -270,6 +270,9 @@ export const handlers = [
   rest.post('*/profile/phone-number/verify', (req, res, ctx) => {
     return res(ctx.json({}));
   }),
+  rest.post('*/account/phone-number/opt-out', (req, res, ctx) => {
+    return res(ctx.json({}));
+  }),
   rest.get('*/profile/security-questions', (req, res, ctx) => {
     return res(ctx.json(securityQuestionsFactory.build()));
   }),

--- a/packages/manager/src/queries/account.ts
+++ b/packages/manager/src/queries/account.ts
@@ -1,12 +1,14 @@
 import {
   Account,
   getAccountInfo,
+  smsOptOut,
   updateAccountInfo,
 } from '@linode/api-v4/lib/account';
 import { APIError } from '@linode/api-v4/lib/types';
 import { useMutation, useQuery } from 'react-query';
 import { getGravatarUrl } from 'src/utilities/gravatar';
 import { mutationHandlers, queryPresets } from './base';
+import { updateProfileData } from './profile';
 
 export const queryKey = 'account';
 
@@ -31,3 +33,10 @@ export const useAccountGravatar = (email: string) =>
       enabled: Boolean(email),
     }
   );
+
+export const useSMSOptOutMutation = () =>
+  useMutation<{}, APIError[]>(smsOptOut, {
+    onSuccess: () => {
+      updateProfileData({ phone_number: null });
+    },
+  });

--- a/packages/manager/src/queries/account.ts
+++ b/packages/manager/src/queries/account.ts
@@ -1,14 +1,12 @@
 import {
   Account,
   getAccountInfo,
-  smsOptOut,
   updateAccountInfo,
 } from '@linode/api-v4/lib/account';
 import { APIError } from '@linode/api-v4/lib/types';
 import { useMutation, useQuery } from 'react-query';
 import { getGravatarUrl } from 'src/utilities/gravatar';
 import { mutationHandlers, queryPresets } from './base';
-import { updateProfileData } from './profile';
 
 export const queryKey = 'account';
 
@@ -33,10 +31,3 @@ export const useAccountGravatar = (email: string) =>
       enabled: Boolean(email),
     }
   );
-
-export const useSMSOptOutMutation = () =>
-  useMutation<{}, APIError[]>(smsOptOut, {
-    onSuccess: () => {
-      updateProfileData({ phone_number: null });
-    },
-  });

--- a/packages/manager/src/queries/profile.ts
+++ b/packages/manager/src/queries/profile.ts
@@ -2,6 +2,7 @@ import {
   getProfile,
   listGrants,
   Profile,
+  smsOptOut,
   updateProfile,
 } from '@linode/api-v4/lib/profile';
 import { APIError } from '@linode/api-v4/lib/types';
@@ -43,3 +44,10 @@ export const useGrants = () =>
 export const getProfileData = () => queryClient.getQueryData<Profile>(queryKey);
 export const getGrantData = () =>
   queryClient.getQueryData<Grants>(`${queryKey}-grants`);
+
+export const useSMSOptOutMutation = () =>
+  useMutation<{}, APIError[]>(smsOptOut, {
+    onSuccess: () => {
+      updateProfileData({ phone_number: null });
+    },
+  });


### PR DESCRIPTION
## Description

**What does this PR do?**
Adds Cypress integration tests for SMS phone number verification opt-out using mocked API responses. Tests for remaining phone number verification functionality will be addressed in a separate PR.

This PR tracks the changes made by #8398 -- please wait to merge until after that has been merged.

(The diff also includes the changes from #8398 -- only the files changed within `/manager/cypress/` are specific to this PR)

**Note:** there will be conflicts between this and #8410; once either of these are merged, I'll fix any conflicts for the other PR.

## How to test

**How do I run relevant unit tests?**
With `yarn up` running separately, run:
```bash
yarn cy:run -s "cypress/integration/account/sms-verification.spec.ts"
```

Alternatively, if you want to watch the test run, you can run:
```bash
yarn cy:debug
```

And then select `sms-verification.spec.ts` in the Cypress window.

## See Also
- #8398 
- #8410 
