### PR TITLE
M3-5833: Make Notifications badge a true circle

### DIFF
--- a/packages/manager/src/features/TopMenu/NotificationButton.tsx
+++ b/packages/manager/src/features/TopMenu/NotificationButton.tsx
@@ -2,7 +2,6 @@ import { Menu, MenuButton, MenuItems, MenuPopover } from '@reach/menu-button';
 import * as React from 'react';
 import Bell from 'src/assets/icons/notification.svg';
 import { makeStyles, Theme } from 'src/components/core/styles';
-import Typography from 'src/components/core/Typography';
 import { NotificationMenu } from 'src/features/NotificationCenter';
 import useNotificationData from 'src/features/NotificationCenter/NotificationData/useNotificationData';
 import { menuId } from '../NotificationCenter/NotificationContext';
@@ -78,7 +77,7 @@ export const NotificationButton: React.FC<{}> = (_) => {
               <Bell />
               {numNotifications > 0 ? (
                 <div className={iconClasses.badge}>
-                  <Typography>{numNotifications}</Typography>
+                  <p>{numNotifications}</p>
                 </div>
               ) : null}
             </MenuButton>

--- a/packages/manager/src/features/TopMenu/NotificationButton.tsx
+++ b/packages/manager/src/features/TopMenu/NotificationButton.tsx
@@ -2,6 +2,7 @@ import { Menu, MenuButton, MenuItems, MenuPopover } from '@reach/menu-button';
 import * as React from 'react';
 import Bell from 'src/assets/icons/notification.svg';
 import { makeStyles, Theme } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
 import { NotificationMenu } from 'src/features/NotificationCenter';
 import useNotificationData from 'src/features/NotificationCenter/NotificationData/useNotificationData';
 import { menuId } from '../NotificationCenter/NotificationContext';
@@ -76,7 +77,9 @@ export const NotificationButton: React.FC<{}> = (_) => {
             >
               <Bell />
               {numNotifications > 0 ? (
-                <span className={iconClasses.badge}>{numNotifications}</span>
+                <div className={iconClasses.badge}>
+                  <Typography>{numNotifications}</Typography>
+                </div>
               ) : null}
             </MenuButton>
           </TopMenuIcon>

--- a/packages/manager/src/features/TopMenu/iconStyles.ts
+++ b/packages/manager/src/features/TopMenu/iconStyles.ts
@@ -39,7 +39,7 @@ export const useStyles = makeStyles((theme: Theme) => ({
   badge: {
     display: 'flex',
     position: 'absolute',
-    top: 5,
+    top: 2,
     left: 20,
     alignItems: 'center',
     justifyContent: 'center',

--- a/packages/manager/src/features/TopMenu/iconStyles.ts
+++ b/packages/manager/src/features/TopMenu/iconStyles.ts
@@ -39,16 +39,17 @@ export const useStyles = makeStyles((theme: Theme) => ({
   badge: {
     display: 'flex',
     position: 'absolute',
-    padding: theme.spacing(0.25),
     top: 5,
     left: 20,
     alignItems: 'center',
     justifyContent: 'center',
-    color: 'white',
     backgroundColor: theme.color.green,
-    fontSize: '0.72rem',
     borderRadius: '50%',
-    minWidth: 16,
-    minHeight: 16,
+    width: '1rem',
+    height: '1rem',
+    '& p': {
+      fontSize: '0.72rem',
+      color: 'white',
+    },
   },
 }));


### PR DESCRIPTION
## Description
Before (more of an oval than a circle):
![Screen Shot 2022-06-14 at 12 45 43 PM](https://user-images.githubusercontent.com/32860776/173631895-185ff1a3-2afa-433a-a32e-518365013122.jpg)

After:
![Screen Shot 2022-06-14 at 12 49 41 PM](https://user-images.githubusercontent.com/32860776/173632578-4f2bbcfa-5907-4323-9bee-fb399f2baa3d.jpg)

## How to test
Check the Notifications badge in several browsers and ensure it is a circle with no distortions to the shape or the text
