### PR TITLE
M3-5652: Display errors in Firewall rules table

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRulesLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRulesLanding.tsx
@@ -22,7 +22,6 @@ import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import FirewallRuleDrawer, { Mode } from './FirewallRuleDrawer';
 import curriedFirewallRuleEditorReducer, {
   editorStateToRules,
-  ExtendedFirewallRule,
   hasModified as _hasModified,
   initRuleEditorState,
   prepareRules,
@@ -228,24 +227,10 @@ const FirewallRulesLanding: React.FC<CombinedProps> = (props) => {
           } else {
             const { idx, category } = parsedError;
 
-            // Refer back to the prepared list of rules to get the actual index to set the error on.
-            // This may be different than the index returned by the API, since we don't send deleted
-            // rules in the PUT request (but we still have them in state).
-            const originalRule: ExtendedFirewallRule =
-              preparedRules[category][idx];
-
-            const originalIndex = originalRule.index;
-
-            if (originalIndex === undefined) {
-              return;
-            }
-
-            const dispatch = dispatchFromCategory(
-              parsedError.category as Category
-            );
+            const dispatch = dispatchFromCategory(category as Category);
             dispatch({
               type: 'SET_ERROR',
-              idx: originalIndex,
+              idx,
               error: parsedError,
             });
           }


### PR DESCRIPTION
## Description
If there is an error with saving Firewall rules, display those errors in the table. 

Note: There is an edge-case bug where the error displays on the wrong rule (see Jira ticket for more info), that will be addressed in M3-5849.

https://user-images.githubusercontent.com/14323019/173919986-7ba9c633-dff6-422b-9319-863811c7db2d.mov

## How to test
Edit a Firewall rule with an invalid IP and you should see an error displayed after clicking "Save Changes"
