### PR TITLE
M3-5823: Change call to contact in security questions copy

### DIFF
--- a/packages/manager/src/features/Profile/AuthenticationSettings/SecurityQuestions/SecurityQuestions.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/SecurityQuestions/SecurityQuestions.tsx
@@ -140,7 +140,7 @@ const SecurityQuestions = () => {
       <Typography variant="h3">Security Questions</Typography>
       <Typography variant="body1" className={classes.copy}>
         Adding security questions helps keep your account secure and will only
-        be used to verify your identity when you call Linode Support. Choose
+        be used to verify your identity when you contact Linode Support. Choose
         answers that are not easily guessed or discoverable through research.
       </Typography>
       <form className={classes.form} onSubmit={handleSubmit}>


### PR DESCRIPTION
## Description

Changes the word `call` to `contact` for the description copy in the security questions section.

## How to test

Ensure the word call has been replaced by the word contact
