### PR TITLE
(Experimental) Detect excessive Linode APIv4 requests during Cypress tests

### DIFF
--- a/packages/manager/cypress/support/index.js
+++ b/packages/manager/cypress/support/index.js
@@ -26,6 +26,7 @@ chai.use(chaiString);
 authenticate();
 
 import './commands';
+import './request-tracking';
 
 // Runs before each test file.
 before(() => {

--- a/packages/manager/cypress/support/request-tracking.ts
+++ b/packages/manager/cypress/support/request-tracking.ts
@@ -1,0 +1,56 @@
+/**
+ * @file Tracks the number of Linode APIv4 requests being made during each test.
+ */
+
+// The number of Linode APIvr requests that are allowed.
+// Set to `null` to allow any number of APIv4 requests.
+const maxRequests: number | null = null;
+
+// Whether a test should fail immediately upon passing `maxRequests` threshold.
+// If `false`, the test will continue running but will fail upon finishing.
+const failImmediately = false;
+
+// Whether or not to report the APIv4 request count at the end of a test.
+const reportRequestCount = true;
+
+const makeErrorString = (requests: number, max: number) => {
+  return `Excessive Linode APIv4 requests were detected, causing this test to fail.\n\nAPIv4 requests: ${requests}\nMaximum requests: ${max}`;
+};
+
+// Set up Linode APIv4 intercepts and set default alias value.
+beforeEach(() => {
+  let requests = 0;
+
+  cy.wrap([]).as('linodeApiV4Request');
+  cy.intercept(
+    {
+      url: /\/v4(?:beta)?\/.*/,
+      middleware: true,
+    },
+    (req) => {
+      requests++;
+      // Short-circuit if `maxRequests` is null.
+      if (maxRequests === null) {
+        return;
+      }
+
+      // Fail test if API threshold is met and `failImmediately` is true.
+      if (requests > maxRequests && failImmediately) {
+        throw new Error(makeErrorString(requests, maxRequests));
+      }
+    }
+  ).as('linodeApiV4Request');
+});
+
+// Tally and report intercepted Linode APIv4 requests, failing test if necessary.
+afterEach(() => {
+  cy.get('@linodeApiV4Request.all').then((calls) => {
+    const count = calls.length;
+    if (reportRequestCount) {
+      cy.log(`${count} Linode APIv4 requests were made during this test`);
+    }
+    if (maxRequests !== null && count > maxRequests) {
+      throw new Error(makeErrorString(count, maxRequests));
+    }
+  });
+});


### PR DESCRIPTION
## Description

**What does this PR do?**
Tracks the number of Linode APIv4 requests made and prints the total to the Cypress log after each test. It also lays the groundwork to add a maximum request threshold and to begin failing tests if they exceed that value.

You can play with the constants in `request-tracking.ts` to tweak the behavior and thresholds for request tracking. Right now I have the max number of requests set to `null` so that no tests fail, but once we have a better understanding of the number of requests that are typical for our tests we can set an appropriate value for the max.

## How to test

**What are the steps to reproduce the issue or verify the changes?**

Run manager with `yarn up`, then:
```
yarn cy:debug
```

Run any test, and observe that the total number of Linode APIv4 requests is shown in Cypress after each test runs. If you play with the constants in `request-tracking.ts`, confirm that the behavior matches your expectations.
