### PR TITLE
M3-5496: Move region text to tooltip in Upload Image

### DIFF
--- a/packages/manager/src/features/Images/ImageUpload.tsx
+++ b/packages/manager/src/features/Images/ImageUpload.tsx
@@ -216,6 +216,9 @@ export const ImageUpload: React.FC<Props> = (props) => {
 
           <RegionSelect
             label="Region"
+            helperText="For fastest initial upload, select the region that is geographically
+            closest to you. Once uploaded you will be able to deploy the image
+            to other regions."
             errorText={errorMap.region}
             handleSelection={setRegion}
             regions={regions}
@@ -234,17 +237,11 @@ export const ImageUpload: React.FC<Props> = (props) => {
           ) : null}
 
           <Typography className={classes.helperText}>
-            For fastest initial upload, select the region that is geographically
-            closest to you. Once uploaded you will be able to deploy the image
-            to other regions. Image files must be raw disk images (.img)
-            compressed using gzip (.gz). The maximum file size is 5 GB
-            (compressed).
-            <>
-              <br />
-              <br />
-              Custom Images are billed at $0.10/GB per month based on the
-              uncompressed image size.
-            </>
+            Image files must be raw disk images (.img) compressed using gzip
+            (.gz). The maximum file size is 5 GB (compressed).
+            <br />
+            Custom Images are billed at $0.10/GB per month based on the
+            uncompressed image size.
           </Typography>
 
           <FileUploader

--- a/packages/manager/src/features/Images/ImageUpload.tsx
+++ b/packages/manager/src/features/Images/ImageUpload.tsx
@@ -240,6 +240,7 @@ export const ImageUpload: React.FC<Props> = (props) => {
             Image files must be raw disk images (.img) compressed using gzip
             (.gz). The maximum file size is 5 GB (compressed).
             <br />
+            <br />
             Custom Images are billed at $0.10/GB per month based on the
             uncompressed image size.
           </Typography>


### PR DESCRIPTION
## Description
Moves some region text in Upload Image to a tooltip

## How to test
Go to `/images/create/upload` and hover over the tooltip next to the region input
