### PR TITLE
M3-5462: Keys and secrets modals update UI

### DIFF
--- a/packages/manager/cypress/integration/objectStorage/access-key.e2e.spec.ts
+++ b/packages/manager/cypress/integration/objectStorage/access-key.e2e.spec.ts
@@ -55,14 +55,27 @@ describe('object storage access key end-to-end tests', () => {
       const accessKey = intercepts.response?.body?.access_key;
       const secretKey = intercepts.response?.body?.secret_key;
 
-      cy.findByText(secretKeyWarning, { exact: false }).should('be.visible');
-      cy.get('[id="access-key"]')
+      ui.dialog
+        .findByTitle('Access Keys')
         .should('be.visible')
-        .should('have.value', accessKey);
-      cy.get('[id="secret-key"]')
-        .should('be.visible')
-        .should('have.value', secretKey);
-      cy.findByLabelText('Close drawer').should('be.visible').click();
+        .within(() => {
+          cy.findByText(secretKeyWarning, { exact: false }).should(
+            'be.visible'
+          );
+
+          cy.get('input[id="access-key"]')
+            .should('be.visible')
+            .should('have.value', accessKey);
+          cy.get('input[id="secret-key"]')
+            .should('be.visible')
+            .should('have.value', secretKey);
+
+          ui.buttonGroup
+            .findButtonByTitle('I Have Saved My Keys')
+            .should('be.visible')
+            .should('be.enabled')
+            .click();
+        });
 
       cy.findByLabelText('List of Object Storage Access Keys').within(() => {
         cy.findByText(keyLabel)
@@ -134,13 +147,23 @@ describe('object storage access key end-to-end tests', () => {
         const accessKey = intercepts.response?.body?.access_key;
         const secretKey = intercepts.response?.body?.secret_key;
 
-        cy.get('[id="access-key"]')
+        ui.dialog
+          .findByTitle('Access Keys')
           .should('be.visible')
-          .should('have.value', accessKey);
-        cy.get('[id="secret-key"]')
-          .should('be.visible')
-          .should('have.value', secretKey);
-        cy.findByLabelText('Close drawer').should('be.visible').click();
+          .within(() => {
+            cy.get('input[id="access-key"]')
+              .should('be.visible')
+              .should('have.value', accessKey);
+            cy.get('input[id="secret-key"]')
+              .should('be.visible')
+              .should('have.value', secretKey);
+
+            ui.buttonGroup
+              .findButtonByTitle('I Have Saved My Keys')
+              .should('be.visible')
+              .should('be.enabled')
+              .click();
+          });
 
         cy.findByLabelText('List of Object Storage Access Keys').within(() => {
           cy.findByText(keyLabel)

--- a/packages/manager/cypress/integration/objectStorage/access-keys.smoke.spec.ts
+++ b/packages/manager/cypress/integration/objectStorage/access-keys.smoke.spec.ts
@@ -67,13 +67,23 @@ describe('object storage access keys smoke tests', () => {
 
     cy.wait(['@createKey', '@getKeys']);
 
-    cy.get('input[id="access-key"]')
+    ui.dialog
+      .findByTitle('Access Keys')
       .should('be.visible')
-      .should('have.value', accessKey);
-    cy.get('input[id="secret-key"]')
-      .should('be.visible')
-      .should('have.value', secretKey);
-    cy.findByLabelText('Close drawer').should('be.visible').click();
+      .within(() => {
+        cy.get('input[id="access-key"]')
+          .should('be.visible')
+          .should('have.value', accessKey);
+        cy.get('input[id="secret-key"]')
+          .should('be.visible')
+          .should('have.value', secretKey);
+
+        ui.buttonGroup
+          .findButtonByTitle('I Have Saved My Keys')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
 
     cy.findByLabelText('List of Object Storage Access Keys').within(() => {
       cy.findByText(keyLabel).should('be.visible');

--- a/packages/manager/src/assets/icons/download.svg
+++ b/packages/manager/src/assets/icons/download.svg
@@ -1,21 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="18px" height="19px" viewBox="0 0 18 19" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 55.2 (78181) - https://sketchapp.com -->
-    <title>icon/download</title>
-    <desc>Created with Sketch.</desc>
-    <g id="2.-Continuted" stroke="none" stroke-width="1" fill="currentColor" fill-rule="evenodd">
-        <g id="Kube-Detail-3.1" transform="translate(-1222.000000, -242.000000)">
-            <g id="right-rail" transform="translate(1112.000000, 169.000000)">
-                <g id="Kubeconfig">
-                    <g id="icon/download" transform="translate(23.000000, 62.000000)">
-                        <g id="button/download">
-                            <g id="icon/download" transform="translate(88.000000, 11.000000)">
-                                <polygon id="Shape" fill="currentColor" transform="translate(14.7, -3) rotate(90)" fill-rule="nonzero" points="10.5 10.5 14.5 6.5 10.5 2.5 10.5 5.5 1.5 5.5 1.5 7.5 10.5 7.5"></polygon>
-                                <polyline id="Line" stroke="currentColor" stroke-width="2" stroke-linecap="square" points="0 14 0 17.3767844 16 17.3767844 16 14"></polyline>
-                            </g>
-                        </g>
-                    </g>
-                </g>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>get_app-24px</title>
+    <g id="Modals" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Client-Secret-modal" transform="translate(-819.000000, -484.000000)">
+            <g id="get_app-24px" transform="translate(819.000000, 484.000000)">
+                <polygon id="Path" points="0 0 24 0 24 24 0 24"></polygon>
+                <path d="M19,9 L15,9 L15,3 L9,3 L9,9 L5,9 L12,16 L19,9 Z M5,18 L5,20 L19,20 L19,18 L5,18 Z" id="Shape" fill="#888F91" fill-rule="nonzero"></path>
             </g>
         </g>
     </g>

--- a/packages/manager/src/assets/icons/download.svg
+++ b/packages/manager/src/assets/icons/download.svg
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <title>get_app-24px</title>
-    <g id="Modals" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="Client-Secret-modal" transform="translate(-819.000000, -484.000000)">
-            <g id="get_app-24px" transform="translate(819.000000, 484.000000)">
-                <polygon id="Path" points="0 0 24 0 24 24 0 24"></polygon>
-                <path d="M19,9 L15,9 L15,3 L9,3 L9,9 L5,9 L12,16 L19,9 Z M5,18 L5,20 L19,20 L19,18 L5,18 Z" id="Shape" fill="#888F91" fill-rule="nonzero"></path>
+<svg width="14px" height="17px" viewBox="0 0 14 17" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>Shape</title>
+    <g id="Page-2" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Personal-Access-Token-modal" transform="translate(-851.000000, -404.000000)" fill="currentColor" fill-rule="nonzero">
+            <g id="get_app-24px" transform="translate(846.000000, 401.000000)">
+                <path d="M19,9 L15,9 L15,3 L9,3 L9,9 L5,9 L12,16 L19,9 Z M5,18 L5,20 L19,20 L19,18 L5,18 Z" id="Shape"></path>
             </g>
         </g>
     </g>

--- a/packages/manager/src/components/CopyableAndDownloadableTextField.tsx
+++ b/packages/manager/src/components/CopyableAndDownloadableTextField.tsx
@@ -25,6 +25,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 type Props = TextFieldProps & {
   className?: string;
   hideIcon?: boolean;
+  fileName?: string;
 };
 
 type CombinedProps = Props;
@@ -34,6 +35,8 @@ export const CopyableAndDownloadableTextField: React.FC<CombinedProps> = (
 ) => {
   const classes = useStyles();
   const { value, className, hideIcon, ...restProps } = props;
+
+  const fileName = props.fileName ?? _.snakeCase(props.label);
 
   return (
     <TextField
@@ -47,7 +50,7 @@ export const CopyableAndDownloadableTextField: React.FC<CombinedProps> = (
             <DownloadTooltip
               text={`${value}`}
               className={classes.copyIcon}
-              fileName={_.snakeCase(props.label)}
+              fileName={fileName}
             />
             <CopyTooltip text={`${value}`} className={classes.copyIcon} />
           </>

--- a/packages/manager/src/components/CopyableAndDownloadableTextField.tsx
+++ b/packages/manager/src/components/CopyableAndDownloadableTextField.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import _ from 'lodash';
 import CopyTooltip from 'src/components/CopyTooltip';
 import DownloadTooltip from 'src/components/DownloadTooltip';
 import { makeStyles, Theme } from 'src/components/core/styles';
@@ -44,7 +45,11 @@ export const CopyableAndDownloadableTextField: React.FC<CombinedProps> = (
         endAdornment: hideIcon ? undefined : (
           <>
             <CopyTooltip text={`${value}`} className={classes.copyIcon} />
-            <DownloadTooltip text={`${value}`} className={classes.copyIcon} />
+            <DownloadTooltip
+              text={`${value}`}
+              className={classes.copyIcon}
+              fileName={_.snakeCase(props.label)}
+            />
           </>
         ),
       }}

--- a/packages/manager/src/components/CopyableAndDownloadableTextField.tsx
+++ b/packages/manager/src/components/CopyableAndDownloadableTextField.tsx
@@ -42,7 +42,7 @@ export const CopyableAndDownloadableTextField: React.FC<CombinedProps> = (
     <TextField
       value={value}
       {...restProps}
-      className={`${className} ${'copy'} ${classes.removeDisabledStyles}`}
+      className={`${className} ${classes.removeDisabledStyles}`}
       disabled
       InputProps={{
         endAdornment: hideIcon ? undefined : (

--- a/packages/manager/src/components/CopyableAndDownloadableTextField.tsx
+++ b/packages/manager/src/components/CopyableAndDownloadableTextField.tsx
@@ -23,13 +23,11 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-type Props = TextFieldProps & {
+type CombinedProps = TextFieldProps & {
   className?: string;
   hideIcon?: boolean;
   fileName?: string;
 };
-
-type CombinedProps = Props;
 
 export const CopyableAndDownloadableTextField: React.FC<CombinedProps> = (
   props

--- a/packages/manager/src/components/CopyableAndDownloadableTextField.tsx
+++ b/packages/manager/src/components/CopyableAndDownloadableTextField.tsx
@@ -44,12 +44,12 @@ export const CopyableAndDownloadableTextField: React.FC<CombinedProps> = (
       InputProps={{
         endAdornment: hideIcon ? undefined : (
           <>
-            <CopyTooltip text={`${value}`} className={classes.copyIcon} />
             <DownloadTooltip
               text={`${value}`}
               className={classes.copyIcon}
               fileName={_.snakeCase(props.label)}
             />
+            <CopyTooltip text={`${value}`} className={classes.copyIcon} />
           </>
         ),
       }}

--- a/packages/manager/src/components/CopyableAndDownloadableTextField.tsx
+++ b/packages/manager/src/components/CopyableAndDownloadableTextField.tsx
@@ -10,6 +10,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     '&.Mui-disabled': {
       borderColor: theme.name === 'lightTheme' ? '#ccc' : '#222',
       color: theme.name === 'lightTheme' ? 'inherit' : '#fff !important',
+      background: theme.bg.main,
       opacity: 1,
     },
   },

--- a/packages/manager/src/components/CopyableAndDownloadableTextField.tsx
+++ b/packages/manager/src/components/CopyableAndDownloadableTextField.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import CopyTooltip from 'src/components/CopyTooltip';
+import DownloadTooltip from 'src/components/DownloadTooltip';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import TextField, { Props as TextFieldProps } from 'src/components/TextField';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  removeDisabledStyles: {
+    '&.Mui-disabled': {
+      borderColor: theme.name === 'lightTheme' ? '#ccc' : '#222',
+      color: theme.name === 'lightTheme' ? 'inherit' : '#fff !important',
+      opacity: 1,
+    },
+  },
+  copyIcon: {
+    marginRight: theme.spacing(0.5),
+    '& svg': {
+      height: 14,
+      top: 1,
+    },
+  },
+}));
+
+type Props = TextFieldProps & {
+  className?: string;
+  hideIcon?: boolean;
+};
+
+type CombinedProps = Props;
+
+export const CopyableAndDownloadableTextField: React.FC<CombinedProps> = (
+  props
+) => {
+  const classes = useStyles();
+  const { value, className, hideIcon, ...restProps } = props;
+
+  return (
+    <TextField
+      value={value}
+      {...restProps}
+      className={`${className} ${'copy'} ${classes.removeDisabledStyles}`}
+      disabled
+      InputProps={{
+        endAdornment: hideIcon ? undefined : (
+          <>
+            <CopyTooltip text={`${value}`} className={classes.copyIcon} />
+            <DownloadTooltip text={`${value}`} className={classes.copyIcon} />
+          </>
+        ),
+      }}
+      data-qa-copy-tooltip
+    />
+  );
+};
+
+export default CopyableAndDownloadableTextField;

--- a/packages/manager/src/components/DownloadTooltip.tsx
+++ b/packages/manager/src/components/DownloadTooltip.tsx
@@ -1,0 +1,84 @@
+import classNames from 'classnames';
+import { downloadFile } from 'src/utilities/downloadFile';
+import * as React from 'react';
+import FileDownload from 'src/assets/icons/download.svg';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+import ToolTip from 'src/components/core/Tooltip';
+
+interface Props {
+  text: string;
+  className?: string;
+  displayText?: string;
+  onClickCallback?: () => void;
+}
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    position: 'relative',
+    padding: 4,
+    backgroundColor: 'transparent',
+    transition: theme.transitions.create(['background-color']),
+    borderRadius: 4,
+    border: 'none',
+    cursor: 'pointer',
+    color: theme.color.grey1,
+    '& svg': {
+      transition: theme.transitions.create(['color']),
+      color: theme.color.grey1,
+      margin: 0,
+      position: 'relative',
+      width: 20,
+      height: 20,
+    },
+    '&:hover': {
+      backgroundColor: theme.color.white,
+    },
+  },
+  flex: {
+    display: 'flex',
+    width: 'auto !important',
+  },
+  displayText: {
+    color: theme.textColors.linkActiveLight,
+    marginLeft: 6,
+  },
+}));
+
+export const DownloadTooltip: React.FC<Props> = (props) => {
+  const classes = useStyles();
+  const [copied, setCopied] = React.useState<boolean>(false);
+
+  const { text, className, displayText, onClickCallback } = props;
+
+  const handleIconClick = () => {
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1500);
+    downloadFile('file.txt', text);
+    if (onClickCallback) {
+      onClickCallback();
+    }
+  };
+
+  return (
+    <ToolTip title={copied ? 'Copied!' : 'Copy'} placement="top" data-qa-copied>
+      <button
+        aria-label={`Copy ${text} to clipboard`}
+        name={text}
+        type="button"
+        onClick={handleIconClick}
+        className={classNames(className, {
+          [classes.root]: true,
+          [classes.flex]: Boolean(displayText),
+        })}
+      >
+        <FileDownload />
+        {displayText && (
+          <Typography className={classes.displayText}>{displayText}</Typography>
+        )}
+      </button>
+    </ToolTip>
+  );
+};
+
+export default DownloadTooltip;

--- a/packages/manager/src/components/DownloadTooltip.tsx
+++ b/packages/manager/src/components/DownloadTooltip.tsx
@@ -48,13 +48,10 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 export const DownloadTooltip: React.FC<Props> = (props) => {
   const classes = useStyles();
-  const [copied, setCopied] = React.useState<boolean>(false);
 
   const { text, className, displayText, onClickCallback, fileName } = props;
 
   const handleIconClick = () => {
-    setCopied(true);
-    window.setTimeout(() => setCopied(false), 1500);
     downloadFile(`${fileName}.txt`, text);
     if (onClickCallback) {
       onClickCallback();
@@ -62,9 +59,9 @@ export const DownloadTooltip: React.FC<Props> = (props) => {
   };
 
   return (
-    <ToolTip title={copied ? 'Copied!' : 'Copy'} placement="top" data-qa-copied>
+    <ToolTip title={'Download'} placement="top" data-qa-copied>
       <button
-        aria-label={`Copy ${text} to clipboard`}
+        aria-label={`Download ${text}`}
         name={text}
         type="button"
         onClick={handleIconClick}

--- a/packages/manager/src/components/DownloadTooltip.tsx
+++ b/packages/manager/src/components/DownloadTooltip.tsx
@@ -59,7 +59,7 @@ export const DownloadTooltip: React.FC<Props> = (props) => {
   };
 
   return (
-    <ToolTip title={'Download'} placement="top" data-qa-copied>
+    <ToolTip title="Download" placement="top" data-qa-copied>
       <button
         aria-label={`Download ${text}`}
         name={text}

--- a/packages/manager/src/components/DownloadTooltip.tsx
+++ b/packages/manager/src/components/DownloadTooltip.tsx
@@ -11,6 +11,7 @@ interface Props {
   className?: string;
   displayText?: string;
   onClickCallback?: () => void;
+  fileName: string;
 }
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -49,12 +50,12 @@ export const DownloadTooltip: React.FC<Props> = (props) => {
   const classes = useStyles();
   const [copied, setCopied] = React.useState<boolean>(false);
 
-  const { text, className, displayText, onClickCallback } = props;
+  const { text, className, displayText, onClickCallback, fileName } = props;
 
   const handleIconClick = () => {
     setCopied(true);
     window.setTimeout(() => setCopied(false), 1500);
-    downloadFile('file.txt', text);
+    downloadFile(`${fileName}.txt`, text);
     if (onClickCallback) {
       onClickCallback();
     }

--- a/packages/manager/src/features/Profile/SecretTokenDialog/SecretTokenDialog.tsx
+++ b/packages/manager/src/features/Profile/SecretTokenDialog/SecretTokenDialog.tsx
@@ -70,7 +70,7 @@ export const SecretTokenDialog: React.FC<CombinedProps> = (props) => {
         warning
         className={classes.noticeText}
         text={`${
-          objectStorageKey ? '' : 'Your keys have been generated.'
+          objectStorageKey ? 'Your keys have been generated.' : ''
         } For security purposes, we can only display your ${
           objectStorageKey ? 'secret key' : title.toLowerCase()
         } once, after which it can\u{2019}t be recovered. Be sure to keep it in a safe place.`}

--- a/packages/manager/src/features/Profile/SecretTokenDialog/SecretTokenDialog.tsx
+++ b/packages/manager/src/features/Profile/SecretTokenDialog/SecretTokenDialog.tsx
@@ -2,9 +2,11 @@ import * as React from 'react';
 import { ObjectStorageKey } from '@linode/api-v4/lib/object-storage';
 import { makeStyles } from 'src/components/core/styles';
 import Notice from 'src/components/Notice';
-import Dialog from 'src/components/Dialog';
+import ConfirmationDialog from 'src/components/ConfirmationDialog';
 import CopyableAndDownloadableTextField from 'src/components/CopyableAndDownloadableTextField';
 import Box from 'src/components/core/Box';
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
 
 interface Props {
   title: string;
@@ -27,21 +29,41 @@ const useStyles = makeStyles(() => ({
 
 type CombinedProps = Props;
 
+const renderActions = (onClose: () => void) => (
+  <ActionsPanel>
+    <Button
+      buttonType="secondary"
+      onClick={onClose}
+      data-qa-cancel
+      data-testid="dialog-cancel"
+    >
+      Cancel
+    </Button>
+    <Button
+      buttonType="primary"
+      onClick={onClose}
+      data-qa-confirm
+      data-testid="dialog-confirm"
+    >
+      I Have Saved My Keys
+    </Button>
+  </ActionsPanel>
+);
+
 export const SecretTokenDialog: React.FC<CombinedProps> = (props) => {
   const classes = useStyles();
   const { title, value, objectStorageKey, open, onClose } = props;
 
+  const actions = renderActions(onClose);
+
   return (
-    <Dialog
+    <ConfirmationDialog
       title={title}
       open={open}
-      onClose={(_, reason) => {
-        if (reason !== 'backdropClick') {
-          onClose();
-        }
-      }}
+      onClose={onClose}
       disableEscapeKeyDown
       maxWidth="sm"
+      actions={actions}
     >
       <Notice
         spacingTop={8}
@@ -82,7 +104,7 @@ export const SecretTokenDialog: React.FC<CombinedProps> = (props) => {
           />
         </Box>
       ) : null}
-    </Dialog>
+    </ConfirmationDialog>
   );
 };
 

--- a/packages/manager/src/features/Profile/SecretTokenDialog/SecretTokenDialog.tsx
+++ b/packages/manager/src/features/Profile/SecretTokenDialog/SecretTokenDialog.tsx
@@ -37,7 +37,7 @@ const renderActions = (onClose: () => void) => (
       data-qa-cancel
       data-testid="dialog-cancel"
     >
-      Cancel
+      Close
     </Button>
     <Button
       buttonType="primary"

--- a/packages/manager/src/features/Profile/SecretTokenDialog/SecretTokenDialog.tsx
+++ b/packages/manager/src/features/Profile/SecretTokenDialog/SecretTokenDialog.tsx
@@ -3,7 +3,7 @@ import { ObjectStorageKey } from '@linode/api-v4/lib/object-storage';
 import { makeStyles } from 'src/components/core/styles';
 import Notice from 'src/components/Notice';
 import Dialog from 'src/components/Dialog';
-import CopyableTextField from 'src/components/CopyableTextField';
+import CopyableAndDownloadableTextField from 'src/components/CopyableAndDownloadableTextField';
 import Box from 'src/components/core/Box';
 
 interface Props {
@@ -47,14 +47,16 @@ export const SecretTokenDialog: React.FC<CombinedProps> = (props) => {
         spacingTop={8}
         warning
         className={classes.noticeText}
-        text={`For security purposes, we can only display your ${
+        text={`${
+          objectStorageKey ? '' : 'Your keys have been generated.'
+        } For security purposes, we can only display your ${
           objectStorageKey ? 'secret key' : title.toLowerCase()
-        } once, after which it can't be recovered. Be sure to keep it in a safe place.`}
+        } once, after which it can\u{2019}t be recovered. Be sure to keep it in a safe place.`}
       />
       {objectStorageKey ? (
         <>
           <Box marginBottom="16px">
-            <CopyableTextField
+            <CopyableAndDownloadableTextField
               expand
               label={'Access Key'}
               value={objectStorageKey.access_key || ''}
@@ -62,7 +64,7 @@ export const SecretTokenDialog: React.FC<CombinedProps> = (props) => {
             />
           </Box>
           <Box marginBottom="16px">
-            <CopyableTextField
+            <CopyableAndDownloadableTextField
               expand
               label={'Secret Key'}
               value={objectStorageKey.secret_key || ''}
@@ -72,7 +74,7 @@ export const SecretTokenDialog: React.FC<CombinedProps> = (props) => {
         </>
       ) : value ? (
         <Box marginBottom="16px">
-          <CopyableTextField
+          <CopyableAndDownloadableTextField
             expand
             label={title}
             value={value || ''}

--- a/packages/manager/src/features/Profile/SecretTokenDialog/SecretTokenDialog.tsx
+++ b/packages/manager/src/features/Profile/SecretTokenDialog/SecretTokenDialog.tsx
@@ -32,14 +32,6 @@ type CombinedProps = Props;
 const renderActions = (onClose: () => void) => (
   <ActionsPanel>
     <Button
-      buttonType="secondary"
-      onClick={onClose}
-      data-qa-cancel
-      data-testid="dialog-cancel"
-    >
-      Close
-    </Button>
-    <Button
       buttonType="primary"
       onClick={onClose}
       data-qa-confirm


### PR DESCRIPTION
## Description

Adds the ability to download the keys for a token from the text field that displays it.

## How to test

1. Navigate to /profile/tokens
2. Create a new Personal Access Token
3. Ensure that the `TextFields` displaying the keys have both a download and copy `Tooltip` at the end of the `TextField`
4. Click the download `Tooltip`
5. Ensure the file downloaded
    - Contains the string displayed in the `TextField`
    - Is named the label of the `TextField` in snake case
