### PR TITLE
M3-5722: Image upload max size bug on Linux

### DIFF
--- a/packages/manager/src/components/FileUploader/FileUploader.tsx
+++ b/packages/manager/src/components/FileUploader/FileUploader.tsx
@@ -187,7 +187,6 @@ const FileUploader: React.FC<CombinedProps> = (props) => {
 
   // This function will be called when the user drops non-.gz files, more than one file at a time, or files that are over the max size.
   const onDropRejected = (files: FileRejection[]) => {
-    console.log(files);
     const wrongFileType = !files[0].file.type.match(/gzip/gi);
     const fileTypeErrorMessage =
       'Only raw disk images (.img) compressed using gzip (.gz) can be uploaded.';

--- a/packages/manager/src/components/FileUploader/FileUploader.tsx
+++ b/packages/manager/src/components/FileUploader/FileUploader.tsx
@@ -187,6 +187,7 @@ const FileUploader: React.FC<CombinedProps> = (props) => {
 
   // This function will be called when the user drops non-.gz files, more than one file at a time, or files that are over the max size.
   const onDropRejected = (files: FileRejection[]) => {
+    console.log(files);
     const wrongFileType = !files[0].file.type.match(/gzip/gi);
     const fileTypeErrorMessage =
       'Only raw disk images (.img) compressed using gzip (.gz) can be uploaded.';

--- a/packages/manager/src/components/FileUploader/FileUploader.tsx
+++ b/packages/manager/src/components/FileUploader/FileUploader.tsx
@@ -374,7 +374,7 @@ const FileUploader: React.FC<CombinedProps> = (props) => {
     disabled: dropzoneDisabled || uploadInProgressOrFinished, // disabled when dropzoneDisabled === true, an upload is in progress, or if an upload finished.
     noClick: true,
     noKeyboard: true,
-    accept: 'application/x-gzip', // Uploaded files must be compressed using gzip.
+    accept: ['application/x-gzip', 'application/gzip'], // Uploaded files must be compressed using gzip.
     maxFiles: 1,
     maxSize: MAX_FILE_SIZE_IN_BYTES,
   });


### PR DESCRIPTION
## Description
We've received intermittent reports since last year about some users on Linux attempting to upload properly-zipped Images under 5GB who received error messages stating that the file was in excess of 5GB.

I replicated this issue on Ubuntu 22.04. First I added a `console.log()` in `onDropRejected()` to see what was going on; the error for a valid file on the `File` object stated that it was not an `x-gzip` file. The `type` property on the `File` object was listed as `application/gzip`, not the `application/x-gzip` that we explicitly accepted. However, `x-gzip` and `gzip` are functionally equivalent, so we should accept both.

In the code, the reason why the max size error was showing erroneously is because of the logic in `onDropRejected()`: `wrongFileType` was false because "gzip" was being matched and `moreThanOneFile` was false, so the only error left was the file size one.

## How to test
On a Linux machine or VM, try uploading an Image file that meets the size and type parameters laid out on the "Upload Image" page. You should not see an error.

Additionally, ensure that the upload functionality has not been adversely impacted on MacOS and works as it did before.