### PR TITLE
M3-5180: Refactor Domains Landing to begin React Query integration

### DIFF
--- a/packages/manager/src/features/Domains/DisableDomainDialog.tsx
+++ b/packages/manager/src/features/Domains/DisableDomainDialog.tsx
@@ -1,15 +1,12 @@
-import { Domain, UpdateDomainPayload } from '@linode/api-v4/lib/domains';
 import { APIError } from '@linode/api-v4/lib/types';
 import * as React from 'react';
 import ActionPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import Dialog from 'src/components/ConfirmationDialog';
+import { useUpdateDomainMutation } from 'src/queries/domains';
 import { sendDomainStatusChangeEvent } from 'src/utilities/ga';
 
 interface Props {
-  updateDomain: (
-    payload: UpdateDomainPayload & { domainId: number }
-  ) => Promise<Domain>;
   selectedDomainID?: number;
   selectedDomainLabel: string;
   closeDialog: () => void;
@@ -17,11 +14,10 @@ interface Props {
   errors?: APIError[];
 }
 
-type CombinedProps = Props;
-
-const DisableDomainDialog: React.FC<CombinedProps> = (props) => {
+const DisableDomainDialog: React.FC<Props> = (props) => {
   const [isSubmitting, setSubmitting] = React.useState<boolean>(false);
   const [errors, setErrors] = React.useState<APIError[] | undefined>(undefined);
+  const { mutateAsync: updateDomain } = useUpdateDomainMutation();
 
   React.useEffect(() => {
     if (props.open) {
@@ -40,11 +36,10 @@ const DisableDomainDialog: React.FC<CombinedProps> = (props) => {
 
     setSubmitting(true);
 
-    props
-      .updateDomain({
-        domainId: props.selectedDomainID,
-        status: 'disabled',
-      })
+    updateDomain({
+      id: props.selectedDomainID,
+      status: 'disabled',
+    })
       .then(() => {
         setSubmitting(false);
         sendDomainStatusChangeEvent('Disable');

--- a/packages/manager/src/features/Domains/DomainTableRow.tsx
+++ b/packages/manager/src/features/Domains/DomainTableRow.tsx
@@ -43,7 +43,6 @@ const DomainTableRow: React.FC<CombinedProps> = (props) => {
     <TableRow
       key={id}
       data-qa-domain-cell={domain}
-      className="fade-in-table"
       ariaLabel={`Domain ${domain}`}
     >
       <TableCell data-qa-domain-label>

--- a/packages/manager/src/features/Domains/DomainsLanding.test.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.test.tsx
@@ -1,81 +1,10 @@
-import { render, waitFor } from '@testing-library/react';
 import * as React from 'react';
-import { domainFactory } from 'src/factories/domain';
-import { reactRouterProps } from 'src/__data__/reactRouterProps';
-import {
-  mockMatchMedia,
-  wrapWithTheme,
-  assertOrder,
-} from 'src/utilities/testHelpers';
-import {
-  CombinedProps,
-  DomainsLanding,
-  getReduxCopyOfDomains,
-} from './DomainsLanding';
-const domains = domainFactory.buildList(5);
-
-const props: CombinedProps = {
-  domainsData: domains,
-  domainsLoading: false,
-  domainsError: {},
-  domainsLastUpdated: 0,
-  domainsResults: domains.length,
-  isRestrictedUser: false,
-  isLargeAccount: false,
-  howManyLinodesOnAccount: 0,
-  shouldGroupDomains: false,
-  createDomain: jest.fn(),
-  updateDomain: jest.fn(),
-  deleteDomain: jest.fn(),
-  getAllDomains: jest.fn(),
-  getDomainsPage: jest.fn(),
-  upsertDomain: jest.fn(),
-  linodesLoading: false,
-  openForCloning: jest.fn(),
-  openForCreating: jest.fn(),
-  openForEditing: jest.fn(),
-  enqueueSnackbar: jest.fn(),
-  closeSnackbar: jest.fn(),
-  domainsByID: {},
-  upsertMultipleDomains: jest.fn(),
-  ...reactRouterProps,
-};
-
-beforeAll(() => mockMatchMedia());
+import { DomainsLanding } from './DomainsLanding';
+import { renderWithTheme } from 'src/utilities/testHelpers';
 
 describe('Domains Landing', () => {
-  it('should render a notice when there are no Linodes but at least 1 domain', () => {
-    const { getByText } = render(wrapWithTheme(<DomainsLanding {...props} />));
-    expect(getByText(/not being served/));
-  });
-
-  it('should sort by Domain name ascending by default', async () => {
-    const { container } = render(wrapWithTheme(<DomainsLanding {...props} />));
-
-    await waitFor(() =>
-      assertOrder(container, '[data-qa-domain-label]', [
-        'domain-0',
-        'domain-1',
-        'domain-2',
-        'domain-3',
-        'domain-4',
-      ])
-    );
-  });
-});
-
-describe('getReduxCopyOfDomains fn', () => {
-  it('returns corresponding domains', () => {
-    const domain1 = domainFactory.build({ id: 1 });
-    const domain2 = domainFactory.build({ id: 2 });
-    const domain3 = domainFactory.build({ id: 3 });
-
-    expect(
-      getReduxCopyOfDomains([domain1, domain2], {
-        1: domain1,
-        2: domain2,
-        3: domain3,
-      })
-    ).toEqual([domain1, domain2]);
+  it('should initially render a loading state', () => {
+    const { getByTestId } = renderWithTheme(<DomainsLanding />);
+    expect(getByTestId('circle-progress')).toBeInTheDocument();
   });
 });

--- a/packages/manager/src/features/Domains/DomainsLanding.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.tsx
@@ -1,49 +1,47 @@
-import { Domain, getDomains } from '@linode/api-v4/lib/domains';
-import { withSnackbar, WithSnackbarProps } from 'notistack';
-import { pathOr } from 'ramda';
 import * as React from 'react';
-import { connect, MapStateToProps } from 'react-redux';
-import { RouteComponentProps } from 'react-router-dom';
-import { compose } from 'recompose';
+import { Domain } from '@linode/api-v4/lib/domains';
+import { useSnackbar } from 'notistack';
+import { useDispatch } from 'react-redux';
+import { useHistory, useLocation } from 'react-router-dom';
 import DomainIcon from 'src/assets/icons/entityIcons/domain.svg';
 import Button from 'src/components/Button';
 import CircleProgress from 'src/components/CircleProgress';
-import {
-  makeStyles,
-  Theme,
-  useMediaQuery,
-  useTheme,
-} from 'src/components/core/styles';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import DeletionDialog from 'src/components/DeletionDialog';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
-import { EntityTableRow, HeaderCell } from 'src/components/EntityTable';
-import EntityTable from 'src/components/EntityTable';
 import ErrorState from 'src/components/ErrorState';
 import LandingHeader from 'src/components/LandingHeader';
 import Link from 'src/components/Link';
 import Notice from 'src/components/Notice';
-import { Order } from 'src/components/Pagey';
 import Placeholder from 'src/components/Placeholder';
-import PreferenceToggle, { ToggleProps } from 'src/components/PreferenceToggle';
-import domainsContainer, {
-  Props as DomainProps,
-} from 'src/containers/domains.container';
-import { ApplicationState } from 'src/store';
 import {
-  openForCloning,
-  openForCreating,
+  openForCloning as _openForCloning,
   openForEditing as _openForEditing,
-  Origin as DomainDrawerOrigin,
 } from 'src/store/domainDrawer';
-import { upsertMultipleDomains } from 'src/store/domains/domains.actions';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
-import { sendGroupByTagEnabledEvent } from 'src/utilities/ga';
 import DisableDomainDialog from './DisableDomainDialog';
 import { Handlers as DomainHandlers } from './DomainActionMenu';
 import DomainBanner from './DomainBanner';
 import DomainRow from './DomainTableRow';
 import DomainZoneImportDrawer from './DomainZoneImportDrawer';
+import { useProfile } from 'src/queries/profile';
+import { useLinodesQuery } from 'src/queries/linodes';
+import {
+  useDeleteDomainMutation,
+  useDomainsQuery,
+  useUpdateDomainMutation,
+} from 'src/queries/domains';
+import usePagination from 'src/hooks/usePagination';
+import { useOrder } from 'src/hooks/useOrder';
+import Table from 'src/components/Table/Table';
+import TableHead from 'src/components/core/TableHead';
+import TableRow from 'src/components/TableRow/TableRow';
+import TableBody from 'src/components/core/TableBody';
+import TableSortCell from 'src/components/TableSortCell/TableSortCell';
+import TableCell from 'src/components/core/TableCell';
+import PaginationFooter from 'src/components/PaginationFooter/PaginationFooter';
+import Hidden from 'src/components/core/Hidden';
 
 const DOMAIN_CREATE_ROUTE = '/domains/create';
 
@@ -63,8 +61,6 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 interface Props {
-  // Purely so we can force a preference to get the unit tests to pass
-  shouldGroupDomains?: boolean;
   // Since secondary Domains do not have a Detail page, we allow the consumer to
   // render this component with the "Edit Domain" drawer already opened.
   domainForEditing?: {
@@ -73,70 +69,48 @@ interface Props {
   };
 }
 
-const initialOrder = { order: 'asc' as Order, orderBy: 'domain' };
+const preferenceKey = 'domains';
 
-export type CombinedProps = DispatchProps &
-  DomainProps &
-  Props &
-  RouteComponentProps<{}, any, any> &
-  StateProps &
-  WithSnackbarProps;
-
-export const getHeaders = (
-  matchesXsDown: boolean,
-  matchesSmDown: boolean,
-  matchesMdDown: boolean
-): HeaderCell[] =>
-  [
-    {
-      label: 'Domain',
-      dataColumn: 'domain',
-      sortable: true,
-      widthPercent: matchesXsDown ? 50 : matchesSmDown ? 35 : 30,
-    },
-    {
-      label: 'Status',
-      dataColumn: 'status',
-      sortable: true,
-      widthPercent: matchesXsDown ? 25 : 12,
-    },
-    {
-      label: 'Type',
-      dataColumn: 'type',
-      sortable: true,
-      widthPercent: 12,
-      hideOnMobile: true,
-    },
-    {
-      label: 'Last Modified',
-      dataColumn: 'updated',
-      sortable: true,
-      widthPercent: matchesSmDown ? 25 : matchesMdDown ? 20 : 15,
-      hideOnMobile: true,
-    },
-  ].filter(Boolean) as HeaderCell[];
-
-export const DomainsLanding: React.FC<CombinedProps> = (props) => {
+export const DomainsLanding: React.FC<Props> = (props) => {
   const classes = useStyles();
-  const theme = useTheme<Theme>();
-  const matchesXsDown = useMediaQuery(theme.breakpoints.down('xs'));
-  const matchesSmDown = useMediaQuery(theme.breakpoints.down('sm'));
-  const matchesMdDown = useMediaQuery(theme.breakpoints.down('md'));
+  const history = useHistory();
+  const location = useLocation<{ recordError?: string }>();
 
-  const {
-    domainForEditing,
-    domainsLastUpdated,
-    getAllDomains,
-    openForEditing,
-    domainsData,
-    domainsLoading,
-    domainsError,
-    deleteDomain,
-    howManyLinodesOnAccount,
-    linodesLoading,
-    isRestrictedUser,
-    isLargeAccount,
-  } = props;
+  const { enqueueSnackbar } = useSnackbar();
+  const { data: profile } = useProfile();
+
+  const pagination = usePagination(1, preferenceKey);
+
+  const { order, orderBy, handleOrderChange } = useOrder(
+    {
+      orderBy: 'domain',
+      order: 'asc',
+    },
+    `${preferenceKey}-order`
+  );
+
+  const filter = {
+    ['+order_by']: orderBy,
+    ['+order']: order,
+  };
+
+  const { data: domains, error, isLoading } = useDomainsQuery(
+    {
+      page: pagination.page,
+      page_size: pagination.pageSize,
+    },
+    filter
+  );
+
+  const shouldCheckLinodeCount = domains !== undefined && domains.results > 0;
+
+  const { data: linodes } = useLinodesQuery({}, {}, shouldCheckLinodeCount);
+
+  const isRestrictedUser = Boolean(profile?.restricted);
+
+  const { domainForEditing } = props;
+
+  const dispatch = useDispatch();
 
   const [selectedDomainLabel, setSelectedDomainLabel] = React.useState<string>(
     ''
@@ -160,26 +134,28 @@ export const DomainsLanding: React.FC<CombinedProps> = (props) => {
     false
   );
 
+  const { mutateAsync: deleteDomain } = useDeleteDomainMutation(
+    selectedDomainID ?? 0
+  );
+
+  const { mutateAsync: updateDomain } = useUpdateDomainMutation();
+
+  const openForEditing = (domain: string, id: number) =>
+    dispatch(_openForEditing(domain, id));
+
+  const openForCloning = (domain: string, id: number) =>
+    dispatch(_openForCloning(domain, id));
+
   React.useEffect(() => {
     // Open the "Edit Domain" drawer if so specified by this component's props.
     if (domainForEditing) {
       const { domainId, domainLabel } = domainForEditing;
-      openForEditing(domainLabel, domainId);
+      dispatch(_openForEditing(domainLabel, domainId));
     }
-
-    if (!isLargeAccount && domainsLastUpdated === 0) {
-      getAllDomains();
-    }
-  }, [
-    domainForEditing,
-    domainsLastUpdated,
-    getAllDomains,
-    isLargeAccount,
-    openForEditing,
-  ]);
+  }, [dispatch, domainForEditing]);
 
   const navigateToCreate = () => {
-    props.history.push(DOMAIN_CREATE_ROUTE);
+    history.push(DOMAIN_CREATE_ROUTE);
   };
 
   const openImportZoneDrawer = () => setImportDrawerOpen(true);
@@ -190,10 +166,8 @@ export const DomainsLanding: React.FC<CombinedProps> = (props) => {
   };
 
   const handleSuccess = (domain: Domain) => {
-    props.upsertDomain(domain);
-
     if (domain.id) {
-      return props.history.push(`/domains/${domain.id}`);
+      return history.push(`/domains/${domain.id}`);
     }
   };
 
@@ -212,22 +186,17 @@ export const DomainsLanding: React.FC<CombinedProps> = (props) => {
     setRemoveDialogLoading(true);
     setRemoveDialogError(undefined);
 
-    if (selectedDomainID) {
-      deleteDomain({ domainId: selectedDomainID })
-        .then(() => {
-          closeRemoveDialog();
-          setRemoveDialogLoading(false);
-        })
-        .catch((e) => {
-          setRemoveDialogLoading(false);
-          setRemoveDialogError(
-            getAPIErrorOrDefault(e, 'Error deleting Domain.')[0].reason
-          );
-        });
-    } else {
-      setRemoveDialogLoading(false);
-      setRemoveDialogError('Error deleting Domain.');
-    }
+    deleteDomain()
+      .then(() => {
+        closeRemoveDialog();
+        setRemoveDialogLoading(false);
+      })
+      .catch((e) => {
+        setRemoveDialogLoading(false);
+        setRemoveDialogError(
+          getAPIErrorOrDefault(e, 'Error deleting Domain.')[0].reason
+        );
+      });
   };
 
   const handleClickEnableOrDisableDomain = (
@@ -236,22 +205,18 @@ export const DomainsLanding: React.FC<CombinedProps> = (props) => {
     domainId: number
   ) => {
     if (action === 'enable') {
-      props
-        .updateDomain({
-          domainId,
-          status: 'active',
-        })
-        .catch((e) => {
-          return props.enqueueSnackbar(
-            getAPIErrorOrDefault(
-              e,
-              'There was an issue enabling your domain'
-            )[0].reason,
-            {
-              variant: 'error',
-            }
-          );
-        });
+      updateDomain({
+        id: domainId,
+        status: 'active',
+      }).catch((e) => {
+        return enqueueSnackbar(
+          getAPIErrorOrDefault(e, 'There was an issue enabling your domain')[0]
+            .reason,
+          {
+            variant: 'error',
+          }
+        );
+      });
     } else {
       setSelectedDomainLabel(domain);
       setselectedDomainID(domainId);
@@ -260,49 +225,54 @@ export const DomainsLanding: React.FC<CombinedProps> = (props) => {
   };
 
   const handlers: DomainHandlers = {
-    onClone: props.openForCloning,
-    onEdit: props.openForEditing,
+    onClone: openForCloning,
+    onEdit: openForEditing,
     onRemove: openRemoveDialog,
     onDisableOrEnable: handleClickEnableOrDisableDomain,
   };
 
-  const domainRow: EntityTableRow<Domain> = {
-    Component: DomainRow,
-    data: domainsData ?? [],
-    request: isLargeAccount ? getDomains : undefined,
-    handlers,
-    loading: domainsLoading,
-    error: domainsError.read,
-    lastUpdated: domainsLastUpdated,
-  };
-
-  if (domainsLoading) {
-    return <RenderLoading />;
+  if (isLoading) {
+    return <CircleProgress />;
   }
 
-  if (domainsError.read) {
-    return <RenderError />;
+  if (error) {
+    return (
+      <ErrorState errorText="There was an error retrieving your domains. Please reload and try again." />
+    );
   }
 
-  if (!isLargeAccount && domainsData?.length === 0) {
-    /**
-     * We don't know whether or not a large account is empty or not
-     * until Pagey has made its first request, and putting this
-     * empty state inside of Pagey would be weird/difficult.
-     *
-     * The other option is to make an initial request when this
-     * component mounts, which Pagey would ignore.
-     *
-     * I think a slightly different empty state for large accounts is
-     * the best trade-off until we have the thing-count endpoint,
-     * but open to persuasion on this.
-     */
+  if (domains?.results === 0) {
     return (
       <>
-        <RenderEmpty
-          onCreateDomain={navigateToCreate}
-          onImportZone={openImportZoneDrawer}
-        />
+        <DocumentTitleSegment segment="Domains" />
+        <Placeholder
+          title="Domains"
+          isEntity
+          icon={DomainIcon}
+          buttonProps={[
+            {
+              onClick: navigateToCreate,
+              children: 'Create Domain',
+            },
+            {
+              onClick: openImportZoneDrawer,
+              children: 'Import a Zone',
+            },
+          ]}
+        >
+          <Typography variant="subtitle1">
+            Create a Domain, add Domain records, import zones and domains.
+          </Typography>
+          <Typography variant="subtitle1">
+            <Link to="https://www.linode.com/docs/platform/manager/dns-manager-new-manager/">
+              Get help managing your Domains
+            </Link>
+            &nbsp;or&nbsp;
+            <Link to="https://www.linode.com/docs/">
+              visit our guides and tutorials.
+            </Link>
+          </Typography>
+        </Placeholder>
         <DomainZoneImportDrawer
           open={importDrawerOpen}
           onClose={closeImportZoneDrawer}
@@ -325,79 +295,92 @@ export const DomainsLanding: React.FC<CombinedProps> = (props) => {
    */
   const shouldShowBanner =
     !isRestrictedUser &&
-    !linodesLoading &&
-    howManyLinodesOnAccount === 0 &&
-    domainsData &&
-    domainsData.length > 0;
+    linodes?.results === 0 &&
+    domains &&
+    domains.results > 0;
 
   return (
     <>
       <DocumentTitleSegment segment="Domains" />
       <DomainBanner hidden={!shouldShowBanner} />
-      {props.location.state?.recordError && (
-        <Notice error text={props.location.state.recordError} />
+      {location.state?.recordError && (
+        <Notice error text={location.state.recordError} />
       )}
-      <PreferenceToggle<boolean>
-        preferenceKey="domains_group_by_tag"
-        preferenceOptions={[false, true]}
-        localStorageKey="GROUP_DOMAINS"
-        toggleCallbackFnDebounced={toggleDomainsGroupBy}
-        /** again, this value prop should be undefined - purely for the unit test's sake */
-        value={props.shouldGroupDomains}
-      >
-        {({
-          preference: domainsAreGrouped,
-          togglePreference: toggleGroupDomains,
-        }: ToggleProps<boolean>) => {
-          return (
-            <div className={classes.root}>
-              <LandingHeader
-                title="Domains"
-                extraActions={
-                  <Button
-                    className={classes.importButton}
-                    onClick={openImportZoneDrawer}
-                    buttonType="secondary"
-                  >
-                    Import a Zone
-                  </Button>
-                }
-                entity="Domain"
-                onAddNew={navigateToCreate}
-                docsLink="https://www.linode.com/docs/platform/manager/dns-manager/"
-              />
-              <EntityTable
-                entity="domain"
-                headers={getHeaders(
-                  matchesXsDown,
-                  matchesSmDown,
-                  matchesMdDown
-                )}
-                row={domainRow}
-                initialOrder={initialOrder}
-                toggleGroupByTag={toggleGroupDomains}
-                isGroupedByTag={domainsAreGrouped}
-                isLargeAccount={isLargeAccount}
-                normalizeData={(pageyData: Domain[]) => {
-                  // Use Redux copies of each Domain, since Redux is more up-to-date.
-                  return getReduxCopyOfDomains(pageyData, props.domainsByID);
-                }}
-                // Persist Pagey data to Redux.
-                persistData={(data: Domain[]) => {
-                  props.upsertMultipleDomains(data);
-                }}
-              />
-            </div>
-          );
-        }}
-      </PreferenceToggle>
+      <LandingHeader
+        title="Domains"
+        extraActions={
+          <Button
+            className={classes.importButton}
+            onClick={openImportZoneDrawer}
+            buttonType="secondary"
+          >
+            Import a Zone
+          </Button>
+        }
+        entity="Domain"
+        onAddNew={navigateToCreate}
+        docsLink="https://www.linode.com/docs/platform/manager/dns-manager/"
+      />
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableSortCell
+              active={orderBy === 'domain'}
+              direction={order}
+              label="domain"
+              handleClick={handleOrderChange}
+            >
+              Domain
+            </TableSortCell>
+            <TableSortCell
+              active={orderBy === 'status'}
+              direction={order}
+              label="status"
+              handleClick={handleOrderChange}
+            >
+              Status
+            </TableSortCell>
+            <Hidden xsDown>
+              <TableSortCell
+                active={orderBy === 'type'}
+                direction={order}
+                label="type"
+                handleClick={handleOrderChange}
+              >
+                Type
+              </TableSortCell>
+              <TableSortCell
+                active={orderBy === 'updated'}
+                direction={order}
+                label="updated"
+                handleClick={handleOrderChange}
+              >
+                Last Modified
+              </TableSortCell>
+            </Hidden>
+            <TableCell></TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {domains?.data.map((domain: Domain) => (
+            <DomainRow key={domain.id} {...domain} {...handlers} />
+          ))}
+        </TableBody>
+      </Table>
+      <PaginationFooter
+        count={domains?.results || 0}
+        handlePageChange={pagination.handlePageChange}
+        handleSizeChange={pagination.handlePageSizeChange}
+        page={pagination.page}
+        pageSize={pagination.pageSize}
+        eventCategory="Domains Table"
+      />
       <DomainZoneImportDrawer
         open={importDrawerOpen}
         onClose={closeImportZoneDrawer}
         onSuccess={handleSuccess}
       />
       <DisableDomainDialog
-        updateDomain={props.updateDomain}
         selectedDomainID={selectedDomainID}
         selectedDomainLabel={selectedDomainLabel}
         closeDialog={() => setDisableDialogOpen(false)}
@@ -417,114 +400,4 @@ export const DomainsLanding: React.FC<CombinedProps> = (props) => {
   );
 };
 
-const RenderLoading: React.FC<{}> = () => {
-  return <CircleProgress />;
-};
-
-const RenderError: React.FC<{}> = () => {
-  return (
-    <ErrorState errorText="There was an error retrieving your domains. Please reload and try again." />
-  );
-};
-
-const RenderEmpty: React.FC<{
-  onCreateDomain: () => void;
-  onImportZone: () => void;
-}> = (props) => {
-  return (
-    <>
-      <DocumentTitleSegment segment="Domains" />
-      <Placeholder
-        title="Domains"
-        isEntity
-        icon={DomainIcon}
-        buttonProps={[
-          {
-            onClick: props.onCreateDomain,
-            children: 'Create Domain',
-          },
-          {
-            onClick: props.onImportZone,
-            children: 'Import a Zone',
-          },
-        ]}
-      >
-        <Typography variant="subtitle1">
-          Create a Domain, add Domain records, import zones and domains.
-        </Typography>
-        <Typography variant="subtitle1">
-          <Link to="https://www.linode.com/docs/platform/manager/dns-manager-new-manager/">
-            Get help managing your Domains
-          </Link>
-          &nbsp;or&nbsp;
-          <Link to="https://www.linode.com/docs/">
-            visit our guides and tutorials.
-          </Link>
-        </Typography>
-      </Placeholder>
-    </>
-  );
-};
-
-const eventCategory = `domains landing`;
-
-const toggleDomainsGroupBy = (checked: boolean) =>
-  sendGroupByTagEnabledEvent(eventCategory, checked);
-
-interface DispatchProps {
-  openForCloning: (domain: string, id: number) => void;
-  openForEditing: (domain: string, id: number) => void;
-  openForCreating: (origin: DomainDrawerOrigin) => void;
-  upsertMultipleDomains: (domains: Domain[]) => void;
-}
-
-interface StateProps {
-  howManyLinodesOnAccount: number;
-  linodesLoading: boolean;
-  isRestrictedUser: boolean;
-  isLargeAccount: boolean;
-  domainsByID: Record<string, Domain>;
-}
-
-const mapStateToProps: MapStateToProps<StateProps, {}, ApplicationState> = (
-  state
-) => ({
-  howManyLinodesOnAccount: state.__resources.linodes.results,
-  linodesLoading: pathOr(false, ['linodes', 'loading'], state.__resources),
-  isRestrictedUser: pathOr(
-    true,
-    ['__resources', 'profile', 'data', 'restricted'],
-    state
-  ),
-  isLargeAccount: state.__resources.accountManagement.isLargeAccount,
-  domainsByID: state.__resources.domains.itemsById,
-});
-
-export const connected = connect(mapStateToProps, {
-  openForCreating,
-  openForCloning,
-  openForEditing: _openForEditing,
-  upsertMultipleDomains,
-});
-
-export default compose<CombinedProps, Props>(
-  domainsContainer(),
-  connected,
-  withSnackbar
-)(DomainsLanding);
-
-// Given a list of "baseDomains" (requested from the API via Pagey) and a record of Domains
-// from Redux, return the Redux copy of each base Domain. This is useful because the Redux
-// copy of the Domain may have updates the original data from Pagey doesn't.
-export const getReduxCopyOfDomains = (
-  baseDomains: Domain[],
-  reduxDomains: Record<string, Domain>
-) => {
-  return baseDomains.reduce((acc, thisDomain) => {
-    const thisReduxDomain = reduxDomains[thisDomain.id];
-    if (thisReduxDomain) {
-      return [...acc, thisReduxDomain];
-    }
-    return acc;
-  }, []);
-};
+export default DomainsLanding;

--- a/packages/manager/src/features/EntityTransfers/EntityTransfersCreate/LinodeTransferTable.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersCreate/LinodeTransferTable.tsx
@@ -9,7 +9,7 @@ import TableContentWrapper from 'src/components/TableContentWrapper';
 import { useTypes } from 'src/hooks/useTypes';
 import { Entity, TransferEntity } from './transferReducer';
 import TransferTable from './TransferTable';
-import { useLinodesQuery } from 'src/queries/linodes';
+import { useLinodesByIdQuery } from 'src/queries/linodes';
 import { usePagination } from 'src/hooks/usePagination';
 
 interface Props {
@@ -25,7 +25,13 @@ export const LinodeTransferTable: React.FC<Props> = (props) => {
 
   const pagination = usePagination();
 
-  const { data, isError, isLoading, error, dataUpdatedAt } = useLinodesQuery(
+  const {
+    data,
+    isError,
+    isLoading,
+    error,
+    dataUpdatedAt,
+  } = useLinodesByIdQuery(
     {
       page: pagination.page,
       page_size: pagination.pageSize,

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/IPTransfer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/IPTransfer.tsx
@@ -26,7 +26,7 @@ import Notice from 'src/components/Notice';
 import usePrevious from 'src/hooks/usePrevious';
 import { ipv6RangeQueryKey } from 'src/queries/networking';
 import { queryClient } from 'src/queries/base';
-import { useLinodesQuery } from 'src/queries/linodes';
+import { useLinodesByIdQuery } from 'src/queries/linodes';
 import { useIpv6RangesQuery } from 'src/queries/networking';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { debounce } from 'throttle-debounce';
@@ -167,7 +167,7 @@ const LinodeNetworkingIPTransferPanel: React.FC<CombinedProps> = (props) => {
     })
   ).current;
 
-  const { data, isLoading, error: linodesError } = useLinodesQuery(
+  const { data, isLoading, error: linodesError } = useLinodesByIdQuery(
     {},
     {
       region: linodeRegion,

--- a/packages/manager/src/queries/domains.ts
+++ b/packages/manager/src/queries/domains.ts
@@ -1,0 +1,77 @@
+import {
+  createDomain,
+  CreateDomainPayload,
+  deleteDomain,
+  Domain,
+  getDomains,
+  updateDomain,
+  UpdateDomainPayload,
+} from '@linode/api-v4/lib/domains';
+import { APIError, ResourcePage } from '@linode/api-v4/lib/types';
+import { useMutation, useQuery } from 'react-query';
+import { queryClient } from './base';
+
+export const queryKey = 'domains';
+
+export const useDomainsQuery = (params: any, filter: any) =>
+  useQuery<ResourcePage<Domain>, APIError[]>(
+    [`${queryKey}-list`, params, filter],
+    () => getDomains(params, filter),
+    { keepPreviousData: true }
+  );
+
+export const useCreateDomainMutation = () =>
+  useMutation<Domain, APIError[], CreateDomainPayload>(createDomain, {
+    onSuccess: () => {
+      queryClient.invalidateQueries(`${queryKey}-list`);
+    },
+  });
+
+export const useDeleteDomainMutation = (id: number) =>
+  useMutation<{}, APIError[]>(() => deleteDomain(id), {
+    onSuccess: () => {
+      queryClient.invalidateQueries(`${queryKey}-list`);
+    },
+  });
+
+export const useUpdateDomainMutation = () =>
+  useMutation<Domain, APIError[], { id: number } & UpdateDomainPayload>(
+    (data) => {
+      const { id, ...rest } = data;
+      return updateDomain(id, rest);
+    },
+    {
+      onSuccess: (data, vars) => {
+        updatePaginatedDomainsStore(vars.id, data);
+      },
+    }
+  );
+
+// @TODO: make this generic
+const updatePaginatedDomainsStore = (id: number, newData: Partial<Domain>) => {
+  queryClient.setQueriesData<ResourcePage<Domain> | undefined>(
+    `${queryKey}-list`,
+    (oldData) => {
+      if (oldData === undefined) {
+        return undefined;
+      }
+
+      const domainToUpdateIndex = oldData.data.findIndex(
+        (domain) => domain.id === id
+      );
+
+      const isDomainOnPage = domainToUpdateIndex !== -1;
+
+      if (!isDomainOnPage) {
+        return oldData;
+      }
+
+      oldData.data[domainToUpdateIndex] = {
+        ...oldData.data[domainToUpdateIndex],
+        ...newData,
+      };
+
+      return oldData;
+    }
+  );
+};

--- a/packages/manager/src/queries/linodes.ts
+++ b/packages/manager/src/queries/linodes.ts
@@ -1,8 +1,10 @@
 import { NetworkTransfer } from '@linode/api-v4/lib/account/types';
-import { APIError } from '@linode/api-v4/lib/types';
+import { APIError, ResourcePage } from '@linode/api-v4/lib/types';
 import { useQuery } from 'react-query';
 import { getAll } from 'src/utilities/getAll';
 import { listToItemsByID, queryPresets } from './base';
+import { parseAPIDate } from 'src/utilities/date';
+import { DateTime } from 'luxon';
 import {
   Linode,
   getLinodes,
@@ -11,8 +13,6 @@ import {
   getLinodeTransferByDate,
   getLinodeStats,
 } from '@linode/api-v4/lib/linodes';
-import { parseAPIDate } from 'src/utilities/date';
-import { DateTime } from 'luxon';
 
 export const STATS_NOT_READY_API_MESSAGE =
   'Stats are unavailable at this time.';
@@ -27,6 +27,18 @@ interface LinodeData {
 }
 
 export const useLinodesQuery = (
+  params: any = {},
+  filter: any = {},
+  enabled: boolean = true
+) => {
+  return useQuery<ResourcePage<Linode>, APIError[]>(
+    [queryKey, params, filter],
+    () => getLinodes(params, filter),
+    { ...queryPresets.longLived, enabled }
+  );
+};
+
+export const useLinodesByIdQuery = (
   params: any = {},
   filter: any = {},
   enabled: boolean = true


### PR DESCRIPTION
## Description 📝

- Refactors Domains Landing and associated files to integrate React Query along with new patterns
- API paginates the Domains Landing table for all users (not just large accounts)

## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**

- Testing functionality of the Domains landing page
  - `Create`, `Delete`, `Enable`, and `Disable` should work like production

**How do I run relevant unit tests?**

`yarn test Domain`

## Known Issues (that will be addressed in follow up PRs)

> **Note**: Most of these are because we need to update the React Query store instead of the Redux store in many places

- Changes when editing Domains are not reflected on the landing page 
- Cloning a Domain is not reflected in the landing page
