### PR TITLE
M3-5305: Support Ticket Table Refactor

### DIFF
--- a/packages/manager/src/features/Support/SupportTickets/TicketRow.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/TicketRow.tsx
@@ -60,10 +60,10 @@ const TicketRow: React.FC<Props> = ({ ticket }) => {
         <TableCell data-qa-support-date>
           <DateTimeDisplay value={ticket.opened} />
         </TableCell>
-        <TableCell data-qa-support-updated>
-          <DateTimeDisplay value={ticket.updated} />
-        </TableCell>
       </Hidden>
+      <TableCell data-qa-support-updated>
+        <DateTimeDisplay value={ticket.updated} />
+      </TableCell>
       <Hidden smDown>
         <TableCell data-qa-support-updated-by>{ticket.updated_by}</TableCell>
       </Hidden>

--- a/packages/manager/src/features/Support/SupportTickets/ticketUtils.ts
+++ b/packages/manager/src/features/Support/SupportTickets/ticketUtils.ts
@@ -9,7 +9,7 @@ import { getTickets } from '@linode/api-v4/lib/support';
  *
  * @example getTicketStatus('closed');
  */
-const getStatusFilter = (ticketStatus: 'open' | 'closed' | 'all') => {
+export const getStatusFilter = (ticketStatus: 'open' | 'closed' | 'all') => {
   switch (ticketStatus) {
     case 'open':
       return { '+or': [{ status: 'open' }, { status: 'new' }] };

--- a/packages/manager/src/queries/support.ts
+++ b/packages/manager/src/queries/support.ts
@@ -1,0 +1,12 @@
+import { getTickets, SupportTicket } from '@linode/api-v4/lib/support';
+import { APIError, ResourcePage } from '@linode/api-v4/lib/types';
+import { useQuery } from 'react-query';
+
+const queryKey = `support`;
+
+export const useSupportTicketsQuery = (params: any, filter: any) =>
+  useQuery<ResourcePage<SupportTicket>, APIError[]>(
+    [`${queryKey}-tickets`, params, filter],
+    () => getTickets(params, filter),
+    { keepPreviousData: true }
+  );


### PR DESCRIPTION
## Description
> **Note**: This ticket was a bug report about scrolling, but it turns out it was not an issue. Users assumed there was a scrolling issue, but in reality, we just hide some columns on small screen sizes.

- To address the table confusion, I made the `Last Updated` column stay visible on small screens
- I took this ticket as opportunity to do a quick clean up and refactor to React Query

## How to test

- Test the two tabs of `http://localhost:3000/support/tickets`
  - Consider testing in a dev environment so you can create tickets without interrupting Linode support
  - Ensure open tickets shown in the **Open** tab and **closed** tickets only show up in the closed tab
  - Test filtering and sorting the table