### PR TITLE
M3-5759: Don't make /account requests if restricted user

### DIFF
--- a/packages/manager/src/queries/account.ts
+++ b/packages/manager/src/queries/account.ts
@@ -5,16 +5,21 @@ import {
 } from '@linode/api-v4/lib/account';
 import { APIError } from '@linode/api-v4/lib/types';
 import { useMutation, useQuery } from 'react-query';
+import { useProfile } from 'src/queries/profile';
 import { getGravatarUrl } from 'src/utilities/gravatar';
 import { mutationHandlers, queryPresets } from './base';
 
 export const queryKey = 'account';
 
-export const useAccount = () =>
-  useQuery<Account, APIError[]>(queryKey, getAccountInfo, {
+export const useAccount = () => {
+  const { data: profile } = useProfile();
+
+  return useQuery<Account, APIError[]>(queryKey, getAccountInfo, {
     ...queryPresets.oneTimeFetch,
     ...queryPresets.noRetry,
+    enabled: !profile?.restricted,
   });
+};
 
 export const useMutateAccount = () => {
   return useMutation<Account, APIError[], Partial<Account>>((data) => {

--- a/packages/manager/src/queries/accountAgreements.ts
+++ b/packages/manager/src/queries/accountAgreements.ts
@@ -6,15 +6,20 @@ import {
 import { APIError } from '@linode/api-v4/lib/types';
 import { useMutation, useQuery } from 'react-query';
 import { reportException } from 'src/exceptionReporting';
+import { useProfile } from 'src/queries/profile';
 import { queryPresets, simpleMutationHandlers } from './base';
 
 export const queryKey = 'account-agreements';
 
-export const useAccountAgreements = () =>
-  useQuery<Agreements, APIError[]>(queryKey, getAccountAgreements, {
+export const useAccountAgreements = () => {
+  const { data: profile } = useProfile();
+
+  return useQuery<Agreements, APIError[]>(queryKey, getAccountAgreements, {
     ...queryPresets.oneTimeFetch,
     ...queryPresets.noRetry,
+    enabled: !profile?.restricted,
   });
+};
 
 export const useMutateAccountAgreements = () => {
   return useMutation<{}, APIError[], Partial<Agreements>>(

--- a/packages/manager/src/queries/accountPayment.ts
+++ b/packages/manager/src/queries/accountPayment.ts
@@ -30,7 +30,7 @@ export const useAllPaymentMethodsQuery = () => {
     getAllPaymentMethodsRequest,
     {
       ...queryPresets.oneTimeFetch,
-      enabled: grants?.global.account_access !== null,
+      enabled: grants?.global?.account_access !== null,
     }
   );
 };

--- a/packages/manager/src/queries/accountPayment.ts
+++ b/packages/manager/src/queries/accountPayment.ts
@@ -6,7 +6,7 @@ import {
 } from '@linode/api-v4/lib/account';
 import { APIError, ResourcePage } from '@linode/api-v4/lib/types';
 import { useQuery } from 'react-query';
-import { useProfile } from 'src/queries/profile';
+import { useGrants } from 'src/queries/profile';
 import { getAll } from 'src/utilities/getAll';
 import { queryPresets } from './base';
 
@@ -23,14 +23,14 @@ export const usePaymentMethodsQuery = (params: any = {}, filter: any = {}) => {
 };
 
 export const useAllPaymentMethodsQuery = () => {
-  const { data: profile } = useProfile();
+  const { data: grants } = useGrants();
 
   return useQuery<PaymentMethod[], APIError[]>(
     queryKey + '-all',
     getAllPaymentMethodsRequest,
     {
       ...queryPresets.oneTimeFetch,
-      enabled: !profile?.restricted,
+      enabled: grants?.global.account_access !== null,
     }
   );
 };

--- a/packages/manager/src/queries/accountPayment.ts
+++ b/packages/manager/src/queries/accountPayment.ts
@@ -1,9 +1,14 @@
-import { getPaymentMethods, PaymentMethod } from '@linode/api-v4/lib/account';
+import {
+  ClientToken,
+  getClientToken,
+  getPaymentMethods,
+  PaymentMethod,
+} from '@linode/api-v4/lib/account';
 import { APIError, ResourcePage } from '@linode/api-v4/lib/types';
 import { useQuery } from 'react-query';
+import { useProfile } from 'src/queries/profile';
 import { getAll } from 'src/utilities/getAll';
 import { queryPresets } from './base';
-import { getClientToken, ClientToken } from '@linode/api-v4/lib/account';
 
 export const queryKey = 'account-payment-methods';
 
@@ -18,11 +23,14 @@ export const usePaymentMethodsQuery = (params: any = {}, filter: any = {}) => {
 };
 
 export const useAllPaymentMethodsQuery = () => {
+  const { data: profile } = useProfile();
+
   return useQuery<PaymentMethod[], APIError[]>(
     queryKey + '-all',
     getAllPaymentMethodsRequest,
     {
       ...queryPresets.oneTimeFetch,
+      enabled: !profile?.restricted,
     }
   );
 };

--- a/packages/manager/src/queries/accountSettings.ts
+++ b/packages/manager/src/queries/accountSettings.ts
@@ -5,15 +5,20 @@ import {
 } from '@linode/api-v4/lib/account';
 import { APIError } from '@linode/api-v4/lib/types';
 import { useMutation, useQuery } from 'react-query';
+import { useProfile } from 'src/queries/profile';
 import { queryClient, queryPresets } from './base';
 
 export const queryKey = 'account-settings';
 
-export const useAccountSettings = () =>
-  useQuery<AccountSettings, APIError[]>(queryKey, getAccountSettings, {
+export const useAccountSettings = () => {
+  const { data: profile } = useProfile();
+
+  return useQuery<AccountSettings, APIError[]>(queryKey, getAccountSettings, {
     ...queryPresets.oneTimeFetch,
     ...queryPresets.noRetry,
+    enabled: !profile?.restricted,
   });
+};
 
 export const useMutateAccountSettings = () => {
   return useMutation<AccountSettings, APIError[], Partial<AccountSettings>>(

--- a/packages/manager/src/queries/accountUsers.ts
+++ b/packages/manager/src/queries/accountUsers.ts
@@ -1,20 +1,26 @@
-import { User, getUsers } from '@linode/api-v4/lib/account';
-import { ResourcePage } from '@linode/api-v4/lib/types';
-import { APIError } from '@linode/api-v4/lib/types';
-import { useQuery } from 'react-query';
-import { queryPresets } from './base';
+import { getUsers, User } from '@linode/api-v4/lib/account';
+import { APIError, ResourcePage } from '@linode/api-v4/lib/types';
 import { map as mapPromise } from 'bluebird';
 import { default as memoize } from 'memoizee';
+import { useQuery } from 'react-query';
+import { useProfile } from 'src/queries/profile';
 import { getGravatarUrl } from 'src/utilities/gravatar';
+import { queryPresets } from './base';
 
 export const queryKey = 'account-users';
 
-export const useAccountUsers = (params: any, withGravatar: boolean = false) =>
-  useQuery<ResourcePage<User>, APIError[]>(
+export const useAccountUsers = (params: any, withGravatar: boolean = false) => {
+  const { data: profile } = useProfile();
+
+  return useQuery<ResourcePage<User>, APIError[]>(
     [queryKey, params.page, params.page_size],
     withGravatar ? () => getUsersWithGravatar(params) : () => getUsers(params),
-    queryPresets.oneTimeFetch
+    {
+      ...queryPresets.oneTimeFetch,
+      enabled: !profile?.restricted,
+    }
   );
+};
 
 const memoizedGetGravatarURL = memoize(getGravatarUrl);
 

--- a/packages/manager/src/queries/entityTransfers.ts
+++ b/packages/manager/src/queries/entityTransfers.ts
@@ -7,6 +7,7 @@ import {
 } from '@linode/api-v4/lib/entity-transfers';
 import { APIError } from '@linode/api-v4/lib/types';
 import { useMutation, useQuery } from 'react-query';
+import { useProfile } from 'src/queries/profile';
 import { creationHandlers, listToItemsByID, queryPresets } from './base';
 
 export const queryKey = 'entity-transfers';
@@ -43,10 +44,15 @@ const getAllEntityTransfersRequest = (
   }));
 
 export const useEntityTransfersQuery = (params: any = {}, filter: any = {}) => {
+  const { data: profile } = useProfile();
+
   return useQuery<EntityTransfersData, APIError[]>(
     [queryKey, params, filter],
     () => getAllEntityTransfersRequest(params, filter),
-    queryPresets.longLived
+    {
+      ...queryPresets.longLived,
+      enabled: !profile?.restricted,
+    }
   );
 };
 


### PR DESCRIPTION
## Description
Once Cloud has established that a user is restricted, we should not attempt to request any of the account endpoints

## How to test
Go to `/account` on a restricted user and click through the tabs while verifying that we longer make requests to /account endpoints