### PR TITLE
Add integration tests for SMS opt-in and opt-out

### DIFF
--- a/packages/manager/cypress/integration/account/sms-verification.spec.ts
+++ b/packages/manager/cypress/integration/account/sms-verification.spec.ts
@@ -1,0 +1,167 @@
+/**
+ * @file Integration tests for SMS phone verification.
+ */
+
+import { getFormattedNumber } from 'src/features/Profile/AuthenticationSettings/PhoneVerification/helpers';
+import { profileFactory } from 'src/factories/profile';
+import {
+  randomLabel,
+  randomNumber,
+  randomPhoneNumber,
+} from 'support/util/random';
+import {
+  mockGetProfile,
+  mockSendVerificationCode,
+  mockSmsVerificationOptOut,
+  mockVerifyVerificationCode,
+} from 'support/intercepts/profile';
+import { ui } from 'support/ui';
+import { assertToast } from 'support/ui/events';
+
+describe('SMS phone verification', () => {
+  /*
+   * - Vaildates SMS phone verification opt-in flow using mocked data.
+   * - Confirms that user is shown phone verification prompt.
+   * - Confirms that user can request OTP to opt into SMS verification.
+   * - Confirms UI flow when user enters incorrect OTP.
+   * - Confirms UI flow when user clicks "Resend Verification Code".
+   * - Confirms UI flow when user enters correct OTP.
+   */
+  it('can opt into SMS phone verification', () => {
+    const optInPhoneNumber = `1115551155`;
+    const userProfile = profileFactory.build({
+      uid: randomNumber(1000, 9999),
+      username: randomLabel(),
+      verified_phone_number: undefined,
+    });
+
+    const verificationNotice =
+      'By clicking Send Verification Code you are opting in to receive SMS messages.';
+    // @TODO Update this to reflect actual API error message.
+    const verificationCodeError = 'Invalid verification code.';
+    const confirmationMessage =
+      'SMS verification code was sent to +1 1115551155';
+
+    mockGetProfile(userProfile).as('getProfile');
+    mockSendVerificationCode().as('sendVerificationCode');
+    mockVerifyVerificationCode(verificationCodeError).as('verifyCode');
+
+    cy.visitWithLogin('/profile/auth');
+    cy.wait('@getProfile');
+
+    cy.findByText(verificationNotice, { exact: false }).should('be.visible');
+    cy.findByText('You are opted out of SMS messaging.').should('be.visible');
+
+    // @TODO Add steps to change country code before typing phone number.
+
+    cy.findByLabelText('Phone Number').click().type(optInPhoneNumber);
+
+    ui.button
+      .findByTitle('Send Verification Code')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    cy.wait('@sendVerificationCode');
+    cy.findByText(confirmationMessage, { exact: false }).should('be.visible');
+
+    // Mock invalid verification code for first attempt.
+    cy.findByLabelText('Verification Code')
+      .should('be.visible')
+      .click()
+      .type(`${randomNumber(10000, 50000)}`);
+
+    ui.button
+      .findByTitle('Verify Phone Number')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    cy.wait('@verifyCode');
+    cy.findByText(verificationCodeError);
+
+    // Resend verification code.
+    cy.findByText('Resend verification code').should('be.visible').click();
+
+    cy.wait('@sendVerificationCode');
+    assertToast('Successfully resent verification code');
+
+    // Mock successful verification code for second attempt.
+    mockVerifyVerificationCode().as('verifyCode');
+    cy.findByLabelText('Verification Code')
+      .should('be.visible')
+      .click()
+      .clear()
+      .type(`${randomNumber(10000, 50000)}`);
+
+    ui.button
+      .findByTitle('Verify Phone Number')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    cy.wait('@verifyCode');
+
+    assertToast('Successfully verified phone number');
+
+    cy.findByText('+1 1115551155').should('be.visible');
+
+    ui.button
+      .findByTitle('Send Verification Code')
+      .should('be.visible')
+      .should('be.disabled');
+  });
+
+  /*
+   * - Validates SMS phone verification opt-out flow using mocked data.
+   * - Confirms that user is shown message telling them they are opted in.
+   * - Confirms that user can opt out by clicking 'Opt Out'
+   * - Confirms that user is then shown message telling them they are opted out.
+   */
+  it('can opt out of SMS phone verification', () => {
+    const userPhoneNumber = randomPhoneNumber();
+    const formattedPhoneNumber = getFormattedNumber(userPhoneNumber);
+    const userProfile = profileFactory.build({
+      uid: randomNumber(1000, 9999),
+      username: randomLabel(),
+      verified_phone_number: userPhoneNumber,
+    });
+
+    const expectedOptInMessage = 'You have opted in to SMS messaging.';
+    const expectedOptOutMessage = 'You are opted out of SMS messaging.';
+
+    mockGetProfile(userProfile).as('getProfile');
+    mockSmsVerificationOptOut().as('smsOptOut');
+
+    cy.visitWithLogin('/profile/auth');
+    cy.wait('@getProfile');
+
+    cy.findByText(expectedOptInMessage).should('be.visible');
+
+    ui.button
+      .findByTitle('Opt Out')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    ui.dialog
+      .findByTitle('Opt out of SMS messaging for phone verification')
+      .should('be.visible')
+      .within(() => {
+        cy.findByText(formattedPhoneNumber, { exact: false }).should(
+          'be.visible'
+        );
+
+        ui.buttonGroup
+          .findButtonByTitle('Opt Out')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    cy.wait('@smsOptOut');
+    cy.findByText(expectedOptOutMessage).should('be.visible');
+
+    assertToast('Successfully opted out of SMS messaging');
+  });
+});

--- a/packages/manager/cypress/support/intercepts/profile.ts
+++ b/packages/manager/cypress/support/intercepts/profile.ts
@@ -1,0 +1,50 @@
+/**
+ * @file Cypress intercepts and mocks for Cloud Manager profile requests.
+ */
+
+import { makeErrorResponse } from 'support/util/errors';
+import { Profile } from '@linode/api-v4/lib/profile/types';
+
+/**
+ * Intercepts GET request to fetch profile and mocks response.
+ *
+ * @param profile - Profile with which to respond.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetProfile = (profile: Profile): Cypress.Chainable<null> => {
+  return cy.intercept('GET', '*/profile', profile);
+};
+
+/**
+ * Intercepts POST request to opt out of SMS verification and mocks response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockSmsVerificationOptOut = (): Cypress.Chainable<null> => {
+  return cy.intercept('DELETE', '*/profile/phone-number', {});
+};
+
+/**
+ * Intercepts POST request to send SMS verification code and mocks response.
+ */
+export const mockSendVerificationCode = (): Cypress.Chainable<null> => {
+  return cy.intercept('POST', '*/profile/phone-number', {});
+};
+
+/**
+ * Intercepts POST request to verify SMS verification code and mocks response.
+ *
+ * If an `errorMessage` is provided, the mocked response will indicate an error.
+ * Otherwise, a successful response is mocked.
+ *
+ * @param errorMessage - If specified, mocks an error response with the given message.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockVerifyVerificationCode = (
+  errorMessage?: string | undefined
+): Cypress.Chainable<null> => {
+  const response = !!errorMessage ? makeErrorResponse(errorMessage) : {};
+  return cy.intercept('POST', '*/profile/phone-number/verify', response);
+};

--- a/packages/manager/cypress/support/util/random.ts
+++ b/packages/manager/cypress/support/util/random.ts
@@ -153,3 +153,27 @@ export const randomIp = () => {
   const randomOctet = () => randomNumber(0, 254);
   return `${randomOctet()}.${randomOctet()}.${randomOctet()}.${randomOctet()}`;
 };
+
+/**
+ * Returns a random phone number.
+ *
+ * The three digits following the area code will always be '555'.
+ *
+ * @param randomCountryCode - Whether country code should be random. If not, '1' is used.
+ *
+ * @example
+ * randomPhoneNumber(); // Example output: `+19965551794`.
+ * randomPhoneNumber(false); // Equivalent to above.
+ * randomPhoneNumber(true); // Example output: `+2642285555485`.
+ *
+ * @returns Random phone number.
+ */
+export const randomPhoneNumber = (
+  randomCountryCode: boolean = false
+): string => {
+  const countryCode = randomCountryCode ? randomNumber(1, 999) : 1;
+  return `+${countryCode}${randomNumber(100, 999)}555${randomNumber(
+    1000,
+    9999
+  )}`;
+};


### PR DESCRIPTION
## Description

**What does this PR do?**
Adds Cypress integration tests for SMS opt-in and opt-out.

This is the same code as #8409 and #8410, but updated to reflect some of the last-minute API and copy changes.

## How to test

**How do I run relevant unit tests?**
Run `yarn up`, then run:

```
yarn cy:run -s "cypress/integration/account/sms-verification.spec.ts"
```

If you would like to run Cypress interactively, you can instead run `yarn cy:debug` and search for _sms-verification_.