### PR TITLE
M3-5861: Return the Phone Verification component to a view state when verifying the same phone number

### DIFF
--- a/packages/manager/src/features/Profile/AuthenticationSettings/PhoneVerification/PhoneVerification.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/PhoneVerification/PhoneVerification.tsx
@@ -42,8 +42,6 @@ export const PhoneVerification = () => {
   React.useEffect(() => {
     // If the user opts-out, hasVerifiedPhoneNumber will change, therefore
     // we need this component to update its state.
-    // This also handles going back to view mode when we mutate the
-    // profile store to have the new phone number on verification success
     if (isViewMode !== hasVerifiedPhoneNumber) {
       setIsViewMode(hasVerifiedPhoneNumber);
     }
@@ -94,8 +92,11 @@ export const PhoneVerification = () => {
       queryClient.invalidateQueries(queryKey);
     }
 
-    // reset form states (the useEffect will handle returning to view mode)
+    // reset form states
     reset();
+
+    // force the flow back into view mode
+    setIsViewMode(true);
 
     enqueueSnackbar('Successfully verified phone number', {
       variant: 'success',


### PR DESCRIPTION
## Description

### The Bug 🐛
- If you tried to _edit_ your verified number by replacing it with the **same phone number**, the Phone verification component would not return to the proper state upon successful verification
- The form was not returning to the view state because we relied on the React Query `profile` store to update via the hook and cause a `useEffect` to run, but the React Query hook did not update because we wrote the same phone number to the cache. 

> **Note**: A view of the bug is attached to the internal ticket if you need more context

### The Fix
- Manually call the set state to return to view mode and keep the `useEffect` so the component reacts to opting out

## How to test

- Test the **Phone Verification** component in depth
  - Test opting out
  - Test setting a phone number without a phone number verified
  - Test editing your verified phone number
  - Test editing a phone number and use the same phone number (this should work as expected now)
