### PR TITLE
M3-5862: Fix Jest DOM nesting validation warnings

### DIFF
--- a/packages/manager/src/features/Domains/DomainBanner.tsx
+++ b/packages/manager/src/features/Domains/DomainBanner.tsx
@@ -51,10 +51,10 @@ export const DomainBanner: React.FC<Props> = (props) => {
       dismissible
       onClose={handleClose}
     >
+      <Typography className={classes.banner}>
+        <strong>Your DNS zones are not being served.</strong>
+      </Typography>
       <Typography>
-        <div className={classes.banner}>
-          <strong>Your DNS zones are not being served.</strong>
-        </div>
         Your domains will not be served by Linode&rsquo;s nameservers unless you
         have at least one active Linode on your account.{` `}
         <Link to="/linodes/create">You can create one here.</Link>

--- a/packages/manager/src/features/Events/EventRow.test.tsx
+++ b/packages/manager/src/features/Events/EventRow.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { renderWithTheme } from 'src/utilities/testHelpers';
+import { renderWithTheme, wrapWithTableBody } from 'src/utilities/testHelpers';
 import { Row, RowProps } from './EventRow';
 
 const message = 'this is a message.';
@@ -13,22 +13,28 @@ const props: RowProps = {
 
 describe('EventRow component', () => {
   it('should render an event with a message', () => {
-    const { getByText } = renderWithTheme(<Row {...props} />);
+    const { getByText } = renderWithTheme(
+      wrapWithTableBody(<Row {...props} />)
+    );
 
     expect(getByText(message)).toBeInTheDocument();
   });
 
   it("shouldn't render events without a message", () => {
     const emptyMessageProps = { ...props, message: undefined };
-    const { container } = renderWithTheme(<Row {...emptyMessageProps} />);
-    expect(container).toBeEmptyDOMElement();
+    const { container } = renderWithTheme(
+      wrapWithTableBody(<Row {...emptyMessageProps} />)
+    );
+    expect(container.closest('tr')).toBeNull();
   });
 
   it('should display the message with a username if one exists', () => {
     const username = 'banks';
     const propsWithUsername = { ...props, username };
 
-    const { getByText } = renderWithTheme(<Row {...propsWithUsername} />);
+    const { getByText } = renderWithTheme(
+      wrapWithTableBody(<Row {...propsWithUsername} />)
+    );
 
     expect(getByText(`this is a message by ${username}.`)).toBeInTheDocument();
   });

--- a/packages/manager/src/features/Events/EventRow.tsx
+++ b/packages/manager/src/features/Events/EventRow.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 import { compose } from 'recompose';
 import Hidden from 'src/components/core/Hidden';
 import { makeStyles, Theme } from 'src/components/core/styles';
-import Typography from 'src/components/core/Typography';
 import DateTimeDisplay from 'src/components/DateTimeDisplay';
 import HighlightedMarkdown from 'src/components/HighlightedMarkdown';
 import Link from 'src/components/Link';
@@ -109,18 +108,8 @@ export const Row: React.FC<RowProps> = (props) => {
         </TableCell>
       </Hidden>
       <TableCell parentColumn="Event" data-qa-event-message-cell>
-        <Typography data-qa-event-message variant="body1">
-          {link ? (
-            <Link to={link}>
-              <HighlightedMarkdown
-                textOrMarkdown={displayedMessage}
-                sanitizeOptions={{
-                  allowedTags: [],
-                  disallowedTagsMode: 'discard',
-                }}
-              />
-            </Link>
-          ) : (
+        {link ? (
+          <Link to={link}>
             <HighlightedMarkdown
               textOrMarkdown={displayedMessage}
               sanitizeOptions={{
@@ -128,8 +117,16 @@ export const Row: React.FC<RowProps> = (props) => {
                 disallowedTagsMode: 'discard',
               }}
             />
-          )}
-        </Typography>
+          </Link>
+        ) : (
+          <HighlightedMarkdown
+            textOrMarkdown={displayedMessage}
+            sanitizeOptions={{
+              allowedTags: [],
+              disallowedTagsMode: 'discard',
+            }}
+          />
+        )}
       </TableCell>
       <TableCell parentColumn="Relative Date">
         {parseAPIDate(created).toRelative()}

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { renderWithTheme } from 'src/utilities/testHelpers';
+import { renderWithTheme, wrapWithTableBody } from 'src/utilities/testHelpers';
 import { buckets } from 'src/__data__/buckets';
 import { BucketTableRow, CombinedProps } from './BucketTableRow';
 
@@ -19,17 +19,23 @@ describe('BucketTableRow', () => {
   };
 
   it('should render the bucket name', () => {
-    const { getByText } = renderWithTheme(<BucketTableRow {...props} />);
+    const { getByText } = renderWithTheme(
+      wrapWithTableBody(<BucketTableRow {...props} />)
+    );
     getByText('test-bucket-001');
   });
 
   it('should render the hostname', () => {
-    const { getByText } = renderWithTheme(<BucketTableRow {...props} />);
+    const { getByText } = renderWithTheme(
+      wrapWithTableBody(<BucketTableRow {...props} />)
+    );
     getByText('test-bucket-001.alpha.linodeobjects.com');
   });
 
   it('should render a size with the correct size abbreviation', () => {
-    const { getByText } = renderWithTheme(<BucketTableRow {...props} />);
+    const { getByText } = renderWithTheme(
+      wrapWithTableBody(<BucketTableRow {...props} />)
+    );
     getByText('5.05 GB');
   });
 });

--- a/packages/manager/src/features/Volumes/VolumeTableRow.test.tsx
+++ b/packages/manager/src/features/Volumes/VolumeTableRow.test.tsx
@@ -1,7 +1,6 @@
 import { VolumeStatus } from '@linode/api-v4/lib/volumes';
-import { render } from '@testing-library/react';
 import * as React from 'react';
-import { wrapWithTheme } from 'src/utilities/testHelpers';
+import { renderWithTheme, wrapWithTableBody } from 'src/utilities/testHelpers';
 import { volumes } from 'src/__data__/volumes';
 import { VolumeTableRow, CombinedProps } from './VolumeTableRow';
 
@@ -42,14 +41,16 @@ const props: CombinedProps = {
 
 describe('Volume table row', () => {
   it("should show the attached Linode's label if present", () => {
-    const { getByText } = render(wrapWithTheme(<VolumeTableRow {...props} />));
+    const { getByText } = renderWithTheme(
+      wrapWithTableBody(<VolumeTableRow {...props} />)
+    );
     expect(getByText(volumeWithLinodeLabel.linodeLabel));
   });
 
   it('should show Unattached if the Volume is not attached to a Linode', () => {
     const unattachedProps = { ...props, volume: unattachedVolume };
-    const { getByText } = render(
-      wrapWithTheme(<VolumeTableRow {...unattachedProps} />)
+    const { getByText } = renderWithTheme(
+      wrapWithTableBody(<VolumeTableRow {...unattachedProps} />)
     );
     expect(getByText('Detach'));
   });


### PR DESCRIPTION
## Description

**What does this PR do?**
This fixes DOM nesting warnings that get logged to the console when running Jest:

```
Warning: validateDOMNesting(...): <tr> cannot appear as a child of <div>.
```

```
Warning: validateDOMNesting(...): <div> cannot appear as a child of <p>.
```

```
Warning: validateDOMNesting(...): <p> cannot appear as a child of <p>.
```

This is a small part of a larger effort to clean up the Jest tests and console errors and ultimately resolve some of the inconsistencies we've been seeing across environments.

## How to test

**What are the steps to reproduce the issue or verify the changes?**
* Navigate to the events landing page at `/events` and confirm that the styling of the events rows has not been impacted by the removal of the `<Typography />` component
* Navigate to the domains landing page and confirm that the domain banner styling has not been impacted by these changes (you may have to enable MSW)

**How do I run relevant unit tests?**
To run the affected tests:
```
yarn test EventRow.test BucketTableRow.test VolumeTableRow.test
```

Feel free to run the rest of the tests and let me know if you see any other variation of this `validateDOMNesting` warning!

```
yarn test
```