### PR TITLE
M3-5853: Make 2FA / Security Questions Errors Accurate

### DIFF
--- a/packages/manager/src/features/Profile/AuthenticationSettings/TwoFactor/TwoFactor.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/TwoFactor/TwoFactor.tsx
@@ -119,6 +119,17 @@ export const TwoFactor: React.FC<Props> = (props) => {
   };
 
   const getToken = () => {
+    if (!hasSecurityQuestions) {
+      setErrors([
+        {
+          reason: `You must add Security Questions to your profile in order to ${
+            twoFactor ? 'reset' : 'enable'
+          } Two-Factor Authentication`,
+        },
+      ]);
+      return Promise.reject('Error');
+    }
+
     setLoading(true);
     return getTFAToken()
       .then((response) => {
@@ -126,29 +137,13 @@ export const TwoFactor: React.FC<Props> = (props) => {
         setLoading(false);
         setErrors(undefined);
       })
-      .catch((_error) => {
-        const error = getAPIErrorOrDefault(
-          _error,
-          'There was an error retrieving your secret key. Please try again.'
+      .catch((error) => {
+        setErrors(
+          getAPIErrorOrDefault(
+            error,
+            'There was an error retrieving your secret key. Please try again.'
+          )
         );
-
-        const securityQuestionsAPIError =
-          'You must add Security Questions to your profile in order to enable Two Factor Authentication';
-
-        if (
-          error.some((e) => e.reason === securityQuestionsAPIError) &&
-          twoFactorEnabled
-        ) {
-          // User does not have security questions but wants to reset their 2FA
-          setErrors([
-            {
-              reason:
-                'You must add Security Questions to your profile in order to reset Two-Factor Authentication',
-            },
-          ]);
-        } else {
-          setErrors(error);
-        }
 
         setLoading(false);
         return Promise.reject('Error');


### PR DESCRIPTION
## Description 📝

- If an existing user with 2FA enabled **and** without security questions tried to press `Reset two-factor authentication`, they would get an error notice saying `You must add Security Questions to your profile in order to enable Two Factor Authentication`. This may be confusing to users because it says `enable` instead of `reset`
- This PR makes it so the error will say `reset` if the API returns `You must add Security Questions to your profile in order to enable Two Factor Authentication` **and** you have 2FA enabled.

## Preview 📷

https://user-images.githubusercontent.com/6440455/176538305-e487e383-340a-4d95-a9b2-6adbb7eb4ec4.mov

## How to test 🧪

- Get an account into a state where it does not have security questions, but it does have 2FA enabled
- Press the `Reset two-factor authentication` button
- Verify that you see `You must add Security Questions to your profile in order to reset Two-Factor Authentication` (specifically it should say `reset` instead of `enable`)