### PR TITLE
M3-5863: Fix Jest 'usePayPalScriptReducer' errors

### DIFF
--- a/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.test.tsx
+++ b/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.test.tsx
@@ -8,9 +8,10 @@ import BillingSummary from 'src/features/Billing/BillingPanels/BillingSummary';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 import PaymentMethodRow from './PaymentMethodRow';
 
-jest.mock('@linode/api-v4/lib', () => {
+jest.mock('@linode/api-v4/lib/account', () => {
   return {
     makeDefaultPaymentMethod: jest.fn().mockResolvedValue({}),
+    getClientToken: jest.fn().mockResolvedValue('mockedBraintreeClientToken'),
   };
 });
 

--- a/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.test.tsx
+++ b/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.test.tsx
@@ -1,10 +1,12 @@
-import userEvent from '@testing-library/user-event';
-import PaymentMethodRow from './PaymentMethodRow';
-import BillingSummary from 'src/features/Billing/BillingPanels/BillingSummary';
-import { paymentMethodFactory } from 'src/factories';
-import { renderWithTheme } from 'src/utilities/testHelpers';
 import { makeDefaultPaymentMethod } from '@linode/api-v4/lib';
+import { PayPalScriptProvider } from '@paypal/react-paypal-js';
+import userEvent from '@testing-library/user-event';
 import * as React from 'react';
+import { PAYPAL_CLIENT_ID } from 'src/constants';
+import { paymentMethodFactory } from 'src/factories';
+import BillingSummary from 'src/features/Billing/BillingPanels/BillingSummary';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+import PaymentMethodRow from './PaymentMethodRow';
 
 jest.mock('@linode/api-v4/lib', () => {
   return {
@@ -15,10 +17,12 @@ jest.mock('@linode/api-v4/lib', () => {
 describe('Payment Method Row', () => {
   it('Displays "Default" chip if payment method is set as default', () => {
     const { getByText } = renderWithTheme(
-      <PaymentMethodRow
-        paymentMethod={paymentMethodFactory.build({ is_default: true })}
-        onDelete={jest.fn()}
-      />
+      <PayPalScriptProvider options={{ 'client-id': PAYPAL_CLIENT_ID }}>
+        <PaymentMethodRow
+          paymentMethod={paymentMethodFactory.build({ is_default: true })}
+          onDelete={jest.fn()}
+        />
+      </PayPalScriptProvider>
     );
 
     expect(getByText('DEFAULT')).toBeVisible();
@@ -26,10 +30,12 @@ describe('Payment Method Row', () => {
 
   it('Does not display "Default" chip if payment method is not set as default', () => {
     const { queryByText } = renderWithTheme(
-      <PaymentMethodRow
-        paymentMethod={paymentMethodFactory.build({ is_default: false })}
-        onDelete={jest.fn()}
-      />
+      <PayPalScriptProvider options={{ 'client-id': PAYPAL_CLIENT_ID }}>
+        <PaymentMethodRow
+          paymentMethod={paymentMethodFactory.build({ is_default: false })}
+          onDelete={jest.fn()}
+        />
+      </PayPalScriptProvider>
     );
 
     expect(queryByText('DEFAULT')).toBeNull();
@@ -60,7 +66,7 @@ describe('Payment Method Row', () => {
     });
 
     const { getByLabelText } = renderWithTheme(
-      <>
+      <PayPalScriptProvider options={{ 'client-id': PAYPAL_CLIENT_ID }}>
         <PaymentMethodRow
           paymentMethod={paymentMethodCreditCard}
           onDelete={jest.fn()}
@@ -69,7 +75,7 @@ describe('Payment Method Row', () => {
           paymentMethod={paymentMethodGooglePay}
           onDelete={jest.fn()}
         />
-      </>
+      </PayPalScriptProvider>
     );
 
     expect(getByLabelText(expectedLabelCreditCard)).toBeVisible();
@@ -89,10 +95,12 @@ describe('Payment Method Row', () => {
     });
 
     const { getByLabelText } = renderWithTheme(
-      <PaymentMethodRow
-        paymentMethod={payPalPaymentMethod}
-        onDelete={jest.fn()}
-      />
+      <PayPalScriptProvider options={{ 'client-id': PAYPAL_CLIENT_ID }}>
+        <PaymentMethodRow
+          paymentMethod={payPalPaymentMethod}
+          onDelete={jest.fn()}
+        />
+      </PayPalScriptProvider>
     );
 
     expect(getByLabelText(expectedLabelPayPal)).toBeVisible();
@@ -100,10 +108,12 @@ describe('Payment Method Row', () => {
 
   it('Disables "Make Default" and "Delete" actions if payment method is set as default', () => {
     const { getByText } = renderWithTheme(
-      <PaymentMethodRow
-        paymentMethod={paymentMethodFactory.build({ is_default: true })}
-        onDelete={jest.fn()}
-      />
+      <PayPalScriptProvider options={{ 'client-id': PAYPAL_CLIENT_ID }}>
+        <PaymentMethodRow
+          paymentMethod={paymentMethodFactory.build({ is_default: true })}
+          onDelete={jest.fn()}
+        />
+      </PayPalScriptProvider>
     );
 
     expect(getByText('Make Default').getAttribute('aria-disabled')).toEqual(
@@ -116,10 +126,12 @@ describe('Payment Method Row', () => {
     const mockFunction = jest.fn();
 
     const { getByText, getByLabelText } = renderWithTheme(
-      <PaymentMethodRow
-        paymentMethod={paymentMethodFactory.build({ is_default: false })}
-        onDelete={mockFunction}
-      />
+      <PayPalScriptProvider options={{ 'client-id': PAYPAL_CLIENT_ID }}>
+        <PaymentMethodRow
+          paymentMethod={paymentMethodFactory.build({ is_default: false })}
+          onDelete={mockFunction}
+        />
+      </PayPalScriptProvider>
     );
 
     const actionMenu = getByLabelText('Action menu for card ending in 1881');
@@ -142,7 +154,9 @@ describe('Payment Method Row', () => {
     });
 
     const { getByText, getByLabelText } = renderWithTheme(
-      <PaymentMethodRow paymentMethod={paymentMethod} onDelete={jest.fn()} />
+      <PayPalScriptProvider options={{ 'client-id': PAYPAL_CLIENT_ID }}>
+        <PaymentMethodRow paymentMethod={paymentMethod} onDelete={jest.fn()} />
+      </PayPalScriptProvider>
     );
 
     const actionMenu = getByLabelText('Action menu for card ending in 1111');
@@ -163,14 +177,14 @@ describe('Payment Method Row', () => {
      * and is required for this test. We may want to consider decoupling these components in the future.
      */
     const { getByText, getByLabelText, getByTestId } = renderWithTheme(
-      <>
+      <PayPalScriptProvider options={{ 'client-id': PAYPAL_CLIENT_ID }}>
         <BillingSummary
           paymentMethods={[paymentMethod]}
           balanceUninvoiced={0}
           balance={0}
         />
         <PaymentMethodRow paymentMethod={paymentMethod} onDelete={jest.fn()} />
-      </>
+      </PayPalScriptProvider>
     );
 
     const actionMenu = getByLabelText('Action menu for card ending in 1881');

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.test.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.test.tsx
@@ -14,6 +14,12 @@ import BillingSummary from './BillingSummary';
 const accountBalanceText = 'account-balance-text';
 const accountBalanceValue = 'account-balance-value';
 
+jest.mock('@linode/api-v4/lib/account', () => {
+  return {
+    getClientToken: jest.fn().mockResolvedValue('mockedBraintreeClientToken'),
+  };
+});
+
 describe('BillingSummary', () => {
   it('displays appropriate helper text and value when there is no balance', () => {
     renderWithTheme(

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.test.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.test.tsx
@@ -1,6 +1,8 @@
+import { PayPalScriptProvider } from '@paypal/react-paypal-js';
 import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
+import { PAYPAL_CLIENT_ID } from 'src/constants';
 import { promoFactory } from 'src/factories';
 import {
   renderWithTheme,
@@ -15,7 +17,9 @@ const accountBalanceValue = 'account-balance-value';
 describe('BillingSummary', () => {
   it('displays appropriate helper text and value when there is no balance', () => {
     renderWithTheme(
-      <BillingSummary balance={0} balanceUninvoiced={5} paymentMethods={[]} />
+      <PayPalScriptProvider options={{ 'client-id': PAYPAL_CLIENT_ID }}>
+        <BillingSummary balance={0} balanceUninvoiced={5} paymentMethods={[]} />
+      </PayPalScriptProvider>
     );
     within(screen.getByTestId(accountBalanceText)).getByText(/no balance/gi);
     within(screen.getByTestId(accountBalanceValue)).getByText('$0.00');
@@ -23,7 +27,13 @@ describe('BillingSummary', () => {
 
   it('displays a credit when there is a negative balance', () => {
     renderWithTheme(
-      <BillingSummary balance={-10} balanceUninvoiced={5} paymentMethods={[]} />
+      <PayPalScriptProvider options={{ 'client-id': PAYPAL_CLIENT_ID }}>
+        <BillingSummary
+          balance={-10}
+          balanceUninvoiced={5}
+          paymentMethods={[]}
+        />
+      </PayPalScriptProvider>
     );
     within(screen.getByTestId(accountBalanceText)).getByText(/credit/gi);
     within(screen.getByTestId(accountBalanceValue)).getByText('$10.00');
@@ -31,7 +41,13 @@ describe('BillingSummary', () => {
 
   it('displays the balance when there is a positive balance that is not yet past due', () => {
     renderWithTheme(
-      <BillingSummary balance={10} balanceUninvoiced={5} paymentMethods={[]} />
+      <PayPalScriptProvider options={{ 'client-id': PAYPAL_CLIENT_ID }}>
+        <BillingSummary
+          balance={10}
+          balanceUninvoiced={5}
+          paymentMethods={[]}
+        />
+      </PayPalScriptProvider>
     );
     within(screen.getByTestId(accountBalanceText)).getByText(/Balance/gi);
     within(screen.getByTestId(accountBalanceValue)).getByText('$10.00');
@@ -39,17 +55,21 @@ describe('BillingSummary', () => {
 
   it('does not display the promotions section unless there are promos', async () => {
     const { rerender } = renderWithTheme(
-      <BillingSummary balance={0} balanceUninvoiced={5} paymentMethods={[]} />
+      <PayPalScriptProvider options={{ 'client-id': PAYPAL_CLIENT_ID }}>
+        <BillingSummary balance={0} balanceUninvoiced={5} paymentMethods={[]} />
+      </PayPalScriptProvider>
     );
     expect(screen.queryByText('Promotions')).not.toBeInTheDocument();
     rerender(
       wrapWithTheme(
-        <BillingSummary
-          balance={0}
-          balanceUninvoiced={5}
-          promotions={promoFactory.buildList(1)}
-          paymentMethods={[]}
-        />
+        <PayPalScriptProvider options={{ 'client-id': PAYPAL_CLIENT_ID }}>
+          <BillingSummary
+            balance={0}
+            balanceUninvoiced={5}
+            promotions={promoFactory.buildList(1)}
+            paymentMethods={[]}
+          />
+        </PayPalScriptProvider>
       )
     );
     expect(screen.getByText('Promotions'));
@@ -57,17 +77,19 @@ describe('BillingSummary', () => {
 
   it('renders promo summary, expiry, and credit remaining', () => {
     renderWithTheme(
-      <BillingSummary
-        balance={0}
-        balanceUninvoiced={5}
-        paymentMethods={[]}
-        promotions={promoFactory.buildList(1, {
-          summary: 'MY_PROMO_CODE',
-          credit_remaining: '15.50',
-          expire_dt: '2020-01-01T12:00:00',
-          credit_monthly_cap: '20.00',
-        })}
-      />
+      <PayPalScriptProvider options={{ 'client-id': PAYPAL_CLIENT_ID }}>
+        <BillingSummary
+          balance={0}
+          balanceUninvoiced={5}
+          paymentMethods={[]}
+          promotions={promoFactory.buildList(1, {
+            summary: 'MY_PROMO_CODE',
+            credit_remaining: '15.50',
+            expire_dt: '2020-01-01T12:00:00',
+            credit_monthly_cap: '20.00',
+          })}
+        />
+      </PayPalScriptProvider>
     );
     const getByTextWithMarkup = withMarkup(screen.getByText);
     screen.getByText('MY_PROMO_CODE');
@@ -95,14 +117,18 @@ describe('BillingSummary', () => {
 
   it('displays accrued charges', () => {
     renderWithTheme(
-      <BillingSummary balance={0} balanceUninvoiced={5} paymentMethods={[]} />
+      <PayPalScriptProvider options={{ 'client-id': PAYPAL_CLIENT_ID }}>
+        <BillingSummary balance={0} balanceUninvoiced={5} paymentMethods={[]} />
+      </PayPalScriptProvider>
     );
     within(screen.getByTestId('accrued-charges-value')).getByText('$5.00');
   });
 
   it('opens "Make a Payment" drawer when "Make a payment." is clicked', () => {
     const { getByText, getByTestId } = renderWithTheme(
-      <BillingSummary balance={5} balanceUninvoiced={5} paymentMethods={[]} />
+      <PayPalScriptProvider options={{ 'client-id': PAYPAL_CLIENT_ID }}>
+        <BillingSummary balance={5} balanceUninvoiced={5} paymentMethods={[]} />
+      </PayPalScriptProvider>
     );
 
     const paymentButton = getByText('Make a payment', { exact: false });

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.test.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.test.tsx
@@ -1,8 +1,10 @@
 // import { fireEvent } from '@testing-library/react';
-import PaymentInformation from './PaymentInformation';
+import { PayPalScriptProvider } from '@paypal/react-paypal-js';
+import * as React from 'react';
+import { PAYPAL_CLIENT_ID } from 'src/constants';
 import { paymentMethodFactory } from 'src/factories';
 import { renderWithTheme } from 'src/utilities/testHelpers';
-import * as React from 'react';
+import PaymentInformation from './PaymentInformation';
 
 /*
  * Build payment method list that includes 1 valid and default payment method,
@@ -23,7 +25,9 @@ const paymentMethods = [
 describe('Payment Info Panel', () => {
   it('Shows loading animation when loading', () => {
     const { getByLabelText } = renderWithTheme(
-      <PaymentInformation loading={true} paymentMethods={paymentMethods} />
+      <PayPalScriptProvider options={{ 'client-id': PAYPAL_CLIENT_ID }}>
+        <PaymentInformation loading={true} paymentMethods={paymentMethods} />
+      </PayPalScriptProvider>
     );
 
     expect(getByLabelText('Content is loading')).toBeVisible();
@@ -32,7 +36,9 @@ describe('Payment Info Panel', () => {
   // @TODO: Restore `PaymentInformation.test.tsx` tests. See M3-5768 for more information.
   // it('Opens "Add Payment Method" drawer when "Add Payment Method" is clicked', () => {
   //   const { getByTestId } = renderWithTheme(
-  //     <PaymentInformation loading={false} paymentMethods={paymentMethods} />
+  //     <PayPalScriptProvider options={{ 'client-id': PAYPAL_CLIENT_ID }}>
+  //       <PaymentInformation loading={false} paymentMethods={paymentMethods} />
+  //     </PayPalScriptProvider>
   //   );
 
   //   const addPaymentMethodButton = getByTestId(
@@ -45,7 +51,9 @@ describe('Payment Info Panel', () => {
 
   // it('Lists all payment methods', () => {
   //   const { getByTestId } = renderWithTheme(
-  //     <PaymentInformation loading={false} paymentMethods={paymentMethods} />
+  //     <PayPalScriptProvider options={{ 'client-id': PAYPAL_CLIENT_ID }}>
+  //       <PaymentInformation loading={false} paymentMethods={paymentMethods} />
+  //     </PayPalScriptProvider>
   //   );
 
   //   paymentMethods.forEach((paymentMethod) => {

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.test.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.test.tsx
@@ -6,6 +6,12 @@ import { paymentMethodFactory } from 'src/factories';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 import PaymentInformation from './PaymentInformation';
 
+jest.mock('@linode/api-v4/lib/account', () => {
+  return {
+    getClientToken: jest.fn().mockResolvedValue('mockedBraintreeClientToken'),
+  };
+});
+
 /*
  * Build payment method list that includes 1 valid and default payment method,
  * 2 valid non-default payment methods, and 1 expired payment method.


### PR DESCRIPTION
## Description

**What does this PR do?**
This fixes `usePayPalScriptReducer` errors that get logged to the console when running Jest:

```
Error: usePayPalScriptReducer must be used within a PayPalScriptProvider
```

I've also mocked a few calls to the APIv4 client library which will eliminate a couple `Warning: captured a ... request without a corresponding request handler` warnings (see M3-5864 for the remaining work on those warnings).

## How to test

**What are the steps to reproduce the issue or verify the changes?**
To reproduce, run `yarn test` against `develop`, and observe a handful of `usePayPalScriptReducer` errors in the console output.

To verify these changes, run `yarn test` against this branch and observe that those errors are no longer present.

**How do I run relevant unit tests?**
To verify just the affected tests, run the following command and confirm that no warnings or errors are shown:

```
yarn test PaymentMethodRow.test BillingSummary.test PaymentInformation.test
```
