### PR TITLE
M3-5255: Fix Linode stats graphs to be more responsive

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -14,6 +14,7 @@ import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
 import LineGraph from 'src/components/LineGraph';
+import { useWindowDimensions } from 'src/hooks/useWindowDimensions';
 import {
   STATS_NOT_READY_API_MESSAGE,
   STATS_NOT_READY_MESSAGE,
@@ -99,10 +100,7 @@ const LinodeSummary: React.FC<Props> = (props) => {
   const { data: profile } = useProfile();
   const timezone = profile?.timezone || DateTime.local().zoneName;
 
-  const [dimensions, setDimensions] = React.useState({
-    height: window.innerHeight,
-    width: window.innerWidth,
-  });
+  const { width: windowWidth, height: windowHeight } = useWindowDimensions();
 
   const options = getDateOptions(linodeCreated);
   const [rangeSelection, setRangeSelection] = React.useState('24');
@@ -153,22 +151,8 @@ const LinodeSummary: React.FC<Props> = (props) => {
   ).current;
 
   React.useEffect(() => {
-    const handleWindowResize = () => {
-      setDimensions({
-        height: window.innerHeight,
-        width: window.innerWidth,
-      });
-
-      debouncedRefetchLinodeStats();
-    };
-
-    // eslint-disable-next-line scanjs-rules/call_addEventListener
-    window.addEventListener('resize', handleWindowResize);
-
-    return () => {
-      window.removeEventListener('resize', handleWindowResize);
-    };
-  }, [dimensions, debouncedRefetchLinodeStats]);
+    debouncedRefetchLinodeStats();
+  }, [windowWidth, windowHeight, debouncedRefetchLinodeStats]);
 
   const renderCPUChart = () => {
     const data = stats?.data.cpu ?? [];


### PR DESCRIPTION
## Description
In prod, when you resize your window while on the "Analytics" tab of a Linode Detail page, there can be periods of up to ~30 seconds where the graphs are distorted in their shapes. This occurs because the graphs did not re-render until the data fetch interval came around again.

This PR adds logic to refetch the stats 1.5 seconds after resizing the window.

## How to test
While on the "Analytics" tab of a Linode Detail page, try resizing the window multiple times. You should see a call to `stats` in the Network tab of Devtools shortly after you do each resize. Compare the behavior on this branch with production.
