### PR TITLE
M3-5092: `hosted-git-info` - CVE-2021-23362 

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "glob-parent": "^5.1.2",
     "browserslist": "^4.16.5",
     "nth-check": "v2.0.1",
-    "trim-newlines": "^4.0.2"
+    "trim-newlines": "^4.0.2",
+    "hosted-git-info": "^5.0.0"
   },
   "workspaces": {
     "packages": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -9738,10 +9738,12 @@ homedir-polyfill@^1.0.1:
   dependencies:
     parse-passwd "^1.0.0"
 
-hosted-git-info@^2.1.4:
-  version "2.8.9"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
-  integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
+hosted-git-info@^2.1.4, hosted-git-info@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-5.0.0.tgz#df7a06678b4ebd722139786303db80fdf302ea56"
+  integrity sha512-rRnjWu0Bxj+nIfUOkz0695C0H6tRrN5iYIzYejb0tDEefe2AekHu/U5Kn9pEie5vsJqpNQU02az7TGSH3qpz4Q==
+  dependencies:
+    lru-cache "^7.5.1"
 
 hpack.js@^2.1.6:
   version "2.1.6"
@@ -11992,6 +11994,11 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+lru-cache@^7.5.1:
+  version "7.12.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.12.0.tgz#be2649a992c8a9116efda5c487538dcf715f3476"
+  integrity sha512-OIP3DwzRZDfLg9B9VP/huWBlpvbkmbfiBy8xmsXp4RPmE4A3MhwNozc5ZJ3fWnSg8fDcdlE/neRTPG2ycEKliw==
 
 lru-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
## Description 📝

- Pins  `hosted-git-info`  to the latest version at address CVE-2021-23362 

With these types of tickets, it would be nice to be able to just update the dependencies that depend on `hosted-git-info` to resolve this, but packages that use `hosted-git-info` such as `npm-run-all` have not updated `hosted-git-info`  to the latest yet, so it's no use.

## How to test 🧪

- Test functionality of Cloud Manager (`yarn up`)
- Test functionality of Storybook (`yarn storybook`)
  - Storybook depends on `hosted-git-info`
