### PR TITLE
Button Placement in User Permissions and `ActionsPanel.tsx` Clean Up

### DIFF
--- a/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
+++ b/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
@@ -1,63 +1,43 @@
-import classNames from 'classnames';
-import { compose } from 'ramda';
 import * as React from 'react';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles,
-} from 'src/components/core/styles';
+import classNames from 'classnames';
 import RenderGuard from 'src/components/RenderGuard';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import Box, { BoxProps } from '../core/Box';
 
-type ClassNames = 'root';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {
-      paddingTop: theme.spacing(2),
-      paddingBottom: theme.spacing(1),
-      '& > button': {
-        marginBottom: theme.spacing(1),
-      },
-      '& > :first-child': {
-        marginRight: theme.spacing(),
-        marginLeft: 0,
-      },
-      '& > :only-child': {
-        marginRight: 0,
-      },
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    paddingTop: theme.spacing(2),
+    paddingBottom: theme.spacing(1),
+    '& > button': {
+      marginBottom: theme.spacing(1),
     },
-  });
+    '& > :first-child': {
+      marginRight: theme.spacing(),
+      marginLeft: 0,
+    },
+    '& > :only-child': {
+      marginRight: 0,
+    },
+  },
+}));
 
-interface Props {
-  className?: string;
-  style?: React.CSSProperties;
-}
-
-type CombinedProps = Props & WithStyles<ClassNames>;
-
-const ActionPanel: React.FC<CombinedProps> = (props) => {
-  const { classes, className, style, children } = props;
+const ActionPanel: React.FC<BoxProps> = (props) => {
+  const classes = useStyles();
+  const { className, children, ...rest } = props;
 
   return (
-    <div
+    <Box
       data-qa-buttons
-      className={classNames({
-        [classes.root]: true,
-        ...(className && { [className]: true }),
-        actionPanel: true,
-      })}
-      style={style}
+      className={classNames(classes.root, className, 'actionPanel')}
+      {...rest}
     >
       {Array.isArray(children)
         ? [...children].sort((child) =>
             child?.props?.buttonType === 'primary' ? 1 : -1
           ) // enforce that the primary button will always be to the right
         : children}
-    </div>
+    </Box>
   );
 };
 
-const styled = withStyles(styles);
-
-export default compose<any, any, any>(styled, RenderGuard)(ActionPanel);
+export default RenderGuard(ActionPanel);

--- a/packages/manager/src/components/RenderGuard.tsx
+++ b/packages/manager/src/components/RenderGuard.tsx
@@ -1,8 +1,7 @@
 import { equals } from 'ramda';
 import * as React from 'react';
 import { withTheme, WithTheme } from 'src/components/core/styles';
-
-import { getDisplayName } from 'src/utilities/getDisplayName.ts';
+import { getDisplayName } from 'src/utilities/getDisplayName';
 
 export interface RenderGuardProps {
   updateFor?: any[];

--- a/packages/manager/src/features/Users/UserPermissions.tsx
+++ b/packages/manager/src/features/Users/UserPermissions.tsx
@@ -502,7 +502,15 @@ class UserPermissions extends React.Component<CombinedProps, State> {
   ) => {
     const { classes } = this.props;
     return (
-      <ActionsPanel className={classes.section}>
+      <ActionsPanel
+        display="flex"
+        alignItems="center"
+        justifyContent="flex-end"
+        className={classes.section}
+      >
+        <Button buttonType="secondary" onClick={onCancel} data-qa-cancel>
+          Cancel
+        </Button>
         <Button
           buttonType="primary"
           onClick={onConfirm}
@@ -510,9 +518,6 @@ class UserPermissions extends React.Component<CombinedProps, State> {
           data-qa-submit
         >
           Save
-        </Button>
-        <Button buttonType="secondary" onClick={onCancel} data-qa-cancel>
-          Cancel
         </Button>
       </ActionsPanel>
     );


### PR DESCRIPTION
## Description 📝

- Improves button alignment in `/account/users/<username>/permissions`
- Includes code clean up and minor refactor 🧹

## Preview 📷

### Before
![Screen Shot 2022-07-01 at 1 09 57 PM](https://user-images.githubusercontent.com/6440455/176942241-88cd2ce5-c309-4179-bbf5-56691134f9b7.jpg)


### After
![Screen Shot 2022-07-01 at 1 22 58 PM](https://user-images.githubusercontent.com/6440455/176942261-4c5dc903-74e5-4b68-86c7-4f16c1ecf5da.jpg)


## How to test 🧪
 
- Test ActionsPanels throughout Cloud Manager
- Check button placement at `/account/users/<username>/permissions`
