### PR TITLE
M3-5771: Add Cypress tests for account security questions

### DIFF
--- a/packages/manager/cypress/integration/account/security-questions.spec.ts
+++ b/packages/manager/cypress/integration/account/security-questions.spec.ts
@@ -2,17 +2,321 @@
  * @file Integration tests for account security questions.
  */
 
-import { randomLabel, randomString } from 'support/util/random';
-import { mockGetProfile } from 'support/intercepts/profile';
+import { securityQuestionsFactory } from 'src/factories/profile';
+import {
+  mockGetSecurityQuestions,
+  mockUpdateSecurityQuestions,
+} from 'support/intercepts/profile';
 import { ui } from 'support/ui';
 import { assertToast } from 'support/ui/events';
 
+/**
+ * Finds the "Security Questions" section on the profile auth page.
+ *
+ * @returns Cypress chainable.
+ */
+const getSecurityQuestionsSection = (): Cypress.Chainable => {
+  return cy.contains('h3', 'Security Questions').parent();
+};
+
+/**
+ * Finds the element containing the given security question's question field.
+ *
+ * @param questionNumber - Security question number (1-3) for which to retrieve question element.
+ *
+ * @returns Cypress chainable.
+ */
+const getSecurityQuestion = (questionNumber: number): Cypress.Chainable => {
+  return cy.contains('label', `Question ${questionNumber}`).parent();
+};
+
+/**
+ * Finds the element containing the given security question's answer field.
+ *
+ * @param questionNumber - Security question number (1-3) for which to retrieve answer element.
+ *
+ * @returns Cypress chainable.
+ */
+const getSecurityQuestionAnswer = (
+  questionNumber: number
+): Cypress.Chainable => {
+  return cy.contains('label', `Answer ${questionNumber}`).parent();
+};
+
+/**
+ * Clicks the "Edit" button next to a security question.
+ *
+ * @param questionNumber - Security question number (1-3) to edit.
+ */
+const editQuestion = (questionNumber: number) => {
+  getSecurityQuestion(questionNumber).within(() => {
+    ui.button
+      .findByTitle('Edit')
+      .should('be.visible')
+      .should('be.enabled')
+      .click({ scrollBehavior: 'center' });
+  });
+};
+
+/**
+ * Asserts that a security question answer matches the given value.
+ *
+ * This assumes that the security question is already in its 'Edit' state.
+ *
+ * @param questionNumber - Security question number (1-3) with value to assert.
+ * @param answer - Security question answer value to assert.
+ */
+const assertSecurityQuestionAnswer = (
+  questionNumber: number,
+  answer: string
+) => {
+  getSecurityQuestionAnswer(questionNumber).within(() => {
+    cy.get('[data-testid="textfield-input"]').should('have.value', answer);
+  });
+};
+
+/**
+ * Sets the question and answer for the given security question.
+ *
+ * This assumes that the security question is already in its 'Edit' state.
+ *
+ * @param questionNumber - Security question number (1-3) to set.
+ * @param question - String containing contents of question to set.
+ * @param answer - Answer to assign for question.
+ */
+const setSecurityQuestionAnswer = (
+  questionNumber: number,
+  question: string,
+  answer: string
+) => {
+  getSecurityQuestion(questionNumber).within(() => {
+    cy.get('[data-qa-enhanced-select]')
+      .should('be.visible')
+      .click()
+      .type(`${question}{enter}`);
+  });
+
+  getSecurityQuestionAnswer(questionNumber).within(() => {
+    cy.get('[data-testid="textfield-input"]')
+      .should('be.visible')
+      .should('be.enabled')
+      .click()
+      .type(answer);
+  });
+};
+
 describe('Account security questions', () => {
-  it('can set account security questions for the first time', () => {});
+  /*
+   * - Validates first-time security question answer flow using mocked data.
+   * - Confirms that user cannot enable TFA before answering security questions.
+   * - Confirms that user cannot submit answers before answering all 3 questions.
+   * - Confirms UI flow when user submits security questions and answers.
+   */
+  it('can set account security questions for the first time', () => {
+    const securityQuestions = securityQuestionsFactory.build();
+    const securityQuestionAnswers = ['Answer 1', 'Answer 2', 'Answer 3'];
 
-  it('can update account security questions', () => {});
+    const securityQuestionsPayload = {
+      security_questions: [
+        { question_id: 1, response: securityQuestionAnswers[0] },
+        { question_id: 2, response: securityQuestionAnswers[1] },
+        { question_id: 3, response: securityQuestionAnswers[2] },
+      ],
+    };
 
-  // @TODO Consider moving to TFA tests once they are written.
-  // @TODO Consider ways to test this with real API calls.
-  it('cannot enable or reset TFA without security questions', () => {});
+    const tfaSecurityQuestionsWarning =
+      'To use two-factor authentication you must set up your security questions listed below.';
+
+    mockGetSecurityQuestions(securityQuestions).as('getSecurityQuestions');
+    mockUpdateSecurityQuestions(securityQuestionsPayload).as(
+      'setSecurityQuestions'
+    );
+
+    cy.visitWithLogin('/profile/auth');
+    cy.wait('@getSecurityQuestions');
+
+    // Confirm that user is informed that they must answer security questions to enable TFA.
+    cy.findByText(tfaSecurityQuestionsWarning).should('be.visible');
+
+    // Confirm that "Add Security Questions" button is initially disabled.
+    ui.button
+      .findByTitle('Add Security Questions')
+      .should('be.visible')
+      .should('be.disabled');
+
+    setSecurityQuestionAnswer(
+      1,
+      securityQuestions.security_questions[0].question,
+      securityQuestionAnswers[0]
+    );
+
+    // Confirm that submission button is now enabled, but clicking it shows an error.
+    ui.button
+      .findByTitle('Add Security Questions')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    assertToast('You must answer all 3 security questions.');
+
+    setSecurityQuestionAnswer(
+      2,
+      securityQuestions.security_questions[1].question,
+      securityQuestionAnswers[1]
+    );
+
+    setSecurityQuestionAnswer(
+      3,
+      securityQuestions.security_questions[2].question,
+      securityQuestionAnswers[2]
+    );
+
+    ui.button
+      .findByTitle('Add Security Questions')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    cy.wait('@setSecurityQuestions');
+    assertToast('Successfully added your security questions');
+
+    // Confirm that TFA security questions warning goes away after answering security questions.
+    cy.contains(tfaSecurityQuestionsWarning).should('not.exist');
+
+    // Confirm that security questions submit button changes to "Update Security Questions".
+    ui.button
+      .findByTitle('Update Security Questions')
+      .should('be.visible')
+      .should('be.disabled');
+
+    // Confirm that chosen security questions are displayed.
+    getSecurityQuestionsSection().within(() => {
+      securityQuestions.security_questions
+        .map((securityQuestion) => securityQuestion.question)
+        .slice(0, 3)
+        .forEach((securityQuestion: string) => {
+          cy.findByText(securityQuestion).should('be.visible');
+        });
+    });
+  });
+
+  /**
+   * - Validates security questinos update flow using mocked data.
+   * - Confirms UI flow when user updates their security questions and answers.
+   * - Confirms UI flow when user cancels while updating their security questions and answers.
+   */
+  it('can update account security questions', () => {
+    const securityQuestions = securityQuestionsFactory.build();
+
+    // Pre-set answers for security questions.
+    const securityQuestionAnswers = [
+      'Original Answer 1',
+      'Original Answer 2',
+      'Original Answer 3',
+    ];
+
+    securityQuestions.security_questions[0].response =
+      securityQuestionAnswers[0];
+    securityQuestions.security_questions[1].response =
+      securityQuestionAnswers[1];
+    securityQuestions.security_questions[2].response =
+      securityQuestionAnswers[2];
+
+    // Newly-chosen questions for security questions.
+    const newSecurityQuestions = [
+      securityQuestions.security_questions[3].question,
+      securityQuestions.security_questions[4].question,
+      securityQuestions.security_questions[5].question,
+    ];
+
+    // New answers for newly-chosen security questions.
+    const newSecurityQuestionAnswers = [
+      'New Answer 1',
+      'New Answer 2',
+      'New Answer 3',
+    ];
+
+    // Payload containing updated security question data.
+    const securityQuestionsPayload = {
+      security_questions: [
+        { question_id: 4, response: newSecurityQuestionAnswers[0] },
+        { question_id: 5, response: newSecurityQuestionAnswers[1] },
+        { question_id: 6, response: newSecurityQuestionAnswers[2] },
+      ],
+    };
+
+    mockGetSecurityQuestions(securityQuestions).as('getSecurityQuestions');
+    mockUpdateSecurityQuestions(securityQuestionsPayload).as(
+      'setSecurityQuestions'
+    );
+
+    cy.visitWithLogin('/profile/auth');
+    cy.wait('@getSecurityQuestions');
+
+    ui.button
+      .findByTitle('Update Security Questions')
+      .should('be.visible')
+      .should('be.disabled');
+
+    // Begin editing question 1, but cancel before saving changes.
+    editQuestion(1);
+    assertSecurityQuestionAnswer(1, securityQuestionAnswers[0]);
+    setSecurityQuestionAnswer(
+      1,
+      newSecurityQuestions[0],
+      newSecurityQuestionAnswers[0]
+    );
+
+    ui.button
+      .findByTitle('Cancel')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    editQuestion(1);
+    assertSecurityQuestionAnswer(1, securityQuestionAnswers[0]);
+    setSecurityQuestionAnswer(
+      1,
+      newSecurityQuestions[0],
+      newSecurityQuestionAnswers[0]
+    );
+
+    editQuestion(2);
+    assertSecurityQuestionAnswer(2, securityQuestionAnswers[1]);
+    setSecurityQuestionAnswer(
+      2,
+      newSecurityQuestions[1],
+      newSecurityQuestionAnswers[1]
+    );
+
+    editQuestion(3);
+    assertSecurityQuestionAnswer(3, securityQuestionAnswers[2]);
+    setSecurityQuestionAnswer(
+      3,
+      newSecurityQuestions[2],
+      newSecurityQuestionAnswers[2]
+    );
+
+    ui.button
+      .findByTitle('Update Security Questions')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+    cy.wait('@setSecurityQuestions');
+
+    assertToast('Successfully updated your security questions');
+
+    // Confirm that 'Update Security Questions' button is disabled again.
+    ui.button
+      .findByTitle('Update Security Questions')
+      .should('be.visible')
+      .should('be.disabled');
+
+    // Confirm that new security questions are displayed.
+    getSecurityQuestionsSection().within(() => {
+      newSecurityQuestions.forEach((securityQuestion: string) => {
+        cy.findByText(securityQuestion).should('be.visible');
+      });
+    });
+  });
 });

--- a/packages/manager/cypress/integration/account/security-questions.spec.ts
+++ b/packages/manager/cypress/integration/account/security-questions.spec.ts
@@ -1,0 +1,18 @@
+/**
+ * @file Integration tests for account security questions.
+ */
+
+import { randomLabel, randomString } from 'support/util/random';
+import { mockGetProfile } from 'support/intercepts/profile';
+import { ui } from 'support/ui';
+import { assertToast } from 'support/ui/events';
+
+describe('Account security questions', () => {
+  it('can set account security questions for the first time', () => {});
+
+  it('can update account security questions', () => {});
+
+  // @TODO Consider moving to TFA tests once they are written.
+  // @TODO Consider ways to test this with real API calls.
+  it('cannot enable or reset TFA without security questions', () => {});
+});

--- a/packages/manager/cypress/support/intercepts/profile.ts
+++ b/packages/manager/cypress/support/intercepts/profile.ts
@@ -3,7 +3,11 @@
  */
 
 import { makeErrorResponse } from 'support/util/errors';
-import { Profile } from '@linode/api-v4/lib/profile/types';
+import {
+  Profile,
+  SecurityQuestionsData,
+  SecurityQuestionsPayload,
+} from '@linode/api-v4/lib/profile/types';
 
 /**
  * Intercepts GET request to fetch profile and mocks response.
@@ -27,6 +31,8 @@ export const mockSmsVerificationOptOut = (): Cypress.Chainable<null> => {
 
 /**
  * Intercepts POST request to send SMS verification code and mocks response.
+ *
+ * @returns Cypress chainable.
  */
 export const mockSendVerificationCode = (): Cypress.Chainable<null> => {
   return cy.intercept('POST', '*/profile/phone-number', {});
@@ -47,4 +53,38 @@ export const mockVerifyVerificationCode = (
 ): Cypress.Chainable<null> => {
   const response = !!errorMessage ? makeErrorResponse(errorMessage) : {};
   return cy.intercept('POST', '*/profile/phone-number/verify', response);
+};
+
+/**
+ * Intercepts GET request to fetch security question data and mocks response.
+ *
+ * @param securityQuestionsData - Security questions response data.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetSecurityQuestions = (
+  securityQuestionsData: SecurityQuestionsData
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'GET',
+    '*/profile/security-questions',
+    securityQuestionsData
+  );
+};
+
+/**
+ * Intercepts POST request to update security questions and mocks response.
+ *
+ * @param securityQuestionsPayload - Security questions response data.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockUpdateSecurityQuestions = (
+  securityQuestionsPayload: SecurityQuestionsPayload
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'POST',
+    '*/profile/security-questions',
+    securityQuestionsPayload
+  );
 };

--- a/packages/manager/cypress/support/intercepts/profile.ts
+++ b/packages/manager/cypress/support/intercepts/profile.ts
@@ -1,0 +1,17 @@
+/**
+ * @file Cypress intercepts and mocks for Cloud Manager profile requests.
+ */
+
+import { makeErrorResponse } from 'support/util/errors';
+import { Profile } from '@linode/api-v4/lib/profile/types';
+
+/**
+ * Intercepts GET request to fetch profile and mocks response.
+ *
+ * @param profile - Profile with which to respond.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetProfile = (profile: Profile): Cypress.Chainable<null> => {
+  return cy.intercept('GET', '*/profile', profile);
+};


### PR DESCRIPTION
## Description

**What does this PR do?**
This PR adds Cypress integration tests for account security questions at `/profile/auth`. These tests use mocked data to confirm that the Cloud Manager UI responds accordingly when adding and updating security questions.

## How to test

**How do I run relevant tests?**


**⚠️ Note:** these tests may fail if you have not yet dismissed the banner regarding Linode/Akamai billing. This is because the banner is displayed over the Cloud Manager content, and in some circumstances can block Cypress's click attempts.

To run via CLI:
```
yarn cy:run -s "cypress/integration/account/security-questions.spec.ts"
```

To run interactively:
```
yarn cy:debug
```
Then search for _security-questions_.