### PR TITLE
Increase Cypress request timeout to 30 seconds from 20 seconds

### DIFF
--- a/packages/manager/cypress.json
+++ b/packages/manager/cypress.json
@@ -7,7 +7,7 @@
   "viewportWidth": 1440,
   "viewportHeight": 900,
   "projectId": "5rhsif",
-  "requestTimeout": 20000,
+  "requestTimeout": 30000,
   "responseTimeout": 80000,
   "retries": 2
 }


### PR DESCRIPTION
## Description

**What does this PR do?**
This PR increases Cypress's request timeout from 20 seconds to 30 seconds. This should help prevent failures that are related to the slow `/account` response time for some of our test accounts while we explore longterm solutions.

## How to test

**What are the steps to reproduce the issue or verify the changes?**
There isn't much to verify since this is a config change and not a code change, but you could run `yarn cy:debug`, run pretty much any test, and observe that the timeout displayed in the left sidebar is 30 seconds rather than 20 seconds.
