### PR TITLE
M3-5889: Safari on iOS Accessibility and Zoom Fix

### DIFF
--- a/packages/manager/public/index.html
+++ b/packages/manager/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+      content="width=device-width, initial-scale=1.0"
     />
     <meta name="theme-color" content="#000000" />
     <% if (process.env.NODE_ENV === 'production') { %>

--- a/packages/manager/src/components/EnhancedSelect/EnhancedSelect.css
+++ b/packages/manager/src/components/EnhancedSelect/EnhancedSelect.css
@@ -3,7 +3,7 @@
   box-sizing: 'content-box';
   overflow: 'hidden';
   text-overflow: 'ellipsis';
-  font-size: .9rem;
+  font-size: 1rem;
   box-sizing: content-box;
   transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1), color .2s cubic-bezier(0.4, 0, 0.2, 1);
   font-weight: 400;

--- a/packages/manager/src/components/EnhancedSelect/Select.styles.ts
+++ b/packages/manager/src/components/EnhancedSelect/Select.styles.ts
@@ -111,7 +111,7 @@ export const styles = (theme: Theme) =>
         backgroundColor: theme.bg.white,
         cursor: 'pointer',
         padding: '10px',
-        fontSize: '0.9rem',
+        fontSize: '1rem',
         '& svg': {
           marginTop: 2,
         },
@@ -188,7 +188,7 @@ export const styles = (theme: Theme) =>
       },
     },
     input: {
-      fontSize: '0.9rem',
+      fontSize: '1rem',
       padding: 0,
       display: 'flex',
       color: theme.palette.text.primary,
@@ -428,7 +428,7 @@ export const reactSelectStyles = (theme: Theme) => ({
       backgroundColor: theme.bg.white,
       cursor: 'pointer',
       padding: '10px',
-      fontSize: '0.9rem',
+      fontSize: '1rem',
     };
 
     if (state.isFocused) {

--- a/packages/manager/src/components/EnhancedSelect/Select.styles.ts
+++ b/packages/manager/src/components/EnhancedSelect/Select.styles.ts
@@ -436,7 +436,7 @@ export const reactSelectStyles = (theme: Theme) => ({
       padding: '10px',
       fontSize: '0.9rem',
       [theme.breakpoints.only('xs')]: {
-        fontSize: '0.9rem',
+        fontSize: '1.0rem',
       },
     };
 

--- a/packages/manager/src/components/EnhancedSelect/Select.styles.ts
+++ b/packages/manager/src/components/EnhancedSelect/Select.styles.ts
@@ -111,7 +111,10 @@ export const styles = (theme: Theme) =>
         backgroundColor: theme.bg.white,
         cursor: 'pointer',
         padding: '10px',
-        fontSize: '1rem',
+        fontSize: '0.9rem',
+        [theme.breakpoints.only('xs')]: {
+          fontSize: '1rem',
+        },
         '& svg': {
           marginTop: 2,
         },
@@ -188,7 +191,10 @@ export const styles = (theme: Theme) =>
       },
     },
     input: {
-      fontSize: '1rem',
+      fontSize: '0.9rem',
+      [theme.breakpoints.only('xs')]: {
+        fontSize: '1rem',
+      },
       padding: 0,
       display: 'flex',
       color: theme.palette.text.primary,
@@ -428,7 +434,10 @@ export const reactSelectStyles = (theme: Theme) => ({
       backgroundColor: theme.bg.white,
       cursor: 'pointer',
       padding: '10px',
-      fontSize: '1rem',
+      fontSize: '0.9rem',
+      [theme.breakpoints.only('xs')]: {
+        fontSize: '0.9rem',
+      },
     };
 
     if (state.isFocused) {

--- a/packages/manager/src/components/EnhancedSelect/components/SelectPlaceholder.tsx
+++ b/packages/manager/src/components/EnhancedSelect/components/SelectPlaceholder.tsx
@@ -18,7 +18,10 @@ const styles = (theme: Theme) =>
       wordWrap: 'normal',
       whiteSpace: 'nowrap',
       overflow: 'hidden',
-      fontSize: '1rem',
+      fontSize: '0.9rem',
+      [theme.breakpoints.only('xs')]: {
+        fontSize: '1rem',
+      },
     },
   });
 

--- a/packages/manager/src/components/EnhancedSelect/components/SelectPlaceholder.tsx
+++ b/packages/manager/src/components/EnhancedSelect/components/SelectPlaceholder.tsx
@@ -18,7 +18,7 @@ const styles = (theme: Theme) =>
       wordWrap: 'normal',
       whiteSpace: 'nowrap',
       overflow: 'hidden',
-      fontSize: '0.9rem',
+      fontSize: '1rem',
     },
   });
 

--- a/packages/manager/src/components/EnhancedSelect/components/SingleValue.tsx
+++ b/packages/manager/src/components/EnhancedSelect/components/SingleValue.tsx
@@ -11,7 +11,10 @@ const useStyles = makeStyles((theme: Theme) => ({
     height: '100%',
   },
   icon: {
-    fontSize: '1.52em',
+    fontSize: '1.8em',
+    [theme.breakpoints.only('xs')]: {
+      fontSize: '1.52em',
+    },
     height: 24,
     marginLeft: 6,
     marginRight: theme.spacing(),

--- a/packages/manager/src/components/EnhancedSelect/components/SingleValue.tsx
+++ b/packages/manager/src/components/EnhancedSelect/components/SingleValue.tsx
@@ -11,7 +11,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     height: '100%',
   },
   icon: {
-    fontSize: '1.8em',
+    fontSize: '1.52em',
     height: 24,
     marginLeft: 6,
     marginRight: theme.spacing(),

--- a/packages/manager/src/components/ImageSelect/ImageOption.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageOption.tsx
@@ -16,7 +16,8 @@ const useStyles = makeStyles((theme: Theme) => ({
     color: 'white',
   },
   icon: {
-    fontSize: '1.8em',
+    fontSize: '1.52em',
+    marginLeft: theme.spacing(),
   },
 }));
 
@@ -50,9 +51,7 @@ export const ImageOption: React.FC<CombinedProps> = (props) => {
         alignItems="center"
         justifyContent="flex-start"
       >
-        <Grid item className="py0">
-          <span className={`${props.data.className} ${classes.icon}`} />
-        </Grid>
+        <span className={`${props.data.className} ${classes.icon}`} />
         <Grid item>{label}</Grid>
       </Grid>
     </Option>

--- a/packages/manager/src/components/ImageSelect/ImageOption.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageOption.tsx
@@ -16,7 +16,10 @@ const useStyles = makeStyles((theme: Theme) => ({
     color: 'white',
   },
   icon: {
-    fontSize: '1.52em',
+    fontSize: '1.8em',
+    [theme.breakpoints.only('xs')]: {
+      fontSize: '1.52em',
+    },
     marginLeft: theme.spacing(),
   },
 }));

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -850,7 +850,10 @@ const themeDefaults: ThemeDefaults = () => {
         disabled: {},
         input: {
           boxSizing: 'border-box',
-          fontSize: '1rem',
+          fontSize: '0.9rem',
+          [breakpoints.only('xs')]: {
+            fontSize: '1rem',
+          },
           padding: 8,
         },
         formControl: {
@@ -866,7 +869,10 @@ const themeDefaults: ThemeDefaults = () => {
       },
       MuiInputAdornment: {
         root: {
-          fontSize: '1rem',
+          fontSize: '0.9rem',
+          [breakpoints.only('xs')]: {
+            fontSize: '1rem',
+          },
           color: '#606469',
           whiteSpace: 'nowrap',
           '& p': {

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -850,7 +850,7 @@ const themeDefaults: ThemeDefaults = () => {
         disabled: {},
         input: {
           boxSizing: 'border-box',
-          fontSize: '.9rem',
+          fontSize: '1rem',
           padding: 8,
         },
         formControl: {
@@ -866,11 +866,11 @@ const themeDefaults: ThemeDefaults = () => {
       },
       MuiInputAdornment: {
         root: {
-          fontSize: '.9rem',
+          fontSize: '1rem',
           color: '#606469',
           whiteSpace: 'nowrap',
           '& p': {
-            fontSize: '.9rem',
+            fontSize: '1rem',
             color: '#606469',
           },
         },

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -876,7 +876,10 @@ const themeDefaults: ThemeDefaults = () => {
           color: '#606469',
           whiteSpace: 'nowrap',
           '& p': {
-            fontSize: '1rem',
+            fontSize: '0.9rem',
+            [breakpoints.only('xs')]: {
+              fontSize: '1rem',
+            },
             color: '#606469',
           },
         },


### PR DESCRIPTION
## Description 📝

- In Safari on iOS, the browser zooms in when a user clicks into any TextField. This is very annoying and not great.
- At first I thought it was an issue with our `<meta name="viewport" />`, but it's not the main issue.
- After some research I found that Safari will do this if your input font size is less than 16px.
- The fix was to make all inputs have a font size of `1rem` / `16px` on `XS` screen sizes

### Before 🚫

https://user-images.githubusercontent.com/6440455/178029324-c51c5c89-ed39-4ee1-8759-dfc315506630.mp4

### After ✅

https://user-images.githubusercontent.com/6440455/178029338-323030c5-453e-4997-8100-cc3729f21bec.mp4

## How to test 🧪

- Test Cloud Manager's inputs in your computer's browser
- Test Cloud Manager on your mobile phone's browser
