### PR TITLE
Add Kali distro icon

### DIFF
--- a/packages/manager/src/components/ImageSelect/icons.ts
+++ b/packages/manager/src/components/ImageSelect/icons.ts
@@ -7,6 +7,7 @@ export const distroIcons = {
   Debian: 'debian',
   Fedora: 'fedora',
   Gentoo: 'gentoo',
+  Kali: 'kali-linux',
   openSUSE: 'opensuse',
   Rocky: 'rocky-linux',
   Slackware: 'slackware',


### PR DESCRIPTION
## Description
Adds Kali distro icon

![image](https://user-images.githubusercontent.com/14323019/178308359-6e7f99a8-83cc-4ae7-aa01-6b8d7bffbf74.png)


## How to test
Go to `/linodes/create` and select Kali as the image
