### PR TITLE
Fix Cypress image upload tests by improving input selector

### DIFF
--- a/packages/manager/cypress/integration/images/machine-image-upload.spec.ts
+++ b/packages/manager/cypress/integration/images/machine-image-upload.spec.ts
@@ -134,7 +134,7 @@ const uploadImage = (label: string) => {
   fbtClick(regionSelect);
   // Pass `null` to `cy.fixture()` to ensure file is encoded as a Cypress buffer object.
   cy.fixture(upload, null).then((fileContent) => {
-    cy.get('input[accept="application/x-gzip"]').attachFile({
+    cy.get('input[type="file"]').attachFile({
       fileContent,
       fileName: 'testImage',
       mimeType: 'application/x-gzip',


### PR DESCRIPTION
## Description

**What does this PR do?**
This fixes the Cypress image uploading tests by changing the selector used to find the file upload `<input />` element. The new selector is more lenient, so these tests should be less fragile going forward.

## How to test

**What are the steps to reproduce the issue or verify the changes?**

Run `yarn up`, then confirm that none of the image upload tests fail:
```
yarn cy:run -s "cypress/integration/images/machine-image-upload.spec.ts"
```
