### PR TITLE
M3-5877: Override Marketplace app doc link with LaunchDarkly

### DIFF
--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -1,4 +1,5 @@
 import { TPAProvider } from '@linode/api-v4/lib/profile';
+import { Link } from './features/OneClickApps/LinkSection';
 // These flags should correspond with active features flags in LD
 
 interface TaxBanner {
@@ -20,6 +21,7 @@ export interface Flags {
   vatBanner: TaxBanner;
   taxBanner: TaxBanner;
   oneClickApps: OneClickApp;
+  oneClickAppsDocsOverride: Record<string, Link[]>;
   promotionalOffers: PromotionalOffer[];
   mainContentBanner: MainContentBanner;
   databases: boolean;

--- a/packages/manager/src/features/OneClickApps/AppDetailDrawer.tsx
+++ b/packages/manager/src/features/OneClickApps/AppDetailDrawer.tsx
@@ -8,6 +8,7 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Drawer from 'src/components/Drawer';
 import { APP_ROOT } from 'src/constants';
+import useFlags from 'src/hooks/useFlags';
 import { sanitizeHTML } from 'src/utilities/sanitize-html';
 import { oneClickApps } from './FakeSpec';
 import LinkSection from './LinkSection';
@@ -52,6 +53,7 @@ interface Props {
 export const AppDetailDrawer: React.FunctionComponent<Props> = (props) => {
   const { stackScriptLabel, open, onClose } = props;
   const classes = useStyles();
+  const { oneClickAppsDocsOverride } = useFlags();
 
   const app = oneClickApps.find((app) => {
     const cleanedStackScriptLabel = stackScriptLabel
@@ -125,7 +127,7 @@ export const AppDetailDrawer: React.FunctionComponent<Props> = (props) => {
         {app.related_guides && (
           <LinkSection
             title="Guides"
-            links={app.related_guides}
+            links={oneClickAppsDocsOverride?.[app.name] ?? app.related_guides}
             icon={LibraryBook}
           />
         )}

--- a/packages/manager/src/features/OneClickApps/FakeSpec.ts
+++ b/packages/manager/src/features/OneClickApps/FakeSpec.ts
@@ -641,7 +641,7 @@ export const oneClickApps: OCA[] = [
       {
         title: 'Deploying Kali Linux through the Linode Marketplace',
         href:
-          'https://www.linode.com/docs/products/tools/marketplace/guides/kalilinux',
+          'https://www.linode.com/docs/products/tools/marketplace/guides/kali-linux',
       },
     ],
     related_info: [

--- a/packages/manager/src/features/OneClickApps/LinkSection.tsx
+++ b/packages/manager/src/features/OneClickApps/LinkSection.tsx
@@ -35,7 +35,7 @@ const styles = (theme: Theme) =>
     },
   });
 
-interface Link {
+export interface Link {
   href: string;
   title: string;
 }


### PR DESCRIPTION
## Description
Sometimes, there are small mismatches in a Marketplace app's doc link that break the link (missing a dash, capital letter, etc).

This PR adds the ability to override the app's doc link using LaunchDarkly so that we can fix the link without an immediate release/hotfix

## How to test
Go to Marketplace and check the docs link in the Kali Linux detail drawer with the `one-click-apps-docs-override` flag on/off
