### PR TITLE
PayPal Loading State Improvement

### DIFF
--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PayPalButton.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PayPalButton.tsx
@@ -56,7 +56,7 @@ export const PayPalButton: React.FC<Props> = (props) => {
     isLoading: clientTokenLoading,
     error: clientTokenError,
   } = useClientToken();
-  const [{ options }, dispatch] = usePayPalScriptReducer();
+  const [{ options, isPending }, dispatch] = usePayPalScriptReducer();
 
   const {
     usd,
@@ -193,7 +193,7 @@ export const PayPalButton: React.FC<Props> = (props) => {
     );
   };
 
-  if (clientTokenLoading || !options['data-client-token']) {
+  if (clientTokenLoading || isPending || !options['data-client-token']) {
     return (
       <Grid
         container

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PayPalChip.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PayPalChip.tsx
@@ -39,7 +39,7 @@ interface Props {
 export const PayPalChip: React.FC<Props> = (props) => {
   const { onClose, disabled, setProcessing, renderError } = props;
   const { data, isLoading, error: clientTokenError } = useClientToken();
-  const [{ options }, dispatch] = usePayPalScriptReducer();
+  const [{ options, isPending }, dispatch] = usePayPalScriptReducer();
   const classes = useStyles();
   const { enqueueSnackbar } = useSnackbar();
 
@@ -153,7 +153,7 @@ export const PayPalChip: React.FC<Props> = (props) => {
     return renderError('Error initializing PayPal');
   }
 
-  if (isLoading || !options['data-client-token']) {
+  if (isLoading || isPending || !options['data-client-token']) {
     return <CircleProgress mini />;
   }
 


### PR DESCRIPTION
## Description 📝

- Takes PayPal's script loading into account when rendering the PayPal button spinner
- Small difference, but creates less time where there is no spinner and no button at the same time

### Before

https://user-images.githubusercontent.com/6440455/179014587-89562fcf-c50e-46d1-8ab7-101725fdfcb0.mov

### After

https://user-images.githubusercontent.com/6440455/179014568-8f4cc36e-0650-40da-8a10-efd26c2f0f82.mov

## How to test 🧪

- Test PayPal functionality the best you can locally and on the preview link
