### PR TITLE
Align Graph Legends on Mobile

### DIFF
--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -85,7 +85,7 @@ const humanizeLargeData = (value: number) => {
 const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
   const classes = useStyles();
   const theme = useTheme<Theme>();
-  const matchesSmDown = useMediaQuery(theme.breakpoints.down(960));
+  const matchesSmDown = useMediaQuery(theme.breakpoints.down('sm'));
 
   const inputEl: React.RefObject<any> = React.useRef(null);
   const chartInstance: React.MutableRefObject<any> = React.useRef(null);

--- a/packages/manager/src/components/LineGraph/NewMetricDisplay.styles.ts
+++ b/packages/manager/src/components/LineGraph/NewMetricDisplay.styles.ts
@@ -55,7 +55,7 @@ const newMetricDisplayStyles = (theme: Theme) =>
       '& td:first-child': {
         backgroundColor: 'transparent !important',
         [theme.breakpoints.down('sm')]: {
-          marginLeft: -50,
+          marginLeft: -45,
         },
       },
       '& .data': {

--- a/packages/manager/src/components/LineGraph/NewMetricDisplay.styles.ts
+++ b/packages/manager/src/components/LineGraph/NewMetricDisplay.styles.ts
@@ -78,13 +78,6 @@ const newMetricDisplayStyles = (theme: Theme) =>
           justifyContent: 'normal',
           minHeight: 'auto',
         },
-        '& tr:not(:first-child) td': {
-          '&:first-child': {
-            marginTop: theme.spacing(2),
-          },
-        },
-      },
-      [theme.breakpoints.only('sm')]: {
         '& tbody': {
           display: 'flex',
           flexWrap: 'wrap',
@@ -92,6 +85,8 @@ const newMetricDisplayStyles = (theme: Theme) =>
         },
         '& tr': {
           flexBasis: '100%',
+          display: 'flex',
+          flexDirection: 'column',
         },
       },
     },
@@ -105,8 +100,8 @@ const newMetricDisplayStyles = (theme: Theme) =>
         '& tr': {
           display: 'flex',
           flexDirection: 'column',
-          marginTop: 26,
-          marginBottom: 42,
+          marginTop: theme.spacing(5.25),
+          marginBottom: theme.spacing(5.25),
           marginRight: theme.spacing(2),
           '&:last-of-type': {
             marginBottom: 0,


### PR DESCRIPTION
## Description

- These changes make it so that the graph legends for the Linode Analytics tab line up on mobile
- This issue was reported in https://github.com/linode/manager/issues/7893


<details>
  <summary>Before</summary>

  ![image](https://user-images.githubusercontent.com/52019096/179052164-331bf527-08d4-4fee-9ae7-efae1d1b8f39.png)

</details>

<details>
  <summary>After</summary>

  ![image](https://user-images.githubusercontent.com/52019096/179052341-bcd6e7e3-d5fa-49c5-bcf5-b0127307ac19.png)

</details>

## How to test

- Run Cloud Manager locally
- Open an account with a running Linode
- Observe the graph legends in the analytics tab

Please let me know if you have any questions!