### PR TITLE
M3-5864: Add MSW handlers for `/account/users` and `/object-storage/keys` requests

### DIFF
--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -50,6 +50,7 @@ import {
   notificationFactory,
   objectStorageBucketFactory,
   objectStorageClusterFactory,
+  objectStorageKeyFactory,
   paymentMethodFactory,
   possibleMySQLReplicationTypes,
   possiblePostgresReplicationTypes,
@@ -586,6 +587,11 @@ export const handlers = [
     const clusters = objectStorageClusterFactory.buildList(3);
     return res(ctx.json(makeResourcePage(clusters)));
   }),
+  rest.get('*object-storage/keys', (req, res, ctx) => {
+    return res(
+      ctx.json(makeResourcePage(objectStorageKeyFactory.buildList(3)))
+    );
+  }),
   rest.get('*/domains', (req, res, ctx) => {
     const domains = domainFactory.buildList(10);
     return res(ctx.json(makeResourcePage(domains)));
@@ -734,6 +740,31 @@ export const handlers = [
     }
 
     return res(ctx.json(makeResourcePage(accountMaintenance)));
+  }),
+  rest.get('*/account/users', (req, res, ctx) => {
+    return res(ctx.json(makeResourcePage([profileFactory.build()])));
+  }),
+  rest.get('*/account/users/:user', (req, res, ctx) => {
+    return res(ctx.json(profileFactory.build()));
+  }),
+  rest.get('*/account/users/:user/grants', (req, res, ctx) => {
+    return res(
+      ctx.json(
+        grantsFactory.build({
+          global: {
+            cancel_account: true,
+          },
+          domain: [],
+          firewall: [],
+          image: [],
+          linode: [],
+          longview: [],
+          nodebalancer: [],
+          stackscript: [],
+          volume: [],
+        })
+      )
+    );
   }),
   rest.get('*/account/payment-methods', (req, res, ctx) => {
     const defaultPaymentMethod = paymentMethodFactory.build({


### PR DESCRIPTION
## Description

**What does this PR do?**
This adds MSW handlers for GET requests to `/account/users`, `/object-storage/keys`, and related endpoints. The primary motivation for this is to clean up the console warnings that appear when running Jest, but adding these handlers also allows us to mock the account users pages (including grants and profiles) and the object storage access keys landing page.

Note that because I did not add any handlers for update operations, attempting to edit anything related to account users or access keys with MSW enabled will result in not found errors.

## How to test

**What are the steps to reproduce the issue or verify the changes?**
1. Confirm that no MSW warning is shown in the console when running the affected tests:

```
yarn test AccessKeyLanding.test UserMenu.test
```

2. (Optional) Confirm that no other MSW warnings appear in the console when running all tests

```
yarn test
```

3. (Optional) Open Cloud Manager, enable MSW, and navigate to these URLs, confirming that they appear and behave as expected:
    - [/account/users](http://localhost:3000/account/users)
    - [/account/users/mock-user](http://localhost:3000/account/users/mock-user)
    - [/account/users/mock-user/permissions](http://localhost:3000/account/users/mock-user/permissions)
    - [/object-storage/access-keys](http://localhost:3000/object-storage/access-keys)