### PR TITLE
[Hotfix] Add dismissible banner to Database Landing and Database Create pages re: maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2022-07-20] - v1.71.1
+
+### Added:
+- Banner regarding maintenance to the Databases Landing and Database Create pages
+
 ## [2022-07-12] - v1.71.0
 
 ### Added:

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.71.0",
+  "version": "1.71.1",
   "private": true,
   "engines": {
     "node": ">= 14.17.4"

--- a/packages/manager/src/components/ProductInformationBanner/ProductInformationBanner.tsx
+++ b/packages/manager/src/components/ProductInformationBanner/ProductInformationBanner.tsx
@@ -8,29 +8,27 @@ import { isAfter } from 'src/utilities/date';
 import { reportException } from 'src/exceptionReporting';
 import Warning from 'src/assets/icons/warning.svg';
 import { makeStyles, Theme } from 'src/components/core/styles';
-import Grid from 'src/components/Grid';
 import classNames from 'classnames';
-
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
     display: 'flex',
     alignItems: 'center',
     borderRadius: 1,
     fontSize: '1rem',
-    // marginBottom: theme.spacing(2),
+    marginBottom: theme.spacing(2),
     maxWidth: '100%',
-    // padding: '4px 16px',
-    // paddingRight: 18,
+    padding: '4px 16px',
+    paddingRight: 18,
     position: 'relative',
-    // '& + .notice': {
-    //   marginTop: `${theme.spacing()}px !important`,
-    // },
+    '& + .notice': {
+      marginTop: `${theme.spacing()}px !important`,
+    },
     '& $important': {
       backgroundColor: theme.bg.bgPaper,
     },
-    // '& $error': {
-    //   borderLeftColor: theme.color.red,
-    // },
+    '& $error': {
+      borderLeftColor: theme.color.red,
+    },
   },
   icon: {
     color: 'white',
@@ -54,6 +52,10 @@ const useStyles = makeStyles((theme: Theme) => ({
     '& $icon': {
       color: '#555',
     },
+  },
+  content: {
+    // Compensate for HighlightedMarkdown component's margin.
+    marginLeft: '-8px',
   },
 }));
 
@@ -103,30 +105,22 @@ const ProductInformationBanner: React.FC<Props> = (props) => {
 
   return (
     <DismissibleBanner
+      className={classNames({
+        [classes.root]: true,
+        [classes.important]: true,
+        [classes.warning]: true,
+        notice: true,
+      })}
       preferenceKey={thisBanner.key}
       productInformationIndicator={displayProductInformationIndicator}
     >
       <>
         {displayProductInformationWarning ? (
-          <Grid
-            item
-            className={classNames({
-              [classes.root]: true,
-              [classes.important]: true,
-              [classes.warning]: true,
-              notice: true,
-            })}
-            style={{
-              marginTop: 0,
-              marginBottom: 24,
-              marginLeft: 0,
-            }}
-            role="alert"
-          >
-            <Warning className={classes.icon} data-qa-warning-img />
-          </Grid>
+          <Warning className={classes.icon} data-qa-warning-img />
         ) : null}
-        <HighlightedMarkdown textOrMarkdown={thisBanner.message} />
+        <div className={classes.content}>
+          <HighlightedMarkdown textOrMarkdown={thisBanner.message} />
+        </div>
       </>
     </DismissibleBanner>
   );

--- a/packages/manager/src/components/ProductInformationBanner/ProductInformationBanner.tsx
+++ b/packages/manager/src/components/ProductInformationBanner/ProductInformationBanner.tsx
@@ -6,13 +6,78 @@ import DismissibleBanner from '../DismissibleBanner';
 import HighlightedMarkdown from 'src/components/HighlightedMarkdown';
 import { isAfter } from 'src/utilities/date';
 import { reportException } from 'src/exceptionReporting';
+import Warning from 'src/assets/icons/warning.svg';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import Grid from 'src/components/Grid';
+import classNames from 'classnames';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    display: 'flex',
+    alignItems: 'center',
+    borderRadius: 1,
+    fontSize: '1rem',
+    // marginBottom: theme.spacing(2),
+    maxWidth: '100%',
+    // padding: '4px 16px',
+    // paddingRight: 18,
+    position: 'relative',
+    // '& + .notice': {
+    //   marginTop: `${theme.spacing()}px !important`,
+    // },
+    '& $important': {
+      backgroundColor: theme.bg.bgPaper,
+    },
+    // '& $error': {
+    //   borderLeftColor: theme.color.red,
+    // },
+  },
+  icon: {
+    color: 'white',
+    position: 'absolute',
+    left: -25, // This value must be static regardless of theme selection
+  },
+  important: {
+    backgroundColor: theme.bg.bgPaper,
+    padding: theme.spacing(2),
+    paddingRight: 18,
+    '& $noticeText': {
+      fontFamily: theme.font.normal,
+    },
+  },
+  warning: {
+    animation: '$fadeIn 225ms linear forwards',
+    borderLeft: `5px solid ${theme.palette.status.warningDark}`,
+    '&$important': {
+      borderLeftWidth: 32,
+    },
+    '& $icon': {
+      color: '#555',
+    },
+  },
+}));
 
 interface Props {
   bannerLocation: ProductInformationBannerLocation;
+  productInformationIndicator?: boolean;
+  productInformationWarning?: boolean;
 }
 
 const ProductInformationBanner: React.FC<Props> = (props) => {
   const { productInformationBanners } = useFlags();
+
+  const classes = useStyles();
+
+  // This component is primarily used to display marketing information, which has a green left border. We therefore have it default to true.
+  const displayProductInformationIndicator =
+    props.productInformationIndicator ?? true;
+
+  /*
+    In select instances, we also use this component to display warning information, e.g. provisioning of new database instances
+    not being possible due to product maintenance. We have it default to false.
+  */
+  const displayProductInformationWarning =
+    props.productInformationWarning ?? false;
 
   const thisBanner = (productInformationBanners ?? []).find(
     (thisBanner) => thisBanner.bannerLocation === props.bannerLocation
@@ -39,9 +104,30 @@ const ProductInformationBanner: React.FC<Props> = (props) => {
   return (
     <DismissibleBanner
       preferenceKey={thisBanner.key}
-      productInformationIndicator
+      productInformationIndicator={displayProductInformationIndicator}
     >
-      <HighlightedMarkdown textOrMarkdown={thisBanner.message} />
+      <>
+        {displayProductInformationWarning ? (
+          <Grid
+            item
+            className={classNames({
+              [classes.root]: true,
+              [classes.important]: true,
+              [classes.warning]: true,
+              notice: true,
+            })}
+            style={{
+              marginTop: 0,
+              marginBottom: 24,
+              marginLeft: 0,
+            }}
+            role="alert"
+          >
+            <Warning className={classes.icon} data-qa-warning-img />
+          </Grid>
+        ) : null}
+        <HighlightedMarkdown textOrMarkdown={thisBanner.message} />
+      </>
     </DismissibleBanner>
   );
 };

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -88,7 +88,7 @@ interface ReferralBannerText {
   };
 }
 
-export type ProductInformationBannerLocation = 'Object Storage';
+export type ProductInformationBannerLocation = 'Object Storage' | 'Databases';
 
 export interface ProductInformationBannerFlag {
   // `key` should be unique across product information banners

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -38,6 +38,7 @@ import Grid from 'src/components/Grid';
 import Link from 'src/components/Link';
 import MultipleIPInput from 'src/components/MultipleIPInput';
 import Notice from 'src/components/Notice';
+import ProductInformationBanner from 'src/components/ProductInformationBanner';
 import Radio from 'src/components/Radio';
 import { regionHelperText } from 'src/components/SelectRegionPanel/SelectRegionPanel';
 import TextField from 'src/components/TextField';
@@ -447,6 +448,11 @@ const DatabaseCreate: React.FC<{}> = () => {
           </Typography>
         </DismissibleBanner>
       ) : null}
+      <ProductInformationBanner
+        bannerLocation="Databases"
+        productInformationIndicator={false}
+        productInformationWarning
+      />
       <BreadCrumb
         labelTitle="Create"
         pathname={location.pathname}

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseEmptyState.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseEmptyState.tsx
@@ -6,6 +6,7 @@ import Typography from 'src/components/core/Typography';
 import DismissibleBanner from 'src/components/DismissibleBanner';
 import Link from 'src/components/Link';
 import Placeholder from 'src/components/Placeholder';
+import ProductInformationBanner from 'src/components/ProductInformationBanner';
 import useFlags from 'src/hooks/useFlags';
 
 const useStyles = makeStyles(() => ({
@@ -42,6 +43,11 @@ const DatabaseEmptyState: React.FC = () => {
           </Typography>
         </DismissibleBanner>
       ) : null}
+      <ProductInformationBanner
+        bannerLocation="Databases"
+        productInformationIndicator={false}
+        productInformationWarning
+      />
       <Placeholder
         title="Databases"
         className={classes.root}

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
@@ -1,4 +1,6 @@
+import { DatabaseInstance } from '@linode/api-v4/lib/databases';
 import * as React from 'react';
+import { useHistory } from 'react-router-dom';
 import CircleProgress from 'src/components/CircleProgress';
 import Hidden from 'src/components/core/Hidden';
 import TableBody from 'src/components/core/TableBody';
@@ -7,17 +9,16 @@ import TableRow from 'src/components/core/TableRow';
 import ErrorState from 'src/components/ErrorState';
 import LandingHeader from 'src/components/LandingHeader';
 import PaginationFooter from 'src/components/PaginationFooter';
+import ProductInformationBanner from 'src/components/ProductInformationBanner';
 import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
 import TableSortCell from 'src/components/TableSortCell';
-import DatabaseEmptyState from './DatabaseEmptyState';
-import { useHistory } from 'react-router-dom';
 import { useOrder } from 'src/hooks/useOrder';
 import { usePagination } from 'src/hooks/usePagination';
 import { useDatabasesQuery } from 'src/queries/databases';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import DatabaseEmptyState from './DatabaseEmptyState';
 import { DatabaseRow } from './DatabaseRow';
-import { DatabaseInstance } from '@linode/api-v4/lib/databases';
 
 const preferenceKey = 'databases';
 
@@ -66,6 +67,11 @@ const DatabaseLanding: React.FC = () => {
 
   return (
     <React.Fragment>
+      <ProductInformationBanner
+        bannerLocation="Databases"
+        productInformationIndicator={false}
+        productInformationWarning
+      />
       <LandingHeader
         title="Database Clusters"
         createButtonText="Create Database Cluster"


### PR DESCRIPTION
## Description
Add a dismissible banner to the Databases Landing and Database Create pages regarding maintenance.

This PR modifies `ProductInformationBanner` to make it capable of displaying a warning icon to the left of the banner text.

## How to Test
Confirm that the dismissible banner is visible on the Databases Landing page (both the empty state and also when you have DBs) and Database Create page, and that dismissing the banner in one location dismisses it in all of them.