### PR TITLE
M3-5869: Marketplace UI Refinement: Create form

### DIFF
--- a/packages/manager/src/factories/stackscripts.ts
+++ b/packages/manager/src/factories/stackscripts.ts
@@ -1,5 +1,8 @@
 import * as Factory from 'factory.ts';
-import { StackScript } from '@linode/api-v4/lib/stackscripts/types';
+import {
+  StackScript,
+  UserDefinedField,
+} from '@linode/api-v4/lib/stackscripts/types';
 
 export const stackScriptFactory = Factory.Sync.makeFactory<StackScript>({
   id: Factory.each((i) => i),
@@ -20,3 +23,10 @@ export const stackScriptFactory = Factory.Sync.makeFactory<StackScript>({
   ordinal: 1, // default value
   logo_url: '', // default value
 });
+
+export const userDefinedFieldFactory = Factory.Sync.makeFactory<UserDefinedField>(
+  {
+    label: Factory.each((i) => `Field${i}`),
+    name: Factory.each((i) => `field${i}`),
+  }
+);

--- a/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
+++ b/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
@@ -164,12 +164,7 @@ class UserDefinedFieldsPanel extends React.PureComponent<CombinedProps> {
     if (this.props.openDrawer !== undefined) {
       return this.props.openDrawer(this.props.selectedLabel);
     }
-
     return null;
-  };
-    this.props.openDrawer !== undefined
-      ? this.props.openDrawer(this.props.selectedLabel)
-      : undefined;
   };
 
   render() {

--- a/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
+++ b/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
@@ -11,6 +11,7 @@ import {
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
+import Box from 'src/components/core/Box';
 import RenderGuard, { RenderGuardProps } from 'src/components/RenderGuard';
 import ShowMoreExpansion from 'src/components/ShowMoreExpansion';
 import UserDefinedMultiSelect from './FieldTypes/UserDefinedMultiSelect';
@@ -21,7 +22,8 @@ type ClassNames =
   | 'root'
   | 'username'
   | 'advDescription'
-  | 'optionalFieldWrapper';
+  | 'optionalFieldWrapper'
+  | 'header';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -41,6 +43,15 @@ const styles = (theme: Theme) =>
       color: theme.color.grey1,
     },
     optionalFieldWrapper: {},
+    header: {
+      display: 'flex',
+      alignItems: 'center',
+      columnGap: theme.spacing(2),
+      '& > img': {
+        width: 60,
+        height: 60,
+      },
+    },
   });
 
 interface Props {
@@ -50,6 +61,7 @@ interface Props {
   udf_data: any;
   selectedLabel: string;
   selectedUsername: string;
+  appLogo?: JSX.Element;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -149,9 +161,12 @@ class UserDefinedFieldsPanel extends React.PureComponent<CombinedProps> {
 
     return (
       <Paper className={classes.root}>
-        <Typography variant="h2" data-qa-user-defined-field-header>
-          <span>{`${this.props.selectedLabel} Options`}</span>
-        </Typography>
+        <Box className={classes.header}>
+          {this.props.appLogo}
+          <Typography variant="h2" data-qa-user-defined-field-header>
+            <span>{`${this.props.selectedLabel} Setup`}</span>
+          </Typography>
+        </Box>
 
         {/* Required Fields */}
         {requiredUDFs.map((field: UserDefinedField) => {

--- a/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
+++ b/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
@@ -17,13 +17,16 @@ import ShowMoreExpansion from 'src/components/ShowMoreExpansion';
 import UserDefinedMultiSelect from './FieldTypes/UserDefinedMultiSelect';
 import UserDefinedSelect from './FieldTypes/UserDefinedSelect';
 import UserDefinedText from './FieldTypes/UserDefinedText';
+import AppInfo from '../../linodes/LinodesCreate/AppInfo';
+import classnames from 'classnames';
 
 type ClassNames =
   | 'root'
   | 'username'
   | 'advDescription'
   | 'optionalFieldWrapper'
-  | 'header';
+  | 'header'
+  | 'marketplaceSpacing';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -46,11 +49,15 @@ const styles = (theme: Theme) =>
     header: {
       display: 'flex',
       alignItems: 'center',
-      columnGap: theme.spacing(2),
+      columnGap: theme.spacing(),
       '& > img': {
         width: 60,
         height: 60,
       },
+    },
+    marketplaceSpacing: {
+      paddingTop: theme.spacing(),
+      paddingBottom: theme.spacing(),
     },
   });
 
@@ -62,6 +69,7 @@ interface Props {
   selectedLabel: string;
   selectedUsername: string;
   appLogo?: JSX.Element;
+  openDrawer?: (stackScriptLabel: string) => void;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -152,6 +160,10 @@ class UserDefinedFieldsPanel extends React.PureComponent<CombinedProps> {
     );
   };
 
+  handleOpenDrawer = () => {
+    this.props.openDrawer?.(this.props.selectedLabel);
+  };
+
   render() {
     const { userDefinedFields, classes } = this.props;
 
@@ -160,12 +172,20 @@ class UserDefinedFieldsPanel extends React.PureComponent<CombinedProps> {
     );
 
     return (
-      <Paper className={classes.root}>
+      <Paper
+        className={classnames(classes.root, {
+          [`${classes.marketplaceSpacing}`]:
+            this.props.openDrawer !== undefined,
+        })}
+      >
         <Box className={classes.header}>
           {this.props.appLogo}
           <Typography variant="h2" data-qa-user-defined-field-header>
             <span>{`${this.props.selectedLabel} Setup`}</span>
           </Typography>
+          {this.props.openDrawer ? (
+            <AppInfo onClick={this.handleOpenDrawer} />
+          ) : null}
         </Box>
 
         {/* Required Fields */}

--- a/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
+++ b/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
@@ -161,7 +161,9 @@ class UserDefinedFieldsPanel extends React.PureComponent<CombinedProps> {
   };
 
   handleOpenDrawer = () => {
-    this.props.openDrawer?.(this.props.selectedLabel);
+    this.props.openDrawer !== undefined
+      ? this.props.openDrawer(this.props.selectedLabel)
+      : undefined;
   };
 
   render() {

--- a/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
+++ b/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
@@ -161,6 +161,12 @@ class UserDefinedFieldsPanel extends React.PureComponent<CombinedProps> {
   };
 
   handleOpenDrawer = () => {
+    if (this.props.openDrawer !== undefined) {
+      return this.props.openDrawer(this.props.selectedLabel);
+    }
+
+    return null;
+  };
     this.props.openDrawer !== undefined
       ? this.props.openDrawer(this.props.selectedLabel)
       : undefined;

--- a/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
+++ b/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
@@ -173,11 +173,12 @@ class UserDefinedFieldsPanel extends React.PureComponent<CombinedProps> {
       userDefinedFields!
     );
 
+    const isDrawerOpenable = this.props.openDrawer !== undefined;
+
     return (
       <Paper
         className={classnames(classes.root, {
-          [`${classes.marketplaceSpacing}`]:
-            this.props.openDrawer !== undefined,
+          [`${classes.marketplaceSpacing}`]: isDrawerOpenable,
         })}
       >
         <Box className={classes.header}>
@@ -185,7 +186,7 @@ class UserDefinedFieldsPanel extends React.PureComponent<CombinedProps> {
           <Typography variant="h2" data-qa-user-defined-field-header>
             <span>{`${this.props.selectedLabel} Setup`}</span>
           </Typography>
-          {this.props.openDrawer ? (
+          {isDrawerOpenable ? (
             <AppInfo onClick={this.handleOpenDrawer} />
           ) : null}
         </Box>

--- a/packages/manager/src/features/linodes/LinodesCreate/AppInfo.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/AppInfo.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import Info from 'src/assets/icons/info.svg';
+
+interface Props {
+  onClick: () => void;
+}
+
+const getOnClickHandler = (openDrawer: Props['onClick']) => (
+  event: React.MouseEvent<any>
+) => {
+  event.stopPropagation();
+  event.preventDefault();
+  openDrawer();
+};
+
+const AppInfo = (props: Props) => {
+  const { onClick } = props;
+  const onClickHandler = getOnClickHandler(onClick);
+  return <Info onClick={onClickHandler} />;
+};
+
+export default AppInfo;

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.test.tsx
@@ -1,0 +1,73 @@
+// import * as React from 'react';
+// import { renderWithTheme } from 'src/utilities/testHelpers';
+import { imageFactory } from 'src/factories/images';
+import { userDefinedFieldFactory } from 'src/factories/stackscripts';
+
+import FromAppsContent, {
+  getCompatibleImages,
+  getDefaultUDFData,
+} from './FromAppsContent';
+
+describe('FromAppsContent', () => {
+  it('should exist', () => {
+    expect(FromAppsContent).toBeDefined();
+  });
+});
+
+describe('getCompatibleImages', () => {
+  it('should exist', () => {
+    expect(getCompatibleImages).toBeDefined();
+  });
+
+  it('should return an empty Array if an empty object or an empty array are passed', () => {
+    const bothEmtpyResult = getCompatibleImages({}, []);
+    const emptyImagesDataResult = getCompatibleImages({}, ['Debian']);
+    const emptyStackScriptImagesResult = getCompatibleImages(
+      { Test: imageFactory.build() },
+      []
+    );
+    expect(bothEmtpyResult).toEqual([]);
+    expect(emptyImagesDataResult).toEqual([]);
+    expect(emptyStackScriptImagesResult).toEqual([]);
+  });
+
+  it('should an array of Images compatible with the StackScript', () => {
+    const imagesDataArray = imageFactory.buildList(5);
+    const imagesData = imagesDataArray.reduce((acc, imageData) => {
+      acc[imageData.label] = imageData;
+      return acc;
+    }, {});
+    const stackScriptImages = Object.keys(imagesData).slice(0, 2);
+    const result = getCompatibleImages(imagesData, stackScriptImages);
+    expect(result.length).toBe(2);
+    result.forEach((image) => {
+      expect(stackScriptImages.includes(image.label));
+    });
+  });
+});
+
+describe('getDefaultUDFData', () => {
+  it('should exist', () => {
+    expect(getDefaultUDFData).toBeDefined();
+  });
+
+  it('should return an empty object when given an empty array', () => {
+    const result = getDefaultUDFData([]);
+    expect(result).toEqual({});
+  });
+
+  it('should return an object with keys that are made up of the subset of user defined fields passed that have the default property set to a string', () => {
+    // Need to get a better docsctring for this
+    const userDefinedFieldWithDefaultValue = userDefinedFieldFactory.build({
+      default: 'foobar',
+    });
+    const udfs = [
+      ...userDefinedFieldFactory.buildList(5),
+      userDefinedFieldWithDefaultValue,
+    ];
+    const result = getDefaultUDFData(udfs);
+    expect(result[userDefinedFieldWithDefaultValue.name]).toEqual(
+      userDefinedFieldWithDefaultValue.default
+    );
+  });
+});

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.test.tsx
@@ -26,7 +26,7 @@ describe('getCompatibleImages', () => {
       { Test: imageFactory.build() },
       []
     );
-    expect(bothEmtpyResult).toEqual([]);
+expect(bothEmptyResult).toEqual([]);
     expect(emptyImagesDataResult).toEqual([]);
     expect(emptyStackScriptImagesResult).toEqual([]);
   });

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.test.tsx
@@ -20,7 +20,7 @@ describe('getCompatibleImages', () => {
   });
 
   it('should return an empty Array if an empty object or an empty array are passed', () => {
-    const bothEmtpyResult = getCompatibleImages({}, []);
+    const bothEmptyResult = getCompatibleImages({}, []);
     const emptyImagesDataResult = getCompatibleImages({}, ['Debian']);
     const emptyStackScriptImagesResult = getCompatibleImages(
       { Test: imageFactory.build() },

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -202,7 +202,19 @@ class FromAppsContent extends React.PureComponent<CombinedProps, State> {
             openDrawer={this.openDrawer}
             error={hasErrorFor('stackscript_id')}
           />
-          {!userCannotCreateLinode && userDefinedFields && (
+          {!userCannotCreateLinode && userDefinedFields ? (
+            <UserDefinedFieldsPanel
+              errors={filterUDFErrors(errorResources, errors)}
+              selectedLabel={selectedStackScriptLabel || ''}
+              selectedUsername="Linode"
+              handleChange={this.handleChangeUDF}
+              userDefinedFields={userDefinedFields}
+              updateFor={[userDefinedFields, udf_data, errors]}
+              udf_data={udf_data || {}}
+              appLogo={renderLogo}
+              openDrawer={this.openDrawer}
+            />
+          ) : null}
             <UserDefinedFieldsPanel
               errors={filterUDFErrors(errorResources, errors)}
               selectedLabel={selectedStackScriptLabel || ''}

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -1,4 +1,4 @@
-import { curry } from 'lodash';
+import _, { curry } from 'lodash';
 import { Image } from '@linode/api-v4/lib/images';
 import { UserDefinedField } from '@linode/api-v4/lib/stackscripts';
 import { assocPath } from 'ramda';
@@ -74,19 +74,10 @@ interface State {
 export const getCompatibleImages = (
   imagesData: Record<string, Image>,
   stackScriptImages: string[]
-) => {
-  /* return _.compact(
-   *   stackScriptImages.map((stackScriptImage) => imagesData[stackScriptImage])
-   * ); */
-
-  return Object.keys(imagesData).reduce((acc, eachKey) => {
-    if (stackScriptImages.some((eachSSImage) => eachSSImage === eachKey)) {
-      acc.push(imagesData[eachKey]);
-    }
-
-    return acc;
-  }, [] as Image[]);
-};
+) =>
+  _.compact(
+    stackScriptImages.map((stackScriptImage) => imagesData[stackScriptImage])
+  );
 
 export const getDefaultUDFData = (userDefinedFields: UserDefinedField[]) => {
   return userDefinedFields.reduce((accum, eachField) => {
@@ -126,6 +117,7 @@ class FromAppsContent extends React.PureComponent<CombinedProps, State> {
     selectedScriptForDrawer: '',
   };
 
+  //ramda's curry placehodler conflicts with lodash so the lodash curry and placeholder is used here
   handleSelectStackScript = curriedHandleSelectStackScript(
     curry.placeholder,
     curry.placeholder,
@@ -215,18 +207,17 @@ class FromAppsContent extends React.PureComponent<CombinedProps, State> {
               openDrawer={this.openDrawer}
             />
           ) : null}
-            <UserDefinedFieldsPanel
-              errors={filterUDFErrors(errorResources, errors)}
-              selectedLabel={selectedStackScriptLabel || ''}
-              selectedUsername="Linode"
-              handleChange={this.handleChangeUDF}
-              userDefinedFields={userDefinedFields}
-              updateFor={[userDefinedFields, udf_data, errors]}
-              udf_data={udf_data || {}}
-              appLogo={renderLogo}
-              openDrawer={this.openDrawer}
-            />
-          )}
+          <UserDefinedFieldsPanel
+            errors={filterUDFErrors(errorResources, errors)}
+            selectedLabel={selectedStackScriptLabel || ''}
+            selectedUsername="Linode"
+            handleChange={this.handleChangeUDF}
+            userDefinedFields={userDefinedFields}
+            updateFor={[userDefinedFields, udf_data, errors]}
+            udf_data={udf_data || {}}
+            appLogo={renderLogo}
+            openDrawer={this.openDrawer}
+          />
           {!userCannotCreateLinode &&
           compatibleImages &&
           compatibleImages.length > 0 ? (

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { curry } from 'lodash';
 import { Image } from '@linode/api-v4/lib/images';
 import { UserDefinedField } from '@linode/api-v4/lib/stackscripts';
 import { assocPath } from 'ramda';
@@ -118,41 +118,23 @@ export const handleSelectStackScript = (
   );
 };
 
+const curriedHandleSelectStackScript = curry(handleSelectStackScript);
+
 class FromAppsContent extends React.PureComponent<CombinedProps, State> {
   state: State = {
     detailDrawerOpen: false,
     selectedScriptForDrawer: '',
   };
 
-  handleSelectStackScript = (
-    id: number,
-    label: string,
-    username: string,
-    stackScriptImages: string[],
-    userDefinedFields: UserDefinedField[]
-  ) => {
-    const { imagesData } = this.props;
-    /**
-     * based on the list of images we get back from the API, compare those
-     * to our list of public images supported by Linode and filter out the ones
-     * that aren't compatible with our selected StackScript
-     */
-    const compatibleImages = getCompatibleImages(imagesData, stackScriptImages);
-
-    /**
-     * if a UDF field comes back from the API with a "default"
-     * value, it means we need to pre-populate the field and form state
-     */
-    const defaultUDFData = getDefaultUDFData(userDefinedFields);
-    this.props.updateStackScript(
-      id,
-      label,
-      username,
-      userDefinedFields,
-      compatibleImages,
-      defaultUDFData
-    );
-  };
+  handleSelectStackScript = curriedHandleSelectStackScript(
+    curry.placeholder,
+    curry.placeholder,
+    curry.placeholder,
+    curry.placeholder,
+    curry.placeholder,
+    this.props.imagesData,
+    this.props.updateStackScript
+  );
 
   handleChangeUDF = (key: string, value: string) => {
     // either overwrite or create new selection

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -207,17 +207,6 @@ class FromAppsContent extends React.PureComponent<CombinedProps, State> {
               openDrawer={this.openDrawer}
             />
           ) : null}
-          <UserDefinedFieldsPanel
-            errors={filterUDFErrors(errorResources, errors)}
-            selectedLabel={selectedStackScriptLabel || ''}
-            selectedUsername="Linode"
-            handleChange={this.handleChangeUDF}
-            userDefinedFields={userDefinedFields}
-            updateFor={[userDefinedFields, udf_data, errors]}
-            udf_data={udf_data || {}}
-            appLogo={renderLogo}
-            openDrawer={this.openDrawer}
-          />
           {!userCannotCreateLinode &&
           compatibleImages &&
           compatibleImages.length > 0 ? (

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -27,6 +27,7 @@ import {
   WithTypesRegionsAndImages,
 } from '../types';
 import { filterUDFErrors } from './formUtilities';
+import { APP_ROOT } from 'src/constants';
 
 type ClassNames = 'main' | 'sidebar';
 
@@ -154,6 +155,20 @@ class FromAppsContent extends React.PureComponent<CombinedProps, State> {
       userCannotCreateLinode,
     } = this.props;
 
+    const logoUrl = appInstances?.find(
+      (app) => app.id === selectedStackScriptID
+    )?.logo_url;
+
+    const renderLogo =
+      logoUrl === undefined ? (
+        <span className="fl-tux" />
+      ) : (
+        <img
+          src={`${APP_ROOT}/${logoUrl}`}
+          alt={`${selectedStackScriptLabel} logo`}
+        />
+      );
+
     const hasErrorFor = getAPIErrorsFor(errorResources, errors);
 
     return (
@@ -180,6 +195,7 @@ class FromAppsContent extends React.PureComponent<CombinedProps, State> {
                 userDefinedFields={userDefinedFields}
                 updateFor={[userDefinedFields, udf_data, errors]}
                 udf_data={udf_data || {}}
+                appLogo={renderLogo}
               />
             )}
           {!userCannotCreateLinode &&

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -184,20 +184,19 @@ class FromAppsContent extends React.PureComponent<CombinedProps, State> {
             openDrawer={this.openDrawer}
             error={hasErrorFor('stackscript_id')}
           />
-          {!userCannotCreateLinode &&
-            userDefinedFields &&
-            userDefinedFields.length > 0 && (
-              <UserDefinedFieldsPanel
-                errors={filterUDFErrors(errorResources, errors)}
-                selectedLabel={selectedStackScriptLabel || ''}
-                selectedUsername="Linode"
-                handleChange={this.handleChangeUDF}
-                userDefinedFields={userDefinedFields}
-                updateFor={[userDefinedFields, udf_data, errors]}
-                udf_data={udf_data || {}}
-                appLogo={renderLogo}
-              />
-            )}
+          {!userCannotCreateLinode && userDefinedFields && (
+            <UserDefinedFieldsPanel
+              errors={filterUDFErrors(errorResources, errors)}
+              selectedLabel={selectedStackScriptLabel || ''}
+              selectedUsername="Linode"
+              handleChange={this.handleChangeUDF}
+              userDefinedFields={userDefinedFields}
+              updateFor={[userDefinedFields, udf_data, errors]}
+              udf_data={udf_data || {}}
+              appLogo={renderLogo}
+              openDrawer={this.openDrawer}
+            />
+          )}
           {!userCannotCreateLinode &&
           compatibleImages &&
           compatibleImages.length > 0 ? (


### PR DESCRIPTION
## Description

Adds the app logo to the header of the setup form if the app has a setup form.

Tasks: 

- [x] Change the word 'options' to 'setup' in the create form header
- [x] Add the App logo to the left of the create form header
- [x] Add help icon tooltip to the right of the form header
- [x] When the help icon is clicked the App details drawer should appear

## How to test

1. Navigate to the Marketplace
2. Click on an App that has a setup form like `Wordpress`
3. Ensure the App logo is shown to the left of the paper's header

**How do I run relevant unit tests?**
