### PR TITLE
M3-5876: Add Payment Drawer error notice

### DIFF
--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/GooglePayButton.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/GooglePayButton.tsx
@@ -1,12 +1,12 @@
 import { APIWarning } from '@linode/api-v4/lib/types';
 import classNames from 'classnames';
-import { VariantType } from 'notistack';
 import * as React from 'react';
 import GooglePayIcon from 'src/assets/icons/payment/gPayButton.svg';
 import CircleProgress from 'src/components/CircleProgress';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Tooltip from 'src/components/core/Tooltip';
 import Grid from 'src/components/Grid';
+import { PaymentMessage } from 'src/features/Billing/BillingPanels/PaymentInfoPanel/AddPaymentMethodDrawer/AddPaymentMethodDrawer';
 import {
   gPay,
   initGooglePaymentInstance,
@@ -112,15 +112,11 @@ export const GooglePayButton: React.FC<Props> = (props) => {
     init();
   }, [status, data]);
 
-  const handleMessage = (
-    message: string,
-    variant: VariantType,
-    warning?: APIWarning[]
-  ) => {
-    if (variant === 'error') {
-      setError(message);
-    } else if (variant === 'success') {
-      setSuccess(message, true, warning);
+  const handleMessage = (message: PaymentMessage, warning?: APIWarning[]) => {
+    if (message.variant === 'error') {
+      setError(message.text);
+    } else if (message.variant === 'success') {
+      setSuccess(message.text, true, warning);
     }
   };
 
@@ -133,7 +129,7 @@ export const GooglePayButton: React.FC<Props> = (props) => {
   }
 
   if (initializationError) {
-    return renderError('Eror initializing Google Pay.');
+    return renderError('Error initializing Google Pay.');
   }
 
   if (isLoading) {

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/AddPaymentMethodDrawer/AddPaymentMethodDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/AddPaymentMethodDrawer/AddPaymentMethodDrawer.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { PaymentMethod } from '@linode/api-v4/lib/account';
-import { useSnackbar, VariantType } from 'notistack';
+import { VariantType } from 'notistack';
 import Divider from 'src/components/core/Divider';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
@@ -19,6 +19,11 @@ interface Props {
   open: boolean;
   onClose: () => void;
   paymentMethods: PaymentMethod[] | undefined;
+}
+
+export interface PaymentMessage {
+  text: string;
+  variant: VariantType;
 }
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -70,20 +75,23 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 export const AddPaymentMethodDrawer: React.FC<Props> = (props) => {
   const { onClose, open, paymentMethods } = props;
+
   const classes = useStyles();
-  const { enqueueSnackbar } = useSnackbar();
+
   const [isProcessing, setIsProcessing] = React.useState<boolean>(false);
+  const [noticeMessage, setNoticeMessage] = React.useState<
+    PaymentMessage | undefined
+  >(undefined);
 
   React.useEffect(() => {
     if (open) {
       setIsProcessing(false);
+      setNoticeMessage(undefined);
     }
   }, [open]);
 
-  const makeToast = (message: string, variant: VariantType) => {
-    enqueueSnackbar(message, {
-      variant,
-    });
+  const setMessage = (message: PaymentMessage) => {
+    setNoticeMessage(message);
   };
 
   const renderError = (errorMsg: string) => {
@@ -107,6 +115,13 @@ export const AddPaymentMethodDrawer: React.FC<Props> = (props) => {
           text="You reached the maximum number of payment methods on your account. Delete an existing payment method to add a new one."
         />
       ) : null}
+      {noticeMessage ? (
+        <Notice
+          error={noticeMessage.variant === 'error'}
+          warning={noticeMessage.variant === 'warning'}
+          text={noticeMessage.text}
+        />
+      ) : null}
       <>
         <Divider />
         <Grid className={classes.root} container>
@@ -126,7 +141,7 @@ export const AddPaymentMethodDrawer: React.FC<Props> = (props) => {
           >
             <GooglePayChip
               disabled={disabled}
-              makeToast={makeToast}
+              setMessage={setMessage}
               onClose={onClose}
               setProcessing={setIsProcessing}
               renderError={renderError}

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/GooglePayChip.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/GooglePayChip.tsx
@@ -1,15 +1,15 @@
+import classNames from 'classnames';
 import * as React from 'react';
-import { VariantType } from 'notistack';
 import GooglePayIcon from 'src/assets/icons/payment/googlePay.svg';
+import CircleProgress from 'src/components/CircleProgress';
+import { makeStyles } from 'src/components/core/styles';
+import { PaymentMessage } from 'src/features/Billing/BillingPanels/PaymentInfoPanel/AddPaymentMethodDrawer/AddPaymentMethodDrawer';
+import {
+  gPay,
+  initGooglePaymentInstance,
+} from 'src/features/Billing/GooglePayProvider';
 import { useScript } from 'src/hooks/useScript';
 import { useClientToken } from 'src/queries/accountPayment';
-import { makeStyles } from 'src/components/core/styles';
-import {
-  initGooglePaymentInstance,
-  gPay,
-} from 'src/features/Billing/GooglePayProvider';
-import CircleProgress from 'src/components/CircleProgress';
-import classNames from 'classnames';
 
 const useStyles = makeStyles(() => ({
   button: {
@@ -32,7 +32,7 @@ const useStyles = makeStyles(() => ({
 }));
 
 interface Props {
-  makeToast: (message: string, variant: VariantType) => void;
+  setMessage: (message: PaymentMessage) => void;
   setProcessing: (processing: boolean) => void;
   onClose: () => void;
   renderError: (errorMsg: string) => JSX.Element;
@@ -42,7 +42,7 @@ interface Props {
 export const GooglePayChip: React.FC<Props> = (props) => {
   const {
     disabled: disabledDueToProcessing,
-    makeToast,
+    setMessage,
     setProcessing,
     onClose,
     renderError,
@@ -68,9 +68,9 @@ export const GooglePayChip: React.FC<Props> = (props) => {
     init();
   }, [status, data]);
 
-  const handleMessage = (message: string, variant: VariantType) => {
-    makeToast(message, variant);
-    if (variant === 'success') {
+  const handleMessage = (message: PaymentMessage) => {
+    setMessage(message);
+    if (message.variant === 'success') {
       onClose();
     }
   };


### PR DESCRIPTION
## Description
Display an error notice in Add Payment Drawer instead of a toast (and some minor refactoring)

Before
![image](https://user-images.githubusercontent.com/14323019/180513544-b2802209-04bd-455b-8194-2a596d445327.png)

After
![image](https://user-images.githubusercontent.com/14323019/180513128-e7f60637-27ed-4bef-9a4a-eede5294d8e4.png)

## How to test
Point to dev and try to make/add a third party payment on an account that has the `pays by akamai` flag

Also test normal flow on an account without the flag