### PR TITLE
M3-5143: Fix Linode Backups tab error

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -794,7 +794,7 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
     }
 
     const backupsMonthlyPrice =
-      type?.response?.addons?.backups?.price?.monthly ?? 0;
+      type.response?.addons?.backups?.price?.monthly ?? 0;
 
     return (
       <div>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -794,7 +794,7 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
     }
 
     const backupsMonthlyPrice =
-      type?.response.addons.backups.price.monthly ?? 0;
+      type?.response?.addons?.backups?.price?.monthly ?? 0;
 
     return (
       <div>


### PR DESCRIPTION
## Description
Under certain circumstances outlined in the ticket, a user would see this screen when navigating to the "Backups" tab of the Linode Detail page:

![Screen Shot 2022-07-27 at 2 40 19 PM](https://user-images.githubusercontent.com/32860776/181347857-efb6df05-b18d-4ae9-b154-c5ff2827f8b9.jpg)

This PR fixes this bug.

More in-depth explanation and steps for testing are in the Slack thread in the team channel.
