### PR TITLE
M3-5435: Filter `read_only` Linodes From Firewall Select For Restricted Users

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddDeviceDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddDeviceDrawer.tsx
@@ -11,6 +11,9 @@ import Notice from 'src/components/Notice';
 import { useStyles } from 'src/components/Notice/Notice';
 import SupportLink from 'src/components/SupportLink';
 import { useGrants, useProfile } from 'src/queries/profile';
+import { getEntityIdsByPermission } from 'src/utilities/grants';
+import { READ_ONLY_LINODES_HIDDEN_MESSAGE } from '../../FirewallLanding/AddFirewallDrawer';
+
 interface Props {
   open: boolean;
   error?: APIError[];
@@ -92,12 +95,11 @@ export const AddDeviceDrawer: React.FC<Props> = (props) => {
 
   // If a user is restricted, they can not add a read-only Linode to a firewall.
   const readOnlyLinodeIds = isRestrictedUser
-    ? grants?.linode
-        .filter((grant) => grant.permissions === 'read_only')
-        .map((grant) => grant.id) ?? []
+    ? getEntityIdsByPermission(grants, 'linode', 'read_only')
     : [];
 
-  const areSomeLinodesReadOnly = readOnlyLinodeIds.length > 0;
+  const linodeSelectGuidance =
+    readOnlyLinodeIds.length > 0 ? READ_ONLY_LINODES_HIDDEN_MESSAGE : undefined;
 
   return (
     <Drawer
@@ -117,11 +119,7 @@ export const AddDeviceDrawer: React.FC<Props> = (props) => {
           handleChange={(selected) => setSelectedLinodes(selected)}
           helperText={`You can assign one or more Linodes to this Firewall. Each Linode can only be assigned to a single Firewall.`}
           filteredLinodes={[...currentDevices, ...readOnlyLinodeIds]}
-          guidance={
-            areSomeLinodesReadOnly
-              ? `Only Linodes you have permission to modify are shown.`
-              : undefined
-          }
+          guidance={linodeSelectGuidance}
         />
         <ActionsPanel>
           <Button buttonType="secondary" onClick={onClose} data-qa-cancel>

--- a/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.test.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.test.tsx
@@ -3,6 +3,14 @@ import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 import AddFirewallDrawer, { CombinedProps } from './AddFirewallDrawer';
+import { rest, server } from 'src/mocks/testServer';
+import { makeResourcePage } from 'src/mocks/serverHandlers';
+import { linodeFactory } from 'src/factories/linodes';
+import { profileFactory } from 'src/factories';
+import { grantsFactory } from 'src/factories/grants';
+import { QueryClient } from 'react-query';
+
+jest.mock('src/components/EnhancedSelect/Select');
 
 const props: CombinedProps = {
   onClose: jest.fn(),
@@ -47,5 +55,46 @@ describe('Create Firewall Drawer', () => {
         },
       })
     );
+  });
+
+  describe('restricted user support', () => {
+    it('should not show a read only linode for a restricted user', async () => {
+      server.use(
+        rest.get('*/linode/instances', (req, res, ctx) => {
+          return res(
+            ctx.json(
+              makeResourcePage([
+                linodeFactory.build({ id: 0, label: 'linode-0' }),
+                linodeFactory.build({ id: 1, label: 'linode-1' }),
+              ])
+            )
+          );
+        }),
+        rest.get('*/profile', (req, res, ctx) => {
+          return res(ctx.json(profileFactory.build({ restricted: true })));
+        }),
+        rest.get('*/profile/grants', (req, res, ctx) => {
+          return res(
+            ctx.json(
+              grantsFactory.build({
+                global: { add_firewalls: true },
+                linode: [
+                  { id: 0, permissions: 'read_write' },
+                  { id: 1, permissions: 'read_only' },
+                ],
+              })
+            )
+          );
+        })
+      );
+
+      const { queryByText } = renderWithTheme(
+        <AddFirewallDrawer {...props} />,
+        { queryClient: new QueryClient() }
+      );
+
+      await waitFor(() => expect(queryByText('linode-0')).toBeInTheDocument());
+      expect(queryByText('linode-1')).not.toBeInTheDocument();
+    });
   });
 });

--- a/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.tsx
@@ -10,10 +10,14 @@ import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
 import { useAccountManagement } from 'src/hooks/useAccountManagement';
 import { useGrants } from 'src/queries/profile';
+import { getEntityIdsByPermission } from 'src/utilities/grants';
 import {
   handleFieldErrors,
   handleGeneralErrors,
 } from 'src/utilities/formikErrorUtils';
+
+export const READ_ONLY_LINODES_HIDDEN_MESSAGE =
+  'Only Linodes you have permission to modify are shown.';
 
 export interface Props extends Omit<DrawerProps, 'onClose' | 'onSubmit'> {
   onClose: () => void;
@@ -96,12 +100,11 @@ const AddFirewallDrawer: React.FC<CombinedProps> = (props) => {
 
   // If a user is restricted, they can not add a read-only Linode to a firewall.
   const readOnlyLinodeIds = _isRestrictedUser
-    ? grants?.linode
-        .filter((grant) => grant.permissions === 'read_only')
-        .map((grant) => grant.id) ?? []
+    ? getEntityIdsByPermission(grants, 'linode', 'read_only')
     : [];
 
-  const areSomeLinodesReadOnly = readOnlyLinodeIds.length > 0;
+  const linodeSelectGuidance =
+    readOnlyLinodeIds.length > 0 ? READ_ONLY_LINODES_HIDDEN_MESSAGE : undefined;
 
   return (
     <Drawer {...restOfDrawerProps} onClose={onClose}>
@@ -167,11 +170,7 @@ const AddFirewallDrawer: React.FC<CombinedProps> = (props) => {
                 }
                 filteredLinodes={readOnlyLinodeIds}
                 onBlur={handleBlur}
-                guidance={
-                  areSomeLinodesReadOnly
-                    ? `Only Linodes you have permission to modify are shown.`
-                    : undefined
-                }
+                guidance={linodeSelectGuidance}
               />
               <ActionsPanel>
                 <Button buttonType="secondary" onClick={onClose} data-qa-cancel>

--- a/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.tsx
@@ -9,6 +9,7 @@ import LinodeMultiSelect from 'src/components/LinodeMultiSelect';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
 import { useAccountManagement } from 'src/hooks/useAccountManagement';
+import { useGrants } from 'src/queries/profile';
 import {
   handleFieldErrors,
   handleGeneralErrors,
@@ -42,6 +43,8 @@ const AddFirewallDrawer: React.FC<CombinedProps> = (props) => {
    * grant here too, but it doesn't exist yet.
    */
   const { _isRestrictedUser, _hasGrant } = useAccountManagement();
+
+  const { data: grants } = useGrants();
 
   const userCannotAddFirewall =
     _isRestrictedUser && !_hasGrant('add_firewalls');
@@ -90,6 +93,15 @@ const AddFirewallDrawer: React.FC<CombinedProps> = (props) => {
 
   const firewallHelperText = `Assign one or more Linodes to this firewall. You can add
   Linodes later if you want to customize your rules first.`;
+
+  // If a user is restricted, they can not add a read-only Linode to a firewall.
+  const readOnlyLinodeIds = _isRestrictedUser
+    ? grants?.linode
+        .filter((grant) => grant.permissions === 'read_only')
+        .map((grant) => grant.id) ?? []
+    : [];
+
+  const areSomeLinodesReadOnly = readOnlyLinodeIds.length > 0;
 
   return (
     <Drawer {...restOfDrawerProps} onClose={onClose}>
@@ -153,7 +165,13 @@ const AddFirewallDrawer: React.FC<CombinedProps> = (props) => {
                 handleChange={(selected: number[]) =>
                   setFieldValue('devices.linodes', selected)
                 }
+                filteredLinodes={readOnlyLinodeIds}
                 onBlur={handleBlur}
+                guidance={
+                  areSomeLinodesReadOnly
+                    ? `Only Linodes you have permission to modify are shown.`
+                    : undefined
+                }
               />
               <ActionsPanel>
                 <Button buttonType="secondary" onClick={onClose} data-qa-cancel>

--- a/packages/manager/src/utilities/grants.test.ts
+++ b/packages/manager/src/utilities/grants.test.ts
@@ -1,0 +1,28 @@
+import { grantsFactory } from 'src/factories/grants';
+import { getEntityIdsByPermission } from './grants';
+
+const grants = grantsFactory.build({
+  linode: [
+    { id: 0, permissions: 'read_only' },
+    { id: 1, permissions: 'read_write' },
+    { id: 2, permissions: 'read_only' },
+    { id: 3, permissions: null },
+  ],
+});
+
+describe('getEntityIdsByPermission', () => {
+  it('should return an empty array when there is no grant data', () => {
+    expect(getEntityIdsByPermission(undefined, 'linode', 'read_write')).toEqual(
+      []
+    );
+  });
+  it('should return read-only entity ids with read_only permission', () => {
+    expect(getEntityIdsByPermission(grants, 'linode', 'read_only')).toEqual([
+      0,
+      2,
+    ]);
+  });
+  it('should return all entity ids if a permission level is omitted', () => {
+    expect(getEntityIdsByPermission(grants, 'linode')).toEqual([0, 1, 2, 3]);
+  });
+});

--- a/packages/manager/src/utilities/grants.ts
+++ b/packages/manager/src/utilities/grants.ts
@@ -1,0 +1,26 @@
+import { GrantLevel, Grants, GrantType } from '@linode/api-v4';
+
+/**
+ * Gets entity ids for a specified permission level given a user's grants
+ * @param grants user grants (probably from React Query)
+ * @param entity the entity type you want grants for
+ * @param permission the level of permission you want ids for. Omit this for all entity ids.
+ * @returns a list of entity ids that match given paramaters
+ */
+export const getEntityIdsByPermission = (
+  grants: Grants | undefined,
+  entity: GrantType,
+  permission?: GrantLevel
+) => {
+  if (!grants) {
+    return [];
+  }
+
+  if (permission === undefined) {
+    return grants[entity].map((grant) => grant.id);
+  }
+
+  return grants[entity]
+    .filter((grant) => grant.permissions === permission)
+    .map((grant) => grant.id);
+};


### PR DESCRIPTION
## Description 📝

- Filters out `ready-only` Linodes from the `Firewall Create Drawer` and `Add Linode to Firewall Drawer` for restricted users. 
- We are doing this because the API does not allow restricted users to create firewalls with Linodes the user does not have permission to modify. The API error message for this was ambiguous and this change will result in a more useable experience for restricted users using firewalls.

## Preview 🔎

### Un-restricted User (Full Permission)
![Screen Shot 2022-07-27 at 3 44 40 PM](https://user-images.githubusercontent.com/6440455/181364718-5a2c830f-84b1-4c04-835c-76731c90da16.jpg)

### Restricted User where Linode `testing-2` is `read-only` for this user
![Screen Shot 2022-07-27 at 3 45 00 PM](https://user-images.githubusercontent.com/6440455/181364693-bee6506f-fddf-43cb-8b12-6df2de0b5854.jpg)

## How to test 🧪

- Have a **primary account with full permission** and a **restricted user** with **read only permission on a Linode**
- Give the restricted user has permission to create firewalls
- On the restricted user, try to create a Firewall and attempt to attach a Linode you have `read-only` permission on
  - You should not see this Linode in the dropdown
  - You should see a note in the dropdown saying `Only Linodes you have permission to modify are shown.`
