### PR TITLE
M3-5874: Improve Marketplace loading

### DIFF
--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -20,16 +20,17 @@ import Logo from 'src/assets/logo/logo.svg';
 import Chip from 'src/components/core/Chip';
 import Divider from 'src/components/core/Divider';
 import Grid from 'src/components/core/Grid';
-import useStyles from './PrimaryNav.styles';
 import useAccountManagement from 'src/hooks/useAccountManagement';
 import useFlags from 'src/hooks/useFlags';
 import usePrefetch from 'src/hooks/usePreFetch';
-import { isFeatureEnabled } from 'src/utilities/accountCapabilities';
-import { linkIsActive } from './utils';
 import {
   useObjectStorageBuckets,
   useObjectStorageClusters,
 } from 'src/queries/objectStorage';
+import { useStackScriptsOCA } from 'src/queries/stackscripts';
+import { isFeatureEnabled } from 'src/utilities/accountCapabilities';
+import useStyles from './PrimaryNav.styles';
+import { linkIsActive } from './utils';
 
 type NavEntity =
   | 'Linodes'
@@ -77,7 +78,18 @@ export const PrimaryNav: React.FC<Props> = (props) => {
 
   const [enableObjectPrefetch, setEnableObjectPrefetch] = React.useState(false);
 
+  const [
+    enableMarketplacePrefetch,
+    setEnableMarketplacePrefetch,
+  ] = React.useState(false);
+
   const { _isManagedAccount, account } = useAccountManagement();
+
+  const {
+    data: oneClickApps,
+    isLoading: oneClickAppsLoading,
+    error: oneClickAppsError,
+  } = useStackScriptsOCA(enableMarketplacePrefetch);
 
   const {
     data: clusters,
@@ -99,6 +111,9 @@ export const PrimaryNav: React.FC<Props> = (props) => {
     !clustersError &&
     !bucketsError;
 
+  const allowMarketplacePrefetch =
+    !oneClickApps && !oneClickAppsLoading && !oneClickAppsError;
+
   const showDatabases = isFeatureEnabled(
     'Managed Databases',
     Boolean(flags.databases),
@@ -108,6 +123,12 @@ export const PrimaryNav: React.FC<Props> = (props) => {
   const prefetchObjectStorage = () => {
     if (!enableObjectPrefetch) {
       setEnableObjectPrefetch(true);
+    }
+  };
+
+  const prefetchMarketplace = () => {
+    if (!enableMarketplacePrefetch) {
+      setEnableMarketplacePrefetch(true);
     }
   };
 
@@ -198,6 +219,8 @@ export const PrimaryNav: React.FC<Props> = (props) => {
           href: '/linodes/create?type=One-Click',
           attr: { 'data-qa-one-click-nav-btn': true },
           icon: <OCA />,
+          prefetchRequestFn: prefetchMarketplace,
+          prefetchRequestCondition: allowMarketplacePrefetch,
         },
       ],
       [
@@ -213,7 +236,13 @@ export const PrimaryNav: React.FC<Props> = (props) => {
         },
       ],
     ],
-    [showDatabases, _isManagedAccount, allowObjPrefetch, flags.databaseBeta]
+    [
+      showDatabases,
+      _isManagedAccount,
+      allowObjPrefetch,
+      allowMarketplacePrefetch,
+      flags.databaseBeta,
+    ]
   );
 
   return (

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectAppPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectAppPanel.tsx
@@ -113,7 +113,7 @@ class SelectAppPanel extends React.PureComponent<CombinedProps> {
       );
     }
 
-    if (appInstancesLoading) {
+    if (appInstancesLoading || !appInstances) {
       return (
         <Panel className={classes.panel} error={error} title="Select App">
           <span className={classes.loading}>

--- a/packages/manager/src/queries/stackscripts.ts
+++ b/packages/manager/src/queries/stackscripts.ts
@@ -1,0 +1,16 @@
+import { StackScript } from '@linode/api-v4/lib/stackscripts';
+import { APIError, ResourcePage } from '@linode/api-v4/lib/types';
+import { useQuery } from 'react-query';
+import { getOneClickApps } from 'src/features/StackScripts/stackScriptUtils';
+
+export const queryKey = 'stackscripts';
+
+export const useStackScriptsOCA = (enabled: boolean) => {
+  return useQuery<ResourcePage<StackScript>, APIError[]>(
+    `${queryKey}-oca`,
+    getOneClickApps,
+    {
+      enabled,
+    }
+  );
+};


### PR DESCRIPTION
## Description
Marketplace apps take a few seconds to load bc the stackscripts API endpoint is slow.

This PR uses React Query to prefetch and cache the apps so that we only have to load the endpoint once

## How to test
- Hover over Marketplace in the nav bar and confirm that a network request to stackscripts is made
- Go to `/linodes/create?type=One-Click` via url and wait for the apps to load. Go somewhere else, and then go back. The apps should display without loading
