### PR TITLE
M3-5831: Fix invoice formatting issue

### DIFF
--- a/packages/manager/src/factories/billing.ts
+++ b/packages/manager/src/factories/billing.ts
@@ -30,7 +30,7 @@ export const paymentFactory = Factory.Sync.makeFactory<Payment>({
   usd: 5,
 });
 
-const invoiceDate = new Date('2020-01-01T00:00:00');
+const invoiceDate = new Date('2022-08-01T00:00:00');
 export const invoiceFactory = Factory.Sync.makeFactory<Invoice>({
   date: Factory.each((i) => {
     invoiceDate.setDate(invoiceDate.getDate() - i + 1);

--- a/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
@@ -16,9 +16,9 @@ import {
   createInvoiceTotalsTable,
   createPaymentsTable,
   createPaymentsTotalsTable,
+  pageMargin,
 } from './utils';
 
-const leftMargin = 30; // space that needs to be applied to every parent element
 const baseFont = 'helvetica';
 
 const addLeftHeader = (
@@ -30,7 +30,7 @@ const addLeftHeader = (
   taxID: string | undefined
 ) => {
   const addLine = (text: string, fontSize = 9) => {
-    doc.text(text, leftMargin, currentLine, { charSpace: 0.75 });
+    doc.text(text, pageMargin, currentLine, { charSpace: 0.75 });
     currentLine += fontSize;
   };
 
@@ -112,7 +112,7 @@ const addTitle = (doc: jsPDF, y: number, ...textStrings: Title[]) => {
   doc.setFont(baseFont, 'bold');
   doc.setFontSize(12);
   textStrings.forEach((eachString) => {
-    doc.text(eachString.text, eachString.leftMargin || leftMargin, y, {
+    doc.text(eachString.text, eachString.leftMargin || pageMargin, y, {
       charSpace: 0.75,
       maxWidth: 100,
     });


### PR DESCRIPTION
## Description

**What does this PR do?**
This fixes the invoice formatting issue that occurs when any of the (sub)totals listed at the bottom of the invoice overflow their column.

This change removes the hardcoded column width (which was `30` units) and implements new logic to calculate the final widths of the columns.

## How to test

**What are the steps to reproduce the issue or verify the changes?**
1. Enable MSW
2. Modify the [mocked invoice values](https://github.com/linode/manager/blob/develop/packages/manager/src/factories/billing.ts#L40-L52) to correspond with what's described in M3-5831.
3. Navigate to `/account/billing` and click _Download PDF_ for any of the listed invoices
4. View the generated PDF and confirm that formatting issue is fixed
5. _(Optional)_ Continue modifying the [mocked invoice values](https://github.com/linode/manager/blob/develop/packages/manager/src/factories/billing.ts#L40-L52) and confirm that formatting issue is fixed even with extreme values
