### PR TITLE
M3-4919: Fix browser Back button behavior on the User Permissions tab

### DIFF
--- a/packages/manager/src/features/Users/UserDetail.tsx
+++ b/packages/manager/src/features/Users/UserDetail.tsx
@@ -182,11 +182,6 @@ const UserDetail: React.FC = () => {
     return Boolean(matchPath(p, { path: location.pathname }));
   };
 
-  const clampTabChoice = () => {
-    const tabChoice = tabs.findIndex((tab) => matches(tab.routeName));
-    return tabChoice < 0 ? 0 : tabChoice;
-  };
-
   const navToURL = (index: number) => {
     history.push(tabs[index].routeName);
   };
@@ -226,7 +221,13 @@ const UserDetail: React.FC = () => {
         ]}
         removeCrumbX={4}
       />
-      <Tabs defaultIndex={clampTabChoice()} onChange={navToURL}>
+      <Tabs
+        index={Math.max(
+          tabs.findIndex((tab) => matches(tab.routeName)),
+          0
+        )}
+        onChange={navToURL}
+      >
         <TabLinkList tabs={tabs} />
 
         {createdUsername && (


### PR DESCRIPTION
## Description
In prod, if you're on the "Users & Grants" tab on the Account page, click on "User Profile" for a user, click on the "User Permissions" tab, and then use the browser Back button to navigate back, you'll observe odd behavior: the tab doesn't switch, and if you hit the Back button enough, you'll go back further than expected.

The changes I made bring the behavior more in line with what we see on the Object Storage landing page. It's not ideal because it still takes two clicks of the browser Back button to get to the first tab, but this seems to be either a problem with ReachTabs or the way we're implementing it.

## How to test
Test out the "Users & Grants" --> "User Profile" --> "User Permissions" path and then the reverse using the browser Back button. You shouldn't get stuck as much now.