### PR TITLE
M3-5910: Make "Copy IP" buttons visible on keyboard focus

### DIFF
--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancerTableRow.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancerTableRow.tsx
@@ -37,15 +37,18 @@ const useStyles = makeStyles((theme: Theme) => ({
   ipsWrapper: {
     display: 'inline-flex',
     flexDirection: 'column',
-    '& [data-qa-copy-ip]': {
+    '& [data-qa-copy-ip] button > svg': {
       opacity: 0,
     },
   },
   row: {
     '&:hover': {
-      '& [data-qa-copy-ip]': {
+      '& [data-qa-copy-ip] button > svg': {
         opacity: 1,
       },
+    },
+    '& [data-qa-copy-ip] button:focus > svg': {
+      opacity: 1,
     },
   },
 }));

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
@@ -89,7 +89,7 @@ const styles = (theme: Theme) =>
       },
     },
     row: {
-      '&:hover $copy > svg': {
+      '&:hover $copy > svg, & $copy:focus > svg': {
         opacity: 1,
       },
     },

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.style.ts
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.style.ts
@@ -29,9 +29,12 @@ const styles = (theme: Theme) =>
       height: 'auto',
       '&:hover': {
         backgroundColor: theme.bg.lightBlue1,
-        '& [data-qa-copy-ip]': {
+        '& [data-qa-copy-ip] button > svg': {
           opacity: 1,
         },
+      },
+      '& [data-qa-copy-ip] button:focus > svg': {
+        opacity: 1,
       },
     },
     progressDisplay: {
@@ -89,7 +92,7 @@ const styles = (theme: Theme) =>
       '& button:hover': {
         backgroundColor: 'transparent',
       },
-      '& [data-qa-copy-ip]': {
+      '& [data-qa-copy-ip] button > svg': {
         opacity: 0,
       },
       '& svg': {


### PR DESCRIPTION
## Description

**What does this PR do?**
This fixes an issue where the "Copy IP" button in the Linodes landing page, Linodes "Network" tab, and Node Balancer landing page are not visible when they have keyboard focus.

Currently, these buttons are only visible when the user hovers their cursor over the corresponding table row. This change makes it so that the buttons are visible on hover _and_ on keyboard focus.

## How to test

**What are the steps to verify the changes?**
1. Navigate to the Linode landing page (create a Linode if one does not already exist)
2. Confirm that "Copy IP" button is visible when you hover your cursor over the row
3. Confirm that "Copy IP" button is visible when you navigate to it via keyboard
4. Repeat for the Linode details page "Network" tab, and Node Balancers landing page