### PR TITLE
M3-5875: Marketplace App Selection Scrolling based on Query Params

### DIFF
--- a/packages/manager/src/components/SelectionCard/SelectionCard.tsx
+++ b/packages/manager/src/components/SelectionCard/SelectionCard.tsx
@@ -39,6 +39,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 export interface Props {
+  id?: string;
   heading: string;
   subheadings: (string | undefined)[];
   checked?: boolean;
@@ -52,6 +53,7 @@ export interface Props {
 
 const SelectionCard: React.FC<Props> = (props) => {
   const {
+    id,
     heading,
     subheadings,
     checked,
@@ -89,6 +91,7 @@ const SelectionCard: React.FC<Props> = (props) => {
 
   const cardGrid = (
     <Grid
+      id={id}
       item
       xs={12}
       sm={6}

--- a/packages/manager/src/features/linodes/LinodesCreate/AppPanelSection.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/AppPanelSection.tsx
@@ -48,6 +48,7 @@ export const AppPanelSection: React.FC<Props> = (props) => {
       <Grid className={classes.flatImagePanelSelections} container>
         {apps.map((eachApp) => (
           <SelectionCardWrapper
+            id={eachApp.id}
             key={eachApp.id}
             checked={eachApp.id === selectedStackScriptID}
             // Decode App labels since they may contain HTML entities.
@@ -57,7 +58,6 @@ export const AppPanelSection: React.FC<Props> = (props) => {
             handleClick={handleClick}
             openDrawer={openDrawer}
             disabled={disabled}
-            id={eachApp.id}
             iconUrl={eachApp.logo_url.toLowerCase() || ''}
           />
         ))}

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectAppPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectAppPanel.tsx
@@ -71,6 +71,16 @@ class SelectAppPanel extends React.PureComponent<CombinedProps> {
         matchedApp.user_defined_fields
       );
 
+      // Scroll to app when an app id is passed in the query params
+      const section = document.querySelector(`#app-${matchedApp.id}`);
+      if (section) {
+        section.scrollIntoView({
+          behavior: 'smooth',
+          block: 'center',
+          inline: 'start',
+        });
+      }
+
       // If the URL also included &showInfo, open the Info drawer as well
       const showInfo = getParamFromUrl(location.search, 'showInfo');
       if (showInfo) {

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectionCardWrapper.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectionCardWrapper.tsx
@@ -97,6 +97,7 @@ export const SelectionCardWrapper: React.FC<Props> = (props) => {
 
   return (
     <SelectionCard
+      id={`app-${String(id)}`}
       key={id}
       checked={checked}
       onClick={handleSelectApp}


### PR DESCRIPTION
## Description

- When an app is passed as a query param for Linode creation, scroll to the selected app in the list
  - This helps clearly show users what app they have selected from a redirect
  - If this new scroll didn't happen, users would be very confused if they were redirected from the `linode.com` site after finding an app they want to deploy
- This ticket requests that we don't open the details drawer when coming from the linode.com site but that change needs to be made on their end. I will make sure that change is made

## Preview

https://user-images.githubusercontent.com/6440455/183512901-3a4dba53-fa1a-4a86-b142-e72f004d73c0.mov


## How to test

- Visit a link like `http://localhost:3000/linodes/create?type=One-Click&appID=607488` and observe scroll behavior