### PR TITLE
M3-5809: Allow environment variables to override .env in Cypress

### DIFF
--- a/packages/manager/cypress/plugins/index.js
+++ b/packages/manager/cypress/plugins/index.js
@@ -26,7 +26,13 @@ function getConfiguration() {
       `Could not load .env from Cypress plugin/index.js: ${conf.error}`
     );
   }
-  return { env: conf.parsed };
+
+  const env = {
+    ...conf.parsed,
+    ...process.env,
+  };
+
+  return { env };
 }
 
 /**


### PR DESCRIPTION
## Description

**What does this PR do?**
This is a small tweak that changes the way Cypress reads environment variables on startup. Currently, only the `.env` file gets read. This change allows those values to be overridden by or supplemented with the process's environment variables.

## How to test

**What are the steps to reproduce the issue or verify the changes?**

Run the tests without specifying any environment variables to confirm that this doesn't break our existing setup. Once a few tests pass, you can quit the process.

```
yarn cy:run
```

Then run the tests with an invalid `MANAGER_OAUTH` value to confirm that you can override the `.env` file. The tests are expected to fail, so you can quit the process once you start seeing failures.

```
MANAGER_OAUTH=intentionallyinvalidvalue yarn cy:run
```
