### PR TITLE
M3-5714: Generate Jest coverage report via GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,11 @@ jobs:
           name: packages-api-v4-lib
           path: packages/api-v4
       - run: yarn --frozen-lockfile
-      - run: yarn workspace linode-manager run test
+      - run: yarn workspace linode-manager run test --coverage
+      - uses: actions/upload-artifact@v2
+        with:
+          name: unit-test-coverage-report
+          path: packages/manager
 
   build-manager:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,14 +124,16 @@ jobs:
           path: packages/api-v4
       - run: yarn --frozen-lockfile
       - run: yarn workspace linode-manager run test --coverage --outputFile=coverage_report.json --json
+      - run: cp packages/manager/coverage/lcov.info packages/manager
       - uses: actions/upload-artifact@v2
         with:
           name: unit-test-coverage-report
           path: packages/manager/coverage_report.json
       - uses: romeovs/lcov-reporter-action@v0.3.1
         with:
-          lcov-file: packages/manager/coverage/lcov.info
+          lcov-file: packages/manager/lcov.info
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - run: rm packages/manager/lcov.info
 
   build-manager:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,11 +123,11 @@ jobs:
           name: packages-api-v4-lib
           path: packages/api-v4
       - run: yarn --frozen-lockfile
-      - run: yarn workspace linode-manager run test --coverage --outputFile=coverage/coverage_report.json --json
+      - run: yarn workspace linode-manager run test --coverage --outputFile=coverage_report.json --json
       - uses: actions/upload-artifact@v2
         with:
           name: unit-test-coverage-report
-          path: coverage/coverage_report.json
+          path: coverage_report.json
 
   build-manager:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: unit-test-coverage-report
-          path: coverage_report.json
+          path: packages/manager/coverage_report.json
 
   build-manager:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,8 @@ jobs:
 
   test-manager:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     needs:
       - build-sdk
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: unit-test-coverage-report
-          path: packages/manager
+          path: packages/manager/coverage_report.json
 
   build-manager:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,7 @@ jobs:
       - uses: romeovs/lcov-reporter-action@v0.3.1
         with:
           lcov-file: packages/manager/coverage/lcov.info
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
   build-manager:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,9 @@ jobs:
         with:
           name: unit-test-coverage-report
           path: packages/manager/coverage_report.json
+      - uses: romeovs/lcov-reporter-action@v0.3.1
+        with:
+          lcov-file: packages/manager/coverage/lcov.info
 
   build-manager:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,11 +123,11 @@ jobs:
           name: packages-api-v4-lib
           path: packages/api-v4
       - run: yarn --frozen-lockfile
-      - run: yarn workspace linode-manager run test --coverage
+      - run: yarn workspace linode-manager run test --coverage --outputFile=coverage/coverage_report.json --json
       - uses: actions/upload-artifact@v2
         with:
           name: unit-test-coverage-report
-          path: packages/manager/coverage_report.json
+          path: coverage/coverage_report.json
 
   build-manager:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
Generate a Jest coverage report when running the CI workflow via GitHub Actions and save it as an artifact.
