### PR TITLE
M3-5899: UI changes for Akamai customer invoicing

### DIFF
--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -22,6 +22,7 @@ export interface Account {
   last_name: string;
   balance: number;
   balance_uninvoiced: number;
+  billing_source: BillingSource;
   city: string;
   phone: string;
   company: string;
@@ -29,6 +30,8 @@ export interface Account {
   capabilities: AccountCapability[];
   euuid: string;
 }
+
+export type BillingSource = 'linode' | 'akamai';
 
 export type AccountCapability =
   | 'Linodes'

--- a/packages/manager/src/__data__/account.ts
+++ b/packages/manager/src/__data__/account.ts
@@ -34,6 +34,7 @@ export const account: Account = {
   last_name: 'McKenna',
   balance: 70.0,
   balance_uninvoiced: 10000,
+  billing_source: 'linode',
   city: 'philadelphia',
   phone: '2151231234',
   company: 'mmckenna',

--- a/packages/manager/src/components/TableContentWrapper/TableContentWrapper.test.tsx
+++ b/packages/manager/src/components/TableContentWrapper/TableContentWrapper.test.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
-
 import * as React from 'react';
+import { akamaiBillingInvoiceText } from 'src/features/Billing/billingUtils';
 import { wrapWithTableBody } from 'src/utilities/testHelpers';
 import TableContentWrapper from './TableContentWrapper';
 
@@ -89,5 +89,24 @@ describe('TableContentWrapper component', () => {
       wrapWithTableBody(<TableContentWrapper {...emptyProps} />)
     );
     getByText(emptyProps.emptyMessage);
+  });
+
+  it('should display text for Akamai customers', () => {
+    const emptyProps = {
+      loading: false,
+      length: 0,
+      isAkamaiCustomer: true,
+      children,
+    };
+
+    const { getByText, rerender } = render(
+      wrapWithTableBody(<TableContentWrapper {...emptyProps} />)
+    );
+    getByText(akamaiBillingInvoiceText);
+
+    const nonEmptyProps = { ...emptyProps, length: 1 };
+
+    rerender(wrapWithTableBody(<TableContentWrapper {...nonEmptyProps} />));
+    getByText(`Future ${akamaiBillingInvoiceText}`);
   });
 });

--- a/packages/manager/src/components/TableContentWrapper/TableContentWrapper.test.tsx
+++ b/packages/manager/src/components/TableContentWrapper/TableContentWrapper.test.tsx
@@ -1,5 +1,9 @@
 import { render } from '@testing-library/react';
 import * as React from 'react';
+import {
+  renderAkamaiInvoiceRow,
+  renderAkamaiRowEmptyState,
+} from 'src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel';
 import { akamaiBillingInvoiceText } from 'src/features/Billing/billingUtils';
 import { wrapWithTableBody } from 'src/utilities/testHelpers';
 import TableContentWrapper from './TableContentWrapper';
@@ -91,22 +95,31 @@ describe('TableContentWrapper component', () => {
     getByText(emptyProps.emptyMessage);
   });
 
-  it('should display text for Akamai customers', () => {
+  it('should render custom empty row state if it is provided', () => {
     const emptyProps = {
       loading: false,
       length: 0,
-      isAkamaiCustomer: true,
+      renderRowEmptyState: renderAkamaiRowEmptyState,
       children,
     };
 
-    const { getByText, rerender } = render(
+    const { getByText } = render(
       wrapWithTableBody(<TableContentWrapper {...emptyProps} />)
     );
     getByText(akamaiBillingInvoiceText);
+  });
 
-    const nonEmptyProps = { ...emptyProps, length: 1 };
+  it('should render custom row if it is provided', () => {
+    const rowProps = {
+      loading: false,
+      length: 2,
+      renderCustomRow: renderAkamaiInvoiceRow,
+      children,
+    };
 
-    rerender(wrapWithTableBody(<TableContentWrapper {...nonEmptyProps} />));
+    const { getByText } = render(
+      wrapWithTableBody(<TableContentWrapper {...rowProps} />)
+    );
     getByText(`Future ${akamaiBillingInvoiceText}`);
   });
 });

--- a/packages/manager/src/components/TableContentWrapper/TableContentWrapper.test.tsx
+++ b/packages/manager/src/components/TableContentWrapper/TableContentWrapper.test.tsx
@@ -1,8 +1,8 @@
 import { render } from '@testing-library/react';
 import * as React from 'react';
 import {
-  renderAkamaiInvoiceRow,
-  renderAkamaiRowEmptyState,
+  akamaiInvoiceRow,
+  akamaiRowEmptyState,
 } from 'src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel';
 import { akamaiBillingInvoiceText } from 'src/features/Billing/billingUtils';
 import { wrapWithTableBody } from 'src/utilities/testHelpers';
@@ -99,7 +99,7 @@ describe('TableContentWrapper component', () => {
     const emptyProps = {
       loading: false,
       length: 0,
-      renderRowEmptyState: renderAkamaiRowEmptyState,
+      rowEmptyState: akamaiRowEmptyState,
       children,
     };
 
@@ -113,7 +113,7 @@ describe('TableContentWrapper component', () => {
     const rowProps = {
       loading: false,
       length: 2,
-      renderCustomRow: renderAkamaiInvoiceRow,
+      customFirstRow: akamaiInvoiceRow,
       children,
     };
 

--- a/packages/manager/src/components/TableContentWrapper/TableContentWrapper.tsx
+++ b/packages/manager/src/components/TableContentWrapper/TableContentWrapper.tsx
@@ -1,11 +1,17 @@
 import { APIError } from '@linode/api-v4/lib/types';
 import * as React from 'react';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+import Grid from 'src/components/Grid/Grid';
+import TableCell from 'src/components/TableCell/TableCell';
+import TableRow from 'src/components/TableRow/TableRow';
 import TableRowEmpty from 'src/components/TableRowEmptyState';
 import TableRowError from 'src/components/TableRowError';
 import {
-  TableRowLoading,
   Props as TableLoadingProps,
-} from '../TableRowLoading/TableRowLoading';
+  TableRowLoading,
+} from 'src/components/TableRowLoading/TableRowLoading';
+import { akamaiBillingInvoiceText } from 'src/features/Billing/billingUtils';
 
 interface Props {
   length: number;
@@ -14,11 +20,17 @@ interface Props {
   error?: APIError[];
   emptyMessage?: string;
   loadingProps?: TableLoadingProps;
+  isAkamaiCustomer?: boolean;
 }
 
-type CombinedProps = Props;
+const useStyles = makeStyles((theme: Theme) => ({
+  grid: {
+    width: '100%',
+    padding: theme.spacing(10),
+  },
+}));
 
-const TableContentWrapper: React.FC<CombinedProps> = (props) => {
+const TableContentWrapper: React.FC<Props> = (props) => {
   const {
     length,
     loading,
@@ -26,7 +38,10 @@ const TableContentWrapper: React.FC<CombinedProps> = (props) => {
     error,
     lastUpdated,
     loadingProps,
+    isAkamaiCustomer,
   } = props;
+
+  const classes = useStyles();
 
   if (loading) {
     return <TableRowLoading {...loadingProps} />;
@@ -37,6 +52,26 @@ const TableContentWrapper: React.FC<CombinedProps> = (props) => {
   }
 
   if (lastUpdated !== 0 && length === 0) {
+    if (isAkamaiCustomer) {
+      return (
+        <TableRow>
+          <TableCell colSpan={6}>
+            <Grid
+              container
+              justifyContent="center"
+              alignItems="center"
+              className={classes.grid}
+            >
+              <Grid item>
+                <Typography style={{ textAlign: 'center' }}>
+                  <strong>{akamaiBillingInvoiceText}</strong>
+                </Typography>
+              </Grid>
+            </Grid>
+          </TableCell>
+        </TableRow>
+      );
+    }
     return (
       <TableRowEmpty
         colSpan={6}
@@ -45,8 +80,18 @@ const TableContentWrapper: React.FC<CombinedProps> = (props) => {
     );
   }
 
-  /* eslint-disable-next-line */
-  return <>{props.children}</>;
+  return (
+    <>
+      {isAkamaiCustomer ? (
+        <TableRow>
+          <TableCell colSpan={6} style={{ textAlign: 'center' }}>
+            <strong>Future {akamaiBillingInvoiceText}</strong>
+          </TableCell>
+        </TableRow>
+      ) : null}
+      {props.children}
+    </>
+  );
 };
 
 export default TableContentWrapper;

--- a/packages/manager/src/components/TableContentWrapper/TableContentWrapper.tsx
+++ b/packages/manager/src/components/TableContentWrapper/TableContentWrapper.tsx
@@ -52,7 +52,7 @@ const TableContentWrapper: React.FC<Props> = (props) => {
 
   return (
     <>
-      {renderCustomRow ? renderCustomRow() : null}
+      {renderCustomRow ? renderCustomRow() : undefined}
       {props.children}
     </>
   );

--- a/packages/manager/src/components/TableContentWrapper/TableContentWrapper.tsx
+++ b/packages/manager/src/components/TableContentWrapper/TableContentWrapper.tsx
@@ -1,17 +1,11 @@
 import { APIError } from '@linode/api-v4/lib/types';
 import * as React from 'react';
-import { makeStyles, Theme } from 'src/components/core/styles';
-import Typography from 'src/components/core/Typography';
-import Grid from 'src/components/Grid/Grid';
-import TableCell from 'src/components/TableCell/TableCell';
-import TableRow from 'src/components/TableRow/TableRow';
 import TableRowEmpty from 'src/components/TableRowEmptyState';
 import TableRowError from 'src/components/TableRowError';
 import {
   Props as TableLoadingProps,
   TableRowLoading,
 } from 'src/components/TableRowLoading/TableRowLoading';
-import { akamaiBillingInvoiceText } from 'src/features/Billing/billingUtils';
 
 interface Props {
   length: number;
@@ -20,15 +14,9 @@ interface Props {
   error?: APIError[];
   emptyMessage?: string;
   loadingProps?: TableLoadingProps;
-  isAkamaiCustomer?: boolean;
+  renderRowEmptyState?: () => JSX.Element;
+  renderCustomRow?: () => JSX.Element;
 }
-
-const useStyles = makeStyles((theme: Theme) => ({
-  grid: {
-    width: '100%',
-    padding: theme.spacing(10),
-  },
-}));
 
 const TableContentWrapper: React.FC<Props> = (props) => {
   const {
@@ -38,10 +26,9 @@ const TableContentWrapper: React.FC<Props> = (props) => {
     error,
     lastUpdated,
     loadingProps,
-    isAkamaiCustomer,
+    renderRowEmptyState,
+    renderCustomRow,
   } = props;
-
-  const classes = useStyles();
 
   if (loading) {
     return <TableRowLoading {...loadingProps} />;
@@ -52,25 +39,8 @@ const TableContentWrapper: React.FC<Props> = (props) => {
   }
 
   if (lastUpdated !== 0 && length === 0) {
-    if (isAkamaiCustomer) {
-      return (
-        <TableRow>
-          <TableCell colSpan={6}>
-            <Grid
-              container
-              justifyContent="center"
-              alignItems="center"
-              className={classes.grid}
-            >
-              <Grid item>
-                <Typography style={{ textAlign: 'center' }}>
-                  <strong>{akamaiBillingInvoiceText}</strong>
-                </Typography>
-              </Grid>
-            </Grid>
-          </TableCell>
-        </TableRow>
-      );
+    if (renderRowEmptyState) {
+      return renderRowEmptyState();
     }
     return (
       <TableRowEmpty
@@ -82,13 +52,7 @@ const TableContentWrapper: React.FC<Props> = (props) => {
 
   return (
     <>
-      {isAkamaiCustomer ? (
-        <TableRow>
-          <TableCell colSpan={6} style={{ textAlign: 'center' }}>
-            <strong>Future {akamaiBillingInvoiceText}</strong>
-          </TableCell>
-        </TableRow>
-      ) : null}
+      {renderCustomRow ? renderCustomRow() : null}
       {props.children}
     </>
   );

--- a/packages/manager/src/components/TableContentWrapper/TableContentWrapper.tsx
+++ b/packages/manager/src/components/TableContentWrapper/TableContentWrapper.tsx
@@ -14,8 +14,8 @@ interface Props {
   error?: APIError[];
   emptyMessage?: string;
   loadingProps?: TableLoadingProps;
-  renderRowEmptyState?: () => JSX.Element;
-  renderCustomRow?: () => JSX.Element;
+  rowEmptyState?: JSX.Element;
+  customFirstRow?: JSX.Element;
 }
 
 const TableContentWrapper: React.FC<Props> = (props) => {
@@ -26,8 +26,8 @@ const TableContentWrapper: React.FC<Props> = (props) => {
     error,
     lastUpdated,
     loadingProps,
-    renderRowEmptyState,
-    renderCustomRow,
+    rowEmptyState,
+    customFirstRow,
   } = props;
 
   if (loading) {
@@ -39,8 +39,8 @@ const TableContentWrapper: React.FC<Props> = (props) => {
   }
 
   if (lastUpdated !== 0 && length === 0) {
-    if (renderRowEmptyState) {
-      return renderRowEmptyState();
+    if (rowEmptyState) {
+      return rowEmptyState;
     }
     return (
       <TableRowEmpty
@@ -52,7 +52,7 @@ const TableContentWrapper: React.FC<Props> = (props) => {
 
   return (
     <>
-      {renderCustomRow ? renderCustomRow() : undefined}
+      {customFirstRow ? customFirstRow : undefined}
       {props.children}
     </>
   );

--- a/packages/manager/src/components/TableRowEmptyState/TableRowEmptyState.tsx
+++ b/packages/manager/src/components/TableRowEmptyState/TableRowEmptyState.tsx
@@ -12,7 +12,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 export interface Props {
   colSpan: number;
-  message?: string;
+  message?: string | JSX.Element;
 }
 
 type CombinedProps = Props;

--- a/packages/manager/src/factories/account.ts
+++ b/packages/manager/src/factories/account.ts
@@ -35,6 +35,7 @@ export const accountFactory = Factory.Sync.makeFactory<Account>({
     expiry: '01/2018',
   },
   balance_uninvoiced: 0.0,
+  billing_source: 'linode',
   active_since: '2018-07-03T12:15:25',
   capabilities: [
     'Linodes',

--- a/packages/manager/src/features/Billing/BillingDetail.tsx
+++ b/packages/manager/src/features/Billing/BillingDetail.tsx
@@ -95,6 +95,7 @@ export const BillingDetail: React.FC<CombinedProps> = (props) => {
                 loading={paymentMethodsLoading}
                 error={paymentMethodsError}
                 paymentMethods={paymentMethods}
+                isAkamaiCustomer={account?.billing_source === 'akamai'}
               />
             </Grid>
             <BillingActivityPanel accountActiveSince={account?.active_since} />

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -6,6 +6,7 @@ import {
 } from '@linode/api-v4/lib/account';
 import { DateTime } from 'luxon';
 import * as React from 'react';
+import Box from 'src/components/core/Box';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
@@ -23,6 +24,7 @@ import TableCell from 'src/components/TableCell';
 import TableContentWrapper from 'src/components/TableContentWrapper';
 import TableRow from 'src/components/TableRow';
 import { ISO_DATETIME_NO_TZ_FORMAT } from 'src/constants';
+import { akamaiBillingInvoiceText } from 'src/features/Billing/billingUtils';
 import {
   printInvoice,
   printPayment,
@@ -110,6 +112,10 @@ const useStyles = makeStyles((theme: Theme) => ({
   pdfError: {
     color: theme.color.red,
   },
+  akamaiEmptyRow: {
+    width: '100%',
+    padding: theme.spacing(10),
+  },
 }));
 
 interface ActivityFeedItem {
@@ -142,6 +148,16 @@ const transactionDateOptions: Item<DateRange>[] = [
   { label: '12 Months', value: '12 Months' },
   { label: 'All Time', value: 'All Time' },
 ];
+
+const renderAkamaiInvoiceRow = () => {
+  return (
+    <TableRow>
+      <TableCell colSpan={6} style={{ textAlign: 'center' }}>
+        <strong>Future {akamaiBillingInvoiceText}</strong>
+      </TableCell>
+    </TableRow>
+  );
+};
 
 const defaultDateRange: DateRange = '6 Months';
 
@@ -308,6 +324,24 @@ export const BillingActivityPanel: React.FC<Props> = (props) => {
     });
   }, [selectedTransactionType, selectedTransactionDate, combinedData]);
 
+  const renderAkamaiRowEmptyState = React.useCallback(() => {
+    return (
+      <TableRow>
+        <TableCell colSpan={4}>
+          <Box
+            className={classes.akamaiEmptyRow}
+            alignItems="center"
+            justifyContent="center"
+          >
+            <Typography style={{ textAlign: 'center' }}>
+              <strong>{akamaiBillingInvoiceText}</strong>
+            </Typography>
+          </Box>
+        </TableCell>
+      </TableRow>
+    );
+  }, [classes.akamaiEmptyRow]);
+
   return (
     <div className={classes.root}>
       <div className={classes.headerContainer}>
@@ -408,7 +442,14 @@ export const BillingActivityPanel: React.FC<Props> = (props) => {
                               ]
                             : undefined
                         }
-                        isAkamaiCustomer={isAkamaiCustomer}
+                        renderRowEmptyState={
+                          isAkamaiCustomer
+                            ? renderAkamaiRowEmptyState
+                            : undefined
+                        }
+                        renderCustomRow={
+                          isAkamaiCustomer ? renderAkamaiInvoiceRow : undefined
+                        }
                       >
                         {paginatedAndOrderedData.map((thisItem) => {
                           return (
@@ -456,6 +497,7 @@ export const BillingActivityPanel: React.FC<Props> = (props) => {
             isAkamaiCustomer,
             downloadInvoicePDF,
             downloadPaymentPDF,
+            renderAkamaiRowEmptyState,
             pdfErrors,
             pdfLoading,
           ]

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -145,33 +145,29 @@ const transactionDateOptions: Item<DateRange>[] = [
   { label: 'All Time', value: 'All Time' },
 ];
 
-export const renderAkamaiRowEmptyState = () => {
-  return (
-    <TableRow>
-      <TableCell colSpan={4}>
-        <Box
-          style={{ width: '100%', padding: 80 }}
-          alignItems="center"
-          justifyContent="center"
-        >
-          <Typography style={{ textAlign: 'center' }}>
-            <strong>{akamaiBillingInvoiceText}</strong>
-          </Typography>
-        </Box>
-      </TableCell>
-    </TableRow>
-  );
-};
+export const akamaiRowEmptyState = (
+  <TableRow>
+    <TableCell colSpan={4}>
+      <Box
+        style={{ width: '100%', padding: 80 }}
+        alignItems="center"
+        justifyContent="center"
+      >
+        <Typography style={{ textAlign: 'center' }}>
+          <strong>{akamaiBillingInvoiceText}</strong>
+        </Typography>
+      </Box>
+    </TableCell>
+  </TableRow>
+);
 
-export const renderAkamaiInvoiceRow = () => {
-  return (
-    <TableRow>
-      <TableCell colSpan={6} style={{ textAlign: 'center' }}>
-        <strong>Future {akamaiBillingInvoiceText}</strong>
-      </TableCell>
-    </TableRow>
-  );
-};
+export const akamaiInvoiceRow = (
+  <TableRow>
+    <TableCell colSpan={6} style={{ textAlign: 'center' }}>
+      <strong>Future {akamaiBillingInvoiceText}</strong>
+    </TableCell>
+  </TableRow>
+);
 
 const defaultDateRange: DateRange = '6 Months';
 
@@ -438,13 +434,11 @@ export const BillingActivityPanel: React.FC<Props> = (props) => {
                               ]
                             : undefined
                         }
-                        renderRowEmptyState={
-                          isAkamaiCustomer
-                            ? renderAkamaiRowEmptyState
-                            : undefined
+                        rowEmptyState={
+                          isAkamaiCustomer ? akamaiRowEmptyState : undefined
                         }
-                        renderCustomRow={
-                          isAkamaiCustomer ? renderAkamaiInvoiceRow : undefined
+                        customFirstRow={
+                          isAkamaiCustomer ? akamaiInvoiceRow : undefined
                         }
                       >
                         {paginatedAndOrderedData.map((thisItem) => {

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -112,10 +112,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   pdfError: {
     color: theme.color.red,
   },
-  akamaiEmptyRow: {
-    width: '100%',
-    padding: theme.spacing(10),
-  },
 }));
 
 interface ActivityFeedItem {
@@ -149,7 +145,25 @@ const transactionDateOptions: Item<DateRange>[] = [
   { label: 'All Time', value: 'All Time' },
 ];
 
-const renderAkamaiInvoiceRow = () => {
+export const renderAkamaiRowEmptyState = () => {
+  return (
+    <TableRow>
+      <TableCell colSpan={4}>
+        <Box
+          style={{ width: '100%', padding: 80 }}
+          alignItems="center"
+          justifyContent="center"
+        >
+          <Typography style={{ textAlign: 'center' }}>
+            <strong>{akamaiBillingInvoiceText}</strong>
+          </Typography>
+        </Box>
+      </TableCell>
+    </TableRow>
+  );
+};
+
+export const renderAkamaiInvoiceRow = () => {
   return (
     <TableRow>
       <TableCell colSpan={6} style={{ textAlign: 'center' }}>
@@ -324,24 +338,6 @@ export const BillingActivityPanel: React.FC<Props> = (props) => {
     });
   }, [selectedTransactionType, selectedTransactionDate, combinedData]);
 
-  const renderAkamaiRowEmptyState = React.useCallback(() => {
-    return (
-      <TableRow>
-        <TableCell colSpan={4}>
-          <Box
-            className={classes.akamaiEmptyRow}
-            alignItems="center"
-            justifyContent="center"
-          >
-            <Typography style={{ textAlign: 'center' }}>
-              <strong>{akamaiBillingInvoiceText}</strong>
-            </Typography>
-          </Box>
-        </TableCell>
-      </TableRow>
-    );
-  }, [classes.akamaiEmptyRow]);
-
   return (
     <div className={classes.root}>
       <div className={classes.headerContainer}>
@@ -497,7 +493,6 @@ export const BillingActivityPanel: React.FC<Props> = (props) => {
             isAkamaiCustomer,
             downloadInvoicePDF,
             downloadPaymentPDF,
-            renderAkamaiRowEmptyState,
             pdfErrors,
             pdfLoading,
           ]

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -156,6 +156,7 @@ export const BillingActivityPanel: React.FC<Props> = (props) => {
   const { accountActiveSince } = props;
 
   const { data: account } = useAccount();
+  const isAkamaiCustomer = account?.billing_source === 'akamai';
 
   const classes = useStyles();
   const flags = useFlags();
@@ -407,6 +408,7 @@ export const BillingActivityPanel: React.FC<Props> = (props) => {
                               ]
                             : undefined
                         }
+                        isAkamaiCustomer={isAkamaiCustomer}
                       >
                         {paginatedAndOrderedData.map((thisItem) => {
                           return (
@@ -451,6 +453,7 @@ export const BillingActivityPanel: React.FC<Props> = (props) => {
             accountInvoicesLoading,
             accountPaymentsError,
             accountInvoicesError,
+            isAkamaiCustomer,
             downloadInvoicePDF,
             downloadPaymentPDF,
             pdfErrors,

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/BillingSummary.tsx
@@ -205,6 +205,11 @@ export const BillingSummary: React.FC<BillingSummaryProps> = (props) => {
     isWithinDays(90, account?.active_since) &&
     promotions?.length === 0;
 
+  const accruedChargesHelperText =
+    account?.billing_source === 'akamai'
+      ? 'Accrued charges shown are an approximation and may not exactly reflect your post-tax invoice.'
+      : 'Our billing cycle ends on the last day of the month. You may be invoiced before the end of the cycle if your balance exceeds your credit limit.';
+
   return (
     <>
       <Grid container spacing={2} className={classes.root}>
@@ -266,7 +271,7 @@ export const BillingSummary: React.FC<BillingSummaryProps> = (props) => {
               <Typography variant="h3">Accrued Charges</Typography>
               <HelpIcon
                 className={classes.helpIcon}
-                text="Our billing cycle ends on the last day of the month. You may be invoiced before the end of the cycle if your balance exceeds your credit limit."
+                text={accruedChargesHelperText}
               />
             </Box>
             <Divider />

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.test.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.test.tsx
@@ -3,7 +3,7 @@ import { PayPalScriptProvider } from '@paypal/react-paypal-js';
 import * as React from 'react';
 import { PAYPAL_CLIENT_ID } from 'src/constants';
 import { paymentMethodFactory } from 'src/factories';
-import { renderWithTheme } from 'src/utilities/testHelpers';
+import { renderWithTheme, wrapWithTheme } from 'src/utilities/testHelpers';
 import PaymentInformation from './PaymentInformation';
 
 jest.mock('@linode/api-v4/lib/account', () => {
@@ -32,11 +32,43 @@ describe('Payment Info Panel', () => {
   it('Shows loading animation when loading', () => {
     const { getByLabelText } = renderWithTheme(
       <PayPalScriptProvider options={{ 'client-id': PAYPAL_CLIENT_ID }}>
-        <PaymentInformation loading={true} paymentMethods={paymentMethods} />
+        <PaymentInformation
+          loading={true}
+          paymentMethods={paymentMethods}
+          isAkamaiCustomer={false}
+        />
       </PayPalScriptProvider>
     );
 
     expect(getByLabelText('Content is loading')).toBeVisible();
+  });
+
+  it('Shows Add Payment button for Linode customers and hides it for Akamai customers', () => {
+    const { queryByText, getByTestId, rerender } = renderWithTheme(
+      <PayPalScriptProvider options={{ 'client-id': PAYPAL_CLIENT_ID }}>
+        <PaymentInformation
+          loading={false}
+          paymentMethods={paymentMethods}
+          isAkamaiCustomer={false}
+        />
+      </PayPalScriptProvider>
+    );
+
+    expect(getByTestId('payment-info-add-payment-method')).toBeInTheDocument();
+
+    rerender(
+      wrapWithTheme(
+        <PayPalScriptProvider options={{ 'client-id': PAYPAL_CLIENT_ID }}>
+          <PaymentInformation
+            loading={false}
+            paymentMethods={paymentMethods}
+            isAkamaiCustomer={true}
+          />
+        </PayPalScriptProvider>
+      )
+    );
+
+    expect(queryByText('Add Payment Method')).toBeNull();
   });
 
   // @TODO: Restore `PaymentInformation.test.tsx` tests. See M3-5768 for more information.
@@ -55,17 +87,40 @@ describe('Payment Info Panel', () => {
   //   expect(getByTestId('drawer')).toBeVisible();
   // });
 
-  // it('Lists all payment methods', () => {
-  //   const { getByTestId } = renderWithTheme(
-  //     <PayPalScriptProvider options={{ 'client-id': PAYPAL_CLIENT_ID }}>
-  //       <PaymentInformation loading={false} paymentMethods={paymentMethods} />
-  //     </PayPalScriptProvider>
-  //   );
+  it('Lists all payment methods for Linode customers', () => {
+    const { getByTestId } = renderWithTheme(
+      <PayPalScriptProvider options={{ 'client-id': PAYPAL_CLIENT_ID }}>
+        <PaymentInformation
+          loading={false}
+          paymentMethods={paymentMethods}
+          isAkamaiCustomer={false}
+        />
+      </PayPalScriptProvider>
+    );
 
-  //   paymentMethods.forEach((paymentMethod) => {
-  //     expect(
-  //       getByTestId(`payment-method-row-${paymentMethod.id}`)
-  //     ).toBeVisible();
-  //   });
-  // });
+    paymentMethods.forEach((paymentMethod) => {
+      expect(
+        getByTestId(`payment-method-row-${paymentMethod.id}`)
+      ).toBeVisible();
+    });
+  });
+
+  it('Hides payment methods and shows text for Akamai customers', () => {
+    const { getByTestId, queryByTestId } = renderWithTheme(
+      <PayPalScriptProvider options={{ 'client-id': PAYPAL_CLIENT_ID }}>
+        <PaymentInformation
+          loading={false}
+          paymentMethods={paymentMethods}
+          isAkamaiCustomer={true}
+        />
+      </PayPalScriptProvider>
+    );
+
+    paymentMethods.forEach((paymentMethod) => {
+      expect(
+        queryByTestId(`payment-method-row-${paymentMethod.id}`)
+      ).toBeNull();
+    });
+    expect(getByTestId('akamai-customer-text')).toBeInTheDocument();
+  });
 });

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.tsx
@@ -14,7 +14,6 @@ import Link from 'src/components/Link';
 import DeletePaymentMethodDialog from 'src/components/PaymentMethodRow/DeletePaymentMethodDialog';
 import styled from 'src/containers/SummaryPanels.styles';
 import PaymentMethods from 'src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentMethods';
-import { useAccount } from 'src/queries/account';
 import { queryKey } from 'src/queries/accountPayment';
 import { queryClient } from 'src/queries/base';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
@@ -77,10 +76,11 @@ interface Props {
   loading: boolean;
   error?: APIError[] | null;
   paymentMethods: PaymentMethod[] | undefined;
+  isAkamaiCustomer: boolean;
 }
 
 const PaymentInformation: React.FC<Props> = (props) => {
-  const { loading, error, paymentMethods } = props;
+  const { loading, error, paymentMethods, isAkamaiCustomer } = props;
   const [addDrawerOpen, setAddDrawerOpen] = React.useState<boolean>(false);
 
   const [deleteDialogOpen, setDeleteDialogOpen] = React.useState<boolean>(
@@ -95,15 +95,12 @@ const PaymentInformation: React.FC<Props> = (props) => {
 
   const classes = useStyles();
   const { replace } = useHistory();
-  const { data: account } = useAccount();
-
-  const isAkamaiAccount = account?.billing_source === 'akamai';
 
   const drawerLink = '/account/billing/add-payment-method';
   const addPaymentMethodRouteMatch = Boolean(useRouteMatch(drawerLink));
 
   const showPayPalAvailableNotice =
-    !isAkamaiAccount &&
+    !isAkamaiCustomer &&
     !loading &&
     !paymentMethods?.some(
       (paymetMethod: PaymentMethod) => paymetMethod.type === 'paypal'
@@ -158,7 +155,7 @@ const PaymentInformation: React.FC<Props> = (props) => {
             </Typography>
           </Grid>
           <Grid item>
-            {!isAkamaiAccount ? (
+            {!isAkamaiCustomer ? (
               <Button
                 data-testid="payment-info-add-payment-method"
                 className={classes.edit}
@@ -169,7 +166,7 @@ const PaymentInformation: React.FC<Props> = (props) => {
             ) : null}
           </Grid>
         </Grid>
-        {!isAkamaiAccount ? (
+        {!isAkamaiCustomer ? (
           <PaymentMethods
             loading={loading}
             error={error}
@@ -177,7 +174,7 @@ const PaymentInformation: React.FC<Props> = (props) => {
             openDeleteDialog={openDeleteDialog}
           />
         ) : (
-          <Typography>
+          <Typography data-testid="akamai-customer-text">
             Payment method is determined by your contract with Akamai
             Technologies.
             <br />

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentInformation.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 import { useHistory, useRouteMatch } from 'react-router-dom';
 import PayPalIcon from 'src/assets/icons/payment/payPal.svg';
 import Button from 'src/components/Button';
-import CircleProgress from 'src/components/CircleProgress';
 import Box from 'src/components/core/Box';
 import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
@@ -12,23 +11,20 @@ import Typography from 'src/components/core/Typography';
 import DismissibleBanner from 'src/components/DismissibleBanner';
 import Grid from 'src/components/Grid';
 import Link from 'src/components/Link';
-import PaymentMethodRow from 'src/components/PaymentMethodRow';
+import DeletePaymentMethodDialog from 'src/components/PaymentMethodRow/DeletePaymentMethodDialog';
 import styled from 'src/containers/SummaryPanels.styles';
+import PaymentMethods from 'src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentMethods';
+import { useAccount } from 'src/queries/account';
+import { queryKey } from 'src/queries/accountPayment';
+import { queryClient } from 'src/queries/base';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import AddPaymentMethodDrawer from './AddPaymentMethodDrawer';
-import DeletePaymentMethodDialog from 'src/components/PaymentMethodRow/DeletePaymentMethodDialog';
-import { queryClient } from 'src/queries/base';
-import { queryKey } from 'src/queries/accountPayment';
 
 const useStyles = makeStyles((theme: Theme) => ({
   ...styled(theme),
   summarySectionHeight: {
     flex: '0 1 auto',
     width: '100%',
-  },
-  loading: {
-    display: 'flex',
-    justifyContent: 'center',
   },
   container: {
     flex: 1,
@@ -99,11 +95,15 @@ const PaymentInformation: React.FC<Props> = (props) => {
 
   const classes = useStyles();
   const { replace } = useHistory();
+  const { data: account } = useAccount();
+
+  const isAkamaiAccount = account?.billing_source === 'akamai';
 
   const drawerLink = '/account/billing/add-payment-method';
   const addPaymentMethodRouteMatch = Boolean(useRouteMatch(drawerLink));
 
   const showPayPalAvailableNotice =
+    !isAkamaiAccount &&
     !loading &&
     !paymentMethods?.some(
       (paymetMethod: PaymentMethod) => paymetMethod.type === 'paypal'
@@ -158,40 +158,31 @@ const PaymentInformation: React.FC<Props> = (props) => {
             </Typography>
           </Grid>
           <Grid item>
-            <Button
-              data-testid="payment-info-add-payment-method"
-              className={classes.edit}
-              onClick={() => replace(drawerLink)}
-            >
-              Add Payment Method
-            </Button>
+            {!isAkamaiAccount ? (
+              <Button
+                data-testid="payment-info-add-payment-method"
+                className={classes.edit}
+                onClick={() => replace(drawerLink)}
+              >
+                Add Payment Method
+              </Button>
+            ) : null}
           </Grid>
         </Grid>
-        {loading ? (
-          <Grid className={classes.loading}>
-            <CircleProgress mini />
-          </Grid>
-        ) : error ? (
-          <Typography>
-            {
-              getAPIErrorOrDefault(
-                error,
-                'There was an error retrieving your payment methods.'
-              )[0].reason
-            }
-          </Typography>
-        ) : !paymentMethods || paymentMethods?.length == 0 ? (
-          <Typography>
-            No payment methods have been specified for this account.
-          </Typography>
+        {!isAkamaiAccount ? (
+          <PaymentMethods
+            loading={loading}
+            error={error}
+            paymentMethods={paymentMethods}
+            openDeleteDialog={openDeleteDialog}
+          />
         ) : (
-          paymentMethods.map((paymentMethod: PaymentMethod) => (
-            <PaymentMethodRow
-              key={paymentMethod.id}
-              paymentMethod={paymentMethod}
-              onDelete={() => openDeleteDialog(paymentMethod)}
-            />
-          ))
+          <Typography>
+            Payment method is determined by your contract with Akamai
+            Technologies.
+            <br />
+            Contact your representative with questions.
+          </Typography>
         )}
         {showPayPalAvailableNotice ? (
           <DismissibleBanner

--- a/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentMethods.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PaymentInfoPanel/PaymentMethods.tsx
@@ -1,0 +1,71 @@
+import { PaymentMethod } from '@linode/api-v4/lib/account/types';
+import { APIError } from '@linode/api-v4/lib/types';
+import * as React from 'react';
+import CircleProgress from 'src/components/CircleProgress';
+import { makeStyles } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+import Grid from 'src/components/Grid';
+import PaymentMethodRow from 'src/components/PaymentMethodRow';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+
+const useStyles = makeStyles(() => ({
+  loading: {
+    display: 'flex',
+    justifyContent: 'center',
+  },
+}));
+
+interface Props {
+  loading: boolean;
+  error: APIError[] | null | undefined;
+  paymentMethods: PaymentMethod[] | undefined;
+  openDeleteDialog: (method: PaymentMethod) => void;
+}
+
+const PaymentMethods: React.FC<Props> = (props) => {
+  const { loading, error, paymentMethods, openDeleteDialog } = props;
+  const classes = useStyles();
+
+  if (loading) {
+    return (
+      <Grid className={classes.loading}>
+        <CircleProgress mini />
+      </Grid>
+    );
+  }
+
+  if (error) {
+    return (
+      <Typography>
+        {
+          getAPIErrorOrDefault(
+            error,
+            'There was an error retrieving your payment methods.'
+          )[0].reason
+        }
+      </Typography>
+    );
+  }
+
+  if (!paymentMethods || paymentMethods?.length == 0) {
+    return (
+      <Typography>
+        No payment methods have been specified for this account.
+      </Typography>
+    );
+  }
+
+  return (
+    <>
+      {paymentMethods.map((paymentMethod: PaymentMethod) => (
+        <PaymentMethodRow
+          key={paymentMethod.id}
+          paymentMethod={paymentMethod}
+          onDelete={() => openDeleteDialog(paymentMethod)}
+        />
+      ))}
+    </>
+  );
+};
+
+export default PaymentMethods;

--- a/packages/manager/src/features/Billing/billingUtils.ts
+++ b/packages/manager/src/features/Billing/billingUtils.ts
@@ -24,3 +24,6 @@ export const renderUnitPrice = (v: null | string) => {
   const parsedValue = parseFloat(`${v}`);
   return Number.isNaN(parsedValue) ? null : `$${parsedValue}`;
 };
+
+export const akamaiBillingInvoiceText =
+  'Linode products and services will appear on your Akamai Technologies invoice.';


### PR DESCRIPTION
## Description
Updates UI in `/account/billing` for Akamai customers
- Hide Make a Payment/Add Payment Method buttons and Payment Methods
- Added information banner to page and text to Payment Methods paper and Billing & Payments table
- Changed Accrued charges tooltip text

![image](https://user-images.githubusercontent.com/14323019/184423145-897669da-78cd-49de-a150-78ce49946efc.png)


## How to test
Check the `/account/billing` page as a Linode user and as an Akamai user (reach out for acc info)

**How do I run relevant unit tests?**
```
yarn test PaymentInformation TableContentWrapper
```