### PR TITLE
M3-5880: "Any/All" option in StackScript Create flow

### DIFF
--- a/packages/manager/src/features/Images/ImageSelect.tsx
+++ b/packages/manager/src/features/Images/ImageSelect.tsx
@@ -1,5 +1,5 @@
 import { Image } from '@linode/api-v4/lib/images';
-import { propOr } from 'ramda';
+import { clone, propOr } from 'ramda';
 import * as React from 'react';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Select, { GroupType, Item } from 'src/components/EnhancedSelect/Select';
@@ -37,6 +37,7 @@ interface Props {
   onSelect: (selected: Item<any> | Item<any>[]) => void;
   label?: string;
   required?: boolean;
+  anyAllOption?: boolean;
 }
 
 type CombinedProps = Props;
@@ -53,6 +54,7 @@ export const ImageSelect: React.FC<CombinedProps> = (props) => {
     value,
     disabled,
     required,
+    anyAllOption,
   } = props;
 
   const classes = useStyles();
@@ -70,6 +72,20 @@ export const ImageSelect: React.FC<CombinedProps> = (props) => {
   const renderedImages = React.useMemo(() => getImagesOptions(images), [
     images,
   ]);
+
+  const imageSelectOptions = clone(renderedImages);
+
+  if (anyAllOption) {
+    imageSelectOptions.unshift({
+      label: '',
+      options: [
+        {
+          label: 'Any/All',
+          value: 'any/all',
+        },
+      ],
+    });
+  }
 
   return (
     <Grid
@@ -89,7 +105,7 @@ export const ImageSelect: React.FC<CombinedProps> = (props) => {
           errorText={imageError || imageFieldError || reduxError}
           disabled={disabled || Boolean(imageError)}
           onChange={onSelect}
-          options={renderedImages as any}
+          options={imageSelectOptions as any}
           placeholder="Select an Image"
           textFieldProps={{
             required,

--- a/packages/manager/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
@@ -231,9 +231,16 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
 
   handleChooseImage = (images: Item<string>[]) => {
     const imageList = images.map((image) => image.value);
+
+    const anyAllOptionChosen = imageList.includes('any/all');
+
     this.setState(
       {
-        images: imageList,
+        /*
+        'Any/All' indicates all image options are compatible with the StackScript,
+        so users are not allowed to add additional selections.
+        */
+        images: anyAllOptionChosen ? ['any/all'] : imageList,
       },
       this.saveStateToLocalStorage
     );

--- a/packages/manager/src/features/StackScripts/StackScriptForm/StackScriptForm.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptForm/StackScriptForm.tsx
@@ -166,6 +166,7 @@ export const StackScriptForm: React.FC<CombinedProps> = (props) => {
               'Select which images are compatible with this StackScript.'
             }
             disabled={disabled}
+            anyAllOption
             data-qa-stackscript-target-select
           />
         </Grid>


### PR DESCRIPTION
## Description
Add an "Any/All" option in the StackScript Create flow in the "Target Images" dropdown.

## How to test
On the StackScript Create page, select "Any/All" for the "Target Images" dropdown. Ensure that no other images can be added. Also test the reverse, i.e., selecting other images and then selecting "Any/All"—doing the latter should clear the other selections out.

Confirm that creation goes through as expected.