### PR TITLE
M3-5881: Add `Any/All` Option on StackScripts Landing

### DIFF
--- a/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptRow.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptRow.tsx
@@ -96,7 +96,9 @@ export const StackScriptRow: React.FC<CombinedProps> = (props) => {
       </Hidden>
       <Hidden mdDown>
         {images.includes('any/all') ? (
-          <TableCell data-qa-stackscript-images>Any/All</TableCell>
+          <TableCell data-qa-stackscript-images className={classes.images}>
+            Any/All
+          </TableCell>
         ) : (
           <TableCell data-qa-stackscript-images className={classes.images}>
             {images.join(',  ')}

--- a/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptRow.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptRow.tsx
@@ -95,15 +95,9 @@ export const StackScriptRow: React.FC<CombinedProps> = (props) => {
         </TableCell>
       </Hidden>
       <Hidden mdDown>
-        {images.includes('any/all') ? (
-          <TableCell data-qa-stackscript-images className={classes.images}>
-            Any/All
-          </TableCell>
-        ) : (
-          <TableCell data-qa-stackscript-images className={classes.images}>
-            {images.join(',  ')}
-          </TableCell>
-        )}
+        <TableCell data-qa-stackscript-images className={classes.images}>
+          {images.includes('any/all') ? 'Any/All' : images.join(',  ')}
+        </TableCell>
       </Hidden>
       {communityStackScript ? null : ( // We hide the "Status" column in the "Community StackScripts" tab of the StackScripts landing page since all of those are public.
         <Hidden mdDown>

--- a/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptRow.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptRow.tsx
@@ -95,9 +95,13 @@ export const StackScriptRow: React.FC<CombinedProps> = (props) => {
         </TableCell>
       </Hidden>
       <Hidden mdDown>
-        <TableCell data-qa-stackscript-images className={classes.images}>
-          {images.join(',  ')}
-        </TableCell>
+        {images.includes('any/all') ? (
+          <TableCell data-qa-stackscript-images>Any/All</TableCell>
+        ) : (
+          <TableCell data-qa-stackscript-images className={classes.images}>
+            {images.join(',  ')}
+          </TableCell>
+        )}
       </Hidden>
       {communityStackScript ? null : ( // We hide the "Status" column in the "Community StackScripts" tab of the StackScripts landing page since all of those are public.
         <Hidden mdDown>


### PR DESCRIPTION
## Description 📝

- If an image has `any/all` as a compatible image, display `Any/All` as the only `Compatible Images` in a normal font

## Preview 📷

![Screen Shot 2022-08-16 at 12 33 08 PM](https://user-images.githubusercontent.com/6440455/184931890-bcbe8e7e-f9ae-4393-a4ef-4d20a6cf2668.jpg)

## How to test 🧪

- Create a Stackscript with `any/all` as the compatible images in dev
- View it from StackScripts landing (`http://localhost:3000/stackscripts/account`)

```
curl -X POST \
  -H "Authorization: Bearer [token]" \
  -H "Content-Type: application/json" \
  -d '{ "images": ["any/all"], "label": "test", "script": "#!/bin/bash" }' \
  https://[dev api domain]/v4/linode/stackscripts | json_pp
```