### PR TITLE
M3-5882: Show `Any/All` Chip on StackScripts Details

### DIFF
--- a/packages/manager/src/components/StackScript/StackScript.tsx
+++ b/packages/manager/src/components/StackScript/StackScript.tsx
@@ -121,6 +121,13 @@ export const StackScript: React.FC<Props> = (props) => {
         return acc;
       }
 
+      if (image === 'any/all') {
+        acc.available.push(
+          <Chip key={image} label="Any/All" component="span" />
+        );
+        return acc;
+      }
+
       if (imageObj) {
         acc.available.push(
           <Chip key={imageObj.id} label={imageObj.label} component="span" />


### PR DESCRIPTION
## Description 📝 

- Shows an `Any/All` chip when a StackScript has `any/all` as its images

## Preview 📷
![Screen Shot 2022-08-17 at 11 29 50 AM](https://user-images.githubusercontent.com/6440455/185180285-c06afb04-834d-41d7-aba2-afd5f5ad9302.jpg)

## How to test 🧪

- Create a StackScript with `any/all` as the compatible image
- Verify that `Any/All` shows up under `Compatible Images`

```
curl -X POST \
  -H "Authorization: Bearer [token]" \
  -H "Content-Type: application/json" \
  -d '{ "images": ["any/all"], "label": "test", "script": "#!/bin/bash" }' \
  https://[dev api domain]/v4/linode/stackscripts | json_pp
```
