### PR TITLE
M3-5902: StackScript Create tooltips edits

### DIFF
--- a/packages/manager/src/features/StackScripts/StackScriptForm/StackScriptForm.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptForm/StackScriptForm.tsx
@@ -162,7 +162,7 @@ export const StackScriptForm: React.FC<CombinedProps> = (props) => {
             label="Target Images"
             imageFieldError={hasErrorFor('images')}
             helperText={
-              'Select which images are compatible with this StackScript.'
+              'Select which images are compatible with this StackScript. "Any/All" allows you to use private images.'
             }
             disabled={disabled}
             anyAllOption

--- a/packages/manager/src/features/StackScripts/StackScriptForm/StackScriptForm.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptForm/StackScriptForm.tsx
@@ -138,7 +138,7 @@ export const StackScriptForm: React.FC<CombinedProps> = (props) => {
             placeholder="Enter a label"
             value={label.value}
             errorText={hasErrorFor('label')}
-            tooltipText="Give your StackScript a label"
+            tooltipText="StackScript labels must be between 3 and 128 characters."
             className={classes.labelField}
             disabled={disabled}
             data-qa-stackscript-label
@@ -150,7 +150,6 @@ export const StackScriptForm: React.FC<CombinedProps> = (props) => {
             placeholder="Enter a description"
             onChange={description.handler}
             value={description.value}
-            tooltipText="Give your StackScript a description"
             disabled={disabled}
             data-qa-stackscript-description
           />


### PR DESCRIPTION
## Description
- Revised tooltip for "Target Images" dropdown to include `"Any/All" allows you to use private images.` at the end
- Revised tooltip for "Label" field to state requirements (3-128 characters)
- Removed tooltip for "Description" field

## How to test
Visit the StackScript Create and StackScript Edit pages and verify the changes above

## Note to Reviewers
~~I'm going to rebase to `develop` again once https://github.com/linode/manager/pull/8499 is merged in since the commit history includes commits from the Cypress PR somehow...~~ done