### PR TITLE
M3-5884: Linode Create - Deploy StackScripts with Private Image

### DIFF
--- a/packages/manager/src/components/ImageSelect/ImageSelect.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.tsx
@@ -53,12 +53,12 @@ export const sortByImageVersion = (a: ImageItem, b: ImageItem) => {
   return 0;
 };
 
-export const sortGroupsWithMyImagesAtTheEnd = (a: string, b: string) => {
+export const sortGroupsWithMyImagesAtTheBeginning = (a: string, b: string) => {
   if (a === 'My Images') {
-    return 1;
+    return -1;
   }
   if (b === 'My Images') {
-    return -1;
+    return 1;
   }
   if (a > b) {
     return 1;
@@ -75,7 +75,7 @@ export const imagesToGroupedItems = (images: Image[]) => {
   }, images);
 
   return Object.keys(groupedImages)
-    .sort(sortGroupsWithMyImagesAtTheEnd)
+    .sort(sortGroupsWithMyImagesAtTheBeginning)
     .reduce((accum: GroupType<string>[], thisGroup) => {
       const group = groupedImages[thisGroup];
       if (!group || group.length === 0) {

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.test.tsx
@@ -14,11 +14,6 @@ const mockImages = imageFactory.buildList(10);
 
 const mockProps: CombinedProps = {
   category: 'community',
-  classes: {
-    main: '',
-    emptyImagePanel: '',
-    emptyImagePanelText: '',
-  },
   accountBackupsEnabled: false,
   updateImageID: jest.fn(),
   updateRegionID: jest.fn(),

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -1,15 +1,9 @@
+import * as React from 'react';
+import Paper from 'src/components/core/Paper';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import { Image } from '@linode/api-v4/lib/images';
 import { UserDefinedField } from '@linode/api-v4/lib/stackscripts';
-import { assocPath } from 'ramda';
-import * as React from 'react';
-import { compose } from 'recompose';
-import Paper from 'src/components/core/Paper';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles,
-} from 'src/components/core/styles';
+import { assocPath, equals } from 'ramda';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 import ImageSelect from 'src/components/ImageSelect';
@@ -20,30 +14,27 @@ import { StackScriptsRequest } from 'src/features/StackScripts/types';
 import UserDefinedFieldsPanel from 'src/features/StackScripts/UserDefinedFieldsPanel';
 import { filterImagesByType } from 'src/store/image/image.helpers';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
+import { filterUDFErrors } from './formUtilities';
 import {
   ReduxStateProps,
   StackScriptFormStateHandlers,
   WithTypesRegionsAndImages,
 } from '../types';
-import { filterUDFErrors } from './formUtilities';
 
-type ClassNames = 'main' | 'emptyImagePanel' | 'emptyImagePanelText';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    main: {
-      [theme.breakpoints.up('md')]: {
-        maxWidth: '100%',
-      },
+const useStyles = makeStyles((theme: Theme) => ({
+  main: {
+    [theme.breakpoints.up('md')]: {
+      maxWidth: '100%',
     },
-    emptyImagePanel: {
-      padding: theme.spacing(3),
-    },
-    emptyImagePanelText: {
-      marginTop: theme.spacing(1),
-      padding: `${theme.spacing(1)}px 0`,
-    },
-  });
+  },
+  emptyImagePanel: {
+    padding: theme.spacing(3),
+  },
+  emptyImagePanelText: {
+    marginTop: theme.spacing(1),
+    padding: `${theme.spacing(1)}px 0`,
+  },
+}));
 
 interface Props {
   request: StackScriptsRequest;
@@ -61,34 +52,55 @@ const errorResources = {
   stackscript_id: 'The selected StackScript',
 };
 
-type InnerProps = Props &
+export type CombinedProps = Props &
   ReduxStateProps &
   StackScriptFormStateHandlers &
   WithTypesRegionsAndImages;
 
-export type CombinedProps = InnerProps & WithStyles<ClassNames>;
+export const FromStackScriptContent = (props: CombinedProps) => {
+  const classes = useStyles();
+  const {
+    selectedImageID,
+    errors,
+    selectedStackScriptID,
+    userCannotCreateLinode,
+    selectedStackScriptUsername,
+    selectedStackScriptLabel,
+    request,
+    header,
+    updateImageID,
+    availableUserDefinedFields: userDefinedFields,
+    availableStackScriptImages: compatibleImages,
+    selectedUDFs: udf_data,
+    imagesData,
+  } = props;
 
-export class FromStackScriptContent extends React.PureComponent<CombinedProps> {
-  handleSelectStackScript = (
+  const handleSelectStackScript = (
     id: number,
     label: string,
     username: string,
     stackScriptImages: string[],
     userDefinedFields: UserDefinedField[]
   ) => {
-    const { imagesData } = this.props;
+    const { imagesData } = props;
+    const allowAllImages = stackScriptImages.includes('any/all');
+
     /**
      * based on the list of images we get back from the API, compare those
      * to our list of public images supported by Linode and filter out the ones
      * that aren't compatible with our selected StackScript
      */
-    const compatibleImages = Object.keys(imagesData).reduce((acc, eachKey) => {
-      if (stackScriptImages.some((eachSSImage) => eachSSImage === eachKey)) {
-        acc.push(imagesData[eachKey]);
-      }
+    const compatibleImages = allowAllImages
+      ? Object.values(imagesData)
+      : Object.keys(imagesData).reduce((acc, eachKey) => {
+          if (
+            stackScriptImages.some((eachSSImage) => eachSSImage === eachKey)
+          ) {
+            acc.push(imagesData[eachKey]);
+          }
 
-      return acc;
-    }, [] as Image[]);
+          return acc;
+        }, [] as Image[]);
 
     /**
      * if a UDF field comes back from the API with a "default"
@@ -101,7 +113,7 @@ export class FromStackScriptContent extends React.PureComponent<CombinedProps> {
       return accum;
     }, {});
 
-    this.props.updateStackScript(
+    props.updateStackScript(
       id,
       label,
       username,
@@ -111,109 +123,90 @@ export class FromStackScriptContent extends React.PureComponent<CombinedProps> {
     );
   };
 
-  handleChangeUDF = (key: string, value: string) => {
+  const handleChangeUDF = (key: string, value: string) => {
     // either overwrite or create new selection
-    const newUDFData = assocPath([key], value, this.props.selectedUDFs);
+    const newUDFData = assocPath([key], value, props.selectedUDFs);
 
-    this.props.handleSelectUDFs({ ...this.props.selectedUDFs, ...newUDFData });
+    props.handleSelectUDFs({ ...props.selectedUDFs, ...newUDFData });
   };
 
-  render() {
-    const {
-      selectedImageID,
-      errors,
-      classes,
-      selectedStackScriptID,
-      userCannotCreateLinode,
-      selectedStackScriptUsername,
-      selectedStackScriptLabel,
-      request,
-      header,
-      updateImageID,
-      availableUserDefinedFields: userDefinedFields,
-      availableStackScriptImages: compatibleImages,
-      selectedUDFs: udf_data,
-      imagesData,
-    } = this.props;
+  const hasErrorFor = getAPIErrorsFor(errorResources, errors);
 
-    const hasErrorFor = getAPIErrorsFor(errorResources, errors);
+  // If all of the StackScript's compatibleImages match the full array of images,
+  // we can assume that the StackScript specified any/all
+  const showAllImages = equals(compatibleImages, Object.values(imagesData));
 
-    return (
-      <React.Fragment>
-        <Grid
-          data-qa-panel={header}
-          item
-          className={`${classes.main} mlMain py0`}
-        >
-          <SelectStackScriptPanel
-            data-qa-select-stackscript
-            error={hasErrorFor('stackscript_id')}
-            header={header}
-            selectedId={selectedStackScriptID}
-            selectedUsername={selectedStackScriptUsername}
-            updateFor={[selectedStackScriptID, errors]}
-            onSelect={this.handleSelectStackScript}
-            publicImages={filterImagesByType(imagesData, 'public')}
-            resetSelectedStackScript={() => null}
-            disabled={userCannotCreateLinode}
-            request={request}
-            category={this.props.category}
-            isOnCreate
-          />
-          {!userCannotCreateLinode &&
-            userDefinedFields &&
-            userDefinedFields.length > 0 && (
-              <UserDefinedFieldsPanel
-                data-qa-udf-panel
-                errors={filterUDFErrors(errorResources, this.props.errors)}
-                selectedLabel={selectedStackScriptLabel || ''}
-                selectedUsername={selectedStackScriptUsername || ''}
-                handleChange={this.handleChangeUDF}
-                userDefinedFields={userDefinedFields}
-                updateFor={[userDefinedFields, udf_data, errors]}
-                udf_data={udf_data || {}}
-              />
-            )}
-          {!userCannotCreateLinode &&
-          compatibleImages &&
-          compatibleImages.length > 0 ? (
-            <ImageSelect
-              data-qa-select-image-panel
-              title="Select an Image"
-              images={compatibleImages}
-              handleSelectImage={updateImageID}
-              selectedImageID={selectedImageID}
-              error={hasErrorFor('image')}
-              variant="public"
+  return (
+    <React.Fragment>
+      <Grid
+        data-qa-panel={header}
+        item
+        className={`${classes.main} mlMain py0`}
+      >
+        <SelectStackScriptPanel
+          data-qa-select-stackscript
+          error={hasErrorFor('stackscript_id')}
+          header={header}
+          selectedId={selectedStackScriptID}
+          selectedUsername={selectedStackScriptUsername}
+          updateFor={[selectedStackScriptID, errors]}
+          onSelect={handleSelectStackScript}
+          publicImages={filterImagesByType(imagesData, 'public')}
+          resetSelectedStackScript={() => null}
+          disabled={userCannotCreateLinode}
+          request={request}
+          category={props.category}
+          isOnCreate
+        />
+        {!userCannotCreateLinode &&
+          userDefinedFields &&
+          userDefinedFields.length > 0 && (
+            <UserDefinedFieldsPanel
+              data-qa-udf-panel
+              errors={filterUDFErrors(errorResources, props.errors)}
+              selectedLabel={selectedStackScriptLabel || ''}
+              selectedUsername={selectedStackScriptUsername || ''}
+              handleChange={handleChangeUDF}
+              userDefinedFields={userDefinedFields}
+              updateFor={[userDefinedFields, udf_data, errors]}
+              udf_data={udf_data || {}}
             />
-          ) : (
-            <Paper className={classes.emptyImagePanel}>
-              {/* empty state for images */}
-              {hasErrorFor('image') && (
-                <Notice error={true} text={hasErrorFor('image')} />
-              )}
-              <Typography variant="h2" data-qa-tp="Select Image">
-                Select Image
-              </Typography>
-              <Typography
-                variant="body1"
-                className={classes.emptyImagePanelText}
-                data-qa-no-compatible-images
-              >
-                No Compatible Images Available
-              </Typography>
-            </Paper>
           )}
-        </Grid>
+        {!userCannotCreateLinode &&
+        compatibleImages &&
+        compatibleImages.length > 0 ? (
+          <ImageSelect
+            data-qa-select-image-panel
+            title="Select an Image"
+            images={compatibleImages}
+            handleSelectImage={updateImageID}
+            selectedImageID={selectedImageID}
+            error={hasErrorFor('image')}
+            variant={showAllImages ? 'all' : 'public'}
+          />
+        ) : (
+          <Paper className={classes.emptyImagePanel}>
+            {/* empty state for images */}
+            {hasErrorFor('image') && (
+              <Notice error={true} text={hasErrorFor('image')} />
+            )}
+            <Typography variant="h2" data-qa-tp="Select Image">
+              Select Image
+            </Typography>
+            <Typography
+              variant="body1"
+              className={classes.emptyImagePanelText}
+              data-qa-no-compatible-images
+            >
+              No Compatible Images Available
+            </Typography>
+          </Paper>
+        )}
+      </Grid>
 
-        <StackScriptDialog />
-      </React.Fragment>
-    );
-  }
-}
+      <StackScriptDialog />
+    </React.Fragment>
+  );
+};
 
-const styled = withStyles(styles);
-
-export default compose<CombinedProps, InnerProps>(styled)(
-  FromStackScriptContent
-);
+export default FromStackScriptContent;

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -82,7 +82,6 @@ export const FromStackScriptContent = (props: CombinedProps) => {
     stackScriptImages: string[],
     userDefinedFields: UserDefinedField[]
   ) => {
-    const { imagesData } = props;
     const allowAllImages = stackScriptImages.includes('any/all');
 
     /**


### PR DESCRIPTION
## Description 📝

- Allow users to deploy Linodes from StackScripts with Private Image
- Refactor `FromStackScriptContent.tsx` to a FC 
- Changes `all` variant of `<ImageSelect />` show private images first
  - **Note**: This will also affect the Linode Rebuild Image input, but I think this is for the better to show private images first

## Preview 📷

![Screen Shot 2022-08-18 at 1 37 25 PM](https://user-images.githubusercontent.com/6440455/185459290-8af4fcc3-d06c-4a13-b8ce-a1a2eeae64c1.jpg)

## How to test 🧪

- Create a StackScript with a Private Image #8499
- Try to deploy a Linode using that private image on `http://localhost:3000/linodes/create?type=StackScripts`