### PR TITLE
Hotfix StackScripts User Defined Field Input Bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2022-08-24] - v1.74.1
+
+### Fixed:
+- Issue causing user-defined fields to clear erroneously during Linode StackScript deploy
+
 ## [2022-08-22] - v1.74.0
 
 ### Added:

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.74.0",
+  "version": "1.74.1",
   "private": true,
   "engines": {
     "node": ">= 14.17.4"

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.test.tsx
@@ -14,6 +14,11 @@ const mockImages = imageFactory.buildList(10);
 
 const mockProps: CombinedProps = {
   category: 'community',
+  classes: {
+    main: '',
+    emptyImagePanel: '',
+    emptyImagePanelText: '',
+  },
   accountBackupsEnabled: false,
   updateImageID: jest.fn(),
   updateRegionID: jest.fn(),


### PR DESCRIPTION
## Description

- Fixes bug relating to UDF Input fields clearing when Deploying a Linode from an Account or Community Stackscript that has UDFs
- This bug was my bad. I rewrote a Class component to a functional component and overlooked the fact that the class component was a PureComponent which handles prop updates differently

## How to test

- Test Deploying a Account or Community Stackscript at `http://localhost:3000/linodes/create?type=StackScripts&subtype=Community` and ensure all types of UDF field configurations work
- Ensure the new `any/all` image option still works as expected
