### PR TITLE
M3-5901: Support Pro Dedicated Plans

### DIFF
--- a/packages/api-v4/src/linodes/types.ts
+++ b/packages/api-v4/src/linodes/types.ts
@@ -294,7 +294,8 @@ export type LinodeTypeClass =
   | 'dedicated'
   | 'highmem'
   | 'gpu'
-  | 'metal';
+  | 'metal'
+  | 'prodedicated';
 
 export interface IPAllocationRequest {
   type: 'ipv4';

--- a/packages/manager/src/components/AccessPanel/UserSSHKeyPanel.tsx
+++ b/packages/manager/src/components/AccessPanel/UserSSHKeyPanel.tsx
@@ -86,7 +86,7 @@ const UserSSHKeyPanel: React.FC<CombinedProps> = (props) => {
   };
 
   const usersWithKeys = users
-    ? users.filter((thisUser) => thisUser.keys.length > 0)
+    ? users.filter((thisUser) => thisUser.keys?.length > 0)
     : [];
 
   return (

--- a/packages/manager/src/factories/linodes.ts
+++ b/packages/manager/src/factories/linodes.ts
@@ -6,6 +6,7 @@ import {
   LinodeBackups,
   LinodeIPsResponse,
   LinodeSpecs,
+  LinodeType,
   NetStats,
   Stats,
   StatsData,
@@ -128,6 +129,37 @@ export const linodeTransferFactory = Factory.Sync.makeFactory<NetworkUtilization
     billable: 0,
   }
 );
+
+export const linodeTypeFactory = Factory.Sync.makeFactory<LinodeType>({
+  id: Factory.each((i) => `g6-standard-${i}`),
+  label: Factory.each((i) => `Linode ${i}GB`),
+  price: {
+    hourly: 0.015,
+    monthly: 10.0,
+  },
+  addons: {
+    backups: {
+      price: {
+        hourly: 0.004,
+        monthly: 2.5,
+      },
+    },
+  },
+  memory: 2048,
+  disk: 51200,
+  transfer: 2000,
+  vcpus: 1,
+  gpus: 0,
+  network_out: 2000,
+  class: 'standard',
+  successor: null,
+});
+
+export const proDedicatedTypeFactory = linodeTypeFactory.extend({
+  id: Factory.each((i) => `g6-prodedicated-${i}`),
+  label: Factory.each((i) => `Pro Dedicated 2${i}GB`),
+  class: 'prodedicated',
+});
 
 export const linodeFactory = Factory.Sync.makeFactory<Linode>({
   id: Factory.each((i) => i),

--- a/packages/manager/src/factories/linodes.ts
+++ b/packages/manager/src/factories/linodes.ts
@@ -155,10 +155,35 @@ export const linodeTypeFactory = Factory.Sync.makeFactory<LinodeType>({
   successor: null,
 });
 
-export const proDedicatedTypeFactory = linodeTypeFactory.extend({
+export const dedicatedTypeFactory = linodeTypeFactory.extend({
+  id: Factory.each((i) => `g6-dedicated-${i}`),
+  label: Factory.each((i) => `Dedicated 2${i}GB`),
+  class: 'dedicated',
+});
+
+export const proDedicatedTypeFactory = Factory.Sync.makeFactory<LinodeType>({
   id: Factory.each((i) => `g6-prodedicated-${i}`),
   label: Factory.each((i) => `Pro Dedicated 2${i}GB`),
   class: 'prodedicated',
+  price: {
+    hourly: 2.88,
+    monthly: 1920.0,
+  },
+  addons: {
+    backups: {
+      price: {
+        hourly: null,
+        monthly: null,
+      },
+    },
+  },
+  memory: 262144,
+  disk: 5120000,
+  transfer: 11000,
+  vcpus: 56,
+  gpus: 0,
+  network_out: 11000,
+  successor: null,
 });
 
 export const linodeFactory = Factory.Sync.makeFactory<Linode>({

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -142,7 +142,7 @@ const getProDedicated = (types: PlanSelectionType[]) =>
   types.filter((t: PlanSelectionType) => /prodedicated/.test(t.class));
 
 const getDedicated = (types: PlanSelectionType[]) =>
-  types.filter((t: PlanSelectionType) => /dedicated/.test(t.class));
+  types.filter((t: PlanSelectionType) => /^dedicated/.test(t.class));
 
 const getGPU = (types: PlanSelectionType[]) =>
   types.filter((t: PlanSelectionType) => /gpu/.test(t.class));
@@ -219,7 +219,7 @@ export const SelectPlanPanel: React.FC<CombinedProps> = (props) => {
               !isSamePlan && !isDisabledClass ? onSelect(type.id) : undefined
             }
             aria-disabled={isSamePlan || planTooSmall || isDisabledClass}
-             className={classNames(classes.focusedRow, {
+            className={classNames(classes.focusedRow, {
               [classes.disabledRow]:
                 isSamePlan || planTooSmall || isDisabledClass,
             })}

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -420,8 +420,8 @@ export const SelectPlanPanel: React.FC<CombinedProps> = (props) => {
           return (
             <>
               <Typography data-qa-prodedi className={classes.copy}>
-                Pro Dedicated CPU instances are for very large plans. They only
-                have AMD 2nd generation processors or above.
+                Pro Dedicated CPU instances are for very demanding workloads.
+                They only have AMD 2nd generation processors or newer.
               </Typography>
               {renderPlanContainer(proDedicated)}
             </>

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -138,6 +138,9 @@ const getStandard = (types: PlanSelectionType[]) =>
 const getHighMem = (types: PlanSelectionType[]) =>
   types.filter((t: PlanSelectionType) => /highmem/.test(t.class));
 
+const getProDedicated = (types: PlanSelectionType[]) =>
+  types.filter((t: PlanSelectionType) => /prodedicated/.test(t.class));
+
 const getDedicated = (types: PlanSelectionType[]) =>
   types.filter((t: PlanSelectionType) => /dedicated/.test(t.class));
 
@@ -402,6 +405,7 @@ export const SelectPlanPanel: React.FC<CombinedProps> = (props) => {
     const nanodes = getNanodes(types);
     const standards = getStandard(types);
     const highmem = getHighMem(types);
+    const proDedicated = getProDedicated(types);
     const dedicated = getDedicated(types);
     const gpu = getGPU(types);
     const metal = getMetal(types);
@@ -409,6 +413,24 @@ export const SelectPlanPanel: React.FC<CombinedProps> = (props) => {
     const tabOrder: LinodeTypeClass[] = [];
 
     const shared = [...nanodes, ...standards];
+
+    if (!isEmpty(proDedicated)) {
+      tabs.push({
+        render: () => {
+          return (
+            <>
+              <Typography data-qa-prodedi className={classes.copy}>
+                Pro Dedicated CPU instances are for very large plans. They only
+                have AMD 2nd generation processors or above.
+              </Typography>
+              {renderPlanContainer(proDedicated)}
+            </>
+          );
+        },
+        title: 'Pro Dedicated CPU',
+      });
+      tabOrder.push('prodedicated');
+    }
 
     if (!isEmpty(dedicated)) {
       tabs.push({

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -67,6 +67,7 @@ import {
   volumeFactory,
   managedIssueFactory,
   linodeTypeFactory,
+  dedicatedTypeFactory,
   proDedicatedTypeFactory,
 } from 'src/factories';
 import { accountAgreementsFactory } from 'src/factories/accountAgreements';
@@ -334,9 +335,7 @@ export const handlers = [
   }),
   rest.get('*/linode/types', (req, res, ctx) => {
     const standardTypes = linodeTypeFactory.buildList(7);
-    const dedicatedTypes = linodeTypeFactory.buildList(7, {
-      class: 'dedicated',
-    });
+    const dedicatedTypes = dedicatedTypeFactory.buildList(7);
     const proDedicatedType = proDedicatedTypeFactory.build();
     return res(
       ctx.json(

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -66,6 +66,8 @@ import {
   VLANFactory,
   volumeFactory,
   managedIssueFactory,
+  linodeTypeFactory,
+  proDedicatedTypeFactory,
 } from 'src/factories';
 import { accountAgreementsFactory } from 'src/factories/accountAgreements';
 import { grantsFactory } from 'src/factories/grants';
@@ -329,6 +331,22 @@ export const handlers = [
       ...creatingImages,
     ];
     return res(ctx.json(makeResourcePage(images)));
+  }),
+  rest.get('*/linode/types', (req, res, ctx) => {
+    const standardTypes = linodeTypeFactory.buildList(7);
+    const dedicatedTypes = linodeTypeFactory.buildList(7, {
+      class: 'dedicated',
+    });
+    const proDedicatedType = proDedicatedTypeFactory.build();
+    return res(
+      ctx.json(
+        makeResourcePage([
+          ...standardTypes,
+          ...dedicatedTypes,
+          proDedicatedType,
+        ])
+      )
+    );
   }),
   rest.get('*/linode/instances', async (req, res, ctx) => {
     const onlineLinodes = linodeFactory.buildList(60, {


### PR DESCRIPTION
## Description
Add support for `prodedicated` plan types in the Linode Create flow

![image](https://user-images.githubusercontent.com/14323019/195655192-03561c97-9771-4bd9-8beb-f23d90ebaeb0.png)

## How to test
Go to `/linodes/create` while pointing to dev or turn on the mocks
