### PR TITLE
M3-5635: Volume Status on Volumes landing

### DIFF
--- a/packages/manager/src/components/SupportLink/SupportLink.tsx
+++ b/packages/manager/src/components/SupportLink/SupportLink.tsx
@@ -1,17 +1,22 @@
 import * as React from 'react';
 import { Link, LinkProps } from 'react-router-dom';
+import { EntityType } from 'src/features/Support/SupportTickets/SupportTicketDrawer';
 
 interface Props {
   title?: string;
   description?: string;
   text: string;
+  entity?: EntityForTicketDetails;
   onClick?: LinkProps['onClick'];
 }
 
-type CombinedProps = Props;
+export interface EntityForTicketDetails {
+  id: number;
+  type: EntityType;
+}
 
-const SupportLink: React.FunctionComponent<CombinedProps> = (props) => {
-  const { description, text, title, onClick } = props;
+const SupportLink = (props: Props) => {
+  const { description, text, title, entity, onClick } = props;
   return (
     <Link
       to={{
@@ -20,6 +25,7 @@ const SupportLink: React.FunctionComponent<CombinedProps> = (props) => {
           open: true,
           title,
           description,
+          entity,
         },
       }}
       onClick={onClick}

--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
@@ -17,6 +17,7 @@ import Dialog from 'src/components/Dialog';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import Notice from 'src/components/Notice';
 import SectionErrorBoundary from 'src/components/SectionErrorBoundary';
+import { EntityForTicketDetails } from 'src/components/SupportLink/SupportLink';
 import TextField from 'src/components/TextField';
 import useEntities, { Entity } from 'src/hooks/useEntities';
 import { useAllDatabasesQuery } from 'src/queries/databases';
@@ -81,6 +82,7 @@ export interface Props {
   open: boolean;
   prefilledTitle?: string;
   prefilledDescription?: string;
+  prefilledEntity?: EntityForTicketDetails;
   onClose: () => void;
   onSuccess: (ticketId: number, attachmentErrors?: AttachmentError[]) => void;
   keepOpenOnSuccess?: boolean;
@@ -138,7 +140,7 @@ export const getInitialValue = (
 };
 
 export const SupportTicketDrawer: React.FC<CombinedProps> = (props) => {
-  const { open, prefilledDescription, prefilledTitle } = props;
+  const { open, prefilledDescription, prefilledTitle, prefilledEntity } = props;
 
   const valuesFromStorage = storage.supportText.get();
 
@@ -149,8 +151,12 @@ export const SupportTicketDrawer: React.FC<CombinedProps> = (props) => {
   const [description, setDescription] = React.useState<string>(
     getInitialValue(prefilledDescription, valuesFromStorage.description)
   );
-  const [entityType, setEntityType] = React.useState<EntityType>('general');
-  const [entityID, setEntityID] = React.useState<string>('');
+  const [entityType, setEntityType] = React.useState<EntityType>(
+    prefilledEntity?.type ?? 'general'
+  );
+  const [entityID, setEntityID] = React.useState<string>(
+    prefilledEntity ? String(prefilledEntity.id) : ''
+  );
 
   // Entities for populating dropdown
   const [data, setData] = React.useState<Item<any>[]>([]);
@@ -166,8 +172,11 @@ export const SupportTicketDrawer: React.FC<CombinedProps> = (props) => {
   const classes = useStyles();
 
   React.useEffect(() => {
-    if (open) {
+    if (!open) {
       resetDrawer();
+    }
+    if (prefilledEntity) {
+      loadSelectedEntities(prefilledEntity.type);
     }
   }, [open]);
 

--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketsLanding.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketsLanding.tsx
@@ -19,6 +19,7 @@ import {
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
+import { EntityForTicketDetails } from 'src/components/SupportLink/SupportLink';
 import withGlobalErrors, {
   Props as GlobalErrorProps,
 } from 'src/containers/globalErrors.container';
@@ -59,6 +60,7 @@ interface State {
   newTicket?: SupportTicket;
   prefilledTitle?: string;
   prefilledDescription?: string;
+  prefilledEntity?: EntityForTicketDetails;
 }
 
 const tabs = ['open', 'closed'];
@@ -97,6 +99,7 @@ export class SupportTicketsLanding extends React.PureComponent<
       drawerOpen: stateParams ? stateParams.open : drawerOpen,
       prefilledDescription: stateParams ? stateParams.description : undefined,
       prefilledTitle: stateParams ? stateParams.title : undefined,
+      prefilledEntity: stateParams ? stateParams.entity : undefined,
     };
   }
 
@@ -155,7 +158,13 @@ export class SupportTicketsLanding extends React.PureComponent<
   };
 
   renderTicketDrawer = () => {
-    const { drawerOpen, prefilledDescription, prefilledTitle } = this.state;
+    const {
+      drawerOpen,
+      prefilledDescription,
+      prefilledTitle,
+      prefilledEntity,
+    } = this.state;
+
     return (
       <SupportTicketDrawer
         open={drawerOpen}
@@ -163,6 +172,7 @@ export class SupportTicketsLanding extends React.PureComponent<
         onSuccess={this.handleAddTicketSuccess}
         prefilledDescription={prefilledDescription}
         prefilledTitle={prefilledTitle}
+        prefilledEntity={prefilledEntity}
       />
     );
   };

--- a/packages/manager/src/features/Volumes/VolumeTableRow.tsx
+++ b/packages/manager/src/features/Volumes/VolumeTableRow.tsx
@@ -50,18 +50,6 @@ export const volumeStatusIconMap: Record<ExtendedVolume['status'], Status> = {
   deleted: 'inactive',
 };
 
-export const volumeStatusMap: Record<
-  ExtendedVolume['status'],
-  string | JSX.Element
-> = {
-  active: 'Active',
-  resizing: 'Resizing',
-  creating: 'Creating',
-  contact_support: <SupportLink text="Contact Support" />,
-  deleting: 'Deleting',
-  deleted: 'Deleted',
-};
-
 export const VolumeTableRow: React.FC<CombinedProps> = (props) => {
   const classes = useStyles();
   const {
@@ -96,6 +84,20 @@ export const VolumeTableRow: React.FC<CombinedProps> = (props) => {
   const isVolumesLanding = Boolean(location.pathname.match(/volumes/));
 
   const formattedRegion = formatRegion(region);
+
+  const volumeStatusMap: Record<
+    ExtendedVolume['status'],
+    string | JSX.Element
+  > = {
+    active: 'Active',
+    resizing: 'Resizing',
+    creating: 'Creating',
+    contact_support: (
+      <SupportLink text="Contact Support" entity={{ type: 'volume_id', id }} />
+    ),
+    deleting: 'Deleting',
+    deleted: 'Deleted',
+  };
 
   const isNVMe = hardwareType === 'nvme';
 

--- a/packages/manager/src/features/Volumes/VolumeTableRow.tsx
+++ b/packages/manager/src/features/Volumes/VolumeTableRow.tsx
@@ -15,7 +15,7 @@ import TableRow from 'src/components/TableRow';
 import { formatRegion } from 'src/utilities';
 import { ExtendedVolume } from './types';
 import VolumesActionMenu, { ActionHandlers } from './VolumesActionMenu';
-import { capitalize } from 'src/utilities/capitalize';
+import SupportLink from 'src/components/SupportLink';
 
 export const useStyles = makeStyles((theme: Theme) => ({
   volumePath: {
@@ -41,13 +41,25 @@ const progressFromEvent = (e?: Event) => {
   return undefined;
 };
 
-export const volumeStatusMap: Record<ExtendedVolume['status'], Status> = {
+export const volumeStatusIconMap: Record<ExtendedVolume['status'], Status> = {
   active: 'active',
   resizing: 'other',
   creating: 'other',
   contact_support: 'error',
   deleting: 'other',
   deleted: 'inactive',
+};
+
+export const volumeStatusMap: Record<
+  ExtendedVolume['status'],
+  string | JSX.Element
+> = {
+  active: 'Active',
+  resizing: 'Resizing',
+  creating: 'Creating',
+  contact_support: <SupportLink text="Contact Support" />,
+  deleting: 'Deleting',
+  deleted: 'Deleted',
 };
 
 export const VolumeTableRow: React.FC<CombinedProps> = (props) => {
@@ -163,10 +175,12 @@ export const VolumeTableRow: React.FC<CombinedProps> = (props) => {
           )}
         </Grid>
       </TableCell>
-      <TableCell statusCell>
-        <StatusIcon status={volumeStatusMap[status]} />
-        {capitalize(status)}
-      </TableCell>
+      {isVolumesLanding ? (
+        <TableCell statusCell>
+          <StatusIcon status={volumeStatusIconMap[status]} />
+          {volumeStatusMap[status]}
+        </TableCell>
+      ) : null}
       {region ? (
         <TableCell data-qa-volume-region noWrap>
           {formattedRegion}

--- a/packages/manager/src/features/Volumes/VolumeTableRow.tsx
+++ b/packages/manager/src/features/Volumes/VolumeTableRow.tsx
@@ -1,4 +1,5 @@
 import { Event } from '@linode/api-v4/lib/account';
+import { Status } from 'src/components/StatusIcon/StatusIcon';
 import * as React from 'react';
 import { Link, useHistory, useLocation } from 'react-router-dom';
 import { compose } from 'recompose';
@@ -8,11 +9,13 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 import LinearProgress from 'src/components/LinearProgress';
+import StatusIcon from 'src/components/StatusIcon';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import { formatRegion } from 'src/utilities';
 import { ExtendedVolume } from './types';
 import VolumesActionMenu, { ActionHandlers } from './VolumesActionMenu';
+import { capitalize } from 'src/utilities/capitalize';
 
 export const useStyles = makeStyles((theme: Theme) => ({
   volumePath: {
@@ -38,6 +41,15 @@ const progressFromEvent = (e?: Event) => {
   return undefined;
 };
 
+export const volumeStatusMap: Record<ExtendedVolume['status'], Status> = {
+  active: 'active',
+  resizing: 'other',
+  creating: 'other',
+  contact_support: 'error',
+  deleting: 'other',
+  deleted: 'inactive',
+};
+
 export const VolumeTableRow: React.FC<CombinedProps> = (props) => {
   const classes = useStyles();
   const {
@@ -52,6 +64,7 @@ export const VolumeTableRow: React.FC<CombinedProps> = (props) => {
     handleUpgrade,
     id,
     label,
+    status,
     tags,
     size,
     recentEvent,
@@ -149,6 +162,10 @@ export const VolumeTableRow: React.FC<CombinedProps> = (props) => {
             </Grid>
           )}
         </Grid>
+      </TableCell>
+      <TableCell statusCell>
+        <StatusIcon status={volumeStatusMap[status]} />
+        {capitalize(status)}
       </TableCell>
       {region ? (
         <TableCell data-qa-volume-region noWrap>

--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -110,7 +110,7 @@ export const volumeHeaders = [
     label: 'Label',
     dataColumn: 'label',
     sortable: true,
-    widthPercent: 30,
+    widthPercent: 35,
   },
   {
     label: 'Status',
@@ -134,7 +134,7 @@ export const volumeHeaders = [
     label: 'Attached To',
     dataColumn: 'Attached To',
     sortable: false,
-    widthPercent: 25,
+    widthPercent: 20,
   },
 ];
 

--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -110,7 +110,13 @@ export const volumeHeaders = [
     label: 'Label',
     dataColumn: 'label',
     sortable: true,
-    widthPercent: 40,
+    widthPercent: 30,
+  },
+  {
+    label: 'Status',
+    dataColumn: 'status',
+    sortable: true,
+    widthPercent: 10,
   },
   {
     label: 'Region',

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -629,6 +629,18 @@ export const handlers = [
       hddVolumeAttached,
       hddVolumeAttached2,
       hddVolumeUnattached,
+      volumeFactory.build({
+        status: 'contact_support',
+      }),
+      volumeFactory.build({
+        status: 'creating',
+      }),
+      volumeFactory.build({
+        status: 'deleting',
+      }),
+      volumeFactory.build({
+        status: 'resizing',
+      }),
     ];
     return res(ctx.json(makeResourcePage(volumes)));
   }),


### PR DESCRIPTION
## Description 📝

- Adds Volume Status to the Volumes Landing Page
- Adds initial support to pre-populate the support ticket modal with a pre-selected entity

## Preview 📷

![Screen Shot 2022-08-24 at 6 23 50 PM](https://user-images.githubusercontent.com/6440455/186534093-c0d1affc-2c70-44c2-81a6-e7b01d1025c1.jpg)

## How to test 🧪

- Check Volumes Landing for Volume statuses
- Use the MSW to see all possible states
