### PR TITLE
M3-5911: Marketplace UI Refinement: Searching and filtering analytics

### DIFF
--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -226,10 +226,10 @@ class FromAppsContent extends React.Component<CombinedProps, State> {
   };
 
   handleSelectCategory = (categoryItem: Item<AppCategory>) => {
-    sendMarketplaceSearchEvent('Category Dropdown', categoryItem.label);
     const didUserSelectCategory = categoryItem !== null;
     let instancesInCategory: StackScript[] | undefined = [];
     if (didUserSelectCategory) {
+      sendMarketplaceSearchEvent('Category Dropdown', categoryItem.label);
       const appsInCategory = oneClickApps.filter((oca) =>
         oca.categories?.includes(categoryItem.value)
       );

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -35,6 +35,7 @@ import Box from 'src/components/core/Box';
 import Paper from 'src/components/core/Paper';
 import Typography from 'src/components/core/Typography';
 import { oneClickApps, AppCategory } from 'src/features/OneClickApps/FakeSpec';
+import { sendMarketplaceSearchEvent } from 'src/utilities/ga';
 
 type ClassNames = 'main' | 'sidebar' | 'searchAndFilter' | 'search' | 'filter';
 
@@ -172,6 +173,10 @@ const renderLogo = (selectedStackScriptLabel?: string, logoUrl?: string) => {
 
 const curriedHandleSelectStackScript = curry(handleSelectStackScript);
 
+const handleSearchFieldClick = () => {
+  sendMarketplaceSearchEvent('Search Field');
+};
+
 class FromAppsContent extends React.Component<CombinedProps, State> {
   state: State = {
     detailDrawerOpen: false,
@@ -221,6 +226,7 @@ class FromAppsContent extends React.Component<CombinedProps, State> {
   };
 
   handleSelectCategory = (categoryItem: Item<AppCategory>) => {
+    sendMarketplaceSearchEvent('Category Dropdown', categoryItem.label);
     const didUserSelectCategory = categoryItem !== null;
     let instancesInCategory: StackScript[] | undefined = [];
     if (didUserSelectCategory) {
@@ -297,6 +303,7 @@ class FromAppsContent extends React.Component<CombinedProps, State> {
                   fullWidth
                   onSearch={this.onSearch}
                   label="Search marketplace"
+                  onClick={handleSearchFieldClick}
                   hideLabel
                   value={query}
                 />

--- a/packages/manager/src/utilities/ga.ts
+++ b/packages/manager/src/utilities/ga.ts
@@ -400,3 +400,16 @@ export const sendObjectStorageDocsEvent = (action: string) => {
     action,
   });
 };
+
+type TypeOfSearch = 'Search Field' | 'Category Dropdown';
+
+export const sendMarketplaceSearchEvent = (
+  typeOfSearch: TypeOfSearch,
+  appCategory?: string
+) => {
+  sendEvent({
+    category: 'Marketplace Create Flow',
+    action: typeOfSearch,
+    label: appCategory,
+  });
+};


### PR DESCRIPTION
## Description

Adds google analytics events for search and filtering on the marketplace page.

## How to test

1. Navigate to the marketplace page.
2. Click on the app search bar.
3. Ensure that a GA event is sent in the network tab of the developer tools
4. Click the category dropdown
5. Select a category
6. Ensure that a GA event is sent in the network tab of the developer tools

