### PR TITLE
M3-5908: Remove Type-to-Confirm checkbox from modals

### DIFF
--- a/packages/manager/src/components/TypeToConfirm/TypeToConfirm.tsx
+++ b/packages/manager/src/components/TypeToConfirm/TypeToConfirm.tsx
@@ -1,18 +1,13 @@
 import * as React from 'react';
-import CheckBox from 'src/components/CheckBox';
-import FormControlLabel from 'src/components/core/FormControlLabel';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
-import Grid from 'src/components/Grid';
 import Link from 'src/components/Link';
-import PreferenceToggle, { ToggleProps } from 'src/components/PreferenceToggle';
 import TextField from 'src/components/TextField';
 
 export interface Props {
   confirmationText?: JSX.Element | string;
   onChange: (str: string) => void;
   label: string;
-  hideDisable?: boolean;
   hideLabel?: boolean;
   textFieldStyle?: React.CSSProperties;
   typographyStyle?: React.CSSProperties;
@@ -38,68 +33,35 @@ const TypeToConfirm: React.FC<Props> = (props) => {
     textFieldStyle,
     typographyStyle,
     title,
-    hideDisable,
     visible,
     ...rest
   } = props;
 
   const classes = useStyles();
 
-  if (visible !== false) {
-    const preferenceToggle = (
-      <PreferenceToggle<boolean>
-        preferenceKey="type_to_confirm"
-        preferenceOptions={[true, false]}
-        localStorageKey="typeToConfirm"
-      >
-        {({
-          preference: istypeToConfirm,
-          togglePreference: toggleTypeToConfirm,
-        }: ToggleProps<boolean>) => {
-          return (
-            <Grid container alignItems="center">
-              <Grid item xs={12} style={{ marginLeft: 2 }}>
-                <FormControlLabel
-                  control={
-                    <CheckBox
-                      onChange={toggleTypeToConfirm}
-                      checked={!istypeToConfirm}
-                      inputProps={{
-                        'aria-label': `Disable type-to-confirm`,
-                      }}
-                    />
-                  }
-                  label="Disable type-to-confirm"
-                />
-              </Grid>
-            </Grid>
-          );
-        }}
-      </PreferenceToggle>
-    );
+  const disableOrEnable = visible ? 'disable' : 'enable';
 
-    return (
-      <>
-        <Typography variant="h2">{title}</Typography>
-        <Typography style={typographyStyle}>{confirmationText}</Typography>
-        <TextField
-          label={label}
-          hideLabel={hideLabel}
-          onChange={(e) => onChange(e.target.value)}
-          style={textFieldStyle}
-          {...rest}
-        />
-        {!hideDisable && preferenceToggle}
-      </>
-    );
-  } else {
-    return (
+  return (
+    <>
+      {visible ? (
+        <>
+          <Typography variant="h2">{title}</Typography>
+          <Typography style={typographyStyle}>{confirmationText}</Typography>
+          <TextField
+            label={label}
+            hideLabel={hideLabel}
+            onChange={(e) => onChange(e.target.value)}
+            style={textFieldStyle}
+            {...rest}
+          />
+        </>
+      ) : null}
       <Typography className={classes.description}>
-        To enable type-to-confirm, go to{' '}
-        <Link to="/profile/settings">My Settings</Link>.
+        To {disableOrEnable} type-to-confirm, go to the Type-to-Confirm section
+        of <Link to="/profile/settings">My Settings</Link>.
       </Typography>
-    );
-  }
+    </>
+  );
 };
 
 export default TypeToConfirm;

--- a/packages/manager/src/features/Account/CloseAccountDialog.tsx
+++ b/packages/manager/src/features/Account/CloseAccountDialog.tsx
@@ -129,13 +129,12 @@ const CloseAccountDialog: React.FC<CombinedProps> = (props) => {
         aria-label="username field"
         value={inputtedUsername}
         visible
-        hideDisable
         placeholder="Username"
       />
       <Typography className={classes.dontgo}>
-        We’d hate to see you go. Please let us know what we could be doing
+        We&rsquo;d hate to see you go. Please let us know what we could be doing
         better in the comments section below. After your account is closed,
-        you’ll be directed to a quick survey so we can better gauge your
+        you&rsquo;ll be directed to a quick survey so we can better gauge your
         feedback.
       </Typography>
       <TextField


### PR DESCRIPTION
## Description
Remove the "Disable type-to-confirm" checkbox from modals and replace it with text and a link to "My Settings".

The TTC setting will now be controlled solely from the "My Settings" page.

## How to test
Confirm that:

1. When TTC is enabled, you see the text field and `To disable type-to-confirm, go to the Type-to-Confirm section of My Settings.` below it
2. When TTC is disabled, you see only the text `To enable type-to-confirm, go to the Type-to-Confirm section of My Settings.`

in the modals for the Rebuild Linode, Resize Linode, Delete Kubernetes Cluster, Delete Bucket, Restore Database from Backup, and Delete Database flows. The Close Account flow should have the TTC regardless of user preference.
