### PR TITLE
M3-5816: Fix apostrophes in Linode Resize and Host Maintenance error

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/HostMaintenanceError.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/HostMaintenanceError.tsx
@@ -4,7 +4,7 @@ import Notice from 'src/components/Notice';
 const HostMaintenanceError = () => (
   <Notice
     warning
-    text="This action is unavailable while your Linode\u{2019}s host is undergoing maintenance."
+    text="This action is unavailable while your Linode&rsquo;s host is undergoing maintenance."
   />
 );
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -316,7 +316,7 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
         {disksError && (
           <Notice
             error
-            text="There was an error loading your Linode\u{2019}s Disks."
+            text="There was an error loading your Linode&rsquo;s Disks."
           />
         )}
         {submissionError && <Notice error>{submissionError}</Notice>}


### PR DESCRIPTION
## Description
Fixes apostrophes for Linode Resize and Host Maintenance errors

Before
![image](https://user-images.githubusercontent.com/14323019/187246341-ecbd2080-8004-47bd-a1ef-ed9539253545.png)

After
![image](https://user-images.githubusercontent.com/14323019/187246174-74469ddb-88c7-47ae-91eb-612f555fa164.png)

## How to test
Set the `disksError` and `hostMaintenance` errors to true in `LinodeResize.tsx` and then check the modal
