### PR TITLE
Improve Cypress/Docker Environment Variable Handling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,9 +30,14 @@ services:
         condition: service_healthy
     environment:
       - CYPRESS_BASE_URL=http://web:3000
-      - CYPRESS_RECORD_KEY=${CYPRESS_RECORD_KEY}
       - CYPRESS_RECORD=${CYPRESS_RECORD}
+      - CYPRESS_RECORD_KEY=${CYPRESS_RECORD_KEY}
       - HOME=/home/node
+      - MANAGER_OAUTH=${MANAGER_OAUTH_1}
+      - REACT_APP_API_ROOT=${REACT_APP_API_ROOT}
+      - REACT_APP_CLIENT_ID=${REACT_APP_CLIENT_ID}
+      - REACT_APP_LAUNCH_DARKLY_ID=${REACT_APP_LAUNCH_DARKLY_ID}
+      - REACT_APP_LOGIN_ROOT=${REACT_APP_LOGIN_ROOT}
     env_file: ./packages/manager/.env
     volumes:
       - ./packages/manager:/home/node/app/packages/manager

--- a/packages/manager/cypress/plugins/index.js
+++ b/packages/manager/cypress/plugins/index.js
@@ -21,14 +21,18 @@ function getConfiguration() {
   const conf = require('dotenv').config({
     path: dotenvPath,
   });
+  let parsedConf = {};
   if (conf.error) {
-    throw Error(
-      `Could not load .env from Cypress plugin/index.js: ${conf.error}`
+    console.warn(`Could not load .env file for Cypress: ${conf.error}`);
+    console.info(
+      'Cypress will rely on environment variables for configuration'
     );
+  } else {
+    parsedConf = conf.parsed;
   }
 
   const env = {
-    ...conf.parsed,
+    ...parsedConf,
     ...process.env,
   };
 


### PR DESCRIPTION
## Description
This builds off the improvements from PR #8490, and accomplishes two things:

- Passes Cypress and Cloud-related environment variables from the host environment (Jenkins, soon) to Docker when running tests
- Allows Cypress to run when no `.env` file is present (currently Cypress stops if it cannot load the file)

## How to test
I've confirmed that the `docker-compose.yml` changes work as expected in Jenkins (feel free to reach out and I can refer you to the related test project and jobs where these changes were applied and demonstrated to work).

To test the `.env` file changes, do the following:

1. Run Cypress as-is and confirm that it behaves as expected (i.e., existing configurations are not broken)
2. Temporarily rename your `.env` file, run Cypress, and confirm that it does not exit upon failing to load the `.env` file
    - Tests will fail with this configuration, which is expected -- we just want to prove that Cypress attempts to run the tests and doesn't quit instead
