### PR TITLE
Fix Type-to-Confirm edge case bug

### DIFF
--- a/packages/manager/src/components/TypeToConfirm/TypeToConfirm.tsx
+++ b/packages/manager/src/components/TypeToConfirm/TypeToConfirm.tsx
@@ -41,11 +41,18 @@ const TypeToConfirm: React.FC<Props> = (props) => {
 
   const classes = useStyles();
 
-  const disableOrEnable = visible ? 'disable' : 'enable';
+  /*
+    There was an edge case bug where, when preferences?.type_to_confirm was undefined,
+    the type-to-confirm input did not appear and the language in the instruction text
+    did not match. If 'visible' is not explicitly false, we treat it as true.
+  */
+
+  const showTypeToConfirmInput = visible !== false;
+  const disableOrEnable = showTypeToConfirmInput ? 'disable' : 'enable';
 
   return (
     <>
-      {visible ? (
+      {showTypeToConfirmInput ? (
         <>
           <Typography variant="h2">{title}</Typography>
           <Typography style={typographyStyle}>{confirmationText}</Typography>


### PR DESCRIPTION
## Description
Following up on https://github.com/linode/manager/pull/8513, this PR addresses an edge case bug revealed by some E2E test failures.

Essentially, when `preferences?.type_to_confirm` (the value that gets passed to the `visible` prop of the `TypeToConfirm` component) was `undefined`, the TTC input did not appear and the language in the instruction text did not match. By treating `visible` as true if it isn't explicitly false, we get the desired and expected behavior.

## How to test
Confirm that:

1. When TTC is enabled, you see the text field and `To disable type-to-confirm, go to the Type-to-Confirm section of My Settings.` below it
2. When TTC is disabled, you see only the text `To enable type-to-confirm, go to the Type-to-Confirm section of My Settings.`

in the modals for the Rebuild Linode, Resize Linode, Delete Kubernetes Cluster, Delete Bucket, Restore Database from Backup, and Delete Database flows. The Close Account flow should have the TTC regardless of user preference.

Also, delete the `"type_to_confirm"` setting from the preferenceEditor and see if the TTC behavior is as you'd expect in the modals.
