### PR TITLE
M3-5850: Add Cypress tests for two-factor authentication

### DIFF
--- a/packages/manager/cypress/integration/account/two-factor-auth.spec.ts
+++ b/packages/manager/cypress/integration/account/two-factor-auth.spec.ts
@@ -2,40 +2,156 @@
  * @file Integration tests for account two-factor authentication functionality.
  */
 
-import { randomNumber, randomLabel, randomString } from 'support/util/random';
+import { SecurityQuestionsData } from '@linode/api-v4/types';
+import {
+  profileFactory,
+  securityQuestionsFactory,
+} from 'src/factories/profile';
 import {
   mockGetProfile,
   interceptEnableTwoFactorAuth,
+  interceptDisableTwoFactorAuth,
+  mockConfirmTwoFactorAuth,
+  mockGetSecurityQuestions,
 } from 'support/intercepts/profile';
-import { profileFactory } from 'src/factories/profile';
 import { ui } from 'support/ui';
+import { randomNumber, randomLabel, randomString } from 'support/util/random';
 
+/**
+ * Returns a Cypress chainable for the "Two-Factor Authentication".
+ *
+ * @returns Cypress chainable for 2fa page section.
+ */
 const getTwoFactorSection = (): Cypress.Chainable => {
   return cy.contains('h3', 'Two-Factor Authentication (2FA)').parent();
 };
 
+/**
+ * Generates a random 2FA scratch code for mocking.
+ *
+ * @returns 2FA scratch code.
+ */
+const randomScratchCode = (): string => {
+  const randomScratchCodeOptions = {
+    lowercase: true,
+    uppercase: false,
+    symbols: false,
+    numbers: false,
+    spaces: false,
+  };
+
+  const segmentA = randomString(5, randomScratchCodeOptions);
+  const segmentB = randomString(5, randomScratchCodeOptions);
+  const segmentC = randomString(5, randomScratchCodeOptions);
+  const segmentD = randomString(4, randomScratchCodeOptions);
+
+  return `${segmentA}-${segmentB}-${segmentC}-${segmentD}`;
+};
+
+/**
+ * Generates a random 2FA token for mocking.
+ *
+ * @returns 2FA token.
+ */
+const randomToken = (): string => {
+  const randomTokenOptions = {
+    lowercase: false,
+    uppercase: false,
+    numbers: true,
+    symbols: false,
+    spaces: false,
+  };
+
+  return randomString(6, randomTokenOptions);
+};
+
+/**
+ * Returns unanswered security question data for mocking.
+ *
+ * @returns Unanswered security question data.
+ */
+const getUnansweredSecurityQuestions = (): SecurityQuestionsData => {
+  return securityQuestionsFactory.build();
+};
+
+/**
+ * Returns answered security question data for mocking.
+ *
+ * @returns Answered security question data.
+ */
+const getAnsweredSecurityQuestions = (): SecurityQuestionsData => {
+  const securityQuestions = securityQuestionsFactory.build();
+
+  // Pre-set answers for security questions.
+  const securityQuestionAnswers = [
+    randomString(10),
+    randomString(10),
+    randomString(10),
+  ];
+
+  securityQuestions.security_questions[0].response = securityQuestionAnswers[0];
+  securityQuestions.security_questions[1].response = securityQuestionAnswers[1];
+  securityQuestions.security_questions[2].response = securityQuestionAnswers[2];
+
+  return securityQuestions;
+};
+
+// User profile with 2FA disabled.
+const userProfile = profileFactory.build({
+  uid: randomNumber(1000, 9999),
+  username: randomLabel(),
+  verified_phone_number: undefined,
+  two_factor_auth: false,
+});
+
+// User profile with 2FA enabled.
+const userProfileTwoFactorEnabled = {
+  ...userProfile,
+  two_factor_auth: true,
+};
+
+// Error that appears when an invalid token is submitted when enabling 2FA.
 const invalidTokenError =
   'Invalid token. Two-factor auth not enabled. Please try again.';
 
+// Message that appears when the user has enabled 2FA.
+const enabledMessage = 'Two-factor authentication has been enabled.';
+
+// Message that appears when the user has disabled 2FA.
+const disabledMessage = 'Two-factor authentication has been disabled.';
+
+// Warning message that appears when the user is resetting 2FA.
+const resetWarningMessage =
+  'Confirming a new key will invalidate codes generated from any previous key.';
+
+// Warning message that appears when security questions are not answered.
+const securityQuestionsMessage =
+  'To use two-factor authentication you must set up your security questions listed below.';
+
 describe('Two-factor authentication', () => {
-  it('can enable two factor authentication', () => {
-    const invalidToken = randomString(6);
-    const validToken = randomString(6);
+  /*
+   * - Validates 2FA enable flow using mocked data.
+   * - Confirms UI flow when user enables 2FA and enters a valid token.
+   * - Confirms UI flow when user enters an invalid token when enabling 2FA.
+   * - Confirms that user is shown instructions to keep scratch code safe.
+   */
+  it('can enable two factor auth', () => {
+    const invalidToken = randomToken();
+    const validToken = randomToken();
+    const mockedScratchCode = randomScratchCode();
 
-    const userProfile = profileFactory.build({
-      uid: randomNumber(1000, 9999),
-      username: randomLabel(),
-      verified_phone_number: undefined,
-      two_factor_auth: false,
-    });
-
+    // Mock profile data to ensure that 2FA is disabled.
     mockGetProfile(userProfile).as('getProfile');
+    mockGetSecurityQuestions(getAnsweredSecurityQuestions()).as(
+      'getSecurityQuestions'
+    );
     cy.visitWithLogin('/profile/auth');
     cy.wait('@getProfile');
+    cy.wait('@getSecurityQuestions');
 
     getTwoFactorSection().within(() => {
       interceptEnableTwoFactorAuth().as('enableTwoFactorAuth');
-      // Confirm that 2FA is disabled, and click the toggle button.
+
       ui.toggle
         .find()
         .should('have.attr', 'data-qa-toggle', 'false')
@@ -43,10 +159,10 @@ describe('Two-factor authentication', () => {
         .click();
 
       cy.wait('@enableTwoFactorAuth');
-
       cy.get('[data-qa-qr-code]').should('be.visible');
 
-      cy.findByLabelText('Token').should('be.visible').type('123456');
+      // Type an invalid token first, confirm that error message appears as expected.
+      cy.findByLabelText('Token').should('be.visible').type(invalidToken);
 
       ui.button
         .findByTitle('Confirm Token')
@@ -55,6 +171,198 @@ describe('Two-factor authentication', () => {
         .click();
 
       cy.findByText(invalidTokenError).should('be.visible');
+
+      // Type a valid token, confirm that 2fa is enabled and scratch code is shown.
+      mockConfirmTwoFactorAuth(mockedScratchCode).as('confirmTwoFactorAuth');
+      mockGetProfile(userProfileTwoFactorEnabled).as(
+        'getProfileTwoFactorEnabled'
+      );
+      cy.findByLabelText('Token').should('be.visible').type(validToken);
+
+      ui.button
+        .findByTitle('Confirm Token')
+        .should('be.visible')
+        .should('be.enabled')
+        .click();
+
+      cy.wait('@confirmTwoFactorAuth');
+      cy.wait('@getProfileTwoFactorEnabled');
+    });
+
+    ui.dialog
+      .findByTitle('Scratch Code')
+      .should('be.visible')
+      .within(() => {
+        /*
+         * Confirm that the user is instructed:
+         *
+         * - To write down their scratch code.
+         * - That Cloud Manager will not show them their scratch code again.
+         */
+        const instructionNoteSecurely = 'make a note of it and keep it secure';
+        const instructionOneTimeAccess = 'this is the only time it will appear';
+
+        cy.findByText(instructionNoteSecurely, { exact: false }).should(
+          'be.visible'
+        );
+        cy.findByText(instructionOneTimeAccess, { exact: false }).should(
+          'be.visible'
+        );
+
+        // Confirm that scratch code is shown.
+        cy.findByText(mockedScratchCode).should('be.visible');
+
+        ui.buttonGroup
+          .findButtonByTitle('Got it')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    // Confirm that two-factor authentication is now enabled.
+    getTwoFactorSection().within(() => {
+      cy.findByText(enabledMessage).should('be.visible');
+      ui.toggle
+        .find()
+        .should('have.attr', 'data-qa-toggle', 'true')
+        .should('be.visible');
+    });
+  });
+
+  /**
+   * - Validates 2FA disable flow using mocked data.
+   */
+  it('can disable two factor auth', () => {
+    mockGetProfile(userProfileTwoFactorEnabled).as('getProfile');
+    mockGetSecurityQuestions(getAnsweredSecurityQuestions()).as(
+      'getSecurityQuestions'
+    );
+    cy.visitWithLogin('/profile/auth');
+    cy.wait('@getProfile');
+    cy.wait('@getSecurityQuestions');
+
+    interceptDisableTwoFactorAuth().as('disableTwoFactorAuth');
+    mockGetProfile(userProfile).as('getProfileTwoFactorDisabled');
+
+    // Confirm that 2FA is already enabled.
+    getTwoFactorSection().within(() => {
+      ui.toggle
+        .find()
+        .should('have.attr', 'data-qa-toggle', 'true')
+        .should('be.visible')
+        .click();
+    });
+
+    // Handle 2FA disable confirmation prompt.
+    ui.dialog.findByTitle('Disable Two-Factor Authentication').within(() => {
+      ui.buttonGroup
+        .findButtonByTitle('Disable Two-factor Authentication')
+        .click();
+    });
+
+    cy.wait('@disableTwoFactorAuth');
+    cy.wait('@getProfileTwoFactorDisabled');
+
+    // Confirm that 2FA is now disabled.
+    getTwoFactorSection().within(() => {
+      cy.findByText(disabledMessage).should('be.visible');
+      ui.toggle
+        .find()
+        .should('have.attr', 'data-qa-toggle', 'false')
+        .should('be.visible');
+    });
+  });
+
+  /**
+   * - Validates 2FA reset flow using mocked data.
+   * - Confirms that user is warned that resetting 2FA will invalidate 2FA codes.
+   */
+  it('can reset two factor auth', () => {
+    const validToken = randomToken();
+    const mockedScratchCode = randomScratchCode();
+
+    mockGetProfile(userProfileTwoFactorEnabled).as('getProfile');
+    mockGetSecurityQuestions(getAnsweredSecurityQuestions()).as(
+      'getSecurityQuestions'
+    );
+    cy.visitWithLogin('/profile/auth');
+    cy.wait('@getProfile');
+    cy.wait('@getSecurityQuestions');
+
+    getTwoFactorSection().within(() => {
+      interceptEnableTwoFactorAuth().as('resetTwoFactorAuth');
+
+      // Confirm that reset link is present, click on it.
+      cy.findByText('Reset two-factor authentication')
+        .should('be.visible')
+        .click();
+
+      cy.wait('@resetTwoFactorAuth');
+      cy.findByText(resetWarningMessage);
+
+      // Type a valid token, confirm that 2fa is enabled and scratch code is shown.
+      mockConfirmTwoFactorAuth(mockedScratchCode).as(
+        'confirmResetTwoFactorAuth'
+      );
+      mockGetProfile(userProfileTwoFactorEnabled).as(
+        'getProfileTwoFactorEnabled'
+      );
+      cy.findByLabelText('Token').should('be.visible').type(validToken);
+
+      ui.button
+        .findByTitle('Confirm Token')
+        .should('be.visible')
+        .should('be.enabled')
+        .click();
+    });
+
+    cy.wait('@confirmResetTwoFactorAuth');
+    cy.wait('@getProfileTwoFactorEnabled');
+
+    // Confirm that scratch code is shown, close dialog.
+    ui.dialog
+      .findByTitle('Scratch Code')
+      .should('be.visible')
+      .within(() => {
+        cy.findByText(mockedScratchCode).should('be.visible');
+
+        ui.buttonGroup
+          .findButtonByTitle('Got it')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    // Confirm that two-factor authentication is reset.
+    getTwoFactorSection().within(() => {
+      // The 2FA enable message appears after reset, not a reset-specific message.
+      cy.findByText(enabledMessage).should('be.visible');
+      ui.toggle
+        .find()
+        .should('have.attr', 'data-qa-toggle', 'true')
+        .should('be.visible');
+    });
+  });
+
+  /**
+   * - Confirms that user cannot enable 2FA when security questions are unanswered.
+   * - Confirms that warning message is shown explaining why 2FA cannot be enabled.
+   */
+  it('cannot enable two factor auth without security questions', () => {
+    mockGetProfile(userProfile).as('getProfile');
+    mockGetSecurityQuestions(getUnansweredSecurityQuestions()).as(
+      'getSecurityQuestions'
+    );
+    cy.visitWithLogin('/profile/auth');
+    cy.wait('@getProfile');
+    cy.wait('@getSecurityQuestions');
+
+    getTwoFactorSection().within(() => {
+      cy.findByText(securityQuestionsMessage).should('be.visible');
+
+      // Confirm that none of the usual 2FA enable/reset controls are present.
+      cy.contains('Enabled').should('not.exist');
+      cy.contains('Reset two-factor authentication').should('not.exist');
     });
   });
 });

--- a/packages/manager/cypress/integration/account/two-factor-auth.spec.ts
+++ b/packages/manager/cypress/integration/account/two-factor-auth.spec.ts
@@ -360,8 +360,9 @@ describe('Two-factor authentication', () => {
     getTwoFactorSection().within(() => {
       cy.findByText(securityQuestionsMessage).should('be.visible');
 
-      // Confirm that none of the usual 2FA enable/reset controls are present.
+      // Confirm that the usual 2FA enable/disable/reset controls are not present.
       cy.contains('Enabled').should('not.exist');
+      cy.contains('Disabled').should('not.exist');
       cy.contains('Reset two-factor authentication').should('not.exist');
     });
   });

--- a/packages/manager/cypress/integration/account/two-factor-auth.spec.ts
+++ b/packages/manager/cypress/integration/account/two-factor-auth.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * @file Integration tests for account two-factor authentication functionality.
+ */
+
+import { randomNumber, randomLabel, randomString } from 'support/util/random';
+import {
+  mockGetProfile,
+  interceptEnableTwoFactorAuth,
+} from 'support/intercepts/profile';
+import { profileFactory } from 'src/factories/profile';
+import { ui } from 'support/ui';
+
+const getTwoFactorSection = (): Cypress.Chainable => {
+  return cy.contains('h3', 'Two-Factor Authentication (2FA)').parent();
+};
+
+const invalidTokenError =
+  'Invalid token. Two-factor auth not enabled. Please try again.';
+
+describe('Two-factor authentication', () => {
+  it('can enable two factor authentication', () => {
+    const invalidToken = randomString(6);
+    const validToken = randomString(6);
+
+    const userProfile = profileFactory.build({
+      uid: randomNumber(1000, 9999),
+      username: randomLabel(),
+      verified_phone_number: undefined,
+      two_factor_auth: false,
+    });
+
+    mockGetProfile(userProfile).as('getProfile');
+    cy.visitWithLogin('/profile/auth');
+    cy.wait('@getProfile');
+
+    getTwoFactorSection().within(() => {
+      interceptEnableTwoFactorAuth().as('enableTwoFactorAuth');
+      // Confirm that 2FA is disabled, and click the toggle button.
+      ui.toggle
+        .find()
+        .should('have.attr', 'data-qa-toggle', 'false')
+        .should('be.visible')
+        .click();
+
+      cy.wait('@enableTwoFactorAuth');
+
+      cy.get('[data-qa-qr-code]').should('be.visible');
+
+      cy.findByLabelText('Token').should('be.visible').type('123456');
+
+      ui.button
+        .findByTitle('Confirm Token')
+        .should('be.visible')
+        .should('be.enabled')
+        .click();
+
+      cy.findByText(invalidTokenError).should('be.visible');
+    });
+  });
+});

--- a/packages/manager/cypress/support/intercepts/profile.ts
+++ b/packages/manager/cypress/support/intercepts/profile.ts
@@ -3,11 +3,11 @@
  */
 
 import { makeErrorResponse } from 'support/util/errors';
-import {
+import type {
   Profile,
   SecurityQuestionsData,
   SecurityQuestionsPayload,
-} from '@linode/api-v4/lib/profile/types';
+} from '@linode/api-v4/types';
 
 /**
  * Intercepts GET request to fetch profile and mocks response.
@@ -87,4 +87,8 @@ export const mockUpdateSecurityQuestions = (
     '*/profile/security-questions',
     securityQuestionsPayload
   );
+};
+
+export const interceptEnableTwoFactorAuth = (): Cypress.Chainable<null> => {
+  return cy.intercept('POST', '*/profile/tfa-enable');
 };

--- a/packages/manager/cypress/support/intercepts/profile.ts
+++ b/packages/manager/cypress/support/intercepts/profile.ts
@@ -90,21 +90,30 @@ export const mockUpdateSecurityQuestions = (
 };
 
 /**
- * Intercepts POST request to enable two factor authentication.
+ * Intercepts POST request to enable 2FA and mocks the response.
+ *
+ * @param secretString - Secret 2FA key to include in mocked response.
  *
  * @returns Cypress chainable.
  */
-export const interceptEnableTwoFactorAuth = (): Cypress.Chainable<null> => {
-  return cy.intercept('POST', '*/profile/tfa-enable');
+export const mockEnableTwoFactorAuth = (
+  secretString: string
+): Cypress.Chainable<null> => {
+  // TODO Create an expiration date based on the current time.
+  const expiry = '2025-05-01T03:59:59';
+  return cy.intercept('POST', '*/profile/tfa-enable', {
+    secret: secretString,
+    expiry,
+  });
 };
 
 /**
- * Intercepts POST request to disable two factor authentication.
+ * Intercepts POST request to disable two factor authentication and mocks response.
  *
  * @returns Cypress chainable.
  */
-export const interceptDisableTwoFactorAuth = (): Cypress.Chainable<null> => {
-  return cy.intercept('POST', '*/profile/tfa-disable');
+export const mockDisableTwoFactorAuth = (): Cypress.Chainable<null> => {
+  return cy.intercept('POST', '*/profile/tfa-disable', {});
 };
 
 /**

--- a/packages/manager/cypress/support/intercepts/profile.ts
+++ b/packages/manager/cypress/support/intercepts/profile.ts
@@ -89,6 +89,35 @@ export const mockUpdateSecurityQuestions = (
   );
 };
 
+/**
+ * Intercepts POST request to enable two factor authentication.
+ *
+ * @returns Cypress chainable.
+ */
 export const interceptEnableTwoFactorAuth = (): Cypress.Chainable<null> => {
   return cy.intercept('POST', '*/profile/tfa-enable');
+};
+
+/**
+ * Intercepts POST request to disable two factor authentication.
+ *
+ * @returns Cypress chainable.
+ */
+export const interceptDisableTwoFactorAuth = (): Cypress.Chainable<null> => {
+  return cy.intercept('POST', '*/profile/tfa-disable');
+};
+
+/**
+ * Intercepts POST request to confirm two factor authentication and mocks response.
+ *
+ * @param scratchCode - Mocked 2FA scratch code.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockConfirmTwoFactorAuth = (
+  scratchCode: string
+): Cypress.Chainable<null> => {
+  return cy.intercept('POST', '*/profile/tfa-enable-confirm', {
+    scratch: scratchCode,
+  });
 };

--- a/packages/manager/cypress/support/ui/index.ts
+++ b/packages/manager/cypress/support/ui/index.ts
@@ -3,6 +3,7 @@ import * as dialog from './dialog';
 import * as drawer from './drawer';
 import * as entityHeader from './entity-header';
 import * as tabList from './tab-list';
+import * as toggle from './toggle';
 
 export const ui = {
   ...buttons,
@@ -10,4 +11,5 @@ export const ui = {
   ...drawer,
   ...entityHeader,
   ...tabList,
+  ...toggle,
 };

--- a/packages/manager/cypress/support/ui/toggle.ts
+++ b/packages/manager/cypress/support/ui/toggle.ts
@@ -1,0 +1,22 @@
+/**
+ * Toggle button UI element.
+ */
+export const toggle = {
+  /**
+   * Find a toggle and returns the Cypress chainable.
+   *
+   * @returns Cypress chainable.
+   */
+  find: (): Cypress.Chainable => {
+    return cy.get('[data-qa-toggle]');
+  },
+
+  /**
+   * Finds a toggle by the given data attribute and returns the Cypress chainable.
+   *
+   * @returns Cypress chainable.
+   */
+  findByDataAttribute: (attributeName: string): Cypress.Chainable => {
+    return cy.get(`[${attributeName}]`);
+  },
+};

--- a/packages/manager/cypress/tsconfig.json
+++ b/packages/manager/cypress/tsconfig.json
@@ -11,8 +11,12 @@
     "paths": {
       "@src/*": ["src/*"],
       "support/*": ["cypress/support/*"],
-      "@linode/api-v4/*": ["../api-v4/lib/index.js"],
-      "@linode/validation/*": ["../validation/lib/index.js"],
+      "@linode/api-v4/lib": ["../api-v4/lib/index.js"],
+      "@linode/api-v4/lib/*": ["../api-v4/lib/index.js"],
+      "@linode/api-v4/types": ["../api-v4/lib/index.d.ts"],
+      "@linode/validation/lib": ["../validation/lib/index.js"],
+      "@linode/validation/lib/*": ["../validation/lib/index.js"],
+      "@linode/validation/types": ["../validation/lib/index.d.ts"]
     },
     "types": ["cypress", "cypress-file-upload", "@testing-library/cypress", "cypress-real-events"]
   },


### PR DESCRIPTION
## Description

**What does this PR do?**
Adds Cypress integration tests for 2FA. Confirms UI flows for enabling, disabling, and resetting 2FA, and confirms that 2FA cannot be enabled when security questions are not answered.

## How to test

**How do I run relevant tests?**
`yarn up`, and then:

```
yarn cy:run -s "cypress/integration/account/two-factor-auth.spec.ts"
```

Or, if you want to run them interactively:

```
yarn cy:debug
```
And search for `two-factor-auth.spec.ts`.
