### PR TITLE
M3-5927: Allow Deletion of Private IPv4 Addresses

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingActionMenu.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingActionMenu.tsx
@@ -42,7 +42,7 @@ export const LinodeNetworkingActionMenu: React.FC<CombinedProps> = (props) => {
     ipType !== 'IPv4 – Reserved (public)' &&
     ipType !== 'IPv4 – Reserved (private)';
 
-  const deletableIPTypes = ['IPv4 – Public', 'IPv6 – Range'];
+  const deletableIPTypes = ['IPv4 – Public', 'IPv4 – Private', 'IPv6 – Range'];
 
   // if we have a 116 we don't want to give the option to remove it
   const is116Range = ipAddress?.prefix === 116;


### PR DESCRIPTION
## Description 📝

- Show a `Delete` button for Private IPv4 addresses on a Linode

### Before 

![Screen Shot 2022-09-01 at 1 47 19 PM](https://user-images.githubusercontent.com/6440455/187979530-7af12472-d89a-46be-8000-68ca5a8107b5.jpg)

### After

![Screen Shot 2022-09-01 at 1 47 44 PM](https://user-images.githubusercontent.com/6440455/187979557-dc2d30a7-2ab1-4b05-92a0-fe172ee8d290.jpg)

## How to test 🧪

- Spin up a Linode in dev
- Add a Private IP address
- Verify that you see a `Delete` Button and that you can successfully delete the private IPv4 address