### PR TITLE
M3-5843: Allow each state to have their own date for a Tax Collection Banner

### DIFF
--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -8,10 +8,15 @@ interface TaxBanner {
   linode_tax_id?: string;
 }
 
+interface TaxCollectionRegion {
+  name: string;
+  date?: string;
+}
+
 interface TaxCollectionBanner {
   date: string;
   action?: boolean;
-  regions?: string[];
+  regions?: TaxCollectionRegion[];
 }
 
 type OneClickApp = Record<string, string>;

--- a/packages/manager/src/features/GlobalNotifications/GlobalNotifications.tsx
+++ b/packages/manager/src/features/GlobalNotifications/GlobalNotifications.tsx
@@ -40,9 +40,9 @@ const GlobalNotifications: React.FC<{}> = () => {
         <APIMaintenanceBanner suppliedMaintenances={suppliedMaintenances} />
       ) : null}
       {flags.taxCollectionBanner &&
-      Object.keys(flags.taxCollectionBanner).length > 0 ? null : (
+      Object.keys(flags.taxCollectionBanner).length > 0 ? (
         <TaxCollectionBanner />
-      )}
+      ) : null}
     </>
   );
 };

--- a/packages/manager/src/features/GlobalNotifications/GlobalNotifications.tsx
+++ b/packages/manager/src/features/GlobalNotifications/GlobalNotifications.tsx
@@ -40,9 +40,9 @@ const GlobalNotifications: React.FC<{}> = () => {
         <APIMaintenanceBanner suppliedMaintenances={suppliedMaintenances} />
       ) : null}
       {flags.taxCollectionBanner &&
-      Object.keys(flags.taxCollectionBanner).length > 0 ? (
+      Object.keys(flags.taxCollectionBanner).length > 0 ? null : (
         <TaxCollectionBanner />
-      ) : null}
+      )}
     </>
   );
 };

--- a/packages/manager/src/features/GlobalNotifications/TaxCollectionBanner.tsx
+++ b/packages/manager/src/features/GlobalNotifications/TaxCollectionBanner.tsx
@@ -7,7 +7,7 @@ import Typography from 'src/components/core/Typography';
 import { useDismissibleBanner } from 'src/components/DismissibleBanner/DismissibleBanner';
 import Link from 'src/components/Link';
 import Notice from 'src/components/Notice';
-// import { useFlags } from 'src/hooks/useFlags';
+import { useFlags } from 'src/hooks/useFlags';
 import { useAccount } from 'src/queries/account';
 import { DateTime } from 'luxon';
 
@@ -22,20 +22,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 const TaxCollectionBanner: React.FC<{}> = () => {
   const classes = useStyles();
   const history = useHistory();
-  const flags = {
-    taxCollectionBanner: {
-      date: 'October 22 2022',
-      action: false,
-      regions: [
-        { name: 'PA', date: 'July 27 2023' },
-        { name: 'CA', date: 'November 27 2022' },
-        { name: 'AZ' },
-        { name: 'VT' },
-      ],
-    },
-  };
-
-  // useFlags();
+  const flags = useFlags();
 
   const { data: account } = useAccount();
   const { hasDismissedBanner, handleDismiss } = useDismissibleBanner(
@@ -45,13 +32,18 @@ const TaxCollectionBanner: React.FC<{}> = () => {
   const countryDateString = flags.taxCollectionBanner?.date ?? '';
   const bannerHasAction = flags.taxCollectionBanner?.action ?? false;
   const bannerRegions =
-    flags.taxCollectionBanner?.regions.map((region) => region.name) ?? [];
+    flags.taxCollectionBanner?.regions?.map((region) => {
+      if (typeof region === 'string') {
+        return region;
+      }
+      return region.name;
+    }) ?? [];
 
   if (!account || hasDismissedBanner || !countryDateString) {
     return null;
   }
 
-  const regionDateString = flags.taxCollectionBanner?.regions.find(
+  const regionDateString = flags.taxCollectionBanner?.regions?.find(
     (region) => region.name === account.state
   )?.date;
 


### PR DESCRIPTION
## Description

Changes the format we expect from the `taxCollectionBanner` flag to allow regions within the same country to have different dates. Also only displays the banner for up to 5 weeks after the date specified in the flag data. The new data shape keeps the top level `date` field. This is now used as the default date for all regions in the list. The region list has been changed from a list of strings to a list of objects. The objects have two properties `name` and `date`. The `name` field is the string that we use to denote the region. The `date` field is used to specify a date that is different from the default one specified for the country. If a region has a date specified that will always override the country level one.  

## How to test

Check ticket for testing procedure