### PR TITLE
M3-5787: Improve Timezone Offsets by Pulling Them From `Luxon`

### DIFF
--- a/packages/manager/src/features/Profile/DisplaySettings/DisplaySettings.tsx
+++ b/packages/manager/src/features/Profile/DisplaySettings/DisplaySettings.tsx
@@ -20,7 +20,6 @@ import { ApplicationState } from 'src/store';
 import withNotifications, {
   WithNotifications,
 } from 'src/store/notification/notification.containers';
-import getUserTimezone from 'src/utilities/getUserTimezone';
 import { v4 } from 'uuid';
 import TimezoneForm from './TimezoneForm';
 
@@ -89,7 +88,6 @@ export const DisplaySettings: React.FC<WithNotifications> = (props) => {
   const noGravatar =
     gravatarLoading || gravatarError || gravatarURL === 'not found';
 
-  const timezone = getUserTimezone();
   const loggedInAsCustomer = useSelector(
     (state: ApplicationState) => state.authentication.loggedInAsCustomer
   );
@@ -107,11 +105,9 @@ export const DisplaySettings: React.FC<WithNotifications> = (props) => {
   // Used as React keys to force-rerender forms.
   const [emailResetToken, setEmailResetToken] = React.useState(v4());
   const [usernameResetToken, setUsernameResetToken] = React.useState(v4());
-  const [timezoneResetToken, setTimezoneResetToken] = React.useState(v4());
 
   const updateUsername = (newUsername: string) => {
     setEmailResetToken(v4());
-    setTimezoneResetToken(v4());
     // Default to empty string... but I don't believe this is possible.
     return updateUser(profile?.username ?? '', {
       username: newUsername,
@@ -120,14 +116,7 @@ export const DisplaySettings: React.FC<WithNotifications> = (props) => {
 
   const updateEmail = (newEmail: string) => {
     setUsernameResetToken(v4());
-    setTimezoneResetToken(v4());
     return updateProfile({ email: newEmail });
-  };
-
-  const updateTimezone = (newTimezone: string) => {
-    setUsernameResetToken(v4());
-    setEmailResetToken(v4());
-    return updateProfile({ timezone: newTimezone });
   };
 
   const helpIconText = (
@@ -218,12 +207,7 @@ export const DisplaySettings: React.FC<WithNotifications> = (props) => {
         type="email"
       />
       <Divider spacingTop={24} spacingBottom={16} />
-      <TimezoneForm
-        key={timezoneResetToken}
-        timezone={timezone}
-        loggedInAsCustomer={loggedInAsCustomer}
-        updateTimezone={updateTimezone}
-      />
+      <TimezoneForm loggedInAsCustomer={loggedInAsCustomer} />
     </Paper>
   );
 };

--- a/packages/manager/src/features/Profile/DisplaySettings/TimezoneForm.tsx
+++ b/packages/manager/src/features/Profile/DisplaySettings/TimezoneForm.tsx
@@ -41,8 +41,7 @@ interface Timezone {
   offset: number;
 }
 
-export const formatOffset = ({ label, name }: Timezone) => {
-  const offset = DateTime.now().setZone(name).offset;
+export const formatOffset = ({ label, offset }: Timezone) => {
   const minutes = (Math.abs(offset) % 60).toLocaleString(undefined, {
     minimumIntegerDigits: 2,
     useGrouping: false,
@@ -54,10 +53,13 @@ export const formatOffset = ({ label, name }: Timezone) => {
 };
 
 const renderTimeZonesList = (): Item[] => {
-  return timezones.map((tz: Timezone) => {
-    const label = formatOffset(tz);
-    return { label, value: tz.name };
-  });
+  return timezones
+    .map((tz) => ({ ...tz, offset: DateTime.now().setZone(tz.name).offset }))
+    .sort((a, b) => a.offset - b.offset)
+    .map((tz: Timezone) => {
+      const label = formatOffset(tz);
+      return { label, value: tz.name };
+    });
 };
 
 const timezoneList = renderTimeZonesList();

--- a/packages/manager/src/features/Profile/DisplaySettings/TimezoneForm.tsx
+++ b/packages/manager/src/features/Profile/DisplaySettings/TimezoneForm.tsx
@@ -1,59 +1,38 @@
-import { Profile } from '@linode/api-v4/lib/profile';
-import { APIError } from '@linode/api-v4/lib/types';
-import { lensPath, pathOr, set } from 'ramda';
 import * as React from 'react';
 import timezones from 'src/assets/timezones/timezones';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import Box from 'src/components/core/Box';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles,
-} from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
+import CircleProgress from 'src/components/CircleProgress';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
-import Notice from 'src/components/Notice';
-import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
-import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
+import { useSnackbar } from 'notistack';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import { useMutateProfile, useProfile } from 'src/queries/profile';
+import { DateTime } from 'luxon';
 
-type ClassNames = 'root' | 'copy' | 'button' | 'loggedInAsCustomerNotice';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {
-      [theme.breakpoints.down('sm')]: {
-        flexDirection: 'column',
-      },
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    [theme.breakpoints.down('sm')]: {
+      flexDirection: 'column',
     },
-    button: {
-      minWidth: 180,
-      [theme.breakpoints.up('md')]: {
-        marginTop: 16,
-      },
+  },
+  button: {
+    minWidth: 180,
+    [theme.breakpoints.up('md')]: {
+      marginTop: 16,
     },
-    loggedInAsCustomerNotice: {
-      backgroundColor: 'pink',
-      padding: 16,
-      marginBottom: 8,
-      textAlign: 'center',
-    },
-  });
+  },
+  loggedInAsCustomerNotice: {
+    backgroundColor: 'pink',
+    padding: 16,
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+}));
 
 interface Props {
-  timezone: string;
   loggedInAsCustomer: boolean;
-  updateTimezone: (newTimezone: string) => Promise<Profile>;
-  errors?: APIError[];
-}
-
-interface State {
-  updatedTimezone: Item | null;
-  inputValue: string;
-  submitting: boolean;
-  success?: string;
-  errors?: APIError[];
 }
 
 interface Timezone {
@@ -62,159 +41,104 @@ interface Timezone {
   offset: number;
 }
 
-type CombinedProps = Props & WithStyles<ClassNames>;
-
-export const formatOffset = (offset: number, label: string) => {
-  const remainder = Math.abs(offset) % 1;
-  // Translate a decimal to minutes.
-  // Example: (0.75 * 100) / (100 / 60) = 0.45
-  const minutes = (remainder * 100) / (100 / 60);
-
-  const formattedMinutes = String(minutes).padStart(2, '0');
+export const formatOffset = ({ label, name }: Timezone) => {
+  const offset = DateTime.now().setZone(name).offset;
+  const minutes = (Math.abs(offset) % 60).toLocaleString(undefined, {
+    minimumIntegerDigits: 2,
+    useGrouping: false,
+  });
+  const hours = Math.floor(Math.abs(offset) / 60);
   const isPositive = Math.abs(offset) === offset ? '+' : '-';
-  const rounded = Math.floor(Math.abs(offset));
-  return `\(GMT ${isPositive}${rounded}:${formattedMinutes}\) ${label}`;
+
+  return `\(GMT ${isPositive}${hours}:${minutes}\) ${label}`;
 };
 
 const renderTimeZonesList = (): Item[] => {
   return timezones.map((tz: Timezone) => {
-    const label = formatOffset(tz.offset, tz.label);
+    const label = formatOffset(tz);
     return { label, value: tz.name };
   });
 };
 
 const timezoneList = renderTimeZonesList();
 
-export class TimezoneForm extends React.Component<CombinedProps, State> {
-  state: State = {
-    updatedTimezone: null,
-    inputValue: '',
-    submitting: false,
-    success: undefined,
-    errors: this.props.errors,
+export const TimezoneForm = (props: Props) => {
+  const classes = useStyles();
+  const { loggedInAsCustomer } = props;
+  const { enqueueSnackbar } = useSnackbar();
+  const { data: profile } = useProfile();
+  const { mutateAsync: updateProfile, isLoading, error } = useMutateProfile();
+  const [value, setValue] = React.useState<Item | null>(null);
+
+  const timezone = profile?.timezone ?? '';
+
+  const handleTimezoneChange = (timezone: Item) => {
+    setValue(timezone);
   };
 
-  getTimezone = (timezoneValue: string) => {
-    const idx = timezoneList.findIndex((el) => {
-      return el.value === timezoneValue;
-    });
-    return timezoneList[idx];
-  };
-
-  handleTimezoneChange = (timezone: Item) => {
-    if (timezone) {
-      this.setState(set(lensPath(['updatedTimezone']), timezone));
-    } else {
-      this.setState({ success: undefined });
-    }
-  };
-
-  onSubmit = () => {
-    const { updatedTimezone } = this.state;
-    if (!updatedTimezone) {
+  const onSubmit = () => {
+    if (value === null) {
       return;
     }
-    this.setState({ submitting: true, success: undefined });
 
-    this.props
-      .updateTimezone(updatedTimezone.value as string)
-      .then(() => {
-        this.setState({
-          submitting: false,
-          success: 'Account timezone updated.',
-          updatedTimezone: null,
-          errors: undefined,
-        });
-      })
-      .catch((e) => {
-        this.setState(
-          {
-            submitting: false,
-            success: undefined,
-            errors: e,
-          },
-          () => {
-            scrollErrorIntoView();
-          }
-        );
-      });
+    updateProfile({ timezone: String(value.value) }).then(() => {
+      enqueueSnackbar('Successfully update timezone', { variant: 'success' });
+    });
   };
 
-  render() {
-    const { classes, loggedInAsCustomer, timezone } = this.props;
-    const { errors, submitting, success, updatedTimezone } = this.state;
-    const timezoneDisplay = pathOr(
-      timezone,
-      ['label'],
-      this.getTimezone(timezone)
-    );
+  const defaultTimeZone = timezoneList.find((eachZone) => {
+    return eachZone.value === timezone;
+  });
 
-    const hasErrorFor = getAPIErrorFor(
-      {
-        timezone: 'timezone',
-      },
-      errors
-    );
-    const generalError = hasErrorFor('none');
-    const timezoneError = hasErrorFor('timezone');
+  const disabled = value === null || defaultTimeZone?.value === value?.value;
 
-    const defaultTimeZone = timezoneList.find((eachZone) => {
-      return eachZone.label === timezoneDisplay;
-    });
-
-    return (
-      <>
-        {loggedInAsCustomer ? (
-          <div
-            className={classes.loggedInAsCustomerNotice}
-            data-qa-admin-notice
-          >
-            <Typography variant="h2">
-              While you are logged in as a customer, all times, dates, and
-              graphs will be displayed in your browser&rsquo;s timezone (
-              {timezone}).
-            </Typography>
-          </div>
-        ) : null}
-        <Box
-          display="flex"
-          justifyContent="space-between"
-          className={classes.root}
-        >
-          <Select
-            options={timezoneList}
-            placeholder={'Choose a Timezone'}
-            errorText={timezoneError}
-            onChange={this.handleTimezoneChange}
-            data-qa-tz-select
-            defaultValue={defaultTimeZone}
-            isClearable={false}
-            label="Timezone"
-          />
-          <ActionsPanel>
-            <Button
-              className={classes.button}
-              buttonType="primary"
-              onClick={this.onSubmit}
-              disabled={updatedTimezone === null}
-              loading={submitting}
-              data-qa-tz-submit
-            >
-              Update Timezone
-            </Button>
-          </ActionsPanel>
-        </Box>
-        {success ? (
-          <Notice success text={success} spacingTop={8} spacingBottom={8} />
-        ) : null}
-        {generalError ? (
-          <Notice error text={generalError} spacingTop={8} spacingBottom={8} />
-        ) : null}
-      </>
-    );
+  if (!profile) {
+    return <CircleProgress />;
   }
-}
 
-const styled = withStyles(styles);
+  return (
+    <>
+      {loggedInAsCustomer ? (
+        <div
+          className={classes.loggedInAsCustomerNotice}
+          data-testid="admin-notice"
+        >
+          <Typography variant="h2">
+            While you are logged in as a customer, all times, dates, and graphs
+            will be displayed in your browser&rsquo;s timezone ({timezone}).
+          </Typography>
+        </div>
+      ) : null}
+      <Box
+        display="flex"
+        justifyContent="space-between"
+        className={classes.root}
+      >
+        <Select
+          options={timezoneList}
+          placeholder={'Choose a Timezone'}
+          errorText={error?.[0].reason}
+          onChange={handleTimezoneChange}
+          data-qa-tz-select
+          defaultValue={defaultTimeZone}
+          isClearable={false}
+          label="Timezone"
+        />
+        <ActionsPanel>
+          <Button
+            className={classes.button}
+            buttonType="primary"
+            onClick={onSubmit}
+            disabled={disabled}
+            loading={isLoading}
+            data-qa-tz-submit
+          >
+            Update Timezone
+          </Button>
+        </ActionsPanel>
+      </Box>
+    </>
+  );
+};
 
-export default styled(TimezoneForm);
+export default TimezoneForm;


### PR DESCRIPTION
## Description 📝

- Pulls timezone offsets from [Luxon](https://github.com/moment/luxon/) so that they are more accurate
  - Previously, we pulled them from the static `timezones.ts` file, which did not incorporate **Daylight Savings Time**
- Rewrites `TimezoneForm.tsx` to be a FC and use hooks
- Rewrites `TimezoneForm.test.tsx` to use React Testing library and newer patterns

## Preview 📷

### Before

> **Note**: Notice how the offset for EST is -5

![Screen Shot 2022-09-06 at 1 50 22 PM](https://user-images.githubusercontent.com/6440455/188704926-a26a964b-f690-44ec-a878-2a4e8b7ec1a6.jpg)

### After

> **Note**: Notice how the offset for EST is -4. This is because it is taking into account the fact we are current in daylight savings time. If you do some Googling, you will see that this is currently the correct offset

![Screen Shot 2022-09-06 at 1 49 59 PM](https://user-images.githubusercontent.com/6440455/188704845-514a0c60-df6f-4d1a-aadb-697ff60d90e2.jpg)
 
## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**

- Go to `http://localhost:3000/profile/display` 
- Check functionality of the timezone input for general use
- Look at the offsets in the dropdown and compare them to what other sources say online about what the current offset is
- It may be useful to compare this PR to production to see how the offsets are different. You should see different offset values for many places

**How do I run relevant unit tests?**

`yarn test packages/manager/src/features/Profile/DisplaySettings/TimezoneForm.test.tsx`
