### PR TITLE
M3-5931: Fix database maintenance window mapping and database_update notification message

### DIFF
--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -60,6 +60,31 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
   credit_card_updated: {
     notification: (e) => `Credit card information has been updated.`,
   },
+  database_create: {
+    scheduled: (e) => `Database ${e.entity!.label} is scheduled for creation.`,
+    notification: (e) =>
+      `Database ${e.entity!.label} is scheduled for creation.`,
+    started: (e) => `Database ${e.entity!.label} is being created.`,
+    failed: (e) => `Database ${e.entity!.label} could not be created.`,
+    finished: (e) => `Database ${e.entity!.label} has been created.`,
+  },
+  database_delete: {
+    notification: (e) => `Database ${e.entity!.label} has been deleted.`,
+  },
+  database_update: {
+    notification: (e) => `Database ${e.entity!.label} has been updated.`,
+  },
+  database_update_failed: {
+    notification: (e) => `Database ${e.entity!.label} failed to update.`,
+  },
+  database_backup_restore: {
+    notification: (e) =>
+      `Database ${e.entity!.label} has been restored from a backup.`,
+  },
+  database_credentials_reset: {
+    notification: (e) =>
+      `Database ${e.entity!.label}'s credentials have been reset.`,
+  },
   disk_create: {
     scheduled: (e) =>
       `${safeSecondaryEntityLabel(
@@ -698,31 +723,6 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
   },
   user_update: {
     notification: (e) => `User ${e.entity!.label} has been updated.`,
-  },
-  database_create: {
-    scheduled: (e) => `Database ${e.entity!.label} is scheduled for creation.`,
-    notification: (e) =>
-      `Database ${e.entity!.label} is scheduled for creation.`,
-    started: (e) => `Database ${e.entity!.label} is being created.`,
-    failed: (e) => `Database ${e.entity!.label} could not be created.`,
-    finished: (e) => `Database ${e.entity!.label} has been created.`,
-  },
-  database_delete: {
-    notification: (e) => `Database ${e.entity!.label} has been deleted.`,
-  },
-  database_update: {
-    notification: (e) => `Database ${e.entity!.label} has been updated.`,
-  },
-  database_update_failed: {
-    notification: (e) => `Database ${e.entity!.label} failed to update.`,
-  },
-  database_backup_restore: {
-    notification: (e) =>
-      `Database ${e.entity!.label} has been restored from a backup.`,
-  },
-  database_credentials_reset: {
-    notification: (e) =>
-      `Database ${e.entity!.label}'s credentials have been reset.`,
   },
 };
 

--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -72,7 +72,7 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
     notification: (e) => `Database ${e.entity!.label} has been deleted.`,
   },
   database_update: {
-    notification: (e) => `Database ${e.entity!.label} has been updated.`,
+    finished: (e) => `Database ${e.entity!.label} has been updated.`,
   },
   database_update_failed: {
     notification: (e) => `Database ${e.entity!.label} failed to update.`,

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/MaintenanceWindow.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/MaintenanceWindow.tsx
@@ -372,13 +372,13 @@ const maintenanceFrequencyMap = [
 ];
 
 const daySelectionMap = [
-  { label: 'Sunday', value: 1 },
-  { label: 'Monday', value: 2 },
-  { label: 'Tuesday', value: 3 },
-  { label: 'Wednesday', value: 4 },
-  { label: 'Thursday', value: 5 },
-  { label: 'Friday', value: 6 },
-  { label: 'Saturday', value: 7 },
+  { label: 'Monday', value: 1 },
+  { label: 'Tuesday', value: 2 },
+  { label: 'Wednesday', value: 3 },
+  { label: 'Thursday', value: 4 },
+  { label: 'Friday', value: 5 },
+  { label: 'Saturday', value: 6 },
+  { label: 'Sunday', value: 7 },
 ];
 
 const hourSelectionMap = [


### PR DESCRIPTION
## Description

- Adjust day mapping so that Monday through Sunday is 1 through 7, respectively

- Change `status` field in `eventMessageCreators` from `notification` to `finished` for `database_update` notification, per confirmation with the API team. This ensures the correctly-worded notification is displayed in the drawer and on the Events landing page.
- Move database-related events in `eventMessageCreators` so that the list is (more) alphabetical order
