### PR TITLE
M3-4882: Reduce unnecessary re-renders in LinodesLanding

### DIFF
--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
@@ -55,11 +55,6 @@ interface Props {
   type?: ExtendedType;
   tags: string[];
   mostRecentBackup: string | null;
-  openTagDrawer: (
-    linodeID: number,
-    linodeLabel: string,
-    tags: string[]
-  ) => void;
   openDialog: (
     type: DialogType,
     linodeID: number,

--- a/packages/manager/src/features/linodes/LinodesLanding/ListView.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/ListView.tsx
@@ -3,11 +3,9 @@ import { Config } from '@linode/api-v4/lib/linodes';
 import * as React from 'react';
 import { PaginationProps } from 'src/components/Paginate';
 import TableRowEmptyState from 'src/components/TableRowEmptyState';
-import TagDrawer, { TagDrawerProps } from 'src/components/TagCell/TagDrawer';
 import { Action } from 'src/features/linodes/PowerActionsDialogOrDrawer';
 import { DialogType } from 'src/features/linodes/types';
 import { notificationContext as _notificationContext } from 'src/features/NotificationCenter/NotificationContext';
-import useLinodeActions from 'src/hooks/useLinodeActions';
 import { LinodeWithMaintenanceAndDisplayStatus } from 'src/store/linodes/types';
 import { ExtendedType } from 'src/store/linodeType/linodeType.reducer';
 import formatDate from 'src/utilities/formatDate';
@@ -35,47 +33,8 @@ type CombinedProps = Props & PaginationProps;
 
 export const ListView: React.FC<CombinedProps> = (props) => {
   const { data, openDialog, openPowerActionDialog } = props;
-  const [tagDrawer, setTagDrawer] = React.useState<TagDrawerProps>({
-    open: false,
-    tags: [],
-    label: '',
-    entityID: 0,
-  });
-
-  const { updateLinode } = useLinodeActions();
 
   const notificationContext = React.useContext(_notificationContext);
-
-  const closeTagDrawer = () => {
-    setTagDrawer({ ...tagDrawer, open: false });
-  };
-
-  const openTagDrawer = (
-    linodeID: number,
-    linodeLabel: string,
-    tags: string[]
-  ) => {
-    setTagDrawer({
-      open: true,
-      label: linodeLabel,
-      tags,
-      entityID: linodeID,
-    });
-  };
-
-  const addTag = (linodeID: number, newTag: string) => {
-    const _tags = [...tagDrawer.tags, newTag];
-    return updateLinode({ linodeId: linodeID, tags: _tags }).then((_) => {
-      setTagDrawer({ ...tagDrawer, tags: _tags });
-    });
-  };
-
-  const deleteTag = (linodeId: number, tagToDelete: string) => {
-    const _tags = tagDrawer.tags.filter((thisTag) => thisTag !== tagToDelete);
-    return updateLinode({ linodeId, tags: _tags }).then((_) => {
-      setTagDrawer({ ...tagDrawer, tags: _tags });
-    });
-  };
 
   // This won't happen in the normal Linodes Landing context (a custom empty
   // state is shown higher up in the tree). This is specifically for the case of
@@ -109,20 +68,11 @@ export const ListView: React.FC<CombinedProps> = (props) => {
           type={linode._type}
           image={linode.image}
           key={`linode-row-${idx}`}
-          openTagDrawer={openTagDrawer}
           openDialog={openDialog}
           openNotificationMenu={notificationContext.openMenu}
           openPowerActionDialog={openPowerActionDialog}
         />
       ))}
-      <TagDrawer
-        entityLabel={tagDrawer.label}
-        open={tagDrawer.open}
-        tags={tagDrawer.tags}
-        addTag={(newTag: string) => addTag(tagDrawer.entityID, newTag)}
-        deleteTag={(tag: string) => deleteTag(tagDrawer.entityID, tag)}
-        onClose={closeTagDrawer}
-      />
     </>
   );
 };


### PR DESCRIPTION
## Description
This is a first stab at reducing unnecessary re-renders in the LinodesLanding page. Through the Profiler, I found that LinodeRow re-rendered unnecessarily when clicking an action such as Power on/off in the action menu due to the `openTagDrawer` prop changing. This shouldn't be happening since we no longer show tags in list view. So, I went ahead and removed the tag code.

![Screen Shot 2022-09-09 at 3 35 56 PM](https://user-images.githubusercontent.com/14323019/189430311-efdf1e3f-1454-4ec8-84cd-81e0da3a2581.jpg)

## How to test
1. Go to the Linodes landing page while on list view (this should be the default view)
2. Start profiling, click on an action in the action menu such as Power on/off for a Linode
3. Stop profiling after you click the action
4. Verify that LinodeRow is no longer being re-rendered
