### PR TITLE
M3-5829: Add contextual help to linode create page

### DIFF
--- a/packages/manager/src/components/DocsLink/DocsLink.tsx
+++ b/packages/manager/src/components/DocsLink/DocsLink.tsx
@@ -36,12 +36,13 @@ interface Props {
   href: string;
   label?: string;
   analyticsLabel?: string;
+  onClick?: () => void;
 }
 
 export const DocsLink: React.FC<Props> = (props) => {
   const classes = useStyles();
 
-  const { href, label, analyticsLabel } = props;
+  const { href, label, analyticsLabel, onClick } = props;
 
   return (
     <IconTextLink
@@ -50,7 +51,11 @@ export const DocsLink: React.FC<Props> = (props) => {
       text={label ?? 'Docs'}
       title={label ?? 'Docs'}
       onClick={() => {
-        sendHelpButtonClickEvent(href, analyticsLabel);
+        if (onClick === undefined) {
+          sendHelpButtonClickEvent(href, analyticsLabel);
+        } else {
+          onClick();
+        }
         window.open(href, '_blank', 'noopener');
       }}
       aria-describedby="external-site"

--- a/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
+++ b/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
@@ -92,7 +92,7 @@ export const TabbedPanel: React.FC<CombinedProps> = (props) => {
         {error && <Notice error>{error}</Notice>}
         <Grid className={classes.header}>
           {header !== '' && (
-            <Grid item sm={6}>
+            <Grid item xs={6}>
               <Typography variant="h2" data-qa-tp-title>
                 {header}
               </Typography>
@@ -101,7 +101,7 @@ export const TabbedPanel: React.FC<CombinedProps> = (props) => {
           {docsLink && onDocsLinkClick && (
             <Grid
               item
-              sm={6}
+              xs={6}
               style={{ display: 'flex', flexDirection: 'row-reverse' }}
             >
               {docsLink}

--- a/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
+++ b/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
@@ -8,6 +8,7 @@ import Tabs from 'src/components/core/ReachTabs';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Notice from '../Notice';
+import Grid from 'src/components/Grid';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -40,6 +41,9 @@ const useStyles = makeStyles((theme: Theme) => ({
       marginBottom: theme.spacing(3),
     },
   },
+  header: {
+    display: 'flex',
+  },
 }));
 
 export interface Tab {
@@ -60,6 +64,7 @@ interface Props {
   noPadding?: boolean;
   handleTabChange?: (index: number) => void;
   value?: number;
+  docsLink?: JSX.Element;
 }
 
 type CombinedProps = Props;
@@ -73,6 +78,9 @@ export const TabbedPanel: React.FC<CombinedProps> = (props) => {
     innerClass,
     tabs,
     handleTabChange,
+    docsLink,
+    onDocsLinkClick,
+    docsLinkLabel,
     ...rest
   } = props;
 
@@ -82,11 +90,24 @@ export const TabbedPanel: React.FC<CombinedProps> = (props) => {
     <Paper className={`${classes.root} ${rootClass}`} data-qa-tp={header}>
       <div className={innerClass}>
         {error && <Notice error>{error}</Notice>}
-        {header !== '' && (
-          <Typography variant="h2" data-qa-tp-title>
-            {header}
-          </Typography>
-        )}
+        <Grid className={classes.header}>
+          {header !== '' && (
+            <Grid item sm={6}>
+              <Typography variant="h2" data-qa-tp-title>
+                {header}
+              </Typography>
+            </Grid>
+          )}
+          {docsLink && onDocsLinkClick && (
+            <Grid
+              item
+              sm={6}
+              style={{ display: 'flex', flexDirection: 'row-reverse' }}
+            >
+              {docsLink}
+            </Grid>
+          )}
+        </Grid>
         {copy && (
           <Typography component="div" className={classes.copy} data-qa-tp-copy>
             {copy}

--- a/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
+++ b/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
@@ -79,8 +79,6 @@ export const TabbedPanel: React.FC<CombinedProps> = (props) => {
     tabs,
     handleTabChange,
     docsLink,
-    onDocsLinkClick,
-    docsLinkLabel,
     ...rest
   } = props;
 
@@ -98,7 +96,7 @@ export const TabbedPanel: React.FC<CombinedProps> = (props) => {
               </Typography>
             </Grid>
           )}
-          {docsLink && onDocsLinkClick && (
+          {docsLink ? (
             <Grid
               item
               xs={6}
@@ -106,7 +104,7 @@ export const TabbedPanel: React.FC<CombinedProps> = (props) => {
             >
               {docsLink}
             </Grid>
-          )}
+          ) : null}
         </Grid>
         {copy && (
           <Typography component="div" className={classes.copy} data-qa-tp-copy>

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -69,6 +69,8 @@ import EUAgreementCheckbox from 'src/features/Account/Agreements/EUAgreementChec
 import { CheckoutSummary } from 'src/components/CheckoutSummary/CheckoutSummary';
 import Button from 'src/components/Button';
 import Box from 'src/components/core/Box';
+import DocsLink from 'src/components/DocsLink';
+import { sendEvent } from 'src/utilities/ga';
 
 type ClassNames =
   | 'form'
@@ -605,6 +607,19 @@ export class LinodeCreate extends React.PureComponent<
             disabledClasses={this.props.disabledClasses}
             isCreate
             showTransfer
+            docsLink={
+              <DocsLink
+                href="https://www.linode.com/docs/guides/choosing-a-compute-instance-plan/"
+                label="Choosing a Plan"
+                onClick={() => {
+                  sendEvent({
+                    category: 'Linode Create Flow',
+                    action: 'Click:link',
+                    label: 'Choosing a Plan',
+                  });
+                }}
+              />
+            }
           />
           <LabelAndTagsPanel
             data-qa-label-and-tags-panel

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -76,6 +76,7 @@ import {
   queryKey,
   reportAgreementSigningError,
 } from 'src/queries/accountAgreements';
+import DocsLink from 'src/components/DocsLink';
 
 const DEFAULT_IMAGE = 'linode/debian11';
 
@@ -733,11 +734,22 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
       <React.Fragment>
         <DocumentTitleSegment segment="Create a Linode" />
         <Grid container spacing={0} className="m0">
-          <Grid item xs={12} className="p0">
+          <Grid item xs={10} className="p0">
             <Breadcrumb
               pathname={'/linodes/create'}
               labelTitle="Create"
               data-qa-create-linode-header
+            />
+          </Grid>
+          <Grid
+            item
+            xs={2}
+            style={{ display: 'flex', flexDirection: 'row-reverse' }}
+          >
+            <DocsLink
+              href="https://www.linode.com/docs/guides/platform/get-started/"
+              label="Getting Started"
+              analyticsLabel="Linode Create Flow"
             />
           </Grid>
           <LinodeCreate

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -77,6 +77,7 @@ import {
   reportAgreementSigningError,
 } from 'src/queries/accountAgreements';
 import DocsLink from 'src/components/DocsLink';
+import { sendEvent } from 'src/utilities/ga';
 
 const DEFAULT_IMAGE = 'linode/debian11';
 
@@ -749,7 +750,13 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
             <DocsLink
               href="https://www.linode.com/docs/guides/platform/get-started/"
               label="Getting Started"
-              analyticsLabel="Linode Create Flow"
+              onClick={() => {
+                sendEvent({
+                  category: 'Linode Create Flow',
+                  action: 'Click:link',
+                  label: 'Getting Started',
+                });
+              }}
             />
           </Grid>
           <LinodeCreate

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -37,7 +37,6 @@ import arrayToList from 'src/utilities/arrayToDelimiterSeparatedList';
 import { convertMegabytesTo } from 'src/utilities/unitConversions';
 import { gpuPlanText } from './utilities';
 import { ExtendedType } from 'src/store/linodeType/linodeType.reducer';
-import { sendEvent } from 'src/utilities/ga';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -557,14 +556,6 @@ export const SelectPlanPanel: React.FC<CombinedProps> = (props) => {
       tabs={tabs}
       initTab={initialTab >= 0 ? initialTab : 0}
       docsLink={docsLink}
-      docsLinkLabel="Choosing a Plan"
-      onDocsLinkClick={() => {
-        sendEvent({
-          category: 'Linode Create Flow',
-          action: 'Click:link',
-          label: 'Choosing a Plan',
-        });
-      }}
       data-qa-select-plan
     />
   );

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -37,6 +37,7 @@ import arrayToList from 'src/utilities/arrayToDelimiterSeparatedList';
 import { convertMegabytesTo } from 'src/utilities/unitConversions';
 import { gpuPlanText } from './utilities';
 import { ExtendedType } from 'src/store/linodeType/linodeType.reducer';
+import { sendEvent } from 'src/utilities/ga';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -121,6 +122,7 @@ interface Props {
   isCreate?: boolean;
   className?: string;
   showTransfer?: boolean;
+  docsLink?: JSX.Element;
 }
 
 const getNanodes = (types: PlanSelectionType[]) =>
@@ -155,6 +157,7 @@ export const SelectPlanPanel: React.FC<CombinedProps> = (props) => {
     className,
     copy,
     error,
+    docsLink,
   } = props;
 
   const classes = useStyles();
@@ -553,6 +556,15 @@ export const SelectPlanPanel: React.FC<CombinedProps> = (props) => {
       copy={copy}
       tabs={tabs}
       initTab={initialTab >= 0 ? initialTab : 0}
+      docsLink={docsLink}
+      docsLinkLabel="Choosing a Plan"
+      onDocsLinkClick={() => {
+        sendEvent({
+          category: 'Linode Create Flow',
+          action: 'Click:link',
+          label: 'Choosing a Plan',
+        });
+      }}
       data-qa-select-plan
     />
   );


### PR DESCRIPTION
## Description

Adds contextual help to the Linode create flow. In particular it adds a link to the _Getting Started_ and _Choosing a Compute Instance Type and Plan_ docs. For the time being I altered the `DocsLink` component to have a prop called `onClick` that allows the developer to specify what should happen when a user clicks the link in addition to the base functionality of the link. Another alteration I made was to the `TabbedPanel` component. I added the `docsLink` prop to allow the developer to add a `DocsLink` on the same paper as the panel across from the header.

## How to test

1. Navigate to the Linode create page
2. Ensure at the top right of the page there is a `DocsLink` labeled _Getting Started_ and that it links to the _Getting Started_ doc
3. Ensure that a GA event is sent that has the content of `{ category: 'Linode Create Flow', action: 'Click:link', label: 'Getting Started' }`
4. Navigate back to the Linode create page
5. Ensure that to the right of the header for the plan selection section is a `DocsLink` that links to the _Choosing a Compute Instance Type and Plan_ docs
6. Ensure that a GA event is sent that has the content of `{ category: 'Linode Create Flow', action: 'Click:link', label: 'Choosing a Plan' }`
