### PR TITLE
M3-5166: Fix close button wrapping for Drawers with long titles

### DIFF
--- a/packages/manager/src/components/Drawer/Drawer.tsx
+++ b/packages/manager/src/components/Drawer/Drawer.tsx
@@ -38,6 +38,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   drawerHeader: {
     marginBottom: theme.spacing(2),
   },
+  title: {
+    wordBreak: 'break-word',
+  },
   button: {
     minWidth: 'auto',
     minHeight: 'auto',
@@ -87,13 +90,15 @@ const DDrawer: React.FC<CombinedProps> = (props) => {
       <Grid
         className={classes.drawerHeader}
         container
-        alignItems="center"
+        alignItems="flex-start"
         justifyContent="space-between"
         updateFor={[title, classes]}
+        wrap="nowrap"
       >
         <Grid item>
           <Typography
             id={titleID}
+            className={classes.title}
             variant="h2"
             data-qa-drawer-title={title}
             data-testid="drawer-title"


### PR DESCRIPTION
## Description

**What does this PR do?**
Fixes an issue where long titles cause a drawer's close button to get forced to a new line:

**Before:**
<img width="494" alt="Screen Shot 2022-09-13 at 3 00 59 PM" src="https://user-images.githubusercontent.com/97627410/189987641-1597c26e-27a2-430d-8ebb-b06e3c801cf9.png">

**After:**
<img width="488" alt="Screen Shot 2022-09-13 at 3 01 37 PM" src="https://user-images.githubusercontent.com/97627410/189987764-492628a8-1352-477b-bcc5-e92e998fadbf.png">

This also tweaks the CSS slightly so that resources with a long but single-word name still break as expected:

<img width="489" alt="Screen Shot 2022-09-13 at 3 02 51 PM" src="https://user-images.githubusercontent.com/97627410/189987973-f5476810-f680-45d8-908d-d722c758212c.png">


## How to test

**What are the steps to reproduce the issue or verify the changes?**
1. Create a Linode with a long label and visit its details page
2. Navigate to the "Storage" tab, click "Create Volume"
3. Confirm that the Drawer title has a line break, but the Drawer close button is in its expected place (top-right corner)
4. Confirm that Drawer behaves as expected with regular length titles as well

This command runs a selection of E2E tests which include drawer interactions:
(Took about 2 and a half minutes on my machine)

```bash
$ yarn cy:run -s "cypress/integration/objectStorage/access-key.e2e.spec.ts,cypress/integration/objectStorage/access-keys.smoke.spec.ts,cypress/integration/objectStorage/object-storage.e2e.spec.ts,cypress/integration/objectStorage/object-storage.smoke.spec.ts,cypress/integration/databases/update-database.spec.ts"
```