### PR TITLE
M3-5905: Events tags on Linodes landing page

### DIFF
--- a/packages/manager/src/features/linodes/LinodesLanding/ListLinodesEmptyState.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/ListLinodesEmptyState.tsx
@@ -4,9 +4,15 @@ import LinodeSvg from 'src/assets/icons/entityIcons/linode.svg';
 import Typography from 'src/components/core/Typography';
 import Link from 'src/components/Link';
 import Placeholder from 'src/components/Placeholder';
+import { sendEvent } from 'src/utilities/ga';
 
 export const ListLinodesEmptyState: React.FC<{}> = (_) => {
   const { push } = useHistory();
+
+  const emptyLinodeLandingGAEventTemplate = {
+    category: 'Linodes Landing Page Empty',
+    action: 'Click:link',
+  };
 
   return (
     <Placeholder
@@ -15,7 +21,13 @@ export const ListLinodesEmptyState: React.FC<{}> = (_) => {
       isEntity
       buttonProps={[
         {
-          onClick: () => push('/linodes/create'),
+          onClick: () => {
+            sendEvent({
+              ...emptyLinodeLandingGAEventTemplate,
+              label: 'Create Linode',
+            });
+            push('/linodes/create');
+          },
           children: 'Create Linode',
         },
       ]}
@@ -25,11 +37,27 @@ export const ListLinodesEmptyState: React.FC<{}> = (_) => {
         getting started?
       </Typography>
       <Typography variant="subtitle1">
-        <Link to="https://linode.com/docs/getting-started-new-manager/">
+        <Link
+          to="https://linode.com/docs/getting-started-new-manager/"
+          onClick={() => {
+            sendEvent({
+              ...emptyLinodeLandingGAEventTemplate,
+              label: 'Learn more about getting started',
+            });
+          }}
+        >
           Learn more about getting started
         </Link>
         &nbsp;or&nbsp;
-        <Link to="https://www.linode.com/docs/">
+        <Link
+          to="https://www.linode.com/docs/"
+          onClick={() => {
+            sendEvent({
+              ...emptyLinodeLandingGAEventTemplate,
+              label: 'visit our guides and tutorials',
+            });
+          }}
+        >
           visit our guides and tutorials.
         </Link>
       </Typography>

--- a/packages/manager/src/features/linodes/LinodesLanding/ListLinodesEmptyState.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/ListLinodesEmptyState.tsx
@@ -10,7 +10,7 @@ export const ListLinodesEmptyState: React.FC<{}> = (_) => {
   const { push } = useHistory();
 
   const emptyLinodeLandingGAEventTemplate = {
-    category: 'Linodes Landing Page Empty',
+    category: 'Linodes landing page empty',
     action: 'Click:link',
   };
 
@@ -23,7 +23,8 @@ export const ListLinodesEmptyState: React.FC<{}> = (_) => {
         {
           onClick: () => {
             sendEvent({
-              ...emptyLinodeLandingGAEventTemplate,
+              category: 'Linodes landing page empty',
+              action: 'Click:button',
               label: 'Create Linode',
             });
             push('/linodes/create');


### PR DESCRIPTION
## Description

Adds GA events to the docs links on the empty Linode landing page.

## How to test

1. Navigate to an empty Linode landing page (you may need to enable mocks)
2. Click the _Learn more about getting started_ link
3. Ensure that it sends a GA event with the contents: `{ category: 'Linodes landing page empty', action: 'Click:link', label: 'Learn more about getting started'}`
4. Click the _visit our guides and tutorials_ link
5. Ensure it sends a GA event with the contents: `{  category: 'Linodes landing page empty', action: 'Click:link', label: 'visit our guides and tutorials' }`
6. Click the `Create` button
7. Ensure that it sends a GA event with the contents: `{  category: 'Linodes landing page empty', action: 'Click:button', label: 'Create Linode' }`
