### PR TITLE
M3-4935: Add initrd selection to Linode Config modal

### DIFF
--- a/packages/api-v4/src/linodes/types.ts
+++ b/packages/api-v4/src/linodes/types.ts
@@ -247,7 +247,7 @@ export type DiskStatus =
 export interface LinodeConfigCreationData {
   label: string;
   devices: Devices;
-  initrd: string | null;
+  initrd: string | number | null;
   kernel?: string;
   comments?: string;
   memory_limit?: number;

--- a/packages/api-v4/src/linodes/types.ts
+++ b/packages/api-v4/src/linodes/types.ts
@@ -247,6 +247,7 @@ export type DiskStatus =
 export interface LinodeConfigCreationData {
   label: string;
   devices: Devices;
+  initrd: string | null;
   kernel?: string;
   comments?: string;
   memory_limit?: number;

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs.tsx
@@ -44,7 +44,7 @@ import {
 import { MapState } from 'src/store/types';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { getAll } from 'src/utilities/getAll';
-import LinodeConfigDrawer from '../LinodeSettings/LinodeConfigDialog';
+import LinodeConfigDialog from '../LinodeSettings/LinodeConfigDialog';
 import ConfigRow from './ConfigRow';
 
 type ClassNames =
@@ -195,7 +195,7 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
           </Grid>
         </Grid>
         <this.linodeConfigsTable />
-        <LinodeConfigDrawer
+        <LinodeConfigDialog
           linodeConfigId={this.state.configDrawer.linodeConfigId}
           linodeHypervisor={this.props.linodeHypervisor}
           linodeRegion={this.props.linodeRegion}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -109,7 +109,7 @@ interface EditableFields {
   useCustomRoot: boolean;
   label: string;
   devices: DevicesAsStrings;
-  initrd: string | null;
+  initrd: string | number | null;
   kernel?: string;
   comments?: string;
   memory_limit?: number;
@@ -329,6 +329,11 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
 
     const configData = convertStateToData(values) as LinodeConfigCreationData;
 
+    // If Finnix was selected, make sure it gets sent as a number in the payload, not a string.
+    if (Number(configData.initrd) === 25669) {
+      configData.initrd = 25669;
+    }
+
     if (!regionHasVLANS) {
       delete configData.interfaces;
     }
@@ -468,19 +473,22 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
       return {
         label: categoryTitle,
         value: category,
-        options: items.map(({ label, id }) => {
-          return {
-            label,
-            value: String(id) as string | null,
-          };
-        }),
+        options: [
+          ...items.map(({ label, id }) => {
+            return {
+              label,
+              value: String(id) as string | number | null,
+            };
+          }),
+          { label: 'Recovery – Finnix (initrd)', value: '25669' },
+        ],
       };
     }
   );
 
   categorizedInitrdOptions.unshift({
-    value: '',
     label: '',
+    value: '',
     options: [{ label: 'None', value: null }],
   });
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -223,6 +223,7 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
     open,
     onClose,
     config,
+    initrdFromConfig,
     kernels,
     linodeConfigId,
     linodeRegion,
@@ -326,6 +327,9 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
 
     const configData = convertStateToData(values) as LinodeConfigCreationData;
 
+    console.log(typeof configData.initrd);
+    console.log(configData.initrd);
+
     if (!regionHasVLANS) {
       delete configData.interfaces;
     }
@@ -420,7 +424,7 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
             useCustomRoot: isUsingCustomRoot(config.root_device),
             label: config.label,
             devices,
-            initrd: String(config.initrd),
+            initrd: initrdFromConfig,
             kernel: config.kernel,
             comments: config.comments,
             memory_limit: config.memory_limit,
@@ -440,7 +444,7 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
         setDeviceCounter(deviceCounterDefault);
       }
     }
-  }, [open, config, resetForm]);
+  }, [open, config, initrdFromConfig, resetForm]);
 
   const isLoading = props.kernelsLoading;
 
@@ -509,9 +513,11 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
 
   const handleInitrdChange = React.useCallback(
     (selectedDisk: Item<string>) => {
+      console.log(selectedDisk);
       setFieldValue('initrd', selectedDisk.value);
+      console.log(values);
     },
-    [setFieldValue]
+    [setFieldValue, values]
   );
 
   return (
@@ -763,7 +769,7 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
                   label="initrd"
                   onChange={handleInitrdChange}
                   options={initrdOptions}
-                  defaultValue={config?.initrd ?? ''}
+                  defaultValue={initrdFromConfig}
                   value={initrdOptions.find(
                     (option) => option.value === values.initrd
                   )}
@@ -1028,6 +1034,7 @@ interface StateProps {
   disks: ExtendedDisk[];
   volumes: ExtendedVolume[];
   config?: Config;
+  initrdFromConfig: string;
 }
 
 interface LinodeContextProps {
@@ -1059,6 +1066,8 @@ const enhanced = compose<CombinedProps, Props>(
       ? state.__resources.linodeConfigs[linodeId].itemsById[linodeConfigId]
       : undefined;
 
+    const initrdFromConfig = config?.initrd ? String(config.initrd) : '';
+
     const volumes = Object.values(itemsById).reduce(
       (result: Volume[], volume: Volume) => {
         /**
@@ -1079,7 +1088,7 @@ const enhanced = compose<CombinedProps, Props>(
       },
       []
     );
-    return { config, volumes };
+    return { config, initrdFromConfig, volumes };
   })
 );
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -107,7 +107,7 @@ interface EditableFields {
   useCustomRoot: boolean;
   label: string;
   devices: DevicesAsStrings;
-  initrd: string | null;
+  initrd: string;
   kernel?: string;
   comments?: string;
   memory_limit?: number;

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -220,6 +220,9 @@ const interfacesToPayload = (interfaces?: ExtendedInterface[]) => {
 const deviceSlots = ['sda', 'sdb', 'sdc', 'sdd', 'sde', 'sdf', 'sdg', 'sdh'];
 const deviceCounterDefault = 1;
 
+// DiskID reserved on the back-end to indicate Finnix.
+const finnixDiskID = 25669;
+
 const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
   const {
     open,
@@ -330,8 +333,8 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
     const configData = convertStateToData(values) as LinodeConfigCreationData;
 
     // If Finnix was selected, make sure it gets sent as a number in the payload, not a string.
-    if (Number(configData.initrd) === 25669) {
-      configData.initrd = 25669;
+    if (Number(configData.initrd) === finnixDiskID) {
+      configData.initrd = finnixDiskID;
     }
 
     if (!regionHasVLANS) {
@@ -480,7 +483,7 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
               value: String(id) as string | number | null,
             };
           }),
-          { label: 'Recovery – Finnix (initrd)', value: '25669' },
+          { label: 'Recovery – Finnix (initrd)', value: String(finnixDiskID) },
         ],
       };
     }

--- a/packages/manager/src/store/linodes/config/config.reducer.test.ts
+++ b/packages/manager/src/store/linodes/config/config.reducer.test.ts
@@ -108,6 +108,7 @@ describe('config reducer', () => {
             linodeId: 1,
             label: mockConfig1.label,
             devices: mockConfig1.devices,
+            initrd: null,
             root_device: mockConfig1.root_device,
             helpers: mockConfig1.helpers,
           },


### PR DESCRIPTION
## Description
Users were able to, in Classic Manager (and presently via the API), select a disk for `initrd`. This PR adds a dropdown in the Linode Config modal in the "Block Device Assignment" section for initrd. The dropdown is populated by disks with an initrd filesystem.

## To-Do
- [ ] Fix bug where initrd somehow gets set to `null` when you change and save the new disk multiple times in quick succession
- [x] Explanatory PR comments
- [x] Confirm with API that the `initrd` should not explicitly be a number/integer (right now a `typeof` is not specified in the API mapping)

## How to test
- Create a few disks with a filesystem type of "initrd"
- Add or edit a Linode Configuration. Confirm that the "initrd" field is visible in the modal and that it is populated with any disks on that Linode with a filesystem type of "initrd".
- Select a disk and save the changes. Go through the modal flow a few times to ensure the correct disk is saved for initrd and shows up the next time you open the modal.
