### PR TITLE
M3-5891: Make Database Engine Icons More Visible on Focus

### DIFF
--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -131,13 +131,10 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   engineSelect: {
     '& .react-select__option--is-focused': {
-      '& svg': {
-        filter: 'brightness(0) invert(1)',
-      },
-    },
-    '& .react-select__option--is-selected': {
-      '& svg': {
-        filter: 'unset !important',
+      '&:not(.react-select__option--is-selected)': {
+        '& svg': {
+          filter: 'brightness(0) invert(1)',
+        },
       },
     },
   },

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -129,6 +129,18 @@ const useStyles = makeStyles((theme: Theme) => ({
     fontSize: 15,
     lineHeight: '18px',
   },
+  engineSelect: {
+    '& .react-select__option--is-focused': {
+      '& svg': {
+        filter: 'brightness(0) invert(1)',
+      },
+    },
+    '& .react-select__option--is-selected': {
+      '& svg': {
+        filter: 'unset !important',
+      },
+    },
+  },
 }));
 
 const engineIcons = {
@@ -498,6 +510,7 @@ const DatabaseCreate: React.FC<{}> = () => {
               values.engine,
               engineOptions
             )}
+            className={classes.engineSelect}
             errorText={errors.engine}
             options={engineOptions}
             components={{ Option: RegionOption, SingleValue }}


### PR DESCRIPTION
## Description 📝

- Makes the Database Engine icon **white** when the option is focused in the Engine Select component
  - I chose to do this with a css filter on the svg to prevent us from needing to include more assets

## Preview 📷

### Before 
![Screen Shot 2022-09-13 at 5 42 29 PM](https://user-images.githubusercontent.com/6440455/190014653-2d160381-aa49-4085-af53-794813f0bc89.jpg)

### After
![Screen Shot 2022-09-13 at 5 42 13 PM](https://user-images.githubusercontent.com/6440455/190014639-e8448964-94e2-43fd-bdfc-9cf5c287a4c7.jpg)


## How to test 🧪

- Test the `Database Engine` select on `http://localhost:3000/databases/create`
- Verify that the icon is easy to see when the option is focused
- Try getting the `Database Engine` Select into weird states and verify that the icon looks correct
