### PR TITLE
Upgrade Cypress action for Cypress 10 support

### DIFF
--- a/.github/workflows/e2e_schedule_and_push.yml
+++ b/.github/workflows/e2e_schedule_and_push.yml
@@ -61,6 +61,5 @@ jobs:
           wait-on-timeout: 1000
           install: false
           browser: chrome
-          headless: true
           record: true
           parallel: true

--- a/.github/workflows/e2e_schedule_and_push.yml
+++ b/.github/workflows/e2e_schedule_and_push.yml
@@ -54,7 +54,7 @@ jobs:
           echo "REACT_APP_APP_ROOT=${{ secrets.REACT_APP_APP_ROOT }}" >> ./packages/manager/.env
           yarn up &
       - name: Run tests
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v4
         with:
           working-directory: packages/manager
           wait-on: "http://localhost:3000"


### PR DESCRIPTION
## Description

**What does this PR do?**
This upgrades the version of the Cypress GitHub Action that we use from v2.x to v4.x so that we can support Cypress 10. It additionally removes the `headless` option, since headless is the default as of Cypress 8.x.

## How to test

**What are the steps to reproduce the issue or verify the changes?**
Once this is merged, I can re-run the scheduled action and hopefully the tests will run as expected. There is the potential that this won't fix the problem (as I haven't been able to test it directly), but it should not make the situation any worse than it already is.
