### PR TITLE
Improve username update E2E test flakiness

### DIFF
--- a/packages/manager/cypress/e2e/account/change-username.spec.ts
+++ b/packages/manager/cypress/e2e/account/change-username.spec.ts
@@ -1,20 +1,98 @@
-import { getProfile } from '../../support/api/account';
-import { fbtVisible, getVisible } from '../../support/helpers';
-const testText = 'testing123';
+import { getProfile } from 'support/api/account';
+import {
+  interceptGetProfile,
+  interceptGetUser,
+  mockUpdateUsername,
+} from 'support/intercepts/profile';
+import { ui } from 'support/ui';
+import { randomString } from 'support/util/random';
 
 describe('username', () => {
-  it('can type new username', () => {
-    cy.intercept('GET', '*/profile/logins').as('getLogin');
-    cy.intercept('GET', '*/object-storage/clusters').as('getClusters');
-    // cy.visitWithLogin(`/dashboard`);
+  /*
+   * - Validates username update flow via the user profile page using mocked data.
+   */
+  it('can change username via user profile page', () => {
+    const newUsername = randomString(12);
+
     getProfile().then((profile) => {
       const username = profile.body.username;
+
+      interceptGetUser(username).as('getUser');
+      mockUpdateUsername(username, newUsername).as('updateUsername');
+
       cy.visitWithLogin(`account/users/${username}`);
-      fbtVisible('Username');
-      fbtVisible('Email');
-      fbtVisible('Delete User');
-      cy.get('[id="username"]').clear().type(testText);
-      getVisible('[id="username"]').should('have.value', testText);
+      cy.wait('@getUser');
+
+      cy.findByText('Username').should('be.visible');
+      cy.findByText('Email').should('be.visible');
+      cy.findByText('Delete User').should('be.visible');
+
+      cy.get('[id="username"]')
+        .should('be.visible')
+        .should('have.value', username)
+        .clear()
+        .type(newUsername);
+
+      cy.get('[data-qa-textfield-label="Username"]')
+        .parent()
+        .parent()
+        .within(() => {
+          ui.button
+            .findByTitle('Save')
+            .should('be.visible')
+            .should('be.enabled')
+            .click();
+        });
+
+      cy.wait('@updateUsername');
+
+      // No confirmation gets shown on this page when changes are saved.
+      // Confirm that the text field has the correct value instead.
+      cy.get('[id="username"]')
+        .should('be.visible')
+        .should('have.value', newUsername);
+    });
+  });
+
+  /*
+   * - Validates username update flow via the profile display page using mocked data.
+   */
+  it('can change username via profile display page', () => {
+    const newUsername = randomString(12);
+
+    getProfile().then((profile) => {
+      const username = profile.body.username;
+
+      interceptGetProfile().as('getUserProfile');
+      mockUpdateUsername(username, newUsername).as('updateUsername');
+
+      cy.visitWithLogin('/profile/display');
+      cy.wait('@getUserProfile');
+
+      ui.button
+        .findByTitle('Update Username')
+        .should('be.visible')
+        .should('be.disabled');
+
+      cy.findByLabelText('Username')
+        .should('be.visible')
+        .should('have.value', username)
+        .clear()
+        .type(newUsername);
+
+      ui.button
+        .findByTitle('Update Username')
+        .should('be.visible')
+        .should('be.enabled')
+        .click();
+
+      cy.wait('@updateUsername');
+
+      cy.findByLabelText('Username')
+        .should('be.visible')
+        .should('have.value', newUsername);
+
+      cy.findByText('Username updated successfully.').should('be.visible');
     });
   });
 });

--- a/packages/manager/cypress/plugins/index.js
+++ b/packages/manager/cypress/plugins/index.js
@@ -78,6 +78,18 @@ function checkNodeVersionRequiredByLinode() {
 module.exports = (on, _config) => {
   checkNodeVersionRequiredByLinode();
 
+  // Disable requests to Google's safe browsing API.
+  on('before:browser:launch', (browser = {}, launchOptions) => {
+    const originalPreferences = launchOptions.preferences.default;
+    launchOptions.preferences.default = {
+      ...originalPreferences,
+      safebrowsing: {
+        enabled: false,
+      },
+    };
+    return launchOptions;
+  });
+
   on('task', {
     datenow() {
       return Date.now();

--- a/packages/manager/cypress/support/intercepts/profile.ts
+++ b/packages/manager/cypress/support/intercepts/profile.ts
@@ -1,5 +1,5 @@
 /**
- * @file Cypress intercepts and mocks for Cloud Manager profile requests.
+ * @file Cypress intercepts and mocks for Cloud Manager profile and account requests.
  */
 
 import { makeErrorResponse } from 'support/util/errors';
@@ -10,7 +10,27 @@ import type {
 } from '@linode/api-v4/types';
 
 /**
- * Intercepts GET request to fetch profile and mocks response.
+ * Intercepts GET request to fetch account user information.
+ *
+ * @param username - Username of user whose info is being fetched.
+ *
+ * @returns Cypress chainable.
+ */
+export const interceptGetUser = (username: string): Cypress.Chainable<null> => {
+  return cy.intercept('GET', `*/account/users/${username}`);
+};
+
+/**
+ * Intercepts GET request to fetch user profile.
+ *
+ * @returns Cypress chainable.
+ */
+export const interceptGetProfile = (): Cypress.Chainable<null> => {
+  return cy.intercept('GET', '*/profile');
+};
+
+/**
+ * Intercepts GET request to fetch user profile and mocks response.
  *
  * @param profile - Profile with which to respond.
  *
@@ -128,5 +148,29 @@ export const mockConfirmTwoFactorAuth = (
 ): Cypress.Chainable<null> => {
   return cy.intercept('POST', '*/profile/tfa-enable-confirm', {
     scratch: scratchCode,
+  });
+};
+
+/**
+ * Intercepts PUT request to update account username and mocks response.
+ *
+ * @param oldUsername - The original username which will be changed.
+ * @param newUsername - The new username for the account.
+ * @param restricted - Whether or not the account is restricted.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockUpdateUsername = (
+  oldUsername: string,
+  newUsername: string,
+  restricted: boolean = false
+) => {
+  return cy.intercept('PUT', `*/account/users/${oldUsername}`, {
+    username: newUsername,
+    email: 'mockEmail@example.com',
+    restricted,
+    ssh_keys: [],
+    tfa_enabled: false,
+    verified_phone_number: null,
   });
 };


### PR DESCRIPTION
## Description

**What does this PR do?**
This makes some improvements and additions to the Cypress username update test to reduce flakiness:

- Disables Google Safebrowsing API requests during tests. These get made automatically by Chrome (not Cloud Manager), and occasionally cause or contribute to test timeouts
- Improves the structure of the existing test (waits for GET requests to be made and for username input field to render before interacting with the page)
- Mocks the username update request and confirms that the UI updates accordingly (currently, the test does not click the "Save Changes" button, so it really is not validating much)
- Adds a new test to confirm that the account username can be changed via the Profile Display page

## How to test

**What are the steps to reproduce the issue or verify the changes?**
To run non-interactively:
```
yarn cy:run -s cypress/e2e/account/change-username.spec.ts
```

To run with debugger:
```
yarn cy:debug
```
Then select _change-username.spec.ts_

Confirm that the tests run and pass