### PR TITLE
M3-5937: Add Firewall Support for `IPENCAP` Protocol

### DIFF
--- a/packages/api-v4/src/firewalls/types.ts
+++ b/packages/api-v4/src/firewalls/types.ts
@@ -1,6 +1,6 @@
 export type FirewallStatus = 'enabled' | 'disabled' | 'deleted';
 
-export type FirewallRuleProtocol = 'ALL' | 'TCP' | 'UDP' | 'ICMP';
+export type FirewallRuleProtocol = 'ALL' | 'TCP' | 'UDP' | 'ICMP' | 'IPENCAP';
 
 export type FirewallDeviceEntityType = 'linode' | 'nodebalancer';
 

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.test.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.test.tsx
@@ -49,6 +49,16 @@ describe('AddRuleDrawer', () => {
     userEvent.selectOptions(screen.getByPlaceholderText(/protocol/i), 'ICMP');
     expect(screen.getByLabelText('Ports')).toBeDisabled();
   });
+
+  it('disables the port input when the IPENCAP protocol is selected', () => {
+    renderWithTheme(<RuleDrawer {...props} mode="create" category="inbound" />);
+    expect(screen.getByLabelText('Ports')).not.toBeDisabled();
+    userEvent.selectOptions(
+      screen.getByPlaceholderText(/protocol/i),
+      'IPENCAP'
+    );
+    expect(screen.getByLabelText('Ports')).toBeDisabled();
+  });
 });
 
 describe('utilities', () => {
@@ -93,6 +103,10 @@ describe('utilities', () => {
       expect(validateForm('ICMP', '80')).toHaveProperty(
         'ports',
         'Ports are not allowed for ICMP protocols.'
+      );
+      expect(validateForm('IPENCAP', '443')).toHaveProperty(
+        'ports',
+        'Ports are not allowed for IPENCAP protocols.'
       );
       expect(validateForm('TCP', 'invalid-port')).toHaveProperty('ports');
     });

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
@@ -332,7 +332,7 @@ const FirewallRuleForm: React.FC<FirewallRuleFormProps> = React.memo(
         }
 
         setFieldValue('protocol', item?.value);
-        if (item?.value === 'ICMP') {
+        if (item?.value === 'ICMP' || item?.value === 'IPENCAP') {
           // Submitting the form with ICMP and defined ports causes an error
           setFieldValue('ports', '');
           setPresetPorts([]);

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
@@ -469,12 +469,11 @@ const FirewallRuleForm: React.FC<FirewallRuleFormProps> = React.memo(
           value={presetPorts}
           options={portOptions}
           onChange={handlePortPresetChange}
-          disabled={values.protocol === 'ICMP'}
+          disabled={['ICMP', 'IPENCAP'].includes(values.protocol)}
           textFieldProps={{
-            helperText:
-              values.protocol === 'ICMP'
-                ? 'Ports are not allowed for ICMP protocols.'
-                : undefined,
+            helperText: ['ICMP', 'IPENCAP'].includes(values.protocol)
+              ? `Ports are not allowed for ${values.protocol} protocols.`
+              : undefined,
           }}
         />
         {hasCustomInput ? (
@@ -848,8 +847,8 @@ export const validateForm = (
     errors.protocol = 'Protocol is required.';
   }
 
-  if (protocol === 'ICMP' && ports) {
-    errors.ports = 'Ports are not allowed for ICMP protocols.';
+  if ((protocol === 'ICMP' || protocol === 'IPENCAP') && ports) {
+    errors.ports = `Ports are not allowed for ${protocol} protocols.`;
   } else if (ports && !ports.match(/^([0-9\-]+,?\s?)+$/)) {
     errors.ports =
       'Ports must be an integer, range of integers, or a comma-separated list of integers.';

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
@@ -333,7 +333,7 @@ const FirewallRuleForm: React.FC<FirewallRuleFormProps> = React.memo(
 
         setFieldValue('protocol', item?.value);
         if (item?.value === 'ICMP' || item?.value === 'IPENCAP') {
-          // Submitting the form with ICMP and defined ports causes an error
+          // Submitting the form with ICMP or IPENCAP and defined ports causes an error
           setFieldValue('ports', '');
           setPresetPorts([]);
         }

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/firewallRuleEditor.test.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/firewallRuleEditor.test.ts
@@ -166,17 +166,21 @@ describe('Rule Editor', () => {
   });
 
   describe('prepareRules', () => {
-    it('removes the `ports` field for ICMP rules if `ports` is an empty string', () => {
+    it('removes the `ports` field for ICMP and IPENCAP rules if `ports` is an empty string', () => {
       const rules = [
         firewallRuleFactory.build({ protocol: 'ICMP', ports: '1234' }),
         firewallRuleFactory.build({ protocol: 'ICMP', ports: '' }),
         firewallRuleFactory.build({ protocol: 'TCP', ports: '' }),
+        firewallRuleFactory.build({ protocol: 'IPENCAP', ports: '1234' }),
+        firewallRuleFactory.build({ protocol: 'IPENCAP', ports: '' }),
       ];
       const editorState = initRuleEditorState(rules);
       const result = prepareRules(editorState);
       expect(result[0]).toHaveProperty('ports', '1234');
       expect(result[1]).not.toHaveProperty('ports');
       expect(result[2]).toHaveProperty('ports', '');
+      expect(result[3]).toHaveProperty('ports', '1234');
+      expect(result[4]).not.toHaveProperty('ports');
     });
   });
 });

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/firewallRuleEditor.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/firewallRuleEditor.ts
@@ -246,7 +246,10 @@ export const removeICMPPort = (
   rules: ExtendedFirewallRule[]
 ): ExtendedFirewallRule[] =>
   rules.map((thisRule) => {
-    if (thisRule.protocol === 'ICMP' && thisRule.ports === '') {
+    if (
+      (thisRule.protocol === 'ICMP' || thisRule.protocol === 'IPENCAP') &&
+      thisRule.ports === ''
+    ) {
       delete thisRule.ports;
     }
     return thisRule;

--- a/packages/manager/src/features/Firewalls/shared.ts
+++ b/packages/manager/src/features/Firewalls/shared.ts
@@ -59,6 +59,7 @@ export const protocolOptions: Item<FirewallRuleProtocol>[] = [
   { label: 'TCP', value: 'TCP' },
   { label: 'ICMP', value: 'ICMP' },
   { label: 'UDP', value: 'UDP' },
+  { label: 'IPENCAP', value: 'IPENCAP' },
 ];
 
 export const addressOptions = [

--- a/packages/manager/src/features/Firewalls/shared.ts
+++ b/packages/manager/src/features/Firewalls/shared.ts
@@ -57,8 +57,8 @@ export const firewallOptionItemsShort = [
 
 export const protocolOptions: Item<FirewallRuleProtocol>[] = [
   { label: 'TCP', value: 'TCP' },
-  { label: 'ICMP', value: 'ICMP' },
   { label: 'UDP', value: 'UDP' },
+  { label: 'ICMP', value: 'ICMP' },
   { label: 'IPENCAP', value: 'IPENCAP' },
 ];
 

--- a/packages/validation/src/firewalls.schema.ts
+++ b/packages/validation/src/firewalls.schema.ts
@@ -42,19 +42,19 @@ export const validateFirewallPorts = string().matches(
   'Ports must be an integer, range of integers, or a comma-separated list of integers.'
 );
 
-const validFirewallRuleProtocol = ['ALL', 'TCP', 'UDP', 'ICMP'];
+const validFirewallRuleProtocol = ['ALL', 'TCP', 'UDP', 'ICMP', 'IPENCAP'];
 export const FirewallRuleTypeSchema = object().shape({
   action: mixed().oneOf(['ACCEPT', 'DROP']).required('Action is required'),
   protocol: mixed()
     .oneOf(validFirewallRuleProtocol)
     .required('Protocol is required.'),
   ports: string().when('protocol', {
-    is: (val: any) => val !== 'ICMP',
+    is: (val: any) => val !== 'ICMP' && val !== 'IPENCAP',
     then: validateFirewallPorts,
-    // Workaround to get the test to fail if ports is defined when protocol === ICMP
+    // Workaround to get the test to fail if ports is defined when protocol === ICMP or IPENCAP
     otherwise: string().test({
       name: 'protocol',
-      message: 'Ports are not allowed for ICMP protocols.',
+      message: 'Ports are not allowed for ICMP and IPENCAP protocols.',
       test: (value) => typeof value === 'undefined',
     }),
   }),


### PR DESCRIPTION
## Description 📝

- Adds support for `IPENCAP` in Cloud Manager
  - 🌎[Linode API Documentation on Firewall Rules](https://www.linode.com/docs/api/networking/#firewall-rules-update)

## Preview 📷
![Screen Shot 2022-09-21 at 11 15 43 AM](https://user-images.githubusercontent.com/6440455/191543241-a6d0b9b0-2a14-4f7a-adb6-86c3c5b3ec58.jpg)

## How to test 🧪

- Create or have a Linode Firewall
- Add a rule to that Firewall that uses `IPENCAP` as the `Protocol`
- Confirm that you can add an `IPENCAP` firewall rule
  - Test many different configurations of firewall rules and ensure Cloud Manager's validation holds up
  - Make sure you are pressing `Save Changes` to commit your firewall changes and get validation from the API