### PR TITLE
Set Storybook logo max width

### DIFF
--- a/packages/manager/.storybook/manager-head.html
+++ b/packages/manager/.storybook/manager-head.html
@@ -1,6 +1,9 @@
 <link rel="icon" href="/favicon.ico">
 <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&display=swap" rel="stylesheet">
 <style>
+  .sidebar-header img {
+    max-width: 260px;
+  }
   .sidebar-container {
     background-color: #3a3f46;
   }


### PR DESCRIPTION
## Description
I was planning to write a ticket to capture this issue, but figured it'd probably just be quicker to fix it while it's still in mind.

**What does this PR do?**
This sets a max width of `260px` on the Storybook logo. I chose `260px` mostly arbitrarily because I thought it looked good, so definitely open to feedback and tweaks.

## How to test

**What are the steps to reproduce the issue or verify the changes?**
Run `yarn storybook`, open Storybook at `localhost:6006` and resize the sidebar. Confirm that the logo stops growing once it reaches a maximum width of 260 pixels.

Note: If `yarn storybook` doesn't show the logo or CSS changes, you may have to run `yarn storybook --no-manager-cache`.