### PR TITLE
M3-5904: Improve graph accessibility

### DIFF
--- a/packages/manager/.eslintrc.js
+++ b/packages/manager/.eslintrc.js
@@ -135,6 +135,18 @@ module.exports = {
     'scanjs-rules/new_Function': 'error',
     'scanjs-rules/property_crypto': 'error',
     'scanjs-rules/property_geolocation': 'error',
+    // Allow roles from WAI-ARIA graphics module proposal.
+    // See: https://www.w3.org/TR/graphics-aria-1.0/
+    'jsx-a11y/aria-role': [
+      'error',
+      {
+        allowedInvalidRoles: [
+          'graphics-document',
+          'graphics-object',
+          'graphics-symbol',
+        ],
+      },
+    ],
     // Prevent patterns susceptible to XSS, like '<div>' + userInput + '</div>'.
     // https://github.com/Rantanen/eslint-plugin-xss/blob/master/docs/rules/no-mixed-html.md
     'xss/no-mixed-html': [

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -209,7 +209,7 @@
     "eslint-config-prettier": "~8.1.0",
     "eslint-plugin-cypress": "^2.11.3",
     "eslint-plugin-jest": "^23.8.2",
-    "eslint-plugin-jsx-a11y": "^6.2.3",
+    "eslint-plugin-jsx-a11y": "^6.6.1",
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-prettier": "~3.3.1",
     "eslint-plugin-ramda": "^2.5.1",

--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -289,7 +289,7 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
     // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
     <div
       className={classes.wrapper}
-      tabIndex={tabIndex || 0}
+      tabIndex={tabIndex ?? 0}
       role="graphics-document"
       aria-label={ariaLabel || 'Stats and metrics'}
     >

--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -283,15 +283,21 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
       });
     }
   });
+
   return (
-    <div className={classes.wrapper} tabIndex={tabIndex || 0}>
+    <div
+      className={classes.wrapper}
+      tabIndex={tabIndex || 0}
+      role="graphics-document"
+      aria-label={ariaLabel || 'Stats and metrics'}
+    >
       <div className={classes.canvasContainer}>
         <canvas height={chartHeight || 300} ref={inputEl} />
       </div>
       {legendRendered && legendRows && (
         <div className={classes.container}>
           <Table
-            aria-label={ariaLabel || 'Stats and metrics'}
+            aria-label={`Controls for ${ariaLabel || 'Stats and metrics'}`}
             className={classes.root}
             noBorder
           >

--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -52,6 +52,8 @@ export interface Props {
   nativeLegend?: boolean; // Display chart.js native legend
   formatData?: (value: number) => number | null;
   formatTooltip?: (value: number) => string;
+  ariaLabel?: string;
+  tabIndex?: number;
 }
 
 type CombinedProps = Props;
@@ -93,6 +95,7 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
   const [hiddenDatasets, setHiddenDatasets] = React.useState<number[]>([]);
 
   const {
+    ariaLabel,
     chartHeight,
     formatData,
     formatTooltip,
@@ -103,6 +106,7 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
     rowHeaders,
     legendRows,
     nativeLegend,
+    tabIndex,
     unit,
   } = props;
 
@@ -280,14 +284,14 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
     }
   });
   return (
-    <div className={classes.wrapper}>
+    <div className={classes.wrapper} tabIndex={tabIndex || 0}>
       <div className={classes.canvasContainer}>
         <canvas height={chartHeight || 300} ref={inputEl} />
       </div>
       {legendRendered && legendRows && (
         <div className={classes.container}>
           <Table
-            aria-label="Stats and metrics"
+            aria-label={ariaLabel || 'Stats and metrics'}
             className={classes.root}
             noBorder
           >

--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -285,6 +285,8 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
   });
 
   return (
+    // Allow `tabIndex` on `<div>` because it represents an interactive element.
+    // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
     <div
       className={classes.wrapper}
       tabIndex={tabIndex || 0}

--- a/packages/manager/src/components/LongviewLineGraph/LongviewLineGraph.tsx
+++ b/packages/manager/src/components/LongviewLineGraph/LongviewLineGraph.tsx
@@ -31,6 +31,7 @@ export interface Props extends LineGraphProps {
   subtitle?: string;
   error?: string;
   loading?: boolean;
+  ariaLabel?: string;
 }
 
 type CombinedProps = Props;
@@ -38,7 +39,7 @@ type CombinedProps = Props;
 const LongviewLineGraph: React.FC<CombinedProps> = (props) => {
   const classes = useStyles();
 
-  const { error, loading, title, subtitle, ...rest } = props;
+  const { error, loading, title, subtitle, ariaLabel, ...rest } = props;
 
   const message = error // Error state is separate, don't want to put text on top of it
     ? undefined
@@ -65,7 +66,7 @@ const LongviewLineGraph: React.FC<CombinedProps> = (props) => {
             <ErrorState errorText={error} />
           </div>
         ) : (
-          <LineGraph {...rest} />
+          <LineGraph {...rest} ariaLabel={ariaLabel} />
         )}
         {message && <div className={classes.message}>{message}</div>}
       </div>

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Apache/ApacheGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Apache/ApacheGraphs.tsx
@@ -112,6 +112,7 @@ export const ApacheGraphs: React.FC<CombinedProps> = (props) => {
           <LongviewLineGraph
             title="Requests"
             subtitle="requests/s"
+            ariaLabel="Requests Per Second Graph"
             data={[
               {
                 label: 'Requests',
@@ -130,6 +131,7 @@ export const ApacheGraphs: React.FC<CombinedProps> = (props) => {
                 title="Throughput"
                 subtitle={`${networkUnit}/s`}
                 unit={'/s'}
+                ariaLabel="Throughput Graph"
                 formatData={(value: number) =>
                   roundTo(convertNetworkToUnit(value * 8, networkUnit))
                 }
@@ -153,6 +155,7 @@ export const ApacheGraphs: React.FC<CombinedProps> = (props) => {
             <Grid item xs={12} sm={6} className={classes.smallGraph}>
               <LongviewLineGraph
                 title="Workers"
+                ariaLabel="Workers Graph"
                 data={[
                   {
                     label: 'Waiting',

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Disks/Graphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Disks/Graphs.tsx
@@ -117,6 +117,7 @@ const Graphs: React.FC<CombinedProps> = (props) => {
                 },
               ]}
               title="Disk I/O"
+              ariaLabel="Disk I/O/ Graph"
               showToday={isToday}
               subtitle="ops/s"
               timezone={timezone}
@@ -145,6 +146,7 @@ const Graphs: React.FC<CombinedProps> = (props) => {
                   showToday={isToday}
                   title="Space"
                   subtitle="GB"
+                  ariaLabel="Disk Space Graph"
                   timezone={timezone}
                   nativeLegend
                   // @todo replace with byte-to-target converter after rebase
@@ -163,6 +165,7 @@ const Graphs: React.FC<CombinedProps> = (props) => {
                   ]}
                   showToday={isToday}
                   title="Inodes"
+                  ariaLabel="Inodes Graph"
                   timezone={timezone}
                   nativeLegend
                   // @todo replace with byte-to-target converter after rebase

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Disks/Graphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Disks/Graphs.tsx
@@ -117,7 +117,7 @@ const Graphs: React.FC<CombinedProps> = (props) => {
                 },
               ]}
               title="Disk I/O"
-              ariaLabel="Disk I/O/ Graph"
+              ariaLabel="Disk I/O Graph"
               showToday={isToday}
               subtitle="ops/s"
               timezone={timezone}

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/MySQL/MySQLGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/MySQL/MySQLGraphs.tsx
@@ -87,6 +87,7 @@ export const MySQLGraphs: React.FC<CombinedProps> = (props) => {
           <LongviewLineGraph
             title="Queries"
             subtitle="queries/s"
+            ariaLabel="Queries Per Second Graph"
             nativeLegend
             error={error}
             loading={loading}
@@ -127,6 +128,7 @@ export const MySQLGraphs: React.FC<CombinedProps> = (props) => {
                 title="Throughput"
                 subtitle={`${maxUnit}/s`}
                 unit={'/s'}
+                ariaLabel="Throughput Graph"
                 formatData={formatNetwork}
                 formatTooltip={formatNetworkTooltip}
                 nativeLegend
@@ -155,6 +157,7 @@ export const MySQLGraphs: React.FC<CombinedProps> = (props) => {
                 title="Connections"
                 subtitle="connections/s"
                 unit={' connections/s'}
+                ariaLabel="Connections Per Second Graph"
                 nativeLegend
                 error={error}
                 loading={loading}
@@ -177,6 +180,7 @@ export const MySQLGraphs: React.FC<CombinedProps> = (props) => {
             <Grid item xs={12} sm={6} className={classes.smallGraph}>
               <LongviewLineGraph
                 title="Slow Queries"
+                ariaLabel="Slow Queries Graph"
                 nativeLegend
                 error={error}
                 loading={loading}
@@ -195,6 +199,7 @@ export const MySQLGraphs: React.FC<CombinedProps> = (props) => {
             <Grid item xs={12} sm={6} className={classes.smallGraph}>
               <LongviewLineGraph
                 title="Aborted"
+                ariaLabel="Aborted Clients and Connections Graph"
                 nativeLegend
                 error={error}
                 loading={loading}

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/NGINX/NGINXGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/NGINX/NGINXGraphs.tsx
@@ -77,6 +77,7 @@ export const NGINXGraphs: React.FC<CombinedProps> = (props) => {
             title="Requests"
             subtitle="requests/s"
             unit=" requests/s"
+            ariaLabel="Requests Per Second Graph"
             data={[
               {
                 label: 'Requests',
@@ -95,6 +96,7 @@ export const NGINXGraphs: React.FC<CombinedProps> = (props) => {
                 title="Connections"
                 subtitle="connections/s"
                 unit=" connections/s"
+                ariaLabel="Connections Per Second Graph"
                 data={[
                   {
                     label: 'Accepted',
@@ -115,6 +117,7 @@ export const NGINXGraphs: React.FC<CombinedProps> = (props) => {
             <Grid item xs={12} sm={6} className={classes.smallGraph}>
               <LongviewLineGraph
                 title="Workers"
+                ariaLabel="Workers Graph"
                 data={[
                   {
                     label: 'Waiting',

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Network/NetworkGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Network/NetworkGraphs.tsx
@@ -84,9 +84,10 @@ export const NetworkGraphs: React.FC<CombinedProps> = (props) => {
             <div style={{ paddingTop: theme.spacing(2) }}>
               <LongviewLineGraph
                 title="Network Traffic"
-                nativeLegend
                 subtitle={maxUnit + '/s'}
                 unit={'/s'}
+                ariaLabel="Network Traffic Graph"
+                nativeLegend
                 formatData={(value: number) =>
                   convertNetworkToUnit(value * 8, maxUnit)
                 }

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/CPUGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/CPUGraph.tsx
@@ -50,6 +50,7 @@ export const CPUGraph: React.FC<CombinedProps> = (props) => {
       title="CPU"
       subtitle="%"
       unit="%"
+      ariaLabel="CPU Usage Graph"
       nativeLegend
       error={error}
       loading={loading}

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/DiskGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/DiskGraph.tsx
@@ -53,6 +53,7 @@ export const DiskGraph: React.FC<CombinedProps> = (props) => {
       loading={loading}
       subtitle={'ops/second'}
       unit={' ops/second'}
+      ariaLabel="Disk I/O Graph"
       showToday={isToday}
       timezone={timezone}
       nativeLegend

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/LoadGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/LoadGraph.tsx
@@ -36,6 +36,7 @@ export const LoadGraph: React.FC<CombinedProps> = (props) => {
     <LongviewLineGraph
       title="Load"
       subtitle="Target < 1.00"
+      ariaLabel="Load Graph"
       error={error}
       loading={loading}
       showToday={isToday}

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/MemoryGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/MemoryGraph.tsx
@@ -60,6 +60,7 @@ export const MemoryGraph: React.FC<CombinedProps> = (props) => {
     <LongviewLineGraph
       title="Memory"
       subtitle={unit}
+      ariaLabel="Memory Usage Graph"
       formatData={(value: number) => convertBytesToTarget(unit, value)}
       formatTooltip={(value: number) => readableBytes(value).formatted}
       error={error}

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/NetworkGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/NetworkGraph.tsx
@@ -56,6 +56,7 @@ export const NetworkGraph: React.FC<CombinedProps> = (props) => {
       title="Network"
       subtitle={maxUnit + '/s'}
       unit={'/s'}
+      ariaLabel="Network Usage Graph"
       formatData={formatNetwork}
       formatTooltip={formatNetworkTooltip}
       error={error}

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ProcessGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ProcessGraphs.tsx
@@ -84,6 +84,7 @@ export const ProcessGraphs: React.FC<CombinedProps> = (props) => {
               title="CPU"
               subtitle={'%'}
               unit="%"
+              ariaLabel="CPU Usage Graph"
               data={[
                 {
                   label: 'CPU',
@@ -99,6 +100,7 @@ export const ProcessGraphs: React.FC<CombinedProps> = (props) => {
             <LongviewLineGraph
               title="RAM"
               subtitle={memoryUnit}
+              ariaLabel="RAM Usage Graph"
               formatData={(value: number) =>
                 convertBytesToTarget(memoryUnit, value)
               }
@@ -123,6 +125,7 @@ export const ProcessGraphs: React.FC<CombinedProps> = (props) => {
               title="Disk I/O"
               subtitle={`${diskUnit}/s`}
               unit={`/s`}
+              ariaLabel="Disk I/O Graph"
               formatData={(value: number) =>
                 convertBytesToTarget(diskUnit, value)
               }
@@ -147,6 +150,7 @@ export const ProcessGraphs: React.FC<CombinedProps> = (props) => {
           <Grid item xs={12} sm={6} className={classes.smallGraph}>
             <LongviewLineGraph
               title="Process Count"
+              ariaLabel="Process Count Graph"
               suggestedMax={maxProcessCount}
               data={[
                 {

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Processes/ProcessesGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Processes/ProcessesGraphs.tsx
@@ -118,6 +118,7 @@ const ProcessesGraphs: React.FC<CombinedProps> = (props) => {
           title="CPU"
           subtitle="%"
           unit="%"
+          ariaLabel="CPU Usage Graph"
           data={[
             {
               data: _convertData(cpu, start, end),
@@ -132,6 +133,7 @@ const ProcessesGraphs: React.FC<CombinedProps> = (props) => {
           <LongviewLineGraph
             title="RAM"
             subtitle={memUnit}
+            ariaLabel="RAM Usage Graph"
             formatData={(value: number) => convertBytesToTarget(memUnit, value)}
             formatTooltip={(value: number) => readableBytes(value).formatted}
             data={[
@@ -149,6 +151,7 @@ const ProcessesGraphs: React.FC<CombinedProps> = (props) => {
           <LongviewLineGraph
             title="Count"
             suggestedMax={10}
+            ariaLabel="Process Count Graph"
             data={[
               {
                 data: _convertData(count, start, end, formatCount),
@@ -165,6 +168,7 @@ const ProcessesGraphs: React.FC<CombinedProps> = (props) => {
             title="Disk I/O"
             subtitle={ioUnit + '/s'}
             unit={'/s'}
+            ariaLabel="Disk I/O Graph"
             formatData={(value: number) => convertBytesToTarget(ioUnit, value)}
             formatTooltip={(value: number) => readableBytes(value).formatted}
             nativeLegend

--- a/packages/manager/src/features/Managed/ManagedDashboardCard/ManagedChartPanel.tsx
+++ b/packages/manager/src/features/Managed/ManagedDashboardCard/ManagedChartPanel.tsx
@@ -127,6 +127,7 @@ const createTabs = (
             <div>{summaryCopy}</div>
             <div className={classes.canvasContainer}>
               <LineGraph
+                ariaLabel="CPU Usage Graph"
                 timezone={timezone}
                 chartHeight={chartHeight}
                 showToday={true}
@@ -152,6 +153,7 @@ const createTabs = (
             <div>{summaryCopy}</div>
             <div className={classes.canvasContainer}>
               <LineGraph
+                ariaLabel="Network Transfer Graph"
                 timezone={timezone}
                 chartHeight={chartHeight}
                 showToday={true}
@@ -187,6 +189,7 @@ const createTabs = (
             <div>{summaryCopy}</div>
             <div className={classes.canvasContainer}>
               <LineGraph
+                ariaLabel="Disk I/O Graph"
                 timezone={timezone}
                 chartHeight={chartHeight}
                 showToday={true}

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
@@ -136,6 +136,7 @@ const TablesPanel: React.FC<Props> = ({ nodeBalancer }) => {
       <React.Fragment>
         <div className={classes.chart}>
           <LineGraph
+            ariaLabel="Connections Graph"
             timezone={timezone}
             showToday={true}
             data={[
@@ -207,6 +208,7 @@ const TablesPanel: React.FC<Props> = ({ nodeBalancer }) => {
       <React.Fragment>
         <div className={classes.chart}>
           <LineGraph
+            ariaLabel="Traffic Graph"
             timezone={timezone}
             showToday={true}
             data={[

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/TransferHistory.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/TransferHistory.tsx
@@ -141,6 +141,8 @@ export const TransferHistory: React.FC<Props> = (props) => {
     ? getAPIErrorOrDefault(statsError, 'Unable to load stats.')[0].reason
     : null;
 
+  const graphAriaLabel = `Network Transfer History Graph for ${humanizedDate}`;
+
   const renderStatsGraph = () => {
     if (statsLoading) {
       return (
@@ -169,6 +171,8 @@ export const TransferHistory: React.FC<Props> = (props) => {
 
     return (
       <LineGraph
+        ariaLabel={graphAriaLabel}
+        tabIndex={-1}
         timezone={profile?.timezone ?? 'UTC'}
         chartHeight={190}
         unit={`/s`}
@@ -188,7 +192,9 @@ export const TransferHistory: React.FC<Props> = (props) => {
   };
 
   return (
-    <>
+    // Allow `tabIndex` on `<div>` because it represents an interactive element.
+    // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+    <div tabIndex={0} role="graphics-document" aria-label={graphAriaLabel}>
       <Box
         display="flex"
         flexDirection="row"
@@ -237,7 +243,7 @@ export const TransferHistory: React.FC<Props> = (props) => {
         </Box>
       </Box>
       {renderStatsGraph()}
-    </>
+    </div>
   );
 };
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -161,6 +161,7 @@ const LinodeSummary: React.FC<Props> = (props) => {
 
     return (
       <LineGraph
+        ariaLabel="CPU Usage Graph"
         timezone={timezone}
         chartHeight={chartHeight}
         showToday={rangeSelection === '24'}
@@ -192,6 +193,7 @@ const LinodeSummary: React.FC<Props> = (props) => {
 
     return (
       <LineGraph
+        ariaLabel="Disk IO Graph"
         timezone={timezone}
         chartHeight={chartHeight}
         showToday={rangeSelection === '24'}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraphs.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraphs.tsx
@@ -173,6 +173,7 @@ export const NetworkGraphs: React.FC<Props> = (props) => {
           title={`Network — IPv4 (${v4Unit}/s)`}
           renderBody={() => (
             <Graph
+              ariaLabel="IPv4 Network Traffic Graph"
               data={v4Data}
               unit={v4Unit}
               totalTraffic={v4totalTraffic}
@@ -188,6 +189,7 @@ export const NetworkGraphs: React.FC<Props> = (props) => {
           title={`Network — IPv6 (${v6Unit}/s)`}
           renderBody={() => (
             <Graph
+              ariaLabel="IPv6 Network Traffic Graph"
               data={v6Data}
               unit={v6Unit}
               totalTraffic={v6totalTraffic}
@@ -203,6 +205,7 @@ export const NetworkGraphs: React.FC<Props> = (props) => {
 };
 
 interface GraphProps {
+  ariaLabel: string;
   timezone: string;
   data: NetworkStats;
   unit: string;
@@ -215,6 +218,7 @@ interface GraphProps {
 
 const Graph: React.FC<GraphProps> = (props) => {
   const {
+    ariaLabel,
     chartHeight,
     data,
     metrics,
@@ -248,6 +252,7 @@ const Graph: React.FC<GraphProps> = (props) => {
 
   return (
     <LineGraph
+      ariaLabel={ariaLabel}
       timezone={timezone}
       chartHeight={chartHeight}
       unit={`/s`}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1281,7 +1281,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.0", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.0", "@babel/runtime@^7.15.4", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.17.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.2.tgz#66f68591605e59da47523c631416b18508779941"
   integrity sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==
@@ -1299,6 +1299,13 @@
   version "7.18.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.0.tgz#6d77142a19cb6088f0af662af1ada37a604d34ae"
   integrity sha512-YMQvx/6nKEaucl0MY56mwIG483xk8SDNdlUwb2Ts6FUpr7fm85DxEmsY18LXBNhcTz6tO6JwZV8w1W06v8UKeg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.18.9":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.0.tgz#22b11c037b094d27a8a2504ea4dcff00f50e2259"
+  integrity sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -5069,6 +5076,17 @@ array-includes@^3.0.3, array-includes@^3.1.3, array-includes@^3.1.4:
     get-intrinsic "^1.1.1"
     is-string "^1.0.7"
 
+array-includes@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.5.tgz#2c320010db8d31031fd2a5f6b3bbd4b1aad31bdb"
+  integrity sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.19.5"
+    get-intrinsic "^1.1.1"
+    is-string "^1.0.7"
+
 array-union@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
@@ -5272,7 +5290,7 @@ axe-core@^3.5.1, axe-core@^3.5.5:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.5.6.tgz#e762a90d7f6dbd244ceacb4e72760ff8aad521b5"
   integrity sha512-LEUDjgmdJoA3LqklSTwKYqkjcZ4HKc4ddIYGSAiSkr46NTjzg2L9RNB+lekO9P7Dlpa87+hBtzc2Fzn/+GUWMQ==
 
-axe-core@^4.3.5:
+axe-core@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.3.tgz#11c74d23d5013c0fa5d183796729bc3482bd2f6f"
   integrity sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==
@@ -7278,7 +7296,7 @@ d@1, d@^1.0.1:
     es5-ext "^0.10.50"
     type "^1.0.1"
 
-damerau-levenshtein@^1.0.7:
+damerau-levenshtein@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz#b43d286ccbd36bc5b2f7ed41caf2d0aba1f8a6e7"
   integrity sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==
@@ -7409,6 +7427,14 @@ define-properties@^1.1.2, define-properties@^1.1.3:
   integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
   dependencies:
     object-keys "^1.0.12"
+
+define-properties@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.4.tgz#0b14d7bd7fbeb2f3572c3a7eda80ea5d57fb05b1"
+  integrity sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==
+  dependencies:
+    has-property-descriptors "^1.0.0"
+    object-keys "^1.1.1"
 
 define-property@^0.2.5:
   version "0.2.5"
@@ -8008,6 +8034,35 @@ es-abstract@^1.17.2, es-abstract@^1.19.0, es-abstract@^1.19.1:
     string.prototype.trimstart "^1.0.4"
     unbox-primitive "^1.0.1"
 
+es-abstract@^1.19.5:
+  version "1.20.2"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.20.2.tgz#8495a07bc56d342a3b8ea3ab01bd986700c2ccb3"
+  integrity sha512-XxXQuVNrySBNlEkTYJoDNFe5+s2yIOpzq80sUHEdPdQr0S5nTLz4ZPPPswNIpKseDDUS5yghX1gfLIHQZ1iNuQ==
+  dependencies:
+    call-bind "^1.0.2"
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    function.prototype.name "^1.1.5"
+    get-intrinsic "^1.1.2"
+    get-symbol-description "^1.0.0"
+    has "^1.0.3"
+    has-property-descriptors "^1.0.0"
+    has-symbols "^1.0.3"
+    internal-slot "^1.0.3"
+    is-callable "^1.2.4"
+    is-negative-zero "^2.0.2"
+    is-regex "^1.1.4"
+    is-shared-array-buffer "^1.0.2"
+    is-string "^1.0.7"
+    is-weakref "^1.0.2"
+    object-inspect "^1.12.2"
+    object-keys "^1.1.1"
+    object.assign "^4.1.4"
+    regexp.prototype.flags "^1.4.3"
+    string.prototype.trimend "^1.0.5"
+    string.prototype.trimstart "^1.0.5"
+    unbox-primitive "^1.0.2"
+
 es-array-method-boxes-properly@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz#873f3e84418de4ee19c5be752990b2e44718d09e"
@@ -8415,23 +8470,24 @@ eslint-plugin-jest@^23.8.2:
   dependencies:
     "@typescript-eslint/experimental-utils" "^2.5.0"
 
-eslint-plugin-jsx-a11y@^6.2.3:
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.5.1.tgz#cdbf2df901040ca140b6ec14715c988889c2a6d8"
-  integrity sha512-sVCFKX9fllURnXT2JwLN5Qgo24Ug5NF6dxhkmxsMEUZhXRcGg+X3e1JbJ84YePQKBl5E0ZjAH5Q4rkdcGY99+g==
+eslint-plugin-jsx-a11y@^6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.6.1.tgz#93736fc91b83fdc38cc8d115deedfc3091aef1ff"
+  integrity sha512-sXgFVNHiWffBq23uiS/JaP6eVR622DqwB4yTzKvGZGcPq6/yZ3WmOZfuBks/vHWo9GaFOqC2ZK4i6+C35knx7Q==
   dependencies:
-    "@babel/runtime" "^7.16.3"
+    "@babel/runtime" "^7.18.9"
     aria-query "^4.2.2"
-    array-includes "^3.1.4"
+    array-includes "^3.1.5"
     ast-types-flow "^0.0.7"
-    axe-core "^4.3.5"
+    axe-core "^4.4.3"
     axobject-query "^2.2.0"
-    damerau-levenshtein "^1.0.7"
+    damerau-levenshtein "^1.0.8"
     emoji-regex "^9.2.2"
     has "^1.0.3"
-    jsx-ast-utils "^3.2.1"
+    jsx-ast-utils "^3.3.2"
     language-tags "^1.0.5"
-    minimatch "^3.0.4"
+    minimatch "^3.1.2"
+    semver "^6.3.0"
 
 eslint-plugin-node@^11.0.0:
   version "11.1.0"
@@ -9523,7 +9579,7 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
-function.prototype.name@^1.1.0, function.prototype.name@^1.1.2, function.prototype.name@^1.1.3:
+function.prototype.name@^1.1.0, function.prototype.name@^1.1.2, function.prototype.name@^1.1.3, function.prototype.name@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.5.tgz#cce0505fe1ffb80503e6f9e46cc64e46a12a9621"
   integrity sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==
@@ -9581,6 +9637,15 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
     function-bind "^1.1.1"
     has "^1.0.3"
     has-symbols "^1.0.1"
+
+get-intrinsic@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.3.tgz#063c84329ad93e83893c7f4f243ef63ffa351385"
+  integrity sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.3"
 
 get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.2"
@@ -9854,6 +9919,11 @@ has-bigints@^1.0.1:
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.1.tgz#64fe6acb020673e3b78db035a5af69aa9d07b113"
   integrity sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==
 
+has-bigints@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
+  integrity sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==
+
 has-flag@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
@@ -9876,10 +9946,22 @@ has-glob@^1.0.0:
   dependencies:
     is-glob "^3.0.0"
 
+has-property-descriptors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz#610708600606d36961ed04c196193b6a607fa861"
+  integrity sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==
+  dependencies:
+    get-intrinsic "^1.1.1"
+
 has-symbols@^1.0.1, has-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
   integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
+
+has-symbols@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
+  integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
 
 has-tostringtag@^1.0.0:
   version "1.0.0"
@@ -10795,7 +10877,7 @@ is-map@^2.0.2:
   resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.2.tgz#00922db8c9bf73e81b7a335827bc2a43f2b91127"
   integrity sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==
 
-is-negative-zero@^2.0.1:
+is-negative-zero@^2.0.1, is-negative-zero@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.2.tgz#7bf6f03a28003b8b3965de3ac26f664d765f3150"
   integrity sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==
@@ -10916,6 +10998,13 @@ is-shared-array-buffer@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz#97b0c85fbdacb59c9c446fe653b82cf2b5b7cfe6"
   integrity sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==
 
+is-shared-array-buffer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz#8f259c573b60b6a32d4058a1a07430c0a7344c79"
+  integrity sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==
+  dependencies:
+    call-bind "^1.0.2"
+
 is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
@@ -10960,7 +11049,7 @@ is-utf8@^0.2.0:
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
   integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
 
-is-weakref@^1.0.1:
+is-weakref@^1.0.1, is-weakref@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.0.2.tgz#9529f383a9338205e89765e0392efc2f100f06f2"
   integrity sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==
@@ -11835,13 +11924,21 @@ jss@10.9.0, jss@^10.5.1:
     is-in-browser "^1.1.3"
     tiny-warning "^1.0.2"
 
-"jsx-ast-utils@^2.4.1 || ^3.0.0", jsx-ast-utils@^3.2.1:
+"jsx-ast-utils@^2.4.1 || ^3.0.0":
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.2.1.tgz#720b97bfe7d901b927d87c3773637ae8ea48781b"
   integrity sha512-uP5vu8xfy2F9A6LGC22KO7e2/vGTS1MhP+18f++ZNlf0Ohaxbc9nIEwHAsejlJKyzfZzU5UIhe5ItYkitcZnZA==
   dependencies:
     array-includes "^3.1.3"
     object.assign "^4.1.2"
+
+jsx-ast-utils@^3.3.2:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz#76b3e6e6cece5c69d49a5792c3d01bd1a0cdc7ea"
+  integrity sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==
+  dependencies:
+    array-includes "^3.1.5"
+    object.assign "^4.1.3"
 
 junk@^3.1.0:
   version "3.1.0"
@@ -12773,6 +12870,13 @@ minimatch@^3.0.2, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  dependencies:
+    brace-expansion "^1.1.7"
+
 minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
@@ -13262,6 +13366,11 @@ object-inspect@^1.11.0, object-inspect@^1.7.0, object-inspect@^1.9.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.0.tgz#6e2c120e868fd1fd18cb4f18c31741d0d6e776f0"
   integrity sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==
 
+object-inspect@^1.12.2:
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.2.tgz#c0641f26394532f28ab8d796ab954e43c009a8ea"
+  integrity sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==
+
 object-is@^1.0.1, object-is@^1.0.2, object-is@^1.1.2:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.5.tgz#b9deeaa5fc7f1846a0faecdceec138e5778f53ac"
@@ -13290,6 +13399,16 @@ object.assign@^4.1.0, object.assign@^4.1.2:
     call-bind "^1.0.0"
     define-properties "^1.1.3"
     has-symbols "^1.0.1"
+    object-keys "^1.1.1"
+
+object.assign@^4.1.3, object.assign@^4.1.4:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.4.tgz#9673c7c7c351ab8c4d0b516f4343ebf4dfb7799f"
+  integrity sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    has-symbols "^1.0.3"
     object-keys "^1.1.1"
 
 object.entries@^1.1.0, object.entries@^1.1.1, object.entries@^1.1.2, object.entries@^1.1.5:
@@ -15028,6 +15147,15 @@ regexp.prototype.flags@^1.2.0, regexp.prototype.flags@^1.3.1:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
 
+regexp.prototype.flags@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz#87cab30f80f66660181a3bb7bf5981a872b367ac"
+  integrity sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    functions-have-names "^1.2.2"
+
 regexpp@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
@@ -16332,6 +16460,15 @@ string.prototype.trimend@^1.0.4:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
 
+string.prototype.trimend@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz#914a65baaab25fbdd4ee291ca7dde57e869cb8d0"
+  integrity sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.19.5"
+
 string.prototype.trimstart@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz#b36399af4ab2999b4c9c648bd7a3fb2bb26feeed"
@@ -16339,6 +16476,15 @@ string.prototype.trimstart@^1.0.4:
   dependencies:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
+
+string.prototype.trimstart@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz#5466d93ba58cfa2134839f81d7f42437e8c01fef"
+  integrity sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.19.5"
 
 string_decoder@^1.0.0, string_decoder@^1.1.1:
   version "1.3.0"
@@ -17168,6 +17314,16 @@ unbox-primitive@^1.0.1:
     function-bind "^1.1.1"
     has-bigints "^1.0.1"
     has-symbols "^1.0.2"
+    which-boxed-primitive "^1.0.2"
+
+unbox-primitive@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.2.tgz#29032021057d5e6cdbd08c5129c226dff8ed6f9e"
+  integrity sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==
+  dependencies:
+    call-bind "^1.0.2"
+    has-bigints "^1.0.2"
+    has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
 
 unfetch@^4.2.0:


### PR DESCRIPTION
## Description

**What does this PR do?**
This improves screen reader accessibility for graphs used throughout Cloud Manager. It accomplishes this by making these changes:

* Graphs can be focused via keyboard navigation
* Graphs now have the `graphics-document` ARIA role. This is still technically a [WAI proposal](https://www.w3.org/TR/graphics-aria-1.0/), but has wide support among browsers and assistive tech.
    * `eslint-plugin-jsx-a11y` doesn't yet recognize this role and related roles, but it seems like support will be added in an upcoming release
* Each graph has an ARIA label describing its purpose

For now, the actual contents of the graphs are still inaccessible to screen readers and other assistive tech -- we have another ticket to improve that aspect later.

## How to test

**What are the steps to reproduce the issue or verify the changes?**
* Open Cloud Manager and go to a page that has graphs
    * If you don't have any resources on your account with graphs, the easiest thing to do is to create a Linode and wait a few minutes for the graphs to show up
* Confirm that graphs continue to behave as expected
* Confirm that graphs can be focused via keyboard navigation with tab
* [Enable VoiceOver](https://support.apple.com/guide/voiceover/turn-voiceover-on-or-off-vo2682/mac), confirm that graphs are announced as expected when navigating the page