### PR TITLE
M3-5903: Add ARIA labels for network transfer history previous/next buttons

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/TransferHistory.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/TransferHistory.test.tsx
@@ -39,30 +39,60 @@ describe('combineGraphData', () => {
 
 const now = DateTime.fromISO('2020-07-01T12:00:00');
 
-describe('getYearAndMonthFromOffset', () => {
-  it('returns the current year and month with an offset is 0', () => {
-    const { year, month, humanizedDate } = parseMonthOffset(0, now);
+describe('parseMonthOffset', () => {
+  it('returns the current year and month with an offset of 0', () => {
+    const { year, month, humanizedDate, longHumanizedDate } = parseMonthOffset(
+      0,
+      now
+    );
     expect(year).toBe('2020');
     expect(month).toBe('07');
     expect(humanizedDate).toBe('Last 30 Days');
+    expect(longHumanizedDate).toBe('Last 30 Days');
   });
 
-  it('correctly adjusts the month based on the offset', () => {
-    const { year, month, humanizedDate } = parseMonthOffset(-1, now);
+  it('correctly adjusts the month with a negative offset', () => {
+    const { year, month, humanizedDate, longHumanizedDate } = parseMonthOffset(
+      -1,
+      now
+    );
     expect(year).toBe('2020');
     expect(month).toBe('06');
     expect(humanizedDate).toBe('Jun 2020');
+    expect(longHumanizedDate).toBe('June 2020');
   });
 
-  it('correctly adjusts the year', () => {
-    const { year, month, humanizedDate } = parseMonthOffset(-7, now);
+  it('correctly adjusts the year with a negative offset', () => {
+    const { year, month, humanizedDate, longHumanizedDate } = parseMonthOffset(
+      -7,
+      now
+    );
     expect(year).toBe('2019');
     expect(month).toBe('12');
     expect(humanizedDate).toBe('Dec 2019');
+    expect(longHumanizedDate).toBe('December 2019');
   });
 
-  it('throws an error if offset is > 0', () => {
-    expect(() => parseMonthOffset(1, now)).toThrowError();
+  it('correctly adjusts the month with a positive offset', () => {
+    const { year, month, humanizedDate, longHumanizedDate } = parseMonthOffset(
+      2,
+      now
+    );
+    expect(year).toBe('2020');
+    expect(month).toBe('09');
+    expect(humanizedDate).toBe('Sep 2020');
+    expect(longHumanizedDate).toBe('September 2020');
+  });
+
+  it('correctly adjusts the year with a positive offset', () => {
+    const { year, month, humanizedDate, longHumanizedDate } = parseMonthOffset(
+      9,
+      now
+    );
+    expect(year).toBe('2021');
+    expect(month).toBe('04');
+    expect(humanizedDate).toBe('Apr 2021');
+    expect(longHumanizedDate).toBe('April 2021');
   });
 });
 


### PR DESCRIPTION
## Description

**What does this PR do?**

- Adds ARIA labels to the previous/next buttons on the Network Transfer History graph shown on the "Network" tab of the Linode details page
    - The labels are formatted _Show network transfer history for \<Month\> \<Year\>_, or _Show network transfer history for last 30 days_ (whichever is applicable) -- very open to feedback for this language
- Disables the previous and next buttons when there is no data left to navigate to
    - We already apply a disabled class to the buttons in these situations, this change just makes it apparent to screen reader users that the buttons are disabled
- Modifies a utility function and updates tests accordingly

## How to test

**What are the steps to reproduce the issue or verify the changes?**
To verify button ARIA label and disabled state:
1. Enable mock service workers, and navigate to a Linode details page "Network" tab
2. Confirm that the Network Transfer History graph previous button has an ARIA label that reads _Show network transfer history for \<Previous Month\> \<Previous Year\>_
3. Confirm that the Network Transfer History graph previous button is enabled, except when you navigate all the way back to the end of the history (January 2020)
4. Confirm that the Network Transfer History graph next button has an ARIA label that reads _Show network transfer history for \<Next Month\> \<Next Year\>_
5. Confirm that the Network Transfer History graph next button is disabled only when the most recent data is shown on the graph
6. (Optional) [Enable VoiceOver](https://support.apple.com/guide/voiceover/turn-voiceover-on-or-off-vo2682/mac), navigate to Network Transfer History buttons, verify that VoiceOver/keyboard navigation works as expected and has a good UX
    * In my experience, these changes make it so users navigating using keyboard + screen reader cannot focus the previous or next button if it is disabled. If the user has either button focused and then navigates to a point where the button becomes disabled, the button will remain focused but the user cannot click it (the screen reader reports "Dimmed" in this case).

**How do I run relevant unit tests?**
```
yarn test TransferHistory.test
```