### PR TITLE
M3-5935: Fix MUI v5 UI Issues

### DIFF
--- a/packages/manager/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/manager/src/components/ActionMenu/ActionMenu.tsx
@@ -64,7 +64,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     '&[data-reach-menu-item]': {
       display: 'flex',
       justifyContent: 'space-between',
-      padding: theme.spacing(1) + 2,
+      padding: theme.spacing(1.25),
       paddingLeft: '16px',
       borderBottom: '1px solid #5294e0',
       background: '#3683dc',

--- a/packages/manager/src/components/EnhancedSelect/components/SelectControl.tsx
+++ b/packages/manager/src/components/EnhancedSelect/components/SelectControl.tsx
@@ -3,15 +3,6 @@ import { ControlProps } from 'react-select';
 
 import TextField from 'src/components/TextField';
 
-interface SelectProps {
-  inputRef: any;
-  props: any;
-}
-
-const inputComponent: React.FC<SelectProps> = ({ inputRef, ...props }) => {
-  return <div ref={inputRef} {...props} />;
-};
-
 interface Props extends ControlProps<any, any> {}
 
 const SelectControl: React.FC<Props> = (props) => {
@@ -24,10 +15,10 @@ const SelectControl: React.FC<Props> = (props) => {
       }
       fullWidth
       InputProps={{
-        inputComponent,
+        inputComponent: 'div',
         inputProps: {
           className: props.selectProps.classes.input,
-          inputRef: props.innerRef,
+          ref: props.innerRef,
           children: props.children,
           ...props.innerProps,
         },

--- a/packages/manager/src/components/HighlightedMarkdown/__snapshots__/HighlightedMarkdown.test.tsx.snap
+++ b/packages/manager/src/components/HighlightedMarkdown/__snapshots__/HighlightedMarkdown.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`HighlightedMarkdown component should highlight text consistently 1`] = `
 <DocumentFragment>
   <p
-    class="MuiTypography-root MuiTypography-body1 makeStyles-root-1 formatted-text css-1snniac-MuiTypography-root"
+    class="MuiTypography-root MuiTypography-body1 makeStyles-root-1 formatted-text css-b9iv27-MuiTypography-root"
   />
   <h1>
     Some markdown

--- a/packages/manager/src/components/TextField.tsx
+++ b/packages/manager/src/components/TextField.tsx
@@ -268,6 +268,7 @@ export const LinodeTextField: React.FC<CombinedProps> = (props) => {
         <TextField
           {...textFieldProps}
           {...dataAttrs}
+          variant="standard"
           error={!!error || !!errorText}
           /**
            * Set _helperText_ and _label_ to no value because we want to

--- a/packages/manager/src/components/core/Divider.tsx
+++ b/packages/manager/src/components/core/Divider.tsx
@@ -1,21 +1,14 @@
-import Divider, {
-  DividerProps as _DividerProps,
-} from '@mui/material/Divider';
+import Divider, { DividerProps as _DividerProps } from '@mui/material/Divider';
 import classNames from 'classnames';
 import * as React from 'react';
 import { makeStyles, Theme } from 'src/components/core/styles';
 
 const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    backgroundColor: theme.borderColors.divider,
-    marginTop: theme.spacing(),
-    marginBottom: theme.spacing(),
-  },
   light: {
-    backgroundColor: theme.name === 'lightTheme' ? '#e3e5e8' : '#2e3238',
+    borderColor: theme.name === 'lightTheme' ? '#e3e5e8' : '#2e3238',
   },
   dark: {
-    backgroundColor: theme.color.border2,
+    borderColor: theme.color.border2,
   },
 }));
 
@@ -36,7 +29,6 @@ const _Divider: React.FC<Props> = (props) => {
   return (
     <Divider
       className={classNames({
-        [classes.root]: true,
         [classes.dark]: dark,
         [classes.light]: light,
       })}

--- a/packages/manager/src/components/core/Grid.ts
+++ b/packages/manager/src/components/core/Grid.ts
@@ -1,6 +1,0 @@
-import Grid, { GridProps as _GridProps } from '@mui/material/Grid';
-
-/* tslint:disable-next-line:no-empty-interface */
-export interface GridProps extends _GridProps {}
-
-export default Grid;

--- a/packages/manager/src/components/core/Grid.tsx
+++ b/packages/manager/src/components/core/Grid.tsx
@@ -1,5 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
 // A grid component using the following libs as inspiration.
 //
 // For the implementation:
@@ -202,7 +200,7 @@ export const styles = (theme: Theme) => ({
 });
 
 const Grid = React.forwardRef<any, GridProps>(function Grid(
-  props: GridProps,
+  props: GridProps & { classes: any },
   ref
 ) {
   const {
@@ -249,10 +247,14 @@ const Grid = React.forwardRef<any, GridProps>(function Grid(
     classNameProp
   );
 
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore 😣
   return <div className={className} ref={ref} {...other} />;
 });
 
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore 😣
 const StyledGrid = withStyles(styles, { name: 'MuiGrid' })(Grid);
 
-export default StyledGrid;
 export { GridProps };
+export default StyledGrid;

--- a/packages/manager/src/components/core/Grid.tsx
+++ b/packages/manager/src/components/core/Grid.tsx
@@ -13,7 +13,7 @@ import * as React from 'react';
 import clsx from 'clsx';
 import { Theme, withStyles } from './styles';
 import { Breakpoint } from '@mui/material';
-import { GridProps } from '@mui/material/Grid';
+import type { GridProps } from '@mui/material/Grid';
 
 const SPACINGS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 const GRID_SIZES = ['auto', true, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];

--- a/packages/manager/src/components/core/Grid.tsx
+++ b/packages/manager/src/components/core/Grid.tsx
@@ -14,11 +14,12 @@ import clsx from 'clsx';
 import { Theme, withStyles } from './styles';
 import { Breakpoint } from '@mui/material';
 import type { GridProps } from '@mui/material/Grid';
+import { breakpoints } from 'src/themeFactory';
 
 const SPACINGS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 const GRID_SIZES = ['auto', true, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
 
-function generateGrid(globalStyles: any, theme: Theme, breakpoint: Breakpoint) {
+function generateGrid(globalStyles: any, breakpoint: Breakpoint) {
   const styles = {};
 
   GRID_SIZES.forEach((size) => {
@@ -59,7 +60,7 @@ function generateGrid(globalStyles: any, theme: Theme, breakpoint: Breakpoint) {
   if (breakpoint === 'xs') {
     Object.assign(globalStyles, styles);
   } else {
-    globalStyles[theme.breakpoints.up(breakpoint)] = styles;
+    globalStyles[breakpoints.up(breakpoint)] = styles;
   }
 }
 
@@ -68,7 +69,7 @@ function getOffset(val: number, div = 1) {
   return `${parse / div}${String(val).replace(String(parse), '') || 'px'}`;
 }
 
-function generateGutter(theme: Theme, breakpoint: Breakpoint) {
+function generateGutter(breakpoint: Breakpoint) {
   const styles = {};
 
   SPACINGS.forEach((spacing) => {
@@ -191,10 +192,10 @@ export const styles = (theme: Theme) => ({
   'justify-content-xs-space-evenly': {
     justifyContent: 'space-evenly',
   },
-  ...generateGutter(theme, 'xs'),
-  ...theme.breakpoints.keys.reduce((accumulator, key) => {
+  ...generateGutter('xs'),
+  ...breakpoints.keys.reduce((accumulator, key) => {
     // Use side effect over immutability for better performance.
-    generateGrid(accumulator, theme, key);
+    generateGrid(accumulator, key);
     return accumulator;
   }, {}),
 });

--- a/packages/manager/src/components/core/Grid.tsx
+++ b/packages/manager/src/components/core/Grid.tsx
@@ -1,0 +1,258 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+// A grid component using the following libs as inspiration.
+//
+// For the implementation:
+// - https://getbootstrap.com/docs/4.3/layout/grid/
+// - https://github.com/kristoferjoseph/flexboxgrid/blob/master/src/css/flexboxgrid.css
+// - https://github.com/roylee0704/react-flexbox-grid
+// - https://material.angularjs.org/latest/layout/introduction
+//
+// Follow this flexbox Guide to better understand the underlying model:
+// - https://css-tricks.com/snippets/css/a-guide-to-flexbox/
+
+import * as React from 'react';
+import clsx from 'clsx';
+import { Theme, withStyles } from './styles';
+import { Breakpoint } from '@mui/material';
+import { GridProps } from '@mui/material/Grid';
+
+const SPACINGS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+const GRID_SIZES = ['auto', true, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+
+function generateGrid(globalStyles: any, theme: Theme, breakpoint: Breakpoint) {
+  const styles = {};
+
+  GRID_SIZES.forEach((size) => {
+    const key = `grid-${breakpoint}-${size}`;
+
+    if (size === true) {
+      // For the auto layouting
+      styles[key] = {
+        flexBasis: 0,
+        flexGrow: 1,
+        maxWidth: '100%',
+      };
+      return;
+    }
+
+    if (size === 'auto') {
+      styles[key] = {
+        flexBasis: 'auto',
+        flexGrow: 0,
+        maxWidth: 'none',
+      };
+      return;
+    }
+
+    // Keep 7 significant numbers.
+    const width = `${Math.round(((size as number) / 12) * 10e7) / 10e5}%`;
+
+    // Close to the bootstrap implementation:
+    // https://github.com/twbs/bootstrap/blob/8fccaa2439e97ec72a4b7dc42ccc1f649790adb0/scss/mixins/_grid.scss#L41
+    styles[key] = {
+      flexBasis: width,
+      flexGrow: 0,
+      maxWidth: width,
+    };
+  });
+
+  // No need for a media query for the first size.
+  if (breakpoint === 'xs') {
+    Object.assign(globalStyles, styles);
+  } else {
+    globalStyles[theme.breakpoints.up(breakpoint)] = styles;
+  }
+}
+
+function getOffset(val: number, div = 1) {
+  const parse = val;
+  return `${parse / div}${String(val).replace(String(parse), '') || 'px'}`;
+}
+
+function generateGutter(theme: Theme, breakpoint: Breakpoint) {
+  const styles = {};
+
+  SPACINGS.forEach((spacing) => {
+    const themeSpacing = 8 * spacing;
+
+    if (themeSpacing === 0) {
+      return;
+    }
+
+    styles[`spacing-${breakpoint}-${spacing}`] = {
+      margin: `-${getOffset(themeSpacing, 2)}`,
+      width: `calc(100% + ${getOffset(themeSpacing)})`,
+      '& > $item': {
+        padding: getOffset(themeSpacing, 2),
+      },
+    };
+  });
+
+  return styles;
+}
+
+// Default CSS values
+// flex: '0 1 auto',
+// flexDirection: 'row',
+// alignItems: 'flex-start',
+// flexWrap: 'nowrap',
+// justifyContent: 'flex-start',
+export const styles = (theme: Theme) => ({
+  /* Styles applied to the root element. */
+  root: {},
+  /* Styles applied to the root element if `container={true}`. */
+  container: {
+    boxSizing: 'border-box',
+    display: 'flex',
+    flexWrap: 'wrap',
+    width: '100%',
+  },
+  /* Styles applied to the root element if `item={true}`. */
+  item: {
+    boxSizing: 'border-box',
+    margin: '0', // For instance, it's useful when used with a `figure` element.
+  },
+  /* Styles applied to the root element if `zeroMinWidth={true}`. */
+  zeroMinWidth: {
+    minWidth: 0,
+  },
+  /* Styles applied to the root element if `direction="column"`. */
+  'direction-xs-column': {
+    flexDirection: 'column',
+  },
+  /* Styles applied to the root element if `direction="column-reverse"`. */
+  'direction-xs-column-reverse': {
+    flexDirection: 'column-reverse',
+  },
+  /* Styles applied to the root element if `direction="row-reverse"`. */
+  'direction-xs-row-reverse': {
+    flexDirection: 'row-reverse',
+  },
+  /* Styles applied to the root element if `wrap="nowrap"`. */
+  'wrap-xs-nowrap': {
+    flexWrap: 'nowrap',
+  },
+  /* Styles applied to the root element if `wrap="reverse"`. */
+  'wrap-xs-wrap-reverse': {
+    flexWrap: 'wrap-reverse',
+  },
+  /* Styles applied to the root element if `alignItems="center"`. */
+  'align-items-xs-center': {
+    alignItems: 'center',
+  },
+  /* Styles applied to the root element if `alignItems="flex-start"`. */
+  'align-items-xs-flex-start': {
+    alignItems: 'flex-start',
+  },
+  /* Styles applied to the root element if `alignItems="flex-end"`. */
+  'align-items-xs-flex-end': {
+    alignItems: 'flex-end',
+  },
+  /* Styles applied to the root element if `alignItems="baseline"`. */
+  'align-items-xs-baseline': {
+    alignItems: 'baseline',
+  },
+  /* Styles applied to the root element if `alignContent="center"`. */
+  'align-content-xs-center': {
+    alignContent: 'center',
+  },
+  /* Styles applied to the root element if `alignContent="flex-start"`. */
+  'align-content-xs-flex-start': {
+    alignContent: 'flex-start',
+  },
+  /* Styles applied to the root element if `alignContent="flex-end"`. */
+  'align-content-xs-flex-end': {
+    alignContent: 'flex-end',
+  },
+  /* Styles applied to the root element if `alignContent="space-between"`. */
+  'align-content-xs-space-between': {
+    alignContent: 'space-between',
+  },
+  /* Styles applied to the root element if `alignContent="space-around"`. */
+  'align-content-xs-space-around': {
+    alignContent: 'space-around',
+  },
+  /* Styles applied to the root element if `justifyContent="center"`. */
+  'justify-content-xs-center': {
+    justifyContent: 'center',
+  },
+  /* Styles applied to the root element if `justifyContent="flex-end"`. */
+  'justify-content-xs-flex-end': {
+    justifyContent: 'flex-end',
+  },
+  /* Styles applied to the root element if `justifyContent="space-between"`. */
+  'justify-content-xs-space-between': {
+    justifyContent: 'space-between',
+  },
+  /* Styles applied to the root element if `justifyContent="space-around"`. */
+  'justify-content-xs-space-around': {
+    justifyContent: 'space-around',
+  },
+  /* Styles applied to the root element if `justifyContent="space-evenly"`. */
+  'justify-content-xs-space-evenly': {
+    justifyContent: 'space-evenly',
+  },
+  ...generateGutter(theme, 'xs'),
+  ...theme.breakpoints.keys.reduce((accumulator, key) => {
+    // Use side effect over immutability for better performance.
+    generateGrid(accumulator, theme, key);
+    return accumulator;
+  }, {}),
+});
+
+const Grid = React.forwardRef<any, GridProps>(function Grid(
+  props: GridProps,
+  ref
+) {
+  const {
+    alignContent = 'stretch',
+    alignItems = 'stretch',
+    classes,
+    className: classNameProp,
+    container = false,
+    direction = 'row',
+    item = false,
+    justifyContent = 'flex-start',
+    lg = false,
+    md = false,
+    sm = false,
+    spacing = 0,
+    wrap = 'wrap',
+    xl = false,
+    xs = false,
+    zeroMinWidth = false,
+    ...other
+  } = props;
+
+  const className = clsx(
+    classes.root,
+    {
+      [classes.container]: container,
+      [classes.item]: item,
+      [classes.zeroMinWidth]: zeroMinWidth,
+      [classes[`spacing-xs-${String(spacing)}`]]: container && spacing !== 0,
+      [classes[`direction-xs-${String(direction)}`]]: direction !== 'row',
+      [classes[`wrap-xs-${String(wrap)}`]]: wrap !== 'wrap',
+      [classes[`align-items-xs-${String(alignItems)}`]]:
+        alignItems !== 'stretch',
+      [classes[`align-content-xs-${String(alignContent)}`]]:
+        alignContent !== 'stretch',
+      [classes[`justify-content-xs-${String(justifyContent)}`]]:
+        justifyContent !== 'flex-start',
+      [classes[`grid-xs-${String(xs)}`]]: xs !== false,
+      [classes[`grid-sm-${String(sm)}`]]: sm !== false,
+      [classes[`grid-md-${String(md)}`]]: md !== false,
+      [classes[`grid-lg-${String(lg)}`]]: lg !== false,
+      [classes[`grid-xl-${String(xl)}`]]: xl !== false,
+    },
+    classNameProp
+  );
+
+  return <div className={className} ref={ref} {...other} />;
+});
+
+const StyledGrid = withStyles(styles, { name: 'MuiGrid' })(Grid);
+
+export default StyledGrid;
+export { GridProps };

--- a/packages/manager/src/containers/SummaryPanels.styles.ts
+++ b/packages/manager/src/containers/SummaryPanels.styles.ts
@@ -54,7 +54,7 @@ const summaryPanelStyles = (theme: Theme) =>
       marginBottom: theme.spacing(2),
     },
     summarySection: {
-      padding: theme.spacing(2) + 4,
+      padding: theme.spacing(2.5),
       marginBottom: theme.spacing(2),
       minHeight: '160px',
       height: '93%',

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -82,7 +82,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     lineHeight: '1.5rem',
   },
   activeSince: {
-    marginRight: theme.spacing() + 2,
+    marginRight: theme.spacing(1.25),
   },
   transactionType: {
     marginRight: theme.spacing(),

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallRow.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallRow.tsx
@@ -5,7 +5,6 @@ import { Link } from 'react-router-dom';
 import { compose } from 'recompose';
 import Hidden from 'src/components/core/Hidden';
 import { makeStyles, Theme } from 'src/components/core/styles';
-import Grid from 'src/components/Grid';
 import StatusIcon from 'src/components/StatusIcon';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
@@ -22,12 +21,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     '&:hover, &:focus': {
       textDecoration: 'underline',
     },
-  },
-  labelWrapper: {
-    display: 'flex',
-    flexFlow: 'row nowrap',
-    alignItems: 'center',
-    whiteSpace: 'nowrap',
   },
 }));
 
@@ -59,19 +52,9 @@ export const FirewallRow: React.FC<CombinedProps> = (props) => {
       ariaLabel={`Firewall ${label}`}
     >
       <TableCell>
-        <Grid container wrap="nowrap" alignItems="center">
-          <Grid item className="py0">
-            <div className={classes.labelWrapper}>
-              <Link
-                className={classes.link}
-                to={`/firewalls/${id}`}
-                tabIndex={0}
-              >
-                {label}
-              </Link>
-            </div>
-          </Grid>
-        </Grid>
+        <Link className={classes.link} to={`/firewalls/${id}`} tabIndex={0}>
+          {label}
+        </Link>
       </TableCell>
       <TableCell statusCell>
         <StatusIcon status={status === 'enabled' ? 'active' : 'inactive'} />

--- a/packages/manager/src/features/Kubernetes/ClusterList/ClusterRow.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/ClusterRow.tsx
@@ -4,7 +4,6 @@ import Chip from 'src/components/core/Chip';
 import Hidden from 'src/components/core/Hidden';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import DateTimeDisplay from 'src/components/DateTimeDisplay';
-import Grid from 'src/components/Grid';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import { dcDisplayNames } from 'src/constants';
@@ -20,12 +19,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     '&:hover, &:focus': {
       textDecoration: 'underline',
     },
-  },
-  labelStatusWrapper: {
-    display: 'flex',
-    flexFlow: 'row nowrap',
-    alignItems: 'center',
-    whiteSpace: 'nowrap',
   },
   clusterRow: {
     '&:before': {
@@ -66,19 +59,13 @@ export const ClusterRow: React.FunctionComponent<CombinedProps> = (props) => {
       ariaLabel={`Cluster ${cluster.label}`}
     >
       <TableCell data-qa-cluster-label>
-        <Grid container wrap="nowrap" alignItems="center">
-          <Grid item className="py0">
-            <div className={classes.labelStatusWrapper}>
-              <Link
-                className={classes.link}
-                to={`/kubernetes/clusters/${cluster.id}/summary`}
-                tabIndex={0}
-              >
-                {cluster.label}
-              </Link>
-            </div>
-          </Grid>
-        </Grid>
+        <Link
+          className={classes.link}
+          to={`/kubernetes/clusters/${cluster.id}/summary`}
+          tabIndex={0}
+        >
+          {cluster.label}
+        </Link>
       </TableCell>
       <Hidden mdDown>
         <TableCell data-qa-cluster-version>

--- a/packages/manager/src/features/Profile/AuthenticationSettings/TPAProviders.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/TPAProviders.tsx
@@ -67,6 +67,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
     '& > span': {
       display: 'inline-block',
+      width: '95%',
       color: theme.color.headline,
     },
   },
@@ -164,19 +165,25 @@ export const TPAProviders: React.FC<CombinedProps> = (props) => {
                     handleProviderChange(thisProvider.name);
                   }}
                 >
-                  <ProviderIcon className={classes.providerIcon} />
                   <Box
                     display="flex"
                     alignItems="center"
                     justifyContent="space-between"
+                    flexDirection="row"
                     className={classes.providerContent}
                   >
-                    <div>
+                    <Box
+                      display="flex"
+                      flexDirection="row"
+                      alignItems="center"
+                      flexGrow={1}
+                    >
+                      <ProviderIcon className={classes.providerIcon} />
                       {thisProvider.displayName}
                       {isProviderEnabled ? (
                         <span className={classes.enabledText}>(Enabled)</span>
                       ) : null}
-                    </div>
+                    </Box>
                     {isProviderEnabled ? <EnabledIcon /> : null}
                   </Box>
                 </Button>

--- a/packages/manager/src/features/Profile/AuthenticationSettings/TPAProviders.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/TPAProviders.tsx
@@ -52,8 +52,8 @@ const useStyles = makeStyles((theme: Theme) => ({
     backgroundColor: theme.name === 'lightTheme' ? '#f5f6f7' : '#444',
     marginTop: theme.spacing(),
     minHeight: 70,
-    paddingRight: `calc(${theme.spacing(3)} - 4)`,
-    paddingLeft: `calc(${theme.spacing(3)} - 4)`,
+    paddingRight: `calc(${theme.spacing(3)} - 4px)`,
+    paddingLeft: `calc(${theme.spacing(3)} - 4px)`,
     width: 'calc(100% - 8px)',
     [theme.breakpoints.down('md')]: {
       marginLeft: 0,
@@ -67,7 +67,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
     '& > span': {
       display: 'inline-block',
-      width: '95%',
+      width: '100%',
       color: theme.color.headline,
     },
   },

--- a/packages/manager/src/features/Profile/LishSettings/LishSettings.tsx
+++ b/packages/manager/src/features/Profile/LishSettings/LishSettings.tsx
@@ -183,7 +183,7 @@ const LishSettings: React.FC = () => {
                   onChange={onPublicKeyChange(idx)}
                   value={authorizedKeys[idx] || ''}
                   multiline
-                  rows="4"
+                  rows={1.75}
                   className={classes.keyTextarea}
                   data-qa-public-key
                 />

--- a/packages/manager/src/features/Profile/SSHKeys/SSHKeyCreationDrawer.tsx
+++ b/packages/manager/src/features/Profile/SSHKeys/SSHKeyCreationDrawer.tsx
@@ -80,7 +80,7 @@ export class SSHKeyCreationDrawer extends React.PureComponent<
           value={this.state.sshKey}
           data-qa-ssh-key-field
           multiline
-          rows={10}
+          rows={1.75}
         />
 
         <ActionsPanel>

--- a/packages/manager/src/features/Volumes/VolumeDrawer/VolumeConfigForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/VolumeConfigForm.tsx
@@ -18,7 +18,7 @@ const styles = (theme: Theme) =>
       marginTop: theme.spacing(3),
     },
     copyField: {
-      marginTop: `calc(${theme.spacing(1)} / 2`,
+      marginTop: theme.spacing(0.5),
     },
   });
 

--- a/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/AddonsPanel.tsx
@@ -37,9 +37,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   caption: {
     marginTop: -8,
-    paddingLeft: theme.spacing(2) + 18, // 34,
+    paddingLeft: `calc(${theme.spacing(2)} + 18px)`, // 34,
     [theme.breakpoints.up('md')]: {
-      paddingLeft: theme.spacing(4) + 18, // 50
+      paddingLeft: `calc(${theme.spacing(4)} + 18px)`, // 50
     },
   },
 }));

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -800,7 +800,6 @@ const themeDefaults: ThemeDefaults = () => {
       MuiIconButton: {
         root: {
           padding: 12,
-          color: textColors.linkActiveLight,
           '&:hover': {
             color: primaryColors.main,
             backgroundColor: 'transparent',

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -1115,6 +1115,9 @@ const themeDefaults: ThemeDefaults = () => {
         root: {
           width: 68,
           height: 48,
+          '.MuiSwitch-track': {
+            opacity: '1 !important',
+          },
           '& $checked': {
             // color: `${primaryColors.main} !important`,
             '& input': {
@@ -1180,6 +1183,12 @@ const themeDefaults: ThemeDefaults = () => {
           padding: 16,
           '&$checked': {
             transform: 'translateX(20px)',
+          },
+          '&.Mui-disabled': {
+            '& +.MuiSwitch-track': {
+              backgroundColor: '#ddd',
+              borderColor: '#ccc',
+            },
           },
         },
       },

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -1317,7 +1317,7 @@ const themeDefaults: ThemeDefaults = () => {
           fontSize: '.9rem',
           lineHeight: '1.1rem',
           transition: 'color 225ms ease-in-out',
-          '&.MuiTableSortLabel-active': {
+          '&.Mui-active': {
             color: textColors.tableHeader,
           },
           '&:hover': {
@@ -1402,16 +1402,18 @@ const themeDefaults: ThemeDefaults = () => {
 
 export default (options: DeprecatedThemeOptions) =>
   createMuiTheme(
-    adaptV4Theme(mergeDeepRight(themeDefaults(), {
-      breakpoints: {
-        values: {
-          xs: 0,
-          sm: 600,
-          md: 960,
-          lg: 1280,
-          xl: 1920,
+    adaptV4Theme(
+      mergeDeepRight(themeDefaults(), {
+        breakpoints: {
+          values: {
+            xs: 0,
+            sm: 600,
+            md: 960,
+            lg: 1280,
+            xl: 1920,
+          },
         },
-      },
-      ...options,
-    }))
+        ...options,
+      })
+    )
   );

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -75,7 +75,15 @@ declare module '@mui/material/styles/createTheme' {
   }
 }
 
-const breakpoints = createBreakpoints({});
+export const breakpoints = createBreakpoints({
+  values: {
+    xs: 0,
+    sm: 600,
+    md: 960,
+    lg: 1280,
+    xl: 1920,
+  },
+});
 
 const textColors = {
   linkActiveLight: '#2575d0',
@@ -1413,15 +1421,6 @@ export default (options: DeprecatedThemeOptions) =>
   createMuiTheme(
     adaptV4Theme(
       mergeDeepRight(themeDefaults(), {
-        breakpoints: {
-          values: {
-            xs: 0,
-            sm: 600,
-            md: 960,
-            lg: 1280,
-            xl: 1920,
-          },
-        },
         ...options,
       })
     )

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -482,7 +482,7 @@ const themeDefaults: ThemeDefaults = () => {
           '&:active': {
             backgroundColor: primaryColors.dark,
           },
-          '&$disabled': {
+          '&:disabled': {
             color: 'white',
           },
           '&.loading': {
@@ -501,7 +501,7 @@ const themeDefaults: ThemeDefaults = () => {
             borderColor: primaryColors.dark,
             color: primaryColors.dark,
           },
-          '&$disabled': {
+          '&:disabled': {
             backgroundColor: 'transparent',
             borderColor: '#c9cacb',
             color: '#c9cacb',

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -693,18 +693,18 @@ const themeDefaults: ThemeDefaults = () => {
         root: {
           justifyContent: 'space-between',
           backgroundColor: 'transparent',
-          paddingRight: 2,
+          paddingRight: 12,
           paddingLeft: 16,
+          '& svg': {
+            fill: '#2575d0',
+            stroke: '#2575d0',
+          },
           '&:hover': {
             '& h3': {
               color: primaryColors.light,
             },
-            '& svg': {
-              fill: '#2575d0',
-              stroke: '#2575d0',
-            },
           },
-          '&$expanded': {
+          '&.Mui-expanded': {
             margin: 0,
             minHeight: 48,
             '& .caret': {
@@ -716,7 +716,7 @@ const themeDefaults: ThemeDefaults = () => {
           },
         },
         content: {
-          '&$expanded': {
+          '&.Mui-expanded': {
             margin: '12px 0',
           },
         },

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -196,6 +196,8 @@ const visuallyHidden = {
 
 const graphTransparency = '0.7';
 
+const spacing = 8;
+
 type ThemeDefaults = () => DeprecatedThemeOptions;
 
 const themeDefaults: ThemeDefaults = () => {
@@ -228,7 +230,7 @@ const themeDefaults: ThemeDefaults = () => {
       'none',
       'none',
     ],
-    spacing: 8,
+    spacing,
     '@keyframes rotate': {
       from: {
         transform: 'rotate(0deg)',
@@ -863,6 +865,13 @@ const themeDefaults: ThemeDefaults = () => {
       MuiInputBase: {
         input: {
           height: 'auto',
+        },
+      },
+      MuiDivider: {
+        root: {
+          borderColor: 'rgba(0, 0, 0, 0.12)',
+          marginTop: spacing,
+          marginBottom: spacing,
         },
       },
       MuiInputAdornment: {

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -662,8 +662,8 @@ const themeDefaults: ThemeDefaults = () => {
           borderBottom: '1px solid #eee',
           marginBottom: 20,
           padding: '16px 24px',
+          color: primaryColors.headline,
           '& h2': {
-            color: primaryColors.headline,
             lineHeight: 1.2,
           },
         },

--- a/packages/manager/src/themes.ts
+++ b/packages/manager/src/themes.ts
@@ -335,13 +335,12 @@ const darkThemeOptions = {
       },
     },
     MuiFormControlLabel: {
-      root: {
-        '& $disabled': {
-          color: '#aaa !important',
-        },
-      },
+      root: {},
       label: {
         color: primaryColors.text,
+        '&.Mui-disabled': {
+          color: '#aaa !important',
+        },
       },
       disabled: {},
     },
@@ -376,12 +375,21 @@ const darkThemeOptions = {
       },
     },
     MuiInput: {
+      input: {
+        '&.Mui-disabled': {
+          borderColor: '#606469',
+          color: '#ccc !important',
+          opacity: 0.5,
+          '-webkit-text-fill-color': 'unset !important',
+        },
+      },
       root: {
         backgroundColor: '#444',
         border: '1px solid #222',
         color: primaryColors.text,
-        '&$disabled': {
+        '&.Mui-disabled': {
           borderColor: '#606469',
+          opacity: 0.5,
           color: '#ccc !important',
         },
         '&$focused': {

--- a/packages/manager/src/themes.ts
+++ b/packages/manager/src/themes.ts
@@ -370,7 +370,6 @@ const darkThemeOptions = {
     },
     MuiIconButton: {
       root: {
-        color: primaryColors.main,
         '&:hover': {
           color: primaryColors.light,
         },

--- a/packages/manager/src/themes.ts
+++ b/packages/manager/src/themes.ts
@@ -191,6 +191,9 @@ const darkThemeOptions = {
     text: {
       primary: primaryColors.text,
     },
+    background: {
+      paper: '#2e3238',
+    },
   },
   typography: {
     h1: {

--- a/packages/manager/src/themes.ts
+++ b/packages/manager/src/themes.ts
@@ -1,7 +1,4 @@
-import createTheme from './themeFactory';
-import createBreakpoints from '@mui/system/createTheme/createBreakpoints';
-
-const breakpoints = createBreakpoints({});
+import createTheme, { breakpoints } from './themeFactory';
 
 export const light = () => {
   const options: any = { name: 'lightTheme' };

--- a/packages/manager/src/themes.ts
+++ b/packages/manager/src/themes.ts
@@ -246,7 +246,7 @@ const darkThemeOptions = {
         '&[aria-expanded="true"]': {
           backgroundColor: primaryColors.dark,
         },
-        '&$disabled': {
+        '&:disabled': {
           backgroundColor: '#454b54',
           color: '#5c6470',
         },
@@ -261,7 +261,7 @@ const darkThemeOptions = {
         '&:active': {
           backgroundColor: primaryColors.dark,
         },
-        '&$disabled': {
+        '&:disabled': {
           backgroundColor: '#454b54',
           color: '#5c6470',
         },

--- a/packages/manager/src/themes.ts
+++ b/packages/manager/src/themes.ts
@@ -1,4 +1,3 @@
-import { adaptV4Theme } from '@mui/material/styles';
 import createTheme from './themeFactory';
 import createBreakpoints from '@mui/system/createTheme/createBreakpoints';
 
@@ -7,7 +6,13 @@ const breakpoints = createBreakpoints({});
 export const light = () => {
   const options: any = { name: 'lightTheme' };
 
-  return createTheme(adaptV4Theme(options));
+  return createTheme(options);
+};
+
+export const dark = () => {
+  const options: any = { ...darkThemeOptions };
+
+  return createTheme(options);
 };
 
 const textColors = {
@@ -92,12 +97,6 @@ const genericTableHeaderStyle = {
       color: textColors.linkActiveLight,
     },
   },
-};
-
-export const dark = () => {
-  const options: any = { ...darkThemeOptions };
-
-  return createTheme(adaptV4Theme(options));
 };
 
 const darkThemeOptions = {

--- a/packages/manager/src/themes.ts
+++ b/packages/manager/src/themes.ts
@@ -317,9 +317,7 @@ const darkThemeOptions = {
     MuiDialogTitle: {
       root: {
         borderBottom: '1px solid #222',
-        '& h2': {
-          color: primaryColors.headline,
-        },
+        color: primaryColors.headline,
       },
     },
     MuiDrawer: {


### PR DESCRIPTION
## Description 📝

- Fix UI regressions caused by the upgrade to MUI v5

## To Fix ☑️

- [x] Make Grid work like it use to
- [x] Papers Have White Background Color in Dark Mode
- [x] Inputs
- [x] Main Content Footer Spacing
- [x] Link Colors in Dark Mode
- [x] Top Navigation Collapse Button Color
- [x] Kubernetes Table label Centering
- [x] Firewalls Table Label Centering
- [x] Action Menu Padding
- [x] Chip Font Color in Dark Mode
- [x] Divider Colors
- [x] White Border on Some Papers in Dark Mode
- [x] Entity Landing Icons

## How to test 🧪

- Open `https://cloud.linode.com` in one tab, and open this PR in another
- Compare the UI visually throughout the entire app
  - Try to find any major UI discrepancies