### PR TITLE
M3-5950: Fix Object Storage overwrite error

### DIFF
--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/reducer.ts
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/reducer.ts
@@ -110,8 +110,8 @@ const cloneLandingReducer = (
       });
       break;
 
-    case 'NOTIFY_FILE_EXISTS':
-      let foundFile = draft.files.find(
+    case 'NOTIFY_FILE_EXISTS': {
+      const foundFile = draft.files.find(
         (fileUpload) => pathOrFileName(fileUpload.file) === action.fileName
       );
       if (foundFile) {
@@ -120,9 +120,10 @@ const cloneLandingReducer = (
       }
       updateCount(draft);
       break;
+    }
 
-    case 'RESUME_UPLOAD':
-      foundFile = draft.files.find(
+    case 'RESUME_UPLOAD': {
+      const foundFile = draft.files.find(
         (fileUpload) => pathOrFileName(fileUpload.file) === action.fileName
       );
       if (foundFile) {
@@ -130,6 +131,7 @@ const cloneLandingReducer = (
       }
       updateCount(draft);
       break;
+    }
 
     case 'CANCEL_OVERWRITE':
       const idx = draft.files.findIndex(


### PR DESCRIPTION
## Description
Fix Cloud Manager crashing when overwriting an Object Storage file that already exists. This was because the `foundFile` variable was being defined and used in two different cases, but was not being correctly scoped with curly braces.

## How to test
1. Upload an object to a bucket.
2. Upload it again.
3. Click `Replace`
