### PR TITLE
M3-5552: Fix Linode Add Disk Drawer UI width bug

### DIFF
--- a/packages/manager/src/components/AccessPanel/AccessPanel.tsx
+++ b/packages/manager/src/components/AccessPanel/AccessPanel.tsx
@@ -21,8 +21,7 @@ type ClassNames = 'root' | 'isOptional' | 'passwordInputOuter';
 const styles = (theme: Theme) =>
   createStyles({
     root: {
-      margin: `${theme.spacing(3)}px 0px ${theme.spacing(3)}px 0px`,
-      padding: 0,
+      marginTop: theme.spacing(3),
     },
     isOptional: {
       '& $passwordInputOuter': {

--- a/packages/manager/src/components/AccessPanel/AccessPanel.tsx
+++ b/packages/manager/src/components/AccessPanel/AccessPanel.tsx
@@ -21,7 +21,8 @@ type ClassNames = 'root' | 'isOptional' | 'passwordInputOuter';
 const styles = (theme: Theme) =>
   createStyles({
     root: {
-      marginTop: theme.spacing(3),
+      margin: `${theme.spacing(3)}px 0px ${theme.spacing(3)}px 0px`,
+      padding: 0,
     },
     isOptional: {
       '& $passwordInputOuter': {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/ImageAndPassword.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/ImageAndPassword.test.tsx
@@ -1,6 +1,6 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
-
+import { wrapWithTheme } from 'src/utilities/testHelpers';
 import { imageFactory, normalizeEntities } from 'src/factories';
 
 const normalizedImages = normalizeEntities(imageFactory.buildList(10));
@@ -22,7 +22,7 @@ const props = {
   permissions: null,
 };
 
-const component = shallow(<ImageAndPassword {...props} />);
+const component = shallow(wrapWithTheme(<ImageAndPassword {...props} />));
 
 describe('Component', () => {
   it('should render', () => {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/ImageAndPassword.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/ImageAndPassword.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import { GrantLevel } from '@linode/api-v4/lib/account';
 import * as React from 'react';
 import { compose } from 'recompose';
@@ -7,10 +8,28 @@ import withImages, { WithImages } from 'src/containers/withImages.container';
 import { ImageSelect } from 'src/features/Images';
 import { withLinodeDetailContext } from '../linodeDetailContext';
 import LinodePermissionsError from '../LinodePermissionsError';
+import {
+  createStyles,
+  Theme,
+  withStyles,
+  WithStyles,
+} from 'src/components/core/styles';
 
 interface ContextProps {
   permissions: GrantLevel;
 }
+
+type ClassNames = 'root';
+
+const styles = (theme: Theme) =>
+  createStyles({
+    root: {
+      margin: `${theme.spacing(3)}px 0px ${theme.spacing(3)}px 0px`,
+      padding: 0,
+    },
+  });
+
+const styled = withStyles(styles);
 
 interface Props {
   onImageChange: (selected: Item<string>) => void;
@@ -23,12 +42,14 @@ interface Props {
   userSSHKeys: UserSSHKeyObject[];
   requestKeys: () => void;
   sshError?: string;
+  className?: string;
 }
 
-type CombinedProps = Props & ContextProps & WithImages;
+type CombinedProps = Props & ContextProps & WithImages & WithStyles<ClassNames>;
 
 export const ImageAndPassword: React.FC<CombinedProps> = (props) => {
   const {
+    classes,
     imagesData,
     imagesError,
     imageFieldError,
@@ -40,6 +61,7 @@ export const ImageAndPassword: React.FC<CombinedProps> = (props) => {
     userSSHKeys,
     sshError,
     permissions,
+    className,
   } = props;
 
   const disabled = permissions === 'read_only';
@@ -55,6 +77,12 @@ export const ImageAndPassword: React.FC<CombinedProps> = (props) => {
         disabled={disabled}
       />
       <AccessPanel
+        className={classNames(
+          {
+            [classes.root]: true,
+          },
+          className
+        )}
         password={password || ''}
         handleChange={onPasswordChange}
         error={passwordError}
@@ -78,7 +106,8 @@ const linodeContext = withLinodeDetailContext<ContextProps>(({ linode }) => ({
 
 const enhanced = compose<CombinedProps, Props>(
   linodeContext,
-  withImages()
+  withImages(),
+  styled
 )(ImageAndPassword);
 
 export default enhanced;

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/ImageAndPassword.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/ImageAndPassword.tsx
@@ -1,4 +1,3 @@
-import classNames from 'classnames';
 import { GrantLevel } from '@linode/api-v4/lib/account';
 import * as React from 'react';
 import { compose } from 'recompose';
@@ -8,28 +7,18 @@ import withImages, { WithImages } from 'src/containers/withImages.container';
 import { ImageSelect } from 'src/features/Images';
 import { withLinodeDetailContext } from '../linodeDetailContext';
 import LinodePermissionsError from '../LinodePermissionsError';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles,
-} from 'src/components/core/styles';
+import { makeStyles, Theme } from 'src/components/core/styles';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    margin: `${theme.spacing(3)}px 0 ${theme.spacing(3)}px 0`,
+    padding: 0,
+  },
+}));
 
 interface ContextProps {
   permissions: GrantLevel;
 }
-
-type ClassNames = 'root';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {
-      margin: `${theme.spacing(3)}px 0px ${theme.spacing(3)}px 0px`,
-      padding: 0,
-    },
-  });
-
-const styled = withStyles(styles);
 
 interface Props {
   onImageChange: (selected: Item<string>) => void;
@@ -45,11 +34,10 @@ interface Props {
   className?: string;
 }
 
-type CombinedProps = Props & ContextProps & WithImages & WithStyles<ClassNames>;
+type CombinedProps = Props & ContextProps & WithImages;
 
 export const ImageAndPassword: React.FC<CombinedProps> = (props) => {
   const {
-    classes,
     imagesData,
     imagesError,
     imageFieldError,
@@ -61,8 +49,9 @@ export const ImageAndPassword: React.FC<CombinedProps> = (props) => {
     userSSHKeys,
     sshError,
     permissions,
-    className,
   } = props;
+
+  const classes = useStyles();
 
   const disabled = permissions === 'read_only';
 
@@ -77,12 +66,7 @@ export const ImageAndPassword: React.FC<CombinedProps> = (props) => {
         disabled={disabled}
       />
       <AccessPanel
-        className={classNames(
-          {
-            [classes.root]: true,
-          },
-          className
-        )}
+        className={classes.root}
         password={password || ''}
         handleChange={onPasswordChange}
         error={passwordError}
@@ -106,8 +90,7 @@ const linodeContext = withLinodeDetailContext<ContextProps>(({ linode }) => ({
 
 const enhanced = compose<CombinedProps, Props>(
   linodeContext,
-  withImages(),
-  styled
+  withImages()
 )(ImageAndPassword);
 
 export default enhanced;

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/ImageAndPassword.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/ImageAndPassword.tsx
@@ -31,7 +31,6 @@ interface Props {
   userSSHKeys: UserSSHKeyObject[];
   requestKeys: () => void;
   sshError?: string;
-  className?: string;
 }
 
 type CombinedProps = Props & ContextProps & WithImages;


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
Fixes the bug causing misalignment of Password and SSH Key fields by removing the default MUI theme padding.
For consistency, applied a bottom margin to match the top margin once bottom padding was removed.

## Preview 📷
![fixedDrawerMargins](https://user-images.githubusercontent.com/114685994/193150231-912b761e-75df-4938-9e28-2522adb23e73.jpg)
![buggyDrawerPadding](https://user-images.githubusercontent.com/114685994/193150241-cf9f52d0-2b7e-4b17-a6b6-511473480888.jpg)

## How to test 🧪
**What are the steps to reproduce the issue or verify the changes?**
Using the browser Developer Tools, view the component with the React Developer Tools > Components tab and search for 'AccessPanel'. Verify that the component's padding has been removed and a bottom margin added in its place.
