### PR TITLE
M3-5900: Visual indicator when navigating Linode and Database plan selection tables

### DIFF
--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -85,6 +85,11 @@ const useStyles = makeStyles((theme: Theme) => ({
     width: '5%',
     paddingRight: 0,
   },
+  focusedRow: {
+    '&:focus-within': {
+      backgroundColor: theme.bg.lightBlue1,
+    },
+  },
   gpuGuideLink: {
     fontSize: '0.9em',
     '& a': {
@@ -212,6 +217,7 @@ export const SelectPlanPanel: React.FC<CombinedProps> = (props) => {
             }
             aria-disabled={isSamePlan || planTooSmall || isDisabledClass}
             className={classNames({
+              [classes.focusedRow]: true,
               [classes.disabledRow]:
                 isSamePlan || planTooSmall || isDisabledClass,
             })}

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -216,8 +216,7 @@ export const SelectPlanPanel: React.FC<CombinedProps> = (props) => {
               !isSamePlan && !isDisabledClass ? onSelect(type.id) : undefined
             }
             aria-disabled={isSamePlan || planTooSmall || isDisabledClass}
-            className={classNames({
-              [classes.focusedRow]: true,
+             className={classNames(classes.focusedRow, {
               [classes.disabledRow]:
                 isSamePlan || planTooSmall || isDisabledClass,
             })}


### PR DESCRIPTION
## Description 📝
Currently in Firefox, if you try using the Tab key to navigate through the Linode or Database Create flow, you run into an issue when you reach the plan selection table: there is no indicator of which row has focus. You may have to press Tab many times to get through the listed plans and to the next field, but you do not know where you are in the table because of the lack of a visual indicator.

This PR addresses this by highlighting the row that has focus.

## Preview 📷
![Screen Shot 2022-10-05 at 4 59 52 PM](https://user-images.githubusercontent.com/32860776/194162973-0703fd73-320e-4dfe-8d5e-146fa5eee3f8.jpg)

![Screen Shot 2022-10-05 at 5 00 41 PM](https://user-images.githubusercontent.com/32860776/194162995-8136cbab-155a-4381-8e97-ca62069da3e4.jpg)

## How to test 🧪
In Chrome and Firefox, use the Tab key to navigate to and through the Linode and Database plan panels in the Create flow. You should observe a visual indicator for the row with focus. If you use the mouse to click the radio button for a row, you should also see the visual indicator.
