### PR TITLE
M3-4792: Handle attempted deletion of last LKE pool

### DIFF
--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
@@ -99,7 +99,7 @@ const NodePool: React.FC<Props> = (props) => {
             Recycle Pool Nodes
           </Button>
           <Tooltip
-            title="This is the last Node Pool"
+            title="Clusters must contain at least one node pool."
             disableFocusListener={!isOnlyNodePool}
             disableHoverListener={!isOnlyNodePool}
             disableTouchListener={!isOnlyNodePool}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePool.tsx
@@ -8,6 +8,7 @@ import Button from 'src/components/Button';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 import NodeTable from './NodeTable';
+import Tooltip from 'src/components/core/Tooltip';
 
 interface Props {
   poolId: number;
@@ -19,6 +20,7 @@ interface Props {
   openDeletePoolDialog: (poolId: number) => void;
   openRecycleAllNodesDialog: (poolId: number) => void;
   openRecycleNodeDialog: (nodeID: string, linodeLabel: string) => void;
+  isOnlyNodePool: boolean;
 }
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -53,6 +55,7 @@ const NodePool: React.FC<Props> = (props) => {
     nodes,
     typeLabel,
     poolId,
+    isOnlyNodePool,
   } = props;
 
   const classes = useStyles();
@@ -95,12 +98,22 @@ const NodePool: React.FC<Props> = (props) => {
           >
             Recycle Pool Nodes
           </Button>
-          <Button
-            buttonType="secondary"
-            onClick={() => openDeletePoolDialog(poolId)}
+          <Tooltip
+            title="This is the last Node Pool"
+            disableFocusListener={!isOnlyNodePool}
+            disableHoverListener={!isOnlyNodePool}
+            disableTouchListener={!isOnlyNodePool}
           >
-            Delete Pool
-          </Button>
+            <div>
+              <Button
+                buttonType="secondary"
+                disabled={isOnlyNodePool}
+                onClick={() => openDeletePoolDialog(poolId)}
+              >
+                Delete Pool
+              </Button>
+            </div>
+          </Tooltip>
         </Grid>
       </Grid>
       <NodeTable

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -337,6 +337,7 @@ export const NodePoolsDisplay: React.FC<Props> = (props) => {
                       }
                       openRecycleNodeDialog={recycleNodeDialog.openDialog}
                       openAutoscalePoolDialog={autoscalePoolDialog.openDialog}
+                      isOnlyNodePool={pools.length === 1}
                     />
                   </div>
                 );


### PR DESCRIPTION
## Description 📝

When a LKE cluster has only one remaining node pool disable the the node pool delete button.  Also adds a tooltip to the disabled delete button explaining why the button is disabled.

## Preview 📷

![image](https://user-images.githubusercontent.com/115022759/194396237-e2ec04fc-0d04-476f-840c-6443126cff9d.png)
![image](https://user-images.githubusercontent.com/115022759/194396367-097562b4-fb99-42f8-826b-ae545c958298.png)


## How to test 🧪

1. Navigate to a LKE cluster
2. Ensure that when there are more than 1 node pools the delete node pool buttons are active
3. Ensure that when there is only 1 node pool the button is disabled
4. Ensure that when hovering over the button a tooltip explaining why the button is disabled appears
