### PR TITLE
M3-5764: Add HA chip to Kubernetes landing page

### DIFF
--- a/packages/manager/.env.example
+++ b/packages/manager/.env.example
@@ -9,6 +9,8 @@ REACT_APP_API_ROOT='https://api.linode.com/v4'
 # REACT_APP_CLIENT_ID='UPDATE_WITH_YOUR_ID'
 REACT_APP_APP_ROOT='http://localhost:3000'
 
+REACT_APP_LKE_HIGH_AVAILABILITY_PRICE='60'
+
 ##################################
 # Optional:
 ##################################

--- a/packages/manager/src/factories/account.ts
+++ b/packages/manager/src/factories/account.ts
@@ -43,6 +43,7 @@ export const accountFactory = Factory.Sync.makeFactory<Account>({
     'Block Storage',
     'Object Storage',
     'Kubernetes',
+    'LKE HA Control Planes',
   ],
   active_promotions: [
     {

--- a/packages/manager/src/factories/kubernetesCluster.ts
+++ b/packages/manager/src/factories/kubernetesCluster.ts
@@ -70,7 +70,7 @@ export const kubernetesClusterFactory = Factory.Sync.makeFactory<ExtendedCluster
     totalCPU: 4,
     totalStorage: 1000,
     tags: [],
-    control_plane: { high_availability: false },
+    control_plane: { high_availability: true },
   }
 );
 
@@ -90,6 +90,6 @@ export const kubernetesAPIResponse = Factory.Sync.makeFactory<KubernetesCluster>
     label: Factory.each((i) => `test-cluster-${i}`),
     k8s_version: '1.21',
     tags: [],
-    control_plane: { high_availability: false },
+    control_plane: { high_availability: true },
   }
 );

--- a/packages/manager/src/features/Kubernetes/ClusterList/ClusterList.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/ClusterList.tsx
@@ -16,6 +16,8 @@ import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import TableSortCell from 'src/components/TableSortCell';
 import withTypes, { WithTypesProps } from 'src/containers/types.container';
+import { getKubeHighAvailability } from 'src/features/Kubernetes/kubeUtils';
+import { useAccount } from 'src/queries/account';
 import { useKubernetesVersionQuery } from 'src/queries/kubernetesVersion';
 import { DeleteClusterParams } from 'src/store/kubernetes/kubernetes.actions';
 import { EntityError } from 'src/store/types';
@@ -24,7 +26,6 @@ import UpgradeVersionModal from '../UpgradeVersionModal';
 import ClusterDialog from './../KubernetesClusterDetail/KubernetesDialog';
 import { ExtendedCluster, PoolNodeWithPrice } from './../types';
 import ClusterRow from './ClusterRow';
-
 interface Props {
   clusters: ExtendedCluster[];
   deleteCluster: (data: DeleteClusterParams) => Promise<void>;
@@ -72,6 +73,8 @@ const defaultUpgradeDialogState = {
 
 export const ClusterList: React.FunctionComponent<CombinedProps> = (props) => {
   const { clearErrors, clusters, deleteCluster, error, history } = props;
+
+  const { data: account } = useAccount();
   const { data: versionData } = useKubernetesVersionQuery();
   const versions = versionData ?? [];
 
@@ -245,6 +248,10 @@ export const ClusterList: React.FunctionComponent<CombinedProps> = (props) => {
                         key={`kubernetes-cluster-list-${idx}`}
                         cluster={cluster}
                         hasUpgrade={Boolean(cluster.nextVersion)}
+                        isClusterHighlyAvailable={
+                          getKubeHighAvailability(account, cluster)
+                            .isClusterHighlyAvailable
+                        }
                         openDeleteDialog={openDialog}
                         openUpgradeDialog={() =>
                           openUpgradeDialog(

--- a/packages/manager/src/features/Kubernetes/ClusterList/ClusterRow.test.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/ClusterRow.test.tsx
@@ -36,4 +36,12 @@ describe('ClusterRow component', () => {
     getByText('cluster-0');
     getByText('Dallas, TX');
   });
+
+  it('renders HA chip for highly available clusters', async () => {
+    const { getByTestId } = render(
+      wrapWithTableBody(<ClusterRow {...props} />)
+    );
+
+    getByTestId('ha-chip');
+  });
 });

--- a/packages/manager/src/features/Kubernetes/ClusterList/ClusterRow.test.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/ClusterRow.test.tsx
@@ -17,6 +17,7 @@ const cluster = {
 const props: Props = {
   cluster,
   hasUpgrade: false,
+  isClusterHighlyAvailable: false,
   openUpgradeDialog: jest.fn(),
   openDeleteDialog: jest.fn(),
 };
@@ -37,11 +38,15 @@ describe('ClusterRow component', () => {
     getByText('Dallas, TX');
   });
 
-  it('renders HA chip for highly available clusters', () => {
-    const { getByTestId } = render(
-      wrapWithTableBody(<ClusterRow {...props} />)
+  it('renders HA chip for highly available clusters and hides chip for non-ha clusters', () => {
+    const haProps = { ...props, isClusterHighlyAvailable: true };
+    const { getByTestId, queryByTestId, rerender } = render(
+      wrapWithTableBody(<ClusterRow {...haProps} />)
     );
 
     getByTestId('ha-chip');
+
+    rerender(wrapWithTableBody(<ClusterRow {...props} />));
+    expect(queryByTestId('ha-chip')).toBeNull();
   });
 });

--- a/packages/manager/src/features/Kubernetes/ClusterList/ClusterRow.test.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/ClusterRow.test.tsx
@@ -37,7 +37,7 @@ describe('ClusterRow component', () => {
     getByText('Dallas, TX');
   });
 
-  it('renders HA chip for highly available clusters', async () => {
+  it('renders HA chip for highly available clusters', () => {
     const { getByTestId } = render(
       wrapWithTableBody(<ClusterRow {...props} />)
     );

--- a/packages/manager/src/features/Kubernetes/ClusterList/ClusterRow.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/ClusterRow.tsx
@@ -8,8 +8,6 @@ import Grid from 'src/components/Grid';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import { dcDisplayNames } from 'src/constants';
-import { getKubeHighAvailability } from 'src/features/Kubernetes/kubeUtils';
-import { useAccount } from 'src/queries/account';
 import { ExtendedCluster, PoolNodeWithPrice } from './../types';
 import ActionMenu from './ClusterActionMenu';
 
@@ -44,6 +42,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 export interface Props {
   cluster: ExtendedCluster;
   hasUpgrade: boolean;
+  isClusterHighlyAvailable: boolean;
   openDeleteDialog: (
     clusterID: number,
     clusterLabel: string,
@@ -56,14 +55,14 @@ type CombinedProps = Props;
 
 export const ClusterRow: React.FunctionComponent<CombinedProps> = (props) => {
   const classes = useStyles();
-  const { data: account } = useAccount();
 
-  const { cluster, hasUpgrade, openDeleteDialog, openUpgradeDialog } = props;
-
-  const { isClusterHighlyAvailable } = getKubeHighAvailability(
-    account,
-    cluster
-  );
+  const {
+    cluster,
+    hasUpgrade,
+    isClusterHighlyAvailable,
+    openDeleteDialog,
+    openUpgradeDialog,
+  } = props;
 
   return (
     <TableRow

--- a/packages/manager/src/features/Kubernetes/ClusterList/ClusterRow.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/ClusterRow.tsx
@@ -8,6 +8,8 @@ import Grid from 'src/components/Grid';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import { dcDisplayNames } from 'src/constants';
+import { getClusterHighAvailability } from 'src/features/Kubernetes/kubeUtils';
+import { useAccount } from 'src/queries/account';
 import { ExtendedCluster, PoolNodeWithPrice } from './../types';
 import ActionMenu from './ClusterActionMenu';
 
@@ -54,8 +56,13 @@ type CombinedProps = Props;
 
 export const ClusterRow: React.FunctionComponent<CombinedProps> = (props) => {
   const classes = useStyles();
+  const { data: account } = useAccount();
 
   const { cluster, hasUpgrade, openDeleteDialog, openUpgradeDialog } = props;
+  const { isClusterHighlyAvailable } = getClusterHighAvailability(
+    account,
+    cluster
+  );
 
   return (
     <TableRow
@@ -66,7 +73,12 @@ export const ClusterRow: React.FunctionComponent<CombinedProps> = (props) => {
       ariaLabel={`Cluster ${cluster.label}`}
     >
       <TableCell data-qa-cluster-label>
-        <Grid container wrap="nowrap" alignItems="center">
+        <Grid
+          container
+          wrap="nowrap"
+          alignItems="center"
+          justifyContent="space-between"
+        >
           <Grid item className="py0">
             <div className={classes.labelStatusWrapper}>
               <Link
@@ -78,6 +90,16 @@ export const ClusterRow: React.FunctionComponent<CombinedProps> = (props) => {
               </Link>
             </div>
           </Grid>
+          {isClusterHighlyAvailable ? (
+            <Grid item>
+              <Chip
+                label="HA"
+                variant="outlined"
+                outlineColor="green"
+                size="small"
+              />
+            </Grid>
+          ) : null}
         </Grid>
       </TableCell>
       <Hidden smDown>

--- a/packages/manager/src/features/Kubernetes/ClusterList/ClusterRow.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/ClusterRow.tsx
@@ -8,7 +8,7 @@ import Grid from 'src/components/Grid';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import { dcDisplayNames } from 'src/constants';
-import { getClusterHighAvailability } from 'src/features/Kubernetes/kubeUtils';
+import { getKubeHighAvailability } from 'src/features/Kubernetes/kubeUtils';
 import { useAccount } from 'src/queries/account';
 import { ExtendedCluster, PoolNodeWithPrice } from './../types';
 import ActionMenu from './ClusterActionMenu';
@@ -59,7 +59,8 @@ export const ClusterRow: React.FunctionComponent<CombinedProps> = (props) => {
   const { data: account } = useAccount();
 
   const { cluster, hasUpgrade, openDeleteDialog, openUpgradeDialog } = props;
-  const { isClusterHighlyAvailable } = getClusterHighAvailability(
+
+  const { isClusterHighlyAvailable } = getKubeHighAvailability(
     account,
     cluster
   );
@@ -97,6 +98,7 @@ export const ClusterRow: React.FunctionComponent<CombinedProps> = (props) => {
                 variant="outlined"
                 outlineColor="green"
                 size="small"
+                data-testid={'ha-chip'}
               />
             </Grid>
           ) : null}

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
@@ -60,7 +60,7 @@ export const KubeCheckoutBar: React.FC<Props> = (props) => {
   const disableCheckout = Boolean(
     needsAPool || (!hasAgreed && showGDPRCheckbox)
   );
-  const { showHighAvalibility } = getKubeHighAvailability(account);
+  const { showHighAvailability } = getKubeHighAvailability(account);
 
   return (
     <CheckoutBar
@@ -93,7 +93,7 @@ export const KubeCheckoutBar: React.FC<Props> = (props) => {
             }
           />
         ))}
-        {showHighAvalibility ? (
+        {showHighAvailability ? (
           <>
             <Divider dark spacingTop={16} spacingBottom={12} />
             <HACheckbox

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
@@ -3,8 +3,8 @@ import CheckoutBar from 'src/components/CheckoutBar';
 import Divider from 'src/components/core/Divider';
 import Notice from 'src/components/Notice';
 import renderGuard from 'src/components/RenderGuard';
-import { HIGH_AVAILABILITY_PRICE } from 'src/constants';
 import EUAgreementCheckbox from 'src/features/Account/Agreements/EUAgreementCheckbox';
+import { getKubeHighAvailability } from 'src/features/Kubernetes/kubeUtils';
 import { useAccount } from 'src/queries/account';
 import { useAccountAgreements } from 'src/queries/accountAgreements';
 import { useProfile } from 'src/queries/profile';
@@ -60,11 +60,7 @@ export const KubeCheckoutBar: React.FC<Props> = (props) => {
   const disableCheckout = Boolean(
     needsAPool || (!hasAgreed && showGDPRCheckbox)
   );
-
-  const capabilities = account?.capabilities ?? [];
-  const showHighAvalibility =
-    HIGH_AVAILABILITY_PRICE !== undefined &&
-    capabilities.includes('LKE HA Control Planes');
+  const { showHighAvalibility } = getKubeHighAvailability(account);
 
   return (
     <CheckoutBar

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
@@ -508,6 +508,7 @@ export const KubeSummaryPanel: React.FunctionComponent<Props> = (props) => {
                         label="HA CLUSTER"
                         variant="outlined"
                         outlineColor="green"
+                        size="small"
                       />
                     </Grid>
                   ) : null}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -19,7 +19,7 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 import DocsLink from 'src/components/DocsLink';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import ErrorState from 'src/components/ErrorState';
-import { HIGH_AVAILABILITY_PRICE } from 'src/constants';
+import { getClusterHighAvailability } from 'src/features/Kubernetes/kubeUtils';
 import KubeContainer, {
   DispatchProps,
 } from 'src/containers/kubernetes.container';
@@ -219,14 +219,10 @@ export const KubernetesClusterDetail: React.FunctionComponent<CombinedProps> = (
     openDialog: openUpgradeDialog,
   } = useDialog(_updateCluster);
 
-  const capabilities = account?.capabilities ?? [];
-  const isHighAvailabilityFeatureEnabled =
-    HIGH_AVAILABILITY_PRICE !== undefined &&
-    capabilities.includes('LKE HA Control Planes');
-
-  const isClusterHighlyAvailable =
-    isHighAvailabilityFeatureEnabled &&
-    cluster?.control_plane?.high_availability;
+  const {
+    isHighAvailabilityFeatureEnabled,
+    isClusterHighlyAvailable,
+  } = getClusterHighAvailability(account, cluster);
 
   if (clustersLoadError) {
     const error = getAPIErrorOrDefault(
@@ -335,10 +331,7 @@ export const KubernetesClusterDetail: React.FunctionComponent<CombinedProps> = (
               tags: newTags,
             })
           }
-          isClusterHighlyAvailable={
-            isHighAvailabilityFeatureEnabled &&
-            cluster.control_plane.high_availability
-          }
+          isClusterHighlyAvailable={isClusterHighlyAvailable}
           isKubeDashboardFeatureEnabled={Boolean(
             flags.kubernetesDashboardAvailability
           )}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -19,11 +19,11 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 import DocsLink from 'src/components/DocsLink';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import ErrorState from 'src/components/ErrorState';
-import { getClusterHighAvailability } from 'src/features/Kubernetes/kubeUtils';
 import KubeContainer, {
   DispatchProps,
 } from 'src/containers/kubernetes.container';
 import withTypes, { WithTypesProps } from 'src/containers/types.container';
+import { getKubeHighAvailability } from 'src/features/Kubernetes/kubeUtils';
 import { useDialog } from 'src/hooks/useDialog';
 import useFlags from 'src/hooks/useFlags';
 import usePolling from 'src/hooks/usePolling';
@@ -220,9 +220,9 @@ export const KubernetesClusterDetail: React.FunctionComponent<CombinedProps> = (
   } = useDialog(_updateCluster);
 
   const {
-    isHighAvailabilityFeatureEnabled,
+    showHighAvalibility,
     isClusterHighlyAvailable,
-  } = getClusterHighAvailability(account, cluster);
+  } = getKubeHighAvailability(account, cluster);
 
   if (clustersLoadError) {
     const error = getAPIErrorOrDefault(
@@ -306,7 +306,7 @@ export const KubernetesClusterDetail: React.FunctionComponent<CombinedProps> = (
           style={{ marginTop: 14, marginBottom: 8, display: 'flex' }}
         >
           <DocsLink href="https://www.linode.com/docs/kubernetes/deploy-and-manage-a-cluster-with-linode-kubernetes-engine-a-tutorial/" />
-          {isHighAvailabilityFeatureEnabled && !isClusterHighlyAvailable ? (
+          {showHighAvalibility && !isClusterHighlyAvailable ? (
             <Button
               className={classes.upgradeToHAButton}
               buttonType="primary"

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -220,7 +220,7 @@ export const KubernetesClusterDetail: React.FunctionComponent<CombinedProps> = (
   } = useDialog(_updateCluster);
 
   const {
-    showHighAvalibility,
+    showHighAvailability,
     isClusterHighlyAvailable,
   } = getKubeHighAvailability(account, cluster);
 
@@ -306,7 +306,7 @@ export const KubernetesClusterDetail: React.FunctionComponent<CombinedProps> = (
           style={{ marginTop: 14, marginBottom: 8, display: 'flex' }}
         >
           <DocsLink href="https://www.linode.com/docs/kubernetes/deploy-and-manage-a-cluster-with-linode-kubernetes-engine-a-tutorial/" />
-          {showHighAvalibility && !isClusterHighlyAvailable ? (
+          {showHighAvailability && !isClusterHighlyAvailable ? (
             <Button
               className={classes.upgradeToHAButton}
               buttonType="primary"

--- a/packages/manager/src/features/Kubernetes/kubeUtils.ts
+++ b/packages/manager/src/features/Kubernetes/kubeUtils.ts
@@ -156,16 +156,16 @@ export const getKubeHighAvailability = (
   account: Account | undefined,
   cluster?: ExtendedCluster | null
 ) => {
-  const showHighAvalibility = account?.capabilities.includes(
+  const showHighAvailability = account?.capabilities.includes(
     'LKE HA Control Planes'
   );
 
   const isClusterHighlyAvailable = Boolean(
-    showHighAvalibility && cluster?.control_plane.high_availability
+    showHighAvailability && cluster?.control_plane.high_availability
   );
 
   return {
-    showHighAvalibility,
+    showHighAvailability,
     isClusterHighlyAvailable,
   };
 };

--- a/packages/manager/src/features/Kubernetes/kubeUtils.ts
+++ b/packages/manager/src/features/Kubernetes/kubeUtils.ts
@@ -152,22 +152,20 @@ export const getNextVersion = (
   return versionStrings[currentIdx + 1];
 };
 
-export const getClusterHighAvailability = (
+export const getKubeHighAvailability = (
   account: Account | undefined,
-  cluster: KubernetesCluster | null
+  cluster?: ExtendedCluster | null
 ) => {
-  const isHighAvailabilityFeatureEnabled = Boolean(
-    HIGH_AVAILABILITY_PRICE !== undefined &&
-      account?.capabilities.includes('LKE HA Control Planes')
+  const showHighAvalibility = account?.capabilities.includes(
+    'LKE HA Control Planes'
   );
 
   const isClusterHighlyAvailable = Boolean(
-    isHighAvailabilityFeatureEnabled &&
-      cluster?.control_plane?.high_availability
+    showHighAvalibility && cluster?.control_plane.high_availability
   );
 
   return {
-    isHighAvailabilityFeatureEnabled,
+    showHighAvalibility,
     isClusterHighlyAvailable,
   };
 };

--- a/packages/manager/src/features/Kubernetes/kubeUtils.ts
+++ b/packages/manager/src/features/Kubernetes/kubeUtils.ts
@@ -1,3 +1,4 @@
+import { Account } from '@linode/api-v4/lib/account';
 import {
   KubernetesCluster,
   KubernetesVersion,
@@ -149,4 +150,24 @@ export const getNextVersion = (
     return null;
   }
   return versionStrings[currentIdx + 1];
+};
+
+export const getClusterHighAvailability = (
+  account: Account | undefined,
+  cluster: KubernetesCluster | null
+) => {
+  const isHighAvailabilityFeatureEnabled = Boolean(
+    HIGH_AVAILABILITY_PRICE !== undefined &&
+      account?.capabilities.includes('LKE HA Control Planes')
+  );
+
+  const isClusterHighlyAvailable = Boolean(
+    isHighAvailabilityFeatureEnabled &&
+      cluster?.control_plane?.high_availability
+  );
+
+  return {
+    isHighAvailabilityFeatureEnabled,
+    isClusterHighlyAvailable,
+  };
 };


### PR DESCRIPTION
## Description 📝
- Add HA chip to the Kubernetes landing page
- Update HA chip size in the Kubernetes details page to match the landing page chip
- Minor refactoring

## Preview 📷
![image](https://user-images.githubusercontent.com/14323019/194407319-ab999e24-9f19-4fa5-bd8b-847ddfabee88.png)

![image](https://user-images.githubusercontent.com/14323019/194407497-94752bf4-cdec-4015-803a-eb666db21955.png)


## How to test 🧪
Check the view in `/kubernetes/clusters` and `/kubernetes/clusters/<cluster_id>/summary`
```
yarn test ClusterRow
```
