### PR TITLE
M3-5501: [BUILD] Update the changelog generation script

### DIFF
--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -11,7 +11,7 @@ except Exception:
     REPO=False
 
 DATE = datetime.datetime.now().strftime('%Y-%m-%d')
-START_INSERT=5 if REPO.lower() == 'manager' else 0
+START_INSERT=0 if (REPO and REPO.lower() != 'manager') else 5
 
 NOT_INCLUDED_IN_LOG = []
 

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -54,7 +54,7 @@ def remove_pull_request_id(commit_message):
     regexp = "\(#\d+\)"
     return re.sub(regexp, '', commit_message).strip()
 
-def generateChangeLog(release, date, origin, repo=False):
+def generateChangeLog(release, date, origin, repo=''):
     git_log_command = ["git", "log", "--no-merges", "--oneline", "--pretty='%s'", "{}/develop...HEAD".format(origin)]
 
     if (repo):

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -74,11 +74,11 @@ def generateChangeLog(release, date, origin, repo=False):
     for commit in commits:
         commit = remove_pull_request_id(commit)
 
-        jira_key_regex=re.match('M3-\d{4}', commit)
+        jira_key_regex=re.match('M3-\d{4}: ', commit)
         if (jira_key_regex is not None):
             jira_key=jira_key_regex.group(0)
             jql_query.append(jira_key)
-            commit.lstrip(jira_key)
+            commit = commit.lstrip(jira_key)
 
         if(checkKeyWords(TEST_KEYWORDS, commit.lower())):
             NOT_INCLUDED_IN_LOG.append(commit)

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -3,7 +3,7 @@ import re
 import sys
 import datetime
 
-RELEASE=sys.argv[1]
+RELEASE='v' + sys.argv[1].strip('v')
 ORIGIN=sys.argv[2]
 try:
     REPO=sys.argv[3]

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -11,7 +11,7 @@ except Exception:
     REPO=False
 
 DATE = datetime.datetime.now().strftime('%Y-%m-%d')
-START_INSERT=5
+START_INSERT=5 if REPO.lower() == 'manager' else 0
 
 NOT_INCLUDED_IN_LOG = []
 
@@ -103,7 +103,9 @@ def generateChangeLog(release, date, origin, repo=False):
 
     changelog_file = "CHANGELOG.md"
 
-    if (repo):
+    if (repo == 'manager'):
+        changelog_file = "CHANGELOG.md"
+    else:
         changelog_file = "packages/{}/CHANGELOG.md".format(repo)
 
     read_change_log=open(changelog_file, 'r')
@@ -111,7 +113,7 @@ def generateChangeLog(release, date, origin, repo=False):
     read_change_log.close()
 
     change_log_lines.insert(START_INSERT,'\n')
-    change_log_lines.insert(incrementLine(),'## [%s] - %s\n'%(release,date))
+    change_log_lines.insert(incrementLine(),'## [%s] - %s\n'%(date, release))
     change_log_lines.insert(incrementLine(),'\n')
 
     if( breaking ):

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -1,15 +1,16 @@
 import subprocess
 import re
 import sys
+import datetime
 
 RELEASE=sys.argv[1]
-DATE=sys.argv[2]
-ORIGIN=sys.argv[3]
+ORIGIN=sys.argv[2]
 try:
-    REPO=sys.argv[4]
+    REPO=sys.argv[3]
 except Exception:
     REPO=False
 
+DATE = datetime.datetime.now().strftime('%Y-%m-%d')
 START_INSERT=5
 
 NOT_INCLUDED_IN_LOG = []

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -103,7 +103,8 @@ def generateChangeLog(release, date, origin, repo=''):
 
     changelog_file = "CHANGELOG.md"
 
-    if (repo == 'manager'):
+    # If the repo isn't explicitly passed in, we default to Manager's CHANGELOG.
+    if (repo == 'manager' or repo == '' or repo is False):
         changelog_file = "CHANGELOG.md"
     else:
         changelog_file = "packages/{}/CHANGELOG.md".format(repo)

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -15,10 +15,10 @@ START_INSERT=5
 
 NOT_INCLUDED_IN_LOG = []
 
-TEST_KEYWORDS = ['test', 'script', 'storybook', 'e2e']
+TEST_KEYWORDS = ['test', 'script', 'storybook', 'e2e', '[TEST]']
 BREAKING_KEYWORDS = ['break', 'deprecate']
-CHANGED_KEYWORDS = ['update', 'change']
-FIXED_KEYWORDS = ['fix', 'repair', 'bug']
+CHANGED_KEYWORDS = ['update', 'change', '[PERF]', '[CHANGED]']
+FIXED_KEYWORDS = ['fix', 'repair', 'bug', '[FIXED]', '[DOCS]', '[REFACTOR]', '[BUILD]']
 
 def incrementLine():
     global START_INSERT

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -5,6 +5,10 @@ import sys
 RELEASE=sys.argv[1]
 DATE=sys.argv[2]
 ORIGIN=sys.argv[3]
+try:
+    REPO=sys.argv[4]
+except Exception:
+    REPO=False
 
 START_INSERT=5
 
@@ -49,8 +53,11 @@ def remove_pull_request_id(commit_message):
     regexp = "\(#\d+\)"
     return re.sub(regexp, '', commit_message).strip()
 
-def generateChangeLog(release, date, origin):
-    git_log_command = ["git", "log", "--no-merges", "--oneline", "--pretty='%s'", "{}/master...HEAD".format(origin)]
+def generateChangeLog(release, date, origin, repo=False):
+    git_log_command = ["git", "log", "--no-merges", "--oneline", "--pretty='%s'", "{}/develop...HEAD".format(origin)]
+
+    if (repo):
+        git_log_command.extend(["--", "packages/{}".format(repo)])
 
     commits = subprocess.check_output(git_log_command, subprocess.STDOUT).decode('utf-8').split('\n')
 
@@ -93,7 +100,12 @@ def generateChangeLog(release, date, origin):
 
     generateJQLQuery(jql_query)
 
-    read_change_log=open('CHANGELOG.md', 'r')
+    changelog_file = "CHANGELOG.md"
+
+    if (repo):
+        changelog_file = "packages/{}/CHANGELOG.md".format(repo)
+
+    read_change_log=open(changelog_file, 'r')
     change_log_lines=read_change_log.readlines()
     read_change_log.close()
 
@@ -125,7 +137,7 @@ def generateChangeLog(release, date, origin):
             change_log_lines.insert(incrementLine(),'- %s\n'%(commit))
         change_log_lines.insert(incrementLine(),'\n')
 
-    write_change_log=open('CHANGELOG.md', 'w')
+    write_change_log=open(changelog_file, 'w')
     write_change_log.writelines(change_log_lines)
 
-generateChangeLog(RELEASE, DATE, ORIGIN)
+generateChangeLog(RELEASE, DATE, ORIGIN, REPO)


### PR DESCRIPTION
## Description 📝

Updates the `generate_changelog.py` script in the following ways:
- Allows the user to specify what sub-repo the changelog should be generated for
- Adds the new naming conventions form PR name standardization proposal 
- Automatically strips Jira labels from changelog
- Automatically inserts current date

the syntax for calling the script has changed it should now take this form
`python generate_changelog.py <version number> <origin> <repo to generate changelog for>`
The repo argument is optional and only needed to specify `api-v4` or `validation`

## How to test 🧪

Ensure you can generate a changelog for the repos without error
