### PR TITLE
M3-5960: Update link regarding Configuration Profile in "Attach a VLAN" section

### DIFF
--- a/packages/manager/src/features/linodes/LinodesCreate/AttachVLAN.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/AttachVLAN.tsx
@@ -95,7 +95,7 @@ const AttachVLAN: React.FC<CombinedProps> = (props) => {
             the Linode&rsquo;s{' '}
             <ExternalLink
               text="Configuration Profile"
-              link="https://linode.com/docs/guides/disk-images-and-configuration-profiles/"
+              link="https://www.linode.com/docs/guides/linode-configuration-profiles/"
               hideIcon
             />
             .


### PR DESCRIPTION
## Description 📝
Update the link regarding Configuration Profiles in the "Attach a VLAN" section in the Linode Create flow.

The link formally directed users to this [deprecated guide](https://www.linode.com/docs/guides/disk-images-and-configuration-profiles/) but it should now direct them [here](https://www.linode.com/docs/guides/linode-configuration-profiles/).

## How to test 🧪
Check that the link in the Linode Create flow brings users to the correct guide titled "Managing Configuration Profiles on a Linode".
