### PR TITLE
M3-5920: Make info button accessible via keyboard nav

### DIFF
--- a/packages/manager/src/features/linodes/LinodesCreate/SelectionCardWrapper.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectionCardWrapper.tsx
@@ -84,6 +84,12 @@ export const SelectionCardWrapper: React.FC<Props> = (props) => {
     openDrawer(label);
   };
 
+  const handleKeyPress = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      openDrawer(label);
+    }
+  };
+
   const renderIcon =
     iconUrl === ''
       ? () => <span className="fl-tux" />
@@ -91,7 +97,13 @@ export const SelectionCardWrapper: React.FC<Props> = (props) => {
 
   const renderVariant = () => (
     <Grid item className={classes.info} xs={2}>
-      <Info onClick={handleInfoClick} />
+      <Info
+        role="button"
+        aria-label={`Info for "${label}"`}
+        onClick={handleInfoClick}
+        onKeyDown={handleKeyPress}
+        tabIndex={0}
+      />
     </Grid>
   );
 

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectionCardWrapper.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectionCardWrapper.tsx
@@ -85,7 +85,7 @@ export const SelectionCardWrapper: React.FC<Props> = (props) => {
   };
 
   const handleKeyPress = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter') {
+    if (e.key === 'Enter' || e.key === ' ') {
       openDrawer(label);
     }
   };


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
Makes the info button on Marketplace app cards keyboard navigable. Users can now select the button and expand the drawer to access information about the application.

## Preview 📷

**Remove this section or include a screenshot or screen recording of the change**

https://user-images.githubusercontent.com/114685994/196762382-90ef0a0b-5101-4ae6-808f-b5836b54aebd.mov


## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**

1. Visit the Marketplace.
2. Use keyboard navigation to tab to a Marketplace app selection card.
3. Once a card is selected, press tab again and observe that the Info button is now focusable.
4. Press Enter and the drawer will open. Tab to the close button and press Enter; observe the drawer closes.
5. Enable a screen reader such as Voice Over, navigate to the Info button on the card, and observe that the screen reader reads out the ARIA label (e.g. "Info for [App Name]").
