### PR TITLE
M3-3166: [CHANGED] Custom User Agent

### DIFF
--- a/packages/api-v4/src/request.ts
+++ b/packages/api-v4/src/request.ts
@@ -12,6 +12,18 @@ export const baseRequest = Axios.create({
   baseURL: 'https://api.linode.com/v4',
 });
 
+baseRequest.interceptors.request.use((config) => {
+  const isRunningInNode = typeof process === 'object';
+  const newConfig = {
+    ...config,
+    headers: {
+      ...config.headers,
+      'User-Agent': 'linodejs',
+    },
+  };
+  return isRunningInNode ? newConfig : config;
+});
+
 /**
  * setToken
  *
@@ -275,6 +287,25 @@ export const CancellableRequest = <T>(
         (response) => response.data
       ),
   };
+};
+
+/**
+ * setUserAgentPrefix
+ *
+ * Helper function to set a custom prefix on the user agent
+ *
+ * @param prefix
+ */
+export const setUserAgentPrefix = (prefix: string) => {
+  return baseRequest.interceptors.request.use((config) => {
+    return {
+      ...config,
+      headers: {
+        ...config.headers,
+        'User-Agent': `${prefix}/${config.headers['User-Agent']}`,
+      },
+    };
+  });
 };
 
 export default requestGenerator;


### PR DESCRIPTION
## Description 📝

When the api-v4 package is used in a node script the User-Agent header is set to `linodejs`. It also provides users with the ability to prefix the new User-Agent with a custom string if they want to. This does not effect the HTTP requests made in cloud or when the package is used in a browser. 

## How to test 🧪

Ensure that HTTP requests made via manager have their normal browser specific User-Agent.
Ensure that HTTP requests made by using the api-v4 package have `linodejs` set for their User-Agent.
