### PR TITLE
Update Cypress domain CAA record test to use domain name value

### DIFF
--- a/packages/manager/cypress/e2e/domains/smoke-create-domain-records.spec.ts
+++ b/packages/manager/cypress/e2e/domains/smoke-create-domain-records.spec.ts
@@ -4,7 +4,7 @@ import {
   deleteDomainById,
   deleteAllTestDomains,
 } from 'support/api/domains';
-import { randomIp, randomLabel } from 'support/util/random';
+import { randomIp, randomLabel, randomDomainName } from 'support/util/random';
 import { fbtClick, getClick } from '../../support/helpers';
 
 const createRecords = () => [
@@ -83,7 +83,7 @@ const createRecords = () => [
       },
       {
         name: '[data-qa-target="Value"]',
-        value: randomLabel(),
+        value: randomDomainName(),
         skipCheck: false,
       },
     ],


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
Fixes our failing domain CAA record test by supplying a random domain name (rather than a regular old random string) when creating the record. This is necessary as of [API v4.138.0](https://developers.linode.com/changelog/#API-4.138.0), which implements validation for CAA record values.

## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**
To reproduce the issue, run the following command against `develop`. To verify the fix, run the same command with this branch checked out:

```
yarn cy:run -s "cypress/e2e/domains/smoke-create-domain-records.spec.ts"
```
