### PR TITLE
M3-5969: Prevent unnecessary error for `company` field when updating Account info

### DIFF
--- a/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
@@ -231,6 +231,14 @@ class UpdateContactInformationForm extends React.Component<
       filteredRegionResults = regionResults;
     }
 
+    // Prevent edge case field error for "Company Name" when updating billing info
+    // for accounts that did not initially require an address.
+    if (this.state.fields.company === null) {
+      this.setState({
+        fields: { ...this.state.fields, company: '' },
+      });
+    }
+
     return (
       <Grid
         container
@@ -619,12 +627,6 @@ class UpdateContactInformationForm extends React.Component<
       success: undefined,
       submitting: true,
     });
-
-    // Prevent edge case field error for "Company Name" when updating billing info
-    // for accounts that did not initially require an address.
-    if (this.state.fields.company === null) {
-      this.composeState([set(L.fields.company, '')]);
-    }
 
     queryClient.executeMutation({
       variables: this.state.fields,

--- a/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/UpdateContactInformationForm/UpdateContactInformationForm.tsx
@@ -620,6 +620,12 @@ class UpdateContactInformationForm extends React.Component<
       submitting: true,
     });
 
+    // Prevent edge case field error for "Company Name" when updating billing info
+    // for accounts that did not initially require an address.
+    if (this.state.fields.company === null) {
+      this.composeState([set(L.fields.company, '')]);
+    }
+
     queryClient.executeMutation({
       variables: this.state.fields,
       mutationFn: updateAccountInfo,

--- a/packages/validation/src/account.schema.ts
+++ b/packages/validation/src/account.schema.ts
@@ -4,9 +4,7 @@ export const updateAccountSchema = object({
   email: string().max(128, 'Email must be 128 characters or less.'),
   address_1: string().max(64, 'Address must be 64 characters or less.'),
   city: string().max(24, 'City must be 24 characters or less.'),
-  company: string()
-    .max(128, 'Company must be 128 characters or less.')
-    .nullable(true),
+  company: string().max(128, 'Company must be 128 characters or less.'),
   country: string()
     .min(2, 'Country code must be two letters.')
     .max(2, 'Country code must be two letters.'),

--- a/packages/validation/src/account.schema.ts
+++ b/packages/validation/src/account.schema.ts
@@ -4,7 +4,9 @@ export const updateAccountSchema = object({
   email: string().max(128, 'Email must be 128 characters or less.'),
   address_1: string().max(64, 'Address must be 64 characters or less.'),
   city: string().max(24, 'City must be 24 characters or less.'),
-  company: string().max(128, 'Company must be 128 characters or less.'),
+  company: string()
+    .max(128, 'Company must be 128 characters or less.')
+    .nullable(true),
   country: string()
     .min(2, 'Country code must be two letters.')
     .max(2, 'Country code must be two letters.'),


### PR DESCRIPTION
## Description 📝
Updates the Account schema to prevent an unnecessary error on the "Company Name" field when you try updating your billing contact info on an account that did not initially require certain information.

## How to test 🧪
The easiest way to test this would be to create a new Cloud account using your Akamai email address. From that account, you can try editing your billing contact info (not the "Company Name" field) in prod and saving it to observe the unnecessary error on the "Company Name" field. On this branch, you should be able to make those initial changes without receiving an error for that field.
