### PR TITLE
React Query for Volumes - Linode Storage

### DIFF
--- a/packages/api-v4/src/volumes/types.ts
+++ b/packages/api-v4/src/volumes/types.ts
@@ -19,6 +19,7 @@ export type VolumeStatus =
   | 'resizing'
   | 'deleting'
   | 'deleted'
+  | 'migrating'
   | 'contact_support';
 
 type VolumeHardwareType = 'hdd' | 'nvme';

--- a/packages/manager/src/features/Volumes/VolumeAttachmentDrawer.tsx
+++ b/packages/manager/src/features/Volumes/VolumeAttachmentDrawer.tsx
@@ -148,12 +148,7 @@ export const VolumeAttachmentDrawer = (props: Props) => {
           name="config"
           id="config"
           errorText={linodeError}
-          disabled={
-            disabled ||
-            readOnly ||
-            selectedLinode === -1 ||
-            configChoices.length === 1
-          }
+          disabled={disabled || readOnly || selectedLinode === -1}
           label="Config"
           isClearable={false}
           isLoading={configsLoading}

--- a/packages/manager/src/features/Volumes/VolumeDrawer/AttachVolumeToLinodeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/AttachVolumeToLinodeForm.tsx
@@ -36,9 +36,13 @@ type CombinedProps = Props & StateProps & DispatchProps;
  * I had to provide a separate validation schema since the linode_id (which is required by API) is
  * provided as a prop and not a user input value.
  */
-const validationScheme = object({
-  volume_id: number().required(),
-  config_id: number().required(),
+const AttachVolumeValidationSchema = object({
+  volume_id: number()
+    .min(0, 'Volume is required.')
+    .required('Volume is required.'),
+  config_id: number()
+    .min(0, 'Config is required.')
+    .required('Config is required.'),
 });
 
 const initialValues = { volume_id: -1, config_id: -1 };
@@ -62,7 +66,7 @@ const AttachVolumeToLinodeForm: React.FC<CombinedProps> = (props) => {
 
   return (
     <Formik
-      validationSchema={validationScheme}
+      validationSchema={AttachVolumeValidationSchema}
       onSubmit={(values, { setSubmitting, setStatus, setErrors }) => {
         attachVolume({
           volumeId: values.volume_id,

--- a/packages/manager/src/features/Volumes/VolumeDrawer/AttachVolumeToLinodeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/AttachVolumeToLinodeForm.tsx
@@ -1,14 +1,10 @@
 import { Formik } from 'formik';
 import { Grant } from '@linode/api-v4/lib/account';
-import { attachVolume } from '@linode/api-v4/lib/volumes';
 import { pathOr } from 'ramda';
 import * as React from 'react';
 import { connect, MapDispatchToProps } from 'react-redux';
 import { compose } from 'recompose';
 import Form from 'src/components/core/Form';
-import withVolumesRequests, {
-  VolumesRequests,
-} from 'src/containers/volumesRequests.container';
 import { resetEventsPolling } from 'src/eventsPolling';
 import { MapState } from 'src/store/types';
 import { openForCreating } from 'src/store/volumeForm';
@@ -24,6 +20,7 @@ import NoticePanel from './NoticePanel';
 import Notice from 'src/components/Notice';
 import VolumesActionsPanel from './VolumesActionsPanel';
 import VolumeSelect from './VolumeSelect';
+import { useAttachVolumeMutation } from 'src/queries/volumes';
 
 interface Props {
   onClose: () => void;
@@ -33,7 +30,7 @@ interface Props {
   readOnly?: boolean;
 }
 
-type CombinedProps = Props & StateProps & DispatchProps & VolumesRequests;
+type CombinedProps = Props & StateProps & DispatchProps;
 
 /**
  * I had to provide a separate validation schema since the linode_id (which is required by API) is
@@ -60,11 +57,15 @@ const AttachVolumeToLinodeForm: React.FC<CombinedProps> = (props) => {
   )[0];
   const disabled =
     readOnly || (linodeGrant && linodeGrant.permissions !== 'read_write');
+
+  const { mutateAsync: attachVolume } = useAttachVolumeMutation();
+
   return (
     <Formik
       validationSchema={validationScheme}
       onSubmit={(values, { setSubmitting, setStatus, setErrors }) => {
-        attachVolume(values.volume_id, {
+        attachVolume({
+          volumeId: values.volume_id,
           linode_id: linodeId,
           config_id: values.config_id,
         })
@@ -196,6 +197,6 @@ const mapStateToProps: MapState<StateProps, CombinedProps> = (state) => ({
 
 const connected = connect(mapStateToProps, mapDispatchToProps);
 
-const enhanced = compose<CombinedProps, Props>(connected, withVolumesRequests);
+const enhanced = compose<CombinedProps, Props>(connected);
 
 export default enhanced(AttachVolumeToLinodeForm);

--- a/packages/manager/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
@@ -8,21 +8,14 @@ import * as React from 'react';
 import { connect, MapDispatchToProps } from 'react-redux';
 import { compose } from 'recompose';
 import Form from 'src/components/core/Form';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles,
-} from 'src/components/core/styles';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import TagsInput, { Tag as _Tag } from 'src/components/TagsInput';
 import { MAX_VOLUME_SIZE } from 'src/constants';
-import withVolumesRequests, {
-  VolumesRequests,
-} from 'src/containers/volumesRequests.container';
 import { resetEventsPolling } from 'src/eventsPolling';
 import { hasGrant } from 'src/features/Profile/permissionsHelpers';
 import { useGrants, useProfile } from 'src/queries/profile';
+import { useCreateVolumeMutation } from 'src/queries/volumes';
 import { MapState } from 'src/store/types';
 import {
   openForAttaching,
@@ -45,14 +38,12 @@ import PricePanel from './PricePanel';
 import SizeField from './SizeField';
 import VolumesActionsPanel from './VolumesActionsPanel';
 
-type ClassNames = 'root' | 'textWrapper';
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {},
-    textWrapper: {
-      marginBottom: theme.spacing(1) + 2,
-    },
-  });
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {},
+  textWrapper: {
+    marginBottom: theme.spacing(1) + 2,
+  },
+}));
 
 interface Props {
   onClose: () => void;
@@ -66,13 +57,10 @@ interface Props {
   ) => void;
 }
 
-type CombinedProps = Props &
-  StateProps &
-  VolumesRequests &
-  DispatchProps &
-  WithStyles<ClassNames>;
+type CombinedProps = Props & StateProps & DispatchProps;
 
 const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
+  const classes = useStyles();
   const {
     onClose,
     onSuccess,
@@ -80,12 +68,12 @@ const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
     linodeLabel,
     linodeRegion,
     actions,
-    createVolume,
     origin,
   } = props;
 
   const { data: profile } = useProfile();
   const { data: grants } = useGrants();
+  const { mutateAsync: createVolume } = useCreateVolumeMutation();
 
   const disabled = profile?.restricted && !hasGrant('add_volumes', grants);
 
@@ -195,7 +183,7 @@ const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
 
             <Typography
               variant="body1"
-              className={props.classes.textWrapper}
+              className={classes.textWrapper}
               data-qa-volume-attach-help
               style={{ marginTop: 24 }}
             >
@@ -204,7 +192,7 @@ const CreateVolumeForm: React.FC<CombinedProps> = (props) => {
 
             <Typography
               variant="body1"
-              className={props.classes.textWrapper}
+              className={classes.textWrapper}
               data-qa-volume-size-help
             >
               A single Volume can range from 10 to {MAX_VOLUME_SIZE} gigabytes
@@ -295,8 +283,6 @@ const initialValues: FormState = {
   tags: [],
 };
 
-const styled = withStyles(styles);
-
 interface DispatchProps {
   actions: {
     switchToAttaching: () => void;
@@ -329,10 +315,6 @@ const mapStateToProps: MapState<StateProps, CombinedProps> = (state) => ({
 
 const connected = connect(mapStateToProps, mapDispatchToProps);
 
-const enhanced = compose<CombinedProps, Props>(
-  styled,
-  connected,
-  withVolumesRequests
-)(CreateVolumeForm);
+const enhanced = compose<CombinedProps, Props>(connected)(CreateVolumeForm);
 
 export default enhanced;

--- a/packages/manager/src/features/Volumes/VolumeTableRow.tsx
+++ b/packages/manager/src/features/Volumes/VolumeTableRow.tsx
@@ -196,13 +196,11 @@ export const VolumeTableRow: React.FC<CombinedProps> = (props) => {
           )}
         </Grid>
       </TableCell>
-      {isVolumesLanding ? (
-        <TableCell statusCell>
-          <StatusIcon status={volumeStatusIconMap[status]} />
-          {volumeStatusMap[status]}
-        </TableCell>
-      ) : null}
-      {region ? (
+      <TableCell statusCell>
+        <StatusIcon status={volumeStatusIconMap[status]} />
+        {volumeStatusMap[status]}
+      </TableCell>
+      {isVolumesLanding && region ? (
         <TableCell data-qa-volume-region noWrap>
           {formattedRegion}
         </TableCell>

--- a/packages/manager/src/features/Volumes/VolumeTableRow.tsx
+++ b/packages/manager/src/features/Volumes/VolumeTableRow.tsx
@@ -58,6 +58,7 @@ export const isVolumeUpdating = (e?: Event) => {
 export const volumeStatusIconMap: Record<ExtendedVolume['status'], Status> = {
   active: 'active',
   resizing: 'other',
+  migrating: 'other',
   creating: 'other',
   contact_support: 'error',
   deleting: 'other',
@@ -132,6 +133,7 @@ export const VolumeTableRow: React.FC<CombinedProps> = (props) => {
     ),
     deleting: 'Deleting',
     deleted: 'Deleted',
+    migrating: 'Migrating',
   };
 
   const isNVMe = hardwareType === 'nvme';

--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -309,7 +309,7 @@ export const VolumesLanding: React.FC<CombinedProps> = (props) => {
             >
               Size
             </TableSortCell>
-            <TableCell>Attaced To</TableCell>
+            <TableCell>Attached To</TableCell>
             <TableCell></TableCell>
           </TableRow>
         </TableHead>

--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -21,9 +21,6 @@ import Table from 'src/components/Table/Table';
 import TableCell from 'src/components/TableCell/TableCell';
 import TableRow from 'src/components/TableRow/TableRow';
 import TableSortCell from 'src/components/TableSortCell/TableSortCell';
-import withVolumesRequests, {
-  VolumesRequests,
-} from 'src/containers/volumesRequests.container';
 import { useOrder } from 'src/hooks/useOrder';
 import { usePagination } from 'src/hooks/usePagination';
 import { useVolumesQuery } from 'src/queries/volumes';
@@ -79,7 +76,7 @@ interface DispatchProps {
   openForConfig: (volumeLabel: string, volumePath: string) => void;
 }
 
-type CombinedProps = Props & VolumesRequests & DispatchProps;
+type CombinedProps = Props & DispatchProps;
 
 export const useStyles = makeStyles(() => ({
   empty: {
@@ -370,7 +367,4 @@ const mapDispatchToProps = (dispatch: Dispatch) =>
 
 const connected = connect(undefined, mapDispatchToProps);
 
-export default compose<CombinedProps, Props>(
-  connected,
-  withVolumesRequests
-)(VolumesLanding);
+export default compose<CombinedProps, Props>(connected)(VolumesLanding);

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeVolumes.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeVolumes.tsx
@@ -282,7 +282,14 @@ export const LinodeVolumes: React.FC<CombinedProps> = (props) => {
             >
               Label
             </TableSortCell>
-            <TableCell>Region</TableCell>
+            <TableSortCell
+              active={orderBy === 'status'}
+              direction={order}
+              label="Status"
+              handleClick={handleOrderChange}
+            >
+              Status
+            </TableSortCell>
             <TableSortCell
               active={orderBy === 'size'}
               direction={order}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeVolumes.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeVolumes.tsx
@@ -239,8 +239,10 @@ export const LinodeVolumes: React.FC<CombinedProps> = (props) => {
       return <TableRowLoading rows={1} columns={5} />;
     } else if (error) {
       return <TableRowError colSpan={6} message={error[0].reason} />;
-    } else if (data?.results == 0) {
-      return <TableRowEmptyState colSpan={5} />;
+    } else if (data?.results === 0) {
+      return (
+        <TableRowEmptyState colSpan={5} message="No Volumes to display." />
+      );
     } else if (data) {
       return data.data.map((volume) => (
         <VolumeTableRow key={volume.id} {...volume} {...handlers} />

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeVolumes.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeVolumes.tsx
@@ -1,30 +1,31 @@
-import { Event } from '@linode/api-v4/lib/account';
 import { Volume } from '@linode/api-v4/lib/volumes';
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
 import { bindActionCreators, Dispatch } from 'redux';
 import AddNewLink from 'src/components/AddNewLink';
 import { makeStyles, Theme } from 'src/components/core/styles';
+import TableBody from 'src/components/core/TableBody';
+import TableHead from 'src/components/core/TableHead';
 import Typography from 'src/components/core/Typography';
-import EntityTable from 'src/components/EntityTable';
 import Grid from 'src/components/Grid';
-import Loading from 'src/components/LandingLoading';
-import { PaginationProps } from 'src/components/Pagey';
-import _withEvents, { EventsProps } from 'src/containers/events.container';
-import { StateProps as WithVolumesProps } from 'src/containers/volumes.container';
-import withVolumesRequests, {
-  VolumesRequests,
-} from 'src/containers/volumesRequests.container';
-import { Props as WithLinodesProps } from 'src/containers/withLinodes.container';
+import PaginationFooter from 'src/components/PaginationFooter/PaginationFooter';
+import Table from 'src/components/Table/Table';
+import TableCell from 'src/components/TableCell/TableCell';
+import TableRow from 'src/components/TableRow/TableRow';
+import TableRowEmptyState from 'src/components/TableRowEmptyState/TableRowEmptyState';
+import TableRowError from 'src/components/TableRowError/TableRowError';
+import { TableRowLoading } from 'src/components/TableRowLoading/TableRowLoading';
+import TableSortCell from 'src/components/TableSortCell';
 import { withLinodeDetailContext } from 'src/features/linodes/LinodesDetail/linodeDetailContext';
 import { DestructiveVolumeDialog } from 'src/features/Volumes/DestructiveVolumeDialog';
-import { ExtendedVolume } from 'src/features/Volumes/types';
 import { VolumeAttachmentDrawer } from 'src/features/Volumes/VolumeAttachmentDrawer';
 import { ActionHandlers as VolumeHandlers } from 'src/features/Volumes/VolumesActionMenu';
 import VolumeTableRow from 'src/features/Volumes/VolumeTableRow';
+import { useOrder } from 'src/hooks/useOrder';
+import usePagination from 'src/hooks/usePagination';
 import { useRegionsQuery } from 'src/queries/regions';
+import { useLinodeVolumesQuery } from 'src/queries/volumes';
 import {
   LinodeOptions,
   openForClone,
@@ -85,57 +86,12 @@ interface DispatchProps {
   openForConfig: (volumeLabel: string, volumePath: string) => void;
 }
 
-type RouteProps = RouteComponentProps<{ linodeId: string }>;
+type CombinedProps = LinodeContextProps & DispatchProps;
 
-type CombinedProps = LinodeContextProps &
-  VolumesRequests &
-  WithVolumesProps &
-  WithLinodesProps &
-  EventsProps &
-  PaginationProps<ExtendedVolume> &
-  DispatchProps &
-  RouteProps;
-
-const volumeHeaders = [
-  {
-    label: 'Label',
-    dataColumn: 'label',
-    sortable: true,
-    widthPercent: 25,
-  },
-  {
-    label: 'Region',
-    dataColumn: 'region',
-    sortable: true,
-    widthPercent: 20,
-  },
-  {
-    label: 'Size',
-    dataColumn: 'size',
-    sortable: true,
-    widthPercent: 5,
-  },
-  {
-    label: 'File System Path',
-    dataColumn: 'File System Path',
-    sortable: false,
-    widthPercent: 25,
-  },
-  {
-    label: 'Action Menu',
-    visuallyHidden: true,
-    dataColumn: '',
-    sortable: false,
-    widthPercent: 25,
-  },
-];
+export const preferenceKey = 'linode-volumes';
 
 export const LinodeVolumes: React.FC<CombinedProps> = (props) => {
   const {
-    volumesLoading,
-    volumesLastUpdated,
-    volumesError,
-    linodeVolumes,
     openForConfig,
     openForClone,
     openForEdit,
@@ -146,9 +102,32 @@ export const LinodeVolumes: React.FC<CombinedProps> = (props) => {
     linodeRegion,
   } = props;
 
+  const { order, orderBy, handleOrderChange } = useOrder(
+    {
+      orderBy: 'label',
+      order: 'desc',
+    },
+    `${preferenceKey}-order`
+  );
+
+  const filter = {
+    ['+order_by']: orderBy,
+    ['+order']: order,
+  };
+
+  const pagination = usePagination(1, preferenceKey);
+
   const classes = useStyles();
 
   const regions = useRegionsQuery().data ?? [];
+  const { data, isLoading, error } = useLinodeVolumesQuery(
+    linodeId ?? 0,
+    {
+      page: pagination.page,
+      page_size: pagination.pageSize,
+    },
+    filter
+  );
 
   const [attachmentDrawer, setAttachmentDrawer] = React.useState({
     open: false,
@@ -255,18 +234,21 @@ export const LinodeVolumes: React.FC<CombinedProps> = (props) => {
     handleDelete,
   };
 
-  const volumeRow = {
-    handlers,
-    Component: VolumeTableRow,
-    data: linodeVolumes ?? [],
-    loading: volumesLoading,
-    lastUpdated: volumesLastUpdated,
-    error: volumesError?.read,
-  };
+  const renderTableContent = () => {
+    if (isLoading) {
+      return <TableRowLoading rows={1} columns={5} />;
+    } else if (error) {
+      return <TableRowError colSpan={6} message={error[0].reason} />;
+    } else if (data?.results == 0) {
+      return <TableRowEmptyState colSpan={5} />;
+    } else if (data) {
+      return data.data.map((volume) => (
+        <VolumeTableRow key={volume.id} {...volume} {...handlers} />
+      ));
+    }
 
-  if (volumesLoading) {
-    return <Loading shouldDelay />;
-  }
+    return null;
+  };
 
   return (
     <div className={classes.volumesPanel}>
@@ -289,11 +271,39 @@ export const LinodeVolumes: React.FC<CombinedProps> = (props) => {
           />
         </Grid>
       </Grid>
-      <EntityTable
-        entity="volume"
-        headers={volumeHeaders}
-        row={volumeRow}
-        initialOrder={{ order: 'asc', orderBy: 'label' }}
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableSortCell
+              active={orderBy === 'label'}
+              direction={order}
+              label="label"
+              handleClick={handleOrderChange}
+            >
+              Label
+            </TableSortCell>
+            <TableCell>Region</TableCell>
+            <TableSortCell
+              active={orderBy === 'size'}
+              direction={order}
+              label="size"
+              handleClick={handleOrderChange}
+            >
+              Size
+            </TableSortCell>
+            <TableCell>File System Path</TableCell>
+            <TableCell></TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>{renderTableContent()}</TableBody>
+      </Table>
+      <PaginationFooter
+        count={data?.results ?? 0}
+        handlePageChange={pagination.handlePageChange}
+        handleSizeChange={pagination.handlePageSizeChange}
+        page={pagination.page}
+        pageSize={pagination.pageSize}
+        eventCategory="Volumes Table"
       />
       <VolumeAttachmentDrawer
         open={attachmentDrawer.open}
@@ -347,18 +357,7 @@ const linodeContext = withLinodeDetailContext(({ linode }) => ({
 
 const connected = connect(undefined, mapDispatchToProps);
 
-const filterVolumeEvents = (event: Event): boolean => {
-  return (
-    !event._initial && Boolean(event.entity) && event.entity!.type === 'volume'
-  );
-};
-
 export default compose<CombinedProps, {}>(
   connected,
-  linodeContext,
-  withVolumesRequests,
-  _withEvents((ownProps: CombinedProps, eventsData) => ({
-    ...ownProps,
-    eventsData: eventsData.filter(filterVolumeEvents),
-  }))
+  linodeContext
 )(LinodeVolumes);

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -343,6 +343,7 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
 
     const handleSuccess = () => {
       formik.setSubmitting(false);
+      queryClient.invalidateQueries(['linode', 'configs', props.linodeId]);
       // If there's any chance a VLAN changed here, make sure our query data is up to date
       if (
         configData.interfaces?.some(

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeStorage/LinodeStorage.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeStorage/LinodeStorage.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import LinodeDisks from '../LinodeAdvanced/LinodeDisks';
 import LinodeVolumes from 'src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeVolumes';
 
-export const LinodeStorage: React.FC = () => {
+export const LinodeStorage = () => {
   return (
     <>
       <LinodeDisks />

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 import { useHistory, useLocation, useRouteMatch } from 'react-router-dom';
 import { compose } from 'recompose';
 import Button from 'src/components/Button';
-import CircleProgress from 'src/components/CircleProgress';
 import Typography from 'src/components/core/Typography';
 import DismissibleBanner from 'src/components/DismissibleBanner';
 import Grid from 'src/components/Grid';
@@ -18,13 +17,14 @@ import { DialogType } from 'src/features/linodes/types';
 import { notificationContext as _notificationContext } from 'src/features/NotificationCenter/NotificationContext';
 import useLinodeActions from 'src/hooks/useLinodeActions';
 import useNotifications from 'src/hooks/useNotifications';
-import useReduxLoad from 'src/hooks/useReduxLoad';
-import useVolumes from 'src/hooks/useVolumes';
+import { useOrder } from 'src/hooks/useOrder';
+import usePagination from 'src/hooks/usePagination';
 import { useProfile } from 'src/queries/profile';
-import { getVolumesForLinode } from 'src/store/volume/volume.selector';
+import { useLinodeVolumesQuery } from 'src/queries/volumes';
 import { parseQueryParams } from 'src/utilities/queryParams';
 import DeleteDialog from '../../LinodesLanding/DeleteDialog';
 import MigrateLinode from '../../MigrateLanding/MigrateLinode';
+import { preferenceKey } from '../LinodeAdvanced/LinodeVolumes';
 import EnableBackupDialog from '../LinodeBackup/EnableBackupsDialog';
 import {
   LinodeDetailContext,
@@ -268,20 +268,34 @@ const LinodeDetailHeader: React.FC<CombinedProps> = (props) => {
       setTagDrawer((tagDrawer) => ({ ...tagDrawer, tags: _tags }));
     });
   };
+
+  const { order, orderBy } = useOrder(
+    {
+      orderBy: 'label',
+      order: 'desc',
+    },
+    `${preferenceKey}-order`
+  );
+
+  const filter = {
+    ['+order_by']: orderBy,
+    ['+order']: order,
+  };
+
+  const pagination = usePagination(1, preferenceKey);
+
   const { data: profile } = useProfile();
-  const { _loading } = useReduxLoad(['volumes']);
-  const { volumes } = useVolumes();
+  const { data: volumesData } = useLinodeVolumesQuery(
+    matchedLinodeId,
+    {
+      page: pagination.page,
+      page_size: pagination.pageSize,
+    },
+    filter
+  );
 
-  if (!profile?.username) {
-    return null;
-  }
-
-  if (_loading) {
-    return <CircleProgress />;
-  }
-
-  const volumesForLinode = getVolumesForLinode(volumes.itemsById, linode.id);
-  const numAttachedVolumes = volumesForLinode.length;
+  const volumesForLinode = volumesData?.data ?? [];
+  const numAttachedVolumes = volumesData?.results ?? 0;
 
   const handleDeleteLinode = (linodeId: number) => {
     history.push('/linodes');

--- a/packages/manager/src/queries/base.ts
+++ b/packages/manager/src/queries/base.ts
@@ -262,3 +262,13 @@ export const getItemInPaginatedStore = <T extends { id: number | string }>(
 
   return null;
 };
+
+export const doesItemExistInPaginatedStore = <
+  T extends { id: number | string }
+>(
+  queryKey: QueryKey,
+  id: number
+) => {
+  const item = getItemInPaginatedStore<T>(queryKey, id);
+  return item !== null;
+};

--- a/packages/manager/src/queries/base.ts
+++ b/packages/manager/src/queries/base.ts
@@ -1,5 +1,10 @@
 import { APIError, ResourcePage } from '@linode/api-v4/lib/types';
-import { QueryClient, UseMutationOptions, UseQueryOptions } from 'react-query';
+import {
+  QueryClient,
+  QueryKey,
+  UseMutationOptions,
+  UseQueryOptions,
+} from 'react-query';
 import { isEmpty } from '@linode/api-v4/lib/request';
 
 // =============================================================================
@@ -237,4 +242,23 @@ export const updateInPaginatedStore = <T extends { id: number | string }>(
       return oldData;
     }
   );
+};
+
+export const getItemInPaginatedStore = <T extends { id: number | string }>(
+  queryKey: QueryKey,
+  id: number
+) => {
+  const stores = queryClient.getQueriesData<ResourcePage<T> | undefined>(
+    queryKey
+  );
+
+  for (const store of stores) {
+    const data = store[1]?.data;
+    const item = data?.find((item) => item.id === id);
+    if (item) {
+      return item;
+    }
+  }
+
+  return null;
 };

--- a/packages/manager/src/queries/volumes.ts
+++ b/packages/manager/src/queries/volumes.ts
@@ -24,6 +24,15 @@ import {
   getLinodeVolumes,
 } from '@linode/api-v4';
 
+/**
+ * For Volumes, we must maintain the following stores to keep our cache up to date.
+ * When we manually mutate our cache, we must keep data under the following queryKeys up to date.
+ *
+ * Query Keys:
+ * - `volumes-list` - Contains Paginated Volumes
+ * - [`volumes-list`, `linode-{id}`] - Conatins Paginated Volumes for a Specifc Linode
+ */
+
 const queryKey = 'volumes';
 
 export const useVolumesQuery = (params: any, filters: any) =>

--- a/packages/manager/src/queries/volumes.ts
+++ b/packages/manager/src/queries/volumes.ts
@@ -160,8 +160,8 @@ export const volumeEventsHandler = (event: Event) => {
         case 'scheduled':
         case 'failed':
         case 'started':
-        case 'notification':
           return;
+        case 'notification':
         case 'finished':
           // This means a detach was successful. Remove associated Linode.
           const volume = getItemInPaginatedStore<Volume>(

--- a/packages/manager/src/queries/volumes.ts
+++ b/packages/manager/src/queries/volumes.ts
@@ -93,10 +93,10 @@ export const useAttachVolumeMutation = () =>
     ({ volumeId, ...data }) => attachVolume(volumeId, data),
     {
       onSuccess(volume) {
-        queryClient.invalidateQueries([
-          `${queryKey}-list`,
-          `linode-${volume.linode_id}`,
-        ]);
+        queryClient.invalidateQueries(
+          [`${queryKey}-list`, `linode-${volume.linode_id}`],
+          { exact: false, refetchInactive: true }
+        );
         updateInPaginatedStore<Volume>(`${queryKey}-list`, volume.id, volume);
       },
     }
@@ -152,10 +152,10 @@ export const volumeEventsHandler = (event: Event) => {
             entity!.id
           );
           if (volume && volume.linode_id !== null) {
-            queryClient.invalidateQueries([
-              `${queryKey}-list`,
-              `linode-${volume.linode_id}`,
-            ]);
+            queryClient.invalidateQueries(
+              [`${queryKey}-list`, `linode-${volume.linode_id}`],
+              { exact: false, refetchInactive: true }
+            );
           }
           updateInPaginatedStore<Volume>(`${queryKey}-list`, entity!.id, {
             linode_id: null,

--- a/packages/manager/src/queries/volumes.ts
+++ b/packages/manager/src/queries/volumes.ts
@@ -103,11 +103,11 @@ export const useAttachVolumeMutation = () =>
     ({ volumeId, ...data }) => attachVolume(volumeId, data),
     {
       onSuccess(volume) {
-        queryClient.invalidateQueries(
-          [`${queryKey}-list`, `linode-${volume.linode_id}`],
-          { exact: false, refetchInactive: true }
-        );
         updateInPaginatedStore<Volume>(`${queryKey}-list`, volume.id, volume);
+        queryClient.invalidateQueries([
+          `${queryKey}-list`,
+          `linode-${volume.linode_id}`,
+        ]);
       },
     }
   );
@@ -134,8 +134,8 @@ export const volumeEventsHandler = (event: Event) => {
       switch (status) {
         case 'scheduled':
         case 'started':
-          return;
         case 'notification':
+          return;
         case 'finished':
           const volume = getItemInPaginatedStore<Volume>(
             `${queryKey}-list`,
@@ -160,24 +160,24 @@ export const volumeEventsHandler = (event: Event) => {
         case 'scheduled':
         case 'failed':
         case 'started':
-          return;
         case 'notification':
+          return;
         case 'finished':
           // This means a detach was successful. Remove associated Linode.
           const volume = getItemInPaginatedStore<Volume>(
             `${queryKey}-list`,
             entity!.id
           );
-          if (volume && volume.linode_id !== null) {
-            queryClient.invalidateQueries(
-              [`${queryKey}-list`, `linode-${volume.linode_id}`],
-              { exact: false, refetchInactive: true }
-            );
-          }
           updateInPaginatedStore<Volume>(`${queryKey}-list`, entity!.id, {
             linode_id: null,
             linode_label: null,
           });
+          if (volume && volume.linode_id !== null) {
+            queryClient.invalidateQueries([
+              `${queryKey}-list`,
+              `linode-${volume.linode_id}`,
+            ]);
+          }
           return;
       }
     case 'volume_resize':


### PR DESCRIPTION
## Description 📝

- Makes `http://localhost:3000/linodes/:id/storage` use React Query

## Preview 📷

https://user-images.githubusercontent.com/115251059/198066432-616af01d-d604-47a2-b6d3-2be813113bfd.mov

## How to test 🧪

- Test all possible volume actions from `http://localhost:3000/linodes/:id/storage` 
  - When testing, check back with the `http://localhost:3000/volumes` page to make sure the cache is updating properly as mutations occur
- Test volume actions `http://localhost:3000/volumes` and make sure `http://localhost:3000/linodes/:id/storage` remains up to date

**How do I run relevant unit or e2e tests?**
