### PR TITLE
M3-5505: [DOCS] Automate developers site changlog PR

### DIFF
--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -55,7 +55,7 @@ def remove_pull_request_id(commit_message):
     return re.sub(regexp, '', commit_message).strip()
 
 def generateChangeLog(release, date, origin, repo=''):
-    git_log_command = ["git", "log", "--no-merges", "--oneline", "--pretty='%s'", "{}/develop...HEAD".format(origin)]
+    git_log_command = ["git", "log", "--no-merges", "--oneline", "--pretty='%s'", "{}/master...HEAD".format(origin)]
 
     if (repo):
         git_log_command.extend(["--", "packages/{}".format(repo)])

--- a/scripts/publish_changelog.sh
+++ b/scripts/publish_changelog.sh
@@ -77,11 +77,11 @@ generate_title_for_post() {
 generate_front_matter() {
     package=$1
     version=$2
-    formated_version=${version/#v}
+    formatted_version=${version/#v}
     title=$(generate_title_for_post $package $version)
     date=$(get_date_time)
     changelog=$(get_package_display_name $package)
-    printf -- "---\ntitle: %s\ndate: %s\nversion: %s\nchangelog:\n  - %s\n---\n" "$title" "$date" "$formated_version" "$changelog"
+    printf -- "---\ntitle: %s\ndate: %s\nversion: %s\nchangelog:\n  - %s\n---\n" "$title" "$date" "$formatted_version" "$changelog"
 }
 
 generate_post_content() {

--- a/scripts/publish_changelog.sh
+++ b/scripts/publish_changelog.sh
@@ -84,7 +84,25 @@ generate_post_content() {
     printf -- "%s\n\n%s\n" "$front_matter" "$changelog_entry_without_version_and_date"
 }
 
+generate_post_filename() {
+    package=$1
+    version=$2
+    case "$package" in
+        "manager")
+            package_filename="cloud-manager-version"
+        ;;
+        "api-v4")
+            package_filename="js-client-version"
+        ;;
+        "validation")
+            package_filename="validation-changelog"
+        ;;
+    esac
+    echo "$package_filename-${version//./-}.md"
+}
+
 changelog_entry=$(get_changelog_entry $PACKAGE)
 version=$(get_version_from_changelog_entry $changelog_entry)
 front_matter=$(generate_front_matter $PACKAGE $version)
-generate_post_content "$front_matter" "$changelog_entry"
+filename=$(generate_post_filename ${PACKAGE,,} ${version/v/})
+generate_post_content "$front_matter" "$changelog_entry" >> "/tmp/$filename"

--- a/scripts/publish_changelog.sh
+++ b/scripts/publish_changelog.sh
@@ -117,7 +117,7 @@ prompt_user_for_developers_repo_path() {
         if [[ $upstream == "git@github.com:linode/developers.git" ]]; then
             echo $developers_repo_path
         else
-            echo "The upstream repo is not git@github.com:linode/developers" >&2
+            echo "The upstream repo is not git@github.com:linode/developers.git" >&2
             return 1
         fi
     else

--- a/scripts/publish_changelog.sh
+++ b/scripts/publish_changelog.sh
@@ -117,12 +117,11 @@ prompt_user_for_developers_repo_path() {
         if [[ $upstream == "git@github.com:linode/developers.git" ]]; then
             echo $developers_repo_path
         else
-            echo "The upstream repo is not git@github.com:linode/developers"
+            echo "The upstream repo is not git@github.com:linode/developers" >&2
             return 1
         fi
-        echo
     else
-        echo "path does not point to a git repo"
+        echo "path does not point to a git repo" >&2
         return 1
     fi
 }
@@ -133,9 +132,11 @@ if (($VALID_PACKAGES[(Ie)$PACKAGE])); then
     front_matter=$(generate_front_matter $PACKAGE $version)
     filename=$(generate_post_filename ${PACKAGE:l} $version)
     developers_repo_path=$(prompt_user_for_developers_repo_path)
-    generate_post_content "$front_matter" "$changelog_entry" > "$developers_repo_path/src/content/changelog/$filename"
+    if [[ -d $developers_repo_path ]]; then
+        generate_post_content "$front_matter" "$changelog_entry" > "$developers_repo_path/src/content/changelog/$filename"
+    fi
 
 else
     echo "$PACKAGE is not a valid package"
-    return 1
+    exit
 fi

--- a/scripts/publish_changelog.sh
+++ b/scripts/publish_changelog.sh
@@ -134,6 +134,7 @@ if (($VALID_PACKAGES[(Ie)$PACKAGE])); then
     developers_repo_path=$(prompt_user_for_developers_repo_path)
     if [[ -d $developers_repo_path ]]; then
         generate_post_content "$front_matter" "$changelog_entry" > "$developers_repo_path/src/content/changelog/$filename"
+        echo "Changelog entry succesfully generated at: $developers_repo_path/src/content/changelog/$filename"
     fi
 
 else

--- a/scripts/publish_changelog.sh
+++ b/scripts/publish_changelog.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+get_changelog_entry() {
+    file="packages/validation/CHANGELOG.md"
+    declare -a changelog_lines
+    number_of_release_headers_read=0
+
+    while IFS=$'\n' read -r line; do
+        if [[ $line = *"## ["* ]]; then
+            ((number_of_release_headers_read++))
+        fi
+
+        if [[ $number_of_release_headers_read -lt 2 && $number_of_release_headers_read -ge 1 ]]; then
+            changelog_lines+=("$line")
+        fi
+    done < "$file"
+    IFS=$'\n'
+    printf "%s\n" ${changelog_lines[@]}
+}
+
+get_changelog_entry

--- a/scripts/publish_changelog.sh
+++ b/scripts/publish_changelog.sh
@@ -1,7 +1,18 @@
 #!/usr/bin/env bash
 
+PACKAGE=$1
+
+get_date_time() {
+    echo $(date +"%FT%TZ")
+}
+
 get_changelog_entry() {
-    file="packages/validation/CHANGELOG.md"
+    package=$1
+    if [[ ${package,,} == "manager" ]]; then
+        file="./CHANGELOG.md"
+    else
+        file="packages/${package,,}/CHANGELOG.md"
+    fi
     declare -a changelog_lines
     number_of_release_headers_read=0
 
@@ -18,4 +29,62 @@ get_changelog_entry() {
     printf "%s\n" ${changelog_lines[@]}
 }
 
-get_changelog_entry
+get_version_from_changelog_entry() {
+    echo $4
+}
+
+get_package_display_name() {
+    package=$1
+    case "$package" in
+        "manager")
+            title="Cloud Manager"
+        ;;
+        "api-v4")
+            title="APIv4 JS Client"
+        ;;
+        "validation")
+            title="Validation"
+        ;;
+    esac
+    echo $title
+}
+
+generate_title_for_post() {
+    package=$1
+    version=$2
+    case "$package" in
+        "manager")
+            title="Cloud Manager"
+        ;;
+        "api-v4")
+            title="Linode APIv4 JS Client"
+        ;;
+        "validation")
+            title="Linode Validation"
+        ;;
+    esac
+    echo "$title $version"
+}
+
+generate_front_matter() {
+    package=$1
+    version=$2
+    formated_version=${version/#v}
+    title=$(generate_title_for_post $package $version)
+    date=$(get_date_time)
+    changelog=$(get_package_display_name $package)
+    printf -- "---\ntitle: %s\ndate: %s\nversion: %s\nchangelog:\n  - %s\n---\n" "$title" "$date" "$formated_version" "$changelog"
+}
+
+generate_post_content() {
+    front_matter=$1
+    changelog_entry=$2
+    changelog_length=${#changelog_entry}
+    changelog_entry_without_version_and_date=${changelog_entry#*$'\n'}
+    printf -- "%s\n\n%s\n" "$front_matter" "$changelog_entry_without_version_and_date"
+}
+
+changelog_entry=$(get_changelog_entry $PACKAGE)
+version=$(get_version_from_changelog_entry $changelog_entry)
+front_matter=$(generate_front_matter $PACKAGE $version)
+generate_post_content "$front_matter" "$changelog_entry"


### PR DESCRIPTION
## Description 📝

Automates the creation of PRs against linode developers repo for package changelogs.

## How to test 🧪

1. Open a terminal to the root of the project repo
2. run `scripts/publish_changelog.sh <PACKAGE_NAME>`
replace `<PACKAGE_NAME>` with `manager`, `api-v4`, or `validation` 
3. Check the success message for the location of the generated file
4. Ensure generated file is properly formatted and has the correct content.
