### PR TITLE
M3-5961: Restore paste functionality for Glish

### DIFF
--- a/packages/manager/src/features/Lish/Glish.tsx
+++ b/packages/manager/src/features/Lish/Glish.tsx
@@ -52,6 +52,9 @@ const Glish = (props: Props) => {
       }
     }, 30 * 1000);
 
+    // eslint-disable-next-line scanjs-rules/call_addEventListener
+    document.addEventListener('paste', handlePaste);
+
     return () => {
       clearInterval(monitorInterval);
       clearInterval(renewInterval);
@@ -64,6 +67,30 @@ const Glish = (props: Props) => {
     connectMonitor();
     ref.current?.connect();
   }, [token]);
+
+  const handlePaste = (event: ClipboardEvent) => {
+    event.preventDefault();
+    if (!ref.current?.rfb) {
+      return;
+    }
+    if (event.clipboardData === null) {
+      return;
+    }
+    if (event.clipboardData.getData('text') === null) {
+      return;
+    }
+
+    const text = event.clipboardData.getData('text/plain');
+    console.log(text);
+
+    ref.current?.rfb.clipboardPasteFrom(text);
+
+    // setTimeout(() => {
+    //   for (let i = 0; i < text.length; i++) {
+    //     ref.current?.rfb?.sendKey(text.charCodeAt(i), 1, false);
+    //   }
+    // }, 100);
+  };
 
   const connectMonitor = () => {
     if (monitor && monitor.readyState === monitor.OPEN) {


### PR DESCRIPTION
## Description 📝
Paste functionality for Glish was introduced a few years ago with https://github.com/linode/manager/pull/5627 but was lost in the recent move from `novnc-node` to `react-vnc` in https://github.com/linode/manager/pull/8531. This PR looks to restore the paste functionality using the new package.

## Preview 📷

## How to test 🧪
Launch Glish and try to paste the contents of your clipboard using the browser's Paste functionality (Edit --> Paste).

