### PR TITLE
M3-5968: Revised copy on Database Backups tab

### DIFF
--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
@@ -118,8 +118,8 @@ export const DatabaseBackups: React.FC = () => {
       <Paper style={{ marginTop: 16 }}>
         <Typography variant="h3">Backup Schedule</Typography>
         <Typography style={{ lineHeight: '20px', marginTop: 4 }}>
-          A backup of this database is created every 24 hours at 0:00 UTC and
-          each backup is retained for 7 days.
+          A backup of this database is created every 24 hours and each backup is
+          retained for 7 days.
         </Typography>
       </Paper>
       {database && backupToRestore ? (


### PR DESCRIPTION
## Description 📝
The copy in the "Backup Schedule" section on the Backups tab of the Database detail page now reads, "A backup of this database is created every 24 hours and each backup is retained for 7 days." 
