### PR TITLE
M3-5977: Improve User Permissions Page for Large Accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2022-11-07] - v1.79.1
+### Fixed:
+- Bug when managing user permissions for large accounts
+
 ## [2022-11-01] - v1.79.0
 ### Added:
 - Set custom UserAgent header for api-v4 when run in node

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.79.0",
+  "version": "1.79.1",
   "private": true,
   "engines": {
     "node": ">= 14.17.4"

--- a/packages/manager/src/components/Paginate.ts
+++ b/packages/manager/src/components/Paginate.ts
@@ -3,9 +3,10 @@ import * as React from 'react';
 import scrollTo from 'src/utilities/scrollTo';
 import { storage } from 'src/utilities/storage';
 
-const createDisplayPage = <T extends any>(page: number, pageSize: number) => (
-  list: T[]
-): T[] => {
+export const createDisplayPage = <T extends any>(
+  page: number,
+  pageSize: number
+) => (list: T[]): T[] => {
   const count = list.length;
   if (count === 0) {
     return list;

--- a/packages/manager/src/factories/grants.ts
+++ b/packages/manager/src/factories/grants.ts
@@ -1,5 +1,11 @@
 import * as Factory from 'factory.ts';
-import { Grants } from '@linode/api-v4/lib/account';
+import { Grant, Grants } from '@linode/api-v4/lib/account';
+
+export const grantFactory = Factory.Sync.makeFactory<Grant>({
+  id: Factory.each((i) => i),
+  label: Factory.each((i) => `entity-${i}`),
+  permissions: null,
+});
 
 export const grantsFactory = Factory.Sync.makeFactory<Grants>({
   domain: [

--- a/packages/manager/src/features/Users/UserPermissions.tsx
+++ b/packages/manager/src/features/Users/UserPermissions.tsx
@@ -594,20 +594,6 @@ class UserPermissions extends React.Component<CombinedProps, State> {
       return eachPerm.value === setAllPerm;
     });
 
-    // const { showTabs, tabs } = this.entityPerms.reduce(
-    //   (acc: TabInfo, entity: GrantType) => {
-    //     const grantsForEntity = this.state.grants?.[entity];
-    //     if (grantsForEntity && grantsForEntity.length > 25) {
-    //       return { showTabs: true, tabs: [...acc.tabs, entity] };
-    //     }
-    //     if (grantsForEntity && grantsForEntity.length > 0) {
-    //       return { ...acc, tabs: [...acc.tabs, entity] };
-    //     }
-    //     return acc;
-    //   },
-    //   { tabs: [], showTabs: false }
-    // );
-
     return (
       <Paper className={classes.globalSection} data-qa-entity-section>
         <Grid container justifyContent="space-between" alignItems="center">

--- a/packages/manager/src/features/Users/UserPermissions.tsx
+++ b/packages/manager/src/features/Users/UserPermissions.tsx
@@ -181,17 +181,26 @@ class UserPermissions extends React.Component<CombinedProps, State> {
     if (username) {
       getGrants(username)
         .then((grants) => {
-          const { showTabs, tabs } = this.getTabInformation(grants);
+          if (grants.global) {
+            const { showTabs, tabs } = this.getTabInformation(grants);
 
-          this.setState({
-            grants,
-            originalGrants: grants,
-            loading: false,
-            loadingGrants: false,
-            restricted: true,
-            showTabs,
-            tabs,
-          });
+            this.setState({
+              grants,
+              originalGrants: grants,
+              loading: false,
+              loadingGrants: false,
+              restricted: true,
+              showTabs,
+              tabs,
+            });
+          } else {
+            this.setState({
+              grants,
+              loading: false,
+              loadingGrants: false,
+              restricted: false,
+            });
+          }
         })
         .catch((errResponse) => {
           this.setState({

--- a/packages/manager/src/features/Users/UserPermissions.tsx
+++ b/packages/manager/src/features/Users/UserPermissions.tsx
@@ -22,23 +22,26 @@ import {
   withStyles,
   WithStyles,
 } from 'src/components/core/styles';
-import TableBody from 'src/components/core/TableBody';
-import TableHead from 'src/components/core/TableHead';
 import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
-import Radio from 'src/components/Radio';
 import SelectionCard from 'src/components/SelectionCard';
-import Table from 'src/components/Table';
-import TableCell from 'src/components/TableCell';
-import TableRow from 'src/components/TableRow';
 import Toggle from 'src/components/Toggle';
 import { queryClient } from 'src/queries/base';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
+import {
+  entityNameMap,
+  UserPermissionsEntitySection,
+} from './UserPermissionsEntitySection';
+import TabPanels from 'src/components/core/ReachTabPanels';
+import Tabs from 'src/components/core/ReachTabs';
+import Tab from 'src/components/core/ReachTab';
+import SafeTabPanel from 'src/components/SafeTabPanel/SafeTabPanel';
+import TabList from 'src/components/core/ReachTabList';
 
 type ClassNames =
   | 'title'
@@ -47,11 +50,7 @@ type ClassNames =
   | 'globalSection'
   | 'globalRow'
   | 'section'
-  | 'grantTable'
-  | 'selectAll'
-  | 'tableSubheading'
-  | 'setAll'
-  | 'label';
+  | 'setAll';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -77,26 +76,6 @@ const styles = (theme: Theme) =>
       marginTop: theme.spacing(2),
       paddingBottom: 0,
     },
-    grantTable: {
-      '& th': {
-        width: '25%',
-        minWidth: 150,
-      },
-      '& td': {
-        width: '100%',
-        [theme.breakpoints.down('sm')]: {
-          paddingRight: '0 !important',
-          paddingLeft: 0,
-        },
-      },
-    },
-    tableSubheading: {
-      marginTop: theme.spacing(3),
-      marginBottom: theme.spacing(2),
-    },
-    selectAll: {
-      cursor: 'pointer',
-    },
     setAll: {
       '& > div': {
         display: 'flex',
@@ -114,13 +93,6 @@ const styles = (theme: Theme) =>
       },
       '& .react-select__menu-list': {
         width: '100%',
-      },
-    },
-    label: {
-      '& div': {
-        [theme.breakpoints.down('sm')]: {
-          width: '100%',
-        },
       },
     },
   });
@@ -509,7 +481,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
         className={classes.section}
       >
         <Button buttonType="secondary" onClick={onCancel} data-qa-cancel>
-          Cancel
+          Reset
         </Button>
         <Button
           buttonType="primary"
@@ -600,135 +572,6 @@ class UserPermissions extends React.Component<CombinedProps, State> {
     this.setState(set(lensPath(['grants', entity, idx, 'permissions']), value));
   };
 
-  renderEntitySection = (entity: GrantType) => {
-    const { classes } = this.props;
-    const { grants } = this.state;
-    if (!(grants && grants[entity] && grants[entity].length)) {
-      return null;
-    }
-    const entityGrants = grants[entity];
-
-    const entityNameMap = {
-      linode: 'Linodes',
-      stackscript: 'StackScripts',
-      image: 'Images',
-      volume: 'Volumes',
-      nodebalancer: 'NodeBalancers',
-      domain: 'Domains',
-      longview: 'Longview Clients',
-      firewall: 'Firewalls',
-    };
-
-    return (
-      <div key={entity} className={classes.section}>
-        <Typography
-          variant="h3"
-          className={classes.tableSubheading}
-          data-qa-permissions-header={entityNameMap[entity]}
-        >
-          {entityNameMap[entity]}
-        </Typography>
-        <Table
-          aria-label="User Permissions"
-          className={classes.grantTable}
-          noBorder
-        >
-          <TableHead data-qa-table-head>
-            <TableRow>
-              <TableCell>Label</TableCell>
-              <TableCell padding="checkbox">
-                {/* eslint-disable-next-line */}
-                <label
-                  className={classes.selectAll}
-                  style={{ marginLeft: -35 }}
-                >
-                  None
-                  <Radio
-                    name={`${entity}-select-all`}
-                    checked={this.entityIsAll(entity, null)}
-                    value="null"
-                    onChange={this.entitySetAllTo(entity, null)}
-                    data-qa-permission-header="None"
-                  />
-                </label>
-              </TableCell>
-              <TableCell padding="checkbox">
-                {/* eslint-disable-next-line */}
-                <label
-                  className={classes.selectAll}
-                  style={{ marginLeft: -65 }}
-                >
-                  Read Only
-                  <Radio
-                    name={`${entity}-select-all`}
-                    checked={this.entityIsAll(entity, 'read_only')}
-                    value="read_only"
-                    onChange={this.entitySetAllTo(entity, 'read_only')}
-                    data-qa-permission-header="Read Only"
-                  />
-                </label>
-              </TableCell>
-              <TableCell padding="checkbox">
-                {/* eslint-disable-next-line */}
-                <label
-                  className={classes.selectAll}
-                  style={{ marginLeft: -73 }}
-                >
-                  Read-Write
-                  <Radio
-                    name={`${entity}-select-all`}
-                    checked={this.entityIsAll(entity, 'read_write')}
-                    value="read_write"
-                    onChange={this.entitySetAllTo(entity, 'read_write')}
-                    data-qa-permission-header="Read-Write"
-                  />
-                </label>
-              </TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {entityGrants.map((grant, idx) => {
-              return (
-                <TableRow key={grant.id} data-qa-specific-grant={grant.label}>
-                  <TableCell className={classes.label} parentColumn="Label">
-                    {grant.label}
-                  </TableCell>
-                  <TableCell parentColumn="None" padding="checkbox">
-                    <Radio
-                      name={`${grant.id}-perms`}
-                      checked={grant.permissions === null}
-                      value="null"
-                      onChange={this.setGrantTo(entity, idx, null)}
-                      data-qa-permission="None"
-                    />
-                  </TableCell>
-                  <TableCell parentColumn="Read Only" padding="checkbox">
-                    <Radio
-                      name={`${grant.id}-perms`}
-                      checked={grant.permissions === 'read_only'}
-                      value="read_only"
-                      onChange={this.setGrantTo(entity, idx, 'read_only')}
-                      data-qa-permission="Read Only"
-                    />
-                  </TableCell>
-                  <TableCell parentColumn="Read-Write" padding="checkbox">
-                    <Radio
-                      name={`${grant.id}-perms`}
-                      checked={grant.permissions === 'read_write'}
-                      value="read_write"
-                      onChange={this.setGrantTo(entity, idx, 'read_write')}
-                      data-qa-permission="Read-Write"
-                    />
-                  </TableCell>
-                </TableRow>
-              );
-            })}
-          </TableBody>
-        </Table>
-      </div>
-    );
-  };
-
   setAllEntitiesTo = (e: Item) => {
     const value = e.value === 'null' ? null : e.value;
     this.entityPerms.map((entity: GrantType) =>
@@ -752,6 +595,16 @@ class UserPermissions extends React.Component<CombinedProps, State> {
     const defaultPerm = permOptions.find((eachPerm) => {
       return eachPerm.value === setAllPerm;
     });
+
+    const tabs = this.entityPerms.reduce((acc: string[], entity: string) => {
+      const grantsForEntity = this.state.grants?.[entity];
+      if (grantsForEntity && grantsForEntity.length > 25) {
+        acc.push(entity);
+      }
+      return acc;
+    }, []);
+
+    const showTabs = tabs.length > 0;
 
     return (
       <Paper className={classes.globalSection} data-qa-entity-section>
@@ -782,10 +635,40 @@ class UserPermissions extends React.Component<CombinedProps, State> {
           </Grid>
         </Grid>
         <div className={classes.section}>
-          {grants &&
-            this.entityPerms.map((entity: GrantType) => {
-              return this.renderEntitySection(entity);
-            })}
+          {showTabs ? (
+            <Tabs>
+              <TabList>
+                {tabs.map((entity) => (
+                  <Tab key={`${entity}-tab`}>{entityNameMap[entity]}</Tab>
+                ))}
+              </TabList>
+              <TabPanels>
+                {tabs.map((entity: GrantType, idx) => (
+                  <SafeTabPanel key={`${entity}-tab-content`} index={idx}>
+                    <UserPermissionsEntitySection
+                      key={entity}
+                      grants={this.state.grants?.[entity]}
+                      entity={entity}
+                      setGrantTo={this.setGrantTo}
+                      entitySetAllTo={this.entitySetAllTo}
+                    />
+                  </SafeTabPanel>
+                ))}
+              </TabPanels>
+            </Tabs>
+          ) : (
+            grants &&
+            this.entityPerms.map((entity: GrantType) => (
+              <UserPermissionsEntitySection
+                key={entity}
+                grants={this.state.grants?.[entity]}
+                entity={entity}
+                setGrantTo={this.setGrantTo}
+                entitySetAllTo={this.entitySetAllTo}
+                showHeading
+              />
+            ))
+          )}
         </div>
         {success && success.specific && (
           <Notice

--- a/packages/manager/src/features/Users/UserPermissionsEntitySection.tsx
+++ b/packages/manager/src/features/Users/UserPermissionsEntitySection.tsx
@@ -1,0 +1,221 @@
+import React from 'react';
+import { Grant, GrantLevel, GrantType } from '@linode/api-v4/lib/account';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import Table from 'src/components/Table/Table';
+import TableHead from 'src/components/core/TableHead';
+import TableRow from 'src/components/TableRow/TableRow';
+import TableCell from 'src/components/TableCell/TableCell';
+import Radio from 'src/components/Radio/Radio';
+import TableBody from 'src/components/core/TableBody';
+import PaginationFooter from 'src/components/PaginationFooter/PaginationFooter';
+import { usePagination } from 'src/hooks/usePagination';
+import { createDisplayPage } from 'src/components/Paginate';
+import Typography from 'src/components/core/Typography';
+
+export const entityNameMap = {
+  linode: 'Linodes',
+  stackscript: 'StackScripts',
+  image: 'Images',
+  volume: 'Volumes',
+  nodebalancer: 'NodeBalancers',
+  domain: 'Domains',
+  longview: 'Longview Clients',
+  firewall: 'Firewalls',
+};
+
+interface Props {
+  entity: GrantType;
+  grants: Grant[] | undefined;
+  setGrantTo: (entity: string, idx: number, value: GrantLevel) => () => void;
+  entitySetAllTo: (entity: GrantType, value: GrantLevel) => () => void;
+  showHeading?: boolean;
+}
+
+const useStyles = makeStyles((theme: Theme) => ({
+  section: {
+    marginTop: theme.spacing(2),
+    paddingBottom: 0,
+  },
+  setAll: {
+    '& > div': {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'flex-end',
+    },
+    '& label': {
+      marginTop: 6,
+    },
+    '& .react-select__menu, & .input': {
+      width: 125,
+      right: 0,
+      marginLeft: theme.spacing(1),
+      textAlign: 'left',
+    },
+    '& .react-select__menu-list': {
+      width: '100%',
+    },
+  },
+  label: {
+    '& div': {
+      [theme.breakpoints.down('sm')]: {
+        width: '100%',
+      },
+    },
+  },
+  selectAll: {
+    cursor: 'pointer',
+  },
+  grantTable: {
+    '& th': {
+      width: '25%',
+      minWidth: 150,
+    },
+    '& td': {
+      width: '100%',
+      [theme.breakpoints.down('sm')]: {
+        paddingRight: '0 !important',
+        paddingLeft: 0,
+      },
+    },
+  },
+  tableSubheading: {
+    marginTop: theme.spacing(3),
+    marginBottom: theme.spacing(2),
+  },
+}));
+
+export const UserPermissionsEntitySection = React.memo((props: Props) => {
+  const { entity, grants, setGrantTo, entitySetAllTo, showHeading } = props;
+  const classes = useStyles();
+
+  const pagination = usePagination(1);
+
+  if (!grants || grants.length === 0) {
+    return null;
+  }
+
+  const page = createDisplayPage<Grant>(
+    pagination.page,
+    pagination.pageSize
+  )(grants);
+
+  const entityIsAll = (value: GrantLevel): boolean => {
+    if (!grants) {
+      return false;
+    }
+
+    return !grants.some((grant) => grant.permissions !== value);
+  };
+
+  return (
+    <div key={entity} className={classes.section}>
+      {showHeading && (
+        <Typography
+          variant="h3"
+          className={classes.tableSubheading}
+          data-qa-permissions-header={entity}
+        >
+          {entityNameMap[entity]}
+        </Typography>
+      )}
+      <Table
+        aria-label="User Permissions"
+        className={classes.grantTable}
+        noBorder
+      >
+        <TableHead data-qa-table-head>
+          <TableRow>
+            <TableCell>Label</TableCell>
+            <TableCell padding="checkbox">
+              {/* eslint-disable-next-line */}
+              <label className={classes.selectAll} style={{ marginLeft: -35 }}>
+                None
+                <Radio
+                  name={`${entity}-select-all`}
+                  checked={entityIsAll(null)}
+                  value="null"
+                  onChange={entitySetAllTo(entity, null)}
+                  data-qa-permission-header="None"
+                />
+              </label>
+            </TableCell>
+            <TableCell padding="checkbox">
+              {/* eslint-disable-next-line */}
+              <label className={classes.selectAll} style={{ marginLeft: -65 }}>
+                Read Only
+                <Radio
+                  name={`${entity}-select-all`}
+                  checked={entityIsAll('read_only')}
+                  value="read_only"
+                  onChange={entitySetAllTo(entity, 'read_only')}
+                  data-qa-permission-header="Read Only"
+                />
+              </label>
+            </TableCell>
+            <TableCell padding="checkbox">
+              {/* eslint-disable-next-line */}
+              <label className={classes.selectAll} style={{ marginLeft: -73 }}>
+                Read-Write
+                <Radio
+                  name={`${entity}-select-all`}
+                  checked={entityIsAll('read_write')}
+                  value="read_write"
+                  onChange={entitySetAllTo(entity, 'read_write')}
+                  data-qa-permission-header="Read-Write"
+                />
+              </label>
+            </TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {page.map((grant, _idx) => {
+            // Index must be corrected to account for pagination
+            const idx = (pagination.page - 1) * pagination.pageSize + _idx;
+            return (
+              <TableRow key={grant.id} data-qa-specific-grant={grant.label}>
+                <TableCell className={classes.label} parentColumn="Label">
+                  {grant.label}
+                </TableCell>
+                <TableCell parentColumn="None" padding="checkbox">
+                  <Radio
+                    name={`${grant.id}-perms`}
+                    checked={grant.permissions === null}
+                    value="null"
+                    onChange={setGrantTo(entity, idx, null)}
+                    data-qa-permission="None"
+                  />
+                </TableCell>
+                <TableCell parentColumn="Read Only" padding="checkbox">
+                  <Radio
+                    name={`${grant.id}-perms`}
+                    checked={grant.permissions === 'read_only'}
+                    value="read_only"
+                    onChange={setGrantTo(entity, idx, 'read_only')}
+                    data-qa-permission="Read Only"
+                  />
+                </TableCell>
+                <TableCell parentColumn="Read-Write" padding="checkbox">
+                  <Radio
+                    name={`${grant.id}-perms`}
+                    checked={grant.permissions === 'read_write'}
+                    value="read_write"
+                    onChange={setGrantTo(entity, idx, 'read_write')}
+                    data-qa-permission="Read-Write"
+                  />
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+      <PaginationFooter
+        count={grants.length}
+        handlePageChange={pagination.handlePageChange}
+        handleSizeChange={pagination.handlePageSizeChange}
+        page={pagination.page}
+        pageSize={pagination.pageSize}
+        eventCategory={`User Permissions for ${entity}`}
+      />
+    </div>
+  );
+});

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -780,11 +780,11 @@ export const handlers = [
           domain: [],
           firewall: [],
           image: [],
-          linode: grantFactory.buildList(6000),
+          linode: grantFactory.buildList(6),
           longview: [],
           nodebalancer: [],
-          stackscript: [],
-          volume: grantFactory.buildList(100),
+          stackscript: grantFactory.buildList(30),
+          volume: grantFactory.buildList(1),
         })
       )
     );

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -780,11 +780,11 @@ export const handlers = [
           domain: [],
           firewall: [],
           image: [],
-          linode: grantFactory.buildList(6),
+          linode: grantFactory.buildList(6000),
           longview: [],
           nodebalancer: [],
           stackscript: grantFactory.buildList(30),
-          volume: grantFactory.buildList(1),
+          volume: grantFactory.buildList(100),
         })
       )
     );

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -75,7 +75,7 @@ import {
   proDedicatedTypeFactory,
 } from 'src/factories';
 import { accountAgreementsFactory } from 'src/factories/accountAgreements';
-import { grantsFactory } from 'src/factories/grants';
+import { grantFactory, grantsFactory } from 'src/factories/grants';
 import { pickRandom } from 'src/utilities/random';
 
 export const makeResourcePage = (
@@ -780,11 +780,11 @@ export const handlers = [
           domain: [],
           firewall: [],
           image: [],
-          linode: [],
+          linode: grantFactory.buildList(6000),
           longview: [],
           nodebalancer: [],
           stackscript: [],
-          volume: [],
+          volume: grantFactory.buildList(100),
         })
       )
     );


### PR DESCRIPTION
## Description 📝

- **Client-side** paginates user grants on `https://cloud.linode.com/account/users/:username/permissions`
- For larger accounts, this page will switch to a "Tab" mode
- For smaller accounts, this page will remain as is

## Preview 📷

### Before 🐌
https://user-images.githubusercontent.com/115251059/200047030-b4a1c459-496d-4727-a715-5dda239ecfbf.mov


### After ✅
https://user-images.githubusercontent.com/115251059/200046392-233d4533-452d-4695-902c-bf53d1cae64e.mov

## How to test 🧪

- Test `https://cloud.linode.com/account/users/:username/permissions` in depth
- Turn on the MSW to simulate a large account
