### PR TITLE
Remove no-longer-used Storybook scripts from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,6 @@
     "test": "yarn workspace linode-manager test --maxWorkers=4",
     "package-versions": "node ./scripts/package-versions/index.js",
     "storybook": "yarn workspace linode-manager storybook",
-    "storybook:e2e": "yarn workspace linode-manager storybook:e2e",
-    "storybook:debug": "yarn storybook:e2e --color --debug",
     "cy:run": "yarn workspace linode-manager cy:run",
     "cy:e2e": "yarn workspace linode-manager cy:e2e",
     "cy:ci": "yarn cypress install && yarn cy:e2e",


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
Removes two old scripts from `package.json` that are no longer used with Storybook. 

## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**

- Run `yarn storybook:e2e` and `yarn storybook:debug` from the base of the repo and verify that you receive a console error of "Command not found" for each. We removed the commands; they should no longer even attempt to run and then fail. 
- Run `yarn storybook` and `yarn build-storybook` to observe output looks normal.