### PR TITLE
Enable Cobertura coverage report

### DIFF
--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -253,6 +253,13 @@
       "src/**/*.{js,jsx,ts,tsx}",
       "!src/**/*.stories.{js,jsx,ts,tsx}"
     ],
+    "coverageReporters": [
+      "clover",
+      "json",
+      "text",
+      "lcov",
+      "cobertura"
+    ],
     "setupFiles": [
       "<rootDir>/config/polyfills.js"
     ],


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
Generates a Cobertura coverage report when running jest with the `--coverage` flag.

## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**
Run `yarn test --coverage` and confirm that the following file exists after it completes:
```
packages/manager/coverage/cobertura-coverage.xml
```
