### PR TITLE
Upgrade to Cypress 11

### DIFF
--- a/packages/manager/Dockerfile
+++ b/packages/manager/Dockerfile
@@ -18,7 +18,7 @@ CMD yarn start:manager:ci
 # `e2e`
 #
 # Runs Cloud Manager Cypress tests.
-FROM cypress/included:11.0.0 as e2e
+FROM cypress/included:11.2.0 as e2e
 WORKDIR /home/node/app
 VOLUME /home/node/app
 USER node

--- a/packages/manager/Dockerfile
+++ b/packages/manager/Dockerfile
@@ -18,7 +18,7 @@ CMD yarn start:manager:ci
 # `e2e`
 #
 # Runs Cloud Manager Cypress tests.
-FROM cypress/included:9.6.0 as e2e
+FROM cypress/included:11.0.0 as e2e
 WORKDIR /home/node/app
 VOLUME /home/node/app
 USER node

--- a/packages/manager/cypress.config.ts
+++ b/packages/manager/cypress.config.ts
@@ -64,6 +64,7 @@ export default defineConfig({
   responseTimeout: 80000,
   retries: 2,
   e2e: {
+    experimentalRunAllSpecs: true,
     baseUrl: 'http://localhost:3000',
     specPattern: 'cypress/e2e/**/*.spec.{ts,tsx}',
     setupNodeEvents(on, config) {

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -191,7 +191,7 @@
     "core-js": "^2.6.5",
     "css-loader": "^6.5.1",
     "csstype": "^2.5.5",
-    "cypress": "^11.0.0",
+    "cypress": "^11.0.1",
     "cypress-axe": "^1.0.0",
     "cypress-file-upload": "^5.0.7",
     "cypress-real-events": "^1.7.0",

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -191,7 +191,7 @@
     "core-js": "^2.6.5",
     "css-loader": "^6.5.1",
     "csstype": "^2.5.5",
-    "cypress": "^11.0.1",
+    "cypress": "^11.2.0",
     "cypress-axe": "^1.0.0",
     "cypress-file-upload": "^5.0.7",
     "cypress-real-events": "^1.7.0",

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -191,7 +191,7 @@
     "core-js": "^2.6.5",
     "css-loader": "^6.5.1",
     "csstype": "^2.5.5",
-    "cypress": "^10.10.0",
+    "cypress": "^11.0.0",
     "cypress-axe": "^1.0.0",
     "cypress-file-upload": "^5.0.7",
     "cypress-real-events": "^1.7.0",

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -141,7 +141,7 @@
     "@svgr/webpack": "^5.5.0",
     "@swc/core": "^1.3.1",
     "@swc/jest": "^0.2.22",
-    "@testing-library/cypress": "^8.0.2",
+    "@testing-library/cypress": "^8.0.7",
     "@testing-library/jest-dom": "~5.11.3",
     "@testing-library/react": "~10.4.9",
     "@testing-library/react-hooks": "~3.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7014,10 +7014,10 @@ cypress-real-events@^1.7.0:
   resolved "https://registry.yarnpkg.com/cypress-real-events/-/cypress-real-events-1.7.0.tgz#ad6a78de33af3af0e6437f5c713e30691c44472c"
   integrity sha512-iyXp07j0V9sG3YClVDcvHN2DAQDgr+EjTID82uWDw6OZBlU3pXEBqTMNYqroz3bxlb0k+F74U81aZwzMNaKyew==
 
-cypress@^11.0.0:
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-11.0.0.tgz#999aa8f62ce3777ea2c45a10d9975025db0337ee"
-  integrity sha512-mYXGi2Wjmy9shRjAUDugSMOr4uuzE2nl7hXQi3oQkIQsnwwBx2HNB8Vbfsix3A0zyPXlL5jTcbb6rCVWKRaXbg==
+cypress@^11.0.1:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-11.0.1.tgz#5332a1825b37ab3f4f81d74389930c55cc7cf31d"
+  integrity sha512-NuEfd0Vim492RJ3m/+bbTZ3OZrqXgfAfuLaZfIQ9D5lKocS3EDr2tyAarZdAhKwLyoh7OJ33jwMeMFIDbzYqog==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7014,10 +7014,10 @@ cypress-real-events@^1.7.0:
   resolved "https://registry.yarnpkg.com/cypress-real-events/-/cypress-real-events-1.7.0.tgz#ad6a78de33af3af0e6437f5c713e30691c44472c"
   integrity sha512-iyXp07j0V9sG3YClVDcvHN2DAQDgr+EjTID82uWDw6OZBlU3pXEBqTMNYqroz3bxlb0k+F74U81aZwzMNaKyew==
 
-cypress@^10.10.0:
-  version "10.10.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-10.10.0.tgz#fd671297b2ca3e64dfffd55fe3857c388cfbb695"
-  integrity sha512-bU8r44x1NIYAUNNXt3CwJpLOVth7HUv2hUhYCxZmgZ1IugowDvuHNpevnoZRQx1KKOEisLvIJW+Xen5Pjn41pg==
+cypress@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-11.0.0.tgz#999aa8f62ce3777ea2c45a10d9975025db0337ee"
+  integrity sha512-mYXGi2Wjmy9shRjAUDugSMOr4uuzE2nl7hXQi3oQkIQsnwwBx2HNB8Vbfsix3A0zyPXlL5jTcbb6rCVWKRaXbg==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3135,10 +3135,10 @@
   resolved "https://registry.yarnpkg.com/@swc/wasm/-/wasm-1.2.130.tgz#88ac26433335d1f957162a9a92f1450b73c176a0"
   integrity sha512-rNcJsBxS70+pv8YUWwf5fRlWX6JoY/HJc25HD/F8m6Kv7XhJdqPPMhyX6TKkUBPAG7TWlZYoxa+rHAjPy4Cj3Q==
 
-"@testing-library/cypress@^8.0.2":
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/@testing-library/cypress/-/cypress-8.0.2.tgz#b13f0ff2424dec4368b6670dfbfb7e43af8eefc9"
-  integrity sha512-KVdm7n37sg/A4e3wKMD4zUl0NpzzVhx06V9Tf0hZHZ7nrZ4yFva6Zwg2EFF1VzHkEfN/ahUzRtT1qiW+vuWnJw==
+"@testing-library/cypress@^8.0.7":
+  version "8.0.7"
+  resolved "https://registry.yarnpkg.com/@testing-library/cypress/-/cypress-8.0.7.tgz#18315eba3cf8852808afadf122e4858406384015"
+  integrity sha512-3HTV725rOS+YHve/gD9coZp/UcPK5xhr4H0GMnq/ni6USdtzVtSOG9WBFtd8rYnrXk8rrGD+0toRFYouJNIG0Q==
   dependencies:
     "@babel/runtime" "^7.14.6"
     "@testing-library/dom" "^8.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7014,10 +7014,10 @@ cypress-real-events@^1.7.0:
   resolved "https://registry.yarnpkg.com/cypress-real-events/-/cypress-real-events-1.7.0.tgz#ad6a78de33af3af0e6437f5c713e30691c44472c"
   integrity sha512-iyXp07j0V9sG3YClVDcvHN2DAQDgr+EjTID82uWDw6OZBlU3pXEBqTMNYqroz3bxlb0k+F74U81aZwzMNaKyew==
 
-cypress@^11.0.1:
-  version "11.0.1"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-11.0.1.tgz#5332a1825b37ab3f4f81d74389930c55cc7cf31d"
-  integrity sha512-NuEfd0Vim492RJ3m/+bbTZ3OZrqXgfAfuLaZfIQ9D5lKocS3EDr2tyAarZdAhKwLyoh7OJ33jwMeMFIDbzYqog==
+cypress@^11.2.0:
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-11.2.0.tgz#63edef8c387b687066c5493f6f0ad7b9ced4b2b7"
+  integrity sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
Upgrades Cloud Manager to use Cypress 11.

It doesn't seem like much has changed between Cypress 10 and 11, and most of the changes are focused on component testing rather than e2e testing.

## How to test 🧪

```bash
yarn cy:run
```

I've run Cypress 11 locally and confirmed that our tests are still passing.