### PR TITLE
M3-5461: Add Object Storage type to confirm

### DIFF
--- a/packages/manager/src/components/TypeToConfirm/TypeToConfirm.test.tsx
+++ b/packages/manager/src/components/TypeToConfirm/TypeToConfirm.test.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+
+import { renderWithTheme } from 'src/utilities/testHelpers';
+import TypeToConfirm from './TypeToConfirm';
+
+const props = { onClick: jest.fn() };
+
+describe('TypeToConfirm Component', () => {
+  const labelText = 'Label';
+
+  it('Should have a label', () => {
+    const { getByText } = renderWithTheme(
+      <TypeToConfirm label={labelText} onChange={jest.fn()} {...props} />
+    );
+    const label = getByText(labelText);
+    expect(label).toHaveTextContent(labelText);
+  });
+
+  it('Should have a text input field associated with label', () => {
+    const { getByLabelText } = renderWithTheme(
+      <TypeToConfirm label={labelText} onChange={jest.fn()} {...props} />
+    );
+    const input = getByLabelText(labelText, { selector: 'input' });
+    expect(input).toBeInTheDocument();
+  });
+
+  it("Should default to displaying instructions with a link to a user's account settings", () => {
+    const { getByRole, queryByTestId } = renderWithTheme(
+      <TypeToConfirm label={labelText} onChange={jest.fn()} {...props} />
+    );
+    expect(
+      queryByTestId('instructions-to-enable-or-disable')
+    ).toBeInTheDocument();
+    expect(getByRole('link')).toHaveAttribute('href', '/profile/settings');
+  });
+
+  it('Should not display instructions when toggled to hidden', () => {
+    const { queryByTestId } = renderWithTheme(
+      <TypeToConfirm
+        label={labelText}
+        onChange={jest.fn()}
+        hideInstructions={true}
+        {...props}
+      />
+    );
+    expect(
+      queryByTestId('instructions-to-enable-or-disable')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/manager/src/components/TypeToConfirm/TypeToConfirm.tsx
+++ b/packages/manager/src/components/TypeToConfirm/TypeToConfirm.tsx
@@ -66,7 +66,10 @@ const TypeToConfirm: React.FC<Props> = (props) => {
         </>
       ) : null}
       {!hideInstructions ? (
-        <Typography className={classes.description}>
+        <Typography
+          data-testid={'instructions-to-enable-or-disable'}
+          className={classes.description}
+        >
           To {disableOrEnable} type-to-confirm, go to the Type-to-Confirm
           section of <Link to="/profile/settings">My Settings</Link>.
         </Typography>

--- a/packages/manager/src/components/TypeToConfirm/TypeToConfirm.tsx
+++ b/packages/manager/src/components/TypeToConfirm/TypeToConfirm.tsx
@@ -67,7 +67,7 @@ const TypeToConfirm: React.FC<Props> = (props) => {
       ) : null}
       {!hideInstructions ? (
         <Typography
-          data-testid={'instructions-to-enable-or-disable'}
+          data-testid="instructions-to-enable-or-disable"
           className={classes.description}
         >
           To {disableOrEnable} type-to-confirm, go to the Type-to-Confirm

--- a/packages/manager/src/features/Account/EnableObjectStorage.test.tsx
+++ b/packages/manager/src/features/Account/EnableObjectStorage.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent } from '@testing-library/react';
+import * as React from 'react';
+
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+import EnableObjectStorage from './EnableObjectStorage';
+
+describe('EnableObjectStorage Component', () => {
+  it('Should display button to cancel object storage, if storage is enabled', () => {
+    const { queryByTestId } = renderWithTheme(
+      <EnableObjectStorage object_storage={'active'} />
+    );
+
+    expect(queryByTestId('open-dialog-button')).toBeInTheDocument();
+  });
+
+  it('Should not display button to cancel object storage, if storage is disabled', () => {
+    const { queryByTestId } = renderWithTheme(
+      <EnableObjectStorage object_storage={'disabled'} />
+    );
+
+    expect(queryByTestId('open-dialog-button')).not.toBeInTheDocument();
+  });
+
+  it('Should open confirmation dialog on Cancel Object Storage', async () => {
+    const { getByTestId, findByTitle } = renderWithTheme(
+      <EnableObjectStorage object_storage={'active'} />
+    );
+    const button = getByTestId('open-dialog-button');
+    fireEvent.click(button);
+
+    const dialog = await findByTitle('Cancel Object Storage');
+
+    expect(dialog).toBeVisible();
+  });
+
+  it('Should close confirmation dialog on Cancel', async () => {
+    const { getByTestId, findByTitle } = renderWithTheme(
+      <EnableObjectStorage object_storage={'active'} />
+    );
+    const dialogButton = getByTestId('open-dialog-button');
+    fireEvent.click(dialogButton);
+
+    const dialog = await findByTitle('Cancel Object Storage');
+    const cancelButton = getByTestId('dialog-cancel');
+    fireEvent.click(cancelButton);
+
+    expect(dialog).not.toBeVisible();
+  });
+});

--- a/packages/manager/src/features/Account/EnableObjectStorage.tsx
+++ b/packages/manager/src/features/Account/EnableObjectStorage.tsx
@@ -3,7 +3,6 @@ import { cancelObjectStorage } from '@linode/api-v4/lib/object-storage';
 import { APIError } from '@linode/api-v4/lib/types';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { compose } from 'recompose';
 import Accordion from 'src/components/Accordion';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
@@ -13,17 +12,15 @@ import TypeToConfirm from 'src/components/TypeToConfirm';
 import Typography from 'src/components/core/Typography';
 import ExternalLink from 'src/components/ExternalLink';
 import Grid from 'src/components/Grid';
-import withPreferences, {
-  Props as PreferencesProps,
-} from 'src/containers/preferences.container';
 import { updateAccountSettingsData } from 'src/queries/accountSettings';
+import usePreferences from 'src/hooks/usePreferences';
 import { useProfile } from 'src/queries/profile';
 
 interface Props {
   object_storage: AccountSettings['object_storage'];
 }
 
-type CombinedProps = Props & PreferencesProps;
+type CombinedProps = Props;
 
 interface ContentProps {
   object_storage: AccountSettings['object_storage'];
@@ -73,11 +70,12 @@ export const ObjectStorageContent: React.FC<ContentProps> = (props) => {
 };
 
 export const EnableObjectStorage: React.FC<CombinedProps> = (props) => {
-  const { object_storage, preferences } = props;
+  const { object_storage } = props;
   const [isOpen, setOpen] = React.useState<boolean>(false);
   const [error, setError] = React.useState<string | undefined>();
   const [isLoading, setLoading] = React.useState<boolean>(false);
   const [confirmText, setConfirmText] = React.useState('');
+  const { preferences } = usePreferences();
   const { data: profile } = useProfile();
   const username = profile?.username;
   const disabled =
@@ -104,29 +102,24 @@ export const EnableObjectStorage: React.FC<CombinedProps> = (props) => {
       .catch(handleError);
   };
 
-  const renderActions = (
-    disabled: boolean,
-    loading: boolean,
-    onClose: () => void,
-    onSubmit: () => void
-  ) => (
+  const actions = (
     <ActionsPanel>
       <Button
         buttonType="secondary"
-        onClick={onClose}
-        data-testid={'dialog-cancel'}
+        onClick={handleClose}
+        data-testid="dialog-cancel"
       >
         Cancel
       </Button>
 
       <Button
         buttonType="primary"
-        onClick={onSubmit}
+        onClick={handleSubmit}
         disabled={disabled}
-        loading={loading}
-        data-testid={'dialog-confirm'}
+        loading={isLoading}
+        data-testid="dialog-confirm"
       >
-        Confirm cancellation
+        Confirm Cancellation
       </Button>
     </ActionsPanel>
   );
@@ -144,7 +137,7 @@ export const EnableObjectStorage: React.FC<CombinedProps> = (props) => {
         error={error}
         onClose={() => handleClose()}
         title="Cancel Object Storage"
-        actions={renderActions(disabled, isLoading, handleClose, handleSubmit)}
+        actions={actions}
       >
         <Notice warning>
           <Typography style={{ fontSize: '0.875rem' }}>
@@ -154,7 +147,7 @@ export const EnableObjectStorage: React.FC<CombinedProps> = (props) => {
           </Typography>
         </Notice>
         <TypeToConfirm
-          data-testid={'dialog-confirm-text-input'}
+          data-testid="dialog-confirm-text-input"
           label="Username"
           onChange={(input) => setConfirmText(input)}
           expand
@@ -172,6 +165,4 @@ export const EnableObjectStorage: React.FC<CombinedProps> = (props) => {
   );
 };
 
-const enhanced = compose<CombinedProps, Props>(withPreferences());
-
-export default enhanced(React.memo(EnableObjectStorage));
+export default React.memo(EnableObjectStorage);

--- a/packages/manager/src/features/Account/EnableObjectStorage.tsx
+++ b/packages/manager/src/features/Account/EnableObjectStorage.tsx
@@ -15,6 +15,8 @@ import Grid from 'src/components/Grid';
 import { updateAccountSettingsData } from 'src/queries/accountSettings';
 import usePreferences from 'src/hooks/usePreferences';
 import { useProfile } from 'src/queries/profile';
+import { queryClient } from 'src/queries/base';
+import { queryKey } from 'src/queries/objectStorage';
 
 interface Props {
   object_storage: AccountSettings['object_storage'];
@@ -78,7 +80,7 @@ export const EnableObjectStorage: React.FC<CombinedProps> = (props) => {
   const { preferences } = usePreferences();
   const { data: profile } = useProfile();
   const username = profile?.username;
-  const disabled =
+  const disabledConfirm =
     preferences?.type_to_confirm !== false && confirmText !== username;
 
   const handleClose = () => {
@@ -98,6 +100,8 @@ export const EnableObjectStorage: React.FC<CombinedProps> = (props) => {
       .then(() => {
         updateAccountSettingsData({ object_storage: 'disabled' });
         handleClose();
+        queryClient.invalidateQueries(`${queryKey}-buckets`);
+        queryClient.invalidateQueries(`${queryKey}-access-keys`);
       })
       .catch(handleError);
   };
@@ -115,7 +119,7 @@ export const EnableObjectStorage: React.FC<CombinedProps> = (props) => {
       <Button
         buttonType="primary"
         onClick={handleSubmit}
-        disabled={disabled}
+        disabled={disabledConfirm}
         loading={isLoading}
         data-testid="dialog-confirm"
       >

--- a/packages/manager/src/features/Account/EnableObjectStorage.tsx
+++ b/packages/manager/src/features/Account/EnableObjectStorage.tsx
@@ -44,7 +44,11 @@ export const ObjectStorageContent: React.FC<ContentProps> = (props) => {
           </Typography>
         </Grid>
         <Grid item>
-          <Button buttonType="outlined" onClick={openConfirmationModal}>
+          <Button
+            data-testid="open-dialog-button"
+            buttonType="outlined"
+            onClick={openConfirmationModal}
+          >
             Cancel Object Storage
           </Button>
         </Grid>
@@ -107,7 +111,11 @@ export const EnableObjectStorage: React.FC<CombinedProps> = (props) => {
     onSubmit: () => void
   ) => (
     <ActionsPanel>
-      <Button buttonType="secondary" onClick={onClose}>
+      <Button
+        buttonType="secondary"
+        onClick={onClose}
+        data-testid={'dialog-cancel'}
+      >
         Cancel
       </Button>
 
@@ -116,6 +124,7 @@ export const EnableObjectStorage: React.FC<CombinedProps> = (props) => {
         onClick={onSubmit}
         disabled={disabled}
         loading={loading}
+        data-testid={'dialog-confirm'}
       >
         Confirm cancellation
       </Button>


### PR DESCRIPTION
## Description 📝

**What does this PR do?**

Implements type-to-confirm for object storage cancellation in the user's Account Settings.

## Preview 📷

**TTC enabled:**
![image](https://user-images.githubusercontent.com/114685994/202315178-fa2db68d-7e45-4a42-b57c-1d52ab71ddc6.png)

**TTC disabled:**
![image](https://user-images.githubusercontent.com/114685994/202315042-98ba638a-ceac-42bd-b007-63955d28b9f6.png)

https://user-images.githubusercontent.com/114685994/202314676-dfbcdef3-0265-4034-9ad1-f669646fd71a.mov

## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**
- If Object Storage is not already active, create a new Object Storage bucket to enable it. 
- Navigate to My Settings and ensure type-to-confirm is enabled.
- Navigate to Account Settings and click the Cancel Object Storage button.
- Observe the type-to-confirm pattern present on the Cancel Object Storage dialog.
- Navigate to My Settings and toggle the type-to-confirm setting to disabled.
- Navigate to Account Settings and click the Cancel Object Storage button
- Observe the type-to-confirm text field is not visible and a description instructs user to visit My Settings to toggle this setting.
- Confirm that clicking 'Confirm cancellation' does disable object storage and delete data.

**How do I run relevant unit or e2e tests?**
- Run `EnableObjectStorage.test.tsx`.
- Run `TypeToConfirm.test.tsx`.