### PR TITLE
M3-5958: [Changed] Landing page 2 column layout – adjust spacing

### DIFF
--- a/packages/manager/src/components/Placeholder/Placeholder.tsx
+++ b/packages/manager/src/components/Placeholder/Placeholder.tsx
@@ -24,7 +24,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   container: {
     display: 'grid',
-    gridTemplateColumns: '1fr 1fr 1fr 1fr 1fr 35% 35% 1fr 1fr 1fr 1fr 1fr',
+    gridTemplateColumns: 'repeat(5, 1fr) 35% 35% repeat(5, 1fr)',
     gridTemplateRows:
       'max-content 12px max-content 7px max-content 15px max-content 24px max-content 111px min-content',
     gridTemplateAreas: `

--- a/packages/manager/src/components/Placeholder/Placeholder.tsx
+++ b/packages/manager/src/components/Placeholder/Placeholder.tsx
@@ -87,12 +87,10 @@ const useStyles = makeStyles((theme: Theme) => ({
   title: {
     textAlign: 'center',
     gridArea: 'title',
-    /*     marginBottom: theme.spacing(2), */
   },
   subtitle: {
     gridArea: 'subtitle',
     textAlign: 'center',
-    /*     marginBottom: theme.spacing(2), */
     color: theme.palette.text.primary,
   },
   '& .insidePath path': {
@@ -105,7 +103,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   button: {
     gridArea: 'button',
-    /*     marginBottom: theme.spacing(4), */
   },
   linksSection: {
     gridArea: 'links',

--- a/packages/manager/src/components/Placeholder/Placeholder.tsx
+++ b/packages/manager/src/components/Placeholder/Placeholder.tsx
@@ -34,7 +34,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     maxWidth: '85%',
     marginTop: -theme.spacing(3),
     [theme.breakpoints.up('md')]: {
-      maxWidth: 800,
+      maxWidth: 600,
     },
   },
   icon: {
@@ -140,7 +140,7 @@ const Placeholder: React.FC<Props> = (props) => {
         />
         {hasSubtitle ? <Typography variant="h2">{subtitle}</Typography> : null}
       </Grid>
-      <Grid item xs={12} lg={10} className={classes.copy}>
+      <Grid item xs={12} lg={2} className={classes.copy}>
         {typeof props.children === 'string' ? (
           <Typography variant="subtitle1">{props.children}</Typography>
         ) : (

--- a/packages/manager/src/components/Placeholder/Placeholder.tsx
+++ b/packages/manager/src/components/Placeholder/Placeholder.tsx
@@ -26,7 +26,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     display: 'grid',
     gridTemplateColumns: '1fr 1fr 1fr 1fr 1fr 35% 35% 1fr 1fr 1fr 1fr 1fr',
     gridTemplateRows:
-      'auto 12px max-content 7px max-content 15px max-content 24px max-content 111px min-content',
+      'max-content 12px max-content 7px max-content 15px max-content 24px max-content 111px min-content',
     gridTemplateAreas: `
       ". . . . . icon icon . . . . ."
       ". . . . . . . . . . . ."
@@ -60,7 +60,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   icon: {
     width: '160px',
     height: '160px',
-    padding: '16px',
+    padding: theme.spacing(2),
     '& .outerCircle': {
       fill: theme.name === 'lightTheme' ? '#fff' : '#000',
       stroke: theme.bg.offWhite,
@@ -116,6 +116,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   iconWrapper: {
     gridArea: 'icon',
+    padding: theme.spacing(2),
   },
 }));
 

--- a/packages/manager/src/components/Placeholder/Placeholder.tsx
+++ b/packages/manager/src/components/Placeholder/Placeholder.tsx
@@ -25,7 +25,8 @@ const useStyles = makeStyles((theme: Theme) => ({
   container: {
     display: 'grid',
     gridTemplateColumns: '1fr 1fr 1fr 1fr 1fr 35% 35% 1fr 1fr 1fr 1fr 1fr',
-    gridTemplateRows: 'auto 12px max-content 7px max-content 15px max-content 24px max-content 111px min-content',
+    gridTemplateRows:
+      'auto 12px max-content 7px max-content 15px max-content 24px max-content 111px min-content',
     gridTemplateAreas: `
       ". . . . . icon icon . . . . ."
       ". . . . . . . . . . . ."
@@ -108,12 +109,14 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   linksSection: {
     gridArea: 'links',
-    borderTop: `1px solid ${theme.name === 'lightTheme' ? '#e3e5e8' : '#2e3238'}`,
+    borderTop: `1px solid ${
+      theme.name === 'lightTheme' ? '#e3e5e8' : '#2e3238'
+    }`,
     paddingTop: '38px',
   },
   iconWrapper: {
     gridArea: 'icon',
-  }
+  },
 }));
 
 export interface ExtendedButtonProps extends ButtonProps {
@@ -146,10 +149,11 @@ const Placeholder: React.FC<Props> = (props) => {
   const hasSubtitle = subtitle !== undefined;
   return (
     <div className={`${classes.container} ${classes.root} ${props.className}`}>
-      <div className={`${classes.iconWrapper} ${isEntity ? classes.entity : ''}`}>
+      <div
+        className={`${classes.iconWrapper} ${isEntity ? classes.entity : ''}`}
+      >
         {Icon && <Icon className={classes.icon} />}
       </div>
-
 
       <H1Header
         title={title}
@@ -157,8 +161,11 @@ const Placeholder: React.FC<Props> = (props) => {
         renderAsSecondary={renderAsSecondary}
         data-qa-placeholder-title
       />
-      {hasSubtitle ? <Typography variant="h2" className={classes.subtitle}>{subtitle}</Typography> : null}
-
+      {hasSubtitle ? (
+        <Typography variant="h2" className={classes.subtitle}>
+          {subtitle}
+        </Typography>
+      ) : null}
 
       <div className={classes.copy}>
         {typeof props.children === 'string' ? (
@@ -168,7 +175,7 @@ const Placeholder: React.FC<Props> = (props) => {
         )}
       </div>
 
-      {buttonProps && (
+      {buttonProps &&
         buttonProps.map((thisButton, index) => (
           <Button
             buttonType="primary"
@@ -176,10 +183,9 @@ const Placeholder: React.FC<Props> = (props) => {
             {...thisButton}
             data-qa-placeholder-button
             data-testid="placeholder-button"
+            key={index}
           />
-        ))
-
-      )}
+        ))}
       <div className={classes.linksSection}>
         {linksSection !== undefined ? linksSection : null}
       </div>

--- a/packages/manager/src/components/Placeholder/Placeholder.tsx
+++ b/packages/manager/src/components/Placeholder/Placeholder.tsx
@@ -3,7 +3,6 @@ import LinodeIcon from 'src/assets/addnewmenu/linode.svg';
 import Button, { ButtonProps } from 'src/components/Button';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
-import Grid from 'src/components/Grid';
 import H1Header from 'src/components/H1Header';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -23,6 +22,20 @@ const useStyles = makeStyles((theme: Theme) => ({
       opacity: 1,
     },
   },
+  container: {
+    display: 'grid',
+    gridTemplateColumns: 'auto 70vw auto',
+    gridTemplateRows: 'repeat(6, max-content)',
+    gridTemplateAreas: `
+      ". icon ."
+      ". title . "
+      ". subtitle ."
+      ". copy ."
+      ". button ."
+      ". links ."
+    `,
+    justifyItems: 'center',
+  },
   root: {
     padding: `${theme.spacing(2)}px 0`,
     [theme.breakpoints.up('md')]: {
@@ -31,14 +44,10 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   copy: {
     textAlign: 'center',
-    maxWidth: '85%',
-    marginTop: -theme.spacing(3),
-    [theme.breakpoints.up('md')]: {
-      maxWidth: 600,
-    },
+    gridArea: 'copy',
   },
   icon: {
-    padding: theme.spacing(2),
+    gridArea: 'icon',
     width: '160px',
     height: '160px',
     '& .outerCircle': {
@@ -68,6 +77,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     textAlign: 'center',
     marginBottom: theme.spacing(2),
   },
+  subtitle: {
+    gridArea: 'subtitle',
+  },
   '& .insidePath path': {
     opacity: 0,
     animation: '$fadeIn .2s ease-in-out forwards .3s',
@@ -77,6 +89,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     fill: theme.palette.primary.main,
   },
   titleWithSubtitle: {
+    gridArea: 'title',
     textAlign: 'center',
     '& + h2': {
       marginBottom: theme.spacing(2),
@@ -84,8 +97,12 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
   },
   button: {
+    gridArea: 'button',
     marginBottom: theme.spacing(4),
   },
+  linksSection: {
+    gridArea: 'links',
+  }
 }));
 
 export interface ExtendedButtonProps extends ButtonProps {
@@ -106,7 +123,6 @@ export interface Props {
 
 const Placeholder: React.FC<Props> = (props) => {
   const {
-    isEntity,
     title,
     icon: Icon,
     buttonProps,
@@ -120,56 +136,43 @@ const Placeholder: React.FC<Props> = (props) => {
     ? classes.titleWithSubtitle
     : classes.title;
   return (
-    <Grid
-      container
-      spacing={3}
-      alignItems="center"
-      direction="column"
-      justifyContent="center"
-      className={`${classes.root} ${props.className}`}
-    >
-      <Grid item xs={12} className={isEntity ? classes.entity : ''}>
-        {Icon && <Icon className={classes.icon} />}
-      </Grid>
-      <Grid item xs={12}>
-        <H1Header
-          title={title}
-          className={titleClassName}
-          renderAsSecondary={renderAsSecondary}
-          data-qa-placeholder-title
-        />
-        {hasSubtitle ? <Typography variant="h2">{subtitle}</Typography> : null}
-      </Grid>
-      <Grid item xs={12} lg={2} className={classes.copy}>
+    <div className={classes.container}>
+      {Icon && <Icon className={classes.icon} />}
+
+
+      <H1Header
+        title={title}
+        className={titleClassName}
+        renderAsSecondary={renderAsSecondary}
+        data-qa-placeholder-title
+      />
+      {hasSubtitle ? <Typography variant="h2" className={classes.subtitle}>{subtitle}</Typography> : null}
+
+
+      <div className={classes.copy}>
         {typeof props.children === 'string' ? (
           <Typography variant="subtitle1">{props.children}</Typography>
         ) : (
           props.children
         )}
-      </Grid>
+      </div>
+
       {buttonProps && (
-        <Grid
-          container
-          item
-          direction="row"
-          alignItems="center"
-          justifyContent="center"
-        >
-          {buttonProps.map((thisButton, index) => (
-            <Grid item key={`placeholder-button-${index}`}>
-              <Button
-                buttonType="primary"
-                className={classes.button}
-                {...thisButton}
-                data-qa-placeholder-button
-                data-testid="placeholder-button"
-              />
-            </Grid>
-          ))}
-        </Grid>
+        buttonProps.map((thisButton, index) => (
+          <Button
+            buttonType="primary"
+            className={classes.button}
+            {...thisButton}
+            data-qa-placeholder-button
+            data-testid="placeholder-button"
+          />
+        ))
+
       )}
-      {linksSection !== undefined ? linksSection : null}
-    </Grid>
+      <div className={classes.linksSection}>
+        {linksSection !== undefined ? linksSection : null}
+      </div>
+    </div>
   );
 };
 

--- a/packages/manager/src/components/Placeholder/Placeholder.tsx
+++ b/packages/manager/src/components/Placeholder/Placeholder.tsx
@@ -24,7 +24,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   container: {
     display: 'grid',
-    gridTemplateColumns: 'auto 70vw auto',
+    gridTemplateColumns: '15% auto 15%',
     gridTemplateRows: 'repeat(6, max-content)',
     gridTemplateAreas: `
       ". icon ."
@@ -32,7 +32,7 @@ const useStyles = makeStyles((theme: Theme) => ({
       ". subtitle ."
       ". copy ."
       ". button ."
-      ". links ."
+      "links links links"
     `,
     justifyItems: 'center',
   },
@@ -45,11 +45,13 @@ const useStyles = makeStyles((theme: Theme) => ({
   copy: {
     textAlign: 'center',
     gridArea: 'copy',
+    minWidth: 'min-content',
+    maxWidth: '70%',
   },
   icon: {
-    gridArea: 'icon',
     width: '160px',
     height: '160px',
+    padding: '16px',
     '& .outerCircle': {
       fill: theme.name === 'lightTheme' ? '#fff' : '#000',
       stroke: theme.bg.offWhite,
@@ -102,6 +104,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   linksSection: {
     gridArea: 'links',
+  },
+  iconWrapper: {
+    gridArea: 'icon',
   }
 }));
 
@@ -123,6 +128,7 @@ export interface Props {
 
 const Placeholder: React.FC<Props> = (props) => {
   const {
+    isEntity,
     title,
     icon: Icon,
     buttonProps,
@@ -136,8 +142,10 @@ const Placeholder: React.FC<Props> = (props) => {
     ? classes.titleWithSubtitle
     : classes.title;
   return (
-    <div className={classes.container}>
-      {Icon && <Icon className={classes.icon} />}
+    <div className={`${classes.container} ${classes.root} ${props.className}`}>
+      <div className={`${classes.iconWrapper} ${isEntity ? classes.entity : ''}`}>
+        {Icon && <Icon className={classes.icon} />}
+      </div>
 
 
       <H1Header

--- a/packages/manager/src/components/Placeholder/Placeholder.tsx
+++ b/packages/manager/src/components/Placeholder/Placeholder.tsx
@@ -38,7 +38,7 @@ const useStyles = makeStyles((theme: Theme) => ({
       ". . . . . . . . . . . ."
       ". . . . . button button . . . . ."
       ". . . . . . . . . . . ."
-      ". . . . links links links links . . . ."
+      ". . . links links links links links links . . ."
     `,
     justifyItems: 'center',
   },

--- a/packages/manager/src/components/Placeholder/Placeholder.tsx
+++ b/packages/manager/src/components/Placeholder/Placeholder.tsx
@@ -25,13 +25,18 @@ const useStyles = makeStyles((theme: Theme) => ({
   container: {
     display: 'grid',
     gridTemplateColumns: '1fr 1fr 1fr 1fr 1fr 35% 35% 1fr 1fr 1fr 1fr 1fr',
-    gridTemplateRows: 'repeat(6, max-content)',
+    gridTemplateRows: 'auto 12px max-content 7px max-content 15px max-content 24px max-content 111px min-content',
     gridTemplateAreas: `
       ". . . . . icon icon . . . . ."
+      ". . . . . . . . . . . ."
       ". . . . . title title . . . . ."
+      ". . . . . . . . . . . ."
       ". . . . . subtitle subtitle . . . . ."
+      ". . . . . . . . . . . ."
       ". . . . . copy copy . . . . ."
+      ". . . . . . . . . . . ."
       ". . . . . button button . . . . ."
+      ". . . . . . . . . . . ."
       ". . . . links links links links . . . ."
     `,
     justifyItems: 'center',
@@ -46,7 +51,10 @@ const useStyles = makeStyles((theme: Theme) => ({
     textAlign: 'center',
     gridArea: 'copy',
     minWidth: 'min-content',
-    maxWidth: '70%',
+    maxWidth: '75%',
+    [theme.breakpoints.down('sm')]: {
+      maxWidth: 'none',
+    },
   },
   icon: {
     width: '160px',
@@ -77,10 +85,14 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   title: {
     textAlign: 'center',
-    marginBottom: theme.spacing(2),
+    gridArea: 'title',
+    /*     marginBottom: theme.spacing(2), */
   },
   subtitle: {
     gridArea: 'subtitle',
+    textAlign: 'center',
+    /*     marginBottom: theme.spacing(2), */
+    color: theme.palette.text.primary,
   },
   '& .insidePath path': {
     opacity: 0,
@@ -90,20 +102,14 @@ const useStyles = makeStyles((theme: Theme) => ({
   '& .bucket.insidePath path': {
     fill: theme.palette.primary.main,
   },
-  titleWithSubtitle: {
-    gridArea: 'title',
-    textAlign: 'center',
-    '& + h2': {
-      marginBottom: theme.spacing(2),
-      color: theme.palette.text.primary,
-    },
-  },
   button: {
     gridArea: 'button',
-    marginBottom: theme.spacing(4),
+    /*     marginBottom: theme.spacing(4), */
   },
   linksSection: {
     gridArea: 'links',
+    borderTop: `1px solid ${theme.name === 'lightTheme' ? '#e3e5e8' : '#2e3238'}`,
+    paddingTop: '38px',
   },
   iconWrapper: {
     gridArea: 'icon',
@@ -138,9 +144,6 @@ const Placeholder: React.FC<Props> = (props) => {
   } = props;
   const classes = useStyles();
   const hasSubtitle = subtitle !== undefined;
-  const titleClassName = hasSubtitle
-    ? classes.titleWithSubtitle
-    : classes.title;
   return (
     <div className={`${classes.container} ${classes.root} ${props.className}`}>
       <div className={`${classes.iconWrapper} ${isEntity ? classes.entity : ''}`}>
@@ -150,7 +153,7 @@ const Placeholder: React.FC<Props> = (props) => {
 
       <H1Header
         title={title}
-        className={titleClassName}
+        className={classes.title}
         renderAsSecondary={renderAsSecondary}
         data-qa-placeholder-title
       />

--- a/packages/manager/src/components/Placeholder/Placeholder.tsx
+++ b/packages/manager/src/components/Placeholder/Placeholder.tsx
@@ -24,15 +24,15 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   container: {
     display: 'grid',
-    gridTemplateColumns: '15% auto 15%',
+    gridTemplateColumns: '1fr 1fr 1fr 1fr 1fr 35% 35% 1fr 1fr 1fr 1fr 1fr',
     gridTemplateRows: 'repeat(6, max-content)',
     gridTemplateAreas: `
-      ". icon ."
-      ". title . "
-      ". subtitle ."
-      ". copy ."
-      ". button ."
-      "links links links"
+      ". . . . . icon icon . . . . ."
+      ". . . . . title title . . . . ."
+      ". . . . . subtitle subtitle . . . . ."
+      ". . . . . copy copy . . . . ."
+      ". . . . . button button . . . . ."
+      ". . . . links links links links . . . ."
     `,
     justifyItems: 'center',
   },

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseEmptyState.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseEmptyState.tsx
@@ -88,9 +88,6 @@ const useStyles = makeStyles(() => ({
       transform: 'scale(0.8)',
     },
   },
-  entityDescription: {
-    marginBottom: '1rem',
-  },
 }));
 
 const gaCategory = 'Managed Databases landing page empty';
@@ -193,10 +190,8 @@ const DatabaseEmptyState: React.FC = () => {
         }
       >
         <Typography variant="subtitle1">
-          <div className={classes.entityDescription}>
-            Deploy popular database engines such as MySQL and PostgreSQL using
-            Linode's performant, reliable, and fully managed database solution.
-          </div>
+          Deploy popular database engines such as MySQL and PostgreSQL using
+          Linode's performant, reliable, and fully managed database solution.
         </Typography>
       </Placeholder>
     </>

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseEmptyState.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseEmptyState.tsx
@@ -191,7 +191,8 @@ const DatabaseEmptyState: React.FC = () => {
       >
         <Typography variant="subtitle1">
           Deploy popular database engines such as MySQL and PostgreSQL using
-          Linode's performant, reliable, and fully managed database solution.
+          Linode&rsquo;s performant, reliable, and fully managed database
+          solution.
         </Typography>
       </Placeholder>
     </>

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.test.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.test.tsx
@@ -103,7 +103,7 @@ describe('Database Table', () => {
 
     expect(
       getByText(
-        "Deploy popular database engines such as MySQL and PostgreSQL using Linode's performant, reliable, and fully managed database solution."
+        'Deploy popular database engines such as MySQL and PostgreSQL using Linode’s performant, reliable, and fully managed database solution.'
       )
     ).toBeInTheDocument();
   });

--- a/packages/manager/src/features/linodes/LinodesLanding/LinksSection.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinksSection.tsx
@@ -1,12 +1,8 @@
 import * as React from 'react';
 
 import { makeStyles, Theme } from 'src/components/core/styles';
-import Divider from 'src/components/core/Divider';
 
 const useStyles = makeStyles((theme: Theme) => ({
-  container: {
-    width: '78.75%',
-  },
   categoryWrapper: {
     display: 'grid',
     gridAutoColumns: '1fr',
@@ -28,10 +24,7 @@ interface Props {
 const LinksSection = (props: Props) => {
   const classes = useStyles();
   return (
-    <div className={classes.container}>
-      <Divider spacingBottom={38} />
-      <div className={classes.categoryWrapper}>{props.children}</div>
-    </div>
+    <div className={classes.categoryWrapper}>{props.children}</div>
   );
 };
 


### PR DESCRIPTION
## Description 📝

Adjusts spacing for the `Placeholder` component. This effects the spacing of all empty state landing pages across the app. Also removes the `Grid` component usage from the `Placeholder` component replacing it with `CSS Grid`. This should allow for a more consistent layout with a wide variety of content and screen sizes.

## Preview 📷
### Databases Old
![image](https://user-images.githubusercontent.com/115022759/202549952-902b000b-a154-4fe3-ad63-c968ef3a8b14.png)
### Databases New
![image](https://user-images.githubusercontent.com/115022759/202550061-09c27e51-fb46-4309-9fb6-faf38a08cbe2.png)
### Linodes Old
![image](https://user-images.githubusercontent.com/115022759/202550849-99200140-509c-4aa2-9a59-db875847b74c.png)
### Linodes New
![image](https://user-images.githubusercontent.com/115022759/202550985-74d978f6-3283-483b-b4f0-7d9433479cec.png)

## How to test 🧪
Ensure the empty state for all entities looks right. Try changing the window size and seeing how things collapse and expand.
