### PR TITLE
M3-5996: Cluster Pricing UI updates

### DIFF
--- a/packages/manager/src/components/CheckoutSummary/CheckoutSummary.test.tsx
+++ b/packages/manager/src/components/CheckoutSummary/CheckoutSummary.test.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { CheckoutSummary } from './CheckoutSummary';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+const displaySections1 = [
+  {
+    title: 'Dedicated 4 GB',
+    details: '$30/month',
+  },
+];
+
+const displaySections2 = [
+  {
+    title: 'Dedicated 4 GB',
+    details: '$30/month',
+    monthly: 30,
+    hourly: 0.045,
+  },
+];
+
+const numberOfNodesForUDFSummary = 3;
+
+describe('CheckoutSummary', () => {
+  it('should not show a blurb about temporary nodes if a One-Click App without clusters is selected', () => {
+    const { queryByTestId } = renderWithTheme(
+      <CheckoutSummary heading="Summary" displaySections={displaySections1} />
+    );
+
+    expect(queryByTestId('summary-blurb-clusters')).not.toBeInTheDocument();
+  });
+
+  it('should show a blurb about temporary nodes if a One-Click App with clusters is selected', () => {
+    const { queryByTestId } = renderWithTheme(
+      <CheckoutSummary
+        heading="Summary"
+        displaySections={displaySections2}
+        numberOfNodesForUDFSummary={numberOfNodesForUDFSummary}
+      />
+    );
+
+    expect(queryByTestId('summary-blurb-clusters')).toBeInTheDocument();
+  });
+});

--- a/packages/manager/src/components/CheckoutSummary/CheckoutSummary.tsx
+++ b/packages/manager/src/components/CheckoutSummary/CheckoutSummary.tsx
@@ -85,7 +85,10 @@ export const CheckoutSummary: React.FC<Props> = (props) => {
       {props.children}
       {numberOfNodesForUDFSummary !== undefined &&
       numberOfNodesForUDFSummary > 0 ? (
-        <Typography className={classes.summaryClusterBlurb}>
+        <Typography
+          className={classes.summaryClusterBlurb}
+          data-testid="summary-blurb-clusters"
+        >
           To provision a cluster, a{' '}
           {addOrdinalSuffix(numberOfNodesForUDFSummary + 1)} node is created and
           then deleted, usually within an hour. You will see this charge on your

--- a/packages/manager/src/components/CheckoutSummary/CheckoutSummary.tsx
+++ b/packages/manager/src/components/CheckoutSummary/CheckoutSummary.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { addOrdinalSuffix } from 'src/utilities/stringUtils';
 import Paper from '../core/Paper';
 import { makeStyles, Theme, useMediaQuery, useTheme } from '../core/styles';
 import Typography from '../core/Typography';
@@ -10,11 +11,14 @@ interface Props {
   children?: JSX.Element | null;
   agreement?: JSX.Element;
   displaySections: SummaryItem[];
+  numberOfNodesForUDFSummary?: number;
 }
 
 export interface SummaryItem {
   title?: string;
   details?: string | number;
+  monthly?: number;
+  hourly?: number;
 }
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -35,6 +39,9 @@ const useStyles = makeStyles((theme: Theme) => ({
       },
     },
   },
+  summaryClusterBlurb: {
+    marginTop: '1rem',
+  },
 }));
 
 export const CheckoutSummary: React.FC<Props> = (props) => {
@@ -42,7 +49,14 @@ export const CheckoutSummary: React.FC<Props> = (props) => {
   const theme = useTheme<Theme>();
   const matchesSmDown = useMediaQuery(theme.breakpoints.down('sm'));
 
-  const { heading, agreement, displaySections } = props;
+  const {
+    heading,
+    agreement,
+    displaySections,
+    numberOfNodesForUDFSummary,
+  } = props;
+
+  const planInformation = displaySections.find((section) => section.hourly);
 
   return (
     <Paper data-qa-summary className={classes.paper}>
@@ -69,6 +83,15 @@ export const CheckoutSummary: React.FC<Props> = (props) => {
         ))}
       </Grid>
       {props.children}
+      {numberOfNodesForUDFSummary !== undefined &&
+      numberOfNodesForUDFSummary > 0 ? (
+        <Typography className={classes.summaryClusterBlurb}>
+          To provision a cluster, a{' '}
+          {addOrdinalSuffix(numberOfNodesForUDFSummary + 1)} node is created and
+          then deleted, usually within an hour. You will see this charge on your
+          next Linode invoice. Estimated charge ${planInformation?.hourly ?? 0}
+        </Typography>
+      ) : null}
       {agreement ? agreement : null}
     </Paper>
   );

--- a/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.test.tsx
+++ b/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.test.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import UserDefinedFieldsPanel from './UserDefinedFieldsPanel';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+
+describe('UserDefinedFieldsPanel', () => {
+  it('does not show a <Notice /> about temporary nodes when a One-Click App without clusters is selected', () => {
+    const { queryByTestId } = renderWithTheme(
+      <UserDefinedFieldsPanel
+        handleChange={() => null}
+        udf_data={[]}
+        selectedLabel={''}
+        selectedUsername={''}
+      />
+    );
+
+    expect(queryByTestId('temp-node-notice')).not.toBeInTheDocument();
+  });
+
+  it('shows a <Notice /> about temporary nodes when a One-Click App with clusters is selected', () => {
+    const { queryByTestId } = renderWithTheme(
+      <UserDefinedFieldsPanel
+        handleChange={() => null}
+        udf_data={[{ name: 'node_options' }]}
+        userDefinedFields={[
+          { name: 'node_options', label: 'Set Number of Nodes' },
+        ]}
+        selectedLabel={''}
+        selectedUsername={''}
+      />
+    );
+
+    expect(queryByTestId('temp-node-notice')).toBeInTheDocument();
+  });
+});

--- a/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
+++ b/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
@@ -221,7 +221,7 @@ const UserDefinedFieldsPanel = (props: CombinedProps) => {
       </Box>
 
       {isCluster ? (
-        <div className={classes.clusterNotice}>
+        <div className={classes.clusterNotice} data-testid="temp-node-notice">
           <Notice informational>
             <strong>
               You are creating a cluster with {numberOfNodes} nodes. A temporary{' '}

--- a/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
+++ b/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
@@ -60,6 +60,7 @@ interface Props {
   selectedUsername: string;
   appLogo?: JSX.Element;
   openDrawer?: (stackScriptLabel: string) => void;
+  setNumberOfNodesForUDFSummary?: (num: number) => void;
 }
 
 type CombinedProps = Props;
@@ -178,19 +179,26 @@ const UserDefinedFieldsPanel = (props: CombinedProps) => {
     udf_data,
     errors,
     appLogo,
+    setNumberOfNodesForUDFSummary,
   } = props;
 
-  const [requiredUDFs, optionalUDFs] = seperateUDFsByRequiredStatus(
+  const [requiredUDFs, optionalUDFs] = separateUDFsByRequiredStatus(
     userDefinedFields!
   );
-
-  // console.log(userDefinedFields);
 
   const isCluster = userDefinedFields?.some(
     (udf) => udf.name === 'node_options'
   );
-  const numberOfNodes = Number(udf_data['node_options']) ?? 3;
-  const temporaryNodeNumber = numberOfNodes + 1; // A temporary additional node is created.
+  const numberOfNodes =
+    udf_data['node_options'] !== undefined && udf_data['node_options'] !== null
+      ? Number(udf_data['node_options'])
+      : 0;
+
+  if (setNumberOfNodesForUDFSummary) {
+    setNumberOfNodesForUDFSummary(numberOfNodes);
+  }
+
+  const temporaryNodeNumber = numberOfNodes > 0 ? numberOfNodes + 1 : 0; // A temporary additional node is created for clusters.
 
   const isDrawerOpenable = openDrawer !== undefined;
 
@@ -277,7 +285,7 @@ const isHeader = (udf: UserDefinedField) => {
  *
  * @return nested array [[...requiredUDFs], [...nonRequiredUDFs]]
  */
-const seperateUDFsByRequiredStatus = (udfs: UserDefinedField[] = []) => {
+const separateUDFsByRequiredStatus = (udfs: UserDefinedField[] = []) => {
   return udfs.reduce(
     (accum, eachUDF) => {
       /**

--- a/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
+++ b/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
@@ -1,18 +1,20 @@
 import { UserDefinedField } from '@linode/api-v4/lib/stackscripts';
 import { APIError } from '@linode/api-v4/lib/types';
+import classnames from 'classnames';
 import * as React from 'react';
+import Box from 'src/components/core/Box';
 import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
-import Box from 'src/components/core/Box';
+import Notice from 'src/components/Notice';
 import RenderGuard from 'src/components/RenderGuard';
 import ShowMoreExpansion from 'src/components/ShowMoreExpansion';
+import AppInfo from '../../linodes/LinodesCreate/AppInfo';
 import UserDefinedMultiSelect from './FieldTypes/UserDefinedMultiSelect';
 import UserDefinedSelect from './FieldTypes/UserDefinedSelect';
 import UserDefinedText from './FieldTypes/UserDefinedText';
-import AppInfo from '../../linodes/LinodesCreate/AppInfo';
-import classnames from 'classnames';
+import { addOrdinalSuffix } from 'src/utilities/stringUtils';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -43,6 +45,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   marketplaceSpacing: {
     paddingTop: theme.spacing(),
     paddingBottom: theme.spacing(),
+  },
+  clusterNotice: {
+    paddingTop: '1rem',
   },
 }));
 
@@ -179,6 +184,14 @@ const UserDefinedFieldsPanel = (props: CombinedProps) => {
     userDefinedFields!
   );
 
+  // console.log(userDefinedFields);
+
+  const isCluster = userDefinedFields?.some(
+    (udf) => udf.name === 'node_options'
+  );
+  const numberOfNodes = Number(udf_data['node_options']) ?? 3;
+  const temporaryNodeNumber = numberOfNodes + 1; // A temporary additional node is created.
+
   const isDrawerOpenable = openDrawer !== undefined;
 
   return (
@@ -197,12 +210,23 @@ const UserDefinedFieldsPanel = (props: CombinedProps) => {
         ) : null}
       </Box>
 
+      {isCluster ? (
+        <div className={classes.clusterNotice}>
+          <Notice informational>
+            <strong>
+              You are creating a cluster with {numberOfNodes} nodes. A temporary{' '}
+              {addOrdinalSuffix(temporaryNodeNumber)} node will be provisioned
+              and deleted once the provisioning is complete.
+            </strong>
+          </Notice>
+        </div>
+      ) : null}
+
       {/* Required Fields */}
       {requiredUDFs.map((field: UserDefinedField) => {
         const error = getError(field, errors);
         return renderField(udf_data, handleChange, field, error);
       })}
-
       {/* Optional Fields */}
       {optionalUDFs.length !== 0 && (
         <ShowMoreExpansion name="Advanced Options" defaultExpanded={true}>

--- a/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
+++ b/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
@@ -194,9 +194,11 @@ const UserDefinedFieldsPanel = (props: CombinedProps) => {
       ? Number(udf_data['node_options'])
       : 0;
 
-  if (setNumberOfNodesForUDFSummary) {
-    setNumberOfNodesForUDFSummary(numberOfNodes);
-  }
+  React.useEffect(() => {
+    if (setNumberOfNodesForUDFSummary) {
+      setNumberOfNodesForUDFSummary(numberOfNodes);
+    }
+  }, [setNumberOfNodesForUDFSummary, numberOfNodes]);
 
   const temporaryNodeNumber = numberOfNodes > 0 ? numberOfNodes + 1 : 0; // A temporary additional node is created for clusters.
 

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -396,7 +396,6 @@ export class LinodeCreate extends React.PureComponent<
       updateLabel,
       tags,
       updateTags,
-      updatePassword,
       errors,
       sshError,
       userSSHKeys,

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -654,6 +654,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
         title: type.label,
         details: `$${type.price.monthly}/month`,
         monthly: type.price.monthly ?? 0,
+        hourly: type.price.hourly ?? 0,
         backupsMonthly: type.addons.backups.price.monthly,
       }
     );

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -102,7 +102,12 @@ const errorResources = {
   stackscript_id: 'The selected App',
 };
 
-type InnerProps = AppsData &
+interface Props {
+  setNumberOfNodesForUDFSummary: (num: number) => void;
+}
+
+type InnerProps = Props &
+  AppsData &
   ReduxStateProps &
   StackScriptFormStateHandlers &
   WithTypesRegionsAndImages;
@@ -262,9 +267,10 @@ class FromAppsContent extends React.Component<CombinedProps, State> {
       appInstancesError,
       appInstancesLoading,
       userCannotCreateLinode,
+      setNumberOfNodesForUDFSummary,
     } = this.props;
 
-    //ramda's curry placehodler conflicts with lodash so the lodash curry and placeholder is used here
+    // ramda's curry placehodler conflicts with lodash so the lodash curry and placeholder is used here
     const handleSelectStackScript = curriedHandleSelectStackScript(
       curry.placeholder,
       curry.placeholder,
@@ -349,6 +355,7 @@ class FromAppsContent extends React.Component<CombinedProps, State> {
               udf_data={udf_data || {}}
               appLogo={appLogo}
               openDrawer={this.openDrawer}
+              setNumberOfNodesForUDFSummary={setNumberOfNodesForUDFSummary}
             />
           ) : null}
           {!userCannotCreateLinode &&

--- a/packages/manager/src/features/linodes/LinodesCreate/types.ts
+++ b/packages/manager/src/features/linodes/LinodesCreate/types.ts
@@ -21,6 +21,7 @@ export type TypeInfo =
       title: string;
       details: string;
       monthly: number;
+      hourly: number;
       backupsMonthly: number | null;
     }
   | undefined;

--- a/packages/manager/src/utilities/stringUtils.test.ts
+++ b/packages/manager/src/utilities/stringUtils.test.ts
@@ -1,4 +1,4 @@
-import { truncateAndJoinList } from './stringUtils';
+import { truncateAndJoinList, addOrdinalSuffix } from './stringUtils';
 
 describe('truncateAndJoinList', () => {
   const strList = ['a', 'b', 'c'];
@@ -25,5 +25,36 @@ describe('truncateAndJoinList', () => {
   it('defaults to a max of 100', () => {
     const result = truncateAndJoinList(bigStrList);
     expect(result).toMatch(/, plus 900 more/);
+  });
+});
+
+describe('addOrdinalSuffix', () => {
+  it('returns the correct ordinal suffix for numbers ending with 1', () => {
+    const suffixFor1 = addOrdinalSuffix(1);
+    expect(suffixFor1).toBe('1st');
+
+    const suffixFor21 = addOrdinalSuffix(21);
+    expect(suffixFor21).toBe('21st');
+  });
+
+  it('returns the correct ordinal suffix for numbers ending with 2', () => {
+    const suffixFor2 = addOrdinalSuffix(2);
+    expect(suffixFor2).toBe('2nd');
+
+    const suffixFor32 = addOrdinalSuffix(32);
+    expect(suffixFor32).toBe('32nd');
+  });
+
+  it('returns the correct ordinal suffix for numbers ending with 3', () => {
+    const suffixFor3 = addOrdinalSuffix(3);
+    expect(suffixFor3).toBe('3rd');
+
+    const suffixFor43 = addOrdinalSuffix(43);
+    expect(suffixFor43).toBe('43rd');
+  });
+
+  it('returns the correct ordinal suffix for other numbers', () => {
+    const suffixFor5 = addOrdinalSuffix(5);
+    expect(suffixFor5).toBe('5th');
   });
 });

--- a/packages/manager/src/utilities/stringUtils.ts
+++ b/packages/manager/src/utilities/stringUtils.ts
@@ -21,3 +21,20 @@ export const truncateAndJoinList = (strList: string[], max = 100) => {
 };
 
 export const wrapInQuotes = (s: string) => '"' + s + '"';
+
+export const addOrdinalSuffix = (num: number) => {
+  const rules = new Intl.PluralRules('en', {
+    type: 'ordinal',
+  });
+
+  const suffixes = {
+    one: 'st',
+    two: 'nd',
+    few: 'rd',
+    other: 'th',
+  };
+
+  const suffix = suffixes[rules.select(num)];
+
+  return `${num}${suffix}`;
+};


### PR DESCRIPTION
## Description 📝
When an OCA with a UDF regarding clusters is selected, display a notice regarding the number of clusters and the creation of an additional temporary node. Additionally, add text regarding the temporary node and pricing for multiple nodes to the Summary panel.

## Preview 📷
Notice:
![Screen Shot 2022-11-18 at 3 08 28 PM](https://user-images.githubusercontent.com/114682940/202798722-73789bf1-88af-4e24-b088-45f836d0aa53.jpg)

Summary:
![Screen Shot 2022-11-18 at 3 09 04 PM](https://user-images.githubusercontent.com/114682940/202798772-a8a33fb0-50e7-47ea-afe9-642016b43ad2.jpg)

## How to test 🧪
Test the OCA flow with an OCA with clusters and an OCA without clusters. The former should show features like the above screenshots; the latter should be unchanged from their current functionality.

StackScript deployments from other areas of the app should be tested as well to ensure they've not been adversely impacted.

## To-Do
- [x] Test related flows to ensure no adverse effects were created
- [x] Some potential refactors
- [x] Possibly more unit tests
