### PR TITLE
M3-5994: [Changed] One Click Cluster App Card

### DIFF
--- a/packages/manager/src/components/SelectionCard/CardBase.test.tsx
+++ b/packages/manager/src/components/SelectionCard/CardBase.test.tsx
@@ -1,0 +1,19 @@
+import { renderWithTheme } from 'src/utilities/testHelpers';
+import * as React from 'react';
+
+import CardBase from './index';
+
+describe('CardBase component', () => {
+  it('should render header decorations when supplied', () => {
+    const { getByText } = renderWithTheme(
+      <CardBase
+        heading="Test"
+        subheadings={['']}
+        headingDecoration={<span>Hello World</span>}
+      />
+    );
+
+    const headingDecoration = getByText('Hello World');
+    expect(headingDecoration).toBeInTheDocument();
+  });
+});

--- a/packages/manager/src/components/SelectionCard/CardBase.tsx
+++ b/packages/manager/src/components/SelectionCard/CardBase.tsx
@@ -29,6 +29,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     fontSize: '1rem',
     color: theme.color.headline,
     wordBreak: 'break-word',
+    display: 'flex',
+    alignItems: 'center',
+    columnGap: theme.spacing(2),
   },
   subheading: {
     fontSize: '0.875rem',
@@ -75,15 +78,22 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 export interface Props {
   renderIcon?: () => JSX.Element;
-  heading: string;
+  heading: string | JSX.Element;
   subheadings: (string | undefined)[];
   renderVariant?: () => JSX.Element | null;
+  headingDecoration?: JSX.Element;
 }
 
 type CombinedProps = Props;
 
 const CardBase: React.FC<CombinedProps> = (props) => {
-  const { renderIcon, heading, subheadings, renderVariant } = props;
+  const {
+    renderIcon,
+    heading,
+    subheadings,
+    renderVariant,
+    headingDecoration,
+  } = props;
 
   const classes = useStyles();
 
@@ -101,6 +111,7 @@ const CardBase: React.FC<CombinedProps> = (props) => {
       <Grid item className={`${classes.flex} cardBaseHeadings`}>
         <div className={classes.heading} data-qa-select-card-heading={heading}>
           {heading}
+          {headingDecoration}
         </div>
         {subheadings.map((subheading, idx) => {
           return (

--- a/packages/manager/src/components/SelectionCard/SelectionCard.tsx
+++ b/packages/manager/src/components/SelectionCard/SelectionCard.tsx
@@ -49,6 +49,7 @@ export interface Props {
   onClick?: (e: React.SyntheticEvent<HTMLElement>) => void;
   renderIcon?: () => JSX.Element;
   renderVariant?: () => JSX.Element | null;
+  headingDecoration?: JSX.Element;
 }
 
 const SelectionCard: React.FC<Props> = (props) => {
@@ -63,6 +64,7 @@ const SelectionCard: React.FC<Props> = (props) => {
     onClick,
     renderIcon,
     renderVariant,
+    headingDecoration,
   } = props;
 
   const classes = useStyles();
@@ -86,6 +88,7 @@ const SelectionCard: React.FC<Props> = (props) => {
       heading={heading}
       subheadings={subheadings}
       renderVariant={renderVariant}
+      headingDecoration={headingDecoration}
     />
   );
 

--- a/packages/manager/src/features/linodes/LinodesCreate/AppPanelSection.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/AppPanelSection.tsx
@@ -68,7 +68,7 @@ export const AppPanelSection: React.FC<Props> = (props) => {
               openDrawer={openDrawer}
               disabled={disabled}
               iconUrl={eachApp.logo_url.toLowerCase() || ''}
-              labelDecoration={isCluster ? <Chip label="Cluster" /> : undefined}
+              labelDecoration={isCluster ? <Chip label="CLUSTER" /> : undefined}
             />
           );
         })}

--- a/packages/manager/src/features/linodes/LinodesCreate/AppPanelSection.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/AppPanelSection.tsx
@@ -50,10 +50,16 @@ export const AppPanelSection: React.FC<Props> = (props) => {
       ) : null}
       <Grid className={classes.flatImagePanelSelections} container>
         {apps.map((eachApp) => {
+          const decodedLabel = decode(eachApp.label);
           const isCluster =
-            eachApp.user_defined_fields.find(
+            decodedLabel.endsWith('Cluster ') &&
+            eachApp.user_defined_fields.some(
               (field) => field.name === 'node_options'
-            ) !== undefined;
+            );
+
+          const label = isCluster
+            ? decodedLabel.split(' Cluster')[0]
+            : decodedLabel;
 
           return (
             <SelectionCardWrapper
@@ -61,7 +67,7 @@ export const AppPanelSection: React.FC<Props> = (props) => {
               key={eachApp.id}
               checked={eachApp.id === selectedStackScriptID}
               // Decode App labels since they may contain HTML entities.
-              label={decode(eachApp.label)}
+              label={label}
               availableImages={eachApp.images}
               userDefinedFields={eachApp.user_defined_fields}
               handleClick={handleClick}

--- a/packages/manager/src/features/linodes/LinodesCreate/AppPanelSection.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/AppPanelSection.tsx
@@ -68,7 +68,9 @@ export const AppPanelSection: React.FC<Props> = (props) => {
               openDrawer={openDrawer}
               disabled={disabled}
               iconUrl={eachApp.logo_url.toLowerCase() || ''}
-              labelDecoration={isCluster ? <Chip label="CLUSTER" /> : undefined}
+              labelDecoration={
+                isCluster ? <Chip size="small" label="CLUSTER" /> : undefined
+              }
             />
           );
         })}

--- a/packages/manager/src/features/linodes/LinodesCreate/AppPanelSection.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/AppPanelSection.tsx
@@ -14,6 +14,11 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginBottom: theme.spacing(),
     padding: `${theme.spacing(1)}px 0`,
   },
+  chip: {
+    '& span': {
+      color: 'inherit !important',
+    },
+  },
 }));
 
 interface Props {
@@ -75,7 +80,9 @@ export const AppPanelSection: React.FC<Props> = (props) => {
               disabled={disabled}
               iconUrl={eachApp.logo_url.toLowerCase() || ''}
               labelDecoration={
-                isCluster ? <Chip size="small" label="CLUSTER" /> : undefined
+                isCluster ? (
+                  <Chip size="small" label="CLUSTER" className={classes.chip} />
+                ) : undefined
               }
             />
           );

--- a/packages/manager/src/features/linodes/LinodesCreate/AppPanelSection.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/AppPanelSection.tsx
@@ -6,6 +6,7 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 import SelectionCardWrapper from 'src/features/linodes/LinodesCreate/SelectionCardWrapper';
+import Chip from 'src/components/core/Chip';
 
 const useStyles = makeStyles((theme: Theme) => ({
   flatImagePanelSelections: {
@@ -48,21 +49,29 @@ export const AppPanelSection: React.FC<Props> = (props) => {
         <Divider spacingTop={16} spacingBottom={16} />
       ) : null}
       <Grid className={classes.flatImagePanelSelections} container>
-        {apps.map((eachApp) => (
-          <SelectionCardWrapper
-            id={eachApp.id}
-            key={eachApp.id}
-            checked={eachApp.id === selectedStackScriptID}
-            // Decode App labels since they may contain HTML entities.
-            label={decode(eachApp.label)}
-            availableImages={eachApp.images}
-            userDefinedFields={eachApp.user_defined_fields}
-            handleClick={handleClick}
-            openDrawer={openDrawer}
-            disabled={disabled}
-            iconUrl={eachApp.logo_url.toLowerCase() || ''}
-          />
-        ))}
+        {apps.map((eachApp) => {
+          const isCluster =
+            eachApp.user_defined_fields.find(
+              (field) => field.name === 'node_options'
+            ) !== undefined;
+
+          return (
+            <SelectionCardWrapper
+              id={eachApp.id}
+              key={eachApp.id}
+              checked={eachApp.id === selectedStackScriptID}
+              // Decode App labels since they may contain HTML entities.
+              label={decode(eachApp.label)}
+              availableImages={eachApp.images}
+              userDefinedFields={eachApp.user_defined_fields}
+              handleClick={handleClick}
+              openDrawer={openDrawer}
+              disabled={disabled}
+              iconUrl={eachApp.logo_url.toLowerCase() || ''}
+              labelDecoration={isCluster ? <Chip label="Cluster" /> : undefined}
+            />
+          );
+        })}
       </Grid>
     </>
   );

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectionCardWrapper.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectionCardWrapper.tsx
@@ -49,6 +49,7 @@ interface Props {
   availableImages: string[];
   disabled: boolean;
   checked: boolean;
+  labelDecoration?: JSX.Element;
 }
 
 export const SelectionCardWrapper: React.FC<Props> = (props) => {
@@ -62,6 +63,7 @@ export const SelectionCardWrapper: React.FC<Props> = (props) => {
     disabled,
     handleClick,
     openDrawer,
+    labelDecoration,
   } = props;
   /**
    * '' is the default value for a stackscript's logo_url;
@@ -120,6 +122,7 @@ export const SelectionCardWrapper: React.FC<Props> = (props) => {
       data-qa-selection-card
       disabled={disabled}
       className={classes.selectionCard}
+      headingDecoration={labelDecoration}
     />
   );
 };


### PR DESCRIPTION
## Description 📝

Adds the ability to add a chip to add components to the right of a card's heading. This is used to add a Chip to the right of the heading on the SelectionCards of one click apps that are targeted at clusters.

## Preview 📷

![image](https://user-images.githubusercontent.com/115022759/203159228-ca503b03-f163-40d6-a825-c0b48c12b4b0.png)


## How to test 🧪

1. In a text editor open the `AppPanelSection.tsx` file
2. On line 53 set the value of `isCluster` to `true`
3. Navigate to the marketplace
4. Ensure Chip indicating that an app is deployed on a cluster is in the correct place.

**How do I run relevant unit or e2e tests?**

`yarn test CardBase`
