### PR TITLE
M3-5991: SMTP add helper text

### DIFF
--- a/packages/manager/src/components/Notice/Notice.tsx
+++ b/packages/manager/src/components/Notice/Notice.tsx
@@ -137,7 +137,7 @@ interface Props extends GridProps {
   className?: string;
   flag?: boolean;
   notificationList?: boolean;
-  spacingTop?: 0 | 4 | 8 | 12 | 16 | 24;
+  spacingTop?: 0 | 4 | 8 | 12 | 16 | 24 | 32;
   spacingBottom?: 0 | 4 | 8 | 12 | 16 | 20 | 24 | 32;
   spacingLeft?: number;
   breakWords?: boolean;

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import { Interface, restoreBackup } from '@linode/api-v4/lib/linodes';
 import { Tag } from '@linode/api-v4/lib/tags/types';
 import * as React from 'react';
@@ -711,9 +712,10 @@ export class LinodeCreate extends React.PureComponent<
             className={classes.buttonGroup}
           >
             <div
-              className={`${classes.messageGroup} ${
-                showAgreement ? classes.messageGroupMaxWidth : ''
-              }`}
+              className={classNames({
+                [classes.messageGroup]: true,
+                [classes.messageGroupMaxWidth]: !!showAgreement,
+              })}
             >
               <SMTPRestrictionText>
                 {({ text }) => (

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -66,6 +66,7 @@ import {
   WithTypesRegionsAndImages,
 } from './types';
 import EUAgreementCheckbox from 'src/features/Account/Agreements/EUAgreementCheckbox';
+import SMTPRestrictionText from 'src/features/linodes/SMTPRestrictionText';
 import { CheckoutSummary } from 'src/components/CheckoutSummary/CheckoutSummary';
 import Button from 'src/components/Button';
 import Box from 'src/components/core/Box';
@@ -699,6 +700,15 @@ export class LinodeCreate extends React.PureComponent<
             flexWrap="wrap"
             className={classes.buttonGroup}
           >
+            <SMTPRestrictionText>
+              {(
+                { text } // TODO: Fix styling.
+              ) => (
+                <Grid item xs={12}>
+                  {text}
+                </Grid>
+              )}
+            </SMTPRestrictionText>
             {showAgreement ? (
               <EUAgreementCheckbox
                 checked={signedAgreement}

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -78,7 +78,8 @@ type ClassNames =
   | 'stackScriptWrapper'
   | 'imageSelect'
   | 'buttonGroup'
-  | 'agreement'
+  | 'messageGroup'
+  | 'messageGroupMaxWidth'
   | 'createButton';
 
 const styles = (theme: Theme) =>
@@ -103,7 +104,16 @@ const styles = (theme: Theme) =>
         justifyContent: 'flex-end',
       },
     },
-    agreement: {
+    messageGroup: {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(2),
+      flexGrow: 1,
+      [theme.breakpoints.down('sm')]: {
+        margin: theme.spacing(1),
+      },
+    },
+    messageGroupMaxWidth: {
       maxWidth: '70%',
       [theme.breakpoints.down('xs')]: {
         maxWidth: 'unset',
@@ -700,23 +710,26 @@ export class LinodeCreate extends React.PureComponent<
             flexWrap="wrap"
             className={classes.buttonGroup}
           >
-            <SMTPRestrictionText>
-              {(
-                { text } // TODO: Fix styling.
-              ) => (
-                <Grid item xs={12}>
-                  {text}
-                </Grid>
-              )}
-            </SMTPRestrictionText>
-            {showAgreement ? (
-              <EUAgreementCheckbox
-                checked={signedAgreement}
-                onChange={handleAgreementChange}
-                className={classes.agreement}
-                centerCheckbox
-              />
-            ) : null}
+            <div
+              className={`${classes.messageGroup} ${
+                showAgreement ? classes.messageGroupMaxWidth : ''
+              }`}
+            >
+              <SMTPRestrictionText>
+                {({ text }) => (
+                  <Grid item xs={12}>
+                    {text}
+                  </Grid>
+                )}
+              </SMTPRestrictionText>
+              {showAgreement ? (
+                <EUAgreementCheckbox
+                  checked={signedAgreement}
+                  onChange={handleAgreementChange}
+                  centerCheckbox
+                />
+              ) : null}
+            </div>
             <Button
               data-qa-deploy-linode
               buttonType="primary"

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
@@ -9,11 +9,13 @@ import Typography from 'src/components/core/Typography';
 import DismissibleBanner from 'src/components/DismissibleBanner';
 import Grid from 'src/components/Grid';
 import Link from 'src/components/Link';
+import Notice from 'src/components/Notice';
 import TagDrawer from 'src/components/TagCell/TagDrawer';
 import LinodeEntityDetail from 'src/features/linodes/LinodeEntityDetail';
 import PowerDialogOrDrawer, {
   Action as BootAction,
 } from 'src/features/linodes/PowerActionsDialogOrDrawer';
+import SMTPRestrictionText from 'src/features/linodes/SMTPRestrictionText';
 import { DialogType } from 'src/features/linodes/types';
 import { notificationContext as _notificationContext } from 'src/features/NotificationCenter/NotificationContext';
 import useLinodeActions from 'src/hooks/useLinodeActions';
@@ -355,6 +357,20 @@ const LinodeDetailHeader: React.FC<CombinedProps> = (props) => {
         openPowerActionDialog={openPowerActionDialog}
         openNotificationMenu={notificationContext.openMenu}
       />
+      <SMTPRestrictionText>
+        {({ text }) => (
+          <Notice
+            style={{ marginTop: '24px' }} // TODO: Fix styling.
+            warning
+            dismissible
+            onClose={() => null}
+          >
+            <Grid item xs={12}>
+              {text}
+            </Grid>
+          </Notice>
+        )}
+      </SMTPRestrictionText>
       <PowerDialogOrDrawer
         isOpen={powerDialog.open}
         action={powerDialog.bootAction}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
@@ -9,13 +9,11 @@ import Typography from 'src/components/core/Typography';
 import DismissibleBanner from 'src/components/DismissibleBanner';
 import Grid from 'src/components/Grid';
 import Link from 'src/components/Link';
-import Notice from 'src/components/Notice';
 import TagDrawer from 'src/components/TagCell/TagDrawer';
 import LinodeEntityDetail from 'src/features/linodes/LinodeEntityDetail';
 import PowerDialogOrDrawer, {
   Action as BootAction,
 } from 'src/features/linodes/PowerActionsDialogOrDrawer';
-import SMTPRestrictionText from 'src/features/linodes/SMTPRestrictionText';
 import { DialogType } from 'src/features/linodes/types';
 import { notificationContext as _notificationContext } from 'src/features/NotificationCenter/NotificationContext';
 import useLinodeActions from 'src/hooks/useLinodeActions';
@@ -357,20 +355,6 @@ const LinodeDetailHeader: React.FC<CombinedProps> = (props) => {
         openPowerActionDialog={openPowerActionDialog}
         openNotificationMenu={notificationContext.openMenu}
       />
-      <SMTPRestrictionText>
-        {({ text }) => (
-          <Notice
-            style={{ marginTop: '24px' }} // TODO: Fix styling.
-            warning
-            dismissible
-            onClose={() => null}
-          >
-            <Grid item xs={12}>
-              {text}
-            </Grid>
-          </Notice>
-        )}
-      </SMTPRestrictionText>
       <PowerDialogOrDrawer
         isOpen={powerDialog.open}
         action={powerDialog.bootAction}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation.tsx
@@ -103,7 +103,7 @@ const LinodesDetailNavigation: React.FC<CombinedProps> = (props) => {
         segment={`${linodeLabel} - ${tabs[getIndex()]?.title ?? 'Detail View'}`}
       />
       {tabs[getIndex()]?.title === 'Network' ? (
-        <SMTPRestrictionText>
+        <SMTPRestrictionText supportLink={true}>
           {({ text }) =>
             !isNoticeDismissed && text !== null ? (
               <Notice

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation.tsx
@@ -41,6 +41,8 @@ const LinodesDetailNavigation: React.FC<CombinedProps> = (props) => {
     match: { url },
   } = props;
 
+  const [isNoticeDismissed, setIsNoticeDismissed] = React.useState(false);
+
   // Bare metal Linodes have a very different detail view
   const isBareMetalInstance = linodeType?.class === 'metal';
 
@@ -102,13 +104,20 @@ const LinodesDetailNavigation: React.FC<CombinedProps> = (props) => {
       />
       {tabs[getIndex()]?.title === 'Network' ? (
         <SMTPRestrictionText>
-          {({ text }) => (
-            <Notice warning dismissible onClose={() => null} spacingTop={32}>
-              <Grid item xs={12}>
-                {text}
-              </Grid>
-            </Notice>
-          )}
+          {({ text }) =>
+            !isNoticeDismissed && text !== null ? (
+              <Notice
+                warning
+                dismissible
+                onClose={() => setIsNoticeDismissed(true)}
+                spacingTop={32}
+              >
+                <Grid item xs={12}>
+                  {text}
+                </Grid>
+              </Notice>
+            ) : null
+          }
         </SMTPRestrictionText>
       ) : null}
       <div style={{ marginTop: 8 }}>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation.tsx
@@ -103,7 +103,7 @@ const LinodesDetailNavigation: React.FC<CombinedProps> = (props) => {
       {tabs[getIndex()]?.title === 'Network' ? (
         <SMTPRestrictionText>
           {({ text }) => (
-            <Notice warning dismissible onClose={() => null}>
+            <Notice warning dismissible onClose={() => null} spacingTop={32}>
               <Grid item xs={12}>
                 {text}
               </Grid>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation.tsx
@@ -5,9 +5,12 @@ import { compose } from 'recompose';
 import TabPanels from 'src/components/core/ReachTabPanels';
 import Tabs from 'src/components/core/ReachTabs';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import Grid from 'src/components/Grid';
+import Notice from 'src/components/Notice';
 import SafeTabPanel from 'src/components/SafeTabPanel';
 import SuspenseLoader from 'src/components/SuspenseLoader';
 import TabLinkList from 'src/components/TabLinkList';
+import SMTPRestrictionText from 'src/features/linodes/SMTPRestrictionText';
 import { withLinodeDetailContext } from './linodeDetailContext';
 const LinodeSummary = React.lazy(() => import('./LinodeSummary/LinodeSummary'));
 const LinodeNetworking = React.lazy(
@@ -97,6 +100,17 @@ const LinodesDetailNavigation: React.FC<CombinedProps> = (props) => {
       <DocumentTitleSegment
         segment={`${linodeLabel} - ${tabs[getIndex()]?.title ?? 'Detail View'}`}
       />
+      {tabs[getIndex()]?.title === 'Network' ? (
+        <SMTPRestrictionText>
+          {({ text }) => (
+            <Notice warning dismissible onClose={() => null}>
+              <Grid item xs={12}>
+                {text}
+              </Grid>
+            </Notice>
+          )}
+        </SMTPRestrictionText>
+      ) : null}
       <div style={{ marginTop: 8 }}>
         <Tabs index={getIndex()} onChange={navToURL}>
           <TabLinkList tabs={tabs} />

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation.tsx
@@ -4,6 +4,7 @@ import { matchPath, RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
 import TabPanels from 'src/components/core/ReachTabPanels';
 import Tabs from 'src/components/core/ReachTabs';
+import { useDismissibleBanner } from 'src/components/DismissibleBanner/DismissibleBanner';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
@@ -41,7 +42,9 @@ const LinodesDetailNavigation: React.FC<CombinedProps> = (props) => {
     match: { url },
   } = props;
 
-  const [isNoticeDismissed, setIsNoticeDismissed] = React.useState(false);
+  const { hasDismissedBanner, handleDismiss } = useDismissibleBanner(
+    `smtp-restriction-notice-${linodeLabel}`
+  );
 
   // Bare metal Linodes have a very different detail view
   const isBareMetalInstance = linodeType?.class === 'metal';
@@ -105,11 +108,11 @@ const LinodesDetailNavigation: React.FC<CombinedProps> = (props) => {
       {tabs[getIndex()]?.title === 'Network' ? (
         <SMTPRestrictionText supportLink={true}>
           {({ text }) =>
-            !isNoticeDismissed && text !== null ? (
+            !hasDismissedBanner && text !== null ? (
               <Notice
                 warning
                 dismissible
-                onClose={() => setIsNoticeDismissed(true)}
+                onClose={handleDismiss}
                 spacingTop={32}
               >
                 <Grid item xs={12}>

--- a/packages/manager/src/features/linodes/SMTPRestrictionText.test.ts
+++ b/packages/manager/src/features/linodes/SMTPRestrictionText.test.ts
@@ -7,8 +7,9 @@ describe('accountCreatedAfterRestrictions', () => {
   });
 
   it('only returns true when the account was created after the magic date', () => {
-    expect(accountCreatedAfterRestrictions('2019-11-04 00:00:00Z')).toBe(false);
-    expect(accountCreatedAfterRestrictions('2019-11-05 23:59:59Z')).toBe(false);
-    expect(accountCreatedAfterRestrictions('2019-11-06 00:00:00Z')).toBe(true);
+    expect(accountCreatedAfterRestrictions('2022-11-27 00:00:00Z')).toBe(false);
+    expect(accountCreatedAfterRestrictions('2022-11-27 23:59:59Z')).toBe(false);
+    expect(accountCreatedAfterRestrictions('2022-11-28 00:00:00Z')).toBe(true);
+    expect(accountCreatedAfterRestrictions('2022-11-28 00:00:01Z')).toBe(true);
   });
 });

--- a/packages/manager/src/features/linodes/SMTPRestrictionText.test.ts
+++ b/packages/manager/src/features/linodes/SMTPRestrictionText.test.ts
@@ -8,8 +8,8 @@ describe('accountCreatedAfterRestrictions', () => {
 
   it('only returns true when the account was created after the magic date', () => {
     expect(accountCreatedAfterRestrictions('2022-11-27 00:00:00Z')).toBe(false);
-    expect(accountCreatedAfterRestrictions('2022-11-27 23:59:59Z')).toBe(false);
-    expect(accountCreatedAfterRestrictions('2022-11-28 00:00:00Z')).toBe(true);
-    expect(accountCreatedAfterRestrictions('2022-11-28 00:00:01Z')).toBe(true);
+    expect(accountCreatedAfterRestrictions('2022-11-28 23:59:59Z')).toBe(false);
+    expect(accountCreatedAfterRestrictions('2022-11-29 00:00:00Z')).toBe(true);
+    expect(accountCreatedAfterRestrictions('2022-11-29 00:00:01Z')).toBe(true);
   });
 });

--- a/packages/manager/src/features/linodes/SMTPRestrictionText.tsx
+++ b/packages/manager/src/features/linodes/SMTPRestrictionText.tsx
@@ -8,7 +8,7 @@ import { sendLinodeCreateDocsEvent } from 'src/utilities/ga';
 // "In an effort to fight spam, Linode restricts outbound connections on ports 25, 465, and 587 on all Linodes for new accounts created after November 5th, 2019."
 // https://www.linode.com/docs/email/best-practices/running-a-mail-server/
 const MAGIC_DATE_THAT_EMAIL_RESTRICTIONS_WERE_IMPLEMENTED =
-  '2022-11-28T00:00:00.000Z'; // Date of release for Manager v81.0.
+  '2022-11-29T00:00:00.000Z'; // Date of release for Manager v1.81.0.
 
 interface Props {
   children: (props: { text: React.ReactNode }) => React.ReactNode;

--- a/packages/manager/src/features/linodes/SMTPRestrictionText.tsx
+++ b/packages/manager/src/features/linodes/SMTPRestrictionText.tsx
@@ -28,7 +28,7 @@ const SMTPRestrictionText: React.FC<Props> = (props) => {
       <ExternalLink
         onClick={() => sendLinodeCreateDocsEvent('SMTP Notice Link')}
         link="https://www.linode.com/docs/email/best-practices/running-a-mail-server/"
-        text="Mail Server Guide"
+        text="mail server guide"
         hideIcon
       />
       , then{' '}

--- a/packages/manager/src/features/linodes/SMTPRestrictionText.tsx
+++ b/packages/manager/src/features/linodes/SMTPRestrictionText.tsx
@@ -12,9 +12,11 @@ const MAGIC_DATE_THAT_EMAIL_RESTRICTIONS_WERE_IMPLEMENTED =
 
 interface Props {
   children: (props: { text: React.ReactNode }) => React.ReactNode;
+  supportLink?: boolean;
 }
 
 const SMTPRestrictionText: React.FC<Props> = (props) => {
+  const { supportLink } = props;
   const { data: account } = useAccount();
 
   // If there account was created before restrictions were put into place,
@@ -32,7 +34,14 @@ const SMTPRestrictionText: React.FC<Props> = (props) => {
         hideIcon
       />
       , then{' '}
-      <SupportLink text="open a support ticket" title="Re: SMTP Restrictions" />
+      {supportLink ? (
+        <SupportLink
+          text="open a support ticket"
+          title="Re: SMTP Restrictions"
+        />
+      ) : (
+        'open a support ticket'
+      )}
       .
     </Typography>
   );

--- a/packages/manager/src/features/linodes/SMTPRestrictionText.tsx
+++ b/packages/manager/src/features/linodes/SMTPRestrictionText.tsx
@@ -1,13 +1,14 @@
 import * as React from 'react';
 import Typography from 'src/components/core/Typography';
 import ExternalLink from 'src/components/ExternalLink';
+import SupportLink from 'src/components/SupportLink';
 import { useAccount } from 'src/queries/account';
 import { sendLinodeCreateDocsEvent } from 'src/utilities/ga';
 
 // "In an effort to fight spam, Linode restricts outbound connections on ports 25, 465, and 587 on all Linodes for new accounts created after November 5th, 2019."
 // https://www.linode.com/docs/email/best-practices/running-a-mail-server/
 const MAGIC_DATE_THAT_EMAIL_RESTRICTIONS_WERE_IMPLEMENTED =
-  '2019-11-06T00:00:00.000Z';
+  '2022-11-28T00:00:00.000Z'; // Date of release for Manager v81.0.
 
 interface Props {
   children: (props: { text: React.ReactNode }) => React.ReactNode;
@@ -22,16 +23,17 @@ const SMTPRestrictionText: React.FC<Props> = (props) => {
     account?.active_since
   ) ? null : (
     <Typography variant="body1">
-      Need to send mail from your Linode? New Linode accounts have ports{' '}
-      <strong>25, 465, and 587</strong> blocked by default. To have these
-      restrictions removed, please review{' '}
+      SMTP ports may be restricted on this Linode. Need to send email? Review
+      our{' '}
       <ExternalLink
         onClick={() => sendLinodeCreateDocsEvent('SMTP Notice Link')}
         link="https://www.linode.com/docs/email/best-practices/running-a-mail-server/"
-        text="this guide"
+        text="Mail Server Guide"
         hideIcon
       />
-      , then <strong>open a Support Ticket after creating your Linode.</strong>
+      , then{' '}
+      <SupportLink text="open a support ticket" title="Re: SMTP Restrictions" />
+      .
     </Typography>
   );
 

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -695,7 +695,7 @@ export const handlers = [
   rest.get('*/account', (req, res, ctx) => {
     const account = accountFactory.build({
       balance: 50,
-      active_since: '2019-11-05',
+      active_since: '2022-11-28',
       active_promotions: promoFactory.buildList(2),
     });
     return res(ctx.json(account));


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
Adds two SMTP restriction notices to Cloud Manager for customers with _**accounts created on or after**_ the next release date.

Notice 1—at the bottom of the Linode create page 
Notice 2—on the Linode detail page, above tab set, with the Network tab selected

## Preview 📷

**Notice 1:**

Without EU agreement:
![Screen Shot 2022-11-21 at 2 31 17 PM](https://user-images.githubusercontent.com/114685994/203171719-e31c1982-8002-43dc-92e3-1db438282bd7.jpg)

With EU agreement:
![Screen Shot 2022-11-21 at 2 31 48 PM](https://user-images.githubusercontent.com/114685994/203171733-249f7f9b-0c0a-4adc-aa78-defee6b2f1f0.jpg)

**Notice 2:**
![Screen Shot 2022-11-21 at 2 32 58 PM](https://user-images.githubusercontent.com/114685994/203171749-85cc18b8-bc16-46b3-9821-9594e1347363.jpg)

## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**
- Turn on MSW to mock a user who created an account on the day of the next release.

Notice 1:
- Navigate to the Linode Create page. Scroll to bottom of page and observe SMTP text.
- Set the new linode's region to London, UK or Frankfurt, DE 
- Scroll to the bottom of the page and observe SMTP text and EU agreement text.
- Adjust the screen size and confirm that the message(s) and Create Linode button at the bottom of the page are still legible and spacing is not weird.

Notice 2:
- Navigate to the Linode Details page of any linode. Click on the Network tab. Observe the dismissible notice. Select a different tab and confirm the notice is not visible.
- On the Network tab, confirm that the notice is dismissible by clicking the 'X'. 
- In `serverHandlers.ts`, adjust the `active_since` value in `rest.get('*/account', (req, res, ctx)` to dates before and after the next release. Ensure that SMTP helper text only appears for accounts active _on or after **11-28-22**_. 

**How do I run relevant unit or e2e tests?**
Run `yarn test SMTPRestrictionText.test.ts`.
