### PR TITLE
M3-5922: Add machine image update and delete E2E tests

### DIFF
--- a/packages/manager/cypress/e2e/images/machine-image-upload.spec.ts
+++ b/packages/manager/cypress/e2e/images/machine-image-upload.spec.ts
@@ -1,5 +1,5 @@
-import { EventStatus } from '@linode/api-v4/lib/account/types';
-import { ImageStatus } from '@linode/api-v4/lib/images/types';
+import { EventStatus } from '@linode/api-v4/types';
+import { ImageStatus } from '@linode/api-v4/types';
 import { eventFactory, imageFactory } from '@src/factories';
 import { makeResourcePage } from '@src/mocks/serverHandlers';
 import 'cypress-file-upload';
@@ -8,8 +8,16 @@ import { DateTime } from 'luxon';
 import { regionsFriendly } from 'support/constants/regions';
 import { fbtClick, fbtVisible, getClick } from 'support/helpers';
 import { interceptOnce } from 'support/ui/common';
-import { assertToast } from 'support/ui/events';
-import { randomLabel, randomItem } from 'support/util/random';
+import { randomLabel, randomItem, randomPhrase } from 'support/util/random';
+import { ui } from 'support/ui';
+
+/*
+ * Amount of time to wait for toast notification after uploading image, in ms.
+ *
+ * We extend the timeout used when waiting for image uploading and processing
+ * since this operation can take a couple minutes.
+ */
+const imageUploadWaitTimeout = 120000;
 
 /**
  * Returns a numeric image ID from a string-based image ID.
@@ -95,7 +103,10 @@ const imageIntercept = (label: string, id: string, status: ImageStatus) => {
  * @param message - Expected failure message.
  */
 const assertFailed = (label: string, id: string, message: string) => {
-  assertToast(`There was a problem processing image ${label}: ${message}`);
+  ui.toast.assertMessage(
+    `There was a problem processing image ${label}: ${message}`
+  );
+
   cy.get(`[data-qa-image-cell="${id}"]`).within(() => {
     fbtVisible(label);
     fbtVisible('Failed');
@@ -149,19 +160,80 @@ describe('machine image', () => {
    * - Confirms that image uploads successfully.
    * - Confirms that machine image is listed in landing page as expected.
    * - Confirms that notifications appear that describe the image's success status.
+   * - Confirms that image label can be updated.
+   * - Confirms that image description can be updated.
+   * - Confirms that image can be deleted.
    */
-  it.skip('uploads machine image, end-to-end', () => {
-    // @TODO Unskip 'uploads machine image, end-to-end' when we have a better path forward for segmenting slower tests.
-    // See also: M3-5723 "Investigate creating a second 'tier' of Cypress tests".
-    const label = randomLabel();
-    uploadImage(label);
+  it('uploads, updates, and deletes a machine image, end-to-end', () => {
+    const initialLabel = randomLabel();
+    const updatedLabel = randomLabel();
+    const updatedDescription = randomPhrase();
+
+    uploadImage(initialLabel);
     cy.wait('@imageUpload').then((xhr) => {
       const imageId = xhr.response?.body.image.id;
-      assertToast(`Image ${label} is now available.`);
-      cy.get(`[data-qa-image-cell="${imageId}"]`).within(() => {
-        fbtVisible(label);
-        fbtVisible('Ready');
+
+      ui.toast.assertMessage(`Image ${initialLabel} is now available.`, {
+        timeout: imageUploadWaitTimeout,
       });
+
+      cy.get(`[data-qa-image-cell="${imageId}"]`).within(() => {
+        cy.findByText(initialLabel).should('be.visible');
+        cy.findByText('Ready').should('be.visible');
+
+        ui.actionMenu
+          .findByTitle(`Action menu for Image ${initialLabel}`)
+          .should('be.visible')
+          .click();
+      });
+
+      ui.actionMenuItem.findByTitle('Edit').should('be.visible').click();
+
+      ui.drawer
+        .findByTitle('Edit Image')
+        .should('be.visible')
+        .within(() => {
+          cy.findByLabelText('Label')
+            .should('be.visible')
+            .clear()
+            .type(updatedLabel);
+
+          cy.findByLabelText('Description')
+            .should('be.visible')
+            .clear()
+            .type(updatedDescription);
+
+          ui.buttonGroup
+            .findButtonByTitle('Save Changes')
+            .should('be.visible')
+            .should('be.enabled')
+            .click();
+        });
+
+      cy.get(`[data-qa-image-cell="${imageId}"]`).within(() => {
+        cy.findByText(updatedLabel).should('be.visible');
+        cy.findByText(initialLabel).should('not.exist');
+        ui.actionMenu
+          .findByTitle(`Action menu for Image ${updatedLabel}`)
+          .should('be.visible')
+          .click();
+      });
+
+      ui.actionMenuItem.findByTitle('Delete').should('be.visible').click();
+
+      ui.dialog
+        .findByTitle(`Delete Image ${updatedLabel}`)
+        .should('be.visible')
+        .within(() => {
+          ui.buttonGroup
+            .findButtonByTitle('Delete Image')
+            .should('be.visible')
+            .should('be.enabled')
+            .click();
+        });
+
+      ui.toast.assertMessage('Image has been scheduled for deletion.');
+      cy.findByText(updatedLabel).should('not.exist');
     });
   });
 
@@ -171,20 +243,22 @@ describe('machine image', () => {
    * - Confirms that machine image is listed in landing page as expected.
    * - Confirms that notifications appear that describe the image's success status.
    */
-  it('uploads machine image, mock finish event', () => {
+  it.skip('uploads machine image, mock finish event', () => {
     const label = randomLabel();
     const status = 'finished';
+
+    const uploadMessage = `Image ${label} uploaded successfully. It is being processed and will be available shortly.`;
+    const availableMessage = `Image ${label} is now available.`;
+
     uploadImage(label);
     cy.wait('@imageUpload').then((xhr) => {
       const imageId = xhr.response?.body.image.id;
       assertProcessing(label, imageId);
       imageIntercept(label, imageId, 'available');
       eventIntercept(label, imageId, status);
-      assertToast(
-        `Image ${label} uploaded successfully. It is being processed and will be available shortly.`
-      );
+      ui.toast.assertMessage(uploadMessage);
       cy.wait('@getImage');
-      assertToast(`Image ${label} is now available.`);
+      ui.toast.assertMessage(availableMessage);
       cy.get(`[data-qa-image-cell="${imageId}"]`).within(() => {
         fbtVisible(label);
         fbtVisible('Ready');
@@ -198,7 +272,7 @@ describe('machine image', () => {
    * - Confirms that machine image is listed in landing page as expected.
    * - Confirms that notifications appear that describe the image's failed status.
    */
-  it('uploads machine image, mock upload canceled failed event', () => {
+  it.skip('uploads machine image, mock upload canceled failed event', () => {
     const label = randomLabel();
     const status = 'failed';
     const message = 'Upload canceled';
@@ -218,7 +292,7 @@ describe('machine image', () => {
    * - Confirms that machine image is listed in landing page as expected.
    * - Confirms that notifications appear that describe the image's failed status.
    */
-  it('uploads machine image, mock failed to decompress failed event', () => {
+  it.skip('uploads machine image, mock failed to decompress failed event', () => {
     const label = randomLabel();
     const status = 'failed';
     const message = 'Failed to decompress image';
@@ -238,7 +312,7 @@ describe('machine image', () => {
    * - Confirms that machine image is listed in landing page as expected.
    * - Confirms that notifications appear that describe the image's failed status.
    */
-  it('uploads machine image, mock expired upload event', () => {
+  it.skip('uploads machine image, mock expired upload event', () => {
     const label = randomLabel();
     const status = 'failed';
     const message = 'Upload window expired';

--- a/packages/manager/cypress/e2e/images/machine-image-upload.spec.ts
+++ b/packages/manager/cypress/e2e/images/machine-image-upload.spec.ts
@@ -242,7 +242,7 @@ describe('machine image', () => {
    * - Confirms that machine image is listed in landing page as expected.
    * - Confirms that notifications appear that describe the image's success status.
    */
-  it.skip('uploads machine image, mock finish event', () => {
+  it('uploads machine image, mock finish event', () => {
     const label = randomLabel();
     const status = 'finished';
 
@@ -271,7 +271,7 @@ describe('machine image', () => {
    * - Confirms that machine image is listed in landing page as expected.
    * - Confirms that notifications appear that describe the image's failed status.
    */
-  it.skip('uploads machine image, mock upload canceled failed event', () => {
+  it('uploads machine image, mock upload canceled failed event', () => {
     const label = randomLabel();
     const status = 'failed';
     const message = 'Upload canceled';
@@ -291,7 +291,7 @@ describe('machine image', () => {
    * - Confirms that machine image is listed in landing page as expected.
    * - Confirms that notifications appear that describe the image's failed status.
    */
-  it.skip('uploads machine image, mock failed to decompress failed event', () => {
+  it('uploads machine image, mock failed to decompress failed event', () => {
     const label = randomLabel();
     const status = 'failed';
     const message = 'Failed to decompress image';
@@ -311,7 +311,7 @@ describe('machine image', () => {
    * - Confirms that machine image is listed in landing page as expected.
    * - Confirms that notifications appear that describe the image's failed status.
    */
-  it.skip('uploads machine image, mock expired upload event', () => {
+  it('uploads machine image, mock expired upload event', () => {
     const label = randomLabel();
     const status = 'failed';
     const message = 'Upload window expired';

--- a/packages/manager/cypress/e2e/images/machine-image-upload.spec.ts
+++ b/packages/manager/cypress/e2e/images/machine-image-upload.spec.ts
@@ -1,5 +1,4 @@
-import { EventStatus } from '@linode/api-v4/types';
-import { ImageStatus } from '@linode/api-v4/types';
+import { EventStatus, ImageStatus } from '@linode/api-v4/types';
 import { eventFactory, imageFactory } from '@src/factories';
 import { makeResourcePage } from '@src/mocks/serverHandlers';
 import 'cypress-file-upload';
@@ -7,9 +6,9 @@ import { RecPartial } from 'factory.ts';
 import { DateTime } from 'luxon';
 import { regionsFriendly } from 'support/constants/regions';
 import { fbtClick, fbtVisible, getClick } from 'support/helpers';
-import { interceptOnce } from 'support/ui/common';
-import { randomLabel, randomItem, randomPhrase } from 'support/util/random';
 import { ui } from 'support/ui';
+import { interceptOnce } from 'support/ui/common';
+import { randomItem, randomLabel, randomPhrase } from 'support/util/random';
 
 /*
  * Amount of time to wait for toast notification after uploading image, in ms.

--- a/packages/manager/cypress/support/ui/action-menu.ts
+++ b/packages/manager/cypress/support/ui/action-menu.ts
@@ -35,7 +35,10 @@ export const actionMenuItem = {
    */
   findByTitle: (menuItemTitle: string): Cypress.Chainable => {
     return cy
-      .get(`[data-qa-action-menu-item="${menuItemTitle}"]`)
+      .get(`[data-reach-popover][data-reach-menu][data-reach-menu-popover]`)
+      .not('[hidden]')
+      .eq(0)
+      .find(`[data-qa-action-menu-item="${menuItemTitle}"]`)
       .should('be.visible');
   },
 };

--- a/packages/manager/cypress/support/ui/toast.ts
+++ b/packages/manager/cypress/support/ui/toast.ts
@@ -1,4 +1,14 @@
 /**
+ * Options that can be applied when waiting for a toast notification.
+ */
+export type ToastFindOptions = Partial<
+  Cypress.Loggable &
+    Cypress.Timeoutable &
+    Cypress.CaseMatchable &
+    Cypress.Shadow
+>;
+
+/**
  * Toast notification UI element.
  */
 export const toast = {
@@ -9,21 +19,29 @@ export const toast = {
    * made as quickly as possible after finding the element.
    *
    * @param message - Message for the toast that should be found.
+   * @param options - Optional Cypress options to find and wait for toast notification.
    *
    * @returns Cypress chainable.
    */
-  findByMessage: (message: string): Cypress.Chainable => {
-    return cy.contains('[data-qa-toast]', message);
+  findByMessage: (
+    message: string,
+    options?: ToastFindOptions | undefined
+  ): Cypress.Chainable => {
+    return cy.contains('[data-qa-toast]', message, options);
   },
 
   /**
    * Asserts that a toast notification with the given message is displayed.
    *
    * @param message - Message for the toast being asserted.
+   * @param options - Optional Cypress options to find and wait for toast notification.
    *
    * @returns Cypress chainable.
    */
-  assertMessage: (message: string): void => {
-    cy.contains('[data-qa-toast]', message).should('be.visible');
+  assertMessage: (
+    message: string,
+    options?: ToastFindOptions | undefined
+  ): void => {
+    cy.contains('[data-qa-toast]', message, options).should('be.visible');
   },
 };

--- a/packages/manager/cypress/support/util/random.ts
+++ b/packages/manager/cypress/support/util/random.ts
@@ -177,3 +177,25 @@ export const randomPhoneNumber = (
     9999
   )}`;
 };
+
+/**
+ * Returns a random phrase of random strings.
+ *
+ * @param count - Number of strings to include in phrase.
+ *
+ * @returns Random phrase.
+ */
+export const randomPhrase = (count: number = 5): string => {
+  return [...Array(count)]
+    .map(() => {
+      const length = randomNumber(3, 9);
+      return randomString(length, {
+        lowercase: true,
+        uppercase: false,
+        numbers: false,
+        symbols: false,
+        spaces: false,
+      });
+    })
+    .join(' ');
+};


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
Adds flows to the machine image E2E test to verify that updating and deleting machine images works as expected.

I opted to add flows to the existing image creation test rather than creating separate tests since the data setup (i.e. creating an image) can take a minute or two.

## How to test 🧪

**How do I run relevant unit or e2e tests?**
Run `yarn dev`, and then run:

```bash
yarn cy:run -s "cypress/e2e/images/machine-image-upload.spec.ts"
```
And confirm that all of the tests pass.

To run the tests interactively, run `yarn cy:debug` and search for `machine-image-upload.spec.ts`.
