### PR TITLE
M3-5997: Update OCA drawer to support clusters

### DIFF
--- a/packages/manager/src/features/OneClickApps/AppDetailDrawer.test.tsx
+++ b/packages/manager/src/features/OneClickApps/AppDetailDrawer.test.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+import AppDetailDrawer from './AppDetailDrawer';
+
+describe('AppDetailDrawer component', () => {
+  it("should have a title ending in 'Cluster' if the app is a cluster", () => {
+    const { queryByTestId } = renderWithTheme(
+      <AppDetailDrawer
+        open={true}
+        onClose={() => {}}
+        stackScriptLabel="MongoDB Cluster "
+      />
+    );
+
+    const innerHTML = queryByTestId('app-name')?.innerHTML;
+    expect(innerHTML).toBe('MongoDB Cluster');
+  });
+
+  it("should not have a title ending in 'Cluster' if the app is not a cluster", () => {
+    const { queryByTestId } = renderWithTheme(
+      <AppDetailDrawer
+        open={true}
+        onClose={() => {}}
+        stackScriptLabel="MongoDB "
+      />
+    );
+
+    const innerHTML = queryByTestId('app-name')?.innerHTML;
+    expect(innerHTML).toBe('MongoDB');
+  });
+
+  it('should not logically break if the stackScriptLabel for a cluster does not have the expected spaces', () => {
+    const { queryByTestId } = renderWithTheme(
+      <AppDetailDrawer
+        open={true}
+        onClose={() => {}}
+        stackScriptLabel="MongoDB Cluster"
+      />
+    );
+
+    const innerHTML = queryByTestId('app-name')?.innerHTML;
+    expect(innerHTML).toBe('MongoDB Cluster');
+  });
+});

--- a/packages/manager/src/features/OneClickApps/AppDetailDrawer.tsx
+++ b/packages/manager/src/features/OneClickApps/AppDetailDrawer.tsx
@@ -1,14 +1,16 @@
-import * as React from 'react';
-import { makeStyles, Theme } from 'src/components/core/styles';
-import { sanitizeHTML } from 'src/utilities/sanitize-html';
-import { oneClickApps } from './FakeSpec';
 import Close from '@material-ui/icons/Close';
+import { cloneDeep } from 'lodash';
+import * as React from 'react';
 import Button from 'src/components/Button/Button';
 import Box from 'src/components/core/Box';
 import Drawer from 'src/components/core/Drawer';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import ExternalLink from 'src/components/ExternalLink';
+import { OCA } from 'src/features/OneClickApps/FakeSpec';
 import useFlags from 'src/hooks/useFlags';
+import { sanitizeHTML } from 'src/utilities/sanitize-html';
+import { oneClickApps } from './FakeSpec';
 
 const useStyles = makeStyles((theme: Theme) => ({
   logoContainer: {
@@ -82,17 +84,70 @@ export const AppDetailDrawer: React.FunctionComponent<Props> = (props) => {
   const classes = useStyles();
   const { oneClickAppsDocsOverride } = useFlags();
 
-  const app = oneClickApps.find((app) => {
-    const cleanedStackScriptLabel = stackScriptLabel
-      .replace(/[^\w\s\/$*+-?&.:()]/gi, '')
-      .trim();
-    const cleanedAppName = app.name.replace('&reg;', '');
-    return cleanedStackScriptLabel === cleanedAppName;
-  });
+  const [selectedApp, setSelectedApp] = React.useState<OCA | null>(null);
+
+  const labelIndicatesCluster = stackScriptLabel.includes(' Cluster ');
+
+  /*
+    Since we use the label to search within the OCA array and clusters use
+    the app info from their individual app counterparts, we need to extract
+    the base StackScript label out to be able to search the array successfully.
+  */
+  const baseStackScriptLabel = stackScriptLabel.replace(' Cluster ', '');
 
   const gradient = {
-    backgroundImage: `url(/assets/marketplace-background.png),linear-gradient(to right, #${app?.colors.start}, #${app?.colors.end})`,
+    backgroundImage: `url(/assets/marketplace-background.png),linear-gradient(to right, #${selectedApp?.colors.start}, #${selectedApp?.colors.end})`,
   };
+
+  React.useEffect(() => {
+    const app = oneClickApps.find((app) => {
+      const cleanedStackScriptLabel = stackScriptLabel
+        .replace(/[^\w\s\/$*+-?&.:()]/gi, '')
+        .trim();
+
+      const cleanedBaseStackScriptLabel = baseStackScriptLabel
+        .replace(/[^\w\s\/$*+-?&.:()]/gi, '')
+        .trim();
+
+      const cleanedAppName = app.name.replace('&reg;', '');
+
+      /* This logic is to capture two cases:
+          1) the matching app name does not contain " Cluster " (e.g., MongoDB)
+          2) the matching app name does contain " Cluster " (e.g., Galera Cluster)
+      */
+      return (
+        cleanedStackScriptLabel === cleanedAppName ||
+        cleanedBaseStackScriptLabel === cleanedAppName
+      );
+    });
+
+    if (!app) {
+      return;
+    }
+
+    const appCopy = cloneDeep(app);
+
+    if (labelIndicatesCluster) {
+      appCopy.name += ' Cluster';
+      // eslint-disable-next-line no-unused-expressions
+      appCopy.related_guides?.push(
+        {
+          title: 'Learn about database clusters',
+          href: 'https://www.linode.com/docs/guides', // temporary placeholder
+        },
+        {
+          title: 'Set up Linode API token',
+          href: 'https://www.linode.com/docs/guides', // temporary placeholder
+        }
+      );
+    }
+
+    setSelectedApp(appCopy);
+
+    return () => {
+      setSelectedApp(null);
+    };
+  }, [baseStackScriptLabel, labelIndicatesCluster, stackScriptLabel]);
 
   return (
     <Drawer
@@ -110,7 +165,7 @@ export const AppDetailDrawer: React.FunctionComponent<Props> = (props) => {
           <Close />
         </Button>
       </Box>
-      {app ? (
+      {selectedApp ? (
         <>
           <Box
             display="flex"
@@ -122,47 +177,50 @@ export const AppDetailDrawer: React.FunctionComponent<Props> = (props) => {
           >
             <img
               className={classes.image}
-              src={`/assets/white/${app.logo_url}`}
-              alt={`${app.name} logo`}
+              src={`/assets/white/${selectedApp.logo_url}`}
+              alt={`${selectedApp.name} logo`}
             />
             <Typography
               variant="h2"
               className={classes.appName}
-              dangerouslySetInnerHTML={{ __html: sanitizeHTML(app.name) }}
+              dangerouslySetInnerHTML={{
+                __html: sanitizeHTML(selectedApp.name),
+              }}
             />
           </Box>
           <Box className={classes.container}>
             <Box>
-              <Typography variant="h3">{app.summary}</Typography>
+              <Typography variant="h3">{selectedApp.summary}</Typography>
               <Typography
                 variant="body1"
                 className={classes.description}
                 dangerouslySetInnerHTML={{
-                  __html: sanitizeHTML(app.description),
+                  __html: sanitizeHTML(selectedApp.description),
                 }}
               />
             </Box>
-            {app.website ? (
+            {selectedApp.website ? (
               <Box>
                 <Typography variant="h3">Website</Typography>
                 <ExternalLink
                   className={classes.link}
-                  link={app.website}
-                  text={app.website}
+                  link={selectedApp.website}
+                  text={selectedApp.website}
                   hideIcon
                 />
               </Box>
             ) : null}
-            {app.related_guides ? (
+            {selectedApp.related_guides ? (
               <Box>
                 <Typography variant="h3">Guides</Typography>
                 <Box display="flex" flexDirection="column" style={{ gap: 6 }}>
                   {(
-                    oneClickAppsDocsOverride?.[app.name] ?? app.related_guides
+                    oneClickAppsDocsOverride?.[selectedApp.name] ??
+                    selectedApp.related_guides
                   ).map((link, idx) => (
                     <ExternalLink
                       className={classes.link}
-                      key={`${app.name}-guide-${idx}`}
+                      key={`${selectedApp.name}-guide-${idx}`}
                       text={link.title}
                       link={link.href}
                       hideIcon
@@ -171,12 +229,15 @@ export const AppDetailDrawer: React.FunctionComponent<Props> = (props) => {
                 </Box>
               </Box>
             ) : null}
-            {app.tips ? (
+            {selectedApp.tips ? (
               <Box>
                 <Typography variant="h3">Tips</Typography>
                 <Box display="flex" flexDirection="column" style={{ gap: 6 }}>
-                  {app.tips.map((tip, idx) => (
-                    <Typography variant="body1" key={`${app.name}-tip-${idx}`}>
+                  {selectedApp.tips.map((tip, idx) => (
+                    <Typography
+                      variant="body1"
+                      key={`${selectedApp.name}-tip-${idx}`}
+                    >
                       {tip}
                     </Typography>
                   ))}

--- a/packages/manager/src/features/OneClickApps/AppDetailDrawer.tsx
+++ b/packages/manager/src/features/OneClickApps/AppDetailDrawer.tsx
@@ -86,14 +86,14 @@ export const AppDetailDrawer: React.FunctionComponent<Props> = (props) => {
 
   const [selectedApp, setSelectedApp] = React.useState<OCA | null>(null);
 
-  const labelIndicatesCluster = stackScriptLabel.includes(' Cluster ');
+  const labelIndicatesCluster = /.+\s(Cluster)/.test(stackScriptLabel);
 
   /*
     Since we use the label to search within the OCA array and clusters use
     the app info from their individual app counterparts, we need to extract
     the base StackScript label out to be able to search the array successfully.
   */
-  const baseStackScriptLabel = stackScriptLabel.replace(' Cluster ', '');
+  const baseStackScriptLabel = stackScriptLabel.replace(' Cluster', '');
 
   const gradient = {
     backgroundImage: `url(/assets/marketplace-background.png),linear-gradient(to right, #${selectedApp?.colors.start}, #${selectedApp?.colors.end})`,
@@ -183,6 +183,7 @@ export const AppDetailDrawer: React.FunctionComponent<Props> = (props) => {
             <Typography
               variant="h2"
               className={classes.appName}
+              data-testid="app-name"
               dangerouslySetInnerHTML={{
                 __html: sanitizeHTML(selectedApp.name),
               }}


### PR DESCRIPTION
## Description 📝
- Refactors in `AppDetailDrawer.tsx` to prevent bugs
- Add support in `AppDetailDrawer.tsx` to support clusters
- Add relevant unit tests

## Preview 📷
![Screen Shot 2022-11-22 at 3 34 54 PM](https://user-images.githubusercontent.com/114682940/203418180-8416769b-c42e-4b4e-a048-2977aa30c8e0.jpg)

## How to test 🧪
1. Confirm that OCCs display in the drawer with the title being `[app name] Cluster` and that "Learn about database cluster" and "Set up Linode API token" links appear in the "Guides" section
2. Confirm that regular OCAs have not been adversely impacted by the changes and also that nothing weird happens when switching between selected apps
