### PR TITLE
Fix for two column layout placeholder button overlap

### DIFF
--- a/packages/manager/src/components/Placeholder/Placeholder.tsx
+++ b/packages/manager/src/components/Placeholder/Placeholder.tsx
@@ -105,6 +105,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     gridArea: 'button',
     display: 'flex',
     gap: theme.spacing(2),
+    [theme.breakpoints.down('xs')]: {
+      flexDirection: 'column',
+    },
   },
   linksSection: {
     gridArea: 'links',

--- a/packages/manager/src/components/Placeholder/Placeholder.tsx
+++ b/packages/manager/src/components/Placeholder/Placeholder.tsx
@@ -103,6 +103,8 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   button: {
     gridArea: 'button',
+    display: 'flex',
+    gap: theme.spacing(2),
   },
   linksSection: {
     gridArea: 'links',
@@ -172,18 +174,18 @@ const Placeholder: React.FC<Props> = (props) => {
           props.children
         )}
       </div>
-
-      {buttonProps &&
-        buttonProps.map((thisButton, index) => (
-          <Button
-            buttonType="primary"
-            className={classes.button}
-            {...thisButton}
-            data-qa-placeholder-button
-            data-testid="placeholder-button"
-            key={index}
-          />
-        ))}
+      <div className={classes.button}>
+        {buttonProps &&
+          buttonProps.map((thisButton, index) => (
+            <Button
+              buttonType="primary"
+              {...thisButton}
+              data-qa-placeholder-button
+              data-testid="placeholder-button"
+              key={index}
+            />
+          ))}
+      </div>
       <div className={classes.linksSection}>
         {linksSection !== undefined ? linksSection : null}
       </div>


### PR DESCRIPTION
## Description 📝

In PR #8615 a bug was introduced that caused empty state landing pages that had more than one action button to overlap the buttons. This PR fixes that by wrapping the buttons in a div and making that div flex with gap. This should help dealing with more buttons in the future as well.

## Preview 📷

Before:
![image](https://user-images.githubusercontent.com/115022759/204363197-93fdf6fe-2d40-444e-b6df-768f57e50c56.png)

After:
![image](https://user-images.githubusercontent.com/115022759/204363289-7c201ce7-dbec-4a71-9918-98d197e8071d.png)


## How to test 🧪

Navigate to domains and get it in an empty state
Ensure both buttons are visible and not overlapping
Change the screen size to a phone and ensure that the two buttons stack

**How do I run relevant unit or e2e tests?**

run `yarn cy:run -s "cypress/e2e/domains/smoke-create-domain.spec.ts"`