### PR TITLE
Update SMTP notice magic date to match pushed release

### DIFF
--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -334,3 +334,8 @@ export const HIGH_AVAILABILITY_PRICE =
     : Number(process.env.REACT_APP_LKE_HIGH_AVAILABILITY_PRICE);
 
 export const DB_ROOT_USERNAME = 'linroot';
+
+// "In an effort to fight spam, Linode restricts outbound connections on ports 25, 465, and 587 on all Linodes for new accounts created after November 5th, 2019."
+// https://www.linode.com/docs/email/best-practices/running-a-mail-server/
+export const MAGIC_DATE_THAT_EMAIL_RESTRICTIONS_WERE_IMPLEMENTED =
+  '2022-11-30T00:00:00.000Z'; // Date of release for Manager v1.81.0.

--- a/packages/manager/src/features/linodes/SMTPRestrictionText.test.tsx
+++ b/packages/manager/src/features/linodes/SMTPRestrictionText.test.tsx
@@ -7,7 +7,7 @@ import { renderWithTheme } from 'src/utilities/testHelpers';
 const defaultChildren = (props: { text: React.ReactNode }) => (
   <span>{props.text}</span>
 );
-const MAGIC_IMPLEMENTATION_DATE = '2022-11-29 00:00:00Z';
+const MAGIC_IMPLEMENTATION_DATE = '2022-11-30 00:00:00Z';
 
 let mockActiveSince = MAGIC_IMPLEMENTATION_DATE;
 
@@ -34,11 +34,11 @@ describe('accountCreatedAfterRestrictions', () => {
 
   it('only returns true when the account was created after the magic date', () => {
     expect(accountCreatedAfterRestrictions('2022-11-27 00:00:00Z')).toBe(false);
-    expect(accountCreatedAfterRestrictions('2022-11-28 23:59:59Z')).toBe(false);
+    expect(accountCreatedAfterRestrictions('2022-11-29 23:59:59Z')).toBe(false);
     expect(accountCreatedAfterRestrictions(MAGIC_IMPLEMENTATION_DATE)).toBe(
       true
     );
-    expect(accountCreatedAfterRestrictions('2022-11-29 00:00:01Z')).toBe(true);
+    expect(accountCreatedAfterRestrictions('2022-11-30 00:00:01Z')).toBe(true);
   });
 });
 

--- a/packages/manager/src/features/linodes/SMTPRestrictionText.test.tsx
+++ b/packages/manager/src/features/linodes/SMTPRestrictionText.test.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
 import { accountCreatedAfterRestrictions } from './SMTPRestrictionText';
 import SMTPRestrictionText, { Props } from './SMTPRestrictionText';
+import { MAGIC_DATE_THAT_EMAIL_RESTRICTIONS_WERE_IMPLEMENTED } from 'src/constants';
 import { accountFactory } from 'src/factories/account';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 
 const defaultChildren = (props: { text: React.ReactNode }) => (
   <span>{props.text}</span>
 );
-const MAGIC_IMPLEMENTATION_DATE = '2022-11-30 00:00:00Z';
 
-let mockActiveSince = MAGIC_IMPLEMENTATION_DATE;
+let mockActiveSince = MAGIC_DATE_THAT_EMAIL_RESTRICTIONS_WERE_IMPLEMENTED;
 
 jest.mock('../../queries/account', () => {
   return {
@@ -35,16 +35,18 @@ describe('accountCreatedAfterRestrictions', () => {
   it('only returns true when the account was created after the magic date', () => {
     expect(accountCreatedAfterRestrictions('2022-11-27 00:00:00Z')).toBe(false);
     expect(accountCreatedAfterRestrictions('2022-11-29 23:59:59Z')).toBe(false);
-    expect(accountCreatedAfterRestrictions(MAGIC_IMPLEMENTATION_DATE)).toBe(
-      true
-    );
+    expect(
+      accountCreatedAfterRestrictions(
+        MAGIC_DATE_THAT_EMAIL_RESTRICTIONS_WERE_IMPLEMENTED
+      )
+    ).toBe(true);
     expect(accountCreatedAfterRestrictions('2022-11-30 00:00:01Z')).toBe(true);
   });
 });
 
 describe('SMTPRestrictionText component', () => {
   it('should render when user account is created on or after the magic date', () => {
-    mockActiveSince = MAGIC_IMPLEMENTATION_DATE;
+    mockActiveSince = MAGIC_DATE_THAT_EMAIL_RESTRICTIONS_WERE_IMPLEMENTED;
 
     const { getByText } = renderWithTheme(
       <SMTPRestrictionText supportLink {...props} />
@@ -72,7 +74,7 @@ describe('SMTPRestrictionText component', () => {
   });
 
   it('should default to not including a link to open a support ticket', () => {
-    mockActiveSince = MAGIC_IMPLEMENTATION_DATE;
+    mockActiveSince = MAGIC_DATE_THAT_EMAIL_RESTRICTIONS_WERE_IMPLEMENTED;
 
     const { getByText } = renderWithTheme(<SMTPRestrictionText {...props} />);
 
@@ -82,7 +84,7 @@ describe('SMTPRestrictionText component', () => {
   });
 
   it('should include a link to open a support ticket when the prop is provided', () => {
-    mockActiveSince = MAGIC_IMPLEMENTATION_DATE;
+    mockActiveSince = MAGIC_DATE_THAT_EMAIL_RESTRICTIONS_WERE_IMPLEMENTED;
 
     const { getByText } = renderWithTheme(
       <SMTPRestrictionText supportLink {...props} />

--- a/packages/manager/src/features/linodes/SMTPRestrictionText.tsx
+++ b/packages/manager/src/features/linodes/SMTPRestrictionText.tsx
@@ -2,14 +2,9 @@ import * as React from 'react';
 import Typography from 'src/components/core/Typography';
 import ExternalLink from 'src/components/ExternalLink';
 import SupportLink from 'src/components/SupportLink';
+import { MAGIC_DATE_THAT_EMAIL_RESTRICTIONS_WERE_IMPLEMENTED } from 'src/constants';
 import { useAccount } from 'src/queries/account';
 import { sendLinodeCreateDocsEvent } from 'src/utilities/ga';
-
-// "In an effort to fight spam, Linode restricts outbound connections on ports 25, 465, and 587 on all Linodes for new accounts created after November 5th, 2019."
-// https://www.linode.com/docs/email/best-practices/running-a-mail-server/
-const MAGIC_DATE_THAT_EMAIL_RESTRICTIONS_WERE_IMPLEMENTED =
-  '2022-11-30T00:00:00.000Z'; // Date of release for Manager v1.81.0.
-
 export interface Props {
   children: (props: { text: React.ReactNode }) => React.ReactNode;
   supportLink?: boolean;

--- a/packages/manager/src/features/linodes/SMTPRestrictionText.tsx
+++ b/packages/manager/src/features/linodes/SMTPRestrictionText.tsx
@@ -8,7 +8,7 @@ import { sendLinodeCreateDocsEvent } from 'src/utilities/ga';
 // "In an effort to fight spam, Linode restricts outbound connections on ports 25, 465, and 587 on all Linodes for new accounts created after November 5th, 2019."
 // https://www.linode.com/docs/email/best-practices/running-a-mail-server/
 const MAGIC_DATE_THAT_EMAIL_RESTRICTIONS_WERE_IMPLEMENTED =
-  '2022-11-29T00:00:00.000Z'; // Date of release for Manager v1.81.0.
+  '2022-11-30T00:00:00.000Z'; // Date of release for Manager v1.81.0.
 
 export interface Props {
   children: (props: { text: React.ReactNode }) => React.ReactNode;

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -695,7 +695,7 @@ export const handlers = [
   rest.get('*/account', (req, res, ctx) => {
     const account = accountFactory.build({
       balance: 50,
-      active_since: '2022-11-28',
+      active_since: '2022-11-30',
       active_promotions: promoFactory.buildList(2),
     });
     return res(ctx.json(account));


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
Updates the magic date of SMTP restriction notices to reflect a pushed release date. 

## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**
Toggle the MSW on (mocks have been updated with an `active_since` date of 11/30/22) and verify that the SMTP notice is visible on the bottom of the Linode Create and above the Network tab of the Linode Details page. Accounts created before this date should not show the notices. (More detailed steps are in #8621.)

**How do I run relevant unit or e2e tests?**
`yarn dev` and then `yarn test SMTPRestrictionText` and confirm 6/6 tests pass.