### PR TITLE
M3-5511: Improve Linode Migration Time Estimates

### DIFF
--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -278,12 +278,12 @@ export const allowedHTMLAttr = ['href', 'lang', 'title', 'align'];
 /**
  * MBps rate for intra DC migrations (AKA Mutations)
  */
-export const MBpsIntraDC = 75;
+export const MBpsIntraDC = 200;
 
 /**
  * MBps rate for inter DC migrations (AKA Cross-Datacenter migrations )
  */
-export const MBpsInterDC = 1.5;
+export const MBpsInterDC = 7.5;
 
 /**
  * The incoming network rate (in Gbps) that is standard for all Linodes


### PR DESCRIPTION
## Description 📝

- Updates the rates that Linodes are migrated at so that our Linode Migration estimates are more accurate

## Preview 📷

### Before
![Screen Shot 2022-12-06 at 11 51 32 AM](https://user-images.githubusercontent.com/115251059/205975978-c65a40ea-13b4-4800-8fbb-e31b6a546d63.jpg)

### After
![Screen Shot 2022-12-06 at 11 51 08 AM](https://user-images.githubusercontent.com/115251059/205975920-f522ff1b-7786-40a0-982e-85736ad20aa8.jpg)

## How to test 🧪

- Verify that the estimates in this PR are lower than estimates in production for the same Linode
  - There is no promise that this estimate is correct, but now it should be closer to the actual time it takes to migrate a Linode
