### PR TITLE
M3-5753: Filter deprecated images

### DIFF
--- a/packages/api-v4/src/images/types.ts
+++ b/packages/api-v4/src/images/types.ts
@@ -5,6 +5,7 @@ export type ImageStatus =
   | 'pending_upload';
 
 export interface Image {
+  eol: string | null;
   id: string;
   label: string;
   description: string | null;

--- a/packages/manager/src/components/ImageSelect/ImageSelect.test.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.test.tsx
@@ -67,13 +67,13 @@ describe('imagesToGroupedItems', () => {
         options: [
           {
             created: '2017-06-16T20:02:29',
-            label: 'Debian 9 (Deprecated)',
+            label: 'Debian 9 (deprecated)',
             value: 'private/6',
             className: 'fl-tux',
           },
           {
             created: '2017-06-16T20:02:29',
-            label: 'Debian 9 (Deprecated)',
+            label: 'Debian 9 (deprecated)',
             value: 'private/7',
             className: 'fl-tux',
           },

--- a/packages/manager/src/components/ImageSelect/ImageSelect.test.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.test.tsx
@@ -11,6 +11,12 @@ describe('imagesToGroupedItems', () => {
         eol: '2022-01-01T14:05:30',
       }),
       ...imageFactory.buildList(2, {
+        label: 'Debian 10',
+        deprecated: false,
+        created: '2017-06-16T20:02:29',
+        eol: '1970-01-01T14:05:30',
+      }),
+      ...imageFactory.buildList(2, {
         label: 'Slackware 14.1',
         deprecated: true,
         created: '2022-10-20T14:05:30',
@@ -23,14 +29,14 @@ describe('imagesToGroupedItems', () => {
         options: [
           {
             created: '2022-10-20T14:05:30',
-            label: 'Slackware 14.1 (Deprecated)',
-            value: 'private/2',
+            label: 'Slackware 14.1',
+            value: 'private/4',
             className: 'fl-tux',
           },
           {
             created: '2022-10-20T14:05:30',
-            label: 'Slackware 14.1 (Deprecated)',
-            value: 'private/3',
+            label: 'Slackware 14.1',
+            value: 'private/5',
             className: 'fl-tux',
           },
         ],

--- a/packages/manager/src/components/ImageSelect/ImageSelect.test.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.test.tsx
@@ -1,0 +1,41 @@
+import { imagesToGroupedItems } from './ImageSelect';
+import { imageFactory } from 'src/factories';
+
+describe('imagesToGroupedItems', () => {
+  it('should filter deprecated images when eol date is beyond 6 months ', () => {
+    const images = [
+      ...imageFactory.buildList(2, {
+        label: 'Debian 9',
+        deprecated: true,
+        created: '2017-06-16T20:02:29',
+        eol: '2022-01-01T14:05:30',
+      }),
+      ...imageFactory.buildList(2, {
+        label: 'Slackware 14.1',
+        deprecated: true,
+        created: '2022-10-20T14:05:30',
+        eol: null,
+      }),
+    ];
+    const expected = [
+      {
+        label: 'My Images',
+        options: [
+          {
+            created: '2022-10-20T14:05:30',
+            label: 'Slackware 14.1 (Deprecated)',
+            value: 'private/2',
+            className: 'fl-tux',
+          },
+          {
+            created: '2022-10-20T14:05:30',
+            label: 'Slackware 14.1 (Deprecated)',
+            value: 'private/3',
+            className: 'fl-tux',
+          },
+        ],
+      },
+    ];
+    expect(imagesToGroupedItems(images)).toStrictEqual(expected);
+  });
+});

--- a/packages/manager/src/components/ImageSelect/ImageSelect.test.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.test.tsx
@@ -1,8 +1,10 @@
-import { imagesToGroupedItems } from './ImageSelect';
+import { DateTime } from 'luxon';
 import { imageFactory } from 'src/factories';
 
+import { imagesToGroupedItems } from './ImageSelect';
+
 describe('imagesToGroupedItems', () => {
-  it('should filter deprecated images when eol date is beyond 6 months ', () => {
+  it('should filter deprecated images when end of life is past beyond 6 months ', () => {
     const images = [
       ...imageFactory.buildList(2, {
         label: 'Debian 9',
@@ -37,6 +39,42 @@ describe('imagesToGroupedItems', () => {
             created: '2022-10-20T14:05:30',
             label: 'Slackware 14.1',
             value: 'private/5',
+            className: 'fl-tux',
+          },
+        ],
+      },
+    ];
+    expect(imagesToGroupedItems(images)).toStrictEqual(expected);
+  });
+  it('should add suffix `deprecated` to images at end of life ', () => {
+    const images = [
+      ...imageFactory.buildList(2, {
+        label: 'Debian 9',
+        deprecated: true,
+        created: '2017-06-16T20:02:29',
+        eol: DateTime.now().toISODate(),
+      }),
+      ...imageFactory.buildList(2, {
+        label: 'Debian 10',
+        deprecated: false,
+        created: '2017-06-16T20:02:29',
+        eol: '1970-01-01T14:05:30',
+      }),
+    ];
+    const expected = [
+      {
+        label: 'My Images',
+        options: [
+          {
+            created: '2017-06-16T20:02:29',
+            label: 'Debian 9 (Deprecated)',
+            value: 'private/6',
+            className: 'fl-tux',
+          },
+          {
+            created: '2017-06-16T20:02:29',
+            label: 'Debian 9 (Deprecated)',
+            value: 'private/7',
             className: 'fl-tux',
           },
         ],

--- a/packages/manager/src/components/ImageSelect/ImageSelect.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.tsx
@@ -1,5 +1,6 @@
 import { Image } from '@linode/api-v4/lib/images';
 import produce from 'immer';
+import { DateTime } from 'luxon';
 import { equals, groupBy } from 'ramda';
 import * as React from 'react';
 import Paper from 'src/components/core/Paper';
@@ -16,6 +17,7 @@ import getSelectedOptionFromGroupedOptions from 'src/utilities/getSelectedOption
 import { distroIcons } from './icons';
 import ImageOption from './ImageOption';
 
+const maxEOLFilter = 6;
 export type Variant = 'public' | 'private' | 'all';
 
 interface ImageItem extends Item<string> {
@@ -85,6 +87,18 @@ export const imagesToGroupedItems = (images: Image[]) => {
         draft.push({
           label: thisGroup,
           options: group
+            .filter((thisImage) => {
+              const { deprecated, eol } = thisImage;
+              if (deprecated) {
+                const diff = DateTime.now().diff(
+                  DateTime.fromISO(eol),
+                  'months'
+                ).months;
+                return Number.isNaN(diff) || diff <= maxEOLFilter;
+              } else {
+                return true;
+              }
+            })
             .map((thisImage) => {
               const isDeprecated = thisImage.deprecated;
               const fullLabel =

--- a/packages/manager/src/components/ImageSelect/ImageSelect.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.tsx
@@ -88,21 +88,19 @@ export const imagesToGroupedItems = (images: Image[]) => {
           label: thisGroup,
           options: group
             .filter((thisImage) => {
-              const { deprecated, eol } = thisImage;
-              if (deprecated) {
-                const diff = DateTime.now().diff(
-                  DateTime.fromISO(eol!),
-                  'months'
-                ).months;
-                return Number.isNaN(diff) || diff <= maxEOLFilter;
-              } else {
-                return true;
-              }
+              const { eol } = thisImage;
+              const diff = DateTime.now().diff(DateTime.fromISO(eol!), 'months')
+                .months;
+              return diff > maxEOLFilter && eol !== null ? false : true;
             })
             .map((thisImage) => {
-              const isDeprecated = thisImage.deprecated;
-              const fullLabel =
-                thisImage.label + (isDeprecated ? ' (Deprecated)' : '');
+              const { eol } = thisImage;
+              const diff = DateTime.fromISO(eol!).diff(DateTime.now(), 'months')
+                .months;
+              let fullLabel = thisImage.label;
+              if (diff <= maxEOLFilter) {
+                fullLabel += ' (Deprecated)';
+              }
               return {
                 created: thisImage.created,
                 label: fullLabel,

--- a/packages/manager/src/components/ImageSelect/ImageSelect.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.tsx
@@ -97,10 +97,11 @@ export const imagesToGroupedItems = (images: Image[]) => {
             })
             .map((thisImage) => {
               const { eol } = thisImage;
-              const diff = DateTime.fromISO(eol!).diff(DateTime.now(), 'months')
+              const diff = DateTime.now().diff(DateTime.fromISO(eol!), 'months')
                 .months;
               let fullLabel = thisImage.label;
-              if (diff <= MAX_MONTHS_EOL_FILTER) {
+              // Add suffix 'depricated' to the image if end of life is past
+              if (diff > 0) {
                 fullLabel += ' (Deprecated)';
               }
               return {

--- a/packages/manager/src/components/ImageSelect/ImageSelect.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.tsx
@@ -91,7 +91,7 @@ export const imagesToGroupedItems = (images: Image[]) => {
               const { deprecated, eol } = thisImage;
               if (deprecated) {
                 const diff = DateTime.now().diff(
-                  DateTime.fromISO(eol),
+                  DateTime.fromISO(eol!),
                   'months'
                 ).months;
                 return Number.isNaN(diff) || diff <= maxEOLFilter;

--- a/packages/manager/src/components/ImageSelect/ImageSelect.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.tsx
@@ -99,7 +99,7 @@ export const imagesToGroupedItems = (images: Image[]) => {
                   created,
                   // Add suffix 'depricated' to the image at end of life.
                   label:
-                    differenceInMonths > 0 ? `${label} (Deprecated)` : label,
+                    differenceInMonths > 0 ? `${label} (deprecated)` : label,
                   value: id,
                   className: vendor
                     ? // Use Tux as a fallback.

--- a/packages/manager/src/components/ImageSelect/ImageSelect.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.tsx
@@ -3,6 +3,7 @@ import produce from 'immer';
 import { DateTime } from 'luxon';
 import { equals, groupBy } from 'ramda';
 import * as React from 'react';
+import { MAX_MONTHS_EOL_FILTER } from 'src/constants';
 import Paper from 'src/components/core/Paper';
 import Typography from 'src/components/core/Typography';
 import Select, { GroupType, Item } from 'src/components/EnhancedSelect';
@@ -17,7 +18,6 @@ import getSelectedOptionFromGroupedOptions from 'src/utilities/getSelectedOption
 import { distroIcons } from './icons';
 import ImageOption from './ImageOption';
 
-const maxEOLFilter = 6;
 export type Variant = 'public' | 'private' | 'all';
 
 interface ImageItem extends Item<string> {
@@ -91,14 +91,16 @@ export const imagesToGroupedItems = (images: Image[]) => {
               const { eol } = thisImage;
               const diff = DateTime.now().diff(DateTime.fromISO(eol!), 'months')
                 .months;
-              return diff > maxEOLFilter && eol !== null ? false : true;
+              return diff > MAX_MONTHS_EOL_FILTER && eol !== null
+                ? false
+                : true;
             })
             .map((thisImage) => {
               const { eol } = thisImage;
               const diff = DateTime.fromISO(eol!).diff(DateTime.now(), 'months')
                 .months;
               let fullLabel = thisImage.label;
-              if (diff <= maxEOLFilter) {
+              if (diff <= MAX_MONTHS_EOL_FILTER) {
                 fullLabel += ' (Deprecated)';
               }
               return {

--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -89,6 +89,13 @@ export const ISO_DATETIME_NO_TZ_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
 export const MAX_VOLUME_SIZE = 10240;
 
 /**
+ * As per the current support polocy
+ * timeline for depricated distro is 6 months beyond eol date from image endpoints.
+ * refere M3-5753 for more info.
+ */
+export const MAX_MONTHS_EOL_FILTER = 6;
+
+/**
  * The lowest interval at which to make an Events request. This is later multiplied by the pollIteration
  * to get the actual interval.
  */

--- a/packages/manager/src/factories/images.ts
+++ b/packages/manager/src/factories/images.ts
@@ -2,6 +2,7 @@ import * as Factory from 'factory.ts';
 import { Image } from '@linode/api-v4/lib/images/types';
 
 export const imageFactory = Factory.Sync.makeFactory<Image>({
+  eol: new Date().toISOString(),
   id: Factory.each((id) => `private/${id}`),
   label: Factory.each((i) => `image-${i}`),
   description: 'An image',


### PR DESCRIPTION
## Description 📝

Goal is to replace manual process of setting flags in DB to get suffix ( "deprecated") added to distro's  in the manager.
- Automatically filters deprecated images 
- Automatically Adds suffix "deprecated"

## Preview 📷

**Before:** 
![image](https://user-images.githubusercontent.com/119517080/205987724-294271b6-854a-4f63-b093-0f2e23300a03.png)

**After:**
![image](https://user-images.githubusercontent.com/119517080/205987855-031a26d2-0e06-4777-bec3-090af6ae3b7f.png)



## How to test 🧪

- Navigate to route /linodes
- Click on create linode
- Validate Images in "Choose a Distribution"

**How do I run relevant unit or e2e tests?**
`yarn test components/ImageSelect/ImageSelect`
