### PR TITLE
M3-5855: Fix delayed loading of /56 ranges in Linode Network tab

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.test.ts
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.test.ts
@@ -7,7 +7,6 @@ import {
   uniqByIP,
 } from './LinodeNetworking';
 import { LinodeIPsResponse } from '@linode/api-v4/lib/linodes';
-import { IPRange } from '@linode/api-v4/lib/networking';
 
 const {
   private: _privateIPs,
@@ -72,28 +71,22 @@ describe('ipResponseToDisplayRows utility function', () => {
       link_local: ipAddressFactory.build({ type: 'ipv6' }),
       global: [
         {
-          range: '0:0:0:0:0::',
+          range: '2600:3c00:e000:0000::',
+          region: 'us-west',
+          route_target: '2a01:7e00::f03c:93ff:fe6e:1233',
           prefix: 64,
-          region: 'us-east',
-          route_target: '0:0:0:0:0:0',
         },
       ],
     },
   };
-  const staticRanges: IPRange = {
-    range: '2600:3c00:e000:0000::',
-    region: 'us-west',
-    route_target: '2a01:7e00::f03c:93ff:fe6e:1233',
-    prefix: 64,
-  };
 
   it('returns a display row for each IP/range', () => {
-    const result = ipResponseToDisplayRows([staticRanges], response);
+    const result = ipResponseToDisplayRows(response);
     expect(result).toHaveLength(7);
   });
 
   it('includes the meta _ip field for IP addresses', () => {
-    const result = ipResponseToDisplayRows([staticRanges], response);
+    const result = ipResponseToDisplayRows(response);
     // Check the first six rows (the IPs)
     for (let i = 0; i < 5; i++) {
       expect(result[i]._ip).toBeDefined();
@@ -101,7 +94,7 @@ describe('ipResponseToDisplayRows utility function', () => {
   });
 
   it('includes the meta _range field for IP ranges', () => {
-    const result = ipResponseToDisplayRows([staticRanges], response);
+    const result = ipResponseToDisplayRows(response);
     // Check the last row (the IPv6 range)
     expect(result[6]._range).toBeDefined();
   });

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
@@ -259,7 +259,6 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
           }
 
           // get info on an IPv6 range; if its shared check if its shared to our Linode
-          // if its not shared (!is_bgp) figure out if its a slaac address or a statically routed range
           const resp = await getIPv6RangeInfo(range.range);
 
           if (
@@ -914,7 +913,7 @@ export const ipResponseToDisplayRows = (
     ipDisplay.push(ipToDisplay(ipv6?.link_local, 'Link Local'));
   }
 
-  // IPv6 ranges and pools (/116s) to display in the networking table
+  // IPv6 ranges and pools to display in the networking table
   ipDisplay.push(
     ...[...(ipv6 ? ipv6.global : [])].map((thisIP) => {
       /* If you want to surface rdns info in the future you have two options:


### PR DESCRIPTION
## Description 📝
- Reduce unnecessary requests to a linode instance's `/ips` endpoint
- Fix delayed loading of /56 & /64 IPv6 ranges
    - This was due to a change made in `LinodeNetworking.tsx` (https://github.com/linode/manager/pull/8082)
    - IPv6 ranges were only displayed after we got IPv6 range info for _all_ IPv6 ranges on the account. And getting one IPv6 range info is one request. So, the more IPv6 ranges an account has, the more requests we need to make and the longer it takes for the last request to finish
    - For just viewing the Linode's IPv6 addresses, we didn't need to wait for all the requests to be finished first. The info we needed to display the IP addresses were already available in the Linode instance's `/ips` response


## Preview 📷
(Linode was deleted after this)
Local

https://user-images.githubusercontent.com/115299789/205991561-4032245d-4b33-48f0-8d54-8d94ac072e2a.mov

Prod

https://user-images.githubusercontent.com/115299789/205991622-977dc97d-5d7d-46ac-958c-4cfcffcf2848.mov


## How to test 🧪
1. Go to the Network tab of a Linode with a /56 range (reach out for info on how to get one)
2. In your browser's dev tools, throttle your network connection to `Slow 3G`
3. Reload the page and observe how the /56 ranges display immediately locally compared to prod
4. Ensure that IPv6 IP sharing still works the same as prod (only certain Data Centers are supported and both Linodes must be in the same DC; use Linodes with the `Frankfurt, DE` region)

**How do I run relevant unit or e2e tests?**
```
yarn test LinodeNetworking
```