### PR TITLE
M3-5925, M3-5926: StackScript User-Defined Fields and Any/All Images E2E

### DIFF
--- a/packages/manager/cypress/e2e/stackscripts/create-stackscripts.spec.ts
+++ b/packages/manager/cypress/e2e/stackscripts/create-stackscripts.spec.ts
@@ -253,11 +253,9 @@ describe('stackscripts', () => {
 
     cy.wait('@createLinode');
 
-    // Wait for Linode boot.
+    // Confirm that Linode has been created and is provisioning.
     cy.findByText(linodeLabel).should('be.visible');
     cy.findByText('PROVISIONING').should('be.visible');
-    cy.findByText('BOOTING').should('be.visible');
-    cy.findByText('RUNNING').should('be.visible');
   });
 
   /*
@@ -361,8 +359,6 @@ describe('stackscripts', () => {
 
       cy.wait('@createLinode');
       cy.findByText(linodeLabel).should('be.visible');
-      // Don't wait for the Linode to boot, because creating a Linode using an
-      // image takes a long time.
       cy.findByText('PROVISIONING').should('be.visible');
     });
   });

--- a/packages/manager/cypress/e2e/stackscripts/create-stackscripts.spec.ts
+++ b/packages/manager/cypress/e2e/stackscripts/create-stackscripts.spec.ts
@@ -5,6 +5,11 @@ import {
   randomPhrase,
   randomItem,
 } from 'support/util/random';
+import {
+  interceptCreateStackScript,
+  interceptGetStackScripts,
+} from 'support/intercepts/stackscripts';
+import { interceptCreateLinode } from 'support/intercepts/linodes';
 import { ui } from 'support/ui';
 
 /*
@@ -114,9 +119,7 @@ const fillOutLinodeForm = (label: string, region: string) => {
     .type(label);
 
   cy.findByText('Dedicated CPU').should('be.visible').click();
-
   cy.get('[id="g6-dedicated-2"]').click();
-
   cy.findByLabelText('Root Password').should('be.visible').type(password);
 };
 
@@ -138,6 +141,10 @@ describe('stackscripts', () => {
     const linodeLabel = randomLabel();
     const linodeRegion = randomItem(regionsFriendly);
 
+    interceptCreateStackScript().as('createStackScript');
+    interceptGetStackScripts().as('getStackScripts');
+    interceptCreateLinode().as('createLinode');
+
     cy.visitWithLogin('/stackscripts/create');
 
     // Submit StackScript creation form with invalid contents, confirm error messages.
@@ -154,6 +161,7 @@ describe('stackscripts', () => {
       .should('be.enabled')
       .click();
 
+    cy.wait('@createStackScript');
     cy.findByText(stackScriptErrorNoShebang).should('be.visible');
 
     cy.get('[data-qa-textfield-label="Script"]')
@@ -168,6 +176,7 @@ describe('stackscripts', () => {
       .should('be.enabled')
       .click();
 
+    cy.wait('@createStackScript');
     cy.findByText(stackScriptErrorUdfAlphanumeric).should('be.visible');
 
     // Insert a script with valid UDF data and submit StackScript create form.
@@ -184,7 +193,9 @@ describe('stackscripts', () => {
       .click();
 
     // Confirm the user is redirected to landing page and StackScript is shown.
+    cy.wait('@createStackScript');
     cy.url().should('endWith', '/stackscripts/account');
+    cy.wait('@getStackScripts');
 
     cy.findByText(stackscriptLabel)
       .should('be.visible')
@@ -223,6 +234,7 @@ describe('stackscripts', () => {
       .should('be.enabled')
       .click();
 
+    cy.wait('@createLinode');
     cy.findByText(linodeLabel).should('be.visible');
     cy.findByText('PROVISIONING').should('be.visible');
     cy.findByText('BOOTING').should('be.visible');

--- a/packages/manager/cypress/e2e/stackscripts/create-stackscripts.spec.ts
+++ b/packages/manager/cypress/e2e/stackscripts/create-stackscripts.spec.ts
@@ -119,8 +119,7 @@ const createLinodeAndImage = async () => {
   );
 
   await pollLinodeStatus(linode.id, 'running', {
-    maxAttempts: 1,
-    initialDelay: 1,
+    initialDelay: 15000,
   });
 
   const diskId = (await getLinodeDisks(linode.id)).data[0].id;
@@ -144,7 +143,7 @@ describe('stackscripts', () => {
    * - Confirms that user-defined fields are displayed as expected during Linode creation.
    * - Confirms that Linode created using StackScript boots.
    */
-  it.skip('creates a StackScript and deploys a Linode with it', () => {
+  it('creates a StackScript and deploys a Linode with it', () => {
     const stackscriptLabel = randomLabel();
     const stackscriptDesc = randomPhrase();
     const stackscriptImage = 'Alpine 3.17';

--- a/packages/manager/cypress/e2e/stackscripts/create-stackscripts.spec.ts
+++ b/packages/manager/cypress/e2e/stackscripts/create-stackscripts.spec.ts
@@ -12,44 +12,15 @@ import {
 } from 'support/intercepts/stackscripts';
 import { interceptCreateLinode } from 'support/intercepts/linodes';
 import { ui } from 'support/ui';
-
 import { createLinodeRequestFactory } from 'src/factories';
-
 import { createLinode, getLinodeDisks } from '@linode/api-v4/lib/linodes';
 import { createImage } from '@linode/api-v4/lib/images';
 
-/*
- * Basic StackScript contents.
- */
-const stackScriptSimple = `#!/bin/bash
-echo "Hello, world!"
-`;
-
-/*
- * StackScript contents that are missing a shebang.
- */
-const stackScriptWithNoShebang = 'echo "Hello, world!';
-
-/*
- * StackScript contents which includes an invalid user-defined-field.
- */
-const stackScriptWithInvalidUdf = `#!/bin/bash
-
-# <UDF name="invalid-field-name" label="This is invalid" default="" example="" />
-
-echo "Hello, world!"
-`;
-
-/*
- * StackScript contents which includes several user-defined-fields.
- */
-const stackScriptWithUdf = `#!/bin/bash
-
-# <UDF name="example_password" label="Example Password" default="" example="" />
-# <UDF name="example_title" label="Example Title" default="Hello, world!" example="Give it a title!" />
-
-echo "Hello, world!"
-`;
+// StackScript fixture paths.
+const stackscriptBasicPath = 'stackscripts/stackscript-basic.sh';
+const stackscriptNoShebangPath = 'stackscripts/stackscript-no-shebang.sh';
+const stackscriptUdfPath = 'stackscripts/stackscript-udf.sh';
+const stackscriptUdfInvalidPath = 'stackscripts/stackscript-udf-invalid.sh';
 
 // StackScript error that is expected to appear when script is missing a shebang.
 const stackScriptErrorNoShebang =
@@ -170,12 +141,14 @@ describe('stackscripts', () => {
     cy.visitWithLogin('/stackscripts/create');
 
     // Submit StackScript creation form with invalid contents, confirm error messages.
-    fillOutStackscriptForm(
-      stackscriptLabel,
-      stackscriptDesc,
-      stackscriptImage,
-      stackScriptWithNoShebang
-    );
+    cy.fixture(stackscriptNoShebangPath).then((stackscriptWithNoShebang) => {
+      fillOutStackscriptForm(
+        stackscriptLabel,
+        stackscriptDesc,
+        stackscriptImage,
+        stackscriptWithNoShebang
+      );
+    });
 
     ui.buttonGroup
       .findButtonByTitle('Create StackScript')
@@ -186,11 +159,13 @@ describe('stackscripts', () => {
     cy.wait('@createStackScript');
     cy.findByText(stackScriptErrorNoShebang).should('be.visible');
 
-    cy.get('[data-qa-textfield-label="Script"]')
-      .should('be.visible')
-      .click()
-      .type('{selectall}{backspace}')
-      .type(stackScriptWithInvalidUdf);
+    cy.fixture(stackscriptUdfInvalidPath).then((stackScriptUdfInvalid) => {
+      cy.get('[data-qa-textfield-label="Script"]')
+        .should('be.visible')
+        .click()
+        .type('{selectall}{backspace}')
+        .type(stackScriptUdfInvalid);
+    });
 
     ui.buttonGroup
       .findButtonByTitle('Create StackScript')
@@ -202,11 +177,13 @@ describe('stackscripts', () => {
     cy.findByText(stackScriptErrorUdfAlphanumeric).should('be.visible');
 
     // Insert a script with valid UDF data and submit StackScript create form.
-    cy.get('[data-qa-textfield-label="Script"]')
-      .should('be.visible')
-      .click()
-      .type('{selectall}{backspace}')
-      .type(stackScriptWithUdf);
+    cy.fixture(stackscriptUdfPath).then((stackScriptUdf) => {
+      cy.get('[data-qa-textfield-label="Script"]')
+        .should('be.visible')
+        .click()
+        .type('{selectall}{backspace}')
+        .type(stackScriptUdf);
+    });
 
     ui.buttonGroup
       .findButtonByTitle('Create StackScript')

--- a/packages/manager/cypress/e2e/stackscripts/create-stackscripts.spec.ts
+++ b/packages/manager/cypress/e2e/stackscripts/create-stackscripts.spec.ts
@@ -233,7 +233,7 @@ describe('stackscripts', () => {
    * - Creates a StackScript with "Any/All" image.
    * - Confirms that any image can be selected when deploying with "Any/All" StackScript.
    */
-  it('creates a stackscript with Any/All target image', () => {
+  it('creates a StackScript with Any/All target image', () => {
     const stackscriptLabel = randomLabel();
     const stackscriptDesc = randomPhrase();
     const stackscriptImage = 'Any/All';

--- a/packages/manager/cypress/e2e/stackscripts/stackscripts.spec.ts
+++ b/packages/manager/cypress/e2e/stackscripts/stackscripts.spec.ts
@@ -19,6 +19,11 @@ const createLinode = () => {
 };
 
 /*
+ * StackScript contents that are missing a shebang.
+ */
+const stackScriptWithNoShebang = 'echo "Hello, world!';
+
+/*
  * StackScript contents which includes an invalid user-defined-field.
  */
 const stackScriptWithInvalidUdf = `#!/bin/bash
@@ -38,6 +43,10 @@ const stackScriptWithUdf = `#!/bin/bash
 
 echo "Hello, world!"
 `;
+
+// StackScript error that is expected to appear when script is missing a shebang.
+const stackScriptErrorNoShebang =
+  "Script must begin with a shebang (example: '#!/bin/bash').";
 
 // StackScript error that is expected to appear when UDFs with non-alphanumeric names are supplied.
 const stackScriptErrorUdfAlphanumeric =
@@ -118,6 +127,7 @@ const fillOutLinodeForm = (label: string, region: string) => {
 describe('stackscripts', () => {
   /*
    * - Creates a StackScript with user-defined fields.
+   * - Confirms that an error message appears upon submitting script without a shebang.
    * - Confirms that an error message appears upon submitting invalid user-defined fields.
    * - Deploys a new Linode using the StackScript.
    * - Confirms that user-defined fields are displayed as expected during Linode creation.
@@ -134,13 +144,27 @@ describe('stackscripts', () => {
 
     cy.visitWithLogin('/stackscripts/create');
 
-    // Submit StackScript creation form with invalid UDF, confirm error message appears.
+    // Submit StackScript creation form with invalid contents, confirm error messages.
     fillOutStackscriptForm(
       stackscriptLabel,
       stackscriptDesc,
       stackscriptImage,
-      stackScriptWithInvalidUdf
+      stackScriptWithNoShebang
     );
+
+    ui.buttonGroup
+      .findButtonByTitle('Create StackScript')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    cy.findByText(stackScriptErrorNoShebang).should('be.visible');
+
+    cy.get('[data-qa-textfield-label="Script"]')
+      .should('be.visible')
+      .click()
+      .type('{selectall}{backspace}')
+      .type(stackScriptWithInvalidUdf);
 
     ui.buttonGroup
       .findButtonByTitle('Create StackScript')

--- a/packages/manager/cypress/e2e/stackscripts/stackscripts.spec.ts
+++ b/packages/manager/cypress/e2e/stackscripts/stackscripts.spec.ts
@@ -1,5 +1,12 @@
 import { fbtClick, fbtVisible, getClick, getVisible } from 'support/helpers';
-import { randomLabel, randomString } from 'support/util/random';
+import { regionsFriendly } from 'support/constants/regions';
+import {
+  randomLabel,
+  randomString,
+  randomPhrase,
+  randomItem,
+} from 'support/util/random';
+import { ui } from 'support/ui';
 
 const createLinode = () => {
   const password = randomString(32);
@@ -11,8 +18,200 @@ const createLinode = () => {
   getClick('[data-qa-deploy-linode]');
 };
 
+/*
+ * StackScript contents which includes an invalid user-defined-field.
+ */
+const stackScriptWithInvalidUdf = `#!/bin/bash
+
+# <UDF name="invalid-field-name" label="This is invalid" default="" example="" />
+
+echo "Hello, world!"
+`;
+
+/*
+ * StackScript contents which includes several user-defined-fields.
+ */
+const stackScriptWithUdf = `#!/bin/bash
+
+# <UDF name="example_password" label="Example Password" default="" example="" />
+# <UDF name="example_title" label="Example Title" default="Hello, world!" example="Give it a title!" />
+
+echo "Hello, world!"
+`;
+
+// StackScript error that is expected to appear when UDFs with non-alphanumeric names are supplied.
+const stackScriptErrorUdfAlphanumeric =
+  'UDF names can only contain alphanumeric and underscore characters.';
+
+/**
+ * Fills out the StackScript creation form.
+ *
+ * This assumes that the user is already on the StackScript creation page. This
+ * function does not attempt to submit the filled out form.
+ *
+ * @param label - StackScript label.
+ * @param description - StackScript description. Optional.
+ * @param targetImage - StackScript target image name.
+ * @param script - StackScript contents.
+ */
+const fillOutStackscriptForm = (
+  label: string,
+  description: string | undefined,
+  targetImage: string,
+  script: string
+) => {
+  // Fill out "StackScript Label", "Description", "Target Images", and "Script" fields.
+  cy.findByLabelText('StackScript Label', { exact: false })
+    .should('be.visible')
+    .click()
+    .type(label);
+
+  if (description) {
+    cy.findByLabelText('Description')
+      .should('be.visible')
+      .click()
+      .type(description);
+  }
+
+  cy.get('[data-qa-multi-select="Select an Image"]')
+    .should('be.visible')
+    .click()
+    .type(`${targetImage}{enter}`);
+
+  // Insert a script with invalid UDF data.
+  cy.get('[data-qa-textfield-label="Script"]')
+    .should('be.visible')
+    .click()
+    .type(script);
+};
+
+/**
+ * Fills out the Linode creation form.
+ *
+ * This assumes that the user is already on the Linode creation page. This
+ * function does not attempt to submit the filled out form.
+ *
+ * @param label - Linode label.
+ * @param region - Linode region.
+ */
+const fillOutLinodeForm = (label: string, region: string) => {
+  const password = randomString(32);
+
+  cy.findByText('Select a Region')
+    .should('be.visible')
+    .click()
+    .type(`${region}{enter}`);
+
+  cy.findByText('Linode Label')
+    .should('be.visible')
+    .click()
+    .type('{selectall}{backspace}')
+    .type(label);
+
+  cy.findByText('Dedicated CPU').should('be.visible').click();
+
+  cy.get('[id="g6-dedicated-2"]').click();
+
+  cy.findByLabelText('Root Password').should('be.visible').type(password);
+};
+
 describe('stackscripts', () => {
-  it('create stackscript, use it to deploy linode', () => {
+  /*
+   * - Creates a StackScript with user-defined fields.
+   * - Confirms that an error message appears upon submitting invalid user-defined fields.
+   * - Deploys a new Linode using the StackScript.
+   * - Confirms that user-defined fields are displayed as expected during Linode creation.
+   * - Confirms that Linode created using StackScript boots.
+   */
+  it('creates a StackScript and deploys a Linode with it', () => {
+    const stackscriptLabel = randomLabel();
+    const stackscriptDesc = randomPhrase();
+    const stackscriptImage = 'Alpine 3.17';
+    const stackscriptImageTag = 'alpine3.17';
+
+    const linodeLabel = randomLabel();
+    const linodeRegion = randomItem(regionsFriendly);
+
+    cy.visitWithLogin('/stackscripts/create');
+
+    // Submit StackScript creation form with invalid UDF, confirm error message appears.
+    fillOutStackscriptForm(
+      stackscriptLabel,
+      stackscriptDesc,
+      stackscriptImage,
+      stackScriptWithInvalidUdf
+    );
+
+    ui.buttonGroup
+      .findButtonByTitle('Create StackScript')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    cy.findByText(stackScriptErrorUdfAlphanumeric).should('be.visible');
+
+    // Insert a script with valid UDF data and submit StackScript create form.
+    cy.get('[data-qa-textfield-label="Script"]')
+      .should('be.visible')
+      .click()
+      .type('{selectall}{backspace}')
+      .type(stackScriptWithUdf);
+
+    ui.buttonGroup
+      .findButtonByTitle('Create StackScript')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    // Confirm the user is redirected to landing page and StackScript is shown.
+    cy.url().should('endWith', '/stackscripts/account');
+
+    cy.findByText(stackscriptLabel)
+      .should('be.visible')
+      .closest('tr')
+      .within(() => {
+        cy.findByText(stackscriptDesc).should('be.visible');
+        cy.findByText(stackscriptImageTag).should('be.visible');
+      });
+
+    // Navigate to StackScript details page and click deploy Linode button.
+    cy.findByText(stackscriptLabel).should('be.visible').click();
+
+    ui.button
+      .findByTitle('Deploy New Linode')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    // Fill out Linode creation form, confirm UDF fields behave as expected.
+    fillOutLinodeForm(linodeLabel, linodeRegion);
+
+    cy.findByLabelText('Example Password')
+      .should('be.visible')
+      .click()
+      .type(randomString(32));
+
+    cy.findByLabelText('Example Title')
+      .should('be.visible')
+      .click()
+      .type('{selectall}{backspace}')
+      .type(randomString(12));
+
+    ui.button
+      .findByTitle('Create Linode')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    cy.findByText(linodeLabel).should('be.visible');
+    cy.findByText('PROVISIONING').should('be.visible');
+    cy.findByText('BOOTING').should('be.visible');
+    cy.findByText('RUNNING').should('be.visible');
+  });
+
+  it.skip('creates a stackscript with Any/All target image', () => {});
+
+  it.skip('create stackscript, use it to deploy linode', () => {
     const disk = 'Alpine 3.15';
     cy.intercept('POST', `*/linode/instances`).as('createLinode');
     const ssLabel = randomLabel();

--- a/packages/manager/cypress/fixtures/stackscripts/stackscript-basic.sh
+++ b/packages/manager/cypress/fixtures/stackscripts/stackscript-basic.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# This is a basic valid StackScript to test StackScript creation.
+
+echo "Hello, world!"

--- a/packages/manager/cypress/fixtures/stackscripts/stackscript-no-shebang.sh
+++ b/packages/manager/cypress/fixtures/stackscripts/stackscript-no-shebang.sh
@@ -1,0 +1,4 @@
+# This is a StackScript that does not include a shebang.
+# This is used to test StackScript validation/error messages.
+
+echo "Hello, world!"

--- a/packages/manager/cypress/fixtures/stackscripts/stackscript-udf-invalid.sh
+++ b/packages/manager/cypress/fixtures/stackscripts/stackscript-udf-invalid.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# This is a StackScript with an invalid user-defined field to test
+# StackScript validation/error messages.
+
+# <UDF name="invalid-field-name" label="This is invalid" default="" example="" />
+
+echo "Hello, world!"

--- a/packages/manager/cypress/fixtures/stackscripts/stackscript-udf.sh
+++ b/packages/manager/cypress/fixtures/stackscripts/stackscript-udf.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# This is a valid StackScript with user-defined fields to test StackScript
+# and Linode creation with user-defined fields.
+
+# <UDF name="example_password" label="Example Password" default="" example="" />
+# <UDF name="example_title" label="Example Title" default="Hello, world!" example="Give it a title!" />
+
+echo "Hello, world!"

--- a/packages/manager/cypress/support/intercepts/linodes.ts
+++ b/packages/manager/cypress/support/intercepts/linodes.ts
@@ -1,0 +1,12 @@
+/**
+ * @file Cypress intercepts and mocks for Cloud Manager Linode operations.
+ */
+
+/**
+ * Intercepts POST request to create a Linode.
+ *
+ * @returns Cypress chainable.
+ */
+export const interceptCreateLinode = (): Cypress.Chainable<null> => {
+  return cy.intercept('POST', '*/linode/instances');
+};

--- a/packages/manager/cypress/support/intercepts/stackscripts.ts
+++ b/packages/manager/cypress/support/intercepts/stackscripts.ts
@@ -1,0 +1,21 @@
+/**
+ * @file Cypress intercepts and mocks for Cloud Manager StackScript operations.
+ */
+
+/**
+ * Intercepts GET request to list StackScripts.
+ *
+ * @returns Cypress chainable.
+ */
+export const interceptGetStackScripts = (): Cypress.Chainable<null> => {
+  return cy.intercept('GET', '*/linode/stackscripts*');
+};
+
+/**
+ * Intercepts POST request to create a StackScript.
+ *
+ * @returns Cypress chainable.
+ */
+export const interceptCreateStackScript = (): Cypress.Chainable<null> => {
+  return cy.intercept('POST', '*/linode/stackscripts');
+};

--- a/packages/manager/cypress/support/util/polling.ts
+++ b/packages/manager/cypress/support/util/polling.ts
@@ -1,0 +1,134 @@
+import { LinodeStatus, ImageStatus } from '@linode/api-v4/types';
+import { getImage } from '@linode/api-v4/lib/images';
+import { getLinode } from '@linode/api-v4/lib/linodes';
+
+/**
+ * @file Utilities for polling APIs and other resources.
+ */
+
+export interface PollingOptions {
+  // Initial delay (in MS) before executing callback. Useful for operations
+  // that are known to fail immediately.
+  initialDelay: number;
+
+  // Maximum polling attempts before failing.
+  maxAttempts: number;
+
+  // Fibonacci number offset. Useful for increasing the delays between attempts.
+  fibonacciOffset: number;
+}
+
+const defaultPollingOptions = {
+  initialDelay: 0,
+  maxAttempts: 10,
+  fibonacciOffset: 0,
+};
+
+/**
+ * Get a fibonacci number with the given index.
+ *
+ * @param index - Index of fibonacci number to retrieve.
+ *
+ * @returns Fibonacci number for `index`.
+ */
+const fibonacci = (index: number): number => {
+  if (index <= 1) {
+    return 1;
+  }
+  return fibonacci(index - 1) + fibonacci(index - 2);
+};
+
+/**
+ * Executes a callback repeatedly until a desired result is achieved.
+ *
+ * Fibonacci backoff is used to increase time between subsequent attempts in
+ * order to avoid overloading remote resources.
+ *
+ * @param callback - Callback that returns a Promise to retrieve some data.
+ * @param evaluator - Callback to evaluate whether the data matches some condition.
+ * @param options - Polling options.
+ *
+ * @returns A Promise that resolves to the retrieved data upon successful evaluation.
+ */
+export const poll = async <T>(
+  callback: () => Promise<T>,
+  evaluator: (T) => boolean,
+  options?: Partial<PollingOptions>
+): Promise<T> => {
+  const { maxAttempts, initialDelay, fibonacciOffset } = {
+    ...defaultPollingOptions,
+    ...options,
+  };
+
+  if (initialDelay) {
+    await new Promise((resolve) => setTimeout(resolve, initialDelay));
+  }
+
+  let attempt = 1;
+
+  // Disable ESLint rule because we do not want to parallelize the async
+  // operations in this case.
+  /* eslint-disable no-await-in-loop */
+  while (attempt < maxAttempts + 1) {
+    const result = await callback();
+    if (evaluator(result)) {
+      return result;
+    }
+    attempt++;
+    const fibonacciNum = fibonacci(attempt + fibonacciOffset);
+    const fibonacciMs = fibonacciNum * 1000;
+    await new Promise((resolve) => setTimeout(resolve, fibonacciMs));
+  }
+
+  throw new Error('Polling failed');
+};
+
+/**
+ * Polls a Linode with the given ID until it has the given status.
+ *
+ * @param linodeId - ID of Linode whose status should be polled.
+ * @param desiredStatus - Desired status of Linode that is being polled.
+ * @param options - Polling options.
+ *
+ * @returns A Promise that resolves to the polled Linode's status.
+ */
+export const pollLinodeStatus = async (
+  linodeId: number,
+  desiredStatus: LinodeStatus,
+  options?: Partial<PollingOptions>
+) => {
+  const getLinodeStatus = async () => {
+    const linode = await getLinode(linodeId);
+    return linode.status;
+  };
+
+  const checkLinodeStatus = (status: LinodeStatus): boolean =>
+    status === desiredStatus;
+
+  return poll(getLinodeStatus, checkLinodeStatus, options);
+};
+
+/**
+ * Polls an Image with the given ID until it has the given status.
+ *
+ * @param imageId - ID of Image whose status should be polled.
+ * @param desiredStatus - Desired status of Image that is being polled.
+ * @param options - Polling options.
+ *
+ * @returns A Promise that resolves to the polled Image's status.
+ */
+export const pollImageStatus = async (
+  imageId: string,
+  desiredStatus: ImageStatus,
+  options?: Partial<PollingOptions>
+) => {
+  const getImageStatus = async () => {
+    const image = await getImage(imageId);
+    return image.status;
+  };
+
+  const checkImageStatus = (status: ImageStatus): boolean =>
+    status === desiredStatus;
+
+  return poll(getImageStatus, checkImageStatus, options);
+};

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -141,7 +141,7 @@
     "@svgr/webpack": "^6.5.1",
     "@swc/core": "^1.3.1",
     "@swc/jest": "^0.2.22",
-    "@testing-library/cypress": "^8.0.2",
+    "@testing-library/cypress": "^8.0.7",
     "@testing-library/jest-dom": "~5.11.3",
     "@testing-library/react": "~10.4.9",
     "@testing-library/react-hooks": "~3.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4020,10 +4020,10 @@
   resolved "https://registry.yarnpkg.com/@swc/wasm/-/wasm-1.2.130.tgz#88ac26433335d1f957162a9a92f1450b73c176a0"
   integrity sha512-rNcJsBxS70+pv8YUWwf5fRlWX6JoY/HJc25HD/F8m6Kv7XhJdqPPMhyX6TKkUBPAG7TWlZYoxa+rHAjPy4Cj3Q==
 
-"@testing-library/cypress@^8.0.2":
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/@testing-library/cypress/-/cypress-8.0.2.tgz#b13f0ff2424dec4368b6670dfbfb7e43af8eefc9"
-  integrity sha512-KVdm7n37sg/A4e3wKMD4zUl0NpzzVhx06V9Tf0hZHZ7nrZ4yFva6Zwg2EFF1VzHkEfN/ahUzRtT1qiW+vuWnJw==
+"@testing-library/cypress@^8.0.7":
+  version "8.0.7"
+  resolved "https://registry.yarnpkg.com/@testing-library/cypress/-/cypress-8.0.7.tgz#18315eba3cf8852808afadf122e4858406384015"
+  integrity sha512-3HTV725rOS+YHve/gD9coZp/UcPK5xhr4H0GMnq/ni6USdtzVtSOG9WBFtd8rYnrXk8rrGD+0toRFYouJNIG0Q==
   dependencies:
     "@babel/runtime" "^7.14.6"
     "@testing-library/dom" "^8.1.0"


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
This fleshes out our StackScript E2E tests so that they validate functionality related to user-defined fields and Any/All target images.

These tests are pretty slow because one of the tests has to wait for a Linode and an Image to be created before the test can begin (taking anywhere between 4-7 minutes total on my machine).

## How to test 🧪

**How do I run relevant e2e tests?**

```
yarn cy:run -s "cypress/e2e/stackscripts/create-stackscripts.spec.ts"
```