### PR TITLE
Allow New Relic to be disabled for production builds

### DIFF
--- a/packages/manager/config/env.js
+++ b/packages/manager/config/env.js
@@ -74,6 +74,9 @@ function getClientEnvironment(publicUrl) {
         // images into the `src` and `import` them in code to get their paths.
         PUBLIC_URL: publicUrl,
         VERSION: paths.appVersion,
+        // Allow New Relic to be disabled when building Cloud Manager for
+        // environments where it is unneeded.
+        DISABLE_NEW_RELIC: process.env.DISABLE_NEW_RELIC,
       }
     );
   // Stringify all values so we can feed into Webpack DefinePlugin

--- a/packages/manager/public/index.html
+++ b/packages/manager/public/index.html
@@ -7,7 +7,7 @@
       content="width=device-width, initial-scale=1.0"
     />
     <meta name="theme-color" content="#000000" />
-    <% if (process.env.NODE_ENV === 'production') { %>
+    <% if (process.env.NODE_ENV === 'production' && !process.env.DISABLE_NEW_RELIC) { %>
     <script type="text/javascript" src="/new-relic.js"></script>
     <% } %>
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
Allows New Relic to be disabled in production builds when the `DISABLE_NEW_RELIC` environment variable is set.

**Why?**
We currently have at least one error being reported by New Relic, and running E2E tests against a production build consistently triggers alerts. This change allows us to disable New Relic on these builds to prevent disruptive alerts during E2E tests.

This may also be useful for any users who want to self host Cloud Manager.

## How to test 🧪

1. (If necessary, manually run `yarn` to install dependencies if they're out of sync)
1. Run `yarn build`
1. Confirm that New Relic is enabled by checking `./packages/manager/build/index.html` and confirming that `<script type="text/javascript" src="/new-relic.js">` is present.
1. Run `DISABLE_NEW_RELIC=1 yarn build`
1. Confirm that New Relic is disabled by checking `./packages/manager/build/index.html` and confirming that `<script type="text/javascript" src="/new-relic.js">` is absent.