### PR TITLE
M3-5182: RQ-ify Images endpoints, Pt. 1

### DIFF
--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -34,6 +34,7 @@ import GoTo from './GoTo';
 import { databaseEventsHandler } from './queries/databases';
 import { domainEventsHandler } from './queries/domains';
 import { volumeEventsHandler } from './queries/volumes';
+import { imageEventsHandler } from './queries/images';
 
 interface Props {
   toggleTheme: () => void;
@@ -125,6 +126,18 @@ export class App extends React.Component<CombinedProps, State> {
     events$
       .filter((event) => event.action.startsWith('volume') && !event._initial)
       .subscribe(volumeEventsHandler);
+
+    /*
+      Send any Image events to the Image events handler in the queries file.
+    */
+    events$
+      .filter(
+        (event) =>
+          (event.action.startsWith('image') ||
+            event.action === 'disk_imagize') &&
+          !event._initial
+      )
+      .subscribe(imageEventsHandler);
 
     /*
      * We want to listen for migration events side-wide

--- a/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
@@ -5,24 +5,21 @@ import { useSnackbar } from 'notistack';
 import { equals } from 'ramda';
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
-import { compose } from 'recompose';
 import Button from 'src/components/Button';
 import Box from 'src/components/core/Box';
 import Paper from 'src/components/core/Paper';
 import { Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
+import Link from 'src/components/Link';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
-import withImages, {
-  ImagesDispatch,
-} from 'src/containers/withImages.container';
 import { resetEventsPolling } from 'src/eventsPolling';
 import DiskSelect from 'src/features/linodes/DiskSelect';
 import LinodeSelect from 'src/features/linodes/LinodeSelect';
+import { useCreateImageMutation } from 'src/queries/images';
 import { useGrants, useProfile } from 'src/queries/profile';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
-import Link from 'src/components/Link';
 
 const useStyles = makeStyles((theme: Theme) => ({
   container: {
@@ -66,14 +63,8 @@ export interface Props {
   changeDescription: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
-  const {
-    label,
-    description,
-    changeLabel,
-    changeDescription,
-    createImage,
-  } = props;
+export const CreateImageTab: React.FC<Props> = (props) => {
+  const { label, description, changeLabel, changeDescription } = props;
 
   const classes = useStyles();
   const { enqueueSnackbar } = useSnackbar();
@@ -81,6 +72,8 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
 
   const { data: profile } = useProfile();
   const { data: grants } = useGrants();
+
+  const { mutateAsync: createImage } = useCreateImageMutation();
 
   const [selectedLinode, setSelectedLinode] = React.useState<Linode>();
   const [selectedDisk, setSelectedDisk] = React.useState<string | null>('');
@@ -319,9 +312,7 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
   );
 };
 
-export default compose<Props & ImagesDispatch, Props>(withImages())(
-  CreateImageTab
-);
+export default CreateImageTab;
 
 const rawDiskWarningText =
   'Using a raw disk may fail, as Linode Images cannot be created from disks formatted with custom filesystems.';

--- a/packages/manager/src/features/Images/ImagesDrawer.tsx
+++ b/packages/manager/src/features/Images/ImagesDrawer.tsx
@@ -412,7 +412,14 @@ export const ImageDrawer: React.FC<CombinedProps> = (props) => {
 
       <ActionsPanel
         style={{ marginTop: 16 }}
-        updateFor={[requirementsMet, classes, submitting, mode]}
+        updateFor={[
+          requirementsMet,
+          classes,
+          submitting,
+          mode,
+          label,
+          description,
+        ]}
       >
         <Button
           onClick={close}

--- a/packages/manager/src/features/Images/ImagesDrawer.tsx
+++ b/packages/manager/src/features/Images/ImagesDrawer.tsx
@@ -90,6 +90,10 @@ export const ImageDrawer: React.FC<CombinedProps> = (props) => {
     enqueueSnackbar,
     changeLabel,
     changeDescription,
+    changeLinode,
+    changeDisk,
+    open,
+    onClose,
   } = props;
 
   // console.log(label);
@@ -143,12 +147,12 @@ export const ImageDrawer: React.FC<CombinedProps> = (props) => {
   }, [props.disks]);
 
   React.useEffect(() => {
-    if (!props.selectedLinode) {
+    if (!selectedLinode) {
       setDisks([]);
     }
 
-    if (props.selectedLinode) {
-      getLinodeDisks(props.selectedLinode)
+    if (selectedLinode) {
+      getLinodeDisks(selectedLinode)
         .then((response) => {
           if (!mounted) {
             return;
@@ -176,22 +180,22 @@ export const ImageDrawer: React.FC<CombinedProps> = (props) => {
           }
         });
     }
-  }, [props.selectedLinode]);
+  }, [selectedLinode]);
 
   const handleLinodeChange = (linodeID: number) => {
     // Clear any errors
     setErrors(undefined);
-    props.changeLinode(linodeID);
+    changeLinode(linodeID);
   };
 
   const handleDiskChange = (diskID: string | null) => {
     // Clear any errors
     setErrors(undefined);
-    props.changeDisk(diskID);
+    changeDisk(diskID);
   };
 
   const close = () => {
-    props.onClose();
+    onClose();
     if (mounted) {
       setErrors(undefined);
       setNotice(undefined);
@@ -204,7 +208,7 @@ export const ImageDrawer: React.FC<CombinedProps> = (props) => {
   const onSubmit = () => {
     setErrors(undefined);
     setNotice(undefined);
-    setSubmitting(false);
+    setSubmitting(true);
 
     switch (mode) {
       case 'edit':
@@ -290,8 +294,6 @@ export const ImageDrawer: React.FC<CombinedProps> = (props) => {
     // When creating an image, disable the submit button until a Linode and
     // disk are selected. When restoring to an existing Linode, the Linode select is the only field.
     // When imagizing, the Linode is selected already so only check for a disk selection.
-    const { mode, selectedDisk, selectedLinode } = props;
-
     const isDiskSelected = Boolean(selectedDisk);
 
     switch (mode) {
@@ -325,7 +327,7 @@ export const ImageDrawer: React.FC<CombinedProps> = (props) => {
   const diskError = hasErrorFor('disk_id');
 
   return (
-    <Drawer open={props.open} onClose={props.onClose} title={titleMap[mode]}>
+    <Drawer open={open} onClose={onClose} title={titleMap[mode]}>
       {!canCreateImage ? (
         <Notice
           error

--- a/packages/manager/src/features/Images/ImagesDrawer.tsx
+++ b/packages/manager/src/features/Images/ImagesDrawer.tsx
@@ -182,7 +182,7 @@ export const ImageDrawer: React.FC<CombinedProps> = (props) => {
     }
   };
 
-  const safeDescription = description ?? ' ';
+  const safeDescription = description ? description : ' ';
 
   const onSubmit = () => {
     setErrors(undefined);

--- a/packages/manager/src/features/Images/ImagesDrawer.tsx
+++ b/packages/manager/src/features/Images/ImagesDrawer.tsx
@@ -7,50 +7,43 @@ import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles,
-} from 'src/components/core/styles';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Drawer from 'src/components/Drawer';
 import Notice from 'src/components/Notice';
 import SectionErrorBoundary from 'src/components/SectionErrorBoundary';
 import TextField from 'src/components/TextField';
 import { IMAGE_DEFAULT_LIMIT } from 'src/constants';
-import withImages, {
-  ImagesDispatch,
-} from 'src/containers/withImages.container';
 import { resetEventsPolling } from 'src/eventsPolling';
 import DiskSelect from 'src/features/linodes/DiskSelect';
 import LinodeSelect from 'src/features/linodes/LinodeSelect';
+import { getGrantData, getProfileData } from 'src/queries/profile';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
-import { getGrantData, getProfileData } from 'src/queries/profile';
+import {
+  useCreateImageMutation,
+  useUpdateImageMutation,
+} from 'src/queries/images';
 
-type ClassNames = 'root' | 'suffix' | 'actionPanel' | 'helperText';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {},
-    suffix: {
-      fontSize: '.9rem',
-      marginRight: theme.spacing(1),
-    },
-    actionPanel: {
-      marginTop: theme.spacing(2),
-    },
-    helperText: {
-      paddingTop: theme.spacing(1) / 2,
-    },
-  });
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {},
+  suffix: {
+    fontSize: '.9rem',
+    marginRight: theme.spacing(1),
+  },
+  actionPanel: {
+    marginTop: theme.spacing(2),
+  },
+  helperText: {
+    paddingTop: theme.spacing(1) / 2,
+  },
+}));
 
 export interface Props {
   mode: DrawerMode;
   open: boolean;
   description?: string;
-  imageID?: string;
+  imageId?: string;
   label?: string;
   // Only used from LinodeDisks to pre-populate the selected Disk
   disks?: Disk[];
@@ -63,189 +56,180 @@ export interface Props {
   changeDescription: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-interface State {
-  disks: Disk[];
-  notice?: string;
-  errors?: APIError[];
-  submitting: boolean;
-}
-
-type CombinedProps = Props &
-  WithStyles<ClassNames> &
-  RouteComponentProps<{}> &
-  WithSnackbarProps &
-  ImagesDispatch;
+type CombinedProps = Props & RouteComponentProps<{}> & WithSnackbarProps;
 
 export type DrawerMode = 'closed' | 'create' | 'imagize' | 'restore' | 'edit';
 
+const createImageText = 'Create Image';
+
 const titleMap: Record<DrawerMode, string> = {
   closed: '',
-  create: 'Create Image',
-  imagize: 'Create Image',
+  create: createImageText,
+  imagize: createImageText,
   edit: 'Edit Image',
   restore: 'Restore from Image',
 };
 
 const buttonTextMap: Record<DrawerMode, string> = {
   closed: '',
-  create: 'Create Image',
+  create: createImageText,
   restore: 'Restore Image',
   edit: 'Save Changes',
-  imagize: 'Create Image',
+  imagize: createImageText,
 };
 
-class ImageDrawer extends React.Component<CombinedProps, State> {
-  mounted: boolean = false;
-  canCreateImage: boolean;
-  availableImages: number[] | null = null;
+export const ImageDrawer: React.FC<CombinedProps> = (props) => {
+  const {
+    mode,
+    imageId,
+    label,
+    description,
+    history,
+    selectedDisk,
+    selectedLinode,
+    enqueueSnackbar,
+    changeLabel,
+    changeDescription,
+  } = props;
 
-  state = {
-    disks: [],
-    errors: undefined,
-    notice: undefined,
-    submitting: false,
-  };
+  // console.log(label);
+  // console.log(description);
 
-  componentDidMount() {
-    this.mounted = true;
+  const classes = useStyles();
+
+  const [mounted, setMounted] = React.useState<boolean>(false);
+  const [notice, setNotice] = React.useState(undefined);
+  const [submitting, setSubmitting] = React.useState<boolean>(false);
+  const [errors, setErrors] = React.useState<APIError[] | undefined>(undefined);
+
+  const [disks, setDisks] = React.useState<Disk[]>([]);
+  const [availableImages, setAvailableImages] = React.useState<number[] | null>(
+    null
+  );
+  const [canCreateImage, setCanCreateImage] = React.useState<boolean>(false);
+
+  const { mutateAsync: updateImage } = useUpdateImageMutation();
+  const { mutateAsync: createImage } = useCreateImageMutation();
+
+  React.useEffect(() => {
+    setMounted(true);
 
     const profile = getProfileData();
     const grants = getGrantData();
 
-    this.canCreateImage =
-      Boolean(!profile?.restricted) || Boolean(grants?.global?.add_images);
+    setCanCreateImage(
+      Boolean(!profile?.restricted) || Boolean(grants?.global?.add_images)
+    );
 
     // Unrestricted users can create Images from any disk;
     // Restricted users need read_write on the Linode they're trying to Imagize
     // (in addition to the global add_images grant).
-    this.availableImages = profile?.restricted
+    const images = profile?.restricted
       ? grants?.linode
           .filter((thisGrant) => thisGrant.permissions === 'read_write')
           .map((thisGrant) => thisGrant.id) ?? []
       : null;
 
-    if (this.props.disks) {
+    setAvailableImages(images);
+
+    if (props.disks) {
       // for the 'imagizing' mode
-      this.setState({ disks: this.props.disks });
-    }
-  }
-
-  componentWillUnmount() {
-    this.mounted = false;
-  }
-
-  componentDidUpdate(prevProps: CombinedProps) {
-    if (this.props.disks && !equals(this.props.disks, prevProps.disks)) {
-      // for the 'imagizing' mode
-      this.setState({ disks: this.props.disks });
+      setDisks(props.disks);
     }
 
-    if (!this.props.selectedLinode && prevProps.selectedLinode) {
-      this.setState({ disks: [] });
+    return () => {
+      setMounted(false);
+    };
+  }, [props.disks]);
+
+  React.useEffect(() => {
+    if (!props.selectedLinode) {
+      setDisks([]);
     }
 
-    if (
-      this.props.selectedLinode &&
-      this.props.selectedLinode !== prevProps.selectedLinode
-    ) {
-      getLinodeDisks(this.props.selectedLinode)
+    if (props.selectedLinode) {
+      getLinodeDisks(props.selectedLinode)
         .then((response) => {
-          if (!this.mounted) {
+          if (!mounted) {
             return;
           }
 
           const filteredDisks = response.data.filter(
             (disk) => disk.filesystem !== 'swap'
           );
-          if (!equals(this.state.disks, filteredDisks)) {
-            this.setState({ disks: filteredDisks });
+          if (!equals(disks, filteredDisks)) {
+            setDisks(filteredDisks);
           }
         })
         .catch((_) => {
-          if (!this.mounted) {
+          if (!mounted) {
             return;
           }
 
-          if (this.mounted) {
-            this.setState({
-              errors: [
-                {
-                  field: 'disk_id',
-                  reason: 'Could not retrieve disks for this Linode.',
-                },
-              ],
-            });
+          if (mounted) {
+            setErrors([
+              {
+                field: 'disk_id',
+                reason: 'Could not retrieve disks for this Linode.',
+              },
+            ]);
           }
         });
     }
-  }
+  }, [props.selectedLinode]);
 
-  handleLinodeChange = (linodeID: number) => {
+  const handleLinodeChange = (linodeID: number) => {
     // Clear any errors
-    this.setState({ errors: undefined });
-    this.props.changeLinode(linodeID);
+    setErrors(undefined);
+    props.changeLinode(linodeID);
   };
 
-  handleDiskChange = (diskID: string | null) => {
+  const handleDiskChange = (diskID: string | null) => {
     // Clear any errors
-    this.setState({ errors: undefined });
-    this.props.changeDisk(diskID);
+    setErrors(undefined);
+    props.changeDisk(diskID);
   };
 
-  close = () => {
-    this.props.onClose();
-    if (this.mounted) {
-      this.setState({
-        errors: undefined,
-        notice: undefined,
-        submitting: false,
-      });
+  const close = () => {
+    props.onClose();
+    if (mounted) {
+      setErrors(undefined);
+      setNotice(undefined);
+      setSubmitting(false);
     }
   };
 
-  onSubmit = () => {
-    const {
-      mode,
-      imageID,
-      label,
-      description,
-      history,
-      selectedDisk,
-      selectedLinode,
-      updateImage,
-      createImage,
-      enqueueSnackbar,
-    } = this.props;
+  const safeDescription = description ?? ' ';
 
-    this.setState({ errors: undefined, notice: undefined, submitting: true });
-    const safeDescription = description ? description : ' ';
+  const onSubmit = () => {
+    setErrors(undefined);
+    setNotice(undefined);
+    setSubmitting(false);
+
     switch (mode) {
       case 'edit':
-        if (!imageID) {
-          this.setState({ submitting: false });
+        if (!imageId) {
+          setSubmitting(false);
           return;
         }
 
-        updateImage({ imageID, label, description: safeDescription })
+        updateImage({ imageId, label, description: safeDescription })
           .then(() => {
-            if (!this.mounted) {
+            if (!mounted) {
               return;
             }
 
-            this.close();
+            close();
           })
-          .catch((errorResponse) => {
-            if (!this.mounted) {
+          .catch((errorResponse: APIError[]) => {
+            if (!mounted) {
               return;
             }
 
-            this.setState({
-              submitting: false,
-              errors: getAPIErrorOrDefault(
-                errorResponse,
-                'Unable to edit Image'
-              ),
-            });
+            setSubmitting(false);
+            setErrors(
+              getAPIErrorOrDefault(errorResponse, 'Unable to edit Image')
+            );
           });
         return;
 
@@ -256,61 +240,57 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
           label,
           description: safeDescription,
         })
-          .then((_) => {
-            if (!this.mounted) {
+          .then(() => {
+            if (!mounted) {
               return;
             }
 
             resetEventsPolling();
 
-            this.setState({
-              submitting: false,
-            });
+            setSubmitting(false);
 
-            this.close();
+            close();
 
             enqueueSnackbar('Image scheduled for creation.', {
               variant: 'info',
             });
           })
-          .catch((errorResponse) => {
-            if (!this.mounted) {
+          .catch((errorResponse: APIError[]) => {
+            if (!mounted) {
               return;
             }
 
-            this.setState({
-              submitting: false,
-              errors: getAPIErrorOrDefault(
+            setSubmitting(false);
+            setErrors(
+              getAPIErrorOrDefault(
                 errorResponse,
                 'There was an error creating the image.'
-              ),
-            });
+              )
+            );
           });
         return;
 
       case 'restore':
         if (!selectedLinode) {
-          this.setState({
-            submitting: false,
-            errors: [{ field: 'linode_id', reason: 'Choose a Linode.' }],
-          });
+          setSubmitting(false);
+          setErrors([{ field: 'linode_id', reason: 'Choose a Linode.' }]);
           return;
         }
-        this.close();
+        close();
         history.push({
           pathname: `/linodes/${selectedLinode}/rebuild`,
-          state: { selectedImageId: imageID },
+          state: { selectedImageId: imageId },
         });
       default:
         return;
     }
   };
 
-  checkRequirements = () => {
+  const checkRequirements = () => {
     // When creating an image, disable the submit button until a Linode and
     // disk are selected. When restoring to an existing Linode, the Linode select is the only field.
     // When imagizing, the Linode is selected already so only check for a disk selection.
-    const { mode, selectedDisk, selectedLinode } = this.props;
+    const { mode, selectedDisk, selectedLinode } = props;
 
     const isDiskSelected = Boolean(selectedDisk);
 
@@ -326,161 +306,137 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
     }
   };
 
-  render() {
-    const {
-      label,
-      description,
-      selectedDisk,
-      selectedLinode,
-      mode,
-      changeLabel,
-      changeDescription,
-      classes,
-    } = this.props;
-    const { disks, errors, notice, submitting } = this.state;
+  const requirementsMet = checkRequirements();
 
-    const requirementsMet = this.checkRequirements();
+  const hasErrorFor = getAPIErrorFor(
+    {
+      linode_id: 'Linode',
+      disk_id: 'Disk',
+      region: 'Region',
+      size: 'Size',
+      label: 'Label',
+    },
+    errors
+  );
+  const labelError = hasErrorFor('label');
+  const descriptionError = hasErrorFor('description');
+  const generalError = hasErrorFor('none');
+  const linodeError = hasErrorFor('linode_id');
+  const diskError = hasErrorFor('disk_id');
 
-    const hasErrorFor = getAPIErrorFor(
-      {
-        linode_id: 'Linode',
-        disk_id: 'Disk',
-        region: 'Region',
-        size: 'Size',
-        label: 'Label',
-      },
-      errors
-    );
-    const labelError = hasErrorFor('label');
-    const descriptionError = hasErrorFor('description');
-    const generalError = hasErrorFor('none');
-    const linodeError = hasErrorFor('linode_id');
-    const diskError = hasErrorFor('disk_id');
+  return (
+    <Drawer open={props.open} onClose={props.onClose} title={titleMap[mode]}>
+      {!canCreateImage ? (
+        <Notice
+          error
+          text="You don't have permissions to create a new Image. Please contact an account administrator for details."
+        />
+      ) : null}
+      {generalError && <Notice error text={generalError} data-qa-notice />}
 
-    return (
-      <Drawer
-        open={this.props.open}
-        onClose={this.props.onClose}
-        title={titleMap[mode]}
-      >
-        {!this.canCreateImage ? (
-          <Notice
-            error
-            text="You don't have permissions to create a new Image. Please contact an account administrator for details."
-          />
-        ) : null}
-        {generalError && <Notice error text={generalError} data-qa-notice />}
+      {notice && <Notice success text={notice} data-qa-notice />}
 
-        {notice && <Notice success text={notice} data-qa-notice />}
-
-        {['create', 'restore'].includes(mode) && (
-          <LinodeSelect
-            selectedLinode={selectedLinode}
-            linodeError={linodeError}
-            disabled={!this.canCreateImage}
-            handleChange={(linode) => {
-              if (linode !== null) {
-                this.handleLinodeChange(linode.id);
-              }
-            }}
-            filterCondition={(linode) =>
-              this.availableImages
-                ? this.availableImages.includes(linode.id)
-                : true
+      {['create', 'restore'].includes(mode) && (
+        <LinodeSelect
+          selectedLinode={selectedLinode}
+          linodeError={linodeError}
+          disabled={!canCreateImage}
+          handleChange={(linode) => {
+            if (linode !== null) {
+              handleLinodeChange(linode.id);
             }
-            updateFor={[
-              selectedLinode,
-              linodeError,
-              classes,
-              this.canCreateImage,
-              this.availableImages,
-            ]}
-            isClearable={false}
+          }}
+          filterCondition={(linode) =>
+            availableImages ? availableImages.includes(linode.id) : true
+          }
+          updateFor={[
+            selectedLinode,
+            linodeError,
+            classes,
+            canCreateImage,
+            availableImages,
+          ]}
+          isClearable={false}
+        />
+      )}
+
+      {['create', 'imagize'].includes(mode) && (
+        <>
+          <DiskSelect
+            selectedDisk={selectedDisk}
+            disks={disks}
+            diskError={diskError}
+            handleChange={handleDiskChange}
+            updateFor={[disks, selectedDisk, diskError, classes]}
+            disabled={mode === 'imagize' || !canCreateImage}
+            data-qa-disk-select
           />
-        )}
+          <Typography className={classes.helperText} variant="body1">
+            Linode Images are limited to {IMAGE_DEFAULT_LIMIT} MB of data per
+            disk by default. Please ensure that your disk content does not
+            exceed this size limit, or open a Support ticket to request a higher
+            limit. Additionally, Linode Images cannot be created if you are
+            using raw disks or disks that have been formatted using custom
+            filesystems.
+          </Typography>
+        </>
+      )}
 
-        {['create', 'imagize'].includes(mode) && (
-          <>
-            <DiskSelect
-              selectedDisk={selectedDisk}
-              disks={disks}
-              diskError={diskError}
-              handleChange={this.handleDiskChange}
-              updateFor={[disks, selectedDisk, diskError, classes]}
-              disabled={mode === 'imagize' || !this.canCreateImage}
-              data-qa-disk-select
-            />
-            <Typography className={classes.helperText} variant="body1">
-              Linode Images are limited to {IMAGE_DEFAULT_LIMIT} MB of data per
-              disk by default. Please ensure that your disk content does not
-              exceed this size limit, or open a Support ticket to request a
-              higher limit. Additionally, Linode Images cannot be created if you
-              are using raw disks or disks that have been formatted using custom
-              filesystems.
-            </Typography>
-          </>
-        )}
+      {['create', 'edit', 'imagizing'].includes(mode) && (
+        <React.Fragment>
+          <TextField
+            label="Label"
+            value={label}
+            onChange={changeLabel}
+            error={Boolean(labelError)}
+            errorText={labelError}
+            disabled={!canCreateImage}
+            data-qa-image-label
+          />
 
-        {['create', 'edit', 'imagizing'].includes(mode) && (
-          <React.Fragment>
-            <TextField
-              label="Label"
-              value={label}
-              onChange={changeLabel}
-              error={Boolean(labelError)}
-              errorText={labelError}
-              disabled={!this.canCreateImage}
-              data-qa-image-label
-            />
+          <TextField
+            label="Description"
+            multiline
+            rows={4}
+            value={description}
+            onChange={changeDescription}
+            error={Boolean(descriptionError)}
+            errorText={descriptionError}
+            disabled={!canCreateImage}
+            data-qa-image-description
+          />
+        </React.Fragment>
+      )}
 
-            <TextField
-              label="Description"
-              multiline
-              rows={4}
-              value={description}
-              onChange={changeDescription}
-              error={Boolean(descriptionError)}
-              errorText={descriptionError}
-              disabled={!this.canCreateImage}
-              data-qa-image-description
-            />
-          </React.Fragment>
-        )}
-
-        <ActionsPanel
-          style={{ marginTop: 16 }}
-          updateFor={[requirementsMet, classes, submitting, mode]}
+      <ActionsPanel
+        style={{ marginTop: 16 }}
+        updateFor={[requirementsMet, classes, submitting, mode]}
+      >
+        <Button
+          onClick={close}
+          buttonType="secondary"
+          className="cancel"
+          disabled={!canCreateImage}
+          data-qa-cancel
         >
-          <Button
-            onClick={this.close}
-            buttonType="secondary"
-            className="cancel"
-            disabled={!this.canCreateImage}
-            data-qa-cancel
-          >
-            Cancel
-          </Button>
-          <Button
-            onClick={this.onSubmit}
-            disabled={requirementsMet || !this.canCreateImage}
-            loading={submitting}
-            buttonType="primary"
-            data-qa-submit
-          >
-            {buttonTextMap[mode] ?? 'Submit'}
-          </Button>
-        </ActionsPanel>
-      </Drawer>
-    );
-  }
-}
-
-const styled = withStyles(styles);
+          Cancel
+        </Button>
+        <Button
+          onClick={onSubmit}
+          disabled={requirementsMet || !canCreateImage}
+          loading={submitting}
+          buttonType="primary"
+          data-qa-submit
+        >
+          {buttonTextMap[mode] ?? 'Submit'}
+        </Button>
+      </ActionsPanel>
+    </Drawer>
+  );
+};
 
 export default compose<CombinedProps, Props>(
-  styled,
   withRouter,
-  withImages(),
   withSnackbar,
   SectionErrorBoundary
 )(ImageDrawer);

--- a/packages/manager/src/features/Images/ImagesDrawer.tsx
+++ b/packages/manager/src/features/Images/ImagesDrawer.tsx
@@ -1,9 +1,9 @@
 import { Disk, getLinodeDisks } from '@linode/api-v4/lib/linodes';
 import { APIError } from '@linode/api-v4/lib/types';
-import { withSnackbar, WithSnackbarProps } from 'notistack';
+import { useSnackbar } from 'notistack';
 import { equals } from 'ramda';
 import * as React from 'react';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 import { compose } from 'recompose';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
@@ -17,13 +17,13 @@ import { IMAGE_DEFAULT_LIMIT } from 'src/constants';
 import { resetEventsPolling } from 'src/eventsPolling';
 import DiskSelect from 'src/features/linodes/DiskSelect';
 import LinodeSelect from 'src/features/linodes/LinodeSelect';
-import { getGrantData, getProfileData } from 'src/queries/profile';
-import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
-import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 import {
   useCreateImageMutation,
   useUpdateImageMutation,
 } from 'src/queries/images';
+import { getGrantData, getProfileData } from 'src/queries/profile';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {},
@@ -56,7 +56,7 @@ export interface Props {
   changeDescription: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-type CombinedProps = Props & RouteComponentProps<{}> & WithSnackbarProps;
+type CombinedProps = Props;
 
 export type DrawerMode = 'closed' | 'create' | 'imagize' | 'restore' | 'edit';
 
@@ -84,10 +84,8 @@ export const ImageDrawer: React.FC<CombinedProps> = (props) => {
     imageId,
     label,
     description,
-    history,
     selectedDisk,
     selectedLinode,
-    enqueueSnackbar,
     changeLabel,
     changeDescription,
     changeLinode,
@@ -96,10 +94,9 @@ export const ImageDrawer: React.FC<CombinedProps> = (props) => {
     onClose,
   } = props;
 
-  // console.log(label);
-  // console.log(description);
-
   const classes = useStyles();
+  const { enqueueSnackbar } = useSnackbar();
+  const history = useHistory();
 
   const [mounted, setMounted] = React.useState<boolean>(false);
   const [notice, setNotice] = React.useState(undefined);
@@ -444,8 +441,4 @@ export const ImageDrawer: React.FC<CombinedProps> = (props) => {
   );
 };
 
-export default compose<CombinedProps, Props>(
-  withRouter,
-  withSnackbar,
-  SectionErrorBoundary
-)(ImageDrawer);
+export default compose<CombinedProps, Props>(SectionErrorBoundary)(ImageDrawer);

--- a/packages/manager/src/features/Images/ImagesLanding.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding.tsx
@@ -296,7 +296,7 @@ export const ImagesLanding: React.FC<CombinedProps> = (props) => {
     imageLabel: string,
     imageDescription: string
   ) => {
-    removeImageFromCache(imageId);
+    removeImageFromCache();
     props.history.push('/images/create/upload', {
       imageLabel,
       imageDescription,
@@ -304,7 +304,7 @@ export const ImagesLanding: React.FC<CombinedProps> = (props) => {
   };
 
   const onCancelFailedClick = (imageId: string) => {
-    removeImageFromCache(imageId);
+    removeImageFromCache();
   };
 
   const openForEdit = (label: string, description: string, imageID: string) => {

--- a/packages/manager/src/features/Images/ImagesLanding.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding.tsx
@@ -4,11 +4,9 @@ import produce from 'immer';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import { partition } from 'ramda';
 import * as React from 'react';
-import { connect, MapDispatchToProps, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
-import { AnyAction } from 'redux';
-import { ThunkDispatch } from 'redux-thunk';
 import ImageIcon from 'src/assets/icons/entityIcons/image.svg';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
@@ -28,13 +26,15 @@ import Link from 'src/components/Link';
 import Notice from 'src/components/Notice';
 import { Order } from 'src/components/Pagey';
 import Placeholder from 'src/components/Placeholder';
-import useReduxLoad from 'src/hooks/useReduxLoad';
-import { ApplicationState } from 'src/store';
-import { DeleteImagePayload, removeImage } from 'src/store/image/image.actions';
+import { useOrder } from 'src/hooks/useOrder';
+import { usePagination } from 'src/hooks/usePagination';
+import { listToItemsByID } from 'src/queries/base';
 import {
-  deleteImage as _deleteImage,
-  requestImages as _requestImages,
-} from 'src/store/image/image.requests';
+  useDeleteImageMutation,
+  useImagesQuery,
+  removeImageFromCache,
+} from 'src/queries/images';
+import { ApplicationState } from 'src/store';
 import imageEvents from 'src/store/selectors/imageEvents';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import ImageRow, { ImageWithEvent } from './ImageRow';
@@ -120,11 +120,9 @@ interface ImageDialogState {
   status?: ImageStatus;
 }
 
-type CombinedProps = ImageDispatch &
-  ImageDrawerState &
+type CombinedProps = ImageDrawerState &
   ImageDialogState &
   RouteComponentProps<{}> &
-  WithPrivateImages &
   WithSnackbarProps;
 
 const defaultDrawerState = {
@@ -143,11 +141,65 @@ const defaultDialogState = {
   error: undefined,
 };
 
-export const ImagesLanding: React.FC<CombinedProps> = (props) => {
-  useReduxLoad(['images']);
+const preferenceKey = 'images';
 
+export const ImagesLanding: React.FC<CombinedProps> = (props) => {
   const classes = useStyles();
-  const { imagesData, imagesLoading, imagesError, deleteImage } = props;
+
+  const pagination = usePagination(1, preferenceKey);
+
+  const { order, orderBy } = useOrder(
+    {
+      orderBy: 'label',
+      order: 'desc',
+    },
+    `${preferenceKey}-order`
+  );
+
+  const filter = {
+    ['+order_by']: orderBy,
+    ['+order']: order,
+  };
+
+  const {
+    data: images,
+    isLoading: imagesLoading,
+    error: imagesError,
+  } = useImagesQuery(
+    {
+      page: pagination.page,
+      page_size: pagination.pageSize,
+    },
+    filter
+  );
+
+  const { mutateAsync: deleteImage } = useDeleteImageMutation();
+
+  const eventState = useSelector((state: ApplicationState) => state.events);
+  const events = imageEvents(eventState);
+
+  // We want private images and also want the associated events tied in.
+  const imagesItemsById = listToItemsByID(images?.data ?? []);
+  const imagesData = Object.values(imagesItemsById).reduce(
+    (accum, thisImage: Image) =>
+      produce(accum, (draft: any) => {
+        if (!thisImage.is_public) {
+          // NB: the secondary_entity returns only the numeric portion of the image ID so we have to interpolate.
+          const matchingEvent = events.find(
+            (thisEvent) =>
+              `private/${thisEvent.secondary_entity?.id}` === thisImage.id ||
+              (`private/${thisEvent.entity?.id}` === thisImage.id &&
+                thisEvent.status === 'failed')
+          );
+          if (matchingEvent) {
+            draft.push({ ...thisImage, event: matchingEvent });
+          } else {
+            draft.push(thisImage);
+          }
+        }
+      }),
+    []
+  ) as ImageWithEvent[];
 
   /**
    * Separate manual Images (created by the user, either from disk or from uploaded file)
@@ -170,8 +222,6 @@ export const ImagesLanding: React.FC<CombinedProps> = (props) => {
   const [dialog, setDialogState] = React.useState<ImageDialogState>(
     defaultDialogState
   );
-
-  const dispatch = useDispatch();
 
   const dialogAction = dialog.status === 'pending_upload' ? 'cancel' : 'delete';
   const dialogMessage =
@@ -207,7 +257,7 @@ export const ImagesLanding: React.FC<CombinedProps> = (props) => {
       error: undefined,
     }));
 
-    deleteImage({ imageID: dialog.imageID! })
+    deleteImage({ imageId: dialog.imageID! })
       .then(() => {
         closeDialog();
         /**
@@ -246,7 +296,7 @@ export const ImagesLanding: React.FC<CombinedProps> = (props) => {
     imageLabel: string,
     imageDescription: string
   ) => {
-    dispatch(removeImage(imageId));
+    removeImageFromCache(imageId);
     props.history.push('/images/create/upload', {
       imageLabel,
       imageDescription,
@@ -254,7 +304,7 @@ export const ImagesLanding: React.FC<CombinedProps> = (props) => {
   };
 
   const onCancelFailedClick = (imageId: string) => {
-    dispatch(removeImage(imageId));
+    removeImageFromCache(imageId);
   };
 
   const openForEdit = (label: string, description: string, imageID: string) => {
@@ -512,61 +562,8 @@ export const ImagesLanding: React.FC<CombinedProps> = (props) => {
     </React.Fragment>
   );
 };
-interface WithPrivateImages {
-  imagesData: ImageWithEvent[];
-  imagesLoading: boolean;
-  imagesError?: APIError[];
-  imagesLastUpdated: number;
-}
-
-interface ImageDispatch {
-  deleteImage: (imageID: DeleteImagePayload) => Promise<{}>;
-  requestImages: () => Promise<Image[]>;
-}
-
-const mapDispatchToProps: MapDispatchToProps<ImageDispatch, {}> = (
-  dispatch: ThunkDispatch<ApplicationState, undefined, AnyAction>
-) => ({
-  deleteImage: (imageID: DeleteImagePayload) => dispatch(_deleteImage(imageID)),
-  requestImages: () => dispatch(_requestImages()),
-});
-
-const withPrivateImages = connect(
-  (state: ApplicationState): WithPrivateImages => {
-    const { error, itemsById, lastUpdated, loading } = state.__resources.images;
-    const events = imageEvents(state.events);
-    const privateImagesWithEvents = Object.values(itemsById).reduce(
-      (accum, thisImage) =>
-        produce(accum, (draft) => {
-          if (!thisImage.is_public) {
-            // NB: the secondary_entity returns only the numeric portion of the image ID so we have to interpolate.
-            const matchingEvent = events.find(
-              (thisEvent) =>
-                `private/${thisEvent.secondary_entity?.id}` === thisImage.id ||
-                (`private/${thisEvent.entity?.id}` === thisImage.id &&
-                  thisEvent.status === 'failed')
-            );
-            if (matchingEvent) {
-              draft.push({ ...thisImage, event: matchingEvent });
-            } else {
-              draft.push(thisImage);
-            }
-          }
-        }),
-      [] as ImageWithEvent[]
-    );
-    return {
-      imagesData: privateImagesWithEvents,
-      imagesLoading: loading,
-      imagesError: error?.read,
-      imagesLastUpdated: lastUpdated,
-    };
-  },
-  mapDispatchToProps
-);
 
 export default compose<CombinedProps, {}>(
-  withPrivateImages,
   withRouter,
   withSnackbar
 )(ImagesLanding);

--- a/packages/manager/src/features/Images/ImagesLanding.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding.tsx
@@ -402,7 +402,7 @@ export const ImagesLanding: React.FC<CombinedProps> = (props) => {
         description={drawer.description}
         selectedDisk={drawer.selectedDisk}
         selectedLinode={drawer.selectedLinode || null}
-        imageID={drawer.imageID}
+        imageId={drawer.imageID}
         changeDisk={changeSelectedDisk}
         changeLinode={changeSelectedLinode}
         changeLabel={setLabel}

--- a/packages/manager/src/queries/base.ts
+++ b/packages/manager/src/queries/base.ts
@@ -214,7 +214,7 @@ export const itemInListDeletionHandler = <
  */
 export const updateInPaginatedStore = <T extends { id: number | string }>(
   queryKey: string,
-  id: number,
+  id: number | string,
   newData: Partial<T>
 ) => {
   queryClient.setQueriesData<ResourcePage<T> | undefined>(

--- a/packages/manager/src/queries/images.ts
+++ b/packages/manager/src/queries/images.ts
@@ -56,11 +56,7 @@ export const useUpdateImageMutation = () =>
       updateImage(imageId, label, description),
     {
       onSuccess(image) {
-        updateInPaginatedStore<Image>(
-          `${queryKey}-list`,
-          Number(image.id),
-          image
-        );
+        updateInPaginatedStore<Image>(`${queryKey}-list`, image.id, image);
       },
     }
   );

--- a/packages/manager/src/queries/images.ts
+++ b/packages/manager/src/queries/images.ts
@@ -77,8 +77,8 @@ export const useDeleteImageMutation = () =>
   );
 
 // Remove Image from cache
-export const removeImageFromCache = (imageId: number | string) =>
-  updateInPaginatedStore<Image>(`${queryKey}-list`, Number(imageId), {});
+export const removeImageFromCache = () =>
+  queryClient.invalidateQueries(`${queryKey}-list`);
 
 export const imageEventsHandler = (event: Event) => {
   const { action, status, entity } = event;

--- a/packages/manager/src/queries/images.ts
+++ b/packages/manager/src/queries/images.ts
@@ -1,0 +1,76 @@
+import { APIError, ResourcePage } from '@linode/api-v4/lib/types';
+import { useMutation, useQuery } from 'react-query';
+import { queryClient, updateInPaginatedStore } from './base';
+import {
+  Image,
+  getImage,
+  getImages,
+  CreateImagePayload,
+  // ImageUploadPayload,
+  createImage,
+  updateImage,
+  deleteImage,
+  // uploadImage,
+} from '@linode/api-v4/lib/images';
+
+export const queryKey = 'images';
+
+export const useImagesQuery = (params: any, filters: any) =>
+  useQuery<ResourcePage<Image>, APIError[]>(
+    [`${queryKey}-list`, params, filters],
+    () => getImages(params, filters),
+    { keepPreviousData: true }
+  );
+
+// Get specific Image
+export const useSingleImageQuery = (imageID: string) =>
+  useQuery<Image, APIError[]>([queryKey, imageID], () => getImage(imageID));
+
+// Create Image
+export const useCreateImageMutation = () => {
+  return useMutation<Image, APIError[], CreateImagePayload>(
+    ({ diskID, label, description }) => {
+      return createImage(diskID, label, description);
+    },
+    {
+      onSuccess() {
+        queryClient.invalidateQueries(`${queryKey}-list`);
+      },
+    }
+  );
+};
+
+// Update Image
+export const useUpdateImageMutation = () =>
+  useMutation<
+    Image,
+    APIError[],
+    { imageId: string; label?: string; description?: string }
+  >(
+    ({ imageId, label, description }) =>
+      updateImage(imageId, label, description),
+    {
+      onSuccess(image) {
+        updateInPaginatedStore<Image>(
+          `${queryKey}-list`,
+          Number(image.id),
+          image
+        );
+      },
+    }
+  );
+
+// Delete Image
+export const useDeleteImageMutation = () =>
+  useMutation<{}, APIError[], { imageId: string }>(
+    ({ imageId }) => deleteImage(imageId),
+    {
+      onSuccess() {
+        queryClient.invalidateQueries(`${queryKey}-list`);
+      },
+    }
+  );
+
+// Remove Image from cache
+export const removeImageFromCache = (imageId: number | string) =>
+  updateInPaginatedStore<Image>(`${queryKey}-list`, Number(imageId), {});

--- a/packages/manager/src/store/index.ts
+++ b/packages/manager/src/store/index.ts
@@ -36,6 +36,7 @@ import globalErrors, {
   defaultState as defaultGlobalErrorState,
   State as GlobalErrorState,
 } from 'src/store/globalErrors';
+// Remove
 import images, {
   defaultState as defaultImagesState,
   State as ImagesState,
@@ -142,7 +143,7 @@ initReselectDevtools();
  */
 const __resourcesDefaultState = {
   accountManagement: defaultAccountManagementState,
-  images: defaultImagesState,
+  images: defaultImagesState, // Remove
   kubernetes: defaultKubernetesState,
   nodePools: defaultNodePoolsState,
   linodes: defaultLinodesState,
@@ -157,7 +158,7 @@ const __resourcesDefaultState = {
 
 export interface ResourcesState {
   accountManagement: AccountManagementState;
-  images: ImagesState;
+  images: ImagesState; // Remove
   kubernetes: KubernetesState;
   nodePools: KubeNodePoolsState;
   linodes: LinodesState;
@@ -221,7 +222,7 @@ export const defaultState: ApplicationState = {
  */
 const __resources = combineReducers({
   accountManagement,
-  images,
+  images, // Remove
   kubernetes,
   nodePools,
   linodes,


### PR DESCRIPTION
## Description 📝
The first of two or three PRs related to transitioning Images out of Redux and into React Query.

In terms of functionality, this PR focuses on the Images landing page and the "Capture Image" tab when you go to create an image, and having them rely on RQ instead of Redux.

The next piece in this effort will be the "Upload Image" tab and associated functionality/infrastructure.

## How to test 🧪
Ensure functionality parity of Images landing & the "Capture Image" tab between this branch and prod.

Confirm that the RQ cache is storing and updating the Images data as you would expect. 

## To-Do:
- [x] Fix bug where Image label and descriptions aren't being updated; ensure RQ cache is updated accordingly
- [x] Fix bug where redirection from "Rebuild an Existing Linode" flow doesn't open the modal on Linode Details page 
- [x] Convert `ImagesDrawer.tsx` to a function component
- [x] Fix status bug on landing page after a newly-created Image is ready
- [x] Cleanup