### PR TITLE
Update imageFactory eol fied as null

### DIFF
--- a/packages/manager/cypress/support/api/images.ts
+++ b/packages/manager/cypress/support/api/images.ts
@@ -6,10 +6,13 @@ export const getImages = (page: number = 1) => getAll(`images?page=${page}`);
 
 export const createMockImage = (
   data?,
+  eol = null,
   label = 'cy-test-image',
   id = 'private/99999999'
 ) => {
-  return makeResourcePage(imageFactory.buildList(1, { label, id, ...data }));
+  return makeResourcePage(
+    imageFactory.buildList(1, { eol, label, id, ...data })
+  );
 };
 
 export const deleteImageById = (imageId: number) =>

--- a/packages/manager/src/factories/images.ts
+++ b/packages/manager/src/factories/images.ts
@@ -2,7 +2,7 @@ import * as Factory from 'factory.ts';
 import { Image } from '@linode/api-v4/lib/images/types';
 
 export const imageFactory = Factory.Sync.makeFactory<Image>({
-  eol: null,
+  eol: new Date().toISOString(),
   id: Factory.each((id) => `private/${id}`),
   label: Factory.each((i) => `image-${i}`),
   description: 'An image',

--- a/packages/manager/src/factories/images.ts
+++ b/packages/manager/src/factories/images.ts
@@ -2,7 +2,7 @@ import * as Factory from 'factory.ts';
 import { Image } from '@linode/api-v4/lib/images/types';
 
 export const imageFactory = Factory.Sync.makeFactory<Image>({
-  eol: new Date().toISOString(),
+  eol: null,
   id: Factory.each((id) => `private/${id}`),
   label: Factory.each((i) => `image-${i}`),
   description: 'An image',


### PR DESCRIPTION
## Description 📝

End of life field is set to null in `imageFactory` As our e2e specs are using this factory to build mock data.
This fixes failed 2e2 test `create-linode-from-image.spec.ts`

## How to test 🧪
Navigate to `imageFactory` validate end of life filed

**How do I run relevant unit or e2e tests?**
yarn cypress:debug 
Then run spec file `create-linode-from-image.spec.ts` under Images
