### PR TITLE
Update modal button text

### DIFF
--- a/packages/manager/src/features/Profile/SecretTokenDialog/SecretTokenDialog.tsx
+++ b/packages/manager/src/features/Profile/SecretTokenDialog/SecretTokenDialog.tsx
@@ -29,7 +29,10 @@ const useStyles = makeStyles(() => ({
 
 type CombinedProps = Props;
 
-const renderActions = (onClose: () => void) => (
+const renderActions = (
+  onClose: () => void,
+  modalConfirmationButtonText: string
+) => (
   <ActionsPanel>
     <Button
       buttonType="primary"
@@ -37,7 +40,7 @@ const renderActions = (onClose: () => void) => (
       data-qa-confirm
       data-testid="dialog-confirm"
     >
-      I Have Saved My Keys
+      {modalConfirmationButtonText}
     </Button>
   </ActionsPanel>
 );
@@ -46,7 +49,11 @@ export const SecretTokenDialog: React.FC<CombinedProps> = (props) => {
   const classes = useStyles();
   const { title, value, objectStorageKey, open, onClose } = props;
 
-  const actions = renderActions(onClose);
+  const modalConfirmationButtonText = objectStorageKey
+    ? `I Have Saved My Secret Key`
+    : `I Have Saved My ${title}`;
+
+  const actions = renderActions(onClose, modalConfirmationButtonText);
 
   return (
     <ConfirmationDialog


### PR DESCRIPTION
## Description 📝

Updates the primary button's text to match the appropriate token creation action.
For example, in `Personal Access Token` the button will read "I Have Saved My Personal Access Token"

## Preview 📷
![img-02](https://user-images.githubusercontent.com/119514965/206785218-17a8c41c-9dd4-4d6e-b361-17737a8723d6.jpg)
![img-01](https://user-images.githubusercontent.com/119514965/206785221-7f44edfc-9ddd-4cff-bfc9-ab65185a6ca5.jpg)
![img-00](https://user-images.githubusercontent.com/119514965/206785223-625618a6-d7e8-4e22-b8d0-19b3775ad970.jpg)




## How to test 🧪
* Separate ticket will be written to implement tests.
