### PR TITLE
Unskip DBaaS update test

### DIFF
--- a/packages/manager/cypress/e2e/databases/update-database.spec.ts
+++ b/packages/manager/cypress/e2e/databases/update-database.spec.ts
@@ -251,7 +251,7 @@ describe('Update database clusters', () => {
    * - Confirms that users cannot reset root passwords for provisioning DBs.
    * - Confirms that users cannot change maintenance schedules for provisioning DBs.
    */
-  it.skip('Cannot update database clusters while they are provisioning', () => {
+  it('Cannot update database clusters while they are provisioning', () => {
     const initialLabel = randomLabel();
     const updateAttemptLabel = randomLabel();
     const allowedIp = randomIp();


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
This unskips a DBaaS test that was accidentally skipped during development for M3-6000 (#8634).

## How to test 🧪

**What are the steps to verify the changes?**
In one console, run `yarn dev`. In another, run:

```bash
yarn cy:run -s "cypress/e2e/databases/update-database.spec.ts"
```

And confirm that both tests pass.
