### PR TITLE
M3-4876: Vertically center breadcrumb, Docs, and buttons

### DIFF
--- a/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -309,8 +309,14 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
           <MaintenanceBanner />
         )}
         <Grid container className={classes.root}>
-          <Grid item xs={12}>
+          <Grid item xs={12} style={{ padding: 0 }}>
             <DocumentTitleSegment segment="Linodes" />
+            <LandingHeader
+              title="Linodes"
+              entity="Linode"
+              onAddNew={() => this.props.history.push('/linodes/create')}
+              docsLink="https://www.linode.com/docs/platform/billing-and-support/linode-beginners-guide/"
+            />
             <PreferenceToggle<boolean>
               localStorageKey="GROUP_LINODES"
               preferenceOptions={[false, true]}

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -310,13 +310,6 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
         )}
         <Grid container className={classes.root}>
           <Grid item xs={12} style={{ padding: 0 }}>
-            <DocumentTitleSegment segment="Linodes" />
-            <LandingHeader
-              title="Linodes"
-              entity="Linode"
-              onAddNew={() => this.props.history.push('/linodes/create')}
-              docsLink="https://www.linode.com/docs/platform/billing-and-support/linode-beginners-guide/"
-            />
             <PreferenceToggle<boolean>
               localStorageKey="GROUP_LINODES"
               preferenceOptions={[false, true]}


### PR DESCRIPTION
## Description 📝

Centers the breadcrumb and action items across the app.

## Preview 📷
### Before
![image](https://user-images.githubusercontent.com/115022759/207098867-37bae58a-d28d-462b-8397-93f9007e5107.png)

### After
![image](https://user-images.githubusercontent.com/115022759/207098785-82c53efc-dfb6-4443-bc1a-d4e79c52f64f.png)


## How to test 🧪

Go through the app and verify that the breadcrumb and action buttons at the top of the page are consistent across pages. 
