### PR TITLE
Update the docs search URL

### DIFF
--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -25,7 +25,7 @@ export const CLIENT_ID = process.env.REACT_APP_CLIENT_ID;
 export const DOCS_BASE_URL = 'https://linode.com';
 export const COMMUNITY_BASE_URL = 'https://linode.com/community/';
 export const DOCS_SEARCH_URL =
-  'https://linode.com/docs/search/?sections=guides&q=';
+  'https://www.linode.com/docs/topresults/?docType=products%2Cguides%2Capi%2Creference-architecture&lndq=';
 export const COMMUNITY_SEARCH_URL =
   'https://linode.com/community/questions/search?query=';
 export const ALGOLIA_APPLICATION_ID =


### PR DESCRIPTION
## Description 📝

Updates the `DOCS_SEARCH_URL` constant to use a more recent URL. It now also searches product docs, api docs, and reference architectures in addition to guides. If there is another place where the URL needs to be updated, please make those changes.

## How to test 🧪

Perform a search where the `DOCS_SEARCH_URL` constant is used (likely within the Help & Support section). Use a product related term (such as `NodeBalancers`) and verify that product documentation appears in the search box.

