### PR TITLE
M3-6016: Relocate SMTP restriction notice for better visibility

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation.tsx
@@ -106,24 +106,17 @@ const LinodesDetailNavigation: React.FC<CombinedProps> = (props) => {
       <DocumentTitleSegment
         segment={`${linodeLabel} - ${tabs[getIndex()]?.title ?? 'Detail View'}`}
       />
-      {tabs[getIndex()]?.title === 'Network' ? (
-        <SMTPRestrictionText supportLink={{ label: linodeLabel, id: linodeId }}>
-          {({ text }) =>
-            !hasDismissedBanner && text !== null ? (
-              <Notice
-                warning
-                dismissible
-                onClose={handleDismiss}
-                spacingTop={32}
-              >
-                <Grid item xs={12}>
-                  {text}
-                </Grid>
-              </Notice>
-            ) : null
-          }
-        </SMTPRestrictionText>
-      ) : null}
+      <SMTPRestrictionText supportLink={{ label: linodeLabel, id: linodeId }}>
+        {({ text }) =>
+          !hasDismissedBanner && text !== null ? (
+            <Notice warning dismissible onClose={handleDismiss} spacingTop={32}>
+              <Grid item xs={12}>
+                {text}
+              </Grid>
+            </Notice>
+          ) : null
+        }
+      </SMTPRestrictionText>
       <div style={{ marginTop: 8 }}>
         <Tabs index={getIndex()} onChange={navToURL}>
           <TabLinkList tabs={tabs} />


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
Displays the SMTP restriction notice above the tab set on the linode details page, _regardless_ of which tab is selected. We want to increase the visibility of the dismissible notice, which currently only displays if the user selects the "Network" tab.

## Preview 📷

**Prod:**

https://user-images.githubusercontent.com/114685994/207397061-f80d4974-d0ff-4d9b-aff5-9c6931ffae7f.mov

**This change:**

https://user-images.githubusercontent.com/114685994/207397295-01684bfa-1d24-4d03-b3c0-c532aa857f74.mov

## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**
1. Use an account created (or temporarily modified) to have an activated date of on or after 11/30/22. **Note**: you can also use the MSW, please be aware that the dismissible notice only dismisses until the page is refreshed, at which point it will repopulate. Without mocks, it should permanently dismiss.
2. View the linode details page for any linode. 
3. Click through the tabs in the tab set.
4. Observe that the SMTP restriction notice is visible when each tab is selected, not just the Network tab.
5. (Optional): Dismiss the notice and observe that the notice remains dismissed across all tabs.
