### PR TITLE
Fix Linode landing page tests for non-localhost environments

### DIFF
--- a/packages/manager/cypress/e2e/linodes/smoke-linode-landing-table.spec.ts
+++ b/packages/manager/cypress/e2e/linodes/smoke-linode-landing-table.spec.ts
@@ -1,4 +1,5 @@
 /* eslint-disable sonarjs/no-duplicate-string */
+import { Linode } from '@linode/api-v4/types';
 import { createLinode } from '../../support/api/linodes';
 import {
   containsVisible,
@@ -11,21 +12,29 @@ import { makeResourcePage } from '@src/mocks/serverHandlers';
 import { accountSettingsFactory } from '@src/factories/accountSettings';
 import { routes } from 'cypress/support/ui/constants';
 import { ui } from 'support/ui';
+import { regions, regionsMap } from 'support/constants/regions';
 
-const regions = {
-  'us-west': 'Fremont, CA',
-  'us-southeast': 'Atlanta, GA',
-  'us-east': 'Newark, NJ',
-  'us-central': 'Dallas, TX',
-  'ca-east': 'Toronto, ON',
-};
-const mockLinodes = makeResourcePage(linodeFactory.buildList(5));
-mockLinodes.data.forEach(
-  (linode, index) => (linode.region = Object.keys(regions)[index])
+const mockLinodes = new Array(5).fill(null).map(
+  (item: null, index: number): Linode => {
+    return linodeFactory.build({
+      label: `Linode ${index}`,
+      region: regions[index],
+    });
+  }
 );
 
+const mockLinodesData = makeResourcePage(mockLinodes);
+
+const sortByRegion = (a: Linode, b: Linode) => {
+  return a.region.localeCompare(b.region);
+};
+
+const sortByLabel = (a: Linode, b: Linode) => {
+  return a.label.localeCompare(b.label);
+};
+
 const linodeLabel = (number) => {
-  return mockLinodes.data[number - 1].label;
+  return mockLinodes[number - 1].label;
 };
 
 const deleteLinodeFromActionMenu = (linodeLabel) => {
@@ -57,7 +66,7 @@ describe('linode landing checks', () => {
     }).as('getAccountSettings');
     cy.intercept('GET', '*/profile').as('getProfile');
     cy.intercept('GET', '*/linode/instances/*', (req) => {
-      req.reply(mockLinodes);
+      req.reply(mockLinodesData);
     }).as('getLinodes');
     cy.visitWithLogin('/', { preferenceOverrides });
     cy.wait('@getAccountSettings');
@@ -117,23 +126,29 @@ describe('linode landing checks', () => {
   });
 
   it('checks label and region sorting behavior for linode table', () => {
-    const firstLinodeLabel = mockLinodes.data[0].label;
-    const lastLinodeLabel = mockLinodes.data[4].label;
-    const firstRegionLabel = Object.values(regions)[0];
-    const lastRegionLabel = Object.values(regions)[4];
+    const linodesByLabel = [...mockLinodes.sort(sortByLabel)];
+    const linodesByRegion = [...mockLinodes.sort(sortByRegion)];
+    const linodesLastIndex = mockLinodes.length - 1;
 
-    const checkFirstRow = (linodeLabel) => {
+    const firstLinodeLabel = linodesByLabel[0].label;
+    const lastLinodeLabel = linodesByLabel[linodesLastIndex].label;
+
+    const firstRegionLabel = regionsMap[linodesByRegion[0].region];
+    const lastRegionLabel =
+      regionsMap[linodesByRegion[linodesLastIndex].region];
+
+    const checkFirstRow = (label: string) => {
       getVisible('tr[data-qa-loading="true"]')
         .first()
         .within(() => {
-          containsVisible(linodeLabel);
+          containsVisible(label);
         });
     };
-    const checkLastRow = (linodeLabel) => {
+    const checkLastRow = (label: string) => {
       getVisible('tr[data-qa-loading="true"]')
         .last()
         .within(() => {
-          containsVisible(linodeLabel);
+          containsVisible(label);
         });
     };
 
@@ -143,11 +158,12 @@ describe('linode landing checks', () => {
     checkFirstRow(lastLinodeLabel);
     checkLastRow(firstLinodeLabel);
 
-    checkFirstRow(lastRegionLabel);
-    checkLastRow(firstRegionLabel);
-    getClick('[aria-label="Sort by region"]').click();
+    getClick('[aria-label="Sort by region"]');
     checkFirstRow(firstRegionLabel);
     checkLastRow(lastRegionLabel);
+    getClick('[aria-label="Sort by region"]');
+    checkFirstRow(lastRegionLabel);
+    checkLastRow(firstRegionLabel);
   });
 
   it('checks the create menu dropdown items', () => {
@@ -180,7 +196,7 @@ describe('linode landing checks', () => {
 
   it('checks the table and action menu buttons/labels', () => {
     const label = linodeLabel(1);
-    const ip = mockLinodes.data[0].ipv4[0];
+    const ip = mockLinodes[0].ipv4[0];
     getVisible('[aria-label="Sort by label"]').within(() => {
       fbtVisible('Label');
     });

--- a/packages/manager/cypress/e2e/linodes/smoke-linode-landing-table.spec.ts
+++ b/packages/manager/cypress/e2e/linodes/smoke-linode-landing-table.spec.ts
@@ -24,7 +24,6 @@ mockLinodes.data.forEach(
   (linode, index) => (linode.region = Object.keys(regions)[index])
 );
 
-const appRoot = Cypress.env('REACT_APP_APP_ROOT');
 const linodeLabel = (number) => {
   return mockLinodes.data[number - 1].label;
 };
@@ -63,7 +62,7 @@ describe('linode landing checks', () => {
     cy.visitWithLogin('/', { preferenceOverrides });
     cy.wait('@getAccountSettings');
     cy.wait('@getLinodes');
-    cy.url().should('eq', `${appRoot}${routes.linodeLanding}`);
+    cy.url().should('endWith', routes.linodeLanding);
   });
 
   it('checks the landing page side menu items', () => {


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
This fixes an issue with a test in `smoke-linode-landing-table.spec.ts` which causes it to fail in cases where the test environment is not `localhost:3000`. Also fixes a TypeScript error and does a little bit of refactoring of the test file.

## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**
You can verify that the test continues to pass locally by running `yarn dev` and then:

```bash
yarn cy:run -s "cypress/e2e/linodes/smoke-linode-landing-table.spec.ts"
```

If you want to confirm the fix for non-localhost environments, an easy (but slow) way to do it is by running the tests via Docker:

(You can speed this up a lot by temporarily setting `specPattern` in `cypress.config.ts` to `'cypress/e2e/linodes/smoke-linode-landing-table.spec.ts'` before running the commands below)

```bash
yarn build
docker compose up -d e2e
docker logs -f manager-e2e-1
```

When you're done, you can clean things up with:
```bash
docker compose down e2e
```