### PR TITLE
M3-5170: Filter blocklisted events from Notification Menu

### DIFF
--- a/packages/manager/src/components/NotificationMenu/NotificationMenu.tsx
+++ b/packages/manager/src/components/NotificationMenu/NotificationMenu.tsx
@@ -4,14 +4,12 @@ import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Events from 'src/features/NotificationCenter/Events';
 import { NotificationData } from 'src/features/NotificationCenter/NotificationData/useNotificationData';
-import { NotificationItem } from 'src/features/NotificationCenter/NotificationSection';
 import Notifications from 'src/features/NotificationCenter/Notifications';
 import useDismissibleNotifications from 'src/hooks/useDismissibleNotifications';
 import useNotifications from 'src/hooks/useNotifications';
 import usePrevious from 'src/hooks/usePrevious';
 import { markAllSeen } from 'src/store/events/event.request';
 import { ThunkDispatch } from 'src/store/types';
-import { removeBlocklistedEvents } from 'src/utilities/eventUtils';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -26,35 +24,6 @@ export interface Props {
   open: boolean;
 }
 
-const isNotificationEventObj = (
-  body: string | JSX.Element
-): body is JSX.Element => {
-  return typeof (body as JSX.Element) === typeof {};
-};
-
-/**
- * Filter notifications based on a list of filtered events.
- * NotificationItems may have a body containing a string or an event object.
- */
-const filterNotifications = (eventNotifications: NotificationItem[]) => {
-  // Extract events from notification items.
-  const events = eventNotifications.map((notification: NotificationItem) => {
-    return isNotificationEventObj(notification.body)
-      ? notification.body?.props.event
-      : notification.body;
-  });
-  const filteredEvents = removeBlocklistedEvents(events);
-
-  // Include all notifications that are non-blocklisted events.
-  return eventNotifications.filter((notification) => {
-    return (
-      (isNotificationEventObj(notification.body) &&
-        filteredEvents.includes(notification.body.props.event)) ||
-      !isNotificationEventObj(notification.body)
-    );
-  });
-};
-
 export const NotificationMenu: React.FC<Props> = (props) => {
   const {
     data: { eventNotifications, formattedNotifications },
@@ -67,8 +36,6 @@ export const NotificationMenu: React.FC<Props> = (props) => {
   const dispatch = useDispatch<ThunkDispatch>();
 
   const wasOpen = usePrevious(open);
-
-  const filteredEventNotifications = filterNotifications(eventNotifications);
 
   React.useEffect(() => {
     if (wasOpen && !open) {
@@ -83,7 +50,7 @@ export const NotificationMenu: React.FC<Props> = (props) => {
       {open ? (
         <>
           <Notifications notificationsList={formattedNotifications} />
-          <Events events={filteredEventNotifications} />
+          <Events events={eventNotifications} />
         </>
       ) : null}
     </Paper>

--- a/packages/manager/src/components/NotificationMenu/NotificationMenu.tsx
+++ b/packages/manager/src/components/NotificationMenu/NotificationMenu.tsx
@@ -34,6 +34,7 @@ const isNotificationEventObj = (
 
 /**
  * Filter notifications based on a list of filtered events.
+ * NotificationItems may have a body containing a string or an event object.
  */
 const filterNotifications = (eventNotifications: NotificationItem[]) => {
   // Extract events from notification items.
@@ -67,7 +68,7 @@ export const NotificationMenu: React.FC<Props> = (props) => {
 
   const wasOpen = usePrevious(open);
 
-  const filteredNotifications = filterNotifications(eventNotifications);
+  const filteredEventNotifications = filterNotifications(eventNotifications);
 
   React.useEffect(() => {
     if (wasOpen && !open) {
@@ -82,7 +83,7 @@ export const NotificationMenu: React.FC<Props> = (props) => {
       {open ? (
         <>
           <Notifications notificationsList={formattedNotifications} />
-          <Events events={filteredNotifications} />
+          <Events events={filteredEventNotifications} />
         </>
       ) : null}
     </Paper>

--- a/packages/manager/src/components/NotificationMenu/NotificationMenu.tsx
+++ b/packages/manager/src/components/NotificationMenu/NotificationMenu.tsx
@@ -4,12 +4,14 @@ import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Events from 'src/features/NotificationCenter/Events';
 import { NotificationData } from 'src/features/NotificationCenter/NotificationData/useNotificationData';
+import { NotificationItem } from 'src/features/NotificationCenter/NotificationSection';
 import Notifications from 'src/features/NotificationCenter/Notifications';
 import useDismissibleNotifications from 'src/hooks/useDismissibleNotifications';
 import useNotifications from 'src/hooks/useNotifications';
 import usePrevious from 'src/hooks/usePrevious';
 import { markAllSeen } from 'src/store/events/event.request';
 import { ThunkDispatch } from 'src/store/types';
+import { removeBlocklistedEvents } from 'src/utilities/eventUtils';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -24,6 +26,34 @@ export interface Props {
   open: boolean;
 }
 
+const isNotificationEventObj = (
+  body: string | JSX.Element
+): body is JSX.Element => {
+  return typeof (body as JSX.Element) === typeof {};
+};
+
+/**
+ * Filter notifications based on a list of filtered events.
+ */
+const filterNotifications = (eventNotifications: NotificationItem[]) => {
+  // Extract events from notification items.
+  const events = eventNotifications.map((notification: NotificationItem) => {
+    return isNotificationEventObj(notification.body)
+      ? notification.body?.props.event
+      : notification.body;
+  });
+  const filteredEvents = removeBlocklistedEvents(events);
+
+  // Include all notifications that are non-blocklisted events.
+  return eventNotifications.filter((notification) => {
+    return (
+      (isNotificationEventObj(notification.body) &&
+        filteredEvents.includes(notification.body.props.event)) ||
+      !isNotificationEventObj(notification.body)
+    );
+  });
+};
+
 export const NotificationMenu: React.FC<Props> = (props) => {
   const {
     data: { eventNotifications, formattedNotifications },
@@ -36,6 +66,8 @@ export const NotificationMenu: React.FC<Props> = (props) => {
   const dispatch = useDispatch<ThunkDispatch>();
 
   const wasOpen = usePrevious(open);
+
+  const filteredNotifications = filterNotifications(eventNotifications);
 
   React.useEffect(() => {
     if (wasOpen && !open) {
@@ -50,7 +82,7 @@ export const NotificationMenu: React.FC<Props> = (props) => {
       {open ? (
         <>
           <Notifications notificationsList={formattedNotifications} />
-          <Events events={eventNotifications} />
+          <Events events={filteredNotifications} />
         </>
       ) : null}
     </Paper>

--- a/packages/manager/src/features/NotificationCenter/NotificationData/useEventNotifications.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useEventNotifications.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import useEvents from 'src/hooks/useEvents';
 import { isInProgressEvent } from 'src/store/events/event.helpers';
 import { ExtendedEvent } from 'src/store/events/event.types';
+import { removeBlocklistedEvents } from 'src/utilities/eventUtils';
 import { notificationContext as _notificationContext } from '../NotificationContext';
 import { NotificationItem } from '../NotificationSection';
 import RenderEvent from './RenderEvent';
@@ -19,7 +20,7 @@ const unwantedEvents: EventAction[] = [
 ];
 
 export const useEventNotifications = (givenEvents?: ExtendedEvent[]) => {
-  const events = givenEvents ?? useEvents().events;
+  const events = removeBlocklistedEvents(givenEvents ?? useEvents().events);
   const notificationContext = React.useContext(_notificationContext);
 
   const _events = events.filter(


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
Removes blocklisted events from the NotificationMenu popover, to reach parity with the list of events on the the Events Landing page. Blocklisted events include events like `linode_migrate_datacenter_create`.

## Preview 📷

**Prod:**
![prod-for-m3-5170](https://user-images.githubusercontent.com/114685994/207920892-90c2d013-42bf-4566-a34c-2e6caa4e57de.jpg)

**This branch:**
![branch-for-m3-5170](https://user-images.githubusercontent.com/114685994/207920864-782d1254-55a7-40d9-92ae-0081f3ae031e.jpg)

## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**
1. Create a new nanode or use an existing one.
2. Kick off a migration for the linode.
3. Navigate to the Events Landing page at localhost:3000/events. 
4. Click on the notification icon in the TopMenu and observe that the list of events in the popover notification menu matches the list of events on the Events Landing page.
5. Compare this to prod and observe that in prod, the event for initiating a migration is visible in the popover's event list but not visible on the Events Landing page.

**How do I run relevant unit or e2e tests?**
```
yarn cy:run -s "cypress/e2e/notificationsAndEvents/notifications.spec.ts"
```
```
yarn cy:run -s "cypress/e2e/notificationsAndEvents/events.spec.ts"
```