### PR TITLE
Bugfix/access controls ips fix

### DIFF
--- a/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
@@ -81,15 +81,6 @@ const AddAccessControlDrawer: React.FC<CombinedProps> = (props) => {
 
       return [...acc, ipString];
     }, []);
-      .map(extendedIPToString)
-      .filter((ip) => ip !== '')
-      .map((ip) => {
-        let curr_ip = ip;
-        if (curr_ip.indexOf('/32') === -1) {
-          curr_ip = `${curr_ip}/32`;
-        }
-        return curr_ip;
-      });
 
     updateDatabase({ allow_list: [...allowListRetracted] })
       .then(() => {

--- a/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
@@ -68,9 +68,19 @@ const AddAccessControlDrawer: React.FC<CombinedProps> = (props) => {
     }
   ) => {
     // Get the IP address strings out of the objects and filter empty strings out.
-    const allowListRetracted = _allowList
-      .map(extendedIPToString)
-      .filter((ip) => ip !== '');
+    // Ensure we append /32 to all IPs if not already present, and remove duplicates.
+    const allowListRetracted = new Set(
+      _allowList
+        .map(extendedIPToString)
+        .filter((ip) => ip !== '')
+        .map((ip) => {
+          let temp = ip;
+          if (temp.indexOf('/32') === -1) {
+            temp = `${temp}/32`;
+          }
+          return temp;
+        })
+    );
 
     updateDatabase({ allow_list: [...allowListRetracted] })
       .then(() => {

--- a/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
@@ -68,14 +68,14 @@ const AddAccessControlDrawer: React.FC<CombinedProps> = (props) => {
     }
   ) => {
     // Get the IP address strings out of the objects and filter empty strings out.
-    // Ensure we append /32 to all IPs if not already present.
+    // Ensure we append /32 to all IPs if / is not already present.
     const allowListRetracted = _allowList.reduce((acc, currentIP) => {
       let ipString = extendedIPToString(currentIP);
       if (ipString === '') {
         return acc;
       }
 
-      if (ipString.indexOf('/32') === -1) {
+      if (ipString.indexOf('/') === -1) {
         ipString += '/32';
       }
 

--- a/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
@@ -69,18 +69,16 @@ const AddAccessControlDrawer: React.FC<CombinedProps> = (props) => {
   ) => {
     // Get the IP address strings out of the objects and filter empty strings out.
     // Ensure we append /32 to all IPs if not already present, and remove duplicates.
-    const allowListRetracted = new Set(
-      _allowList
-        .map(extendedIPToString)
-        .filter((ip) => ip !== '')
-        .map((ip) => {
-          let temp = ip;
-          if (temp.indexOf('/32') === -1) {
-            temp = `${temp}/32`;
-          }
-          return temp;
-        })
-    );
+    const allowListRetracted = _allowList
+      .map(extendedIPToString)
+      .filter((ip) => ip !== '')
+      .map((ip) => {
+        let temp = ip;
+        if (temp.indexOf('/32') === -1) {
+          temp = `${temp}/32`;
+        }
+        return temp;
+      });
 
     updateDatabase({ allow_list: [...allowListRetracted] })
       .then(() => {

--- a/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
@@ -68,16 +68,16 @@ const AddAccessControlDrawer: React.FC<CombinedProps> = (props) => {
     }
   ) => {
     // Get the IP address strings out of the objects and filter empty strings out.
-    // Ensure we append /32 to all IPs if not already present, and remove duplicates.
+    // Ensure we append /32 to all IPs if not already present.
     const allowListRetracted = _allowList
       .map(extendedIPToString)
       .filter((ip) => ip !== '')
       .map((ip) => {
-        let temp = ip;
-        if (temp.indexOf('/32') === -1) {
-          temp = `${temp}/32`;
+        let curr_ip = ip;
+        if (curr_ip.indexOf('/32') === -1) {
+          curr_ip = `${curr_ip}/32`;
         }
-        return temp;
+        return curr_ip;
       });
 
     updateDatabase({ allow_list: [...allowListRetracted] })

--- a/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
@@ -69,7 +69,18 @@ const AddAccessControlDrawer: React.FC<CombinedProps> = (props) => {
   ) => {
     // Get the IP address strings out of the objects and filter empty strings out.
     // Ensure we append /32 to all IPs if not already present.
-    const allowListRetracted = _allowList
+    const allowListRetracted = _allowList.reduce((acc, currentIP) => {
+      let ipString = extendedIPToString(currentIP);
+      if (ipString === '') {
+        return acc;
+      }
+
+      if (ipString.indexOf('/32') === -1) {
+        ipString += '/32';
+      }
+
+      return [...acc, ipString];
+    }, []);
       .map(extendedIPToString)
       .filter((ip) => ip !== '')
       .map((ip) => {


### PR DESCRIPTION
## Description 📝

**What does this PR do?**

This PR it ensures `/32` is appended to the end of every IP address in the list.

## Preview 📷

With `/32` filtering enabled:
![Screen Shot 2022-12-15 at 3 42 04 PM](https://user-images.githubusercontent.com/5467060/207990932-f80389cd-0a0c-4e43-a92e-647be957a14c.jpg)

Without `/32` filtering enabled (adding one more IP after reverting the changes):
![Screen Shot 2022-12-15 at 3 44 14 PM](https://user-images.githubusercontent.com/5467060/207991073-c656696e-4657-46d1-99f4-ec3eb787746d.jpg)

## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**

* Navigate to your `/databases` endpoint and create a new database (I used MySQL but it should work for any DB).
* Click the blue **Manage Access Controls** button under the **Summary** tab.
* Add an IP, like 127.0.0.0 and hit Enter right away without clicking **Update Access Controls**
* When the right sidebar collapses, ensure that `/32` is prepended to the newly added IP in the **Summary** tab.

**How do I run relevant unit or e2e tests?**

```
yarn test AccessControls.test
```
