### PR TITLE
M3-5726: Update and Improve PayPal Payment Limits and Logic

### DIFF
--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -334,6 +334,11 @@ export const MOCK_SERVICE_WORKER =
 // Maximum payment methods
 export const MAXIMUM_PAYMENT_METHODS = 6;
 
+// Default payment limits of Braintree payments in USD ($)
+export const PAYMENT_MIN = 5;
+export const PAYMENT_SOFT_MAX = 2_000;
+export const PAYMENT_HARD_MAX = 50_000;
+
 // Price of LKE's High Availability offering in USD
 export const HIGH_AVAILABILITY_PRICE =
   process.env.REACT_APP_LKE_HIGH_AVAILABILITY_PRICE === undefined

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/GooglePayButton.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/GooglePayButton.tsx
@@ -7,11 +7,13 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 import Tooltip from 'src/components/core/Tooltip';
 import Grid from 'src/components/Grid';
 import { PaymentMessage } from 'src/features/Billing/BillingPanels/PaymentInfoPanel/AddPaymentMethodDrawer/AddPaymentMethodDrawer';
+import { getPaymentLimits } from 'src/features/Billing/billingUtils';
 import {
   gPay,
   initGooglePaymentInstance,
 } from 'src/features/Billing/GooglePayProvider';
 import { useScript } from 'src/hooks/useScript';
+import { useAccount } from 'src/queries/account';
 import { useClientToken } from 'src/queries/accountPayment';
 import { SetSuccess } from './types';
 
@@ -61,7 +63,6 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 interface Props {
   transactionInfo: google.payments.api.TransactionInfo;
-  balance: false | number;
   setSuccess: SetSuccess;
   setError: (error: string) => void;
   setProcessing: (processing: boolean) => void;
@@ -76,10 +77,10 @@ export const GooglePayButton: React.FC<Props> = (props) => {
   const [initializationError, setInitializationError] = React.useState<boolean>(
     false
   );
+  const { data: account } = useAccount();
 
   const {
     transactionInfo,
-    balance,
     disabled: disabledDueToProcessing,
     setSuccess,
     setError,
@@ -87,16 +88,10 @@ export const GooglePayButton: React.FC<Props> = (props) => {
     renderError,
   } = props;
 
-  /**
-   * We're following API's validation logic:
-   *
-   * GPay min is $5, max of $2000.
-   * If the customer has a balance over $2000, then the max is $50000
-   */
+  const { min, max } = getPaymentLimits(account?.balance);
+
   const disabledDueToPrice =
-    +transactionInfo.totalPrice < 5 ||
-    (+transactionInfo.totalPrice > 2000 && balance < 2000) ||
-    +transactionInfo.totalPrice > 50000;
+    +transactionInfo.totalPrice < min || +transactionInfo.totalPrice > max;
 
   React.useEffect(() => {
     const init = async () => {
@@ -149,9 +144,7 @@ export const GooglePayButton: React.FC<Props> = (props) => {
     <div className={classes.root}>
       {disabledDueToPrice && (
         <Tooltip
-          title={`Payment amount must be between $5 and ${
-            balance > 2000 ? '$50000' : '$2000'
-          }`}
+          title={`Payment amount must be between $${min} and $${max}`}
           data-qa-help-tooltip
           enterTouchDelay={0}
           leaveTouchDelay={5000}

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PayPalButton.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PayPalButton.tsx
@@ -19,6 +19,8 @@ import { queryClient } from 'src/queries/base';
 import { SetSuccess } from './types';
 import { APIError } from '@linode/api-v4/lib/types';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import { useAccount } from 'src/queries/account';
+import { getPaymentLimits } from 'src/features/Billing/billingUtils';
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -59,6 +61,7 @@ export const PayPalButton: React.FC<Props> = (props) => {
     error: clientTokenError,
   } = useClientToken();
   const [{ options, isPending }, dispatch] = usePayPalScriptReducer();
+  const { data: account } = useAccount();
 
   const {
     usd,
@@ -69,7 +72,9 @@ export const PayPalButton: React.FC<Props> = (props) => {
     renderError,
   } = props;
 
-  const disabledDueToPrice = +usd < 5 || +usd > 10000;
+  const { min, max } = getPaymentLimits(account?.balance);
+
+  const disabledDueToPrice = +usd < min || +usd > max;
 
   React.useEffect(() => {
     /**
@@ -228,7 +233,7 @@ export const PayPalButton: React.FC<Props> = (props) => {
     <div className={classes.root}>
       {disabledDueToPrice && (
         <Tooltip
-          title="Payment amount must be between $5 and $10000"
+          title={`Payment amount must be between $${min} and $${max}`}
           data-qa-help-tooltip
           enterTouchDelay={0}
           leaveTouchDelay={5000}

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PayPalButton.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PayPalButton.tsx
@@ -159,47 +159,45 @@ export const PayPalButton: React.FC<Props> = (props) => {
   ) => {
     setProcessing(true);
 
-    actions.braintree
-      .tokenizePayment(data)
-      .then((payload) => {
-        // send nonce to the Linode API
-        makePayment({
-          nonce: payload.nonce,
-          usd: stateRef!.current!.amount,
-        })
-          .then(({ warnings, usd }) => {
-            queryClient.invalidateQueries(`${accountBillingKey}-payments`);
+    try {
+      const payload = await actions.braintree.tokenizePayment(data);
 
-            setSuccess(
-              `Payment for $${usd} successfully submitted with PayPal`,
-              true,
-              warnings
-            );
-          })
-          .catch((error: APIError[]) => {
-            // Process and surface any Linode API errors during payment
-            const errorText = getAPIErrorOrDefault(
-              error,
-              'Unable to complete PayPal payment.'
-            )[0].reason;
-            setError(errorText);
-            setProcessing(false);
-          });
-      })
-      .catch((error) => {
-        // Process, surface, and log any Braintree errors during payment
-        if (error.statusCode === 'CANCELED') {
-          return;
-        }
-
-        const errorMsg = 'Unable to tokenize PayPal payment.';
-        reportException(
-          'Braintree was unable to tokenize PayPal one time payment.',
-          { error }
-        );
-        setError(errorMsg);
+      // send nonce to the Linode API
+      const response = await makePayment({
+        nonce: payload.nonce,
+        usd: stateRef!.current!.amount,
+      }).catch((error: APIError[]) => {
+        // Process and surface any Linode API errors during payment
+        const errorText = getAPIErrorOrDefault(
+          error,
+          'Unable to complete PayPal payment.'
+        )[0].reason;
+        setError(errorText);
         setProcessing(false);
       });
+      if (response) {
+        queryClient.invalidateQueries(`${accountBillingKey}-payments`);
+
+        setSuccess(
+          `Payment for $${response.usd} successfully submitted with PayPal`,
+          true,
+          response.warnings
+        );
+      }
+    } catch (error) {
+      // Process, surface, and log any Braintree errors during payment
+      if (error.statusCode === 'CANCELED') {
+        return;
+      }
+
+      const errorMsg = 'Unable to tokenize PayPal payment.';
+      reportException(
+        'Braintree was unable to tokenize PayPal one time payment.',
+        { error }
+      );
+      setError(errorMsg);
+      setProcessing(false);
+    }
   };
 
   const onError = (error: any) => {

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
@@ -358,7 +358,6 @@ export const PaymentDrawer: React.FC<Props> = (props) => {
                   countryCode: 'US',
                   totalPrice: usd,
                 }}
-                balance={account?.balance ?? false}
                 disabled={isProcessing}
                 setSuccess={setSuccess}
                 setError={setErrorMessage}

--- a/packages/manager/src/features/Billing/billingUtils.ts
+++ b/packages/manager/src/features/Billing/billingUtils.ts
@@ -51,9 +51,8 @@ export function getPaymentLimits(
     return { min: PAYMENT_MIN, max: PAYMENT_HARD_MAX };
   }
 
-  const min = balance < 5 && balance > 0 ? balance : PAYMENT_MIN;
-
-  const max = balance <= PAYMENT_SOFT_MAX ? PAYMENT_SOFT_MAX : PAYMENT_HARD_MAX;
-
-  return { min, max };
+  return {
+    min: balance < PAYMENT_MIN && balance > 0 ? balance : PAYMENT_MIN,
+    max: balance <= PAYMENT_SOFT_MAX ? PAYMENT_SOFT_MAX : PAYMENT_HARD_MAX,
+  };
 }

--- a/packages/manager/src/features/Billing/billingUtils.ts
+++ b/packages/manager/src/features/Billing/billingUtils.ts
@@ -1,5 +1,10 @@
 import { DateTime } from 'luxon';
-import { AKAMAI_DATE } from 'src/constants';
+import {
+  AKAMAI_DATE,
+  PAYMENT_HARD_MAX,
+  PAYMENT_MIN,
+  PAYMENT_SOFT_MAX,
+} from 'src/constants';
 import { TaxDetail } from 'src/featureFlags';
 import { parseAPIDate } from 'src/utilities/date';
 
@@ -38,3 +43,17 @@ export const getShouldUseAkamaiBilling = (date: string) => {
   const akamaiDate = DateTime.fromSQL(AKAMAI_DATE);
   return invoiceDate > akamaiDate;
 };
+
+export function getPaymentLimits(
+  balance: number | undefined
+): { min: number; max: number } {
+  if (balance === undefined) {
+    return { min: PAYMENT_MIN, max: PAYMENT_HARD_MAX };
+  }
+
+  const min = balance < 5 && balance > 0 ? balance : PAYMENT_MIN;
+
+  const max = balance <= PAYMENT_SOFT_MAX ? PAYMENT_SOFT_MAX : PAYMENT_HARD_MAX;
+
+  return { min, max };
+}


### PR DESCRIPTION
## Description 📝

- Surface any API errors that happen when we make a payment with PayPal 
  -  Previously we just showed a generic error
  - This is important because the API may return something like `{ "errors": [ { "reason": "Maximum amount is $2000.00" } ] }`
- Makes Paypal and Google pay buttons use updated limit logic
  - Ask me for the link to this if you need to see it

## Preview 📷

## Before

https://user-images.githubusercontent.com/115251059/208533774-b2972e0a-cd31-4613-905f-416969e3c841.mov

## After

https://user-images.githubusercontent.com/115251059/208533725-02db67e4-1579-43a3-b78f-2c53b3fc8fd7.mov

## How to test 🧪

- I recommend testing with local development or development environment
- Test one-time payments in the make a payment drawer (`/account/billing/make-payment`)
- Verify logic is correct with internal documentation (ask me for links)
