### PR TITLE
M3-5999: Cloning in Cloud Manager should highlight the Linode to be cloned in the "Select Linode to Clone From" matrix

### DIFF
--- a/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
+++ b/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { useEffect, useState } from 'react';
 import Paper from 'src/components/core/Paper';
 import Tab from 'src/components/core/ReachTab';
 import TabList from 'src/components/core/ReachTabList';
@@ -62,7 +62,7 @@ interface Props {
   initTab?: number;
   bodyClass?: string;
   noPadding?: boolean;
-  handleTabChange?: (index: number) => void;
+  handleTabChange?: () => void;
   value?: number;
   docsLink?: JSX.Element;
 }
@@ -79,10 +79,22 @@ export const TabbedPanel: React.FC<CombinedProps> = (props) => {
     tabs,
     handleTabChange,
     docsLink,
+    initTab,
     ...rest
   } = props;
 
+  const [tabIndex, setTabIndex] = useState(initTab);
+
   const classes = useStyles();
+
+  const tabChangeHandler = (index: number) => {
+    setTabIndex(index);
+    handleTabChange?.();
+  };
+
+  useEffect(() => {
+    if (tabIndex !== initTab) setTabIndex(initTab);
+  }, [initTab]);
 
   return (
     <Paper className={`${classes.root} ${rootClass}`} data-qa-tp={header}>
@@ -112,7 +124,11 @@ export const TabbedPanel: React.FC<CombinedProps> = (props) => {
           </Typography>
         )}
 
-        <Tabs className={classes.tabsWrapper} onChange={handleTabChange}>
+        <Tabs
+          className={classes.tabsWrapper}
+          onChange={tabChangeHandler}
+          index={tabIndex}
+        >
           <TabList className={classes.tabList}>
             {tabs.map((tab, idx) => (
               <Tab className={classes.tab} key={`tabs-${tab.title}-${idx}`}>

--- a/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
+++ b/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
@@ -89,7 +89,9 @@ const [tabIndex, setTabIndex] = useState<number | undefined>(initTab);
 
   const tabChangeHandler = (index: number) => {
     setTabIndex(index);
-    handleTabChange?.();
+    if (handleTabChange) {
+      handleTabChange();
+    }
   };
 
   useEffect(() => {

--- a/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
+++ b/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
@@ -83,7 +83,7 @@ export const TabbedPanel: React.FC<CombinedProps> = (props) => {
     ...rest
   } = props;
 
-  const [tabIndex, setTabIndex] = useState(initTab);
+const [tabIndex, setTabIndex] = useState<number | undefined>(initTab);
 
   const classes = useStyles();
 

--- a/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
+++ b/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
@@ -83,7 +83,7 @@ export const TabbedPanel: React.FC<CombinedProps> = (props) => {
     ...rest
   } = props;
 
-const [tabIndex, setTabIndex] = useState<number | undefined>(initTab);
+  const [tabIndex, setTabIndex] = useState<number | undefined>(initTab);
 
   const classes = useStyles();
 
@@ -95,7 +95,9 @@ const [tabIndex, setTabIndex] = useState<number | undefined>(initTab);
   };
 
   useEffect(() => {
-    if (tabIndex !== initTab) setTabIndex(initTab);
+    if (tabIndex !== initTab) {
+      setTabIndex(initTab);
+    }
   }, [initTab]);
 
   return (

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -609,6 +609,7 @@ export class LinodeCreate extends React.PureComponent<
             types={this.filterTypes()}
             onSelect={this.props.updateTypeID}
             selectedID={this.props.selectedTypeID}
+            linodeID={this.props.selectedLinodeID}
             updateFor={[
               this.props.selectedTypeID,
               this.props.disabledClasses,

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -1,3 +1,4 @@
+import { useSelector } from 'react-redux';
 import {
   LinodeTypeClass,
   BaseType,
@@ -37,6 +38,7 @@ import arrayToList from 'src/utilities/arrayToDelimiterSeparatedList';
 import { convertMegabytesTo } from 'src/utilities/unitConversions';
 import { gpuPlanText } from './utilities';
 import { ExtendedType } from 'src/store/linodeType/linodeType.reducer';
+import { ApplicationState } from 'src/store';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -115,6 +117,7 @@ interface Props {
   error?: string;
   onSelect: (key: string) => void;
   selectedID?: string;
+  linodeID?: number | undefined;
   selectedDiskSize?: number;
   currentPlanHeading?: string;
   disabled?: boolean;
@@ -159,6 +162,7 @@ export const SelectPlanPanel: React.FC<CombinedProps> = (props) => {
     disabled,
     isCreate,
     header,
+    linodeID,
     showTransfer,
     types,
     className,
@@ -166,6 +170,13 @@ export const SelectPlanPanel: React.FC<CombinedProps> = (props) => {
     error,
     docsLink,
   } = props;
+
+  const selectedLinodePlanType = useSelector((state: ApplicationState) => {
+    if (linodeID) {
+      return state?.__resources.linodes.itemsById[linodeID]?.type;
+    }
+    return linodeID;
+  });
 
   const classes = useStyles();
 
@@ -191,7 +202,7 @@ export const SelectPlanPanel: React.FC<CombinedProps> = (props) => {
     let tooltip;
     const planTooSmall = selectedDiskSize > type.disk;
     const isSamePlan =
-      type.heading === currentPlanHeading || type.id === selectedID;
+      type.heading === currentPlanHeading || type.id === selectedLinodePlanType;
     const isGPU = type.class === 'gpu';
     const isDisabledClass = getDisabledClass(type.class);
     const shouldShowTransfer = showTransfer && type.transfer;

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -190,7 +190,8 @@ export const SelectPlanPanel: React.FC<CombinedProps> = (props) => {
       : 0;
     let tooltip;
     const planTooSmall = selectedDiskSize > type.disk;
-    const isSamePlan = type.heading === currentPlanHeading;
+    const isSamePlan =
+      type.heading === currentPlanHeading || type.id === selectedID;
     const isGPU = type.class === 'gpu';
     const isDisabledClass = getDisabledClass(type.class);
     const shouldShowTransfer = showTransfer && type.transfer;

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
@@ -42,6 +42,8 @@ export const FromLinodeContent: React.FC<CombinedProps> = (props) => {
     selectedLinodeID,
     typesData,
     userCannotCreateLinode,
+    updateLinodeID,
+    updateTypeID,
   } = props;
 
   const hasErrorFor = getAPIErrorsFor(errorResources, errors);
@@ -53,7 +55,8 @@ export const FromLinodeContent: React.FC<CombinedProps> = (props) => {
     );
 
     if (linode) {
-      props.updateLinodeID(linode.id, linode.specs.disk);
+      updateLinodeID(linode.id, linode.specs.disk);
+      updateTypeID(linode.type);
     }
   };
 

--- a/packages/manager/src/features/linodes/LinodesCreate/types.ts
+++ b/packages/manager/src/features/linodes/LinodesCreate/types.ts
@@ -139,6 +139,7 @@ export interface CloneFormStateHandlers extends BasicFromContentProps {
   updateDiskSize: (id: number) => void;
   selectedLinodeID?: number;
   updateLinodeID: (id: number, diskSize?: number) => void;
+  updateTypeID: (id: string | null) => void;
 }
 
 /**


### PR DESCRIPTION
## Description 📝

**What does this PR do?**

- In the Plan selection table, default selection to the currently selected Linode's plan
- Add the "Current Plan" chip to the selected Linode's plan 
- Focus the correct tab on the plan selection table.

Addressed this in both cloning and resizing Linode. 

## Preview 📷

https://user-images.githubusercontent.com/119517080/208792119-de97f49c-47a8-43dc-9c73-ac965661a92f.mov




https://user-images.githubusercontent.com/119517080/208792460-e90a5334-4f72-4e62-9c72-c3411258780e.mov


## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**

- Click clone Linode
- Select Linode to be cloned
- Scroll down the page and validate selected tab w.r.t the Linode's plan.

- Click resize Linode
- Scroll down the modal and validate selected tab w.r.t the Linode's plan.

**How do I run relevant unit or e2e tests?**

`yarn cy:run`
