### PR TITLE
Feature/autocomplete ips

### DIFF
--- a/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
@@ -210,14 +210,13 @@ const AddAccessControlDrawer: React.FC<CombinedProps> = (props) => {
 
   // Fills in the active IP field with a new one.  This function is intended to be called when a possible IP is clicked.
   const applyIP = (ip: string) => {
-    // Update the list with the new IP
+    // Find the position in the IP list that needs updating
+    const dashPos = activeIPElement?.id.lastIndexOf('-');
     const pos = Number(
-      activeIPElement?.id?.substring(
-        activeIPElement?.id.length - 1,
-        activeIPElement?.id.length
-      )
+      activeIPElement?.id?.substring(dashPos! + 1, activeIPElement?.id.length)
     );
     // todo: get rid of tempAllowList when we figure out how to cleanly access _allowList from this function
+    // Update the list with the new IP
     tempAllowList[pos].address = `${ip}/32`;
     setValues({ _allowList: tempAllowList });
     return ip;


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
When a user starts typing an IP address in the Access Controls sidebar, a list of possible IPs will be presented on-the-fly.  The user can click the one they'd like without needing to use periods at all.

_Note: this is a proof of concept - styling is still needed to display the solutions in a tabbable, clean overlay above the field.  This way, the user can select possible IPs using their keyboard without having to look/scroll up.  I've created an ordered list for now._

## Preview 📷

Only numeric characters are supported here.  Others (like alphabetic characters) are just ignored.

https://user-images.githubusercontent.com/5467060/209249512-aa96d1a2-baee-4504-9325-285a0150b155.mov

## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**
Create a database, click on `Manage Access Controls`, and start typing in the IP fields to verify the list appears.

**How do I run relevant unit or e2e tests?**
```
yarn test AccessControls.test
```