### PR TITLE
Increase page size to prevent api throttle error

### DIFF
--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCard.test.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCard.test.tsx
@@ -21,7 +21,7 @@ it('Displays formatted expiration date for cards with expiration', () => {
   const creditCardData: CreditCardData = {
     last_four: '1111',
     card_type: 'Visa',
-    expiry: '12/2022',
+    expiry: '12/2023',
   };
 
   const { getByText } = renderWithTheme(

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCard.test.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCard.test.tsx
@@ -28,7 +28,7 @@ it('Displays formatted expiration date for cards with expiration', () => {
     <CreditCard creditCard={creditCardData} />
   );
 
-  expect(getByText('Expires 12/22')).toBeVisible();
+  expect(getByText('Expires 12/23')).toBeVisible();
 });
 
 it('Displays "expired" notice for cards that are expired', () => {

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -146,7 +146,7 @@ const withStackScriptBase = (options: WithStackScriptBaseOptions) => (
         currentPage: page,
       });
 
-      return request({ page, page_size: 25 }, filter)
+      return request({ page, page_size: 500 }, filter)
         .then((response: ResourcePage<StackScript>) => {
           if (!this.mounted) {
             return;

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -146,7 +146,16 @@ const withStackScriptBase = (options: WithStackScriptBaseOptions) => (
         currentPage: page,
       });
 
-      return request({ page, page_size: 500 }, filter)
+      // const currentStackScriptsTab = window.location.pathname;
+
+      return request(
+        {
+          page,
+          page_size:
+            window.location.pathname === '/stackscripts/community' ? 25 : 500,
+        },
+        filter
+      )
         .then((response: ResourcePage<StackScript>) => {
           if (!this.mounted) {
             return;

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -146,8 +146,6 @@ const withStackScriptBase = (options: WithStackScriptBaseOptions) => (
         currentPage: page,
       });
 
-      // const currentStackScriptsTab = window.location.pathname;
-
       return request(
         {
           page,

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -149,8 +149,7 @@ const withStackScriptBase = (options: WithStackScriptBaseOptions) => (
       return request(
         {
           page,
-          page_size:
-            window.location.pathname === '/stackscripts/community' ? 25 : 500,
+          page_size: category === 'community' ? 25 : 500,
         },
         filter
       )


### PR DESCRIPTION
## Description 📝

This PR sets the value of `page_size` to either `25` or `500` based on the current value of `window.location.pathname`. This change helps avoid the API from throttling users who switch routes frequently resulting in a 429 error code from the server.

## Preview 📷
**`page_size=25`**

![page-size-25](https://user-images.githubusercontent.com/119514965/209858910-2ebfbbaf-4716-456c-b82f-c428fb43cf8e.jpg)


**`page_size=500`**

![page-size-500](https://user-images.githubusercontent.com/119514965/209858916-14582dd2-dd9c-43ab-8344-a346e192d673.jpg)


## How to test 🧪
Log into Cloud Manager with a user account that has more than one StackScript. Next navigate to any other page and then quickly return to the StackScripts landing page. User should NOT experience any 429 server codes.

**How do I run relevant unit or e2e tests?**
`yarn test`
