### PR TITLE
M3-6037: Fix Linode clone, delete, and rescue test flake

### DIFF
--- a/packages/manager/cypress/e2e/firewalls/migrate-linode-with-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/firewalls/migrate-linode-with-firewall.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable sonarjs/no-duplicate-string */
-import { clickLinodeActionMenu, createLinode } from '../../support/api/linodes';
-import { deleteFirewallByLabel } from '../../support/api/firewalls';
+import { createLinode } from 'support/api/linodes';
+import { deleteFirewallByLabel } from 'support/api/firewalls';
 import {
   getClick,
   containsClick,
@@ -8,8 +8,9 @@ import {
   getVisible,
   fbtVisible,
   containsVisible,
-} from '../../support/helpers';
-import { selectRegionString } from '../../support/ui/constants';
+} from 'support/helpers';
+import { ui } from 'support/ui';
+import { selectRegionString } from 'support/ui/constants';
 import { randomString } from 'support/util/random';
 
 const fakeRegionsData = {
@@ -214,8 +215,13 @@ describe('Migrate Linode With Firewall', () => {
         cy.contains('PROVISIONING', { timeout: 180000 }).should('not.exist') &&
         cy.contains('BOOTING', { timeout: 180000 }).should('not.exist')
       ) {
-        clickLinodeActionMenu(linode.label);
-        fbtClick('Migrate');
+        ui.actionMenu
+          .findByTitle(`Action menu for Linode ${linode.label}`)
+          .should('be.visible')
+          .click();
+
+        ui.actionMenuItem.findByTitle('Migrate').should('be.visible').click();
+
         containsVisible(`Migrate Linode ${linode.label}`);
         getClick('[data-qa-checked="false"]');
         fbtClick(selectRegionString);

--- a/packages/manager/cypress/e2e/linodes/clone-linode.spec.ts
+++ b/packages/manager/cypress/e2e/linodes/clone-linode.spec.ts
@@ -1,15 +1,12 @@
-import {
-  createLinode,
-  deleteLinodeById,
-  deleteLinodeByLabel,
-} from '../../support/api/linodes';
+import { createLinode } from 'support/api/linodes';
 import {
   containsClick,
   containsVisible,
   fbtClick,
   getClick,
   getVisible,
-} from '../../support/helpers';
+} from 'support/helpers';
+import { ui } from 'support/ui';
 import { assertToast } from '../../support/ui/events';
 
 describe('clone linode', () => {
@@ -24,8 +21,13 @@ describe('clone linode', () => {
         cy.contains('PROVISIONING', { timeout: 180000 }).should('not.exist') &&
         cy.contains('BOOTING', { timeout: 180000 }).should('not.exist')
       ) {
-        getClick(`[aria-label="Action menu for Linode ${linode.label}"]`);
-        containsClick('Clone');
+        ui.actionMenu
+          .findByTitle(`Action menu for Linode ${linode.label}`)
+          .should('be.visible')
+          .click();
+
+        ui.actionMenuItem.findByTitle('Clone').should('be.visible').click();
+
         containsClick('Select a Region');
         containsClick('Newark, NJ');
         getVisible('[data-qa-summary]').within(() => {
@@ -36,7 +38,6 @@ describe('clone linode', () => {
         getClick('[data-qa-deploy-linode="true"]');
         cy.wait('@cloneLinode').then((xhr) => {
           const newLinodeLabel = xhr.response?.body?.label;
-          const newLinodeId = xhr.response?.body?.id;
           assert.equal(xhr.response?.statusCode, 200);
           assertToast(`Your Linode ${newLinodeLabel} is being created.`);
           containsVisible(newLinodeLabel);

--- a/packages/manager/cypress/e2e/linodes/rescue-linode.spec.ts
+++ b/packages/manager/cypress/e2e/linodes/rescue-linode.spec.ts
@@ -1,10 +1,6 @@
-import {
-  createLinode,
-  deleteLinodeById,
-  clickLinodeActionMenu,
-} from '../../support/api/linodes';
-import { fbtClick, fbtVisible, getClick } from '../../support/helpers';
-import { assertToast } from '../../support/ui/events';
+import { createLinode } from 'support/api/linodes';
+import { fbtClick, fbtVisible, getClick } from 'support/helpers';
+import { ui } from 'support/ui';
 
 const rebootInRescueMode = () => {
   fbtClick('Reboot into Rescue Mode');
@@ -20,14 +16,20 @@ describe('rescue linode', () => {
       }).as('postRebootInRescueMode');
       const rescueUrl = `/linodes/${linode.id}`;
       cy.visit(rescueUrl);
-      clickLinodeActionMenu(linode.label);
-      getClick('[data-qa-action-menu-item="Rescue"]:visible');
+      ui.actionMenu
+        .findByTitle(`Action menu for Linode ${linode.label}`)
+        .should('be.visible')
+        .click();
+
+      ui.actionMenuItem.findByTitle('Rescue').should('be.visible').click();
+
       rebootInRescueMode();
       // check mocked response and make sure UI responded correctly
       cy.wait('@postRebootInRescueMode')
         .its('response.statusCode')
         .should('eq', 200);
-      assertToast('Linode rescue started.');
+
+      ui.toast.assertMessage('Linode rescue started.');
     });
   });
 

--- a/packages/manager/cypress/e2e/linodes/smoke-delete-linode.spec.ts
+++ b/packages/manager/cypress/e2e/linodes/smoke-delete-linode.spec.ts
@@ -1,24 +1,27 @@
 /* eslint-disable sonarjs/no-duplicate-string */
-import { createLinode, clickLinodeActionMenu } from '../../support/api/linodes';
-import { containsClick, fbtVisible, getVisible } from '../../support/helpers';
+import { createLinode } from 'support/api/linodes';
+import { containsClick, fbtVisible, getVisible } from 'support/helpers';
+import { ui } from 'support/ui';
 
 describe('delete linode', () => {
-  it('deletes linode from linodes page', () => {
+  it('deletes linode from linode details page', () => {
     createLinode().then((linode) => {
       // catch delete request
       cy.intercept('DELETE', '*/linode/instances/*').as('deleteLinode');
       cy.visitWithLogin(`/linodes/${linode.id}`);
-      clickLinodeActionMenu(linode.label);
+
       // delete linode
-      cy.get('[data-qa-action-menu-item="Delete"]:visible')
+      ui.actionMenu
+        .findByTitle(`Action menu for Linode ${linode.label}`)
         .should('be.visible')
         .click();
+
+      ui.actionMenuItem.findByTitle('Delete').should('be.visible').click();
 
       fbtVisible(linode.label);
       getVisible('[type="button"]').within(() => {
         containsClick('Delete Linode');
       });
-      // cy.get('[data-qa-loading="false"]').should('have.text', 'Delete').click();
 
       // confirm delete
       cy.wait('@deleteLinode').its('response.statusCode').should('eq', 200);
@@ -26,5 +29,5 @@ describe('delete linode', () => {
       cy.findByText(linode.label).should('not.exist');
     });
   });
-  // will add a test for deleting from the dashboard here and maybe one for deleting from linode detail
+  // will add a test for deleting from the dashboard here and maybe one for deleting from linode landing
 });

--- a/packages/manager/cypress/support/api/linodes.ts
+++ b/packages/manager/cypress/support/api/linodes.ts
@@ -7,7 +7,7 @@ import {
 } from './common';
 import { randomLabel, randomString } from 'support/util/random';
 
-import { CreateLinodeRequest } from '@linode/api-v4/lib/linodes/types';
+import { CreateLinodeRequest } from '@linode/api-v4/types';
 import { linodeFactory } from '@src/factories';
 import { makeResourcePage } from '@src/mocks/serverHandlers';
 
@@ -84,8 +84,4 @@ export const deleteAllTestLinodes = () => {
       });
     }
   });
-};
-
-export const clickLinodeActionMenu = (title) => {
-  cy.get(`[aria-label="Action menu for Linode ${title}"]`).click();
 };


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
This fixes some test flake we've been seeing recently involving the action menu on Linode details pages. The underlying issue (involving incorrect `data-valuetext` attribs on the menu items) is still present and can be fixed separately since it has no UX impact.

## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**
Run the affected E2E tests and confirm that they all pass, ideally without any flakiness.

**How do I run relevant unit or e2e tests?**
Run `yarn dev`, then:
```bash
yarn cy:run -s "cypress/e2e/firewalls/migrate-linode-with-firewall.spec.ts,cypress/e2e/linodes/clone-linode.spec.ts,cypress/e2e/linodes/rescue-linode.spec.ts,cypress/e2e/linodes/smoke-delete-linode.spec.ts"
```
