### PR TITLE
Proof of Concept: idle session timeout

### DIFF
--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -73,6 +73,7 @@
     "react-dom": "^17.0.2",
     "react-dropzone": "~11.2.0",
     "react-ga": "^2.5.3",
+    "react-idle-timer": "^5.4.2",
     "react-number-format": "^3.5.0",
     "react-page-visibility": "^6.2.0",
     "react-query": "^3.3.2",

--- a/packages/manager/src/IdleSessionTimer.tsx
+++ b/packages/manager/src/IdleSessionTimer.tsx
@@ -1,0 +1,91 @@
+import { Duration } from 'luxon';
+import * as React from 'react';
+import { useIdleTimer } from 'react-idle-timer';
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
+import ConfirmationDialog from 'src/components/ConfirmationDialog';
+import Typography from 'src/components/core/Typography';
+import usePreferences from 'src/hooks/usePreferences';
+
+// const PROMPT_TIMEOUT_IN_MS = 1000 * 60 * 3; // 3 minutes
+// const MINIMUM_TIMEOUT = 1000 * 60 * 15; // 15 minutes;
+
+// USE THESE VALUES FOR TESTING:
+const PROMPT_TIMEOUT_IN_MS = 1000 * 5; // 5 seconds
+const MINIMUM_TIMEOUT = 1000 * 10; // 10 seconds
+
+const logout = () => {
+  // eslint-disable-next-line scanjs-rules/assign_to_href
+  window.location.href = '/logout';
+};
+
+export const IdleSessionTimer: React.FC<{}> = () => {
+  const { preferences } = usePreferences();
+  const timeoutPreference = preferences?.idle_session_timeout ?? 0;
+
+  const onIdle = () => {
+    logout();
+  };
+
+  const timeout = Math.max(timeoutPreference, MINIMUM_TIMEOUT);
+
+  const idleTimer = useIdleTimer({
+    onIdle,
+    // The overall timeout should equal the value from user preferences.
+    // Overall timeout = timeout + promptTimeout
+    timeout: timeout - PROMPT_TIMEOUT_IN_MS,
+    promptTimeout: PROMPT_TIMEOUT_IN_MS,
+    stopOnIdle: true,
+    crossTab: true,
+    // Disable the timeout if the user has no preference set
+    startManually: timeoutPreference === 0,
+  });
+
+  const [remainingTime, setRemainingTime] = React.useState<number>(0);
+  const getRemainingTime = idleTimer.getRemainingTime;
+  React.useEffect(() => {
+    const timer = setInterval(() => {
+      setRemainingTime(getRemainingTime());
+    }, 1000);
+    return () => {
+      clearInterval(timer);
+    };
+  }, [idleTimer.isIdle, getRemainingTime]);
+
+  // @TODO: Humanize these duration format.
+  const formattedTimeRemaining = Duration.fromMillis(remainingTime).toFormat(
+    'mm:ss'
+  );
+
+  return (
+    <ConfirmationDialog
+      title="Idle Session"
+      open={idleTimer.isPrompted()}
+      onClose={() => {
+        idleTimer.reset();
+      }}
+      actions={
+        <ActionsPanel style={{ padding: 0 }}>
+          <Button buttonType="secondary" onClick={logout}>
+            Log Out
+          </Button>
+          <Button
+            buttonType="primary"
+            onClick={() => {
+              idleTimer.reset();
+            }}
+          >
+            Stay Logged In
+          </Button>
+        </ActionsPanel>
+      }
+    >
+      <Typography>
+        You will be logged out due to inactivity in {formattedTimeRemaining}{' '}
+        minutes.{' '}
+      </Typography>
+    </ConfirmationDialog>
+  );
+};
+
+export default IdleSessionTimer;

--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -38,6 +38,7 @@ import usePreferences from 'src/hooks/usePreferences';
 import { isFeatureEnabled } from 'src/utilities/accountCapabilities';
 import { complianceUpdateContext } from './context/complianceUpdateContext';
 import { FlagSet } from './featureFlags';
+import IdleSessionTimer from './IdleSessionTimer';
 import { UserPreferences } from './store/preferences/preferences.actions';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -317,6 +318,7 @@ const MainContent: React.FC<CombinedProps> = (props) => {
                   >
                     <Grid container spacing={0} className={classes.grid}>
                       <Grid item className={`${classes.switchWrapper} p0`}>
+                        <IdleSessionTimer />
                         <GlobalNotifications />
                         <React.Suspense fallback={<SuspenseLoader />}>
                           <Switch>

--- a/packages/manager/src/features/Profile/AuthenticationSettings/AuthenticationSettings.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/AuthenticationSettings.tsx
@@ -6,17 +6,18 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import ErrorState from 'src/components/ErrorState';
+import Link from 'src/components/Link';
 import Notice from 'src/components/Notice';
 import { useMutateProfile, useProfile } from 'src/queries/profile';
 import { PhoneVerification } from './PhoneVerification/PhoneVerification';
 import ResetPassword from './ResetPassword';
+import SecurityQuestions from './SecurityQuestions';
 import SecuritySettings from './SecuritySettings';
+import SessionTimeoutSettings from './SessionTimeoutSettings';
 import { SMSMessaging } from './SMSMessaging';
 import TPAProviders from './TPAProviders';
 import TrustedDevices from './TrustedDevices';
 import TwoFactor from './TwoFactor';
-import SecurityQuestions from './SecurityQuestions';
-import Link from 'src/components/Link';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -113,6 +114,13 @@ export const AuthenticationSettings: React.FC = () => {
         <Divider spacingTop={22} spacingBottom={16} />
         <Typography variant="h3">SMS Messaging</Typography>
         <SMSMessaging />
+        <Divider spacingTop={22} spacingBottom={16} />
+        <Typography variant="h3">Idle Session Timeout</Typography>
+        <Typography variant="body1" className={classes.copy}>
+          Choose the length of time before Cloud Manager sessions time out due
+          to inactivity.{' '}
+        </Typography>
+        <SessionTimeoutSettings />
         {!isThirdPartyAuthEnabled ? (
           <>
             <Divider spacingTop={22} spacingBottom={16} />

--- a/packages/manager/src/features/Profile/AuthenticationSettings/SessionTimeoutSettings.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/SessionTimeoutSettings.tsx
@@ -1,0 +1,90 @@
+import * as React from 'react';
+import Button from 'src/components/Button';
+import Box from 'src/components/core/Box';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import Select, { Item } from 'src/components/EnhancedSelect/Select';
+import Notice from 'src/components/Notice';
+import usePreferences from 'src/hooks/usePreferences';
+
+export const useStyles = makeStyles((theme: Theme) => ({
+  buttonContainer: {
+    gap: theme.spacing(),
+    [theme.breakpoints.down('sm')]: {
+      marginTop: theme.spacing(2),
+    },
+  },
+}));
+
+const options: Item[] = [
+  { label: '10 seconds', value: 1000 * 10 },
+  { label: '15 minutes ', value: 1000 * 60 * 15 },
+  { label: '30 minutes ', value: 1000 * 60 * 30 },
+  { label: '60 minutes ', value: 1000 * 60 * 60 },
+  { label: 'No timeout', value: 0 },
+];
+
+const SessionTimeoutSettings: React.FC<{}> = () => {
+  const classes = useStyles();
+
+  const {
+    preferences,
+    preferencesLoading,
+    preferencesError,
+    updatePreferences,
+  } = usePreferences();
+
+  const initialSelected =
+    options.find((opt) => opt.value === preferences?.idle_session_timeout) ??
+    options[options.length - 1];
+
+  const [selected, setSelected] = React.useState<Item>(initialSelected);
+  const [changed, setChanged] = React.useState<boolean>(false);
+  const [success, setSuccess] = React.useState<boolean>(false);
+
+  return (
+    <>
+      {preferencesError?.update ? (
+        <Notice spacingTop={16} text="An error occurred" error />
+      ) : null}
+      {success ? (
+        <Notice
+          spacingTop={16}
+          text="Successfully updated your session length"
+          informational
+        />
+      ) : null}
+      <Select
+        options={options}
+        value={selected}
+        isClearable={false}
+        onChange={(selected: Item) => {
+          setChanged(true);
+          setSelected(selected);
+        }}
+      />
+      <Box
+        display="flex"
+        justifyContent="flex-end"
+        className={classes.buttonContainer}
+      >
+        <Button
+          buttonType="primary"
+          disabled={!changed}
+          loading={preferencesLoading}
+          onClick={() => {
+            setChanged(false);
+            updatePreferences({
+              idle_session_timeout: Number(selected.value),
+            }).then(() => {
+              setSuccess(true);
+            });
+          }}
+        >
+          Save
+        </Button>
+      </Box>
+    </>
+  );
+};
+
+export default SessionTimeoutSettings;

--- a/packages/manager/src/hooks/usePreferences.ts
+++ b/packages/manager/src/hooks/usePreferences.ts
@@ -5,10 +5,13 @@ import {
   getUserPreferences,
   updateUserPreferences,
 } from 'src/store/preferences/preferences.requests';
+import { EntityError } from 'src/store/types';
 import { Dispatch } from './types';
 
 export interface Preferences {
   preferences: UserPreferences;
+  preferencesLoading: boolean;
+  preferencesError: EntityError;
   updateUserPreferences: (
     preferences: UserPreferences
   ) => Promise<UserPreferences>;
@@ -17,7 +20,7 @@ export interface Preferences {
 export const usePreferences = () => {
   const dispatch: Dispatch = useDispatch();
   const preferences = useSelector(
-    (state: ApplicationState) => state.preferences.data
+    (state: ApplicationState) => state.preferences
   );
 
   const updatePreferences = (newPreferences: UserPreferences) =>
@@ -28,8 +31,10 @@ export const usePreferences = () => {
     });
 
   return {
-    preferences,
+    preferences: preferences.data,
     updatePreferences,
+    preferencesLoading: preferences.loading,
+    preferencesError: preferences.error,
   };
 };
 

--- a/packages/manager/src/store/preferences/preferences.actions.ts
+++ b/packages/manager/src/store/preferences/preferences.actions.ts
@@ -35,6 +35,7 @@ export interface UserPreferences {
   backups_cta_dismissed?: boolean;
   type_to_confirm?: boolean;
   dismissed_notifications?: Record<string, DismissedNotification>;
+  idle_session_timeout?: number;
 }
 
 export const handleGetPreferences = actionCreator.async<

--- a/yarn.lock
+++ b/yarn.lock
@@ -15000,6 +15000,11 @@ react-ga@^2.5.3:
   resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-2.7.0.tgz#24328f157f31e8cffbf4de74a3396536679d8d7c"
   integrity sha512-AjC7UOZMvygrWTc2hKxTDvlMXEtbmA0IgJjmkhgmQQ3RkXrWR11xEagLGFGaNyaPnmg24oaIiaNPnEoftUhfXA==
 
+react-idle-timer@^5.4.2:
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/react-idle-timer/-/react-idle-timer-5.4.2.tgz#69e20044cf2ecc421aef99cd82298c526d8acf37"
+  integrity sha512-ofCS/qpFjm6ZguEyePvtf9YMDnLj7zZfeLXRWGRpsC6Ga47H4dm7EvoUW8MsozGEGy8zCvPK0Sk6YuAnwLEzRQ==
+
 react-input-autosize@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.2.tgz#fcaa7020568ec206bc04be36f4eb68e647c4d8c2"


### PR DESCRIPTION
## Description 📝

**What does this PR do?**

**NOTE: this is an incomplete proof of concept**

- Adds a new control in My Profile -> Login & Authentication to specify the length of time before an inactive Cloud Manager tab(s) redirect to `/logout`, ending the session. 
- This value is stored in user preferences.
- When Cloud Manager tabs are inactive for the length of time (minus 3 minutes) specified in user preferences, a prompt is displayed saying you will be logged out in 3 minutes.
- If the user does nothing (or clicks the "Logout" button), they are redirect to `/logout`.
- Works across multiple tabs
- Uses a new library, [react-idle-timer](https://idletimer.dev/), to achieve this. 

Still needs:
- More validation / testing
- Some cleanup
- Copy / UX consideration
- ... probably more

## Preview 📷

![Screen Shot 2022-12-29 at 4 49 46 PM](https://user-images.githubusercontent.com/114753608/210014577-a0bbc89e-5599-4ea3-9535-d60ae20318fb.jpg)

![Screen Shot 2022-12-29 at 4 53 55 PM](https://user-images.githubusercontent.com/114753608/210014659-c7110d19-3a8d-4a65-9146-67285928c232.jpg)

## How to test 🧪

- Navigate to http://localhost:3000/profile/auth and change the idle session timeout to "10 seconds" for quicker testing

**How do I run relevant unit or e2e tests?**
No tests yet.
