### PR TITLE
Feature: show login history on Account page

### DIFF
--- a/packages/api-v4/src/account/index.ts
+++ b/packages/api-v4/src/account/index.ts
@@ -15,3 +15,5 @@ export * from './promos';
 export * from './types';
 
 export * from './maintenance';
+
+export * from './logins';

--- a/packages/api-v4/src/account/logins.ts
+++ b/packages/api-v4/src/account/logins.ts
@@ -1,0 +1,32 @@
+import { API_ROOT } from '../constants';
+import Request, { setMethod, setParams, setURL, setXFilter } from '../request';
+import { ResourcePage } from '../types';
+import { AccountLogin } from './types';
+
+/**
+ * getAccountLogins
+ *
+ * Retrieve a paginated list of logins on your account.
+ *
+ */
+export const getAccountLogins = (params?: any, filter?: any) =>
+  Request<ResourcePage<AccountLogin>>(
+    setURL(`${API_ROOT}/account/logins`),
+    setMethod('GET'),
+    setParams(params),
+    setXFilter(filter)
+  );
+
+/**
+ * getAccountLogin
+ *
+ * Retrieve details for a single login.
+ *
+ * @param loginId { number } The ID of the login to be retrieved
+ *
+ */
+export const getAccountLogin = (loginId: number) =>
+  Request<AccountLogin>(
+    setURL(`${API_ROOT}/account/logins/${loginId}`),
+    setMethod('GET')
+  );

--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -452,3 +452,11 @@ export interface MakePaymentData {
   nonce?: string;
   payment_method_id?: number;
 }
+
+export interface AccountLogin {
+  datetime: string;
+  id: number;
+  ip: string;
+  restricted: boolean;
+  username: string;
+}

--- a/packages/manager/src/features/Account/AccountLanding.tsx
+++ b/packages/manager/src/features/Account/AccountLanding.tsx
@@ -14,6 +14,7 @@ import TabLinkList from 'src/components/TabLinkList';
 import { akamaiBillingInvoiceText } from 'src/features/Billing/billingUtils';
 import { useAccount } from 'src/queries/account';
 import { getGrantData, useProfile } from 'src/queries/profile';
+import AccountLogins from './AccountLogins';
 
 const Billing = React.lazy(() => import('src/features/Billing'));
 const EntityTransfersLanding = React.lazy(
@@ -44,6 +45,10 @@ const AccountLanding: React.FC = () => {
     {
       title: 'Users & Grants',
       routeName: '/account/users',
+    },
+    {
+      title: 'Logins',
+      routeName: '/account/logins',
     },
     {
       title: 'Service Transfers',
@@ -134,6 +139,9 @@ const AccountLanding: React.FC = () => {
             </SafeTabPanel>
             <SafeTabPanel index={++idx}>
               <Users isRestrictedUser={profile?.restricted || false} />
+            </SafeTabPanel>
+            <SafeTabPanel index={++idx}>
+              <AccountLogins />
             </SafeTabPanel>
             <SafeTabPanel index={++idx}>
               <EntityTransfersLanding />

--- a/packages/manager/src/features/Account/AccountLanding.tsx
+++ b/packages/manager/src/features/Account/AccountLanding.tsx
@@ -47,8 +47,8 @@ const AccountLanding: React.FC = () => {
       routeName: '/account/users',
     },
     {
-      title: 'Logins',
-      routeName: '/account/logins',
+      title: 'Login History',
+      routeName: '/account/login-history',
     },
     {
       title: 'Service Transfers',

--- a/packages/manager/src/features/Account/AccountLogins.tsx
+++ b/packages/manager/src/features/Account/AccountLogins.tsx
@@ -17,7 +17,6 @@ import { useOrder } from 'src/hooks/useOrder';
 import usePagination from 'src/hooks/usePagination';
 import { useAccountLoginsQuery } from 'src/queries/accountLogins';
 import AccountLoginsTableRow from './AccountLoginsTableRow';
-import Paper from 'src/components/core/Paper';
 
 const preferenceKey = 'account-logins';
 
@@ -27,7 +26,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   copy: {
     lineHeight: '20px',
-    marginTop: theme.spacing(),
+    marginTop: theme.spacing(2),
     marginBottom: theme.spacing(2),
   },
 }));
@@ -69,11 +68,14 @@ const AccountLogins = () => {
           }}
         />
       );
-    } else if (error) {
+    }
+    if (error) {
       return <TableRowError colSpan={5} message={error[0].reason} />;
-    } else if (data?.results == 0) {
+    }
+    if (data?.results == 0) {
       return <TableRowEmptyState message="No account logins" colSpan={6} />;
-    } else if (data) {
+    }
+    if (data) {
       return data.data.map((item: AccountLogin) => (
         <AccountLoginsTableRow key={item.id} {...item} />
       ));
@@ -83,8 +85,7 @@ const AccountLogins = () => {
   };
 
   return (
-    <Paper>
-      <Typography variant="h3">Logins</Typography>
+    <>
       <Typography variant="body1" className={classes.copy}>
         Logins across all users on your account over the last 90 days.
       </Typography>
@@ -135,7 +136,7 @@ const AccountLogins = () => {
         pageSize={pagination.pageSize}
         eventCategory="Account Logins Table"
       />
-    </Paper>
+    </>
   );
 };
 

--- a/packages/manager/src/features/Account/AccountLogins.tsx
+++ b/packages/manager/src/features/Account/AccountLogins.tsx
@@ -32,7 +32,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-const AccountLogins: React.FC<{}> = () => {
+const AccountLogins = () => {
   const classes = useStyles();
   const pagination = usePagination(1, preferenceKey);
 

--- a/packages/manager/src/features/Account/AccountLogins.tsx
+++ b/packages/manager/src/features/Account/AccountLogins.tsx
@@ -75,7 +75,7 @@ const AccountLogins = () => {
       return <TableRowEmptyState message="No account logins" colSpan={6} />;
     } else if (data) {
       return data.data.map((item: AccountLogin) => (
-        <AccountLoginsTableRow key={`${item.id}`} {...item} />
+        <AccountLoginsTableRow key={item.id} {...item} />
       ));
     }
 

--- a/packages/manager/src/features/Account/AccountLogins.tsx
+++ b/packages/manager/src/features/Account/AccountLogins.tsx
@@ -1,0 +1,142 @@
+import { AccountLogin } from '@linode/api-v4/lib/account/types';
+import Typography from 'src/components/core/Typography';
+import * as React from 'react';
+import Hidden from 'src/components/core/Hidden';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import TableBody from 'src/components/core/TableBody';
+import TableHead from 'src/components/core/TableHead';
+import PaginationFooter from 'src/components/PaginationFooter';
+import Table from 'src/components/Table/Table';
+import TableCell from 'src/components/TableCell';
+import TableRow from 'src/components/TableRow/TableRow';
+import TableRowEmptyState from 'src/components/TableRowEmptyState';
+import TableRowError from 'src/components/TableRowError';
+import { TableRowLoading } from 'src/components/TableRowLoading/TableRowLoading';
+import TableSortCell from 'src/components/TableSortCell/TableSortCell';
+import { useOrder } from 'src/hooks/useOrder';
+import usePagination from 'src/hooks/usePagination';
+import { useAccountLoginsQuery } from 'src/queries/accountLogins';
+import AccountLoginsTableRow from './AccountLoginsTableRow';
+import Paper from 'src/components/core/Paper';
+
+const preferenceKey = 'account-logins';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  cell: {
+    width: '12%',
+  },
+  copy: {
+    lineHeight: '20px',
+    marginTop: theme.spacing(),
+    marginBottom: theme.spacing(2),
+  },
+}));
+
+const AccountLogins: React.FC<{}> = () => {
+  const classes = useStyles();
+  const pagination = usePagination(1, preferenceKey);
+
+  const { order, orderBy, handleOrderChange } = useOrder(
+    {
+      orderBy: 'datetime',
+      order: 'desc',
+    },
+    `${preferenceKey}-order}`
+  );
+
+  const filter = {
+    ['+order_by']: orderBy,
+    ['+order']: order,
+  };
+
+  const { data, isLoading, error } = useAccountLoginsQuery(
+    {
+      page: pagination.page,
+      page_size: pagination.pageSize,
+    },
+    filter
+  );
+
+  const renderTableContent = () => {
+    if (isLoading) {
+      return (
+        <TableRowLoading
+          rows={1}
+          columns={4}
+          responsive={{
+            1: { xsDown: true },
+            3: { smDown: true },
+          }}
+        />
+      );
+    } else if (error) {
+      return <TableRowError colSpan={5} message={error[0].reason} />;
+    } else if (data?.results == 0) {
+      return <TableRowEmptyState message="No account logins" colSpan={6} />;
+    } else if (data) {
+      return data.data.map((item: AccountLogin) => (
+        <AccountLoginsTableRow key={`${item.id}`} {...item} />
+      ));
+    }
+
+    return null;
+  };
+
+  return (
+    <Paper>
+      <Typography variant="h3">Logins</Typography>
+      <Typography variant="body1" className={classes.copy}>
+        Logins across all users on your account over the last 90 days.
+      </Typography>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableSortCell
+              active={orderBy === 'datetime'}
+              direction={order}
+              label="datetime"
+              handleClick={handleOrderChange}
+              className={classes.cell}
+            >
+              Date
+            </TableSortCell>
+            <TableSortCell
+              active={orderBy === 'username'}
+              direction={order}
+              label="username"
+              handleClick={handleOrderChange}
+              className={classes.cell}
+            >
+              Username
+            </TableSortCell>
+            <Hidden xsDown>
+              <TableSortCell
+                active={orderBy === 'ip'}
+                direction={order}
+                label="ip"
+                handleClick={handleOrderChange}
+                className={classes.cell}
+              >
+                IP
+              </TableSortCell>
+            </Hidden>
+            <Hidden smDown>
+              <TableCell className={classes.cell}>Permission Level</TableCell>
+            </Hidden>
+          </TableRow>
+        </TableHead>
+        <TableBody>{renderTableContent()}</TableBody>
+      </Table>
+      <PaginationFooter
+        count={data?.results || 0}
+        handlePageChange={pagination.handlePageChange}
+        handleSizeChange={pagination.handlePageSizeChange}
+        page={pagination.page}
+        pageSize={pagination.pageSize}
+        eventCategory="Account Logins Table"
+      />
+    </Paper>
+  );
+};
+
+export default AccountLogins;

--- a/packages/manager/src/features/Account/AccountLogins.tsx
+++ b/packages/manager/src/features/Account/AccountLogins.tsx
@@ -28,6 +28,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     lineHeight: '20px',
     marginTop: theme.spacing(2),
     marginBottom: theme.spacing(2),
+    [theme.breakpoints.down('sm')]: {
+      marginLeft: theme.spacing(2),
+    },
   },
 }));
 

--- a/packages/manager/src/features/Account/AccountLoginsTableRow.tsx
+++ b/packages/manager/src/features/Account/AccountLoginsTableRow.tsx
@@ -1,0 +1,27 @@
+import { AccountLogin } from '@linode/api-v4/lib/account/types';
+import * as React from 'react';
+import Hidden from 'src/components/core/Hidden';
+import TableCell from 'src/components/TableCell';
+import TableRow from 'src/components/TableRow';
+import formatDate from 'src/utilities/formatDate';
+
+const AccountLoginsTableRow: React.FC<AccountLogin> = (props) => {
+  const { datetime, ip, restricted, username, id } = props;
+
+  return (
+    <TableRow key={id}>
+      <TableCell>{formatDate(datetime)}</TableCell>
+      <TableCell noWrap>{username}</TableCell>
+      <Hidden xsDown>
+        <TableCell>{ip}</TableCell>
+      </Hidden>
+      <Hidden smDown>
+        <TableCell noWrap>
+          {restricted ? 'Restricted' : 'Unrestricted'}
+        </TableCell>
+      </Hidden>
+    </TableRow>
+  );
+};
+
+export default AccountLoginsTableRow;

--- a/packages/manager/src/features/Account/AccountLoginsTableRow.tsx
+++ b/packages/manager/src/features/Account/AccountLoginsTableRow.tsx
@@ -1,17 +1,20 @@
 import { AccountLogin } from '@linode/api-v4/lib/account/types';
 import * as React from 'react';
 import Hidden from 'src/components/core/Hidden';
+import Link from 'src/components/Link';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import formatDate from 'src/utilities/formatDate';
 
-const AccountLoginsTableRow: React.FC<AccountLogin> = (props) => {
+const AccountLoginsTableRow = (props: AccountLogin) => {
   const { datetime, ip, restricted, username, id } = props;
 
   return (
     <TableRow key={id}>
       <TableCell>{formatDate(datetime)}</TableCell>
-      <TableCell noWrap>{username}</TableCell>
+      <TableCell noWrap>
+        <Link to={`/account/users/${username}`}>{username}</Link>
+      </TableCell>
       <Hidden xsDown>
         <TableCell>{ip}</TableCell>
       </Hidden>

--- a/packages/manager/src/queries/accountLogins.ts
+++ b/packages/manager/src/queries/accountLogins.ts
@@ -1,0 +1,11 @@
+import { AccountLogin, getAccountLogins } from '@linode/api-v4/lib/account';
+import { APIError, ResourcePage } from '@linode/api-v4/lib/types';
+import { useQuery } from 'react-query';
+
+export const queryKey = 'account-login';
+
+export const useAccountLoginsQuery = (params?: any, filter?: any) =>
+  useQuery<ResourcePage<AccountLogin>, APIError[]>(
+    [`${queryKey}-list`, params, filter],
+    () => getAccountLogins(params, filter)
+  );

--- a/packages/manager/src/queries/accountLogins.ts
+++ b/packages/manager/src/queries/accountLogins.ts
@@ -7,5 +7,8 @@ export const queryKey = 'account-login';
 export const useAccountLoginsQuery = (params?: any, filter?: any) =>
   useQuery<ResourcePage<AccountLogin>, APIError[]>(
     [`${queryKey}-list`, params, filter],
-    () => getAccountLogins(params, filter)
+    () => getAccountLogins(params, filter),
+    {
+      keepPreviousData: true,
+    }
   );


### PR DESCRIPTION
## Description 📝

**What does this PR do?**

This consumes the /account/logins API endpoint and displays the data on a new "Logins" tab/page in the Account section.

I used existing patterns for RQ, API paginated tables, etc.

This still needs to be validated with UX.

## Preview 📷

![Screen Shot 2022-12-30 at 3 05 35 PM](https://user-images.githubusercontent.com/114753608/210108467-c06a0f3e-1901-4bef-8c63-1e1b011c0606.jpg)

## How to test 🧪

- Visit localhost:3000/account/logins. 
- Check error states, loading state, responsiveness, etc. 
- Check sortable table columns
- Try viewing it with a restricted user (you'll receive an "Unauthorized" error from the API)
- Populate it with a variety of data by creating a restricted user on your account and logging in with it

**How do I run relevant unit or e2e tests?**
No unit tests yet.
