### PR TITLE
M3-6034: Fix broken URL in Linode Config Profile edit view

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDialog.tsx
@@ -909,7 +909,7 @@ const LinodeConfigDialog: React.FC<CombinedProps> = (props) => {
                         Interfaces. For more information, see our{' '}
                         <ExternalLink
                           text="Network Interfaces guide"
-                          link="https://linode.com/docs/products/networking/vlans/guides/linode-network-interfaces/"
+                          link="https://www.linode.com/docs/products/networking/vlans/guides/attach-to-compute-instance/#attaching-a-vlan-to-an-existing-compute-instance"
                           hideIcon
                         />
                         .


### PR DESCRIPTION
## Description 📝

This PR fixes a broken from the Linode's Config Profile edit view when the Linode has a VLAN enabled. 


## How to test 🧪

Test that the URL does indeed lead a page that doesn't result in a 404, specifically points to [Attach a VLAN to a Compute Instance | Linode](https://www.linode.com/docs/products/networking/vlans/guides/attach-to-compute-instance/#attaching-a-vlan-to-an-existing-compute-instance.)
