### PR TITLE
M3-6020: Add external link icons to YouTube docs

### DIFF
--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseEmptyState.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseEmptyState.tsx
@@ -76,6 +76,7 @@ const youtubeLinks = (
       <ListItem key={linkData.to}>
         <Link to={linkData.to} onClick={getLinkOnClick(linkData.text)}>
           {linkData.text}
+          <ExternalLinkIcon />
         </Link>
       </ListItem>
     ))}


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
Adds the `<ExternalLinkIcon />` to the YouTube links on the empty state Database Landing page. Maintains consistency with the external links on the empty state Linode Landing page.

## Preview 📷

This branch:
![Screen Shot 2023-01-04 at 12 12 44 PM](https://user-images.githubusercontent.com/114685994/210642799-8502ca53-bc20-4675-8419-7ed2010ec839.jpg)

Prod:
![Screen Shot 2023-01-04 at 12 12 24 PM](https://user-images.githubusercontent.com/114685994/210642835-f08196fa-6451-482c-929b-62b528bbe185.jpg)


## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**

1. Use an account without any existing databases.
2. Navigate to http://localhost:3000/databases. 
3. Observe that the links in the Getting Started Playlist section display the external link icon beside the link text.
4. Adjust window size and confirm no strange spacing issues occur.
5. Confirm that clicking the icon or the link text redirects to external YouTube links.