### PR TITLE
M3-5980: Update text for Akamai-billed customers

### DIFF
--- a/packages/manager/src/components/BillingTooltip.tsx
+++ b/packages/manager/src/components/BillingTooltip.tsx
@@ -6,7 +6,6 @@ import Link from 'src/components/Link';
 
 interface Props {
   text: string;
-  className?: string;
 }
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -21,6 +20,11 @@ const useStyles = makeStyles((theme: Theme) => ({
   flex: {
     display: 'flex',
     width: 'auto !important',
+  },
+  popper: {
+    '& .MuiTooltip-tooltip': {
+      minWidth: 375,
+    },
   },
 }));
 
@@ -46,6 +50,7 @@ export const BillingTooltip: React.FC<Props> = (props) => {
       title={akamaiBillingInvoiceText}
       placement="bottom"
       className={classes.root}
+      classes={{ popper: classes.popper }}
     >
       <Typography>{text}</Typography>
     </ToolTip>

--- a/packages/manager/src/components/BillingTooltip.tsx
+++ b/packages/manager/src/components/BillingTooltip.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import ToolTip from 'src/components/core/Tooltip';
 import Typography from 'src/components/core/Typography';
-import { akamaiBillingInvoiceText } from 'src/features/Billing/billingUtils';
+import Link from 'src/components/Link';
 
 interface Props {
   text: string;
@@ -27,6 +27,18 @@ const useStyles = makeStyles((theme: Theme) => ({
 export const BillingTooltip: React.FC<Props> = (props) => {
   const classes = useStyles();
   const { text } = props;
+  const akamaiBillingInvoiceText = (
+    <Typography>
+      Charges in the final Akamai invoice should be considered the final source
+      of truth. Linode invoice will not reflect discounting, currency
+      adjustment, or any negotiated terms and conditions. Condensed and
+      finalized invoice is available within{' '}
+      <Link to="https://control.akamai.com/apps/billing">
+        Akamai Control Center &gt; Billing
+      </Link>
+      .
+    </Typography>
+  );
 
   return (
     <ToolTip

--- a/packages/manager/src/components/BillingTooltip.tsx
+++ b/packages/manager/src/components/BillingTooltip.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import ToolTip from 'src/components/core/Tooltip';
+import Typography from 'src/components/core/Typography';
+import { akamaiBillingInvoiceText } from 'src/features/Billing/billingUtils';
+
+interface Props {
+  text: string;
+  className?: string;
+}
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    position: 'relative',
+    padding: `4 4 0 4`,
+    backgroundColor: 'transparent',
+    transition: theme.transitions.create(['background-color']),
+    borderRadius: 4,
+    border: 'none',
+    cursor: 'pointer',
+    borderBottom: `1px dotted ${theme.palette.primary.main}`,
+    color: theme.palette.primary.main,
+  },
+  flex: {
+    display: 'flex',
+    width: 'auto !important',
+  },
+}));
+
+export const BillingTooltip: React.FC<Props> = (props) => {
+  const classes = useStyles();
+  const { text } = props;
+
+  return (
+    <ToolTip
+      title={akamaiBillingInvoiceText}
+      placement="bottom"
+      className={classes.root}
+    >
+      <Typography>{text}</Typography>
+    </ToolTip>
+  );
+};
+
+export default BillingTooltip;

--- a/packages/manager/src/components/BillingTooltip.tsx
+++ b/packages/manager/src/components/BillingTooltip.tsx
@@ -12,13 +12,10 @@ interface Props {
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
     position: 'relative',
-    padding: `4 4 0 4`,
-    backgroundColor: 'transparent',
-    transition: theme.transitions.create(['background-color']),
+    padding: 4,
     borderRadius: 4,
-    border: 'none',
     cursor: 'pointer',
-    borderBottom: `1px dotted ${theme.palette.primary.main}`,
+    textDecoration: `underline dotted ${theme.palette.primary.main}`,
     color: theme.palette.primary.main,
   },
   flex: {

--- a/packages/manager/src/components/BillingTooltip.tsx
+++ b/packages/manager/src/components/BillingTooltip.tsx
@@ -42,6 +42,7 @@ export const BillingTooltip: React.FC<Props> = (props) => {
 
   return (
     <ToolTip
+      interactive
       title={akamaiBillingInvoiceText}
       placement="bottom"
       className={classes.root}

--- a/packages/manager/src/components/BillingTooltip.tsx
+++ b/packages/manager/src/components/BillingTooltip.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import ExternalLinkIcon from 'src/assets/icons/external-link.svg';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import ToolTip from 'src/components/core/Tooltip';
 import Typography from 'src/components/core/Typography';
@@ -28,21 +29,22 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
+const akamaiBillingInvoiceText = (
+  <Typography>
+    Charges in the final Akamai invoice should be considered the final source
+    truth. Linode invoice will not reflect discounting, currency adjustment, or
+    any negotiated terms and conditions. Condensed and finalized invoice is
+    available within{' '}
+    <Link to="https://control.akamai.com/apps/billing">
+      Akamai Control Center &gt; Billing <ExternalLinkIcon />
+    </Link>
+    .
+  </Typography>
+);
+
 export const BillingTooltip: React.FC<Props> = (props) => {
   const classes = useStyles();
   const { text } = props;
-  const akamaiBillingInvoiceText = (
-    <Typography>
-      Charges in the final Akamai invoice should be considered the final source
-      of truth. Linode invoice will not reflect discounting, currency
-      adjustment, or any negotiated terms and conditions. Condensed and
-      finalized invoice is available within{' '}
-      <Link to="https://control.akamai.com/apps/billing">
-        Akamai Control Center &gt; Billing
-      </Link>
-      .
-    </Typography>
-  );
 
   return (
     <ToolTip

--- a/packages/manager/src/components/TableContentWrapper/TableContentWrapper.test.tsx
+++ b/packages/manager/src/components/TableContentWrapper/TableContentWrapper.test.tsx
@@ -1,9 +1,6 @@
 import { render } from '@testing-library/react';
 import * as React from 'react';
-import // akamaiInvoiceRow,
-// akamaiRowEmptyState,
-'src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel';
-import { akamaiBillingInvoiceText } from 'src/features/Billing/billingUtils';
+import 'src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel';
 import { wrapWithTableBody } from 'src/utilities/testHelpers';
 import TableContentWrapper from './TableContentWrapper';
 
@@ -15,6 +12,20 @@ const children = [
     <td>Another row!</td>
   </tr>,
 ];
+
+const customEmptyRow = (
+  <tr>
+    <td colSpan={4}>
+      <div> A custom empty row </div>
+    </td>
+  </tr>
+);
+
+const customRow = (
+  <tr>
+    <td> A custom row </td>
+  </tr>
+);
 
 describe('TableContentWrapper component', () => {
   it('should render its children if everything is kosher', () => {
@@ -98,27 +109,27 @@ describe('TableContentWrapper component', () => {
     const emptyProps = {
       loading: false,
       length: 0,
-      // rowEmptyState: akamaiRowEmptyState,
+      rowEmptyState: customEmptyRow,
       children,
     };
 
     const { getByText } = render(
       wrapWithTableBody(<TableContentWrapper {...emptyProps} />)
     );
-    getByText(akamaiBillingInvoiceText);
+    getByText('A custom empty row');
   });
 
   it('should render custom row if it is provided', () => {
     const rowProps = {
       loading: false,
       length: 2,
-      // customFirstRow: akamaiInvoiceRow,
+      customFirstRow: customRow,
       children,
     };
 
     const { getByText } = render(
       wrapWithTableBody(<TableContentWrapper {...rowProps} />)
     );
-    getByText(`Future ${akamaiBillingInvoiceText}`);
+    getByText('A custom row');
   });
 });

--- a/packages/manager/src/components/TableContentWrapper/TableContentWrapper.test.tsx
+++ b/packages/manager/src/components/TableContentWrapper/TableContentWrapper.test.tsx
@@ -1,6 +1,5 @@
 import { render } from '@testing-library/react';
 import * as React from 'react';
-import 'src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel';
 import { wrapWithTableBody } from 'src/utilities/testHelpers';
 import TableContentWrapper from './TableContentWrapper';
 

--- a/packages/manager/src/components/TableContentWrapper/TableContentWrapper.test.tsx
+++ b/packages/manager/src/components/TableContentWrapper/TableContentWrapper.test.tsx
@@ -1,9 +1,8 @@
 import { render } from '@testing-library/react';
 import * as React from 'react';
-import {
-  akamaiInvoiceRow,
-  akamaiRowEmptyState,
-} from 'src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel';
+import // akamaiInvoiceRow,
+// akamaiRowEmptyState,
+'src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel';
 import { akamaiBillingInvoiceText } from 'src/features/Billing/billingUtils';
 import { wrapWithTableBody } from 'src/utilities/testHelpers';
 import TableContentWrapper from './TableContentWrapper';
@@ -99,7 +98,7 @@ describe('TableContentWrapper component', () => {
     const emptyProps = {
       loading: false,
       length: 0,
-      rowEmptyState: akamaiRowEmptyState,
+      // rowEmptyState: akamaiRowEmptyState,
       children,
     };
 
@@ -113,7 +112,7 @@ describe('TableContentWrapper component', () => {
     const rowProps = {
       loading: false,
       length: 2,
-      customFirstRow: akamaiInvoiceRow,
+      // customFirstRow: akamaiInvoiceRow,
       children,
     };
 

--- a/packages/manager/src/features/Account/AccountLanding.tsx
+++ b/packages/manager/src/features/Account/AccountLanding.tsx
@@ -2,8 +2,6 @@ import * as React from 'react';
 import { matchPath, useHistory, useLocation } from 'react-router-dom';
 import TabPanels from 'src/components/core/ReachTabPanels';
 import Tabs from 'src/components/core/ReachTabs';
-import Typography from 'src/components/core/Typography';
-import DismissibleBanner from 'src/components/DismissibleBanner';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import LandingHeader, {
   LandingHeaderProps,
@@ -11,7 +9,6 @@ import LandingHeader, {
 import SafeTabPanel from 'src/components/SafeTabPanel';
 import SuspenseLoader from 'src/components/SuspenseLoader';
 import TabLinkList from 'src/components/TabLinkList';
-import { akamaiBillingInvoiceText } from 'src/features/Billing/billingUtils';
 import { useAccount } from 'src/queries/account';
 import { getGrantData, useProfile } from 'src/queries/profile';
 
@@ -114,14 +111,6 @@ const AccountLanding: React.FC = () => {
   return (
     <React.Fragment>
       <DocumentTitleSegment segment="Account Settings" />
-      {isAkamaiAccount ? (
-        <DismissibleBanner
-          preferenceKey="akamai-account-billing"
-          productInformationIndicator
-        >
-          <Typography>{akamaiBillingInvoiceText}</Typography>
-        </DismissibleBanner>
-      ) : null}
       <LandingHeader {...landingHeaderProps} data-qa-profile-header />
 
       <Tabs index={getDefaultTabIndex()} onChange={handleTabChange}>

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -50,11 +50,16 @@ const useStyles = makeStyles((theme: Theme) => ({
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'space-between',
     [theme.breakpoints.down('xs')]: {
       flexDirection: 'column',
       alignItems: 'flex-start',
     },
+  },
+  headerLeft: {
+    display: 'flex',
+    marginLeft: 10,
+    padding: 5,
+    flexGrow: 2,
   },
   headerRight: {
     display: 'flex',
@@ -317,7 +322,7 @@ export const BillingActivityPanel: React.FC<Props> = (props) => {
           {`${isAkamaiCustomer ? 'Usage' : 'Billing & Payment'} History`}
         </Typography>
         {isAkamaiCustomer ? (
-          <div>
+          <div className={classes.headerLeft}>
             <BillingTooltip text="Usage History may not reflect finalized invoice"></BillingTooltip>
           </div>
         ) : null}

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -6,11 +6,11 @@ import {
 } from '@linode/api-v4/lib/account';
 import { DateTime } from 'luxon';
 import * as React from 'react';
-import Box from 'src/components/core/Box';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
 import Typography from 'src/components/core/Typography';
+import BillingTooltip from 'src/components/BillingTooltip';
 import Currency from 'src/components/Currency';
 import DateTimeDisplay from 'src/components/DateTimeDisplay';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
@@ -24,10 +24,7 @@ import TableCell from 'src/components/TableCell';
 import TableContentWrapper from 'src/components/TableContentWrapper';
 import TableRow from 'src/components/TableRow';
 import { ISO_DATETIME_NO_TZ_FORMAT } from 'src/constants';
-import {
-  akamaiBillingInvoiceText,
-  getShouldUseAkamaiBilling,
-} from 'src/features/Billing/billingUtils';
+import { getShouldUseAkamaiBilling } from 'src/features/Billing/billingUtils';
 import {
   printInvoice,
   printPayment,
@@ -147,30 +144,6 @@ const transactionDateOptions: Item<DateRange>[] = [
   { label: '12 Months', value: '12 Months' },
   { label: 'All Time', value: 'All Time' },
 ];
-
-export const akamaiRowEmptyState = (
-  <TableRow>
-    <TableCell colSpan={4}>
-      <Box
-        style={{ width: '100%', padding: 80 }}
-        alignItems="center"
-        justifyContent="center"
-      >
-        <Typography style={{ textAlign: 'center' }}>
-          <strong>{akamaiBillingInvoiceText}</strong>
-        </Typography>
-      </Box>
-    </TableCell>
-  </TableRow>
-);
-
-export const akamaiInvoiceRow = (
-  <TableRow>
-    <TableCell colSpan={6} style={{ textAlign: 'center' }}>
-      <strong>Future {akamaiBillingInvoiceText}</strong>
-    </TableCell>
-  </TableRow>
-);
 
 const defaultDateRange: DateRange = '6 Months';
 
@@ -341,8 +314,13 @@ export const BillingActivityPanel: React.FC<Props> = (props) => {
     <div className={classes.root}>
       <div className={classes.headerContainer}>
         <Typography variant="h2" className={classes.headline}>
-          Billing &amp; Payment History
+          {`${isAkamaiCustomer ? 'Usage' : 'Billing & Payment'} History`}
         </Typography>
+        {isAkamaiCustomer ? (
+          <div>
+            <BillingTooltip text="Usage History may not reflect finalized invoice"></BillingTooltip>
+          </div>
+        ) : null}
         <div className={classes.headerRight}>
           {accountActiveSince && (
             <div className={classes.flexContainer}>
@@ -436,12 +414,6 @@ export const BillingActivityPanel: React.FC<Props> = (props) => {
                                 },
                               ]
                             : undefined
-                        }
-                        rowEmptyState={
-                          isAkamaiCustomer ? akamaiRowEmptyState : undefined
-                        }
-                        customFirstRow={
-                          isAkamaiCustomer ? akamaiInvoiceRow : undefined
                         }
                       >
                         {paginatedAndOrderedData.map((thisItem) => {

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -59,8 +59,11 @@ const useStyles = makeStyles((theme: Theme) => ({
   headerLeft: {
     display: 'flex',
     marginLeft: 10,
-    padding: 5,
+    paddingLeft: 20,
     flexGrow: 2,
+    [theme.breakpoints.down('xs')]: {
+      paddingLeft: 0,
+    },
   },
   headerRight: {
     display: 'flex',
@@ -324,7 +327,7 @@ export const BillingActivityPanel: React.FC<Props> = (props) => {
         </Typography>
         {isAkamaiCustomer ? (
           <div className={classes.headerLeft}>
-            <BillingTooltip text="Usage History may not reflect finalized invoice"></BillingTooltip>
+            <BillingTooltip text="Usage History may not reflect finalized invoice" />
           </div>
         ) : null}
         <div className={classes.headerRight}>

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -50,6 +50,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',
+    justifyContent: 'space-between',
     [theme.breakpoints.down('xs')]: {
       flexDirection: 'column',
       alignItems: 'flex-start',

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -465,7 +465,6 @@ export const BillingActivityPanel: React.FC<Props> = (props) => {
             accountInvoicesLoading,
             accountPaymentsError,
             accountInvoicesError,
-            isAkamaiCustomer,
             downloadInvoicePDF,
             downloadPaymentPDF,
             pdfErrors,

--- a/packages/manager/src/features/Billing/billingUtils.ts
+++ b/packages/manager/src/features/Billing/billingUtils.ts
@@ -35,8 +35,7 @@ export const renderUnitPrice = (v: null | string) => {
   return Number.isNaN(parsedValue) ? null : `$${parsedValue}`;
 };
 
-export const akamaiBillingInvoiceText =
-  'Linode products and services will appear on your Akamai Technologies invoice.';
+export const akamaiBillingInvoiceText = `Charges in the final Akamai invoice should be considered the final source of truth. Linode invoice will not reflect discounting, currency adjustment, or any negotiated terms and conditions. Condensed and finalized invoice is available within Akamai Control Center > Billing.`;
 
 export const getShouldUseAkamaiBilling = (date: string) => {
   const invoiceDate = parseAPIDate(date);

--- a/packages/manager/src/features/Billing/billingUtils.ts
+++ b/packages/manager/src/features/Billing/billingUtils.ts
@@ -35,8 +35,6 @@ export const renderUnitPrice = (v: null | string) => {
   return Number.isNaN(parsedValue) ? null : `$${parsedValue}`;
 };
 
-export const akamaiBillingInvoiceText = `Charges in the final Akamai invoice should be considered the final source of truth. Linode invoice will not reflect discounting, currency adjustment, or any negotiated terms and conditions. Condensed and finalized invoice is available within Akamai Control Center > Billing.`;
-
 export const getShouldUseAkamaiBilling = (date: string) => {
   const invoiceDate = parseAPIDate(date);
   const akamaiDate = DateTime.fromSQL(AKAMAI_DATE);


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
For _Akamai-billed customers only_, we are making the following changes to the billing information text:
 - Removing the /Account banner that says: "Linode products and services will appear on your Akamai Technologies invoice"
 - Removing the text "Future Linode products and services will appear on your Akamai Technologies invoice" from the  billing table
 - Adding a tooltip to explain invoicing in the billing table with new copy
 - Updating the header of the billing table to correspond with new tooltip copy

## Preview 📷

Previously:


https://user-images.githubusercontent.com/114685994/211042981-70245bc7-6dd6-4410-910d-3626642554a6.mov


This change:


https://user-images.githubusercontent.com/114685994/211069140-b5ca21cb-477d-47b8-8cb1-1698d5dba18e.mov



## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**
1. In `src/factories/account.ts`, change the `billing_source` from `linode` to `akamai` and then turn on the MSW to mock an Akamai-billed account.
2. Navigate to http://localhost:3000/account/billing.
3. Observe there is no dismissible banner about Linode/Akamai invoicing at the top of the page and no custom first row in the table with Linode/Akamai invoicing.
4. Observe that the billing table header copy is "Usage History", a usage history tooltip with a dashed underline displays next to the header, and hovering over tooltip displays updated copy with link below the tooltip. **Note:** Close the notices at the top of the page and zoom out browser window to move the mocked page content far enough from the bottom of the window that the tooltip popover will display underneath the tooltip rather than on top, which is MUI Tooltip default behavior to avoid cutting the popover text off.
5. Adjust the window size and check that the table header components still display neatly with the addition of the tooltip.
6. Turn off MSW and confirm that http://localhost:3000/account/billing displays and behaves like prod. New "usage history" copy changes should not be visible to accounts with a Linode billing source; these accounts did not see the Linode/Akamai invoice banner or custom table text to begin with.

**How do I run relevant unit or e2e tests?**
```
yarn test TableContentWrapper
```