### PR TITLE
M3-4876: Vertically center breadcrumbs

### DIFF
--- a/packages/manager/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/manager/src/components/Breadcrumb/Breadcrumb.tsx
@@ -33,7 +33,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     display: 'flex',
     alignItems: 'center',
     flexWrap: 'wrap',
-    minHeight: 48,
   },
   editablePreContainer: {
     alignItems: 'center',


### PR DESCRIPTION
## Description 📝

Removes a `minHeight` CSS style from the `Breadcrumb` component. This should help visually center the `Breadcrumb` in the on the top of the page.

## Preview 📷

Before:
![image](https://user-images.githubusercontent.com/115022759/211372895-7c24f5f2-f70c-4292-a4ab-703aa7f8703a.png)

After:
![image](https://user-images.githubusercontent.com/115022759/211372993-d6ff39cd-65e4-4e57-ba3f-f2812b86c531.png)


## How to test 🧪

Ensure the Breadcrumbs at the top of the page look vertically centered throughout the app.
