### PR TITLE
Fix E2E Tests for MUIv5, Region Selection Improvements

### DIFF
--- a/packages/manager/cypress/e2e/firewalls/migrate-linode-with-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/firewalls/migrate-linode-with-firewall.spec.ts
@@ -152,7 +152,9 @@ describe('Migrate Linode With Firewall', () => {
     getClick('[data-qa-checked="false"]');
     cy.findByText(`United States: Dallas, TX`).should('be.visible');
     containsClick(selectRegionString);
-    fbtClick('Singapore, SG');
+
+    ui.regionSelect.findItemByRegionName('Singapore, SG').click();
+
     fbtClick('Enter Migration Queue');
     cy.wait('@migrateReq').its('response.statusCode').should('eq', 200);
   });
@@ -225,7 +227,8 @@ describe('Migrate Linode With Firewall', () => {
         containsVisible(`Migrate Linode ${linode.label}`);
         getClick('[data-qa-checked="false"]');
         fbtClick(selectRegionString);
-        fbtClick('Toronto, ON');
+
+        ui.regionSelect.findItemByRegionName('Toronto, ON').click();
         validateMigration();
 
         if (

--- a/packages/manager/cypress/e2e/images/machine-image-upload.spec.ts
+++ b/packages/manager/cypress/e2e/images/machine-image-upload.spec.ts
@@ -4,7 +4,7 @@ import { makeResourcePage } from '@src/mocks/serverHandlers';
 import 'cypress-file-upload';
 import { RecPartial } from 'factory.ts';
 import { DateTime } from 'luxon';
-import { regionsFriendly } from 'support/constants/regions';
+import { regions } from 'support/constants/regions';
 import { fbtClick, fbtVisible, getClick } from 'support/helpers';
 import { ui } from 'support/ui';
 import { interceptOnce } from 'support/ui/common';
@@ -135,13 +135,15 @@ const assertProcessing = (label: string, id: string) => {
  * @param label - Label to apply to uploaded image.
  */
 const uploadImage = (label: string) => {
-  const regionSelect = randomItem(regionsFriendly);
+  const regionId = randomItem(regions);
   const upload = 'testImage.gz';
   cy.visitWithLogin('/images/create/upload');
   getClick('[id="label"][data-testid="textfield-input"]').type(label);
   getClick('[id="description"]').type('This is a machine image upload test');
   fbtClick('Select a Region');
-  fbtClick(regionSelect);
+
+  ui.regionSelect.findItemByRegionId(regionId).click();
+
   // Pass `null` to `cy.fixture()` to ensure file is encoded as a Cypress buffer object.
   cy.fixture(upload, null).then((fileContent) => {
     cy.get('input[type="file"]').attachFile({

--- a/packages/manager/cypress/e2e/stackscripts/create-stackscripts.spec.ts
+++ b/packages/manager/cypress/e2e/stackscripts/create-stackscripts.spec.ts
@@ -80,15 +80,14 @@ const fillOutStackscriptForm = (
  * function does not attempt to submit the filled out form.
  *
  * @param label - Linode label.
- * @param region - Linode region.
+ * @param region - Linode region name.
  */
 const fillOutLinodeForm = (label: string, region: string) => {
   const password = randomString(32);
 
-  cy.findByText('Select a Region')
-    .should('be.visible')
-    .click()
-    .type(`${region}{enter}`);
+  cy.findByText('Select a Region').should('be.visible').click();
+
+  ui.regionSelect.findItemByRegionName(region).click();
 
   cy.findByText('Linode Label')
     .should('be.visible')

--- a/packages/manager/cypress/e2e/stackscripts/create-stackscripts.spec.ts
+++ b/packages/manager/cypress/e2e/stackscripts/create-stackscripts.spec.ts
@@ -49,7 +49,7 @@ const fillOutStackscriptForm = (
   script: string
 ) => {
   // Fill out "StackScript Label", "Description", "Target Images", and "Script" fields.
-  cy.findByLabelText('StackScript Label', { exact: false })
+  cy.findByLabelText(/^StackScript Label.*/)
     .should('be.visible')
     .click()
     .type(label);

--- a/packages/manager/cypress/support/ui/index.ts
+++ b/packages/manager/cypress/support/ui/index.ts
@@ -5,6 +5,7 @@ import * as drawer from './drawer';
 import * as entityHeader from './entity-header';
 import * as heading from './heading';
 import * as nav from './nav';
+import * as select from './select';
 import * as tabList from './tab-list';
 import * as toast from './toast';
 import * as toggle from './toggle';
@@ -17,6 +18,7 @@ export const ui = {
   ...entityHeader,
   ...heading,
   ...nav,
+  ...select,
   ...toast,
   ...tabList,
   ...toggle,

--- a/packages/manager/cypress/support/ui/select.ts
+++ b/packages/manager/cypress/support/ui/select.ts
@@ -1,0 +1,86 @@
+import { regionsMap } from 'support/constants/regions';
+
+/**
+ * UI helpers for Enhanced Select component.
+ */
+export const select = {
+  /**
+   * Finds a Select menu item by its text contents.
+   *
+   * This assumes that the Enhanced Select menu is already open.
+   *
+   * @param text - Text of menu item to find.
+   *
+   * @returns Cypress chainable.
+   */
+  findItemByText: (text: string) => {
+    return cy
+      .get('[data-qa-option]')
+      .contains(text)
+      .scrollIntoView()
+      .should('be.visible');
+  },
+
+  /**
+   * Finds a Select menu item by its `data-qa-option` ID.
+   *
+   * This assumes that the Enhanced Select menu is already open.
+   *
+   * @param id - ID of menu item to find.
+   *
+   * @returns Cypress chainable.
+   */
+  findItemById: (id: string) => {
+    return cy
+      .get(`[data-qa-option="${id}"]`)
+      .scrollIntoView()
+      .should('be.visible');
+  },
+};
+
+/**
+ * UI helpers for region selection Enhanced Select.
+ */
+export const regionSelect = {
+  /**
+   * Finds a Region Select menu item using the ID of a region.
+   *
+   * This assumes that the Region Select menu is already open.
+   *
+   * @param regionId - ID of region for which to find Region Select menu item.
+   *
+   * @returns Cypress chainable.
+   */
+  findItemByRegionId: (regionId: string) => {
+    const regionName = regionsMap[regionId];
+
+    if (!regionName) {
+      throw new Error(`Unable to find a region name for ID '${regionId}'`);
+    }
+
+    return select.findItemByText(`${regionName} (${regionId})`);
+  },
+
+  /**
+   * Finds a Region Select menu item using the name of a region.
+   *
+   * This assumes that the Region Select menu is already open.
+   *
+   * @param regionName - Region name.
+   *
+   * @returns Cypress chainable.
+   */
+  findItemByRegionName: (regionName: string) => {
+    const regionId = Object.keys(regionsMap).find(
+      (regionIdKey) => regionsMap[regionIdKey] === regionName
+    );
+
+    if (!regionId) {
+      throw new Error(
+        `Unable to find a region ID for region name '${regionName}'`
+      );
+    }
+
+    return select.findItemByText(`${regionName} (${regionId})`);
+  },
+};


### PR DESCRIPTION
## Description 📝

**What does this PR do?**

* Fixes the StackScript test failures related to the MUIv5 upgrade
* Fixes the Image, Migration, and StackScript test failures related to the recent region selection improvements

**MUIv5 Fix**

Since upgrading to MUIv5, our `<HelpIcon />` buttons have an `aria-label` attribute containing the contents of the tooltip when it had previously used the `title` attribute. `cy.findByLabelText` checks against `aria-label`, so it was tripping up on that help icon since its content matches our query.

This PR increases the strictness of the selector, matching against any element with a label which begins with "StackScript Label" (case sensitive). Now only the input field will be selected, not the tooltip button.

**Region Selection Fix**

This adds some helpers to make interacting with region selection drop-downs easier. There's still some discussion around these improvements, so if they should change in a breaking way again it'll only require updating these two util functions to fix the affected tests.

## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**

To reproduce, run the command below against `develop`. To confirm the changes, run it against this branch.
```bash
yarn cy:run -s "cypress/e2e/stackscripts/create-stackscripts.spec.ts,cypress/e2e/firewalls/migrate-linode-with-firewall.spec.ts,cypress/e2e/images/machine-image-upload.spec.ts"
```
