### PR TITLE
M3 6045: Add modal content, tabs and validation check

### DIFF
--- a/packages/api-v4/src/index.ts
+++ b/packages/api-v4/src/index.ts
@@ -38,4 +38,9 @@ export * from './databases';
 
 export * from './entity-transfers';
 
-export { baseRequest, setToken, isEmpty } from './request';
+export {
+  baseRequest,
+  setToken,
+  isEmpty,
+  convertYupToLinodeErrors,
+} from './request';

--- a/packages/api-v4/src/request.ts
+++ b/packages/api-v4/src/request.ts
@@ -115,7 +115,7 @@ export const setData = (
  * Attempt to convert a Yup error to our pattern. The only magic here is the recursive call
  * to itself since we have nested structures (think NodeBalancers).
  */
-const convertYupToLinodeErrors = (
+export const convertYupToLinodeErrors = (
   validationError: ValidationError
 ): APIError[] => {
   const { inner } = validationError;

--- a/packages/manager/src/components/Notice/Notice.tsx
+++ b/packages/manager/src/components/Notice/Notice.tsx
@@ -124,6 +124,7 @@ export const useStyles = makeStyles((theme: Theme) => ({
   informationalList: {
     borderLeft: `5px solid ${theme.palette.primary.main}`,
   },
+  marketing: { borderLeft: `5px solid ${theme.palette.status.marketingDark}` },
 }));
 
 interface Props extends GridProps {
@@ -132,6 +133,7 @@ interface Props extends GridProps {
   errorGroup?: string;
   important?: boolean;
   warning?: boolean;
+  marketing?: boolean;
   success?: boolean;
   typeProps?: TypographyProps;
   className?: string;
@@ -161,6 +163,7 @@ const Notice: React.FC<CombinedProps> = (props) => {
     errorGroup,
     warning,
     success,
+    marketing,
     typeProps,
     children,
     flag,
@@ -223,6 +226,7 @@ const Notice: React.FC<CombinedProps> = (props) => {
         [classes.important]: important,
         [errorScrollClassName]: error,
         [classes.breakWords]: breakWords,
+        [classes.marketing]: marketing && !notificationList,
         [classes.error]: error && !notificationList,
         [classes.errorList]: error && notificationList,
         [classes.success]: success && !notificationList,

--- a/packages/manager/src/components/Notice/Notice.tsx
+++ b/packages/manager/src/components/Notice/Notice.tsx
@@ -124,7 +124,6 @@ export const useStyles = makeStyles((theme: Theme) => ({
   informationalList: {
     borderLeft: `5px solid ${theme.palette.primary.main}`,
   },
-  marketing: { borderLeft: `5px solid ${theme.palette.status.marketingDark}` },
 }));
 
 interface Props extends GridProps {
@@ -133,7 +132,6 @@ interface Props extends GridProps {
   errorGroup?: string;
   important?: boolean;
   warning?: boolean;
-  marketing?: boolean;
   success?: boolean;
   typeProps?: TypographyProps;
   className?: string;
@@ -163,7 +161,6 @@ const Notice: React.FC<CombinedProps> = (props) => {
     errorGroup,
     warning,
     success,
-    marketing,
     typeProps,
     children,
     flag,
@@ -226,7 +223,6 @@ const Notice: React.FC<CombinedProps> = (props) => {
         [classes.important]: important,
         [errorScrollClassName]: error,
         [classes.breakWords]: breakWords,
-        [classes.marketing]: marketing && !notificationList,
         [classes.error]: error && !notificationList,
         [classes.errorList]: error && notificationList,
         [classes.success]: success && !notificationList,

--- a/packages/manager/src/features/linodes/LinodesCreate/ApiAwarenessModal/index.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/ApiAwarenessModal/index.test.tsx
@@ -9,6 +9,7 @@ import ApiAwarenessModal, { Props } from '.';
 const defaultProps: Props = {
   isOpen: false,
   onClose: jest.fn(),
+  label: '',
   route: '',
 };
 

--- a/packages/manager/src/features/linodes/LinodesCreate/ApiAwarenessModal/index.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/ApiAwarenessModal/index.test.tsx
@@ -9,6 +9,7 @@ import ApiAwarenessModal, { Props } from '.';
 const defaultProps: Props = {
   isOpen: false,
   onClose: jest.fn(),
+  route: '',
 };
 
 const renderComponent = (overrideProps?: Partial<Props>) => {

--- a/packages/manager/src/features/linodes/LinodesCreate/ApiAwarenessModal/index.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/ApiAwarenessModal/index.test.tsx
@@ -9,7 +9,7 @@ import ApiAwarenessModal, { Props } from '.';
 const defaultProps: Props = {
   isOpen: false,
   onClose: jest.fn(),
-  label: '',
+  label: 'debian-us-central',
   route: '',
 };
 
@@ -25,12 +25,12 @@ describe('ApiAwarenessModal', () => {
   it('Should not render ApiAwarenessModal componet', () => {
     renderComponent();
     expect(
-      screen.queryByText('Create using command line')
+      screen.queryByText('Create Linode debian-us-central using command line')
     ).not.toBeInTheDocument();
   });
   it('Should render ApiAwarenessModal componet when enabled', () => {
     renderComponent({ isOpen: true });
-    screen.getByText('Create using command line');
+    screen.getByText('Create Linode debian-us-central using command line');
   });
   it('Should invoke onClose handler upon cliking close button', () => {
     renderComponent({ isOpen: true });

--- a/packages/manager/src/features/linodes/LinodesCreate/ApiAwarenessModal/index.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/ApiAwarenessModal/index.tsx
@@ -4,16 +4,61 @@ import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import Dialog from 'src/components/Dialog';
 import ExternalLink from 'src/components/ExternalLink';
-
+import SafeTabPanel from 'src/components/SafeTabPanel';
+import TabLinkList from 'src/components/TabLinkList';
 import Typography from 'src/components/core/Typography';
+import Notice from 'src/components/Notice';
+
+import { makeStyles } from 'src/components/core/styles';
+import Tabs from 'src/components/core/ReachTabs';
+import TabPanels from 'src/components/core/ReachTabPanels';
+
+import { sendEvent } from 'src/utilities/ga';
+
+const useStyles = makeStyles(() => ({
+  guides: {
+    marginTop: 16,
+  },
+}));
 
 export interface Props {
   isOpen: boolean;
   onClose: () => void;
+  route: string;
 }
 
+const fireGAEvent = (action: string) => {
+  sendEvent({
+    action: action,
+    category: 'API CLI Awareness Contextual Help',
+  });
+};
+
 const ApiAwarenessModal = (props: Props) => {
-  const { isOpen, onClose } = props;
+  const { isOpen, onClose, route } = props;
+
+  const classes = useStyles();
+
+  const tabs = [
+    {
+      title: 'cURL',
+      type: 'API',
+      routeName: route,
+    },
+    {
+      title: 'Linode CLI',
+      type: 'CLI',
+      routeName: route,
+    },
+  ];
+
+  const handleTabChange = (index: number) => {
+    sendEvent({
+      category: 'API CLI Awareness',
+      action: `Click: ${tabs[index].type} Tab`,
+    });
+  };
+
   return (
     <Dialog
       title="Create using command line"
@@ -25,6 +70,7 @@ const ApiAwarenessModal = (props: Props) => {
       <Typography variant="body1">
         You&#39;ll first need to{' '}
         <ExternalLink
+          onClick={() => fireGAEvent('Click: Creatre API Access Token Link')}
           link="/profile/tokens"
           text="create an API access token"
           hideIcon
@@ -32,18 +78,68 @@ const ApiAwarenessModal = (props: Props) => {
         then save your existing token to an environment variable or substitue it
         into the command. Read our guides to learn about creating{' '}
         <ExternalLink
+          onClick={() => fireGAEvent('Click: API Access Token Link')}
           link="https://www.linode.com/docs/api/profile/#personal-access-token-create"
           text=" API access tokens"
           hideIcon
         />{' '}
         and Linodes using the{' '}
         <ExternalLink
+          onClick={() => fireGAEvent('Click: Linode API Link')}
           link="https://www.linode.com/docs/api/"
           text="Linode API"
           hideIcon
         />
         .
       </Typography>
+      <Tabs defaultIndex={0} onChange={handleTabChange}>
+        <TabLinkList tabs={tabs} />
+        <TabPanels>
+          <SafeTabPanel index={0}>cRUL Pannel</SafeTabPanel>
+          <SafeTabPanel index={1}>
+            Linode CLI Pannel
+            <Typography className={classes.guides} variant="h2">
+              Guides
+            </Typography>
+            <Typography>
+              <ExternalLink
+                onClick={() =>
+                  fireGAEvent(
+                    'Click: Install and Configure the Linode CLI Link'
+                  )
+                }
+                link="https://www.linode.com/docs/products/tools/cli/get-started/#installing-the-linode-cli"
+                text="Install and Configure the Linode CLI"
+                hideIcon
+              />
+            </Typography>
+            <Typography>
+              <ExternalLink
+                onClick={() => fireGAEvent('Click: Using The Linode CLI Link')}
+                link="https://www.linode.com/docs/products/tools/cli/get-started/#basic-usage"
+                text="Using the Linode CLI"
+                hideIcon
+              />
+            </Typography>
+          </SafeTabPanel>
+        </TabPanels>
+      </Tabs>
+      <Notice marketing spacingTop={16} spacingBottom={16}>
+        <Typography>
+          Check out our{' '}
+          <ExternalLink
+            onClick={() =>
+              fireGAEvent('Click: Collection Of Integrations Link')
+            }
+            link="https://www.linode.com/docs/products/tools/api/developers/#linode-developedsupported-tools"
+            text="collection of integrations"
+            hideIcon
+          />{' '}
+          such as Terraform and Ansible that allow you to connect infrastructure
+          and dev tools to the Linode platform. Manage your Linode resources
+          using the tools you know and love.
+        </Typography>
+      </Notice>
 
       <ActionsPanel>
         <Button

--- a/packages/manager/src/features/linodes/LinodesCreate/ApiAwarenessModal/index.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/ApiAwarenessModal/index.tsx
@@ -24,6 +24,7 @@ const useStyles = makeStyles(() => ({
 export interface Props {
   isOpen: boolean;
   onClose: () => void;
+  label: string;
   route: string;
 }
 
@@ -35,7 +36,7 @@ const fireGAEvent = (action: string) => {
 };
 
 const ApiAwarenessModal = (props: Props) => {
-  const { isOpen, onClose, route } = props;
+  const { isOpen, label, onClose, route } = props;
 
   const classes = useStyles();
 
@@ -61,7 +62,7 @@ const ApiAwarenessModal = (props: Props) => {
 
   return (
     <Dialog
-      title="Create using command line"
+      title={`Create using command line ${label}`}
       open={isOpen}
       onClose={onClose}
       maxWidth={'sm'}

--- a/packages/manager/src/features/linodes/LinodesCreate/ApiAwarenessModal/index.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/ApiAwarenessModal/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import Dialog from 'src/components/Dialog';
@@ -8,11 +7,9 @@ import SafeTabPanel from 'src/components/SafeTabPanel';
 import TabLinkList from 'src/components/TabLinkList';
 import Typography from 'src/components/core/Typography';
 import Notice from 'src/components/Notice';
-
 import { makeStyles } from 'src/components/core/styles';
 import Tabs from 'src/components/core/ReachTabs';
 import TabPanels from 'src/components/core/ReachTabPanels';
-
 import { sendEvent } from 'src/utilities/ga';
 
 const useStyles = makeStyles(() => ({
@@ -66,9 +63,8 @@ const ApiAwarenessModal = (props: Props) => {
       open={isOpen}
       onClose={onClose}
       maxWidth={'sm'}
-      fullHeight
     >
-      <Typography variant="body1">
+      <Typography variant="body1" style={{ paddingTop: '16px' }}>
         You&#39;ll first need to{' '}
         <ExternalLink
           onClick={() => fireGAEvent('Click: Create API Access Token Link')}
@@ -93,9 +89,13 @@ const ApiAwarenessModal = (props: Props) => {
         />
         .
       </Typography>
-      <Tabs defaultIndex={0} onChange={handleTabChange}>
+      <Tabs
+        defaultIndex={0}
+        onChange={handleTabChange}
+        style={{ marginTop: '14px' }}
+      >
         <TabLinkList tabs={tabs} />
-        <TabPanels>
+        <TabPanels style={{ paddingBottom: '24px', paddingTop: '16px' }}>
           <SafeTabPanel index={0}>Code block API component WIP...</SafeTabPanel>
           <SafeTabPanel index={1}>
             Code block CLI component WIP...
@@ -125,7 +125,7 @@ const ApiAwarenessModal = (props: Props) => {
           </SafeTabPanel>
         </TabPanels>
       </Tabs>
-      <Notice marketing spacingTop={16} spacingBottom={16}>
+      <Notice success spacingBottom={16}>
         <Typography>
           Check out our{' '}
           <ExternalLink
@@ -142,7 +142,7 @@ const ApiAwarenessModal = (props: Props) => {
         </Typography>
       </Notice>
 
-      <ActionsPanel>
+      <ActionsPanel style={{ marginTop: '0px', paddingTop: '4px' }}>
         <Button
           buttonType="secondary"
           onClick={onClose}

--- a/packages/manager/src/features/linodes/LinodesCreate/ApiAwarenessModal/index.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/ApiAwarenessModal/index.tsx
@@ -95,9 +95,9 @@ const ApiAwarenessModal = (props: Props) => {
       <Tabs defaultIndex={0} onChange={handleTabChange}>
         <TabLinkList tabs={tabs} />
         <TabPanels>
-          <SafeTabPanel index={0}>cRUL Pannel</SafeTabPanel>
+          <SafeTabPanel index={0}>Code block API component WIP...</SafeTabPanel>
           <SafeTabPanel index={1}>
-            Linode CLI Pannel
+            Code block CLI component WIP...
             <Typography className={classes.guides} variant="h2">
               Guides
             </Typography>

--- a/packages/manager/src/features/linodes/LinodesCreate/ApiAwarenessModal/index.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/ApiAwarenessModal/index.tsx
@@ -13,6 +13,10 @@ import TabPanels from 'src/components/core/ReachTabPanels';
 import { sendEvent } from 'src/utilities/ga';
 
 const useStyles = makeStyles(() => ({
+  cancelButtonStyles: {
+    justifyContent: 'right',
+    paddingRight: '4px',
+  },
   guides: {
     marginTop: 16,
   },
@@ -159,6 +163,7 @@ const ApiAwarenessModal = (props: Props) => {
       <ActionsPanel className={classes.actionPanelStyles}>
         <Button
           buttonType="secondary"
+          className={classes.cancelButtonStyles}
           onClick={onClose}
           data-testid="close-button"
         >

--- a/packages/manager/src/features/linodes/LinodesCreate/ApiAwarenessModal/index.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/ApiAwarenessModal/index.tsx
@@ -16,6 +16,20 @@ const useStyles = makeStyles(() => ({
   guides: {
     marginTop: 16,
   },
+  modalIntroTypoClass: {
+    paddingTop: '16px',
+  },
+  tabsStyles: {
+    marginTop: '14px',
+  },
+  tabPanelStyles: {
+    paddingBottom: '24px',
+    paddingTop: '16px',
+  },
+  actionPanelStyles: {
+    marginTop: '0px',
+    paddingTop: '4px',
+  },
 }));
 
 export interface Props {
@@ -64,7 +78,7 @@ const ApiAwarenessModal = (props: Props) => {
       onClose={onClose}
       maxWidth={'sm'}
     >
-      <Typography variant="body1" style={{ paddingTop: '16px' }}>
+      <Typography variant="body1" className={classes.modalIntroTypoClass}>
         You&#39;ll first need to{' '}
         <ExternalLink
           onClick={() => fireGAEvent('Click: Create API Access Token Link')}
@@ -92,10 +106,10 @@ const ApiAwarenessModal = (props: Props) => {
       <Tabs
         defaultIndex={0}
         onChange={handleTabChange}
-        style={{ marginTop: '14px' }}
+        className={classes.tabsStyles}
       >
         <TabLinkList tabs={tabs} />
-        <TabPanels style={{ paddingBottom: '24px', paddingTop: '16px' }}>
+        <TabPanels className={classes.tabPanelStyles}>
           <SafeTabPanel index={0}>Code block API component WIP...</SafeTabPanel>
           <SafeTabPanel index={1}>
             Code block CLI component WIP...
@@ -142,7 +156,7 @@ const ApiAwarenessModal = (props: Props) => {
         </Typography>
       </Notice>
 
-      <ActionsPanel style={{ marginTop: '0px', paddingTop: '4px' }}>
+      <ActionsPanel className={classes.actionPanelStyles}>
         <Button
           buttonType="secondary"
           onClick={onClose}

--- a/packages/manager/src/features/linodes/LinodesCreate/ApiAwarenessModal/index.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/ApiAwarenessModal/index.tsx
@@ -62,7 +62,7 @@ const ApiAwarenessModal = (props: Props) => {
 
   return (
     <Dialog
-      title={`Create using command line ${label}`}
+      title={`Create Linode ${label} using command line`}
       open={isOpen}
       onClose={onClose}
       maxWidth={'sm'}

--- a/packages/manager/src/features/linodes/LinodesCreate/ApiAwarenessModal/index.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/ApiAwarenessModal/index.tsx
@@ -71,7 +71,7 @@ const ApiAwarenessModal = (props: Props) => {
       <Typography variant="body1">
         You&#39;ll first need to{' '}
         <ExternalLink
-          onClick={() => fireGAEvent('Click: Creatre API Access Token Link')}
+          onClick={() => fireGAEvent('Click: Create API Access Token Link')}
           link="/profile/tokens"
           text="create an API access token"
           hideIcon

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -149,7 +149,7 @@ interface Props {
   togglePrivateIPEnabled: () => void;
   updateTags: (tags: Tag[]) => void;
   handleSubmitForm: HandleSubmit;
-  runValidation: LinodeCreateValidation;
+  checkValidation: LinodeCreateValidation;
   resetCreationState: () => void;
   setBackupID: (id: number) => void;
   showGeneralError?: boolean;
@@ -157,7 +157,9 @@ interface Props {
   ipamAddress: string | null;
   handleVLANChange: (updatedInterface: Interface) => void;
   showAgreement: boolean;
+  showApiAwarenessModal: boolean;
   handleAgreementChange: () => void;
+  handleShowApiAwarenessModal: () => void;
   signedAgreement: boolean;
 }
 
@@ -198,7 +200,6 @@ interface State {
   selectedTab: number;
   stackScriptSelectedTab: number;
   planKey: string;
-  isApiAwarenessModalOpen: boolean;
 }
 
 interface CreateTab extends Tab {
@@ -243,7 +244,6 @@ export class LinodeCreate extends React.PureComponent<
           ? 1
           : 0,
       planKey: v4(),
-      isApiAwarenessModalOpen: false,
     };
   }
 
@@ -379,7 +379,7 @@ export class LinodeCreate extends React.PureComponent<
     this.props.handleSubmitForm(payload, this.props.selectedLinodeID);
   };
 
-  setIsApiAwarenessModalOpen = (value: boolean) => {
+  handleClickCreateUsingCommandLine = () => {
     const payload = {
       image: this.props.selectedImageID,
       region: this.props.selectedRegionID,
@@ -401,13 +401,8 @@ export class LinodeCreate extends React.PureComponent<
       stackscript_id: this.props.selectedStackScriptID,
       stackscript_data: this.props.selectedUDFs,
     };
-    this.props.runValidation(payload);
-    if (!this.props.errors) {
-      this.setState({ ...this.state, isApiAwarenessModalOpen: false });
-    }
+    this.props.checkValidation(payload);
   };
-
-  //Run validation
 
   render() {
     const { selectedTab, stackScriptSelectedTab } = this.state;
@@ -444,7 +439,9 @@ export class LinodeCreate extends React.PureComponent<
       accountBackupsEnabled,
       showGeneralError,
       showAgreement,
+      showApiAwarenessModal,
       handleAgreementChange,
+      handleShowApiAwarenessModal,
       signedAgreement,
       ...rest
     } = this.props;
@@ -773,7 +770,7 @@ export class LinodeCreate extends React.PureComponent<
               <Button
                 data-qa-api-cli-linode
                 buttonType="outlined"
-                onClick={() => this.setIsApiAwarenessModalOpen(true)}
+                onClick={this.handleClickCreateUsingCommandLine}
                 className={classes.createButton}
                 disabled={
                   formIsSubmitting ||
@@ -798,8 +795,8 @@ export class LinodeCreate extends React.PureComponent<
                 Create Linode
               </Button>
               <ApiAwarenessModal
-                isOpen={this.state.isApiAwarenessModalOpen}
-                onClose={() => this.setIsApiAwarenessModalOpen(false)}
+                isOpen={showApiAwarenessModal}
+                onClose={handleShowApiAwarenessModal}
                 route={this.props.match.url}
               />
             </div>

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -60,6 +60,7 @@ import {
   Info,
   ReduxStateProps,
   ReduxStatePropsAndSSHKeys,
+  LinodeCreateValidation,
   StackScriptFormStateHandlers,
   WithDisplayData,
   WithLinodesProps,
@@ -148,6 +149,7 @@ interface Props {
   togglePrivateIPEnabled: () => void;
   updateTags: (tags: Tag[]) => void;
   handleSubmitForm: HandleSubmit;
+  runValidation: LinodeCreateValidation;
   resetCreationState: () => void;
   setBackupID: (id: number) => void;
   showGeneralError?: boolean;
@@ -378,8 +380,34 @@ export class LinodeCreate extends React.PureComponent<
   };
 
   setIsApiAwarenessModalOpen = (value: boolean) => {
-    this.setState({ ...this.state, isApiAwarenessModalOpen: value });
+    const payload = {
+      image: this.props.selectedImageID,
+      region: this.props.selectedRegionID,
+      type: this.props.selectedTypeID,
+      label: this.props.label,
+      tags: this.props.tags
+        ? this.props.tags.map((eachTag) => eachTag.label)
+        : [],
+      root_pass: this.props.password,
+      authorized_users: this.props.userSSHKeys
+        .filter((u) => u.selected)
+        .map((u) => u.username),
+      booted: true,
+      backups_enabled: this.props.backupsEnabled,
+      backup_id: this.props.selectedBackupID,
+      private_ip: this.props.privateIPEnabled,
+
+      // StackScripts
+      stackscript_id: this.props.selectedStackScriptID,
+      stackscript_data: this.props.selectedUDFs,
+    };
+    this.props.runValidation(payload);
+    if (!this.props.errors) {
+      this.setState({ ...this.state, isApiAwarenessModalOpen: false });
+    }
   };
+
+  //Run validation
 
   render() {
     const { selectedTab, stackScriptSelectedTab } = this.state;
@@ -772,6 +800,7 @@ export class LinodeCreate extends React.PureComponent<
               <ApiAwarenessModal
                 isOpen={this.state.isApiAwarenessModalOpen}
                 onClose={() => this.setIsApiAwarenessModalOpen(false)}
+                route={this.props.match.url}
               />
             </div>
           </Box>

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -798,6 +798,7 @@ export class LinodeCreate extends React.PureComponent<
                 isOpen={showApiAwarenessModal}
                 onClose={handleShowApiAwarenessModal}
                 route={this.props.match.url}
+                label={this.props.label}
               />
             </div>
           </Box>

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -159,7 +159,7 @@ interface Props {
   showAgreement: boolean;
   showApiAwarenessModal: boolean;
   handleAgreementChange: () => void;
-  handleShowApiAwarenessModal: () => void;
+  handleToggleApiAwarenessModal: () => void;
   signedAgreement: boolean;
 }
 
@@ -441,7 +441,7 @@ export class LinodeCreate extends React.PureComponent<
       showAgreement,
       showApiAwarenessModal,
       handleAgreementChange,
-      handleShowApiAwarenessModal,
+      handleToggleApiAwarenessModal,
       signedAgreement,
       ...rest
     } = this.props;
@@ -796,7 +796,7 @@ export class LinodeCreate extends React.PureComponent<
               </Button>
               <ApiAwarenessModal
                 isOpen={showApiAwarenessModal}
-                onClose={handleShowApiAwarenessModal}
+                onClose={handleToggleApiAwarenessModal}
                 route={this.props.match.url}
                 label={this.props.label}
               />

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -646,7 +646,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
     try {
       CreateLinodeSchema.validateSync(payload, { abortEarly: false });
       //reset errors to default state
-      this.setState({ errors: undefined });
+      this.setState({ errors: undefined, showApiAwarenessModal: true });
     } catch (error) {
       const processedErrors = convertYupToLinodeErrors(error);
       this.setState(

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -103,6 +103,7 @@ interface State {
   tags?: Tag[];
   errors?: APIError[];
   showAgreement: boolean;
+  showApiAwarenessModal: boolean;
   signedAgreement: boolean;
   formIsSubmitting: boolean;
   appInstances?: StackScript[];
@@ -152,6 +153,7 @@ const defaultState: State = {
   appInstancesLoading: false,
   attachedVLANLabel: '',
   vlanIPAMAddress: null,
+  showApiAwarenessModal: false,
 };
 
 const getDisabledClasses = (regionID: string, regions: Region[] = []) => {
@@ -408,6 +410,12 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
     }));
   };
 
+  handleShowApiAwarenessModal = () => {
+    this.setState((prevState) => ({
+      showApiAwarenessModal: !prevState.showApiAwarenessModal,
+    }));
+  };
+
   generateLabel = () => {
     const { createType, getLabel, imagesData, regionsData } = this.props;
     const {
@@ -634,9 +642,11 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
       });
   };
 
-  runValidation: LinodeCreateValidation = (payload) => {
+  checkValidation: LinodeCreateValidation = (payload) => {
     try {
       CreateLinodeSchema.validateSync(payload, { abortEarly: false });
+      //reset errors to default state
+      this.setState({ errors: undefined, showApiAwarenessModal: true });
     } catch (error) {
       const processedErrors = convertYupToLinodeErrors(error);
       this.setState(
@@ -795,7 +805,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
             togglePrivateIPEnabled={this.togglePrivateIPEnabled}
             updateTags={this.setTags}
             handleSubmitForm={this.submitForm}
-            runValidation={this.runValidation}
+            checkValidation={this.checkValidation}
             resetCreationState={this.clearCreationState}
             setBackupID={this.setBackupID}
             regionsData={filteredRegions!}
@@ -805,6 +815,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
             ipamAddress={this.state.vlanIPAMAddress}
             handleVLANChange={this.handleVLANChange}
             handleAgreementChange={this.handleAgreementChange}
+            handleShowApiAwarenessModal={this.handleShowApiAwarenessModal}
             userCannotCreateLinode={userCannotCreateLinode}
             accountBackupsEnabled={getAccountBackupsEnabled()}
             {...restOfProps}

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -410,7 +410,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
     }));
   };
 
-  handleShowApiAwarenessModal = () => {
+  handleToggleApiAwarenessModal = () => {
     this.setState((prevState) => ({
       showApiAwarenessModal: !prevState.showApiAwarenessModal,
     }));
@@ -815,7 +815,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
             ipamAddress={this.state.vlanIPAMAddress}
             handleVLANChange={this.handleVLANChange}
             handleAgreementChange={this.handleAgreementChange}
-            handleShowApiAwarenessModal={this.handleShowApiAwarenessModal}
+            handleToggleApiAwarenessModal={this.handleToggleApiAwarenessModal}
             userCannotCreateLinode={userCannotCreateLinode}
             accountBackupsEnabled={getAccountBackupsEnabled()}
             {...restOfProps}

--- a/packages/manager/src/features/linodes/LinodesCreate/types.ts
+++ b/packages/manager/src/features/linodes/LinodesCreate/types.ts
@@ -82,6 +82,8 @@ export type HandleSubmit = (
   linodeID?: number
 ) => void;
 
+export type LinodeCreateValidation = (payload: CreateLinodeRequest) => void;
+
 export interface BasicFromContentProps {
   errors?: APIError[];
   selectedImageID?: string;

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -18,6 +18,7 @@ declare module '@material-ui/core/styles/createPalette' {
       warningDark: string;
       error: string;
       errorDark: string;
+      marketingDark?: boolean;
     };
   }
 
@@ -392,6 +393,7 @@ const themeDefaults: ThemeDefaults = () => {
         warningDark: '#ffd002',
         error: '#f8dedf',
         errorDark: '#cd2227',
+        marketingDark: '#00b159',
       },
     },
     typography: {


### PR DESCRIPTION
## Description 📝
Show the API awareness modal after validation check passes.

**What does this PR do?**

- Adds content and respective links to the API awareness modal.
- Adds Tabs component.
- Add installation guides.
- Wired GA events
-  Validation check to show / hide modal

## Preview 📷
![image](https://user-images.githubusercontent.com/119517080/212408858-adb3aeac-6951-457e-89a9-1c038594e281.png)


## How to test 🧪

- Navigate to Create Linode page
- Click on "Create using command line" button - Try with out filling required data.
- Should show the inline error messages.
- Enter data for all required fields.
- Click on "Create using command line"
- Show show the API awareness modal.
- Validate all the links. 

**How do I run relevant unit or e2e tests?**
yarn test