### PR TITLE
Fix Linodes Landing Showing Past Maintenance Events

### DIFF
--- a/packages/manager/src/features/linodes/index.tsx
+++ b/packages/manager/src/features/linodes/index.tsx
@@ -33,7 +33,10 @@ export default LinodesRoutes;
 // I needed a Function Component. It seemed safer to do it this way instead of
 // refactoring LinodesLanding.
 const LinodesLandingWrapper: React.FC = React.memo(() => {
-  const { data: accountMaintenanceData } = useAllAccountMaintenanceQuery();
+  const { data: accountMaintenanceData } = useAllAccountMaintenanceQuery(
+    {},
+    { status: { '+or': ['pending, started'] } }
+  );
   const { linodes } = useLinodes();
   const { typesMap } = useTypes();
 


### PR DESCRIPTION
## Description 📝

- Fixes Linodes landing showing past maintenance events for a Linode

## Preview 📷

![image](https://user-images.githubusercontent.com/115251059/211686042-3eff0da0-4349-4560-8d30-abeb21e142b1.png)

## How to test 🧪

- Find an account with past maintenance on a Linode that exists and verify you do not see this tooltip
