### PR TITLE
M3-6046: dynamically generate cURL and CLI commands

### DIFF
--- a/packages/manager/src/features/linodes/LinodesCreate/ApiAwarenessModal/index.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/ApiAwarenessModal/index.tsx
@@ -13,6 +13,8 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 import Tabs from 'src/components/core/ReachTabs';
 import TabPanels from 'src/components/core/ReachTabPanels';
 import { sendEvent } from 'src/utilities/ga';
+import generateCurlCommand from 'src/utilities/generate-cURL';
+import generateCLICommand from 'src/utilities/generate-cli';
 
 import CodeBlock from '../CodeBlock';
 
@@ -47,6 +49,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     fontSize: '14px !important',
   },
 }));
+
 export interface Props {
   isOpen: boolean;
   onClose: () => void;
@@ -62,38 +65,14 @@ const fireGAEvent = (label: string) => {
   });
 };
 const ApiAwarenessModal = (props: Props) => {
-  const { isOpen, onClose, route } = props;
+  const { isOpen, onClose, route, payLoad } = props;
 
   const classes = useStyles();
 
   // This harcoded values will be removed as part of following story that generated dynamic CURL and CLI commands.
-  const curlCommand = `curl -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" -X POST -d '{
-    "image": "linode/debian11",
-    "region": "us-southeast",
-    "type": "g6-nanode-1",
-    "label": "debian-us-southeast-001",
-    "tags": [],
-    "root_pass": "asdfasdfasdfasdf",
-    "authorized_users": [],
-    "booted": true,
-    "backups_enabled": false,
-    "private_ip": false
-  }' https://api.linode.com/v4/linode/instances`;
+  const curlCommand = generateCurlCommand(payLoad, '/linode/instances');
 
-  const cliCommand = `linode-cli linodes create 
-  --image linode/debian11 
-  --region us-central 
-  --type g6-nanode-1 
-  --label debian-us-central 
-  --tags 
-  --root_pass asd 
-  --authorized_users 
-  --booted true 
-  --backups_enabled false 
-  --backup_id undefined 
-  --private_ip false 
-  --stackscript_id undefined 
-  --stackscript_data undefined`;
+  const cliCommand = generateCLICommand(payLoad);
 
   const tabs = [
     {

--- a/packages/manager/src/features/linodes/LinodesCreate/CodeBlock/styles.ts
+++ b/packages/manager/src/features/linodes/LinodesCreate/CodeBlock/styles.ts
@@ -19,6 +19,9 @@ export const useCodeBlockStyles = makeStyles((theme: Theme) => ({
       '& .hljs-symbol': {
         color: '#f8f8f2',
       },
+      '& .hljs-variable': {
+        color: 'teal',
+      },
     },
   },
   copyIcon: {

--- a/packages/manager/src/utilities/generate-cURL.test.ts
+++ b/packages/manager/src/utilities/generate-cURL.test.ts
@@ -12,7 +12,7 @@ const linodeData = {
 
 const createLinodePath = '/linode/instance';
 
-const linodeDataString = JSON.stringify(linodeData);
+const linodeDataString = JSON.stringify(linodeData, null, 4);
 
 const generatedCommand = generateCurlCommand(linodeData, createLinodePath);
 
@@ -42,6 +42,6 @@ describe('generateCurlCommand', () => {
   });
 
   it('should return a curl command that has a data option set to the argument passed to it', () => {
-    expect(generatedCommand).toMatch(`-d ${linodeDataString}`);
+    expect(generatedCommand).toMatch(`-d '${linodeDataString}'`);
   });
 });

--- a/packages/manager/src/utilities/generate-cURL.test.ts
+++ b/packages/manager/src/utilities/generate-cURL.test.ts
@@ -1,4 +1,4 @@
-import generateCurlCommand, { generateCLICommand } from './generate-cURL';
+import generateCurlCommand from './generate-cURL';
 
 const linodeData = {
   label: 'linode-1',
@@ -6,15 +6,6 @@ const linodeData = {
   region: 'us-east',
   type: 'g6-standard-2',
 };
-
-const linodeDataForCLI = `
---label linode-1
---root_pass aComplex@Password
---region us-east
---type g6-standard-2
-`
-  .trimStart()
-  .trimEnd();
 
 const linodeDataString = JSON.stringify(linodeData);
 
@@ -52,24 +43,5 @@ describe('generateCurlCommand', () => {
   it('should return a curl command that has a data option set to the argument passed to it', () => {
     const generatedCommand = generateCurlCommand(linodeData);
     expect(generatedCommand).toMatch(`-d ${linodeDataString}`);
-  });
-});
-
-describe('generateCLICommand', () => {
-  it('should return a linode-cli command', () => {
-    const generatedCommand = generateCLICommand(linodeData);
-    expect(generatedCommand.startsWith('linode-cli')).toBeTruthy();
-  });
-
-  it('should return a linode-cli linodes create command', () => {
-    const generatedCommand = generateCLICommand(linodeData);
-    expect(
-      generatedCommand.startsWith('linode-cli linodes create')
-    ).toBeTruthy();
-  });
-
-  it('should return a linode-cli command with the data provided formatted as arguments', () => {
-    const generatedCommand = generateCLICommand(linodeData);
-    expect(generatedCommand).toMatch(linodeDataForCLI);
   });
 });

--- a/packages/manager/src/utilities/generate-cURL.test.ts
+++ b/packages/manager/src/utilities/generate-cURL.test.ts
@@ -1,0 +1,75 @@
+import generateCurlCommand, { generateCLICommand } from './generate-cURL';
+
+const linodeData = {
+  label: 'linode-1',
+  root_pass: 'aComplex@Password',
+  region: 'us-east',
+  type: 'g6-standard-2',
+};
+
+const linodeDataForCLI = `
+--label linode-1
+--root_pass aComplex@Password
+--region us-east
+--type g6-standard-2
+`
+  .trimStart()
+  .trimEnd();
+
+const linodeDataString = JSON.stringify(linodeData);
+
+describe('generateCurlCommand', () => {
+  it('should return a string that starts with curl', () => {
+    const generatedCommand = generateCurlCommand(linodeDataString);
+    expect(generatedCommand.slice(0, 4)).toBe('curl');
+  });
+
+  it('should produce a curl command that targets the linode API', () => {
+    const generatedCommand = generateCurlCommand(linodeDataString);
+    expect(generatedCommand).toMatch('https://api.linode.com/v4/');
+  });
+
+  it('should return a curl command that has a Content-Type header set to application/json', () => {
+    const generatedCommand = generateCurlCommand(linodeDataString);
+    expect(generatedCommand).toMatch('-H "Content-Type: application/json"');
+  });
+
+  it('should return a curl command that has an Authorization header set to Bearer $TOKEN', () => {
+    const generatedCommand = generateCurlCommand(linodeDataString);
+    expect(generatedCommand).toMatch('-H "Authorization: Bearer $TOKEN"');
+  });
+
+  it('should return a curl command that has an HTTP method set', () => {
+    const generatedCommand = generateCurlCommand(linodeDataString);
+    expect(generatedCommand).toMatch(/-X (POST)/);
+  });
+
+  it('should return a curl command that has a data option set', () => {
+    const generatedCommand = generateCurlCommand(linodeDataString);
+    expect(generatedCommand).toMatch('-d');
+  });
+
+  it('should return a curl command that has a data option set to the argument passed to it', () => {
+    const generatedCommand = generateCurlCommand(linodeData);
+    expect(generatedCommand).toMatch(`-d ${linodeDataString}`);
+  });
+});
+
+describe('generateCLICommand', () => {
+  it('should return a linode-cli command', () => {
+    const generatedCommand = generateCLICommand(linodeData);
+    expect(generatedCommand.startsWith('linode-cli')).toBeTruthy();
+  });
+
+  it('should return a linode-cli linodes create command', () => {
+    const generatedCommand = generateCLICommand(linodeData);
+    expect(
+      generatedCommand.startsWith('linode-cli linodes create')
+    ).toBeTruthy();
+  });
+
+  it('should return a linode-cli command with the data provided formatted as arguments', () => {
+    const generatedCommand = generateCLICommand(linodeData);
+    expect(generatedCommand).toMatch(linodeDataForCLI);
+  });
+});

--- a/packages/manager/src/utilities/generate-cURL.test.ts
+++ b/packages/manager/src/utilities/generate-cURL.test.ts
@@ -1,47 +1,47 @@
 import generateCurlCommand from './generate-cURL';
+import { createLinodeRequestFactory } from 'src/factories/linodes';
 
+const linodeRequest = createLinodeRequestFactory.build();
 const linodeData = {
-  label: 'linode-1',
-  root_pass: 'aComplex@Password',
-  region: 'us-east',
-  type: 'g6-standard-2',
+  ...linodeRequest,
+  stackscript_id: 10079,
+  stackscript_data: {
+    gh_username: 'linode',
+  },
 };
+
+const createLinodePath = '/linode/instance';
 
 const linodeDataString = JSON.stringify(linodeData);
 
+const generatedCommand = generateCurlCommand(linodeData, createLinodePath);
+
 describe('generateCurlCommand', () => {
   it('should return a string that starts with curl', () => {
-    const generatedCommand = generateCurlCommand(linodeDataString);
     expect(generatedCommand.slice(0, 4)).toBe('curl');
   });
 
   it('should produce a curl command that targets the linode API', () => {
-    const generatedCommand = generateCurlCommand(linodeDataString);
     expect(generatedCommand).toMatch('https://api.linode.com/v4/');
   });
 
   it('should return a curl command that has a Content-Type header set to application/json', () => {
-    const generatedCommand = generateCurlCommand(linodeDataString);
     expect(generatedCommand).toMatch('-H "Content-Type: application/json"');
   });
 
   it('should return a curl command that has an Authorization header set to Bearer $TOKEN', () => {
-    const generatedCommand = generateCurlCommand(linodeDataString);
     expect(generatedCommand).toMatch('-H "Authorization: Bearer $TOKEN"');
   });
 
   it('should return a curl command that has an HTTP method set', () => {
-    const generatedCommand = generateCurlCommand(linodeDataString);
     expect(generatedCommand).toMatch(/-X (POST)/);
   });
 
   it('should return a curl command that has a data option set', () => {
-    const generatedCommand = generateCurlCommand(linodeDataString);
     expect(generatedCommand).toMatch('-d');
   });
 
   it('should return a curl command that has a data option set to the argument passed to it', () => {
-    const generatedCommand = generateCurlCommand(linodeData);
     expect(generatedCommand).toMatch(`-d ${linodeDataString}`);
   });
 });

--- a/packages/manager/src/utilities/generate-cURL.ts
+++ b/packages/manager/src/utilities/generate-cURL.ts
@@ -1,16 +1,14 @@
 // type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
 
-const headers = ` -H "Content-Type: application/json"
-    -H "Authorization: Bearer $TOKEN"
-`;
+const headers = [
+  '-H "Content-Type: application/json"',
+  '-H "Authorization: Bearer $TOKEN"',
+].join('\n');
 
-const generateCurlCommand = (data: {}) => {
-  const command = `
-curl ${headers}
-  -X POST
-  -d ${JSON.stringify(data)}
-  https://api.linode.com/v4/
-`;
+const generateCurlCommand = (data: {}, path: string) => {
+  const command = `curl ${headers}\n-X POST -d ${JSON.stringify(
+    data
+  )}\n https://api.linode.com/v4/${path}`;
   return command.trimStart().trimEnd();
 };
 

--- a/packages/manager/src/utilities/generate-cURL.ts
+++ b/packages/manager/src/utilities/generate-cURL.ts
@@ -14,20 +14,4 @@ curl ${headers}
   return command.trimStart().trimEnd();
 };
 
-type JSONFieldToArray = [string, unknown];
-
-const convertJSONFieldToCLIArg = ([key, value]: JSONFieldToArray) => {
-  return `--${key} ${value}`;
-};
-
-export const generateCLICommand = (data: {}) => {
-  const dataForCLI = Object.entries(data).map(convertJSONFieldToCLIArg);
-  return `
-linode-cli linodes create
-${dataForCLI.join('\n')}
-  `
-    .trimStart()
-    .trimEnd();
-};
-
 export default generateCurlCommand;

--- a/packages/manager/src/utilities/generate-cURL.ts
+++ b/packages/manager/src/utilities/generate-cURL.ts
@@ -1,14 +1,16 @@
 // type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
 
 const headers = [
-  '-H "Content-Type: application/json"',
-  '-H "Authorization: Bearer $TOKEN"',
+  '-H "Content-Type: application/json" \\',
+  '-H "Authorization: Bearer $TOKEN" \\',
 ].join('\n');
 
 const generateCurlCommand = (data: {}, path: string) => {
-  const command = `curl ${headers}\n-X POST -d ${JSON.stringify(
-    data
-  )}\n https://api.linode.com/v4/${path}`;
+  const command = `curl ${headers}\n-X POST -d '${JSON.stringify(
+    data,
+    null,
+    4
+  )}' https://api.linode.com/v4${path}`;
   return command.trim();
 };
 

--- a/packages/manager/src/utilities/generate-cURL.ts
+++ b/packages/manager/src/utilities/generate-cURL.ts
@@ -9,7 +9,7 @@ const generateCurlCommand = (data: {}, path: string) => {
   const command = `curl ${headers}\n-X POST -d ${JSON.stringify(
     data
   )}\n https://api.linode.com/v4/${path}`;
-  return command.trimStart().trimEnd();
+  return command.trim();
 };
 
 export default generateCurlCommand;

--- a/packages/manager/src/utilities/generate-cURL.ts
+++ b/packages/manager/src/utilities/generate-cURL.ts
@@ -1,0 +1,33 @@
+// type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
+
+const headers = ` -H "Content-Type: application/json"
+    -H "Authorization: Bearer $TOKEN"
+`;
+
+const generateCurlCommand = (data: {}) => {
+  const command = `
+curl ${headers}
+  -X POST
+  -d ${JSON.stringify(data)}
+  https://api.linode.com/v4/
+`;
+  return command.trimStart().trimEnd();
+};
+
+type JSONFieldToArray = [string, unknown];
+
+const convertJSONFieldToCLIArg = ([key, value]: JSONFieldToArray) => {
+  return `--${key} ${value}`;
+};
+
+export const generateCLICommand = (data: {}) => {
+  const dataForCLI = Object.entries(data).map(convertJSONFieldToCLIArg);
+  return `
+linode-cli linodes create
+${dataForCLI.join('\n')}
+  `
+    .trimStart()
+    .trimEnd();
+};
+
+export default generateCurlCommand;

--- a/packages/manager/src/utilities/generate-cli.test.ts
+++ b/packages/manager/src/utilities/generate-cli.test.ts
@@ -12,17 +12,15 @@ const linodeData = {
 };
 
 const linodeDataForCLI = `
---label ${linodeRequest.label}
---root_pass ${linodeRequest.root_pass}
---image ${linodeRequest.image}
---type ${linodeRequest.type}
---region ${linodeRequest.region}
---booted ${linodeRequest.booted}
---stackscript_id 10079
+--label ${linodeRequest.label} \\
+--root_pass ${linodeRequest.root_pass} \\
+--image ${linodeRequest.image} \\
+--type ${linodeRequest.type} \\
+--region ${linodeRequest.region} \\
+--booted ${linodeRequest.booted} \\
+--stackscript_id 10079 \\
 --stackscript_data '{"gh_username": "linode"}'
-`
-  .trimStart()
-  .trimEnd();
+`.trim();
 
 const generatedCommand = generateCLICommand(linodeData);
 

--- a/packages/manager/src/utilities/generate-cli.test.ts
+++ b/packages/manager/src/utilities/generate-cli.test.ts
@@ -1,0 +1,36 @@
+import generateCLICommand from './generate-cli';
+
+const linodeData = {
+  label: 'linode-1',
+  root_pass: 'aComplex@Password',
+  region: 'us-east',
+  type: 'g6-standard-2',
+};
+
+const linodeDataForCLI = `
+--label linode-1
+--root_pass aComplex@Password
+--region us-east
+--type g6-standard-2
+`
+  .trimStart()
+  .trimEnd();
+
+describe('generateCLICommand', () => {
+  it('should return a linode-cli command', () => {
+    const generatedCommand = generateCLICommand(linodeData);
+    expect(generatedCommand.startsWith('linode-cli')).toBeTruthy();
+  });
+
+  it('should return a linode-cli linodes create command', () => {
+    const generatedCommand = generateCLICommand(linodeData);
+    expect(
+      generatedCommand.startsWith('linode-cli linodes create')
+    ).toBeTruthy();
+  });
+
+  it('should return a linode-cli command with the data provided formatted as arguments', () => {
+    const generatedCommand = generateCLICommand(linodeData);
+    expect(generatedCommand).toMatch(linodeDataForCLI);
+  });
+});

--- a/packages/manager/src/utilities/generate-cli.test.ts
+++ b/packages/manager/src/utilities/generate-cli.test.ts
@@ -1,10 +1,13 @@
 import generateCLICommand from './generate-cli';
+import { createLinodeRequestFactory } from 'src/factories/linodes';
 
+const linodeRequest = createLinodeRequestFactory.build();
 const linodeData = {
-  label: 'linode-1',
-  root_pass: 'aComplex@Password',
-  region: 'us-east',
-  type: 'g6-standard-2',
+  ...linodeRequest,
+  stackscript_id: 10079,
+  stackscript_data: {
+    gh_username: 'linode',
+  },
 };
 
 const linodeDataForCLI = `
@@ -12,25 +15,22 @@ const linodeDataForCLI = `
 --root_pass aComplex@Password
 --region us-east
 --type g6-standard-2
+--stackscript_id 10079
+--stackscript_data '{"gh_username": "linode"}'
 `
   .trimStart()
   .trimEnd();
 
-describe('generateCLICommand', () => {
-  it('should return a linode-cli command', () => {
-    const generatedCommand = generateCLICommand(linodeData);
-    expect(generatedCommand.startsWith('linode-cli')).toBeTruthy();
-  });
+const generatedCommand = generateCLICommand(linodeData);
 
+describe('generateCLICommand', () => {
   it('should return a linode-cli linodes create command', () => {
-    const generatedCommand = generateCLICommand(linodeData);
     expect(
       generatedCommand.startsWith('linode-cli linodes create')
     ).toBeTruthy();
   });
 
   it('should return a linode-cli command with the data provided formatted as arguments', () => {
-    const generatedCommand = generateCLICommand(linodeData);
     expect(generatedCommand).toMatch(linodeDataForCLI);
   });
 });

--- a/packages/manager/src/utilities/generate-cli.test.ts
+++ b/packages/manager/src/utilities/generate-cli.test.ts
@@ -9,17 +9,18 @@ const linodeData = {
   stackscript_data: {
     gh_username: 'linode',
   },
+  backup_id: undefined,
 };
 
 const linodeDataForCLI = `
---label ${linodeRequest.label} \\
---root_pass ${linodeRequest.root_pass} \\
---image ${linodeRequest.image} \\
---type ${linodeRequest.type} \\
---region ${linodeRequest.region} \\
---booted ${linodeRequest.booted} \\
---stackscript_id 10079 \\
---stackscript_data '{"gh_username": "linode"}'
+  --label ${linodeRequest.label} \\
+  --root_pass ${linodeRequest.root_pass} \\
+  --image ${linodeRequest.image} \\
+  --type ${linodeRequest.type} \\
+  --region ${linodeRequest.region} \\
+  --booted ${linodeRequest.booted} \\
+  --stackscript_id 10079 \\
+  --stackscript_data '{"gh_username": "linode"}'
 `.trim();
 
 const generatedCommand = generateCLICommand(linodeData);
@@ -33,5 +34,9 @@ describe('generateCLICommand', () => {
 
   it('should return a linode-cli command with the data provided formatted as arguments', () => {
     expect(generatedCommand).toMatch(linodeDataForCLI);
+  });
+
+  it('should not return a linode-cli command with undefined fields', () => {
+    expect(generatedCommand).not.toMatch('undefined');
   });
 });

--- a/packages/manager/src/utilities/generate-cli.test.ts
+++ b/packages/manager/src/utilities/generate-cli.test.ts
@@ -2,6 +2,7 @@ import generateCLICommand from './generate-cli';
 import { createLinodeRequestFactory } from 'src/factories/linodes';
 
 const linodeRequest = createLinodeRequestFactory.build();
+
 const linodeData = {
   ...linodeRequest,
   stackscript_id: 10079,
@@ -11,10 +12,12 @@ const linodeData = {
 };
 
 const linodeDataForCLI = `
---label linode-1
---root_pass aComplex@Password
---region us-east
---type g6-standard-2
+--label ${linodeRequest.label}
+--root_pass ${linodeRequest.root_pass}
+--image ${linodeRequest.image}
+--type ${linodeRequest.type}
+--region ${linodeRequest.region}
+--booted ${linodeRequest.booted}
 --stackscript_id 10079
 --stackscript_data '{"gh_username": "linode"}'
 `

--- a/packages/manager/src/utilities/generate-cli.ts
+++ b/packages/manager/src/utilities/generate-cli.ts
@@ -13,9 +13,7 @@ export const generateCLICommand = (data: {}) => {
   return `
 linode-cli linodes create
 ${dataForCLI.join('\n')}
-  `
-    .trimStart()
-    .trimEnd();
+  `.trim();
 };
 
 export default generateCLICommand;

--- a/packages/manager/src/utilities/generate-cli.ts
+++ b/packages/manager/src/utilities/generate-cli.ts
@@ -1,15 +1,25 @@
 type JSONFieldToArray = [string, unknown];
 
-const convertJSONFieldToCLIArg = ([key, value]: JSONFieldToArray) => {
-  let valueAsString = value;
-  if (typeof value === 'object') {
-    valueAsString = `'${JSON.stringify(value).replace(':', ': ')}'`;
+const convertObjectToCLIArg = (data: {} | null) => {
+  return `'${JSON.stringify(data).replace(':', ': ')}'`;
+};
+
+const dataEntriesReduce = (acc: string[], [key, value]: JSONFieldToArray) => {
+  if (value === undefined || value === null) {
+    return acc;
+  } else if (Array.isArray(value) && value.length === 0) {
+    return acc;
+  } else if (typeof value === 'object') {
+    const valueAsString = convertObjectToCLIArg(value);
+    acc.push(`  --${key} ${valueAsString}`);
+  } else {
+    acc.push(`  --${key} ${value}`);
   }
-  return `--${key} ${valueAsString}`;
+  return acc;
 };
 
 export const generateCLICommand = (data: {}) => {
-  const dataForCLI = Object.entries(data).map(convertJSONFieldToCLIArg);
+  const dataForCLI = Object.entries(data).reduce(dataEntriesReduce, []);
   return `linode-cli linodes create \\\n${dataForCLI.join(' \\\n')}`;
 };
 

--- a/packages/manager/src/utilities/generate-cli.ts
+++ b/packages/manager/src/utilities/generate-cli.ts
@@ -10,10 +10,7 @@ const convertJSONFieldToCLIArg = ([key, value]: JSONFieldToArray) => {
 
 export const generateCLICommand = (data: {}) => {
   const dataForCLI = Object.entries(data).map(convertJSONFieldToCLIArg);
-  return `
-linode-cli linodes create
-${dataForCLI.join('\n')}
-  `.trim();
+  return `linode-cli linodes create \\\n${dataForCLI.join(' \\\n')}`;
 };
 
 export default generateCLICommand;

--- a/packages/manager/src/utilities/generate-cli.ts
+++ b/packages/manager/src/utilities/generate-cli.ts
@@ -1,0 +1,17 @@
+type JSONFieldToArray = [string, unknown];
+
+const convertJSONFieldToCLIArg = ([key, value]: JSONFieldToArray) => {
+  return `--${key} ${value}`;
+};
+
+export const generateCLICommand = (data: {}) => {
+  const dataForCLI = Object.entries(data).map(convertJSONFieldToCLIArg);
+  return `
+linode-cli linodes create
+${dataForCLI.join('\n')}
+  `
+    .trimStart()
+    .trimEnd();
+};
+
+export default generateCLICommand;

--- a/packages/manager/src/utilities/generate-cli.ts
+++ b/packages/manager/src/utilities/generate-cli.ts
@@ -1,7 +1,11 @@
 type JSONFieldToArray = [string, unknown];
 
 const convertJSONFieldToCLIArg = ([key, value]: JSONFieldToArray) => {
-  return `--${key} ${value}`;
+  let valueAsString = value;
+  if (typeof value === 'object') {
+    valueAsString = `'${JSON.stringify(value).replace(':', ': ')}'`;
+  }
+  return `--${key} ${valueAsString}`;
 };
 
 export const generateCLICommand = (data: {}) => {


### PR DESCRIPTION
## Description 📝

Adds functions to generate Linode CLI and cURL commands to create Linodes.
This is a work in progress to just get the basics down. I want to move this to a single function or an object that can generate both cURL and Linode CLI comands.

## How to test 🧪

`yarn test generate-cURL`
