### PR TITLE
M3-6002: Align left modal title

### DIFF
--- a/packages/manager/src/components/Dialog/Dialog.tsx
+++ b/packages/manager/src/components/Dialog/Dialog.tsx
@@ -9,6 +9,7 @@ import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 import { convertForAria } from 'src/components/TabLink/TabLink';
 import Notice from 'src/components/Notice';
+import classNames from 'classnames';
 
 export interface DialogProps extends _DialogProps {
   className?: string;
@@ -146,7 +147,7 @@ const Dialog: React.FC<DialogProps> = (props) => {
         </div>
         {titleBottomBorder && <hr className={classes.titleBottomBorder} />}
         <Grid container>
-          <div className={className ? className : classes.dialogContent}>
+          <div className={classNames(classes.dialogContent, className)}>
             {error && <Notice text={error} error />}
             {children}
           </div>


### PR DESCRIPTION
## Description 📝

Fixes an alignment issue in some `Dialog`s that was caused by the `className` prop overriding existing styles.

## Preview 📷

Before:
![image](https://user-images.githubusercontent.com/122488130/211937652-08404bca-b50c-4866-9d4c-183546dca908.png)

After: 
![image](https://user-images.githubusercontent.com/122488130/211937767-24773d04-9dd4-4a34-8a8a-1163e067073f.png)

## How to test 🧪

1. Navigate to Account > Service Transfers > Make a Service Transfer.
2. Create a Service Transfer.
3. Inspect the alignment of the "Service Transfer Token" modal.
4. Verify other dialogs in the app look as expected.