### PR TITLE
Fix broken URL for Peppermint OCA

### DIFF
--- a/packages/manager/src/features/OneClickApps/FakeSpec.ts
+++ b/packages/manager/src/features/OneClickApps/FakeSpec.ts
@@ -1402,7 +1402,7 @@ export const oneClickApps: OCA[] = [
           'https://www.linode.com/docs/products/tools/marketplace/guides/peppermint/',
       },
     ],
-    website: 'https://pmint.dev/',
+    website: 'https://peppermint.sh/',
     logo_url: 'peppermint.svg',
     colors: {
       start: '4cff4c',


### PR DESCRIPTION
## Description 📝

This PR fixes a broken from the Information drawer for the Peppermint Marketplace App to point to the correct official URL

## How to test 🧪

Test that the URL loads the official [peppermint.sh](https://peppermint.sh/) website. 
