### PR TITLE
M3-6066: Fix `api-v4` and `validation` Node Errors

### DIFF
--- a/packages/validation/src/firewalls.schema.ts
+++ b/packages/validation/src/firewalls.schema.ts
@@ -1,4 +1,6 @@
-import { parse as parseIP, parseCIDR } from 'ipaddr.js';
+// We must use a default export for ipaddr.js so our packages node compatability
+// Refer to https://github.com/linode/manager/issues/8675
+import ipaddr from 'ipaddr.js';
 import { array, mixed, number, object, string } from 'yup';
 
 export const IP_ERROR_MESSAGE =
@@ -13,9 +15,9 @@ export const validateIP = (ipAddress?: string | null): boolean => {
   const [, mask] = ipAddress.split('/');
   try {
     if (mask) {
-      parseCIDR(ipAddress);
+      ipaddr.parseCIDR(ipAddress);
     } else {
-      parseIP(ipAddress);
+      ipaddr.parse(ipAddress);
     }
   } catch (err) {
     // Empty addresses are OK for the sake of validating the form.

--- a/packages/validation/src/linodes.schema.ts
+++ b/packages/validation/src/linodes.schema.ts
@@ -1,5 +1,7 @@
 import { array, boolean, mixed, number, object, string } from 'yup';
-import { parseCIDR } from 'ipaddr.js';
+// We must use a default export for ipaddr.js so our packages node compatability
+// Refer to https://github.com/linode/manager/issues/8675
+import ipaddr from 'ipaddr.js';
 
 const validateIP = (ipAddress?: string | null) => {
   if (!ipAddress) {
@@ -8,7 +10,7 @@ const validateIP = (ipAddress?: string | null) => {
 
   // We accept IP ranges (i.e., CIDR notation).
   try {
-    parseCIDR(ipAddress);
+    ipaddr.parseCIDR(ipAddress);
   } catch (err) {
     return false;
   }


### PR DESCRIPTION
## Description 📝

- Uses a default export of the `ipaddr.js` package to prevent node errors. We are thinking that `ipaddr.js` is lacking support for our build system.

- Fixes
  - #8713
  - #8706
  - #8675 

## How to test 🧪

- Checkout this PR
- Run `yarn build && yarn pack` in `packages/validation`
  - Note the absolute path of the built package (for me it is `/Users/bnussman/Development/manager/packages/validation/linode-validation-v0.17.0.tgz`)
  - Set this version in api-v4's package.json in palace of `"*"`
- Run `yarn build && yarn pack` in `packages/api-v4`
  - Note the absolute path of the built package (for me it is `/Users/bnussman/Development/manager/packages/api-v4/linode-api-v4-v0.85.0.tgz`)
- Make a new Node.js + Typescript project outside of Cloud Manager
- Install the built package into your test node project and make sure you can build your node projct with tsc AND run it with node.js without observing any errors 

```json
"dependencies": {
    "@linode/api-v4": "/Users/bnussman/Development/manager/packages/api-v4/linode-api-v4-v0.85.0.tgz"
  },
```
