### PR TITLE
M3-6068: Incorrect tab selection on Linode Create

### DIFF
--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -571,7 +571,7 @@ export const SelectPlanPanel: React.FC<CombinedProps> = (props) => {
   // Determine initial plan category tab based on current plan selection
   // (if there is one).
   let selectedTypeClass: LinodeTypeClass = pathOr(
-    'dedicated', // Use `standard` by default
+    'dedicated', // Use `dedicated` by default
     ['class'],
     types.find(
       (type) => type.id === selectedID || type.heading === currentPlanHeading

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -571,7 +571,7 @@ export const SelectPlanPanel: React.FC<CombinedProps> = (props) => {
   // Determine initial plan category tab based on current plan selection
   // (if there is one).
   let selectedTypeClass: LinodeTypeClass = pathOr(
-    'standard', // Use `standard` by default
+    'dedicated', // Use `standard` by default
     ['class'],
     types.find(
       (type) => type.id === selectedID || type.heading === currentPlanHeading

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
@@ -401,7 +401,7 @@ export class SelectPlanPanel extends React.Component<
     // Determine initial plan category tab based on current plan selection
     // (if there is one).
     let selectedTypeClass: LinodeTypeClass = pathOr(
-      'standard', // Use `standard` by default
+      'dedicated', // Use `dedicated` by default
       ['class'],
       types.find(
         (type) => type.id === selectedID || type.heading === currentPlanHeading


### PR DESCRIPTION
## Description 📝
Sets plan tab to "Dedicated"

## Preview 📷
![image](https://user-images.githubusercontent.com/119517080/212197781-e02355b1-ba31-48ee-bf8e-273ced01444c.png)

**Remove this section or include a screenshot or screen recording of the change**

## How to test 🧪
Navigate to create linode
Validate the plan tab is set to default if no plan is selected.
