### PR TITLE
Fix Linodes Detail Showing Past Maintenance Events

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/Notifications.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/Notifications.tsx
@@ -20,7 +20,10 @@ const Notifications: React.FC<CombinedProps> = (props) => {
     linodeStatus,
   } = props;
 
-  const { data: accountMaintenanceData } = useAllAccountMaintenanceQuery();
+  const { data: accountMaintenanceData } = useAllAccountMaintenanceQuery(
+    {},
+    { status: { '+or': ['pending, started'] } }
+  );
 
   const maintenanceForThisLinode = accountMaintenanceData?.find(
     (thisMaintenance) =>

--- a/packages/manager/src/queries/accountMaintenance.ts
+++ b/packages/manager/src/queries/accountMaintenance.ts
@@ -24,7 +24,7 @@ export const useAllAccountMaintenanceQuery = (
   enabled: boolean = true
 ) => {
   return useQuery<AccountMaintenance[], APIError[]>(
-    queryKey,
+    [queryKey, 'all', params, filter],
     () => getAllAccountMaintenance(params, filter),
     { ...queryPresets.longLived, enabled }
   );


### PR DESCRIPTION
## Description 📝

- Fixes linode details header showing past maintenance events
- Relates to (https://github.com/linode/manager/pull/8707 but I failed to also make the same change change here

## How to test 🧪

- Use the MSW to verify that you don't see a maintenance banner (like the one shown below) at the top of a Linode's Details Page on linodes that show no maintenance on the Linodes landing page

![Screen Shot 2023-01-13 at 11 39 57 AM](https://user-images.githubusercontent.com/115251059/212372528-c131d716-fdfb-481d-8bd4-1e7a24407a4c.jpg)

