### PR TITLE
M3-6069: Fix NodeBalanacer Mode Change Select

### DIFF
--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigNode.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigNode.tsx
@@ -71,7 +71,10 @@ export interface Props {
   onNodeLabelChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onNodeAddressChange: (nodeIdx: number, value: string) => void;
   onNodeWeightChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  onNodeModeChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onNodeModeChange: (
+    e: React.ChangeEvent<HTMLInputElement>,
+    nodeId: number
+  ) => void;
   onNodePortChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   removeNode: (e: React.MouseEvent<HTMLElement>) => void;
 }
@@ -218,7 +221,9 @@ export const NodeBalancerConfigNode: React.FC<Props> = (props) => {
                 value={node.mode}
                 select
                 inputProps={{ 'data-node-idx': idx }}
-                onChange={onNodeModeChange}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  onNodeModeChange(e, idx)
+                }
                 errorText={nodesErrorMap.mode}
                 data-qa-backend-ip-mode
                 noMarginTop

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -201,11 +201,11 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
     }
   };
 
-  onNodeModeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const nodeIdx = e.currentTarget.getAttribute(DATA_NODE);
-    if (nodeIdx) {
-      this.props.onNodeModeChange!(+nodeIdx, e.target.value);
-    }
+  onNodeModeChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+    nodeIdx: number
+  ) => {
+    this.props.onNodeModeChange!(nodeIdx, e.target.value);
   };
 
   addNode = () => {


### PR DESCRIPTION
## Description 📝

- Fixes NodeBalanacer Mode Change Select
- Fixed by using function parameters rather than relying on the event

It was caused by this error
![Screen Shot 2023-01-12 at 6 24 37 PM](https://user-images.githubusercontent.com/115251059/212202353-dad37223-e95a-4c09-afc4-17279e4ef9c7.jpg)


## How to test 🧪

- Test changing the `Mode` of a nodebalancer node
- Verify you can change the mode and save it successfully
