### PR TITLE
Fix tests for Type-to-Confirm improvements

### DIFF
--- a/packages/manager/cypress/e2e/linodes/smoke-delete-linode.spec.ts
+++ b/packages/manager/cypress/e2e/linodes/smoke-delete-linode.spec.ts
@@ -10,6 +10,9 @@ describe('delete linode', () => {
       cy.intercept('DELETE', '*/linode/instances/*').as('deleteLinode');
       cy.visitWithLogin(`/linodes/${linode.id}`);
 
+      // Wait for content to load before performing actions via action menu.
+      cy.findByText('Stats for this Linode are not available yet');
+
       // delete linode
       ui.actionMenu
         .findByTitle(`Action menu for Linode ${linode.label}`)
@@ -24,11 +27,16 @@ describe('delete linode', () => {
       cy.get('@deleteButton').click();
 
       ui.dialog
-        .findByTitle(`Delete Linode ${linode.label}?`)
+        .findByTitle(`Delete ${linode.label}?`)
         .should('be.visible')
         .within(() => {
-          ui.button
-            .findByTitle('Delete Linode')
+          cy.findByLabelText('Linode Label')
+            .should('be.visible')
+            .click()
+            .type(linode.label);
+
+          ui.buttonGroup
+            .findButtonByTitle('Delete')
             .should('be.visible')
             .should('be.enabled')
             .click();

--- a/packages/manager/cypress/e2e/linodes/smoke-linode-landing-table.spec.ts
+++ b/packages/manager/cypress/e2e/linodes/smoke-linode-landing-table.spec.ts
@@ -40,7 +40,21 @@ const linodeLabel = (number) => {
 const deleteLinodeFromActionMenu = (linodeLabel) => {
   getClick(`[aria-label="Action menu for Linode ${linodeLabel}"]`);
   cy.get(`[data-qa-action-menu-item="Delete"]`).filter(`:visible`).click();
-  cy.findAllByRole('button').filter(':contains("Delete")').click();
+  ui.dialog
+    .findByTitle(`Delete ${linodeLabel}?`)
+    .should('be.visible')
+    .within(() => {
+      cy.findByLabelText('Linode Label')
+        .should('be.visible')
+        .click()
+        .type(linodeLabel);
+
+      ui.buttonGroup
+        .findButtonByTitle('Delete')
+        .should('be.visible')
+        .should('be.enabled')
+        .click();
+    });
   cy.wait('@deleteLinode').its('response.statusCode').should('eq', 200);
 };
 

--- a/packages/manager/cypress/e2e/objectStorage/object-storage.e2e.spec.ts
+++ b/packages/manager/cypress/e2e/objectStorage/object-storage.e2e.spec.ts
@@ -97,7 +97,7 @@ describe('object storage end-to-end tests', () => {
         .within(() => {
           cy.findByLabelText('Bucket Name').click().type(bucketLabel);
           ui.buttonGroup
-            .findButtonByTitle('Delete Bucket')
+            .findButtonByTitle('Delete')
             .should('be.visible')
             .should('be.enabled')
             .click();

--- a/packages/manager/cypress/e2e/objectStorage/object-storage.smoke.spec.ts
+++ b/packages/manager/cypress/e2e/objectStorage/object-storage.smoke.spec.ts
@@ -170,13 +170,17 @@ describe('object storage smoke tests', () => {
         cy.findByText('Delete').should('be.visible').click();
       });
 
-    ui.dialog.findByTitle(`Delete Bucket ${bucketLabel}`).should('be.visible');
-    cy.findByLabelText('Bucket Name').click().type(bucketLabel);
-    ui.buttonGroup
-      .findButtonByTitle('Delete Bucket')
-      .should('be.enabled')
+    ui.dialog
+      .findByTitle(`Delete Bucket ${bucketLabel}`)
       .should('be.visible')
-      .click();
+      .within(() => {
+        cy.findByLabelText('Bucket Name').click().type(bucketLabel);
+        ui.buttonGroup
+          .findButtonByTitle('Delete')
+          .should('be.enabled')
+          .should('be.visible')
+          .click();
+      });
 
     cy.wait('@deleteBucket');
     cy.findByText('Need help getting started?').should('be.visible');

--- a/packages/manager/cypress/e2e/volumes/create-volume.smoke.spec.ts
+++ b/packages/manager/cypress/e2e/volumes/create-volume.smoke.spec.ts
@@ -194,8 +194,13 @@ describe('volumes', () => {
       .findByTitle(`Detach Volume ${attachedVolumeLabel}?`)
       .should('be.visible')
       .within(() => {
+        cy.findByLabelText('Volume Label')
+          .should('be.visible')
+          .click()
+          .type(attachedVolumeLabel);
+
         ui.button
-          .findByTitle('Detach Volume')
+          .findByTitle('Detach')
           .should('be.visible')
           .should('be.enabled')
           .click();

--- a/packages/manager/cypress/e2e/volumes/delete-volume.spec.ts
+++ b/packages/manager/cypress/e2e/volumes/delete-volume.spec.ts
@@ -1,8 +1,10 @@
-import { createVolume, Volume } from '@linode/api-v4/lib/volumes';
+import { createVolume } from '@linode/api-v4/lib/volumes';
+import { Volume } from '@linode/api-v4/types';
 import { volumeRequestPayloadFactory } from 'src/factories/volume';
 import { authenticate } from 'support/api/authentication';
 import { assertToast } from 'support/ui/events';
 import { randomLabel } from 'support/util/random';
+import { ui } from 'support/ui';
 
 // Local storage override to force volume table to list up to 100 items.
 // This is a workaround while we wait to get stuck volumes removed.
@@ -39,11 +41,15 @@ describe('volume delete flow', () => {
         .click();
 
       // Cancel deletion when prompted to confirm.
-      cy.findByText(`Delete Volume ${volume.label}?`)
+      ui.dialog
+        .findByTitle(`Delete Volume ${volume.label}?`)
         .should('be.visible')
-        .closest('div[role="dialog"]')
         .within(() => {
-          cy.findByText('Cancel').click();
+          ui.buttonGroup
+            .findButtonByTitle('Cancel')
+            .should('be.visible')
+            .should('be.enabled')
+            .click();
         });
 
       // Confirm that volume is still listed and initiate deletion again.
@@ -54,11 +60,20 @@ describe('volume delete flow', () => {
         .click();
 
       // Confirm deletion.
-      cy.findByText(`Delete Volume ${volume.label}?`)
+      ui.dialog
+        .findByTitle(`Delete Volume ${volume.label}?`)
         .should('be.visible')
-        .closest('div[role="dialog"]')
         .within(() => {
-          cy.findByText('Delete Volume').click();
+          cy.findByLabelText('Volume Label')
+            .should('be.visible')
+            .click()
+            .type(volume.label);
+
+          ui.buttonGroup
+            .findButtonByTitle('Delete')
+            .should('be.visible')
+            .should('be.enabled')
+            .click();
         });
 
       // Confirm that volume is deleted.


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
Updates E2E tests to account for type to confirm improvements. This should fix the ~6 tests that have been failing recently as a result.

## How to test 🧪

**How do I run relevant unit or e2e tests?**
```bash
yarn cy:run -s "cypress/e2e/linodes/smoke-delete-linode.spec.ts,cypress/e2e/linodes/smoke-linode-landing-table.spec.ts,cypress/e2e/objectStorage/object-storage.e2e.spec.ts,cypress/e2e/objectStorage/object-storage.smoke.spec.ts,cypress/e2e/volumes/create-volume.smoke.spec.ts,cypress/e2e/volumes/delete-volume.spec.ts"
```

Note that I have observed some flakiness in `create-volume.smoke.spec.ts` that's unrelated to these changes; try re-running those tests if you happen to encounter a failure when you run the command above.