### PR TITLE
Use `@types/react-csv` for `react-csv`

### DIFF
--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -168,6 +168,7 @@
     "@types/ramda": "0.25.16",
     "@types/reach__router": "^1.3.10",
     "@types/react": "^17.0.27",
+    "@types/react-csv": "^1.1.3",
     "@types/react-dom": "^17.0.9",
     "@types/react-page-visibility": "^6.4.1",
     "@types/react-redux": "~7.1.7",

--- a/packages/manager/src/types/index.ts
+++ b/packages/manager/src/types/index.ts
@@ -5,5 +5,3 @@
  */
 declare module '*.svg';
 declare module '*.png';
-
-declare module 'react-csv';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3932,6 +3932,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-csv@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@types/react-csv/-/react-csv-1.1.3.tgz#b93a33314d71e8e3c5c41b20d19a2912c6e642c8"
+  integrity sha512-dkEdyRvRpygSnNg4cyzYWSUjukIQ5lAtXJwc7BqyUfzww/Cv2dcAFGYd+sWTFpGiDNZMVPp6vVPLcAPvJID8Kg==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-dom@*":
   version "18.0.9"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.9.tgz#ffee5e4bfc2a2f8774b15496474f8e7fe8d0b504"


### PR DESCRIPTION
## Description 📝

- We use `react-csv` but we did not install typescript types for it
- This PR adds a real typescript `@types/...` package for `react-csv`

## How to test 🧪

- Nothing really to test here, just verify the app runs locally without errors and passes all builds in CI
