### PR TITLE
Switch `require`s to `import`s for `highlight.js` Languages

### DIFF
--- a/packages/manager/src/components/HighlightedMarkdown/HighlightedMarkdown.tsx
+++ b/packages/manager/src/components/HighlightedMarkdown/HighlightedMarkdown.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 import classNames from 'classnames';
 import * as hljs from 'highlight.js/lib/core';
 import * as React from 'react';
@@ -8,17 +7,17 @@ import 'src/formatted-text.css';
 import { sanitizeHTML } from 'src/utilities/sanitize-html';
 import { unsafe_MarkdownIt } from 'src/utilities/markdown';
 import sanitize from 'sanitize-html';
-// Register all languages we intend to use
-// This is not great. Require doesn't work in the broswer and modern TS/JS tooling
-// gets very upset.
-hljs.registerLanguage('apache', require('highlight.js/lib/languages/apache'));
-hljs.registerLanguage('bash', require('highlight.js/lib/languages/bash'));
-hljs.registerLanguage(
-  'javascript',
-  require('highlight.js/lib/languages/javascript')
-);
-hljs.registerLanguage('nginx', require('highlight.js/lib/languages/nginx'));
-hljs.registerLanguage('yaml', require('highlight.js/lib/languages/yaml'));
+import apache from 'highlight.js/lib/languages/apache';
+import bash from 'highlight.js/lib/languages/bash';
+import javascript from 'highlight.js/lib/languages/javascript';
+import nginx from 'highlight.js/lib/languages/nginx';
+import yaml from 'highlight.js/lib/languages/yaml';
+
+hljs.registerLanguage('apache', apache);
+hljs.registerLanguage('bash', bash);
+hljs.registerLanguage('javascript', javascript);
+hljs.registerLanguage('nginx', nginx);
+hljs.registerLanguage('yaml', yaml);
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {


### PR DESCRIPTION
## Description 📝

- Switches `require` statements to`import` statements in `HighlightedMarkdown.tsx` to match our current import patterns and better support modern build tools
- There should be no visible change

## How to test 🧪

- Verify the app builds and runs as normal
- Check a component such as the Kubernetes Kube Config Drawer to verify yaml is highlighted as you would expect (compare to production to verify)