### PR TITLE
Update and Modernize Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,18 +10,17 @@ jobs:
   build-validation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: "14.17.4"
+          node-version: "16"
+          cache: 'yarn'
       - run: yarn --frozen-lockfile
       - run: yarn workspace @linode/validation run build
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: packages-validation-lib
-          path: |
-            packages/validation/index.js
-            packages/validation/lib
+          path: packages/validation/lib
 
   publish-validation:
     runs-on: ubuntu-latest
@@ -29,8 +28,8 @@ jobs:
     needs:
       - build-validation
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: packages-validation-lib
           path: packages/validation
@@ -55,17 +54,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-validation
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: "14.17.4"
-      - uses: actions/cache@v2
-        with:
-          path: |
-            **/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          node-version: "16"
+          cache: 'yarn'
       - run: yarn --frozen-lockfile
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: packages-validation-lib
           path: packages/validation
@@ -76,48 +71,37 @@ jobs:
     needs:
       - test-sdk
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: "14.17.4"
-      - uses: actions/cache@v2
-        with:
-          path: |
-            **/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/download-artifact@v2
+          node-version: "16"
+          cache: 'yarn'
+      - uses: actions/download-artifact@v3
         with:
           name: packages-validation-lib
           path: packages/validation
       - run: yarn --frozen-lockfile
       - run: yarn workspace @linode/api-v4 run build
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: packages-api-v4-lib
-          path: |
-            packages/api-v4/index.js
-            packages/api-v4/index.node.js
-            packages/api-v4/lib
+          path: packages/api-v4/lib
 
   test-manager:
     runs-on: ubuntu-latest
     needs:
       - build-sdk
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: "14.17.4"
-      - uses: actions/cache@v2
-        with:
-          path: |
-            **/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/download-artifact@v2
+          node-version: "16"
+          cache: 'yarn'
+      - uses: actions/download-artifact@v3
         with:
           name: packages-validation-lib
           path: packages/validation
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: packages-api-v4-lib
           path: packages/api-v4
@@ -130,27 +114,23 @@ jobs:
     needs:
       - build-sdk
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: "14.17.4"
-      - uses: actions/cache@v2
-        with:
-          path: |
-            **/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          node-version: "16"
+          cache: 'yarn'
       - run: cp packages/manager/config/environments/beta packages/manager/.env
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: packages-validation-lib
           path: packages/validation
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: packages-api-v4-lib
           path: packages/api-v4
       - run: yarn --frozen-lockfile
       - run: yarn workspace linode-manager run build
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: packages-manager-build
           path: packages/manager/build
@@ -164,8 +144,8 @@ jobs:
       # If the validation publish failed we could have mismatched versions and a broken JS client
       - publish-validation
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: packages-api-v4-lib
           path: packages/api-v4
@@ -193,8 +173,8 @@ jobs:
       - test-manager
       - build-manager
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: packages-manager-build
           path: packages/manager/build
@@ -215,26 +195,22 @@ jobs:
     needs:
       - build-sdk
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: "14.17.4"
-      - uses: actions/cache@v2
-        with:
-          path: |
-            **/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/download-artifact@v2
+          node-version: "16"
+          cache: 'yarn'
+      - uses: actions/download-artifact@v3
         with:
           name: packages-validation-lib
           path: packages/validation
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: packages-api-v4-lib
           path: packages/api-v4
       - run: yarn --frozen-lockfile
       - run: yarn workspace linode-manager run build-storybook
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: storybook-build
           path: packages/manager/storybook-static
@@ -245,8 +221,8 @@ jobs:
     needs:
       - build-storybook
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: storybook-build
           path: storybook/build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: packages-validation-lib
-          path: packages/validation
+          path: packages/validation/lib
       - run: yarn workspace @linode/api-v4 run test
 
   build-sdk:
@@ -79,7 +79,7 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: packages-validation-lib
-          path: packages/validation
+          path: packages/validation/lib
       - run: yarn --frozen-lockfile
       - run: yarn workspace @linode/api-v4 run build
       - uses: actions/upload-artifact@v3
@@ -100,11 +100,11 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: packages-validation-lib
-          path: packages/validation
+          path: packages/validation/lib
       - uses: actions/download-artifact@v3
         with:
           name: packages-api-v4-lib
-          path: packages/api-v4
+          path: packages/api-v4/lib
       - run: yarn --frozen-lockfile
       - run: yarn workspace linode-manager run test
 
@@ -123,11 +123,11 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: packages-validation-lib
-          path: packages/validation
+          path: packages/validation/lib
       - uses: actions/download-artifact@v3
         with:
           name: packages-api-v4-lib
-          path: packages/api-v4
+          path: packages/api-v4/lib
       - run: yarn --frozen-lockfile
       - run: yarn workspace linode-manager run build
       - uses: actions/upload-artifact@v3
@@ -148,7 +148,7 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: packages-api-v4-lib
-          path: packages/api-v4
+          path: packages/api-v4/lib
       - uses: JS-DevTools/npm-publish@v1
         id: npm-publish
         with:
@@ -203,11 +203,11 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: packages-validation-lib
-          path: packages/validation
+          path: packages/validation/lib
       - uses: actions/download-artifact@v3
         with:
           name: packages-api-v4-lib
-          path: packages/api-v4
+          path: packages/api-v4/lib
       - run: yarn --frozen-lockfile
       - run: yarn workspace linode-manager run build-storybook
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
## Description 📝

- Update Github Actions actions to newer versions
- Uses `actions/setup-node@v3` to handle caching rather than using `actions/cache` manually
- Added cache to build-validation
  - I want to re-enable it, but we should do this with caution https://github.com/linode/manager/pull/7475

## How to test 🧪

- Observe Github Actions CI for speed and success
