### PR TITLE
refactor: [M3-6070] - Increase minimum acceptable password strength

### DIFF
--- a/packages/api-v4/src/constants.ts
+++ b/packages/api-v4/src/constants.ts
@@ -2,6 +2,6 @@ export const API_ROOT = 'https://api.linode.com/v4';
 export const BETA_API_ROOT = API_ROOT + 'beta';
 
 // Value from  1-4 reflecting a minimum score from zxcvbn
-export const MINIMUM_PASSWORD_STRENGTH = 2;
+export const MINIMUM_PASSWORD_STRENGTH = 4;
 
 export const MAX_VOLUME_SIZE = 10240;

--- a/packages/manager/src/components/PasswordInput/PasswordInput.tsx
+++ b/packages/manager/src/components/PasswordInput/PasswordInput.tsx
@@ -83,13 +83,9 @@ const PasswordInput: React.FC<CombinedProps> = (props) => {
 const maybeStrength = (value?: string) => {
   if (!value || isEmpty(value)) {
     return null;
-  } else {
-    const score = zxcvbn(value).score;
-    if (score === 4) {
-      return 3;
-    }
-    return score;
   }
+
+  return zxcvbn(value).score;
 };
 
 export default React.memo(PasswordInput);

--- a/packages/manager/src/components/PasswordInput/StrengthIndicator.test.tsx
+++ b/packages/manager/src/components/PasswordInput/StrengthIndicator.test.tsx
@@ -20,6 +20,7 @@ describe('convertStrengthScore', () => {
     expect(convertStrengthScore(0)).toBe(' Weak');
     expect(convertStrengthScore(1)).toBe(' Weak');
     expect(convertStrengthScore(2)).toBe(' Fair');
-    expect(convertStrengthScore(3)).toBe(' Good');
+    expect(convertStrengthScore(3)).toBe(' Fair');
+    expect(convertStrengthScore(4)).toBe(' Good');
   });
 });

--- a/packages/manager/src/components/PasswordInput/StrengthIndicator.test.tsx
+++ b/packages/manager/src/components/PasswordInput/StrengthIndicator.test.tsx
@@ -1,0 +1,25 @@
+import { render } from '@testing-library/react';
+import * as React from 'react';
+import StrengthIndicator, { convertStrengthScore } from './StrengthIndicator';
+import { wrapWithTheme } from 'src/utilities/testHelpers';
+
+describe('StrengthIndicator', () => {
+  it('renders a StrengthIndicator', () => {
+    const { queryByText } = render(
+      wrapWithTheme(
+        <StrengthIndicator strength={1} hideStrengthLabel={false} />
+      )
+    );
+    expect(queryByText('Strength:')).toBeTruthy();
+  });
+});
+
+describe('convertStrengthScore', () => {
+  it('converts the scores into the correct scale', () => {
+    expect(convertStrengthScore(null)).toBe(' Weak');
+    expect(convertStrengthScore(0)).toBe(' Weak');
+    expect(convertStrengthScore(1)).toBe(' Weak');
+    expect(convertStrengthScore(2)).toBe(' Fair');
+    expect(convertStrengthScore(3)).toBe(' Good');
+  });
+});

--- a/packages/manager/src/components/PasswordInput/StrengthIndicator.tsx
+++ b/packages/manager/src/components/PasswordInput/StrengthIndicator.tsx
@@ -64,7 +64,7 @@ const StrengthIndicator: React.FC<CombinedProps> = (props: Props) => {
           <div
             className={classNames({
               [classes.block]: true,
-              [`strength-${strength}`]: !isNil(strength) && idx <= strength,
+              [`strength-${strength}`]: !isNil(strength) && idx < strength,
             })}
           />
         </Grid>
@@ -94,8 +94,9 @@ export const convertStrengthScore = (strength: StrengthValues) => {
     case 1:
       return ' Weak';
     case 2:
-      return ' Fair';
     case 3:
+      return ' Fair';
+    case 4:
       return ' Good';
     default:
       return ' Weak';

--- a/packages/manager/src/components/PasswordInput/StrengthIndicator.tsx
+++ b/packages/manager/src/components/PasswordInput/StrengthIndicator.tsx
@@ -1,5 +1,4 @@
 import classNames from 'classnames';
-import { isNil } from 'ramda';
 import * as React from 'react';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
@@ -44,9 +43,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-type CombinedProps = Props;
-
-const StrengthIndicator: React.FC<CombinedProps> = (props: Props) => {
+const StrengthIndicator = (props: Props) => {
   const classes = useStyles();
 
   const { strength, hideStrengthLabel } = props;
@@ -64,7 +61,10 @@ const StrengthIndicator: React.FC<CombinedProps> = (props: Props) => {
           <div
             className={classNames({
               [classes.block]: true,
-              [`strength-${strength}`]: !isNil(strength) && idx < strength,
+              [`strength-${strength}`]:
+                strength !== undefined &&
+                strength !== null &&
+                idx <= scaledStrength(strength),
             })}
           />
         </Grid>
@@ -86,6 +86,22 @@ const StrengthIndicator: React.FC<CombinedProps> = (props: Props) => {
 };
 
 export default StrengthIndicator;
+
+const scaledStrength = (strength: number) => {
+  if ([0, 1].includes(strength)) {
+    return 1;
+  }
+
+  if ([2, 3].includes(strength)) {
+    return 2;
+  }
+
+  if (strength === 4) {
+    return 3;
+  }
+
+  return 0;
+};
 
 export const convertStrengthScore = (strength: StrengthValues) => {
   switch (strength) {

--- a/packages/manager/src/components/PasswordInput/StrengthIndicator.tsx
+++ b/packages/manager/src/components/PasswordInput/StrengthIndicator.tsx
@@ -1,66 +1,55 @@
 import classNames from 'classnames';
 import { isNil } from 'ramda';
 import * as React from 'react';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles,
-} from 'src/components/core/styles';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 
+type StrengthValues = null | 0 | 1 | 2 | 3 | 4;
 interface Props {
-  strength: null | 0 | 1 | 2 | 3;
+  strength: StrengthValues;
   hideStrengthLabel?: boolean;
 }
-type ClassNames =
-  | 'root'
-  | 'block'
-  | 'strengthText'
-  | 'strengthLabel'
-  | 'blockOuter';
 
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {
-      maxWidth: `calc(415px + ${theme.spacing(1)})`,
-      [theme.breakpoints.down('sm')]: {
-        maxWidth: `calc(100% + ${theme.spacing(1)})`,
-      },
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    maxWidth: `calc(415px + ${theme.spacing(1)})`,
+    [theme.breakpoints.down('sm')]: {
+      maxWidth: `calc(100% + ${theme.spacing(1)})`,
     },
-    block: {
-      backgroundColor: '#C9CACB',
-      height: '4px',
-      transition: 'background-color .5s ease-in-out',
-      '&[class*="strength-"]': {
-        backgroundColor: theme.palette.primary.main,
-      },
+  },
+  block: {
+    backgroundColor: '#C9CACB',
+    height: '4px',
+    transition: 'background-color .5s ease-in-out',
+    '&[class*="strength-"]': {
+      backgroundColor: theme.palette.primary.main,
     },
-    strengthText: {
-      position: 'relative',
-      fontSize: '.85rem',
-      textAlign: 'right',
-      [theme.breakpoints.down('sm')]: {
-        textAlign: 'center',
-      },
+  },
+  strengthText: {
+    position: 'relative',
+    fontSize: '.85rem',
+    textAlign: 'right',
+    [theme.breakpoints.down('sm')]: {
+      textAlign: 'center',
     },
-    strengthLabel: {
-      [theme.breakpoints.down('sm')]: {
-        display: 'none',
-      },
+  },
+  strengthLabel: {
+    [theme.breakpoints.down('sm')]: {
+      display: 'none',
     },
-    blockOuter: {
-      padding: '4px !important' as '4px',
-    },
-  });
+  },
+  blockOuter: {
+    padding: '4px !important' as '4px',
+  },
+}));
 
-const styled = withStyles(styles);
+type CombinedProps = Props;
 
-type CombinedProps = Props & WithStyles<ClassNames>;
+const StrengthIndicator: React.FC<CombinedProps> = (props: Props) => {
+  const classes = useStyles();
 
-const StrengthIndicator: React.FC<CombinedProps> = (props) => {
-  const { classes, strength, hideStrengthLabel } = props;
+  const { strength, hideStrengthLabel } = props;
 
   return (
     <Grid
@@ -89,15 +78,26 @@ const StrengthIndicator: React.FC<CombinedProps> = (props) => {
           {!hideStrengthLabel && (
             <span className={classes.strengthLabel}>Strength:</span>
           )}
-          {strength
-            ? (strength === 1 && ' Weak') ||
-              (strength === 2 && ' Fair') ||
-              (strength === 3 && ' Good')
-            : ' Weak'}
+          {convertStrengthScore(strength)}
         </Typography>
       </Grid>
     </Grid>
   );
 };
 
-export default styled(StrengthIndicator);
+export default StrengthIndicator;
+
+export const convertStrengthScore = (strength: StrengthValues) => {
+  switch (strength) {
+    case null:
+    case 0:
+    case 1:
+      return ' Weak';
+    case 2:
+      return ' Fair';
+    case 3:
+      return ' Good';
+    default:
+      return ' Weak';
+  }
+};

--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -250,7 +250,7 @@ export const OBJECT_STORAGE_ROOT = 'linodeobjects.com';
 export const OBJECT_STORAGE_DELIMITER = '/';
 
 // Value from  1-4 reflecting a minimum score from zxcvbn
-export const MINIMUM_PASSWORD_STRENGTH = 2;
+export const MINIMUM_PASSWORD_STRENGTH = 4;
 
 // When true, use the mock API defined in serverHandlers.ts instead of making network requests
 export const MOCK_SERVICE_WORKER =

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
@@ -22,6 +22,7 @@ import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import { debounce } from 'throttle-debounce';
 import { withLinodeDetailContext } from '../linodeDetailContext';
+import { validatePassword } from 'src/utilities/validatePassword';
 
 interface Props {
   isBareMetalInstance: boolean;
@@ -68,6 +69,22 @@ class LinodeSettingsPasswordPanel extends React.Component<
     const { linodeId, isBareMetalInstance } = this.props;
 
     if (!diskId && !isBareMetalInstance) {
+      return;
+    }
+
+    // Enforce password complexity/requirements
+    const passwordError = validatePassword(value);
+    if (passwordError) {
+      this.setState({
+        ...this.state,
+        success: undefined,
+        errors: [
+          {
+            field: 'password',
+            reason: passwordError,
+          },
+        ],
+      });
       return;
     }
 


### PR DESCRIPTION
## Description 📝

- Increase `MINIMUM_PASSWORD_STRENGTH` from 2 to 4
- Refactors in `StrengthIndicator.tsx` to bring it up-to-date with our modern code conventions
- Add unit tests for `StrengthIndicator.tsx`
- Don't scale scores of 4 down in `PasswordInput.tsx`
- Enforce password complexity/requirements in `LinodeSettingsPasswordPanel.tsx`

`Do Not Merge` until the 3/6 release process begins.

## How to test 🧪
- Ensure that the strength indicators for password inputs throughout the app have not been adversely impacted.
- Run `yarn test strengthindicator`
