### PR TITLE
M3-6039: Update FirewallRuleTable to support screen readers

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -54,8 +54,17 @@ const useStyles = makeStyles((theme: Theme) => ({
     backgroundColor: 'transparent',
     border: 'none',
   },
+  unmodified: {
+    backgroundColor: '#FFFFFF',
+  },
   highlight: {
     backgroundColor: theme.bg.lightBlue1,
+  },
+  disabled: {
+    backgroundColor: 'rgba(247, 247, 247, 0.25)',
+    '& td': {
+      color: '#D2D3D4',
+    },
   },
   error: {
     '& p': { color: theme.color.red },
@@ -72,6 +81,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   labelCol: {
     paddingLeft: 6,
     whiteSpace: 'nowrap',
+  },
+  ruleGrid: {
+    spacing: 0,
   },
   ruleList: {
     backgroundColor: theme.color.border3,
@@ -92,7 +104,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   // },
   ruleRow: {
     margin: 0,
-    background: '#FFFFFF',
     borderBottom: '1px solid #F4F5F6',
     alignItems: 'center',
     rowSpacing: 0.5,
@@ -228,7 +239,7 @@ const FirewallRuleTable: React.FC<CombinedProps> = (props) => {
       <Grid
         container
         aria-label={`${category} Rules List`}
-        tabIndex={0}
+        // tabIndex={0}
         style={{ margin: 0 }}
       >
         <Grid
@@ -353,7 +364,6 @@ type FirewallRuleTableRowProps = RuleRow &
     innerRef: any;
     isDragging: boolean;
     disabled: boolean;
-    highlight?: boolean | undefined;
   };
 
 const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
@@ -364,7 +374,6 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
       id,
       action,
       label,
-      // description,
       protocol,
       ports,
       addresses,
@@ -374,10 +383,10 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
       triggerOpenRuleDrawerForEditing,
       triggerUndo,
       errors,
-      // innerRef,
+      innerRef,
       // isDragging,
       disabled,
-      // originalIndex,
+      originalIndex,
       // ...rest
     } = props;
 
@@ -393,17 +402,19 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
       <Grid
         container
         key={id}
-        // highlight={
-        //   // Highlight the row if it's been modified or reordered. ID is the
-        //   // current index, so if it doesn't match the original index we know
-        //   // that the rule has been moved.
-        //   status === 'MODIFIED' || status === 'NEW' || originalIndex !== id
-        // }
-        // disabled={status === 'PENDING_DELETION' || disabled}
-        // domRef={innerRef}
-        className={classes.ruleRow}
+        ref={innerRef}
         aria-label={label}
         role="option"
+        className={classNames({
+          [classes.ruleRow]: true,
+          // Highlight the row if it's been modified or reordered. ID is the
+          // current index, so if it doesn't match the original index we know
+          // that the rule has been moved.
+          [classes.unmodified]: status === 'NOT_MODIFIED',
+          [classes.highlight]:
+            status === 'MODIFIED' || status === 'NEW' || originalIndex !== id,
+          [classes.disabled]: status === 'PENDING_DELETION' || disabled,
+        })}
       >
         <Grid
           item

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -33,6 +33,16 @@ import { ExtendedFirewallRule, RuleStatus } from './firewallRuleEditor';
 import { Category, FirewallRuleError, sortPortString } from './shared';
 
 const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    '& .MuiGrid-root': {
+      margin: 0,
+      alignItems: 'center',
+      fontSize: '.875rem',
+    },
+    '& .MuiGrid-spacing-xs-2 > .MuiGrid-item': {
+      padding: 0,
+    },
+  },
   header: {
     display: 'flex',
     justifyContent: 'space-between',
@@ -83,7 +93,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     whiteSpace: 'nowrap',
   },
   ruleGrid: {
-    margin: 0,
     width: '100%',
   },
   ruleList: {
@@ -97,18 +106,17 @@ const useStyles = makeStyles((theme: Theme) => ({
   ruleHeaderRow: {
     marginTop: '5px',
     background: '#F9FAFA',
-    color: '#878F91',
     fontWeight: 'bold',
     height: '40px',
+    alignContent: 'center',
+  },
+  ruleHeaderItem: {
+    border: '1px solid #F4F5F6',
+    padding: 8,
   },
   ruleRow: {
     borderBottom: '1px solid #F4F5F6',
-    alignItems: 'center',
   },
-  // ruleCell: {
-  //   backgroundColor: '#FFFFFF',
-  //   padding: 10,
-  // },
   addLabelButton: {
     ...theme.applyLinkStyles,
   },
@@ -129,6 +137,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   policyText: {
     textAlign: 'right',
+    padding: '8px !important',
   },
   policySelect: {
     paddingLeft: 4,
@@ -138,6 +147,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   policyRow: {
     marginTop: '10px !important',
+    justifyContent: 'center',
   },
 }));
 
@@ -236,12 +246,11 @@ const FirewallRuleTable: React.FC<CombinedProps> = (props) => {
       <Grid
         container
         aria-label={`${category} Rules List`}
-        // tabIndex={0}
-        className={classes.ruleGrid}
+        className={classes.root}
       >
         <Grid
           container
-          className={classNames(classes.ruleHeaderRow, classes.ruleGrid)}
+          className={classes.ruleHeaderRow}
           aria-label={`${category} Rules List Headers`}
           tabIndex={0}
         >
@@ -250,13 +259,12 @@ const FirewallRuleTable: React.FC<CombinedProps> = (props) => {
             style={{
               paddingLeft: 27,
               width: xsDown ? '50%' : '30%',
-              border: '1px solid #F4F5F6',
             }}
           >
             Label
           </Grid>
           <Hidden lgDown>
-            <Grid item style={{ width: '10%', border: '1px solid #F4F5F6' }}>
+            <Grid item style={{ width: '10%' }}>
               Protocol
             </Grid>
           </Hidden>
@@ -266,24 +274,19 @@ const FirewallRuleTable: React.FC<CombinedProps> = (props) => {
               style={{
                 whiteSpace: 'nowrap',
                 width: '10%',
-                border: '1px solid #F4F5F6',
               }}
             >
               Port Range
             </Grid>
-            <Grid item style={{ width: '15%', border: '1px solid #F4F5F6' }}>
+            <Grid item style={{ width: '15%' }}>
               {capitalize(addressColumnLabel)}
             </Grid>
           </Hidden>
-          <Grid
-            item
-            className={classes.ruleGrid}
-            style={{ width: '5%', border: '1px solid #F4F5F6' }}
-          >
+          <Grid item style={{ width: '5%' }}>
             Action
           </Grid>
         </Grid>
-        <Grid container className={classes.ruleGrid}>
+        <Grid container>
           <DragDropContext onDragEnd={onDragEnd}>
             <Droppable droppableId="droppable" isDropDisabled={disabled}>
               {(provided) => (
@@ -293,7 +296,16 @@ const FirewallRuleTable: React.FC<CombinedProps> = (props) => {
                   {...provided.droppableProps}
                 >
                   {rowData.length === 0 ? (
-                    <Grid container data-testid={'table-row-empty'}>
+                    <Grid
+                      container
+                      data-testid={'table-row-empty'}
+                      className={classNames(classes.unmodified)}
+                      style={{
+                        padding: 8,
+                        width: '100%',
+                        justifyContent: 'center',
+                      }}
+                    >
                       <Grid item>{zeroRulesMessage}</Grid>
                     </Grid>
                   ) : (
@@ -303,7 +315,7 @@ const FirewallRuleTable: React.FC<CombinedProps> = (props) => {
                         draggableId={String(thisRuleRow.id)}
                         index={index}
                       >
-                        {(provided, snapshot) => (
+                        {(provided) => (
                           <li
                             key={thisRuleRow.id}
                             role="option"
@@ -314,7 +326,6 @@ const FirewallRuleTable: React.FC<CombinedProps> = (props) => {
                             {...provided.dragHandleProps}
                           >
                             <FirewallRuleTableRow
-                              isDragging={snapshot.isDragging}
                               disabled={disabled}
                               triggerCloneFirewallRule={
                                 triggerCloneFirewallRule
@@ -328,8 +339,6 @@ const FirewallRuleTable: React.FC<CombinedProps> = (props) => {
                               triggerUndo={triggerUndo}
                               innerRef={provided.innerRef}
                               {...thisRuleRow}
-                              {...provided.draggableProps}
-                              {...provided.dragHandleProps}
                             />
                           </li>
                         )}
@@ -363,7 +372,6 @@ export default React.memo(FirewallRuleTable);
 type FirewallRuleTableRowProps = RuleRow &
   Omit<RowActionHandlers, 'triggerReorder'> & {
     innerRef: any;
-    isDragging: boolean;
     disabled: boolean;
   };
 
@@ -403,7 +411,6 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
         key={id}
         ref={innerRef}
         aria-label={label}
-        role="option"
         className={classNames({
           [classes.ruleGrid]: true,
           [classes.ruleRow]: true,
@@ -418,8 +425,9 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
       >
         <Grid
           item
-          style={{ paddingLeft: 27, width: 'xsDown' ? '20%' : '15%' }}
+          style={{ paddingLeft: 27, width: 'xsDown' ? '30%' : '15%' }}
           aria-label={`Label: ${label}`}
+          tabIndex={0}
         >
           <DragIndicator
             className={classes.dragIcon}
@@ -477,7 +485,7 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
         >
           {capitalize(action?.toLocaleLowerCase() ?? '')}
         </Grid>
-        <Grid item>
+        <Grid item style={{ marginLeft: 'auto' }}>
           {status !== 'NOT_MODIFIED' ? (
             <div className={classes.undoButtonContainer}>
               <button
@@ -535,16 +543,11 @@ export const PolicyRow: React.FC<PolicyRowProps> = React.memo((props) => {
   );
 
   return (
-    <Grid
-      container
-      className={classNames(classes.policyRow, classes.ruleGrid)}
-      tabIndex={0}
-      justifyContent="center"
-    >
-      <Grid item className={classes.policyText}>
+    <Grid container className={classes.policyRow} tabIndex={0}>
+      <Grid item /*xs={colSpan}*/ className={classes.policyText}>
         {helperText}
       </Grid>
-      <Grid item className={classes.policySelect}>
+      <Grid item xs={1} className={classes.policySelect}>
         <Select
           className={classes.policySelectInner}
           label={`${category} policy`}

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -41,6 +41,10 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
     '& .MuiGrid-spacing-xs-2 > .MuiGrid-item': {
       padding: 0,
+      [theme.breakpoints.down('md')]: {
+        marginLeft: theme.spacing(),
+        marginRight: theme.spacing(),
+      },
     },
   },
   header: {
@@ -95,6 +99,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   ruleGrid: {
     width: '100%',
+    margin: 0,
   },
   ruleList: {
     backgroundColor: theme.color.border3,
@@ -109,15 +114,11 @@ const useStyles = makeStyles((theme: Theme) => ({
     backgroundColor: '#F9FAFA',
     color: '#888F91',
     fontWeight: 'bold',
-    height: '40px',
-    alignContent: 'center',
-  },
-  ruleHeaderItem: {
-    border: '1px solid #F4F5F6',
-    padding: 8,
+    height: '46px',
   },
   ruleRow: {
     borderBottom: '1px solid #F4F5F6',
+    height: '40px',
   },
   addLabelButton: {
     ...theme.applyLinkStyles,
@@ -139,7 +140,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   policyText: {
     textAlign: 'right',
-    padding: '10px !important',
+    padding: '0px 15px 0px 15px !important',
   },
   policySelect: {
     paddingLeft: 4,
@@ -150,6 +151,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   policyRow: {
     marginTop: '10px !important',
     justifyContent: 'center',
+    height: '40px',
   },
 }));
 
@@ -251,7 +253,7 @@ const FirewallRuleTable: React.FC<CombinedProps> = (props) => {
       <Grid
         container
         aria-label={`${category} Rules List`}
-        className={classes.root}
+        className={classNames(classes.root, classes.ruleGrid)}
       >
         <Grid
           container
@@ -343,7 +345,6 @@ const FirewallRuleTable: React.FC<CombinedProps> = (props) => {
                                 triggerOpenRuleDrawerForEditing
                               }
                               triggerUndo={triggerUndo}
-                              innerRef={provided.innerRef}
                               {...thisRuleRow}
                             />
                           </li>
@@ -377,13 +378,14 @@ export default React.memo(FirewallRuleTable);
 // =============================================================================
 type FirewallRuleTableRowProps = RuleRow &
   Omit<RowActionHandlers, 'triggerReorder'> & {
-    innerRef: any;
     disabled: boolean;
   };
 
 const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
   (props) => {
     const classes = useStyles();
+    const theme: Theme = useTheme();
+    const xsDown = useMediaQuery(theme.breakpoints.down('sm'));
 
     const {
       id,
@@ -398,7 +400,6 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
       triggerOpenRuleDrawerForEditing,
       triggerUndo,
       errors,
-      innerRef,
       disabled,
       originalIndex,
     } = props;
@@ -415,7 +416,6 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
       <Grid
         container
         key={id}
-        ref={innerRef}
         aria-label={label}
         className={classNames({
           [classes.ruleGrid]: true,
@@ -431,7 +431,7 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
       >
         <Grid
           item
-          style={{ paddingLeft: 8, width: 'xsDown' ? '30%' : '15%' }}
+          style={{ paddingLeft: 8, width: xsDown ? '50%' : '30%' }}
           aria-label={`Label: ${label}`}
         >
           <DragIndicator
@@ -455,7 +455,7 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
           <Grid
             item
             style={{ width: '10%' }}
-            tabIndex={-1}
+            tabIndex={0}
             aria-label={`Protocol: ${protocol}`}
           >
             {protocol}
@@ -466,7 +466,7 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
           <Grid
             item
             style={{ whiteSpace: 'nowrap', width: '10%' }}
-            tabIndex={-1}
+            tabIndex={0}
             aria-label={`Ports: ${ports}`}
           >
             {ports === '1-65535' ? 'All Ports' : ports}
@@ -475,7 +475,7 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
           <Grid
             item
             style={{ whiteSpace: 'nowrap', width: '15%' }}
-            tabIndex={-1}
+            tabIndex={0}
             aria-label={`Addresses: ${addresses}`}
           >
             {addresses}{' '}
@@ -485,7 +485,7 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
         <Grid
           item
           style={{ width: '5%' }}
-          tabIndex={-1}
+          tabIndex={0}
           aria-label={`Action: ${action}`}
         >
           {capitalize(action?.toLocaleLowerCase() ?? '')}
@@ -534,9 +534,9 @@ export const PolicyRow: React.FC<PolicyRowProps> = React.memo((props) => {
   // Calculate how many cells the text should span so that the Select lines up
   // with the Action column
   const theme: Theme = useTheme();
-  // const xsDown = useMediaQuery(theme.breakpoints.down('sm'));
+  const xsDown = useMediaQuery(theme.breakpoints.down('sm'));
   const mdDown = useMediaQuery(theme.breakpoints.down('lg'));
-  // const colSpan = xsDown ? 1 : mdDown ? 3 : 4;
+  const colSpan = xsDown ? 3 : mdDown ? 5 : 7;
 
   const helperText = mdDown ? (
     <strong>{capitalize(category)} policy:</strong>
@@ -553,10 +553,10 @@ export const PolicyRow: React.FC<PolicyRowProps> = React.memo((props) => {
       className={classNames(classes.policyRow, classes.unmodified)}
       tabIndex={0}
     >
-      <Grid item /*xs={colSpan}*/ className={classes.policyText}>
+      <Grid item xs={colSpan} className={classes.policyText}>
         {helperText}
       </Grid>
-      <Grid item xs={1} className={classes.policySelect}>
+      <Grid item xs={4} className={classes.policySelect}>
         <Select
           className={classes.policySelectInner}
           label={`${category} policy`}

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -11,6 +11,7 @@ import {
 import DragIndicator from 'src/assets/icons/drag-indicator.svg';
 import Undo from 'src/assets/icons/undo.svg';
 import Button from 'src/components/Button';
+import Grid from 'src/components/Grid';
 import Hidden from 'src/components/core/Hidden';
 import {
   makeStyles,
@@ -18,15 +19,8 @@ import {
   useMediaQuery,
   useTheme,
 } from 'src/components/core/styles';
-import TableBody from 'src/components/core/TableBody';
-import TableFooter from 'src/components/core/TableFooter';
-import TableHead from 'src/components/core/TableHead';
 import Typography from 'src/components/core/Typography';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
-import Table from 'src/components/Table';
-import TableCell from 'src/components/TableCell';
-import TableRow from 'src/components/TableRow';
-import TableRowEmptyState from 'src/components/TableRowEmptyState';
 import {
   generateAddressesLabel,
   generateRuleLabel,
@@ -79,8 +73,32 @@ const useStyles = makeStyles((theme: Theme) => ({
     paddingLeft: 6,
     whiteSpace: 'nowrap',
   },
-  table: {
+  ruleList: {
     backgroundColor: theme.color.border3,
+    whiteSpace: 'nowrap',
+    listStyle: 'none',
+    paddingLeft: 0,
+    width: '100%',
+  },
+  ruleHeaderRow: {
+    marginTop: '5px',
+    background: '#F9FAFA',
+    color: '#878F91',
+    fontWeight: 'bold',
+    height: '40px',
+  },
+  // ruleHeaderCell: {
+  //   border: '1px solid #F4F5F6',
+  // },
+  ruleRow: {
+    margin: 0,
+    background: '#FFFFFF',
+    borderBottom: '1px solid #F4F5F6',
+    alignItems: 'center',
+    rowSpacing: 0.5,
+  },
+  ruleCell: {
+    margin: 0,
   },
   addLabelButton: {
     ...theme.applyLinkStyles,
@@ -123,6 +141,7 @@ interface RuleRow {
   ports: string;
   addresses: string;
   id: number;
+  role?: string;
   status: RuleStatus;
   errors?: FirewallRuleError[];
   originalIndex: number;
@@ -206,95 +225,120 @@ const FirewallRuleTable: React.FC<CombinedProps> = (props) => {
           Add an {capitalize(category)} Rule
         </Button>
       </div>
-      <Table style={{ tableLayout: 'auto' }} aria-label={`${category} Rules`}>
-        <TableHead tabIndex={0}>
-          <TableRow>
-            <TableCell
-              style={{ paddingLeft: 27, width: xsDown ? '50%' : '30%' }}
-              id="Label"
-              tabIndex={0}
+      <Grid
+        container
+        aria-label={`${category} Rules List`}
+        tabIndex={0}
+        style={{ margin: 0 }}
+      >
+        <Grid
+          container
+          className={classes.ruleHeaderRow}
+          aria-label={`${category} Rules List Headers`}
+          tabIndex={0}
+        >
+          <Grid
+            item
+            style={{
+              paddingLeft: 27,
+              width: xsDown ? '50%' : '30%',
+              border: '1px solid #F4F5F6',
+            }}
+          >
+            Label
+          </Grid>
+          <Hidden lgDown>
+            <Grid item style={{ width: '10%', border: '1px solid #F4F5F6' }}>
+              Protocol
+            </Grid>
+          </Hidden>
+          <Hidden smDown>
+            <Grid
+              item
+              style={{
+                whiteSpace: 'nowrap',
+                width: '10%',
+                border: '1px solid #F4F5F6',
+              }}
             >
-              Label
-            </TableCell>
-            <Hidden lgDown>
-              <TableCell style={{ width: '10%' }} id="Protocol" tabIndex={0}>
-                Protocol
-              </TableCell>
-            </Hidden>
-            <Hidden smDown>
-              <TableCell
-                style={{ whiteSpace: 'nowrap', width: '10%' }}
-                id="Port Range"
-                tabIndex={0}
-              >
-                Port Range
-              </TableCell>
-              <TableCell style={{ width: '15%' }} id="Sources" tabIndex={0}>
-                {capitalize(addressColumnLabel)}
-              </TableCell>
-            </Hidden>
-            <TableCell style={{ width: '5%' }} id="Action" tabIndex={0}>
-              Action
-            </TableCell>
-            <TableCell />
-          </TableRow>
-        </TableHead>
-        <DragDropContext onDragEnd={onDragEnd}>
-          <Droppable droppableId="droppable" isDropDisabled={disabled}>
-            {(provided) => (
-              <TableBody
-                {...provided.droppableProps}
-                className={classes.table}
-                ref={provided.innerRef}
-              >
-                {rowData.length === 0 ? (
-                  <TableRowEmptyState colSpan={6} message={zeroRulesMessage} />
-                ) : (
-                  rowData.map((thisRuleRow: RuleRow, index) => (
-                    <Draggable
-                      key={thisRuleRow.id}
-                      draggableId={String(thisRuleRow.id)}
-                      index={index}
-                    >
-                      {(provided, snapshot) => {
-                        return (
-                          <FirewallRuleTableRow
-                            isDragging={snapshot.isDragging}
-                            disabled={disabled}
+              Port Range
+            </Grid>
+            <Grid item style={{ width: '15%', border: '1px solid #F4F5F6' }}>
+              {capitalize(addressColumnLabel)}
+            </Grid>
+          </Hidden>
+          <Grid item style={{ width: '5%', border: '1px solid #F4F5F6' }}>
+            Action
+          </Grid>
+        </Grid>
+        <Grid container>
+          <DragDropContext onDragEnd={onDragEnd}>
+            <Droppable droppableId="droppable" isDropDisabled={disabled}>
+              {(provided) => (
+                <ul
+                  className={classes.ruleList}
+                  ref={provided.innerRef}
+                  {...provided.droppableProps}
+                >
+                  {rowData.length === 0 ? (
+                    <Grid container data-testid={'table-row-empty'}>
+                      <Grid item>{zeroRulesMessage}</Grid>
+                    </Grid>
+                  ) : (
+                    rowData.map((thisRuleRow: RuleRow, index) => (
+                      <Draggable
+                        key={thisRuleRow.id}
+                        draggableId={String(thisRuleRow.id)}
+                        index={index}
+                      >
+                        {(provided, snapshot) => (
+                          <li
                             key={thisRuleRow.id}
-                            {...thisRuleRow}
-                            triggerCloneFirewallRule={triggerCloneFirewallRule}
-                            triggerDeleteFirewallRule={
-                              triggerDeleteFirewallRule
-                            }
-                            triggerOpenRuleDrawerForEditing={
-                              triggerOpenRuleDrawerForEditing
-                            }
-                            triggerUndo={triggerUndo}
-                            innerRef={provided.innerRef}
-                            aria-roledescription="Press space bar to lift the firewall"
+                            role="option"
+                            ref={provided.innerRef}
+                            aria-label={thisRuleRow.label}
+                            aria-selected={false}
                             {...provided.draggableProps}
                             {...provided.dragHandleProps}
-                          />
-                        );
-                      }}
-                    </Draggable>
-                  ))
-                )}
-                {provided.placeholder}
-              </TableBody>
-            )}
-          </Droppable>
-        </DragDropContext>
-        <TableFooter className={classes.footer}>
-          <PolicyRow
-            category={category}
-            policy={policy}
-            disabled={disabled}
-            handlePolicyChange={onPolicyChange}
-          />
-        </TableFooter>
-      </Table>
+                          >
+                            <FirewallRuleTableRow
+                              isDragging={snapshot.isDragging}
+                              disabled={disabled}
+                              triggerCloneFirewallRule={
+                                triggerCloneFirewallRule
+                              }
+                              triggerDeleteFirewallRule={
+                                triggerDeleteFirewallRule
+                              }
+                              triggerOpenRuleDrawerForEditing={
+                                triggerOpenRuleDrawerForEditing
+                              }
+                              triggerUndo={triggerUndo}
+                              innerRef={provided.innerRef}
+                              {...thisRuleRow}
+                              {...provided.draggableProps}
+                              {...provided.dragHandleProps}
+                            />
+                          </li>
+                        )}
+                      </Draggable>
+                    ))
+                  )}
+                  {provided.placeholder}
+                </ul>
+              )}
+            </Droppable>
+          </DragDropContext>
+          <Grid container>
+            <PolicyRow
+              category={category}
+              policy={policy}
+              disabled={disabled}
+              handlePolicyChange={onPolicyChange}
+            />
+          </Grid>
+        </Grid>
+      </Grid>
     </>
   );
 };
@@ -309,6 +353,7 @@ type FirewallRuleTableRowProps = RuleRow &
     innerRef: any;
     isDragging: boolean;
     disabled: boolean;
+    highlight?: boolean | undefined;
   };
 
 const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
@@ -319,7 +364,7 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
       id,
       action,
       label,
-      description,
+      // description,
       protocol,
       ports,
       addresses,
@@ -329,11 +374,11 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
       triggerOpenRuleDrawerForEditing,
       triggerUndo,
       errors,
-      innerRef,
-      isDragging,
+      // innerRef,
+      // isDragging,
       disabled,
-      originalIndex,
-      ...rest
+      // originalIndex,
+      // ...rest
     } = props;
 
     const actionMenuProps = {
@@ -345,55 +390,83 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
     };
 
     return (
-      <TableRow
+      <Grid
+        container
         key={id}
-        highlight={
-          // Highlight the row if it's been modified or reordered. ID is the
-          // current index, so if it doesn't match the original index we know
-          // that the rule has been moved.
-          status === 'MODIFIED' || status === 'NEW' || originalIndex !== id
-        }
-        disabled={status === 'PENDING_DELETION' || disabled}
-        domRef={innerRef}
-        className={isDragging ? classes.dragging : ''}
-        ariaLabel={label}
-        // role="rowgroup"
-        {...rest}
+        // highlight={
+        //   // Highlight the row if it's been modified or reordered. ID is the
+        //   // current index, so if it doesn't match the original index we know
+        //   // that the rule has been moved.
+        //   status === 'MODIFIED' || status === 'NEW' || originalIndex !== id
+        // }
+        // disabled={status === 'PENDING_DELETION' || disabled}
+        // domRef={innerRef}
+        className={classes.ruleRow}
+        aria-label={label}
+        role="option"
       >
-        <TableCell className={classes.labelCol} scope="col">
-          <DragIndicator className={classes.dragIcon} />
+        <Grid
+          item
+          style={{ paddingLeft: 27, width: 'xsDown' ? '20%' : '15%' }}
+          aria-label={`Label: ${label}`}
+        >
+          <DragIndicator
+            className={classes.dragIcon}
+            aria-label="Drag indicator icon"
+          />
           {label || (
             <button
               className={classes.addLabelButton}
-              style={{ color: disabled ? 'inherit' : '' }}
+              style={{
+                color: disabled ? 'inherit' : '',
+              }}
               onClick={() => triggerOpenRuleDrawerForEditing(id)}
               disabled={disabled}
             >
               Add a label
             </button>
-          )}
-        </TableCell>
+          )}{' '}
+        </Grid>
         <Hidden lgDown>
-          <TableCell scope="col">
+          <Grid
+            item
+            style={{ width: '10%' }}
+            tabIndex={0}
+            aria-label={`Protocol: ${protocol}`}
+          >
             {protocol}
             <ConditionalError errors={errors} formField="protocol" />
-          </TableCell>
+          </Grid>
         </Hidden>
         <Hidden smDown>
-          <TableCell scope="col">
+          <Grid
+            item
+            style={{ whiteSpace: 'nowrap', width: '10%' }}
+            tabIndex={0}
+            aria-label={`Ports: ${ports}`}
+          >
             {ports === '1-65535' ? 'All Ports' : ports}
             <ConditionalError errors={errors} formField="ports" />
-          </TableCell>
-          <TableCell style={{ whiteSpace: 'nowrap' }} scope="col">
+          </Grid>
+          <Grid
+            item
+            style={{ whiteSpace: 'nowrap', width: '15%' }}
+            tabIndex={0}
+            aria-label={`Addresses: ${addresses}`}
+          >
             {addresses}{' '}
             <ConditionalError errors={errors} formField="addresses" />
-          </TableCell>
+          </Grid>
         </Hidden>
-
-        <TableCell scope="col">
+        <Grid
+          item
+          style={{ width: '5%' }}
+          tabIndex={0}
+          aria-label={`Action: ${action}`}
+        >
           {capitalize(action?.toLocaleLowerCase() ?? '')}
-        </TableCell>
-        <TableCell actionCell>
+        </Grid>
+        <Grid item>
           {status !== 'NOT_MODIFIED' ? (
             <div className={classes.undoButtonContainer}>
               <button
@@ -412,8 +485,8 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
           ) : (
             <FirewallRuleActionMenu {...actionMenuProps} />
           )}
-        </TableCell>
-      </TableRow>
+        </Grid>
+      </Grid>
     );
   }
 );
@@ -437,9 +510,9 @@ export const PolicyRow: React.FC<PolicyRowProps> = React.memo((props) => {
   // Calculate how many cells the text should span so that the Select lines up
   // with the Action column
   const theme: Theme = useTheme();
-  const xsDown = useMediaQuery(theme.breakpoints.down('sm'));
+  // const xsDown = useMediaQuery(theme.breakpoints.down('sm'));
   const mdDown = useMediaQuery(theme.breakpoints.down('lg'));
-  const colSpan = xsDown ? 1 : mdDown ? 3 : 4;
+  // const colSpan = xsDown ? 1 : mdDown ? 3 : 4;
 
   const helperText = mdDown ? (
     <strong>{capitalize(category)} policy:</strong>
@@ -451,11 +524,11 @@ export const PolicyRow: React.FC<PolicyRowProps> = React.memo((props) => {
   );
 
   return (
-    <TableRow className={classes.policyRow}>
-      <TableCell colSpan={colSpan} className={classes.policyText}>
+    <Grid container className={classes.policyRow}>
+      <Grid item className={classes.policyText}>
         {helperText}
-      </TableCell>
-      <TableCell colSpan={1} className={classes.policySelect}>
+      </Grid>
+      <Grid item className={classes.policySelect}>
         <Select
           className={classes.policySelectInner}
           label={`${category} policy`}
@@ -471,9 +544,8 @@ export const PolicyRow: React.FC<PolicyRowProps> = React.memo((props) => {
             handlePolicyChange(selected.value)
           }
         />
-      </TableCell>
-      <TableCell />
-    </TableRow>
+      </Grid>
+    </Grid>
   );
 });
 

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -66,6 +66,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   unmodified: {
     backgroundColor: '#FFFFFF',
+    color: '#606469',
   },
   highlight: {
     backgroundColor: theme.bg.lightBlue1,
@@ -430,7 +431,7 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
       >
         <Grid
           item
-          style={{ paddingLeft: 27, width: 'xsDown' ? '30%' : '15%' }}
+          style={{ paddingLeft: 8, width: 'xsDown' ? '30%' : '15%' }}
           aria-label={`Label: ${label}`}
         >
           <DragIndicator
@@ -454,7 +455,7 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
           <Grid
             item
             style={{ width: '10%' }}
-            tabIndex={0}
+            tabIndex={-1}
             aria-label={`Protocol: ${protocol}`}
           >
             {protocol}
@@ -465,7 +466,7 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
           <Grid
             item
             style={{ whiteSpace: 'nowrap', width: '10%' }}
-            tabIndex={0}
+            tabIndex={-1}
             aria-label={`Ports: ${ports}`}
           >
             {ports === '1-65535' ? 'All Ports' : ports}
@@ -474,7 +475,7 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
           <Grid
             item
             style={{ whiteSpace: 'nowrap', width: '15%' }}
-            tabIndex={0}
+            tabIndex={-1}
             aria-label={`Addresses: ${addresses}`}
           >
             {addresses}{' '}
@@ -484,7 +485,7 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
         <Grid
           item
           style={{ width: '5%' }}
-          tabIndex={0}
+          tabIndex={-1}
           aria-label={`Action: ${action}`}
         >
           {capitalize(action?.toLocaleLowerCase() ?? '')}

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -220,6 +220,9 @@ const FirewallRuleTable: React.FC<CombinedProps> = (props) => {
 
   const zeroRulesMessage = `No ${category} rules have been added.`;
 
+  const screenReaderMessage =
+    'Screen reading with NVDA requires users to activate focus mode using Insert + Space to interact with this list item. After entering focus mode, press spacebar to begin a drag or tab to access item actions.';
+
   const onDragEnd = (result: DropResult) => {
     if (result.destination) {
       triggerReorder(result.source.index, result.destination?.index);
@@ -322,6 +325,7 @@ const FirewallRuleTable: React.FC<CombinedProps> = (props) => {
                             ref={provided.innerRef}
                             aria-label={thisRuleRow.label}
                             aria-selected={false}
+                            aria-roledescription={screenReaderMessage}
                             {...provided.draggableProps}
                             {...provided.dragHandleProps}
                           >

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -105,7 +105,8 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   ruleHeaderRow: {
     marginTop: '5px',
-    background: '#F9FAFA',
+    backgroundColor: '#F9FAFA',
+    color: '#888F91',
     fontWeight: 'bold',
     height: '40px',
     alignContent: 'center',
@@ -137,7 +138,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   policyText: {
     textAlign: 'right',
-    padding: '8px !important',
+    padding: '10px !important',
   },
   policySelect: {
     paddingLeft: 4,
@@ -431,7 +432,6 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
           item
           style={{ paddingLeft: 27, width: 'xsDown' ? '30%' : '15%' }}
           aria-label={`Label: ${label}`}
-          tabIndex={0}
         >
           <DragIndicator
             className={classes.dragIcon}
@@ -547,7 +547,11 @@ export const PolicyRow: React.FC<PolicyRowProps> = React.memo((props) => {
   );
 
   return (
-    <Grid container className={classes.policyRow} tabIndex={0}>
+    <Grid
+      container
+      className={classNames(classes.policyRow, classes.unmodified)}
+      tabIndex={0}
+    >
       <Grid item /*xs={colSpan}*/ className={classes.policyText}>
         {helperText}
       </Grid>

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -455,7 +455,6 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
           <Grid
             item
             style={{ width: '10%' }}
-            tabIndex={0}
             aria-label={`Protocol: ${protocol}`}
           >
             {protocol}
@@ -466,7 +465,6 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
           <Grid
             item
             style={{ whiteSpace: 'nowrap', width: '10%' }}
-            tabIndex={0}
             aria-label={`Ports: ${ports}`}
           >
             {ports === '1-65535' ? 'All Ports' : ports}
@@ -475,19 +473,13 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
           <Grid
             item
             style={{ whiteSpace: 'nowrap', width: '15%' }}
-            tabIndex={0}
             aria-label={`Addresses: ${addresses}`}
           >
             {addresses}{' '}
             <ConditionalError errors={errors} formField="addresses" />
           </Grid>
         </Hidden>
-        <Grid
-          item
-          style={{ width: '5%' }}
-          tabIndex={0}
-          aria-label={`Action: ${action}`}
-        >
+        <Grid item style={{ width: '5%' }} aria-label={`Action: ${action}`}>
           {capitalize(action?.toLocaleLowerCase() ?? '')}
         </Grid>
         <Grid item style={{ marginLeft: 'auto' }}>

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -225,7 +225,7 @@ const FirewallRuleTable: React.FC<CombinedProps> = (props) => {
   const zeroRulesMessage = `No ${category} rules have been added.`;
 
   const screenReaderMessage =
-    'Screen reading with NVDA requires users to activate focus mode using Insert + Space to interact with this list item. After entering focus mode, press spacebar to begin a drag or tab to access item actions.';
+    'Some screen readers may require you to enter focus mode to interact with firewall rule list items. In focus mode, press spacebar to begin a drag or tab to access item actions.';
 
   const onDragEnd = (result: DropResult) => {
     if (result.destination) {

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -83,7 +83,8 @@ const useStyles = makeStyles((theme: Theme) => ({
     whiteSpace: 'nowrap',
   },
   ruleGrid: {
-    spacing: 0,
+    margin: 0,
+    width: '100%',
   },
   ruleList: {
     backgroundColor: theme.color.border3,
@@ -91,6 +92,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     listStyle: 'none',
     paddingLeft: 0,
     width: '100%',
+    margin: 0,
   },
   ruleHeaderRow: {
     marginTop: '5px',
@@ -99,18 +101,14 @@ const useStyles = makeStyles((theme: Theme) => ({
     fontWeight: 'bold',
     height: '40px',
   },
-  // ruleHeaderCell: {
-  //   border: '1px solid #F4F5F6',
-  // },
   ruleRow: {
-    margin: 0,
     borderBottom: '1px solid #F4F5F6',
     alignItems: 'center',
-    rowSpacing: 0.5,
   },
-  ruleCell: {
-    margin: 0,
-  },
+  // ruleCell: {
+  //   backgroundColor: '#FFFFFF',
+  //   padding: 10,
+  // },
   addLabelButton: {
     ...theme.applyLinkStyles,
   },
@@ -152,7 +150,6 @@ interface RuleRow {
   ports: string;
   addresses: string;
   id: number;
-  role?: string;
   status: RuleStatus;
   errors?: FirewallRuleError[];
   originalIndex: number;
@@ -240,11 +237,11 @@ const FirewallRuleTable: React.FC<CombinedProps> = (props) => {
         container
         aria-label={`${category} Rules List`}
         // tabIndex={0}
-        style={{ margin: 0 }}
+        className={classes.ruleGrid}
       >
         <Grid
           container
-          className={classes.ruleHeaderRow}
+          className={classNames(classes.ruleHeaderRow, classes.ruleGrid)}
           aria-label={`${category} Rules List Headers`}
           tabIndex={0}
         >
@@ -278,11 +275,15 @@ const FirewallRuleTable: React.FC<CombinedProps> = (props) => {
               {capitalize(addressColumnLabel)}
             </Grid>
           </Hidden>
-          <Grid item style={{ width: '5%', border: '1px solid #F4F5F6' }}>
+          <Grid
+            item
+            className={classes.ruleGrid}
+            style={{ width: '5%', border: '1px solid #F4F5F6' }}
+          >
             Action
           </Grid>
         </Grid>
-        <Grid container>
+        <Grid container className={classes.ruleGrid}>
           <DragDropContext onDragEnd={onDragEnd}>
             <Droppable droppableId="droppable" isDropDisabled={disabled}>
               {(provided) => (
@@ -384,10 +385,8 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
       triggerUndo,
       errors,
       innerRef,
-      // isDragging,
       disabled,
       originalIndex,
-      // ...rest
     } = props;
 
     const actionMenuProps = {
@@ -406,6 +405,7 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
         aria-label={label}
         role="option"
         className={classNames({
+          [classes.ruleGrid]: true,
           [classes.ruleRow]: true,
           // Highlight the row if it's been modified or reordered. ID is the
           // current index, so if it doesn't match the original index we know
@@ -535,7 +535,12 @@ export const PolicyRow: React.FC<PolicyRowProps> = React.memo((props) => {
   );
 
   return (
-    <Grid container className={classes.policyRow}>
+    <Grid
+      container
+      className={classNames(classes.policyRow, classes.ruleGrid)}
+      tabIndex={0}
+      justifyContent="center"
+    >
       <Grid item className={classes.policyText}>
         {helperText}
       </Grid>

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -82,6 +82,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   table: {
     backgroundColor: theme.color.border3,
   },
+  ruleList: {
+    listStyle: 'none',
+  },
   addLabelButton: {
     ...theme.applyLinkStyles,
   },
@@ -241,33 +244,42 @@ const FirewallRuleTable: React.FC<CombinedProps> = (props) => {
                   <TableRowEmptyState colSpan={6} message={zeroRulesMessage} />
                 ) : (
                   rowData.map((thisRuleRow: RuleRow, index) => (
-                    <Draggable
+                    <ul
                       key={thisRuleRow.id}
-                      draggableId={String(thisRuleRow.id)}
-                      index={index}
+                      role="listbox"
+                      className={classes.ruleList}
                     >
-                      {(provided, snapshot) => {
-                        return (
-                          <FirewallRuleTableRow
-                            isDragging={snapshot.isDragging}
-                            disabled={disabled}
-                            key={thisRuleRow.id}
-                            {...thisRuleRow}
-                            triggerCloneFirewallRule={triggerCloneFirewallRule}
-                            triggerDeleteFirewallRule={
-                              triggerDeleteFirewallRule
-                            }
-                            triggerOpenRuleDrawerForEditing={
-                              triggerOpenRuleDrawerForEditing
-                            }
-                            triggerUndo={triggerUndo}
-                            innerRef={provided.innerRef}
-                            {...provided.draggableProps}
-                            {...provided.dragHandleProps}
-                          />
-                        );
-                      }}
-                    </Draggable>
+                      <Draggable
+                        key={thisRuleRow.id}
+                        draggableId={String(thisRuleRow.id)}
+                        index={index}
+                      >
+                        {(provided, snapshot) => {
+                          return (
+                            <FirewallRuleTableRow
+                              isDragging={snapshot.isDragging}
+                              disabled={disabled}
+                              key={thisRuleRow.id}
+                              {...thisRuleRow}
+                              triggerCloneFirewallRule={
+                                triggerCloneFirewallRule
+                              }
+                              triggerDeleteFirewallRule={
+                                triggerDeleteFirewallRule
+                              }
+                              triggerOpenRuleDrawerForEditing={
+                                triggerOpenRuleDrawerForEditing
+                              }
+                              triggerUndo={triggerUndo}
+                              innerRef={provided.innerRef}
+                              {...provided.draggableProps}
+                              {...provided.dragHandleProps}
+                              aria-roledescription="Press space bar to lift the firewall"
+                            />
+                          );
+                        }}
+                      </Draggable>
+                    </ul>
                   ))
                 )}
                 {provided.placeholder}
@@ -334,71 +346,74 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
     };
 
     return (
-      <TableRow
-        key={id}
-        highlight={
-          // Highlight the row if it's been modified or reordered. ID is the
-          // current index, so if it doesn't match the original index we know
-          // that the rule has been moved.
-          status === 'MODIFIED' || status === 'NEW' || originalIndex !== id
-        }
-        disabled={status === 'PENDING_DELETION' || disabled}
-        domRef={innerRef}
-        className={isDragging ? classes.dragging : ''}
-        {...rest}
-      >
-        <TableCell className={classes.labelCol}>
-          <DragIndicator className={classes.dragIcon} />
-          {label || (
-            <button
-              className={classes.addLabelButton}
-              style={{ color: disabled ? 'inherit' : '' }}
-              onClick={() => triggerOpenRuleDrawerForEditing(id)}
-              disabled={disabled}
-            >
-              Add a label
-            </button>
-          )}
-        </TableCell>
-        <Hidden lgDown>
-          <TableCell>
-            {protocol}
-            <ConditionalError errors={errors} formField="protocol" />
-          </TableCell>
-        </Hidden>
-        <Hidden smDown>
-          <TableCell>
-            {ports === '1-65535' ? 'All Ports' : ports}
-            <ConditionalError errors={errors} formField="ports" />
-          </TableCell>
-          <TableCell style={{ whiteSpace: 'nowrap' }}>
-            {addresses}{' '}
-            <ConditionalError errors={errors} formField="addresses" />
-          </TableCell>
-        </Hidden>
-
-        <TableCell>{capitalize(action?.toLocaleLowerCase() ?? '')}</TableCell>
-        <TableCell actionCell>
-          {status !== 'NOT_MODIFIED' ? (
-            <div className={classes.undoButtonContainer}>
+      <li aria-selected="false" role="option" draggable>
+        <TableRow
+          key={id}
+          highlight={
+            // Highlight the row if it's been modified or reordered. ID is the
+            // current index, so if it doesn't match the original index we know
+            // that the rule has been moved.
+            status === 'MODIFIED' || status === 'NEW' || originalIndex !== id
+          }
+          disabled={status === 'PENDING_DELETION' || disabled}
+          domRef={innerRef}
+          className={isDragging ? classes.dragging : ''}
+          ariaLabel={label}
+          {...rest}
+        >
+          <TableCell className={classes.labelCol}>
+            <DragIndicator className={classes.dragIcon} />
+            {label || (
               <button
-                className={classNames({
-                  [classes.undoButton]: true,
-                  [classes.highlight]: status !== 'PENDING_DELETION',
-                })}
-                onClick={() => triggerUndo(id)}
-                aria-label="Undo change to Firewall Rule"
+                className={classes.addLabelButton}
+                style={{ color: disabled ? 'inherit' : '' }}
+                onClick={() => triggerOpenRuleDrawerForEditing(id)}
                 disabled={disabled}
               >
-                <Undo />
+                Add a label
               </button>
+            )}
+          </TableCell>
+          <Hidden lgDown>
+            <TableCell>
+              {protocol}
+              <ConditionalError errors={errors} formField="protocol" />
+            </TableCell>
+          </Hidden>
+          <Hidden smDown>
+            <TableCell>
+              {ports === '1-65535' ? 'All Ports' : ports}
+              <ConditionalError errors={errors} formField="ports" />
+            </TableCell>
+            <TableCell style={{ whiteSpace: 'nowrap' }}>
+              {addresses}{' '}
+              <ConditionalError errors={errors} formField="addresses" />
+            </TableCell>
+          </Hidden>
+
+          <TableCell>{capitalize(action?.toLocaleLowerCase() ?? '')}</TableCell>
+          <TableCell actionCell>
+            {status !== 'NOT_MODIFIED' ? (
+              <div className={classes.undoButtonContainer}>
+                <button
+                  className={classNames({
+                    [classes.undoButton]: true,
+                    [classes.highlight]: status !== 'PENDING_DELETION',
+                  })}
+                  onClick={() => triggerUndo(id)}
+                  aria-label="Undo change to Firewall Rule"
+                  disabled={disabled}
+                >
+                  <Undo />
+                </button>
+                <FirewallRuleActionMenu {...actionMenuProps} />
+              </div>
+            ) : (
               <FirewallRuleActionMenu {...actionMenuProps} />
-            </div>
-          ) : (
-            <FirewallRuleActionMenu {...actionMenuProps} />
-          )}
-        </TableCell>
-      </TableRow>
+            )}
+          </TableCell>
+        </TableRow>
+      </li>
     );
   }
 );


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
Refactors `FirewallRuleTable.tsx` to support screen readers by converting the underlying structure from a table into an unordered list arranged in a `Grid` to [improve compatibility with react-beautiful-dnd](https://github.com/atlassian/react-beautiful-dnd/issues/2233). Added `aria-label`s and tab navigability where necessary to improve access to fields within a list item. 

Previously, the FirewallRuleTable was [inaccessible for users using screen readers and keyboard navigation](https://github.com/linode/manager/issues/7483#event-4432711610). The table did not always provide enough context for the user to know how to interact with drag & drop functionality or interact with the FirewallRuleAccessMenu buttons, and the fields in each table row were unknown to the user due to lack of focusability.

Detailed list of issue -> fixed behavior for each screen reader:

Both screen readers:
- No label name read for firewall rule row, just 'View details' ➡️ Screen reader reads firewall rule label when rule is focused
- ~No keyboard access to fields in firewall rule: Protocols, Port Range, Sources, Actions ➡️  Keyboard navigate to fields in a firewall rule when rule is focused~ - removed tab focus and made M3-6154; users can still view details about a rule by editing it in the meantime
- No table header focus - keyboard navigation jumped to first rule row with no context for the table ➡️ Keyboard navigate within list header group to read column headers

VoiceOver:
- No instructions about how to interact with drag & drop functionality read by screen reader ➡️ Screen reader reads drag & drop instructions when rule is focused

NVDA:
- Screen reader reads drag and drop instructions, but requires users to toggle focus mode before a firewall rule can be selected or any action buttons pressed. Screen reader instructions are confusing and misleading about dragging a row. ➡️ Screen reader still requires that user enter focus mode to activate a row... but an `aria-roledescription` added to the list item widget, mentioned in the [react-beautiful-dnd screen reader guide](https://github.com/atlassian/react-beautiful-dnd/blob/master/docs/guides/screen-reader.md), provides more context about how to interact with the draggable option.
 
## Preview 📷
<details>
<summary>
Screencaps with screen readers
</summary>
Prod - Mac/Chrome/VoiceOver:

https://user-images.githubusercontent.com/114685994/214673727-4a6b3e6a-124c-414e-8413-42fa125eadca.mov

This branch - Mac/Chrome/VoiceOver:

https://user-images.githubusercontent.com/114685994/214680631-9e482baa-3515-4bd0-a0f3-cb30bf4cb767.mov

Prod - Windows/Chrome/NVDA:

https://user-images.githubusercontent.com/114685994/214682408-555e0587-d508-44d4-a64d-a9b3ca18a3e0.mov

This branch - Windows/Chrome/NVDA:

https://user-images.githubusercontent.com/114685994/214682924-05875a6b-e180-41c3-92bd-a5f11d5012b0.mov
</details>

## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**
These changes need to be tested with multiple screen readers (VoiceOver, NVDA) and ideally on multiple browsers (Chrome, Firefox, Safari) to ensure the FirewallRuleTable functionality is accessible. 

VoiceOver
1. Turn on VoiceOver. Shortcut keys are `Command` + `F5` to toggle the screen reader. You can also find it in Mac settings under Accessibility.

NVDA:
1. Use a Windows machine installed with NVDA you have access to  _or_  set up a Windows emulator and install NVDA using our internal documentation on "Accessibility Testing with Virtual Machines and Screen Readers". (Ask me if you don't know where to find this.)
2. Turn on NVDA. Shortcut keys are `Control` + `Alt` + `N`.

With both screen readers:
1. Navigate to the Firewall Landing page.
2. Create a new firewall or use an existing one. Click on the firewall to view the Firewall Detail page.
3. Use the screen reader and keyboard navigation to navigate to either the inbound or outbound rule button. Create at least two new firewall rules with distinct labels (easiest way is to just set different presets, e.g. `SSH` and `HTTPS`). 
4. Navigate using the screen reader + keyboard to the appropriate firewall rules table (list).
5. Confirm that the above list of fixed behaviors are present using each screen reader. Firewall rules should be draggable and droppable, should be able to be edited, deleted, cloned, and reordered. Changes should persist as long as the changes are saved.
6. Confirm that the styling of the table and rules matches the styling in production.

**How do I run relevant unit or e2e tests?**
```yarn test FirewallTableRule```