### PR TITLE
M3-6027: Update UX copy for getting started playlists

### DIFF
--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseEmptyState.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseEmptyState.tsx
@@ -70,6 +70,12 @@ const guideLinks = (
   </List>
 );
 
+const guidesMoreLinkText = 'Check out all our Docs';
+const youtubeMoreLinkText = 'View our YouTube channel';
+
+// retaining the old label for tracking
+const youtubeMoreLinkLabel = 'View the complete playlist';
+
 const youtubeLinks = (
   <List>
     {youtubeLinkData.map((linkData) => (
@@ -96,13 +102,6 @@ const gaCategory = 'Managed Databases landing page empty';
 const linkGAEventTemplate = {
   category: gaCategory,
   action: 'Click:link',
-};
-
-const onLinkClick = (
-  event: React.MouseEvent<HTMLAnchorElement, MouseEvent>
-) => {
-  const label = event.currentTarget.textContent ?? '';
-  sendEvent({ ...linkGAEventTemplate, label });
 };
 
 const DatabaseEmptyState: React.FC = () => {
@@ -159,11 +158,11 @@ const DatabaseEmptyState: React.FC = () => {
               icon={<DocsIcon />}
               MoreLink={(props) => (
                 <Link
-                  onClick={onLinkClick}
+                  onClick={getLinkOnClick(guidesMoreLinkText)}
                   to="https://www.linode.com/docs/"
                   {...props}
                 >
-                  Check out all our Docs
+                  {guidesMoreLinkText}
                   <PointerIcon />
                 </Link>
               )}
@@ -171,16 +170,16 @@ const DatabaseEmptyState: React.FC = () => {
               {guideLinks}
             </LinkSubSection>
             <LinkSubSection
-              title="Getting Started Playlist"
+              title="Video Playlist"
               icon={<YoutubeIcon />}
               external
               MoreLink={(props) => (
                 <Link
-                  onClick={onLinkClick}
+                  onClick={getLinkOnClick(youtubeMoreLinkLabel)}
                   to="https://www.youtube.com/playlist?list=PLTnRtjQN5ieb4XyvC9OUhp7nxzBENgCxJ"
                   {...props}
                 >
-                  View the complete playlist
+                  {youtubeMoreLinkText}
                   <ExternalLinkIcon style={{ marginLeft: 8 }} />
                 </Link>
               )}

--- a/packages/manager/src/features/linodes/LinodesLanding/ListLinodesEmptyState.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/ListLinodesEmptyState.tsx
@@ -84,7 +84,10 @@ const guideLinks = (
 
 const guidesMoreLinkText = 'Check out all our Docs';
 const appsMoreLinkText = 'See all Marketplace apps';
-const youtubeMoreLinkText = 'View the complete playlist';
+const youtubeMoreLinkText = 'View our YouTube channel';
+
+// retaining the old label for tracking
+const youtubeMoreLinkLabel = 'View the complete playlist';
 
 const youtubeLinks = (
   <List>
@@ -156,12 +159,12 @@ export const ListLinodesEmptyState: React.FC<{}> = (_) => {
             <AppsSection />
           </LinksSubSection>
           <LinksSubSection
-            title="Getting Started Playlist"
+            title="Video Playlist"
             icon={<YoutubeIcon />}
             external
             MoreLink={(props) => (
               <Link
-                onClick={getLinkOnClick(youtubeMoreLinkText)}
+                onClick={getLinkOnClick(youtubeMoreLinkLabel)}
                 to="https://www.youtube.com/playlist?list=PLTnRtjQN5ieb4XyvC9OUhp7nxzBENgCxJ"
                 {...props}
               >


### PR DESCRIPTION
## Description 📝

Updates the labels for the video playlist section in Linodes and Databases.

Also includes a minor code refactoring to preserve the existing analytics labels and make the analytics events more consistent between the two affected components.

## Preview 📷

### Before:

Linodes:

<img src="https://user-images.githubusercontent.com/122488130/213569388-67bc5217-01c9-4285-98c1-38e153c58d79.png" height="400"/>

Databases:

<img src="https://user-images.githubusercontent.com/122488130/213569442-2541de00-cd9d-496d-abff-ee1e4bed52ec.png" height="400"/>

### After:

Linodes:

<img src="https://user-images.githubusercontent.com/122488130/213569543-75d10add-ab06-4924-b2b3-7ab2d9de5efc.png" height="400"/>

Databases:

<img src="https://user-images.githubusercontent.com/122488130/213569564-a5ad3147-67a7-4f0e-89ea-685b8aafc560.png" height="400"/>

## How to test 🧪

1. Navigate to the Linodes/Databases features.
2. Delete any existing Linodes/Databases
3. Verify UX copy is correct
4. Verify analytics tags remain the same as before
