### PR TITLE
M3-6135: Fix `api-v4` and `validation` CommonJS not accepted by Node.js

### DIFF
--- a/packages/api-v4/README.md
+++ b/packages/api-v4/README.md
@@ -17,7 +17,7 @@ $ yarn add @linode/api-v4
 or with a CDN:
 
 ```js
-<script src="https://unpkg.com/@linode/api-v4/lib/iife/index.js"></script>
+<script src="https://unpkg.com/@linode/api-v4/lib/index.global.js"></script>
 ```
 
 ## Usage

--- a/packages/api-v4/package.json
+++ b/packages/api-v4/package.json
@@ -23,25 +23,25 @@
   "license": "Apache-2.0",
   "private": false,
   "type": "module",
-  "main": "lib/index.js",
-  "module": "lib/esm/index.js",
+  "main": "lib/index.cjs",
+  "module": "lib/index.js",
   "exports": {
     ".": {
-      "import": "./lib/esm/index.js",
-      "require": "./lib/index.js"
+      "import": "./lib/index.js",
+      "require": "./lib/index.cjs"
     },
     "./lib": {
-      "import": "./lib/esm/index.js",
-      "require": "./lib/index.js"
+      "import": "./lib/index.js",
+      "require": "./lib/index.cjs"
     },
     "./lib/*": {
-      "import": "./lib/esm/index.js",
-      "require": "./lib/index.js"
+      "import": "./lib/index.js",
+      "require": "./lib/index.cjs"
     }
   },
   "types": "./lib/index.d.ts",
-  "browser": "./lib/iife/index.js",
-  "unpkg": "./lib/iife/index.js",
+  "browser": "./lib/index.global.js",
+  "unpkg": "./lib/index.global.js",
   "dependencies": {
     "@linode/validation": "*",
     "axios": "~0.21.4",

--- a/packages/api-v4/tsup.config.ts
+++ b/packages/api-v4/tsup.config.ts
@@ -5,7 +5,6 @@ export default defineConfig({
   format: ['esm', 'cjs', 'iife'],
   target: 'es6',
   outDir: 'lib',
-  legacyOutput: true,
   splitting: false,
   dts: false,
 });

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -306,10 +306,10 @@
       "^react-native$": "react-native-web",
       "ramda": "ramda/src/index.js",
       "^src/(.*)": "<rootDir>/src/$1",
+      "@linode/api-v4/lib(.*)$": "<rootDir>/../api-v4/src/$1",
+      "@linode/validation/lib(.*)$": "<rootDir>/../validation/src/$1",
       "@linode/api-v4": "<rootDir>/../api-v4/src/index.ts",
-      "@linode/validation": "<rootDir>/../validation/src/index.ts",
-      "@linode/api-v4/lib(.*)$": "<rootDir>/../api-v4/src/index.ts",
-      "@linode/validation/lib(.*)$": "<rootDir>/../validation/src/index.ts"
+      "@linode/validation": "<rootDir>/../validation/src/index.ts"
     },
     "moduleFileExtensions": [
       "mjs",

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -306,8 +306,10 @@
       "^react-native$": "react-native-web",
       "ramda": "ramda/src/index.js",
       "^src/(.*)": "<rootDir>/src/$1",
-      "@linode/api-v4/lib(.*)$": "<rootDir>/../api-v4/src/$1",
-      "@linode/validation/lib(.*)$": "<rootDir>/../validation/src/$1"
+      "@linode/api-v4": "<rootDir>/../api-v4/src/index.ts",
+      "@linode/validation": "<rootDir>/../validation/src/index.ts",
+      "@linode/api-v4/lib(.*)$": "<rootDir>/../api-v4/src/index.ts",
+      "@linode/validation/lib(.*)$": "<rootDir>/../validation/src/index.ts"
     },
     "moduleFileExtensions": [
       "mjs",

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -3,25 +3,25 @@
   "version": "0.17.1",
   "description": "Yup validation schemas for use with the Linode APIv4",
   "type": "module",
-  "main": "lib/index.js",
-  "module": "lib/esm/index.js",
+  "main": "lib/index.cjs",
+  "module": "lib/index.js",
   "exports": {
     ".": {
-      "import": "./lib/esm/index.js",
-      "require": "./lib/index.js"
+      "import": "./lib/index.js",
+      "require": "./lib/index.cjs"
     },
     "./lib": {
-      "import": "./lib/esm/index.js",
-      "require": "./lib/index.js"
+      "import": "./lib/index.js",
+      "require": "./lib/index.cjs"
     },
     "./lib/*": {
-      "import": "./lib/esm/index.js",
-      "require": "./lib/index.js"
+      "import": "./lib/index.js",
+      "require": "./lib/index.cjs"
     }
   },
   "types": "./lib/index.d.ts",
-  "browser": "./lib/iife/index.js",
-  "unpkg": "./lib/iife/index.js",
+  "browser": "./lib/index.global.js",
+  "unpkg": "./lib/index.global.js",
   "files": [
     "lib"
   ],

--- a/packages/validation/tsup.config.ts
+++ b/packages/validation/tsup.config.ts
@@ -5,7 +5,6 @@ export default defineConfig({
   format: ['esm', 'cjs', 'iife'],
   target: 'es6',
   outDir: 'lib',
-  legacyOutput: true,
   splitting: false,
   dts: false,
 });


### PR DESCRIPTION
## Description 📝

### The Bug
- Users that want to use api-v4 or validation in plain javascript + node would see an error like this

```sh
index.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
Instead rename index.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs"
```

### The Fix
- Removes tsup's `legacyOutput` option so we get expected file extension (`.cjs`) that work in Node.js

> **Note**: This is completely unrelated to https://github.com/linode/manager/pull/8716


## How to test 🧪

- Checkout this PR
- Build and Pack validation by doing `cd packages/validation && yarn build && yarn pack`
  - Copy output file path to clipboard for next step
- Edit api-v4's package.json to point validation's version to that file
```
  "dependencies": {
    "@linode/validation": "/Users/bnussman/Development/manager/packages/validation/linode-validation-v0.17.1.tgz",
  },
```
- Go to the repo's root and run `yarn` to re-resolve packages
- Build and pack api-v4 with `cd packages/api-v4 && yarn build && yarn pack`
  - Note the output file 
- Make a new folder outside cloud manager's repo
- Init a new npm (or yarn or pnpm) project with `npm init`
- Install api-v4's build into this project with `npm i /Users/bnussman/Development/manager/packages/api-v4/linode-api-v4-v0.85.0.tgz`  (make sure you update that absolute path with the one you noted when you built api-v4)
- Make an index.js with the following content
```javascript
const api = require("@linode/api-v4");

api.setToken("test");

async function run() {
	const l = await api.getLinodes();
	console.log(l)
}

run();
```
- Run that javascript with `node index.js`
- If you did not get the error described above and the JS executed as expected, this bug has been fixed! 🚀
