### PR TITLE
Manually pin `ua-parser-js` to `0.7.33` for CVE-2022-25927

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "csv-parse": "^4.6.3",
     "node-fetch": "^2.6.7",
     "y18n": "^4.0.0",
-    "ua-parser-js": "^0.7.23",
+    "ua-parser-js": "^0.7.33",
     "trim": "^0.0.3",
     "prismjs": "^1.24.0",
     "immer": "^9.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17703,10 +17703,10 @@ typescript@~4.1.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.6.tgz#1becd85d77567c3c741172339e93ce2e69932138"
   integrity sha512-pxnwLxeb/Z5SP80JDRzVjh58KsM6jZHRAOtTpS7sXLS4ogXNKC9ANxHHZqLLeVHZN35jCtI4JdmLLbLiC1kBow==
 
-ua-parser-js@^0.7.23, ua-parser-js@^0.7.30:
-  version "0.7.32"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.32.tgz#cd8c639cdca949e30fa68c44b7813ef13e36d211"
-  integrity sha512-f9BESNVhzlhEFf2CHMSj40NWOjYPl1YKYbrvIr/hFTDEmLq7SRbWvm7FcdcpCYT95zrOhC7gZSxjdnnTpBcwVw==
+ua-parser-js@^0.7.30, ua-parser-js@^0.7.33:
+  version "0.7.33"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.33.tgz#1d04acb4ccef9293df6f70f2c3d22f3030d8b532"
+  integrity sha512-s8ax/CeZdK9R/56Sui0WM6y9OFREJarMRHqLB2EwkovemBxNQ+Bqu8GAsUnVcXKgphb++ghr/B2BZx4mahujPw==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
## Description 📝

- Update `ua-parser-js` to `0.7.33` for CVE-2022-25927
- We prefer to do this instead of approving https://github.com/linode/manager/pull/8741 because this yarn  resolution method allows our `yarn.lock` to remain in sync with our package.json(s)

## How to test 🧪

- Ensure manager builds and works as expected
