### PR TITLE
M3-6153: Add Databases as a User Permissions Option 

### DIFF
--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -164,6 +164,7 @@ export type GrantType =
   | 'longview'
   | 'stackscript'
   | 'volume'
+  | 'database'
   | 'firewall';
 
 export type Grants = GlobalGrants & Record<GrantType, Grant[]>;

--- a/packages/manager/src/factories/grants.ts
+++ b/packages/manager/src/factories/grants.ts
@@ -77,4 +77,11 @@ export const grantsFactory = Factory.Sync.makeFactory<Grants>({
       permissions: 'read_only',
     },
   ],
+  database: [
+    {
+      id: 0,
+      label: 'example-entity',
+      permissions: 'read_only',
+    },
+  ],
 });

--- a/packages/manager/src/features/Users/UserPermissions.tsx
+++ b/packages/manager/src/features/Users/UserPermissions.tsx
@@ -147,6 +147,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
     'add_images',
     'add_volumes',
     'add_firewalls',
+    'add_databases',
     'cancel_account',
   ];
 
@@ -159,6 +160,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
     'nodebalancer',
     'domain',
     'longview',
+    'database',
   ];
 
   getTabInformation = (grants: Grants) =>
@@ -404,6 +406,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
       add_volumes: 'Can add Block Storage Volumes to this account ($)',
       add_firewalls: 'Can add Firewalls to this account',
       cancel_account: 'Can cancel the entire account',
+      add_databases: 'Can add Databases to this account ($)',
     };
     return (
       <Grid item key={perm} xs={12} sm={6} className="py0">

--- a/packages/manager/src/features/Users/UserPermissionsEntitySection.tsx
+++ b/packages/manager/src/features/Users/UserPermissionsEntitySection.tsx
@@ -12,7 +12,7 @@ import { usePagination } from 'src/hooks/usePagination';
 import { createDisplayPage } from 'src/components/Paginate';
 import Typography from 'src/components/core/Typography';
 
-export const entityNameMap = {
+export const entityNameMap: Record<GrantType, string> = {
   linode: 'Linodes',
   stackscript: 'StackScripts',
   image: 'Images',
@@ -21,6 +21,7 @@ export const entityNameMap = {
   domain: 'Domains',
   longview: 'Longview Clients',
   firewall: 'Firewalls',
+  database: 'Databases',
 };
 
 interface Props {


### PR DESCRIPTION
## Description 📝

- Allows unrestricted user to adjust Database related permissions of a user
- Adds `add_databases` and `database` as user permissions options

## Preview 📷

<details>
  <summary>Screenshots</summary>
  
  ### Before
  
  ![Screen Shot 2023-02-01 at 4 11 00 PM](https://user-images.githubusercontent.com/115251059/216164131-290f3291-74b3-4d51-a899-17f2ffa45d92.jpg)

  ### After
  ![Screen Shot 2023-02-01 at 4 11 52 PM](https://user-images.githubusercontent.com/115251059/216164261-8d7828b3-2f11-4298-9800-139e9998f1a1.jpg)
  ![Screen Shot 2023-02-01 at 4 12 15 PM](https://user-images.githubusercontent.com/115251059/216164357-4053b7c1-d51a-4afb-a8b9-91d78c6c8b46.jpg)


</details>

## How to test 🧪

- Test modifying permissions on a user
  - Specify test Database-related permissions
