### PR TITLE
M3-4090: Object Storage Add Ability to Create "Folders"

### DIFF
--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -179,7 +179,7 @@ export const BucketDetail: React.FC = () => {
 
       if (itemsInFolder.data.length > 1) {
         setDeleteObjectLoading(false);
-        setDeleteObjectError('The folder must be empty to delete it');
+        setDeleteObjectError('The folder must be empty to delete it.');
         return;
       }
     }

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -67,6 +67,11 @@ const useStyles = makeStyles((theme: Theme) => ({
     textDecoration: 'underline',
     cursor: 'pointer',
   },
+  createFolderButton: {
+    [theme.breakpoints.down('md')]: {
+      marginRight: theme.spacing(),
+    },
+  },
 }));
 
 interface MatchParams {
@@ -357,6 +362,7 @@ export const BucketDetail: React.FC = () => {
       <Box display="flex" justifyContent="flex-end" mt={1.5} mb={0.5}>
         <Button
           buttonType="outlined"
+          className={classes.createFolderButton}
           onClick={() => setIsCreateFolderDrawerOpen(true)}
         >
           Create Folder

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -33,6 +33,7 @@ import ObjectUploader from '../ObjectUploader';
 import {
   displayName,
   generateObjectUrl,
+  isEmptyObjectForFolder,
   tableUpdateAction,
 } from '../utilities';
 import BucketBreadcrumb from './BucketBreadcrumb';
@@ -172,12 +173,20 @@ export const BucketDetail: React.FC = () => {
     setDeleteObjectError(undefined);
 
     if (objectToDelete.endsWith('/')) {
-      const itemsInFolder = await getObjectList(clusterId, bucketName, {
+      const itemsInFolderData = await getObjectList(clusterId, bucketName, {
         prefix: objectToDelete,
         delimiter: OBJECT_STORAGE_DELIMITER,
       });
 
-      if (itemsInFolder.data.length > 1) {
+      // Exclude the empty object the represents a folder so we can
+      // find the true number of objects on the page
+      const itemsInFolder = itemsInFolderData.data.filter(
+        (object) =>
+          !isEmptyObjectForFolder(object) &&
+          !objectToDelete.endsWith(object.name)
+      );
+
+      if (itemsInFolder.length > 0) {
         setDeleteObjectLoading(false);
         setDeleteObjectError('The folder must be empty to delete it.');
         return;

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -463,6 +463,7 @@ export const BucketDetail: React.FC = () => {
       <CreateFolderDrawer
         bucketName={bucketName}
         clusterId={clusterId}
+        prefix={prefix}
         open={isCreateFolderDrawerOpen}
         onClose={() => setIsCreateFolderDrawerOpen(false)}
         maybeAddObjectToTable={maybeAddObjectToTable}

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -1,4 +1,5 @@
 import {
+  getObjectList,
   getObjectURL,
   ObjectStorageClusterID,
   ObjectStorageObject,
@@ -43,6 +44,7 @@ import produce from 'immer';
 import { debounce } from 'throttle-debounce';
 import Box from 'src/components/core/Box';
 import { CreateFolderDrawer } from './CreateFolderDrawer';
+import { OBJECT_STORAGE_DELIMITER } from 'src/constants';
 
 const useStyles = makeStyles((theme: Theme) => ({
   objectTable: {
@@ -163,6 +165,19 @@ export const BucketDetail: React.FC = () => {
 
     setDeleteObjectLoading(true);
     setDeleteObjectError(undefined);
+
+    if (objectToDelete.endsWith('/')) {
+      const itemsInFolder = await getObjectList(clusterId, bucketName, {
+        prefix: objectToDelete,
+        delimiter: OBJECT_STORAGE_DELIMITER,
+      });
+
+      if (itemsInFolder.data.length > 1) {
+        setDeleteObjectLoading(false);
+        setDeleteObjectError('The folder must be empty to delete it');
+        return;
+      }
+    }
 
     try {
       const { url } = await getObjectURL(
@@ -450,6 +465,7 @@ export const BucketDetail: React.FC = () => {
         clusterId={clusterId}
         open={isCreateFolderDrawerOpen}
         onClose={() => setIsCreateFolderDrawerOpen(false)}
+        maybeAddObjectToTable={maybeAddObjectToTable}
       />
     </>
   );

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/CreateFolderDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/CreateFolderDrawer.tsx
@@ -11,12 +11,20 @@ interface Props {
   open: boolean;
   bucketName: string;
   clusterId: string;
+  prefix: string;
   onClose: () => void;
   maybeAddObjectToTable: (path: string, sizeInBytes: number) => void;
 }
 
 export const CreateFolderDrawer = (props: Props) => {
-  const { open, onClose, bucketName, clusterId, maybeAddObjectToTable } = props;
+  const {
+    open,
+    onClose,
+    bucketName,
+    clusterId,
+    maybeAddObjectToTable,
+    prefix,
+  } = props;
 
   const { mutateAsync, isLoading, error } = useCreateObjectUrlMutation(
     clusterId,
@@ -28,22 +36,23 @@ export const CreateFolderDrawer = (props: Props) => {
       name: '',
     },
     async onSubmit({ name }) {
+      const newObjectAbsolutePath = prefix + name + '/';
       const { url } = await mutateAsync({
-        name: `${name}/`,
+        name: newObjectAbsolutePath,
         method: 'PUT',
         options: {
           content_type: 'application/octet-stream',
         },
       });
 
-      await fetch(url, {
+      fetch(url, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/octet-stream',
         },
       });
 
-      maybeAddObjectToTable(`${name}/`, 0);
+      maybeAddObjectToTable(newObjectAbsolutePath, 0);
       onClose();
     },
   });

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/CreateFolderDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/CreateFolderDrawer.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import Drawer from 'src/components/Drawer/Drawer';
+import TextField from 'src/components/TextField';
+import { useFormik } from 'formik';
+import { useCreateObjectUrlMutation } from 'src/queries/objectStorage';
+import ActionsPanel from 'src/components/ActionsPanel';
+import { Button } from 'src/components/Button/Button';
+import Notice from 'src/components/Notice';
+
+interface Props {
+  open: boolean;
+  bucketName: string;
+  clusterId: string;
+  onClose: () => void;
+}
+
+export const CreateFolderDrawer = (props: Props) => {
+  const { open, onClose, bucketName, clusterId } = props;
+
+  const { mutateAsync, isLoading, error } = useCreateObjectUrlMutation(
+    clusterId,
+    bucketName
+  );
+
+  const formik = useFormik<{ name: string }>({
+    initialValues: {
+      name: '',
+    },
+    async onSubmit({ name }) {
+      const { url } = await mutateAsync({
+        name,
+        method: 'PUT',
+        options: {
+          content_type: 'application/octet-stream',
+        },
+      });
+
+      fetch(url, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/octet-stream',
+        },
+      });
+    },
+  });
+
+  return (
+    <Drawer title="Create Folder" open={open} onClose={onClose}>
+      {error && <Notice error text={error[0].reason} />}
+      <form onSubmit={formik.handleSubmit}>
+        <TextField
+          label="Folder Name"
+          name="name"
+          onChange={formik.handleChange}
+        />
+        <ActionsPanel>
+          <Button buttonType="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button type="submit" buttonType="primary" loading={isLoading}>
+            Create
+          </Button>
+        </ActionsPanel>
+      </form>
+    </Drawer>
+  );
+};

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/CreateFolderDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/CreateFolderDrawer.tsx
@@ -12,10 +12,11 @@ interface Props {
   bucketName: string;
   clusterId: string;
   onClose: () => void;
+  maybeAddObjectToTable: (path: string, sizeInBytes: number) => void;
 }
 
 export const CreateFolderDrawer = (props: Props) => {
-  const { open, onClose, bucketName, clusterId } = props;
+  const { open, onClose, bucketName, clusterId, maybeAddObjectToTable } = props;
 
   const { mutateAsync, isLoading, error } = useCreateObjectUrlMutation(
     clusterId,
@@ -28,19 +29,22 @@ export const CreateFolderDrawer = (props: Props) => {
     },
     async onSubmit({ name }) {
       const { url } = await mutateAsync({
-        name,
+        name: `${name}/`,
         method: 'PUT',
         options: {
           content_type: 'application/octet-stream',
         },
       });
 
-      fetch(url, {
+      await fetch(url, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/octet-stream',
         },
       });
+
+      maybeAddObjectToTable(`${name}/`, 0);
+      onClose();
     },
   });
 

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/FolderActionMenu.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/FolderActionMenu.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import ActionMenu, { Action } from 'src/components/ActionMenu';
+import { Theme, useMediaQuery, useTheme } from 'src/components/core/styles';
+import InlineMenuAction from 'src/components/InlineMenuAction';
+
+interface Props {
+  objectName: string;
+  handleClickDelete: (objectName: string) => void;
+}
+
+export const FolderActionMenu = (props: Props) => {
+  const theme = useTheme<Theme>();
+  const matchesSmDown = useMediaQuery(theme.breakpoints.down('md'));
+
+  const { handleClickDelete, objectName } = props;
+
+  const actions: Action[] = [
+    {
+      title: 'Delete',
+      onClick: () => {
+        handleClickDelete(objectName);
+      },
+    },
+  ];
+
+  return (
+    // eslint-disable-next-line react/jsx-no-useless-fragment
+    <>
+      {matchesSmDown ? (
+        <ActionMenu
+          actionsList={actions}
+          ariaLabel={`Action menu for Folder ${objectName}`}
+        />
+      ) : (
+        actions.map((action) => {
+          return (
+            <InlineMenuAction
+              key={action.title}
+              actionText={action.title}
+              onClick={action.onClick}
+            />
+          );
+        })
+      )}
+    </>
+  );
+};

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/FolderTableRow.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/FolderTableRow.tsx
@@ -6,6 +6,7 @@ import EntityIcon from 'src/components/EntityIcon';
 import Grid from 'src/components/Grid';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
+import { FolderActionMenu } from './FolderActionMenu';
 
 const useStyles = makeStyles((theme: Theme) => ({
   manuallyCreated: {
@@ -22,12 +23,13 @@ interface Props {
   folderName: string;
   displayName: string;
   manuallyCreated: boolean;
+  handleClickDelete: (objectName: string) => void;
 }
 
 const FolderTableRow: React.FC<Props> = (props) => {
   const classes = useStyles();
 
-  const { folderName, displayName, manuallyCreated } = props;
+  const { folderName, displayName, manuallyCreated, handleClickDelete } = props;
 
   return (
     <TableRow
@@ -52,7 +54,12 @@ const FolderTableRow: React.FC<Props> = (props) => {
       <Hidden mdDown>
         <TableCell />
       </Hidden>
-      <TableCell />
+      <TableCell actionCell>
+        <FolderActionMenu
+          handleClickDelete={handleClickDelete}
+          objectName={folderName}
+        />
+      </TableCell>
     </TableRow>
   );
 };

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableContent.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableContent.tsx
@@ -69,6 +69,19 @@ const ObjectTableContent: React.FC<Props> = (props) => {
     <>
       {data.map((page) => {
         return page.data.map((object) => {
+          if (object.name.endsWith('/') && object.size === 0) {
+            if (numOfDisplayedObjects === 1) {
+              return (
+                <TableRowEmptyState
+                  key={`empty-${object.name}`}
+                  colSpan={6}
+                  message="This folder is empty."
+                />
+              );
+            }
+            return null;
+          }
+
           if (isFolder(object)) {
             return (
               <FolderTableRow

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableContent.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableContent.tsx
@@ -92,6 +92,7 @@ const ObjectTableContent: React.FC<Props> = (props) => {
                   maxNameWidth
                 )}
                 manuallyCreated={false}
+                handleClickDelete={handleClickDelete}
               />
             );
           }

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableContent.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableContent.tsx
@@ -9,7 +9,7 @@ import TableRowError from 'src/components/TableRowError';
 import { TableRowLoading } from 'src/components/TableRowLoading/TableRowLoading';
 import { useWindowDimensions } from 'src/hooks/useWindowDimensions';
 import { truncateEnd, truncateMiddle } from 'src/utilities/truncate';
-import { displayName, isFolder } from '../utilities';
+import { displayName, isEmptyObjectForFolder, isFolder } from '../utilities';
 import FolderTableRow from './FolderTableRow';
 import ObjectTableRow from './ObjectTableRow';
 
@@ -69,7 +69,7 @@ const ObjectTableContent: React.FC<Props> = (props) => {
     <>
       {data.map((page) => {
         return page.data.map((object) => {
-          if (object.name.endsWith('/') && object.size === 0) {
+          if (isEmptyObjectForFolder(object)) {
             if (numOfDisplayedObjects === 1) {
               return (
                 <TableRowEmptyState

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableContent.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableContent.tsx
@@ -41,7 +41,7 @@ const ObjectTableContent: React.FC<Props> = (props) => {
   const { width } = useWindowDimensions();
 
   if (isFetching && !isFetchingNextPage) {
-    return <TableRowLoading columns={4} responsive={{ 2: { smDown: true } }} />;
+    return <TableRowLoading columns={4} responsive={{ 2: { mdDown: true } }} />;
   }
 
   if (error) {
@@ -122,7 +122,7 @@ const ObjectTableContent: React.FC<Props> = (props) => {
         });
       })}
       {isFetchingNextPage ? (
-        <TableRowLoading columns={4} responsive={{ 2: { smDown: true } }} />
+        <TableRowLoading columns={4} responsive={{ 2: { mdDown: true } }} />
       ) : null}
     </>
   );

--- a/packages/manager/src/features/ObjectStorage/utilities.ts
+++ b/packages/manager/src/features/ObjectStorage/utilities.ts
@@ -20,6 +20,11 @@ export const generateObjectUrl = (
   };
 };
 
+// Objects ending with a / and having a size of 0 are often used to represent
+// "folders".
+export const isEmptyObjectForFolder = (object: ObjectStorageObject) =>
+  object.name.endsWith('/') && object.size === 0;
+
 // If an Object does not have an etag, last_modified, owner, or size, it can
 // be considered a "folder".
 export const isFolder = (object: ObjectStorageObject) =>

--- a/packages/manager/src/queries/objectStorage.ts
+++ b/packages/manager/src/queries/objectStorage.ts
@@ -17,6 +17,9 @@ import {
   ObjectStorageObjectListResponse,
   getBucketsInCluster,
   getBucket,
+  getObjectURL,
+  ObjectStorageObjectURLOptions,
+  ObjectStorageObjectURL,
 } from '@linode/api-v4/lib/object-storage';
 
 export interface BucketError {
@@ -215,3 +218,19 @@ export const updateBucket = async (cluster: string, bucketName: string) => {
     }
   );
 };
+
+export const useCreateObjectUrlMutation = (
+  clusterId: string,
+  bucketName: string
+) =>
+  useMutation<
+    ObjectStorageObjectURL,
+    APIError[],
+    {
+      name: string;
+      method: 'GET' | 'PUT' | 'POST' | 'DELETE';
+      options?: ObjectStorageObjectURLOptions;
+    }
+  >(({ name, method, options }) =>
+    getObjectURL(clusterId, bucketName, name, method, options)
+  );


### PR DESCRIPTION
## Description 📝

- Adds ability to create Object Storage "folders"

## Preview 📷

![Screen Shot 2023-02-02 at 3 32 05 PM](https://user-images.githubusercontent.com/115251059/216443050-8808dd20-eff4-47b8-acb6-8b407b788dda.jpg)

## How to test 🧪

- Test Object Storage in depth
  - Test folder creation and deletion
  - Verify object functionality still works as expected

## Questions for Team ❓

I don’t think I’m going to do a good job of asking this question, but I need some guidance on this. Which method should we use to create a folder in Cloud Manager?

- Create a fake folder in memory that does not get sent to the API at all so the user can go into the folder to upload an object, resulting in the folder actually being “created”
  - **Pros:** Less hacky from an S3 perspective
  - **Cons:** Folder will not persist if user refreshes the page
- Create a 0 byte object with a name that ends in a forward slash (the PR is currently doing this)
  - **Pros:** “Folder” will persist upon refresh
  - **Cons:** Feels hacky from an S3 perspective, "folders" will count towards the total object count because they are really objects

Object Storage (s3) does not really support “folders” so either solution seems hacky to me. 
