### PR TITLE
feat: Allow Databases to be filtered by `engine` and `region`

### DIFF
--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
@@ -11,7 +11,6 @@ import LandingHeader from 'src/components/LandingHeader';
 import PaginationFooter from 'src/components/PaginationFooter';
 import ProductInformationBanner from 'src/components/ProductInformationBanner';
 import Table from 'src/components/Table';
-import TableCell from 'src/components/TableCell';
 import TableSortCell from 'src/components/TableSortCell';
 import { useOrder } from 'src/hooks/useOrder';
 import { usePagination } from 'src/hooks/usePagination';
@@ -104,9 +103,23 @@ const DatabaseLanding: React.FC = () => {
                 Configuration
               </TableSortCell>
             </Hidden>
-            <TableCell>Engine</TableCell>
+            <TableSortCell
+              active={orderBy === 'engine'}
+              direction={order}
+              label="engine"
+              handleClick={handleOrderChange}
+            >
+              Engine
+            </TableSortCell>
             <Hidden mdDown>
-              <TableCell>Region</TableCell>
+              <TableSortCell
+                active={orderBy === 'region'}
+                direction={order}
+                label="region"
+                handleClick={handleOrderChange}
+              >
+                Region
+              </TableSortCell>
             </Hidden>
             <Hidden lgDown>
               <TableSortCell


### PR DESCRIPTION
## Description 📝

- **Pending an API PR**, we can filter databases by `engine` and `region`

## Preview 📷

### Before
![Screen Shot 2023-02-06 at 1 07 31 PM](https://user-images.githubusercontent.com/115251059/217050749-05b300a6-02bb-4d89-aac2-61bcb164c523.jpg)

### After
https://user-images.githubusercontent.com/115251059/217050778-620f1856-8091-41b2-910b-7585d9fbc076.mov

## How to test 🧪

- Test Database Landing sorting
