### PR TITLE
M3-6079: Creating a Linode via a StackScript - Require `image` Field

### DIFF
--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -511,6 +511,7 @@ export class LinodeCreate extends React.PureComponent<
                   // error={hasErrorFor.image}
                   accountBackupsEnabled={accountBackupsEnabled}
                   userCannotCreateLinode={userCannotCreateLinode}
+                  errors={errors}
                   {...rest}
                 />
               </SafeTabPanel>

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -530,6 +530,7 @@ export class LinodeCreate extends React.PureComponent<
                           imagesData={imagesData!}
                           regionsData={regionsData!}
                           typesData={typesData!}
+                          errors={errors}
                           {...rest}
                         />
                       </SafeTabPanel>
@@ -543,6 +544,7 @@ export class LinodeCreate extends React.PureComponent<
                           imagesData={imagesData!}
                           regionsData={regionsData!}
                           typesData={typesData!}
+                          errors={errors}
                           {...rest}
                         />
                       </SafeTabPanel>

--- a/packages/validation/src/linodes.schema.ts
+++ b/packages/validation/src/linodes.schema.ts
@@ -84,7 +84,14 @@ export const CreateLinodeSchema = object({
   stackscript_id: number().notRequired(),
   backup_id: number().notRequired(),
   swap_size: number().notRequired(),
-  image: string().notRequired(),
+  image: string().when('stackscript_id', {
+    is: (value: unknown) =>
+      value !== null || value !== undefined || value !== '',
+    then: string().required(
+      'An image is required when deploying from a StackScript.'
+    ),
+    otherwise: string().notRequired(),
+  }),
   authorized_keys: array().of(string()).notRequired(),
   backups_enabled: boolean().notRequired(),
   stackscript_data,

--- a/packages/validation/src/linodes.schema.ts
+++ b/packages/validation/src/linodes.schema.ts
@@ -86,9 +86,7 @@ export const CreateLinodeSchema = object({
   swap_size: number().notRequired(),
   image: string().when('stackscript_id', {
     is: (value?: number) => value !== undefined,
-    then: string().required(
-      'An image is required when deploying from a StackScript.'
-    ),
+    then: string().required('Image is required.'),
     otherwise: string().notRequired(),
   }),
   authorized_keys: array().of(string()).notRequired(),

--- a/packages/validation/src/linodes.schema.ts
+++ b/packages/validation/src/linodes.schema.ts
@@ -85,8 +85,7 @@ export const CreateLinodeSchema = object({
   backup_id: number().notRequired(),
   swap_size: number().notRequired(),
   image: string().when('stackscript_id', {
-    is: (value: unknown) =>
-      value !== null || value !== undefined || value !== '',
+    is: (value?: number) => value !== undefined,
     then: string().required(
       'An image is required when deploying from a StackScript.'
     ),


### PR DESCRIPTION
## Description 📝

- Updates the `CreateLinodeSchema` in `validation` to match the Linode API. 
- `image` is now required by the API when you specify a `stackscript_id`, we need to update our client side validation to match this API behavior
- This PR also passes the `errors` prop to both `FromStackScriptContent` panels because they did not previously have errors data passed to them, resulting in image errors not being surfaced
 
## Preview 📷

### Before
![Screen Shot 2023-02-07 at 2 35 22 PM](https://user-images.githubusercontent.com/115251059/217347304-af551270-93f5-490f-a937-7d5eb66622c9.jpg)

### After
![Screen Shot 2023-02-10 at 10 00 40 AM](https://user-images.githubusercontent.com/115251059/218123868-4b81c36b-fa08-46bc-baf7-2cdaeb031981.jpg)

## How to test 🧪

- Test Linode Creation
  - Test that you see an error under the image field if you try to deploy a Linode from a Stackscript with no image selected
  - Test all other ways to deploy a Linode and ensure that no other flows were adversely affected
