### PR TITLE
M3-6009: Add Cypress integration tests for Personal Access Token CRUD

### DIFF
--- a/packages/manager/cypress/e2e/account/personal-access-tokens.spec.ts
+++ b/packages/manager/cypress/e2e/account/personal-access-tokens.spec.ts
@@ -2,16 +2,26 @@
  * @file Integration tests for personal access token CRUD operations.
  */
 
+import { Token } from '@linode/api-v4/types';
 import { appTokenFactory } from 'src/factories/oauth';
 import {
-  mockGetPersonalAccessTokens,
   mockCreatePersonalAccessToken,
   mockGetAppTokens,
+  mockGetPersonalAccessTokens,
+  mockRevokePersonalAccessToken,
+  mockUpdatePersonalAccessToken,
 } from 'support/intercepts/profile';
 import { randomLabel, randomString } from 'support/util/random';
 import { ui } from 'support/ui';
 
 describe('Personal access tokens', () => {
+  /*
+   * - Uses mocked API requests to confirm UI flow to create a personal access token
+   * - Confirms that user is shown an error upon attempting creation without a label
+   * - Confirms that user is shown the token secret upon successful PAT creation
+   * - Confirms that new personal access token is shown in list
+   * - Confirms that user can open and close "View Scopes" drawer
+   */
   it('can create personal access tokens', () => {
     const tokenLabel = randomLabel();
     const tokenSecret = randomString(64);
@@ -27,6 +37,7 @@ describe('Personal access tokens', () => {
     cy.visitWithLogin('/profile/tokens');
     cy.wait(['@getTokens', '@getAppTokens']);
 
+    // Confirm that no PATs or 3rd party app tokens are listed.
     cy.findByLabelText('List of Personal Access Tokens')
       .should('be.visible')
       .within(() => {
@@ -39,6 +50,7 @@ describe('Personal access tokens', () => {
         cy.findByText('No items to display.').should('be.visible');
       });
 
+    // Click create button, fill out and submit PAT create form.
     ui.button
       .findByTitle('Create a Personal Access Token')
       .should('be.visible')
@@ -50,7 +62,21 @@ describe('Personal access tokens', () => {
       .findByTitle('Add Personal Access Token')
       .should('be.visible')
       .within(() => {
+        // Attempt to submit form without specifying a label
+        ui.buttonGroup
+          .findButtonByTitle('Create Token')
+          .scrollIntoView()
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+
+        cy.findByText('Label must be between 1 and 100 characters.')
+          .scrollIntoView()
+          .should('be.visible');
+
+        // Specify a label and re-submit.
         cy.findByLabelText('Label')
+          .scrollIntoView()
           .should('be.visible')
           .should('be.enabled')
           .click()
@@ -64,6 +90,7 @@ describe('Personal access tokens', () => {
           .click();
       });
 
+    // Confirm that PAT secret dialog is shown and close it.
     cy.wait('@createToken');
     ui.dialog
       .findByTitle('Personal Access Token')
@@ -90,11 +117,116 @@ describe('Personal access tokens', () => {
           .click();
       });
 
+    // Confirm that new PAT is shown in list and "View Scopes" drawer works.
     cy.wait('@getTokens');
-    cy.findByText(tokenLabel).should('be.visible');
+    cy.findByText(tokenLabel)
+      .should('be.visible')
+      .closest('tr')
+      .within(() => {
+        ui.button
+          .findByTitle('View Scopes')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    ui.drawer
+      .findByTitle(tokenLabel)
+      .should('be.visible')
+      .within(() => {
+        ui.drawerCloseButton.find().click();
+      });
   });
 
-  it('can rename personal access tokens', () => {});
+  /*
+   * - Uses mocked API requests to confirm UI flow when renaming and revoking tokens
+   * - Confirms that list shows the correct label after renaming a token
+   * - Confirms that token is removed from list after revoking it
+   */
+  it('can rename and revoke personal access tokens', () => {
+    const tokenOldLabel = randomLabel();
+    const tokenNewLabel = randomLabel();
 
-  it('can revoke personal access tokens', () => {});
+    const oldToken: Token = appTokenFactory.build({
+      label: tokenOldLabel,
+      token: randomString(64),
+    });
+
+    const newToken: Token = {
+      ...oldToken,
+      label: tokenNewLabel,
+    };
+
+    mockGetPersonalAccessTokens([oldToken]).as('getTokens');
+    mockGetAppTokens([]).as('getAppTokens');
+    mockUpdatePersonalAccessToken(oldToken.id, newToken).as('updateToken');
+    mockRevokePersonalAccessToken(oldToken.id).as('revokeToken');
+
+    cy.visitWithLogin('/profile/tokens');
+    cy.wait(['@getTokens', '@getAppTokens']);
+
+    // Find token in list, click "Rename", and fill out and submit form.
+    cy.findByText(tokenOldLabel)
+      .should('be.visible')
+      .closest('tr')
+      .within(() => {
+        ui.button
+          .findByTitle('Rename')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    ui.drawer
+      .findByTitle('Edit Personal Access Token')
+      .should('be.visible')
+      .within(() => {
+        cy.findByLabelText('Label')
+          .should('be.visible')
+          .click()
+          .clear()
+          .type(tokenNewLabel);
+
+        ui.buttonGroup
+          .findButtonByTitle('Save')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    // Confirm that token has been renamed, initiate revocation.
+    cy.wait('@updateToken');
+    cy.findByText(tokenNewLabel)
+      .should('be.visible')
+      .closest('tr')
+      .within(() => {
+        ui.button
+          .findByTitle('Revoke')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    mockGetPersonalAccessTokens([]).as('getTokens');
+    ui.dialog
+      .findByTitle(`Revoke ${tokenNewLabel}?`)
+      .should('be.visible')
+      .within(() => {
+        ui.buttonGroup
+          .findButtonByTitle('Revoke')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    // Confirm that token is removed from list after revoking.
+    cy.wait(['@revokeToken', '@getTokens']);
+    ui.toast.assertMessage(`Successfully revoked ${tokenNewLabel}`);
+    cy.findByLabelText('List of Personal Access Tokens')
+      .should('be.visible')
+      .within(() => {
+        cy.findByText(tokenNewLabel).should('not.exist');
+        cy.findByText('No items to display.').should('be.visible');
+      });
+  });
 });

--- a/packages/manager/cypress/e2e/account/personal-access-tokens.spec.ts
+++ b/packages/manager/cypress/e2e/account/personal-access-tokens.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * @file Integration tests for personal access token CRUD operations.
+ */
+
+import { appTokenFactory } from 'src/factories/oauth';
+import {
+  mockGetPersonalAccessTokens,
+  mockCreatePersonalAccessToken,
+  mockGetAppTokens,
+} from 'support/intercepts/profile';
+import { randomLabel, randomString } from 'support/util/random';
+import { ui } from 'support/ui';
+
+describe('Personal access tokens', () => {
+  it('can create personal access tokens', () => {
+    const tokenLabel = randomLabel();
+    const tokenSecret = randomString(64);
+    const token = appTokenFactory.build({
+      label: tokenLabel,
+      token: tokenSecret,
+    });
+
+    mockGetPersonalAccessTokens([]).as('getTokens');
+    mockGetAppTokens([]).as('getAppTokens');
+    mockCreatePersonalAccessToken(token).as('createToken');
+
+    cy.visitWithLogin('/profile/tokens');
+    cy.wait(['@getTokens', '@getAppTokens']);
+
+    cy.findByLabelText('List of Personal Access Tokens')
+      .should('be.visible')
+      .within(() => {
+        cy.findByText('No items to display.').should('be.visible');
+      });
+
+    cy.findByLabelText('List of Third Party Access Tokens')
+      .should('be.visible')
+      .within(() => {
+        cy.findByText('No items to display.').should('be.visible');
+      });
+
+    ui.button
+      .findByTitle('Create a Personal Access Token')
+      .should('be.visible')
+      .should('be.enabled')
+      .click();
+
+    mockGetPersonalAccessTokens([token]).as('getTokens');
+    ui.drawer
+      .findByTitle('Add Personal Access Token')
+      .should('be.visible')
+      .within(() => {
+        cy.findByLabelText('Label')
+          .should('be.visible')
+          .should('be.enabled')
+          .click()
+          .type(tokenLabel);
+
+        ui.buttonGroup
+          .findButtonByTitle('Create Token')
+          .scrollIntoView()
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    cy.wait('@createToken');
+    ui.dialog
+      .findByTitle('Personal Access Token')
+      .should('be.visible')
+      .within(() => {
+        // Confirm that user is informed that PAT is only shown once, and that
+        // it cannot be recovered.
+        cy.findByText('we can only display your personal access token once', {
+          exact: false,
+        }).should('be.visible');
+        cy.findByText('it can’t be recovered', { exact: false }).should(
+          'be.visible'
+        );
+
+        // Confirm that PAT is shown.
+        cy.get('[data-testid="textfield-input"]')
+          .should('be.visible')
+          .should('have.attr', 'value', tokenSecret);
+
+        ui.button
+          .findByTitle('I Have Saved My Personal Access Token')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    cy.wait('@getTokens');
+    cy.findByText(tokenLabel).should('be.visible');
+  });
+
+  it('can rename personal access tokens', () => {});
+
+  it('can revoke personal access tokens', () => {});
+});

--- a/packages/manager/cypress/support/intercepts/profile.ts
+++ b/packages/manager/cypress/support/intercepts/profile.ts
@@ -193,3 +193,35 @@ export const mockCreatePersonalAccessToken = (
 ): Cypress.Chainable<null> => {
   return cy.intercept('POST', '*/profile/tokens', makeResponse(token));
 };
+
+/**
+ * Intercepts PUT request to update a personal access token and mocks response.
+ *
+ * @param id - ID of token for intercepted update request.
+ * @param updatedToken - Token data with which to mock response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockUpdatePersonalAccessToken = (
+  id: number,
+  updatedToken: Token
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'PUT',
+    `*/profile/tokens/${id}`,
+    makeResponse(updatedToken)
+  );
+};
+
+/**
+ * Intercepts DELETE request to revoke a personal access token and mocks response.
+ *
+ * @param id - ID of token for intercepted revoke request.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockRevokePersonalAccessToken = (
+  id: number
+): Cypress.Chainable<null> => {
+  return cy.intercept('DELETE', `*/profile/tokens/${id}`, makeResponse({}));
+};

--- a/packages/manager/cypress/support/intercepts/profile.ts
+++ b/packages/manager/cypress/support/intercepts/profile.ts
@@ -2,12 +2,15 @@
  * @file Cypress intercepts and mocks for Cloud Manager profile requests.
  */
 
+import { makeResponse } from 'support/util/response';
+import { paginateResponse } from 'support/util/paginate';
 import { makeErrorResponse } from 'support/util/errors';
 import type {
   Profile,
   UserPreferences,
   SecurityQuestionsData,
   SecurityQuestionsPayload,
+  Token,
 } from '@linode/api-v4/types';
 
 /**
@@ -152,4 +155,41 @@ export const mockConfirmTwoFactorAuth = (
   return cy.intercept('POST', '*/profile/tfa-enable-confirm', {
     scratch: scratchCode,
   });
+};
+
+/**
+ * Intercepts GET request to retrieve third party app tokens and mocks response.
+ *
+ * @param tokens - Array of third party app tokens with which to respond.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetAppTokens = (tokens: Token[]): Cypress.Chainable<null> => {
+  return cy.intercept('GET', '*/profile/apps*', paginateResponse(tokens));
+};
+
+/**
+ * Intercepts GET request to retrieve personal access tokens and mocks response.
+ *
+ * @param tokens - Array of personal access tokens with which to respond.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetPersonalAccessTokens = (
+  tokens: Token[]
+): Cypress.Chainable<null> => {
+  return cy.intercept('GET', '*/profile/tokens*', paginateResponse(tokens));
+};
+
+/**
+ * Intercepts POST request to create a personal access token and mocks response.
+ *
+ * @param token - Personal access token with which to respond.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockCreatePersonalAccessToken = (
+  token: Token
+): Cypress.Chainable<null> => {
+  return cy.intercept('POST', '*/profile/tokens', makeResponse(token));
 };

--- a/packages/manager/src/features/Profile/APITokens/APITokenTable.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokenTable.tsx
@@ -223,7 +223,7 @@ export const APITokenTable = (props: Props) => {
           )}
         </Grid>
       </Grid>
-      <Table aria-label="List of Personal Access Tokens">
+      <Table aria-label={`List of ${title}`}>
         <TableHead>
           <TableRow data-qa-table-head>
             <TableSortCell

--- a/packages/manager/src/features/Profile/APITokens/RevokeTokenDialog.tsx
+++ b/packages/manager/src/features/Profile/APITokens/RevokeTokenDialog.tsx
@@ -32,7 +32,7 @@ export const RevokeTokenDialog = ({ open, onClose, token, type }: Props) => {
   const onRevoke = () => {
     mutateAsync().then(() => {
       onClose();
-      enqueueSnackbar(`Sucessfully revoked ${token?.label}`, {
+      enqueueSnackbar(`Successfully revoked ${token?.label}`, {
         variant: 'success',
       });
     });


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
This adds a couple integration tests for Cloud Manager PAT CRUD operations. It confirms that UI flows work as expected when users create, rename, and revoke personal access tokens. I opted to mock all of the data involved rather than create actual PATs and risk them leaking into logs, recordings, etc.

## How to test 🧪
Run `yarn up` and then:

```bash
yarn cy:run -s "cypress/e2e/account/personal-access-tokens.spec.ts"
```
