### PR TITLE
Account Agreements Query Small Optimization

### DIFF
--- a/packages/manager/src/features/linodes/MigrateLanding/MigrateLinode.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/MigrateLinode.tsx
@@ -87,7 +87,7 @@ const MigrateLanding: React.FC<CombinedProps> = (props) => {
   const linode = useExtendedLinode(linodeID);
   const { images } = useImages();
   const { data: profile } = useProfile();
-  const { data: agreements } = useAccountAgreements();
+  const { data: agreements } = useAccountAgreements(open);
   const { mutateAsync: updateAccountAgreements } = useMutateAccountAgreements();
 
   const [selectedRegion, handleSelectRegion] = React.useState<string | null>(

--- a/packages/manager/src/queries/accountAgreements.ts
+++ b/packages/manager/src/queries/accountAgreements.ts
@@ -11,13 +11,16 @@ import { queryPresets, simpleMutationHandlers } from './base';
 
 export const queryKey = 'account-agreements';
 
-export const useAccountAgreements = () => {
+export const useAccountAgreements = (enabled?: boolean) => {
   const { data: profile } = useProfile();
 
   return useQuery<Agreements, APIError[]>(queryKey, getAccountAgreements, {
     ...queryPresets.oneTimeFetch,
     ...queryPresets.noRetry,
-    enabled: !profile?.restricted,
+    enabled:
+      enabled === undefined
+        ? !profile?.restricted
+        : enabled && !profile?.restricted,
   });
 };
 


### PR DESCRIPTION
## Description 📝

- Allow us to conditionally enable the User Agreements query
- Only enable the `useAccountAgreements` in the Migrate Linode Modal if the modal is open
- This will save us one fetch to the API when we load cloud manager at `http://localhost:3000/linodes`

## Preview 📷

### Before
![Screen Shot 2023-02-07 at 3 46 41 PM](https://user-images.githubusercontent.com/115251059/217362204-e9873c79-3cb8-44b1-8cf7-384dbc117a9a.jpg)

### After
![Screen Shot 2023-02-07 at 3 46 23 PM](https://user-images.githubusercontent.com/115251059/217362230-c3966b35-b1e4-4571-ba75-a68197166c59.jpg)


## How to test 🧪

- Go to `http://localhost:3000/linodes` with at least one Linode on your account 
- First verify account agreements have **not** been fetched 
- Verify that when you open the Linode **Migrate** modal, the account agreements endpoint is fetched to get a user's agreements