### PR TITLE
Fix dialog close button ARIA label mismatch

### DIFF
--- a/packages/manager/cypress/e2e/account/service-transfer.spec.ts
+++ b/packages/manager/cypress/e2e/account/service-transfer.spec.ts
@@ -284,7 +284,7 @@ describe('Account service transfers', () => {
             cy.findByDisplayValue(token).should('be.visible');
 
             // Close dialog.
-            cy.findByLabelText('Close drawer').should('be.visible').click();
+            cy.findByLabelText('Close').should('be.visible').click();
           });
 
         // Confirm token is listed on landing page and that correct information


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
This fixes an ARIA label mismatch that's causing one of the new service transfer tests to fail. Sorry for the trouble, I should've caught this before merging earlier!

## How to test 🧪
Run the service transfer tests and confirm that they all pass.

**How do I run relevant unit or e2e tests?**

`yarn up` and
```bash
yarn cy:run -s "cypress/e2e/account/service-transfer.spec.ts"
```