### PR TITLE
Fix tags with spaces in cli

### DIFF
--- a/packages/manager/src/utilities/generate-cli.ts
+++ b/packages/manager/src/utilities/generate-cli.ts
@@ -1,14 +1,4 @@
-const escapeStringForCLI = (value: string) => {
-  const doesContainEscapableChars = value.match(/[^\w\s]/gi);
-  let parsedValue = value;
-  if (doesContainEscapableChars) {
-    parsedValue = value.replace(/[^\w\s]/gi, function (char) {
-      return '\\' + char;
-    });
-    return parsedValue;
-  }
-  return value;
-};
+import escapeStringForCLI from './escapeStringForCLI';
 
 type JSONFieldToArray = [string, unknown];
 

--- a/packages/manager/src/utilities/generate-cli.ts
+++ b/packages/manager/src/utilities/generate-cli.ts
@@ -37,7 +37,7 @@ const parseArray = (key: string, value: any[]) => {
     );
   } else {
     value.forEach((item) => {
-      results.push(`  --${key} ${escapeStringForCLI(item)}`);
+      results.push(`  --${key} '${escapeStringForCLI(item)}'`);
     });
   }
   return results.join(' \\\n');


### PR DESCRIPTION
## Description 📝

Wraps the tags in CLI commands in case they have spaces in them

**What are the steps to reproduce the issue or verify the changes?**
1. Navigate to create a new linode
2. Add a tag with just spaces in its name like `tag with spaces`
3. Add a tag with paces and special characters in its name like `\tag\/with&special-+&chars`
4. Click `Create Using Command Line`
5. Click the Linode CLI tab
6. Copy the linode-cli command and try to run it
7. Ensure that the linode is successfully created
8. Ensure that the tags on the linode are as typed in the create form
