### PR TITLE
Fix FirewallRuleTable styling for dark mode

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -69,8 +69,8 @@ const useStyles = makeStyles((theme: Theme) => ({
     border: 'none',
   },
   unmodified: {
-    backgroundColor: '#FFFFFF',
-    color: '#606469',
+    backgroundColor: theme.bg.bgPaper,
+    color: theme.textColors.tableStatic,
   },
   highlight: {
     backgroundColor: theme.bg.lightBlue1,
@@ -111,13 +111,13 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   ruleHeaderRow: {
     marginTop: '5px',
-    backgroundColor: '#F9FAFA',
-    color: '#888F91',
+    backgroundColor: theme.bg.tableHeader,
+    color: theme.textColors.tableHeader,
     fontWeight: 'bold',
     height: '46px',
   },
   ruleRow: {
-    borderBottom: '1px solid #F4F5F6',
+    borderBottom: `1px solid ${theme.borderColors.borderTable}`,
     height: '40px',
   },
   addLabelButton: {


### PR DESCRIPTION
## Description 📝

**What does this PR do?**

Fixes styling of FirewallRuleTable when in dark mode by relying on `theme` colors.. I forgot to test dark mode when working on [M3-6039](https://github.com/linode/manager/pull/8735)...

## Preview 📷

**Remove this section or include a screenshot or screen recording of the change**
This branch ✅ :
![Screen Shot 2023-02-08 at 9 16 02 AM](https://user-images.githubusercontent.com/114685994/217605717-9c1ffe20-6cef-4572-abaf-71c005912029.jpg)

Staging ❌ :
![Screen Shot 2023-02-08 at 9 21 53 AM](https://user-images.githubusercontent.com/114685994/217605735-03a5c74d-57f4-4a4d-b5bc-1a9c709640bb.jpg)

## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**
Switch dark mode on and off in My Settings and test that firewall rules colors correspond with the theme.
)