### PR TITLE
New Escape Function for CLI Generation

### DIFF
--- a/packages/manager/src/utilities/generate-cli.ts
+++ b/packages/manager/src/utilities/generate-cli.ts
@@ -1,14 +1,13 @@
-const escapeStringForCLI = (value: string) => {
-  const doesContainEscapableChars = value.match(/[^\w\s]/gi);
-  let parsedValue = value;
-  if (doesContainEscapableChars) {
-    parsedValue = value.replace(/[^\w\s]/gi, function (char) {
-      return '\\' + char;
-    });
-    return parsedValue;
+// Credit: https://github.com/xxorax/node-shell-escape
+function escapeStringForCLI(s: string): string {
+  if (/[^A-Za-z0-9_\/:=-]/.test(s)) {
+    s = "'" + s.replace(/'/g, "'\\''") + "'";
+    s = s
+      .replace(/^(?:'')+/g, '') // unduplicate single-quote at the beginning
+      .replace(/\\'''/g, "\\'"); // remove non-escaped single-quote if there are enclosed between 2 escaped
   }
-  return value;
-};
+  return s;
+}
 
 type JSONFieldToArray = [string, unknown];
 


### PR DESCRIPTION
## Description 📝

- Uses new escapeStringForCLI function for parsing strings in CLI command generation

## How to test 🧪

- Test creating a Linode using the new **Create from Command** Line button, using the **CLI** tab
- Verify you can use spaces in tags names
- Verify you can use complex characters in both tags and root passwords

Some test cases
- `testing’okay/this\is!a&testing’okay`
- `\\yay’’testing//\\okay’test'okay'test!!nice`
- `this is a test tag`

