### PR TITLE
Fix dark mode illegible text, undo button spacing on newly added rules

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -70,7 +70,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   unmodified: {
     backgroundColor: theme.bg.bgPaper,
-    color: theme.textColors.tableStatic,
   },
   highlight: {
     backgroundColor: theme.bg.lightBlue1,
@@ -118,7 +117,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   ruleRow: {
     borderBottom: `1px solid ${theme.borderColors.borderTable}`,
-    height: '40px',
+    color: theme.textColors.tableStatic,
   },
   addLabelButton: {
     ...theme.applyLinkStyles,
@@ -306,7 +305,10 @@ const FirewallRuleTable: React.FC<CombinedProps> = (props) => {
                     <Grid
                       container
                       data-testid={'table-row-empty'}
-                      className={classNames(classes.unmodified)}
+                      className={classNames(
+                        classes.unmodified,
+                        classes.ruleRow
+                      )}
                       style={{
                         padding: 8,
                         width: '100%',
@@ -542,7 +544,11 @@ export const PolicyRow: React.FC<PolicyRowProps> = React.memo((props) => {
   return (
     <Grid
       container
-      className={classNames(classes.policyRow, classes.unmodified)}
+      className={classNames(
+        classes.policyRow,
+        classes.unmodified,
+        classes.ruleRow
+      )}
       tabIndex={0}
     >
       <Grid item xs={colSpan} className={classes.policyText}>


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
Fixes a previous fix that was missed in #8776: due to applying the text styling to the wrong CSS rule, a newly created firewall rule row would should up in dark mode with black text rather than `theme.textColors.tableStatic`. 

A set height of 40px for a firewall rule row also caused a strange issue, noticeable in dark mode, for the undo button of newly added firewall rule(s), where the button had a height of 41px and extended beyond the container. Unsetting the row `height` seemed to fix the issue.

## Preview 📷

**Remove this section or include a screenshot or screen recording of the change**
Fix:

https://user-images.githubusercontent.com/114685994/217683444-9cfca002-125c-466f-a9f2-ab0ee69412bf.mov


Staging:

https://user-images.githubusercontent.com/114685994/217683459-b89f15ab-5e19-4384-adf6-96c90932cb69.mov


## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**
Use dark mode and Add an Inbound (or Outbound) Firewall Rule. Ensure the rule displays with legible text in both dark and light mode. Ensure the "undo" button doesn't stick out beyond the bottom of the row.
