### PR TITLE
M3-5065: Add status to Linode Backups table

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/BackupTableRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/BackupTableRow.tsx
@@ -2,6 +2,7 @@ import { LinodeBackup } from '@linode/api-v4/lib/linodes';
 import { Duration } from 'luxon';
 import * as React from 'react';
 import DateTimeDisplay from 'src/components/DateTimeDisplay';
+import StatusIcon, { Status } from 'src/components/StatusIcon/StatusIcon';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import { parseAPIDate } from 'src/utilities/date';
@@ -20,6 +21,26 @@ const typeMap = {
   snapshot: 'Manual',
 };
 
+const statusTextMap: Record<LinodeBackup['status'], string> = {
+  pending: 'Pending',
+  running: 'Running',
+  needsPostProcessing: 'Processing',
+  successful: 'Success',
+  paused: 'Paused',
+  failed: 'Failed',
+  userAborted: 'Aborted',
+};
+
+const statusIconMap: Record<LinodeBackup['status'], Status> = {
+  pending: 'other',
+  running: 'other',
+  needsPostProcessing: 'other',
+  successful: 'active',
+  paused: 'inactive',
+  failed: 'error',
+  userAborted: 'error',
+};
+
 const BackupTableRow: React.FC<Props> = (props) => {
   const { backup, disabled, handleRestore } = props;
 
@@ -34,6 +55,14 @@ const BackupTableRow: React.FC<Props> = (props) => {
         data-qa-backup-name={backup.label || typeMap[backup.type]}
       >
         {backup.label || typeMap[backup.type]}
+      </TableCell>
+      <TableCell
+        statusCell
+        parentColumn="Status"
+        data-qa-backup-name={backup.status}
+      >
+        <StatusIcon status={statusIconMap[backup.status] ?? 'other'} />
+        {statusTextMap[backup.status]}
       </TableCell>
       <TableCell parentColumn="Date Created">
         {/** important to note that we're intentionally not humanizing the time here */}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -266,8 +266,11 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
         getBackupsTimer: setTimeout(
           () =>
             getLinodeBackups(this.props.linodeID).then((data) => {
-              this.setState({ backups: data });
-              this.setState({ getBackupsTimer: null });
+              this.setState({
+                ...this.state,
+                backups: data,
+                getBackupsTimer: null,
+              });
             }),
           15000
         ),

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -493,6 +493,7 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
           <TableHead>
             <TableRow>
               <TableCell>Label</TableCell>
+              <TableCell>Status</TableCell>
               <TableCell>Date Created</TableCell>
               <TableCell>Duration</TableCell>
               <TableCell>Disks</TableCell>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -150,6 +150,7 @@ interface PreloadedProps {
 
 interface State {
   backups: LinodeBackupsResponse;
+  getBackupsTimer: NodeJS.Timeout | null;
   snapshotForm: {
     label: string;
     errors?: APIError[];
@@ -200,6 +201,7 @@ export const aggregateBackups = (
 class _LinodeBackup extends React.Component<CombinedProps, State> {
   state: State = {
     backups: this.props.backups.response,
+    getBackupsTimer: null,
     snapshotForm: {
       label: '',
     },
@@ -256,15 +258,20 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
       return;
     }
     if (
-      this.state.backups.snapshot.in_progress.status === 'needsPostProcessing'
+      this.state.backups.snapshot.in_progress.status ===
+        'needsPostProcessing' &&
+      this.state.getBackupsTimer === null
     ) {
-      setTimeout(
-        () =>
-          getLinodeBackups(this.props.linodeID).then((data) => {
-            this.setState({ backups: data });
-          }),
-        15000
-      );
+      this.setState({
+        getBackupsTimer: setTimeout(
+          () =>
+            getLinodeBackups(this.props.linodeID).then((data) => {
+              this.setState({ backups: data });
+              this.setState({ getBackupsTimer: null });
+            }),
+          15000
+        ),
+      });
     }
   }
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -250,6 +250,24 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
       });
   }
 
+  // update backup status column from processing -> success/failure
+  componentDidUpdate() {
+    if (this.state.backups.snapshot.in_progress === null) {
+      return;
+    }
+    if (
+      this.state.backups.snapshot.in_progress.status === 'needsPostProcessing'
+    ) {
+      setTimeout(
+        () =>
+          getLinodeBackups(this.props.linodeID).then((data) => {
+            this.setState({ backups: data });
+          }),
+        15000
+      );
+    }
+  }
+
   componentWillUnmount() {
     this.mounted = false;
     this.eventSubscription.unsubscribe();

--- a/packages/manager/src/utilities/getEventsActionLink.ts
+++ b/packages/manager/src/utilities/getEventsActionLink.ts
@@ -64,6 +64,10 @@ export default (
     return `/images`;
   }
 
+  if (['linode_snapshot', 'backups_enable'].includes(action)) {
+    return `/linodes/${id}/backup`;
+  }
+
   switch (type) {
     case 'linode':
       return action === 'linode_addip'


### PR DESCRIPTION
## Description 📝
Currently, we do not indicate on Cloud when a Linode backup is still post-processing, or if it fails after processing. This PR adds a status column to the Linode backups table and links the event row message to the Linode's backup tab for more transparency. 

## Preview 📷
![image](https://user-images.githubusercontent.com/115299789/217607709-0eae41c3-817b-4bad-993b-2f1a27032ab9.png)

Failure state
![image](https://user-images.githubusercontent.com/115299789/217608009-df8fb668-1c12-418e-bdcf-b7dc32b6fa35.png)

## How to test 🧪
Enable/create a snapshot in a Linode's detail page -> Backups tab. Notice the new status column.

When a snapshot has finished being taken (100%, check the notification menu or the entity detail header), the Backups table should update with the new snapshot and you should see a status of Processing. Wait a little while and the status should then update to success/failure.

In the notification menu/events page, clicking on the snapshot backup event should bring you to the Linode's backup tab

To mock a failure state, you can override the backup status in BackupTableRow.tsx 