### PR TITLE
Fix Cypress failure involving top menu icon changes

### DIFF
--- a/packages/manager/cypress/e2e/linodes/smoke-linode-landing-table.spec.ts
+++ b/packages/manager/cypress/e2e/linodes/smoke-linode-landing-table.spec.ts
@@ -127,7 +127,7 @@ describe('linode landing checks', () => {
         .should('be.visible')
         .should('have.attr', 'href', '/support');
 
-      cy.findByLabelText('Linode Cloud Community')
+      cy.findByTitle('Linode Cloud Community')
         .should('be.visible')
         .parent()
         .should('have.attr', 'href', 'https://linode.com/community');


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
This is a tiny fix for the failure in `smoke-linode-landing-table.spec.ts`, which stems from the accessibility improvements made by PR #8779 -- the affected test attempts to find a top menu icon by its `aria-label` attribute, but that attribute is no longer present. This PR fixes it by finding the element by its `title` attribute instead.

## How to test 🧪
Run Cloud Manager with `yarn up`, then run the command below and confirm that the tests pass, particularly the `checks the landing top menu items` test.

**How do I run relevant e2e tests?**
```bash
yarn cy:run -s "cypress/e2e/linodes/smoke-linode-landing-table.spec.ts"
```
