### PR TITLE
M3-5807: Don't Reset the Firewall Rule Drawer if the same preset is reselected

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
@@ -278,6 +278,12 @@ const FirewallRuleForm: React.FC<FirewallRuleFormProps> = React.memo(
     const handleTypeChange = React.useCallback(
       (item: Item | null) => {
         const selectedType = item?.value;
+
+        // If the user re-selectes the same preset, don't do anything
+        if (selectedType === values.type) {
+          return;
+        }
+
         setFieldValue('type', selectedType);
 
         if (!selectedType) {

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
@@ -318,6 +318,7 @@ const FirewallRuleForm: React.FC<FirewallRuleFormProps> = React.memo(
         category,
         setPresetPorts,
         values.action,
+        values.type,
       ]
     );
 


### PR DESCRIPTION
## Description 📝

- If the user reselectes the **same preset** in the firewalls rule drawer, **do not reset the form** to the preset defaults
  - This was causing users to accidentally loose their progress when they reselected the same preset

## Preview 📷

### Before
Note how form resets when the same preset is selected resulting in the users progress being lost

https://user-images.githubusercontent.com/115251059/218135926-12711216-1df3-44aa-900b-70f2005341f9.mov

### After
Note how the form does not change state at all

https://user-images.githubusercontent.com/115251059/218135792-dc2c847c-4fd5-4618-a57a-af2940e1fdda.mov

## How to test 🧪

- Test the behavior and functionality of the Firewall Rules drawer 