### PR TITLE
M3-6163: Standardize Text Tooltip

### DIFF
--- a/packages/manager/src/components/TextTooltip/TextTooltip.tsx
+++ b/packages/manager/src/components/TextTooltip/TextTooltip.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
-import ExternalLinkIcon from 'src/assets/icons/external-link.svg';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import ToolTip from 'src/components/core/Tooltip';
 import Typography from 'src/components/core/Typography';
-import Link from 'src/components/Link';
 
 interface Props {
-  text: string;
+  displayText: string;
+  tooltipText: JSX.Element | string;
 }
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -29,33 +28,21 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-const akamaiBillingInvoiceText = (
-  <Typography>
-    Charges in the final Akamai invoice should be considered the final source
-    truth. Linode invoice will not reflect discounting, currency adjustment, or
-    any negotiated terms and conditions. Condensed and finalized invoice is
-    available within{' '}
-    <Link to="https://control.akamai.com/apps/billing">
-      Akamai Control Center &gt; Billing <ExternalLinkIcon />
-    </Link>
-    .
-  </Typography>
-);
-
-export const BillingTooltip: React.FC<Props> = (props) => {
+export const TextTooltip: React.FC<Props> = (props: Props) => {
   const classes = useStyles();
-  const { text } = props;
+  const { displayText, tooltipText } = props;
 
   return (
     <ToolTip
-      title={akamaiBillingInvoiceText}
+      title={tooltipText}
       placement="bottom"
+      enterTouchDelay={0}
       className={classes.root}
       classes={{ popper: classes.popper }}
     >
-      <Typography>{text}</Typography>
+      <Typography>{displayText}</Typography>
     </ToolTip>
   );
 };
 
-export default BillingTooltip;
+export default TextTooltip;

--- a/packages/manager/src/components/TextTooltip/TextTooltip.tsx
+++ b/packages/manager/src/components/TextTooltip/TextTooltip.tsx
@@ -28,7 +28,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-export const TextTooltip: React.FC<Props> = (props: Props) => {
+export const TextTooltip = (props: Props) => {
   const classes = useStyles();
   const { displayText, tooltipText } = props;
 

--- a/packages/manager/src/components/TextTooltip/index.ts
+++ b/packages/manager/src/components/TextTooltip/index.ts
@@ -1,0 +1,2 @@
+import TextTooltip from './TextTooltip';
+export default TextTooltip;

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -6,11 +6,12 @@ import {
 } from '@linode/api-v4/lib/account';
 import { DateTime } from 'luxon';
 import * as React from 'react';
+import ExternalLinkIcon from 'src/assets/icons/external-link.svg';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
 import Typography from 'src/components/core/Typography';
-import BillingTooltip from 'src/components/BillingTooltip';
+import TextTooltip from 'src/components/TextTooltip/TextTooltip';
 import Currency from 'src/components/Currency';
 import DateTimeDisplay from 'src/components/DateTimeDisplay';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
@@ -61,7 +62,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginLeft: 10,
     paddingLeft: 20,
     flexGrow: 2,
-    [theme.breakpoints.down('xs')]: {
+    [theme.breakpoints.down('sm')]: {
       paddingLeft: 0,
     },
   },
@@ -203,6 +204,19 @@ export const BillingActivityPanel: React.FC<Props> = (props) => {
     makeFilter(getCutoffFromDateRange(selectedTransactionDate))
   );
 
+  const akamaiBillingInvoiceText = (
+    <Typography>
+      Charges in the final Akamai invoice should be considered the final source
+      truth. Linode invoice will not reflect discounting, currency adjustment,
+      or any negotiated terms and conditions. Condensed and finalized invoice is
+      available within{' '}
+      <Link to="https://control.akamai.com/apps/billing">
+        Akamai Control Center &gt; Billing <ExternalLinkIcon />
+      </Link>
+      .
+    </Typography>
+  );
+
   const downloadInvoicePDF = React.useCallback(
     (invoiceId: number) => {
       const invoice = invoices?.find(
@@ -338,7 +352,10 @@ export const BillingActivityPanel: React.FC<Props> = (props) => {
         </Typography>
         {isAkamaiCustomer ? (
           <div className={classes.headerLeft}>
-            <BillingTooltip text="Usage History may not reflect finalized invoice" />
+            <TextTooltip
+              displayText="Usage History may not reflect finalized invoice"
+              tooltipText={akamaiBillingInvoiceText}
+            />
           </div>
         ) : null}
         <div className={classes.headerRight}>

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -157,6 +157,19 @@ const transactionDateOptions: Item<DateRange>[] = [
 
 const defaultDateRange: DateRange = '6 Months';
 
+const AkamaiBillingInvoiceText = (
+  <Typography>
+    Charges in the final Akamai invoice should be considered the final source
+    truth. Linode invoice will not reflect discounting, currency adjustment, or
+    any negotiated terms and conditions. Condensed and finalized invoice is
+    available within{' '}
+    <Link to="https://control.akamai.com/apps/billing">
+      Akamai Control Center &gt; Billing <ExternalLinkIcon />
+    </Link>
+    .
+  </Typography>
+);
+
 // =============================================================================
 // <BillingActivityPanel />
 // =============================================================================
@@ -202,19 +215,6 @@ export const BillingActivityPanel: React.FC<Props> = (props) => {
   } = useAllAccountInvoices(
     {},
     makeFilter(getCutoffFromDateRange(selectedTransactionDate))
-  );
-
-  const AkamaiBillingInvoiceText = (
-    <Typography>
-      Charges in the final Akamai invoice should be considered the final source
-      truth. Linode invoice will not reflect discounting, currency adjustment,
-      or any negotiated terms and conditions. Condensed and finalized invoice is
-      available within{' '}
-      <Link to="https://control.akamai.com/apps/billing">
-        Akamai Control Center &gt; Billing <ExternalLinkIcon />
-      </Link>
-      .
-    </Typography>
   );
 
   const downloadInvoicePDF = React.useCallback(

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -204,7 +204,7 @@ export const BillingActivityPanel: React.FC<Props> = (props) => {
     makeFilter(getCutoffFromDateRange(selectedTransactionDate))
   );
 
-  const akamaiBillingInvoiceText = (
+  const AkamaiBillingInvoiceText = (
     <Typography>
       Charges in the final Akamai invoice should be considered the final source
       truth. Linode invoice will not reflect discounting, currency adjustment,
@@ -354,7 +354,7 @@ export const BillingActivityPanel: React.FC<Props> = (props) => {
           <div className={classes.headerLeft}>
             <TextTooltip
               displayText="Usage History may not reflect finalized invoice"
-              tooltipText={akamaiBillingInvoiceText}
+              tooltipText={AkamaiBillingInvoiceText}
             />
           </div>
         ) : null}


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
Makes a few updates to standardize the tooltip by doing the following:
- Renames from `BillingTooltip` to a more generic `TextTooltip`
- Removes const billing text and replace with prop for popover text
- Replicates default behavior for triggering tooltips on mobile – our other tooltips using button components open popover immediately on click; don't require a long-press which is the MUI Tooltip default
- Also fixes a small alignment issue in the table header at `sm` screen breakpoint; `xs` breakpoint was previously used and should not have been

Previously, this was only used as a billing notice for Akamai customers, but we expect to expand its use.

## Preview 📷

Tooltip in non-mobile view should behave and look unchanged:
![Screen Shot 2023-02-13 at 11 25 21 AM](https://user-images.githubusercontent.com/114685994/218555899-f84e48c6-3102-4b27-81f9-bd5c8b867a33.jpg)

<details>
<summary> Screencaps 📹  </summary>

**Before** (note the long-press)

https://user-images.githubusercontent.com/114685994/218554530-f87f9b20-a943-46bd-87e3-2c56f37b2e38.mov


**After**

https://user-images.githubusercontent.com/114685994/218554508-2b1948c6-1478-4b85-9022-17b3915dddf7.mov


</details>

## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**
Since the Billing Activity Panel is currently the only existing place in the app that the tooltip exists, follow the same steps to replicate as #8690: 
1. In `src/factories/account.ts`, change the `billing_source` from `linode` to `akamai` and then turn on the MSW to mock an Akamai-billed account.
2. Navigate to http://localhost:3000/account/billing.
3. Observe that the billing table header copy is "Usage History", a usage history tooltip with a dashed underline displays next to the header, and hovering over tooltip displays updated copy with link below the tooltip. 
4. Use dev tools to toggle device to a couple different mobile devices, at least one of them with a small screen. Click on the tooltip in mobile view and observe that the popover text is triggered immediately, rather than after a delay. Compare this to the behavior when clicking help tooltips elsewhere on the Account page to confirm tooltip behavior is consistent.
5. Observe that on small screens (`xs` and `sm` breakpoint), table header components are consistently aligned to the left, including the tooltip.
