### PR TITLE
M3-6078: Account Logins Show `Successful` or `Failed` Access

### DIFF
--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -458,10 +458,13 @@ export interface MakePaymentData {
   payment_method_id?: number;
 }
 
+export type AccountLoginStatus = 'successful' | 'failed';
+
 export interface AccountLogin {
   datetime: string;
   id: number;
   ip: string;
   restricted: boolean;
   username: string;
+  status: AccountLoginStatus;
 }

--- a/packages/manager/src/components/StatusIcon/StatusIcon.tsx
+++ b/packages/manager/src/components/StatusIcon/StatusIcon.tsx
@@ -23,30 +23,40 @@ const useStyles = makeStyles((theme: Theme) => ({
   statusIconOther: {
     backgroundColor: theme.color.orange,
   },
+  pulse: {
+    animation: 'pulse 1.5s ease-in-out infinite',
+  },
 }));
 
 export type Status = 'active' | 'inactive' | 'error' | 'other';
 
 export interface StatusProps {
   status: Status;
+  pulse?: boolean;
 }
 
-export const StatusIcon: React.FC<StatusProps> = (props) => {
-  const { status } = props;
+export const StatusIcon = (props: StatusProps) => {
+  const { status, pulse } = props;
 
   const classes = useStyles();
+
+  const shouldPulse =
+    pulse === undefined
+      ? // If pulse is not defined, use old behavior for choosing when to pulse
+        !['inactive', 'active', 'error'].includes(status)
+      : pulse;
 
   return (
     <div
       className={classNames({
         [classes.statusIcon]: true,
+        [classes.pulse]: shouldPulse,
         [classes.statusIconRunning]: status === 'active',
         [classes.statusIconOffline]: status === 'inactive',
         [classes.statusIconError]: status === 'error',
         [classes.statusIconOther]: !['inactive', 'active', 'error'].includes(
           status
         ),
-        statusOther: !['inactive', 'active', 'error'].includes(status),
       })}
     />
   );

--- a/packages/manager/src/features/Account/AccountLogins.tsx
+++ b/packages/manager/src/features/Account/AccountLogins.tsx
@@ -64,7 +64,7 @@ const AccountLogins = () => {
       return (
         <TableRowLoading
           rows={1}
-          columns={4}
+          columns={5}
           responsive={{
             2: { smDown: true },
             3: { mdDown: true },
@@ -76,7 +76,7 @@ const AccountLogins = () => {
       return <TableRowError colSpan={5} message={error[0].reason} />;
     }
     if (data?.results == 0) {
-      return <TableRowEmptyState message="No account logins" colSpan={6} />;
+      return <TableRowEmptyState message="No account logins" colSpan={5} />;
     }
     if (data) {
       return data.data.map((item: AccountLogin) => (

--- a/packages/manager/src/features/Account/AccountLogins.tsx
+++ b/packages/manager/src/features/Account/AccountLogins.tsx
@@ -66,8 +66,8 @@ const AccountLogins = () => {
           rows={1}
           columns={4}
           responsive={{
-            1: { xsDown: true },
-            3: { smDown: true },
+            2: { smDown: true },
+            3: { mdDown: true },
           }}
         />
       );
@@ -113,7 +113,7 @@ const AccountLogins = () => {
             >
               Username
             </TableSortCell>
-            <Hidden xsDown>
+            <Hidden smDown>
               <TableSortCell
                 active={orderBy === 'ip'}
                 direction={order}
@@ -124,7 +124,7 @@ const AccountLogins = () => {
                 IP
               </TableSortCell>
             </Hidden>
-            <Hidden smDown>
+            <Hidden mdDown>
               <TableCell className={classes.cell}>Permission Level</TableCell>
             </Hidden>
             <TableSortCell

--- a/packages/manager/src/features/Account/AccountLogins.tsx
+++ b/packages/manager/src/features/Account/AccountLogins.tsx
@@ -127,6 +127,15 @@ const AccountLogins = () => {
             <Hidden smDown>
               <TableCell className={classes.cell}>Permission Level</TableCell>
             </Hidden>
+            <TableSortCell
+              active={orderBy === 'status'}
+              direction={order}
+              label="status"
+              handleClick={handleOrderChange}
+              className={classes.cell}
+            >
+              Access
+            </TableSortCell>
           </TableRow>
         </TableHead>
         <TableBody>{renderTableContent()}</TableBody>

--- a/packages/manager/src/features/Account/AccountLoginsTableRow.tsx
+++ b/packages/manager/src/features/Account/AccountLoginsTableRow.tsx
@@ -25,10 +25,10 @@ const AccountLoginsTableRow = (props: AccountLogin) => {
       <TableCell noWrap>
         <Link to={`/account/users/${username}`}>{username}</Link>
       </TableCell>
-      <Hidden xsDown>
+      <Hidden smDown>
         <TableCell>{ip}</TableCell>
       </Hidden>
-      <Hidden smDown>
+      <Hidden mdDown>
         <TableCell noWrap>
           {restricted ? 'Restricted' : 'Unrestricted'}
         </TableCell>

--- a/packages/manager/src/features/Account/AccountLoginsTableRow.tsx
+++ b/packages/manager/src/features/Account/AccountLoginsTableRow.tsx
@@ -1,13 +1,23 @@
-import { AccountLogin } from '@linode/api-v4/lib/account/types';
 import * as React from 'react';
 import Hidden from 'src/components/core/Hidden';
 import Link from 'src/components/Link';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import formatDate from 'src/utilities/formatDate';
+import StatusIcon, { Status } from 'src/components/StatusIcon/StatusIcon';
+import { capitalize } from 'src/utilities/capitalize';
+import {
+  AccountLogin,
+  AccountLoginStatus,
+} from '@linode/api-v4/lib/account/types';
+
+const accessIconMap: Record<AccountLoginStatus, Status> = {
+  failed: 'other',
+  successful: 'active',
+};
 
 const AccountLoginsTableRow = (props: AccountLogin) => {
-  const { datetime, ip, restricted, username, id } = props;
+  const { datetime, ip, restricted, username, id, status } = props;
 
   return (
     <TableRow key={id}>
@@ -23,6 +33,10 @@ const AccountLoginsTableRow = (props: AccountLogin) => {
           {restricted ? 'Restricted' : 'Unrestricted'}
         </TableCell>
       </Hidden>
+      <TableCell statusCell>
+        <StatusIcon status={accessIconMap[status] ?? 'other'} pulse={false} />
+        {capitalize(status)}
+      </TableCell>
     </TableRow>
   );
 };

--- a/packages/manager/src/index.css
+++ b/packages/manager/src/index.css
@@ -324,16 +324,6 @@ button::-moz-focus-inner {
   }
 }
 
-/* Animate Linode Landing pending action status icons */
-.statusOther {
-  animation: pulse 1.5s ease-in-out infinite;
-}
-
-/* Animate Linode Details pending action status icon */
-.statusOtherDetail::before {
-  animation: pulse 1.5s ease-in-out infinite;
-}
-
 .no-transition *,
 .no-transition *::before,
 .no-transition *::after {


### PR DESCRIPTION
## Description 📝

- Adds new `Access` column to the Account Logins table to show if a login was `successful` or `failed`
  - `http://localhost:3000/account/login-history`

## Preview 📷

![Screen Shot 2023-02-15 at 2 33 17 PM](https://user-images.githubusercontent.com/115251059/219133675-11989137-af20-44b1-a0ec-c51bee38f091.jpg)

## How to test 🧪

- Checkout internal api PR that adds `status` to `/v4/account/logins`
- Switch Cloud Manager's env to use local development
- Visit `http://localhost:3000/account/login-history` and test the new column
  - Test loading state
  - Test ordering
  - Test mobile experience 