### PR TITLE
Update workflow to remove beta site deployment step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,29 +186,6 @@ jobs:
           SLACK_ICON_EMOJI: ":package:"
           MSG_MINIMAL: true
 
-  publish-manager:
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
-    needs:
-      - test-manager
-      - build-manager
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
-        with:
-          name: packages-manager-build
-          path: packages/manager/build
-      - uses: jakejarvis/s3-sync-action@master
-        with:
-          args: --acl public-read --follow-symlinks --delete
-        env:
-          AWS_S3_ENDPOINT: https://us-east-1.linodeobjects.com
-          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: us-east-1
-          SOURCE_DIR: packages/manager/build
-
   build-storybook:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
We're dropping cloud.beta.linode.com.