### PR TITLE
feat: [M3-6149] - Add Cloud Init checkbox to Image Capture/Create flow

### DIFF
--- a/packages/api-v4/src/images/images.ts
+++ b/packages/api-v4/src/images/images.ts
@@ -53,10 +53,7 @@ export const createImage = (
     ...(label && { label }),
     ...(description && { description }),
     ...(cloud_init && { cloud_init }),
-    // cloud_init: true,
   };
-  // console.log({ cloud_init });
-  // console.log({ data });
 
   return Request<Image>(
     setURL(`${API_ROOT}/images`),

--- a/packages/api-v4/src/images/images.ts
+++ b/packages/api-v4/src/images/images.ts
@@ -40,16 +40,19 @@ export const getImages = (params: any = {}, filters: any = {}) =>
  * @param diskId { number } The ID of the Linode Disk that this Image will be created from.
  * @param label { string } A short description of the Image. Labels cannot contain special characters.
  * @param description { string } A detailed description of this Image.
+ * @param cloud_init { boolean } An indicator of whether Image supports Cloudinit.
  */
 export const createImage = (
   diskId: number,
   label?: string,
-  description?: string
+  description?: string,
+  cloud_init?: boolean
 ) => {
   const data = {
     disk_id: diskId,
     ...(label && { label }),
     ...(description && { description }),
+    ...(cloud_init && { cloud_init }),
   };
 
   return Request<Image>(

--- a/packages/api-v4/src/images/images.ts
+++ b/packages/api-v4/src/images/images.ts
@@ -40,7 +40,7 @@ export const getImages = (params: any = {}, filters: any = {}) =>
  * @param diskId { number } The ID of the Linode Disk that this Image will be created from.
  * @param label { string } A short description of the Image. Labels cannot contain special characters.
  * @param description { string } A detailed description of this Image.
- * @param cloud_init { boolean } An indicator of whether Image supports Cloudinit.
+ * @param cloud_init { boolean } An indicator of whether Image supports cloud-init.
  */
 export const createImage = (
   diskId: number,

--- a/packages/api-v4/src/images/images.ts
+++ b/packages/api-v4/src/images/images.ts
@@ -53,7 +53,10 @@ export const createImage = (
     ...(label && { label }),
     ...(description && { description }),
     ...(cloud_init && { cloud_init }),
+    // cloud_init: true,
   };
+  // console.log({ cloud_init });
+  // console.log({ data });
 
   return Request<Image>(
     setURL(`${API_ROOT}/images`),

--- a/packages/api-v4/src/images/types.ts
+++ b/packages/api-v4/src/images/types.ts
@@ -29,11 +29,11 @@ export interface UploadImageResponse {
 export interface BaseImagePayload {
   label?: string;
   description?: string;
+  cloud_init?: boolean;
 }
 
 export interface CreateImagePayload extends BaseImagePayload {
   diskID: number;
-  cloud_init?: boolean;
 }
 
 export interface ImageUploadPayload extends BaseImagePayload {

--- a/packages/api-v4/src/images/types.ts
+++ b/packages/api-v4/src/images/types.ts
@@ -33,6 +33,7 @@ export interface BaseImagePayload {
 
 export interface CreateImagePayload extends BaseImagePayload {
   diskID: number;
+  cloud_init?: boolean;
 }
 
 export interface ImageUploadPayload extends BaseImagePayload {

--- a/packages/manager/src/components/CheckBox/CheckBox.tsx
+++ b/packages/manager/src/components/CheckBox/CheckBox.tsx
@@ -33,18 +33,16 @@ const useStyles = makeStyles((theme: Theme) => ({
   formControlStyles: {
     marginRight: 0,
   },
-  helpIcon: {
-    padding: '0px 0px 0px 8px',
-  },
 }));
 
 interface Props extends CheckboxProps {
   text?: string | JSX.Element;
   toolTipText?: string | JSX.Element;
+  toolTipInteractive?: boolean;
 }
 
-const LinodeCheckBox: React.FC<Props> = (props) => {
-  const { toolTipText, text, ...rest } = props;
+const LinodeCheckBox = (props: Props) => {
+  const { toolTipInteractive, toolTipText, text, ...rest } = props;
   const classes = useStyles();
 
   const classnames = classNames({
@@ -68,10 +66,10 @@ const LinodeCheckBox: React.FC<Props> = (props) => {
               {...rest}
             />
           }
-          label={props.text}
+          label={text}
         />
         {toolTipText ? (
-          <HelpIcon text={toolTipText} className={classes.helpIcon} />
+          <HelpIcon interactive={toolTipInteractive} text={toolTipText} />
         ) : null}
       </React.Fragment>
     );

--- a/packages/manager/src/components/CheckBox/CheckBox.tsx
+++ b/packages/manager/src/components/CheckBox/CheckBox.tsx
@@ -30,11 +30,17 @@ const useStyles = makeStyles((theme: Theme) => ({
       fill: `${theme.bg.main}`,
     },
   },
+  formControlStyles: {
+    marginRight: 0,
+  },
+  helpIcon: {
+    padding: '0px 0px 0px 8px',
+  },
 }));
 
 interface Props extends CheckboxProps {
   text?: string | JSX.Element;
-  toolTipText?: string;
+  toolTipText?: string | JSX.Element;
 }
 
 const LinodeCheckBox: React.FC<Props> = (props) => {
@@ -51,6 +57,7 @@ const LinodeCheckBox: React.FC<Props> = (props) => {
     return (
       <React.Fragment>
         <FormControlLabel
+          className={classes.formControlStyles}
           control={
             <Checkbox
               color="primary"
@@ -63,7 +70,9 @@ const LinodeCheckBox: React.FC<Props> = (props) => {
           }
           label={props.text}
         />
-        {toolTipText && <HelpIcon text={toolTipText} />}
+        {toolTipText ? (
+          <HelpIcon text={toolTipText} className={classes.helpIcon} />
+        ) : null}
       </React.Fragment>
     );
   }

--- a/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
@@ -23,6 +23,7 @@ import { useGrants, useProfile } from 'src/queries/profile';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 import Link from 'src/components/Link';
+import CheckBox from 'src/components/CheckBox';
 
 const useStyles = makeStyles((theme: Theme) => ({
   container: {
@@ -57,7 +58,18 @@ const useStyles = makeStyles((theme: Theme) => ({
       width: '100%',
     },
   },
+  cloudInitCheckboxWrapper: {
+    marginTop: theme.spacing(2),
+    marginLeft: 3,
+  },
 }));
+
+const cloudInitTooltipMessage = (
+  <Typography>
+    Copy TBD-If you deployed this from one of our cloud-init compatible disks
+    then it probably is. <Link to="/">Link to doc</Link>
+  </Typography>
+);
 
 export interface Props {
   label?: string;
@@ -84,6 +96,9 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
 
   const [selectedLinode, setSelectedLinode] = React.useState<Linode>();
   const [selectedDisk, setSelectedDisk] = React.useState<string | null>('');
+  const [isCloudInitChecked, setIsCloudInitChecked] = React.useState<boolean>(
+    false
+  );
   const [disks, setDisks] = React.useState<Disk[]>([]);
   const [notice, setNotice] = React.useState<string | undefined>();
   const [errors, setErrors] = React.useState<APIError[] | undefined>();
@@ -138,6 +153,10 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
     // Clear any errors
     setErrors(undefined);
     setSelectedDisk(diskID);
+  };
+
+  const handleCloudInitChange = () => {
+    setIsCloudInitChecked(!isCloudInitChecked);
   };
 
   const onSubmit = () => {
@@ -265,6 +284,14 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
         />
       </Box>
       {isRawDisk ? rawDiskWarning : null}
+      <Box className={classes.cloudInitCheckboxWrapper}>
+        <CheckBox
+          checked={isCloudInitChecked}
+          onChange={handleCloudInitChange}
+          text="This image is Cloud-init compatible"
+          toolTipText={cloudInitTooltipMessage}
+        />
+      </Box>
       <>
         <TextField
           label="Label"

--- a/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
@@ -96,9 +96,7 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
 
   const [selectedLinode, setSelectedLinode] = React.useState<Linode>();
   const [selectedDisk, setSelectedDisk] = React.useState<string | null>('');
-  const [isCloudInitChecked, setIsCloudInitChecked] = React.useState<boolean>(
-    false
-  );
+  const [isCloudInitChecked, setIsCloudInitChecked] = React.useState<boolean>();
   const [disks, setDisks] = React.useState<Disk[]>([]);
   const [notice, setNotice] = React.useState<string | undefined>();
   const [errors, setErrors] = React.useState<APIError[] | undefined>();
@@ -169,6 +167,7 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
       diskID: Number(selectedDisk),
       label,
       description: safeDescription,
+      cloud_init: isCloudInitChecked,
     })
       .then((_) => {
         resetEventsPolling();

--- a/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
@@ -67,7 +67,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 const cloudInitTooltipMessage = (
   <Typography>
     Copy TBD-If you deployed this from one of our cloud-init compatible disks
-    then it probably is. <Link to="/">Link to doc</Link>
+    then it probably is. <Link to="https://cloud.linode.com">Link to doc</Link>
   </Typography>
 );
 
@@ -288,6 +288,7 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
           onChange={changeIsCloudInit}
           text="This image is Cloud-init compatible"
           toolTipText={cloudInitTooltipMessage}
+          toolTipInteractive
         />
       </Box>
       <>

--- a/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
@@ -74,16 +74,20 @@ const cloudInitTooltipMessage = (
 export interface Props {
   label?: string;
   description?: string;
+  isCloudInit?: boolean;
   changeLabel: (e: React.ChangeEvent<HTMLInputElement>) => void;
   changeDescription: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  changeCloudInit: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
   const {
     label,
     description,
+    isCloudInit,
     changeLabel,
     changeDescription,
+    changeCloudInit,
     createImage,
   } = props;
 
@@ -96,9 +100,6 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
 
   const [selectedLinode, setSelectedLinode] = React.useState<Linode>();
   const [selectedDisk, setSelectedDisk] = React.useState<string | null>('');
-  const [isCloudInitChecked, setIsCloudInitChecked] = React.useState<boolean>(
-    false
-  );
   const [disks, setDisks] = React.useState<Disk[]>([]);
   const [notice, setNotice] = React.useState<string | undefined>();
   const [errors, setErrors] = React.useState<APIError[] | undefined>();
@@ -155,22 +156,17 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
     setSelectedDisk(diskID);
   };
 
-  const handleCloudInitChange = () => {
-    setIsCloudInitChecked(!isCloudInitChecked);
-  };
-
   const onSubmit = () => {
     setErrors(undefined);
     setNotice(undefined);
     setSubmitting(true);
-    // console.log({isCloudInitChecked})
 
     const safeDescription = description ?? '';
     createImage({
       diskID: Number(selectedDisk),
       label,
       description: safeDescription,
-      cloud_init: isCloudInitChecked ? isCloudInitChecked : undefined,
+      cloud_init: isCloudInit ? isCloudInit : undefined,
     })
       .then((_) => {
         resetEventsPolling();
@@ -288,8 +284,8 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
       {isRawDisk ? rawDiskWarning : null}
       <Box className={classes.cloudInitCheckboxWrapper}>
         <CheckBox
-          checked={isCloudInitChecked}
-          onChange={handleCloudInitChange}
+          checked={isCloudInit}
+          onChange={changeCloudInit}
           text="This image is Cloud-init compatible"
           toolTipText={cloudInitTooltipMessage}
         />

--- a/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
@@ -77,7 +77,7 @@ export interface Props {
   isCloudInit?: boolean;
   changeLabel: (e: React.ChangeEvent<HTMLInputElement>) => void;
   changeDescription: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  changeCloudInit: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  changeIsCloudInit: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
@@ -87,7 +87,7 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
     isCloudInit,
     changeLabel,
     changeDescription,
-    changeCloudInit,
+    changeIsCloudInit,
     createImage,
   } = props;
 
@@ -285,7 +285,7 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
       <Box className={classes.cloudInitCheckboxWrapper}>
         <CheckBox
           checked={isCloudInit}
-          onChange={changeCloudInit}
+          onChange={changeIsCloudInit}
           text="This image is Cloud-init compatible"
           toolTipText={cloudInitTooltipMessage}
         />

--- a/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
@@ -66,8 +66,9 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 const cloudInitTooltipMessage = (
   <Typography>
-    Copy TBD-If you deployed this from one of our cloud-init compatible disks
-    then it probably is. <Link to="https://cloud.linode.com">Link to doc</Link>
+    Many Linode supported distributions are compatible with cloud-init by
+    default, or you may have installed cloud-init.{' '}
+    <Link to="/">Learn more.</Link>
   </Typography>
 );
 

--- a/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
@@ -163,6 +163,7 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
     setErrors(undefined);
     setNotice(undefined);
     setSubmitting(true);
+    // console.log({isCloudInitChecked})
 
     const safeDescription = description ?? '';
     createImage({

--- a/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
@@ -96,7 +96,9 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
 
   const [selectedLinode, setSelectedLinode] = React.useState<Linode>();
   const [selectedDisk, setSelectedDisk] = React.useState<string | null>('');
-  const [isCloudInitChecked, setIsCloudInitChecked] = React.useState<boolean>();
+  const [isCloudInitChecked, setIsCloudInitChecked] = React.useState<boolean>(
+    false
+  );
   const [disks, setDisks] = React.useState<Disk[]>([]);
   const [notice, setNotice] = React.useState<string | undefined>();
   const [errors, setErrors] = React.useState<APIError[] | undefined>();
@@ -167,7 +169,7 @@ export const CreateImageTab: React.FC<Props & ImagesDispatch> = (props) => {
       diskID: Number(selectedDisk),
       label,
       description: safeDescription,
-      cloud_init: isCloudInitChecked,
+      cloud_init: isCloudInitChecked ? isCloudInitChecked : undefined,
     })
       .then((_) => {
         resetEventsPolling();

--- a/packages/manager/src/features/Images/ImagesCreate/ImageCreate.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/ImageCreate.tsx
@@ -18,6 +18,11 @@ export const ImageCreate: React.FC<CombinedProps> = (props) => {
   const [description, setDescription] = React.useState<string>(
     location?.state ? location.state.imageDescription : ''
   );
+  const [isCloudInit, setIsCloudInit] = React.useState<boolean>(false);
+
+  const handleSetCloudInit = () => {
+    setIsCloudInit(!isCloudInit);
+  };
 
   const handleSetLabel = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
@@ -37,8 +42,10 @@ export const ImageCreate: React.FC<CombinedProps> = (props) => {
         <CreateImageTab
           label={label}
           description={description}
+          isCloudInit={isCloudInit}
           changeLabel={handleSetLabel}
           changeDescription={handleSetDescription}
+          changeCloudInit={handleSetCloudInit}
         />
       ),
     },

--- a/packages/manager/src/features/Images/ImagesCreate/ImageCreate.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/ImageCreate.tsx
@@ -20,10 +20,6 @@ export const ImageCreate: React.FC<CombinedProps> = (props) => {
   );
   const [isCloudInit, setIsCloudInit] = React.useState<boolean>(false);
 
-  const handleSetCloudInit = () => {
-    setIsCloudInit(!isCloudInit);
-  };
-
   const handleSetLabel = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     setLabel(value);
@@ -45,7 +41,7 @@ export const ImageCreate: React.FC<CombinedProps> = (props) => {
           isCloudInit={isCloudInit}
           changeLabel={handleSetLabel}
           changeDescription={handleSetDescription}
-          changeCloudInit={handleSetCloudInit}
+          changeIsCloudInit={() => setIsCloudInit(!isCloudInit)}
         />
       ),
     },

--- a/packages/manager/src/store/image/image.requests.ts
+++ b/packages/manager/src/store/image/image.requests.ts
@@ -29,7 +29,8 @@ export const requestImages = createRequestThunk(requestImagesActions, () =>
 
 export const createImage = createRequestThunk(
   createImageActions,
-  ({ diskID, label, description }) => _create(diskID, label, description)
+  ({ diskID, label, description, cloud_init }) =>
+    _create(diskID, label, description, cloud_init)
 );
 
 export const uploadImage = createRequestThunk(uploadImageActions, (payload) =>

--- a/packages/validation/src/images.schema.ts
+++ b/packages/validation/src/images.schema.ts
@@ -1,4 +1,4 @@
-import { number, object, string } from 'yup';
+import { boolean, number, object, string } from 'yup';
 
 const labelSchema = string()
   .max(50, 'Length must be 50 characters or less.')
@@ -10,6 +10,7 @@ const labelSchema = string()
 export const baseImageSchema = object().shape({
   label: labelSchema.notRequired(),
   description: string().notRequired().min(1).max(65000),
+  cloud_init: boolean().notRequired(),
 });
 
 export const createImageSchema = baseImageSchema.shape({


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
Adds a non-required checkbox field (and accompanying help tooltip) to the Image **Capture** form so that a user can indicate if an image supports cloud init. By default, a captured image does not support cloud init.

Note that #8800 is the related PR for the Image **Upload** form.

TODO:
- [x] Finalize UX copy. Any changes (e.g. final links) will be addressed in a final copy PR to come.

## Preview 📷

![Screen Shot 2023-02-27 at 3 25 12 PM](https://user-images.githubusercontent.com/114685994/221712546-e64cd84c-88b5-45a3-862b-9dfadd01e6c7.jpg)

## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**
1. Check out this PR and switch your environment to Dev to test these changes. Ask if you need more details on testing these changes with a properly configured dev account.
2. Have at least one Linode with an attached Disk on your account.
3. Navigate to http://localhost:3000/images/create/disk to the Capture Image form.
4. Open the browser's dev tools, navigate to the network tab, and use the search bar to filter traffic by keyword "images" to make it easier to find the requests we want to verify.
5. Observe that the Capture Image form now includes a checkbox for cloud-init. Verify that the checkbox is unchecked by default and the UI (checkbox + tooltip) matches the mock in our internal issue. (Check back if you want to verify this; copy not yet finalized.)
7. Fill out the form with the required fields  **check** the cloud-init checkbox.
8. Examine the POST request in the dev tools Networks tab to verify that the request contains a value `cloud_init: true` and the image response contains `capabilities: ['cloud-init']`.
9. Fill out the form with the required fields and **do not check** the cloud-init checkbox.
10. Examine the POST request in the dev tools Networks tab to verify that the request contains **does not contain** a value `cloud_init` (since this is an optional field, we do not need to send `cloud_init: false`) and the image response **does not contain** `capabilities: ['cloud-init']`.
11. Change screen size and make sure UI looks consistent.

**How do I run relevant unit or e2e tests?**
