### PR TITLE
feat: [M3 6143] - Add User Data Accordion to Linode Create page

### DIFF
--- a/packages/api-v4/src/images/types.ts
+++ b/packages/api-v4/src/images/types.ts
@@ -4,6 +4,8 @@ export type ImageStatus =
   | 'deleted'
   | 'pending_upload';
 
+type ImageCapabilities = 'cloud-init';
+
 export interface Image {
   eol: string | null;
   id: string;
@@ -19,6 +21,7 @@ export interface Image {
   deprecated: boolean;
   expiry: null | string;
   status: ImageStatus;
+  capabilities: ImageCapabilities[];
 }
 
 export interface UploadImageResponse {

--- a/packages/api-v4/src/linodes/types.ts
+++ b/packages/api-v4/src/linodes/types.ts
@@ -302,6 +302,10 @@ export interface IPAllocationRequest {
   public: boolean;
 }
 
+interface UserData {
+  user_data: string;
+}
+
 export interface CreateLinodeRequest {
   type?: string;
   region?: string;
@@ -319,6 +323,7 @@ export interface CreateLinodeRequest {
   private_ip?: boolean;
   authorized_users?: string[];
   interfaces?: Interface[];
+  metadata?: UserData;
 }
 
 export type RescueRequestObject = Pick<

--- a/packages/manager/src/components/Accordion/Accordion.tsx
+++ b/packages/manager/src/components/Accordion/Accordion.tsx
@@ -82,7 +82,11 @@ export const Accordion: React.FC<CombinedProps> = (props) => {
         {...summaryProps}
         data-qa-panel-summary={props.heading}
       >
-        <Typography {...headingProps} variant="h3" data-qa-panel-subheading>
+        <Typography
+          {...headingProps}
+          variant={headingProps?.variant ?? 'h3'}
+          data-qa-panel-subheading
+        >
           {props.heading}
         </Typography>
         {headingNumberCount && headingNumberCount > 0 ? (

--- a/packages/manager/src/factories/images.ts
+++ b/packages/manager/src/factories/images.ts
@@ -16,4 +16,5 @@ export const imageFactory = Factory.Sync.makeFactory<Image>({
   vendor: null,
   expiry: null,
   status: 'available',
+  capabilities: [],
 });

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -531,10 +531,10 @@ export class LinodeCreate extends React.PureComponent<
       });
     }
 
-    let showUserData = true;
+    let showUserData = false;
     if (
       this.props.selectedImageID &&
-      this.props.imagesData[this.props.selectedImageID]?.capabilities.includes(
+      this.props.imagesData[this.props.selectedImageID]?.capabilities?.includes(
         'cloud-init'
       )
     ) {

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -1,12 +1,15 @@
-import classNames from 'classnames';
 import { Interface, restoreBackup } from '@linode/api-v4/lib/linodes';
 import { Tag } from '@linode/api-v4/lib/tags/types';
+import classNames from 'classnames';
 import * as React from 'react';
 import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
 import { compose as recompose } from 'recompose';
 import AccessPanel from 'src/components/AccessPanel';
+import Button from 'src/components/Button';
+import { CheckoutSummary } from 'src/components/CheckoutSummary/CheckoutSummary';
 import CircleProgress from 'src/components/CircleProgress';
+import Box from 'src/components/core/Box';
 import Paper from 'src/components/core/Paper';
 import TabPanels from 'src/components/core/ReachTabPanels';
 import Tabs from 'src/components/core/ReachTabs';
@@ -18,6 +21,7 @@ import {
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import CreateLinodeDisabled from 'src/components/CreateLinodeDisabled';
+import DocsLink from 'src/components/DocsLink';
 import DocsSidebar from 'src/components/DocsSidebar';
 import setDocs, { SetDocsProps } from 'src/components/DocsSidebar/setDocs';
 import ErrorState from 'src/components/ErrorState';
@@ -29,6 +33,9 @@ import SelectRegionPanel from 'src/components/SelectRegionPanel';
 import TabLinkList, { Tab } from 'src/components/TabLinkList';
 import { WithImages } from 'src/containers/withImages.container';
 import { AppsDocs } from 'src/documentation';
+import EUAgreementCheckbox from 'src/features/Account/Agreements/EUAgreementCheckbox';
+import SMTPRestrictionText from 'src/features/linodes/SMTPRestrictionText';
+import UserDataAccordion from 'src/features/linodes/UserDataAccordion';
 import {
   getCommunityStackscripts,
   getMineAndAccountStackScripts,
@@ -42,8 +49,11 @@ import { getInitialType } from 'src/store/linodeCreate/linodeCreate.reducer';
 import { doesRegionSupportFeature } from 'src/utilities/doesRegionSupportFeature';
 import { getErrorMap } from 'src/utilities/errorUtils';
 import { filterCurrentTypes } from 'src/utilities/filterCurrentLinodeTypes';
+import { sendEvent } from 'src/utilities/ga';
 import { getParamsFromUrl } from 'src/utilities/queryParams';
+import { v4 } from 'uuid';
 import AddonsPanel from './AddonsPanel';
+import ApiAwarenessModal from './ApiAwarenessModal';
 import SelectPlanPanel from './SelectPlanPanel';
 import FromAppsContent from './TabbedContent/FromAppsContent';
 import FromBackupsContent from './TabbedContent/FromBackupsContent';
@@ -51,16 +61,14 @@ import FromImageContent from './TabbedContent/FromImageContent';
 import FromLinodeContent from './TabbedContent/FromLinodeContent';
 import FromStackScriptContent from './TabbedContent/FromStackScriptContent';
 import { renderBackupsDisplaySection } from './TabbedContent/utils';
-import { v4 } from 'uuid';
-import ApiAwarenessModal from './ApiAwarenessModal';
 import {
   AllFormStateAndHandlers,
   AppsData,
   HandleSubmit,
   Info,
+  LinodeCreateValidation,
   ReduxStateProps,
   ReduxStatePropsAndSSHKeys,
-  LinodeCreateValidation,
   StackScriptFormStateHandlers,
   WithDisplayData,
   WithLinodesProps,
@@ -68,13 +76,6 @@ import {
   WithTypesProps,
   WithTypesRegionsAndImages,
 } from './types';
-import EUAgreementCheckbox from 'src/features/Account/Agreements/EUAgreementCheckbox';
-import SMTPRestrictionText from 'src/features/linodes/SMTPRestrictionText';
-import { CheckoutSummary } from 'src/components/CheckoutSummary/CheckoutSummary';
-import Button from 'src/components/Button';
-import Box from 'src/components/core/Box';
-import DocsLink from 'src/components/DocsLink';
-import { sendEvent } from 'src/utilities/ga';
 
 type ClassNames =
   | 'form'
@@ -161,6 +162,8 @@ interface Props {
   handleAgreementChange: () => void;
   handleShowApiAwarenessModal: () => void;
   signedAgreement: boolean;
+  userData: string | undefined;
+  updateUserData: (userData: string) => void;
 }
 
 const errorMap = [
@@ -451,6 +454,7 @@ export class LinodeCreate extends React.PureComponent<
       handleAgreementChange,
       handleShowApiAwarenessModal,
       signedAgreement,
+      updateUserData,
       ...rest
     } = this.props;
 
@@ -519,6 +523,8 @@ export class LinodeCreate extends React.PureComponent<
         title: 'Private IP',
       });
     }
+
+    let showUserData = true;
 
     return (
       <form className={classes.form}>
@@ -720,6 +726,12 @@ export class LinodeCreate extends React.PureComponent<
               requestKeys={requestKeys}
             />
           )}
+          {showUserData ? (
+            <UserDataAccordion
+              userData={this.props.userData}
+              onChange={updateUserData}
+            />
+          ) : null}
           <AddonsPanel
             data-qa-addons-panel
             backups={this.props.backupsEnabled}

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -525,6 +525,14 @@ export class LinodeCreate extends React.PureComponent<
     }
 
     let showUserData = true;
+    if (
+      this.props.selectedImageID &&
+      this.props.imagesData[this.props.selectedImageID]?.capabilities.includes(
+        'cloud-init'
+      )
+    ) {
+      showUserData = true;
+    }
 
     return (
       <form className={classes.form}>

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -377,6 +377,13 @@ export class LinodeCreate extends React.PureComponent<
       }
       payload['interfaces'] = interfaces;
     }
+
+    if (this.props.userData) {
+      payload['metadata'] = {
+        user_data: window.btoa(this.props.userData),
+      };
+    }
+
     return payload;
   };
 

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -111,6 +111,7 @@ interface State {
   disabledClasses?: LinodeTypeClass[];
   attachedVLANLabel: string | null;
   vlanIPAMAddress: string | null;
+  userData: string | undefined;
 }
 
 type CombinedProps = WithSnackbarProps &
@@ -153,6 +154,7 @@ const defaultState: State = {
   attachedVLANLabel: '',
   vlanIPAMAddress: null,
   showApiAwarenessModal: false,
+  userData: undefined,
 };
 
 const getDisabledClasses = (regionID: string, regions: Region[] = []) => {
@@ -395,6 +397,8 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
   setTags = (tags: Tag[]) => this.setState({ tags });
 
   setUDFs = (udfs: any) => this.setState({ udfs });
+
+  setUserData = (userData: string) => this.setState({ userData });
 
   handleVLANChange = (updatedInterface: Interface) => {
     this.setState({
@@ -815,6 +819,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
             handleShowApiAwarenessModal={this.handleShowApiAwarenessModal}
             userCannotCreateLinode={userCannotCreateLinode}
             accountBackupsEnabled={getAccountBackupsEnabled()}
+            updateUserData={this.setUserData}
             {...restOfProps}
             {...restOfState}
           />

--- a/packages/manager/src/features/linodes/UserDataAccordion.tsx
+++ b/packages/manager/src/features/linodes/UserDataAccordion.tsx
@@ -28,7 +28,7 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-const UserDataAccordion: React.FC<Props> = (props) => {
+const UserDataAccordion = (props: Props) => {
   const { disabled, userData, onChange } = props;
   const classes = useStyles();
 

--- a/packages/manager/src/features/linodes/UserDataAccordion.tsx
+++ b/packages/manager/src/features/linodes/UserDataAccordion.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import Accordion from 'src/components/Accordion';
+import { makeStyles } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+import HelpIcon from 'src/components/HelpIcon';
+import TextField from 'src/components/TextField';
+
+interface Props {
+  userData: string | undefined;
+  onChange: (userData: string) => void;
+  disabled?: boolean;
+}
+
+const useStyles = makeStyles(() => ({
+  helpIcon: {
+    padding: '0px 0px 4px 8px',
+    '& svg': {
+      fill: 'currentColor',
+      stroke: 'none',
+    },
+  },
+}));
+
+const UserDataAccordion: React.FC<Props> = (props) => {
+  const { disabled, userData, onChange } = props;
+  const classes = useStyles();
+
+  const accordionHeading = (
+    <>
+      Add User Data{' '}
+      <HelpIcon
+        text={'Definition of user data and what it is used for'}
+        className={classes.helpIcon}
+        interactive
+      />
+    </>
+  );
+
+  return (
+    <Accordion heading={accordionHeading} style={{ marginTop: 24 }}>
+      <Typography>
+        Paste user data into the field below. Formats accepted are YAML and
+        bash. Helper text with links to docs and guides.
+      </Typography>
+      <TextField
+        label="User Data"
+        multiline
+        rows={1}
+        expand
+        onChange={(e) => onChange(e.target.value)}
+        value={userData}
+        disabled={Boolean(disabled)}
+        data-qa-user-data-input
+      />
+    </Accordion>
+  );
+};
+
+export default UserDataAccordion;

--- a/packages/manager/src/features/linodes/UserDataAccordion.tsx
+++ b/packages/manager/src/features/linodes/UserDataAccordion.tsx
@@ -21,8 +21,7 @@ const useStyles = makeStyles(() => ({
     },
   },
   accordionSummary: {
-    paddingLeft: 24,
-    paddingRight: 24,
+    padding: '5px 24px 0px 24px',
   },
   accordionDetail: {
     padding: '0px 24px 24px 24px',

--- a/packages/manager/src/features/linodes/UserDataAccordion.tsx
+++ b/packages/manager/src/features/linodes/UserDataAccordion.tsx
@@ -3,6 +3,7 @@ import Accordion from 'src/components/Accordion';
 import { makeStyles } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import HelpIcon from 'src/components/HelpIcon';
+import Link from 'src/components/Link';
 import TextField from 'src/components/TextField';
 
 interface Props {
@@ -19,6 +20,13 @@ const useStyles = makeStyles(() => ({
       stroke: 'none',
     },
   },
+  accordionSummary: {
+    paddingLeft: 24,
+    paddingRight: 24,
+  },
+  accordionDetail: {
+    padding: '0px 24px 24px 24px',
+  },
 }));
 
 const UserDataAccordion: React.FC<Props> = (props) => {
@@ -29,7 +37,13 @@ const UserDataAccordion: React.FC<Props> = (props) => {
     <>
       Add User Data{' '}
       <HelpIcon
-        text={'Definition of user data and what it is used for'}
+        text={
+          <>
+            User data is part of a virtual machine&rsquo;s cloud-init metadata
+            containing information related to a user&rsquo;s local account.{' '}
+            <Link to="/">Learn more.</Link>
+          </>
+        }
         className={classes.helpIcon}
         interactive
       />
@@ -37,10 +51,31 @@ const UserDataAccordion: React.FC<Props> = (props) => {
   );
 
   return (
-    <Accordion heading={accordionHeading} style={{ marginTop: 24 }}>
+    <Accordion
+      heading={accordionHeading}
+      style={{ marginTop: 24 }}
+      headingProps={{
+        variant: 'h2',
+      }}
+      summaryProps={{
+        classes: {
+          root: classes.accordionSummary,
+        },
+      }}
+      detailProps={{
+        classes: {
+          root: classes.accordionDetail,
+        },
+      }}
+    >
       <Typography>
-        Paste user data into the field below. Formats accepted are YAML and
-        bash. Helper text with links to docs and guides.
+        <Link to="https://cloudinit.readthedocs.io/en/latest/reference/examples.html">
+          User Data
+        </Link>{' '}
+        is part of a virtual machine&rsquo;s cloud-init metadata that contains
+        anything related to a user&rsquo;s local account, including username and
+        user group(s). <br /> Accepted formats are YAML and bash.{' '}
+        <Link to="https://www.linode.com/docs">Learn more.</Link>
       </Typography>
       <TextField
         label="User Data"

--- a/packages/validation/src/linodes.schema.ts
+++ b/packages/validation/src/linodes.schema.ts
@@ -78,7 +78,7 @@ export const UpdateLinodePasswordSchema = object({
   // .concat(rootPasswordValidation)
 });
 
-const metadata = object({
+const MetadataSchema = object({
   user_data: string().notRequired(),
 });
 
@@ -114,7 +114,7 @@ export const CreateLinodeSchema = object({
     otherwise: string().notRequired(),
   }),
   interfaces: linodeInterfaceSchema,
-  metadata,
+  metadata: MetadataSchema,
 });
 
 const alerts = object({

--- a/packages/validation/src/linodes.schema.ts
+++ b/packages/validation/src/linodes.schema.ts
@@ -78,6 +78,10 @@ export const UpdateLinodePasswordSchema = object({
   // .concat(rootPasswordValidation)
 });
 
+const metadata = object({
+  user_data: string().notRequired(),
+});
+
 export const CreateLinodeSchema = object({
   type: string().ensure().required('Plan is required.'),
   region: string().ensure().required('Region is required.'),
@@ -110,6 +114,7 @@ export const CreateLinodeSchema = object({
     otherwise: string().notRequired(),
   }),
   interfaces: linodeInterfaceSchema,
+  metadata,
 });
 
 const alerts = object({


### PR DESCRIPTION
## Description 📝
Add User Data accordion to the Linode Create flow so that a user can configure their Linode using cloud-init.

Todo:
- [x] Finalize UX copy

## Preview 📷
![image](https://user-images.githubusercontent.com/115299789/221030423-d197afe7-331c-4b33-98a9-722692c3eedf.png)

## How to test 🧪
Testing Create via Distribution
1. Point to the dev environment (you might also need additional account setup, reach out for more info)
2. Navigate to the Linode create page http://localhost:3000/linodes/create
3. Select a distribution that supports cloud-init
    - Arch Linux, Cent OS 7, and Ubuntu 16.04 LTS have been marked as cloud-init compatible for testing purposes
4. If the distribution supports cloud-init, you should see an `Add User Data` accordion
    - If the distribution doesn't support cloud-init, you should _not_ see the accordion
5. Enter some text (can be anything) into the User Data input field and fill out the rest of the required Linode Create fields
6. Click on Create Linode and observe the POST payload to `/linode/instances`. You should see a metadata field with the user_data object
    - If you did not enter anything into the User Data input, you should _not_ see any metadata field in the payload.
    - You can just block the network request to `/linode/instances` and check the payload w/o actually creating another Linode
7. There are no changes to the API response so you will not see a metadata field returned

![image](https://user-images.githubusercontent.com/115299789/221034511-b49c2936-ea22-44c9-ae40-127697d44f8e.png)

Testing Create via Image
- Navigate to the Linode Create Image tab http://localhost:3000/linodes/create?type=Images
- Select an image that supports cloud-init
  - You can create and mark an image as cloud-init compatible in https://github.com/linode/manager/pull/8807
- Follow steps 4-7 above