### PR TITLE
Fetch all tags when cleaning Cypress test tags

### DIFF
--- a/packages/manager/cypress/support/api/tags.ts
+++ b/packages/manager/cypress/support/api/tags.ts
@@ -1,15 +1,22 @@
+import { Tag } from '@linode/api-v4/types';
 import { deleteTag, getTags } from '@linode/api-v4/lib/tags';
+import { depaginate } from 'support/util/paginate';
 import { isTestLabel } from './common';
 
 /**
  * Delete all tags whose labels are prefixed "cy-test-".
+ *
+ * @returns Promise that resolves when tags have been deleted or rejects on HTTP error.
  */
-export const deleteAllTestTags = () => {
-  getTags().then((resp) => {
-    resp.data.forEach((tag) => {
-      if (isTestLabel(tag.label)) {
-        deleteTag(tag.label);
-      }
-    });
-  });
+export const deleteAllTestTags = async (): Promise<void> => {
+  const tags = await depaginate<Tag>((page: number) =>
+    getTags({ page_size: 500, page })
+  );
+  const testTags = tags.filter((tag: Tag) => isTestLabel(tag.label));
+  for (const testTag of testTags) {
+    // Accounts can have thousands of tags, so we want to send these requests
+    // sequentially to avoid overloading the API.
+    // eslint-disable-next-line no-await-in-loop
+    await deleteTag(testTag.label);
+  }
 };

--- a/packages/manager/cypress/support/ui/common.ts
+++ b/packages/manager/cypress/support/ui/common.ts
@@ -77,6 +77,7 @@ export const deleteAllTestData = () => {
   const asyncDeletionPromise = Promise.all([
     deleteAllTestBuckets(),
     deleteAllTestAccessKeys(),
+    deleteAllTestTags(),
   ]);
 
   // Remaining deletion functions then run sequentially.
@@ -89,6 +90,5 @@ export const deleteAllTestData = () => {
     deleteAllTestFirewalls();
     deleteAllTestStackscripts();
     deleteAllTestDomains();
-    deleteAllTestTags();
   });
 };


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
This fixes a small issue with the Cypress clean-up function for tags -- it was only fetching the first page of results, causing a lot of tags not to get cleaned up, ultimately contributing to some recent failures.

## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**
1. Create some tags that are prefixed with `cy-test-`. I think the easiest way to do this is to create a new Linode, specifying the new tags during the process.
2. Run `yarn cy:debug` and run any test
3. In the test `before` hook, you should observe HTTP DELETE requests for each of the tags you created (and no tags that aren't prefixed with `cy-test-`). You can observe this in the left sidebar, or you can open the dev tools and observe the Network tab.