### PR TITLE
fix cm route via SOCKS5 proxy on devenv

### DIFF
--- a/packages/manager/config/webpackDevServer.config.js
+++ b/packages/manager/config/webpackDevServer.config.js
@@ -11,6 +11,7 @@ module.exports = {
   https: protocol === 'https',
   host: HOST,
   port: PORT,
+  allowedHosts: ['.lindev.local', '.linode.com'],
   historyApiFallback: {
     disableDotRule: true,
   },


### PR DESCRIPTION
## Description 📝

Webpeck CORS blocks access in devenv which is different from localhost.
this working on remote devenv, will block socks5 proxy.