### PR TITLE
Add support for local development access from local domain

### DIFF
--- a/packages/manager/config/webpackDevServer.config.js
+++ b/packages/manager/config/webpackDevServer.config.js
@@ -11,6 +11,7 @@ module.exports = {
   https: protocol === 'https',
   host: HOST,
   port: PORT,
+  allowedHosts: ['.lindev.local', '.linode.com'],
   historyApiFallback: {
     disableDotRule: true,
   },


### PR DESCRIPTION
## Description 📝

- Allow webpack server to be accessed by linode domains

## How to test 🧪

- Checkout this PR in our internal development envrionemnt
- Verify that you can access cloud manager from `cloud.lindev.local` without seeing a `invalid host header` error