### PR TITLE
fix: [M3-5840] - Fix validateDOMNesting warning in console

### DIFF
--- a/packages/manager/src/features/NotificationCenter/NotificationData/RenderEvent.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/RenderEvent.tsx
@@ -63,13 +63,13 @@ export const RenderEvent: React.FC<Props> = (props) => {
   }
 
   const eventMessage = (
-    <Typography
+    <div
       className={classNames({
         [classes.unseenEvent]: !event.seen,
       })}
     >
       <HighlightedMarkdown textOrMarkdown={message} />
-    </Typography>
+    </div>
   );
 
   return (


### PR DESCRIPTION
## Description 📝
When opening the Notifications dropdown currently, a `validateDOMNesting` warning gets logged to the console because there's a case of `<p>` being a descendant of `<p>`.

It seems this was being caused in `RenderEvent.tsx` by `<Typography>` wrapping `<HighlightedMarkdown>`, which returns `<Typography>`. 

## How to test 🧪
Confirm the warning displayed below is no longer logged to the console when opening the Notifications dropdown on this branch.

![Screenshot 2023-02-23 at 6 14 45 PM](https://user-images.githubusercontent.com/114682940/221052721-c9c2c168-f38b-4675-a774-618ca4f7c62b.jpg)
