### PR TITLE
refactor: M3-6195 - Add tss-react and refactor Button to styled API

### DIFF
--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -90,6 +90,7 @@
     "search-string": "^3.1.0",
     "stream-browserify": "^3.0.0",
     "throttle-debounce": "^2.0.0",
+    "tss-react": "^4.6.1",
     "typescript-fsa": "^3.0.0",
     "typescript-fsa-reducers": "^1.2.0",
     "url-parse": "^1.5.9",

--- a/packages/manager/src/assets/icons/reload.svg
+++ b/packages/manager/src/assets/icons/reload.svg
@@ -1,14 +1,15 @@
-<svg 
-  version="1.1" 
-  xmlns="http://www.w3.org/2000/svg" 
-  xmlns:xlink="http://www.w3.org/1999/xlink" 
-  x="0px" 
+<svg
+  version="1.1"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  x="0px"
   y="0px"
   width="12px"
   height="12px"
   fill="currentColor"
   stroke-width="1"
-  viewBox="0 0 467.871 467.871" xml:space="preserve">
+  viewBox="0 0 467.871 467.871" xml:space="preserve"
+  data-testId="ReloadIcon">
   <g>
     <path d="M392.098,344.131c-6.597-5.014-16.007-3.729-21.019,2.868c-0.962,1.266-1.948,2.516-2.957,3.751
       c-15.046,18.411-35.315,33.36-60.321,44.474c-0.124,0.055-0.247,0.111-0.369,0.17c-39.456,18.831-85.618,21.405-129.896,7.274

--- a/packages/manager/src/components/Button/Button.test.tsx
+++ b/packages/manager/src/components/Button/Button.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import Button from './Button';
+import { render } from '@testing-library/react';
+
+describe('Button', () => {
+  it('should render', () => {
+    const { getByText } = render(<Button>Test</Button>);
+    getByText('Test');
+  });
+
+  it('should render the loading state', () => {
+    const { getByTestId } = render(<Button loading>Test</Button>);
+
+    const loadingIcon = getByTestId('loadingIcon');
+    expect(loadingIcon).toBeInTheDocument();
+  });
+
+  it('should render the HelpIcon when tooltipText is true', () => {
+    const { getByTestId } = render(<Button tooltipText="Test">Test</Button>);
+
+    const helpIcon = getByTestId('HelpOutlineIcon');
+    expect(helpIcon).toBeInTheDocument();
+  });
+});

--- a/packages/manager/src/components/Button/Button.tsx
+++ b/packages/manager/src/components/Button/Button.tsx
@@ -1,121 +1,101 @@
-import classNames from 'classnames';
-import { always, cond, propEq } from 'ramda';
 import * as React from 'react';
 import Reload from 'src/assets/icons/reload.svg';
-import _Button, { ButtonProps } from 'src/components/core/Button';
-import { makeStyles, Theme } from 'src/components/core/styles';
+import _Button, { ButtonProps } from '@mui/material/Button';
 import HelpIcon from 'src/components/HelpIcon';
+import { useTheme, styled } from '@mui/material/styles';
+import { SxProps } from '@mui/system';
+import { isPropValid } from '../../utilities/isPropValid';
+import { rotate360 } from '../../styles/keyframes';
 
 export interface Props extends ButtonProps {
   buttonType?: 'primary' | 'secondary' | 'outlined';
   className?: string;
+  sx?: SxProps;
   compactX?: boolean;
   compactY?: boolean;
   loading?: boolean;
   tooltipText?: string;
 }
 
-const useStyles = makeStyles((theme: Theme) => ({
-  '@keyframes rotate': {
-    from: {
-      transform: 'rotate(0deg)',
-    },
-    to: {
-      transform: 'rotate(360deg)',
-    },
-  },
-  loading: {
+const StyledButton = styled(_Button, {
+  shouldForwardProp: (prop) =>
+    isPropValid(['compactX', 'compactY', 'loading', 'buttonType'], prop),
+})<Props>(({ theme, ...props }) => ({
+  ...(props.buttonType === 'secondary' &&
+    props.compactX && {
+      minWidth: 50,
+      paddingRight: 0,
+      paddingLeft: 0,
+    }),
+  ...(props.buttonType === 'secondary' &&
+    props.compactY && {
+      minHeight: 20,
+      paddingTop: 0,
+      paddingBottom: 0,
+    }),
+  ...(props.loading && {
     '& svg': {
-      animation: '$rotate 2s linear infinite',
+      animation: `${rotate360} 2s linear infinite`,
       margin: '0 auto',
-      height: `${theme.spacing(2)} !important`,
-      width: `${theme.spacing(2)} !important`,
+      height: `${theme.spacing(2)}`,
+      width: `${theme.spacing(2)}`,
     },
-  },
-  compactX: {
-    minWidth: 50,
-    paddingRight: 0,
-    paddingLeft: 0,
-  },
-  compactY: {
-    minHeight: 20,
-    paddingTop: 0,
-    paddingBottom: 0,
-  },
-  reg: {
-    display: 'flex',
-    alignItems: 'center',
-  },
-  '@supports (-moz-appearance: none)': {
-    /* Fix text alignment for Firefox */
-    reg: {
-      marginTop: 2,
+    '&:disabled': {
+      backgroundColor:
+        props.buttonType === 'primary' && theme.palette.text.primary,
     },
-  },
-  helpIcon: {
-    marginLeft: `-${theme.spacing()}`,
-  },
+  }),
 }));
 
-type CombinedProps = Props;
+const Span = styled('span')({
+  display: 'flex',
+  alignItems: 'center',
+  '@supports (-moz-appearance: none)': {
+    /* Fix text alignment for Firefox */
+    marginTop: 2,
+  },
+});
 
-const getVariant = cond([
-  [propEq('buttonType', 'primary'), always('contained')],
-  [propEq('buttonType', 'secondary'), always('contained')],
-  [propEq('buttonType', 'outlined'), always('outlined')],
-  [() => true, always(undefined)],
-]);
+const Button = ({
+  buttonType,
+  children,
+  className,
+  compactX,
+  compactY,
+  disabled,
+  loading,
+  sx,
+  tooltipText,
+  ...rest
+}: Props) => {
+  const theme = useTheme();
+  const color = buttonType === 'primary' ? 'primary' : 'secondary';
+  const sxHelpIcon = { marginLeft: `-${theme.spacing()}` };
 
-const getColor = cond([
-  [propEq('buttonType', 'primary'), always('primary')],
-  [propEq('buttonType', 'secondary'), always('secondary')],
-  [() => true, always(undefined)],
-]);
-
-export const Button: React.FC<CombinedProps> = (props) => {
-  const classes = useStyles();
-
-  const {
-    buttonType,
-    className,
-    compactX,
-    compactY,
-    loading,
-    tooltipText,
-    ...rest
-  } = props;
+  const variant =
+    buttonType === 'primary' || buttonType === 'secondary'
+      ? 'contained'
+      : buttonType === 'outlined'
+      ? 'outlined'
+      : 'text';
 
   return (
     <React.Fragment>
-      <_Button
+      <StyledButton
         {...rest}
-        className={classNames(
-          buttonType,
-          {
-            [classes.compactX]: buttonType === 'secondary' ? compactX : false,
-            [classes.compactY]: buttonType === 'secondary' ? compactY : false,
-            [classes.loading]: loading,
-            disabled: props.disabled,
-            loading,
-          },
-          className
-        )}
-        color={getColor(props)}
-        disabled={props.disabled || loading}
-        variant={getVariant(props)}
+        buttonType={buttonType}
+        className={className}
+        color={color}
+        compactX={compactX}
+        compactY={compactY}
+        disabled={disabled || loading}
+        loading={loading}
+        sx={sx}
+        variant={variant}
       >
-        <span
-          className={classNames({
-            [classes.reg]: true,
-          })}
-          data-qa-loading={loading}
-        >
-          {loading ? <Reload /> : props.children}
-        </span>
-      </_Button>
-      {tooltipText && (
-        <HelpIcon className={classes.helpIcon} text={tooltipText} />
-      )}
+        <Span data-testid="loadingIcon">{loading ? <Reload /> : children}</Span>
+      </StyledButton>
+      {tooltipText && <HelpIcon sx={sxHelpIcon} text={tooltipText} />}
     </React.Fragment>
   );
 };

--- a/packages/manager/src/components/HelpIcon/HelpIcon.tsx
+++ b/packages/manager/src/components/HelpIcon/HelpIcon.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import IconButton from 'src/components/core/IconButton';
 import { makeStyles } from 'src/components/core/styles';
 import Tooltip, { TooltipProps } from 'src/components/core/Tooltip';
+import { SxProps } from '@mui/system';
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -20,6 +21,7 @@ const useStyles = makeStyles(() => ({
 
 interface Props
   extends Omit<TooltipProps, 'leaveDelay' | 'title' | 'children'> {
+  sx?: SxProps;
   text: string | JSX.Element;
   className?: string;
   interactive?: boolean;
@@ -56,10 +58,12 @@ const HelpIcon: React.FC<CombinedProps> = (props) => {
     leaveDelay,
     classes,
     onMouseEnter,
+    sx,
   } = props;
 
   return (
     <Tooltip
+      sx={sx}
       title={text}
       data-qa-help-tooltip
       enterTouchDelay={0}

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/CreateFolderDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/CreateFolderDrawer.tsx
@@ -4,7 +4,7 @@ import TextField from 'src/components/TextField';
 import ActionsPanel from 'src/components/ActionsPanel';
 import { useFormik } from 'formik';
 import { useCreateObjectUrlMutation } from 'src/queries/objectStorage';
-import { Button } from 'src/components/Button/Button';
+import Button from 'src/components/Button/Button';
 
 interface Props {
   open: boolean;

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/CreateFolderDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/CreateFolderDrawer.tsx
@@ -4,7 +4,7 @@ import TextField from 'src/components/TextField';
 import ActionsPanel from 'src/components/ActionsPanel';
 import { useFormik } from 'formik';
 import { useCreateObjectUrlMutation } from 'src/queries/objectStorage';
-import Button from 'src/components/Button/Button';
+import Button from 'src/components/Button';
 
 interface Props {
   open: boolean;

--- a/packages/manager/src/features/Profile/APITokens/RevokeTokenDialog.tsx
+++ b/packages/manager/src/features/Profile/APITokens/RevokeTokenDialog.tsx
@@ -3,7 +3,7 @@ import ConfirmationDialog from 'src/components/ConfirmationDialog';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Typography from 'src/components/core/Typography';
 import { Token } from '@linode/api-v4/lib/profile/types';
-import { Button } from 'src/components/Button/Button';
+import Button from 'src/components/Button/Button';
 import { APITokenType } from './APITokenTable';
 import {
   useRevokeAppAccessTokenMutation,

--- a/packages/manager/src/features/Profile/APITokens/RevokeTokenDialog.tsx
+++ b/packages/manager/src/features/Profile/APITokens/RevokeTokenDialog.tsx
@@ -3,7 +3,7 @@ import ConfirmationDialog from 'src/components/ConfirmationDialog';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Typography from 'src/components/core/Typography';
 import { Token } from '@linode/api-v4/lib/profile/types';
-import Button from 'src/components/Button/Button';
+import Button from 'src/components/Button';
 import { APITokenType } from './APITokenTable';
 import {
   useRevokeAppAccessTokenMutation,

--- a/packages/manager/src/styles/index.ts
+++ b/packages/manager/src/styles/index.ts
@@ -1,0 +1,1 @@
+export { rotate360 } from './keyframes';

--- a/packages/manager/src/styles/keyframes.ts
+++ b/packages/manager/src/styles/keyframes.ts
@@ -1,0 +1,10 @@
+import { keyframes } from 'tss-react';
+
+export const rotate360 = keyframes`
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+`;

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -488,6 +488,7 @@ export const base: ThemeOptions = {
           '&:disabled': {
             color: 'white',
           },
+          // TODO: We can remove this after migration since we can define variants
           '&.loading': {
             backgroundColor: primaryColors.text,
           },
@@ -509,6 +510,7 @@ export const base: ThemeOptions = {
             borderColor: '#c9cacb',
             color: '#c9cacb',
           },
+          // TODO: We can remove this after migration since we can define variants
           '&.loading': {
             color: primaryColors.text,
           },

--- a/packages/manager/src/utilities/isPropValid/index.ts
+++ b/packages/manager/src/utilities/isPropValid/index.ts
@@ -1,0 +1,1 @@
+export { isPropValid } from './isPropValid';

--- a/packages/manager/src/utilities/isPropValid/isPropValid.ts
+++ b/packages/manager/src/utilities/isPropValid/isPropValid.ts
@@ -1,0 +1,18 @@
+/**
+ * Helper to filter out props that are not valid for a component to avoid
+ * passing them down to the DOM. This is to avoid the verbose API presented by
+ * MUI and Emotion and to provide type safety.
+ * @param props Array of props to filter out
+ * @param prop The prop to check
+ * @returns Boolean indicating whether the prop is valid
+ * @see https://mui.com/material-ui/customization/how-to-customize/#dynamic-overrides
+ * @Usage
+ *    const MyComponent = styled(Button, {
+ *      shouldForwardProp: (prop) =>
+ *      isPropValid(['compactX', 'compactY'], prop),
+ *    })<Props>(({ theme, ...props }) => ({ ... }));
+ */
+export const isPropValid = <CustomProps extends Record<string, unknown>>(
+  props: Array<keyof CustomProps>,
+  prop: PropertyKey
+): boolean => !props.includes(prop as string);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1263,6 +1263,17 @@
     source-map "^0.5.7"
     stylis "4.0.13"
 
+"@emotion/cache@*":
+  version "11.10.5"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.10.5.tgz#c142da9351f94e47527ed458f7bbbbe40bb13c12"
+  integrity sha512-dGYHWyzTdmK+f2+EnIGBpkz1lKc4Zbj2KHd4cX3Wi8/OWr5pKslNjc3yABKH4adRGCvSX4VDC0i04mrrq0aiRA==
+  dependencies:
+    "@emotion/memoize" "^0.8.0"
+    "@emotion/sheet" "^1.2.1"
+    "@emotion/utils" "^1.2.0"
+    "@emotion/weak-memoize" "^0.3.0"
+    stylis "4.1.3"
+
 "@emotion/cache@^10.0.27", "@emotion/cache@^10.0.9":
   version "10.0.29"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.29.tgz#87e7e64f412c060102d589fe7c6dc042e6f9d1e0"
@@ -1346,6 +1357,17 @@
     "@emotion/weak-memoize" "^0.3.0"
     hoist-non-react-statics "^3.3.1"
 
+"@emotion/serialize@*":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.1.1.tgz#0595701b1902feded8a96d293b26be3f5c1a5cf0"
+  integrity sha512-Zl/0LFggN7+L1liljxXdsVSVlg6E/Z/olVWpfxUTxOAmi8NU7YoeWeLfi1RmnB2TATHoaWwIBRoL+FvAJiTUQA==
+  dependencies:
+    "@emotion/hash" "^0.9.0"
+    "@emotion/memoize" "^0.8.0"
+    "@emotion/unitless" "^0.8.0"
+    "@emotion/utils" "^1.2.0"
+    csstype "^3.0.2"
+
 "@emotion/serialize@^0.11.15", "@emotion/serialize@^0.11.16":
   version "0.11.16"
   resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-0.11.16.tgz#dee05f9e96ad2fb25a5206b6d759b2d1ed3379ad"
@@ -1377,6 +1399,11 @@
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.2.0.tgz#771b1987855839e214fc1741bde43089397f7be5"
   integrity sha512-OiTkRgpxescko+M51tZsMq7Puu/KP55wMT8BgpcXVG2hqXc0Vo0mfymJ/Uj24Hp0i083ji/o0aLddh08UEjq8w==
+
+"@emotion/sheet@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.2.1.tgz#0767e0305230e894897cadb6c8df2c51e61a6c2c"
+  integrity sha512-zxRBwl93sHMsOj4zs+OslQKg/uhF38MB+OMKoCrVuS0nyTkqnau+BM3WGEoOptg9Oz45T/aIGs1qbVAsEFo3nA==
 
 "@emotion/styled@^11.10.4":
   version "11.10.4"
@@ -1410,15 +1437,15 @@
   resolved "https://registry.yarnpkg.com/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz#ffadaec35dbb7885bd54de3fa267ab2f860294df"
   integrity sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==
 
+"@emotion/utils@*", "@emotion/utils@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.2.0.tgz#9716eaccbc6b5ded2ea5a90d65562609aab0f561"
+  integrity sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw==
+
 "@emotion/utils@0.11.3":
   version "0.11.3"
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.11.3.tgz#a759863867befa7e583400d322652a3f44820924"
   integrity sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==
-
-"@emotion/utils@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.2.0.tgz#9716eaccbc6b5ded2ea5a90d65562609aab0f561"
-  integrity sha512-sn3WH53Kzpw8oQ5mgMmIzzyAaH2ZqFEbozVVBSYp538E06OSE6ytOp7pRAjNQR+Q/orwqdQYJSe2m3hCOeznkw==
 
 "@emotion/weak-memoize@0.2.5":
   version "0.2.5"
@@ -5294,9 +5321,9 @@ axe-core@^3.5.1, axe-core@^3.5.5:
   integrity sha512-LEUDjgmdJoA3LqklSTwKYqkjcZ4HKc4ddIYGSAiSkr46NTjzg2L9RNB+lekO9P7Dlpa87+hBtzc2Fzn/+GUWMQ==
 
 axe-core@^4.4.3:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.6.2.tgz#6e566ab2a3d29e415f5115bc0fd2597a5eb3e5e3"
-  integrity sha512-b1WlTV8+XKLj9gZy2DZXgQiyDp9xkkoe2a6U6UbYccScq2wgH/YwCeI2/Jq2mgo0HzQxqJOjWZBLeA/mqsk5Mg==
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.6.3.tgz#fc0db6fdb65cc7a80ccf85286d91d64ababa3ece"
+  integrity sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg==
 
 axios-mock-adapter@^1.15.0, axios-mock-adapter@^1.18.1:
   version "1.21.2"
@@ -12491,9 +12518,9 @@ lru-cache@^6.0.0:
     yallist "^4.0.0"
 
 lru-cache@^7.5.1:
-  version "7.14.1"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.14.1.tgz#8da8d2f5f59827edb388e63e459ac23d6d408fea"
-  integrity sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==
+  version "7.17.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.17.0.tgz#00c7ba5919e5ea7c69ff94ddabbf32cb09ab805c"
+  integrity sha512-zSxlVVwOabhVyTi6E8gYv2cr6bXK+8ifYz5/uyJb9feXX6NACVDwY4p5Ut3WC3Ivo/QhpARHU3iujx2xGAYHbQ==
 
 lru-queue@^0.1.0:
   version "0.1.0"
@@ -13296,9 +13323,9 @@ minimatch@3.1.2, minimatch@^3.0.2, minimatch@^3.0.4, minimatch@^3.0.5, minimatch
     brace-expansion "^1.1.7"
 
 minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@^1.2.6:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.7.tgz#daa1c4d91f507390437c6a8bc01078e7000c4d18"
-  integrity sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
 minipass-collect@^1.0.2:
   version "1.0.2"
@@ -17004,6 +17031,11 @@ stylis@4.0.13:
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.13.tgz#f5db332e376d13cc84ecfe5dace9a2a51d954c91"
   integrity sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag==
 
+stylis@4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.1.3.tgz#fd2fbe79f5fed17c55269e16ed8da14c84d069f7"
+  integrity sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA==
+
 sucrase@^3.20.3:
   version "3.29.0"
   resolved "https://registry.yarnpkg.com/sucrase/-/sucrase-3.29.0.tgz#3207c5bc1b980fdae1e539df3f8a8a518236da7d"
@@ -17522,6 +17554,15 @@ tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
   integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
+
+tss-react@^4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/tss-react/-/tss-react-4.6.1.tgz#a584d720d417350bcca327752e0a4ea77868726c"
+  integrity sha512-4MktjVhHqEav6JxipiTqFU7YcXbAt0DHD4CIGFpqQdYKkUHK6URLf/2hYjwDcHkiC22K5f3vTo8q2O1WQs1H3Q==
+  dependencies:
+    "@emotion/cache" "*"
+    "@emotion/serialize" "*"
+    "@emotion/utils" "*"
 
 tsup@6.2.1:
   version "6.2.1"


### PR DESCRIPTION
## Description 📝
This refactors the `Button` component to the new [sx](https://mui.com/material-ui/react-box/#the-sx-prop) and [styled](https://mui.com/system/styled/#difference-with-the-sx-prop) API. I also added [tss-react](https://github.com/garronej/tss-react) so that we can begin migrating the older makeStyles API which will give us better type safety and autocomplete than MUI v4, while providing an almost seamless transition in moving away from the deprecated JSS API.

## Major Changes 🔄 
- Added `tss-react`
- Added `Button.test.tsx` for more coverage
- Refactored `Button` to use `styled` API
- Added `sx` prop to `HelpIcon` for one-off styling
- Added util `isPropValid` to filter out props that are not valid DOM attributes
- Created `packages/manager/src/styles` folder for all future shared `keyframes`

## Preview 📷
| Before & After |
| ----------- |
| <img width="1723" alt="Screen Shot 2023-02-23 at 11 00 12 PM" src="https://user-images.githubusercontent.com/125309814/221088857-fdb30f16-d2d4-4606-9f67-1d2700d18af7.png"> | 

## How to test 🧪
1. Start local environments and storybook to ensure `Button` stayed the same.
2. Run unit test in root `yarn test packages/manager/src/components/Button` and observe unit tests pass.
3. Run E2E tests in root `yarn cy:debug`
