### PR TITLE
M3-6081 Dynamic Lish URLs

### DIFF
--- a/packages/api-v4/src/networking/types.ts
+++ b/packages/api-v4/src/networking/types.ts
@@ -1,18 +1,3 @@
-export type ZoneName =
-  | 'newark'
-  | 'dallas'
-  | 'fremont'
-  | 'atlanta'
-  | 'london'
-  | 'tokyo'
-  | 'singapore'
-  | 'frankfurt'
-  | 'shinagawa1'
-  | 'toronto1'
-  | 'mumbai1'
-  | 'sydney1'
-  | 'washington3';
-
 export interface IPAddress {
   address: string;
   gateway: string | null;

--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -1,4 +1,3 @@
-import { ZoneName } from '@linode/api-v4/lib/networking';
 import { ObjectStorageClusterID } from '@linode/api-v4/lib/object-storage';
 
 const PRODUCTION = 'production';
@@ -105,36 +104,6 @@ export const INTERVAL = 1000;
  * Time after which data from the API is considered stale (half an hour)
  */
 export const REFRESH_INTERVAL = 60 * 30 * 1000;
-
-/**
- * Used by e.g. LISH to determine the websocket connection address.
- * Whenever updating this, also update the corresponding name in resolvers.ts
- */
-export const ZONES: Record<string, ZoneName> = {
-  'us-east': 'newark',
-  'us-east-1a': 'newark',
-  'us-south': 'dallas',
-  'us-south-1a': 'dallas',
-  'us-west': 'fremont',
-  'us-west-1a': 'fremont',
-  'us-central': 'dallas',
-  'us-southeast': 'atlanta',
-  'us-southeast-1a': 'atlanta',
-  'eu-central': 'frankfurt',
-  'eu-central-1a': 'frankfurt',
-  'eu-west': 'london',
-  'eu-west-1a': 'london',
-  'ap-northeast': 'shinagawa1',
-  'ap-northeast-1a': 'tokyo',
-  'ap-northeast-1b': 'shinagawa1',
-  'ap-south': 'singapore',
-  'ap-south-1a': 'singapore',
-  'ca-central': 'toronto1',
-  'ca-east': 'toronto1', // @todo Fallback for old Toronto ID; remove once DB has been updated.
-  'ap-west': 'mumbai1',
-  'ap-southeast': 'sydney1',
-  'us-iad': 'washington3',
-};
 
 export const dcDisplayNames = {
   // us-east-1 is for backwards-compatibility

--- a/packages/manager/src/features/Lish/lishUtils.ts
+++ b/packages/manager/src/features/Lish/lishUtils.ts
@@ -1,4 +1,4 @@
-import { LISH_ROOT, ZONES } from 'src/constants';
+import { LISH_ROOT } from 'src/constants';
 
 export const lishLaunch = (linodeId: number) => {
   window.open(
@@ -13,7 +13,7 @@ export const getLishSchemeAndHostname = (region: string): string => {
     /* Note: This is only the case for pre-production environments! */
     return `wss://${LISH_ROOT}`;
   }
-  return `wss://${ZONES[region]}.${LISH_ROOT}`;
+  return `wss://${region}.${LISH_ROOT}`;
 };
 
 export const resizeViewPort = (width: number, height: number) => {

--- a/packages/manager/src/features/linodes/LinodesDetail/utilities.ts
+++ b/packages/manager/src/features/linodes/LinodesDetail/utilities.ts
@@ -1,5 +1,3 @@
-import { ZONES } from 'src/constants';
-
 export const sshLink = (ipv4: string) => {
   return `ssh root@${ipv4}`;
 };
@@ -9,6 +7,5 @@ export const lishLink = (
   region: string,
   linodeLabel: string
 ) => {
-  const zoneName = ZONES[region];
-  return `ssh -t ${username}@lish-${zoneName}.linode.com ${linodeLabel}`;
+  return `ssh -t ${username}@lish-${region}.linode.com ${linodeLabel}`;
 };


### PR DESCRIPTION
## Description 📝

**What does this PR do?**

Lish URLs have been updated to accept the scheme: `<region.id>.webconsole.linode.com`. Previously, it used a custom, hardcoded prefix (that isn't returned from the /regions endpoint). This way, we don't have to update this hardcoded map every time we open a new datacenter.

This is Part 1 of the changes described in the ticket. Part 2 will be to update region display names to make use of the new "label" field on the /regions endpoint.

## Preview 📷

![Screen Shot 2023-02-24 at 1 54 59 PM](https://user-images.githubusercontent.com/114753608/221267322-8c88840c-e28c-4757-8d9c-c06b3da61f18.jpg)


## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**
Create new Linodes in different DCs, click "Launch LISH console" and make sure it works. Use the "LISH Console via SSH" command in your own terminal and verify it works.

