### PR TITLE
feat: [M3-6160] - Add resource links to Kubernetes empty state landing page

### DIFF
--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseEmptyState.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseEmptyState.tsx
@@ -1,20 +1,34 @@
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
+import DocsIcon from 'src/assets/icons/docs.svg';
 import DatabaseIcon from 'src/assets/icons/entityIcons/database.svg';
+import ExternalLinkIcon from 'src/assets/icons/external-link.svg';
+import PointerIcon from 'src/assets/icons/pointer.svg';
+import YoutubeIcon from 'src/assets/icons/youtube.svg';
+import List from 'src/components/core/List';
+import ListItem from 'src/components/core/ListItem';
 import { makeStyles } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Link from 'src/components/Link';
 import Placeholder from 'src/components/Placeholder';
 import ProductInformationBanner from 'src/components/ProductInformationBanner';
-import { sendEvent } from 'src/utilities/ga';
 import LinksSection from 'src/features/linodes/LinodesLanding/LinksSection';
 import LinkSubSection from 'src/features/linodes/LinodesLanding/LinksSubSection';
-import DocsIcon from 'src/assets/icons/docs.svg';
-import ExternalLinkIcon from 'src/assets/icons/external-link.svg';
-import YoutubeIcon from 'src/assets/icons/youtube.svg';
-import PointerIcon from 'src/assets/icons/pointer.svg';
-import List from 'src/components/core/List';
-import ListItem from 'src/components/core/ListItem';
+import {
+  docsLink,
+  getLinkOnClick,
+  guidesMoreLinkText,
+  youtubeChannelLink,
+  youtubeMoreLinkLabel,
+  youtubeMoreLinkText,
+} from 'src/utilities/emptyStateLandingUtils';
+import { sendEvent } from 'src/utilities/ga';
+
+const gaCategory = 'Managed Databases landing page empty';
+const linkGAEventTemplate = {
+  category: gaCategory,
+  action: 'Click:link',
+};
 
 const guidesLinkData = [
   {
@@ -49,18 +63,14 @@ const youtubeLinkData = [
   },
 ];
 
-const getLinkOnClick = (linkText: string) => () => {
-  sendEvent({
-    ...linkGAEventTemplate,
-    label: linkText,
-  });
-};
-
 const guideLinks = (
   <List>
     {guidesLinkData.map((linkData) => (
       <ListItem key={linkData.to}>
-        <Link to={linkData.to} onClick={getLinkOnClick(linkData.text)}>
+        <Link
+          to={linkData.to}
+          onClick={getLinkOnClick(linkGAEventTemplate, linkData.text)}
+        >
           {linkData.text}
         </Link>
       </ListItem>
@@ -68,17 +78,14 @@ const guideLinks = (
   </List>
 );
 
-const guidesMoreLinkText = 'Check out all our Docs';
-const youtubeMoreLinkText = 'View our YouTube channel';
-
-// retaining the old label for tracking
-const youtubeMoreLinkLabel = 'View the complete playlist';
-
 const youtubeLinks = (
   <List>
     {youtubeLinkData.map((linkData) => (
       <ListItem key={linkData.to}>
-        <Link to={linkData.to} onClick={getLinkOnClick(linkData.text)}>
+        <Link
+          to={linkData.to}
+          onClick={getLinkOnClick(linkGAEventTemplate, linkData.text)}
+        >
           {linkData.text}
           <ExternalLinkIcon />
         </Link>
@@ -94,13 +101,6 @@ const useStyles = makeStyles(() => ({
     },
   },
 }));
-
-const gaCategory = 'Managed Databases landing page empty';
-
-const linkGAEventTemplate = {
-  category: gaCategory,
-  action: 'Click:link',
-};
 
 const DatabaseEmptyState: React.FC = () => {
   const classes = useStyles();
@@ -135,8 +135,11 @@ const DatabaseEmptyState: React.FC = () => {
               icon={<DocsIcon />}
               MoreLink={(props) => (
                 <Link
-                  onClick={getLinkOnClick(guidesMoreLinkText)}
-                  to="https://www.linode.com/docs/"
+                  onClick={getLinkOnClick(
+                    linkGAEventTemplate,
+                    guidesMoreLinkText
+                  )}
+                  to={docsLink}
                   {...props}
                 >
                   {guidesMoreLinkText}
@@ -152,8 +155,11 @@ const DatabaseEmptyState: React.FC = () => {
               external
               MoreLink={(props) => (
                 <Link
-                  onClick={getLinkOnClick(youtubeMoreLinkLabel)}
-                  to="https://www.youtube.com/playlist?list=PLTnRtjQN5ieb4XyvC9OUhp7nxzBENgCxJ"
+                  onClick={getLinkOnClick(
+                    linkGAEventTemplate,
+                    youtubeMoreLinkLabel
+                  )}
+                  to={youtubeChannelLink}
                   {...props}
                 >
                   {youtubeMoreLinkText}

--- a/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLanding.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLanding.tsx
@@ -18,7 +18,7 @@ import { usePagination } from 'src/hooks/usePagination';
 import { useKubernetesClustersQuery } from 'src/queries/kubernetes';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import { KubernetesClusterRow } from '../ClusterList/KubernetesClusterRow';
-import { KubernetesEmptyState } from './KubernetesLandingEmptyState';
+import KubernetesEmptyState from './KubernetesLandingEmptyState';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { useHistory } from 'react-router-dom';
 import { KubeNodePoolResponse } from '@linode/api-v4';

--- a/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLandingEmptyState.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLandingEmptyState.tsx
@@ -1,49 +1,183 @@
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
+import DocsIcon from 'src/assets/icons/docs.svg';
 import KubernetesSvg from 'src/assets/icons/entityIcons/kubernetes.svg';
+import ExternalLinkIcon from 'src/assets/icons/external-link.svg';
+import YoutubeIcon from 'src/assets/icons/youtube.svg';
+import List from 'src/components/core/List';
+import ListItem from 'src/components/core/ListItem';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
+import Link from 'src/components/Link';
 import Placeholder from 'src/components/Placeholder';
+import LinksSection from 'src/features/linodes/LinodesLanding/LinksSection';
+import LinkSubSection from 'src/features/linodes/LinodesLanding/LinksSubSection';
+import {
+  getLinkOnClick,
+  guidesMoreLinkText,
+  youtubeMoreLinkLabel,
+  youtubeMoreLinkText,
+} from 'src/utilities/emptyStateLandingUtils';
+import { sendEvent } from 'src/utilities/ga';
 
 const useStyles = makeStyles((theme: Theme) => ({
   placeholderAdjustment: {
-    padding: `${theme.spacing(2)} 0 0 0`,
+    padding: `${theme.spacing(2)} 0`,
     [theme.breakpoints.up('md')]: {
-      padding: `${theme.spacing(10)} 0 0 0`,
+      padding: `${theme.spacing(10)} 0 ${theme.spacing(4)}`,
     },
   },
 }));
 
-export const KubernetesEmptyState = () => {
+const guidesLinkData = [
+  {
+    to: 'https://www.linode.com/docs/products/compute/kubernetes/get-started/',
+    text: 'Get Started with the Linode Kubernetes Engine (LKE)',
+  },
+  {
+    to:
+      'https://www.linode.com/docs/products/compute/kubernetes/guides/create-lke-cluster',
+    text: 'Create and Administer a Kubernetes Cluster on LKE',
+  },
+  {
+    to:
+      'https://www.linode.com/docs/guides/using-the-kubernetes-dashboard-on-lke/',
+    text: 'Using the Kubernetes Dashboard',
+  },
+  {
+    to: 'https://www.linode.com/docs/guides/beginners-guide-to-kubernetes/',
+    text: 'A Beginner\u{2019}s Guide to Kubernetes',
+  },
+];
+
+const youtubeLinkData = [
+  {
+    to: 'https://www.youtube.com/watch?v=erthAqqdD_c',
+    text: 'Easily Deploy a Kubernetes Cluster on LKE',
+  },
+  {
+    to: 'https://www.youtube.com/watch?v=VYUr_WvXCsY',
+    text: 'Enable High Availability on an LKE Cluster',
+  },
+  {
+    to: 'https://www.youtube.com/watch?v=odPmyT5DONg',
+    text: 'Use a Load Balancer with an LKE Cluster',
+  },
+  {
+    to: 'https://www.youtube.com/watch?v=1564_DrFRSE',
+    text: 'Use TOBS (The Observability Stack) with LKE',
+  },
+];
+
+const gaCategory = 'Kubernetes landing page empty';
+const linkGAEventTemplate = {
+  category: gaCategory,
+  action: 'Click:link',
+};
+
+const guideLinks = (
+  <List>
+    {guidesLinkData.map((linkData) => (
+      <ListItem key={linkData.to}>
+        <Link
+          to={linkData.to}
+          onClick={getLinkOnClick(linkGAEventTemplate, linkData.text)}
+        >
+          {linkData.text}
+        </Link>
+      </ListItem>
+    ))}
+  </List>
+);
+
+const youtubeLinks = (
+  <List>
+    {youtubeLinkData.map((linkData) => (
+      <ListItem key={linkData.to}>
+        <Link
+          onClick={getLinkOnClick(linkGAEventTemplate, linkData.text)}
+          to={linkData.to}
+        >
+          {linkData.text}
+          <ExternalLinkIcon />
+        </Link>
+      </ListItem>
+    ))}
+  </List>
+);
+
+const KubernetesEmptyState = () => {
   const { push } = useHistory();
   const classes = useStyles();
 
   return (
     <Placeholder
       title="Kubernetes"
-      isEntity
-      icon={KubernetesSvg}
+      subtitle=""
       className={classes.placeholderAdjustment}
+      icon={KubernetesSvg}
+      isEntity
+      showTransferDisplay
       buttonProps={[
         {
-          onClick: () => push('/kubernetes/create'),
+          onClick: () => {
+            sendEvent({
+              category: gaCategory,
+              action: 'Click:button',
+              label: 'Create Cluster',
+            });
+            push('/kubernetes/create');
+          },
           children: 'Create Cluster',
         },
       ]}
-      showTransferDisplay
+      linksSection={
+        <LinksSection>
+          <LinkSubSection
+            title="Getting Started Guides"
+            icon={<DocsIcon />}
+            MoreLink={(props) => (
+              <Link
+                onClick={getLinkOnClick(
+                  linkGAEventTemplate,
+                  guidesMoreLinkText
+                )}
+                to="https://www.linode.com/docs/"
+                {...props}
+              >
+                {guidesMoreLinkText}
+              </Link>
+            )}
+          >
+            {guideLinks}
+          </LinkSubSection>
+          <LinkSubSection
+            title="Video Playlist"
+            icon={<YoutubeIcon />}
+            external
+            MoreLink={(props) => (
+              <Link
+                onClick={getLinkOnClick(
+                  linkGAEventTemplate,
+                  youtubeMoreLinkLabel
+                )}
+                to="https://www.youtube.com/playlist?list=PLTnRtjQN5ieb4XyvC9OUhp7nxzBENgCxJ"
+                {...props}
+              >
+                {youtubeMoreLinkText}
+                <ExternalLinkIcon style={{ marginLeft: 8 }} />
+              </Link>
+            )}
+          >
+            {youtubeLinks}
+          </LinkSubSection>
+        </LinksSection>
+      }
     >
       {' '}
-      <Typography variant="subtitle1">Need help getting started?</Typography>
-      <Typography variant="subtitle1">
-        <a
-          href="https://www.linode.com/docs/applications/containers/kubernetes/how-to-deploy-a-cluster-with-lke/"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="h-u"
-        >
-          Learn more about getting started with LKE.
-        </a>
-      </Typography>
+      <Typography variant="subtitle1">Placeholder</Typography>
     </Placeholder>
   );
 };
+
+export default React.memo(KubernetesEmptyState);

--- a/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLandingEmptyState.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLandingEmptyState.tsx
@@ -113,7 +113,7 @@ const KubernetesEmptyState = () => {
   return (
     <Placeholder
       title="Kubernetes"
-      subtitle=""
+      subtitle="Fully managed Kubernetes infrastructure"
       className={classes.placeholderAdjustment}
       icon={KubernetesSvg}
       isEntity
@@ -175,7 +175,10 @@ const KubernetesEmptyState = () => {
       }
     >
       {' '}
-      <Typography variant="subtitle1">Placeholder</Typography>
+      <Typography variant="subtitle1">
+        Deploy and scale your applications with the Linode Kubernetes Engine
+        (LKE), a Kubernetes service equipped with a fully managed control plane.
+      </Typography>
     </Placeholder>
   );
 };

--- a/packages/manager/src/features/linodes/LinodesLanding/AppsSection.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/AppsSection.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Link from 'src/components/Link';
 import PointerIcon from 'src/assets/icons/pointer.svg';
-import { sendEvent } from 'src/utilities/ga';
+import { getLinkOnClick } from 'src/utilities/emptyStateLandingUtils';
 
 const useStyles = makeStyles((theme: Theme) => {
   const isDarkTheme = theme.name === 'darkTheme';
@@ -31,7 +31,7 @@ const useStyles = makeStyles((theme: Theme) => {
       maxWidth: theme.spacing(20),
       paddingLeft: theme.spacing(),
       justifyContent: 'space-between',
-      backgroundColor: backgroundColor,
+      backgroundColor,
       fontSize: '0.875rem',
       fontWeight: 700,
       color: theme.palette.text.primary,
@@ -56,7 +56,6 @@ const useStyles = makeStyles((theme: Theme) => {
 });
 
 const gaCategory = 'Linodes landing page empty';
-
 const linkGAEventTemplate = {
   category: gaCategory,
   action: 'Click:link',
@@ -95,14 +94,6 @@ const appsLinkData = [
   },
 ];
 
-const getOnLinkClick = (label: string) => {
-  return () =>
-    sendEvent({
-      ...linkGAEventTemplate,
-      label,
-    });
-};
-
 interface AppLinkProps {
   to: string;
   text: string;
@@ -112,7 +103,11 @@ const AppLink = (props: AppLinkProps) => {
   const { to, text } = props;
   const classes = useStyles();
   return (
-    <Link onClick={getOnLinkClick(text)} to={to} className={classes.appLink}>
+    <Link
+      onClick={getLinkOnClick(linkGAEventTemplate, text)}
+      to={to}
+      className={classes.appLink}
+    >
       {text}
       <div className={classes.appLinkIcon}>
         <PointerIcon />

--- a/packages/manager/src/features/linodes/LinodesLanding/ListLinodesEmptyState.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/ListLinodesEmptyState.tsx
@@ -12,13 +12,20 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Link from 'src/components/Link';
 import Placeholder from 'src/components/Placeholder';
+import {
+  docsLink,
+  getLinkOnClick,
+  guidesMoreLinkText,
+  youtubeChannelLink,
+  youtubeMoreLinkLabel,
+  youtubeMoreLinkText,
+} from 'src/utilities/emptyStateLandingUtils';
 import { sendEvent } from 'src/utilities/ga';
 import AppsSection from './AppsSection';
 import LinksSection from './LinksSection';
 import LinksSubSection from './LinksSubSection';
 
 const gaCategory = 'Linodes landing page empty';
-
 const linkGAEventTemplate = {
   category: gaCategory,
   action: 'Click:link',
@@ -64,18 +71,14 @@ const youtubeLinksData = [
   },
 ];
 
-const getLinkOnClick = (linkText: string) => () => {
-  sendEvent({
-    ...linkGAEventTemplate,
-    label: linkText,
-  });
-};
-
 const guideLinks = (
   <List>
     {gettingStartedGuideLinksData.map((linkData) => (
       <ListItem key={linkData.to}>
-        <Link to={linkData.to} onClick={getLinkOnClick(linkData.text)}>
+        <Link
+          to={linkData.to}
+          onClick={getLinkOnClick(linkGAEventTemplate, linkData.text)}
+        >
           {linkData.text}
         </Link>
       </ListItem>
@@ -83,18 +86,16 @@ const guideLinks = (
   </List>
 );
 
-const guidesMoreLinkText = 'Check out all our Docs';
 const appsMoreLinkText = 'See all Marketplace apps';
-const youtubeMoreLinkText = 'View our YouTube channel';
-
-// retaining the old label for tracking
-const youtubeMoreLinkLabel = 'View the complete playlist';
 
 const youtubeLinks = (
   <List>
     {youtubeLinksData.map((linkData) => (
       <ListItem key={linkData.to}>
-        <Link onClick={getLinkOnClick(linkData.text)} to={linkData.to}>
+        <Link
+          onClick={getLinkOnClick(linkGAEventTemplate, linkData.text)}
+          to={linkData.to}
+        >
           {linkData.text}
           <ExternalLinkIcon />
         </Link>
@@ -144,8 +145,11 @@ export const ListLinodesEmptyState: React.FC<{}> = (_) => {
             icon={<DocsIcon />}
             MoreLink={(props) => (
               <Link
-                onClick={getLinkOnClick(guidesMoreLinkText)}
-                to="https://www.linode.com/docs/"
+                onClick={getLinkOnClick(
+                  linkGAEventTemplate,
+                  guidesMoreLinkText
+                )}
+                to={docsLink}
                 {...props}
               >
                 {guidesMoreLinkText}
@@ -160,7 +164,7 @@ export const ListLinodesEmptyState: React.FC<{}> = (_) => {
             icon={<MarketplaceIcon />}
             MoreLink={(props) => (
               <Link
-                onClick={getLinkOnClick(appsMoreLinkText)}
+                onClick={getLinkOnClick(linkGAEventTemplate, appsMoreLinkText)}
                 to="/linodes/create?type=One-Click"
                 {...props}
               >
@@ -177,8 +181,11 @@ export const ListLinodesEmptyState: React.FC<{}> = (_) => {
             external
             MoreLink={(props) => (
               <Link
-                onClick={getLinkOnClick(youtubeMoreLinkLabel)}
-                to="https://www.youtube.com/playlist?list=PLTnRtjQN5ieb4XyvC9OUhp7nxzBENgCxJ"
+                onClick={getLinkOnClick(
+                  linkGAEventTemplate,
+                  youtubeMoreLinkLabel
+                )}
+                to={youtubeChannelLink}
                 {...props}
               >
                 {youtubeMoreLinkText}

--- a/packages/manager/src/utilities/emptyStateLandingUtils.ts
+++ b/packages/manager/src/utilities/emptyStateLandingUtils.ts
@@ -1,0 +1,25 @@
+import { sendEvent } from 'src/utilities/ga';
+
+export const guidesMoreLinkText = 'Check out all our Docs';
+export const docsLink = 'https://www.linode.com/docs/';
+export const youtubeMoreLinkText = 'View our YouTube channel';
+export const youtubeChannelLink =
+  'https://www.youtube.com/playlist?list=PLTnRtjQN5ieb4XyvC9OUhp7nxzBENgCxJ';
+
+// retaining the old label for tracking
+export const youtubeMoreLinkLabel = 'View the complete playlist';
+
+interface GAEventTemplate {
+  category: string;
+  action: string;
+}
+
+export const getLinkOnClick = (
+  linkGAEventTemplate: GAEventTemplate,
+  linkText: string
+) => () => {
+  sendEvent({
+    ...linkGAEventTemplate,
+    label: linkText,
+  });
+};


### PR DESCRIPTION
## Description 📝
- New utility file for empty state landing page constants and GA send event function
  - Refactors for DBaaS and Linode empty state landing pages related to the above
 - Resource links added to Kubernetes empty state landing page

## Preview 📷

![Screenshot 2023-02-27 at 1 50 17 PM](https://user-images.githubusercontent.com/114682940/221655687-c063ad2c-b981-42db-9713-ca73e9d6f4fb.jpg)

## How to test 🧪
- Confirm that the GA events are still being sent as expected for the DBaaS and Linode empty state landing page interactions
  - This can be checked via network requests -- in Firefox, for example, you should see Google Analytics-related requests and you can drill down into the request and see the label, etc. associated with the click. In Chrome it seems the visibility of these requests depends on your local browser settings/configuration
- Confirm the GA events are being sent as expected for the Kubernetes empty state landing page interactions
- Confirm the links match the specs