### PR TITLE
refactor: [M3-5800] - Improve notification event links

### DIFF
--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -809,14 +809,6 @@ function applyBolding(event: Event, message: string) {
     'upgraded',
   ];
 
-  if (event.entity) {
-    wordsToBold.push(event.entity.label);
-  }
-
-  if (event.secondary_entity) {
-    wordsToBold.push(event.secondary_entity.label);
-  }
-
   let newMessage = message;
 
   for (const word of wordsToBold) {

--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -772,9 +772,8 @@ export default (e: Event): string => {
   }
 
   /** return either the formatted message or an empty string */
-  let formattedMessage = applyLinking(e, message);
-  formattedMessage = applyBolding(e, formattedMessage);
-  return formattedMessage;
+  const formattedMessage = applyLinking(e, message);
+  return applyBolding(e, formattedMessage);
 };
 
 function applyBolding(event: Event, message: string) {

--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -831,17 +831,28 @@ function applyLinking(event: Event, message: string) {
     return '';
   }
 
-  const linkTarget = createLinkHandlerForNotification(
+  const entityLinkTarget = createLinkHandlerForNotification(
     event.action,
     event.entity,
     false
   );
+  const secondaryEntityLinkTarget = createLinkHandlerForNotification(
+    event.action,
+    event.secondary_entity,
+    false
+  );
   let newMessage = message;
 
-  if (event.entity && linkTarget) {
+  if (event.entity && entityLinkTarget) {
     newMessage = newMessage.replace(
       event.entity.label,
-      `<a href="${linkTarget}">${event.entity.label}</a>`
+      `<a href="${entityLinkTarget}">${event.entity.label}</a>`
+    );
+  }
+  if (event.secondary_entity && secondaryEntityLinkTarget) {
+    newMessage = newMessage.replace(
+      event.secondary_entity.label,
+      `<a href="${secondaryEntityLinkTarget}">${event.secondary_entity.label}</a>`
     );
   }
 

--- a/packages/manager/src/features/Events/EventRow.tsx
+++ b/packages/manager/src/features/Events/EventRow.tsx
@@ -22,9 +22,6 @@ const useStyles = makeStyles((theme: Theme) => ({
       backgroundColor:
         theme.name === 'lightTheme' ? '#fbfbfb' : 'rgba(0, 0, 0, 0.1)',
     },
-    '& a': {
-      color: 'inherit',
-    },
   },
   icon: {
     height: 24,

--- a/packages/manager/src/features/Events/EventRow.tsx
+++ b/packages/manager/src/features/Events/EventRow.tsx
@@ -83,7 +83,7 @@ export interface RowProps {
 export const Row: React.FC<RowProps> = (props) => {
   const classes = useStyles();
 
-  const { action, link, message, created, username } = props;
+  const { action, message, created, username } = props;
 
   /** Some event types may not be handled by our system (or new types
    * may be added). Filter these out so we don't display blank messages to the user.
@@ -99,7 +99,7 @@ export const Row: React.FC<RowProps> = (props) => {
       data-qa-event-row
       data-test-id={action}
       ariaLabel={`Event ${displayedMessage}`}
-      className={link ? classes.row : ''}
+      className={classes.row}
     >
       <Hidden smDown>
         <TableCell data-qa-event-icon-cell>

--- a/packages/manager/src/features/Events/EventRow.tsx
+++ b/packages/manager/src/features/Events/EventRow.tsx
@@ -6,7 +6,6 @@ import Hidden from 'src/components/core/Hidden';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import DateTimeDisplay from 'src/components/DateTimeDisplay';
 import HighlightedMarkdown from 'src/components/HighlightedMarkdown';
-import Link from 'src/components/Link';
 import renderGuard, { RenderGuardProps } from 'src/components/RenderGuard';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
@@ -111,25 +110,13 @@ export const Row: React.FC<RowProps> = (props) => {
         </TableCell>
       </Hidden>
       <TableCell parentColumn="Event" data-qa-event-message-cell>
-        {link ? (
-          <Link to={link}>
-            <HighlightedMarkdown
-              textOrMarkdown={displayedMessage}
-              sanitizeOptions={{
-                allowedTags: [],
-                disallowedTagsMode: 'discard',
-              }}
-            />
-          </Link>
-        ) : (
-          <HighlightedMarkdown
-            textOrMarkdown={displayedMessage}
-            sanitizeOptions={{
-              allowedTags: [],
-              disallowedTagsMode: 'discard',
-            }}
-          />
-        )}
+        <HighlightedMarkdown
+          textOrMarkdown={displayedMessage}
+          sanitizeOptions={{
+            allowedTags: ['a'],
+            disallowedTagsMode: 'discard',
+          }}
+        />
       </TableCell>
       <TableCell parentColumn="Relative Date">
         {parseAPIDate(created).toRelative()}

--- a/packages/manager/src/features/NotificationCenter/NotificationData/RenderEvent.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/RenderEvent.tsx
@@ -54,7 +54,7 @@ export const RenderEvent: React.FC<Props> = (props) => {
   const classes = useStyles();
 
   const { event } = props;
-  const { message, linkTarget } = useEventInfo(event);
+  const { message } = useEventInfo(event);
 
   if (message === null) {
     return null;
@@ -75,7 +75,7 @@ export const RenderEvent: React.FC<Props> = (props) => {
       <Box
         className={classNames({
           [classes.root]: true,
-          [classes.event]: !!linkTarget,
+          [classes.event]: true,
         })}
         display="flex"
         data-test-id={event.action}

--- a/packages/manager/src/features/NotificationCenter/NotificationData/RenderEvent.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/RenderEvent.tsx
@@ -31,9 +31,6 @@ export const useStyles = makeStyles((theme: Theme) => ({
       paddingLeft: 20,
       paddingRight: 20,
       width: 'calc(100% + 40px)',
-      '& a': {
-        textDecoration: 'none',
-      },
     },
   },
   eventMessage: {

--- a/packages/manager/src/features/NotificationCenter/NotificationData/RenderEvent.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/RenderEvent.tsx
@@ -6,7 +6,6 @@ import Divider from 'src/components/core/Divider';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import HighlightedMarkdown from 'src/components/HighlightedMarkdown';
-import { Link } from 'src/components/Link';
 import { GravatarByUsername } from 'src/components/GravatarByUsername';
 import { parseAPIDate } from 'src/utilities/date';
 import useEventInfo from './useEventInfo';
@@ -26,7 +25,6 @@ export const useStyles = makeStyles((theme: Theme) => ({
     color: theme.textColors.tableHeader,
     '&:hover': {
       backgroundColor: theme.bg.app,
-      cursor: 'pointer',
       // Extends the hover state to the edges of the drawer
       marginLeft: -20,
       marginRight: -20,
@@ -55,7 +53,7 @@ interface Props {
 export const RenderEvent: React.FC<Props> = (props) => {
   const classes = useStyles();
 
-  const { event, onClose } = props;
+  const { event } = props;
   const { message, linkTarget } = useEventInfo(event);
 
   if (message === null) {
@@ -87,13 +85,7 @@ export const RenderEvent: React.FC<Props> = (props) => {
           className={classes.icon}
         />
         <div className={classes.eventMessage}>
-          {linkTarget ? (
-            <Link to={linkTarget} onClick={onClose}>
-              {eventMessage}
-            </Link>
-          ) : (
-            eventMessage
-          )}
+          {eventMessage}
           <Typography
             className={classNames({ [classes.unseenEvent]: !event.seen })}
           >

--- a/packages/manager/src/features/NotificationCenter/NotificationData/RenderProgressEvent.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/RenderProgressEvent.tsx
@@ -7,7 +7,6 @@ import Box from 'src/components/core/Box';
 import Divider from 'src/components/core/Divider';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
-import { Link } from 'src/components/Link';
 import {
   eventLabelGenerator,
   eventMessageGenerator,
@@ -32,7 +31,7 @@ interface Props {
 export type CombinedProps = Props;
 
 export const RenderProgressEvent: React.FC<Props> = (props) => {
-  const { event, onClose } = props;
+  const { event } = props;
   const eventClasses = useEventStyles();
   const classes = useStyles();
 
@@ -77,13 +76,7 @@ export const RenderProgressEvent: React.FC<Props> = (props) => {
           className={eventClasses.icon}
         />
         <div className={eventClasses.eventMessage} data-test-id={event.action}>
-          {linkTarget ? (
-            <Link to={linkTarget} onClick={onClose}>
-              {eventMessage}
-            </Link>
-          ) : (
-            eventMessage
-          )}
+          {eventMessage}
           <BarPercent
             className={classes.bar}
             max={100}

--- a/packages/manager/src/features/NotificationCenter/NotificationData/RenderProgressEvent.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/RenderProgressEvent.tsx
@@ -15,7 +15,6 @@ import { GravatarByUsername } from 'src/components/GravatarByUsername';
 import useLinodes from 'src/hooks/useLinodes';
 import { useTypes } from 'src/hooks/useTypes';
 import { useStyles as useEventStyles } from './RenderEvent';
-import useEventInfo from './useEventInfo';
 
 const useStyles = makeStyles((theme: Theme) => ({
   bar: {
@@ -39,7 +38,6 @@ export const RenderProgressEvent: React.FC<Props> = (props) => {
   const { types } = useTypes();
   const _linodes = Object.values(linodes.itemsById);
   const _types = types.entities;
-  const { linkTarget } = useEventInfo(event);
   const message = eventMessageGenerator(event, _linodes, _types);
 
   if (message === null) {
@@ -66,7 +64,7 @@ export const RenderProgressEvent: React.FC<Props> = (props) => {
       <Box
         className={classNames({
           [eventClasses.root]: true,
-          [eventClasses.event]: !!linkTarget,
+          [eventClasses.event]: true,
         })}
         display="flex"
         data-test-id={event.action}

--- a/packages/manager/src/features/NotificationCenter/NotificationData/useEventInfo.ts
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/useEventInfo.ts
@@ -6,7 +6,6 @@ import {
   EntityType,
   getEntityByIDFromStore,
 } from 'src/utilities/getEntityByIDFromStore';
-import createLinkHandlerForNotification from 'src/utilities/getEventsActionLink';
 import { formatEventSeconds } from 'src/utilities/minute-conversion/minute-conversion';
 import { Variant } from 'src/components/EntityIcon';
 
@@ -20,7 +19,6 @@ export interface EventInfo {
   message: string | null;
   type: Variant;
   status?: string;
-  linkTarget?: string;
 }
 
 export const useEventInfo = (event: Event): EventInfo => {
@@ -36,12 +34,6 @@ export const useEventInfo = (event: Event): EventInfo => {
     event.entity?.id ?? -1
   );
 
-  const linkTarget = createLinkHandlerForNotification(
-    event.action,
-    event.entity,
-    false
-  );
-
   const status = path<string>(['status'], entity);
 
   const duration = formatEventSeconds(event.duration);
@@ -51,7 +43,6 @@ export const useEventInfo = (event: Event): EventInfo => {
     message: messageWithUsername,
     status,
     type,
-    linkTarget,
   };
 };
 

--- a/packages/manager/src/utilities/getEventsActionLink.ts
+++ b/packages/manager/src/utilities/getEventsActionLink.ts
@@ -89,6 +89,9 @@ export default (
     case 'stackscript':
       return `/stackscripts/${id}`;
 
+    case 'firewall':
+      return `/firewalls/${id}`;
+
     case 'nodebalancer':
       // eslint-disable-next-line sonarjs/no-small-switch
       switch (action) {


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
Improves the notification event messages by making the following changes:
- Applying hover state on every event type
   - Previously, events referencing a deleted (non-linkable) entity did not have a hover state because only linkable events were hoverable
- Adding hyperlinks to entity names 
- Removing hyperlinks from event row itself
   - Pointer will no longer appear when hovering anywhere on the event row
   - This will make the target of the pointer more clear and allow for multiple hyperlinks (e.g. an entity name and a docs link) to be clickable within a single  event message

## Preview 📷

**Notification Center:**
| Prod | This branch  | 
| ------- | --- | 
| ![Screen Shot 2023-03-01 at 10 20 48 PM](https://user-images.githubusercontent.com/114685994/222347433-b3b0327e-878e-4c5c-80f8-84e5494e5e3a.jpg) |  ![Screen Shot 2023-03-01 at 10 20 25 PM](https://user-images.githubusercontent.com/114685994/222347469-1f891115-21af-43cd-97e0-488c8a5a9868.jpg) | 

**Events Landing:**

Prod:
![Screen Shot 2023-03-01 at 10 01 07 PM](https://user-images.githubusercontent.com/114685994/222346257-8c7f4f9d-359e-4058-8fdb-681b4f20337e.jpg)

This branch:
![Screen Shot 2023-03-01 at 10 18 31 PM](https://user-images.githubusercontent.com/114685994/222346897-b99c7591-dc8a-4cfe-9d51-9caba553d072.jpg)

<details>
<summary>
Videos  📹 
</summary>
(Linodes deleted after testing.)

**Prod**:

https://user-images.githubusercontent.com/114685994/222345992-fed9db76-654b-4ceb-8463-009e5dbfc7d2.mov

**This branch**:

https://user-images.githubusercontent.com/114685994/222345962-f56aa446-aa8c-400a-8642-86cef6766292.mov


</details>

## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**
1. Create a new entity whose created event returns a link to that new entity in its message body. (e.g. Linode)
2. Open the Notification menu with the bell icon in the top menu.
3. Verify that hyperlinks have been removed from the event row and added to the entity name. Click the hyperlink on an entity name and verify it redirects to the expected location from both the Notification menu and Events Landing (http://localhost:3000/events).
4. Delete the newly created resource from step 1.
5. Verify that the event for the deleted entity does not contain a link to that entity.
6. Verify that hovering over events of every type (including in progress, error, and delete events) registers a hover state with a gray event row background in both the Notification menu and Events Landing table. Compare behavior to prod, where non-linkable (some error, all delete) events have no hover state.
7. Verify that behavior and display of _notifications_ in the Notifications menu is unchanged from prod.
8. In general, try generating various events and look out for inconsistencies in the Notification menu and Events Landing. Test an event whose event message contains a secondary entity, like cloning or rebooting a Linode and check that links redirect as expected.
9. Turn on MSW to check behavior of more event and notification types.

**How do I run relevant unit or e2e tests?**
```
yarn test EventMessageGenerator EventsLanding EventRow
```
