### PR TITLE
fix: [M3-6211] - Fix Firewall Rules Table rendering overlapping text

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -433,7 +433,11 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
       >
         <Grid
           item
-          style={{ paddingLeft: 8, width: xsDown ? '50%' : '30%' }}
+          style={{
+            paddingLeft: 8,
+            width: xsDown ? '50%' : '30%',
+            whiteSpace: 'normal',
+          }}
           aria-label={`Label: ${label}`}
         >
           <DragIndicator

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -94,7 +94,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   labelCol: {
     paddingLeft: 6,
-    whiteSpace: 'nowrap',
   },
   ruleGrid: {
     width: '100%',
@@ -102,7 +101,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   ruleList: {
     backgroundColor: theme.color.border3,
-    whiteSpace: 'nowrap',
     listStyle: 'none',
     paddingLeft: 0,
     width: '100%',
@@ -278,7 +276,6 @@ const FirewallRuleTable: React.FC<CombinedProps> = (props) => {
             <Grid
               item
               style={{
-                whiteSpace: 'nowrap',
                 width: '10%',
               }}
             >
@@ -436,7 +433,7 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
           style={{
             paddingLeft: 8,
             width: xsDown ? '50%' : '30%',
-            whiteSpace: 'normal',
+            overflowWrap: 'break-word',
           }}
           aria-label={`Label: ${label}`}
         >
@@ -468,17 +465,13 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
           </Grid>
         </Hidden>
         <Hidden smDown>
-          <Grid
-            item
-            style={{ whiteSpace: 'normal', width: '10%' }}
-            aria-label={`Ports: ${ports}`}
-          >
+          <Grid item style={{ width: '10%' }} aria-label={`Ports: ${ports}`}>
             {ports === '1-65535' ? 'All Ports' : ports}
             <ConditionalError errors={errors} formField="ports" />
           </Grid>
           <Grid
             item
-            style={{ whiteSpace: 'normal', width: '15%' }}
+            style={{ width: '15%' }}
             aria-label={`Addresses: ${addresses}`}
           >
             {addresses}{' '}

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -466,7 +466,7 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
         <Hidden smDown>
           <Grid
             item
-            style={{ whiteSpace: 'nowrap', width: '10%' }}
+            style={{ whiteSpace: 'normal', width: '10%' }}
             aria-label={`Ports: ${ports}`}
           >
             {ports === '1-65535' ? 'All Ports' : ports}
@@ -474,7 +474,7 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
           </Grid>
           <Grid
             item
-            style={{ whiteSpace: 'nowrap', width: '15%' }}
+            style={{ whiteSpace: 'normal', width: '15%' }}
             aria-label={`Addresses: ${addresses}`}
           >
             {addresses}{' '}


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
Fixes a bug in the Firewall Rules Table where `whiteSpace: 'nowrap'` [CSS property](https://developer.mozilla.org/en-US/docs/Web/CSS/white-space) was preventing fields with long labels or long lists of ports or IP addresses from wrapping text in their containers. The result was overlapping, illegible text in the Port, Sources, and Action columns. The `whiteSpace` property was previously used when rendering the rules with table components, but caused rendering issues after the refactor in #8735. 

## Preview 📷

🐛 Bug in prod:
![Screen Shot 2023-02-28 at 3 25 06 PM](https://user-images.githubusercontent.com/114685994/222006072-b4cc68aa-23ad-4ae7-a806-2788e9e981f8.jpg)

Fix in this branch:
![image](https://user-images.githubusercontent.com/114685994/222005866-55f403d0-45bc-444d-8a95-6fd06ed4d4d4.png)

## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**

*Bug in prod:*

1. Navigate to the Firewalls landing page (https://cloud.linode.com/firewalls/) and create a firewall or use an existing one.
2. Click on the firewall name to navigate to the firewall rules page.
3. Click button to add in Inbound or Outbound rule -- the logic is the same for both, so it shouldn't matter which.
4. In the drawer, fill out the form with a label that is 32 characters long (the max length), select TCP or UDP protocol (both allow ports), add multiple ports (4+ should be enough), and select *IP/Netmask* as the source. Input 4+ IP addresses. **Note**: if you want to be able to *save* your changes so the newly added rule persists, you will need valid IP addresses. Add duplicate valid IPs such as `192.0.2.1/32` to avoid seeing an invalid IP error in save.
5. Click add rule and observe the firewall rules table with the newly added rule. If you do not see the text in the Port Range and Sources columns extending beyond their data columns, resize the browser window to make the screen smaller. To see the overlap on the Label column, you will need to resize the screen width to `~700px`.

*Fix in this branch:*

1. Repeat the above steps on this branch, but when you get to step 5, resize the window like above and observe that the text in the Port Range, Sources, and Label columns wrap, preventing any rendering issues with overlapping text.
3.  Test different window sizes and check for any other overlapping text or display issues.


