### PR TITLE
fix: Cypress React Query Images improvements

### DIFF
--- a/packages/manager/cypress/e2e/images/smoke-create-image.spec.ts
+++ b/packages/manager/cypress/e2e/images/smoke-create-image.spec.ts
@@ -29,7 +29,7 @@ describe('create image', () => {
     });
 
     // stub incoming response
-    cy.intercept(apiMatcher('images?page_size=100'), {
+    cy.intercept(apiMatcher('images?*'), {
       results: 0,
       data: [],
       page: 1,
@@ -38,7 +38,7 @@ describe('create image', () => {
     cy.intercept('POST', apiMatcher('images'), mockNewImage).as('createImage');
     createLinode().then((linode: Linode) => {
       // stub incoming disks response
-      cy.intercept(apiMatcher(`linode/instances/${linode.id}/disks*`), {
+      cy.intercept('GET', apiMatcher(`linode/instances/${linode.id}/disks*`), {
         results: 2,
         data: [
           {
@@ -74,9 +74,8 @@ describe('create image', () => {
       cy.wait('@getImages');
       fbtClick('Create Image');
       fbtClick('Select a Linode').type(`${linode.label}{enter}`);
-      cy.wait('@getDisks').then(() => {
-        containsClick('Select a Disk').type(`${diskLabel}{enter}`);
-      });
+      cy.wait('@getDisks');
+      containsClick('Select a Disk').type(`${diskLabel}{enter}`);
       cy.findAllByLabelText('Label', { exact: false }).type(
         `${imageLabel}{enter}`
       );

--- a/packages/manager/cypress/e2e/images/smoke-create-image.spec.ts
+++ b/packages/manager/cypress/e2e/images/smoke-create-image.spec.ts
@@ -1,13 +1,6 @@
 import type { Linode } from '@linode/api-v4/types';
 import { imageFactory } from 'src/factories/images';
 import { createLinode, deleteLinodeById } from 'support/api/linodes';
-import {
-  containsClick,
-  fbtClick,
-  fbtVisible,
-  getClick,
-  getVisible,
-} from 'support/helpers';
 import { apiMatcher } from 'support/util/intercepts';
 import { randomLabel, randomNumber, randomPhrase } from 'support/util/random';
 
@@ -64,23 +57,28 @@ describe('create image', () => {
         pages: 1,
       }).as('getDisks');
       cy.visitWithLogin('/images');
-      getVisible('[data-qa-header]').within(() => {
-        fbtVisible('Images');
-      });
+      cy.get('[data-qa-header]')
+        .should('be.visible')
+        .within(() => {
+          cy.findByText('Images').should('be.visible');
+        });
 
-      getVisible('[data-qa-header]').within(() => {
-        fbtVisible('Images');
-      });
+      cy.get('[data-qa-header]')
+        .should('be.visible')
+        .within(() => {
+          cy.findByText('Images').should('be.visible');
+        });
+
       cy.wait('@getImages');
-      fbtClick('Create Image');
-      fbtClick('Select a Linode').type(`${linode.label}{enter}`);
+      cy.findByText('Create Image').click();
+      cy.findByText('Select a Linode').click().type(`${linode.label}{enter}`);
       cy.wait('@getDisks');
-      containsClick('Select a Disk').type(`${diskLabel}{enter}`);
+      cy.contains('Select a Disk').click().type(`${diskLabel}{enter}`);
       cy.findAllByLabelText('Label', { exact: false }).type(
         `${imageLabel}{enter}`
       );
       cy.findAllByLabelText('Description').type(imageDescription);
-      getClick('[data-qa-submit="true"]');
+      cy.get('[data-qa-submit]').click();
       cy.wait('@createImage');
       cy.url().should('endWith', 'images');
       deleteLinodeById(linode.id);


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
This updates the Image capture smoke test for the React Query improvements that were recently made. It also cleans up some util functions that I'm gradually removing from tests.

## How to test 🧪

**How do I run relevant unit or e2e tests?**
```bash
yarn cy:run -s 'cypress/e2e/images/smoke-create-image.spec.ts'
```
