### PR TITLE
dep: Manually pin `@braintree/sanitize-url` to `6.0.2` for CVE-2022-48345

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "minimatch": "^3.0.5",
     "nth-check": "^2.0.1",
     "@types/react": "^17",
-    "loader-utils": "^2.0.4"
+    "loader-utils": "^2.0.4",
+    "@braintree/sanitize-url": "^6.0.2"
   },
   "workspaces": {
     "packages": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1183,10 +1183,10 @@
   resolved "https://registry.yarnpkg.com/@braintree/iframer/-/iframer-1.1.0.tgz#7e59b975c2a48bd92616f653367a5214fc2ddd4b"
   integrity sha512-tVpr7U6u6bqeQlHreEjYMNtnHX62vLnNWziY2kQLqkWhvusPuY5DfuGEIPpWqsd+V/a1slyTQaxK6HWTlH6A/Q==
 
-"@braintree/sanitize-url@6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-6.0.0.tgz#fe364f025ba74f6de6c837a84ef44bdb1d61e68f"
-  integrity sha512-mgmE7XBYY/21erpzhexk4Cj1cyTQ9LzvnTxtzM17BJ7ERMNE6W72mQRo0I1Ud8eFJ+RVVIcBNhLFZ3GX4XFz5w==
+"@braintree/sanitize-url@6.0.0", "@braintree/sanitize-url@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-6.0.2.tgz#6110f918d273fe2af8ea1c4398a88774bb9fc12f"
+  integrity sha512-Tbsj02wXCbqGmzdnXNk0SOF19ChhRU70BsroIi4Pm6Ehp56in6vch94mfbdQ17DozxkL3BAVjbZ4Qc1a0HFRAg==
 
 "@braintree/uuid@0.1.0", "@braintree/uuid@^0.1.0":
   version "0.1.0"


### PR DESCRIPTION
## Description 📝

- Manually pin `@braintree/sanitize-url` to `6.0.2` for CVE-2022-48345
- We need to do this because `braintree-web` has had no activity sadly
  - https://github.com/braintree/braintree-web/pull/672

## How to test 🧪

- In the dev environment, try adding payment methods and try making payments with braintree test cards
  - https://developer.paypal.com/braintree/docs/guides/credit-cards/testing-go-live/php#valid-card-numbers
