### PR TITLE
fix: Improve Cypress Managed SSH Test Flake

### DIFF
--- a/packages/manager/cypress/e2e/managed/managed-ssh.spec.ts
+++ b/packages/manager/cypress/e2e/managed/managed-ssh.spec.ts
@@ -2,6 +2,7 @@
  * @file Integration tests for Managed SSH access.
  */
 
+import type { ManagedLinodeSetting } from '@linode/api-v4/types';
 import {
   managedLinodeSettingFactory,
   managedSSHSettingFactory,
@@ -48,19 +49,18 @@ describe('Managed SSH Access tab', () => {
    */
   it('shows Managed SSH access info and list of Linodes', () => {
     const sshKey = randomPublicSshKey();
+    const mockManagedLinodes = managedLinodeSettingFactory.buildList(5);
 
     // Confirm that public SSH key is shown, and managed Linodes are shown.
     mockGetSshPublicKey(sshKey).as('getSshPublicKey');
-    mockGetLinodeSettings(managedLinodeSettingFactory.buildList(5)).as(
-      'getLinodeSettings'
-    );
+    mockGetLinodeSettings(mockManagedLinodes).as('getLinodeSettings');
+
     visitUrlWithManagedEnabled('/managed/ssh-access');
     cy.wait(['@getSshPublicKey', '@getLinodeSettings']);
 
     cy.findByText(sshKey).should('be.visible');
-
-    [0, 1, 2, 3, 4].forEach((managedLinodeId) => {
-      cy.findByText(`Managed Linode ${managedLinodeId}`).should('be.visible');
+    mockManagedLinodes.forEach((mockManagedLinode: ManagedLinodeSetting) => {
+      cy.findByText(mockManagedLinode.label).should('be.visible');
     });
 
     // Reset mocks, reload page, confirm that no managed Linodes are shown.

--- a/packages/manager/cypress/support/api/managed.ts
+++ b/packages/manager/cypress/support/api/managed.ts
@@ -33,7 +33,7 @@ export const visitUrlWithManagedEnabled = (url: string) => {
  * @param url - URL to visit.
  */
 export const visitUrlWithManagedDisabled = (url: string) => {
-  mockGetUserPreferences(nonManagedAccount).as('getAccountSettings');
+  mockGetAccountSettings(nonManagedAccount).as('getAccountSettings');
   cy.visitWithLogin(url);
   cy.wait('@getAccountSettings');
 };


### PR DESCRIPTION
## Description 📝

**What does this PR do?**

- Fixes an issue where an initial failure in the Managed SSH test causes subsequent attempts to be guaranteed to fail. This is because the test assumes the IDs of some mock data created using factory.ts, but factory.ts's sequence numbers do not automatically reset between attempts
- Fixes a typo involving a mock; this never manifested as a failure before since the real data matches the desired mock data in this case

## How to test 🧪

**How do I run relevant unit or e2e tests?**
```bash
yarn cy:run -s "cypress/e2e/managed/managed-ssh.spec.ts,cypress/e2e/managed/managed-navigation.spec.ts"
```
