### PR TITLE
fix: [M3-6166] - Revert select changes to logo brand update

### DIFF
--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -260,8 +260,7 @@ export const PrimaryNav: React.FC<Props> = (props) => {
     >
       <Grid item>
         <div
-          className={classNames({
-            [classes.logoItemAkamai]: !isCollapsed,
+          className={classNames(classes.logoItemAkamai, {
             [classes.logoItemAkamaiCollapsed]: isCollapsed,
           })}
         >
@@ -275,8 +274,7 @@ export const PrimaryNav: React.FC<Props> = (props) => {
             })}
           >
             <AkamaiLogo
-              width={140}
-              height={45}
+              width={128}
               className={classNames(
                 {
                   [classes.logoAkamaiCollapsed]: isCollapsed,


### PR DESCRIPTION
## Description 📝
Reverted regression changes for logo when we removed outdated code for brand update.

## Preview 📷
| Before      | After |
| ----------- | ----------- |
| <video src="https://user-images.githubusercontent.com/125309814/222316265-10b5c06c-d9e7-4f9d-be85-4608e5468041.mp4" /> | <video src="https://user-images.githubusercontent.com/125309814/220502069-781d4117-805c-4b66-8255-59f3fcee047a.mp4" /> |

## How to test 🧪
- Pull down branch
- Run `yarn up` to run locally
- Observe logo is back to normal
