### PR TITLE
fix: [M3-6216] - Cluster search regression

### DIFF
--- a/packages/manager/src/features/OneClickApps/FakeSpec.ts
+++ b/packages/manager/src/features/OneClickApps/FakeSpec.ts
@@ -11,6 +11,7 @@ export interface OCA {
   website?: string;
   colors: Colors;
   categories: AppCategory[];
+  cluster_name?: string;
 }
 
 export interface Doc {
@@ -1178,6 +1179,7 @@ export const oneClickApps: OCA[] = [
     alt_name: 'NoSQL database',
     alt_description: 'Popular document database.',
     categories: ['Databases'],
+    cluster_name: 'MongoDB Cluster',
     description: `MongoDB provides an alternative to traditional relational database management systems (RDBMS). In addition to its schema-free design and scalable architecture, MongoDB provides JSON output and specialized language-specific bindings that make it particularly attractive for use in custom application development and rapid prototyping.`,
     summary: `MongoDB is a database engine that provides access to non-relational, document-oriented databases.`,
     related_guides: [
@@ -1221,6 +1223,7 @@ export const oneClickApps: OCA[] = [
     alt_name: 'SQL database',
     alt_description: 'SQL database.',
     categories: ['Databases'],
+    cluster_name: 'Galera Cluster',
     description: `MySQL, or MariaDB for Linux distributions, is primarily used for web and server applications, including as a component of the industry-standard LAMP and LEMP stacks.`,
     summary: `World's most popular open source database.`,
     related_guides: [
@@ -1635,6 +1638,7 @@ export const oneClickApps: OCA[] = [
     alt_name: 'SQL database',
     alt_description: 'MySQL alternative for SQL database.',
     categories: ['Databases'],
+    cluster_name: 'PostgreSQL Cluster',
     description: `PostgreSQL is a popular open source relational database system that provides many advanced configuration options that can help optimize your database’s performance in a production environment.`,
     summary: `The PostgreSQL relational database system is a powerful, scalable, and standards-compliant open-source database platform.`,
     related_guides: [
@@ -1741,6 +1745,7 @@ export const oneClickApps: OCA[] = [
     alt_name: 'High performance database',
     alt_description: 'In-memory caching database.',
     categories: ['Databases'],
+    cluster_name: 'Redis Sentinel Cluster',
     description: `Redis is an open-source, in-memory, data-structure store, with the optional ability to write and persist data to a disk, which can be used as a key-value database, cache, and message broker. Redis features built-in transactions, replication, and support for a variety of data structures such as strings, hashes, lists, sets, and others.`,
     summary:
       'Flexible, in-memory, NoSQL database service supported in many different coding languages.',

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -228,10 +228,13 @@ class FromAppsContent extends React.Component<CombinedProps, State> {
         .split(' ');
 
       const matchingOCALabels = oneClickApps.reduce(
-        (acc: string[], { categories, name, alt_name, alt_description }) => {
-          const ocaAppString = `${name} ${alt_name} ${categories.join(
-            ' '
-          )} ${alt_description}`.toLocaleLowerCase();
+        (
+          acc: string[],
+          { categories, name, alt_name, alt_description, cluster_name }
+        ) => {
+          const ocaAppString = `${name} ${alt_name} ${
+            cluster_name || ''
+          } ${categories.join(' ')} ${alt_description}`.toLocaleLowerCase();
 
           const hasMatchingOCA = queryWords.every((queryWord) =>
             ocaAppString.includes(queryWord)
@@ -239,6 +242,9 @@ class FromAppsContent extends React.Component<CombinedProps, State> {
 
           if (hasMatchingOCA) {
             acc.push(name.trim());
+            if (cluster_name) {
+              acc.push(cluster_name.trim());
+            }
           }
 
           return acc;

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -274,7 +274,13 @@ class FromAppsContent extends React.Component<CombinedProps, State> {
       const appsInCategory = oneClickApps.filter((oca) =>
         oca.categories?.includes(categoryItem.value)
       );
-      const appLabels = appsInCategory.map((app) => app.name.trim());
+      const appLabels = appsInCategory.reduce((acc: string[], app: any) => {
+        if (app.cluster_name) {
+          acc.push(app.cluster_name.trim());
+        }
+        acc.push(app.name.trim());
+        return acc;
+      }, []);
       instancesInCategory = this.props.appInstances?.filter((instance) => {
         return appLabels.includes(instance.label.trim());
       });

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -241,7 +241,9 @@ class FromAppsContent extends React.Component<CombinedProps, State> {
           );
 
           if (hasMatchingOCA) {
-            acc.push(name.trim());
+            if (!queryWords.includes('cluster') || /cluster/i.test(name)) {
+              acc.push(name.trim());
+            }
             if (cluster_name) {
               acc.push(cluster_name.trim());
             }


### PR DESCRIPTION
## Description 📝
The One Click Clusters feature branch has been stale for a few months. So, when we pulled in changes from develop, there was a regression from when we added the ability to search by category & alt name/desc in https://github.com/linode/manager/pull/8657.

This PR fixes Cluster apps not showing up when trying to search for "cluster" or their app name/category (e.g. "MongoDB", "database", etc) by adding the `cluster_name` property to apps that can also be deployed as a Cluster

Note: The Cluster app StackScripts are still being worked on/finalized so there will be missing icons, etc.

## Preview 📷
![image](https://user-images.githubusercontent.com/115299789/222538165-a82bf9d6-8443-4f84-b0b3-c10fce5c09e2.png)

## How to test 🧪
Go to `/linodes/create?type=One-Click` and try searching for cluster/database/mongodb/postgre/redis/mysql/etc
