### PR TITLE
fix: Removed development branch and reverted to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,7 @@ name: ci
 on:
   push:
     branches:
-      - feature/validate-api-v4
-      # - master
+      - master
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Description 📝
Reverts temporary changes we made to `workflows/ci.yml` found here: https://github.com/linode/manager/pull/8677. We forgot to undo changes before merging.
