### PR TITLE
change: [M3-6218] - Temporarily change Remit To invoice address

### DIFF
--- a/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
@@ -59,8 +59,12 @@ const addLeftHeader = (
   const isInternational = !['US', 'CA'].includes(country);
 
   const getRemitAddress = (isAkamaiBilling: boolean) => {
+    if (!isAkamaiBilling) {
+      return ADDRESSES.linode;
+    }
     // M3-6218: Temporarily change "Remit To" address for US customers back to the Philly address
-    if (!isAkamaiBilling || country === 'US') {
+    if (country === 'US') {
+      ADDRESSES.linode.entity = 'Akamai Technologies, Inc.';
       return ADDRESSES.linode;
     }
     if (['CA'].includes(country)) {

--- a/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
@@ -58,11 +58,18 @@ const addLeftHeader = (
   const isAkamaiBilling = getShouldUseAkamaiBilling(date);
   const isInternational = !['US', 'CA'].includes(country);
 
-  const remitAddress = isAkamaiBilling
-    ? ['US', 'CA'].includes(country)
-      ? ADDRESSES.akamai.us
-      : ADDRESSES.akamai.international
-    : ADDRESSES.linode;
+  const getRemitAddress = (isAkamaiBilling: boolean) => {
+    // M3-6218: Temporarily change "Remit To" address for US customers back to the Philly address
+    if (!isAkamaiBilling || country === 'US') {
+      return ADDRESSES.linode;
+    }
+    if (['CA'].includes(country)) {
+      return ADDRESSES.akamai.us;
+    }
+    return ADDRESSES.akamai.international;
+  };
+
+  const remitAddress = getRemitAddress(isAkamaiBilling);
 
   addLine(remitAddress.entity);
   addLine(remitAddress.address1);


### PR DESCRIPTION
## Description 📝
Temporarily change the "Remit To" invoice address for US customers from the Akamai office back to the Philly office

## Preview 📷
Before
![image](https://user-images.githubusercontent.com/115299789/223260720-d00a942d-f483-40a0-a2f6-c2bcc6c1873d.png)

After
![image](https://user-images.githubusercontent.com/115299789/223563359-44357a7c-a316-48ce-8b99-33b27f803698.png)

## How to test 🧪
1. Go to /account/billing
2. Update Billing Contact address to a US address
3. Download PDF of an invoice
4. Check the "Remit To" address in the invoice, it should display the Philly office
5. Update Billing Contact address to a CA address
6. Download PDF of an invoice, the "Remit To" address should display the Akamai Cambridge office
7. Update Billing Contact address to an international address
8. Download PDF of an invoice, the "Remit To" address should display the Akamai international office
