### PR TITLE
feat: [M3-6146] - Add User Data to Linode Rebuild flow

### DIFF
--- a/packages/api-v4/src/linodes/types.ts
+++ b/packages/api-v4/src/linodes/types.ts
@@ -302,8 +302,8 @@ export interface IPAllocationRequest {
   public: boolean;
 }
 
-interface UserData {
-  user_data: string;
+export interface UserData {
+  user_data: string | null;
 }
 
 export interface CreateLinodeRequest {
@@ -345,6 +345,7 @@ export interface LinodeCloneData {
 export interface RebuildRequest {
   image: string;
   root_pass: string;
+  metadata?: UserData;
   authorized_keys?: SSHKey[];
   authorized_users?: string[];
   stackscript_id?: number;

--- a/packages/manager/src/components/CheckBox/CheckBox.tsx
+++ b/packages/manager/src/components/CheckBox/CheckBox.tsx
@@ -1,3 +1,4 @@
+import { SxProps } from '@mui/system';
 import classNames from 'classnames';
 import * as React from 'react';
 import CheckboxIcon from 'src/assets/icons/checkbox.svg';
@@ -39,10 +40,11 @@ interface Props extends CheckboxProps {
   text?: string | JSX.Element;
   toolTipText?: string | JSX.Element;
   toolTipInteractive?: boolean;
+  sxFormLabel?: SxProps;
 }
 
 const LinodeCheckBox = (props: Props) => {
-  const { toolTipInteractive, toolTipText, text, ...rest } = props;
+  const { toolTipInteractive, toolTipText, text, sxFormLabel, ...rest } = props;
   const classes = useStyles();
 
   const classnames = classNames({
@@ -67,6 +69,7 @@ const LinodeCheckBox = (props: Props) => {
             />
           }
           label={text}
+          sx={sxFormLabel}
         />
         {toolTipText ? (
           <HelpIcon interactive={toolTipInteractive} text={toolTipText} />

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.styles.ts
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.styles.ts
@@ -1,0 +1,8 @@
+import Notice from 'src/components/Notice';
+import { styled } from '@mui/material/styles';
+
+export const StyledNotice = styled(Notice)({
+  // @TODO: Remove the !important's once Notice.tsx has been refactored to use MUI's styled()
+  padding: '8px !important',
+  marginBottom: '0px !important',
+});

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
@@ -108,7 +108,7 @@ export const RebuildFromImage: React.FC<CombinedProps> = (props) => {
     setUserData(userData);
   };
 
-  const handleReuseUserDataChange = () => {
+  const handleShouldReuseUserDataChange = () => {
     setShouldReuseUserData((shouldReuseUserData) => !shouldReuseUserData);
   };
 
@@ -268,7 +268,7 @@ export const RebuildFromImage: React.FC<CombinedProps> = (props) => {
                       <Box>
                         <CheckBox
                           checked={shouldReuseUserData}
-                          onChange={handleReuseUserDataChange}
+                          onChange={handleShouldReuseUserDataChange}
                           text="Reuse user data previously provided for this Linode."
                           sxFormLabel={{ paddingLeft: '2px' }}
                         />

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
@@ -30,6 +30,7 @@ import {
 } from 'src/utilities/formikErrorUtils';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import { extendValidationSchema } from 'src/utilities/validatePassword';
+import Divider from 'src/components/core/Divider';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -102,7 +103,7 @@ export const RebuildFromImage: React.FC<CombinedProps> = (props) => {
   };
 
   const handleReuseUserDataChange = () => {
-    setReuseUserData(!reuseUserData);
+    setReuseUserData((reuseUserData) => !reuseUserData);
   };
 
   React.useEffect(() => {
@@ -133,6 +134,11 @@ export const RebuildFromImage: React.FC<CombinedProps> = (props) => {
         .filter((u) => u.selected)
         .map((u) => u.username),
     };
+
+    // If no user data has been added, do not include the metadata property in the payload.
+    if (!userData && !reuseUserData) {
+      delete params['metadata'];
+    }
 
     // @todo: eventually this should be a dispatched action instead of a services library call
     rebuildLinode(linodeId, params)
@@ -239,14 +245,18 @@ export const RebuildFromImage: React.FC<CombinedProps> = (props) => {
                 passwordHelperText={passwordHelperText}
               />
               {shouldDisplayUserDataAccordion ? (
-                <UserDataAccordion
-                  userData={userData}
-                  onChange={handleUserDataChange}
-                  flowSource="rebuild"
-                  reuseUserData={reuseUserData}
-                  onReuseUserDataChange={handleReuseUserDataChange}
-                  disabled={reuseUserData}
-                />
+                <>
+                  <Divider spacingTop={40} />
+                  <UserDataAccordion
+                    userData={userData}
+                    onChange={handleUserDataChange}
+                    reuseUserData={reuseUserData}
+                    onReuseUserDataChange={handleReuseUserDataChange}
+                    disabled={reuseUserData}
+                    renderNotice
+                    renderCheckbox
+                  />
+                </>
               ) : null}
               <ActionsPanel className={classes.actionPanel}>
                 <TypeToConfirm

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
@@ -266,13 +266,13 @@ export const RebuildFromImage: React.FC<CombinedProps> = (props) => {
                     userData={userData}
                     onChange={handleUserDataChange}
                     disabled={shouldReuseUserData}
-                    renderNotice={() => (
+                    renderNotice={
                       <StyledNotice
                         success
                         text="Adding new user data is recommended as part of the rebuild process."
                       />
-                    )}
-                    renderCheckbox={() => (
+                    }
+                    renderCheckbox={
                       <Box>
                         <CheckBox
                           checked={shouldReuseUserData}
@@ -281,7 +281,7 @@ export const RebuildFromImage: React.FC<CombinedProps> = (props) => {
                           sxFormLabel={{ paddingLeft: '2px' }}
                         />
                       </Box>
-                    )}
+                    }
                   />
                 </>
               ) : null}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
@@ -34,6 +34,7 @@ import {
 } from 'src/utilities/formikErrorUtils';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import { extendValidationSchema } from 'src/utilities/validatePassword';
+import { styled } from '@mui/material/styles';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -255,7 +256,7 @@ export const RebuildFromImage: React.FC<CombinedProps> = (props) => {
                     onChange={handleUserDataChange}
                     disabled={reuseUserData}
                     renderNotice={() => (
-                      <Notice
+                      <StyledNotice
                         success
                         text="Adding new user data is recommended as part of the rebuild process."
                       />
@@ -312,3 +313,9 @@ export const RebuildFromImage: React.FC<CombinedProps> = (props) => {
 const enhanced = compose<CombinedProps, Props>(userSSHKeyHoc);
 
 export default enhanced(RebuildFromImage);
+
+const StyledNotice = styled(Notice)({
+  // @TODO: Remove the !important's once Notice.tsx has been refactored to use MUI's styled()
+  padding: '8px !important',
+  marginBottom: '0px !important',
+});

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
@@ -18,7 +18,6 @@ import Divider from 'src/components/core/Divider';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Grid from 'src/components/Grid';
 import ImageSelect from 'src/components/ImageSelect';
-import Notice from 'src/components/Notice';
 import TypeToConfirm from 'src/components/TypeToConfirm';
 import { resetEventsPolling } from 'src/eventsPolling';
 import UserDataAccordion from 'src/features/linodes/UserDataAccordion';
@@ -34,7 +33,7 @@ import {
 } from 'src/utilities/formikErrorUtils';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import { extendValidationSchema } from 'src/utilities/validatePassword';
-import { styled } from '@mui/material/styles';
+import { StyledNotice } from './RebuildFromImage.styles';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -316,9 +315,3 @@ export const RebuildFromImage: React.FC<CombinedProps> = (props) => {
 const enhanced = compose<CombinedProps, Props>(userSSHKeyHoc);
 
 export default enhanced(RebuildFromImage);
-
-const StyledNotice = styled(Notice)({
-  // @TODO: Remove the !important's once Notice.tsx has been refactored to use MUI's styled()
-  padding: '8px !important',
-  marginBottom: '0px !important',
-});

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
@@ -133,16 +133,25 @@ export const RebuildFromImage: React.FC<CombinedProps> = (props) => {
       image,
       root_pass,
       metadata: {
-        user_data:
-          userData && !shouldReuseUserData ? window.btoa(userData) : null,
+        user_data: userData
+          ? window.btoa(userData)
+          : !userData && !shouldReuseUserData
+          ? null
+          : '',
       },
       authorized_users: userSSHKeys
         .filter((u) => u.selected)
         .map((u) => u.username),
     };
 
-    // If no user data has been added, do not include the metadata property in the payload.
-    if (!userData && !shouldReuseUserData) {
+    /*
+      User Data logic:
+      1) if user data has been provided, encode it and include it in the payload
+      2) if user data has not been provided and the Reuse User Data checkbox is
+        not checked, send null in the payload
+      3) if the Reuse User Data checkbox is checked, remove the Metadata property from the payload.
+    */
+    if (shouldReuseUserData) {
       delete params['metadata'];
     }
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
@@ -100,21 +100,23 @@ export const RebuildFromImage: React.FC<CombinedProps> = (props) => {
   const [confirmationText, setConfirmationText] = React.useState<string>('');
 
   const [userData, setUserData] = React.useState<string | undefined>('');
-  const [reuseUserData, setReuseUserData] = React.useState<boolean>(false);
+  const [shouldReuseUserData, setShouldReuseUserData] = React.useState<boolean>(
+    false
+  );
 
   const handleUserDataChange = (userData: string) => {
     setUserData(userData);
   };
 
   const handleReuseUserDataChange = () => {
-    setReuseUserData((reuseUserData) => !reuseUserData);
+    setShouldReuseUserData((shouldReuseUserData) => !shouldReuseUserData);
   };
 
   React.useEffect(() => {
-    if (reuseUserData) {
+    if (shouldReuseUserData) {
       setUserData('');
     }
-  }, [reuseUserData]);
+  }, [shouldReuseUserData]);
 
   const submitButtonDisabled =
     preferences?.type_to_confirm !== false && confirmationText !== linodeLabel;
@@ -132,7 +134,8 @@ export const RebuildFromImage: React.FC<CombinedProps> = (props) => {
       image,
       root_pass,
       metadata: {
-        user_data: userData && !reuseUserData ? window.btoa(userData) : null,
+        user_data:
+          userData && !shouldReuseUserData ? window.btoa(userData) : null,
       },
       authorized_users: userSSHKeys
         .filter((u) => u.selected)
@@ -140,7 +143,7 @@ export const RebuildFromImage: React.FC<CombinedProps> = (props) => {
     };
 
     // If no user data has been added, do not include the metadata property in the payload.
-    if (!userData && !reuseUserData) {
+    if (!userData && !shouldReuseUserData) {
       delete params['metadata'];
     }
 
@@ -254,7 +257,7 @@ export const RebuildFromImage: React.FC<CombinedProps> = (props) => {
                   <UserDataAccordion
                     userData={userData}
                     onChange={handleUserDataChange}
-                    disabled={reuseUserData}
+                    disabled={shouldReuseUserData}
                     renderNotice={() => (
                       <StyledNotice
                         success
@@ -264,7 +267,7 @@ export const RebuildFromImage: React.FC<CombinedProps> = (props) => {
                     renderCheckbox={() => (
                       <Box>
                         <CheckBox
-                          checked={reuseUserData}
+                          checked={shouldReuseUserData}
                           onChange={handleReuseUserDataChange}
                           text="Reuse user data previously provided for this Linode."
                           sxFormLabel={{ paddingLeft: '2px' }}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
@@ -12,9 +12,13 @@ import { compose } from 'recompose';
 import AccessPanel from 'src/components/AccessPanel';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
+import CheckBox from 'src/components/CheckBox';
+import Box from 'src/components/core/Box';
+import Divider from 'src/components/core/Divider';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Grid from 'src/components/Grid';
 import ImageSelect from 'src/components/ImageSelect';
+import Notice from 'src/components/Notice';
 import TypeToConfirm from 'src/components/TypeToConfirm';
 import { resetEventsPolling } from 'src/eventsPolling';
 import UserDataAccordion from 'src/features/linodes/UserDataAccordion';
@@ -30,7 +34,6 @@ import {
 } from 'src/utilities/formikErrorUtils';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import { extendValidationSchema } from 'src/utilities/validatePassword';
-import Divider from 'src/components/core/Divider';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -250,11 +253,23 @@ export const RebuildFromImage: React.FC<CombinedProps> = (props) => {
                   <UserDataAccordion
                     userData={userData}
                     onChange={handleUserDataChange}
-                    reuseUserData={reuseUserData}
-                    onReuseUserDataChange={handleReuseUserDataChange}
                     disabled={reuseUserData}
-                    renderNotice
-                    renderCheckbox
+                    renderNotice={() => (
+                      <Notice
+                        success
+                        text="Adding new user data is recommended as part of the rebuild process."
+                      />
+                    )}
+                    renderCheckbox={() => (
+                      <Box>
+                        <CheckBox
+                          checked={reuseUserData}
+                          onChange={handleReuseUserDataChange}
+                          text="Reuse user data previously provided for this Linode."
+                          sxFormLabel={{ paddingLeft: '2px' }}
+                        />
+                      </Box>
+                    )}
                   />
                 </>
               ) : null}

--- a/packages/manager/src/features/linodes/UserDataAccordion.styles.ts
+++ b/packages/manager/src/features/linodes/UserDataAccordion.styles.ts
@@ -1,0 +1,10 @@
+import { styled } from '@mui/material/styles';
+import HelpIcon from 'src/components/HelpIcon';
+
+export const StyledHelpIcon = styled(HelpIcon)({
+  padding: '0px 0px 4px 8px',
+  '& svg': {
+    fill: 'currentColor',
+    stroke: 'none',
+  },
+});

--- a/packages/manager/src/features/linodes/UserDataAccordion.test.tsx
+++ b/packages/manager/src/features/linodes/UserDataAccordion.test.tsx
@@ -3,13 +3,9 @@ import { renderWithTheme } from 'src/utilities/testHelpers';
 import UserDataAccordion from 'src/features/linodes/UserDataAccordion';
 
 describe('UserDataAccordion', () => {
-  it('should have a notice recommending new user data be used when a Linode is being rebuilt', () => {
+  it('should have a notice recommending new user data be used when the renderNotice prop is passed in', () => {
     const { getByText } = renderWithTheme(
-      <UserDataAccordion
-        userData={''}
-        onChange={() => null}
-        flowSource="rebuild"
-      />
+      <UserDataAccordion userData={''} onChange={() => null} renderNotice />
     );
 
     expect(
@@ -19,7 +15,7 @@ describe('UserDataAccordion', () => {
     ).toBeInTheDocument();
   });
 
-  it('should NOT have a notice recommending new user data be used if a Linode is not being rebuilt', () => {
+  it('should NOT have a notice recommending new user data be used when the renderNotice prop is not passed in', () => {
     const { queryByText } = renderWithTheme(
       <UserDataAccordion userData={''} onChange={() => null} />
     );

--- a/packages/manager/src/features/linodes/UserDataAccordion.test.tsx
+++ b/packages/manager/src/features/linodes/UserDataAccordion.test.tsx
@@ -20,12 +20,12 @@ describe('UserDataAccordion', () => {
   });
 
   it('should NOT have a notice recommending new user data be used if a Linode is not being rebuilt', () => {
-    const { getByText } = renderWithTheme(
+    const { queryByText } = renderWithTheme(
       <UserDataAccordion userData={''} onChange={() => null} />
     );
 
     expect(
-      getByText(
+      queryByText(
         'Adding new user data is recommended as part of the rebuild process.'
       )
     ).not.toBeInTheDocument();

--- a/packages/manager/src/features/linodes/UserDataAccordion.test.tsx
+++ b/packages/manager/src/features/linodes/UserDataAccordion.test.tsx
@@ -3,27 +3,11 @@ import { renderWithTheme } from 'src/utilities/testHelpers';
 import UserDataAccordion from 'src/features/linodes/UserDataAccordion';
 
 describe('UserDataAccordion', () => {
-  it('should have a notice recommending new user data be used when the renderNotice prop is passed in', () => {
-    const { getByText } = renderWithTheme(
-      <UserDataAccordion userData={''} onChange={() => null} renderNotice />
-    );
-
-    expect(
-      getByText(
-        'Adding new user data is recommended as part of the rebuild process.'
-      )
-    ).toBeInTheDocument();
-  });
-
-  it('should NOT have a notice recommending new user data be used when the renderNotice prop is not passed in', () => {
-    const { queryByText } = renderWithTheme(
+  it('should not have a notice when a renderNotice prop is not passed in', () => {
+    const { getByTestId } = renderWithTheme(
       <UserDataAccordion userData={''} onChange={() => null} />
     );
 
-    expect(
-      queryByText(
-        'Adding new user data is recommended as part of the rebuild process.'
-      )
-    ).not.toBeInTheDocument();
+    expect(getByTestId('render-notice')).not.toBeInTheDocument();
   });
 });

--- a/packages/manager/src/features/linodes/UserDataAccordion.test.tsx
+++ b/packages/manager/src/features/linodes/UserDataAccordion.test.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+import UserDataAccordion from 'src/features/linodes/UserDataAccordion';
+
+describe('UserDataAccordion', () => {
+  it('should have a notice recommending new user data be used when a Linode is being rebuilt', () => {
+    const { getByText } = renderWithTheme(
+      <UserDataAccordion
+        userData={''}
+        onChange={() => null}
+        flowSource="rebuild"
+      />
+    );
+
+    expect(
+      getByText(
+        'Adding new user data is recommended as part of the rebuild process.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('should NOT have a notice recommending new user data be used if a Linode is not being rebuilt', () => {
+    const { getByText } = renderWithTheme(
+      <UserDataAccordion userData={''} onChange={() => null} />
+    );
+
+    expect(
+      getByText(
+        'Adding new user data is recommended as part of the rebuild process.'
+      )
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/manager/src/features/linodes/UserDataAccordion.test.tsx
+++ b/packages/manager/src/features/linodes/UserDataAccordion.test.tsx
@@ -3,11 +3,11 @@ import { renderWithTheme } from 'src/utilities/testHelpers';
 import UserDataAccordion from 'src/features/linodes/UserDataAccordion';
 
 describe('UserDataAccordion', () => {
-  it('should not have a notice when a renderNotice prop is not passed in', () => {
-    const { getByTestId } = renderWithTheme(
+  it('should NOT have a notice when a renderNotice prop is not passed in', () => {
+    const { queryByTestId } = renderWithTheme(
       <UserDataAccordion userData={''} onChange={() => null} />
     );
 
-    expect(getByTestId('render-notice')).not.toBeInTheDocument();
+    expect(queryByTestId('render-notice')).toBeNull();
   });
 });

--- a/packages/manager/src/features/linodes/UserDataAccordion.tsx
+++ b/packages/manager/src/features/linodes/UserDataAccordion.tsx
@@ -43,19 +43,6 @@ const accordionHeading = (
   </>
 );
 
-const StyledBox = styled(Box)({
-  '.MuiFormControlLabel-root': {
-    paddingLeft: 2,
-  },
-});
-
-const StyledDiv = styled('div')({
-  '& .notice': {
-    padding: '8px !important',
-    marginBottom: '0px !important',
-  },
-});
-
 const UserDataAccordion = (props: Props) => {
   const {
     disabled,
@@ -89,6 +76,10 @@ const UserDataAccordion = (props: Props) => {
     }
   };
 
+  const sxDetails = {
+    padding: `0px 24px 24px ${renderNotice ? 0 : 24}px`,
+  };
+
   return (
     <Accordion
       heading={accordionHeading}
@@ -99,11 +90,7 @@ const UserDataAccordion = (props: Props) => {
       summaryProps={{
         sx: { padding: '5px 24px 0px 24px' },
       }}
-      detailProps={{
-        sx: renderNotice
-          ? { padding: '0px 24px 24px 0px' }
-          : { padding: '0px 24px 24px 24px' },
-      }}
+      detailProps={{ sx: sxDetails }}
       sx={{
         '&:before': {
           display: 'none',
@@ -111,13 +98,13 @@ const UserDataAccordion = (props: Props) => {
       }}
     >
       {renderNotice ? (
-        <StyledDiv>
+        <div>
           <Notice
             success
             text="Adding new user data is recommended as part of the rebuild process."
           />
           {acceptedFormatsCopy}
-        </StyledDiv>
+        </div>
       ) : (
         <>
           {userDataExplanatoryCopy}
@@ -146,13 +133,14 @@ const UserDataAccordion = (props: Props) => {
         data-qa-user-data-input
       />
       {renderCheckbox ? (
-        <StyledBox>
+        <Box>
           <CheckBox
             checked={reuseUserData}
             onChange={onReuseUserDataChange}
             text="Reuse user data previously provided for this Linode."
+            sxFormLabel={{ paddingLeft: '2px' }}
           />
-        </StyledBox>
+        </Box>
       ) : null}
     </Accordion>
   );

--- a/packages/manager/src/features/linodes/UserDataAccordion.tsx
+++ b/packages/manager/src/features/linodes/UserDataAccordion.tsx
@@ -1,11 +1,10 @@
-import { styled } from '@mui/material/styles';
 import * as React from 'react';
 import Accordion from 'src/components/Accordion';
 import Typography from 'src/components/core/Typography';
-import HelpIcon from 'src/components/HelpIcon';
 import Link from 'src/components/Link';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
+import { StyledHelpIcon } from './UserDataAccordion.styles';
 
 interface Props {
   userData: string | undefined;
@@ -14,30 +13,6 @@ interface Props {
   renderNotice?: () => JSX.Element;
   renderCheckbox?: () => JSX.Element;
 }
-
-const StyledHelpIcon = styled(HelpIcon)({
-  padding: '0px 0px 4px 8px',
-  '& svg': {
-    fill: 'currentColor',
-    stroke: 'none',
-  },
-});
-
-const accordionHeading = (
-  <>
-    Add User Data{' '}
-    <StyledHelpIcon
-      text={
-        <>
-          User data is part of a virtual machine&rsquo;s cloud-init metadata
-          containing information related to a user&rsquo;s local account.{' '}
-          <Link to="/">Learn more.</Link>
-        </>
-      }
-      interactive
-    />
-  </>
-);
 
 const UserDataAccordion = (props: Props) => {
   const { disabled, userData, onChange, renderNotice, renderCheckbox } = props;
@@ -118,6 +93,22 @@ const UserDataAccordion = (props: Props) => {
 };
 
 export default UserDataAccordion;
+
+const accordionHeading = (
+  <>
+    Add User Data{' '}
+    <StyledHelpIcon
+      text={
+        <>
+          User data is part of a virtual machine&rsquo;s cloud-init metadata
+          containing information related to a user&rsquo;s local account.{' '}
+          <Link to="/">Learn more.</Link>
+        </>
+      }
+      interactive
+    />
+  </>
+);
 
 const userDataExplanatoryCopy = (
   <Typography>

--- a/packages/manager/src/features/linodes/UserDataAccordion.tsx
+++ b/packages/manager/src/features/linodes/UserDataAccordion.tsx
@@ -1,39 +1,70 @@
+import { styled } from '@mui/material/styles';
 import * as React from 'react';
 import Accordion from 'src/components/Accordion';
-import { makeStyles } from 'src/components/core/styles';
+import CheckBox from 'src/components/CheckBox';
+import Box from 'src/components/core/Box';
 import Typography from 'src/components/core/Typography';
 import HelpIcon from 'src/components/HelpIcon';
-import Notice from 'src/components/Notice';
 import Link from 'src/components/Link';
+import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
 
 interface Props {
   userData: string | undefined;
   onChange: (userData: string) => void;
   disabled?: boolean;
+  flowSource?: 'rebuild' | null;
+  reuseUserData?: boolean;
+  onReuseUserDataChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-const useStyles = makeStyles(() => ({
-  helpIcon: {
-    padding: '0px 0px 4px 8px',
-    '& svg': {
-      fill: 'currentColor',
-      stroke: 'none',
-    },
+const StyledHelpIcon = styled(HelpIcon)({
+  padding: '0px 0px 4px 8px',
+  '& svg': {
+    fill: 'currentColor',
+    stroke: 'none',
   },
-  accordionSummary: {
-    padding: '5px 24px 0px 24px',
+});
+
+const accordionHeading = (
+  <>
+    Add User Data{' '}
+    <StyledHelpIcon
+      text={
+        <>
+          User data is part of a virtual machine&rsquo;s cloud-init metadata
+          containing information related to a user&rsquo;s local account.{' '}
+          <Link to="/">Learn more.</Link>
+        </>
+      }
+      interactive
+    />
+  </>
+);
+
+const StyledBox = styled(Box)({
+  '.MuiFormControlLabel-root': {
+    paddingLeft: 2,
   },
-  accordionDetail: {
-    padding: '0px 24px 24px 24px',
+});
+
+const StyledDiv = styled('div')({
+  '& .notice': {
+    padding: '8px !important',
+    marginBottom: '0px !important',
   },
-}));
+});
 
 const UserDataAccordion = (props: Props) => {
-  const { disabled, userData, onChange } = props;
+  const {
+    disabled,
+    userData,
+    onChange,
+    flowSource,
+    reuseUserData,
+    onReuseUserDataChange,
+  } = props;
   const [formatWarning, setFormatWarning] = React.useState(false);
-
-  const classes = useStyles();
 
   const checkFormat = ({
     userData,
@@ -56,23 +87,6 @@ const UserDataAccordion = (props: Props) => {
     }
   };
 
-  const accordionHeading = (
-    <>
-      Add User Data{' '}
-      <HelpIcon
-        text={
-          <>
-            User data is part of a virtual machine&rsquo;s cloud-init metadata
-            containing information related to a user&rsquo;s local account.{' '}
-            <Link to="/">Learn more.</Link>
-          </>
-        }
-        className={classes.helpIcon}
-        interactive
-      />
-    </>
-  );
-
   return (
     <Accordion
       heading={accordionHeading}
@@ -81,25 +95,29 @@ const UserDataAccordion = (props: Props) => {
         variant: 'h2',
       }}
       summaryProps={{
-        classes: {
-          root: classes.accordionSummary,
-        },
+        sx: { padding: '5px 24px 0px 24px' },
       }}
       detailProps={{
-        classes: {
-          root: classes.accordionDetail,
-        },
+        sx:
+          flowSource !== 'rebuild'
+            ? { padding: '0px 24px 24px 24px' }
+            : { padding: '0px 24px 24px 0px' },
       }}
     >
-      <Typography>
-        <Link to="https://cloudinit.readthedocs.io/en/latest/reference/examples.html">
-          User Data
-        </Link>{' '}
-        is part of a virtual machine&rsquo;s cloud-init metadata that contains
-        anything related to a user&rsquo;s local account, including username and
-        user group(s). <br /> Accepted formats are YAML and bash.{' '}
-        <Link to="https://www.linode.com/docs">Learn more.</Link>
-      </Typography>
+      {flowSource !== 'rebuild' ? (
+        <>
+          {userDataExplanatoryCopy}
+          {acceptedFormatsCopy}
+        </>
+      ) : (
+        <StyledDiv>
+          <Notice
+            success
+            text="Adding new user data is recommended as part of the rebuild process."
+          />
+          {acceptedFormatsCopy}
+        </StyledDiv>
+      )}
       {formatWarning ? (
         <Notice warning spacingTop={16} spacingBottom={16}>
           This user data may not be in a format accepted by cloud-init.
@@ -121,8 +139,35 @@ const UserDataAccordion = (props: Props) => {
         }
         data-qa-user-data-input
       />
+      {flowSource === 'rebuild' ? (
+        <StyledBox>
+          <CheckBox
+            checked={reuseUserData}
+            onChange={onReuseUserDataChange}
+            text="Reuse user data previously provided for this Linode."
+          />
+        </StyledBox>
+      ) : null}
     </Accordion>
   );
 };
 
 export default UserDataAccordion;
+
+const userDataExplanatoryCopy = (
+  <Typography>
+    <Link to="https://cloudinit.readthedocs.io/en/latest/reference/examples.html">
+      User Data
+    </Link>{' '}
+    is part of a virtual machine&rsquo;s cloud-init metadata that contains
+    anything related to a user&rsquo;s local account, including username and
+    user group(s).
+  </Typography>
+);
+
+const acceptedFormatsCopy = (
+  <Typography>
+    <br /> Accepted formats are YAML and bash.{' '}
+    <Link to="https://www.linode.com/docs">Learn more.</Link>
+  </Typography>
+);

--- a/packages/manager/src/features/linodes/UserDataAccordion.tsx
+++ b/packages/manager/src/features/linodes/UserDataAccordion.tsx
@@ -10,8 +10,8 @@ interface Props {
   userData: string | undefined;
   onChange: (userData: string) => void;
   disabled?: boolean;
-  renderNotice?: () => JSX.Element;
-  renderCheckbox?: () => JSX.Element;
+  renderNotice?: JSX.Element;
+  renderCheckbox?: JSX.Element;
 }
 
 const UserDataAccordion = (props: Props) => {
@@ -61,7 +61,7 @@ const UserDataAccordion = (props: Props) => {
       }}
     >
       {renderNotice ? (
-        <div data-testid="render-notice">{renderNotice()}</div>
+        <div data-testid="render-notice">{renderNotice}</div>
       ) : (
         userDataExplanatoryCopy
       )}
@@ -87,7 +87,7 @@ const UserDataAccordion = (props: Props) => {
         }
         data-qa-user-data-input
       />
-      {renderCheckbox ? renderCheckbox() : null}
+      {renderCheckbox ?? null}
     </Accordion>
   );
 };

--- a/packages/manager/src/features/linodes/UserDataAccordion.tsx
+++ b/packages/manager/src/features/linodes/UserDataAccordion.tsx
@@ -1,8 +1,6 @@
 import { styled } from '@mui/material/styles';
 import * as React from 'react';
 import Accordion from 'src/components/Accordion';
-import CheckBox from 'src/components/CheckBox';
-import Box from 'src/components/core/Box';
 import Typography from 'src/components/core/Typography';
 import HelpIcon from 'src/components/HelpIcon';
 import Link from 'src/components/Link';
@@ -13,10 +11,8 @@ interface Props {
   userData: string | undefined;
   onChange: (userData: string) => void;
   disabled?: boolean;
-  reuseUserData?: boolean;
-  onReuseUserDataChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  renderNotice?: boolean;
-  renderCheckbox?: boolean;
+  renderNotice?: () => JSX.Element;
+  renderCheckbox?: () => JSX.Element;
 }
 
 const StyledHelpIcon = styled(HelpIcon)({
@@ -44,15 +40,7 @@ const accordionHeading = (
 );
 
 const UserDataAccordion = (props: Props) => {
-  const {
-    disabled,
-    userData,
-    onChange,
-    reuseUserData,
-    onReuseUserDataChange,
-    renderNotice,
-    renderCheckbox,
-  } = props;
+  const { disabled, userData, onChange, renderNotice, renderCheckbox } = props;
   const [formatWarning, setFormatWarning] = React.useState(false);
 
   const checkFormat = ({
@@ -98,19 +86,11 @@ const UserDataAccordion = (props: Props) => {
       }}
     >
       {renderNotice ? (
-        <div>
-          <Notice
-            success
-            text="Adding new user data is recommended as part of the rebuild process."
-          />
-          {acceptedFormatsCopy}
-        </div>
+        <div data-testid="render-notice">{renderNotice()}</div>
       ) : (
-        <>
-          {userDataExplanatoryCopy}
-          {acceptedFormatsCopy}
-        </>
+        userDataExplanatoryCopy
       )}
+      {acceptedFormatsCopy}
       {formatWarning ? (
         <Notice warning spacingTop={16} spacingBottom={16}>
           This user data may not be in a format accepted by cloud-init.
@@ -132,16 +112,7 @@ const UserDataAccordion = (props: Props) => {
         }
         data-qa-user-data-input
       />
-      {renderCheckbox ? (
-        <Box>
-          <CheckBox
-            checked={reuseUserData}
-            onChange={onReuseUserDataChange}
-            text="Reuse user data previously provided for this Linode."
-            sxFormLabel={{ paddingLeft: '2px' }}
-          />
-        </Box>
-      ) : null}
+      {renderCheckbox ? renderCheckbox() : null}
     </Accordion>
   );
 };

--- a/packages/manager/src/features/linodes/UserDataAccordion.tsx
+++ b/packages/manager/src/features/linodes/UserDataAccordion.tsx
@@ -13,9 +13,10 @@ interface Props {
   userData: string | undefined;
   onChange: (userData: string) => void;
   disabled?: boolean;
-  flowSource?: 'rebuild' | null;
   reuseUserData?: boolean;
   onReuseUserDataChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  renderNotice?: boolean;
+  renderCheckbox?: boolean;
 }
 
 const StyledHelpIcon = styled(HelpIcon)({
@@ -60,9 +61,10 @@ const UserDataAccordion = (props: Props) => {
     disabled,
     userData,
     onChange,
-    flowSource,
     reuseUserData,
     onReuseUserDataChange,
+    renderNotice,
+    renderCheckbox,
   } = props;
   const [formatWarning, setFormatWarning] = React.useState(false);
 
@@ -90,7 +92,7 @@ const UserDataAccordion = (props: Props) => {
   return (
     <Accordion
       heading={accordionHeading}
-      style={{ marginTop: 24 }}
+      style={{ marginTop: renderNotice && renderCheckbox ? 0 : 24 }} // for now, these props can be taken as an indicator we're in the Rebuild flow.
       headingProps={{
         variant: 'h2',
       }}
@@ -98,18 +100,17 @@ const UserDataAccordion = (props: Props) => {
         sx: { padding: '5px 24px 0px 24px' },
       }}
       detailProps={{
-        sx:
-          flowSource !== 'rebuild'
-            ? { padding: '0px 24px 24px 24px' }
-            : { padding: '0px 24px 24px 0px' },
+        sx: renderNotice
+          ? { padding: '0px 24px 24px 0px' }
+          : { padding: '0px 24px 24px 24px' },
+      }}
+      sx={{
+        '&:before': {
+          display: 'none',
+        },
       }}
     >
-      {flowSource !== 'rebuild' ? (
-        <>
-          {userDataExplanatoryCopy}
-          {acceptedFormatsCopy}
-        </>
-      ) : (
+      {renderNotice ? (
         <StyledDiv>
           <Notice
             success
@@ -117,6 +118,11 @@ const UserDataAccordion = (props: Props) => {
           />
           {acceptedFormatsCopy}
         </StyledDiv>
+      ) : (
+        <>
+          {userDataExplanatoryCopy}
+          {acceptedFormatsCopy}
+        </>
       )}
       {formatWarning ? (
         <Notice warning spacingTop={16} spacingBottom={16}>
@@ -139,7 +145,7 @@ const UserDataAccordion = (props: Props) => {
         }
         data-qa-user-data-input
       />
-      {flowSource === 'rebuild' ? (
+      {renderCheckbox ? (
         <StyledBox>
           <CheckBox
             checked={reuseUserData}

--- a/packages/validation/src/linodes.schema.ts
+++ b/packages/validation/src/linodes.schema.ts
@@ -79,7 +79,7 @@ export const UpdateLinodePasswordSchema = object({
 });
 
 const MetadataSchema = object({
-  user_data: string().notRequired(),
+  user_data: string().notRequired().nullable(true),
 });
 
 export const CreateLinodeSchema = object({
@@ -194,6 +194,7 @@ export const RebuildLinodeSchema = object().shape({
   stackscript_id: number().notRequired(),
   stackscript_data,
   booted: boolean().notRequired(),
+  metadata: MetadataSchema,
 });
 
 export const RebuildLinodeFromStackScriptSchema = RebuildLinodeSchema.shape({


### PR DESCRIPTION
## Description 📝
Adds User Data section to the Linode Rebuild flow when an image with `cloud-init` capability is selected.

## Preview 📷
![Screenshot 2023-03-07 at 11 33 22 AM](https://user-images.githubusercontent.com/114682940/223487141-234304c0-911c-4a2c-ae13-f70efe967406.jpg)

## To-Do
- [x] Add unit tests

## How to test 🧪
- Ensure that the existing User Data work elsewhere in the app has not been adversely impacted by changes made on this branch
- Confirm that Linode rebuild requests go through with the `{ metadata: { user_data: [encoded string ...] } }` property (or `null` instead of encoded string when the Reuse checkbox is marked)
