### PR TITLE
refactor: [M3-6228] - Use Mock Linode Data for Managed Service Transfer Test

### DIFF
--- a/packages/manager/cypress/support/intercepts/linodes.ts
+++ b/packages/manager/cypress/support/intercepts/linodes.ts
@@ -2,6 +2,8 @@
  * @file Cypress intercepts and mocks for Cloud Manager Linode operations.
  */
 
+import { Linode } from '@linode/api-v4/types';
+import { makeResourcePage } from 'src/mocks/serverHandlers';
 import { apiMatcher } from 'support/util/intercepts';
 
 /**
@@ -11,4 +13,17 @@ import { apiMatcher } from 'support/util/intercepts';
  */
 export const interceptCreateLinode = (): Cypress.Chainable<null> => {
   return cy.intercept('POST', apiMatcher('linode/instances'));
+};
+
+/**
+ * Intercepts GET request to mock linode data.
+ *
+ * @param linodes - an array of mock linode objects
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetLinodes = (linodes: Linode[]): Cypress.Chainable<null> => {
+  return cy.intercept('GET', apiMatcher('linode/instances/*'), (req) => {
+    req.reply(makeResourcePage(linodes));
+  });
 };


### PR DESCRIPTION
## Description 📝

- Added mock linode data
- Used mock linode data in some tests of `service-transfer.spec.ts`


## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**
1. Mock a Linode.
2. Navigate to Service Transfer landing page with managed enable.
3. Make a service transfer.
4. An error message "You cannot initiate transfers with Managed enabled." is shown.

**How do I run relevant unit or e2e tests?**
Run command: `yarn cy:run -s "cypress/e2e/account/service-transfer.spec.ts"`
