### PR TITLE
refactor: [M3-6155] - Change Domain length validation to 253

### DIFF
--- a/packages/validation/src/domains.schema.ts
+++ b/packages/validation/src/domains.schema.ts
@@ -13,8 +13,8 @@ const domainSchemaBase = object().shape({
   status: mixed().oneOf(['disabled', 'active', 'edit_mode', 'has_errors']),
   tags: array(),
   description: string()
-    .min(1, 'Description must be between 1 and 255 characters.')
-    .max(255, 'Description must be between 1 and 255 characters.'),
+    .min(1, 'Description must be between 1 and 253 characters.')
+    .max(253, 'Description must be between 1 and 253 characters.'),
   retry_sec: number(),
   master_ips: array().of(string()),
   axfr_ips: array()


### PR DESCRIPTION
## Description 📝
Change domain length validation from 255 characters to 253 characters to match the API's length validation. See ticket for more details and discussion.
