### PR TITLE
refactor: Use `yarn start:manager:ci` for GitHub Actions E2E workflows

### DIFF
--- a/.github/workflows/e2e_schedule_and_push.yml
+++ b/.github/workflows/e2e_schedule_and_push.yml
@@ -52,7 +52,9 @@ jobs:
           echo "REACT_APP_LOGIN_ROOT=${{ secrets.REACT_APP_LOGIN_ROOT }}" >> ./packages/manager/.env
           echo "REACT_APP_API_ROOT=${{ secrets.REACT_APP_API_ROOT }}" >> ./packages/manager/.env
           echo "REACT_APP_APP_ROOT=${{ secrets.REACT_APP_APP_ROOT }}" >> ./packages/manager/.env
-          yarn up &
+          echo "REACT_APP_DISABLE_NEW_RELIC=1" >> ./packages/manager/.env
+          yarn build
+          yarn start:manager:ci &
       - name: Run tests
         uses: cypress-io/github-action@v4
         with:


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
This updates the GitHub Actions e2e test workflow that runs each morning and each time code is merged to `develop`, `staging`, and `master`. It replaces `yarn up` with `yarn build` followed by `yarn start:manager:ci`. We've observed better performance using this command, and it may sidestep the issues currently occurring with Cypress timing out.

## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**
The best we can really do is run the `yarn build`, etc., commands locally and hope they'll work just as well via GitHub Actions. We'll know pretty quickly once we merge this if there are any problems.