### PR TITLE
chore: [M3-5975] - Upgrade actions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,13 @@ jobs:
   build-validation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: "18.14"
       - run: yarn --frozen-lockfile
       - run: yarn workspace @linode/validation run build
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: packages-validation-lib
           path: |
@@ -57,17 +57,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-validation
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: "18.14"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             **/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn --frozen-lockfile
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: packages-validation-lib
           path: packages/validation
@@ -78,22 +78,22 @@ jobs:
     needs:
       - build-validation
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: "18.14"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             **/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: packages-validation-lib
           path: packages/validation
       - run: yarn --frozen-lockfile
       - run: yarn workspace @linode/api-v4 run build
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: packages-api-v4-lib
           path: |
@@ -106,17 +106,17 @@ jobs:
     needs:
       - build-sdk
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: "18.14"
 
       # Download the validation and api-v4 artifacts (built packages)
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: packages-validation-lib
           path: packages/validation
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: packages-api-v4-lib
           path: packages/api-v4
@@ -139,20 +139,20 @@ jobs:
     needs:
       - build-sdk
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: "18.14"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             **/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: packages-validation-lib
           path: packages/validation
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: packages-api-v4-lib
           path: packages/api-v4
@@ -168,7 +168,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: "18.14"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             **/node_modules
@@ -190,27 +190,27 @@ jobs:
     needs:
       - build-sdk
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: "18.14"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             **/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: cp packages/manager/config/environments/beta packages/manager/.env
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: packages-validation-lib
           path: packages/validation
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: packages-api-v4-lib
           path: packages/api-v4
       - run: yarn --frozen-lockfile
       - run: yarn workspace linode-manager run build
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: packages-manager-build
           path: packages/manager/build
@@ -224,8 +224,8 @@ jobs:
       # If the validation publish failed we could have mismatched versions and a broken JS client
       - publish-validation
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: packages-api-v4-lib
           path: packages/api-v4
@@ -252,26 +252,26 @@ jobs:
     needs:
       - build-sdk
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: "18.14"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             **/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: packages-validation-lib
           path: packages/validation
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: packages-api-v4-lib
           path: packages/api-v4
       - run: yarn --frozen-lockfile
       - run: yarn workspace linode-manager run build-storybook
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: storybook-build
           path: packages/manager/storybook-static
@@ -282,8 +282,8 @@ jobs:
     needs:
       - build-storybook
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: storybook-build
           path: storybook/build

--- a/.github/workflows/e2e_schedule_and_push.yml
+++ b/.github/workflows/e2e_schedule_and_push.yml
@@ -23,11 +23,11 @@ jobs:
       matrix:
         user: ["USER_1", "USER_2", "USER_3", "USER_4"]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: "18.14"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             node_modules
@@ -57,7 +57,7 @@ jobs:
           yarn build
           yarn start:manager:ci &
       - name: Run tests
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v5
         with:
           working-directory: packages/manager
           wait-on: "http://localhost:3000"


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
This upgrades the versions of the actions that we use in our CI and E2E workflows to resolve the warnings shown on our runs.

This is related to the PR I accidentally opened a few minutes ago. Sorry about that!

## Preview 📷

**Before:**
<img width="614" alt="Screen Shot 2023-03-09 at 9 18 42 AM" src="https://user-images.githubusercontent.com/97627410/224052895-be00214e-0651-4ff7-8778-c87ec31a0f3f.png">

**After:**
<img width="626" alt="Screen Shot 2023-03-09 at 9 18 22 AM" src="https://user-images.githubusercontent.com/97627410/224052927-bb59b84d-b9e4-4f56-b9ef-ab297d630af2.png">

## How to test 🧪

We can't really test the E2E workflow changes until after this PR gets merged. However, the CI changes will be included in the run against this PR so we'll have a partial view of whether things work before merging.