### PR TITLE
chore: [M3-6232] - Update `VolumeStatus` type and logic

### DIFF
--- a/packages/api-v4/src/volumes/types.ts
+++ b/packages/api-v4/src/volumes/types.ts
@@ -19,10 +19,8 @@ export type VolumeStatus =
   | 'creating'
   | 'active'
   | 'resizing'
-  | 'deleting'
-  | 'deleted'
   | 'migrating'
-  | 'contact_support';
+  | 'offline';
 
 export interface VolumeRequestPayload {
   label: string;

--- a/packages/manager/src/components/TableCell/TableCell.tsx
+++ b/packages/manager/src/components/TableCell/TableCell.tsx
@@ -57,6 +57,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
   },
   status: {
+    textTransform: 'capitalize',
     display: 'flex',
     alignItems: 'center',
     whiteSpace: 'nowrap',

--- a/packages/manager/src/features/Volumes/VolumeTableRow.tsx
+++ b/packages/manager/src/features/Volumes/VolumeTableRow.tsx
@@ -12,7 +12,7 @@ import TableRow from 'src/components/TableRow';
 import { formatRegion } from 'src/utilities';
 import VolumesActionMenu, { ActionHandlers } from './VolumesActionMenu';
 import SupportLink from 'src/components/SupportLink';
-import { Volume } from '@linode/api-v4/lib/volumes/types';
+import { Volume, VolumeStatus } from '@linode/api-v4/lib/volumes/types';
 // import useEvents from 'src/hooks/useEvents';
 
 export const useStyles = makeStyles({
@@ -60,9 +60,7 @@ export const volumeStatusIconMap: Record<Volume['status'], Status> = {
   resizing: 'other',
   migrating: 'other',
   creating: 'other',
-  contact_support: 'error',
-  deleting: 'other',
-  deleted: 'inactive',
+  offline: 'inactive',
 };
 
 export const VolumeTableRow = (props: CombinedProps) => {
@@ -97,16 +95,16 @@ export const VolumeTableRow = (props: CombinedProps) => {
   // const isUpdating = isVolumeUpdating(recentEvent);
   // const progress = progressFromEvent(recentEvent);
 
-  const volumeStatusMap: Record<Volume['status'], string | JSX.Element> = {
-    active: 'Active',
-    resizing: 'Resizing',
-    creating: 'Creating',
-    contact_support: (
-      <SupportLink text="Contact Support" entity={{ type: 'volume_id', id }} />
-    ),
-    deleting: 'Deleting',
-    deleted: 'Deleted',
-    migrating: 'Migrating',
+  const getVolumeStatus = (status: VolumeStatus) => {
+    if (status === 'offline') {
+      return (
+        <SupportLink
+          text="Contact Support"
+          entity={{ type: 'volume_id', id }}
+        />
+      );
+    }
+    return status.replace('_', ' ');
   };
 
   return (
@@ -125,7 +123,7 @@ export const VolumeTableRow = (props: CombinedProps) => {
       </TableCell>
       <TableCell statusCell>
         <StatusIcon status={volumeStatusIconMap[status]} />
-        {volumeStatusMap[status]}
+        {getVolumeStatus(status)}
       </TableCell>
       {isVolumesLanding && region ? (
         <TableCell data-qa-volume-region noWrap>

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -4,6 +4,7 @@ import {
   NotificationType,
   SecurityQuestionsPayload,
   TokenRequest,
+  VolumeStatus,
 } from '@linode/api-v4';
 import { RequestHandler, rest } from 'msw';
 import cachedRegions from 'src/cachedData/regions.json';
@@ -629,48 +630,14 @@ export const handlers = [
     );
   }),
   rest.get('*/volumes', (req, res, ctx) => {
-    const hddVolumeUnattached = volumeFactory.build({
-      id: 30,
-      label: 'hdd-unattached',
-    });
-    const hddVolumeAttached = volumeFactory.build({
-      id: 20,
-      linode_id: 20,
-      label: 'eligible-now-for-nvme',
-    });
-    const hddVolumeAttached2 = volumeFactory.build({
-      id: 2,
-      linode_id: 2,
-      label: 'example-upgrading',
-    });
-    const nvmeVolumeUpgrading = volumeFactory.build({
-      id: 2,
-      // hardware_type: 'nvme',
-    });
-    const newNVMeVolume = volumeFactory.build({
-      id: 1,
-      // hardware_type: 'nvme',
-    });
-
-    const volumes = [
-      newNVMeVolume,
-      nvmeVolumeUpgrading,
-      hddVolumeAttached,
-      hddVolumeAttached2,
-      hddVolumeUnattached,
-      volumeFactory.build({
-        status: 'contact_support',
-      }),
-      volumeFactory.build({
-        status: 'creating',
-      }),
-      volumeFactory.build({
-        status: 'deleting',
-      }),
-      volumeFactory.build({
-        status: 'resizing',
-      }),
+    const statuses: VolumeStatus[] = [
+      'active',
+      'creating',
+      'migrating',
+      'offline',
+      'resizing',
     ];
+    const volumes = statuses.map((status) => volumeFactory.build({ status }));
     return res(ctx.json(makeResourcePage(volumes)));
   }),
   rest.post('*/volumes', (req, res, ctx) => {


### PR DESCRIPTION
## Description 📝

- We were not in sync with what the API actually returns for Volume statuses
- This PR updates the api-v4 types
- Also updates cloud manager to be more dynamic in the way Volume statuses are handled

## Preview 📷

- No visual changes

## How to test 🧪

- `yarn test volume`

- Turn on the **MSW** to see all of the possible volume statuses on `/volumes`