### PR TITLE
chore: Run Typescript in watch mode for local development

### DIFF
--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -89,7 +89,7 @@
   "scripts": {
     "postinstall": "patch-package",
     "compare": "./scripts/jira-changelog.sh",
-    "start": "vite",
+    "start": "concurrently --raw \"vite\" \"tsc --watch --preserveWatchOutput\"",
     "start:ci": "yarn serve ./build -p 3000 -s --cors",
     "lint": "yarn run eslint . --ext .js,.ts,.tsx --quiet",
     "build": "node scripts/prebuild.mjs && vite build",


### PR DESCRIPTION
## Description 📝

- Runs the typescript compiler concurrently alongside the Vite dev server
- We are doing this so we can get instant feedback when we make changes that result in type errors
  - This is very useful when refactoring and making changes that affect other files in the codebase
- I chose this method over https://vite-plugin-checker.netlify.app/ for the following reasons
  - Saves us from needing yet another dependency
  - As a team, we decided we don't care for an error overlay
- If we find that tsc in watch mode has annoying behavior or output, we can revert this and give the plugin a try


> **Note**: Folloing this ticket, I will investinate to see if we would benefit from https://www.typescriptlang.org/docs/handbook/project-references.html

## Preview 📷

https://user-images.githubusercontent.com/115251059/224132664-7fb18929-25b7-4aa8-857d-f9bfc1b4cb84.mov

## How to test 🧪

- Checkout this PR
- Run `yarn dev`
- Make a change in Cloud Manager (or api-v4 or validation) that causes a type error
- Verify that you get feedback in your console showing the typescript errors
