### PR TITLE
chore: [M3-6210] - Update Cypress recommended Node version message

### DIFF
--- a/packages/manager/cypress.config.ts
+++ b/packages/manager/cypress.config.ts
@@ -41,7 +41,7 @@ const loadConfiguration = () => {
  * Displays a warning if tests are running on an unsupported version of Node JS.
  */
 const nodeVersionCheck = () => {
-  const recommendedVersions = [14];
+  const recommendedVersions = [18];
   const versionString = process.version.substr(1, process.version.length - 1);
   const currentVersion = versionString
     .split('.')


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
This updates the Node version warning that shows when you run Cypress. It will now recommend using Node 18 to align with our recent Node version improvements.

Throwing this question out there too: do any of us get any value out of this warning? Do we think it's helpful for other potential contributors?

## Preview 📷
This message will no longer be shown if you're running Node 18.x:

<img width="439" alt="Screen Shot 2023-03-09 at 3 13 08 PM" src="https://user-images.githubusercontent.com/97627410/224144909-3015c029-f8dc-491e-9129-e27b37f0c902.png">

## How to test 🧪

1. Run `yarn cy:run` (note: the dev server does not need to be running for this)
2. If you're running Node 18, confirm that no warning is shown
3. If you're not running Node 18, confirm that a warning is shown and that Node 18 is recommended