### PR TITLE
ci: Re-add cache to `build-validation` CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,11 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: "18.14"
+      - uses: actions/cache@v3
+        with:
+          path: |
+            **/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - run: yarn --frozen-lockfile
       - run: yarn workspace @linode/validation run build
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
## Description 📝

- Re-adds yarn cache step to `build-validation` step
- For some unknown reason, we removed it https://github.com/linode/manager/pull/7475 but I can't figure out why
- I think it's worth trying this again, if things go bad we can just revert this PR
- This could save us some time in CI

## How to test 🧪

- Verify that the Github Actions ci passes for this PR
- Well just have to observe this change once it's merged
