### PR TITLE
fix: [M3-6235] - Fix Radio Styles after Vite Upgrade

### DIFF
--- a/packages/manager/src/components/Radio/Radio.tsx
+++ b/packages/manager/src/components/Radio/Radio.tsx
@@ -11,6 +11,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     padding: '10px 10px',
     transition: theme.transitions.create(['color']),
     '& .defaultFill': {
+      fill: theme.color.white,
       transition: theme.transitions.create(['fill']),
     },
     '&:hover': {


### PR DESCRIPTION
## Description 📝

- Fixes the Radio styles caused (somehow) by https://github.com/linode/manager/pull/8838

## Preview 📷

### Before
![bug](https://user-images.githubusercontent.com/115251059/224768228-4aa28be2-f346-4785-96f7-4719afed85dc.jpg)

### After
![expected](https://user-images.githubusercontent.com/115251059/224768270-c9924a24-7025-4090-8b0f-9b51b8ebe80a.jpg)


## How to test 🧪

1. Go to `http://localhost:3000/linodes/create`
2. Select a Plan
3. Observe that the Radio buttons look correct AFTER a selection has been made. Please check both **light** and **dark** mode.
