### PR TITLE
chore: [M3-6233] - Add cloud-init compatible image to MSW

### DIFF
--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -330,12 +330,16 @@ export const handlers = [
       expiry: '2021-05-01',
     });
     const publicImages = imageFactory.buildList(0, { is_public: true });
+    const cloudInitImages = imageFactory.buildList(1, {
+      capabilities: ['cloud-init'],
+    });
     const images = [
       ...automaticImages,
       ...privateImages,
       ...publicImages,
       ...pendingImages,
       ...creatingImages,
+      ...cloudInitImages,
     ];
     return res(ctx.json(makeResourcePage(images)));
   }),


### PR DESCRIPTION
## Description 📝

Adds a cloud-init compatible image to MSW that can be viewed in the Linode Create/Rebuild flows.

## Preview 📷

https://user-images.githubusercontent.com/122488130/224840016-087b2e6e-ab6e-4e3c-9752-66ba9f638def.mov

## How to test 🧪

1. Enable MSW in DevTools
2. Enter the Linode Create or Linode Rebuild flow
3. Chose the 'Image' tab at the top
4. Select the cloud-init compatible image (this is currently labelled 'image-17 (deprecated)')
5. The User Data accordion should now be visible