### PR TITLE
refactor: Infinitely Loaded Entity Select

### DIFF
--- a/packages/manager/src/features/Volumes/VolumeDrawer/AttachVolumeToLinodeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/AttachVolumeToLinodeForm.tsx
@@ -129,7 +129,6 @@ const AttachVolumeToLinodeForm: React.FC<CombinedProps> = (props) => {
 
             <VolumeSelect
               error={touched.volume_id ? errors.volume_id : undefined}
-              name="volumd_id"
               value={values.volume_id}
               onBlur={handleBlur}
               onChange={(v) => setFieldValue('volume_id', v)}

--- a/packages/manager/src/features/Volumes/VolumeDrawer/VolumeSelect.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/VolumeSelect.tsx
@@ -1,191 +1,89 @@
-import { Grant } from '@linode/api-v4/lib/account';
-import { getVolumes, Volume } from '@linode/api-v4/lib/volumes';
 import * as React from 'react';
-import { compose } from 'recompose';
-import FormControl from 'src/components/core/FormControl';
-import FormHelperText from 'src/components/core/FormHelperText';
-import EnhancedSelect, { Item } from 'src/components/EnhancedSelect/Select';
-import withProfile, { ProfileProps } from 'src/components/withProfile';
-import { getGrants } from 'src/features/Profile/permissionsHelpers';
-import { debounce } from 'throttle-debounce';
+import Autocomplete from '@mui/material/Autocomplete';
+import TextField from 'src/components/TextField';
+import { useInfiniteVolumesQuery } from 'src/queries/volumes';
 
 interface Props {
   error?: string;
-  onChange: (linodeId: number) => void;
-  name: string;
+  onChange: (volumeId: number | null) => void;
   onBlur: (e: any) => void;
   value: number;
-  region: string;
+  region?: string;
   disabled?: boolean;
 }
 
-interface State {
-  loading: boolean;
-  volumes: Item[];
-  selectedVolumeId?: number;
-}
+const VolumeSelect = (props: Props) => {
+  const { error, onBlur, disabled, onChange, value, region } = props;
 
-type CombinedProps = Props & ProfileProps;
+  const [inputValue, setInputValue] = React.useState<string>('');
 
-class VolumeSelect extends React.Component<CombinedProps, State> {
-  state: State = {
-    volumes: [],
-    loading: true,
-  };
+  const searchFilter = inputValue
+    ? {
+        '+or': [
+          { label: { '+contains': inputValue } },
+          { tags: { '+contains': inputValue } },
+        ],
+      }
+    : {};
 
-  componentDidMount() {
-    this.searchVolumes();
-  }
+  const {
+    data,
+    isLoading,
+    fetchNextPage,
+    hasNextPage,
+  } = useInfiniteVolumesQuery({
+    ...searchFilter,
+    ...(region ? { region } : {}),
+    // linode_id: null,  <- if the API let us, we would do this
+    '+order_by': 'label',
+    '+order': 'asc',
+  });
 
-  componentDidUpdate(prevProps: CombinedProps, prevState: State) {
-    const { region } = this.props;
-    if (region !== prevProps.region) {
-      this.searchVolumes();
-    }
-  }
+  const options = data?.pages
+    .flatMap((page) => page.data)
+    .map(({ id, label }) => ({ id, label }));
 
-  getSelectedVolume = (linodeId?: number) => {
-    if (!linodeId) {
-      return -1;
-    }
+  const selectedVolume = options?.find((option) => option.id === value) ?? null;
 
-    const { volumes } = this.state;
-    const idx = volumes.findIndex(
-      (linode) => Number(linodeId) === Number(linode.value)
-    );
-    return idx > -1 ? volumes[idx] : -1;
-  };
-
-  setSelectedVolume = (selected: Item<number>) => {
-    if (selected) {
-      const { value } = selected;
-      this.setState({ selectedVolumeId: value });
-      this.props.onChange(value);
-    } else {
-      this.props.onChange(-1);
-      this.setState({ selectedVolumeId: -1 });
-    }
-  };
-
-  renderLinodeOptions = (volumes: Volume[]) => {
-    if (!volumes) {
-      return [];
-    }
-
-    const { grants, profile } = this.props;
-
-    const volumeGrants = Boolean(profile.data?.restricted)
-      ? getGrants(grants.data, 'volume')
-      : undefined;
-
-    let volumeOptions = [];
-
-    if (volumeGrants) {
-      const allowedVolumeGrants = volumeGrants.reduce(
-        (acc: number[], volume: Grant) => {
-          if (volume.permissions === 'read_write') {
-            acc.push(volume.id);
+  return (
+    <Autocomplete
+      disabled={disabled}
+      options={options ?? []}
+      value={selectedVolume}
+      onChange={(event, value) => onChange(value?.id ?? -1)}
+      inputValue={inputValue}
+      onInputChange={(event, value) => {
+        setInputValue(value);
+      }}
+      isOptionEqualToValue={(option) => option.id === selectedVolume?.id}
+      ListboxProps={{
+        onScroll: (event: React.SyntheticEvent) => {
+          const listboxNode = event.currentTarget;
+          if (
+            listboxNode.scrollTop + listboxNode.clientHeight >=
+              listboxNode.scrollHeight &&
+            hasNextPage
+          ) {
+            fetchNextPage();
           }
-          return acc;
         },
-        []
-      );
-
-      volumeOptions = volumes.filter(
-        (volume) => allowedVolumeGrants.indexOf(volume.id) !== -1
-      );
-    } else {
-      volumeOptions = volumes;
-    }
-
-    return volumeOptions.map((volume) => ({
-      value: volume.id,
-      label: volume.label,
-      data: {
-        region: volume.region,
-      },
-    }));
-  };
-
-  getVolumeFilter = (inputValue: string) => {
-    const { region } = this.props;
-
-    if (region && region !== 'none') {
-      return {
-        label: {
-          '+contains': inputValue,
-        },
-        region,
-      };
-    } else {
-      return {
-        label: {
-          '+contains': inputValue,
-        },
-      };
-    }
-  };
-
-  searchVolumes = (inputValue: string = '') => {
-    this.setState({ loading: true });
-
-    const filterVolumes = this.getVolumeFilter(inputValue);
-
-    getVolumes({}, filterVolumes)
-      .then((response) => {
-        return {
-          ...response,
-          data: response.data.filter(
-            (v) => v.region === this.props.region && v.linode_id === null
-          ),
-        };
-      })
-      .then((response) => {
-        const volumes = this.renderLinodeOptions(response.data);
-        this.setState({ volumes, loading: false });
-      })
-      .catch(() => {
-        this.setState({ loading: false });
-      });
-  };
-
-  onInputChange = (inputValue: string, actionMeta: { action: string }) => {
-    if (actionMeta.action !== 'input-change') {
-      return;
-    }
-    this.setState({ loading: true });
-    this.debouncedSearch(inputValue);
-  };
-
-  debouncedSearch = debounce(400, false, this.searchVolumes);
-
-  render() {
-    const { error, name, onBlur, disabled } = this.props;
-    const { loading, volumes, selectedVolumeId } = this.state;
-
-    return (
-      <FormControl fullWidth>
-        <EnhancedSelect
-          onBlur={onBlur}
-          name={name}
+      }}
+      loading={isLoading}
+      renderInput={(params) => (
+        <TextField
           label="Volume"
           placeholder="Select a Volume"
-          value={this.getSelectedVolume(selectedVolumeId)}
-          isLoading={loading}
+          helperText={
+            region && "Only volumes in this Linode's region are attachable."
+          }
+          onBlur={onBlur}
+          loading={isLoading}
           errorText={error}
-          options={volumes}
-          onChange={this.setSelectedVolume}
-          onInputChange={this.onInputChange}
-          disabled={disabled}
+          {...params}
         />
-        {!error && (
-          <FormHelperText data-qa-volume-region>
-            Only volumes in this Linode&rsquo;s region are displayed.
-          </FormHelperText>
-        )}
-      </FormControl>
-    );
-  }
-}
+      )}
+    />
+  );
+};
 
-export default compose<CombinedProps, Props>(withProfile)(VolumeSelect);
+export default VolumeSelect;

--- a/packages/manager/src/queries/volumes.ts
+++ b/packages/manager/src/queries/volumes.ts
@@ -1,5 +1,5 @@
 import { APIError, ResourcePage } from '@linode/api-v4/lib/types';
-import { useMutation, useQuery } from 'react-query';
+import { useInfiniteQuery, useMutation, useQuery } from 'react-query';
 import { getAll } from 'src/utilities/getAll';
 import {
   doesItemExistInPaginatedStore,
@@ -44,6 +44,20 @@ export const useVolumesQuery = (params: any, filters: any) =>
     [`${queryKey}-list`, params, filters],
     () => getVolumes(params, filters),
     { keepPreviousData: true }
+  );
+
+export const useInfiniteVolumesQuery = (filter: any) =>
+  useInfiniteQuery<ResourcePage<Volume>, APIError[]>(
+    [queryKey, filter],
+    ({ pageParam }) => getVolumes({ page: pageParam, page_size: 25 }, filter),
+    {
+      getNextPageParam: ({ page, pages }) => {
+        if (page === pages) {
+          return undefined;
+        }
+        return page + 1;
+      },
+    }
   );
 
 export const useLinodeVolumesQuery = (

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -461,6 +461,27 @@ export const base: ThemeOptions = {
         },
       },
     },
+    MuiAutocomplete: {
+      styleOverrides: {
+        listbox: {
+          backgroundColor: bg.white,
+          border: `1px solid ${primaryColors.main}`,
+        },
+        endAdornment: {
+          top: 'unset',
+          paddingRight: 8,
+        },
+        inputRoot: {
+          paddingLeft: 8,
+        },
+        loading: {
+          border: `1px solid ${primaryColors.main}`,
+        },
+        noOptions: {
+          border: `1px solid ${primaryColors.main}`,
+        },
+      },
+    },
     MuiButton: {
       styleOverrides: {
         root: {

--- a/packages/manager/src/themes.ts
+++ b/packages/manager/src/themes.ts
@@ -213,6 +213,17 @@ const darkThemeOptions: ThemeOptions = {
         },
       },
     },
+    MuiAutocomplete: {
+      styleOverrides: {
+        listbox: {
+          backgroundColor: customDarkModeOptions.bg.white,
+          border: `1px solid ${primaryColors.main}`,
+        },
+        loading: {
+          color: '#fff',
+        },
+      },
+    },
     MuiButton: {
       styleOverrides: {
         root: {


### PR DESCRIPTION
## Description 📝

- Introduces a new pattern to infinite load entities in Select components
- Why?
  - For large customers our `useAll` queries are loading tens of thousands of items which will cause Cloud Manager so slow down or crash when rendering large numbers of items in Select components 

Main Points
- Infinity loads items in the Volumes Select component
- Never loads all volumes on the account 
- Allows you to search for volumes using an API filter 
- Uses MUI and not react-select 🥹

> **Note**: I know I did not add any debouncing. We can add that if we think it is important

## Preview 📷

https://user-images.githubusercontent.com/115251059/224890641-fd246800-d238-4f26-a10d-2a9b842d41c5.mov

## How to test 🧪

- Test attaching an existing volume to a Linode form `http://localhost:3000/linodes/:id/storage`
