### PR TITLE
(style): [M3 6187] - Update maintenance and account activation screen logo

### DIFF
--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -3,7 +3,7 @@ import { isEmpty } from 'ramda';
 import * as React from 'react';
 import { Redirect, Route, RouteComponentProps, Switch } from 'react-router-dom';
 import { compose } from 'recompose';
-import Logo from 'src/assets/logo/logo.svg';
+import Logo from 'src/assets/logo/akamai-logo.svg';
 import Box from 'src/components/core/Box';
 import {
   makeStyles,

--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -129,6 +129,13 @@ const useStyles = makeStyles((theme: Theme) => ({
       margin: '0 auto',
     },
   },
+  bgStyling: {
+    backgroundColor: theme.bg.main,
+    minHeight: '100vh',
+    display: 'flex',
+    justifyContent: 'center',
+    flexDirection: 'column',
+  },
 }));
 
 interface Props {
@@ -213,19 +220,15 @@ const MainContent: React.FC<CombinedProps> = (props) => {
    */
   if (props.globalErrors.account_unactivated) {
     return (
-      <div
-        style={{
-          backgroundColor: props.theme.bg.main,
-          minHeight: '100vh',
-        }}
-      >
+      <div className={classes.bgStyling}>
         <div className={classes.activationWrapper}>
           <Box
             style={{
               display: 'flex',
+              justifyContent: 'center',
             }}
           >
-            <Logo className={classes.logo} />
+            <Logo width={215} className={classes.logo} />
           </Box>
           <Switch>
             <Route

--- a/packages/manager/src/components/ErrorState/ErrorState.tsx
+++ b/packages/manager/src/components/ErrorState/ErrorState.tsx
@@ -17,6 +17,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   root: {
     width: '100%',
     padding: theme.spacing(10),
+    marginLeft: 0,
   },
   compact: {
     padding: theme.spacing(5),

--- a/packages/manager/src/components/MaintenanceScreen.tsx
+++ b/packages/manager/src/components/MaintenanceScreen.tsx
@@ -11,6 +11,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   bgStyling: {
     backgroundColor: theme.bg.main,
     minHeight: '100vh',
+    display: 'flex',
+    justifyContent: 'center',
+    flexDirection: 'column',
   },
   maintenanceWrapper: {
     padding: theme.spacing(4),
@@ -56,9 +59,10 @@ export const MaintenanceScreen: React.FC<{}> = () => {
         <Box
           style={{
             display: 'flex',
+            justifyContent: 'center',
           }}
         >
-          <Logo width={115} height={43} className={classes.logo} />
+          <Logo width={215} className={classes.logo} />
         </Box>
 
         <ErrorState

--- a/packages/manager/src/components/MaintenanceScreen.tsx
+++ b/packages/manager/src/components/MaintenanceScreen.tsx
@@ -3,7 +3,7 @@ import Link from 'src/components/Link';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Box from 'src/components/core/Box';
-import Logo from 'src/assets/logo/logo.svg';
+import Logo from 'src/assets/logo/akamai-logo.svg';
 import ErrorState from 'src/components/ErrorState';
 import BuildIcon from '@mui/icons-material/Build';
 
@@ -46,7 +46,7 @@ export const MaintenanceScreen: React.FC<{}> = () => {
     <Typography className={classes.subheading}>
       Visit{' '}
       <Link to="https://status.linode.com/">https://status.linode.com</Link> for
-      updates on the Linode Cloud Manager and API.
+      updates on the Cloud Manager and API.
     </Typography>
   );
 


### PR DESCRIPTION
## Description 📝

**What does this PR do?**

- Updates the logo on the account activation and maintenance screens. 
- Standardizes the size and placement of the logo. 
- Makes a minor copy update on the maintenance screen.

## Preview 📷

**Remove this section or include a screenshot or screen recording of the change**

## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**
1. Check out this PR.
2. Verify the logo and the copy change on the `MaintenanceScreen` by making the condition `true` on L255 of `MainContent.tsx`. 
3. Verify the logo change on the `AccountLandingScreen` by making the condition `true` on L221 of `MainContent.tsx`. 
4. Resize the window and check to make sure the page layout looks good at various breakpoints. 
5. Check to make sure alignment of the `ErrorState` component throughout the app was not adversely impacted by the margin adjustment that was made to fix a misalignment issue on the maintenance and account activation screens.