### PR TITLE
fix: Use Jenkins build number for Cypress unique build ID

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.4'
 
 x-e2e-env:
   &default-env
-  BUILD_ID: ${BUILD_ID}
+  BUILD_ID: ${BUILD_NUMBER}
   BUILD_URL: ${BUILD_URL}
   BUILD_NUMBER: ${BUILD_NUMBER}
   COMMIT_INFO_BRANCH: ${GIT_BRANCH}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.4'
 
 x-e2e-env:
   &default-env
-  BUILD_ID: ${BUILD_NUMBER}
+  BUILD_ID: "${GIT_BRANCH}-${BUILD_NUMBER}"
   BUILD_URL: ${BUILD_URL}
   BUILD_NUMBER: ${BUILD_NUMBER}
   COMMIT_INFO_BRANCH: ${GIT_BRANCH}


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
This fixes the Cypress runs that occur against our PRs by prefixing the build IDs with the PR branch name. This ensures that the build ID that gets passed to Cypress is unique, preventing an issue where Cypress would bail out because it was seeing existing runs under the same ID.

Existing PRs and branches created before this gets merged will continue having this issue, but since it doesn't block anything we can either choose to ignore it or merge these changes in on a case-by-case basis.