### PR TITLE
fix: Region in e2e tests for region `Tokyo, JP`

### DIFF
--- a/packages/manager/cypress/support/constants/regions.ts
+++ b/packages/manager/cypress/support/constants/regions.ts
@@ -13,7 +13,7 @@ export const regionsMap = {
   'eu-west': 'London, UK',
   'ap-south': 'Singapore, SG',
   'eu-central': 'Frankfurt, DE',
-  'ap-northeast': 'Tokyo 2, JP',
+  'ap-northeast': 'Tokyo, JP',
   'ca-central': 'Toronto, CA',
   'ap-west': 'Mumbai, IN',
   'ap-southeast': 'Sydney, AU',


### PR DESCRIPTION
## Description 📝

- Updates the expected region `Tokyo 2, JP` to `Tokyo, JP` because `Tokyo 2, JP` is not a real thing according to the API
- Caused by us using the API to get region names https://github.com/linode/manager/pull/8851

## How to test 🧪

- Check e2e status in CI
