### PR TITLE
feat: [M3-5746] - Disable Download CA Certificate when DB is provisioning

### DIFF
--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
@@ -58,8 +58,18 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
     marginLeft: theme.spacing(2),
   },
+  actionBtnDisabled: {
+    display: 'flex',
+    '& g': {
+      stroke: theme.color.disabledText,
+    },
+  },
   actionText: {
     color: theme.textColors.linkActiveLight,
+    whiteSpace: 'nowrap',
+  },
+  actionTextDisabled: {
+    color: theme.color.disabledText,
     whiteSpace: 'nowrap',
   },
   connectionDetailsCtn: {
@@ -166,6 +176,7 @@ export const DatabaseSummaryConnectionDetails: React.FC<Props> = (props) => {
   };
 
   const disableShowBtn = ['provisioning', 'failed'].includes(database.status);
+  const disableDownloadCACertificateBtn = database.status === 'provisioning';
   // const connectionDetailsCopy = `username = ${credentials?.username}\npassword = ${credentials?.password}\nhost = ${database.host}\nport = ${database.port}\ssl = ${ssl}`;
 
   const credentialsBtn = (handleClick: () => void, btnText: string) => {
@@ -179,6 +190,53 @@ export const DatabaseSummaryConnectionDetails: React.FC<Props> = (props) => {
       </Button>
     );
   };
+
+  const caCertificateJSX = (
+    <>
+      <Grid
+        item
+        onClick={() => {
+          if (disableDownloadCACertificateBtn) {
+            return;
+          }
+
+          handleDownloadCACertificate();
+        }}
+        role="button"
+        onKeyDown={(e) => {
+          if (disableDownloadCACertificateBtn) {
+            return;
+          }
+          if (e.key === 'Enter') {
+            handleDownloadCACertificate();
+          }
+        }}
+        tabIndex={0}
+        className={
+          disableDownloadCACertificateBtn
+            ? classes.actionBtnDisabled
+            : classes.actionBtn
+        }
+      >
+        <DownloadIcon style={{ marginRight: 8 }} />
+        <Typography
+          className={
+            disableDownloadCACertificateBtn
+              ? classes.actionTextDisabled
+              : classes.actionText
+          }
+        >
+          Download CA Certificate
+        </Typography>
+      </Grid>
+      {disableDownloadCACertificateBtn ? (
+        <HelpIcon
+          className={classes.helpIcon}
+          text="Your Database Cluster is currently provisioning."
+        />
+      ) : null}
+    </>
+  );
 
   return (
     <>
@@ -346,25 +404,7 @@ export const DatabaseSummaryConnectionDetails: React.FC<Props> = (props) => {
         </Typography>
       </Grid>
       <div className={classes.actionBtnsCtn}>
-        {database.ssl_connection ? (
-          <Grid
-            item
-            onClick={handleDownloadCACertificate}
-            role="button"
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                handleDownloadCACertificate();
-              }
-            }}
-            tabIndex={0}
-            className={classes.actionBtn}
-          >
-            <DownloadIcon style={{ marginRight: 8 }} />
-            <Typography className={classes.actionText}>
-              Download CA Certificate
-            </Typography>
-          </Grid>
-        ) : null}
+        {database.ssl_connection ? caCertificateJSX : null}
       </div>
     </>
   );


### PR DESCRIPTION
## Description 📝
Disable the "Download CA Certificate" button while the database is be provisioned.

## Preview 📷
![Screenshot 2023-03-17 at 10 35 53 AM](https://user-images.githubusercontent.com/114682940/225935336-4d9411f7-0265-433a-b8ea-0aafd4b2ed71.jpg)

## How to test 🧪
You can either spin up a new DB instance or utilize the MSW. I believe right now we have it so that if you go to a Database Details page with the MSW on, it randomizes the database status and view according to the status. You can either refresh until you get `Provisioning` (shouldn't be more than 2-3 refreshes) or make a change in `serverHandlers.ts`.

Confirm that DBs in statuses other than provisioning have not been impacted.