### PR TITLE
refactor: [M3-6241] - MUI v5 Migration - Features > Account

### DIFF
--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -78,7 +78,7 @@
     "sanitize-html": "~2.3.2",
     "search-string": "^3.1.0",
     "throttle-debounce": "^2.0.0",
-    "tss-react": "^4.8.1",
+    "tss-react": "^4.8.2",
     "typescript-fsa": "^3.0.0",
     "typescript-fsa-reducers": "^1.2.0",
     "url-parse": "^1.5.9",

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -78,7 +78,7 @@
     "sanitize-html": "~2.3.2",
     "search-string": "^3.1.0",
     "throttle-debounce": "^2.0.0",
-    "tss-react": "^4.6.1",
+    "tss-react": "^4.8.1",
     "typescript-fsa": "^3.0.0",
     "typescript-fsa-reducers": "^1.2.0",
     "url-parse": "^1.5.9",

--- a/packages/manager/src/features/Account/AccountLanding.tsx
+++ b/packages/manager/src/features/Account/AccountLanding.tsx
@@ -23,7 +23,7 @@ const MaintenanceLanding = React.lazy(
   () => import('./Maintenance/MaintenanceLanding')
 );
 
-const AccountLanding: React.FC = () => {
+const AccountLanding = () => {
   const history = useHistory();
   const location = useLocation();
   const { data: profile } = useProfile();

--- a/packages/manager/src/features/Account/AccountLogins.tsx
+++ b/packages/manager/src/features/Account/AccountLogins.tsx
@@ -2,7 +2,7 @@ import { AccountLogin } from '@linode/api-v4/lib/account/types';
 import Typography from 'src/components/core/Typography';
 import * as React from 'react';
 import Hidden from 'src/components/core/Hidden';
-import { makeStyles } from '@mui/styles';
+import { makeStyles } from 'tss-react/mui';
 import { Theme } from '@mui/material/styles';
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
@@ -21,7 +21,7 @@ import AccountLoginsTableRow from './AccountLoginsTableRow';
 
 const preferenceKey = 'account-logins';
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles()((theme: Theme) => ({
   cell: {
     width: '12%',
   },
@@ -36,7 +36,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 const AccountLogins = () => {
-  const classes = useStyles();
+  const { classes } = useStyles();
   const pagination = usePagination(1, preferenceKey);
 
   const { order, orderBy, handleOrderChange } = useOrder(

--- a/packages/manager/src/features/Account/Agreements/EUAgreementCheckbox.tsx
+++ b/packages/manager/src/features/Account/Agreements/EUAgreementCheckbox.tsx
@@ -14,7 +14,7 @@ interface Props {
   ) => void;
 }
 
-const EUAgreementCheckbox: React.FC<Props> = (props) => {
+const EUAgreementCheckbox = (props: Props) => {
   const { checked, onChange, className, centerCheckbox } = props;
 
   const checkboxStyle = centerCheckbox

--- a/packages/manager/src/features/Account/Agreements/withAgreements.ts
+++ b/packages/manager/src/features/Account/Agreements/withAgreements.ts
@@ -8,13 +8,16 @@ export interface AgreementsProps {
   agreements: UseQueryResult<Agreements, APIError[]>;
 }
 
-export default (Component: React.ComponentType<any>) => {
-  return (props: any) => {
+// P represents the props of the component we're wrapping
+export default <P extends AgreementsProps>(
+  Component: React.ComponentType<P>
+) => {
+  return (props: Omit<P, keyof AgreementsProps>) => {
     const agreements = useAccountAgreements();
 
     return React.createElement(Component, {
       ...props,
       agreements,
-    });
+    } as P);
   };
 };

--- a/packages/manager/src/features/Account/AutoBackups.tsx
+++ b/packages/manager/src/features/Account/AutoBackups.tsx
@@ -1,4 +1,4 @@
-import { makeStyles } from '@mui/styles';
+import { makeStyles } from 'tss-react/mui';
 import { Theme } from '@mui/material/styles';
 import * as React from 'react';
 import Accordion from 'src/components/Accordion';
@@ -9,7 +9,7 @@ import OpenInNew from '@mui/icons-material/OpenInNew';
 import Toggle from 'src/components/Toggle';
 import Typography from 'src/components/core/Typography';
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles()((theme: Theme) => ({
   footnote: {
     fontSize: '0.875rem',
     cursor: 'pointer',
@@ -33,7 +33,7 @@ interface Props {
   isManagedCustomer: boolean;
 }
 
-const AutoBackups: React.FC<Props> = (props) => {
+const AutoBackups = (props: Props) => {
   const {
     backups_enabled,
     hasLinodesWithoutBackups,
@@ -42,7 +42,7 @@ const AutoBackups: React.FC<Props> = (props) => {
     isManagedCustomer,
   } = props;
 
-  const classes = useStyles();
+  const { classes } = useStyles();
 
   return (
     <Accordion heading="Backup Auto Enrollment" defaultExpanded={true}>

--- a/packages/manager/src/features/Account/CloseAccountDialog.tsx
+++ b/packages/manager/src/features/Account/CloseAccountDialog.tsx
@@ -2,11 +2,10 @@ import { cancelAccount } from '@linode/api-v4/lib/account';
 import { APIError } from '@linode/api-v4/lib/types';
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
-import { compose } from 'recompose';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import Dialog from 'src/components/ConfirmationDialog';
-import { makeStyles } from '@mui/styles';
+import { makeStyles } from 'tss-react/mui';
 import { Theme } from '@mui/material/styles';
 import Notice from 'src/components/Notice';
 import Typography from 'src/components/core/Typography';
@@ -19,15 +18,13 @@ interface Props {
   closeDialog: () => void;
 }
 
-type CombinedProps = Props;
-
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles()((theme: Theme) => ({
   dontgo: {
     marginTop: theme.spacing(2),
   },
 }));
 
-const CloseAccountDialog: React.FC<CombinedProps> = (props) => {
+const CloseAccountDialog = ({ closeDialog, open }: Props) => {
   const [isClosingAccount, setIsClosingAccount] = React.useState<boolean>(
     false
   );
@@ -36,12 +33,12 @@ const CloseAccountDialog: React.FC<CombinedProps> = (props) => {
   const [inputtedUsername, setUsername] = React.useState<string>('');
   const [canSubmit, setCanSubmit] = React.useState<boolean>(false);
 
-  const classes = useStyles();
+  const { classes } = useStyles();
   const history = useHistory();
   const { data: profile } = useProfile();
 
   React.useEffect(() => {
-    if (props.open) {
+    if (open) {
       /**
        * reset error state, username, and disabled status when we open the modal
        * intentionally not resetting comments
@@ -50,7 +47,7 @@ const CloseAccountDialog: React.FC<CombinedProps> = (props) => {
       setUsername('');
       setCanSubmit(false);
     }
-  }, [props.open]);
+  }, [open]);
 
   /**
    * enable the submit button if the user entered their
@@ -69,11 +66,11 @@ const CloseAccountDialog: React.FC<CombinedProps> = (props) => {
       /**
        * focus on first textfield when modal is opened
        */
-      if (node && node.focus && props.open === true) {
+      if (node && node.focus && open === true) {
         node.focus();
       }
     },
-    [props.open]
+    [open]
   );
 
   const handleCancelAccount = () => {
@@ -102,13 +99,13 @@ const CloseAccountDialog: React.FC<CombinedProps> = (props) => {
 
   return (
     <Dialog
-      open={props.open}
+      open={open}
       title="Are you sure you want to close your Linode account?"
-      onClose={props.closeDialog}
+      onClose={closeDialog}
       error={errors ? errors[0].reason : ''}
       actions={
         <Actions
-          onClose={props.closeDialog}
+          onClose={closeDialog}
           isCanceling={isClosingAccount}
           onSubmit={handleCancelAccount}
           disabled={!canSubmit}
@@ -160,17 +157,22 @@ interface ActionsProps {
   disabled: boolean;
 }
 
-const Actions: React.FC<ActionsProps> = (props) => {
+const Actions = ({
+  disabled,
+  isCanceling,
+  onClose,
+  onSubmit,
+}: ActionsProps) => {
   return (
     <ActionsPanel>
-      <Button buttonType="secondary" onClick={props.onClose}>
+      <Button buttonType="secondary" onClick={onClose}>
         Cancel
       </Button>
       <Button
         buttonType="primary"
-        onClick={props.onSubmit}
-        disabled={props.disabled}
-        loading={props.isCanceling}
+        onClick={onSubmit}
+        disabled={disabled}
+        loading={isCanceling}
       >
         Close Account
       </Button>
@@ -178,4 +180,4 @@ const Actions: React.FC<ActionsProps> = (props) => {
   );
 };
 
-export default compose<CombinedProps, Props>(React.memo)(CloseAccountDialog);
+export default React.memo(CloseAccountDialog);

--- a/packages/manager/src/features/Account/CloseAccountSetting.tsx
+++ b/packages/manager/src/features/Account/CloseAccountSetting.tsx
@@ -4,7 +4,7 @@ import Button from 'src/components/Button';
 import Grid from 'src/components/Grid';
 import CloseAccountDialog from './CloseAccountDialog';
 
-const CloseAccountSetting: React.FC<{}> = () => {
+const CloseAccountSetting = () => {
   const [dialogOpen, setDialogOpen] = React.useState<boolean>(false);
 
   return (

--- a/packages/manager/src/features/Account/EnableManaged.tsx
+++ b/packages/manager/src/features/Account/EnableManaged.tsx
@@ -29,7 +29,7 @@ interface ContentProps {
   isManaged: boolean;
   openConfirmationModal: () => void;
 }
-export const ManagedContent: React.FC<ContentProps> = (props) => {
+export const ManagedContent = (props: ContentProps) => {
   const { isManaged, openConfirmationModal } = props;
 
   if (isManaged) {
@@ -65,7 +65,7 @@ export const ManagedContent: React.FC<ContentProps> = (props) => {
   );
 };
 
-export const EnableManaged: React.FC<CombinedProps> = (props) => {
+export const EnableManaged = (props: CombinedProps) => {
   const { isManaged, linodeCount } = props;
   const [isOpen, setOpen] = React.useState<boolean>(false);
   const [error, setError] = React.useState<string | undefined>();

--- a/packages/manager/src/features/Account/EnableObjectStorage.tsx
+++ b/packages/manager/src/features/Account/EnableObjectStorage.tsx
@@ -22,14 +22,11 @@ interface Props {
   object_storage: AccountSettings['object_storage'];
 }
 
-type CombinedProps = Props;
-
-interface ContentProps {
-  object_storage: AccountSettings['object_storage'];
+interface ContentProps extends Props {
   openConfirmationModal: () => void;
 }
 
-export const ObjectStorageContent: React.FC<ContentProps> = (props) => {
+export const ObjectStorageContent = (props: ContentProps) => {
   const { object_storage, openConfirmationModal } = props;
 
   if (object_storage !== 'disabled') {
@@ -71,7 +68,7 @@ export const ObjectStorageContent: React.FC<ContentProps> = (props) => {
   );
 };
 
-export const EnableObjectStorage: React.FC<CombinedProps> = (props) => {
+export const EnableObjectStorage = (props: Props) => {
   const { object_storage } = props;
   const [isOpen, setOpen] = React.useState<boolean>(false);
   const [error, setError] = React.useState<string | undefined>();

--- a/packages/manager/src/features/Account/GlobalSettings.tsx
+++ b/packages/manager/src/features/Account/GlobalSettings.tsx
@@ -50,7 +50,7 @@ type CombinedProps = StateProps &
   WithSnackbarProps &
   RouteComponentProps<{}>;
 
-const GlobalSettings: React.FC<CombinedProps> = (props) => {
+const GlobalSettings = (props: CombinedProps) => {
   const {
     actions: { openBackupsDrawer, openImportDrawer },
     linodesWithoutBackups,

--- a/packages/manager/src/features/Account/ImportGroupsAsTags.test.tsx
+++ b/packages/manager/src/features/Account/ImportGroupsAsTags.test.tsx
@@ -1,6 +1,6 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { ImportGroupsAsTags } from './ImportGroupsAsTags';
+import ImportGroupsAsTags from './ImportGroupsAsTags';
 
 const classes = { root: '', helperText: '' };
 

--- a/packages/manager/src/features/Account/ImportGroupsAsTags.tsx
+++ b/packages/manager/src/features/Account/ImportGroupsAsTags.tsx
@@ -1,28 +1,25 @@
 import * as React from 'react';
 import Button from 'src/components/Button';
-import { createStyles, withStyles, WithStyles } from '@mui/styles';
+import { makeStyles } from 'tss-react/mui';
 import { Theme } from '@mui/material/styles';
 import Typography from 'src/components/core/Typography';
 import Accordion from 'src/components/Accordion';
 
-type ClassNames = 'root' | 'helperText';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {},
-    helperText: {
-      marginBottom: theme.spacing(2),
-    },
-  });
+const useStyles = makeStyles()((theme: Theme) => ({
+  root: {},
+  helperText: {
+    marginBottom: theme.spacing(2),
+  },
+}));
 
 interface Props {
   openDrawer: () => void;
 }
 
-type CombinedProps = Props & WithStyles<ClassNames>;
+const ImportGroupsAsTags = (props: Props) => {
+  const { classes } = useStyles();
+  const { openDrawer } = props;
 
-export const ImportGroupsAsTags: React.FC<CombinedProps> = (props) => {
-  const { classes, openDrawer } = props;
   return (
     <Accordion
       className={classes.root}
@@ -47,6 +44,4 @@ export const ImportGroupsAsTags: React.FC<CombinedProps> = (props) => {
   );
 };
 
-const styled = withStyles(styles);
-
-export default styled(ImportGroupsAsTags);
+export default ImportGroupsAsTags;

--- a/packages/manager/src/features/Account/Maintenance/MaintenanceTable.tsx
+++ b/packages/manager/src/features/Account/Maintenance/MaintenanceTable.tsx
@@ -15,7 +15,7 @@ import TableRowEmptyState from 'src/components/TableRowEmptyState';
 import Typography from 'src/components/core/Typography';
 import { AccountMaintenance } from '@linode/api-v4/lib/account/types';
 import { CSVLink } from 'react-csv';
-import { makeStyles } from '@mui/styles';
+import { makeStyles } from 'tss-react/mui';
 import { Theme } from '@mui/material/styles';
 import { cleanCSVData } from 'src/components/DownloadCSV/DownloadCSV';
 import { useOrder } from 'src/hooks/useOrder';
@@ -38,7 +38,7 @@ const headersForCSVDownload = [
   { label: 'Reason', key: 'reason' },
 ];
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles()((theme: Theme) => ({
   csvLink: {
     [theme.breakpoints.down('md')]: {
       marginRight: theme.spacing(),
@@ -63,9 +63,9 @@ interface Props {
   type: 'pending' | 'completed';
 }
 
-export const MaintenanceTable = ({ type }: Props) => {
+const MaintenanceTable = ({ type }: Props) => {
   const csvRef = React.useRef<any>();
-  const classes = useStyles();
+  const { classes } = useStyles();
   const pagination = usePagination(1, `${preferenceKey}-${type}`);
 
   const { order, orderBy, handleOrderChange } = useOrder(
@@ -238,3 +238,5 @@ export const MaintenanceTable = ({ type }: Props) => {
     </>
   );
 };
+
+export { MaintenanceTable };

--- a/packages/manager/src/features/Account/NetworkHelper.tsx
+++ b/packages/manager/src/features/Account/NetworkHelper.tsx
@@ -1,40 +1,19 @@
 import * as React from 'react';
 import FormControlLabel from 'src/components/core/FormControlLabel';
-import { makeStyles } from 'tss-react/mui';
-import { Theme } from '@mui/material/styles';
 import Typography from 'src/components/core/Typography';
 import Accordion from 'src/components/Accordion';
 import Grid from 'src/components/Grid';
 import Toggle from 'src/components/Toggle';
-
-const useStyles = makeStyles()((theme: Theme) => ({
-  root: {},
-  footnote: {
-    fontSize: 14,
-    cursor: 'pointer',
-  },
-  link: {
-    textDecoration: 'underline',
-  },
-  icon: {
-    display: 'inline-block',
-    fontSize: '0.8em',
-    marginLeft: `calc(${theme.spacing(1)} / 3)`,
-  },
-}));
 
 interface Props {
   onChange: () => void;
   networkHelperEnabled: boolean;
 }
 
-const NetworkHelper = (props: Props) => {
-  const { classes } = useStyles();
-  const { onChange, networkHelperEnabled } = props;
-
+const NetworkHelper = ({ onChange, networkHelperEnabled }: Props) => {
   return (
     <Accordion heading="Network Helper" defaultExpanded={true}>
-      <Grid container direction="column" className={classes.root}>
+      <Grid container direction="column">
         <Grid item>
           <Typography variant="body1">
             Network Helper automatically deposits a static networking

--- a/packages/manager/src/features/Account/NetworkHelper.tsx
+++ b/packages/manager/src/features/Account/NetworkHelper.tsx
@@ -1,76 +1,65 @@
 import * as React from 'react';
 import FormControlLabel from 'src/components/core/FormControlLabel';
-import { createStyles, withStyles, WithStyles } from '@mui/styles';
+import { makeStyles } from 'tss-react/mui';
 import { Theme } from '@mui/material/styles';
 import Typography from 'src/components/core/Typography';
 import Accordion from 'src/components/Accordion';
 import Grid from 'src/components/Grid';
 import Toggle from 'src/components/Toggle';
 
-type ClassNames = 'root' | 'footnote' | 'link' | 'icon';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {},
-    footnote: {
-      fontSize: 14,
-      cursor: 'pointer',
-    },
-    link: {
-      textDecoration: 'underline',
-    },
-    icon: {
-      display: 'inline-block',
-      fontSize: '0.8em',
-      marginLeft: `calc(${theme.spacing(1)} / 3)`,
-    },
-  });
+const useStyles = makeStyles()((theme: Theme) => ({
+  root: {},
+  footnote: {
+    fontSize: 14,
+    cursor: 'pointer',
+  },
+  link: {
+    textDecoration: 'underline',
+  },
+  icon: {
+    display: 'inline-block',
+    fontSize: '0.8em',
+    marginLeft: `calc(${theme.spacing(1)} / 3)`,
+  },
+}));
 
 interface Props {
   onChange: () => void;
   networkHelperEnabled: boolean;
 }
 
-type CombinedProps = Props & WithStyles<ClassNames>;
-
-const NetworkHelper: React.FC<CombinedProps> = (props) => {
-  const { classes, onChange, networkHelperEnabled } = props;
+const NetworkHelper = (props: Props) => {
+  const { classes } = useStyles();
+  const { onChange, networkHelperEnabled } = props;
 
   return (
-    <React.Fragment>
-      <Accordion heading="Network Helper" defaultExpanded={true}>
-        <Grid container direction="column" className={classes.root}>
+    <Accordion heading="Network Helper" defaultExpanded={true}>
+      <Grid container direction="column" className={classes.root}>
+        <Grid item>
+          <Typography variant="body1">
+            Network Helper automatically deposits a static networking
+            configuration into your Linode at boot.
+          </Typography>
+        </Grid>
+        <Grid item container direction="row" alignItems="center">
           <Grid item>
-            <Typography variant="body1">
-              Network Helper automatically deposits a static networking
-              configuration into your Linode at boot.
-            </Typography>
-          </Grid>
-          <Grid item container direction="row" alignItems="center">
-            <Grid item>
-              <FormControlLabel
-                // className="toggleLabel"
-                control={
-                  <Toggle
-                    onChange={onChange}
-                    checked={networkHelperEnabled}
-                    data-qa-toggle-network-helper
-                  />
-                }
-                label={
-                  networkHelperEnabled
-                    ? 'Enabled (default behavior)'
-                    : 'Disabled'
-                }
-              />
-            </Grid>
+            <FormControlLabel
+              control={
+                <Toggle
+                  onChange={onChange}
+                  checked={networkHelperEnabled}
+                  data-qa-toggle-network-helper
+                />
+              }
+              label={
+                networkHelperEnabled ? 'Enabled (default behavior)' : 'Disabled'
+              }
+            />
           </Grid>
         </Grid>
-      </Accordion>
-    </React.Fragment>
+      </Grid>
+    </Accordion>
   );
 };
 
-const styled = withStyles(styles, { withTheme: true });
-
-export default styled(NetworkHelper);
+export default NetworkHelper;

--- a/yarn.lock
+++ b/yarn.lock
@@ -14311,10 +14311,10 @@ tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.4.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
   integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
 
-tss-react@^4.6.1:
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/tss-react/-/tss-react-4.6.1.tgz#a584d720d417350bcca327752e0a4ea77868726c"
-  integrity sha512-4MktjVhHqEav6JxipiTqFU7YcXbAt0DHD4CIGFpqQdYKkUHK6URLf/2hYjwDcHkiC22K5f3vTo8q2O1WQs1H3Q==
+tss-react@^4.8.1:
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/tss-react/-/tss-react-4.8.1.tgz#17e167ebdc2338df24021d3983e05b7d4b8deb83"
+  integrity sha512-6o607zBA+tSlagxHzgU9D5NcN7o3wEjX9peIXLtl3meg0KzZ0HvYApLdnmSmg8a5QuCGylUlHkhNRgUmgtgRpg==
   dependencies:
     "@emotion/cache" "*"
     "@emotion/serialize" "*"


### PR DESCRIPTION
## Description 📝
Migrates `SRC > Features > Account` from JSS to tss-react (Emotion)

## Changes
- Bumped `tss-react` version to get latest fixes from author 🎉 
   - https://github.com/garronej/tss-react/issues/160 
   - New updated documentation for class components: https://docs.tss-react.dev/api/withstyles#with-class-components 
- Removed `@mui/styles` imports
- Removed `React.FC`
- Removed `any` and added better typechecking to `Account/Agreements/withAgreements.ts`
- Removed deprecated `createStyles` and unnecessary `withStyles`
- Other minor cleanup

## How to test 🧪
- Go to `/account/` locally and ensure all functionality still works