### PR TITLE
refactor: [M3-6261] - MUI v5 Migration - `Features > Databases`

### DIFF
--- a/packages/manager/src/components/CopyTooltip/CopyTooltip.tsx
+++ b/packages/manager/src/components/CopyTooltip/CopyTooltip.tsx
@@ -1,10 +1,9 @@
-import classNames from 'classnames';
+import { Theme } from '@mui/material/styles';
 import copy from 'copy-to-clipboard';
 import * as React from 'react';
 import FileCopy from 'src/assets/icons/copy.svg';
-import { makeStyles } from '@mui/styles';
-import { Theme } from '@mui/material/styles';
 import ToolTip from 'src/components/core/Tooltip';
+import { makeStyles } from 'tss-react/mui';
 
 interface Props {
   text: string;
@@ -13,7 +12,7 @@ interface Props {
   onClickCallback?: () => void;
 }
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles()((theme: Theme) => ({
   root: {
     position: 'relative',
     padding: 4,
@@ -49,8 +48,8 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-export const CopyTooltip: React.FC<Props> = (props) => {
-  const classes = useStyles();
+export const CopyTooltip = (props: Props) => {
+  const { classes, cx } = useStyles();
   const [copied, setCopied] = React.useState<boolean>(false);
 
   const { text, className, copyableText, onClickCallback } = props;
@@ -71,8 +70,7 @@ export const CopyTooltip: React.FC<Props> = (props) => {
         name={text}
         type="button"
         onClick={handleIconClick}
-        className={classNames(className, {
-          [classes.root]: true,
+        className={cx(classes.root, className, {
           [classes.copyableTextBtn]: copyableText,
         })}
         data-qa-copy-btn

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -9,6 +9,7 @@ import {
 } from '@linode/api-v4/lib/databases/types';
 import { APIError } from '@linode/api-v4/lib/types';
 import { createDatabaseSchema } from '@linode/validation/lib/databases.schema';
+import { Theme } from '@mui/material/styles';
 import { useFormik } from 'formik';
 import { groupBy } from 'ramda';
 import * as React from 'react';
@@ -24,8 +25,6 @@ import FormControl from 'src/components/core/FormControl';
 import FormControlLabel from 'src/components/core/FormControlLabel';
 import Paper from 'src/components/core/Paper';
 import RadioGroup from 'src/components/core/RadioGroup';
-import { makeStyles } from '@mui/styles';
-import { Theme } from '@mui/material/styles';
 import Typography from 'src/components/core/Typography';
 import SingleValue from 'src/components/EnhancedSelect/components/SingleValue';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
@@ -33,6 +32,7 @@ import RegionSelect from 'src/components/EnhancedSelect/variants/RegionSelect';
 import RegionOption from 'src/components/EnhancedSelect/variants/RegionSelect/RegionOption';
 import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
+import LandingHeader from 'src/components/LandingHeader';
 import Link from 'src/components/Link';
 import MultipleIPInput from 'src/components/MultipleIPInput';
 import Notice from 'src/components/Notice';
@@ -45,6 +45,7 @@ import { enforceIPMasks } from 'src/features/Firewalls/FirewallDetail/Rules/Fire
 import SelectPlanPanel, {
   PlanSelectionType,
 } from 'src/features/linodes/LinodesCreate/SelectPlanPanel';
+import { typeLabelDetails } from 'src/features/linodes/presentation';
 import useFlags from 'src/hooks/useFlags';
 import {
   useCreateDatabaseMutation,
@@ -61,10 +62,9 @@ import {
   validateIPs,
 } from 'src/utilities/ipUtils';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
-import { typeLabelDetails } from 'src/features/linodes/presentation';
-import LandingHeader from 'src/components/LandingHeader';
+import { makeStyles } from 'tss-react/mui';
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles()((theme: Theme) => ({
   formControlLabel: {
     marginBottom: theme.spacing(),
   },
@@ -190,8 +190,8 @@ interface NodePricing {
   multi: DatabasePriceObject | undefined;
 }
 
-const DatabaseCreate: React.FC<{}> = () => {
-  const classes = useStyles();
+const DatabaseCreate = () => {
+  const { classes } = useStyles();
   const history = useHistory();
   const flags = useFlags();
 

--- a/packages/manager/src/features/Databases/DatabaseDetail/AccessControls.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/AccessControls.tsx
@@ -1,12 +1,11 @@
 import { Database } from '@linode/api-v4/lib/databases';
 import { APIError } from '@linode/api-v4/lib/types';
+import { Theme } from '@mui/material/styles';
 import * as React from 'react';
 import ActionsPanel from 'src/components/ActionsPanel';
 import AddNewLink from 'src/components/AddNewLink';
 import Button from 'src/components/Button';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
-import { makeStyles } from '@mui/styles';
-import { Theme } from '@mui/material/styles';
 import TableBody from 'src/components/core/TableBody';
 import Typography from 'src/components/core/Typography';
 import InlineMenuAction from 'src/components/InlineMenuAction';
@@ -16,9 +15,10 @@ import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import { useDatabaseMutation } from 'src/queries/databases';
 import { ExtendedIP, stringToExtendedIP } from 'src/utilities/ipUtils';
+import { makeStyles } from 'tss-react/mui';
 import AddAccessControlDrawer from './AddAccessControlDrawer';
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles()((theme: Theme) => ({
   topSection: {
     display: 'flex',
     alignItems: 'center',
@@ -82,13 +82,13 @@ interface Props {
   description?: JSX.Element;
 }
 
-export const AccessControls: React.FC<Props> = (props) => {
+export const AccessControls = (props: Props) => {
   const {
     database: { id, engine, allow_list: allowList },
     description,
   } = props;
 
-  const classes = useStyles();
+  const { classes } = useStyles();
 
   const [isDialogOpen, setDialogOpen] = React.useState<boolean>(false);
   const [error, setError] = React.useState<string | undefined>();

--- a/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
@@ -1,10 +1,9 @@
 import { APIError } from '@linode/api-v4/lib/types';
+import { Theme } from '@mui/material/styles';
 import { useFormik } from 'formik';
 import * as React from 'react';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
-import { makeStyles } from '@mui/styles';
-import { Theme } from '@mui/material/styles';
 import Typography from 'src/components/core/Typography';
 import Drawer from 'src/components/Drawer';
 import MultipleIPInput from 'src/components/MultipleIPInput/MultipleIPInput';
@@ -17,8 +16,9 @@ import {
   ipFieldPlaceholder,
   validateIPs,
 } from 'src/utilities/ipUtils';
+import { makeStyles } from 'tss-react/mui';
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles()((theme: Theme) => ({
   instructions: {
     marginBottom: '2rem',
   },
@@ -40,10 +40,10 @@ interface Values {
 
 type CombinedProps = Props;
 
-const AddAccessControlDrawer: React.FC<CombinedProps> = (props) => {
+const AddAccessControlDrawer = (props: CombinedProps) => {
   const { open, onClose, updateDatabase, allowList } = props;
 
-  const classes = useStyles();
+  const { classes } = useStyles();
 
   const [error, setError] = React.useState<string | undefined>('');
   const [allowListErrors, setAllowListErrors] = React.useState<APIError[]>();

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackupActionMenu.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackupActionMenu.tsx
@@ -1,9 +1,9 @@
-import * as React from 'react';
 import { DatabaseBackup } from '@linode/api-v4/lib/databases';
-import { makeStyles } from '@mui/styles';
+import * as React from 'react';
 import InlineAction from 'src/components/InlineMenuAction';
+import { makeStyles } from 'tss-react/mui';
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles()(() => ({
   inlineActions: {
     display: 'flex',
     alignItems: 'center',
@@ -16,8 +16,8 @@ interface Props {
   onRestore: (id: number) => void;
 }
 
-const DatabaseBackupActionMenu: React.FC<Props> = (props) => {
-  const classes = useStyles();
+const DatabaseBackupActionMenu = (props: Props) => {
+  const { classes } = useStyles();
   const { backup, onRestore } = props;
 
   const actions = [

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseBackups/DatabaseBackups.tsx
@@ -20,7 +20,7 @@ import {
 } from 'src/queries/databases';
 import { TableRowLoading } from 'src/components/TableRowLoading/TableRowLoading';
 
-export const DatabaseBackups: React.FC = () => {
+export const DatabaseBackups = () => {
   const { databaseId, engine } = useParams<{
     databaseId: string;
     engine: Engine;

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsMenuItem.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/DatabaseSettingsMenuItem.tsx
@@ -1,8 +1,8 @@
+import { Theme } from '@mui/material/styles';
 import * as React from 'react';
 import Button from 'src/components/Button';
-import { makeStyles } from '@mui/styles';
-import { Theme } from '@mui/material/styles';
 import Typography from 'src/components/core/Typography';
+import { makeStyles } from 'tss-react/mui';
 
 interface Props {
   buttonText: string;
@@ -12,7 +12,7 @@ interface Props {
   disabled?: boolean;
 }
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles()((theme: Theme) => ({
   topSection: {
     display: 'flex',
     alignItems: 'center',
@@ -44,7 +44,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-export const DatabaseSettingsMenuItem: React.FC<Props> = (props) => {
+export const DatabaseSettingsMenuItem = (props: Props) => {
   const {
     buttonText,
     descriptiveText,
@@ -53,7 +53,7 @@ export const DatabaseSettingsMenuItem: React.FC<Props> = (props) => {
     disabled = false,
   } = props;
 
-  const classes = useStyles();
+  const { classes } = useStyles();
 
   return (
     <div className={classes.topSection} data-qa-settings-section={sectionTitle}>

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/MaintenanceWindow.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSettings/MaintenanceWindow.tsx
@@ -1,5 +1,6 @@
 import { Database, UpdatesSchedule } from '@linode/api-v4/lib/databases';
 import { APIError } from '@linode/api-v4/lib/types';
+import { Theme } from '@mui/material/styles';
 import { useFormik } from 'formik';
 import { DateTime } from 'luxon';
 import { useSnackbar } from 'notistack';
@@ -9,17 +10,16 @@ import Button from 'src/components/Button';
 import FormControl from 'src/components/core/FormControl';
 import FormControlLabel from 'src/components/core/FormControlLabel';
 import RadioGroup from 'src/components/core/RadioGroup';
-import { makeStyles } from '@mui/styles';
-import { Theme } from '@mui/material/styles';
 import Typography from 'src/components/core/Typography';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import HelpIcon from 'src/components/HelpIcon';
 import Notice from 'src/components/Notice';
 import Radio from 'src/components/Radio';
 import { useDatabaseMutation } from 'src/queries/databases';
+import { makeStyles } from 'tss-react/mui';
 // import { updateDatabaseSchema } from '@linode/validation/src/databases.schema';
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles()((theme: Theme) => ({
   topSection: {
     display: 'flex',
     alignItems: 'center',
@@ -58,6 +58,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   formControlDropdown: {
     marginRight: '3rem',
+    '& label': {
+      overflow: 'visible',
+    },
   },
 }));
 
@@ -66,7 +69,7 @@ interface Props {
   timezone?: string;
 }
 
-export const MaintenanceWindow: React.FC<Props> = (props) => {
+export const MaintenanceWindow = (props: Props) => {
   const { database, timezone } = props;
 
   const [maintenanceUpdateError, setMaintenanceUpdateError] = React.useState<
@@ -82,7 +85,7 @@ export const MaintenanceWindow: React.FC<Props> = (props) => {
     setModifiedWeekSelectionMap,
   ] = React.useState<Item[]>([]);
 
-  const classes = useStyles();
+  const { classes } = useStyles();
   const { enqueueSnackbar } = useSnackbar();
 
   const { mutateAsync: updateDatabase } = useDatabaseMutation(

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryClusterConfiguration.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryClusterConfiguration.tsx
@@ -1,19 +1,19 @@
 import { Database, DatabaseInstance } from '@linode/api-v4/lib/databases/types';
+import { Theme } from '@mui/material/styles';
 import * as React from 'react';
 import Box from 'src/components/core/Box';
-import { makeStyles } from '@mui/styles';
-import { Theme } from '@mui/material/styles';
 import Typography from 'src/components/core/Typography';
 import StatusIcon from 'src/components/StatusIcon';
 import { useDatabaseTypesQuery } from 'src/queries/databases';
 import { useRegionsQuery } from 'src/queries/regions';
 import { convertMegabytesTo } from 'src/utilities/unitConversions';
+import { makeStyles } from 'tss-react/mui';
 import {
   databaseEngineMap,
   databaseStatusMap,
 } from '../../DatabaseLanding/DatabaseRow';
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles()((theme: Theme) => ({
   header: {
     marginBottom: theme.spacing(2),
   },
@@ -41,8 +41,8 @@ export const getDatabaseVersionNumber = (
   version: DatabaseInstance['version']
 ) => version.split('/')[1];
 
-export const DatabaseSummaryClusterConfiguration: React.FC<Props> = (props) => {
-  const classes = useStyles();
+export const DatabaseSummaryClusterConfiguration = (props: Props) => {
+  const { classes } = useStyles();
 
   const { database } = props;
 

--- a/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/DatabaseSummary/DatabaseSummaryConnectionDetails.tsx
@@ -1,23 +1,23 @@
 import { getSSLFields } from '@linode/api-v4/lib/databases/databases';
 import { Database, SSLFields } from '@linode/api-v4/lib/databases/types';
+import { Theme } from '@mui/material/styles';
 import { useSnackbar } from 'notistack';
 import * as React from 'react';
 import DownloadIcon from 'src/assets/icons/lke-download.svg';
 import Button from 'src/components/Button';
 import CircleProgress from 'src/components/CircleProgress';
-import Box from 'src/components/core/Box';
-import { makeStyles } from '@mui/styles';
-import { Theme } from '@mui/material/styles';
-import Typography from 'src/components/core/Typography';
 import CopyTooltip from 'src/components/CopyTooltip';
+import Box from 'src/components/core/Box';
+import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 import HelpIcon from 'src/components/HelpIcon';
 import { DB_ROOT_USERNAME } from 'src/constants';
 import { useDatabaseCredentialsQuery } from 'src/queries/databases';
 import { downloadFile } from 'src/utilities/downloadFile';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
+import { makeStyles } from 'tss-react/mui';
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles()((theme: Theme) => ({
   header: {
     marginBottom: theme.spacing(2),
   },
@@ -113,9 +113,9 @@ const privateHostCopy =
 const mongoHostHelperCopy =
   'This is a public hostname. Coming soon: connect to your MongoDB clusters using private IPs';
 
-export const DatabaseSummaryConnectionDetails: React.FC<Props> = (props) => {
+export const DatabaseSummaryConnectionDetails = (props: Props) => {
   const { database } = props;
-  const classes = useStyles();
+  const { classes } = useStyles();
   const { enqueueSnackbar } = useSnackbar();
   const [showCredentials, setShowPassword] = React.useState<boolean>(false);
 

--- a/packages/manager/src/features/Databases/DatabaseDetail/index.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/index.tsx
@@ -22,7 +22,7 @@ const DatabaseSummary = React.lazy(() => import('./DatabaseSummary'));
 const DatabaseBackups = React.lazy(() => import('./DatabaseBackups'));
 const DatabaseSettings = React.lazy(() => import('./DatabaseSettings'));
 
-export const DatabaseDetail: React.FC = () => {
+export const DatabaseDetail = () => {
   const history = useHistory();
 
   const { databaseId, engine } = useParams<{

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseActionMenu.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseActionMenu.tsx
@@ -1,11 +1,12 @@
+import { Theme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { useTheme } from '@mui/styles';
 import * as React from 'react';
 import ActionMenu, { Action } from 'src/components/ActionMenu';
 import InlineAction from 'src/components/InlineMenuAction';
-import { makeStyles, useTheme } from '@mui/styles';
-import { Theme } from '@mui/material/styles';
-import useMediaQuery from '@mui/material/useMediaQuery';
+import { makeStyles } from 'tss-react/mui';
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles()(() => ({
   root: {
     padding: '0px !important',
     display: 'flex',
@@ -27,8 +28,8 @@ interface Props extends ActionHandlers {
 
 type CombinedProps = Props;
 
-const DatabaseActionMenu: React.FC<CombinedProps> = (props) => {
-  const classes = useStyles();
+const DatabaseActionMenu = (props: CombinedProps) => {
+  const { classes } = useStyles();
   const theme = useTheme<Theme>();
   const matchesSmDown = useMediaQuery(theme.breakpoints.down('md'));
 

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseEmptyState.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseEmptyState.tsx
@@ -7,7 +7,6 @@ import PointerIcon from 'src/assets/icons/pointer.svg';
 import YoutubeIcon from 'src/assets/icons/youtube.svg';
 import List from 'src/components/core/List';
 import ListItem from 'src/components/core/ListItem';
-import { makeStyles } from '@mui/styles';
 import Typography from 'src/components/core/Typography';
 import Link from 'src/components/Link';
 import Placeholder from 'src/components/Placeholder';
@@ -23,6 +22,7 @@ import {
   youtubeMoreLinkText,
 } from 'src/utilities/emptyStateLandingUtils';
 import { sendEvent } from 'src/utilities/ga';
+import { makeStyles } from 'tss-react/mui';
 
 const gaCategory = 'Managed Databases landing page empty';
 const linkGAEventTemplate = {
@@ -94,7 +94,7 @@ const youtubeLinks = (
   </List>
 );
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles()(() => ({
   root: {
     '& > svg': {
       transform: 'scale(0.8)',
@@ -102,8 +102,8 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-const DatabaseEmptyState: React.FC = () => {
-  const classes = useStyles();
+const DatabaseEmptyState = () => {
+  const { classes } = useStyles();
   const history = useHistory();
 
   return (

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseLanding.tsx
@@ -22,7 +22,7 @@ import { DatabaseRow } from './DatabaseRow';
 
 const preferenceKey = 'databases';
 
-const DatabaseLanding: React.FC = () => {
+const DatabaseLanding = () => {
   const history = useHistory();
   const pagination = usePagination(1, preferenceKey);
 

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseRow.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseRow.tsx
@@ -38,7 +38,7 @@ interface Props {
   database: DatabaseInstance;
 }
 
-export const DatabaseRow: React.FC<Props> = ({ database }) => {
+export const DatabaseRow = ({ database }: Props) => {
   const {
     id,
     label,

--- a/packages/manager/src/features/Databases/index.tsx
+++ b/packages/manager/src/features/Databases/index.tsx
@@ -2,29 +2,12 @@ import * as React from 'react';
 import { Route, Switch } from 'react-router-dom';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import SuspenseLoader from 'src/components/SuspenseLoader';
-import useAccountManagement from 'src/hooks/useAccountManagement';
-import useFlags from 'src/hooks/useFlags';
-import { isFeatureEnabled } from 'src/utilities/accountCapabilities';
 
 const DatabaseLanding = React.lazy(() => import('./DatabaseLanding'));
 const DatabaseDetail = React.lazy(() => import('./DatabaseDetail'));
 const DatabaseCreate = React.lazy(() => import('./DatabaseCreate'));
 
-const Database: React.FC = () => {
-  // @TODO: Remove when Database goes to GA
-  const { account } = useAccountManagement();
-  const flags = useFlags();
-
-  const showDatabases = isFeatureEnabled(
-    'Managed Databases',
-    Boolean(flags.databases),
-    account?.capabilities ?? []
-  );
-
-  if (!showDatabases) {
-    return null;
-  }
-
+const Database = () => {
   return (
     <React.Suspense fallback={<SuspenseLoader />}>
       <DocumentTitleSegment segment="Databases" />


### PR DESCRIPTION
## Description 📝
Migrates `SRC > Features > Databases` from JSS to tss-react (Emotion)

## Major Changes 🔄 
- Removed `@mui/styles` imports
- Removed `React.FC`
- Removed deprecated `createStyles` and unnecessary `withStyles`
- Removed conditional display logic from when DBaaS was in beta
- Fixed truncation bug in Maintenance Window section

<details>
<summary>Maintenance Window truncation bug</summary>

**Production**:
![Screenshot 2023-03-20 at 5 20 15 PM](https://user-images.githubusercontent.com/114682940/226468490-e41375dd-f925-43db-9781-f3557e56aa45.jpg)

**This branch**:
![Screenshot 2023-03-20 at 5 20 31 PM](https://user-images.githubusercontent.com/114682940/226468530-a2a3a5f8-1e23-4cb1-9ccf-6f1dd58f3587.jpg)
</details>


## How to test 🧪
Take a look through the `/databases` flows in the app to ensure there have been no regressions.

