### PR TITLE
refactor: [M3-6290] - MUI v5 Migration - `Components > Accordion`

### DIFF
--- a/packages/manager/src/components/Accordion/Accordion.tsx
+++ b/packages/manager/src/components/Accordion/Accordion.tsx
@@ -51,6 +51,7 @@ export const Accordion = (props: Props) => {
     summaryProps,
     detailProps,
     headingProps,
+    heading,
     actions,
     success,
     warning,
@@ -78,10 +79,10 @@ export const Accordion = (props: Props) => {
         onClick={handleClick}
         expandIcon={<KeyboardArrowDown className="caret" />}
         {...summaryProps}
-        data-qa-panel-summary={props.heading}
+        data-qa-panel-summary={heading}
       >
         <Typography {...headingProps} variant="h3" data-qa-panel-subheading>
-          {props.heading}
+          {heading}
         </Typography>
         {headingNumberCount && headingNumberCount > 0 ? (
           <span className={classes.itemCount}>{headingNumberCount}</span>
@@ -89,7 +90,7 @@ export const Accordion = (props: Props) => {
       </AccordionSummary>
       <AccordionDetails {...detailProps} data-qa-panel-details>
         <Grid container>
-          {notice && (
+          {notice ? (
             <Grid item xs={12}>
               <Notice
                 data-qa-notice
@@ -100,13 +101,13 @@ export const Accordion = (props: Props) => {
                 spacingBottom={0}
               />
             </Grid>
-          )}
+          ) : null}
           <Grid item xs={12} data-qa-grid-item>
             {props.children}
           </Grid>
         </Grid>
       </AccordionDetails>
-      {actions && actions(accordionProps)}
+      {actions ? actions(accordionProps) : null}
     </_Accordion>
   );
 };

--- a/packages/manager/src/components/Accordion/Accordion.tsx
+++ b/packages/manager/src/components/Accordion/Accordion.tsx
@@ -7,13 +7,13 @@ import AccordionDetails, {
 import AccordionSummary, {
   AccordionSummaryProps,
 } from 'src/components/core/AccordionSummary';
-import { makeStyles } from '@mui/styles';
 import Typography, { TypographyProps } from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 import RenderGuard from 'src/components/RenderGuard';
+import { makeStyles } from 'tss-react/mui';
 import Notice from '../Notice';
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles()(() => ({
   itemCount: {
     display: 'flex',
     alignItems: 'center',
@@ -44,10 +44,8 @@ export interface Props extends AccordionProps {
   headingNumberCount?: number;
 }
 
-type CombinedProps = Props;
-
-export const Accordion: React.FC<CombinedProps> = (props) => {
-  const classes = useStyles();
+export const Accordion = (props: Props) => {
+  const { classes } = useStyles();
 
   const {
     summaryProps,


### PR DESCRIPTION
## Description 📝
Migrates `SRC > Components > Accordion` from JSS to tss-react (Emotion)

## How to test 🧪
Confirm there have been no visual regressions for Accordions in the app (ex: on Service Transfers tab)