### PR TITLE
refactor: [M3-6327, M3-6328] - MUI v5 Migration - Components > Drawer, DrawerContent 

### DIFF
--- a/packages/manager/src/components/Drawer/Drawer.tsx
+++ b/packages/manager/src/components/Drawer/Drawer.tsx
@@ -1,8 +1,8 @@
 import Close from '@mui/icons-material/Close';
 import * as React from 'react';
 import Button from 'src/components/Button';
-import Drawer, { DrawerProps } from 'src/components/core/Drawer';
-import { makeStyles } from '@mui/styles';
+import _Drawer, { DrawerProps } from 'src/components/core/Drawer';
+import { makeStyles } from 'tss-react/mui';
 import { Theme } from '@mui/material/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
@@ -13,7 +13,7 @@ export interface Props extends DrawerProps {
   wide?: boolean;
 }
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles()((theme: Theme) => ({
   paper: {
     width: 300,
     padding: theme.spacing(2),
@@ -59,17 +59,15 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-type CombinedProps = Props;
-
-const DDrawer: React.FC<CombinedProps> = (props) => {
-  const classes = useStyles();
+const Drawer = (props: Props) => {
+  const { classes } = useStyles();
 
   const { title, children, onClose, wide, ...rest } = props;
 
   const titleID = convertForAria(title);
 
   return (
-    <Drawer
+    <_Drawer
       anchor="right"
       classes={{ paper: `${classes.paper} ${wide ? classes.wide : ''}` }}
       onClose={(event, reason) => {
@@ -111,7 +109,7 @@ const DDrawer: React.FC<CombinedProps> = (props) => {
           <Button
             className={classes.button}
             buttonType="secondary"
-            onClick={props.onClose as (e: any) => void}
+            onClick={onClose as (e: any) => void}
             aria-label="Close drawer"
             data-qa-close-drawer
           >
@@ -120,8 +118,8 @@ const DDrawer: React.FC<CombinedProps> = (props) => {
         </Grid>
       </Grid>
       {children}
-    </Drawer>
+    </_Drawer>
   );
 };
 
-export default DDrawer;
+export default Drawer;

--- a/packages/manager/src/components/Drawer/Drawer.tsx
+++ b/packages/manager/src/components/Drawer/Drawer.tsx
@@ -37,7 +37,9 @@ const useStyles = makeStyles()((theme: Theme) => ({
     },
   },
   drawerHeader: {
-    marginBottom: theme.spacing(2),
+    '&&': {
+      marginBottom: theme.spacing(2),
+    },
   },
   title: {
     wordBreak: 'break-word',

--- a/packages/manager/src/components/DrawerContent/DrawerContent.test.tsx
+++ b/packages/manager/src/components/DrawerContent/DrawerContent.test.tsx
@@ -3,17 +3,16 @@ import * as React from 'react';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 import { DrawerContent, Props } from './DrawerContent';
 
+const defaultChildren = <div>Content</div>;
+
 const renderDrawer = (props: Props) =>
-  renderWithTheme(
-    <DrawerContent {...props}>
-      <div>Content</div>
-    </DrawerContent>
-  );
+  renderWithTheme(<DrawerContent {...props} />);
 
 const props: Props = {
   loading: true,
   error: false,
   title: 'my-drawer',
+  children: defaultChildren,
 };
 
 describe('DrawerContent', () => {

--- a/packages/manager/src/components/DrawerContent/DrawerContent.tsx
+++ b/packages/manager/src/components/DrawerContent/DrawerContent.tsx
@@ -7,9 +7,10 @@ export interface Props {
   loading: boolean;
   error: boolean;
   errorMessage?: string;
+  children: React.ReactNode;
 }
 
-export const DrawerContent: React.FC<Props> = (props) => {
+export const DrawerContent = (props: Props) => {
   const { title, loading, error, errorMessage, children } = props;
   if (loading) {
     return <CircleProgress />;
@@ -23,7 +24,7 @@ export const DrawerContent: React.FC<Props> = (props) => {
     );
   }
   // eslint-disable-next-line
-  return <React.Fragment>{children}</React.Fragment>;
+  return <>{children}</>;
 };
 
 export default DrawerContent;


### PR DESCRIPTION
## Description 📝

**What does this PR do?**

- Runs the codemod on `Drawer.tsx`.
- Runs the codemod on `DrawerContent.tsx` but no styling updates here -- this component didn't have styles to begin with!
- Removes `React.FC` from `Drawer` and `DrawerContent`.
   - Updates the unit test for `DrawerContent` due to the need to explicitly declare the `children` prop with the removal of `React.FC`.
- A couple other small code clean up items (renaming 'DDrawer' to 'Drawer', destructuring rather than using `props.`)

## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**
Visually compare prod and this branch in a few places the components are used throughout the app. For example:
- The Add/Resize/Rename a Disk on a linode drawer
- The Add Payment Method drawer: https://cloud.linode.com/account/billing/add-payment-method
- The View Kubeconfig drawer (the only place `DrawerContent` component is used)

There should be no visual changes.

**How do I run relevant unit or e2e tests?**
```
yarn test DrawerContent
```
