### PR TITLE
fix: [M3-6433] - Fix crash for Events with a `null` community post `entity`

### DIFF
--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -55,19 +55,19 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
     notification: (e) =>
       e.entity
         ? `There has been a reply to your thread "${e.entity.label}".`
-        : `There has been a reply to your thread`,
+        : `There has been a reply to your thread.`,
   },
   community_like: {
     notification: (e) =>
       e.entity
         ? `A post on "${e.entity.label}" has been liked.`
-        : `There has been a like on your community post`,
+        : `There has been a like on your community post.`,
   },
   community_mention: {
     notification: (e) =>
       e.entity
-        ? `You have been mentioned in a Community post: ${e.entity.label}`
-        : `You have been mentioned in a Community post`,
+        ? `You have been mentioned in a Community post: ${e.entity.label}.`
+        : `You have been mentioned in a Community post.`,
   },
   credit_card_updated: {
     notification: (e) => `Credit card information has been updated.`,

--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -2,7 +2,7 @@ import { Event } from '@linode/api-v4/lib/account';
 import { path } from 'ramda';
 import { isProductionBuild } from 'src/constants';
 import { reportException } from 'src/exceptionReporting';
-import createLinkHandlerForNotification from 'src/utilities/getEventsActionLink';
+import { getLinkForEvent } from 'src/utilities/getEventsActionLink';
 import {
   formatEventWithUsername,
   formatEventWithAppendedText,
@@ -53,14 +53,21 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
   },
   community_question_reply: {
     notification: (e) =>
-      `There has been a reply to your thread "${e.entity!.label}".`,
+      e.entity
+        ? `There has been a reply to your thread "${e.entity.label}".`
+        : `There has been a reply to your thread`,
   },
   community_like: {
-    notification: (e) => e.entity!.label,
+    notification: (e) =>
+      e.entity
+        ? `A post on "${e.entity.label}" has been liked.`
+        : `There has been a like on your community post`,
   },
   community_mention: {
     notification: (e) =>
-      `You have been mentioned in a Community post: ${e.entity!.label}`,
+      e.entity
+        ? `You have been mentioned in a Community post: ${e.entity.label}`
+        : `You have been mentioned in a Community post`,
   },
   credit_card_updated: {
     notification: (e) => `Credit card information has been updated.`,
@@ -844,12 +851,8 @@ function applyLinking(event: Event, message: string) {
     return '';
   }
 
-  const entityLinkTarget = createLinkHandlerForNotification(
-    event.action,
-    event.entity,
-    false
-  );
-  const secondaryEntityLinkTarget = createLinkHandlerForNotification(
+  const entityLinkTarget = getLinkForEvent(event.action, event.entity, false);
+  const secondaryEntityLinkTarget = getLinkForEvent(
     event.action,
     event.secondary_entity,
     false

--- a/packages/manager/src/features/Events/EventRow.tsx
+++ b/packages/manager/src/features/Events/EventRow.tsx
@@ -13,7 +13,7 @@ import TableRow from 'src/components/TableRow';
 import eventMessageGenerator from 'src/eventMessageGenerator';
 import { parseAPIDate } from 'src/utilities/date';
 import { getEntityByIDFromStore } from 'src/utilities/getEntityByIDFromStore';
-import getEventsActionLink from 'src/utilities/getEventsActionLink';
+import { getLinkForEvent } from 'src/utilities/getEventsActionLink';
 import { GravatarByUsername } from '../../components/GravatarByUsername';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -42,7 +42,7 @@ type CombinedProps = Props;
 
 export const EventRow: React.FC<CombinedProps> = (props) => {
   const { event, entityId } = props;
-  const link = getEventsActionLink(event.action, event.entity, event._deleted);
+  const link = getLinkForEvent(event.action, event.entity, event._deleted);
   const type = pathOr<string>('linode', ['entity', 'type'], event);
   const id = pathOr<string | number>(-1, ['entity', 'id'], event);
   const entity = getEntityByIDFromStore(type, id);

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -1,6 +1,5 @@
 import { DateTime } from 'luxon';
 import {
-  EventAction,
   NotificationType,
   SecurityQuestionsPayload,
   TokenRequest,
@@ -799,49 +798,38 @@ export const handlers = [
     );
   }),
   rest.get('*/events', (req, res, ctx) => {
-    const events = eventFactory.buildList(1, {
-      action: 'lke_node_create',
-      percent_complete: 15,
-      entity: { type: 'linode', id: 999, label: 'linode-1' },
-      message:
-        'Rebooting this thing and showing an extremely long event message for no discernible reason other than the fairly obvious reason that we want to do some testing of whether or not these messages wrap.',
+    const brokenEvent = eventFactory.build({
+      action: 'community_question_reply',
+      message: 'some community reply',
+      username: 'randomperson',
+      status: 'notification',
+      percent_complete: null,
+      entity: null,
+      seen: false,
+      read: false,
     });
-    const volumeMigrationScheduled = eventFactory.build({
-      entity: { type: 'volume', id: 6, label: 'bravoExample' },
-      action: 'volume_migrate_scheduled' as EventAction,
-      status: 'scheduled',
-      message: 'Volume bravoExample has been scheduled for an upgrade to NVMe.',
-      percent_complete: 100,
+    const brokenEvent2 = eventFactory.build({
+      action: 'community_mention',
+      message: 'some community reply',
+      username: 'randomperson',
+      status: 'notification',
+      percent_complete: null,
+      entity: null,
+      seen: false,
+      read: false,
     });
-    const volumeMigrating = eventFactory.build({
-      entity: { type: 'volume', id: 2, label: 'example-upgrading' },
-      action: 'volume_migrate' as EventAction,
-      status: 'started',
-      message: 'Volume example-upgrading is being upgraded to NVMe.',
-      percent_complete: 65,
+    const brokenEvent3 = eventFactory.build({
+      action: 'community_like',
+      message: 'some community reply',
+      username: 'randomperson',
+      status: 'notification',
+      percent_complete: null,
+      entity: null,
+      seen: false,
+      read: false,
     });
-    const volumeMigrationFinished = eventFactory.build({
-      entity: { type: 'volume', id: 6, label: 'alphaExample' },
-      action: 'volume_migrate',
-      status: 'finished',
-      message: 'Volume alphaExample has finished upgrading to NVMe.',
-      percent_complete: 100,
-    });
-    const oldEvents = eventFactory.buildList(20, {
-      action: 'account_update',
-      seen: true,
-      percent_complete: 100,
-    });
-    return res.once(
-      ctx.json(
-        makeResourcePage([
-          ...events,
-          ...oldEvents,
-          volumeMigrationScheduled,
-          volumeMigrating,
-          volumeMigrationFinished,
-        ])
-      )
+    return res(
+      ctx.json(makeResourcePage([brokenEvent, brokenEvent2, brokenEvent3]))
     );
   }),
   rest.get('*/support/tickets', (req, res, ctx) => {

--- a/packages/manager/src/utilities/getEventsActionLink.ts
+++ b/packages/manager/src/utilities/getEventsActionLink.ts
@@ -9,7 +9,7 @@ export const getEngineFromDatabaseEntityURL = (url: string) => {
   return url.match(/databases\/(\w*)\/instances/i)?.[1];
 };
 
-export default (
+export const getLinkForEvent = (
   action: EventAction,
   entity: null | Entity,
   deleted: undefined | string | boolean
@@ -18,8 +18,8 @@ export default (
   const id = entity?.id;
   const label = entity?.label;
 
-  if (action.match(/community/gi)) {
-    return entity!.url;
+  if (action.startsWith('community')) {
+    return entity?.url;
   }
 
   if (['disk_delete', 'linode_config_delete'].includes(action)) {
@@ -104,7 +104,7 @@ export default (
 
     case 'database':
       return `/databases/${getEngineFromDatabaseEntityURL(
-        entity!.url
+        entity?.url
       )}/${id}/summary`;
 
     case 'user':


### PR DESCRIPTION
## Description 📝

### The Bug 🐛
- Users who use https://www.linode.com/community/ were experiencing crashes when they opened the events menu when they clicked the bell icon in the top right of Cloud Manager
- Cloud Manager would crash because a `community_question_reply` event would exist where `entity` is `null`. When we did `entity!.url`, this would cause a crash because you can't access a property on null

### The Fix 🧰
- The actual fix is safely accessing the `url` value on line `22` of `packages/manager/src/utilities/getEventsActionLink.ts` (this is what was causing the crash)
- This PR also includes some minor improvements:
  - Uses named export instead of default export 
  - Improves some event messages for community related events

## Preview 📷

![Screenshot 2023-03-23 at 3 10 22 PM](https://user-images.githubusercontent.com/115251059/227322752-a1769d4b-792f-4089-8f72-e999ed28ee96.jpg)

## How to test 🧪

- Turn the MSW **on**
- Open the Event/Notification menu by clicking the bell icon in the top right of Cloud Manager
- If Cloud Manager does not crash, we can conclude this bug is fixed
  
### 
  > **Note**: I updated the events mocks to test this. I will restore them to more sane defaults before merging