### PR TITLE
refactor: [M3-6323, M3-6339, M3-6348] - MUI v5 Migration - Components > DocsLink, ExternalLink, IconTextLink

### DIFF
--- a/packages/manager/src/components/DocsLink/DocsLink.tsx
+++ b/packages/manager/src/components/DocsLink/DocsLink.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import DocsIcon from 'src/assets/icons/docs.svg';
-import { makeStyles } from '@mui/styles';
+import { makeStyles } from 'tss-react/mui';
 import { Theme } from '@mui/material/styles';
 import { sendHelpButtonClickEvent } from 'src/utilities/ga';
 import IconTextLink from '../IconTextLink';
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles()((theme: Theme) => ({
   root: {
     alignItems: 'center',
     fontFamily: theme.font.normal,
@@ -38,8 +38,8 @@ interface Props {
   onClick?: () => void;
 }
 
-export const DocsLink: React.FC<Props> = (props) => {
-  const classes = useStyles();
+export const DocsLink = (props: Props) => {
+  const { classes } = useStyles();
 
   const { href, label, analyticsLabel, onClick } = props;
 

--- a/packages/manager/src/components/ExternalLink/ExternalLink.tsx
+++ b/packages/manager/src/components/ExternalLink/ExternalLink.tsx
@@ -1,49 +1,51 @@
 import * as React from 'react';
-import classNames from 'classnames';
 import OpenInNew from '@mui/icons-material/OpenInNew';
 import Arrow from 'src/assets/icons/diagonalArrow.svg';
-import { makeStyles } from '@mui/styles';
+import { makeStyles } from 'tss-react/mui';
 import { Theme } from '@mui/material/styles';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    color: theme.name === 'dark' ? theme.textColors.linkActiveLight : undefined,
-    display: 'inline-flex',
-    alignItems: 'baseline',
-    '&:hover': {
-      '& $icon': {
-        opacity: 1,
+const useStyles = makeStyles<void, 'icon'>()(
+  (theme: Theme, _params, classes) => ({
+    root: {
+      color:
+        theme.name === 'dark' ? theme.textColors.linkActiveLight : undefined,
+      display: 'inline-flex',
+      alignItems: 'baseline',
+      '&:hover': {
+        [`& .${classes.icon}`]: {
+          opacity: 1,
+        },
       },
     },
-  },
-  icon: {
-    color: theme.palette.primary.main,
-    position: 'relative',
-    left: theme.spacing(1),
-    opacity: 0,
-    width: 14,
-    height: 14,
-  },
-  absoluteIcon: {
-    display: 'inline',
-    position: 'relative',
-    paddingRight: 26,
-    '& $icon': {
-      position: 'absolute',
-      right: 0,
-      bottom: 2,
+    icon: {
+      color: theme.palette.primary.main,
+      position: 'relative',
+      left: theme.spacing(1),
       opacity: 0,
-      left: 'initial',
+      width: 14,
+      height: 14,
     },
-  },
-  fixedIcon: {
-    display: 'inline-block',
-    fontSize: '0.8em',
-  },
-  black: {
-    color: theme.palette.text.primary,
-  },
-}));
+    absoluteIcon: {
+      display: 'inline',
+      position: 'relative',
+      paddingRight: 26,
+      [`& .${classes.icon}`]: {
+        position: 'absolute',
+        right: 0,
+        bottom: 2,
+        opacity: 0,
+        left: 'initial',
+      },
+    },
+    fixedIcon: {
+      display: 'inline-block',
+      fontSize: '0.8em',
+    },
+    black: {
+      color: theme.palette.text.primary,
+    },
+  })
+);
 
 interface Props {
   link: string;
@@ -56,8 +58,8 @@ interface Props {
   onClick?: () => void;
 }
 
-const ExternalLink: React.FC<Props> = (props) => {
-  const classes = useStyles();
+const ExternalLink = (props: Props) => {
+  const { classes, cx } = useStyles();
   const {
     link,
     text,
@@ -76,7 +78,7 @@ const ExternalLink: React.FC<Props> = (props) => {
       aria-describedby="external-site"
       rel="noopener noreferrer"
       href={link}
-      className={classNames(
+      className={cx(
         {
           [classes.root]: true,
           [classes.absoluteIcon]: absoluteIcon,

--- a/packages/manager/src/components/IconTextLink/IconTextLink.tsx
+++ b/packages/manager/src/components/IconTextLink/IconTextLink.tsx
@@ -3,76 +3,66 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 import Button from 'src/components/Button';
 import ConditionalWrapper from 'src/components/ConditionalWrapper';
-import { createStyles, withStyles, WithStyles } from '@mui/styles';
+import { makeStyles } from 'tss-react/mui';
 import { Theme } from '@mui/material/styles';
 import SvgIcon from 'src/components/core/SvgIcon';
 
-type CSSClasses =
-  | 'root'
-  | 'active'
-  | 'disabled'
-  | 'icon'
-  | 'left'
-  | 'label'
-  | 'linkWrapper';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {
-      display: 'flex',
-      alignItems: 'flex-start',
-      cursor: 'pointer',
-      padding: theme.spacing(1) + theme.spacing(0.5),
-      color: theme.textColors.linkActiveLight,
-      transition: 'none',
-      margin: `0 ${theme.spacing(1)} 2px 0`,
-      minHeight: 'auto',
-      borderRadius: 0,
-      '&:hover': {
-        color: theme.palette.primary.light,
-        backgroundColor: 'transparent',
-        '& .border': {
-          color: theme.palette.primary.light,
-        },
-      },
-      '&:focus': { outline: '1px dotted #999' },
-    },
-    active: {
-      color: '#1f64b6',
-    },
-    disabled: {
-      color: '#939598',
-      pointerEvents: 'none',
-      '& $icon': {
-        color: '#939598',
-        borderColor: '#939598',
-      },
-    },
-    icon: {
-      transition: 'none',
-      fontSize: 18,
-      marginRight: theme.spacing(0.5),
-      color: 'inherit',
+const useStyles = makeStyles()((theme: Theme) => ({
+  root: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    cursor: 'pointer',
+    padding: theme.spacing(1) + theme.spacing(0.5),
+    color: theme.textColors.linkActiveLight,
+    transition: 'none',
+    margin: `0 ${theme.spacing(1)} 2px 0`,
+    minHeight: 'auto',
+    borderRadius: 0,
+    '&:hover': {
+      color: theme.palette.primary.light,
+      backgroundColor: 'transparent',
       '& .border': {
-        transition: 'none',
+        color: theme.palette.primary.light,
       },
     },
-    left: {
-      left: -(theme.spacing(1) + theme.spacing(0.5)),
+    '&:focus': { outline: '1px dotted #999' },
+  },
+  active: {
+    color: '#1f64b6',
+  },
+  disabled: {
+    color: '#939598',
+    pointerEvents: 'none',
+    '& $icon': {
+      color: '#939598',
+      borderColor: '#939598',
     },
-    label: {
-      whiteSpace: 'nowrap',
-      position: 'relative',
-      top: -1,
+  },
+  icon: {
+    transition: 'none',
+    fontSize: 18,
+    marginRight: theme.spacing(0.5),
+    color: 'inherit',
+    '& .border': {
+      transition: 'none',
     },
-    linkWrapper: {
-      display: 'flex',
-      justifyContent: 'center',
-      '&:hover, &:focus': {
-        textDecoration: 'none',
-      },
+  },
+  left: {
+    left: -(theme.spacing(1) + theme.spacing(0.5)),
+  },
+  label: {
+    whiteSpace: 'nowrap',
+    position: 'relative',
+    top: -1,
+  },
+  linkWrapper: {
+    display: 'flex',
+    justifyContent: 'center',
+    '&:hover, &:focus': {
+      textDecoration: 'none',
     },
-  });
+  },
+}));
 
 export interface Props {
   SideIcon: typeof SvgIcon | React.ComponentClass;
@@ -82,17 +72,17 @@ export interface Props {
   disabled?: boolean;
   title: string;
   left?: boolean;
-  className?: any;
+  className?: string;
   to?: string;
   hideText?: boolean;
+  children?: string;
 }
 
-type FinalProps = Props & WithStyles<CSSClasses>;
+const IconTextLink = (props: Props) => {
+  const { classes } = useStyles();
 
-const IconTextLink: React.FC<FinalProps> = (props) => {
   const {
     SideIcon,
-    classes,
     text,
     onClick,
     active,
@@ -143,4 +133,4 @@ const IconTextLink: React.FC<FinalProps> = (props) => {
   );
 };
 
-export default withStyles(styles)(IconTextLink);
+export default IconTextLink;


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
- Runs the tss-react codemod on `DocsLink.tsx`, `ExternalLink.tsx`, and `IconTextLink.tsx`.
- Removes `withStyles` and `createStyles` from `IconTextLink.tsx`.
- Removes `React.FC` from all components and explicitly defines `children` prop as necessary.

## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**
- Test that there have been no visual regressions in `ExternalLink`s, such as on an empty state landing page.
- Test that there have been no visual regressions in the `DocsLink` (and `IconTextLink`, which is used by `DocsLink`), such as on the Linode Create page.