### PR TITLE
fix: [M3-4876] - Update incorrect headline

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
@@ -741,7 +741,7 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
         >
           <Grid item className="p0">
             <Typography variant="h3" className={classes.headline}>
-              Volumes
+              IP Addresses
             </Typography>
           </Grid>
           <Grid item className={classes.addNewWrapper}>


### PR DESCRIPTION
## Description 📝
During header refactor, the IP Addresses headline was accidentally changed: https://github.com/linode/manager/commit/49d2b7f003b05ba19bd089a0620016988e641771#diff-5caa4223a15c042e9ba9a0431e4cdfc099eff9021c407a2b8f41b927c9895b7dL716

## How to test 🧪
1. Go to a Linode details page
2. Click on the Networking tab
3. Scroll down to table of IP Addresses and observe the header change