### PR TITLE
refactor: [M3-6387] - MUI v5 Migration - Components > SelectionCard

### DIFF
--- a/packages/manager/src/components/SelectionCard/CardBase.tsx
+++ b/packages/manager/src/components/SelectionCard/CardBase.tsx
@@ -1,133 +1,127 @@
 import * as React from 'react';
-import { makeStyles } from '@mui/styles';
-import { Theme } from '@mui/material/styles';
-import Grid from 'src/components/Grid';
+import Grid from '@mui/material/Unstable_Grid2';
+import { styled } from '@mui/material/styles';
+import { SxProps } from '@mui/system';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  '@keyframes fadeIn': {
-    from: {
-      opacity: 0,
-    },
-    to: {
-      opacity: 1,
-    },
+const CardBaseGrid = styled(Grid, {
+  label: 'CardBaseGrid',
+})(({ theme }) => ({
+  alignItems: 'center',
+  backgroundColor: theme.bg.offWhite,
+  border: `1px solid ${theme.bg.main}`,
+  height: '100%',
+  margin: 0,
+  minHeight: 60,
+  padding: `0 ${theme.spacing(1)} !important`,
+  position: 'relative',
+  transition:
+    'background-color 225ms ease-in-out, border-color 225ms ease-in-out',
+  width: '100%',
+
+  '&:hover': {
+    backgroundColor: theme.bg.main,
+    borderColor: theme.color.border2,
   },
-  icon: {
-    display: 'flex',
-    alignItems: 'flex-end',
-    justifyContent: 'flex-end',
-    '& svg, & span': {
-      fontSize: 32,
-      color: '#939598',
-    },
-    '& img': {
-      maxHeight: 32,
-      maxWidth: 32,
-    },
-  },
-  heading: {
-    fontFamily: theme.font.bold,
-    fontSize: '1rem',
-    color: theme.color.headline,
-    wordBreak: 'break-word',
-    display: 'flex',
-    alignItems: 'center',
-    columnGap: theme.spacing(2),
-  },
-  subheading: {
-    fontSize: '0.875rem',
-    color: theme.palette.text.primary,
-  },
-  cardBaseGrid: {
-    position: 'relative',
-    width: '100%',
+  '&:before': {
+    content: '""',
+    display: 'block',
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: 5,
     height: '100%',
-    minHeight: 60,
-    backgroundColor: theme.bg.offWhite,
-    border: `1px solid ${theme.bg.main}`,
-    margin: 0,
-    padding: `0 ${theme.spacing(1)} !important`,
-    transition: `
-      ${'background-color 225ms ease-in-out, '}
-      ${'border-color 225ms ease-in-out'}
-    `,
-    '&:hover': {
-      backgroundColor: theme.bg.main,
-      borderColor: theme.color.border2,
-    },
-    '&:before': {
-      content: '""',
-      display: 'block',
-      position: 'absolute',
-      top: 0,
-      left: 0,
-      width: 5,
-      height: '100%',
-      backgroundColor: 'transparent',
-      transition: theme.transitions.create('backgroundColor'),
-    },
-  },
-  flex: {
-    flex: 1,
-    flexDirection: 'column',
-    justifyContent: 'space-around',
-    '&> div': {
-      lineHeight: 1.3,
-    },
+    backgroundColor: 'transparent',
+    transition: theme.transitions.create('backgroundColor'),
   },
 }));
 
-export interface Props {
-  renderIcon?: () => JSX.Element;
+const CardBaseIcon = styled(Grid)(() => ({
+  display: 'flex',
+  alignItems: 'flex-end',
+  justifyContent: 'flex-end',
+  '& svg, & span': {
+    fontSize: 32,
+    color: '#939598',
+  },
+  '& img': {
+    maxHeight: 32,
+    maxWidth: 32,
+  },
+}));
+
+const CardBaseHeadings = styled(Grid)(() => ({
+  flex: 1,
+  flexDirection: 'column',
+  justifyContent: 'space-around',
+  '& > div': {
+    lineHeight: 1.3,
+  },
+}));
+
+const CardBaseHeading = styled('div')(({ theme }) => ({
+  fontFamily: theme.font.bold,
+  fontSize: '1rem',
+  color: theme.color.headline,
+  wordBreak: 'break-word',
+  display: 'flex',
+  alignItems: 'center',
+  columnGap: theme.spacing(2),
+}));
+
+const CardBaseSubheading = styled('div')(({ theme }) => ({
+  color: theme.palette.text.primary,
+  fontSize: '0.875rem',
+}));
+
+interface Props {
   heading: string | JSX.Element;
-  subheadings: (string | undefined)[];
-  renderVariant?: () => JSX.Element | null;
   headingDecoration?: JSX.Element;
+  renderIcon?: () => JSX.Element;
+  renderVariant?: () => JSX.Element | null;
+  subheadings: (string | undefined)[];
+  sx?: SxProps;
+  sxHeading?: SxProps;
+  sxIcon?: SxProps;
+  sxSubheading?: SxProps;
 }
 
-type CombinedProps = Props;
-
-const CardBase: React.FC<CombinedProps> = (props) => {
+const CardBase = (props: Props) => {
   const {
-    renderIcon,
     heading,
-    subheadings,
-    renderVariant,
     headingDecoration,
+    renderIcon,
+    renderVariant,
+    subheadings,
+    sx,
+    sxHeading,
+    sxIcon,
+    sxSubheading,
   } = props;
 
-  const classes = useStyles();
+  const renderSubheadings = subheadings.map((subheading, idx) => {
+    return (
+      <CardBaseSubheading
+        key={idx}
+        data-qa-select-card-subheading={subheading}
+        sx={sxSubheading}
+      >
+        {subheading}
+      </CardBaseSubheading>
+    );
+  });
 
   return (
-    <Grid
-      container
-      alignItems="center"
-      className={`${classes.cardBaseGrid} cardBaseGrid`}
-    >
-      {renderIcon && (
-        <Grid item className={`${classes.icon} cardBaseIcon`}>
-          {renderIcon()}
-        </Grid>
-      )}
-      <Grid item className={`${classes.flex} cardBaseHeadings`}>
-        <div className={classes.heading} data-qa-select-card-heading={heading}>
+    <CardBaseGrid container sx={sx} spacing={2}>
+      {renderIcon && <CardBaseIcon sx={sxIcon}>{renderIcon()}</CardBaseIcon>}
+      <CardBaseHeadings sx={sxHeading}>
+        <CardBaseHeading data-qa-select-card-heading={heading}>
           {heading}
           {headingDecoration}
-        </div>
-        {subheadings.map((subheading, idx) => {
-          return (
-            <div
-              key={idx}
-              className={`${classes.subheading} cardBaseSubHeading`}
-              data-qa-select-card-subheading={subheading}
-            >
-              {subheading}
-            </div>
-          );
-        })}
-      </Grid>
+        </CardBaseHeading>
+        {renderSubheadings}
+      </CardBaseHeadings>
       {renderVariant ? renderVariant() : null}
-    </Grid>
+    </CardBaseGrid>
   );
 };
 

--- a/packages/manager/src/components/SelectionCard/CardBase.tsx
+++ b/packages/manager/src/components/SelectionCard/CardBase.tsx
@@ -5,9 +5,10 @@ import { SxProps } from '@mui/system';
 
 const CardBaseGrid = styled(Grid, {
   label: 'CardBaseGrid',
-})(({ theme }) => ({
+})<Partial<Props>>(({ theme, ...props }) => ({
   alignItems: 'center',
-  backgroundColor: theme.bg.offWhite,
+  backgroundColor: props.checked ? theme.bg.lightBlue2 : theme.bg.offWhite,
+  borderColor: props.checked ? theme.palette.primary.main : undefined,
   border: `1px solid ${theme.bg.main}`,
   height: '100%',
   margin: 0,
@@ -74,6 +75,7 @@ const CardBaseSubheading = styled('div')(({ theme }) => ({
 }));
 
 interface Props {
+  checked?: boolean;
   heading: string | JSX.Element;
   headingDecoration?: JSX.Element;
   renderIcon?: () => JSX.Element;
@@ -87,6 +89,7 @@ interface Props {
 
 const CardBase = (props: Props) => {
   const {
+    checked,
     heading,
     headingDecoration,
     renderIcon,
@@ -111,7 +114,7 @@ const CardBase = (props: Props) => {
   });
 
   return (
-    <CardBaseGrid container sx={sx} spacing={2}>
+    <CardBaseGrid checked={checked} container sx={sx} spacing={2}>
       {renderIcon && <CardBaseIcon sx={sxIcon}>{renderIcon()}</CardBaseIcon>}
       <CardBaseHeadings sx={sxHeading}>
         <CardBaseHeading data-qa-select-card-heading={heading}>

--- a/packages/manager/src/components/SelectionCard/CardBase.tsx
+++ b/packages/manager/src/components/SelectionCard/CardBase.tsx
@@ -20,8 +20,14 @@ const CardBaseGrid = styled(Grid, {
   width: '100%',
 
   '&:hover': {
-    backgroundColor: theme.bg.main,
-    borderColor: theme.color.border2,
+    backgroundColor: props.checked ? theme.bg.lightBlue2 : theme.bg.main,
+    borderColor: props.checked
+      ? theme.palette.primary.main
+      : theme.color.border2,
+  },
+
+  '&:focus-visible': {
+    borderStyle: 'dashed',
   },
 
   '&:before': {

--- a/packages/manager/src/components/SelectionCard/CardBase.tsx
+++ b/packages/manager/src/components/SelectionCard/CardBase.tsx
@@ -26,10 +26,6 @@ const CardBaseGrid = styled(Grid, {
       : theme.color.border2,
   },
 
-  '&:focus-visible': {
-    borderStyle: 'dashed',
-  },
-
   '&:before': {
     content: '""',
     display: 'block',

--- a/packages/manager/src/components/SelectionCard/CardBase.tsx
+++ b/packages/manager/src/components/SelectionCard/CardBase.tsx
@@ -8,8 +8,8 @@ const CardBaseGrid = styled(Grid, {
 })<Partial<Props>>(({ theme, ...props }) => ({
   alignItems: 'center',
   backgroundColor: props.checked ? theme.bg.lightBlue2 : theme.bg.offWhite,
-  borderColor: props.checked ? theme.palette.primary.main : undefined,
   border: `1px solid ${theme.bg.main}`,
+  borderColor: props.checked ? theme.palette.primary.main : undefined,
   height: '100%',
   margin: 0,
   minHeight: 60,
@@ -23,6 +23,7 @@ const CardBaseGrid = styled(Grid, {
     backgroundColor: theme.bg.main,
     borderColor: theme.color.border2,
   },
+
   '&:before': {
     content: '""',
     display: 'block',

--- a/packages/manager/src/components/SelectionCard/SelectionCard.tsx
+++ b/packages/manager/src/components/SelectionCard/SelectionCard.tsx
@@ -1,74 +1,88 @@
-import classNames from 'classnames';
 import * as React from 'react';
-import { makeStyles } from '@mui/styles';
-import { Theme } from '@mui/material/styles';
-import Tooltip from 'src/components/core/Tooltip';
-import Grid from 'src/components/Grid';
 import CardBase from './CardBase';
+import Grid from '@mui/material/Unstable_Grid2';
+import Tooltip from 'src/components/core/Tooltip';
+import { styled } from '@mui/material/styles';
+import { SxProps } from '@mui/system';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    minWidth: 200,
-    padding: theme.spacing(2),
-    justifyContent: 'center',
-    alignItems: 'center',
-    display: 'flex',
-    outline: 0,
-    '&.checked .cardBaseGrid': {
+export interface Props {
+  checked?: boolean;
+  className?: string;
+  disabled?: boolean;
+  heading: string;
+  headingDecoration?: JSX.Element;
+  id?: string;
+  onClick?: (e: React.SyntheticEvent<HTMLElement>) => void;
+  renderIcon?: () => JSX.Element;
+  renderVariant?: () => JSX.Element | null;
+  subheadings: (string | undefined)[];
+  sx?: SxProps;
+  sxCardBase?: SxProps;
+  sxCardBaseHeading?: SxProps;
+  sxCardBaseIcon?: SxProps;
+  sxCardBaseSubheading?: SxProps;
+  sxGrid?: SxProps;
+  sxTooltip?: SxProps;
+  tooltip?: string;
+}
+
+const StyledGrid = styled(Grid, {
+  label: 'SelectionCardGrid',
+})<Partial<Props>>(({ theme, ...props }) => ({
+  minWidth: 200,
+  padding: theme.spacing(2),
+  justifyContent: 'center',
+  alignItems: 'center',
+  display: 'flex',
+  outline: 0,
+  '&:focus': {
+    outline: '1px dotted #999',
+  },
+  '& [class^="fl-"]': {
+    transition: 'color 225ms ease-in-out',
+  },
+  ...(props.onClick &&
+    !props.disabled && {
+      cursor: 'pointer',
+    }),
+  ...(props.disabled && {
+    cursor: 'not-allowed',
+    '& > div': {
+      opacity: 0.4,
+    },
+  }),
+}));
+
+const SelectionCardBase = styled(CardBase)<Partial<Props>>(
+  ({ theme, ...props }) => ({
+    ...(props.checked && {
       backgroundColor: theme.bg.lightBlue2,
       borderColor: theme.palette.primary.main,
       '& span': {
         color: theme.palette.primary.main,
       },
-    },
-    '&:focus .cardBaseGrid': {
-      outline: '1px dotted #999',
-    },
-    '& [class^="fl-"]': {
-      transition: 'color 225ms ease-in-out',
-    },
-  },
-  showCursor: {
-    cursor: 'pointer',
-  },
-  disabled: {
-    cursor: 'not-allowed',
-    '& > div': {
-      opacity: 0.4,
-    },
-  },
-}));
+    }),
+  })
+);
 
-export interface Props {
-  id?: string;
-  heading: string;
-  subheadings: (string | undefined)[];
-  checked?: boolean;
-  disabled?: boolean;
-  tooltip?: string;
-  className?: string;
-  onClick?: (e: React.SyntheticEvent<HTMLElement>) => void;
-  renderIcon?: () => JSX.Element;
-  renderVariant?: () => JSX.Element | null;
-  headingDecoration?: JSX.Element;
-}
-
-const SelectionCard: React.FC<Props> = (props) => {
+const SelectionCard = (props: Props) => {
   const {
-    id,
-    heading,
-    subheadings,
-    checked,
-    disabled,
-    tooltip,
     className,
+    disabled,
+    heading,
+    headingDecoration,
+    id,
     onClick,
     renderIcon,
     renderVariant,
-    headingDecoration,
+    subheadings,
+    sxCardBase,
+    sxCardBaseHeading,
+    sxCardBaseIcon,
+    sxCardBaseSubheading,
+    sxGrid,
+    tooltip,
   } = props;
-
-  const classes = useStyles();
 
   const handleKeyPress = (e: React.KeyboardEvent<HTMLElement>) => {
     if (onClick && !disabled) {
@@ -84,39 +98,36 @@ const SelectionCard: React.FC<Props> = (props) => {
   };
 
   const content = (
-    <CardBase
+    <SelectionCardBase
       renderIcon={renderIcon}
       heading={heading}
       subheadings={subheadings}
       renderVariant={renderVariant}
       headingDecoration={headingDecoration}
+      sx={sxCardBase}
+      sxHeading={sxCardBaseHeading}
+      sxIcon={sxCardBaseIcon}
+      sxSubheading={sxCardBaseSubheading}
     />
   );
 
   const cardGrid = (
-    <Grid
+    <StyledGrid
+      className={className}
+      data-qa-selection-card
+      disabled={disabled}
       id={id}
-      item
+      onClick={handleClick}
+      onKeyPress={handleKeyPress}
+      sx={sxGrid}
+      tabIndex={0}
       xs={12}
       sm={6}
       lg={4}
       xl={3}
-      tabIndex={0}
-      className={classNames(
-        {
-          [classes.root]: true,
-          checked,
-          [classes.disabled]: disabled,
-          [classes.showCursor]: onClick && !disabled,
-        },
-        className
-      )}
-      onClick={handleClick}
-      onKeyPress={handleKeyPress}
-      data-qa-selection-card
     >
       {content}
-    </Grid>
+    </StyledGrid>
   );
 
   if (tooltip) {

--- a/packages/manager/src/components/SelectionCard/SelectionCard.tsx
+++ b/packages/manager/src/components/SelectionCard/SelectionCard.tsx
@@ -53,20 +53,22 @@ const StyledGrid = styled(Grid, {
   }),
 }));
 
-const SelectionCardBase = styled(CardBase)<Partial<Props>>(
-  ({ theme, ...props }) => ({
-    ...(props.checked && {
-      backgroundColor: theme.bg.lightBlue2,
-      borderColor: theme.palette.primary.main,
-      '& span': {
-        color: theme.palette.primary.main,
-      },
-    }),
-  })
-);
+// const SelectionCardBase = styled(CardBase)<Partial<Props>>(
+//   ({ theme, ...props }) => ({
+//     background: 'red  !important',
+//     ...(props.checked && {
+//       backgroundColor: theme.bg.lightBlue2,
+//       borderColor: theme.palette.primary.main,
+//       '& span': {
+//         color: theme.palette.primary.main,
+//       },
+//     }),
+//   })
+// );
 
 const SelectionCard = (props: Props) => {
   const {
+    checked,
     className,
     disabled,
     heading,
@@ -98,12 +100,13 @@ const SelectionCard = (props: Props) => {
   };
 
   const content = (
-    <SelectionCardBase
-      renderIcon={renderIcon}
+    <CardBase
+      checked={checked}
       heading={heading}
-      subheadings={subheadings}
-      renderVariant={renderVariant}
       headingDecoration={headingDecoration}
+      renderIcon={renderIcon}
+      renderVariant={renderVariant}
+      subheadings={subheadings}
       sx={sxCardBase}
       sxHeading={sxCardBaseHeading}
       sxIcon={sxCardBaseIcon}

--- a/packages/manager/src/components/SelectionCard/SelectionCard.tsx
+++ b/packages/manager/src/components/SelectionCard/SelectionCard.tsx
@@ -53,19 +53,6 @@ const StyledGrid = styled(Grid, {
   }),
 }));
 
-// const SelectionCardBase = styled(CardBase)<Partial<Props>>(
-//   ({ theme, ...props }) => ({
-//     background: 'red  !important',
-//     ...(props.checked && {
-//       backgroundColor: theme.bg.lightBlue2,
-//       borderColor: theme.palette.primary.main,
-//       '& span': {
-//         color: theme.palette.primary.main,
-//       },
-//     }),
-//   })
-// );
-
 const SelectionCard = (props: Props) => {
   const {
     checked,

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentMethodCard.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentMethodCard.tsx
@@ -1,9 +1,7 @@
 import { PaymentMethod, PaymentType } from '@linode/api-v4';
 import * as React from 'react';
 import Chip from 'src/components/core/Chip';
-import { makeStyles } from 'tss-react/mui';
-import { Theme } from '@mui/material/styles';
-import Grid from 'src/components/Grid';
+import Grid from '@mui/material/Unstable_Grid2';
 import {
   getIcon as getTPPIcon,
   thirdPartyPaymentMap,
@@ -11,38 +9,7 @@ import {
 import SelectionCard from 'src/components/SelectionCard';
 import { getIcon as getCreditCardIcon } from 'src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCard';
 import isCreditCardExpired, { formatExpiry } from 'src/utilities/creditCard';
-
-const useStyles = makeStyles()((theme: Theme) => ({
-  paymentMethod: {
-    marginBottom: theme.spacing(),
-  },
-  selectionCard: {
-    minWidth: '100%',
-    padding: 0,
-    marginBottom: theme.spacing(),
-    '& .cardBaseGrid': {
-      flexWrap: 'nowrap',
-    },
-    '& .cardBaseIcon': {
-      width: 45,
-      padding: 0,
-      justifyContent: 'center',
-    },
-    '& .cardBaseHeadings': {
-      flex: 'inherit',
-    },
-  },
-  expired: {
-    '& .cardBaseSubHeading': {
-      color: theme.color.red,
-    },
-  },
-  chip: {
-    '& span': {
-      color: 'inherit !important',
-    },
-  },
-}));
+import { useTheme } from '@mui/material/styles';
 
 interface Props {
   paymentMethod: PaymentMethod;
@@ -93,10 +60,9 @@ const getSubHeading = (paymentMethod: PaymentMethod, isExpired: boolean) => {
 };
 
 export const PaymentMethodCard = (props: Props) => {
+  const theme = useTheme();
   const { paymentMethod, paymentMethodId, handlePaymentMethodChange } = props;
   const { id, type, is_default } = paymentMethod;
-
-  const { classes, cx } = useStyles();
 
   const heading = getHeading(paymentMethod, type);
   const cardIsExpired = getIsCardExpired(paymentMethod);
@@ -109,25 +75,44 @@ export const PaymentMethodCard = (props: Props) => {
 
   const renderVariant = () => {
     return is_default ? (
-      <Grid item className={classes.chip} xs={3} md={2}>
+      <Grid xs={3} md={2}>
         <Chip label="DEFAULT" component="span" size="small" />
       </Grid>
     ) : null;
   };
 
   return (
-    <Grid className={classes.paymentMethod}>
+    <Grid
+      sx={{
+        marginBottom: theme.spacing(),
+      }}
+    >
       <SelectionCard
-        className={cx({
-          [classes.selectionCard]: true,
-          [classes.expired]: cardIsExpired,
-        })}
         checked={id === paymentMethodId}
         onClick={() => handlePaymentMethodChange(id, cardIsExpired)}
         renderIcon={renderIcon}
         renderVariant={renderVariant}
         heading={heading}
         subheadings={[subHeading]}
+        sxCardBaseIcon={{
+          justifyContent: 'center',
+          padding: 0,
+          width: 45,
+        }}
+        sxGrid={{
+          marginBottom: theme.spacing(),
+          minWidth: '100%',
+          padding: 0,
+        }}
+        sxCardBase={{
+          flexWrap: 'nowrap',
+        }}
+        sxCardBaseHeading={{
+          flex: 'inherit',
+        }}
+        sxCardBaseSubheading={{
+          color: cardIsExpired ? theme.color.red : undefined,
+        }}
       />
     </Grid>
   );

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectionCardWrapper.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectionCardWrapper.tsx
@@ -15,11 +15,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   selectionCard: {
     mixBlendMode: theme.name === 'dark' ? 'initial' : 'darken',
-    '& .cardBaseIcon': {
-      width: 40,
-      paddingRight: 0,
-      justifyContent: 'flex-start',
-    },
   },
   info: {
     display: 'flex',
@@ -126,6 +121,11 @@ export const SelectionCardWrapper: React.FC<Props> = (props) => {
       disabled={disabled}
       className={classes.selectionCard}
       headingDecoration={labelDecoration}
+      sxCardBaseIcon={{
+        justifyContent: 'flex-start',
+        paddingRight: 0,
+        width: 40,
+      }}
     />
   );
 };

--- a/packages/manager/src/styles/keyframes.ts
+++ b/packages/manager/src/styles/keyframes.ts
@@ -8,3 +8,12 @@ export const rotate360 = keyframes`
     transform: rotate(360deg);
   }
 `;
+
+export const fadeIn = keyframes`
+  from: {
+    opacity: 0,
+  },
+  to: {
+    opacity: 1,
+  }
+`;


### PR DESCRIPTION
## Description 📝
Migrates SRC > Components > SelectionCard from JSS to `styled`/`sx` API

## Major Changes 🔄 
- Migrated to MUI `Grid` v2
- Removed `@mui/styles` imports
- Removed React.FC
- Replaced hardcoded classnames with `sx` equivalent
- Removed several unused styles

## Preview 📷
> **Note**: This drawer in `develop` seemed to be broken. Using test prod account `prod-test-012` seems to be fine: https://cloud.linode.com/account/billing/make-payment

| Before      | After |
| ----------- | ----------- |
| ![Screen Shot 2023-03-27 at 12 48 08 PM](https://user-images.githubusercontent.com/125309814/228018383-fb40aaa0-ca5d-4da5-941d-77fa8b74f207.png) | ![Screen Shot 2023-03-24 at 10 55 44 AM](https://user-images.githubusercontent.com/125309814/228018421-d397aac9-fcf2-48fe-a1ec-3fa74f932e25.png)|

## How to test 🧪
1. Toggle our mock service workers
2. Go to: http://localhost:3000/account/billing/make-payment
3. Observe everything looks the same as when you view the page off the `develop` branch