### PR TITLE
refactor: [M3-6291, M3-6292] – MUI v5 Migration - `Components > AccountActivation`, `Components > ActionMenu`

### DIFF
--- a/packages/manager/src/components/AccountActivation/AccountActivationError.tsx
+++ b/packages/manager/src/components/AccountActivation/AccountActivationError.tsx
@@ -10,7 +10,7 @@ interface InnerProps {
 
 type CombinedProps = Props & InnerProps;
 
-const AccountActivationError: React.FC<CombinedProps> = (props) => {
+const AccountActivationError = (props: CombinedProps) => {
   React.useEffect(() => {
     /** set an account_unactivated error if one hasn't already been set */
     if (!props.globalErrors.account_unactivated) {

--- a/packages/manager/src/components/AccountActivation/AccountActivationLanding.tsx
+++ b/packages/manager/src/components/AccountActivation/AccountActivationLanding.tsx
@@ -1,15 +1,14 @@
 import Warning from '@mui/icons-material/CheckCircle';
-import * as React from 'react';
-import { RouteComponentProps } from 'react-router-dom';
-import { compose } from 'recompose';
-import { makeStyles, withTheme, WithTheme } from '@mui/styles';
 import { Theme } from '@mui/material/styles';
+import * as React from 'react';
+import { useHistory } from 'react-router-dom';
 import Typography from 'src/components/core/Typography';
 import ErrorState from 'src/components/ErrorState';
 import { AttachmentError } from 'src/features/Support/SupportTicketDetail/SupportTicketDetail';
 import SupportTicketDrawer from 'src/features/Support/SupportTickets/SupportTicketDrawer';
+import { makeStyles } from 'tss-react/mui';
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles()((theme: Theme) => ({
   errorHeading: {
     marginBottom: theme.spacing(2),
   },
@@ -22,10 +21,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-type CombinedProps = WithTheme & RouteComponentProps;
-
-const AccountActivationLanding: React.FC<CombinedProps> = (props) => {
-  const classes = useStyles();
+const AccountActivationLanding = () => {
+  const { classes } = useStyles();
+  const history = useHistory();
 
   const [supportDrawerIsOpen, toggleSupportDrawer] = React.useState<boolean>(
     false
@@ -35,7 +33,7 @@ const AccountActivationLanding: React.FC<CombinedProps> = (props) => {
     ticketID: number,
     attachmentErrors?: AttachmentError[]
   ) => {
-    props.history.push({
+    history.push({
       pathname: `/support/tickets/${ticketID}`,
       state: { attachmentErrors },
     });
@@ -78,7 +76,4 @@ const AccountActivationLanding: React.FC<CombinedProps> = (props) => {
   );
 };
 
-export default compose<CombinedProps, {}>(
-  React.memo,
-  withTheme
-)(AccountActivationLanding);
+export default React.memo(AccountActivationLanding);

--- a/packages/manager/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/manager/src/components/ActionMenu/ActionMenu.tsx
@@ -1,3 +1,4 @@
+import { Theme } from '@mui/material/styles';
 import {
   Menu,
   MenuButton,
@@ -7,12 +8,10 @@ import {
 } from '@reach/menu-button';
 import '@reach/menu-button/styles.css';
 import { positionRight } from '@reach/popover';
-import classNames from 'classnames';
 import * as React from 'react';
 import KebabIcon from 'src/assets/icons/kebab.svg';
-import { makeStyles } from '@mui/styles';
-import { Theme } from '@mui/material/styles';
 import HelpIcon from 'src/components/HelpIcon';
+import { makeStyles } from 'tss-react/mui';
 
 export interface Action {
   title: string;
@@ -21,7 +20,7 @@ export interface Action {
   onClick: () => void;
 }
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles()((theme: Theme) => ({
   button: {
     '&[data-reach-menu-button]': {
       display: 'flex',
@@ -107,10 +106,8 @@ export interface Props {
   className?: string;
 }
 
-type CombinedProps = Props;
-
-const ActionMenu: React.FC<CombinedProps> = (props) => {
-  const classes = useStyles();
+const ActionMenu = (props: Props) => {
+  const { classes, cx } = useStyles();
   const { toggleOpenCallback, actionsList } = props;
 
   const { ariaLabel } = props;
@@ -134,7 +131,7 @@ const ActionMenu: React.FC<CombinedProps> = (props) => {
   return (
     <Menu>
       <MenuButton
-        className={classNames({
+        className={cx({
           [classes.button]: true,
         })}
         aria-label={ariaLabel}
@@ -148,7 +145,7 @@ const ActionMenu: React.FC<CombinedProps> = (props) => {
           {(actionsList as Action[]).map((a, idx) => (
             <MenuItem
               key={idx}
-              className={classNames({
+              className={cx({
                 [classes.item]: true,
                 [classes.disabled]: a.disabled,
               })}


### PR DESCRIPTION
## Description 📝
Migrates `SRC > Components > AccountActivation` and `SRC > Components > ActionMenu` from JSS to tss-react (Emotion)

## Changes 🔄 
- Removed `@mui/styles` imports
- Removed `React.FC`

## Preview 📸 
<details>
<summary>Account Activation landing page</summary>

![Screenshot 2023-03-28 at 12 17 34 PM](https://user-images.githubusercontent.com/114682940/228304212-361f0980-533c-4f9f-8549-4f6523dbb33d.jpg)
</details>

## How to test 🧪
To see the Account Activation landing page, you can set L217 of `MainContent.tsx` to `true`.

Ensure that `ActionMenu`'s in the app behave and appear as expected.