### PR TITLE
fix: [M3-6387] - MUI v5 Migration - Components > SelectionCard & ActionsPanel

### DIFF
--- a/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
+++ b/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
-import classNames from 'classnames';
 import RenderGuard from 'src/components/RenderGuard';
-import { makeStyles } from '@mui/styles';
+import { makeStyles } from 'tss-react/mui';
 import { Theme } from '@mui/material/styles';
 import Box, { BoxProps } from '../core/Box';
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles()((theme: Theme) => ({
   root: {
     paddingTop: theme.spacing(2),
     paddingBottom: theme.spacing(1),
@@ -22,14 +21,14 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-const ActionPanel: React.FC<BoxProps> = (props) => {
-  const classes = useStyles();
+const ActionPanel = (props: BoxProps) => {
+  const { classes, cx } = useStyles();
   const { className, children, ...rest } = props;
 
   return (
     <Box
       data-qa-buttons
-      className={classNames(classes.root, className, 'actionPanel')}
+      className={cx(classes.root, className, 'actionPanel')}
       {...rest}
     >
       {Array.isArray(children)

--- a/packages/manager/src/components/SelectionCard/CardBase.tsx
+++ b/packages/manager/src/components/SelectionCard/CardBase.tsx
@@ -39,7 +39,9 @@ const CardBaseGrid = styled(Grid, {
   },
 }));
 
-const CardBaseIcon = styled(Grid)(() => ({
+const CardBaseIcon = styled(Grid, {
+  label: 'CardBaseIcon',
+})(() => ({
   display: 'flex',
   alignItems: 'flex-end',
   justifyContent: 'flex-end',
@@ -53,7 +55,9 @@ const CardBaseIcon = styled(Grid)(() => ({
   },
 }));
 
-const CardBaseHeadings = styled(Grid)(() => ({
+const CardBaseHeadings = styled(Grid, {
+  label: 'CardBaseHeadings',
+})(() => ({
   flex: 1,
   flexDirection: 'column',
   justifyContent: 'space-around',
@@ -62,7 +66,9 @@ const CardBaseHeadings = styled(Grid)(() => ({
   },
 }));
 
-const CardBaseHeading = styled('div')(({ theme }) => ({
+const CardBaseHeading = styled('div', {
+  label: 'CardBaseHeading',
+})(({ theme }) => ({
   fontFamily: theme.font.bold,
   fontSize: '1rem',
   color: theme.color.headline,
@@ -72,7 +78,9 @@ const CardBaseHeading = styled('div')(({ theme }) => ({
   columnGap: theme.spacing(2),
 }));
 
-const CardBaseSubheading = styled('div')(({ theme }) => ({
+const CardBaseSubheading = styled('div', {
+  label: 'CardBaseSubheading',
+})(({ theme }) => ({
   color: theme.palette.text.primary,
   fontSize: '0.875rem',
 }));

--- a/packages/manager/src/components/SelectionCard/SelectionCard.tsx
+++ b/packages/manager/src/components/SelectionCard/SelectionCard.tsx
@@ -29,12 +29,6 @@ export interface Props {
 const StyledGrid = styled(Grid, {
   label: 'SelectionCardGrid',
 })<Partial<Props>>(({ theme, ...props }) => ({
-  minWidth: 200,
-  padding: theme.spacing(2),
-  justifyContent: 'center',
-  alignItems: 'center',
-  display: 'flex',
-  outline: 0,
   '&:focus': {
     outline: '1px dotted #999',
   },

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentMethodCard.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentMethodCard.tsx
@@ -73,21 +73,21 @@ export const PaymentMethodCard = (props: Props) => {
     return <Icon />;
   };
 
+  const sxVariant = {
+    paddingLeft: { xs: 0, sm: 1 },
+    flexShrink: 0,
+  };
+
   const renderVariant = () => {
     return is_default ? (
-      <Grid xs={3} md={2}>
+      <Grid xs={3} md={2} sx={sxVariant}>
         <Chip label="DEFAULT" component="span" size="small" />
       </Grid>
     ) : null;
   };
 
   return (
-    <Grid
-      container
-      sx={{
-        marginBottom: theme.spacing(),
-      }}
-    >
+    <Grid container>
       <SelectionCard
         checked={id === paymentMethodId}
         onClick={() => handlePaymentMethodChange(id, cardIsExpired)}

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentMethodCard.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentMethodCard.tsx
@@ -83,6 +83,7 @@ export const PaymentMethodCard = (props: Props) => {
 
   return (
     <Grid
+      container
       sx={{
         marginBottom: theme.spacing(),
       }}

--- a/packages/manager/src/features/LinodeConfigSelectionDrawer/LinodeConfigSelectionDrawer.tsx
+++ b/packages/manager/src/features/LinodeConfigSelectionDrawer/LinodeConfigSelectionDrawer.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import Drawer from 'src/components/Drawer';
-import Grid from 'src/components/Grid';
+import Grid from '@mui/material/Unstable_Grid2';
 import Notice from 'src/components/Notice';
 import SelectionCard from 'src/components/SelectionCard';
 

--- a/packages/manager/src/features/Users/UserPermissions.tsx
+++ b/packages/manager/src/features/Users/UserPermissions.tsx
@@ -16,12 +16,12 @@ import CircleProgress from 'src/components/CircleProgress';
 import Divider from 'src/components/core/Divider';
 import FormControlLabel from 'src/components/core/FormControlLabel';
 import Paper from 'src/components/core/Paper';
-import { createStyles, withStyles, WithStyles } from '@mui/styles';
+import { withStyles } from 'tss-react/mui';
 import { Theme } from '@mui/material/styles';
 import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
-import Grid from 'src/components/Grid';
+import Grid from '@mui/material/Unstable_Grid2';
 import Notice from 'src/components/Notice';
 import SelectionCard from 'src/components/SelectionCard';
 import Toggle from 'src/components/Toggle';
@@ -49,54 +49,54 @@ type ClassNames =
   | 'section'
   | 'setAll';
 
-const styles = (theme: Theme) =>
-  createStyles({
-    title: {
-      [theme.breakpoints.down('md')]: {
-        paddingLeft: theme.spacing(),
-      },
+const styles = (theme: Theme) => ({
+  title: {
+    [theme.breakpoints.down('md')]: {
+      paddingLeft: theme.spacing(),
     },
-    toggle: {
-      marginRight: 3,
+  },
+  toggle: {
+    marginRight: 3,
+  },
+  unrestrictedRoot: {
+    marginTop: theme.spacing(2),
+    padding: theme.spacing(3),
+  },
+  globalSection: {
+    marginTop: theme.spacing(2),
+  },
+  globalRow: {
+    padding: `${theme.spacing(1)} 0`,
+  },
+  section: {
+    marginTop: theme.spacing(2),
+    paddingBottom: 0,
+  },
+  setAll: {
+    '& > div': {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'flex-end',
     },
-    unrestrictedRoot: {
-      marginTop: theme.spacing(2),
-      padding: theme.spacing(3),
+    '& label': {
+      marginTop: 6,
     },
-    globalSection: {
-      marginTop: theme.spacing(2),
+    '& .react-select__menu, & .input': {
+      width: 125,
+      right: 0,
+      marginLeft: theme.spacing(1),
+      textAlign: 'left' as const,
     },
-    globalRow: {
-      padding: `${theme.spacing(1)} 0`,
+    '& .react-select__menu-list': {
+      width: '100%',
     },
-    section: {
-      marginTop: theme.spacing(2),
-      paddingBottom: 0,
-    },
-    setAll: {
-      '& > div': {
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'flex-end',
-      },
-      '& label': {
-        marginTop: 6,
-      },
-      '& .react-select__menu, & .input': {
-        width: 125,
-        right: 0,
-        marginLeft: theme.spacing(1),
-        textAlign: 'left',
-      },
-      '& .react-select__menu-list': {
-        width: '100%',
-      },
-    },
-  });
+  },
+});
 
 interface Props {
   username?: string;
   currentUser?: string;
+  classes?: Partial<Record<ClassNames, string>>;
   clearNewUser: () => void;
 }
 
@@ -122,7 +122,7 @@ interface State {
   tabs?: string[];
 }
 
-type CombinedProps = Props & WithStyles<ClassNames> & WithSnackbarProps;
+type CombinedProps = Props & WithSnackbarProps;
 
 class UserPermissions extends React.Component<CombinedProps, State> {
   state: State = {
@@ -389,7 +389,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
   };
 
   renderGlobalPerm = (perm: string, checked: boolean) => {
-    const { classes } = this.props;
+    const classes = withStyles.getClasses(this.props);
     const permDescriptionMap = {
       add_linodes: 'Can add Linodes to this account ($)',
       add_nodebalancers: 'Can add NodeBalancers to this account ($)',
@@ -405,7 +405,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
       add_databases: 'Can add Databases to this account ($)',
     };
     return (
-      <Grid item key={perm} xs={12} sm={6} className="py0">
+      <Grid key={perm} xs={12} sm={6} className="py0">
         <FormControlLabel
           className={classes.globalRow}
           label={permDescriptionMap[perm]}
@@ -428,7 +428,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
   };
 
   renderBillingPerm = () => {
-    const { classes } = this.props;
+    const classes = withStyles.getClasses(this.props);
     const { grants } = this.state;
     if (!(grants && grants.global)) {
       return null;
@@ -436,14 +436,19 @@ class UserPermissions extends React.Component<CombinedProps, State> {
 
     return (
       <div className={classes.section}>
-        <Grid container className={classes.section} data-qa-billing-section>
-          <Grid item>
+        <Grid
+          spacing={2}
+          container
+          className={classes.section}
+          data-qa-billing-section
+        >
+          <Grid>
             <Typography variant="h3" data-qa-permissions-header="billing">
               Billing Access
             </Typography>
           </Grid>
         </Grid>
-        <Grid container className={classes.section}>
+        <Grid container spacing={2} className={classes.section}>
           <SelectionCard
             heading="None"
             subheadings={['The user cannot view any billing information.']}
@@ -477,7 +482,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
     onCancel: () => void,
     loading: boolean
   ) => {
-    const { classes } = this.props;
+    const classes = withStyles.getClasses(this.props);
     return (
       <ActionsPanel
         display="flex"
@@ -501,7 +506,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
   };
 
   renderGlobalPerms = () => {
-    const { classes } = this.props;
+    const classes = withStyles.getClasses(this.props);
     const { grants, isSavingGlobal } = this.state;
     return (
       <Paper className={classes.globalSection} data-qa-global-section>
@@ -511,7 +516,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
         >
           Global Permissions
         </Typography>
-        <Grid container className={classes.section}>
+        <Grid container className={classes.section} spacing={2}>
           {grants &&
             grants.global &&
             this.globalBooleanPerms
@@ -580,7 +585,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
   };
 
   renderSpecificPerms = () => {
-    const { classes } = this.props;
+    const classes = withStyles.getClasses(this.props);
     const { grants, setAllPerm, isSavingEntity } = this.state;
 
     const permOptions = [
@@ -596,7 +601,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
     return (
       <Paper className={classes.globalSection} data-qa-entity-section>
         <Grid container justifyContent="space-between" alignItems="center">
-          <Grid item>
+          <Grid>
             <Typography
               variant="h2"
               data-qa-permissions-header="Specific Permissions"
@@ -605,7 +610,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
             </Typography>
           </Grid>
 
-          <Grid item style={{ marginTop: 5 }}>
+          <Grid style={{ marginTop: 5 }}>
             <Select
               options={permOptions}
               defaultValue={defaultPerm}
@@ -681,7 +686,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
   };
 
   renderUnrestricted = () => {
-    const { classes } = this.props;
+    const classes = withStyles.getClasses(this.props);
     /* TODO: render all permissions disabled with this message above */
     return (
       <Paper className={classes.unrestrictedRoot}>
@@ -693,7 +698,8 @@ class UserPermissions extends React.Component<CombinedProps, State> {
   };
 
   renderBody = () => {
-    const { classes, currentUser, username } = this.props;
+    const classes = withStyles.getClasses(this.props);
+    const { currentUser, username } = this.props;
     const { restricted, errors } = this.state;
     const hasErrorFor = getAPIErrorsFor({ restricted: 'Restricted' }, errors);
     const generalError = hasErrorFor('none');
@@ -701,8 +707,13 @@ class UserPermissions extends React.Component<CombinedProps, State> {
     return (
       <React.Fragment>
         {generalError && <Notice error text={generalError} spacingTop={8} />}
-        <Grid container alignItems="center" style={{ width: 'auto' }}>
-          <Grid item>
+        <Grid
+          spacing={2}
+          container
+          alignItems="center"
+          style={{ width: 'auto' }}
+        >
+          <Grid>
             <Typography
               className={classes.title}
               variant="h2"
@@ -711,10 +722,10 @@ class UserPermissions extends React.Component<CombinedProps, State> {
               Full Account Access:
             </Typography>
           </Grid>
-          <Grid item>
+          <Grid>
             <Typography variant="h2">{!restricted ? 'On' : 'Off'}</Typography>
           </Grid>
-          <Grid item>
+          <Grid>
             <Toggle
               tooltipText={
                 username === currentUser
@@ -746,6 +757,4 @@ class UserPermissions extends React.Component<CombinedProps, State> {
   }
 }
 
-const styled = withStyles(styles);
-
-export default withSnackbar(styled(UserPermissions));
+export default withSnackbar(withStyles(UserPermissions, styles));

--- a/packages/manager/src/features/linodes/LinodesCreate/AppPanelSection.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/AppPanelSection.tsx
@@ -2,24 +2,16 @@ import { StackScript, UserDefinedField } from '@linode/api-v4/lib/stackscripts';
 import { decode } from 'he';
 import * as React from 'react';
 import Divider from 'src/components/core/Divider';
-import { makeStyles } from '@mui/styles';
-import { Theme } from '@mui/material/styles';
+import { styled } from '@mui/material/styles';
 import Typography from 'src/components/core/Typography';
-import Grid from 'src/components/Grid';
+import Grid from '@mui/material/Unstable_Grid2';
 import SelectionCardWrapper from 'src/features/linodes/LinodesCreate/SelectionCardWrapper';
 import Chip from 'src/components/core/Chip';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  flatImagePanelSelections: {
-    marginTop: theme.spacing(2),
-    marginBottom: theme.spacing(),
-    padding: `${theme.spacing(1)} 0`,
-  },
-  chip: {
-    '& span': {
-      color: 'inherit !important',
-    },
-  },
+const AppPanelGrid = styled(Grid)(({ theme }) => ({
+  marginTop: theme.spacing(2),
+  marginBottom: theme.spacing(),
+  padding: `${theme.spacing(1)} 0`,
 }));
 
 interface Props {
@@ -46,7 +38,6 @@ export const AppPanelSection: React.FC<Props> = (props) => {
     openDrawer,
     handleClick,
   } = props;
-  const classes = useStyles();
 
   return (
     <>
@@ -54,7 +45,7 @@ export const AppPanelSection: React.FC<Props> = (props) => {
       {heading && heading.length > 0 ? (
         <Divider spacingTop={16} spacingBottom={16} />
       ) : null}
-      <Grid className={classes.flatImagePanelSelections} container>
+      <AppPanelGrid container spacing={2}>
         {apps.map((eachApp) => {
           const decodedLabel = decode(eachApp.label);
           const isCluster =
@@ -82,14 +73,12 @@ export const AppPanelSection: React.FC<Props> = (props) => {
               disabled={disabled}
               iconUrl={eachApp.logo_url.toLowerCase() || ''}
               labelDecoration={
-                isCluster ? (
-                  <Chip size="small" label="CLUSTER" className={classes.chip} />
-                ) : undefined
+                isCluster ? <Chip size="small" label="CLUSTER" /> : undefined
               }
             />
           );
         })}
-      </Grid>
+      </AppPanelGrid>
     </>
   );
 };

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectLinodePanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectLinodePanel.tsx
@@ -5,7 +5,7 @@ import Paper from 'src/components/core/Paper';
 import { createStyles, withStyles, WithStyles } from '@mui/styles';
 import { Theme } from '@mui/material/styles';
 import Typography from 'src/components/core/Typography';
-import Grid from 'src/components/Grid';
+import Grid from '@mui/material/Unstable_Grid2';
 import Notice from 'src/components/Notice';
 import Paginate from 'src/components/Paginate';
 import PaginationFooter from 'src/components/PaginationFooter';
@@ -95,7 +95,7 @@ class SelectLinodePanel extends React.Component<CombinedProps> {
                   {!!header ? header : 'Select Linode'}
                 </Typography>
                 <Typography component="div" className={classes.panelBody}>
-                  <Grid container>
+                  <Grid container spacing={2}>
                     {linodesData.map((linode) => {
                       return this.renderCard(linode);
                     })}

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -15,7 +15,7 @@ import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
 import Typography from 'src/components/core/Typography';
 import Currency from 'src/components/Currency';
-import Grid from 'src/components/Grid';
+import Grid from '@mui/material/Unstable_Grid2';
 import HelpIcon from 'src/components/HelpIcon';
 import Notice from 'src/components/Notice';
 import Radio from 'src/components/Radio';
@@ -330,12 +330,12 @@ export const SelectPlanPanel: React.FC<CombinedProps> = (props) => {
       showTransfer && plans.some((plan: ExtendedType) => plan.network_out);
 
     return (
-      <Grid container>
+      <Grid container spacing={2}>
         <Hidden lgUp={isCreate} mdUp={!isCreate}>
           {plans.map(renderSelection)}
         </Hidden>
         <Hidden lgDown={isCreate} mdDown={!isCreate}>
-          <Grid item xs={12}>
+          <Grid xs={12}>
             <Table
               aria-label="List of Linode Plans"
               className={classes.table}

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
@@ -11,7 +11,7 @@ import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
 import Typography from 'src/components/core/Typography';
 import EnhancedNumberInput from 'src/components/EnhancedNumberInput';
-import Grid from 'src/components/Grid';
+import Grid from '@mui/material/Unstable_Grid2';
 import Notice from 'src/components/Notice';
 import RenderGuard, { RenderGuardProps } from 'src/components/RenderGuard';
 import SelectionCard from 'src/components/SelectionCard';
@@ -147,7 +147,7 @@ export class SelectPlanPanel extends React.Component<
     const subHeadings = type.subHeadings.slice(0, -2);
 
     const renderVariant = () => (
-      <Grid item xs={12}>
+      <Grid xs={12}>
         <div className={classes.enhancedInputOuter}>
           <EnhancedNumberInput
             value={type.count}
@@ -262,10 +262,10 @@ export class SelectPlanPanel extends React.Component<
     );
 
     return (
-      <Grid container>
+      <Grid container spacing={2}>
         <Hidden mdUp>{plans.map(this.renderSelection)}</Hidden>
         <Hidden mdDown>
-          <Grid item xs={12} lg={12}>
+          <Grid xs={12} lg={12}>
             <Table aria-label="List of Linode Plans" spacingBottom={16}>
               {tableHeader}
               <TableBody role="grid">

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectionCardWrapper.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectionCardWrapper.tsx
@@ -1,33 +1,10 @@
 import { UserDefinedField } from '@linode/api-v4/lib/stackscripts';
 import * as React from 'react';
 import Info from 'src/assets/icons/info.svg';
-import { makeStyles } from '@mui/styles';
-import { Theme } from '@mui/material/styles';
+import { styled, useTheme } from '@mui/material/styles';
 import Grid from 'src/components/Grid';
 import SelectionCard from 'src/components/SelectionCard';
 import { APP_ROOT } from 'src/constants';
-
-const useStyles = makeStyles((theme: Theme) => ({
-  flatImagePanelSelections: {
-    marginTop: theme.spacing(2),
-    marginBottom: theme.spacing(),
-    padding: `${theme.spacing(1)} 0`,
-  },
-  selectionCard: {
-    mixBlendMode: theme.name === 'dark' ? 'initial' : 'darken',
-  },
-  info: {
-    display: 'flex',
-    justifyContent: 'flex-end',
-    color: theme.palette.primary.main,
-    paddingLeft: 0,
-    maxWidth: 40,
-    '& svg': {
-      width: 19,
-      height: 19,
-    },
-  },
-}));
 
 interface Props {
   handleClick: (
@@ -49,7 +26,23 @@ interface Props {
   labelDecoration?: JSX.Element;
 }
 
+const InfoGrid = styled(Grid, {
+  label: 'InfoGrid',
+})(({ theme }) => ({
+  display: 'flex',
+  justifyContent: 'flex-end',
+  color: theme.palette.primary.main,
+  padding: theme.spacing(1),
+  paddingLeft: 0,
+  maxWidth: 40,
+  '& svg': {
+    width: '19px',
+    height: '19px',
+  },
+}));
+
 export const SelectionCardWrapper: React.FC<Props> = (props) => {
+  const theme = useTheme();
   const {
     iconUrl,
     id,
@@ -67,7 +60,6 @@ export const SelectionCardWrapper: React.FC<Props> = (props) => {
    * '' is the default value for a stackscript's logo_url;
    * display a fallback image in this case, to avoid broken image icons
    */
-  const classes = useStyles();
 
   const handleSelectApp = () =>
     handleClick(
@@ -96,7 +88,7 @@ export const SelectionCardWrapper: React.FC<Props> = (props) => {
       : () => <img src={`${APP_ROOT}/${iconUrl}`} alt={`${label} logo`} />;
 
   const renderVariant = () => (
-    <Grid item className={classes.info} xs={2}>
+    <InfoGrid xs={2}>
       <Info
         role="button"
         aria-label={`Info for "${label}"`}
@@ -104,7 +96,7 @@ export const SelectionCardWrapper: React.FC<Props> = (props) => {
         onKeyDown={handleKeyPress}
         tabIndex={0}
       />
-    </Grid>
+    </InfoGrid>
   );
 
   return (
@@ -119,7 +111,9 @@ export const SelectionCardWrapper: React.FC<Props> = (props) => {
       subheadings={['']}
       data-qa-selection-card
       disabled={disabled}
-      className={classes.selectionCard}
+      sxGrid={{
+        mixBlendMode: theme.name === 'dark' ? 'initial' : 'darken',
+      }}
       headingDecoration={labelDecoration}
       sxCardBaseIcon={{
         justifyContent: 'flex-start',


### PR DESCRIPTION
## Description 📝
The parent components for Marketplace selection cards needed to be updated as well with new Gridv2.

## Major Changes 🔄 
- Updated all Grid references that used `SelectionCard`
- Migrated `ActionsPanel` since that was connected to one of the files affected

## Preview 📷
| Before      | After |
| ----------- | ----------- |
|<img width="889" alt="Screen Shot 2023-03-29 at 4 32 55 PM" src="https://user-images.githubusercontent.com/125309814/228661204-76251380-13fd-40d1-baaf-64617a2ef83d.png">|<img width="1918" alt="Screen Shot 2023-03-29 at 4 31 25 PM" src="https://user-images.githubusercontent.com/125309814/228661232-11390ab1-8424-4899-8843-fbc79ead28a0.png">|

<img width="1150" alt="Screen Shot 2023-03-29 at 6 00 39 PM" src="https://user-images.githubusercontent.com/125309814/228677434-6f422ad9-be4c-4693-a212-21560c4704d8.png">

## How to test 🧪
- Compare http://localhost:3000/linodes/create?type=One-Click with Prod
- Ensure "Make a Payment" is still good: http://localhost:3000/account/billing/make-payment
- User Permissions: http://localhost:3000/account/users/{USER}/permissions