### PR TITLE
perf: Only fetch `/v4/profile/grants` if a user is `restricted`

### DIFF
--- a/packages/manager/src/queries/profile.ts
+++ b/packages/manager/src/queries/profile.ts
@@ -43,12 +43,13 @@ export const updateProfileData = (newData: Partial<Profile>): void => {
   }));
 };
 
-export const useGrants = () =>
-  useQuery<Grants, APIError[]>(
-    [queryKey, 'grants'],
-    listGrants,
-    queryPresets.oneTimeFetch
-  );
+export const useGrants = () => {
+  const { data: profile } = useProfile();
+  return useQuery<Grants, APIError[]>([queryKey, 'grants'], listGrants, {
+    ...queryPresets.oneTimeFetch,
+    enabled: Boolean(profile?.restricted),
+  });
+};
 
 export const getProfileData = () => queryClient.getQueryData<Profile>(queryKey);
 export const getGrantData = () =>


### PR DESCRIPTION
## Description 📝

- This is a small tweak to our grants query that only enables the query when a user is restricted

### Why ❓
- For unrestricted users, the `/v4/profile/grants` endpoint returns an empty response because the user is unrestricted 
  - https://www.linode.com/docs/api/profile/#grants-list
- This change will save Cloud Manager from making an unnecessary API call resulting in possible better performance and less load on the Linode API

## Preview 📷

| Before | After |
|--------|-------|
| ![Screenshot 2023-03-29 at 6 40 49 PM](https://user-images.githubusercontent.com/115251059/228688375-fc7723e9-4c76-414d-b4bf-d342053c5686.jpg)     | ![after](https://user-images.githubusercontent.com/115251059/228688293-331d6e60-8015-4d01-b675-133098d45d7b.jpg)     |

## How to test 🧪

- As an unrestricted user
  - Login and verify that Cloud does **not** make an API call to `/v4/profile/grants` 
- As a restricted user
  - Login and verify that Cloud **does** make an API call to `/v4/profile/grants` 
 