### PR TITLE
fix: [M3-6453] - Filtering by `Status` on Linode Details Volumes Table

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallLanding.tsx
@@ -19,6 +19,7 @@ import { TableSortCell } from 'src/components/TableSortCell/TableSortCell';
 import TableCell from 'src/components/TableCell/TableCell';
 import TableBody from 'src/components/core/TableBody';
 import Hidden from 'src/components/core/Hidden';
+import PaginationFooter from 'src/components/PaginationFooter';
 
 const preferenceKey = 'firewalls';
 
@@ -172,6 +173,14 @@ const FirewallLanding = () => {
           ))}
         </TableBody>
       </Table>
+      <PaginationFooter
+        count={data?.results ?? 0}
+        handlePageChange={pagination.handlePageChange}
+        handleSizeChange={pagination.handlePageSizeChange}
+        page={pagination.page}
+        pageSize={pagination.pageSize}
+        eventCategory="Firewalls Table"
+      />
       <CreateFirewallDrawer
         open={isCreateFirewallDrawerOpen}
         onClose={closeDrawer}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeVolumes.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeVolumes.tsx
@@ -301,7 +301,7 @@ export const LinodeVolumes: React.FC<CombinedProps> = (props) => {
             <TableSortCell
               active={orderBy === 'status'}
               direction={order}
-              label="Status"
+              label="status"
               handleClick={handleOrderChange}
             >
               Status


### PR DESCRIPTION
## Description 📝

- Fixes a bug that caused users to see `Could not apply filter` when filtering by `Status` on the `/linodes/:id/storage` page in the Volumes Table
- This bug was caused by misspelling `status` as `Status` which resulted in an API error because `Status` is not a field returned by the API but `status` is
- This PR also adds pagination controls to Firewalls Landing because they were missing

## The Bug 🐛

https://user-images.githubusercontent.com/115251059/228903288-5cd57927-8c13-48ed-8b38-058fe3871424.mov

## How to test 🧪

- You may need a volume attached to a Linode
- Go to  `/linodes/:id/storage` for that Linode and stort the volumes table by `Status`
- Verify that the API returns a successful response in the dev tools and that the table shows no errors