### PR TITLE
refactor: [M3-6296] - MUI v5 Migration - `Components > BarPercent`

### DIFF
--- a/packages/manager/src/components/BarPercent/BarPercent.tsx
+++ b/packages/manager/src/components/BarPercent/BarPercent.tsx
@@ -1,35 +1,6 @@
-import { Theme } from '@mui/material/styles';
+import { styled } from '@mui/material/styles';
 import * as React from 'react';
 import LinearProgress from 'src/components/core/LinearProgress';
-import { makeStyles } from 'tss-react/mui';
-
-const useStyles = makeStyles()((theme: Theme) => ({
-  base: {
-    display: 'flex',
-    alignItems: 'center',
-    position: 'relative',
-  },
-  root: {
-    backgroundColor: theme.color.grey2,
-    padding: 12,
-    width: '100%',
-    '&.narrow': {
-      padding: 8,
-    },
-  },
-  primaryColor: {
-    backgroundColor: '#5ad865',
-  },
-  secondaryColor: {
-    backgroundColor: '#99ec79',
-  },
-  rounded: {
-    borderRadius: theme.shape.borderRadius,
-  },
-  dashed: {
-    display: 'none',
-  },
-}));
 
 interface Props {
   max: number;
@@ -42,21 +13,23 @@ interface Props {
 }
 
 export const BarPercent = (props: Props) => {
-  const { classes, cx } = useStyles();
+  const { max, value, className, valueBuffer, isFetchingValue } = props;
 
-  const {
-    max,
-    value,
-    className,
-    valueBuffer,
-    isFetchingValue,
-    rounded,
-    narrow,
-  } = props;
+  const sxDetails = {
+    '& .MuiLinearProgress-barColorPrimary': {
+      backgroundColor: '#5ad865',
+    },
+    '& .MuiLinearProgress-bar2Buffer': {
+      backgroundColor: '#99ec79',
+    },
+    '& .MuiLinearProgress-dashed': {
+      display: 'none',
+    },
+  };
 
   return (
-    <div className={`${className} ${classes.base}`}>
-      <LinearProgress
+    <StyledDiv className={`${className}`}>
+      <StyledLinearProgress
         value={getPercentage(value, max)}
         valueBuffer={valueBuffer}
         variant={
@@ -66,22 +39,33 @@ export const BarPercent = (props: Props) => {
             ? 'buffer'
             : 'determinate'
         }
-        classes={{
-          root: classes.root,
-          barColorPrimary: classes.primaryColor,
-          bar2Buffer: classes.secondaryColor,
-          dashed: classes.dashed,
-        }}
-        className={cx({
-          [classes.rounded]: rounded,
-          narrow,
-        })}
+        sx={sxDetails}
       />
-    </div>
+    </StyledDiv>
   );
 };
+
+export default React.memo(BarPercent);
 
 export const getPercentage = (value: number, max: number) =>
   (value / max) * 100;
 
-export default React.memo(BarPercent);
+const StyledDiv = styled('div')({
+  display: 'flex',
+  alignItems: 'center',
+  position: 'relative',
+});
+
+const StyledLinearProgress = styled(LinearProgress, {
+  label: 'StyledLinearProgress',
+})<Partial<Props>>(({ theme, ...props }) => ({
+  backgroundColor: theme.color.grey2,
+  padding: 12,
+  width: '100%',
+  ...(props.rounded && {
+    borderRadius: theme.shape.borderRadius,
+  }),
+  ...(props.narrow && {
+    padding: 8,
+  }),
+}));

--- a/packages/manager/src/components/BarPercent/BarPercent.tsx
+++ b/packages/manager/src/components/BarPercent/BarPercent.tsx
@@ -1,4 +1,5 @@
 import { styled } from '@mui/material/styles';
+import { SxProps } from '@mui/system';
 import * as React from 'react';
 import LinearProgress from 'src/components/core/LinearProgress';
 
@@ -10,6 +11,7 @@ interface Props {
   isFetchingValue?: boolean;
   rounded?: boolean;
   narrow?: boolean;
+  sx?: SxProps;
 }
 
 export const BarPercent = (props: Props) => {
@@ -21,19 +23,8 @@ export const BarPercent = (props: Props) => {
     isFetchingValue,
     rounded,
     narrow,
+    sx,
   } = props;
-
-  const sxDetails = {
-    '& .MuiLinearProgress-barColorPrimary': {
-      backgroundColor: '#5ad865',
-    },
-    '& .MuiLinearProgress-bar2Buffer': {
-      backgroundColor: '#99ec79',
-    },
-    '& .MuiLinearProgress-dashed': {
-      display: 'none',
-    },
-  };
 
   return (
     <StyledDiv className={`${className}`}>
@@ -47,9 +38,9 @@ export const BarPercent = (props: Props) => {
             ? 'buffer'
             : 'determinate'
         }
-        sx={sxDetails}
         rounded={rounded}
         narrow={narrow}
+        sx={sx}
       />
     </StyledDiv>
   );
@@ -73,4 +64,13 @@ const StyledLinearProgress = styled(LinearProgress, {
   padding: props.narrow ? 8 : 12,
   width: '100%',
   borderRadius: props.rounded ? theme.shape.borderRadius : undefined,
+  '& .MuiLinearProgress-barColorPrimary': {
+    backgroundColor: '#5ad865',
+  },
+  '& .MuiLinearProgress-bar2Buffer': {
+    backgroundColor: '#99ec79',
+  },
+  '& .MuiLinearProgress-dashed': {
+    display: 'none',
+  },
 }));

--- a/packages/manager/src/components/BarPercent/BarPercent.tsx
+++ b/packages/manager/src/components/BarPercent/BarPercent.tsx
@@ -1,10 +1,9 @@
-import classNames from 'classnames';
+import { Theme } from '@mui/material/styles';
 import * as React from 'react';
 import LinearProgress from 'src/components/core/LinearProgress';
-import { makeStyles } from '@mui/styles';
-import { Theme } from '@mui/material/styles';
+import { makeStyles } from 'tss-react/mui';
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles()((theme: Theme) => ({
   base: {
     display: 'flex',
     alignItems: 'center',
@@ -42,10 +41,8 @@ interface Props {
   narrow?: boolean;
 }
 
-type CombinedProps = Props;
-
-export const BarPercent: React.FC<CombinedProps> = (props) => {
-  const classes = useStyles();
+export const BarPercent = (props: Props) => {
+  const { classes, cx } = useStyles();
 
   const {
     max,
@@ -75,7 +72,7 @@ export const BarPercent: React.FC<CombinedProps> = (props) => {
           bar2Buffer: classes.secondaryColor,
           dashed: classes.dashed,
         }}
-        className={classNames({
+        className={cx({
           [classes.rounded]: rounded,
           narrow,
         })}

--- a/packages/manager/src/components/BarPercent/BarPercent.tsx
+++ b/packages/manager/src/components/BarPercent/BarPercent.tsx
@@ -13,7 +13,15 @@ interface Props {
 }
 
 export const BarPercent = (props: Props) => {
-  const { max, value, className, valueBuffer, isFetchingValue } = props;
+  const {
+    max,
+    value,
+    className,
+    valueBuffer,
+    isFetchingValue,
+    rounded,
+    narrow,
+  } = props;
 
   const sxDetails = {
     '& .MuiLinearProgress-barColorPrimary': {
@@ -40,6 +48,8 @@ export const BarPercent = (props: Props) => {
             : 'determinate'
         }
         sx={sxDetails}
+        rounded={rounded}
+        narrow={narrow}
       />
     </StyledDiv>
   );
@@ -60,12 +70,7 @@ const StyledLinearProgress = styled(LinearProgress, {
   label: 'StyledLinearProgress',
 })<Partial<Props>>(({ theme, ...props }) => ({
   backgroundColor: theme.color.grey2,
-  padding: 12,
+  padding: props.narrow ? 8 : 12,
   width: '100%',
-  ...(props.rounded && {
-    borderRadius: theme.shape.borderRadius,
-  }),
-  ...(props.narrow && {
-    padding: 8,
-  }),
+  borderRadius: props.rounded ? theme.shape.borderRadius : undefined,
 }));


### PR DESCRIPTION
## Description 📝
Migrates `SRC > Components > BarPcent` from JSS to tss-react (Emotion)

## How to test 🧪
Confirm that the `BarPercent` component looks as expected throughout the app, including in the Monthly Network Transfer Pool modal and event progress bar in the notifications drawer.