### PR TITLE
fix: Fix Clone Linode e2e test flake when Newark resources exist

### DIFF
--- a/packages/manager/cypress/e2e/linodes/clone-linode.spec.ts
+++ b/packages/manager/cypress/e2e/linodes/clone-linode.spec.ts
@@ -29,8 +29,14 @@ describe('clone linode', () => {
 
         ui.actionMenuItem.findByTitle('Clone').should('be.visible').click();
 
-        containsClick('Select a Region');
-        containsClick('Newark, NJ');
+        cy.get('[data-qa-tp="Region"]')
+          .parent()
+          .should('be.visible')
+          .within(() => {
+            containsClick('Select a Region');
+            containsClick('Newark, NJ');
+          });
+
         getVisible('[data-qa-summary]').within(() => {
           containsVisible(linode.label);
         });


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
This fixes some flake with our `clone-linode.spec.ts` e2e tests. The tests fail when there are Linodes present on the account in the Newark region, because Cypress mistakenly clicks the Linode in the "Select Linode to Clone From" section instead of the "Newark, NJ" region selection item.

This is a quick band aid to fix the problem, but in the future we'll introduce UI helpers to simplify interactions with drop-downs, autocomplete text fields, etc. that will guard against issues like this.

## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**
1. On your test account, create a Linode in the Newark region. Make sure the Linode label does **not** have a `cy-test-` prefix.
2. Run `yarn && yarn build && yarn start:manager:ci`
3. To reproduce the issue, run `yarn cy:run -s "cypress/e2e/linodes/clone-linode.spec.ts"` with `develop` checked out and confirm that the tests fail
4. To validate this fix, run `yarn cy:run -s "cypress/e2e/linodes/clone-linode.spec.ts"` with this branch checked out and confirm that the tests pass
