### PR TITLE
refactor: [M3-6297, M3-6298] - MUI v5 Migration - Components > BetaChip & Breadcrumb

### DIFF
--- a/packages/manager/src/components/BetaChip/BetaChip.tsx
+++ b/packages/manager/src/components/BetaChip/BetaChip.tsx
@@ -1,8 +1,7 @@
+import { Theme } from '@mui/material/styles';
 import * as React from 'react';
 import Chip, { ChipProps } from 'src/components/core/Chip';
-import classNames from 'classnames';
-import { makeStyles } from '@mui/styles';
-import { Theme } from '@mui/material/styles';
+import { makeStyles } from 'tss-react/mui';
 
 interface Props
   extends Omit<
@@ -21,7 +20,7 @@ interface Props
   color?: 'default' | 'primary';
 }
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles()((theme: Theme) => ({
   root: {
     fontFamily: theme.font.bold,
     fontSize: '0.625rem',
@@ -32,8 +31,8 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-const BetaChip: React.FC<Props> = (props) => {
-  const classes = useStyles();
+const BetaChip = (props: Props) => {
+  const { classes, cx } = useStyles();
 
   const { className, color } = props;
 
@@ -42,11 +41,11 @@ const BetaChip: React.FC<Props> = (props) => {
       {...props}
       label="beta"
       color={color}
-      className={classNames(className, {
+      className={cx(className, {
         [classes.root]: true,
       })}
     />
   );
 };
 
-export default BetaChip;
+export { BetaChip };

--- a/packages/manager/src/components/BetaChip/BetaChip.tsx
+++ b/packages/manager/src/components/BetaChip/BetaChip.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import Chip, { ChipProps } from 'src/components/core/Chip';
 import { makeStyles } from 'tss-react/mui';
 
-interface Props
+interface BetaChipProps
   extends Omit<
     ChipProps,
     | 'label'
@@ -31,7 +31,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
   },
 }));
 
-const BetaChip = (props: Props) => {
+const BetaChip = (props: BetaChipProps) => {
   const { classes, cx } = useStyles();
 
   const { className, color } = props;

--- a/packages/manager/src/components/BetaChip/index.ts
+++ b/packages/manager/src/components/BetaChip/index.ts
@@ -1,2 +1,0 @@
-import BetaChip from './BetaChip';
-export default BetaChip;

--- a/packages/manager/src/components/Breadcrumb/Breadcrumb.test.tsx
+++ b/packages/manager/src/components/Breadcrumb/Breadcrumb.test.tsx
@@ -1,9 +1,9 @@
 import { render } from '@testing-library/react';
 import * as React from 'react';
 import { wrapWithTheme } from 'src/utilities/testHelpers';
-import { Breadcrumb, Props as BreadCrumbProps } from './Breadcrumb';
+import { Breadcrumb, BreadcrumbProps } from './Breadcrumb';
 
-const props: BreadCrumbProps = {
+const props: BreadcrumbProps = {
   pathname: '/linodes/9872893679817/test/lastcrumb',
 };
 

--- a/packages/manager/src/components/Breadcrumb/Breadcrumb.test.tsx
+++ b/packages/manager/src/components/Breadcrumb/Breadcrumb.test.tsx
@@ -1,8 +1,7 @@
 import { render } from '@testing-library/react';
 import * as React from 'react';
 import { wrapWithTheme } from 'src/utilities/testHelpers';
-
-import { Breadcrumb, CombinedProps as BreadCrumbProps } from './Breadcrumb';
+import { Breadcrumb, Props as BreadCrumbProps } from './Breadcrumb';
 
 const props: BreadCrumbProps = {
   pathname: '/linodes/9872893679817/test/lastcrumb',

--- a/packages/manager/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/manager/src/components/Breadcrumb/Breadcrumb.tsx
@@ -1,9 +1,7 @@
-import classNames from 'classnames';
-import * as React from 'react';
-import { makeStyles } from '@mui/styles';
 import { Theme } from '@mui/material/styles';
+import * as React from 'react';
+import { makeStyles } from 'tss-react/mui';
 import Crumbs, { CrumbOverridesProps } from './Crumbs';
-
 import { EditableProps, LabelProps } from './types';
 
 export interface Props {
@@ -18,9 +16,7 @@ export interface Props {
   removeCrumbX?: number;
 }
 
-export type CombinedProps = Props;
-
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles()((theme: Theme) => ({
   root: {
     display: 'flex',
     alignItems: 'center',
@@ -45,8 +41,8 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-export const Breadcrumb: React.FC<CombinedProps> = (props) => {
-  const classes = useStyles();
+const Breadcrumb = (props: Props) => {
+  const { classes, cx } = useStyles();
 
   const {
     breadcrumbDataAttrs,
@@ -71,7 +67,7 @@ export const Breadcrumb: React.FC<CombinedProps> = (props) => {
 
   return (
     <div
-      className={classNames(
+      className={cx(
         {
           [classes.root]: true,
           [classes.hasError]: hasError,
@@ -81,7 +77,7 @@ export const Breadcrumb: React.FC<CombinedProps> = (props) => {
       {...breadcrumbDataAttrs}
     >
       <div
-        className={classNames({
+        className={cx({
           [classes.preContainer]: true,
           [classes.editablePreContainer]: onEditHandlers !== undefined,
         })}
@@ -105,4 +101,4 @@ const removeByIndex = (list: string[], indexToRemove: number) => {
   });
 };
 
-export default Breadcrumb;
+export { Breadcrumb };

--- a/packages/manager/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/manager/src/components/Breadcrumb/Breadcrumb.tsx
@@ -4,7 +4,7 @@ import { makeStyles } from 'tss-react/mui';
 import Crumbs, { CrumbOverridesProps } from './Crumbs';
 import { EditableProps, LabelProps } from './types';
 
-export interface Props {
+export interface BreadcrumbProps {
   breadcrumbDataAttrs?: { [key: string]: boolean };
   className?: string;
   crumbOverrides?: CrumbOverridesProps[];
@@ -41,7 +41,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
   },
 }));
 
-const Breadcrumb = (props: Props) => {
+const Breadcrumb = (props: BreadcrumbProps) => {
   const { classes, cx } = useStyles();
 
   const {

--- a/packages/manager/src/components/Breadcrumb/index.tsx
+++ b/packages/manager/src/components/Breadcrumb/index.tsx
@@ -1,4 +1,0 @@
-import Breadcrumb, { Props } from './Breadcrumb';
-/* tslint:disable */
-export interface BreadcrumbProps extends Props {}
-export default Breadcrumb;

--- a/packages/manager/src/components/LandingHeader/LandingHeader.tsx
+++ b/packages/manager/src/components/LandingHeader/LandingHeader.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import Button from 'src/components/Button';
 import {
   Breadcrumb,
-  Props as BreadcrumbProps,
+  BreadcrumbProps,
 } from 'src/components/Breadcrumb/Breadcrumb';
 import DocsLink from '../DocsLink';
 import Grid from '@mui/material/Grid';

--- a/packages/manager/src/components/LandingHeader/LandingHeader.tsx
+++ b/packages/manager/src/components/LandingHeader/LandingHeader.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import Button from 'src/components/Button';
-import Breadcrumb, { BreadcrumbProps } from '../Breadcrumb';
+import {
+  Breadcrumb,
+  Props as BreadcrumbProps,
+} from 'src/components/Breadcrumb/Breadcrumb';
 import DocsLink from '../DocsLink';
 import Grid from '@mui/material/Grid';
 import { useTheme, styled } from '@mui/material/styles';

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -17,7 +17,7 @@ import Volume from 'src/assets/icons/entityIcons/volume.svg';
 import TooltipIcon from 'src/assets/icons/get_help.svg';
 import Longview from 'src/assets/icons/longview.svg';
 import AkamaiLogo from 'src/assets/logo/akamai-logo.svg';
-import BetaChip from 'src/components/BetaChip';
+import { BetaChip } from 'src/components/BetaChip/BetaChip';
 import Divider from 'src/components/core/Divider';
 import Grid from 'src/components/core/Grid';
 import useAccountManagement from 'src/hooks/useAccountManagement';

--- a/packages/manager/src/dev-tools/FeatureFlagTool.tsx
+++ b/packages/manager/src/dev-tools/FeatureFlagTool.tsx
@@ -9,6 +9,7 @@ import Grid from 'src/components/core/Grid';
 
 const options: { label: string; flag: keyof Flags }[] = [
   { label: 'Metadata', flag: 'metadata' },
+  { label: 'Database Beta', flag: 'databaseBeta' },
 ];
 
 const FeatureFlagTool: React.FC<{}> = () => {

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -17,7 +17,7 @@ import { useHistory } from 'react-router-dom';
 import MongoDBIcon from 'src/assets/icons/mongodb.svg';
 import MySQLIcon from 'src/assets/icons/mysql.svg';
 import PostgreSQLIcon from 'src/assets/icons/postgresql.svg';
-import BetaChip from 'src/components/BetaChip';
+import { BetaChip } from 'src/components/BetaChip/BetaChip';
 import Button from 'src/components/Button';
 import CircleProgress from 'src/components/CircleProgress';
 import Divider from 'src/components/core/Divider';

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeControls.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeControls.tsx
@@ -3,7 +3,10 @@ import { last } from 'ramda';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
-import Breadcrumb, { BreadcrumbProps } from 'src/components/Breadcrumb';
+import {
+  Breadcrumb,
+  Props as BreadcrumbProps,
+} from 'src/components/Breadcrumb/Breadcrumb';
 import Button from 'src/components/Button';
 import { createStyles, withStyles, WithStyles } from '@mui/styles';
 import { Theme } from '@mui/material/styles';

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeControls.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeControls.tsx
@@ -5,7 +5,7 @@ import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
 import {
   Breadcrumb,
-  Props as BreadcrumbProps,
+  BreadcrumbProps,
 } from 'src/components/Breadcrumb/Breadcrumb';
 import Button from 'src/components/Button';
 import { createStyles, withStyles, WithStyles } from '@mui/styles';

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailsBreadcrumb.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailsBreadcrumb.tsx
@@ -3,7 +3,10 @@ import { last } from 'ramda';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
-import Breadcrumb, { BreadcrumbProps } from 'src/components/Breadcrumb';
+import {
+  Breadcrumb,
+  Props as BreadcrumbProps,
+} from 'src/components/Breadcrumb/Breadcrumb';
 import { makeStyles } from '@mui/styles';
 import { Theme } from '@mui/material/styles';
 import DocsLink from 'src/components/DocsLink';

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailsBreadcrumb.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailsBreadcrumb.tsx
@@ -5,7 +5,7 @@ import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
 import {
   Breadcrumb,
-  Props as BreadcrumbProps,
+  BreadcrumbProps,
 } from 'src/components/Breadcrumb/Breadcrumb';
 import { makeStyles } from '@mui/styles';
 import { Theme } from '@mui/material/styles';


### PR DESCRIPTION
## Description 📝
- Migrate BetaChip and Breadcrumb component from JSS to tss-react (Emotion)
- Remove React.FC
- Use named exports instead of default

## How to test 🧪
Use the DevTools to turn the Database Beta flag on and observe the Beta chip in the primary nav and Database Create breadcrumb. Check other places in the app where Breadcrumb is used

![image](https://user-images.githubusercontent.com/115299789/230208045-d02c7c7f-5176-4cd8-bc21-e99cf70eee0e.png)

