### PR TITLE
fix: NodeBalancer Create e2e tests and associated bug

### DIFF
--- a/packages/manager/cypress/e2e/nodebalancers/smoke-create-nodebal.spec.ts
+++ b/packages/manager/cypress/e2e/nodebalancers/smoke-create-nodebal.spec.ts
@@ -13,11 +13,10 @@ import { randomLabel } from 'support/util/random';
 
 const deployNodeBalancer = () => {
   // This is not an error, the tag is deploy-linode
-  cy.get('[data-qa-deploy-linode]').click();
+  cy.get('[data-qa-deploy-nodebalancer]').click();
 };
 const createNodeBalancerWithUI = (nodeBal) => {
   cy.visitWithLogin('/nodebalancers/create');
-  fbtVisible('NodeBalancer Settings');
   getVisible('[id="nodebalancer-label"]').click().clear().type(nodeBal.label);
   containsClick('create a tag').type(testNodeBalTag);
   // this will create the NB in newark, where the default Linode was created

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigNode.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigNode.tsx
@@ -109,7 +109,7 @@ export const NodeBalancerConfigNode: React.FC<Props> = (props) => {
 
   return (
     <React.Fragment>
-      <Grid updateFor={[node, classes]} item data-qa-node xs={12}>
+      <Grid item data-qa-node xs={12}>
         {idx !== 0 && (
           <Grid item xs={12}>
             <Divider
@@ -163,12 +163,7 @@ export const NodeBalancerConfigNode: React.FC<Props> = (props) => {
         </Grid>
       </Grid>
       <Grid item xs={12}>
-        <Grid
-          key={idx}
-          updateFor={[nodeBalancerRegion, node, configIdx, classes]}
-          container
-          data-qa-node
-        >
+        <Grid key={idx} container data-qa-node>
           <Grid item xs={12} sm={3} lg={forEdit ? 2 : 4}>
             <SelectIP
               textfieldProps={{

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigNode.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigNode.tsx
@@ -109,7 +109,7 @@ export const NodeBalancerConfigNode: React.FC<Props> = (props) => {
 
   return (
     <React.Fragment>
-      <Grid item data-qa-node xs={12}>
+      <Grid updateFor={[node, classes]} item data-qa-node xs={12}>
         {idx !== 0 && (
           <Grid item xs={12}>
             <Divider
@@ -163,7 +163,12 @@ export const NodeBalancerConfigNode: React.FC<Props> = (props) => {
         </Grid>
       </Grid>
       <Grid item xs={12}>
-        <Grid key={idx} container data-qa-node>
+        <Grid
+          key={idx}
+          updateFor={[nodeBalancerRegion, node, configIdx, classes]}
+          container
+          data-qa-node
+        >
           <Grid item xs={12} sm={3} lg={forEdit ? 2 : 4}>
             <SelectIP
               textfieldProps={{

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -806,7 +806,17 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
           </Grid>
         </Grid>
 
-        <Grid container>
+        <Grid
+          container
+          updateFor={[
+            nodes,
+            errors,
+            nodeMessage,
+            classes,
+            errorMap.nodes,
+            this.props.nodeBalancerRegion,
+          ]}
+        >
           <Grid item xs={12}>
             <Grid updateFor={[nodeMessage, classes]} item xs={12}>
               {nodeMessage && <Notice text={nodeMessage} success />}

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -806,17 +806,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
           </Grid>
         </Grid>
 
-        <Grid
-          updateFor={[
-            nodes,
-            errors,
-            nodeMessage,
-            classes,
-            errorMap.nodes,
-            this.props.nodeBalancerRegion,
-          ]}
-          container
-        >
+        <Grid container>
           <Grid item xs={12}>
             <Grid updateFor={[nodeMessage, classes]} item xs={12}>
               {nodeMessage && <Notice text={nodeMessage} success />}

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -144,7 +144,9 @@ const NodeBalancerCreate = () => {
   ) =>
     setNodeBalancerFields((prev) => {
       const newConfigs = [...prev.configs];
-      newConfigs[cidx].nodes[nodeidx][key] = value;
+      const newNodeArray = [...prev.configs[cidx].nodes];
+      newNodeArray[nodeidx] = { ...newNodeArray[nodeidx], [key]: value };
+      newConfigs[cidx].nodes = newNodeArray;
       return { ...prev, configs: newConfigs };
     });
 

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -549,7 +549,12 @@ const NodeBalancerCreate = () => {
             onChange={(e) => updateAgreements({ eu_model: e.target.checked })}
           />
         ) : undefined}
-        <Button buttonType="primary" onClick={onCreate} loading={isLoading}>
+        <Button
+          buttonType="primary"
+          onClick={onCreate}
+          loading={isLoading}
+          data-qa-deploy-nodebalancer
+        >
           Create NodeBalancer
         </Button>
       </Box>


### PR DESCRIPTION
## Description 📝

- Caused by https://github.com/linode/manager/pull/8964
- Fixes e2e test failure caused by updates
- Removes some render guards because the equals function that the render guard is using does not work as expected

## How to test 🧪

- Look at cypress results of this PR
  - If the nodebal spec passes, we can assume I fixed the bug and the e2e test