### PR TITLE
chore: [M3-5751] - Improve the `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,19 @@
     <img src="https://github.com/linode/manager/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI Build Stats on develop" />
   </a>
   <a href="https://github.com/linode/manager/releases">
-    <img src="https://img.shields.io/github/package-json/v/linode/manager?filename=packages%2Fmanager%2Fpackage.json&label=manager" alt="Cloud Manager Version" />
+    <img src="https://img.shields.io/github/package-json/v/linode/manager?filename=packages%2Fmanager%2Fpackage.json&label=cloud.linode.com" alt="Cloud Manager Version" />
   </a>
   <a href="https://www.npmjs.com/package/@linode/api-v4">
     <img src="https://img.shields.io/npm/v/@linode/api-v4?label=%40linode%2Fapi-v4" alt="@linode/api-v4 version" />
   </a>
+  <a href="https://bundlephobia.com/package/@linode/api-v4">
+    <img alt="api-v4 bundle size" src="https://img.shields.io/bundlephobia/min/@linode/api-v4?label=api-v4 size">
+  </a>
   <a href="https://www.npmjs.com/package/@linode/validation">
     <img src="https://img.shields.io/npm/v/@linode/validation?label=%40linode%2Fapi-v4" alt="@linode/validation version" />
+  </a>
+  <a href="https://bundlephobia.com/package/@linode/validation">
+    <img alt="validation bundle size" src="https://img.shields.io/bundlephobia/min/@linode/validation?label=validation size">
   </a>
   <a href="https://design.linode.com">
     <img src="https://cdn.jsdelivr.net/gh/storybookjs/brand@main/badge/badge-storybook.svg" alt="Storybook" />

--- a/README.md
+++ b/README.md
@@ -1,29 +1,43 @@
-<h1 align="center">
-  <img src="https://user-images.githubusercontent.com/32860776/156064400-4eb7e3ef-aa93-4b75-9962-07f6090de2ed.png" width="200" />
+<h3 align="center">
+  <img src="https://github.com/linode/manager/blob/develop/packages/manager/src/assets/logo/akamai-logo.svg" width="200" />
   <br />
-  Linode Cloud Manager
-</h1>
+  <br />
+  Akamai Connected Cloud Manager
+</h2>
 
 <p align="center">
-  <a href="https://travis-ci.com/linode/manager"><img src="https://travis-ci.com/linode/manager.svg?branch=master" alt="Build status" /></a>
-  <a href="https://coveralls.io/github/linode/manager?branch=master"><img src="https://coveralls.io/repos/github/linode/manager/badge.svg?branch=master" alt="Code coverage" /></a>
+  <a href="https://github.com/linode/manager/actions/workflows/ci.yml">
+    <img src="https://github.com/linode/manager/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI Build Stats on develop" />
+  </a>
+  <a href="https://github.com/linode/manager/releases">
+    <img src="https://img.shields.io/github/package-json/v/linode/manager?filename=packages%2Fmanager%2Fpackage.json&label=manager" alt="Cloud Manager Version" />
+  </a>
+  <a href="https://www.npmjs.com/package/@linode/api-v4">
+    <img src="https://img.shields.io/npm/v/@linode/api-v4?label=%40linode%2Fapi-v4" alt="@linode/api-v4 version" />
+  </a>
+  <a href="https://www.npmjs.com/package/@linode/validation">
+    <img src="https://img.shields.io/npm/v/@linode/validation?label=%40linode%2Fapi-v4" alt="@linode/validation version" />
+  </a>
+  <a href="https://design.linode.com">
+    <img src="https://cdn.jsdelivr.net/gh/storybookjs/brand@main/badge/badge-storybook.svg" alt="Storybook" />
+  </a>
 </p>
 
-This repository is home to the [Linode Cloud Manager](https://cloud.linode.com) and related projects, including the [JavaScript SDK](https://www.npmjs.com/package/@linode/api-v4).
+## Overview 📒
 
-## Running Projects Within the Repository
+This repository is home to the Linode **[Cloud Manager](https://cloud.linode.com)** and Linode's related `@linode/api-v4` and `@linode/validation` Typescript packages.
+
+## Developing Locally 💻
 
 To get started running Cloud Manager locally, please see the [_Getting Started_ guide](docs/GETTING_STARTED.md).
 
-## Contributing
+## Contributing 👏
 
 If you already have your development environment set up, please read the [contributing guidelines](docs/CONTRIBUTING.md) to get help in creating your first Pull Request.
 
-## Reaching Out
-
 To report a bug or request a feature in Cloud Manager, please [open a GitHub Issue](https://github.com/linode/manager/issues/new). For general feedback, use [linode.com/feedback](https://www.linode.com/feedback/).
 
-## License
+## License 📝
 
 All code located in this repository is distributed under the terms of the [APLv2
 license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 
 ## Overview 📒
 
-This repository is home to the Linode **[Cloud Manager](https://cloud.linode.com)** and Linode's related `@linode/api-v4` and `@linode/validation` Typescript packages.
+This repository is home to the Linode **[Cloud Manager](https://cloud.linode.com)** and Linode's related [`@linode/api-v4`](packages/api-v4/) and [`@linode/validation`](packages/validation/) Typescript packages.
 
 ## Developing Locally 💻
 

--- a/README.md
+++ b/README.md
@@ -35,21 +35,21 @@
   
 </p>
 
-## Overview 📒
+## Overview
 
-This repository is home to the Linode **[Cloud Manager](https://cloud.linode.com)** and Linode's related [`@linode/api-v4`](packages/api-v4/) and [`@linode/validation`](packages/validation/) Typescript packages.
+This repository is home to the Akamai Connected **[Cloud Manager](https://cloud.linode.com)** and related [`@linode/api-v4`](packages/api-v4/) and [`@linode/validation`](packages/validation/) Typescript packages.
 
-## Developing Locally 💻
+## Developing Locally
 
 To get started running Cloud Manager locally, please see the [_Getting Started_ guide](docs/GETTING_STARTED.md).
 
-## Contributing 👏
+## Contributing
 
 If you already have your development environment set up, please read the [contributing guidelines](docs/CONTRIBUTING.md) to get help in creating your first Pull Request.
 
 To report a bug or request a feature in Cloud Manager, please [open a GitHub Issue](https://github.com/linode/manager/issues/new). For general feedback, use [linode.com/feedback](https://www.linode.com/feedback/).
 
-## License 📝
+## License
 
 All code located in this repository is distributed under the terms of the [APLv2
 license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -9,9 +9,17 @@
   <a href="https://github.com/linode/manager/actions/workflows/ci.yml">
     <img src="https://github.com/linode/manager/actions/workflows/ci.yml/badge.svg?branch=develop" alt="CI Build Stats on develop" />
   </a>
+  <a href="https://cloud.linode.com">
+  <img alt="Website" src="https://img.shields.io/website?down_color=red&down_message=outage&label=cloud.linode.com&up_color=green&up_message=up&url=https%3A%2F%2Fcloud.linode.com" />
+  </a>
   <a href="https://github.com/linode/manager/releases">
     <img src="https://img.shields.io/github/package-json/v/linode/manager?filename=packages%2Fmanager%2Fpackage.json&label=cloud.linode.com" alt="Cloud Manager Version" />
   </a>
+  <a href="https://design.linode.com">
+    <img src="https://cdn.jsdelivr.net/gh/storybookjs/brand@main/badge/badge-storybook.svg" alt="Storybook" />
+  </a>
+</p>
+<p align="center">
   <a href="https://www.npmjs.com/package/@linode/api-v4">
     <img src="https://img.shields.io/npm/v/@linode/api-v4?label=%40linode%2Fapi-v4" alt="@linode/api-v4 version" />
   </a>
@@ -24,9 +32,7 @@
   <a href="https://bundlephobia.com/package/@linode/validation">
     <img alt="validation bundle size" src="https://img.shields.io/bundlephobia/min/@linode/validation?label=validation size">
   </a>
-  <a href="https://design.linode.com">
-    <img src="https://cdn.jsdelivr.net/gh/storybookjs/brand@main/badge/badge-storybook.svg" alt="Storybook" />
-  </a>
+  
 </p>
 
 ## Overview 📒


### PR DESCRIPTION
## Description 📝

- Rebrands to Akamai
- Makes our `README.md` look less crusty
- Uses badges to give us (and users) some useful stats
  - CI status (we can't do cypress with our current setup, sorry)
  - Online status for cloud.linode.com
  - Cloud Manager's version
  - Storybook Link
  - api-v4 and validation versions
  - api-v4 and validation bundle sizes
- ~Adds some emojis to add some color (we can remove if it's too cringe)~

## Preview 📷

![Screenshot 2023-04-07 at 1 53 30 PM](https://user-images.githubusercontent.com/115251059/230654823-2a267225-0c55-45d2-b765-5067880c3d07.jpg)
