### PR TITLE
refactor: [M3-6299] – MUI v5 Migration - `Components > CheckBox`

### DIFF
--- a/packages/manager/src/components/CheckBox/CheckBox.tsx
+++ b/packages/manager/src/components/CheckBox/CheckBox.tsx
@@ -1,41 +1,11 @@
+import { styled } from '@mui/material/styles';
 import { SxProps } from '@mui/system';
-import classNames from 'classnames';
 import * as React from 'react';
 import CheckboxIcon from 'src/assets/icons/checkbox.svg';
 import CheckboxCheckedIcon from 'src/assets/icons/checkboxChecked.svg';
 import Checkbox, { CheckboxProps } from 'src/components/core/Checkbox';
 import FormControlLabel from 'src/components/core/FormControlLabel';
-import { makeStyles } from '@mui/styles';
-import { Theme } from '@mui/material/styles';
 import { TooltipIcon } from 'src/components/TooltipIcon/TooltipIcon';
-
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    color: '#ccc',
-    transition: theme.transitions.create(['color']),
-    '& .defaultFill': {
-      transition: theme.transitions.create(['fill']),
-    },
-    '&:hover': {
-      color: theme.palette.primary.main,
-    },
-  },
-  checked: {
-    color: theme.palette.primary.main,
-  },
-  disabled: {
-    color: '#ccc !important',
-    fill: `${theme.bg.main} !important`,
-    pointerEvents: 'none',
-    '& .defaultFill': {
-      opacity: 0.5,
-      fill: `${theme.bg.main}`,
-    },
-  },
-  formControlStyles: {
-    marginRight: 0,
-  },
-}));
 
 interface Props extends CheckboxProps {
   text?: string | JSX.Element;
@@ -46,23 +16,14 @@ interface Props extends CheckboxProps {
 
 const LinodeCheckBox = (props: Props) => {
   const { toolTipInteractive, toolTipText, text, sxFormLabel, ...rest } = props;
-  const classes = useStyles();
-
-  const classnames = classNames({
-    [classes.root]: true,
-    [classes.disabled]: props.disabled === true,
-    [classes.checked]: Boolean(props.checked),
-  });
 
   if (props.text) {
     return (
-      <React.Fragment>
-        <FormControlLabel
-          className={classes.formControlStyles}
+      <>
+        <StyledFormControlLabel
           control={
-            <Checkbox
+            <StyledCheckbox
               color="primary"
-              className={classnames}
               icon={<CheckboxIcon />}
               checkedIcon={<CheckboxCheckedIcon />}
               data-qa-checked={props.checked}
@@ -79,14 +40,13 @@ const LinodeCheckBox = (props: Props) => {
             status="help"
           />
         ) : null}
-      </React.Fragment>
+      </>
     );
   }
 
   return (
-    <Checkbox
+    <StyledCheckbox
       color="primary"
-      className={classnames}
       icon={<CheckboxIcon />}
       checkedIcon={<CheckboxCheckedIcon />}
       data-qa-checked={props.checked}
@@ -96,3 +56,30 @@ const LinodeCheckBox = (props: Props) => {
 };
 
 export default LinodeCheckBox;
+
+const StyledCheckbox = styled(Checkbox)(({ theme, ...props }) => ({
+  color: '#ccc',
+  transition: theme.transitions.create(['color']),
+  '& .defaultFill': {
+    transition: theme.transitions.create(['fill']),
+  },
+  '&:hover': {
+    color: theme.palette.primary.main,
+  },
+  ...(props.checked && {
+    color: theme.palette.primary.main,
+  }),
+  ...(props.disabled && {
+    color: '#ccc !important',
+    fill: `${theme.bg.main} !important`,
+    pointerEvents: 'none',
+    '& .defaultFill': {
+      opacity: 0.5,
+      fill: `${theme.bg.main}`,
+    },
+  }),
+}));
+
+const StyledFormControlLabel = styled(FormControlLabel)(() => ({
+  marginRight: 0,
+}));


### PR DESCRIPTION
## Description 📝
Migrates `SRC > Components > CheckBox` from JSS to styled components

## How to test 🧪
Confirm that there have been no visual regressions in the app where the `CheckBox` component is used (e.g., the "Enable HA Control Plane" option in the LKE Create flow, SSH Key panel in the Linode Create flow, etc.).

