### PR TITLE
fix: [M3-6425] - Linode Details Add Configurations Modal Header

### DIFF
--- a/packages/manager/src/components/Dialog/Dialog.tsx
+++ b/packages/manager/src/components/Dialog/Dialog.tsx
@@ -21,7 +21,6 @@ export interface DialogProps extends _DialogProps {
 
 const useStyles = makeStyles((theme: Theme) => ({
   paper: {
-    padding: `${theme.spacing(2)} ${theme.spacing(4)}`,
     paddingTop: 0,
     maxHeight: '100%',
     '& .actionPanel': {
@@ -64,9 +63,8 @@ const useStyles = makeStyles((theme: Theme) => ({
     backgroundColor: theme.bg.bgPaper,
     position: 'sticky',
     top: 0,
-    padding: `${theme.spacing(1.5)} 0`,
-    paddingTop: theme.spacing(4),
-    zIndex: 1,
+    padding: `${theme.spacing(2)} ${theme.spacing(4)}`,
+    zIndex: 2,
     width: '100%',
     display: 'flex',
     justifyContent: 'space-between',
@@ -118,30 +116,27 @@ const Dialog: React.FC<DialogProps> = (props) => {
     >
       <Grid container alignItems="center">
         <div className={classes.sticky}>
-          <Grid>
-            <Typography
-              variant="h2"
-              id={titleID}
-              data-qa-drawer-title={title}
-              data-qa-dialog-title={title}
-            >
-              {title}
-            </Typography>
-          </Grid>
-          <Grid>
-            <Button
-              buttonType="secondary"
-              onClick={props.onClose as (e: any) => void}
-              className={classes.button}
-              data-qa-close-drawer
-              aria-label="Close"
-            >
-              <Close />
-            </Button>
-          </Grid>
+          <Typography
+            variant="h2"
+            id={titleID}
+            data-qa-drawer-title={title}
+            data-qa-dialog-title={title}
+          >
+            {title}
+          </Typography>
+
+          <Button
+            buttonType="secondary"
+            onClick={props.onClose as (e: any) => void}
+            className={classes.button}
+            data-qa-close-drawer
+            aria-label="Close"
+          >
+            <Close />
+          </Button>
         </div>
         {titleBottomBorder && <hr className={classes.titleBottomBorder} />}
-        <Grid container>
+        <Grid container sx={{ margin: '0 32px 0 32px' }}>
           <div className={className}>
             {error && <Notice text={error} error />}
             {children}

--- a/packages/manager/src/components/Dialog/Dialog.tsx
+++ b/packages/manager/src/components/Dialog/Dialog.tsx
@@ -136,7 +136,7 @@ const Dialog: React.FC<DialogProps> = (props) => {
           </Button>
         </div>
         {titleBottomBorder && <hr className={classes.titleBottomBorder} />}
-        <Grid container sx={{ margin: '0 32px 0 32px' }}>
+        <Grid container sx={{ margin: '0 32px' }}>
           <div className={className}>
             {error && <Notice text={error} error />}
             {children}


### PR DESCRIPTION
## Description 📝

- This PR fixes the Block Device Assignment related form labels bleed through the header background.
- Removes unwanted Grid tags.

**What does this PR do?**

## Preview 📷

**Remove this section or include a screenshot or screen recording of the change**
## Before :

![image](https://user-images.githubusercontent.com/119517080/231178548-3f75c73d-6b77-4807-a8a4-0eb12f406dd1.png)

## After: 
![image](https://user-images.githubusercontent.com/119517080/231178821-7cb7db06-37f6-4072-9807-44c9fe00dbae.png)

**What are the steps to reproduce the issue or verify the changes?**

- Navigate to Linode's page and click on Linode.
- Click on Configurations tab.
- Click on Add Configuration button.
-  Validate Block Device Assignment related form labels. (Content shouldn't overlap the header)

**How do I run relevant unit or e2e tests?**

- yarn test
- yarn cy:run