### PR TITLE
fix: [M3-6298] - Fix breadcrumb story import and missing react import

### DIFF
--- a/packages/manager/src/components/Breadcrumb/Breadcrumb.stories.mdx
+++ b/packages/manager/src/components/Breadcrumb/Breadcrumb.stories.mdx
@@ -1,5 +1,6 @@
+import React from 'react';
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
-import Breadcrumb from 'src/components/Breadcrumb';
+import { Breadcrumb } from './Breadcrumb';
 import UserIcon from 'src/assets/icons/user.svg';
 
 <Meta
@@ -73,7 +74,12 @@ export const EditableBreadcrumbTemplate = (args, context) => {
   <Story name="Default">{BreadcrumbTemplate.bind({})}</Story>
 </Canvas>
 
-<ArgsTable story="Default" sort="requiredFirst" exclude={['className']} sort="requiredFirst"/>
+<ArgsTable
+  story="Default"
+  sort="requiredFirst"
+  exclude={['className']}
+  sort="requiredFirst"
+/>
 
 ### Breadcrumb with Subtitle
 


### PR DESCRIPTION
## Description 📝

Looks like default exports are being deprecated and the `Breadcrumb` Storybook doc import was broken as a result. We were also missing a `React` import for the `EditableBreadcrumbTemplate` `useState` instance.

I think it broke from this [PR](https://github.com/alioso/manager/commit/f40f7b607f42ac59fad7aee4d819afd073b5a368)

## Preview 📷

**Before**
![Screenshot 2023-04-12 at 10 20 42 AM](https://user-images.githubusercontent.com/205353/231487517-2293151d-4a5d-4c5d-ac8b-7f681f4f2d72.jpg)

![Screenshot 2023-04-12 at 10 20 24 AM](https://user-images.githubusercontent.com/205353/231487535-ca1f7a93-59df-47f3-9eae-a1844deca386.jpg)

**After**
![Screenshot 2023-04-12 at 10 20 00 AM](https://user-images.githubusercontent.com/205353/231487677-f8948595-3cce-4fcf-9b89-14ed64741639.jpg)

![Screenshot 2023-04-12 at 10 20 08 AM](https://user-images.githubusercontent.com/205353/231487788-78c576f2-0132-47fe-a88c-2288ca388d12.jpg)


## How to test 🧪

Pull PR locally, run `yarn storybook` and navigate to http://localhost:6006/?path=/docs/components-breadcrumb--docs
