### PR TITLE
refactor: [M3-6397, M3 6416] - MUI v5 Migration - Components > SupportLink, TextTooltip

### DIFF
--- a/packages/manager/src/components/MigrateError.tsx
+++ b/packages/manager/src/components/MigrateError.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import Typography from 'src/components/core/Typography';
-import SupportLink from 'src/components/SupportLink';
+import { SupportLink } from 'src/components/SupportLink';
 
 export const MigrateError: React.FC<{}> = () => {
   return (

--- a/packages/manager/src/components/SupportError.tsx
+++ b/packages/manager/src/components/SupportError.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { APIError } from '@linode/api-v4/lib/types';
 import Typography from 'src/components/core/Typography';
-import SupportLink from 'src/components/SupportLink';
+import { SupportLink } from 'src/components/SupportLink';
 import { useTheme } from '@mui/material/styles';
 
 interface Props {

--- a/packages/manager/src/components/SupportLink/SupportLink.tsx
+++ b/packages/manager/src/components/SupportLink/SupportLink.tsx
@@ -5,7 +5,7 @@ import {
   TicketType,
 } from 'src/features/Support/SupportTickets/SupportTicketDrawer';
 
-interface Props {
+interface SupportLinkProps {
   title?: string;
   description?: string;
   text: string;
@@ -19,7 +19,7 @@ export interface EntityForTicketDetails {
   type: EntityType;
 }
 
-const SupportLink = (props: Props) => {
+const SupportLink = (props: SupportLinkProps) => {
   const { description, text, title, entity, ticketType, onClick } = props;
   return (
     <Link
@@ -40,4 +40,4 @@ const SupportLink = (props: Props) => {
   );
 };
 
-export default SupportLink;
+export { SupportLink };

--- a/packages/manager/src/components/SupportLink/index.tsx
+++ b/packages/manager/src/components/SupportLink/index.tsx
@@ -1,1 +1,1 @@
-export { default } from './SupportLink';
+export { SupportLink } from './SupportLink';

--- a/packages/manager/src/components/TextTooltip/TextTooltip.tsx
+++ b/packages/manager/src/components/TextTooltip/TextTooltip.tsx
@@ -1,17 +1,17 @@
 import { SxProps } from '@mui/material';
 import * as React from 'react';
-import { makeStyles } from '@mui/styles';
+import { makeStyles } from 'tss-react/mui';
 import { Theme } from '@mui/material/styles';
 import ToolTip from 'src/components/core/Tooltip';
 import Typography from 'src/components/core/Typography';
 
-interface Props {
+interface TextTooltipProps {
   displayText: string;
   tooltipText: JSX.Element | string;
   sxTypography?: SxProps;
 }
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles()((theme: Theme) => ({
   root: {
     position: 'relative',
     borderRadius: 4,
@@ -30,8 +30,8 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-export const TextTooltip = (props: Props) => {
-  const classes = useStyles();
+const TextTooltip = (props: TextTooltipProps) => {
+  const { classes } = useStyles();
   const { displayText, tooltipText, sxTypography } = props;
 
   return (
@@ -49,4 +49,4 @@ export const TextTooltip = (props: Props) => {
   );
 };
 
-export default TextTooltip;
+export { TextTooltip };

--- a/packages/manager/src/components/TextTooltip/index.ts
+++ b/packages/manager/src/components/TextTooltip/index.ts
@@ -1,2 +1,1 @@
-import TextTooltip from './TextTooltip';
-export default TextTooltip;
+export { TextTooltip } from './TextTooltip';

--- a/packages/manager/src/components/VerificationError.tsx
+++ b/packages/manager/src/components/VerificationError.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import Typography from 'src/components/core/Typography';
-import SupportLink from 'src/components/SupportLink';
+import { SupportLink } from 'src/components/SupportLink';
 
 interface Props {
   title: string;

--- a/packages/manager/src/features/Account/EnableManaged.tsx
+++ b/packages/manager/src/features/Account/EnableManaged.tsx
@@ -8,7 +8,7 @@ import ConfirmationDialog from 'src/components/ConfirmationDialog';
 import Typography from 'src/components/core/Typography';
 import ExternalLink from 'src/components/ExternalLink';
 import Grid from 'src/components/Grid';
-import SupportLink from 'src/components/SupportLink';
+import { SupportLink } from 'src/components/SupportLink';
 import withLinodes, {
   DispatchProps,
 } from 'src/containers/withLinodes.container';

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -12,7 +12,7 @@ import { Theme } from '@mui/material/styles';
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
 import Typography from 'src/components/core/Typography';
-import TextTooltip from 'src/components/TextTooltip/TextTooltip';
+import { TextTooltip } from 'src/components/TextTooltip';
 import Currency from 'src/components/Currency';
 import DateTimeDisplay from 'src/components/DateTimeDisplay';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentDrawer.tsx
@@ -16,7 +16,7 @@ import Grid from '@mui/material/Unstable_Grid2';
 import { TooltipIcon } from 'src/components/TooltipIcon/TooltipIcon';
 import LinearProgress from 'src/components/LinearProgress';
 import Notice from 'src/components/Notice';
-import SupportLink from 'src/components/SupportLink';
+import { SupportLink } from 'src/components/SupportLink';
 import TextField from 'src/components/TextField';
 import PayPalErrorBoundary from 'src/features/Billing/BillingPanels/PaymentInfoPanel/PayPalErrorBoundary';
 import { useAccount } from 'src/queries/account';

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddDeviceDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Devices/AddDeviceDrawer.tsx
@@ -6,7 +6,7 @@ import Drawer from 'src/components/Drawer';
 import Link from 'src/components/Link';
 import LinodeMultiSelect from 'src/components/LinodeMultiSelect/LinodeMultiSelect';
 import Notice from 'src/components/Notice';
-import SupportLink from 'src/components/SupportLink';
+import { SupportLink } from 'src/components/SupportLink';
 import { useGrants, useProfile } from 'src/queries/profile';
 import { getEntityIdsByPermission } from 'src/utilities/grants';
 import { READ_ONLY_LINODES_HIDDEN_MESSAGE } from '../../FirewallLanding/CreateFirewallDrawer';

--- a/packages/manager/src/features/GlobalNotifications/ComplianceUpdateModal.tsx
+++ b/packages/manager/src/features/GlobalNotifications/ComplianceUpdateModal.tsx
@@ -3,7 +3,7 @@ import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
 import Typography from 'src/components/core/Typography';
-import SupportLink from 'src/components/SupportLink';
+import { SupportLink } from 'src/components/SupportLink';
 import { useMutateAccountAgreements } from 'src/queries/accountAgreements';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import EUAgreementCheckbox from '../Account/Agreements/EUAgreementCheckbox';

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewPlans.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewPlans.tsx
@@ -17,7 +17,7 @@ import TableHead from 'src/components/core/TableHead';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Notice from 'src/components/Notice';
 import Radio from 'src/components/Radio';
-import SupportLink from 'src/components/SupportLink';
+import { SupportLink } from 'src/components/SupportLink';
 import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.tsx
@@ -21,7 +21,7 @@ import { Link } from 'src/components/Link';
 import ModeSelect, { Mode } from 'src/components/ModeSelect';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
-import TextTooltip from 'src/components/TextTooltip';
+import { TextTooltip } from 'src/components/TextTooltip';
 import {
   handleFieldErrors,
   handleGeneralErrors,

--- a/packages/manager/src/features/linodes/MigrateLinode/MigrationImminentNotice.tsx
+++ b/packages/manager/src/features/linodes/MigrateLinode/MigrationImminentNotice.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { compose } from 'recompose';
 
 import Notice from 'src/components/Notice';
-import SupportLink from 'src/components/SupportLink';
+import { SupportLink } from 'src/components/SupportLink';
 
 interface Props {
   notifications: Notification[];

--- a/packages/manager/src/features/linodes/SMTPRestrictionText.tsx
+++ b/packages/manager/src/features/linodes/SMTPRestrictionText.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Typography from 'src/components/core/Typography';
 import ExternalLink from 'src/components/ExternalLink';
-import SupportLink from 'src/components/SupportLink';
+import { SupportLink } from 'src/components/SupportLink';
 import { MAGIC_DATE_THAT_EMAIL_RESTRICTIONS_WERE_IMPLEMENTED } from 'src/constants';
 import { useAccount } from 'src/queries/account';
 import { sendLinodeCreateDocsEvent } from 'src/utilities/ga';


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
- Runs the codemod on `TextTooltip.tsx`
- No changes from the codemod on `SupportLink.tsx`
- Minor refactoring to use named exports and better interface name for props

## Preview 📷

Example TextTooltip:
![Screenshot 2023-04-12 at 11 30 25 AM](https://user-images.githubusercontent.com/114685994/231552880-4bb02712-935b-478b-8196-527bb6068a9d.jpg)

Example SupportLink:
![Screenshot 2023-04-12 at 11 33 06 AM](https://user-images.githubusercontent.com/114685994/231552904-d6f8798e-23c1-4760-955c-2fef0d1bba6d.jpg)


## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**
Check areas of the app where the SupportLink and TextTooltip exist to check that there are no styling regressions. 

SupportLink:
- Check Linode Details > SMTP warning notice > "open a support ticket" or other places (generally notices/error messages) where we're linking to Support

TextTooltip:
- Check the Linode Details > Storage > Resize > "Check disk usage" tooltip
