### PR TITLE
fix: [M3-6472] - [Marketplace] One Click Cluster - UDF Caching issue

### DIFF
--- a/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedSelect.test.tsx
+++ b/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedSelect.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+import UserDefinedSelect from './UserDefinedSelect';
+
+describe('UserDefinedSelect', () => {
+  it('renders select when oneof has more than 4 options', () => {
+    const field = {
+      name: 'selectField',
+      label: 'Select Field',
+      oneof: 'option1,option2,option3,option4,option5',
+    };
+    const { getByLabelText, getByText } = renderWithTheme(
+      <UserDefinedSelect
+        field={field}
+        value=""
+        updateFormState={() => {}}
+        classes={{} as any}
+        isOptional={false}
+      />
+    );
+
+    const selectField = getByLabelText('Select Field');
+    fireEvent.change(selectField, { target: { value: 'option3' } });
+
+    expect(getByText('option3')).toBeInTheDocument();
+  });
+
+  it('renders radio when oneof has 4 or fewer options', () => {
+    const field = {
+      name: 'radioField',
+      label: 'Radio Field',
+      oneof: 'option1,option2,option3,option4',
+    };
+    const updateFormState = jest.fn();
+    const { getAllByRole } = renderWithTheme(
+      <UserDefinedSelect
+        field={field}
+        value=""
+        updateFormState={updateFormState}
+        classes={{} as any}
+        isOptional={false}
+      />
+    );
+
+    const radioElements = getAllByRole('radio');
+
+    expect(radioElements.length).toEqual(4);
+  });
+
+  it('calls updateFormState when a new option is selected', () => {
+    const field = {
+      name: 'selectField',
+      label: 'Select Field',
+      oneof: 'option1,option2,option3,option4',
+    };
+    const updateFormState = jest.fn();
+    const { getAllByRole } = renderWithTheme(
+      <UserDefinedSelect
+        field={field}
+        value=""
+        updateFormState={updateFormState}
+        classes={{} as any}
+        isOptional={false}
+      />
+    );
+
+    const radioElements = getAllByRole('radio');
+
+    fireEvent.click(radioElements[2]);
+
+    expect(updateFormState).toHaveBeenCalledWith('selectField', 'option3');
+  });
+});

--- a/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedSelect.tsx
+++ b/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedSelect.tsx
@@ -7,7 +7,6 @@ import { Theme } from '@mui/material/styles';
 import MenuItem from 'src/components/MenuItem';
 import Notice from 'src/components/Notice';
 import Radio from 'src/components/Radio';
-import RenderGuard from 'src/components/RenderGuard';
 import TextField from 'src/components/TextField';
 
 type ClassNames = 'root' | 'radioGroupLabel';
@@ -34,88 +33,73 @@ interface Props {
   error?: string;
 }
 
-interface State {
-  oneof: string[];
-  selectedOption: string;
-}
-
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-class UserDefinedSelect extends React.Component<CombinedProps, State> {
-  state: State = {
-    oneof: this.props.field.oneof!.split(','),
-    selectedOption: '',
+const UserDefinedSelect = (props: CombinedProps) => {
+  const { field, value, error, classes, isOptional, updateFormState } = props;
+
+  const [oneof, setOneof] = React.useState<string[]>(field.oneof!.split(','));
+
+  React.useEffect(() => {
+    setOneof(field.oneof!.split(','));
+  }, [field.oneof]);
+
+  const handleSelectOneOf = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selectedValue = e.target.value;
+    updateFormState(field.name, selectedValue);
   };
 
-  handleSelectOneOf = (e: any) => {
-    const { updateFormState, field } = this.props;
-    updateFormState(field.name, e.target.value);
-  };
-
-  render() {
-    const { oneof } = this.state;
-    const { value, error, field, classes, isOptional } = this.props;
-
-    /* Display a select if there are more than 2 oneof options, otherwise display as radio. */
-    if (oneof.length > 4) {
-      return (
-        <div>
-          {error && <Notice error text={error} spacingTop={8} />}
-          <TextField
-            label={field.label}
-            onChange={this.handleSelectOneOf}
-            value={value}
-            select
-          >
-            {oneof.map((choice: string, index) => {
-              return (
-                <MenuItem value={choice} key={index}>
-                  {choice}
-                </MenuItem>
-              );
-            })}
-          </TextField>
-        </div>
-      );
-    } else {
-      return (
-        <div className={classes.root}>
-          {error && <Notice error text={error} spacingTop={8} />}
-          <InputLabel className={classes.radioGroupLabel}>
-            {field.label}
-            {!isOptional && '*'}
-          </InputLabel>
-
+  if (oneof.length > 4) {
+    return (
+      <div>
+        {error && <Notice error text={error} spacingTop={8} />}
+        <TextField
+          label={field.label}
+          onChange={handleSelectOneOf}
+          value={value}
+          select
+        >
           {oneof.map((choice: string, index) => {
             return (
-              <React.Fragment key={index}>
-                <FormControlLabel
-                  value={choice}
-                  control={
-                    <Radio
-                      name={choice}
-                      checked={!!value && value === choice}
-                      /*
-                      NOTE: Although the API returns a default value and we're auto selecting
-                      a value for the user, it is not necessary to store this value
-                      in the state because it's not necessary for the POST request, since
-                      the backend will automatically POST with that default value
-                    */
-                      onChange={this.handleSelectOneOf}
-                      data-qa-perm-none-radio
-                    />
-                  }
-                  label={choice}
-                />
-              </React.Fragment>
+              <MenuItem value={choice} key={index}>
+                {choice}
+              </MenuItem>
             );
           })}
-        </div>
-      );
-    }
+        </TextField>
+      </div>
+    );
   }
-}
+  return (
+    <div className={classes.root}>
+      {error && <Notice error text={error} spacingTop={8} />}
+      <InputLabel className={classes.radioGroupLabel}>
+        {field.label}
+        {!isOptional && '*'}
+      </InputLabel>
+
+      {oneof.map((choice: string, index) => {
+        return (
+          <React.Fragment key={index}>
+            <FormControlLabel
+              value={choice}
+              control={
+                <Radio
+                  name={choice}
+                  checked={!!value && value === choice}
+                  onChange={handleSelectOneOf}
+                  data-qa-perm-none-radio
+                />
+              }
+              label={choice}
+            />
+          </React.Fragment>
+        );
+      })}
+    </div>
+  );
+};
 
 const styled = withStyles(styles);
 
-export default styled(RenderGuard<CombinedProps>(UserDefinedSelect));
+export default styled(UserDefinedSelect);

--- a/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
+++ b/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
@@ -107,7 +107,6 @@ const renderField = (
           field={field}
           updateFormState={handleChange}
           value={udf_data[field.name] || ''}
-          updateFor={[field.label, udf_data[field.name], error]}
           isOptional={isOptional}
           key={field.name}
           error={error}


### PR DESCRIPTION
## Description 📝

- Fixes UDF caching issue for OCA apps.
- Refactor UserDefinedSelect component to functional
- Unit test coverage for UserDefinedSelect

## Preview 📷

**Remove this section or include a screenshot or screen recording of the change**

## How to test 🧪

**What are the steps to reproduce the issue or verify the changes?**

- Navigate to marketplace 
- Switch OCA apps to check UDF fields (switch between mango cluster and Redis)
- Validate respective UDFs are rendering. (Checkout screen capture attached in the ticket)

**How do I run relevant unit or e2e tests?**

- yarn test
- yarn cy:run