### PR TITLE
fix: [M3-6312] - Clear Kubernetes Delete Dialog when it is reopened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed:
+- Clear the Kubernetes Delete Dialog when it is opened [#9000](https://github.com/linode/manager/pull/9000)
+
 ## [2023-04-03] - v1.90.0
 
 ### Added:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [Unreleased]
 
 ### Fixed:
-- Clear the Kubernetes Delete Dialog when it is opened [#9000](https://github.com/linode/manager/pull/9000)
+- Clear the Kubernetes Delete Dialog when it is opened #9000
 
 ## [2023-04-03] - v1.90.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [Unreleased]
 
 ### Fixed:
-- Clear the Kubernetes Delete Dialog when it is opened #9000
+- Clear the Kubernetes Delete Dialog when it is re-opened #9000
 
 ## [2023-04-03] - v1.90.0
 

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/DeleteKubernetesClusterDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/DeleteKubernetesClusterDialog.tsx
@@ -41,6 +41,7 @@ export const DeleteKubernetesClusterDialog = (props: Props) => {
   const onDelete = () => {
     deleteCluster({ id: clusterId }).then(() => {
       onClose();
+      setConfirmText('');
       history.replace('/kubernetes/clusters');
     });
   };

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/DeleteKubernetesClusterDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/DeleteKubernetesClusterDialog.tsx
@@ -38,10 +38,15 @@ export const DeleteKubernetesClusterDialog = (props: Props) => {
   const disabled =
     preferences?.type_to_confirm !== false && confirmText !== clusterLabel;
 
+  React.useEffect(() => {
+    if (open && confirmText !== '') {
+      setConfirmText('');
+    }
+  }, [open]);
+
   const onDelete = () => {
     deleteCluster({ id: clusterId }).then(() => {
       onClose();
-      setConfirmText('');
       history.replace('/kubernetes/clusters');
     });
   };


### PR DESCRIPTION
## Description 📝

- Clears the Kubernetes Delete Dialog onSuccess so that the dialog input is empty the next time it is opened
- Thank you @jdamore-linode for finding this

## Before 😖

https://user-images.githubusercontent.com/115251059/231811670-8b38f5b3-5d94-4511-b605-1af5ac88c3ca.mov

## After 🎉

https://user-images.githubusercontent.com/115251059/231811550-71d2dd08-6f8e-4962-965e-81bb14d509ca.mov

## How to test 🧪

- Make sure the Kubernetes Delete Dialog clears when reopening it