### PR TITLE
fix: [M3-6430] - Event entities should only be linked for true labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Fixed:
 - Typesafety of the `<Select />` component #8986
 - Clear the Kubernetes Delete Dialog when it is re-opened #9000
+- Event entities should only be linked for true labels
 
 ### Tech Stories:
 - MUIv5 Migration - Components > TagsInput, TagsPanel #8995

--- a/packages/manager/src/eventMessageGenerator.test.ts
+++ b/packages/manager/src/eventMessageGenerator.test.ts
@@ -90,48 +90,38 @@ describe('Event message generation', () => {
   });
 
   describe('apply linking to labels', () => {
+    const entity = entityFactory.build({ id: 10, label: 'foo' });
+
     it('should return empty string if message is falsy', () => {
-      const mockEvent = {
-        action: 'create',
-        entity: null,
-        secondary_entity: null,
-      };
+      const mockEvent = eventFactory.build({ action: 'domain_record_create' });
       const message = null;
-      const result = applyLinking(mockEvent as Event, message as any);
+      const result = applyLinking(mockEvent, message as any); // casting since message is a required prop
 
       expect(result).toEqual('');
     });
 
-    it('should replace entity label with link if entity and link exist', () => {
-      const entity = { id: '123', label: 'foo', type: 'linode' };
-      const mockEvent = { action: 'create', entity, secondary_entity: null };
+    it('should replace entity label with link if entity and link exist', async () => {
+      const mockEvent = eventFactory.build({ entity });
       const message = 'created entity foo';
-      const link = '/linodes/123';
-      const result = applyLinking(mockEvent as any, message);
+      const result = applyLinking(mockEvent, message);
 
-      expect(result).toEqual(`created entity <a href="${link}">foo</a> `);
+      expect(result).toEqual(`created entity <a href="/linodes/10">foo</a> `);
     });
 
     it('should replace secondary entity label with link if entity and link exist', () => {
-      jest.clearAllMocks();
-
-      const entity = { id: '123', label: 'foo', type: 'linode' };
-      const secondary_entity = { id: '456', label: 'bar' };
-      const mockEvent = { action: 'create', entity, secondary_entity };
+      const mockEvent = eventFactory.build({ entity });
       const message = 'created secondary_entity for foo';
-      const link = '/linodes/123';
-      const result = applyLinking(mockEvent as any, message);
+      const result = applyLinking(mockEvent, message);
 
       expect(result).toEqual(
-        `created secondary_entity for <a href="${link}">foo</a> `
+        `created secondary_entity for <a href="/linodes/10">foo</a> `
       );
     });
 
     it('should not replace entity label if label is inside backticks', () => {
-      const entity = { id: '123', label: 'foo' };
-      const mockEvent = { action: 'create', entity, secondary_entity: null };
+      const mockEvent = eventFactory.build({ entity });
       const message = 'created `foo`';
-      const result = applyLinking(mockEvent as any, message);
+      const result = applyLinking(mockEvent, message);
 
       expect(result).toEqual('created `foo`');
     });

--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -846,7 +846,7 @@ function applyBolding(event: Event, message: string) {
   return newMessage;
 }
 
-function applyLinking(event: Event, message: string) {
+export function applyLinking(event: Event, message: string) {
   if (!message) {
     return '';
   }
@@ -857,14 +857,19 @@ function applyLinking(event: Event, message: string) {
     event.secondary_entity,
     false
   );
+
   let newMessage = message;
 
   if (event.entity && entityLinkTarget) {
+    const label = event.entity.label;
+    const nonTickedLabels = new RegExp(`(?<!\`)${label}`, 'g');
+
     newMessage = newMessage.replace(
-      event.entity.label,
-      `<a href="${entityLinkTarget}">${event.entity.label}</a>`
+      nonTickedLabels,
+      `<a href="${entityLinkTarget}">${label}</a> `
     );
   }
+
   if (event.secondary_entity && secondaryEntityLinkTarget) {
     newMessage = newMessage.replace(
       event.secondary_entity.label,


### PR DESCRIPTION
## Description 📝

**Issue**
Our `applyLinking` script was attempting to replace entity labels within backticks, resulting in plaintext HTML in our event list. It was also not linking the true entity because the replace instance wasn't using a global modifier in case two instances of the label were matching.

**Solution**
Modified the replace to only target true labels and leave alone strings surrounded by backticks. Also added a test for the `applyLinking` function

## Preview 📷

**Before**
![Screenshot 2023-04-14 at 2 27 36 PM](https://user-images.githubusercontent.com/130582365/232127281-6084057c-1857-4cf1-a385-499131b5903a.jpg)

**After**
![Screenshot 2023-04-14 at 2 27 23 PM](https://user-images.githubusercontent.com/130582365/232127316-ec2a4bea-acf4-4810-b3a8-361936e091d8.jpg)


## How to test 🧪

1. add a new domain
2. add a new ttl record with a different name
3. add a new ttl record with same name as domain
4. navigate to /events
