### PR TITLE
fix: [M3-6442] - Inefficient firewall custom ports regex

### DIFF
--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.test.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.test.tsx
@@ -119,6 +119,10 @@ describe('utilities', () => {
         'ports',
         'Ports must be an integer, range of integers, or a comma-separated list of integers.'
       );
+      expect(validateForm('TCP', '1-2,3-4')).toHaveProperty(
+        'ports',
+        'Ports must be an integer, range of integers, or a comma-separated list of integers.'
+      );
       expect(validateForm('TCP', '-20')).toHaveProperty(
         'ports',
         'Ports must be an integer, range of integers, or a comma-separated list of integers.'

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.test.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.test.tsx
@@ -110,6 +110,20 @@ describe('utilities', () => {
       );
       expect(validateForm('TCP', 'invalid-port')).toHaveProperty('ports');
     });
+    it('validates custom ports', () => {
+      expect(validateForm('TCP', 'abc')).toHaveProperty(
+        'ports',
+        'Ports must be an integer, range of integers, or a comma-separated list of integers.'
+      );
+      expect(validateForm('TCP', '1--20')).toHaveProperty(
+        'ports',
+        'Ports must be an integer, range of integers, or a comma-separated list of integers.'
+      );
+      expect(validateForm('TCP', '-20')).toHaveProperty(
+        'ports',
+        'Ports must be an integer, range of integers, or a comma-separated list of integers.'
+      );
+    });
     it('validates label', () => {
       const expectedResults = [
         {

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.test.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.test.tsx
@@ -111,6 +111,10 @@ describe('utilities', () => {
       expect(validateForm('TCP', 'invalid-port')).toHaveProperty('ports');
     });
     it('validates custom ports', () => {
+      expect(validateForm('TCP', '1')).toEqual({});
+      expect(validateForm('TCP', '1,2,3,4,5')).toEqual({});
+      expect(validateForm('TCP', '1, 2, 3, 4, 5')).toEqual({});
+      expect(validateForm('TCP', '1-20')).toEqual({});
       expect(validateForm('TCP', 'abc')).toHaveProperty(
         'ports',
         'Ports must be an integer, range of integers, or a comma-separated list of integers.'

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
@@ -853,7 +853,7 @@ export const validateForm = (
 
   if ((protocol === 'ICMP' || protocol === 'IPENCAP') && ports) {
     errors.ports = `Ports are not allowed for ${protocol} protocols.`;
-  } else if (ports && !ports.match(/^([0-9\-]+,?\s?)+$/)) {
+  } else if (ports && !ports.match(/^(?:\d+|\d+-\d+)(?:,\d+|\,\d+-\d+)*$/)) {
     errors.ports =
       'Ports must be an integer, range of integers, or a comma-separated list of integers.';
   }

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
@@ -3,6 +3,10 @@ import {
   FirewallRuleProtocol,
   FirewallRuleType,
 } from '@linode/api-v4/lib/firewalls';
+import {
+  CUSTOM_PORTS_VALIDATION_REGEX,
+  CUSTOM_PORTS_ERROR_MESSAGE,
+} from '@linode/validation';
 import { Formik, FormikProps } from 'formik';
 import { parse as parseIP, parseCIDR } from 'ipaddr.js';
 import { uniq } from 'ramda';
@@ -853,9 +857,8 @@ export const validateForm = (
 
   if ((protocol === 'ICMP' || protocol === 'IPENCAP') && ports) {
     errors.ports = `Ports are not allowed for ${protocol} protocols.`;
-  } else if (ports && !ports.match(/^(?:\d+|\d+-\d+)(?:,\d+|\,\d+-\d+)*$/)) {
-    errors.ports =
-      'Ports must be an integer, range of integers, or a comma-separated list of integers.';
+  } else if (ports && !ports.match(CUSTOM_PORTS_VALIDATION_REGEX)) {
+    errors.ports = CUSTOM_PORTS_ERROR_MESSAGE;
   }
 
   return errors;

--- a/packages/validation/src/firewalls.schema.ts
+++ b/packages/validation/src/firewalls.schema.ts
@@ -7,7 +7,7 @@ export const IP_ERROR_MESSAGE =
   'Must be a valid IPv4 or IPv6 address or range.';
 export const CUSTOM_PORTS_ERROR_MESSAGE =
   'Ports must be an integer, range of integers, or a comma-separated list of integers.';
-export const CUSTOM_PORTS_VALIDATION_REGEX = /^(?:\d+|\d+-\d+)(?:,\d+|\,\d+-\d+)*$/;
+export const CUSTOM_PORTS_VALIDATION_REGEX = /^(?:\d+|\d+-\d+|(?:\d+,)*\d+)$/;
 
 export const validateIP = (ipAddress?: string | null): boolean => {
   if (!ipAddress) {

--- a/packages/validation/src/firewalls.schema.ts
+++ b/packages/validation/src/firewalls.schema.ts
@@ -40,7 +40,7 @@ export const ipAddress = string().test({
 });
 
 export const validateFirewallPorts = string().matches(
-  /^([0-9\-]+,?\s?)+$/,
+  /^(?:\d+|\d+-\d+)(?:,\d+|\,\d+-\d+)*$/,
   'Ports must be an integer, range of integers, or a comma-separated list of integers.'
 );
 

--- a/packages/validation/src/firewalls.schema.ts
+++ b/packages/validation/src/firewalls.schema.ts
@@ -7,7 +7,7 @@ export const IP_ERROR_MESSAGE =
   'Must be a valid IPv4 or IPv6 address or range.';
 export const CUSTOM_PORTS_ERROR_MESSAGE =
   'Ports must be an integer, range of integers, or a comma-separated list of integers.';
-export const CUSTOM_PORTS_VALIDATION_REGEX = /^(?:\d+|\d+-\d+|(?:\d+,)*\d+)$/;
+export const CUSTOM_PORTS_VALIDATION_REGEX = /^(?:\d+|\d+-\d+|(?:\d+,\s*)*\d+)$/;
 
 export const validateIP = (ipAddress?: string | null): boolean => {
   if (!ipAddress) {

--- a/packages/validation/src/firewalls.schema.ts
+++ b/packages/validation/src/firewalls.schema.ts
@@ -5,6 +5,9 @@ import { array, mixed, number, object, string } from 'yup';
 
 export const IP_ERROR_MESSAGE =
   'Must be a valid IPv4 or IPv6 address or range.';
+export const CUSTOM_PORTS_ERROR_MESSAGE =
+  'Ports must be an integer, range of integers, or a comma-separated list of integers.';
+export const CUSTOM_PORTS_VALIDATION_REGEX = /^(?:\d+|\d+-\d+)(?:,\d+|\,\d+-\d+)*$/;
 
 export const validateIP = (ipAddress?: string | null): boolean => {
   if (!ipAddress) {
@@ -40,8 +43,8 @@ export const ipAddress = string().test({
 });
 
 export const validateFirewallPorts = string().matches(
-  /^(?:\d+|\d+-\d+)(?:,\d+|\,\d+-\d+)*$/,
-  'Ports must be an integer, range of integers, or a comma-separated list of integers.'
+  CUSTOM_PORTS_VALIDATION_REGEX,
+  CUSTOM_PORTS_ERROR_MESSAGE
 );
 
 const validFirewallRuleProtocol = ['ALL', 'TCP', 'UDP', 'ICMP', 'IPENCAP'];


### PR DESCRIPTION
## Description 📝

Fix a [codeQL inefficient regex warning](https://github.com/linode/manager/security/code-scanning/25) for firewall custom ports (exponential backtracking on strings containing many repetitions of '-') in the firewall rule drawer.

I increased the regex matching specificity to only match:
`42`
`1-10`
`1,2,3,4,5`

and disallow things like:
`1--10`
`1-2-3`
`1,2,3-4-5`
`1-2,3-4`

along with extra spaces etc

## Preview 📷
![Screenshot 2023-04-17 at 1 54 39 PM](https://user-images.githubusercontent.com/130582365/232570719-fbabc2b6-d0cb-463a-a6c2-5814c76fe031.jpg)

## How to test 🧪

- pull code locally, and add some rules at `/firewalls/[id]/rules`
- `yarn test FirewallRuleDrawer`
or
- test regex at https://regex101.com/ or other online tool
