### PR TITLE
fix: `README.md` Validation Version Badge Label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Fixed:
 - Typesafety of the `<Select />` component #8986
 - Clear the Kubernetes Delete Dialog when it is re-opened #9000
+- @linode/validation version badge Label in `README.md`
 
 ### Tech Stories:
 - MUIv5 Migration - Components > TagsInput, TagsPanel #8995

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
     <img alt="api-v4 bundle size" src="https://img.shields.io/bundlephobia/min/@linode/api-v4?label=api-v4 size">
   </a>
   <a href="https://www.npmjs.com/package/@linode/validation">
-    <img src="https://img.shields.io/npm/v/@linode/validation?label=%40linode%2Fapi-v4" alt="@linode/validation version" />
+    <img src="https://img.shields.io/npm/v/@linode/validation?label=%40linode%2Fvalidation" alt="@linode/validation version" />
   </a>
   <a href="https://bundlephobia.com/package/@linode/validation">
     <img alt="validation bundle size" src="https://img.shields.io/bundlephobia/min/@linode/validation?label=validation size">


### PR DESCRIPTION
## Description 📝

- The badge for the validation said api-v4 on accident. This updates the badge to show the correct label

## Preview 📷

## Before
![Screenshot 2023-04-17 at 3 00 43 PM](https://user-images.githubusercontent.com/115251059/232585522-b185c458-03f0-4227-8a67-e3f2f6dfe52d.jpg)

## After
![Screenshot 2023-04-17 at 3 03 16 PM](https://user-images.githubusercontent.com/115251059/232585732-f5950705-9d29-4dbd-ace5-c01d68882397.jpg)


## How to test 🧪

- Use Github's view feature to see the `README.md`