### PR TITLE
feat: [M3-6502] - Add Premium plans to LKE

### DIFF
--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
@@ -128,6 +128,9 @@ const getDedicated = (types: ExtendedType[]) =>
 const getGPU = (types: ExtendedType[]) =>
   types.filter((t) => /gpu/.test(t.class));
 
+const getPremium = (types: ExtendedType[]) =>
+  types.filter((t) => /premium/.test(t.class));
+
 export class SelectPlanPanel extends React.Component<
   Props & WithStyles<ClassNames>
 > {
@@ -286,6 +289,7 @@ export class SelectPlanPanel extends React.Component<
     const highmem = getHighMem(types);
     const dedicated = getDedicated(types);
     const gpu = getGPU(types);
+    const premium = getPremium(types);
 
     const tabOrder: LinodeTypeClass[] = [];
 
@@ -371,6 +375,29 @@ export class SelectPlanPanel extends React.Component<
         title: 'GPU',
       });
       tabOrder.push('gpu');
+    }
+
+    if (!isEmpty(premium)) {
+      tabs.push({
+        render: () => {
+          return (
+            <>
+              <Notice warning>
+                {' '}
+                This plan is only available in the Washington, DC region.
+              </Notice>
+              <Typography data-qa-gpu className={classes.copy}>
+                Premium CPU instances guarantee a minimum processor model, AMD
+                Epyc<sup>TM</sup> 7713 or higher, to ensure consistent high
+                performance for more demanding workloads.
+              </Typography>
+              {this.renderPlanContainer(premium)}
+            </>
+          );
+        },
+        title: 'Premium',
+      });
+      tabOrder.push('premium');
     }
 
     return [tabs, tabOrder];


### PR DESCRIPTION
## Description 📝
- Adds Premium plans tab to LKE

## Preview 📷
![image](https://user-images.githubusercontent.com/119517080/232837588-98d694be-8cd0-4836-bdef-6ed73e84c3d7.png)


## How to test 🧪

- Navigate to http://localhost:3000/kubernetes/create
- Validate the premium plans tab.

**How do I run relevant unit or e2e tests?**
- yarn test
- yarn cy:run