### PR TITLE
fix: [M3-5976] - Prevent IP transfer & sharing modals form submission if no action selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - @linode/validation version badge Label in `README.md` #9011
 - Event entities should only be linked for true labels
 - Radio button hover effect #9031
+- Prevent form submission unless action was taken (IP transfer & IP sharing modals) #5976
 
 ### Tech Stories:
 - MUIv5 Migration - Components > TagsInput, TagsPanel #8995

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/IPSharing.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/IPSharing.tsx
@@ -26,6 +26,7 @@ import useFlags from 'src/hooks/useFlags';
 import { API_MAX_PAGE_SIZE } from 'src/constants';
 import { useAllLinodesQuery } from 'src/queries/linodes';
 import { getAPIErrorOrDefault, getErrorMap } from 'src/utilities/errorUtils';
+import { areArraysEqual } from 'src/utilities/areArraysEqual';
 
 const useStyles = makeStyles((theme: Theme) => ({
   addNewButton: {
@@ -234,6 +235,14 @@ const IPSharingPanel: React.FC<CombinedProps> = (props) => {
     setSubmitting(localSubmitting);
     setSuccessMessage(undefined);
 
+    // if the user hasn't selected any IP to share or hasn't removed any, don't do anything
+    if (areArraysEqual(linodeSharedIPs, ipsToShare)) {
+      setErrors([{ reason: 'Please select an action.' }]);
+      setSubmitting(false);
+
+      return;
+    }
+
     const share = flags.ipv6Sharing ? shareAddresses : shareAddressesv4;
     const promises: Promise<void | {}>[] = [];
 
@@ -376,30 +385,28 @@ const IPSharingPanel: React.FC<CombinedProps> = (props) => {
                 </React.Fragment>
               )}
             </Grid>
-            <Grid container justifyContent="flex-end" className="m0">
-              <ActionsPanel>
-                <Button
-                  buttonType="secondary"
-                  disabled={submitting || noChoices}
-                  onClick={onReset}
-                  data-qa-reset
-                >
-                  Reset Form
-                </Button>
-                <Button
-                  buttonType="primary"
-                  disabled={readOnly || noChoices}
-                  loading={submitting}
-                  onClick={onSubmit}
-                  data-qa-submit
-                >
-                  Save
-                </Button>
-              </ActionsPanel>
-            </Grid>
           </Grid>
         </>
       </DialogContent>
+      <ActionsPanel>
+        <Button
+          buttonType="secondary"
+          disabled={submitting || noChoices}
+          onClick={onReset}
+          data-qa-reset
+        >
+          Reset Form
+        </Button>
+        <Button
+          buttonType="primary"
+          disabled={readOnly || noChoices}
+          loading={submitting}
+          onClick={onSubmit}
+          data-qa-submit
+        >
+          Save
+        </Button>
+      </ActionsPanel>
     </Dialog>
   );
 };
@@ -444,7 +451,7 @@ export const IPRow: React.FC<RowProps> = React.memo((props) => {
   const { ip } = props;
   const classes = useStyles();
   return (
-    <Grid container key={ip}>
+    <Grid container key={ip} spacing={2}>
       <Grid xs={12}>
         <Divider spacingBottom={0} />
       </Grid>
@@ -495,7 +502,7 @@ export const IPSharingRow: React.FC<SharingRowProps> = React.memo((props) => {
   });
 
   return (
-    <Grid container key={idx}>
+    <Grid container key={idx} spacing={2}>
       <Grid xs={12}>
         <Divider spacingBottom={0} />
       </Grid>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/IPTransfer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/IPTransfer.tsx
@@ -161,9 +161,7 @@ const LinodeNetworkingIPTransferPanel: React.FC<CombinedProps> = (props) => {
       {}
     )
   );
-  const [error, setError] = React.useState<APIError[] | undefined | string>(
-    undefined
-  );
+  const [error, setError] = React.useState<APIError[] | undefined>(undefined);
   const [successMessage, setSuccessMessage] = React.useState('');
   const [submitting, setSubmitting] = React.useState(false);
   const [searchText, setSearchText] = React.useState('');
@@ -448,7 +446,7 @@ const LinodeNetworkingIPTransferPanel: React.FC<CombinedProps> = (props) => {
       (ip) => ip.mode !== 'none'
     );
     if (noActionSelected) {
-      setError('Please select an action.');
+      setError([{ reason: 'Please select an action.' }]);
       setSubmitting(false);
 
       return;
@@ -505,13 +503,9 @@ const LinodeNetworkingIPTransferPanel: React.FC<CombinedProps> = (props) => {
     <Dialog title="IP Transfer" open={open} onClose={onClose}>
       {error && (
         <Grid xs={12}>
-          {typeof error === 'string' ? (
-            <Notice error text={error} />
-          ) : (
-            error.map(({ reason }, idx) => (
-              <Notice key={idx} error text={reason} />
-            ))
-          )}
+          {error.map(({ reason }, idx) => (
+            <Notice key={idx} error text={reason} />
+          ))}
         </Grid>
       )}
       {successMessage && (

--- a/packages/manager/src/utilities/areArraysEqual.test.ts
+++ b/packages/manager/src/utilities/areArraysEqual.test.ts
@@ -1,0 +1,44 @@
+import { areArraysEqual } from './areArraysEqual';
+
+describe('compare arrays', () => {
+  const array1: string[] = ['104.237.150.6', '192.168.216.240'];
+
+  it('should return `true` if the given arrays are the same.', () => {
+    const array2: string[] = ['104.237.150.6', '192.168.216.240'];
+    const result = areArraysEqual(array1, array2);
+
+    expect(result).toBe(true);
+  });
+
+  it('should return `false` if the given arrays contain different data types', () => {
+    const array2: (string | number)[] = [10, 2];
+    const result = areArraysEqual(array1, array2);
+
+    expect(result).toBe(false);
+  });
+
+  it('should return `false` if the given arrays have the same elements in different order.', () => {
+    const array2: string[] = ['192.168.216.240', '104.237.150.6'];
+    const result = areArraysEqual(array1, array2);
+
+    expect(result).toBe(false);
+  });
+
+  it('should return `false` if the given arrays have different values', () => {
+    const array3: string[] = ['104.237.150.6', '192.168.216.241'];
+    const result = areArraysEqual(array1, array3);
+
+    expect(result).toBe(false);
+  });
+
+  it('should return `false` if the given arrays have different sizes', () => {
+    const array4: string[] = [
+      '104.237.150.6',
+      '192.168.216.240',
+      '143.42.184.169',
+    ];
+    const result = areArraysEqual(array1, array4);
+
+    expect(result).toBe(false);
+  });
+});

--- a/packages/manager/src/utilities/areArraysEqual.ts
+++ b/packages/manager/src/utilities/areArraysEqual.ts
@@ -1,0 +1,16 @@
+/**
+ * Specify props to compare string arrays.
+ * Note: This function is not recursive and will only be true if arrays are sorted equally.
+ * The reason is that this function is intended to do the bare minimum for the sake of performance and its current use cases.
+ *
+ * @param array1
+ * @param array2
+ *
+ * @returns boolean
+ */
+export const areArraysEqual = <T>(array1: T[], array2: T[]): boolean => {
+  return (
+    array1.length === array2.length &&
+    array1.every((v: T, i: number) => v === array2[i])
+  );
+};

--- a/packages/manager/src/utilities/areArraysEqual.ts
+++ b/packages/manager/src/utilities/areArraysEqual.ts
@@ -1,7 +1,7 @@
 /**
- * Specify props to compare string arrays.
+ * Specify props to compare arrays.
  * Note: This function is not recursive and will only be true if arrays are sorted equally.
- * The reason is that this function is intended to do the bare minimum for the sake of performance and its current use cases.
+ * The reason is that this function is intended to do the bare minimum for the sake of performance and its current use case(s).
  *
  * @param array1
  * @param array2


### PR DESCRIPTION
## Description 📝

When the IP Transfer dialog is opened, a user can click "Save" without having selected any action. Clicking the button displays a message that says "IP transferred successfully" even though no action was taken.

This is confusing since it may lead users to believe that they've successfully transferred an IP from one Linode to another without having done so.

This PR adds a simple check to the onSubmit to see if any action has been selected for a linode. If not, it displays an error to the user. It also does so for the IP sharing modal.

This PR also:
- Resets the error messages on modal open
- Fixes a styling regression from https://github.com/linode/manager/pull/8985/files

## Preview 📷

![Screenshot 2023-04-18 at 4 50 14 PM](https://user-images.githubusercontent.com/130582365/232901994-80cd9a9b-bbf8-4b28-b766-46ea89f29f47.jpg)

## How to test 🧪

- If necessary, create a Linode
- Navigate to its details page, click on the "Network" tab
- Click the "IP Transfer" button
- In the dialog, click "Save" without having selected an action (or any action if multiple linodes)
- Observe the new error message
- Repeat with IP sharing modal
