### PR TITLE
refactor: Clean up Linode rescue tests, work around flake caused by action menu interactions

### DIFF
--- a/packages/manager/cypress/e2e/linodes/rescue-linode.spec.ts
+++ b/packages/manager/cypress/e2e/linodes/rescue-linode.spec.ts
@@ -1,60 +1,120 @@
-import { createLinode } from 'support/api/linodes';
-import { fbtClick, fbtVisible } from 'support/helpers';
+import { createLinode, Linode } from '@linode/api-v4';
+import { createLinodeRequestFactory } from '@src/factories';
+import { authenticate } from 'support/api/authentication';
+import { regions } from 'support/constants/regions';
+import {
+  interceptGetLinodeDetails,
+  interceptRebootLinodeIntoRescueMode,
+} from 'support/intercepts/linodes';
 import { ui } from 'support/ui';
-import { apiMatcher } from 'support/util/intercepts';
+import { SimpleBackoffMethod } from 'support/util/backoff';
+import { pollLinodeStatus } from 'support/util/polling';
+import { randomLabel, randomItem } from 'support/util/random';
 
+// Submits the Rescue Linode dialog, initiating reboot into rescue mode.
 const rebootInRescueMode = () => {
-  fbtClick('Reboot into Rescue Mode');
+  ui.button
+    .findByTitle('Reboot into Rescue Mode')
+    .should('be.visible')
+    .should('be.enabled')
+    .click();
 };
 
-describe('rescue linode', () => {
-  it('rescue a linode', () => {
-    cy.visitWithLogin('/support');
-    createLinode().then((linode) => {
-      // mock 200 response
-      cy.intercept(
-        'POST',
-        apiMatcher(`linode/instances/${linode.id}/rescue`),
-        (req) => {
-          req.reply(200);
-        }
-      ).as('postRebootInRescueMode');
-      const rescueUrl = `/linodes/${linode.id}`;
-      cy.visit(rescueUrl);
-      ui.actionMenu
-        .findByTitle(`Action menu for Linode ${linode.label}`)
-        .should('be.visible')
-        .click();
-
-      ui.actionMenuItem.findByTitle('Rescue').should('be.visible').click();
-
-      rebootInRescueMode();
-      // check mocked response and make sure UI responded correctly
-      cy.wait('@postRebootInRescueMode')
-        .its('response.statusCode')
-        .should('eq', 200);
-
-      ui.toast.assertMessage('Linode rescue started.');
-    });
+// Creates a Linode and waits for it to be in "running" state.
+const createAndBootLinode = async () => {
+  const linodeRequest = createLinodeRequestFactory.build({
+    label: randomLabel(),
+    region: randomItem(regions),
   });
 
-  it('rescue blocked', () => {
-    cy.visitWithLogin('/support');
-    createLinode().then((linode) => {
-      // not mocking response here, intercepting post
-      cy.intercept(
-        'POST',
-        apiMatcher(`linode/instances/${linode.id}/rescue`)
-      ).as('postRebootInRescueMode');
-      const rescueUrl = `/linodes/${linode.id}/rescue`;
-      cy.visit(rescueUrl);
-      fbtVisible(`Rescue Linode ${linode.label}`);
-      rebootInRescueMode();
-      // check response, verify bad request and UI response (toast)
-      cy.wait('@postRebootInRescueMode')
-        .its('response.statusCode')
-        .should('eq', 400);
-      fbtVisible('Linode busy.');
+  const linode = await createLinode(linodeRequest);
+  await pollLinodeStatus(
+    linode.id,
+    'running',
+    new SimpleBackoffMethod(5000, {
+      initialDelay: 15000,
+      maxAttempts: 25,
+    })
+  );
+
+  return linode;
+};
+
+authenticate();
+describe('Rescue Linodes', () => {
+  /*
+   * - Creates a Linode, waits for it to boot, and reboots it into rescue mode.
+   * - Confirms that rescue mode API requests succeed.
+   * - Confirms that Linode status changes to "Rebooting".
+   * - Confirms that toast appears confirming successful reboot into rescue mode.
+   */
+  it('Can reboot a Linode into rescue mode', () => {
+    cy.wrap<Promise<Linode>, Linode>(createAndBootLinode()).then(
+      (linode: Linode) => {
+        // mock 200 response
+        interceptGetLinodeDetails(linode.id).as('getLinode');
+        interceptRebootLinodeIntoRescueMode(linode.id).as(
+          'rebootLinodeRescueMode'
+        );
+
+        const rescueUrl = `/linodes/${linode.id}/?rescue=true`;
+        cy.visitWithLogin(rescueUrl);
+        cy.wait('@getLinode');
+
+        ui.dialog
+          .findByTitle(`Rescue Linode ${linode.label}`)
+          .should('be.visible')
+          .within(() => {
+            rebootInRescueMode();
+          });
+
+        // Check mocked response and make sure UI responded correctly.
+        cy.wait('@rebootLinodeRescueMode')
+          .its('response.statusCode')
+          .should('eq', 200);
+
+        ui.toast.assertMessage('Linode rescue started.');
+        cy.findByText('REBOOTING').should('be.visible');
+      }
+    );
+  });
+
+  /*
+   * - Creates a Linode and immediately attempts to reboot it into rescue mode.
+   * - Confirms that an error message appears in the UI explaining that the Linode is busy.
+   */
+  it('Cannot reboot a provisioning Linode into rescue mode', () => {
+    const linodeRequest = createLinodeRequestFactory.build({
+      label: randomLabel(),
+      region: randomItem(regions),
     });
+
+    cy.wrap<Promise<Linode>, Linode>(createLinode(linodeRequest)).then(
+      (linode: Linode) => {
+        interceptGetLinodeDetails(linode.id).as('getLinode');
+        interceptRebootLinodeIntoRescueMode(linode.id).as(
+          'rebootLinodeRescueMode'
+        );
+
+        const rescueUrl = `/linodes/${linode.id}?rescue=true`;
+
+        cy.visitWithLogin(rescueUrl);
+        cy.wait('@getLinode');
+
+        ui.dialog
+          .findByTitle(`Rescue Linode ${linode.label}`)
+          .should('be.visible')
+          .within(() => {
+            rebootInRescueMode();
+
+            // Wait for API request and confirm that error message appears in dialog.
+            cy.wait('@rebootLinodeRescueMode')
+              .its('response.statusCode')
+              .should('eq', 400);
+
+            cy.findByText('Linode busy.').should('be.visible');
+          });
+      }
+    );
   });
 });

--- a/packages/manager/cypress/support/intercepts/linodes.ts
+++ b/packages/manager/cypress/support/intercepts/linodes.ts
@@ -31,6 +31,19 @@ export const mockGetLinodes = (linodes: Linode[]): Cypress.Chainable<null> => {
 };
 
 /**
+ * Intercepts GET request to retrieve Linode details.
+ *
+ * @param linodeId - ID of Linode for intercepted request.
+ *
+ * @returns Cypress chainable.
+ */
+export const interceptGetLinodeDetails = (
+  linodeId: number
+): Cypress.Chainable<null> => {
+  return cy.intercept('GET', apiMatcher(`linode/instances/${linodeId}*`));
+};
+
+/**
  * Intercepts GET request to retrieve Linode details and mocks response.
  *
  * @param linodeId - ID of Linode for intercepted request.
@@ -65,5 +78,21 @@ export const mockGetLinodeVolumes = (
     'GET',
     apiMatcher(`linode/instances/${linodeId}/volumes*`),
     paginateResponse(volumes)
+  );
+};
+
+/**
+ * Intercepts POST request to reboot a Linode into rescue mode.
+ *
+ * @param linodeId - ID of Linode for intercepted request.
+ *
+ * @returns Cypress chainable.
+ */
+export const interceptRebootLinodeIntoRescueMode = (
+  linodeId: number
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'POST',
+    apiMatcher(`linode/instances/${linodeId}/rescue`)
   );
 };


### PR DESCRIPTION
## Description 📝

**What does this PR do?**
Attempts to resolve the flakiness we've been seeing with these tests by navigating directly to the Linode rescue dialog at `/linodes/:id/?rescue=true`. We've been seeing some flakiness in this test and others related to Cypress's interactions with our action menus (and I still haven't nailed down the root cause of that) so this works around that problem by cutting out the action menu interactions.

## How to test 🧪

**How do I run relevant unit or e2e tests?**
`yarn && yarn build && yarn start:manager:ci`, and then:

```bash
yarn cy:run -s "cypress/e2e/linodes/rescue-linode.spec.ts"
```
