### PR TITLE
fix: [M3-6446] - Fix code scanning alert that DOM text is reinterpreted as HTML

### DIFF
--- a/packages/manager/src/components/ExternalLink/ExternalLink.tsx
+++ b/packages/manager/src/components/ExternalLink/ExternalLink.tsx
@@ -3,6 +3,7 @@ import OpenInNew from '@mui/icons-material/OpenInNew';
 import Arrow from 'src/assets/icons/diagonalArrow.svg';
 import { makeStyles } from 'tss-react/mui';
 import { Theme } from '@mui/material/styles';
+import { sanitizeUrl } from '@braintree/sanitize-url';
 
 const useStyles = makeStyles<void, 'icon'>()(
   (theme: Theme, _params, classes) => ({
@@ -77,10 +78,10 @@ const ExternalLink = (props: Props) => {
       target="_blank"
       aria-describedby="external-site"
       rel="noopener noreferrer"
-      href={link}
+      href={sanitizeUrl(link)}
       className={cx(
+        classes.root,
         {
-          [classes.root]: true,
           [classes.absoluteIcon]: absoluteIcon,
           [classes.black]: black,
         },


### PR DESCRIPTION
## Description 📝

- Fixes https://github.com/linode/manager/security/code-scanning/23
- Uses Braintree's `sanitize-url` because it already is already baked into our repo
  - I considered `sanitize-html`, which we also have installed, but Braintree's `sanitize-url` seems like a better fit for this use case

## Major Changes 🔄
- The `<ExternalLink />` component now sanitizes any link it is given

## How to test 🧪

- Verify that the `<ExternalLink />` component still works as expected
  - You can test this by clicking links in the Footer
- Verify that `SupportSearchLanding` (http://localhost:3000/support/search/?query=) still works as expected because this is what triggered the alert
