### PR TITLE
refactor: Improve Object Storage E2E flake related to ACL select

### DIFF
--- a/packages/manager/cypress/e2e/objectStorage/object-storage.e2e.spec.ts
+++ b/packages/manager/cypress/e2e/objectStorage/object-storage.e2e.spec.ts
@@ -316,7 +316,12 @@ describe('object storage end-to-end tests', () => {
           cy.findByText('Access Control List (ACL)')
             .should('be.visible')
             .click()
-            .type('Public Read{enter}');
+            .type('Public Read');
+
+          ui.autocompletePopper
+            .findByTitle('Public Read')
+            .should('be.visible')
+            .click();
 
           ui.button.findByTitle('Save').should('be.visible').click();
 

--- a/packages/manager/src/components/EnhancedSelect/components/MenuList.tsx
+++ b/packages/manager/src/components/EnhancedSelect/components/MenuList.tsx
@@ -11,7 +11,7 @@ const Menu: React.FC<CombinedProps> = (props) => {
   return (
     <React.Fragment>
       <reactSelectComponents.MenuList {...props}>
-        {props.children}
+        <div data-qa-autocomplete-popper>{props.children}</div>
       </reactSelectComponents.MenuList>
       {guidance !== undefined && <Guidance text={guidance} />}
     </React.Fragment>


### PR DESCRIPTION
## Description 📝

- Uses the `autocompletePopper` UI helper to interact with the Object Storage ACL select element, eliminating the issue that causes occasional flakiness with the Object Storage end-to-end tests.
- Wraps the `EnhancedSelect` component's menu list items in a div with a `data-qa-autocomplete-popper` attribute. This was done so that our e2e `autocompletePopper` UI helper works with our old selects (`EnhancedSelect`) in addition to newer selects based on MUI. I was reluctant to change the DOM structure but haven't observed any issues or changes stemming from this addition -- happy to revisit if the team would prefer another approach.

## How to test 🧪
`yarn && yarn build && yarn start:manager:ci` and then:

```bash
yarn cy:run -s "cypress/e2e/objectStorage/object-storage.e2e.spec.ts"
```

Confirm that the tests pass. Optionally, run the test multiple times to ensure there is no flake related to the ACL select.