### PR TITLE
fix: Improve stability of `ObjectDetailsDrawer.test.tsx`

### DIFF
--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.tsx
@@ -75,7 +75,7 @@ const ObjectDetailsDrawer: React.FC<Props> = (props) => {
           {readableBytes(size).formatted}
         </Typography>
       ) : null}
-      {formattedLastModified ? (
+      {formattedLastModified && Boolean(profile) ? (
         <Typography variant="subtitle2" data-testid="lastModified">
           Last modified: {formattedLastModified}
         </Typography>


### PR DESCRIPTION
## Description 📝

- Fixes flake in `ObjectDetailsDrawer.test.tsx` by ensuring a test has a clean environment with a consistent timezone

## How to test 🧪

- `yarn test ObjectDetailsDrawer`
