### PR TITLE
fix: Fix Managed e2e navigation test flake on SSH tab

### DIFF
--- a/packages/manager/cypress/e2e/managed/managed-navigation.spec.ts
+++ b/packages/manager/cypress/e2e/managed/managed-navigation.spec.ts
@@ -96,7 +96,10 @@ describe('Managed navigation', () => {
     managedURLs.forEach((url) => {
       mockUnauthorizedManagedRequests();
       visitUrlWithManagedDisabled(url);
-      cy.findByText('Unauthorized').should('be.visible');
+
+      // The Managed SSH tab has two sections that can each display an "Unauthorized" notice.
+      // We're using `findAllByText` to ensure that Cypress succeeds when both load at the same time.
+      cy.findAllByText('Unauthorized').should('exist').should('be.visible');
     });
   });
 


### PR DESCRIPTION
## Description 📝
Fixes test flake that occurs in `managed-navigation.spec.ts` when both "Unauthorized" notices on the SSH tab load and appear at the same time; Cypress expected only one instance of the notice to appear and would fail when both appeared at the same time.

## How to test 🧪
Run `yarn && yarn build && yarn start:manager:ci` and then:

```bash
yarn cy:run -s "cypress/e2e/managed/managed-navigation.spec.ts"
```

Confirm that each test passes, preferably on the first attempt.