### PR TITLE
chore: add more hook rules to eslint

### DIFF
--- a/packages/manager/.eslintrc.js
+++ b/packages/manager/.eslintrc.js
@@ -95,6 +95,8 @@ module.exports = {
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     // react and jsx specific rules
     'react/display-name': 'off',
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'warn',
     // requires the definition of proptypes for react components
     'react/prop-types': 'off',
     'react/jsx-no-script-url': 'error',


### PR DESCRIPTION
## Description 📝
Adding a couple rules that should prevent a commit from going through if condition met (before that contributors may have been able to see the error in the IDE but commit could go through nonetheless

I set `react-hooks/exhaustive-deps` as a warning for now (there's 80+ offenders in the codebase) but since we only lint staged code anyway it shouldn't affect velocity either way unless you start editing and attempt to commit said offender


