### PR TITLE
feat: [M3-5915] Accessible graph data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Metadata
 - Add No Results section for Marketplace Search #8999
 - Add Private IP checkbox when cloning a Linode #9039
+- Accessible graph tabled data for `LineGraph` component #5915
 
 ### Changed:
-- `<RegionSelect />` can now dynamically get country flag and group all countrys #8996
+- `<RegionSelect />` can now dynamically get country flag and group all countries #8996
 
 ### Fixed:
 - Typesafety of the `<Select />` component #8986

--- a/packages/manager/src/components/LineGraph/AccessibleGraphData.test.tsx
+++ b/packages/manager/src/components/LineGraph/AccessibleGraphData.test.tsx
@@ -31,6 +31,7 @@ describe('AccessibleGraphData', () => {
   it('renders a table with correct data', () => {
     const { getAllByRole } = render(
       <AccessibleGraphData
+        ariaLabel="data filter"
         chartInstance={chartInstance}
         hiddenDatasets={[]}
         accessibleUnit="%"
@@ -48,7 +49,7 @@ describe('AccessibleGraphData', () => {
     // Check that the table has the correct summary attribute
     expect(table).toHaveAttribute(
       'summary',
-      'This table contains the data for the Dataset 1 graph.'
+      'This table contains the data for the data filter (Dataset 1)'
     );
 
     // Check that the table header is correct

--- a/packages/manager/src/components/LineGraph/AccessibleGraphData.test.tsx
+++ b/packages/manager/src/components/LineGraph/AccessibleGraphData.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import AccessibleGraphData from './AccessibleGraphData';
+import type { GraphTabledDataProps } from './AccessibleGraphData';
 
 const chartInstance = {
   config: {
@@ -32,7 +33,7 @@ describe('AccessibleGraphData', () => {
     const { getAllByRole } = render(
       <AccessibleGraphData
         ariaLabel="data filter"
-        chartInstance={chartInstance}
+        chartInstance={chartInstance as GraphTabledDataProps['chartInstance']}
         hiddenDatasets={[]}
         accessibleUnit="%"
       />
@@ -62,9 +63,9 @@ describe('AccessibleGraphData', () => {
     expect(tableBodyRows.length).toEqual(3);
 
     tableBodyRows.forEach((row, idx) => {
-      const value = chartInstance.config.data.datasets[0].data[idx].y.toFixed(
-        2
-      );
+      const value: any = chartInstance.config.data.datasets[0].data[
+        idx
+      ].y.toFixed(2);
 
       expect(row.querySelector('td:nth-child(2)')).toHaveTextContent(
         value + '%'
@@ -74,7 +75,11 @@ describe('AccessibleGraphData', () => {
 
   it('hides the correct datasets', () => {
     const { getByRole, queryByText } = render(
-      <AccessibleGraphData chartInstance={chartInstance} hiddenDatasets={[0]} />
+      <AccessibleGraphData
+        chartInstance={chartInstance as GraphTabledDataProps['chartInstance']}
+        hiddenDatasets={[0]}
+        accessibleUnit="%"
+      />
     );
 
     // Check that the first table is hidden

--- a/packages/manager/src/components/LineGraph/AccessibleGraphData.test.tsx
+++ b/packages/manager/src/components/LineGraph/AccessibleGraphData.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import AccessibleGraphData from './AccessibleGraphData';
+
+const chartInstance = {
+  config: {
+    data: {
+      datasets: [
+        {
+          label: 'Dataset 1',
+          data: [
+            { t: 1631026800000, y: 10 },
+            { t: 1631030400000, y: 20 },
+            { t: 1631034000000, y: 30 },
+          ],
+        },
+        {
+          label: 'Dataset 2',
+          data: [
+            { t: 1631026800000, y: 5 },
+            { t: 1631030400000, y: 15 },
+            { t: 1631034000000, y: 25 },
+          ],
+        },
+      ],
+    },
+  },
+};
+
+describe('AccessibleGraphData', () => {
+  it('renders a table with correct data', () => {
+    const { getAllByRole } = render(
+      <AccessibleGraphData
+        chartInstance={chartInstance}
+        hiddenDatasets={[]}
+        accessibleUnit="%"
+      />
+    );
+
+    // Check that the component renders
+    const table = getAllByRole('table')[0];
+    expect(table).toBeInTheDocument();
+
+    // Check that the correct number of tables are rendered
+    const tables = getAllByRole('table');
+    expect(tables.length).toEqual(2);
+
+    // Check that the table has the correct summary attribute
+    expect(table).toHaveAttribute(
+      'summary',
+      'This table contains the data for the Dataset 1 graph.'
+    );
+
+    // Check that the table header is correct
+    const tableHeader = table.querySelector('thead > tr');
+    expect(tableHeader).toHaveTextContent('Time');
+    expect(tableHeader).toHaveTextContent('Dataset 1');
+
+    // Check that the table data is correct in the body
+    const tableBodyRows = table.querySelectorAll('tbody > tr');
+    expect(tableBodyRows.length).toEqual(3);
+
+    tableBodyRows.forEach((row, idx) => {
+      const value = chartInstance.config.data.datasets[0].data[idx].y.toFixed(
+        2
+      );
+
+      expect(row.querySelector('td:nth-child(2)')).toHaveTextContent(
+        value + '%'
+      );
+    });
+  });
+
+  it('hides the correct datasets', () => {
+    const { getByRole, queryByText } = render(
+      <AccessibleGraphData chartInstance={chartInstance} hiddenDatasets={[0]} />
+    );
+
+    // Check that the first table is hidden
+    expect(getByRole('table', { hidden: true })).toBeInTheDocument();
+    expect(getByRole('table', { hidden: false })).toBeInTheDocument();
+
+    // Check that the hidden table is not visible
+    expect(queryByText('Dataset 1')).not.toBeInTheDocument();
+  });
+});

--- a/packages/manager/src/components/LineGraph/AccessibleGraphData.tsx
+++ b/packages/manager/src/components/LineGraph/AccessibleGraphData.tsx
@@ -72,7 +72,7 @@ const AccessibleGraphData = (props: GraphTabledDataProps) => {
           id={id}
           key={`accessible-graph-data-table-${tableID}`}
           summary={`This table contains the data for the ${
-            ariaLabel ? ariaLabel : label + 'graph.'
+            ariaLabel ? ariaLabel : label + ' graph.'
           }`}
         >
           <thead>{tableHeader}</thead>

--- a/packages/manager/src/components/LineGraph/AccessibleGraphData.tsx
+++ b/packages/manager/src/components/LineGraph/AccessibleGraphData.tsx
@@ -10,6 +10,11 @@ interface GraphTabledDataProps {
   hiddenDatasets: number[];
 }
 
+/**
+ * This component is used to provide an accessible representation of the data
+ * It does not care about styles, it only cares about presenting the data in bare HTML tables,
+ * visually hidden from the user, yet available to screen readers.
+ */
 const AccessibleGraphData = (props: GraphTabledDataProps) => {
   const { ariaLabel, chartInstance, hiddenDatasets } = props;
 
@@ -54,7 +59,6 @@ const AccessibleGraphData = (props: GraphTabledDataProps) => {
       !hidden && (
         <table
           key={`accessible-graph-data-table-${tableID}`}
-          style={{ textAlign: 'left' }}
           summary={`This table contains the data for the ${
             ariaLabel ? ariaLabel : label + 'graph.'
           }`}
@@ -66,8 +70,7 @@ const AccessibleGraphData = (props: GraphTabledDataProps) => {
     );
   });
 
-  // return <Grid sx={visuallyHidden}>{tables}</Grid>;
-  return <Grid>{tables}</Grid>;
+  return <Grid sx={visuallyHidden}>{tables}</Grid>;
 };
 
 export default AccessibleGraphData;

--- a/packages/manager/src/components/LineGraph/AccessibleGraphData.tsx
+++ b/packages/manager/src/components/LineGraph/AccessibleGraphData.tsx
@@ -52,8 +52,10 @@ const AccessibleGraphData = (props: GraphTabledDataProps) => {
                 : 'timestamp unavailable'}
             </td>
             <td>
-              {value ? Number(value).toFixed(2) : 'value unavailable'}
-              {value && accessibleUnit}
+              {value !== undefined
+                ? Number(value).toFixed(2)
+                : 'value unavailable'}
+              {value !== undefined && accessibleUnit}
             </td>
           </tr>
         );

--- a/packages/manager/src/components/LineGraph/AccessibleGraphData.tsx
+++ b/packages/manager/src/components/LineGraph/AccessibleGraphData.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import type { ChartData, ChartPoint } from 'chart.js';
+import { DateTime } from 'luxon';
+
+interface GraphTabledDataProps {
+  chartInstance: React.MutableRefObject<any>['current'];
+}
+
+const AccessibleGraphData = (props: GraphTabledDataProps) => {
+  const { chartInstance } = props;
+  if (!chartInstance?.config?.data?.datasets) return null;
+
+  const { datasets }: ChartData = chartInstance.config.data;
+
+  const tables = datasets.map((dataset, tableID) => {
+    if (!dataset.data) return '';
+
+    const { label, data } = dataset;
+    const tableHeader = (
+      <tr>
+        <th>Time</th>
+        <th>{label}</th>
+      </tr>
+    );
+
+    const tableBody = data.map((entry, idx) => {
+      if (!entry) return 'no data';
+      const { t: timestamp, y: value } = entry as ChartPoint;
+
+      return (
+        <tr key={`accessible-graph-data-body-row-${idx}`}>
+          <td>
+            {timestamp
+              ? DateTime.fromMillis(+timestamp).toLocaleString(
+                  DateTime.DATETIME_SHORT
+                )
+              : ''}
+          </td>
+          <td>{value}</td>
+        </tr>
+      );
+    });
+
+    return (
+      <table
+        key={`accessible-graph-data-table-${tableID}`}
+        style={{ textAlign: 'left' }}
+      >
+        <thead>{tableHeader}</thead>
+        <tbody>{tableBody}</tbody>
+      </table>
+    );
+  });
+
+  return <div>{tables}</div>;
+};
+
+export default AccessibleGraphData;

--- a/packages/manager/src/components/LineGraph/AccessibleGraphData.tsx
+++ b/packages/manager/src/components/LineGraph/AccessibleGraphData.tsx
@@ -5,7 +5,6 @@ import Grid from '@mui/material/Unstable_Grid2';
 import { visuallyHidden } from '@mui/utils';
 
 interface GraphTabledDataProps {
-  id?: string;
   ariaLabel?: string;
   accessibleUnit?: string;
   chartInstance: React.MutableRefObject<any>['current'];
@@ -18,13 +17,7 @@ interface GraphTabledDataProps {
  * visually hidden from the user, yet available to screen readers.
  */
 const AccessibleGraphData = (props: GraphTabledDataProps) => {
-  const {
-    accessibleUnit,
-    ariaLabel,
-    chartInstance,
-    hiddenDatasets,
-    id,
-  } = props;
+  const { accessibleUnit, ariaLabel, chartInstance, hiddenDatasets } = props;
 
   // This is necessary because the chartInstance is not immediately available
   if (!chartInstance?.config?.data?.datasets) {
@@ -56,11 +49,11 @@ const AccessibleGraphData = (props: GraphTabledDataProps) => {
                 ? DateTime.fromMillis(Number(timestamp)).toLocaleString(
                     DateTime.DATETIME_SHORT
                   )
-                : ''}
+                : 'timestamp unavailable'}
             </td>
             <td>
-              {value && Number(value).toFixed(2)}
-              {accessibleUnit}
+              {value ? Number(value).toFixed(2) : 'value unavailable'}
+              {value && accessibleUnit}
             </td>
           </tr>
         );
@@ -69,10 +62,9 @@ const AccessibleGraphData = (props: GraphTabledDataProps) => {
     return (
       !hidden && (
         <table
-          id={id}
           key={`accessible-graph-data-table-${tableID}`}
           summary={`This table contains the data for the ${
-            ariaLabel ? ariaLabel : label + ' graph.'
+            ariaLabel && label ? ariaLabel + ` (${label})` : 'graph below'
           }`}
         >
           <thead>{tableHeader}</thead>

--- a/packages/manager/src/components/LineGraph/AccessibleGraphData.tsx
+++ b/packages/manager/src/components/LineGraph/AccessibleGraphData.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import type { ChartData, ChartPoint } from 'chart.js';
 import { DateTime } from 'luxon';
-import Grid from '@mui/material/Unstable_Grid2';
 import { visuallyHidden } from '@mui/utils';
+import Box from 'src/components/core/Box';
 
-interface GraphTabledDataProps {
+export interface GraphTabledDataProps {
   ariaLabel?: string;
-  accessibleUnit?: string;
-  chartInstance: React.MutableRefObject<any>['current'];
+  accessibleUnit: string;
+  chartInstance: React.MutableRefObject<Chart | null>['current'];
   hiddenDatasets: number[];
 }
 
@@ -74,7 +74,7 @@ const AccessibleGraphData = (props: GraphTabledDataProps) => {
     );
   });
 
-  return <Grid sx={visuallyHidden}>{tables}</Grid>;
+  return <Box sx={visuallyHidden}>{tables}</Box>;
 };
 
 export default AccessibleGraphData;

--- a/packages/manager/src/components/LineGraph/AccessibleGraphData.tsx
+++ b/packages/manager/src/components/LineGraph/AccessibleGraphData.tsx
@@ -7,10 +7,11 @@ import { visuallyHidden } from '@mui/utils';
 interface GraphTabledDataProps {
   ariaLabel?: string;
   chartInstance: React.MutableRefObject<any>['current'];
+  hiddenDatasets: number[];
 }
 
 const AccessibleGraphData = (props: GraphTabledDataProps) => {
-  const { ariaLabel, chartInstance } = props;
+  const { ariaLabel, chartInstance, hiddenDatasets } = props;
 
   // This is necessary because the chartInstance is not immediately available
   if (!chartInstance?.config?.data?.datasets) {
@@ -21,6 +22,8 @@ const AccessibleGraphData = (props: GraphTabledDataProps) => {
 
   const tables = datasets.map((dataset, tableID) => {
     const { label, data } = dataset;
+    const hidden = hiddenDatasets.includes(tableID);
+
     const tableHeader = (
       <tr>
         <th>Time</th>
@@ -48,20 +51,23 @@ const AccessibleGraphData = (props: GraphTabledDataProps) => {
       });
 
     return (
-      <table
-        key={`accessible-graph-data-table-${tableID}`}
-        style={{ textAlign: 'left' }}
-        summary={`This table contains the data for the ${
-          ariaLabel ? ariaLabel : label + 'graph.'
-        }`}
-      >
-        <thead>{tableHeader}</thead>
-        <tbody>{tableBody}</tbody>
-      </table>
+      !hidden && (
+        <table
+          key={`accessible-graph-data-table-${tableID}`}
+          style={{ textAlign: 'left' }}
+          summary={`This table contains the data for the ${
+            ariaLabel ? ariaLabel : label + 'graph.'
+          }`}
+        >
+          <thead>{tableHeader}</thead>
+          <tbody>{tableBody}</tbody>
+        </table>
+      )
     );
   });
 
-  return <Grid sx={visuallyHidden}>{tables}</Grid>;
+  // return <Grid sx={visuallyHidden}>{tables}</Grid>;
+  return <Grid>{tables}</Grid>;
 };
 
 export default AccessibleGraphData;

--- a/packages/manager/src/components/LineGraph/AccessibleGraphData.tsx
+++ b/packages/manager/src/components/LineGraph/AccessibleGraphData.tsx
@@ -5,6 +5,7 @@ import Grid from '@mui/material/Unstable_Grid2';
 import { visuallyHidden } from '@mui/utils';
 
 interface GraphTabledDataProps {
+  id?: string;
   ariaLabel?: string;
   accessibleUnit?: string;
   chartInstance: React.MutableRefObject<any>['current'];
@@ -17,7 +18,13 @@ interface GraphTabledDataProps {
  * visually hidden from the user, yet available to screen readers.
  */
 const AccessibleGraphData = (props: GraphTabledDataProps) => {
-  const { accessibleUnit, ariaLabel, chartInstance, hiddenDatasets } = props;
+  const {
+    accessibleUnit,
+    ariaLabel,
+    chartInstance,
+    hiddenDatasets,
+    id,
+  } = props;
 
   // This is necessary because the chartInstance is not immediately available
   if (!chartInstance?.config?.data?.datasets) {
@@ -62,6 +69,7 @@ const AccessibleGraphData = (props: GraphTabledDataProps) => {
     return (
       !hidden && (
         <table
+          id={id}
           key={`accessible-graph-data-table-${tableID}`}
           summary={`This table contains the data for the ${
             ariaLabel ? ariaLabel : label + 'graph.'

--- a/packages/manager/src/components/LineGraph/AccessibleGraphData.tsx
+++ b/packages/manager/src/components/LineGraph/AccessibleGraphData.tsx
@@ -6,6 +6,7 @@ import { visuallyHidden } from '@mui/utils';
 
 interface GraphTabledDataProps {
   ariaLabel?: string;
+  accessibleUnit?: string;
   chartInstance: React.MutableRefObject<any>['current'];
   hiddenDatasets: number[];
 }
@@ -16,7 +17,7 @@ interface GraphTabledDataProps {
  * visually hidden from the user, yet available to screen readers.
  */
 const AccessibleGraphData = (props: GraphTabledDataProps) => {
-  const { ariaLabel, chartInstance, hiddenDatasets } = props;
+  const { accessibleUnit, ariaLabel, chartInstance, hiddenDatasets } = props;
 
   // This is necessary because the chartInstance is not immediately available
   if (!chartInstance?.config?.data?.datasets) {
@@ -50,7 +51,10 @@ const AccessibleGraphData = (props: GraphTabledDataProps) => {
                   )
                 : ''}
             </td>
-            <td>{value && Number(value).toFixed(2)}</td>
+            <td>
+              {value && Number(value).toFixed(2)}
+              {accessibleUnit}
+            </td>
           </tr>
         );
       });

--- a/packages/manager/src/components/LineGraph/AccessibleGraphData.tsx
+++ b/packages/manager/src/components/LineGraph/AccessibleGraphData.tsx
@@ -30,14 +30,14 @@ const AccessibleGraphData = (props: GraphTabledDataProps) => {
     const { label, data } = dataset;
     const hidden = hiddenDatasets.includes(tableID);
 
-    const tableHeader = (
+    const TableHeader = (
       <tr>
         <th>Time</th>
         <th>{label}</th>
       </tr>
     );
 
-    const tableBody =
+    const TableBody =
       data &&
       data.map((entry, idx) => {
         const { t: timestamp, y: value } = entry as ChartPoint;
@@ -69,8 +69,8 @@ const AccessibleGraphData = (props: GraphTabledDataProps) => {
             ariaLabel && label ? ariaLabel + ` (${label})` : 'graph below'
           }`}
         >
-          <thead>{tableHeader}</thead>
-          <tbody>{tableBody}</tbody>
+          <thead>{TableHeader}</thead>
+          <tbody>{TableBody}</tbody>
         </table>
       )
     );

--- a/packages/manager/src/components/LineGraph/LineGraph.stories.mdx
+++ b/packages/manager/src/components/LineGraph/LineGraph.stories.mdx
@@ -66,7 +66,10 @@ export const Template = (args) => <LineGraph {...args} />;
       nativeLegend: false,
       timezone: 'America/New_York',
       unit: '%',
-      accessibleUnit:"%",
+      accessibleDataTable: {
+        display: true,
+        unit: "%"
+      },
       chartHeight: undefined,
       suggestedMax: undefined,
       rowHeaders: undefined,

--- a/packages/manager/src/components/LineGraph/LineGraph.stories.mdx
+++ b/packages/manager/src/components/LineGraph/LineGraph.stories.mdx
@@ -66,6 +66,7 @@ export const Template = (args) => <LineGraph {...args} />;
       nativeLegend: false,
       timezone: 'America/New_York',
       unit: '%',
+      accessibleUnit:"%",
       chartHeight: undefined,
       suggestedMax: undefined,
       rowHeaders: undefined,

--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -297,6 +297,7 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
       <AccessibleGraphData
         chartInstance={chartInstance.current}
         ariaLabel={ariaLabel}
+        hiddenDatasets={hiddenDatasets}
       />
       {legendRendered && legendRows && (
         <div className={classes.container}>

--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -285,20 +285,17 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
   return (
     // Allow `tabIndex` on `<div>` because it represents an interactive element.
     // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+
+    // Note on markup and styling: the legend is rendered first for accessibility reasons.
+    // Screen readers read from top to bottom, so the legend should be read before the data tables, esp considering their size
+    // and the fact that the legend can filter them.
+    // Meanwhile the CSS uses column-reverse to visually retain the original order
     <div
       className={classes.wrapper}
       tabIndex={tabIndex ?? 0}
       role="graphics-document"
       aria-label={ariaLabel || 'Stats and metrics'}
     >
-      <div className={classes.canvasContainer}>
-        <canvas height={chartHeight || 300} ref={inputEl} />
-      </div>
-      <AccessibleGraphData
-        chartInstance={chartInstance.current}
-        ariaLabel={ariaLabel}
-        hiddenDatasets={hiddenDatasets}
-      />
       {legendRendered && legendRows && (
         <div className={classes.container}>
           <Table
@@ -396,6 +393,14 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
           </Table>
         </div>
       )}
+      <div className={classes.canvasContainer}>
+        <canvas height={chartHeight || 300} ref={inputEl} />
+        <AccessibleGraphData
+          chartInstance={chartInstance.current}
+          ariaLabel={ariaLabel}
+          hiddenDatasets={hiddenDatasets}
+        />
+      </div>
     </div>
   );
 };

--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -111,6 +111,11 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
   } = props;
 
   const finalRowHeaders = rowHeaders ? rowHeaders : ['Max', 'Avg', 'Last'];
+  // the chartID is used to associate the chart with the table for accessibility purpose
+  // trying to use a more readable ariaLabel as the chartID, but if it's undefined, we'll generate a random ID
+  const chartID: string = ariaLabel
+    ? ariaLabel.replace(/\s+/g, '-').toLocaleLowerCase()
+    : crypto.randomUUID();
   // is undefined on linode/summary
   const plugins = [
     {
@@ -395,10 +400,12 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
           height={chartHeight || 300}
           ref={inputEl}
           role="img"
+          aria-describedby={chartID}
           aria-label={ariaLabel || 'Stats and metrics'}
         />
       </div>
       <AccessibleGraphData
+        id={chartID}
         chartInstance={chartInstance.current}
         ariaLabel={ariaLabel}
         hiddenDatasets={hiddenDatasets}

--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -48,9 +48,13 @@ export interface Props {
   legendRows?: Array<any>;
   unit?: string;
   /**
-   * If provided, will be used to render the accessible graph data
+   * If provided, will be responsible to both rendering the accessible graph data table and an associated unit.
+   * Both nested props require a value for the table to render.
    */
-  accessibleUnit?: string;
+  accessibleDataTable?: {
+    display: boolean;
+    unit: string;
+  };
   nativeLegend?: boolean; // Display chart.js native legend
   formatData?: (value: number) => number | null;
   formatTooltip?: (value: number) => string;
@@ -110,7 +114,7 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
     nativeLegend,
     tabIndex,
     unit,
-    accessibleUnit,
+    accessibleDataTable,
   } = props;
 
   const finalRowHeaders = rowHeaders ? rowHeaders : ['Max', 'Avg', 'Last'];
@@ -401,12 +405,12 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
           aria-label={ariaLabel || 'Stats and metrics'}
         />
       </div>
-      {accessibleUnit && (
+      {accessibleDataTable?.display && accessibleDataTable?.unit && (
         <AccessibleGraphData
           chartInstance={chartInstance.current}
           ariaLabel={ariaLabel}
           hiddenDatasets={hiddenDatasets}
-          accessibleUnit={accessibleUnit}
+          accessibleUnit={accessibleDataTable.unit}
         />
       )}
     </div>

--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -113,9 +113,10 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
   const finalRowHeaders = rowHeaders ? rowHeaders : ['Max', 'Avg', 'Last'];
   // the chartID is used to associate the chart with the table for accessibility purpose
   // trying to use a more readable ariaLabel as the chartID, but if it's undefined, we'll generate a random ID
-  const chartID: string = ariaLabel
+  // TODO: update to use React.useId when we upgrade to React 18
+  const chartID: string | undefined = ariaLabel
     ? ariaLabel.replace(/\s+/g, '-').toLocaleLowerCase()
-    : crypto.randomUUID();
+    : crypto && crypto.randomUUID();
   // is undefined on linode/summary
   const plugins = [
     {

--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -294,7 +294,10 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
       <div className={classes.canvasContainer}>
         <canvas height={chartHeight || 300} ref={inputEl} />
       </div>
-      <AccessibleGraphData chartInstance={chartInstance.current} />
+      <AccessibleGraphData
+        chartInstance={chartInstance.current}
+        ariaLabel={ariaLabel}
+      />
       {legendRendered && legendRows && (
         <div className={classes.container}>
           <Table

--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -112,11 +112,9 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
 
   const finalRowHeaders = rowHeaders ? rowHeaders : ['Max', 'Avg', 'Last'];
   // the chartID is used to associate the chart with the table for accessibility purpose
-  // trying to use a more readable ariaLabel as the chartID, but if it's undefined, we'll generate a random ID
   // TODO: update to use React.useId when we upgrade to React 18
-  const chartID: string | undefined = ariaLabel
-    ? ariaLabel.replace(/\s+/g, '-').toLocaleLowerCase()
-    : crypto && crypto.randomUUID();
+  const chartID: string | undefined =
+    ariaLabel && ariaLabel.replace(/\s+/g, '-').toLocaleLowerCase();
   // is undefined on linode/summary
   const plugins = [
     {

--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -47,6 +47,7 @@ export interface Props {
   rowHeaders?: Array<string>;
   legendRows?: Array<any>;
   unit?: string;
+  accessibleUnit?: string;
   nativeLegend?: boolean; // Display chart.js native legend
   formatData?: (value: number) => number | null;
   formatTooltip?: (value: number) => string;
@@ -106,6 +107,7 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
     nativeLegend,
     tabIndex,
     unit,
+    accessibleUnit,
   } = props;
 
   const finalRowHeaders = rowHeaders ? rowHeaders : ['Max', 'Avg', 'Last'];
@@ -395,12 +397,13 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
           role="img"
           aria-label={ariaLabel || 'Stats and metrics'}
         />
-        <AccessibleGraphData
-          chartInstance={chartInstance.current}
-          ariaLabel={ariaLabel}
-          hiddenDatasets={hiddenDatasets}
-        />
       </div>
+      <AccessibleGraphData
+        chartInstance={chartInstance.current}
+        ariaLabel={ariaLabel}
+        hiddenDatasets={hiddenDatasets}
+        accessibleUnit={accessibleUnit}
+      />
     </div>
   );
 };

--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -13,6 +13,7 @@ import Button from 'src/components/Button';
 import { makeStyles, useTheme } from '@mui/styles';
 import { Theme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
+import AccessibleGraphData from './AccessibleGraphData';
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
 import Typography from 'src/components/core/Typography';
@@ -293,6 +294,7 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
       <div className={classes.canvasContainer}>
         <canvas height={chartHeight || 300} ref={inputEl} />
       </div>
+      <AccessibleGraphData chartInstance={chartInstance.current} />
       {legendRendered && legendRows && (
         <div className={classes.container}>
           <Table

--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -48,11 +48,9 @@ export interface Props {
   legendRows?: Array<any>;
   unit?: string;
   /**
-   * If provided, will be responsible to both rendering the accessible graph data table and an associated unit.
-   * Both nested props require a value for the table to render.
+   * `accessibleDataTable` is responsible to both rendering the accessible graph data table and an associated unit.
    */
   accessibleDataTable?: {
-    display: boolean;
     unit: string;
   };
   nativeLegend?: boolean; // Display chart.js native legend
@@ -405,7 +403,7 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
           aria-label={ariaLabel || 'Stats and metrics'}
         />
       </div>
-      {accessibleDataTable?.display && accessibleDataTable?.unit && (
+      {accessibleDataTable?.unit && (
         <AccessibleGraphData
           chartInstance={chartInstance.current}
           ariaLabel={ariaLabel}

--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -290,12 +290,7 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
     // Screen readers read from top to bottom, so the legend should be read before the data tables, esp considering their size
     // and the fact that the legend can filter them.
     // Meanwhile the CSS uses column-reverse to visually retain the original order
-    <div
-      className={classes.wrapper}
-      tabIndex={tabIndex ?? 0}
-      role="graphics-document"
-      aria-label={ariaLabel || 'Stats and metrics'}
-    >
+    <div className={classes.wrapper} tabIndex={tabIndex ?? 0}>
       {legendRendered && legendRows && (
         <div className={classes.container}>
           <Table
@@ -394,7 +389,12 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
         </div>
       )}
       <div className={classes.canvasContainer}>
-        <canvas height={chartHeight || 300} ref={inputEl} />
+        <canvas
+          height={chartHeight || 300}
+          ref={inputEl}
+          role="img"
+          aria-label={ariaLabel || 'Stats and metrics'}
+        />
         <AccessibleGraphData
           chartInstance={chartInstance.current}
           ariaLabel={ariaLabel}

--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -111,10 +111,6 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
   } = props;
 
   const finalRowHeaders = rowHeaders ? rowHeaders : ['Max', 'Avg', 'Last'];
-  // the chartID is used to associate the chart with the table for accessibility purpose
-  // TODO: update to use React.useId when we upgrade to React 18
-  const chartID: string | undefined =
-    ariaLabel && ariaLabel.replace(/\s+/g, '-').toLocaleLowerCase();
   // is undefined on linode/summary
   const plugins = [
     {
@@ -399,12 +395,10 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
           height={chartHeight || 300}
           ref={inputEl}
           role="img"
-          aria-describedby={chartID}
           aria-label={ariaLabel || 'Stats and metrics'}
         />
       </div>
       <AccessibleGraphData
-        id={chartID}
         chartInstance={chartInstance.current}
         ariaLabel={ariaLabel}
         hiddenDatasets={hiddenDatasets}

--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -47,6 +47,9 @@ export interface Props {
   rowHeaders?: Array<string>;
   legendRows?: Array<any>;
   unit?: string;
+  /**
+   * If provided, will be used to render the accessible graph data
+   */
   accessibleUnit?: string;
   nativeLegend?: boolean; // Display chart.js native legend
   formatData?: (value: number) => number | null;
@@ -398,12 +401,14 @@ const LineGraph: React.FC<CombinedProps> = (props: CombinedProps) => {
           aria-label={ariaLabel || 'Stats and metrics'}
         />
       </div>
-      <AccessibleGraphData
-        chartInstance={chartInstance.current}
-        ariaLabel={ariaLabel}
-        hiddenDatasets={hiddenDatasets}
-        accessibleUnit={accessibleUnit}
-      />
+      {accessibleUnit && (
+        <AccessibleGraphData
+          chartInstance={chartInstance.current}
+          ariaLabel={ariaLabel}
+          hiddenDatasets={hiddenDatasets}
+          accessibleUnit={accessibleUnit}
+        />
+      )}
     </div>
   );
 };

--- a/packages/manager/src/components/LineGraph/NewMetricDisplay.styles.ts
+++ b/packages/manager/src/components/LineGraph/NewMetricDisplay.styles.ts
@@ -24,11 +24,7 @@ const newMetricDisplayStyles = (theme: Theme) =>
   createStyles({
     wrapper: {
       display: 'flex',
-      flexDirection: 'row',
-      flexWrap: 'wrap',
-      '& > div': {
-        flexBasis: '100%',
-      },
+      flexDirection: 'column-reverse',
     },
     container: {
       borderTop: `1px solid ${theme.borderColors.divider}`,

--- a/packages/manager/src/components/LineGraph/NewMetricDisplay.styles.ts
+++ b/packages/manager/src/components/LineGraph/NewMetricDisplay.styles.ts
@@ -25,6 +25,11 @@ const newMetricDisplayStyles = (theme: Theme) =>
     wrapper: {
       display: 'flex',
       flexDirection: 'column-reverse',
+      flex: 1,
+      width: '100%',
+      '& > div': {
+        width: '100%',
+      },
     },
     container: {
       borderTop: `1px solid ${theme.borderColors.divider}`,

--- a/packages/manager/src/features/Managed/ManagedDashboardCard/ManagedChartPanel.tsx
+++ b/packages/manager/src/features/Managed/ManagedDashboardCard/ManagedChartPanel.tsx
@@ -120,6 +120,7 @@ const createTabs = (
             <div className={classes.canvasContainer}>
               <LineGraph
                 ariaLabel="CPU Usage Graph"
+                accessibleUnit="%"
                 timezone={timezone}
                 chartHeight={chartHeight}
                 showToday={true}
@@ -151,6 +152,7 @@ const createTabs = (
                 showToday={true}
                 nativeLegend
                 unit="/s"
+                accessibleUnit="Kb/s"
                 formatData={convertNetworkData}
                 formatTooltip={_formatTooltip}
                 data={[
@@ -185,6 +187,7 @@ const createTabs = (
                 timezone={timezone}
                 chartHeight={chartHeight}
                 showToday={true}
+                accessibleUnit="op/s"
                 data={[
                   {
                     borderColor: 'transparent',

--- a/packages/manager/src/features/Managed/ManagedDashboardCard/ManagedChartPanel.tsx
+++ b/packages/manager/src/features/Managed/ManagedDashboardCard/ManagedChartPanel.tsx
@@ -120,7 +120,7 @@ const createTabs = (
             <div className={classes.canvasContainer}>
               <LineGraph
                 ariaLabel="CPU Usage Graph"
-                accessibleDataTable={{ display: true, unit: '%' }}
+                accessibleDataTable={{ unit: '%' }}
                 timezone={timezone}
                 chartHeight={chartHeight}
                 showToday={true}
@@ -152,7 +152,7 @@ const createTabs = (
                 showToday={true}
                 nativeLegend
                 unit="/s"
-                accessibleDataTable={{ display: true, unit: 'Kb/s"' }}
+                accessibleDataTable={{ unit: 'Kb/s"' }}
                 formatData={convertNetworkData}
                 formatTooltip={_formatTooltip}
                 data={[
@@ -187,7 +187,7 @@ const createTabs = (
                 timezone={timezone}
                 chartHeight={chartHeight}
                 showToday={true}
-                accessibleDataTable={{ display: true, unit: 'op/s' }}
+                accessibleDataTable={{ unit: 'op/s' }}
                 data={[
                   {
                     borderColor: 'transparent',

--- a/packages/manager/src/features/Managed/ManagedDashboardCard/ManagedChartPanel.tsx
+++ b/packages/manager/src/features/Managed/ManagedDashboardCard/ManagedChartPanel.tsx
@@ -120,7 +120,7 @@ const createTabs = (
             <div className={classes.canvasContainer}>
               <LineGraph
                 ariaLabel="CPU Usage Graph"
-                accessibleUnit="%"
+                accessibleDataTable={{ display: true, unit: '%' }}
                 timezone={timezone}
                 chartHeight={chartHeight}
                 showToday={true}
@@ -152,7 +152,7 @@ const createTabs = (
                 showToday={true}
                 nativeLegend
                 unit="/s"
-                accessibleUnit="Kb/s"
+                accessibleDataTable={{ display: true, unit: 'Kb/s"' }}
                 formatData={convertNetworkData}
                 formatTooltip={_formatTooltip}
                 data={[
@@ -187,7 +187,7 @@ const createTabs = (
                 timezone={timezone}
                 chartHeight={chartHeight}
                 showToday={true}
-                accessibleUnit="op/s"
+                accessibleDataTable={{ display: true, unit: 'op/s' }}
                 data={[
                   {
                     borderColor: 'transparent',

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
@@ -139,7 +139,7 @@ const TablesPanel = () => {
             ariaLabel="Connections Graph"
             timezone={timezone}
             showToday={true}
-            accessibleDataTable={{ display: true, unit: 'CXN/s' }}
+            accessibleDataTable={{ unit: 'CXN/s' }}
             data={[
               {
                 label: 'Connections',
@@ -208,7 +208,7 @@ const TablesPanel = () => {
             ariaLabel="Traffic Graph"
             timezone={timezone}
             showToday={true}
-            accessibleDataTable={{ display: true, unit: 'bits/s' }}
+            accessibleDataTable={{ unit: 'bits/s' }}
             data={[
               {
                 label: 'Traffic In',

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
@@ -139,7 +139,7 @@ const TablesPanel = () => {
             ariaLabel="Connections Graph"
             timezone={timezone}
             showToday={true}
-            accessibleUnit="CXN/s"
+            accessibleDataTable={{ display: true, unit: 'CXN/s' }}
             data={[
               {
                 label: 'Connections',
@@ -208,7 +208,7 @@ const TablesPanel = () => {
             ariaLabel="Traffic Graph"
             timezone={timezone}
             showToday={true}
-            accessibleUnit="bits/s"
+            accessibleDataTable={{ display: true, unit: 'bits/s' }}
             data={[
               {
                 label: 'Traffic In',

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
@@ -139,6 +139,7 @@ const TablesPanel = () => {
             ariaLabel="Connections Graph"
             timezone={timezone}
             showToday={true}
+            accessibleUnit="CXN/s"
             data={[
               {
                 label: 'Connections',
@@ -207,6 +208,7 @@ const TablesPanel = () => {
             ariaLabel="Traffic Graph"
             timezone={timezone}
             showToday={true}
+            accessibleUnit="bits/s"
             data={[
               {
                 label: 'Traffic In',

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/TransferHistory.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/TransferHistory.tsx
@@ -183,6 +183,7 @@ export const TransferHistory: React.FC<Props> = (props) => {
         timezone={profile?.timezone ?? 'UTC'}
         chartHeight={190}
         unit={`/s`}
+        accessibleUnit="Kb/s"
         formatData={convertNetworkData}
         formatTooltip={formatTooltip}
         showToday={true}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/TransferHistory.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/TransferHistory.tsx
@@ -183,7 +183,7 @@ export const TransferHistory: React.FC<Props> = (props) => {
         timezone={profile?.timezone ?? 'UTC'}
         chartHeight={190}
         unit={`/s`}
-        accessibleUnit="Kb/s"
+        accessibleDataTable={{ display: true, unit: 'Kb/s' }}
         formatData={convertNetworkData}
         formatTooltip={formatTooltip}
         showToday={true}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/TransferHistory.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/TransferHistory.tsx
@@ -183,7 +183,7 @@ export const TransferHistory: React.FC<Props> = (props) => {
         timezone={profile?.timezone ?? 'UTC'}
         chartHeight={190}
         unit={`/s`}
-        accessibleDataTable={{ display: true, unit: 'Kb/s' }}
+        accessibleDataTable={{ unit: 'Kb/s' }}
         formatData={convertNetworkData}
         formatTooltip={formatTooltip}
         showToday={true}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -158,7 +158,7 @@ const LinodeSummary: React.FC<Props> = (props) => {
     return (
       <LineGraph
         ariaLabel="CPU Usage Graph"
-        accessibleUnit="%"
+        accessibleDataTable={{ display: true, unit: '%' }}
         timezone={timezone}
         chartHeight={chartHeight}
         showToday={rangeSelection === '24'}
@@ -191,7 +191,7 @@ const LinodeSummary: React.FC<Props> = (props) => {
     return (
       <LineGraph
         ariaLabel="Disk I/O Graph"
-        accessibleUnit="blocks/s"
+        accessibleDataTable={{ display: true, unit: 'blocks/s' }}
         timezone={timezone}
         chartHeight={chartHeight}
         showToday={rangeSelection === '24'}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -158,6 +158,7 @@ const LinodeSummary: React.FC<Props> = (props) => {
     return (
       <LineGraph
         ariaLabel="CPU Usage Graph"
+        accessibleUnit="%"
         timezone={timezone}
         chartHeight={chartHeight}
         showToday={rangeSelection === '24'}
@@ -190,6 +191,7 @@ const LinodeSummary: React.FC<Props> = (props) => {
     return (
       <LineGraph
         ariaLabel="Disk I/O Graph"
+        accessibleUnit="blocks/s"
         timezone={timezone}
         chartHeight={chartHeight}
         showToday={rangeSelection === '24'}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -158,7 +158,7 @@ const LinodeSummary: React.FC<Props> = (props) => {
     return (
       <LineGraph
         ariaLabel="CPU Usage Graph"
-        accessibleDataTable={{ display: true, unit: '%' }}
+        accessibleDataTable={{ unit: '%' }}
         timezone={timezone}
         chartHeight={chartHeight}
         showToday={rangeSelection === '24'}
@@ -191,7 +191,7 @@ const LinodeSummary: React.FC<Props> = (props) => {
     return (
       <LineGraph
         ariaLabel="Disk I/O Graph"
-        accessibleDataTable={{ display: true, unit: 'blocks/s' }}
+        accessibleDataTable={{ unit: 'blocks/s' }}
         timezone={timezone}
         chartHeight={chartHeight}
         showToday={rangeSelection === '24'}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraphs.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraphs.tsx
@@ -257,7 +257,7 @@ const Graph: React.FC<GraphProps> = (props) => {
       timezone={timezone}
       chartHeight={chartHeight}
       unit={`/s`}
-      accessibleDataTable={{ display: true, unit: 'Kb/s' }}
+      accessibleDataTable={{ unit: 'Kb/s' }}
       formatData={convertNetworkData}
       formatTooltip={_formatTooltip}
       showToday={rangeSelection === '24'}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraphs.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraphs.tsx
@@ -257,7 +257,7 @@ const Graph: React.FC<GraphProps> = (props) => {
       timezone={timezone}
       chartHeight={chartHeight}
       unit={`/s`}
-      accessibleUnit="Kb/s"
+      accessibleDataTable={{ display: true, unit: 'Kb/s' }}
       formatData={convertNetworkData}
       formatTooltip={_formatTooltip}
       showToday={rangeSelection === '24'}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraphs.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/NetworkGraphs.tsx
@@ -257,6 +257,7 @@ const Graph: React.FC<GraphProps> = (props) => {
       timezone={timezone}
       chartHeight={chartHeight}
       unit={`/s`}
+      accessibleUnit="Kb/s"
       formatData={convertNetworkData}
       formatTooltip={_formatTooltip}
       showToday={rangeSelection === '24'}


### PR DESCRIPTION
## Description 📝
Apart from a general description as to what the chart is representing, there's is currently no information details available to screen readers users. This is an accessibility issue described in M3-5915.

This PR attempts to improve this limitation by adding a visually hidden data table to each line chart. Please refer to the self review for implementation details as well as the code inline comments.

This PR follows the [accessibility guidelines for the canvas element](https://pauljadam.com/demos/canvas.html).

Note: this only targets `<Linegraphs />` and does not address Longview graphs (I added a separate M3-6517 ticket for those, which is lower priority).

## Preview 📷
There is no visual change associated with this PR

## How to test 🧪
A few ways this PR should be tested.

1. Use an accessibility tool to inspect the new data tables for various graphs
2. Inspect the tables visually (locally) by removing the `sx={visuallyHidden}` prop at https://github.com/abailly-akamai/manager/blob/d09521ff8b924106c05a29df8a19d962f68c35a9/packages/manager/src/components/LineGraph/AccessibleGraphData.tsx#L77 - make sure the filters are working for the tabled data as well.
3. Use the PR preview link to inspect that page performance isn't affected by much, and that graphs that rely on pagination also get their data tables re-rendered.  (ex: /linodes/[id]/networking)
