### PR TITLE
refactor: [M3-5181] - RQify Events

### DIFF
--- a/packages/manager/src/queries/events.ts
+++ b/packages/manager/src/queries/events.ts
@@ -1,16 +1,29 @@
 import { APIError } from '@linode/api-v4/lib/types';
 import { QueryClient, useQuery, useQueryClient } from 'react-query';
-import { Entity, Event } from '@linode/api-v4/lib/account';
-import { requestEvents } from 'src/events';
+import { Entity, Event, getEvents } from '@linode/api-v4/lib/account';
 import { useEffect } from 'react';
+import { generatePollingFilter } from 'src/utilities/requestFilters';
+import { DateTime } from 'luxon';
+import { ISO_DATETIME_NO_TZ_FORMAT } from 'src/constants';
+import {
+  isCompletedEvent,
+  isInProgressEvent,
+  isLongPendingEvent,
+  mostRecentCreated,
+  updateEvents,
+} from 'src/store/events/event.helpers';
+import { parseAPIDate } from 'src/utilities/date';
+import { events } from 'src/__data__/events';
 
 export interface EventsState {
   events: ExtendedEvent[];
-  mostRecentEventTime: number;
-  countUnseenEvents: number;
-  inProgressEvents: Record<number, number>;
-  pollingInterval: number;
-  requestDeadline: number;
+  mostRecentEventTime: number | undefined;
+  unseenEventsCount: number;
+
+  /**
+   * Map from Event ID to percentage complete.
+   */
+  inProgressEvents: Map<number, number>;
 }
 
 export interface ExtendedEvent extends Event {
@@ -37,27 +50,162 @@ const dispatchEvents = (
 
 const eventsCacheKey = [queryKey, 'cache'];
 export const useEventsPolling = (
-  eventHandler: (event: ExtendedEvent) => void
+  eventHandler?: (event: ExtendedEvent) => void
 ) => {
   const queryClient = useQueryClient();
 
   const eventHandlers = getEventHandlers(queryClient);
-  useEffect(() => {
-    eventHandlers.add(eventHandler);
-    return () => {
-      eventHandlers.delete(eventHandler);
-    };
-  }, [eventHandler, eventHandlers]);
+  useEffect(
+    () =>
+      eventHandler &&
+      (eventHandlers.add(eventHandler),
+      () => {
+        eventHandlers.delete(eventHandler);
+      }),
+    [eventHandler, eventHandlers]
+  );
 
-  return useQuery<EventsState, APIError[]>(eventsCacheKey, async () => {
-    const eventsCache = queryClient.getQueryData<EventsState>(queryKey);
-    const { eventsState, newEvents } = await requestEvents(eventsCache);
-    dispatchEvents(newEvents, eventHandlers);
-    return eventsState;
-  });
+  return useQuery<EventsState, APIError[]>(
+    eventsCacheKey,
+    async () => {
+      const eventsStateCache = queryClient.getQueryData<EventsState>(queryKey);
+      const { eventsState, newEvents } = await requestEvents(eventsStateCache);
+      dispatchEvents(newEvents, eventHandlers);
+      return eventsState;
+    },
+    {
+      refetchInterval: 5000,
+      retryDelay: 5000,
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+    }
+  );
 };
 
 const eventHandlersKey = [queryKey, 'handlers'];
 const getEventHandlers = (queryClient: QueryClient) =>
   queryClient.getQueryData<Set<EventHandler>>(eventHandlersKey) ??
   queryClient.setQueryData<Set<EventHandler>>(eventHandlersKey, new Set());
+
+/**
+ * Will send a filtered request for events which have been created on or after the most recent existing
+ * event or the epoch if there are no stored events. Exclude events already in memory with a "+neq" filter.
+ */
+const requestEvents = (
+  eventsStateCache: EventsState | undefined
+): Promise<{
+  eventsState: EventsState;
+  newEvents: ExtendedEvent[];
+}> =>
+  getEvents(
+    { page_size: 25 },
+    eventsStateCache && createEventsFilter(eventsStateCache)
+  )
+    .then((response) => response.data)
+    /**
+     * There is where we set _initial on the events. In the default state of events the
+     * mostRecentEventTime is set to epoch. On the completion of the first successful events
+     * update the mostRecentEventTime is updated, meaning it's impossible for subsequent events
+     * to be incorrectly marked as _initial. This addresses our reappearing toast issue.
+     */
+    .then((events) =>
+      events.map((e) => ({ ...e, _initial: eventsStateCache === undefined }))
+    )
+    .then((events) => ({
+      eventsState: updateEventsState(eventsStateCache, events),
+      newEvents: events,
+    }));
+
+const createEventsFilter = (eventsStateCache: EventsState) => {
+  const {
+    mostRecentEventTime,
+    inProgressEvents,
+    events: _events,
+  } = eventsStateCache;
+
+  // Regardless of date created, we request events that are still in-progress.
+  const inIds = Object.keys(inProgressEvents).map((thisId) => +thisId);
+
+  // We need to keep polling the event for any database that is still creating.
+  // The same event will change its status from `notification` to `finished`.
+  const databaseEventIds = _events
+    .filter(
+      (event) =>
+        event.action === 'database_create' && event.status === 'notification'
+    )
+    .map((event) => event.id);
+
+  const includeIds = [...inIds, ...databaseEventIds];
+
+  // Generate a list of event IDs for the "+neq" filter. We want to request events created
+  // on or after the most recent created date, minus any events we've already requested.
+  // This is to catch any events that may be "lost" if the request/query lands at just the
+  // right moment such that we receive some events with a specific created date, but not all.
+  const neqIds: number[] = [];
+  if (_events.length > 0) {
+    _events.forEach((thisEvent) => {
+      const thisEventCreated = parseAPIDate(thisEvent.created).valueOf();
+
+      if (
+        thisEventCreated === mostRecentEventTime &&
+        !isInProgressEvent(thisEvent) &&
+        !isLongPendingEvent(thisEvent)
+      ) {
+        neqIds.push(thisEvent.id);
+      }
+    });
+  }
+
+  return generatePollingFilter(
+    DateTime.fromMillis(mostRecentEventTime ?? 0, { zone: 'utc' }).toFormat(
+      ISO_DATETIME_NO_TZ_FORMAT
+    ),
+    includeIds,
+    neqIds
+  );
+};
+
+const updateEventsState = (
+  eventsStateCache: EventsState | undefined,
+  newEvents: ExtendedEvent[]
+): EventsState => {
+  const updatedEvents = updateEvents(eventsStateCache?.events ?? [], newEvents);
+  return {
+    events: updatedEvents,
+    mostRecentEventTime: events.reduce(
+      mostRecentCreated,
+      eventsStateCache?.mostRecentEventTime
+    ),
+    unseenEventsCount: getNumUnseenEvents(updatedEvents),
+    inProgressEvents: updateInProgressEvents(
+      eventsStateCache?.inProgressEvents ?? new Map(),
+      events
+    ),
+  };
+};
+
+/**
+ * Iterate through new events.
+ * If an event is "in-progress" it's added to the inProgressEvents map.
+ * If an event is "completed" it is removed from the inProgressEvents map.
+ * Otherwise the inProgressEvents is unchanged.
+ */
+export const updateInProgressEvents = (
+  inProgressEvents: Map<number, number>,
+  events: Event[]
+) => {
+  return events.reduce((acc, e) => {
+    if (isCompletedEvent(e)) {
+      const updatedMap = new Map(acc);
+      updatedMap.delete(e.id);
+      return updatedMap;
+    }
+
+    return isInProgressEvent(e)
+      ? new Map(acc).set(e.id, e.percent_complete)
+      : acc;
+  }, inProgressEvents);
+};
+
+export const getNumUnseenEvents = (events: Pick<Event, 'seen'>[]) =>
+  events.reduce((result, event) => (event.seen ? result : result + 1), 0);

--- a/packages/manager/src/queries/events.ts
+++ b/packages/manager/src/queries/events.ts
@@ -1,0 +1,63 @@
+import { APIError } from '@linode/api-v4/lib/types';
+import { QueryClient, useQuery, useQueryClient } from 'react-query';
+import { Entity, Event } from '@linode/api-v4/lib/account';
+import { requestEvents } from 'src/events';
+import { useEffect } from 'react';
+
+export interface EventsState {
+  events: ExtendedEvent[];
+  mostRecentEventTime: number;
+  countUnseenEvents: number;
+  inProgressEvents: Record<number, number>;
+  pollingInterval: number;
+  requestDeadline: number;
+}
+
+export interface ExtendedEvent extends Event {
+  _deleted?: string;
+  _initial?: boolean;
+}
+
+export interface EntityEvent extends Omit<Event, 'entity'> {
+  entity: Entity;
+}
+
+export const queryKey = 'events';
+
+export type EventHandler = (event: ExtendedEvent) => void;
+
+const dispatchEvents = (
+  events: ExtendedEvent[],
+  eventHandlers: Set<EventHandler>
+) => {
+  events.forEach((event) =>
+    Array.from(eventHandlers.values()).forEach((handler) => handler(event))
+  );
+};
+
+const eventsCacheKey = [queryKey, 'cache'];
+export const useEventsPolling = (
+  eventHandler: (event: ExtendedEvent) => void
+) => {
+  const queryClient = useQueryClient();
+
+  const eventHandlers = getEventHandlers(queryClient);
+  useEffect(() => {
+    eventHandlers.add(eventHandler);
+    return () => {
+      eventHandlers.delete(eventHandler);
+    };
+  }, [eventHandler, eventHandlers]);
+
+  return useQuery<EventsState, APIError[]>(eventsCacheKey, async () => {
+    const eventsCache = queryClient.getQueryData<EventsState>(queryKey);
+    const { eventsState, newEvents } = await requestEvents(eventsCache);
+    dispatchEvents(newEvents, eventHandlers);
+    return eventsState;
+  });
+};
+
+const eventHandlersKey = [queryKey, 'handlers'];
+const getEventHandlers = (queryClient: QueryClient) =>
+  queryClient.getQueryData<Set<EventHandler>>(eventHandlersKey) ??
+  queryClient.setQueryData<Set<EventHandler>>(eventHandlersKey, new Set());

--- a/packages/manager/src/store/events/event.helpers.ts
+++ b/packages/manager/src/store/events/event.helpers.ts
@@ -123,11 +123,11 @@ export const updateEvents = compose(
  *
  */
 export const mostRecentCreated = (
-  latestTime: number,
+  latestTime: number | undefined,
   current: Pick<Event, 'created'>
 ) => {
   const time: number = parseAPIDate(current.created).valueOf(); // Unix time (milliseconds)
-  return latestTime > time ? latestTime : time;
+  return latestTime !== undefined && latestTime > time ? latestTime : time;
 };
 
 /**
@@ -153,7 +153,9 @@ export const isLongPendingEvent = (event: Event): boolean => {
   return status === 'scheduled' && action === 'image_upload';
 };
 
-export const isInProgressEvent = (event: Event) => {
+export const isInProgressEvent = (
+  event: Event
+): event is Event & { percent_complete: number } => {
   const { percent_complete } = event;
   if (percent_complete === null || isLongPendingEvent(event)) {
     return false;

--- a/packages/manager/src/store/events/event.reducer.ts
+++ b/packages/manager/src/store/events/event.reducer.ts
@@ -33,7 +33,10 @@ export const defaultState: State = {
   requestDeadline: Date.now(),
 };
 
-const reducer: Reducer<State> = (state = defaultState, action: AnyAction) => {
+const reducer: Reducer<State> = (
+  state = defaultState,
+  action: AnyAction
+): State => {
   if (isType(action, addEvents)) {
     const { payload: events } = action;
     const {
@@ -46,10 +49,8 @@ const reducer: Reducer<State> = (state = defaultState, action: AnyAction) => {
     return {
       ...state,
       events: updatedEvents,
-      mostRecentEventTime: events.reduce(
-        mostRecentCreated,
-        mostRecentEventTime
-      ),
+      mostRecentEventTime:
+        events.reduce(mostRecentCreated, mostRecentEventTime) ?? 0,
       countUnseenEvents: getNumUnseenEvents(updatedEvents),
       inProgressEvents: updateInProgressEvents(prevInProgressEvents, events),
     };


### PR DESCRIPTION
## Description 📝
This PR migrates all Events endpoints to two React Query hooks (`useEvents` for fetching event notifications and `useEventsPolling` for registering event handlers) while hugely simplifying the current implementation.

The current Redux-based events system in Cloud Manager is pretty complex, making it difficult to understand and develop. Functionality is defined across several files, including `events.ts`, `eventsPolling.ts`, `event.request.ts`, `event.reducer.ts`, `event.actions.ts` and `event.helpers.ts`. Event handlers are used for important app functions like snackbar/toasts and cache invalidation but are defined via two redundant mechanisms (an rxjs subject and a custom Redux middleware).

The current system handles a lot of considerations and edge cases that must be accounted for:

- Polling rate backoff to minimize API load
- Increasing polling during background operations
- Updates to in-progress events
- Avoiding 'replaying' previously seen events
- Separate read statuses for separate users under a single account

The plan is to reduce complexity by consolidating all Events-related functionality to these two hooks, remove the singular usage of the rxjs library and leverage the API-provided `seen` and `read` flags on events to avoid the complicated logic needed for maintaining an up-to-date events store.

<!--
## Major Changes 🔄
**List highlighting major changes**
- Change #1
- Change #2

## Preview 📷
**Include a screenshot or screen recording of the change**

> **Note**: Use `<video src="" />` tag when including recordings in table

| Before  | After   |
| ------- | ------- |
| Content | Content |

## How to test 🧪
1. **How to setup test environment?**
2. **How to reproduce the issue (if applicable)?**
3. **How to verify changes?**
4. **How to run Unit or E2E tests?**
-->