### PR TITLE
fix: `firewallRuleEditor.test.ts` failure

### DIFF
--- a/packages/api-v4/src/firewalls/types.ts
+++ b/packages/api-v4/src/firewalls/types.ts
@@ -24,8 +24,8 @@ export interface FirewallRules {
 }
 
 export interface FirewallRuleType {
-  label?: string;
-  description?: string;
+  label?: string | null;
+  description?: string | null;
   protocol: FirewallRuleProtocol;
   ports?: string;
   action: FirewallPolicyType;

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.tsx
@@ -150,11 +150,15 @@ const FirewallRuleDrawer: React.FC<CombinedProps> = (props) => {
       action: values.action,
     };
 
-    if (values.label) {
+    if (values.label === '') {
+      payload.label = null;
+    } else {
       payload.label = values.label;
     }
 
-    if (values.description) {
+    if (values.description === '') {
+      payload.description = null;
+    } else {
       payload.description = values.description;
     }
 

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleTable.tsx
@@ -132,8 +132,8 @@ const sxItemSpacing = {
 
 interface RuleRow {
   type: string;
-  label?: string;
-  description?: string;
+  label?: string | null;
+  description?: string | null;
   action?: string;
   protocol: string;
   ports: string;
@@ -298,7 +298,10 @@ const FirewallRuleTable: React.FC<CombinedProps> = (props) => {
                             key={thisRuleRow.id}
                             role="option"
                             ref={provided.innerRef}
-                            aria-label={thisRuleRow.label}
+                            aria-label={
+                              thisRuleRow.label ??
+                              `firewall rule ${thisRuleRow.id}`
+                            }
                             aria-selected={false}
                             aria-roledescription={screenReaderMessage}
                             {...provided.draggableProps}
@@ -384,7 +387,7 @@ const FirewallRuleTableRow: React.FC<FirewallRuleTableRowProps> = React.memo(
     return (
       <Box
         key={id}
-        aria-label={label}
+        aria-label={label ?? `firewall rule ${id}`}
         className={classNames({
           [classes.ruleGrid]: true,
           [classes.ruleRow]: true,

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/firewallRuleEditor.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/firewallRuleEditor.ts
@@ -126,14 +126,6 @@ const ruleEditorReducer = (
       // Errors might no longer apply to the modified rule, so we delete them.
       delete lastRevision.errors;
 
-      // if (!action.modifiedRule.label) {
-      //   delete lastRevision.label;
-      // }
-
-      // if (!action.modifiedRule.description) {
-      //   delete lastRevision.description;
-      // }
-
       draft[action.idx].push({
         ...lastRevision,
         ...action.modifiedRule,

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/firewallRuleEditor.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/firewallRuleEditor.ts
@@ -126,13 +126,13 @@ const ruleEditorReducer = (
       // Errors might no longer apply to the modified rule, so we delete them.
       delete lastRevision.errors;
 
-      if (!action.modifiedRule.label) {
-        delete lastRevision.label;
-      }
+      // if (!action.modifiedRule.label) {
+      //   delete lastRevision.label;
+      // }
 
-      if (!action.modifiedRule.description) {
-        delete lastRevision.description;
-      }
+      // if (!action.modifiedRule.description) {
+      //   delete lastRevision.description;
+      // }
 
       draft[action.idx].push({
         ...lastRevision,


### PR DESCRIPTION
## Description 📝

- Fixes `firewallRuleEditor.test.ts` failing caused by changes in #9017 

## Major Changes 🔄
- Makes api-v4 types accurate
- Improves handling of `label` and `description`

## How to test 🧪

- `yarn test firewallRuleEditor.test.ts`
- Thoroughly test the firewalls rule editor
  - Specifically test the functionality of creating rules, editing rules, and discarding changes.
  - Specifically test the `label` and `description` fields and their behavior