### PR TITLE
refactor: [M3-6300] - MUI v5 Migration - `Components > CheckoutBar` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - MUIv5 Migration - `Components > DateTimeDisplay, DebouncedSearchTextField` #9007
 - MUIv5 Migration - `SRC > Components > ConfirmationDialog` #9016
 - MUIv5 Migration - `SRC > Components > CopyTooltip` #9040
-- - MUIv5 Migration - `SRC > Components > CopyTooltip` #9040
+- MUIv5 Migration - `SRC > Components > CopyTooltip` #9040
+- MUIv5 Migration - `SRC > Components > CheckoutBar` #9051
 - Add basic Adobe Analytics tracking #8989
 
 ## [2023-04-18] - v1.91.1

--- a/packages/manager/src/components/CheckoutBar/CheckoutBar.tsx
+++ b/packages/manager/src/components/CheckoutBar/CheckoutBar.tsx
@@ -4,7 +4,7 @@ import Typography from 'src/components/core/Typography';
 import { DisplayPrice } from 'src/components/DisplayPrice';
 import { StyledButton, StyledDiv1, StyledDiv2, SxTypography } from './styles';
 
-interface Props {
+interface CheckoutBarProps {
   onDeploy: () => void;
   heading: string;
   calculatedPrice?: number;
@@ -17,7 +17,7 @@ interface Props {
   agreement?: JSX.Element;
 }
 
-const CheckoutBar = (props: Props) => {
+const CheckoutBar = (props: CheckoutBarProps) => {
   const {
     onDeploy,
     heading,

--- a/packages/manager/src/components/CheckoutBar/CheckoutBar.tsx
+++ b/packages/manager/src/components/CheckoutBar/CheckoutBar.tsx
@@ -2,8 +2,7 @@ import { useTheme } from '@mui/material/styles';
 import * as React from 'react';
 import Typography from 'src/components/core/Typography';
 import { DisplayPrice } from 'src/components/DisplayPrice';
-import { fadeIn } from 'src/styles/keyframes';
-import { StyledButton, StyledDiv1, StyledDiv2 } from './styles';
+import { StyledButton, StyledDiv1, StyledDiv2, SxTypography } from './styles';
 
 interface Props {
   onDeploy: () => void;
@@ -51,20 +50,12 @@ const CheckoutBar = (props: Props) => {
       </Typography>
       {children}
       {
-        <StyledDiv2
-          sx={{
-            animation: `${fadeIn} 225ms linear forwards`,
-            opacity: 0,
-          }}
-          data-qa-total-price
-        >
+        <StyledDiv2 data-qa-total-price>
           <DisplayPrice price={price} interval="mo" />
           {priceHelperText && price > 0 && (
             <Typography
               sx={{
-                color: theme.color.headline,
-                fontSize: '.8rem',
-                lineHeight: '1.5em',
+                ...SxTypography,
                 marginTop: theme.spacing(),
               }}
             >

--- a/packages/manager/src/components/CheckoutBar/CheckoutBar.tsx
+++ b/packages/manager/src/components/CheckoutBar/CheckoutBar.tsx
@@ -2,7 +2,12 @@ import { useTheme } from '@mui/material/styles';
 import * as React from 'react';
 import Typography from 'src/components/core/Typography';
 import { DisplayPrice } from 'src/components/DisplayPrice';
-import { StyledButton, StyledDiv1, StyledDiv2, SxTypography } from './styles';
+import {
+  StyledButton,
+  StyledCheckoutSection,
+  StyledRoot,
+  SxTypography,
+} from './styles';
 
 interface CheckoutBarProps {
   onDeploy: () => void;
@@ -36,7 +41,7 @@ const CheckoutBar = (props: CheckoutBarProps) => {
   const price = calculatedPrice ?? 0;
 
   return (
-    <StyledDiv1>
+    <StyledRoot>
       <Typography
         variant="h2"
         sx={{
@@ -50,7 +55,7 @@ const CheckoutBar = (props: CheckoutBarProps) => {
       </Typography>
       {children}
       {
-        <StyledDiv2 data-qa-total-price>
+        <StyledCheckoutSection data-qa-total-price>
           <DisplayPrice price={price} interval="mo" />
           {priceHelperText && price > 0 && (
             <Typography
@@ -62,10 +67,10 @@ const CheckoutBar = (props: CheckoutBarProps) => {
               {priceHelperText}
             </Typography>
           )}
-        </StyledDiv2>
+        </StyledCheckoutSection>
       }
       {agreement ? agreement : null}
-      <StyledDiv2>
+      <StyledCheckoutSection>
         <StyledButton
           buttonType="primary"
           disabled={disabled}
@@ -75,9 +80,9 @@ const CheckoutBar = (props: CheckoutBarProps) => {
         >
           {submitText ?? 'Create'}
         </StyledButton>
-      </StyledDiv2>
+      </StyledCheckoutSection>
       {footer ? footer : null}
-    </StyledDiv1>
+    </StyledRoot>
   );
 };
 

--- a/packages/manager/src/components/CheckoutBar/CheckoutBar.tsx
+++ b/packages/manager/src/components/CheckoutBar/CheckoutBar.tsx
@@ -1,8 +1,9 @@
+import { useTheme } from '@mui/material/styles';
 import * as React from 'react';
-import Button from 'src/components/Button';
 import Typography from 'src/components/core/Typography';
 import { DisplayPrice } from 'src/components/DisplayPrice';
-import useStyles from './styles';
+import { fadeIn } from 'src/styles/keyframes';
+import { StyledButton, StyledDiv1, StyledDiv2 } from './styles';
 
 interface Props {
   onDeploy: () => void;
@@ -17,11 +18,7 @@ interface Props {
   agreement?: JSX.Element;
 }
 
-type CombinedProps = Props;
-
-const CheckoutBar: React.FC<CombinedProps> = (props) => {
-  const classes = useStyles();
-
+const CheckoutBar = (props: Props) => {
   const {
     onDeploy,
     heading,
@@ -32,44 +29,65 @@ const CheckoutBar: React.FC<CombinedProps> = (props) => {
     submitText,
     footer,
     agreement,
+    children,
   } = props;
+
+  const theme = useTheme();
 
   const price = calculatedPrice ?? 0;
 
   return (
-    <div className={classes.root}>
+    <StyledDiv1>
       <Typography
         variant="h2"
-        className={classes.sidebarTitle}
+        sx={{
+          color: theme.color.headline,
+          fontSize: '1.125rem',
+          wordBreak: 'break-word',
+        }}
         data-qa-order-summary
       >
         {heading}
       </Typography>
-      {props.children}
+      {children}
       {
-        <div className={classes.checkoutSection} data-qa-total-price>
+        <StyledDiv2
+          sx={{
+            animation: `${fadeIn} 225ms linear forwards`,
+            opacity: 0,
+          }}
+          data-qa-total-price
+        >
           <DisplayPrice price={price} interval="mo" />
           {priceHelperText && price > 0 && (
-            <Typography className={classes.price}>{priceHelperText}</Typography>
+            <Typography
+              sx={{
+                color: theme.color.headline,
+                fontSize: '.8rem',
+                lineHeight: '1.5em',
+                marginTop: theme.spacing(),
+              }}
+            >
+              {priceHelperText}
+            </Typography>
           )}
-        </div>
+        </StyledDiv2>
       }
       {agreement ? agreement : null}
-      <div className={classes.checkoutSection}>
-        <Button
+      <StyledDiv2>
+        <StyledButton
           buttonType="primary"
-          className={classes.createButton}
           disabled={disabled}
           onClick={onDeploy}
           data-qa-deploy-linode
           loading={isMakingRequest}
         >
           {submitText ?? 'Create'}
-        </Button>
-      </div>
+        </StyledButton>
+      </StyledDiv2>
       {footer ? footer : null}
-    </div>
+    </StyledDiv1>
   );
 };
 
-export default CheckoutBar;
+export { CheckoutBar };

--- a/packages/manager/src/components/CheckoutBar/DisplaySection.tsx
+++ b/packages/manager/src/components/CheckoutBar/DisplaySection.tsx
@@ -1,7 +1,6 @@
-import { useTheme } from '@mui/material/styles';
 import * as React from 'react';
 import Typography from 'src/components/core/Typography';
-import { StyledDiv2 } from './styles';
+import { StyledDiv2, SxTypography } from './styles';
 
 export interface Props {
   title: string;
@@ -10,8 +9,6 @@ export interface Props {
 
 const DisplaySection = React.memo((props: Props) => {
   const { title, details } = props;
-
-  const theme = useTheme();
 
   return (
     <StyledDiv2>
@@ -24,11 +21,7 @@ const DisplaySection = React.memo((props: Props) => {
         <Typography
           component="span"
           data-qa-details={details}
-          sx={{
-            color: theme.color.headline,
-            fontSize: '.8rem',
-            lineHeight: '1.5em',
-          }}
+          sx={SxTypography}
         >
           {details}
         </Typography>

--- a/packages/manager/src/components/CheckoutBar/DisplaySection.tsx
+++ b/packages/manager/src/components/CheckoutBar/DisplaySection.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Typography from 'src/components/core/Typography';
-import { StyledDiv2, SxTypography } from './styles';
+import { StyledCheckoutSection, SxTypography } from './styles';
 
 export interface DisplaySectionProps {
   title: string;
@@ -11,7 +11,7 @@ const DisplaySection = React.memo((props: DisplaySectionProps) => {
   const { title, details } = props;
 
   return (
-    <StyledDiv2>
+    <StyledCheckoutSection>
       {title && (
         <Typography variant="h3" data-qa-subheading={title}>
           {title}
@@ -26,7 +26,7 @@ const DisplaySection = React.memo((props: DisplaySectionProps) => {
           {details}
         </Typography>
       ) : null}
-    </StyledDiv2>
+    </StyledCheckoutSection>
   );
 });
 

--- a/packages/manager/src/components/CheckoutBar/DisplaySection.tsx
+++ b/packages/manager/src/components/CheckoutBar/DisplaySection.tsx
@@ -2,12 +2,12 @@ import * as React from 'react';
 import Typography from 'src/components/core/Typography';
 import { StyledDiv2, SxTypography } from './styles';
 
-export interface Props {
+export interface DisplaySectionProps {
   title: string;
   details?: string | number;
 }
 
-const DisplaySection = React.memo((props: Props) => {
+const DisplaySection = React.memo((props: DisplaySectionProps) => {
   const { title, details } = props;
 
   return (

--- a/packages/manager/src/components/CheckoutBar/DisplaySection.tsx
+++ b/packages/manager/src/components/CheckoutBar/DisplaySection.tsx
@@ -1,33 +1,40 @@
+import { useTheme } from '@mui/material/styles';
 import * as React from 'react';
 import Typography from 'src/components/core/Typography';
-import useStyles from './styles';
+import { StyledDiv2 } from './styles';
 
 export interface Props {
   title: string;
   details?: string | number;
 }
 
-export const DisplaySection: React.FC<Props> = (props) => {
+const DisplaySection = React.memo((props: Props) => {
   const { title, details } = props;
-  const classes = useStyles();
+
+  const theme = useTheme();
+
   return (
-    <div className={classes.checkoutSection}>
+    <StyledDiv2>
       {title && (
         <Typography variant="h3" data-qa-subheading={title}>
           {title}
         </Typography>
       )}
-      {details && (
+      {details ? (
         <Typography
           component="span"
           data-qa-details={details}
-          className={classes.detail}
+          sx={{
+            color: theme.color.headline,
+            fontSize: '.8rem',
+            lineHeight: '1.5em',
+          }}
         >
           {details}
         </Typography>
-      )}
-    </div>
+      ) : null}
+    </StyledDiv2>
   );
-};
+});
 
-export default React.memo(DisplaySection);
+export { DisplaySection };

--- a/packages/manager/src/components/CheckoutBar/DisplaySectionList.tsx
+++ b/packages/manager/src/components/CheckoutBar/DisplaySectionList.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import Divider from '../core/Divider';
-import DisplaySection from './DisplaySection';
+import { DisplaySection } from './DisplaySection';
 
 interface Props {
   displaySections?: { title: string; details?: string | number }[];
 }
 
-export const DisplaySectionList: React.FC<Props> = ({ displaySections }) => {
+const DisplaySectionList = ({ displaySections }: Props) => {
   if (!displaySections) {
     return null;
   }
@@ -27,4 +27,4 @@ export const DisplaySectionList: React.FC<Props> = ({ displaySections }) => {
   );
 };
 
-export default DisplaySectionList;
+export { DisplaySectionList };

--- a/packages/manager/src/components/CheckoutBar/DisplaySectionList.tsx
+++ b/packages/manager/src/components/CheckoutBar/DisplaySectionList.tsx
@@ -2,11 +2,11 @@ import * as React from 'react';
 import Divider from '../core/Divider';
 import { DisplaySection } from './DisplaySection';
 
-interface Props {
+interface DisplaySectionListProps {
   displaySections?: { title: string; details?: string | number }[];
 }
 
-const DisplaySectionList = ({ displaySections }: Props) => {
+const DisplaySectionList = ({ displaySections }: DisplaySectionListProps) => {
   if (!displaySections) {
     return null;
   }

--- a/packages/manager/src/components/CheckoutBar/index.ts
+++ b/packages/manager/src/components/CheckoutBar/index.ts
@@ -1,4 +1,0 @@
-import CheckoutBar from './CheckoutBar';
-export { default as DisplaySection } from './DisplaySection';
-export { default as DisplaySectionList } from './DisplaySectionList';
-export default CheckoutBar;

--- a/packages/manager/src/components/CheckoutBar/styles.ts
+++ b/packages/manager/src/components/CheckoutBar/styles.ts
@@ -37,4 +37,14 @@ const StyledDiv2 = styled('div')(({ theme }) => ({
   },
 }));
 
-export { StyledButton, StyledDiv1, StyledDiv2 };
+const SxTypography = () => {
+  const theme = useTheme();
+
+  return {
+    color: theme.color.headline,
+    fontSize: '.8rem',
+    lineHeight: '1.5em',
+  };
+};
+
+export { StyledButton, StyledDiv1, StyledDiv2, SxTypography };

--- a/packages/manager/src/components/CheckoutBar/styles.ts
+++ b/packages/manager/src/components/CheckoutBar/styles.ts
@@ -1,16 +1,18 @@
-import { makeStyles } from '@mui/styles';
-import { Theme } from '@mui/material/styles';
+import { useTheme } from '@mui/material/styles';
+import { styled } from '@mui/system';
+import Button from 'src/components/Button';
 
-export const useStyles = makeStyles((theme: Theme) => ({
-  '@keyframes fadeIn': {
-    from: {
-      opacity: 0,
-    },
-    to: {
-      opacity: 1,
-    },
+const StyledButton = styled(Button)(({ theme }) => ({
+  marginTop: 18,
+  [theme.breakpoints.up('lg')]: {
+    width: '100%',
   },
-  root: {
+}));
+
+const StyledDiv1 = styled('div')(() => {
+  const theme = useTheme();
+
+  return {
     minHeight: '24px',
     minWidth: '24px',
     [theme.breakpoints.down('md')]: {
@@ -20,42 +22,19 @@ export const useStyles = makeStyles((theme: Theme) => ({
       left: '0 !important' as '0',
       bottom: '0 !important' as '0',
     },
-  },
-  sidebarTitle: {
-    color: theme.color.headline,
-    fontSize: '1.125rem',
-    wordBreak: 'break-word',
-  },
-  checkoutSection: {
-    animation: '$fadeIn 225ms linear forwards',
-    opacity: 0,
-    padding: '12px 0',
-    [theme.breakpoints.down('md')]: {
-      '& button': {
-        marginLeft: 0,
-      },
-    },
-    [theme.breakpoints.down('lg')]: {
-      paddingBottom: `0px !important`,
+  };
+});
+
+const StyledDiv2 = styled('div')(({ theme }) => ({
+  padding: '12px 0',
+  [theme.breakpoints.down('md')]: {
+    '& button': {
+      marginLeft: 0,
     },
   },
-  price: {
-    color: theme.color.headline,
-    fontSize: '.8rem',
-    lineHeight: '1.5em',
-    marginTop: theme.spacing(),
-  },
-  detail: {
-    color: theme.color.headline,
-    fontSize: '.8rem',
-    lineHeight: '1.5em',
-  },
-  createButton: {
-    marginTop: 18,
-    [theme.breakpoints.up('lg')]: {
-      width: '100%',
-    },
+  [theme.breakpoints.down('lg')]: {
+    paddingBottom: `0px !important`,
   },
 }));
 
-export default useStyles;
+export { StyledButton, StyledDiv1, StyledDiv2 };

--- a/packages/manager/src/components/CheckoutBar/styles.ts
+++ b/packages/manager/src/components/CheckoutBar/styles.ts
@@ -9,7 +9,7 @@ const StyledButton = styled(Button)(({ theme }) => ({
   },
 }));
 
-const StyledDiv1 = styled('div')(() => {
+const StyledRoot = styled('div')(() => {
   const theme = useTheme();
 
   return {
@@ -25,7 +25,7 @@ const StyledDiv1 = styled('div')(() => {
   };
 });
 
-const StyledDiv2 = styled('div')(({ theme }) => ({
+const StyledCheckoutSection = styled('div')(({ theme }) => ({
   padding: '12px 0',
   [theme.breakpoints.down('md')]: {
     '& button': {
@@ -47,4 +47,4 @@ const SxTypography = () => {
   };
 };
 
-export { StyledButton, StyledDiv1, StyledDiv2, SxTypography };
+export { StyledButton, StyledRoot, StyledCheckoutSection, SxTypography };

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/KubeCheckoutBar.tsx
@@ -1,6 +1,6 @@
 import { KubeNodePoolResponse } from '@linode/api-v4';
 import * as React from 'react';
-import CheckoutBar from 'src/components/CheckoutBar';
+import { CheckoutBar } from 'src/components/CheckoutBar/CheckoutBar';
 import { CircleProgress } from 'src/components/CircleProgress';
 import Divider from 'src/components/core/Divider';
 import Notice from 'src/components/Notice';
@@ -14,11 +14,11 @@ import { useAccount } from 'src/queries/account';
 import { useAccountAgreements } from 'src/queries/accountAgreements';
 import { useProfile } from 'src/queries/profile';
 import { useSpecificTypes } from 'src/queries/types';
+import { extendTypesQueryResult } from 'src/utilities/extendType';
 import { isEURegion } from 'src/utilities/formatRegion';
 import { getTotalClusterPrice, nodeWarning } from '../kubeUtils';
 import HACheckbox from './HACheckbox';
 import NodePoolSummary from './NodePoolSummary';
-import { extendTypesQueryResult } from 'src/utilities/extendType';
 
 export interface Props {
   pools: KubeNodePoolResponse[];


### PR DESCRIPTION
## Description 📝
Migrates `SRC > Components > CheckoutBar` from JSS to styled components.

## Major Changes 🔄
- Removed `packages/manager/src/components/CheckoutBar/index.ts`
- Made use of styled components in `CheckoutBar.tsx`, housed in `/CheckoutBar/styles.ts`

## How to test 🧪
Go to `/kubernetes/create` and ensure the checkout bar looks and functions the same as in prod.

## To-Do:
- [x] Fix total amount display bug
- [x] Some `sx` refactoring
