### PR TITLE
refactor: [M3-6217]: Refactor Domains E2E Test Intercepts

### DIFF
--- a/packages/manager/cypress/e2e/domains/smoke-create-domain-records.spec.ts
+++ b/packages/manager/cypress/e2e/domains/smoke-create-domain-records.spec.ts
@@ -2,8 +2,8 @@
 import { createDomain, deleteAllTestDomains } from 'support/api/domains';
 import { randomIp, randomLabel, randomDomainName } from 'support/util/random';
 import { fbtClick, getClick } from 'support/helpers';
-import { apiMatcher } from 'support/util/intercepts';
 import { authenticate } from 'support/api/authentication';
+import { interceptCreateDomainRecord } from 'support/intercepts/domains';
 
 const createRecords = () => [
   {
@@ -98,9 +98,7 @@ describe('Creates Domains record with Form', () => {
     return it(rec.name, () => {
       createDomain().then((domain) => {
         // intercept create api record request
-        cy.intercept('POST', apiMatcher('domains/*/record*')).as(
-          'apiCreateRecord'
-        );
+        interceptCreateDomainRecord().as('apiCreateRecord');
         const url = `/domains/${domain.id}`;
         cy.visitWithLogin(url);
         cy.url().should('contain', url);

--- a/packages/manager/cypress/e2e/domains/smoke-create-domain.spec.ts
+++ b/packages/manager/cypress/e2e/domains/smoke-create-domain.spec.ts
@@ -1,22 +1,25 @@
-import { fbtClick, fbtVisible, getClick, getVisible } from 'support/helpers';
-import { apiMatcher } from 'support/util/intercepts';
+import { Domain } from '@linode/api-v4/types';
+import { domainFactory } from '@src/factories';
+import { fbtClick, getClick, getVisible } from 'support/helpers';
+import {
+  interceptCreateDomain,
+  mockGetDomains,
+} from 'support/intercepts/domains';
 import { randomDomainName } from 'support/util/random';
 
 describe('Create a Domain', () => {
   it('Creates first Domain', () => {
-    // modify incoming response
-    cy.intercept('GET', apiMatcher('domains*'), (req) => {
-      req.reply((res) => {
-        res.send({
-          results: 0,
-          page: 1,
-          pages: 1,
-          data: [],
+    // Mock Domains to modify incoming response.
+    const mockDomains = new Array(2).fill(null).map(
+      (item: null, index: number): Domain => {
+        return domainFactory.build({
+          label: `Domain ${index}`,
         });
-      });
-    }).as('getDomains');
+      }
+    );
+    mockGetDomains(mockDomains).as('getDomains');
     // intercept create Domain request
-    cy.intercept('POST', apiMatcher('domains')).as('createDomain');
+    interceptCreateDomain().as('createDomain');
     cy.visitWithLogin('/domains');
     cy.wait('@getDomains');
     fbtClick('Create Domain');

--- a/packages/manager/cypress/support/intercepts/domains.ts
+++ b/packages/manager/cypress/support/intercepts/domains.ts
@@ -1,0 +1,36 @@
+/**
+ * @file Cypress intercepts and mocks for Domain API requests.
+ */
+
+import type { Domain } from '@linode/api-v4/types';
+import { apiMatcher } from 'support/util/intercepts';
+import { paginateResponse } from 'support/util/paginate';
+
+/**
+ * Intercepts POST request to create a Domain.
+ *
+ * @returns Cypress chainable.
+ */
+export const interceptCreateDomain = (): Cypress.Chainable<null> => {
+  return cy.intercept('POST', apiMatcher('domains'));
+};
+
+/**
+ * Intercepts GET request to mock domain data.
+ *
+ * @param domains - an array of mock domain objects
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetDomains = (domains: Domain[]): Cypress.Chainable<null> => {
+  return cy.intercept('GET', apiMatcher('domains*'), paginateResponse(domains));
+};
+
+/**
+ * Intercepts POST request to create a Domain record.
+ *
+ * @returns Cypress chainable.
+ */
+export const interceptCreateDomainRecord = (): Cypress.Chainable<null> => {
+  return cy.intercept('POST', apiMatcher('domains/*/record*'));
+};


### PR DESCRIPTION
## Description 📝
- Refactor Domains tests to use defined intercepts methods

## Major Changes 🔄
- Created a `domains.ts` file.
- Changed to use the intercepts methods in the file above.

## How to test 🧪
Run the commands:
`yarn cy:run -s "cypress/e2e/domains/smoke-create-domain-records.spec.ts"`
`yarn cy:run -s "cypress/e2e/domains/smoke-create-domain.spec.ts"`