### PR TITLE
fix: [M3-5852] - Phone Verification - Verification Code State Does Not Reset

### DIFF
--- a/packages/manager/src/features/Profile/AuthenticationSettings/PhoneVerification/PhoneVerification.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/PhoneVerification/PhoneVerification.tsx
@@ -64,6 +64,7 @@ export const PhoneVerification = () => {
 
   const {
     mutateAsync: sendVerificationCode,
+    reset: resetCodeMutation,
     error: verifyError,
   } = useVerifyPhoneVerificationCodeMutation();
 
@@ -72,6 +73,7 @@ export const PhoneVerification = () => {
   const onSubmitPhoneNumber = async (
     values: SendPhoneVerificationCodePayload
   ) => {
+    resetCodeMutation();
     return await sendPhoneVerificationCode(values);
   };
 


### PR DESCRIPTION
## Description 📝

- Clear phone verification code error so error does not persist on new flow

## How to test 🧪
- Go to `http://localhost:3000/profile/auth`
- First make sure you have your phone number verified
- `Edit` your verified phone number
- Send yourself a verification code
- Enter an **incorrect code** so an error shows
- Click `Enter a different phone number` or `Canel` to start the flow over
- Send yourself a verification code again
- **Verify that you don't see the same error as before**
  - If you don't see the same error as before, this bug has been fixed