### PR TITLE
feat: [M3-6464] – Add resource links to empty Volumes landing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Add No Results section for Marketplace Search #8999
 - Add Private IP checkbox when cloning a Linode #9039
 - Accessible graph tabled data for `LineGraph` component #5915
+- Resource links to empty state Volumes landing page #9065
 
 ### Changed:
 

--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -1,22 +1,18 @@
 import { Event } from '@linode/api-v4/lib/account';
 import { Config } from '@linode/api-v4/lib/linodes';
+import { makeStyles } from '@mui/styles';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { compose } from 'recompose';
 import { bindActionCreators, Dispatch } from 'redux';
-import VolumeIcon from 'src/assets/icons/entityIcons/volume.svg';
-import { makeStyles } from '@mui/styles';
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
-import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import ErrorState from 'src/components/ErrorState';
 import LandingHeader from 'src/components/LandingHeader';
 import Loading from 'src/components/LandingLoading';
-import Link from 'src/components/Link';
 import PaginationFooter from 'src/components/PaginationFooter/PaginationFooter';
-import Placeholder from 'src/components/Placeholder';
 import Table from 'src/components/Table/Table';
 import TableCell from 'src/components/TableCell/TableCell';
 import TableRow from 'src/components/TableRow/TableRow';
@@ -38,6 +34,7 @@ import { DestructiveVolumeDialog } from './DestructiveVolumeDialog';
 import { UpgradeVolumeDialog } from './UpgradeVolumeDialog';
 import { VolumeAttachmentDrawer } from './VolumeAttachmentDrawer';
 import { ActionHandlers as VolumeHandlers } from './VolumesActionMenu';
+import { VolumesLandingEmptyState } from './VolumesLandingEmptyState';
 import VolumeTableRow from './VolumeTableRow';
 
 interface Props {
@@ -88,8 +85,7 @@ export const useStyles = makeStyles(() => ({
 
 const preferenceKey = 'volumes';
 
-export const VolumesLanding: React.FC<CombinedProps> = (props) => {
-  const classes = useStyles();
+export const VolumesLanding = (props: CombinedProps) => {
   const history = useHistory();
 
   const pagination = usePagination(1, preferenceKey);
@@ -226,32 +222,7 @@ export const VolumesLanding: React.FC<CombinedProps> = (props) => {
   }
 
   if (volumes?.results === 0) {
-    return (
-      <>
-        <DocumentTitleSegment segment="Volumes" />
-        <Placeholder
-          title="Volumes"
-          className={classes.empty}
-          icon={VolumeIcon}
-          isEntity
-          buttonProps={[
-            {
-              onClick: () => history.push('/volumes/create'),
-              children: 'Create Volume',
-            },
-          ]}
-        >
-          <Typography variant="subtitle1">
-            Attach additional storage to your Linode.
-          </Typography>
-          <Typography variant="subtitle1">
-            <Link to="https://www.linode.com/docs/products/storage/block-storage/">
-              Learn more about Linode Block Storage Volumes.
-            </Link>
-          </Typography>
-        </Placeholder>
-      </>
-    );
+    return <VolumesLandingEmptyState />;
   }
 
   const handlers: VolumeHandlers = {

--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -1,6 +1,5 @@
 import { Event } from '@linode/api-v4/lib/account';
 import { Config } from '@linode/api-v4/lib/linodes';
-import { makeStyles } from '@mui/styles';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { useHistory } from 'react-router-dom';
@@ -74,14 +73,6 @@ interface DispatchProps {
 }
 
 type CombinedProps = Props & DispatchProps;
-
-export const useStyles = makeStyles(() => ({
-  empty: {
-    '& svg': {
-      transform: 'scale(0.75)',
-    },
-  },
-}));
 
 const preferenceKey = 'volumes';
 

--- a/packages/manager/src/features/Volumes/VolumesLandingEmptyState.styles.ts
+++ b/packages/manager/src/features/Volumes/VolumesLandingEmptyState.styles.ts
@@ -1,10 +1,8 @@
 import { styled } from '@mui/material/styles';
-import Placeholder from 'src/components/Placeholder';
+import VolumeIcon from 'src/assets/icons/entityIcons/volume.svg';
 
-const StyledPlaceholder = styled(Placeholder)(() => ({
-  '& svg': {
-    transform: 'scale(0.75)',
-  },
+const StyledVolumeIcon = styled(VolumeIcon)(() => ({
+  transform: 'scale(0.75)',
 }));
 
-export { StyledPlaceholder };
+export { StyledVolumeIcon };

--- a/packages/manager/src/features/Volumes/VolumesLandingEmptyState.styles.ts
+++ b/packages/manager/src/features/Volumes/VolumesLandingEmptyState.styles.ts
@@ -1,10 +1,9 @@
 import { styled } from '@mui/material/styles';
 import Placeholder from 'src/components/Placeholder';
 
-const StyledPlaceholder = styled(Placeholder)(({ theme }) => ({
-  padding: `${theme.spacing(2)} 0`,
-  [theme.breakpoints.up('md')]: {
-    padding: `${theme.spacing(10)} 0 ${theme.spacing(4)}`,
+const StyledPlaceholder = styled(Placeholder)(() => ({
+  '& svg': {
+    transform: 'scale(0.75)',
   },
 }));
 

--- a/packages/manager/src/features/Volumes/VolumesLandingEmptyState.styles.ts
+++ b/packages/manager/src/features/Volumes/VolumesLandingEmptyState.styles.ts
@@ -1,0 +1,11 @@
+import { styled } from '@mui/material/styles';
+import Placeholder from 'src/components/Placeholder';
+
+const StyledPlaceholder = styled(Placeholder)(({ theme }) => ({
+  padding: `${theme.spacing(2)} 0`,
+  [theme.breakpoints.up('md')]: {
+    padding: `${theme.spacing(10)} 0 ${theme.spacing(4)}`,
+  },
+}));
+
+export { StyledPlaceholder };

--- a/packages/manager/src/features/Volumes/VolumesLandingEmptyState.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLandingEmptyState.tsx
@@ -12,7 +12,6 @@ import LinksSection from 'src/features/linodes/LinodesLanding/LinksSection';
 import LinkSubSection from 'src/features/linodes/LinodesLanding/LinksSubSection';
 import {
   getLinkOnClick,
-  guidesMoreLinkText,
   youtubeMoreLinkLabel,
 } from 'src/utilities/emptyStateLandingUtils';
 import { sendEvent } from 'src/utilities/ga';
@@ -55,6 +54,8 @@ const linkGAEventTemplate = {
   category: gaCategory,
   action: 'Click:link',
 };
+
+const volumesGuidesMoreLinkText = 'Browse Linode Block Storage documentation';
 
 const guideLinks = (
   <List>
@@ -119,12 +120,12 @@ const VolumesLandingEmptyState = () => {
               <Link
                 onClick={getLinkOnClick(
                   linkGAEventTemplate,
-                  guidesMoreLinkText
+                  volumesGuidesMoreLinkText
                 )}
                 to="https://www.linode.com/docs/products/storage/block-storage/"
                 {...props}
               >
-                Browse Linode Block Storage documentation
+                {volumesGuidesMoreLinkText}
               </Link>
             )}
           >

--- a/packages/manager/src/features/Volumes/VolumesLandingEmptyState.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLandingEmptyState.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 import DocsIcon from 'src/assets/icons/docs.svg';
 import ExternalLinkIcon from 'src/assets/icons/external-link.svg';
+import PointerIcon from 'src/assets/icons/pointer.svg';
 import YoutubeIcon from 'src/assets/icons/youtube.svg';
 import List from 'src/components/core/List';
 import ListItem from 'src/components/core/ListItem';
@@ -11,8 +12,10 @@ import Placeholder from 'src/components/Placeholder';
 import LinksSection from 'src/features/linodes/LinodesLanding/LinksSection';
 import LinkSubSection from 'src/features/linodes/LinodesLanding/LinksSubSection';
 import {
+  docsLink,
   getLinkOnClick,
   guidesMoreLinkText,
+  youtubeChannelLink,
   youtubeMoreLinkLabel,
   youtubeMoreLinkText,
 } from 'src/utilities/emptyStateLandingUtils';
@@ -57,7 +60,7 @@ const linkGAEventTemplate = {
   action: 'Click:link',
 };
 
-const guideLinks = (
+const GuideLinks = (
   <List>
     {guidesLinkData.map((linkData) => (
       <ListItem key={linkData.to}>
@@ -72,7 +75,7 @@ const guideLinks = (
   </List>
 );
 
-const youtubeLinks = (
+const YoutubeLinks = (
   <List>
     {youtubeLinkData.map((linkData) => (
       <ListItem key={linkData.to}>
@@ -111,46 +114,49 @@ const VolumesLandingEmptyState = () => {
         },
       ]}
       linksSection={
-        <LinksSection>
-          <LinkSubSection
-            title="Getting Started Guides"
-            icon={<DocsIcon />}
-            MoreLink={(props) => (
-              <Link
-                onClick={getLinkOnClick(
-                  linkGAEventTemplate,
-                  guidesMoreLinkText
-                )}
-                to="https://www.linode.com/docs/products/storage/block-storage/"
-                {...props}
-              >
-                {guidesMoreLinkText}
-              </Link>
-            )}
-          >
-            {guideLinks}
-          </LinkSubSection>
-          <LinkSubSection
-            title="Video Playlist"
-            icon={<YoutubeIcon />}
-            external
-            MoreLink={(props) => (
-              <Link
-                onClick={getLinkOnClick(
-                  linkGAEventTemplate,
-                  youtubeMoreLinkLabel
-                )}
-                to="https://www.youtube.com/playlist?list=PLTnRtjQN5ieb4XyvC9OUhp7nxzBENgCxJ"
-                {...props}
-              >
-                {youtubeMoreLinkText}
-                <ExternalLinkIcon style={{ marginLeft: 8 }} />
-              </Link>
-            )}
-          >
-            {youtubeLinks}
-          </LinkSubSection>
-        </LinksSection>
+        <div style={{ maxWidth: '762px' }}>
+          <LinksSection>
+            <LinkSubSection
+              title="Getting Started Guides"
+              icon={<DocsIcon />}
+              MoreLink={(props) => (
+                <Link
+                  onClick={getLinkOnClick(
+                    linkGAEventTemplate,
+                    guidesMoreLinkText
+                  )}
+                  to={docsLink}
+                  {...props}
+                >
+                  {guidesMoreLinkText}
+                  <PointerIcon />
+                </Link>
+              )}
+            >
+              {GuideLinks}
+            </LinkSubSection>
+            <LinkSubSection
+              title="Video Playlist"
+              icon={<YoutubeIcon />}
+              external
+              MoreLink={(props) => (
+                <Link
+                  onClick={getLinkOnClick(
+                    linkGAEventTemplate,
+                    youtubeMoreLinkLabel
+                  )}
+                  to={youtubeChannelLink}
+                  {...props}
+                >
+                  {youtubeMoreLinkText}
+                  <ExternalLinkIcon style={{ marginLeft: 8 }} />
+                </Link>
+              )}
+            >
+              {YoutubeLinks}
+            </LinkSubSection>
+          </LinksSection>
+        </div>
       }
     >
       <Typography variant="subtitle1">

--- a/packages/manager/src/features/Volumes/VolumesLandingEmptyState.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLandingEmptyState.tsx
@@ -1,21 +1,23 @@
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 import DocsIcon from 'src/assets/icons/docs.svg';
-import VolumeIcon from 'src/assets/icons/entityIcons/volume.svg';
 import ExternalLinkIcon from 'src/assets/icons/external-link.svg';
 import YoutubeIcon from 'src/assets/icons/youtube.svg';
 import List from 'src/components/core/List';
 import ListItem from 'src/components/core/ListItem';
 import Typography from 'src/components/core/Typography';
 import Link from 'src/components/Link';
+import Placeholder from 'src/components/Placeholder';
 import LinksSection from 'src/features/linodes/LinodesLanding/LinksSection';
 import LinkSubSection from 'src/features/linodes/LinodesLanding/LinksSubSection';
 import {
   getLinkOnClick,
+  guidesMoreLinkText,
   youtubeMoreLinkLabel,
+  youtubeMoreLinkText,
 } from 'src/utilities/emptyStateLandingUtils';
 import { sendEvent } from 'src/utilities/ga';
-import { StyledPlaceholder } from './VolumesLandingEmptyState.styles';
+import { StyledVolumeIcon } from './VolumesLandingEmptyState.styles';
 
 const guidesLinkData = [
   {
@@ -55,8 +57,6 @@ const linkGAEventTemplate = {
   action: 'Click:link',
 };
 
-const volumesGuidesMoreLinkText = 'Browse Linode Block Storage documentation';
-
 const guideLinks = (
   <List>
     {guidesLinkData.map((linkData) => (
@@ -92,12 +92,11 @@ const VolumesLandingEmptyState = () => {
   const { push } = useHistory();
 
   return (
-    <StyledPlaceholder
+    <Placeholder
       title="Volumes"
       subtitle="NVM block storage service"
-      icon={VolumeIcon}
+      icon={StyledVolumeIcon}
       isEntity
-      showTransferDisplay
       buttonProps={[
         {
           onClick: () => {
@@ -120,12 +119,12 @@ const VolumesLandingEmptyState = () => {
               <Link
                 onClick={getLinkOnClick(
                   linkGAEventTemplate,
-                  volumesGuidesMoreLinkText
+                  guidesMoreLinkText
                 )}
                 to="https://www.linode.com/docs/products/storage/block-storage/"
                 {...props}
               >
-                {volumesGuidesMoreLinkText}
+                {guidesMoreLinkText}
               </Link>
             )}
           >
@@ -144,7 +143,7 @@ const VolumesLandingEmptyState = () => {
                 to="https://www.youtube.com/playlist?list=PLTnRtjQN5ieb4XyvC9OUhp7nxzBENgCxJ"
                 {...props}
               >
-                Check out our YouTube channel
+                {youtubeMoreLinkText}
                 <ExternalLinkIcon style={{ marginLeft: 8 }} />
               </Link>
             )}
@@ -154,12 +153,11 @@ const VolumesLandingEmptyState = () => {
         </LinksSection>
       }
     >
-      {' '}
       <Typography variant="subtitle1">
         Attach scalable, fault-tolerant, and performant block storage volumes to
         your Linode Compute Instances or Kubernetes Clusters.
       </Typography>
-    </StyledPlaceholder>
+    </Placeholder>
   );
 };
 

--- a/packages/manager/src/features/Volumes/VolumesLandingEmptyState.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLandingEmptyState.tsx
@@ -1,0 +1,166 @@
+import * as React from 'react';
+import { useHistory } from 'react-router-dom';
+import DocsIcon from 'src/assets/icons/docs.svg';
+import VolumeIcon from 'src/assets/icons/entityIcons/volume.svg';
+import ExternalLinkIcon from 'src/assets/icons/external-link.svg';
+import YoutubeIcon from 'src/assets/icons/youtube.svg';
+import List from 'src/components/core/List';
+import ListItem from 'src/components/core/ListItem';
+import Typography from 'src/components/core/Typography';
+import Link from 'src/components/Link';
+import LinksSection from 'src/features/linodes/LinodesLanding/LinksSection';
+import LinkSubSection from 'src/features/linodes/LinodesLanding/LinksSubSection';
+import {
+  getLinkOnClick,
+  guidesMoreLinkText,
+  youtubeMoreLinkLabel,
+  youtubeMoreLinkText,
+} from 'src/utilities/emptyStateLandingUtils';
+import { sendEvent } from 'src/utilities/ga';
+import { StyledPlaceholder } from './VolumesLandingEmptyState.styles';
+
+const guidesLinkData = [
+  {
+    to: 'https://www.linode.com/docs/products/storage/block-storage/',
+    text: 'Overview of Block Storage',
+  },
+  {
+    to: 'https://www.linode.com/docs/products/storage/block-storage/guides/',
+    text: 'Create and Manage Block Storage Volumes',
+  },
+  {
+    to:
+      'https://www.linode.com/docs/products/storage/block-storage/guides/configure-volume/',
+    text: 'Configure a Volume on a Compute Instance',
+  },
+];
+
+const youtubeLinkData = [
+  {
+    to: 'https://www.youtube.com/watch?v=7ti25oK7UMA',
+    text: 'How to Use Block Storage with Your Linode',
+  },
+  {
+    to: 'https://www.youtube.com/watch?v=8G0cNZZIxNc',
+    text: 'Block Storage Vs Object Storage',
+  },
+  {
+    to: 'https://www.youtube.com/watch?v=Z9jZv_IHO2s',
+    text:
+      'How to use Block Storage to Increase Space on Your Nextcloud Instance',
+  },
+];
+
+const gaCategory = 'Volumes landing page empty';
+const linkGAEventTemplate = {
+  category: gaCategory,
+  action: 'Click:link',
+};
+
+const guideLinks = (
+  <List>
+    {guidesLinkData.map((linkData) => (
+      <ListItem key={linkData.to}>
+        <Link
+          to={linkData.to}
+          onClick={getLinkOnClick(linkGAEventTemplate, linkData.text)}
+        >
+          {linkData.text}
+        </Link>
+      </ListItem>
+    ))}
+  </List>
+);
+
+const youtubeLinks = (
+  <List>
+    {youtubeLinkData.map((linkData) => (
+      <ListItem key={linkData.to}>
+        <Link
+          onClick={getLinkOnClick(linkGAEventTemplate, linkData.text)}
+          to={linkData.to}
+        >
+          {linkData.text}
+          <ExternalLinkIcon />
+        </Link>
+      </ListItem>
+    ))}
+  </List>
+);
+
+const VolumesLandingEmptyState = () => {
+  const { push } = useHistory();
+
+  return (
+    <StyledPlaceholder
+      title="Volumes"
+      subtitle="NVM block storage service"
+      icon={VolumeIcon}
+      isEntity
+      showTransferDisplay
+      buttonProps={[
+        {
+          onClick: () => {
+            sendEvent({
+              category: gaCategory,
+              action: 'Click:button',
+              label: 'Create Volume',
+            });
+            push('/volumes/create');
+          },
+          children: 'Create Volume',
+        },
+      ]}
+      linksSection={
+        <LinksSection>
+          <LinkSubSection
+            title="Getting Started Guides"
+            icon={<DocsIcon />}
+            MoreLink={(props) => (
+              <Link
+                onClick={getLinkOnClick(
+                  linkGAEventTemplate,
+                  guidesMoreLinkText
+                )}
+                to="https://www.linode.com/docs/"
+                {...props}
+              >
+                {guidesMoreLinkText}
+              </Link>
+            )}
+          >
+            {guideLinks}
+          </LinkSubSection>
+          <LinkSubSection
+            title="Video Playlist"
+            icon={<YoutubeIcon />}
+            external
+            MoreLink={(props) => (
+              <Link
+                onClick={getLinkOnClick(
+                  linkGAEventTemplate,
+                  youtubeMoreLinkLabel
+                )}
+                to="https://www.youtube.com/playlist?list=PLTnRtjQN5ieb4XyvC9OUhp7nxzBENgCxJ"
+                {...props}
+              >
+                {youtubeMoreLinkText}
+                <ExternalLinkIcon style={{ marginLeft: 8 }} />
+              </Link>
+            )}
+          >
+            {youtubeLinks}
+          </LinkSubSection>
+        </LinksSection>
+      }
+    >
+      {' '}
+      <Typography variant="subtitle1">
+        Attach scalable, fault-tolerant, and performant block storage volumes to
+        your Linode Compute Instances or Kubernetes Clusters.
+      </Typography>
+    </StyledPlaceholder>
+  );
+};
+
+export { VolumesLandingEmptyState };

--- a/packages/manager/src/features/Volumes/VolumesLandingEmptyState.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLandingEmptyState.tsx
@@ -14,7 +14,6 @@ import {
   getLinkOnClick,
   guidesMoreLinkText,
   youtubeMoreLinkLabel,
-  youtubeMoreLinkText,
 } from 'src/utilities/emptyStateLandingUtils';
 import { sendEvent } from 'src/utilities/ga';
 import { StyledPlaceholder } from './VolumesLandingEmptyState.styles';
@@ -122,10 +121,10 @@ const VolumesLandingEmptyState = () => {
                   linkGAEventTemplate,
                   guidesMoreLinkText
                 )}
-                to="https://www.linode.com/docs/"
+                to="https://www.linode.com/docs/products/storage/block-storage/"
                 {...props}
               >
-                {guidesMoreLinkText}
+                Browse Linode Block Storage documentation
               </Link>
             )}
           >
@@ -144,7 +143,7 @@ const VolumesLandingEmptyState = () => {
                 to="https://www.youtube.com/playlist?list=PLTnRtjQN5ieb4XyvC9OUhp7nxzBENgCxJ"
                 {...props}
               >
-                {youtubeMoreLinkText}
+                Check out our YouTube channel
                 <ExternalLinkIcon style={{ marginLeft: 8 }} />
               </Link>
             )}

--- a/packages/manager/src/features/linodes/LinodesLanding/LinksSubSection.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinksSubSection.tsx
@@ -7,7 +7,7 @@ import { Theme } from '@mui/material/styles';
 const useStyles = makeStyles((theme: Theme) => ({
   linksSubSection: {
     display: 'grid',
-    gridTemplateRows: `22px  minmax(${theme.spacing(3)}, 100%) 1.125rem`,
+    gridTemplateRows: `22px minmax(${theme.spacing(3)}, 100%) 1.125rem`,
     rowGap: theme.spacing(2),
     width: '100%',
     '& > h2': {


### PR DESCRIPTION
## Description 📝
Add resource links to Volumes empty state landing page

## Major Changes 🔄
- New files: `VolumesLandingEmptyState.tsx` & `VolumesLandingEmptyState.styles.ts`
- Some empty state styling updated to use `styled()` API
- Associated changes in `VolumesLanding.tsx`

## Preview 📷
<details>
<summary>Normal view</summary>

![Screenshot 2023-04-28 at 3 34 09 PM](https://user-images.githubusercontent.com/114682940/235237188-18d9e3e6-e2ec-4fe7-9f40-49df0c70f4da.jpg)
</details>

<details>
<summary>Mobile view</summary>

![Screenshot 2023-04-28 at 3 54 44 PM](https://user-images.githubusercontent.com/114682940/235241164-50113e1b-d1f7-4dbd-9d09-b4ff1278b78e.jpg)
</details>

## How to test 🧪
Confirm that all links and copy are correct. Check the layout at various breakpoints.