### PR TITLE
feat: [M3-6520] - Add new flag to deliver DC availability notice for premium plans

### DIFF
--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -56,7 +56,7 @@ export interface Flags {
   taxCollectionBanner: TaxCollectionBanner;
   databaseBeta: boolean;
   metadata: boolean;
-  premiumPlansAvailabilityNotice: PremiumPlansAvailabilityNotice;
+  premiumPlansAvailabilityNotice: string;
 }
 
 type PromotionalOfferFeature =
@@ -134,5 +134,3 @@ export interface SuppliedMaintenanceData {
 export interface APIMaintenance {
   maintenances: SuppliedMaintenanceData[];
 }
-
-export type PremiumPlansAvailabilityNotice = string;

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -56,6 +56,7 @@ export interface Flags {
   taxCollectionBanner: TaxCollectionBanner;
   databaseBeta: boolean;
   metadata: boolean;
+  premiumPlansAvailabilityNotice: PremiumPlansAvailabilityNotice;
 }
 
 type PromotionalOfferFeature =
@@ -133,3 +134,5 @@ export interface SuppliedMaintenanceData {
 export interface APIMaintenance {
   maintenances: SuppliedMaintenanceData[];
 }
+
+export type PremiumPlansAvailabilityNotice = string;

--- a/packages/manager/src/features/linodes/LinodesCreate/PremiumPlansAvailabilityNotice.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/PremiumPlansAvailabilityNotice.tsx
@@ -4,7 +4,7 @@ import useFlags from 'src/hooks/useFlags';
 
 // Ideally we should add premium as a capability so the availability is returned by the API,
 // but it's not there yet so we're using a flag for now.
-const PremiumPlansAvailabilityNotice = React.memo(() => {
+export const PremiumPlansAvailabilityNotice = React.memo(() => {
   const { premiumPlansAvailabilityNotice } = useFlags();
 
   if (premiumPlansAvailabilityNotice) {
@@ -13,5 +13,3 @@ const PremiumPlansAvailabilityNotice = React.memo(() => {
 
   return null;
 });
-
-export default PremiumPlansAvailabilityNotice;

--- a/packages/manager/src/features/linodes/LinodesCreate/PremiumPlansAvailabilityNotice.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/PremiumPlansAvailabilityNotice.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import Notice from 'src/components/Notice';
+import useFlags from 'src/hooks/useFlags';
+
+// Ideally we should add premium as a capability so the availability is returned by the API,
+// but it's not there yet so we're using a flag for now.
+const PremiumPlansAvailabilityNotice = React.memo(() => {
+  const { premiumPlansAvailabilityNotice } = useFlags();
+
+  if (premiumPlansAvailabilityNotice) {
+    return <Notice warning>{premiumPlansAvailabilityNotice}</Notice>;
+  }
+
+  return null;
+});
+
+export default PremiumPlansAvailabilityNotice;

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -32,6 +32,7 @@ import { gpuPlanText } from './utilities';
 import { ExtendedType } from 'src/utilities/extendType';
 import { ApplicationState } from 'src/store';
 import { useRegionsQuery } from 'src/queries/regions';
+import useFlags from 'src/hooks/useFlags';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -189,6 +190,16 @@ export const SelectPlanPanel = (props: Props) => {
       ?.filter((thisRegion) => thisRegion.capabilities.includes(capability))
       .map((thisRegion) => thisRegion.label);
     return arrayToList(withCapability ?? []);
+  };
+
+  const PremiumPlansAvailabilityNotice = () => {
+    const { premiumPlansAvailabilityNotice } = useFlags();
+
+    if (premiumPlansAvailabilityNotice) {
+      return <Notice warning>{premiumPlansAvailabilityNotice}</Notice>;
+    }
+
+    return null;
   };
 
   const renderSelection = (type: PlanSelectionType, idx: number) => {
@@ -568,9 +579,7 @@ export const SelectPlanPanel = (props: Props) => {
         render: () => {
           return (
             <>
-              <Notice warning>
-                This plan is only available in the Washington, DC region.
-              </Notice>
+              <PremiumPlansAvailabilityNotice />
               <Typography data-qa-gpu className={classes.copy}>
                 Premium CPU instances guarantee a minimum processor model, AMD
                 Epyc<sup>TM</sup> 7713 or higher, to ensure consistent high

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -32,7 +32,7 @@ import { gpuPlanText } from './utilities';
 import { ExtendedType } from 'src/utilities/extendType';
 import { ApplicationState } from 'src/store';
 import { useRegionsQuery } from 'src/queries/regions';
-import PremiumPlansAvailabilityNotice from './PremiumPlansAvailabilityNotice';
+import { PremiumPlansAvailabilityNotice } from './PremiumPlansAvailabilityNotice';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -93,6 +93,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
     '& a:hover': {
       color: '#3683dc',
+    },
+    '& p': {
+      fontFamily: '"LatoWebBold", sans-serif',
     },
   },
 }));
@@ -508,7 +511,7 @@ export const SelectPlanPanel = (props: Props) => {
           {getRegionsWithCapability('GPU Linodes')}.
         </>
       ) : (
-        <div className={classes.gpuGuideLink}>{gpuPlanText()}</div>
+        <div className={classes.gpuGuideLink}>{gpuPlanText(true)}</div>
       );
       tabs.push({
         render: () => {

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -32,7 +32,7 @@ import { gpuPlanText } from './utilities';
 import { ExtendedType } from 'src/utilities/extendType';
 import { ApplicationState } from 'src/store';
 import { useRegionsQuery } from 'src/queries/regions';
-import useFlags from 'src/hooks/useFlags';
+import PremiumPlansAvailabilityNotice from './PremiumPlansAvailabilityNotice';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -190,16 +190,6 @@ export const SelectPlanPanel = (props: Props) => {
       ?.filter((thisRegion) => thisRegion.capabilities.includes(capability))
       .map((thisRegion) => thisRegion.label);
     return arrayToList(withCapability ?? []);
-  };
-
-  const PremiumPlansAvailabilityNotice = () => {
-    const { premiumPlansAvailabilityNotice } = useFlags();
-
-    if (premiumPlansAvailabilityNotice) {
-      return <Notice warning>{premiumPlansAvailabilityNotice}</Notice>;
-    }
-
-    return null;
   };
 
   const renderSelection = (type: PlanSelectionType, idx: number) => {

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
@@ -23,7 +23,7 @@ import { convertMegabytesTo } from 'src/utilities/unitConversions';
 import { gpuPlanText } from './utilities';
 import { CreateNodePoolData } from '@linode/api-v4';
 import { ExtendedType } from 'src/utilities/extendType';
-import PremiumPlansAvailabilityNotice from './PremiumPlansAvailabilityNotice';
+import { PremiumPlansAvailabilityNotice } from './PremiumPlansAvailabilityNotice';
 
 type ClassNames =
   | 'root'

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
@@ -23,6 +23,7 @@ import { convertMegabytesTo } from 'src/utilities/unitConversions';
 import { gpuPlanText } from './utilities';
 import { CreateNodePoolData } from '@linode/api-v4';
 import { ExtendedType } from 'src/utilities/extendType';
+import PremiumPlansAvailabilityNotice from './PremiumPlansAvailabilityNotice';
 
 type ClassNames =
   | 'root'
@@ -378,9 +379,7 @@ export class SelectPlanQuantityPanel extends React.Component<CombinedProps> {
         render: () => {
           return (
             <>
-              <Notice warning>
-                This plan is only available in the Washington, DC region.
-              </Notice>
+              <PremiumPlansAvailabilityNotice />
               <Typography data-qa-gpu className={classes.copy}>
                 Premium CPU instances guarantee a minimum processor model, AMD
                 Epyc<sup>TM</sup> 7713 or higher, to ensure consistent high


### PR DESCRIPTION
## Description 📝
This PR allows the "This plan is only available in the Washington, DC region." notices for the Linode and LKE creation pages to be dynamic for quick iteration during the launch, as the available DC(s) isn't confirmed yet. 

## Preview 📷
This PR introduces no visual difference as the content is the same, just made dynamic
![Screenshot 2023-05-01 at 11 38 47 AM](https://user-images.githubusercontent.com/130582365/235479754-abede6fe-6e08-4b3a-b84a-2d6a786573c4.jpg)

## How to test 🧪

1. make sure to have the `premium_dedicatedcpu` tag in admin (enables premium feature)
2. make sure to have your `REACT_APP_LAUNCH_DARKLY_ID` env var set locally to the production key
3. confirm flag setup is proper in LaunchDarkly (`premiumPlansAvailabilityNotice`)
4. navigate to /linodes/create & /kubernetes/create then Linode Plan > Premium and confirm both banners are showing up and have the right content
5. Alternatively feel free to change the flag string in LD to confirm the content can be updated instantly

