### PR TITLE
fix: [M3-6022] - Add compression to logo when rendering in JPG format during invoice PDF generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Prevent form submission unless action was taken (IP transfer & IP sharing modals) #5976
 - Recycle LKE Node confirmation dialog gets dismissed upon submission #9054
 - Inability to edit and save Linode Configurations #9053
+- Excessively large file size for invoices due to uncompressed JPG logo #9069
 
 ### Tech Stories:
 

--- a/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
@@ -219,7 +219,7 @@ export const printInvoice = (
 
     // Create a separate page for each set of invoice items
     itemsChunks.forEach((itemsChunk, index) => {
-      doc.addImage(AkamaiLogo, 'JPEG', 160, 10, 120, 40);
+      doc.addImage(AkamaiLogo, 'JPEG', 160, 10, 120, 40, undefined, "MEDIUM");
 
       const leftHeaderYPosition = addLeftHeader(
         doc,
@@ -277,7 +277,7 @@ export const printPayment = (
     });
     doc.setFontSize(10);
 
-    doc.addImage(AkamaiLogo, 'JPEG', 160, 10, 120, 40);
+    doc.addImage(AkamaiLogo, 'JPEG', 160, 10, 120, 40, undefined, "MEDIUM");
 
     const leftHeaderYPosition = addLeftHeader(
       doc,


### PR DESCRIPTION
## Description 📝
Currently these PDFs are >1 MB in size. With this change, my testing showed the resulting PDF to be closer to 50kb in size. Logo quality looks the same to me 🤷🏽 

## How to test 🧪
Generate a PDF of the same invoice with and without this change.
