### PR TITLE
fix: [M3-5088] - Allow simple search for IPv6 addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,18 +17,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [2023-05-01] - v1.92.0
 
 ### Added:
-
 - No Results section for Marketplace Search #8999
 - Private IP checkbox when cloning a Linode #9039
 - Metadata migrate warning #9033
 
 ### Changed:
-
 - Region Select will dynamically get country flags and group all countries based on API data #8996
 - Removed MongoDB Marketplace Apps #9071
 
 ### Fixed:
-
 - Kubernetes Delete Dialog clears when it is re-opened #9000
 - HTML showing up in event messages #9003
 - Inability to edit and save Linode Configurations #9053
@@ -38,7 +35,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Blank Kubernetes Node Pool plan selection #9009
 
 ### Tech Stories:
-
 - MUI v5 Migration - `Components > CircleProgress` #9028
 - MUI v5 Migration - `Components > StatusIcon` #9014
 - MUI v5 Migration - `Components > TagsInput, TagsPanel` #8995
@@ -73,32 +69,27 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [2023-04-18] - v1.91.1
 
 ### Fixed:
-
 - Add Premium plans to LKE #9021
 
 ## [2023-04-17] - v1.91.0
 
 ### Added:
-
 - Cross Data Center Clone warning #8937
 - `Plan` column header to plan select table #8943
 
 ### Changed:
-
 - Use Akamai logo for TPA provider screen #8982
 - Use Akamai logo for the favicon #8988
 - Only fetch grants when the user is restricted #8941
 - Improve the StackScript user defined fields (UDF) forms #8973
 
 ### Fixed:
-
 - Styling of Linode Details Add Configurations modal header #8981
 - Alignment issues with Kubernetes Node Pool table and buttons #8967
 - Domain Records not updating when navigating #8957
 - Notification menu displaying empty menu on secondary status click #8902
 
 ### Tech Story:
-
 - React Query for NodeBalancers #8964
 - React Query for Profile - Trusted Devices #8942
 - React Query for OAuth Apps #8938

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,15 +17,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [2023-05-01] - v1.92.0
 
 ### Added:
+
 - No Results section for Marketplace Search #8999
 - Private IP checkbox when cloning a Linode #9039
 - Metadata migrate warning #9033
 
 ### Changed:
+
 - Region Select will dynamically get country flags and group all countries based on API data #8996
 - Removed MongoDB Marketplace Apps #9071
 
 ### Fixed:
+
 - Kubernetes Delete Dialog clears when it is re-opened #9000
 - HTML showing up in event messages #9003
 - Inability to edit and save Linode Configurations #9053
@@ -35,6 +38,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Blank Kubernetes Node Pool plan selection #9009
 
 ### Tech Stories:
+
 - MUI v5 Migration - `Components > CircleProgress` #9028
 - MUI v5 Migration - `Components > StatusIcon` #9014
 - MUI v5 Migration - `Components > TagsInput, TagsPanel` #8995
@@ -69,27 +73,32 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [2023-04-18] - v1.91.1
 
 ### Fixed:
+
 - Add Premium plans to LKE #9021
 
 ## [2023-04-17] - v1.91.0
 
 ### Added:
+
 - Cross Data Center Clone warning #8937
 - `Plan` column header to plan select table #8943
 
 ### Changed:
+
 - Use Akamai logo for TPA provider screen #8982
 - Use Akamai logo for the favicon #8988
 - Only fetch grants when the user is restricted #8941
 - Improve the StackScript user defined fields (UDF) forms #8973
 
 ### Fixed:
+
 - Styling of Linode Details Add Configurations modal header #8981
 - Alignment issues with Kubernetes Node Pool table and buttons #8967
 - Domain Records not updating when navigating #8957
 - Notification menu displaying empty menu on secondary status click #8902
 
 ### Tech Story:
+
 - React Query for NodeBalancers #8964
 - React Query for Profile - Trusted Devices #8942
 - React Query for OAuth Apps #8938

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Changed:
 
 ### Fixed:
+- Allow simple search for IPv6 addresses #5088
 
 ### Tech Stories:
 

--- a/packages/manager/src/features/Search/refinedSearch.test.ts
+++ b/packages/manager/src/features/Search/refinedSearch.test.ts
@@ -324,7 +324,7 @@ describe('isSimpleQuery', () => {
     expect(isSimpleQuery(query, parsedQuery)).toBe(false);
   });
 
-  it('returns true if we match a forceSkipFieldSearch rule', () => {
+  it('returns true if we match a shouldSkipFieldSearch rule', () => {
     const query = 'label::hello';
     const parsedQuery = searchString.parse(query).getParsedQuery();
     expect(isSimpleQuery(query, parsedQuery)).toBe(true);

--- a/packages/manager/src/features/Search/refinedSearch.test.ts
+++ b/packages/manager/src/features/Search/refinedSearch.test.ts
@@ -297,25 +297,37 @@ describe('testItem', () => {
 
 describe('isSimpleQuery', () => {
   it('returns true if there are no specified search fields', () => {
-    let parsedQuery = searchString.parse('-hello world').getParsedQuery();
-    expect(isSimpleQuery(parsedQuery)).toBe(true);
+    let query = '-hello world';
+    let parsedQuery = searchString.parse(query).getParsedQuery();
+    expect(isSimpleQuery(query, parsedQuery)).toBe(true);
 
-    parsedQuery = searchString.parse('hello world').getParsedQuery();
-    expect(isSimpleQuery(parsedQuery)).toBe(true);
+    query = '-hello world';
+    parsedQuery = searchString.parse(query).getParsedQuery();
+    expect(isSimpleQuery(query, parsedQuery)).toBe(true);
 
-    parsedQuery = searchString.parse('hello -world').getParsedQuery();
-    expect(isSimpleQuery(parsedQuery)).toBe(true);
+    query = 'hello -world';
+    parsedQuery = searchString.parse(query).getParsedQuery();
+    expect(isSimpleQuery(query, parsedQuery)).toBe(true);
   });
 
   it('returns false if there are specified search fields', () => {
-    let parsedQuery = searchString.parse('label:hello').getParsedQuery();
-    expect(isSimpleQuery(parsedQuery)).toBe(false);
+    let query = 'label:hello';
+    let parsedQuery = searchString.parse(query).getParsedQuery();
+    expect(isSimpleQuery(query, parsedQuery)).toBe(false);
 
-    parsedQuery = searchString.parse('tags:hello,world').getParsedQuery();
-    expect(isSimpleQuery(parsedQuery)).toBe(false);
+    query = 'tags:hello,world';
+    parsedQuery = searchString.parse(query).getParsedQuery();
+    expect(isSimpleQuery(query, parsedQuery)).toBe(false);
 
-    parsedQuery = searchString.parse('-label:hello').getParsedQuery();
-    expect(isSimpleQuery(parsedQuery)).toBe(false);
+    query = '-label:hello';
+    parsedQuery = searchString.parse(query).getParsedQuery();
+    expect(isSimpleQuery(query, parsedQuery)).toBe(false);
+  });
+
+  it('returns true if we match a forceSkipFieldSearch rule', () => {
+    const query = 'label::hello';
+    const parsedQuery = searchString.parse(query).getParsedQuery();
+    expect(isSimpleQuery(query, parsedQuery)).toBe(true);
   });
 });
 

--- a/packages/manager/src/features/Search/refinedSearch.test.ts
+++ b/packages/manager/src/features/Search/refinedSearch.test.ts
@@ -4,6 +4,7 @@ import { searchableItems } from 'src/__data__/searchableItems';
 import * as RefinedSearch from './refinedSearch';
 import { QueryJSON } from './refinedSearch';
 import { SearchableItem } from './search.interfaces';
+import { COMPRESSED_IPV6_REGEX } from './refinedSearch';
 
 const {
   areAllTrue,
@@ -328,6 +329,17 @@ describe('isSimpleQuery', () => {
     const query = '2001:db8:3c4d:15::1a2f:1a2b';
     const parsedQuery = searchString.parse(query).getParsedQuery();
     expect(isSimpleQuery(query, parsedQuery)).toBe(true);
+  });
+});
+
+describe('IPv6 regex', () => {
+  it('matches compressed IPv6 addresses', () => {
+    expect(
+      '2001:db8:3c4d:15::1a2f:1a2b'.match(COMPRESSED_IPV6_REGEX)
+    ).toBeTruthy();
+    expect('2001:db8::'.match(COMPRESSED_IPV6_REGEX)).toBeTruthy();
+    expect('2001:db8::1234:5678'.match(COMPRESSED_IPV6_REGEX)).toBeTruthy();
+    expect('::1234:5678'.match(COMPRESSED_IPV6_REGEX)).toBeTruthy();
   });
 });
 

--- a/packages/manager/src/features/Search/refinedSearch.test.ts
+++ b/packages/manager/src/features/Search/refinedSearch.test.ts
@@ -325,7 +325,7 @@ describe('isSimpleQuery', () => {
   });
 
   it('returns true if we match a shouldSkipFieldSearch rule', () => {
-    const query = 'label::hello';
+    const query = '2001:db8:3c4d:15::1a2f:1a2b';
     const parsedQuery = searchString.parse(query).getParsedQuery();
     expect(isSimpleQuery(query, parsedQuery)).toBe(true);
   });

--- a/packages/manager/src/features/Search/refinedSearch.ts
+++ b/packages/manager/src/features/Search/refinedSearch.ts
@@ -122,11 +122,13 @@ export const testItem = (item: SearchableItem, query: string) => {
   return areAllTrue(matchedSearchTerms);
 };
 
-const forceSkipFieldSearch = (query: string): boolean => {
+// Force to skip field search (make a simple query) if there's a match
+const shouldSkipFieldSearch = (query: string): boolean => {
   const skipConditions = {
-    // matches a compressed ipv6 addresses which we are using. e.g. 2600:3c03::f03c:91ff:fe96:1d2f
-    // a double semi-colon present in the string will indicate that it is an ipv6 address or that the string is malformed, in which case we can safely skip field search
-    isIPV6: query.match('::'),
+    // matches a compressed ipv6 addresses (which we are using). e.g. xxxx:xxxx::xxxx:xxxx:xxxx:xxxx
+    // a double semi-colon present in the string will indicate that it is an ipv6 address or that the search query is malformed,
+    // in which case we can safely skip the search fields lookup
+    isIPV6: query.match(/::/),
   };
 
   return Object.values(skipConditions).some((condition) => condition);
@@ -139,7 +141,7 @@ export const isSimpleQuery = (originalQuery: string, parsedQuery: any) => {
 
   return (
     (isEmpty(exclude) && isEmpty(include)) ||
-    forceSkipFieldSearch(originalQuery)
+    shouldSkipFieldSearch(originalQuery)
   );
 };
 

--- a/packages/manager/src/features/Search/refinedSearch.ts
+++ b/packages/manager/src/features/Search/refinedSearch.ts
@@ -124,7 +124,9 @@ export const testItem = (item: SearchableItem, query: string) => {
 
 const forceSkipFieldSearch = (query: string): boolean => {
   const skipConditions = {
-    isIPV6: query.includes('::'), // ex: an IPV6 address should be searchable without being broken up into fields
+    // matches a compressed ipv6 addresses which we are using. e.g. 2600:3c03::f03c:91ff:fe96:1d2f
+    // a double semi-colon present in the string will indicate that it is an ipv6 address or that the string is malformed, in which case we can safely skip field search
+    isIPV6: query.match('::'),
   };
 
   return Object.values(skipConditions).some((condition) => condition);

--- a/packages/manager/src/features/Search/refinedSearch.ts
+++ b/packages/manager/src/features/Search/refinedSearch.ts
@@ -3,6 +3,7 @@ import { all, any, equals, isEmpty } from 'ramda';
 import searchString from 'search-string';
 import { SearchableItem, SearchField } from './search.interfaces';
 
+const COMPRESSED_IPV6_REGEX = /^([0-9A-Fa-f]{1,4}(:[0-9A-Fa-f]{1,4}){0,7})?::([0-9A-Fa-f]{1,4}(:[0-9A-Fa-f]{1,4}){0,7})?$/;
 const DEFAULT_SEARCH_FIELDS = ['label', 'tags', 'ips'];
 
 // =============================================================================
@@ -125,10 +126,8 @@ export const testItem = (item: SearchableItem, query: string) => {
 // Force to skip field search (make a simple query) if there's a match
 const shouldSkipFieldSearch = (query: string): boolean => {
   const skipConditions = {
-    // matches a compressed ipv6 addresses (which we are using). e.g. xxxx:xxxx::xxxx:xxxx:xxxx:xxxx
-    // a double semi-colon present in the string will indicate that it is an ipv6 address or that the search query is malformed,
-    // in which case we can safely skip the search fields lookup
-    isIPV6: query.match(/::/),
+    // matches a compressed ipv6 addresses. e.g. xxxx:xxxx::xxxx:xxxx:xxxx:xxxx
+    isIPV6: query.match(COMPRESSED_IPV6_REGEX),
   };
 
   return Object.values(skipConditions).some((condition) => condition);

--- a/packages/manager/src/features/Search/refinedSearch.ts
+++ b/packages/manager/src/features/Search/refinedSearch.ts
@@ -3,7 +3,7 @@ import { all, any, equals, isEmpty } from 'ramda';
 import searchString from 'search-string';
 import { SearchableItem, SearchField } from './search.interfaces';
 
-const COMPRESSED_IPV6_REGEX = /^([0-9A-Fa-f]{1,4}(:[0-9A-Fa-f]{1,4}){0,7})?::([0-9A-Fa-f]{1,4}(:[0-9A-Fa-f]{1,4}){0,7})?$/;
+export const COMPRESSED_IPV6_REGEX = /^([0-9A-Fa-f]{1,4}(:[0-9A-Fa-f]{1,4}){0,7})?::([0-9A-Fa-f]{1,4}(:[0-9A-Fa-f]{1,4}){0,7})?$/;
 const DEFAULT_SEARCH_FIELDS = ['label', 'tags', 'ips'];
 
 // =============================================================================


### PR DESCRIPTION
## Description 📝
`simpleSearch` is mistakingly interpreting an IPv6 address as containing a search field because of the presence of semi-colons. This PR adds a `shouldSkipFieldSearch` utility that maps through x number of string matching expressions that can force a simple search (no field lookup)

## Preview 📷
![Screenshot 2023-05-01 at 9 20 01 PM](https://user-images.githubusercontent.com/130582365/235559731-91bdee01-3041-4835-952a-89704c06820c.jpg)

## How to test 🧪
1. Make sure to have a linode with an IPv6 address
2. Copy address from the summary, paste it in the search bar and make sure there's a match 
