### PR TITLE
fix: [M3-6509] - Enable Cypress's experimental memory management config

### DIFF
--- a/packages/manager/cypress.config.ts
+++ b/packages/manager/cypress.config.ts
@@ -73,6 +73,7 @@ export default defineConfig({
   requestTimeout: 30000,
   responseTimeout: 80000,
   retries: 2,
+  experimentalMemoryManagement: true,
   e2e: {
     experimentalRunAllSpecs: true,
     baseUrl: 'http://localhost:3000',


### PR DESCRIPTION
## Description 📝
Enables Cypress's experimental memory management config option in an attempt to reduce the number of failed runs caused by Chrome renderer process crashes.

I'm going to run our tests against this PR several times to get an idea of whether or not this is effective, and will have this labeled with Work in Progress and Do Not Merge in the meantime.

## Testing Instructions
There are two things that we want to confirm with this PR to the best of our abilities: that it fixes the Chrome renderer crash when run via Jenkins/GHA, and that it continues working when running locally.

We can rely on the Jenkins PR runs to confirm the first, and to confirm the second we can run Cypress locally:

```bash
yarn cy:run
```

I'll probably re-run the Jenkins job several times to continue building confidence that this change is helping.