### PR TITLE
refactor: [M3-6222] - Refactor Images E2E Test Intercepts

### DIFF
--- a/packages/manager/cypress/e2e/images/create-linode-from-image.spec.ts
+++ b/packages/manager/cypress/e2e/images/create-linode-from-image.spec.ts
@@ -3,6 +3,7 @@ import { createMockLinodeList } from 'support/api/linodes';
 import { containsClick, fbtClick, fbtVisible, getClick } from 'support/helpers';
 import { apiMatcher } from 'support/util/intercepts';
 import { randomString } from 'support/util/random';
+import { mockGetImages } from 'support/intercepts/images';
 
 const mockImage = createMockImage().data[0];
 const imageLabel = mockImage.label;
@@ -22,9 +23,7 @@ const mockLinodeList = createMockLinodeList({
 const mockLinode = mockLinodeList.data[0];
 
 const createLinodeWithImageMock = (preselectedImage: boolean) => {
-  cy.intercept(apiMatcher('images*'), (req) => {
-    req.reply(createMockImage());
-  }).as('mockImage');
+  mockGetImages(createMockImage().data).as('mockImage');
 
   cy.intercept('POST', apiMatcher('linode/instances'), (req) => {
     req.reply({

--- a/packages/manager/cypress/e2e/images/machine-image-upload.spec.ts
+++ b/packages/manager/cypress/e2e/images/machine-image-upload.spec.ts
@@ -10,6 +10,7 @@ import { ui } from 'support/ui';
 import { interceptOnce } from 'support/ui/common';
 import { apiMatcher } from 'support/util/intercepts';
 import { randomItem, randomLabel, randomPhrase } from 'support/util/random';
+import { mockGetImage } from 'support/intercepts/images';
 
 /*
  * Amount of time to wait for toast notification after uploading image, in ms.
@@ -72,27 +73,6 @@ const eventIntercept = (
       })
     )
   ).as('getEvent');
-};
-
-/**
- * Intercepts the response for an image GET request.
- *
- * Responds with an image with the given label, ID, and status.
- *
- * @param label - Response image label.
- * @param id - Response image ID. Expected to be prefixed with a string (e.g. 'private/12345').
- * @param status - Image status.
- */
-const imageIntercept = (label: string, id: string, status: ImageStatus) => {
-  cy.intercept('GET', apiMatcher(`images/${id}*`), (req) => {
-    req.reply(
-      imageFactory.build({
-        label,
-        id,
-        status,
-      })
-    );
-  }).as('getImage');
 };
 
 /**
@@ -256,7 +236,7 @@ describe('machine image', () => {
     cy.wait('@imageUpload').then((xhr) => {
       const imageId = xhr.response?.body.image.id;
       assertProcessing(label, imageId);
-      imageIntercept(label, imageId, 'available');
+      mockGetImage(label, imageId, 'available').as('getImage');
       eventIntercept(label, imageId, status);
       ui.toast.assertMessage(uploadMessage);
       cy.wait('@getImage');

--- a/packages/manager/cypress/support/intercepts/images.ts
+++ b/packages/manager/cypress/support/intercepts/images.ts
@@ -1,0 +1,57 @@
+/**
+ * @file Cypress intercepts and mocks for Image API requests.
+ */
+
+import type { Image, ImageStatus } from '@linode/api-v4/types';
+import { apiMatcher } from 'support/util/intercepts';
+import { paginateResponse } from 'support/util/paginate';
+import { imageFactory } from '@src/factories';
+
+/**
+ * Intercepts POST request to create a Image.
+ *
+ * @param image - an image objects
+ *
+ * @returns Cypress chainable.
+ */
+export const interceptCreateImage = (image: Image): Cypress.Chainable<null> => {
+  return cy.intercept('POST', apiMatcher('images'), image);
+};
+
+/**
+ * Intercepts GET request to mock image data.
+ *
+ * @param images - an array of mock image objects
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetImages = (images: Image[]): Cypress.Chainable<null> => {
+  return cy.intercept('GET', apiMatcher('images*'), paginateResponse(images));
+};
+
+/**
+ * Intercepts the response for an image GET request.
+ *
+ * Responds with an image with the given label, ID, and status.
+ *
+ * @param label - Response image label.
+ * @param id - Response image ID. Expected to be prefixed with a string (e.g. 'private/12345').
+ * @param status - Image status.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetImage = (
+  label: string,
+  id: string,
+  status: ImageStatus
+): Cypress.Chainable<null> => {
+  return cy.intercept('GET', apiMatcher(`images/${id}*`), (req) => {
+    return req.reply(
+      imageFactory.build({
+        label,
+        id,
+        status,
+      })
+    );
+  });
+};

--- a/packages/manager/cypress/support/intercepts/linodes.ts
+++ b/packages/manager/cypress/support/intercepts/linodes.ts
@@ -2,7 +2,7 @@
  * @file Cypress intercepts and mocks for Cloud Manager Linode operations.
  */
 
-import type { Linode, Volume } from '@linode/api-v4/types';
+import type { Disk, Linode, Volume } from '@linode/api-v4/types';
 import { apiMatcher } from 'support/util/intercepts';
 import { paginateResponse } from 'support/util/paginate';
 
@@ -94,5 +94,24 @@ export const interceptRebootLinodeIntoRescueMode = (
   return cy.intercept(
     'POST',
     apiMatcher(`linode/instances/${linodeId}/rescue`)
+  );
+};
+
+/**
+ * Intercepts GET request to retrieve a Linode's Disks and mocks response.
+ *
+ * @param linodeId - ID of Linode for intercepted request.
+ * @param disks - Array of Disks with which to mock response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetLinodeDisks = (
+  linodeId: number,
+  disks: Disk[]
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'GET',
+    apiMatcher(`linode/instances/${linodeId}/disks*`),
+    paginateResponse(disks)
   );
 };


### PR DESCRIPTION
## Description 📝
- Refactor Images tests to use defined intercepts methods

## Major Changes 🔄
- Created a `images.ts` file.
- Updated code in `linodes.ts` file.
- Changed to use the intercepts methods in the file above.

## How to test 🧪
`yarn cy:run -s "cypress/e2e/images/create-linode-from-image.spec.ts"`
`yarn cy:run -s "cypress/e2e/images/machine-image-upload.spec.ts"`
`yarn cy:run -s "cypress/e2e/images/smoke-create-image.spec.ts"`
