### PR TITLE
fix: [M3-6558] - Remove 'MongoDB' from ClusterControl description in Marketplace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Resource links to empty state Volumes landing page #9065
 
 ### Changed:
+- Removed MongoDB reference from ClusterControl description #9081
 
 ### Fixed:
 

--- a/packages/manager/src/features/OneClickApps/FakeSpec.ts
+++ b/packages/manager/src/features/OneClickApps/FakeSpec.ts
@@ -313,7 +313,7 @@ export const oneClickApps: OCA[] = [
     alt_description:
       'SQL and NoSQL database interface and monitoring for MySQL, MongoDB, PostgreSQL, and more.',
     categories: ['Databases'],
-    description: `All-in-one interface for scripting and monitoring databases, including MySQL, MariaDB, Percona, MongoDB, PostgreSQL, Galera Cluster and more. Easily deploy database instances, manage with an included CLI, and automate performance monitoring.`,
+    description: `All-in-one interface for scripting and monitoring databases, including MySQL, MariaDB, Percona, PostgreSQL, Galera Cluster and more. Easily deploy database instances, manage with an included CLI, and automate performance monitoring.`,
     summary:
       'All-in-one database deployment, management, and monitoring system.',
     related_guides: [


### PR DESCRIPTION
## Description 📝
Remove 'MongoDB' from ClusterControl description in Marketplace

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screen Shot 2023-05-03 at 3 22 59 PM](https://user-images.githubusercontent.com/125309814/236024233-768c1d29-1e86-46bd-8e51-142a0d541ca5.png) | ![Screen Shot 2023-05-03 at 3 22 30 PM](https://user-images.githubusercontent.com/125309814/236024274-0a6c4d86-2d39-4360-8b77-0f2f6e1ae3a2.png) |

## How to test 🧪
1. Go to: http://localhost:3000/linodes/create?type=One-Click
3. Search for "ClusterControl"
4. Click information icon
5. Observe drawer no longer contains reference to MongoDB