### PR TITLE
change: [M3-6483] – Update OCAs highlighted on empty state Linodes landing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Changed:
 - Removed MongoDB reference from ClusterControl description #9081
+- Highlighted Marketplace apps and button card height on empty state Linodes landing page #9083
 
 ### Fixed:
 - Allow simple search for IPv6 addresses #5088

--- a/packages/manager/src/features/linodes/LinodesLanding/AppsSection.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/AppsSection.tsx
@@ -70,8 +70,8 @@ const appsLinkData = [
   },
   {
     to:
-      '/linodes/create?type=One-Click&appID=869129&utm_source=marketplace&utm_medium=website&utm_campaign=aaPanel',
-    text: 'aaPanel',
+      '/linodes/create?type=One-Click&appID=912262&utm_source=marketplace&utm_medium=website&utm_campaign=Harbor',
+    text: 'Harbor',
   },
   {
     to:
@@ -80,18 +80,18 @@ const appsLinkData = [
   },
   {
     to:
-      '/linodes/create?type=One-Click&appID=691621&utm_source=marketplace&utm_medium=website&utm_campaign=Cloudron',
-    text: 'Cloudron',
+      '/linodes/create?type=One-Click&appID=1068726&utm_source=marketplace&utm_medium=website&utm_campaign=Postgres_Cluster',
+    text: 'Postgres Cluster',
   },
   {
     to:
-      '/linodes/create?type=One-Click&appID=593835&utm_source=marketplace&utm_medium=website&utm_campaign=Plesk',
-    text: 'Plesk',
+      '/linodes/create?type=One-Click&appID=985364&utm_source=marketplace&utm_medium=website&utm_campaign=Prometheus_Grafana',
+    text: 'Prometheus & Grafana',
   },
   {
     to:
-      '/linodes/create?type=One-Click&appID=985372&utm_source=marketplace&utm_medium=website&utm_campaign=Joomla',
-    text: 'Joomla',
+      '/linodes/create?type=One-Click&appID=1017300&utm_source=marketplace&utm_medium=website&utm_campaign=Kali',
+    text: 'Kali',
   },
 ];
 

--- a/packages/manager/src/features/linodes/LinodesLanding/AppsSection.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/AppsSection.tsx
@@ -28,7 +28,7 @@ const useStyles = makeStyles((theme: Theme) => {
       display: 'flex',
       alignItems: 'center',
       gridColumn: 'span 1',
-      height: theme.spacing(4.25),
+      height: theme.spacing(4.75),
       maxWidth: theme.spacing(20),
       paddingLeft: theme.spacing(),
       justifyContent: 'space-between',


### PR DESCRIPTION
## Description 📝
Update the highlighted OCAs on the empty state Linodes landing page and slightly increase the height of the button cards

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-05-04 at 4 28 03 PM](https://user-images.githubusercontent.com/114682940/236322117-c1c1567d-a4cf-4d34-860a-0bb9671119f1.jpg) | ![Screenshot 2023-05-04 at 4 36 21 PM](https://user-images.githubusercontent.com/114682940/236323377-03795922-b02c-4fee-81eb-186d46e7f105.jpg) |

## How to test 🧪
- Ensure the OCA links on the empty state Linodes landing page take you to the indicated OCAs