### PR TITLE
fix: Linode Details Access Table UI

### DIFF
--- a/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
+++ b/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
@@ -46,7 +46,8 @@ import { useTheme } from '@mui/material/styles';
 import { SxProps } from '@mui/system';
 import { useProfile } from 'src/queries/profile';
 import { LinodeHandlers } from './LinodesLanding/LinodesLanding';
-import { Table } from 'src/components/Table';
+// This component was built asuming an unmodified MUI <Table />
+import Table from '@mui/material/Table';
 import { TableCell } from 'src/components/TableCell';
 
 interface LinodeEntityDetailProps {


### PR DESCRIPTION
## Description 📝

- Fixes UI regression in the Linode Details Entity Header access table caused by https://github.com/linode/manager/pull/9082
- This could probably be fixed other ways but making the easy change because it matches the original intention of the component and we may rebuild some UI soon and it can be fixed then

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-05-05 at 9 21 08 AM](https://user-images.githubusercontent.com/115251059/236469194-3c65113f-844b-4146-a225-44d2ed850e33.jpg) | ![Screenshot 2023-05-05 at 9 20 50 AM](https://user-images.githubusercontent.com/115251059/236469243-0c54c586-c826-4971-a2c4-6cb5933dedd0.jpg) |

## How to test 🧪
- Check the UI shown above