### PR TITLE
test: Increase machine image upload timeout from 2 minutes to 4 minutes

### DIFF
--- a/packages/manager/cypress/e2e/images/create-linode-from-image.spec.ts
+++ b/packages/manager/cypress/e2e/images/create-linode-from-image.spec.ts
@@ -68,6 +68,25 @@ const createLinodeWithImageMock = (preselectedImage: boolean) => {
 };
 
 describe('create linode from image, mocked data', () => {
+  /*
+   * - Confirms UI flow when user attempts to create a Linode from images without having any images.
+   */
+  it('cannot create a Linode when the user has no private images', () => {
+    // Substrings of the message shown to ensure user is informed of why they
+    // cannot create a Linode and guided towards creating an Image.
+    const noImagesMessages = [
+      'You don’t have any private Images.',
+      'create an Image from one of your Linode’s disks.',
+    ];
+
+    mockGetAllImages([]).as('getImages');
+    cy.visitWithLogin('/linodes/create?type=Images');
+    cy.wait('@getImages');
+    noImagesMessages.forEach((message: string) => {
+      cy.findByText(message, { exact: false }).should('be.visible');
+    });
+  });
+
   it('creates linode from image on images tab', () => {
     cy.visitWithLogin('/linodes/create?type=Images');
     createLinodeWithImageMock(false);

--- a/packages/manager/cypress/e2e/images/machine-image-upload.spec.ts
+++ b/packages/manager/cypress/e2e/images/machine-image-upload.spec.ts
@@ -18,7 +18,7 @@ import { mockGetImage } from 'support/intercepts/images';
  * We extend the timeout used when waiting for image uploading and processing
  * since this operation can take a couple minutes.
  */
-const imageUploadWaitTimeout = 120000;
+const imageUploadWaitTimeout = 240000;
 
 /**
  * Returns a numeric image ID from a string-based image ID.

--- a/packages/manager/cypress/e2e/images/machine-image-upload.spec.ts
+++ b/packages/manager/cypress/e2e/images/machine-image-upload.spec.ts
@@ -10,15 +10,12 @@ import { ui } from 'support/ui';
 import { interceptOnce } from 'support/ui/common';
 import { apiMatcher } from 'support/util/intercepts';
 import { randomItem, randomLabel, randomPhrase } from 'support/util/random';
-import { mockGetImage } from 'support/intercepts/images';
-
-/*
- * Amount of time to wait for toast notification after uploading image, in ms.
- *
- * We extend the timeout used when waiting for image uploading and processing
- * since this operation can take a couple minutes.
- */
-const imageUploadWaitTimeout = 240000;
+import {
+  mockGetImage,
+  mockGetCustomImages,
+  mockDeleteImage,
+  mockUpdateImage,
+} from 'support/intercepts/images';
 
 /**
  * Returns a numeric image ID from a string-based image ID.
@@ -138,85 +135,94 @@ const uploadImage = (label: string) => {
 
 describe('machine image', () => {
   /*
-   * - Uploads machine image.
-   * - Confirms that image uploads successfully.
-   * - Confirms that machine image is listed in landing page as expected.
-   * - Confirms that notifications appear that describe the image's success status.
+   * - Confirms update and delete UI flows using mock API data.
    * - Confirms that image label can be updated.
    * - Confirms that image description can be updated.
    * - Confirms that image can be deleted.
    */
-  it('uploads, updates, and deletes a machine image, end-to-end', () => {
+  it('updates and deletes a machine image', () => {
     const initialLabel = randomLabel();
     const updatedLabel = randomLabel();
     const updatedDescription = randomPhrase();
 
-    uploadImage(initialLabel);
-    cy.wait('@imageUpload').then((xhr) => {
-      const imageId = xhr.response?.body.image.id;
-
-      ui.toast.assertMessage(`Image ${initialLabel} is now available.`, {
-        timeout: imageUploadWaitTimeout,
-      });
-
-      cy.get(`[data-qa-image-cell="${imageId}"]`).within(() => {
-        cy.findByText(initialLabel).should('be.visible');
-        cy.findByText('Ready').should('be.visible');
-
-        ui.actionMenu
-          .findByTitle(`Action menu for Image ${initialLabel}`)
-          .should('be.visible')
-          .click();
-      });
-
-      ui.actionMenuItem.findByTitle('Edit').should('be.visible').click();
-
-      ui.drawer
-        .findByTitle('Edit Image')
-        .should('be.visible')
-        .within(() => {
-          cy.findByLabelText('Label')
-            .should('be.visible')
-            .clear()
-            .type(updatedLabel);
-
-          cy.findByLabelText('Description')
-            .should('be.visible')
-            .clear()
-            .type(updatedDescription);
-
-          ui.buttonGroup
-            .findButtonByTitle('Save Changes')
-            .should('be.visible')
-            .should('be.enabled')
-            .click();
-        });
-
-      cy.get(`[data-qa-image-cell="${imageId}"]`).within(() => {
-        cy.findByText(updatedLabel).should('be.visible');
-        cy.findByText(initialLabel).should('not.exist');
-        ui.actionMenu
-          .findByTitle(`Action menu for Image ${updatedLabel}`)
-          .should('be.visible')
-          .click();
-      });
-
-      ui.actionMenuItem.findByTitle('Delete').should('be.visible').click();
-
-      ui.dialog
-        .findByTitle(`Delete Image ${updatedLabel}`)
-        .should('be.visible')
-        .within(() => {
-          ui.buttonGroup
-            .findButtonByTitle('Delete Image')
-            .should('be.visible')
-            .should('be.enabled')
-            .click();
-        });
-
-      ui.toast.assertMessage('Image has been scheduled for deletion.');
-      cy.findByText(updatedLabel).should('not.exist');
+    const mockImage = imageFactory.build({
+      label: initialLabel,
     });
+
+    const mockImageUpdated = {
+      ...mockImage,
+      label: updatedLabel,
+      description: updatedDescription,
+    };
+
+    mockGetCustomImages([mockImage]).as('getImages');
+    cy.visitWithLogin('/images');
+    cy.wait('@getImages');
+
+    cy.get(`[data-qa-image-cell="${mockImage.id}"]`).within(() => {
+      cy.findByText(initialLabel).should('be.visible');
+      cy.findByText('Ready').should('be.visible');
+
+      ui.actionMenu
+        .findByTitle(`Action menu for Image ${initialLabel}`)
+        .should('be.visible')
+        .click();
+    });
+
+    ui.actionMenuItem.findByTitle('Edit').should('be.visible').click();
+
+    mockUpdateImage(mockImage.id, mockImageUpdated).as('updateImage');
+    mockGetCustomImages([mockImageUpdated]).as('getImages');
+
+    ui.drawer
+      .findByTitle('Edit Image')
+      .should('be.visible')
+      .within(() => {
+        cy.findByLabelText('Label')
+          .should('be.visible')
+          .clear()
+          .type(updatedLabel);
+
+        cy.findByLabelText('Description')
+          .should('be.visible')
+          .clear()
+          .type(updatedDescription);
+
+        ui.buttonGroup
+          .findButtonByTitle('Save Changes')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    cy.wait(['@getImages', '@updateImage']);
+    cy.get(`[data-qa-image-cell="${mockImage.id}"]`).within(() => {
+      cy.findByText(updatedLabel).should('be.visible');
+      cy.findByText(initialLabel).should('not.exist');
+      ui.actionMenu
+        .findByTitle(`Action menu for Image ${updatedLabel}`)
+        .should('be.visible')
+        .click();
+    });
+
+    mockDeleteImage(mockImage.id).as('deleteImage');
+    mockGetCustomImages([]).as('getImages');
+    ui.actionMenuItem.findByTitle('Delete').should('be.visible').click();
+
+    ui.dialog
+      .findByTitle(`Delete Image ${updatedLabel}`)
+      .should('be.visible')
+      .within(() => {
+        ui.buttonGroup
+          .findButtonByTitle('Delete Image')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    cy.wait(['@deleteImage', '@getImages']);
+    ui.toast.assertMessage('Image has been scheduled for deletion.');
+    cy.findByText(updatedLabel).should('not.exist');
   });
 
   /*

--- a/packages/manager/cypress/e2e/images/smoke-create-image.spec.ts
+++ b/packages/manager/cypress/e2e/images/smoke-create-image.spec.ts
@@ -1,7 +1,10 @@
 import type { Image, Linode, Disk } from '@linode/api-v4/types';
 import { imageFactory } from 'src/factories/images';
 import { createLinode, deleteLinodeById } from 'support/api/linodes';
-import { interceptCreateImage, mockGetImages } from 'support/intercepts/images';
+import {
+  interceptCreateImage,
+  mockGetCustomImages,
+} from 'support/intercepts/images';
 import { mockGetLinodeDisks } from 'support/intercepts/linodes';
 import { randomLabel, randomNumber, randomPhrase } from 'support/util/random';
 
@@ -47,7 +50,7 @@ describe('create image', () => {
 
     // stub incoming response
     const mockImages = imageFactory.buildList(2);
-    mockGetImages(mockImages).as('getImages');
+    mockGetCustomImages(mockImages).as('getImages');
     interceptCreateImage(mockNewImage).as('createImage');
     createLinode().then((linode: Linode) => {
       // stub incoming disks response

--- a/packages/manager/cypress/support/intercepts/images.ts
+++ b/packages/manager/cypress/support/intercepts/images.ts
@@ -6,6 +6,7 @@ import type { Image, ImageStatus } from '@linode/api-v4/types';
 import { apiMatcher } from 'support/util/intercepts';
 import { paginateResponse } from 'support/util/paginate';
 import { imageFactory } from '@src/factories';
+import { getFilters } from 'support/util/request';
 
 /**
  * Intercepts POST request to create a Image.
@@ -19,14 +20,54 @@ export const interceptCreateImage = (image: Image): Cypress.Chainable<null> => {
 };
 
 /**
- * Intercepts GET request to mock image data.
+ * Intercepts GET request to retrieve all images and mocks response.
  *
- * @param images - an array of mock image objects
+ * @param images - Array of Image objects with which to mock response.
  *
  * @returns Cypress chainable.
  */
-export const mockGetImages = (images: Image[]): Cypress.Chainable<null> => {
+export const mockGetAllImages = (images: Image[]): Cypress.Chainable<null> => {
   return cy.intercept('GET', apiMatcher('images*'), paginateResponse(images));
+};
+
+/**
+ * Intercepts GET request to retrieve custom images and mocks response.
+ *
+ * @param images - Array of Image objects with which to mock response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetCustomImages = (
+  images: Image[]
+): Cypress.Chainable<null> => {
+  return cy.intercept('GET', apiMatcher('images*'), (req) => {
+    const filters = getFilters(req);
+    if (filters?.type === 'manual') {
+      req.reply(paginateResponse(images));
+      return;
+    }
+    req.continue();
+  });
+};
+
+/**
+ * Intercepts GET request to retrieve custom images and mocks response.
+ *
+ * @param images - Array of Image objects with which to mock response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetRecoveryImages = (
+  images: Image[]
+): Cypress.Chainable<null> => {
+  return cy.intercept('GET', apiMatcher('images*'), (req) => {
+    const filters = getFilters(req);
+    if (filters?.type === 'automatic') {
+      req.reply(paginateResponse(images));
+      return;
+    }
+    req.continue();
+  });
 };
 
 /**
@@ -54,4 +95,30 @@ export const mockGetImage = (
       })
     );
   });
+};
+
+/**
+ * Intercepts PUT request to update an image and mocks the response.
+ *
+ * @param id - ID of image being updated.
+ * @param updatedImage - Updated image with which to mock response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockUpdateImage = (
+  id: string,
+  updatedImage: Image
+): Cypress.Chainable<null> => {
+  return cy.intercept('PUT', apiMatcher(`images/${id}`), updatedImage);
+};
+
+/**
+ * Intercepts DELETE request to delete an image and mocks the response.
+ *
+ * @param id - ID of image being deleted.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockDeleteImage = (id: string): Cypress.Chainable<null> => {
+  return cy.intercept('DELETE', apiMatcher(`images/${id}`), {});
 };


### PR DESCRIPTION
## Description 📝
This increases the timeout in `machine-image-upload.spec.ts` when uploading a machine image and waiting for the success toast notification. We've been seeing a lot of flake (currently our flakiest test) because it's taking longer than 2 minutes for the uploaded images to become available.

## How to test 🧪
`yarn && yarn build && yarn start:manager:ci`, and then:

```bash
yarn cy:run -s "cypress/e2e/images/machine-image-upload.spec.ts"
```
