### PR TITLE
feat: [M3-6467] - Add resource links to Domains empty state landing page

### DIFF
--- a/packages/manager/src/features/Domains/DomainsEmptyLandingPage.tsx
+++ b/packages/manager/src/features/Domains/DomainsEmptyLandingPage.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import DomainIcon from 'src/assets/icons/entityIcons/domain.svg';
+import { ResourcesSection } from 'src/components/EmptyLandingPageResources/ResourcesSection';
+import { sendEvent } from 'src/utilities/ga';
+import {
+  gettingStartedGuides,
+  headers,
+  linkGAEvent,
+  youtubeLinkData,
+} from './DomainsEmptyResourcesData';
+
+interface Props {
+  navigateToCreate: () => void;
+  openImportZoneDrawer: () => void;
+}
+
+export const DomainsEmptyLandingState = (props: Props) => {
+  const { navigateToCreate, openImportZoneDrawer } = props;
+
+  return (
+    <ResourcesSection
+      buttonProps={[
+        {
+          onClick: () => {
+            sendEvent({
+              category: linkGAEvent.category,
+              action: 'Click:button',
+              label: 'Create Domain',
+            });
+            navigateToCreate();
+          },
+          children: 'Create Domain',
+        },
+        {
+          onClick: () => {
+            sendEvent({
+              category: linkGAEvent.category,
+              action: 'Click:button',
+              label: 'Import a Zone',
+            });
+            openImportZoneDrawer();
+          },
+          children: 'Import a Zone',
+        },
+      ]}
+      gettingStartedGuidesData={gettingStartedGuides}
+      headers={headers}
+      icon={DomainIcon}
+      linkGAEvent={linkGAEvent}
+      youtubeLinkData={youtubeLinkData}
+    />
+  );
+};

--- a/packages/manager/src/features/Domains/DomainsEmptyResourcesData.ts
+++ b/packages/manager/src/features/Domains/DomainsEmptyResourcesData.ts
@@ -1,0 +1,71 @@
+import {
+  youtubeChannelLink,
+  youtubeMoreLinkText,
+} from 'src/utilities/emptyStateLandingUtils';
+import type {
+  ResourcesHeaders,
+  ResourcesLinkSection,
+  ResourcesLinks,
+} from 'src/components/EmptyLandingPageResources/ResourcesLinksTypes';
+
+export const headers: ResourcesHeaders = {
+  description:
+    'A comprehensive, reliable, and fast DNS service that provides easy domain management for no additional cost.',
+
+  subtitle: 'Easy domain management',
+  title: 'Domains',
+};
+
+export const gettingStartedGuides: ResourcesLinkSection = {
+  links: [
+    {
+      to: 'https://www.linode.com/docs/products/networking/dns-manager/',
+      text: 'Overview of DNS Manager',
+    },
+    {
+      to:
+        'https://www.linode.com/docs/products/networking/dns-manager/get-started/',
+      text: 'Getting Started with DNS Manager',
+    },
+    {
+      to:
+        'https://www.linode.com/docs/products/networking/dns-manager/guides/create-domain/',
+      text: 'Create a Domain Zone',
+    },
+  ],
+  moreInfo: {
+    to: 'https://www.linode.com/docs/products/networking/dns-manager/guides/',
+    text: 'View additional DNS Manager guides',
+  },
+  title: 'Getting Started Guides',
+};
+
+export const youtubeLinkData: ResourcesLinkSection = {
+  links: [
+    {
+      to: 'https://www.youtube.com/watch?v=ganwcCm53Qs',
+      text: 'Linode DNS Manager | Total Control Over Your DNS Records',
+      external: true,
+    },
+    {
+      to: 'https://www.youtube.com/watch?v=Vb1JsfZlFLE',
+      text: 'Using Domains with Your Server | Common DNS Configurations',
+      external: true,
+    },
+    {
+      to: 'https://www.youtube.com/watch?v=mKfx4ryuMtY',
+      text: 'Connect a Domain to a Linode Server',
+      external: true,
+    },
+  ],
+  moreInfo: {
+    to: youtubeChannelLink,
+    text: youtubeMoreLinkText,
+  },
+  title: 'Video Playlist',
+};
+
+export const linkGAEvent: ResourcesLinks['linkGAEvent'] = {
+  action: 'Click:link',
+  category: 'Domains landing page empty',
+};

--- a/packages/manager/src/features/Domains/DomainsLanding.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.tsx
@@ -2,19 +2,15 @@ import * as React from 'react';
 import { Domain } from '@linode/api-v4/lib/domains';
 import { useSnackbar } from 'notistack';
 import { useHistory, useLocation } from 'react-router-dom';
-import DomainIcon from 'src/assets/icons/entityIcons/domain.svg';
 import Button from 'src/components/Button';
 import { CircleProgress } from 'src/components/CircleProgress';
 import { makeStyles } from '@mui/styles';
 import { Theme } from '@mui/material/styles';
-import Typography from 'src/components/core/Typography';
 import { DeletionDialog } from 'src/components/DeletionDialog/DeletionDialog';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import ErrorState from 'src/components/ErrorState';
 import LandingHeader from 'src/components/LandingHeader';
-import Link from 'src/components/Link';
 import Notice from 'src/components/Notice';
-import Placeholder from 'src/components/Placeholder';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import DisableDomainDialog from './DisableDomainDialog';
 import { Handlers as DomainHandlers } from './DomainActionMenu';
@@ -40,6 +36,7 @@ import { PaginationFooter } from 'src/components/PaginationFooter/PaginationFoot
 import Hidden from 'src/components/core/Hidden';
 import { CloneDomainDrawer } from './CloneDomainDrawer';
 import { EditDomainDrawer } from './EditDomainDrawer';
+import { DomainsEmptyLandingState } from './DomainsEmptyLandingPage';
 
 const DOMAIN_CREATE_ROUTE = '/domains/create';
 
@@ -207,35 +204,10 @@ export const DomainsLanding: React.FC<Props> = (props) => {
   if (domains?.results === 0) {
     return (
       <>
-        <DocumentTitleSegment segment="Domains" />
-        <Placeholder
-          title="Domains"
-          isEntity
-          icon={DomainIcon}
-          buttonProps={[
-            {
-              onClick: navigateToCreate,
-              children: 'Create Domain',
-            },
-            {
-              onClick: openImportZoneDrawer,
-              children: 'Import a Zone',
-            },
-          ]}
-        >
-          <Typography variant="subtitle1">
-            Create a Domain, add Domain records, import zones and domains.
-          </Typography>
-          <Typography variant="subtitle1">
-            <Link to="https://www.linode.com/docs/platform/manager/dns-manager-new-manager/">
-              Get help managing your Domains
-            </Link>
-            &nbsp;or&nbsp;
-            <Link to="https://www.linode.com/docs/">
-              visit our guides and tutorials.
-            </Link>
-          </Typography>
-        </Placeholder>
+        <DomainsEmptyLandingState
+          navigateToCreate={navigateToCreate}
+          openImportZoneDrawer={openImportZoneDrawer}
+        />
         <DomainZoneImportDrawer
           open={importDrawerOpen}
           onClose={closeImportZoneDrawer}


### PR DESCRIPTION
## Description 📝
**Add resource links to Domains empty state landing page**

> **Note**: Use `<video src="" />` tag when including recordings in table

| Before  | After   |
| ------- | ------- |
| ![image](https://user-images.githubusercontent.com/119517080/236835985-56dbc1b4-4457-4749-a7a6-cedc3f84828d.png) | ![image](https://user-images.githubusercontent.com/119517080/236835916-aec7ea45-ae56-4ff7-b815-c7fbf2f977b8.png) |

## How to test 🧪

- Navigate to http://localhost:3000/domains
- Validate empty domains landing page and validate the links
- Validate Create Domain and Import A Zone functionalities
- yarn test
- yarn cy:run 