### PR TITLE
refactor: [M3-6390] - MUI v5 - Components/ShowMoreExpansion

### DIFF
--- a/packages/manager/src/components/ShowMoreExpansion/ShowMoreExpansion.tsx
+++ b/packages/manager/src/components/ShowMoreExpansion/ShowMoreExpansion.tsx
@@ -1,49 +1,52 @@
 import * as React from 'react';
-import { makeStyles } from '@mui/styles';
+import { makeStyles } from 'tss-react/mui';
 import { Theme } from '@mui/material/styles';
 import KeyboardArrowRight from '@mui/icons-material/KeyboardArrowRight';
 import Button from 'src/components/Button';
 import Collapse from 'src/components/core/Collapse';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    paddingLeft: 0,
-    paddingRight: 0,
-    backgroundColor: 'transparent !important',
-    display: 'flex',
-    alignItems: 'center',
-    fontFamily: theme.font.bold,
-    width: 'auto',
-    color: theme.color.headline,
-    transition: theme.transitions.create('color'),
-    '&:hover': {
-      color: theme.palette.primary.main,
-      '& $caret': {
-        color: theme.palette.primary.light,
+const useStyles = makeStyles<void, 'caret'>()(
+  (theme: Theme, _params, classes) => ({
+    root: {
+      paddingLeft: 0,
+      paddingRight: 0,
+      backgroundColor: 'transparent !important',
+      display: 'flex',
+      alignItems: 'center',
+      fontFamily: theme.font.bold,
+      width: 'auto',
+      color: theme.color.headline,
+      transition: theme.transitions.create('color'),
+      '&:hover': {
+        color: theme.palette.primary.main,
+        [`& .${classes.caret}`]: {
+          color: theme.palette.primary.light,
+        },
       },
     },
-  },
-  caret: {
-    color: theme.palette.primary.main,
-    marginRight: theme.spacing(0.5),
-    fontSize: 28,
-    transition: 'transform .1s ease-in-out',
-    '&.rotate': {
-      transition: 'transform .3s ease-in-out',
-      transform: 'rotate(90deg)',
+    caret: {
+      color: theme.palette.primary.main,
+      marginRight: theme.spacing(0.5),
+      fontSize: 28,
+      transition: 'transform .1s ease-in-out',
+      '&.rotate': {
+        transition: 'transform .3s ease-in-out',
+        transform: 'rotate(90deg)',
+      },
     },
-  },
-}));
+  })
+);
 
-interface Props {
+interface ShowMoreExpansionProps {
   name: string;
   defaultExpanded?: boolean;
+  children?: JSX.Element;
 }
 
-const ShowMoreExpansion: React.FC<Props> = (props) => {
+const ShowMoreExpansion = (props: ShowMoreExpansionProps) => {
   const { name, defaultExpanded, children } = props;
 
-  const classes = useStyles();
+  const { classes } = useStyles();
 
   const [open, setOpen] = React.useState<boolean>(defaultExpanded || false);
 

--- a/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
+++ b/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
@@ -258,7 +258,6 @@ const UserDefinedFieldsPanel = (props: CombinedProps) => {
               required for creation.
             </Typography>
             <div
-              className={`${classes.optionalFieldWrapper} optionalFieldWrapper`}
             >
               {optionalUDFs.map((field: UserDefinedField) => {
                 const error = getError(field, errors);

--- a/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
+++ b/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
@@ -34,7 +34,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   username: {
     color: theme.color.grey1,
   },
-  optionalFieldWrapper: {},
   header: {
     display: 'flex',
     alignItems: 'center',
@@ -257,8 +256,7 @@ const UserDefinedFieldsPanel = (props: CombinedProps) => {
               These fields are additional configuration options and are not
               required for creation.
             </Typography>
-            <div
-            >
+            <div>
               {optionalUDFs.map((field: UserDefinedField) => {
                 const error = getError(field, errors);
                 return renderField(udf_data, handleChange, field, error);

--- a/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
+++ b/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
@@ -252,18 +252,20 @@ const UserDefinedFieldsPanel = (props: CombinedProps) => {
       {/* Optional Fields */}
       {optionalUDFs.length !== 0 && (
         <ShowMoreExpansion name="Advanced Options" defaultExpanded={true}>
-          <Typography variant="body1" className={classes.advDescription}>
-            These fields are additional configuration options and are not
-            required for creation.
-          </Typography>
-          <div
-            className={`${classes.optionalFieldWrapper} optionalFieldWrapper`}
-          >
-            {optionalUDFs.map((field: UserDefinedField) => {
-              const error = getError(field, errors);
-              return renderField(udf_data, handleChange, field, error);
-            })}
-          </div>
+          <>
+            <Typography variant="body1" className={classes.advDescription}>
+              These fields are additional configuration options and are not
+              required for creation.
+            </Typography>
+            <div
+              className={`${classes.optionalFieldWrapper} optionalFieldWrapper`}
+            >
+              {optionalUDFs.map((field: UserDefinedField) => {
+                const error = getError(field, errors);
+                return renderField(udf_data, handleChange, field, error);
+              })}
+            </div>
+          </>
         </ShowMoreExpansion>
       )}
     </Paper>


### PR DESCRIPTION
## Description 📝
Updates `ShowMoreExpansion` component used for Stackscripts `UserDefinedFieldsPanel` and `TicketAttachments` (although you're not able to attach more than 5 attachments at a time to a ticket, so we may be able to be remove this). I didn't want to do too much refactoring here since this seems like a component that will get removed in the future.

## Major Changes 🔄
- Update import/exports
- Remove jss for tss emotion

## Preview 📷
| TicketAttachment.tsx (can't get to show)  | UserDefinedFieldsPanel.tsx   |
| ------- | ------- |
| <img width="581" alt="Screen Shot 2023-05-08 at 1 22 57 PM" src="https://user-images.githubusercontent.com/125309814/236892465-1b826e3b-69fb-4481-b121-c9ba9a2cb131.png"> | ![Screen Shot 2023-05-08 at 1 03 41 PM](https://user-images.githubusercontent.com/125309814/236892488-01d5a579-a70a-4933-9f77-67df83fcb9b3.png) |

## How to test 🧪
1. You can either add some User Defined Fields (UDFs), or locally [comment out this line](https://github.com/linode/manager/blob/develop/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx#L253)