### PR TITLE
refactor: [M3-6301] – `MUI v5 - Components > CheckoutSummary`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - MUI v5 Migration - `Components > TableSortCell` #9082
 - MUI v5 Migration - `Components > TableRow` #9082
 - MUI v5 Migration - `Components > Notice` #9094
+- MUI v5 Migration - `Components > CheckoutSummary` #9100
 - React Query for Linodes Landing #9062
 
 ## [2023-05-01] - v1.92.0

--- a/packages/manager/src/components/CheckoutSummary/CheckoutSummary.tsx
+++ b/packages/manager/src/components/CheckoutSummary/CheckoutSummary.tsx
@@ -1,8 +1,8 @@
+import { styled, Theme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { useTheme } from '@mui/styles';
 import * as React from 'react';
 import Paper from '../core/Paper';
-import useMediaQuery from '@mui/material/useMediaQuery';
-import { makeStyles, useTheme } from '@mui/styles';
-import { Theme } from '@mui/material/styles';
 
 import Typography from '../core/Typography';
 import Grid from '../Grid';
@@ -22,59 +22,53 @@ export interface SummaryItem {
   hourly?: number;
 }
 
-const useStyles = makeStyles((theme: Theme) => ({
-  paper: {
-    marginTop: theme.spacing(3),
-    marginBottom: theme.spacing(3),
-  },
-  heading: {
-    marginBottom: theme.spacing(3),
-  },
-  summary: {
-    [theme.breakpoints.up('md')]: {
-      '& > div': {
-        borderRight: 'solid 1px #9DA4A6',
-        '&:last-child': {
-          borderRight: 'none',
-        },
-      },
-    },
-  },
-}));
-
 export const CheckoutSummary = (props: Props) => {
-  const classes = useStyles();
   const theme = useTheme<Theme>();
   const matchesSmDown = useMediaQuery(theme.breakpoints.down('md'));
 
   const { heading, agreement, displaySections, children } = props;
 
   return (
-    <Paper data-qa-summary className={classes.paper}>
-      <Typography
-        variant="h2"
-        data-qa-order-summary
-        className={classes.heading}
-      >
+    <StyledPaper data-qa-summary>
+      <StyledHeading variant="h2" data-qa-order-summary>
         {heading}
-      </Typography>
+      </StyledHeading>
       {displaySections.length === 0 ? (
-        <Typography variant="body1" className={classes.heading}>
+        <StyledHeading variant="body1">
           Please configure your Linode.
-        </Typography>
+        </StyledHeading>
       ) : null}
-      <Grid
+      <StyledSummary
         container
         spacing={3}
         direction={matchesSmDown ? 'column' : 'row'}
-        className={classes.summary}
       >
         {displaySections.map((item) => (
           <SummaryItem key={`${item.title}-${item.details}`} {...item} />
         ))}
-      </Grid>
+      </StyledSummary>
       {children}
       {agreement ? agreement : null}
-    </Paper>
+    </StyledPaper>
   );
 };
+
+const StyledPaper = styled(Paper)(({ theme }) => ({
+  marginTop: theme.spacing(3),
+  marginBottom: theme.spacing(3),
+}));
+
+const StyledHeading = styled(Typography)(({ theme }) => ({
+  marginBottom: theme.spacing(3),
+}));
+
+const StyledSummary = styled(Grid)(({ theme }) => ({
+  [theme.breakpoints.up('md')]: {
+    '& > div': {
+      borderRight: 'solid 1px #9DA4A6',
+      '&:last-child': {
+        borderRight: 'none',
+      },
+    },
+  },
+}));

--- a/packages/manager/src/components/CheckoutSummary/SummaryItem.tsx
+++ b/packages/manager/src/components/CheckoutSummary/SummaryItem.tsx
@@ -1,27 +1,15 @@
+import { styled } from '@mui/material/styles';
 import React from 'react';
-import { makeStyles } from '@mui/styles';
-import { Theme } from '@mui/material/styles';
 import Typography from '../core/Typography';
 import Grid from '../Grid';
 import { SummaryItem as Props } from './CheckoutSummary';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  item: {
-    paddingTop: '0 !important',
-    paddingBottom: '0 !important',
-    marginTop: theme.spacing(),
-    marginBottom: theme.spacing(),
-  },
-}));
-
 export const SummaryItem = ({ title, details }: Props) => {
-  const classes = useStyles();
-
   return (
-    <Grid item className={classes.item}>
+    <StyledGrid item>
       {title ? (
         <>
-          <Typography style={{ fontWeight: 'bold' }} component="span">
+          <Typography sx={{ fontWeight: 'bold' }} component="span">
             {title}
           </Typography>{' '}
         </>
@@ -29,6 +17,13 @@ export const SummaryItem = ({ title, details }: Props) => {
       <Typography component="span" data-qa-details={details}>
         {details}
       </Typography>
-    </Grid>
+    </StyledGrid>
   );
 };
+
+const StyledGrid = styled(Grid)(({ theme }) => ({
+  paddingTop: '0 !important',
+  paddingBottom: '0 !important',
+  marginTop: `${theme.spacing()} !important`,
+  marginBottom: `${theme.spacing()} !important`,
+}));


### PR DESCRIPTION
## Description 📝
Migrates `SRC > Components > CheckoutSummary` from JSS to styled components.

## How to test 🧪
Confirm that the checkout summary sections in the Linode Create and Kubernetes Create flows are unchanged compared to prod across viewport widths.