### PR TITLE
chore: [M3-6574] - Send Adobe Analytics Page Views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Add compression to logo when rendering in JPG format during invoice PDF generation #9069
 - Phone Verification - Verification Code State Does Not Reset #9059
 - Show error for PayPal payments #9058
+- Send Adobe Analytics Page Views #9108
 
 ### Tech Stories:
 - Enable Cypress `experimentalMemoryManagement` #9076

--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -91,11 +91,19 @@ export class App extends React.Component<CombinedProps, State> {
     }
 
     /**
-     * Send pageviews unless blocklisted.
+     * Send pageviews
      */
     this.props.history.listen(({ pathname }) => {
+      // Send Google Analytics page view events
       if ((window as any).ga) {
         (window as any).ga('send', 'pageview', pathname);
+      }
+
+      // Send Adobe Analytics page view events
+      if ((window as any)._satellite) {
+        (window as any)._satellite.track('page view', {
+          url: pathname,
+        });
       }
     });
 


### PR DESCRIPTION
## Description 📝

- Send page views to Adobe Analytics
- We are making this change to match what we did for Google Analytics
- This is pretty typical SPAs to need this

## How to test 🧪
- Check out this PR
- Run `_satellite.setDebug(true)` in the dev console
- Refresh the page
- Navigate around the app 
- Verify you see `🚀 "page view" does not match any direct call identifiers.` in the console
  - This sounds like an error, but I think it's just because configuration is needed on the Adobe Analytics side