### PR TITLE
refactor: [M3-6334] - MUI v5 - Components > EntityHeader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,23 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### Added:
+- Resource links to empty state Images landing page #9095
+- Resource links to empty state Object Storage landing page #9098
+
+### Changed:
+
+
+### Fixed:
+
+- Ability to search Linodes by IPv6 #9073
+
 ### Tech Stories:
 
 - React Query - Linodes - Networking #9046
 - React Query - Linodes - Details Header #9099
+- MUI v5 Migration - `Components > IconButton` #9102
+- MUI v5 Migration - `Components > EntityHeader` #9109
 
 ## [2023-05-15] - v1.93.0
 
@@ -19,8 +32,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Resource links to empty state Firewalls landing page #9078
 - Resource links to empty state StackScripts landing page #9091
 - Resource links to empty state Domains landing page #9092
-- Resource links to empty state Images landing page #9095
-- Resource links to empty state Object Storage landing page #9092
 - Ability download DNS zone file #9075
 
 ### Changed:
@@ -43,7 +54,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - MUI v5 Migration - `Components > TableRow` #9082
 - MUI v5 Migration - `Components > DownloadCSV` #9084
 - MUI v5 Migration - `Components > Notice` #9094
-- MUI v5 Migration - `Components > IconButton` #9102
 - MUI v5 Migration - `Components > CheckoutSummary` #9100
 - MUI v5 Migration - `Components > PrimaryNav` #9090
 - React Query for Linodes Landing #9062

--- a/packages/manager/src/components/EntityHeader/EntityHeader.stories.tsx
+++ b/packages/manager/src/components/EntityHeader/EntityHeader.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import EntityHeader from './EntityHeader';
+import { EntityHeader } from 'src/components/EntityHeader/EntityHeader';
 import Button from '../Button';
 import Link from '../Link';
 import Box from 'src/components/core/Box';

--- a/packages/manager/src/components/EntityHeader/EntityHeader.tsx
+++ b/packages/manager/src/components/EntityHeader/EntityHeader.tsx
@@ -10,12 +10,12 @@ export interface HeaderProps {
   variant?: TypographyProps['variant'];
 }
 
-export const EntityHeader: React.FC<HeaderProps> = ({
+export const EntityHeader = ({
   children,
   isSummaryView,
   title,
   variant = 'h2',
-}) => {
+}: HeaderProps) => {
   return (
     <Wrapper>
       {isSummaryView ? (
@@ -38,8 +38,6 @@ export const EntityHeader: React.FC<HeaderProps> = ({
     </Wrapper>
   );
 };
-
-export default EntityHeader;
 
 const Wrapper = styled('div', {
   name: 'EntityHeader',

--- a/packages/manager/src/components/EntityHeader/index.tsx
+++ b/packages/manager/src/components/EntityHeader/index.tsx
@@ -1,5 +1,0 @@
-import EntityHeader, { HeaderProps as _HeaderProps } from './EntityHeader';
-/* tslint:disable */
-export interface HeaderProps extends _HeaderProps {}
-
-export default EntityHeader;

--- a/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
+++ b/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
@@ -30,7 +30,7 @@ import { sendLinodeActionMenuItemEvent } from 'src/utilities/ga';
 import { pluralize } from 'src/utilities/pluralize';
 import { ipv4TableID } from './LinodesDetail/LinodeNetworking/LinodeNetworking';
 import { lishLink, sshLink } from './LinodesDetail/utilities';
-import EntityHeader from 'src/components/EntityHeader';
+import { EntityHeader } from 'src/components/EntityHeader/EntityHeader';
 import {
   getProgressOrDefault,
   isEventWithSecondaryLinodeStatus,


### PR DESCRIPTION
## Major Changes 🔄
- Fix import/export of EntityHeader
- removed React.FC

## Preview 📷
We currently have disabled summary view in dev, but it affects this component:
![Screen Shot 2023-05-11 at 4 39 42 PM](https://github.com/linode/manager/assets/125309814/d3739751-5b4f-4a53-868e-e161f21d5989)

## How to test 🧪
1. Things should function the same
