### PR TITLE
fix: [M3-6575] – Restore `<ProductInformationBanner />` in DatabaseEmptyState.tsx

### DIFF
--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseEmptyState.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseEmptyState.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
+import { useHistory } from 'react-router-dom';
 import DatabaseIcon from 'src/assets/icons/entityIcons/database.svg';
 import { ResourcesSection } from 'src/components/EmptyLandingPageResources/ResourcesSection';
+import ProductInformationBanner from 'src/components/ProductInformationBanner';
 import { sendEvent } from 'src/utilities/ga';
-import { useHistory } from 'react-router-dom';
 import {
   gettingStartedGuides,
   headers,
@@ -14,25 +15,29 @@ export const DatabaseEmptyState = () => {
   const { push } = useHistory();
 
   return (
-    <ResourcesSection
-      buttonProps={[
-        {
-          onClick: () => {
-            sendEvent({
-              category: linkGAEvent.category,
-              action: 'Click:button',
-              label: 'Create Database Cluster',
-            });
-            push('/databases/create');
+    <>
+      <ProductInformationBanner bannerLocation="Databases" warning important />
+
+      <ResourcesSection
+        buttonProps={[
+          {
+            onClick: () => {
+              sendEvent({
+                category: linkGAEvent.category,
+                action: 'Click:button',
+                label: 'Create Database Cluster',
+              });
+              push('/databases/create');
+            },
+            children: 'Create Database Cluster',
           },
-          children: 'Create Database Cluster',
-        },
-      ]}
-      gettingStartedGuidesData={gettingStartedGuides}
-      headers={headers}
-      icon={DatabaseIcon}
-      linkGAEvent={linkGAEvent}
-      youtubeLinkData={youtubeLinkData}
-    />
+        ]}
+        gettingStartedGuidesData={gettingStartedGuides}
+        headers={headers}
+        icon={DatabaseIcon}
+        linkGAEvent={linkGAEvent}
+        youtubeLinkData={youtubeLinkData}
+      />
+    </>
   );
 };


### PR DESCRIPTION
## Description 📝
Restores `<ProductInformationBanner />` in `DatabaseEmptyState.tsx` so DBaaS-specific banners will display on the empty state landing page.

## How to test 🧪
On an account with no DBaaS instances, confirm that you see the banner displayed in the screenshot below:

![Screenshot 2023-05-11 at 5 00 27 PM](https://github.com/linode/manager/assets/114682940/68fcec84-b5f3-40a8-80af-3e4dd5355872)
