### PR TITLE
fix typo in empty StackScripts page

### DIFF
--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptsEmptyResourcesData.ts
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptsEmptyResourcesData.ts
@@ -36,7 +36,7 @@ export const gettingStartedGuides: ResourcesLinkSection = {
   ],
   moreInfo: {
     to: 'https://www.linode.com/docs/products/tools/stackscripts/ ',
-    text: 'View additional Object Storage documentation',
+    text: 'View additional StackScripts documentation',
   },
   title: 'Getting Started Guides',
 };


### PR DESCRIPTION
## Description 📝
Fix typo in empty StackScripts landing page.

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/linode/manager/assets/119517080/99ff590c-2f3f-4c45-83fa-e584213e9d14) | ![image](https://github.com/linode/manager/assets/119517080/89796ec1-b57c-475b-8a2d-1655e5ab0e46) |

## How to test 🧪

- Navigate to http://localhost:3000/stackscripts/account
- Validate empty state StackScripts page


