### PR TITLE
fix: Redirect to Linodes Landing when delete happens on the Linode details page

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
@@ -196,6 +196,10 @@ const LinodeDetailHeader: React.FC<CombinedProps> = (props) => {
     setMigrateDialogOpen(true);
   };
 
+  const onDeleteSuccess = () => {
+    history.push('/linodes');
+  };
+
   const handlers = {
     onOpenPowerDialog,
     onOpenDeleteDialog,
@@ -253,6 +257,7 @@ const LinodeDetailHeader: React.FC<CombinedProps> = (props) => {
         open={deleteDialogOpen}
         onClose={closeDialogs}
         linodeId={matchedLinodeId}
+        onSuccess={onDeleteSuccess}
       />
       <LinodeResize
         open={resizeDialogOpen}

--- a/packages/manager/src/features/linodes/LinodesLanding/DeleteLinodeDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/DeleteLinodeDialog.tsx
@@ -11,10 +11,11 @@ interface Props {
   linodeId: number | undefined;
   open: boolean;
   onClose: () => void;
+  onSuccess?: () => void;
 }
 
 export const DeleteLinodeDialog = (props: Props) => {
-  const { linodeId, open, onClose } = props;
+  const { linodeId, open, onClose, onSuccess } = props;
 
   const { data: linode } = useLinodeQuery(
     linodeId ?? -1,
@@ -34,6 +35,9 @@ export const DeleteLinodeDialog = (props: Props) => {
   const onDelete = async () => {
     await mutateAsync();
     onClose();
+    if (onSuccess) {
+      onSuccess();
+    }
   };
 
   return (


### PR DESCRIPTION
## Description 📝

- Send the user back to `/linodes` when they delete a Linode from the details page
- This behavior was lost during a React Query for Linodes refactor, this PR is restoring the lost functionality

## Before

https://github.com/linode/manager/assets/115251059/0da079da-6a26-4b03-9afa-d5759534f426


## After

https://github.com/linode/manager/assets/115251059/4bd88bbf-e882-4edc-a889-4e340ae48ef5


## How to test 🧪
- Delete a Linode from its details page and verify that you get sent back to `/linodes` upon a successful deletion