### PR TITLE
fix: Remove 'MongoDB' from ClusterControl alt_description in Marketplace

### DIFF
--- a/packages/manager/src/features/OneClickApps/FakeSpec.ts
+++ b/packages/manager/src/features/OneClickApps/FakeSpec.ts
@@ -311,7 +311,7 @@ export const oneClickApps: OCA[] = [
     name: 'ClusterControl',
     alt_name: 'Database monitoring',
     alt_description:
-      'SQL and NoSQL database interface and monitoring for MySQL, MongoDB, PostgreSQL, and more.',
+      'SQL and NoSQL database interface and monitoring for MySQL, PostgreSQL, and more.',
     categories: ['Databases'],
     description: `All-in-one interface for scripting and monitoring databases, including MySQL, MariaDB, Percona, PostgreSQL, Galera Cluster and more. Easily deploy database instances, manage with an included CLI, and automate performance monitoring.`,
     summary:


### PR DESCRIPTION
## Description 📝
**Brief description explaining the purpose of the changes**
This is a follow up from #9081 because the `alt_description` still contained a reference to the app. This meant that ClusterControl came up in the search results if a user searched "MongoDB" (and would likely be read out via a screenreader, though I didn't confirm that). 

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-05-15 at 11 25 20 AM](https://github.com/linode/manager/assets/114685994/4888a8af-7dd9-4e2d-b167-1584cd7e0f42) | ![Screenshot 2023-05-15 at 11 25 07 AM](https://github.com/linode/manager/assets/114685994/69362702-feed-4456-8462-2bb3b14f6f9a) |

## How to test 🧪
2. **How to reproduce the issue (if applicable)?**
Test the marketplace search on staging and note that "ClusterControl" is returned as a search result if the user searches for "MongoDB". 
4. **How to verify changes?**
Test the marketplace search on staging and note that no search results are returned as a search result if the user searches for "MongoDB". 

