### PR TITLE
Refactor: [M3-6333] - MUI v5 Migration - `Components > EntityDetail`

### DIFF
--- a/packages/manager/src/components/EntityDetail/EntityDetail.tsx
+++ b/packages/manager/src/components/EntityDetail/EntityDetail.tsx
@@ -22,7 +22,6 @@ export const EntityDetail = (props: EntityDetailProps) => {
   return (
     <>
       {header}
-
       {body !== undefined && <GridBody xs={12}>{body}</GridBody>}
       <GridFooter xs={12} body={body}>
         {footer}

--- a/packages/manager/src/components/EntityDetail/EntityDetail.tsx
+++ b/packages/manager/src/components/EntityDetail/EntityDetail.tsx
@@ -7,8 +7,7 @@
  */
 
 import * as React from 'react';
-import { makeStyles } from '@mui/styles';
-import { Theme } from '@mui/material/styles';
+import { styled } from '@mui/material/styles';
 import Grid from '@mui/material/Unstable_Grid2';
 
 export interface EntityDetailProps {
@@ -17,50 +16,41 @@ export interface EntityDetailProps {
   footer: JSX.Element;
 }
 
-const useStyles = makeStyles((theme: Theme) => ({
-  header: {},
-  body: {
-    paddingRight: theme.spacing(),
-    paddingBottom: theme.spacing(),
-    backgroundColor: theme.bg.bgPaper,
-    borderTop: `1px solid ${theme.borderColors.borderTable}`,
-    borderBottom: `1px solid ${theme.borderColors.borderTable}`,
-  },
-  footer: {
-    backgroundColor: theme.bg.bgPaper,
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
-    padding: `7px 16px !important`, // This will be taken care of during refactor
-  },
-  footerBorder: {
-    borderTop: `1px solid ${theme.borderColors.borderTable}`,
-  },
-}));
-
-export const EntityDetail: React.FC<EntityDetailProps> = (props) => {
+export const EntityDetail = (props: EntityDetailProps) => {
   const { header, body, footer } = props;
-  const classes = useStyles();
 
   return (
     <>
       {header}
 
-      {body !== undefined && (
-        <Grid xs={12} className={classes.body}>
-          {body}
-        </Grid>
-      )}
-      <Grid
-        xs={12}
-        className={`${classes.footer} ${
-          body === undefined && classes.footerBorder
-        }`}
-      >
+      {body !== undefined && <GridBody xs={12}>{body}</GridBody>}
+      <GridFooter xs={12} body={body}>
         {footer}
-      </Grid>
+      </GridFooter>
     </>
   );
 };
+
+const GridBody = styled(Grid)(({ theme }) => ({
+  backgroundColor: theme.bg.bgPaper,
+  borderBottom: `1px solid ${theme.borderColors.borderTable}`,
+  borderTop: `1px solid ${theme.borderColors.borderTable}`,
+  paddingBottom: theme.spacing(),
+  paddingRight: theme.spacing(),
+}));
+
+const GridFooter = styled(Grid)<Partial<EntityDetailProps>>(
+  ({ theme, ...props }) => ({
+    alignItems: 'center',
+    backgroundColor: theme.bg.bgPaper,
+    borderTop:
+      props.body === undefined
+        ? `1px solid ${theme.borderColors.borderTable}`
+        : '',
+    display: 'flex',
+    flexDirection: 'row',
+    padding: `7px 16px`,
+  })
+);
 
 export default EntityDetail;

--- a/packages/manager/src/components/EntityDetail/EntityDetail.tsx
+++ b/packages/manager/src/components/EntityDetail/EntityDetail.tsx
@@ -45,7 +45,7 @@ const GridFooter = styled(Grid)<Partial<EntityDetailProps>>(
     borderTop:
       props.body === undefined
         ? `1px solid ${theme.borderColors.borderTable}`
-        : '',
+        : undefined,
     display: 'flex',
     flexDirection: 'row',
     padding: `7px 16px`,


### PR DESCRIPTION
## Description 📝
Refactor `EntityDetail` to `styled` api away from `jss`.

## Preview 📷
| Screenshot   |
| ------- |
| <img width="1200" alt="Screen Shot 2023-05-16 at 10 58 44 AM" src="https://github.com/linode/manager/assets/125309814/870a00ab-994c-44f1-b771-14d77b3e2056"> |

## How to test 🧪
1. `yarn dev`
2. Go to a linodes detail page: http://localhost:3000/linodes/ {id}
3. Observe there are no visual changes
