### PR TITLE
fix: [M3-6581] - Fix Cloud Manager Maintenance Mode

### DIFF
--- a/packages/manager/.changeset/pr-9130-fixed-1684419720777.md
+++ b/packages/manager/.changeset/pr-9130-fixed-1684419720777.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+fix cloud manager maintenance mode ([#9130](https://github.com/linode/manager/pull/9130))

--- a/packages/manager/src/IdentifyUser.tsx
+++ b/packages/manager/src/IdentifyUser.tsx
@@ -15,7 +15,7 @@ import { useProfile } from './queries/profile';
  * and this is a good side-effect usage of useEffect().
  */
 
-export const IdentifyUser: React.FC<{}> = () => {
+export const IdentifyUser = () => {
   const { data: account, error: accountError } = useAccount();
   const { data: profile } = useProfile();
 
@@ -86,6 +86,14 @@ export const IdentifyUser: React.FC<{}> = () => {
            */
 
           .catch(() => setFeatureFlagsLoaded());
+      } else {
+        // We "setFeatureFlagsLoaded" here because if the API is
+        // in maintenance mode, we can't fetch the user's username.
+        // Therefore, the `if` above won't "setFeatureFlagsLoaded".
+
+        // If we're being honest, featureFlagsLoading shouldn't be tracked by Redux
+        // and this code should go away eventually.
+        setFeatureFlagsLoaded();
       }
     }
   }, [client, userID, username, account, accountError]);


### PR DESCRIPTION
## Description 📝

- Wow this literally took me almost entire workday to figure out 😖
- Fixes API Maintenance mode (I think) 🎉🚀
  - I say I think because I can't perfectly reproduce our production load balancer configuration locally so if other problems lie at the loadbalancer level, maintenance mode may still not work. I'm pretty confident this will fix it.

## Major Changes 🔄
- If the `if` statement that calls `client.identify` can't run, just mark feature flags as loaded in an `else`
  - This allows `MainContent.tsx` to render, therefore allowing `<MaintenanceScreen />` to render when our axios interceptor intercepts the maintenance header

## Preview 📷

> **Note**: Before, Cloud Manager would just show the splash screen loading spinner infinitely 

![Screenshot 2023-05-16 at 10 30 43 PM](https://github.com/linode/manager/assets/115251059/c38f4f2a-dd63-4f31-b737-72c9449446f8)

## How to test 🧪

Contact me, trust me and approve, or wait for testing instructions to be updated