### PR TITLE
refactor: [M3-6374, M3-6344] - MUI v5 Migration - `Components > Placeholder & H1Header`

### DIFF
--- a/packages/manager/.changeset/pr-9131-tech-stories-1684293772869.md
+++ b/packages/manager/.changeset/pr-9131-tech-stories-1684293772869.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+[M3-6374] - MUI v5 Migration - `Components > Placeholder` ([#9131](https://github.com/linode/manager/pull/9131))

--- a/packages/manager/.changeset/pr-9131-tech-stories-1684293796866.md
+++ b/packages/manager/.changeset/pr-9131-tech-stories-1684293796866.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+[M3-6344] - MUI v5 Migration - `Components > H1Header` ([#9131](https://github.com/linode/manager/pull/9131))

--- a/packages/manager/src/components/Breadcrumb/FinalCrumb.tsx
+++ b/packages/manager/src/components/Breadcrumb/FinalCrumb.tsx
@@ -5,7 +5,7 @@ import { makeStyles } from '@mui/styles';
 import { Theme } from '@mui/material/styles';
 import Typography from 'src/components/core/Typography';
 import EditableText from 'src/components/EditableText';
-import H1Header from 'src/components/H1Header';
+import { H1Header } from 'src/components/H1Header/H1Header';
 import { EditableProps, LabelProps } from './types';
 
 const useStyles = makeStyles((theme: Theme) => ({

--- a/packages/manager/src/components/EditableText/EditableText.tsx
+++ b/packages/manager/src/components/EditableText/EditableText.tsx
@@ -8,7 +8,7 @@ import ClickAwayListener from 'src/components/core/ClickAwayListener';
 import { makeStyles } from '@mui/styles';
 import { Theme } from '@mui/material/styles';
 import { TextFieldProps } from 'src/components/core/TextField';
-import H1Header from 'src/components/H1Header';
+import { H1Header } from 'src/components/H1Header/H1Header';
 import TextField from '../TextField';
 
 const useStyles = makeStyles((theme: Theme) => ({

--- a/packages/manager/src/components/EmptyLandingPageResources/ResourcesSection.tsx
+++ b/packages/manager/src/components/EmptyLandingPageResources/ResourcesSection.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import DocsIcon from 'src/assets/icons/docs.svg';
 import ExternalLinkIcon from 'src/assets/icons/external-link.svg';
-import Placeholder from 'src/components/Placeholder';
+import { Placeholder } from 'src/components/Placeholder/Placeholder';
 import PointerIcon from 'src/assets/icons/pointer.svg';
 import Typography from 'src/components/core/Typography';
 import YoutubeIcon from 'src/assets/icons/youtube.svg';

--- a/packages/manager/src/components/EnhancedSelect/Select.tsx
+++ b/packages/manager/src/components/EnhancedSelect/Select.tsx
@@ -19,7 +19,7 @@ import MultiValueRemove from './components/MultiValueRemove';
 import NoOptionsMessage from './components/NoOptionsMessage';
 import Option from './components/Option';
 import Control from './components/SelectControl';
-import Placeholder from './components/SelectPlaceholder';
+import { Placeholder } from 'src/components/Placeholder/Placeholder';
 import { reactSelectStyles, useStyles } from './Select.styles';
 import { Theme, useTheme } from '@mui/material';
 

--- a/packages/manager/src/components/EnhancedSelect/Select.tsx
+++ b/packages/manager/src/components/EnhancedSelect/Select.tsx
@@ -19,7 +19,7 @@ import MultiValueRemove from './components/MultiValueRemove';
 import NoOptionsMessage from './components/NoOptionsMessage';
 import Option from './components/Option';
 import Control from './components/SelectControl';
-import { Placeholder } from 'src/components/Placeholder/Placeholder';
+import Placeholder from './components/SelectPlaceholder';
 import { reactSelectStyles, useStyles } from './Select.styles';
 import { Theme, useTheme } from '@mui/material';
 

--- a/packages/manager/src/components/H1Header/H1Header.tsx
+++ b/packages/manager/src/components/H1Header/H1Header.tsx
@@ -1,30 +1,21 @@
 import * as React from 'react';
-import { makeStyles } from '@mui/styles';
+import { SxProps } from '@mui/system';
 import Typography from 'src/components/core/Typography';
 
-interface Props {
-  title: string;
+interface H1HeaderProps {
   className?: string;
   dataQaEl?: string;
   renderAsSecondary?: boolean;
+  sx?: SxProps;
+  title: string;
 }
-
-const useStyles = makeStyles({
-  root: {
-    '&:focus': {
-      outline: 'none',
-    },
-  },
-});
-
 // Accessibility Feature:
 // The role of this component is to implement focus to the main content when navigating the application
 // Since it is a one page APP, we need to help users focus on the main content when switching views
 // It should serve as the only source for all H1s
-const H1Header: React.FC<Props> = (props) => {
+export const H1Header = (props: H1HeaderProps) => {
   const h1Header = React.useRef<HTMLDivElement>(null);
-  const { className, title, dataQaEl, renderAsSecondary } = props;
-  const classes = useStyles();
+  const { className, dataQaEl, renderAsSecondary, sx, title } = props;
 
   // React.useEffect(() => {
   //   if (h1Header.current !== null) {
@@ -34,17 +25,20 @@ const H1Header: React.FC<Props> = (props) => {
 
   return (
     <Typography
-      variant="h1"
+      className={className}
       component={renderAsSecondary ? 'h2' : 'h1'}
-      className={`${classes.root} ${className}`}
-      // If we're rendering as an h2, we want to remove the autofocus functionality
-      ref={renderAsSecondary ? null : h1Header}
-      tabIndex={0}
       data-qa-header={dataQaEl ? dataQaEl : ''}
+      ref={renderAsSecondary ? null : h1Header} // If we're rendering as an h2, we want to remove the autofocus functionality
+      tabIndex={0}
+      sx={{
+        '&:focus': {
+          outline: 'none',
+        },
+        ...sx,
+      }}
+      variant="h1"
     >
       {title}
     </Typography>
   );
 };
-
-export default H1Header;

--- a/packages/manager/src/components/H1Header/index.tsx
+++ b/packages/manager/src/components/H1Header/index.tsx
@@ -1,2 +1,0 @@
-import H1Header from './H1Header';
-export default H1Header;

--- a/packages/manager/src/components/NotFound.tsx
+++ b/packages/manager/src/components/NotFound.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import ErrorOutline from '@mui/icons-material/ErrorOutline';
 
-import Placeholder from 'src/components/Placeholder';
+import { Placeholder } from 'src/components/Placeholder/Placeholder';
 
 interface Props {
   className?: string;

--- a/packages/manager/src/components/Placeholder/.Placeholder.stories.mdx
+++ b/packages/manager/src/components/Placeholder/.Placeholder.stories.mdx
@@ -1,5 +1,5 @@
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
-import Placeholder from '/src/components/Placeholder';
+import { Placeholder } from 'src/components/Placeholder/Placeholder';
 
 <Meta
   title="Features/Entity Landing Page/Placeholders"

--- a/packages/manager/src/components/Placeholder/Placeholder.tsx
+++ b/packages/manager/src/components/Placeholder/Placeholder.tsx
@@ -1,87 +1,53 @@
-import classNames from 'classnames';
 import * as React from 'react';
 import LinodeIcon from 'src/assets/addnewmenu/linode.svg';
 import Button, { ButtonProps } from 'src/components/Button';
-import { makeStyles } from '@mui/styles';
-import { Theme } from '@mui/material/styles';
+import { styled, useTheme } from '@mui/material/styles';
 import Typography from 'src/components/core/Typography';
-import H1Header from 'src/components/H1Header';
+import { H1Header } from 'src/components/H1Header/H1Header';
 import { TransferDisplay } from '../TransferDisplay/TransferDisplay';
+import { fadeIn } from 'src/styles/keyframes';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  '@keyframes scaleIn': {
-    from: {
-      transform: 'translateX( -10px ) rotateY( -180deg )',
-    },
-    to: {
-      transformOrigin: 'center center',
-    },
-  },
-  '@keyframes fadeIn': {
-    from: {
-      opacity: 0,
-    },
-    to: {
-      opacity: 1,
-    },
-  },
-  container: {
-    display: 'grid',
-    gridTemplateColumns: 'repeat(5, 1fr) 35% 35% repeat(5, 1fr)',
-    gridTemplateRows:
-      'max-content 12px max-content 7px max-content 15px max-content 24px max-content 64px min-content',
-    gridTemplateAreas: `
-      ". . . . . icon icon . . . . ."
-      ". . . . . . . . . . . ."
-      ". . . . . title title . . . . ."
-      ". . . . . . . . . . . ."
-      ". . . . . subtitle subtitle . . . . ."
-      ". . . . . . . . . . . ."
-      ". . . . . copy copy . . . . ."
-      ". . . . . . . . . . . ."
-      ". . . . . button button . . . . ."
-      ". . . . . . . . . . . ."
-      ". . . links links links links links links . . ."
-    `,
-    justifyItems: 'center',
-  },
-  containerAdjustment: {
-    gridTemplateRows:
-      'max-content 12px max-content 7px max-content 15px max-content 24px max-content 40px',
-    gridTemplateAreas: `
-      ". . . . . icon icon . . . . ."
-      ". . . . . . . . . . . ."
-      ". . . . . title title . . . . ."
-      ". . . . . . . . . . . ."
-      ". . . . . subtitle subtitle . . . . ."
-      ". . . . . . . . . . . ."
-      ". . . . . copy copy . . . . ."
-      ". . . . . . . . . . . ."
-      ". . . . . button button . . . . ."
-    `,
-  },
-  root: {
-    padding: `${theme.spacing(2)} 0`,
-    [theme.breakpoints.up('md')]: {
-      padding: `${theme.spacing(10)} 0`,
-    },
-  },
-  rootWithShowTransferDisplay: {
-    padding: `${theme.spacing(4)} 0`,
-    [theme.breakpoints.up('md')]: {
-      padding: `${theme.spacing(10)} 0 ${theme.spacing(4)}`,
-    },
-  },
-  copy: {
-    textAlign: 'center',
-    gridArea: 'copy',
-    minWidth: 'min-content',
-    maxWidth: '75%',
-    [theme.breakpoints.down('md')]: {
-      maxWidth: 'none',
-    },
-  },
-  icon: {
+export interface ExtendedButtonProps extends ButtonProps {
+  target?: string;
+}
+
+export interface PlaceholderProps {
+  buttonProps?: ExtendedButtonProps[];
+  children?: string | React.ReactNode;
+  className?: string;
+  dataQAPlaceholder?: string | boolean;
+  descriptionMaxWidth?: number;
+  icon?: React.ComponentType<any>;
+  isEntity?: boolean;
+  linksSection?: JSX.Element;
+  renderAsSecondary?: boolean;
+  showTransferDisplay?: boolean;
+  subtitle?: string;
+  title: string;
+}
+
+export const Placeholder = (props: PlaceholderProps) => {
+  const {
+    buttonProps,
+    dataQAPlaceholder,
+    descriptionMaxWidth,
+    icon: Icon = LinodeIcon,
+    isEntity,
+    linksSection,
+    renderAsSecondary,
+    showTransferDisplay,
+    subtitle,
+    title,
+  } = props;
+
+  const theme = useTheme();
+  const hasSubtitle = subtitle !== undefined;
+
+  /**
+   * TODO: We should use these styles to create a Styled component THEN
+   * pass that into the Placeholder component
+   * */
+  const IconStyles = {
     width: '160px',
     height: '160px',
     padding: theme.spacing(2),
@@ -99,140 +65,48 @@ const useStyles = makeStyles((theme: Theme) => ({
     '& .bucket.insidePath path': {
       fill: theme.palette.primary.main,
     },
-  },
-  entity: {
-    borderRadius: '50%',
-    backgroundColor: theme.bg.bgPaper,
-    color: theme.color.green,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  title: {
-    textAlign: 'center',
-    gridArea: 'title',
-  },
-  subtitle: {
-    gridArea: 'subtitle',
-    textAlign: 'center',
-    color: theme.palette.text.primary,
-  },
-  '& .insidePath path': {
-    opacity: 0,
-    animation: '$fadeIn .2s ease-in-out forwards .3s',
-    stroke: theme.palette.primary.main,
-  },
-  '& .bucket.insidePath path': {
-    fill: theme.palette.primary.main,
-  },
-  button: {
-    gridArea: 'button',
-    display: 'flex',
-    gap: theme.spacing(2),
-    [theme.breakpoints.down('xs')]: {
-      flexDirection: 'column',
-    },
-  },
-  linksSection: {
-    gridArea: 'links',
-    borderTop: `1px solid ${theme.name === 'light' ? '#e3e5e8' : '#2e3238'}`,
-    paddingTop: '38px',
-  },
-  linksSectionBottomSeparation: {
-    paddingBottom: theme.spacing(2),
-    [theme.breakpoints.up('md')]: {
-      paddingBottom: theme.spacing(4),
-    },
-    borderBottom: `1px solid ${theme.name === 'light' ? '#e3e5e8' : '#2e3238'}`,
-  },
-  iconWrapper: {
-    gridArea: 'icon',
-    padding: theme.spacing(2),
-  },
-}));
-
-export interface ExtendedButtonProps extends ButtonProps {
-  target?: string;
-}
-
-export interface Props {
-  buttonProps?: ExtendedButtonProps[];
-  children?: string | React.ReactNode;
-  className?: string;
-  dataQAPlaceholder?: string | boolean;
-  descriptionMaxWidth?: number;
-  icon?: React.ComponentType<any>;
-  isEntity?: boolean;
-  linksSection?: JSX.Element;
-  renderAsSecondary?: boolean;
-  showTransferDisplay?: boolean;
-  subtitle?: string;
-  title: string;
-}
-
-const Placeholder: React.FC<Props> = (props) => {
-  const {
-    buttonProps,
-    dataQAPlaceholder,
-    descriptionMaxWidth,
-    icon: Icon,
-    isEntity,
-    linksSection,
-    renderAsSecondary,
-    showTransferDisplay,
-    subtitle,
-    title,
-  } = props;
-
-  const classes = useStyles();
-
-  const hasSubtitle = subtitle !== undefined;
+  };
 
   return (
     <>
-      <div
-        className={classNames(props.className, {
-          [classes.container]: true,
-          [classes.root]: true,
-          [classes.containerAdjustment]:
-            showTransferDisplay && linksSection === undefined,
-          [classes.rootWithShowTransferDisplay]: showTransferDisplay,
-        })}
+      <PlaceholderRoot
+        className={props.className}
         data-qa-placeholder-container={dataQAPlaceholder || true}
       >
-        <div
-          className={`${classes.iconWrapper} ${isEntity ? classes.entity : ''}`}
-        >
-          {Icon && <Icon className={classes.icon} />}
-        </div>
+        <StyledIconWrapper isEntity={isEntity}>
+          {Icon && <Icon style={IconStyles} />}
+        </StyledIconWrapper>
 
         <H1Header
           title={title}
-          className={classes.title}
           renderAsSecondary={renderAsSecondary}
           data-qa-placeholder-title
+          sx={{
+            textAlign: 'center',
+            gridArea: 'title',
+          }}
         />
         {hasSubtitle ? (
-          <Typography variant="h2" className={classes.subtitle}>
+          <Typography
+            variant="h2"
+            sx={{
+              gridArea: 'subtitle',
+              textAlign: 'center',
+              color: theme.palette.text.primary,
+            }}
+          >
             {subtitle}
           </Typography>
         ) : null}
 
-        <div
-          className={classes.copy}
-          style={{
-            maxWidth: descriptionMaxWidth
-              ? descriptionMaxWidth
-              : classes.copy['maxWidth'],
-          }}
-        >
+        <StyledCopy descriptionMaxWidth={descriptionMaxWidth}>
           {typeof props.children === 'string' ? (
             <Typography variant="subtitle1">{props.children}</Typography>
           ) : (
             props.children
           )}
-        </div>
-        <div className={classes.button}>
+        </StyledCopy>
+        <StyledButtonWrapper>
           {buttonProps &&
             buttonProps.map((thisButton, index) => (
               <Button
@@ -243,25 +117,124 @@ const Placeholder: React.FC<Props> = (props) => {
                 key={index}
               />
             ))}
-        </div>
+        </StyledButtonWrapper>
         {linksSection !== undefined ? (
-          <div
-            className={classNames({
-              [classes.linksSection]: true,
-              [classes.linksSectionBottomSeparation]: showTransferDisplay,
-            })}
-          >
+          <StyledLinksSection showTransferDisplay={showTransferDisplay}>
             {linksSection}
-          </div>
+          </StyledLinksSection>
         ) : null}
-      </div>
+      </PlaceholderRoot>
       {showTransferDisplay ? <TransferDisplay spacingTop={0} /> : null}
     </>
   );
 };
 
-Placeholder.defaultProps = {
-  icon: LinodeIcon,
-};
+const StyledIconWrapper = styled('div')<Pick<PlaceholderProps, 'isEntity'>>(
+  ({ theme, ...props }) => ({
+    gridArea: 'icon',
+    padding: theme.spacing(2),
+    ...(props.isEntity && {
+      borderRadius: '50%',
+      backgroundColor: theme.bg.bgPaper,
+      color: theme.color.green,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+    }),
+  })
+);
 
-export default Placeholder;
+const StyledButtonWrapper = styled('div')(({ theme }) => ({
+  button: {
+    gridArea: 'button',
+    display: 'flex',
+    gap: theme.spacing(2),
+    [theme.breakpoints.down('xs')]: {
+      flexDirection: 'column',
+    },
+  },
+}));
+
+const StyledLinksSection = styled('div')<
+  Pick<PlaceholderProps, 'showTransferDisplay'>
+>(({ theme, ...props }) => ({
+  gridArea: 'links',
+  borderTop: `1px solid ${theme.name === 'light' ? '#e3e5e8' : '#2e3238'}`,
+  paddingTop: '38px',
+
+  ...(props.showTransferDisplay && {
+    paddingBottom: theme.spacing(2),
+    [theme.breakpoints.up('md')]: {
+      paddingBottom: theme.spacing(4),
+    },
+    borderBottom: `1px solid ${theme.name === 'light' ? '#e3e5e8' : '#2e3238'}`,
+  }),
+}));
+
+const StyledCopy = styled('div', {
+  label: 'StyledCopy',
+})<Pick<PlaceholderProps, 'descriptionMaxWidth'>>(({ theme, ...props }) => ({
+  textAlign: 'center',
+  gridArea: 'copy',
+  minWidth: 'min-content',
+  maxWidth: props.descriptionMaxWidth ? props.descriptionMaxWidth : '75%',
+  [theme.breakpoints.down('md')]: {
+    maxWidth: 'none',
+  },
+}));
+
+const PlaceholderRoot = styled('div')<Partial<PlaceholderProps>>(
+  ({ theme, ...props }) => ({
+    display: 'grid',
+    gridTemplateColumns: 'repeat(5, 1fr) 35% 35% repeat(5, 1fr)',
+    gridTemplateRows:
+      props.showTransferDisplay && props.linksSection === undefined
+        ? 'max-content 12px max-content 7px max-content 15px max-content 24px max-content 40px'
+        : 'max-content 12px max-content 7px max-content 15px max-content 24px max-content 64px min-content',
+    gridTemplateAreas:
+      props.showTransferDisplay && props.linksSection === undefined
+        ? `
+        ". . . . . icon icon . . . . ."
+        ". . . . . . . . . . . ."
+        ". . . . . title title . . . . ."
+        ". . . . . . . . . . . ."
+        ". . . . . subtitle subtitle . . . . ."
+        ". . . . . . . . . . . ."
+        ". . . . . copy copy . . . . ."
+        ". . . . . . . . . . . ."
+        ". . . . . button button . . . . ."
+      `
+        : `
+        ". . . . . icon icon . . . . ."
+        ". . . . . . . . . . . ."
+        ". . . . . title title . . . . ."
+        ". . . . . . . . . . . ."
+        ". . . . . subtitle subtitle . . . . ."
+        ". . . . . . . . . . . ."
+        ". . . . . copy copy . . . . ."
+        ". . . . . . . . . . . ."
+        ". . . . . button button . . . . ."
+        ". . . . . . . . . . . ."
+        ". . . links links links links links links . . ."
+      `,
+    justifyItems: 'center',
+    padding: props.showTransferDisplay
+      ? `${theme.spacing(4)} 0`
+      : `${theme.spacing(2)} 0`,
+    [theme.breakpoints.up('md')]: {
+      padding: props.showTransferDisplay
+        ? `${theme.spacing(10)} 0 ${theme.spacing(4)}`
+        : `${theme.spacing(10)} 0`,
+    },
+
+    // @TODO: Check! These were in the root of the makeStyles function...
+    '& .insidePath path': {
+      opacity: 0,
+      animation: `${fadeIn} .2s ease-in-out forwards .3s`,
+      stroke: theme.palette.primary.main,
+    },
+    '& .bucket.insidePath path': {
+      fill: theme.palette.primary.main,
+    },
+  })
+);

--- a/packages/manager/src/components/Placeholder/Placeholder.tsx
+++ b/packages/manager/src/components/Placeholder/Placeholder.tsx
@@ -145,13 +145,11 @@ const StyledIconWrapper = styled('div')<Pick<PlaceholderProps, 'isEntity'>>(
 );
 
 const StyledButtonWrapper = styled('div')(({ theme }) => ({
-  button: {
-    gridArea: 'button',
-    display: 'flex',
-    gap: theme.spacing(2),
-    [theme.breakpoints.down('xs')]: {
-      flexDirection: 'column',
-    },
+  gridArea: 'button',
+  display: 'flex',
+  gap: theme.spacing(2),
+  [theme.breakpoints.down('xs')]: {
+    flexDirection: 'column',
   },
 }));
 

--- a/packages/manager/src/components/Placeholder/index.ts
+++ b/packages/manager/src/components/Placeholder/index.ts
@@ -1,5 +1,0 @@
-import Placeholder, { Props as _PlaceholderProps } from './Placeholder';
-/* tslint:disable */
-export interface PlaceholderProps extends _PlaceholderProps {}
-
-export default Placeholder;

--- a/packages/manager/src/components/StackScript/StackScript.tsx
+++ b/packages/manager/src/components/StackScript/StackScript.tsx
@@ -9,7 +9,7 @@ import Chip from 'src/components/core/Chip';
 import Divider from 'src/components/core/Divider';
 import Typography from 'src/components/core/Typography';
 import { DateTimeDisplay } from 'src/components/DateTimeDisplay';
-import H1Header from 'src/components/H1Header';
+import { H1Header } from 'src/components/H1Header/H1Header';
 import ScriptCode from 'src/components/ScriptCode';
 import { useAccountManagement } from 'src/hooks/useAccountManagement';
 import { listToItemsByID } from 'src/queries/base';

--- a/packages/manager/src/features/CancelLanding/CancelLanding.tsx
+++ b/packages/manager/src/features/CancelLanding/CancelLanding.tsx
@@ -7,7 +7,7 @@ import { Theme } from '@mui/material/styles';
 import AkamaiLogo from 'src/assets/logo/akamai-logo.svg';
 import Button from 'src/components/Button';
 import Typography from 'src/components/core/Typography';
-import H1Header from 'src/components/H1Header';
+import { H1Header } from 'src/components/H1Header/H1Header';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {

--- a/packages/manager/src/features/Events/EventsLanding.tsx
+++ b/packages/manager/src/features/Events/EventsLanding.tsx
@@ -12,7 +12,7 @@ import { Theme } from '@mui/material/styles';
 import { TableBody } from 'src/components/TableBody';
 import { TableHead } from 'src/components/TableHead';
 import Typography from 'src/components/core/Typography';
-import H1Header from 'src/components/H1Header';
+import { H1Header } from 'src/components/H1Header/H1Header';
 import { Table } from 'src/components/Table';
 import { TableCell } from 'src/components/TableCell';
 import { TableRow } from 'src/components/TableRow';

--- a/packages/manager/src/features/Help/Panels/SearchPanel.tsx
+++ b/packages/manager/src/features/Help/Panels/SearchPanel.tsx
@@ -3,7 +3,7 @@ import LinodeIcon from 'src/assets/addnewmenu/linode.svg';
 import Paper from 'src/components/core/Paper';
 import { createStyles, withStyles, WithStyles, WithTheme } from '@mui/styles';
 import { Theme } from '@mui/material/styles';
-import H1Header from 'src/components/H1Header';
+import { H1Header } from 'src/components/H1Header/H1Header';
 import AlgoliaSearchBar from './AlgoliaSearchBar';
 
 type ClassNames = 'root' | 'bgIcon' | 'searchHeading';

--- a/packages/manager/src/features/Help/SupportSearchLanding/SupportSearchLanding.test.tsx
+++ b/packages/manager/src/features/Help/SupportSearchLanding/SupportSearchLanding.test.tsx
@@ -2,7 +2,7 @@ import { shallow } from 'enzyme';
 import { assocPath } from 'ramda';
 import * as React from 'react';
 import { reactRouterProps } from 'src/__data__/reactRouterProps';
-import H1Header from 'src/components/H1Header';
+import { H1Header } from 'src/components/H1Header/H1Header';
 import { CombinedProps, SupportSearchLanding } from './SupportSearchLanding';
 
 const classes = {

--- a/packages/manager/src/features/Help/SupportSearchLanding/SupportSearchLanding.tsx
+++ b/packages/manager/src/features/Help/SupportSearchLanding/SupportSearchLanding.tsx
@@ -7,7 +7,7 @@ import { createStyles, withStyles, WithStyles } from '@mui/styles';
 import { Theme } from '@mui/material/styles';
 import Grid from '@mui/material/Unstable_Grid2';
 import Box from '@mui/material/Box';
-import H1Header from 'src/components/H1Header';
+import { H1Header } from 'src/components/H1Header/H1Header';
 import { Notice } from 'src/components/Notice/Notice';
 import TextField from 'src/components/TextField';
 import { COMMUNITY_SEARCH_URL, DOCS_SEARCH_URL } from 'src/constants';

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Disks/Disks.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Disks/Disks.tsx
@@ -7,7 +7,7 @@ import { Theme } from '@mui/material/styles';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import ErrorState from 'src/components/ErrorState';
 import LandingLoading from 'src/components/LandingLoading';
-import Placeholder from 'src/components/Placeholder';
+import { Placeholder } from 'src/components/Placeholder/Placeholder';
 import { WithStartAndEnd } from '../../../request.types';
 import TimeRangeSelect from '../../../shared/TimeRangeSelect';
 import { useGraphs } from '../OverviewGraphs/useGraphs';

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Network/NetworkGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Network/NetworkGraphs.tsx
@@ -3,7 +3,7 @@ import { CircleProgress } from 'src/components/CircleProgress';
 import { withTheme, WithTheme } from '@mui/styles';
 import ErrorState from 'src/components/ErrorState';
 import LongviewLineGraph from 'src/components/LongviewLineGraph';
-import Placeholder from 'src/components/Placeholder';
+import { Placeholder } from 'src/components/Placeholder/Placeholder';
 import {
   convertNetworkToUnit,
   formatNetworkTooltip,

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLandingEmptyState.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLandingEmptyState.tsx
@@ -6,7 +6,7 @@ import { Theme } from '@mui/material/styles';
 import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Link from 'src/components/Link';
-import Placeholder from 'src/components/Placeholder';
+import { Placeholder } from 'src/components/Placeholder/Placeholder';
 
 const useStyles = makeStyles((theme: Theme) => ({
   placeholderAdjustment: {

--- a/packages/manager/src/features/Search/SearchLanding.tsx
+++ b/packages/manager/src/features/Search/SearchLanding.tsx
@@ -9,7 +9,7 @@ import { makeStyles } from '@mui/styles';
 import { Theme } from '@mui/material/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from '@mui/material/Unstable_Grid2';
-import H1Header from 'src/components/H1Header';
+import { H1Header } from 'src/components/H1Header/H1Header';
 import { Notice } from 'src/components/Notice/Notice';
 import { REFRESH_INTERVAL } from 'src/constants';
 import useAPISearch from 'src/features/Search/useAPISearch';

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -14,7 +14,7 @@ import ErrorState from 'src/components/ErrorState';
 import { Image } from '@linode/api-v4/lib/images';
 import { pathOr } from 'ramda';
 import { Notice } from 'src/components/Notice/Notice';
-import Placeholder from 'src/components/Placeholder';
+import { Placeholder } from 'src/components/Placeholder/Placeholder';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import StackScriptsIcon from 'src/assets/icons/entityIcons/stackscript.svg';
 import StackScriptTableHead from '../Partials/StackScriptTableHead';

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
@@ -10,7 +10,7 @@ import Paper from 'src/components/core/Paper';
 import { createStyles, withStyles, WithStyles } from '@mui/styles';
 import { Theme } from '@mui/material/styles';
 import Grid from '@mui/material/Unstable_Grid2';
-import Placeholder from 'src/components/Placeholder';
+import { Placeholder } from 'src/components/Placeholder/Placeholder';
 import { reportException } from 'src/exceptionReporting';
 import { extendType } from 'src/utilities/extendType';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -6,7 +6,7 @@ import { Theme } from '@mui/material/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from '@mui/material/Unstable_Grid2';
 import ImageSelect from 'src/components/ImageSelect';
-import Placeholder from 'src/components/Placeholder';
+import { Placeholder } from 'src/components/Placeholder/Placeholder';
 import { filterImagesByType } from 'src/store/image/image.helpers';
 import ImageIcon from 'src/assets/icons/entityIcons/image.svg';
 import {

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
@@ -5,7 +5,7 @@ import { useHistory } from 'react-router-dom';
 import VolumeIcon from 'src/assets/icons/entityIcons/volume.svg';
 import Paper from 'src/components/core/Paper';
 import Grid from '@mui/material/Unstable_Grid2';
-import Placeholder from 'src/components/Placeholder';
+import { Placeholder } from 'src/components/Placeholder/Placeholder';
 import { buildQueryStringForLinodeClone } from 'src/features/linodes/LinodesLanding/LinodeActionMenu';
 import { extendType } from 'src/utilities/extendType';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/BackupsPlaceholder.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/BackupsPlaceholder.tsx
@@ -3,7 +3,7 @@ import VolumeIcon from 'src/assets/icons/entityIcons/volume.svg';
 import { makeStyles } from 'tss-react/mui';
 import Typography from 'src/components/core/Typography';
 import { Currency } from 'src/components/Currency';
-import Placeholder from 'src/components/Placeholder';
+import { Placeholder } from 'src/components/Placeholder/Placeholder';
 import LinodePermissionsError from '../LinodePermissionsError';
 import { EnableBackupsDialog } from './EnableBackupsDialog';
 

--- a/packages/manager/src/styles/keyframes.ts
+++ b/packages/manager/src/styles/keyframes.ts
@@ -11,9 +11,9 @@ export const rotate360 = keyframes`
 
 export const fadeIn = keyframes`
   from: {
-    opacity: 0,
+    opacity: 0;
   },
   to: {
-    opacity: 1,
+    opacity: 1;
   }
 `;


### PR DESCRIPTION
## Description 📝
Migrated `Placeholder` and `H1Header` to `styled` api and removed `jss`

## Major Changes 🔄
- Update import/exports
- Converted to styled component

## Preview 📷
There should be no visual changes.

![Screen Shot 2023-05-16 at 11 17 01 PM](https://github.com/linode/manager/assets/125309814/b0f8085f-bc70-4deb-b308-c423de8ab6b7)

## How to test 🧪
1. `yarn dev`
2. Find any empty landing page
3. Example: http://localhost:3000/nodebalancers