### PR TITLE
hotfix: Linodes Details - Backups - Initialize linode before referencing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [2023-05-15] - v1.93.1
 
 ### Fixed:
-- Initialize linode before referencing
+- Initialize linode before referencing #9133
 
 ## [2023-05-15] - v1.93.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2023-05-15] - v1.93.1
+
+### Fixed:
+- Initialize linode before referencing
+
 ## [2023-05-15] - v1.93.0
 
 ### Added:

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackups.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackups.tsx
@@ -52,19 +52,18 @@ export const LinodeBackups = () => {
 
   const { data: profile } = useProfile();
   const { data: grants } = useGrants();
-
-  const doesNotHavePermission =
-    Boolean(profile?.restricted) &&
-    grants?.linode.find(
-      (grant) => grant.id === linode?.id && grant.permissions !== 'read_write'
-    ) !== undefined;
-
   const { data: linode } = useLinodeQuery(id);
   const { data: type } = useTypeQuery(linode?.type ?? '', linode !== undefined);
   const { data: backups, error, isLoading } = useLinodeBackupsQuery(
     id,
     Boolean(linode?.backups.enabled)
   );
+
+  const doesNotHavePermission =
+    Boolean(profile?.restricted) &&
+    grants?.linode.find(
+      (grant) => grant.id === linode?.id && grant.permissions !== 'read_write'
+    ) !== undefined;
 
   const [isRestoreDrawerOpen, setIsRestoreDrawerOpen] = React.useState(false);
 


### PR DESCRIPTION
## Description 📝
Hotfix for a reference error for linodes detail page backup tabs

## Major Changes 🔄
- Placement / reference of the code needed to happen after initialization

## Preview 📷
**Include a screenshot or screen recording of the change**

> **Note**: Use `<video src="" />` tag when including recordings in table

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-05-17 at 9 24 35 AM](https://github.com/linode/manager/assets/125309814/2e53ad45-4291-4da2-a53e-37dadf590c62) | ![Screen Shot 2023-05-17 at 10 00 43 AM](https://github.com/linode/manager/assets/125309814/56a99fca-975e-455c-b2af-a974e73d37ed) |

## How to test 🧪
1. Checkout branch `yarn dev`
2. Go to: http://localhost:3000/linodes/44259525/backup
3. Observe page loads and backups are restored