### PR TITLE
hotfix: Revert Linode Landing Changes

### DIFF
--- a/packages/manager/cypress/e2e/linodes/smoke-linode-landing-table.spec.ts
+++ b/packages/manager/cypress/e2e/linodes/smoke-linode-landing-table.spec.ts
@@ -146,8 +146,7 @@ describe('linode landing checks', () => {
     fbtVisible('Create Linode');
   });
 
-  // Skipping because the sorting is now done by the API
-  it.skip('checks label and region sorting behavior for linode table', () => {
+  it('checks label and region sorting behavior for linode table', () => {
     const linodesByLabel = [...mockLinodes.sort(sortByLabel)];
     const linodesByRegion = [...mockLinodes.sort(sortByRegion)];
     const linodesLastIndex = mockLinodes.length - 1;
@@ -224,16 +223,15 @@ describe('linode landing checks', () => {
       fbtVisible('Label');
     });
 
-    // We can't sort by these with the API:
-    // getVisible('[aria-label="Sort by status"]').within(() => {
-    //   fbtVisible('Status');
-    // });
-    // getVisible('[aria-label="Sort by type"]').within(() => {
-    //   fbtVisible('Plan');
-    // });
-    // getVisible('[aria-label="Sort by ipv4[0]"]').within(() => {
-    //   fbtVisible('IP Address');
-    // });
+    getVisible('[aria-label="Sort by _statusPriority"]').within(() => {
+      fbtVisible('Status');
+    });
+    getVisible('[aria-label="Sort by type"]').within(() => {
+      fbtVisible('Plan');
+    });
+    getVisible('[aria-label="Sort by ipv4[0]"]').within(() => {
+      fbtVisible('IP Address');
+    });
 
     getVisible(`tr[data-qa-linode="${label}"]`).within(() => {
       ui.button
@@ -280,10 +278,9 @@ describe('linode landing actions', () => {
         cy.visitWithLogin('/linodes', { preferenceOverrides });
         cy.wait('@getAccountSettings');
         getVisible('[data-qa-header="Linodes"]');
-        // I think we can assume the linodes are on the page and we don't need to sort
-        // if (!cy.get('[data-qa-sort-label="asc"]')) {
-        //   getClick('[aria-label="Sort by label"]');
-        // }
+        if (!cy.get('[data-qa-sort-label="asc"]')) {
+          getClick('[aria-label="Sort by label"]');
+        }
         deleteLinodeFromActionMenu(linodeA.label);
         deleteLinodeFromActionMenu(linodeB.label);
         cy.findByText('Oh Snap!', { timeout: 1000 }).should('not.exist');

--- a/packages/manager/src/components/EntityTable/EntityTableHeader.tsx
+++ b/packages/manager/src/components/EntityTable/EntityTableHeader.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import GroupByTag from 'src/assets/icons/group-by-tag.svg';
 import Hidden from 'src/components/core/Hidden';
-import { IconButton } from 'src/components/IconButton';
+import IconButton from 'src/components/IconButton';
 import { makeStyles } from '@mui/styles';
 import { Theme } from '@mui/material/styles';
 import { TableHead } from 'src/components/TableHead';

--- a/packages/manager/src/components/EntityTable/EntityTableHeader.tsx
+++ b/packages/manager/src/components/EntityTable/EntityTableHeader.tsx
@@ -1,0 +1,205 @@
+import * as React from 'react';
+import GroupByTag from 'src/assets/icons/group-by-tag.svg';
+import Hidden from 'src/components/core/Hidden';
+import { IconButton } from 'src/components/IconButton';
+import { makeStyles } from '@mui/styles';
+import { Theme } from '@mui/material/styles';
+import { TableHead } from 'src/components/TableHead';
+import Tooltip from 'src/components/core/Tooltip';
+import { OrderByProps } from 'src/components/OrderBy';
+import { TableCell } from 'src/components/TableCell';
+import { TableRow } from 'src/components/TableRow';
+import { TableSortCell } from 'src/components/TableSortCell';
+import { Entity, HeaderCell } from './types';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  hiddenHeaderCell: theme.visually.hidden,
+  groupByTagCell: {
+    backgroundColor: theme.bg.tableHeader,
+    paddingRight: `0px !important`,
+    textAlign: 'right',
+  },
+}));
+
+interface Props extends Omit<OrderByProps<Entity>, 'data'> {
+  headers: HeaderCell[];
+  toggleGroupByTag?: () => boolean;
+  isGroupedByTag?: boolean;
+  isLargeAccount?: boolean;
+}
+
+interface SortCellProps extends Omit<Props, 'headers'> {
+  thisCell: HeaderCell;
+}
+
+interface NormalCellProps {
+  thisCell: HeaderCell;
+}
+
+export const EntityTableHeader: React.FC<Props> = (props) => {
+  const {
+    headers,
+    handleOrderChange,
+    order,
+    orderBy,
+    toggleGroupByTag,
+    isGroupedByTag,
+    isLargeAccount,
+  } = props;
+  const classes = useStyles();
+
+  const SortCell: React.FC<SortCellProps> = (props) => {
+    const { orderBy, order, thisCell, handleOrderChange } = props;
+    return (
+      <TableSortCell
+        active={orderBy === thisCell.dataColumn}
+        label={thisCell.dataColumn}
+        direction={order}
+        handleClick={handleOrderChange}
+        style={{ width: `${thisCell.widthPercent}%` }}
+        data-testid={`${thisCell.label}-header-cell`}
+      >
+        {thisCell.label}
+      </TableSortCell>
+    );
+  };
+
+  const _NormalCell: React.FC<NormalCellProps> = (props) => {
+    const { thisCell } = props;
+    return (
+      <TableCell
+        data-testid={`${thisCell.label}-header-cell`}
+        style={{ width: `${thisCell.widthPercent}%` }}
+      >
+        <span
+          className={
+            thisCell.visuallyHidden ? classes.hiddenHeaderCell : undefined
+          }
+        >
+          {thisCell.label}
+        </span>
+      </TableCell>
+    );
+  };
+
+  return (
+    <TableHead>
+      <TableRow>
+        {headers.map((thisCell) =>
+          thisCell.sortable ? (
+            thisCell.hideOnTablet ? (
+              <Hidden mdDown key={thisCell.dataColumn}>
+                <SortCell
+                  thisCell={thisCell}
+                  order={order}
+                  orderBy={orderBy}
+                  handleOrderChange={handleOrderChange}
+                />
+              </Hidden>
+            ) : thisCell.hideOnMobile ? (
+              <Hidden smDown key={thisCell.dataColumn}>
+                <SortCell
+                  thisCell={thisCell}
+                  order={order}
+                  orderBy={orderBy}
+                  handleOrderChange={handleOrderChange}
+                />
+              </Hidden>
+            ) : (
+              <SortCell
+                thisCell={thisCell}
+                key={thisCell.dataColumn}
+                order={order}
+                orderBy={orderBy}
+                handleOrderChange={handleOrderChange}
+              />
+            )
+          ) : (
+            [
+              thisCell.hideOnTablet ? (
+                <Hidden mdDown key={thisCell.dataColumn}>
+                  <_NormalCell thisCell={thisCell} />
+                </Hidden>
+              ) : thisCell.hideOnMobile ? (
+                <Hidden smDown key={thisCell.dataColumn}>
+                  <_NormalCell thisCell={thisCell} />
+                </Hidden>
+              ) : (
+                <_NormalCell thisCell={thisCell} key={thisCell.dataColumn} />
+              ),
+            ]
+          )
+        )}
+        {toggleGroupByTag && typeof isGroupedByTag !== 'undefined' ? (
+          <TableCell className={classes.groupByTagCell}>
+            <GroupByTagToggle
+              isLargeAccount={isLargeAccount}
+              toggleGroupByTag={toggleGroupByTag}
+              isGroupedByTag={isGroupedByTag}
+            />
+          </TableCell>
+        ) : null}
+      </TableRow>
+    </TableHead>
+  );
+};
+
+export default React.memo(EntityTableHeader);
+
+// =============================================================================
+// <GroupByTagToggle />
+// =============================================================================
+interface GroupByTagToggleProps {
+  toggleGroupByTag: () => boolean;
+  isGroupedByTag: boolean;
+  isLargeAccount?: boolean;
+}
+
+const useGroupByTagToggleStyles = makeStyles(() => ({
+  toggleButton: {
+    color: '#d2d3d4',
+    padding: '0 10px',
+    '&:focus': {
+      outline: '1px dotted #999',
+    },
+    '&.Mui-disabled': {
+      display: 'none',
+    },
+  },
+}));
+
+export const GroupByTagToggle: React.FC<GroupByTagToggleProps> = React.memo(
+  (props) => {
+    const classes = useGroupByTagToggleStyles();
+
+    const { toggleGroupByTag, isGroupedByTag, isLargeAccount } = props;
+
+    return (
+      <>
+        <div id="groupByDescription" className="visually-hidden">
+          {isGroupedByTag
+            ? 'group by tag is currently enabled'
+            : 'group by tag is currently disabled'}
+        </div>
+        <Tooltip
+          placement="top-end"
+          title={`${isGroupedByTag ? 'Ungroup' : 'Group'} by tag`}
+        >
+          <IconButton
+            aria-label={`Toggle group by tag`}
+            aria-describedby={'groupByDescription'}
+            onClick={toggleGroupByTag}
+            disableRipple
+            className={classes.toggleButton}
+            // Group by Tag is not available if you have a large account.
+            // See https://github.com/linode/manager/pull/6653 for more details
+            disabled={isLargeAccount}
+            size="large"
+          >
+            <GroupByTag />
+          </IconButton>
+        </Tooltip>
+      </>
+    );
+  }
+);

--- a/packages/manager/src/components/EntityTable/types.ts
+++ b/packages/manager/src/components/EntityTable/types.ts
@@ -1,0 +1,50 @@
+import { Domain } from '@linode/api-v4/lib/domains/types';
+import { Image } from '@linode/api-v4/lib/images/types';
+import { Firewall } from '@linode/api-v4/lib/firewalls/types';
+import { Linode } from '@linode/api-v4/lib/linodes/types';
+import { Volume } from '@linode/api-v4/lib/volumes/types';
+import { APIError } from '@linode/api-v4/lib/types';
+import { OrderByProps } from 'src/components/OrderBy';
+// eslint-disable-next-line
+export type Handlers = any;
+export type Entity = Linode | Domain | Firewall | Image | Volume; // @todo add more here
+
+export interface HeaderCell {
+  sortable: boolean;
+  label: string;
+  dataColumn: string;
+  widthPercent: number;
+  visuallyHidden?: boolean;
+  hideOnMobile?: boolean;
+  hideOnTablet?: boolean;
+}
+export interface BaseProps {
+  error?: APIError[];
+  loading: boolean;
+  lastUpdated: number;
+  handlers?: Handlers;
+}
+export interface ListProps extends BaseProps {
+  entity: string;
+  data: Entity[];
+  RowComponent: React.ComponentType;
+  headers: HeaderCell[];
+  initialOrder?: {
+    order: OrderByProps<Entity>['order'];
+    orderBy: OrderByProps<Entity>['orderBy'];
+  };
+  toggleGroupByTag?: () => boolean;
+  isGroupedByTag?: boolean;
+  emptyMessage?: string;
+}
+
+export interface EntityTableRow<T> extends BaseProps {
+  Component: React.ComponentType<any>;
+  data: T[];
+  request?: () => Promise<T[]>;
+}
+
+export interface PageyIntegrationProps {
+  persistData?: (data: Entity[]) => void;
+  normalizeData?: (data: Entity[]) => Entity[];
+}

--- a/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
+++ b/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
@@ -33,7 +33,6 @@ import { pluralize } from 'src/utilities/pluralize';
 import { ipv4TableID } from './LinodesDetail/LinodeNetworking/LinodeNetworking';
 import { lishLink, sshLink } from './LinodesDetail/utilities';
 import EntityHeader from 'src/components/EntityHeader';
-import { WithRecentEvent } from './LinodesLanding/withRecentEvent';
 import {
   getProgressOrDefault,
   isEventWithSecondaryLinodeStatus,
@@ -51,6 +50,7 @@ import Table from '@mui/material/Table';
 import { TableCell } from 'src/components/TableCell';
 import { useAllLinodeConfigsQuery } from 'src/queries/linodes/linodes';
 import { useLinodeVolumesQuery } from 'src/queries/volumes';
+import { useRecentEventForLinode } from 'src/store/selectors/recentEventForLinode';
 
 interface LinodeEntityDetailProps {
   variant?: TypographyProps['variant'];
@@ -63,8 +63,9 @@ interface LinodeEntityDetailProps {
   isSummaryView?: boolean;
 }
 
-export type CombinedProps = LinodeEntityDetailProps &
-  WithRecentEvent & { handlers: LinodeHandlers };
+export type CombinedProps = LinodeEntityDetailProps & {
+  handlers: LinodeHandlers;
+};
 
 const LinodeEntityDetail: React.FC<CombinedProps> = (props) => {
   const {
@@ -75,9 +76,10 @@ const LinodeEntityDetail: React.FC<CombinedProps> = (props) => {
     isSummaryView,
     openTagDrawer,
     openNotificationMenu,
-    recentEvent,
     handlers,
   } = props;
+
+  const recentEvent = useRecentEventForLinode(linode.id);
 
   const { data: images } = useAllImagesQuery({}, {});
   const imagesItemsById = listToItemsByID(images ?? []);

--- a/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
+++ b/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
@@ -112,10 +112,12 @@ const LinodeEntityDetail: React.FC<CombinedProps> = (props) => {
 
   let progress;
   let transitionText;
+
   if (recentEvent && isEventWithSecondaryLinodeStatus(recentEvent, linode.id)) {
     progress = getProgressOrDefault(recentEvent);
     transitionText = _transitionText(linode.status, linode.id, recentEvent);
   }
+
   const trimmedIPv6 = linode.ipv6?.replace('/128', '') || null;
 
   return (

--- a/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
+++ b/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
@@ -49,6 +49,8 @@ import { LinodeHandlers } from './LinodesLanding/LinodesLanding';
 // This component was built asuming an unmodified MUI <Table />
 import Table from '@mui/material/Table';
 import { TableCell } from 'src/components/TableCell';
+import { useAllLinodeConfigsQuery } from 'src/queries/linodes/linodes';
+import { useLinodeVolumesQuery } from 'src/queries/volumes';
 
 interface LinodeEntityDetailProps {
   variant?: TypographyProps['variant'];
@@ -56,8 +58,6 @@ interface LinodeEntityDetailProps {
   linode: Linode;
   username?: string;
   backups: LinodeBackups;
-  linodeConfigs: Config[];
-  numVolumes: number;
   openTagDrawer: (tags: string[]) => void;
   openNotificationMenu?: () => void;
   isSummaryView?: boolean;
@@ -72,9 +72,7 @@ const LinodeEntityDetail: React.FC<CombinedProps> = (props) => {
     linode,
     username,
     backups,
-    linodeConfigs,
     isSummaryView,
-    numVolumes,
     openTagDrawer,
     openNotificationMenu,
     recentEvent,
@@ -86,6 +84,11 @@ const LinodeEntityDetail: React.FC<CombinedProps> = (props) => {
 
   const typesQuery = useSpecificTypes(linode.type ? [linode.type] : []);
   const type = typesQuery[0]?.data ? extendType(typesQuery[0].data) : undefined;
+
+  const { data: configs } = useAllLinodeConfigsQuery(linode.id);
+  const { data: volumes } = useLinodeVolumesQuery(linode.id);
+
+  const numberOfVolumes = volumes?.results ?? 0;
 
   const extendedLinode = useExtendedLinode(linode.id);
 
@@ -126,7 +129,7 @@ const LinodeEntityDetail: React.FC<CombinedProps> = (props) => {
           linodeRegionDisplay={linodeRegionDisplay}
           backups={backups}
           isSummaryView={isSummaryView}
-          linodeConfigs={linodeConfigs}
+          linodeConfigs={configs ?? []}
           type={linodeType}
           image={linode.image ?? 'Unknown Image'}
           openNotificationMenu={openNotificationMenu || (() => null)}
@@ -138,7 +141,7 @@ const LinodeEntityDetail: React.FC<CombinedProps> = (props) => {
       body={
         <Body
           linodeLabel={linode.label}
-          numVolumes={numVolumes}
+          numVolumes={numberOfVolumes}
           numCPUs={linode.specs.vcpus}
           gbRAM={linode.specs.memory / 1024}
           gbStorage={linode.specs.disk / 1024}

--- a/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
+++ b/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
@@ -51,6 +51,7 @@ import { TableCell } from 'src/components/TableCell';
 import { useAllLinodeConfigsQuery } from 'src/queries/linodes/linodes';
 import { useLinodeVolumesQuery } from 'src/queries/volumes';
 import { useRecentEventForLinode } from 'src/store/selectors/recentEventForLinode';
+import { notificationContext as _notificationContext } from 'src/features/NotificationCenter/NotificationContext';
 
 interface LinodeEntityDetailProps {
   variant?: TypographyProps['variant'];
@@ -59,7 +60,6 @@ interface LinodeEntityDetailProps {
   username?: string;
   backups: LinodeBackups;
   openTagDrawer: (tags: string[]) => void;
-  openNotificationMenu?: () => void;
   isSummaryView?: boolean;
 }
 
@@ -75,9 +75,10 @@ const LinodeEntityDetail: React.FC<CombinedProps> = (props) => {
     backups,
     isSummaryView,
     openTagDrawer,
-    openNotificationMenu,
     handlers,
   } = props;
+
+  const notificationContext = React.useContext(_notificationContext);
 
   const recentEvent = useRecentEventForLinode(linode.id);
 
@@ -136,7 +137,7 @@ const LinodeEntityDetail: React.FC<CombinedProps> = (props) => {
           linodeConfigs={configs ?? []}
           type={linodeType}
           image={linode.image ?? 'Unknown Image'}
-          openNotificationMenu={openNotificationMenu || (() => null)}
+          openNotificationMenu={notificationContext.openMenu}
           progress={progress}
           transitionText={transitionText}
           handlers={handlers}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
@@ -10,7 +10,6 @@ import {
 } from 'src/features/linodes/PowerActionsDialogOrDrawer';
 import useLinodeActions from 'src/hooks/useLinodeActions';
 import { useProfile } from 'src/queries/profile';
-import { useLinodeVolumesQuery } from 'src/queries/volumes';
 import { parseQueryParams } from 'src/utilities/queryParams';
 import { DeleteLinodeDialog } from '../../LinodesLanding/DeleteLinodeDialog';
 import { MigrateLinode } from 'src/features/linodes/MigrateLinode';
@@ -61,7 +60,7 @@ const LinodeDetailHeader: React.FC<CombinedProps> = (props) => {
 
   const matchedLinodeId = Number(match?.params?.linodeId ?? 0);
 
-  const { linode, linodeStatus, linodeDisks, linodeConfigs } = props;
+  const { linode, linodeStatus, linodeDisks } = props;
 
   const [powerAction, setPowerAction] = React.useState<Action>('Reboot');
   const [powerDialogOpen, setPowerDialogOpen] = React.useState(false);
@@ -132,9 +131,6 @@ const LinodeDetailHeader: React.FC<CombinedProps> = (props) => {
   };
 
   const { data: profile } = useProfile();
-  const { data: volumesData } = useLinodeVolumesQuery(matchedLinodeId);
-
-  const numAttachedVolumes = volumesData?.results ?? 0;
 
   const {
     editableLabelError,
@@ -240,9 +236,7 @@ const LinodeDetailHeader: React.FC<CombinedProps> = (props) => {
       <LinodeEntityDetail
         id={linode.id}
         linode={linode}
-        numVolumes={numAttachedVolumes}
         username={profile?.username}
-        linodeConfigs={linodeConfigs}
         backups={linode.backups}
         openTagDrawer={openTagDrawer}
         handlers={handlers}

--- a/packages/manager/src/features/linodes/LinodesLanding/CardView.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/CardView.tsx
@@ -100,6 +100,8 @@ const CardView: React.FC<RenderLinodesProps> = (props) => {
                 openTagDrawer={(tags) =>
                   openTagDrawer(linode.label, linode.id, tags)
                 }
+                linode={linode}
+                backups={linode.backups}
               />
             </Grid>
           </React.Fragment>

--- a/packages/manager/src/features/linodes/LinodesLanding/CardView.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/CardView.tsx
@@ -1,0 +1,119 @@
+import * as React from 'react';
+import { makeStyles } from '@mui/styles';
+import { Theme } from '@mui/material/styles';
+import Typography from 'src/components/core/Typography';
+import Grid from '@mui/material/Unstable_Grid2';
+import TagDrawer, { TagDrawerProps } from 'src/components/TagCell/TagDrawer';
+import LinodeEntityDetail from 'src/features/linodes/LinodeEntityDetail';
+import useLinodeActions from 'src/hooks/useLinodeActions';
+import { useProfile } from 'src/queries/profile';
+import { RenderLinodesProps } from './DisplayLinodes';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  '@keyframes pulse': {
+    to: {
+      backgroundColor: `hsla(40, 100%, 55%, 0)`,
+    },
+  },
+  summaryOuter: {
+    backgroundColor: theme.bg.bgPaper,
+    margin: `${theme.spacing()} 0`,
+    marginBottom: 20,
+    '&.MuiGrid-item': {
+      padding: 0,
+    },
+    '& .statusOther:before': {
+      animation: '$pulse 1.5s ease-in-out infinite',
+    },
+  },
+}));
+
+const CardView: React.FC<RenderLinodesProps> = (props) => {
+  const classes = useStyles();
+
+  const { updateLinode } = useLinodeActions();
+  const { data: profile } = useProfile();
+
+  const [tagDrawer, setTagDrawer] = React.useState<TagDrawerProps>({
+    open: false,
+    tags: [],
+    label: '',
+    entityID: 0,
+  });
+
+  const closeTagDrawer = () => {
+    setTagDrawer({ ...tagDrawer, open: false });
+  };
+
+  const openTagDrawer = (label: string, entityID: number, tags: string[]) => {
+    setTagDrawer({
+      open: true,
+      label,
+      tags,
+      entityID,
+    });
+  };
+
+  const updateTags = (linodeId: number, tags: string[]) => {
+    return updateLinode({ linodeId, tags }).then((_) => {
+      setTagDrawer({ ...tagDrawer, tags });
+    });
+  };
+
+  const { data, openDialog, openPowerActionDialog } = props;
+
+  if (!profile?.username) {
+    return null;
+  }
+
+  if (data.length === 0) {
+    return (
+      <Typography style={{ textAlign: 'center' }}>
+        No items to display.
+      </Typography>
+    );
+  }
+
+  return (
+    <React.Fragment>
+      <Grid container className="m0" style={{ width: '100%' }}>
+        {data.map((linode, idx: number) => (
+          <React.Fragment key={`linode-card-${idx}`}>
+            <Grid xs={12} className={`${classes.summaryOuter} py0`}>
+              <LinodeEntityDetail
+                id={linode.id}
+                handlers={{
+                  onOpenDeleteDialog: () =>
+                    openDialog('delete', linode.id, linode.label),
+                  onOpenMigrateDialog: () =>
+                    openDialog('migrate', linode.id, linode.label),
+                  onOpenRebuildDialog: () =>
+                    openDialog('rebuild', linode.id, linode.label),
+                  onOpenRescueDialog: () =>
+                    openDialog('rescue', linode.id, linode.label),
+                  onOpenResizeDialog: () =>
+                    openDialog('resize', linode.id, linode.label),
+                  onOpenPowerDialog: (action) =>
+                    openPowerActionDialog(action, linode.id, linode.label, []),
+                }}
+                isSummaryView
+                openTagDrawer={(tags) =>
+                  openTagDrawer(linode.label, linode.id, tags)
+                }
+              />
+            </Grid>
+          </React.Fragment>
+        ))}
+      </Grid>
+      <TagDrawer
+        entityLabel={tagDrawer.label}
+        open={tagDrawer.open}
+        tags={tagDrawer.tags}
+        updateTags={(tags) => updateTags(tagDrawer.entityID, tags)}
+        onClose={closeTagDrawer}
+      />
+    </React.Fragment>
+  );
+};
+
+export default CardView;

--- a/packages/manager/src/features/linodes/LinodesLanding/DeleteLinodeDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/DeleteLinodeDialog.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import Typography from 'src/components/core/Typography';
 import { Notice } from 'src/components/Notice/Notice';
 import TypeToConfirmDialog from 'src/components/TypeToConfirmDialog';
+import { resetEventsPolling } from 'src/eventsPolling';
 import {
   useDeleteLinodeMutation,
   useLinodeQuery,
@@ -35,6 +36,8 @@ export const DeleteLinodeDialog = (props: Props) => {
   const onDelete = async () => {
     await mutateAsync();
     onClose();
+    resetEventsPolling();
+
     if (onSuccess) {
       onSuccess();
     }

--- a/packages/manager/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
@@ -3,7 +3,7 @@ import { compose } from 'ramda';
 import * as React from 'react';
 import GroupByTag from 'src/assets/icons/group-by-tag.svg';
 import TableView from 'src/assets/icons/table-view.svg';
-import { IconButton } from 'src/components/IconButton';
+import IconButton from 'src/components/IconButton';
 import { makeStyles } from '@mui/styles';
 import { Theme } from '@mui/material/styles';
 import { TableBody } from 'src/components/TableBody';

--- a/packages/manager/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
@@ -3,21 +3,22 @@ import { compose } from 'ramda';
 import * as React from 'react';
 import GroupByTag from 'src/assets/icons/group-by-tag.svg';
 import TableView from 'src/assets/icons/table-view.svg';
-import IconButton from 'src/components/core/IconButton';
+import { IconButton } from 'src/components/IconButton';
 import { makeStyles } from '@mui/styles';
 import { Theme } from '@mui/material/styles';
-import TableBody from 'src/components/core/TableBody';
-import TableCell from 'src/components/core/TableCell';
+import { TableBody } from 'src/components/TableBody';
+import { TableCell } from 'src/components/TableCell';
 import Tooltip from 'src/components/core/Tooltip';
 import Typography from 'src/components/core/Typography';
 import Grid from '@mui/material/Unstable_Grid2';
 import { OrderByProps } from 'src/components/OrderBy';
 import Paginate from 'src/components/Paginate';
-import PaginationFooter, {
+import {
   MIN_PAGE_SIZE,
-} from 'src/components/PaginationFooter';
-import { getMinimumPageSizeForNumberOfItems } from 'src/components/PaginationFooter/PaginationFooter';
-import TableRow from 'src/components/TableRow';
+  PaginationFooter,
+  getMinimumPageSizeForNumberOfItems,
+} from 'src/components/PaginationFooter/PaginationFooter';
+import { TableRow } from 'src/components/TableRow';
 import TableRowEmptyState from 'src/components/TableRowEmptyState';
 import { Action } from 'src/features/linodes/PowerActionsDialogOrDrawer';
 import { DialogType } from 'src/features/linodes/types';

--- a/packages/manager/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
@@ -1,0 +1,349 @@
+import { Config } from '@linode/api-v4/lib/linodes';
+import { compose } from 'ramda';
+import * as React from 'react';
+import GroupByTag from 'src/assets/icons/group-by-tag.svg';
+import TableView from 'src/assets/icons/table-view.svg';
+import IconButton from 'src/components/core/IconButton';
+import { makeStyles } from '@mui/styles';
+import { Theme } from '@mui/material/styles';
+import TableBody from 'src/components/core/TableBody';
+import TableCell from 'src/components/core/TableCell';
+import Tooltip from 'src/components/core/Tooltip';
+import Typography from 'src/components/core/Typography';
+import Grid from '@mui/material/Unstable_Grid2';
+import { OrderByProps } from 'src/components/OrderBy';
+import Paginate from 'src/components/Paginate';
+import PaginationFooter, {
+  MIN_PAGE_SIZE,
+} from 'src/components/PaginationFooter';
+import { getMinimumPageSizeForNumberOfItems } from 'src/components/PaginationFooter/PaginationFooter';
+import TableRow from 'src/components/TableRow';
+import TableRowEmptyState from 'src/components/TableRowEmptyState';
+import { Action } from 'src/features/linodes/PowerActionsDialogOrDrawer';
+import { DialogType } from 'src/features/linodes/types';
+import { useInfinitePageSize } from 'src/hooks/useInfinitePageSize';
+import { groupByTags, sortGroups } from 'src/utilities/groupByTags';
+import TableWrapper from './TableWrapper';
+import { LinodeWithMaintenance } from 'src/store/linodes/linodes.helpers';
+import { RenderLinodesProps } from './DisplayLinodes';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  tagGridRow: {
+    marginBottom: 20,
+  },
+  tagHeaderRow: {
+    backgroundColor: theme.bg.main,
+    height: 'auto',
+    '& td': {
+      // This is maintaining the spacing between groups because of how tables handle margin/padding. Adjust with care!
+      padding: `calc(${theme.spacing(2)} + 4px) 0 2px`,
+      borderBottom: 'none',
+      borderTop: 'none',
+    },
+  },
+  groupContainer: {
+    [theme.breakpoints.up('md')]: {
+      '& $tagHeaderRow > td': {
+        padding: '10px 0 2px',
+        borderTop: 'none',
+      },
+    },
+  },
+  tagHeader: {
+    marginBottom: 2,
+    marginLeft: theme.spacing(),
+  },
+  paginationCell: {
+    padding: 0,
+  },
+  controlHeader: {
+    marginBottom: 28,
+    display: 'flex',
+    justifyContent: 'flex-end',
+    backgroundColor: theme.bg.tableHeader,
+  },
+  toggleButton: {
+    color: '#d2d3d4',
+    padding: 10,
+    '&:focus': {
+      // Browser default until we get styling direction for focus states
+      outline: '1px dotted #999',
+    },
+  },
+}));
+
+interface Props {
+  openDialog: (type: DialogType, linodeID: number, linodeLabel: string) => void;
+  openPowerActionDialog: (
+    bootAction: Action,
+    linodeID: number,
+    linodeLabel: string,
+    linodeConfigs: Config[]
+  ) => void;
+  display: 'grid' | 'list';
+  component: React.ComponentType<RenderLinodesProps>;
+  data: LinodeWithMaintenance[];
+  someLinodesHaveMaintenance: boolean;
+  toggleLinodeView: () => 'grid' | 'list';
+  toggleGroupLinodes: () => boolean;
+  linodeViewPreference: 'grid' | 'list';
+  linodesAreGrouped: boolean;
+  isVLAN?: boolean;
+}
+
+type CombinedProps = Props & OrderByProps<LinodeWithMaintenance>;
+
+const DisplayGroupedLinodes: React.FC<CombinedProps> = (props) => {
+  const classes = useStyles();
+
+  const {
+    data,
+    display,
+    component: Component,
+    order,
+    orderBy,
+    handleOrderChange,
+    toggleLinodeView,
+    toggleGroupLinodes,
+    linodeViewPreference,
+    linodesAreGrouped,
+    isVLAN,
+    ...rest
+  } = props;
+
+  const dataLength = data.length;
+
+  const orderedGroupedLinodes = compose(sortGroups, groupByTags)(data);
+  const tableWrapperProps = {
+    handleOrderChange,
+    order,
+    orderBy,
+    someLinodesHaveMaintenance: props.someLinodesHaveMaintenance,
+    dataLength,
+    isVLAN,
+  };
+
+  const { infinitePageSize, setInfinitePageSize } = useInfinitePageSize();
+  const numberOfLinodesWithMaintenance = data.reduce((acc, thisLinode) => {
+    if (thisLinode.maintenance) {
+      acc++;
+    }
+    return acc;
+  }, 0);
+
+  if (display === 'grid') {
+    return (
+      <>
+        <Grid xs={12} className={'px0'}>
+          <div className={classes.controlHeader}>
+            <div id="displayViewDescription" className="visually-hidden">
+              Currently in {linodeViewPreference} view
+            </div>
+            <Tooltip placement="top" title="List view">
+              <IconButton
+                aria-label="Toggle display"
+                aria-describedby={'displayViewDescription'}
+                onClick={toggleLinodeView}
+                disableRipple
+                className={classes.toggleButton}
+                size="large"
+              >
+                <TableView />
+              </IconButton>
+            </Tooltip>
+
+            <div id="groupByDescription" className="visually-hidden">
+              {linodesAreGrouped
+                ? 'group by tag is currently enabled'
+                : 'group by tag is currently disabled'}
+            </div>
+            <Tooltip placement="top-end" title="Ungroup by tag">
+              <IconButton
+                aria-label={`Toggle group by tag`}
+                aria-describedby={'groupByDescription'}
+                onClick={toggleGroupLinodes}
+                disableRipple
+                className={classes.toggleButton}
+                size="large"
+              >
+                <GroupByTag />
+              </IconButton>
+            </Tooltip>
+          </div>
+        </Grid>
+        {orderedGroupedLinodes.length === 0 ? (
+          <Typography style={{ textAlign: 'center' }}>
+            No items to display.
+          </Typography>
+        ) : null}
+        {orderedGroupedLinodes.map(([tag, linodes]) => {
+          return (
+            <div
+              key={tag}
+              className={classes.tagGridRow}
+              data-qa-tag-header={tag}
+            >
+              <Grid container>
+                <Grid xs={12}>
+                  <Typography
+                    variant="h2"
+                    component="h3"
+                    className={classes.tagHeader}
+                  >
+                    {tag}
+                  </Typography>
+                </Grid>
+              </Grid>
+              <Paginate
+                data={linodes}
+                // If there are more Linodes with maintenance than the current page size, show the minimum
+                // page size needed to show ALL Linodes with maintenance.
+                pageSize={
+                  numberOfLinodesWithMaintenance > infinitePageSize
+                    ? getMinimumPageSizeForNumberOfItems(
+                        numberOfLinodesWithMaintenance
+                      )
+                    : infinitePageSize
+                }
+                pageSizeSetter={setInfinitePageSize}
+              >
+                {({
+                  data: paginatedData,
+                  handlePageChange,
+                  handlePageSizeChange,
+                  page,
+                  pageSize,
+                  count,
+                }) => {
+                  const finalProps = {
+                    ...rest,
+                    data: paginatedData,
+                    pageSize,
+                    page,
+                    handlePageSizeChange,
+                    handlePageChange,
+                    handleOrderChange,
+                    order,
+                    orderBy,
+                    isVLAN,
+                    count,
+                  };
+                  return (
+                    <React.Fragment>
+                      <Component {...finalProps} />
+                      <Grid xs={12}>
+                        <PaginationFooter
+                          count={count}
+                          handlePageChange={handlePageChange}
+                          handleSizeChange={handlePageSizeChange}
+                          pageSize={pageSize}
+                          page={page}
+                          eventCategory={'linodes landing'}
+                          showAll
+                        />
+                      </Grid>
+                    </React.Fragment>
+                  );
+                }}
+              </Paginate>
+            </div>
+          );
+        })}
+      </>
+    );
+  }
+
+  if (display === 'list') {
+    return (
+      <TableWrapper
+        {...tableWrapperProps}
+        linodeViewPreference="list"
+        linodesAreGrouped={true}
+        toggleLinodeView={toggleLinodeView}
+        toggleGroupLinodes={toggleGroupLinodes}
+      >
+        {orderedGroupedLinodes.length === 0 ? (
+          <TableBody>
+            <TableRowEmptyState colSpan={12} />
+          </TableBody>
+        ) : null}
+        {orderedGroupedLinodes.map(([tag, linodes]) => {
+          return (
+            <React.Fragment key={tag}>
+              <Paginate
+                data={linodes}
+                pageSize={infinitePageSize}
+                pageSizeSetter={setInfinitePageSize}
+              >
+                {({
+                  data: paginatedData,
+                  handlePageChange,
+                  handlePageSizeChange,
+                  page,
+                  pageSize,
+                  count,
+                }) => {
+                  const finalProps = {
+                    ...rest,
+                    data: paginatedData,
+                    pageSize,
+                    page,
+                    handlePageSizeChange,
+                    handlePageChange,
+                    handleOrderChange,
+                    order,
+                    orderBy,
+                    isVLAN,
+                    count,
+                  };
+                  return (
+                    <TableBody
+                      className={classes.groupContainer}
+                      data-qa-tag-header={tag}
+                    >
+                      <TableRow className={classes.tagHeaderRow}>
+                        <TableCell colSpan={7}>
+                          <Typography
+                            variant="h2"
+                            component="h3"
+                            className={classes.tagHeader}
+                          >
+                            {tag}
+                          </Typography>
+                        </TableCell>
+                      </TableRow>
+                      <Component {...finalProps} />
+                      {count > MIN_PAGE_SIZE && (
+                        <TableRow>
+                          <TableCell
+                            colSpan={7}
+                            className={classes.paginationCell}
+                          >
+                            <PaginationFooter
+                              count={count}
+                              handlePageChange={handlePageChange}
+                              handleSizeChange={handlePageSizeChange}
+                              pageSize={pageSize}
+                              page={page}
+                              eventCategory={'linodes landing'}
+                              // Disabling showAll as it is impacting page performance.
+                              showAll={false}
+                            />
+                          </TableCell>
+                        </TableRow>
+                      )}
+                    </TableBody>
+                  );
+                }}
+              </Paginate>
+            </React.Fragment>
+          );
+        })}
+      </TableWrapper>
+    );
+  }
+
+  return null;
+};
+
+export default DisplayGroupedLinodes;

--- a/packages/manager/src/features/linodes/LinodesLanding/DisplayLinodes.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/DisplayLinodes.tsx
@@ -19,7 +19,7 @@ import GroupByTag from 'src/assets/icons/group-by-tag.svg';
 import TableView from 'src/assets/icons/table-view.svg';
 import { getParamsFromUrl } from 'src/utilities/queryParams';
 import { LinodeWithMaintenanceAndDisplayStatus } from 'src/store/linodes/types';
-import { ExtendedLinode } from 'src/hooks/useExtendedLinode';
+import { LinodeWithMaintenance } from 'src/store/linodes/linodes.helpers';
 
 const useStyles = makeStyles((theme: Theme) => ({
   controlHeader: {
@@ -59,7 +59,7 @@ interface Props {
   count: number;
   display: 'grid' | 'list';
   component: React.ComponentType<RenderLinodesProps>;
-  data: (ExtendedLinode & LinodeWithMaintenanceAndDisplayStatus)[];
+  data: LinodeWithMaintenance[];
   someLinodesHaveMaintenance: boolean;
   toggleLinodeView: () => 'grid' | 'list';
   toggleGroupLinodes: () => boolean;

--- a/packages/manager/src/features/linodes/LinodesLanding/DisplayLinodes.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/DisplayLinodes.tsx
@@ -1,0 +1,226 @@
+import { Config } from '@linode/api-v4/lib/linodes';
+import * as React from 'react';
+import { useLocation } from 'react-router-dom';
+import { TableBody } from 'src/components/TableBody';
+import { makeStyles } from '@mui/styles';
+import { Theme } from '@mui/material/styles';
+import Grid from '@mui/material/Unstable_Grid2';
+import { OrderByProps } from 'src/components/OrderBy';
+import Paginate, { PaginationProps } from 'src/components/Paginate';
+import { PaginationFooter } from 'src/components/PaginationFooter/PaginationFooter';
+import { getMinimumPageSizeForNumberOfItems } from 'src/components/PaginationFooter/PaginationFooter';
+import { Action } from 'src/features/linodes/PowerActionsDialogOrDrawer';
+import { DialogType } from 'src/features/linodes/types';
+import { useInfinitePageSize } from 'src/hooks/useInfinitePageSize';
+import TableWrapper from './TableWrapper';
+import { IconButton } from 'src/components/IconButton';
+import Tooltip from 'src/components/core/Tooltip';
+import GroupByTag from 'src/assets/icons/group-by-tag.svg';
+import TableView from 'src/assets/icons/table-view.svg';
+import { getParamsFromUrl } from 'src/utilities/queryParams';
+import { LinodeWithMaintenanceAndDisplayStatus } from 'src/store/linodes/types';
+import { ExtendedLinode } from 'src/hooks/useExtendedLinode';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  controlHeader: {
+    marginBottom: 28,
+    display: 'flex',
+    justifyContent: 'flex-end',
+    backgroundColor: theme.bg.tableHeader,
+  },
+  toggleButton: {
+    color: '#d2d3d4',
+    padding: 10,
+    '&:focus': {
+      // Browser default until we get styling direction for focus states
+      outline: '1px dotted #999',
+    },
+  },
+  table: {
+    // tableLayout: 'fixed'
+  },
+}));
+
+export interface RenderLinodesProps extends PaginationProps {
+  data: Props['data'];
+  showHead?: boolean;
+  openDialog: Props['openDialog'];
+  openPowerActionDialog: Props['openPowerActionDialog'];
+}
+
+interface Props {
+  openDialog: (type: DialogType, linodeID: number, linodeLabel: string) => void;
+  openPowerActionDialog: (
+    bootAction: Action,
+    linodeID: number,
+    linodeLabel: string,
+    linodeConfigs: Config[]
+  ) => void;
+  count: number;
+  display: 'grid' | 'list';
+  component: React.ComponentType<RenderLinodesProps>;
+  data: (ExtendedLinode & LinodeWithMaintenanceAndDisplayStatus)[];
+  someLinodesHaveMaintenance: boolean;
+  toggleLinodeView: () => 'grid' | 'list';
+  toggleGroupLinodes: () => boolean;
+  linodeViewPreference: 'grid' | 'list';
+  linodesAreGrouped: boolean;
+  updatePageUrl: (page: number) => void;
+}
+
+type CombinedProps = Props &
+  OrderByProps<LinodeWithMaintenanceAndDisplayStatus>;
+
+const DisplayLinodes = (props: CombinedProps) => {
+  const classes = useStyles();
+  const {
+    count,
+    data,
+    display,
+    component: Component,
+    order,
+    orderBy,
+    handleOrderChange,
+    toggleLinodeView,
+    toggleGroupLinodes,
+    linodeViewPreference,
+    linodesAreGrouped,
+    updatePageUrl,
+    ...rest
+  } = props;
+
+  const { infinitePageSize, setInfinitePageSize } = useInfinitePageSize();
+  const numberOfLinodesWithMaintenance = React.useMemo(() => {
+    return data.reduce((acc, thisLinode) => {
+      if (thisLinode.maintenance) {
+        acc++;
+      }
+      return acc;
+    }, 0);
+  }, [JSON.stringify(data)]);
+  const pageSize =
+    numberOfLinodesWithMaintenance > infinitePageSize
+      ? getMinimumPageSizeForNumberOfItems(numberOfLinodesWithMaintenance)
+      : infinitePageSize;
+  const maxPageNumber = Math.ceil(count / pageSize);
+
+  const { search } = useLocation();
+  const params = getParamsFromUrl(search);
+  const queryPage = Math.min(Number(params.page), maxPageNumber) || 1;
+
+  return (
+    <Paginate
+      data={data}
+      page={queryPage}
+      // If there are more Linodes with maintenance than the current page size, show the minimum
+      // page size needed to show ALL Linodes with maintenance.
+      pageSize={pageSize}
+      pageSizeSetter={setInfinitePageSize}
+      updatePageUrl={updatePageUrl}
+    >
+      {({
+        data: paginatedData,
+        handlePageChange,
+        handlePageSizeChange,
+        page,
+        pageSize,
+      }) => {
+        const componentProps = {
+          ...rest,
+          count,
+          data: paginatedData,
+          pageSize,
+          page,
+          handlePageSizeChange,
+          handlePageChange,
+        };
+        const tableWrapperProps = {
+          handleOrderChange,
+          order,
+          orderBy,
+          someLinodesHaveMaintenance: props.someLinodesHaveMaintenance,
+          dataLength: paginatedData.length,
+        };
+        return (
+          <React.Fragment>
+            {display === 'list' && (
+              <TableWrapper
+                {...tableWrapperProps}
+                linodeViewPreference={linodeViewPreference}
+                linodesAreGrouped={linodesAreGrouped}
+                toggleLinodeView={toggleLinodeView}
+                toggleGroupLinodes={toggleGroupLinodes}
+                tableProps={{ tableClass: classes.table }}
+              >
+                <TableBody>
+                  <Component showHead {...componentProps} />
+                </TableBody>
+              </TableWrapper>
+            )}
+            {display === 'grid' && (
+              <>
+                <Grid xs={12} className={'px0'}>
+                  <div className={classes.controlHeader}>
+                    <div
+                      id="displayViewDescription"
+                      className="visually-hidden"
+                    >
+                      Currently in {linodeViewPreference} view
+                    </div>
+                    <Tooltip placement="top" title="List view">
+                      <IconButton
+                        aria-label="Toggle display"
+                        aria-describedby={'displayViewDescription'}
+                        onClick={toggleLinodeView}
+                        disableRipple
+                        className={classes.toggleButton}
+                        size="large"
+                      >
+                        <TableView />
+                      </IconButton>
+                    </Tooltip>
+
+                    <div id="groupByDescription" className="visually-hidden">
+                      {linodesAreGrouped
+                        ? 'group by tag is currently enabled'
+                        : 'group by tag is currently disabled'}
+                    </div>
+                    <Tooltip placement="top-end" title="Group by tag">
+                      <IconButton
+                        aria-label={`Toggle group by tag`}
+                        aria-describedby={'groupByDescription'}
+                        onClick={toggleGroupLinodes}
+                        disableRipple
+                        className={classes.toggleButton}
+                        size="large"
+                      >
+                        <GroupByTag />
+                      </IconButton>
+                    </Tooltip>
+                  </div>
+                </Grid>
+                <Component showHead {...componentProps} />
+              </>
+            )}
+            <Grid xs={12}>
+              {
+                <PaginationFooter
+                  count={data.length}
+                  handlePageChange={handlePageChange}
+                  handleSizeChange={handlePageSizeChange}
+                  pageSize={pageSize}
+                  page={queryPage}
+                  eventCategory={'linodes landing'}
+                  // Disabling showAll as it is impacting page performance.
+                  showAll={false}
+                />
+              }
+            </Grid>
+          </React.Fragment>
+        );
+      }}
+    </Paginate>
+  );
+};
+
+export default React.memo(DisplayLinodes);

--- a/packages/manager/src/features/linodes/LinodesLanding/DisplayLinodes.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/DisplayLinodes.tsx
@@ -13,7 +13,7 @@ import { Action } from 'src/features/linodes/PowerActionsDialogOrDrawer';
 import { DialogType } from 'src/features/linodes/types';
 import { useInfinitePageSize } from 'src/hooks/useInfinitePageSize';
 import TableWrapper from './TableWrapper';
-import { IconButton } from 'src/components/IconButton';
+import IconButton from 'src/components/IconButton';
 import Tooltip from 'src/components/core/Tooltip';
 import GroupByTag from 'src/assets/icons/group-by-tag.svg';
 import TableView from 'src/assets/icons/table-view.svg';

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
@@ -27,10 +27,10 @@ import { LinodeHandlers } from '../LinodesLanding';
 import { useTypeQuery } from 'src/queries/types';
 import { useStyles } from './LinodeRow.style';
 import { useAllAccountMaintenanceQuery } from 'src/queries/accountMaintenance';
-import { useNotificationContext } from 'src/features/NotificationCenter/NotificationContext';
 import { BackupStatus } from 'src/components/BackupStatus/BackupStatus';
 import { formatStorageUnits } from 'src/utilities/formatStorageUnits';
 import { useRecentEventForLinode } from 'src/store/selectors/recentEventForLinode';
+import { notificationContext as _notificationContext } from 'src/features/NotificationCenter/NotificationContext';
 
 type Props = Linode & { handlers: LinodeHandlers };
 
@@ -38,7 +38,7 @@ export const LinodeRow = (props: Props) => {
   const classes = useStyles();
   const { backups, id, ipv4, label, region, status, type, handlers } = props;
 
-  const { openMenu } = useNotificationContext();
+  const notificationContext = React.useContext(_notificationContext);
 
   const { data: notifications } = useNotificationsQuery();
 
@@ -112,7 +112,10 @@ export const LinodeRow = (props: Props) => {
           loading ? (
             <>
               <StatusIcon status={iconStatus} />
-              <button className={classes.statusLink} onClick={() => openMenu()}>
+              <button
+                className={classes.statusLink}
+                onClick={notificationContext.openMenu}
+              >
                 <ProgressDisplay
                   className={classes.progressDisplay}
                   progress={getProgressOrDefault(recentEvent)}

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
@@ -99,7 +99,7 @@ export const LinodeRow = (props: Props) => {
       data-qa-linode={label}
       ariaLabel={label}
     >
-      <TableCell>
+      <TableCell noWrap>
         <Link to={`/linodes/${id}`} tabIndex={0}>
           {label}
         </Link>

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
@@ -25,12 +25,12 @@ import { SxProps } from '@mui/system';
 import { useNotificationsQuery } from 'src/queries/accountNotifications';
 import { LinodeHandlers } from '../LinodesLanding';
 import { useTypeQuery } from 'src/queries/types';
-import useEvents from 'src/hooks/useEvents';
 import { useStyles } from './LinodeRow.style';
 import { useAllAccountMaintenanceQuery } from 'src/queries/accountMaintenance';
 import { useNotificationContext } from 'src/features/NotificationCenter/NotificationContext';
 import { BackupStatus } from 'src/components/BackupStatus/BackupStatus';
 import { formatStorageUnits } from 'src/utilities/formatStorageUnits';
+import { useRecentEventForLinode } from 'src/store/selectors/recentEventForLinode';
 
 type Props = Linode & { handlers: LinodeHandlers };
 
@@ -59,11 +59,7 @@ export const LinodeRow = (props: Props) => {
 
   const { data: linodeType } = useTypeQuery(type ?? '', type !== null);
 
-  const { events } = useEvents();
-
-  const recentEvent = events.find(
-    (e) => e.entity?.id === id && e.entity.type === 'linode'
-  );
+  const recentEvent = useRecentEventForLinode(id);
 
   const isBareMetalInstance = linodeType?.class === 'metal';
 

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
@@ -30,6 +30,7 @@ import { useStyles } from './LinodeRow.style';
 import { useAllAccountMaintenanceQuery } from 'src/queries/accountMaintenance';
 import { useNotificationContext } from 'src/features/NotificationCenter/NotificationContext';
 import { BackupStatus } from 'src/components/BackupStatus/BackupStatus';
+import { formatStorageUnits } from 'src/utilities/formatStorageUnits';
 
 type Props = Linode & { handlers: LinodeHandlers };
 
@@ -143,7 +144,9 @@ export const LinodeRow = (props: Props) => {
         )}
       </TableCell>
       <Hidden smDown>
-        <TableCell noWrap>{linodeType?.label ?? type}</TableCell>
+        <TableCell noWrap>
+          {linodeType ? formatStorageUnits(linodeType.label) : type}
+        </TableCell>
         <TableCell data-qa-ips className={classes.ipCellWrapper}>
           <IPAddress ips={ipv4} />
         </TableCell>

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.styles.ts
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.styles.ts
@@ -1,0 +1,41 @@
+import { createStyles, withStyles, WithStyles } from '@mui/styles';
+import { Theme } from '@mui/material/styles';
+
+type ClassNames = 'root' | 'CSVlinkContainer' | 'CSVlink' | 'CSVwrapper';
+
+const styles = (theme: Theme) =>
+  createStyles({
+    root: {
+      margin: 0,
+      width: '100%',
+      '& > .MuiGrid-item': {
+        paddingLeft: 0,
+        paddingRight: 0,
+      },
+    },
+    CSVlink: {
+      color: theme.textColors.tableHeader,
+      fontSize: '.9rem',
+      '&:hover': {
+        textDecoration: 'underline',
+      },
+      [theme.breakpoints.down('md')]: {
+        marginRight: theme.spacing(),
+      },
+    },
+    CSVlinkContainer: {
+      marginTop: theme.spacing(0.5),
+      '&.MuiGrid-item': {
+        paddingRight: 0,
+      },
+    },
+    CSVwrapper: {
+      marginLeft: 0,
+      marginRight: 0,
+      width: '100%',
+    },
+  });
+
+export type StyleProps = WithStyles<ClassNames>;
+
+export default withStyles(styles);

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -24,7 +24,6 @@ import {
 import withFeatureFlagConsumer from 'src/containers/withFeatureFlagConsumer.container';
 import { BackupsCTA } from 'src/features/Backups';
 import { DialogType } from 'src/features/linodes/types';
-import { ExtendedLinode } from 'src/hooks/useExtendedLinode';
 import { ApplicationState } from 'src/store';
 import { deleteLinode } from 'src/store/linodes/linode.requests';
 import { MapState } from 'src/store/types';
@@ -48,6 +47,7 @@ import { LinodesLandingCSVDownload } from './LinodesLandingCSVDownload';
 import LinodeResize from '../LinodesDetail/LinodeResize/LinodeResize';
 import { RescueDialog } from '../LinodesDetail/LinodeRescue/RescueDialog';
 import { DeleteLinodeDialog } from './DeleteLinodeDialog';
+import { LinodeWithMaintenance } from 'src/store/linodes/linodes.helpers';
 
 interface State {
   powerDialogOpen: boolean;
@@ -83,7 +83,7 @@ type RouteProps = RouteComponentProps<Params>;
 export interface Props {
   LandingHeader?: React.ReactElement;
   someLinodesHaveScheduledMaintenance: boolean;
-  linodesData: ExtendedLinode[];
+  linodesData: LinodeWithMaintenance[];
   linodesRequestError?: APIError[];
   linodesRequestLoading: boolean;
 }

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -6,6 +6,7 @@ import LandingHeader from 'src/components/LandingHeader';
 import LinodeResize from '../LinodesDetail/LinodeResize/LinodeResize';
 import MaintenanceBanner from 'src/components/MaintenanceBanner';
 import TransferDisplay from 'src/components/TransferDisplay';
+import GroupByTag from 'src/assets/icons/group-by-tag.svg';
 import { BackupsCTA } from 'src/features/Backups';
 import { CircleProgress } from 'src/components/CircleProgress';
 import { DeleteLinodeDialog } from './DeleteLinodeDialog';
@@ -15,7 +16,10 @@ import { LinodeRow } from './LinodeRow/LinodeRow';
 import { LinodesLandingCSVDownload } from './LinodesLandingCSVDownload';
 import { LinodesLandingEmptyState } from './LinodesLandingEmptyState';
 import { MigrateLinode } from 'src/features/linodes/MigrateLinode';
-import { PaginationFooter } from 'src/components/PaginationFooter/PaginationFooter';
+import {
+  MIN_PAGE_SIZE,
+  PaginationFooter,
+} from 'src/components/PaginationFooter/PaginationFooter';
 import { PowerActionsDialog, Action } from '../PowerActionsDialogOrDrawer';
 import { RescueDialog } from '../LinodesDetail/LinodeRescue/RescueDialog';
 import { Table } from 'src/components/Table';
@@ -25,9 +29,22 @@ import { TableHead } from 'src/components/TableHead';
 import { TableRow } from 'src/components/TableRow';
 import { TableSortCell } from 'src/components/TableSortCell/TableSortCell';
 import { useHistory } from 'react-router-dom';
-import { useLinodesQuery } from 'src/queries/linodes/linodes';
+import {
+  useAllLinodesQuery,
+  useLinodesQuery,
+} from 'src/queries/linodes/linodes';
 import { useOrder } from 'src/hooks/useOrder';
 import { usePagination } from 'src/hooks/usePagination';
+import Tooltip from 'src/components/core/Tooltip';
+import { IconButton } from 'src/components/IconButton';
+import { useMutatePreferences, usePreferences } from 'src/queries/preferences';
+import { groupByTags, sortGroups } from 'src/utilities/groupByTags';
+import TableRowEmptyState from 'src/components/TableRowEmptyState';
+import Paginate from 'src/components/Paginate';
+import { useInfinitePageSize } from 'src/hooks/useInfinitePageSize';
+import Typography from 'src/components/core/Typography';
+import { Linode } from '@linode/api-v4';
+import OrderBy from 'src/components/OrderBy';
 
 export interface LinodeHandlers {
   onOpenPowerDialog: (action: Action) => void;
@@ -57,6 +74,19 @@ export const LinodesLanding = () => {
 
   const pagination = usePagination(1, preferenceKey);
 
+  const { data: preferences } = usePreferences();
+  const { mutateAsync: updatePreferences } = useMutatePreferences();
+
+  const groupByTag = preferences?.linodes_group_by_tag;
+
+  const groupByTagsOrder = useOrder(
+    {
+      orderBy: 'label',
+      order: 'desc',
+    },
+    `${preferenceKey}-group-by-tags-order`
+  );
+
   const { order, orderBy, handleOrderChange } = useOrder(
     {
       orderBy: 'label',
@@ -75,8 +105,13 @@ export const LinodesLanding = () => {
       page: pagination.page,
       page_size: pagination.pageSize,
     },
-    filter
+    filter,
+    !groupByTag
   );
+
+  const { data: linodes } = useAllLinodesQuery({}, {}, groupByTag);
+
+  const { infinitePageSize, setInfinitePageSize } = useInfinitePageSize();
 
   const onOpenPowerDialog = (linodeId: number, action: Action) => {
     setPowerDialogOpen(true);
@@ -121,6 +156,207 @@ export const LinodesLanding = () => {
     return <LinodesLandingEmptyState />;
   }
 
+  if (groupByTag) {
+    return (
+      <React.Fragment>
+        <DocumentTitleSegment segment="Linodes" />
+        <MaintenanceBanner />
+        <BackupsCTA />
+        <LandingHeader
+          title="Linodes"
+          entity="Linode"
+          onButtonClick={() => history.push('/linodes/create')}
+          docsLink="https://www.linode.com/docs/platform/billing-and-support/linode-beginners-guide/"
+        />
+        <OrderBy
+          preferenceKey={'linodes-landing'}
+          data={linodes ?? []}
+          order="asc"
+        >
+          {({ data, handleOrderChange, order, orderBy }) => {
+            const orderedGroupedLinodes = sortGroups(groupByTags(data));
+            return (
+              <Table>
+                <TableHead>
+                  <TableRow>
+                    <TableSortCell
+                      active={orderBy === 'label'}
+                      direction={order}
+                      label="label"
+                      handleClick={handleOrderChange}
+                      data-qa-sort-label={order}
+                    >
+                      Label
+                    </TableSortCell>
+                    <TableSortCell
+                      active={groupByTagsOrder.orderBy === 'status'}
+                      direction={groupByTagsOrder.order}
+                      label="status"
+                      handleClick={groupByTagsOrder.handleOrderChange}
+                      data-qa-sort-label={order}
+                    >
+                      Status
+                    </TableSortCell>
+                    <Hidden smDown>
+                      <TableCell>Plan</TableCell>
+                      <TableCell>IP Address</TableCell>
+                    </Hidden>
+                    <Hidden lgDown>
+                      <TableSortCell
+                        active={orderBy === 'region'}
+                        direction={order}
+                        label="region"
+                        handleClick={handleOrderChange}
+                      >
+                        Region
+                      </TableSortCell>
+                      <TableCell>Last Backup</TableCell>
+                    </Hidden>
+                    <TableCell>
+                      <Tooltip
+                        placement="top-end"
+                        title={groupByTag ? 'Ungroup by tag' : 'Group by tag'}
+                      >
+                        <IconButton
+                          aria-label={`Toggle group by tag`}
+                          aria-describedby={'groupByDescription'}
+                          onClick={() =>
+                            updatePreferences({
+                              linodes_group_by_tag: !preferences?.linodes_group_by_tag,
+                            })
+                          }
+                          disableRipple
+                          sx={{
+                            padding: 0,
+                            color: '#d2d3d4',
+                            '&:focus': {
+                              outline: '1px dotted #999',
+                            },
+                          }}
+                          size="large"
+                        >
+                          <GroupByTag />
+                        </IconButton>
+                      </Tooltip>
+                    </TableCell>
+                  </TableRow>
+                </TableHead>
+                {orderedGroupedLinodes.length === 0 ? (
+                  <TableBody>
+                    <TableRowEmptyState colSpan={12} />
+                  </TableBody>
+                ) : null}
+                {orderedGroupedLinodes.map(([tag, linodes]) => {
+                  return (
+                    <React.Fragment key={tag}>
+                      <Paginate
+                        data={linodes}
+                        pageSize={infinitePageSize}
+                        pageSizeSetter={setInfinitePageSize}
+                      >
+                        {({
+                          data: paginatedData,
+                          handlePageChange,
+                          handlePageSizeChange,
+                          page,
+                          pageSize,
+                          count,
+                        }) => {
+                          return (
+                            <TableBody data-qa-tag-header={tag}>
+                              <TableRow>
+                                <TableCell colSpan={7}>
+                                  <Typography variant="h2" component="h3">
+                                    {tag}
+                                  </Typography>
+                                </TableCell>
+                              </TableRow>
+                              {paginatedData.map((linode: Linode) => (
+                                <LinodeRow
+                                  key={linode.id}
+                                  {...linode}
+                                  handlers={{
+                                    onOpenDeleteDialog: () =>
+                                      onOpenDeleteDialog(linode.id),
+                                    onOpenMigrateDialog: () =>
+                                      onOpenMigrateDialog(linode.id),
+                                    onOpenPowerDialog: (action: Action) =>
+                                      onOpenPowerDialog(linode.id, action),
+                                    onOpenRebuildDialog: () =>
+                                      onOpenRebuildDialog(linode.id),
+                                    onOpenRescueDialog: () =>
+                                      onOpenRescueDialog(linode.id),
+                                    onOpenResizeDialog: () =>
+                                      onOpenResizeDialog(linode.id),
+                                  }}
+                                />
+                              ))}
+                              {count > MIN_PAGE_SIZE && (
+                                <TableRow>
+                                  <TableCell colSpan={7}>
+                                    <PaginationFooter
+                                      count={count}
+                                      handlePageChange={handlePageChange}
+                                      handleSizeChange={handlePageSizeChange}
+                                      pageSize={pageSize}
+                                      page={page}
+                                      eventCategory={'linodes landing'}
+                                      // Disabling showAll as it is impacting page performance.
+                                      showAll={false}
+                                    />
+                                  </TableCell>
+                                </TableRow>
+                              )}
+                            </TableBody>
+                          );
+                        }}
+                      </Paginate>
+                    </React.Fragment>
+                  );
+                })}
+              </Table>
+            );
+          }}
+        </OrderBy>
+        <Box display="flex" justifyContent="flex-end" marginTop={1}>
+          <LinodesLandingCSVDownload />
+        </Box>
+        <TransferDisplay />
+        <PowerActionsDialog
+          isOpen={powerDialogOpen}
+          linodeId={selectedLinodeId}
+          onClose={() => setPowerDialogOpen(false)}
+          action={powerAction}
+        />
+        <DeleteLinodeDialog
+          open={deleteDialogOpen}
+          onClose={() => setDeleteDialogOpen(false)}
+          linodeId={selectedLinodeId}
+        />
+        <LinodeResize
+          open={linodeResizeOpen}
+          onClose={() => setResizeDialogOpen(false)}
+          linodeId={selectedLinodeId}
+        />
+        <MigrateLinode
+          open={linodeMigrateOpen}
+          onClose={() => setMigrateDialogOpen(false)}
+          linodeId={selectedLinodeId}
+        />
+        <LinodeRebuildDialog
+          open={rebuildDialogOpen}
+          onClose={() => setRebuildDialogOpen(false)}
+          linodeId={selectedLinodeId}
+        />
+        <RescueDialog
+          open={rescueDialogOpen}
+          onClose={() => setRescueDialogOpen(false)}
+          linodeId={selectedLinodeId}
+        />
+      </React.Fragment>
+    );
+  }
+
   return (
     <React.Fragment>
       <DocumentTitleSegment segment="Linodes" />
@@ -160,7 +396,33 @@ export const LinodesLanding = () => {
               </TableSortCell>
               <TableCell>Last Backup</TableCell>
             </Hidden>
-            <TableCell></TableCell>
+            <TableCell>
+              <Tooltip
+                placement="top-end"
+                title={groupByTag ? 'Ungroup by tag' : 'Group by tag'}
+              >
+                <IconButton
+                  aria-label={`Toggle group by tag`}
+                  aria-describedby={'groupByDescription'}
+                  onClick={() =>
+                    updatePreferences({
+                      linodes_group_by_tag: !preferences?.linodes_group_by_tag,
+                    })
+                  }
+                  disableRipple
+                  sx={{
+                    padding: 0,
+                    color: '#d2d3d4',
+                    '&:focus': {
+                      outline: '1px dotted #999',
+                    },
+                  }}
+                  size="large"
+                >
+                  <GroupByTag />
+                </IconButton>
+              </Tooltip>
+            </TableCell>
           </TableRow>
         </TableHead>
         <TableBody>

--- a/packages/manager/src/features/linodes/LinodesLanding/ListView.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/ListView.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import TableRowEmptyState from 'src/components/TableRowEmptyState';
+import { RenderLinodesProps } from './DisplayLinodes';
+import { LinodeRow } from './LinodeRow/LinodeRow';
+
+export const ListView: React.FC<RenderLinodesProps> = (props) => {
+  const { data, openDialog, openPowerActionDialog } = props;
+
+  // This won't happen in the normal Linodes Landing context (a custom empty
+  // state is shown higher up in the tree). This is specifically for the case of
+  // VLAN Details, where we want to show the table even if there's nothing attached.
+  if (data.length === 0) {
+    return <TableRowEmptyState colSpan={12} />;
+  }
+
+  return (
+    // eslint-disable-next-line
+    <>
+      {/* @todo: fix this "any" typing once https://github.com/linode/manager/pull/6999 is merged. */}
+      {data.map((linode, idx: number) => (
+        <LinodeRow
+          backups={linode.backups}
+          id={linode.id}
+          ipv4={linode.ipv4}
+          ipv6={linode.ipv6 || ''}
+          label={linode.label}
+          region={linode.region}
+          status={linode.status}
+          tags={linode.tags}
+          type={linode.type}
+          image={linode.image}
+          key={`linode-row-${idx}`}
+          alerts={linode.alerts}
+          created={linode.created}
+          group={linode.group}
+          updated={linode.updated}
+          hypervisor={linode.hypervisor}
+          specs={linode.specs}
+          watchdog_enabled={linode.watchdog_enabled}
+          handlers={{
+            onOpenDeleteDialog: () =>
+              openDialog('delete', linode.id, linode.label),
+            onOpenMigrateDialog: () =>
+              openDialog('migrate', linode.id, linode.label),
+            onOpenRebuildDialog: () =>
+              openDialog('rebuild', linode.id, linode.label),
+            onOpenRescueDialog: () =>
+              openDialog('rescue', linode.id, linode.label),
+            onOpenResizeDialog: () =>
+              openDialog('resize', linode.id, linode.label),
+            onOpenPowerDialog: (action) =>
+              openPowerActionDialog(action, linode.id, linode.label, []),
+          }}
+        />
+      ))}
+    </>
+  );
+};
+
+export default ListView;

--- a/packages/manager/src/features/linodes/LinodesLanding/SortableTableHead.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/SortableTableHead.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import GridView from 'src/assets/icons/grid-view.svg';
 import Hidden from 'src/components/core/Hidden';
-import { IconButton } from 'src/components/IconButton';
+import IconButton from 'src/components/IconButton';
 import { makeStyles } from '@mui/styles';
 import { Theme } from '@mui/material/styles';
 import { TableHead } from 'src/components/TableHead';

--- a/packages/manager/src/features/linodes/LinodesLanding/SortableTableHead.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/SortableTableHead.tsx
@@ -1,0 +1,205 @@
+import * as React from 'react';
+import GridView from 'src/assets/icons/grid-view.svg';
+import Hidden from 'src/components/core/Hidden';
+import { IconButton } from 'src/components/IconButton';
+import { makeStyles } from '@mui/styles';
+import { Theme } from '@mui/material/styles';
+import { TableHead } from 'src/components/TableHead';
+import Tooltip from 'src/components/core/Tooltip';
+import { GroupByTagToggle } from 'src/components/EntityTable/EntityTableHeader';
+import { OrderByProps } from 'src/components/OrderBy';
+import { TableCell } from 'src/components/TableCell';
+import { TableRow } from 'src/components/TableRow';
+import { TableSortCell } from 'src/components/TableSortCell';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  controlHeader: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    backgroundColor: theme.bg.tableHeader,
+  },
+  toggleButton: {
+    color: '#d2d3d4',
+    padding: '0 10px',
+    '&:focus': {
+      outline: '1px dotted #999',
+    },
+  },
+  // There's nothing very scientific about the widths across the breakpoints
+  // here, just a lot of trial and error based on maximum expected column sizes.
+  labelCell: {
+    ...theme.applyTableHeaderStyles,
+    width: '24%',
+    [theme.breakpoints.down('lg')]: {
+      width: '20%',
+    },
+  },
+  statusCell: {
+    ...theme.applyTableHeaderStyles,
+    width: '20%',
+    [theme.breakpoints.only('md')]: {
+      width: '27%',
+    },
+    [theme.breakpoints.down('md')]: {
+      width: '25%',
+    },
+  },
+  planCell: {
+    ...theme.applyTableHeaderStyles,
+    width: '14%',
+    [theme.breakpoints.only('sm')]: {
+      width: '15%',
+    },
+  },
+  regionCell: {
+    ...theme.applyTableHeaderStyles,
+    width: '14%',
+    [theme.breakpoints.down('sm')]: {
+      width: '18%',
+    },
+  },
+  lastBackupCell: {
+    ...theme.applyTableHeaderStyles,
+    width: '14%',
+    [theme.breakpoints.down('sm')]: {
+      width: '18%',
+    },
+  },
+}));
+
+interface Props {
+  toggleLinodeView: () => 'list' | 'grid';
+  linodeViewPreference: 'list' | 'grid';
+  toggleGroupLinodes: () => boolean;
+  linodesAreGrouped: boolean;
+  isVLAN?: boolean;
+}
+
+type CombinedProps<T> = Props & Omit<OrderByProps<T>, 'data'>;
+
+const SortableTableHead = <T extends unknown>(props: CombinedProps<T>) => {
+  const classes = useStyles();
+
+  const {
+    handleOrderChange,
+    order,
+    orderBy,
+    toggleLinodeView,
+    linodeViewPreference,
+    toggleGroupLinodes,
+    linodesAreGrouped,
+    isVLAN,
+  } = props;
+
+  const isActive = (label: string) =>
+    label.toLowerCase() === orderBy.toLowerCase();
+
+  return (
+    <TableHead role="rowgroup" data-qa-table-head>
+      <TableRow>
+        <TableSortCell
+          label="label"
+          direction={order}
+          active={isActive('label')}
+          handleClick={handleOrderChange}
+          className={classes.labelCell}
+          data-qa-sort-label={order}
+        >
+          Label
+        </TableSortCell>
+        <TableSortCell
+          noWrap
+          label="_statusPriority"
+          direction={order}
+          active={isActive('_statusPriority')}
+          className={classes.statusCell}
+          handleClick={handleOrderChange}
+        >
+          Status
+        </TableSortCell>
+        {isVLAN ? (
+          <TableSortCell
+            label="_vlanIP"
+            active={isActive('_vlanIP')}
+            handleClick={handleOrderChange}
+            direction={order}
+          >
+            VLAN IP
+          </TableSortCell>
+        ) : null}
+        {isVLAN ? null : (
+          <>
+            <Hidden smDown>
+              <TableSortCell
+                label="type"
+                active={isActive('type')}
+                handleClick={handleOrderChange}
+                direction={order}
+                className={classes.planCell}
+              >
+                Plan
+              </TableSortCell>
+              <TableSortCell
+                label="ipv4[0]" // we want to sort by the first ipv4
+                active={isActive('ipv4[0]')}
+                handleClick={handleOrderChange}
+                direction={order}
+              >
+                IP Address
+              </TableSortCell>
+              <Hidden lgDown>
+                <TableSortCell
+                  label="region"
+                  direction={order}
+                  active={isActive('region')}
+                  handleClick={handleOrderChange}
+                  className={classes.regionCell}
+                  data-qa-sort-region={order}
+                >
+                  Region
+                </TableSortCell>
+              </Hidden>
+            </Hidden>
+            <Hidden lgDown>
+              <TableSortCell
+                noWrap
+                label="backups:last_successful"
+                direction={order}
+                active={isActive('backups:last_successful')}
+                className={classes.lastBackupCell}
+                handleClick={handleOrderChange}
+              >
+                Last Backup
+              </TableSortCell>
+            </Hidden>
+          </>
+        )}
+        <TableCell>
+          <div className={classes.controlHeader}>
+            <div id="displayViewDescription" className="visually-hidden">
+              Currently in {linodeViewPreference} view
+            </div>
+            <Tooltip placement="top" title="Summary view">
+              <IconButton
+                aria-label="Toggle display"
+                aria-describedby={'displayViewDescription'}
+                onClick={toggleLinodeView}
+                disableRipple
+                className={classes.toggleButton}
+                size="large"
+              >
+                <GridView />
+              </IconButton>
+            </Tooltip>
+            <GroupByTagToggle
+              toggleGroupByTag={toggleGroupLinodes}
+              isGroupedByTag={linodesAreGrouped}
+            />
+          </div>
+        </TableCell>
+      </TableRow>
+    </TableHead>
+  );
+};
+
+export default SortableTableHead;

--- a/packages/manager/src/features/linodes/LinodesLanding/TableWrapper.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/TableWrapper.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import Grid from '@mui/material/Unstable_Grid2';
+import { OrderByProps } from 'src/components/OrderBy';
+import { Table, TableProps } from 'src/components/Table';
+import SortableTableHead from './SortableTableHead';
+
+interface Props {
+  dataLength: number;
+  toggleLinodeView: () => 'list' | 'grid';
+  linodeViewPreference: 'list' | 'grid';
+  toggleGroupLinodes: () => boolean;
+  linodesAreGrouped: boolean;
+  isVLAN?: boolean;
+  tableProps?: TableProps;
+  children: React.ReactNode;
+}
+
+type CombinedProps<T> = Omit<OrderByProps<T>, 'data'> & Props;
+
+const TableWrapper = <T extends unknown>(props: CombinedProps<T>) => {
+  const {
+    dataLength,
+    order,
+    orderBy,
+    handleOrderChange,
+    toggleLinodeView,
+    linodeViewPreference,
+    toggleGroupLinodes,
+    linodesAreGrouped,
+    isVLAN,
+    tableProps,
+  } = props;
+
+  return (
+    <Grid container className="m0" spacing={0} style={{ width: '100%' }}>
+      <Grid xs={12} className="p0">
+        <Table
+          aria-label="List of Linodes"
+          rowCount={dataLength}
+          colCount={5}
+          stickyHeader
+          {...tableProps}
+        >
+          <SortableTableHead
+            order={order}
+            orderBy={orderBy}
+            handleOrderChange={handleOrderChange}
+            toggleGroupLinodes={toggleGroupLinodes}
+            linodeViewPreference={linodeViewPreference}
+            toggleLinodeView={toggleLinodeView}
+            linodesAreGrouped={linodesAreGrouped}
+            isVLAN={isVLAN}
+          />
+          {props.children}
+        </Table>
+      </Grid>
+    </Grid>
+  );
+};
+
+export default TableWrapper;

--- a/packages/manager/src/features/linodes/PowerActionsDialogOrDrawer.tsx
+++ b/packages/manager/src/features/linodes/PowerActionsDialogOrDrawer.tsx
@@ -16,6 +16,7 @@ import {
   useRebootLinodeMutation,
   useShutdownLinodeMutation,
 } from 'src/queries/linodes/linodes';
+import { resetEventsPolling } from 'src/eventsPolling';
 
 export type Action = 'Reboot' | 'Power Off' | 'Power On';
 
@@ -129,6 +130,7 @@ export const PowerActionsDialog = (props: Props) => {
       const mutateAsync = mutationMap[action as 'Power Off'];
       await mutateAsync();
     }
+    resetEventsPolling();
     onClose();
   };
 

--- a/packages/manager/src/features/linodes/index.tsx
+++ b/packages/manager/src/features/linodes/index.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import SuspenseLoader from 'src/components/SuspenseLoader';
 import { useAllAccountMaintenanceQuery } from 'src/queries/accountMaintenance';
-import { useExtendedLinodes } from 'src/hooks/useExtendedLinode';
-import useLinodes from 'src/hooks/useLinodes';
+import { useAllLinodesQuery } from 'src/queries/linodes/linodes';
+import { addMaintenanceToLinodes } from 'src/store/linodes/linodes.helpers';
 
 const LinodesLanding = React.lazy(
   () => import('./LinodesLanding/LinodesLanding')
@@ -38,13 +38,16 @@ const LinodesLandingWrapper: React.FC = React.memo(() => {
     {},
     { status: { '+or': ['pending, started'] } }
   );
-  const { linodes } = useLinodes();
-  const extendedLinodes = useExtendedLinodes();
+
+  const { data: linodes, isLoading, error } = useAllLinodesQuery();
 
   const someLinodesHaveScheduledMaintenance = accountMaintenanceData?.some(
-    (thisAccountMaintenance) => {
-      return linodes.itemsById[thisAccountMaintenance.entity.id];
-    }
+    (thisAccountMaintenance) => thisAccountMaintenance.entity.type === 'linode'
+  );
+
+  const linodesData = addMaintenanceToLinodes(
+    accountMaintenanceData ?? [],
+    linodes ?? []
   );
 
   return (
@@ -52,9 +55,9 @@ const LinodesLandingWrapper: React.FC = React.memo(() => {
       someLinodesHaveScheduledMaintenance={Boolean(
         someLinodesHaveScheduledMaintenance
       )}
-      linodesData={extendedLinodes}
-      linodesRequestLoading={linodes.loading}
-      linodesRequestError={linodes.error.read}
+      linodesData={linodesData}
+      linodesRequestLoading={isLoading}
+      linodesRequestError={error ?? undefined}
     />
   );
 });

--- a/packages/manager/src/features/linodes/index.tsx
+++ b/packages/manager/src/features/linodes/index.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import SuspenseLoader from 'src/components/SuspenseLoader';
+import { useAllAccountMaintenanceQuery } from 'src/queries/accountMaintenance';
+import { useExtendedLinodes } from 'src/hooks/useExtendedLinode';
+import useLinodes from 'src/hooks/useLinodes';
 
 const LinodesLanding = React.lazy(
   () => import('./LinodesLanding/LinodesLanding')
@@ -16,7 +19,7 @@ const LinodesRoutes: React.FC = () => {
       <Switch>
         <Route component={LinodesCreate} path="/linodes/create" />
         <Route component={LinodesDetail} path="/linodes/:linodeId" />
-        <Route component={LinodesLanding} path="/linodes" exact strict />
+        <Route component={LinodesLandingWrapper} path="/linodes" exact strict />
         <Redirect to="/linodes" />
       </Switch>
     </React.Suspense>
@@ -24,3 +27,34 @@ const LinodesRoutes: React.FC = () => {
 };
 
 export default LinodesRoutes;
+
+// Light wrapper around LinodesLanding that injects "extended" Linodes (with
+// plan type and maintenance information). This extra data used to come from
+// mapStateToProps, but since I wanted to use a query (for accountMaintenance)
+// I needed a Function Component. It seemed safer to do it this way instead of
+// refactoring LinodesLanding.
+const LinodesLandingWrapper: React.FC = React.memo(() => {
+  const { data: accountMaintenanceData } = useAllAccountMaintenanceQuery(
+    {},
+    { status: { '+or': ['pending, started'] } }
+  );
+  const { linodes } = useLinodes();
+  const extendedLinodes = useExtendedLinodes();
+
+  const someLinodesHaveScheduledMaintenance = accountMaintenanceData?.some(
+    (thisAccountMaintenance) => {
+      return linodes.itemsById[thisAccountMaintenance.entity.id];
+    }
+  );
+
+  return (
+    <LinodesLanding
+      someLinodesHaveScheduledMaintenance={Boolean(
+        someLinodesHaveScheduledMaintenance
+      )}
+      linodesData={extendedLinodes}
+      linodesRequestLoading={linodes.loading}
+      linodesRequestError={linodes.error.read}
+    />
+  );
+});

--- a/packages/manager/src/features/linodes/transitions.ts
+++ b/packages/manager/src/features/linodes/transitions.ts
@@ -96,7 +96,7 @@ export const linodesInTransition = (events: Event[]) => {
 // but its status is still briefly in transition, so give it a progress of 100.
 export const getProgressOrDefault = (
   event?: ExtendedEvent,
-  defaultProgress = 100
+  defaultProgress = 0
 ) => event?.percent_complete ?? defaultProgress;
 
 // Linodes have a literal "status" given by the API (linode.status). There are

--- a/packages/manager/src/features/linodes/transitions.ts
+++ b/packages/manager/src/features/linodes/transitions.ts
@@ -31,6 +31,7 @@ const transitionActionMap: Partial<Record<EventAction, string>> = {
   disk_resize: 'Disk Resizing',
   disk_imagize: 'Capturing Image',
   disk_duplicate: 'Disk Duplicating',
+  linode_rebuild: 'Rebuilding',
 };
 
 export const linodeInTransition = (
@@ -112,6 +113,7 @@ const eventsWithSecondaryStatus: EventAction[] = [
   'linode_migrate',
   'linode_migrate_datacenter',
   'linode_mutate',
+  'linode_rebuild',
 ];
 
 export const isEventWithSecondaryLinodeStatus = (


### PR DESCRIPTION
## Description 📝

- Manually reverts #9062

## How to test 🧪

> **Warning**: Please test Linodes Landing thoroughly 

- Test functionality of Linodes Landing
- Test action menu actions
  - Please verify that actions and their respective dialogs work
- Test Group by tag and summary view
- Verify that the table still updates in real time with percentages from events data