### PR TITLE
fix: [M3-6576]: Fix Bucket Access Component Reloading API Data too often

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Fixed:
 - LISH Console via SSH containing `None` as the username #9148
 - Inability of restricted users with NodeBalancer creation permissions to add NodeBalancers #9150
+- Bucket Access unnecessarily refreshing #9140
 
 ## [2023-05-22] - v1.93.2
 

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/AccessSelect.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/AccessSelect.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { renderWithTheme } from 'src/utilities/testHelpers';
-import AccessSelect, { Props } from './AccessSelect';
+import { AccessSelect, Props } from './AccessSelect';
 
 jest.mock('src/components/EnhancedSelect/Select');
 

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/AccessSelect.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/AccessSelect.tsx
@@ -32,9 +32,7 @@ export interface Props {
   updateAccess: (acl: ACLType, cors_enabled?: boolean) => Promise<{}>;
 }
 
-type CombinedProps = Props;
-
-const AccessSelect: React.FC<CombinedProps> = (props) => {
+export const AccessSelect = (props: Props) => {
   const classes = useStyles();
 
   const { getAccess, updateAccess, name, variant } = props;
@@ -245,8 +243,6 @@ const AccessSelect: React.FC<CombinedProps> = (props) => {
     </>
   );
 };
-
-export default React.memo(AccessSelect);
 
 const copy: Record<
   'bucket' | 'object',

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/AccessSelect.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/AccessSelect.tsx
@@ -32,7 +32,7 @@ export interface Props {
   updateAccess: (acl: ACLType, cors_enabled?: boolean) => Promise<{}>;
 }
 
-export const AccessSelect = (props: Props) => {
+export const AccessSelect = React.memo((props: Props) => {
   const classes = useStyles();
 
   const { getAccess, updateAccess, name, variant } = props;
@@ -242,7 +242,7 @@ export const AccessSelect = (props: Props) => {
       </ConfirmationDialog>
     </>
   );
-};
+});
 
 const copy: Record<
   'bucket' | 'object',

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketAccess.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketAccess.tsx
@@ -21,7 +21,7 @@ interface Props {
   clusterId: string;
 }
 
-export const BucketAccess: React.FC<Props> = (props) => {
+export const BucketAccess = React.memo((props: Props) => {
   const classes = useStyles();
 
   const { bucketName, clusterId } = props;
@@ -44,6 +44,4 @@ export const BucketAccess: React.FC<Props> = (props) => {
       />
     </Paper>
   );
-};
-
-export default React.memo(BucketAccess);
+});

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketAccess.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketAccess.tsx
@@ -8,7 +8,7 @@ import Paper from 'src/components/core/Paper';
 import { makeStyles } from '@mui/styles';
 import { Theme } from '@mui/material/styles';
 import Typography from 'src/components/core/Typography';
-import AccessSelect from './AccessSelect';
+import { AccessSelect } from './AccessSelect';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectDetailsDrawer.tsx
@@ -13,7 +13,7 @@ import ExternalLink from 'src/components/ExternalLink';
 import formatDate from 'src/utilities/formatDate';
 import { truncateMiddle } from 'src/utilities/truncate';
 import { readableBytes } from 'src/utilities/unitConversions';
-import AccessSelect from './AccessSelect';
+import { AccessSelect } from './AccessSelect';
 import { useProfile } from 'src/queries/profile';
 
 const useStyles = makeStyles(() => ({

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDetailsDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDetailsDrawer.tsx
@@ -17,7 +17,7 @@ import formatDate from 'src/utilities/formatDate';
 import { pluralize } from 'src/utilities/pluralize';
 import { truncateMiddle } from 'src/utilities/truncate';
 import { readableBytes } from 'src/utilities/unitConversions';
-import AccessSelect from '../BucketDetail/AccessSelect';
+import { AccessSelect } from '../BucketDetail/AccessSelect';
 import { useProfile } from 'src/queries/profile';
 
 const useStyles = makeStyles(() => ({


### PR DESCRIPTION
## Description 📝

- This one is kind of hard to explain, but `packages/manager/src/features/ObjectStorage/BucketDetail/index.tsx` named imported `<BucketAccess />` which was **not** memoized, which resulted in this component's `useEffect`running more often then it should. It made an API call in the useEffect which caused the loading state to happen every time the parent component updated. 
- This fix is just to remove default imports and memoize the component so that we are guaranteed to import a memoized version of the component.
- Another fix probably could have been to React Query ify `<AccessSelect />` so that is does not rely on props and useEffects to track its state
  - I'll make a ticket and react query-ify this at a later date 

## The Bug 🐛

https://github.com/linode/manager/assets/115251059/34a74534-9dec-4aab-8f4b-be46d659dee7



## How to test 🧪

> **Note**: To recreate the bug, you must have an event that is being polled

- Create a Linode (or trigger any long-running event that will be polled)
- **_Quickly_** go to a valid`https://cloud.linode.com/object-storage/buckets/:cluster/:bucket/access` page
- Verify the loading state does not repeatedly happen
