### PR TITLE
change: [M3-5963] - Update Marketplace analytics search event

### DIFF
--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -249,7 +249,7 @@ class FromAppsContent extends React.Component<CombinedProps, State> {
     const didUserSelectCategory = categoryItem !== null;
     let instancesInCategory: StackScript[] | undefined = [];
     if (didUserSelectCategory) {
-      sendMarketplaceSearchEvent(categoryItem.label);
+      sendMarketplaceSearchEvent('Category Dropdown', categoryItem.label);
       const appsInCategory = oneClickApps.filter((oca) =>
         oca.categories?.includes(categoryItem.value)
       );
@@ -296,6 +296,10 @@ class FromAppsContent extends React.Component<CombinedProps, State> {
       this.props.updateStackScript
     );
 
+    const handleSearchFieldClick = () => {
+      sendMarketplaceSearchEvent('Search Field');
+    };
+
     const logoUrl = appInstances?.find(
       (app) => app.id === selectedStackScriptID
     )?.logo_url;
@@ -324,6 +328,7 @@ class FromAppsContent extends React.Component<CombinedProps, State> {
                   fullWidth
                   onSearch={this.onSearch}
                   label="Search marketplace"
+                  onClick={handleSearchFieldClick}
                   hideLabel
                   value={query}
                 />

--- a/packages/manager/src/utilities/ga.ts
+++ b/packages/manager/src/utilities/ga.ts
@@ -396,10 +396,15 @@ export const sendObjectStorageDocsEvent = (action: string) => {
   });
 };
 
-export const sendMarketplaceSearchEvent = (appCategory?: string) => {
+type TypeOfSearch = 'Search Field' | 'Category Dropdown';
+
+export const sendMarketplaceSearchEvent = (
+  typeOfSearch: TypeOfSearch,
+  appCategory?: string
+) => {
   sendEvent({
     category: 'Marketplace Create Flow',
-    action: 'Category Dropdown',
-    label: appCategory,
+    action: `Click: ${typeOfSearch}`,
+    label: appCategory ?? 'Apps Search',
   });
 };


### PR DESCRIPTION
## Description 📝
Updates the `sendMarketplaceSearchEvent` that fires on both the category dropdown and search bar in the Marketplace. 

## Major Changes 🔄
- Formats the event in a more standard way (e.g. `action:` `[interaction_type] : [input type]`)
- Restores ability to track when users search via search bar for a Marketplace app, while providing a generic label and not tracking the search query

P.S. Another PR will go through the rest of the custom events to standardize the format/contents of the `category`, `action`, `label`, and `value` fields, in cases where it is inconsistent. It is separate from this PR to keep the scope of these changes small, while we're comparing GA to AA data during the migration. 

## How to test 🧪
1. **How to setup test environment?**
   -  Use the PR preview link. (Alternatively: check this PR out locally, but you'll need to define the `REACT_APP_ADOBE_ANALYTICS_URL` environment variable defined in your `.env`.)
   -  Type `_satellite.setDebug(true)` in the developer console and refresh the page. You should see some debug logs to indicate that Adobe Analytics is running.
2. **How to verify changes?**
   - Navigate to Marketplace.
   - Select an option from the category dropdown and confirm the analytics event, with `Click: Category Dropdown` and the category name fires by checking the browser console.
   - Type in the search bar and confirm the analytics event, with `Click: Search Field` and `Apps Search`, fires by checking the browser console.