### PR TITLE
refactor: [M3-6073] - Move dismissibleButton to DismissibleBanner component

### DIFF
--- a/packages/manager/.changeset/pr-9142-tech-stories-1685027048549.md
+++ b/packages/manager/.changeset/pr-9142-tech-stories-1685027048549.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Move dismissibleButton to DismissibleBanner component ([#9142](https://github.com/linode/manager/pull/9142))

--- a/packages/manager/src/components/DismissibleBanner/DismissibleBanner.tsx
+++ b/packages/manager/src/components/DismissibleBanner/DismissibleBanner.tsx
@@ -1,10 +1,11 @@
 import Close from '@mui/icons-material/Close';
-import { styled } from '@mui/material/styles';
 import Grid from '@mui/material/Unstable_Grid2';
+import { styled } from '@mui/material/styles';
 import { SxProps } from '@mui/system';
 import * as React from 'react';
-import { Notice } from 'src/components/Notice/Notice';
 import type { NoticeProps } from 'src/components/Notice/Notice';
+import { Notice } from 'src/components/Notice/Notice';
+import Box from 'src/components/core/Box';
 import useDismissibleNotifications, {
   DismissibleNotificationOptions,
 } from 'src/hooks/useDismissibleNotifications';
@@ -15,12 +16,20 @@ interface Props {
   className?: string;
   options?: DismissibleNotificationOptions;
   sx?: SxProps;
+  actionButton?: JSX.Element;
 }
 
 type CombinedProps = Props & Partial<NoticeProps>;
 
 export const DismissibleBanner = (props: CombinedProps) => {
-  const { className, preferenceKey, options, children, ...rest } = props;
+  const {
+    className,
+    preferenceKey,
+    options,
+    children,
+    actionButton,
+    ...rest
+  } = props;
 
   const { hasDismissedBanner, handleDismiss } = useDismissibleBanner(
     preferenceKey,
@@ -44,12 +53,19 @@ export const DismissibleBanner = (props: CombinedProps) => {
   );
 
   return (
-    <StyledNotice
-      className={className}
-      dismissibleButton={dismissibleButton}
-      {...rest}
-    >
-      {children}
+    <StyledNotice className={className} {...rest}>
+      <Box
+        display="flex"
+        flexDirection="row"
+        alignItems="center"
+        justifyContent="space-between"
+      >
+        {children}
+        <Box display="flex" alignItems="center">
+          {actionButton}
+          {dismissibleButton}
+        </Box>
+      </Box>
     </StyledNotice>
   );
 };

--- a/packages/manager/src/components/Notice/Notice.tsx
+++ b/packages/manager/src/components/Notice/Notice.tsx
@@ -1,13 +1,13 @@
+import Grid, { Grid2Props } from '@mui/material/Unstable_Grid2';
+import { Theme } from '@mui/material/styles';
+import { SxProps } from '@mui/system';
 import * as React from 'react';
 import Error from 'src/assets/icons/alert.svg';
 import Check from 'src/assets/icons/check.svg';
 import Flag from 'src/assets/icons/flag.svg';
 import Warning from 'src/assets/icons/warning.svg';
-import { makeStyles } from 'tss-react/mui';
-import { Theme } from '@mui/material/styles';
 import Typography, { TypographyProps } from 'src/components/core/Typography';
-import Grid, { Grid2Props } from '@mui/material/Unstable_Grid2';
-import { SxProps } from '@mui/system';
+import { makeStyles } from 'tss-react/mui';
 
 export const useStyles = makeStyles<
   void,
@@ -126,7 +126,6 @@ export interface NoticeProps extends Grid2Props {
   sx?: SxProps;
   breakWords?: boolean;
   onClick?: (e: React.MouseEvent<HTMLElement>) => void;
-  dismissibleButton?: JSX.Element;
 }
 
 export const Notice = (props: NoticeProps) => {
@@ -148,7 +147,6 @@ export const Notice = (props: NoticeProps) => {
     spacingTop,
     spacingBottom,
     spacingLeft,
-    dismissibleButton,
     sx,
   } = props;
 
@@ -233,7 +231,6 @@ export const Notice = (props: NoticeProps) => {
           )) ||
           (error && <Error className={classes.icon} data-qa-error-img />))}
       <div className={classes.inner}>{innerText || _children}</div>
-      {dismissibleButton}
     </Grid>
   );
 };

--- a/packages/manager/src/features/GlobalNotifications/ComplianceBanner.tsx
+++ b/packages/manager/src/features/GlobalNotifications/ComplianceBanner.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import Button from 'src/components/Button';
+import DismissibleBanner from 'src/components/DismissibleBanner';
 import Box from 'src/components/core/Box';
 import Typography from 'src/components/core/Typography';
-import DismissibleBanner from 'src/components/DismissibleBanner';
 import { complianceUpdateContext } from 'src/context/complianceUpdateContext';
 import { useNotificationsQuery } from 'src/queries/accountNotifications';
 import { isEUModelContractNotification } from '../NotificationCenter/NotificationData/useFormattedNotifications';
@@ -19,8 +19,23 @@ const ComplianceBanner = () => {
     return null;
   }
 
+  const actionButton = (
+    <Button
+      buttonType="primary"
+      style={{ marginLeft: 12, minWidth: 150 }}
+      onClick={() => context.open()}
+    >
+      Review Update
+    </Button>
+  );
+
   return (
-    <DismissibleBanner important warning preferenceKey="gdpr-compliance">
+    <DismissibleBanner
+      important
+      warning
+      preferenceKey="gdpr-compliance"
+      actionButton={actionButton}
+    >
       <Box
         display="flex"
         flexDirection="row"
@@ -30,16 +45,9 @@ const ComplianceBanner = () => {
         <Typography>
           Please review the compliance update for guidance regarding the EU
           Standard Contractual Clauses and its application to users located in
-          Europe as well as deployments in Linode’s London and Frankfurt data
-          centers
+          Europe as well as deployments in Linode&rsquo;s London and Frankfurt
+          data centers
         </Typography>
-        <Button
-          buttonType="primary"
-          style={{ marginLeft: 12, minWidth: 150 }}
-          onClick={() => context.open()}
-        >
-          Review Update
-        </Button>
       </Box>
     </DismissibleBanner>
   );

--- a/packages/manager/src/features/GlobalNotifications/ComplianceBanner.tsx
+++ b/packages/manager/src/features/GlobalNotifications/ComplianceBanner.tsx
@@ -1,3 +1,4 @@
+import { styled } from '@mui/system';
 import * as React from 'react';
 import Button from 'src/components/Button';
 import DismissibleBanner from 'src/components/DismissibleBanner';
@@ -19,22 +20,16 @@ const ComplianceBanner = () => {
     return null;
   }
 
-  const actionButton = (
-    <Button
-      buttonType="primary"
-      style={{ marginLeft: 12, minWidth: 150 }}
-      onClick={() => context.open()}
-    >
-      Review Update
-    </Button>
-  );
-
   return (
     <DismissibleBanner
       important
       warning
       preferenceKey="gdpr-compliance"
-      actionButton={actionButton}
+      actionButton={
+        <StyledActionButton buttonType="primary" onClick={() => context.open()}>
+          Review Update
+        </StyledActionButton>
+      }
     >
       <Box
         display="flex"
@@ -52,5 +47,10 @@ const ComplianceBanner = () => {
     </DismissibleBanner>
   );
 };
+
+const StyledActionButton = styled(Button)(({}) => ({
+  marginLeft: 12,
+  minWidth: 150,
+}));
 
 export default ComplianceBanner;

--- a/packages/manager/src/features/GlobalNotifications/TaxCollectionBanner.tsx
+++ b/packages/manager/src/features/GlobalNotifications/TaxCollectionBanner.tsx
@@ -1,13 +1,12 @@
+import { Theme } from '@mui/material/styles';
+import { makeStyles } from '@mui/styles';
 import { DateTime } from 'luxon';
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 import Button from 'src/components/Button';
-import Box from 'src/components/core/Box';
-import { makeStyles } from '@mui/styles';
-import { Theme } from '@mui/material/styles';
-import Typography from 'src/components/core/Typography';
 import DismissibleBanner from 'src/components/DismissibleBanner';
 import Link from 'src/components/Link';
+import Typography from 'src/components/core/Typography';
 import { useFlags } from 'src/hooks/useFlags';
 import { useAccount } from 'src/queries/account';
 
@@ -19,7 +18,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-const TaxCollectionBanner: React.FC<{}> = () => {
+const TaxCollectionBanner = () => {
   const classes = useStyles();
   const history = useHistory();
   const flags = useFlags();
@@ -62,33 +61,32 @@ const TaxCollectionBanner: React.FC<{}> = () => {
   const isUserInTaxableRegion =
     bannerRegions.length > 0 && bannerRegions.includes(account.state);
 
+  const actionButton = bannerHasAction ? (
+    <Button
+      buttonType="primary"
+      className={classes.button}
+      onClick={() => history.push('/account/billing/edit')}
+    >
+      Update Tax ID
+    </Button>
+  ) : undefined;
+
   return (isEntireCountryTaxable || isUserInTaxableRegion) &&
     !isBannerDateWithinFiveWeeksPrior ? (
-    <DismissibleBanner warning important preferenceKey="tax-collection-banner">
-      <Box
-        display="flex"
-        flexDirection="row"
-        alignItems="center"
-        justifyContent="space-between"
-      >
-        <Typography>
-          Starting {bannerDateString}, tax may be applied to your Linode
-          services. For more information, please see the{' '}
-          <Link to="https://www.linode.com/docs/platform/billing-and-support/tax-information/">
-            Tax Information Guide
-          </Link>
-          .
-        </Typography>
-        {bannerHasAction ? (
-          <Button
-            buttonType="primary"
-            className={classes.button}
-            onClick={() => history.push('/account/billing/edit')}
-          >
-            Update Tax ID
-          </Button>
-        ) : null}
-      </Box>
+    <DismissibleBanner
+      warning
+      important
+      preferenceKey="tax-collection-banner"
+      actionButton={actionButton}
+    >
+      <Typography>
+        Starting {bannerDateString}, tax may be applied to your Linode services.
+        For more information, please see the{' '}
+        <Link to="https://www.linode.com/docs/platform/billing-and-support/tax-information/">
+          Tax Information Guide
+        </Link>
+        .
+      </Typography>
     </DismissibleBanner>
   ) : null;
 };

--- a/packages/manager/src/features/Help/StatusBanners.tsx
+++ b/packages/manager/src/features/Help/StatusBanners.tsx
@@ -1,10 +1,11 @@
+import Box from '@mui/material/Box';
+import { Theme } from '@mui/material/styles';
+import { makeStyles } from '@mui/styles';
 import { DateTime } from 'luxon';
 import * as React from 'react';
-import { makeStyles } from '@mui/styles';
-import { Theme } from '@mui/material/styles';
-import Typography from 'src/components/core/Typography';
 import DismissibleBanner from 'src/components/DismissibleBanner';
 import Link from 'src/components/Link';
+import Typography from 'src/components/core/Typography';
 import {
   IncidentImpact,
   IncidentStatus,
@@ -16,12 +17,6 @@ import { truncateEnd } from 'src/utilities/truncate';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
-    padding: theme.spacing(),
-    paddingLeft: theme.spacing(2),
-    display: 'flex',
-    justifyContent: 'space-between',
-    flexFlow: 'row nowrap',
-    alignItems: 'center',
     marginBottom: theme.spacing(),
   },
   button: {
@@ -101,7 +96,7 @@ export const IncidentBanner: React.FC<IncidentProps> = React.memo((props) => {
         expiry: DateTime.utc().plus({ days: 1 }).toISO(),
       }}
     >
-      <>
+      <Box display="flex" flexDirection="column">
         <Typography data-testid="status-banner" className={classes.header}>
           <Link to={href}>
             <strong data-testid="incident-status">
@@ -116,7 +111,7 @@ export const IncidentBanner: React.FC<IncidentProps> = React.memo((props) => {
           }}
           className={classes.text}
         />
-      </>
+      </Box>
     </DismissibleBanner>
   );
 });

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeKubernetesVersionBanner.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/UpgradeKubernetesVersionBanner.tsx
@@ -19,6 +19,11 @@ export const UpgradeKubernetesVersionBanner = (props: Props) => {
   const nextVersion = getNextVersion(currentVersion, versions ?? []);
 
   const [dialogOpen, setDialogOpen] = React.useState(false);
+  const actionButton = (
+    <Button onClick={() => setDialogOpen(true)} buttonType="primary">
+      Upgrade Version
+    </Button>
+  );
 
   return (
     <>
@@ -26,6 +31,7 @@ export const UpgradeKubernetesVersionBanner = (props: Props) => {
         <DismissibleBanner
           preferenceKey={`${clusterID}-${currentVersion}`}
           success
+          actionButton={actionButton}
         >
           <Grid
             container
@@ -37,11 +43,6 @@ export const UpgradeKubernetesVersionBanner = (props: Props) => {
               <Typography>
                 A new version of Kubernetes is available ({nextVersion}).
               </Typography>
-            </Grid>
-            <Grid>
-              <Button onClick={() => setDialogOpen(true)} buttonType="primary">
-                Upgrade Version
-              </Button>
             </Grid>
           </Grid>
         </DismissibleBanner>


### PR DESCRIPTION
## Description 📝
- Move dismissibleButton to DismissibleBanner component instead of passing it to the Notice Component.
- Minor refactoring so that primary action buttons are aligned with the dismissible button

## Preview 📷
![image](https://github.com/linode/manager/assets/115299789/d33d694d-fdbf-4ca8-8760-5054f288a55c)

## How to test 🧪
Turn the MSW on and check for any dismissible banner regressions