### PR TITLE
hotfix: [M3-6594] - Enable linode action menu "reboot" on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2023-05-22] - v1.93.2
+
+### Fixed:
+- Issue where linode "Reboot" button was disabled #9143
+
 ## [2023-05-18] - v1.93.1
 
 ### Fixed:

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.93.1",
+  "version": "1.93.2",
   "private": true,
   "bugs": {
     "url": "https://github.com/Linode/manager/issues"

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.test.tsx
@@ -76,10 +76,17 @@ describe('LinodeActionMenu', () => {
       );
     });
 
-    it.skip('should disable the reboot action if the Linode is not running', () => {
-      // @todo update ActionMenu mock to fix this test once CMR action menu is gone
+    it('should allow a reboot if the Linode is running', () => {
+      renderWithTheme(<LinodeActionMenu {...props} />);
+      expect(screen.queryByText('Reboot')).not.toHaveAttribute('aria-disabled');
+    });
+
+    it('should disable the reboot action if the Linode is not running', () => {
       renderWithTheme(<LinodeActionMenu {...props} linodeStatus="offline" />);
-      expect(screen.queryByText('Reboot')).toBeDisabled();
+      expect(screen.queryByText('Reboot')).toHaveAttribute(
+        'aria-disabled',
+        'true'
+      );
     });
   });
 

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.test.tsx
@@ -82,6 +82,7 @@ describe('LinodeActionMenu', () => {
     });
 
     it('should disable the reboot action if the Linode is not running', () => {
+      // TODO: Should check for "read_only" permissions too
       renderWithTheme(<LinodeActionMenu {...props} linodeStatus="offline" />);
       expect(screen.queryByText('Reboot')).toHaveAttribute(
         'aria-disabled',

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
@@ -118,7 +118,7 @@ export const LinodeActionMenu: React.FC<Props> = (props) => {
     inListView || matchesSmDown
       ? {
           title: 'Reboot',
-          disabled: linodeStatus !== 'running' || matchesSmDown || readOnly,
+          disabled: linodeStatus !== 'running' || readOnly,
           tooltip: readOnly ? noPermissionTooltipText : undefined,
           onClick: () => {
             sendLinodeActionMenuItemEvent('Reboot Linode');


### PR DESCRIPTION
## Description 📝
Seems to be a slight bug introduced with [a refactor](https://github.com/linode/manager/commit/b9fcf70f3d51094067b578fd10fbd2fd0da7c1ac#diff-af5757c9f2be53593a6a9655c8ea746d322078c01a070da0400f8325d4e127b3L167-R125). We no longer should need to check for `matchesSmDown` anymore.

## Major Changes 🔄
- Reboot should be disabled if there's readonly access or if the linodes not running

## Preview 📷
| Before  | After   |
| ------- | ------- |
| <img width="203" alt="Screen Shot 2023-05-21 at 6 13 29 PM" src="https://github.com/linode/manager/assets/125309814/0dab6634-d54c-43d8-b43f-5b8055dee9c6"> | <img width="206" alt="Screen Shot 2023-05-21 at 6 14 18 PM" src="https://github.com/linode/manager/assets/125309814/8bb2ba0d-6fa2-41c6-b8d8-4914c755037c"> |

## How to test 🧪
1. Go to a linode detail page
2. Reduce screen size below < 960px
3. Open action menu and observe "Reboot" is enabled
