### PR TITLE
hotfix: Fix LISH Console via SSH containing `None` as the username in Summary View

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2023-05-22] - v1.93.3
+
+### Fixed:
+- LISH Console via SSH containing `None` as the username
+
 ## [2023-05-22] - v1.93.2
 
 ### Fixed:

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.93.2",
+  "version": "1.93.3",
   "private": true,
   "bugs": {
     "url": "https://github.com/Linode/manager/issues"

--- a/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
+++ b/packages/manager/src/features/linodes/LinodeEntityDetail.tsx
@@ -57,7 +57,6 @@ interface LinodeEntityDetailProps {
   variant?: TypographyProps['variant'];
   id: number;
   linode: Linode;
-  username?: string;
   backups: LinodeBackups;
   openTagDrawer: (tags: string[]) => void;
   isSummaryView?: boolean;
@@ -71,7 +70,6 @@ const LinodeEntityDetail: React.FC<CombinedProps> = (props) => {
   const {
     variant,
     linode,
-    username,
     backups,
     isSummaryView,
     openTagDrawer,
@@ -154,7 +152,6 @@ const LinodeEntityDetail: React.FC<CombinedProps> = (props) => {
           ipv4={linode.ipv4}
           ipv6={trimmedIPv6}
           linodeId={linode.id}
-          username={username ? username : 'none'}
         />
       }
       footer={
@@ -414,7 +411,6 @@ export interface BodyProps {
   ipv4: Linode['ipv4'];
   ipv6: Linode['ipv6'];
   linodeId: number;
-  username: string;
   linodeLabel: string;
   numVolumes: number;
 }
@@ -461,11 +457,15 @@ export const Body: React.FC<BodyProps> = React.memo((props) => {
     region,
     ipv4,
     ipv6,
-    username,
     linodeLabel,
     linodeId,
     numVolumes,
   } = props;
+
+  const { data: profile } = useProfile();
+
+  const username = profile?.username ?? 'none';
+
   const theme = useTheme();
   const numIPAddresses = ipv4.length + (ipv6 ? 1 : 0);
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
@@ -9,7 +9,6 @@ import {
   Action,
 } from 'src/features/linodes/PowerActionsDialogOrDrawer';
 import useLinodeActions from 'src/hooks/useLinodeActions';
-import { useProfile } from 'src/queries/profile';
 import { parseQueryParams } from 'src/utilities/queryParams';
 import { DeleteLinodeDialog } from '../../LinodesLanding/DeleteLinodeDialog';
 import { MigrateLinode } from 'src/features/linodes/MigrateLinode';
@@ -130,8 +129,6 @@ const LinodeDetailHeader: React.FC<CombinedProps> = (props) => {
     });
   };
 
-  const { data: profile } = useProfile();
-
   const {
     editableLabelError,
     setEditableLabelError,
@@ -236,7 +233,6 @@ const LinodeDetailHeader: React.FC<CombinedProps> = (props) => {
       <LinodeEntityDetail
         id={linode.id}
         linode={linode}
-        username={profile?.username}
         backups={linode.backups}
         openTagDrawer={openTagDrawer}
         handlers={handlers}


### PR DESCRIPTION
## Description 📝

- During all of the hecticness with Linodes, an optional prop was missed, resulting in the LISH username saying `none` in Summary view
- The fix is to not prop drill the username so that it is impossible to not include it 

## Preview 📷

### Before
![Screenshot 2023-05-22 at 12 45 46 PM](https://github.com/linode/manager/assets/115251059/3d184dc0-49c1-46f5-bf5b-324f73668974)

### After

![Screenshot 2023-05-22 at 12 46 13 PM](https://github.com/linode/manager/assets/115251059/3b32d9a9-3077-45d4-9309-0c80ee7ee019)

## How to test 🧪
- Verify you can see the correct username in the LISH connection command in two places:
  - The Linodes Detail page
  - The Linodes Landing page when in summary view