### PR TITLE
hotfix: [M3-6598] - Limited cannot create NodeBalancer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed:
 - LISH Console via SSH containing `None` as the username #9148
-- Limited user cannot create NodeBalancer #9150
+Inability of restricted users with NodeBalancer creation permissions to add NodeBalancers #9150
 
 ## [2023-05-22] - v1.93.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed:
 - LISH Console via SSH containing `None` as the username #9148
+- Limited user cannot create NodeBalancer
 
 ## [2023-05-22] - v1.93.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed:
 - LISH Console via SSH containing `None` as the username #9148
-Inability of restricted users with NodeBalancer creation permissions to add NodeBalancers #9150
+- Inability of restricted users with NodeBalancer creation permissions to add NodeBalancers #9150
 
 ## [2023-05-22] - v1.93.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed:
 - LISH Console via SSH containing `None` as the username #9148
-- Limited user cannot create NodeBalancer
+- Limited user cannot create NodeBalancer #9150
 
 ## [2023-05-22] - v1.93.2
 

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -101,7 +101,8 @@ const NodeBalancerCreate = () => {
 
   const { mutateAsync: updateAgreements } = useMutateAccountAgreements();
 
-  const disabled = Boolean(profile?.restricted) && !grants?.global.add_domains;
+  const disabled =
+    Boolean(profile?.restricted) && !grants?.global.add_nodebalancers;
 
   const addNodeBalancer = () => {
     if (disabled) {


### PR DESCRIPTION
## Description 📝
Users without full account access cannot create NodeBalancers if they do not have the global permission to add Domains, even if they are granted the permission to add NodeBalancers.

## Major Changes 🔄
- We were checking the wrong grant for `NodeBalancerCreate`

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screen Shot 2023-05-22 at 2 02 05 PM](https://github.com/linode/manager/assets/125309814/c6aedc40-b8ac-41fc-9aa2-3a472eb0d494) | User should now have access to create a node balancer if given permissions |

## How to test 🧪
1. add a limited user
2. enable that user's global permission for "Can add NodeBalancers to this account ($)"
3. save
4. login as the limed user.
5. create a nodebalancer