### PR TITLE
hotfix: Linode Multi Select not working with large filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed:
 - LISH Console via SSH containing `None` as the username #9148
+- Ability to add a Linode to a Firewall when the Firewall contains a large number of Linodes #9151
 
 ## [2023-05-22] - v1.93.2
 

--- a/packages/manager/src/components/LinodeMultiSelect/LinodeMultiSelect.tsx
+++ b/packages/manager/src/components/LinodeMultiSelect/LinodeMultiSelect.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
-import { useInfiniteLinodesQuery } from 'src/queries/linodes/linodes';
+import { useAllLinodesQuery } from 'src/queries/linodes/linodes';
 import Autocomplete from '@mui/material/Autocomplete';
 import Popper from '@mui/material/Popper';
 import TextField from 'src/components/TextField';
-import { isNumeric } from 'src/utilities/stringUtils';
 
 export interface Props {
   allowedRegions?: string[];
@@ -28,30 +27,6 @@ const LinodeMultiSelect = (props: Props) => {
     onBlur,
   } = props;
 
-  const [inputValue, setInputValue] = React.useState<string>('');
-
-  const isInputValueNumeric = isNumeric(inputValue);
-
-  const searchFilter = inputValue
-    ? {
-        '+or': isInputValueNumeric
-          ? [
-              { id: Number(inputValue) },
-              { label: { '+contains': inputValue } },
-              { tags: { '+contains': inputValue } },
-            ]
-          : [
-              { label: { '+contains': inputValue } },
-              { tags: { '+contains': inputValue } },
-            ],
-      }
-    : {};
-
-  const linodesFilter =
-    filteredLinodes && filteredLinodes.length > 0
-      ? { '+and': filteredLinodes.map((id) => ({ id: { '+neq': id } })) }
-      : {};
-
   const regionFilter = allowedRegions
     ? {
         '+and': allowedRegions.map((regionId) => ({
@@ -60,20 +35,10 @@ const LinodeMultiSelect = (props: Props) => {
       }
     : {};
 
-  const {
-    data,
-    isLoading,
-    error,
-    hasNextPage,
-    fetchNextPage,
-  } = useInfiniteLinodesQuery({
-    ...searchFilter,
-    ...regionFilter,
-    ...linodesFilter,
-  });
+  const { data, isLoading, error } = useAllLinodesQuery({}, regionFilter);
 
-  const options = data?.pages
-    .flatMap((page) => page.data)
+  const options = data
+    ?.filter((linode) => !filteredLinodes?.includes(linode.id))
     .map(({ id, label }) => ({ id, label }));
 
   const selectedLinodeOptions =
@@ -83,39 +48,17 @@ const LinodeMultiSelect = (props: Props) => {
     <Autocomplete
       multiple
       clearOnBlur
-      onBlur={(e) => {
-        onBlur?.(e);
-        setInputValue('');
-      }}
+      onBlur={onBlur}
       disabled={disabled}
       loading={isLoading}
       options={options ?? []}
       value={selectedLinodeOptions}
-      filterOptions={(options) => options}
       onChange={(event, value) => {
         onChange(value.map((option) => option.id));
-      }}
-      inputValue={inputValue}
-      onInputChange={(event, value, reason) => {
-        if (reason !== 'reset') {
-          setInputValue(value);
-        }
       }}
       PopperComponent={(popperProps) => (
         <Popper {...popperProps} data-qa-autocomplete-popper />
       )}
-      ListboxProps={{
-        onScroll: (event: React.SyntheticEvent) => {
-          const listboxNode = event.currentTarget;
-          if (
-            listboxNode.scrollTop + listboxNode.clientHeight >=
-              listboxNode.scrollHeight &&
-            hasNextPage
-          ) {
-            fetchNextPage();
-          }
-        },
-      }}
       renderInput={(params) => (
         <TextField
           label="Linodes"


### PR DESCRIPTION
## Description 📝

- Uses a fetch all for the Linode Multi Select because the Linode API could not handle large filters when filtering out linodes
- As a fix for now, I think we can just let the client do the searching and filtering rather than the API
- This fixes the ability for some users to attach linodes to firewalls that already consist of hundreds of linodes

## How to test 🧪
- Verify you can add and remove linodes to a firewall
- Check the functionality of the Select component that displays these linodes