### PR TITLE
refactor: [M3-6331] - MUI v5 - `Components > EnhancedNumberInput`

### DIFF
--- a/packages/manager/src/components/EnhancedNumberInput/EnhancedNumberInput.stories.mdx
+++ b/packages/manager/src/components/EnhancedNumberInput/EnhancedNumberInput.stories.mdx
@@ -1,6 +1,6 @@
 import Typography from 'src/components/core/Typography';
 import Paper from 'src/components/core/Paper';
-import { EnhancedNumberInput } from './EnhancedNumberInput';
+import { EnhancedNumberInput } from 'src/components/EnhancedNumberInput/EnhancedNumberInput';
 import { Canvas, Meta, Story, ArgsTable } from '@storybook/addon-docs';
 import * as React from 'react';
 

--- a/packages/manager/src/components/EnhancedNumberInput/EnhancedNumberInput.test.tsx
+++ b/packages/manager/src/components/EnhancedNumberInput/EnhancedNumberInput.test.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import { wrapWithTheme } from 'src/utilities/testHelpers';
 
-import EnhancedNumberInput from './EnhancedNumberInput';
+import { EnhancedNumberInput } from 'src/components/EnhancedNumberInput/EnhancedNumberInput';
 
 const setValue = jest.fn();
 

--- a/packages/manager/src/components/EnhancedNumberInput/EnhancedNumberInput.tsx
+++ b/packages/manager/src/components/EnhancedNumberInput/EnhancedNumberInput.tsx
@@ -1,80 +1,64 @@
-import classNames from 'classnames';
 import * as React from 'react';
 import Minus from 'src/assets/icons/LKEminusSign.svg';
 import Plus from 'src/assets/icons/LKEplusSign.svg';
 import Button from 'src/components/Button';
-import { makeStyles } from '@mui/styles';
+import { styled } from '@mui/material/styles';
 import TextField from 'src/components/TextField';
 
-const useStyles = makeStyles(() => ({
-  root: {
-    '& $button': {
-      width: 35,
-      height: 34,
-      minWidth: 30,
-      border: 'none',
-      '&:hover': {
-        backgroundColor: 'rgba(224, 224, 224, 0.69) !important',
-      },
-    },
-    '& $input': {
-      padding: '0 8px',
-    },
-    '& $textField': {
-      width: 53,
-      minWidth: 40,
-      height: 34,
-      minHeight: 30,
-    },
-    '& $plusIcon': {
-      width: 14,
-    },
-    '& $minusIcon': {
-      width: 12,
-    },
-  },
-  button: {
-    width: 40,
-    height: 40,
-    minWidth: 40,
-  },
-  textField: {
-    margin: '0 5px',
-    height: 40,
-    minHeight: 40,
-    width: 60,
-    minWidth: 50,
-    flexDirection: 'row',
-  },
-  input: {
-    textAlign: 'right',
-    '-moz-appearance': 'textfield',
-    '&::-webkit-inner-spin-button': {
-      '-webkit-appearance': 'none',
-      margin: 0,
-    },
-    '&::-webkit-outer-spin-button': {
-      '-webkit-appearance': 'none',
-      margin: 0,
-    },
-  },
-  plusIcon: {
-    width: 17,
-  },
-  minusIcon: {
-    width: 14,
-  },
-  inputGroup: {
-    display: 'flex',
-    position: 'relative',
-    '& button': {
-      borderRadius: 0,
-      minHeight: 'fit-content',
-    },
-  },
-}));
+// const useStyles = makeStyles<
+//   void,
+//   'button' | 'input' | 'textField' | 'plusIcon' | 'minusIcon'
+// >()((_theme, _params, classes) => ({
+//   root: {
+//     [`& .${classes.button}`]: {
+//       width: 35,
+//       height: 34,
+//       minWidth: 30,
+//       border: 'none',
+//       '&:hover': {
+//         backgroundColor: 'rgba(224, 224, 224, 0.69) !important',
+//       },
+//     },
+//     [`& .${classes.input}`]: {
+//       padding: '0 8px',
+//     },
+//     [`& .${classes.textField}`]: {
+//       width: 53,
+//       minWidth: 40,
+//       height: 34,
+//       minHeight: 30,
+//     },
+//     [`& .${classes.plusIcon}`]: {
+//       width: 14,
+//     },
+//     [`& .${classes.minusIcon}`]: {
+//       width: 12,
+//     },
+//   },
+//   inputGroup: {
+//     display: 'flex',
+//     position: 'relative',
+//     '& button': {
+//       borderRadius: 0,
+//       minHeight: 'fit-content',
+//     },
+//   },
+// }));
 
-interface Props {
+const inputOverrides = {
+  textAlign: 'right',
+  '-moz-appearance': 'textfield',
+  '&::-webkit-inner-spin-button': {
+    '-webkit-appearance': 'none',
+    margin: 0,
+  },
+  '&::-webkit-outer-spin-button': {
+    '-webkit-appearance': 'none',
+    margin: 0,
+  },
+};
+
+interface EnhancedNumberInputProps {
   inputLabel?: string;
   value: number;
   setValue: (value: number) => void;
@@ -83,7 +67,7 @@ interface Props {
   min?: number;
 }
 
-export const EnhancedNumberInput: React.FC<Props> = (props) => {
+export const EnhancedNumberInput = (props: EnhancedNumberInputProps) => {
   const { inputLabel, setValue, disabled } = props;
 
   const max = props.max ?? 100;
@@ -116,23 +100,26 @@ export const EnhancedNumberInput: React.FC<Props> = (props) => {
   };
 
   // TODO add error prop for error handling
-  const classes = useStyles();
+
   return (
-    <div className={`${classes.root} ${classes.inputGroup}`}>
+    <EnhancedNumberInputRoot>
       <Button
         buttonType="outlined"
-        className={classes.button}
         compactX
         disabled={disabled || value === min}
         onClick={decrementValue}
         name="Subtract 1"
         aria-label="Subtract 1"
         data-testid={'decrement-button'}
+        sx={{
+          height: 40,
+          minWidth: 40,
+          width: 40,
+        }}
       >
-        <Minus className={classes.minusIcon} />
+        <MinusIcon />
       </Button>
       <TextField
-        className={classes.textField}
         type="number"
         label={inputLabel ? inputLabel : 'Edit Quantity'}
         aria-live="polite"
@@ -140,30 +127,52 @@ export const EnhancedNumberInput: React.FC<Props> = (props) => {
         hideLabel
         value={value}
         onChange={onChange}
-        inputProps={{
-          className: classNames({
-            [classes.input]: true,
-          }),
-        }}
         min={min}
         max={max}
         disabled={disabled}
         data-testid={'quantity-input'}
+        sx={{
+          flexDirection: 'row',
+          height: 40,
+          margin: '0 5px',
+          minHeight: 40,
+          minWidth: 50,
+          width: 60,
+          '.MuiInputBase-input': inputOverrides,
+        }}
       />
       <Button
         buttonType="outlined"
-        className={classes.button}
         compactX
         disabled={disabled || value === max}
         onClick={incrementValue}
         name="Add 1"
         aria-label="Add 1"
         data-testid={'increment-button'}
+        sx={{
+          height: 40,
+          minWidth: 40,
+          width: 40,
+        }}
       >
-        <Plus className={classes.plusIcon} />
+        <PlusIcon />
       </Button>
-    </div>
+    </EnhancedNumberInputRoot>
   );
 };
+
+const EnhancedNumberInputRoot = styled('div', {
+  label: 'EnhancedNumberInput',
+})({
+  // Add className={`${classes.root} ${classes.inputGroup}`}
+});
+
+const MinusIcon = styled(Minus)({
+  width: 14,
+});
+
+const PlusIcon = styled(Plus)({
+  width: 17,
+});
 
 export default React.memo(EnhancedNumberInput);

--- a/packages/manager/src/components/EnhancedNumberInput/EnhancedNumberInput.tsx
+++ b/packages/manager/src/components/EnhancedNumberInput/EnhancedNumberInput.tsx
@@ -6,7 +6,7 @@ import { styled } from '@mui/material/styles';
 import TextField from 'src/components/TextField';
 import Box from '@mui/material/Box';
 
-const sxInput = {
+const sxTextFieldBase = {
   padding: '0 8px',
   textAlign: 'right',
   '-moz-appearance': 'textfield',
@@ -51,92 +51,94 @@ interface EnhancedNumberInputProps {
   min?: number;
 }
 
-export const EnhancedNumberInput = (props: EnhancedNumberInputProps) => {
-  const { inputLabel, setValue, disabled } = props;
+export const EnhancedNumberInput = React.memo(
+  (props: EnhancedNumberInputProps) => {
+    const { inputLabel, setValue, disabled } = props;
 
-  const max = props.max ?? 100;
-  const min = props.min ?? 0;
+    const max = props.max ?? 100;
+    const min = props.min ?? 0;
 
-  let value = props.value;
-  if (value > max) {
-    value = max;
-  } else if (value < min) {
-    value = min;
-  }
-
-  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const parsedValue = +e.target.value;
-    if (parsedValue >= min && parsedValue <= max) {
-      setValue(+e.target.value);
+    let value = props.value;
+    if (value > max) {
+      value = max;
+    } else if (value < min) {
+      value = min;
     }
-  };
 
-  const incrementValue = () => {
-    if (value < max) {
-      setValue(value + 1);
-    }
-  };
+    const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      const parsedValue = +e.target.value;
+      if (parsedValue >= min && parsedValue <= max) {
+        setValue(+e.target.value);
+      }
+    };
 
-  const decrementValue = () => {
-    if (value > min) {
-      setValue(value - 1);
-    }
-  };
+    const incrementValue = () => {
+      if (value < max) {
+        setValue(value + 1);
+      }
+    };
 
-  // TODO add error prop for error handling
+    const decrementValue = () => {
+      if (value > min) {
+        setValue(value - 1);
+      }
+    };
 
-  return (
-    <Box
-      sx={{
-        display: 'flex',
-        position: 'relative',
-      }}
-    >
-      <Button
-        buttonType="outlined"
-        compactX
-        disabled={disabled || value === min}
-        onClick={decrementValue}
-        name="Subtract 1"
-        aria-label="Subtract 1"
-        data-testid={'decrement-button'}
-        sx={sxButton}
-      >
-        <MinusIcon />
-      </Button>
-      <TextField
-        type="number"
-        label={inputLabel ? inputLabel : 'Edit Quantity'}
-        aria-live="polite"
-        name="Quantity"
-        hideLabel
-        value={value}
-        onChange={onChange}
-        min={min}
-        max={max}
-        disabled={disabled}
-        data-testid={'quantity-input'}
+    // TODO add error prop for error handling
+
+    return (
+      <Box
         sx={{
-          ...sxTextField,
-          '.MuiInputBase-root': sxTextField,
-          '.MuiInputBase-input': sxInput,
+          display: 'flex',
+          position: 'relative',
         }}
-      />
-      <Button
-        buttonType="outlined"
-        compactX
-        disabled={disabled || value === max}
-        onClick={incrementValue}
-        name="Add 1"
-        aria-label="Add 1"
-        data-testid={'increment-button'}
-        sx={sxButton}
       >
-        <PlusIcon />
-      </Button>
-    </Box>
-  );
-};
+        <Button
+          buttonType="outlined"
+          compactX
+          disabled={disabled || value === min}
+          onClick={decrementValue}
+          name="Subtract 1"
+          aria-label="Subtract 1"
+          data-testid={'decrement-button'}
+          sx={sxButton}
+        >
+          <MinusIcon />
+        </Button>
+        <TextField
+          type="number"
+          label={inputLabel ? inputLabel : 'Edit Quantity'}
+          aria-live="polite"
+          name="Quantity"
+          hideLabel
+          value={value}
+          onChange={onChange}
+          min={min}
+          max={max}
+          disabled={disabled}
+          data-testid={'quantity-input'}
+          sx={{
+            ...sxTextField,
+            '.MuiInputBase-root': sxTextField,
+            '.MuiInputBase-input': sxTextFieldBase,
+          }}
+        />
+        <Button
+          buttonType="outlined"
+          compactX
+          disabled={disabled || value === max}
+          onClick={incrementValue}
+          name="Add 1"
+          aria-label="Add 1"
+          data-testid={'increment-button'}
+          sx={sxButton}
+        >
+          <PlusIcon />
+        </Button>
+      </Box>
+    );
+  }
+);
 
 const MinusIcon = styled(Minus)({
   width: 12,
@@ -145,5 +147,3 @@ const MinusIcon = styled(Minus)({
 const PlusIcon = styled(Plus)({
   width: 14,
 });
-
-export default React.memo(EnhancedNumberInput);

--- a/packages/manager/src/components/EnhancedNumberInput/EnhancedNumberInput.tsx
+++ b/packages/manager/src/components/EnhancedNumberInput/EnhancedNumberInput.tsx
@@ -4,48 +4,10 @@ import Plus from 'src/assets/icons/LKEplusSign.svg';
 import Button from 'src/components/Button';
 import { styled } from '@mui/material/styles';
 import TextField from 'src/components/TextField';
+import Box from '@mui/material/Box';
 
-// const useStyles = makeStyles<
-//   void,
-//   'button' | 'input' | 'textField' | 'plusIcon' | 'minusIcon'
-// >()((_theme, _params, classes) => ({
-//   root: {
-//     [`& .${classes.button}`]: {
-//       width: 35,
-//       height: 34,
-//       minWidth: 30,
-//       border: 'none',
-//       '&:hover': {
-//         backgroundColor: 'rgba(224, 224, 224, 0.69) !important',
-//       },
-//     },
-//     [`& .${classes.input}`]: {
-//       padding: '0 8px',
-//     },
-//     [`& .${classes.textField}`]: {
-//       width: 53,
-//       minWidth: 40,
-//       height: 34,
-//       minHeight: 30,
-//     },
-//     [`& .${classes.plusIcon}`]: {
-//       width: 14,
-//     },
-//     [`& .${classes.minusIcon}`]: {
-//       width: 12,
-//     },
-//   },
-//   inputGroup: {
-//     display: 'flex',
-//     position: 'relative',
-//     '& button': {
-//       borderRadius: 0,
-//       minHeight: 'fit-content',
-//     },
-//   },
-// }));
-
-const inputOverrides = {
+const sxInput = {
+  padding: '0 8px',
   textAlign: 'right',
   '-moz-appearance': 'textfield',
   '&::-webkit-inner-spin-button': {
@@ -55,6 +17,28 @@ const inputOverrides = {
   '&::-webkit-outer-spin-button': {
     '-webkit-appearance': 'none',
     margin: 0,
+  },
+};
+
+const sxTextField = {
+  flexDirection: 'row',
+  height: 34,
+  margin: '0 5px',
+  minHeight: 30,
+  minWidth: 40,
+  width: 53,
+};
+
+const sxButton = {
+  borderRadius: 0,
+  height: 34,
+  minHeight: 'fit-content',
+  minWidth: 30,
+  width: 35,
+  border: 'none',
+  '&:hover': {
+    backgroundColor: 'rgba(224, 224, 224, 0.69)',
+    border: 'none',
   },
 };
 
@@ -102,7 +86,12 @@ export const EnhancedNumberInput = (props: EnhancedNumberInputProps) => {
   // TODO add error prop for error handling
 
   return (
-    <EnhancedNumberInputRoot>
+    <Box
+      sx={{
+        display: 'flex',
+        position: 'relative',
+      }}
+    >
       <Button
         buttonType="outlined"
         compactX
@@ -111,11 +100,7 @@ export const EnhancedNumberInput = (props: EnhancedNumberInputProps) => {
         name="Subtract 1"
         aria-label="Subtract 1"
         data-testid={'decrement-button'}
-        sx={{
-          height: 40,
-          minWidth: 40,
-          width: 40,
-        }}
+        sx={sxButton}
       >
         <MinusIcon />
       </Button>
@@ -132,13 +117,9 @@ export const EnhancedNumberInput = (props: EnhancedNumberInputProps) => {
         disabled={disabled}
         data-testid={'quantity-input'}
         sx={{
-          flexDirection: 'row',
-          height: 40,
-          margin: '0 5px',
-          minHeight: 40,
-          minWidth: 50,
-          width: 60,
-          '.MuiInputBase-input': inputOverrides,
+          ...sxTextField,
+          '.MuiInputBase-root': sxTextField,
+          '.MuiInputBase-input': sxInput,
         }}
       />
       <Button
@@ -149,30 +130,20 @@ export const EnhancedNumberInput = (props: EnhancedNumberInputProps) => {
         name="Add 1"
         aria-label="Add 1"
         data-testid={'increment-button'}
-        sx={{
-          height: 40,
-          minWidth: 40,
-          width: 40,
-        }}
+        sx={sxButton}
       >
         <PlusIcon />
       </Button>
-    </EnhancedNumberInputRoot>
+    </Box>
   );
 };
 
-const EnhancedNumberInputRoot = styled('div', {
-  label: 'EnhancedNumberInput',
-})({
-  // Add className={`${classes.root} ${classes.inputGroup}`}
-});
-
 const MinusIcon = styled(Minus)({
-  width: 14,
+  width: 12,
 });
 
 const PlusIcon = styled(Plus)({
-  width: 17,
+  width: 14,
 });
 
 export default React.memo(EnhancedNumberInput);

--- a/packages/manager/src/components/EnhancedNumberInput/index.tsx
+++ b/packages/manager/src/components/EnhancedNumberInput/index.tsx
@@ -1,1 +1,0 @@
-export { default } from './EnhancedNumberInput';

--- a/packages/manager/src/features/Kubernetes/KubeCheckoutBar/NodePoolSummary.tsx
+++ b/packages/manager/src/features/Kubernetes/KubeCheckoutBar/NodePoolSummary.tsx
@@ -6,7 +6,7 @@ import { makeStyles } from '@mui/styles';
 import { Theme } from '@mui/material/styles';
 import Typography from 'src/components/core/Typography';
 import { DisplayPrice } from 'src/components/DisplayPrice';
-import EnhancedNumberInput from 'src/components/EnhancedNumberInput';
+import { EnhancedNumberInput } from 'src/components/EnhancedNumberInput/EnhancedNumberInput';
 import { IconButton } from 'src/components/IconButton';
 import { ExtendedType } from 'src/utilities/extendType';
 import { pluralize } from 'src/utilities/pluralize';

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/ResizeNodePoolDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/ResizeNodePoolDrawer.tsx
@@ -7,7 +7,7 @@ import { makeStyles } from '@mui/styles';
 import { Theme } from '@mui/material/styles';
 import Typography from 'src/components/core/Typography';
 import Drawer from 'src/components/Drawer';
-import EnhancedNumberInput from 'src/components/EnhancedNumberInput';
+import { EnhancedNumberInput } from 'src/components/EnhancedNumberInput/EnhancedNumberInput';
 import { Notice } from 'src/components/Notice/Notice';
 import { useUpdateNodePoolMutation } from 'src/queries/kubernetes';
 import { useSpecificTypes } from 'src/queries/types';

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
@@ -177,6 +177,9 @@ export class SelectPlanQuantityPanel extends React.Component<CombinedProps> {
             className={classNames({
               [classes.disabledRow]: disabled,
             })}
+            style={{
+              background: 'red !important',
+            }}
           >
             <TableCell data-qa-plan-name>
               <div className={classes.headingCellContainer}>
@@ -189,7 +192,7 @@ export class SelectPlanQuantityPanel extends React.Component<CombinedProps> {
               {convertMegabytesTo(type.memory, true)}
             </TableCell>
             <TableCell center data-qa-cpu>
-              {type.vcpus}
+              {type.vcpus} KEKLOL
             </TableCell>
             <TableCell center data-qa-storage>
               {convertMegabytesTo(type.disk, true)}

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
@@ -10,7 +10,7 @@ import { Theme } from '@mui/material/styles';
 import { TableBody } from 'src/components/TableBody';
 import { TableHead } from 'src/components/TableHead';
 import Typography from 'src/components/core/Typography';
-import EnhancedNumberInput from 'src/components/EnhancedNumberInput';
+import { EnhancedNumberInput } from 'src/components/EnhancedNumberInput/EnhancedNumberInput';
 import Grid from '@mui/material/Unstable_Grid2';
 import { Notice } from 'src/components/Notice/Notice';
 import SelectionCard from 'src/components/SelectionCard';


### PR DESCRIPTION
## Description 📝
Migrate `EnhancedNumberInput` to `styled/sx` api and remove `jss`

## Major Changes 🔄
- Used `sx` props for most things since no theme or props were needed.
- Update exports/imports

## Preview 📷
| Local vs Prod   |
| ------- |
| <img width="1915" alt="Screen Shot 2023-05-22 at 4 23 32 PM" src="https://github.com/linode/manager/assets/125309814/b8d6be9c-3196-470e-b334-aa6514fba018"> | 

## How to test 🧪
1. Run branch and go to a kubernetes cluster and go to details page
2. Select "Resize Pool" and observe the enhanced number input
3. Confirm there are no visual changes from Prod