### PR TITLE
fix: [M3-6622] - Fix Dialog Title Close Button Color

### DIFF
--- a/packages/manager/src/components/DialogTitle/DialogTitle.tsx
+++ b/packages/manager/src/components/DialogTitle/DialogTitle.tsx
@@ -48,6 +48,7 @@ const DialogTitle = (props: DialogTitleProps) => {
         {title}
         {onClose != null && (
           <IconButton
+            color="primary"
             aria-label="Close"
             data-qa-close-drawer
             onClick={onClose}


### PR DESCRIPTION
## Description 📝

- Now that our `<IconButton />` is properly handled at the theme level (https://github.com/linode/manager/pull/9102) we need to set the color explicitly when we want to deviate from the default icon button colors
- This PR sets the color of the close button in the Dialog title to `primary` to make it match production

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-05-23 at 1 31 02 PM](https://github.com/linode/manager/assets/115251059/5e40506d-e826-4624-9227-8736f471c140) | ![Screenshot 2023-05-23 at 1 30 50 PM](https://github.com/linode/manager/assets/115251059/3077965d-437f-4b84-ad3b-febec46c2b3f) |

## How to test 🧪
- Check the style of IconButtons throughout the app in **both** dark and light mode
- Check that the Dialog close button colors match what is live in production 