### PR TITLE
fix: [M3-6586] - Improve error handing for loadScript and Adobe Analytics

### DIFF
--- a/packages/manager/.changeset/pr-9161-fixed-1684864339130.md
+++ b/packages/manager/.changeset/pr-9161-fixed-1684864339130.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Improve error handing for loadScript and Adobe Analytics ([#9161](https://github.com/linode/manager/pull/9161))

--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -94,14 +94,12 @@ export class App extends React.Component<CombinedProps, State> {
           const adobeScriptTags = document.querySelectorAll(
             'script[src^="https://assets.adobedtm.com/"]'
           );
-
           // Log an error; if the promise resolved, the _satellite object and 3 Adobe scripts should be present in the DOM.
           if (
             data.status !== 'ready' ||
             !(window as any)._satellite ||
             adobeScriptTags.length !== NUM_ADOBE_SCRIPTS
           ) {
-            adobeScriptTags.forEach((script) => script.remove());
             reportException(
               'Adobe Analytics error: Not all Adobe Launch scripts and extensions were loaded correctly; analytics cannot be sent.'
             );

--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -94,11 +94,16 @@ export class App extends React.Component<CombinedProps, State> {
           const adobeScriptTags = document.querySelectorAll(
             'script[src^="https://assets.adobedtm.com/"]'
           );
-          // Log an error; if the promise resolved, three Adobe scripts should be present in the DOM.
-          if (data.status !== 'ready' || adobeScriptTags.length !== 3) {
+
+          // Log an error; if the promise resolved, the _satellite object and 3 Adobe scripts should be present in the DOM.
+          if (
+            data.status !== 'ready' ||
+            !(window as any)._satellite ||
+            adobeScriptTags.length !== 3
+          ) {
             adobeScriptTags.forEach((script) => script.remove());
             reportException(
-              'Not all Adobe Launch scripts and extensions were not loaded correctly; analytics cannot be sent.'
+              'Adobe Analytics error: Not all Adobe Launch scripts and extensions were loaded correctly; analytics cannot be sent.'
             );
           }
         })

--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -41,7 +41,7 @@ import { sshKeyEventHandler } from './queries/profile';
 import { firewallEventsHandler } from './queries/firewalls';
 import { nodebalanacerEventHandler } from './queries/nodebalancers';
 import { oauthClientsEventHandler } from './queries/accountOAuth';
-import { ADOBE_ANALYTICS_URL } from './constants';
+import { ADOBE_ANALYTICS_URL, NUM_ADOBE_SCRIPTS } from './constants';
 import { linodeEventsHandler } from './queries/linodes/events';
 import { supportTicketEventHandler } from './queries/support';
 import { reportException } from './exceptionReporting';
@@ -99,7 +99,7 @@ export class App extends React.Component<CombinedProps, State> {
           if (
             data.status !== 'ready' ||
             !(window as any)._satellite ||
-            adobeScriptTags.length !== 3
+            adobeScriptTags.length !== NUM_ADOBE_SCRIPTS
           ) {
             adobeScriptTags.forEach((script) => script.remove());
             reportException(

--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -69,6 +69,7 @@ export const GTM_ID = import.meta.env.REACT_APP_GTM_ID;
 /** Adobe Analytics */
 export const ADOBE_ANALYTICS_URL = import.meta.env
   .REACT_APP_ADOBE_ANALYTICS_URL;
+export const NUM_ADOBE_SCRIPTS = 3;
 /** for hard-coding token used for API Requests. Example: "Bearer 1234" */
 export const ACCESS_TOKEN = import.meta.env.REACT_APP_ACCESS_TOKEN;
 

--- a/packages/manager/src/hooks/useScript.ts
+++ b/packages/manager/src/hooks/useScript.ts
@@ -13,62 +13,62 @@ interface ScriptOptions {
  * The logic comes from https://usehooks.com/useScript/
  * @param src source url of the script you intend to load
  * @param options setStatus - a react state set function so that the hook's state can be updated; location - placement of the script in document
- * @returns void
+ * @returns Promise
  */
-export const loadScript = (src: string, options?: ScriptOptions) => {
-  // Allow falsy src value if waiting on other data needed for
-  // constructing the script URL passed to this hook.
-  if (!src) {
-    options?.setStatus?.('idle');
-    return;
-  }
-  // Fetch existing script element by src
-  // It may have been added by another intance of this hook
-  let script = document.querySelector(
-    `script[src='${src}']`
-  ) as HTMLScriptElement;
-  if (!script) {
-    // Create script
-    script = document.createElement('script');
-    script.src = src;
-    script.async = true;
-    script.setAttribute('data-status', 'loading');
-    // Add script to document; default to body
-    if (options?.location === 'head') {
-      document.head.appendChild(script);
+export const loadScript = (
+  src: string,
+  options?: ScriptOptions
+): Promise<any> => {
+  return new Promise((resolve, reject) => {
+    // Allow falsy src value if waiting on other data needed for
+    // constructing the script URL passed to this hook.
+    if (!src) {
+      options?.setStatus?.('idle');
+      return;
+    }
+    // Fetch existing script element by src
+    // It may have been added by another intance of this hook
+    let script = document.querySelector(
+      `script[src='${src}']`
+    ) as HTMLScriptElement;
+    if (!script) {
+      // Create script
+      script = document.createElement('script');
+      script.src = src;
+      script.async = true;
+      script.setAttribute('data-status', 'loading');
+
+      script.onload = (event: any) => {
+        script.setAttribute('data-status', 'ready');
+        setStateFromEvent(event);
+        resolve({ status: 'ready' });
+      };
+      script.onerror = (event: any) => {
+        script.setAttribute('data-status', 'error');
+        setStateFromEvent(event);
+        reject({
+          status: 'error',
+          message: `Failed to load script with src ${src}`,
+        });
+      };
+
+      // Add script to document; default to body
+      if (options?.location === 'head') {
+        document.head.appendChild(script);
+      } else {
+        document.body.appendChild(script);
+      }
     } else {
-      document.body.appendChild(script);
+      // Grab existing script status from attribute and set to state.
+      options?.setStatus?.(script.getAttribute('data-status') as ScriptStatus);
     }
-    // Store status in attribute on script
-    // This can be read by other instances of this hook
-    const setAttributeFromEvent = (event: any) => {
-      script.setAttribute(
-        'data-status',
-        event.type === 'load' ? 'ready' : 'error'
-      );
+    // Script event handler to update status in state
+    // Note: Even if the script already exists we still need to add
+    // event handlers to update the state for *this* hook instance.
+    const setStateFromEvent = (event: any) => {
+      options?.setStatus?.(event.type === 'load' ? 'ready' : 'error');
     };
-    script.addEventListener('load', setAttributeFromEvent);
-    script.addEventListener('error', setAttributeFromEvent);
-  } else {
-    // Grab existing script status from attribute and set to state.
-    options?.setStatus?.(script.getAttribute('data-status') as ScriptStatus);
-  }
-  // Script event handler to update status in state
-  // Note: Even if the script already exists we still need to add
-  // event handlers to update the state for *this* hook instance.
-  const setStateFromEvent = (event: any) => {
-    options?.setStatus?.(event.type === 'load' ? 'ready' : 'error');
-  };
-  // Add event listeners
-  script.addEventListener('load', setStateFromEvent);
-  script.addEventListener('error', setStateFromEvent);
-  // Remove event listeners on cleanup
-  return () => {
-    if (script) {
-      script.removeEventListener('load', setStateFromEvent);
-      script.removeEventListener('error', setStateFromEvent);
-    }
-  };
+  });
 };
 
 /**
@@ -83,7 +83,11 @@ export const useScript = (
 ): ScriptStatus => {
   const [status, setStatus] = useState<ScriptStatus>(src ? 'loading' : 'idle');
 
-  useEffect(() => loadScript(src, { setStatus, location }), [src]);
+  useEffect(() => {
+    (async () => {
+      await loadScript(src, { setStatus, location });
+    })();
+  }, [src]);
 
   return status;
 };

--- a/packages/manager/src/hooks/useScript.ts
+++ b/packages/manager/src/hooks/useScript.ts
@@ -24,7 +24,7 @@ export const loadScript = (
     // constructing the script URL passed to this hook.
     if (!src) {
       options?.setStatus?.('idle');
-      return;
+      return resolve({ status: 'idle' });
     }
     // Fetch existing script element by src
     // It may have been added by another intance of this hook
@@ -85,7 +85,9 @@ export const useScript = (
 
   useEffect(() => {
     (async () => {
-      await loadScript(src, { setStatus, location });
+      try {
+        await loadScript(src, { setStatus, location });
+      } catch (e) {} // Handle errors where useScript is called.
     })();
   }, [src]);
 

--- a/packages/manager/src/utilities/ga.ts
+++ b/packages/manager/src/utilities/ga.ts
@@ -1,6 +1,5 @@
 import { event } from 'react-ga';
 import { GA_ID, ADOBE_ANALYTICS_URL } from 'src/constants';
-import { reportException } from 'src/exceptionReporting';
 
 interface AnalyticsEvent {
   category: string;
@@ -15,17 +14,12 @@ export const sendEvent = (eventPayload: AnalyticsEvent): void => {
   }
 
   // Send a Direct Call Rule if our environment is configured with an Adobe Launch script
-  try {
+  if ((window as any)._satellite) {
     (window as any)._satellite.track('custom event', {
       category: eventPayload.category,
       action: eventPayload.action,
       label: eventPayload.label,
       value: eventPayload.value,
-    });
-  } catch (error) {
-    reportException(error, {
-      message:
-        'An error occurred when tracking a custom event. Adobe Launch script not loaded correctly; no analytics will be sent.',
     });
   }
 


### PR DESCRIPTION
## Description 📝
This is an attempt to improve the `loadScript` function and error handling for its use with Adobe Analytics.

## Major Changes 🔄
- Removes the error logged when a custom event fires unsuccessfully
   - This will get rid of the annoying Sentry errors that are currently being triggered when any user blocking the analytics scripts performs an action that would fire a custom event to track, if analytics were enabled.
- Modifies `loadScript` function to return a promise.
- Attempts to verify that all three scripts necessary for Adobe (the launch script and its two extensions) are present in the DOM if the script claims it has loaded successfully with a resolved promise.
   - "Attempts" because I haven't found a way to successfully stop all 3 scripts from loading, even with `assets.adobedtm.com/extensions/*`requests blocked, to come closer to mimicking what we saw with the extensions not fully loading (200 response but in `pending` state and not present in the DOM) a week ago.

## How to test 🧪
1. **How to setup test environment?**
    - Check this PR out locally and have the REACT_APP_ADOBE_ANALYTICS_URL environment variable defined in your .env.
   - Type `_satellite.setDebug(true)` in the developer console and refresh the page. You should see some debug logs to indicate that Adobe Analytics is running.
2. **How to reproduce the issue (if applicable)?**
   - To verify an error on custom events is logged:
      - Check out `develop` locally.
      - Use dev tools to block requests to `assets.adobedtm.com`.
      - Trigger a custom event (e.g. create a linode or volume).  
      - Observe that [an exception](https://github.com/linode/manager/pull/9161/files#diff-a30d9e66e4612f3a3181b2cabe2770862cef00550bb1797c8faca8a602deb9f5L28) is logged to the browser console; in prod, this would be logged to Sentry. 
3. **How to verify changes?**
    - To verify an error on custom events is *not* logged:
      - Use dev tools to block requests to `assets.adobedtm.com`.
      - Trigger a custom event (e.g. create a linode or volume).  
      - Observe that [an exception](https://github.com/linode/manager/pull/9161/files#diff-a30d9e66e4612f3a3181b2cabe2770862cef00550bb1797c8faca8a602deb9f5L28) is no longer logged.
   - Check that there have been no regressions in the places the app calls `useScript`, such as the Google Pay button and chip on the Billing page. (Try blocking network requests and testing.) I had to slightly modify this hook when I changed the `loadScript` function.
   - With requests to `assets.adobedtm.com` blocked, confirm that the app works as expected and no new console errors/warnings are logged. 
