### PR TITLE
test: [M3-6549] - Add Cypress Integration tests for OAuth Apps

### DIFF
--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -373,6 +373,7 @@ export interface OAuthClient {
   thumbnail_url: string | null;
   public: boolean;
   status: 'disabled' | 'active' | 'suspended';
+  secret: string | null;
 }
 
 export interface OAuthClientRequest {

--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -373,7 +373,7 @@ export interface OAuthClient {
   thumbnail_url: string | null;
   public: boolean;
   status: 'disabled' | 'active' | 'suspended';
-  secret: string | null;
+  secret: string;
 }
 
 export interface OAuthClientRequest {

--- a/packages/api-v4/src/profile/profile.ts
+++ b/packages/api-v4/src/profile/profile.ts
@@ -5,7 +5,7 @@ import {
 } from '@linode/validation/lib/profile.schema';
 import { updateProfileSchema } from '@linode/validation/lib/profile.schema';
 import { API_ROOT } from '../constants';
-import { Grants } from '../account';
+import { Grants, OAuthClient } from '../account';
 import Request, {
   setData,
   setMethod,
@@ -199,3 +199,29 @@ export const verifyPhoneNumberCode = (data: VerifyVerificationCodePayload) => {
     setData(data, VerifyPhoneNumberCodeSchema)
   );
 };
+
+/**
+ * getOAuthApps
+ *
+ * Retrieves an array of oauth apps for the current user.
+ */
+export const getOAuthApps = (params?: Params, filters?: Filter) => {
+  return Request<ResourcePage<OAuthClient>>(
+    setURL(`${API_ROOT}/account/oauth-clients`),
+    setMethod('GET'),
+    setParams(params),
+    setXFilter(filters)
+  );
+};
+
+/**
+ * Deletes an oauth app from Linode's Profile Clients. The Domain will be removed from Linode's nameservers shortly after this
+ * operation completes. This also deletes all associated Domain Records.
+ *
+ * @param oauthAppId { string } The ID of the oauth app to delete.
+ */
+export const deleteOAuthApp = (oauthAppId: string) =>
+  Request<{}>(
+    setURL(`${API_ROOT}/account/oauth-clients/${oauthAppId}`),
+    setMethod('DELETE')
+  );

--- a/packages/api-v4/src/profile/profile.ts
+++ b/packages/api-v4/src/profile/profile.ts
@@ -5,7 +5,7 @@ import {
 } from '@linode/validation/lib/profile.schema';
 import { updateProfileSchema } from '@linode/validation/lib/profile.schema';
 import { API_ROOT } from '../constants';
-import { Grants, OAuthClient } from '../account';
+import { Grants } from '../account';
 import Request, {
   setData,
   setMethod,
@@ -199,29 +199,3 @@ export const verifyPhoneNumberCode = (data: VerifyVerificationCodePayload) => {
     setData(data, VerifyPhoneNumberCodeSchema)
   );
 };
-
-/**
- * getOAuthApps
- *
- * Retrieves an array of oauth apps for the current user.
- */
-export const getOAuthApps = (params?: Params, filters?: Filter) => {
-  return Request<ResourcePage<OAuthClient>>(
-    setURL(`${API_ROOT}/account/oauth-clients`),
-    setMethod('GET'),
-    setParams(params),
-    setXFilter(filters)
-  );
-};
-
-/**
- * Deletes an oauth app from Linode's Profile Clients. The Domain will be removed from Linode's nameservers shortly after this
- * operation completes. This also deletes all associated Domain Records.
- *
- * @param oauthAppId { string } The ID of the oauth app to delete.
- */
-export const deleteOAuthApp = (oauthAppId: string) =>
-  Request<{}>(
-    setURL(`${API_ROOT}/account/oauth-clients/${oauthAppId}`),
-    setMethod('DELETE')
-  );

--- a/packages/manager/cypress/e2e/profile/add-oauth-app.spec.ts
+++ b/packages/manager/cypress/e2e/profile/add-oauth-app.spec.ts
@@ -1,0 +1,132 @@
+import { fbltClick } from 'support/helpers';
+import { oauthClientFactory } from '@src/factories';
+import 'cypress-file-upload';
+import { interceptGetProfile } from 'support/intercepts/profile';
+import { ui } from 'support/ui';
+import { randomLabel } from 'support/util/random';
+
+/**
+ * Creates an OAuth App with the given parameters.
+ *
+ * This assumes that the user has already navigated to the profile/clients
+ * page.
+ *
+ * @param label - Label for the oauth app.
+ * @param url - Callback URL for the oauth app.
+ * @param isPublic - Access for the oauth app.
+ */
+const createOAuthApp = (label: string, url: string, isPublic: boolean) => {
+  ui.button
+    .findByTitle('Add an OAuth App')
+    .should('be.visible')
+    .should('be.enabled')
+    .click();
+
+  // Nothing will happen when cancelling.
+  ui.drawer
+    .findByTitle('Create OAuth App')
+    .should('be.visible')
+    .within(() => {
+      fbltClick('Label').clear().type(label);
+      fbltClick('Callback URL').clear().type(url);
+      ui.buttonGroup
+        .findButtonByTitle('Cancel')
+        .should('be.visible')
+        .should('be.enabled')
+        .click();
+    });
+
+  cy.findByText(label).should('not.exist');
+
+  // Add an oauth app
+  ui.button
+    .findByTitle('Add an OAuth App')
+    .should('be.visible')
+    .should('be.enabled')
+    .click();
+
+  ui.drawer
+    .findByTitle('Create OAuth App')
+    .should('be.visible')
+    .within(() => {
+      // An error message appears when attempting to create an OAuth App without a label
+      fbltClick('Label').clear();
+      fbltClick('Callback URL').clear();
+      ui.button
+        .findByTitle('Create')
+        .should('be.visible')
+        .should('be.enabled')
+        .click();
+      cy.findByText('Label is required.');
+      cy.findByText('Redirect URI is required.');
+
+      // Fill out and submit OAuth App create form.
+      fbltClick('Label').clear().type(label);
+      fbltClick('Callback URL').clear().type(url);
+      // Check the 'public' checkbox
+      if (isPublic) {
+        cy.get('[data-qa-checked]').should('be.visible').click();
+      }
+      ui.button
+        .findByTitle('Create')
+        .should('be.visible')
+        .should('be.enabled')
+        .click();
+    });
+
+  ui.dialog
+    .findByTitle('Client Secret')
+    .should('be.visible')
+    .within(() => {
+      ui.button
+        .findByTitle('I Have Saved My Client Secret')
+        .should('be.visible')
+        .should('be.enabled')
+        .click();
+    });
+
+  // Confirms that the oauth app is listed on landing page with expected configuration.
+  const accessLevel = isPublic ? 'Public' : 'Private';
+  cy.findByText(label)
+    .closest('tr')
+    .within(() => {
+      cy.findByText(label).should('be.visible');
+      cy.findByText(accessLevel).should('be.visible');
+      cy.findByText(url).should('be.visible');
+    });
+};
+
+describe('Add OAuth Apps', () => {
+  /*
+   * - Adds an oauth app
+   * - Confirms that nothing happens when cancelling the configuration.
+   * - Confirms that an error message appears upon submitting without a label and a callback URL.
+   * - Confirms that the oauth app is listed correctly on OAuth Apps landing page.
+   */
+  it('Adds an OAuth App', () => {
+    const oauthApps = oauthClientFactory.buildList(2);
+    const privateOauthApp = oauthApps[0];
+    privateOauthApp.label = randomLabel(5);
+    const publicOauApp = oauthApps[1];
+    publicOauApp.label = randomLabel(5);
+    publicOauApp.public = true;
+
+    interceptGetProfile().as('getProfile');
+    cy.visitWithLogin('/profile/clients');
+    cy.wait('@getProfile');
+
+    // Create a private access OAuth App
+    createOAuthApp(
+      privateOauthApp.label,
+      privateOauthApp.redirect_uri,
+      privateOauthApp.public
+    );
+
+    // Create a public access OAuth App
+    createOAuthApp(
+      publicOauApp.label,
+      publicOauApp.redirect_uri,
+      publicOauApp.public
+    );
+  });
+});

--- a/packages/manager/cypress/e2e/profile/delete-oauth-app.spec.ts
+++ b/packages/manager/cypress/e2e/profile/delete-oauth-app.spec.ts
@@ -46,6 +46,8 @@ describe('Delete OAuth Apps', () => {
           .should('be.enabled')
           .click();
       });
+    // The diaglog is no longer rendered or visible
+    ui.dialog.find().should('not.exist');
     cy.findByText(privateOauthApp.label).should('be.visible');
 
     // Confirm deletion.
@@ -67,6 +69,8 @@ describe('Delete OAuth Apps', () => {
           .should('be.enabled')
           .click();
       });
+    // The diaglog is no longer rendered or visible
+    ui.dialog.find().should('not.exist');
     cy.wait('@deleteOAuthApp');
     cy.wait('@getDeletedOAuthApps');
     cy.findByText(privateOauthApp.label).should('not.exist');

--- a/packages/manager/cypress/e2e/profile/delete-oauth-app.spec.ts
+++ b/packages/manager/cypress/e2e/profile/delete-oauth-app.spec.ts
@@ -1,0 +1,74 @@
+import { fbtVisible, fbtClick } from 'support/helpers';
+import { oauthClientFactory } from '@src/factories';
+import 'cypress-file-upload';
+import {
+  interceptGetProfile,
+  mockDeleteOAuthApps,
+  mockGetOAuthApps,
+} from 'support/intercepts/profile';
+import { ui } from 'support/ui';
+import { randomLabel } from 'support/util/random';
+
+describe('Delete OAuth Apps', () => {
+  /*
+   * - Deletes an oauth app
+   * - Confirms that nothing happens when cancelling the deletion.
+   * - Confirms that the oauth app is removed correctly on OAuth Apps landing page.
+   */
+  it('Deletes an OAuth App', () => {
+    const oauthApps = oauthClientFactory.buildList(2);
+    const privateOauthApp = oauthApps[0];
+    privateOauthApp.label = randomLabel(5);
+    const publicOauApp = oauthApps[1];
+    publicOauApp.label = randomLabel(5);
+    publicOauApp.public = true;
+
+    interceptGetProfile().as('getProfile');
+    mockGetOAuthApps(oauthApps).as('getOAuthApps');
+    cy.visitWithLogin('/profile/clients');
+    cy.wait('@getProfile');
+    cy.wait('@getOAuthApps');
+
+    // Nothing will happen when the deletion is cancelled.
+    cy.findByText(privateOauthApp.label)
+      .closest('tr')
+      .within(() => {
+        fbtVisible('Delete');
+        fbtClick('Delete');
+      });
+    ui.dialog
+      .findByTitle(`Delete ${privateOauthApp.label}?`)
+      .should('be.visible')
+      .within(() => {
+        ui.buttonGroup
+          .findButtonByTitle('Cancel')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+    cy.findByText(privateOauthApp.label).should('be.visible');
+
+    // Confirm deletion.
+    cy.findByText(privateOauthApp.label)
+      .closest('tr')
+      .within(() => {
+        fbtVisible('Delete');
+        fbtClick('Delete');
+      });
+    mockDeleteOAuthApps(privateOauthApp.id).as('deleteOAuthApp');
+    mockGetOAuthApps(oauthApps.slice(1)).as('getDeletedOAuthApps');
+    ui.dialog
+      .findByTitle(`Delete ${privateOauthApp.label}?`)
+      .should('be.visible')
+      .within(() => {
+        ui.buttonGroup
+          .findButtonByTitle('Delete')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+    cy.wait('@deleteOAuthApp');
+    cy.wait('@getDeletedOAuthApps');
+    cy.findByText(privateOauthApp.label).should('not.exist');
+  });
+});

--- a/packages/manager/cypress/e2e/profile/edit-oauth-app.spec.ts
+++ b/packages/manager/cypress/e2e/profile/edit-oauth-app.spec.ts
@@ -1,0 +1,96 @@
+import { fbtVisible, fbtClick, fbltClick } from 'support/helpers';
+import { oauthClientFactory } from '@src/factories';
+import 'cypress-file-upload';
+import {
+  interceptGetProfile,
+  mockGetOAuthApps,
+  mockUpdateOAuthApps,
+} from 'support/intercepts/profile';
+import { ui } from 'support/ui';
+import { randomLabel } from 'support/util/random';
+
+describe('Edit OAuth Apps', () => {
+  /*
+   * - Edits an oauth app
+   * - Confirms that nothing happens when cancelling the edition.
+   * - Confirms that the oauth app is updated correctly on OAuth Apps landing page.
+   */
+  it('Edits an OAuth App', () => {
+    const oauthApps = oauthClientFactory.buildList(2);
+    const privateOauthApp = oauthApps[0];
+    privateOauthApp.label = randomLabel(5);
+    const publicOauApp = oauthApps[1];
+    publicOauApp.label = randomLabel(5);
+    publicOauApp.public = true;
+
+    interceptGetProfile().as('getProfile');
+    mockGetOAuthApps(oauthApps).as('getOAuthApps');
+    cy.visitWithLogin('/profile/clients');
+    cy.wait('@getProfile');
+    cy.wait('@getOAuthApps');
+
+    // Nothing will happen when the edition is cancelled.
+    cy.findByText(privateOauthApp.label)
+      .closest('tr')
+      .within(() => {
+        fbtVisible('Edit');
+        fbtClick('Edit');
+      });
+    ui.drawer
+      .findByTitle('Create OAuth App')
+      .should('be.visible')
+      .within(() => {
+        ui.buttonGroup
+          .findButtonByTitle('Cancel')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+    cy.findByText(privateOauthApp.label).should('be.visible');
+
+    // Confirm edition.
+    cy.findByText(privateOauthApp.label)
+      .closest('tr')
+      .within(() => {
+        fbtVisible('Edit');
+        fbtClick('Edit');
+      });
+
+    // Deep copy the oauth apps array
+    const updatedApps = JSON.parse(JSON.stringify(oauthApps));
+    const modified = '-modified';
+    updatedApps[0].label = privateOauthApp.label + modified;
+    updatedApps[0].redirect_uri = privateOauthApp.redirect_uri + modified;
+    mockGetOAuthApps(updatedApps).as('getUpdatedOAuthApps');
+    mockUpdateOAuthApps(updatedApps[0].id, updatedApps).as('updateOAuthApp');
+    ui.drawer
+      .findByTitle('Create OAuth App')
+      .should('be.visible')
+      .within(() => {
+        // If there is no changes, the 'save' button should disabled
+        ui.buttonGroup
+          .findButtonByTitle('Save Changes')
+          .should('be.visible')
+          .should('be.disabled');
+
+        fbltClick('Label').clear().type(updatedApps[0].label);
+        fbltClick('Callback URL').clear().type(updatedApps[0].label);
+
+        ui.buttonGroup
+          .findButtonByTitle('Save Changes')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+    cy.wait('@getUpdatedOAuthApps');
+    cy.wait('@updateOAuthApp');
+    cy.findByText(privateOauthApp.label).should('not.exist');
+    cy.findByText(updatedApps[0].label)
+      .closest('tr')
+      .within(() => {
+        cy.findByText(updatedApps[0].label).should('be.visible');
+        cy.findByText('Private').should('be.visible');
+        cy.findByText(updatedApps[0].redirect_uri).should('be.visible');
+      });
+  });
+});

--- a/packages/manager/cypress/e2e/profile/edit-oauth-app.spec.ts
+++ b/packages/manager/cypress/e2e/profile/edit-oauth-app.spec.ts
@@ -46,7 +46,19 @@ describe('Edit OAuth Apps', () => {
           .should('be.enabled')
           .click();
       });
+    // The drawer is no longer rendered or visible
+    ui.drawer.find().should('not.exist');
     cy.findByText(privateOauthApp.label).should('be.visible');
+
+    // Nothing will happen when clicking the 'X' button.
+    cy.findByText(privateOauthApp.label)
+      .closest('tr')
+      .within(() => {
+        fbtVisible('Edit');
+        fbtClick('Edit');
+      });
+    ui.drawer.findByTitle('Create OAuth App').should('be.visible');
+    ui.drawerCloseButton.find().click();
 
     // Confirm edition.
     cy.findByText(privateOauthApp.label)
@@ -82,6 +94,8 @@ describe('Edit OAuth Apps', () => {
           .should('be.enabled')
           .click();
       });
+    // The drawer is no longer rendered or visible
+    ui.drawer.find().should('not.exist');
     cy.wait('@getUpdatedOAuthApps');
     cy.wait('@updateOAuthApp');
     cy.findByText(privateOauthApp.label).should('not.exist');

--- a/packages/manager/cypress/e2e/profile/reset-oauth-app.spec.ts
+++ b/packages/manager/cypress/e2e/profile/reset-oauth-app.spec.ts
@@ -5,7 +5,6 @@ import {
   interceptGetProfile,
   mockGetOAuthApps,
   mockResetOAuthApps,
-  mockUpdateOAuthApps,
 } from 'support/intercepts/profile';
 import { ui } from 'support/ui';
 import { randomLabel, randomSecret } from 'support/util/random';
@@ -47,6 +46,8 @@ describe('Reset OAuth Apps', () => {
           .should('be.enabled')
           .click();
       });
+    // The dialog is no longer rendered or visible
+    ui.dialog.find().should('not.exist');
     cy.findByText(privateOauthApp.label).should('be.visible');
 
     // Confirm resetting.
@@ -79,6 +80,8 @@ describe('Reset OAuth Apps', () => {
           .should('be.enabled')
           .click();
       });
+    // The dialog is no longer rendered or visible
+    ui.dialog.find().should('not.exist');
     cy.findByText(privateOauthApp.label).should('be.visible');
   });
 });

--- a/packages/manager/cypress/e2e/profile/reset-oauth-app.spec.ts
+++ b/packages/manager/cypress/e2e/profile/reset-oauth-app.spec.ts
@@ -1,0 +1,84 @@
+import { fbtVisible, fbtClick, fbltClick } from 'support/helpers';
+import { oauthClientFactory } from '@src/factories';
+import 'cypress-file-upload';
+import {
+  interceptGetProfile,
+  mockGetOAuthApps,
+  mockResetOAuthApps,
+  mockUpdateOAuthApps,
+} from 'support/intercepts/profile';
+import { ui } from 'support/ui';
+import { randomLabel, randomSecret } from 'support/util/random';
+
+describe('Reset OAuth Apps', () => {
+  /*
+   * - Resets an oauth app
+   * - Confirms that nothing happens when cancelling the edition.
+   * - Confirms that the oauth app is reset correctly on OAuth Apps landing page.
+   */
+  it('Resets an OAuth App', () => {
+    const oauthApps = oauthClientFactory.buildList(2);
+    const privateOauthApp = oauthApps[0];
+    privateOauthApp.label = randomLabel(5);
+    const publicOauApp = oauthApps[1];
+    publicOauApp.label = randomLabel(5);
+    publicOauApp.public = true;
+
+    interceptGetProfile().as('getProfile');
+    mockGetOAuthApps(oauthApps).as('getOAuthApps');
+    cy.visitWithLogin('/profile/clients');
+    cy.wait('@getProfile');
+    cy.wait('@getOAuthApps');
+
+    // Nothing will happen when the edition is cancelled.
+    cy.findByText(privateOauthApp.label)
+      .closest('tr')
+      .within(() => {
+        fbtVisible('Reset');
+        fbtClick('Reset');
+      });
+    ui.dialog
+      .findByTitle(`Reset secret for ${privateOauthApp.label}?`)
+      .should('be.visible')
+      .within(() => {
+        ui.buttonGroup
+          .findButtonByTitle('Cancel')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+    cy.findByText(privateOauthApp.label).should('be.visible');
+
+    // Confirm resetting.
+    cy.findByText(privateOauthApp.label)
+      .closest('tr')
+      .within(() => {
+        fbtVisible('Reset');
+        fbtClick('Reset');
+      });
+    privateOauthApp['secret'] = randomSecret(64);
+    mockResetOAuthApps(privateOauthApp.id, privateOauthApp).as('resetOAuthApp');
+    ui.dialog
+      .findByTitle(`Reset secret for ${privateOauthApp.label}?`)
+      .should('be.visible')
+      .within(() => {
+        ui.buttonGroup
+          .findButtonByTitle('Reset Secret')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+    cy.wait('@resetOAuthApp');
+    ui.dialog
+      .findByTitle('Client Secret')
+      .should('be.visible')
+      .within(() => {
+        ui.buttonGroup
+          .findButtonByTitle('I Have Saved My Client Secret')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+    cy.findByText(privateOauthApp.label).should('be.visible');
+  });
+});

--- a/packages/manager/cypress/support/api/profile.ts
+++ b/packages/manager/cypress/support/api/profile.ts
@@ -1,16 +1,11 @@
-import { apiCheckErrors } from './common';
 import { isTestLabel } from 'support/api/common';
-import { randomDomainName } from 'support/util/random';
 import {
-  Domain,
-  getDomains,
-  deleteDomain,
-  getOAuthApps,
+  getOAuthClients,
   OAuthClient,
-  deleteOAuthApp,
+  deleteOAuthClient,
 } from '@linode/api-v4';
 import { depaginate } from 'support/util/paginate';
-import { oauthToken, pageSize } from 'support/constants/api';
+import { pageSize } from 'support/constants/api';
 
 /**
  * Deletes all oauth apps which are prefixed with the test entity prefix.
@@ -19,7 +14,7 @@ import { oauthToken, pageSize } from 'support/constants/api';
  */
 export const deleteAllTestOAuthApps = async (): Promise<void> => {
   const oauthApps = await depaginate<OAuthClient>((page: number) =>
-    getOAuthApps({ page_size: pageSize, page })
+    getOAuthClients({ page_size: pageSize, page })
   );
 
   console.log(`oauth apps: ${JSON.stringify(oauthApps)}`);
@@ -28,25 +23,8 @@ export const deleteAllTestOAuthApps = async (): Promise<void> => {
     .filter((oauthApp: OAuthClient) => isTestLabel(oauthApp.label))
     .map(async (oauthApp: OAuthClient) => {
       console.log(`deleting ${oauthApp.label}`);
-      await deleteOAuthApp(oauthApp.id);
+      await deleteOAuthClient(oauthApp.id);
     });
 
   await Promise.all(deletionPromises);
 };
-
-// export const deleteAllTestVolumes = async (): Promise<void> => {
-//   const volumes = await depaginate<Volume>((page: number) =>
-//     getVolumes({ page_size: pageSize, page })
-//   );
-
-//   const detachDeletePromises = volumes
-//     .filter((volume: Volume) => isTestLabel(volume.label))
-//     .map(async (volume: Volume) => {
-//       if (volume.linode_id) {
-//         await detachVolume(volume.id);
-//       }
-//       await deleteVolume(volume.id);
-//     });
-
-//   await Promise.all(detachDeletePromises);
-// };

--- a/packages/manager/cypress/support/api/profile.ts
+++ b/packages/manager/cypress/support/api/profile.ts
@@ -1,0 +1,52 @@
+import { apiCheckErrors } from './common';
+import { isTestLabel } from 'support/api/common';
+import { randomDomainName } from 'support/util/random';
+import {
+  Domain,
+  getDomains,
+  deleteDomain,
+  getOAuthApps,
+  OAuthClient,
+  deleteOAuthApp,
+} from '@linode/api-v4';
+import { depaginate } from 'support/util/paginate';
+import { oauthToken, pageSize } from 'support/constants/api';
+
+/**
+ * Deletes all oauth apps which are prefixed with the test entity prefix.
+ *
+ * @returns Promise that resolves when oauth apps have been deleted.
+ */
+export const deleteAllTestOAuthApps = async (): Promise<void> => {
+  const oauthApps = await depaginate<OAuthClient>((page: number) =>
+    getOAuthApps({ page_size: pageSize, page })
+  );
+
+  console.log(`oauth apps: ${JSON.stringify(oauthApps)}`);
+
+  const deletionPromises = oauthApps
+    .filter((oauthApp: OAuthClient) => isTestLabel(oauthApp.label))
+    .map(async (oauthApp: OAuthClient) => {
+      console.log(`deleting ${oauthApp.label}`);
+      await deleteOAuthApp(oauthApp.id);
+    });
+
+  await Promise.all(deletionPromises);
+};
+
+// export const deleteAllTestVolumes = async (): Promise<void> => {
+//   const volumes = await depaginate<Volume>((page: number) =>
+//     getVolumes({ page_size: pageSize, page })
+//   );
+
+//   const detachDeletePromises = volumes
+//     .filter((volume: Volume) => isTestLabel(volume.label))
+//     .map(async (volume: Volume) => {
+//       if (volume.linode_id) {
+//         await detachVolume(volume.id);
+//       }
+//       await deleteVolume(volume.id);
+//     });
+
+//   await Promise.all(detachDeletePromises);
+// };

--- a/packages/manager/cypress/support/intercepts/profile.ts
+++ b/packages/manager/cypress/support/intercepts/profile.ts
@@ -12,6 +12,7 @@ import type {
   SecurityQuestionsData,
   SecurityQuestionsPayload,
   Token,
+  OAuthClient,
 } from '@linode/api-v4/types';
 
 /**
@@ -244,5 +245,73 @@ export const mockRevokePersonalAccessToken = (
     'DELETE',
     apiMatcher(`profile/tokens/${id}`),
     makeResponse({})
+  );
+};
+
+/**
+ * Intercepts GET request to fetch oauth apps and mocks response.
+ *
+ * @param oauthApps - oauth apps with which to respond.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetOAuthApps = (
+  oauthApps: OAuthClient[]
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'GET',
+    apiMatcher('account/oauth-clients*'),
+    paginateResponse(oauthApps)
+  );
+};
+
+/**
+ * Intercepts DELETE request to delete an oauth app.
+ *
+ * @param oauthApp - An oauth app with which to reset.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockDeleteOAuthApps = (appId: string): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'DELETE',
+    apiMatcher(`account/oauth-clients/${appId}`),
+    makeResponse({})
+  );
+};
+
+/**
+ * Intercepts PUT request to update an oauth and mocks response.
+ *
+ * @param oauthApp - An OAuth App with which to update.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockUpdateOAuthApps = (
+  appId: string,
+  oauthApp: OAuthClient
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'PUT',
+    apiMatcher(`account/oauth-clients/${appId}`),
+    oauthApp
+  );
+};
+
+/**
+ * Intercepts POST request to fetch oauth apps and mocks response.
+ *
+ * @param oauthApp - An OAuth App with which to reset.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockResetOAuthApps = (
+  appId: string,
+  oauthApp: OAuthClient
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'POST',
+    apiMatcher(`account/oauth-clients/${appId}/reset-secret`),
+    oauthApp
   );
 };

--- a/packages/manager/cypress/support/intercepts/profile.ts
+++ b/packages/manager/cypress/support/intercepts/profile.ts
@@ -249,6 +249,19 @@ export const mockRevokePersonalAccessToken = (
 };
 
 /**
+ * Intercepts POST request to create an oauth app and mocks response.
+ *
+ * @param oauthApp - oauth app with which to respond.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockCreateOAuthApp = (
+  oauthApp: OAuthClient
+): Cypress.Chainable<null> => {
+  return cy.intercept('POST', apiMatcher('account/oauth-clients*'), oauthApp);
+};
+
+/**
  * Intercepts GET request to fetch oauth apps and mocks response.
  *
  * @param oauthApps - oauth apps with which to respond.

--- a/packages/manager/cypress/support/ui/common.ts
+++ b/packages/manager/cypress/support/ui/common.ts
@@ -18,6 +18,7 @@ import { deleteAllTestTags } from '../api/tags';
 import { cancelAllTestEntityTransfers } from '../api/entityTransfer';
 import { apiMatcher } from 'support/util/intercepts';
 import { SimpleBackoffMethod, attemptWithBackoff } from 'support/util/backoff';
+import { deleteAllTestOAuthApps } from 'support/api/profile';
 
 export const waitForAppLoad = (path = '/', withLogin = true) => {
   cy.intercept('GET', apiMatcher('linode/instances/*')).as('getLinodes');
@@ -87,6 +88,7 @@ export const deleteAllTestData = async () => {
       deleteAllTestAccessKeys(),
       deleteAllTestTags(),
       deleteAllTestVolumes(),
+      deleteAllTestOAuthApps(),
     ]);
   });
 };

--- a/packages/manager/cypress/support/util/random.ts
+++ b/packages/manager/cypress/support/util/random.ts
@@ -226,3 +226,23 @@ export const randomUuid = (): string => {
     randomString(12, randomStringOptions),
   ].join('-');
 };
+
+/**
+ * Returns a random secret of fixed length.
+ *
+ * @param length - Length of the secret strings.
+ *
+ * @returns Random secret.
+ */
+export const randomSecret = (length: number = 64): string => {
+  const hexNumber = '0123456789abcdef';
+
+  const characterSelection = [hexNumber].join('').split('');
+
+  let output = '';
+  for (let i = 0; i < length; i++) {
+    output += randomItem(characterSelection);
+  }
+
+  return output;
+};

--- a/packages/manager/cypress/support/util/random.ts
+++ b/packages/manager/cypress/support/util/random.ts
@@ -237,7 +237,7 @@ export const randomUuid = (): string => {
 export const randomSecret = (length: number = 64): string => {
   const hexNumber = '0123456789abcdef';
 
-  const characterSelection = [hexNumber].join('').split('');
+  const characterSelection = hexNumber.split('');
 
   let output = '';
   for (let i = 0; i < length; i++) {

--- a/packages/manager/src/factories/accountOAuth.ts
+++ b/packages/manager/src/factories/accountOAuth.ts
@@ -8,5 +8,5 @@ export const oauthClientFactory = Factory.Sync.makeFactory<OAuthClient>({
   redirect_uri: 'http://localhost:3000/api/auth/callback/linode',
   status: 'active',
   thumbnail_url: null,
-  secret: null,
+  secret: Factory.each((id) => `1a2b3c4d5e6f0123456789abcdef${id}`),
 });

--- a/packages/manager/src/factories/accountOAuth.ts
+++ b/packages/manager/src/factories/accountOAuth.ts
@@ -8,4 +8,5 @@ export const oauthClientFactory = Factory.Sync.makeFactory<OAuthClient>({
   redirect_uri: 'http://localhost:3000/api/auth/callback/linode',
   status: 'active',
   thumbnail_url: null,
+  secret: null,
 });

--- a/packages/manager/src/factories/index.ts
+++ b/packages/manager/src/factories/index.ts
@@ -1,6 +1,7 @@
 export * from './account';
 export * from './accountSettings';
 export * from './accountMaintenance';
+export * from './accountOAuth';
 export * from './accountPayment';
 export * from './billing';
 export * from './config';


### PR DESCRIPTION
## Description 📝
Add new cypress tests for OAuth Apps

## Major Changes 🔄
- Add `OAuth Apps` addition tests.
- Add `OAuth Apps` editing  tests.
- Add `OAuth Apps` resetting tests.
- Add `OAuth Apps` deletion tests.


## How to test 🧪
`yarn cy:run -s "cypress/e2e/profile/*.spec.ts"`