### PR TITLE
refactor: [M3-6389] - MUI v5 Migration - `Components > ShowMore`

### DIFF
--- a/packages/manager/src/components/ShowMore/ShowMore.stories.tsx
+++ b/packages/manager/src/components/ShowMore/ShowMore.stories.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { ShowMore } from 'src/components/ShowMore/ShowMore';
+
+const mockArray = [...Array(5)].map((_, i) => String.fromCharCode(97 + i));
+
+const meta: Meta<typeof ShowMore> = {
+  title: 'Components/ShowMore',
+  component: ShowMore,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ShowMore>;
+
+export const Default: Story = {
+  args: {
+    items: mockArray,
+    ariaItemType: 'Alphabet',
+    render: (items: string[]) => {
+      return items.map((item) => <span key={item}>{item}</span>);
+    },
+  },
+  render: (args) => <ShowMore {...args} />,
+};

--- a/packages/manager/src/components/ShowMore/ShowMore.test.tsx
+++ b/packages/manager/src/components/ShowMore/ShowMore.test.tsx
@@ -2,7 +2,7 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 
 import Chip from 'src/components/core/Chip';
-import { ShowMore } from './ShowMore';
+import { ShowMore } from 'src/components/ShowMore/ShowMore';
 
 const mockRender = jest.fn();
 const classes = {

--- a/packages/manager/src/components/ShowMore/ShowMore.tsx
+++ b/packages/manager/src/components/ShowMore/ShowMore.tsx
@@ -1,18 +1,18 @@
-import classNames from 'classnames';
 import * as React from 'react';
 import Chip, { ChipProps } from 'src/components/core/Chip';
 import Popover from '@mui/material/Popover';
-import { styled } from '@mui/material/styles';
+import { styled, useTheme } from '@mui/material/styles';
 
 interface ShowMoreProps<T> {
+  ariaItemType: string;
+  chipProps?: ChipProps;
   items: T[];
   render: (items: T[]) => any;
-  chipProps?: ChipProps;
-  ariaItemType: string;
 }
 
 export const ShowMore = <T extends unknown>(props: ShowMoreProps<T>) => {
   const { render, items, chipProps, ariaItemType } = props;
+  const theme = useTheme();
   const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null);
 
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
@@ -28,35 +28,31 @@ export const ShowMore = <T extends unknown>(props: ShowMoreProps<T>) => {
   return (
     <React.Fragment>
       <StyledChip
-        className={classNames(
-          {
-            active: anchorEl,
-          },
-          'chip'
-        )}
-        label={`+${items.length}`}
-        aria-label={`+${items.length} ${ariaItemType}`}
-        onClick={handleClick}
         {...chipProps}
-        data-qa-show-more-chip
-        component={'button' as 'div'}
+        aria-label={`+${items.length} ${ariaItemType}`}
         clickable
+        component={'button'}
+        data-qa-show-more-chip
+        label={`+${items.length}`}
+        onClick={handleClick}
+        sx={
+          anchorEl
+            ? {
+                backgroundColor: theme.palette.primary.main,
+                color: 'white',
+              }
+            : null
+        }
       />
 
       <StyledPopover
-        role="dialog"
-        aria-label={`${items.length} additional ${ariaItemType}`}
         anchorEl={anchorEl}
-        open={Boolean(anchorEl)}
+        anchorOrigin={{ vertical: 28, horizontal: 'left' }}
+        aria-label={`${items.length} additional ${ariaItemType}`}
         onClose={handleClose}
-        anchorOrigin={{
-          vertical: 28,
-          horizontal: 'left',
-        }}
-        transformOrigin={{
-          vertical: 'top',
-          horizontal: 'left',
-        }}
+        open={Boolean(anchorEl)}
+        role="dialog"
+        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
       >
         {render(items)}
       </StyledPopover>
@@ -65,15 +61,14 @@ export const ShowMore = <T extends unknown>(props: ShowMoreProps<T>) => {
 };
 
 const StyledChip = styled(Chip)(({ theme }) => ({
-  // backgroundColor: theme.bg.lightBlue1,
-  backgroundColor: 'red !important',
+  backgroundColor: theme.bg.lightBlue1,
   fontWeight: 500,
   lineHeight: 1,
   marginLeft: theme.spacing(0.5),
   paddingLeft: 2,
   paddingRight: 2,
   position: 'relative',
-  '&:hover, &.active': {
+  '&:hover': {
     backgroundColor: theme.palette.primary.main,
     color: 'white',
   },

--- a/packages/manager/src/components/ShowMore/ShowMore.tsx
+++ b/packages/manager/src/components/ShowMore/ShowMore.tsx
@@ -1,133 +1,110 @@
 import classNames from 'classnames';
 import * as React from 'react';
 import Chip, { ChipProps } from 'src/components/core/Chip';
-import Popover from 'src/components/core/Popover';
-import { createStyles, withStyles, WithStyles } from '@mui/styles';
-import { Theme } from '@mui/material/styles';
+import Popover from '@mui/material/Popover';
+import { styled } from '@mui/material/styles';
 
-type CSSClasses = 'chip' | 'label' | 'popover' | 'link';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    chip: {
-      position: 'relative',
-      marginLeft: theme.spacing(0.5),
-      paddingLeft: 2,
-      paddingRight: 2,
-      backgroundColor: theme.bg.lightBlue1,
-      fontWeight: 500,
-      lineHeight: 1,
-      '&:hover, &.active': {
-        backgroundColor: theme.palette.primary.main,
-        color: 'white',
-      },
-      '&:focus': {
-        backgroundColor: theme.bg.lightBlue1,
-        outline: '1px dotted #999',
-      },
-    },
-    label: {
-      paddingLeft: 6,
-      paddingRight: 6,
-    },
-    link: {
-      color: `${theme.color.blueDTwhite} !important`,
-      '&:hover': {
-        textDecoration: 'underline',
-      },
-    },
-    popover: {
-      minWidth: 'auto',
-      maxWidth: 400,
-      maxHeight: 200,
-      overflowY: 'scroll',
-      padding: theme.spacing(1),
-      [theme.breakpoints.down('sm')]: {
-        maxWidth: 285,
-      },
-      '&::-webkit-scrollbar': {
-        webkitAppearance: 'none',
-        width: 7,
-      },
-      '&::-webkit-scrollbar-thumb': {
-        borderRadius: 4,
-        backgroundColor: theme.color.grey2,
-        WebkitBoxShadow: '0 0 1px rgba(255,255,255,.5)',
-      },
-    },
-  });
-
-interface Props<T> {
+interface ShowMoreProps<T> {
   items: T[];
   render: (items: T[]) => any;
   chipProps?: ChipProps;
   ariaItemType: string;
 }
 
-export class ShowMore<T> extends React.Component<
-  Props<T> & WithStyles<CSSClasses>
-> {
-  state = {
-    anchorEl: undefined,
-  };
+export const ShowMore = <T extends unknown>(props: ShowMoreProps<T>) => {
+  const { render, items, chipProps, ariaItemType } = props;
+  const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null);
 
-  handleClick = (event: React.MouseEvent<HTMLElement>) => {
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     event.preventDefault();
-    this.setState({
-      anchorEl: event.currentTarget,
-    });
+    setAnchorEl(event.currentTarget);
   };
 
-  handleClose = (event: React.MouseEvent<HTMLElement>) => {
+  const handleClose = (event: React.MouseEvent<HTMLElement>) => {
     event.preventDefault();
-    this.setState({ anchorEl: undefined });
+    setAnchorEl(null);
   };
 
-  render() {
-    const { classes, render, items, chipProps, ariaItemType } = this.props;
-    const { anchorEl } = this.state;
+  return (
+    <React.Fragment>
+      <StyledChip
+        className={classNames(
+          {
+            active: anchorEl,
+          },
+          'chip'
+        )}
+        label={`+${items.length}`}
+        aria-label={`+${items.length} ${ariaItemType}`}
+        onClick={handleClick}
+        {...chipProps}
+        data-qa-show-more-chip
+        component={'button' as 'div'}
+        clickable
+      />
 
-    return (
-      <React.Fragment>
-        <Chip
-          className={classNames(
-            {
-              [classes.chip]: true,
-              active: anchorEl,
-            },
-            'chip'
-          )}
-          label={`+${items.length}`}
-          aria-label={`+${items.length} ${ariaItemType}`}
-          classes={{ label: classes.label }}
-          onClick={this.handleClick}
-          {...chipProps}
-          data-qa-show-more-chip
-          component={'button' as 'div'}
-          clickable
-        />
+      <StyledPopover
+        role="dialog"
+        aria-label={`${items.length} additional ${ariaItemType}`}
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: 28,
+          horizontal: 'left',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'left',
+        }}
+      >
+        {render(items)}
+      </StyledPopover>
+    </React.Fragment>
+  );
+};
 
-        <Popover
-          classes={{ paper: classes.popover }}
-          role="dialog"
-          aria-label={`${items.length} additional ${ariaItemType}`}
-          anchorEl={anchorEl}
-          open={Boolean(anchorEl)}
-          onClose={this.handleClose}
-          anchorOrigin={{
-            vertical: 28,
-            horizontal: 'left',
-          }}
-          transformOrigin={{
-            vertical: 'top',
-            horizontal: 'left',
-          }}
-        >
-          {render(items)}
-        </Popover>
-      </React.Fragment>
-    );
-  }
-}
+const StyledChip = styled(Chip)(({ theme }) => ({
+  // backgroundColor: theme.bg.lightBlue1,
+  backgroundColor: 'red !important',
+  fontWeight: 500,
+  lineHeight: 1,
+  marginLeft: theme.spacing(0.5),
+  paddingLeft: 2,
+  paddingRight: 2,
+  position: 'relative',
+  '&:hover, &.active': {
+    backgroundColor: theme.palette.primary.main,
+    color: 'white',
+  },
+  '&:focus': {
+    backgroundColor: theme.bg.lightBlue1,
+    outline: '1px dotted #999',
+  },
+  '& .MuiChip-label': {
+    paddingLeft: 6,
+    paddingRight: 6,
+  },
+}));
 
-export default withStyles(styles)(ShowMore);
+const StyledPopover = styled(Popover)(({ theme }) => ({
+  '& .MuiPopover-paper': {
+    maxHeight: 200,
+    maxWidth: 400,
+    minWidth: 'auto',
+    overflowY: 'scroll',
+    padding: theme.spacing(1),
+    [theme.breakpoints.down('sm')]: {
+      maxWidth: 285,
+    },
+    '&::-webkit-scrollbar': {
+      webkitAppearance: 'none',
+      width: 7,
+    },
+    '&::-webkit-scrollbar-thumb': {
+      backgroundColor: theme.color.grey2,
+      borderRadius: 4,
+      WebkitBoxShadow: '0 0 1px rgba(255,255,255,.5)',
+    },
+  },
+}));

--- a/packages/manager/src/components/ShowMore/index.ts
+++ b/packages/manager/src/components/ShowMore/index.ts
@@ -1,2 +1,0 @@
-import ShowMore from './ShowMore';
-export default ShowMore;

--- a/packages/manager/src/components/Tags/Tags.tsx
+++ b/packages/manager/src/components/Tags/Tags.tsx
@@ -1,6 +1,6 @@
 import { splitAt } from 'ramda';
 import * as React from 'react';
-import ShowMore from 'src/components/ShowMore';
+import { ShowMore } from 'src/components/ShowMore/ShowMore';
 import Tag from 'src/components/Tag';
 
 export interface Props {

--- a/packages/manager/src/components/core/Popover.ts
+++ b/packages/manager/src/components/core/Popover.ts
@@ -1,6 +1,0 @@
-import Popover, { PopoverProps as _PopoverProps } from '@mui/material/Popover';
-
-/* tslint:disable-next-line:no-empty-interface */
-export interface PopoverProps extends _PopoverProps {}
-
-export default Popover;

--- a/packages/manager/src/containers/SummaryPanels.styles.ts
+++ b/packages/manager/src/containers/SummaryPanels.styles.ts
@@ -66,7 +66,7 @@ const summaryPanelStyles = (theme: Theme) =>
       '& .dif': {
         position: 'relative',
         width: 'auto',
-        '& .chip': {
+        '& .MuiChip-root': {
           position: 'absolute',
           top: '-4px',
           right: -10,

--- a/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/ContactInfoPanel/ContactInformation.tsx
@@ -32,7 +32,7 @@ const StyledTypography = styled(Typography)(({ theme }) => ({
   '& .dif': {
     position: 'relative',
     width: 'auto',
-    '& .chip': {
+    '& .MuiChip-root': {
       position: 'absolute',
       top: '-4px',
       right: -10,

--- a/packages/manager/src/features/linodes/LinodesLanding/IPAddress.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/IPAddress.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { CopyTooltip } from 'src/components/CopyTooltip/CopyTooltip';
 import { createStyles, withStyles, WithStyles } from '@mui/styles';
 import { Theme } from '@mui/material/styles';
-import ShowMore from 'src/components/ShowMore';
+import { ShowMore } from 'src/components/ShowMore/ShowMore';
 import { privateIPRegex } from 'src/utilities/ipUtils';
 
 type CSSClasses =


### PR DESCRIPTION
## Description 📝
Migrate `ShowMore` to `styled/sx` api and remove `jss`

## Major Changes 🔄
- Added new storybook page
- Updated imports/exports
- Converted class to functional component
- Removed hardcoded classes: 
    - `.chip` → `.MuiChip-root`
    - `.active` → Uses `sx` prop to handle this now

## Preview 📷
No visual changes

| Storybook Page   | Search Page
| ------- | ------- |
| ![Screen Shot 2023-05-24 at 1 08 40 PM](https://github.com/linode/manager/assets/125309814/fb8b0081-86da-4464-99ef-c714b1fbb6f6) | ![Screen Shot 2023-05-24 at 1 18 18 PM](https://github.com/linode/manager/assets/125309814/7a14419e-5c7f-4e03-88c1-3d53f6b676da) |

## How to test 🧪
1. Go to http://localhost:3000/search?query=debian
2. Ensure you have a linode with lots of tags to see the `ShowMore`
