### PR TITLE
refactor: [M3-6388] - MUI v5 - `Components > SelectRegionPanel`

### DIFF
--- a/packages/manager/.changeset/pr-9173-tech-stories-1684963143824.md
+++ b/packages/manager/.changeset/pr-9173-tech-stories-1684963143824.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+MUI v5 - Components > SelectRegionPanel ([#9173](https://github.com/linode/manager/pull/9173))

--- a/packages/manager/src/components/SelectRegionPanel/RegionHelperText.tsx
+++ b/packages/manager/src/components/SelectRegionPanel/RegionHelperText.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import Typography from 'src/components/core/Typography';
+
+interface RegionHelperTextProps {
+  onClick?: () => void;
+}
+
+export const RegionHelperText = (props: RegionHelperTextProps) => {
+  const { onClick } = props;
+
+  return (
+    <Typography variant="body1">
+      You can use
+      {` `}
+      <a
+        onClick={onClick}
+        target="_blank"
+        aria-describedby="external-site"
+        rel="noopener noreferrer"
+        href="https://www.linode.com/speed-test/"
+      >
+        our speedtest page
+      </a>
+      {` `}
+      to find the best region for your current location.
+    </Typography>
+  );
+};

--- a/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
+++ b/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
@@ -1,64 +1,28 @@
-import { Region } from '@linode/api-v4/lib/regions';
-import { Theme } from '@mui/material/styles';
-import { createStyles, withStyles, WithStyles } from '@mui/styles';
 import * as React from 'react';
-import { useLocation } from 'react-router-dom';
-import { compose } from 'recompose';
 import Box from 'src/components/core/Box';
 import Paper from 'src/components/core/Paper';
 import Typography from 'src/components/core/Typography';
-import { RegionSelect } from 'src/components/EnhancedSelect/variants/RegionSelect';
-import { Notice } from 'src/components/Notice/Notice';
-import RenderGuard, { RenderGuardProps } from 'src/components/RenderGuard';
 import { CROSS_DATA_CENTER_CLONE_WARNING } from 'src/features/linodes/LinodesCreate/utilities';
-import { sendLinodeCreateDocsEvent } from 'src/utilities/ga';
 import { getParamsFromUrl } from 'src/utilities/queryParams';
+import { Notice } from 'src/components/Notice/Notice';
+import { Region } from '@linode/api-v4/lib/regions';
+import { RegionHelperText } from 'src/components/SelectRegionPanel/RegionHelperText';
+import { RegionSelect } from 'src/components/EnhancedSelect/variants/RegionSelect';
+import { sendLinodeCreateDocsEvent } from 'src/utilities/ga';
+import { useLocation } from 'react-router-dom';
+import { useTheme } from '@mui/material/styles';
 
-type ClassNames = 'root';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {
-      marginTop: theme.spacing(3),
-      '& svg': {
-        '& g': {
-          // Super hacky fix for Firefox rendering of some flag icons that had a clip-path property.
-          clipPath: 'none !important' as 'none',
-        },
-      },
-    },
-  });
-
-interface Props {
-  regions: Region[];
+interface SelectRegionPanelProps {
+  disabled?: boolean;
   error?: string;
   handleSelection: (id: string) => void;
-  selectedID?: string;
-  disabled?: boolean;
   helperText?: string;
+  regions: Region[];
+  selectedID?: string;
 }
 
-export const regionHelperText = (onClick?: () => void) => (
-  <Typography variant="body1">
-    You can use
-    {` `}
-    <a
-      onClick={onClick}
-      target="_blank"
-      aria-describedby="external-site"
-      rel="noopener noreferrer"
-      href="https://www.linode.com/speed-test/"
-    >
-      our speedtest page
-    </a>
-    {` `}
-    to find the best region for your current location.
-  </Typography>
-);
-
-const SelectRegionPanel: React.FC<Props & WithStyles<ClassNames>> = (props) => {
+export const SelectRegionPanel = (props: SelectRegionPanelProps) => {
   const {
-    classes,
     disabled,
     error,
     handleSelection,
@@ -66,23 +30,34 @@ const SelectRegionPanel: React.FC<Props & WithStyles<ClassNames>> = (props) => {
     regions,
     selectedID,
   } = props;
-
+  const theme = useTheme();
   const location = useLocation();
+  const params = getParamsFromUrl(location.search);
+  const showCrossDataCenterCloneWarning =
+    /clone/i.test(params.type) && selectedID && params.regionID !== selectedID;
 
   if (props.regions.length === 0) {
     return null;
   }
 
-  const params = getParamsFromUrl(location.search);
-  const showCrossDataCenterCloneWarning =
-    /clone/i.test(params.type) && selectedID && params.regionID !== selectedID;
-
   return (
-    <Paper className={classes.root}>
+    <Paper
+      sx={{
+        marginTop: theme.spacing(3),
+        '& svg': {
+          '& g': {
+            // Super hacky fix for Firefox rendering of some flag icons that had a clip-path property.
+            clipPath: 'none !important' as 'none',
+          },
+        },
+      }}
+    >
       <Typography variant="h2" data-qa-tp="Region">
         Region
       </Typography>
-      {regionHelperText(() => sendLinodeCreateDocsEvent('Speedtest Link'))}
+      <RegionHelperText
+        onClick={() => sendLinodeCreateDocsEvent('Speedtest')}
+      />
       {showCrossDataCenterCloneWarning ? (
         <Box marginTop="16px" data-testid="region-select-warning">
           <Notice warning text={CROSS_DATA_CENTER_CLONE_WARNING} />
@@ -99,13 +74,3 @@ const SelectRegionPanel: React.FC<Props & WithStyles<ClassNames>> = (props) => {
     </Paper>
   );
 };
-
-const styled = withStyles(styles);
-
-export default compose<
-  Props & WithStyles<ClassNames>,
-  Props & RenderGuardProps
->(
-  RenderGuard,
-  styled
-)(SelectRegionPanel);

--- a/packages/manager/src/components/SelectRegionPanel/index.ts
+++ b/packages/manager/src/components/SelectRegionPanel/index.ts
@@ -1,1 +1,0 @@
-export { default } from './SelectRegionPanel';

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -38,7 +38,7 @@ import MultipleIPInput from 'src/components/MultipleIPInput';
 import { Notice } from 'src/components/Notice/Notice';
 import ProductInformationBanner from 'src/components/ProductInformationBanner';
 import Radio from 'src/components/Radio';
-import { regionHelperText } from 'src/components/SelectRegionPanel/SelectRegionPanel';
+import { RegionHelperText } from 'src/components/SelectRegionPanel/RegionHelperText';
 import TextField from 'src/components/TextField';
 import { databaseEngineMap } from 'src/features/Databases/DatabaseLanding/DatabaseRow';
 import { enforceIPMasks } from 'src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.utils';
@@ -503,7 +503,9 @@ const DatabaseCreate = () => {
             regions={regionsData}
             selectedID={values.region}
           />
-          <div style={{ marginTop: 8 }}>{regionHelperText()}</div>
+          <div style={{ marginTop: 8 }}>
+            <RegionHelperText />
+          </div>
         </Grid>
         <Divider spacingTop={38} spacingBottom={12} />
         <Grid>

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -17,7 +17,7 @@ import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import { RegionSelect } from 'src/components/EnhancedSelect/variants/RegionSelect';
 import { ErrorState } from 'src/components/ErrorState/ErrorState';
 import { Notice } from 'src/components/Notice/Notice';
-import { regionHelperText } from 'src/components/SelectRegionPanel/SelectRegionPanel';
+import { RegionHelperText } from 'src/components/SelectRegionPanel/RegionHelperText';
 import TextField from 'src/components/TextField';
 import {
   reportAgreementSigningError,
@@ -276,7 +276,7 @@ export const CreateCluster = () => {
                 regions={filteredRegions}
                 selectedID={selectedID}
                 textFieldProps={{
-                  helperText: regionHelperText(),
+                  helperText: <RegionHelperText />,
                   helperTextPosition: 'top',
                 }}
               />

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -7,7 +7,7 @@ import Paper from 'src/components/core/Paper';
 import LandingHeader from 'src/components/LandingHeader';
 import TextField from 'src/components/TextField';
 import Typography from 'src/components/core/Typography';
-import SelectRegionPanel from 'src/components/SelectRegionPanel';
+import { SelectRegionPanel } from 'src/components/SelectRegionPanel/SelectRegionPanel';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import EUAgreementCheckbox from '../Account/Agreements/EUAgreementCheckbox';

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -23,7 +23,7 @@ import Grid from '@mui/material/Unstable_Grid2';
 import LabelAndTagsPanel from 'src/components/LabelAndTagsPanel';
 import { Notice } from 'src/components/Notice/Notice';
 import SafeTabPanel from 'src/components/SafeTabPanel';
-import SelectRegionPanel from 'src/components/SelectRegionPanel';
+import { SelectRegionPanel } from 'src/components/SelectRegionPanel/SelectRegionPanel';
 import TabLinkList, { Tab } from 'src/components/TabLinkList';
 import { DefaultProps as ImagesProps } from 'src/containers/images.container';
 import { FeatureFlagConsumerProps } from 'src/containers/withFeatureFlagConsumer.container';
@@ -697,7 +697,6 @@ export class LinodeCreate extends React.PureComponent<
               regions={regionsData!}
               handleSelection={this.props.updateRegionID}
               selectedID={this.props.selectedRegionID}
-              updateFor={[this.props.selectedRegionID, regionsData, errors]}
               disabled={userCannotCreateLinode}
               helperText={this.props.regionHelperText}
             />


### PR DESCRIPTION
## Description 📝
Migrate `SelectRegionPanel` to `styled/sx` api and remove `jss`

## Major Changes 🔄
- Converted the `regionHelperText` function to a component since we don't want to invoke functions like this in the JSX
- Update export/imports
- Other changes involved removing `compose`, alphabetizing props & attributes

## Preview 📷
No Visual changes

<img width="583" alt="Screen Shot 2023-05-24 at 5 16 17 PM" src="https://github.com/linode/manager/assets/125309814/9e463a85-719c-41c1-8b1c-937e87a9d981">

## How to test 🧪
1. Try to create a nodebalancer http://localhost:3000/nodebalancers/create
2. Do the same for linode create from backups https://cloud.linode.com/linodes/create?type=Backups
3. Observe / test "Region" section
