### PR TITLE
chore: Upgrade cypress-vite dependency to v1.4.0

### DIFF
--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -182,7 +182,7 @@
     "cypress-axe": "^1.0.0",
     "cypress-file-upload": "^5.0.7",
     "cypress-real-events": "^1.7.0",
-    "cypress-vite": "^1.3.2",
+    "cypress-vite": "^1.4.0",
     "dotenv": "^16.0.3",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6419,11 +6419,12 @@ cypress-real-events@^1.7.0:
   resolved "https://registry.yarnpkg.com/cypress-real-events/-/cypress-real-events-1.7.6.tgz#6f17e0b2ceea1d6dc60f6737d8f84cc517bbbb4c"
   integrity sha512-yP6GnRrbm6HK5q4DH6Nnupz37nOfZu/xn1xFYqsE2o4G73giPWQOdu6375QYpwfU1cvHNCgyD2bQ2hPH9D7NMw==
 
-cypress-vite@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/cypress-vite/-/cypress-vite-1.3.2.tgz#7e7e94b36d2f01701258a4664c8385f9a947a545"
-  integrity sha512-PYQd4Y8vCVY+dHZyfrFQ1zPPLOpFFFyKcEeolQ/1UvrB2MELNsz9lj3LfqIpNc+tqO9pemt9nGmSspZS+4LNeQ==
+cypress-vite@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/cypress-vite/-/cypress-vite-1.4.0.tgz#4d2889d62c11aed7188b1082af16210240aac2e6"
+  integrity sha512-BHmOku8q6nRtDGPiBcE7zcAZs56/OsiX5SFoldHEMSQ+I6nnPUU2tcrRNeRsCArONQAvwTu2Da7R/rFGA/DSEg==
   dependencies:
+    chokidar "^3.5.3"
     debug "^4.3.4"
 
 cypress@^12.11.0:


### PR DESCRIPTION
## Description 📝
This upgrades `cypress-vite`, which allows us to preprocess our Cypress spec files using Vite. I believe this upgrade fixes an issue we see where spec files are occasionally built multiple times before Cypress is able to run them.

## Major Changes 🔄
- Upgrade `cypress-vite` from `v1.3.2` to `v1.4.0`.

## How to test 🧪
Confirm Cypress tests run and pass as expected. We can rely on the automated run for this.