### PR TITLE
fix: IP Sharing Query Invalidation

### DIFF
--- a/packages/manager/src/queries/linodes/networking.ts
+++ b/packages/manager/src/queries/linodes/networking.ts
@@ -144,7 +144,7 @@ export const useAllDetailedIPv6RangesQuery = (
 ) => {
   const { data: ranges } = useAllIPv6RangesQuery(params, filter, enabled);
   return useQuery<IPRangeInformation[], APIError[]>(
-    [queryKey, 'ipv6', 'ranges', 'details', params, filter],
+    [queryKey, 'ipv6', 'ranges', 'details', ranges, params, filter],
     async () => {
       return await Promise.all(
         (ranges ?? []).map((range) => getIPv6RangeInfo(range.range))


### PR DESCRIPTION
## Description 📝

- If you allocated an IPv6 range, query invalidation would happen properly but a dependent query would not be guaranteed to be invalided with the correct information

## The Bug 🐛 

Notice how after allocating an IPv6 range in the same DC, the IPv6 does **not** show up in the sharing dialog as expected. It would show up if the user refreshed, but that is obviously bad.

https://github.com/linode/manager/assets/115251059/e43b3457-f22d-4dab-b749-895f321f75a1

## How to test 🧪
1. Create two linodes (Linode A and Linode B) in the same datacenter
2. Open the IP Sharing dialog on Linode B (we must do this is populate the initial cache)
3. Navigate to LInode A's details page and allocate an IPv6 on Linode A
4. Navigate back to the IP Sharing dialog on Linode B
5. Verify that you can see the new IPv6 you just allocated in the sharing dropdown