### PR TITLE
Refactor: [M3-6519]: Replace trademark html entities

### DIFF
--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -575,7 +575,7 @@ export const SelectPlanPanel = (props: Props) => {
               <PremiumPlansAvailabilityNotice />
               <Typography data-qa-gpu className={classes.copy}>
                 Premium CPU instances guarantee a minimum processor model, AMD
-                Epyc<sup>TM</sup> 7713 or higher, to ensure consistent high
+                Epyc&trade; 7713 or higher, to ensure consistent high
                 performance for more demanding workloads.
               </Typography>
               {renderPlanContainer(premium)}

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanQuantityPanel.tsx
@@ -385,7 +385,7 @@ export class SelectPlanQuantityPanel extends React.Component<CombinedProps> {
               <PremiumPlansAvailabilityNotice />
               <Typography data-qa-gpu className={classes.copy}>
                 Premium CPU instances guarantee a minimum processor model, AMD
-                Epyc<sup>TM</sup> 7713 or higher, to ensure consistent high
+                Epyc&trade; 7713 or higher, to ensure consistent high
                 performance for more demanding workloads.
               </Typography>
               {this.renderPlanContainer(premium)}


### PR DESCRIPTION
## Description 📝
Simple PR to use the correct HTML entity for our premium plans trademark characters

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-05-30 at 3 08 18 PM](https://github.com/linode/manager/assets/130582365/782af123-7298-4c73-bad7-65adb83ca2b6) | ![Screenshot 2023-05-30 at 3 07 58 PM](https://github.com/linode/manager/assets/130582365/e8785930-20e0-42c5-9879-d6873d8eaa34) |

## How to test 🧪
1. Navigate to the create Linode workflow > Linode Plan > Premium tab
2. Verify the trademark character has been replaced with the proper entity 
