### PR TITLE
fix: Re-add `fs` import to Cypress config

### DIFF
--- a/packages/manager/cypress.config.ts
+++ b/packages/manager/cypress.config.ts
@@ -5,6 +5,7 @@ import { resolve } from 'path';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const vitePreprocessor = require('cypress-vite');
 import * as dotenv from 'dotenv';
+import * as fs from 'fs';
 
 /**
  * Returns a configuration object containing environment variables.

--- a/packages/manager/cypress.config.ts
+++ b/packages/manager/cypress.config.ts
@@ -5,7 +5,7 @@ import { resolve } from 'path';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const vitePreprocessor = require('cypress-vite');
 import * as dotenv from 'dotenv';
-import * as fs from 'fs';
+import { unlinkSync } from 'fs';
 
 /**
  * Returns a configuration object containing environment variables.
@@ -158,7 +158,7 @@ export default defineConfig({
           });
 
           if (!isFailedOrFlaky && configWithEnv.env['CI']) {
-            fs.unlinkSync(results.video);
+            unlinkSync(results.video);
           }
         }
       });


### PR DESCRIPTION
## Description 📝

- Fixes missing `fs` import in our cypress config (https://github.com/linode/manager/commit/b53e73d96c91af68b3f6fc60cd48514d0023a184#diff-d023ed4a17f94524bd01ac032411794e19ef22a83c9fdb54d55eed8ced993248)

## How to test 🧪
- Verify all CI and e2es pass for this PR