### PR TITLE
docs: [M3-6513] - Document Adobe Analytics best practices

### DIFF
--- a/docs/development-guide/13-coding-standards.md
+++ b/docs/development-guide/13-coding-standards.md
@@ -55,7 +55,7 @@ The styles for Cloud Manager are located in three places:
 
 ### Writing a Custom Event
 
-Custom events live (mostly) in `analytics.ts`. Try to write and export custom events in this file if possible, and import them in the component(s) where they are used.
+Custom events live (mostly) in `src/utilities/analytics.ts`. Try to write and export custom events in this file if possible, and import them in the component(s) where they are used.
 
 ```tsx
 // Component.tsx {file(s) where the event is called, for quick reference}
@@ -63,7 +63,7 @@ Custom events live (mostly) in `analytics.ts`. Try to write and export custom ev
 
 sendDescriptiveNameEvent () => {
       category: '{Descriptive/Page Name}',
-      action: '{interaction; e.g. Click, Hover, Focus}:{input type; e.g. button, link, toggle, checkbox, text field}',
+      action: '{interaction such as Click, Hover, Focus}:{input type such as button, link, toggle, checkbox, text field} e.g. Click:link',
       label: '{string associated with the event; e.g event label} (optional)',
       value: '{number associated with the event; e.g. size of a volume} (optional)',
 }


### PR DESCRIPTION
## Description 📝
With the migration from Google Analytics to Adobe Analytics nearing completion, this PR documents best practices for AA.

## How to test 🧪
1. Review this diff for clarity and typos. 
2. Review the Adobe Analytics page in our internal documentation (ask if you don't know where to find this) for an overview of the project.
3. Comment with any questions or suggestions. 