### PR TITLE
Fix: [M3-6482] Marketplace: disable app search till loading complete

### DIFF
--- a/packages/manager/.changeset/pr-9207-fixed-1685730490031.md
+++ b/packages/manager/.changeset/pr-9207-fixed-1685730490031.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Marketplace: disable app search till loading complete ([#9207](https://github.com/linode/manager/pull/9207))

--- a/packages/manager/src/features/Linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -324,13 +324,28 @@ class FromAppsContent extends React.Component<CombinedProps, State> {
             <Box className={classes.searchAndFilter}>
               <Box className={classes.search}>
                 <DebouncedSearchTextField
-                  placeholder="Search for app name"
+                  placeholder={
+                    appInstancesLoading ? 'Loading...' : 'Search for app name'
+                  }
                   fullWidth
                   onSearch={this.onSearch}
                   label="Search marketplace"
                   onClick={handleSearchFieldClick}
                   hideLabel
                   value={query}
+                  disabled={appInstancesLoading}
+                  sx={
+                    appInstancesLoading
+                      ? {
+                          '& input': {
+                            cursor: 'not-allowed',
+                          },
+                          '& svg': {
+                            opacity: 0.5,
+                          },
+                        }
+                      : null
+                  }
                 />
               </Box>
               <Box className={classes.filter}>

--- a/packages/manager/src/features/Linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -351,10 +351,13 @@ class FromAppsContent extends React.Component<CombinedProps, State> {
               <Box className={classes.filter}>
                 <Select
                   label="Select category"
-                  placeholder="Select category"
+                  placeholder={
+                    appInstancesLoading ? 'Loading...' : 'Select category'
+                  }
                   options={appCategoryOptions}
                   onChange={this.handleSelectCategory}
                   value={categoryFilter}
+                  disabled={appInstancesLoading}
                   hideLabel
                 />
               </Box>


### PR DESCRIPTION
## Description 📝
There's currently an issue with the app search input in marketplace if the apps haven't loaded yet (the loader will just keep showing). To remediate this I disabled the input until the apps have loaded and improved the disabled styles and placeholder text to reflect that.

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/130582365/283c7e1c-b5c0-4ef6-b867-3db01f5014b1" /> | <video src="https://github.com/linode/manager/assets/130582365/24f858bf-ed25-44f6-9c3e-67877f959794" /> |

## How to test 🧪
1. Pull code locally and navigate to /linodes/create?type=One-Click
2. Confirm behavior described in PR description 
