### PR TITLE
refactor: [M3-6378] - MUI v5 - Components > ProductNotification

### DIFF
--- a/packages/manager/.changeset/pr-9211-tech-stories-1686019152206.md
+++ b/packages/manager/.changeset/pr-9211-tech-stories-1686019152206.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+MUI v5 - Components > ProductNotification ([#9211](https://github.com/linode/manager/pull/9211))

--- a/packages/manager/src/components/ProductNotification/ProductNotification.test.tsx
+++ b/packages/manager/src/components/ProductNotification/ProductNotification.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+import {
+  ProductNotification,
+  ProductNotificationProps,
+} from './ProductNotification';
+
+describe('ProductNotification', () => {
+  test('renders a notice with the correct severity level and text', () => {
+    const props: ProductNotificationProps = {
+      severity: 'critical',
+      text: 'This is a critical notification',
+    };
+
+    const { getByText, container } = renderWithTheme(
+      <ProductNotification {...props} />
+    );
+
+    const noticeElement = getByText('This is a critical notification');
+    expect(noticeElement).toBeInTheDocument();
+    const noticeRoot = container.firstChild;
+
+    expect(noticeRoot).toHaveClass('error-for-scroll');
+  });
+});

--- a/packages/manager/src/components/ProductNotification/ProductNotification.tsx
+++ b/packages/manager/src/components/ProductNotification/ProductNotification.tsx
@@ -17,7 +17,6 @@ export const ProductNotification = ({
   severity,
   text,
 }: ProductNotificationProps) => {
-  debugger;
   const level = severityLevelMap[severity] ?? 'warning';
   return React.createElement(Notice, { flag: true, [level]: true }, text);
 };

--- a/packages/manager/src/components/ProductNotification/ProductNotification.tsx
+++ b/packages/manager/src/components/ProductNotification/ProductNotification.tsx
@@ -18,5 +18,7 @@ export const ProductNotification = ({
   text,
 }: ProductNotificationProps) => {
   const level = severityLevelMap[severity] ?? 'warning';
-  return React.createElement(Notice, { flag: true, [level]: true }, text);
+  const props = { flag: true, [level]: true };
+
+  return <Notice {...props}>{text}</Notice>;
 };

--- a/packages/manager/src/components/ProductNotification/ProductNotification.tsx
+++ b/packages/manager/src/components/ProductNotification/ProductNotification.tsx
@@ -1,24 +1,23 @@
 import * as React from 'react';
 import { Notice } from 'src/components/Notice/Notice';
 
-interface Props {
-  text: string;
-  severity: 'minor' | 'major' | 'critical';
+export interface ProductNotificationProps {
   onClick?: () => void;
+  severity: 'minor' | 'major' | 'critical';
+  text: string;
 }
 
-type CombinedProps = Props;
+const severityLevelMap = {
+  critical: 'error',
+  major: 'warning',
+  minor: 'warning',
+};
 
-const ProductNotifications: React.FC<CombinedProps> = (props) => {
-  const { text, severity } = props;
+export const ProductNotification = ({
+  severity,
+  text,
+}: ProductNotificationProps) => {
+  debugger;
   const level = severityLevelMap[severity] ?? 'warning';
   return React.createElement(Notice, { flag: true, [level]: true }, text);
 };
-
-const severityLevelMap = {
-  minor: 'warning',
-  major: 'warning',
-  critical: 'error',
-};
-
-export default ProductNotifications;

--- a/packages/manager/src/components/ProductNotification/index.ts
+++ b/packages/manager/src/components/ProductNotification/index.ts
@@ -1,2 +1,0 @@
-import ProductNotification from './ProductNotification';
-export default ProductNotification;

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailHeader/Notifications.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailHeader/Notifications.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Notification } from '@linode/api-v4/lib/account';
 import MaintenanceBanner from 'src/components/MaintenanceBanner';
-import ProductNotification from 'src/components/ProductNotification';
+import { ProductNotification } from 'src/components/ProductNotification/ProductNotification';
 import { useAllAccountMaintenanceQuery } from 'src/queries/accountMaintenance';
 import { useNotificationsQuery } from 'src/queries/accountNotifications';
 import MigrationNotification from './MigrationNotification';


### PR DESCRIPTION
## Description 📝
**MUI migration SRC > Components > TableContentWrapper**

## Major Changes 🔄

- Run tss-react codemod on `ProductNotification` 
- Renamed Props to    ProductNotificationProps,
- Changes default exports to named exports
- Add  unit test coverage to `ProductNotification` 

## How to test 🧪

- Verify Notifications component where it uses `ProductNotification`.
- Verify e2e tests pass
- Verify unit test passes: ```yarn test ProductNotification```

