### PR TITLE
fix: [M3-6555] - Don't conditionally render VLANs depending on Account Capabilities

### DIFF
--- a/packages/manager/.changeset/pr-9214-fixed-1686072216523.md
+++ b/packages/manager/.changeset/pr-9214-fixed-1686072216523.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+VLANs configuration not showing for restricted users ([#9214](https://github.com/linode/manager/pull/9214))

--- a/packages/manager/src/features/Linodes/LinodesCreate/AddonsPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/AddonsPanel.tsx
@@ -11,7 +11,6 @@ import Typography from 'src/components/core/Typography';
 import { Currency } from 'src/components/Currency';
 import Grid from '@mui/material/Unstable_Grid2';
 import { TooltipIcon } from 'src/components/TooltipIcon/TooltipIcon';
-import { useAccount } from 'src/queries/account';
 import { CreateTypes } from 'src/store/linodeCreate/linodeCreate.actions';
 import AttachVLAN from './AttachVLAN';
 import { privateIPRegex } from 'src/utilities/ipUtils';
@@ -88,17 +87,9 @@ export const AddonsPanel = React.memo((props: AddonsPanelProps) => {
   } = props;
 
   const classes = useStyles();
-  const { data: account } = useAccount();
 
-  // Making this an && instead of the usual hasFeatureEnabled, which is || based.
-  // Doing this so that we can toggle our flag without enabling vlans for all customers.
-  const capabilities = account?.capabilities ?? [];
-
-  // The VLAN section is shown when:
-  // - the user has the capability
-  // - the user is not creating by cloning (cloning copies the network interfaces)
-  const showVlans =
-    capabilities.includes('Vlans') && createType !== 'fromLinode';
+  // The VLAN section is shown when the user is not creating by cloning (cloning copies the network interfaces)
+  const showVlans = createType !== 'fromLinode';
 
   const isBareMetal = /metal/.test(selectedTypeID ?? '');
 

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigDialog.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeConfigs/LinodeConfigDialog.tsx
@@ -33,7 +33,6 @@ import TextField from 'src/components/TextField';
 import { Toggle } from 'src/components/Toggle';
 import DeviceSelection from 'src/features/Linodes/LinodesDetail/LinodeRescue/DeviceSelection';
 import { titlecase } from 'src/features/Linodes/presentation';
-import { useAccount } from 'src/queries/account';
 import { useRegionsQuery } from 'src/queries/regions';
 import { queryKey as vlansQueryKey } from 'src/queries/vlans';
 import { useAllVolumesQuery } from 'src/queries/volumes';
@@ -245,22 +244,19 @@ export const LinodeConfigDialog = (props: Props) => {
 
   const queryClient = useQueryClient();
 
-  const { data: account } = useAccount();
   const [deviceCounter, setDeviceCounter] = React.useState(
     deviceCounterDefault
   );
 
   const [useCustomRoot, setUseCustomRoot] = React.useState(false);
 
-  // Making this an && instead of the usual hasFeatureEnabled, which is || based.
-  // Doing this so that we can toggle our flag without enabling vlans for all customers.
-  const capabilities = account?.capabilities ?? [];
   const regionHasVLANS = regions.some(
     (thisRegion) =>
       thisRegion.id === linode?.region &&
       thisRegion.capabilities.includes('Vlans')
   );
-  const showVlans = capabilities.includes('Vlans') && regionHasVLANS;
+
+  const showVlans = regionHasVLANS;
 
   const { values, resetForm, setFieldValue, ...formik } = useFormik({
     initialValues: defaultFieldsValues,

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetail.container.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetail.container.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import { CircleProgress } from 'src/components/CircleProgress';
-import useAccountManagement from 'src/hooks/useAccountManagement';
 import { useLinodes } from 'src/hooks/useLinodes';
 import { useAllImagesQuery } from 'src/queries/images';
 import { ApplicationState } from 'src/store';
@@ -24,7 +23,6 @@ import LinodesDetail from './LinodesDetail';
 export const LinodesDetailContainer = () => {
   const { linodes } = useLinodes();
   const dispatch = useDispatch<ThunkDispatch>();
-  const { account } = useAccountManagement();
 
   const params = useParams<{ linodeId: string }>();
   const linodeId = params.linodeId;
@@ -36,10 +34,6 @@ export const LinodesDetailContainer = () => {
     const configs = state.__resources.linodeConfigs[linodeId];
     return { disks, configs };
   });
-
-  const capabilities = account?.capabilities ?? [];
-
-  const showVlans = capabilities.includes('Vlans');
 
   React.useEffect(() => {
     // Unconditionally request data for the Linode being viewed
@@ -65,7 +59,7 @@ export const LinodesDetailContainer = () => {
     if (shouldRequestEntity(disks)) {
       dispatch(getAllLinodeDisks({ linodeId: +linodeId }));
     }
-  }, [dispatch, configs, disks, showVlans, linodeId, linodes]);
+  }, [dispatch, configs, disks, linodeId, linodes]);
 
   if ((linodes.lastUpdated === 0 && linodes.loading) || imagesLoading) {
     return <CircleProgress />;

--- a/packages/manager/src/features/Linodes/MigrateLinode/CautionNotice.tsx
+++ b/packages/manager/src/features/Linodes/MigrateLinode/CautionNotice.tsx
@@ -7,7 +7,6 @@ import Typography from 'src/components/core/Typography';
 import { Link } from 'src/components/Link';
 import { Notice } from 'src/components/Notice/Notice';
 import { API_MAX_PAGE_SIZE } from 'src/constants';
-import { useAccount } from 'src/queries/account';
 import { useLinodeVolumesQuery } from 'src/queries/volumes';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -51,10 +50,6 @@ interface Props {
 
 const CautionNotice = (props: Props) => {
   const classes = useStyles();
-  const { data: account } = useAccount();
-
-  const capabilities = account?.capabilities ?? [];
-  const vlansCapability = capabilities.includes('Vlans');
 
   // This is not great, but lets us get all of the volumes for a Linode while keeping
   // the React Query store in a paginated shape. We want to keep data in a paginated shape
@@ -93,15 +88,13 @@ const CautionNotice = (props: Props) => {
             Configure Your Linode for Reverse DNS (rDNS).
           </Link>
         </li>
-        {vlansCapability && (
-          <li>
-            Any attached VLANs will be inaccessible if the destination region
-            does not support VLANs.{` `}
-            <Link to="https://linode.com/docs/products/networking/vlans/">
-              Check VLAN region compatibility.
-            </Link>
-          </li>
-        )}
+        <li>
+          Any attached VLANs will be inaccessible if the destination region does
+          not support VLANs.{` `}
+          <Link to="https://linode.com/docs/products/networking/vlans/">
+            Check VLAN region compatibility.
+          </Link>
+        </li>
         <li>Your Linode will be powered off.</li>
         <li>
           Block Storage can&rsquo;t be migrated to other regions.{' '}


### PR DESCRIPTION

## Description 📝
- Don't conditionally render VLANs depending on Account Capabilities

## Why ❓
- Restricted users do not have permission to GET /account which does **not** allow them to see account capabilities
  - Therefore it's not valid to check for permissions for restricted users using account capabilities
- This resulted in us hiding VLANs related UI for restricted users unintentionally

## The Fix 🔧
- Simply just don't perform any checks against `account.capabilities` because it is not a valid way to check permissions when considering restricted users

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-06-06 at 1 20 16 PM](https://github.com/linode/manager/assets/115251059/115d1849-93c5-4098-99f5-e613cbb23351) | ![Screenshot 2023-06-06 at 1 20 23 PM](https://github.com/linode/manager/assets/115251059/326612b0-85ae-4bed-a19a-fca9c8dc4877) |

## How to test 🧪
- Create a restricted user at `http://localhost:3000/account/users` if you don't have one
- Login to your restricted user in a private window or different browser
- Verify you can see the VLANs section on the Linode Create page