### PR TITLE
fix: [M3-5972] - Better/correct timestamps for finished event messages

### DIFF
--- a/packages/manager/.changeset/pr-9215-fixed-1686154022321.md
+++ b/packages/manager/.changeset/pr-9215-fixed-1686154022321.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Timestamps for finished events show time of completion instead of start ([#9215](https://github.com/linode/manager/pull/9215))

--- a/packages/manager/src/features/Events/EventRow.test.tsx
+++ b/packages/manager/src/features/Events/EventRow.test.tsx
@@ -1,73 +1,31 @@
 import * as React from 'react';
 import { renderWithTheme, wrapWithTableBody } from 'src/utilities/testHelpers';
 import { Row, RowProps } from './EventRow';
-import { getEventTimestamp } from 'src/utilities/eventUtils';
-import { eventFactory } from 'src/factories';
+import { DateTime } from 'luxon';
 
-const inProgressMessage = 'this is an in-progress message.';
-const finishedMessage = 'this is a finished message';
-const createdTimestamp = '2018-12-02T20:23:43';
-const finishedTimestamp = '2018-12-02T20:24:43';
-
-const mockInProgressEvent = eventFactory.build({
-  status: 'started',
-  created: createdTimestamp,
-  duration: 0,
-});
-const mockFinishedEvent = eventFactory.build({
-  status: 'finished',
-  duration: 60,
-  created: createdTimestamp,
-});
-
-const inProgressEventProps: RowProps = {
+const message = 'this is a message.';
+const props: RowProps = {
   action: 'linode_boot',
-  message: inProgressMessage,
+  message,
   type: 'linode',
   username: null,
-  timestamp: getEventTimestamp(mockInProgressEvent),
-};
-
-const finishedEventProps: RowProps = {
-  action: 'linode_boot',
-  message: finishedMessage,
-  type: 'linode',
-  username: null,
-  timestamp: getEventTimestamp(mockFinishedEvent),
+  timestamp: DateTime.now(),
 };
 
 describe('EventRow component', () => {
   it('should render an event with a message', () => {
     const { getByText } = renderWithTheme(
-      wrapWithTableBody(<Row {...inProgressEventProps} />)
+      wrapWithTableBody(<Row {...props} />)
     );
 
-    expect(getByText(inProgressMessage)).toBeInTheDocument();
+    expect(getByText(message)).toBeInTheDocument();
   });
 
   it("shouldn't render events without a message", () => {
-    const emptyMessageProps = { ...inProgressEventProps, message: undefined };
+    const emptyMessageProps = { ...props, message: undefined };
     const { container } = renderWithTheme(
       wrapWithTableBody(<Row {...emptyMessageProps} />)
     );
     expect(container.closest('tr')).toBeNull();
-  });
-
-  // TODO: figure out why table row doesn't display Absolute Date column
-  xit('should render an in-progress event with the original "created" timestamp', () => {
-    const { getByText } = renderWithTheme(
-      wrapWithTableBody(<Row {...finishedEventProps} />)
-    );
-
-    expect(getByText(createdTimestamp)).toBeInTheDocument();
-  });
-
-  // TODO: figure out why table row doesn't display Absolute Date column
-  xit('should render a finished event with a finished timestamp', () => {
-    const { getByText } = renderWithTheme(
-      wrapWithTableBody(<Row {...finishedEventProps} />)
-    );
-
-    expect(getByText(finishedTimestamp)).toBeInTheDocument();
   });
 });

--- a/packages/manager/src/features/Events/EventRow.test.tsx
+++ b/packages/manager/src/features/Events/EventRow.test.tsx
@@ -1,30 +1,106 @@
 import * as React from 'react';
 import { renderWithTheme, wrapWithTableBody } from 'src/utilities/testHelpers';
 import { Row, RowProps } from './EventRow';
+import { getEventTimestamp } from 'src/utilities/eventUtils';
+import { Event } from '@linode/api-v4/lib/account';
 
-const message = 'this is a message.';
-const props: RowProps = {
+const inProgressMessage = 'this is an in-progress message.';
+const finishedMessage = 'this is a finished message';
+const createdTimestamp = '2018-12-02T20:23:43';
+const finishedTimestamp = '2018-12-02T20:24:43';
+
+const inProgressEvent: Event = {
+  id: 1234,
+  time_remaining: '30',
+  secondary_entity: null,
+  seen: true,
+  created: createdTimestamp,
   action: 'linode_boot',
-  message,
-  type: 'linode',
-  created: '2018-01-01',
+  read: false,
+  percent_complete: 50,
   username: null,
+  rate: null,
+  entity: {
+    id: 11440645,
+    label: 'linode11440645',
+    type: 'linode',
+    url: '/v4/linode/instances/11440645',
+  },
+  status: 'started',
+  duration: 30,
+  message: inProgressMessage,
+};
+
+const finishedEvent: Event = {
+  id: 1234,
+  time_remaining: null,
+  secondary_entity: null,
+  seen: true,
+  created: createdTimestamp,
+  action: 'linode_boot',
+  read: false,
+  percent_complete: 100,
+  username: null,
+  rate: null,
+  entity: {
+    id: 11440645,
+    label: 'linode11440645',
+    type: 'linode',
+    url: '/v4/linode/instances/11440645',
+  },
+  status: 'finished',
+  duration: 60,
+  message: finishedMessage,
+};
+
+const inProgressEventProps: RowProps = {
+  action: 'linode_boot',
+  message: inProgressMessage,
+  type: 'linode',
+  username: null,
+  timestamp: getEventTimestamp(inProgressEvent),
+};
+
+const finishedEventProps: RowProps = {
+  action: 'linode_boot',
+  message: finishedMessage,
+  type: 'linode',
+  username: null,
+  timestamp: getEventTimestamp(finishedEvent),
 };
 
 describe('EventRow component', () => {
   it('should render an event with a message', () => {
     const { getByText } = renderWithTheme(
-      wrapWithTableBody(<Row {...props} />)
+      wrapWithTableBody(<Row {...inProgressEventProps} />)
     );
 
-    expect(getByText(message)).toBeInTheDocument();
+    expect(getByText(inProgressMessage)).toBeInTheDocument();
   });
 
   it("shouldn't render events without a message", () => {
-    const emptyMessageProps = { ...props, message: undefined };
+    const emptyMessageProps = { ...inProgressEventProps, message: undefined };
     const { container } = renderWithTheme(
       wrapWithTableBody(<Row {...emptyMessageProps} />)
     );
     expect(container.closest('tr')).toBeNull();
+  });
+
+  // TODO: figure out why table row doesn't display Absolute Date column
+  xit('should render an in-progress event with the original "created" timestamp', () => {
+    const { getByText } = renderWithTheme(
+      wrapWithTableBody(<Row {...finishedEventProps} />)
+    );
+
+    expect(getByText(createdTimestamp)).toBeInTheDocument();
+  });
+
+  // TODO: figure out why table row doesn't display Absolute Date column
+  xit('should render a finished event with a finished timestamp', () => {
+    const { getByText } = renderWithTheme(
+      wrapWithTableBody(<Row {...finishedEventProps} />)
+    );
+
+    expect(getByText(finishedTimestamp)).toBeInTheDocument();
   });
 });

--- a/packages/manager/src/features/Events/EventRow.test.tsx
+++ b/packages/manager/src/features/Events/EventRow.test.tsx
@@ -2,63 +2,30 @@ import * as React from 'react';
 import { renderWithTheme, wrapWithTableBody } from 'src/utilities/testHelpers';
 import { Row, RowProps } from './EventRow';
 import { getEventTimestamp } from 'src/utilities/eventUtils';
-import { Event } from '@linode/api-v4/lib/account';
+import { eventFactory } from 'src/factories';
 
 const inProgressMessage = 'this is an in-progress message.';
 const finishedMessage = 'this is a finished message';
 const createdTimestamp = '2018-12-02T20:23:43';
 const finishedTimestamp = '2018-12-02T20:24:43';
 
-const inProgressEvent: Event = {
-  id: 1234,
-  time_remaining: '30',
-  secondary_entity: null,
-  seen: true,
-  created: createdTimestamp,
-  action: 'linode_boot',
-  read: false,
-  percent_complete: 50,
-  username: null,
-  rate: null,
-  entity: {
-    id: 11440645,
-    label: 'linode11440645',
-    type: 'linode',
-    url: '/v4/linode/instances/11440645',
-  },
+const mockInProgressEvent = eventFactory.build({
   status: 'started',
-  duration: 30,
-  message: inProgressMessage,
-};
-
-const finishedEvent: Event = {
-  id: 1234,
-  time_remaining: null,
-  secondary_entity: null,
-  seen: true,
   created: createdTimestamp,
-  action: 'linode_boot',
-  read: false,
-  percent_complete: 100,
-  username: null,
-  rate: null,
-  entity: {
-    id: 11440645,
-    label: 'linode11440645',
-    type: 'linode',
-    url: '/v4/linode/instances/11440645',
-  },
+  duration: 0,
+});
+const mockFinishedEvent = eventFactory.build({
   status: 'finished',
   duration: 60,
-  message: finishedMessage,
-};
+  created: createdTimestamp,
+});
 
 const inProgressEventProps: RowProps = {
   action: 'linode_boot',
   message: inProgressMessage,
   type: 'linode',
   username: null,
-  timestamp: getEventTimestamp(inProgressEvent),
+  timestamp: getEventTimestamp(mockInProgressEvent),
 };
 
 const finishedEventProps: RowProps = {
@@ -66,7 +33,7 @@ const finishedEventProps: RowProps = {
   message: finishedMessage,
   type: 'linode',
   username: null,
-  timestamp: getEventTimestamp(finishedEvent),
+  timestamp: getEventTimestamp(mockFinishedEvent),
 };
 
 describe('EventRow component', () => {

--- a/packages/manager/src/features/Events/EventRow.tsx
+++ b/packages/manager/src/features/Events/EventRow.tsx
@@ -84,7 +84,7 @@ export interface RowProps {
 export const Row: React.FC<RowProps> = (props) => {
   const classes = useStyles();
 
-  const { action, message, username, timestamp } = props;
+  const { action, message, timestamp, username } = props;
 
   /** Some event types may not be handled by our system (or new types
    * may be added). Filter these out so we don't display blank messages to the user.

--- a/packages/manager/src/features/Events/EventRow.tsx
+++ b/packages/manager/src/features/Events/EventRow.tsx
@@ -11,11 +11,12 @@ import renderGuard, { RenderGuardProps } from 'src/components/RenderGuard';
 import { TableCell } from 'src/components/TableCell';
 import { TableRow } from 'src/components/TableRow';
 import eventMessageGenerator from 'src/eventMessageGenerator';
-import { parseAPIDate } from 'src/utilities/date';
 import { getEntityByIDFromStore } from 'src/utilities/getEntityByIDFromStore';
 import { getLinkForEvent } from 'src/utilities/getEventsActionLink';
 import { GravatarByUsername } from '../../components/GravatarByUsername';
 import { useApplicationStore } from 'src/store';
+import { getEventTimestamp } from 'src/utilities/eventUtils';
+import { DateTime } from 'luxon';
 
 const useStyles = makeStyles((theme: Theme) => ({
   row: {
@@ -48,6 +49,7 @@ export const EventRow: React.FC<CombinedProps> = (props) => {
   const type = pathOr<string>('linode', ['entity', 'type'], event);
   const id = pathOr<string | number>(-1, ['entity', 'id'], event);
   const entity = getEntityByIDFromStore(type, id, store);
+  const timestamp = getEventTimestamp(event);
 
   const rowProps = {
     action: event.action,
@@ -56,8 +58,8 @@ export const EventRow: React.FC<CombinedProps> = (props) => {
     message: eventMessageGenerator(event),
     status: pathOr(undefined, ['status'], entity),
     type,
-    created: event.created,
     username: event.username,
+    timestamp,
   };
 
   return <Row {...rowProps} data-qa-events-row={event.id} />;
@@ -75,14 +77,14 @@ export interface RowProps {
     | 'stackscript'
     | 'volume'
     | 'database';
-  created: string;
   username: string | null;
+  timestamp: DateTime;
 }
 
 export const Row: React.FC<RowProps> = (props) => {
   const classes = useStyles();
 
-  const { action, message, created, username } = props;
+  const { action, message, username, timestamp } = props;
 
   /** Some event types may not be handled by our system (or new types
    * may be added). Filter these out so we don't display blank messages to the user.
@@ -116,11 +118,11 @@ export const Row: React.FC<RowProps> = (props) => {
         />
       </TableCell>
       <TableCell parentColumn="Relative Date">
-        {parseAPIDate(created).toRelative()}
+        {timestamp.toRelative()}
       </TableCell>
       <Hidden mdDown>
         <TableCell parentColumn="Absolute Date" data-qa-event-created-cell>
-          <DateTimeDisplay value={created} />
+          <DateTimeDisplay value={timestamp.toString()} />
         </TableCell>
       </Hidden>
     </TableRow>

--- a/packages/manager/src/features/NotificationCenter/NotificationData/RenderEvent.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/RenderEvent.tsx
@@ -6,13 +6,13 @@ import HighlightedMarkdown from 'src/components/HighlightedMarkdown';
 import Typography from 'src/components/core/Typography';
 import useEventInfo from './useEventInfo';
 import { Event } from '@linode/api-v4/lib/account/types';
-import { parseAPIDate } from 'src/utilities/date';
 import {
   RenderEventGravatar,
   RenderEventStyledBox,
   useRenderEventStyles,
 } from './RenderEvent.styles';
 import { useApplicationStore } from 'src/store';
+import { getEventTimestamp } from 'src/utilities/eventUtils';
 
 interface RenderEventProps {
   event: Event;
@@ -44,7 +44,7 @@ export const RenderEvent = React.memo((props: RenderEventProps) => {
         <Box sx={{ marginTop: '-2px' }}>
           {eventMessage}
           <Typography className={unseenEventClass}>
-            {parseAPIDate(event.created).toRelative()}
+            {getEventTimestamp(event).toRelative()}
           </Typography>
         </Box>
       </RenderEventStyledBox>

--- a/packages/manager/src/utilities/eventUtils.test.ts
+++ b/packages/manager/src/utilities/eventUtils.test.ts
@@ -5,18 +5,18 @@ import { parseAPIDate } from './date';
 const createdTimestamp = '2023-06-06T20:23:43.000Z';
 const finishedTimestamp = '2023-06-06T20:24:43.000Z';
 const mockInProgressEvent = eventFactory.build({
-  status: 'started',
   created: createdTimestamp,
   duration: 0,
+  status: 'started',
 });
 const mockFinishedEvent1 = eventFactory.build({
-  status: 'finished',
-  duration: 60,
   created: createdTimestamp,
+  duration: 60,
+  status: 'finished',
 });
 const mockFinishedEvent2 = eventFactory.build({
-  status: 'finished',
   created: createdTimestamp,
+  status: 'finished',
 });
 
 describe('getEventTimestamp utility function', () => {

--- a/packages/manager/src/utilities/eventUtils.test.ts
+++ b/packages/manager/src/utilities/eventUtils.test.ts
@@ -4,24 +4,24 @@ import { parseAPIDate } from './date';
 
 const createdTimestamp = '2023-06-06T20:23:43.000Z';
 const finishedTimestamp = '2023-06-06T20:24:43.000Z';
-const mockScheduledEvent = eventFactory.build({
-  status: 'scheduled',
-  created: createdTimestamp,
-});
 const mockInProgressEvent = eventFactory.build({
   status: 'started',
   created: createdTimestamp,
   duration: 0,
 });
-const mockFinishedEvent = eventFactory.build({
+const mockFinishedEvent1 = eventFactory.build({
   status: 'finished',
   duration: 60,
+  created: createdTimestamp,
+});
+const mockFinishedEvent2 = eventFactory.build({
+  status: 'finished',
   created: createdTimestamp,
 });
 
 describe('getEventTimestamp utility function', () => {
   it('calculates the finished event timestamp from the created event timestamp by adding the duration', () => {
-    expect(getEventTimestamp(mockFinishedEvent)).toEqual(
+    expect(getEventTimestamp(mockFinishedEvent1)).toEqual(
       parseAPIDate(finishedTimestamp)
     );
   });
@@ -30,8 +30,8 @@ describe('getEventTimestamp utility function', () => {
       parseAPIDate(createdTimestamp)
     );
   });
-  it('uses the created event timestamp for an event without a duration', () => {
-    expect(getEventTimestamp(mockScheduledEvent)).toEqual(
+  it('uses the created event timestamp for a finished event without a duration', () => {
+    expect(getEventTimestamp(mockFinishedEvent2)).toEqual(
       parseAPIDate(createdTimestamp)
     );
   });

--- a/packages/manager/src/utilities/eventUtils.test.ts
+++ b/packages/manager/src/utilities/eventUtils.test.ts
@@ -1,0 +1,38 @@
+import { eventFactory } from 'src/factories';
+import { getEventTimestamp } from './eventUtils';
+import { parseAPIDate } from './date';
+
+const createdTimestamp = '2023-06-06T20:23:43.000Z';
+const finishedTimestamp = '2023-06-06T20:24:43.000Z';
+const mockScheduledEvent = eventFactory.build({
+  status: 'scheduled',
+  created: createdTimestamp,
+});
+const mockInProgressEvent = eventFactory.build({
+  status: 'started',
+  created: createdTimestamp,
+  duration: 0,
+});
+const mockFinishedEvent = eventFactory.build({
+  status: 'finished',
+  duration: 60,
+  created: createdTimestamp,
+});
+
+describe('getEventTimestamp utility function', () => {
+  it('calculates the finished event timestamp from the created event timestamp by adding the duration', () => {
+    expect(getEventTimestamp(mockFinishedEvent)).toEqual(
+      parseAPIDate(finishedTimestamp)
+    );
+  });
+  it('uses the created event timestamp for an in-progress event', () => {
+    expect(getEventTimestamp(mockInProgressEvent)).toEqual(
+      parseAPIDate(createdTimestamp)
+    );
+  });
+  it('uses the created event timestamp for an event without a duration', () => {
+    expect(getEventTimestamp(mockScheduledEvent)).toEqual(
+      parseAPIDate(createdTimestamp)
+    );
+  });
+});

--- a/packages/manager/src/utilities/eventUtils.ts
+++ b/packages/manager/src/utilities/eventUtils.ts
@@ -1,4 +1,14 @@
 import { Event, EventAction } from '@linode/api-v4/lib/account';
+import { DateTime } from 'luxon';
+import { parseAPIDate } from './date';
+
+// Calculates the finished event timestamp from the created event timestamp by adding the duration;
+// if the event is not finished, uses the created event timestamp.
+export const getEventTimestamp = (event: Event): DateTime => {
+  return event.status === 'finished' && event?.duration
+    ? parseAPIDate(event.created).plus({ seconds: event.duration })
+    : parseAPIDate(event.created);
+};
 
 // Removes events we don't want to display.
 export const removeBlocklistedEvents = (

--- a/packages/manager/src/utilities/eventUtils.ts
+++ b/packages/manager/src/utilities/eventUtils.ts
@@ -2,10 +2,11 @@ import { Event, EventAction } from '@linode/api-v4/lib/account';
 import { DateTime } from 'luxon';
 import { parseAPIDate } from './date';
 
-// Calculates the finished event timestamp from the created event timestamp by adding the duration;
-// if the event is not finished, uses the created event timestamp.
+// Calculates the finished (or failed) event timestamp from the created event timestamp by adding the duration;
+// if the event is not finished or has not failed, uses the created event timestamp.
 export const getEventTimestamp = (event: Event): DateTime => {
-  return event?.status === 'finished' && event?.duration
+  return (event?.status === 'finished' || event?.status === 'failed') &&
+    event?.duration
     ? parseAPIDate(event.created).plus({ seconds: event.duration })
     : parseAPIDate(event.created);
 };

--- a/packages/manager/src/utilities/eventUtils.ts
+++ b/packages/manager/src/utilities/eventUtils.ts
@@ -5,7 +5,7 @@ import { parseAPIDate } from './date';
 // Calculates the finished event timestamp from the created event timestamp by adding the duration;
 // if the event is not finished, uses the created event timestamp.
 export const getEventTimestamp = (event: Event): DateTime => {
-  return event.status === 'finished' && event?.duration
+  return event?.status === 'finished' && event?.duration
     ? parseAPIDate(event.created).plus({ seconds: event.duration })
     : parseAPIDate(event.created);
 };


### PR DESCRIPTION
## Description 📝
The original ask was to show an accurate completion timestamp for a Backup Restore event in the Activity Feed. Currently, these events show the created timestamp, even when the event has completed. The time between a backup restore starting and completing is most noticeable for a large linode (over 10 GB) and the inaccurate information can be misleading and confusing to users.

Because we always displayed the `created` timestamp and had no method of calculating or updating it for completed events, other events that take some time to complete (e.g. a linode migration) also had inaccurate timestamps. API does not return a completed timestamp, but it does return an event `duration` (the total duration in seconds that it takes for the Event to complete).

This PR fixes that by adding a util function to update the timestamp based on the duration of a finished event. It does the same thing for a failed event with a duration in order to more accurately reflect the content of the event message. 

## Major Changes 🔄
**List highlighting major changes**
- In the notification menu, events landing page, and activity feed, the relative and absolute timestamps for `finished` and `failed` events now reflects the time of completion (or failure) rather than the time of event creation.

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-06-07 at 1 33 50 PM](https://github.com/linode/manager/assets/114685994/d575ac68-f9a6-40a0-91cb-c1ab18d5a2ac) | ![Screenshot 2023-06-07 at 1 32 14 PM](https://github.com/linode/manager/assets/114685994/1c2ad26e-6f76-4616-a00d-904a73e66e67) |

## How to test 🧪

1. **How to reproduce the issue (if applicable)?**
   -   These are the original steps reported on the M3 ticket to see the issue:
         - Create linode, enable backups and take backup snapshot
         - Deploy from existing snapshot overwriting existing linode
         - Take note of the message shown in the event activity ("Backup restoration completed for" ...), specifically, take note of the time-stamp from Cloud Manager.
         - Verify start end job time-stamp in the Linode jobs queue from admin (I didn't actually do this - looked at the API response for events endpoint instead)
         - Note: this is more noticeable for larger backups. backups under 10gb the duration discrepancy is not so noticeable
    -   Another way to test this is by kicking off a linode migration:
        - Start a migration and note both the relative and absolute timestamps of the migration event on the events landing page.
        - Wait about until the migration completes (usually ~10 minutes for a cross-country migration of a nanode, just from anecdotal observation).
        - Use the Network tab of the browser dev tools to filter requests by "events" and find the last request that returned your event's data. Note the `created` timestamp is the same as the absolute timestamp on events landing, even though the event message has changed to reflect that the event has completed.
2. **How to verify changes?**
   - Repeat the above to check the accuracy of the timestamp for either a completed backup restore event or migration event.
   -  Use the Network tab of the browser dev tools to filter requests by "events" and find the last request that returned your event's data. Note the `created` timestamp and the `duration` in seconds. Verify this math looks correct for the completed timestamps you see for the event. 
   - Optionally, if you want to test failed events, follow the steps in #9184 to kick off a image creation event that will fail after 1-2 minutes. You should also see the updated timestamp for the time of the failure, not the creation. 

3. **How to run Unit or E2E tests?**
```
yarn test EventRow eventUtils
```
