### PR TITLE
build: Ignore file casing in tsconfig

### DIFF
--- a/packages/manager/tsconfig.json
+++ b/packages/manager/tsconfig.json
@@ -34,6 +34,7 @@
     "noUnusedLocals": true,
     "strictNullChecks": true,
     "suppressImplicitAnyIndexErrors": true,
+    "forceConsistentCasingInFileNames": false,
 
     /* Completeness */
     "skipLibCheck": true,


### PR DESCRIPTION
## Description 📝
We recently renamed some files which caused TS to throw false positive errors. This PR adds an option to the tsconfig file to ignore file casing.

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-06-06 at 4 11 31 PM](https://github.com/linode/manager/assets/115299789/f22b86e1-f10c-49c3-9f70-3d86b97b6185) | ![Screenshot 2023-06-06 at 4 11 43 PM](https://github.com/linode/manager/assets/115299789/a0ee25ab-44ed-40fc-803f-ac989e067455) |

## How to test 🧪
Run `yarn up` and you should not see any TS errors about file names