### PR TITLE
Fix: [M3-6036] Ensure ActionMenu item valueText tag gets updated on resize

### DIFF
--- a/packages/manager/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/manager/src/components/ActionMenu/ActionMenu.tsx
@@ -168,6 +168,7 @@ const ActionMenu = (props: Props) => {
               }}
               data-qa-action-menu-item={a.title}
               disabled={a.disabled}
+              valueText={a.title}
             >
               {a.title}
               {a.tooltip ? (


### PR DESCRIPTION
## Description 📝
When we resize the browser, the ActionMenu items get modified as the three first ones get either displayed in the bar (desktop) or in the ActionMenu itself (mobile).

While all visible data gets updated in the menu, the `data-valuetext` tag was not updating to reflect the proper value, which could cause flakiness when relying on them for E2E tests.

This PR adds the `valueText` prop to the menu item so it's always updating on resize.

Note: this isn't at all customer impacting or a fix necessitating a changeset


## How to test 🧪
Comparing production and local code:
1. Go to linode detail on desktop
2. Open the action menu and inspect the first item
3. Keep menu open and resize browser till items are shuffled
4. Confirm fix on the `data-valuetext` tag for each menu item