### PR TITLE
refactor: [M3-6490] - React Query - Linode Storage - Finish Volumes

### DIFF
--- a/packages/manager/.changeset/pr-9218-tech-stories-1686268120191.md
+++ b/packages/manager/.changeset/pr-9218-tech-stories-1686268120191.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+React Query - Linode Volumes continued ([#9218](https://github.com/linode/manager/pull/9218))

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeAdvanced/LinodeVolumes.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeAdvanced/LinodeVolumes.tsx
@@ -1,32 +1,32 @@
 import * as React from 'react';
-import { connect } from 'react-redux';
-import { compose } from 'recompose';
-import { bindActionCreators, Dispatch } from 'redux';
 import AddNewLink from 'src/components/AddNewLink';
 import Hidden from 'src/components/core/Hidden';
+import Typography from 'src/components/core/Typography';
+import Grid from '@mui/material/Unstable_Grid2';
+import TableRowEmptyState from 'src/components/TableRowEmptyState/TableRowEmptyState';
+import TableRowError from 'src/components/TableRowError/TableRowError';
+import { connect } from 'react-redux';
+import { bindActionCreators, Dispatch } from 'redux';
 import { makeStyles } from '@mui/styles';
 import { Theme } from '@mui/material/styles';
 import { TableBody } from 'src/components/TableBody';
 import { TableHead } from 'src/components/TableHead';
-import Typography from 'src/components/core/Typography';
-import Grid from '@mui/material/Unstable_Grid2';
 import { PaginationFooter } from 'src/components/PaginationFooter/PaginationFooter';
 import { Table } from 'src/components/Table';
 import { TableCell } from 'src/components/TableCell';
 import { TableRow } from 'src/components/TableRow';
-import TableRowEmptyState from 'src/components/TableRowEmptyState/TableRowEmptyState';
-import TableRowError from 'src/components/TableRowError/TableRowError';
 import { TableRowLoading } from 'src/components/TableRowLoading/TableRowLoading';
 import { TableSortCell } from 'src/components/TableSortCell';
-import { withLinodeDetailContext } from 'src/features/Linodes/LinodesDetail/linodeDetailContext';
 import { DestructiveVolumeDialog } from 'src/features/Volumes/DestructiveVolumeDialog';
 import { VolumeAttachmentDrawer } from 'src/features/Volumes/VolumeAttachmentDrawer';
 import { ActionHandlers as VolumeHandlers } from 'src/features/Volumes/VolumesActionMenu';
-import VolumeTableRow from 'src/features/Volumes/VolumeTableRow';
+import { VolumeTableRow } from 'src/features/Volumes/VolumeTableRow';
 import { useOrder } from 'src/hooks/useOrder';
 import { usePagination } from 'src/hooks/usePagination';
 import { useRegionsQuery } from 'src/queries/regions';
 import { useLinodeVolumesQuery } from 'src/queries/volumes';
+import { useParams } from 'react-router-dom';
+import { useLinodeQuery } from 'src/queries/linodes/linodes';
 import {
   LinodeOptions,
   openForClone,
@@ -87,21 +87,23 @@ interface DispatchProps {
   openForConfig: (volumeLabel: string, volumePath: string) => void;
 }
 
-type CombinedProps = LinodeContextProps & DispatchProps;
+type Props = DispatchProps;
 
 export const preferenceKey = 'linode-volumes';
 
-export const LinodeVolumes: React.FC<CombinedProps> = (props) => {
+export const LinodeVolumes = (props: Props) => {
   const {
     openForConfig,
     openForClone,
     openForEdit,
     openForResize,
     openForCreating,
-    linodeId,
-    linodeLabel,
-    linodeRegion,
   } = props;
+
+  const { linodeId } = useParams<{ linodeId: string }>();
+  const id = Number(linodeId);
+
+  const { data: linode } = useLinodeQuery(id);
 
   const { order, orderBy, handleOrderChange } = useOrder(
     {
@@ -121,8 +123,9 @@ export const LinodeVolumes: React.FC<CombinedProps> = (props) => {
   const classes = useStyles();
 
   const regions = useRegionsQuery().data ?? [];
+
   const { data, isLoading, error } = useLinodeVolumesQuery(
-    linodeId ?? 0,
+    id,
     {
       page: pagination.page,
       page_size: pagination.pageSize,
@@ -208,20 +211,18 @@ export const LinodeVolumes: React.FC<CombinedProps> = (props) => {
   const openCreateVolumeDrawer = (e: any) => {
     e.preventDefault();
 
-    if (linodeId && linodeLabel && linodeRegion) {
+    if (linode) {
       return openForCreating('Created from Linode Details', {
-        linodeId,
-        linodeLabel,
-        linodeRegion,
+        linodeId: linode.id,
+        linodeLabel: linode.label,
+        linodeRegion: linode.region,
       });
     }
   };
 
-  const currentRegion = regions.find(
-    (thisRegion) => thisRegion.id === linodeRegion
-  );
+  const region = regions.find((thisRegion) => thisRegion.id === linode?.region);
 
-  if (!currentRegion || !currentRegion.capabilities.includes('Block Storage')) {
+  if (!region?.capabilities.includes('Block Storage')) {
     return null;
   }
 
@@ -342,7 +343,7 @@ export const LinodeVolumes: React.FC<CombinedProps> = (props) => {
         open={destructiveDialog.open}
         volumeLabel={destructiveDialog.volumeLabel}
         linodeLabel={destructiveDialog.linodeLabel}
-        linodeId={linodeId ?? 0}
+        linodeId={id}
         volumeId={destructiveDialog.volumeId ?? 0}
         mode={destructiveDialog.mode}
         onClose={closeDestructiveDialog}
@@ -363,25 +364,6 @@ const mapDispatchToProps = (dispatch: Dispatch) =>
     dispatch
   );
 
-interface LinodeContextProps {
-  linodeId?: number;
-  linodeStatus?: string;
-  linodeLabel?: string;
-  linodeRegion?: string;
-  readOnly: boolean;
-}
-
-const linodeContext = withLinodeDetailContext(({ linode }) => ({
-  linodeId: linode.id,
-  linodeStatus: linode.status,
-  linodeLabel: linode.label,
-  linodeRegion: linode.region,
-  readOnly: linode._permissions === 'read_only',
-}));
-
 const connected = connect(undefined, mapDispatchToProps);
 
-export default compose<CombinedProps, {}>(
-  connected,
-  linodeContext
-)(LinodeVolumes);
+export default connected(LinodeVolumes);

--- a/packages/manager/src/features/Volumes/VolumeTableRow.tsx
+++ b/packages/manager/src/features/Volumes/VolumeTableRow.tsx
@@ -62,7 +62,7 @@ export const volumeStatusIconMap: Record<Volume['status'], Status> = {
   offline: 'inactive',
 };
 
-export const VolumeTableRow = (props: CombinedProps) => {
+export const VolumeTableRow = React.memo((props: CombinedProps) => {
   const classes = useStyles();
   const { data: regions } = useRegionsQuery();
   const {
@@ -171,6 +171,4 @@ export const VolumeTableRow = (props: CombinedProps) => {
       </TableCell>
     </TableRow>
   );
-};
-
-export default React.memo(VolumeTableRow);
+});

--- a/packages/manager/src/features/Volumes/VolumesActionMenu.tsx
+++ b/packages/manager/src/features/Volumes/VolumesActionMenu.tsx
@@ -147,7 +147,7 @@ export const VolumesActionMenu = (props: Props) => {
     disabled: !isVolumesLanding,
     tooltip: isVolumesLanding
       ? undefined
-      : 'This volume must be detched before it can be deleted.',
+      : 'This volume must be detached before it can be deleted.',
   });
 
   const splitActionsArrayIndex = matchesSmDown ? 0 : 2;

--- a/packages/manager/src/features/Volumes/VolumesActionMenu.tsx
+++ b/packages/manager/src/features/Volumes/VolumesActionMenu.tsx
@@ -144,10 +144,10 @@ export const VolumesActionMenu = (props: Props) => {
     onClick: () => {
       handleDelete();
     },
-    disabled: !isVolumesLanding,
-    tooltip: isVolumesLanding
-      ? undefined
-      : 'This volume must be detached before it can be deleted.',
+    disabled: attached,
+    tooltip: attached
+      ? 'Your volume must be detached before it can be deleted.'
+      : undefined,
   });
 
   const splitActionsArrayIndex = matchesSmDown ? 0 : 2;

--- a/packages/manager/src/features/Volumes/VolumesActionMenu.tsx
+++ b/packages/manager/src/features/Volumes/VolumesActionMenu.tsx
@@ -144,6 +144,10 @@ export const VolumesActionMenu = (props: Props) => {
     onClick: () => {
       handleDelete();
     },
+    disabled: !isVolumesLanding,
+    tooltip: isVolumesLanding
+      ? undefined
+      : 'This volume must be detched before it can be deleted.',
   });
 
   const splitActionsArrayIndex = matchesSmDown ? 0 : 2;

--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -34,7 +34,7 @@ import { UpgradeVolumeDialog } from './UpgradeVolumeDialog';
 import { VolumeAttachmentDrawer } from './VolumeAttachmentDrawer';
 import { ActionHandlers as VolumeHandlers } from './VolumesActionMenu';
 import { VolumesLandingEmptyState } from './VolumesLandingEmptyState';
-import VolumeTableRow from './VolumeTableRow';
+import { VolumeTableRow } from './VolumeTableRow';
 
 interface Props {
   isVolumesLanding?: boolean;


### PR DESCRIPTION
## Description 📝

- Finishes up React Query for Linode Storage - Volumes
  - Linode Volumes have already been React Query-ifyed but we never removed the crazy `withLinodeDetailContext` part of it

## Preview 📷
![Screenshot 2023-06-06 at 4 52 50 PM](https://github.com/linode/manager/assets/115251059/ea379067-ab18-4ee3-bc29-5208f4f5edd5)


## How to test 🧪
- Check the volumes table on `http://localhost:3000/linodes/{id}/storage` for any issues
  - Check basic operations like creating a volume and deleting a volume from this view