### PR TITLE
fix: [M3-6071] - Use final URL for link to Backups pricing page

### DIFF
--- a/packages/manager/src/features/Account/AutoBackups.tsx
+++ b/packages/manager/src/features/Account/AutoBackups.tsx
@@ -61,7 +61,7 @@ const AutoBackups = (props: Props) => {
             rate noted on the&nbsp;
             <a
               data-qa-backups-price
-              href="https://linode.com/backups"
+              href="https://www.linode.com/products/backups/"
               target="_blank"
               aria-describedby="external-site"
               rel="noopener noreferrer"

--- a/packages/manager/src/features/Backups/AutoEnroll.tsx
+++ b/packages/manager/src/features/Backups/AutoEnroll.tsx
@@ -61,7 +61,7 @@ export const AutoEnroll: React.FC<CombinedProps> = (props) => {
               <ExternalLink
                 data-qa-backups-price
                 fixedIcon
-                link="https://www.linode.com/backups"
+                link="https://www.linode.com/products/backups/"
                 text="Backups pricing page"
               />
             </Typography>


### PR DESCRIPTION
## Description 📝
In the past, the "Backup pricing page" URL on the Accounts page could result in a broken link for some customers when Google Analytics were attached to the parameter for cross-domain tracking. For example, the URL becomes `https://linode.com/backups?_gl=<something>` and `https://linode.com/backups` needed to be redirected to `https://www.linode.com/products/backups/`. A workaround with regex pattern matching was added on the backend when this issue came up to fix the broken redirect link.

Long-term: we should still fix this URL in Cloud because it is best practice to link to the final URL directly, rather than the URL that will be redirected.

## Major Changes 🔄
- Updated URL from `https://www.linode.com/backups` (or `https://linode.com/backups`) to `https://www.linode.com/products/backups/` 

## Preview 📷
![image](https://github.com/linode/manager/assets/114685994/257ba476-2eb1-4806-bad1-47316746293d)
![image](https://github.com/linode/manager/assets/114685994/a194d6e4-abc8-422e-86c3-8bddaee5e77f)


## How to test 🧪
1. **How to reproduce the issue (if applicable)?**
   -   Go to https://cloud.linode.com/account/settings.
   -   In the Backups Auto Enrollment section, hover the text "Backups pricing page" to see the URL.
   -   Note that it is something like the following: 
![image](https://github.com/linode/manager/assets/114685994/88b76e51-b2ae-4a34-a8ad-d5df974e76d5)
   -   Click the "Enable now" link to open the Enable All Backups drawer and repeat the same process as above to note the url for the "Backups pricing page" link.
   - Click either "Backups pricing page" link and note that when you are redirected, the final URL of the page begins with `https://www.linode.com/products/backups/`.

2. **How to verify changes?**
   -   Go to https://localhost:3000/account/settings.
   -   In the Backups Auto Enrollment section, hover the text "Backups pricing page" to see the URL.
   -   Click the "Enable now" link to open the Enable All Backups drawer and repeat the same process as above to note the url for the "Backups pricing page" link.
   -   Note that both URLs are now linking directly to: 
![Screenshot 2023-06-06 at 2 47 53 PM](https://github.com/linode/manager/assets/114685994/3f8942af-80dc-438a-8d75-09f654426cc4)

