### PR TITLE
feat: [M3-6674] - Add kubernetes product information banner

### DIFF
--- a/packages/manager/.changeset/pr-9226-added-1686168141780.md
+++ b/packages/manager/.changeset/pr-9226-added-1686168141780.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Add kubernetes product information banner ([#9226](https://github.com/linode/manager/pull/9226))

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -113,7 +113,20 @@ interface ReferralBannerText {
   };
 }
 
-export type ProductInformationBannerLocation = 'Object Storage' | 'Databases';
+export type ProductInformationBannerLocation =
+  | 'Account'
+  | 'Databases'
+  | 'Domains'
+  | 'Firewalls'
+  | 'Images'
+  | 'Kubernetes'
+  | 'Linodes'
+  | 'Managed'
+  | 'Marketplace'
+  | 'NodeBalancers'
+  | 'Object Storage'
+  | 'StackScripts'
+  | 'Volumes';
 
 export interface ProductInformationBannerFlag {
   // `key` should be unique across product information banners

--- a/packages/manager/src/features/GlobalNotifications/APIMaintenanceBanner.tsx
+++ b/packages/manager/src/features/GlobalNotifications/APIMaintenanceBanner.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import Box from 'src/components/core/Box';
 import Typography from 'src/components/core/Typography';
 import DismissibleBanner from 'src/components/DismissibleBanner';
 import Link from 'src/components/Link';
@@ -66,7 +67,7 @@ export const APIMaintenanceBanner: React.FC<Props> = (props) => {
         preferenceKey={scheduledAPIMaintenance.id}
         key={scheduledAPIMaintenance.id}
       >
-        <>
+        <Box display="flex" flexDirection="column">
           <Typography data-testid="scheduled-maintenance-banner">
             <Link to={scheduledAPIMaintenance.shortlink}>
               <strong data-testid="scheduled-maintenance-status">
@@ -77,7 +78,7 @@ export const APIMaintenanceBanner: React.FC<Props> = (props) => {
           <Typography
             dangerouslySetInnerHTML={{ __html: sanitizeHTML(bannerBody) }}
           />
-        </>
+        </Box>
       </DismissibleBanner>
     );
   };

--- a/packages/manager/src/features/GlobalNotifications/APIMaintenanceBanner.tsx
+++ b/packages/manager/src/features/GlobalNotifications/APIMaintenanceBanner.tsx
@@ -67,7 +67,7 @@ export const APIMaintenanceBanner: React.FC<Props> = (props) => {
         preferenceKey={scheduledAPIMaintenance.id}
         key={scheduledAPIMaintenance.id}
       >
-        <Box display="flex" flexDirection="column">
+        <Stack>
           <Typography data-testid="scheduled-maintenance-banner">
             <Link to={scheduledAPIMaintenance.shortlink}>
               <strong data-testid="scheduled-maintenance-status">

--- a/packages/manager/src/features/GlobalNotifications/APIMaintenanceBanner.tsx
+++ b/packages/manager/src/features/GlobalNotifications/APIMaintenanceBanner.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Box from 'src/components/core/Box';
+import Stack from '@mui/material/Stack';
 import Typography from 'src/components/core/Typography';
 import DismissibleBanner from 'src/components/DismissibleBanner';
 import Link from 'src/components/Link';
@@ -78,7 +78,7 @@ export const APIMaintenanceBanner: React.FC<Props> = (props) => {
           <Typography
             dangerouslySetInnerHTML={{ __html: sanitizeHTML(bannerBody) }}
           />
-        </Box>
+        </Stack>
       </DismissibleBanner>
     );
   };

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -36,6 +36,7 @@ import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import KubeCheckoutBar from '../KubeCheckoutBar';
 import NodePoolPanel from './NodePoolPanel';
 import LandingHeader from 'src/components/LandingHeader';
+import ProductInformationBanner from 'src/components/ProductInformationBanner';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -245,6 +246,7 @@ export const CreateCluster = () => {
   return (
     <Grid container className={classes.root}>
       <DocumentTitleSegment segment="Create a Kubernetes Cluster" />
+      <ProductInformationBanner bannerLocation="Kubernetes" warning important />
       <LandingHeader
         title="Create Cluster"
         docsLabel="Docs"

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -16,6 +16,7 @@ import { NodePoolsDisplay } from './NodePoolsDisplay/NodePoolsDisplay';
 import { UpgradeKubernetesClusterToHADialog } from './UpgradeClusterDialog';
 import UpgradeKubernetesVersionBanner from './UpgradeKubernetesVersionBanner';
 import LandingHeader from 'src/components/LandingHeader';
+import ProductInformationBanner from 'src/components/ProductInformationBanner';
 
 export const KubernetesClusterDetail = () => {
   const { data: account } = useAccount();
@@ -73,6 +74,7 @@ export const KubernetesClusterDetail = () => {
   return (
     <>
       <DocumentTitleSegment segment={`Kubernetes Cluster ${cluster?.label}`} />
+      <ProductInformationBanner bannerLocation="Kubernetes" warning important />
       <Grid>
         <UpgradeKubernetesVersionBanner
           clusterID={cluster?.id}

--- a/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLanding.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLanding.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { ErrorState } from 'src/components/ErrorState/ErrorState';
 import Hidden from 'src/components/core/Hidden';
 import LandingHeader from 'src/components/LandingHeader';
+import ProductInformationBanner from 'src/components/ProductInformationBanner';
 import { TransferDisplay } from 'src/components/TransferDisplay/TransferDisplay';
 import UpgradeVersionModal from '../UpgradeVersionModal';
 import { CircleProgress } from 'src/components/CircleProgress';
@@ -148,6 +149,7 @@ export const KubernetesLanding = () => {
   return (
     <>
       <DocumentTitleSegment segment="Kubernetes Clusters" />
+      <ProductInformationBanner bannerLocation="Kubernetes" warning important />
       <LandingHeader
         title="Kubernetes"
         docsLink="https://www.linode.com/docs/kubernetes/deploy-and-manage-a-cluster-with-linode-kubernetes-engine-a-tutorial/"


### PR DESCRIPTION
## Description 📝
We needed to add product information banners on Kubernetes pages for upcoming maintenance.

## Major Changes 🔄
- fix: Fixed banner regression
- feat: Updated banner types
- feat: Added banner to landing, detail, and create pages

> **Note**: You will see two banners on the LKE pages since we're currently using `apiMaintenance` flag to serve the banner for now.

## Preview 📷
![Screen Shot 2023-06-07 at 3 59 24 PM](https://github.com/linode/manager/assets/125309814/69e4aa09-0c5e-4a1c-a916-db4a769e7080)

| Before      | After |
| ----------- | ----------- |
|![Screen Shot 2023-06-07 at 4 11 58 PM](https://github.com/linode/manager/assets/125309814/cea05e78-d283-4e1d-9471-ab6723925b7b)|![Screen Shot 2023-06-07 at 4 13 58 PM](https://github.com/linode/manager/assets/125309814/57cb785f-7a88-4914-8b5c-d39f5f3b4c06)|

## How to test 🧪
1. Confirm you see banners when going to http://localhost:3000/kubernetes/clusters