### PR TITLE
Refactor: [M3-6619]: HelpLanding: remove icon and MUI refactor

### DIFF
--- a/packages/manager/.changeset/pr-9230-tech-stories-1686242146063.md
+++ b/packages/manager/.changeset/pr-9230-tech-stories-1686242146063.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Help Landing: remove banner icon and refactor class components  ([#9230](https://github.com/linode/manager/pull/9230))

--- a/packages/manager/src/features/Help/HelpLanding.test.tsx
+++ b/packages/manager/src/features/Help/HelpLanding.test.tsx
@@ -4,13 +4,7 @@ import * as React from 'react';
 import { HelpLanding } from './HelpLanding';
 
 describe('Help Landing', () => {
-  const component = shallow(
-    <HelpLanding
-      classes={{
-        root: '',
-      }}
-    />
-  );
+  const component = shallow(<HelpLanding />);
   xit('should render search panel', () => {
     expect(component.find('WithStyles(SearchPanel)')).toHaveLength(1);
   });

--- a/packages/manager/src/features/Help/HelpLanding.tsx
+++ b/packages/manager/src/features/Help/HelpLanding.tsx
@@ -1,39 +1,25 @@
 import * as React from 'react';
-import { createStyles, withStyles, WithStyles } from '@mui/styles';
-import { Theme } from '@mui/material/styles';
-import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import OtherWays from './Panels/OtherWays';
 import PopularPosts from './Panels/PopularPosts';
-import SearchPanel from './Panels/SearchPanel';
+import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import { SearchPanel } from './Panels/SearchPanel';
+import { styled } from '@mui/material/styles';
 
-type ClassNames = 'root';
+export const HelpLanding = () => {
+  return (
+    <StyledRootContainer>
+      <DocumentTitleSegment segment="Get Help" />
+      <SearchPanel />
+      <PopularPosts />
+      <OtherWays />
+    </StyledRootContainer>
+  );
+};
 
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {
-      [theme.breakpoints.up('lg')]: {
-        padding: `${theme.spacing(2)} ${theme.spacing(14)}`,
-      },
-    },
-  });
-
-type CombinedProps = WithStyles<ClassNames>;
-
-export class HelpLanding extends React.Component<CombinedProps, {}> {
-  render(): JSX.Element {
-    const { classes } = this.props;
-
-    return (
-      <div className={classes.root}>
-        <DocumentTitleSegment segment="Get Help" />
-        <SearchPanel />
-        <PopularPosts />
-        <OtherWays />
-      </div>
-    );
-  }
-}
-
-const styled = withStyles(styles);
-
-export default styled(HelpLanding);
+const StyledRootContainer = styled('div', {
+  label: 'StyledRootContainer',
+})(({ theme }) => ({
+  [theme.breakpoints.up('lg')]: {
+    padding: `${theme.spacing(2)} ${theme.spacing(14)}`,
+  },
+}));

--- a/packages/manager/src/features/Help/Panels/AlgoliaSearchBar.tsx
+++ b/packages/manager/src/features/Help/Panels/AlgoliaSearchBar.tsx
@@ -16,7 +16,8 @@ type ClassNames =
   | 'root'
   | 'searchIcon'
   | 'searchItem'
-  | 'enhancedSelectWrapper';
+  | 'enhancedSelectWrapper'
+  | 'notice';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -55,6 +56,12 @@ const styles = (theme: Theme) =>
       },
       [theme.breakpoints.up('md')]: {
         width: 500,
+      },
+    },
+    notice: {
+      '& p': {
+        color: theme.color.white,
+        fontFamily: 'LatoWeb',
       },
     },
   });
@@ -147,7 +154,7 @@ class AlgoliaSearchBar extends React.Component<CombinedProps, State> {
     return (
       <React.Fragment>
         {searchError && (
-          <Notice error spacingTop={8} spacingBottom={0}>
+          <Notice error spacingTop={8} className={classes.notice}>
             {searchError}
           </Notice>
         )}

--- a/packages/manager/src/features/Help/Panels/SearchPanel.tsx
+++ b/packages/manager/src/features/Help/Panels/SearchPanel.tsx
@@ -1,74 +1,42 @@
 import * as React from 'react';
-import LinodeIcon from 'src/assets/addnewmenu/linode.svg';
-import Paper from 'src/components/core/Paper';
-import { createStyles, withStyles, WithStyles, WithTheme } from '@mui/styles';
-import { Theme } from '@mui/material/styles';
-import { H1Header } from 'src/components/H1Header/H1Header';
 import AlgoliaSearchBar from './AlgoliaSearchBar';
+import Paper from 'src/components/core/Paper';
+import { H1Header } from 'src/components/H1Header/H1Header';
+import { styled } from '@mui/material/styles';
 
-type ClassNames = 'root' | 'bgIcon' | 'searchHeading';
+export const SearchPanel = () => {
+  return (
+    <StyledRootContainer>
+      <StyledH1Header
+        title="What can we help you with?"
+        data-qa-search-heading
+      />
+      <AlgoliaSearchBar />
+    </StyledRootContainer>
+  );
+};
 
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {
-      padding: theme.spacing(4),
-      backgroundColor: theme.color.green,
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'center',
-      justifyContent: 'center',
-      position: 'relative',
-      [theme.breakpoints.up('md')]: {
-        padding: theme.spacing(8),
-      },
-    },
-    bgIcon: {
-      color: '#04994D',
-      position: 'absolute',
-      left: 0,
-      width: 250,
-      height: 250,
-      '& .circle': {
-        fill: 'transparent',
-      },
-      '& .outerCircle': {
-        stroke: 'transparent',
-      },
-      '& .insidePath path': {
-        stroke: '#04994D',
-      },
-      [theme.breakpoints.down('sm')]: {
-        display: 'none',
-      },
-    },
-    searchHeading: {
-      textAlign: 'center',
-      color: theme.color.white,
-      position: 'relative',
-      zIndex: 2,
-    },
-  });
+const StyledRootContainer = styled(Paper, {
+  label: 'StyledRootContainer',
+})(({ theme }) => ({
+  alignItems: 'center',
+  backgroundColor: theme.color.green,
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  padding: theme.spacing(4),
+  position: 'relative',
+  [theme.breakpoints.up('md')]: {
+    padding: theme.spacing(8),
+  },
+}));
 
-type CombinedProps = WithStyles<ClassNames> & WithTheme;
-
-class SearchPanel extends React.Component<CombinedProps, {}> {
-  render() {
-    const { classes } = this.props;
-
-    return (
-      <Paper className={classes.root}>
-        <LinodeIcon className={classes.bgIcon} />
-        <H1Header
-          title="What can we help you with?"
-          className={classes.searchHeading}
-          data-qa-search-heading
-        />
-        <AlgoliaSearchBar />
-      </Paper>
-    );
-  }
-}
-
-const styled = withStyles(styles, { withTheme: true });
-
-export default styled(SearchPanel);
+const StyledH1Header = styled(H1Header, {
+  label: 'StyledH1Header',
+})(({ theme }) => ({
+  color: theme.color.white,
+  marginBottom: theme.spacing(),
+  position: 'relative',
+  textAlign: 'center',
+  zIndex: 2,
+}));

--- a/packages/manager/src/features/Help/index.tsx
+++ b/packages/manager/src/features/Help/index.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
-import { Redirect, Route, Switch } from 'react-router-dom';
 import StatusBanners from './StatusBanners';
+import { Redirect, Route, Switch } from 'react-router-dom';
 
-const HelpLanding = React.lazy(() => import('./HelpLanding'));
-
+const HelpLanding = React.lazy(() =>
+  import('./HelpLanding').then((module) => ({
+    default: module.HelpLanding,
+  }))
+);
 const SupportSearchLanding = React.lazy(
   () => import('src/features/Help/SupportSearchLanding')
 );
-
 const SupportTickets = React.lazy(
   () => import('src/features/Support/SupportTickets')
 );
@@ -15,7 +17,7 @@ const SupportTicketDetail = React.lazy(
   () => import('src/features/Support/SupportTicketDetail')
 );
 
-const HelpAndSupport: React.FC<{}> = (_) => {
+const HelpAndSupport = () => {
   return (
     <>
       <StatusBanners />


### PR DESCRIPTION
## Description 📝
Simple PR to remove the icon in the Help Landing green banner.

This PR also refactors touched class components and make use of styled components.

**Note**: added a subtle margin below the banner search title. Everything else should be identical.

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-06-08 at 12 38 42 PM](https://github.com/linode/manager/assets/130582365/a7f3df7b-fa17-4f92-8afd-9053803778d9) | ![Screenshot 2023-06-08 at 12 38 35 PM](https://github.com/linode/manager/assets/130582365/40346da7-05ae-4de8-b12f-2216126f494f) |

## How to test 🧪
Navigate to /support locally and compare page with production

