### PR TITLE
Fix: [M3-6637] - Linode networking v6 resolvers overflow

### DIFF
--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/DNSResolvers.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/DNSResolvers.tsx
@@ -34,9 +34,9 @@ export const DNSResolvers = (props: DNSResolversProps) => {
   return (
     <Grid
       container
-      spacing={2}
       sx={{
         display: 'grid',
+        overflowX: 'auto',
         gridTemplateAreas: `
             'one one'
             'two three'

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkingSummaryPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeNetworking/NetworkingSummaryPanel/NetworkingSummaryPanel.tsx
@@ -26,7 +26,6 @@ const useStyles = makeStyles()((theme: Theme) => ({
   },
   dnsResolverContainer: {
     display: 'flex',
-    justifyContent: 'flex-end',
     [theme.breakpoints.down('md')]: {
       order: 2,
     },
@@ -51,8 +50,8 @@ const LinodeNetworkingSummaryPanel = (props: Props) => {
 
   return (
     <Paper className={classes.root}>
-      <Grid container spacing={2} sx={{ flexGrow: 1 }}>
-        <Grid xs={12} sm={6} md={3}>
+      <Grid container spacing={4} sx={{ flexGrow: 1 }}>
+        <Grid xs={12} sm={6} md={2.5}>
           <NetworkTransfer linodeID={linode.id} linodeLabel={linode.label} />
         </Grid>
         <Grid xs={12} sm md className={classes.transferHistoryContainer}>
@@ -64,7 +63,7 @@ const LinodeNetworkingSummaryPanel = (props: Props) => {
         <Grid
           xs={12}
           sm={6}
-          md={3}
+          md={3.5}
           className={classes.dnsResolverContainer}
           sx={{
             paddingBottom: 0,


### PR DESCRIPTION
## Description 📝
On the linode detail > network tab, when showing the networking v6 resolvers, they overflow their containers and we sometimes can't even read the value. This PR does two things:
- adjust the the width os the grid items so that the addresses show in full > 1268px and increase grid spacing slightly for better readability
- add an `overflow: auto` to be able to scroll through the values at mid size breakpoints before the grid items get stacked on mobile (100% width, no change there)

It's not perfect (when v4 resolvers there's a bit of white space to the right) but this display has always been a problematic responsive layout and at some point we should consider redesigning it a bit so we don't cram too much in a grid row and account for various type of data to fit in gracefully.

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-06-09 at 9 36 23 AM](https://github.com/linode/manager/assets/130582365/09e02fcc-9cdb-44da-b4df-2d043b3df124) | ![Screenshot 2023-06-09 at 9 34 46 AM](https://github.com/linode/manager/assets/130582365/77f08e42-4c83-46c7-997d-6932cd37f12c) |
| ![Screenshot 2023-06-09 at 9 48 22 AM](https://github.com/linode/manager/assets/130582365/1e7c9a67-26ab-47bd-8c34-2336af6fa7a9) | ![Screenshot 2023-06-09 at 9 35 03 AM](https://github.com/linode/manager/assets/130582365/9aba72fd-c65d-401d-bd42-edd878d6740b) |

## How to test 🧪
1. Navigate to linode detail > network tab with a linode featuring networking v6 resolvers 
2. Compare responsive behavior with PROD and confirm fix is working and changes are not disruptive
3. Repeat with a linode featuring networking v4 resolvers 

