### PR TITLE
feat, fix: [M3-6560, M3-6641] - Update Linode Power confirmation dialog layout and UX copy

### DIFF
--- a/packages/manager/.changeset/pr-9240-changed-1686335599449.md
+++ b/packages/manager/.changeset/pr-9240-changed-1686335599449.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Improve Linode Power confirmation dialog layout and UX copy ([#9240](https://github.com/linode/manager/pull/9240))

--- a/packages/manager/src/components/DialogTitle/DialogTitle.tsx
+++ b/packages/manager/src/components/DialogTitle/DialogTitle.tsx
@@ -54,7 +54,6 @@ const DialogTitle = (props: DialogTitleProps) => {
             onClick={onClose}
             size="large"
             sx={{
-              position: 'absolute',
               right: '-12px',
             }}
           >

--- a/packages/manager/src/features/Linodes/PowerActionsDialogOrDrawer.tsx
+++ b/packages/manager/src/features/Linodes/PowerActionsDialogOrDrawer.tsx
@@ -23,7 +23,6 @@ export type Action = 'Reboot' | 'Power Off' | 'Power On';
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
     marginBottom: theme.spacing(1.25),
-    display: 'flex',
     alignItems: 'center',
     lineHeight: '1.25rem',
     fontSize: '0.875rem',
@@ -165,7 +164,13 @@ export const PowerActionsDialog = (props: Props) => {
     >
       {props.action === 'Power On' ? (
         <Typography className={classes.root}>
-          Are you sure you want to {props.action.toLowerCase()} your Linode?{' '}
+          See the&nbsp;
+          <ExternalLink
+            link="https://www.linode.com/docs/products/compute/compute-instances/guides/set-up-and-secure/"
+            text="guide for setting up and securing a compute instance"
+            hideIcon
+          />
+          &nbsp;for more information.
         </Typography>
       ) : null}
       {showConfigSelect && (

--- a/packages/manager/src/features/Linodes/PowerActionsDialogOrDrawer.tsx
+++ b/packages/manager/src/features/Linodes/PowerActionsDialogOrDrawer.tsx
@@ -163,9 +163,11 @@ export const PowerActionsDialog = (props: Props) => {
         </ActionsPanel>
       }
     >
-      <Typography className={classes.root}>
-        Are you sure you want to {props.action.toLowerCase()} your Linode?
-      </Typography>
+      {props.action === 'Power On' ? (
+        <Typography className={classes.root}>
+          Are you sure you want to {props.action.toLowerCase()} your Linode?{' '}
+        </Typography>
+      ) : null}
       {showConfigSelect && (
         <Select
           label="Config"
@@ -179,9 +181,11 @@ export const PowerActionsDialog = (props: Props) => {
       )}
       {props.action === 'Power Off' && (
         <span>
-          <Notice warning important className={classes.notice}>
+          <Notice warning className={classes.notice}>
             <strong>Note: </strong>
-            Powered down Linodes will still accrue charges. See the&nbsp;
+            Powered down Linodes will still accrue charges.
+            <br />
+            See the&nbsp;
             <ExternalLink
               link="https://www.linode.com/docs/guides/understanding-billing-and-payments/#will-i-be-billed-for-powered-off-or-unused-services"
               text="Billing and Payments documentation"


### PR DESCRIPTION
## Description 📝
This ticket addresses a few small dialog layout and copy improvements for the Linode Power Actions dialog. 

## Major Changes 🔄
- Removes "Are you sure..." Typography in both Power Off and On states
- Reformats the notice's line breaks on Power Off dialog
- Includes new copy linking to [Guides - Setting Up and Securing a Compute Instance](https://www.linode.com/docs/products/compute/compute-instances/guides/set-up-and-secure/) on Power On dialog
- Changes the notice to a warning notice, not an important warning notice on Power Off dialog
- Fixes bug where a long dialog title overlaps and obscures the dialog 'X' button

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-06-09 at 11 17 15 AM](https://github.com/linode/manager/assets/114685994/0d3cce49-2f25-475c-a60f-a3d670c36a70) | ![Screenshot 2023-06-12 at 10 43 49 AM](https://github.com/linode/manager/assets/114685994/91938bf1-2c99-44e6-84f3-6f965346def4) |
|  ![Screenshot 2023-06-09 at 11 17 40 AM](https://github.com/linode/manager/assets/114685994/0772ff1b-8987-4094-9447-f6f9251dd570) | ![Screenshot 2023-06-09 at 11 17 55 AM](https://github.com/linode/manager/assets/114685994/5cecbaac-1014-44ad-ab26-e5f76ca49bcc) |

## How to test 🧪
1. **How to reproduce the issue (if applicable)?**
- Have a linode on hand with a long label name (e.g. debian-us-west-large-test). 
- Use the action menu to power on/off a linode via the dialog.  
- Observe the current layout and copy of the dialog. 
- Observe that, for a linode with a long label name, the dialog title overlaps the 'X' button when the power on dialog is shown.
2. **How to verify changes?**
- Use the action menu to power on/off a linode via the dialog.  
- Check the mocks on the ticket to confirm the requested UX adjustments have been made.
- Check that, for a linode with a long label name, the dialog title does not overlap the 'X' button and removing style `position: absolute` didn't cause any other unexpected regressions. 

