### PR TITLE
refactor: [M3-6559] - React Query - Linodes - Resize

### DIFF
--- a/packages/api-v4/src/linodes/actions.ts
+++ b/packages/api-v4/src/linodes/actions.ts
@@ -7,6 +7,7 @@ import {
   LinodeCloneData,
   RebuildRequest,
   RescueRequestObject,
+  ResizeLinodePayload,
 } from './types';
 
 /**
@@ -81,20 +82,13 @@ export const linodeShutdown = (linodeId: number | string) =>
  * the Linode is resized? NOTE: Unless the user has 1 ext disk or 1 ext disk and
  * 1 swap disk, this flag does nothing, regardless of whether it's true or false
  */
-export const resizeLinode = (
-  linodeId: number,
-  type: string,
-  allow_auto_disk_resize: boolean = true
-) =>
+export const resizeLinode = (linodeId: number, data: ResizeLinodePayload) =>
   Request<{}>(
     setURL(
       `${API_ROOT}/linode/instances/${encodeURIComponent(linodeId)}/resize`
     ),
     setMethod('POST'),
-    setData({
-      type,
-      allow_auto_disk_resize,
-    })
+    setData(data)
   );
 
 /**

--- a/packages/api-v4/src/linodes/types.ts
+++ b/packages/api-v4/src/linodes/types.ts
@@ -371,3 +371,9 @@ export interface LinodeDiskCreationData {
   stackscript_id?: number;
   stackscript_data?: any;
 }
+
+export interface ResizeLinodePayload {
+  type: string;
+  /** @default true */
+  allow_auto_disk_resize?: boolean;
+}

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeResize/LinodeResize.test.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeResize/LinodeResize.test.tsx
@@ -1,73 +1,35 @@
-import { shallow } from 'enzyme';
 import * as React from 'react';
-import { UseQueryResult } from 'react-query';
-import { profileFactory } from 'src/factories';
-import { mockMatchMedia } from 'src/utilities/testHelpers';
+import { mockMatchMedia, renderWithTheme } from 'src/utilities/testHelpers';
 import { extDisk, swapDisk } from 'src/__data__/disks';
 import { extendedTypes } from 'src/__data__/ExtendedType';
-import { reactRouterProps } from 'src/__data__/reactRouterProps';
-import { Grants, Profile } from '@linode/api-v4/lib';
-import { APIError } from '@linode/api-v4/lib/types';
 import {
   isSmallerThanCurrentPlan,
   LinodeResize,
   shouldEnableAutoResizeDiskOption,
 } from './LinodeResize';
-import { grantsFactory } from 'src/factories/grants';
-import { preferencesFactory } from 'src/factories/preferences';
+import { rest, server } from 'src/mocks/testServer';
+import { linodeFactory } from 'src/factories';
 
 beforeAll(() => {
   mockMatchMedia();
 });
 
 describe('LinodeResize', () => {
-  const component = shallow(
-    <LinodeResize
-      profile={
-        { data: profileFactory.build() } as UseQueryResult<Profile, APIError[]>
-      }
-      grants={
-        { data: grantsFactory.build() } as UseQueryResult<Grants, APIError[]>
-      }
-      closeSnackbar={jest.fn()}
-      enqueueSnackbar={jest.fn()}
-      {...reactRouterProps}
-      classes={{
-        title: '',
-        subTitle: '',
-        toolTip: '',
-        currentPlanContainer: '',
-        resizeTitle: '',
-        currentHeaderEmptyCell: '',
-        selectPlanPanel: '',
-        actionPanel: '',
-      }}
-      linodeId={12}
-      linodeLabel=""
-      open={false}
-      getUserPreferences={jest.fn()}
-      updateUserPreferences={jest.fn()}
-      preferences={preferencesFactory.build()}
-      onClose={jest.fn()}
-      getLinodeDisks={jest.fn()}
-      updateLinode={jest.fn()}
-      typesData={extendedTypes}
-      typesLoading={false}
-      setRequestedTypes={jest.fn()}
-      requestedTypesData={[]}
-    />
-  );
-
-  it('submit button should be enabled if a plan is selected', () => {
-    component.setState({ selectedId: 'selected' });
-    const submitBtn = component.find('[data-qa-resize]');
-    expect(submitBtn.prop('disabled')).toBeFalsy();
-  });
-
-  it('submit button should be disabled if no plan is selected', () => {
-    component.setState({ selectedId: '' });
-    const submitBtn = component.find('[data-qa-resize]');
-    expect(submitBtn.prop('disabled')).toBeTruthy();
+  it('to render', async () => {
+    server.use(
+      rest.get('*/linode/instances/:id', (req, res, ctx) => {
+        return res(ctx.json(linodeFactory.build({ label: 'test-resize' })));
+      })
+    );
+    const { findByText } = renderWithTheme(
+      <LinodeResize
+        linodeId={12}
+        linodeLabel=""
+        open={true}
+        onClose={jest.fn()}
+      />
+    );
+    await findByText('Resize Linode test-resize');
   });
 
   describe('utility functions', () => {

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -1,16 +1,10 @@
-import { GrantLevel } from '@linode/api-v4/lib/account';
-import { Disk, LinodeStatus, resizeLinode } from '@linode/api-v4/lib/linodes';
+import { Disk, LinodeType } from '@linode/api-v4/lib/linodes';
 import { APIError } from '@linode/api-v4/lib/types';
-import { withSnackbar, WithSnackbarProps } from 'notistack';
+import { useSnackbar } from 'notistack';
 import * as React from 'react';
-import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux';
-import { compose } from 'recompose';
-import { Action } from 'redux';
-import { ThunkDispatch } from 'redux-thunk';
-import { StyledActionPanel } from 'src/components/ActionsPanel/ActionsPanel';
 import Button from 'src/components/Button';
 import Checkbox from 'src/components/CheckBox';
-import { createStyles, withStyles, WithStyles } from '@mui/styles';
+import { makeStyles } from '@mui/styles';
 import { Theme } from '@mui/material/styles';
 import Typography from 'src/components/core/Typography';
 import { Dialog } from 'src/components/Dialog/Dialog';
@@ -18,83 +12,39 @@ import ExternalLink from 'src/components/ExternalLink';
 import { TooltipIcon } from 'src/components/TooltipIcon/TooltipIcon';
 import { Notice } from 'src/components/Notice/Notice';
 import { TypeToConfirm } from 'src/components/TypeToConfirm/TypeToConfirm';
-import {
-  withProfile,
-  WithProfileProps,
-} from 'src/containers/profile.container';
-import withPreferences, {
-  Props as PreferencesProps,
-} from 'src/containers/preferences.container';
-import {
-  withTypes,
-  withSpecificTypes,
-  WithSpecificTypesProps,
-  WithTypesProps,
-} from 'src/containers/types.container';
 import { resetEventsPolling } from 'src/eventsPolling';
 import PlansPanel from 'src/features/Linodes/LinodesCreate/SelectPlanPanel/PlansPanel';
 import { linodeInTransition } from 'src/features/Linodes/transitions';
-import { ApplicationState } from 'src/store';
-import { getAllLinodeDisks } from 'src/store/linodes/disk/disk.requests';
-import { getLinodeDisksForLinode } from 'src/store/linodes/disk/disk.selectors';
-import { requestLinodeForStore } from 'src/store/linodes/linode.requests';
 import { getPermissionsForLinode } from 'src/store/linodes/permissions/permissions.selector';
-import { EntityError } from 'src/store/types';
-import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
-import { GetAllData } from 'src/utilities/getAll';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import HostMaintenanceError from '../HostMaintenanceError';
 import LinodePermissionsError from '../LinodePermissionsError';
-import { filterCurrentTypes } from 'src/utilities/filterCurrentLinodeTypes';
-import { ExtendedType, extendType } from 'src/utilities/extendType';
-import { isNotNullOrUndefined } from 'src/utilities/nullOrUndefined';
+import { extendType } from 'src/utilities/extendType';
+import { useFormik } from 'formik';
+import { useAllLinodeDisksQuery } from 'src/queries/linodes/disks';
+import {
+  useLinodeQuery,
+  useLinodeResizeMutation,
+} from 'src/queries/linodes/linodes';
+import { useAllTypes } from 'src/queries/types';
+import { useGrants } from 'src/queries/profile';
+import { usePreferences } from 'src/queries/preferences';
+import Box from 'src/components/core/Box';
 
-type ClassNames =
-  | 'title'
-  | 'subTitle'
-  | 'toolTip'
-  | 'currentPlanContainer'
-  | 'resizeTitle'
-  | 'currentHeaderEmptyCell'
-  | 'selectPlanPanel'
-  | 'actionPanel';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    title: {
-      marginBottom: theme.spacing(2),
+const useStyles = makeStyles((theme: Theme) => ({
+  resizeTitle: {
+    display: 'flex',
+    alignItems: 'center',
+    minHeight: '44px',
+  },
+  selectPlanPanel: {
+    marginTop: theme.spacing(5),
+    marginBottom: theme.spacing(3),
+    '& > div': {
+      padding: 0,
     },
-    resizeTitle: {
-      display: 'flex',
-      alignItems: 'center',
-      minHeight: '44px',
-    },
-    subTitle: {
-      marginTop: theme.spacing(3),
-      marginBottom: theme.spacing(1),
-    },
-    currentPlanContainer: {
-      '& input[type=radio]': {
-        cursor: 'not-allowed',
-      },
-    },
-    currentHeaderEmptyCell: {
-      width: '13%',
-    },
-    selectPlanPanel: {
-      marginTop: theme.spacing(5),
-      marginBottom: theme.spacing(3),
-      '& > div': {
-        padding: 0,
-      },
-    },
-    actionPanel: {
-      flexDirection: 'column',
-      '& button': {
-        alignSelf: 'flex-end',
-      },
-    },
-  });
+  },
+}));
 
 interface Props {
   linodeId?: number;
@@ -103,238 +53,108 @@ interface Props {
   onClose: () => void;
 }
 
-interface State {
-  selectedId: string | null;
-  errors?: APIError[];
-  autoDiskResize: boolean;
-  confirmationText: string;
-  submitting: boolean;
-  submissionError?: string | JSX.Element;
-}
+export const LinodeResize = (props: Props) => {
+  const classes = useStyles();
+  const { linodeId, open, onClose } = props;
 
-type CombinedProps = Props &
-  WithTypesProps &
-  WithSpecificTypesProps &
-  WithStyles<ClassNames> &
-  DispatchProps &
-  PreferencesProps &
-  WithSnackbarProps &
-  StateProps &
-  WithProfileProps;
+  const { data: linode } = useLinodeQuery(
+    linodeId ?? -1,
+    linodeId !== undefined
+  );
 
-export class LinodeResize extends React.Component<CombinedProps, State> {
-  state: State = {
-    selectedId: null,
-    autoDiskResize: false,
-    confirmationText: '',
-    submitting: false,
-  };
+  const { data: disks, error: disksError } = useAllLinodeDisksQuery(
+    linodeId ?? -1,
+    linodeId !== undefined
+  );
 
-  onSubmit = () => {
-    const {
-      linodeId,
-      linodeType,
-      enqueueSnackbar,
-      updateLinode,
-      requestedTypesData,
-    } = this.props;
-    const { selectedId } = this.state;
+  const { data: types } = useAllTypes(open);
 
-    const extendedTypeData = requestedTypesData.map(extendType);
+  const { data: grants } = useGrants();
+  const { data: preferences } = usePreferences(open);
 
-    if (!linodeId || !selectedId) {
-      return;
-    }
+  const { enqueueSnackbar } = useSnackbar();
 
-    const isSmaller = isSmallerThanCurrentPlan(
-      selectedId,
-      linodeType ?? null,
-      extendedTypeData
-    );
+  const [confirmationText, setConfirmationText] = React.useState('');
 
-    this.setState({
-      submitting: true,
-    });
+  const {
+    mutateAsync: resizeLinode,
+    isLoading,
+    error: resizeError,
+  } = useLinodeResizeMutation(linodeId ?? -1);
 
-    /**
-     * Only set the allow_auto_disk_resize flag to true if both the user
-     * has selected it (this.state.autoDiskResize) and
-     * the flag would be honored (so disable if the current plan
-     * is larger than the target plan).
-     */
-    resizeLinode(linodeId, selectedId, this.state.autoDiskResize && !isSmaller)
-      .then((_) => {
-        this.setState({
-          selectedId: null,
-          submitting: false,
-        });
-        resetEventsPolling();
-        enqueueSnackbar('Linode queued for resize.', {
-          variant: 'info',
-        });
-
-        // Update the Linode so we display the new plan information.
-        // This is important if resizing from a legacy plan. We need
-        // to do this in order for the "Upgrade available" banner to
-        // go away.
-        updateLinode(linodeId);
-
-        this.props.onClose();
-      })
-      .catch((errorResponse) => {
-        let error: string | JSX.Element = '';
-        const reason = errorResponse[0]?.reason ?? '';
-        /**
-         * The logic below is to manually intercept a certain
-         * error and add some JSX with a hyperlink to it.
-         *
-         * Unfortunately, we have global error interceptors that
-         * do the same thing, as is the case when your reputation
-         * score is too low to do what you're trying to do.
-         *
-         * If one of those already-intercepted errors comes through here,
-         * it will break the logic (since error[0].reason is not a string).
-         */
-        if (
-          typeof reason === 'string' &&
-          reason.match(/allocated more disk/i)
-        ) {
-          error = (
-            <Typography>
-              The current disk size of your Linode is too large for the new
-              service plan. Please resize your disk to accommodate the new plan.
-              You can read our{' '}
-              <ExternalLink
-                hideIcon
-                text="Resize Your Linode"
-                link="https://www.linode.com/docs/platform/disk-images/resizing-a-linode/"
-              />{' '}
-              guide for more detailed instructions.
-            </Typography>
-          );
-        } else {
-          error = getAPIErrorOrDefault(
-            errorResponse,
-            'There was an issue resizing your Linode.'
-          )[0].reason;
-        }
-        this.setState({
-          submissionError: error,
-          submitting: false,
-        });
-        // Set to "block: end" since the sticky header would otherwise interfere.
-        scrollErrorIntoView(undefined, { block: 'end' });
+  const formik = useFormik({
+    enableReinitialize: true,
+    initialValues: {
+      type: '',
+      allow_auto_disk_resize: shouldEnableAutoResizeDiskOption(disks ?? [])[1],
+    },
+    async onSubmit(values) {
+      const isSmaller = isSmallerThanCurrentPlan(
+        values.type,
+        linode?.type ?? null,
+        types ?? []
+      );
+      /**
+       * Only set the allow_auto_disk_resize flag to true if both the user
+       * has selected it (this.state.autoDiskResize) and
+       * the flag would be honored (so disable if the current plan
+       * is larger than the target plan).
+       */
+      await resizeLinode({
+        type: values.type,
+        allow_auto_disk_resize: values.allow_auto_disk_resize && !isSmaller,
       });
-  };
-
-  handleSelectPlan = (id: string) => {
-    this.setState({ selectedId: id });
-  };
-
-  handleToggleAutoDisksResize = () => {
-    this.setState({ autoDiskResize: !this.state.autoDiskResize });
-  };
-
-  updateRequestedTypes = () => {
-    this.props.setRequestedTypes(
-      [this.props.linodeType, this.state.selectedId]
-        .filter(isNotNullOrUndefined)
-        .filter((type) => type.length > 0)
-    );
-  };
-
-  componentDidMount = () => {
-    this.updateRequestedTypes();
-  };
-
-  componentDidUpdate = (prevProps: CombinedProps, prevState: State) => {
-    if (
-      prevProps.linodeId !== this.props.linodeId &&
-      !!this.props.linodeId &&
-      this.props.linodeDisks?.length === 0
-    ) {
-      // @todo: Error?
-      this.props.getLinodeDisks(this.props.linodeId).catch((_) => null);
-    }
-
-    if (
-      prevProps.linodeDisks?.length == 0 &&
-      this.props.linodeDisks && // TS Compiler wasn't recognizing the optional chaining here.
-      this.props.linodeDisks.length > 0
-    ) {
-      this.setState({
-        autoDiskResize: shouldEnableAutoResizeDiskOption(
-          this.props.linodeDisks ?? []
-        )[1],
+      resetEventsPolling();
+      enqueueSnackbar('Linode queued for resize.', {
+        variant: 'info',
       });
-    }
+      onClose();
+    },
+  });
 
-    if (
-      prevProps.linodeType !== this.props.linodeType ||
-      prevState.selectedId !== this.state.selectedId
-    ) {
-      this.updateRequestedTypes();
-    }
-  };
+  React.useEffect(() => {
+    // Set to "block: end" since the sticky header would otherwise interfere.
+    scrollErrorIntoView(undefined, { block: 'end' });
+  }, [resizeError]);
 
-  render() {
-    const {
-      typesData,
-      requestedTypesData,
-      linodeType,
-      classes,
-      linodeDisks,
-      linodeStatus,
-      linodeDisksError,
-      linodeLabel,
-      linodeId,
-      grants,
-      preferences,
-    } = this.props;
-    const { confirmationText, submissionError } = this.state;
-    const extendedTypeData = requestedTypesData.map(extendType);
-    const type = extendedTypeData.find((t) => t.id === linodeType);
+  const hostMaintenance = linode?.status === 'stopped';
+  const unauthorized =
+    getPermissionsForLinode(grants, linodeId || 0) === 'read_only';
 
-    const hostMaintenance = linodeStatus === 'stopped';
-    const unauthorized =
-      getPermissionsForLinode(grants.data, linodeId || 0) === 'read_only';
-    const disksError = linodeDisksError?.read;
+  const tableDisabled = hostMaintenance || unauthorized;
 
-    const tableDisabled =
-      hostMaintenance || unauthorized || Boolean(disksError);
+  const submitButtonDisabled =
+    preferences?.type_to_confirm !== false &&
+    confirmationText !== linode?.label;
 
-    const submitButtonDisabled =
-      preferences?.type_to_confirm !== false &&
-      confirmationText !== linodeLabel;
+  const type = types?.find((t) => t.id === linode?.type);
 
-    const currentPlanHeading = linodeType
-      ? type
-        ? type.formattedLabel
-        : 'Unknown Plan'
-      : 'No Assigned Plan';
+  const [
+    diskToResize,
+    _shouldEnableAutoResizeDiskOption,
+  ] = shouldEnableAutoResizeDiskOption(disks ?? []);
 
-    const [
-      diskToResize,
-      _shouldEnableAutoResizeDiskOption,
-    ] = shouldEnableAutoResizeDiskOption(linodeDisks ?? []);
+  const isSmaller = isSmallerThanCurrentPlan(
+    formik.values.type,
+    linode?.type || '',
+    types ?? []
+  );
 
-    const isSmaller = isSmallerThanCurrentPlan(
-      this.state.selectedId,
-      linodeType || '',
-      extendedTypeData
-    );
+  const currentTypes =
+    types?.filter((thisType) => !Boolean(thisType.successor)) ?? [];
 
-    const currentTypes = filterCurrentTypes(typesData?.map(extendType));
+  const error = getError(resizeError);
 
-    return (
-      <Dialog
-        title={`Resize Linode ${this.props.linodeLabel ?? ''}`}
-        open={this.props.open}
-        onClose={this.props.onClose}
-        fullWidth
-        fullHeight
-        maxWidth="md"
-      >
+  return (
+    <Dialog
+      title={`Resize Linode ${linode?.label}`}
+      open={open}
+      onClose={onClose}
+      fullWidth
+      fullHeight
+      maxWidth="md"
+    >
+      <form onSubmit={formik.handleSubmit}>
         {unauthorized && <LinodePermissionsError />}
         {hostMaintenance && <HostMaintenanceError />}
         {disksError && (
@@ -343,7 +163,7 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
             text="There was an error loading your Linode&rsquo;s Disks."
           />
         )}
-        {submissionError && <Notice error>{submissionError}</Notice>}
+        {error && <Notice error>{error}</Notice>}
         <Typography data-qa-description>
           If you&rsquo;re expecting a temporary burst of traffic to your
           website, or if you&rsquo;re not using your Linode as much as you
@@ -358,12 +178,11 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
 
         <div className={classes.selectPlanPanel}>
           <PlansPanel
-            currentPlanHeading={currentPlanHeading}
-            types={currentTypes}
-            onSelect={this.handleSelectPlan}
-            selectedID={this.state.selectedId ?? undefined}
+            currentPlanHeading={type ? extendType(type).heading : undefined} // lol, why make us pass the heading and not the plan id?
+            types={currentTypes.map(extendType)}
+            onSelect={(type) => formik.setFieldValue('type', type)}
+            selectedID={formik.values.type}
             disabled={tableDisabled}
-            updateFor={[this.state.selectedId, currentTypes]}
           />
         </div>
         <Typography variant="h2" className={classes.resizeTitle}>
@@ -390,7 +209,7 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
                 marginLeft: '-2px',
               }}
               text={`Your ext disk can only be automatically resized if you have one ext
-                      disk or one ext disk and one swap disk on this Linode.`}
+                    disk or one ext disk and one swap disk on this Linode.`}
               status="help"
             />
           ) : null}
@@ -400,9 +219,11 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
           checked={
             !_shouldEnableAutoResizeDiskOption || isSmaller
               ? false
-              : this.state.autoDiskResize
+              : formik.values.allow_auto_disk_resize
           }
-          onChange={this.handleToggleAutoDisksResize}
+          onChange={(value, checked) =>
+            formik.setFieldValue('allow_auto_disk_resize', checked)
+          }
           text={
             <Typography>
               Would you like{' '}
@@ -419,107 +240,68 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
             </Typography>
           }
         />
-
-        <StyledActionPanel className={classes.actionPanel}>
+        <Box marginTop={2}>
           <TypeToConfirm
             title="Confirm"
             confirmationText={
               <span>
                 To confirm these changes, type the label of the Linode (
-                <strong>{linodeLabel}</strong>) in the field below:
+                <strong>{linode?.label}</strong>) in the field below:
               </span>
             }
             typographyStyle={{ marginBottom: 8 }}
-            onChange={(input) => {
-              this.setState({ confirmationText: input });
-            }}
+            onChange={setConfirmationText}
             value={confirmationText}
             hideLabel
             visible={preferences?.type_to_confirm}
             label="Linode Label"
             textFieldStyle={{ marginBottom: 16 }}
           />
+        </Box>
+        <Box display="flex" justifyContent="flex-end">
           <Button
             disabled={
-              !this.state.selectedId ||
-              linodeInTransition(this.props.linodeStatus || '') ||
+              !formik.values.type ||
+              linodeInTransition(linode?.status || '') ||
               tableDisabled ||
               submitButtonDisabled
             }
-            loading={this.state.submitting}
+            loading={isLoading}
             buttonType="primary"
-            onClick={this.onSubmit}
+            type="submit"
             data-qa-resize
           >
             Resize Linode
           </Button>
-        </StyledActionPanel>
-      </Dialog>
+        </Box>
+      </form>
+    </Dialog>
+  );
+};
+
+const getError = (error: APIError[] | null) => {
+  if (!error) {
+    return null;
+  }
+
+  const errorText = error?.[0]?.reason;
+  if (errorText.match(/allocated more disk/i)) {
+    return (
+      <Typography>
+        The current disk size of your Linode is too large for the new service
+        plan. Please resize your disk to accommodate the new plan. You can read
+        our{' '}
+        <ExternalLink
+          hideIcon
+          text="Resize Your Linode"
+          link="https://www.linode.com/docs/platform/disk-images/resizing-a-linode/"
+        />{' '}
+        guide for more detailed instructions.
+      </Typography>
     );
   }
-}
 
-const styled = withStyles(styles);
-
-interface DispatchProps {
-  updateLinode: (id: number) => void;
-  getLinodeDisks: (linodeId: number) => Promise<GetAllData<Disk>>;
-}
-
-const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
-  dispatch: ThunkDispatch<ApplicationState, undefined, Action<any>>
-) => {
-  return {
-    updateLinode: (id: number) => dispatch(requestLinodeForStore(id)),
-    getLinodeDisks: (linodeId: number) =>
-      dispatch(getAllLinodeDisks({ linodeId })),
-  };
-};
-
-interface StateProps {
-  linodeId?: number;
-  linodeType?: null | string;
-  linodeStatus?: LinodeStatus;
-  linodeLabel?: string;
-  permissions?: GrantLevel;
-  linodeDisks?: Disk[];
-  linodeDisksError?: EntityError;
-}
-
-const mapStateToProps: MapStateToProps<StateProps, Props> = (
-  state: ApplicationState,
-  ownProps
-) => {
-  const { linodeId } = ownProps;
-
-  if (!linodeId) {
-    return {};
-  }
-
-  const linode = state.__resources.linodes.itemsById[linodeId];
-  const linodeDisks = state.__resources.linodeDisks;
-
-  if (!linode) {
-    return {};
-  }
-
-  return {
-    linodeId: linode.id,
-    linodeType: linode.type,
-    linodeStatus: linode.status,
-    linodeLabel: linode.label,
-    linodeDisks: getLinodeDisksForLinode(linodeDisks, linodeId),
-    linodeDisksError: linodeDisks[linodeId]?.error,
-  };
-};
-
-const connected = connect(mapStateToProps, mapDispatchToProps);
-
-export const getLinodeType = (
-  types: ExtendedType[],
-  selectedTypeID: string
-) => {
-  return types.find((thisType) => thisType.id === selectedTypeID);
+  return errorText;
 };
 
 /**
@@ -560,7 +342,7 @@ export const shouldEnableAutoResizeDiskOption = (
 export const isSmallerThanCurrentPlan = (
   selectedPlanID: string | null,
   currentPlanID: string | null,
-  types: ExtendedType[]
+  types: LinodeType[]
 ) => {
   const currentType = types.find((thisType) => thisType.id === currentPlanID);
   const nextType = types.find((thisType) => thisType.id === selectedPlanID);
@@ -571,16 +353,3 @@ export const isSmallerThanCurrentPlan = (
 
   return currentType.disk > nextType.disk;
 };
-
-export default compose<CombinedProps, Props>(
-  // this awkward line avoids fetching all types until this dialog is opened which
-  // is important since LinodeResize is mounted on the default landing page
-  (component: React.ComponentType<CombinedProps>) => (props: CombinedProps) =>
-    withTypes(component, props.open)(props),
-  withSpecificTypes,
-  styled,
-  withSnackbar,
-  connected,
-  withProfile,
-  withPreferences
-)(LinodeResize);

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
@@ -24,7 +24,7 @@ import { DeleteLinodeDialog } from '../../LinodesLanding/DeleteLinodeDialog';
 import { EnableBackupsDialog } from '../LinodeBackup/EnableBackupsDialog';
 import { LinodeRebuildDialog } from '../LinodeRebuild/LinodeRebuildDialog';
 import { RescueDialog } from '../LinodeRescue/RescueDialog';
-import LinodeResize from '../LinodeResize/LinodeResize';
+import { LinodeResize } from '../LinodeResize/LinodeResize';
 import HostMaintenance from './HostMaintenance';
 import { MutationNotification } from './MutationNotification';
 import Notifications from './Notifications';

--- a/packages/manager/src/features/Linodes/LinodesLanding/LinodesLanding.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/LinodesLanding.tsx
@@ -43,7 +43,7 @@ import { LinodesLandingEmptyState } from './LinodesLandingEmptyState';
 import ListView from './ListView';
 import { ExtendedStatus, statusToPriority } from './utils';
 import { LinodesLandingCSVDownload } from './LinodesLandingCSVDownload';
-import LinodeResize from '../LinodesDetail/LinodeResize/LinodeResize';
+import { LinodeResize } from '../LinodesDetail/LinodeResize/LinodeResize';
 import { RescueDialog } from '../LinodesDetail/LinodeRescue/RescueDialog';
 import { DeleteLinodeDialog } from './DeleteLinodeDialog';
 import { LinodeWithMaintenance } from 'src/store/linodes/linodes.helpers';

--- a/packages/manager/src/queries/linodes/linodes.ts
+++ b/packages/manager/src/queries/linodes/linodes.ts
@@ -30,6 +30,8 @@ import {
   getLinodeKernels,
   Kernel,
   getLinodeKernel,
+  resizeLinode,
+  ResizeLinodePayload,
 } from '@linode/api-v4/lib/linodes';
 
 export const queryKey = 'linodes';
@@ -215,6 +217,18 @@ export const useLinodeMigrateMutation = (id: number) => {
   const queryClient = useQueryClient();
   return useMutation<{}, APIError[], { region: string } | undefined>(
     (data) => scheduleOrQueueMigration(id, data),
+    {
+      onSuccess() {
+        queryClient.invalidateQueries([queryKey]);
+      },
+    }
+  );
+};
+
+export const useLinodeResizeMutation = (id: number) => {
+  const queryClient = useQueryClient();
+  return useMutation<{}, APIError[], ResizeLinodePayload>(
+    (data) => resizeLinode(id, data),
     {
       onSuccess() {
         queryClient.invalidateQueries([queryKey]);


### PR DESCRIPTION
## Description 📝

- React Query for the Linode Resize Dialog

## Major Changes 🔄
- Rewrites `<LinodeResize />` from a class component to a functional component
- Uses React Query for all queries and mutations in this Dialog

## Preview 📷
> **Note**: No major UI changes are expected

![Screenshot 2023-06-09 at 3 18 59 PM](https://github.com/linode/manager/assets/115251059/a96ce541-4abd-4e72-84f9-91bde78b2ff3)

## How to test 🧪
- Test Resizing Linodes
  - Test many different configurations and resize options