### PR TITLE
refactor: [M3-6346] - MUI v5 Migration – Components > HighlightedMarkdown…

### DIFF
--- a/packages/manager/src/components/HighlightedMarkdown/HighlightedMarkdown.test.tsx
+++ b/packages/manager/src/components/HighlightedMarkdown/HighlightedMarkdown.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { renderWithTheme } from 'src/utilities/testHelpers';
-import HighlightedMarkdown from './HighlightedMarkdown';
+import { HighlightedMarkdown } from './HighlightedMarkdown';
 
 const sampleMarkdown =
   '# Some markdown \n ```\n const x = function() { return true; }\n```';

--- a/packages/manager/src/components/HighlightedMarkdown/HighlightedMarkdown.tsx
+++ b/packages/manager/src/components/HighlightedMarkdown/HighlightedMarkdown.tsx
@@ -1,8 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-import classNames from 'classnames';
 import * as hljs from 'highlight.js/lib/core';
 import * as React from 'react';
-import { makeStyles } from '@mui/styles';
+import { makeStyles } from 'tss-react/mui';
 import { Theme } from '@mui/material/styles';
 import Typography from 'src/components/core/Typography';
 import 'src/formatted-text.css';
@@ -21,7 +20,7 @@ hljs.registerLanguage('javascript', javascript);
 hljs.registerLanguage('nginx', nginx);
 hljs.registerLanguage('yaml', yaml);
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles()((theme: Theme) => ({
   root: {
     '& .hljs': {
       color: theme.color.offBlack,
@@ -46,7 +45,7 @@ export interface HighlightedMarkdownProps {
 }
 
 export const HighlightedMarkdown = (props: HighlightedMarkdownProps) => {
-  const classes = useStyles();
+  const { classes, cx } = useStyles();
   const { className, language, textOrMarkdown, sanitizeOptions } = props;
   const rootRef = React.useRef<HTMLDivElement>(null);
 
@@ -85,7 +84,7 @@ export const HighlightedMarkdown = (props: HighlightedMarkdownProps) => {
 
   return (
     <Typography
-      className={classNames(classes.root, 'formatted-text', className)}
+      className={cx(classes.root, 'formatted-text', className)}
       ref={rootRef}
       dangerouslySetInnerHTML={{
         __html: sanitizedHtml,
@@ -93,5 +92,3 @@ export const HighlightedMarkdown = (props: HighlightedMarkdownProps) => {
     />
   );
 };
-
-export default HighlightedMarkdown;

--- a/packages/manager/src/components/HighlightedMarkdown/__snapshots__/HighlightedMarkdown.test.tsx.snap
+++ b/packages/manager/src/components/HighlightedMarkdown/__snapshots__/HighlightedMarkdown.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`HighlightedMarkdown component should highlight text consistently 1`] = `
 <DocumentFragment>
   <p
-    class="MuiTypography-root MuiTypography-body1 makeStyles-root-1 formatted-text css-14m9nel-MuiTypography-root"
+    class="MuiTypography-root MuiTypography-body1 formatted-text css-3d6o5w-MuiTypography-root-root"
   />
   <h1>
     Some markdown

--- a/packages/manager/src/components/HighlightedMarkdown/index.tsx
+++ b/packages/manager/src/components/HighlightedMarkdown/index.tsx
@@ -1,1 +1,0 @@
-export { default } from './HighlightedMarkdown';

--- a/packages/manager/src/components/ProductInformationBanner/ProductInformationBanner.tsx
+++ b/packages/manager/src/components/ProductInformationBanner/ProductInformationBanner.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import HighlightedMarkdown from 'src/components/HighlightedMarkdown';
+import { HighlightedMarkdown } from 'src/components/HighlightedMarkdown/HighlightedMarkdown';
 import type { NoticeProps } from 'src/components/Notice/Notice';
 import { reportException } from 'src/exceptionReporting';
 import { ProductInformationBannerLocation } from 'src/featureFlags';

--- a/packages/manager/src/features/Account/Maintenance/MaintenanceTableRow.tsx
+++ b/packages/manager/src/features/Account/Maintenance/MaintenanceTableRow.tsx
@@ -4,7 +4,7 @@ import Tooltip from 'src/components/core/Tooltip';
 import Link from 'src/components/Link';
 import { TableCell } from 'src/components/TableCell';
 import { TableRow } from 'src/components/TableRow';
-import HighlightedMarkdown from 'src/components/HighlightedMarkdown';
+import { HighlightedMarkdown } from 'src/components/HighlightedMarkdown/HighlightedMarkdown';
 import { capitalize } from 'src/utilities/capitalize';
 import { StatusIcon, Status } from 'src/components/StatusIcon/StatusIcon';
 import { AccountMaintenance } from '@linode/api-v4/lib/account/types';

--- a/packages/manager/src/features/Events/EventRow.tsx
+++ b/packages/manager/src/features/Events/EventRow.tsx
@@ -6,7 +6,7 @@ import Hidden from 'src/components/core/Hidden';
 import { makeStyles } from '@mui/styles';
 import { Theme } from '@mui/material/styles';
 import { DateTimeDisplay } from 'src/components/DateTimeDisplay';
-import HighlightedMarkdown from 'src/components/HighlightedMarkdown';
+import { HighlightedMarkdown } from 'src/components/HighlightedMarkdown/HighlightedMarkdown';
 import renderGuard, { RenderGuardProps } from 'src/components/RenderGuard';
 import { TableCell } from 'src/components/TableCell';
 import { TableRow } from 'src/components/TableRow';

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigDrawer.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigDrawer.tsx
@@ -8,7 +8,7 @@ import Typography from 'src/components/core/Typography';
 import Drawer from 'src/components/Drawer';
 import DrawerContent from 'src/components/DrawerContent';
 import { downloadFile } from 'src/utilities/downloadFile';
-import HighlightedMarkdown from 'src/components/HighlightedMarkdown';
+import { HighlightedMarkdown } from 'src/components/HighlightedMarkdown/HighlightedMarkdown';
 import { useKubenetesKubeConfigQuery } from 'src/queries/kubernetes';
 
 const useStyles = makeStyles((theme: Theme) => ({

--- a/packages/manager/src/features/Linodes/LinodesCreate/CodeBlock/index.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/CodeBlock/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import HighlightedMarkdown from 'src/components/HighlightedMarkdown';
+import { HighlightedMarkdown } from 'src/components/HighlightedMarkdown/HighlightedMarkdown';
 import { CopyTooltip } from 'src/components/CopyTooltip/CopyTooltip';
 import { sendEvent } from 'src/utilities/ga';
 import { useCodeBlockStyles } from './styles';

--- a/packages/manager/src/features/NotificationCenter/NotificationData/RenderEvent.tsx
+++ b/packages/manager/src/features/NotificationCenter/NotificationData/RenderEvent.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import Box from 'src/components/core/Box';
 import classNames from 'classnames';
 import Divider from 'src/components/core/Divider';
-import HighlightedMarkdown from 'src/components/HighlightedMarkdown';
+import { HighlightedMarkdown } from 'src/components/HighlightedMarkdown/HighlightedMarkdown';
 import Typography from 'src/components/core/Typography';
 import useEventInfo from './useEventInfo';
 import { Event } from '@linode/api-v4/lib/account/types';

--- a/packages/manager/src/features/Support/SupportTicketDetail/TabbedReply/PreviewReply.tsx
+++ b/packages/manager/src/features/Support/SupportTicketDetail/TabbedReply/PreviewReply.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { compose } from 'recompose';
 import Paper from 'src/components/core/Paper';
 import { createStyles, withStyles, WithStyles } from '@mui/styles';
-import HighlightedMarkdown from 'src/components/HighlightedMarkdown';
+import { HighlightedMarkdown } from 'src/components/HighlightedMarkdown/HighlightedMarkdown';
 
 type ClassNames = 'root';
 

--- a/packages/manager/src/features/Support/TicketDetailText.tsx
+++ b/packages/manager/src/features/Support/TicketDetailText.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { makeStyles } from '@mui/styles';
 import { Theme } from '@mui/material/styles';
 import Grid from '@mui/material/Unstable_Grid2';
-import HighlightedMarkdown from 'src/components/HighlightedMarkdown';
+import { HighlightedMarkdown } from 'src/components/HighlightedMarkdown/HighlightedMarkdown';
 import { IconButton } from 'src/components/IconButton';
 import { truncate } from 'src/utilities/truncate';
 


### PR DESCRIPTION
## Description 📝
**MUI migration SRC > Components > HighlightedMarkdown**

## Major Changes 🔄

- Run tss-react codemod on `HighlightedMarkdown` 
- Changes default exports to named exports.

## How to test 🧪

- Verify all the references of `HighlightedMarkdown`.
- Verify e2e tests pass

