### PR TITLE
fix: [M3-6686] - Linode Details crashing for Linodes that don't have plans

### DIFF
--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Prevent rendering of purple content within Buttons without a buttonType prop ([#9209])
 - VLANs configuration not showing for restricted users ([#9214])
 - Linode Settings Disk I/O notification threshold value unable to be changed ([#9247])
+- Linode Details crashing for Linodes with no `type` ([#9249])
 
 ### Tech Stories:
 

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/LinodeBackups.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/LinodeBackups.tsx
@@ -53,7 +53,10 @@ export const LinodeBackups = () => {
   const { data: profile } = useProfile();
   const { data: grants } = useGrants();
   const { data: linode } = useLinodeQuery(id);
-  const { data: type } = useTypeQuery(linode?.type ?? '', linode !== undefined);
+  const { data: type } = useTypeQuery(
+    linode?.type ?? '',
+    Boolean(linode?.type)
+  );
   const { data: backups, error, isLoading } = useLinodeBackupsQuery(
     id,
     Boolean(linode?.backups.enabled)

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeRescue/RescueDialog.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeRescue/RescueDialog.tsx
@@ -17,7 +17,10 @@ export const RescueDialog = (props: Props) => {
     linodeId ?? -1,
     linodeId !== undefined && open
   );
-  const { data: type } = useTypeQuery(linode?.type ?? '', linode !== undefined);
+  const { data: type } = useTypeQuery(
+    linode?.type ?? '',
+    Boolean(linode?.type)
+  );
 
   const isBareMetalInstance = type?.class === 'metal';
 

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/LinodeSettingsAlertsPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/LinodeSettingsAlertsPanel.tsx
@@ -31,7 +31,10 @@ export const LinodeSettingsAlertsPanel = (props: Props) => {
     error,
   } = useLinodeUpdateMutation(linodeId);
 
-  const { data: type } = useTypeQuery(linode?.type ?? '', linode !== undefined);
+  const { data: type } = useTypeQuery(
+    linode?.type ?? '',
+    Boolean(linode?.type)
+  );
 
   const isBareMetalInstance = type?.class === 'metal';
 

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
@@ -38,7 +38,10 @@ export const LinodeSettingsPasswordPanel = (props: Props) => {
 
   const { enqueueSnackbar } = useSnackbar();
 
-  const { data: type } = useTypeQuery(linode?.type ?? '', linode !== undefined);
+  const { data: type } = useTypeQuery(
+    linode?.type ?? '',
+    Boolean(linode?.type)
+  );
 
   const [selectedDiskId, setSelectedDiskId] = React.useState<number | null>(
     null

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailHeader/MutationNotification.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailHeader/MutationNotification.tsx
@@ -32,12 +32,12 @@ export const MutationNotification = (props: Props) => {
 
   const { data: currentTypeInfo } = useTypeQuery(
     linode?.type ?? '',
-    linode !== undefined
+    Boolean(linode?.type)
   );
 
   const { data: successorTypeInfo } = useTypeQuery(
     currentTypeInfo?.successor ?? '',
-    currentTypeInfo !== undefined && currentTypeInfo.successor !== null
+    Boolean(currentTypeInfo?.successor)
   );
 
   const { data: disks } = useAllLinodeDisksQuery(

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailNavigation.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailNavigation.tsx
@@ -42,7 +42,10 @@ const LinodesDetailNavigation = () => {
   const { url } = useRouteMatch();
   const history = useHistory();
 
-  const { data: type } = useTypeQuery(linode?.type ?? '', linode !== undefined);
+  const { data: type } = useTypeQuery(
+    linode?.type ?? '',
+    Boolean(linode?.type)
+  );
 
   // Bare metal Linodes have a very different detail view
   const isBareMetalInstance = type?.class === 'metal';

--- a/packages/manager/src/features/Linodes/MigrateLinode/MigrateLinode.tsx
+++ b/packages/manager/src/features/Linodes/MigrateLinode/MigrateLinode.tsx
@@ -88,7 +88,10 @@ export const MigrateLinode = React.memo((props: Props) => {
     linodeId !== undefined && open
   );
 
-  const { data: type } = useTypeQuery(linode?.type ?? '', linode !== undefined);
+  const { data: type } = useTypeQuery(
+    linode?.type ?? '',
+    Boolean(linode?.type)
+  );
 
   const { data: image } = useImageQuery(
     linode?.image ?? '',

--- a/packages/manager/src/queries/types.ts
+++ b/packages/manager/src/queries/types.ts
@@ -54,6 +54,6 @@ export const useTypeQuery = (type: string, enabled = true) => {
     queryKey: specificTypesQueryKey(type),
     queryFn: () => getType(type),
     ...queryPresets.oneTimeFetch,
-    enabled: enabled && type !== '',
+    enabled: enabled && Boolean(type),
   });
 };

--- a/packages/manager/src/queries/types.ts
+++ b/packages/manager/src/queries/types.ts
@@ -54,6 +54,6 @@ export const useTypeQuery = (type: string, enabled = true) => {
     queryKey: specificTypesQueryKey(type),
     queryFn: () => getType(type),
     ...queryPresets.oneTimeFetch,
-    enabled,
+    enabled: enabled && type !== '',
   });
 };


### PR DESCRIPTION
## Description 📝

- Fix Linode details crashing for Linodes with no plan
- For Linodes with no plan, we were requesting `/v4/linode/types/${id}` but id was empty string resulting in the query actually GETing all the types from the API

## How to test 🧪
- Test against an account with Linodes that don't have plans