### PR TITLE
refactor: [M3-6340] - MUI v5 Migration - `Components > FileUploader`

### DIFF
--- a/packages/manager/.changeset/pr-9254-tech-stories-1686608779585.md
+++ b/packages/manager/.changeset/pr-9254-tech-stories-1686608779585.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+MUI v5 Migration - `Components > FileUploader` ([#9254](https://github.com/linode/manager/pull/9254))

--- a/packages/manager/src/components/FileUploader/FileUploader.stories.mdx
+++ b/packages/manager/src/components/FileUploader/FileUploader.stories.mdx
@@ -1,5 +1,5 @@
-import FileUploader from './FileUploader';
 import { Canvas, Meta, Story, ArgsTable } from '@storybook/addon-docs';
+import { FileUploader } from 'src/components/FileUploader/FileUploader';
 import { ObjectUploader } from '/src/features/ObjectStorage/ObjectUploader/ObjectUploader';
 
 <Meta title="Features/File Uploader" />

--- a/packages/manager/src/components/FileUploader/FileUploader.styles.ts
+++ b/packages/manager/src/components/FileUploader/FileUploader.styles.ts
@@ -1,0 +1,88 @@
+import Button from 'src/components/Button';
+import { styled } from '@mui/material/styles';
+import { isPropValid } from 'src/utilities/isPropValid';
+import Typography from 'src/components/core/Typography';
+import { makeStyles } from 'tss-react/mui';
+import { Theme } from '@mui/material/styles';
+
+export const StyledDropZoneDiv = styled('div')(({ theme }) => ({
+  position: 'relative',
+  display: 'flex',
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+  backgroundColor: 'transparent',
+  borderColor: theme.palette.primary.main,
+  borderStyle: 'dashed',
+  borderWidth: 1,
+  color: theme.palette.primary.main,
+  height: '100%',
+  maxHeight: 400,
+  marginTop: theme.spacing(2),
+  minHeight: 140,
+  outline: 'none',
+  overflow: 'auto',
+  padding: theme.spacing(),
+  transition: theme.transitions.create(['border-color', 'background-color']),
+}));
+
+export const StyledFileUploadsDiv = styled('div')({
+  display: 'flex',
+  flexDirection: 'column',
+  flexGrow: 1,
+  justifyContent: 'flex-start',
+});
+
+export const StyledDropZoneContentDiv = styled('div', {
+  shouldForwardProp: (prop) => isPropValid(['uploadZoneActive'], prop),
+})<{
+  uploadZoneActive: boolean;
+}>(({ theme, ...props }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: theme.spacing(2),
+  textAlign: 'center',
+  width: '100%',
+  ...(props.uploadZoneActive && {
+    backgroundColor: 'transparent',
+    bottom: theme.spacing(1.5),
+    padding: 0,
+    position: 'absolute',
+    width: `calc(100% - ${theme.spacing(4)})`,
+    zIndex: 10,
+  }),
+}));
+
+export const StyledCopy = styled(Typography)(({ theme }) => ({
+  color: theme.palette.text.primary,
+  margin: '0 auto',
+}));
+
+export const StyledUploadButton = styled(Button)(({ theme }) => ({
+  marginTop: theme.spacing(2),
+  opacity: 1,
+  transition: theme.transitions.create(['opacity']),
+}));
+
+export const useStyles = makeStyles()((theme: Theme) => ({
+  active: {
+    // The `active` class active when a user is hovering over the dropzone.
+    borderColor: theme.palette.primary.light,
+    backgroundColor: theme.color.white,
+  },
+  inactive: {
+    // When the dropzone is disabled
+    borderColor: '#888',
+  },
+  accept: {
+    // The `accept` class active when a user is hovering over the dropzone
+    // with files that will be accepted (based on file size, number of files).
+    borderColor: theme.palette.primary.light,
+  },
+  reject: {
+    // The `reject` class active when a user is hovering over the dropzone
+    // with files that will be rejected (based on file size, number of files).
+    borderColor: theme.color.red,
+  },
+}));

--- a/packages/manager/src/components/FileUploader/FileUploader.styles.ts
+++ b/packages/manager/src/components/FileUploader/FileUploader.styles.ts
@@ -2,12 +2,22 @@ import Button from 'src/components/Button';
 import { styled } from '@mui/material/styles';
 import { isPropValid } from 'src/utilities/isPropValid';
 import Typography from 'src/components/core/Typography';
-import { makeStyles } from 'tss-react/mui';
-import { Theme } from '@mui/material/styles';
+
+interface DropZoneClassProps {
+  isDragActive: boolean;
+  isDragAccept: boolean;
+  isDragReject: boolean;
+  dropzoneDisabled: boolean;
+}
 
 export const StyledDropZoneDiv = styled('div', {
   label: 'StyledDropZoneDiv',
-})(({ theme }) => ({
+  shouldForwardProp: (prop) =>
+    isPropValid(
+      ['dropzoneDisabled', 'isDragActive', 'isDragAccept', 'isDragReject'],
+      prop
+    ),
+})<DropZoneClassProps>(({ theme, ...props }) => ({
   position: 'relative',
   display: 'flex',
   flexDirection: 'row',
@@ -25,6 +35,25 @@ export const StyledDropZoneDiv = styled('div', {
   overflow: 'auto',
   padding: theme.spacing(),
   transition: theme.transitions.create(['background-color', 'border-color']),
+  ...(props.isDragActive && {
+    // The `active` class active when a user is hovering over the dropzone.
+    borderColor: theme.palette.primary.light,
+    backgroundColor: theme.color.white,
+  }),
+  ...(props.isDragAccept && {
+    // The `accept` class active when a user is hovering over the dropzone
+    // with files that will be accepted (based on file size, number of files).
+    borderColor: theme.palette.primary.light,
+  }),
+  ...(props.isDragReject && {
+    // The `reject` class active when a user is hovering over the dropzone
+    // with files that will be rejected (based on file size, number of files).
+    borderColor: theme.color.red,
+  }),
+  ...(props.dropzoneDisabled && {
+    // When the dropzone is disabled
+    borderColor: '#888',
+  }),
 }));
 
 export const StyledFileUploadsDiv = styled('div', {
@@ -72,26 +101,4 @@ export const StyledUploadButton = styled(Button, {
   marginTop: theme.spacing(2),
   opacity: 1,
   transition: theme.transitions.create(['opacity']),
-}));
-
-export const useStyles = makeStyles()((theme: Theme) => ({
-  active: {
-    // The `active` class active when a user is hovering over the dropzone.
-    borderColor: theme.palette.primary.light,
-    backgroundColor: theme.color.white,
-  },
-  inactive: {
-    // When the dropzone is disabled
-    borderColor: '#888',
-  },
-  accept: {
-    // The `accept` class active when a user is hovering over the dropzone
-    // with files that will be accepted (based on file size, number of files).
-    borderColor: theme.palette.primary.light,
-  },
-  reject: {
-    // The `reject` class active when a user is hovering over the dropzone
-    // with files that will be rejected (based on file size, number of files).
-    borderColor: theme.color.red,
-  },
 }));

--- a/packages/manager/src/components/FileUploader/FileUploader.styles.ts
+++ b/packages/manager/src/components/FileUploader/FileUploader.styles.ts
@@ -5,7 +5,9 @@ import Typography from 'src/components/core/Typography';
 import { makeStyles } from 'tss-react/mui';
 import { Theme } from '@mui/material/styles';
 
-export const StyledDropZoneDiv = styled('div')(({ theme }) => ({
+export const StyledDropZoneDiv = styled('div', {
+  label: 'StyledDropZoneDiv',
+})(({ theme }) => ({
   position: 'relative',
   display: 'flex',
   flexDirection: 'row',
@@ -22,10 +24,12 @@ export const StyledDropZoneDiv = styled('div')(({ theme }) => ({
   outline: 'none',
   overflow: 'auto',
   padding: theme.spacing(),
-  transition: theme.transitions.create(['border-color', 'background-color']),
+  transition: theme.transitions.create(['background-color', 'border-color']),
 }));
 
-export const StyledFileUploadsDiv = styled('div')({
+export const StyledFileUploadsDiv = styled('div', {
+  label: 'StyledFileUploadsDiv',
+})({
   display: 'flex',
   flexDirection: 'column',
   flexGrow: 1,
@@ -33,6 +37,7 @@ export const StyledFileUploadsDiv = styled('div')({
 });
 
 export const StyledDropZoneContentDiv = styled('div', {
+  label: 'StyledDropZoneContentDiv',
   shouldForwardProp: (prop) => isPropValid(['uploadZoneActive'], prop),
 })<{
   uploadZoneActive: boolean;
@@ -54,12 +59,16 @@ export const StyledDropZoneContentDiv = styled('div', {
   }),
 }));
 
-export const StyledCopy = styled(Typography)(({ theme }) => ({
+export const StyledCopy = styled(Typography, {
+  label: 'StyledCopy',
+})(({ theme }) => ({
   color: theme.palette.text.primary,
   margin: '0 auto',
 }));
 
-export const StyledUploadButton = styled(Button)(({ theme }) => ({
+export const StyledUploadButton = styled(Button, {
+  label: 'StyledUploadButton',
+})(({ theme }) => ({
   marginTop: theme.spacing(2),
   opacity: 1,
   transition: theme.transitions.create(['opacity']),

--- a/packages/manager/src/components/FileUploader/FileUploader.tsx
+++ b/packages/manager/src/components/FileUploader/FileUploader.tsx
@@ -11,7 +11,6 @@ import {
   StyledDropZoneDiv,
   StyledFileUploadsDiv,
   StyledUploadButton,
-  useStyles,
 } from 'src/components/FileUploader/FileUploader.styles';
 import { uploadImageFile } from 'src/features/Images/requests';
 import { FileUpload } from 'src/features/ObjectStorage/ObjectUploader/FileUpload';
@@ -66,7 +65,6 @@ export const FileUploader = React.memo((props: FileUploaderProps) => {
     cloud_init: isCloudInit ? isCloudInit : undefined,
   });
 
-  const { classes, cx } = useStyles();
   const history = useHistory();
 
   // Keep track of the session token since we may need to grab the user a new
@@ -302,23 +300,6 @@ export const FileUploader = React.memo((props: FileUploaderProps) => {
   const hideDropzoneBrowseBtn =
     (isDragAccept || acceptedFiles.length > 0) && !apiError; // Checking that there isn't an apiError set to prevent disappearance of button if image creation isn't available in a region at that moment, etc.
 
-  const dropZoneClasses = React.useMemo(
-    () =>
-      cx({
-        [classes.active]: isDragActive,
-        [classes.accept]: isDragAccept,
-        [classes.reject]: isDragReject,
-        [classes.inactive]: dropzoneDisabled || uploadInProgressOrFinished,
-      }),
-    [
-      isDragActive,
-      isDragAccept,
-      isDragReject,
-      dropzoneDisabled,
-      uploadInProgressOrFinished,
-    ]
-  );
-
   // const UploadZoneActive =
   //   state.files.filter((upload) => upload.status !== 'QUEUED').length !== 0;
 
@@ -330,9 +311,11 @@ export const FileUploader = React.memo((props: FileUploaderProps) => {
 
   return (
     <StyledDropZoneDiv
-      {...getRootProps({
-        className: `${dropZoneClasses}`,
-      })}
+      {...getRootProps({})}
+      isDragActive={isDragActive}
+      isDragAccept={isDragAccept}
+      isDragReject={isDragReject}
+      dropzoneDisabled={dropzoneDisabled || uploadInProgressOrFinished}
     >
       <input {...getInputProps()} placeholder={placeholder} />
       <StyledFileUploadsDiv>

--- a/packages/manager/src/features/Images/ImageUpload.tsx
+++ b/packages/manager/src/features/Images/ImageUpload.tsx
@@ -9,7 +9,7 @@ import Button from 'src/components/Button';
 import CheckBox from 'src/components/CheckBox';
 import { ConfirmationDialog } from 'src/components/ConfirmationDialog/ConfirmationDialog';
 import { RegionSelect } from 'src/components/EnhancedSelect/variants/RegionSelect';
-import FileUploader from 'src/components/FileUploader/FileUploader';
+import { FileUploader } from 'src/components/FileUploader/FileUploader';
 import Link from 'src/components/Link';
 import { LinodeCLIModal } from 'src/components/LinodeCLIModal/LinodeCLIModal';
 import { Notice } from 'src/components/Notice/Notice';

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/FileUpload.styles.ts
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/FileUpload.styles.ts
@@ -1,8 +1,10 @@
-import Typography from 'src/components/core/Typography';
-import { makeStyles } from 'tss-react/mui';
-import { styled } from '@mui/material/styles';
-import type { FileUploadProps } from './FileUpload';
 import type { Theme } from '@mui/material/styles';
+import { styled } from '@mui/material/styles';
+import UploadPending from 'src/assets/icons/uploadPending.svg';
+import Typography from 'src/components/core/Typography';
+import { rotate360 } from 'src/styles/keyframes';
+import { makeStyles } from 'tss-react/mui';
+import type { FileUploadProps } from './FileUpload';
 
 export const StyledRootContainer = styled('div', {
   label: 'StyledRootContainer',
@@ -43,6 +45,12 @@ export const StyledRightWrapper = styled('div', {
 })(() => ({
   display: 'flex',
   alignItems: 'center',
+}));
+
+export const StyledUploadPending = styled(UploadPending, {
+  label: 'StyledUploadPending',
+})(() => ({
+  animation: `${rotate360} 2s linear infinite`,
 }));
 
 export const StyledFileSizeTypography = styled(Typography, {
@@ -91,16 +99,5 @@ export const useStyles = makeStyles()((theme: Theme) => ({
     width: '100%',
     position: 'absolute',
     zIndex: 1,
-  },
-  rotate: {
-    animation: '$rotate 2s linear infinite',
-  },
-  '@keyframes rotate': {
-    from: {
-      transform: 'rotate(360deg)',
-    },
-    to: {
-      transform: 'rotate(0deg)',
-    },
   },
 }));

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/FileUpload.styles.ts
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/FileUpload.styles.ts
@@ -49,8 +49,9 @@ export const StyledRightWrapper = styled('div', {
 
 export const StyledUploadPending = styled(UploadPending, {
   label: 'StyledUploadPending',
-})(() => ({
+})(({ theme }) => ({
   animation: `${rotate360} 2s linear infinite`,
+  color: theme.textColors.headlineStatic,
 }));
 
 export const StyledFileSizeTypography = styled(Typography, {

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/FileUpload.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/FileUpload.tsx
@@ -104,11 +104,7 @@ export const FileUpload = React.memo((props: FileUploadProps) => {
               width={22}
             />
           ) : (
-            <StyledUploadPending
-              className={classes.iconRight}
-              height={22}
-              width={22}
-            />
+            <StyledUploadPending height={22} width={22} />
           )}
         </StyledRightWrapper>
       </StyledContainer>

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/FileUpload.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/FileUpload.tsx
@@ -1,12 +1,10 @@
 import * as React from 'react';
-import Button from 'src/components/Button';
 import CautionIcon from 'src/assets/icons/caution.svg';
 import FileUploadComplete from 'src/assets/icons/fileUploadComplete.svg';
-import UploadPending from 'src/assets/icons/uploadPending.svg';
+import Button from 'src/components/Button';
+import { LinearProgress } from 'src/components/LinearProgress';
 import Tooltip from 'src/components/core/Tooltip';
 import Typography from 'src/components/core/Typography';
-import { LinearProgress } from 'src/components/LinearProgress';
-import { ObjectUploaderAction } from './reducer';
 import { readableBytes } from 'src/utilities/unitConversions';
 import {
   StyledActionsContainer,
@@ -15,8 +13,10 @@ import {
   StyledLeftWrapper,
   StyledRightWrapper,
   StyledRootContainer,
+  StyledUploadPending,
   useStyles,
 } from './FileUpload.styles';
+import { ObjectUploaderAction } from './reducer';
 
 export interface FileUploadProps {
   dispatch: React.Dispatch<ObjectUploaderAction>;
@@ -104,8 +104,8 @@ export const FileUpload = React.memo((props: FileUploadProps) => {
               width={22}
             />
           ) : (
-            <UploadPending
-              className={`${classes.iconRight} ${classes.rotate}`}
+            <StyledUploadPending
+              className={classes.iconRight}
               height={22}
               width={22}
             />


### PR DESCRIPTION
## Description 📝
- Fix bug where the upload arrow wasn't animating
- Migrate styles for the FileUploader component and code pattern updates

## Preview 📷
Before

https://github.com/linode/manager/assets/115299789/b9101542-592b-4d2f-ba31-f0c789c472df

After

https://github.com/linode/manager/assets/115299789/9857eced-d717-4e1c-a590-4ddd8d3572ad

## How to test 🧪
Check the success/error states of the File Upload in `/images/create/upload` and in an Object Storage bucket, ensure there are no regressions
