### PR TITLE
refactor: [M3-6362,M3-6365] - Update `Components > ModeSelect, NavTabs`

### DIFF
--- a/packages/manager/src/components/ModeSelect/ModeSelect.tsx
+++ b/packages/manager/src/components/ModeSelect/ModeSelect.tsx
@@ -8,19 +8,14 @@ export interface Mode<modes> {
   mode: modes;
 }
 
-interface Props {
+interface ModeSelectProps {
   selected: string;
   modes: Mode<any>[];
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-type CombinedProps = Props;
-
-export const ModeSelect: React.FC<CombinedProps> = ({
-  modes,
-  onChange,
-  selected,
-}) => {
+export const ModeSelect = React.memo((props: ModeSelectProps) => {
+  const { modes, onChange, selected } = props;
   return (
     <RadioGroup
       aria-label="mode"
@@ -40,6 +35,4 @@ export const ModeSelect: React.FC<CombinedProps> = ({
       ))}
     </RadioGroup>
   );
-};
-
-export default React.memo(ModeSelect);
+});

--- a/packages/manager/src/components/ModeSelect/index.tsx
+++ b/packages/manager/src/components/ModeSelect/index.tsx
@@ -1,3 +1,0 @@
-import ModeSelect, { Mode as _Mode } from './ModeSelect';
-export interface Mode<modes> extends _Mode<modes> {}
-export default ModeSelect;

--- a/packages/manager/src/components/NavTabs/NavTabs.tsx
+++ b/packages/manager/src/components/NavTabs/NavTabs.tsx
@@ -25,9 +25,7 @@ export interface NavTabsProps {
   navToTabRouteOnChange?: boolean;
 }
 
-type CombinedProps = NavTabsProps;
-
-const NavTabs: React.FC<CombinedProps> = (props) => {
+export const NavTabs = React.memo((props: NavTabsProps) => {
   const history = useHistory();
   const reactRouterLocation = useLocation();
 
@@ -85,9 +83,7 @@ const NavTabs: React.FC<CombinedProps> = (props) => {
       </React.Suspense>
     </ReachTabs>
   );
-};
-
-export default React.memo(NavTabs);
+});
 
 // Given tabs and a pathname, return the index of the matched tab, and whether
 // or not it's an exact match. If no match is found, the returned index is -1.

--- a/packages/manager/src/components/NavTabs/index.ts
+++ b/packages/manager/src/components/NavTabs/index.ts
@@ -1,5 +1,0 @@
-import NavTabs, { NavTabsProps as _TabsProps } from './NavTabs';
-
-// eslint-disable-next-line
-export interface TabsProps extends _TabsProps {}
-export default NavTabs;

--- a/packages/manager/src/features/Images/ImagesCreate/ImageCreate.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/ImageCreate.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { RouteComponentProps, withRouter, useHistory } from 'react-router-dom';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
-import NavTabs, { NavTab } from 'src/components/NavTabs/NavTabs';
+import { NavTabs, NavTab } from 'src/components/NavTabs/NavTabs';
 import SuspenseLoader from 'src/components/SuspenseLoader';
 
 type CombinedProps = RouteComponentProps<{}>;

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.tsx
@@ -18,7 +18,7 @@ import Drawer from 'src/components/Drawer';
 import { Item } from 'src/components/EnhancedSelect/Select';
 import Grid from '@mui/material/Unstable_Grid2';
 import { Link } from 'src/components/Link';
-import ModeSelect, { Mode } from 'src/components/ModeSelect';
+import { ModeSelect, Mode } from 'src/components/ModeSelect/ModeSelect';
 import { Notice } from 'src/components/Notice/Notice';
 import TextField from 'src/components/TextField';
 import { TextTooltip } from 'src/components/TextTooltip';

--- a/packages/manager/src/features/Managed/ManagedLanding.tsx
+++ b/packages/manager/src/features/Managed/ManagedLanding.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import { NavTab } from 'src/components/NavTabs/NavTabs';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import LandingHeader from 'src/components/LandingHeader';
-import NavTabs from 'src/components/NavTabs';
+import { NavTab, NavTabs } from 'src/components/NavTabs/NavTabs';
 import ManagedDashboardCard from './ManagedDashboardCard';
 import SupportWidget from './SupportWidget';
 

--- a/packages/manager/src/features/Profile/Profile.tsx
+++ b/packages/manager/src/features/Profile/Profile.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import LandingHeader from 'src/components/LandingHeader';
-import NavTabs, { NavTab } from 'src/components/NavTabs/NavTabs';
+import { NavTab, NavTabs } from 'src/components/NavTabs/NavTabs';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 

--- a/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptPanel.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptPanel.tsx
@@ -3,8 +3,7 @@ import { Linode } from '@linode/api-v4/lib/linodes';
 import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
-import NavTabs from 'src/components/NavTabs';
-import { NavTab } from 'src/components/NavTabs/NavTabs';
+import { NavTab, NavTabs } from 'src/components/NavTabs/NavTabs';
 import RenderGuard from 'src/components/RenderGuard';
 import { useProfile } from 'src/queries/profile';
 import {

--- a/packages/manager/src/features/TopMenu/NotificationMenu/NotificationMenu.tsx
+++ b/packages/manager/src/features/TopMenu/NotificationMenu/NotificationMenu.tsx
@@ -25,6 +25,30 @@ import { useNotificationsQuery } from 'src/queries/accountNotifications';
 import usePrevious from 'src/hooks/usePrevious';
 import { isPropValid } from 'src/utilities/isPropValid';
 
+const NotificationIconWrapper = styled(StyledTopMenuIconWrapper, {
+  label: 'NotificationIconWrapper',
+  shouldForwardProp: (prop) => isPropValid(['isMenuOpen'], prop),
+})<{
+  isMenuOpen: boolean;
+}>(({ ...props }) => ({
+  color: props.isMenuOpen ? '#606469' : '#c9c7c7',
+}));
+
+const NotificationIconBadge = styled('div')(({ theme }) => ({
+  alignItems: 'center',
+  backgroundColor: theme.color.green,
+  borderRadius: '50%',
+  color: 'white',
+  display: 'flex',
+  fontSize: '0.72rem',
+  height: '1rem',
+  justifyContent: 'center',
+  left: 20,
+  position: 'absolute',
+  top: 2,
+  width: '1rem',
+}));
+
 export const NotificationMenu = () => {
   const theme = useTheme();
 
@@ -165,27 +189,3 @@ export const NotificationMenu = () => {
     </>
   );
 };
-
-const NotificationIconWrapper = styled(StyledTopMenuIconWrapper, {
-  label: 'NotificationIconWrapper',
-  shouldForwardProp: (prop) => isPropValid(['isMenuOpen'], prop),
-})<{
-  isMenuOpen: boolean;
-}>(({ ...props }) => ({
-  color: props.isMenuOpen ? '#606469' : '#c9c7c7',
-}));
-
-const NotificationIconBadge = styled('div')(({ theme }) => ({
-  alignItems: 'center',
-  backgroundColor: theme.color.green,
-  borderRadius: '50%',
-  color: 'white',
-  display: 'flex',
-  fontSize: '0.72rem',
-  height: '1rem',
-  justifyContent: 'center',
-  left: 20,
-  position: 'absolute',
-  top: 2,
-  width: '1rem',
-}));

--- a/packages/manager/src/features/TopMenu/NotificationMenu/NotificationMenu.tsx
+++ b/packages/manager/src/features/TopMenu/NotificationMenu/NotificationMenu.tsx
@@ -25,30 +25,6 @@ import { useNotificationsQuery } from 'src/queries/accountNotifications';
 import usePrevious from 'src/hooks/usePrevious';
 import { isPropValid } from 'src/utilities/isPropValid';
 
-const NotificationIconWrapper = styled(StyledTopMenuIconWrapper, {
-  label: 'NotificationIconWrapper',
-  shouldForwardProp: (prop) => isPropValid(['isMenuOpen'], prop),
-})<{
-  isMenuOpen: boolean;
-}>(({ ...props }) => ({
-  color: props.isMenuOpen ? '#606469' : '#c9c7c7',
-}));
-
-const NotificationIconBadge = styled('div')(({ theme }) => ({
-  alignItems: 'center',
-  backgroundColor: theme.color.green,
-  borderRadius: '50%',
-  color: 'white',
-  display: 'flex',
-  fontSize: '0.72rem',
-  height: '1rem',
-  justifyContent: 'center',
-  left: 20,
-  position: 'absolute',
-  top: 2,
-  width: '1rem',
-}));
-
 export const NotificationMenu = () => {
   const theme = useTheme();
 
@@ -189,3 +165,27 @@ export const NotificationMenu = () => {
     </>
   );
 };
+
+const NotificationIconWrapper = styled(StyledTopMenuIconWrapper, {
+  label: 'NotificationIconWrapper',
+  shouldForwardProp: (prop) => isPropValid(['isMenuOpen'], prop),
+})<{
+  isMenuOpen: boolean;
+}>(({ ...props }) => ({
+  color: props.isMenuOpen ? '#606469' : '#c9c7c7',
+}));
+
+const NotificationIconBadge = styled('div')(({ theme }) => ({
+  alignItems: 'center',
+  backgroundColor: theme.color.green,
+  borderRadius: '50%',
+  color: 'white',
+  display: 'flex',
+  fontSize: '0.72rem',
+  height: '1rem',
+  justifyContent: 'center',
+  left: 20,
+  position: 'absolute',
+  top: 2,
+  width: '1rem',
+}));

--- a/packages/manager/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
@@ -32,11 +32,11 @@ import { array, object, string } from 'yup';
 import ConfigSelect from './ConfigSelect';
 import LabelField from './LabelField';
 import { modes } from './modes';
-import { ModeSelection } from './ModeSelection';
 import NoticePanel from './NoticePanel';
 import { PricePanel } from './PricePanel';
 import SizeField from './SizeField';
 import VolumesActionsPanel from './VolumesActionsPanel';
+import { ModeSelection } from './ModeSelection';
 
 const useStyles = makeStyles((theme: Theme) => ({
   textWrapper: {


### PR DESCRIPTION
## Description 📝
These were MUI Migration tickets, but there were no styles to migrate.

I looked into removing Reach UI from NavTabs in favor of the MUI Tabs but decided that effort should be its own tech story due to the amount of tab-related components we have and how widely we use tabs across the app. A ticket for this is now in our backlog: M3-6705.

## Major Changes 🔄
- Use named rather than default exports
- Update props names
- Remove React.FC

## How to test 🧪
Check that there have been no regressions in NavTabs or ModeSelect components in the app. 
NavTabs can be found on https://localhost:3000/profile/display and ModeSelect can be found on the Linode Disk Drawer from Linode Details > Storage > Add Disk.