### PR TITLE
refactor: [M3-6351] - Refactor `<IPSelect />`

### DIFF
--- a/packages/manager/.changeset/pr-9263-tech-stories-1686839868932.md
+++ b/packages/manager/.changeset/pr-9263-tech-stories-1686839868932.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Refactor <IPSelect /> ([#9263](https://github.com/linode/manager/pull/9263))

--- a/packages/manager/src/components/IPSelect/IPSelect.tsx
+++ b/packages/manager/src/components/IPSelect/IPSelect.tsx
@@ -1,10 +1,6 @@
-import { Linode } from '@linode/api-v4/lib/linodes';
 import * as React from 'react';
-import { compose } from 'recompose';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
-import withLinodes, {
-  Props as LinodeProps,
-} from 'src/containers/withLinodes.container';
+import { useLinodeQuery } from 'src/queries/linodes/linodes';
 
 interface Props {
   linodeId: number;
@@ -14,22 +10,10 @@ interface Props {
   errorText?: string;
 }
 
-interface WithLinodesProps
-  extends Pick<LinodeProps, 'linodesLoading' | 'linodesError'> {
-  linode?: Linode;
-}
+export const IPSelect = (props: Props) => {
+  const { linodeId, value, handleChange, customizeOptions } = props;
 
-type CombinedProps = Props & WithLinodesProps;
-
-const IPSelect: React.FC<CombinedProps> = (props) => {
-  const {
-    linode,
-    value,
-    handleChange,
-    linodesLoading,
-    linodesError,
-    customizeOptions,
-  } = props;
+  const { data: linode, isLoading, error } = useLinodeQuery(linodeId);
 
   const ips: string[] = [];
 
@@ -55,7 +39,7 @@ const IPSelect: React.FC<CombinedProps> = (props) => {
 
   if (props.errorText) {
     errorText = props.errorText;
-  } else if (linodesError) {
+  } else if (error) {
     errorText =
       'There was an error retrieving this Linode\u{2019}s IP addresses.';
   }
@@ -65,25 +49,11 @@ const IPSelect: React.FC<CombinedProps> = (props) => {
       value={options.find((option) => option.value === value.value)}
       label="IP Address"
       options={options}
-      isLoading={linodesLoading}
-      onChange={(selected: Item<string>) => handleChange(selected.value)}
+      isLoading={isLoading}
+      onChange={(selected) => handleChange(selected.value)}
       errorText={errorText}
       isClearable={false}
       placeholder="Select an IP Address..."
     />
   );
 };
-
-const enhanced = compose<CombinedProps, Props>(
-  withLinodes<WithLinodesProps, Props>(
-    (ownProps, linodesData, linodesLoading, linodesError) => ({
-      ...ownProps,
-      // Find the Linode in Redux that corresponds with the given ID.
-      linode: linodesData.find((linode) => linode.id === ownProps.linodeId),
-      linodesLoading,
-      linodesError,
-    })
-  )
-);
-
-export default enhanced(IPSelect);

--- a/packages/manager/src/components/IPSelect/index.ts
+++ b/packages/manager/src/components/IPSelect/index.ts
@@ -1,2 +1,0 @@
-import IPSelect from './IPSelect';
-export default IPSelect;

--- a/packages/manager/src/factories/linodes.ts
+++ b/packages/manager/src/factories/linodes.ts
@@ -198,7 +198,7 @@ export const linodeFactory = Factory.Sync.makeFactory<Linode>({
   image: 'linode/debian10',
   watchdog_enabled: true,
   status: 'running',
-  ipv4: ['192.168.0.0'],
+  ipv4: ['50.116.6.212', '192.168.203.1'],
   ipv6: '2600:3c00::f03c:92ff:fee2:6c40/64',
   group: '',
   alerts: linodeAlertsFactory.build(),

--- a/packages/manager/src/features/Managed/SSHAccess/EditSSHAccessDrawer.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/EditSSHAccessDrawer.tsx
@@ -9,7 +9,7 @@ import { Theme } from '@mui/material/styles';
 import Typography from 'src/components/core/Typography';
 import Drawer from 'src/components/Drawer';
 import Grid from '@mui/material/Unstable_Grid2';
-import IPSelect from 'src/components/IPSelect';
+import { IPSelect } from 'src/components/IPSelect/IPSelect';
 import { Notice } from 'src/components/Notice/Notice';
 import TextField from 'src/components/TextField';
 import { Toggle } from 'src/components/Toggle';

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -451,6 +451,10 @@ export const handlers = [
     ];
     return res(ctx.json(makeResourcePage(linodes)));
   }),
+  rest.get('*/linode/instances/:id', async (req, res, ctx) => {
+    const id = Number(req.params.clusterId);
+    return res(ctx.json(linodeFactory.build({ id })));
+  }),
   rest.delete('*/instances/*', async (req, res, ctx) => {
     return res(ctx.json({}));
   }),

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -452,7 +452,7 @@ export const handlers = [
     return res(ctx.json(makeResourcePage(linodes)));
   }),
   rest.get('*/linode/instances/:id', async (req, res, ctx) => {
-    const id = Number(req.params.clusterId);
+    const id = Number(req.params.id);
     return res(ctx.json(linodeFactory.build({ id })));
   }),
   rest.delete('*/instances/*', async (req, res, ctx) => {


### PR DESCRIPTION
## Description 📝

- This ticket is technically a style migration ticket but no styles are needed so I am going to refactor this to use RQ

## Major Changes 🔄
- Makes `<IPSelect />` source data from React Query
- Made the Linode mock data more realistic

## Preview 📷
![Screenshot 2023-06-15 at 10 27 24 AM](https://github.com/linode/manager/assets/115251059/b38365a2-6563-416e-b048-fb3d855f69d1)

## How to test 🧪
1. Enable the MSW
2. Go to `http://localhost:3000/managed/ssh-access`
3. Click edit on a row
4. Verify that the IP Select component shows IP addresses

If you want to test further
1. Enable managed on your account
2. Go to `http://localhost:3000/managed/ssh-access`
3. Click edit on a row
3. Test the IP Select component 
