### PR TITLE
refactor: [M3-6352] - MUI v5 Migration - `Components > LabelAndTagsPanel`

### DIFF
--- a/packages/manager/.changeset/pr-9270-tech-stories-1686927343871.md
+++ b/packages/manager/.changeset/pr-9270-tech-stories-1686927343871.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+MUI v5 Migration - `Components > LabelAndTagsPanel` ([#9270](https://github.com/linode/manager/pull/9270))

--- a/packages/manager/src/components/LabelAndTagsPanel/LabelAndTagsPanel.test.tsx
+++ b/packages/manager/src/components/LabelAndTagsPanel/LabelAndTagsPanel.test.tsx
@@ -1,52 +1,69 @@
-import { shallow } from 'enzyme';
 import * as React from 'react';
+import { LabelAndTagsPanel } from './LabelAndTagsPanel';
+import { renderWithTheme } from 'src/utilities/testHelpers';
 
-import { InfoPanel } from './LabelAndTagsPanel';
-
-const onLabelChange = () => jest.fn();
-const onTagsChange = () => jest.fn();
+const onLabelChange = jest.fn();
+const onTagsChange = jest.fn();
+const INPUT_LABEL = 'Linode Label';
+const TAG_LABEL = 'Custom Label';
 
 describe('Tags list', () => {
   it('should render tags input if tagsInputProps are specified', () => {
-    const component = shallow(
-      <InfoPanel
+    const { getByLabelText, queryByText } = renderWithTheme(
+      <LabelAndTagsPanel
         labelFieldProps={{
-          label: 'Linode Label',
-          value: '',
+          label: INPUT_LABEL,
           onChange: onLabelChange,
-          errorText: 'Your label is rude!',
+          value: '',
         }}
         tagsInputProps={{
-          value: ['a', 'b'].map((tag) => ({ label: tag, value: tag })),
+          label: TAG_LABEL,
           onChange: onTagsChange,
-          tagError: 'Tag names are too short!',
-        }}
-        classes={{
-          root: '',
-          inner: '',
-          expPanelButton: '',
+          value: ['tag1', 'tag2'].map((tag) => ({ label: tag, value: tag })),
         }}
       />
     );
-    expect(component.find('TagsInput')).toHaveLength(1);
+
+    expect(getByLabelText(TAG_LABEL)).toBeInTheDocument();
+    expect(queryByText('tag1')).toBeInTheDocument();
+    expect(queryByText('tag2')).toBeInTheDocument();
+  });
+
+  it('should render error text if errorText or tagError is specified', () => {
+    const { getByText } = renderWithTheme(
+      <LabelAndTagsPanel
+        labelFieldProps={{
+          errorText: 'Your label is rude!',
+          label: INPUT_LABEL,
+          onChange: onLabelChange,
+          value: '',
+        }}
+        tagsInputProps={{
+          label: TAG_LABEL,
+          onChange: onTagsChange,
+          tagError: 'Tag names are too short!',
+          value: ['a', 'b'].map((tag) => ({
+            label: tag,
+            value: tag,
+          })),
+        }}
+      />
+    );
+
+    expect(getByText('Your label is rude!')).toBeInTheDocument();
+    expect(getByText('Tag names are too short!')).toBeInTheDocument();
   });
 
   it('should NOT render tags input if tagsInputProps are NOT specified', () => {
-    const component = shallow(
-      <InfoPanel
+    const { queryByLabelText } = renderWithTheme(
+      <LabelAndTagsPanel
         labelFieldProps={{
-          label: 'Linode Label',
-          value: '',
+          label: INPUT_LABEL,
           onChange: onLabelChange,
-          errorText: 'Your label is rude!',
-        }}
-        classes={{
-          root: '',
-          inner: '',
-          expPanelButton: '',
+          value: '',
         }}
       />
     );
-    expect(component.find('TagsInput')).toHaveLength(0);
+    expect(queryByLabelText(TAG_LABEL)).not.toBeInTheDocument();
   });
 });

--- a/packages/manager/src/components/LabelAndTagsPanel/LabelAndTagsPanel.tsx
+++ b/packages/manager/src/components/LabelAndTagsPanel/LabelAndTagsPanel.tsx
@@ -19,7 +19,7 @@ export const LabelAndTagsPanel = (props: Props) => {
     <Paper
       data-qa-label-header
       sx={{
-        backgroundColor: 'red',
+        backgroundColor: theme.color.white,
         flexGrow: 1,
         marginTop: theme.spacing(3),
         width: '100%',

--- a/packages/manager/src/components/LabelAndTagsPanel/LabelAndTagsPanel.tsx
+++ b/packages/manager/src/components/LabelAndTagsPanel/LabelAndTagsPanel.tsx
@@ -1,60 +1,40 @@
 import * as React from 'react';
-import { compose } from 'recompose';
 import Paper from 'src/components/core/Paper';
-import { createStyles, withStyles, WithStyles } from '@mui/styles';
-import { Theme } from '@mui/material/styles';
-import { Notice } from 'src/components/Notice/Notice';
-import RenderGuard, { RenderGuardProps } from 'src/components/RenderGuard';
-import { TagsInput, TagsInputProps } from 'src/components/TagsInput/TagsInput';
 import TextField, { Props as TextFieldProps } from 'src/components/TextField';
+import { Notice } from 'src/components/Notice/Notice';
+import { TagsInput, TagsInputProps } from 'src/components/TagsInput/TagsInput';
+import { useTheme } from '@mui/material/styles';
 
-type ClassNames = 'root' | 'inner' | 'expPanelButton';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {
-      flexGrow: 1,
-      width: '100%',
-      marginTop: theme.spacing(3),
-      backgroundColor: theme.color.white,
-    },
-    expPanelButton: {
-      padding: 0,
-      marginTop: theme.spacing(2),
-    },
-  });
-
-const styled = withStyles(styles);
 interface Props {
   error?: string;
   labelFieldProps?: TextFieldProps;
   tagsInputProps?: TagsInputProps;
 }
 
-type CombinedProps = Props & WithStyles<ClassNames>;
+export const LabelAndTagsPanel = (props: Props) => {
+  const theme = useTheme();
+  const { error, labelFieldProps, tagsInputProps } = props;
 
-export class InfoPanel extends React.Component<CombinedProps> {
-  render() {
-    const { classes, error, labelFieldProps, tagsInputProps } = this.props;
-
-    return (
-      <Paper className={classes.root} data-qa-label-header>
-        {error && <Notice text={error} error />}
-        <TextField
-          {...(labelFieldProps || {
-            label: 'Label',
-            placeholder: 'Enter a label',
-          })}
-          data-qa-label-input
-          noMarginTop
-        />
-        {tagsInputProps && <TagsInput {...tagsInputProps} />}
-      </Paper>
-    );
-  }
-}
-
-export default compose<CombinedProps, Props & RenderGuardProps>(
-  RenderGuard,
-  styled
-)(InfoPanel);
+  return (
+    <Paper
+      data-qa-label-header
+      sx={{
+        backgroundColor: 'red',
+        flexGrow: 1,
+        marginTop: theme.spacing(3),
+        width: '100%',
+      }}
+    >
+      {error && <Notice text={error} error />}
+      <TextField
+        {...(labelFieldProps || {
+          label: 'Label',
+          placeholder: 'Enter a label',
+        })}
+        data-qa-label-input
+        noMarginTop
+      />
+      {tagsInputProps && <TagsInput {...tagsInputProps} />}
+    </Paper>
+  );
+};

--- a/packages/manager/src/components/LabelAndTagsPanel/LabelAndTagsPanel.tsx
+++ b/packages/manager/src/components/LabelAndTagsPanel/LabelAndTagsPanel.tsx
@@ -11,7 +11,7 @@ interface LabelAndTagsProps {
   tagsInputProps?: TagsInputProps;
 }
 
-export const LabelAndTagsPanel = (props: Props) => {
+export const LabelAndTagsPanel = (props: LabelAndTagsProps) => {
   const theme = useTheme();
   const { error, labelFieldProps, tagsInputProps } = props;
 

--- a/packages/manager/src/components/LabelAndTagsPanel/LabelAndTagsPanel.tsx
+++ b/packages/manager/src/components/LabelAndTagsPanel/LabelAndTagsPanel.tsx
@@ -5,7 +5,7 @@ import { Notice } from 'src/components/Notice/Notice';
 import { TagsInput, TagsInputProps } from 'src/components/TagsInput/TagsInput';
 import { useTheme } from '@mui/material/styles';
 
-interface Props {
+interface LabelAndTagsProps {
   error?: string;
   labelFieldProps?: TextFieldProps;
   tagsInputProps?: TagsInputProps;

--- a/packages/manager/src/components/LabelAndTagsPanel/index.tsx
+++ b/packages/manager/src/components/LabelAndTagsPanel/index.tsx
@@ -1,2 +1,0 @@
-import LabelAndTagsPanel from './LabelAndTagsPanel';
-export default LabelAndTagsPanel;

--- a/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/LinodeCreate.tsx
@@ -20,7 +20,7 @@ import Typography from 'src/components/core/Typography';
 import DocsLink from 'src/components/DocsLink';
 import { ErrorState } from 'src/components/ErrorState/ErrorState';
 import Grid from '@mui/material/Unstable_Grid2';
-import LabelAndTagsPanel from 'src/components/LabelAndTagsPanel';
+import { LabelAndTagsPanel } from 'src/components/LabelAndTagsPanel/LabelAndTagsPanel';
 import { Notice } from 'src/components/Notice/Notice';
 import { SafeTabPanel } from 'src/components/SafeTabPanel/SafeTabPanel';
 import { SelectRegionPanel } from 'src/components/SelectRegionPanel/SelectRegionPanel';
@@ -748,7 +748,6 @@ export class LinodeCreate extends React.PureComponent<
                 ? tagsInputProps
                 : undefined
             }
-            updateFor={[tags, label, errors]}
           />
           {/* Hide for backups and clone */}
           {!['fromBackup', 'fromLinode'].includes(this.props.createType) && (


### PR DESCRIPTION
## Description 📝
Refactored `LabelAndTagsPanel` by removing jss, converting to functional component.

## Major Changes 🔄
- Converted from class to functional component
- Removed render guards
- Converted tests from Enzyme to RTL and added some more tests

## Preview 📷
<img width="556" alt="Screenshot 2023-06-16 at 10 52 38 AM" src="https://github.com/linode/manager/assets/125309814/d74b7d0a-bc8c-4fd4-a149-af281ad4cac3">

## How to test 🧪
1. Ensure everything renders and functionality is unchanged
2. Run tests `yarn test packages/manager/src/components/LabelAndTagsPanel/LabelAndTagsPanel.test.tsx`