### PR TITLE
refactor: Round dates on the filters for invoices and payments

### DIFF
--- a/packages/manager/.changeset/pr-9271-tech-stories-1686927837582.md
+++ b/packages/manager/.changeset/pr-9271-tech-stories-1686927837582.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Refactor billing activity filters to improve caching ([#9271](https://github.com/linode/manager/pull/9271))

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.test.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.test.tsx
@@ -179,9 +179,7 @@ describe('paymentToActivityFeedItem', () => {
       expect(getCutoffFromDateRange('12 Months', testDateISO)).toBe(
         testDate.minus({ months: 12 }).toISO()
       );
-      expect(getCutoffFromDateRange('All Time', testDateISO)).toBe(
-        DateTime.fromMillis(0, { zone: 'utc' }).toISO()
-      );
+      expect(getCutoffFromDateRange('All Time', testDateISO)).toBeUndefined();
     });
   });
 

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -39,7 +39,7 @@ import {
   useAllAccountInvoices,
   useAllAccountPayments,
 } from 'src/queries/accountBilling';
-import { isAfter, parseAPIDate } from 'src/utilities/date';
+import { parseAPIDate } from 'src/utilities/date';
 import formatDate from 'src/utilities/formatDate';
 import { getAll } from 'src/utilities/getAll';
 import { getTaxID } from '../../billingUtils';
@@ -317,23 +317,12 @@ export const BillingActivityPanel = (props: Props) => {
     [invoices, payments]
   );
 
-  // Filter on transaction type and transaction date.
+  // Filter on transaction type
   const filteredData = React.useMemo(() => {
-    return combinedData.filter((thisBillingItem) => {
-      const matchesType =
-        selectedTransactionType !== 'all'
-          ? thisBillingItem.type === selectedTransactionType
-          : true;
-
-      const dateCutoff = getCutoffFromDateRange(selectedTransactionDate);
-
-      const matchesDate = dateCutoff
-        ? isAfter(thisBillingItem.date, dateCutoff)
-        : true;
-
-      return matchesType && matchesDate;
-    });
-  }, [selectedTransactionType, selectedTransactionDate, combinedData]);
+    return combinedData.filter(
+      (thisBillingItem) => thisBillingItem.type === selectedTransactionType
+    );
+  }, [selectedTransactionType, combinedData]);
 
   return (
     <Grid xs={12}>
@@ -399,7 +388,11 @@ export const BillingActivityPanel = (props: Props) => {
             </div>
           </div>
         </div>
-        <OrderBy data={filteredData} orderBy={'date'} order={'desc'}>
+        <OrderBy
+          data={selectedTransactionType === 'all' ? combinedData : filteredData}
+          orderBy={'date'}
+          order={'desc'}
+        >
           {React.useCallback(
             ({ data: orderedData }) => (
               <Paginate pageSize={25} data={orderedData} shouldScroll={false}>

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -203,23 +203,22 @@ export const BillingActivityPanel = (props: Props) => {
     setSelectedTransactionDate,
   ] = React.useState<DateRange>(defaultDateRange);
 
+  const endDate =
+    selectedTransactionDate !== 'All Time'
+      ? getCutoffFromDateRange(selectedTransactionDate)
+      : undefined;
+
   const {
     data: payments,
     isLoading: accountPaymentsLoading,
     error: accountPaymentsError,
-  } = useAllAccountPayments(
-    {},
-    makeFilter(getCutoffFromDateRange(selectedTransactionDate))
-  );
+  } = useAllAccountPayments({}, makeFilter(endDate));
 
   const {
     data: invoices,
     isLoading: accountInvoicesLoading,
     error: accountInvoicesError,
-  } = useAllAccountInvoices(
-    {},
-    makeFilter(getCutoffFromDateRange(selectedTransactionDate))
-  );
+  } = useAllAccountInvoices({}, makeFilter(endDate));
 
   const downloadInvoicePDF = React.useCallback(
     (invoiceId: number) => {

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -203,22 +203,20 @@ export const BillingActivityPanel = (props: Props) => {
     setSelectedTransactionDate,
   ] = React.useState<DateRange>(defaultDateRange);
 
-  const endDate =
-    selectedTransactionDate !== 'All Time'
-      ? getCutoffFromDateRange(selectedTransactionDate)
-      : undefined;
+  const endDate = getCutoffFromDateRange(selectedTransactionDate);
+  const filter = makeFilter(endDate);
 
   const {
     data: payments,
     isLoading: accountPaymentsLoading,
     error: accountPaymentsError,
-  } = useAllAccountPayments({}, makeFilter(endDate));
+  } = useAllAccountPayments({}, filter);
 
   const {
     data: invoices,
     isLoading: accountInvoicesLoading,
     error: accountInvoicesError,
-  } = useAllAccountInvoices({}, makeFilter(endDate));
+  } = useAllAccountInvoices({}, filter);
 
   const downloadInvoicePDF = React.useCallback(
     (invoiceId: number) => {
@@ -329,7 +327,9 @@ export const BillingActivityPanel = (props: Props) => {
 
       const dateCutoff = getCutoffFromDateRange(selectedTransactionDate);
 
-      const matchesDate = isAfter(thisBillingItem.date, dateCutoff);
+      const matchesDate = dateCutoff
+        ? isAfter(thisBillingItem.date, dateCutoff)
+        : true;
 
       return matchesType && matchesDate;
     });
@@ -608,7 +608,11 @@ export const paymentToActivityFeedItem = (
 export const getCutoffFromDateRange = (
   range: DateRange,
   currentDatetime?: string
-): string => {
+): string | undefined => {
+  if (range === 'All Time') {
+    return undefined;
+  }
+
   const date = currentDatetime ? parseAPIDate(currentDatetime) : DateTime.utc();
 
   let outputDate: DateTime;

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -633,7 +633,7 @@ export const getCutoffFromDateRange = (
       outputDate = DateTime.fromMillis(0, { zone: 'utc' });
       break;
   }
-  return outputDate.toISO();
+  return outputDate.startOf('day').toISO();
 };
 
 /**


### PR DESCRIPTION
## Description 📝
On the Billing Activity table, requests to `/payments` and `/invoices` include a `date` filter depending on which time range the user has selected. 

E.g. if the user selected "30 days", Cloud requests invoices with a filter like this: `{ date: { "+gte": <currentDate - 30 days> } }`.

This negatively impacts RQ caching, because a new cache key is generated for every request (since the date is specified down to the _second_). 

**This PR rounds these dates to the start of the given day**. This means that RQ will cache results for an entire day.

**Additionally,** I removed the `date` filter when users select "All Time". Previously the unix epoch was used to keep the code simpler, but removing this altogether might be better from an API perspective.

## Preview 📷
![Screenshot 2023-06-16 at 10 54 42 AM](https://github.com/linode/manager/assets/114753608/b7b84df2-56a2-4f41-8006-70c8d9ba6c5a)

## How to test 🧪
- Run the app and test the /account page. 
- Open RQ dev tools and observe the caching when you select different date ranges
- This is a refactor and performance improvement: there should be no behavioral differences between what's here and what's in production.


