### PR TITLE
fix: [M3-6568] - Button alignment on Nodebalancer Create page

### DIFF
--- a/packages/manager/.changeset/pr-9272-fixed-1686929413003.md
+++ b/packages/manager/.changeset/pr-9272-fixed-1686929413003.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Button alignment on Nodebalancer Create page  ([#9272](https://github.com/linode/manager/pull/9272))

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -1,3 +1,6 @@
+import { Theme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { useTheme } from '@mui/styles';
 import * as React from 'react';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
@@ -103,6 +106,9 @@ const NodeBalancerCreate = () => {
 
   const disabled =
     Boolean(profile?.restricted) && !grants?.global.add_nodebalancers;
+
+  const theme = useTheme<Theme>();
+  const matchesSmDown = useMediaQuery(theme.breakpoints.down('md'));
 
   const addNodeBalancer = () => {
     if (disabled) {
@@ -520,6 +526,7 @@ const NodeBalancerCreate = () => {
         buttonType="outlined"
         onClick={addNodeBalancer}
         disabled={disabled}
+        sx={matchesSmDown ? { marginLeft: '16px' } : null}
       >
         Add another Configuration
       </Button>
@@ -553,6 +560,7 @@ const NodeBalancerCreate = () => {
           onClick={onCreate}
           loading={isLoading}
           data-qa-deploy-nodebalancer
+          sx={matchesSmDown ? { marginRight: '8px' } : null}
         >
           Create NodeBalancer
         </Button>

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -104,11 +104,11 @@ const NodeBalancerCreate = () => {
 
   const { mutateAsync: updateAgreements } = useMutateAccountAgreements();
 
-  const disabled =
-    Boolean(profile?.restricted) && !grants?.global.add_nodebalancers;
-
   const theme = useTheme<Theme>();
   const matchesSmDown = useMediaQuery(theme.breakpoints.down('md'));
+
+  const disabled =
+    Boolean(profile?.restricted) && !grants?.global.add_nodebalancers;
 
   const addNodeBalancer = () => {
     if (disabled) {

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -526,7 +526,7 @@ const NodeBalancerCreate = () => {
         buttonType="outlined"
         onClick={addNodeBalancer}
         disabled={disabled}
-        sx={matchesSmDown ? { marginLeft: '16px' } : null}
+        sx={matchesSmDown ? { marginLeft: theme.spacing(2) } : null}
       >
         Add another Configuration
       </Button>
@@ -560,7 +560,7 @@ const NodeBalancerCreate = () => {
           onClick={onCreate}
           loading={isLoading}
           data-qa-deploy-nodebalancer
-          sx={matchesSmDown ? { marginRight: '8px' } : null}
+          sx={matchesSmDown ? { marginRight: theme.spacing(1) } : null}
         >
           Create NodeBalancer
         </Button>


### PR DESCRIPTION
## Description 📝
At smaller screen sizes, the `Add Another Configuration` and `Create Nodebalancer` buttons on https://cloud.linode.com/nodebalancers/create were misaligned. 

## Major Changes 🔄
- Applies the necessary left or right margin to each button at smaller breakpoints to maintain consistent spacing.

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-06-16 at 8 20 23 AM](https://github.com/linode/manager/assets/114685994/9ce176ce-a119-467e-85a3-c735b02e63b6) | ![Screenshot 2023-06-16 at 8 20 39 AM](https://github.com/linode/manager/assets/114685994/f5f9aea4-e2f4-4260-aaf5-2a9039695b36) |

## How to test 🧪
1. **How to reproduce the issue (if applicable)?**
Go to https://cloud.linode.com/nodebalancers/create, use the browser dev tools to adjust viewport, and observe that the buttons are too close to the edge of the screen at smaller screen sizes.
2. **How to verify changes?**
Go to http://localhost:3000/nodebalancers/create, use the browser dev tools to adjust viewport, and observe that the buttons now have margins and are not too close to the edge of the screen at any screen size. 