### PR TITLE
Fix: [M3-6612] Grid/Tag views and toggle styling (Linodes Landing)

### DIFF
--- a/packages/manager/.changeset/pr-9273-fixed-1686932547524.md
+++ b/packages/manager/.changeset/pr-9273-fixed-1686932547524.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Linodes Landing Grid/Tag views and toggle button styling ([#9273](https://github.com/linode/manager/pull/9273))

--- a/packages/manager/src/components/EntityTable/EntityTableHeader.tsx
+++ b/packages/manager/src/components/EntityTable/EntityTableHeader.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import GroupByTag from 'src/assets/icons/group-by-tag.svg';
 import Hidden from 'src/components/core/Hidden';
-import { IconButton } from 'src/components/IconButton';
 import { makeStyles } from '@mui/styles';
 import { Theme } from '@mui/material/styles';
 import { TableHead } from 'src/components/TableHead';
@@ -11,6 +10,7 @@ import { TableCell } from 'src/components/TableCell';
 import { TableRow } from 'src/components/TableRow';
 import { TableSortCell } from 'src/components/TableSortCell';
 import { Entity, HeaderCell } from './types';
+import { StyledToggleButton } from 'src/features/Linodes/LinodesLanding/DisplayLinodes.styles';
 
 const useStyles = makeStyles((theme: Theme) => ({
   hiddenHeaderCell: theme.visually.hidden,
@@ -155,23 +155,8 @@ interface GroupByTagToggleProps {
   isLargeAccount?: boolean;
 }
 
-const useGroupByTagToggleStyles = makeStyles(() => ({
-  toggleButton: {
-    color: '#d2d3d4',
-    padding: '0 10px',
-    '&:focus': {
-      outline: '1px dotted #999',
-    },
-    '&.Mui-disabled': {
-      display: 'none',
-    },
-  },
-}));
-
 export const GroupByTagToggle: React.FC<GroupByTagToggleProps> = React.memo(
   (props) => {
-    const classes = useGroupByTagToggleStyles();
-
     const { toggleGroupByTag, isGroupedByTag, isLargeAccount } = props;
 
     return (
@@ -185,19 +170,19 @@ export const GroupByTagToggle: React.FC<GroupByTagToggleProps> = React.memo(
           placement="top-end"
           title={`${isGroupedByTag ? 'Ungroup' : 'Group'} by tag`}
         >
-          <IconButton
+          <StyledToggleButton
             aria-label={`Toggle group by tag`}
             aria-describedby={'groupByDescription'}
             onClick={toggleGroupByTag}
             disableRipple
-            className={classes.toggleButton}
+            isActive={isGroupedByTag}
             // Group by Tag is not available if you have a large account.
             // See https://github.com/linode/manager/pull/6653 for more details
             disabled={isLargeAccount}
             size="large"
           >
             <GroupByTag />
-          </IconButton>
+          </StyledToggleButton>
         </Tooltip>
       </>
     );

--- a/packages/manager/src/features/Linodes/LinodesLanding/CardView.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/CardView.tsx
@@ -17,7 +17,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   summaryOuter: {
     backgroundColor: theme.bg.bgPaper,
-    margin: `${theme.spacing()} 0`,
     marginBottom: 20,
     '&.MuiGrid-item': {
       padding: 0,

--- a/packages/manager/src/features/Linodes/LinodesLanding/DisplayGroupedLinodes.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/DisplayGroupedLinodes.tsx
@@ -2,10 +2,7 @@ import { Config } from '@linode/api-v4/lib/linodes';
 import { compose } from 'ramda';
 import * as React from 'react';
 import GroupByTag from 'src/assets/icons/group-by-tag.svg';
-import TableView from 'src/assets/icons/table-view.svg';
-import { IconButton } from 'src/components/IconButton';
-import { makeStyles } from '@mui/styles';
-import { Theme } from '@mui/material/styles';
+import GridView from 'src/assets/icons/grid-view.svg';
 import { TableBody } from 'src/components/TableBody';
 import { TableCell } from 'src/components/TableCell';
 import Tooltip from 'src/components/core/Tooltip';
@@ -13,6 +10,7 @@ import Typography from 'src/components/core/Typography';
 import Grid from '@mui/material/Unstable_Grid2';
 import { OrderByProps } from 'src/components/OrderBy';
 import Paginate from 'src/components/Paginate';
+import Box from 'src/components/core/Box';
 import {
   MIN_PAGE_SIZE,
   PaginationFooter,
@@ -27,51 +25,13 @@ import { groupByTags, sortGroups } from 'src/utilities/groupByTags';
 import TableWrapper from './TableWrapper';
 import { LinodeWithMaintenance } from 'src/store/linodes/linodes.helpers';
 import { RenderLinodesProps } from './DisplayLinodes';
-
-const useStyles = makeStyles((theme: Theme) => ({
-  tagGridRow: {
-    marginBottom: 20,
-  },
-  tagHeaderRow: {
-    backgroundColor: theme.bg.main,
-    height: 'auto',
-    '& td': {
-      // This is maintaining the spacing between groups because of how tables handle margin/padding. Adjust with care!
-      padding: `calc(${theme.spacing(2)} + 4px) 0 2px`,
-      borderBottom: 'none',
-      borderTop: 'none',
-    },
-  },
-  groupContainer: {
-    [theme.breakpoints.up('md')]: {
-      '& $tagHeaderRow > td': {
-        padding: '10px 0 2px',
-        borderTop: 'none',
-      },
-    },
-  },
-  tagHeader: {
-    marginBottom: 2,
-    marginLeft: theme.spacing(),
-  },
-  paginationCell: {
-    padding: 0,
-  },
-  controlHeader: {
-    marginBottom: 28,
-    display: 'flex',
-    justifyContent: 'flex-end',
-    backgroundColor: theme.bg.tableHeader,
-  },
-  toggleButton: {
-    color: '#d2d3d4',
-    padding: 10,
-    '&:focus': {
-      // Browser default until we get styling direction for focus states
-      outline: '1px dotted #999',
-    },
-  },
-}));
+import {
+  StyledControlHeader,
+  StyledGroupContainer,
+  StyledTagHeader,
+  StyledTagHeaderRow,
+  StyledToggleButton,
+} from './DisplayLinodes.styles';
 
 interface Props {
   openDialog: (type: DialogType, linodeID: number, linodeLabel: string) => void;
@@ -94,9 +54,7 @@ interface Props {
 
 type CombinedProps = Props & OrderByProps<LinodeWithMaintenance>;
 
-const DisplayGroupedLinodes: React.FC<CombinedProps> = (props) => {
-  const classes = useStyles();
-
+export const DisplayGroupedLinodes = (props: CombinedProps) => {
   const {
     data,
     display,
@@ -136,21 +94,21 @@ const DisplayGroupedLinodes: React.FC<CombinedProps> = (props) => {
     return (
       <>
         <Grid xs={12} className={'px0'}>
-          <div className={classes.controlHeader}>
+          <StyledControlHeader isGroupedByTag={linodesAreGrouped}>
             <div id="displayViewDescription" className="visually-hidden">
               Currently in {linodeViewPreference} view
             </div>
             <Tooltip placement="top" title="List view">
-              <IconButton
+              <StyledToggleButton
                 aria-label="Toggle display"
                 aria-describedby={'displayViewDescription'}
                 onClick={toggleLinodeView}
                 disableRipple
-                className={classes.toggleButton}
+                isActive={linodesAreGrouped}
                 size="large"
               >
-                <TableView />
-              </IconButton>
+                <GridView />
+              </StyledToggleButton>
             </Tooltip>
 
             <div id="groupByDescription" className="visually-hidden">
@@ -159,18 +117,18 @@ const DisplayGroupedLinodes: React.FC<CombinedProps> = (props) => {
                 : 'group by tag is currently disabled'}
             </div>
             <Tooltip placement="top-end" title="Ungroup by tag">
-              <IconButton
+              <StyledToggleButton
                 aria-label={`Toggle group by tag`}
                 aria-describedby={'groupByDescription'}
                 onClick={toggleGroupLinodes}
                 disableRipple
-                className={classes.toggleButton}
+                isActive={linodesAreGrouped}
                 size="large"
               >
                 <GroupByTag />
-              </IconButton>
+              </StyledToggleButton>
             </Tooltip>
-          </div>
+          </StyledControlHeader>
         </Grid>
         {orderedGroupedLinodes.length === 0 ? (
           <Typography style={{ textAlign: 'center' }}>
@@ -179,20 +137,10 @@ const DisplayGroupedLinodes: React.FC<CombinedProps> = (props) => {
         ) : null}
         {orderedGroupedLinodes.map(([tag, linodes]) => {
           return (
-            <div
-              key={tag}
-              className={classes.tagGridRow}
-              data-qa-tag-header={tag}
-            >
+            <Box key={tag} sx={{ marginBottom: 2 }} data-qa-tag-header={tag}>
               <Grid container>
                 <Grid xs={12}>
-                  <Typography
-                    variant="h2"
-                    component="h3"
-                    className={classes.tagHeader}
-                  >
-                    {tag}
-                  </Typography>
+                  <StyledTagHeader variant="h2">{tag}</StyledTagHeader>
                 </Grid>
               </Grid>
               <Paginate
@@ -247,7 +195,7 @@ const DisplayGroupedLinodes: React.FC<CombinedProps> = (props) => {
                   );
                 }}
               </Paginate>
-            </div>
+            </Box>
           );
         })}
       </>
@@ -298,28 +246,16 @@ const DisplayGroupedLinodes: React.FC<CombinedProps> = (props) => {
                     count,
                   };
                   return (
-                    <TableBody
-                      className={classes.groupContainer}
-                      data-qa-tag-header={tag}
-                    >
-                      <TableRow className={classes.tagHeaderRow}>
+                    <StyledGroupContainer data-qa-tag-header={tag}>
+                      <StyledTagHeaderRow>
                         <TableCell colSpan={7}>
-                          <Typography
-                            variant="h2"
-                            component="h3"
-                            className={classes.tagHeader}
-                          >
-                            {tag}
-                          </Typography>
+                          <StyledTagHeader variant="h2">{tag}</StyledTagHeader>
                         </TableCell>
-                      </TableRow>
+                      </StyledTagHeaderRow>
                       <Component {...finalProps} />
                       {count > MIN_PAGE_SIZE && (
                         <TableRow>
-                          <TableCell
-                            colSpan={7}
-                            className={classes.paginationCell}
-                          >
+                          <TableCell colSpan={7} sx={{ padding: 0 }}>
                             <PaginationFooter
                               count={count}
                               handlePageChange={handlePageChange}
@@ -333,7 +269,7 @@ const DisplayGroupedLinodes: React.FC<CombinedProps> = (props) => {
                           </TableCell>
                         </TableRow>
                       )}
-                    </TableBody>
+                    </StyledGroupContainer>
                   );
                 }}
               </Paginate>

--- a/packages/manager/src/features/Linodes/LinodesLanding/DisplayGroupedLinodes.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/DisplayGroupedLinodes.tsx
@@ -27,7 +27,6 @@ import { LinodeWithMaintenance } from 'src/store/linodes/linodes.helpers';
 import { RenderLinodesProps } from './DisplayLinodes';
 import {
   StyledControlHeader,
-  StyledGroupContainer,
   StyledTagHeader,
   StyledTagHeaderRow,
   StyledToggleButton,
@@ -246,7 +245,7 @@ export const DisplayGroupedLinodes = (props: CombinedProps) => {
                     count,
                   };
                   return (
-                    <StyledGroupContainer data-qa-tag-header={tag}>
+                    <TableBody data-qa-tag-header={tag}>
                       <StyledTagHeaderRow>
                         <TableCell colSpan={7}>
                           <StyledTagHeader variant="h2">{tag}</StyledTagHeader>
@@ -269,7 +268,7 @@ export const DisplayGroupedLinodes = (props: CombinedProps) => {
                           </TableCell>
                         </TableRow>
                       )}
-                    </StyledGroupContainer>
+                    </TableBody>
                   );
                 }}
               </Paginate>

--- a/packages/manager/src/features/Linodes/LinodesLanding/DisplayLinodes.styles.ts
+++ b/packages/manager/src/features/Linodes/LinodesLanding/DisplayLinodes.styles.ts
@@ -42,7 +42,11 @@ export const StyledToggleButton = styled(IconButton, {
 })<{ isActive: boolean }>(({ theme, isActive }) => ({
   color: isActive ? theme.palette.primary.main : theme.palette.grey[400],
   padding: 10,
-  height: 20,
+  borderRadius: '100%',
+  '&:hover': {
+    backgroundColor: theme.palette.grey[300],
+    color: isActive ? theme.palette.primary.main : theme.palette.grey[600],
+  },
   '&:focus': {
     // Browser default until we get styling direction for focus states
     outline: '1px dotted #999',

--- a/packages/manager/src/features/Linodes/LinodesLanding/DisplayLinodes.styles.ts
+++ b/packages/manager/src/features/Linodes/LinodesLanding/DisplayLinodes.styles.ts
@@ -1,0 +1,62 @@
+import Typography from 'src/components/core/Typography';
+import { IconButton } from 'src/components/IconButton';
+import { styled } from '@mui/material/styles';
+import { TableBody } from 'src/components/TableBody';
+import { TableRow } from 'src/components/TableRow';
+
+export const StyledTagHeaderRow = styled(TableRow, {
+  label: 'StyledTagHeaderRow',
+})(({ theme }) => ({
+  backgroundColor: 'transparent !important',
+  height: 'auto',
+  '& td': {
+    // This is maintaining the spacing between groups because of how tables handle margin/padding. Adjust with care!
+    padding: `${theme.spacing(1.25)} 0 2px`,
+    borderBottom: 'none',
+    borderTop: 'none',
+  },
+}));
+
+export const StyledGroupContainer = styled(TableBody, {
+  label: 'StyledGroupContainer',
+})(({ theme }) => ({
+  [theme.breakpoints.up('md')]: {
+    '& $tagHeaderRow > td': {
+      padding: '10px 0 2px',
+      borderTop: 'none',
+    },
+  },
+}));
+
+export const StyledTagHeader = styled(Typography, {
+  label: 'StyledTagHeader',
+})(({ theme }) => ({
+  marginBottom: 4,
+  marginLeft: theme.spacing(),
+}));
+
+export const StyledControlHeader = styled('div', {
+  label: 'StyledControlHeader',
+})<{ isGroupedByTag: boolean }>(({ theme, isGroupedByTag }) => ({
+  height: 46,
+  marginBottom: isGroupedByTag ? theme.spacing(4) : 0,
+  display: 'flex',
+  justifyContent: 'flex-end',
+  alignItems: 'center',
+  backgroundColor: theme.bg.tableHeader,
+}));
+
+export const StyledToggleButton = styled(IconButton, {
+  label: 'StyledToggleButton',
+})<{ isActive: boolean }>(({ theme, isActive }) => ({
+  color: isActive ? theme.palette.primary.main : theme.palette.grey[400],
+  padding: 10,
+  height: 20,
+  '&:focus': {
+    // Browser default until we get styling direction for focus states
+    outline: '1px dotted #999',
+  },
+  '&.Mui-disabled': {
+    display: 'none',
+  },
+}));

--- a/packages/manager/src/features/Linodes/LinodesLanding/DisplayLinodes.styles.ts
+++ b/packages/manager/src/features/Linodes/LinodesLanding/DisplayLinodes.styles.ts
@@ -1,7 +1,7 @@
 import Typography from 'src/components/core/Typography';
 import { IconButton } from 'src/components/IconButton';
+import { isPropValid } from 'src/utilities/isPropValid';
 import { styled } from '@mui/material/styles';
-import { TableBody } from 'src/components/TableBody';
 import { TableRow } from 'src/components/TableRow';
 
 export const StyledTagHeaderRow = styled(TableRow, {
@@ -17,17 +17,6 @@ export const StyledTagHeaderRow = styled(TableRow, {
   },
 }));
 
-export const StyledGroupContainer = styled(TableBody, {
-  label: 'StyledGroupContainer',
-})(({ theme }) => ({
-  [theme.breakpoints.up('md')]: {
-    '& $tagHeaderRow > td': {
-      padding: '10px 0 2px',
-      borderTop: 'none',
-    },
-  },
-}));
-
 export const StyledTagHeader = styled(Typography, {
   label: 'StyledTagHeader',
 })(({ theme }) => ({
@@ -37,6 +26,7 @@ export const StyledTagHeader = styled(Typography, {
 
 export const StyledControlHeader = styled('div', {
   label: 'StyledControlHeader',
+  shouldForwardProp: (prop) => isPropValid(['isGroupedByTag'], prop),
 })<{ isGroupedByTag: boolean }>(({ theme, isGroupedByTag }) => ({
   height: 46,
   marginBottom: isGroupedByTag ? theme.spacing(4) : 0,
@@ -48,6 +38,7 @@ export const StyledControlHeader = styled('div', {
 
 export const StyledToggleButton = styled(IconButton, {
   label: 'StyledToggleButton',
+  shouldForwardProp: (prop) => isPropValid(['isActive'], prop),
 })<{ isActive: boolean }>(({ theme, isActive }) => ({
   color: isActive ? theme.palette.primary.main : theme.palette.grey[400],
   padding: 10,

--- a/packages/manager/src/features/Linodes/LinodesLanding/DisplayLinodes.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/DisplayLinodes.tsx
@@ -2,8 +2,6 @@ import { Config } from '@linode/api-v4/lib/linodes';
 import * as React from 'react';
 import { useLocation } from 'react-router-dom';
 import { TableBody } from 'src/components/TableBody';
-import { makeStyles } from '@mui/styles';
-import { Theme } from '@mui/material/styles';
 import Grid from '@mui/material/Unstable_Grid2';
 import { OrderByProps } from 'src/components/OrderBy';
 import Paginate, { PaginationProps } from 'src/components/Paginate';
@@ -13,33 +11,16 @@ import { Action } from 'src/features/Linodes/PowerActionsDialogOrDrawer';
 import { DialogType } from 'src/features/Linodes/types';
 import { useInfinitePageSize } from 'src/hooks/useInfinitePageSize';
 import TableWrapper from './TableWrapper';
-import { IconButton } from 'src/components/IconButton';
 import Tooltip from 'src/components/core/Tooltip';
 import GroupByTag from 'src/assets/icons/group-by-tag.svg';
-import TableView from 'src/assets/icons/table-view.svg';
+import GridView from 'src/assets/icons/grid-view.svg';
 import { getQueryParamsFromQueryString } from 'src/utilities/queryParams';
 import { LinodeWithMaintenanceAndDisplayStatus } from 'src/store/linodes/types';
 import { LinodeWithMaintenance } from 'src/store/linodes/linodes.helpers';
-
-const useStyles = makeStyles((theme: Theme) => ({
-  controlHeader: {
-    marginBottom: 28,
-    display: 'flex',
-    justifyContent: 'flex-end',
-    backgroundColor: theme.bg.tableHeader,
-  },
-  toggleButton: {
-    color: '#d2d3d4',
-    padding: 10,
-    '&:focus': {
-      // Browser default until we get styling direction for focus states
-      outline: '1px dotted #999',
-    },
-  },
-  table: {
-    // tableLayout: 'fixed'
-  },
-}));
+import {
+  StyledControlHeader,
+  StyledToggleButton,
+} from './DisplayLinodes.styles';
 
 export interface RenderLinodesProps extends PaginationProps {
   data: Props['data'];
@@ -71,8 +52,7 @@ interface Props {
 type CombinedProps = Props &
   OrderByProps<LinodeWithMaintenanceAndDisplayStatus>;
 
-const DisplayLinodes = (props: CombinedProps) => {
-  const classes = useStyles();
+export const DisplayLinodes = React.memo((props: CombinedProps) => {
   const {
     count,
     data,
@@ -150,7 +130,6 @@ const DisplayLinodes = (props: CombinedProps) => {
                 linodesAreGrouped={linodesAreGrouped}
                 toggleLinodeView={toggleLinodeView}
                 toggleGroupLinodes={toggleGroupLinodes}
-                tableProps={{ tableClass: classes.table }}
               >
                 <TableBody>
                   <Component showHead {...componentProps} />
@@ -160,7 +139,7 @@ const DisplayLinodes = (props: CombinedProps) => {
             {display === 'grid' && (
               <>
                 <Grid xs={12} className={'px0'}>
-                  <div className={classes.controlHeader}>
+                  <StyledControlHeader isGroupedByTag={linodesAreGrouped}>
                     <div
                       id="displayViewDescription"
                       className="visually-hidden"
@@ -168,16 +147,16 @@ const DisplayLinodes = (props: CombinedProps) => {
                       Currently in {linodeViewPreference} view
                     </div>
                     <Tooltip placement="top" title="List view">
-                      <IconButton
+                      <StyledToggleButton
                         aria-label="Toggle display"
                         aria-describedby={'displayViewDescription'}
-                        onClick={toggleLinodeView}
                         disableRipple
-                        className={classes.toggleButton}
+                        isActive={true}
+                        onClick={toggleLinodeView}
                         size="large"
                       >
-                        <TableView />
-                      </IconButton>
+                        <GridView />
+                      </StyledToggleButton>
                     </Tooltip>
 
                     <div id="groupByDescription" className="visually-hidden">
@@ -186,18 +165,18 @@ const DisplayLinodes = (props: CombinedProps) => {
                         : 'group by tag is currently disabled'}
                     </div>
                     <Tooltip placement="top-end" title="Group by tag">
-                      <IconButton
+                      <StyledToggleButton
                         aria-label={`Toggle group by tag`}
                         aria-describedby={'groupByDescription'}
                         onClick={toggleGroupLinodes}
                         disableRipple
-                        className={classes.toggleButton}
+                        isActive={linodesAreGrouped}
                         size="large"
                       >
                         <GroupByTag />
-                      </IconButton>
+                      </StyledToggleButton>
                     </Tooltip>
-                  </div>
+                  </StyledControlHeader>
                 </Grid>
                 <Component showHead {...componentProps} />
               </>
@@ -221,6 +200,4 @@ const DisplayLinodes = (props: CombinedProps) => {
       }}
     </Paginate>
   );
-};
-
-export default React.memo(DisplayLinodes);
+});

--- a/packages/manager/src/features/Linodes/LinodesLanding/LinodesLanding.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/LinodesLanding.tsx
@@ -37,7 +37,7 @@ import { PowerActionsDialog, Action } from '../PowerActionsDialogOrDrawer';
 import { linodesInTransition as _linodesInTransition } from '../transitions';
 import CardView from './CardView';
 import DisplayGroupedLinodes from './DisplayGroupedLinodes';
-import DisplayLinodes from './DisplayLinodes';
+import { DisplayLinodes } from './DisplayLinodes';
 import styled, { StyleProps } from './LinodesLanding.styles';
 import { LinodesLandingEmptyState } from './LinodesLandingEmptyState';
 import ListView from './ListView';

--- a/packages/manager/src/features/Linodes/LinodesLanding/SortableTableHead.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/SortableTableHead.tsx
@@ -167,7 +167,7 @@ const SortableTableHead = <T extends unknown>(props: CombinedProps<T>) => {
             </Hidden>
           </>
         )}
-        <TableCell>
+        <TableCell sx={{ padding: '0 !important' }}>
           <div className={classes.controlHeader}>
             <div id="displayViewDescription" className="visually-hidden">
               Currently in {linodeViewPreference} view

--- a/packages/manager/src/features/Linodes/LinodesLanding/SortableTableHead.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/SortableTableHead.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import GridView from 'src/assets/icons/grid-view.svg';
 import Hidden from 'src/components/core/Hidden';
-import { IconButton } from 'src/components/IconButton';
 import { makeStyles } from '@mui/styles';
 import { Theme } from '@mui/material/styles';
 import { TableHead } from 'src/components/TableHead';
@@ -11,19 +10,13 @@ import { OrderByProps } from 'src/components/OrderBy';
 import { TableCell } from 'src/components/TableCell';
 import { TableRow } from 'src/components/TableRow';
 import { TableSortCell } from 'src/components/TableSortCell';
+import { StyledToggleButton } from './DisplayLinodes.styles';
 
 const useStyles = makeStyles((theme: Theme) => ({
   controlHeader: {
     display: 'flex',
     justifyContent: 'flex-end',
     backgroundColor: theme.bg.tableHeader,
-  },
-  toggleButton: {
-    color: '#d2d3d4',
-    padding: '0 10px',
-    '&:focus': {
-      outline: '1px dotted #999',
-    },
   },
   // There's nothing very scientific about the widths across the breakpoints
   // here, just a lot of trial and error based on maximum expected column sizes.
@@ -180,16 +173,16 @@ const SortableTableHead = <T extends unknown>(props: CombinedProps<T>) => {
               Currently in {linodeViewPreference} view
             </div>
             <Tooltip placement="top" title="Summary view">
-              <IconButton
+              <StyledToggleButton
                 aria-label="Toggle display"
                 aria-describedby={'displayViewDescription'}
                 onClick={toggleLinodeView}
                 disableRipple
-                className={classes.toggleButton}
+                isActive={linodeViewPreference === 'grid'}
                 size="large"
               >
                 <GridView />
-              </IconButton>
+              </StyledToggleButton>
             </Tooltip>
             <GroupByTagToggle
               toggleGroupByTag={toggleGroupLinodes}

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
@@ -134,7 +134,7 @@ const StyledSummarySection = styled(Paper, {
 })(({ theme }) => ({
   padding: theme.spacing(2.5),
   marginBottom: theme.spacing(2),
-  // minHeight: '160px',
+  minHeight: '160px',
   height: '93%',
 }));
 

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
@@ -134,7 +134,7 @@ const StyledSummarySection = styled(Paper, {
 })(({ theme }) => ({
   padding: theme.spacing(2.5),
   marginBottom: theme.spacing(2),
-  minHeight: '160px',
+  // minHeight: '160px',
   height: '93%',
 }));
 


### PR DESCRIPTION
## Description 📝

This code is a mess. There's so much duplication and it needs a serious refactor. Trying to have a minimal footprint here so only addressing styles and some exports.

The PR achieves a couple things:
- Add the active/toggled color on the icon
- Cleans up the styles and consolidates grid/list styles and layout

**Note: default view (no summary view, no tags) should be unchanged**

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-06-16 at 11 52 03 AM](https://github.com/linode/manager/assets/130582365/46dbdd0f-3ca0-4624-8f08-c32acf9e7384) | ![Screenshot 2023-06-16 at 11 51 53 AM](https://github.com/linode/manager/assets/130582365/18fdcd88-d36d-46ab-9bf4-b5b79b43a909) |
| ![Screenshot 2023-06-16 at 11 52 34 AM](https://github.com/linode/manager/assets/130582365/42d74f1f-f172-4de6-bcba-c76bf2844b4d) | ![Screenshot 2023-06-16 at 11 52 26 AM](https://github.com/linode/manager/assets/130582365/9571a5eb-a3ff-456b-8118-88be80afb1ad) |
| ![Screenshot 2023-06-16 at 11 52 55 AM](https://github.com/linode/manager/assets/130582365/0e961d36-9aa5-4512-8375-e5bf0a3f6e68) | ![Screenshot 2023-06-16 at 11 52 48 AM](https://github.com/linode/manager/assets/130582365/8d832d73-952f-460a-918e-6b67020a316d) |


## How to test 🧪
1. Get to Linodes Landing and toggle all the things
