### PR TITLE
fix: Github Actions CI `build-manager`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
 
   build-manager:
     runs-on: ubuntu-latest
-    # if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master'
     needs:
       - build-sdk
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
 
   build-manager:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    # if: github.ref == 'refs/heads/master'
     needs:
       - build-sdk
     steps:
@@ -207,7 +207,6 @@ jobs:
           path: |
             **/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - run: cp packages/manager/config/environments/beta packages/manager/.env
       - uses: actions/download-artifact@v3
         with:
           name: packages-validation-lib

--- a/packages/manager/.changeset/pr-9274-tech-stories-1686938963869.md
+++ b/packages/manager/.changeset/pr-9274-tech-stories-1686938963869.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Fixed Github Actions build-manager step ([#9274](https://github.com/linode/manager/pull/9274))


### PR DESCRIPTION
## Why ❓

Any PR to `master` has been failing our Github Actions pipeline over the last few weeks and its annoying to see the ❌ every time 
![Screenshot 2023-06-16 at 1 23 10 PM](https://github.com/linode/manager/assets/115251059/bd8b50c6-7797-4008-abf7-18d049b75666)

## Description 📝
- Removes `cp` command that was used when we deployed a beta environment 
- Related PRs
  - https://github.com/linode/manager/pull/8804 
  - https://github.com/linode/manager/pull/9041


## How to test 🧪
- The proof this works is here: https://github.com/linode/manager/actions/runs/5292639874/jobs/9579833769?pr=9274