### PR TITLE
test: [M3-6506] - Add StackScript Landing Page Integration Tests

### DIFF
--- a/packages/manager/cypress/e2e/core/stackscripts/smoke-stackscripts-landing-page.spec.ts
+++ b/packages/manager/cypress/e2e/core/stackscripts/smoke-stackscripts-landing-page.spec.ts
@@ -1,0 +1,63 @@
+import { authenticate } from 'support/api/authentication';
+import { stackScriptFactory } from 'src/factories';
+import { mockGetStackScripts } from 'support/intercepts/stackscripts';
+import { ui } from 'support/ui';
+
+authenticate();
+describe('stackscripts', () => {
+  /*
+   * - Displays welcom message in the landing page.
+   * - Confirms that "Automate Deployment with StackScripts!" welcome page appears when user has no StackScripts.
+   */
+  it('display the correct welcom message in landing page', () => {
+    mockGetStackScripts([]).as('getStackScripts');
+    cy.visitWithLogin('/stackscripts/account');
+    cy.wait('@getStackScripts');
+
+    cy.findByText('Automate deployment scripts').should('be.visible');
+    cy.get('[data-qa-stackscript-empty-msg="true"]')
+      .should('be.visible')
+      .within(() => {
+        ui.button
+          .findByTitle('Create StackScript')
+          .should('be.visible')
+          .should('be.enabled');
+      });
+  });
+
+  /*
+   * - Displays Account StackScripts in the landing page.
+   * - Confirms that all the StackScripts are shown as expected.
+   */
+  it('display Account StackScripts in landing page', () => {
+    const stackScripts = stackScriptFactory.buildList(2);
+    mockGetStackScripts(stackScripts).as('getStackScripts');
+    cy.visitWithLogin('/stackscripts/account');
+    cy.wait('@getStackScripts');
+
+    stackScripts.forEach((stackScript) => {
+      cy.get(`[aria-label="${stackScript.label}"]`)
+        .closest('tr')
+        .within(() => {
+          cy.findByText(stackScript.deployments_total).should('be.visible');
+          cy.findByText(`${stackScript.updated.split('T')[0]}`).should(
+            'be.visible'
+          );
+          if (stackScript.is_public) {
+            cy.findByText('Public').should('be.visible');
+          }
+        });
+    });
+  });
+
+  /*
+   * - Displays Community StackScripts in the landing page.
+   * - Confirms that Community page is not empty.
+   */
+  it('display Community StackScripts in landing page', () => {
+    cy.visitWithLogin('/stackscripts/community');
+
+    cy.get('[data-qa-stackscript-empty-msg="true"]').should('not.exist');
+    cy.findByText('Automate deployment scripts').should('not.exist');
+  });
+});

--- a/packages/manager/cypress/support/intercepts/stackscripts.ts
+++ b/packages/manager/cypress/support/intercepts/stackscripts.ts
@@ -2,7 +2,9 @@
  * @file Cypress intercepts and mocks for Cloud Manager StackScript operations.
  */
 
+import type { StackScript } from '@linode/api-v4/types';
 import { apiMatcher } from 'support/util/intercepts';
+import { paginateResponse } from 'support/util/paginate';
 
 /**
  * Intercepts GET request to list StackScripts.
@@ -11,6 +13,23 @@ import { apiMatcher } from 'support/util/intercepts';
  */
 export const interceptGetStackScripts = (): Cypress.Chainable<null> => {
   return cy.intercept('GET', apiMatcher('linode/stackscripts*'));
+};
+
+/**
+ * Intercepts GET request to mock StackScript data.
+ *
+ * @param stackScripts - an array of mock StackScript objects
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetStackScripts = (
+  stackScripts: StackScript[]
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'GET',
+    apiMatcher('linode/stackscripts*'),
+    paginateResponse(stackScripts)
+  );
 };
 
 /**

--- a/packages/manager/src/factories/stackscripts.ts
+++ b/packages/manager/src/factories/stackscripts.ts
@@ -6,7 +6,7 @@ import {
 
 export const stackScriptFactory = Factory.Sync.makeFactory<StackScript>({
   id: Factory.each((i) => i),
-  label: 'MySQL',
+  label: Factory.each((i) => `stackScript-${i}`),
   images: [],
   user_defined_fields: [],
   is_public: true,


### PR DESCRIPTION
## Description 📝
Add new cypress tests for StackScript landing page

## Major Changes 🔄
- Add `StackScript landing page` smoke tests.

## How to test 🧪
`yarn cy:run -s "cypress/e2e/stackscripts/smoke-stackscripts-landing-page.spec.ts"`