### PR TITLE
refactor: [M3-6360] - MUI v5 Migration - `Components > MaintenanceBanner`

### DIFF
--- a/packages/manager/.changeset/pr-9278-tech-stories-1686942932396.md
+++ b/packages/manager/.changeset/pr-9278-tech-stories-1686942932396.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+MUI v5 Migration - Components > MaintenanceBanner ([#9278](https://github.com/linode/manager/pull/9278))

--- a/packages/manager/src/components/MaintenanceBanner/index.ts
+++ b/packages/manager/src/components/MaintenanceBanner/index.ts
@@ -1,1 +1,0 @@
-export { default } from './MaintenanceBanner';

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailHeader/Notifications.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodesDetailHeader/Notifications.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Notification } from '@linode/api-v4/lib/account';
-import MaintenanceBanner from 'src/components/MaintenanceBanner';
+import { MaintenanceBanner } from 'src/components/MaintenanceBanner/MaintenanceBanner';
 import { ProductNotification } from 'src/components/ProductNotification/ProductNotification';
 import { useAllAccountMaintenanceQuery } from 'src/queries/accountMaintenance';
 import { useNotificationsQuery } from 'src/queries/accountNotifications';

--- a/packages/manager/src/features/Linodes/LinodesLanding/LinodesLanding.tsx
+++ b/packages/manager/src/features/Linodes/LinodesLanding/LinodesLanding.tsx
@@ -13,7 +13,7 @@ import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { ErrorState } from 'src/components/ErrorState/ErrorState';
 import Grid from '@mui/material/Unstable_Grid2';
 import LandingHeader from 'src/components/LandingHeader';
-import MaintenanceBanner from 'src/components/MaintenanceBanner';
+import { MaintenanceBanner } from 'src/components/MaintenanceBanner/MaintenanceBanner';
 import OrderBy from 'src/components/OrderBy';
 import { PreferenceToggle } from 'src/components/PreferenceToggle/PreferenceToggle';
 import {

--- a/packages/manager/src/features/Profile/APITokens/utils.ts
+++ b/packages/manager/src/features/Profile/APITokens/utils.ts
@@ -1,5 +1,5 @@
 import { DateTime } from 'luxon';
-import isPast from 'src/utilities/isPast';
+import { isPast } from 'src/utilities/isPast';
 
 export type Permission = [string, number];
 

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -383,6 +383,7 @@ export const handlers = [
       })
   ),
   rest.get('*/linode/instances', async (req, res, ctx) => {
+    linodeFactory.resetSequenceNumber();
     const metadataLinodeWithCompatibleImage = linodeFactory.build({
       image: 'metadata-test-image',
       label: 'metadata-test-image',
@@ -450,6 +451,10 @@ export const handlers = [
       multipleIPLinode,
     ];
     return res(ctx.json(makeResourcePage(linodes)));
+  }),
+  rest.get('*/linode/instances/:id', async (req, res, ctx) => {
+    const id = Number(req.params.id);
+    return res(ctx.json(linodeFactory.build({ id })));
   }),
   rest.delete('*/instances/*', async (req, res, ctx) => {
     return res(ctx.json({}));
@@ -760,7 +765,7 @@ export const handlers = [
       headers.status === 'completed'
         ? accountMaintenanceFactory.buildList(30, { status: 'completed' })
         : [
-            ...accountMaintenanceFactory.buildList(2, { status: 'pending' }),
+            ...accountMaintenanceFactory.buildList(90, { status: 'pending' }),
             ...accountMaintenanceFactory.buildList(3, { status: 'started' }),
           ];
 
@@ -1242,6 +1247,7 @@ export const mockDataHandlers: Record<
 > = {
   linode: (count) =>
     rest.get('*/linode/instances', async (req, res, ctx) => {
+      linodeFactory.resetSequenceNumber();
       const linodes = linodeFactory.buildList(count);
       return res(ctx.json(makeResourcePage(linodes)));
     }),

--- a/packages/manager/src/utilities/isPast.test.ts
+++ b/packages/manager/src/utilities/isPast.test.ts
@@ -1,4 +1,4 @@
-import isPast from './isPast';
+import { isPast } from './isPast';
 
 /** @see http://krl.io/510e5 */
 describe('isPastNow', () => {

--- a/packages/manager/src/utilities/isPast.ts
+++ b/packages/manager/src/utilities/isPast.ts
@@ -1,4 +1,4 @@
 import { parseAPIDate } from './date';
 
-export default (a: string) => (b: string): boolean =>
+export const isPast = (a: string) => (b: string): boolean =>
   parseAPIDate(b) >= parseAPIDate(a);


### PR DESCRIPTION
## Description 📝

- Style migration for MaintenanceBanner 
- The general UX of this banner feels questionable but this is just a clean up / style migration for it

## Major Changes 🔄
- Cleans up `<MaintenanceBanner />` 
- Fixes default export of `isPast`

## Preview 📷

## Before
![Screenshot 2023-06-16 at 3 14 12 PM](https://github.com/linode/manager/assets/115251059/b086299f-9328-41c1-b2ad-3a1d64674e1b)

## After
Some styles were removed but the component should look the same
![Screenshot 2023-06-16 at 3 08 58 PM](https://github.com/linode/manager/assets/115251059/ea25da99-3006-4109-acad-718916ee5dd1)

## How to test 🧪
- Turn on the MSW
- Go to the Linodes Landing Page
- Look for a Linode that has a status of `Maintenance Scheduled`
- Click it to go to the details page
- Check the banner