### PR TITLE
fix: [M3-6664] - Fix crash due to unescaped RegEx

### DIFF
--- a/packages/manager/.changeset/pr-9280-fixed-1686949826559.md
+++ b/packages/manager/.changeset/pr-9280-fixed-1686949826559.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Fixed crash caused by un-escaped RegEx ([#9280](https://github.com/linode/manager/pull/9280))

--- a/packages/manager/src/eventMessageGenerator.test.ts
+++ b/packages/manager/src/eventMessageGenerator.test.ts
@@ -125,5 +125,21 @@ describe('Event message generation', () => {
 
       expect(result).toEqual('created `foo`');
     });
+
+    it('should escape regex special characters', () => {
+      const mockEvent = eventFactory.build({
+        entity: entityFactory.build({
+          id: 10,
+          label: 'Weird label with special characters.(?)',
+        }),
+      });
+      const message = 'created entity Weird label with special characters.(?)';
+      const result = applyLinking(mockEvent, message);
+
+      // eslint-disable-next-line xss/no-mixed-html
+      expect(result).toEqual(
+        'created entity <a href="/linodes/10">Weird label with special characters.(?)</a> '
+      );
+    });
   });
 });

--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -4,8 +4,8 @@ import { isProductionBuild } from 'src/constants';
 import { reportException } from 'src/exceptionReporting';
 import { getLinkForEvent } from 'src/utilities/getEventsActionLink';
 import {
-  formatEventWithUsername,
   formatEventWithAppendedText,
+  formatEventWithUsername,
 } from './features/Events/Event.helpers';
 import { escapeRegExp } from './utilities/escapeRegExp';
 

--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -7,6 +7,7 @@ import {
   formatEventWithUsername,
   formatEventWithAppendedText,
 } from './features/Events/Event.helpers';
+import { escapeRegExp } from './utilities/escapeRegExp';
 
 type EventMessageCreator = (e: Event) => string;
 
@@ -873,7 +874,7 @@ export function applyLinking(event: Event, message: string) {
 
   if (event.entity && entityLinkTarget) {
     const label = event.entity.label;
-    const nonTickedLabels = new RegExp(`(?<!\`)${label}`, 'g');
+    const nonTickedLabels = new RegExp(`(?<!\`)${escapeRegExp(label)}`, 'g');
 
     newMessage = newMessage.replace(
       nonTickedLabels,

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -877,6 +877,8 @@ export const handlers = [
         label: 'Ticket name with special characters... (?)',
         id: 10,
       },
+      message: 'Ticket name with special characters... (?)',
+      percent_complete: 100,
     });
     return res.once(
       ctx.json(

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -869,7 +869,20 @@ export const handlers = [
       seen: true,
       percent_complete: 100,
     });
-    return res.once(ctx.json(makeResourcePage([...events, ...oldEvents])));
+    const eventWithSpecialCharacters = eventFactory.build({
+      action: 'ticket_update',
+      status: 'notification',
+      entity: {
+        type: 'ticket',
+        label: 'Ticket name with special characters... (?)',
+        id: 10,
+      },
+    });
+    return res.once(
+      ctx.json(
+        makeResourcePage([...events, ...oldEvents, eventWithSpecialCharacters])
+      )
+    );
   }),
   rest.get('*/support/tickets', (req, res, ctx) => {
     const tickets = supportTicketFactory.buildList(15, { status: 'open' });


### PR DESCRIPTION
## Description 📝
Fixes a crash that occurs when viewing events that contain RegEx special characters.

## Todo:
- [x] Figure out how to reproduce
- [x] Add unit test

## How to test 🧪
1. Trigger an entity event containing RegEx special characters (a known bad string is `(?)`).
   - This PR adds an event to the MSW that contains special characters and should crash the app without this fix
2. Open the Notifications menu or navigate to `/events`.
3. Verify the app doesn't crash.