### PR TITLE
fix: [M3-6687] - Show accurate Notification Threshold values when toggling in Linode Settings

### DIFF
--- a/packages/manager/.changeset/pr-9281-fixed-1686955648087.md
+++ b/packages/manager/.changeset/pr-9281-fixed-1686955648087.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Show accurate Notification Threshold values when toggling in Linode Settings ([#9281](https://github.com/linode/manager/pull/9281))

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/LinodeSettingsAlertsPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeSettings/LinodeSettingsAlertsPanel.tsx
@@ -92,7 +92,11 @@ export const LinodeSettingsAlertsPanel = (props: Props) => {
       ) =>
         formik.setFieldValue(
           'cpu',
-          checked ? 90 * (linode?.specs.vcpus ?? 1) : 0
+          checked
+            ? linode?.alerts.cpu
+              ? linode?.alerts.cpu
+              : 90 * (linode?.specs.vcpus ?? 1)
+            : 0
         ),
       onValueChange: (e: React.ChangeEvent<HTMLInputElement>) =>
         formik.setFieldValue('cpu', e.target.valueAsNumber),
@@ -112,7 +116,11 @@ export const LinodeSettingsAlertsPanel = (props: Props) => {
       onStateChange: (
         e: React.ChangeEvent<HTMLInputElement>,
         checked: boolean
-      ) => formik.setFieldValue('io', checked ? 10000 : 0),
+      ) =>
+        formik.setFieldValue(
+          'io',
+          checked ? (linode?.alerts.io ? linode?.alerts.io : 10000) : 0
+        ),
       onValueChange: (e: React.ChangeEvent<HTMLInputElement>) =>
         formik.setFieldValue('io', e.target.valueAsNumber),
       error: hasErrorFor('alerts.io'),
@@ -131,7 +139,15 @@ export const LinodeSettingsAlertsPanel = (props: Props) => {
       onStateChange: (
         e: React.ChangeEvent<HTMLInputElement>,
         checked: boolean
-      ) => formik.setFieldValue('network_in', checked ? 10 : 0),
+      ) =>
+        formik.setFieldValue(
+          'network_in',
+          checked
+            ? linode?.alerts.network_in
+              ? linode?.alerts.network_in
+              : 10
+            : 0
+        ),
       onValueChange: (e: React.ChangeEvent<HTMLInputElement>) =>
         formik.setFieldValue('network_in', e.target.valueAsNumber),
       error: hasErrorFor('alerts.network_in'),
@@ -149,7 +165,15 @@ export const LinodeSettingsAlertsPanel = (props: Props) => {
       onStateChange: (
         e: React.ChangeEvent<HTMLInputElement>,
         checked: boolean
-      ) => formik.setFieldValue('network_out', checked ? 10 : 0),
+      ) =>
+        formik.setFieldValue(
+          'network_out',
+          checked
+            ? linode?.alerts.network_out
+              ? linode?.alerts.network_out
+              : 10
+            : 0
+        ),
       onValueChange: (e: React.ChangeEvent<HTMLInputElement>) =>
         formik.setFieldValue('network_out', e.target.valueAsNumber),
       error: hasErrorFor('alerts.network_out'),
@@ -167,7 +191,15 @@ export const LinodeSettingsAlertsPanel = (props: Props) => {
       onStateChange: (
         e: React.ChangeEvent<HTMLInputElement>,
         checked: boolean
-      ) => formik.setFieldValue('transfer_quota', checked ? 80 : 0),
+      ) =>
+        formik.setFieldValue(
+          'transfer_quota',
+          checked
+            ? linode?.alerts.transfer_quota
+              ? linode?.alerts.transfer_quota
+              : 80
+            : 0
+        ),
       onValueChange: (e: React.ChangeEvent<HTMLInputElement>) =>
         formik.setFieldValue('transfer_quota', e.target.valueAsNumber),
       error: hasErrorFor('alerts.transfer_quota'),


### PR DESCRIPTION
## Description 📝
Fixes unexpected behavior in the Notification Thresholds accordion within a Linode's Settings where default values were being displayed after toggling off -> on a setting, rather than the values a user saved.

Now, when a user makes and saves a change to a value and then toggles a setting, that saved threshold value will accurately display in the text field, rather than the default value.

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <video src="https://github.com/linode/manager/assets/114685994/fb0e0be0-8450-4ab0-97f3-4c52e04c37f7" /> | <video src="https://github.com/linode/manager/assets/114685994/590ee075-e469-4450-8703-20ab7fdbd92e" /> |

## How to test 🧪
**How to reproduce the issue (if applicable)?**
1. Have a Linode on hand or spin one up and and navigate to the Settings tab of the Linode Details page.
2. Under the Notification Threshold accordion, change the values of any one of the thresholds and click Save. 
3. Toggle off that threshold alert. Then toggle it back on.
4. Observe that the textfield shows the original default value, not the custom value you just saved for that threshold. 
5. Edit the threshold value to be the value you previously updated, before the default was restored.
6. Observe that the Save button is disabled, because as far as the form is concerned, now no changes to the values have been made.
7. Refresh the page and observe that the changed threshold value displays for that threshold setting.

**How to verify changes?**
1. Repeat the steps above, but observe that the textfield shows custom value you just saved for that threshold, not the default value, and the Save button is disabled, as expected.
2. Test different toggling and editing scenarios to make sure there are no regressions.

