### PR TITLE
refactor: [M3-6364] - MUI v5 Migration - `Components > MultipleIPInput`

### DIFF
--- a/packages/manager/src/components/MultipleIPInput/MultipleIPInput.test.tsx
+++ b/packages/manager/src/components/MultipleIPInput/MultipleIPInput.test.tsx
@@ -1,9 +1,7 @@
 import { fireEvent } from '@testing-library/react';
 import * as React from 'react';
-
 import { renderWithTheme } from 'src/utilities/testHelpers';
-
-import MultipleIPInput, { Props } from './MultipleIPInput';
+import { MultipleIPInput, Props } from './MultipleIPInput';
 
 const baseProps: Props = {
   title: 'My Input',

--- a/packages/manager/src/components/MultipleIPInput/MultipleIPInput.tsx
+++ b/packages/manager/src/components/MultipleIPInput/MultipleIPInput.tsx
@@ -1,11 +1,10 @@
 // @todo: this import?
 import { InputBaseProps } from '@mui/material/InputBase';
 import Close from '@mui/icons-material/Close';
-import classNames from 'classnames';
 import * as React from 'react';
 import Button from 'src/components/Button';
 import InputLabel from 'src/components/core/InputLabel';
-import { makeStyles } from '@mui/styles';
+import { makeStyles } from 'tss-react/mui';
 import { Theme } from '@mui/material/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from '@mui/material/Unstable_Grid2';
@@ -14,7 +13,7 @@ import { Notice } from 'src/components/Notice/Notice';
 import TextField from 'src/components/TextField';
 import { ExtendedIP } from 'src/utilities/ipUtils';
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles()((theme: Theme) => ({
   addIP: {
     paddingLeft: 0,
     paddingTop: theme.spacing(1.5),
@@ -71,7 +70,7 @@ export interface Props {
   forDatabaseAccessControls?: boolean;
 }
 
-export const MultipleIPInput: React.FC<Props> = (props) => {
+export const MultipleIPInput = React.memo((props: Props) => {
   const {
     error,
     onChange,
@@ -83,8 +82,9 @@ export const MultipleIPInput: React.FC<Props> = (props) => {
     placeholder,
     required,
     forDatabaseAccessControls,
+    className,
   } = props;
-  const classes = useStyles();
+  const { classes, cx } = useStyles();
 
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement>,
@@ -123,13 +123,7 @@ export const MultipleIPInput: React.FC<Props> = (props) => {
   }
 
   return (
-    <div
-      className={classNames({
-        [classes.root]: true,
-        // Inject the className if given as as prop.
-        [props.className ?? '']: Boolean(props.className),
-      })}
-    >
+    <div className={cx(classes.root, className)}>
       {tooltip ? (
         <div className={classes.ipNetmaskTooltipSection}>
           <InputLabel>{title}</InputLabel>
@@ -206,6 +200,4 @@ export const MultipleIPInput: React.FC<Props> = (props) => {
       </Button>
     </div>
   );
-};
-
-export default React.memo(MultipleIPInput);
+});

--- a/packages/manager/src/components/MultipleIPInput/index.tsx
+++ b/packages/manager/src/components/MultipleIPInput/index.tsx
@@ -1,1 +1,0 @@
-export { default } from './MultipleIPInput';

--- a/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
+++ b/packages/manager/src/features/Databases/DatabaseCreate/DatabaseCreate.tsx
@@ -34,7 +34,7 @@ import { ErrorState } from 'src/components/ErrorState/ErrorState';
 import Grid from '@mui/material/Unstable_Grid2';
 import LandingHeader from 'src/components/LandingHeader';
 import Link from 'src/components/Link';
-import MultipleIPInput from 'src/components/MultipleIPInput';
+import { MultipleIPInput } from 'src/components/MultipleIPInput/MultipleIPInput';
 import { Notice } from 'src/components/Notice/Notice';
 import { ProductInformationBanner } from 'src/components/ProductInformationBanner/ProductInformationBanner';
 import { Radio } from 'src/components/Radio/Radio';

--- a/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
+++ b/packages/manager/src/features/Databases/DatabaseDetail/AddAccessControlDrawer.tsx
@@ -6,7 +6,7 @@ import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import Typography from 'src/components/core/Typography';
 import Drawer from 'src/components/Drawer';
-import MultipleIPInput from 'src/components/MultipleIPInput/MultipleIPInput';
+import { MultipleIPInput } from 'src/components/MultipleIPInput/MultipleIPInput';
 import { Notice } from 'src/components/Notice/Notice';
 import { enforceIPMasks } from 'src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.utils';
 import { handleAPIErrors } from 'src/utilities/formikErrorUtils';

--- a/packages/manager/src/features/Domains/CreateDomain/CreateDomain.tsx
+++ b/packages/manager/src/features/Domains/CreateDomain/CreateDomain.tsx
@@ -19,7 +19,7 @@ import Button from 'src/components/Button';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import LandingHeader from 'src/components/LandingHeader';
-import MultipleIPInput from 'src/components/MultipleIPInput';
+import { MultipleIPInput } from 'src/components/MultipleIPInput/MultipleIPInput';
 import { Notice } from 'src/components/Notice/Notice';
 import { Radio } from 'src/components/Radio/Radio';
 import TextField from 'src/components/TextField';

--- a/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
@@ -24,7 +24,7 @@ import ActionsPanel from 'src/components/ActionsPanel';
 import Button, { ButtonProps } from 'src/components/Button';
 import Drawer from 'src/components/Drawer';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
-import MultipleIPInput from 'src/components/MultipleIPInput';
+import { MultipleIPInput } from 'src/components/MultipleIPInput/MultipleIPInput';
 import { Notice } from 'src/components/Notice/Notice';
 import TextField from 'src/components/TextField';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';

--- a/packages/manager/src/features/Domains/EditDomainDrawer.tsx
+++ b/packages/manager/src/features/Domains/EditDomainDrawer.tsx
@@ -4,7 +4,7 @@ import Button from 'src/components/Button';
 import FormControlLabel from 'src/components/core/FormControlLabel';
 import RadioGroup from 'src/components/core/RadioGroup';
 import Drawer from 'src/components/Drawer';
-import MultipleIPInput from 'src/components/MultipleIPInput';
+import { MultipleIPInput } from 'src/components/MultipleIPInput/MultipleIPInput';
 import { Notice } from 'src/components/Notice/Notice';
 import { Radio } from 'src/components/Radio/Radio';
 import { TagsInput } from 'src/components/TagsInput/TagsInput';

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleForm.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleForm.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import FormControlLabel from 'src/components/core/FormControlLabel';
-import MultipleIPInput from 'src/components/MultipleIPInput/MultipleIPInput';
+import { MultipleIPInput } from 'src/components/MultipleIPInput/MultipleIPInput';
 import { Radio } from 'src/components/Radio/Radio';
 import RadioGroup from 'src/components/core/RadioGroup';
 import Select from 'src/components/EnhancedSelect';


### PR DESCRIPTION
## Description 📝

- Style migration for `<MultipleIPInput />`

## Major Changes 🔄
- Runs the `tss-react` migration on `<MultipleIPInput />`
- Cleans up some code
- Use named exports only

## Preview 📷
Here is one instance of this component. It can be found on the Database details page by clicking `Manage Access Controls`
![Screenshot 2023-06-20 at 12 13 37 PM](https://github.com/linode/manager/assets/115251059/2b50718a-dffa-4818-a43a-dbb15ee8697b)

## How to test 🧪
- Test this component and verify it generally works and looks the same