### PR TITLE
feat: [M3-6707] – Light/dark mode shortcut copy on the "My Settings" page

### DIFF
--- a/packages/manager/.changeset/pr-9286-added-1687296191023.md
+++ b/packages/manager/.changeset/pr-9286-added-1687296191023.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Light/dark mode keyboard shortcut copy on "My Settings" page ([#9286](https://github.com/linode/manager/pull/9286))

--- a/packages/manager/.changeset/pr-9286-fixed-1687296191023.md
+++ b/packages/manager/.changeset/pr-9286-fixed-1687296191023.md
@@ -1,5 +1,0 @@
----
-"@linode/manager": Fixed
----
-
-Unreliable light/dark mode keyboard shortcut ([#9286](https://github.com/linode/manager/pull/9286))

--- a/packages/manager/.changeset/pr-9286-fixed-1687296191023.md
+++ b/packages/manager/.changeset/pr-9286-fixed-1687296191023.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Unreliable light/dark mode keyboard shortcut ([#9286](https://github.com/linode/manager/pull/9286))

--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -70,7 +70,7 @@ const BaseApp = withFeatureFlagProvider(
     const theme = preferences?.theme;
     const keyboardListener = React.useCallback(
       (event: KeyboardEvent) => {
-        const letterForThemeShortcut = 'L';
+        const letterForThemeShortcut = 'D';
         const letterForGoToOpen = 'K';
         const modifierKey = isOSMac ? 'ctrlKey' : 'altKey';
         if (event[modifierKey] && event.shiftKey) {
@@ -83,9 +83,6 @@ const BaseApp = withFeatureFlagProvider(
               break;
             case letterForGoToOpen:
               setGoToOpen(!goToOpen);
-              break;
-            default:
-              console.log(event.key);
               break;
           }
         }

--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -71,7 +71,7 @@ const BaseApp = withFeatureFlagProvider(
     const keyboardListener = React.useCallback(
       (event: KeyboardEvent) => {
         const isOSMac = navigator.userAgent.includes('Mac');
-        const letterForThemeShortcut = 'D';
+        const letterForThemeShortcut = 'L';
         const letterForGoToOpen = 'K';
         const modifierKey = isOSMac ? 'ctrlKey' : 'altKey';
         if (event[modifierKey] && event.shiftKey) {
@@ -84,6 +84,9 @@ const BaseApp = withFeatureFlagProvider(
               break;
             case letterForGoToOpen:
               setGoToOpen(!goToOpen);
+              break;
+            default:
+              console.log(event.key);
               break;
           }
         }

--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -70,7 +70,6 @@ const BaseApp = withFeatureFlagProvider(
     const theme = preferences?.theme;
     const keyboardListener = React.useCallback(
       (event: KeyboardEvent) => {
-        const isOSMac = navigator.userAgent.includes('Mac');
         const letterForThemeShortcut = 'L';
         const letterForGoToOpen = 'K';
         const modifierKey = isOSMac ? 'ctrlKey' : 'altKey';
@@ -315,3 +314,5 @@ export const hasOauthError = (...args: (Error | APIError[] | undefined)[]) => {
       : cleanedError.toLowerCase().includes('oauth');
   });
 };
+
+export const isOSMac = navigator.userAgent.includes('Mac');

--- a/packages/manager/src/features/Profile/Settings/Settings.tsx
+++ b/packages/manager/src/features/Profile/Settings/Settings.tsx
@@ -2,6 +2,7 @@ import { FormLabel } from '@mui/material';
 import Grid from '@mui/material/Unstable_Grid2';
 import { useTheme } from '@mui/material/styles';
 import * as React from 'react';
+import { isOSMac } from 'src/App';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import type { PreferenceToggleProps } from 'src/components/PreferenceToggle/PreferenceToggle';
 import { PreferenceToggle } from 'src/components/PreferenceToggle/PreferenceToggle';
@@ -17,6 +18,7 @@ import { useMutateProfile, useProfile } from 'src/queries/profile';
 import { getQueryParamFromQueryString } from 'src/utilities/queryParams';
 import { ThemeChoice } from 'src/utilities/theme';
 import PreferenceEditor from './PreferenceEditor';
+import { Code } from 'src/components/Code/Code';
 
 export const ProfileSettings = () => {
   const theme = useTheme();
@@ -93,6 +95,10 @@ export const ProfileSettings = () => {
               <FormLabel>
                 <Typography variant="h2">Theme</Typography>
               </FormLabel>
+              <Typography variant="body1">
+                You may toggle your theme with the keyboard shortcut{' '}
+                {ThemeKeyboardShortcut}.
+              </Typography>
               <RadioGroup
                 row
                 style={{ marginBottom: 0 }}
@@ -161,3 +167,9 @@ export const ProfileSettings = () => {
     </>
   );
 };
+
+const ThemeKeyboardShortcut = isOSMac ? (
+  <Code>Ctrl + Shift + L</Code>
+) : (
+  <Code>Alt + Shift + L</Code>
+);

--- a/packages/manager/src/features/Profile/Settings/Settings.tsx
+++ b/packages/manager/src/features/Profile/Settings/Settings.tsx
@@ -168,8 +168,9 @@ export const ProfileSettings = () => {
   );
 };
 
-const ThemeKeyboardShortcut = isOSMac ? (
-  <Code>Ctrl + Shift + L</Code>
-) : (
-  <Code>Alt + Shift + L</Code>
+const ThemeKeyboardShortcut = (
+  <>
+    <Code>{isOSMac ? 'Ctrl' : 'Alt'}</Code> + <Code>Shift</Code> +{' '}
+    <Code>D</Code>
+  </>
 );

--- a/packages/manager/src/features/Profile/Settings/Settings.tsx
+++ b/packages/manager/src/features/Profile/Settings/Settings.tsx
@@ -3,6 +3,7 @@ import Grid from '@mui/material/Unstable_Grid2';
 import { useTheme } from '@mui/material/styles';
 import * as React from 'react';
 import { isOSMac } from 'src/App';
+import { Code } from 'src/components/Code/Code';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import type { PreferenceToggleProps } from 'src/components/PreferenceToggle/PreferenceToggle';
 import { PreferenceToggle } from 'src/components/PreferenceToggle/PreferenceToggle';
@@ -18,7 +19,6 @@ import { useMutateProfile, useProfile } from 'src/queries/profile';
 import { getQueryParamFromQueryString } from 'src/utilities/queryParams';
 import { ThemeChoice } from 'src/utilities/theme';
 import PreferenceEditor from './PreferenceEditor';
-import { Code } from 'src/components/Code/Code';
 
 export const ProfileSettings = () => {
   const theme = useTheme();


### PR DESCRIPTION
## Description 📝
For some historical context on the light/dark mode keyboard shortcut feature, refer to #7595 and #7606.

This PR exposes the keyboard shortcut in copy as opposed to having it be just an easter egg.

## Major Changes 🔄
- Instructional text/copy added to the "Theme" section re: keyboard shortcut

## How to test 🧪
Confirm that `Ctrl` + `Shift` + `D` works to change the theme in the app in Chrome, Firefox, and Safari.

Confirm that the copy in the Theme section of the "My Settings" page is accurate.