### PR TITLE
fix: [M3-6683]: Fix confirmation modal overflow on mobile

### DIFF
--- a/packages/manager/.changeset/pr-9289-fixed-1687364211275.md
+++ b/packages/manager/.changeset/pr-9289-fixed-1687364211275.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Fix confirmation modal overflow on mobile ([#9289](https://github.com/linode/manager/pull/9289))

--- a/packages/manager/src/components/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/packages/manager/src/components/ConfirmationDialog/ConfirmationDialog.tsx
@@ -9,9 +9,6 @@ import { DialogTitle } from 'src/components/DialogTitle/DialogTitle';
 
 const useStyles = makeStyles()((theme: Theme) => ({
   root: {
-    '& .MuiPaper-root': {
-      minWidth: 480,
-    },
     '& .MuiDialogTitle-root': {
       marginBottom: 10,
     },

--- a/packages/manager/src/components/DialogTitle/DialogTitle.tsx
+++ b/packages/manager/src/components/DialogTitle/DialogTitle.tsx
@@ -43,6 +43,7 @@ const DialogTitle = (props: DialogTitleProps) => {
           justifyContent: 'space-between',
           position: 'relative',
           width: '100%',
+          lineHeight: '1.5rem',
         }}
       >
         {title}


### PR DESCRIPTION
## Description 📝
The confirmation modal had a min width CSS rule that made it overflow on mobile under 450px. This PR removes the rule to fix the overflow as well as improving the line height of the modal title which was unecessarily excessive.

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-06-21 at 12 12 28 PM](https://github.com/linode/manager/assets/130582365/ea0f569f-f56a-4cf0-ba37-22ae8040eb24) | ![Screenshot 2023-06-21 at 12 12 50 PM](https://github.com/linode/manager/assets/130582365/4de961e2-eb45-4614-8c8e-60fdad4ad024) |

## How to test 🧪
Try deleting a Linode to be prompted for the confirmation modal in mobile view (450 or lower) and confirm both changes