### PR TITLE
fix: [M3-6638] - Object Storage > Create Access Key Drawer Layout Issue

### DIFF
--- a/packages/manager/.changeset/pr-9296-fixed-1687442580014.md
+++ b/packages/manager/.changeset/pr-9296-fixed-1687442580014.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Object Storage > Create Access Key Drawer Layout Issue ([#9296](https://github.com/linode/manager/pull/9296))

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
@@ -79,6 +79,7 @@ export const AccessKeyDrawer = (props: AccessKeyDrawerProps) => {
     data: objectStorageClusters,
     isLoading: areClustersLoading,
   } = useObjectStorageClusters();
+
   const {
     data: objectStorageBucketsResponse,
     isLoading: areBucketsLoading,
@@ -133,7 +134,12 @@ export const AccessKeyDrawer = (props: AccessKeyDrawerProps) => {
   };
 
   return (
-    <Drawer title={title} open={open} onClose={onClose} wide={createMode}>
+    <Drawer
+      title={title}
+      open={open}
+      onClose={onClose}
+      wide={createMode && buckets?.length > 0}
+    >
       {areBucketsLoading || areClustersLoading ? (
         <CircleProgress />
       ) : (

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
@@ -89,6 +89,8 @@ export const AccessKeyDrawer = (props: AccessKeyDrawerProps) => {
 
   const buckets = objectStorageBucketsResponse?.buckets || [];
 
+  const hasBuckets = buckets?.length > 0;
+
   const hidePermissionsTable =
     bucketsError || objectStorageBucketsResponse?.buckets.length === 0;
 
@@ -138,7 +140,7 @@ export const AccessKeyDrawer = (props: AccessKeyDrawerProps) => {
       title={title}
       open={open}
       onClose={onClose}
-      wide={createMode && buckets?.length > 0}
+      wide={createMode && hasBuckets}
     >
       {areBucketsLoading || areClustersLoading ? (
         <CircleProgress />
@@ -211,7 +213,7 @@ export const AccessKeyDrawer = (props: AccessKeyDrawerProps) => {
                   </Typography>
                 )}
 
-                {buckets?.length <= 0 ? (
+                {!hasBuckets ? (
                   <Typography sx={{ paddingTop: '10px' }}>
                     This key will have unlimited access to all buckets on your
                     account. The option to create a limited access key is only

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
@@ -211,6 +211,14 @@ export const AccessKeyDrawer = (props: AccessKeyDrawerProps) => {
                   </Typography>
                 )}
 
+                {buckets?.length <= 0 ? (
+                  <Typography sx={{ paddingTop: '10px' }}>
+                    This key will have unlimited access to all buckets on your
+                    account. The option to create a limited access key is only
+                    available after creating one or more buckets.
+                  </Typography>
+                ) : null}
+
                 <TextField
                   name="label"
                   label="Label"


### PR DESCRIPTION
## Description 📝
**Fix Object Storage > Create Access Key Drawer Layout Issue**

| Before  | After   |
| ------- | ------- |
| ![image](https://github.com/linode/manager/assets/119517080/37254eb8-73bc-43b9-bb40-bfc24c71715f) | ![image](https://github.com/linode/manager/assets/119517080/864b508f-cae8-4f07-bc54-850d09c1f998)|
|![image](https://github.com/linode/manager/assets/119517080/99fc6f22-4a6f-43e3-b2cc-cca19bc4930d)|![image](https://github.com/linode/manager/assets/119517080/8eb47b3e-9692-436b-8b5e-2f6763d44950)|

## How to test 🧪
1. **Navigate to Object storage and click create access key button**
2. **Validate drawer layout with no buckets.**
3. **Validate drawer layout with one or more buckets**


