### PR TITLE
fix: Reduce Firewall create and update e2e test flakiness

### DIFF
--- a/packages/manager/.changeset/pr-9298-fixed-1687455527847.md
+++ b/packages/manager/.changeset/pr-9298-fixed-1687455527847.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Fix LinodeSelectV2 label association ([#9298](https://github.com/linode/manager/pull/9298))

--- a/packages/manager/cypress/e2e/core/firewalls/create-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/create-firewall.spec.ts
@@ -33,8 +33,13 @@ describe('create firewall', () => {
         cy.findByText('Label is required.');
         // Fill out and submit firewall create form.
         containsClick('Label').type(firewall.label);
-        getClick('[data-testid="create-firewall-submit"]');
+        ui.buttonGroup
+          .findButtonByTitle('Create Firewall')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
       });
+    cy.wait('@createFirewall');
 
     // Confirm that firewall is listed on landing page with expected configuration.
     cy.findByText(firewall.label)
@@ -93,6 +98,8 @@ describe('create firewall', () => {
             .should('be.enabled')
             .click();
         });
+
+      cy.wait('@createFirewall');
 
       // Confirm that firewall is listed on landing page with expected configuration.
       cy.findByText(firewall.label)

--- a/packages/manager/cypress/e2e/core/firewalls/create-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/create-firewall.spec.ts
@@ -75,22 +75,23 @@ describe('create firewall', () => {
         .within(() => {
           // Fill out and submit firewall create form.
           containsClick('Label').type(firewall.label);
-          cy.get('[data-testid="textfield-input"]:last')
+          cy.findByLabelText('Linodes')
             .should('be.visible')
             .click()
             .type(linode.label);
-        });
 
-      ui.autocompletePopper
-        .findByTitle(linode.label)
-        .should('be.visible')
-        .click();
+          ui.autocompletePopper
+            .findByTitle(linode.label)
+            .should('be.visible')
+            .click();
 
-      ui.drawer
-        .findByTitle('Create Firewall')
-        .should('be.visible')
-        .within(() => {
-          getClick('[data-testid="create-firewall-submit"]');
+          cy.findByLabelText('Linodes').should('be.visible').click();
+
+          ui.button
+            .findByTitle('Create Firewall')
+            .should('be.visible')
+            .should('be.enabled')
+            .click();
         });
 
       // Confirm that firewall is listed on landing page with expected configuration.

--- a/packages/manager/cypress/e2e/core/firewalls/create-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/create-firewall.spec.ts
@@ -87,8 +87,8 @@ describe('create firewall', () => {
 
           cy.findByLabelText('Linodes').should('be.visible').click();
 
-          ui.button
-            .findByTitle('Create Firewall')
+          ui.buttonGroup
+            .findButtonByTitle('Create Firewall')
             .should('be.visible')
             .should('be.enabled')
             .click();

--- a/packages/manager/cypress/e2e/core/firewalls/update-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/update-firewall.spec.ts
@@ -123,7 +123,7 @@ const addLinodesToFirewall = (firewall: Firewall, linode: Linode) => {
     .should('be.visible')
     .within(() => {
       // Fill out and submit firewall edit form.
-      cy.get('[data-testid="textfield-input"]:last')
+      cy.findByLabelText('Linodes')
         .should('be.visible')
         .click()
         .type(linode.label);
@@ -133,9 +133,7 @@ const addLinodesToFirewall = (firewall: Firewall, linode: Linode) => {
         .should('be.visible')
         .click();
 
-      cy.get('[data-testid="textfield-input"]:last')
-        .should('be.visible')
-        .click();
+      cy.findByLabelText('Linodes').should('be.visible').click();
 
       ui.button.findByTitle('Add').should('be.visible').click();
     });

--- a/packages/manager/cypress/e2e/core/firewalls/update-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/update-firewall.spec.ts
@@ -13,7 +13,11 @@ import {
 } from 'src/factories';
 import { authenticate } from 'support/api/authentication';
 import { containsClick, getClick } from 'support/helpers';
-import { interceptCreateFirewall } from 'support/intercepts/firewalls';
+import {
+  interceptCreateFirewall,
+  interceptUpdateFirewallLinodes,
+  interceptUpdateFirewallRules,
+} from 'support/intercepts/firewalls';
 import { randomItem, randomString, randomLabel } from 'support/util/random';
 import { fbtVisible, fbtClick } from 'support/helpers';
 import { ui } from 'support/ui';
@@ -228,6 +232,7 @@ describe('update firewall', () => {
           });
 
         // Save configuration
+        interceptUpdateFirewallRules(firewall.id).as('updateFirewallRules');
         ui.button
           .findByTitle('Save Changes')
           .should('be.visible')
@@ -235,7 +240,7 @@ describe('update firewall', () => {
           .click();
 
         // Go back to landing page and check rules are added to the firewall
-        cy.wait(100);
+        cy.wait('@updateFirewallRules');
         cy.visitWithLogin('/firewalls');
         cy.findByText(firewall.label)
           .closest('tr')
@@ -253,6 +258,7 @@ describe('update firewall', () => {
         removeFirewallRules(outboundRule.label);
 
         // Save configuration
+        interceptUpdateFirewallRules(firewall.id).as('updateFirewallRules');
         ui.button
           .findByTitle('Save Changes')
           .should('be.visible')
@@ -260,7 +266,7 @@ describe('update firewall', () => {
           .click();
 
         // Go back to landing page and check rules are removed to the firewall
-        cy.wait(100);
+        cy.wait('@updateFirewallRules');
         cy.visitWithLogin('/firewalls');
         cy.findByText(firewall.label)
           .closest('tr')
@@ -272,7 +278,9 @@ describe('update firewall', () => {
         cy.findByText(firewall.label).click();
 
         // Confirm that the firewall can be assigned to the linode
+        interceptUpdateFirewallLinodes(firewall.id).as('updateFirewallLinodes');
         addLinodesToFirewall(firewall, linode);
+        cy.wait('@updateFirewallLinodes');
         cy.visitWithLogin('/firewalls');
         cy.findByText(firewall.label)
           .closest('tr')

--- a/packages/manager/cypress/e2e/core/firewalls/update-firewall.spec.ts
+++ b/packages/manager/cypress/e2e/core/firewalls/update-firewall.spec.ts
@@ -133,6 +133,10 @@ const addLinodesToFirewall = (firewall: Firewall, linode: Linode) => {
         .should('be.visible')
         .click();
 
+      cy.get('[data-testid="textfield-input"]:last')
+        .should('be.visible')
+        .click();
+
       ui.button.findByTitle('Add').should('be.visible').click();
     });
 };

--- a/packages/manager/cypress/e2e/core/images/smoke-create-image.spec.ts
+++ b/packages/manager/cypress/e2e/core/images/smoke-create-image.spec.ts
@@ -70,9 +70,8 @@ describe('create image', () => {
 
       cy.wait('@getImages');
       cy.findByText('Create Image').click();
-      cy.get('input[placeholder="Select a Linode"]').click();
+      cy.findByLabelText('Linodes').click();
       cy.findByText(linode.label).click();
-      cy.get('input[placeholder="Select a Linode"]').click();
       cy.wait('@getDisks');
       cy.contains('Select a Disk').click().type(`${diskLabel}{enter}`);
       cy.findAllByLabelText('Label', { exact: false }).type(

--- a/packages/manager/cypress/support/intercepts/firewalls.ts
+++ b/packages/manager/cypress/support/intercepts/firewalls.ts
@@ -10,5 +10,5 @@ import { apiMatcher } from 'support/util/intercepts';
  * @returns Cypress chainable.
  */
 export const interceptCreateFirewall = (): Cypress.Chainable<null> => {
-  return cy.intercept('POST', apiMatcher('firewalls'));
+  return cy.intercept('POST', apiMatcher('networking/firewalls'));
 };

--- a/packages/manager/cypress/support/intercepts/firewalls.ts
+++ b/packages/manager/cypress/support/intercepts/firewalls.ts
@@ -12,3 +12,31 @@ import { apiMatcher } from 'support/util/intercepts';
 export const interceptCreateFirewall = (): Cypress.Chainable<null> => {
   return cy.intercept('POST', apiMatcher('networking/firewalls'));
 };
+
+/**
+ * Intercepts PUT request to update a Firewall's rules.
+ *
+ * @returns Cypress chainable.
+ */
+export const interceptUpdateFirewallRules = (
+  firewallId: number
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'PUT',
+    apiMatcher(`networking/firewalls/${firewallId}/rules`)
+  );
+};
+
+/**
+ * Intercepts POST request to update a Firewall's Linodes.
+ *
+ * @returns Cypress chainable.
+ */
+export const interceptUpdateFirewallLinodes = (
+  firewallId: number
+): Cypress.Chainable<null> => {
+  return cy.intercept(
+    'POST',
+    apiMatcher(`networking/firewalls/${firewallId}/devices`)
+  );
+};

--- a/packages/manager/src/features/Linodes/LinodeSelect/LinodeSelectV2.tsx
+++ b/packages/manager/src/features/Linodes/LinodeSelect/LinodeSelectV2.tsx
@@ -118,6 +118,7 @@ export const LinodeSelectV2 = (
       renderInput={(params) => (
         <TextField
           label="Linodes"
+          inputId={params.id}
           placeholder={
             placeholder ?? multiple ? 'Select Linodes' : 'Select a Linode'
           }


### PR DESCRIPTION
## Description 📝
This makes a few changes to the Firewall create and update e2e tests, as well as the Image capture test, to reduce flakiness.

Changes to address flake:
- Updates interactions involving Linode multi select fields to reflect recent UX improvements made to the component
- Adds a couple intercepts and waits for them to resolve during UI interactions

Other changes:
- Removes some UI interactions involving Firewall creation in update tests and replaces them with API calls
- Fixes a small accessibility issue with `LinodeSelectV2` involving its label `for` attribute not matching the input field's ID

## How to test 🧪
We can lean on the automated run for this, but you can run these tests locally to better confirm that flake is resolved:

`yarn && yarn start:manager:ci && yarn build`, and then
```bash
yarn cy:run -s "cypress/e2e/core/firewalls/update-firewall.spec.ts,cypress/e2e/core/firewalls/create-firewall.spec.ts"
```

To confirm the change involving `LinodeSelectV2`:
1. Navigate to a place on the app which uses it (Create Firewall drawer, for example)
2. Inspect the "Linodes" input field via your browser dev tools, and confirm that the related `<label />` element's `for` attribute matches the `id` attribute of the input