### PR TITLE
refactor: [M3-6386] - MUI v5 Migration - `Components > SelectableTableRow`

### DIFF
--- a/packages/manager/src/components/SelectableTableRow/SelectableTableRow.tsx
+++ b/packages/manager/src/components/SelectableTableRow/SelectableTableRow.tsx
@@ -1,50 +1,51 @@
+import { styled } from '@mui/material/styles';
 import * as React from 'react';
 import CheckBox from 'src/components/CheckBox';
-import { makeStyles } from '@mui/styles';
 import { TableCell } from 'src/components/TableCell';
 import { TableRow } from 'src/components/TableRow';
 
-const useStyles = makeStyles(() => ({
-  root: {
-    '& td': {
-      padding: '0px 15px',
-    },
-  },
-  checkBox: {
-    textAlign: 'center',
-    width: 25,
-    paddingLeft: 0,
-    paddingRight: 0,
-    '& svg': {
-      width: 20,
-      height: 20,
-    },
-  },
-}));
-
-interface Props {
+interface SelectableTableRowProps {
   children: JSX.Element[];
   isChecked: boolean;
   handleToggleCheck: () => void;
 }
 
-export const SelectableTableRow: React.FC<Props> = (props) => {
-  const { isChecked, handleToggleCheck } = props;
-  const classes = useStyles();
-  return (
-    <TableRow className={classes.root}>
-      <TableCell className={classes.checkBox}>
-        <CheckBox
-          checked={isChecked}
-          onChange={handleToggleCheck}
-          inputProps={{
-            'aria-label': `Select all entities on page`,
-          }}
-        />
-      </TableCell>
-      {props.children}
-    </TableRow>
-  );
-};
+export const SelectableTableRow = React.memo(
+  (props: SelectableTableRowProps) => {
+    const { isChecked, handleToggleCheck } = props;
 
-export default React.memo(SelectableTableRow);
+    return (
+      <TableRow
+        sx={{
+          '& td': {
+            padding: '0px 15px',
+          },
+        }}
+      >
+        <StyledTableCell>
+          <CheckBox
+            checked={isChecked}
+            onChange={handleToggleCheck}
+            inputProps={{
+              'aria-label': `Select all entities on page`,
+            }}
+          />
+        </StyledTableCell>
+        {props.children}
+      </TableRow>
+    );
+  }
+);
+
+const StyledTableCell = styled(TableCell, {
+  label: 'StyledTableCell',
+})({
+  textAlign: 'center',
+  width: 25,
+  paddingLeft: 0,
+  paddingRight: 0,
+  '& svg': {
+    width: 20,
+    height: 20,
+  },
+});

--- a/packages/manager/src/components/SelectableTableRow/index.tsx
+++ b/packages/manager/src/components/SelectableTableRow/index.tsx
@@ -1,1 +1,0 @@
-export { default } from './SelectableTableRow';

--- a/packages/manager/src/features/EntityTransfers/EntityTransfersCreate/LinodeTransferTable.tsx
+++ b/packages/manager/src/features/EntityTransfers/EntityTransfersCreate/LinodeTransferTable.tsx
@@ -4,7 +4,7 @@ import Hidden from 'src/components/core/Hidden';
 import { useTheme } from '@mui/styles';
 import { Theme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
-import SelectableTableRow from 'src/components/SelectableTableRow';
+import { SelectableTableRow } from 'src/components/SelectableTableRow/SelectableTableRow';
 import { TableCell } from 'src/components/TableCell';
 import { TableContentWrapper } from 'src/components/TableContentWrapper/TableContentWrapper';
 import { useSpecificTypes } from 'src/queries/types';


### PR DESCRIPTION
## Description 📝
Migrate styles and update code patterns for the SelectableTableRow component

## Preview 📷
![image](https://github.com/linode/manager/assets/115299789/7c3783ad-89aa-4f68-bfeb-6a80cfcecff5)

## How to test 🧪
Verify that there has been no visual regressions in `/account/service-transfers/create`
