### PR TITLE
Fix: [M3-6716] Regression with placeholder opacity

### DIFF
--- a/packages/manager/.changeset/pr-9303-fixed-1687530086967.md
+++ b/packages/manager/.changeset/pr-9303-fixed-1687530086967.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Regression with text input placeholder opacity ([#9303](https://github.com/linode/manager/pull/9303))

--- a/packages/manager/src/foundations/themes/light.ts
+++ b/packages/manager/src/foundations/themes/light.ts
@@ -875,7 +875,7 @@ export const lightTheme: ThemeOptions = {
         input: {
           height: 'auto',
           '&::placeholder': {
-            opacity: 1,
+            opacity: 0.42,
           },
         },
       },


### PR DESCRIPTION
## Description 📝
Tiny PR to fix the regression with our text input placeholder opacity. It affects any text field in the application.

regression was introduced by the LinodeSelect refactor: https://github.com/linode/manager/commit/6b0ea3f70e67de6bd027fce31fc8b3715a5e0cb8#diff-f767369a01cd40921dc0da8dac44cf6777e3c155f3680aa2990be0da93c2dc48R877

## Major Changes 🔄

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-06-23 at 10 26 09 AM](https://github.com/linode/manager/assets/130582365/f4944600-f65a-41cb-9838-6e80dde632f5) | ![Screenshot 2023-06-23 at 10 24 53 AM](https://github.com/linode/manager/assets/130582365/c210a3cd-f2ba-4934-b6d0-9ecb96d8ee6e) |
| ![Screenshot 2023-06-23 at 10 26 25 AM](https://github.com/linode/manager/assets/130582365/58210631-64d3-41dd-a956-1130c06c55fb) | ![Screenshot 2023-06-23 at 10 24 17 AM](https://github.com/linode/manager/assets/130582365/76003563-6956-4bb3-b49f-f14582c0fdc6) |
