### PR TITLE
feat: Update metadata docs link

### DIFF
--- a/packages/manager/.changeset/pr-9304-added-1687531307023.md
+++ b/packages/manager/.changeset/pr-9304-added-1687531307023.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Add metadata docs links ([#9304](https://github.com/linode/manager/pull/9304))

--- a/packages/manager/src/features/Images/ImageUpload.tsx
+++ b/packages/manager/src/features/Images/ImageUpload.tsx
@@ -69,7 +69,10 @@ const cloudInitTooltipMessage = (
   <Typography>
     Only check this box if your Custom Image is compatible with cloud-init, or
     has cloud-init installed, and the config has been changed to use our data
-    service. <Link to="/">Learn how.</Link>
+    service.{' '}
+    <Link to="https://www.linode.com/docs/products/compute/compute-instances/guides/metadata-cloud-config/">
+      Learn how.
+    </Link>
   </Typography>
 );
 

--- a/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
+++ b/packages/manager/src/features/Images/ImagesCreate/CreateImageTab.tsx
@@ -67,7 +67,9 @@ const cloudInitTooltipMessage = (
   <Typography>
     Many Linode supported distributions are compatible with cloud-init by
     default, or you may have installed cloud-init.{' '}
-    <Link to="/">Learn more.</Link>
+    <Link to="https://www.linode.com/docs/products/compute/compute-instances/guides/metadata/">
+      Learn more.
+    </Link>
   </Typography>
 );
 

--- a/packages/manager/src/features/Linodes/LinodesCreate/UserDataAccordion/UserDataAccordion.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/UserDataAccordion/UserDataAccordion.tsx
@@ -88,7 +88,9 @@ export const UserDataAccordion = (props: Props) => {
         User data is a virtual machine&rsquo;s cloud-init metadata relating to a
         user&rsquo;s local account, including username and user group(s). <br />
         User data must be added before the Linode provisions.{' '}
-        <Link to="http://linode.com/docs">Learn more.</Link>{' '}
+        <Link to="https://www.linode.com/docs/products/compute/compute-instances/guides/metadata/">
+          Learn more.
+        </Link>{' '}
       </Typography>
       {formatWarning ? (
         <Notice warning spacingTop={16} spacingBottom={16}>

--- a/packages/manager/src/features/Linodes/LinodesCreate/UserDataAccordion/UserDataAccordionHeading.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/UserDataAccordion/UserDataAccordionHeading.tsx
@@ -33,7 +33,9 @@ export const UserDataAccordionHeading = ({ createType }: Props) => {
             <>
               User data is a virtual machine&rsquo;s cloud-init metadata
               relating to a user&rsquo;s local account.{' '}
-              <Link to="/">Learn more.</Link>
+              <Link to="https://www.linode.com/docs/products/compute/compute-instances/guides/metadata/">
+                Learn more.
+              </Link>
             </>
           }
           status="help"


### PR DESCRIPTION
## Description 📝
Update placeholder metadata docs link with the actual link.

## Preview 📷
![Screenshot 2023-06-23 at 10 32 11 AM](https://github.com/linode/manager/assets/114753608/4cb3a8b9-5b82-4286-8062-6ba3e51efeec)

## How to test 🧪
- Check the two metadata docs links on the Linode Create flow (there's one in the tooltip, and one in the User Data explainer copy)
- The UserDataAccordion also appears in the Rebuild from Image flow
- To see the metadata sections in Linode Create, you can just change L761 of LinodeCreate.tsx.
