### PR TITLE
Refactor: [M3-6522] Chip: MUI refactor + v7 story

### DIFF
--- a/packages/manager/src/components/.DragAndDrop.stories.mdx
+++ b/packages/manager/src/components/.DragAndDrop.stories.mdx
@@ -1,5 +1,0 @@
-import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
-
-<Meta title="Elements/Drag and Drop" />
-
-# Drag and Drop

--- a/packages/manager/src/components/BetaChip/BetaChip.tsx
+++ b/packages/manager/src/components/BetaChip/BetaChip.tsx
@@ -1,6 +1,6 @@
 import { Theme } from '@mui/material/styles';
 import * as React from 'react';
-import Chip, { ChipProps } from 'src/components/core/Chip';
+import { Chip, ChipProps } from 'src/components/core/Chip';
 import { makeStyles } from 'tss-react/mui';
 
 interface BetaChipProps

--- a/packages/manager/src/components/Chip.stories.tsx
+++ b/packages/manager/src/components/Chip.stories.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { Chip } from 'src/components/core/Chip';
+import type { ChipProps } from './core/Chip';
+import type { Meta, StoryObj } from '@storybook/react';
+
+export const Default: StoryObj<ChipProps> = {
+  render: (args) => <Chip {...args} />,
+};
+
+/**
+ * Actionable Chips indicate a state and allow users to take action.<br />
+ * **Example:** An ‘Upgrade’ chip on a Kubernetes cluster shows the software is not current and allows a user to upgrade to a new version.<br />
+ * **Visual style:** solid color background.
+ */
+export const Clickable: StoryObj<ChipProps> = {
+  render: (args) => <Chip {...args} label="Upgrade" clickable />,
+};
+
+/**
+ * Static Chips are an indication of status and are intended to be informational.<br />
+ * No action is required or enabled.<br />
+ * **Example:** ‘NVMe’ chip on a volume.<br />
+ * **Visual style:** outline.
+ */
+export const Outlined: StoryObj<ChipProps> = {
+  render: (args) => <Chip {...args} variant="outlined" />,
+};
+
+export const Custom: StoryObj<ChipProps> = {
+  render: (args) => (
+    <Chip
+      {...args}
+      label="NVMe"
+      variant="outlined"
+      outlineColor="green"
+      size="small"
+    />
+  ),
+};
+
+export const WithDeleteButton: StoryObj<ChipProps> = {
+  render: (args) => {
+    const ChipWrapper = () => {
+      const [isDeleted, setIsDeleted] = React.useState(false);
+
+      const handleDelete = () => {
+        setIsDeleted(true);
+        setTimeout(() => {
+          setIsDeleted(false);
+        }, 1000);
+      };
+
+      return (
+        <div style={{ height: 20 }}>
+          {!isDeleted ? <Chip {...args} onDelete={handleDelete} /> : null};
+        </div>
+      );
+    };
+
+    return <ChipWrapper />;
+  },
+};
+
+const meta: Meta<ChipProps> = {
+  title: 'Components/Core/Chip',
+  component: Chip,
+  args: { label: 'Chip', onDelete: undefined },
+};
+export default meta;

--- a/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.tsx
+++ b/packages/manager/src/components/PaymentMethodRow/PaymentMethodRow.tsx
@@ -4,7 +4,7 @@ import { PaymentMethod } from '@linode/api-v4/lib/account/types';
 import { useTheme } from '@mui/material/styles';
 import Paper from 'src/components/core/Paper';
 import Box from '@mui/material/Box';
-import Chip from 'src/components/core/Chip';
+import { Chip } from 'src/components/core/Chip';
 import CreditCard from 'src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/CreditCard';
 import ThirdPartyPayment from './ThirdPartyPayment';
 import ActionMenu, { Action } from 'src/components/ActionMenu';

--- a/packages/manager/src/components/ShowMore/ShowMore.tsx
+++ b/packages/manager/src/components/ShowMore/ShowMore.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Chip, { ChipProps } from 'src/components/core/Chip';
+import { Chip, ChipProps } from 'src/components/core/Chip';
 import Popover from '@mui/material/Popover';
 import { styled, useTheme } from '@mui/material/styles';
 

--- a/packages/manager/src/components/StackScript/StackScript.tsx
+++ b/packages/manager/src/components/StackScript/StackScript.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { Link, useHistory } from 'react-router-dom';
 import Button from 'src/components/Button';
 import { CopyTooltip } from 'src/components/CopyTooltip/CopyTooltip';
-import Chip from 'src/components/core/Chip';
+import { Chip } from 'src/components/core/Chip';
 import Divider from 'src/components/core/Divider';
 import Typography from 'src/components/core/Typography';
 import { DateTimeDisplay } from 'src/components/DateTimeDisplay';

--- a/packages/manager/src/components/Tag/Tag.tsx
+++ b/packages/manager/src/components/Tag/Tag.tsx
@@ -2,7 +2,7 @@ import Close from '@mui/icons-material/Close';
 import { styled } from '@mui/material/styles';
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
-import Chip, { ChipProps } from 'src/components/core/Chip';
+import { Chip, ChipProps } from 'src/components/core/Chip';
 import { truncateEnd } from 'src/utilities/truncate';
 
 type Variants = 'blue' | 'lightBlue';

--- a/packages/manager/src/components/core/Chip.tsx
+++ b/packages/manager/src/components/core/Chip.tsx
@@ -1,49 +1,52 @@
 import * as React from 'react';
-import classNames from 'classnames';
-import { makeStyles } from '@mui/styles';
-import { Theme } from '@mui/material/styles';
 import { default as _Chip, ChipProps as _ChipProps } from '@mui/material/Chip';
+import { styled } from '@mui/material/styles';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  inTable: {
+export interface ChipProps extends _ChipProps {
+  /**
+   * Optional component to render instead of a span.
+   */
+  component?: string;
+  /**
+   * If true, the chip will inherit styles to allow for use in a table.
+   * @default false
+   */
+  inTable?: boolean;
+  /**
+   * The color of the outline when the variant is outlined.
+   * @default 'gray'
+   */
+  outlineColor?: 'green' | 'gray';
+}
+
+export const Chip = ({
+  outlineColor = 'gray',
+  className,
+  inTable,
+  ...props
+}: ChipProps) => {
+  return (
+    <StyledChip
+      inTable={inTable}
+      outlineColor={outlineColor}
+      className={className}
+      {...props}
+    />
+  );
+};
+
+const StyledChip = styled(_Chip, {
+  label: 'StyledChip',
+})<ChipProps>(({ theme, ...props }) => ({
+  ...(props.inTable && {
     marginTop: 0,
     marginBottom: 0,
     marginLeft: theme.spacing(2),
     minHeight: theme.spacing(2),
     paddingLeft: theme.spacing(0.5),
     paddingRight: theme.spacing(0.5),
-  },
-  ['outline-gray']: {
-    border: '1px solid #ccc',
-  },
-  ['outline-green']: {
-    border: '1px solid #02B159',
-  },
+  }),
+  ...(props.variant === 'outlined' && {
+    border: `1px solid ${props.outlineColor === 'green' ? '#02B159' : '#ccc'}`,
+  }),
 }));
-
-export interface ChipProps extends _ChipProps {
-  outlineColor?: 'green' | 'gray';
-  component?: string;
-  inTable?: boolean;
-}
-
-const Chip: React.FC<ChipProps> = ({
-  outlineColor = 'gray',
-  className,
-  inTable,
-  ...props
-}) => {
-  const classes = useStyles();
-
-  return (
-    <_Chip
-      className={classNames(className, {
-        [classes.inTable]: inTable,
-        [classes[`outline-${outlineColor}`]]: props.variant === 'outlined',
-      })}
-      {...props}
-    />
-  );
-};
-
-export default Chip;

--- a/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentMethodCard.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingSummary/PaymentDrawer/PaymentMethodCard.tsx
@@ -1,6 +1,6 @@
 import { PaymentMethod, PaymentType } from '@linode/api-v4';
 import * as React from 'react';
-import Chip from 'src/components/core/Chip';
+import { Chip } from 'src/components/core/Chip';
 import Grid from '@mui/material/Unstable_Grid2';
 import {
   getIcon as getTPPIcon,

--- a/packages/manager/src/features/Databases/DatabaseLanding/DatabaseRow.tsx
+++ b/packages/manager/src/features/Databases/DatabaseLanding/DatabaseRow.tsx
@@ -5,7 +5,7 @@ import {
 } from '@linode/api-v4/lib/databases/types';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import Chip from 'src/components/core/Chip';
+import { Chip } from 'src/components/core/Chip';
 import Hidden from 'src/components/core/Hidden';
 import { StatusIcon } from 'src/components/StatusIcon/StatusIcon';
 import { Status } from 'src/components/StatusIcon/StatusIcon';

--- a/packages/manager/src/features/Kubernetes/ClusterList/KubernetesClusterRow.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/KubernetesClusterRow.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import Chip from 'src/components/core/Chip';
+import { Chip } from 'src/components/core/Chip';
 import Hidden from 'src/components/core/Hidden';
 import Grid from '@mui/material/Unstable_Grid2';
 import { DateTimeDisplay } from 'src/components/DateTimeDisplay';

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import { ConfirmationDialog } from 'src/components/ConfirmationDialog/ConfirmationDialog';
-import Chip from 'src/components/core/Chip';
+import { Chip } from 'src/components/core/Chip';
 import Paper from 'src/components/core/Paper';
 import Grid from '@mui/material/Unstable_Grid2';
 import { TagsPanel } from 'src/components/TagsPanel/TagsPanel';

--- a/packages/manager/src/features/Linodes/LinodeEntityDetail.tsx
+++ b/packages/manager/src/features/Linodes/LinodeEntityDetail.tsx
@@ -17,7 +17,7 @@ import { TableBody } from 'src/components/TableBody';
 import { TableRow } from 'src/components/TableRow';
 import { TagCell } from 'src/components/TagCell/TagCell';
 import Box from 'src/components/core/Box';
-import Chip from 'src/components/core/Chip';
+import { Chip } from 'src/components/core/Chip';
 import Hidden from 'src/components/core/Hidden';
 import Typography, { TypographyProps } from 'src/components/core/Typography';
 import { lishLaunch } from 'src/features/Lish/lishUtils';

--- a/packages/manager/src/features/Linodes/LinodesCreate/AppPanelSection.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/AppPanelSection.tsx
@@ -6,7 +6,7 @@ import { styled } from '@mui/material/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from '@mui/material/Unstable_Grid2';
 import SelectionCardWrapper from 'src/features/Linodes/LinodesCreate/SelectionCardWrapper';
-import Chip from 'src/components/core/Chip';
+import { Chip } from 'src/components/core/Chip';
 
 const AppPanelGrid = styled(Grid)(({ theme }) => ({
   marginTop: theme.spacing(2),

--- a/packages/manager/src/features/Linodes/LinodesCreate/SelectPlanPanel/PlanSelection.styles.ts
+++ b/packages/manager/src/features/Linodes/LinodesCreate/SelectPlanPanel/PlanSelection.styles.ts
@@ -1,4 +1,4 @@
-import Chip from 'src/components/core/Chip';
+import { Chip } from 'src/components/core/Chip';
 import { styled } from '@mui/material/styles';
 import { TableCell } from 'src/components/TableCell';
 

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewPlans.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewPlans.tsx
@@ -7,7 +7,7 @@ import { APIError } from '@linode/api-v4/lib/types';
 import classNames from 'classnames';
 import * as React from 'react';
 import Button from 'src/components/Button';
-import Chip from 'src/components/core/Chip';
+import { Chip } from 'src/components/core/Chip';
 import CircularProgress from 'src/components/core/CircularProgress';
 import Paper from 'src/components/core/Paper';
 import { makeStyles } from '@mui/styles';

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigNode.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigNode.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
-import Chip from 'src/components/core/Chip';
 import Divider from 'src/components/core/Divider';
 import Grid from '@mui/material/Unstable_Grid2';
 import MenuItem from 'src/components/core/MenuItem';
 import TextField from 'src/components/TextField';
 import Typography from 'src/components/core/Typography';
+import { Chip } from 'src/components/core/Chip';
 import { ConfigNodeIPSelect } from './ConfigNodeIPSelect';
 import { getErrorMap } from 'src/utilities/errorUtils';
 import { NodeBalancerConfigNodeFields } from './types';

--- a/packages/manager/src/features/Support/SupportTicketDetail/SupportTicketDetail.tsx
+++ b/packages/manager/src/features/Support/SupportTicketDetail/SupportTicketDetail.tsx
@@ -3,7 +3,7 @@ import { isEmpty } from 'ramda';
 import * as React from 'react';
 import { Link, useHistory, useLocation, useParams } from 'react-router-dom';
 import { CircleProgress } from 'src/components/CircleProgress';
-import Chip from 'src/components/core/Chip';
+import { Chip } from 'src/components/core/Chip';
 import { makeStyles } from 'tss-react/mui';
 import { Theme } from '@mui/material/styles';
 import Typography from 'src/components/core/Typography';


### PR DESCRIPTION
## Description 📝
This PR refactors the `Chip` component exports and handles the new way of doing stories. It does not modify the component in any way, or at least shouldn't. This is the first PR of many to get away from .mdx files.

Note: the new story lives in `Components > Core` which is a new directory (other core components will be moved in there

## Preview 📷
No visual diff

## How to test 🧪
1. Confirm no regression on Chips
2. Confirm new story at /?path=/docs/components-core-chip--documentation