### PR TITLE
refactor: [M3-6791] - MUI v5 Migration - `Components > Toolbar`

### DIFF
--- a/packages/manager/.changeset/pr-9319-tech-stories-1687875908852.md
+++ b/packages/manager/.changeset/pr-9319-tech-stories-1687875908852.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+MUI v5 Migration - Components > Toolbar ([#9319](https://github.com/linode/manager/pull/9319))

--- a/packages/manager/src/components/Toolbar.ts
+++ b/packages/manager/src/components/Toolbar.ts
@@ -1,0 +1,2 @@
+export { default as Toolbar } from '@mui/material/Toolbar';
+export type { ToolbarProps } from '@mui/material/Toolbar';

--- a/packages/manager/src/components/core/Toolbar.ts
+++ b/packages/manager/src/components/core/Toolbar.ts
@@ -1,6 +1,0 @@
-import Toolbar, { ToolbarProps as _ToolbarProps } from '@mui/material/Toolbar';
-
-/* tslint:disable-next-line:no-empty-interface */
-export interface ToolbarProps extends _ToolbarProps {}
-
-export default Toolbar;

--- a/packages/manager/src/features/TopMenu/TopMenu.tsx
+++ b/packages/manager/src/features/TopMenu/TopMenu.tsx
@@ -6,7 +6,7 @@ import { IconButton } from 'src/components/IconButton';
 import { makeStyles } from '@mui/styles';
 import { Theme, useTheme } from '@mui/material/styles';
 import clsx from 'clsx';
-import Toolbar from 'src/components/core/Toolbar';
+import { Toolbar } from 'src/components/Toolbar';
 import Typography from 'src/components/core/Typography';
 import { AddNewMenu } from './AddNewMenu/AddNewMenu';
 import Community from './Community';


### PR DESCRIPTION
## Description 📝
- Style migration for the `<Toolbar />` component

## Major Changes 🔄
- Moves `packages/manager/src/components/core/Toolbar.ts` to `packages/manager/src/components/Toolbar.ts` 🗂️
- Use **only** named exports 🧼💡

## How to test 🧪
- Verify the app's Top Menu bar looks normal