### PR TITLE
refactor: [M3-6793] - MUI v5 Migration - `Components > AppBar`

### DIFF
--- a/packages/manager/.changeset/pr-9321-tech-stories-1687879529410.md
+++ b/packages/manager/.changeset/pr-9321-tech-stories-1687879529410.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+MUI v5 Migration - Components > AppBar ([#9321](https://github.com/linode/manager/pull/9321))

--- a/packages/manager/src/components/AppBar.ts
+++ b/packages/manager/src/components/AppBar.ts
@@ -1,0 +1,2 @@
+export { default as AppBar } from '@mui/material/AppBar';
+export { AppBarProps } from '@mui/material/AppBar';

--- a/packages/manager/src/components/core/AppBar.ts
+++ b/packages/manager/src/components/core/AppBar.ts
@@ -1,6 +1,0 @@
-import AppBar, { AppBarProps as _AppBarProps } from '@mui/material/AppBar';
-
-/* tslint:disable-next-line:no-empty-interface */
-export interface AppBarProps extends _AppBarProps {}
-
-export default AppBar;

--- a/packages/manager/src/features/TopMenu/TopMenu.tsx
+++ b/packages/manager/src/features/TopMenu/TopMenu.tsx
@@ -1,6 +1,6 @@
 import MenuIcon from '@mui/icons-material/Menu';
 import * as React from 'react';
-import AppBar from 'src/components/core/AppBar';
+import { AppBar } from 'src/components/AppBar';
 import Hidden from 'src/components/core/Hidden';
 import { IconButton } from 'src/components/IconButton';
 import { makeStyles } from '@mui/styles';


### PR DESCRIPTION
## Description 📝
- Style migration for the `<AppBar />` component

## Major Changes 🔄
- Moves `packages/manager/src/components/core/AppBar.ts` ➡️ `packages/manager/src/components/AppBar.ts` 🗂️
- Changed default export to named export 🧼

## How to test 🧪
- Verify the app's top navigation bar looks and works as expected