### PR TITLE
hotfix: Notification Menu crash due to null value

### DIFF
--- a/packages/api-v4/CHANGELOG.md
+++ b/packages/api-v4/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2023-06-27] - v0.95.1
+
+
+### Fixed:
+
+- Updated Entity interface to reflect the possibility of a null label ([#9331](https://github.com/linode/manager/pull/9331))
+
 ## [2023-06-26] - v0.95.0
 
 ### Added:

--- a/packages/api-v4/package.json
+++ b/packages/api-v4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linode/api-v4",
-  "version": "0.95.0",
+  "version": "0.95.1",
   "homepage": "https://github.com/linode/manager/tree/develop/packages/api-v4",
   "bugs": {
     "url": "https://github.com/linode/manager/issues"

--- a/packages/api-v4/src/account/types.ts
+++ b/packages/api-v4/src/account/types.ts
@@ -223,7 +223,7 @@ export interface Notification {
 
 export interface Entity {
   id: number;
-  label: string;
+  label: string | null;
   type: string;
   url: string;
 }

--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2023-06-27] - v1.96.1
+
+
+### Fixed:
+
+- Added check for null label in event entity ([#9331](https://github.com/linode/manager/pull/9331))
+
 ## [2023-06-26] - v1.96.0
 
 ### Added:

--- a/packages/manager/CHANGELOG.md
+++ b/packages/manager/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed:
 
-- Added check for null label in event entity ([#9331](https://github.com/linode/manager/pull/9331))
+- Crash when viewing notifications due to `null` label in event entity ([#9331](https://github.com/linode/manager/pull/9331))
 
 ## [2023-06-26] - v1.96.0
 

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "1.96.0",
+  "version": "1.96.1",
   "private": true,
   "bugs": {
     "url": "https://github.com/Linode/manager/issues"

--- a/packages/manager/src/eventMessageGenerator.test.ts
+++ b/packages/manager/src/eventMessageGenerator.test.ts
@@ -141,5 +141,18 @@ describe('Event message generation', () => {
         'created entity <a href="/linodes/10">Weird label with special characters.(?)</a> '
       );
     });
+
+    it('should work when label is null', () => {
+      const mockEvent = eventFactory.build({
+        entity: entityFactory.build({
+          id: 10,
+          label: null,
+        }),
+      });
+      const message = 'created entity Null label';
+      const result = applyLinking(mockEvent, message);
+
+      expect(result).toEqual('created entity Null label');
+    });
   });
 });

--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -872,7 +872,7 @@ export function applyLinking(event: Event, message: string) {
 
   let newMessage = message;
 
-  if (event.entity && entityLinkTarget) {
+  if (event.entity?.label && entityLinkTarget) {
     const label = event.entity.label;
     const nonTickedLabels = new RegExp(`(?<!\`)${escapeRegExp(label)}`, 'g');
 
@@ -882,7 +882,7 @@ export function applyLinking(event: Event, message: string) {
     );
   }
 
-  if (event.secondary_entity && secondaryEntityLinkTarget) {
+  if (event.secondary_entity?.label && secondaryEntityLinkTarget) {
     newMessage = newMessage.replace(
       event.secondary_entity.label,
       `<a href="${secondaryEntityLinkTarget}">${event.secondary_entity.label}</a>`

--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -54,19 +54,19 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
   },
   community_question_reply: {
     notification: (e) =>
-      e.entity
+      e.entity?.label
         ? `There has been a reply to your thread "${e.entity.label}".`
         : `There has been a reply to your thread.`,
   },
   community_like: {
     notification: (e) =>
-      e.entity
+      e.entity?.label
         ? `A post on "${e.entity.label}" has been liked.`
         : `There has been a like on your community post.`,
   },
   community_mention: {
     notification: (e) =>
-      e.entity
+      e.entity?.label
         ? `You have been mentioned in a Community post: ${e.entity.label}.`
         : `You have been mentioned in a Community post.`,
   },
@@ -790,7 +790,7 @@ export default (e: Event): string => {
     /** finally return some default fallback text */
     return e.message
       ? formatEventWithAPIMessage(e)
-      : `${e.action}${e.entity ? ` on ${e.entity.label}` : ''}`;
+      : `${e.action}${e.entity?.label ? ` on ${e.entity.label}` : ''}`;
   }
 
   let message = '';


### PR DESCRIPTION
## Description 📝
Fixes a bug that causes the app to crash when opening the Notification Menu.

## Major Changes 🔄
- Updates `Entity` type in `api-v4` package to reflect the possibility of a null `label`
- Adds null check to `applyLinking` function

## How to test 🧪
1. Verify opening the Events Menu does not cause a crash when a user has an entity event with a null label (e.g., `entity_transfer`)
