### PR TITLE
fix: local dev server `AppBarProps` export

### DIFF
--- a/packages/manager/src/components/AppBar.ts
+++ b/packages/manager/src/components/AppBar.ts
@@ -1,2 +1,2 @@
 export { default as AppBar } from '@mui/material/AppBar';
-export { AppBarProps } from '@mui/material/AppBar';
+export type { AppBarProps } from '@mui/material/AppBar';


### PR DESCRIPTION
## Description 📝
- Fixes dev server not starting

## Major Changes 🔄
- Fixes bad import causing Vite dev server to break https://github.com/linode/manager/pull/9321

## How to test 🧪
- Verify Cloud Manager works when `yarn dev` is ran