### PR TITLE
chore: [M3-6666] -  Clean up for consistent spelling of "canceled"

### DIFF
--- a/packages/api-v4/.changeset/pr-9335-changed-1687980892035.md
+++ b/packages/api-v4/.changeset/pr-9335-changed-1687980892035.md
@@ -1,0 +1,5 @@
+---
+"@linode/api-v4": Changed
+---
+
+Use 'canceled' instead of 'cancelled' for EntityTransferStatus ([#9335](https://github.com/linode/manager/pull/9335))

--- a/packages/api-v4/src/entity-transfers/types.ts
+++ b/packages/api-v4/src/entity-transfers/types.ts
@@ -1,7 +1,7 @@
 export type EntityTransferStatus =
   | 'pending'
   | 'accepted'
-  | 'cancelled'
+  | 'canceled'
   | 'completed'
   | 'failed'
   | 'stale';

--- a/packages/manager/cypress/e2e/core/account/service-transfer.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/service-transfer.spec.ts
@@ -37,7 +37,7 @@ const serviceTransferStatuses = [
   'failed',
   'accepted',
   'stale',
-  'cancelled',
+  'canceled',
 ];
 
 /**
@@ -214,10 +214,9 @@ describe('Account service transfers', () => {
                 cy.findByText(
                   formatDate(sentTransfer.created, dateFormatOptions)
                 ).should('be.visible');
-                cy.findByText(
-                  sentTransfer.status.replace('cancelled', 'canceled'),
-                  { exact: false }
-                ).should('be.visible');
+                cy.findByText(sentTransfer.status, { exact: false }).should(
+                  'be.visible'
+                );
               });
           });
         });

--- a/packages/manager/src/features/EntityTransfers/RenderTransferRow.tsx
+++ b/packages/manager/src/features/EntityTransfers/RenderTransferRow.tsx
@@ -167,7 +167,7 @@ export const RenderTransferRow: React.FC<CombinedProps> = (props) => {
       ) : null}
       {transferTypeIsSent ? (
         <TableCell className={classes.cellContents}>
-          {capitalize(status?.replace('cancelled', 'canceled') ?? '')}
+          {capitalize(status ?? '')}
         </TableCell>
       ) : null}
     </TableRow>

--- a/packages/manager/src/features/ToastNotifications/ToastNotifications.tsx
+++ b/packages/manager/src/features/ToastNotifications/ToastNotifications.tsx
@@ -139,7 +139,7 @@ class ToastNotifications extends React.PureComponent<WithSnackbarProps, {}> {
               ),
             });
           case 'image_upload':
-            const isDeletion = event.message === 'Upload cancelled.';
+            const isDeletion = event.message === 'Upload canceled.';
             return toastSuccessAndFailure({
               enqueueSnackbar,
               eventStatus: event.status,
@@ -147,9 +147,10 @@ class ToastNotifications extends React.PureComponent<WithSnackbarProps, {}> {
               successMessage: `Image ${label} is now available.`,
               failureMessage: isDeletion
                 ? undefined
-                : `There was a problem uploading image ${label}: ${event.message
-                    ?.replace('cancelled', 'canceled')
-                    .replace(/(\d+)/g, '$1 MB')}`,
+                : `There was a problem uploading image ${label}: ${event.message?.replace(
+                    /(\d+)/g,
+                    '$1 MB'
+                  )}`,
             });
           case 'image_delete':
             return toastSuccessAndFailure({

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -123,11 +123,16 @@ const entityTransfers = [
       is_sender: true,
       status: 'pending',
     });
+    const transfer5 = entityTransferFactory.build({
+      is_sender: true,
+      status: 'canceled',
+    });
 
     const combinedTransfers = transfers1.concat(
       transfers2,
       transfers3,
-      transfer4
+      transfer4,
+      transfer5
     );
     return res(ctx.json(makeResourcePage(combinedTransfers)));
   }),


### PR DESCRIPTION
## Description 📝
There are two places in Cloud Manager ([image upload error toast](https://github.com/linode/manager/blob/develop/packages/manager/src/features/ToastNotifications/ToastNotifications.tsx#L140-L142), [entity transfer request status table column](https://github.com/linode/manager/blob/develop/packages/manager/src/features/EntityTransfers/RenderTransferRow.tsx#L170)) where we were performing string manipulation to edit an event message or status from API that returns "cancelled" rather than "canceled". Both spellings are correct -  "cancelled" is British-English and "canceled" is American English - but for consistency's sake, it would be better to use one spelling; "canceled" is already in use in all other places throughout the app.

API is now always returning the spelling "canceled" (see linked internal ticket), so this PR does some clean up to reflect those changes. 

## Major Changes 🔄
**List highlighting major changes**
- 'Canceled' has a consistent spelling throughout the app without string manipulation needed.
- `EntityTransferStatus` types are updated to maintain parity with API. 

## Preview 📷
Should be no visual differences from prod, since we were already manually changing the spelling. Now we don't have to.

## How to test 🧪
1. **How to setup test environment?**
- Check out this branch.
- `yarn up`
- Test this with the dev API.
2. **How to verify changes?**
- Upload an image in a valid region. After being redirected back to the image landing page, use the action menu to cancel the upload. Confirm that _no_ error toast displays with the "Upload canceled" message, which is the existing behavior in prod, where canceling an upload isn't considered an error and only the "image deleted" toast will display. 
(Note: There is an event message for a failed `image_upload` that does display when an upload is canceled, and it's not formatted particularly well due to the username tacked on the end. Thoughts welcome here; just didn't want to add more complexity to the already sketchy events message generator if no one is too bothered by this.)
- We can't make service transfers on dev, so turn on the MSW and observe the mocked entity transfer on the second page of the table with a status of 'canceled'. (http://localhost:3000/account/service-transfers?sent-transfers-table-page=2)
- Double check the API PR to make sure I didn't miss anything.
6. **How to run Unit or E2E tests?**
```
yarn cy:run -s "cypress/e2e/core/account/service-transfer.spec.ts"
```