### PR TITLE
Fix: [M3-6800] Firewall custom port validation

### DIFF
--- a/packages/manager/.changeset/pr-9336-fixed-1687982995866.md
+++ b/packages/manager/.changeset/pr-9336-fixed-1687982995866.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Firewall custom ports validation ([#9336](https://github.com/linode/manager/pull/9336))

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.test.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.test.tsx
@@ -121,7 +121,8 @@ describe('utilities', () => {
         label: 'Firewalllabel',
         addresses: 'All IPv4',
       };
-      expect(validateForm({ protocol: 'TCP', ports: '1', ...rest })).toEqual(
+      // SUCCESS CASES
+      expect(validateForm({ protocol: 'TCP', ports: '1234', ...rest })).toEqual(
         {}
       );
       expect(
@@ -134,28 +135,46 @@ describe('utilities', () => {
         {}
       );
       expect(
-        validateForm({ protocol: 'TCP', ports: 'abc', ...rest })
-      ).toHaveProperty(
-        'ports',
-        'Ports must be an integer, range of integers, or a comma-separated list of integers.'
-      );
-      expect(
-        validateForm({ protocol: 'TCP', ports: '1--20', ...rest })
-      ).toHaveProperty(
-        'ports',
-        'Ports must be an integer, range of integers, or a comma-separated list of integers.'
-      );
+        validateForm({
+          protocol: 'TCP',
+          ports: '1,2,3,4,5,6,7,8,9,10,11,12,13,14,15',
+          ...rest,
+        })
+      ).toEqual({});
       expect(
         validateForm({ protocol: 'TCP', ports: '1-2,3-4', ...rest })
+      ).toEqual({});
+      expect(
+        validateForm({ protocol: 'TCP', ports: '1,5-12', ...rest })
+      ).toEqual({});
+      // FAILURE CASES
+      expect(
+        validateForm({ protocol: 'TCP', ports: '1,21-12', ...rest })
       ).toHaveProperty(
         'ports',
-        'Ports must be an integer, range of integers, or a comma-separated list of integers.'
+        'Range must start with a smaller number and end with a larger number'
       );
       expect(
+        validateForm({ protocol: 'TCP', ports: '1-21-45', ...rest })
+      ).toHaveProperty('ports', 'Ranges must have 2 values');
+      expect(
+        validateForm({ protocol: 'TCP', ports: 'abc', ...rest })
+      ).toHaveProperty('ports', 'Must be 1-65535');
+      expect(
+        validateForm({ protocol: 'TCP', ports: '1--20', ...rest })
+      ).toHaveProperty('ports', 'Must be 1-65535');
+      expect(
         validateForm({ protocol: 'TCP', ports: '-20', ...rest })
+      ).toHaveProperty('ports', 'Must be 1-65535');
+      expect(
+        validateForm({
+          protocol: 'TCP',
+          ports: '1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16',
+          ...rest,
+        })
       ).toHaveProperty(
         'ports',
-        'Ports must be an integer, range of integers, or a comma-separated list of integers.'
+        'Number of ports or port range endpoints exceeded. Max allowed is 15'
       );
     });
     it('validates label', () => {

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.utils.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.utils.ts
@@ -13,7 +13,7 @@ import {
 } from 'src/features/Firewalls/shared';
 import {
   CUSTOM_PORTS_ERROR_MESSAGE,
-  runCustomPortsValidation,
+  isCustomPortsValid,
 } from '@linode/validation';
 import type {
   FirewallRuleProtocol,
@@ -332,7 +332,7 @@ export const validateForm = ({
 
   if ((protocol === 'ICMP' || protocol === 'IPENCAP') && ports) {
     errors.ports = `Ports are not allowed for ${protocol} protocols.`;
-  } else if (ports && !runCustomPortsValidation(ports)) {
+  } else if (ports && !isCustomPortsValid(ports)) {
     errors.ports = CUSTOM_PORTS_ERROR_MESSAGE;
   }
 

--- a/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.utils.ts
+++ b/packages/manager/src/features/Firewalls/FirewallDetail/Rules/FirewallRuleDrawer.utils.ts
@@ -12,8 +12,8 @@ import {
   predefinedFirewallFromRule,
 } from 'src/features/Firewalls/shared';
 import {
-  CUSTOM_PORTS_VALIDATION_REGEX,
   CUSTOM_PORTS_ERROR_MESSAGE,
+  runCustomPortsValidation,
 } from '@linode/validation';
 import type {
   FirewallRuleProtocol,
@@ -332,7 +332,7 @@ export const validateForm = ({
 
   if ((protocol === 'ICMP' || protocol === 'IPENCAP') && ports) {
     errors.ports = `Ports are not allowed for ${protocol} protocols.`;
-  } else if (ports && !ports.match(CUSTOM_PORTS_VALIDATION_REGEX)) {
+  } else if (ports && !runCustomPortsValidation(ports)) {
     errors.ports = CUSTOM_PORTS_ERROR_MESSAGE;
   }
 

--- a/packages/validation/.changeset/pr-9336-fixed-1687983041491.md
+++ b/packages/validation/.changeset/pr-9336-fixed-1687983041491.md
@@ -1,0 +1,5 @@
+---
+"@linode/validation": Fixed
+---
+
+Firewall custom port validation ([#9336](https://github.com/linode/manager/pull/9336))

--- a/packages/validation/src/firewalls.schema.ts
+++ b/packages/validation/src/firewalls.schema.ts
@@ -5,8 +5,6 @@ import { array, mixed, number, object, string } from 'yup';
 
 export const IP_ERROR_MESSAGE =
   'Must be a valid IPv4 or IPv6 address or range.';
-// export const CUSTOM_PORTS_ERROR_MESSAGE =
-//   'Ports must be an integer, range of integers, or a comma-separated list of integers.';
 export const CUSTOM_PORTS_VALIDATION_REGEX = /^(?:\d+|\d+-\d+|(?:\d+,\s*)*\d+)$/;
 
 export const validateIP = (ipAddress?: string | null): boolean => {

--- a/packages/validation/src/firewalls.schema.ts
+++ b/packages/validation/src/firewalls.schema.ts
@@ -42,6 +42,11 @@ export const ipAddress = string().test({
 export let CUSTOM_PORTS_ERROR_MESSAGE =
   'Ports must be an integer, range of integers, or a comma-separated list of integers.';
 
+/**
+ * @param port
+ * @returns boolean
+ * @description Validates a single port or port range and sets the error message
+ */
 const validatePort = (port: string): boolean => {
   if (!port) {
     CUSTOM_PORTS_ERROR_MESSAGE = 'Must be 1-65535';
@@ -62,8 +67,13 @@ const validatePort = (port: string): boolean => {
   return true;
 };
 
-export const runCustomPortsValidation = (value: string): boolean => {
-  const portList = value?.split(',') || [];
+/**
+ * @param ports
+ * @returns boolean
+ * @description Validates a comma-separated list of ports and port ranges and sets the error message
+ */
+export const isCustomPortsValid = (ports: string): boolean => {
+  const portList = ports?.split(',') || [];
   let portLimitCount = 0;
 
   for (const port of portList) {
@@ -114,7 +124,7 @@ const validateFirewallPorts = string().test({
     }
 
     try {
-      runCustomPortsValidation(value);
+      isCustomPortsValid(value);
     } catch (err) {
       return false;
     }

--- a/packages/validation/src/firewalls.schema.ts
+++ b/packages/validation/src/firewalls.schema.ts
@@ -39,8 +39,7 @@ export const ipAddress = string().test({
   test: validateIP,
 });
 
-export let CUSTOM_PORTS_ERROR_MESSAGE =
-  'Ports must be an integer, range of integers, or a comma-separated list of integers.';
+export let CUSTOM_PORTS_ERROR_MESSAGE = '';
 
 /**
  * @param port
@@ -48,6 +47,9 @@ export let CUSTOM_PORTS_ERROR_MESSAGE =
  * @description Validates a single port or port range and sets the error message
  */
 const validatePort = (port: string): boolean => {
+  CUSTOM_PORTS_ERROR_MESSAGE =
+    'Ports must be an integer, range of integers, or a comma-separated list of integers.';
+
   if (!port) {
     CUSTOM_PORTS_ERROR_MESSAGE = 'Must be 1-65535';
     return false;
@@ -59,8 +61,12 @@ const validatePort = (port: string): boolean => {
     return false;
   }
 
-  if (String(convertedPort) !== port) {
+  if (port.startsWith('0')) {
     CUSTOM_PORTS_ERROR_MESSAGE = 'Port must not have leading zeroes';
+    return false;
+  }
+
+  if (String(convertedPort) !== port) {
     return false;
   }
 

--- a/packages/validation/src/firewalls.schema.ts
+++ b/packages/validation/src/firewalls.schema.ts
@@ -5,7 +5,6 @@ import { array, mixed, number, object, string } from 'yup';
 
 export const IP_ERROR_MESSAGE =
   'Must be a valid IPv4 or IPv6 address or range.';
-export const CUSTOM_PORTS_VALIDATION_REGEX = /^(?:\d+|\d+-\d+|(?:\d+,\s*)*\d+)$/;
 
 export const validateIP = (ipAddress?: string | null): boolean => {
   if (!ipAddress) {


### PR DESCRIPTION
## Description 📝
The previous validation for firewall custom ports made use of a regex that was not encompassing the same conditions as what the validation was doing sever-side. 

In order to fix this in a more permanent manner, I more closely matched the API validation on the client and returned the same error messages for better feedback for the user. I also added test cases to reflect these new changes. 

![Screenshot 2023-06-28 at 4 23 35 PM](https://github.com/linode/manager/assets/130582365/eea7dfa2-b86a-4676-b92b-96dc813b0183)

## How to test 🧪
1. Navigate to an existing firewall or create a new one
2. Click on the "Add an Outbound Rule" (or "Inbound"), follow a similar config as the screenshot above, and hit the "Custom Port Range" fields with a lot of combinations making sure it passes or fails properly (you can use the examples in the updated test for example
3. Click on Add Rule with a valid port/port range
4. When drawer close, hit save and confirm the value saved properly without an API error (client and API validation should always match!)


