### PR TITLE
fix: Fix miscellaneous Cypress test flake

### DIFF
--- a/packages/manager/cypress/e2e/core/account/default-payment-method.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/default-payment-method.spec.ts
@@ -38,13 +38,10 @@ const gpayLastFourCcDefault = (ccDefault[1].data as CreditCardData).last_four;
 const ccLastFourGpayDefault = (gpayDefault[0].data as CreditCardData).last_four;
 
 describe('Default Payment Method', () => {
-  beforeEach(() => {
-    cy.visitWithLogin('/account/billing');
-  });
-
   it('makes google pay default', () => {
     mockGetPaymentMethods(ccDefault).as('getPaymentMethod');
     mockSetDefaultPaymentMethod(gpayIdCcDefault).as('changeDefault');
+    cy.visitWithLogin('/account/billing');
     cy.wait('@getPaymentMethod');
     cy.get(
       `[aria-label="Action menu for card ending in ${gpayLastFourCcDefault}"]`
@@ -71,7 +68,7 @@ describe('Default Payment Method', () => {
   it('makes cc default', () => {
     mockGetPaymentMethods(gpayDefault).as('getPaymentMethod');
     mockSetDefaultPaymentMethod(ccIdGpayDefault).as('changeDefault');
-
+    cy.visitWithLogin('/account/billing');
     cy.wait('@getPaymentMethod');
     cy.get(
       `[aria-label="Action menu for card ending in ${ccLastFourGpayDefault}"]`

--- a/packages/manager/cypress/e2e/core/account/google-pay.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/google-pay.spec.ts
@@ -54,13 +54,10 @@ const pastDueExpiry = 'Expired 07/20';
 const braintreeURL = 'https://client-analytics.braintreegateway.com/*';
 
 describe('Google Pay', () => {
-  beforeEach(() => {
-    cy.visitWithLogin('/account/billing');
-  });
-
   it('adds google pay method', () => {
     cy.intercept(braintreeURL).as('braintree');
     mockGetPaymentMethods(mockPaymentMethods).as('getPaymentMethods');
+    cy.visitWithLogin('/account/billing');
     cy.wait('@getPaymentMethods');
     cy.findByText('Add Payment Method').should('be.visible').click();
     cy.get('[data-qa-button="gpayChip"]').should('be.visible').click();
@@ -70,6 +67,7 @@ describe('Google Pay', () => {
   it('tests make payment flow - google pay', () => {
     cy.intercept(braintreeURL).as('braintree');
     mockGetPaymentMethods(mockPaymentMethods).as('getPaymentMethods');
+    cy.visitWithLogin('/account/billing');
     cy.wait('@getPaymentMethods');
 
     ui.actionMenu
@@ -103,6 +101,7 @@ describe('Google Pay', () => {
   it('tests payment flow with expired card - google pay', () => {
     cy.intercept(braintreeURL).as('braintree');
     mockGetPaymentMethods(mockPaymentMethodsExpired).as('getPaymentMethods');
+    cy.visitWithLogin('/account/billing');
     cy.wait('@getPaymentMethods');
 
     cy.get('[data-qa-payment-row="google_pay"]').within(() => {

--- a/packages/manager/cypress/e2e/core/images/create-linode-from-image.spec.ts
+++ b/packages/manager/cypress/e2e/core/images/create-linode-from-image.spec.ts
@@ -53,7 +53,9 @@ const createLinodeWithImageMock = (url: string, preselectedImage: boolean) => {
   getClick('[data-qa-enhanced-select="Select a Region"]').within(() => {
     containsClick('Select a Region');
   });
-  containsClick(region.label);
+
+  ui.regionSelect.findItemByRegionId(region.id).should('be.visible').click();
+
   fbtClick('Shared CPU');
   getClick('[id="g6-nanode-1"][type="radio"]');
   cy.get('[id="root-password"]').type(randomString(32));

--- a/packages/manager/cypress/e2e/core/images/create-linode-from-image.spec.ts
+++ b/packages/manager/cypress/e2e/core/images/create-linode-from-image.spec.ts
@@ -4,6 +4,7 @@ import { randomLabel, randomNumber, randomString } from 'support/util/random';
 import { mockGetAllImages } from 'support/intercepts/images';
 import { imageFactory, linodeFactory } from '@src/factories';
 import { chooseRegion } from 'support/util/regions';
+import { ui } from 'support/ui';
 
 const region = chooseRegion();
 
@@ -18,7 +19,7 @@ const mockImage = imageFactory.build({
   id: `private/${randomNumber()}`,
 });
 
-const createLinodeWithImageMock = (preselectedImage: boolean) => {
+const createLinodeWithImageMock = (url: string, preselectedImage: boolean) => {
   mockGetAllImages([mockImage]).as('mockImage');
 
   cy.intercept('POST', apiMatcher('linode/instances'), (req) => {
@@ -35,6 +36,8 @@ const createLinodeWithImageMock = (preselectedImage: boolean) => {
       req.reply(mockLinode);
     }
   ).as('mockLinodeResponse');
+
+  cy.visitWithLogin(url);
 
   cy.wait('@mockImage');
   if (!preselectedImage) {
@@ -85,12 +88,13 @@ describe('create linode from image, mocked data', () => {
   });
 
   it('creates linode from image on images tab', () => {
-    cy.visitWithLogin('/linodes/create?type=Images');
-    createLinodeWithImageMock(false);
+    createLinodeWithImageMock('/linodes/create?type=Images', false);
   });
 
   it('creates linode from preselected image on images tab', () => {
-    cy.visitWithLogin(`/linodes/create/?type=Images&imageID=${mockImage.id}`);
-    createLinodeWithImageMock(true);
+    createLinodeWithImageMock(
+      `/linodes/create/?type=Images&imageID=${mockImage.id}`,
+      true
+    );
   });
 });

--- a/packages/manager/cypress/e2e/core/linodes/backup-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/backup-linode.spec.ts
@@ -48,12 +48,13 @@ describe('linode backups', () => {
 
   it('create linode from snapshot', () => {
     createLinode({ backups_enabled: true }).then((linode) => {
-      cy.visitWithLogin(`/linodes/${linode.id}/backup`);
-      // intercept request
       cy.intercept(
         'POST',
         apiMatcher(`linode/instances/${linode.id}/backups`)
       ).as('enableBackups');
+      cy.visitWithLogin(`/linodes/${linode.id}/backup`);
+      // intercept request
+
       fbtVisible(`${linode.label}`);
       if (
         // TODO Resolve potential flake.

--- a/packages/manager/cypress/e2e/core/linodes/backup-linode.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/backup-linode.spec.ts
@@ -13,7 +13,6 @@ import { apiMatcher } from 'support/util/intercepts';
 describe('linode backups', () => {
   it('enable backups', () => {
     createLinode().then((linode) => {
-      cy.visitWithLogin(`/dashboard`);
       // intercept request
       cy.intercept(
         'POST',
@@ -21,7 +20,7 @@ describe('linode backups', () => {
       ).as('enableBackups');
       // intercept response
       cy.intercept(apiMatcher('account/settings')).as('getSettings');
-      cy.visit(`/linodes/${linode.id}/backup`);
+      cy.visitWithLogin(`/linodes/${linode.id}/backup`);
       // if account is managed, test will pass but skip enabling backups
       containsVisible(`${linode.label}`);
       cy.wait('@getSettings').then((xhr) => {
@@ -48,9 +47,8 @@ describe('linode backups', () => {
   });
 
   it('create linode from snapshot', () => {
-    cy.visitWithLogin('/dashboard');
     createLinode({ backups_enabled: true }).then((linode) => {
-      cy.visit(`/linodes/${linode.id}/backup`);
+      cy.visitWithLogin(`/linodes/${linode.id}/backup`);
       // intercept request
       cy.intercept(
         'POST',
@@ -77,7 +75,6 @@ describe('linode backups', () => {
 
   // this test has become irrelevant for now
   it.skip('cant snapshot while booting linode', () => {
-    cy.visitWithLogin('/dashboard');
     createLinode({ backups_enabled: true }).then((linode) => {
       cy.visit(`/linodes/${linode.id}/backup`);
       fbtClick('Take Snapshot');


### PR DESCRIPTION
## Description 📝
A couple small changes to slightly improve the resiliency of our tests.

- Most changes involve positioning intercepts and mocks before calls to `cy.visitWithLogin()`. Sometimes the desired API request is triggered before `cy.visitWithLogin()` has finished (since it waits for the page to finish loading before allowing the next command to execute, and some API requests are made in the meantime), so the desired API request is never intercepted and the test fails. This seems to happen more often on local runs than in CI.
- Fixes another potential cause of flake when interacting with a region select drop-down. I made the assertion more specific because the existing selector occasionally finds multiple matching elements which causes the test to fail.

## How to test 🧪
1. Wait for the automated run to finish
2. Confirm that there are no failures or flake caused by either of the two issues described above