### PR TITLE
fix: Fix Linode landing page delete smoke test flake

### DIFF
--- a/packages/manager/cypress/e2e/core/linodes/smoke-linode-landing-table.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/smoke-linode-landing-table.spec.ts
@@ -295,7 +295,7 @@ describe('linode landing checks', () => {
 });
 
 describe('linode landing actions', () => {
-  it.only('deleting multiple linodes with action menu', () => {
+  it('deleting multiple linodes with action menu', () => {
     const mockAccountSettings = accountSettingsFactory.build({
       managed: false,
     });

--- a/packages/manager/cypress/e2e/core/linodes/smoke-linode-landing-table.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/smoke-linode-landing-table.spec.ts
@@ -56,7 +56,9 @@ const deleteLinodeFromActionMenu = (linodeLabel) => {
         .should('be.enabled')
         .click();
     });
+
   cy.wait('@deleteLinode').its('response.statusCode').should('eq', 200);
+  cy.findByText(linodeLabel).should('not.exist');
 };
 
 const preferenceOverrides = {

--- a/packages/manager/cypress/e2e/core/linodes/smoke-linode-landing-table.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/smoke-linode-landing-table.spec.ts
@@ -1,19 +1,24 @@
 /* eslint-disable sonarjs/no-duplicate-string */
+import { createLinode } from '@linode/api-v4';
 import { Linode } from '@linode/api-v4/types';
-import { createLinode } from 'support/api/linodes';
+import { accountSettingsFactory } from '@src/factories/accountSettings';
+import {
+  createLinodeRequestFactory,
+  linodeFactory,
+} from '@src/factories/linodes';
+import { makeResourcePage } from '@src/mocks/serverHandlers';
 import {
   containsVisible,
   fbtVisible,
   getClick,
   getVisible,
 } from 'support/helpers';
-import { linodeFactory } from '@src/factories/linodes';
-import { makeResourcePage } from '@src/mocks/serverHandlers';
-import { accountSettingsFactory } from '@src/factories/accountSettings';
-import { routes } from 'support/ui/constants';
 import { ui } from 'support/ui';
+import { routes } from 'support/ui/constants';
 import { apiMatcher } from 'support/util/intercepts';
+import { randomLabel } from 'support/util/random';
 import { chooseRegion, getRegionById } from 'support/util/regions';
+import { authenticate } from 'support/api/authentication';
 
 const mockLinodes = new Array(5).fill(null).map(
   (_item: null, index: number): Linode => {
@@ -72,6 +77,7 @@ const preferenceOverrides = {
   },
 };
 
+authenticate();
 describe('linode landing checks', () => {
   beforeEach(() => {
     const mockAccountSettings = accountSettingsFactory.build({
@@ -289,28 +295,37 @@ describe('linode landing checks', () => {
 });
 
 describe('linode landing actions', () => {
-  it('deleting multiple linodes with action menu', () => {
+  it.only('deleting multiple linodes with action menu', () => {
     const mockAccountSettings = accountSettingsFactory.build({
       managed: false,
     });
+
+    const createTwoLinodes = async (): Promise<[Linode, Linode]> => {
+      return Promise.all([
+        createLinode(
+          createLinodeRequestFactory.build({ label: randomLabel() })
+        ),
+        createLinode(
+          createLinodeRequestFactory.build({ label: randomLabel() })
+        ),
+      ]);
+    };
 
     cy.intercept('GET', apiMatcher('account/settings'), (req) => {
       req.reply(mockAccountSettings);
     }).as('getAccountSettings');
 
     cy.intercept('DELETE', apiMatcher('linode/instances/*')).as('deleteLinode');
-    createLinode().then((linodeA) => {
-      createLinode().then((linodeB) => {
-        cy.visitWithLogin('/linodes', { preferenceOverrides });
-        cy.wait('@getAccountSettings');
-        getVisible('[data-qa-header="Linodes"]');
-        if (!cy.get('[data-qa-sort-label="asc"]')) {
-          getClick('[aria-label="Sort by label"]');
-        }
-        deleteLinodeFromActionMenu(linodeA.label);
-        deleteLinodeFromActionMenu(linodeB.label);
-        cy.findByText('Oh Snap!', { timeout: 1000 }).should('not.exist');
-      });
+    cy.defer(createTwoLinodes()).then(([linodeA, linodeB]) => {
+      cy.visitWithLogin('/linodes', { preferenceOverrides });
+      cy.wait('@getAccountSettings');
+      getVisible('[data-qa-header="Linodes"]');
+      if (!cy.get('[data-qa-sort-label="asc"]')) {
+        getClick('[aria-label="Sort by label"]');
+      }
+      deleteLinodeFromActionMenu(linodeA.label);
+      deleteLinodeFromActionMenu(linodeB.label);
+      cy.findByText('Oh Snap!', { timeout: 1000 }).should('not.exist');
     });
   });
 });


### PR DESCRIPTION
## Description 📝
This fixes some flake in the Linode landing page test which deletes multiple Linodes in sequence. This test is flaky because it does not wait for the UI to update before proceeding with the next deletion, but when the UI does update it causes any action menus which are open to close. When this happens after Cypress has already clicked on the action menu, the test fails. 

## How to test 🧪
We can rely on the automated tests to confirm that this test passes without flake, but to test this locally you can run:

```bash
yarn cy:run -s "cypress/e2e/core/linodes/smoke-linode-landing-table.spec.ts"
```
