### PR TITLE
Fix: [M3-6786] ActionMenu tooltip icon color

### DIFF
--- a/packages/manager/.changeset/pr-9352-fixed-1688140397688.md
+++ b/packages/manager/.changeset/pr-9352-fixed-1688140397688.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+ActionMenu tooltip icon color deprecation ([#9352](https://github.com/linode/manager/pull/9352))

--- a/packages/manager/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/manager/src/components/ActionMenu/ActionMenu.tsx
@@ -134,7 +134,8 @@ const ActionMenu = (props: Props) => {
       color: '#4d99f1',
     },
     padding: '0 0 0 8px',
-    '& svg': {
+    '& .MuiSvgIcon-root': {
+      fill: '#fff',
       height: '20px',
       width: '20px',
     },


### PR DESCRIPTION
## Description 📝
Small fix to address a deprecation of the color of the tooltip help icon in the action menu. This PR targets that particular tooltip icon and should not introduce any deprecation to other tooltip icons.

## Preview 📷

| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-06-30 at 11 50 51 AM](https://github.com/linode/manager/assets/130582365/3a6c26e6-df46-4bd1-a98f-8a6a54dac92a) | ![Screenshot 2023-06-30 at 11 50 28 AM](https://github.com/linode/manager/assets/130582365/160cb297-f7fd-479c-8925-d7c5d47fd948) |

## How to test 🧪
1. Linode Details > Storage tab > Disk action menu > Try to Delete a disk with a _powered on_ linode
