### PR TITLE
M3-6782: Fix Third-Party Access Tokens Flaky Tests

### DIFF
--- a/packages/manager/cypress/e2e/core/account/third-party-access-tokens.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/third-party-access-tokens.spec.ts
@@ -7,8 +7,12 @@ import {
 } from 'support/intercepts/profile';
 import { ui } from 'support/ui';
 import { randomLabel, randomString } from 'support/util/random';
-import { Token } from '@linode/api-v4/types';
+import { Token, Profile } from '@linode/api-v4/types';
+import { getProfile } from '@linode/api-v4/lib/profile';
+import { formatDate } from 'src/utilities/formatDate';
+import { authenticate } from 'support/api/authentication';
 
+authenticate();
 describe('Third party access tokens', () => {
   let tokenLabel: string;
   let tokenSecret: string;
@@ -38,7 +42,12 @@ describe('Third party access tokens', () => {
       .closest('tr')
       .within(() => {
         cy.findByText(tokenLabel).should('be.visible');
-        cy.findByText('2020-01-01 12:00').should('be.visible');
+        cy.defer(getProfile()).then((profile: Profile) => {
+          const dateFormatOptions = { timezone: profile.timezone };
+          cy.findByText(formatDate(token.created, dateFormatOptions)).should(
+            'be.visible'
+          );
+        });
         cy.findByText('never').should('be.visible');
       });
   });


### PR DESCRIPTION
## Description 📝
Fix the third-party access tokens flaky tests.

## Major Changes 🔄
- Fix third-party access tokens tests, checking time with user's timezone.

## How to test 🧪
`yarn cy:run -s "cypress/e2e/core/account/third-party-access-tokens.spec.ts"`
