### PR TITLE
fix: [M3-6177] - Only request logo once for invoice pdf

### DIFF
--- a/packages/manager/.changeset/pr-9355-fixed-1688147944694.md
+++ b/packages/manager/.changeset/pr-9355-fixed-1688147944694.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Only request logo once for invoice pdf ([#9355](https://github.com/linode/manager/pull/9355))

--- a/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/BillingActivityPanel/BillingActivityPanel.tsx
@@ -239,10 +239,15 @@ export const BillingActivityPanel = (props: Props) => {
       pdfLoading.add(id);
 
       getAllInvoiceItems(invoiceId)
-        .then((invoiceItems) => {
+        .then(async (invoiceItems) => {
           pdfLoading.delete(id);
 
-          const result = printInvoice(account!, invoice, invoiceItems, taxes);
+          const result = await printInvoice(
+            account!,
+            invoice,
+            invoiceItems,
+            taxes
+          );
 
           if (result.status === 'error') {
             pdfErrors.add(id);

--- a/packages/manager/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
+++ b/packages/manager/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
@@ -76,14 +76,14 @@ export const InvoiceDetail = () => {
     requestData();
   }, []);
 
-  const printInvoicePDF = (
+  const printInvoicePDF = async (
     account: Account,
     invoice: Invoice,
     items: InvoiceItem[]
   ) => {
     const taxes =
       flags[getShouldUseAkamaiBilling(invoice.date) ? 'taxes' : 'taxBanner'];
-    const result = printInvoice(account, invoice, items, taxes);
+    const result = await printInvoice(account, invoice, items, taxes);
 
     setPDFGenerationError(result.status === 'error' ? result.error : undefined);
   };


### PR DESCRIPTION
## Description 📝
Previously, when downloading an invoice, we would make a request for the logo image for every page of the invoice potentially causing delays for large accounts. This PR fixes that by fetching the image only once and passing that to jsPDF's addImage function

## Preview 📷
![image](https://github.com/linode/manager/assets/115299789/30574b87-2b3b-4247-b0c7-75bc532080b5)

## How to test 🧪
- Go to /account/billing
- In the browser dev tools, go to the network tab and filter by .png
- Download an invoice PDF and observe only 1 request made for the akamai logo
- Open the PDF and ensure that the logo is still on every page
