### PR TITLE
fix: wording in "My Profile" -> "Login and Authentication"

### DIFF
--- a/packages/manager/.changeset/pr-9358-fixed-1688405470106.md
+++ b/packages/manager/.changeset/pr-9358-fixed-1688405470106.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Fixed wording in Profile ([#9358](https://github.com/linode/manager/pull/9358))

--- a/packages/manager/src/features/Profile/AuthenticationSettings/TPAProviders.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/TPAProviders.tsx
@@ -147,9 +147,9 @@ export const TPAProviders = (props: Props) => {
             </StyledCopy>
             <StyledCopy variant="body1" style={{ marginBottom: 8 }}>
               To disable {currentProvider.displayName} authentication and log in
-              using your Linode credentials, click the Linode button above.
-              We&rsquo;ll send you an e-mail with instructions on how to reset
-              your password.
+              using your Cloud Manager credentials, click the Cloud Manager
+              button above. We&rsquo;ll send you an e-mail with instructions on
+              how to reset your password.
             </StyledCopy>
           </div>
         ) : null}

--- a/packages/manager/src/features/Profile/AuthenticationSettings/TwoFactor/QRCodeForm.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/TwoFactor/QRCodeForm.tsx
@@ -14,7 +14,7 @@ export const QRCodeForm = (props: Props) => {
   return (
     <React.Fragment>
       <StyledInstructions variant="h3" data-qa-copy>
-        Scan this QR code to add your Linode account to your 2FA app:
+        Scan this QR code to add your Cloud Manager account to your 2FA app:
       </StyledInstructions>
       <StyledQRCodeContainer>
         <QRCode

--- a/packages/manager/src/features/Profile/DisplaySettings/DisplaySettings.tsx
+++ b/packages/manager/src/features/Profile/DisplaySettings/DisplaySettings.tsx
@@ -56,8 +56,8 @@ export const DisplaySettings = () => {
   const tooltipIconText = (
     <>
       Go to <Link to="https://en.gravatar.com/">gravatar.com</Link> and register
-      an account using the same email address as your Linode account. Upload
-      your desired profile image to your Gravatar account and it will be
+      an account using the same email address as your Cloud Manager account.
+      Upload your desired profile image to your Gravatar account and it will be
       automatically linked.
     </>
   );


### PR DESCRIPTION
## Description 📝
**Old:** 
```
To disable Google authentication and log in using your Linode credentials, click the Linode button above. 
```

**New:**
```
To disable Google authentication and log in using your Cloud Manager credentials, click the Cloud Manager button above.
```

## Preview 📷
![Screenshot 2023-07-03 at 11 13 07 AM](https://github.com/linode/manager/assets/114753608/4ab704a2-d99c-44e2-a748-65c92639914f)

## How to test 🧪
- Run the app and check the copy at http://localhost:3000/profile/auth.


