### PR TITLE
fix: [M3-6834]: Misleading MNTP percentage for accounts with no active services

### DIFF
--- a/packages/manager/.changeset/pr-9362-fixed-1688576649790.md
+++ b/packages/manager/.changeset/pr-9362-fixed-1688576649790.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Misleading MNTP percentage for accounts with no active services ([#9362](https://github.com/linode/manager/pull/9362))

--- a/packages/manager/src/components/BarPercent/BarPercent.tsx
+++ b/packages/manager/src/components/BarPercent/BarPercent.tsx
@@ -2,6 +2,7 @@ import { styled } from '@mui/material/styles';
 import { SxProps } from '@mui/system';
 import * as React from 'react';
 import { LinearProgress } from 'src/components/LinearProgress';
+import { isPropValid } from 'src/utilities/isPropValid';
 
 export interface BarPercentProps {
   /** Additional css class to pass to the component */
@@ -69,6 +70,7 @@ const StyledDiv = styled('div')({
 
 const StyledLinearProgress = styled(LinearProgress, {
   label: 'StyledLinearProgress',
+  shouldForwardProp: (prop) => isPropValid(['rounded'], prop),
 })<Partial<BarPercentProps>>(({ theme, ...props }) => ({
   backgroundColor: theme.color.grey2,
   padding: props.narrow ? 8 : 12,

--- a/packages/manager/src/components/TransferDisplay/TransferDisplay.test.tsx
+++ b/packages/manager/src/components/TransferDisplay/TransferDisplay.test.tsx
@@ -1,8 +1,7 @@
+import { fireEvent } from '@testing-library/react';
 import React from 'react';
 import { renderWithTheme } from 'src/utilities/testHelpers';
-import { fireEvent } from '@testing-library/react';
 import { TransferDisplay } from './TransferDisplay';
-import { QueryClient } from 'react-query';
 
 const MockData = {
   used: 0,
@@ -23,9 +22,7 @@ jest.mock('../../queries/accountTransfer', () => {
 
 describe('TransferDisplay', () => {
   it('renders the MNTP button display text and opens the TransferDialog on click', async () => {
-    const { getByText, getByTestId } = renderWithTheme(<TransferDisplay />, {
-      queryClient: new QueryClient(),
-    });
+    const { getByText, getByTestId } = renderWithTheme(<TransferDisplay />);
 
     expect(
       getByText(transferDisplayButtonSubstring, { exact: false })
@@ -41,9 +38,7 @@ describe('TransferDisplay', () => {
   });
 
   it('displays a percentage of 0.00% for no usage', async () => {
-    const { getByText } = renderWithTheme(<TransferDisplay />, {
-      queryClient: new QueryClient(),
-    });
+    const { getByText } = renderWithTheme(<TransferDisplay />);
 
     const usage = getByText(transferDisplayPercentageSubstring, {
       exact: false,

--- a/packages/manager/src/components/TransferDisplay/TransferDisplay.test.tsx
+++ b/packages/manager/src/components/TransferDisplay/TransferDisplay.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+import { fireEvent } from '@testing-library/react';
+import { TransferDisplay } from './TransferDisplay';
+import { QueryClient } from 'react-query';
+
+const MockData = {
+  used: 0,
+  quota: 0,
+  billable: 0,
+};
+
+const transferDisplayPercentageSubstring = /You have used \d+\.\d\d%/;
+const transferDisplayButtonSubstring = /Monthly Network Transfer Pool/;
+
+jest.mock('../../queries/accountTransfer', () => {
+  return {
+    useAccountTransfer: jest.fn(() => {
+      return { data: MockData };
+    }),
+  };
+});
+
+describe('TransferDisplay', () => {
+  it('renders the MNTP button display text and opens the TransferDialog on click', async () => {
+    const { getByText, getByTestId } = renderWithTheme(<TransferDisplay />, {
+      queryClient: new QueryClient(),
+    });
+
+    expect(
+      getByText(transferDisplayButtonSubstring, { exact: false })
+    ).toBeInTheDocument();
+    expect(
+      getByText(transferDisplayPercentageSubstring, { exact: false })
+    ).toBeInTheDocument();
+
+    fireEvent.click(getByText(transferDisplayButtonSubstring));
+
+    const transferDialog = getByTestId('drawer');
+    expect(transferDialog).toBeInTheDocument();
+  });
+
+  it('displays a percentage of 0.00% for no usage', async () => {
+    const { getByText } = renderWithTheme(<TransferDisplay />, {
+      queryClient: new QueryClient(),
+    });
+
+    const usage = getByText(transferDisplayPercentageSubstring, {
+      exact: false,
+    }).innerHTML;
+    expect(usage).toMatch(/0.00%/);
+  });
+});

--- a/packages/manager/src/components/TransferDisplay/TransferDisplay.test.tsx
+++ b/packages/manager/src/components/TransferDisplay/TransferDisplay.test.tsx
@@ -12,6 +12,7 @@ const MockData = {
 
 const transferDisplayPercentageSubstring = /You have used \d+\.\d\d%/;
 const transferDisplayButtonSubstring = /Monthly Network Transfer Pool/;
+const docsLink = 'https://www.linode.com/docs/guides/network-transfer-quota/';
 
 describe('TransferDisplay', () => {
   it('renders transfer display text and opens the transfer dialog, with GB data stats, on click', async () => {
@@ -70,8 +71,23 @@ describe('TransferDisplay', () => {
 
     const transferDialog = getByTestId('drawer');
     expect(transferDialog.innerHTML).toMatch(
-      /Create a resource to start using Monthly Network Transfer./
+      /Your monthly network transfer will be shown when you create a resource./
     );
     expect(transferDialog.innerHTML).not.toMatch(/GB/);
+  });
+
+  it('renders the transfer display dialog with an accessible docs link', async () => {
+    server.use(
+      rest.get('*/account/transfer', (req, res, ctx) => {
+        return res(ctx.json(MockData));
+      })
+    );
+
+    const { findByText, getByRole } = renderWithTheme(<TransferDisplay />);
+    const transferButton = await findByText(transferDisplayButtonSubstring);
+    fireEvent.click(transferButton);
+
+    expect(getByRole('link')).toHaveAttribute('href', docsLink);
+    expect(getByRole('link').getAttribute('aria-label'));
   });
 });

--- a/packages/manager/src/components/TransferDisplay/TransferDisplay.tsx
+++ b/packages/manager/src/components/TransferDisplay/TransferDisplay.tsx
@@ -1,4 +1,3 @@
-import OpenInNew from '@mui/icons-material/OpenInNew';
 import Grid from '@mui/material/Unstable_Grid2';
 import { Theme } from '@mui/material/styles';
 import { DateTime } from 'luxon';
@@ -26,20 +25,11 @@ const useStyles = makeStyles()((theme: Theme) => ({
     },
   },
   link: {
-    display: 'flex',
-    alignItems: 'center',
-    flexFlow: 'row nowrap',
     marginTop: theme.spacing(1),
-    '& p': {
-      marginRight: 4,
-    },
-    '& svg': {
-      width: 15,
-      height: 15,
-      color: theme.palette.text.primary,
-      '&:hover': {
-        color: 'inherit',
-      },
+  },
+  paddedDocsText: {
+    [theme.breakpoints.up('md')]: {
+      paddingRight: theme.spacing(3), // Prevents link text from being split onto two lines.
     },
   },
   paper: {
@@ -136,6 +126,15 @@ export const TransferDialog = React.memo((props: DialogProps) => {
   const daysRemainingInMonth = getDaysRemaining();
   // Don't display usage, quota, or bar percent if the network transfer pool is empty (e.g. account has no resources).
   const isEmptyPool = quota === 0;
+  const transferQuotaDocsText =
+    used === 0 ? (
+      <span className={classes.paddedDocsText}>
+        Compute instances, NodeBalancers, and Object Storage include network
+        transfer.
+      </span>
+    ) : (
+      'View products and services that include network transfer, and learn how to optimize network usage to avoid billing surprises.'
+    );
 
   return (
     <Dialog
@@ -193,17 +192,19 @@ export const TransferDialog = React.memo((props: DialogProps) => {
       </Typography>
       <Typography className={classes.proratedNotice}>
         Your account&rsquo;s network transfer pool adds up all the included
-        transfer associated with the active Linode services on your account, and
-        is prorated based on service creation and deletion dates.
+        transfer associated with active Linode services on your account and is
+        prorated based on service creation.
       </Typography>
       <div className={classes.link}>
         <Typography>
-          Optimize your network usage and avoid billing surprises related to
-          network transfer.
+          {transferQuotaDocsText}{' '}
+          <Link
+            to="https://www.linode.com/docs/guides/network-transfer-quota/"
+            aria-label="Learn more – link opens in a new tab"
+          >
+            Learn more.
+          </Link>
         </Typography>
-        <Link to="https://www.linode.com/docs/guides/network-transfer-quota/">
-          <OpenInNew />
-        </Link>
       </div>
     </Dialog>
   );

--- a/packages/manager/src/components/TransferDisplay/TransferDisplay.tsx
+++ b/packages/manager/src/components/TransferDisplay/TransferDisplay.tsx
@@ -66,7 +66,9 @@ export const TransferDisplay = React.memo(({ spacingTop }: Props) => {
   const quota = data?.quota ?? 0;
   const used = data?.used ?? 0;
 
-  const poolUsagePct = used < quota ? (used / quota) * 100 : 100;
+  // Usage percentage should not be 100% if there has been no usage or usage has not exceeded quota.
+  const poolUsagePct =
+    used < quota ? (used / quota) * 100 : used === 0 ? 0 : 100;
 
   if (isError) {
     // We may want to add an error state for this but I think that would clutter

--- a/packages/manager/src/components/TransferDisplay/TransferDisplay.tsx
+++ b/packages/manager/src/components/TransferDisplay/TransferDisplay.tsx
@@ -134,6 +134,8 @@ export const TransferDialog = React.memo((props: DialogProps) => {
   const { isOpen, onClose, poolUsagePct, quota, used } = props;
   const { classes } = useStyles();
   const daysRemainingInMonth = getDaysRemaining();
+  // Don't display usage, quota, or bar percent if the network transfer pool is empty (e.g. account has no resources).
+  const isEmptyPool = quota === 0;
 
   return (
     <Dialog
@@ -151,26 +153,36 @@ export const TransferDialog = React.memo((props: DialogProps) => {
         spacing={2}
       >
         <Grid style={{ marginRight: 10 }}>
-          <Typography>{used} GB Used</Typography>
+          {!isEmptyPool ? (
+            <Typography>{used} GB Used</Typography>
+          ) : (
+            <Typography>
+              Create a resource to start using Monthly Network Transfer.
+            </Typography>
+          )}
         </Grid>
         <Grid>
-          <Typography>
-            {quota >= used ? (
-              <span>{quota - used} GB Available</span>
-            ) : (
-              <span>
-                {(quota - used).toString().replace(/\-/, '')} GB Over Quota
-              </span>
-            )}
-          </Typography>
+          {!isEmptyPool ? (
+            <Typography>
+              {quota >= used ? (
+                <span>{quota - used} GB Available</span>
+              ) : (
+                <span>
+                  {(quota - used).toString().replace(/\-/, '')} GB Over Quota
+                </span>
+              )}
+            </Typography>
+          ) : null}
         </Grid>
       </Grid>
-      <BarPercent
-        max={100}
-        value={Math.ceil(poolUsagePct)}
-        className={classes.poolUsageProgress}
-        rounded
-      />
+      {!isEmptyPool ? (
+        <BarPercent
+          max={100}
+          value={Math.ceil(poolUsagePct)}
+          className={classes.poolUsageProgress}
+          rounded
+        />
+      ) : null}
 
       <Typography className={classes.proratedNotice}>
         <strong>

--- a/packages/manager/src/components/TransferDisplay/TransferDisplay.tsx
+++ b/packages/manager/src/components/TransferDisplay/TransferDisplay.tsx
@@ -157,7 +157,8 @@ export const TransferDialog = React.memo((props: DialogProps) => {
             <Typography>{used} GB Used</Typography>
           ) : (
             <Typography>
-              Create a resource to start using Monthly Network Transfer.
+              Your monthly network transfer will be shown when you create a
+              resource.
             </Typography>
           )}
         </Grid>


### PR DESCRIPTION
## Description 📝
For accounts without any active Linode services, the MNTP percentage was displaying a misleading "You have used 100% of your Monthly Network Transfer Pool". This was due to `poolUsagePct` calculation: if `used` < `quota`, calculate the percentage; else, set the percentage to 100% because the `quota` must have been reached. 

In the case where usage was `0` and quota was `0`, this calculation resulted in 100%. Although technically a correct calculation, I think this seems misleading because it could cause customers to think they have reached a limit or are being billed for something they are not.

TODO:
- [x] Confirm UX copy with Product Marketing
- [x] Fix the link
- [x] Fix failing unit test

## Major Changes 🔄
- `poolUsagePct` evaluates to `0` if the data `used` is `0`
- When an account's usage is 0%, such as when there are no active services on the account, the MNTP text reads "You have used 0.00% of your Monthly Network Transfer Pool." and dialog shows a BarPercent at 0%.
- Fixes a console error for styled `BarPercent` whose DOM element was being passed the invalid prop `rounded` after the styled migration.
- Adds unit test file for `TransferDisplay`.

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![Screenshot 2023-07-03 at 10 14 50 AM](https://github.com/linode/manager/assets/114685994/5773f007-4039-4797-9f28-71f1aec43de0) |![image](https://github.com/linode/manager/assets/114685994/7ffbbf4e-c4b3-4ef3-a19c-eda9aabd7b65) |


## How to test 🧪
1. **How to setup test environment?**

   - Use an account with no active services. This can also be mocked by updating the `accountTransferFactory` to 
   ``` 
    used: 0,
    quota: 0,
    billable: 0,
   ``` 
and turning on the MSW.

2. **How to reproduce the issue (if applicable)?**
   - Go to the landing page and observe the MNTP is 100%, as in the Before screenshot above.
   - Check the browser console and note the console error when the MNTP dialog is opened. 
3. **How to verify changes?**
   - Go to the landing page and observe the MNTP is 0%, as in the After screenshot above.
   - Check the browser console and note there is no more console error when the MNTP dialog is opened. 
4. **How to run Unit or E2E tests?**
```
yarn test TransferDisplay
```