### PR TITLE
feat: [M3-6789] - Improve failed backup error messaging

### DIFF
--- a/packages/manager/.changeset/pr-9364-added-1688576551150.md
+++ b/packages/manager/.changeset/pr-9364-added-1688576551150.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Added
+---
+
+Improved warning and error messaging for failed backup events ([#9364](https://github.com/linode/manager/pull/9364))

--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -52,7 +52,7 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
       `${formatEventWithAppendedText(
         e,
         `Backup restoration failed for ${e.entity!.label}.`,
-        'Learn more about limits and considerations.',
+        'Learn more about limits and considerations',
         'https://www.linode.com/docs/products/storage/backups/#limits-and-considerations'
       )}`,
     finished: (e) => `Backup restoration completed for ${e.entity!.label}.`,
@@ -518,7 +518,7 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
       `${formatEventWithAppendedText(
         e,
         `Snapshot backup failed on Linode ${e.entity!.label}.`,
-        'Learn more about limits and considerations.',
+        'Learn more about limits and considerations',
         'https://www.linode.com/docs/products/storage/backups/#limits-and-considerations'
       )}`,
     finished: (e) =>

--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -48,7 +48,13 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
   backups_restore: {
     scheduled: (e) => `Backup restoration scheduled for ${e.entity!.label}`,
     started: (e) => `Backup restoration started for ${e.entity!.label}`,
-    failed: (e) => `Backup restoration failed for ${e.entity!.label}.`,
+    failed: (e) =>
+      `${formatEventWithAppendedText(
+        e,
+        `Backup restoration failed for ${e.entity!.label}.`,
+        'Learn more about limits and considerations.',
+        'https://www.linode.com/docs/products/storage/backups/#limits-and-considerations'
+      )}`,
     finished: (e) => `Backup restoration completed for ${e.entity!.label}.`,
     notification: (e) => `Backup restoration completed for ${e.entity!.label}.`,
   },
@@ -508,7 +514,13 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
       `Linode ${e.entity!.label} is scheduled for a snapshot backup.`,
     started: (e) =>
       `A snapshot backup is being created for Linode ${e.entity!.label}.`,
-    failed: (e) => `Snapshot backup failed on Linode ${e.entity!.label}.`,
+    failed: (e) =>
+      `${formatEventWithAppendedText(
+        e,
+        `Snapshot backup failed on Linode ${e.entity!.label}.`,
+        'Learn more about limits and considerations.',
+        'https://www.linode.com/docs/products/storage/backups/#limits-and-considerations'
+      )}`,
     finished: (e) =>
       `A snapshot backup has been created for ${e.entity!.label}.`,
   },

--- a/packages/manager/src/features/Linodes/LinodesCreate/AddonsPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/AddonsPanel.tsx
@@ -95,9 +95,6 @@ export const AddonsPanel = React.memo((props: AddonsPanelProps) => {
     Boolean(selectedImageID)
   );
 
-  // The backups warning is shown when the user checks to enable backups, but they are using a custom image that may not be compatible.
-  const [showBackupsWarning, setShowBackupsWarning] = React.useState(false);
-
   // The VLAN section is shown when the user is not creating by cloning (cloning copies the network interfaces)
   const showVlans = createType !== 'fromLinode';
 
@@ -126,6 +123,29 @@ export const AddonsPanel = React.memo((props: AddonsPanelProps) => {
     );
   };
 
+  const getShouldShowBackupsWarning = () => {
+    if (accountBackups || props.backups) {
+      if (selectedLinodeID) {
+        const selectedLinode = linodesData?.find(
+          (linode) => linode.id === selectedLinodeID
+        );
+        if (
+          selectedLinode?.image?.includes('private/') ||
+          !selectedLinode?.image
+        ) {
+          return true;
+        }
+      } else if (selectedImageID && !image?.is_public) {
+        return true;
+      }
+    }
+
+    return false;
+  };
+
+  // The backups warning is shown when the user checks to enable backups, but they are using a custom image that may not be compatible.
+  const showBackupsWarning = getShouldShowBackupsWarning();
+
   // Check whether the source Linode has been allocated a private IP to select/unselect the 'Private IP' checkbox.
   React.useEffect(() => {
     if (selectedLinodeID) {
@@ -143,34 +163,6 @@ export const AddonsPanel = React.memo((props: AddonsPanelProps) => {
       }
     }
   }, [selectedLinodeID]);
-
-  // Check whether the source Linode has a private image to display the backups warning message.
-  React.useEffect(() => {
-    if (accountBackups || props.backups) {
-      if (selectedLinodeID) {
-        const selectedLinode = linodesData?.find(
-          (image) => image.id === selectedLinodeID
-        );
-        if (
-          selectedLinode?.image?.includes('private/') ||
-          !selectedLinode?.image
-        ) {
-          setShowBackupsWarning(true);
-        }
-      } else if (selectedImageID && !image?.is_public) {
-        setShowBackupsWarning(true);
-      }
-    } else {
-      setShowBackupsWarning(false);
-    }
-  }, [
-    accountBackups,
-    props.backups,
-    image,
-    linodesData,
-    selectedLinodeID,
-    selectedImageID,
-  ]);
 
   return (
     <>

--- a/packages/manager/src/features/Linodes/LinodesCreate/AddonsPanel.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/AddonsPanel.tsx
@@ -123,7 +123,7 @@ export const AddonsPanel = React.memo((props: AddonsPanelProps) => {
     );
   };
 
-  const getShouldShowBackupsWarning = () => {
+  const checkBackupsWarning = () => {
     if (accountBackups || props.backups) {
       if (selectedLinodeID) {
         const selectedLinode = linodesData?.find(
@@ -144,7 +144,7 @@ export const AddonsPanel = React.memo((props: AddonsPanelProps) => {
   };
 
   // The backups warning is shown when the user checks to enable backups, but they are using a custom image that may not be compatible.
-  const showBackupsWarning = getShouldShowBackupsWarning();
+  const showBackupsWarning = checkBackupsWarning();
 
   // Check whether the source Linode has been allocated a private IP to select/unselect the 'Private IP' checkbox.
   React.useEffect(() => {
@@ -190,7 +190,7 @@ export const AddonsPanel = React.memo((props: AddonsPanelProps) => {
         <Grid container>
           {showBackupsWarning && (
             <Notice warning>
-              Linodes must have a disk formatted with an EXT3 or EXT4 file
+              Linodes must have a disk formatted with an ext3 or ext4 file
               system to use the backup service.
             </Notice>
           )}

--- a/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/CaptureSnapshot.tsx
+++ b/packages/manager/src/features/Linodes/LinodesDetail/LinodeBackup/CaptureSnapshot.tsx
@@ -13,6 +13,7 @@ import { CaptureSnapshotConfirmationDialog } from './CaptureSnapshotConfirmation
 import { Button } from 'src/components/Button/Button';
 import { resetEventsPolling } from 'src/eventsPolling';
 import { getErrorMap } from 'src/utilities/errorUtils';
+import { Box } from 'src/components/Box';
 
 interface Props {
   linodeId: number;
@@ -79,29 +80,31 @@ export const CaptureSnapshot = ({ linodeId, isReadOnly }: Props) => {
         size of your Linode and the amount of data you have stored on it. The
         manual snapshot will not be overwritten by automatic backups.
       </Typography>
-      <FormControl className={classes.snapshotFormControl}>
+      <FormControl>
         {hasErrorFor.none && (
           <Notice spacingBottom={8} error>
             {hasErrorFor.none}
           </Notice>
         )}
-        <TextField
-          errorText={hasErrorFor.label}
-          label="Name Snapshot"
-          name="label"
-          value={snapshotForm.values.label}
-          onChange={snapshotForm.handleChange}
-          data-qa-manual-name
-          className={classes.snapshotNameField}
-        />
-        <Button
-          buttonType="primary"
-          onClick={() => setIsSnapshotConfirmationDialogOpen(true)}
-          data-qa-snapshot-button
-          disabled={snapshotForm.values.label === '' || isReadOnly}
-        >
-          Take Snapshot
-        </Button>
+        <Box className={classes.snapshotFormControl}>
+          <TextField
+            errorText={hasErrorFor.label}
+            label="Name Snapshot"
+            name="label"
+            value={snapshotForm.values.label}
+            onChange={snapshotForm.handleChange}
+            data-qa-manual-name
+            className={classes.snapshotNameField}
+          />
+          <Button
+            buttonType="primary"
+            onClick={() => setIsSnapshotConfirmationDialogOpen(true)}
+            data-qa-snapshot-button
+            disabled={snapshotForm.values.label === '' || isReadOnly}
+          >
+            Take Snapshot
+          </Button>
+        </Box>
       </FormControl>
       <CaptureSnapshotConfirmationDialog
         open={isSnapshotConfirmationDialogOpen}

--- a/packages/manager/src/features/ToastNotifications/ToastNotifications.tsx
+++ b/packages/manager/src/features/ToastNotifications/ToastNotifications.tsx
@@ -172,7 +172,12 @@ class ToastNotifications extends React.PureComponent<WithSnackbarProps, {}> {
             return toastSuccessAndFailure({
               enqueueSnackbar,
               eventStatus: event.status,
+              persistFailureMessage: true,
               failureMessage: `There was an error creating a snapshot on Linode ${label}.`,
+              link: formatLink(
+                'Learn more about limits and considerations.',
+                'https://www.linode.com/docs/products/storage/backups/#limits-and-considerations'
+              ),
             });
           /**
            * These create/delete failures are hypothetical.

--- a/packages/manager/src/features/ToastNotifications/ToastNotifications.tsx
+++ b/packages/manager/src/features/ToastNotifications/ToastNotifications.tsx
@@ -173,7 +173,18 @@ class ToastNotifications extends React.PureComponent<WithSnackbarProps, {}> {
               enqueueSnackbar,
               eventStatus: event.status,
               persistFailureMessage: true,
-              failureMessage: `There was an error creating a snapshot on Linode ${label}.`,
+              failureMessage: `Snapshot backup failed on Linode ${label}.`,
+              link: formatLink(
+                'Learn more about limits and considerations.',
+                'https://www.linode.com/docs/products/storage/backups/#limits-and-considerations'
+              ),
+            });
+          case 'backups_restore':
+            return toastSuccessAndFailure({
+              enqueueSnackbar,
+              eventStatus: event.status,
+              persistFailureMessage: true,
+              failureMessage: `Backup restoration failed for ${label}.`,
               link: formatLink(
                 'Learn more about limits and considerations.',
                 'https://www.linode.com/docs/products/storage/backups/#limits-and-considerations'

--- a/packages/manager/src/features/ToastNotifications/ToastNotifications.tsx
+++ b/packages/manager/src/features/ToastNotifications/ToastNotifications.tsx
@@ -1,4 +1,5 @@
 import { Event, EventStatus } from '@linode/api-v4/lib/account/types';
+import { styled } from '@mui/material/styles';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import * as React from 'react';
 import 'rxjs/add/operator/bufferTime';
@@ -297,8 +298,14 @@ export default withSnackbar(ToastNotifications);
 
 const formatLink = (text: string, link: string, handleClick?: any) => {
   return (
-    <Link to={link} onClick={handleClick}>
+    <StyledToastNotificationLink to={link} onClick={handleClick}>
       {text}
-    </Link>
+    </StyledToastNotificationLink>
   );
 };
+
+export const StyledToastNotificationLink = styled(Link, {
+  label: 'StyledToastNotificationLink',
+})(({ theme }) => ({
+  color: theme.textColors.linkActiveLight,
+}));

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -893,19 +893,9 @@ export const handlers = [
       message: 'Ticket name with special characters... (?)',
       percent_complete: 100,
     });
-    const failedBackupRestoreEvent = eventFactory.build({
-      action: 'backups_restore',
-      status: 'failed',
-      percent_complete: 100,
-    });
     return res.once(
       ctx.json(
-        makeResourcePage([
-          ...events,
-          ...oldEvents,
-          eventWithSpecialCharacters,
-          failedBackupRestoreEvent,
-        ])
+        makeResourcePage([...events, ...oldEvents, eventWithSpecialCharacters])
       )
     );
   }),

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -893,9 +893,19 @@ export const handlers = [
       message: 'Ticket name with special characters... (?)',
       percent_complete: 100,
     });
+    const failedBackupRestoreEvent = eventFactory.build({
+      action: 'backups_restore',
+      status: 'failed',
+      percent_complete: 100,
+    });
     return res.once(
       ctx.json(
-        makeResourcePage([...events, ...oldEvents, eventWithSpecialCharacters])
+        makeResourcePage([
+          ...events,
+          ...oldEvents,
+          eventWithSpecialCharacters,
+          failedBackupRestoreEvent,
+        ])
       )
     );
   }),


### PR DESCRIPTION
## Description 📝
Error messaging for the backups service is minimal and does not provide users with much insight on the reason for a failure or whether they can address it.

Ultimately, we want to display more detailed error messages in Cloud Manager for failed backup restores and snapshot backups, which will require API to return these errors for Cloud to surface. This is ticketed and in the backlog: ARB-4001.

In the meantime, this PR addresses front-end improvements we can make to error messaging with the goal of (a) error prevention and (b) providing additional general context of limitations and requirements for the backup service.

We are updating generic error messages with a docs link to point users to potential reasons for the failure. We are also adding a warning notice in the linode create page to help prevent customers from encountering backup service failures due to unsupported disks being present in their configuration, which is a common reason backup restores fail. 

> **Note**: When testing, you may notice a bug where failed snapshot backups are returning incorrect `finished` timestamps (e.g. 2 seconds ago when the failure was 5 minutes ago). This is a known and ticketed API bug due to the way `duration` continues to accumulate for `linode_snapshot` events when the event is finished/failed. We're seeing it now due to recent changes (#9215) to update the timestamp for finished events, rather than use the created timestamp. 

TODO - Address UX feedback:
- [x] Fix the link color in dark mode on error toasts.

## Major Changes 🔄
- Updates notification menu/activity feed events for `backups_restore` and `linode_snapshot` failure events include link to doc.
- Updates error toasts for `backups_restore` and `linode_snapshot` failures to make them persistent, link to doc, and match the copy in the event failure message for consistency.
- Displays a warning notice above the backups section when a user enables Backups as an Add-on when creating or cloning a new linode with a custom image.
- Fixes a styling bug where the error notice on the Manual Snapshot section was displaying inline with textfield, rather than above.

## Preview 📷
| Before  | After   | Description |
| ------- | ------- | ------- |
| ![Screenshot 2023-07-04 at 10 05 33 PM](https://github.com/linode/manager/assets/114685994/6aaee5fb-3b69-4e0a-b45b-e12d92b62ff0) | ![Screenshot 2023-07-04 at 10 06 00 PM](https://github.com/linode/manager/assets/114685994/8faec0e6-b07f-439e-91ce-9e935917e7f3) | `linode_snapshot` error toast for failed manual snapshot backup |
| ![Screenshot 2023-07-04 at 10 02 22 PM](https://github.com/linode/manager/assets/114685994/926d177d-bf75-4d98-8a20-37e0c9d0ba08) | ![Screenshot 2023-07-04 at 10 03 02 PM](https://github.com/linode/manager/assets/114685994/282e9dfb-8f92-4de4-a647-e2a355046b54) | `linode_snapshot` event message for failed manual snapshot backup
| ![Screenshot 2023-07-05 at 10 53 23 AM](https://github.com/linode/manager/assets/114685994/2f8321c1-8456-4d77-80c5-07a83bbd2e78) | ![Screenshot 2023-07-05 at 10 48 28 AM](https://github.com/linode/manager/assets/114685994/fbce65dc-bc4e-43cf-b2d5-c1391b3199fa) | `backups_restore` event message for failure |
| | ![Screenshot 2023-07-05 at 10 48 17 AM](https://github.com/linode/manager/assets/114685994/5f51de2d-8be1-4495-b8bc-7e3cd275a541) | added `backups_restore` error toast for failure
| | ![Screenshot 2023-07-05 at 9 35 40 AM](https://github.com/linode/manager/assets/114685994/9f4503b6-f14f-4b0b-8e02-419bde60fc3d) | warning notice for enabled Backups Add-on when creating with custom image
| ![Screenshot 2023-07-04 at 10 04 52 PM](https://github.com/linode/manager/assets/114685994/5ee983d5-c203-4120-a7dd-4e570ab1b6c7)| ![Screenshot 2023-07-04 at 10 04 26 PM](https://github.com/linode/manager/assets/114685994/bc095ab9-cd77-48ee-90d6-166b5052de05) | fixed styling regression for error notice in Manual Backups section






## How to test 🧪
1. **How to setup test environment?**
2. **How to reproduce the issue (if applicable)?**
   1. Repeat steps below in 'How to verify changes' in prod and note that generic error messaging, non-persistent error toasts, and lack of warning about incompatible filesystems when enabling the backup service.
4. **How to verify changes?**
   1. Create a Linode that backups will fail for. One way to do this is to create a Linode from an Image that is not a valid filesystem. Reach out to me for the test account that has a Linode with a bad image set up already or follow the steps below to create your own.
	   1. Go to http://localhost:3000/images/create/upload and upload an image that is not in ext3 or ext4 format. For the purposes of testing, this can be a zipped text file containing anything. Call the image  label  `bad-image` or something similar.
   2. Once the `bad-image` has uploaded, go to http://localhost:3000/linodes/create?type=Images and select `bad-image` in the image dropdown. Fill in the necessary fields and then click the Backups checkbox to enable backups. 
		1. Confirm that, only when the Backups add-on is checked, a warning notice appears informing the user of the file system limitations of backups when using custom images. 
		2. Create the new linode (e.g. `bad-image-us-west`) from the bad image.
   3. Navigate to the Linode Details > Backups page and try to create a new manual snapshot backup. 
      4. Quickly, while that backup is in progress, try to take another snapshot. Observe the error notice is displayed above the text field, fixing a regression in prod. 
      5. When the snapshot backup fails (which it will, because our image is bad), confirm the error toast and event message with updated copy appear. If you want to test the error messaging for `backups_restore`, we can mock the event by adding to the MSW `events` endpoint:  
```
    const failedBackupRestoreEvent = eventFactory.build({
      action: 'backups_restore',
      status: 'failed',
      percent_complete: 100,
    });
```
   4. Verify that the warning notice for compatible filesystems when enabling Backups also appears in the Clone create flow and not on the Distro create flow.
      1. Go to http://localhost:3000/linodes/create?type=Clone%20Linode and select your linode with a public image and enable backups; confirm no warning message. Select linode with a bad image and enable backups; confirm warning message. Go to http://localhost:3000/linodes/create?type=distro, select an image, and also confirm no warning message.
