### PR TITLE
fix: NVM should be NVMe

### DIFF
--- a/packages/manager/.changeset/pr-9366-fixed-1688578241873.md
+++ b/packages/manager/.changeset/pr-9366-fixed-1688578241873.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Fixed
+---
+
+Volume empty state misspelling of NVMe ([#9366](https://github.com/linode/manager/pull/9366))

--- a/packages/manager/src/features/Volumes/VolumesLandingEmptyStateData.ts
+++ b/packages/manager/src/features/Volumes/VolumesLandingEmptyStateData.ts
@@ -13,7 +13,7 @@ import type {
 export const headers: ResourcesHeaders = {
   description:
     'Attach scalable, fault-tolerant, and performant block storage volumes to your Linode Compute Instances or Kubernetes Clusters.',
-  subtitle: 'NVM block storage service',
+  subtitle: 'NVMe block storage service',
   title: 'Volumes',
 };
 


### PR DESCRIPTION
## Description 📝
`NVM` should be `NVMe` for Block Storage

## Preview 📷
![Screenshot 2023-07-05 at 1 29 06 PM](https://github.com/linode/manager/assets/125309814/1d4ceded-07f4-4e41-8007-e42fc2c8c5c6)

