### PR TITLE
test: [M3-6627] - Add region tests for Linodes

### DIFF
--- a/packages/manager/cypress.config.ts
+++ b/packages/manager/cypress.config.ts
@@ -41,7 +41,7 @@ export default defineConfig({
     // This can be overridden using `CYPRESS_BASE_URL`.
     baseUrl: 'http://localhost:3000',
 
-    // This is overridden when `CY_SUITE` is defined.
+    // This is overridden when `CY_TEST_SUITE` is defined.
     // See `cypress/support/plugins/configure-test-suite.ts`.
     specPattern: 'cypress/e2e/core/**/*.spec.{ts,tsx}',
 

--- a/packages/manager/cypress/e2e/region/hello-world.spec.ts
+++ b/packages/manager/cypress/e2e/region/hello-world.spec.ts
@@ -1,3 +1,0 @@
-describe('Region tests placeholder', () => {
-  it('can run regions test suite', () => {});
-});

--- a/packages/manager/cypress/e2e/region/linodes/create-linode.spec.ts
+++ b/packages/manager/cypress/e2e/region/linodes/create-linode.spec.ts
@@ -1,0 +1,48 @@
+import { testRegions } from 'support/util/regions';
+import { ui } from 'support/ui';
+import { randomLabel, randomString } from 'support/util/random';
+import { interceptCreateLinode } from 'support/intercepts/linodes';
+import type { Region } from '@linode/api-v4';
+
+describe('Create Linodes', () => {
+  testRegions('can create and boot a Linode', (region: Region) => {
+    const label = randomLabel();
+
+    interceptCreateLinode().as('createLinode');
+    cy.visitWithLogin('linodes/create');
+
+    cy.contains('Select a Region')
+      .should('be.visible')
+      .click();
+
+    ui.regionSelect
+      .findItemByRegionId(region.id)
+      .should('be.visible')
+      .click();
+
+    cy.get('[data-qa-plan-row="Dedicated 4 GB"]')
+      .closest('tr')
+      .within(() => {
+        cy.get('[data-qa-radio]')
+          .click();
+      });
+
+    cy.findByLabelText('Linode Label')
+      .click()
+      .clear()
+      .type(label);
+
+    cy.findByLabelText('Root Password')
+      .click()
+      .type(randomString(32));
+
+    ui.button
+      .findByTitle('Create Linode')
+      .click();
+
+    cy.wait('@createLinode');
+    cy.findByText(label).should('be.visible');
+    cy.findByText(region.label).should('be.visible');
+    cy.findByText('RUNNING').should('be.visible');
+  });
+});

--- a/packages/manager/cypress/e2e/region/linodes/create-linode.spec.ts
+++ b/packages/manager/cypress/e2e/region/linodes/create-linode.spec.ts
@@ -16,8 +16,8 @@ describeRegions('Create Linodes', (region: Region) => {
     interceptCreateLinode().as('createLinode');
     cy.visitWithLogin('linodes/create');
 
+    // Select region and plan.
     cy.contains('Select a Region').should('be.visible').click();
-
     ui.regionSelect.findItemByRegionId(region.id).should('be.visible').click();
 
     cy.get('[data-qa-plan-row="Dedicated 4 GB"]')
@@ -26,15 +26,17 @@ describeRegions('Create Linodes', (region: Region) => {
         cy.get('[data-qa-radio]').click();
       });
 
+    // Enter label and password.
     cy.findByLabelText('Linode Label').click().clear().type(label);
-
     cy.findByLabelText('Root Password').click().type(randomString(32));
 
+    // Submit.
     ui.button.findByTitle('Create Linode').click();
 
+    // Confirm Linode boots.
     cy.wait('@createLinode');
     cy.findByText(label).should('be.visible');
     cy.findByText(region.label).should('be.visible');
-    cy.findByText('RUNNING').should('be.visible');
+    cy.findByText('RUNNING', { timeout: 180000 }).should('be.visible');
   });
 });

--- a/packages/manager/cypress/e2e/region/linodes/create-linode.spec.ts
+++ b/packages/manager/cypress/e2e/region/linodes/create-linode.spec.ts
@@ -1,44 +1,36 @@
-import { testRegions } from 'support/util/regions';
+import { describeRegions } from 'support/util/regions';
 import { ui } from 'support/ui';
 import { randomLabel, randomString } from 'support/util/random';
 import { interceptCreateLinode } from 'support/intercepts/linodes';
 import type { Region } from '@linode/api-v4';
 
-describe('Create Linodes', () => {
-  testRegions('can create and boot a Linode', (region: Region) => {
+describeRegions('Create Linodes', (region: Region) => {
+  /*
+   * - Navigates to Linode create page.
+   * - Selects a region, plan (Dedicated 4 GB), and enters label and password.
+   * - Clicks "Create Linode" and confirms that new Linode boots.
+   */
+  it('can create and boot a Linode', () => {
     const label = randomLabel();
 
     interceptCreateLinode().as('createLinode');
     cy.visitWithLogin('linodes/create');
 
-    cy.contains('Select a Region')
-      .should('be.visible')
-      .click();
+    cy.contains('Select a Region').should('be.visible').click();
 
-    ui.regionSelect
-      .findItemByRegionId(region.id)
-      .should('be.visible')
-      .click();
+    ui.regionSelect.findItemByRegionId(region.id).should('be.visible').click();
 
     cy.get('[data-qa-plan-row="Dedicated 4 GB"]')
       .closest('tr')
       .within(() => {
-        cy.get('[data-qa-radio]')
-          .click();
+        cy.get('[data-qa-radio]').click();
       });
 
-    cy.findByLabelText('Linode Label')
-      .click()
-      .clear()
-      .type(label);
+    cy.findByLabelText('Linode Label').click().clear().type(label);
 
-    cy.findByLabelText('Root Password')
-      .click()
-      .type(randomString(32));
+    cy.findByLabelText('Root Password').click().type(randomString(32));
 
-    ui.button
-      .findByTitle('Create Linode')
-      .click();
+    ui.button.findByTitle('Create Linode').click();
 
     cy.wait('@createLinode');
     cy.findByText(label).should('be.visible');

--- a/packages/manager/cypress/e2e/region/linodes/delete-linode.spec.ts
+++ b/packages/manager/cypress/e2e/region/linodes/delete-linode.spec.ts
@@ -1,95 +1,66 @@
 import { createLinodeRequestFactory } from '@src/factories';
-import { testRegions, getTestableRegions } from 'support/util/regions';
+import { testRegions } from 'support/util/regions';
 import { randomLabel, randomString } from 'support/util/random';
-import { getLinodes, Region } from '@linode/api-v4';
+import { Region } from '@linode/api-v4';
 import { createLinode } from '@linode/api-v4';
-import { poll } from 'support/util/polling';
-import { depaginate } from 'support/util/paginate';
 import type { Linode } from '@linode/api-v4';
 import { ui } from 'support/ui';
 import { authenticate } from 'support/api/authentication';
-import { resolveInBatches } from 'support/util/promises';
-
-/**
- * Creates a Linode for each testable region, and waits for each to boot.
- */
-const createLinodesAndWait = async () => {
-  const createLinodePromiseGenerators = getTestableRegions()
-    .map((region: Region) => {
-      const linodeRequest = createLinodeRequestFactory.build({
-        label: randomLabel(),
-        region: region.id,
-        root_password: randomString(32),
-      });
-
-      return () => createLinode(linodeRequest);
-    });
-
-  //const newLinodes = await Promise.all(createLinodePromises);
-  const newLinodes = await resolveInBatches(createLinodePromiseGenerators, 2, 6500);
-  const checkLinodeStatuses = (allLinodes: Linode[]) => {
-    return allLinodes
-      .filter((linode) => newLinodes.some((newLinode) => newLinode.label === linode.label))
-      .every((linode) => linode.status === 'running');
-  };
-
-  await poll<Linode[]>(
-    async () => depaginate((page) => getLinodes({ page })),
-    (linodes: Linode[]) => checkLinodeStatuses(linodes),
-  );
-
-  return newLinodes;
-};
+import {
+  interceptGetLinodeDetails,
+  interceptGetLinodes,
+} from 'support/intercepts/linodes';
 
 authenticate();
 describe('Delete Linodes', () => {
-  // Create Linodes to delete first.
-  let linodes: Linode[];
-  before(() => {
-    const deferOptions = {
-      label: 'creating Linodes to delete',
-      timeout: 180000,
-    };
-    cy.defer(createLinodesAndWait(), deferOptions).then((newLinodes: Linode[]) => {
-      linodes = newLinodes;
-    });
-  });
-
   testRegions('can delete a Linode', (region: Region) => {
-    const linode = linodes.find((aLinode) => aLinode.region === region.id);
-    if (!linode) {
-      throw new Error(`Unable to find created Linode for region ${region.id}`);
-    }
-    cy.visitWithLogin(`/linodes/${linode.id}`);
-    ui.actionMenu
-      .findByTitle(`Action menu for Linode ${linode.label}`)
-      .should('be.visible')
-      .click();
+    const linodeCreatePayload = createLinodeRequestFactory.build({
+      label: randomLabel(),
+      region: region.id,
+      root_password: randomString(32),
+    });
 
-    ui.actionMenuItem
-      .findByTitle('Delete')
-      .should('be.visible')
-      .click();
+    // Create a Linode before navigating to its details page to delete it.
+    cy.defer(
+      createLinode(linodeCreatePayload),
+      `creating Linode in ${region.label}`
+    ).then((linode: Linode) => {
+      interceptGetLinodeDetails(linode.id).as('getLinode');
+      cy.visitWithLogin(`/linodes/${linode.id}`);
+      cy.wait('@getLinode');
 
-    ui.dialog
-      .findByTitle(`Delete ${linode.label}?`)
-      .should('be.visible')
-      .within(() => {
-        cy.findByLabelText('Linode Label')
-          .should('be.visible')
-          .click()
-          .type(linode.label);
+      // Delete Linode via action menu.
+      ui.actionMenu
+        .findByTitle(`Action menu for Linode ${linode.label}`)
+        .should('be.visible')
+        .click();
 
-        ui.buttonGroup
-          .findButtonByTitle('Delete')
-          .should('be.visible')
-          .should('be.enabled')
-          .click();
-      });
+      ui.actionMenuItem.findByTitle('Delete').should('be.visible').click();
 
-    // Cloud currently does not navigate back to landing page.
-    // Remove call to `cy.visitWithLogin()` once redirect is restored.
-    cy.visitWithLogin('/linodes');
-    cy.findByText(linode.label).should('not.exist');
+      // Confirm deletion via type-to-confirm dialog.
+      ui.dialog
+        .findByTitle(`Delete ${linode.label}?`)
+        .should('be.visible')
+        .within(() => {
+          cy.findByLabelText('Linode Label')
+            .should('be.visible')
+            .click()
+            .type(linode.label);
+
+          ui.buttonGroup
+            .findButtonByTitle('Delete')
+            .should('be.visible')
+            .should('be.enabled')
+            .click();
+        });
+
+      // Confirm that Linode is no longer listed on landing page.
+      // Cloud currently does not navigate back to landing page.
+      // Remove call to `cy.visitWithLogin()` once redirect is restored.
+      interceptGetLinodes().as('getLinodes');
+      cy.visitWithLogin('/linodes');
+      cy.wait('@getLinodes');
+      cy.findByText(linode.label).should('not.exist');
+    });
   });
 });

--- a/packages/manager/cypress/e2e/region/linodes/delete-linode.spec.ts
+++ b/packages/manager/cypress/e2e/region/linodes/delete-linode.spec.ts
@@ -1,5 +1,5 @@
 import { createLinodeRequestFactory } from '@src/factories';
-import { testRegions } from 'support/util/regions';
+import { describeRegions } from 'support/util/regions';
 import { randomLabel, randomString } from 'support/util/random';
 import { Region } from '@linode/api-v4';
 import { createLinode } from '@linode/api-v4';
@@ -12,8 +12,13 @@ import {
 } from 'support/intercepts/linodes';
 
 authenticate();
-describe('Delete Linodes', () => {
-  testRegions('can delete a Linode', (region: Region) => {
+describeRegions('Delete Linodes', (region: Region) => {
+  /*
+   * - Navigates to a Linode details page.
+   * - Deletes the Linode via the "Delete" action menu item.
+   * - Navigates back to Linode landing page, confirms deleted Linode is not shown.
+   */
+  it('can delete a Linode', () => {
     const linodeCreatePayload = createLinodeRequestFactory.build({
       label: randomLabel(),
       region: region.id,

--- a/packages/manager/cypress/e2e/region/linodes/delete-linode.spec.ts
+++ b/packages/manager/cypress/e2e/region/linodes/delete-linode.spec.ts
@@ -1,0 +1,91 @@
+import { createLinodeRequestFactory } from '@src/factories';
+import { testRegions, getTestableRegions } from 'support/util/regions';
+import { randomLabel, randomString } from 'support/util/random';
+import { getLinodes, Region } from '@linode/api-v4';
+import { createLinode } from '@linode/api-v4';
+import { poll } from 'support/util/polling';
+import { depaginate } from 'support/util/paginate';
+import type { Linode } from '@linode/api-v4';
+import { ui } from 'support/ui';
+import { authenticate } from 'support/api/authentication';
+import { resolveInBatches } from 'support/util/promises';
+
+/**
+ * Creates a Linode for each testable region, and waits for each to boot.
+ */
+const createLinodesAndWait = async () => {
+  const createLinodePromises = getTestableRegions()
+    .map((region: Region) => {
+      const linodeRequest = createLinodeRequestFactory.build({
+        label: randomLabel(),
+        region: region.id,
+        root_password: randomString(32),
+      });
+
+      return createLinode(linodeRequest);
+    });
+
+  //const newLinodes = await Promise.all(createLinodePromises);
+  const newLinodes = await resolveInBatches(createLinodePromises, 2, 15000);
+  const checkLinodeStatuses = (allLinodes: Linode[]) => {
+    return allLinodes
+      .filter((linode) => newLinodes.some((newLinode) => newLinode.label === linode.label))
+      .every((linode) => linode.status === 'running');
+  };
+
+  await poll<Linode[]>(
+    async () => depaginate((page) => getLinodes({ page })),
+    (linodes: Linode[]) => checkLinodeStatuses(linodes),
+  );
+
+  return newLinodes;
+};
+
+authenticate();
+describe('Delete Linodes', () => {
+  // Create Linodes to delete first.
+  let linodes: Linode[];
+  before(() => {
+    cy.defer(createLinodesAndWait()).then((newLinodes: Linode[]) => {
+      linodes = newLinodes;
+    });
+  });
+
+  testRegions('can delete a Linode', (region: Region) => {
+    const linode = linodes.find((aLinode) => aLinode.region === region.id);
+    if (!linode) {
+      throw new Error(`Unable to find created Linode for region ${region.id}`);
+    }
+    cy.visitWithLogin(`/linodes/${linode.id}`);
+    ui.actionMenu
+      .findByTitle(`Action menu for Linode ${linode.label}`)
+      .should('be.visible')
+      .click();
+
+    ui.actionMenuItem
+      .findByTitle('Delete')
+      .should('be.visible')
+      .click();
+
+    ui.dialog
+      .findByTitle(`Delete ${linode.label}?`)
+      .should('be.visible')
+      .within(() => {
+        cy.findByLabelText('Linode Label')
+          .should('be.visible')
+          .click()
+          .type(linode.label);
+
+        ui.buttonGroup
+          .findButtonByTitle('Delete')
+          .should('be.visible')
+          .should('be.enabled')
+          .click();
+      });
+
+    // Cloud currently does not navigate back to landing page.
+    // Remove call to `cy.visitWithLogin()` once redirect is restored.
+    cy.visitWithLogin('/linodes');
+    cy.findByText(linode.label).should('not.exist');
+  });
+});

--- a/packages/manager/cypress/e2e/region/linodes/update-linode.spec.ts
+++ b/packages/manager/cypress/e2e/region/linodes/update-linode.spec.ts
@@ -1,47 +1,141 @@
-import { authenticate } from 'support/api/authentication';
-import { describeRegions } from 'support/util/regions';
-import { createLinode, Region } from '@linode/api-v4';
+import type { Disk, Linode } from '@linode/api-v4';
+import { createLinode, getLinodeDisks } from '@linode/api-v4';
 import { createLinodeRequestFactory } from '@src/factories';
-import { randomLabel, randomString } from 'support/util/random';
+import { authenticate } from 'support/api/authentication';
 import { interceptGetLinodeDetails } from 'support/intercepts/linodes';
-import type { Linode } from '@linode/api-v4';
+import { ui } from 'support/ui';
+import { depaginate } from 'support/util/paginate';
+import { randomLabel, randomString } from 'support/util/random';
+import { describeRegions } from 'support/util/regions';
+
+/*
+ * Returns a Linode create payload for the given region.
+ */
+const makeLinodePayload = (region: string, booted: boolean) => {
+  return createLinodeRequestFactory.build({
+    label: randomLabel(),
+    password: randomString(32),
+    region,
+    booted,
+  });
+};
 
 authenticate();
-describeRegions('Can update Linodes', (region: Region) => {
-  // const  linodePayload = createLinodeRequestFactory.build({
-
-  // })
-  let linode: Linode;
-  before(() => {
-    const payload = createLinodeRequestFactory.build({
-      label: randomLabel(),
-      region: region.id,
-      password: randomString(32),
-    });
-
-    cy.defer(createLinode(payload), 'creating Linode').then((createdLinode) => {
-      linode = createdLinode;
-    });
-  });
-
+describeRegions('Can update Linodes', (region) => {
+  /*
+   * - Navigates to a Linode details page's "Settings" tab.
+   * - Enters a new label and clicks "Save".
+   * - Confirms that label is updated and shown on Linode landing page.
+   */
   it('can update a Linode label', () => {
-    const newLabel = randomLabel();
-    const oldLabel = linode.label;
+    cy.defer(
+      createLinode(makeLinodePayload(region.id, true)),
+      'creating Linode'
+    ).then((linode: Linode) => {
+      const newLabel = randomLabel();
+      const oldLabel = linode.label;
 
-    // Navigate to Linode details page.
-    interceptGetLinodeDetails(linode.id).as('getLinode');
-    cy.visitWithLogin(`/linodes/${linode.id}`);
-    cy.wait('@getLinode');
+      // Navigate to Linode details page.
+      interceptGetLinodeDetails(linode.id).as('getLinode');
+      cy.visitWithLogin(`/linodes/${linode.id}`);
+      cy.wait('@getLinode');
 
-    // Click on 'Settings' tab.
-    cy.findByText('Settings').should('be.visible').click();
+      // Click on 'Settings' tab.
+      cy.findByText('Settings').should('be.visible').click();
 
-    cy.findByLabelText('Label')
-      .should('be.visible')
-      .click()
-      .clear()
-      .type(newLabel);
+      // Type in new label, click "Save".
+      cy.get('[data-qa-panel="Linode Label"]')
+        .should('be.visible')
+        .within(() => {
+          cy.findByLabelText('Label')
+            .should('be.visible')
+            .click()
+            .clear()
+            .type(newLabel);
+
+          ui.button
+            .findByTitle('Save')
+            .should('be.visible')
+            .should('be.enabled')
+            .click();
+        });
+
+      // Confirm that label has been updated.
+      ui.toast.assertMessage(
+        `Successfully updated Linode label to ${newLabel}`
+      );
+      ui.entityHeader.find().within(() => {
+        cy.findByText(newLabel).should('be.visible');
+        cy.findByText('linodes').should('be.visible').click();
+      });
+
+      cy.url().should('endWith', '/linodes');
+      cy.findByText(oldLabel).should('not.exist');
+      cy.findByText(newLabel).should('be.visible');
+    });
   });
 
-  it('can update a Linode root password', () => {});
+  /*
+   * - Navigates to a Linode details page's "Settings" tab.
+   * - Enters a new password and clicks "Save".
+   * - Confirms that successful toast notification appears.
+   */
+  it('can update a Linode root password', () => {
+    const newPassword = randomString(32);
+
+    const createLinodeAndGetDisk = async (): Promise<[Linode, Disk]> => {
+      const linode = await createLinode(makeLinodePayload(region.id, false));
+      const disks = await depaginate((page) =>
+        getLinodeDisks(linode.id, { page })
+      );
+
+      // Throw if Linode has no disks. Shouldn't happen in practice.
+      if (!disks[0]) {
+        throw new Error('Created Linode does not have any disks');
+      }
+      return [linode, disks[0]];
+    };
+
+    cy.defer(createLinodeAndGetDisk()).then(
+      ([linode, disk]: [Linode, Disk]) => {
+        // Navigate to Linode details page.
+        interceptGetLinodeDetails(linode.id).as('getLinode');
+        cy.visitWithLogin(`/linodes/${linode.id}`);
+        cy.wait('@getLinode');
+
+        // Wait for Linode to finish provisioning.
+        cy.findByText('PROVISIONING').should('not.exist');
+        cy.findByText('OFFLINE').should('be.visible');
+
+        // Click on 'Settings' tab.
+        cy.findByText('Settings').should('be.visible').click();
+
+        cy.get('[data-qa-panel="Reset Root Password"]')
+          .should('be.visible')
+          .within(() => {
+            cy.findByText('Disk').should('be.visible').click().type(disk.label);
+
+            ui.autocompletePopper
+              .findByTitle(disk.label)
+              .should('be.visible')
+              .click();
+
+            cy.findByLabelText('New Root Password')
+              .should('be.visible')
+              .click()
+              .clear()
+              .type(newPassword);
+
+            ui.button
+              .findByTitle('Save')
+              .should('be.visible')
+              .should('be.enabled')
+              .click();
+          });
+
+        ui.toast.assertMessage('Sucessfully changed password');
+        // TODO Investigate whether e2e solution to test password can be done securely.
+      }
+    );
+  });
 });

--- a/packages/manager/cypress/e2e/region/linodes/update-linode.spec.ts
+++ b/packages/manager/cypress/e2e/region/linodes/update-linode.spec.ts
@@ -1,0 +1,47 @@
+import { authenticate } from 'support/api/authentication';
+import { describeRegions } from 'support/util/regions';
+import { createLinode, Region } from '@linode/api-v4';
+import { createLinodeRequestFactory } from '@src/factories';
+import { randomLabel, randomString } from 'support/util/random';
+import { interceptGetLinodeDetails } from 'support/intercepts/linodes';
+import type { Linode } from '@linode/api-v4';
+
+authenticate();
+describeRegions('Can update Linodes', (region: Region) => {
+  // const  linodePayload = createLinodeRequestFactory.build({
+
+  // })
+  let linode: Linode;
+  before(() => {
+    const payload = createLinodeRequestFactory.build({
+      label: randomLabel(),
+      region: region.id,
+      password: randomString(32),
+    });
+
+    cy.defer(createLinode(payload), 'creating Linode').then((createdLinode) => {
+      linode = createdLinode;
+    });
+  });
+
+  it('can update a Linode label', () => {
+    const newLabel = randomLabel();
+    const oldLabel = linode.label;
+
+    // Navigate to Linode details page.
+    interceptGetLinodeDetails(linode.id).as('getLinode');
+    cy.visitWithLogin(`/linodes/${linode.id}`);
+    cy.wait('@getLinode');
+
+    // Click on 'Settings' tab.
+    cy.findByText('Settings').should('be.visible').click();
+
+    cy.findByLabelText('Label')
+      .should('be.visible')
+      .click()
+      .clear()
+      .type(newLabel);
+  });
+
+  it('can update a Linode root password', () => {});
+});

--- a/packages/manager/cypress/e2e/region/linodes/update-linode.spec.ts
+++ b/packages/manager/cypress/e2e/region/linodes/update-linode.spec.ts
@@ -96,7 +96,7 @@ describeRegions('Can update Linodes', (region) => {
       return [linode, disks[0]];
     };
 
-    cy.defer(createLinodeAndGetDisk()).then(
+    cy.defer(createLinodeAndGetDisk(), 'creating Linode').then(
       ([linode, disk]: [Linode, Disk]) => {
         // Navigate to Linode details page.
         interceptGetLinodeDetails(linode.id).as('getLinode');

--- a/packages/manager/cypress/support/constants/timeouts.ts
+++ b/packages/manager/cypress/support/constants/timeouts.ts
@@ -1,0 +1,8 @@
+/**
+ * @file Timeout lengths for various Cloud Manager operations.
+ */
+
+/**
+ * Timeout when creating, provisioning, and booting a Linode.
+ */
+const provisionLinodeTimeout = 180000;

--- a/packages/manager/cypress/support/intercepts/linodes.ts
+++ b/packages/manager/cypress/support/intercepts/linodes.ts
@@ -16,7 +16,16 @@ export const interceptCreateLinode = (): Cypress.Chainable<null> => {
 };
 
 /**
- * Intercepts GET request to mock linode data.
+ * Intercepts GET request to get all Linodes.
+ *
+ * @returns Cypress chainable.
+ */
+export const interceptGetLinodes = (): Cypress.Chainable<null> => {
+  return cy.intercept('GET', apiMatcher('linode/instances/*'));
+};
+
+/**
+ * Intercepts GET request to get all Linodes and mocks the response.
  *
  * @param linodes - an array of mock linode objects
  *

--- a/packages/manager/cypress/support/util/backoff.ts
+++ b/packages/manager/cypress/support/util/backoff.ts
@@ -2,8 +2,14 @@
  * @file Utilities to handle retries with configurable backoff logic.
  */
 
-// Util to wait a given number of milliseconds before resolving.
-const timeout = (timeout: number) =>
+/**
+ * Promise that waits a given number of milliseconds before resolving.
+ *
+ * @param timeout - Timeout in milliseconds.
+ *
+ * @returns Promise that resolves when timeout has passed.
+ */
+export const timeout = (timeout: number) =>
   new Promise((resolve) => setTimeout(resolve, timeout));
 
 // Util to calculate fibonacci number for a given index.

--- a/packages/manager/cypress/support/util/promises.ts
+++ b/packages/manager/cypress/support/util/promises.ts
@@ -1,0 +1,38 @@
+/**
+ * @file Utilities related to Promise handling.
+ */
+
+import { timeout } from './backoff';
+
+/**
+ * Resolves all of the given Promises in batches.
+ *
+ * @param promises - Promises to resolve.
+ * @param promisesPerPatch - How many Promises to attempt to resolve at once.
+ * @param delayMs - Time in milliseconds to wait between batches.
+ */
+export const resolveInBatches = async <T>(
+  promises: Promise<T>[],
+  promisesPerBatch: number = 3,
+  delayMs: number = 1000): Promise<T[]> => {
+    let results: T[] = [];
+    const unhandledPromises = [...promises];
+    console.log('a...');
+    while (unhandledPromises.length >= promisesPerBatch) {
+      console.log('b...');
+      const batchPromises = unhandledPromises.splice(0, promisesPerBatch);
+      console.log({promiseLength: batchPromises.length});
+      results.push(...await Promise.all(batchPromises));
+      if (unhandledPromises.length > 0) {
+        console.log('timin out bro');
+        await timeout(delayMs);
+      }
+    }
+    console.log('c...');
+    // Resolve leftover promises.
+    if (unhandledPromises.length > 0) {
+      results.push(...await Promise.all(promises));
+    }
+    console.log('d...');
+    return results;
+}

--- a/packages/manager/cypress/support/util/regions.ts
+++ b/packages/manager/cypress/support/util/regions.ts
@@ -94,8 +94,23 @@ export const chooseRegion = (): Region => {
 /**
  * Executes a test for each Linode region exposed to Cypress.
  */
-export const testRegions = (description: string, testCallback: (region: Region) => void) => {
+export const testRegions = (
+  description: string,
+  testCallback: (region: Region) => void
+) => {
   getTestableRegions().forEach((region: Region) => {
     it(`${description} (${region.id})`, () => testCallback(region));
+  });
+};
+
+/**
+ * Describes a group of test runs for each Linode region exposed to Cypress.
+ */
+export const describeRegions = (
+  description: string,
+  describeCallback: (region: Region) => void
+) => {
+  getTestableRegions().forEach((region: Region) => {
+    describe(`${description} (${region.id})`, () => describeCallback(region));
   });
 };

--- a/packages/manager/cypress/support/util/regions.ts
+++ b/packages/manager/cypress/support/util/regions.ts
@@ -14,8 +14,6 @@ export const getOverrideRegion = (): Region | undefined => {
 
   try {
     const reg = getRegionById(overrideRegionId);
-    console.log(`Found override region!`);
-    console.log(reg);
     return reg;
   } catch (e) {
     return undefined;
@@ -23,11 +21,25 @@ export const getOverrideRegion = (): Region | undefined => {
 };
 
 /**
- * Linode regions available to the current Cloud Manager user.
+ * All Linode regions available to the current Cloud Manager user.
  *
  * Retrieved via Linode APIv4 during Cypress start-up.
  */
 export const regions: Region[] = Cypress.env('cloudManagerRegions') as Region[];
+
+/**
+ * Linode region(s) exposed to Cypress for testing.
+ *
+ * This may be a subset of `regions` in order to test functionality for specific
+ * regions.
+ */
+export const getTestableRegions = (): Region[] => {
+  const overrideRegion = getOverrideRegion();
+  if (overrideRegion) {
+    return [overrideRegion];
+  }
+  return regions;
+};
 
 /**
  * Returns an object describing a Cloud Manager region with the given ID.
@@ -77,4 +89,13 @@ export const getRegionByLabel = (label: string) => {
 export const chooseRegion = (): Region => {
   const overrideRegion = getOverrideRegion();
   return overrideRegion ? overrideRegion : randomItem(regions);
+};
+
+/**
+ * Executes a test for each Linode region exposed to Cypress.
+ */
+export const testRegions = (description: string, testCallback: (region: Region) => void) => {
+  getTestableRegions().forEach((region: Region) => {
+    it(`${description} (${region.id})`, () => testCallback(region));
+  });
 };


### PR DESCRIPTION
## Description 📝
Adds end-to-end tests to our Cypress regions test suite to confirm that Linode create, update, and delete operations work end-to-end against all of our regions.

## Major Changes 🔄
- Add Linode create region tests
- Add Linode update (label, root password) region tests
- Add Linode delete (via details page) region tests

## How to test 🧪
At the moment, these tests can only be run locally. They're also slow because they create real resources against all of our regions. To speed things up, you can run the tests against only a single region:

(Note: You don't have to have Cloud running locally for this.)
```bash
CYPRESS_BASE_URL="https://cloud.linode.com" CY_TEST_SUITE="region" CY_TEST_REGION="us-east" yarn cy:run -s "cypress/e2e/region/linodes/*.spec.ts"
```

If you do want to run the tests against every region (which will be pretty slow), just omit the `CY_TEST_REGION` environment variable:

```bash
CYPRESS_BASE_URL="https://cloud.linode.com" CY_TEST_SUITE="region" yarn cy:run -s "cypress/e2e/region/linodes/*.spec.ts"
```
