### PR TITLE
chore: Add Cypress mocking utilities for Cloud Manager feature flags

### DIFF
--- a/packages/manager/cypress/support/intercepts/feature-flags.ts
+++ b/packages/manager/cypress/support/intercepts/feature-flags.ts
@@ -1,0 +1,55 @@
+/**
+ * @file Cypress intercepts and mocks for Cloud Manager feature flags.
+ */
+
+import { makeResponse } from 'support/util/response';
+import type { FeatureFlagResponseData } from 'support/util/feature-flags';
+
+// LaunchDarkly URL pattern for feature flag retrieval.
+const launchDarklyUrlPattern =
+  'https://app.launchdarkly.com/sdk/evalx/*/users/*';
+
+/**
+ * Intercepts GET request to fetch feature flags and modifies the response.
+ *
+ * The given feature flag data is merged with the actual response data so that
+ * existing but unrelated feature flags are left intact.
+ *
+ * The response from LaunchDarkly is not modified if the status code is
+ * anything other than 200.
+ *
+ * @param featureFlags - Feature flag response data with which to append response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockAppendFeatureFlags = (
+  featureFlags: FeatureFlagResponseData
+): Cypress.Chainable => {
+  return cy.intercept('GET', launchDarklyUrlPattern, (req) => {
+    req.continue((res) => {
+      if (res.statusCode === 200) {
+        res.body = {
+          ...res.body,
+          ...featureFlags,
+        };
+      }
+    });
+  });
+};
+
+/**
+ * Intercepts GET request to fetch feature flags and mocks the response.
+ *
+ * @param featureFlags - Feature flag response data with which to mock response.
+ *
+ * @returns Cypress chainable.
+ */
+export const mockGetFeatureFlags = (
+  featureFlags: FeatureFlagResponseData
+): Cypress.Chainable => {
+  return cy.intercept(
+    'GET',
+    launchDarklyUrlPattern,
+    makeResponse(featureFlags)
+  );
+};

--- a/packages/manager/cypress/support/util/feature-flags.ts
+++ b/packages/manager/cypress/support/util/feature-flags.ts
@@ -1,0 +1,53 @@
+/**
+ * @file Types and utilities related to Cloud Manager feature flags.
+ */
+
+/**
+ * Data for a Cloud Manager feature flag.
+ */
+export interface FeatureFlagData<T> {
+  flagVersion: number;
+  trackEvents: boolean;
+  value: T;
+  variation: number;
+  version: number;
+}
+
+/**
+ * Cloud Manager feature flag response.
+ */
+export interface FeatureFlagResponseData {
+  [key: string]: FeatureFlagData<any>;
+}
+
+/**
+ * Returns an object containing feature flag data.
+ *
+ * @param value - Feature flag value.
+ * @param variation - Feature flag variation. Optional.
+ * @param version - Version shared by flag data. Optional.
+ * @param trackEvents - Whether events are tracked. Optional.
+ * @param flagVersion - Flag version. Optional.
+ */
+export const makeFeatureFlagData = <T>(
+  value: T,
+  variation?: number,
+  version?: number,
+  trackEvents?: boolean,
+  flagVersion?: number
+): FeatureFlagData<T> => {
+  const defaultFeatureFlagData = {
+    flagVersion: 1,
+    trackEvents: false,
+    variation: 0,
+    version: 1,
+  };
+
+  return {
+    value,
+    variation: variation ?? defaultFeatureFlagData.variation,
+    version: version ?? defaultFeatureFlagData.version,
+    trackEvents: trackEvents ?? defaultFeatureFlagData.trackEvents,
+    flagVersion: flagVersion ?? defaultFeatureFlagData.flagVersion,
+  };
+};


### PR DESCRIPTION
## Description 📝
This adds a pair of utils that allow us to mock feature flag data from our Cypress tests. Just trying to squeeze this in before we start test development for VPC and AGLB so that everything is ready to go.

## Major Changes 🔄
* - Adds `mockGetFeatureFlags()` and `mockAppendFeatureFlags()` utils.

## How to test 🧪
* Confirm nothing breaks (we can lean on the automated build for this)
* You can manually test the utils by inserting a new spec which calls them, and then examining the Launch Darkly HTTP response from inside the Cypress debugger. For example, I was using this code:

```typescript
import { mockAppendFeatureFlags, mockGetFeatureFlags } from 'support/intercepts/feature-flags';
import { makeFeatureFlagData } from 'support/util/feature-flags';

describe('Test spec', () => {
  it('can mess with features', () => {
    mockAppendFeatureFlags({
      aglb: makeFeatureFlagData(false),
    }).as('getFeatureFlags');
    cy.visitWithLogin('/');
    cy.wait('@getFeatureFlags');
    // Give myself time to examine the response.
    cy.wait(100000);
  });
});
```