### PR TITLE
feat: [M3-6842] - Update Metadata copy

### DIFF
--- a/packages/manager/.changeset/pr-9374-changed-1688763763302.md
+++ b/packages/manager/.changeset/pr-9374-changed-1688763763302.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Changed
+---
+
+Update Metadata copy ([#9374](https://github.com/linode/manager/pull/9374))

--- a/packages/manager/cypress/e2e/core/account/change-username.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/change-username.spec.ts
@@ -36,6 +36,7 @@ describe('username', () => {
       cy.get('[data-qa-textfield-label="Username"]')
         .parent()
         .parent()
+        .parent()
         .within(() => {
           ui.button
             .findByTitle('Save')

--- a/packages/manager/cypress/e2e/core/account/security-questions.spec.ts
+++ b/packages/manager/cypress/e2e/core/account/security-questions.spec.ts
@@ -26,7 +26,7 @@ const getSecurityQuestionsSection = (): Cypress.Chainable => {
  * @returns Cypress chainable.
  */
 const getSecurityQuestion = (questionNumber: number): Cypress.Chainable => {
-  return cy.contains('label', `Question ${questionNumber}`).parent();
+  return cy.contains('label', `Question ${questionNumber}`).parent().parent();
 };
 
 /**
@@ -39,7 +39,7 @@ const getSecurityQuestion = (questionNumber: number): Cypress.Chainable => {
 const getSecurityQuestionAnswer = (
   questionNumber: number
 ): Cypress.Chainable => {
-  return cy.contains('label', `Answer ${questionNumber}`).parent();
+  return cy.contains('label', `Answer ${questionNumber}`).parent().parent();
 };
 
 /**

--- a/packages/manager/cypress/e2e/core/kubernetes/smoke-lke-create.spec.ts
+++ b/packages/manager/cypress/e2e/core/kubernetes/smoke-lke-create.spec.ts
@@ -60,11 +60,7 @@ describe('LKE Create Cluster', () => {
     mockCreateCluster(mockCluster).as('createCluster');
     cy.visitWithLogin('/kubernetes/create');
     cy.findByText('Add Node Pools').should('be.visible');
-    cy.contains('Cluster Label')
-      .next()
-      .children()
-      .click()
-      .type(mockCluster.label);
+    cy.findByLabelText('Cluster Label').click().type(mockCluster.label);
     cy.findByLabelText('Region')
       .should('be.visible')
       .focus()

--- a/packages/manager/src/components/TextField.tsx
+++ b/packages/manager/src/components/TextField.tsx
@@ -1,19 +1,20 @@
 import KeyboardArrowDown from '@mui/icons-material/KeyboardArrowDown';
+import Box from '@mui/material/Box';
+import { Theme } from '@mui/material/styles';
+import {
+  default as _TextField,
+  StandardTextFieldProps,
+} from '@mui/material/TextField';
 import { clamp } from 'ramda';
 import * as React from 'react';
 import { CircleProgress } from 'src/components/CircleProgress';
 import FormHelperText from 'src/components/core/FormHelperText';
 import InputAdornment from 'src/components/core/InputAdornment';
 import InputLabel from 'src/components/core/InputLabel';
-import { makeStyles } from 'tss-react/mui';
-import { Theme } from '@mui/material/styles';
-import {
-  default as _TextField,
-  StandardTextFieldProps,
-} from '@mui/material/TextField';
 import { TooltipProps as _TooltipProps } from 'src/components/Tooltip';
 import { TooltipIcon } from 'src/components/TooltipIcon';
 import { convertToKebabCase } from 'src/utilities/convertToKebobCase';
+import { makeStyles } from 'tss-react/mui';
 
 const useStyles = makeStyles()((theme: Theme) => ({
   helpWrapper: {
@@ -142,7 +143,11 @@ interface BaseProps {
 
 type Value = string | number | undefined | null;
 
-interface ToolTipProps {
+interface LabelToolTipProps {
+  labelTooltipText?: string | JSX.Element;
+}
+
+interface InputToolTipProps {
   tooltipPosition?: _TooltipProps['placement'];
   tooltipText?: string | JSX.Element;
   tooltipInteractive?: boolean;
@@ -155,7 +160,10 @@ interface TextFieldPropsOverrides extends StandardTextFieldProps {
   label: string;
 }
 
-export type TextFieldProps = BaseProps & TextFieldPropsOverrides & ToolTipProps;
+export type TextFieldProps = BaseProps &
+  TextFieldPropsOverrides &
+  LabelToolTipProps &
+  InputToolTipProps;
 
 export const TextField = (props: TextFieldProps) => {
   const { classes, cx } = useStyles();
@@ -178,6 +186,7 @@ export const TextField = (props: TextFieldProps) => {
     inputProps,
     InputProps,
     label,
+    labelTooltipText,
     loading,
     max,
     min,
@@ -273,22 +282,33 @@ export const TextField = (props: TextFieldProps) => {
         [errorScrollClassName]: !!errorText,
       })}
     >
-      <InputLabel
-        data-qa-textfield-label={label}
-        className={cx({
-          [classes.wrapper]: noMarginTop ? false : true,
-          [classes.noTransform]: true,
-          'visually-hidden': hideLabel,
-        })}
-        htmlFor={validInputId}
-      >
-        {label}
-        {required ? (
-          <span className={classes.label}> (required)</span>
-        ) : optional ? (
-          <span className={classes.label}> (optional)</span>
-        ) : null}
-      </InputLabel>
+      <Box display="flex">
+        <InputLabel
+          data-qa-textfield-label={label}
+          className={cx({
+            [classes.wrapper]: noMarginTop ? false : true,
+            [classes.noTransform]: true,
+            'visually-hidden': hideLabel,
+          })}
+          htmlFor={validInputId}
+        >
+          {label}
+          {required ? (
+            <span className={classes.label}> (required)</span>
+          ) : optional ? (
+            <span className={classes.label}> (optional)</span>
+          ) : null}
+        </InputLabel>
+        {labelTooltipText && (
+          <TooltipIcon
+            text={labelTooltipText}
+            status="help"
+            sxTooltipIcon={{
+              padding: '8px 0px 0px 8px',
+            }}
+          />
+        )}
+      </Box>
 
       {helperText && helperTextPosition === 'top' && (
         <FormHelperText

--- a/packages/manager/src/features/Linodes/LinodesCreate/UserDataAccordion/UserDataAccordion.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/UserDataAccordion/UserDataAccordion.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
-import { Box } from 'src/components/Box';
 import { Accordion } from 'src/components/Accordion';
+import { Box } from 'src/components/Box';
 import { Link } from 'src/components/Link';
 import { Notice } from 'src/components/Notice/Notice';
 import { TextField } from 'src/components/TextField';
 import { Typography } from 'src/components/Typography';
-import { UserDataAccordionHeading } from './UserDataAccordionHeading';
-import { useExpandIconStyles } from './UserDataAccordion.styles';
 import { CreateTypes } from 'src/store/linodeCreate/linodeCreate.actions';
+import { useExpandIconStyles } from './UserDataAccordion.styles';
+import { UserDataAccordionHeading } from './UserDataAccordionHeading';
 
 interface Props {
   createType?: CreateTypes;
@@ -58,59 +58,62 @@ export const UserDataAccordion = (props: Props) => {
 
   return (
     <Accordion
+      detailProps={{ sx: sxDetails }}
+      expandIconClassNames={fromBackupOrFromLinode ? expandIconStyles : ''}
       heading={<UserDataAccordionHeading createType={createType} />}
-      style={{
-        marginTop: renderNotice && renderCheckbox ? 0 : 24,
-      }} // for now, these props can be taken as an indicator we're in the Rebuild flow.
       headingProps={{
         variant: 'h2',
       }}
+      style={{
+        marginTop: renderNotice && renderCheckbox ? 0 : 24,
+      }} // for now, these props can be taken as an indicator we're in the Rebuild flow.
       summaryProps={{
         sx: {
           padding: '5px 24px 0px 24px',
           alignItems: fromBackupOrFromLinode ? 'flex-start' : 'center',
         },
       }}
-      detailProps={{ sx: sxDetails }}
       sx={{
         '&:before': {
           display: 'none',
         },
       }}
-      expandIconClassNames={fromBackupOrFromLinode ? expandIconStyles : ''}
     >
       {renderNotice ? (
         <Box marginBottom="16px" data-testid="render-notice">
           {renderNotice}
         </Box>
       ) : null}
-      <Typography sx={{ marginBottom: 3 }}>
-        User data is a virtual machine&rsquo;s cloud-init metadata relating to a
-        user&rsquo;s local account, including username and user group(s). <br />
-        User data must be added before the Linode provisions.{' '}
+      <Typography sx={{ marginBottom: 1 }}>
+        User data is a feature of the Metadata service that enables you to
+        perform system configuration tasks (such as adding users and installing
+        software) by providing custom instructions or scripts to cloud-init. Any
+        user data should be added at this step and cannot be modified after the
+        the Linode has been created.{' '}
         <Link to="https://www.linode.com/docs/products/compute/compute-instances/guides/metadata/">
           Learn more.
         </Link>{' '}
       </Typography>
       {formatWarning ? (
         <Notice warning spacingTop={16} spacingBottom={16}>
-          The user data may be formatted incorrectly.
+          The User Data may be formatted incorrectly.
         </Notice>
       ) : null}
       <TextField
-        label="User Data"
-        multiline
-        rows={1}
+        disabled={Boolean(disabled)}
         expand
+        label="User Data"
+        labelTooltipText="Compatible formats include cloud-config data and executable scripts."
+        multiline
+        onBlur={(e) =>
+          checkFormat({ userData: e.target.value, hasInputValueChanged: false })
+        }
         onChange={(e) => {
           checkFormat({ userData: e.target.value, hasInputValueChanged: true });
           onChange(e.target.value);
         }}
+        rows={1}
         value={userData}
-        disabled={Boolean(disabled)}
-        onBlur={(e) =>
-          checkFormat({ userData: e.target.value, hasInputValueChanged: false })
-        }
         data-qa-user-data-input
       />
       {renderCheckbox ?? null}

--- a/packages/manager/src/features/Linodes/LinodesCreate/UserDataAccordion/UserDataAccordion.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/UserDataAccordion/UserDataAccordion.tsx
@@ -96,7 +96,7 @@ export const UserDataAccordion = (props: Props) => {
       </Typography>
       {formatWarning ? (
         <Notice warning spacingTop={16} spacingBottom={16}>
-          The User Data may be formatted incorrectly.
+          The user data may be formatted incorrectly.
         </Notice>
       ) : null}
       <TextField

--- a/packages/manager/src/features/Linodes/LinodesCreate/UserDataAccordion/UserDataAccordionHeading.tsx
+++ b/packages/manager/src/features/Linodes/LinodesCreate/UserDataAccordion/UserDataAccordionHeading.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { BetaChip } from 'src/components/BetaChip/BetaChip';
+import { Box } from 'src/components/Box';
 import { Link } from 'src/components/Link';
 import { Notice } from 'src/components/Notice/Notice';
 import { TooltipIcon } from 'src/components/TooltipIcon';
-import { Box } from 'src/components/Box';
 import { CreateTypes } from 'src/store/linodeCreate/linodeCreate.actions';
 
 interface Props {
@@ -31,8 +31,8 @@ export const UserDataAccordionHeading = ({ createType }: Props) => {
           sxTooltipIcon={{ padding: '0 8px', alignItems: 'baseline' }}
           text={
             <>
-              User data is a virtual machine&rsquo;s cloud-init metadata
-              relating to a user&rsquo;s local account.{' '}
+              User data allows you to provide additional custom data to
+              cloud-init to further configure your system.{' '}
               <Link to="https://www.linode.com/docs/products/compute/compute-instances/guides/metadata/">
                 Learn more.
               </Link>


### PR DESCRIPTION
## Description 📝
- Add labelTooltipText prop to the TextField component
- Update Metadata copy with suggested changes from @wildmanonline

## Preview 📷
| Before  | After   |
| ------- | ------- |
| ![user data tooltip before](https://github.com/linode/manager/assets/115299789/0c7be335-0810-4c23-805b-b08d4c4136f9) | ![user data tooltip after](https://github.com/linode/manager/assets/115299789/39111b25-3ded-40c6-a923-c24abd81ff68) |
| ![user data before](https://github.com/linode/manager/assets/115299789/9fb1fd10-2c69-4b7d-a1e8-93ed5214d48f) | ![user data after](https://github.com/linode/manager/assets/115299789/687535df-625e-45fc-afa6-6f6915819db7) |

## How to test 🧪
- Turn on the MSW and go to `/linodes/create`
- Select `metadata-test-distro`
- Select the London, UK region
- Scroll down to the Add User Data accordion