### PR TITLE
feat: [M3-6822] - Add initial routes, folders, pages, and tabs for AGLB

### DIFF
--- a/packages/manager/.changeset/pr-9376-tech-stories-1689016335781.md
+++ b/packages/manager/.changeset/pr-9376-tech-stories-1689016335781.md
@@ -1,0 +1,5 @@
+---
+"@linode/manager": Tech Stories
+---
+
+Add initial AGLB routes, folders, pages, and tabs ([#9376](https://github.com/linode/manager/pull/9376))

--- a/packages/manager/src/GoTo.tsx
+++ b/packages/manager/src/GoTo.tsx
@@ -84,7 +84,7 @@ const GoTo: React.FC<CombinedProps> = (props) => {
         href: '/volumes',
       },
       {
-        display: 'LoadBalancers',
+        display: 'Load Balancers',
         href: '/loadbalancers',
       },
       {

--- a/packages/manager/src/GoTo.tsx
+++ b/packages/manager/src/GoTo.tsx
@@ -84,6 +84,10 @@ const GoTo: React.FC<CombinedProps> = (props) => {
         href: '/volumes',
       },
       {
+        display: 'LoadBalancers',
+        href: '/loadbalancers',
+      },
+      {
         display: 'NodeBalancers',
         href: '/nodebalancers',
       },

--- a/packages/manager/src/GoTo.tsx
+++ b/packages/manager/src/GoTo.tsx
@@ -5,6 +5,7 @@ import EnhancedSelect, { Item } from 'src/components/EnhancedSelect/Select';
 import MUIDialog from 'src/components/core/Dialog';
 import { useHistory } from 'react-router-dom';
 import useAccountManagement from './hooks/useAccountManagement';
+import useFlags from './hooks/useFlags';
 
 const useStyles = makeStyles((theme: Theme) => ({
   paper: {
@@ -61,6 +62,7 @@ const GoTo: React.FC<CombinedProps> = (props) => {
   const classes = useStyles();
   const routerHistory = useHistory();
   const { _isManagedAccount, _hasAccountAccess } = useAccountManagement();
+  const flags = useFlags();
 
   const onSelect = (item: Item<string>) => {
     routerHistory.push(item.value);
@@ -84,6 +86,7 @@ const GoTo: React.FC<CombinedProps> = (props) => {
         href: '/volumes',
       },
       {
+        hide: !flags.aglb,
         display: 'Load Balancers',
         href: '/loadbalancers',
       },

--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -141,6 +141,7 @@ const Images = React.lazy(() => import('src/features/Images'));
 const Kubernetes = React.lazy(() => import('src/features/Kubernetes'));
 const ObjectStorage = React.lazy(() => import('src/features/ObjectStorage'));
 const Profile = React.lazy(() => import('src/features/Profile'));
+const LoadBalancers = React.lazy(() => import('src/features/LoadBalancers'));
 const NodeBalancers = React.lazy(
   () => import('src/features/NodeBalancers/NodeBalancers')
 );
@@ -309,6 +310,10 @@ const MainContent = (props: CombinedProps) => {
                             <Route path="/linodes" component={LinodesRoutes} />
                             <Route path="/volumes" component={Volumes} />
                             <Redirect path="/volumes*" to="/volumes" />
+                            <Route
+                              path="/loadbalancers"
+                              component={LoadBalancers}
+                            />
                             <Route
                               path="/nodebalancers"
                               component={NodeBalancers}

--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -310,10 +310,12 @@ const MainContent = (props: CombinedProps) => {
                             <Route path="/linodes" component={LinodesRoutes} />
                             <Route path="/volumes" component={Volumes} />
                             <Redirect path="/volumes*" to="/volumes" />
-                            <Route
-                              path="/loadbalancer*"
-                              component={LoadBalancers}
-                            />
+                            {flags.aglb && (
+                              <Route
+                                path="/loadbalancer*"
+                                component={LoadBalancers}
+                              />
+                            )}
                             <Route
                               path="/nodebalancers"
                               component={NodeBalancers}

--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -311,7 +311,7 @@ const MainContent = (props: CombinedProps) => {
                             <Route path="/volumes" component={Volumes} />
                             <Redirect path="/volumes*" to="/volumes" />
                             <Route
-                              path="/loadbalancers"
+                              path="/loadbalancer*"
                               component={LoadBalancers}
                             />
                             <Route

--- a/packages/manager/src/features/LoadBalancers/EntryPoints/EntryPointCreate/EntryPointCreate.tsx
+++ b/packages/manager/src/features/LoadBalancers/EntryPoints/EntryPointCreate/EntryPointCreate.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { DocumentTitleSegment } from 'src/components/DocumentTitle/DocumentTitle';
+
+export const EntryPointCreate = () => {
+  return (
+    <>
+      <DocumentTitleSegment segment="Service Targets" />
+      TODO: AGLB M3-6817: Service Target Create
+    </>
+  );
+};

--- a/packages/manager/src/features/LoadBalancers/EntryPoints/EntryPointCreate/EntryPointCreate.tsx
+++ b/packages/manager/src/features/LoadBalancers/EntryPoints/EntryPointCreate/EntryPointCreate.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle/DocumentTitle';
 
-export const EntryPointCreate = () => {
+const EntryPointCreate = () => {
   return (
     <>
       <DocumentTitleSegment segment="Service Targets" />
@@ -9,3 +9,5 @@ export const EntryPointCreate = () => {
     </>
   );
 };
+
+export default EntryPointCreate;

--- a/packages/manager/src/features/LoadBalancers/EntryPoints/EntryPointLanding/EntryPointLanding.tsx
+++ b/packages/manager/src/features/LoadBalancers/EntryPoints/EntryPointLanding/EntryPointLanding.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { DocumentTitleSegment } from 'src/components/DocumentTitle/DocumentTitle';
+
+export const EntryPointLanding = () => {
+  return (
+    <>
+      <DocumentTitleSegment segment="Service Targets" />
+      TODO: AGLB M3-6811: Service Target Landing
+    </>
+  );
+};

--- a/packages/manager/src/features/LoadBalancers/EntryPoints/EntryPointLanding/EntryPointLanding.tsx
+++ b/packages/manager/src/features/LoadBalancers/EntryPoints/EntryPointLanding/EntryPointLanding.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle/DocumentTitle';
 
-export const EntryPointLanding = () => {
+const EntryPointLanding = () => {
   return (
     <>
       <DocumentTitleSegment segment="Service Targets" />
@@ -9,3 +9,5 @@ export const EntryPointLanding = () => {
     </>
   );
 };
+
+export default EntryPointLanding;

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerCreate/LoadBalancerCreate.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerCreate/LoadBalancerCreate.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle/DocumentTitle';
 
-export const LoadBalancerCreate = () => {
+const LoadBalancerCreate = () => {
   return (
     <>
       <DocumentTitleSegment segment="Load Balancers" />
@@ -9,3 +9,5 @@ export const LoadBalancerCreate = () => {
     </>
   );
 };
+
+export default LoadBalancerCreate;

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerCreate/LoadBalancerCreate.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerCreate/LoadBalancerCreate.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { DocumentTitleSegment } from 'src/components/DocumentTitle/DocumentTitle';
+
+export const LoadBalancerCreate = () => {
+  return (
+    <>
+      <DocumentTitleSegment segment="Load Balancers" />
+      TODO: AGLB M3-6815: Load Balancer Create
+    </>
+  );
+};

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/LoadBalancerDetail.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/LoadBalancerDetail.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle/DocumentTitle';
 
-export const LoadBalancerDetail = () => {
+const LoadBalancerDetail = () => {
   return (
     <>
       <DocumentTitleSegment segment="Load Balancers" />
@@ -9,3 +9,5 @@ export const LoadBalancerDetail = () => {
     </>
   );
 };
+
+export default LoadBalancerDetail;

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/LoadBalancerDetail.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/LoadBalancerDetail.tsx
@@ -1,13 +1,101 @@
+// import { useLocation } from '@reach/router';
 import * as React from 'react';
-import { DocumentTitleSegment } from 'src/components/DocumentTitle/DocumentTitle';
+import { matchPath, useHistory, useParams } from 'react-router-dom';
+import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import LandingHeader from 'src/components/LandingHeader';
+import { SafeTabPanel } from 'src/components/SafeTabPanel/SafeTabPanel';
+import SuspenseLoader from 'src/components/SuspenseLoader';
+import { TabLinkList } from 'src/components/TabLinkList/TabLinkList';
+import TabPanels from 'src/components/core/ReachTabPanels';
+import Tabs from 'src/components/core/ReachTabs';
 
-const LoadBalancerDetail = () => {
+interface Props {
+  location: Location;
+}
+
+const LoadBalancerDetailLanding = (props: Props) => {
+  const { location } = props;
+
+  const history = useHistory();
+  const { loadbalancerId } = useParams<{
+    loadbalancerId: string;
+    tab?: 'summary' | 'entrypoints' | 'activity' | 'settings';
+  }>();
+
+  const id = Number(loadbalancerId);
+
+  const tabs = [
+    {
+      title: 'Summary',
+      routeName: `loadbalancers/${id}/summary`,
+    },
+    {
+      title: 'Entry Points',
+      routeName: `loadbalancers/${id}/entrypoints`,
+    },
+    {
+      title: 'Activity Feed',
+      routeName: `loadbalancers/${id}/activity`,
+    },
+    {
+      title: 'Settings',
+      routeName: `loadbalancers/${id}/settings`,
+    },
+  ];
+
+  const [index, setIndex] = React.useState(
+    tabs.findIndex(
+      (tab) =>
+        Boolean(matchPath(tab.routeName, { path: location.pathname })) || 0
+    )
+  );
+
+  const handleTabChange = (index: number) => {
+    setIndex(index);
+    history.push(tabs[index].routeName);
+  };
+
   return (
     <>
-      <DocumentTitleSegment segment="Load Balancers" />
-      TODO: AGLB M3-6818, M3-681, M3-6820, M3-6821: Load Balancer Details
+      {/* TODO: AGLB - Use Load Balancer label */}
+      <DocumentTitleSegment segment={loadbalancerId} />
+      <LandingHeader
+        breadcrumbProps={{
+          pathname: `/loadbalancers/${id}`, // TODO: AGLB - Use Load Balancer label
+          labelOptions: { noCap: true },
+          crumbOverrides: [
+            {
+              position: 1,
+              label: 'Load Balancer',
+            },
+          ],
+        }}
+        docsLabel="Docs"
+        docsLink="" // TODO: AGLB - Add docs link
+      />
+
+      <Tabs index={index} onChange={handleTabChange}>
+        <TabLinkList tabs={tabs} />
+
+        <React.Suspense fallback={<SuspenseLoader />}>
+          <TabPanels>
+            <SafeTabPanel index={0}>
+              <>TODO: AGLB M3-6818: Load Balancer Details Summary </>
+            </SafeTabPanel>
+            <SafeTabPanel index={1}>
+              <>TODO: AGLB M3-6819: Load Balancer Details Entry Points </>
+            </SafeTabPanel>
+            <SafeTabPanel index={2}>
+              <>TODO: AGLB M3-6820: Load Balancer Details Activity Feed </>
+            </SafeTabPanel>
+            <SafeTabPanel index={3}>
+              <>TODO: AGLB M3-6821: Load Balancer Details Settings </>
+            </SafeTabPanel>
+          </TabPanels>
+        </React.Suspense>
+      </Tabs>
     </>
   );
 };
 
-export default LoadBalancerDetail;
+export default LoadBalancerDetailLanding;

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/LoadBalancerDetail.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/LoadBalancerDetail.tsx
@@ -27,19 +27,19 @@ const LoadBalancerDetailLanding = (props: Props) => {
   const tabs = [
     {
       title: 'Summary',
-      routeName: `loadbalancers/${id}/summary`,
+      routeName: `loadbalancer/${id}`,
     },
     {
       title: 'Entry Points',
-      routeName: `loadbalancers/${id}/entrypoints`,
+      routeName: `loadbalancer/${id}/entrypoints`,
     },
     {
       title: 'Activity Feed',
-      routeName: `loadbalancers/${id}/activity`,
+      routeName: `loadbalancer/${id}/activity`,
     },
     {
       title: 'Settings',
-      routeName: `loadbalancers/${id}/settings`,
+      routeName: `loadbalancer/${id}/settings`,
     },
   ];
 

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/LoadBalancerDetail.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerDetail/LoadBalancerDetail.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { DocumentTitleSegment } from 'src/components/DocumentTitle/DocumentTitle';
+
+export const LoadBalancerDetail = () => {
+  return (
+    <>
+      <DocumentTitleSegment segment="Load Balancers" />
+      TODO: AGLB M3-6818, M3-681, M3-6820, M3-6821: Load Balancer Details
+    </>
+  );
+};

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerLanding/LoadBalancerLanding.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerLanding/LoadBalancerLanding.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { matchPath, useHistory, useParams } from 'react-router-dom';
+import { useHistory, useParams } from 'react-router-dom';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle/DocumentTitle';
 import LandingHeader from 'src/components/LandingHeader/LandingHeader';
 import { SafeTabPanel } from 'src/components/SafeTabPanel/SafeTabPanel';
@@ -8,23 +8,16 @@ import { TabLinkList } from 'src/components/TabLinkList/TabLinkList';
 import TabPanels from 'src/components/core/ReachTabPanels';
 import Tabs from 'src/components/core/ReachTabs';
 
-const RouteLanding = React.lazy(() =>
-  import('../Routes/RouteLanding/RouteLanding').then((module) => ({
-    default: module.RouteLanding,
-  }))
+const RouteLanding = React.lazy(
+  () => import('../Routes/RouteLanding/RouteLanding')
 );
-const EntryPointLanding = React.lazy(() =>
-  import('../EntryPoints/EntryPointLanding/EntryPointLanding').then(
-    (module) => ({
-      default: module.EntryPointLanding,
-    })
-  )
+const EntryPointLanding = React.lazy(
+  () => import('../EntryPoints/EntryPointLanding/EntryPointLanding')
 );
 
 const LoadBalancerLanding = () => {
   const history = useHistory();
   const { tab } = useParams<{
-    //action?: 'create'; // TODO: AGLB
     tab?: 'loadbalancers' | 'routes' | 'entrypoints';
   }>();
 
@@ -43,57 +36,32 @@ const LoadBalancerLanding = () => {
     },
   ];
 
-  const getDefaultTabIndex = () => {
-    const tabChoice = tabs.findIndex((tab) =>
-      Boolean(matchPath(tab.routeName, { path: location.pathname }))
-    );
-    if (tabChoice < 0) {
-      // Redirect to the landing page if the path does not exist
-      return 0;
-    } else {
-      return tabChoice;
-    }
-  };
+  const realTabs = ['loadbalancers', 'routes', 'entrypoints'];
 
   const handleTabChange = (index: number) => {
     history.push(tabs[index].routeName);
   };
 
-  // TODO: debug and cleanup
-  // const createButtonText =
-  //   tab === 'routes'
-  //     ? 'Create Route'
-  //     : 'entry-points'
-  //     ? 'Create Service Target'
-  //     : 'Create Load Balancer';
-
   const createButtonText = () => {
-    const tabChoice = location.pathname.substring(
-      location.pathname.lastIndexOf('/') + 1
-    );
     let buttonText = 'Create ';
 
-    switch (tabChoice) {
-      case 'routes':
-        buttonText += 'Route';
-        break;
-      case 'entrypoints':
-        buttonText += 'Service Target';
-        break;
-      default:
-        buttonText += 'Load Balancer';
+    if (tab === 'routes') {
+      buttonText += 'Route';
+    } else if (tab === 'entrypoints') {
+      buttonText += 'Service Target';
+    } else {
+      buttonText += 'Load Balancer';
     }
-
     return buttonText;
   };
 
   const createButtonAction = () => {
     if (tab === 'loadbalancers') {
-      history.replace(`/loadbalancers/create`);
+      history.push(`/loadbalancers/create`);
     } else if (tab === 'routes') {
-      history.replace(`/loadbalancers/routes/create`);
+      history.push(`/loadbalancers/routes/create`);
     } else if (tab === 'entrypoints') {
-      history.replace(`/loadbalancers/entrypoints/create`);
+      history.push(`/loadbalancers/entrypoints/create`);
     }
   };
 
@@ -105,11 +73,18 @@ const LoadBalancerLanding = () => {
         createButtonText={createButtonText()}
         docsLink="" // TODO: AGLB
         entity="Akamai Global Load Balancers"
-        onButtonClick={createButtonAction} // TODO: AGLB
+        onButtonClick={createButtonAction}
         removeCrumbX={1}
         title="Akamai Global Load Balancers"
       />
-      <Tabs index={getDefaultTabIndex()} onChange={handleTabChange}>
+      <Tabs
+        index={
+          realTabs.findIndex((t) => t === tab) !== -1
+            ? realTabs.findIndex((t) => t === tab)
+            : 0
+        }
+        onChange={handleTabChange}
+      >
         <TabLinkList tabs={tabs} />
         <React.Suspense fallback={<SuspenseLoader />}>
           <TabPanels>

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerLanding/LoadBalancerLanding.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerLanding/LoadBalancerLanding.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useHistory, useParams } from 'react-router-dom';
+import { matchPath, useHistory, useParams } from 'react-router-dom';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle/DocumentTitle';
 import LandingHeader from 'src/components/LandingHeader/LandingHeader';
 import { SafeTabPanel } from 'src/components/SafeTabPanel/SafeTabPanel';
@@ -18,7 +18,7 @@ const EntryPointLanding = React.lazy(
 const LoadBalancerLanding = () => {
   const history = useHistory();
   const { tab } = useParams<{
-    tab?: 'loadbalancers' | 'routes' | 'entrypoints';
+    tab?: 'routes' | 'entrypoints';
   }>();
 
   const tabs = [
@@ -36,32 +36,33 @@ const LoadBalancerLanding = () => {
     },
   ];
 
-  const realTabs = ['loadbalancers', 'routes', 'entrypoints'];
+  const [index, setIndex] = React.useState(
+    tabs.findIndex(
+      (tab) =>
+        Boolean(matchPath(tab.routeName, { path: location.pathname })) || 0
+    )
+  );
 
   const handleTabChange = (index: number) => {
+    setIndex(index);
     history.push(tabs[index].routeName);
   };
 
-  const createButtonText = () => {
-    let buttonText = 'Create ';
-
-    if (tab === 'routes') {
-      buttonText += 'Route';
-    } else if (tab === 'entrypoints') {
-      buttonText += 'Service Target';
-    } else {
-      buttonText += 'Load Balancer';
-    }
-    return buttonText;
-  };
+  const createButtonText = tab
+    ? tab === 'routes'
+      ? 'Create Route'
+      : tab === 'entrypoints'
+      ? 'Create Service Target'
+      : 'Create Load Balancer'
+    : 'Create Load Balancer';
 
   const createButtonAction = () => {
-    if (tab === 'loadbalancers') {
-      history.push(`/loadbalancers/create`);
-    } else if (tab === 'routes') {
+    if (tab === 'routes') {
       history.push(`/loadbalancers/routes/create`);
     } else if (tab === 'entrypoints') {
       history.push(`/loadbalancers/entrypoints/create`);
+    } else {
+      history.push(`/loadbalancers/create`);
     }
   };
 
@@ -70,21 +71,15 @@ const LoadBalancerLanding = () => {
       <DocumentTitleSegment segment="Akamai Global Load Balancers" />
       <LandingHeader
         breadcrumbProps={{ pathname: '/loadbalancers' }}
-        createButtonText={createButtonText()}
-        docsLink="" // TODO: AGLB
+        createButtonText={createButtonText}
+        docsLabel="Docs"
+        docsLink="" // TODO: AGLB -  Add docs link
         entity="Akamai Global Load Balancers"
         onButtonClick={createButtonAction}
         removeCrumbX={1}
         title="Akamai Global Load Balancers"
       />
-      <Tabs
-        index={
-          realTabs.findIndex((t) => t === tab) !== -1
-            ? realTabs.findIndex((t) => t === tab)
-            : 0
-        }
-        onChange={handleTabChange}
-      >
+      <Tabs index={index} onChange={handleTabChange}>
         <TabLinkList tabs={tabs} />
         <React.Suspense fallback={<SuspenseLoader />}>
           <TabPanels>

--- a/packages/manager/src/features/LoadBalancers/LoadBalancerLanding/LoadBalancerLanding.tsx
+++ b/packages/manager/src/features/LoadBalancers/LoadBalancerLanding/LoadBalancerLanding.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { matchPath, useHistory, useParams } from 'react-router-dom';
+import { DocumentTitleSegment } from 'src/components/DocumentTitle/DocumentTitle';
+import LandingHeader from 'src/components/LandingHeader/LandingHeader';
+import { SafeTabPanel } from 'src/components/SafeTabPanel/SafeTabPanel';
+import SuspenseLoader from 'src/components/SuspenseLoader/SuspenseLoader';
+import { TabLinkList } from 'src/components/TabLinkList/TabLinkList';
+import TabPanels from 'src/components/core/ReachTabPanels';
+import Tabs from 'src/components/core/ReachTabs';
+
+const RouteLanding = React.lazy(() =>
+  import('../Routes/RouteLanding/RouteLanding').then((module) => ({
+    default: module.RouteLanding,
+  }))
+);
+const EntryPointLanding = React.lazy(() =>
+  import('../EntryPoints/EntryPointLanding/EntryPointLanding').then(
+    (module) => ({
+      default: module.EntryPointLanding,
+    })
+  )
+);
+
+const LoadBalancerLanding = () => {
+  const history = useHistory();
+  const { tab } = useParams<{
+    //action?: 'create'; // TODO: AGLB
+    tab?: 'loadbalancers' | 'routes' | 'entrypoints';
+  }>();
+
+  const tabs = [
+    {
+      title: 'Load Balancers',
+      routeName: `/loadbalancers`,
+    },
+    {
+      title: 'Routes',
+      routeName: `/loadbalancers/routes`,
+    },
+    {
+      title: 'Service Targets',
+      routeName: `/loadbalancers/entrypoints`,
+    },
+  ];
+
+  const getDefaultTabIndex = () => {
+    const tabChoice = tabs.findIndex((tab) =>
+      Boolean(matchPath(tab.routeName, { path: location.pathname }))
+    );
+    if (tabChoice < 0) {
+      // Redirect to the landing page if the path does not exist
+      return 0;
+    } else {
+      return tabChoice;
+    }
+  };
+
+  const handleTabChange = (index: number) => {
+    history.push(tabs[index].routeName);
+  };
+
+  // TODO: debug and cleanup
+  // const createButtonText =
+  //   tab === 'routes'
+  //     ? 'Create Route'
+  //     : 'entry-points'
+  //     ? 'Create Service Target'
+  //     : 'Create Load Balancer';
+
+  const createButtonText = () => {
+    const tabChoice = location.pathname.substring(
+      location.pathname.lastIndexOf('/') + 1
+    );
+    let buttonText = 'Create ';
+
+    switch (tabChoice) {
+      case 'routes':
+        buttonText += 'Route';
+        break;
+      case 'entrypoints':
+        buttonText += 'Service Target';
+        break;
+      default:
+        buttonText += 'Load Balancer';
+    }
+
+    return buttonText;
+  };
+
+  const createButtonAction = () => {
+    if (tab === 'loadbalancers') {
+      history.replace(`/loadbalancers/create`);
+    } else if (tab === 'routes') {
+      history.replace(`/loadbalancers/routes/create`);
+    } else if (tab === 'entrypoints') {
+      history.replace(`/loadbalancers/entrypoints/create`);
+    }
+  };
+
+  return (
+    <>
+      <DocumentTitleSegment segment="Akamai Global Load Balancers" />
+      <LandingHeader
+        breadcrumbProps={{ pathname: '/loadbalancers' }}
+        createButtonText={createButtonText()}
+        docsLink="" // TODO: AGLB
+        entity="Akamai Global Load Balancers"
+        onButtonClick={createButtonAction} // TODO: AGLB
+        removeCrumbX={1}
+        title="Akamai Global Load Balancers"
+      />
+      <Tabs index={getDefaultTabIndex()} onChange={handleTabChange}>
+        <TabLinkList tabs={tabs} />
+        <React.Suspense fallback={<SuspenseLoader />}>
+          <TabPanels>
+            <SafeTabPanel index={0}>
+              <>TODO: AGLB M3-6807: Load Balancer Landing </>
+            </SafeTabPanel>
+            <SafeTabPanel index={1}>
+              <RouteLanding />
+            </SafeTabPanel>
+            <SafeTabPanel index={2}>
+              <EntryPointLanding />
+            </SafeTabPanel>
+          </TabPanels>
+        </React.Suspense>
+      </Tabs>
+    </>
+  );
+};
+
+export default LoadBalancerLanding;

--- a/packages/manager/src/features/LoadBalancers/Routes/RouteCreate/RouteCreate.tsx
+++ b/packages/manager/src/features/LoadBalancers/Routes/RouteCreate/RouteCreate.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle/DocumentTitle';
 
-export const RouteCreate = () => {
+const RouteCreate = () => {
   return (
     <>
       <DocumentTitleSegment segment="Routes" />
@@ -9,3 +9,5 @@ export const RouteCreate = () => {
     </>
   );
 };
+
+export default RouteCreate;

--- a/packages/manager/src/features/LoadBalancers/Routes/RouteCreate/RouteCreate.tsx
+++ b/packages/manager/src/features/LoadBalancers/Routes/RouteCreate/RouteCreate.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { DocumentTitleSegment } from 'src/components/DocumentTitle/DocumentTitle';
+
+export const RouteCreate = () => {
+  return (
+    <>
+      <DocumentTitleSegment segment="Routes" />
+      TODO: AGLB M3-6816: Routes Create
+    </>
+  );
+};

--- a/packages/manager/src/features/LoadBalancers/Routes/RouteLanding/RouteLanding.tsx
+++ b/packages/manager/src/features/LoadBalancers/Routes/RouteLanding/RouteLanding.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle/DocumentTitle';
 
-export const RouteLanding = () => {
+const RouteLanding = () => {
   return (
     <>
       <DocumentTitleSegment segment="Routes" />
@@ -9,3 +9,5 @@ export const RouteLanding = () => {
     </>
   );
 };
+
+export default RouteLanding;

--- a/packages/manager/src/features/LoadBalancers/Routes/RouteLanding/RouteLanding.tsx
+++ b/packages/manager/src/features/LoadBalancers/Routes/RouteLanding/RouteLanding.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { DocumentTitleSegment } from 'src/components/DocumentTitle/DocumentTitle';
+
+export const RouteLanding = () => {
+  return (
+    <>
+      <DocumentTitleSegment segment="Routes" />
+      TODO: AGLB M3-6809: Routes Landing
+    </>
+  );
+};

--- a/packages/manager/src/features/LoadBalancers/index.tsx
+++ b/packages/manager/src/features/LoadBalancers/index.tsx
@@ -28,7 +28,10 @@ const LoadBalancer = () => {
           path="/loadbalancers/entrypoints/create"
         />
         <Route component={LoadBalancerCreate} path="/loadbalancers/create" />
-        <Route component={LoadBalancerDetail} path="/loadbalancer/:id/:tab?" />
+        <Route
+          component={LoadBalancerDetail}
+          path="/loadbalancer/:loadbalancerId/:tab?"
+        />
         <Route component={LoadBalancerLanding} path="/loadbalancers/:tab?" />
       </Switch>
     </React.Suspense>

--- a/packages/manager/src/features/LoadBalancers/index.tsx
+++ b/packages/manager/src/features/LoadBalancers/index.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { Route, Switch } from 'react-router-dom';
-import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import { Route, RouteComponentProps, Switch } from 'react-router-dom';
 import SuspenseLoader from 'src/components/SuspenseLoader';
 
 const LoadBalancerLanding = React.lazy(
@@ -19,10 +18,13 @@ const RouteCreate = React.lazy(
   () => import('./Routes/RouteCreate/RouteCreate')
 );
 
-const LoadBalancer = () => {
+type CombinedProps = RouteComponentProps;
+
+const LoadBalancer = (props: CombinedProps) => {
+  const path = props.match.path;
+
   return (
     <React.Suspense fallback={<SuspenseLoader />}>
-      <DocumentTitleSegment segment="LoadBalancers" />
       <Switch>
         <Route component={RouteCreate} path="/loadbalancers/routes/create" />
         <Route
@@ -30,8 +32,8 @@ const LoadBalancer = () => {
           path="/loadbalancers/entrypoints/create"
         />
         <Route component={LoadBalancerCreate} path="/loadbalancers/create" />
-        <Route component={LoadBalancerDetail} path="/loadbalancers/:id/:tab" />
-        <Route component={LoadBalancerLanding} path={'/loadbalancers/:tab?'} />
+        <Route component={LoadBalancerDetail} path={`${path}/:id/:tab`} />
+        <Route component={LoadBalancerLanding} path="/loadbalancers/:tab?" />
       </Switch>
     </React.Suspense>
   );

--- a/packages/manager/src/features/LoadBalancers/index.tsx
+++ b/packages/manager/src/features/LoadBalancers/index.tsx
@@ -1,2 +1,40 @@
-import LoadBalancers from './LoadBalancerLanding/LoadBalancerLanding';
-export default LoadBalancers;
+import * as React from 'react';
+import { Route, Switch } from 'react-router-dom';
+import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import SuspenseLoader from 'src/components/SuspenseLoader';
+
+const LoadBalancerLanding = React.lazy(
+  () => import('./LoadBalancerLanding/LoadBalancerLanding')
+);
+const LoadBalancerDetail = React.lazy(
+  () => import('./LoadBalancerDetail/LoadBalancerDetail')
+);
+const LoadBalancerCreate = React.lazy(
+  () => import('./LoadBalancerCreate/LoadBalancerCreate')
+);
+const EntryPointCreate = React.lazy(
+  () => import('./EntryPoints/EntryPointCreate/EntryPointCreate')
+);
+const RouteCreate = React.lazy(
+  () => import('./Routes/RouteCreate/RouteCreate')
+);
+
+const LoadBalancer = () => {
+  return (
+    <React.Suspense fallback={<SuspenseLoader />}>
+      <DocumentTitleSegment segment="LoadBalancers" />
+      <Switch>
+        <Route component={RouteCreate} path="/loadbalancers/routes/create" />
+        <Route
+          component={EntryPointCreate}
+          path="/loadbalancers/entrypoints/create"
+        />
+        <Route component={LoadBalancerCreate} path="/loadbalancers/create" />
+        <Route component={LoadBalancerDetail} path="/loadbalancers/:id/:tab" />
+        <Route component={LoadBalancerLanding} path={'/loadbalancers/:tab?'} />
+      </Switch>
+    </React.Suspense>
+  );
+};
+
+export default LoadBalancer;

--- a/packages/manager/src/features/LoadBalancers/index.tsx
+++ b/packages/manager/src/features/LoadBalancers/index.tsx
@@ -1,0 +1,2 @@
+import LoadBalancers from './LoadBalancerLanding/LoadBalancerLanding';
+export default LoadBalancers;

--- a/packages/manager/src/features/LoadBalancers/index.tsx
+++ b/packages/manager/src/features/LoadBalancers/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Route, RouteComponentProps, Switch } from 'react-router-dom';
+import { Route, Switch } from 'react-router-dom';
 import SuspenseLoader from 'src/components/SuspenseLoader';
 
 const LoadBalancerLanding = React.lazy(
@@ -18,11 +18,7 @@ const RouteCreate = React.lazy(
   () => import('./Routes/RouteCreate/RouteCreate')
 );
 
-type CombinedProps = RouteComponentProps;
-
-const LoadBalancer = (props: CombinedProps) => {
-  const path = props.match.path;
-
+const LoadBalancer = () => {
   return (
     <React.Suspense fallback={<SuspenseLoader />}>
       <Switch>
@@ -32,7 +28,7 @@ const LoadBalancer = (props: CombinedProps) => {
           path="/loadbalancers/entrypoints/create"
         />
         <Route component={LoadBalancerCreate} path="/loadbalancers/create" />
-        <Route component={LoadBalancerDetail} path={`${path}/:id/:tab`} />
+        <Route component={LoadBalancerDetail} path="/loadbalancer/:id/:tab?" />
         <Route component={LoadBalancerLanding} path="/loadbalancers/:tab?" />
       </Switch>
     </React.Suspense>


### PR DESCRIPTION
## Description 📝
Create basic files, folders, and routing for AGLB routes.

Initial routes in include:

Load Balancer Landing - `/loadbalancers`
Load Balancer Create - `/loadbalancers/create`
Load Balancer Details - `/loadbalancer/:id/:tab`
Route Landing - `/loadbalancers/routes`
Route Create - `/loadbalancers/routes/create`
Entry Point Landing - `/loadbalancers/entrypoints`
Entry Point Create - `/loadbalancers/entrypoints/create`

See self-review for a couple places I request feedback from the team.

## Preview 📷
Akamai Global Load Balancer Landing:
![Screenshot 2023-07-10 at 12 27 04 PM](https://github.com/linode/manager/assets/114685994/181ceac8-77dd-4996-af7f-1e577b941921)

Load Balancer Details Landing:
![Screenshot 2023-07-11 at 7 17 55 AM](https://github.com/linode/manager/assets/114685994/b021e403-b726-41af-b571-5a6af2b6d3cc)

## How to test 🧪
**How to setup test environment?**
Check out this branch.
**How to verify changes?**
Confirm that you can navigate to the following URLs:

Load Balancer Landing:
- http://localhost:3000/loadbalancers (url when the 'Load Balancers' tab is clicked) 
- http://localhost:3000/loadbalancers/routes (url when the 'Routes' tab is clicked) 
- http://localhost:3000/loadbalancers/entrypoints (url when the 'Service Targets' tab is clicked) 
- http://localhost:3000/loadbalancers/create (url when the 'Create Load Balancer' button is clicked from the Load Balancers tab) 
- http://localhost:3000/loadbalancers/routes/create (url when the 'Create Route' button is clicked from the Routes tab) 
- http://localhost:3000/loadbalancers/entrypoints/create (url when the 'Create Service Target' button is clicked from the Service Target tab) 

Load Balancer Details (use the URL bar for these; `1` is just an example id):
- http://localhost:3000/loadbalancer/1 (url when the 'Summary' tab is clicked) 
- http://localhost:3000/loadbalancer/1/entrypoints (url when the 'Entry Points' tab is clicked) 
- http://localhost:3000/loadbalancer/1/activity (url when the 'Activity Feed' tab is clicked) 
- http://localhost:3000/loadbalancer/settings (url when the 'Settings' tab is clicked) 

Also verify the structure of the folders/files makes sense. I followed other feature folders for this, but they weren't always consistent.