### PR TITLE
fix: minor css regression account > billing history dropdowns

### DIFF
--- a/packages/manager/src/components/EnhancedSelect/Select.tsx
+++ b/packages/manager/src/components/EnhancedSelect/Select.tsx
@@ -216,7 +216,7 @@ const Select = <
       filterOption={filterOption}
       isMulti={isMulti}
       classes={classes}
-      className={classNames(className, classes.root)}
+      className={classNames(classes.root, className)}
       classNamePrefix="react-select"
       inputId={
         inputId


### PR DESCRIPTION
## Description 📝
Fixed larger than normal gap between selects

## Major Changes 🔄
- Changed order to apply overrides properly

## Preview 📷

| Before  | After   |
| ------- | ------- |
| <img width="577" alt="Screenshot 2023-07-10 at 2 52 57 PM" src="https://github.com/linode/manager/assets/125309814/0bb63d6b-1dc4-4c3f-bfaf-78ac69221ef0"> | <img width="572" alt="Screenshot 2023-07-10 at 2 52 51 PM" src="https://github.com/linode/manager/assets/125309814/a07da4e7-a06c-4a7f-86a5-2abb9510069c"> |

## How to test 🧪
Go to `/account/billing`