### PR TITLE
Feat: [M3-6809] - AGLB Routes Landing Page (Skeleton)

### DIFF
--- a/packages/api-v4/src/aglb/routes.ts
+++ b/packages/api-v4/src/aglb/routes.ts
@@ -1,5 +1,11 @@
-import Request, { setData, setMethod, setURL } from '../request';
-import { ResourcePage } from 'src/types';
+import Request, {
+  setData,
+  setMethod,
+  setParams,
+  setURL,
+  setXFilter,
+} from '../request';
+import { Filter, Params, ResourcePage } from 'src/types';
 import { BETA_API_ROOT } from 'src/constants';
 import type { Route, RoutePayload } from './types';
 
@@ -8,10 +14,12 @@ import type { Route, RoutePayload } from './types';
  *
  * Returns a paginated list of Akamai Global Load Balancer routes
  */
-export const getRoutes = () =>
+export const getRoutes = (params: Params, filter?: Filter) =>
   Request<ResourcePage<Route>>(
     setURL(`${BETA_API_ROOT}/aglb/routes`),
-    setMethod('GET')
+    setMethod('GET'),
+    setParams(params),
+    setXFilter(filter)
   );
 
 /**

--- a/packages/manager/src/factories/aglb.ts
+++ b/packages/manager/src/factories/aglb.ts
@@ -149,7 +149,7 @@ export const updateLoadbalancerFactory = Factory.Sync.makeFactory<UpdateLoadbala
 
 export const getRouteFactory = Factory.Sync.makeFactory<Route2>({
   id: Factory.each((i) => i),
-  label: 'images-route',
+  label: Factory.each((i) => `route-${i}`),
   rules: [
     {
       match_condition: {

--- a/packages/manager/src/features/LoadBalancers/Routes/RouteActionMenu.tsx
+++ b/packages/manager/src/features/LoadBalancers/Routes/RouteActionMenu.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import ActionMenu, { Action } from 'src/components/ActionMenu';
+import type { Route } from '@linode/api-v4/lib/aglb/types';
+
+export interface RouteActionHandlers {
+  onEdit: (route: Route) => void;
+  onDelete: (route: Route) => void;
+}
+
+interface Props extends RouteActionHandlers {
+  route: Route;
+}
+
+interface ExtendedAction extends Action {
+  className?: string;
+}
+
+type CombinedProps = Props & RouteActionHandlers;
+
+export const RouteActionMenu = React.memo((props: CombinedProps) => {
+  const { route, onEdit, onDelete } = props;
+
+  const actions = [
+    {
+      title: 'Edit',
+      onClick: () => {
+        onEdit(route);
+      },
+    },
+    {
+      title: 'Delete',
+      onClick: () => {
+        onDelete(route);
+      },
+    },
+  ] as ExtendedAction[];
+
+  return (
+    <ActionMenu
+      actionsList={actions}
+      ariaLabel={`Action menu for Route ${route.label}`}
+    />
+  );
+});

--- a/packages/manager/src/features/LoadBalancers/Routes/RouteLanding/RouteLanding.test.tsx
+++ b/packages/manager/src/features/LoadBalancers/Routes/RouteLanding/RouteLanding.test.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import RouteLanding from './RouteLanding';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+import { getRouteFactory } from 'src/factories/aglb';
+
+const routes = getRouteFactory.buildList(4);
+let isLoading = false;
+let error = false;
+
+// Mock the useRoutesQuery hook to return routes data
+jest.mock('src/queries/aglb/routes', () => ({
+  useRoutesQuery: () => ({
+    data: {
+      data: routes,
+    },
+    error,
+    isLoading,
+  }),
+}));
+
+describe('Domains Landing', () => {
+  it('should initially render a loading state', () => {
+    isLoading = true;
+
+    const { getByTestId } = renderWithTheme(<RouteLanding />);
+    expect(getByTestId('circle-progress')).toBeInTheDocument();
+  });
+
+  it('should render an error state', () => {
+    isLoading = false;
+    error = true;
+
+    const { getByText } = renderWithTheme(<RouteLanding />);
+    expect(
+      getByText(
+        'There was an error retrieving your domains. Please reload and try again.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('should render a table of routes', () => {
+    isLoading = false;
+    error = false;
+
+    const { getByTestId } = renderWithTheme(<RouteLanding />);
+    expect(getByTestId('aglb-route-landing-table')).toBeInTheDocument();
+  });
+
+  it('should render a table with the correct number of rows', () => {
+    isLoading = false;
+    error = false;
+
+    const { getAllByTestId } = renderWithTheme(<RouteLanding />);
+    expect(getAllByTestId('aglb-route-landing-table-row')).toHaveLength(
+      routes.length
+    );
+  });
+
+  it('should render a table with the correct number of columns', () => {
+    isLoading = false;
+    error = false;
+
+    const { getAllByTestId } = renderWithTheme(<RouteLanding />);
+    expect(
+      getAllByTestId('aglb-route-landing-table-row')[0].children
+    ).toHaveLength(4);
+  });
+});

--- a/packages/manager/src/features/LoadBalancers/Routes/RouteLanding/RouteLanding.tsx
+++ b/packages/manager/src/features/LoadBalancers/Routes/RouteLanding/RouteLanding.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { CircleProgress } from 'src/components/CircleProgress';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle/DocumentTitle';
 import { ErrorState } from 'src/components/ErrorState/ErrorState';
+import { PaginationFooter } from 'src/components/PaginationFooter/PaginationFooter';
 import { RouteTableRow } from '../RouteTableRow';
 import { Table } from 'src/components/Table';
 import { TableHead } from 'src/components/TableHead';
@@ -32,6 +33,7 @@ const RouteLanding = () => {
   const { data: routes, error, isLoading } = useRoutesQuery(
     {
       page: pagination.page,
+      page_size: pagination.pageSize,
     },
     filter
   );
@@ -102,6 +104,14 @@ const RouteLanding = () => {
           })}
         </TableBody>
       </Table>
+      <PaginationFooter
+        count={routes?.results || 0}
+        handlePageChange={pagination.handlePageChange}
+        handleSizeChange={pagination.handlePageSizeChange}
+        page={pagination.page}
+        pageSize={pagination.pageSize}
+        eventCategory="Routes Table"
+      />
     </>
   );
 };

--- a/packages/manager/src/features/LoadBalancers/Routes/RouteLanding/RouteLanding.tsx
+++ b/packages/manager/src/features/LoadBalancers/Routes/RouteLanding/RouteLanding.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
+import { CircleProgress } from 'src/components/CircleProgress';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle/DocumentTitle';
+import { ErrorState } from 'src/components/ErrorState/ErrorState';
+import { RouteTableRow } from '../RouteTableRow';
 import { Table } from 'src/components/Table';
 import { TableHead } from 'src/components/TableHead';
 import { TableRow } from 'src/components/TableRow';
@@ -33,7 +36,25 @@ const RouteLanding = () => {
     filter
   );
 
-  console.log('routes', routes);
+  const onEdit = (route: Route) => {
+    // TODO: AGLB - does this trigger an edit modal? We need UX
+    return () => null;
+  };
+
+  const onDelete = (route: Route) => {
+    // TODO: AGLB - does this trigger a delete modal with confirmation? We need UX
+    return () => null;
+  };
+
+  if (isLoading) {
+    return <CircleProgress />;
+  }
+
+  if (error) {
+    return (
+      <ErrorState errorText="There was an error retrieving your domains. Please reload and try again." />
+    );
+  }
 
   return (
     <>
@@ -50,33 +71,35 @@ const RouteLanding = () => {
               Label
             </TableSortCell>
             <TableSortCell
-              active={orderBy === 'status'}
+              active={orderBy === 'Match Type'}
               direction={order}
-              label="status"
+              label="Match Type"
               handleClick={handleOrderChange}
             >
               Match Type
+            </TableSortCell>
+            <TableSortCell
+              active={orderBy === 'Service Targets'}
+              direction={order}
+              label="Service Targets"
+              handleClick={handleOrderChange}
+            >
+              Service Targets
             </TableSortCell>
             <TableCell></TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
-          {routes?.data.map((route: Route) => (
-            <TableRow key={route.id} data-qa-route-cell={route.id}>
-              <TableCell parentColumn="Label">{route.label}</TableCell>
-              <TableCell parentColumn="Match Type">match type</TableCell>
-              <TableCell>
-                {/* <ActionMenu
-                  routeId={route.id}
-                  routeType={route.type}
-                  routeStatus={route.status}
-                  routeDomain={route.domain}
-                  routePath={route.path}
-                  routeServiceId={route.id}
-                /> */}
-              </TableCell>
-            </TableRow>
-          ))}
+          {routes?.data.map((route: Route) => {
+            return (
+              <RouteTableRow
+                key={`route-tablerow-${route.id}`}
+                route={route}
+                onDelete={onDelete}
+                onEdit={onEdit}
+              />
+            );
+          })}
         </TableBody>
       </Table>
     </>

--- a/packages/manager/src/features/LoadBalancers/Routes/RouteLanding/RouteLanding.tsx
+++ b/packages/manager/src/features/LoadBalancers/Routes/RouteLanding/RouteLanding.tsx
@@ -59,7 +59,7 @@ const RouteLanding = () => {
   return (
     <>
       <DocumentTitleSegment segment="Routes" />
-      <Table>
+      <Table data-testid="aglb-route-landing-table">
         <TableHead>
           <TableRow>
             <TableSortCell

--- a/packages/manager/src/features/LoadBalancers/Routes/RouteLanding/RouteLanding.tsx
+++ b/packages/manager/src/features/LoadBalancers/Routes/RouteLanding/RouteLanding.tsx
@@ -1,11 +1,67 @@
 import * as React from 'react';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle/DocumentTitle';
+import { Table } from 'src/components/Table';
+import { TableHead } from 'src/components/TableHead';
+import { TableRow } from 'src/components/TableRow';
+import { TableBody } from 'src/components/TableBody';
+import { TableSortCell } from 'src/components/TableSortCell';
+import { TableCell } from 'src/components/TableCell';
+import { useRouteQuery } from 'src/queries/aglb/routes';
 
 const RouteLanding = () => {
+  const { data: routes } = useRouteQuery();
+
+  console.log('routes', routes);
+
   return (
     <>
       <DocumentTitleSegment segment="Routes" />
-      TODO: AGLB M3-6809: Routes Landing
+      {/* <Table>
+        <TableHead>
+          <TableRow>
+            <TableSortCell
+              active={orderBy === 'domain'}
+              direction={order}
+              label="domain"
+              handleClick={handleOrderChange}
+            >
+              Domain
+            </TableSortCell>
+            <TableSortCell
+              active={orderBy === 'status'}
+              direction={order}
+              label="status"
+              handleClick={handleOrderChange}
+            >
+              Status
+            </TableSortCell>
+            <Hidden smDown>
+              <TableSortCell
+                active={orderBy === 'type'}
+                direction={order}
+                label="type"
+                handleClick={handleOrderChange}
+              >
+                Type
+              </TableSortCell>
+              <TableSortCell
+                active={orderBy === 'updated'}
+                direction={order}
+                label="updated"
+                handleClick={handleOrderChange}
+              >
+                Last Modified
+              </TableSortCell>
+            </Hidden>
+            <TableCell></TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {domains?.data.map((domain: Domain) => (
+            <DomainRow key={domain.id} domain={domain} {...handlers} />
+          ))}
+        </TableBody>
+      </Table> */}
     </>
   );
 };

--- a/packages/manager/src/features/LoadBalancers/Routes/RouteLanding/RouteLanding.tsx
+++ b/packages/manager/src/features/LoadBalancers/Routes/RouteLanding/RouteLanding.tsx
@@ -6,26 +6,48 @@ import { TableRow } from 'src/components/TableRow';
 import { TableBody } from 'src/components/TableBody';
 import { TableSortCell } from 'src/components/TableSortCell';
 import { TableCell } from 'src/components/TableCell';
-import { useRouteQuery } from 'src/queries/aglb/routes';
+import { useOrder } from 'src/hooks/useOrder';
+import { usePagination } from 'src/hooks/usePagination';
+import { useRoutesQuery } from 'src/queries/aglb/routes';
+import type { Route } from '@linode/api-v4';
+
+const PREFERENCE_KEY = 'aglb-routes';
 
 const RouteLanding = () => {
-  const { data: routes } = useRouteQuery();
+  const pagination = usePagination(1, PREFERENCE_KEY);
+  const { order, orderBy, handleOrderChange } = useOrder(
+    {
+      orderBy: 'label',
+      order: 'asc',
+    },
+    `${PREFERENCE_KEY}-order`
+  );
+  const filter = {
+    ['+order_by']: orderBy,
+    ['+order']: order,
+  };
+  const { data: routes, error, isLoading } = useRoutesQuery(
+    {
+      page: pagination.page,
+    },
+    filter
+  );
 
   console.log('routes', routes);
 
   return (
     <>
       <DocumentTitleSegment segment="Routes" />
-      {/* <Table>
+      <Table>
         <TableHead>
           <TableRow>
             <TableSortCell
-              active={orderBy === 'domain'}
+              active={orderBy === 'label'}
               direction={order}
-              label="domain"
+              label="label"
               handleClick={handleOrderChange}
             >
-              Domain
+              Label
             </TableSortCell>
             <TableSortCell
               active={orderBy === 'status'}
@@ -33,35 +55,30 @@ const RouteLanding = () => {
               label="status"
               handleClick={handleOrderChange}
             >
-              Status
+              Match Type
             </TableSortCell>
-            <Hidden smDown>
-              <TableSortCell
-                active={orderBy === 'type'}
-                direction={order}
-                label="type"
-                handleClick={handleOrderChange}
-              >
-                Type
-              </TableSortCell>
-              <TableSortCell
-                active={orderBy === 'updated'}
-                direction={order}
-                label="updated"
-                handleClick={handleOrderChange}
-              >
-                Last Modified
-              </TableSortCell>
-            </Hidden>
             <TableCell></TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
-          {domains?.data.map((domain: Domain) => (
-            <DomainRow key={domain.id} domain={domain} {...handlers} />
+          {routes?.data.map((route: Route) => (
+            <TableRow key={route.id} data-qa-route-cell={route.id}>
+              <TableCell parentColumn="Label">{route.label}</TableCell>
+              <TableCell parentColumn="Match Type">match type</TableCell>
+              <TableCell>
+                {/* <ActionMenu
+                  routeId={route.id}
+                  routeType={route.type}
+                  routeStatus={route.status}
+                  routeDomain={route.domain}
+                  routePath={route.path}
+                  routeServiceId={route.id}
+                /> */}
+              </TableCell>
+            </TableRow>
           ))}
         </TableBody>
-      </Table> */}
+      </Table>
     </>
   );
 };

--- a/packages/manager/src/features/LoadBalancers/Routes/RouteTableRow.tsx
+++ b/packages/manager/src/features/LoadBalancers/Routes/RouteTableRow.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { TableCell } from 'src/components/TableCell';
+import { TableRow } from 'src/components/TableRow';
+import { RouteActionMenu } from './RouteActionMenu';
+import type { RouteActionHandlers } from './RouteActionMenu';
+import type { Route } from '@linode/api-v4/lib/aglb/types';
+
+interface Props {
+  route: Route;
+}
+
+type RouteTableRowProps = Props & RouteActionHandlers;
+
+export const RouteTableRow = React.memo((props: RouteTableRowProps) => {
+  const { route, onDelete, onEdit } = props;
+
+  return (
+    <TableRow key={route.id} data-qa-route-cell={route.id}>
+      <TableCell parentColumn="Label">{route.label}</TableCell>
+      {/* TODO: AGLB - match type is not currently returned anywhere in the API */}
+      <TableCell parentColumn="Match Type">TBD</TableCell>
+      <TableCell parentColumn="Service Targets">
+        {/* TODO: AGLB - it is still unclear what will end up in this column */}
+      </TableCell>
+      <TableCell actionCell>
+        <RouteActionMenu route={route} onDelete={onDelete} onEdit={onEdit} />
+      </TableCell>
+    </TableRow>
+  );
+});

--- a/packages/manager/src/features/LoadBalancers/Routes/RouteTableRow.tsx
+++ b/packages/manager/src/features/LoadBalancers/Routes/RouteTableRow.tsx
@@ -15,12 +15,20 @@ export const RouteTableRow = React.memo((props: RouteTableRowProps) => {
   const { route, onDelete, onEdit } = props;
 
   return (
-    <TableRow key={route.id} data-qa-route-cell={route.id}>
+    <TableRow
+      key={route.id}
+      data-qa-route-cell={route.id}
+      data-testid="aglb-route-landing-table-row"
+    >
       <TableCell parentColumn="Label">{route.label}</TableCell>
-      {/* TODO: AGLB - match type is not currently returned anywhere in the API */}
-      <TableCell parentColumn="Match Type">TBD</TableCell>
+
+      <TableCell parentColumn="Match Type">
+        {/* TODO: AGLB - match type is not currently returned anywhere in the API */}
+        TBD
+      </TableCell>
       <TableCell parentColumn="Service Targets">
         {/* TODO: AGLB - it is still unclear what will end up in this column */}
+        TBD
       </TableCell>
       <TableCell actionCell>
         <RouteActionMenu route={route} onDelete={onDelete} onEdit={onEdit} />

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -334,7 +334,7 @@ const aglb = [
   }),
   // Routes
   rest.get('*/aglb/routes', (req, res, ctx) => {
-    const routes = getRouteFactory.buildList(4);
+    const routes = getRouteFactory.buildList(110);
     return res(ctx.json(makeResourcePage(routes)));
   }),
   rest.post('*/aglb/routes', (req, res, ctx) => {

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -334,7 +334,8 @@ const aglb = [
   }),
   // Routes
   rest.get('*/aglb/routes', (req, res, ctx) => {
-    return res(ctx.json(getRouteFactory.buildList(4)));
+    const routes = getRouteFactory.buildList(4);
+    return res(ctx.json(makeResourcePage(routes)));
   }),
   rest.post('*/aglb/routes', (req, res, ctx) => {
     return res(ctx.json(createRouteFactory.buildList(4)));

--- a/packages/manager/src/mocks/serverHandlers.ts
+++ b/packages/manager/src/mocks/serverHandlers.ts
@@ -334,7 +334,7 @@ const aglb = [
   }),
   // Routes
   rest.get('*/aglb/routes', (req, res, ctx) => {
-    const routes = getRouteFactory.buildList(110);
+    const routes = getRouteFactory.buildList(4);
     return res(ctx.json(makeResourcePage(routes)));
   }),
   rest.post('*/aglb/routes', (req, res, ctx) => {

--- a/packages/manager/src/queries/aglb/routes.ts
+++ b/packages/manager/src/queries/aglb/routes.ts
@@ -1,0 +1,14 @@
+import { getRoutes } from '@linode/api-v4/lib/aglb/routes';
+import { useQuery } from 'react-query';
+import { Route2 } from '@linode/api-v4/lib/aglb/types';
+
+import type { APIError, ResourcePage } from '@linode/api-v4/lib/types';
+
+export const queryKey = 'domains';
+
+export const useRouteQuery = () =>
+  useQuery<ResourcePage<Route2>, APIError[]>(
+    [queryKey, 'paginated'],
+    () => getRoutes(),
+    { keepPreviousData: true }
+  );

--- a/packages/manager/src/queries/aglb/routes.ts
+++ b/packages/manager/src/queries/aglb/routes.ts
@@ -1,14 +1,19 @@
 import { getRoutes } from '@linode/api-v4/lib/aglb/routes';
 import { useQuery } from 'react-query';
-import { Route2 } from '@linode/api-v4/lib/aglb/types';
+import { Route } from '@linode/api-v4/lib/aglb/types';
 
-import type { APIError, ResourcePage } from '@linode/api-v4/lib/types';
+import type {
+  APIError,
+  Filter,
+  Params,
+  ResourcePage,
+} from '@linode/api-v4/lib/types';
 
-export const queryKey = 'domains';
+export const queryKey = 'routes';
 
-export const useRouteQuery = () =>
-  useQuery<ResourcePage<Route2>, APIError[]>(
-    [queryKey, 'paginated'],
-    () => getRoutes(),
+export const useRoutesQuery = (params: Params, filter: Filter) =>
+  useQuery<ResourcePage<Route>, APIError[]>(
+    [`${queryKey}-list`, 'paginated', params, filter],
+    () => getRoutes(params, filter),
     { keepPreviousData: true }
   );


### PR DESCRIPTION
## Description 📝
This PR builds the skeleton for the routes landing page table. There are TODO items that have been documented in a follow up ticket (column data and action menu items). See self review for more details about this feature.

## Preview 📷

![Screenshot 2023-07-13 at 12 26 47 PM](https://github.com/linode/manager/assets/130582365/bc6691fd-3364-4e87-8c95-238192c20ce6)

## How to test 🧪
1. Pull code locally, enable both MSW & the AGLB flag
2. Navigate to http://localhost:3000/loadbalancers/routes
3. Confirm table behavior (**Note**: the sorting and pagination behaves oddly with RQ and factories, similarly to existing tables such as domains etc). Shouldn't be taken into consideration while review PR


