### PR TITLE
chore: Fix broken Linode landing table top bar navigation test

### DIFF
--- a/packages/manager/cypress/e2e/core/linodes/smoke-linode-landing-table.spec.ts
+++ b/packages/manager/cypress/e2e/core/linodes/smoke-linode-landing-table.spec.ts
@@ -134,14 +134,20 @@ describe('linode landing checks', () => {
         'Search for Linodes, Volumes, NodeBalancers, Domains, Buckets, Tags...'
       );
 
-      cy.findByLabelText('Link to Linode Support')
+      cy.findByLabelText('Help & Support')
         .should('be.visible')
-        .should('have.attr', 'href', '/support');
+        .should('be.enabled')
+        .click();
 
-      cy.findByTitle('Linode Cloud Community')
+      cy.url().should('endWith', '/support');
+      cy.go('back');
+
+      // Cypress cannot work with other tabs and windows, so we can't test
+      // that this takes the user to the expected place since it has no `href`
+      // attribute.
+      cy.findByLabelText('Linode Cloud Community (opens in new tab)')
         .should('be.visible')
-        .parents('a')
-        .should('have.attr', 'href', 'https://linode.com/community');
+        .should('be.enabled');
 
       getVisible('[aria-label="Notifications"]');
       getVisible('[data-testid="nav-group-profile"]').within(() => {


### PR DESCRIPTION
## Description 📝
Recent improvements to the Linode top bar navigation broke the Linode landing table tests which check those elements. This fixes that.

Because we replaced links with buttons for navigation, we can no longer test that the Linode Cloud Community button navigates the user to the expected place because it also opens in a separate tab, which Cypress is unable to interact with. Previously we asserted that the `href` attribute had an expected value but this is no longer available.

## How to test 🧪
We'll wait for the automated run to confirm that `smoke-linode-landing-table.spec.ts` passes.